### PR TITLE
Add patchlevel to CMake requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(spirv-tools)
 enable_testing()
 set(SPIRV_TOOLS "SPIRV-Tools")


### PR DESCRIPTION
As far as I know, CMake <2.8.12 will not have `target_compile_options`. See the [CMake 2.8.12 ChangeLog](https://cmake.org/files/v2.8/CMakeChangeLog-2.8.12) for details.