### PR TITLE
Fix several warnings exposed in MSVS.

### DIFF
--- a/source/diagnostic.cpp
+++ b/source/diagnostic.cpp
@@ -75,8 +75,6 @@ spv_result_t spvDiagnosticPrint(const spv_diagnostic diagnostic) {
               << diagnostic->error << "\n";
     return SPV_SUCCESS;
   }
-
-  return SPV_ERROR_INVALID_VALUE;
 }
 
 namespace libspirv {

--- a/source/operand.cpp
+++ b/source/operand.cpp
@@ -228,7 +228,7 @@ void spvPrependOperandTypesForMask(const spv_operand_table operandTable,
                                    spv_operand_pattern_t* pattern) {
   // Scan from highest bits to lowest bits because we will prepend in LIFO
   // fashion, and we need the operands for lower order bits to appear first.
-  for (uint32_t candidate_bit = (1 << 31); candidate_bit; candidate_bit >>= 1) {
+  for (uint32_t candidate_bit = (1u << 31u); candidate_bit; candidate_bit >>= 1) {
     if (candidate_bit & mask) {
       spv_operand_desc entry = nullptr;
       if (SPV_SUCCESS == spvOperandTableValueLookup(operandTable, type,
@@ -320,5 +320,4 @@ bool spvIsIdType(spv_operand_type_t type) {
     default:
       return false;
   }
-  return false;
 }

--- a/source/util/hex_float.h
+++ b/source/util/hex_float.h
@@ -515,7 +515,7 @@ class HexFloat {
     // If we are up-casting, then we just have to shift to the right location.
     if (num_throwaway_bits <= 0) {
       out_val = static_cast<other_uint_type>(significand);
-      uint_type shift_amount = -num_throwaway_bits;
+      uint_type shift_amount = static_cast<uint_type>(-num_throwaway_bits);
       out_val = static_cast<other_uint_type>(out_val << shift_amount);
       return out_val;
     }
@@ -567,9 +567,6 @@ class HexFloat {
       return static_cast<other_uint_type>(
           negatable_right_shift<num_throwaway_bits>::val(significand));
     }
-    // We really shouldn't get here.
-    assert(false && "We should not have ended up here");
-    return 0;
   }
 
   // Casts this value to another HexFloat. If the cast is widening,

--- a/source/validate_id.cpp
+++ b/source/validate_id.cpp
@@ -271,13 +271,13 @@ bool idUsage::isValid<SpvOpTypeSampler>(const spv_instruction_t*,
 bool aboveZero(const std::vector<uint32_t>& constWords,
                const std::vector<uint32_t>& typeWords) {
   const uint32_t width = typeWords[2];
-  const bool is_signed = typeWords[3];
+  const bool is_signed = typeWords[3] > 0;
   const uint32_t loWord = constWords[3];
   if (width > 32) {
     // The spec currently doesn't allow integers wider than 64 bits.
     const uint32_t hiWord = constWords[4];  // Must exist, per spec.
     if (is_signed && (hiWord >> 31)) return false;
-    return loWord | hiWord;
+    return (loWord | hiWord) > 0;
   } else {
     if (is_signed && (loWord >> 31)) return false;
     return loWord > 0;

--- a/source/validate_types.cpp
+++ b/source/validate_types.cpp
@@ -304,7 +304,7 @@ void ValidationState_t::registerCapability(SpvCapability cap) {
 }
 
 bool ValidationState_t::hasCapability(SpvCapability cap) const {
-  return module_capabilities_ & SPV_CAPABILITY_AS_MASK(cap);
+  return (module_capabilities_ & SPV_CAPABILITY_AS_MASK(cap)) != 0;
 }
 
 bool ValidationState_t::HasAnyOf(spv_capability_mask_t capabilities) const {


### PR DESCRIPTION
diagnostic.cpp:
- unreachable code

operand.cpp
- conversion between int and uint32_t
- unreachable code

text.cpp:
- assignment within conditional expression

hex_float.h:
- assignment within conditional expression
- conversion from 'const int' to 'unsigned int'
- unreachable code

validate_id.cpp
- forcing value to bool 'true' or 'false'

validate_types.cpp:
- forcing value to bool 'true' or 'false'