### PR TITLE
Hooked up 16-bit floating point numbers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,6 @@ It supports the standard `googletest` command line options.
 
 ### Assembler and disassembler
 
-* Support 16-bit floating point literals.
 * The disassembler could emit helpful annotations in comments.  For example:
   * Use variable name information from debug instructions to annotate
     key operations on variables.

--- a/source/disassemble.cpp
+++ b/source/disassemble.cpp
@@ -233,9 +233,12 @@ void Disassembler::EmitOperand(const spv_parsed_instruction_t& inst,
             stream_ << word;
             break;
           case SPV_NUMBER_FLOATING:
-            // Assume only 32-bit floats.
-            // TODO(dneto): Handle 16-bit floats also.
-            stream_ << spvutils::FloatProxy<float>(word);
+            if (operand.number_bit_width == 16) {
+              stream_ << spvutils::FloatProxy<spvutils::Float16>(uint16_t(word & 0xFFFF));
+            } else {
+              // Assume 32-bit floats.
+              stream_ << spvutils::FloatProxy<float>(word);
+            }
             break;
           default:
             assert(false && "Unreachable");

--- a/test/TestFixture.h
+++ b/test/TestFixture.h
@@ -183,7 +183,9 @@ class TextToBinaryTestBase : public T {
 };
 
 using TextToBinaryTest = TextToBinaryTestBase<::testing::Test>;
-
 }  // namespace spvtest
+
+using RoundTripTest =
+    spvtest::TextToBinaryTestBase<::testing::TestWithParam<std::string>>;
 
 #endif  // LIBSPIRV_TEST_TEST_FIXTURE_H_

--- a/test/TextToBinary.Constant.cpp
+++ b/test/TextToBinary.Constant.cpp
@@ -341,17 +341,9 @@ INSTANTIATE_TEST_CASE_P(
     }));
 // clang-format on
 
-using RoundTripTest =
-    spvtest::TextToBinaryTestBase<::testing::TestWithParam<std::string>>;
-
 const int64_t kMaxUnsigned48Bit = (int64_t(1) << 48) - 1;
 const int64_t kMaxSigned48Bit = (int64_t(1) << 47) - 1;
 const int64_t kMinSigned48Bit = -kMaxSigned48Bit - 1;
-
-TEST_P(RoundTripTest, Sample) {
-  EXPECT_THAT(EncodeAndDecodeSuccessfully(GetParam()), Eq(GetParam()))
-      << GetParam();
-}
 
 INSTANTIATE_TEST_CASE_P(
     OpConstantRoundTrip, RoundTripTest,
@@ -394,6 +386,41 @@ INSTANTIATE_TEST_CASE_P(
         "%1 = OpTypeFloat 64\n%2 = OpConstant %1 0\n",
         "%1 = OpTypeFloat 64\n%2 = OpConstant %1 1.79769e+308\n",
         "%1 = OpTypeFloat 64\n%2 = OpConstant %1 -1.79769e+308\n",
+    }));
+
+INSTANTIATE_TEST_CASE_P(
+    OpConstantHalfRoundTrip, RoundTripTest,
+    ::testing::ValuesIn(std::vector<std::string>{
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 -0x0p+0\n",
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 0x0p+0\n",
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 0x1p+0\n",
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 0x1.1p+0\n",
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 0x1.01p-1\n",
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 0x1.8p+1\n",
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 0x1.ffcp+1\n",
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 -0x1p+0\n",
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 -0x1.1p+0\n",
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 -0x1.01p-1\n",
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 -0x1.8p+1\n",
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 -0x1.ffcp+1\n",
+
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 0x1p-16\n", // some denorms
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 0x1p-24\n",
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 -0x1p-24\n",
+
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 0x1p+16\n", // +inf
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 -0x1p+16\n", // -inf
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 -0x1.01p+16\n", // -inf
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 0x1.01p+16\n", // nan
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 0x1.11p+16\n", // nan
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 0x1.ffp+16\n", // nan
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 0x1.ffcp+16\n", // nan
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 0x1.004p+16\n", // nan
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 -0x1.01p+16\n", // -nan
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 -0x1.11p+16\n", // -nan
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 -0x1.ffp+16\n", // -nan
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 -0x1.ffcp+16\n", // -nan
+        "%1 = OpTypeFloat 16\n%2 = OpConstant %1 -0x1.004p+16\n", // -nan
     }));
 
 // clang-format off

--- a/test/TextToBinary.ControlFlow.cpp
+++ b/test/TextToBinary.ControlFlow.cpp
@@ -272,13 +272,6 @@ INSTANTIATE_TEST_CASE_P(
         MakeSwitchTestCase(64, 1, "0x700000123", {0x123, 7}, "12", {12, 0}),
     })));
 
-using RoundTripTest =
-    spvtest::TextToBinaryTestBase<::testing::TestWithParam<std::string>>;
-
-TEST_P(RoundTripTest, Sample) {
-  EXPECT_THAT(EncodeAndDecodeSuccessfully(GetParam()), Eq(GetParam()));
-}
-
 INSTANTIATE_TEST_CASE_P(
     OpSwitchRoundTripUnsignedIntegers, RoundTripTest,
     ::testing::ValuesIn(std::vector<std::string>({

--- a/test/UnitSPIRV.cpp
+++ b/test/UnitSPIRV.cpp
@@ -27,6 +27,7 @@
 #include "UnitSPIRV.h"
 
 #include "gmock/gmock.h"
+#include "TestFixture.h"
 
 namespace {
 
@@ -54,6 +55,11 @@ TEST(WordVectorPrintTo, PreservesFlagsAndFill) {
   s << std::setw(4) << 9;
 
   EXPECT_THAT(s.str(), Eq("xx10 0x0000000a 0x00000010 xx11"));
+}
+
+TEST_P(RoundTripTest, Sample) {
+  EXPECT_THAT(EncodeAndDecodeSuccessfully(GetParam()), Eq(GetParam()))
+      << GetParam();
 }
 
 }  // anonymous namespace

--- a/test/UnitSPIRV.h
+++ b/test/UnitSPIRV.h
@@ -215,5 +215,4 @@ inline std::string MakeLongUTF8String(size_t num_4_byte_chars) {
 }
 
 }  // namespace spvtest
-
 #endif  // LIBSPIRV_TEST_UNITSPIRV_H_


### PR DESCRIPTION
This adds half-precision constants to spirv-tools.
16-bit floats are always disassembled into hex-float format,
but can be assembled from floating point or hex-float inputs.