### PR TITLE
Check ID definition block is a dominator of use block

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,8 @@ Revision history for SPIRV-Tools
 
 v2016.2-dev 2016-07-19
  - Start v2016.2
+ - Validator is incomplete
+   - Checks ID use block is dominated by definition block
 
 v2016.1 2016-07-19
  - Fix https://github.com/KhronosGroup/SPIRV-Tools/issues/261

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -229,6 +229,7 @@ spv_result_t spvValidate(const spv_const_context context,
   // CFG checks are performed after the binary has been parsed
   // and the CFGPass has collected information about the control flow
   spvCheckReturn(PerformCfgChecks(vstate));
+  spvCheckReturn(CheckIdDefinitionDominateUse(vstate));
 
   // NOTE: Copy each instruction for easier processing
   std::vector<spv_instruction_t> instructions;

--- a/source/validate.h
+++ b/source/validate.h
@@ -88,6 +88,18 @@ std::vector<std::pair<BasicBlock*, BasicBlock*>> CalculateDominators(
 /// @return SPV_SUCCESS if no errors are found. SPV_ERROR_INVALID_CFG otherwise
 spv_result_t PerformCfgChecks(ValidationState_t& _);
 
+/// @brief This function checks all ID definitions dominate their use in the
+/// CFG.
+///
+/// This function will iterate over all ID definitions that are defined in the
+/// functions of a module and make sure that the definitions appear in a
+/// block that dominates their use.
+///
+/// @param[in] _ the validation state of the module
+///
+/// @return SPV_SUCCESS if no errors are found. SPV_ERROR_INVALID_ID otherwise
+spv_result_t CheckIdDefinitionDominateUse(const ValidationState_t& _);
+
 /// @brief Updates the immediate dominator for each of the block edges
 ///
 /// Updates the immediate dominator of the blocks for each of the edges

--- a/source/validate_id.cpp
+++ b/source/validate_id.cpp
@@ -2401,8 +2401,9 @@ spv_result_t CheckIdDefinitionDominateUse(const ValidationState_t& _) {
           }
         }
       } else {
-        // If the Ids appear within a function but not in a block, then make
-        // sure all references to that Id appear within the same function
+        // If the Ids defined within a function but not in a block(i.e. function
+        // parameters, block ids), then make sure all references to that Id
+        // appear within the same function
         bool found = false;
         for (auto use : definition.second.uses()) {
           tie(ignore, found) = func->GetBlock(use->id());
@@ -2439,8 +2440,9 @@ spv_result_t IdPass(ValidationState_t& _,
     switch (type) {
       case SPV_OPERAND_TYPE_RESULT_ID:
         // NOTE: Multiple Id definitions are being checked by the binary parser
+        // NOTE: result Id is added *after* all of the other Ids have been
+        // checked to avoid premature use in the same instruction
         _.RemoveIfForwardDeclared(*operand_ptr);
-        _.AddId(*inst);
         ret = SPV_SUCCESS;
         break;
       case SPV_OPERAND_TYPE_ID:
@@ -2465,6 +2467,9 @@ spv_result_t IdPass(ValidationState_t& _,
     if (SPV_SUCCESS != ret) {
       return ret;
     }
+  }
+  if (inst->result_id) {
+    _.AddId(*inst);
   }
   return SPV_SUCCESS;
 }

--- a/source/validate_id.cpp
+++ b/source/validate_id.cpp
@@ -2376,13 +2376,55 @@ function<bool(unsigned)> getCanBeForwardDeclaredFunction(SpvOp opcode) {
 
 namespace libspirv {
 
+/// This function checks all ID definitions dominate their use in the CFG.
+///
+/// This function will iterate over all ID definitions that are defined in the
+/// functions of a module and make sure that the definitions appear in a
+/// block that dominates their use.
+///
+/// NOTE: This function does NOT check module scoped functions which are
+/// checked during the initial binary parse in the IdPass below
+spv_result_t CheckIdDefinitionDominateUse(const ValidationState_t& _) {
+  for (const auto& definition : _.all_definitions()) {
+    // Check only those blocks defined in a function
+    if (const Function* func = definition.second.defining_function()) {
+      if (const BasicBlock* block = definition.second.defining_block()) {
+        // If the Id is defined within a block then make sure all references to
+        // that Id appear in a blocks that are dominated by the defining block
+        for (auto use : definition.second.uses()) {
+          if (use->dom_end() == find(use->dom_begin(), use->dom_end(), block)) {
+            return _.diag(SPV_ERROR_INVALID_ID)
+                   << "ID " << _.getIdName(definition.first)
+                   << " defined in block " << _.getIdName(block->id())
+                   << " does not dominate its use in block "
+                   << _.getIdName(use->id());
+          }
+        }
+      } else {
+        // If the Ids appear within a function but not in a block, then make
+        // sure all references to that Id appear within the same function
+        bool found = false;
+        for (auto use : definition.second.uses()) {
+          tie(ignore, found) = func->GetBlock(use->id());
+          if (!found) {
+            return _.diag(SPV_ERROR_INVALID_ID)
+                   << "ID " << _.getIdName(definition.first)
+                   << " used in block " << _.getIdName(use->id())
+                   << " is used outside of it's defining function "
+                   << _.getIdName(func->id());
+          }
+        }
+      }
+    }
+    // NOTE: Ids defined outside of functions must appear before they are used
+    // This check is being performed in the IdPass function
+  }
+  return SPV_SUCCESS;
+}
+
 // Performs SSA validation on the IDs of an instruction. The
 // can_have_forward_declared_ids  functor should return true if the
 // instruction operand's ID can be forward referenced.
-//
-// TODO(umar): Use dominators to correctly validate SSA. For example, the result
-// id from a 'then' block cannot dominate its usage in the 'else' block. This
-// is not yet performed by this function.
 spv_result_t IdPass(ValidationState_t& _,
                     const spv_parsed_instruction_t* inst) {
   auto can_have_forward_declared_ids =
@@ -2396,6 +2438,7 @@ spv_result_t IdPass(ValidationState_t& _,
     auto ret = SPV_ERROR_INTERNAL;
     switch (type) {
       case SPV_OPERAND_TYPE_RESULT_ID:
+        // NOTE: Multiple Id definitions are being checked by the binary parser
         _.RemoveIfForwardDeclared(*operand_ptr);
         _.AddId(*inst);
         ret = SPV_SUCCESS;

--- a/test/Validate.CFG.cpp
+++ b/test/Validate.CFG.cpp
@@ -91,12 +91,13 @@ class Block {
       : label_(label), body_(), type_(type), successors_() {}
 
   /// Sets the instructions which will appear in the body of the block
-  Block& setBody(std::string body, bool append = false) {
-    if (append) {
-      body_ += body;
-    } else {
+  Block& SetBody(std::string body) {
       body_ = body;
-    }
+    return *this;
+  }
+
+  Block& AppendBody(std::string body) {
+      body_ += body;
     return *this;
   }
 
@@ -200,9 +201,9 @@ TEST_P(ValidateCFG, Simple) {
   Block cont("cont");
   Block merge("merge", SpvOpReturn);
 
-  entry.setBody("%cond    = OpSLessThan %intt %one %two\n");
+  entry.SetBody("%cond    = OpSLessThan %intt %one %two\n");
   if (is_shader) {
-    loop.setBody("OpLoopMerge %merge %cont None\n");
+    loop.SetBody("OpLoopMerge %merge %cont None\n");
   }
 
   string str = header(GetParam()) + nameOps("loop", "entry", "cont", "merge",
@@ -224,7 +225,7 @@ TEST_P(ValidateCFG, Variable) {
   Block cont("cont");
   Block exit("exit", SpvOpReturn);
 
-  entry.setBody("%var = OpVariable %ptrt Function\n");
+  entry.SetBody("%var = OpVariable %ptrt Function\n");
 
   string str = header(GetParam()) + nameOps(make_pair("func", "Main")) +
                types_consts() + " %func    = OpFunction %voidt None %funct\n";
@@ -243,7 +244,7 @@ TEST_P(ValidateCFG, VariableNotInFirstBlockBad) {
   Block exit("exit", SpvOpReturn);
 
   // This operation should only be performed in the entry block
-  cont.setBody("%var = OpVariable %ptrt Function\n");
+  cont.SetBody("%var = OpVariable %ptrt Function\n");
 
   string str = header(GetParam()) + nameOps(make_pair("func", "Main")) +
                types_consts() + " %func    = OpFunction %voidt None %funct\n";
@@ -268,8 +269,8 @@ TEST_P(ValidateCFG, BlockAppearsBeforeDominatorBad) {
   Block branch("branch", SpvOpBranchConditional);
   Block merge("merge", SpvOpReturn);
 
-  entry.setBody("%cond    = OpSLessThan %intt %one %two\n");
-  if (is_shader) branch.setBody("OpSelectionMerge %merge None\n");
+  entry.SetBody("%cond    = OpSLessThan %intt %one %two\n");
+  if (is_shader) branch.SetBody("OpSelectionMerge %merge None\n");
 
   string str = header(GetParam()) +
                nameOps("cont", "branch", make_pair("func", "Main")) +
@@ -295,11 +296,11 @@ TEST_P(ValidateCFG, MergeBlockTargetedByMultipleHeaderBlocksBad) {
   Block selection("selection", SpvOpBranchConditional);
   Block merge("merge", SpvOpReturn);
 
-  entry.setBody("%cond    = OpSLessThan %intt %one %two\n");
-  if (is_shader) loop.setBody(" OpLoopMerge %merge %loop None\n");
+  entry.SetBody("%cond    = OpSLessThan %intt %one %two\n");
+  if (is_shader) loop.SetBody(" OpLoopMerge %merge %loop None\n");
 
   // cannot share the same merge
-  if (is_shader) selection.setBody("OpSelectionMerge %merge None\n");
+  if (is_shader) selection.SetBody("OpSelectionMerge %merge None\n");
 
   string str = header(GetParam()) +
                nameOps("merge", make_pair("func", "Main")) + types_consts() +
@@ -329,11 +330,11 @@ TEST_P(ValidateCFG, MergeBlockTargetedByMultipleHeaderBlocksSelectionBad) {
   Block selection("selection", SpvOpBranchConditional);
   Block merge("merge", SpvOpReturn);
 
-  entry.setBody("%cond    = OpSLessThan %intt %one %two\n");
-  if (is_shader) selection.setBody(" OpSelectionMerge %merge None\n");
+  entry.SetBody("%cond    = OpSLessThan %intt %one %two\n");
+  if (is_shader) selection.SetBody(" OpSelectionMerge %merge None\n");
 
   // cannot share the same merge
-  if (is_shader) loop.setBody(" OpLoopMerge %merge %loop None\n");
+  if (is_shader) loop.SetBody(" OpLoopMerge %merge %loop None\n");
 
   string str = header(GetParam()) +
                nameOps("merge", make_pair("func", "Main")) + types_consts() +
@@ -381,8 +382,8 @@ TEST_P(ValidateCFG, BranchConditionalTrueTargetFirstBlockBad) {
   Block bad("bad", SpvOpBranchConditional);
   Block exit("exit", SpvOpReturn);
 
-  entry.setBody("%cond    = OpSLessThan %intt %one %two\n");
-  bad.setBody(" OpLoopMerge %entry %exit None\n");
+  entry.SetBody("%cond    = OpSLessThan %intt %one %two\n");
+  bad.SetBody(" OpLoopMerge %entry %exit None\n");
 
   string str = header(GetParam()) +
                nameOps("entry", "bad", make_pair("func", "Main")) +
@@ -407,8 +408,8 @@ TEST_P(ValidateCFG, BranchConditionalFalseTargetFirstBlockBad) {
   Block merge("merge");
   Block end("end", SpvOpReturn);
 
-  entry.setBody("%cond    = OpSLessThan %intt %one %two\n");
-  bad.setBody("OpLoopMerge %merge %cont None\n");
+  entry.SetBody("%cond    = OpSLessThan %intt %one %two\n");
+  bad.SetBody("OpLoopMerge %merge %cont None\n");
 
   string str = header(GetParam()) +
                nameOps("entry", "bad", make_pair("func", "Main")) +
@@ -437,8 +438,8 @@ TEST_P(ValidateCFG, SwitchTargetFirstBlockBad) {
   Block merge("merge");
   Block end("end", SpvOpReturn);
 
-  entry.setBody("%cond    = OpSLessThan %intt %one %two\n");
-  bad.setBody("OpSelectionMerge %merge None\n");
+  entry.SetBody("%cond    = OpSLessThan %intt %one %two\n");
+  bad.SetBody("OpSelectionMerge %merge None\n");
 
   string str = header(GetParam()) +
                nameOps("entry", "bad", make_pair("func", "Main")) +
@@ -466,8 +467,8 @@ TEST_P(ValidateCFG, BranchToBlockInOtherFunctionBad) {
   Block middle("middle", SpvOpBranchConditional);
   Block end("end", SpvOpReturn);
 
-  entry.setBody("%cond    = OpSLessThan %intt %one %two\n");
-  middle.setBody("OpSelectionMerge %end None\n");
+  entry.SetBody("%cond    = OpSLessThan %intt %one %two\n");
+  middle.SetBody("OpSelectionMerge %end None\n");
 
   Block entry2("entry2");
   Block middle2("middle2");
@@ -503,9 +504,9 @@ TEST_P(ValidateCFG, HeaderDoesntDominatesMergeBad) {
   Block f("f");
   Block merge("merge", SpvOpReturn);
 
-  head.setBody("%cond = OpSLessThan %intt %one %two\n");
+  head.SetBody("%cond = OpSLessThan %intt %one %two\n");
 
-  if (is_shader) head.setBody("OpSelectionMerge %merge None\n", true);
+  if (is_shader) head.AppendBody("OpSelectionMerge %merge None\n");
 
   string str = header(GetParam()) +
                nameOps("head", "merge", make_pair("func", "Main")) +
@@ -538,8 +539,8 @@ TEST_P(ValidateCFG, UnreachableMerge) {
   Block f("f", SpvOpReturn);
   Block merge("merge", SpvOpReturn);
 
-  entry.setBody("%cond    = OpSLessThan %intt %one %two\n");
-  if (is_shader) branch.setBody("OpSelectionMerge %merge None\n", true);
+  entry.SetBody("%cond    = OpSLessThan %intt %one %two\n");
+  if (is_shader) branch.AppendBody("OpSelectionMerge %merge None\n");
 
   string str = header(GetParam()) +
                nameOps("branch", "merge", make_pair("func", "Main")) +
@@ -564,8 +565,8 @@ TEST_P(ValidateCFG, UnreachableMergeDefinedByOpUnreachable) {
   Block f("f", SpvOpReturn);
   Block merge("merge", SpvOpUnreachable);
 
-  entry.setBody("%cond    = OpSLessThan %intt %one %two\n");
-  if (is_shader) branch.setBody("OpSelectionMerge %merge None\n", true);
+  entry.SetBody("%cond    = OpSLessThan %intt %one %two\n");
+  if (is_shader) branch.AppendBody("OpSelectionMerge %merge None\n");
 
   string str = header(GetParam()) +
                nameOps("branch", "merge", make_pair("func", "Main")) +
@@ -609,8 +610,8 @@ TEST_P(ValidateCFG, UnreachableBranch) {
   Block merge("merge");
   Block exit("exit", SpvOpReturn);
 
-  unreachable.setBody("%cond    = OpSLessThan %intt %one %two\n");
-  if (is_shader) unreachable.setBody("OpSelectionMerge %merge None\n", true);
+  unreachable.SetBody("%cond    = OpSLessThan %intt %one %two\n");
+  if (is_shader) unreachable.AppendBody("OpSelectionMerge %merge None\n");
   string str = header(GetParam()) +
                nameOps("unreachable", "exit", make_pair("func", "Main")) +
                types_consts() + "%func    = OpFunction %voidt None %funct\n";
@@ -641,8 +642,8 @@ TEST_P(ValidateCFG, SingleBlockLoop) {
   Block loop("loop", SpvOpBranchConditional);
   Block exit("exit", SpvOpReturn);
 
-  entry.setBody("%cond    = OpSLessThan %intt %one %two\n");
-  if (is_shader) loop.setBody("OpLoopMerge %exit %loop None\n", true);
+  entry.SetBody("%cond    = OpSLessThan %intt %one %two\n");
+  if (is_shader) loop.AppendBody("OpLoopMerge %exit %loop None\n");
 
   string str = header(GetParam()) + string(types_consts()) +
                "%func    = OpFunction %voidt None %funct\n";
@@ -667,10 +668,10 @@ TEST_P(ValidateCFG, NestedLoops) {
   Block loop1_merge("loop1_merge");
   Block exit("exit", SpvOpReturn);
 
-  entry.setBody("%cond    = OpSLessThan %intt %one %two\n");
+  entry.SetBody("%cond    = OpSLessThan %intt %one %two\n");
   if (is_shader) {
-    loop1.setBody("OpLoopMerge %loop1_merge %loop2 None\n");
-    loop2.setBody("OpLoopMerge %loop2_merge %loop2 None\n");
+    loop1.SetBody("OpLoopMerge %loop1_merge %loop2 None\n");
+    loop2.SetBody("OpLoopMerge %loop2_merge %loop2 None\n");
   }
 
   string str = header(GetParam()) + nameOps("loop2", "loop2_merge") +
@@ -697,11 +698,11 @@ TEST_P(ValidateCFG, NestedSelection) {
   vector<Block> merge_blocks;
   Block inner("inner");
 
-  entry.setBody("%cond    = OpSLessThan %intt %one %two\n");
+  entry.SetBody("%cond    = OpSLessThan %intt %one %two\n");
 
   if_blocks.emplace_back("if0", SpvOpBranchConditional);
 
-  if (is_shader) if_blocks[0].setBody("OpSelectionMerge %if_merge0 None\n");
+  if (is_shader) if_blocks[0].SetBody("OpSelectionMerge %if_merge0 None\n");
   merge_blocks.emplace_back("if_merge0", SpvOpReturn);
 
   for (int i = 1; i < N; i++) {
@@ -709,7 +710,7 @@ TEST_P(ValidateCFG, NestedSelection) {
     ss << i;
     if_blocks.emplace_back("if" + ss.str(), SpvOpBranchConditional);
     if (is_shader)
-      if_blocks[i].setBody("OpSelectionMerge %if_merge" + ss.str() + " None\n");
+      if_blocks[i].SetBody("OpSelectionMerge %if_merge" + ss.str() + " None\n");
     merge_blocks.emplace_back("if_merge" + ss.str(), SpvOpBranch);
   }
   string str = header(GetParam()) + string(types_consts()) +
@@ -740,10 +741,10 @@ TEST_P(ValidateCFG, BackEdgeBlockDoesntPostDominateContinueTargetBad) {
   Block be_block("be_block");
   Block exit("exit", SpvOpReturn);
 
-  entry.setBody("%cond    = OpSLessThan %intt %one %two\n");
+  entry.SetBody("%cond    = OpSLessThan %intt %one %two\n");
   if (is_shader) {
-    loop1.setBody("OpLoopMerge %exit %loop2_merge None\n");
-    loop2.setBody("OpLoopMerge %loop2_merge %loop2 None\n");
+    loop1.SetBody("OpLoopMerge %exit %loop2_merge None\n");
+    loop2.SetBody("OpLoopMerge %loop2_merge %loop2 None\n");
   }
 
   string str = header(GetParam()) +
@@ -778,8 +779,8 @@ TEST_P(ValidateCFG, BranchingToNonLoopHeaderBlockBad) {
   Block f("f");
   Block exit("exit", SpvOpReturn);
 
-  entry.setBody("%cond    = OpSLessThan %intt %one %two\n");
-  if (is_shader) split.setBody("OpSelectionMerge %exit None\n");
+  entry.SetBody("%cond    = OpSLessThan %intt %one %two\n");
+  if (is_shader) split.SetBody("OpSelectionMerge %exit None\n");
 
   string str = header(GetParam()) + nameOps("split", "f") + types_consts() +
                "%func    = OpFunction %voidt None %funct\n";
@@ -809,8 +810,8 @@ TEST_P(ValidateCFG, BranchingToSameNonLoopHeaderBlockBad) {
   Block split("split", SpvOpBranchConditional);
   Block exit("exit", SpvOpReturn);
 
-  entry.setBody("%cond    = OpSLessThan %intt %one %two\n");
-  if (is_shader) split.setBody("OpSelectionMerge %exit None\n");
+  entry.SetBody("%cond    = OpSLessThan %intt %one %two\n");
+  if (is_shader) split.SetBody("OpSelectionMerge %exit None\n");
 
   string str = header(GetParam()) + nameOps("split") + types_consts() +
                "%func    = OpFunction %voidt None %funct\n";
@@ -839,8 +840,8 @@ TEST_P(ValidateCFG, MultipleBackEdgesToLoopHeaderBad) {
   Block cont("cont", SpvOpBranchConditional);
   Block merge("merge", SpvOpReturn);
 
-  entry.setBody("%cond    = OpSLessThan %intt %one %two\n");
-  if (is_shader) loop.setBody("OpLoopMerge %merge %loop None\n");
+  entry.SetBody("%cond    = OpSLessThan %intt %one %two\n");
+  if (is_shader) loop.SetBody("OpLoopMerge %merge %loop None\n");
 
   string str = header(GetParam()) + nameOps("cont", "loop") + types_consts() +
                "%func    = OpFunction %voidt None %funct\n";
@@ -871,8 +872,8 @@ TEST_P(ValidateCFG, ContinueTargetMustBePostDominatedByBackEdge) {
   Block merge("merge", SpvOpReturn);
   Block exit("exit", SpvOpReturn);
 
-  entry.setBody("%cond    = OpSLessThan %intt %one %two\n");
-  if (is_shader) loop.setBody("OpLoopMerge %merge %cheader None\n");
+  entry.SetBody("%cond    = OpSLessThan %intt %one %two\n");
+  if (is_shader) loop.SetBody("OpLoopMerge %merge %cheader None\n");
 
   string str = header(GetParam()) + nameOps("cheader", "be_block") +
                types_consts() + "%func    = OpFunction %voidt None %funct\n";
@@ -904,8 +905,8 @@ TEST_P(ValidateCFG, BranchOutOfConstructToMergeBad) {
   Block cont("cont", SpvOpBranchConditional);
   Block merge("merge", SpvOpReturn);
 
-  entry.setBody("%cond    = OpSLessThan %intt %one %two\n");
-  if (is_shader) loop.setBody("OpLoopMerge %merge %loop None\n");
+  entry.SetBody("%cond    = OpSLessThan %intt %one %two\n");
+  if (is_shader) loop.SetBody("OpLoopMerge %merge %loop None\n");
 
   string str = header(GetParam()) + nameOps("cont", "loop") + types_consts() +
                "%func    = OpFunction %voidt None %funct\n";
@@ -936,8 +937,8 @@ TEST_P(ValidateCFG, BranchOutOfConstructBad) {
   Block merge("merge");
   Block exit("exit", SpvOpReturn);
 
-  entry.setBody("%cond    = OpSLessThan %intt %one %two\n");
-  if (is_shader) loop.setBody("OpLoopMerge %merge %loop None\n");
+  entry.SetBody("%cond    = OpSLessThan %intt %one %two\n");
+  if (is_shader) loop.SetBody("OpLoopMerge %merge %loop None\n");
 
   string str = header(GetParam()) + nameOps("cont", "loop") + types_consts() +
                "%func    = OpFunction %voidt None %funct\n";
@@ -990,7 +991,7 @@ OpDecorate %id BuiltIn GlobalInvocationId
 %main      = OpFunction %void None %voidf
 )";
 
-  entry.setBody(
+  entry.SetBody(
       "%idval    = OpLoad %uvec3 %id\n"
       "%x        = OpCompositeExtract %u32 %idval 0\n"
       "%selector = OpUMod %u32 %x %three\n"


### PR DESCRIPTION
The validator now checks that the ID definition appears in a block that dominates the block where they are used.  This is using a simpler approach than PR #237.

Relies on #264 