### PR TITLE
Parse overflow for fp16  like for 32- and 64-bit

### DIFF
--- a/test/HexFloat.cpp
+++ b/test/HexFloat.cpp
@@ -1200,19 +1200,17 @@ TEST_P(FloatProxyParseOverflowFloat16Test, Sample) {
 INSTANTIATE_TEST_CASE_P(
     Float16Overflow, FloatProxyParseOverflowFloat16Test,
     ::testing::ValuesIn(std::vector<OverflowParseCase<uint16_t>>({
-        // For Float16, too-large values are parsed as
-        // infinities, and also valid.
-        // TODO(dneto): Overflow for 16-bit float should be an error,
-        // just like for 32-bit and 64-bit.
         {"0", true, uint16_t{0}},
         {"0.0", true, uint16_t{0}},
         {"1.0", true, uint16_t{0x3c00}},
-        {"1e38", true, uint16_t{0x7c00}},
-        {"-1e38", true, uint16_t{0xfc00}},
-        {"1e40", true, uint16_t{0x7c00}},
-        {"1e400", true, uint16_t{0x7c00}},
-        {"-1e40", true, uint16_t{0xfc00}},
-        {"-1e400", true, uint16_t{0xfc00}},
+        // Overflow for 16-bit float is an error, and returns max or
+        // lowest value.
+        {"1e38", false, uint16_t{0x7bff}},
+        {"1e40", false, uint16_t{0x7bff}},
+        {"1e400", false, uint16_t{0x7bff}},
+        {"-1e38", false, uint16_t{0xfbff}},
+        {"-1e40", false, uint16_t{0xfbff}},
+        {"-1e400", false, uint16_t{0xfbff}},
     })));
 
 TEST(FloatProxy, Max) {

--- a/test/TextToBinary.Constant.cpp
+++ b/test/TextToBinary.Constant.cpp
@@ -310,8 +310,12 @@ INSTANTIATE_TEST_CASE_P(
         {16, "-+1"},
         {16, "+-1"},
         {16, "++1"},
-        // TODO(dneto): Overflow for 16-bit floats should be an error,
-        // just like for 32-bit and 64-bit.
+        {16, "1e30"}, // Overflow is an error for 16-bit floats.
+        {16, "-1e30"},
+        {16, "1e40"},
+        {16, "-1e40"},
+        {16, "1e400"},
+        {16, "-1e400"},
         {32, "abc"},
         {32, "--1"},
         {32, "-+1"},

--- a/test/TextToBinary.cpp
+++ b/test/TextToBinary.cpp
@@ -514,23 +514,31 @@ TEST(AssemblyContextParseFloat16, Infinities) {
   AssemblyContext context(AutoText(""), nullptr);
   const spv_result_t ec = SPV_FAILED_MATCH;
   spvutils::HexFloat<spvutils::FloatProxy<spvutils::Float16>> f(0.0f);
+  const uint32_t f16_max = uint32_t{0x7bff};
+  const uint32_t f16_low = uint32_t{0xfbff};
 
-  EXPECT_EQ(SPV_SUCCESS, context.parseNumber("0", ec, &f, ""));
-  EXPECT_TRUE(!f.value().isInfinity());
-  EXPECT_EQ(SPV_SUCCESS, context.parseNumber("1.5", ec, &f, ""));
-  EXPECT_TRUE(!f.value().isInfinity());
-  EXPECT_EQ(SPV_SUCCESS, context.parseNumber("1e38", ec, &f, ""));
-  EXPECT_TRUE(f.value().isInfinity());
-  EXPECT_EQ(SPV_SUCCESS, context.parseNumber("-1e38", ec, &f, ""));
-  EXPECT_TRUE(f.value().isInfinity());
-  EXPECT_EQ(SPV_SUCCESS, context.parseNumber("1e40", ec, &f, ""));
-  EXPECT_TRUE(f.value().isInfinity());
-  EXPECT_EQ(SPV_SUCCESS, context.parseNumber("-1e40", ec, &f, ""));
-  EXPECT_TRUE(f.value().isInfinity());
-  EXPECT_EQ(SPV_SUCCESS, context.parseNumber("1e400", ec, &f, ""));
-  EXPECT_TRUE(f.value().isInfinity());
-  EXPECT_EQ(SPV_SUCCESS, context.parseNumber("-1e400", ec, &f, ""));
-  EXPECT_TRUE(f.value().isInfinity());
+  EXPECT_EQ(SPV_SUCCESS, context.parseNumber("-0.0", ec, &f, ""));
+  EXPECT_EQ(uint16_t{0x8000}, f.value().getAsFloat().get_value());
+  EXPECT_EQ(SPV_SUCCESS, context.parseNumber("1.0", ec, &f, ""));
+  EXPECT_EQ(uint16_t{0x3c00}, f.value().getAsFloat().get_value());
+
+  // Overflows 16-bit but not 32-bit
+  EXPECT_EQ(ec, context.parseNumber("1e38", ec, &f, ""));
+  EXPECT_EQ(f16_max, f.value().getAsFloat().get_value());
+  EXPECT_EQ(ec, context.parseNumber("-1e38", ec, &f, ""));
+  EXPECT_EQ(f16_low, f.value().getAsFloat().get_value());
+
+  // Overflows 32-bit but not 64-bit
+  EXPECT_EQ(ec, context.parseNumber("1e40", ec, &f, ""));
+  EXPECT_EQ(f16_max, f.value().getAsFloat().get_value());
+  EXPECT_EQ(ec, context.parseNumber("-1e40", ec, &f, ""));
+  EXPECT_EQ(f16_low, f.value().getAsFloat().get_value());
+
+  // Overflows 64-bit
+  EXPECT_EQ(ec, context.parseNumber("1e400", ec, &f, ""));
+  EXPECT_EQ(f16_max, f.value().getAsFloat().get_value());
+  EXPECT_EQ(ec, context.parseNumber("-1e400", ec, &f, ""));
+  EXPECT_EQ(f16_low, f.value().getAsFloat().get_value());
 }
 
 TEST(AssemblyContextParseMessages, Errors) {


### PR DESCRIPTION
In that case, set the stream fail bit, and set the maximum normal
value or lowest normal value, depending on the sign of the original
value.