### PR TITLE
Construct and back-edge validation

### DIFF
--- a/source/val/BasicBlock.cpp
+++ b/source/val/BasicBlock.cpp
@@ -35,9 +35,10 @@ namespace libspirv {
 BasicBlock::BasicBlock(uint32_t id)
     : id_(id),
       immediate_dominator_(nullptr),
+      immediate_post_dominator_(nullptr),
       predecessors_(),
       successors_(),
-      type_(1),
+      type_(0),
       reachable_(false) {}
 
 void BasicBlock::SetImmediateDominator(BasicBlock* dom_block) {
@@ -65,7 +66,7 @@ void BasicBlock::RegisterSuccessors(vector<BasicBlock*> next_blocks) {
   for (auto& block : next_blocks) {
     block->predecessors_.push_back(this);
     successors_.push_back(block);
-    if (block->reachable_ == false) block->set_reachability(reachable_);
+    if (block->reachable_ == false) block->set_reachable(reachable_);
   }
 }
 

--- a/source/val/BasicBlock.cpp
+++ b/source/val/BasicBlock.cpp
@@ -37,6 +37,7 @@ BasicBlock::BasicBlock(uint32_t id)
       immediate_dominator_(nullptr),
       predecessors_(),
       successors_(),
+      type_(1),
       reachable_(false) {}
 
 void BasicBlock::SetImmediateDominator(BasicBlock* dom_block) {

--- a/source/val/BasicBlock.cpp
+++ b/source/val/BasicBlock.cpp
@@ -62,7 +62,7 @@ BasicBlock* BasicBlock::GetImmediatePostDominator() {
   return immediate_post_dominator_;
 }
 
-void BasicBlock::RegisterSuccessors(vector<BasicBlock*> next_blocks) {
+void BasicBlock::RegisterSuccessors(const vector<BasicBlock*>& next_blocks) {
   for (auto& block : next_blocks) {
     block->predecessors_.push_back(this);
     successors_.push_back(block);

--- a/source/val/BasicBlock.cpp
+++ b/source/val/BasicBlock.cpp
@@ -44,11 +44,22 @@ void BasicBlock::SetImmediateDominator(BasicBlock* dom_block) {
   immediate_dominator_ = dom_block;
 }
 
+void BasicBlock::SetImmediatePostDominator(BasicBlock* pdom_block) {
+  immediate_post_dominator_ = pdom_block;
+}
+
 const BasicBlock* BasicBlock::GetImmediateDominator() const {
   return immediate_dominator_;
 }
 
+const BasicBlock* BasicBlock::GetImmediatePostDominator() const {
+  return immediate_post_dominator_;
+}
+
 BasicBlock* BasicBlock::GetImmediateDominator() { return immediate_dominator_; }
+BasicBlock* BasicBlock::GetImmediatePostDominator() {
+  return immediate_post_dominator_;
+}
 
 void BasicBlock::RegisterSuccessors(vector<BasicBlock*> next_blocks) {
   for (auto& block : next_blocks) {
@@ -64,24 +75,29 @@ void BasicBlock::RegisterBranchInstruction(SpvOp branch_instruction) {
 }
 
 BasicBlock::DominatorIterator::DominatorIterator() : current_(nullptr) {}
-BasicBlock::DominatorIterator::DominatorIterator(const BasicBlock* block)
-    : current_(block) {}
+
+BasicBlock::DominatorIterator::DominatorIterator(
+    const BasicBlock* block,
+    std::function<const BasicBlock*(const BasicBlock*)> dominator_func)
+    : current_(block), dom_func_(dominator_func) {}
 
 BasicBlock::DominatorIterator& BasicBlock::DominatorIterator::operator++() {
-  if (current_ == current_->GetImmediateDominator()) {
+  if (current_ == dom_func_(current_)) {
     current_ = nullptr;
   } else {
-    current_ = current_->GetImmediateDominator();
+    current_ = dom_func_(current_);
   }
   return *this;
 }
 
 const BasicBlock::DominatorIterator BasicBlock::dom_begin() const {
-  return DominatorIterator(this);
+  return DominatorIterator(
+      this, [](const BasicBlock* b) { return b->GetImmediateDominator(); });
 }
 
 BasicBlock::DominatorIterator BasicBlock::dom_begin() {
-  return DominatorIterator(this);
+  return DominatorIterator(
+      this, [](const BasicBlock* b) { return b->GetImmediateDominator(); });
 }
 
 const BasicBlock::DominatorIterator BasicBlock::dom_end() const {
@@ -89,6 +105,24 @@ const BasicBlock::DominatorIterator BasicBlock::dom_end() const {
 }
 
 BasicBlock::DominatorIterator BasicBlock::dom_end() {
+  return DominatorIterator();
+}
+
+const BasicBlock::DominatorIterator BasicBlock::pdom_begin() const {
+  return DominatorIterator(
+      this, [](const BasicBlock* b) { return b->GetImmediatePostDominator(); });
+}
+
+BasicBlock::DominatorIterator BasicBlock::pdom_begin() {
+  return DominatorIterator(
+    this, [](const BasicBlock* b) { return b->GetImmediatePostDominator(); });
+}
+
+const BasicBlock::DominatorIterator BasicBlock::pdom_end() const {
+  return DominatorIterator();
+}
+
+BasicBlock::DominatorIterator BasicBlock::pdom_end() {
   return DominatorIterator();
 }
 

--- a/source/val/BasicBlock.h
+++ b/source/val/BasicBlock.h
@@ -78,21 +78,26 @@ class BasicBlock {
   /// Returns true if the block is reachable in the CFG
   bool is_reachable() const { return reachable_; }
 
-  /// Returns the type of the BasicBlock
-  bool is_type(BlockType type) const { return type_.test(type); }
+  /// Returns true if BasicBlock is of the given type
+  bool is_type(BlockType type) const {
+    if (type == kBlockTypeUndefined) return type_.none();
+    return type_.test(type);
+  }
 
-  /// Sets the reacability of the basic block in the CFG
-  void set_reachability(bool reachability) { reachable_ = reachability; }
+  /// Sets the reachability of the basic block in the CFG
+  void set_reachable(bool reachability) { reachable_ = reachability; }
 
   /// Sets the type of the BasicBlock
-  void set_type(BlockType type) { type_.set(static_cast<int>(type)); }
+  void set_type(BlockType type) {
+    type_.set(type);
+  }
 
   /// Sets the immedate dominator of this basic block
   ///
   /// @param[in] dom_block The dominator block
   void SetImmediateDominator(BasicBlock* dom_block);
 
-  /// Sets the immedate dominator of this basic block
+  /// Sets the immedate post dominator of this basic block
   ///
   /// @param[in] pdom_block The post dominator block
   void SetImmediatePostDominator(BasicBlock* pdom_block);
@@ -137,8 +142,8 @@ class BasicBlock {
     ///        @p block
     ///
     /// @param block          The block which is referenced by the iterator
-    /// @param dominator_func This function will be called to get the dominator
-    ///                       of the current block
+    /// @param dominator_func This function will be called to get the immediate
+    ///                       (post)dominator of the current block
     DominatorIterator(
         const BasicBlock* block,
         std::function<const BasicBlock*(const BasicBlock*)> dominator_func);
@@ -157,17 +162,17 @@ class BasicBlock {
     std::function<const BasicBlock*(const BasicBlock*)> dom_func_;
   };
 
-  /// Returns an dominator iterator which points to the current block
+  /// Returns a dominator iterator which points to the current block
   const DominatorIterator dom_begin() const;
 
-  /// Returns an dominator iterator which points to the current block
+  /// Returns a dominator iterator which points to the current block
   DominatorIterator dom_begin();
 
-  /// Returns an dominator iterator which points to one element past the first
+  /// Returns a dominator iterator which points to one element past the first
   /// block
   const DominatorIterator dom_end() const;
 
-  /// Returns an dominator iterator which points to one element past the first
+  /// Returns a dominator iterator which points to one element past the first
   /// block
   DominatorIterator dom_end();
 
@@ -201,7 +206,7 @@ class BasicBlock {
   std::vector<BasicBlock*> successors_;
 
   /// The type of the block
-  std::bitset<kBlockTypeCOUNT> type_;
+  std::bitset<kBlockTypeCOUNT - 1> type_;
 
   /// True if the block is reachable in the CFG
   bool reachable_;

--- a/source/val/BasicBlock.h
+++ b/source/val/BasicBlock.h
@@ -30,9 +30,22 @@
 #include "spirv/1.1/spirv.h"
 
 #include <cstdint>
+
+#include <bitset>
 #include <vector>
 
 namespace libspirv {
+
+enum BlockType : uint32_t {
+  kBlockTypeUndefined,
+  kBlockTypeHeader,
+  kBlockTypeLoop,
+  kBlockTypeMerge,
+  kBlockTypeBreak,
+  kBlockTypeContinue,
+  kBlockTypeReturn,
+  kBlockTypeCOUNT  ///< Total number of block types. (must be the last element)
+};
 
 // This class represents a basic block in a SPIR-V module
 class BasicBlock {
@@ -61,10 +74,17 @@ class BasicBlock {
   /// Returns the successors of the BasicBlock
   std::vector<BasicBlock*>* get_successors() { return &successors_; }
 
-  /// Returns true if the  block should be reachable in the CFG
+  /// Returns true if the block is reachable in the CFG
   bool is_reachable() const { return reachable_; }
 
+  /// Returns the type of the BasicBlock
+  bool is_type(BlockType type) const { return type_.test(type); }
+
+  /// Sets the reacability of the basic block in the CFG
   void set_reachability(bool reachability) { reachable_ = reachability; }
+
+  /// Sets the type of the BasicBlock
+  void set_type(BlockType type) { type_.set(static_cast<int>(type)); }
 
   /// Sets the immedate dominator of this basic block
   ///
@@ -140,6 +160,9 @@ class BasicBlock {
 
   /// The set of successors of the BasicBlock
   std::vector<BasicBlock*> successors_;
+
+  /// The type of the block
+  std::bitset<kBlockTypeCOUNT> type_;
 
   bool reachable_;
 };

--- a/source/val/BasicBlock.h
+++ b/source/val/BasicBlock.h
@@ -121,7 +121,7 @@ class BasicBlock {
   void RegisterBranchInstruction(SpvOp branch_instruction);
 
   /// Adds @p next BasicBlocks as successors of this BasicBlock
-  void RegisterSuccessors(std::vector<BasicBlock*> next = {});
+  void RegisterSuccessors(const std::vector<BasicBlock*>& next = {});
 
   /// Returns true if the id of the BasicBlock matches
   bool operator==(const BasicBlock& other) const { return other.id_ == id_; }

--- a/source/val/BasicBlock.h
+++ b/source/val/BasicBlock.h
@@ -89,6 +89,7 @@ class BasicBlock {
 
   /// Sets the type of the BasicBlock
   void set_type(BlockType type) {
+    if (type == kBlockTypeUndefined) type_.reset();
     type_.set(type);
   }
 

--- a/source/val/BasicBlock.h
+++ b/source/val/BasicBlock.h
@@ -89,8 +89,10 @@ class BasicBlock {
 
   /// Sets the type of the BasicBlock
   void set_type(BlockType type) {
-    if (type == kBlockTypeUndefined) type_.reset();
-    type_.set(type);
+    if (type == kBlockTypeUndefined)
+      type_.reset();
+    else
+      type_.set(type);
   }
 
   /// Sets the immedate dominator of this basic block

--- a/source/val/BasicBlock.h
+++ b/source/val/BasicBlock.h
@@ -32,6 +32,7 @@
 #include <cstdint>
 
 #include <bitset>
+#include <functional>
 #include <vector>
 
 namespace libspirv {
@@ -91,11 +92,22 @@ class BasicBlock {
   /// @param[in] dom_block The dominator block
   void SetImmediateDominator(BasicBlock* dom_block);
 
+  /// Sets the immedate dominator of this basic block
+  ///
+  /// @param[in] pdom_block The post dominator block
+  void SetImmediatePostDominator(BasicBlock* pdom_block);
+
   /// Returns the immedate dominator of this basic block
   BasicBlock* GetImmediateDominator();
 
   /// Returns the immedate dominator of this basic block
   const BasicBlock* GetImmediateDominator() const;
+
+  /// Returns the immedate post dominator of this basic block
+  BasicBlock* GetImmediatePostDominator();
+
+  /// Returns the immedate post dominator of this basic block
+  const BasicBlock* GetImmediatePostDominator() const;
 
   /// Ends the block without a successor
   void RegisterBranchInstruction(SpvOp branch_instruction);
@@ -111,7 +123,7 @@ class BasicBlock {
 
   /// @brief A BasicBlock dominator iterator class
   ///
-  /// This iterator will iterate over the dominators of the block
+  /// This iterator will iterate over the (post)dominators of the block
   class DominatorIterator
       : public std::iterator<std::forward_iterator_tag, BasicBlock*> {
    public:
@@ -124,8 +136,12 @@ class BasicBlock {
     /// @brief Constructs an iterator for the given block which points to
     ///        @p block
     ///
-    /// @param block The block which is referenced by the iterator
-    explicit DominatorIterator(const BasicBlock* block);
+    /// @param block          The block which is referenced by the iterator
+    /// @param dominator_func This function will be called to get the dominator
+    ///                       of the current block
+    DominatorIterator(
+        const BasicBlock* block,
+        std::function<const BasicBlock*(const BasicBlock*)> dominator_func);
 
     /// @brief Advances the iterator
     DominatorIterator& operator++();
@@ -138,15 +154,35 @@ class BasicBlock {
 
    private:
     const BasicBlock* current_;
+    std::function<const BasicBlock*(const BasicBlock*)> dom_func_;
   };
 
-  /// Returns an iterator which points to the current block
+  /// Returns an dominator iterator which points to the current block
   const DominatorIterator dom_begin() const;
+
+  /// Returns an dominator iterator which points to the current block
   DominatorIterator dom_begin();
 
-  /// Returns an iterator which points to one element past the first block
+  /// Returns an dominator iterator which points to one element past the first
+  /// block
   const DominatorIterator dom_end() const;
+
+  /// Returns an dominator iterator which points to one element past the first
+  /// block
   DominatorIterator dom_end();
+
+  /// Returns a post dominator iterator which points to the current block
+  const DominatorIterator pdom_begin() const;
+  /// Returns a post dominator iterator which points to the current block
+  DominatorIterator pdom_begin();
+
+  /// Returns a post dominator iterator which points to one element past the
+  /// last block
+  const DominatorIterator pdom_end() const;
+
+  /// Returns a post dominator iterator which points to one element past the
+  /// last block
+  DominatorIterator pdom_end();
 
  private:
   /// Id of the BasicBlock
@@ -154,6 +190,9 @@ class BasicBlock {
 
   /// Pointer to the immediate dominator of the BasicBlock
   BasicBlock* immediate_dominator_;
+
+  /// Pointer to the immediate dominator of the BasicBlock
+  BasicBlock* immediate_post_dominator_;
 
   /// The set of predecessors of the BasicBlock
   std::vector<BasicBlock*> predecessors_;
@@ -164,6 +203,7 @@ class BasicBlock {
   /// The type of the block
   std::bitset<kBlockTypeCOUNT> type_;
 
+  /// True if the block is reachable in the CFG
   bool reachable_;
 };
 

--- a/source/val/Construct.cpp
+++ b/source/val/Construct.cpp
@@ -28,17 +28,45 @@
 
 namespace libspirv {
 
-Construct::Construct(BasicBlock* header_block, BasicBlock* merge_block,
-                     BasicBlock* continue_block)
-    : header_block_(header_block),
-      merge_block_(merge_block),
-      continue_block_(continue_block) {}
+Construct::Construct(ConstructType type, BasicBlock* dominator,
+                     BasicBlock* exit, std::vector<Construct*> constructs)
+    : type_(type),
+      corresponding_constructs_(constructs),
+      base_dominator_(dominator),
+      exit_block_(exit) {}
 
-const BasicBlock* Construct::get_header() const { return header_block_; }
-const BasicBlock* Construct::get_merge() const { return merge_block_; }
-const BasicBlock* Construct::get_continue() const { return continue_block_; }
+ConstructType Construct::get_type() const { return type_; }
 
-BasicBlock* Construct::get_header() { return header_block_; }
-BasicBlock* Construct::get_merge() { return merge_block_; }
-BasicBlock* Construct::get_continue() { return continue_block_; }
+const std::vector<Construct*>& Construct::get_corresponding_constructs() const {
+  return corresponding_constructs_;
 }
+std::vector<Construct*>& Construct::get_corresponding_constructs() {
+  return corresponding_constructs_;
+}
+
+bool ValidateConstructSize(ConstructType type, size_t size) {
+  switch (type) {
+    case ConstructType::kSelection: return size == 0;
+    case ConstructType::kContinue:  return size == 1;
+    case ConstructType::kLoop:      return size == 1;
+    case ConstructType::kCase:      return size > 1;
+    default: assert(1 == 0 && "Type not defined");
+  }
+}
+
+void Construct::set_corresponding_constructs(
+    std::vector<Construct*> constructs) {
+  assert(ValidateConstructSize(type_, constructs.size()));
+  corresponding_constructs_ = constructs;
+}
+
+const BasicBlock* Construct::get_dominator() const { return base_dominator_; }
+BasicBlock* Construct::get_dominator() { return base_dominator_; }
+
+const BasicBlock* Construct::get_exit() const { return exit_block_; }
+BasicBlock* Construct::get_exit() { return exit_block_; }
+
+void Construct::set_exit(BasicBlock* exit_block) {
+  exit_block_ = exit_block;
+}
+}  /// namespace libspirv

--- a/source/val/Construct.cpp
+++ b/source/val/Construct.cpp
@@ -31,11 +31,11 @@
 
 namespace libspirv {
 
-Construct::Construct(ConstructType type, BasicBlock* dominator,
+Construct::Construct(ConstructType type, BasicBlock* entry,
                      BasicBlock* exit, std::vector<Construct*> constructs)
     : type_(type),
       corresponding_constructs_(constructs),
-      base_dominator_(dominator),
+      entry_block_(entry),
       exit_block_(exit) {}
 
 ConstructType Construct::get_type() const { return type_; }
@@ -52,7 +52,7 @@ bool ValidateConstructSize(ConstructType type, size_t size) {
     case ConstructType::kSelection: return size == 0;
     case ConstructType::kContinue:  return size == 1;
     case ConstructType::kLoop:      return size == 1;
-    case ConstructType::kCase:      return size > 1;
+    case ConstructType::kCase:      return size >= 1;
     default: assert(1 == 0 && "Type not defined");
   }
   return false;
@@ -64,8 +64,8 @@ void Construct::set_corresponding_constructs(
   corresponding_constructs_ = constructs;
 }
 
-const BasicBlock* Construct::get_dominator() const { return base_dominator_; }
-BasicBlock* Construct::get_dominator() { return base_dominator_; }
+const BasicBlock* Construct::get_entry() const { return entry_block_; }
+BasicBlock* Construct::get_entry() { return entry_block_; }
 
 const BasicBlock* Construct::get_exit() const { return exit_block_; }
 BasicBlock* Construct::get_exit() { return exit_block_; }

--- a/source/val/Construct.cpp
+++ b/source/val/Construct.cpp
@@ -26,6 +26,9 @@
 
 #include "val/Construct.h"
 
+#include <cassert>
+#include <cstddef>
+
 namespace libspirv {
 
 Construct::Construct(ConstructType type, BasicBlock* dominator,
@@ -52,6 +55,7 @@ bool ValidateConstructSize(ConstructType type, size_t size) {
     case ConstructType::kCase:      return size > 1;
     default: assert(1 == 0 && "Type not defined");
   }
+  return false;
 }
 
 void Construct::set_corresponding_constructs(

--- a/source/val/Construct.h
+++ b/source/val/Construct.h
@@ -67,25 +67,34 @@ class Construct {
   std::vector<Construct*>& get_corresponding_constructs();
   void set_corresponding_constructs(std::vector<Construct*> constructs);
 
-  /// Returns the dominator block of the construct. This is usually the header
-  /// block or the first block of the construct.
+  /// Returns the dominator block of the construct.
+  ///
+  /// This is usually the header block or the first block of the construct.
   const BasicBlock* get_entry() const;
 
-  /// Returns the dominator block of the construct. This is usually the header
-  /// block or the first block of the construct.
+  /// Returns the dominator block of the construct.
+  ///
+  /// This is usually the header block or the first block of the construct.
   BasicBlock* get_entry();
 
-  /// Returns the exit block of the construct. This is usually the merge block
-  /// or the last block of the construct
+  /// Returns the exit block of the construct.
+  ///
+  /// For a continue construct it is  the backedge block of the corresponding
+  /// loop construct. For the case  construct it is the block that branches to
+  /// the OpSwitch merge block or  other case blocks. Otherwise it is the merge
+  /// block of the corresponding  header block
   const BasicBlock* get_exit() const;
 
-  /// Returns the exit block of the construct. This is usually the merge block
-  /// or the last block of the construct
+  /// Returns the exit block of the construct.
+  ///
+  /// For a continue construct it is  the backedge block of the corresponding
+  /// loop construct. For the case  construct it is the block that branches to
+  /// the OpSwitch merge block or  other case blocks. Otherwise it is the merge
+  /// block of the corresponding  header block
   BasicBlock* get_exit();
 
   /// Sets the exit block for this construct. This is useful for continue
-  /// constructs which do not know the back-edge block before during
-  /// construction
+  /// constructs which do not know the back-edge block during construction
   void set_exit(BasicBlock* exit_block);
 
  private:

--- a/source/val/Construct.h
+++ b/source/val/Construct.h
@@ -69,11 +69,11 @@ class Construct {
 
   /// Returns the dominator block of the construct. This is usually the header
   /// block or the first block of the construct.
-  const BasicBlock* get_dominator() const;
+  const BasicBlock* get_entry() const;
 
   /// Returns the dominator block of the construct. This is usually the header
   /// block or the first block of the construct.
-  BasicBlock* get_dominator();
+  BasicBlock* get_entry();
 
   /// Returns the exit block of the construct. This is usually the merge block
   /// or the last block of the construct
@@ -93,8 +93,9 @@ class Construct {
   ConstructType type_;
 
   /// These are the constructs that are related to this construct. These
-  /// constructs can be the loop construct, the corresponding loop construct,
-  /// the case construct that are part of the same OpSwitch instruction
+  /// constructs can be the continue construct, for the corresponding loop
+  /// construct, the case construct that are part of the same OpSwitch
+  /// instruction
   std::vector<Construct*> corresponding_constructs_;
 
   /// @brief Dominator block for the construct
@@ -102,7 +103,7 @@ class Construct {
   /// The dominator block for the construct. Depending on the construct this may
   /// be a selection header, a continue target of a loop, a loop header or a
   /// Target or Default block of a switch
-  BasicBlock* base_dominator_;
+  BasicBlock* entry_block_;
 
   /// @brief Exiting block for the construct
   ///

--- a/source/val/Construct.h
+++ b/source/val/Construct.h
@@ -28,29 +28,88 @@
 #define LIBSPIRV_VAL_CONSTRUCT_H_
 
 #include <cstdint>
+#include <vector>
 
 namespace libspirv {
+
+enum class ConstructType {
+  kNone,
+  /// The set of blocks dominated by a selection header, minus the set of blocks
+  /// dominated by the header's merge block
+  kSelection,
+  /// The set of blocks dominated by an OpLoopMerge's Continue Target and post
+  /// dominated by the corresponding back
+  kContinue,
+  ///  The set of blocks dominated by a loop header, minus the set of blocks
+  ///  dominated by the loop's merge block, minus the loop's corresponding
+  ///  continue construct
+  kLoop,
+  ///  The set of blocks dominated by an OpSwitch's Target or Default, minus the
+  ///  set of blocks dominated by the OpSwitch's merge block (this construct is
+  ///  only defined for those OpSwitch Target or Default that are not equal to
+  ///  the OpSwitch's corresponding merge block)
+  kCase
+};
 
 class BasicBlock;
 
 /// @brief This class tracks the CFG constructs as defined in the SPIR-V spec
 class Construct {
  public:
-  Construct(BasicBlock* header_block, BasicBlock* merge_block,
-            BasicBlock* continue_block = nullptr);
+  Construct(ConstructType type, BasicBlock* dominator,
+            BasicBlock* exit = nullptr,
+            std::vector<Construct*> constructs = {});
 
-  const BasicBlock* get_header() const;
-  const BasicBlock* get_merge() const;
-  const BasicBlock* get_continue() const;
+  /// Returns the type of the construct
+  ConstructType get_type() const;
 
-  BasicBlock* get_header();
-  BasicBlock* get_merge();
-  BasicBlock* get_continue();
+  const std::vector<Construct*>& get_corresponding_constructs() const;
+  std::vector<Construct*>& get_corresponding_constructs();
+  void set_corresponding_constructs(std::vector<Construct*> constructs);
+
+  /// Returns the dominator block of the construct. This is usually the header
+  /// block or the first block of the construct.
+  const BasicBlock* get_dominator() const;
+
+  /// Returns the dominator block of the construct. This is usually the header
+  /// block or the first block of the construct.
+  BasicBlock* get_dominator();
+
+  /// Returns the exit block of the construct. This is usually the merge block
+  /// or the last block of the construct
+  const BasicBlock* get_exit() const;
+
+  /// Returns the exit block of the construct. This is usually the merge block
+  /// or the last block of the construct
+  BasicBlock* get_exit();
+
+  /// Sets the exit block for this construct. This is useful for continue
+  /// constructs which do not know the back-edge block before during
+  /// construction
+  void set_exit(BasicBlock* exit_block);
 
  private:
-  BasicBlock* header_block_;    ///< The header block of a loop or selection
-  BasicBlock* merge_block_;     ///< The merge block of a loop or selection
-  BasicBlock* continue_block_;  ///< The continue block of a loop block
+  /// The type of the construct
+  ConstructType type_;
+
+  /// These are the constructs that are related to this construct. These
+  /// constructs can be the loop construct, the corresponding loop construct,
+  /// the case construct that are part of the same OpSwitch instruction
+  std::vector<Construct*> corresponding_constructs_;
+
+  /// @brief Dominator block for the construct
+  ///
+  /// The dominator block for the construct. Depending on the construct this may
+  /// be a selection header, a continue target of a loop, a loop header or a
+  /// Target or Default block of a switch
+  BasicBlock* base_dominator_;
+
+  /// @brief Exiting block for the construct
+  ///
+  /// The exit block for the construct. This can be a merge block for the loop
+  /// and selection constructs, a back-edge block for a continue construct, or
+  /// the branching block for the case construct
+  BasicBlock* exit_block_;
 };
 
 }  /// namespace libspirv

--- a/source/val/Construct.h
+++ b/source/val/Construct.h
@@ -105,6 +105,17 @@ class Construct {
   /// constructs can be the continue construct, for the corresponding loop
   /// construct, the case construct that are part of the same OpSwitch
   /// instruction
+  ///
+  /// Here is a table that describes what constructs are included in
+  /// @p corresponding_constructs_
+  /// | this construct | corresponding construct          |
+  /// |----------------|----------------------------------|
+  /// | loop           | continue                         |
+  /// | continue       | loop                             |
+  /// | case           | other cases in the same OpSwitch |
+  ///
+  /// kContinue and kLoop constructs will always have corresponding
+  /// constructs even if they are represented by the same block
   std::vector<Construct*> corresponding_constructs_;
 
   /// @brief Dominator block for the construct

--- a/source/val/Function.cpp
+++ b/source/val/Function.cpp
@@ -101,7 +101,6 @@ spv_result_t Function::RegisterLoopMerge(uint32_t merge_id,
   RegisterBlock(continue_id, false);
   BasicBlock& merge_block = blocks_.at(merge_id);
   BasicBlock& continue_block = blocks_.at(continue_id);
-  assert(merge_block.is_type(kBlockTypeUndefined));
   assert(current_block_ &&
          "RegisterLoopMerge must be called when called within a block");
 

--- a/source/val/Function.cpp
+++ b/source/val/Function.cpp
@@ -102,7 +102,6 @@ spv_result_t Function::RegisterLoopMerge(uint32_t merge_id,
   BasicBlock& merge_block = blocks_.at(merge_id);
   BasicBlock& continue_block = blocks_.at(continue_id);
   assert(merge_block.is_type(kBlockTypeUndefined));
-  assert(continue_block.is_type(kBlockTypeUndefined));
 
   current_block_->set_type(kBlockTypeLoop);
   merge_block.set_type(kBlockTypeMerge);
@@ -179,7 +178,7 @@ spv_result_t Function::RegisterBlock(uint32_t id, bool is_definition) {
     undefined_blocks_.erase(id);
     current_block_ = &inserted_block->second;
     ordered_blocks_.push_back(current_block_);
-    if (IsFirstBlock(id)) current_block_->set_reachability(true);
+    if (IsFirstBlock(id)) current_block_->set_reachable(true);
   } else if (success) {  // Block doesn't exsist but this is not a definition
     undefined_blocks_.insert(id);
   }

--- a/source/val/Function.cpp
+++ b/source/val/Function.cpp
@@ -102,17 +102,16 @@ spv_result_t Function::RegisterLoopMerge(uint32_t merge_id,
   BasicBlock& merge_block = blocks_.at(merge_id);
   BasicBlock& continue_block = blocks_.at(continue_id);
   assert(merge_block.is_type(kBlockTypeUndefined));
+  assert(current_block_ &&
+         "RegisterLoopMerge must be called when called within a block");
 
   current_block_->set_type(kBlockTypeLoop);
   merge_block.set_type(kBlockTypeMerge);
   continue_block.set_type(kBlockTypeContinue);
-  assert(current_block_ &&
-         "RegisterLoopMerge must be called when called within a block");
-  cfg_constructs_.emplace_back(ConstructType::kLoop, get_current_block(),
+  cfg_constructs_.emplace_back(ConstructType::kLoop, current_block_,
                                &merge_block);
   Construct& loop_construct = cfg_constructs_.back();
-  cfg_constructs_.emplace_back(ConstructType::kContinue, &continue_block,
-                               nullptr);
+  cfg_constructs_.emplace_back(ConstructType::kContinue, &continue_block);
   Construct& continue_construct = cfg_constructs_.back();
   continue_construct.set_corresponding_constructs({&loop_construct});
   loop_construct.set_corresponding_constructs({&continue_construct});
@@ -127,7 +126,7 @@ spv_result_t Function::RegisterSelectionMerge(uint32_t merge_id) {
   merge_block.set_type(kBlockTypeMerge);
 
   cfg_constructs_.emplace_back(ConstructType::kSelection, get_current_block(),
-                               &blocks_.at(merge_id));
+                               &merge_block);
   return SPV_SUCCESS;
 }
 

--- a/source/val/Function.cpp
+++ b/source/val/Function.cpp
@@ -71,7 +71,7 @@ Function::Function(uint32_t id, uint32_t result_type_id,
       declaration_type_(FunctionDecl::kFunctionDeclUnknown),
       blocks_(),
       current_block_(nullptr),
-      exit_block_(kInvalidId),
+      pseudo_exit_block_(kInvalidId),
       cfg_constructs_(),
       variable_ids_(),
       parameter_ids_() {}
@@ -211,7 +211,7 @@ void Function::RegisterBlockEnd(vector<uint32_t> next_list,
   if (branch_instruction == SpvOpReturn ||
       branch_instruction == SpvOpReturnValue) {
     assert(next_blocks.empty());
-    next_blocks.push_back(&exit_block_);
+    next_blocks.push_back(&pseudo_exit_block_);
   }
   current_block_->RegisterBranchInstruction(branch_instruction);
   current_block_->RegisterSuccessors(next_blocks);
@@ -233,9 +233,9 @@ vector<BasicBlock*>& Function::get_blocks() { return ordered_blocks_; }
 const BasicBlock* Function::get_current_block() const { return current_block_; }
 BasicBlock* Function::get_current_block() { return current_block_; }
 
-BasicBlock* Function::get_psudo_exit_block() { return &exit_block_; }
-const BasicBlock* Function::get_psudo_exit_block() const {
-  return &exit_block_;
+BasicBlock* Function::get_pseudo_exit_block() { return &pseudo_exit_block_; }
+const BasicBlock* Function::get_pseudo_exit_block() const {
+  return &pseudo_exit_block_;
 }
 
 const list<Construct>& Function::get_constructs() const {

--- a/source/val/Function.h
+++ b/source/val/Function.h
@@ -150,10 +150,10 @@ class Function {
   const BasicBlock* get_current_block() const;
 
   /// Returns the psudo exit block
-  BasicBlock* get_psudo_exit_block();
+  BasicBlock* get_pseudo_exit_block();
 
   /// Returns the psudo exit block
-  const BasicBlock* get_psudo_exit_block() const;
+  const BasicBlock* get_pseudo_exit_block() const;
 
   /// Prints a GraphViz digraph of the CFG of the current funciton
   void printDotGraph() const;
@@ -192,8 +192,8 @@ class Function {
   /// The block that is currently being parsed
   BasicBlock* current_block_;
 
-  /// A psudo exit block that is the successor to all return blocks
-  BasicBlock exit_block_;
+  /// A pseudo exit block that is the successor to all return blocks
+  BasicBlock pseudo_exit_block_;
 
   /// The constructs that are available in this function
   std::list<Construct> cfg_constructs_;

--- a/source/val/Function.h
+++ b/source/val/Function.h
@@ -149,6 +149,12 @@ class Function {
   /// Returns the block that is currently being parsed in the binary
   const BasicBlock* get_current_block() const;
 
+  /// Returns the psudo exit block
+  BasicBlock* get_psudo_exit_block();
+
+  /// Returns the psudo exit block
+  const BasicBlock* get_psudo_exit_block() const;
+
   /// Prints a GraphViz digraph of the CFG of the current funciton
   void printDotGraph() const;
 
@@ -185,6 +191,9 @@ class Function {
 
   /// The block that is currently being parsed
   BasicBlock* current_block_;
+
+  /// A psudo exit block that is the successor to all return blocks
+  BasicBlock exit_block_;
 
   /// The constructs that are available in this function
   std::list<Construct> cfg_constructs_;

--- a/source/val/Function.h
+++ b/source/val/Function.h
@@ -28,9 +28,9 @@
 #define LIBSPIRV_VAL_FUNCTION_H_
 
 #include <list>
-#include <vector>
-#include <unordered_set>
 #include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 #include "spirv/1.1/spirv.h"
 #include "spirv-tools/libspirv.h"
@@ -100,11 +100,18 @@ class Function {
   void RegisterBlockEnd(std::vector<uint32_t> successors_list,
                         SpvOp branch_instruction);
 
-  /// Returns true if the \p merge_block_id is a merge block
-  bool IsMergeBlock(uint32_t merge_block_id) const;
-
-  /// Returns true if the \p id is the first block of this function
+  /// Returns true if the \p id block is the first block of this function
   bool IsFirstBlock(uint32_t id) const;
+
+  /// Returns true if the \p merge_block_id is a BlockType of \p type
+  bool IsBlockType(uint32_t merge_block_id, BlockType type) const;
+
+  /// Returns a pair consisting of the BasicBlock with \p id and a bool
+  /// which is true if the block has been defined, and false if it is
+  /// declared but not defined. This function will return nullptr if the
+  /// \p id was not declared and not defined at the current point in the binary
+  std::pair<const BasicBlock*, bool> GetBlock(uint32_t id) const;
+  std::pair<BasicBlock*, bool> GetBlock(uint32_t id);
 
   /// Returns the first block of the current function
   const BasicBlock* get_first_block() const;
@@ -190,6 +197,5 @@ class Function {
 };
 
 }  /// namespace libspirv
-
 
 #endif  /// LIBSPIRV_VAL_FUNCTION_H_

--- a/source/val/ValidationState.h
+++ b/source/val/ValidationState.h
@@ -42,6 +42,9 @@
 
 namespace libspirv {
 
+// Universal Limit of ResultID + 1
+static const uint32_t kInvalidId = 0x400000;
+
 // Info about a result ID.
 typedef struct spv_id_info_t {
   /// Id value.

--- a/source/validate.h
+++ b/source/validate.h
@@ -70,7 +70,7 @@ using get_blocks_func =
 ///
 /// @return a set of dominator edges represented as a pair of blocks
 std::vector<std::pair<BasicBlock*, BasicBlock*>> CalculateDominators(
-    std::vector<const BasicBlock*>& postorder,
+    const std::vector<const BasicBlock*>& postorder,
     get_blocks_func predecessor_func);
 
 /// @brief Performs the Control Flow Graph checks
@@ -89,7 +89,7 @@ spv_result_t PerformCfgChecks(ValidationState_t& _);
 /// @param[in] set_func This function will be called to updated the Immediate
 ///                     dominator
 void UpdateImmediateDominators(
-    std::vector<std::pair<BasicBlock*, BasicBlock*>>& dom_edges,
+    const std::vector<std::pair<BasicBlock*, BasicBlock*>>& dom_edges,
     std::function<void(BasicBlock*, BasicBlock*)> set_func);
 
 /// @brief Prints all of the dominators of a BasicBlock

--- a/source/validate.h
+++ b/source/validate.h
@@ -29,6 +29,7 @@
 
 #include <algorithm>
 #include <array>
+#include <functional>
 #include <list>
 #include <map>
 #include <string>
@@ -52,16 +53,25 @@ namespace libspirv {
 
 class ValidationState_t;
 
-/// @brief Calculates dominator edges of a root basic block
+/// A function that returns a vector of BasicBlocks given a BasicBlock. Used to
+/// get the successor and predecessor nodes of a CFG block
+using get_blocks_func =
+    std::function<const std::vector<BasicBlock*>*(const BasicBlock*)>;
+
+/// @brief Calculates dominator edges for a set of blocks
 ///
-/// This function calculates the dominator edges form a root BasicBlock. Uses
-/// the dominator algorithm by Cooper et al.
+/// This function calculates the dominator edges for a set of blocks in the CFG.
+/// Uses the dominator algorithm by Cooper et al.
 ///
-/// @param[in] first_block the root or entry BasicBlock of a function
+/// @param[in] postorder        A vector of blocks in post order traversal order
+///                             in a CFG
+/// @param[in] predecessor_func Function used to get the predecessor nodes of a
+///                             block
 ///
 /// @return a set of dominator edges represented as a pair of blocks
 std::vector<std::pair<BasicBlock*, BasicBlock*>> CalculateDominators(
-    const BasicBlock& first_block);
+    std::vector<const BasicBlock*>& postorder,
+    get_blocks_func predecessor_func);
 
 /// @brief Performs the Control Flow Graph checks
 ///
@@ -76,8 +86,11 @@ spv_result_t PerformCfgChecks(ValidationState_t& _);
 /// provided by the @p dom_edges parameter
 ///
 /// @param[in,out] dom_edges The edges of the dominator tree
+/// @param[in] set_func This function will be called to updated the Immediate
+///                     dominator
 void UpdateImmediateDominators(
-    std::vector<std::pair<BasicBlock*, BasicBlock*>>& dom_edges);
+    std::vector<std::pair<BasicBlock*, BasicBlock*>>& dom_edges,
+    std::function<void(BasicBlock*, BasicBlock*)> set_func);
 
 /// @brief Prints all of the dominators of a BasicBlock
 ///

--- a/source/validate_cfg.cpp
+++ b/source/validate_cfg.cpp
@@ -154,7 +154,7 @@ const vector<BasicBlock*>* predecessor(const BasicBlock* b) {
 }  // namespace
 
 vector<pair<BasicBlock*, BasicBlock*>> CalculateDominators(
-    vector<cbb_ptr>& postorder, get_blocks_func predecessor_func) {
+    const vector<cbb_ptr>& postorder, get_blocks_func predecessor_func) {
   struct block_detail {
     size_t dominator;  ///< The index of blocks's dominator in post order array
     size_t postorder_index;  ///< The index of the block in the post order array
@@ -222,14 +222,14 @@ vector<pair<BasicBlock*, BasicBlock*>> CalculateDominators(
 }
 
 void UpdateImmediateDominators(
-    vector<pair<bb_ptr, bb_ptr>>& dom_edges,
+    const vector<pair<bb_ptr, bb_ptr>>& dom_edges,
     function<void(BasicBlock*, BasicBlock*)> set_func) {
   for (auto& edge : dom_edges) {
     set_func(get<0>(edge), get<1>(edge));
   }
 }
 
-void printDominatorList(BasicBlock& b) {
+void printDominatorList(const BasicBlock& b) {
   std::cout << b.get_id() << " is dominated by: ";
   const BasicBlock* bb = &b;
   while (bb->GetImmediateDominator() != bb) {
@@ -293,8 +293,10 @@ void UpdateContinueConstructExitBlocks(
 }
 
 /// Constructs an error message for construct validation errors
-string ConstructErrorString(Construct construct, string header_string,
-                            string exit_string, bool post_dominate = false) {
+string ConstructErrorString(const Construct& construct,
+                            const string& header_string,
+                            const string& exit_string,
+                            bool post_dominate = false) {
   string construct_name;
   string header_name;
   string exit_name;
@@ -336,7 +338,7 @@ string ConstructErrorString(Construct construct, string header_string,
 }
 
 spv_result_t StructuredControlFlowChecks(
-    ValidationState_t& _, Function function,
+    const ValidationState_t& _, const Function& function,
     const vector<pair<uint32_t, uint32_t>>& back_edges) {
   /// Check all backedges target only loop headers and have exactly one
   /// back-edge branching to it
@@ -363,7 +365,7 @@ spv_result_t StructuredControlFlowChecks(
   }
 
   // Check construct rules
-  for (Construct& construct : function.get_constructs()) {
+  for (const Construct& construct : function.get_constructs()) {
     auto header = construct.get_entry();
     auto merge = construct.get_exit();
 

--- a/source/validate_cfg.cpp
+++ b/source/validate_cfg.cpp
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <functional>
 #include <set>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -49,6 +50,7 @@ using std::make_pair;
 using std::numeric_limits;
 using std::pair;
 using std::set;
+using std::string;
 using std::tie;
 using std::transform;
 using std::unordered_map;
@@ -96,8 +98,8 @@ bool FindInWorkList(const vector<block_info>& work_list, uint32_t id) {
 /// @param[in] entry The root BasicBlock of a CFG tree
 /// @param[in] successor_func  A function which will return a pointer to the
 ///                            successor nodes
-/// @param[in] preorder   A function that will be called for every block in a CFG
-///                       following preorder traversal semantics
+/// @param[in] preorder   A function that will be called for every block in a
+///                       CFG following preorder traversal semantics
 /// @param[in] postorder  A function that will be called for every block in a
 ///                       CFG following postorder traversal semantics
 /// @param[in] backedge   A function that will be called when a backedge is
@@ -147,10 +149,14 @@ const vector<BasicBlock*>* successor(const BasicBlock* b) {
   return b->get_successors();
 }
 
+const vector<BasicBlock*>* predecessor(const BasicBlock* b) {
+  return b->get_predecessors();
+}
+
 }  // namespace
 
 vector<pair<BasicBlock*, BasicBlock*>> CalculateDominators(
-    vector<cbb_ptr>& postorder) {
+    vector<cbb_ptr>& postorder, get_blocks_func predecessor_func) {
   struct block_detail {
     size_t dominator;  ///< The index of blocks's dominator in post order array
     size_t postorder_index;  ///< The index of the block in the post order array
@@ -170,7 +176,7 @@ vector<pair<BasicBlock*, BasicBlock*>> CalculateDominators(
     changed = false;
     for (auto b = postorder.rbegin() + 1; b != postorder.rend(); b++) {
       size_t& b_dom = idoms[*b].dominator;
-      const vector<BasicBlock*>* predecessors = (*b)->get_predecessors();
+      const vector<BasicBlock*>* predecessors = predecessor_func(*b);
 
       // first processed predecessor
       auto res = find_if(begin(*predecessors), end(*predecessors),
@@ -217,9 +223,11 @@ vector<pair<BasicBlock*, BasicBlock*>> CalculateDominators(
   return out;
 }
 
-void UpdateImmediateDominators(vector<pair<bb_ptr, bb_ptr>>& dom_edges) {
+void UpdateImmediateDominators(
+    vector<pair<bb_ptr, bb_ptr>>& dom_edges,
+    function<void(BasicBlock*, BasicBlock*)> set_func) {
   for (auto& edge : dom_edges) {
-    get<0>(edge)->SetImmediateDominator(get<1>(edge));
+    set_func(get<0>(edge), get<1>(edge));
   }
 }
 
@@ -256,34 +264,143 @@ spv_result_t MergeBlockAssert(ValidationState_t& _, uint32_t merge_block) {
   return SPV_SUCCESS;
 }
 
+void UpdateContinueConstructExitBlocks(
+    Function& function, const vector<pair<uint32_t, uint32_t>>& back_edges) {
+  auto& constructs = function.get_constructs();
+  // TODO(umar): Think of a faster way to do this
+  for (auto& edge : back_edges) {
+    uint32_t back_edge_block_id;
+    uint32_t loop_header_block_id;
+    tie(back_edge_block_id, loop_header_block_id) = edge;
+
+    auto is_this_header = [=](Construct& c) {
+      return c.get_type() == ConstructType::kLoop &&
+             c.get_dominator()->get_id() == loop_header_block_id;
+    };
+
+    for (auto construct : constructs) {
+      if (is_this_header(construct)) {
+        Construct* continue_construct =
+            construct.get_corresponding_constructs().back();
+        assert(continue_construct->get_type() == ConstructType::kContinue);
+
+        BasicBlock* back_edge_block;
+        tie(back_edge_block, ignore) = function.GetBlock(back_edge_block_id);
+        continue_construct->set_exit(back_edge_block);
+      }
+    }
+  }
+}
+
+/// Constructs an error message for construct validation errors
+string ConstructErrorString(Construct construct, string header_string,
+                            string exit_string, bool post_dominate = false) {
+  string construct_name;
+  string header_name;
+  string exit_name;
+  string dominate_text = "dominate";
+  if (post_dominate) {
+    dominate_text = "post " + dominate_text;
+  }
+  switch (construct.get_type()) {
+    case ConstructType::kSelection:
+      construct_name = "selection";
+      header_name = "selection header";
+      exit_name = "merge block";
+      break;
+    case ConstructType::kLoop:
+      construct_name = "loop";
+      header_name = "loop header";
+      exit_name = "merge block";
+      break;
+    case ConstructType::kContinue:
+      construct_name = "continue";
+      header_name = "continue target";
+      exit_name = "back-edge block";
+      break;
+    case ConstructType::kCase:
+      construct_name = "case";
+      header_name = "case block";
+      exit_name = "exit block";  // TODO(umar): there has to be a better name
+      break;
+    default:
+      assert(1 == 0 && "Not defined type");
+  }
+  // TODO(umar): Add header block for continue constructs to error message
+  return "The " + construct_name + " construct with the " + header_name + " " +
+         header_string + " does not " + dominate_text + " the " + exit_name +
+         " " + exit_string;
+}
+
 spv_result_t PerformCfgChecks(ValidationState_t& _) {
   for (auto& function : _.get_functions()) {
     // Check all referenced blocks are defined within a function
     if (function.get_undefined_block_count() != 0) {
-      std::stringstream ss;
-      ss << "{";
+      string undef_blocks("{");
       for (auto undefined_block : function.get_undefined_blocks()) {
-        ss << _.getIdName(undefined_block) << " ";
+        undef_blocks += _.getIdName(undefined_block) + " ";
       }
       return _.diag(SPV_ERROR_INVALID_CFG)
-             << "Block(s) " << ss.str() << "\b}"
+             << "Block(s) " << undef_blocks << "\b}"
              << " are referenced but not defined in function "
              << _.getIdName(function.get_id());
     }
 
     // Updates each blocks immediate dominators
     vector<const BasicBlock*> postorder;
+    vector<const BasicBlock*> postdom_postorder;
     vector<pair<uint32_t, uint32_t>> back_edges;
     if (auto* first_block = function.get_first_block()) {
+      /// calculate dominators
       DepthFirstTraversal(*first_block, successor, [](cbb_ptr) {},
                           [&](cbb_ptr b) { postorder.push_back(b); },
                           [&](cbb_ptr from, cbb_ptr to) {
                             back_edges.emplace_back(from->get_id(),
                                                     to->get_id());
                           });
-      auto edges = libspirv::CalculateDominators(postorder);
-      libspirv::UpdateImmediateDominators(edges);
+      auto edges = libspirv::CalculateDominators(postorder, predecessor);
+      libspirv::UpdateImmediateDominators(
+          edges, [](bb_ptr block, bb_ptr dominator) {
+            block->SetImmediateDominator(dominator);
+          });
+
+      /// calculate post dominators
+      auto exit_block = function.get_psudo_exit_block();
+      DepthFirstTraversal(*exit_block, predecessor, [](cbb_ptr) {},
+                          [&](cbb_ptr b) { postdom_postorder.push_back(b); },
+                          [&](cbb_ptr, cbb_ptr) {});
+      auto postdom_edges =
+          libspirv::CalculateDominators(postdom_postorder, successor);
+      libspirv::UpdateImmediateDominators(
+          postdom_edges, [](bb_ptr block, bb_ptr dominator) {
+            block->SetImmediatePostDominator(dominator);
+          });
     }
+
+    /// Check all backedges target only loop headers and have exactly one
+    /// back-edge branching to it
+    set<uint32_t> loop_headers;
+    for (auto back_edge : back_edges) {
+      uint32_t back_edge_block;
+      uint32_t header_block;
+      tie(back_edge_block, header_block) = back_edge;
+      if (!function.IsBlockType(header_block, kBlockTypeLoop)) {
+        return _.diag(SPV_ERROR_INVALID_CFG)
+               << "Back-edges (" << _.getIdName(back_edge_block) << " -> "
+               << _.getIdName(header_block)
+               << ") can only be formed between a block and a loop header.";
+      }
+      bool success;
+      tie(ignore, success) = loop_headers.insert(header_block);
+      if (!success) {
+        // TODO(umar): List the back-edge blocks that are branching to loop
+        // header
+        return _.diag(SPV_ERROR_INVALID_CFG)
+               << "Loop header " << _.getIdName(header_block)
+               << " targeted by multiple back-edges";
+      }
+    }
+    UpdateContinueConstructExitBlocks(function, back_edges);
 
     // Check if the order of blocks in the binary appear before the blocks they
     // dominate
@@ -301,49 +418,39 @@ spv_result_t PerformCfgChecks(ValidationState_t& _) {
       }
     }
 
-    // Check all headers dominate their merge blocks
+    // Check construct rules
     for (Construct& construct : function.get_constructs()) {
-      auto header = construct.get_header();
-      auto merge = construct.get_merge();
-      // auto cont = construct.get_continue();
+      auto header = construct.get_dominator();
+      auto merge = construct.get_exit();
 
+      //  for a given loop, its back-edge block must post dominate the
+      //  OpLoopMerge's Continue Target , and that Continue Target must dominate
+      //  that back edge block
       if (merge->is_reachable() &&
           find(merge->dom_begin(), merge->dom_end(), header) ==
               merge->dom_end()) {
         return _.diag(SPV_ERROR_INVALID_CFG)
-               << "Header block " << _.getIdName(header->get_id())
-               << " doesn't dominate its merge block "
-               << _.getIdName(merge->get_id());
+               << ConstructErrorString(construct, _.getIdName(header->get_id()),
+                                       _.getIdName(merge->get_id()));
       }
+      if (construct.get_type() == ConstructType::kContinue) {
+        if (find(header->pdom_begin(), header->pdom_end(), merge) ==
+            merge->pdom_end()) {
+          return _.diag(SPV_ERROR_INVALID_CFG) << ConstructErrorString(
+                     construct, _.getIdName(header->get_id()),
+                     _.getIdName(merge->get_id()), true);
+        }
+      }
+      // TODO(umar):  an OpSwitch block dominates all its defined case
+      // constructs
+      // TODO(umar):  each case construct has at most one branch to another
+      // case construct
+      // TODO(umar):  each case construct is branched to by at most one other
+      // case construct
+      // TODO(umar):  if Target T1 branches to Target T2, or if Target T1
+      // branches to the Default and the Default branches to Target T2, then T1
+      // must immediately precede T2 in the list of the OpSwitch Target operands
     }
-
-    /// Check all backedges target only loop headers and have exactly one
-    /// back-edge branching to it
-    set<uint32_t> loop_headers;
-    for (auto back_edge : back_edges) {
-      uint32_t back_edge_block;
-      uint32_t header_block;
-      tie(back_edge_block, header_block) = back_edge;
-      if (!function.IsBlockType(header_block, kBlockTypeLoop)) {
-        return _.diag(SPV_ERROR_INVALID_CFG)
-               << "Back-edges (" << _.getIdName(back_edge_block) << " -> "
-               << _.getIdName(header_block)
-               << ") can only be formed between a block and a loop header.";
-      }
-      bool success;
-      tie(std::ignore, success) = loop_headers.insert(header_block);
-      if (!success) {
-        // TODO(umar): List the back-edge blocks that are branching to loop
-        // header
-        return _.diag(SPV_ERROR_INVALID_CFG)
-               << "Loop header " << _.getIdName(header_block)
-               << " targeted by multiple back-edges";
-      }
-    }
-
-    // TODO(umar): For a given loop, its back-edge block must post dominate the
-    // OpLoopMerge's Continue Target, and that Continue Target must dominate the
-    // back-edge block
   }
   return SPV_SUCCESS;
 }
@@ -356,7 +463,6 @@ spv_result_t CfgPass(ValidationState_t& _,
       spvCheckReturn(_.get_current_function().RegisterBlock(inst->result_id));
       break;
     case SpvOpLoopMerge: {
-      // TODO(umar): mark current block as a loop header
       uint32_t merge_block = inst->words[inst->operands[0].offset];
       uint32_t continue_block = inst->words[inst->operands[1].offset];
       CFG_ASSERT(MergeBlockAssert, merge_block);

--- a/source/validate_cfg.cpp
+++ b/source/validate_cfg.cpp
@@ -337,7 +337,7 @@ string ConstructErrorString(Construct construct, string header_string,
 
 spv_result_t StructuredControlFlowChecks(
     ValidationState_t& _, Function function,
-    vector<pair<uint32_t, uint32_t>> back_edges) {
+    const vector<pair<uint32_t, uint32_t>>& back_edges) {
   /// Check all backedges target only loop headers and have exactly one
   /// back-edge branching to it
   set<uint32_t> loop_headers;

--- a/source/validate_cfg.cpp
+++ b/source/validate_cfg.cpp
@@ -365,7 +365,7 @@ spv_result_t PerformCfgChecks(ValidationState_t& _) {
           });
 
       /// calculate post dominators
-      auto exit_block = function.get_psudo_exit_block();
+      auto exit_block = function.get_pseudo_exit_block();
       DepthFirstTraversal(*exit_block, predecessor, [](cbb_ptr) {},
                           [&](cbb_ptr b) { postdom_postorder.push_back(b); },
                           [&](cbb_ptr, cbb_ptr) {});

--- a/source/validate_cfg.cpp
+++ b/source/validate_cfg.cpp
@@ -275,7 +275,7 @@ void UpdateContinueConstructExitBlocks(
 
     auto is_this_header = [=](Construct& c) {
       return c.get_type() == ConstructType::kLoop &&
-             c.get_dominator()->get_id() == loop_header_block_id;
+             c.get_entry()->get_id() == loop_header_block_id;
     };
 
     for (auto construct : constructs) {
@@ -420,7 +420,7 @@ spv_result_t PerformCfgChecks(ValidationState_t& _) {
 
     // Check construct rules
     for (Construct& construct : function.get_constructs()) {
-      auto header = construct.get_dominator();
+      auto header = construct.get_entry();
       auto merge = construct.get_exit();
 
       //  for a given loop, its back-edge block must post dominate the

--- a/source/validate_cfg.cpp
+++ b/source/validate_cfg.cpp
@@ -67,8 +67,6 @@ using bb_ptr = BasicBlock*;
 using cbb_ptr = const BasicBlock*;
 using bb_iter = vector<BasicBlock*>::const_iterator;
 
-using get_blocks_func = function<const vector<BasicBlock*>*(const BasicBlock*)>;
-
 struct block_info {
   cbb_ptr block;  ///< pointer to the block
   bb_iter iter;   ///< Iterator to the current child node being processed
@@ -264,6 +262,8 @@ spv_result_t MergeBlockAssert(ValidationState_t& _, uint32_t merge_block) {
   return SPV_SUCCESS;
 }
 
+/// Update the continue construct's exit blocks once the backedge blocks are
+/// identified in the CFG.
 void UpdateContinueConstructExitBlocks(
     Function& function, const vector<pair<uint32_t, uint32_t>>& back_edges) {
   auto& constructs = function.get_constructs();

--- a/test/ValidateFixtures.cpp
+++ b/test/ValidateFixtures.cpp
@@ -90,4 +90,5 @@ template class spvtest::ValidateBase<
 template class spvtest::ValidateBase<
     std::tuple<int, std::tuple<std::string, std::function<spv_result_t(int)>,
                                std::function<spv_result_t(int)>>>>;
+template class spvtest::ValidateBase<SpvCapability>;
 }


### PR DESCRIPTION
- [x] all CFG back edges must branch to a loop header, with each loop header having exactly one back edge branching to it
- [x] for a given loop, its back-edge block must post dominate the OpLoopMerge's Continue Target, and that Continue Target must dominate the back-edge block