### PR TITLE
Float literal parsing fixes

### DIFF
--- a/include/util/hex_float.h
+++ b/include/util/hex_float.h
@@ -772,8 +772,11 @@ inline bool RejectParseDueToLeadingSign(std::istream& is, bool negate_value,
 // If negate_value is true then the number may not have a leading minus or
 // plus, and if it successfully parses, then the number is negated before
 // being stored into the value parameter.
-// If the value is an infinity, then set the fail bit on the stream, and set
-// the value to 0.
+// If the value cannot be correctly parsed, then set the fail bit on the
+// stream, and set the value to zero.
+// If the value overflows the target floating point type, then set the fail
+// bit on the stream and set the value to the nearest finite value for the
+// type, which can either be positive or negative.
 template <typename T, typename Traits>
 inline std::istream& ParseNormalFloat(std::istream& is, bool negate_value,
                                       HexFloat<T, Traits>& value) {

--- a/include/util/hex_float.h
+++ b/include/util/hex_float.h
@@ -32,7 +32,6 @@
 #include <cmath>
 #include <cstdint>
 #include <iomanip>
-#include <iostream>
 #include <limits>
 
 #include "bitutils.h"
@@ -46,8 +45,17 @@ class Float16 {
   static bool isNan(const Float16 val) {
     return ((val.val & 0x7C00) == 0x7C00) && ((val.val & 0x3FF) != 0);
   }
+  // Returns true if the given value is any kind of infinity.
+  static bool isInfinity(const Float16 val) {
+    return ((val.val & 0x7C00) == 0x7C00) && ((val.val & 0x3FF) == 0);
+  }
   Float16(const Float16& other) { val = other.val; }
   uint16_t get_value() const { return val; }
+
+  // Returns the maximum normal value.
+  static Float16 max() { return Float16(0x7bff); }
+  // Returns the lowest normal value.
+  static Float16 lowest() { return Float16(0xfbff); }
 
  private:
   uint16_t val;
@@ -66,18 +74,36 @@ template <>
 struct FloatProxyTraits<float> {
   using uint_type = uint32_t;
   static bool isNan(float f) { return std::isnan(f); }
+  // Returns true if the given value is any kind of infinity.
+  static bool isInfinity(float f) { return std::isinf(f); }
+  // Returns the maximum normal value.
+  static float max() { return std::numeric_limits<float>::max(); }
+  // Returns the lowest normal value.
+  static float lowest() { return std::numeric_limits<float>::lowest(); }
 };
 
 template <>
 struct FloatProxyTraits<double> {
   using uint_type = uint64_t;
   static bool isNan(double f) { return std::isnan(f); }
+  // Returns true if the given value is any kind of infinity.
+  static bool isInfinity(double f) { return std::isinf(f); }
+  // Returns the maximum normal value.
+  static double max() { return std::numeric_limits<double>::max(); }
+  // Returns the lowest normal value.
+  static double lowest() { return std::numeric_limits<double>::lowest(); }
 };
 
 template <>
 struct FloatProxyTraits<Float16> {
   using uint_type = uint16_t;
   static bool isNan(Float16 f) { return Float16::isNan(f); }
+  // Returns true if the given value is any kind of infinity.
+  static bool isInfinity(Float16 f) { return Float16::isInfinity(f); }
+  // Returns the maximum normal value.
+  static Float16 max() { return Float16::max(); }
+  // Returns the lowest normal value.
+  static Float16 lowest() { return Float16::lowest(); }
 };
 
 // Since copying a floating point number (especially if it is NaN)
@@ -114,6 +140,17 @@ class FloatProxy {
 
   // Returns true if the value represents any type of NaN.
   bool isNan() { return FloatProxyTraits<T>::isNan(getAsFloat()); }
+  // Returns true if the value represents any type of infinity.
+  bool isInfinity() { return FloatProxyTraits<T>::isInfinity(getAsFloat()); }
+
+  // Returns the maximum normal value.
+  static FloatProxy<T> max() {
+    return FloatProxy<T>(FloatProxyTraits<T>::max());
+  }
+  // Returns the lowest normal value.
+  static FloatProxy<T> lowest() {
+    return FloatProxy<T>(FloatProxyTraits<T>::lowest());
+  }
 
  private:
   uint_type data_;
@@ -722,7 +759,7 @@ inline bool RejectParseDueToLeadingSign(std::istream& is, bool negate_value,
     if (next_char == '-' || next_char == '+') {
       // Fail the parse.  Emulate standard behaviour by setting the value to
       // the zero value, and set the fail bit on the stream.
-      value = HexFloat<T, Traits>(typename HexFloat<T, Traits>::uint_type(0));
+      value = HexFloat<T, Traits>(typename HexFloat<T, Traits>::uint_type{0});
       is.setstate(std::ios_base::failbit);
       return true;
     }
@@ -735,6 +772,8 @@ inline bool RejectParseDueToLeadingSign(std::istream& is, bool negate_value,
 // If negate_value is true then the number may not have a leading minus or
 // plus, and if it successfully parses, then the number is negated before
 // being stored into the value parameter.
+// If the value is an infinity, then set the fail bit on the stream, and set
+// the value to 0.
 template <typename T, typename Traits>
 inline std::istream& ParseNormalFloat(std::istream& is, bool negate_value,
                                       HexFloat<T, Traits>& value) {
@@ -747,6 +786,17 @@ inline std::istream& ParseNormalFloat(std::istream& is, bool negate_value,
     val = -val;
   }
   value.set_value(val);
+  // In the failure case, map -0.0 to 0.0.
+  if (is.fail() && value.getUnsignedBits() == 0u) {
+    value = HexFloat<T, Traits>(typename HexFloat<T, Traits>::uint_type{0});
+  }
+  if (val.isInfinity()) {
+    // Fail the parse.  Emulate standard behaviour by setting the value to
+    // the closest normal value, and set the fail bit on the stream.
+    value.set_value((value.isNegative() | negate_value) ? T::lowest()
+                                                        : T::max());
+    is.setstate(std::ios_base::failbit);
+  }
   return is;
 }
 
@@ -763,16 +813,23 @@ inline std::istream&
 ParseNormalFloat<FloatProxy<Float16>, HexFloatTraits<FloatProxy<Float16>>>(
     std::istream& is, bool negate_value,
     HexFloat<FloatProxy<Float16>, HexFloatTraits<FloatProxy<Float16>>>& value) {
-  if (RejectParseDueToLeadingSign(is, negate_value, value)) {
-    return is;
-  }
-  float f;
-  is >> f;
-  if (negate_value) {
-    f = -f;
-  }
-  HexFloat<FloatProxy<float>> float_val(f);
+  // First parse as a 32-bit float.
+  HexFloat<FloatProxy<float>> float_val(0.0f);
+  ParseNormalFloat(is, negate_value, float_val);
+
+  // Then convert to 16-bit float, saturating at infinities, and
+  // rounding toward zero.
   float_val.castTo(value, round_direction::kToZero);
+
+  // Our (current) rule is to allow overflow in 16-bit floats
+  // to validly map to infinities.  But we might have overflowed the
+  // 32-bit float in the first place and set the fail bit on the stream.
+  // If we did, then reset the fail bit.
+  // TODO(dneto): Overflow on 16-bit should behave the same as for 32- and
+  // 64-bit.  It should set the fail bit and set the lowest or highest value.
+  if (Float16::isInfinity(value.value().getAsFloat())) {
+    is.clear(is.rdstate() & ~std::ios_base::failbit);
+  }
   return is;
 }
 

--- a/test/HexFloat.cpp
+++ b/test/HexFloat.cpp
@@ -1051,38 +1051,39 @@ FloatParseCase<T> GoodFloatParseCase(std::string literal, bool negate_value,
   return FloatParseCase<T>{literal, negate_value, true, proxy_expected_value};
 }
 
-INSTANTIATE_TEST_CASE_P(FloatParse, ParseNormalFloatTest,
-                        ::testing::ValuesIn(std::vector<FloatParseCase<float>>{
-                            // Failing cases due to trivially incorrect syntax.
-                            BadFloatParseCase<float>("abc", false, 0.0f),
-                            BadFloatParseCase<float>("abc", true, 0.0f),
+INSTANTIATE_TEST_CASE_P(
+    FloatParse, ParseNormalFloatTest,
+    ::testing::ValuesIn(std::vector<FloatParseCase<float>>{
+        // Failing cases due to trivially incorrect syntax.
+        BadFloatParseCase("abc", false, 0.0f),
+        BadFloatParseCase("abc", true, 0.0f),
 
-                            // Valid cases.
-                            GoodFloatParseCase<float>("0", false, 0.0f),
-                            GoodFloatParseCase<float>("0.0", false, 0.0f),
-                            GoodFloatParseCase<float>("-0.0", false, -0.0f),
-                            GoodFloatParseCase<float>("2.0", false, 2.0f),
-                            GoodFloatParseCase<float>("-2.0", false, -2.0f),
-                            GoodFloatParseCase<float>("+2.0", false, 2.0f),
-                            // Cases with negate_value being true.
-                            GoodFloatParseCase<float>("0.0", true, -0.0f),
-                            GoodFloatParseCase<float>("2.0", true, -2.0f),
+        // Valid cases.
+        GoodFloatParseCase("0", false, 0.0f),
+        GoodFloatParseCase("0.0", false, 0.0f),
+        GoodFloatParseCase("-0.0", false, -0.0f),
+        GoodFloatParseCase("2.0", false, 2.0f),
+        GoodFloatParseCase("-2.0", false, -2.0f),
+        GoodFloatParseCase("+2.0", false, 2.0f),
+        // Cases with negate_value being true.
+        GoodFloatParseCase("0.0", true, -0.0f),
+        GoodFloatParseCase("2.0", true, -2.0f),
 
-                            // When negate_value is true, we should not accept a
-                            // leading minus or plus.
-                            BadFloatParseCase<float>("-0.0", true, 0.0f),
-                            BadFloatParseCase<float>("-2.0", true, 0.0f),
-                            BadFloatParseCase<float>("+0.0", true, 0.0f),
-                            BadFloatParseCase<float>("+2.0", true, 0.0f),
+        // When negate_value is true, we should not accept a
+        // leading minus or plus.
+        BadFloatParseCase("-0.0", true, 0.0f),
+        BadFloatParseCase("-2.0", true, 0.0f),
+        BadFloatParseCase("+0.0", true, 0.0f),
+        BadFloatParseCase("+2.0", true, 0.0f),
 
-                            // Overflow is an error for 32-bit float parsing.
-                            BadFloatParseCase<float>("1e40", false, FLT_MAX),
-                            BadFloatParseCase<float>("1e40", true, -FLT_MAX),
-                            BadFloatParseCase<float>("-1e40", false, -FLT_MAX),
-                            // We can't have -1e40 and negate_value == true since
-                            // that represents an original case of "--1e40" which
-                            // is invalid.
-                        }));
+        // Overflow is an error for 32-bit float parsing.
+        BadFloatParseCase("1e40", false, FLT_MAX),
+        BadFloatParseCase("1e40", true, -FLT_MAX),
+        BadFloatParseCase("-1e40", false, -FLT_MAX),
+        // We can't have -1e40 and negate_value == true since
+        // that represents an original case of "--1e40" which
+        // is invalid.
+    }));
 
 using ParseNormalFloat16Test =
     ::testing::TestWithParam<FloatParseCase<Float16>>;
@@ -1127,16 +1128,16 @@ INSTANTIATE_TEST_CASE_P(
 
 // A test case for detecting infinities.
 template <typename T>
-struct InfinityParseCase {
+struct OverflowParseCase {
   std::string input;
   bool expect_success;
   T expected_value;
 };
 
-using FloatProxyParseInfinityFloatTest =
-    ::testing::TestWithParam<InfinityParseCase<float>>;
+using FloatProxyParseOverflowFloatTest =
+    ::testing::TestWithParam<OverflowParseCase<float>>;
 
-TEST_P(FloatProxyParseInfinityFloatTest, Sample) {
+TEST_P(FloatProxyParseOverflowFloatTest, Sample) {
   std::istringstream input(GetParam().input);
   HexFloat<FloatProxy<float>> value(0.0f);
   input >> value;
@@ -1145,8 +1146,8 @@ TEST_P(FloatProxyParseInfinityFloatTest, Sample) {
 }
 
 INSTANTIATE_TEST_CASE_P(
-    FloatInfinity, FloatProxyParseInfinityFloatTest,
-    ::testing::ValuesIn(std::vector<InfinityParseCase<float>>({
+    FloatOverflow, FloatProxyParseOverflowFloatTest,
+    ::testing::ValuesIn(std::vector<OverflowParseCase<float>>({
         {"0", true, 0.0f},
         {"0.0", true, 0.0f},
         {"1.0", true, 1.0f},
@@ -1158,10 +1159,10 @@ INSTANTIATE_TEST_CASE_P(
         {"-1e400", false, -FLT_MAX},
     })));
 
-using FloatProxyParseInfinityDoubleTest =
-    ::testing::TestWithParam<InfinityParseCase<double>>;
+using FloatProxyParseOverflowDoubleTest =
+    ::testing::TestWithParam<OverflowParseCase<double>>;
 
-TEST_P(FloatProxyParseInfinityDoubleTest, Sample) {
+TEST_P(FloatProxyParseOverflowDoubleTest, Sample) {
   std::istringstream input(GetParam().input);
   HexFloat<FloatProxy<double>> value(0.0);
   input >> value;
@@ -1170,8 +1171,8 @@ TEST_P(FloatProxyParseInfinityDoubleTest, Sample) {
 }
 
 INSTANTIATE_TEST_CASE_P(
-    DoubleInfinity, FloatProxyParseInfinityDoubleTest,
-    ::testing::ValuesIn(std::vector<InfinityParseCase<double>>({
+    DoubleOverflow, FloatProxyParseOverflowDoubleTest,
+    ::testing::ValuesIn(std::vector<OverflowParseCase<double>>({
         {"0", true, 0.0},
         {"0.0", true, 0.0},
         {"1.0", true, 1.0},
@@ -1183,22 +1184,22 @@ INSTANTIATE_TEST_CASE_P(
         {"-1e400", false, -DBL_MAX},
     })));
 
-using FloatProxyParseInfinityFloat16Test =
-    ::testing::TestWithParam<InfinityParseCase<uint16_t>>;
+using FloatProxyParseOverflowFloat16Test =
+    ::testing::TestWithParam<OverflowParseCase<uint16_t>>;
 
-TEST_P(FloatProxyParseInfinityFloat16Test, Sample) {
+TEST_P(FloatProxyParseOverflowFloat16Test, Sample) {
   std::istringstream input(GetParam().input);
   HexFloat<FloatProxy<Float16>> value(0);
   input >> value;
-  EXPECT_NE(GetParam().expect_success, input.fail())
-      << " literal: " << GetParam().input;
+  EXPECT_NE(GetParam().expect_success, input.fail()) << " literal: "
+                                                     << GetParam().input;
   EXPECT_THAT(value.value().data(), Eq(GetParam().expected_value))
       << " literal: " << GetParam().input;
 }
 
 INSTANTIATE_TEST_CASE_P(
-    Float16Infinity, FloatProxyParseInfinityFloat16Test,
-    ::testing::ValuesIn(std::vector<InfinityParseCase<uint16_t>>({
+    Float16Overflow, FloatProxyParseOverflowFloat16Test,
+    ::testing::ValuesIn(std::vector<OverflowParseCase<uint16_t>>({
         // For Float16, too-large values are parsed as
         // infinities, and also valid.
         // TODO(dneto): Overflow for 16-bit float should be an error,

--- a/test/TextToBinary.Constant.cpp
+++ b/test/TextToBinary.Constant.cpp
@@ -301,6 +301,7 @@ TEST_P(OpConstantInvalidFloatConstant, Samples) {
   }
 }
 
+// clang-format off
 INSTANTIATE_TEST_CASE_P(
     TextToBinaryInvalidFloatConstant, OpConstantInvalidFloatConstant,
     ::testing::ValuesIn(std::vector<InvalidFloatConstantCase>{
@@ -309,17 +310,26 @@ INSTANTIATE_TEST_CASE_P(
         {16, "-+1"},
         {16, "+-1"},
         {16, "++1"},
+        // TODO(dneto): Overflow for 16-bit floats should be an error,
+        // just like for 32-bit and 64-bit.
         {32, "abc"},
         {32, "--1"},
         {32, "-+1"},
         {32, "+-1"},
         {32, "++1"},
+        {32, "1e40"}, // Overflow is an error for 32-bit floats.
+        {32, "-1e40"},
+        {32, "1e400"},
+        {32, "-1e400"},
         {64, "abc"},
         {64, "--1"},
         {64, "-+1"},
         {64, "+-1"},
         {64, "++1"},
+        {32, "1e400"}, // Overflow is an error for 64-bit floats.
+        {32, "-1e400"},
     }));
+// clang-format on
 
 using OpConstantInvalidTypeTest =
     spvtest::TextToBinaryTestBase<::testing::TestWithParam<std::string>>;


### PR DESCRIPTION
- For 32- and 64-bit floats, overflow is a parse error

  This works around a difference between Xcode's istringstream
  and other platforms.  Xcode's runtime library will happlily
  "round up" overflow values to infinity.  We want to make it fail.

- When parsing a float fails due to bad syntax, follow C++11
  behaviour for operator>> and set the value to zero.

- When parsing a 32-bit or 64-bit float overflows, follow C++11
  behaviour for operator>> and set the value to the nearest
  normal value: either max or lowest finite value for the type.

- Add FloatProxy<T>::max() and ::lowest()

- Make 16-bit overflow behaviour more consistent: we always get a
  16-bit infinity of the right sign, whether the original string
  is a normal value for 32-bit or an overflow value for 32-bit.
  That matches our earlier intent.
  Added TODO's to make 16-bit overflow always an error, just like
  for 32-bit and 64-bit.

- Simplify normal parsing of Float16 values by delegating to
  normal parsing of 32-bit floats.