### PR TITLE
Validate mask operand capabilities in a more data driven way

### DIFF
--- a/include/libspirv/libspirv.h
+++ b/include/libspirv/libspirv.h
@@ -157,14 +157,19 @@ typedef enum spv_operand_type_t {
   SPV_OPERAND_TYPE_KERNEL_PROFILING_INFO,         // SPIR-V Sec 3.30
   SPV_OPERAND_TYPE_CAPABILITY,                    // SPIR-V Sec 3.31
 
-  // Set 5:  Operands that are a single word bitmask.
-  // Sometimes a set bit indicates the instruction requires still more operands.
-  SPV_OPERAND_TYPE_IMAGE,                         // SPIR-V Sec 3.14
+// Set 5:  Operands that are a single word bitmask.
+// Sometimes a set bit indicates the instruction requires still more operands.
+#define FIRST_CONCRETE_MASK(ENUM) \
+  ENUM, SPV_OPERAND_TYPE_FIRST_CONCRETE_MASK_TYPE = ENUM
+  FIRST_CONCRETE_MASK(SPV_OPERAND_TYPE_IMAGE),    // SPIR-V Sec 3.14
   SPV_OPERAND_TYPE_FP_FAST_MATH_MODE,             // SPIR-V Sec 3.15
   SPV_OPERAND_TYPE_SELECTION_CONTROL,             // SPIR-V Sec 3.22
   SPV_OPERAND_TYPE_LOOP_CONTROL,                  // SPIR-V Sec 3.23
   SPV_OPERAND_TYPE_FUNCTION_CONTROL,              // SPIR-V Sec 3.24
   LAST_CONCRETE(SPV_OPERAND_TYPE_MEMORY_ACCESS),  // SPIR-V Sec 3.26
+  SPV_OPERAND_TYPE_LAST_CONCRETE_MASK_TYPE =
+      SPV_OPERAND_TYPE_LAST_CONCRETE_TYPE,
+#undef FIRST_CONCRETE_MASK
 #undef FIRST_CONCRETE
 #undef LAST_CONCRETE
 

--- a/source/operand.cpp
+++ b/source/operand.cpp
@@ -1299,6 +1299,11 @@ void spvPrependOperandTypesForMask(const spv_operand_table operandTable,
   }
 }
 
+bool spvOperandIsConcreteMask(spv_operand_type_t type) {
+  return SPV_OPERAND_TYPE_FIRST_CONCRETE_MASK_TYPE <= type &&
+         type <= SPV_OPERAND_TYPE_LAST_CONCRETE_MASK_TYPE;
+}
+
 bool spvOperandIsOptional(spv_operand_type_t type) {
   return SPV_OPERAND_TYPE_FIRST_OPTIONAL_TYPE <= type &&
          type <= SPV_OPERAND_TYPE_LAST_OPTIONAL_TYPE;

--- a/source/operand.h
+++ b/source/operand.h
@@ -61,6 +61,9 @@ spv_result_t spvOperandTableValueLookup(const spv_operand_table table,
 // Gets the name string of the non-variable operand type.
 const char* spvOperandTypeStr(spv_operand_type_t type);
 
+// Returns true if the given type is a concrete and also a mask.
+bool spvOperandIsConcreteMask(spv_operand_type_t type);
+
 // Returns true if an operand of the given type is optional.
 bool spvOperandIsOptional(spv_operand_type_t type);
 

--- a/test/Operand.cpp
+++ b/test/Operand.cpp
@@ -49,4 +49,27 @@ TEST(OperandString, AllAreDefinedExceptVariable) {
   }
 }
 
+TEST(OperandIsConcreteMask, Sample) {
+  // Check a few operand types preceding the concrete mask types.
+  EXPECT_FALSE(spvOperandIsConcreteMask(SPV_OPERAND_TYPE_NONE));
+  EXPECT_FALSE(spvOperandIsConcreteMask(SPV_OPERAND_TYPE_ID));
+  EXPECT_FALSE(spvOperandIsConcreteMask(SPV_OPERAND_TYPE_LITERAL_INTEGER));
+  EXPECT_FALSE(spvOperandIsConcreteMask(SPV_OPERAND_TYPE_CAPABILITY));
+
+  // Check all the concrete mask operand types.
+  EXPECT_TRUE(spvOperandIsConcreteMask(SPV_OPERAND_TYPE_IMAGE));
+  EXPECT_TRUE(spvOperandIsConcreteMask(SPV_OPERAND_TYPE_FP_FAST_MATH_MODE));
+  EXPECT_TRUE(spvOperandIsConcreteMask(SPV_OPERAND_TYPE_SELECTION_CONTROL));
+  EXPECT_TRUE(spvOperandIsConcreteMask(SPV_OPERAND_TYPE_LOOP_CONTROL));
+  EXPECT_TRUE(spvOperandIsConcreteMask(SPV_OPERAND_TYPE_FUNCTION_CONTROL));
+  EXPECT_TRUE(spvOperandIsConcreteMask(SPV_OPERAND_TYPE_MEMORY_ACCESS));
+
+  // Check a few operand types after the concrete mask types, including the
+  // optional forms for Image and MemoryAccess.
+  EXPECT_FALSE(spvOperandIsConcreteMask(SPV_OPERAND_TYPE_OPTIONAL_ID));
+  EXPECT_FALSE(spvOperandIsConcreteMask(SPV_OPERAND_TYPE_OPTIONAL_IMAGE));
+  EXPECT_FALSE(
+      spvOperandIsConcreteMask(SPV_OPERAND_TYPE_OPTIONAL_MEMORY_ACCESS));
+}
+
 }  // anonymous namespace


### PR DESCRIPTION
Adds spvOperandIsConcreteMask.

Use spvOperandIsConcreteMask to determine if an operand is a bitmask.  Check its individual
bits in a generic way.