### PR TITLE
Avoid relative path in #include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,7 @@ if (NOT ${SPIRV_SKIP_EXECUTABLES})
     add_executable(UnitSPIRV ${TEST_SOURCES})
     default_compile_options(UnitSPIRV)
     target_include_directories(UnitSPIRV PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}
       ${gmock_SOURCE_DIR}/include ${gtest_SOURCE_DIR}/include)
     target_link_libraries(UnitSPIRV PRIVATE ${SPIRV_TOOLS} gmock)
   else()

--- a/test/AssemblyContext.cpp
+++ b/test/AssemblyContext.cpp
@@ -29,7 +29,7 @@
 #include <vector>
 #include <gmock/gmock.h>
 
-#include "../source/instruction.h"
+#include "source/instruction.h"
 
 using libspirv::AssemblyContext;
 using spvtest::AutoText;

--- a/test/BinaryHeaderGet.cpp
+++ b/test/BinaryHeaderGet.cpp
@@ -24,7 +24,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 
-#include "../source/spirv_constant.h"
+#include "source/spirv_constant.h"
 #include "UnitSPIRV.h"
 
 namespace {

--- a/test/BinaryToText.cpp
+++ b/test/BinaryToText.cpp
@@ -30,7 +30,7 @@
 
 #include "gmock/gmock.h"
 
-#include "../source/spirv_constant.h"
+#include "source/spirv_constant.h"
 #include "TestFixture.h"
 
 using ::testing::Eq;

--- a/test/GeneratorMagicNumber.cpp
+++ b/test/GeneratorMagicNumber.cpp
@@ -28,7 +28,7 @@
 
 #include <gmock/gmock.h>
 
-#include "../source/opcode.h"
+#include "source/opcode.h"
 
 using ::spvtest::EnumCase;
 using ::testing::Eq;

--- a/test/OperandPattern.cpp
+++ b/test/OperandPattern.cpp
@@ -27,7 +27,7 @@
 #include "UnitSPIRV.h"
 
 #include "gmock/gmock.h"
-#include "../source/operand.h"
+#include "source/operand.h"
 
 using ::testing::Eq;
 

--- a/test/TextToBinary.cpp
+++ b/test/TextToBinary.cpp
@@ -32,8 +32,8 @@
 
 #include "TestFixture.h"
 #include "UnitSPIRV.h"
+#include "source/spirv_constant.h"
 #include "util/bitutils.h"
-#include "../source/spirv_constant.h"
 
 namespace {
 

--- a/test/UnitSPIRV.h
+++ b/test/UnitSPIRV.h
@@ -32,14 +32,14 @@
 #include <iomanip>
 
 #include "libspirv/libspirv.h"
-#include "../source/assembly_grammar.h"
-#include "../source/binary.h"
-#include "../source/diagnostic.h"
-#include "../source/opcode.h"
-#include "../source/spirv_endian.h"
-#include "../source/text.h"
-#include "../source/text_handler.h"
-#include "../source/validate.h"
+#include "source/assembly_grammar.h"
+#include "source/binary.h"
+#include "source/diagnostic.h"
+#include "source/opcode.h"
+#include "source/spirv_endian.h"
+#include "source/text.h"
+#include "source/text_handler.h"
+#include "source/validate.h"
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
Adds CMAKE_CURRENT_SOURCE_DIR to the include path for UnitSPIRV