### PR TITLE
Track changes in SPIRV-Headers for SPIR-V 1.1 rev 2.

### DIFF
--- a/test/OperandCapabilities.cpp
+++ b/test/OperandCapabilities.cpp
@@ -171,7 +171,6 @@ INSTANTIATE_TEST_CASE_P(
     Combine(Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1),
             ValuesIn(std::vector<EnumCapabilityCase>{
                 CASE0(STORAGE_CLASS, StorageClassUniformConstant),
-                CASE1(STORAGE_CLASS, StorageClassInput, Shader),
                 CASE1(STORAGE_CLASS, StorageClassUniform, Shader),
                 CASE1(STORAGE_CLASS, StorageClassOutput, Shader),
                 CASE0(STORAGE_CLASS, StorageClassWorkgroup),
@@ -690,10 +689,8 @@ INSTANTIATE_TEST_CASE_P(
             CASE1(CAPABILITY, CapabilityInputAttachment, Shader),
             CASE1(CAPABILITY, CapabilitySparseResidency, Shader),
             CASE1(CAPABILITY, CapabilityMinLod, Shader),
-            CASE1(CAPABILITY, CapabilitySampled1D, Shader),
             CASE1(CAPABILITY, CapabilityImage1D, Sampled1D),
             CASE1(CAPABILITY, CapabilitySampledCubeArray, Shader),
-            CASE1(CAPABILITY, CapabilitySampledBuffer, Shader),
             CASE1(CAPABILITY, CapabilityImageBuffer, SampledBuffer),
             CASE1(CAPABILITY, CapabilityImageMSArray, Shader),
             CASE1(CAPABILITY, CapabilityStorageImageExtendedFormats, Shader),

--- a/test/Validate.Capability.cpp
+++ b/test/Validate.Capability.cpp
@@ -284,12 +284,8 @@ const vector<string>& MatrixDependencies() {
   "InputAttachment",
   "SparseResidency",
   "MinLod",
-  "Sampled1D",
-  "Image1D",
   "SampledCubeArray",
-  "SampledBuffer",
   "ImageMSArray",
-  "ImageBuffer",
   "StorageImageExtendedFormats",
   "ImageQuery",
   "DerivativeControl",
@@ -325,12 +321,8 @@ const vector<string>& ShaderDependencies() {
   "InputAttachment",
   "SparseResidency",
   "MinLod",
-  "Sampled1D",
-  "Image1D",
   "SampledCubeArray",
-  "SampledBuffer",
   "ImageMSArray",
-  "ImageBuffer",
   "StorageImageExtendedFormats",
   "ImageQuery",
   "DerivativeControl",
@@ -651,7 +643,7 @@ make_pair(string(kGLSL450MemoryModel) +
 make_pair(string(kOpenCLMemoryModel) +
           " %intt = OpTypeInt 32 0\n"
           " %ptrt = OpTypePointer Input %intt"
-          " %var = OpVariable %ptrt Input\n", ShaderDependencies()),
+          " %var = OpVariable %ptrt Input\n", AllCapabilities()),
 make_pair(string(kOpenCLMemoryModel) +
           " %intt = OpTypeInt 32 0\n"
           " %ptrt = OpTypePointer Uniform %intt\n"
@@ -1154,8 +1146,6 @@ bool Exists(const std::string& capability, spv_target_env env) {
              .lookupOperand(SPV_OPERAND_TYPE_CAPABILITY, capability.c_str(),
                             capability.size(), &dummy);
 }
-
-
 
 TEST_P(ValidateCapability, Capability) {
   const string capability = Capability(GetParam());


### PR DESCRIPTION
* The `Input` StorageClass doesn't require the `Shader` capability
  anymore.
* The `Sampled1D` and `SampledBuffer` capabilities don't require
  the `Shader` capability anymore. So they do not indirectly
  depend on the `Matrix` capability. So are the `Image1D` and
  `ImageBuffer` capabilities, which depend on `Sampled1D` and
  `SampledBuffer`.

A new GLSL grammar file is uploaded for SPIR-V 1.1, but it's the
same as the existing one for SPIR-V 1.0.

Now tracking commit 3814effb879ab5a98a7b9288a4b4c7849d2bc8ac in
SPIRV-Headers.

