### PR TITLE
Fix setting of off-by-default cmake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,17 @@ option(SPIRV_WERROR "Enable error on warning" ON)
 if(UNIX)
   set(SPIRV_WARNINGS -Wall -Wextra -Wno-missing-field-initializers)
 
-  option(SPIRV_WARN_EVERYTHING "Enable -Weverything" OFF)
+  option(SPIRV_WARN_EVERYTHING "Enable -Weverything" ${SPIRV_WARN_EVERYTHING})
   if(${SPIRV_WARN_EVERYTHING})
-    set(SPIRV_WARNINGS ${SPIRV_WARNINGS}
-      -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-padded)
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+      set(SPIRV_WARNINGS ${SPIRV_WARNINGS}
+        -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-padded)
+    elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+      set(SPIRV_WARNINGS ${SPIRV_WARNINGS} -Wpedantic -pedantic-errors)
+    else()
+      message(STATUS "Unknown compiler ${CMAKE_CXX_COMPILER_ID}, "
+                     "so SPIRV_WARN_EVERYTHING has no effect")
+    endif()
   endif()
 
   if(${SPIRV_WERROR})
@@ -129,8 +136,10 @@ target_include_directories(${SPIRV_TOOLS} PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${CMAKE_CURRENT_SOURCE_DIR}/external/include)
 
+# Defaults to OFF if the user didn't set it.
 option(SPIRV_SKIP_EXECUTABLES
-  "Skip building the executables and tests along with the library" OFF)
+       "Skip building the executable and tests along with the library"
+       ${SPIRV_SKIP_EXECUTABLES})
 set(SPIRV_INSTALL_TARGETS ${SPIRV_TOOLS})
 if (NOT ${SPIRV_SKIP_EXECUTABLES})
   list(APPEND SPIRV_INSTALL_TARGETS spirv-as spirv-dis spirv-val)

--- a/README.md
+++ b/README.md
@@ -93,17 +93,21 @@ development environment.
 
 The following CMake options are supported:
 
-* `SPIRV_COLOR_TERMINAL=ON` - Enables color console output, enabled by default.
-* `SPIRV_SKIP_EXECUTABLES=ON` - Build only the library, not the command line
-  tools.  This will also prevent the tests from being built.
-* `SPIRV_USE_SANITIZER=<sanitizer>` - On UNIX platforms with an appropriate
-  version of `clang` this option enables the use of the sanitizers documented
+* `SPIRV_COLOR_TERMINAL={ON|OFF}`, default `ON` - Enables color console output.
+* `SPIRV_SKIP_EXECUTABLES={ON|OFF}`, default `OFF`- Build only the library, not
+  the command line tools.  This will also prevent the tests from being built.
+* `SPIRV_USE_SANITIZER=<sanitizer>`, default is no sanitizing - On UNIX platforms
+  with an appropriate version of `clang` this option enables the use of the
+  sanitizers documented
   [here](http://clang.llvm.org/docs/UsersManual.html#controlling-code-generation).
-  This should only be used with a debug build. Disabled by default.
-* `SPIRV_WARN_EVERYTHING=OFF` - On UNIX platforms enable the `-Weverything`
-  compiler front end option, disabled by default.
-* `SPIRV_WERROR=ON` - Forces a compilation error on any warnings encountered by
-  enabling the compiler-specific compiler front-end option, enabled by default.
+  This should only be used with a debug build.
+* `SPIRV_WARN_EVERYTHING={ON|OFF}`, default `OFF` - On UNIX platforms enable
+  more strict warnings.  The code might not compile with this option enabled.
+  For Clang, enables `-Weverything`.  For GCC, enables `-Wpedantic`.
+  See [`CMakeLists.txt`](CMakeLists.txt) for details.
+* `SPIRV_WERROR={ON|OFF}`, default `ON` - Forces a compilation error on any
+  warnings encountered by enabling the compiler-specific compiler front-end
+  option.
 
 ## Library
 


### PR DESCRIPTION
An enclosing CMake project should be able to set the
off-by-default CMake options in SPIRV-Tools by just doing:
  set(SPIRV_SKIP_EXECUTABLES ON)
instead of
  set(SPIRV_SKIP_EXECUTABLES ON CACHE BOOL "" FORCE)

Also, fix the SPIRV_WARN_EVERYTHING option processing so Cmake understands which options
to send to Clang vs. GCC.

Note: With SPIRV_WARN_EVERYTHING enabled, the code doesn't
compile with either Clang or GCC.