### PR TITLE
Fix in-function storage class validation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,7 @@ if (NOT ${SPIRV_SKIP_EXECUTABLES})
       ${CMAKE_CURRENT_SOURCE_DIR}/test/ValidateFixtures.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/test/Validate.Capability.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/test/Validate.Layout.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/test/Validate.Storage.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/test/Validate.SSA.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/test/ValidateID.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/test/main.cpp)

--- a/source/validate_instruction.cpp
+++ b/source/validate_instruction.cpp
@@ -492,7 +492,7 @@ spv_result_t InstructionPass(ValidationState_t& _,
             static_cast<SpvStorageClass>(inst->words[inst->operands[2].offset]);
         spvCheckReturn(StorageClassCapabilityCheck(_, storage_class));
 
-        if (_.getLayoutSection() == kLayoutFunctionDeclarations) {
+        if (_.getLayoutSection() == kLayoutFunctionDefinitions) {
           if (storage_class != SpvStorageClassFunction) {
             return _.diag(SPV_ERROR_INVALID_LAYOUT)
                    << "Variables must have a function[7] storage class inside"

--- a/test/Validate.Layout.cpp
+++ b/test/Validate.Layout.cpp
@@ -236,47 +236,6 @@ TEST_F(ValidateLayout, MemoryModelMissing) {
   ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
 }
 
-TEST_F(ValidateLayout, VariableFunctionStorageGood) {
-  char str[] = R"(
-          OpMemoryModel Logical GLSL450
-          OpDecorate %var Restrict
-%intt   = OpTypeInt 32 1
-%voidt  = OpTypeVoid
-%vfunct = OpTypeFunction %voidt
-%ptrt   = OpTypePointer Function %intt
-%func   = OpFunction %voidt None %vfunct
-%funcl  = OpLabel
-%var    = OpVariable %ptrt Function
-          OpReturn
-          OpFunctionEnd
-)";
-
-  CompileSuccessfully(str);
-  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
-}
-
-
-// TODO(umar): This function should be moved to another validation file
-TEST_F(ValidateLayout, DISABLED_VariableFunctionStorageBad) {
-  char str[] = R"(
-          OpMemoryModel Logical GLSL450
-          OpDecorate %var Restrict
-%intt   = OpTypeInt 32 1
-%voidt  = OpTypeVoid
-%vfunct = OpTypeFunction %voidt
-%ptrt   = OpTypePointer Function %intt
-%var    = OpVariable %ptrt Function     ; Invalid storage class for OpVariable
-%func   = OpFunction %voidt None %vfunct
-%funcl  = OpLabel
-          OpNop
-          OpReturn
-          OpFunctionEnd
-)";
-
-  CompileSuccessfully(str);
-  ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
-}
-
 TEST_F(ValidateLayout, FunctionDefinitionBeforeDeclarationBad) {
   char str[] = R"(
            OpMemoryModel Logical GLSL450

--- a/test/Validate.Storage.cpp
+++ b/test/Validate.Storage.cpp
@@ -74,4 +74,227 @@ TEST_F(ValidateStorage, FunctionStorageOutsideFunction) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
 }
+
+TEST_F(ValidateStorage, OtherStorageOutsideFunction) {
+  char str[] = R"(
+          OpCapability Shader
+          OpCapability Kernel
+          OpCapability AtomicStorage
+          OpMemoryModel Logical GLSL450
+%intt   = OpTypeInt 32 1
+%voidt  = OpTypeVoid
+%vfunct = OpTypeFunction %voidt
+%ptrt   = OpTypePointer Function %intt
+%unicon = OpVariable %ptrt UniformConstant
+%input  = OpVariable %ptrt Input
+%unif   = OpVariable %ptrt Uniform
+%output = OpVariable %ptrt Output
+%wgroup = OpVariable %ptrt Workgroup
+%xwgrp  = OpVariable %ptrt CrossWorkgroup
+%priv   = OpVariable %ptrt Private
+%gener  = OpVariable %ptrt Generic
+%pushco = OpVariable %ptrt PushConstant
+%atomct = OpVariable %ptrt AtomicCounter
+%image  = OpVariable %ptrt Image
+%func   = OpFunction %voidt None %vfunct
+%funcl  = OpLabel
+          OpReturn
+          OpFunctionEnd
+)";
+
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateStorage, InputStorageInsideFunction) {
+  char str[] = R"(
+          OpCapability Shader
+          OpMemoryModel Logical GLSL450
+%intt   = OpTypeInt 32 1
+%voidt  = OpTypeVoid
+%vfunct = OpTypeFunction %voidt
+%ptrt   = OpTypePointer Function %intt
+%func   = OpFunction %voidt None %vfunct
+%funcl  = OpLabel
+%var    = OpVariable %ptrt Input
+          OpReturn
+          OpFunctionEnd
+)";
+
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
+}
+
+TEST_F(ValidateStorage, UniformStorageInsideFunction) {
+  char str[] = R"(
+          OpCapability Shader
+          OpMemoryModel Logical GLSL450
+%intt   = OpTypeInt 32 1
+%voidt  = OpTypeVoid
+%vfunct = OpTypeFunction %voidt
+%ptrt   = OpTypePointer Function %intt
+%func   = OpFunction %voidt None %vfunct
+%funcl  = OpLabel
+%var    = OpVariable %ptrt Uniform
+          OpReturn
+          OpFunctionEnd
+)";
+
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
+}
+
+TEST_F(ValidateStorage, OutputStorageInsideFunction) {
+  char str[] = R"(
+          OpCapability Shader
+          OpMemoryModel Logical GLSL450
+%intt   = OpTypeInt 32 1
+%voidt  = OpTypeVoid
+%vfunct = OpTypeFunction %voidt
+%ptrt   = OpTypePointer Function %intt
+%func   = OpFunction %voidt None %vfunct
+%funcl  = OpLabel
+%var    = OpVariable %ptrt Output
+          OpReturn
+          OpFunctionEnd
+)";
+
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
+}
+
+TEST_F(ValidateStorage, WorkgroupStorageInsideFunction) {
+  char str[] = R"(
+          OpCapability Shader
+          OpMemoryModel Logical GLSL450
+%intt   = OpTypeInt 32 1
+%voidt  = OpTypeVoid
+%vfunct = OpTypeFunction %voidt
+%ptrt   = OpTypePointer Function %intt
+%func   = OpFunction %voidt None %vfunct
+%funcl  = OpLabel
+%var    = OpVariable %ptrt Workgroup
+          OpReturn
+          OpFunctionEnd
+)";
+
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
+}
+
+TEST_F(ValidateStorage, CrossWorkgroupStorageInsideFunction) {
+  char str[] = R"(
+          OpCapability Shader
+          OpMemoryModel Logical GLSL450
+%intt   = OpTypeInt 32 1
+%voidt  = OpTypeVoid
+%vfunct = OpTypeFunction %voidt
+%ptrt   = OpTypePointer Function %intt
+%func   = OpFunction %voidt None %vfunct
+%funcl  = OpLabel
+%var    = OpVariable %ptrt CrossWorkgroup
+          OpReturn
+          OpFunctionEnd
+)";
+
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
+}
+
+TEST_F(ValidateStorage, PrivateStorageInsideFunction) {
+  char str[] = R"(
+          OpCapability Shader
+          OpMemoryModel Logical GLSL450
+%intt   = OpTypeInt 32 1
+%voidt  = OpTypeVoid
+%vfunct = OpTypeFunction %voidt
+%ptrt   = OpTypePointer Function %intt
+%func   = OpFunction %voidt None %vfunct
+%funcl  = OpLabel
+%var    = OpVariable %ptrt Private
+          OpReturn
+          OpFunctionEnd
+)";
+
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
+}
+
+TEST_F(ValidateStorage, GenericStorageInsideFunction) {
+  char str[] = R"(
+          OpCapability Shader
+          OpCapability Kernel
+          OpMemoryModel Logical GLSL450
+%intt   = OpTypeInt 32 1
+%voidt  = OpTypeVoid
+%vfunct = OpTypeFunction %voidt
+%ptrt   = OpTypePointer Function %intt
+%func   = OpFunction %voidt None %vfunct
+%funcl  = OpLabel
+%var    = OpVariable %ptrt Generic
+          OpReturn
+          OpFunctionEnd
+)";
+
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
+}
+
+TEST_F(ValidateStorage, PushConstantStorageInsideFunction) {
+  char str[] = R"(
+          OpCapability Shader
+          OpMemoryModel Logical GLSL450
+%intt   = OpTypeInt 32 1
+%voidt  = OpTypeVoid
+%vfunct = OpTypeFunction %voidt
+%ptrt   = OpTypePointer Function %intt
+%func   = OpFunction %voidt None %vfunct
+%funcl  = OpLabel
+%var    = OpVariable %ptrt PushConstant
+          OpReturn
+          OpFunctionEnd
+)";
+
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
+}
+
+TEST_F(ValidateStorage, AtomicCounterStorageInsideFunction) {
+  char str[] = R"(
+          OpCapability Shader
+          OpCapability AtomicStorage
+          OpMemoryModel Logical GLSL450
+%intt   = OpTypeInt 32 1
+%voidt  = OpTypeVoid
+%vfunct = OpTypeFunction %voidt
+%ptrt   = OpTypePointer Function %intt
+%func   = OpFunction %voidt None %vfunct
+%funcl  = OpLabel
+%var    = OpVariable %ptrt AtomicCounter
+          OpReturn
+          OpFunctionEnd
+)";
+
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
+}
+
+TEST_F(ValidateStorage, ImageStorageInsideFunction) {
+  char str[] = R"(
+          OpCapability Shader
+          OpMemoryModel Logical GLSL450
+%intt   = OpTypeInt 32 1
+%voidt  = OpTypeVoid
+%vfunct = OpTypeFunction %voidt
+%ptrt   = OpTypePointer Function %intt
+%func   = OpFunction %voidt None %vfunct
+%funcl  = OpLabel
+%var    = OpVariable %ptrt Image
+          OpReturn
+          OpFunctionEnd
+)";
+
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
+}
 }

