### PR TITLE
Fix strict clang warnings

### DIFF
--- a/include/util/hex_float.h
+++ b/include/util/hex_float.h
@@ -608,15 +608,16 @@ class HexFloat {
 };
 
 // Returns 4 bits represented by the hex character.
-inline uint8_t get_nibble_from_character(char character) {
+inline uint8_t get_nibble_from_character(int character) {
   const char* dec = "0123456789";
   const char* lower = "abcdef";
   const char* upper = "ABCDEF";
-  if (auto p = strchr(dec, character)) {
+  const char* p = nullptr;
+  if ((p = strchr(dec, character))) {
     return static_cast<uint8_t>(p - dec);
-  } else if (auto p = strchr(lower, character)) {
+  } else if ((p = strchr(lower, character))) {
     return static_cast<uint8_t>(p - lower + 0xa);
-  } else if (auto p = strchr(upper, character)) {
+  } else if ((p = strchr(upper, character))) {
     return static_cast<uint8_t>(p - upper + 0xa);
   }
 
@@ -686,8 +687,8 @@ std::ostream& operator<<(std::ostream& os, const HexFloat<T, Traits>& value) {
   if (fraction_nibbles) {
     // Make sure to keep the leading 0s in place, since this is the fractional
     // part.
-    os << "." << std::setw(fraction_nibbles) << std::setfill('0') << std::hex
-       << fraction;
+    os << "." << std::setw(static_cast<int>(fraction_nibbles))
+       << std::setfill('0') << std::hex << fraction;
   }
   os << "p" << std::dec << (int_exponent >= 0 ? "+" : "") << int_exponent;
 
@@ -743,7 +744,7 @@ std::istream& operator>>(std::istream& is, HexFloat<T, Traits>& value) {
     }
   }
 
-  char next_char = is.peek();
+  auto next_char = is.peek();
   bool negate_value = false;
 
   if (next_char != '-' && next_char != '0') {
@@ -758,7 +759,7 @@ std::istream& operator>>(std::istream& is, HexFloat<T, Traits>& value) {
 
   if (next_char == '0') {
     is.get();  // We may have to unget this.
-    char maybe_hex_start = is.peek();
+    auto maybe_hex_start = is.peek();
     if (maybe_hex_start != 'x' && maybe_hex_start != 'X') {
       is.unget();
       return ParseNormalFloat(is, negate_value, value);

--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -769,7 +769,8 @@ spv_result_t Parser::setNumericTypeInfoForType(
 
   parsed_operand->number_kind = info.type;
   parsed_operand->number_bit_width = info.bit_width;
-  parsed_operand->num_words = (info.bit_width + 31) / 32;  // Round up
+  // Round up the word count.
+  parsed_operand->num_words = static_cast<uint16_t>((info.bit_width + 31) / 32);
   return SPV_SUCCESS;
 }
 

--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -463,18 +463,20 @@ spv_result_t Parser::parseOperand(size_t inst_offset,
 
   switch (type) {
     case SPV_OPERAND_TYPE_TYPE_ID:
-      if (!word) return diagnostic(SPV_ERROR_INVALID_ID) << "Error: Type Id is 0";
+      if (!word)
+        return diagnostic(SPV_ERROR_INVALID_ID) << "Error: Type Id is 0";
       inst->type_id = word;
       break;
 
     case SPV_OPERAND_TYPE_RESULT_ID:
-      if (!word) return diagnostic(SPV_ERROR_INVALID_ID) << "Error: Result Id is 0";
+      if (!word)
+        return diagnostic(SPV_ERROR_INVALID_ID) << "Error: Result Id is 0";
       inst->result_id = word;
       // Save the result ID to type ID mapping.
       // In the grammar, type ID always appears before result ID.
       if (_.id_to_type_id.find(inst->result_id) != _.id_to_type_id.end())
         return diagnostic(SPV_ERROR_INVALID_ID) << "Id " << inst->result_id
-                            << " is defined more than once";
+                                                << " is defined more than once";
       // Record it.
       // A regular value maps to its type.  Some instructions (e.g. OpLabel)
       // have no type Id, and will map to 0.  The result Id for a
@@ -736,8 +738,8 @@ spv_result_t Parser::parseOperand(size_t inst_offset,
     if (convert_operand_endianness) {
       const spv_endianness_t endianness = _.endian;
       std::transform(_.words + _.word_index, _.words + index_after_operand,
-                     words->end(), [endianness](const uint32_t word) {
-                       return spvFixWord(word, endianness);
+                     words->end(), [endianness](const uint32_t raw_word) {
+                       return spvFixWord(raw_word, endianness);
                      });
     } else {
       words->insert(words->end(), _.words + _.word_index,

--- a/source/diagnostic.h
+++ b/source/diagnostic.h
@@ -37,21 +37,22 @@ namespace libspirv {
 
 class diagnostic_helper {
  public:
-  diagnostic_helper(spv_position_t& position, spv_diagnostic* pDiagnostic)
-      : position(&position), pDiagnostic(pDiagnostic) {}
+  diagnostic_helper(spv_position_t& position, spv_diagnostic* diagnostic)
+      : position_(&position), diagnostic_(diagnostic) {}
 
-  diagnostic_helper(spv_position position, spv_diagnostic* pDiagnostic)
-      : position(position), pDiagnostic(pDiagnostic) {}
+  diagnostic_helper(spv_position position, spv_diagnostic* diagnostic)
+      : position_(position), diagnostic_(diagnostic) {}
 
   ~diagnostic_helper() {
-    *pDiagnostic = spvDiagnosticCreate(position, stream.str().c_str());
+    *diagnostic_ = spvDiagnosticCreate(position_, stream().str().c_str());
   }
 
-  std::stringstream stream;
+  std::stringstream& stream() { return stream_; }
 
  private:
-  spv_position position;
-  spv_diagnostic* pDiagnostic;
+  std::stringstream stream_;
+  spv_position position_;
+  spv_diagnostic* diagnostic_;
 };
 
 // A DiagnosticStream remembers the current position of the input and an error
@@ -99,7 +100,7 @@ class DiagnosticStream {
 
 #define DIAGNOSTIC                                           \
   libspirv::diagnostic_helper helper(position, pDiagnostic); \
-  helper.stream
+  helper.stream()
 
 }  // namespace libspirv
 

--- a/source/disassemble.cpp
+++ b/source/disassemble.cpp
@@ -260,7 +260,7 @@ void Disassembler::EmitOperand(const spv_parsed_instruction_t& inst,
         }
       } else {
         // TODO(dneto): Support more than 64-bits at a time.
-        assert("Unhandled");
+        assert(false && "Unhandled");
       }
     } break;
     case SPV_OPERAND_TYPE_LITERAL_STRING: {

--- a/source/text.cpp
+++ b/source/text.cpp
@@ -368,8 +368,8 @@ spv_result_t spvTextEncodeOperand(const libspirv::AssemblyGrammar& grammar,
                  << "Invalid extended instruction import '" << literal.str
                  << "'";
         }
-        if (auto error = context->recordIdAsExtInstImport(pInst->words[1],
-                                                          ext_inst_type))
+        if ((error = context->recordIdAsExtInstImport(pInst->words[1],
+                                                      ext_inst_type)))
           return error;
       }
 

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -552,11 +552,10 @@ spv_result_t ProcessInstructions(void* user_data,
   // TODO(umar): Perform CFG pass
   // TODO(umar): Perform data rules pass
   // TODO(umar): Perform instruction validation pass
-  spv_result_t ret = SPV_SUCCESS;
   CHECK_RESULT(ModuleLayoutPass(_, inst))
   CHECK_RESULT(SsaPass(_, can_have_forward_declared_ids, inst))
 
-  return ret;
+  return SPV_SUCCESS;
 }
 
 } // anonymous namespace

--- a/source/validate_id.cpp
+++ b/source/validate_id.cpp
@@ -44,20 +44,20 @@
 namespace {
 class idUsage {
  public:
-  idUsage(const spv_opcode_table opcodeTable,
-          const spv_operand_table operandTable,
-          const spv_ext_inst_table extInstTable, const spv_id_info_t* pIdUses,
+  idUsage(const spv_opcode_table opcodeTableArg,
+          const spv_operand_table operandTableArg,
+          const spv_ext_inst_table extInstTableArg, const spv_id_info_t* pIdUses,
           const uint64_t idUsesCount, const spv_id_info_t* pIdDefs,
           const uint64_t idDefsCount, const spv_instruction_t* pInsts,
-          const uint64_t instCount, spv_position position,
-          spv_diagnostic* pDiagnostic)
-      : opcodeTable(opcodeTable),
-        operandTable(operandTable),
-        extInstTable(extInstTable),
+          const uint64_t instCountArg, spv_position positionArg,
+          spv_diagnostic* pDiagnosticArg)
+      : opcodeTable(opcodeTableArg),
+        operandTable(operandTableArg),
+        extInstTable(extInstTableArg),
         firstInst(pInsts),
-        instCount(instCount),
-        position(position),
-        pDiagnostic(pDiagnostic) {
+        instCount(instCountArg),
+        position(positionArg),
+        pDiagnostic(pDiagnosticArg) {
     for (uint64_t idUsesIndex = 0; idUsesIndex < idUsesCount; ++idUsesIndex) {
       idUses[pIdUses[idUsesIndex].id].push_back(pIdUses[idUsesIndex]);
     }


### PR DESCRIPTION
Avoid:
- variable or argument shadowing
- implicit narrowing conversions
- implicit conversions of character array to bool (that the compiler complains about)