### PR TITLE
Made compilation with gcc and clang more strict.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,9 @@ function(default_compile_options TARGET)
   if (UNIX)
     target_compile_options(${TARGET} PRIVATE
       -std=c++11 -fno-exceptions -fno-rtti)
+    target_compile_options(${TARGET} PRIVATE
+      -Wall -Wextra -Wno-long-long -Wshadow -Wundef -Wconversion
+      -Wno-sign-conversion)
     # For good call stacks in profiles, keep the frame pointers.
     if(NOT "${SPIRV_PERF}" STREQUAL "")
       target_compile_options(${TARGET} PRIVATE -fno-omit-frame-pointer)
@@ -92,6 +95,9 @@ function(default_compile_options TARGET)
         target_compile_options(${TARGET} PRIVATE
           -fsanitize=${SPIRV_USE_SANITIZER})
       endif()
+    else()
+      target_compile_options(${TARGET} PRIVATE
+         -Wno-missing-field-initializers)
     endif()
   endif()
 endfunction()
@@ -231,6 +237,10 @@ if (NOT ${SPIRV_SKIP_EXECUTABLES})
 
     add_executable(UnitSPIRV ${TEST_SOURCES})
     default_compile_options(UnitSPIRV)
+    if(UNIX)
+     target_compile_options(UnitSPIRV PRIVATE
+        -Wno-undef)
+    endif()
     target_include_directories(UnitSPIRV PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
       ${gmock_SOURCE_DIR}/include ${gtest_SOURCE_DIR}/include)

--- a/test/BinaryDestroy.cpp
+++ b/test/BinaryDestroy.cpp
@@ -40,7 +40,6 @@ using BinaryDestroySomething = spvtest::TextToBinaryTest;
 
 // Checks safety of destroying a validly constructed binary.
 TEST_F(BinaryDestroySomething, Default) {
-  spv_context context = spvContextCreate();
   // Use a binary object constructed by the API instead of rolling our own.
   SetText("OpSource OpenCL_C 120");
   spv_binary my_binary = nullptr;
@@ -48,7 +47,6 @@ TEST_F(BinaryDestroySomething, Default) {
                                          &my_binary, &diagnostic));
   ASSERT_NE(nullptr, my_binary);
   spvBinaryDestroy(my_binary);
-  spvContextDestroy(context);
 }
 
 }  // anonymous namespace

