### PR TITLE
Updated spirv.h header. Fixes SPV_VERSION macro

### DIFF
--- a/external/include/headers/spirv.h
+++ b/external/include/headers/spirv.h
@@ -50,7 +50,7 @@
 
 typedef unsigned int SpvId;
 
-#define SPV_VERSION 10000
+#define SPV_VERSION 0x10000
 #define SPV_REVISION 2
 
 static const unsigned int SpvMagicNumber = 0x07230203;


### PR DESCRIPTION
Use the new spirv.h from the SPIR-V registry.

The SPV_VERSION macro value was updated to be 0x10000.
Previously it was missing the "0x" prefix, which caused
confusion.

The value of the const unsigned int SpvVersion has always
been 0x00010000.  That's what should appear as the version
word in the SPIR-V header.

The SPV_VERSION symbol is to be used in preprocessor directives.