### PR TITLE
First tests for SPIR-V v1.1.

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -334,8 +334,8 @@ typedef spv_context_t* spv_context;
 // environment-agnostic SPIR-V.
 typedef enum {
   SPV_ENV_UNIVERSAL_1_0,  // SPIR-V 1.0 latest revision, no other restrictions.
-  SPV_ENV_UNIVERSAL_1_1,  // SPIR-V 1.1 latest revision, no other restrictions.
   SPV_ENV_VULKAN_1_0,     // Vulkan 1.0 latest revision.
+  SPV_ENV_UNIVERSAL_1_1,  // SPIR-V 1.1 latest revision, no other restrictions.
 } spv_target_env;
 
 // Returns a string describing the given SPIR-V target environment.

--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -334,8 +334,8 @@ typedef spv_context_t* spv_context;
 // environment-agnostic SPIR-V.
 typedef enum {
   SPV_ENV_UNIVERSAL_1_0,  // SPIR-V 1.0 latest revision, no other restrictions.
+  SPV_ENV_UNIVERSAL_1_1,  // SPIR-V 1.1 latest revision, no other restrictions.
   SPV_ENV_VULKAN_1_0,     // Vulkan 1.0 latest revision.
-  SPV_ENV_UNIVERSAL_1_1,  // SPIR-V 1.1 any revision, no other restrictions.
 } spv_target_env;
 
 // Returns a string describing the given SPIR-V target environment.
@@ -349,7 +349,8 @@ void spvContextDestroy(spv_context context);
 
 // Encodes the given SPIR-V assembly text to its binary representation. The
 // length parameter specifies the number of bytes for text. Encoded binary will
-// be stored into *binary. Any error will be written into *diagnostic.
+// be stored into *binary. Any error will be written into *diagnostic. The
+// generated binary is independent of the context and may outlive it.
 spv_result_t spvTextToBinary(const spv_const_context context, const char* text,
                              const size_t length, spv_binary* binary,
                              spv_diagnostic* diagnostic);

--- a/test/AssemblyFormat.cpp
+++ b/test/AssemblyFormat.cpp
@@ -32,9 +32,9 @@ using spvtest::TextToBinaryTest;
 
 TEST_F(TextToBinaryTest, NotPlacingResultIDAtTheBeginning) {
   SetText("OpTypeMatrix %1 %2 1000");
-  EXPECT_EQ(
-      SPV_ERROR_INVALID_TEXT,
-      spvTextToBinary(context, text.str, text.length, &binary, &diagnostic));
+  EXPECT_EQ(SPV_ERROR_INVALID_TEXT,
+            spvTextToBinary(ScopedContext().context, text.str, text.length,
+                            &binary, &diagnostic));
   ASSERT_NE(nullptr, diagnostic);
   EXPECT_STREQ(
       "Expected <result-id> at the beginning of an instruction, found "

--- a/test/BinaryDestroy.cpp
+++ b/test/BinaryDestroy.cpp
@@ -43,8 +43,8 @@ TEST_F(BinaryDestroySomething, Default) {
   // Use a binary object constructed by the API instead of rolling our own.
   SetText("OpSource OpenCL_C 120");
   spv_binary my_binary = nullptr;
-  ASSERT_EQ(SPV_SUCCESS, spvTextToBinary(context, text.str, text.length,
-                                         &my_binary, &diagnostic));
+  ASSERT_EQ(SPV_SUCCESS, spvTextToBinary(ScopedContext().context, text.str,
+                                         text.length, &my_binary, &diagnostic));
   ASSERT_NE(nullptr, my_binary);
   spvBinaryDestroy(my_binary);
 }

--- a/test/BinaryParse.cpp
+++ b/test/BinaryParse.cpp
@@ -218,9 +218,9 @@ class BinaryParseTest : public spvtest::TextToBinaryTestBase<::testing::Test> {
                      });
     }
     EXPECT_EQ(expected_result,
-              spvBinaryParse(context, &client_, flipped_words.data(),
-                             flipped_words.size(), invoke_header,
-                             invoke_instruction, &diagnostic_));
+              spvBinaryParse(ScopedContext().context, &client_,
+                             flipped_words.data(), flipped_words.size(),
+                             invoke_header, invoke_instruction, &diagnostic_));
   }
 
   spv_diagnostic diagnostic_ = nullptr;