--- a/test/BinaryHeaderGet.cpp
+++ b/test/BinaryHeaderGet.cpp
@@ -70,10 +70,10 @@ TEST_F(BinaryHeaderGet, Default) {
 }
 
 TEST_F(BinaryHeaderGet, InvalidCode) {
-  spv_const_binary_t binary = {nullptr, 0};
+  spv_const_binary_t my_binary = {nullptr, 0};
   spv_header_t header;
   ASSERT_EQ(SPV_ERROR_INVALID_BINARY,
-            spvBinaryHeaderGet(&binary, SPV_ENDIANNESS_LITTLE, &header));
+            spvBinaryHeaderGet(&my_binary, SPV_ENDIANNESS_LITTLE, &header));
 }
 
 TEST_F(BinaryHeaderGet, InvalidPointerHeader) {

--- a/test/BinaryToText.cpp
+++ b/test/BinaryToText.cpp
@@ -396,7 +396,6 @@ OpStore %2 %3 Aligned|Volatile 4 ; bogus, but not indented
 TEST_F(TextToBinaryTest, VersionString) {
   auto words = CompileSuccessfully("");
   spv_text decoded_text = nullptr;
-  spv_diagnostic diagnostic = nullptr;
   EXPECT_THAT(spvBinaryToText(context, words.data(), words.size(),
                               SPV_BINARY_TO_TEXT_OPTION_NONE, &decoded_text,
                               &diagnostic),
@@ -430,7 +429,6 @@ TEST_P(GeneratorStringTest, Sample) {
       SPV_GENERATOR_WORD(GetParam().generator, GetParam().misc);
 
   spv_text decoded_text = nullptr;
-  spv_diagnostic diagnostic = nullptr;
   EXPECT_THAT(spvBinaryToText(context, words.data(), words.size(),
                               SPV_BINARY_TO_TEXT_OPTION_NONE, &decoded_text,
                               &diagnostic),

--- a/test/HexFloat.cpp
+++ b/test/HexFloat.cpp
@@ -592,7 +592,7 @@ TEST(HexFloatOperationTest, UnbiasedExponent) {
 float float_fractions(const std::vector<uint32_t>& fractions) {
   float f = 0;
   for(int32_t i: fractions) {
-    f += ldexp(1.0f, -i);
+    f += std::ldexp(1.0f, -i);
   }
   return f;
 }
@@ -626,7 +626,7 @@ uint16_t half_bits_set(const std::vector<uint32_t>& bits) {
   for(uint32_t i: bits) {
     val |= top_bit >> i;
   }
-  return val;
+  return static_cast<uint16_t>(val);
 }
 
 TEST(HexFloatOperationTest, NormalizedSignificand) {

--- a/test/ImmediateInt.cpp
+++ b/test/ImmediateInt.cpp
@@ -184,7 +184,7 @@ TEST_F(ImmediateIntTest, StringFollowingImmediate) {
     EXPECT_EQ(original,
               CompiledInstructions("OpMemberName !1 !4 \"" + name + "\""))
         << name;
-    const uint32_t wordCount = 4 + name.size() / 4;
+    const uint16_t wordCount = static_cast<uint16_t>(4 + name.size() / 4);
     const uint32_t firstWord = spvOpcodeMake(wordCount, SpvOpMemberName);
     EXPECT_EQ(original, CompiledInstructions("!" + std::to_string(firstWord) +
                                              " %10 !4 \"" + name + "\""))

--- a/test/TestFixture.h
+++ b/test/TestFixture.h
@@ -65,10 +65,10 @@ class TextToBinaryTestBase : public T {
 
   // Compiles SPIR-V text in the given assembly syntax format, asserting
   // compilation success. Returns the compiled code.
-  SpirvVector CompileSuccessfully(const std::string& text) {
-    spv_result_t status = spvTextToBinary(context, text.c_str(), text.size(),
+  SpirvVector CompileSuccessfully(const std::string& txt) {
+    spv_result_t status = spvTextToBinary(context, txt.c_str(), txt.size(),
                                           &binary, &diagnostic);
-    EXPECT_EQ(SPV_SUCCESS, status) << text;
+    EXPECT_EQ(SPV_SUCCESS, status) << txt;
     SpirvVector code_copy;
     if (status == SPV_SUCCESS) {
       code_copy = SpirvVector(binary->code, binary->code + binary->wordCount);
@@ -81,26 +81,26 @@ class TextToBinaryTestBase : public T {
 
   // Compiles SPIR-V text with the given format, asserting compilation failure.
   // Returns the error message(s).
-  std::string CompileFailure(const std::string& text) {
-    EXPECT_NE(SPV_SUCCESS, spvTextToBinary(context, text.c_str(), text.size(),
+  std::string CompileFailure(const std::string& txt) {
+    EXPECT_NE(SPV_SUCCESS, spvTextToBinary(context, txt.c_str(), txt.size(),
                                            &binary, &diagnostic))
-        << text;
+        << txt;
     DestroyBinary();
     return diagnostic->error;
   }
 
   // Encodes SPIR-V text into binary and then decodes the binary using
   // default options. Returns the decoded text.
-  std::string EncodeAndDecodeSuccessfully(const std::string& text) {
-    return EncodeAndDecodeSuccessfully(text, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string EncodeAndDecodeSuccessfully(const std::string& txt) {
+    return EncodeAndDecodeSuccessfully(txt, SPV_BINARY_TO_TEXT_OPTION_NONE);
   }
 
   // Encodes SPIR-V text into binary and then decodes the binary using
   // given options. Returns the decoded text.
-  std::string EncodeAndDecodeSuccessfully(const std::string& text,
+  std::string EncodeAndDecodeSuccessfully(const std::string& txt,
                                           uint32_t disassemble_options) {
     DestroyBinary();
-    spv_result_t error = spvTextToBinary(context, text.c_str(), text.size(),
+    spv_result_t error = spvTextToBinary(context, txt.c_str(), txt.size(),
                                          &binary, &diagnostic);
     if (error) {
       spvDiagnosticPrint(diagnostic);
@@ -116,7 +116,7 @@ class TextToBinaryTestBase : public T {
       spvDiagnosticPrint(diagnostic);
       spvDiagnosticDestroy(diagnostic);
     }
-    EXPECT_EQ(SPV_SUCCESS, error) << text;
+    EXPECT_EQ(SPV_SUCCESS, error) << txt;
 
     const std::string decoded_string = decoded_text->str;
     spvTextDestroy(decoded_text);
@@ -132,9 +132,9 @@ class TextToBinaryTestBase : public T {
   // is then decoded. This is expected to fail.
   // Returns the error message.
   std::string EncodeSuccessfullyDecodeFailed(
-      const std::string& text, const SpirvVector& words_to_append) {
+      const std::string& txt, const SpirvVector& words_to_append) {
     SpirvVector code =
-        spvtest::Concatenate({CompileSuccessfully(text), words_to_append});
+        spvtest::Concatenate({CompileSuccessfully(txt), words_to_append});
 
     spv_text decoded_text;
     EXPECT_NE(SPV_SUCCESS, spvBinaryToText(context, code.data(), code.size(),
@@ -151,8 +151,8 @@ class TextToBinaryTestBase : public T {
 
   // Compiles SPIR-V text, asserts success, and returns the words representing
   // the instructions.  In particular, skip the words in the SPIR-V header.
-  SpirvVector CompiledInstructions(const std::string& text) {
-    const SpirvVector code = CompileSuccessfully(text);
+  SpirvVector CompiledInstructions(const std::string& txt) {
+    const SpirvVector code = CompileSuccessfully(txt);
     SpirvVector result;
     // Extract just the instructions.
     // If the code fails to compile, then return the empty vector.

--- a/test/TextToBinary.cpp
+++ b/test/TextToBinary.cpp
@@ -140,7 +140,6 @@ union char_word_t {
 };
 
 TEST_F(TextToBinaryTest, InvalidText) {
-  spv_binary binary;
   ASSERT_EQ(SPV_ERROR_INVALID_TEXT,
             spvTextToBinary(context, nullptr, 0, &binary, &diagnostic));
   EXPECT_NE(nullptr, diagnostic);
@@ -158,7 +157,6 @@ TEST_F(TextToBinaryTest, InvalidPointer) {
 TEST_F(TextToBinaryTest, InvalidDiagnostic) {
   SetText(
       "OpEntryPoint Kernel 0 \"\"\nOpExecutionMode 0 LocalSizeHint 1 1 1\n");
-  spv_binary binary;
   ASSERT_EQ(SPV_ERROR_INVALID_DIAGNOSTIC,
             spvTextToBinary(context, text.str, text.length, &binary, nullptr));
 }

--- a/test/UnitSPIRV.h
+++ b/test/UnitSPIRV.h
@@ -79,7 +79,7 @@ void PrintTo(const WordVector& words, ::std::ostream* os);
 // A proxy class to allow us to easily write out vectors of SPIR-V words.
 class WordVector {
  public:
-  explicit WordVector(const std::vector<uint32_t>& value) : value_(value) {}
+  explicit WordVector(const std::vector<uint32_t>& val) : value_(val) {}
   explicit WordVector(const spv_binary_t& binary)
       : value_(binary.code, binary.code + binary.wordCount) {}
 
@@ -179,8 +179,8 @@ struct AutoText {
 template <typename E>
 class EnumCase {
  public:
-  EnumCase(E value, std::string name, std::vector<uint32_t> operands = {})
-      : enum_value_(value), name_(name), operands_(operands) {}
+  EnumCase(E val, std::string enum_name, std::vector<uint32_t> ops = {})
+      : enum_value_(val), name_(enum_name), operands_(ops) {}
   // Returns the enum value as a uint32_t.
   uint32_t value() const { return static_cast<uint32_t>(enum_value_); }
   // Returns the name of the enumerant.


### PR DESCRIPTION
Added additional compilation flags to gcc and clang builds.
Adds -Wall -Wextra -Wno-long-long -Wshadow -Wundef -Wconversion
-WNo-sign-conversion and -Wno-missing-field-initializers
where appropriate.

Does not add -Wundef to tests, because GTEST tests undefined
macros all over the place.