### PR TITLE
Enable linking against libSPIRV-Tools from linux shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ project(spirv-tools)
 enable_testing()
 set(SPIRV_TOOLS "SPIRV-Tools")
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
   add_definitions(-DSPIRV_LINUX)
 elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")


### PR DESCRIPTION
Required for linking against libSPIRV-Tools from LVL's
libVkLayer_core_validation.so.