### PR TITLE
spvDiagnosticDestroy is safe to call on nullptr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,7 @@ if (NOT ${SPIRV_SKIP_EXECUTABLES})
       ${CMAKE_CURRENT_SOURCE_DIR}/test/BinaryToText.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/test/BinaryToText.Literal.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/test/Comment.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/test/DiagnosticDestroy.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/test/DiagnosticPrint.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/test/DiagnosticStream.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/test/ExtInstGLSLstd450.cpp

--- a/include/libspirv/libspirv.h
+++ b/include/libspirv/libspirv.h
@@ -390,7 +390,8 @@ spv_result_t spvValidate(const spv_const_context context,
 spv_diagnostic spvDiagnosticCreate(const spv_position position,
                                    const char* message);
 
-/// Destroys a diagnostic object.
+// Destroys a diagnostic object.  This is a no-op if diagnostic is a null
+// pointer.
 void spvDiagnosticDestroy(spv_diagnostic diagnostic);
 
 // Prints the diagnostic to stderr.

--- a/test/DiagnosticDestroy.cpp
+++ b/test/DiagnosticDestroy.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2015-2016 The Khronos Group Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and/or associated documentation files (the
+// "Materials"), to deal in the Materials without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Materials, and to
+// permit persons to whom the Materials are furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Materials.
+//
+// MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS
+// KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS
+// SPECIFICATIONS AND HEADER INFORMATION ARE LOCATED AT
+//    https://www.khronos.org/registry/
+//
+// THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+#include "UnitSPIRV.h"
+
+namespace {
+
+TEST(DiagnosticDestroy, DestroyNull) { spvDiagnosticDestroy(nullptr); }
+
+// Returns a newly created diagnostic value.
+spv_diagnostic MakeValidDiagnostic() {
+  spv_position_t position = {};
+  spv_diagnostic diagnostic = spvDiagnosticCreate(&position, "");
+  EXPECT_NE(nullptr, diagnostic);
+  return diagnostic;
+}
+
+TEST(DiagnosticDestroy, DestroyValidDiagnostic) {
+  spv_diagnostic diagnostic = MakeValidDiagnostic();
+  spvDiagnosticDestroy(diagnostic);
+  // We aren't allowed to use the diagnostic pointer anymore.
+  // So we can't test its behaviour.
+}
+
+TEST(DiagnosticDestroy, DestroyValidDiagnosticAfterReassignment) {
+  spv_diagnostic diagnostic = MakeValidDiagnostic();
+  spv_diagnostic second_diagnostic = MakeValidDiagnostic();
+  EXPECT_TRUE(diagnostic != second_diagnostic);
+  spvDiagnosticDestroy(diagnostic);
+  diagnostic = second_diagnostic;
+  spvDiagnosticDestroy(diagnostic);
+}
+
+}  // anonymous namespace


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/62