### PR TITLE
Return ptr instead of ref for get_current_function

### DIFF
--- a/source/val/ValidationState.cpp
+++ b/source/val/ValidationState.cpp
@@ -280,9 +280,8 @@ DiagnosticStream ValidationState_t::diag(spv_result_t error_code) const {
 
 list<Function>& ValidationState_t::get_functions() { return module_functions_; }
 
-Function& ValidationState_t::get_current_function() {
-  assert(in_function_body());
-  return module_functions_.back();
+Function* ValidationState_t::get_current_function() {
+  return (in_function_) ? &module_functions_.back() : nullptr;
 }
 
 bool ValidationState_t::in_function_body() const { return in_function_; }

--- a/source/val/ValidationState.h
+++ b/source/val/ValidationState.h
@@ -125,7 +125,7 @@ class ValidationState_t {
   std::list<Function>& get_functions();
 
   /// Returns the function states
-  Function& get_current_function();
+  Function* get_current_function();
 
   /// Returns true if the called after a function instruction but before the
   /// function end instruction

--- a/source/validate_cfg.cpp
+++ b/source/validate_cfg.cpp
@@ -232,19 +232,19 @@ void printDominatorList(BasicBlock& b) {
   if (spv_result_t rcode = ASSERT_FUNC(_, TARGET)) return rcode
 
 spv_result_t FirstBlockAssert(ValidationState_t& _, uint32_t target) {
-  if (_.get_current_function().IsFirstBlock(target)) {
+  if (_.get_current_function()->IsFirstBlock(target)) {
     return _.diag(SPV_ERROR_INVALID_CFG)
            << "First block " << _.getIdName(target) << " of funciton "
-           << _.getIdName(_.get_current_function().get_id())
+           << _.getIdName(_.get_current_function()->get_id())
            << " is targeted by block "
            << _.getIdName(
-                  _.get_current_function().get_current_block()->get_id());
+                  _.get_current_function()->get_current_block()->get_id());
   }
   return SPV_SUCCESS;
 }
 
 spv_result_t MergeBlockAssert(ValidationState_t& _, uint32_t merge_block) {
-  if (_.get_current_function().IsMergeBlock(merge_block)) {
+  if (_.get_current_function()->IsMergeBlock(merge_block)) {
     return _.diag(SPV_ERROR_INVALID_CFG)
            << "Block " << _.getIdName(merge_block)
            << " is already a merge block for another header";
@@ -328,7 +328,7 @@ spv_result_t CfgPass(ValidationState_t& _,
   SpvOp opcode = static_cast<SpvOp>(inst->opcode);
   switch (opcode) {
     case SpvOpLabel:
-      spvCheckReturn(_.get_current_function().RegisterBlock(inst->result_id));
+      spvCheckReturn(_.get_current_function()->RegisterBlock(inst->result_id));
       break;
     case SpvOpLoopMerge: {
       // TODO(umar): mark current block as a loop header
@@ -336,7 +336,7 @@ spv_result_t CfgPass(ValidationState_t& _,
       uint32_t continue_block = inst->words[inst->operands[1].offset];
       CFG_ASSERT(MergeBlockAssert, merge_block);
 
-      spvCheckReturn(_.get_current_function().RegisterLoopMerge(
+      spvCheckReturn(_.get_current_function()->RegisterLoopMerge(
           merge_block, continue_block));
     } break;
     case SpvOpSelectionMerge: {
@@ -344,13 +344,13 @@ spv_result_t CfgPass(ValidationState_t& _,
       CFG_ASSERT(MergeBlockAssert, merge_block);
 
       spvCheckReturn(
-          _.get_current_function().RegisterSelectionMerge(merge_block));
+          _.get_current_function()->RegisterSelectionMerge(merge_block));
     } break;
     case SpvOpBranch: {
       uint32_t target = inst->words[inst->operands[0].offset];
       CFG_ASSERT(FirstBlockAssert, target);
 
-      _.get_current_function().RegisterBlockEnd({target}, opcode);
+      _.get_current_function()->RegisterBlockEnd({target}, opcode);
     } break;
     case SpvOpBranchConditional: {
       uint32_t tlabel = inst->words[inst->operands[1].offset];
@@ -358,7 +358,7 @@ spv_result_t CfgPass(ValidationState_t& _,
       CFG_ASSERT(FirstBlockAssert, tlabel);
       CFG_ASSERT(FirstBlockAssert, flabel);
 
-      _.get_current_function().RegisterBlockEnd({tlabel, flabel}, opcode);
+      _.get_current_function()->RegisterBlockEnd({tlabel, flabel}, opcode);
     } break;
 
     case SpvOpSwitch: {
@@ -368,13 +368,13 @@ spv_result_t CfgPass(ValidationState_t& _,
         CFG_ASSERT(FirstBlockAssert, target);
         cases.push_back(target);
       }
-      _.get_current_function().RegisterBlockEnd({cases}, opcode);
+      _.get_current_function()->RegisterBlockEnd({cases}, opcode);
     } break;
     case SpvOpKill:
     case SpvOpReturn:
     case SpvOpReturnValue:
     case SpvOpUnreachable:
-      _.get_current_function().RegisterBlockEnd({}, opcode);
+      _.get_current_function()->RegisterBlockEnd({}, opcode);
       break;
     default:
       break;

--- a/source/validate_instruction.cpp
+++ b/source/validate_instruction.cpp
@@ -144,9 +144,12 @@ spv_result_t InstructionPass(ValidationState_t& _,
                << "Variables must have a function[7] storage class inside"
                   " of a function";
       }
-      if(_.get_current_function().IsFirstBlock(_.get_current_function().get_current_block()->get_id()) == false) {
-        return _.diag(SPV_ERROR_INVALID_CFG)
-          << "Variables can only be defined in the first block of a function";
+      if (_.get_current_function()->IsFirstBlock(
+              _.get_current_function()->get_current_block()->get_id()) ==
+          false) {
+        return _.diag(SPV_ERROR_INVALID_CFG) << "Variables can only be defined "
+                                                "in the first block of a "
+                                                "function";
       }
     } else {
       if (storage_class == SpvStorageClassFunction) {

--- a/source/validate_layout.cpp
+++ b/source/validate_layout.cpp
@@ -93,7 +93,7 @@ spv_result_t FunctionScopedInstructions(ValidationState_t& _,
             _.RegisterFunction(inst->result_id, inst->type_id, control_mask,
                                inst->words[inst->operands[3].offset]));
         if (_.getLayoutSection() == kLayoutFunctionDefinitions)
-          spvCheckReturn(_.get_current_function().RegisterSetFunctionDeclType(
+          spvCheckReturn(_.get_current_function()->RegisterSetFunctionDeclType(
               FunctionDecl::kFunctionDeclDefinition));
       } break;
 
@@ -103,13 +103,13 @@ spv_result_t FunctionScopedInstructions(ValidationState_t& _,
                                                      "instructions must be in "
                                                      "a function body";
         }
-        if (_.get_current_function().get_block_count() != 0) {
+        if (_.get_current_function()->get_block_count() != 0) {
           return _.diag(SPV_ERROR_INVALID_LAYOUT)
                  << "Function parameters must only appear immediately after "
                     "the "
                     "function definition";
         }
-        spvCheckReturn(_.get_current_function().RegisterFunctionParameter(
+        spvCheckReturn(_.get_current_function()->RegisterFunctionParameter(
             inst->result_id, inst->type_id));
         break;
 
@@ -122,14 +122,14 @@ spv_result_t FunctionScopedInstructions(ValidationState_t& _,
           return _.diag(SPV_ERROR_INVALID_LAYOUT)
                  << "Function end cannot be called in blocks";
         }
-        if (_.get_current_function().get_block_count() == 0 &&
+        if (_.get_current_function()->get_block_count() == 0 &&
             _.getLayoutSection() == kLayoutFunctionDefinitions) {
           return _.diag(SPV_ERROR_INVALID_LAYOUT) << "Function declarations "
                                                      "must appear before "
                                                      "function definitions.";
         }
         if (_.getLayoutSection() == kLayoutFunctionDeclarations) {
-          spvCheckReturn(_.get_current_function().RegisterSetFunctionDeclType(
+          spvCheckReturn(_.get_current_function()->RegisterSetFunctionDeclType(
               FunctionDecl::kFunctionDeclDeclaration));
         }
         spvCheckReturn(_.RegisterFunctionEnd());
@@ -152,7 +152,7 @@ spv_result_t FunctionScopedInstructions(ValidationState_t& _,
         }
         if (_.getLayoutSection() == kLayoutFunctionDeclarations) {
           _.progressToNextLayoutSectionOrder();
-          spvCheckReturn(_.get_current_function().RegisterSetFunctionDeclType(
+          spvCheckReturn(_.get_current_function()->RegisterSetFunctionDeclType(
               FunctionDecl::kFunctionDeclDefinition));
         }
         break;


### PR DESCRIPTION
This PR changes the return type for the `get_current_function` from a reference to a pointer.