--- a/test/Validate.Storage.cpp
+++ b/test/Validate.Storage.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2015-2016 The Khronos Group Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and/or associated documentation files (the
+// "Materials"), to deal in the Materials without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Materials, and to
+// permit persons to whom the Materials are furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Materials.
+//
+// MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS
+// KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS
+// SPECIFICATIONS AND HEADER INFORMATION ARE LOCATED AT
+//    https://www.khronos.org/registry/
+//
+// THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+// Validation tests for OpVariable storage class
+
+#include <string>
+#include <tuple>
+
+#include "ValidateFixtures.h"
+#include "gmock/gmock.h"
+
+using ValidateStorage =
+    spvtest::ValidateBase<int, SPV_VALIDATE_LAYOUT_BIT |
+                                   SPV_VALIDATE_INSTRUCTION_BIT>;
+namespace {
+
+TEST_F(ValidateStorage, FunctionStorageInsideFunction) {
+  char str[] = R"(
+          OpCapability Shader
+          OpMemoryModel Logical GLSL450
+%intt   = OpTypeInt 32 1
+%voidt  = OpTypeVoid
+%vfunct = OpTypeFunction %voidt
+%ptrt   = OpTypePointer Function %intt
+%func   = OpFunction %voidt None %vfunct
+%funcl  = OpLabel
+%var    = OpVariable %ptrt Function
+          OpReturn
+          OpFunctionEnd
+)";
+
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateStorage, FunctionStorageOutsideFunction) {
+  char str[] = R"(
+          OpCapability Shader
+          OpMemoryModel Logical GLSL450
+%intt   = OpTypeInt 32 1
+%voidt  = OpTypeVoid
+%vfunct = OpTypeFunction %voidt
+%ptrt   = OpTypePointer Function %intt
+%var    = OpVariable %ptrt Function
+%func   = OpFunction %voidt None %vfunct
+%funcl  = OpLabel
+          OpReturn
+          OpFunctionEnd
+)";
+
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
+}
+}

