### PR TITLE
Since g++-4.9 has an ICE occasionally in travis add a retry.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,11 @@ before_script:
 script:
   - mkdir build && cd build
   - cmake -GNinja -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
-  - ninja
+    # Sometimes g++-4.9 flakes with an ICE. This may be an OOM thing when
+    # expanding many templates.
+    # If we fail the build the first time, then try to continue in
+    # single-process mode.
+  - ninja || ninja -j 1
   - ./UnitSPIRV --gtest_break_on_failure
 
 


### PR DESCRIPTION
Try to re-run the build with ninja -j 1 if the build fails,
this should reduce the number of build failures we see.