### PR TITLE
Fixed internal compiler error in gcc-4.9.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ set(SPIRV_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/source/disassemble.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/diagnostic.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/ext_inst.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/source/instruction.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/opcode.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/operand.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/print.cpp

--- a/source/instruction.cpp
+++ b/source/instruction.cpp
@@ -24,37 +24,9 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 
-#ifndef LIBSPIRV_INSTRUCTION_H_
-#define LIBSPIRV_INSTRUCTION_H_
+#include "instruction.h"
 
-#include <cstdint>
-#include <vector>
+void spvInstructionAddWord(spv_instruction_t* inst, uint32_t value) {
+  inst->words.push_back(value);
+}
 
-#include "headers/spirv.h"
-
-#include "table.h"
-
-// Describes an instruction.
-struct spv_instruction_t {
-  // Normally, both opcode and extInstType contain valid data.
-  // However, when the assembler parses !<number> as the first word in
-  // an instruction and opcode and extInstType are invalid.
-  SpvOp opcode;
-  spv_ext_inst_type_t extInstType;
-
-  // The Id of the result type, if this instruction has one.  Zero otherwise.
-  uint32_t resultTypeId;
-
-  // The instruction, as a sequence of 32-bit words.
-  // For a regular instruction the opcode and word count are combined
-  // in words[0], as described in the SPIR-V spec.
-  // Otherwise, the first token was !<number>, and that number appears
-  // in words[0].  Subsequent elements are the result of parsing
-  // tokens in the alternate parsing mode as described in syntax.md.
-  std::vector<uint32_t> words;
-};
-
-// Appends a word to an instruction, without checking for overflow.
-void spvInstructionAddWord(spv_instruction_t* inst, uint32_t value);
-
-#endif  // LIBSPIRV_INSTRUCTION_H_

--- a/source/text_handler.h
+++ b/source/text_handler.h
@@ -282,6 +282,7 @@ class AssemblyContext {
   }
 
  private:
+
   // Appends the given floating point literal to the given instruction.
   // Returns SPV_SUCCESS if the value was correctly parsed.  Otherwise
   // returns the given error code, and emits a diagnostic if that error
@@ -301,20 +302,6 @@ class AssemblyContext {
                                           spv_result_t error_code,
                                           const IdType& type,
                                           spv_instruction_t* pInst);
-
-  // Returns SPV_SUCCESS if the given value fits within the target scalar
-  // integral type.  The target type may have an unusual bit width.
-  // If the value was originally specified as a hexadecimal number, then
-  // the overflow bits should be zero.  If it was hex and the target type is
-  // signed, then return the sign-extended value through the
-  // updated_value_for_hex pointer argument.
-  // On failure, return the given error code and emit a diagnostic if that error
-  // code is not SPV_FAILED_MATCH.
-  template <typename T>
-  spv_result_t checkRangeAndIfHexThenSignExtend(T value,
-                                                spv_result_t error_code,
-                                                const IdType& type, bool is_hex,
-                                                T* updated_value_for_hex);
 
   // Writes the given 64-bit literal value into the instruction.
   // return SPV_SUCCESS if the value could be written in the instruction.


### PR DESCRIPTION
This showed up in mips and mips64 builds. A combination of templates
and the error reporting were causing gcc to crash. This splits up the
functionality in a way that now successfully compiles.