### PR TITLE
Remove spv_validate_options_t and change tests accrodingly.

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -24,7 +24,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 
-#ifndef SPIRV_TOOLS_LIBSPIRV_H_      
+#ifndef SPIRV_TOOLS_LIBSPIRV_H_
 #define SPIRV_TOOLS_LIBSPIRV_H_
 
 #include "spirv/GLSL.std.450.h"
@@ -48,7 +48,7 @@ extern "C" {
 
 // Helpers
 
-#define spvIsInBitfield(value, bitfield) ((value) == ((value) & bitfield))
+#define spvIsInBitfield(value, bitfield) ((value) == ((value)&bitfield))
 
 #define SPV_BIT(shift) (1 << (shift))
 
@@ -63,7 +63,7 @@ typedef enum spv_result_t {
   SPV_END_OF_STREAM = 2,
   SPV_WARNING = 3,
   SPV_FAILED_MATCH = 4,
-  SPV_REQUESTED_TERMINATION = 5, // Success, but signals early termination.
+  SPV_REQUESTED_TERMINATION = 5,  // Success, but signals early termination.
   SPV_ERROR_INTERNAL = -1,
   SPV_ERROR_OUT_OF_MEMORY = -2,
   SPV_ERROR_INVALID_POINTER = -3,
@@ -263,19 +263,6 @@ typedef enum spv_binary_to_text_options_t {
   SPV_FORCE_32_BIT_ENUM(spv_binary_to_text_options_t)
 } spv_binary_to_text_options_t;
 
-typedef enum spv_validate_options_t {
-  SPV_VALIDATE_BASIC_BIT = SPV_BIT(0),
-  SPV_VALIDATE_LAYOUT_BIT = SPV_BIT(1),
-  SPV_VALIDATE_ID_BIT = SPV_BIT(2),
-  SPV_VALIDATE_RULES_BIT = SPV_BIT(3),
-  SPV_VALIDATE_SSA_BIT = SPV_BIT(4),
-  SPV_VALIDATE_INSTRUCTION_BIT = SPV_BIT(5),
-  SPV_VALIDATE_ALL = SPV_VALIDATE_BASIC_BIT | SPV_VALIDATE_LAYOUT_BIT |
-                     SPV_VALIDATE_ID_BIT | SPV_VALIDATE_RULES_BIT |
-                     SPV_VALIDATE_SSA_BIT | SPV_VALIDATE_INSTRUCTION_BIT ,
-  SPV_FORCE_32_BIT_ENUM(spv_validation_options_t)
-} spv_validate_options_t;
-
 // Structures
 
 // Information about an operand parsed from a binary SPIR-V module.
@@ -388,10 +375,9 @@ spv_result_t spvBinaryToText(const spv_const_context context,
 // pointer.
 void spvBinaryDestroy(spv_binary binary);
 
-// Validates a SPIR-V binary for correctness. The options parameter is a bit
-// field of spv_validation_options_t.
+// Validates a SPIR-V binary for correctness.
 spv_result_t spvValidate(const spv_const_context context,
-                         const spv_const_binary binary, const uint32_t options,
+                         const spv_const_binary binary,
                          spv_diagnostic* pDiagnostic);
 
 // Creates a diagnostic object. The position parameter specifies the location in

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -30,9 +30,9 @@
 #include "binary.h"
 #include "diagnostic.h"
 #include "instruction.h"
-#include "spirv-tools/libspirv.h"
 #include "opcode.h"
 #include "operand.h"
+#include "spirv-tools/libspirv.h"
 #include "spirv_constant.h"
 #include "spirv_endian.h"
 
@@ -278,8 +278,7 @@ void ProcessIds(ValidationState_t& _, const spv_parsed_instruction_t& inst) {
          std::vector<uint32_t>(inst.words, inst.words + inst.num_words)});
   }
   for (auto op = inst.operands; op != inst.operands + inst.num_operands; ++op) {
-    if (spvIsIdType(op->type))
-      _.usedefs().AddUse(inst.words[op->offset]);
+    if (spvIsIdType(op->type)) _.usedefs().AddUse(inst.words[op->offset]);
   }
 }
 
