### PR TITLE
Check ID definitions appear in dominator of use

### DIFF
--- a/source/val/ValidationState.cpp
+++ b/source/val/ValidationState.cpp
@@ -280,9 +280,8 @@ DiagnosticStream ValidationState_t::diag(spv_result_t error_code) const {
 
 list<Function>& ValidationState_t::get_functions() { return module_functions_; }
 
-Function& ValidationState_t::get_current_function() {
-  assert(in_function_body());
-  return module_functions_.back();
+Function* ValidationState_t::get_current_function() {
+  return (in_function_) ? &module_functions_.back() : nullptr;
 }
 
 bool ValidationState_t::in_function_body() const { return in_function_; }

--- a/source/val/ValidationState.h
+++ b/source/val/ValidationState.h
@@ -125,7 +125,7 @@ class ValidationState_t {
   std::list<Function>& get_functions();
 
   /// Returns the function states
-  Function& get_current_function();
+  Function* get_current_function();
 
   /// Returns true if the called after a function instruction but before the
   /// function end instruction

--- a/source/validate.h
+++ b/source/validate.h
@@ -70,6 +70,14 @@ std::vector<std::pair<BasicBlock*, BasicBlock*>> CalculateDominators(
 /// @return SPV_SUCCESS if no errors are found. SPV_ERROR_INVALID_CFG otherwise
 spv_result_t PerformCfgChecks(ValidationState_t& _);
 
+/// @brief Checks the definitions of ids appear in the dominators of the blocks
+/// of where they are used
+///
+/// @param[in] _ the validation state of the module
+/// @return SPV_SUCCESS if no errors are found. SPV_ERROR_INVALID_ID otherwise
+/// NOTE: This function can only be called after PerformCfgChecks
+spv_result_t CheckIdUse(ValidationState_t& _);
+
 /// @brief Updates the immediate dominator for each of the block edges
 ///
 /// Updates the immediate dominator of the blocks for each of the edges
@@ -84,8 +92,9 @@ void UpdateImmediateDominators(
 /// @param[in] block The dominators of this block will be printed
 void printDominatorList(BasicBlock& block);
 
-/// Performs logical layout validation as described in section 2.4 of the SPIR-V
-/// spec.
+
+/// Performs logical layout validation as described in section 2.4 of the
+/// SPIR-V spec.
 spv_result_t ModuleLayoutPass(ValidationState_t& _,
                               const spv_parsed_instruction_t* inst);
 

--- a/source/validate_cfg.cpp
+++ b/source/validate_cfg.cpp
@@ -232,19 +232,19 @@ void printDominatorList(BasicBlock& b) {
   if (spv_result_t rcode = ASSERT_FUNC(_, TARGET)) return rcode
 
 spv_result_t FirstBlockAssert(ValidationState_t& _, uint32_t target) {
-  if (_.get_current_function().IsFirstBlock(target)) {
+  if (_.get_current_function()->IsFirstBlock(target)) {
     return _.diag(SPV_ERROR_INVALID_CFG)
            << "First block " << _.getIdName(target) << " of funciton "
-           << _.getIdName(_.get_current_function().get_id())
+           << _.getIdName(_.get_current_function()->get_id())
            << " is targeted by block "
            << _.getIdName(
-                  _.get_current_function().get_current_block()->get_id());
+                  _.get_current_function()->get_current_block()->get_id());
   }
   return SPV_SUCCESS;
 }
 
 spv_result_t MergeBlockAssert(ValidationState_t& _, uint32_t merge_block) {
-  if (_.get_current_function().IsMergeBlock(merge_block)) {
+  if (_.get_current_function()->IsMergeBlock(merge_block)) {
     return _.diag(SPV_ERROR_INVALID_CFG)
            << "Block " << _.getIdName(merge_block)
            << " is already a merge block for another header";
@@ -328,7 +328,7 @@ spv_result_t CfgPass(ValidationState_t& _,
   SpvOp opcode = static_cast<SpvOp>(inst->opcode);
   switch (opcode) {
     case SpvOpLabel:
-      spvCheckReturn(_.get_current_function().RegisterBlock(inst->result_id));
+      spvCheckReturn(_.get_current_function()->RegisterBlock(inst->result_id));
       break;
     case SpvOpLoopMerge: {
       // TODO(umar): mark current block as a loop header
@@ -336,7 +336,7 @@ spv_result_t CfgPass(ValidationState_t& _,
       uint32_t continue_block = inst->words[inst->operands[1].offset];
       CFG_ASSERT(MergeBlockAssert, merge_block);
 
-      spvCheckReturn(_.get_current_function().RegisterLoopMerge(
+      spvCheckReturn(_.get_current_function()->RegisterLoopMerge(
           merge_block, continue_block));
     } break;
     case SpvOpSelectionMerge: {
@@ -344,13 +344,13 @@ spv_result_t CfgPass(ValidationState_t& _,
       CFG_ASSERT(MergeBlockAssert, merge_block);
 
       spvCheckReturn(
-          _.get_current_function().RegisterSelectionMerge(merge_block));
+          _.get_current_function()->RegisterSelectionMerge(merge_block));
     } break;
     case SpvOpBranch: {
       uint32_t target = inst->words[inst->operands[0].offset];
       CFG_ASSERT(FirstBlockAssert, target);
 
-      _.get_current_function().RegisterBlockEnd({target}, opcode);
+      _.get_current_function()->RegisterBlockEnd({target}, opcode);
     } break;
     case SpvOpBranchConditional: {
       uint32_t tlabel = inst->words[inst->operands[1].offset];
@@ -358,7 +358,7 @@ spv_result_t CfgPass(ValidationState_t& _,
       CFG_ASSERT(FirstBlockAssert, tlabel);
       CFG_ASSERT(FirstBlockAssert, flabel);
 
-      _.get_current_function().RegisterBlockEnd({tlabel, flabel}, opcode);
+      _.get_current_function()->RegisterBlockEnd({tlabel, flabel}, opcode);
     } break;
 
     case SpvOpSwitch: {
@@ -368,13 +368,13 @@ spv_result_t CfgPass(ValidationState_t& _,
         CFG_ASSERT(FirstBlockAssert, target);
         cases.push_back(target);
       }
-      _.get_current_function().RegisterBlockEnd({cases}, opcode);
+      _.get_current_function()->RegisterBlockEnd({cases}, opcode);
     } break;
     case SpvOpKill:
     case SpvOpReturn:
     case SpvOpReturnValue:
     case SpvOpUnreachable:
-      _.get_current_function().RegisterBlockEnd({}, opcode);
+      _.get_current_function()->RegisterBlockEnd({}, opcode);
       break;
     default:
       break;

--- a/source/validate_instruction.cpp
+++ b/source/validate_instruction.cpp
@@ -144,9 +144,12 @@ spv_result_t InstructionPass(ValidationState_t& _,
                << "Variables must have a function[7] storage class inside"
                   " of a function";
       }
-      if(_.get_current_function().IsFirstBlock(_.get_current_function().get_current_block()->get_id()) == false) {
-        return _.diag(SPV_ERROR_INVALID_CFG)
-          << "Variables can only be defined in the first block of a function";
+      if (_.get_current_function()->IsFirstBlock(
+              _.get_current_function()->get_current_block()->get_id()) ==
+          false) {
+        return _.diag(SPV_ERROR_INVALID_CFG) << "Variables can only be defined "
+                                                "in the first block of a "
+                                                "function";
       }
     } else {
       if (storage_class == SpvStorageClassFunction) {

--- a/source/validate_layout.cpp
+++ b/source/validate_layout.cpp
@@ -93,7 +93,7 @@ spv_result_t FunctionScopedInstructions(ValidationState_t& _,
             _.RegisterFunction(inst->result_id, inst->type_id, control_mask,
                                inst->words[inst->operands[3].offset]));
         if (_.getLayoutSection() == kLayoutFunctionDefinitions)
-          spvCheckReturn(_.get_current_function().RegisterSetFunctionDeclType(
+          spvCheckReturn(_.get_current_function()->RegisterSetFunctionDeclType(
               FunctionDecl::kFunctionDeclDefinition));
       } break;
 
@@ -103,13 +103,13 @@ spv_result_t FunctionScopedInstructions(ValidationState_t& _,
                                                      "instructions must be in "
                                                      "a function body";
         }
-        if (_.get_current_function().get_block_count() != 0) {
+        if (_.get_current_function()->get_block_count() != 0) {
           return _.diag(SPV_ERROR_INVALID_LAYOUT)
                  << "Function parameters must only appear immediately after "
                     "the "
                     "function definition";
         }
-        spvCheckReturn(_.get_current_function().RegisterFunctionParameter(
+        spvCheckReturn(_.get_current_function()->RegisterFunctionParameter(
             inst->result_id, inst->type_id));
         break;
 
@@ -122,14 +122,14 @@ spv_result_t FunctionScopedInstructions(ValidationState_t& _,
           return _.diag(SPV_ERROR_INVALID_LAYOUT)
                  << "Function end cannot be called in blocks";
         }
-        if (_.get_current_function().get_block_count() == 0 &&
+        if (_.get_current_function()->get_block_count() == 0 &&
             _.getLayoutSection() == kLayoutFunctionDefinitions) {
           return _.diag(SPV_ERROR_INVALID_LAYOUT) << "Function declarations "
                                                      "must appear before "
                                                      "function definitions.";
         }
         if (_.getLayoutSection() == kLayoutFunctionDeclarations) {
-          spvCheckReturn(_.get_current_function().RegisterSetFunctionDeclType(
+          spvCheckReturn(_.get_current_function()->RegisterSetFunctionDeclType(
               FunctionDecl::kFunctionDeclDeclaration));
         }
         spvCheckReturn(_.RegisterFunctionEnd());
@@ -152,7 +152,7 @@ spv_result_t FunctionScopedInstructions(ValidationState_t& _,
         }
         if (_.getLayoutSection() == kLayoutFunctionDeclarations) {
           _.progressToNextLayoutSectionOrder();
-          spvCheckReturn(_.get_current_function().RegisterSetFunctionDeclType(
+          spvCheckReturn(_.get_current_function()->RegisterSetFunctionDeclType(
               FunctionDecl::kFunctionDeclDefinition));
         }
         break;

--- a/test/Validate.SSA.cpp
+++ b/test/Validate.SSA.cpp
@@ -35,15 +35,16 @@
 #include <utility>
 
 using ::testing::HasSubstr;
+using ::testing::MatchesRegex;
 
 using std::string;
 using std::pair;
 using std::stringstream;
 
 namespace {
-using Validate = spvtest::ValidateBase<pair<string, bool>>;
+using ValidateSSA = spvtest::ValidateBase<pair<string, bool>>;
 
-TEST_F(Validate, Default) {
+TEST_F(ValidateSSA, Default) {
   char str[] = R"(
      OpCapability Shader
      OpMemoryModel Logical GLSL450
@@ -60,7 +61,7 @@ TEST_F(Validate, Default) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(Validate, IdUndefinedBad) {
+TEST_F(ValidateSSA, IdUndefinedBad) {
   char str[] = R"(
           OpCapability Shader
           OpMemoryModel Logical GLSL450
@@ -77,7 +78,7 @@ TEST_F(Validate, IdUndefinedBad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("missing"));
 }
 
-TEST_F(Validate, IdRedefinedBad) {
+TEST_F(ValidateSSA, IdRedefinedBad) {
   char str[] = R"(
      OpCapability Shader
      OpMemoryModel Logical GLSL450
@@ -93,7 +94,7 @@ TEST_F(Validate, IdRedefinedBad) {
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
 }
 
-TEST_F(Validate, DominateUsageBad) {
+TEST_F(ValidateSSA, DominateUsageBad) {
   char str[] = R"(
      OpCapability Shader
      OpMemoryModel Logical GLSL450
@@ -106,7 +107,7 @@ TEST_F(Validate, DominateUsageBad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("not_dominant"));
 }
 
-TEST_F(Validate, ForwardNameGood) {
+TEST_F(ValidateSSA, ForwardNameGood) {
   char str[] = R"(
      OpCapability Shader
      OpMemoryModel Logical GLSL450
@@ -122,7 +123,7 @@ TEST_F(Validate, ForwardNameGood) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(Validate, ForwardNameMissingTargetBad) {
+TEST_F(ValidateSSA, ForwardNameMissingTargetBad) {
   char str[] = R"(
       OpCapability Shader
       OpMemoryModel Logical GLSL450
@@ -133,7 +134,7 @@ TEST_F(Validate, ForwardNameMissingTargetBad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("main"));
 }
 
-TEST_F(Validate, ForwardMemberNameGood) {
+TEST_F(ValidateSSA, ForwardMemberNameGood) {
   char str[] = R"(
            OpCapability Shader
            OpMemoryModel Logical GLSL450
@@ -147,7 +148,7 @@ TEST_F(Validate, ForwardMemberNameGood) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(Validate, ForwardMemberNameMissingTargetBad) {
+TEST_F(ValidateSSA, ForwardMemberNameMissingTargetBad) {
   char str[] = R"(
            OpCapability Shader
            OpMemoryModel Logical GLSL450
@@ -162,7 +163,7 @@ TEST_F(Validate, ForwardMemberNameMissingTargetBad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("size"));
 }
 
-TEST_F(Validate, ForwardDecorateGood) {
+TEST_F(ValidateSSA, ForwardDecorateGood) {
   char str[] = R"(
            OpCapability Shader
            OpMemoryModel Logical GLSL450
@@ -175,7 +176,7 @@ TEST_F(Validate, ForwardDecorateGood) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(Validate, ForwardDecorateInvalidIDBad) {
+TEST_F(ValidateSSA, ForwardDecorateInvalidIDBad) {
   char str[] = R"(
            OpCapability Shader
            OpMemoryModel Logical GLSL450
@@ -196,7 +197,7 @@ TEST_F(Validate, ForwardDecorateInvalidIDBad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("missing"));
 }
 
-TEST_F(Validate, ForwardMemberDecorateGood) {
+TEST_F(ValidateSSA, ForwardMemberDecorateGood) {
   char str[] = R"(
            OpCapability Shader
            OpMemoryModel Logical GLSL450
@@ -210,7 +211,7 @@ TEST_F(Validate, ForwardMemberDecorateGood) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(Validate, ForwardMemberDecorateInvalidIdBad) {
+TEST_F(ValidateSSA, ForwardMemberDecorateInvalidIdBad) {
   char str[] = R"(
            OpCapability Shader
            OpMemoryModel Logical GLSL450
@@ -226,7 +227,7 @@ TEST_F(Validate, ForwardMemberDecorateInvalidIdBad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("missing"));
 }
 
-TEST_F(Validate, ForwardGroupDecorateGood) {
+TEST_F(ValidateSSA, ForwardGroupDecorateGood) {
   char str[] = R"(
           OpCapability Shader
           OpMemoryModel Logical GLSL450
@@ -243,7 +244,7 @@ TEST_F(Validate, ForwardGroupDecorateGood) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(Validate, ForwardGroupDecorateMissingGroupBad) {
+TEST_F(ValidateSSA, ForwardGroupDecorateMissingGroupBad) {
   char str[] = R"(
            OpCapability Shader
            OpMemoryModel Logical GLSL450
@@ -262,7 +263,7 @@ TEST_F(Validate, ForwardGroupDecorateMissingGroupBad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("missing"));
 }
 
-TEST_F(Validate, ForwardGroupDecorateMissingTargetBad) {
+TEST_F(ValidateSSA, ForwardGroupDecorateMissingTargetBad) {
   char str[] = R"(
            OpCapability Shader
            OpMemoryModel Logical GLSL450
@@ -281,7 +282,7 @@ TEST_F(Validate, ForwardGroupDecorateMissingTargetBad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("missing"));
 }
 
-TEST_F(Validate, ForwardGroupDecorateDecorationGroupDominateBad) {
+TEST_F(ValidateSSA, ForwardGroupDecorateDecorationGroupDominateBad) {
   char str[] = R"(
            OpCapability Shader
            OpMemoryModel Logical GLSL450
@@ -300,7 +301,7 @@ TEST_F(Validate, ForwardGroupDecorateDecorationGroupDominateBad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("group"));
 }
 
-TEST_F(Validate, ForwardDecorateInvalidIdBad) {
+TEST_F(ValidateSSA, ForwardDecorateInvalidIdBad) {
   char str[] = R"(
            OpCapability Shader
            OpMemoryModel Logical GLSL450
@@ -321,7 +322,7 @@ TEST_F(Validate, ForwardDecorateInvalidIdBad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("missing"));
 }
 
-TEST_F(Validate, FunctionCallGood) {
+TEST_F(ValidateSSA, FunctionCallGood) {
   char str[] = R"(
          OpCapability Shader
          OpMemoryModel Logical GLSL450
@@ -348,7 +349,7 @@ TEST_F(Validate, FunctionCallGood) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(Validate, ForwardFunctionCallGood) {
+TEST_F(ValidateSSA, ForwardFunctionCallGood) {
   char str[] = R"(
          OpCapability Shader
          OpMemoryModel Logical GLSL450
@@ -375,7 +376,7 @@ TEST_F(Validate, ForwardFunctionCallGood) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(Validate, ForwardBranchConditionalGood) {
+TEST_F(ValidateSSA, ForwardBranchConditionalGood) {
   char str[] = R"(
             OpCapability Shader
             OpMemoryModel Logical GLSL450
@@ -401,7 +402,7 @@ TEST_F(Validate, ForwardBranchConditionalGood) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(Validate, ForwardBranchConditionalWithWeightsGood) {
+TEST_F(ValidateSSA, ForwardBranchConditionalWithWeightsGood) {
   char str[] = R"(
            OpCapability Shader
            OpMemoryModel Logical GLSL450
@@ -427,7 +428,7 @@ TEST_F(Validate, ForwardBranchConditionalWithWeightsGood) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(Validate, ForwardBranchConditionalNonDominantConditionBad) {
+TEST_F(ValidateSSA, ForwardBranchConditionalNonDominantConditionBad) {
   char str[] = R"(
            OpCapability Shader
            OpMemoryModel Logical GLSL450
@@ -456,7 +457,7 @@ TEST_F(Validate, ForwardBranchConditionalNonDominantConditionBad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("conditional"));
 }
 
-TEST_F(Validate, ForwardBranchConditionalMissingTargetBad) {
+TEST_F(ValidateSSA, ForwardBranchConditionalMissingTargetBad) {
   char str[] = R"(
            OpCapability Shader
            OpMemoryModel Logical GLSL450
@@ -541,7 +542,7 @@ const string kKernelDefinition = R"(
           OpFunctionEnd
 )";
 
-TEST_F(Validate, EnqueueKernelGood) {
+TEST_F(ValidateSSA, EnqueueKernelGood) {
   string str = kHeader + kBasicTypes + kKernelTypesAndConstants +
                kKernelDefinition + R"(
                 %main   = OpFunction %voidt None %vfunct
@@ -558,7 +559,7 @@ TEST_F(Validate, EnqueueKernelGood) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(Validate, ForwardEnqueueKernelGood) {
+TEST_F(ValidateSSA, ForwardEnqueueKernelGood) {
   string str = kHeader + kBasicTypes + kKernelTypesAndConstants + R"(
                 %main   = OpFunction %voidt None %vfunct
                 %mainl  = OpLabel
@@ -575,7 +576,7 @@ TEST_F(Validate, ForwardEnqueueKernelGood) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(Validate, EnqueueMissingFunctionBad) {
+TEST_F(ValidateSSA, EnqueueMissingFunctionBad) {
   string str = kHeader + "OpName %kfunc \"kfunc\"" + kBasicTypes +
                kKernelTypesAndConstants + R"(
                 %main   = OpFunction %voidt None %vfunct
@@ -610,7 +611,7 @@ string forwardKernelNonDominantParameterBaseCode(string name = string()) {
   return out;
 }
 
-TEST_F(Validate, ForwardEnqueueKernelMissingParameter1Bad) {
+TEST_F(ValidateSSA, ForwardEnqueueKernelMissingParameter1Bad) {
   string str = forwardKernelNonDominantParameterBaseCode("missing") + R"(
                 %err    = OpEnqueueKernel %missing %dqueue %flags %ndval
                                         %nevent %event %revent %kfunc %firstp
@@ -623,7 +624,7 @@ TEST_F(Validate, ForwardEnqueueKernelMissingParameter1Bad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("missing"));
 }
 
-TEST_F(Validate, ForwardEnqueueKernelNonDominantParameter2Bad) {
+TEST_F(ValidateSSA, ForwardEnqueueKernelNonDominantParameter2Bad) {
   string str = forwardKernelNonDominantParameterBaseCode("dqueue2") + R"(
                 %err     = OpEnqueueKernel %uintt %dqueue2 %flags %ndval
                                             %nevent %event %revent %kfunc
@@ -637,7 +638,7 @@ TEST_F(Validate, ForwardEnqueueKernelNonDominantParameter2Bad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("dqueue2"));
 }
 
-TEST_F(Validate, ForwardEnqueueKernelNonDominantParameter3Bad) {
+TEST_F(ValidateSSA, ForwardEnqueueKernelNonDominantParameter3Bad) {
   string str = forwardKernelNonDominantParameterBaseCode("ndval2") + R"(
                 %err    = OpEnqueueKernel %uintt %dqueue %flags %ndval2
                                         %nevent %event %revent %kfunc %firstp
@@ -651,7 +652,7 @@ TEST_F(Validate, ForwardEnqueueKernelNonDominantParameter3Bad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("ndval2"));
 }
 
-TEST_F(Validate, ForwardEnqueueKernelNonDominantParameter4Bad) {
+TEST_F(ValidateSSA, ForwardEnqueueKernelNonDominantParameter4Bad) {
   string str = forwardKernelNonDominantParameterBaseCode("nevent2") + R"(
               %err    = OpEnqueueKernel %uintt %dqueue %flags %ndval %nevent2
                                         %event %revent %kfunc %firstp %psize
@@ -665,7 +666,7 @@ TEST_F(Validate, ForwardEnqueueKernelNonDominantParameter4Bad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("nevent2"));
 }
 
-TEST_F(Validate, ForwardEnqueueKernelNonDominantParameter5Bad) {
+TEST_F(ValidateSSA, ForwardEnqueueKernelNonDominantParameter5Bad) {
   string str = forwardKernelNonDominantParameterBaseCode("event2") + R"(
               %err     = OpEnqueueKernel %uintt %dqueue %flags %ndval %nevent
                                         %event2 %revent %kfunc %firstp %psize
@@ -679,7 +680,7 @@ TEST_F(Validate, ForwardEnqueueKernelNonDominantParameter5Bad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("event2"));
 }
 
-TEST_F(Validate, ForwardEnqueueKernelNonDominantParameter6Bad) {
+TEST_F(ValidateSSA, ForwardEnqueueKernelNonDominantParameter6Bad) {
   string str = forwardKernelNonDominantParameterBaseCode("revent2") + R"(
               %err     = OpEnqueueKernel %uintt %dqueue %flags %ndval %nevent
                                         %event %revent2 %kfunc %firstp %psize
@@ -693,7 +694,7 @@ TEST_F(Validate, ForwardEnqueueKernelNonDominantParameter6Bad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("revent2"));
 }
 
-TEST_F(Validate, ForwardEnqueueKernelNonDominantParameter8Bad) {
+TEST_F(ValidateSSA, ForwardEnqueueKernelNonDominantParameter8Bad) {
   string str = forwardKernelNonDominantParameterBaseCode("firstp2") + R"(
               %err     = OpEnqueueKernel %uintt %dqueue %flags %ndval %nevent
                                         %event %revent %kfunc %firstp2 %psize
@@ -707,7 +708,7 @@ TEST_F(Validate, ForwardEnqueueKernelNonDominantParameter8Bad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("firstp2"));
 }
 
-TEST_F(Validate, ForwardEnqueueKernelNonDominantParameter9Bad) {
+TEST_F(ValidateSSA, ForwardEnqueueKernelNonDominantParameter9Bad) {
   string str = forwardKernelNonDominantParameterBaseCode("psize2") + R"(
               %err    = OpEnqueueKernel %uintt %dqueue %flags %ndval %nevent
                                         %event %revent %kfunc %firstp %psize2
@@ -721,7 +722,7 @@ TEST_F(Validate, ForwardEnqueueKernelNonDominantParameter9Bad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("psize2"));
 }
 
-TEST_F(Validate, ForwardEnqueueKernelNonDominantParameter10Bad) {
+TEST_F(ValidateSSA, ForwardEnqueueKernelNonDominantParameter10Bad) {
   string str = forwardKernelNonDominantParameterBaseCode("palign2") + R"(
               %err     = OpEnqueueKernel %uintt %dqueue %flags %ndval %nevent
                                         %event %revent %kfunc %firstp %psize
@@ -735,7 +736,7 @@ TEST_F(Validate, ForwardEnqueueKernelNonDominantParameter10Bad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("palign2"));
 }
 
-TEST_F(Validate, ForwardEnqueueKernelNonDominantParameter11Bad) {
+TEST_F(ValidateSSA, ForwardEnqueueKernelNonDominantParameter11Bad) {
   string str = forwardKernelNonDominantParameterBaseCode("lsize2") + R"(
               %err     = OpEnqueueKernel %uintt %dqueue %flags %ndval %nevent
                                         %event %revent %kfunc %firstp %psize
@@ -758,14 +759,14 @@ pair<string, bool> cases[] = {
     {"OpGetKernelWorkGroupSize", kNoNDrange},
     {"OpGetKernelPreferredWorkGroupSizeMultiple", kNoNDrange}};
 
-INSTANTIATE_TEST_CASE_P(KernelArgs, Validate, ::testing::ValuesIn(cases),);
+INSTANTIATE_TEST_CASE_P(KernelArgs, ValidateSSA, ::testing::ValuesIn(cases), );
 
 static const string return_instructions = R"(
   OpReturn
   OpFunctionEnd
 )";
 
-TEST_P(Validate, GetKernelGood) {
+TEST_P(ValidateSSA, GetKernelGood) {
   string instruction = GetParam().first;
   bool with_ndrange = GetParam().second;
   string ndrange_param = with_ndrange ? " %ndval " : " ";
@@ -781,7 +782,7 @@ TEST_P(Validate, GetKernelGood) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_P(Validate, ForwardGetKernelGood) {
+TEST_P(ValidateSSA, ForwardGetKernelGood) {
   string instruction = GetParam().first;
   bool with_ndrange = GetParam().second;
   string ndrange_param = with_ndrange ? " %ndval " : " ";
@@ -801,7 +802,7 @@ TEST_P(Validate, ForwardGetKernelGood) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_P(Validate, ForwardGetKernelMissingDefinitionBad) {
+TEST_P(ValidateSSA, ForwardGetKernelMissingDefinitionBad) {
   string instruction = GetParam().first;
   bool with_ndrange = GetParam().second;
   string ndrange_param = with_ndrange ? " %ndval " : " ";
@@ -818,7 +819,7 @@ TEST_P(Validate, ForwardGetKernelMissingDefinitionBad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("missing"));
 }
 
-TEST_P(Validate, ForwardGetKernelNDrangeSubGroupCountMissingParameter1Bad) {
+TEST_P(ValidateSSA, ForwardGetKernelNDrangeSubGroupCountMissingParameter1Bad) {
   string instruction = GetParam().first;
   bool with_ndrange = GetParam().second;
   string ndrange_param = with_ndrange ? " %ndval " : " ";
@@ -835,7 +836,8 @@ TEST_P(Validate, ForwardGetKernelNDrangeSubGroupCountMissingParameter1Bad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("missing"));
 }
 
-TEST_P(Validate, ForwardGetKernelNDrangeSubGroupCountNonDominantParameter2Bad) {
+TEST_P(ValidateSSA,
+       ForwardGetKernelNDrangeSubGroupCountNonDominantParameter2Bad) {
   string instruction = GetParam().first;
   bool with_ndrange = GetParam().second;
   string ndrange_param = with_ndrange ? " %ndval2 " : " ";
@@ -855,7 +857,8 @@ TEST_P(Validate, ForwardGetKernelNDrangeSubGroupCountNonDominantParameter2Bad) {
   }
 }
 
-TEST_P(Validate, ForwardGetKernelNDrangeSubGroupCountNonDominantParameter4Bad) {
+TEST_P(ValidateSSA,
+       ForwardGetKernelNDrangeSubGroupCountNonDominantParameter4Bad) {
   string instruction = GetParam().first;
   bool with_ndrange = GetParam().second;
   string ndrange_param = with_ndrange ? " %ndval " : " ";
@@ -873,7 +876,8 @@ TEST_P(Validate, ForwardGetKernelNDrangeSubGroupCountNonDominantParameter4Bad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("firstp2"));
 }
 
-TEST_P(Validate, ForwardGetKernelNDrangeSubGroupCountNonDominantParameter5Bad) {
+TEST_P(ValidateSSA,
+       ForwardGetKernelNDrangeSubGroupCountNonDominantParameter5Bad) {
   string instruction = GetParam().first;
   bool with_ndrange = GetParam().second;
   string ndrange_param = with_ndrange ? " %ndval " : " ";
@@ -891,7 +895,8 @@ TEST_P(Validate, ForwardGetKernelNDrangeSubGroupCountNonDominantParameter5Bad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("psize2"));
 }
 
-TEST_P(Validate, ForwardGetKernelNDrangeSubGroupCountNonDominantParameter6Bad) {
+TEST_P(ValidateSSA,
+       ForwardGetKernelNDrangeSubGroupCountNonDominantParameter6Bad) {
   string instruction = GetParam().first;
   bool with_ndrange = GetParam().second;
   string ndrange_param = with_ndrange ? " %ndval " : " ";
@@ -911,7 +916,7 @@ TEST_P(Validate, ForwardGetKernelNDrangeSubGroupCountNonDominantParameter6Bad) {
   }
 }
 
-TEST_F(Validate, PhiGood) {
+TEST_F(ValidateSSA, PhiGood) {
   string str = kHeader + kBasicTypes +
                R"(
 %zero      = OpConstant %intt 0
@@ -937,7 +942,7 @@ TEST_F(Validate, PhiGood) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(Validate, PhiMissingTypeBad) {
+TEST_F(ValidateSSA, PhiMissingTypeBad) {
   string str = kHeader + "OpName %missing \"missing\"" + kBasicTypes +
                R"(
 %zero      = OpConstant %intt 0
@@ -964,7 +969,7 @@ TEST_F(Validate, PhiMissingTypeBad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("missing"));
 }
 
-TEST_F(Validate, PhiMissingIdBad) {
+TEST_F(ValidateSSA, PhiMissingIdBad) {
   string str = kHeader + "OpName %missing \"missing\"" + kBasicTypes +
                R"(
 %zero      = OpConstant %intt 0
@@ -991,7 +996,7 @@ TEST_F(Validate, PhiMissingIdBad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("missing"));
 }
 
-TEST_F(Validate, PhiMissingLabelBad) {
+TEST_F(ValidateSSA, PhiMissingLabelBad) {
   string str = kHeader + "OpName %missing \"missing\"" + kBasicTypes +
                R"(
 %zero      = OpConstant %intt 0
@@ -1018,5 +1023,125 @@ TEST_F(Validate, PhiMissingLabelBad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr("missing"));
 }
 
-// TODO(umar): OpGroupMemberDecorate
+TEST_F(ValidateSSA, IdDominatesItsUseGood) {
+  string str = kHeader + kBasicTypes +
+               R"(
+%one       = OpConstant %intt 1
+%ten       = OpConstant %intt 10
+%func      = OpFunction %voidt None %vfunct
+%entry     = OpLabel
+%cond      = OpSLessThan %intt %one %ten
+%eleven    = OpIAdd %intt %one %ten
+             OpSelectionMerge %merge None
+             OpBranchConditional %cond %t %f
+%t         = OpLabel
+%twelve    = OpIAdd %intt %eleven %one
+             OpBranch %merge
+%f         = OpLabel
+%twentytwo = OpIAdd %intt %eleven %ten
+             OpBranch %merge
+%merge     = OpLabel
+             OpReturn
+             OpFunctionEnd
+)";
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
+
+TEST_F(ValidateSSA, IdDoesNotDominateItsUseBad) {
+  string str = kHeader +
+               "OpName %eleven \"eleven\"\n"
+               "OpName %true_block \"true_block\"\n"
+               "OpName %false_block \"false_block\"" +
+               kBasicTypes +
+               R"(
+%one         = OpConstant %intt 1
+%ten         = OpConstant %intt 10
+%func        = OpFunction %voidt None %vfunct
+%entry       = OpLabel
+%cond        = OpSLessThan %intt %one %ten
+               OpSelectionMerge %merge None
+               OpBranchConditional %cond %true_block %false_block
+%true_block  = OpLabel
+%eleven      = OpIAdd %intt %one %ten
+%twelve      = OpIAdd %intt %eleven %one
+               OpBranch %merge
+%false_block = OpLabel
+%twentytwo   = OpIAdd %intt %eleven %ten
+               OpBranch %merge
+%merge       = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      MatchesRegex("ID .\\[eleven\\] defined in block .\\[true_block\\] does "
+                   "not dominate its use in block .\\[false_block\\]"));
+}
+
+TEST_F(ValidateSSA, PhiUseDoesntDominateDefinitionGood) {
+
+  string str = kHeader + kBasicTypes +
+      R"(
+%one         = OpConstant %intt 1
+%ten         = OpConstant %intt 10
+%intptrt     = OpTypePointer UniformConstant %intt
+%func        = OpFunction %voidt None %vfunct
+%entry       = OpLabel
+%var_one     = OpVariable %intptrt Function %one
+%one_val     = OpLoad %intt %var_one
+               OpBranch %loop
+%loop        = OpLabel
+%i           = OpPhi %intt %one_val %entry %inew %cont
+%cond        = OpSLessThan %intt %one %ten
+               OpLoopMerge %merge %cont None
+               OpBranchConditional %cond %body %merge
+%body        = OpLabel
+               OpBranch %cont
+%cont        = OpLabel
+%inew        = OpIAdd %intt %i %one
+               OpBranch %loop
+%merge       = OpLabel
+               OpReturn
+)";
+
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateSSA, PhiUseDoesntDominateWithOverlappingUseDefinitionBad) {
+
+  string str = kHeader +
+      kBasicTypes +
+      R"(
+%one         = OpConstant %intt 1
+%ten         = OpConstant %intt 10
+%intptrt     = OpTypePointer UniformConstant %intt
+%func        = OpFunction %voidt None %vfunct
+%entry       = OpLabel
+%var_one     = OpVariable %intptrt Function %one
+%one_val     = OpLoad %intt %var_one
+               OpBranch %loop
+%loop        = OpLabel
+%i           = OpPhi %intt %one_val %entry %inew %cont
+%bad         = OpIAdd %intt %inew %one
+%cond        = OpSLessThan %intt %one %ten
+               OpLoopMerge %merge %cont None
+               OpBranchConditional %cond %body %merge
+%body        = OpLabel
+               OpBranch %cont
+%cont        = OpLabel
+%inew        = OpIAdd %intt %i %one
+               OpBranch %loop
+%merge       = OpLabel
+               OpReturn
+)";
+
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+}
+
+// TODO(umar): OpGroupMemberDecorate
+}  // namespace


### PR DESCRIPTION
depends on #236 

This PR checks if definitions of ID appear in the dominators of the blocks of where they are used.

Takes into account of phi instructions that may appear in the header of a loop.