@@ -229,12 +229,12 @@ class BinaryParseTest : public spvtest::TextToBinaryTestBase<::testing::Test> {
 
 // Adds an EXPECT_CALL to client_->Header() with appropriate parameters,
 // including bound.  Returns the EXPECT_CALL result.
-#define EXPECT_HEADER(bound)                                                 \
-  EXPECT_CALL(client_,                                                       \
-              Header(AnyOf(SPV_ENDIANNESS_LITTLE, SPV_ENDIANNESS_BIG),       \
-                     SpvMagicNumber, 0x10000,                                \
-                     SPV_GENERATOR_WORD(SPV_GENERATOR_KHRONOS_ASSEMBLER, 0), \
-                     bound, 0 /*reserved*/))
+#define EXPECT_HEADER(bound)                                                   \
+  EXPECT_CALL(                                                                 \
+      client_,                                                                 \
+      Header(AnyOf(SPV_ENDIANNESS_LITTLE, SPV_ENDIANNESS_BIG), SpvMagicNumber, \
+             0x10000, SPV_GENERATOR_WORD(SPV_GENERATOR_KHRONOS_ASSEMBLER, 0),  \
+             bound, 0 /*reserved*/))
 
 static const bool kSwapEndians[] = {false, true};
 
@@ -267,9 +267,9 @@ TEST_F(BinaryParseTest, NullHeaderCallbackIsIgnored) {
       .Times(0);  // No header callback.
   EXPECT_CALL(client_, Instruction(MakeParsedVoidTypeInstruction(1)))
       .WillOnce(Return(SPV_SUCCESS));
-  EXPECT_EQ(SPV_SUCCESS,
-            spvBinaryParse(context, &client_, words.data(), words.size(),
-                           nullptr, invoke_instruction, &diagnostic_));
+  EXPECT_EQ(SPV_SUCCESS, spvBinaryParse(ScopedContext().context, &client_,
+                                        words.data(), words.size(), nullptr,
+                                        invoke_instruction, &diagnostic_));
   EXPECT_EQ(nullptr, diagnostic_);
 }
 
@@ -278,8 +278,8 @@ TEST_F(BinaryParseTest, NullInstructionCallbackIsIgnored) {
   EXPECT_HEADER((2)).WillOnce(Return(SPV_SUCCESS));
   EXPECT_CALL(client_, Instruction(_)).Times(0);  // No instruction callback.
   EXPECT_EQ(SPV_SUCCESS,
-            spvBinaryParse(context, &client_, words.data(), words.size(),
-                           invoke_header, nullptr, &diagnostic_));
+            spvBinaryParse(ScopedContext().context, &client_, words.data(),
+                           words.size(), invoke_header, nullptr, &diagnostic_));
   EXPECT_EQ(nullptr, diagnostic_);
 }
 
@@ -443,8 +443,8 @@ using BinaryParseWordsAndCountDiagnosticTest = spvtest::TextToBinaryTestBase<
 TEST_P(BinaryParseWordsAndCountDiagnosticTest, WordAndCountCases) {
   EXPECT_EQ(
       SPV_ERROR_INVALID_BINARY,
-      spvBinaryParse(context, nullptr, GetParam().words, GetParam().num_words,
-                     nullptr, nullptr, &diagnostic));
+      spvBinaryParse(ScopedContext().context, nullptr, GetParam().words,
+                     GetParam().num_words, nullptr, nullptr, &diagnostic));
   ASSERT_NE(nullptr, diagnostic);
   EXPECT_THAT(diagnostic->error, Eq(GetParam().expected_diagnostic));
 }