@@ -287,7 +286,8 @@ spv_result_t ProcessInstruction(void* user_data,
                                 const spv_parsed_instruction_t* inst) {
   ValidationState_t& _ = *(reinterpret_cast<ValidationState_t*>(user_data));
   _.incrementInstructionCount();
-  if (inst->opcode == SpvOpEntryPoint) _.entry_points().push_back(inst->words[2]);
+  if (inst->opcode == SpvOpEntryPoint)
+    _.entry_points().push_back(inst->words[2]);
 
   DebugInstructionPass(_, inst);
   // TODO(umar): Perform data rules pass
@@ -303,7 +303,7 @@ spv_result_t ProcessInstruction(void* user_data,
 }  // anonymous namespace
 
 spv_result_t spvValidate(const spv_const_context context,
-                         const spv_const_binary binary, const uint32_t options,
+                         const spv_const_binary binary,
                          spv_diagnostic* pDiagnostic) {
   if (!pDiagnostic) return SPV_ERROR_INVALID_DIAGNOSTIC;
 
@@ -322,7 +322,7 @@ spv_result_t spvValidate(const spv_const_context context,
 
   // NOTE: Parse the module and perform inline validation checks. These
   // checks do not require the the knowledge of the whole module.
-  ValidationState_t vstate(pDiagnostic, options, context);
+  ValidationState_t vstate(pDiagnostic, context);
   spvCheckReturn(spvBinaryParse(context, &vstate, binary->code,
                                 binary->wordCount, setHeader,
                                 ProcessInstruction, pDiagnostic));
@@ -358,13 +358,11 @@ spv_result_t spvValidate(const spv_const_context context,
     index += wordCount;
   }
 
-  if (spvIsInBitfield(SPV_VALIDATE_ID_BIT, options)) {
-    position.index = SPV_INDEX_INSTRUCTION;
-    spvCheckReturn(spvValidateIDs(instructions.data(), instructions.size(),
-                                  context->opcode_table, context->operand_table,
-                                  context->ext_inst_table, vstate, &position,
-                                  pDiagnostic));
-  }
+  position.index = SPV_INDEX_INSTRUCTION;
+  spvCheckReturn(spvValidateIDs(instructions.data(), instructions.size(),
+                                context->opcode_table, context->operand_table,
+                                context->ext_inst_table, vstate, &position,
+                                pDiagnostic));
 
   return SPV_SUCCESS;
 }

--- a/source/validate.h
+++ b/source/validate.h
@@ -173,7 +173,7 @@ class Functions {
 
 class ValidationState_t {
  public:
-  ValidationState_t(spv_diagnostic* diagnostic, uint32_t options,
+  ValidationState_t(spv_diagnostic* diagnostic,
                     const spv_const_context context);
 
   // Forward declares the id in the module
@@ -198,10 +198,6 @@ class ValidationState_t {
 
   // Returns true if the id has been defined
   bool isDefinedId(uint32_t id) const;
-
-  // Returns true if an spv_validate_options_t option is enabled in the
-  // validation instruction
-  bool is_enabled(spv_validate_options_t flag) const;
 
   // Increments the instruction count. Used for diagnostic
   int incrementInstructionCount();
@@ -285,9 +281,6 @@ class ValidationState_t {
 
   // IDs which have been forward declared but have not been defined
   std::unordered_set<uint32_t> unresolved_forward_ids_;
-
-  // Validation options to determine the passes to execute
-  uint32_t validation_flags_;
 
   std::map<uint32_t, std::string> operand_names_;
 

--- a/source/validate_instruction.cpp
+++ b/source/validate_instruction.cpp
@@ -116,36 +116,31 @@ spv_result_t CapCheck(ValidationState_t& _,
   return SPV_SUCCESS;
 }
 
-// clang-format off
 spv_result_t InstructionPass(ValidationState_t& _,
                              const spv_parsed_instruction_t* inst) {
-  if (_.is_enabled(SPV_VALIDATE_INSTRUCTION_BIT)) {
-    if (inst->opcode == SpvOpCapability)
-        _.registerCapability(
-            static_cast<SpvCapability>(inst->words[inst->operands[0].offset]));
-    if (inst->opcode == SpvOpVariable) {
-        const auto storage_class =
-            static_cast<SpvStorageClass>(inst->words[inst->operands[2].offset]);
-        if (storage_class == SpvStorageClassGeneric)
-          return _.diag(SPV_ERROR_INVALID_BINARY)
-              << "OpVariable storage class cannot be Generic";
-        if (_.getLayoutSection() == kLayoutFunctionDefinitions) {
-          if (storage_class != SpvStorageClassFunction) {
-            return _.diag(SPV_ERROR_INVALID_LAYOUT)
-                   << "Variables must have a function[7] storage class inside"
-                      " of a function";
-          }
-        } else {
-          if (storage_class == SpvStorageClassFunction) {
-            return _.diag(SPV_ERROR_INVALID_LAYOUT)
-                   << "Variables can not have a function[7] storage class "
-                      "outside of a function";
-          }
-        }
+  if (inst->opcode == SpvOpCapability)
+    _.registerCapability(
+        static_cast<SpvCapability>(inst->words[inst->operands[0].offset]));
+  if (inst->opcode == SpvOpVariable) {
+    const auto storage_class =
+        static_cast<SpvStorageClass>(inst->words[inst->operands[2].offset]);
+    if (storage_class == SpvStorageClassGeneric)
+      return _.diag(SPV_ERROR_INVALID_BINARY)
+             << "OpVariable storage class cannot be Generic";
+    if (_.getLayoutSection() == kLayoutFunctionDefinitions) {
+      if (storage_class != SpvStorageClassFunction) {
+        return _.diag(SPV_ERROR_INVALID_LAYOUT)
+               << "Variables must have a function[7] storage class inside"
+                  " of a function";
+      }
+    } else {
+      if (storage_class == SpvStorageClassFunction) {
+        return _.diag(SPV_ERROR_INVALID_LAYOUT)
+               << "Variables can not have a function[7] storage class "
+                  "outside of a function";
+      }
     }
-    return CapCheck(_, inst);
   }
-  return SPV_SUCCESS;
+  return CapCheck(_, inst);
 }
-// clang-format on
 }  // namespace libspirv

--- a/source/validate_layout.cpp
+++ b/source/validate_layout.cpp
@@ -26,8 +26,8 @@
 
 // Source code for logical layout validation as described in section 2.4
 
-#include "validate_passes.h"
 #include "spirv-tools/libspirv.h"
+#include "validate_passes.h"
 
 #include "diagnostic.h"
 #include "opcode.h"
@@ -182,28 +182,26 @@ namespace libspirv {
 // Performs logical layout validation. See Section 2.4
 spv_result_t ModuleLayoutPass(ValidationState_t& _,
                               const spv_parsed_instruction_t* inst) {
-  if (_.is_enabled(SPV_VALIDATE_LAYOUT_BIT)) {
-    SpvOp opcode = inst->opcode;
+  SpvOp opcode = inst->opcode;
 
-    switch (_.getLayoutSection()) {
-      case kLayoutCapabilities:
-      case kLayoutExtensions:
-      case kLayoutExtInstImport:
-      case kLayoutMemoryModel:
-      case kLayoutEntryPoint:
-      case kLayoutExecutionMode:
-      case kLayoutDebug1:
-      case kLayoutDebug2:
-      case kLayoutAnnotations:
-      case kLayoutTypes:
-        spvCheckReturn(ModuleScopedInstructions(_, inst, opcode));
-        break;
-      case kLayoutFunctionDeclarations:
-      case kLayoutFunctionDefinitions:
-        spvCheckReturn(FunctionScopedInstructions(_, inst, opcode));
-        break;
-    }  // switch(getLayoutSection())
-  }
+  switch (_.getLayoutSection()) {
+    case kLayoutCapabilities:
+    case kLayoutExtensions:
+    case kLayoutExtInstImport:
+    case kLayoutMemoryModel:
+    case kLayoutEntryPoint:
+    case kLayoutExecutionMode:
+    case kLayoutDebug1:
+    case kLayoutDebug2:
+    case kLayoutAnnotations:
+    case kLayoutTypes:
+      spvCheckReturn(ModuleScopedInstructions(_, inst, opcode));
+      break;
+    case kLayoutFunctionDeclarations:
+    case kLayoutFunctionDefinitions:
+      spvCheckReturn(FunctionScopedInstructions(_, inst, opcode));
+      break;
+  }  // switch(getLayoutSection())
   return SPV_SUCCESS;
 }
 }

--- a/source/validate_types.cpp
+++ b/source/validate_types.cpp
@@ -210,12 +210,10 @@ bool IsInstructionInLayoutSection(ModuleLayoutSection layout, SpvOp op) {
 namespace libspirv {
 
 ValidationState_t::ValidationState_t(spv_diagnostic* diagnostic,
-                                     uint32_t options,
                                      const spv_const_context context)
     : diagnostic_(diagnostic),
       instruction_counter_(0),
       unresolved_forward_ids_{},
-      validation_flags_(options),
       operand_names_{},
       current_layout_section_(kLayoutCapabilities),
       module_functions_(*this),
@@ -257,10 +255,6 @@ vector<uint32_t> ValidationState_t::unresolvedForwardIds() const {
 
 bool ValidationState_t::isDefinedId(uint32_t id) const {
   return usedefs_.FindDef(id).first;
-}
-
-bool ValidationState_t::is_enabled(spv_validate_options_t flag) const {
-  return (flag & validation_flags_) == flag;
 }
 
 // Increments the instruction count. Used for diagnostic

--- a/test/Validate.Capability.cpp
+++ b/test/Validate.Capability.cpp
@@ -49,8 +49,7 @@ using testing::Values;
 using testing::ValuesIn;
 
 using ValidateCapability =
-    spvtest::ValidateBase<tuple<string, pair<string, vector<string>>>,
-                          SPV_VALIDATE_INSTRUCTION_BIT>;
+    spvtest::ValidateBase<tuple<string, pair<string, vector<string>>>>;
 
 TEST_F(ValidateCapability, Default) {
   const char str[] = R"(
@@ -284,18 +283,48 @@ const vector<string>& SampledBufferDependencies() {
   return *r;
 }
 
+const char kOpenCLMemoryModel[] = \
+  " OpCapability Kernel"
+  " OpMemoryModel Logical OpenCL ";
+
+const char kGLSL450MemoryModel[] = \
+  " OpCapability Shader"
+  " OpMemoryModel Logical GLSL450 ";
+
+const char kVoidFVoid[] = \
+  " %void   = OpTypeVoid"
+  " %void_f = OpTypeFunction %void"
+  " %func   = OpFunction %void None %void_f"
+  " %label  = OpLabel"
+  "           OpReturn"
+  "           OpFunctionEnd ";
+
 INSTANTIATE_TEST_CASE_P(ExecutionModel, ValidateCapability,
                         Combine(
                             ValuesIn(AllCapabilities()),
                             Values(
-make_pair("OpEntryPoint Vertex %func \"shader\" %var1 %var2\n",                 ShaderDependencies()),
-make_pair("OpEntryPoint TessellationControl %func \"shader\" %var1 %var2\n",    TessellationDependencies()),
-make_pair("OpEntryPoint TessellationEvaluation %func \"shader\" %var1 %var2\n", TessellationDependencies()),
-make_pair("OpEntryPoint Geometry %func \"shader\" %var1 %var2\n",               GeometryDependencies()),
-make_pair("OpEntryPoint Fragment %func \"shader\" %var1 %var2\n",               ShaderDependencies()),
-make_pair("OpEntryPoint GLCompute %func \"shader\" %var1 %var2\n",              ShaderDependencies()),
-make_pair("OpEntryPoint Kernel %func \"shader\" %var1 %var2\n",                 KernelDependencies())
-                                                           )));
+make_pair(string(kOpenCLMemoryModel) +
+          " OpEntryPoint Vertex %func \"shader\"" +
+          string(kVoidFVoid), ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          " OpEntryPoint TessellationControl %func \"shader\"" +
+          string(kVoidFVoid), TessellationDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          " OpEntryPoint TessellationEvaluation %func \"shader\"" +
+          string(kVoidFVoid), TessellationDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          " OpEntryPoint Geometry %func \"shader\"" +
+          string(kVoidFVoid), GeometryDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          " OpEntryPoint Fragment %func \"shader\"" +
+          string(kVoidFVoid), ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          " OpEntryPoint GLCompute %func \"shader\"" +
+          string(kVoidFVoid), ShaderDependencies()),
+make_pair(string(kGLSL450MemoryModel) +
+          " OpEntryPoint Kernel %func \"shader\"" +
+          string(kVoidFVoid), KernelDependencies())
+)));
 
 INSTANTIATE_TEST_CASE_P(AddressingAndMemoryModel, ValidateCapability,
                         Combine(
@@ -325,101 +354,226 @@ INSTANTIATE_TEST_CASE_P(ExecutionMode, ValidateCapability,
                         Combine(
                             ValuesIn(AllCapabilities()),
                             Values(
-make_pair("OpExecutionMode %func Invocations 42",          GeometryDependencies()),
-make_pair("OpExecutionMode %func SpacingEqual",            TessellationDependencies()),
-make_pair("OpExecutionMode %func SpacingFractionalEven",   TessellationDependencies()),
-make_pair("OpExecutionMode %func SpacingFractionalOdd",    TessellationDependencies()),
-make_pair("OpExecutionMode %func VertexOrderCw",           TessellationDependencies()),
-make_pair("OpExecutionMode %func VertexOrderCcw",          TessellationDependencies()),
-make_pair("OpExecutionMode %func PixelCenterInteger",      ShaderDependencies()),
-make_pair("OpExecutionMode %func OriginUpperLeft",         ShaderDependencies()),
-make_pair("OpExecutionMode %func OriginLowerLeft",         ShaderDependencies()),
-make_pair("OpExecutionMode %func EarlyFragmentTests",      ShaderDependencies()),
-make_pair("OpExecutionMode %func PointMode",               TessellationDependencies()),
-make_pair("OpExecutionMode %func Xfb",                     vector<string>{"TransformFeedback"}),
-make_pair("OpExecutionMode %func DepthReplacing",          ShaderDependencies()),
-make_pair("OpExecutionMode %func DepthGreater",            ShaderDependencies()),
-make_pair("OpExecutionMode %func DepthLess",               ShaderDependencies()),
-make_pair("OpExecutionMode %func DepthUnchanged",          ShaderDependencies()),
-make_pair("OpExecutionMode %func LocalSize 42 42 42",      AllCapabilities()),
-make_pair("OpExecutionMode %func LocalSizeHint 42 42 42",  KernelDependencies()),
-make_pair("OpExecutionMode %func InputPoints",             GeometryDependencies()),
-make_pair("OpExecutionMode %func InputLines",              GeometryDependencies()),
-make_pair("OpExecutionMode %func InputLinesAdjacency",     GeometryDependencies()),
-make_pair("OpExecutionMode %func Triangles",               GeometryTessellationDependencies()),
-make_pair("OpExecutionMode %func InputTrianglesAdjacency", GeometryDependencies()),
-make_pair("OpExecutionMode %func Quads",                   TessellationDependencies()),
-make_pair("OpExecutionMode %func Isolines",                TessellationDependencies()),
-make_pair("OpExecutionMode %func OutputVertices 42",       GeometryTessellationDependencies()),
-make_pair("OpExecutionMode %func OutputPoints",            GeometryDependencies()),
-make_pair("OpExecutionMode %func OutputLineStrip",         GeometryDependencies()),
-make_pair("OpExecutionMode %func OutputTriangleStrip",     GeometryDependencies()),
-make_pair("OpExecutionMode %func VecTypeHint 2",           KernelDependencies()),
-make_pair("OpExecutionMode %func ContractionOff",          KernelDependencies())
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint Geometry %func \"shader\" "
+          "OpExecutionMode %func Invocations 42" +
+          string(kVoidFVoid), GeometryDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint TessellationControl %func \"shader\" "
+          "OpExecutionMode %func SpacingEqual" +
+          string(kVoidFVoid), TessellationDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint TessellationControl %func \"shader\" "
+          "OpExecutionMode %func SpacingFractionalEven" +
+          string(kVoidFVoid), TessellationDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint TessellationControl %func \"shader\" "
+          "OpExecutionMode %func SpacingFractionalOdd" +
+          string(kVoidFVoid), TessellationDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint TessellationControl %func \"shader\" "
+          "OpExecutionMode %func VertexOrderCw" +
+          string(kVoidFVoid), TessellationDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint TessellationControl %func \"shader\" "
+          "OpExecutionMode %func VertexOrderCcw" +
+          string(kVoidFVoid), TessellationDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint Vertex %func \"shader\" "
+          "OpExecutionMode %func PixelCenterInteger" +
+          string(kVoidFVoid), ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint Vertex %func \"shader\" "
+          "OpExecutionMode %func OriginUpperLeft" +
+          string(kVoidFVoid), ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint Vertex %func \"shader\" "
+          "OpExecutionMode %func OriginLowerLeft" +
+          string(kVoidFVoid), ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint Vertex %func \"shader\" "
+          "OpExecutionMode %func EarlyFragmentTests" +
+          string(kVoidFVoid), ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint TessellationControl %func \"shader\" "
+          "OpExecutionMode %func PointMode" +
+          string(kVoidFVoid), TessellationDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint Vertex %func \"shader\" "
+          "OpExecutionMode %func Xfb" +
+          string(kVoidFVoid), vector<string>{"TransformFeedback"}),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint Vertex %func \"shader\" "
+          "OpExecutionMode %func DepthReplacing" +
+          string(kVoidFVoid), ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint Vertex %func \"shader\" "
+          "OpExecutionMode %func DepthGreater" +
+          string(kVoidFVoid), ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint Vertex %func \"shader\" "
+          "OpExecutionMode %func DepthLess" +
+          string(kVoidFVoid), ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint Vertex %func \"shader\" "
+          "OpExecutionMode %func DepthUnchanged" +
+          string(kVoidFVoid), ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint Kernel %func \"shader\" "
+          "OpExecutionMode %func LocalSize 42 42 42" +
+          string(kVoidFVoid), AllCapabilities()),
+make_pair(string(kGLSL450MemoryModel) +
+          "OpEntryPoint Kernel %func \"shader\" "
+          "OpExecutionMode %func LocalSizeHint 42 42 42" +
+          string(kVoidFVoid), KernelDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint Geometry %func \"shader\" "
+          "OpExecutionMode %func InputPoints" +
+          string(kVoidFVoid), GeometryDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint Geometry %func \"shader\" "
+          "OpExecutionMode %func InputLines" +
+          string(kVoidFVoid), GeometryDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint Geometry %func \"shader\" "
+          "OpExecutionMode %func InputLinesAdjacency" +
+          string(kVoidFVoid), GeometryDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint Geometry %func \"shader\" "
+          "OpExecutionMode %func Triangles" +
+          string(kVoidFVoid), GeometryDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint TessellationControl %func \"shader\" "
+          "OpExecutionMode %func Triangles" +
+          string(kVoidFVoid), TessellationDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint Geometry %func \"shader\" "
+          "OpExecutionMode %func InputTrianglesAdjacency" +
+          string(kVoidFVoid), GeometryDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint TessellationControl %func \"shader\" "
+          "OpExecutionMode %func Quads" +
+          string(kVoidFVoid), TessellationDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint TessellationControl %func \"shader\" "
+          "OpExecutionMode %func Isolines" +
+          string(kVoidFVoid), TessellationDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint Geometry %func \"shader\" "
+          "OpExecutionMode %func OutputVertices 42" +
+          string(kVoidFVoid), GeometryDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint TessellationControl %func \"shader\" "
+          "OpExecutionMode %func OutputVertices 42" +
+          string(kVoidFVoid), TessellationDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint Geometry %func \"shader\" "
+          "OpExecutionMode %func OutputPoints" +
+          string(kVoidFVoid), GeometryDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint Geometry %func \"shader\" "
+          "OpExecutionMode %func OutputLineStrip" +
+          string(kVoidFVoid), GeometryDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpEntryPoint Geometry %func \"shader\" "
+          "OpExecutionMode %func OutputTriangleStrip" +
+          string(kVoidFVoid), GeometryDependencies()),
+make_pair(string(kGLSL450MemoryModel) +
+          "OpEntryPoint Kernel %func \"shader\" "
+          "OpExecutionMode %func VecTypeHint 2" +
+          string(kVoidFVoid), KernelDependencies()),
+make_pair(string(kGLSL450MemoryModel) +
+          "OpEntryPoint Kernel %func \"shader\" "
+          "OpExecutionMode %func ContractionOff" +
+          string(kVoidFVoid), KernelDependencies())
 )));
 
 INSTANTIATE_TEST_CASE_P(StorageClass, ValidateCapability,
                         Combine(
                             ValuesIn(AllCapabilities()),
                             Values(
-make_pair(" %intt = OpTypeInt 32 0\n"
+make_pair(string(kGLSL450MemoryModel) +
+          " %intt = OpTypeInt 32 0\n"
           " %ptrt = OpTypePointer UniformConstant %intt\n"
-          " %var = OpVariable %ptrt UniformConstant\n",             AllCapabilities()),
-make_pair(" %intt = OpTypeInt 32 0\n"
+          " %var = OpVariable %ptrt UniformConstant\n", AllCapabilities()),
+make_pair(string(kOpenCLMemoryModel) +
+          " %intt = OpTypeInt 32 0\n"
           " %ptrt = OpTypePointer Input %intt"
-          " %var = OpVariable %ptrt Input\n",                       ShaderDependencies()),
-make_pair(" %intt = OpTypeInt 32 0\n"
+          " %var = OpVariable %ptrt Input\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          " %intt = OpTypeInt 32 0\n"
           " %ptrt = OpTypePointer Uniform %intt\n"
-          " %var = OpVariable %ptrt Uniform\n",                     ShaderDependencies()),
-make_pair(" %intt = OpTypeInt 32 0\n"
+          " %var = OpVariable %ptrt Uniform\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          " %intt = OpTypeInt 32 0\n"
           " %ptrt = OpTypePointer Output %intt\n"
-          " %var = OpVariable %ptrt Output\n",                      ShaderDependencies()),
-make_pair(" %intt = OpTypeInt 32 0\n"
+          " %var = OpVariable %ptrt Output\n", ShaderDependencies()),
+make_pair(string(kGLSL450MemoryModel) +
+          " %intt = OpTypeInt 32 0\n"
           " %ptrt = OpTypePointer Workgroup %intt\n"
-          " %var = OpVariable %ptrt Workgroup\n",                   AllCapabilities()),
-make_pair(" %intt = OpTypeInt 32 0\n"
+          " %var = OpVariable %ptrt Workgroup\n", AllCapabilities()),
+make_pair(string(kGLSL450MemoryModel) +
+          " %intt = OpTypeInt 32 0\n"
           " %ptrt = OpTypePointer CrossWorkgroup %intt\n"
-          " %var = OpVariable %ptrt CrossWorkgroup\n",              AllCapabilities()),
-make_pair(" %intt = OpTypeInt 32 0\n"
+          " %var = OpVariable %ptrt CrossWorkgroup\n", AllCapabilities()),
+make_pair(string(kOpenCLMemoryModel) +
+          " %intt = OpTypeInt 32 0\n"
           " %ptrt = OpTypePointer Private %intt\n"
-          " %var = OpVariable %ptrt Private\n",                     ShaderDependencies()),
-make_pair(" %intt = OpTypeInt 32 0\n"
+          " %var = OpVariable %ptrt Private\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          " %intt = OpTypeInt 32 0\n"
           " %ptrt = OpTypePointer PushConstant %intt\n"
-          " %var = OpVariable %ptrt PushConstant\n",                ShaderDependencies()),
-make_pair(" %intt = OpTypeInt 32 0\n"
+          " %var = OpVariable %ptrt PushConstant\n", ShaderDependencies()),
+make_pair(string(kGLSL450MemoryModel) +
+          " %intt = OpTypeInt 32 0\n"
           " %ptrt = OpTypePointer AtomicCounter %intt\n"
-          " %var = OpVariable %ptrt AtomicCounter\n",               vector<string>{"AtomicStorage"}),
-make_pair(" %intt = OpTypeInt 32 0\n"
+          " %var = OpVariable %ptrt AtomicCounter\n", vector<string>{"AtomicStorage"}),
+make_pair(string(kGLSL450MemoryModel) +
+          " %intt = OpTypeInt 32 0\n"
           " %ptrt = OpTypePointer Image %intt\n"
-          " %var = OpVariable %ptrt Image\n",                       AllCapabilities())
-  )));
+          " %var = OpVariable %ptrt Image\n", AllCapabilities())
+)));
 
 INSTANTIATE_TEST_CASE_P(Dim, ValidateCapability,
                         Combine(
                             ValuesIn(AllCapabilities()),
                             Values(
-make_pair(" OpCapability ImageBasic"
+make_pair(" OpCapability ImageBasic" +
+          string(kOpenCLMemoryModel) +
           " %voidt = OpTypeVoid"
-          " %imgt = OpTypeImage %voidt 1D 0 0 0 0 Unknown",       Sampled1DDependencies()),
-make_pair(" OpCapability ImageBasic"
+          " %imgt = OpTypeImage %voidt 1D 0 0 0 0 Unknown",
+          Sampled1DDependencies()),
+make_pair(" OpCapability ImageBasic" +
+          string(kOpenCLMemoryModel) +
           " %voidt = OpTypeVoid"
-          " %imgt = OpTypeImage %voidt 2D 0 0 0 0 Unknown",       AllCapabilities()),
-make_pair(" OpCapability ImageBasic"
+          " %imgt = OpTypeImage %voidt 2D 0 0 0 0 Unknown",
+          AllCapabilities()),
+make_pair(" OpCapability ImageBasic" +
+          string(kOpenCLMemoryModel) +
           " %voidt = OpTypeVoid"
-          " %imgt = OpTypeImage %voidt 3D 0 0 0 0 Unknown",       AllCapabilities()),
-make_pair(" OpCapability ImageBasic"
+          " %imgt = OpTypeImage %voidt 3D 0 0 0 0 Unknown",
+          AllCapabilities()),
+make_pair(" OpCapability ImageBasic" +
+          string(kOpenCLMemoryModel) +
           " %voidt = OpTypeVoid"
-          " %imgt = OpTypeImage %voidt Cube 0 0 0 0 Unknown",     ShaderDependencies()),
-make_pair(" OpCapability ImageBasic"
+          " %imgt = OpTypeImage %voidt Cube 0 0 0 0 Unknown",
+          ShaderDependencies()),
+make_pair(" OpCapability ImageBasic" +
+          string(kOpenCLMemoryModel) +
           " %voidt = OpTypeVoid"
-          " %imgt = OpTypeImage %voidt Rect 0 0 0 0 Unknown",     SampledRectDependencies()),
-make_pair(" OpCapability ImageBasic"
+          " %imgt = OpTypeImage %voidt Rect 0 0 0 0 Unknown",
+          SampledRectDependencies()),
+make_pair(" OpCapability ImageBasic" +
+          string(kOpenCLMemoryModel) +
           " %voidt = OpTypeVoid"
-          " %imgt = OpTypeImage %voidt Buffer 0 0 0 0 Unknown",   SampledBufferDependencies()),
-make_pair(" OpCapability ImageBasic"
+          " %imgt = OpTypeImage %voidt Buffer 0 0 0 0 Unknown",
+          SampledBufferDependencies()),
+make_pair(" OpCapability ImageBasic" +
+          string(kOpenCLMemoryModel) +
           " %voidt = OpTypeVoid"
-          " %imgt = OpTypeImage %voidt SubpassData 0 0 0 2 Unknown", vector<string>{"InputAttachment"})
-                                          )));
+          " %imgt = OpTypeImage %voidt SubpassData 0 0 0 2 Unknown",
+          vector<string>{"InputAttachment"})
+)));
 
 // NOTE: All Sampler Address Modes require kernel capabilities but the
 // OpConstantSampler requires LiteralSampler which depends on Kernel
@@ -427,17 +581,27 @@ INSTANTIATE_TEST_CASE_P(SamplerAddressingMode, ValidateCapability,
                         Combine(
                             ValuesIn(AllCapabilities()),
                             Values(
-make_pair(" %samplert = OpTypeSampler"
-          " %sampler = OpConstantSampler %samplert None 1 Nearest",           vector<string>{"LiteralSampler"}),
-make_pair(" %samplert = OpTypeSampler"
-          " %sampler = OpConstantSampler %samplert ClampToEdge 1 Nearest",    vector<string>{"LiteralSampler"}),
-make_pair(" %samplert = OpTypeSampler"
-          " %sampler = OpConstantSampler %samplert Clamp 1 Nearest",          vector<string>{"LiteralSampler"}),
-make_pair(" %samplert = OpTypeSampler"
-          " %sampler = OpConstantSampler %samplert Repeat 1 Nearest",         vector<string>{"LiteralSampler"}),
-make_pair(" %samplert = OpTypeSampler"
-          " %sampler = OpConstantSampler %samplert RepeatMirrored 1 Nearest", vector<string>{"LiteralSampler"})
-                                        )));
+make_pair(string(kGLSL450MemoryModel) +
+          " %samplert = OpTypeSampler"
+          " %sampler = OpConstantSampler %samplert None 1 Nearest",
+          vector<string>{"LiteralSampler"}),
+make_pair(string(kGLSL450MemoryModel) +
+          " %samplert = OpTypeSampler"
+          " %sampler = OpConstantSampler %samplert ClampToEdge 1 Nearest",
+          vector<string>{"LiteralSampler"}),
+make_pair(string(kGLSL450MemoryModel) +
+          " %samplert = OpTypeSampler"
+          " %sampler = OpConstantSampler %samplert Clamp 1 Nearest",
+          vector<string>{"LiteralSampler"}),
+make_pair(string(kGLSL450MemoryModel) +
+          " %samplert = OpTypeSampler"
+          " %sampler = OpConstantSampler %samplert Repeat 1 Nearest",
+          vector<string>{"LiteralSampler"}),
+make_pair(string(kGLSL450MemoryModel) +
+          " %samplert = OpTypeSampler"
+          " %sampler = OpConstantSampler %samplert RepeatMirrored 1 Nearest",
+          vector<string>{"LiteralSampler"})
+)));
 
 //TODO(umar): Sampler Filter Mode
 //TODO(umar): Image Format
