### PR TITLE
Test v1.1 loop dependency support

### DIFF
--- a/test/BinaryToText.cpp
+++ b/test/BinaryToText.cpp
@@ -35,11 +35,14 @@
 
 namespace {
 
+using ::testing::Combine;
 using ::testing::Eq;
 using ::testing::HasSubstr;
 using spvtest::AutoText;
 using spvtest::ScopedContext;
 using spvtest::TextToBinaryTest;
+using std::get;
+using std::tuple;
 
 class BinaryToText : public ::testing::Test {
  public:
@@ -241,97 +244,105 @@ OpExecutionMode %1 LocalSizeHint 100 200 300
   EXPECT_EQ(input, EncodeAndDecodeSuccessfully(input));
 }
 
-using RoundTripInstructionsTest =
-    spvtest::TextToBinaryTestBase<::testing::TestWithParam<std::string>>;
+using RoundTripInstructionsTest = spvtest::TextToBinaryTestBase<
+    ::testing::TestWithParam<tuple<spv_target_env, std::string>>>;
 
 TEST_P(RoundTripInstructionsTest, Sample) {
-  EXPECT_THAT(EncodeAndDecodeSuccessfully(GetParam()), Eq(GetParam()));
+  EXPECT_THAT(EncodeAndDecodeSuccessfully(get<1>(GetParam()),
+                                          SPV_BINARY_TO_TEXT_OPTION_NONE,
+                                          get<0>(GetParam())),
+              Eq(get<1>(GetParam())));
 }
 
-// clang-format off
 INSTANTIATE_TEST_CASE_P(
     MemoryAccessMasks, RoundTripInstructionsTest,
-    ::testing::ValuesIn(std::vector<std::string>{
-        "OpStore %1 %2\n",       // 3 words long.
-        "OpStore %1 %2 None\n",  // 4 words long, explicit final 0.
-        "OpStore %1 %2 Volatile\n",
-        "OpStore %1 %2 Aligned 8\n",
-        "OpStore %1 %2 Nontemporal\n",
-        // Combinations show the names from LSB to MSB
-        "OpStore %1 %2 Volatile|Aligned 16\n",
-        "OpStore %1 %2 Volatile|Nontemporal\n",
-        "OpStore %1 %2 Volatile|Aligned|Nontemporal 32\n",
-    }),);
-// clang-format on
+    Combine(::testing::Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1),
+            ::testing::ValuesIn(std::vector<std::string>{
+                "OpStore %1 %2\n",       // 3 words long.
+                "OpStore %1 %2 None\n",  // 4 words long, explicit final 0.
+                "OpStore %1 %2 Volatile\n", "OpStore %1 %2 Aligned 8\n",
+                "OpStore %1 %2 Nontemporal\n",
+                // Combinations show the names from LSB to MSB
+                "OpStore %1 %2 Volatile|Aligned 16\n",
+                "OpStore %1 %2 Volatile|Nontemporal\n",
+                "OpStore %1 %2 Volatile|Aligned|Nontemporal 32\n",
+            })), );
 
 INSTANTIATE_TEST_CASE_P(
     FPFastMathModeMasks, RoundTripInstructionsTest,
-    ::testing::ValuesIn(std::vector<std::string>{
-        "OpDecorate %1 FPFastMathMode None\n",
-        "OpDecorate %1 FPFastMathMode NotNaN\n",
-        "OpDecorate %1 FPFastMathMode NotInf\n",
-        "OpDecorate %1 FPFastMathMode NSZ\n",
-        "OpDecorate %1 FPFastMathMode AllowRecip\n",
-        "OpDecorate %1 FPFastMathMode Fast\n",
-        // Combinations show the names from LSB to MSB
-        "OpDecorate %1 FPFastMathMode NotNaN|NotInf\n",
-        "OpDecorate %1 FPFastMathMode NSZ|AllowRecip\n",
-        "OpDecorate %1 FPFastMathMode NotNaN|NotInf|NSZ|AllowRecip|Fast\n",
-    }), );
+    Combine(
+        ::testing::Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1),
+        ::testing::ValuesIn(std::vector<std::string>{
+            "OpDecorate %1 FPFastMathMode None\n",
+            "OpDecorate %1 FPFastMathMode NotNaN\n",
+            "OpDecorate %1 FPFastMathMode NotInf\n",
+            "OpDecorate %1 FPFastMathMode NSZ\n",
+            "OpDecorate %1 FPFastMathMode AllowRecip\n",
+            "OpDecorate %1 FPFastMathMode Fast\n",
+            // Combinations show the names from LSB to MSB
+            "OpDecorate %1 FPFastMathMode NotNaN|NotInf\n",
+            "OpDecorate %1 FPFastMathMode NSZ|AllowRecip\n",
+            "OpDecorate %1 FPFastMathMode NotNaN|NotInf|NSZ|AllowRecip|Fast\n",
+        })), );
 
