### PR TITLE
test binary parsing where the string operand is shorter than implied by the word count

### DIFF
--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -99,9 +99,18 @@ spv_operand_type_t convertOperandClassToType(SpvOp opcode,
         break;
     }
   } else if (operandClass == OperandVariableLiterals) {
-    if (opcode == SpvOpConstant || opcode == SpvOpSpecConstant) {
-      // The number type is determined by the type Id operand.
-      return SPV_OPERAND_TYPE_TYPED_LITERAL_NUMBER;
+    switch (opcode) {
+      case SpvOpConstant:
+      case SpvOpSpecConstant:
+        // The number type is determined by the type Id operand.
+        return SPV_OPERAND_TYPE_TYPED_LITERAL_NUMBER;
+      case SpvOpDecorate:
+      case SpvOpMemberDecorate:
+        // The operand types at the end of the instruction are
+        // determined instead by the decoration kind.
+        return SPV_OPERAND_TYPE_NONE;
+      default:
+        break;
     }
   }
 

--- a/test/BinaryParse.cpp
+++ b/test/BinaryParse.cpp
@@ -555,6 +555,42 @@ INSTANTIATE_TEST_CASE_P(
                       {0 /* this word does not belong*/}}),
          "Invalid instruction OpString starting at word 5: expected no more"
          " operands after 3 words, but stated word count is 4."},
+        // Word count is too large.  There are too many words after the string
+        // literal.  A linkage attribute decoration is the only case in SPIR-V
+        // where a string operand is followed by another operand.
+        {Concatenate({ExpectedHeaderForBound(2),
+                      {spvOpcodeMake(6, SpvOpDecorate), 1 /* target id */,
+                       uint32_t(SpvDecorationLinkageAttributes)},
+                      MakeVector("abc"),
+                      {uint32_t(SpvLinkageTypeImport),
+                       0 /* does not belong */}}),
+         "Invalid instruction OpDecorate starting at word 5: expected no more"
+         " operands after 5 words, but stated word count is 6."},
+        // Same as the previous case, but with OpMemberDecorate.
+        {Concatenate(
+             {ExpectedHeaderForBound(2),
+              {spvOpcodeMake(7, SpvOpMemberDecorate), 1 /* target id */,
+               42 /* member index */, uint32_t(SpvDecorationLinkageAttributes)},
+              MakeVector("abc"),
+              {uint32_t(SpvLinkageTypeImport), 0 /* does not belong */}}),
+         "Invalid instruction OpMemberDecorate starting at word 5: expected no"
+         " more operands after 6 words, but stated word count is 7."},
+        // Word count is too large.  There should be no more words
+        // after the RelaxedPrecision decoration.
+        {Concatenate({ExpectedHeaderForBound(2),
+                      {spvOpcodeMake(4, SpvOpDecorate), 1 /* target id */,
+                       uint32_t(SpvDecorationRelaxedPrecision),
+                       0 /* does not belong */}}),
+         "Invalid instruction OpDecorate starting at word 5: expected no"
+         " more operands after 3 words, but stated word count is 4."},
+        // Word count is too large.  There should be only one word after
+        // the SpecId decoration enum word.
+        {Concatenate({ExpectedHeaderForBound(2),
+                      {spvOpcodeMake(5, SpvOpDecorate), 1 /* target id */,
+                       uint32_t(SpvDecorationSpecId), 42 /* the spec id */,
+                       0 /* does not belong */}}),
+         "Invalid instruction OpDecorate starting at word 5: expected no"
+         " more operands after 4 words, but stated word count is 5."},
         {Concatenate({ExpectedHeaderForBound(2),
                       {spvOpcodeMake(2, SpvOpTypeVoid), 0}}),
          "Error: Result Id is 0"},

