### PR TITLE
getWord() should not go beyond the end of the source text.

### DIFF
--- a/source/text_handler.cpp
+++ b/source/text_handler.cpp
@@ -127,6 +127,11 @@ spv_result_t getWord(spv_text text, spv_position position, std::string& word,
 
   // NOTE: Assumes first character is not white space!
   while (true) {
+    if (endPosition->index >= text->length) {
+      word.assign(text->str + position->index,
+                  static_cast<size_t>(endPosition->index - position->index));
+      return SPV_SUCCESS;
+    }
     const char ch = text->str[endPosition->index];
     if (ch == '\\')
       escaping = !escaping;
@@ -142,8 +147,9 @@ spv_result_t getWord(spv_text text, spv_position position, std::string& word,
           if (escaping || quoting) break;
         // Fall through.
         case '\0': {  // NOTE: End of word found!
-          word.assign(text->str + position->index,
-                      (size_t)(endPosition->index - position->index));
+          word.assign(
+              text->str + position->index,
+              static_cast<size_t>(endPosition->index - position->index));
           return SPV_SUCCESS;
         }
         default:

--- a/test/TextWordGet.cpp
+++ b/test/TextWordGet.cpp
@@ -80,6 +80,21 @@ TEST(TextWordGet, SemicolonTerminator) {
   ASSERT_STREQ("Wo", word.c_str());
 }
 
+TEST(TextWordGet, NoTerminator) {
+  const std::string full_text = "abcdefghijklmn";
+  for (size_t len = 1; len <= full_text.size(); ++len) {
+    std::string word;
+    spv_text_t text = {full_text.data(), len};
+    spv_position_t endPosition = {};
+    ASSERT_EQ(SPV_SUCCESS,
+              AssemblyContext(&text, nullptr).getWord(word, &endPosition));
+    ASSERT_EQ(0u, endPosition.line);
+    ASSERT_EQ(len, endPosition.column);
+    ASSERT_EQ(len, endPosition.index);
+    ASSERT_EQ(full_text.substr(0, len), word);
+  }
+}
+
 TEST(TextWordGet, MultipleWords) {
   AutoText input("Words in a sentence");
   AssemblyContext data(input, nullptr);


### PR DESCRIPTION
This addresses Bug #126 where EOL is missing at the end of
source file.