-INSTANTIATE_TEST_CASE_P(LoopControlMasks, RoundTripInstructionsTest,
-                        ::testing::ValuesIn(std::vector<std::string>{
-                            "OpLoopMerge %1 %2 None\n",
-                            "OpLoopMerge %1 %2 Unroll\n",
-                            "OpLoopMerge %1 %2 DontUnroll\n",
-                            "OpLoopMerge %1 %2 Unroll|DontUnroll\n",
-                        }), );
+INSTANTIATE_TEST_CASE_P(
+    LoopControlMasks, RoundTripInstructionsTest,
+    Combine(::testing::Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1),
+            ::testing::ValuesIn(std::vector<std::string>{
+                "OpLoopMerge %1 %2 None\n", "OpLoopMerge %1 %2 Unroll\n",
+                "OpLoopMerge %1 %2 DontUnroll\n",
+                "OpLoopMerge %1 %2 Unroll|DontUnroll\n",
+            })), );
 
-INSTANTIATE_TEST_CASE_P(SelectionControlMasks, RoundTripInstructionsTest,
-                        ::testing::ValuesIn(std::vector<std::string>{
-                            "OpSelectionMerge %1 None\n",
-                            "OpSelectionMerge %1 Flatten\n",
-                            "OpSelectionMerge %1 DontFlatten\n",
-                            "OpSelectionMerge %1 Flatten|DontFlatten\n",
-                        }), );
+INSTANTIATE_TEST_CASE_P(LoopControlMasksV11, RoundTripInstructionsTest,
+                        Combine(::testing::Values(SPV_ENV_UNIVERSAL_1_1),
+                                ::testing::ValuesIn(std::vector<std::string>{
+                                    "OpLoopMerge %1 %2 DependencyInfinite\n",
+                                    "OpLoopMerge %1 %2 DependencyLength 8\n",
+                                })), );
 
-// clang-format off
+INSTANTIATE_TEST_CASE_P(
+    SelectionControlMasks, RoundTripInstructionsTest,
+    Combine(::testing::Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1),
+            ::testing::ValuesIn(std::vector<std::string>{
+                "OpSelectionMerge %1 None\n", "OpSelectionMerge %1 Flatten\n",
+                "OpSelectionMerge %1 DontFlatten\n",
+                "OpSelectionMerge %1 Flatten|DontFlatten\n",
+            })), );
+
 INSTANTIATE_TEST_CASE_P(
     FunctionControlMasks, RoundTripInstructionsTest,
-    ::testing::ValuesIn(std::vector<std::string>{
-        "%2 = OpFunction %1 None %3\n",
-        "%2 = OpFunction %1 Inline %3\n",
-        "%2 = OpFunction %1 DontInline %3\n",
-        "%2 = OpFunction %1 Pure %3\n",
-        "%2 = OpFunction %1 Const %3\n",
-        "%2 = OpFunction %1 Inline|Pure|Const %3\n",
-        "%2 = OpFunction %1 DontInline|Const %3\n",
-    }),);
-// clang-format on
+    Combine(::testing::Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1),
+            ::testing::ValuesIn(std::vector<std::string>{
+                "%2 = OpFunction %1 None %3\n",
+                "%2 = OpFunction %1 Inline %3\n",
+                "%2 = OpFunction %1 DontInline %3\n",
+                "%2 = OpFunction %1 Pure %3\n", "%2 = OpFunction %1 Const %3\n",
+                "%2 = OpFunction %1 Inline|Pure|Const %3\n",
+                "%2 = OpFunction %1 DontInline|Const %3\n",
+            })), );
 