--- a/test/BinaryParse.cpp
+++ b/test/BinaryParse.cpp
@@ -560,26 +560,27 @@ INSTANTIATE_TEST_CASE_P(
         // where a string operand is followed by another operand.
         {Concatenate({ExpectedHeaderForBound(2),
                       {spvOpcodeMake(6, SpvOpDecorate), 1 /* target id */,
-                       uint32_t(SpvDecorationLinkageAttributes)},
+                       static_cast<uint32_t>(SpvDecorationLinkageAttributes)},
                       MakeVector("abc"),
-                      {uint32_t(SpvLinkageTypeImport),
+                      {static_cast<uint32_t>(SpvLinkageTypeImport),
                        0 /* does not belong */}}),
          "Invalid instruction OpDecorate starting at word 5: expected no more"
          " operands after 5 words, but stated word count is 6."},
         // Same as the previous case, but with OpMemberDecorate.
-        {Concatenate(
-             {ExpectedHeaderForBound(2),
-              {spvOpcodeMake(7, SpvOpMemberDecorate), 1 /* target id */,
-               42 /* member index */, uint32_t(SpvDecorationLinkageAttributes)},
-              MakeVector("abc"),
-              {uint32_t(SpvLinkageTypeImport), 0 /* does not belong */}}),
+        {Concatenate({ExpectedHeaderForBound(2),
+                      {spvOpcodeMake(7, SpvOpMemberDecorate), 1 /* target id */,
+                       42 /* member index */,
+                       static_cast<uint32_t>(SpvDecorationLinkageAttributes)},
+                      MakeVector("abc"),
+                      {static_cast<uint32_t>(SpvLinkageTypeImport),
+                       0 /* does not belong */}}),
          "Invalid instruction OpMemberDecorate starting at word 5: expected no"
          " more operands after 6 words, but stated word count is 7."},
         // Word count is too large.  There should be no more words
         // after the RelaxedPrecision decoration.
         {Concatenate({ExpectedHeaderForBound(2),
                       {spvOpcodeMake(4, SpvOpDecorate), 1 /* target id */,
-                       uint32_t(SpvDecorationRelaxedPrecision),
+                       static_cast<uint32_t>(SpvDecorationRelaxedPrecision),
                        0 /* does not belong */}}),
          "Invalid instruction OpDecorate starting at word 5: expected no"
          " more operands after 3 words, but stated word count is 4."},
@@ -587,8 +588,8 @@ INSTANTIATE_TEST_CASE_P(
         // the SpecId decoration enum word.
         {Concatenate({ExpectedHeaderForBound(2),
                       {spvOpcodeMake(5, SpvOpDecorate), 1 /* target id */,
-                       uint32_t(SpvDecorationSpecId), 42 /* the spec id */,
-                       0 /* does not belong */}}),
+                       static_cast<uint32_t>(SpvDecorationSpecId),
+                       42 /* the spec id */, 0 /* does not belong */}}),
          "Invalid instruction OpDecorate starting at word 5: expected no"
          " more operands after 4 words, but stated word count is 5."},
         {Concatenate({ExpectedHeaderForBound(2),

--- a/test/BinaryParse.cpp
+++ b/test/BinaryParse.cpp
@@ -547,6 +547,14 @@ INSTANTIATE_TEST_CASE_P(
                       {spvOpcodeMake(3, SpvOpString), 1, 0x41414141, 0}}),
          "Invalid word count: OpString starting at word 5 says it has 3"
          " words, but found 4 words instead."},
+        // Word count is too large.  The string terminates before the last
+        // word.
+        {Concatenate({ExpectedHeaderForBound(2),
+                      {spvOpcodeMake(4, SpvOpString), 1 /* result id */},
+                      MakeVector("abc"),
+                      {0 /* this word does not belong*/}}),
+         "Invalid instruction OpString starting at word 5: expected no more"
+         " operands after 3 words, but stated word count is 4."},
         {Concatenate({ExpectedHeaderForBound(2),
                       {spvOpcodeMake(2, SpvOpTypeVoid), 0}}),
          "Error: Result Id is 0"},

--- a/test/BinaryParse.cpp
+++ b/test/BinaryParse.cpp
@@ -466,6 +466,11 @@ INSTANTIATE_TEST_CASE_P(
                       MakeInstruction(SpvOpNop, {42})}),
          "Invalid instruction OpNop starting at word 5: expected "
          "no more operands after 1 words, but stated word count is 2."},
