### PR TITLE
Configure gmock locally only if not already configured.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,15 +168,20 @@ if (NOT ${SPIRV_SKIP_EXECUTABLES})
   spvtools_default_compile_options(spirv-val)
   target_link_libraries(spirv-val PRIVATE ${SPIRV_TOOLS})
 
-  set(GMOCK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/googletest/googlemock)
-  if(EXISTS ${GMOCK_DIR})
-    if(WIN32)
-      option(gtest_force_shared_crt
-        "Use shared (DLL) run-time lib even when Google Test is built as static lib."
-        ON)
+  # Find gmock if we can. If it's not already configured, then try finding
+  # it in external/googletest
+  if (TARGET gmock)
+    message(STATUS "Google Mock already configured")
+  else()
+    set(GMOCK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/googletest/googlemock)
+    if(EXISTS ${GMOCK_DIR})
+      if(WIN32)
+	option(gtest_force_shared_crt
+	  "Use shared (DLL) run-time lib even when Google Test is built as static lib."
+	  ON)
+      endif()
+      add_subdirectory(${GMOCK_DIR})
     endif()
-
-    add_subdirectory(${GMOCK_DIR})
   endif()
   if (TARGET gmock)
     message(STATUS "Found Google Mock, building tests.")

--- a/README.md
+++ b/README.md
@@ -66,9 +66,13 @@ We intend to maintain a linear history on the GitHub `master` branch.
 The project contains a number of tests, used to drive development
 and ensure correctness.  The tests are written using the
 [googletest](https://github.com/google/googletest) framework.  The `googletest`
-source is not provided with this project.  Download the `googletest` source
-into the `<spirv-dir>/external/googletest` directory before configuring
-and building the project.
+source is not provided with this project.  There are two ways to enable
+tests:
+* If SPIR-V Tools is configured as part of an enclosing project, then the
+  enclosing project should configure `googletest` before configuring SPIR-V Tools.
+* If SPIR-V Tools is configured as a standalone project, then download the
+  `googletest` source into the `<spirv-dir>/external/googletest` directory before
+  configuring and building the project.
 
 *Note*: You must use a version of googletest that includes
 [a fix](https://github.com/google/googletest/pull/612) for


### PR DESCRIPTION
Allows an enclosing project to have already configured gmock, even
if the developer has placed the googletest sources under this
project's external/googletest directory.

Describe how to enable the tests in the two essential scenarios:
where SPIR-V Tools is standalone, or where SPIR-V Tools is configured
as a part of a larger project.