-// clang-format off
 INSTANTIATE_TEST_CASE_P(
     ImageMasks, RoundTripInstructionsTest,
-    ::testing::ValuesIn(std::vector<std::string>{
-        "%2 = OpImageFetch %1 %3 %4\n",
-        "%2 = OpImageFetch %1 %3 %4 None\n",
-        "%2 = OpImageFetch %1 %3 %4 Bias %5\n",
-        "%2 = OpImageFetch %1 %3 %4 Lod %5\n",
-        "%2 = OpImageFetch %1 %3 %4 Grad %5 %6\n",
-        "%2 = OpImageFetch %1 %3 %4 ConstOffset %5\n",
-        "%2 = OpImageFetch %1 %3 %4 Offset %5\n",
-        "%2 = OpImageFetch %1 %3 %4 ConstOffsets %5\n",
-        "%2 = OpImageFetch %1 %3 %4 Sample %5\n",
-        "%2 = OpImageFetch %1 %3 %4 MinLod %5\n",
-        "%2 = OpImageFetch %1 %3 %4 Bias|Lod|Grad %5 %6 %7 %8\n",
-        "%2 = OpImageFetch %1 %3 %4 ConstOffset|Offset|ConstOffsets"
-              " %5 %6 %7\n",
-        "%2 = OpImageFetch %1 %3 %4 Sample|MinLod %5 %6\n",
-        "%2 = OpImageFetch %1 %3 %4"
-              " Bias|Lod|Grad|ConstOffset|Offset|ConstOffsets|Sample|MinLod"
-              " %5 %6 %7 %8 %9 %10 %11 %12 %13\n"
-    }),);
-// clang-format on
+    Combine(::testing::Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1),
+            ::testing::ValuesIn(std::vector<std::string>{
+                "%2 = OpImageFetch %1 %3 %4\n",
+                "%2 = OpImageFetch %1 %3 %4 None\n",
+                "%2 = OpImageFetch %1 %3 %4 Bias %5\n",
+                "%2 = OpImageFetch %1 %3 %4 Lod %5\n",
+                "%2 = OpImageFetch %1 %3 %4 Grad %5 %6\n",
+                "%2 = OpImageFetch %1 %3 %4 ConstOffset %5\n",
+                "%2 = OpImageFetch %1 %3 %4 Offset %5\n",
+                "%2 = OpImageFetch %1 %3 %4 ConstOffsets %5\n",
+                "%2 = OpImageFetch %1 %3 %4 Sample %5\n",
+                "%2 = OpImageFetch %1 %3 %4 MinLod %5\n",
+                "%2 = OpImageFetch %1 %3 %4 Bias|Lod|Grad %5 %6 %7 %8\n",
+                "%2 = OpImageFetch %1 %3 %4 ConstOffset|Offset|ConstOffsets"
+                " %5 %6 %7\n",
+                "%2 = OpImageFetch %1 %3 %4 Sample|MinLod %5 %6\n",
+                "%2 = OpImageFetch %1 %3 %4"
+                " Bias|Lod|Grad|ConstOffset|Offset|ConstOffsets|Sample|MinLod"
+                " %5 %6 %7 %8 %9 %10 %11 %12 %13\n"})), );
 
 using MaskSorting = TextToBinaryTest;
 

--- a/test/OperandCapabilities.cpp
+++ b/test/OperandCapabilities.cpp
@@ -546,6 +546,14 @@ INSTANTIATE_TEST_CASE_P(
                 CASE0(LOOP_CONTROL, LoopControlDontUnrollMask),
             })), );
 
+INSTANTIATE_TEST_CASE_P(
+    LoopControlV11, EnumCapabilityTest,
+    Combine(Values(SPV_ENV_UNIVERSAL_1_1),
+            ValuesIn(std::vector<EnumCapabilityCase>{
+                CASE0(LOOP_CONTROL, LoopControlDependencyInfiniteMask),
+                CASE0(LOOP_CONTROL, LoopControlDependencyLengthMask),
+            })), );
+
 // See SPIR-V Section 3.24 Function Control
 INSTANTIATE_TEST_CASE_P(
     FunctionControl, EnumCapabilityTest,


### PR DESCRIPTION
For DependencyInfinite and DependencyLength, test
that they don't require a capability to be turned on.
Also, that they are assembled, binary parsed, and disassembled
correctly.