### PR TITLE
bitcast fixes

### DIFF
--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -236,22 +236,10 @@ int32_t spvOpcodeIsPointer(const SpvOp opcode) {
   switch (opcode) {
     case SpvOpVariable:
     case SpvOpAccessChain:
-    case SpvOpPtrAccessChain:
     case SpvOpInBoundsAccessChain:
-    case SpvOpInBoundsPtrAccessChain:
     case SpvOpFunctionParameter:
-      return true;
-    default:
-      return false;
-  }
-}
-
-int32_t spvOpcodeIsPotentialPointer(const SpvOp opcode) {
-  if (spvOpcodeIsPointer(opcode))
-    return true;
-
-  switch (opcode) {
-    case SpvOpBitcast:
+    case SpvOpImageTexelPointer:
+    case SpvOpCopyObject:
       return true;
     default:
       return false;

--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -246,6 +246,18 @@ int32_t spvOpcodeIsPointer(const SpvOp opcode) {
   }
 }
 
+int32_t spvOpcodeIsPotentialPointer(const SpvOp opcode) {
+  if (spvOpcodeIsPointer(opcode))
+    return true;
+
+  switch (opcode) {
+    case SpvOpBitcast:
+      return true;
+    default:
+      return false;
+  }
+}
+
 int32_t spvOpcodeGeneratesType(SpvOp op) {
   switch (op) {
     case SpvOpTypeVoid:

--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -232,7 +232,7 @@ int32_t spvOpcodeIsComposite(const SpvOp opcode) {
   }
 }
 
-int32_t spvOpcodeIsPointer(const SpvOp opcode) {
+int32_t spvOpcodeReturnsLogicalPointer(const SpvOp opcode) {
   switch (opcode) {
     case SpvOpVariable:
     case SpvOpAccessChain:

--- a/source/opcode.h
+++ b/source/opcode.h
@@ -89,10 +89,6 @@ int32_t spvOpcodeIsComposite(const SpvOp opcode);
 // non-zero otherwise.
 int32_t spvOpcodeIsPointer(const SpvOp opcode);
 
-// Determines if the given opcode potentially results in a pointer. Returns zero
-// if false, non-zero otherwise.
-int32_t spvOpcodeIsPotentialPointer(const SpvOp opcode);
-
 // Determines if the given opcode generates a type. Returns zero if false,
 // non-zero otherwise.
 int32_t spvOpcodeGeneratesType(SpvOp opcode);

--- a/source/opcode.h
+++ b/source/opcode.h
@@ -89,6 +89,10 @@ int32_t spvOpcodeIsComposite(const SpvOp opcode);
 // non-zero otherwise.
 int32_t spvOpcodeIsPointer(const SpvOp opcode);
 
+// Determines if the given opcode potentially results in a pointer. Returns zero
+// if false, non-zero otherwise.
+int32_t spvOpcodeIsPotentialPointer(const SpvOp opcode);
+
 // Determines if the given opcode generates a type. Returns zero if false,
 // non-zero otherwise.
 int32_t spvOpcodeGeneratesType(SpvOp opcode);

--- a/source/opcode.h
+++ b/source/opcode.h
@@ -85,9 +85,9 @@ int32_t spvOpcodeIsConstant(const SpvOp opcode);
 // non-zero otherwise.
 int32_t spvOpcodeIsComposite(const SpvOp opcode);
 
-// Determines if the given opcode results in a pointer. Returns zero if false,
-// non-zero otherwise.
-int32_t spvOpcodeIsPointer(const SpvOp opcode);
+// Determines if the given opcode results in a pointer when using the logical
+// addressing model. Returns zero if false, non-zero otherwise.
+int32_t spvOpcodeReturnsLogicalPointer(const SpvOp opcode);
 
 // Determines if the given opcode generates a type. Returns zero if false,
 // non-zero otherwise.

--- a/source/validate.h
+++ b/source/validate.h
@@ -272,6 +272,18 @@ class ValidationState_t {
   // capabilities==0.
   bool HasAnyOf(spv_capability_mask_t capabilities) const;
 
+  // Sets the addressing model of this module (logical/physical).
+  void setAddressingModel(SpvAddressingModel am);
+
+  // Returns the addressing model of this module, or Logical if uninitialized.
+  SpvAddressingModel getAddressingModel() const;
+
+  // Sets the memory model of this module.
+  void setMemoryModel(SpvMemoryModel mm);
+
+  // Returns the memory model of this module, or Simple if uninitialized.
+  SpvMemoryModel getMemoryModel() const;
+
   AssemblyGrammar& grammar() { return grammar_; }
 
  private:
@@ -298,6 +310,10 @@ class ValidationState_t {
   std::vector<uint32_t> entry_points_;
 
   AssemblyGrammar grammar_;
+
+  SpvAddressingModel addressing_model_;
+  SpvMemoryModel memory_model_;
+
 };
 
 }  // namespace libspirv

--- a/source/validate_id.cpp
+++ b/source/validate_id.cpp
@@ -763,7 +763,7 @@ bool idUsage::isValid<SpvOpLoad>(const spv_instruction_t* inst,
   auto pointer = usedefs_.FindDef(inst->words[pointerIndex]);
   if (!pointer.first ||
       (addressingModel == SpvAddressingModelLogical &&
-       !spvOpcodeIsPointer(pointer.second.opcode))) {
+       !spvOpcodeReturnsLogicalPointer(pointer.second.opcode))) {
     DIAG(pointerIndex) << "OpLoad Pointer <id> '" << inst->words[pointerIndex]
                        << "' is not a pointer.";
     return false;
@@ -793,7 +793,7 @@ bool idUsage::isValid<SpvOpStore>(const spv_instruction_t* inst,
   auto pointer = usedefs_.FindDef(inst->words[pointerIndex]);
   if (!pointer.first ||
       (addressingModel == SpvAddressingModelLogical &&
-       !spvOpcodeIsPointer(pointer.second.opcode))) {
+       !spvOpcodeReturnsLogicalPointer(pointer.second.opcode))) {
     DIAG(pointerIndex) << "OpStore Pointer <id> '" << inst->words[pointerIndex]
                        << "' is not a pointer.";
     return false;

--- a/source/validate_instruction.cpp
+++ b/source/validate_instruction.cpp
@@ -122,6 +122,12 @@ spv_result_t InstructionPass(ValidationState_t& _,
   if (opcode == SpvOpCapability)
     _.registerCapability(
         static_cast<SpvCapability>(inst->words[inst->operands[0].offset]));
+  if (opcode == SpvOpMemoryModel) {
+    _.setAddressingModel(
+        static_cast<SpvAddressingModel>(inst->words[inst->operands[0].offset]));
+    _.setMemoryModel(
+        static_cast<SpvMemoryModel>(inst->words[inst->operands[1].offset]));
+  }
   if (opcode == SpvOpVariable) {
     const auto storage_class =
         static_cast<SpvStorageClass>(inst->words[inst->operands[2].offset]);

--- a/source/validate_types.cpp
+++ b/source/validate_types.cpp
@@ -218,7 +218,9 @@ ValidationState_t::ValidationState_t(spv_diagnostic* diagnostic,
       current_layout_section_(kLayoutCapabilities),
       module_functions_(*this),
       module_capabilities_(0u),
-      grammar_(context) {}
+      grammar_(context),
+      addressing_model_(SpvAddressingModelLogical),
+      memory_model_(SpvMemoryModelSimple) {}
 
 spv_result_t ValidationState_t::forwardDeclareId(uint32_t id) {
   unresolved_forward_ids_.insert(id);
@@ -315,6 +317,22 @@ bool ValidationState_t::HasAnyOf(spv_capability_mask_t capabilities) const {
     found |= hasCapability(c);
   });
   return found;
+}
+	
+void ValidationState_t::setAddressingModel(SpvAddressingModel am) {
+  addressing_model_ = am;
+}
+
+SpvAddressingModel ValidationState_t::getAddressingModel() const {
+  return addressing_model_;
+}
+
+void ValidationState_t::setMemoryModel(SpvMemoryModel mm) {
+  memory_model_ = mm;
+}
+
+SpvMemoryModel ValidationState_t::getMemoryModel() const {
+  return memory_model_;
 }
 
 Functions::Functions(ValidationState_t& module)

--- a/test/ValidateID.cpp
+++ b/test/ValidateID.cpp
@@ -937,6 +937,40 @@ TEST_F(ValidateID, OpLoadPointerBad) {
 )";
   CHECK(spirv, SPV_ERROR_INVALID_ID);
 }
+TEST_F(ValidateID, OpLoadBitcastPointerGood) {
+  const char* spirv = R"(
+%1  = OpTypeVoid
+%2  = OpTypeInt 32 1
+%9  = OpTypeFloat 32
+%3  = OpTypePointer UniformConstant %2
+%10 = OpTypePointer UniformConstant %9
+%4  = OpTypeFunction %1
+%6  = OpFunction %1 None %4
+%7  = OpLabel
+%11 = OpBitcast %10 %3
+%8  = OpLoad %9 %11
+      OpReturn
+      OpFunctionEnd
+)";
+  CHECK(spirv, SPV_SUCCESS);
+}
+TEST_F(ValidateID, OpLoadBitcastNonPointerBad) {
+  const char* spirv = R"(
+%1  = OpTypeVoid
+%2  = OpTypeInt 32 1
+%9  = OpTypeFloat 32
+%3  = OpTypePointer UniformConstant %2
+%4  = OpTypeFunction %1
+%6  = OpFunction %1 None %4
+%7  = OpLabel
+%8  = OpLoad %2 %3
+%10 = OpBitcast %9 %8
+%8  = OpLoad %2 %10
+      OpReturn
+      OpFunctionEnd
+)";
+  CHECK(spirv, SPV_ERROR_INVALID_ID);
+}
 
 TEST_F(ValidateID, OpStoreGood) {
   const char* spirv = R"(
@@ -966,6 +1000,41 @@ TEST_F(ValidateID, OpStorePointerBad) {
      OpStore %3 %5
      OpReturn
      OpFunctionEnd)";
+  CHECK(spirv, SPV_ERROR_INVALID_ID);
+}
+TEST_F(ValidateID, OpStoreBitcastPointerGood) {
+  const char* spirv = R"(
+%1  = OpTypeVoid
+%2  = OpTypeInt 32 1
+%9  = OpTypeFloat 32
+%3  = OpTypePointer Function %2
+%10 = OpTypePointer Function %9
+%4  = OpTypeFunction %1
+%5  = OpConstant %2 42
+%7  = OpFunction %1 None %4
+%8  = OpLabel
+%6  = OpVariable %10 Function
+%11 = OpBitcast %3 %6
+      OpStore %11 %5
+      OpReturn
+      OpFunctionEnd)";
+  CHECK(spirv, SPV_SUCCESS);
+}
+TEST_F(ValidateID, OpStoreBitcastNonPointerBad) {
+  const char* spirv = R"(
+%1  = OpTypeVoid
+%2  = OpTypeInt 32 1
+%9  = OpTypeFloat 32
+%10 = OpTypePointer Function %9
+%4  = OpTypeFunction %1
+%5  = OpConstant %9 42
+%7  = OpFunction %1 None %4
+%8  = OpLabel
+%6  = OpVariable %10 Function
+%11 = OpBitcast %2 %5
+      OpStore %11 %5
+      OpReturn
+      OpFunctionEnd)";
   CHECK(spirv, SPV_ERROR_INVALID_ID);
 }
 TEST_F(ValidateID, OpStoreObjectGood) {

--- a/test/ValidateID.cpp
+++ b/test/ValidateID.cpp
@@ -944,10 +944,11 @@ TEST_F(ValidateID, OpLoadBitcastPointerGood) {
 %9  = OpTypeFloat 32
 %3  = OpTypePointer UniformConstant %2
 %10 = OpTypePointer UniformConstant %9
+%5  = OpVariable %3 UniformConstant
 %4  = OpTypeFunction %1
 %6  = OpFunction %1 None %4
 %7  = OpLabel
-%11 = OpBitcast %10 %3
+%11 = OpBitcast %10 %5
 %8  = OpLoad %9 %11
       OpReturn
       OpFunctionEnd
@@ -961,11 +962,12 @@ TEST_F(ValidateID, OpLoadBitcastNonPointerBad) {
 %9  = OpTypeFloat 32
 %3  = OpTypePointer UniformConstant %2
 %4  = OpTypeFunction %1
+%5  = OpVariable %3 UniformConstant
 %6  = OpFunction %1 None %4
 %7  = OpLabel
-%8  = OpLoad %2 %3
+%8  = OpLoad %2 %5
 %10 = OpBitcast %9 %8
-%8  = OpLoad %2 %10
+%11 = OpLoad %2 %10
       OpReturn
       OpFunctionEnd
 )";

--- a/test/ValidateID.cpp
+++ b/test/ValidateID.cpp
@@ -937,42 +937,6 @@ TEST_F(ValidateID, OpLoadPointerBad) {
 )";
   CHECK(spirv, SPV_ERROR_INVALID_ID);
 }
-TEST_F(ValidateID, OpLoadBitcastPointerGood) {
-  const char* spirv = R"(
-%1  = OpTypeVoid
-%2  = OpTypeInt 32 1
-%9  = OpTypeFloat 32
-%3  = OpTypePointer UniformConstant %2
-%10 = OpTypePointer UniformConstant %9
-%5  = OpVariable %3 UniformConstant
-%4  = OpTypeFunction %1
-%6  = OpFunction %1 None %4
-%7  = OpLabel
-%11 = OpBitcast %10 %5
-%8  = OpLoad %9 %11
-      OpReturn
-      OpFunctionEnd
-)";
-  CHECK(spirv, SPV_SUCCESS);
-}
-TEST_F(ValidateID, OpLoadBitcastNonPointerBad) {
-  const char* spirv = R"(
-%1  = OpTypeVoid
-%2  = OpTypeInt 32 1
-%9  = OpTypeFloat 32
-%3  = OpTypePointer UniformConstant %2
-%4  = OpTypeFunction %1
-%5  = OpVariable %3 UniformConstant
-%6  = OpFunction %1 None %4
-%7  = OpLabel
-%8  = OpLoad %2 %5
-%10 = OpBitcast %9 %8
-%11 = OpLoad %2 %10
-      OpReturn
-      OpFunctionEnd
-)";
-  CHECK(spirv, SPV_ERROR_INVALID_ID);
-}
 
 TEST_F(ValidateID, OpStoreGood) {
   const char* spirv = R"(
@@ -1002,41 +966,6 @@ TEST_F(ValidateID, OpStorePointerBad) {
      OpStore %3 %5
      OpReturn
      OpFunctionEnd)";
-  CHECK(spirv, SPV_ERROR_INVALID_ID);
-}
-TEST_F(ValidateID, OpStoreBitcastPointerGood) {
-  const char* spirv = R"(
-%1  = OpTypeVoid
-%2  = OpTypeInt 32 1
-%9  = OpTypeFloat 32
-%3  = OpTypePointer Function %2
-%10 = OpTypePointer Function %9
-%4  = OpTypeFunction %1
-%5  = OpConstant %2 42
-%7  = OpFunction %1 None %4
-%8  = OpLabel
-%6  = OpVariable %10 Function
-%11 = OpBitcast %3 %6
-      OpStore %11 %5
-      OpReturn
-      OpFunctionEnd)";
-  CHECK(spirv, SPV_SUCCESS);
-}
-TEST_F(ValidateID, OpStoreBitcastNonPointerBad) {
-  const char* spirv = R"(
-%1  = OpTypeVoid
-%2  = OpTypeInt 32 1
-%9  = OpTypeFloat 32
-%10 = OpTypePointer Function %9
-%4  = OpTypeFunction %1
-%5  = OpConstant %9 42
-%7  = OpFunction %1 None %4
-%8  = OpLabel
-%6  = OpVariable %10 Function
-%11 = OpBitcast %2 %5
-      OpStore %11 %5
-      OpReturn
-      OpFunctionEnd)";
   CHECK(spirv, SPV_ERROR_INVALID_ID);
 }
 TEST_F(ValidateID, OpStoreObjectGood) {
@@ -1763,6 +1692,76 @@ TEST_F(ValidateID, OpPtrAccessChainGood) {
       OpReturn
       OpFunctionEnd)";
   CHECK_KERNEL(spirv, SPV_SUCCESS, 64);
+}
+
+TEST_F(ValidateID, OpLoadBitcastPointerGood) {
+  const char* spirv = R"(
+%2  = OpTypeVoid
+%3  = OpTypeInt 32 1
+%4  = OpTypeFloat 32
+%5  = OpTypePointer UniformConstant %3
+%6  = OpTypePointer UniformConstant %4
+%7  = OpVariable %5 UniformConstant
+%8  = OpTypeFunction %2
+%9  = OpFunction %2 None %8
+%10 = OpLabel
+%11 = OpBitcast %6 %7
+%12 = OpLoad %4 %11
+      OpReturn
+      OpFunctionEnd)";
+  CHECK_KERNEL(spirv, SPV_SUCCESS, 64);
+}
+TEST_F(ValidateID, OpLoadBitcastNonPointerBad) {
+  const char* spirv = R"(
+%2  = OpTypeVoid
+%3  = OpTypeInt 32 1
+%4  = OpTypeFloat 32
+%5  = OpTypePointer UniformConstant %3
+%6  = OpTypeFunction %2
+%7  = OpVariable %5 UniformConstant
+%8  = OpFunction %2 None %6
+%9  = OpLabel
+%10 = OpLoad %3 %7
+%11 = OpBitcast %4 %10
+%12 = OpLoad %3 %11
+      OpReturn
+      OpFunctionEnd)";
+  CHECK_KERNEL(spirv, SPV_ERROR_INVALID_ID, 64);
+}
+TEST_F(ValidateID, OpStoreBitcastPointerGood) {
+  const char* spirv = R"(
+%2  = OpTypeVoid
+%3  = OpTypeInt 32 1
+%4  = OpTypeFloat 32
+%5  = OpTypePointer Function %3
+%6  = OpTypePointer Function %4
+%7  = OpTypeFunction %2
+%8  = OpConstant %3 42
+%9  = OpFunction %2 None %7
+%10 = OpLabel
+%11 = OpVariable %6 Function
+%12 = OpBitcast %5 %11
+      OpStore %12 %8
+      OpReturn
+      OpFunctionEnd)";
+  CHECK_KERNEL(spirv, SPV_SUCCESS, 64);
+}
+TEST_F(ValidateID, OpStoreBitcastNonPointerBad) {
+  const char* spirv = R"(
+%2  = OpTypeVoid
+%3  = OpTypeInt 32 1
+%4  = OpTypeFloat 32
+%5  = OpTypePointer Function %4
+%6  = OpTypeFunction %2
+%7  = OpConstant %4 42
+%8  = OpFunction %2 None %6
+%9  = OpLabel
+%10 = OpVariable %5 Function
+%11 = OpBitcast %3 %7
+      OpStore %11 %7
+      OpReturn
+      OpFunctionEnd)";
+  CHECK_KERNEL(spirv, SPV_ERROR_INVALID_ID, 64);
 }
 
 // TODO: OpLifetimeStart


### PR DESCRIPTION
-> commit message

I'm not sure about the spvOpcodeIsPointer/spvOpcodeIsPotentialPointer split, but putting OpBitcast into spvOpcodeIsPointer isn't correct either (imo). Since it's only used in OpLoad and OpStore it might make sense to put everything in spvOpcodeIsPotentialPointer and simply remove spvOpcodeIsPointer?
Note though that both OpLoad and OpStore now go on and check if the operand is actually a pointer type, making the spvOpcodeIsPointer/spvOpcodeIsPotentialPointer redundant -> could remove the check + spvOpcodeIsPointer/spvOpcodeIsPotentialPointer, but the error msg might be nice to have?