### PR TITLE
Fix warnings with Apple clang++

### DIFF
--- a/include/util/hex_float.h
+++ b/include/util/hex_float.h
@@ -483,7 +483,7 @@ class HexFloat {
     // rounding rules.
     switch (dir) {
       case round_direction::kToZero:
-          break;
+        break;
       case round_direction::kToPositiveInfinity:
         round_away_from_zero = !isNegative();
         break;
@@ -493,7 +493,7 @@ class HexFloat {
       case round_direction::kToNearestEven:
         // Have to round down, round bit is 0
         if ((first_rounded_bit & significand) == 0) {
-            break;
+          break;
         }
         if (((significand & throwaway_mask) & ~first_rounded_bit) != 0) {
           // If any subsequent bit of the rounded portion is non-0 then we round
@@ -573,8 +573,9 @@ class HexFloat {
     if (is_nan) {
       typename other_T::uint_type shifted_significand;
       shifted_significand = static_cast<typename other_T::uint_type>(
-          negatable_left_shift<other_T::num_fraction_bits -
-                               num_fraction_bits>::val(significand));
+          negatable_left_shift<static_cast<int_type>(other_T::num_fraction_bits) -
+                               static_cast<int_type>(
+                                   num_fraction_bits)>::val(significand));
 
       // We are some sort of Nan. We try to keep the bit-pattern of the Nan
       // as close as possible. If we had to shift off bits so we are 0, then we

--- a/source/disassemble.cpp
+++ b/source/disassemble.cpp
@@ -48,10 +48,9 @@ namespace {
 // representation.
 class Disassembler {
  public:
-  Disassembler(const libspirv::AssemblyGrammar& grammar, uint32_t const* words,
+  Disassembler(const libspirv::AssemblyGrammar& grammar,
                uint32_t options)
-      : words_(words),
-        grammar_(grammar),
+      : grammar_(grammar),
         print_(spvIsInBitfield(SPV_BINARY_TO_TEXT_OPTION_PRINT, options)),
         color_(print_ &&
                spvIsInBitfield(SPV_BINARY_TO_TEXT_OPTION_COLOR, options)),
@@ -113,9 +112,6 @@ class Disassembler {
     if (color_) out_.get() << libspirv::clr::green();
   }
 
-  // The SPIR-V binary. The endianness is not necessarily converted
-  // to native endianness.
-  const uint32_t* const words_;
   const libspirv::AssemblyGrammar& grammar_;
   const bool print_;  // Should we also print to the standard output stream?
   const bool color_;  // Should we print in colour?
@@ -394,7 +390,7 @@ spv_result_t spvBinaryToText(const spv_const_context context,
   const libspirv::AssemblyGrammar grammar(context);
   if (!grammar.isValid()) return SPV_ERROR_INVALID_TABLE;
 
-  Disassembler disassembler(grammar, code, options);
+  Disassembler disassembler(grammar, options);
   if (auto error = spvBinaryParse(context, &disassembler, code, wordCount,
                                   DisassembleHeader, DisassembleInstruction,
                                   pDiagnostic)) {


### PR DESCRIPTION
* Unused private member
* Overflow error when subtracting num_fraction_bits for HF16 and HF
* Formatting