### PR TITLE
Put DiagnosticStream and clr exports in libspirv namespace

### DIFF
--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -163,12 +163,12 @@ class Parser {
   // the input stream, and for the given error code. Any data written to the
   // returned object will be propagated to the current parse's diagnostic
   // object.
-  DiagnosticStream diagnostic(spv_result_t error) {
-    return DiagnosticStream({0, 0, _.word_index}, _.diagnostic, error);
+  libspirv::DiagnosticStream diagnostic(spv_result_t error) {
+    return libspirv::DiagnosticStream({0, 0, _.word_index}, _.diagnostic, error);
   }
 
   // Returns a diagnostic stream object with the default parse error code.
-  DiagnosticStream diagnostic() {
+  libspirv::DiagnosticStream diagnostic() {
     // The default failure for parsing is invalid binary.
     return diagnostic(SPV_ERROR_INVALID_BINARY);
   }

--- a/source/diagnostic.cpp
+++ b/source/diagnostic.cpp
@@ -81,8 +81,12 @@ spv_result_t spvDiagnosticPrint(const spv_diagnostic diagnostic) {
   return SPV_ERROR_INVALID_VALUE;
 }
 
+namespace libspirv {
+
 DiagnosticStream::~DiagnosticStream() {
   if (pDiagnostic_ && error_ != SPV_FAILED_MATCH) {
     *pDiagnostic_ = spvDiagnosticCreate(&position_, stream_.str().c_str());
   }
 }
+
+}  // namespace libspirv

--- a/source/diagnostic.h
+++ b/source/diagnostic.h
@@ -33,6 +33,8 @@
 
 #include "libspirv/libspirv.h"
 
+namespace libspirv {
+
 class diagnostic_helper {
  public:
   diagnostic_helper(spv_position_t& position, spv_diagnostic* pDiagnostic)
@@ -95,8 +97,10 @@ class DiagnosticStream {
   spv_result_t error_;
 };
 
-#define DIAGNOSTIC                                 \
-  diagnostic_helper helper(position, pDiagnostic); \
+#define DIAGNOSTIC                                           \
+  libspirv::diagnostic_helper helper(position, pDiagnostic); \
   helper.stream
+
+}  // namespace libspirv
 
 #endif  // LIBSPIRV_DIAGNOSTIC_H_

--- a/source/disassemble.cpp
+++ b/source/disassemble.cpp
@@ -49,6 +49,8 @@ namespace {
 class Disassembler {
   enum { kStandardIndent = 15 };
 
+  using out_stream = libspirv::out_stream;
+
  public:
   Disassembler(const libspirv::AssemblyGrammar& grammar, uint32_t const* words,
                uint32_t options)
@@ -88,27 +90,27 @@ class Disassembler {
 
   // Resets the output color, if color is turned on.
   void ResetColor() {
-    if (color_) out_.get() << clr::reset();
+    if (color_) out_.get() << libspirv::clr::reset();
   }
   // Sets the output to grey, if color is turned on.
   void SetGrey() {
-    if (color_) out_.get() << clr::grey();
+    if (color_) out_.get() << libspirv::clr::grey();
   }
   // Sets the output to blue, if color is turned on.
   void SetBlue() {
-    if (color_) out_.get() << clr::blue();
+    if (color_) out_.get() << libspirv::clr::blue();
   }
   // Sets the output to yellow, if color is turned on.
   void SetYellow() {
-    if (color_) out_.get() << clr::yellow();
+    if (color_) out_.get() << libspirv::clr::yellow();
   }
   // Sets the output to red, if color is turned on.
   void SetRed() {
-    if (color_) out_.get() << clr::red();
+    if (color_) out_.get() << libspirv::clr::red();
   }
   // Sets the output to green, if color is turned on.
   void SetGreen() {
-    if (color_) out_.get() << clr::green();
+    if (color_) out_.get() << libspirv::clr::green();
   }
 
   // The SPIR-V binary. The endianness is not necessarily converted

--- a/source/print.cpp
+++ b/source/print.cpp
@@ -27,6 +27,8 @@
 #include "print.h"
 
 #if defined(SPIRV_LINUX) || defined(SPIRV_MAC)
+namespace libspirv {
+
 clr::reset::operator const char*() { return "\e[0m"; }
 
 clr::grey::operator const char*() { return "\e[1;30m"; }
@@ -38,8 +40,12 @@ clr::green::operator const char*() { return "\e[32m"; }
 clr::yellow::operator const char*() { return "\e[33m"; }
 
 clr::blue::operator const char*() { return "\e[34m"; }
+
+}  // namespace libspirv
 #elif defined(SPIRV_WINDOWS)
 #include <Windows.h>
+
+namespace libspirv {
 
 clr::reset::operator const char*() {
   const DWORD color = 0Xf;
@@ -100,4 +106,6 @@ clr::blue::operator const char*() {
   SetConsoleTextAttribute(hConsole, color);
   return "";
 }
+
+}  // namespace libspirv
 #endif

--- a/source/print.h
+++ b/source/print.h
@@ -30,6 +30,8 @@
 #include <iostream>
 #include <sstream>
 
+namespace libspirv {
+
 // Wrapper for out stream selection.
 class out_stream {
  public:
@@ -72,6 +74,8 @@ struct yellow {
 struct blue {
   operator const char*();
 };
-}
+}  // namespace clr
+
+}  // namespace libspirv
 
 #endif  // LIBSPIRV_PRINT_H_

--- a/test/DiagnosticStream.cpp
+++ b/test/DiagnosticStream.cpp
@@ -28,6 +28,8 @@
 
 namespace {
 
+using libspirv::DiagnosticStream;
+
 TEST(DiagnosticStream, ConversionToResultType) {
   // Check after the DiagnosticStream object is destroyed.
   spv_result_t value;


### PR DESCRIPTION
Each exported functions either has an "spv" prefix, or is in the libspirv
namespace.

Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/18