@@ -454,99 +618,269 @@ INSTANTIATE_TEST_CASE_P(Decoration, ValidateCapability,
                         Combine(
                             ValuesIn(AllCapabilities()),
                             Values(
-make_pair("OpDecorate %intt RelaxedPrecision\n",                    ShaderDependencies()),
-make_pair("OpDecorate %intt SpecId 1\n",                            ShaderDependencies()),
-make_pair("OpDecorate %intt Block\n",                               ShaderDependencies()),
-make_pair("OpDecorate %intt BufferBlock\n",                         ShaderDependencies()),
-make_pair("OpDecorate %intt RowMajor\n",                            MatrixDependencies()),
-make_pair("OpDecorate %intt ColMajor\n",                            MatrixDependencies()),
-make_pair("OpDecorate %intt ArrayStride 1\n",                       ShaderDependencies()),
-make_pair("OpDecorate %intt MatrixStride 1\n",                      MatrixDependencies()),
-make_pair("OpDecorate %intt GLSLShared\n",                          ShaderDependencies()),
-make_pair("OpDecorate %intt GLSLPacked\n",                          ShaderDependencies()),
-make_pair("OpDecorate %intt CPacked\n",                             KernelDependencies()),
-make_pair("OpDecorate %intt NoPerspective\n",                       ShaderDependencies()),
-make_pair("OpDecorate %intt Flat\n",                                ShaderDependencies()),
-make_pair("OpDecorate %intt Patch\n",                               TessellationDependencies()),
-make_pair("OpDecorate %intt Centroid\n",                            ShaderDependencies()),
-make_pair("OpDecorate %intt Sample\n",                              vector<string>{"SampleRateShading"}),
-make_pair("OpDecorate %intt Invariant\n",                           ShaderDependencies()),
-make_pair("OpDecorate %intt Restrict\n",                            AllCapabilities()),
-make_pair("OpDecorate %intt Aliased\n",                             AllCapabilities()),
-make_pair("OpDecorate %intt Volatile\n",                            AllCapabilities()),
-make_pair("OpDecorate %intt Constant\n",                            KernelDependencies()),
-make_pair("OpDecorate %intt Coherent\n",                            AllCapabilities()),
-make_pair("OpDecorate %intt NonWritable\n",                         AllCapabilities()),
-make_pair("OpDecorate %intt NonReadable\n",                         AllCapabilities()),
-make_pair("OpDecorate %intt Uniform\n",                             ShaderDependencies()),
-make_pair("OpDecorate %intt SaturatedConversion\n",                 KernelDependencies()),
-make_pair("OpDecorate %intt Stream 0\n",                            vector<string>{"GeometryStreams"}),
-make_pair("OpDecorate %intt Location 0\n",                          ShaderDependencies()),
-make_pair("OpDecorate %intt Component 0\n",                         ShaderDependencies()),
-make_pair("OpDecorate %intt Index 0\n",                             ShaderDependencies()),
-make_pair("OpDecorate %intt Binding 0\n",                           ShaderDependencies()),
-make_pair("OpDecorate %intt DescriptorSet 0\n",                     ShaderDependencies()),
-make_pair("OpDecorate %intt Offset 0\n",                            ShaderDependencies()),
-make_pair("OpDecorate %intt XfbBuffer 0\n",                         vector<string>{"TransformFeedback"}),
-make_pair("OpDecorate %intt XfbStride 0\n",                         vector<string>{"TransformFeedback"}),
-make_pair("OpDecorate %intt FuncParamAttr Zext\n",                  KernelDependencies()),
-make_pair("OpDecorate %intt FPRoundingMode RTE\n",                  KernelDependencies()),
-make_pair("OpDecorate %intt FPFastMathMode Fast\n",                 KernelDependencies()),
-make_pair("OpDecorate %intt LinkageAttributes \"other\" Import\n",  vector<string>{"Linkage"}),
-make_pair("OpDecorate %intt NoContraction\n",                       ShaderDependencies()),
-make_pair("OpDecorate %intt InputAttachmentIndex 0\n",              vector<string>{"InputAttachment"}),
-make_pair("OpDecorate %intt Alignment 4\n",                         KernelDependencies())
-  )));
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt RelaxedPrecision\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt SpecId 1\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt Block\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BufferBlock\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt RowMajor\n"
+          "%intt = OpTypeInt 32 1\n", MatrixDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt ColMajor\n"
+          "%intt = OpTypeInt 32 1\n", MatrixDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt ArrayStride 1\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt MatrixStride 1\n"
+          "%intt = OpTypeInt 32 1\n", MatrixDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt GLSLShared\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt GLSLPacked\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kGLSL450MemoryModel) +
+          "OpDecorate %intt CPacked\n"
+          "%intt = OpTypeInt 32 1\n", KernelDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt NoPerspective\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt Flat\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt Patch\n"
+          "%intt = OpTypeInt 32 1\n", TessellationDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt Centroid\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt Sample\n"
+          "%intt = OpTypeInt 32 1\n", vector<string>{"SampleRateShading"}),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt Invariant\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt Restrict\n"
+          "%intt = OpTypeInt 32 1\n", AllCapabilities()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt Aliased\n"
+          "%intt = OpTypeInt 32 1\n", AllCapabilities()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt Volatile\n"
+          "%intt = OpTypeInt 32 1\n", AllCapabilities()),
+make_pair(string(kGLSL450MemoryModel) +
+          "OpDecorate %intt Constant\n"
+          "%intt = OpTypeInt 32 1\n", KernelDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt Coherent\n"
+          "%intt = OpTypeInt 32 1\n", AllCapabilities()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt NonWritable\n"
+          "%intt = OpTypeInt 32 1\n", AllCapabilities()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt NonReadable\n"
+          "%intt = OpTypeInt 32 1\n", AllCapabilities()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt Uniform\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kGLSL450MemoryModel) +
+          "OpDecorate %intt SaturatedConversion\n"
+          "%intt = OpTypeInt 32 1\n", KernelDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt Stream 0\n"
+          "%intt = OpTypeInt 32 1\n", vector<string>{"GeometryStreams"}),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt Location 0\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt Component 0\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt Index 0\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt Binding 0\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt DescriptorSet 0\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt Offset 0\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt XfbBuffer 0\n"
+          "%intt = OpTypeInt 32 1\n", vector<string>{"TransformFeedback"}),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt XfbStride 0\n"
+          "%intt = OpTypeInt 32 1\n", vector<string>{"TransformFeedback"}),
+make_pair(string(kGLSL450MemoryModel) +
+          "OpDecorate %intt FuncParamAttr Zext\n"
+          "%intt = OpTypeInt 32 1\n", KernelDependencies()),
+make_pair(string(kGLSL450MemoryModel) +
+          "OpDecorate %intt FPRoundingMode RTE\n"
+          "%intt = OpTypeInt 32 1\n", KernelDependencies()),
+make_pair(string(kGLSL450MemoryModel) +
+          "OpDecorate %intt FPFastMathMode Fast\n"
+          "%intt = OpTypeInt 32 1\n", KernelDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt LinkageAttributes \"other\" Import\n"
+          "%intt = OpTypeInt 32 1\n", vector<string>{"Linkage"}),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt NoContraction\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt InputAttachmentIndex 0\n"
+          "%intt = OpTypeInt 32 1\n", vector<string>{"InputAttachment"}),
+make_pair(string(kGLSL450MemoryModel) +
+          "OpDecorate %intt Alignment 4\n"
+          "%intt = OpTypeInt 32 1\n", KernelDependencies())
+)));
 
 
 INSTANTIATE_TEST_CASE_P(BuiltIn, ValidateCapability,
                         Combine(
                             ValuesIn(AllCapabilities()),
                             Values(
-make_pair("OpDecorate %intt BuiltIn Position\n",                  ShaderDependencies()),
-make_pair("OpDecorate %intt BuiltIn PointSize\n",                 ShaderDependencies()),
-make_pair("OpDecorate %intt BuiltIn ClipDistance\n",              vector<string>{"ClipDistance"}),
-make_pair("OpDecorate %intt BuiltIn CullDistance\n",              vector<string>{"CullDistance"}),
-make_pair("OpDecorate %intt BuiltIn VertexId\n",                  ShaderDependencies()),
-make_pair("OpDecorate %intt BuiltIn InstanceId\n",                ShaderDependencies()),
-make_pair("OpDecorate %intt BuiltIn PrimitiveId\n",               GeometryTessellationDependencies()),
-make_pair("OpDecorate %intt BuiltIn InvocationId\n",              GeometryTessellationDependencies()),
-make_pair("OpDecorate %intt BuiltIn Layer\n",                     GeometryDependencies()),
-make_pair("OpDecorate %intt BuiltIn ViewportIndex\n",             vector<string>{"MultiViewport"}),
-make_pair("OpDecorate %intt BuiltIn TessLevelOuter\n",            TessellationDependencies()),
-make_pair("OpDecorate %intt BuiltIn TessLevelInner\n",            TessellationDependencies()),
-make_pair("OpDecorate %intt BuiltIn TessCoord\n",                 TessellationDependencies()),
-make_pair("OpDecorate %intt BuiltIn PatchVertices\n",             TessellationDependencies()),
-make_pair("OpDecorate %intt BuiltIn FragCoord\n",                 ShaderDependencies()),
-make_pair("OpDecorate %intt BuiltIn PointCoord\n",                ShaderDependencies()),
-make_pair("OpDecorate %intt BuiltIn FrontFacing\n",               ShaderDependencies()),
-make_pair("OpDecorate %intt BuiltIn SampleId\n",                  vector<string>{"SampleRateShading"}),
-make_pair("OpDecorate %intt BuiltIn SamplePosition\n",            vector<string>{"SampleRateShading"}),
-make_pair("OpDecorate %intt BuiltIn SampleMask\n",                vector<string>{"SampleRateShading"}),
-make_pair("OpDecorate %intt BuiltIn FragDepth\n",                 ShaderDependencies()),
-make_pair("OpDecorate %intt BuiltIn HelperInvocation\n",          ShaderDependencies()),
-make_pair("OpDecorate %intt BuiltIn VertexIndex\n",               ShaderDependencies()),
-make_pair("OpDecorate %intt BuiltIn InstanceIndex\n",             ShaderDependencies()),
-make_pair("OpDecorate %intt BuiltIn NumWorkgroups\n",             AllCapabilities()),
-make_pair("OpDecorate %intt BuiltIn WorkgroupSize\n",             AllCapabilities()),
-make_pair("OpDecorate %intt BuiltIn WorkgroupId\n",               AllCapabilities()),
-make_pair("OpDecorate %intt BuiltIn LocalInvocationId\n",         AllCapabilities()),
-make_pair("OpDecorate %intt BuiltIn GlobalInvocationId\n",        AllCapabilities()),
-make_pair("OpDecorate %intt BuiltIn LocalInvocationIndex\n",      AllCapabilities()),
-make_pair("OpDecorate %intt BuiltIn WorkDim\n",                   KernelDependencies()),
-make_pair("OpDecorate %intt BuiltIn GlobalSize\n",                KernelDependencies()),
-make_pair("OpDecorate %intt BuiltIn EnqueuedWorkgroupSize\n",     KernelDependencies()),
-make_pair("OpDecorate %intt BuiltIn GlobalOffset\n",              KernelDependencies()),
-make_pair("OpDecorate %intt BuiltIn GlobalLinearId\n",            KernelDependencies()),
-make_pair("OpDecorate %intt BuiltIn SubgroupSize\n",              KernelDependencies()),
-make_pair("OpDecorate %intt BuiltIn SubgroupMaxSize\n",           KernelDependencies()),
-make_pair("OpDecorate %intt BuiltIn NumSubgroups\n",              KernelDependencies()),
-make_pair("OpDecorate %intt BuiltIn NumEnqueuedSubgroups\n",      KernelDependencies()),
-make_pair("OpDecorate %intt BuiltIn SubgroupId\n",                KernelDependencies()),
-make_pair("OpDecorate %intt BuiltIn SubgroupLocalInvocationId\n", KernelDependencies()),
-make_pair("OpDecorate %intt BuiltIn VertexIndex\n",               ShaderDependencies()),
-make_pair("OpDecorate %intt BuiltIn InstanceIndex\n",             ShaderDependencies())
-                                                           )));
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn Position\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn PointSize\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn ClipDistance\n"
+          "%intt = OpTypeInt 32 1\n", vector<string>{"ClipDistance"}),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn CullDistance\n"
+          "%intt = OpTypeInt 32 1\n", vector<string>{"CullDistance"}),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn VertexId\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn InstanceId\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn PrimitiveId\n"
+          "%intt = OpTypeInt 32 1\n", GeometryTessellationDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn InvocationId\n"
+          "%intt = OpTypeInt 32 1\n", GeometryTessellationDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn Layer\n"
+          "%intt = OpTypeInt 32 1\n", GeometryDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn ViewportIndex\n"
+          "%intt = OpTypeInt 32 1\n", vector<string>{"MultiViewport"}),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn TessLevelOuter\n"
+          "%intt = OpTypeInt 32 1\n", TessellationDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn TessLevelInner\n"
+          "%intt = OpTypeInt 32 1\n", TessellationDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn TessCoord\n"
+          "%intt = OpTypeInt 32 1\n", TessellationDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn PatchVertices\n"
+          "%intt = OpTypeInt 32 1\n", TessellationDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn FragCoord\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn PointCoord\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn FrontFacing\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn SampleId\n"
+          "%intt = OpTypeInt 32 1\n", vector<string>{"SampleRateShading"}),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn SamplePosition\n"
+          "%intt = OpTypeInt 32 1\n", vector<string>{"SampleRateShading"}),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn SampleMask\n"
+          "%intt = OpTypeInt 32 1\n", vector<string>{"SampleRateShading"}),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn FragDepth\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn HelperInvocation\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn VertexIndex\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn InstanceIndex\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn NumWorkgroups\n"
+          "%intt = OpTypeInt 32 1\n", AllCapabilities()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn WorkgroupSize\n"
+          "%intt = OpTypeInt 32 1\n", AllCapabilities()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn WorkgroupId\n"
+          "%intt = OpTypeInt 32 1\n", AllCapabilities()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn LocalInvocationId\n"
+          "%intt = OpTypeInt 32 1\n", AllCapabilities()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn GlobalInvocationId\n"
+          "%intt = OpTypeInt 32 1\n", AllCapabilities()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn LocalInvocationIndex\n"
+          "%intt = OpTypeInt 32 1\n", AllCapabilities()),
+make_pair(string(kGLSL450MemoryModel) +
+          "OpDecorate %intt BuiltIn WorkDim\n"
+          "%intt = OpTypeInt 32 1\n", KernelDependencies()),
+make_pair(string(kGLSL450MemoryModel) +
+          "OpDecorate %intt BuiltIn GlobalSize\n"
+          "%intt = OpTypeInt 32 1\n", KernelDependencies()),
+make_pair(string(kGLSL450MemoryModel) +
+          "OpDecorate %intt BuiltIn EnqueuedWorkgroupSize\n"
+          "%intt = OpTypeInt 32 1\n", KernelDependencies()),
+make_pair(string(kGLSL450MemoryModel) +
+          "OpDecorate %intt BuiltIn GlobalOffset\n"
+          "%intt = OpTypeInt 32 1\n", KernelDependencies()),
+make_pair(string(kGLSL450MemoryModel) +
+          "OpDecorate %intt BuiltIn GlobalLinearId\n"
+          "%intt = OpTypeInt 32 1\n", KernelDependencies()),
+make_pair(string(kGLSL450MemoryModel) +
+          "OpDecorate %intt BuiltIn SubgroupSize\n"
+          "%intt = OpTypeInt 32 1\n", KernelDependencies()),
+make_pair(string(kGLSL450MemoryModel) +
+          "OpDecorate %intt BuiltIn SubgroupMaxSize\n"
+          "%intt = OpTypeInt 32 1\n", KernelDependencies()),
+make_pair(string(kGLSL450MemoryModel) +
+          "OpDecorate %intt BuiltIn NumSubgroups\n"
+          "%intt = OpTypeInt 32 1\n", KernelDependencies()),
+make_pair(string(kGLSL450MemoryModel) +
+          "OpDecorate %intt BuiltIn NumEnqueuedSubgroups\n"
+          "%intt = OpTypeInt 32 1\n", KernelDependencies()),
+make_pair(string(kGLSL450MemoryModel) +
+          "OpDecorate %intt BuiltIn SubgroupId\n"
+          "%intt = OpTypeInt 32 1\n", KernelDependencies()),
+make_pair(string(kGLSL450MemoryModel) +
+          "OpDecorate %intt BuiltIn SubgroupLocalInvocationId\n"
+          "%intt = OpTypeInt 32 1\n", KernelDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn VertexIndex\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies()),
+make_pair(string(kOpenCLMemoryModel) +
+          "OpDecorate %intt BuiltIn InstanceIndex\n"
+          "%intt = OpTypeInt 32 1\n", ShaderDependencies())
+)));
 
 // TODO(umar): Selection Control
 // TODO(umar): Loop Control
