### PR TITLE
Turned warnings-as-errors on by default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ if ("${CMAKE_BUILD_TYPE}" STREQUAL "")
   set(CMAKE_BUILD_TYPE "Debug")
 endif()
 
+option(SPIRV_WERROR "Enable error on warning" ON)
 if(UNIX)
   set(SPIRV_WARNINGS -Wall -Wextra -Wno-missing-field-initializers)
 
@@ -52,12 +53,15 @@ if(UNIX)
       -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-padded)
   endif()
 
-  option(SPIRV_WERROR "Enable error on warning" OFF)
   if(${SPIRV_WERROR})
     set(SPIRV_WARNINGS ${SPIRV_WARNINGS} -Werror)
   endif()
 elseif(WIN32)
   set(SPIRV_WARNINGS -D_CRT_SECURE_NO_WARNINGS /wd4800)
+
+  if(${SPIRV_WERROR})
+    set(SPIRV_WARNINGS ${SPIRV_WARNINGS} /WX)
+  endif()
 endif()
 
 option(SPIRV_COLOR_TERMINAL "Enable color terminal output" ON)

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ The following CMake options are supported:
   This should only be used with a debug build. Disabled by default.
 * `SPIRV_WARN_EVERYTHING=OFF` - On UNIX platforms enable the `-Weverything`
   compiler front end option, disabled by default.
-* `SPIRV_WERROR=OFF` - On UNIX platforms enable the `-Werror` compiler front end
-  option, disabled by default.
+* `SPIRV_WERROR=ON` - Forces a compilation error on any warnings encountered by
+  enabling the compiler-specific compiler front-end option, enabled by default.
 
 ## Library
 

--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -318,7 +318,7 @@ spv_result_t Parser::parseInstruction() {
       opcode_desc->operandTypes + opcode_desc->numTypes);
 
   while (_.word_index < inst.offset + inst_word_count) {
-    const uint16_t inst_word_index = _.word_index - inst.offset;
+    const uint16_t inst_word_index = uint16_t(_.word_index - inst.offset);
     if (expected_operands.empty()) {
       return diagnostic() << "Invalid instruction Op" << opcode_desc->name
                           << " starting at word " << inst.offset
@@ -354,7 +354,7 @@ spv_result_t Parser::parseInstruction() {
   // Must wait until here to set the inst.operands pointer because the vector
   // might be resized while we accumulate itse elements.
   inst.operands = operands.data();
-  inst.num_operands = operands.size();
+  inst.num_operands = uint16_t(operands.size());
 
   // Issue the callback.  The callee should know that all the storage in inst
   // is transient, and will disappear immediately afterward.
@@ -371,7 +371,7 @@ spv_result_t Parser::parseOperand(spv_parsed_instruction_t* inst,
                                   spv_operand_pattern_t* expected_operands) {
   // We'll fill in this result as we go along.
   spv_parsed_operand_t parsed_operand;
-  parsed_operand.offset = _.word_index - inst->offset;
+  parsed_operand.offset = uint16_t(_.word_index - inst->offset);
   // Most operands occupy one word.  This might be be adjusted later.
   parsed_operand.num_words = 1;
   // The type argument is the one used by the grammar to parse the instruction.
@@ -526,7 +526,7 @@ spv_result_t Parser::parseOperand(spv_parsed_instruction_t* inst,
                             << std::numeric_limits<uint16_t>::max()
                             << " words: " << string_num_words << " words long";
       }
-      parsed_operand.num_words = string_num_words;
+      parsed_operand.num_words = uint16_t(string_num_words);
       parsed_operand.type = SPV_OPERAND_TYPE_LITERAL_STRING;
 
       if (SpvOpExtInstImport == inst->opcode) {

--- a/source/text.cpp
+++ b/source/text.cpp
@@ -645,7 +645,7 @@ spv_result_t spvTextEncodeOpcode(const libspirv::AssemblyGrammar& grammar,
            << SPV_LIMIT_INSTRUCTION_WORD_COUNT_MAX;
   }
 
-  pInst->words[0] = spvOpcodeMake(pInst->words.size(), opcodeEntry->opcode);
+  pInst->words[0] = spvOpcodeMake(uint16_t(pInst->words.size()), opcodeEntry->opcode);
 
   return SPV_SUCCESS;
 }

--- a/test/HexFloat.cpp
+++ b/test/HexFloat.cpp
@@ -24,12 +24,6 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 
-#ifdef _MSC_VER
-// We define this so that we can use sscanf in the tests without
-// MSVC warning us all the time.
-#define _CRT_SECURE_NO_WARNINGS
-#endif
-
 #include <cmath>
 #include <cstdio>
 #include <sstream>


### PR DESCRIPTION
Fixed a few warnings that appear in builds on VS2013 and VS2015.