### PR TITLE
Fix the corner case in version generation script.

### DIFF
--- a/utils/update_build_version.py
+++ b/utils/update_build_version.py
@@ -62,7 +62,8 @@ def describe(dir):
         try:
             return command_output(['git', 'rev-parse', 'HEAD'], dir).rstrip()
         except:
-            return 'unknown hash, ' + datetime.date.today().isoformat()
+            return 'unknown hash, {}'.format(
+                datetime.date.today().isoformat()).encode('ascii')
 
 
 def main():


### PR DESCRIPTION
When the given directory is not inside the SPIRV-Tools project,
`describe()` returns a `str` instance instead of `bytes` instance
in Python3, which will case problem when calling `decode()` on it.