@@ -562,7 +896,7 @@ INSTANTIATE_TEST_CASE_P(MatrixOp, ValidateCapability,
                         Combine(
                             ValuesIn(AllCapabilities()),
                             Values(
-make_pair(
+make_pair(string(kOpenCLMemoryModel) +
           "%intt     = OpTypeInt 32 1\n"
           "%vec3     = OpTypeVector %intt 3\n"
           "%mat33    = OpTypeMatrix %vec3 3\n", MatrixDependencies()))));
@@ -621,7 +955,7 @@ TEST_P(ValidateCapability, Capability) {
   pair<string, vector<string>> operation;
   std::tie(capability, operation) = GetParam();
   stringstream ss;
-  if (capability.empty() == false) {
+  if (!capability.empty()) {
     ss << "OpCapability " + capability + " ";
   }
 

--- a/test/Validate.Layout.cpp
+++ b/test/Validate.Layout.cpp
@@ -53,8 +53,8 @@ using libspirv::spvResultToString;
 
 using pred_type = function<spv_result_t(int)>;
 using ValidateLayout =
-    spvtest::ValidateBase<tuple<int, tuple<string, pred_type, pred_type>>,
-                          SPV_VALIDATE_LAYOUT_BIT>;
+    spvtest::ValidateBase<tuple<int, tuple<string, pred_type, pred_type>>>;
+
 namespace {
 
 // returns true if order is equal to VAL
@@ -86,17 +86,18 @@ spv_result_t InvalidSet(int order) {
 const vector<string>& getInstructions() {
   // clang-format off
   static const vector<string> instructions = {
-    "OpCapability Matrix",
+    "OpCapability Shader",
     "OpExtension \"TestExtension\"",
     "%inst = OpExtInstImport \"GLSL.std.450\"",
     "OpMemoryModel Logical GLSL450",
     "OpEntryPoint GLCompute %func \"\"",
     "OpExecutionMode %func LocalSize 1 1 1",
     "%str = OpString \"Test String\"",
+    "%str2 = OpString \"blabla\"",
     "OpSource GLSL 450 %str \"uniform vec3 var = vec3(4.0);\"",
     "OpSourceContinued \"void main(){return;}\"",
     "OpSourceExtension \"Test extension\"",
-    "OpName %id \"MyID\"",
+    "OpName %func \"MyFunction\"",
     "OpMemberName %struct 1 \"my_member\"",
     "OpDecorate %dgrp RowMajor",
     "OpMemberDecorate %struct 1 RowMajor",
@@ -137,37 +138,42 @@ pred_type All = Range<0, kRangeEnd>();
 INSTANTIATE_TEST_CASE_P(InstructionsOrder,
     ValidateLayout,
     ::testing::Combine(::testing::Range((int)0, (int)getInstructions().size()),
-    //                                   | Instruction              | Line(s) valid     | Lines to compile
-    ::testing::Values( make_tuple(string("OpCapability")            , Equals<0>         , All)
-                     , make_tuple(string("OpExtension")             , Equals<1>         , All)
-                     , make_tuple(string("OpExtInstImport")         , Equals<2>         , All)
-                     , make_tuple(string("OpMemoryModel")           , Equals<3>         , All)
-                     , make_tuple(string("OpEntryPoint")            , Equals<4>         , All)
-                     , make_tuple(string("OpExecutionMode")         , Equals<5>         , All)
-                     , make_tuple(string("OpSource ")               , Range<6, 9>()     , All)
-                     , make_tuple(string("OpSourceContinued ")      , Range<6, 9>()     , All)
-                     , make_tuple(string("OpSourceExtension ")      , Range<6, 9>()     , All)
-                     , make_tuple(string("OpString ")               , Range<6, 9>()     , All)
-                     , make_tuple(string("OpName ")                 , Range<10, 11>()   , All)
-                     , make_tuple(string("OpMemberName ")           , Range<10, 11>()   , All)
-                     , make_tuple(string("OpDecorate ")             , Range<12, 15>()   , All)
-                     , make_tuple(string("OpMemberDecorate ")       , Range<12, 15>()   , All)
-                     , make_tuple(string("OpGroupDecorate ")        , Range<12, 15>()   , All)
-                     , make_tuple(string("OpDecorationGroup")       , Range<12, 15>()   , All)
-                     , make_tuple(string("OpTypeBool")              , Range<16, 29>()   , All)
-                     , make_tuple(string("OpTypeVoid")              , Range<16, 29>()   , All)
-                     , make_tuple(string("OpTypeFloat")             , Range<16, 29>()   , All)
-                     , make_tuple(string("OpTypeInt")               , Range<16, 29>()   , static_cast<pred_type>(Range<0, 25>()))
-                     , make_tuple(string("OpTypeVector %intt 4")    , Range<16, 29>()   , All)
-                     , make_tuple(string("OpTypeMatrix %vec4 4")    , Range<16, 29>()   , All)
-                     , make_tuple(string("OpTypeStruct")            , Range<16, 29>()   , All)
-                     , make_tuple(string("%vfunct   = OpTypeFunction"), Range<16,29>()   , All)
-                     , make_tuple(string("OpConstant")              , Range<19, 29>()   , static_cast<pred_type>(Range<19, kRangeEnd>()))
-                     , make_tuple(string("OpLine ")                 , Range<16, kRangeEnd>()   , All)
-                     , make_tuple(string("OpNoLine")                , Range<16, kRangeEnd>()   , All)
-                     , make_tuple(string("OpLabel")                 , Equals<35>        , All)
-                     , make_tuple(string("OpNop")                   , Equals<36>        , All)
-                     , make_tuple(string("OpReturn")                , Equals<37>        , All)
+    // Note: Because of ID dependencies between instructions, some instructions
+    // are not free to be placed anywhere without triggering an non-layout
+    // validation error. Therefore, "Lines to compile" for some instructions
+    // are not "All" in the below.
+    //
+    //                                   | Instruction                | Line(s) valid          | Lines to compile
+    ::testing::Values( make_tuple(string("OpCapability")              , Equals<0>              , Range<0, 2>())
+                     , make_tuple(string("OpExtension")               , Equals<1>              , All)
+                     , make_tuple(string("OpExtInstImport")           , Equals<2>              , All)
+                     , make_tuple(string("OpMemoryModel")             , Equals<3>              , Range<1, kRangeEnd>())
+                     , make_tuple(string("OpEntryPoint")              , Equals<4>              , All)
+                     , make_tuple(string("OpExecutionMode")           , Equals<5>              , All)
+                     , make_tuple(string("OpSource ")                 , Range<6, 10>()         , Range<7, kRangeEnd>())
+                     , make_tuple(string("OpSourceContinued ")        , Range<6, 10>()         , All)
+                     , make_tuple(string("OpSourceExtension ")        , Range<6, 10>()         , All)
+                     , make_tuple(string("%str2 = OpString ")         , Range<6, 10>()         , All)
+                     , make_tuple(string("OpName ")                   , Range<11, 12>()        , All)
+                     , make_tuple(string("OpMemberName ")             , Range<11, 12>()        , All)
+                     , make_tuple(string("OpDecorate ")               , Range<13, 16>()        , All)
+                     , make_tuple(string("OpMemberDecorate ")         , Range<13, 16>()        , All)
+                     , make_tuple(string("OpGroupDecorate ")          , Range<13, 16>()        , Range<16, kRangeEnd>())
+                     , make_tuple(string("OpDecorationGroup")         , Range<13, 16>()        , Range<0, 15>())
+                     , make_tuple(string("OpTypeBool")                , Range<17, 30>()        , All)
+                     , make_tuple(string("OpTypeVoid")                , Range<17, 30>()        , Range<0, 25>())
+                     , make_tuple(string("OpTypeFloat")               , Range<17, 30>()        , All)
+                     , make_tuple(string("OpTypeInt")                 , Range<17, 30>()        , Range<0, 20>())
+                     , make_tuple(string("OpTypeVector %intt 4")      , Range<17, 30>()        , Range<18, 23>())
+                     , make_tuple(string("OpTypeMatrix %vec4 4")      , Range<17, 30>()        , Range<22, kRangeEnd>())
+                     , make_tuple(string("OpTypeStruct")              , Range<17, 30>()        , Range<24, kRangeEnd>())
+                     , make_tuple(string("%vfunct   = OpTypeFunction"), Range<17, 30>()        , Range<20, 30>())
+                     , make_tuple(string("OpConstant")                , Range<17, 30>()        , Range<20, kRangeEnd>())
+                     , make_tuple(string("OpLine ")                   , Range<17, kRangeEnd>() , Range<7, kRangeEnd>())
+                     , make_tuple(string("OpNoLine")                  , Range<17, kRangeEnd>() , All)
+                     , make_tuple(string("OpLabel")                   , Equals<36>             , All)
+                     , make_tuple(string("OpNop")                     , Equals<37>             , All)
+                     , make_tuple(string("OpReturn")                  , Equals<38>             , All)
     )));
 // clang-format on
 
@@ -189,10 +195,7 @@ vector<string> GenerateCode(string substr, int order) {
 
 // This test will check the logical layout of a binary by removing each
 // instruction in the pair of the INSTANTIATE_TEST_CASE_P call and moving it in
-// the SPIRV source formed by combining the vector "instructions"
-//
-// NOTE: The test will only execute with the SPV_VALIDATE_LAYOUT_BIT flag so SSA
-// and other tests are not performed
+// the SPIRV source formed by combining the vector "instructions".
 TEST_P(ValidateLayout, Layout) {
   int order;
   string instruction;
@@ -239,6 +242,7 @@ TEST_F(ValidateLayout, MemoryModelMissing) {
 
 TEST_F(ValidateLayout, FunctionDefinitionBeforeDeclarationBad) {
   char str[] = R"(
+           OpCapability Shader
            OpMemoryModel Logical GLSL450
            OpDecorate %var Restrict
 %intt    = OpTypeInt 32 1
@@ -264,6 +268,7 @@ TEST_F(ValidateLayout, FunctionDefinitionBeforeDeclarationBad) {
 // type checking
 TEST_F(ValidateLayout, LabelBeforeFunctionParameterBad) {
   char str[] = R"(
+           OpCapability Shader
            OpMemoryModel Logical GLSL450
            OpDecorate %var Restrict
 %intt    = OpTypeInt 32 1
@@ -285,6 +290,7 @@ TEST_F(ValidateLayout, LabelBeforeFunctionParameterBad) {
 
 TEST_F(ValidateLayout, FuncParameterNotImmediatlyAfterFuncBad) {
   char str[] = R"(
+           OpCapability Shader
            OpMemoryModel Logical GLSL450
            OpDecorate %var Restrict
 %intt    = OpTypeInt 32 1
@@ -307,8 +313,7 @@ TEST_F(ValidateLayout, FuncParameterNotImmediatlyAfterFuncBad) {
   ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
 }
 
-using ValidateOpFunctionParameter =
-    spvtest::ValidateBase<int, SPV_VALIDATE_LAYOUT_BIT | SPV_VALIDATE_ID_BIT>;
+using ValidateOpFunctionParameter = spvtest::ValidateBase<int>;
 
 TEST_F(ValidateOpFunctionParameter, OpLineBetweenParameters) {
   const auto s = R"(

--- a/test/Validate.SSA.cpp
+++ b/test/Validate.SSA.cpp
@@ -42,12 +42,11 @@ using std::stringstream;
 
 namespace {
 
-using Validate =
-    spvtest::ValidateBase<pair<string, bool>,
-                          SPV_VALIDATE_SSA_BIT | SPV_VALIDATE_LAYOUT_BIT>;
+using Validate = spvtest::ValidateBase<pair<string, bool>>;
 
 TEST_F(Validate, Default) {
   char str[] = R"(
+     OpCapability Shader
      OpMemoryModel Logical GLSL450
      OpEntryPoint GLCompute %3 ""
      OpExecutionMode %3 LocalSize 1 1 1
@@ -64,6 +63,7 @@ TEST_F(Validate, Default) {
 
 TEST_F(Validate, IdUndefinedBad) {
   char str[] = R"(
+          OpCapability Shader
           OpMemoryModel Logical GLSL450
           OpName %missing "missing"
 %voidt  = OpTypeVoid
@@ -80,6 +80,7 @@ TEST_F(Validate, IdUndefinedBad) {
 
 TEST_F(Validate, IdRedefinedBad) {
   char str[] = R"(
+     OpCapability Shader
      OpMemoryModel Logical GLSL450
      OpName %2 "redefined"
 %1 = OpTypeVoid
@@ -95,6 +96,7 @@ TEST_F(Validate, IdRedefinedBad) {
 
 TEST_F(Validate, DominateUsageBad) {
   char str[] = R"(
+     OpCapability Shader
      OpMemoryModel Logical GLSL450
      OpName %1 "not_dominant"
 %2 = OpTypeFunction %1              ; uses %1 before it's definition
@@ -107,6 +109,7 @@ TEST_F(Validate, DominateUsageBad) {
 
 TEST_F(Validate, ForwardNameGood) {
   char str[] = R"(
+     OpCapability Shader
      OpMemoryModel Logical GLSL450
      OpName %3 "main"
 %1 = OpTypeVoid
@@ -122,6 +125,7 @@ TEST_F(Validate, ForwardNameGood) {
 
 TEST_F(Validate, ForwardNameMissingTargetBad) {
   char str[] = R"(
+      OpCapability Shader
       OpMemoryModel Logical GLSL450
       OpName %5 "main"              ; Target never defined
 )";
@@ -132,6 +136,7 @@ TEST_F(Validate, ForwardNameMissingTargetBad) {
 
 TEST_F(Validate, ForwardMemberNameGood) {
   char str[] = R"(
+           OpCapability Shader
            OpMemoryModel Logical GLSL450
            OpMemberName %struct 0 "value"
            OpMemberName %struct 1 "size"
@@ -145,6 +150,7 @@ TEST_F(Validate, ForwardMemberNameGood) {
 
 TEST_F(Validate, ForwardMemberNameMissingTargetBad) {
   char str[] = R"(
+           OpCapability Shader
            OpMemoryModel Logical GLSL450
            OpMemberName %struct 0 "value"
            OpMemberName %bad 1 "size"     ; Target is not defined
@@ -159,6 +165,7 @@ TEST_F(Validate, ForwardMemberNameMissingTargetBad) {
 
 TEST_F(Validate, ForwardDecorateGood) {
   char str[] = R"(
+           OpCapability Shader
            OpMemoryModel Logical GLSL450
            OpDecorate %var Restrict
 %intt   =  OpTypeInt 32 1
@@ -171,6 +178,7 @@ TEST_F(Validate, ForwardDecorateGood) {
 
 TEST_F(Validate, ForwardDecorateInvalidIDBad) {
   char str[] = R"(
+           OpCapability Shader
            OpMemoryModel Logical GLSL450
            OpName %missing "missing"
            OpDecorate %missing Restrict        ;Missing ID
@@ -191,7 +199,7 @@ TEST_F(Validate, ForwardDecorateInvalidIDBad) {
 
 TEST_F(Validate, ForwardMemberDecorateGood) {
   char str[] = R"(
-           OpCapability Matrix
+           OpCapability Shader
            OpMemoryModel Logical GLSL450
            OpMemberDecorate %struct 1 RowMajor
 %intt   =  OpTypeInt 32 1
@@ -205,7 +213,7 @@ TEST_F(Validate, ForwardMemberDecorateGood) {
 
 TEST_F(Validate, ForwardMemberDecorateInvalidIdBad) {
   char str[] = R"(
-           OpCapability Matrix
+           OpCapability Shader
            OpMemoryModel Logical GLSL450
            OpName %missing "missing"
            OpMemberDecorate %missing 1 RowMajor ; Target not defined
@@ -221,7 +229,7 @@ TEST_F(Validate, ForwardMemberDecorateInvalidIdBad) {
 
 TEST_F(Validate, ForwardGroupDecorateGood) {
   char str[] = R"(
-          OpCapability Matrix
+          OpCapability Shader
           OpMemoryModel Logical GLSL450
           OpDecorate %dgrp RowMajor
 %dgrp   = OpDecorationGroup
@@ -238,7 +246,7 @@ TEST_F(Validate, ForwardGroupDecorateGood) {
 
 TEST_F(Validate, ForwardGroupDecorateMissingGroupBad) {
   char str[] = R"(
-           OpCapability Matrix
+           OpCapability Shader
            OpMemoryModel Logical GLSL450
            OpName %missing "missing"
            OpDecorate %dgrp RowMajor
@@ -257,7 +265,7 @@ TEST_F(Validate, ForwardGroupDecorateMissingGroupBad) {
 
 TEST_F(Validate, ForwardGroupDecorateMissingTargetBad) {
   char str[] = R"(
-           OpCapability Matrix
+           OpCapability Shader
            OpMemoryModel Logical GLSL450
            OpName %missing "missing"
            OpDecorate %dgrp RowMajor
@@ -276,7 +284,7 @@ TEST_F(Validate, ForwardGroupDecorateMissingTargetBad) {
 
 TEST_F(Validate, ForwardGroupDecorateDecorationGroupDominateBad) {
   char str[] = R"(
-           OpCapability Matrix
+           OpCapability Shader
            OpMemoryModel Logical GLSL450
            OpName %dgrp "group"
            OpDecorate %dgrp RowMajor
@@ -295,6 +303,7 @@ TEST_F(Validate, ForwardGroupDecorateDecorationGroupDominateBad) {
 
 TEST_F(Validate, ForwardDecorateInvalidIdBad) {
   char str[] = R"(
+           OpCapability Shader
            OpMemoryModel Logical GLSL450
            OpName %missing "missing"
            OpDecorate %missing Restrict        ; Missing target
@@ -315,6 +324,7 @@ TEST_F(Validate, ForwardDecorateInvalidIdBad) {
 
 TEST_F(Validate, FunctionCallGood) {
   char str[] = R"(
+         OpCapability Shader
          OpMemoryModel Logical GLSL450
 %1    =  OpTypeVoid
 %2    =  OpTypeInt 32 1
@@ -341,6 +351,7 @@ TEST_F(Validate, FunctionCallGood) {
 
 TEST_F(Validate, ForwardFunctionCallGood) {
   char str[] = R"(
+         OpCapability Shader
          OpMemoryModel Logical GLSL450
 %1    =  OpTypeVoid
 %2    =  OpTypeInt 32 1
@@ -367,6 +378,7 @@ TEST_F(Validate, ForwardFunctionCallGood) {
 
 TEST_F(Validate, ForwardBranchConditionalGood) {
   char str[] = R"(
+            OpCapability Shader
             OpMemoryModel Logical GLSL450
 %voidt  =   OpTypeVoid
 %boolt  =   OpTypeBool
@@ -392,6 +404,7 @@ TEST_F(Validate, ForwardBranchConditionalGood) {
 
 TEST_F(Validate, ForwardBranchConditionalWithWeightsGood) {
   char str[] = R"(
+           OpCapability Shader
            OpMemoryModel Logical GLSL450
 %voidt  =  OpTypeVoid
 %boolt  =  OpTypeBool
@@ -417,6 +430,7 @@ TEST_F(Validate, ForwardBranchConditionalWithWeightsGood) {
 
 TEST_F(Validate, ForwardBranchConditionalNonDominantConditionBad) {
   char str[] = R"(
+           OpCapability Shader
            OpMemoryModel Logical GLSL450
            OpName %tcpy "conditional"
 %voidt  =  OpTypeVoid
@@ -445,6 +459,7 @@ TEST_F(Validate, ForwardBranchConditionalNonDominantConditionBad) {
 
 TEST_F(Validate, ForwardBranchConditionalMissingTargetBad) {
   char str[] = R"(
+           OpCapability Shader
            OpMemoryModel Logical GLSL450
            OpName %missing "missing"
 %voidt  =  OpTypeVoid
@@ -473,7 +488,7 @@ TEST_F(Validate, ForwardBranchConditionalMissingTargetBad) {
 const string kHeader = R"(
 OpCapability Int8
 OpCapability DeviceEnqueue
-OpMemoryModel Logical GLSL450
+OpMemoryModel Logical OpenCL
 )";
 
 const string kBasicTypes = R"(

--- a/test/Validate.Storage.cpp
+++ b/test/Validate.Storage.cpp
@@ -33,9 +33,8 @@
 #include "ValidateFixtures.h"
 #include "gmock/gmock.h"
 
-using ValidateStorage =
-    spvtest::ValidateBase<std::string, SPV_VALIDATE_LAYOUT_BIT |
-                                           SPV_VALIDATE_INSTRUCTION_BIT>;
+using ValidateStorage = spvtest::ValidateBase<std::string>;
+
 namespace {
 
 TEST_F(ValidateStorage, FunctionStorageInsideFunction) {

--- a/test/ValidateFixtures.cpp
+++ b/test/ValidateFixtures.cpp
@@ -26,8 +26,8 @@
 
 // Common validation fixtures for unit tests
 
-#include "ValidateFixtures.h"
 #include "UnitSPIRV.h"
+#include "ValidateFixtures.h"
 
 #include <functional>
 #include <tuple>
@@ -35,22 +35,22 @@
 
 namespace spvtest {
 
-template <typename T, uint32_t OPTIONS>
-ValidateBase<T, OPTIONS>::ValidateBase()
+template <typename T>
+ValidateBase<T>::ValidateBase()
     : context_(spvContextCreate()), binary_(), diagnostic_() {}
 
-template <typename T, uint32_t OPTIONS>
-ValidateBase<T, OPTIONS>::~ValidateBase() {
+template <typename T>
+ValidateBase<T>::~ValidateBase() {
   spvContextDestroy(context_);
 }
 
-template <typename T, uint32_t OPTIONS>
-spv_const_binary ValidateBase<T, OPTIONS>::get_const_binary() {
+template <typename T>
+spv_const_binary ValidateBase<T>::get_const_binary() {
   return spv_const_binary(binary_);
 }
 
-template <typename T, uint32_t OPTIONS>
-void ValidateBase<T, OPTIONS>::TearDown() {
+template <typename T>
+void ValidateBase<T>::TearDown() {
   if (diagnostic_) {
     spvDiagnosticPrint(diagnostic_);
   }
@@ -58,8 +58,8 @@ void ValidateBase<T, OPTIONS>::TearDown() {
   spvBinaryDestroy(binary_);
 }
 
-template <typename T, uint32_t OPTIONS>
-void ValidateBase<T, OPTIONS>::CompileSuccessfully(std::string code) {
+template <typename T>
+void ValidateBase<T>::CompileSuccessfully(std::string code) {
   spv_diagnostic diagnostic = nullptr;
   ASSERT_EQ(SPV_SUCCESS, spvTextToBinary(context_, code.c_str(), code.size(),
                                          &binary_, &diagnostic))
@@ -68,37 +68,28 @@ void ValidateBase<T, OPTIONS>::CompileSuccessfully(std::string code) {
       << code;
 }
 
-template <typename T, uint32_t OPTIONS>
-spv_result_t ValidateBase<T, OPTIONS>::ValidateInstructions() {
-  return spvValidate(context_, get_const_binary(), validation_options_,
-                     &diagnostic_);
+template <typename T>
+spv_result_t ValidateBase<T>::ValidateInstructions() {
+  return spvValidate(context_, get_const_binary(), &diagnostic_);
 }
 
-template <typename T, uint32_t OPTIONS>
-std::string ValidateBase<T, OPTIONS>::getDiagnosticString() {
+template <typename T>
+std::string ValidateBase<T>::getDiagnosticString() {
   return std::string(diagnostic_->error);
 }
 
-template <typename T, uint32_t OPTIONS>
-spv_position_t ValidateBase<T, OPTIONS>::getErrorPosition() {
+template <typename T>
+spv_position_t ValidateBase<T>::getErrorPosition() {
   return diagnostic_->position;
 }
 
-template class spvtest::ValidateBase<std::pair<std::string, bool>,
-                                     SPV_VALIDATE_SSA_BIT |
-                                         SPV_VALIDATE_LAYOUT_BIT>;
-template class spvtest::ValidateBase<bool, SPV_VALIDATE_SSA_BIT>;
+template class spvtest::ValidateBase<bool>;
+template class spvtest::ValidateBase<int>;
+template class spvtest::ValidateBase<std::string>;
+template class spvtest::ValidateBase<std::pair<std::string, bool>>;
+template class spvtest::ValidateBase<
+    std::tuple<std::string, std::pair<std::string, std::vector<std::string>>>>;
 template class spvtest::ValidateBase<
     std::tuple<int, std::tuple<std::string, std::function<spv_result_t(int)>,
-                               std::function<spv_result_t(int)>>>,
-    SPV_VALIDATE_LAYOUT_BIT>;
-template class spvtest::ValidateBase<int, SPV_VALIDATE_LAYOUT_BIT |
-                                              SPV_VALIDATE_ID_BIT>;
-
-template class spvtest::ValidateBase<
-    std::tuple<std::string, std::pair<std::string, std::vector<std::string>>>,
-    SPV_VALIDATE_INSTRUCTION_BIT>;
-
-template class spvtest::ValidateBase<
-    std::string, SPV_VALIDATE_LAYOUT_BIT | SPV_VALIDATE_INSTRUCTION_BIT>;
+                               std::function<spv_result_t(int)>>>>;
 }

--- a/test/ValidateFixtures.h
+++ b/test/ValidateFixtures.h
@@ -33,7 +33,7 @@
 
 namespace spvtest {
 
-template <typename T, uint32_t OPTIONS = SPV_VALIDATE_ALL>
+template <typename T>
 class ValidateBase : public ::testing::Test,
                      public ::testing::WithParamInterface<T> {
  public:
@@ -57,7 +57,6 @@ class ValidateBase : public ::testing::Test,
   spv_context context_;
   spv_binary binary_;
   spv_diagnostic diagnostic_;
-  static const uint32_t validation_options_ = OPTIONS;
 };
 }
 #endif

--- a/test/ValidationState.cpp
+++ b/test/ValidationState.cpp
@@ -42,7 +42,7 @@ using std::vector;
 class ValidationStateTest : public testing::Test {
  public:
   ValidationStateTest()
-      : context_(spvContextCreate()), state_(&diag_, 0, context_) {}
+      : context_(spvContextCreate()), state_(&diag_, context_) {}
 
  protected:
   spv_diagnostic diag_;

--- a/tools/val/val.cpp
+++ b/tools/val/val.cpp
@@ -42,35 +42,17 @@ The SPIR-V binary is read from <filename>. If no file is specified,
 or if the filename is "-", then the binary is read from standard input.
 
 NOTE: The validator is a work in progress.
-
-Options:
-  -all       Perform all validation (default OFF)
-  -basic     Perform basic validation (default OFF)
-  -id        Perform id validation (default OFF)
-  -layout    Perform layout validation (default OFF)
-  -rules     Perform rules validation (default OFF)
 )",
       argv0, argv0);
 }
 
 int main(int argc, char** argv) {
   const char* inFile = nullptr;
-  uint32_t options = 0;
 
   for (int argi = 1; argi < argc; ++argi) {
     const char* cur_arg = argv[argi];
     if ('-' == cur_arg[0]) {
-      if (!strcmp("all", cur_arg + 1)) {
-        options |= SPV_VALIDATE_ALL;
-      } else if (!strcmp("basic", cur_arg + 1)) {
-        options |= SPV_VALIDATE_BASIC_BIT;
-      } else if (!strcmp("id", cur_arg + 1)) {
-        options |= SPV_VALIDATE_ID_BIT;
-      } else if (!strcmp("layout", cur_arg + 1)) {
-        options |= SPV_VALIDATE_LAYOUT_BIT;
-      } else if (!strcmp("rules", cur_arg + 1)) {
-        options |= SPV_VALIDATE_RULES_BIT;
-      } else if (0 == cur_arg[1]) {
+      if (0 == cur_arg[1]) {
         // Setting a filename of "-" to indicate stdin.
         if (!inFile) {
           inFile = cur_arg;
@@ -111,7 +93,7 @@ int main(int argc, char** argv) {
 
   spv_diagnostic diagnostic = nullptr;
   spv_context context = spvContextCreate();
-  spv_result_t error = spvValidate(context, &binary, options, &diagnostic);
+  spv_result_t error = spvValidate(context, &binary, &diagnostic);
   spvContextDestroy(context);
   if (error) {
     spvDiagnosticPrint(diagnostic);


### PR DESCRIPTION
Users always want to run all the checks. The `spv_validate_options_t`
mechanism, which provides little benefits to users, complicates the
internal implementation and also makes the tests exercise different
paths as users do.

Right now the tests are more like integration tests instead of
unit tests, which should be our next refactoring aim.

Addresses #89.