### PR TITLE
Nice disasm

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,9 @@ v2016.1-dev 2016-07-04
  - Start v2016.1
  - Fix https://github.com/KhronosGroup/SPIRV-Tools/issues/261
    Turn off ClipDistance and CullDistance capability checks for Vulkan.
+ - The disassembler can emit friendly names based on debug info (OpName
+   instructions), and will infer somewhat friendly names for most types.
+   This is turned on by default for the spirv-dis command line tool.
 
 v2016.0 2016-07-04
 

--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -246,6 +246,10 @@ typedef enum spv_binary_to_text_options_t {
   SPV_BINARY_TO_TEXT_OPTION_SHOW_BYTE_OFFSET = SPV_BIT(4),
   // Do not output the module header as leading comments in the assembly.
   SPV_BINARY_TO_TEXT_OPTION_NO_HEADER = SPV_BIT(5),
+  // Use friendly names where possible.  The heuristic may expand over
+  // time, but will use common names for scalar types, and debug names from
+  // OpName instructions.
+  SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES = SPV_BIT(6),
   SPV_FORCE_32_BIT_ENUM(spv_binary_to_text_options_t)
 } spv_binary_to_text_options_t;
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -133,6 +133,7 @@ set(SPIRV_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/ext_inst.h
   ${CMAKE_CURRENT_SOURCE_DIR}/instruction.h
   ${CMAKE_CURRENT_SOURCE_DIR}/macro.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/name_mapper.h
   ${CMAKE_CURRENT_SOURCE_DIR}/opcode.h
   ${CMAKE_CURRENT_SOURCE_DIR}/operand.h
   ${CMAKE_CURRENT_SOURCE_DIR}/print.h
@@ -151,6 +152,7 @@ set(SPIRV_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/disassemble.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ext_inst.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/instruction.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/name_mapper.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/opcode.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/operand.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/print.cpp

--- a/source/disassemble.cpp
+++ b/source/disassemble.cpp
@@ -27,6 +27,7 @@
 // This file contains a disassembler:  It converts a SPIR-V binary
 // to text.
 
+#include <algorithm>
 #include <cassert>
 #include <cstring>
 #include <iomanip>

--- a/source/name_mapper.cpp
+++ b/source/name_mapper.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2016 Google Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and/or associated documentation files (the
+// "Materials"), to deal in the Materials without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Materials, and to
+// permit persons to whom the Materials are furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Materials.
+//
+// MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS
+// KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS
+// SPECIFICATIONS AND HEADER INFORMATION ARE LOCATED AT
+//    https://www.khronos.org/registry/
+//
+// THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+#include "name_mapper.h"
+
+#include <sstream>
+#include <string>
+
+namespace {
+
+std::string to_string(uint32_t id) {
+  // Use stringstream, since some versions of Android compilers lack
+  // std::to_string.
+  std::stringstream os;
+  os << id;
+  return os.str();
+}
+
+}  // anonymous namespace
+
+namespace libspirv {
+
+NameMapper GetTrivialNameMapper() { return to_string; }
+
+}  // namespace libspirv

--- a/source/name_mapper.cpp
+++ b/source/name_mapper.cpp
@@ -27,6 +27,7 @@
 #include "name_mapper.h"
 
 #include <algorithm>
+#include <iterator>
 #include <sstream>
 #include <string>
 #include <unordered_map>

--- a/source/name_mapper.cpp
+++ b/source/name_mapper.cpp
@@ -173,10 +173,52 @@ spv_result_t FriendlyNameMapper::ParseInstruction(
       SaveName(result_id, std::string("mat") + to_string(inst.words[3]) +
                               NameForId(inst.words[2]));
       break;
+    case SpvOpTypeArray:
+      SaveName(result_id, std::string("_arr_") + NameForId(inst.words[2]) +
+                              "_" + NameForId(inst.words[3]));
+      break;
+    case SpvOpTypeRuntimeArray:
+      SaveName(result_id, std::string("_runtimearr_") + NameForId(inst.words[2]));
+      break;
     case SpvOpTypePointer:
-      SaveName(result_id, NameForEnumOperand(SPV_OPERAND_TYPE_STORAGE_CLASS,
-                                             inst.words[2]) +
-                              "_ptr_" + NameForId(inst.words[3]));
+      SaveName(result_id, std::string("_ptr_") +
+                              NameForEnumOperand(SPV_OPERAND_TYPE_STORAGE_CLASS,
+                                                 inst.words[2]) +
+                              "_" + NameForId(inst.words[3]));
+      break;
+    case SpvOpTypePipe:
+      SaveName(result_id,
+               std::string("Pipe") +
+                   NameForEnumOperand(SPV_OPERAND_TYPE_ACCESS_QUALIFIER,
+                                      inst.words[2]));
+      break;
+    case SpvOpTypeEvent:
+      SaveName(result_id, "Event");
+      break;
+    case SpvOpTypeDeviceEvent:
+      SaveName(result_id, "DeviceEvent");
+      break;
+    case SpvOpTypeReserveId:
+      SaveName(result_id, "ReserveId");
+      break;
+    case SpvOpTypeQueue:
+      SaveName(result_id, "Queue");
+      break;
+    case SpvOpTypeOpaque:
+      SaveName(result_id,
+               std::string("Opaque_") +
+                   Sanitize(reinterpret_cast<const char*>(inst.words + 2)));
+      break;
+    case SpvOpTypePipeStorage:
+      SaveName(result_id, "PipeStorage");
+      break;
+    case SpvOpTypeNamedBarrier:
+      SaveName(result_id, "NamedBarrierType");
+      break;
+    case SpvOpTypeStruct:
+      // Structs are mapped rather simplisitically. Just indicate that they
+      // are a struct and then give the raw Id number.
+      SaveName(result_id, std::string("_struct_") + to_string(result_id));
       break;
     default:
       // If this instruction otherwise defines an Id, then save a mapping for

--- a/source/name_mapper.h
+++ b/source/name_mapper.h
@@ -50,10 +50,16 @@ NameMapper GetTrivialNameMapper();
 // The mapping is friendly in the following sense:
 //  - If an Id has a debug name (via OpName), then that will be used when
 //    possible.
-//  - Well known types map to their usual names, for example the result of
-//  OpTypeVoid should be %void.  Also, GLSL type names are used when parsing a
-//  module with Shader capability, and OpenCL C type names are used when parsing
-//  a module with Kernel capability.
+//  - Well known scalar types map to friendly names.  For example,
+//  OpTypeVoid should be %void.  Scalar types map to their names in OpenCL when
+//  there is a correspondence, and otherwise as follows:
+//     - unsigned integer type of n bits map to "u" followed by n
+//     - signed integer type of n bits map to "i" followed by n
+//     - floating point type of n bits map to "fp" followed by n
+//  - Vector type names map to "v" followed by the number of components,
+//  followed by the friendly name for the base type.
+//  - Matrix type names map to "mat" followed by the number of columns,
+//  followed by the friendly name for the base vector type.
 class FriendlyNameMapper {
  public:
   // Construct a friendly name mapper, and determine friendly names for each
@@ -74,16 +80,17 @@ class FriendlyNameMapper {
   std::string NameForId(uint32_t id);
 
  private:
+  // Transforms the given string so that it is acceptable as an Id name in
+  // assembly language.  Two distinct inputs can map to the same output.
+  std::string Sanitize(const std::string& suggested_name);
+
   // Records a name for the given id.  Use the given suggested_name if it
-  // hasn't
-  // already been taken, and otherwise generate a new (unused) name based on
-  // the
-  // suggested name.
+  // hasn't already been taken, and otherwise generate a new (unused) name
+  // based on the suggested name.
   void SaveName(uint32_t id, const std::string& suggested_name);
 
   // Collects information from the given parsed instruction to populate
   // name_for_id_.  Returns SPV_SUCCESS;
-  // TODO(dneto): This is very incomplete.
   spv_result_t ParseInstruction(const spv_parsed_instruction_t& inst);
 
   // Forwards a parsed-instruction callback from the binary parser into the

--- a/source/name_mapper.h
+++ b/source/name_mapper.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2016 Google Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and/or associated documentation files (the
+// "Materials"), to deal in the Materials without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Materials, and to
+// permit persons to whom the Materials are furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Materials.
+//
+// MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS
+// KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS
+// SPECIFICATIONS AND HEADER INFORMATION ARE LOCATED AT
+//    https://www.khronos.org/registry/
+//
+// THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+#ifndef LIBSPIRV_NAME_MAPPER_H_
+#define LIBSPIRV_NAME_MAPPER_H_
+
+#include <functional>
+#include <string>
+
+#include "spirv-tools/libspirv.h"
+
+namespace libspirv {
+
+// A NameMapper maps SPIR-V Id values to names.  Each name is valid to use in
+// SPIR-V assembly.  The mapping is one-to-one, i.e. no two Ids map to the same
+// name.
+using NameMapper = std::function<std::string(uint32_t)>;
+
+// Returns a NameMapper which always maps an Id to its decimal representation.
+NameMapper GetTrivialNameMapper();
+
+}  // namespace libspirv
+
+#endif  // _LIBSPIRV_NAME_MAPPER_H_

--- a/source/name_mapper.h
+++ b/source/name_mapper.h
@@ -33,6 +33,7 @@
 #include <unordered_set>
 
 #include "spirv-tools/libspirv.h"
+#include "assembly_grammar.h"
 
 namespace libspirv {
 
@@ -59,6 +60,9 @@ NameMapper GetTrivialNameMapper();
 //  - Vector type names map to "v" followed by the number of components,
 //  followed by the friendly name for the base type.
 //  - Matrix type names map to "mat" followed by the number of columns,
+//  followed by the friendly name for the base vector type.
+//  - Pointer types map to the name of the storage class, then "_ptr_", then the
+//  name for the pointee type.
 //  followed by the friendly name for the base vector type.
 class FriendlyNameMapper {
  public:
@@ -101,11 +105,16 @@ class FriendlyNameMapper {
         *parsed_instruction);
   }
 
+  // Returns the friendly name for an enumerant.
+  std::string NameForEnumOperand(spv_operand_type_t type, uint32_t word);
+
   // Maps an id to its friendly name.  This will have an entry for each Id
   // defined in the module.
   std::unordered_map<uint32_t, std::string> name_for_id_;
   // The set of names that have a mapping in name_for_id_;
   std::unordered_set<std::string> used_names_;
+  // The assembly grammar for the current context.
+  const libspirv::AssemblyGrammar grammar_;
 };
 
 }  // namespace libspirv

--- a/source/name_mapper.h
+++ b/source/name_mapper.h
@@ -61,9 +61,12 @@ NameMapper GetTrivialNameMapper();
 //  followed by the friendly name for the base type.
 //  - Matrix type names map to "mat" followed by the number of columns,
 //  followed by the friendly name for the base vector type.
-//  - Pointer types map to the name of the storage class, then "_ptr_", then the
+//  - Pointer types map to "_ptr_", then the name of the storage class, then the
 //  name for the pointee type.
-//  followed by the friendly name for the base vector type.
+//  - Exotic types like event, pipe, opaque, queue, reserve-id map to their own
+//  human readable names.
+//  - A struct type maps to "_struct_" followed by the raw Id number.  That's
+//  pretty simplistic, but workable.
 class FriendlyNameMapper {
  public:
   // Construct a friendly name mapper, and determine friendly names for each

--- a/test/BinaryToText.cpp
+++ b/test/BinaryToText.cpp
@@ -406,6 +406,28 @@ OpStore %2 %3 Aligned|Volatile 4 ; bogus, but not indented
       expected);
 }
 
+using FriendlyNameDisassemblyTest = spvtest::TextToBinaryTest;
+
+TEST_F(FriendlyNameDisassemblyTest, Sample) {
+  const std::string input = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+%1 = OpTypeInt 32 0
+%2 = OpTypeStruct %1 %3 %4 %5 %6 %7 %8 %9 %10 ; force IDs into double digits
+%11 = OpConstant %1 42
+)";
+  const std::string expected =
+      R"(OpCapability Shader
+OpMemoryModel Logical GLSL450
+%uint = OpTypeInt 32 0
+%_struct_2 = OpTypeStruct %uint %3 %4 %5 %6 %7 %8 %9 %10
+%11 = OpConstant %uint 42
+)";
+  EXPECT_THAT(EncodeAndDecodeSuccessfully(
+                  input, SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES),
+              expected);
+}
+
 TEST_F(TextToBinaryTest, ShowByteOffsetsWhenRequested) {
   const std::string input = R"(
 OpCapability Shader

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -87,6 +87,7 @@ if (NOT ${SPIRV_SKIP_EXECUTABLES})
       ${CMAKE_CURRENT_SOURCE_DIR}/ImmediateInt.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/LibspirvMacros.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/NamedId.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/NameMapper.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/OpcodeMake.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/OpcodeRequiresCapabilities.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/OpcodeSplit.cpp

--- a/test/NameMapper.cpp
+++ b/test/NameMapper.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2016 Google Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and/or associated documentation files (the
+// "Materials"), to deal in the Materials without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Materials, and to
+// permit persons to whom the Materials are furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Materials.
+//
+// MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS
+// KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS
+// SPECIFICATIONS AND HEADER INFORMATION ARE LOCATED AT
+//    https://www.khronos.org/registry/
+//
+// THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+#include "gmock/gmock.h"
+
+#include "TestFixture.h"
+#include "UnitSPIRV.h"
+
+#include "source/name_mapper.h"
+
+using spvtest::ScopedContext;
+using ::testing::Eq;
+
+namespace {
+
+TEST(TrivialNameTest, Samples) {
+  auto mapper = libspirv::GetTrivialNameMapper();
+  EXPECT_THAT(mapper(1), "1");
+  EXPECT_THAT(mapper(1999), "1999");
+  EXPECT_THAT(mapper(1024), "1024");
+}
+
+}  // anonymous namespace

--- a/test/NameMapper.cpp
+++ b/test/NameMapper.cpp
@@ -161,4 +161,18 @@ INSTANTIATE_TEST_CASE_P(
         {"%1 = OpTypeVoid %2 = OpTypeVoid %3 = OpTypeVoid", 3, "void_1"},
     }), );
 
+INSTANTIATE_TEST_CASE_P(
+    Pointer, FriendlyNameTest,
+    ::testing::ValuesIn(std::vector<NameIdCase>{
+        {"%1 = OpTypeFloat 32 %2 = OpTypePointer Workgroup %1", 2,
+         "Workgroup_ptr_float"},
+        {"%1 = OpTypeBool %2 = OpTypePointer Private %1", 2,
+         "Private_ptr_bool"},
+        // OpTypeForwardPointer doesn't force generation of the name for its
+        // target type.
+        {"%1 = OpTypeBool OpTypeForwardPointer %2 Private %2 = OpTypePointer "
+         "Private %1",
+         2, "Private_ptr_bool"},
+    }), );
+
 }  // anonymous namespace

--- a/tools/dis/dis.cpp
+++ b/tools/dis/dis.cpp
@@ -57,6 +57,8 @@ Options:
 
   --no-header     Don't output the header as leading comments.
 
+  --raw-id        Show raw Id values instead of friendly names.
+
   --offsets       Show byte offsets for each instruction.
 )",
       argv0, argv0);
