### PR TITLE
Add disassembler option to show byte offset

### DIFF
--- a/include/libspirv/libspirv.h
+++ b/include/libspirv/libspirv.h
@@ -251,6 +251,7 @@ typedef enum spv_binary_to_text_options_t {
   SPV_BINARY_TO_TEXT_OPTION_PRINT = SPV_BIT(1),
   SPV_BINARY_TO_TEXT_OPTION_COLOR = SPV_BIT(2),
   SPV_BINARY_TO_TEXT_OPTION_INDENT = SPV_BIT(3),
+  SPV_BINARY_TO_TEXT_OPTION_SHOW_BYTE_OFFSET = SPV_BIT(4),
   SPV_FORCE_32_BIT_ENUM(spv_binary_to_text_options_t)
 } spv_binary_to_text_options_t;
 

--- a/test/BinaryToText.cpp
+++ b/test/BinaryToText.cpp
@@ -392,6 +392,24 @@ OpStore %2 %3 Aligned|Volatile 4 ; bogus, but not indented
       expected);
 }
 
+TEST_F(TextToBinaryTest, ShowByteOffsetsWhenRequested) {
+  const std::string input = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+%1 = OpTypeInt 32 0
+%2 = OpTypeVoid
+)";
+  const std::string expected =
+      R"(OpCapability Shader ; 0x00000014
+OpMemoryModel Logical GLSL450 ; 0x0000001c
+%1 = OpTypeInt 32 0 ; 0x00000028
+%2 = OpTypeVoid ; 0x00000038
+)";
+  EXPECT_THAT(EncodeAndDecodeSuccessfully(
+                  input, SPV_BINARY_TO_TEXT_OPTION_SHOW_BYTE_OFFSET),
+              expected);
+}
+
 // Test version string.
 TEST_F(TextToBinaryTest, VersionString) {
   auto words = CompileSuccessfully("");

--- a/tools/dis/dis.cpp
+++ b/tools/dis/dis.cpp
@@ -52,6 +52,8 @@ Options:
                   The default when output goes to a file.
 
   --no-indent     Don't indent instructions.
+
+  --offsets       Show byte offsets for each instruction.
 )",
       argv0, argv0);
 }
@@ -65,6 +67,7 @@ int main(int argc, char** argv) {
   allow_color = true;
 #endif
   bool allow_indent = true;
+  bool show_byte_offsets = false;
 
   for (int argi = 1; argi < argc; ++argi) {
     if ('-' == argv[argi][0]) {
@@ -84,6 +87,7 @@ int main(int argc, char** argv) {
           // Long options
           if (0 == strcmp(argv[argi], "--no-color")) allow_color = false;
           if (0 == strcmp(argv[argi], "--no-indent")) allow_indent = false;
+          if (0 == strcmp(argv[argi], "--offsets")) show_byte_offsets = true;
           if (0 == strcmp(argv[argi], "--help")) {
             print_usage(argv[0]);
             return 0;
@@ -114,8 +118,9 @@ int main(int argc, char** argv) {
 
   uint32_t options = SPV_BINARY_TO_TEXT_OPTION_NONE;
 
-  if (allow_indent)
-    options |= SPV_BINARY_TO_TEXT_OPTION_INDENT;
+  if (allow_indent) options |= SPV_BINARY_TO_TEXT_OPTION_INDENT;
+
+  if (show_byte_offsets) options |= SPV_BINARY_TO_TEXT_OPTION_SHOW_BYTE_OFFSET;
 
   if (!outFile || (0 == strcmp("-", outFile))) {
     // Print to standard output.


### PR DESCRIPTION
The option is disabled by default.

The offset is printed in hex, as a comment after each instruction.