--- a/test/Validate.Storage.cpp
+++ b/test/Validate.Storage.cpp
@@ -93,7 +93,6 @@ TEST_F(ValidateStorage, OtherStorageOutsideFunction) {
 %wgroup = OpVariable %ptrt Workgroup
 %xwgrp  = OpVariable %ptrt CrossWorkgroup
 %priv   = OpVariable %ptrt Private
-%gener  = OpVariable %ptrt Generic
 %pushco = OpVariable %ptrt PushConstant
 %atomct = OpVariable %ptrt AtomicCounter
 %image  = OpVariable %ptrt Image
@@ -138,7 +137,6 @@ INSTANTIATE_TEST_CASE_P(MatrixOp, ValidateStorage,
                              "Workgroup",
                              "CrossWorkgroup",
                              "Private",
-                             "Generic",
                              "PushConstant",
                              "AtomicCounter",
                              "Image"));

--- a/test/ValidateFixtures.cpp
+++ b/test/ValidateFixtures.cpp
@@ -26,12 +26,12 @@
 
 // Common validation fixtures for unit tests
 
-#include "UnitSPIRV.h"
 #include "ValidateFixtures.h"
+#include "UnitSPIRV.h"
 
 #include <functional>
-#include <utility>
 #include <tuple>
+#include <utility>
 
 namespace spvtest {
 
@@ -64,7 +64,8 @@ void ValidateBase<T, OPTIONS>::CompileSuccessfully(std::string code) {
   ASSERT_EQ(SPV_SUCCESS, spvTextToBinary(context_, code.c_str(), code.size(),
                                          &binary_, &diagnostic))
       << "ERROR: " << diagnostic->error
-      << "\nSPIR-V could not be compiled into binary:\n" << code;
+      << "\nSPIR-V could not be compiled into binary:\n"
+      << code;
 }
 
 template <typename T, uint32_t OPTIONS>
@@ -92,5 +93,10 @@ template class spvtest::ValidateBase<
                                std::function<spv_result_t(int)>>>,
     SPV_VALIDATE_LAYOUT_BIT>;
 
-  template class spvtest::ValidateBase<std::tuple<std::string, std::pair<std::string, std::vector<std::string> > >, SPV_VALIDATE_INSTRUCTION_BIT>;
+template class spvtest::ValidateBase<
+    std::tuple<std::string, std::pair<std::string, std::vector<std::string>>>,
+    SPV_VALIDATE_INSTRUCTION_BIT>;
+
+template class spvtest::ValidateBase<int, SPV_VALIDATE_LAYOUT_BIT |
+                                              SPV_VALIDATE_INSTRUCTION_BIT>;
 }

--- a/test/ValidateFixtures.cpp
+++ b/test/ValidateFixtures.cpp
@@ -97,6 +97,6 @@ template class spvtest::ValidateBase<
     std::tuple<std::string, std::pair<std::string, std::vector<std::string>>>,
     SPV_VALIDATE_INSTRUCTION_BIT>;
 
-template class spvtest::ValidateBase<int, SPV_VALIDATE_LAYOUT_BIT |
-                                              SPV_VALIDATE_INSTRUCTION_BIT>;
+template class spvtest::ValidateBase<
+    std::string, SPV_VALIDATE_LAYOUT_BIT | SPV_VALIDATE_INSTRUCTION_BIT>;
 }


### PR DESCRIPTION
Move tests into a fixture that properly turns on the relevant passes.

Test all storage classes.