### PR TITLE
Fix parser assert failure for a bad OpSwitch

### DIFF
--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -555,8 +555,9 @@ spv_result_t Parser::parseOperand(size_t inst_offset,
         // The literal operands have the same type as the value
         // referenced by the selector Id.
         const uint32_t selector_id = peekAt(inst_offset + 1);
-        auto type_id_iter = _.id_to_type_id.find(selector_id);
-        if (type_id_iter == _.id_to_type_id.end()) {
+        const auto type_id_iter = _.id_to_type_id.find(selector_id);
+        if (type_id_iter == _.id_to_type_id.end() ||
+            type_id_iter->second == 0) {
           return diagnostic() << "Invalid OpSwitch: selector id " << selector_id
                               << " has no type";
         }

--- a/test/BinaryParse.cpp
+++ b/test/BinaryParse.cpp
@@ -628,7 +628,14 @@ INSTANTIATE_TEST_CASE_P(
                       MakeInstruction(SpvOpExtInst, {2, 3, 100, 4, 5})}),
          "OpExtInst set Id 100 does not reference an OpExtInstImport result "
          "Id"},
+        // In this case, the OpSwitch selector refers to an invalid ID.
         {Concatenate({ExpectedHeaderForBound(3),
+                      MakeInstruction(SpvOpSwitch, {1, 2, 42, 3})}),
+         "Invalid OpSwitch: selector id 1 has no type"},
+        // In this case, the OpSwitch selector refers to an ID that has
+        // no type.
+        {Concatenate({ExpectedHeaderForBound(3),
+                      MakeInstruction(SpvOpLabel, {1}),
                       MakeInstruction(SpvOpSwitch, {1, 2, 42, 3})}),
          "Invalid OpSwitch: selector id 1 has no type"},
         {Concatenate({ExpectedHeaderForBound(3),


### PR DESCRIPTION
Emit a diagnostic if the OpSwitch selector refers to an ID that
is valid but has no type.

Discovered by afl-fuzz.