### PR TITLE
Fix build by renaming ValidationState_t constructor argument.

### DIFF
--- a/source/validate_types.cpp
+++ b/source/validate_types.cpp
@@ -116,8 +116,8 @@ const vector<vector<SpvOp>>& GetModuleOrder() {
 
 namespace libspirv {
 
-ValidationState_t::ValidationState_t(spv_diagnostic* diag, uint32_t options)
-    : diagnostic_(diag),
+ValidationState_t::ValidationState_t(spv_diagnostic* diagnostic, uint32_t options)
+    : diagnostic_(diagnostic),
       instruction_counter_(0),
       defined_ids_{},
       unresolved_forward_ids_{},

--- a/source/validate_types.h
+++ b/source/validate_types.h
@@ -152,7 +152,7 @@ class Functions {
 
 class ValidationState_t {
  public:
-  ValidationState_t(spv_diagnostic* diag, uint32_t options);
+  ValidationState_t(spv_diagnostic* diagnostic, uint32_t options);
 
   // Defines the \p id for the module
   spv_result_t defineId(uint32_t id);


### PR DESCRIPTION
The `diag` argument shadows the `diag` method, so the strict build fails.