### PR TITLE
Added missing <cstdint> in bitutils.

### DIFF
--- a/source/util/bitutils.h
+++ b/source/util/bitutils.h
@@ -27,6 +27,7 @@
 #ifndef LIBSPIRV_UTIL_BITUTILS_H_
 #define LIBSPIRV_UTIL_BITUTILS_H_
 
+#include <cstdint>
 #include <cstring>
 
 namespace spvutils {


### PR DESCRIPTION
This was breaking MSVC2013.