+        // Supply several more unexpectd words.
+        {Concatenate({ExpectedHeaderForBound(1),
+                      MakeInstruction(SpvOpNop, {42, 43, 44, 45, 46, 47})}),
+         "Invalid instruction OpNop starting at word 5: expected "
+         "no more operands after 1 words, but stated word count is 7."},
         {Concatenate({ExpectedHeaderForBound(1),
                       MakeInstruction(SpvOpTypeVoid, {1, 2})}),
          "Invalid instruction OpTypeVoid starting at word 5: expected "
@@ -566,7 +571,16 @@ INSTANTIATE_TEST_CASE_P(
                        0 /* does not belong */}}),
          "Invalid instruction OpDecorate starting at word 5: expected no more"
          " operands after 5 words, but stated word count is 6."},
-        // Same as the previous case, but with OpMemberDecorate.
+        // Like the previous case, but with 5 extra words.
+        {Concatenate({ExpectedHeaderForBound(2),
+                      {spvOpcodeMake(10, SpvOpDecorate), 1 /* target id */,
+                       static_cast<uint32_t>(SpvDecorationLinkageAttributes)},
+                      MakeVector("abc"),
+                      {static_cast<uint32_t>(SpvLinkageTypeImport),
+                       /* don't belong */ 0, 1, 2, 3, 4}}),
+         "Invalid instruction OpDecorate starting at word 5: expected no more"
+         " operands after 5 words, but stated word count is 10."},
+        // Like the previous two cases, but with OpMemberDecorate.
         {Concatenate({ExpectedHeaderForBound(2),
                       {spvOpcodeMake(7, SpvOpMemberDecorate), 1 /* target id */,
                        42 /* member index */,
@@ -576,6 +590,15 @@ INSTANTIATE_TEST_CASE_P(
                        0 /* does not belong */}}),
          "Invalid instruction OpMemberDecorate starting at word 5: expected no"
          " more operands after 6 words, but stated word count is 7."},
+        {Concatenate({ExpectedHeaderForBound(2),
+                      {spvOpcodeMake(11, SpvOpMemberDecorate),
+                       1 /* target id */, 42 /* member index */,
+                       static_cast<uint32_t>(SpvDecorationLinkageAttributes)},
+                      MakeVector("abc"),
+                      {static_cast<uint32_t>(SpvLinkageTypeImport),
+                       /* don't belong */ 0, 1, 2, 3, 4}}),
+         "Invalid instruction OpMemberDecorate starting at word 5: expected no"
+         " more operands after 6 words, but stated word count is 11."},
         // Word count is too large.  There should be no more words
         // after the RelaxedPrecision decoration.
         {Concatenate({ExpectedHeaderForBound(2),


### PR DESCRIPTION
There are two commits in this PR.

The first adds a test case where the string operand occurs last in the instruction, but has fewer words than implied by the instruction word count.

The second adds short string test cases where the string operand is not the last operand in an instruction.  This only occurs with OpDecorate and OpMemberDecorate for LinkageAttributes decorations.  A LinkageAttributes decoration takes a literal string operand, followed by an attributes enum word.  It should take nothing else.  But to enforce that, we have to tweak the grammar to drop the OperandVariableLiterals at the end of OpDecorate and OpMemberDecorate when parsing opcode.inc.  So I did that and also wrote a few more failing assembler and disassembler cases for OpDecorate and OpMemberDecorate.  OpMemberDecorate did not have any test cases before; I cloned a big set from the OpDecorate set.  (I cloned rather them rather than further complexify the OpDecorate tests via parameterization.)  Yes, I made up the word "complexify".