### PR TITLE
Remove old names for enums: memory semantics, scope ID

### DIFF
--- a/include/libspirv/libspirv.h
+++ b/include/libspirv/libspirv.h
@@ -109,10 +109,6 @@ typedef enum spv_operand_type_t {
   SPV_OPERAND_TYPE_MEMORY_SEMANTICS_ID,  // SPIR-V Sec 3.25
   SPV_OPERAND_TYPE_SCOPE_ID,             // SPIR-V Sec 3.27
 
-  // TODO(dneto): Remove these old names.
-  SPV_OPERAND_TYPE_MEMORY_SEMANTICS = SPV_OPERAND_TYPE_MEMORY_SEMANTICS_ID,
-  SPV_OPERAND_TYPE_EXECUTION_SCOPE = SPV_OPERAND_TYPE_SCOPE_ID,
-
   // Set 2:  Operands that are literal numbers.
   SPV_OPERAND_TYPE_LITERAL_INTEGER,  // Always unsigned 32-bits.
   // The Instruction argument to OpExtInst. It's an unsigned 32-bit literal

--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -428,8 +428,8 @@ spv_result_t Parser::parseOperand(spv_parsed_instruction_t* inst,
       }
       break;
 
-    case SPV_OPERAND_TYPE_EXECUTION_SCOPE:
-    case SPV_OPERAND_TYPE_MEMORY_SEMANTICS:
+    case SPV_OPERAND_TYPE_SCOPE_ID:
+    case SPV_OPERAND_TYPE_MEMORY_SEMANTICS_ID:
       if (!word) return diagnostic() << spvOperandTypeStr(type) << " Id is 0";
       break;
 

--- a/source/disassemble.cpp
+++ b/source/disassemble.cpp
@@ -207,8 +207,8 @@ void Disassembler::EmitOperand(const spv_parsed_instruction_t& inst,
       break;
     case SPV_OPERAND_TYPE_ID:
     case SPV_OPERAND_TYPE_TYPE_ID:
-    case SPV_OPERAND_TYPE_EXECUTION_SCOPE:
-    case SPV_OPERAND_TYPE_MEMORY_SEMANTICS:
+    case SPV_OPERAND_TYPE_SCOPE_ID:
+    case SPV_OPERAND_TYPE_MEMORY_SEMANTICS_ID:
       SetYellow();
       stream_ << "%" << word;
       break;

--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -204,7 +204,7 @@ spv_operand_type_t convertOperandClassToType(SpvOp opcode,
     case OperandFunction:
       return SPV_OPERAND_TYPE_FUNCTION_CONTROL;
     case OperandMemorySemantics:
-      return SPV_OPERAND_TYPE_MEMORY_SEMANTICS;
+      return SPV_OPERAND_TYPE_MEMORY_SEMANTICS_ID;
     case OperandMemoryAccess:
       // This case does not occur in the table for SPIR-V 0.99 Rev 32.
       // We expect that it will become SPV_OPERAND_TYPE_OPTIONAL_MEMORY_ACCESS,
@@ -212,7 +212,7 @@ spv_operand_type_t convertOperandClassToType(SpvOp opcode,
       // instructions.
       break;
     case OperandScope:
-      return SPV_OPERAND_TYPE_EXECUTION_SCOPE;
+      return SPV_OPERAND_TYPE_SCOPE_ID;
     case OperandGroupOperation:
       return SPV_OPERAND_TYPE_GROUP_OPERATION;
     case OperandKernelEnqueueFlags:

--- a/source/operand.cpp
+++ b/source/operand.cpp
@@ -946,6 +946,7 @@ static const spv_operand_desc_t kernelProfilingInfoEntries[] = {
     }                                                                         \
   }
 
+// clang-format off
 static const spv_operand_desc_t capabilityInfoEntries[] = {
     CASE(Matrix),
     CASE_CAP(Shader, Matrix),
@@ -1005,6 +1006,7 @@ static const spv_operand_desc_t capabilityInfoEntries[] = {
     CASE_CAP(StorageImageReadWithoutFormat, Shader),
     CASE_CAP(StorageImageWriteWithoutFormat, Shader),
 };
+// clang-format on
 #undef CASE
 #undef CASE_CAP
 
@@ -1079,7 +1081,7 @@ static const spv_operand_desc_group_t opcodeEntryTypes[] = {
     {SPV_OPERAND_TYPE_FUNCTION_CONTROL,
      sizeof(functionControlEntries) / sizeof(spv_operand_desc_t),
      functionControlEntries},
-    {SPV_OPERAND_TYPE_MEMORY_SEMANTICS,
+    {SPV_OPERAND_TYPE_MEMORY_SEMANTICS_ID,
      sizeof(memorySemanticsEntries) / sizeof(spv_operand_desc_t),
      memorySemanticsEntries},
     {SPV_OPERAND_TYPE_MEMORY_ACCESS,
@@ -1088,7 +1090,7 @@ static const spv_operand_desc_group_t opcodeEntryTypes[] = {
     {SPV_OPERAND_TYPE_OPTIONAL_MEMORY_ACCESS,  // Same as *_MEMORY_ACCESS
      sizeof(memoryAccessEntries) / sizeof(spv_operand_desc_t),
      memoryAccessEntries},
-    {SPV_OPERAND_TYPE_EXECUTION_SCOPE,
+    {SPV_OPERAND_TYPE_SCOPE_ID,
      sizeof(scopeEntries) / sizeof(spv_operand_desc_t), scopeEntries},
     {SPV_OPERAND_TYPE_GROUP_OPERATION,
      sizeof(groupOperationEntries) / sizeof(spv_operand_desc_t),
@@ -1229,12 +1231,12 @@ const char* spvOperandTypeStr(spv_operand_type_t type) {
       return "loop control";
     case SPV_OPERAND_TYPE_FUNCTION_CONTROL:
       return "function control";
-    case SPV_OPERAND_TYPE_MEMORY_SEMANTICS:
+    case SPV_OPERAND_TYPE_MEMORY_SEMANTICS_ID:
       return "memory semantics";
     case SPV_OPERAND_TYPE_MEMORY_ACCESS:
     case SPV_OPERAND_TYPE_OPTIONAL_MEMORY_ACCESS:
       return "memory access";
-    case SPV_OPERAND_TYPE_EXECUTION_SCOPE:
+    case SPV_OPERAND_TYPE_SCOPE_ID:
       return "execution scope ID";
     case SPV_OPERAND_TYPE_GROUP_OPERATION:
       return "group operation";

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -27,8 +27,8 @@
 #include "validate.h"
 
 #include <assert.h>
-#include <string.h>
 #include <stdio.h>
+#include <string.h>
 
 #include <vector>
 
@@ -106,9 +106,9 @@ spv_result_t spvValidateOperandValue(const spv_operand_type_t type,
     case SPV_OPERAND_TYPE_SELECTION_CONTROL:
     case SPV_OPERAND_TYPE_LOOP_CONTROL:
     case SPV_OPERAND_TYPE_FUNCTION_CONTROL:
-    case SPV_OPERAND_TYPE_MEMORY_SEMANTICS:
+    case SPV_OPERAND_TYPE_MEMORY_SEMANTICS_ID:
     case SPV_OPERAND_TYPE_OPTIONAL_MEMORY_ACCESS:
-    case SPV_OPERAND_TYPE_EXECUTION_SCOPE:
+    case SPV_OPERAND_TYPE_SCOPE_ID:
     case SPV_OPERAND_TYPE_GROUP_OPERATION:
     case SPV_OPERAND_TYPE_KERNEL_ENQ_FLAGS:
     case SPV_OPERAND_TYPE_KERNEL_PROFILING_INFO: {

--- a/test/OperandCapabilities.cpp
+++ b/test/OperandCapabilities.cpp
@@ -182,6 +182,7 @@ INSTANTIATE_TEST_CASE_P(
         CASE1(SAMPLER_FILTER_MODE, SamplerFilterModeLinear, Kernel),
     }));
 
+// clang-format off
 // See SPIR-V Section 3.11 Image Format
 INSTANTIATE_TEST_CASE_P(
     ImageFormat, EnumCapabilityTest,
@@ -227,6 +228,7 @@ INSTANTIATE_TEST_CASE_P(
         CASE1(SAMPLER_IMAGE_FORMAT, ImageFormatR16ui, StorageImageExtendedFormats),
         CASE1(SAMPLER_IMAGE_FORMAT, ImageFormatR8ui, StorageImageExtendedFormats),
     }));
+// clang-format on
 
 // See SPIR-V Section 3.12 Image Channel Order
 INSTANTIATE_TEST_CASE_P(
@@ -279,7 +281,8 @@ INSTANTIATE_TEST_CASE_P(
         CASE1(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataTypeHalfFloat, Kernel),
         CASE1(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataTypeFloat, Kernel),
         CASE1(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataTypeUnormInt24, Kernel),
-        CASE1(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataTypeUnormInt101010_2, Kernel),
+        CASE1(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataTypeUnormInt101010_2,
+              Kernel),
     }));
 
 // See SPIR-V Section 3.14 Image Operands
@@ -489,17 +492,18 @@ INSTANTIATE_TEST_CASE_P(FunctionControl, EnumCapabilityTest,
 INSTANTIATE_TEST_CASE_P(
     MemorySemantics, EnumCapabilityTest,
     ::testing::ValuesIn(std::vector<EnumCapabilityCase>{
-        CASE0(MEMORY_SEMANTICS, MemorySemanticsMaskNone),
-        CASE0(MEMORY_SEMANTICS, MemorySemanticsAcquireMask),
-        CASE0(MEMORY_SEMANTICS, MemorySemanticsReleaseMask),
-        CASE0(MEMORY_SEMANTICS, MemorySemanticsAcquireReleaseMask),
-        CASE0(MEMORY_SEMANTICS, MemorySemanticsSequentiallyConsistentMask),
-        CASE1(MEMORY_SEMANTICS, MemorySemanticsUniformMemoryMask, Shader),
-        CASE0(MEMORY_SEMANTICS, MemorySemanticsSubgroupMemoryMask),
-        CASE0(MEMORY_SEMANTICS, MemorySemanticsWorkgroupMemoryMask),
-        CASE0(MEMORY_SEMANTICS, MemorySemanticsCrossWorkgroupMemoryMask),
-        CASE1(MEMORY_SEMANTICS, MemorySemanticsAtomicCounterMemoryMask, Shader),
-        CASE0(MEMORY_SEMANTICS, MemorySemanticsImageMemoryMask),
+        CASE0(MEMORY_SEMANTICS_ID, MemorySemanticsMaskNone),
+        CASE0(MEMORY_SEMANTICS_ID, MemorySemanticsAcquireMask),
+        CASE0(MEMORY_SEMANTICS_ID, MemorySemanticsReleaseMask),
+        CASE0(MEMORY_SEMANTICS_ID, MemorySemanticsAcquireReleaseMask),
+        CASE0(MEMORY_SEMANTICS_ID, MemorySemanticsSequentiallyConsistentMask),
+        CASE1(MEMORY_SEMANTICS_ID, MemorySemanticsUniformMemoryMask, Shader),
+        CASE0(MEMORY_SEMANTICS_ID, MemorySemanticsSubgroupMemoryMask),
+        CASE0(MEMORY_SEMANTICS_ID, MemorySemanticsWorkgroupMemoryMask),
+        CASE0(MEMORY_SEMANTICS_ID, MemorySemanticsCrossWorkgroupMemoryMask),
+        CASE1(MEMORY_SEMANTICS_ID, MemorySemanticsAtomicCounterMemoryMask,
+              Shader),
+        CASE0(MEMORY_SEMANTICS_ID, MemorySemanticsImageMemoryMask),
     }));
 
 // See SPIR-V Section 3.26 Memory Access
@@ -513,14 +517,13 @@ INSTANTIATE_TEST_CASE_P(
     }));
 
 // See SPIR-V Section 3.27 Scope <id>
-INSTANTIATE_TEST_CASE_P(Scope, EnumCapabilityTest,
-                        ::testing::ValuesIn(std::vector<EnumCapabilityCase>{
-                            CASE0(EXECUTION_SCOPE, ScopeCrossDevice),
-                            CASE0(EXECUTION_SCOPE, ScopeDevice),
-                            CASE0(EXECUTION_SCOPE, ScopeWorkgroup),
-                            CASE0(EXECUTION_SCOPE, ScopeSubgroup),
-                            CASE0(EXECUTION_SCOPE, ScopeInvocation),
-                        }));
+INSTANTIATE_TEST_CASE_P(
+    Scope, EnumCapabilityTest,
+    ::testing::ValuesIn(std::vector<EnumCapabilityCase>{
+        CASE0(SCOPE_ID, ScopeCrossDevice), CASE0(SCOPE_ID, ScopeDevice),
+        CASE0(SCOPE_ID, ScopeWorkgroup), CASE0(SCOPE_ID, ScopeSubgroup),
+        CASE0(SCOPE_ID, ScopeInvocation),
+    }));
 
 // See SPIR-V Section 3.28 Group Operation
 INSTANTIATE_TEST_CASE_P(


### PR DESCRIPTION
We prefer the new names because they end with "ID" and match the section headers in the SPIR-V spec.  They are:
Remove the uses of the old names.

Also ran clang-format on the affected files.  In one case, the reformatting of a table was painfully different, so I added a "clang-format off" directive around it.