### PR TITLE
Use SPIR-V headers for 1.0 Rev3

### DIFF
--- a/external/include/headers/GLSL.std.450.h
+++ b/external/include/headers/GLSL.std.450.h
@@ -27,8 +27,8 @@
 #ifndef GLSLstd450_H
 #define GLSLstd450_H
 
-const int GLSLstd450Version = 99;
-const int GLSLstd450Revision = 3;
+static const int GLSLstd450Version = 100;
+static const int GLSLstd450Revision = 1;
 
 enum GLSLstd450 {
     GLSLstd450Bad = 0,              // Don't use
@@ -83,7 +83,7 @@ enum GLSLstd450 {
     GLSLstd450UClamp = 44,
     GLSLstd450SClamp = 45,
     GLSLstd450FMix = 46,
-    GLSLstd450IMix = 47,
+    GLSLstd450IMix = 47,            // Reserved
     GLSLstd450Step = 48,
     GLSLstd450SmoothStep = 49,
 
@@ -120,6 +120,10 @@ enum GLSLstd450 {
     GLSLstd450InterpolateAtCentroid = 76,
     GLSLstd450InterpolateAtSample = 77,
     GLSLstd450InterpolateAtOffset = 78,
+
+    GLSLstd450NMin = 79,
+    GLSLstd450NMax = 80,
+    GLSLstd450NClamp = 81,
 
     GLSLstd450Count
 };

--- a/external/include/headers/spirv.h
+++ b/external/include/headers/spirv.h
@@ -51,11 +51,11 @@
 typedef unsigned int SpvId;
 
 #define SPV_VERSION 0x10000
-#define SPV_REVISION 2
+#define SPV_REVISION 3
 
 static const unsigned int SpvMagicNumber = 0x07230203;
 static const unsigned int SpvVersion = 0x00010000;
-static const unsigned int SpvRevision = 2;
+static const unsigned int SpvRevision = 3;
 static const unsigned int SpvOpCodeMask = 0xffff;
 static const unsigned int SpvWordCountShift = 16;
 
@@ -567,6 +567,7 @@ typedef enum SpvCapability_ {
     SpvCapabilityGeometryStreams = 54,
     SpvCapabilityStorageImageReadWithoutFormat = 55,
     SpvCapabilityStorageImageWriteWithoutFormat = 56,
+    SpvCapabilityMultiViewport = 57,
 } SpvCapability;
 
 typedef enum SpvOp_ {
@@ -863,6 +864,7 @@ typedef enum SpvOp_ {
     SpvOpNoLine = 317,
     SpvOpAtomicFlagTestAndSet = 318,
     SpvOpAtomicFlagClear = 319,
+    SpvOpImageSparseRead = 320,
 } SpvOp;
 
 #endif  // #ifndef spirv_H

--- a/external/include/headers/spirv.py
+++ b/external/include/headers/spirv.py
@@ -42,7 +42,7 @@
 spv = {
     'MagicNumber' : 0x07230203,
     'Version' : 0x00010000,
-    'Revision' : 2,
+    'Revision' : 3,
     'OpCodeMask' : 0xffff,
     'WordCountShift' : 16,
 
@@ -554,6 +554,7 @@ spv = {
         'GeometryStreams' : 54,
         'StorageImageReadWithoutFormat' : 55,
         'StorageImageWriteWithoutFormat' : 56,
+        'MultiViewport' : 57,
     },
 
     'Op' : {
@@ -850,6 +851,7 @@ spv = {
         'OpNoLine' : 317,
         'OpAtomicFlagTestAndSet' : 318,
         'OpAtomicFlagClear' : 319,
+        'OpImageSparseRead' : 320,
     },
 
 }


### PR DESCRIPTION
Refresh from the SPIR-V registry.