### PR TITLE
Fix diagnostic message for layout errors

### DIFF
--- a/source/val/ValidationState.cpp
+++ b/source/val/ValidationState.cpp
@@ -288,7 +288,8 @@ Function& ValidationState_t::get_current_function() {
 bool ValidationState_t::in_function_body() const { return in_function_; }
 
 bool ValidationState_t::in_block() const {
-  return module_functions_.back().get_current_block() != nullptr;
+  return module_functions_.empty() == false &&
+         module_functions_.back().get_current_block() != nullptr;
 }
 
 void ValidationState_t::RegisterCapability(SpvCapability cap) {

--- a/source/validate_layout.cpp
+++ b/source/validate_layout.cpp
@@ -158,7 +158,8 @@ spv_result_t FunctionScopedInstructions(ValidationState_t& _,
         break;
 
       default:
-        if (_.getLayoutSection() == kLayoutFunctionDeclarations) {
+        if (_.getLayoutSection() == kLayoutFunctionDeclarations &&
+            _.in_function_body()) {
           return _.diag(SPV_ERROR_INVALID_LAYOUT)
                  << "A function must begin with a label";
         } else {


### PR DESCRIPTION
Fixed invalid error message when an instruction that appears in a block is encountered before a function declaration.

Fixes #228 