### PR TITLE
fix the off-by-one bug, found in Windows Debug build tests

### DIFF
--- a/source/validate.h
+++ b/source/validate.h
@@ -287,6 +287,9 @@ class ValidationState_t {
 
   Functions module_functions_;
 
+  // We are using vector to map the ID of the capability to its availability.
+  // The size of the vector needs to be the maximum ID plus one to cover the
+  // entire range of the capability.
   std::vector<bool> module_capabilities_;
 
   // Definitions and uses of all the IDs in the module.

--- a/source/validate_types.cpp
+++ b/source/validate_types.cpp
@@ -204,8 +204,7 @@ bool IsInstructionInLayoutSection(ModuleLayoutSection layout, SpvOp op) {
   return out;
 }
 
-// NOTE: We are using vector to map the ID of the capability to its
-// availability. This variable is the maximum ID of capabilities.
+// This variable is the maximum ID of capabilities.
 static const size_t kCapabilitiesMaxValue =
     SpvCapabilityStorageImageWriteWithoutFormat;
 
@@ -222,8 +221,9 @@ ValidationState_t::ValidationState_t(spv_diagnostic* diagnostic,
       operand_names_{},
       current_layout_section_(kLayoutCapabilities),
       module_functions_(*this),
-      // The size of the vector needs to be the maximum ID plus one to
-      // cover the entire range of the capability.
+      // NOTE: We are using vector to map the ID of the capability to its
+      // availability. The size of the vector needs to be the maximum ID plus
+      // one to cover the entire range of the capability.
       module_capabilities_(kCapabilitiesMaxValue + 1, false) {}
 
 spv_result_t ValidationState_t::forwardDeclareId(uint32_t id) {

--- a/source/validate_types.cpp
+++ b/source/validate_types.cpp
@@ -221,9 +221,6 @@ ValidationState_t::ValidationState_t(spv_diagnostic* diagnostic,
       operand_names_{},
       current_layout_section_(kLayoutCapabilities),
       module_functions_(*this),
-      // NOTE: We are using vector to map the ID of the capability to its
-      // availability. The size of the vector needs to be the maximum ID plus
-      // one to cover the entire range of the capability.
       module_capabilities_(kCapabilitiesMaxValue + 1, false) {}
 
 spv_result_t ValidationState_t::forwardDeclareId(uint32_t id) {

--- a/source/validate_types.cpp
+++ b/source/validate_types.cpp
@@ -206,9 +206,8 @@ bool IsInstructionInLayoutSection(ModuleLayoutSection layout, SpvOp op) {
 
 // NOTE: We are using vector to map the ID of the capability to its
 // availability. This variable is the maximum ID of capabilities.
-// The size of the vector needs to be the maximum ID plus one to
-// cover the entire range of the capability.
-static const size_t kCapabilitiesMaxValue = 56;
+static const size_t kCapabilitiesMaxValue =
+    SpvCapabilityStorageImageWriteWithoutFormat;
 
 }  // anonymous namespace
 
@@ -223,6 +222,8 @@ ValidationState_t::ValidationState_t(spv_diagnostic* diagnostic,
       operand_names_{},
       current_layout_section_(kLayoutCapabilities),
       module_functions_(*this),
+      // The size of the vector needs to be the maximum ID plus one to
+      // cover the entire range of the capability.
       module_capabilities_(kCapabilitiesMaxValue + 1, false) {}
 
 spv_result_t ValidationState_t::forwardDeclareId(uint32_t id) {

--- a/source/validate_types.cpp
+++ b/source/validate_types.cpp
@@ -205,10 +205,9 @@ bool IsInstructionInLayoutSection(ModuleLayoutSection layout, SpvOp op) {
 }
 
 // NOTE: We are using vector to map the ID of the capability to its
-// availability. this variable needs to be the maximum id plus one to cover the
-// entire range of the capability. Currently capability 26 is missing so the
-// count is actually 54
-// The maximum ID of capabilities plus one
+// availability. This variable is the maximum ID of capabilities.
+// The size of the vector needs to be the maximum ID plus one to
+// cover the entire range of the capability.
 static const size_t kCapabilitiesMaxValue = 56;
 
 }  // anonymous namespace

--- a/source/validate_types.cpp
+++ b/source/validate_types.cpp
@@ -209,7 +209,7 @@ bool IsInstructionInLayoutSection(ModuleLayoutSection layout, SpvOp op) {
 // entire range of the capability. Currently capability 26 is missing so the
 // count is actually 54
 // The maximum ID of capabilities plus one
-static const size_t kCapabilitiesCount = 56;
+static const size_t kCapabilitiesMaxValue = 56;
 
 }  // anonymous namespace
 
@@ -224,7 +224,7 @@ ValidationState_t::ValidationState_t(spv_diagnostic* diagnostic,
       operand_names_{},
       current_layout_section_(kLayoutCapabilities),
       module_functions_(*this),
-      module_capabilities_(kCapabilitiesCount, false) {}
+      module_capabilities_(kCapabilitiesMaxValue + 1, false) {}
 
 spv_result_t ValidationState_t::forwardDeclareId(uint32_t id) {
   unresolved_forward_ids_.insert(id);


### PR DESCRIPTION
validate_types.cpp:line 374 in ValidationState_t::registerCapability() triggers Debug assertion on Windows build, as we are dereferencing module_capabilities_[56] while the size of the vector is 56. 

Updating the size of the vector to the correct number of buckets required fixed the bug.