### PR TITLE
Remove duplicate and buggy implementation of getWord().

### DIFF
--- a/source/text_handler.cpp
+++ b/source/text_handler.cpp
@@ -143,6 +143,8 @@ spv_result_t getWord(spv_text text, spv_position position, std::string& word,
         case ' ':
         case ';':
         case '\t':
+        case '\v':
+        case '\r':
         case '\n':
           if (escaping || quoting) break;
         // Fall through.
@@ -234,22 +236,11 @@ bool AssemblyContext::hasText() const {
 }
 
 std::string AssemblyContext::getWord() const {
-  uint64_t index = current_position_.index;
-  while (true) {
-    switch (text_->str[index]) {
-      case '\0':
-      case '\t':
-      case '\v':
-      case '\r':
-      case '\n':
-      case ' ':
-        return std::string(text_->str, text_->str + index);
-      default:
-        index++;
-    }
-  }
-  assert(0 && "Unreachable");
-  return "";  // Make certain compilers happy.
+  spv_position_t start_position = current_position_;
+  spv_position_t end_position = {};
+  std::string word;
+  ::getWord(text_, &start_position, word, &end_position);
+  return word;
 }
 
 void AssemblyContext::seekForward(uint32_t size) {

--- a/test/TextToBinary.cpp
+++ b/test/TextToBinary.cpp
@@ -62,6 +62,34 @@ TEST(GetWord, Simple) {
   EXPECT_EQ("abc", AssemblyContext(AutoText("abc\n"), nullptr).getWord());
 }
 
+TEST(GetWord, MultipleWords) {
+  const std::string contents = "abc  def  ghi l mnopqrstuvwxyz12";
+  spv_text_t text = {contents.data(), contents.size()};
+  auto context = AssemblyContext(&text, nullptr);
+
+  EXPECT_EQ("abc", context.getWord());
+
+  size_t index = contents.find('d');
+  spv_position_t position = {0, index, index};
+  context.setPosition(position);
+  EXPECT_EQ("def", context.getWord());
+
+  index = contents.find('g');
+  position = {0, index, index};
+  context.setPosition(position);
+  EXPECT_EQ("ghi", context.getWord());
+
+  index = contents.find('l');
+  position = {0, index, index};
+  context.setPosition(position);
+  EXPECT_EQ("l", context.getWord());
+
+  index = contents.find('m');
+  position = {0, index, index};
+  context.setPosition(position);
+  EXPECT_EQ("mnopqrstuvwxyz12", context.getWord());
+}
+
 // An mask parsing test case.
 struct MaskCase {
   spv_operand_type_t which_enum;

--- a/test/UnitSPIRV.h
+++ b/test/UnitSPIRV.h
@@ -169,7 +169,7 @@ inline std::vector<uint32_t> MakeVector(std::string input) {
 // A type for easily creating spv_text_t values, with an implicit conversion to
 // spv_text.
 struct AutoText {
-  explicit AutoText(std::string value)
+  explicit AutoText(const std::string& value)
       : str(value), text({str.data(), str.size()}) {}
   operator spv_text() { return &text; }
   std::string str;


### PR DESCRIPTION
We already have a better `getWord()` implemented as a free function.
Use that instead of creating another one.

Addresses #152.