### PR TITLE
Use pseudo entry and pseudo exit blocks for dominance.

### DIFF
--- a/source/val/BasicBlock.cpp
+++ b/source/val/BasicBlock.cpp
@@ -26,6 +26,7 @@
 
 #include "BasicBlock.h"
 
+#include <utility>
 #include <vector>
 
 using std::vector;
@@ -73,6 +74,14 @@ void BasicBlock::RegisterSuccessors(const vector<BasicBlock*>& next_blocks) {
 void BasicBlock::RegisterBranchInstruction(SpvOp branch_instruction) {
   if (branch_instruction == SpvOpUnreachable) reachable_ = false;
   return;
+}
+
+void BasicBlock::SetSuccessorsUnsafe(std::vector<BasicBlock*>&& others) {
+  successors_ = std::move(others);
+}
+
+void BasicBlock::SetPredecessorsUnsafe(std::vector<BasicBlock*>&& others) {
+  predecessors_ = std::move(others);
 }
 
 BasicBlock::DominatorIterator::DominatorIterator() : current_(nullptr) {}

--- a/source/val/BasicBlock.h
+++ b/source/val/BasicBlock.h
@@ -123,6 +123,14 @@ class BasicBlock {
   /// Adds @p next BasicBlocks as successors of this BasicBlock
   void RegisterSuccessors(const std::vector<BasicBlock*>& next = {});
 
+  /// Set the successors to this block, without updating other internal state,
+  /// and without updating the other blocks.
+  void SetSuccessorsUnsafe(std::vector<BasicBlock*>&& others);
+
+  /// Set the predecessors to this block, without updating other internal state,
+  /// and without updating the other blocks.
+  void SetPredecessorsUnsafe(std::vector<BasicBlock*>&& others);
+
   /// Returns true if the id of the BasicBlock matches
   bool operator==(const BasicBlock& other) const { return other.id_ == id_; }
 

--- a/source/val/Function.h
+++ b/source/val/Function.h
@@ -95,10 +95,13 @@ class Function {
 
   /// Registers the end of the block
   ///
-  /// @param[in] successors_list A list of ids to the blocks successors
+  /// @param[in] successors_list A list of ids to the block's successors
   /// @param[in] branch_instruction the branch instruction that ended the block
   void RegisterBlockEnd(std::vector<uint32_t> successors_list,
                         SpvOp branch_instruction);
+
+  /// Registers the end of the function.  This is idempotent.
+  void RegisterFunctionEnd();
 
   /// Returns true if the \p id block is the first block of this function
   bool IsFirstBlock(uint32_t id) const;
@@ -149,11 +152,31 @@ class Function {
   /// Returns the block that is currently being parsed in the binary
   const BasicBlock* get_current_block() const;
 
-  /// Returns the psudo exit block
+  /// Returns the pseudo exit block
+  BasicBlock* get_pseudo_entry_block();
+
+  /// Returns the pseudo exit block
+  const BasicBlock* get_pseudo_entry_block() const;
+
+  /// Returns the pseudo exit block
   BasicBlock* get_pseudo_exit_block();
 
-  /// Returns the psudo exit block
+  /// Returns the pseudo exit block
   const BasicBlock* get_pseudo_exit_block() const;
+
+  /// Returns a vector with just the pseudo entry block.
+  /// This serves as the predecessors of each source node in the CFG when computing
+  /// dominators.
+  const std::vector<BasicBlock*>* get_pseudo_entry_blocks() const {
+    return &pseudo_entry_blocks_;
+  }
+
+  /// Returns a vector with just the pseudo exit block.
+  /// This serves as the successors of each sink node in the CFG when computing
+  /// dominators.
+  const std::vector<BasicBlock*>* get_pseudo_exit_blocks() const {
+    return &pseudo_exit_blocks_;
+  }
 
   /// Prints a GraphViz digraph of the CFG of the current funciton
   void printDotGraph() const;
@@ -180,6 +203,9 @@ class Function {
   /// The type of declaration of each function
   FunctionDecl declaration_type_;
 
+  // Have we finished parsing this function?
+  bool end_has_been_registered_;
+
   /// The blocks in the function mapped by block ID
   std::unordered_map<uint32_t, BasicBlock> blocks_;
 
@@ -192,8 +218,28 @@ class Function {
   /// The block that is currently being parsed
   BasicBlock* current_block_;
 
-  /// A pseudo exit block that is the successor to all return blocks
+  /// A pseudo entry block that, for the purposes of dominance analysis,
+  /// is considered the predecessor to any ordinary block without predecessors.
+  /// After the function end has been registered, its successor list consists
+  /// of all ordinary blocks without predecessors.  It has no predecessors.
+  /// It does not appear in the predecessor or successor list of any
+  /// ordinary block.
+  /// It has Id 0.
+  BasicBlock pseudo_entry_block_;
+
+  /// A pseudo exit block that, for the purposes of dominance analysis,
+  /// is considered the successor to any ordinary block without successors.
+  /// After the function end has been registered, its predecessor list consists
+  /// of all ordinary blocks without successors.  It has no successors.
+  /// It does not appear in the predecessor or successor list of any
+  /// ordinary block.
   BasicBlock pseudo_exit_block_;
+
+  // A vector containing pseudo_entry_block_.
+  const std::vector<BasicBlock*> pseudo_entry_blocks_;
+
+  // A vector containing pseudo_exit_block_.
+  const std::vector<BasicBlock*> pseudo_exit_blocks_;
 
   /// The constructs that are available in this function
   std::list<Construct> cfg_constructs_;

--- a/source/val/ValidationState.cpp
+++ b/source/val/ValidationState.cpp
@@ -353,6 +353,7 @@ spv_result_t ValidationState_t::RegisterFunctionEnd() {
   assert(in_block() == false &&
          "RegisterFunctionParameter can only be called when parsing the binary "
          "ouside of a block");
+  get_current_function().RegisterFunctionEnd();
   in_function_ = false;
   return SPV_SUCCESS;
 }

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -185,6 +185,10 @@ spv_result_t spvValidate(const spv_const_context context,
                                 binary->wordCount, setHeader,
                                 ProcessInstruction, pDiagnostic));
 
+  if (vstate.in_function_body())
+    return vstate.diag(SPV_ERROR_INVALID_LAYOUT)
+           << "Missing OpFunctionEnd at end of module.";
+
   // TODO(umar): Add validation checks which require the parsing of the entire
   // module. Use the information from the ProcessInstruction pass to make the
   // checks.

--- a/source/validate.h
+++ b/source/validate.h
@@ -60,6 +60,12 @@ using get_blocks_func =
 
 /// @brief Calculates dominator edges for a set of blocks
 ///
+/// Computes dominators using the algorithm of Cooper, Harvey, and Kennedy
+/// "A Simple, Fast Dominance Algorithm", 2001.
+///
+/// The algorithm assumes there is a unique root node (a node without predecessors),
+/// and it is therefore at the end of the postorder vector.
+///
 /// This function calculates the dominator edges for a set of blocks in the CFG.
 /// Uses the dominator algorithm by Cooper et al.
 ///
@@ -68,7 +74,10 @@ using get_blocks_func =
 /// @param[in] predecessor_func Function used to get the predecessor nodes of a
 ///                             block
 ///
-/// @return a set of dominator edges represented as a pair of blocks
+/// @return the dominator tree of the graph, as a vector of pairs of nodes.
+/// The first node in the pair is a node in the graph. The second node in the pair
+/// is its immediate dominator in the sense of Cooper et.al., where a block without
+/// predecessors (such as the root node) is its own immediate dominator.
 std::vector<std::pair<BasicBlock*, BasicBlock*>> CalculateDominators(
     const std::vector<const BasicBlock*>& postorder,
     get_blocks_func predecessor_func);

--- a/test/Validate.CFG.cpp
+++ b/test/Validate.CFG.cpp
@@ -511,6 +511,7 @@ TEST_P(ValidateCFG, HeaderDoesntDominatesMergeBad) {
   str += head >> vector<Block>({merge, f});
   str += f >> merge;
   str += merge;
+  str += "OpFunctionEnd\n";
 
   CompileSuccessfully(str);
 
@@ -679,6 +680,7 @@ TEST_P(ValidateCFG, NestedLoops) {
   str += loop2_merge >> loop1;
   str += loop1_merge >> exit;
   str += exit;
+  str += "OpFunctionEnd";
 
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());

--- a/test/Validate.Layout.cpp
+++ b/test/Validate.Layout.cpp
@@ -332,6 +332,38 @@ TEST_F(ValidateLayout, InstructionAppearBeforeFunctionDefinition) {
   EXPECT_THAT(getDiagnosticString(), StrEq("Undef must appear in a block"));
 }
 
+TEST_F(ValidateLayout, MissingFunctionEndForFunctionWithBody) {
+  const auto s = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+%void = OpTypeVoid
+%tf = OpTypeFunction %void
+%f = OpFunction %void None %tf
+%l = OpLabel
+OpReturn
+)";
+
+  CompileSuccessfully(s);
+  ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              StrEq("Missing OpFunctionEnd at end of module."));
+}
+
+TEST_F(ValidateLayout, MissingFunctionEndForFunctionPrototype) {
+  const auto s = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+%void = OpTypeVoid
+%tf = OpTypeFunction %void
+%f = OpFunction %void None %tf
+)";
+
+  CompileSuccessfully(s);
+  ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              StrEq("Missing OpFunctionEnd at end of module."));
+}
+
 using ValidateOpFunctionParameter = spvtest::ValidateBase<int>;
 
 TEST_F(ValidateOpFunctionParameter, OpLineBetweenParameters) {


### PR DESCRIPTION
For dominance calculations we use an "augmented" CFG
where we always add a pseudo-entry node that is the predecessor
in the augmented CFG to any nodes that have no predecessors in the
regular CFG.  Similarly, we add a pseudo-exit node that is the
predecessor in the augmented CFG that is a successor to any
node that has no successors in the regular CFG.

Fixes a subtle problem where we were implicitly creating
the block_details for the pseudo-exit node since it didn't
appear in the idoms map, and yet we referenced it.  In such a case the
contents of the block details could be garbage, or zero-initialized.
That sometimes caused incorrect calculation of immediate dominators
and post-dominators.  For example, on a debug build where the details
could be zero-initialized, the dominator of an unreachable block would
be given as the pseudo-exit node.  Bizarre.