### PR TITLE
Don't add -frtti for tests. Use newer googletest.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,13 +219,6 @@ if (NOT ${SPIRV_SKIP_EXECUTABLES})
 
     add_executable(UnitSPIRV ${TEST_SOURCES})
     default_compile_options(UnitSPIRV)
-    if (UNIX)
-      # The tests use mocking, and mocking requires runtime type information
-      # for the test classes.  Until we adopt a version of gmock that avoids
-      # this problem (see https://github.com/google/googletest/issues/610),
-      # add RTTI.
-      target_compile_options(UnitSPIRV PRIVATE -frtti)
-    endif()
     target_include_directories(UnitSPIRV PRIVATE
       ${gmock_SOURCE_DIR}/include ${gtest_SOURCE_DIR}/include)
     target_link_libraries(UnitSPIRV PRIVATE ${SPIRV_TOOLS} gmock)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ source is not provided with this project.  Download the `googletest` source
 into the `<spirv-dir>/external/googletest` directory before configuring
 and building the project.
 
+*Note*: You must use a version of googletest that includes
+[a fix](https://github.com/google/googletest/pull/612) for
+[googletest issue 610](https://github.com/google/googletest/issues/610).
+The fix is included on the googletest master branch any time after 2015-11-10.
+In particular, googletest must be newer than version 1.7.0.
+
 ## Build
 
 The project uses [CMake](https://cmake.org/) to generate platform-specific


### PR DESCRIPTION
Using -frtti caused link failures when both of the following are
in effect:
	-DDISABLE_EXCEPTIONS=ON
	-DDISABLE_RTTI=ON

The correct fix is to use tip-of-tree googletest.
Specifically, we need a version of googletest with the fix in
https://github.com/google/googletest/pull/612
In particular, it must be later than googletest 1.7.0.