### PR TITLE
WIP: Control Flow Graph Validation

### DIFF
--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -24,6 +24,16 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 
+#include <cassert>
+#include <cstdio>
+
+#include <algorithm>
+#include <functional>
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <vector>
+
 #include "validate.h"
 #include "validate_passes.h"
 
@@ -35,15 +45,6 @@
 #include "spirv-tools/libspirv.h"
 #include "spirv_constant.h"
 #include "spirv_endian.h"
-
-#include <algorithm>
-#include <cassert>
-#include <cstdio>
-#include <functional>
-#include <iterator>
-#include <sstream>
-#include <string>
-#include <vector>
 
 using std::function;
 using std::ostream_iterator;

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -184,10 +184,11 @@ spv_result_t spvValidate(const spv_const_context context,
   // TODO(umar): Add validation checks which require the parsing of the entire
   // module. Use the information from the ProcessInstruction pass to make the
   // checks.
-  vstate.get_functions().printDotGraph();
+  //vstate.get_functions().printDotGraph();
 
   for(auto& block : vstate.get_functions().get_first_blocks()) {
-    libspirv::CalculateDominators(*block);
+    auto edges = libspirv::CalculateDominators(*block);
+    libspirv::UpdateImmediateDominators(edges);
   }
 
   if (vstate.unresolvedForwardIdCount() > 0) {

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -184,13 +184,6 @@ spv_result_t spvValidate(const spv_const_context context,
   // TODO(umar): Add validation checks which require the parsing of the entire
   // module. Use the information from the ProcessInstruction pass to make the
   // checks.
-  //vstate.get_functions().printDotGraph();
-
-  for(auto& block : vstate.get_functions().get_first_blocks()) {
-    auto edges = libspirv::CalculateDominators(*block);
-    libspirv::UpdateImmediateDominators(edges);
-  }
-
   if (vstate.unresolvedForwardIdCount() > 0) {
     stringstream ss;
     vector<uint32_t> ids = vstate.unresolvedForwardIds();
@@ -203,6 +196,15 @@ spv_result_t spvValidate(const spv_const_context context,
            << "The following forward referenced IDs have not be defined:\n"
            << id_str.substr(0, id_str.size() - 1);
   }
+
+  //vstate.get_functions().printDotGraph();
+  for(auto& function : vstate.get_functions()) {
+    if(auto* block = function.get_first_block()) {
+      auto edges = libspirv::CalculateDominators(*block);
+      libspirv::UpdateImmediateDominators(edges);
+    }
+  }
+
 
   // NOTE: Copy each instruction for easier processing
   std::vector<spv_instruction_t> instructions;

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -184,6 +184,7 @@ spv_result_t spvValidate(const spv_const_context context,
   // TODO(umar): Add validation checks which require the parsing of the entire
   // module. Use the information from the ProcessInstruction pass to make the
   // checks.
+  vstate.get_functions().printDotGraph();
 
   if (vstate.unresolvedForwardIdCount() > 0) {
     stringstream ss;

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -197,14 +197,9 @@ spv_result_t spvValidate(const spv_const_context context,
            << id_str.substr(0, id_str.size() - 1);
   }
 
-  //vstate.get_functions().printDotGraph();
-  for(auto& function : vstate.get_functions()) {
-    if(auto* block = function.get_first_block()) {
-      auto edges = libspirv::CalculateDominators(*block);
-      libspirv::UpdateImmediateDominators(edges);
-    }
-  }
-
+  // CFG checks are performed after the binary has been parsed
+  // and the CFGPass has collected information about the control flow
+  spvCheckReturn(PerformCfgChecks(vstate));
 
   // NOTE: Copy each instruction for easier processing
   std::vector<spv_instruction_t> instructions;

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -186,6 +186,10 @@ spv_result_t spvValidate(const spv_const_context context,
   // checks.
   vstate.get_functions().printDotGraph();
 
+  for(auto& block : vstate.get_functions().get_first_blocks()) {
+    libspirv::CalculateDominators(*block);
+  }
+
   if (vstate.unresolvedForwardIdCount() > 0) {
     stringstream ss;
     vector<uint32_t> ids = vstate.unresolvedForwardIds();

--- a/source/validate.h
+++ b/source/validate.h
@@ -35,6 +35,7 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include <list>
 
 #include "assembly_grammar.h"
 #include "binary.h"
@@ -160,7 +161,7 @@ class BasicBlock {
   ///
   /// This iterator will iterate to the the immediate dominators
   /// of the block
-  class DominatorIterator {
+  class DominatorIterator : public std::iterator<std::forward_iterator_tag, BasicBlock*> {
    public:
     /// @brief Constructs the end of dominator iterator
     ///
@@ -308,9 +309,9 @@ class Function {
   std::vector<BasicBlock*>& get_blocks();
 
   /// Returns a vector of all the cfg constructs in the function
-  const std::vector<CFConstruct>& get_constructs() const;
+  const std::list<CFConstruct>& get_constructs() const;
   /// Returns a vector of all the cfg constructs in the function
-  std::vector<CFConstruct>& get_constructs();
+  std::list<CFConstruct>& get_constructs();
 
   // Returns the number of blocks in the current function being parsed
   size_t get_block_count() const;
@@ -372,7 +373,7 @@ class Function {
   BasicBlock* current_block_;
 
   /// The constructs that are available in this function
-  std::vector<CFConstruct> cfg_constructs_;
+  std::list<CFConstruct> cfg_constructs_;
 
   /// The variable IDs of the functions
   std::vector<uint32_t> variable_ids_;
@@ -426,7 +427,7 @@ class ValidationState_t {
   libspirv::DiagnosticStream diag(spv_result_t error_code) const;
 
   // Returns the function states
-  std::vector<Function>& get_functions();
+  std::list<Function>& get_functions();
 
   // Returns the function states
   Function& get_current_function();
@@ -523,7 +524,7 @@ class ValidationState_t {
   // The section of the code being processed
   ModuleLayoutSection current_layout_section_;
 
-  std::vector<Function> module_functions_;
+  std::list<Function> module_functions_;
 
   spv_capability_mask_t
       module_capabilities_;  // Module's declared capabilities.

--- a/source/validate.h
+++ b/source/validate.h
@@ -111,11 +111,15 @@ public:
 
   uint32_t get_id() const {return id_; }
 
-  const std::vector<BasicBlock*>& get_dominators() const {return dominators_; }
-  std::vector<BasicBlock*>&       get_dominators()       {return dominators_; }
+  const std::vector<BasicBlock*>& get_predecessors() const {return predecessors_; }
+  std::vector<BasicBlock*>&       get_predecessors()       {return predecessors_; }
 
   const std::vector<BasicBlock*>& get_out_blocks() const {return out_blocks_; }
   std::vector<BasicBlock*>&       get_out_blocks()       {return out_blocks_; }
+
+  void SetImmediateDominator(BasicBlock* dom_block);
+  BasicBlock* GetImmediateDominator();
+  const BasicBlock *const GetImmediateDominator() const;
 
   void RegisterNext(BasicBlock& next);
   void RegisterNext(std::vector<BasicBlock*> next);
@@ -128,7 +132,6 @@ private:
   const uint32_t id_;
   BasicBlock* immediate_dominator_;
   std::vector<BasicBlock*> predecessors_;
-  std::vector<BasicBlock*> dominators_;
   std::vector<BasicBlock*> out_blocks_;
   ValidationState_t& module_;
 };
@@ -222,6 +225,8 @@ class Functions {
   bool IsMergeBlock(uint32_t merge_block_id) const;
 
   bool isFirstBlock(uint32_t id) const;
+
+  std::vector<BasicBlock*>& get_first_blocks() { return first_blocks_; }
 
   // Returns the number of blocks in the current function being parsed
   size_t get_block_count() const;
@@ -423,6 +428,10 @@ class ValidationState_t {
   SpvMemoryModel memory_model_;
 
 };
+
+
+std::unordered_map<BasicBlock*, uint32_t>
+CalculateDominators(BasicBlock &first_block);
 
 }  // namespace libspirv
 

--- a/source/validate.h
+++ b/source/validate.h
@@ -298,13 +298,10 @@ class Function {
   spv_result_t RegisterSelectionMerge(uint32_t merge_id);
 
   /// Registers the end of the block
-  void RegisterBlockEnd(SpvOp branch_instruction);
-
-  /// Registers the end of the block
-  void RegisterBlockEnd(uint32_t next_id, SpvOp branch_instruction);
-
-  /// Registers the end of the block
-  void RegisterBlockEnd(std::vector<uint32_t> next_list,
+  ///
+  /// @param[in] successors_list A list of ids to the blocks successors
+  /// @param[in] branch_instruction the branch instruction that ended the block
+  void RegisterBlockEnd(std::vector<uint32_t> successors_list,
                         SpvOp branch_instruction);
 
   /// Returns true if the \p merge_block_id is a merge block

--- a/source/validate.h
+++ b/source/validate.h
@@ -147,14 +147,11 @@ class BasicBlock {
   /// Returns the immedate dominator of this basic block
   const BasicBlock* GetImmediateDominator() const;
 
-  /// Adds @p next as a successor of this BasicBlock
-  void RegisterBranchWithoutSuccessor(SpvOp branch_instruction);
-
-  /// Adds @p next as a successor of this BasicBlock
-  void RegisterSuccessor(BasicBlock& next, SpvOp branch_instruction);
+  /// Ends the block without a successor
+  void RegisterBranchInstruction(SpvOp branch_instruction);
 
   /// Adds @p next BasicBlocks as successors of this BasicBlock
-  void RegisterSuccessor(std::vector<BasicBlock*> next, SpvOp branch_instruction);
+  void RegisterSuccessor(std::vector<BasicBlock*> next = {});
 
   /// Returns true if the id of the BasicBlock matches
   bool operator==(const BasicBlock& other) const { return other.id_ == id_; }
@@ -248,6 +245,10 @@ class CFConstruct {
   const BasicBlock* get_merge() const { return merge_block_; }
   const BasicBlock* get_continue() const { return continue_block_; }
 
+  BasicBlock* get_header() { return header_block_; }
+  BasicBlock* get_merge() { return merge_block_; }
+  BasicBlock* get_continue() { return continue_block_; }
+
  private:
   BasicBlock* header_block_;    ///< The header block of a loop or selection
   BasicBlock* merge_block_;     ///< The merge block of a loop or selection
@@ -337,7 +338,7 @@ class Function {
   size_t get_block_count() const;
 
   /// Returns the id of the funciton
-  uint32_t get_id() const { return id_; };
+  uint32_t get_id() const { return id_; }
 
   // Returns the number of blocks in the current function being parsed
   size_t get_undefined_block_count() const;
@@ -380,7 +381,7 @@ class Function {
   /// The type of declaration of each function
   FunctionDecl declaration_type_;
 
-  /// The beginning of the block of functions
+  /// The blocks in the function mapped by block ID
   std::unordered_map<uint32_t, BasicBlock> blocks_;
 
   /// A list of blocks in the order they appeared in the binary

--- a/source/validate.h
+++ b/source/validate.h
@@ -111,7 +111,6 @@ class BasicBlock {
   /// Constructor for a BasicBlock
   ///
   /// @param[in] id The ID of the basic block
-  /// @param[in] module A reference of the module of the basic block
   explicit BasicBlock(uint32_t id);
 
   /// Returns the id of the BasicBlock
@@ -151,7 +150,7 @@ class BasicBlock {
   void RegisterBranchInstruction(SpvOp branch_instruction);
 
   /// Adds @p next BasicBlocks as successors of this BasicBlock
-  void RegisterSuccessor(std::vector<BasicBlock*> next = {});
+  void RegisterSuccessors(std::vector<BasicBlock*> next = {});
 
   /// Returns true if the id of the BasicBlock matches
   bool operator==(const BasicBlock& other) const { return other.id_ == id_; }
@@ -420,6 +419,7 @@ class ValidationState_t {
   // the OpName instruction
   std::string getIdName(uint32_t id) const;
 
+  /// Like getIdName but does not display the id if the \p id has a name
   std::string getIdOrName(uint32_t id) const;
 
   // Returns the number of ID which have been forward referenced but not defined

--- a/source/validate.h
+++ b/source/validate.h
@@ -112,7 +112,7 @@ class BasicBlock {
   ///
   /// @param[in] id The ID of the basic block
   /// @param[in] module A reference of the module of the basic block
-  BasicBlock(uint32_t id);
+  explicit BasicBlock(uint32_t id);
 
   /// Returns the id of the BasicBlock
   uint32_t get_id() const { return id_; }
@@ -175,7 +175,7 @@ class BasicBlock {
     ///        @p block
     ///
     /// @param block The block which is referenced by the iterator
-    DominatorIterator(const BasicBlock* block);
+    explicit DominatorIterator(const BasicBlock* block);
 
     /// @brief Advances the iterator
     DominatorIterator& operator++();
@@ -210,9 +210,6 @@ class BasicBlock {
 
   /// The set of successors of the BasicBlock
   std::vector<BasicBlock*> successors_;
-
-  /// The function which contains this block
-  Function* function_;
 
   SpvOp branch_instruction_;
 
@@ -308,7 +305,8 @@ class Function {
   void RegisterBlockEnd(uint32_t next_id, SpvOp branch_instruction);
 
   /// Registers the end of the block
-  void RegisterBlockEnd(std::vector<uint32_t> next_list, SpvOp branch_instruction);
+  void RegisterBlockEnd(std::vector<uint32_t> next_list,
+                        SpvOp branch_instruction);
 
   /// Returns true if the \p merge_block_id is a merge block
   bool IsMergeBlock(uint32_t merge_block_id) const;

--- a/source/validate.h
+++ b/source/validate.h
@@ -132,7 +132,9 @@ class BasicBlock {
   std::vector<BasicBlock*>& get_successors() { return successors_; }
 
   /// Returns true if the  block should be reachable in the CFG
-  bool is_reachable() { return SpvOpUnreachable != branch_instruction_; }
+  bool is_reachable() const { return reachable_; }
+
+  void set_reachability(bool reachability) { reachable_ = reachability; }
 
   /// Sets the immedate dominator of this basic block
   ///
@@ -176,25 +178,27 @@ class BasicBlock {
     ///        @p block
     ///
     /// @param block The block which is referenced by the iterator
-    DominatorIterator(BasicBlock* block);
+    DominatorIterator(const BasicBlock* block);
 
     /// @brief Advances the iterator
     DominatorIterator& operator++();
 
     /// @brief Returns the current element
-    BasicBlock*& operator*();
+    const BasicBlock*& operator*();
 
     friend bool operator==(const DominatorIterator& lhs,
                            const DominatorIterator& rhs);
 
    private:
-    BasicBlock* current_;
+    const BasicBlock* current_;
   };
 
   /// Returns an iterator which points to the current block
+  const DominatorIterator dom_begin() const;
   DominatorIterator dom_begin();
 
   /// Returns an iterator which points to one element past the first block
+  const DominatorIterator dom_end() const;
   DominatorIterator dom_end();
 
  private:
@@ -214,6 +218,8 @@ class BasicBlock {
   Function* function_;
 
   SpvOp branch_instruction_;
+
+  bool reachable_;
 };
 
 /// @brief Returns true if the iterators point to the same element or if both
@@ -238,10 +244,14 @@ class CFConstruct {
         merge_block_(merge_block),
         continue_block_(continue_block) {}
 
+  const BasicBlock* get_header() const { return header_block_; }
+  const BasicBlock* get_merge() const { return merge_block_; }
+  const BasicBlock* get_continue() const { return continue_block_; }
+
+ private:
   BasicBlock* header_block_;    ///< The header block of a loop or selection
   BasicBlock* merge_block_;     ///< The merge block of a loop or selection
   BasicBlock* continue_block_;  ///< The continue block of a loop block
- private:
 };
 
 // This class manages all function declaration and definitions in a module. It
@@ -355,7 +365,7 @@ class Function {
   /// Parent module
   ValidationState_t& module_;
 
-  /// Function ID of
+  /// The result id of the OpLabel that defined this block
   uint32_t id_;
 
   /// The type of the function

--- a/source/validate.h
+++ b/source/validate.h
@@ -183,7 +183,6 @@ public:
 
   spv_result_t RegisterSelectionMerge(uint32_t header_id, uint32_t merge_id);
 
-
 private:
   libspirv::DiagnosticStream diag(spv_result_t error_code) const;
 
@@ -242,23 +241,29 @@ class Function {
 
   bool IsMergeBlock(uint32_t merge_block_id) const;
 
-  bool isFirstBlock(uint32_t id) const;
+  bool IsFirstBlock(uint32_t id) const;
 
-  const BasicBlock* get_first_block() const { return ordered_blocks_[0]; }
-        BasicBlock* get_first_block()       { return ordered_blocks_[0]; }
+  const BasicBlock* get_first_block() const;
+        BasicBlock* get_first_block();
 
   const std::vector<BasicBlock*>& get_blocks() const;
         std::vector<BasicBlock*>& get_blocks();
 
+  const CFConstructs& get_constructs() const;
+        CFConstructs& get_constructs();
+
   // Returns the number of blocks in the current function being parsed
   size_t get_block_count() const;
+
+  // Returns the number of blocks in the current function being parsed
+  size_t get_undefined_block_count() const;
 
   // Returns true if called after a label instruction but before a branch
   // instruction
   bool in_block() const;
 
-        BasicBlock& get_current_block()       { return *current_block_; }
-  const BasicBlock& get_current_block() const { return *current_block_; }
+        BasicBlock& get_current_block();
+  const BasicBlock& get_current_block() const;
 
   void printDotGraph() const;
 
@@ -287,6 +292,9 @@ class Function {
 
   // A list of blocks in the order they appeared in the binary
   std::vector<BasicBlock*> ordered_blocks_;
+
+  // Blocks which are forward referenced by blocks but not defined
+  std::unordered_set<uint32_t> undefined_blocks_;
 
   // The block that is currently being parsed
   BasicBlock* current_block_;

--- a/source/validate.h
+++ b/source/validate.h
@@ -29,13 +29,13 @@
 
 #include <algorithm>
 #include <array>
+#include <list>
 #include <map>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
-#include <list>
 
 #include "assembly_grammar.h"
 #include "binary.h"
@@ -73,14 +73,14 @@ namespace libspirv {
 
 void message(std::string file, size_t line, std::string name);
 
-template<typename T>
+template <typename T>
 void message(std::string file, size_t line, std::string name, T val) {
   std::cout << file << ":" << line << ": " << name << " " << val << std::endl;
 }
 
-// This enum represents the sections of a SPIRV module. See section 2.4
-// of the SPIRV spec for additional details of the order. The enumerant values
-// are in the same order as the vector returned by GetModuleOrder
+/// This enum represents the sections of a SPIRV module. See section 2.4
+/// of the SPIRV spec for additional details of the order. The enumerant values
+/// are in the same order as the vector returned by GetModuleOrder
 enum ModuleLayoutSection {
   kLayoutCapabilities,          // < Section 2.4 #1
   kLayoutExtensions,            // < Section 2.4 #2
@@ -142,10 +142,10 @@ class BasicBlock {
   /// Returns the immedate dominator of this basic block
   const BasicBlock* GetImmediateDominator() const;
 
-  /// Sets the @p next BasicBlock as the successor of this BasicBlock
+  /// Adds @p next as a successor of this BasicBlock
   void RegisterSuccessor(BasicBlock& next);
 
-  /// Sets the @p next BasicBlock as the successor of this BasicBlock
+  /// Adds @p next BasicBlocks as successors of this BasicBlock
   void RegisterSuccessor(std::vector<BasicBlock*> next);
 
   /// Returns true if the id of the BasicBlock matches
@@ -156,9 +156,9 @@ class BasicBlock {
 
   /// @brief A BasicBlock dominator iterator class
   ///
-  /// This iterator will iterate to the the immediate dominators
-  /// of the block
-  class DominatorIterator : public std::iterator<std::forward_iterator_tag, BasicBlock*> {
+  /// This iterator will iterate over the dominators of the block
+  class DominatorIterator
+      : public std::iterator<std::forward_iterator_tag, BasicBlock*> {
    public:
     /// @brief Constructs the end of dominator iterator
     ///
@@ -192,19 +192,19 @@ class BasicBlock {
   DominatorIterator dom_end();
 
  private:
-  // Id of the BasicBlock
+  /// Id of the BasicBlock
   const uint32_t id_;
 
-  // Pointer to the immediate dominator of the BasicBlock
+  /// Pointer to the immediate dominator of the BasicBlock
   BasicBlock* immediate_dominator_;
 
-  // The set of predecessors of the BasicBlock
+  /// The set of predecessors of the BasicBlock
   std::vector<BasicBlock*> predecessors_;
 
-  // The set of successors of the BasicBlock
+  /// The set of successors of the BasicBlock
   std::vector<BasicBlock*> successors_;
 
-  // The function which contains this block
+  /// The function which contains this block
   Function* function_;
 };
 
@@ -309,9 +309,10 @@ class Function {
   /// Returns a vector of all the blocks in the function
   std::vector<BasicBlock*>& get_blocks();
 
-  /// Returns a vector of all the cfg constructs in the function
+  /// Returns a list of all the cfg constructs in the function
   const std::list<CFConstruct>& get_constructs() const;
-  /// Returns a vector of all the cfg constructs in the function
+
+  /// Returns a list of all the cfg constructs in the function
   std::list<CFConstruct>& get_constructs();
 
   // Returns the number of blocks in the current function being parsed
@@ -326,8 +327,8 @@ class Function {
     return undefined_blocks_;
   }
 
-  // Returns true if called after a label instruction but before a branch
-  // instruction
+  /// Returns true if called after a label instruction but before a branch
+  /// instruction
   bool in_block() const;
 
   /// Returns the block that is currently being parsed in the binary
@@ -545,14 +546,14 @@ class ValidationState_t {
   bool in_function_;
 };
 
-// @brief Calculates dominator edges of a root basic block
-//
-// This function calculates the dominator edges form a root BasicBlock. Uses
-// the dominator algorithm by Cooper et al.
-//
-// @param[in] first_block the root or entry BasicBlock of a function
-//
-// @return a set of dominator edges represented as a pair of blocks
+/// @brief Calculates dominator edges of a root basic block
+///
+/// This function calculates the dominator edges form a root BasicBlock. Uses
+/// the dominator algorithm by Cooper et al.
+///
+/// @param[in] first_block the root or entry BasicBlock of a function
+///
+/// @return a set of dominator edges represented as a pair of blocks
 std::vector<std::pair<BasicBlock*, BasicBlock*> > CalculateDominators(
     const BasicBlock& first_block);
 

--- a/source/validate.h
+++ b/source/validate.h
@@ -104,35 +104,60 @@ enum class FunctionDecl {
 
 class ValidationState_t;
 
+// This class represents a basic block in a SPIR-V module
 class BasicBlock
 {
 public:
   BasicBlock(uint32_t id, ValidationState_t& module);
 
+  // Returns the id of the BasicBlock
   uint32_t get_id() const {return id_; }
 
+  // Returns the predecessors of the BasicBlock
   const std::vector<BasicBlock*>& get_predecessors() const {return predecessors_; }
+
+  // Returns the predecessors of the BasicBlock
   std::vector<BasicBlock*>&       get_predecessors()       {return predecessors_; }
 
-  const std::vector<BasicBlock*>& get_out_blocks() const {return out_blocks_; }
-  std::vector<BasicBlock*>&       get_out_blocks()       {return out_blocks_; }
+  // Returns the successors of the BasicBlock
+  const std::vector<BasicBlock*>& get_successors() const {return successors_; }
+  std::vector<BasicBlock*>&       get_successors()       {return successors_; }
 
+  // Sets the immedate dominator of this basic block
+  //
+  // @param[in] dom_block The dominator block
   void SetImmediateDominator(BasicBlock* dom_block);
-  BasicBlock* GetImmediateDominator();
-  const BasicBlock *const GetImmediateDominator() const;
 
-  void RegisterNext(BasicBlock& next);
-  void RegisterNext(std::vector<BasicBlock*> next);
+  // Returns the immedate dominator of this basic block
+  //
+  // @return The dominator block
+  BasicBlock* GetImmediateDominator();
+
+  // Returns the immedate dominator of this basic block
+  const BasicBlock * GetImmediateDominator() const;
+
+  // Sets the @p next BasicBlock as the successor of this BasicBlock
+  void RegisterSuccessor(BasicBlock& next);
+
+  // Sets the @p next BasicBlock as the successor of this BasicBlock
+  void RegisterSuccessor(std::vector<BasicBlock*> next);
 
   bool operator==(const BasicBlock &other) const { return other.id_ == id_; }
   bool operator==(const uint32_t &id) const { return id == id_; }
 
   friend std::ostream& operator<<(std::ostream& os, const BasicBlock &other);
 private:
+  // Id of the BasicBlock
   const uint32_t id_;
+
+  // Pointer to the immediate dominator of the BasicBlock
   BasicBlock* immediate_dominator_;
+
+  // The set of predecessors of the BasicBlock
   std::vector<BasicBlock*> predecessors_;
-  std::vector<BasicBlock*> out_blocks_;
+
+  // The set of successors of the BasicBlock
+  std::vector<BasicBlock*> successors_;
   ValidationState_t& module_;
 };
 
@@ -430,8 +455,31 @@ class ValidationState_t {
 };
 
 
-std::unordered_map<BasicBlock*, uint32_t>
-CalculateDominators(BasicBlock &first_block);
+// @brief Calculates dominator edges of a root basic block
+//
+// This function calculates the dominator edges form a root BasicBlock. Uses
+// the dominator algorithm by Cooper et al.
+//
+// @param[in] first_block the root or entry BasicBlock of a function
+//
+// @return a set of dominator edges represented as a pair of blocks
+std::vector< std::pair<BasicBlock*, BasicBlock*> >
+CalculateDominators(const BasicBlock &first_block);
+
+// @brief Updates the immediate dominator for each of the block edges
+//
+// Updates the immediate dominator of the blocks for each of the edges
+// provided by the @p dom_edges parameter
+//
+// @param[in,out] dom_edges The edges of the dominator tree
+void
+UpdateImmediateDominators(std::vector<std::pair<BasicBlock*, BasicBlock*> >& dom_edges);
+
+// @brief Prints all of the dominators of a BasicBlock
+//
+// @param[in] block The dominators of this block will be printed
+void
+printDominatorList(BasicBlock &block);
 
 }  // namespace libspirv
 

--- a/source/validate.h
+++ b/source/validate.h
@@ -131,6 +131,9 @@ class BasicBlock {
   /// Returns the successors of the BasicBlock
   std::vector<BasicBlock*>& get_successors() { return successors_; }
 
+  /// Returns true if the  block should be reachable in the CFG
+  bool is_reachable() { return SpvOpUnreachable != branch_instruction_; }
+
   /// Sets the immedate dominator of this basic block
   ///
   /// @param[in] dom_block The dominator block
@@ -143,10 +146,13 @@ class BasicBlock {
   const BasicBlock* GetImmediateDominator() const;
 
   /// Adds @p next as a successor of this BasicBlock
-  void RegisterSuccessor(BasicBlock& next);
+  void RegisterBranchWithoutSuccessor(SpvOp branch_instruction);
+
+  /// Adds @p next as a successor of this BasicBlock
+  void RegisterSuccessor(BasicBlock& next, SpvOp branch_instruction);
 
   /// Adds @p next BasicBlocks as successors of this BasicBlock
-  void RegisterSuccessor(std::vector<BasicBlock*> next);
+  void RegisterSuccessor(std::vector<BasicBlock*> next, SpvOp branch_instruction);
 
   /// Returns true if the id of the BasicBlock matches
   bool operator==(const BasicBlock& other) const { return other.id_ == id_; }
@@ -206,6 +212,8 @@ class BasicBlock {
 
   /// The function which contains this block
   Function* function_;
+
+  SpvOp branch_instruction_;
 };
 
 /// @brief Returns true if the iterators point to the same element or if both
@@ -283,13 +291,13 @@ class Function {
   spv_result_t RegisterSelectionMerge(uint32_t merge_id);
 
   /// Registers the end of the block
-  spv_result_t RegisterBlockEnd();
+  void RegisterBlockEnd(SpvOp branch_instruction);
 
   /// Registers the end of the block
-  spv_result_t RegisterBlockEnd(uint32_t next_id);
+  void RegisterBlockEnd(uint32_t next_id, SpvOp branch_instruction);
 
   /// Registers the end of the block
-  spv_result_t RegisterBlockEnd(std::vector<uint32_t> next_list);
+  void RegisterBlockEnd(std::vector<uint32_t> next_list, SpvOp branch_instruction);
 
   /// Returns true if the \p merge_block_id is a merge block
   bool IsMergeBlock(uint32_t merge_block_id) const;

--- a/source/validate.h
+++ b/source/validate.h
@@ -115,7 +115,7 @@ class BasicBlock {
   ///
   /// @param[in] id The ID of the basic block
   /// @param[in] module A reference of the module of the basic block
-  BasicBlock(uint32_t id, ValidationState_t& module);
+  BasicBlock(uint32_t id);
 
   /// Returns the id of the BasicBlock
   uint32_t get_id() const { return id_; }
@@ -169,7 +169,10 @@ class BasicBlock {
     /// before the root node of the dominator tree
     DominatorIterator();
 
-    /// @brief Constructs an iterator for the given block which points
+    /// @brief Constructs an iterator for the given block which points to
+    ///        @p block
+    ///
+    /// @param block The block which is referenced by the iterator
     DominatorIterator(BasicBlock* block);
 
     /// @brief Advances the iterator
@@ -185,11 +188,11 @@ class BasicBlock {
     BasicBlock* current_;
   };
 
+  /// Returns an iterator which points to the current block
   DominatorIterator dom_begin();
 
+  /// Returns an iterator which points to one element past the first block
   DominatorIterator dom_end();
-
-  friend std::ostream& operator<<(std::ostream& os, const BasicBlock& other);
 
  private:
   // Id of the BasicBlock
@@ -203,15 +206,18 @@ class BasicBlock {
 
   // The set of successors of the BasicBlock
   std::vector<BasicBlock*> successors_;
-  ValidationState_t& module_;
+
+  // The function which contains this block
   Function* function_;
 };
 
-/// @brief Returns true if the iterators point to the same element
+/// @brief Returns true if the iterators point to the same element or if both
+///        iterators point to the @p dom_end block
 bool operator==(const BasicBlock::DominatorIterator& lhs,
                 const BasicBlock::DominatorIterator& rhs);
 
-/// @brief Returns true if the iterators point to the differet element
+/// @brief Returns true if the iterators point to different elements and they
+///        do not both point to the @p dom_end block
 bool operator!=(const BasicBlock::DominatorIterator& lhs,
                 const BasicBlock::DominatorIterator& rhs);
 
@@ -232,8 +238,6 @@ class CFConstruct {
   BasicBlock* continue_block_;  ///< The continue block of a loop block
  private:
 };
-
-std::ostream& operator<<(std::ostream& os, const BasicBlock& other);
 
 // This class manages all function declaration and definitions in a module. It
 // handles the state and id information while parsing a function in the SPIR-V

--- a/source/validate.h
+++ b/source/validate.h
@@ -45,25 +45,15 @@
 #include "spirv_definition.h"
 #include "table.h"
 
-// clang-format off
-#define _printf_  printf
-#define MSG(msg,...) do {                       \
-    _printf_(__FILE__":%d: " msg "\n",          \
-             __LINE__, ##__VA_ARGS__);          \
+#define MSG(msg)                                        \
+  do {                                                  \
+    libspirv::message(__FILE__, size_t(__LINE__), msg); \
   } while (0)
 
-#ifdef DEBUG
-#define MSG_DBG      MSG
-#else
-#define MSG_DBG(...) do { /* nothing */ } while (0)
-#endif
-
-
-#define SHOW(exp)   do { MSG("%s  %ld",   #exp, (long)exp);   } while (0)
-#define SHOW_P(ptr) do { MSG("%s  %#zx",  #ptr, (size_t)ptr); } while (0)
-#define SHOW_F(exp) do { MSG("%s  %g",    #exp, (double)exp); } while (0)
-#define SHOW_S(exp) do { MSG("%s  %s",    #exp, exp);         } while (0)
-// clang-format on
+#define SHOW(exp)                                               \
+  do {                                                          \
+    libspirv::message(__FILE__, size_t(__LINE__), #exp, (exp)); \
+  } while (0)
 
 // Structures
 
@@ -80,6 +70,13 @@ typedef struct spv_id_info_t {
 } spv_id_info_t;
 
 namespace libspirv {
+
+void message(std::string file, size_t line, std::string name);
+
+template<typename T>
+void message(std::string file, size_t line, std::string name, T val) {
+  std::cout << file << ":" << line << ": " << name << " " << val << std::endl;
+}
 
 // This enum represents the sections of a SPIRV module. See section 2.4
 // of the SPIRV spec for additional details of the order. The enumerant values

--- a/source/validate_cfg.cpp
+++ b/source/validate_cfg.cpp
@@ -294,7 +294,7 @@ spv_result_t CfgPass(ValidationState_t& _,
       uint32_t target = inst->words[inst->operands[0].offset];
       CFG_ASSERT(FirstBlockAssert, target);
 
-      _.get_current_function().RegisterBlockEnd(target, opcode);
+      _.get_current_function().RegisterBlockEnd({target}, opcode);
     } break;
     case SpvOpBranchConditional: {
       uint32_t tlabel = inst->words[inst->operands[1].offset];
@@ -312,13 +312,13 @@ spv_result_t CfgPass(ValidationState_t& _,
         CFG_ASSERT(FirstBlockAssert, target);
         cases.push_back(target);
       }
-      _.get_current_function().RegisterBlockEnd(cases, opcode);
+      _.get_current_function().RegisterBlockEnd({cases}, opcode);
     } break;
     case SpvOpKill:
     case SpvOpReturn:
     case SpvOpReturnValue:
     case SpvOpUnreachable:
-      _.get_current_function().RegisterBlockEnd(opcode);
+      _.get_current_function().RegisterBlockEnd({}, opcode);
       break;
     default:
       break;

--- a/source/validate_cfg.cpp
+++ b/source/validate_cfg.cpp
@@ -198,16 +198,16 @@ MergeBlockAssert(ValidationState_t& _, uint32_t merge_block) {
 }
 
 spv_result_t PerformCfgChecks(ValidationState_t& _) {
-  //vstate.get_functions().printDotGraph();
   for(auto& function : _.get_functions()) {
+
     // Updates each blocks immediate dominators
     if(auto* first_block = function.get_first_block()) {
       auto edges = libspirv::CalculateDominators(*first_block);
       libspirv::UpdateImmediateDominators(edges);
     }
 
-    // Check the order of blocks in the binary appear dominators appear before
-    // the blocks they dominate
+    // Check if the order of blocks in the binary appear before the blocks they
+    // dominate
     auto& blocks = function.get_blocks();
     for(size_t i = 1; i < blocks.size(); i++) {
       auto block = blocks[i];
@@ -246,12 +246,19 @@ spv_result_t PerformCfgChecks(ValidationState_t& _) {
           << " doesn't dominate its merge block " << _.getIdName(merge->get_id());
       }
     }
+
+    // TODO(umar): All CFG back edges must branch to a loop header, with each
+    // loop header having exactly one back edge branching to it
+
+    // TODO(umar): For a given loop, its back-edge block must post dominate the
+    // OpLoopMerge's Continue Target, and that Continue Target must dominate the
+    // back-edge block
+
+
   }
   return SPV_SUCCESS;
 }
 
-// TODO(umar): Support for merge instructions
-// TODO(umar): Structured control flow checks
 spv_result_t CfgPass(ValidationState_t& _,
                      const spv_parsed_instruction_t* inst) {
   SpvOp opcode = static_cast<SpvOp>(inst->opcode);

--- a/source/validate_cfg.cpp
+++ b/source/validate_cfg.cpp
@@ -32,6 +32,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
+#include <vector>
 
 using std::find;
 using std::get;
@@ -93,13 +94,13 @@ vector<const BasicBlock*> PostOrderSort(const BasicBlock& entry, size_t size) {
   }
   return out;
 }
-}
+}  // namespace
 
 vector<pair<BasicBlock*, BasicBlock*>> CalculateDominators(
     const BasicBlock& first_block) {
   struct block_detail {
-    size_t dominator; ///< The index of the blocks's dominator in the post order array
-    size_t postorder_index;///< The index of the block in the post order array
+    size_t dominator;  ///< The index of blocks's dominator in post order array
+    size_t postorder_index;  ///< The index of the block in the post order array
   };
 
   vector<cbb_ptr> postorder = PostOrderSort(first_block, 10);
@@ -324,4 +325,4 @@ spv_result_t CfgPass(ValidationState_t& _,
   }
   return SPV_SUCCESS;
 }
-}
+}  // namespace libspirv

--- a/source/validate_cfg.cpp
+++ b/source/validate_cfg.cpp
@@ -98,8 +98,8 @@ vector<const BasicBlock*> PostOrderSort(const BasicBlock& entry, size_t size) {
 vector<pair<BasicBlock*, BasicBlock*>> CalculateDominators(
     const BasicBlock& first_block) {
   struct block_detail {
-    size_t dominator;
-    size_t postorder_index;
+    size_t dominator; ///< The index of the blocks's dominator in the post order array
+    size_t postorder_index;///< The index of the block in the post order array
   };
 
   vector<cbb_ptr> postorder = PostOrderSort(first_block, 10);

--- a/source/validate_cfg.cpp
+++ b/source/validate_cfg.cpp
@@ -24,32 +24,195 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 
+#include "validate.h"
 #include "validate_passes.h"
 
+#include <algorithm>
+#include <tuple>
+#include <unordered_map>
+
+using std::get;
+using std::vector;
+using std::transform;
+using std::tuple;
+using std::make_tuple;
+using std::unordered_map;
+using libspirv::BasicBlock;
+
 namespace libspirv {
+
+namespace {
+
+using bb_ptr = BasicBlock *;
+using bb_iter = vector<BasicBlock *>::iterator;
+enum                    {kBlock, kIter  , kEnd };
+using stack_info = tuple<bb_ptr, bb_iter, bb_iter>;
+
+stack_info CreateStack(BasicBlock &block) {
+  return make_tuple(&block, begin(block.get_out_blocks()),
+                    end(block.get_out_blocks()));
+}
+
+template <typename T>
+bool Contains(vector<T> &vec, T val) {
+  return find(begin(vec), end(vec), val) == end(vec);
+}
+}
+
+vector<BasicBlock*>
+PostOrderSort(BasicBlock &entry, size_t size) {
+  vector<bb_ptr> out;
+  vector<stack_info> stack;
+  vector<uint32_t> processed;
+
+  stack.reserve(size);
+  stack.emplace_back(CreateStack(entry));
+  processed.push_back(entry.get_id());
+
+  while (!stack.empty()) {
+    stack_info &top = stack.back();
+    if (get<kIter>(top) == get<kEnd>(top)) {
+      // No children left to process
+      out.push_back(get<kBlock>(top));
+      stack.pop_back();
+    } else {
+      bb_iter &child_iter = get<kIter>(top);
+
+      if (Contains(processed, (*child_iter)->get_id())) {
+        // Process next child
+        stack.emplace_back(CreateStack(**child_iter));
+        processed.push_back((*child_iter)->get_id());
+      }
+      child_iter++;
+    }
+  }
+  return out;
+}
+
+  //  *for all nodes, b /* initialize the dominators array */
+  //  *  doms[b] ← Undefined
+  //  *  doms[start node] ← start node
+  //  *  Changed ← true
+  //  *  while (Changed)
+  //  *    Changed ← false
+  //  *      for all nodes, b, in reverse postorder (except start node)
+  //          new idom ← first (processed) predecessor of b /* (pick one) */
+  //          for all other predecessors, p, of b
+  //            if doms[p] = Undefined /* i.e., if doms[p] already calculated */
+  //              new idom ← intersect(p, new idom)
+  //            if doms[b] = new idom
+  //              doms[b] ← new idom
+  //              Changed ← true
+  //    function intersect(b1, b2) returns node
+  //      finger1 ← b1
+  //      finger2 ← b2
+  //      while (finger1 != finger2)
+  //        while (finger1 < finger2)
+  //          finger1 = doms[finger1]
+  //        while (finger2 < finger1)
+  //          finger2 = doms[finger2]
+  //      return finger1
+
+BasicBlock*
+intersect(BasicBlock* b1, BasicBlock* b2) {
+  BasicBlock* finger1 = b1;
+  BasicBlock* finger2 = b2;
+  while(finger1 != finger2) {
+    while (finger1 < finger2) {
+      finger1 = finger1->get_dominators().back();
+    }
+    while (finger2 < finger1) {
+      finger2 = finger2->get_dominators().back();
+    }
+  }
+  return finger1;
+}
+
+void
+CalculateDominators(vector<BasicBlock*> &blocks) {
+  vector<BasicBlock*> post_order = PostOrderSort(*blocks[0], 10);
+  for(auto &block : post_order) {
+    block->get_dominators().clear();
+  }
+  post_order[0]->get_dominators().push_back(post_order[0]);
+  bool changed = true;
+
+  vector<BasicBlock*> pred;
+  pred.push_back(post_order[0]);
+
+  while (changed) {
+    changed = false;
+
+    for(auto b = post_order.rbegin() + 1; b != post_order.rend(); b++) {
+      if(post_order[0] == *b) {
+        continue;
+      }
+      BasicBlock* new_idom = *b;
+      for(auto p = pred.rbegin(); p != pred.rend(); p++) {
+        if((*p)->get_dominators().empty()){
+          new_idom = intersect(*p, new_idom);
+        }
+      }
+    }
+  }
+}
 
 // TODO(umar): Support for merge instructions
 // TODO(umar): Structured control flow checks
 spv_result_t CfgPass(ValidationState_t& _,
                      const spv_parsed_instruction_t* inst) {
-  if (_.getLayoutSection() == kLayoutFunctionDefinitions) {
-    SpvOp opcode = static_cast<SpvOp>(inst->opcode);
-    switch (opcode) {
-      case SpvOpLabel:
-        spvCheckReturn(_.get_functions().RegisterBlock(inst->result_id));
-        break;
-      case SpvOpBranch:
-      case SpvOpBranchConditional:
-      case SpvOpSwitch:
-      case SpvOpKill:
-      case SpvOpReturn:
-      case SpvOpReturnValue:
-      case SpvOpUnreachable:
-        spvCheckReturn(_.get_functions().RegisterBlockEnd());
-        break;
-      default:
-        break;
-    }
+  SpvOp opcode = inst->opcode;
+  switch (opcode) {
+    case SpvOpLabel:
+      spvCheckReturn(_.get_functions().RegisterBlock(inst->result_id));
+      break;
+    case SpvOpLoopMerge: {
+      // TODO(umar): mark current block as a loop header
+      uint32_t merge_block = inst->words[inst->operands[0].offset];
+      uint32_t continue_block = inst->words[inst->operands[1].offset];
+
+      if(_.get_functions().IsMergeBlock(merge_block)) {
+        return _.diag(SPV_ERROR_INVALID_CFG)
+          << "Block " << _.getIdName(merge_block) << " is already a merge block for another header";
+      }
+
+      spvCheckReturn(_.get_functions().RegisterLoopMerge(merge_block, continue_block));
+    } break;
+    case SpvOpSelectionMerge: {
+      uint32_t merge_block = inst->words[inst->operands[0].offset];
+
+      if(_.get_functions().IsMergeBlock(merge_block)) {
+        return _.diag(SPV_ERROR_INVALID_CFG)
+          << "Block " << _.getIdName(merge_block) << " is already a merge block for another header";
+      }
+
+      spvCheckReturn(_.get_functions().RegisterSelectionMerge(merge_block));
+    } break;
+    case SpvOpBranch:
+      spvCheckReturn(_.get_functions().RegisterBlockEnd(inst->words[inst->operands[0].offset]));
+      break;
+    case SpvOpBranchConditional: {
+      uint32_t tlabel = inst->words[inst->operands[1].offset];
+      uint32_t flabel = inst->words[inst->operands[2].offset];
+
+      spvCheckReturn(_.get_functions().RegisterBlockEnd({tlabel, flabel}));
+    } break;
+
+    case SpvOpSwitch: {
+      vector<uint32_t> cases((inst->num_operands - 2) / 2);
+        for(int i = 3; i < inst->num_operands; i += 2) {
+          cases.push_back(inst->words[inst->operands[i].offset]);
+        }
+        spvCheckReturn(_.get_functions().RegisterBlockEnd(cases));
+    } break;
+    case SpvOpKill:
+    case SpvOpReturn:
+    case SpvOpReturnValue:
+    case SpvOpUnreachable:
+      spvCheckReturn(_.get_functions().RegisterBlockEnd());
+      break;
+    default:
+      break;
   }
   return SPV_SUCCESS;
 }

--- a/source/validate_cfg.cpp
+++ b/source/validate_cfg.cpp
@@ -48,46 +48,54 @@ namespace libspirv {
 
 namespace {
 
-using bb_ptr = BasicBlock *;
-using cbb_ptr = const BasicBlock *;
-using bb_iter = vector<BasicBlock *>::const_iterator;
-enum                    {kBlock, kIter  , kEnd };
-using stack_info = tuple<cbb_ptr, bb_iter, bb_iter>;
-
-stack_info CreateStack(const BasicBlock &block) {
-  return make_tuple(&block, begin(block.get_successors()),
-                    end(block.get_successors()));
-}
+using bb_ptr = BasicBlock*;
+using cbb_ptr = const BasicBlock*;
+using bb_iter = vector<BasicBlock*>::const_iterator;
 
 template <typename T>
-bool Contains(const vector<T> &vec, T val) {
-  return find(begin(vec), end(vec), val) == end(vec);
+bool Contains(const vector<T>& vec, T val) {
+  return find(begin(vec), end(vec), val) != end(vec);
 }
 
-}
+/// @brief Sorts the blocks in a CFG given the entry node
+///
+/// Returns a vector of basic block pointers in a Control Flow Graph(CFG) which
+/// are sorted in the order they were accessed in a post order traversal.
+///
+/// @param[in] entry the first block of a CFG
+/// @param[in] depth_hint a hint about the depth of the CFG
+///
+/// @return A vector of pointers in the order they were access in a post order
+/// traversal
+vector<const BasicBlock*> PostOrderSort(const BasicBlock& entry, size_t size) {
+  struct block_info {
+    cbb_ptr block;
+    bb_iter current_successor;
+    bb_iter end_successor;
+  };
 
-vector<const BasicBlock*>
-PostOrderSort(const BasicBlock &entry, size_t size) {
   vector<cbb_ptr> out;
-  vector<stack_info> stack;
+  vector<block_info> staged;
   vector<uint32_t> processed;
 
-  stack.reserve(size);
-  stack.emplace_back(CreateStack(entry));
+  staged.reserve(size);
+  staged.emplace_back(block_info{&entry, begin(entry.get_successors()),
+                                 end(entry.get_successors())});
   processed.push_back(entry.get_id());
 
-  while (!stack.empty()) {
-    stack_info &top = stack.back();
-    if (get<kIter>(top) == get<kEnd>(top)) {
+  while (!staged.empty()) {
+    block_info& top = staged.back();
+    if (top.current_successor == top.end_successor) {
       // No children left to process
-      out.push_back(get<kBlock>(top));
-      stack.pop_back();
+      out.push_back(top.block);
+      staged.pop_back();
     } else {
-      bb_iter &child_iter = get<kIter>(top);
+      bb_iter& child_iter = top.current_successor;
 
-      if (Contains(processed, (*child_iter)->get_id())) {
+      if (!Contains(processed, (*child_iter)->get_id())) {
         // Process next child
-        stack.emplace_back(CreateStack(**child_iter));
+        staged.emplace_back(block_info{*child_iter, begin((*child_iter)->get_successors()),
+              end((*child_iter)->get_successors())});
         processed.push_back((*child_iter)->get_id());
       }
       child_iter++;
@@ -95,76 +103,84 @@ PostOrderSort(const BasicBlock &entry, size_t size) {
   }
   return out;
 }
+}
 
-vector< pair<BasicBlock*, BasicBlock*> >
-CalculateDominators(const BasicBlock &first_block) {
+vector<pair<BasicBlock*, BasicBlock*>>
+CalculateDominators(const BasicBlock& first_block) {
+  struct block_detail {
+    size_t dominator;
+    size_t postorder_index;
+  };
+
   vector<cbb_ptr> postorder = PostOrderSort(first_block, 10);
   const size_t undefined_dom = static_cast<uint32_t>(postorder.size());
 
-  enum block_info           { DOM , INDEX };
-  using block_detail = pair<size_t, size_t>;
-
-  // pair(Block, postorder index of dominator)
   unordered_map<cbb_ptr, block_detail> idoms;
-  for(size_t i = 0; i < postorder.size(); i++) {
-    idoms[postorder[i]] = make_pair(undefined_dom, i);
+  for (size_t i = 0; i < postorder.size(); i++) {
+    idoms[postorder[i]] = {undefined_dom, i};
   }
 
-  get<DOM>(idoms[postorder.back()]) = get<INDEX>(idoms[postorder.back()]);
+  idoms[postorder.back()].dominator = idoms[postorder.back()].postorder_index;
 
   bool changed = true;
   while (changed) {
     changed = false;
-    for(auto b = postorder.rbegin() + 1; b != postorder.rend(); b++) {
-      //printf("processing: %d\n", (*b)->get_id());
-      size_t &b_dom = get<DOM>(idoms[*b]);
+    for (auto b = postorder.rbegin() + 1; b != postorder.rend(); b++) {
+      // printf("processing: %d\n", (*b)->get_id());
+      size_t& b_dom = idoms[*b].dominator;
       const vector<BasicBlock*>& predecessors = (*b)->get_predecessors();
 
       // first processed predecessor
-      BasicBlock* idom = *find_if(begin(predecessors),
-                                      end(predecessors),
-                                      [&idoms, undefined_dom] (BasicBlock* pred) {
-                                        return get<DOM>(idoms[pred]) != undefined_dom;
-                                      });
-      size_t idom_idx = get<INDEX>(idoms[idom]);
+      BasicBlock* idom =
+          *find_if(begin(predecessors), end(predecessors),
+                   [&idoms, undefined_dom](BasicBlock* pred) {
+                     return idoms[pred].dominator != undefined_dom;
+                   });
+      size_t idom_idx = idoms[idom].postorder_index;
 
       // all other predecessors
-      for(auto p : predecessors) {
-        if(idom == p) { continue; }
-        if(get<DOM>(idoms[p]) != undefined_dom) {
-          size_t finger1 = get<INDEX>(idoms[p]);
+      for (auto p : predecessors) {
+        if (idom == p) {
+          continue;
+        }
+        if (idoms[p].dominator != undefined_dom) {
+          size_t finger1 = idoms[p].postorder_index;
           size_t finger2 = idom_idx;
-          while(finger1 != finger2) {
-            while (finger1 < finger2) {finger1 = get<DOM>(idoms[postorder[finger1]]);}
-            while (finger2 < finger1) {finger2 = get<DOM>(idoms[postorder[finger2]]);}
+          while (finger1 != finger2) {
+            while (finger1 < finger2) {
+              finger1 = idoms[postorder[finger1]].dominator;
+            }
+            while (finger2 < finger1) {
+              finger2 = idoms[postorder[finger2]].dominator;
+            }
           }
           idom_idx = finger1;
         }
       }
-      if(b_dom != idom_idx) {
+      if (b_dom != idom_idx) {
         b_dom = idom_idx;
         changed = true;
       }
     }
   }
 
-  vector<pair<bb_ptr, bb_ptr> > out;
-  for(auto idom : idoms) {
-    // NOTE: performing a const cast for convenience usage with UpdateImmediateDominators
+  vector<pair<bb_ptr, bb_ptr>> out;
+  for (auto idom : idoms) {
+    // NOTE: performing a const cast for convenience usage with
+    // UpdateImmediateDominators
     out.push_back({const_cast<BasicBlock*>(get<0>(idom)),
-                   const_cast<BasicBlock*>(postorder[get<DOM>(get<1>(idom))])});
+                   const_cast<BasicBlock*>(postorder[get<1>(idom).dominator])});
   }
   return out;
 }
 
-void
-UpdateImmediateDominators(vector<pair<bb_ptr, bb_ptr> >& dom_edges) {
-  for(auto &edge : dom_edges) {
+void UpdateImmediateDominators(vector<pair<bb_ptr, bb_ptr>>& dom_edges) {
+  for (auto& edge : dom_edges) {
     get<0>(edge)->SetImmediateDominator(get<1>(edge));
   }
 }
 
-void printDominatorList(BasicBlock &b) {
+void printDominatorList(BasicBlock& b) {
   std::cout << b.get_id() << " is dominated by: ";
   const BasicBlock* bb = &b;
   while (bb->GetImmediateDominator() != bb) {
@@ -173,35 +189,34 @@ void printDominatorList(BasicBlock &b) {
   }
 }
 
-#define CFG_ASSERT(ASSERT_FUNC, TARGET)                         \
-  if(spv_result_t rcode = ASSERT_FUNC(_, TARGET)) return rcode
+#define CFG_ASSERT(ASSERT_FUNC, TARGET) \
+  if (spv_result_t rcode = ASSERT_FUNC(_, TARGET)) return rcode
 
-
-spv_result_t
-FirstBlockAssert(ValidationState_t& _, uint32_t target) {
-  if(_.get_current_function().IsFirstBlock(target)) {
+spv_result_t FirstBlockAssert(ValidationState_t& _, uint32_t target) {
+  if (_.get_current_function().IsFirstBlock(target)) {
     return _.diag(SPV_ERROR_INVALID_CFG)
-      << "First block " << _.getIdName(target)
-      << " of funciton "<< _.getIdName(_.get_current_function().get_id())
-      << " is targeted by block " << _.getIdName(_.get_current_function().get_current_block().get_id());
+           << "First block " << _.getIdName(target) << " of funciton "
+           << _.getIdName(_.get_current_function().get_id())
+           << " is targeted by block "
+           << _.getIdName(
+                  _.get_current_function().get_current_block().get_id());
   }
   return SPV_SUCCESS;
 }
 
-spv_result_t
-MergeBlockAssert(ValidationState_t& _, uint32_t merge_block) {
-  if(_.get_current_function().IsMergeBlock(merge_block)) {
+spv_result_t MergeBlockAssert(ValidationState_t& _, uint32_t merge_block) {
+  if (_.get_current_function().IsMergeBlock(merge_block)) {
     return _.diag(SPV_ERROR_INVALID_CFG)
-      << "Block " << _.getIdName(merge_block) << " is already a merge block for another header";
+           << "Block " << _.getIdName(merge_block)
+           << " is already a merge block for another header";
   }
   return SPV_SUCCESS;
 }
 
 spv_result_t PerformCfgChecks(ValidationState_t& _) {
-  for(auto& function : _.get_functions()) {
-
+  for (auto& function : _.get_functions()) {
     // Updates each blocks immediate dominators
-    if(auto* first_block = function.get_first_block()) {
+    if (auto* first_block = function.get_first_block()) {
       auto edges = libspirv::CalculateDominators(*first_block);
       libspirv::UpdateImmediateDominators(edges);
     }
@@ -209,41 +224,43 @@ spv_result_t PerformCfgChecks(ValidationState_t& _) {
     // Check if the order of blocks in the binary appear before the blocks they
     // dominate
     auto& blocks = function.get_blocks();
-    for(size_t i = 1; i < blocks.size(); i++) {
+    for (size_t i = 1; i < blocks.size(); i++) {
       auto block = blocks[i];
       auto idom = block->GetImmediateDominator();
 
       auto this_block = blocks.begin() + i;
-      if(this_block == std::find(begin(blocks), this_block, idom)) {
+      if (this_block == std::find(begin(blocks), this_block, idom)) {
         return _.diag(SPV_ERROR_INVALID_CFG)
-          << "Block " << _.getIdName(block->get_id())
-          << " appears in the binary before its dominator "
-          << _.getIdName(idom->get_id());
+               << "Block " << _.getIdName(block->get_id())
+               << " appears in the binary before its dominator "
+               << _.getIdName(idom->get_id());
       }
     }
 
     // Check all referenced blocks are defined within a function
-    if(function.get_undefined_block_count() != 0) {
+    if (function.get_undefined_block_count() != 0) {
       std::stringstream ss;
       ss << "{";
-      for(auto undefined_block : function.get_undefined_blocks()) {
+      for (auto undefined_block : function.get_undefined_blocks()) {
         ss << _.getIdName(undefined_block) << " ";
       }
       return _.diag(SPV_ERROR_INVALID_CFG)
-        << "Block(s) " << ss.str() << "\b}"
-        << " are referenced but not defined in function "
-        << _.getIdName(function.get_id());
+             << "Block(s) " << ss.str() << "\b}"
+             << " are referenced but not defined in function "
+             << _.getIdName(function.get_id());
     }
 
     // Check all headers dominate their merge blocks
-    for(CFConstruct& construct : function.get_constructs()) {
+    for (CFConstruct& construct : function.get_constructs()) {
       auto header = construct.header_block_;
       auto merge = construct.merge_block_;
 
-      if(merge->dom_end() == std::find(merge->dom_begin(), merge->dom_end(), header)) {
+      if (merge->dom_end() ==
+          std::find(merge->dom_begin(), merge->dom_end(), header)) {
         return _.diag(SPV_ERROR_INVALID_CFG)
-          << "Header block " << _.getIdName(header->get_id())
-          << " doesn't dominate its merge block " << _.getIdName(merge->get_id());
+               << "Header block " << _.getIdName(header->get_id())
+               << " doesn't dominate its merge block "
+               << _.getIdName(merge->get_id());
       }
     }
 
@@ -253,8 +270,6 @@ spv_result_t PerformCfgChecks(ValidationState_t& _) {
     // TODO(umar): For a given loop, its back-edge block must post dominate the
     // OpLoopMerge's Continue Target, and that Continue Target must dominate the
     // back-edge block
-
-
   }
   return SPV_SUCCESS;
 }
@@ -272,13 +287,15 @@ spv_result_t CfgPass(ValidationState_t& _,
       uint32_t continue_block = inst->words[inst->operands[1].offset];
       CFG_ASSERT(MergeBlockAssert, merge_block);
 
-      spvCheckReturn(_.get_current_function().RegisterLoopMerge(merge_block, continue_block));
+      spvCheckReturn(_.get_current_function().RegisterLoopMerge(
+          merge_block, continue_block));
     } break;
     case SpvOpSelectionMerge: {
       uint32_t merge_block = inst->words[inst->operands[0].offset];
       CFG_ASSERT(MergeBlockAssert, merge_block);
 
-      spvCheckReturn(_.get_current_function().RegisterSelectionMerge(merge_block));
+      spvCheckReturn(
+          _.get_current_function().RegisterSelectionMerge(merge_block));
     } break;
     case SpvOpBranch: {
       uint32_t target = inst->words[inst->operands[0].offset];
@@ -292,17 +309,18 @@ spv_result_t CfgPass(ValidationState_t& _,
       CFG_ASSERT(FirstBlockAssert, tlabel);
       CFG_ASSERT(FirstBlockAssert, flabel);
 
-      spvCheckReturn(_.get_current_function().RegisterBlockEnd({tlabel, flabel}));
+      spvCheckReturn(
+          _.get_current_function().RegisterBlockEnd({tlabel, flabel}));
     } break;
 
     case SpvOpSwitch: {
       vector<uint32_t> cases((inst->num_operands - 2) / 2);
-        for(int i = 3; i < inst->num_operands; i += 2) {
-          uint32_t target = inst->words[inst->operands[i].offset];
-          CFG_ASSERT(FirstBlockAssert, target);
-          cases.push_back(target);
-        }
-        spvCheckReturn(_.get_current_function().RegisterBlockEnd(cases));
+      for (int i = 3; i < inst->num_operands; i += 2) {
+        uint32_t target = inst->words[inst->operands[i].offset];
+        CFG_ASSERT(FirstBlockAssert, target);
+        cases.push_back(target);
+      }
+      spvCheckReturn(_.get_current_function().RegisterBlockEnd(cases));
     } break;
     case SpvOpKill:
     case SpvOpReturn:

--- a/source/validate_instruction.cpp
+++ b/source/validate_instruction.cpp
@@ -140,7 +140,7 @@ spv_result_t InstructionPass(ValidationState_t& _,
                << "Variables must have a function[7] storage class inside"
                   " of a function";
       }
-      if(_.get_current_function().isFirstBlock(_.get_current_function().get_current_block().get_id()) == false) {
+      if(_.get_current_function().IsFirstBlock(_.get_current_function().get_current_block().get_id()) == false) {
         return _.diag(SPV_ERROR_INVALID_CFG)
           << "Variables can only be defined in the first block of a function";
       }

--- a/source/validate_instruction.cpp
+++ b/source/validate_instruction.cpp
@@ -120,7 +120,7 @@ spv_result_t InstructionPass(ValidationState_t& _,
                              const spv_parsed_instruction_t* inst) {
   const SpvOp opcode = static_cast<SpvOp>(inst->opcode);
   if (opcode == SpvOpCapability)
-    _.registerCapability(
+    _.RegisterCapability(
         static_cast<SpvCapability>(inst->words[inst->operands[0].offset]));
   if (opcode == SpvOpMemoryModel) {
     _.setAddressingModel(
@@ -140,7 +140,7 @@ spv_result_t InstructionPass(ValidationState_t& _,
                << "Variables must have a function[7] storage class inside"
                   " of a function";
       }
-      if(_.get_functions().isFirstBlock(_.get_functions().get_current_block().get_id()) == false) {
+      if(_.get_current_function().isFirstBlock(_.get_current_function().get_current_block().get_id()) == false) {
         return _.diag(SPV_ERROR_INVALID_CFG)
           << "Variables can only be defined in the first block of a function";
       }

--- a/source/validate_instruction.cpp
+++ b/source/validate_instruction.cpp
@@ -140,6 +140,10 @@ spv_result_t InstructionPass(ValidationState_t& _,
                << "Variables must have a function[7] storage class inside"
                   " of a function";
       }
+      if(_.get_functions().isFirstBlock(_.get_functions().get_current_block().get_id()) == false) {
+        return _.diag(SPV_ERROR_INVALID_CFG)
+          << "Variables can only be defined in the first block of a function";
+      }
     } else {
       if (storage_class == SpvStorageClassFunction) {
         return _.diag(SPV_ERROR_INVALID_LAYOUT)

--- a/source/validate_types.cpp
+++ b/source/validate_types.cpp
@@ -213,6 +213,10 @@ bool IsInstructionInLayoutSection(ModuleLayoutSection layout, SpvOp op) {
 
 namespace libspirv {
 
+void message(std::string file, size_t line, std::string name) {
+  std::cout << file << ":" << line << ": " << name << std::endl;
+}
+
 ValidationState_t::ValidationState_t(spv_diagnostic* diagnostic,
                                      const spv_const_context context)
     : diagnostic_(diagnostic),

--- a/source/validate_types.cpp
+++ b/source/validate_types.cpp
@@ -26,19 +26,20 @@
 
 #include <algorithm>
 #include <cassert>
+#include <iomanip>
+#include <iterator>
+#include <limits>
 #include <map>
 #include <string>
 #include <unordered_set>
 #include <vector>
-#include <iterator>
-#include <iomanip>
 
 #include "spirv/spirv.h"
-
 #include "spirv_definition.h"
 #include "validate.h"
 
 using std::find;
+using std::numeric_limits;
 using std::string;
 using std::unordered_set;
 using std::vector;
@@ -514,11 +515,22 @@ size_t Functions::get_block_count() const { return blocks_.back().size(); }
 
 BasicBlock::BasicBlock(uint32_t id, ValidationState_t& module )
   : id_(id)
-  , immediate_dominator_()
+  , immediate_dominator_(nullptr)
   , predecessors_()
-  , dominators_()
   , out_blocks_()
   , module_(module) {
+}
+
+void BasicBlock::SetImmediateDominator(BasicBlock *dom_block) {
+  immediate_dominator_ = &dom_block;
+}
+
+const BasicBlock* BasicBlock::GetImmediateDominator() const {
+  return immediate_dominator_;
+}
+
+BasicBlock* BasicBlock::GetImmediateDominator(){
+  return immediate_dominator_;
 }
 
 void

--- a/source/validate_types.cpp
+++ b/source/validate_types.cpp
@@ -485,7 +485,7 @@ spv_result_t Functions::RegisterBlockEnd(uint32_t next_id) {
 
   std::unordered_map<uint32_t, BasicBlock>::iterator tmp;
   tie(tmp, std::ignore) = blocks_.back().insert({next_id, BasicBlock(next_id, module_)});
-  current_block_->RegisterNext(tmp->second);
+  current_block_->RegisterSuccessor(tmp->second);
 
   current_block_ = nullptr;
   return SPV_SUCCESS;
@@ -506,7 +506,7 @@ spv_result_t Functions::RegisterBlockEnd(vector<uint32_t> next_list) {
     next_blocks.push_back(&tmp->second);
   }
 
-  current_block_->RegisterNext(next_blocks);
+  current_block_->RegisterSuccessor(next_blocks);
   current_block_ = nullptr;
   return SPV_SUCCESS;
 }
@@ -517,12 +517,12 @@ BasicBlock::BasicBlock(uint32_t id, ValidationState_t& module )
   : id_(id)
   , immediate_dominator_(nullptr)
   , predecessors_()
-  , out_blocks_()
+  , successors_()
   , module_(module) {
 }
 
 void BasicBlock::SetImmediateDominator(BasicBlock *dom_block) {
-  immediate_dominator_ = &dom_block;
+  immediate_dominator_ = dom_block;
 }
 
 const BasicBlock* BasicBlock::GetImmediateDominator() const {
@@ -534,25 +534,25 @@ BasicBlock* BasicBlock::GetImmediateDominator(){
 }
 
 void
-BasicBlock::RegisterNext(BasicBlock& next) {
+BasicBlock::RegisterSuccessor(BasicBlock& next) {
   next.predecessors_.push_back(this);
-  out_blocks_.push_back(&next);
+  successors_.push_back(&next);
 }
 
 void
-BasicBlock::RegisterNext(vector<BasicBlock*> next_blocks) {
+BasicBlock::RegisterSuccessor(vector<BasicBlock*> next_blocks) {
   for(auto &block: next_blocks) {
     block->predecessors_.push_back(this);
-    out_blocks_.push_back(block);
+    successors_.push_back(block);
   }
 }
 
 std::ostream& operator<<(std::ostream& os, const BasicBlock &other) {
   os << other.module_.getIdOrName(other.id_) << " -> {";
-  if(other.out_blocks_.empty()) {
+  if(other.successors_.empty()) {
     os << "end";
   } else {
-    for(auto &block : other.out_blocks_) {
+    for(auto &block : other.successors_) {
       os << other.module_.getIdOrName(block->get_id()) << " ";
     }
   }

--- a/source/validate_types.cpp
+++ b/source/validate_types.cpp
@@ -252,8 +252,7 @@ string ValidationState_t::getIdOrName(uint32_t id) const {
   std::stringstream out;
   if (operand_names_.find(id) != end(operand_names_)) {
     out << operand_names_.at(id);
-  }
-  else {
+  } else {
     out << id;
   }
   return out.str();
@@ -309,9 +308,7 @@ Function& ValidationState_t::get_current_function() {
   return module_functions_.back();
 }
 
-bool ValidationState_t::in_function_body() const {
-  return in_function_;
-}
+bool ValidationState_t::in_function_body() const { return in_function_; }
 
 bool ValidationState_t::in_block() const {
   return module_functions_.back().in_block();
@@ -320,7 +317,8 @@ bool ValidationState_t::in_block() const {
 void ValidationState_t::RegisterCapability(SpvCapability cap) {
   module_capabilities_ |= SPV_CAPABILITY_AS_MASK(cap);
   spv_operand_desc desc;
-  if (SPV_SUCCESS == grammar_.lookupOperand(SPV_OPERAND_TYPE_CAPABILITY, cap, &desc))
+  if (SPV_SUCCESS ==
+      grammar_.lookupOperand(SPV_OPERAND_TYPE_CAPABILITY, cap, &desc))
     libspirv::ForEach(desc->capabilities,
                       [this](SpvCapability c) { RegisterCapability(c); });
 }
@@ -355,42 +353,37 @@ SpvMemoryModel ValidationState_t::getMemoryModel() const {
   return memory_model_;
 }
 
-Function::Function(  uint32_t id, uint32_t result_type_id,
-                     SpvFunctionControlMask function_control,
-                     uint32_t function_type_id,
-                     ValidationState_t& module)
-  : module_(module)
-  , id_(id)
-  , function_type_id_(function_type_id)
-  , result_type_id_(result_type_id)
-  , function_control_(function_control)
-  , declaration_type_(FunctionDecl::kFunctionDeclUnknown)
-  , blocks_()
-  , current_block_(nullptr)
-  , cfg_constructs_()
-  , variable_ids_()
-  , parameter_ids_()
-{
+Function::Function(uint32_t id, uint32_t result_type_id,
+                   SpvFunctionControlMask function_control,
+                   uint32_t function_type_id, ValidationState_t& module)
+    : module_(module),
+      id_(id),
+      function_type_id_(function_type_id),
+      result_type_id_(result_type_id),
+      function_control_(function_control),
+      declaration_type_(FunctionDecl::kFunctionDeclUnknown),
+      blocks_(),
+      current_block_(nullptr),
+      cfg_constructs_(),
+      variable_ids_(),
+      parameter_ids_() {}
 
-}
-
-bool Function::in_block() const {
-  return static_cast<bool>(current_block_);
-}
+bool Function::in_block() const { return static_cast<bool>(current_block_); }
 
 bool Function::IsFirstBlock(uint32_t id) const {
   return *get_first_block() == id;
 }
 
-spv_result_t ValidationState_t::RegisterFunction(uint32_t id, uint32_t ret_type_id,
-                                         SpvFunctionControlMask function_control,
-                                         uint32_t function_type_id) {
+spv_result_t ValidationState_t::RegisterFunction(
+    uint32_t id, uint32_t ret_type_id, SpvFunctionControlMask function_control,
+    uint32_t function_type_id) {
   assert(in_function_ == false &&
          "Function instructions can not be declared in a function");
   assert(in_function_ == false &&
          "Function instructions can not be declared in a function");
   in_function_ = true;
-  module_functions_.emplace_back(id, ret_type_id, function_control, function_type_id, *this);
+  module_functions_.emplace_back(id, ret_type_id, function_control,
+                                 function_type_id, *this);
 
   // TODO(umar): validate function type and type_id
 
@@ -406,7 +399,7 @@ spv_result_t ValidationState_t::RegisterFunctionEnd() {
 }
 
 spv_result_t Function::RegisterFunctionParameter(uint32_t id,
-                                                  uint32_t type_id) {
+                                                 uint32_t type_id) {
   assert(module_.in_function_body() == true &&
          "Function parameter instructions cannot be declared outside of a "
          "function");
@@ -420,19 +413,18 @@ spv_result_t Function::RegisterFunctionParameter(uint32_t id,
 }
 
 spv_result_t Function::RegisterLoopMerge(uint32_t merge_id,
-                                          uint32_t continue_id) {
+                                         uint32_t continue_id) {
   RegisterBlock(merge_id, false);
   RegisterBlock(continue_id, false);
-  cfg_constructs_.emplace_back(&get_current_block(),
-                               &blocks_.at(merge_id), &blocks_.at(continue_id));
+  cfg_constructs_.emplace_back(&get_current_block(), &blocks_.at(merge_id),
+                               &blocks_.at(continue_id));
 
   return SPV_SUCCESS;
 }
 
 spv_result_t Function::RegisterSelectionMerge(uint32_t merge_id) {
   RegisterBlock(merge_id, false);
-  cfg_constructs_.emplace_back(&get_current_block(),
-                               &blocks_.at(merge_id));
+  cfg_constructs_.emplace_back(&get_current_block(), &blocks_.at(merge_id));
   return SPV_SUCCESS;
 }
 
@@ -442,17 +434,17 @@ void Function::printDotGraph() const {
   printf("digraph %s {\n", func_name.c_str());
 
   cout << setw(10) << func_name << " -> "
-       << module_.getIdOrName(get_first_block()->get_id())
-       << endl;
-  for(auto block: blocks_) {
+       << module_.getIdOrName(get_first_block()->get_id()) << endl;
+  for (auto block : blocks_) {
     std::cout << setw(10) << block.second << std::endl;
   }
   printf("}\n");
 }
 
 void Function::printBlocks() const {
-  printf("begin -> %s\n", module_.getIdOrName(get_first_block()->get_id()).c_str());
-  for(auto block: blocks_) {
+  printf("begin -> %s\n",
+         module_.getIdOrName(get_first_block()->get_id()).c_str());
+  for (auto block : blocks_) {
     std::cout << block.second << std::endl;
   }
 }
@@ -464,7 +456,8 @@ spv_result_t Function::RegisterSetFunctionDeclType(FunctionDecl type) {
 }
 
 spv_result_t Function::RegisterBlock(uint32_t id, bool is_definition) {
-  assert(module_.in_function_body() == true && "Blocks can only exsist in functions");
+  assert(module_.in_function_body() == true &&
+         "Blocks can only exsist in functions");
   assert(module_.getLayoutSection() !=
              ModuleLayoutSection::kLayoutFunctionDeclarations &&
          "Function declartions must appear before function definitions");
@@ -474,13 +467,13 @@ spv_result_t Function::RegisterBlock(uint32_t id, bool is_definition) {
   std::unordered_map<uint32_t, BasicBlock>::iterator tmp;
   bool success = false;
   tie(tmp, success) = blocks_.insert({id, BasicBlock(id, module_)});
-  if(is_definition) { // new block definition
+  if (is_definition) {  // new block definition
     assert(in_block() == false && "Blocks cannot be nested");
 
     undefined_blocks_.erase(id);
     current_block_ = &tmp->second;
     ordered_blocks_.push_back(current_block_);
-  } else if (success) { // Block doesn't exsist but this is not a definition
+  } else if (success) {  // Block doesn't exsist but this is not a definition
     undefined_blocks_.insert(id);
   }
 
@@ -505,7 +498,7 @@ spv_result_t Function::RegisterBlockEnd(uint32_t next_id) {
   std::unordered_map<uint32_t, BasicBlock>::iterator tmp;
   bool success;
   tie(tmp, success) = blocks_.insert({next_id, BasicBlock(next_id, module_)});
-  if(success) {
+  if (success) {
     undefined_blocks_.insert(next_id);
   }
   current_block_->RegisterSuccessor(tmp->second);
@@ -525,9 +518,9 @@ spv_result_t Function::RegisterBlockEnd(vector<uint32_t> next_list) {
 
   std::unordered_map<uint32_t, BasicBlock>::iterator tmp;
   bool success;
-  for(uint32_t id : next_list) {
+  for (uint32_t id : next_list) {
     tie(tmp, success) = blocks_.insert({id, BasicBlock(id, module_)});
-    if(success) {
+    if (success) {
       undefined_blocks_.insert(id);
     }
     next_blocks.push_back(&tmp->second);
@@ -540,36 +533,42 @@ spv_result_t Function::RegisterBlockEnd(vector<uint32_t> next_list) {
 
 size_t Function::get_block_count() const { return blocks_.size(); }
 
-size_t Function::get_undefined_block_count() const { return undefined_blocks_.size(); }
+size_t Function::get_undefined_block_count() const {
+  return undefined_blocks_.size();
+}
 
-const vector<BasicBlock*>& Function::get_blocks() const { return ordered_blocks_; }
-      vector<BasicBlock*>& Function::get_blocks()       { return ordered_blocks_; }
+const vector<BasicBlock*>& Function::get_blocks() const {
+  return ordered_blocks_;
+}
+vector<BasicBlock*>& Function::get_blocks() { return ordered_blocks_; }
 
-const BasicBlock& Function::get_current_block() const { return *current_block_; }
-      BasicBlock& Function::get_current_block()       { return *current_block_; }
+const BasicBlock& Function::get_current_block() const {
+  return *current_block_;
+}
+BasicBlock& Function::get_current_block() { return *current_block_; }
 
-const vector<CFConstruct>& Function::get_constructs() const { return cfg_constructs_; }
-      vector<CFConstruct>& Function::get_constructs()       { return cfg_constructs_; }
-
+const vector<CFConstruct>& Function::get_constructs() const {
+  return cfg_constructs_;
+}
+vector<CFConstruct>& Function::get_constructs() { return cfg_constructs_; }
 
 const BasicBlock* Function::get_first_block() const {
-  if(ordered_blocks_.empty()) return nullptr;
+  if (ordered_blocks_.empty()) return nullptr;
   return ordered_blocks_[0];
 }
 BasicBlock* Function::get_first_block() {
-  if(ordered_blocks_.empty()) return nullptr;
+  if (ordered_blocks_.empty()) return nullptr;
   return ordered_blocks_[0];
 }
 
-BasicBlock::BasicBlock(uint32_t id, ValidationState_t& module )
-  : id_(id)
-  , immediate_dominator_(nullptr)
-  , predecessors_()
-  , successors_()
-  , module_(module) {
-}
+BasicBlock::BasicBlock(uint32_t id, ValidationState_t& module)
+    : id_(id),
+      immediate_dominator_(nullptr),
+      predecessors_(),
+      successors_(),
+      module_(module) {}
 
-void BasicBlock::SetImmediateDominator(BasicBlock *dom_block) {
+void BasicBlock::SetImmediateDominator(BasicBlock* dom_block) {
   immediate_dominator_ = dom_block;
 }
 
@@ -577,30 +576,26 @@ const BasicBlock* BasicBlock::GetImmediateDominator() const {
   return immediate_dominator_;
 }
 
-BasicBlock* BasicBlock::GetImmediateDominator(){
-  return immediate_dominator_;
-}
+BasicBlock* BasicBlock::GetImmediateDominator() { return immediate_dominator_; }
 
-void
-BasicBlock::RegisterSuccessor(BasicBlock& next) {
+void BasicBlock::RegisterSuccessor(BasicBlock& next) {
   next.predecessors_.push_back(this);
   successors_.push_back(&next);
 }
 
-void
-BasicBlock::RegisterSuccessor(vector<BasicBlock*> next_blocks) {
-  for(auto &block: next_blocks) {
+void BasicBlock::RegisterSuccessor(vector<BasicBlock*> next_blocks) {
+  for (auto& block : next_blocks) {
     block->predecessors_.push_back(this);
     successors_.push_back(block);
   }
 }
 
-std::ostream& operator<<(std::ostream& os, const BasicBlock &other) {
+std::ostream& operator<<(std::ostream& os, const BasicBlock& other) {
   os << other.module_.getIdOrName(other.id_) << " -> {";
-  if(other.successors_.empty()) {
+  if (other.successors_.empty()) {
     os << "end";
   } else {
-    for(auto &block : other.successors_) {
+    for (auto& block : other.successors_) {
       os << other.module_.getIdOrName(block->get_id()) << " ";
     }
   }
@@ -608,28 +603,25 @@ std::ostream& operator<<(std::ostream& os, const BasicBlock &other) {
   return os;
 }
 
-bool
-Function::IsMergeBlock(uint32_t merge_block_id) const {
-  const auto b =  blocks_.find(merge_block_id);
-  if(b != end(blocks_)) {
-    return cfg_constructs_.end() != find_if(begin(cfg_constructs_), end(cfg_constructs_), [&](const CFConstruct &construct) {
-        return construct.merge_block_ == &b->second;
-      });
-  }
-  else {
+bool Function::IsMergeBlock(uint32_t merge_block_id) const {
+  const auto b = blocks_.find(merge_block_id);
+  if (b != end(blocks_)) {
+    return cfg_constructs_.end() !=
+           find_if(begin(cfg_constructs_), end(cfg_constructs_),
+                   [&](const CFConstruct& construct) {
+                     return construct.merge_block_ == &b->second;
+                   });
+  } else {
     return false;
   }
-
 }
 
-BasicBlock::DominatorIterator::DominatorIterator()
-  : current_(nullptr) {}
+BasicBlock::DominatorIterator::DominatorIterator() : current_(nullptr) {}
 BasicBlock::DominatorIterator::DominatorIterator(BasicBlock* block)
-  : current_(block) {
-}
+    : current_(block) {}
 
 BasicBlock::DominatorIterator& BasicBlock::DominatorIterator::operator++() {
-  if(current_ == current_->GetImmediateDominator()) {
+  if (current_ == current_->GetImmediateDominator()) {
     current_ = nullptr;
   } else {
     current_ = current_->GetImmediateDominator();

--- a/source/validate_types.cpp
+++ b/source/validate_types.cpp
@@ -305,9 +305,7 @@ DiagnosticStream ValidationState_t::diag(spv_result_t error_code) const {
       error_code);
 }
 
-list<Function>& ValidationState_t::get_functions() {
-  return module_functions_;
-}
+list<Function>& ValidationState_t::get_functions() { return module_functions_; }
 
 Function& ValidationState_t::get_current_function() {
   assert(in_function_body());
@@ -342,7 +340,7 @@ bool ValidationState_t::HasAnyOf(spv_capability_mask_t capabilities) const {
   });
   return found;
 }
-	
+
 void ValidationState_t::setAddressingModel(SpvAddressingModel am) {
   addressing_model_ = am;
 }
@@ -377,16 +375,15 @@ Function::Function(uint32_t id, uint32_t result_type_id,
 bool Function::in_block() const { return static_cast<bool>(current_block_); }
 
 bool Function::IsFirstBlock(uint32_t id) const {
-  return *get_first_block() == id;
+  return !ordered_blocks_.empty() && *get_first_block() == id;
 }
 
 spv_result_t ValidationState_t::RegisterFunction(
     uint32_t id, uint32_t ret_type_id, SpvFunctionControlMask function_control,
     uint32_t function_type_id) {
-  assert(in_function_ == false &&
-         "Function instructions can not be declared in a function");
-  assert(in_function_ == false &&
-         "Function instructions can not be declared in a function");
+  assert(in_function_body() == false &&
+         "RegisterFunction can only be called when parsing the binary outside "
+         "of another function");
   in_function_ = true;
   module_functions_.emplace_back(id, ret_type_id, function_control,
                                  function_type_id, *this);
@@ -398,8 +395,11 @@ spv_result_t ValidationState_t::RegisterFunction(
 
 spv_result_t ValidationState_t::RegisterFunctionEnd() {
   assert(in_function_body() == true &&
-         "Function end can only be called in functions");
-  assert(in_block() == false && "Function end cannot be called inside a block");
+         "RegisterFunctionEnd can only be called when parsing the binary "
+         "inside of another function");
+  assert(in_block() == false &&
+         "RegisterFunctionParameter can only be called when parsing the binary "
+         "ouside of a block");
   in_function_ = false;
   return SPV_SUCCESS;
 }
@@ -407,10 +407,11 @@ spv_result_t ValidationState_t::RegisterFunctionEnd() {
 spv_result_t Function::RegisterFunctionParameter(uint32_t id,
                                                  uint32_t type_id) {
   assert(module_.in_function_body() == true &&
-         "Function parameter instructions cannot be declared outside of a "
-         "function");
+         "RegisterFunctionParameter can only be called when parsing the binary "
+         "outside of another function");
   assert(in_block() == false &&
-         "Function parameters cannot be called in blocks");
+         "RegisterFunctionParameter can only be called when parsing the binary "
+         "ouside of a block");
   // TODO(umar): Validate function parameter type order and count
   // TODO(umar): Use these variables to validate parameter type
   (void)id;
@@ -443,12 +444,13 @@ void printDot(const BasicBlock& other, const ValidationState_t& module) {
       block_string += module.getIdOrName(block->get_id()) + " ";
     }
   }
-  printf("%10s -> {%s\b}\n", module.getIdOrName(other.get_id()).c_str(), block_string.c_str());
+  printf("%10s -> {%s\b}\n", module.getIdOrName(other.get_id()).c_str(),
+         block_string.c_str());
 }
 
 void Function::printDotGraph() const {
   using namespace std;
-  if(get_first_block()) {
+  if (get_first_block()) {
     string func_name(module_.getIdOrName(id_));
     printf("digraph %s {\n", func_name.c_str());
     printBlocks();
@@ -457,9 +459,9 @@ void Function::printDotGraph() const {
 }
 
 void Function::printBlocks() const {
-  if(get_first_block()) {
-    printf("%10s -> %s\n",
-           module_.getIdOrName(id_).c_str() , module_.getIdOrName(get_first_block()->get_id()).c_str());
+  if (get_first_block()) {
+    printf("%10s -> %s\n", module_.getIdOrName(id_).c_str(),
+           module_.getIdOrName(get_first_block()->get_id()).c_str());
     for (const auto& block : blocks_) {
       printDot(block.second, module_);
     }
@@ -474,23 +476,27 @@ spv_result_t Function::RegisterSetFunctionDeclType(FunctionDecl type) {
 
 spv_result_t Function::RegisterBlock(uint32_t id, bool is_definition) {
   assert(module_.in_function_body() == true &&
-         "Blocks can only exsist in functions");
+         "RegisterBlocks can only be called when parsing a binary inside of a "
+         "function");
   assert(module_.getLayoutSection() !=
              ModuleLayoutSection::kLayoutFunctionDeclarations &&
-         "Function declartions must appear before function definitions");
-  assert(declaration_type_ == FunctionDecl::kFunctionDeclDefinition &&
-         "Function declaration type should have already been defined");
+         "RegisterBlocks cannot be called within a function declaration");
+  assert(
+      declaration_type_ == FunctionDecl::kFunctionDeclDefinition &&
+      "RegisterBlocks can only be called after declaration_type_ is defined");
 
-  std::unordered_map<uint32_t, BasicBlock>::iterator tmp;
+  std::unordered_map<uint32_t, BasicBlock>::iterator inserted_block;
   bool success = false;
-  tie(tmp, success) = blocks_.insert({id, BasicBlock(id)});
+  tie(inserted_block, success) = blocks_.insert({id, BasicBlock(id)});
   if (is_definition) {  // new block definition
-    assert(in_block() == false && "Blocks cannot be nested");
+    assert(in_block() == false &&
+           "Register Block can only be called when parsing a binary outside of "
+           "a BasicBlock");
 
     undefined_blocks_.erase(id);
-    current_block_ = &tmp->second;
-    if(ordered_blocks_.empty()) current_block_->set_reachability(true);
+    current_block_ = &inserted_block->second;
     ordered_blocks_.push_back(current_block_);
+    if (IsFirstBlock(id)) current_block_->set_reachability(true);
   } else if (success) {  // Block doesn't exsist but this is not a definition
     undefined_blocks_.insert(id);
   }
@@ -500,52 +506,61 @@ spv_result_t Function::RegisterBlock(uint32_t id, bool is_definition) {
 
 void Function::RegisterBlockEnd(SpvOp branch_instruction) {
   assert(module_.in_function_body() == true &&
-         "Branch instruction can only be called in a function");
+         "RegisterFunction can only be called when parsing the binary inside "
+         "of a function");
   assert(in_block() == true &&
-         "Branch instruction can only be called in a block");
+         "RegisterBlockEnd can only be called when parsing the binary inside "
+         "of a block");
 
-  current_block_->RegisterBranchWithoutSuccessor(branch_instruction);
+  current_block_->RegisterBranchInstruction(branch_instruction);
   current_block_ = nullptr;
   return;
 }
 
 void Function::RegisterBlockEnd(uint32_t next_id, SpvOp branch_instruction) {
   assert(module_.in_function_body() == true &&
-         "Branch instruction can only be called in a function");
-  assert(in_block() == true &&
-         "Branch instruction can only be called in a block");
+         "RegisterBlockEnd can only be called when parsing a binary in a "
+         "function");
+  assert(
+      in_block() == true &&
+      "RegisterBlockEnd can only be called when parsing a binary in a block");
 
-  std::unordered_map<uint32_t, BasicBlock>::iterator tmp;
+  std::unordered_map<uint32_t, BasicBlock>::iterator inserted_block;
   bool success;
-  tie(tmp, success) = blocks_.insert({next_id, BasicBlock(next_id)});
+  tie(inserted_block, success) = blocks_.insert({next_id, BasicBlock(next_id)});
   if (success) {
     undefined_blocks_.insert(next_id);
   }
-  current_block_->RegisterSuccessor(tmp->second, branch_instruction);
+  current_block_->RegisterBranchInstruction(branch_instruction);
+  current_block_->RegisterSuccessor({&inserted_block->second});
   current_block_ = nullptr;
   return;
 }
 
-void Function::RegisterBlockEnd(vector<uint32_t> next_list, SpvOp branch_instruction) {
+void Function::RegisterBlockEnd(vector<uint32_t> next_list,
+                                SpvOp branch_instruction) {
   assert(module_.in_function_body() == true &&
-         "Branch instruction can only be called in a function");
-  assert(in_block() == true &&
-         "Branch instruction can only be called in a block");
+         "RegisterBlockEnd can only be called when parsing a binary in a "
+         "function");
+  assert(
+      in_block() == true &&
+      "RegisterBlockEnd can only be called when parsing a binary in a block");
 
   vector<BasicBlock*> next_blocks;
   next_blocks.reserve(next_list.size());
 
-  std::unordered_map<uint32_t, BasicBlock>::iterator tmp;
+  std::unordered_map<uint32_t, BasicBlock>::iterator inserted_block;
   bool success;
   for (uint32_t id : next_list) {
-    tie(tmp, success) = blocks_.insert({id, BasicBlock(id)});
+    tie(inserted_block, success) = blocks_.insert({id, BasicBlock(id)});
     if (success) {
       undefined_blocks_.insert(id);
     }
-    next_blocks.push_back(&tmp->second);
+    next_blocks.push_back(&inserted_block->second);
   }
 
-  current_block_->RegisterSuccessor(next_blocks, branch_instruction);
+  current_block_->RegisterBranchInstruction(branch_instruction);
+  current_block_->RegisterSuccessor(next_blocks);
   current_block_ = nullptr;
   return;
 }
@@ -597,27 +612,16 @@ const BasicBlock* BasicBlock::GetImmediateDominator() const {
 
 BasicBlock* BasicBlock::GetImmediateDominator() { return immediate_dominator_; }
 
-void BasicBlock::RegisterSuccessor(BasicBlock& next, SpvOp branch_instruction) {
-  next.predecessors_.push_back(this);
-  successors_.push_back(&next);
-  branch_instruction_ = branch_instruction;
-  if(next.reachable_ == false)
-    next.set_reachability(reachable_);
-}
-
-void BasicBlock::RegisterSuccessor(vector<BasicBlock*> next_blocks, SpvOp branch_instruction) {
+void BasicBlock::RegisterSuccessor(vector<BasicBlock*> next_blocks) {
   for (auto& block : next_blocks) {
     block->predecessors_.push_back(this);
     successors_.push_back(block);
-    branch_instruction_ = branch_instruction;
-    if(block->reachable_ == false)
-      block->set_reachability(reachable_);
+    if (block->reachable_ == false) block->set_reachability(reachable_);
   }
 }
 
-void BasicBlock::RegisterBranchWithoutSuccessor(SpvOp branch_instruction) {
-  if(branch_instruction == SpvOpUnreachable) reachable_ = false;
-  branch_instruction_ = branch_instruction;
+void BasicBlock::RegisterBranchInstruction(SpvOp branch_instruction) {
+  if (branch_instruction == SpvOpUnreachable) reachable_ = false;
   return;
 }
 
@@ -655,10 +659,9 @@ BasicBlock::DominatorIterator BasicBlock::dom_begin() {
   return DominatorIterator(this);
 }
 
-
 const BasicBlock::DominatorIterator BasicBlock::dom_end() const {
-    return DominatorIterator();
-  }
+  return DominatorIterator();
+}
 
 BasicBlock::DominatorIterator BasicBlock::dom_end() {
   return DominatorIterator();
@@ -674,5 +677,7 @@ bool operator!=(const BasicBlock::DominatorIterator& lhs,
   return !(lhs == rhs);
 }
 
-const BasicBlock*& BasicBlock::DominatorIterator::operator*() { return current_; }
+const BasicBlock*& BasicBlock::DominatorIterator::operator*() {
+  return current_;
+}
 }

--- a/source/validate_types.cpp
+++ b/source/validate_types.cpp
@@ -531,7 +531,7 @@ void Function::RegisterBlockEnd(uint32_t next_id, SpvOp branch_instruction) {
     undefined_blocks_.insert(next_id);
   }
   current_block_->RegisterBranchInstruction(branch_instruction);
-  current_block_->RegisterSuccessor({&inserted_block->second});
+  current_block_->RegisterSuccessors({&inserted_block->second});
   current_block_ = nullptr;
   return;
 }
@@ -559,7 +559,7 @@ void Function::RegisterBlockEnd(vector<uint32_t> next_list,
   }
 
   current_block_->RegisterBranchInstruction(branch_instruction);
-  current_block_->RegisterSuccessor(next_blocks);
+  current_block_->RegisterSuccessors(next_blocks);
   current_block_ = nullptr;
   return;
 }
@@ -611,7 +611,7 @@ const BasicBlock* BasicBlock::GetImmediateDominator() const {
 
 BasicBlock* BasicBlock::GetImmediateDominator() { return immediate_dominator_; }
 
-void BasicBlock::RegisterSuccessor(vector<BasicBlock*> next_blocks) {
+void BasicBlock::RegisterSuccessors(vector<BasicBlock*> next_blocks) {
   for (auto& block : next_blocks) {
     block->predecessors_.push_back(this);
     successors_.push_back(block);

--- a/source/validate_types.cpp
+++ b/source/validate_types.cpp
@@ -449,7 +449,6 @@ void printDot(const BasicBlock& other, const ValidationState_t& module) {
 }
 
 void Function::printDotGraph() const {
-  using namespace std;
   if (get_first_block()) {
     string func_name(module_.getIdOrName(id_));
     printf("digraph %s {\n", func_name.c_str());
@@ -680,4 +679,4 @@ bool operator!=(const BasicBlock::DominatorIterator& lhs,
 const BasicBlock*& BasicBlock::DominatorIterator::operator*() {
   return current_;
 }
-}
+}  // namespace libspirv

--- a/source/validate_types.cpp
+++ b/source/validate_types.cpp
@@ -606,7 +606,6 @@ void BasicBlock::RegisterSuccessor(vector<BasicBlock*> next_blocks) {
   }
 }
 
-
 bool Function::IsMergeBlock(uint32_t merge_block_id) const {
   const auto b = blocks_.find(merge_block_id);
   if (b != end(blocks_)) {

--- a/source/validate_types.cpp
+++ b/source/validate_types.cpp
@@ -503,39 +503,6 @@ spv_result_t Function::RegisterBlock(uint32_t id, bool is_definition) {
   return SPV_SUCCESS;
 }
 
-void Function::RegisterBlockEnd(SpvOp branch_instruction) {
-  assert(module_.in_function_body() == true &&
-         "RegisterFunction can only be called when parsing the binary inside "
-         "of a function");
-  assert(in_block() == true &&
-         "RegisterBlockEnd can only be called when parsing the binary inside "
-         "of a block");
-
-  current_block_->RegisterBranchInstruction(branch_instruction);
-  current_block_ = nullptr;
-  return;
-}
-
-void Function::RegisterBlockEnd(uint32_t next_id, SpvOp branch_instruction) {
-  assert(module_.in_function_body() == true &&
-         "RegisterBlockEnd can only be called when parsing a binary in a "
-         "function");
-  assert(
-      in_block() == true &&
-      "RegisterBlockEnd can only be called when parsing a binary in a block");
-
-  std::unordered_map<uint32_t, BasicBlock>::iterator inserted_block;
-  bool success;
-  tie(inserted_block, success) = blocks_.insert({next_id, BasicBlock(next_id)});
-  if (success) {
-    undefined_blocks_.insert(next_id);
-  }
-  current_block_->RegisterBranchInstruction(branch_instruction);
-  current_block_->RegisterSuccessors({&inserted_block->second});
-  current_block_ = nullptr;
-  return;
-}
-
 void Function::RegisterBlockEnd(vector<uint32_t> next_list,
                                 SpvOp branch_instruction) {
   assert(module_.in_function_body() == true &&

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -85,6 +85,7 @@ if (NOT ${SPIRV_SKIP_EXECUTABLES})
       ${CMAKE_CURRENT_SOURCE_DIR}/UnitSPIRV.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/ValidateFixtures.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/Validate.Capability.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/Validate.CFG.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/Validate.Layout.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/Validate.Storage.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/Validate.SSA.cpp

--- a/test/UnitSPIRV.h
+++ b/test/UnitSPIRV.h
@@ -31,15 +31,15 @@
 
 #include <iomanip>
 
-#include "source/assembly_grammar.h"
-#include "source/binary.h"
-#include "source/diagnostic.h"
-#include "source/opcode.h"
-#include "source/spirv_endian.h"
-#include "source/text.h"
-#include "source/text_handler.h"
-#include "source/validate.h"
-#include "spirv-tools/libspirv.h"
+#include <source/assembly_grammar.h>
+#include <source/binary.h>
+#include <source/diagnostic.h>
+#include <source/opcode.h>
+#include <source/spirv_endian.h>
+#include <source/text.h>
+#include <source/text_handler.h>
+#include <source/validate.h>
+#include <spirv-tools/libspirv.h>
 
 #include <gtest/gtest.h>
 

--- a/test/Validate.CFG.cpp
+++ b/test/Validate.CFG.cpp
@@ -305,6 +305,7 @@ TEST_F(ValidateCFG, VariableNotInFirstBlockBad) {
 
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("first block"));
 }
 
 TEST_F(ValidateCFG, DISABLED_NonInlineBlock) {
@@ -350,7 +351,7 @@ TEST_F(ValidateCFG, MergeBlockTargetedByMultipleHeaderBlocksBad) {
       "OpSelectionMerge %merge None\n");
 
   string str = header
-             + nameOps(make_pair("func", "Main"))
+             + nameOps("merge", make_pair("func", "Main"))
              + types_consts
              + "%func    = OpFunction %voidt None %funct\n";
 
@@ -365,6 +366,7 @@ TEST_F(ValidateCFG, MergeBlockTargetedByMultipleHeaderBlocksBad) {
 
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("merge"));
 }
 
 TEST_F(ValidateCFG, BranchTargetFirstBlockBad) {
@@ -382,6 +384,7 @@ TEST_F(ValidateCFG, BranchTargetFirstBlockBad) {
 
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("First block"));
 }
 
 TEST_F(ValidateCFG, BranchConditionalTrueTargetFirstBlockBad) {
@@ -407,6 +410,7 @@ TEST_F(ValidateCFG, BranchConditionalTrueTargetFirstBlockBad) {
 
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("First block"));
 }
 
 TEST_F(ValidateCFG, BranchConditionalFalseTargetFirstBlockBad) {
@@ -431,6 +435,7 @@ TEST_F(ValidateCFG, BranchConditionalFalseTargetFirstBlockBad) {
 
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("First block"));
 }
 
 TEST_F(ValidateCFG, SwitchTargetFirstBlockBad) {
@@ -461,6 +466,7 @@ TEST_F(ValidateCFG, SwitchTargetFirstBlockBad) {
 
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("First block"));
 }
 
 }

--- a/test/Validate.CFG.cpp
+++ b/test/Validate.CFG.cpp
@@ -154,7 +154,7 @@ TEST_F(ValidateCFG, PostOrderLinear) {
                           ScopedContext(SPV_ENV_UNIVERSAL_1_0).context);
 
   for (int i = 0; i < 7; i++) {
-    blocks.emplace_back(i, state);
+    blocks.emplace_back(i);
   }
 
   for (int i = 0; i < 6; i++) {
@@ -175,7 +175,7 @@ TEST_F(ValidateCFG, PostOrderWithCycle) {
                           ScopedContext(SPV_ENV_UNIVERSAL_1_0).context);
 
   for (int i = 0; i < 7; i++) {
-    blocks.emplace_back(i, state);
+    blocks.emplace_back(i);
   }
 
   blocks[0].RegisterSuccessor({&blocks[1]});
@@ -204,7 +204,7 @@ TEST_F(ValidateCFG, PostOrderWithSwitch) {
                           ScopedContext(SPV_ENV_UNIVERSAL_1_0).context);
 
   for (int i = 0; i < 7; i++) {
-    blocks.emplace_back(i, state);
+    blocks.emplace_back(i);
   }
 
   blocks[0].RegisterSuccessor({&blocks[1]});

--- a/test/Validate.CFG.cpp
+++ b/test/Validate.CFG.cpp
@@ -40,6 +40,7 @@
 #include "UnitSPIRV.h"
 #include "source/validate.h"
 #include "ValidateFixtures.h"
+#include "TestFixture.h"
 #include "source/diagnostic.h"
 
 using std::array;
@@ -57,6 +58,8 @@ using libspirv::ValidationState_t;
 using ValidateCFG = spvtest::ValidateBase<bool>;
 
 using libspirv::BasicBlock;
+using spvtest::ScopedContext;
+
 namespace libspirv {
 vector<const BasicBlock *> PostOrderSort(const BasicBlock &entry,
                                          size_t size = 10);
@@ -149,7 +152,7 @@ Block &operator>>(Block &lhs, Block &successor) {
 
 TEST_F(ValidateCFG, PostOrderLinear) {
   vector<BasicBlock> blocks;
-  ValidationState_t state(nullptr, context_);
+  ValidationState_t state(nullptr, ScopedContext().context);
 
   for (int i = 0; i < 7; i++) {
     blocks.emplace_back(i, state);
@@ -169,7 +172,7 @@ TEST_F(ValidateCFG, PostOrderLinear) {
 
 TEST_F(ValidateCFG, PostOrderWithCycle) {
   vector<BasicBlock> blocks;
-  ValidationState_t state(nullptr, context_);
+  ValidationState_t state(nullptr, ScopedContext().context);
 
   for (int i = 0; i < 7; i++) {
     blocks.emplace_back(i, state);
@@ -197,7 +200,7 @@ TEST_F(ValidateCFG, PostOrderWithCycle) {
 
 TEST_F(ValidateCFG, PostOrderWithSwitch) {
   vector<BasicBlock> blocks;
-  ValidationState_t state(nullptr, context_);
+  ValidationState_t state(nullptr, ScopedContext().context);
 
   for (int i = 0; i < 7; i++) {
     blocks.emplace_back(i, state);

--- a/test/Validate.CFG.cpp
+++ b/test/Validate.CFG.cpp
@@ -44,10 +44,10 @@
 #include "source/validate.h"
 
 using std::array;
+using std::make_pair;
 using std::pair;
 using std::string;
 using std::stringstream;
-using std::tie;
 using std::vector;
 
 using ::testing::HasSubstr;
@@ -260,7 +260,7 @@ TEST_F(ValidateCFG, Default) {
       "OpLoopMerge %merge %cont None\n");
 
   string str = header +
-               nameOps("loop", "first", "cont", "merge", tie("func", "Main")) +
+               nameOps("loop", "first", "cont", "merge", make_pair("func", "Main")) +
                types_consts + "%func    = OpFunction %voidt None %funct\n";
 
   str += first >> loop;
@@ -279,7 +279,7 @@ TEST_F(ValidateCFG, Variable) {
 
   entry.setBody("%var = OpVariable %ptrt Function\n");
 
-  string str = header + nameOps(tie("func", "Main")) + types_consts +
+  string str = header + nameOps(make_pair("func", "Main")) + types_consts +
                " %func    = OpFunction %voidt None %funct\n";
   str += entry >> cont;
   str += cont >> exit;
@@ -297,7 +297,7 @@ TEST_F(ValidateCFG, VariableNotInFirstBlockBad) {
   // This operation should only be performed in the entry block
   cont.setBody("%var = OpVariable %ptrt Function\n");
 
-  string str = header + nameOps(tie("func", "Main")) + types_consts +
+  string str = header + nameOps(make_pair("func", "Main")) + types_consts +
                " %func    = OpFunction %voidt None %funct\n";
 
   str += entry >> cont;
@@ -319,7 +319,7 @@ TEST_F(ValidateCFG, BlockAppearsBeforeDominatorBad) {
       " %cond    = OpSLessThan %intt %one %two\n"
       "OpSelectionMerge %merge None\n");
 
-  string str = header + nameOps("cont", "branch", tie("func", "Main")) +
+  string str = header + nameOps("cont", "branch", make_pair("func", "Main")) +
                types_consts + "%func    = OpFunction %voidt None %funct\n";
 
   str += entry >> branch;
@@ -353,7 +353,7 @@ TEST_F(ValidateCFG, MergeBlockTargetedByMultipleHeaderBlocksBad) {
       " %cond1   = OpSLessThan %intt %one %two\n"
       "OpSelectionMerge %merge None\n");
 
-  string str = header + nameOps("merge", tie("func", "Main")) + types_consts +
+  string str = header + nameOps("merge", make_pair("func", "Main")) + types_consts +
                "%func    = OpFunction %voidt None %funct\n";
 
   str += entry >> loop;
@@ -387,7 +387,7 @@ TEST_F(ValidateCFG, MergeBlockTargetedByMultipleHeaderBlocksSelectionBad) {
       " %cond   = OpSLessThan %intt %one %two\n"
       " OpSelectionMerge %merge None\n");
 
-  string str = header + nameOps("merge", tie("func", "Main")) + types_consts +
+  string str = header + nameOps("merge", make_pair("func", "Main")) + types_consts +
                "%func    = OpFunction %voidt None %funct\n";
 
   str += entry >> badhead;
@@ -408,7 +408,7 @@ TEST_F(ValidateCFG, BranchTargetFirstBlockBad) {
   Block entry("entry");
   Block bad("bad");
   Block end("end", SpvOpReturn);
-  string str = header + nameOps("entry", "bad", tie("func", "Main")) +
+  string str = header + nameOps("entry", "bad", make_pair("func", "Main")) +
                types_consts + "%func    = OpFunction %voidt None %funct\n";
 
   str += entry >> bad;
@@ -434,7 +434,7 @@ TEST_F(ValidateCFG, BranchConditionalTrueTargetFirstBlockBad) {
       " %cond    = OpSLessThan %intt %one %two\n"
       "OpLoopMerge %merge %cont None\n");
 
-  string str = header + nameOps("entry", "bad", tie("func", "Main")) +
+  string str = header + nameOps("entry", "bad", make_pair("func", "Main")) +
                types_consts + "%func    = OpFunction %voidt None %funct\n";
 
   str += entry >> bad;
@@ -462,7 +462,7 @@ TEST_F(ValidateCFG, BranchConditionalFalseTargetFirstBlockBad) {
       "%cond    = OpSLessThan %intt %one %two\n"
       "OpLoopMerge %merge %cont None\n");
 
-  string str = header + nameOps("entry", "bad", tie("func", "Main")) +
+  string str = header + nameOps("entry", "bad", make_pair("func", "Main")) +
                types_consts + "%func    = OpFunction %voidt None %funct\n";
 
   str += entry >> bad;
@@ -492,7 +492,7 @@ TEST_F(ValidateCFG, SwitchTargetFirstBlockBad) {
       "%cond    = OpSLessThan %intt %one %two\n"
       "OpSelectionMerge %merge None\n");
 
-  string str = header + nameOps("entry", "bad", tie("func", "Main")) +
+  string str = header + nameOps("entry", "bad", make_pair("func", "Main")) +
                types_consts + "%func    = OpFunction %voidt None %funct\n";
 
   str += entry >> bad;
@@ -525,7 +525,7 @@ TEST_F(ValidateCFG, BranchToBlockInOtherFunctionBad) {
   Block middle2("middle2");
   Block end2("end2", SpvOpReturn);
 
-  string str = header + nameOps("middle2", tie("func", "Main")) + types_consts +
+  string str = header + nameOps("middle2", make_pair("func", "Main")) + types_consts +
                "%func    = OpFunction %voidt None %funct\n";
 
   str += entry >> middle;
@@ -559,7 +559,7 @@ TEST_F(ValidateCFG, HeaderDoesntDominatesMergeBad) {
       " %cond    = OpSLessThan %intt %one %two\n"
       "OpSelectionMerge %end None\n");
 
-  string str = header + nameOps("bad", "merge", tie("func", "Main")) +
+  string str = header + nameOps("bad", "merge", make_pair("func", "Main")) +
                types_consts + "%func    = OpFunction %voidt None %funct\n";
 
   str += entry >> merge;

--- a/test/Validate.CFG.cpp
+++ b/test/Validate.CFG.cpp
@@ -1,0 +1,339 @@
+
+// Copyright (c) 2015-2016 The Khronos Group Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and/or associated documentation files (the
+// "Materials"), to deal in the Materials without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Materials, and to
+// permit persons to whom the Materials are furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Materials.
+//
+// MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS
+// KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS
+// SPECIFICATIONS AND HEADER INFORMATION ARE LOCATED AT
+//    https://www.khronos.org/registry/
+//
+// THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+// Validation tests for Control Flow Graph
+
+#include <array>
+#include <functional>
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <utility>
+
+#include "gmock/gmock.h"
+
+#include "UnitSPIRV.h"
+#include "source/validate.h"
+#include "ValidateFixtures.h"
+#include "source/diagnostic.h"
+
+using std::array;
+using std::string;
+using std::vector;
+
+using ::testing::HasSubstr;
+
+using libspirv::spvResultToString;
+using libspirv::ValidationState_t;
+
+using ValidateCFG = spvtest::ValidateBase<bool>;
+
+using libspirv::BasicBlock;
+namespace libspirv{
+  vector<const BasicBlock*> PostOrderSort(const BasicBlock &entry, size_t size = 10);
+}
+
+namespace {
+
+TEST_F(ValidateCFG, PostOrderLinear) {
+  vector<BasicBlock> blocks;
+  ValidationState_t state(nullptr, context_);
+
+  for(int i = 0; i < 7; i++) {
+    blocks.emplace_back(i, state);
+  }
+
+  for(int i = 0; i < 6; i++) {
+    blocks[i].RegisterSuccessor({&blocks[i+1]});
+  }
+
+  vector<const BasicBlock*> out = PostOrderSort(blocks[0]);
+  vector<uint32_t> gold = {6, 5, 4, 3, 2, 1, 0};
+
+  for(size_t i = 0; i < gold.size(); i++) {
+    ASSERT_EQ(gold[i], out[i]->get_id());
+  }
+}
+
+TEST_F(ValidateCFG, PostOrderWithCycle) {
+  vector<BasicBlock> blocks;
+  ValidationState_t state(nullptr, context_);
+
+  for(int i = 0; i < 7; i++) {
+    blocks.emplace_back(i, state);
+  }
+
+  blocks[0].RegisterSuccessor({&blocks[1]});
+  blocks[1].RegisterSuccessor({&blocks[2]});
+  blocks[2].RegisterSuccessor({&blocks[3], &blocks[4]});
+  blocks[3].RegisterSuccessor({&blocks[5]});
+  blocks[5].RegisterSuccessor({&blocks[6]});
+  blocks[4].RegisterSuccessor({&blocks[2]});
+
+  vector<const BasicBlock*> out = PostOrderSort(blocks[0]);
+  vector<array<uint32_t, 7>> possible_gold = {
+    {{4, 6, 5, 3, 2, 1, 0}},
+    {{6, 5, 3, 4, 2, 1, 0}}
+  };
+
+  ASSERT_TRUE(any_of(begin(possible_gold), end(possible_gold),
+                     [&](array<uint32_t, 7> gold) {
+                       return equal(begin(gold), end(gold), begin(out),
+                                    [](uint32_t val, const BasicBlock *block) {
+                                      return val == block->get_id();
+                                    });
+                     }));
+}
+
+TEST_F(ValidateCFG, PostOrderWithSwitch) {
+  vector<BasicBlock> blocks;
+  ValidationState_t state(nullptr, context_);
+
+  for(int i = 0; i < 7; i++) {
+    blocks.emplace_back(i, state);
+  }
+
+  blocks[0].RegisterSuccessor({&blocks[1]});
+  blocks[1].RegisterSuccessor({&blocks[2]});
+  blocks[2].RegisterSuccessor({&blocks[3], &blocks[4], &blocks[6]});
+  blocks[3].RegisterSuccessor({&blocks[6]});
+  blocks[5].RegisterSuccessor({&blocks[6]});
+  blocks[4].RegisterSuccessor({&blocks[5]});
+
+  vector<const BasicBlock*> out = PostOrderSort(blocks[0]);
+  vector<std::array<uint32_t, 7>> gold = {
+    {{6, 3, 5, 4, 2, 1, 0}},
+    {{6, 5, 4, 3, 2, 1, 0}}
+  };
+
+  auto dom = libspirv::CalculateDominators(blocks[0]);
+  libspirv::UpdateImmediateDominators(dom);
+
+  //for(auto &block : blocks) {
+  //  printDominatorList(block);
+  //  std::cout << std::endl;
+  //}
+
+  ASSERT_TRUE(
+      any_of(begin(gold), end(gold), [&out](std::array<uint32_t, 7> &gold_array) {
+        return std::equal(begin(gold_array), end(gold_array), begin(out),
+                          [](uint32_t val, const BasicBlock *block) {
+                            return val == block->get_id();
+                          });
+      }));
+}
+
+TEST_F(ValidateCFG, Default) {
+  string str = R"(
+           OpCapability Shader
+           OpMemoryModel Logical GLSL450
+           OpName %loop "loop"
+           OpName %first "first"
+           OpName %cont "cont"
+           OpName %merge "merge"
+           OpName %func "Main"
+%voidt   = OpTypeVoid
+%boolt   = OpTypeBool
+%intt    = OpTypeInt 32 1
+%one     = OpConstant %intt 1
+%two     = OpConstant %intt 2
+%funct   = OpTypeFunction %voidt
+%func    = OpFunction %voidt None %funct
+%first   = OpLabel
+           OpBranch %loop
+%loop    = OpLabel
+%cond    = OpSLessThan %intt %one %two
+           OpLoopMerge %merge %cont None
+           OpBranchConditional %cond %cont %merge
+%cont    = OpLabel
+           OpNop
+           OpBranch %loop
+%merge   = OpLabel
+           OpNop
+           OpReturn
+           OpFunctionEnd
+  )";
+
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateCFG, Variable) {
+    string str = R"(
+           OpCapability Shader
+           OpMemoryModel Logical GLSL450
+           OpName %func "Main"
+%voidt   = OpTypeVoid
+%boolt   = OpTypeBool
+%intt    = OpTypeInt 32 1
+%ptrt    = OpTypePointer Function %intt
+%one     = OpConstant %intt 1
+%two     = OpConstant %intt 2
+%funct   = OpTypeFunction %voidt
+%func    = OpFunction %voidt None %funct
+%first   = OpLabel
+%var     = OpVariable %ptrt Function
+           OpBranch %loop
+%loop    = OpLabel
+%cond    = OpSLessThan %intt %one %two
+           OpLoopMerge %merge %cont None
+           OpBranchConditional %cond %cont %merge
+%cont    = OpLabel
+           OpNop
+           OpBranch %loop
+%merge   = OpLabel
+           OpNop
+           OpReturn
+           OpFunctionEnd
+  )";
+
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateCFG, VariableNotInFirstBlockBad) {
+  string str = R"(
+           OpCapability Shader
+           OpMemoryModel Logical GLSL450
+           OpName %func "Main"
+%voidt   = OpTypeVoid
+%boolt   = OpTypeBool
+%intt    = OpTypeInt 32 1
+%ptrt    = OpTypePointer Function %intt
+%one     = OpConstant %intt 1
+%two     = OpConstant %intt 2
+%funct   = OpTypeFunction %voidt
+%func    = OpFunction %voidt None %funct
+%first   = OpLabel
+           OpBranch %loop
+%loop    = OpLabel
+%varbad  = OpVariable %ptrt Function   ;Varaible not in first block
+%cond    = OpSLessThan %intt %one %two
+           OpLoopMerge %merge %cont None
+           OpBranchConditional %cond %cont %merge
+%cont    = OpLabel
+           OpNop
+           OpBranch %loop
+%merge   = OpLabel
+           OpNop
+           OpReturn
+           OpFunctionEnd
+  )";
+
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
+}
+
+TEST_F(ValidateCFG, NonDominantContinueConstruct) {
+  string str = R"(
+           OpCapability Shader
+           OpMemoryModel Logical GLSL450
+           OpName %func "Main"
+%voidt   = OpTypeVoid
+%boolt   = OpTypeBool
+%intt    = OpTypeInt 32 1
+%one     = OpConstant %intt 1
+%two     = OpConstant %intt 2
+%funct   = OpTypeFunction %voidt
+%func    = OpFunction %voidt None %funct
+
+%first   = OpLabel
+           OpBranch %loop
+
+%cont    = OpLabel
+           OpNop
+           OpBranch %loop
+
+%loop    = OpLabel
+%cond    = OpSLessThan %intt %one %two
+           OpLoopMerge %merge %cont None
+           OpBranchConditional %cond %cont %merge
+
+%merge   = OpLabel
+           OpNop
+           OpReturn
+
+           OpFunctionEnd
+  )";
+
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateCFG, MergeBlockTargetedByMultipleHeaderBlocksBad) {
+    string str = R"(
+           OpCapability Shader
+           OpMemoryModel Logical GLSL450
+           OpName %func "Main"
+%voidt   = OpTypeVoid
+%boolt   = OpTypeBool
+%intt    = OpTypeInt 32 1
+%one     = OpConstant %intt 1
+%two     = OpConstant %intt 2
+%funct   = OpTypeFunction %voidt
+%func    = OpFunction %voidt None %funct
+
+%first   = OpLabel
+           OpBranch %loop
+
+%loop    = OpLabel
+%cond2   = OpSLessThan %intt %one %two
+           OpLoopMerge %merge1 %cont None
+           OpBranch %badhead
+
+%badhead = OpLabel
+%cond1   = OpSLessThan %intt %one %two
+           OpSelectionMerge %merge1 None    ; cannot share the same merge
+           OpBranchConditional %cond1 %t %f
+
+%t       = OpLabel
+           OpBranch %merge1
+%f       = OpLabel
+           OpBranch %cont
+
+%cont    = OpLabel
+           OpNop
+           OpBranch %loop
+
+%merge1  = OpLabel
+           OpNop
+           OpBranch %end
+
+%end     = OpLabel
+           OpReturn
+
+           OpFunctionEnd
+  )";
+
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
+}
+
+
+// TODO(umar): Test optional instructions
+}

--- a/test/ValidationState.cpp
+++ b/test/ValidationState.cpp
@@ -63,27 +63,27 @@ class ValidationState_HasAnyOfTest : public ValidationStateTest {
 
 TEST_F(ValidationState_HasAnyOfTest, EmptyMask) {
   EXPECT_TRUE(state_.HasAnyOf(0));
-  state_.registerCapability(SpvCapabilityMatrix);
+  state_.RegisterCapability(SpvCapabilityMatrix);
   EXPECT_TRUE(state_.HasAnyOf(0));
-  state_.registerCapability(SpvCapabilityImageMipmap);
+  state_.RegisterCapability(SpvCapabilityImageMipmap);
   EXPECT_TRUE(state_.HasAnyOf(0));
-  state_.registerCapability(SpvCapabilityPipes);
+  state_.RegisterCapability(SpvCapabilityPipes);
   EXPECT_TRUE(state_.HasAnyOf(0));
-  state_.registerCapability(SpvCapabilityStorageImageArrayDynamicIndexing);
+  state_.RegisterCapability(SpvCapabilityStorageImageArrayDynamicIndexing);
   EXPECT_TRUE(state_.HasAnyOf(0));
-  state_.registerCapability(SpvCapabilityClipDistance);
+  state_.RegisterCapability(SpvCapabilityClipDistance);
   EXPECT_TRUE(state_.HasAnyOf(0));
-  state_.registerCapability(SpvCapabilityStorageImageWriteWithoutFormat);
+  state_.RegisterCapability(SpvCapabilityStorageImageWriteWithoutFormat);
   EXPECT_TRUE(state_.HasAnyOf(0));
 }
 
 TEST_F(ValidationState_HasAnyOfTest, SingleCapMask) {
   EXPECT_FALSE(state_.HasAnyOf(mask({SpvCapabilityMatrix})));
   EXPECT_FALSE(state_.HasAnyOf(mask({SpvCapabilityImageMipmap})));
-  state_.registerCapability(SpvCapabilityMatrix);
+  state_.RegisterCapability(SpvCapabilityMatrix);
   EXPECT_TRUE(state_.HasAnyOf(mask({SpvCapabilityMatrix})));
   EXPECT_FALSE(state_.HasAnyOf(mask({SpvCapabilityImageMipmap})));
-  state_.registerCapability(SpvCapabilityImageMipmap);
+  state_.RegisterCapability(SpvCapabilityImageMipmap);
   EXPECT_TRUE(state_.HasAnyOf(mask({SpvCapabilityMatrix})));
   EXPECT_TRUE(state_.HasAnyOf(mask({SpvCapabilityImageMipmap})));
 }
@@ -95,7 +95,7 @@ TEST_F(ValidationState_HasAnyOfTest, MultiCapMask) {
                            SpvCapabilityGeometryStreams});
   EXPECT_FALSE(state_.HasAnyOf(mask1));
   EXPECT_FALSE(state_.HasAnyOf(mask2));
-  state_.registerCapability(SpvCapabilityImageBuffer);
+  state_.RegisterCapability(SpvCapabilityImageBuffer);
   EXPECT_TRUE(state_.HasAnyOf(mask1));
   EXPECT_FALSE(state_.HasAnyOf(mask2));
 }


### PR DESCRIPTION
## Control-Flow Graph
- [x] Blocks exist only within a function.
- [x] The first block in a function definition is the entry point of that function and cannot be the target of any branch.
- [X] The order of blocks in a function must satisfy the rule that blocks appear before all blocks they dominate.
- [X] Each block starts with a label.
  - [X] A label is made by OpLabel.
  - [X] This includes the first block of a function (OpFunction is not a label).
  - [X] Labels are used only to form blocks.
- [X] The last instruction of each block is a branch instruction.
- [X] Branch instructions can only appear as the last instruction in a block.
- [X] OpLabel instructions can only appear within a function.
- [X] All branches within a function must be to labels in that function.

## Control-Flow declarations
- [X] the merge block declared by a header block cannot be a merge block declared by any other header block
- [X] each header block must dominate (in the CFG) its merge block, unless the merge block is unreachable in the CFG
- [ ] all CFG back edges must branch to a loop header, with each loop header having exactly one back edge branching to it
- [ ] for a given loop, its back-edge block must post dominate the OpLoopMerge's Continue Target, and that Continue Target must dominate the back-edge block

- [X] Within a function definition:
  - [X] A block always starts with an *OpLabel* instruction. This may be immediately preceded by an *OpLine* instruction, but the *OpLabel* is considered as the beginning of the block.

  - [X] A block always ends with a branch instruction.

  - [X] All *OpVariable* instructions in a function must have a Storage Class of *Function*.

  - [X] All *OpVariable* instructions in a function must be in the first block in the function. These instructions, together with any immediately preceding *OpLine* instructions, must be the first instructions in that block. 

  - [X] A function definition can be immediately preceded by an *OpLine* instruction.

## Constructs must satisfy
- [ ] the only blocks in a construct that can branch outside the construct are
   - [ ] a block branching to the construct's merge block
   - [ ] a block branching from one _case construct_ to another, for the same *OpSwitch*
   - [ ] a continue block for the innermost loop it is nested inside of
   - [ ] a break block for the innermost loop it is nested inside of
   - [ ] a return block