@@ -73,6 +75,7 @@ int main(int argc, char** argv) {
   bool allow_indent = true;
   bool show_byte_offsets = false;
   bool no_header = false;
+  bool friendly_names = true;
 
   for (int argi = 1; argi < argc; ++argi) {
     if ('-' == argv[argi][0]) {
@@ -98,6 +101,8 @@ int main(int argc, char** argv) {
             show_byte_offsets = true;
           } else if (0 == strcmp(argv[argi], "--no-header")) {
             no_header = true;
+          } else if (0 == strcmp(argv[argi], "--raw-id")) {
+            friendly_names = false;
           } else if (0 == strcmp(argv[argi], "--help")) {
             print_usage(argv[0]);
             return 0;
@@ -141,6 +146,8 @@ int main(int argc, char** argv) {
   if (show_byte_offsets) options |= SPV_BINARY_TO_TEXT_OPTION_SHOW_BYTE_OFFSET;
 
   if (no_header) options |= SPV_BINARY_TO_TEXT_OPTION_NO_HEADER;
+
+  if (friendly_names) options |= SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES;
 
   if (!outFile || (0 == strcmp("-", outFile))) {
     // Print to standard output.


### PR DESCRIPTION
This is a long-requested feature.  It should make disassembly more readable.
It might enhance testabilty for SPIR-V generators since it will make it easier to write matchers against disassembled output.