### PR TITLE
Object files should depend on spirv.h and friends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,8 +92,7 @@ if(UNIX)
   endif()
 endif()
 
-include_directories(SYSTEM
-  ${CMAKE_CURRENT_SOURCE_DIR}/external/include)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/external/include)
 
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/include/libspirv/libspirv.h
+++ b/include/libspirv/libspirv.h
@@ -27,9 +27,9 @@
 #ifndef LIBSPIRV_LIBSPIRV_LIBSPIRV_H_
 #define LIBSPIRV_LIBSPIRV_LIBSPIRV_H_
 
-#include <headers/GLSL.std.450.h>
-#include <headers/OpenCL.std.h>
-#include <headers/spirv.h>
+#include "headers/GLSL.std.450.h"
+#include "headers/OpenCL.std.h"
+#include "headers/spirv.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/source/instruction.h
+++ b/source/instruction.h
@@ -30,7 +30,7 @@
 #include <cstdint>
 #include <vector>
 
-#include <headers/spirv.h>
+#include "headers/spirv.h"
 
 #include "table.h"
 


### PR DESCRIPTION
Don't use SYSTEM attribute on include_directories directive
for the SPIR-V standard header files.  When you do, object files
are not considered dependent on those headers.

Checked by looking at the dependency file source/disassemble.cpp.o.d,
and by trying to compile after a trivial edit to spirv.h

Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/7

Also, use "" inclusion instead of <> inclusion for standard SPIR-V
headers.