### PR TITLE
operator<< on FloatProxy preserves float and fill

### DIFF
--- a/include/util/hex_float.h
+++ b/include/util/hex_float.h
@@ -679,6 +679,9 @@ std::ostream& operator<<(std::ostream& os, const HexFloat<T, Traits>& value) {
     --fraction_nibbles;
   }
 
+  const auto saved_flags = os.flags();
+  const auto saved_fill = os.fill();
+
   os << sign << "0x" << (is_zero ? '0' : '1');
   if (fraction_nibbles) {
     // Make sure to keep the leading 0s in place, since this is the fractional
@@ -687,6 +690,10 @@ std::ostream& operator<<(std::ostream& os, const HexFloat<T, Traits>& value) {
        << fraction;
   }
   os << "p" << std::dec << (int_exponent >= 0 ? "+" : "") << int_exponent;
+
+  os.flags(saved_flags);
+  os.fill(saved_fill);
+
   return os;
 }
 

--- a/test/HexFloat.cpp
+++ b/test/HexFloat.cpp
@@ -248,6 +248,21 @@ INSTANTIATE_TEST_CASE_P(
         {uint64_t(0x7FFFFFFFFFFFFFFFLL), "0x1.fffffffffffffp+1024"},   // -nan
     })));
 
+TEST(HexFloatStreamTest, OperatorLeftShiftPreservesFloatAndFill) {
+  std::stringstream s;
+  s << std::setw(4) << std::oct << std::setfill('x') << 8 << " "
+    << FloatProxy<float>(uint32_t(0xFF800100)) << " " << std::setw(4) << 9;
+  EXPECT_THAT(s.str(), Eq(std::string("xx10 -0x1.0002p+128 xx11")));
+}
+
+TEST(HexDoubleStreamTest, OperatorLeftShiftPreservesFloatAndFill) {
+  std::stringstream s;
+  s << std::setw(4) << std::oct << std::setfill('x') << 8 << " "
+    << FloatProxy<double>(uint64_t(0x7FF0F00000000000LL)) << " " << std::setw(4)
+    << 9;
+  EXPECT_THAT(s.str(), Eq(std::string("xx10 0x1.0fp+1024 xx11")));
+}
+
 TEST_P(DecodeHexFloatTest, DecodeCorrectly) {
   EXPECT_THAT(Decode<float>(GetParam().first), Eq(GetParam().second));
 }


### PR DESCRIPTION
Fixes formatting of disassembler output after printing
a hex float, e.g. for a NaN or subnormal.