### PR TITLE
SPIR-V Tools fully supports SPIR-V 1.0 Rev3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,7 @@ if (NOT ${SPIRV_SKIP_EXECUTABLES})
       ${CMAKE_CURRENT_SOURCE_DIR}/test/Validate.SSA.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/test/ValidateID.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/test/ValidationState.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/test/Version.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/test/main.cpp)
 
     add_executable(UnitSPIRV ${TEST_SOURCES})

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ SPIR-V specification, headers, and XML registry.
 
 ### Assembler, binary parser, and disassembler
 
-* Based on SPIR-V 1.0 Revision 2.
+* Based on SPIR-V 1.0 Revision 3.
   * Supports GLSL std450 extended instructions.
   * Supports OpenCL extended instructions.
 * Assembler only does basic syntax checking.  No cross validation of

--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -42,9 +42,9 @@ extern "C" {
 // This library is based on SPIR-V 1.0 Rev2
 // TODO(dneto): Use the values from the SPIR-V header, when it's updated for
 // SPIR-V 1.0 public release.
-#define SPV_SPIRV_VERSION_MAJOR 1
-#define SPV_SPIRV_VERSION_MINOR 0
-#define SPV_SPIRV_VERSION_REVISION 2
+#define SPV_SPIRV_VERSION_MAJOR (SPV_VERSION >> 16)
+#define SPV_SPIRV_VERSION_MINOR (SPV_VERSION & 0xffff)
+#define SPV_SPIRV_VERSION_REVISION (SPV_REVISION)
 
 // Helpers
 

--- a/test/Version.cpp
+++ b/test/Version.cpp
@@ -1,0 +1,39 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and/or associated documentation files (the
+// "Materials"), to deal in the Materials without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Materials, and to
+// permit persons to whom the Materials are furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Materials.
+//
+// MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS
+// KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS
+// SPECIFICATIONS AND HEADER INFORMATION ARE LOCATED AT
+//    https://www.khronos.org/registry/
+//
+// THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+#include "gmock/gmock.h"
+
+#include "UnitSPIRV.h"
+
+namespace {
+
+TEST(LibspirvMacros, Version) {
+  EXPECT_EQ(1, SPV_SPIRV_VERSION_MAJOR);
+  EXPECT_EQ(0, SPV_SPIRV_VERSION_MINOR);
+  EXPECT_EQ(3, SPV_SPIRV_VERSION_REVISION);
+}
+
+}  // anonymous namespace


### PR DESCRIPTION
- Update version numbers in libspirv.h.
  Add a test for the relevant macros.
- Update the README