@@ -479,8 +479,8 @@ using BinaryParseWordVectorDiagnosticTest = spvtest::TextToBinaryTestBase<
 
 TEST_P(BinaryParseWordVectorDiagnosticTest, WordVectorCases) {
   const auto& words = GetParam().words;
-  EXPECT_THAT(spvBinaryParse(context, nullptr, words.data(), words.size(),
-                             nullptr, nullptr, &diagnostic),
+  EXPECT_THAT(spvBinaryParse(ScopedContext().context, nullptr, words.data(),
+                             words.size(), nullptr, nullptr, &diagnostic),
               AnyOf(SPV_ERROR_INVALID_BINARY, SPV_ERROR_INVALID_ID));
   ASSERT_NE(nullptr, diagnostic);
   EXPECT_THAT(diagnostic->error, Eq(GetParam().expected_diagnostic));
@@ -709,8 +709,8 @@ using BinaryParseAssemblyDiagnosticTest = spvtest::TextToBinaryTestBase<
 
 TEST_P(BinaryParseAssemblyDiagnosticTest, AssemblyCases) {
   auto words = CompileSuccessfully(GetParam().assembly);
-  EXPECT_THAT(spvBinaryParse(context, nullptr, words.data(), words.size(),
-                             nullptr, nullptr, &diagnostic),
+  EXPECT_THAT(spvBinaryParse(ScopedContext().context, nullptr, words.data(),
+                             words.size(), nullptr, nullptr, &diagnostic),
               AnyOf(SPV_ERROR_INVALID_BINARY, SPV_ERROR_INVALID_ID));
   ASSERT_NE(nullptr, diagnostic);
   EXPECT_THAT(diagnostic->error, Eq(GetParam().expected_diagnostic));

--- a/test/BinaryToText.cpp
+++ b/test/BinaryToText.cpp
@@ -415,9 +415,9 @@ OpMemoryModel Logical GLSL450 ; 0x0000001c
 TEST_F(TextToBinaryTest, VersionString) {
   auto words = CompileSuccessfully("");
   spv_text decoded_text = nullptr;
-  EXPECT_THAT(spvBinaryToText(context, words.data(), words.size(),
-                              SPV_BINARY_TO_TEXT_OPTION_NONE, &decoded_text,
-                              &diagnostic),
+  EXPECT_THAT(spvBinaryToText(ScopedContext().context, words.data(),
+                              words.size(), SPV_BINARY_TO_TEXT_OPTION_NONE,
+                              &decoded_text, &diagnostic),
               Eq(SPV_SUCCESS));
   EXPECT_EQ(nullptr, diagnostic);
 
@@ -446,9 +446,9 @@ TEST_P(GeneratorStringTest, Sample) {
       SPV_GENERATOR_WORD(GetParam().generator, GetParam().misc);
 
   spv_text decoded_text = nullptr;
-  EXPECT_THAT(spvBinaryToText(context, words.data(), words.size(),
-                              SPV_BINARY_TO_TEXT_OPTION_NONE, &decoded_text,
-                              &diagnostic),
+  EXPECT_THAT(spvBinaryToText(ScopedContext().context, words.data(),
+                              words.size(), SPV_BINARY_TO_TEXT_OPTION_NONE,
+                              &decoded_text, &diagnostic),
               Eq(SPV_SUCCESS));
   EXPECT_THAT(diagnostic, Eq(nullptr));
   EXPECT_THAT(std::string(decoded_text->str), HasSubstr(GetParam().expected));

--- a/test/ImmediateInt.cpp
+++ b/test/ImmediateInt.cpp
@@ -30,8 +30,8 @@
 
 #include <gmock/gmock.h>
 
-#include "source/util/bitutils.h"
 #include "TestFixture.h"
+#include "source/util/bitutils.h"
 
 namespace {
 
@@ -46,8 +46,8 @@ using ::testing::StrEq;
 
 TEST_F(TextToBinaryTest, ImmediateIntOpCode) {
   SetText("!0x00FF00FF");
-  ASSERT_EQ(SPV_SUCCESS, spvTextToBinary(context, text.str, text.length,
-                                         &binary, &diagnostic));
+  ASSERT_EQ(SPV_SUCCESS, spvTextToBinary(ScopedContext().context, text.str,
+                                         text.length, &binary, &diagnostic));
   EXPECT_EQ(0x00FF00FFu, binary->code[5]);
   if (diagnostic) {
     spvDiagnosticPrint(diagnostic);
@@ -56,8 +56,8 @@ TEST_F(TextToBinaryTest, ImmediateIntOpCode) {
 
 TEST_F(TextToBinaryTest, ImmediateIntOperand) {
   SetText("OpCapability !0x00FF00FF");
-  EXPECT_EQ(SPV_SUCCESS, spvTextToBinary(context, text.str, text.length,
-                                         &binary, &diagnostic));
+  EXPECT_EQ(SPV_SUCCESS, spvTextToBinary(ScopedContext().context, text.str,
+                                         text.length, &binary, &diagnostic));
   EXPECT_EQ(0x00FF00FFu, binary->code[6]);
   if (diagnostic) {
     spvDiagnosticPrint(diagnostic);

--- a/test/OpcodeRequiresCapabilities.cpp
+++ b/test/OpcodeRequiresCapabilities.cpp
@@ -46,7 +46,7 @@ class Requires : public ::testing::TestWithParam<SpvCapability> {
   spv_opcode_desc_t entry;
 };
 
-TEST_P(Requires, Capabilityabilities) {
+TEST_P(Requires, Capabilities) {
   ASSERT_NE(0, spvOpcodeRequiresCapabilities(&entry));
 }
 
@@ -94,7 +94,7 @@ using OpcodeTableCapabilitiesTest =
 TEST_P(OpcodeTableCapabilitiesTest, TableEntryMatchesExpectedCapabilities) {
   spv_opcode_table opcodeTable;
   ASSERT_EQ(SPV_SUCCESS,
-            spvOpcodeTableGet(&opcodeTable, SPV_ENV_UNIVERSAL_1_0));
+            spvOpcodeTableGet(&opcodeTable, SPV_ENV_UNIVERSAL_1_1));
   spv_opcode_desc entry;
   ASSERT_EQ(SPV_SUCCESS,
             spvOpcodeTableValueLookup(opcodeTable, GetParam().opcode, &entry));
@@ -133,6 +133,8 @@ INSTANTIATE_TEST_CASE_P(
         ExpectedOpCodeCapabilities{SpvOpFunction, 0},
         ExpectedOpCodeCapabilities{SpvOpConvertFToS, 0},
         ExpectedOpCodeCapabilities{SpvOpEmitStreamVertex,
-                                   mask(SpvCapabilityGeometryStreams)}), );
+                                   mask(SpvCapabilityGeometryStreams)},
+        ExpectedOpCodeCapabilities{SpvOpTypeNamedBarrier,
+                                   mask(SpvCapabilityNamedBarrier)}), );
 
 }  // anonymous namespace

--- a/test/TestFixture.h
+++ b/test/TestFixture.h
@@ -160,8 +160,9 @@ class TextToBinaryTestBase : public T {
 
   // Compiles SPIR-V text, asserts success, and returns the words representing
   // the instructions.  In particular, skip the words in the SPIR-V header.
-  SpirvVector CompiledInstructions(const std::string& txt) {
-    const SpirvVector code = CompileSuccessfully(txt);
+  SpirvVector CompiledInstructions(const std::string& txt,
+                                   spv_target_env env = SPV_ENV_UNIVERSAL_1_0) {
+    const SpirvVector code = CompileSuccessfully(txt, env);
     SpirvVector result;
     // Extract just the instructions.
     // If the code fails to compile, then return the empty vector.

--- a/test/TextToBinary.Barrier.cpp
+++ b/test/TextToBinary.Barrier.cpp
@@ -88,20 +88,7 @@ TEST_F(OpMemoryBarrier, BadInvalidMemorySemanticsId) {
 // TODO(dneto): OpGroupUMax
 // TODO(dneto): OpGroupSMax
 
-// Matches if the SpirvVector under test has length+opcode in the first word of
-// the first instruction.
-MATCHER_P2(StartsWith, opcode, length, "") {
-  return arg[TextToBinaryTest::kFirstInstruction] ==
-         spvOpcodeMake(length, opcode);
-}
-
 using NamedMemoryBarrierTest = spvtest::TextToBinaryTest;
-
-TEST_F(NamedMemoryBarrierTest, OpcodeRecognizedInV11) {
-  EXPECT_THAT(CompileSuccessfully("OpMemoryNamedBarrier %bar %scope %semantics",
-                                  SPV_ENV_UNIVERSAL_1_1),
-              StartsWith(SpvOpMemoryNamedBarrier, 4));
-}
 
 TEST_F(NamedMemoryBarrierTest, OpcodeUnrecognizedInV10) {
   EXPECT_THAT(CompileFailure("OpMemoryNamedBarrier %bar %scope %semantics",
@@ -119,6 +106,10 @@ TEST_F(NamedMemoryBarrierTest, ArgumentCount) {
       CompileFailure("OpMemoryNamedBarrier %bar %scope", SPV_ENV_UNIVERSAL_1_1),
       Eq("Expected operand, found end of stream."));
   EXPECT_THAT(
+      CompiledInstructions("OpMemoryNamedBarrier %bar %scope %semantics",
+                           SPV_ENV_UNIVERSAL_1_1),
+      ElementsAre(spvOpcodeMake(4, SpvOpMemoryNamedBarrier), _, _, _));
+  EXPECT_THAT(
       CompileFailure("OpMemoryNamedBarrier %bar %scope %semantics %extra",
                      SPV_ENV_UNIVERSAL_1_1),
       Eq("Expected '=', found end of stream."));
@@ -135,12 +126,6 @@ TEST_F(NamedMemoryBarrierTest, ArgumentTypes) {
 
 using TypeNamedBarrierTest = spvtest::TextToBinaryTest;
 
-TEST_F(TypeNamedBarrierTest, OpcodeRecognizedInV11) {
-  EXPECT_THAT(
-      CompileSuccessfully("%t = OpTypeNamedBarrier", SPV_ENV_UNIVERSAL_1_1),
-      StartsWith(SpvOpTypeNamedBarrier, 2));
-}
-
 TEST_F(TypeNamedBarrierTest, OpcodeUnrecognizedInV10) {
   EXPECT_THAT(CompileFailure("%t = OpTypeNamedBarrier", SPV_ENV_UNIVERSAL_1_0),
               Eq("Invalid Opcode name 'OpTypeNamedBarrier'"));
@@ -151,19 +136,15 @@ TEST_F(TypeNamedBarrierTest, ArgumentCount) {
               Eq("Expected <result-id> at the beginning of an instruction, "
                  "found 'OpTypeNamedBarrier'."));
   EXPECT_THAT(
+      CompiledInstructions("%t = OpTypeNamedBarrier", SPV_ENV_UNIVERSAL_1_1),
+      ElementsAre(spvOpcodeMake(2, SpvOpTypeNamedBarrier), _));
+  EXPECT_THAT(
       CompileFailure("%t = OpTypeNamedBarrier 1 2 3", SPV_ENV_UNIVERSAL_1_1),
       Eq("Expected <opcode> or <result-id> at the beginning of an instruction, "
          "found '1'."));
 }
 
 using NamedBarrierInitializeTest = spvtest::TextToBinaryTest;
-
-TEST_F(NamedBarrierInitializeTest, OpcodeRecognizedInV11) {
-  EXPECT_THAT(
-      CompileSuccessfully("%bar = OpNamedBarrierInitialize %type %count",
-                          SPV_ENV_UNIVERSAL_1_1),
-      StartsWith(SpvOpNamedBarrierInitialize, 4));
-}
 
 TEST_F(NamedBarrierInitializeTest, OpcodeUnrecognizedInV10) {
   EXPECT_THAT(CompileFailure("%bar = OpNamedBarrierInitialize %type %count",
@@ -178,6 +159,10 @@ TEST_F(NamedBarrierInitializeTest, ArgumentCount) {
   EXPECT_THAT(CompileFailure("%bar = OpNamedBarrierInitialize %ype",
                              SPV_ENV_UNIVERSAL_1_1),
               Eq("Expected operand, found end of stream."));
+  EXPECT_THAT(
+      CompiledInstructions("%bar = OpNamedBarrierInitialize %type %count",
+                           SPV_ENV_UNIVERSAL_1_1),
+      ElementsAre(spvOpcodeMake(4, SpvOpNamedBarrierInitialize), _, _, _));
   EXPECT_THAT(
       CompileFailure("%bar = OpNamedBarrierInitialize %type %count \"extra\"",
                      SPV_ENV_UNIVERSAL_1_1),

--- a/test/TextToBinary.cpp
+++ b/test/TextToBinary.cpp
@@ -123,7 +123,8 @@ INSTANTIATE_TEST_CASE_P(ParseMask, BadFPFastMathMaskParseTest,
 
 TEST_F(TextToBinaryTest, InvalidText) {
   ASSERT_EQ(SPV_ERROR_INVALID_TEXT,
-            spvTextToBinary(context, nullptr, 0, &binary, &diagnostic));
+            spvTextToBinary(ScopedContext().context, nullptr, 0, &binary,
+                            &diagnostic));
   EXPECT_NE(nullptr, diagnostic);
   EXPECT_THAT(diagnostic->error, Eq(std::string("Missing assembly text.")));
 }
@@ -131,16 +132,17 @@ TEST_F(TextToBinaryTest, InvalidText) {
 TEST_F(TextToBinaryTest, InvalidPointer) {
   SetText(
       "OpEntryPoint Kernel 0 \"\"\nOpExecutionMode 0 LocalSizeHint 1 1 1\n");
-  ASSERT_EQ(
-      SPV_ERROR_INVALID_POINTER,
-      spvTextToBinary(context, text.str, text.length, nullptr, &diagnostic));
+  ASSERT_EQ(SPV_ERROR_INVALID_POINTER,
+            spvTextToBinary(ScopedContext().context, text.str, text.length,
+                            nullptr, &diagnostic));
 }
 
 TEST_F(TextToBinaryTest, InvalidDiagnostic) {
   SetText(
       "OpEntryPoint Kernel 0 \"\"\nOpExecutionMode 0 LocalSizeHint 1 1 1\n");
   ASSERT_EQ(SPV_ERROR_INVALID_DIAGNOSTIC,
-            spvTextToBinary(context, text.str, text.length, &binary, nullptr));
+            spvTextToBinary(ScopedContext().context, text.str, text.length,
+                            &binary, nullptr));
 }
 
 TEST_F(TextToBinaryTest, InvalidPrefix) {

--- a/test/ValidateID.cpp
+++ b/test/ValidateID.cpp
@@ -414,7 +414,8 @@ class OpTypeArrayLengthTest
   // Runs spvValidate() on v, printing any errors via spvDiagnosticPrint().
   spv_result_t Val(const SpirvVector& v) {
     spv_const_binary_t cbinary{v.data(), v.size()};
-    const auto status = spvValidate(context, &cbinary, &diagnostic_);
+    const auto status =
+        spvValidate(ScopedContext().context, &cbinary, &diagnostic_);
     if (status != SPV_SUCCESS) {
       spvDiagnosticPrint(diagnostic_);
     }

--- a/tools/val/val.cpp
+++ b/tools/val/val.cpp
@@ -63,10 +63,9 @@ int main(int argc, char** argv) {
     if ('-' == cur_arg[0]) {
       if (0 == strcmp(cur_arg, "--version")) {
         printf("%s\n", kBuildVersion);
-        printf("Targets:\n  %s\n  %s\n  %s\n",
-               spvTargetEnvDescription(SPV_ENV_UNIVERSAL_1_0),
-               spvTargetEnvDescription(SPV_ENV_VULKAN_1_0),
-               spvTargetEnvDescription(SPV_ENV_UNIVERSAL_1_1));
+        printf("Targets:\n  %s\n  %s\n",
+               spvTargetEnvDescription(SPV_ENV_UNIVERSAL_1_1),
+               spvTargetEnvDescription(SPV_ENV_VULKAN_1_0));
         return 0;
       } else if (0 == strcmp(cur_arg, "--help") || 0 == strcmp(cur_arg, "-h")) {
         print_usage(argv[0]);


### PR DESCRIPTION
Add test for named-barrier instructions and capability.

Add spv_target_env as an optional argument to CompileSuccessfully() and
CompileFailure().  Currently defaults to UNIVERSAL_1_0, though that
could change in the future.

Make spv_context a local variable in test methods instead of a
TextToBinaryTestBase member.  Introduce ScopedContext to make temp
contexts easier.