### PR TITLE
Remove revision from SPV_ENV_*.

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -333,10 +333,8 @@ typedef spv_context_t* spv_context;
 // often necessary to specify which one applies.  SPV_ENV_UNIVERSAL means
 // environment-agnostic SPIR-V.
 typedef enum {
-  SPV_ENV_UNIVERSAL_1_0,    // SPIR-V 1.0 any revision, no other restrictions.
-  SPV_ENV_UNIVERSAL_1_0_4,  // SPIR-V 1.0 revision 4, no other restrictions.
-  SPV_ENV_VULKAN_1_0,       // Vulkan 1.0 any revision.
-  SPV_ENV_VULKAN_1_0_7      // Vulkan 1.0 revision 7.
+  SPV_ENV_UNIVERSAL_1_0,  // SPIR-V 1.0 latest revision, no other restrictions.
+  SPV_ENV_VULKAN_1_0,     // Vulkan 1.0 latest revision.
 } spv_target_env;
 
 // Returns a string describing the given SPIR-V target environment.

--- a/source/spirv_target_env.cpp
+++ b/source/spirv_target_env.cpp
@@ -33,12 +33,8 @@ const char* spvTargetEnvDescription(spv_target_env env) {
   switch (env) {
     case SPV_ENV_UNIVERSAL_1_0:
       return "SPIR-V 1.0";
-    case SPV_ENV_UNIVERSAL_1_0_4:
-      return "SPIR-V 1.0 rev 4";
     case SPV_ENV_VULKAN_1_0:
       return "SPIR-V 1.0 (under Vulkan 1.0 semantics)";
-    case SPV_ENV_VULKAN_1_0_7:
-      return "SPIR-V 1.0 (under Vulkan 1.0.7 semantics)";
     default:
       break;
   }
@@ -49,9 +45,7 @@ const char* spvTargetEnvDescription(spv_target_env env) {
 uint32_t spvVersionForTargetEnv(spv_target_env env) {
   switch (env) {
     case SPV_ENV_UNIVERSAL_1_0:
-    case SPV_ENV_UNIVERSAL_1_0_4:
     case SPV_ENV_VULKAN_1_0:
-    case SPV_ENV_VULKAN_1_0_7:
       return SPV_SPIRV_VERSION_WORD(1, 0);
     default:
       break;

--- a/source/table.cpp
+++ b/source/table.cpp
@@ -30,9 +30,7 @@
 
 spv_context spvContextCreate(spv_target_env env) {
   switch (env) {
-    case SPV_ENV_UNIVERSAL_1_0_4:
     case SPV_ENV_UNIVERSAL_1_0:
-    case SPV_ENV_VULKAN_1_0_7:
     case SPV_ENV_VULKAN_1_0:
       break;
     default:

--- a/tools/as/as.cpp
+++ b/tools/as/as.cpp
@@ -89,7 +89,7 @@ int main(int argc, char** argv) {
           if (0 == strcmp(argv[argi], "--version")) {
             printf("%s\n", kBuildVersion);
             printf("Target: %s\n",
-                   spvTargetEnvDescription(SPV_ENV_UNIVERSAL_1_0_4));
+                   spvTargetEnvDescription(SPV_ENV_UNIVERSAL_1_0));
             return 0;
           }
           if (0 == strcmp(argv[argi], "--help")) {
@@ -129,7 +129,7 @@ int main(int argc, char** argv) {
 
   spv_binary binary;
   spv_diagnostic diagnostic = nullptr;
-  spv_context context = spvContextCreate(SPV_ENV_UNIVERSAL_1_0_4);
+  spv_context context = spvContextCreate(SPV_ENV_UNIVERSAL_1_0);
   spv_result_t error = spvTextToBinary(context, contents.data(),
                                        contents.size(), &binary, &diagnostic);
   spvContextDestroy(context);

--- a/tools/dis/dis.cpp
+++ b/tools/dis/dis.cpp
@@ -102,7 +102,7 @@ int main(int argc, char** argv) {
           } else if (0 == strcmp(argv[argi], "--version")) {
             printf("%s\n", kBuildVersion);
             printf("Target: %s\n",
-                   spvTargetEnvDescription(SPV_ENV_UNIVERSAL_1_0_4));
+                   spvTargetEnvDescription(SPV_ENV_UNIVERSAL_1_0));
             return 0;
           } else {
             print_usage(argv[0]);
@@ -178,7 +178,7 @@ int main(int argc, char** argv) {
   spv_text text;
   spv_text* textOrNull = print_to_stdout ? nullptr : &text;
   spv_diagnostic diagnostic = nullptr;
-  spv_context context = spvContextCreate(SPV_ENV_UNIVERSAL_1_0_4);
+  spv_context context = spvContextCreate(SPV_ENV_UNIVERSAL_1_0);
   spv_result_t error =
       spvBinaryToText(context, contents.data(), contents.size(), options,
                       textOrNull, &diagnostic);

--- a/tools/val/val.cpp
+++ b/tools/val/val.cpp
@@ -56,7 +56,7 @@ const char kBuildVersion[] =
 
 int main(int argc, char** argv) {
   const char* inFile = nullptr;
-  spv_target_env target_env = SPV_ENV_UNIVERSAL_1_0_4;
+  spv_target_env target_env = SPV_ENV_UNIVERSAL_1_0;
 
   for (int argi = 1; argi < argc; ++argi) {
     const char* cur_arg = argv[argi];
@@ -64,14 +64,14 @@ int main(int argc, char** argv) {
       if (0 == strcmp(cur_arg, "--version")) {
         printf("%s\n", kBuildVersion);
         printf("Targets:\n  %s\n  %s\n",
-               spvTargetEnvDescription(SPV_ENV_UNIVERSAL_1_0_4),
-               spvTargetEnvDescription(SPV_ENV_VULKAN_1_0_7));
+               spvTargetEnvDescription(SPV_ENV_UNIVERSAL_1_0),
+               spvTargetEnvDescription(SPV_ENV_VULKAN_1_0));
         return 0;
       } else if (0 == strcmp(cur_arg, "--help") || 0 == strcmp(cur_arg, "-h")) {
         print_usage(argv[0]);
         return 0;
       } else if (0 == strcmp(cur_arg, "--vulkan")) {
-        target_env = SPV_ENV_VULKAN_1_0_7;
+        target_env = SPV_ENV_VULKAN_1_0;
       } else if (0 == cur_arg[1]) {
         // Setting a filename of "-" to indicate stdin.
         if (!inFile) {


### PR DESCRIPTION
Revisions proliferate quickly and we don't promise to retain extra
grammar copies for every historical one.

@antiagainst @AWoloszyn @dneto0 @Qining PTAL