### PR TITLE
WIP: Add -load <pass-module> for spirv-opt

### DIFF
--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -6,8 +6,11 @@ add_library(SPIRV-Tools-opt
   libspirv.hpp
   module.h
   reflect.h
+  pass.h
   passes.h
   pass_manager.h
+  pass_registry_impl.h
+  pass_registry.h
 
   function.cpp
   instruction.cpp
@@ -15,6 +18,7 @@ add_library(SPIRV-Tools-opt
   libspirv.cpp
   module.cpp
   passes.cpp
+  pass_registry.cpp
 )
 
 spvtools_default_compile_options(SPIRV-Tools-opt)

--- a/source/opt/pass.h
+++ b/source/opt/pass.h
@@ -24,32 +24,28 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 
-#ifndef LIBSPIRV_OPT_PASSES_H_
-#define LIBSPIRV_OPT_PASSES_H_
-
-#include <memory>
+#ifndef LIBSPIRV_OPT_PASS_H
+#define LIBSPIRV_OPT_PASS_H
 
 #include "module.h"
-#include "pass.h"
+#include "pass_registry.h"
 
 namespace spvtools {
 namespace opt {
 
-// A null pass that does nothing.
-class NullPass : public Pass {
-  const char* name() const override { return "Null"; }
-  bool Process(ir::Module*) override { return false; }
-};
-
-// The optimization pass for removing debug instructions (as documented in
-// Section 3.32.2 of the SPIR-V spec).
-class StripDebugInfoPass : public Pass {
+// A pass. All analysis and transformation is done via the Process() method.
+class Pass {
  public:
-  const char* name() const override { return "StripDebugInfo"; }
-  bool Process(ir::Module* module) override;
+  Pass() {}
+  virtual ~Pass() {};
+  // Returns a descriptive name for this pass.
+  virtual const char* name() const = 0;
+  // Processes the given |module| and returns true if the given |module| is
+  // modified for optimization.
+  virtual bool Process(ir::Module* module) = 0;
 };
 
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_PASSES_H_
+#endif  // LIBSPIRV_OPT_PASS_H

--- a/source/opt/pass_registry.cpp
+++ b/source/opt/pass_registry.cpp
@@ -24,32 +24,27 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 
-#ifndef LIBSPIRV_OPT_PASSES_H_
-#define LIBSPIRV_OPT_PASSES_H_
-
-#include <memory>
-
-#include "module.h"
-#include "pass.h"
+#include "pass_registry_impl.h"
 
 namespace spvtools {
 namespace opt {
 
-// A null pass that does nothing.
-class NullPass : public Pass {
-  const char* name() const override { return "Null"; }
-  bool Process(ir::Module*) override { return false; }
-};
+PassRegistryImpl* PassRegistryImpl::GetPassRegistryImpl() {
+  // TODO(qining): thread safe?
+  static PassRegistryImpl registry_impl;
+  return &registry_impl;
+}
 
-// The optimization pass for removing debug instructions (as documented in
-// Section 3.32.2 of the SPIR-V spec).
-class StripDebugInfoPass : public Pass {
- public:
-  const char* name() const override { return "StripDebugInfo"; }
-  bool Process(ir::Module* module) override;
-};
+PassRegistry* PassRegistry::GetPassRegistry() {
+  // TODO(qining): thread safe? And need to control the scope.
+  static PassRegistry registry(PassRegistryImpl::GetPassRegistryImpl());
+  return &registry;
+}
+
+bool PassRegistry::Register(const char* cmd_arg, MakePassPfn make_pass,
+                            DeletePassPfn delete_pass) {
+  return impl_->Register(cmd_arg, make_pass, delete_pass);
+}
 
 }  // namespace opt
 }  // namespace spvtools
-
-#endif  // LIBSPIRV_OPT_PASSES_H_

--- a/source/opt/pass_registry.h
+++ b/source/opt/pass_registry.h
@@ -1,0 +1,89 @@
+// Copyright (c) 2016 Google Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and/or associated documentation files (the
+// "Materials"), to deal in the Materials without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Materials, and to
+// permit persons to whom the Materials are furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Materials.
+//
+// MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS
+// KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS
+// SPECIFICATIONS AND HEADER INFORMATION ARE LOCATED AT
+//    https://www.khronos.org/registry/
+//
+// THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+// This is the public pass registry header which should be included in all
+// loadable pass module through pass.h.
+
+#ifndef LIBSPIRV_OPT_PASSREGISTRY_H
+#define LIBSPIRV_OPT_PASSREGISTRY_H
+
+namespace spvtools {
+namespace opt {
+
+class Pass;
+class PassRegistryImpl;
+
+// Define the pass maker and deleter function signatures. Confine the calling
+// convention to be C Calling Convention.
+using MakePassPfn = Pass* __attribute((cdecl))(*)();
+using DeletePassPfn = void __attribute((cdecl))(*)(Pass*);
+
+// A pass maker function, which wraps the default constructor of a pass type.
+template <typename PassT>
+__attribute((cdecl))
+static Pass* MakePass() {
+  return new PassT;
+}
+
+// A pass deleter function, which wraps the default destructor of a pass type.
+template <typename PassT>
+__attribute((cdecl))
+static void DeletePass(Pass* pass) {
+  delete static_cast<PassT*>(pass);
+}
+
+// PassRegistry holds all the registered passes. A pass should be registered
+// with a command line argument as an identifier, pass maker function and pass
+// deleter function.
+class PassRegistry {
+ public:
+  // Returns true if a pass is registered successfully, otherwise return false.
+  bool Register(const char* cmd_arg, MakePassPfn make_pass,
+                DeletePassPfn delete_pass);
+
+  static PassRegistry* GetPassRegistry();
+
+ private:
+  PassRegistry() = delete;
+  ~PassRegistry() {};
+  PassRegistry(PassRegistryImpl* impl) : impl_(impl) {}
+  PassRegistryImpl* impl_;
+};
+
+
+// RegisterPass registers a pass type to the registry.
+template <typename PassT>
+struct RegisterPass {
+  RegisterPass(const char* cmd_arg) {
+    PassRegistry::GetPassRegistry()->Register(cmd_arg, &MakePass<PassT>,
+                                              &DeletePass<PassT>);
+  }
+};
+
+}  // namespace opt
+}  // namespace spvtools
+
+#endif  // LIBSPIRV_OPT_PASSREGISTRY_H

--- a/source/opt/pass_registry.h
+++ b/source/opt/pass_registry.h
@@ -38,19 +38,19 @@ class PassRegistryImpl;
 
 // Define the pass maker and deleter function signatures. Confine the calling
 // convention to be C Calling Convention.
-using MakePassPfn = Pass* __attribute((cdecl))(*)();
-using DeletePassPfn = void __attribute((cdecl))(*)(Pass*);
+using MakePassPfn = Pass* /* __attribute((cdecl)) */(*)();
+using DeletePassPfn = void /* __attribute((cdecl)) */(*)(Pass*);
 
 // A pass maker function, which wraps the default constructor of a pass type.
 template <typename PassT>
-__attribute((cdecl))
+// __attribute((cdecl))
 static Pass* MakePass() {
   return new PassT;
 }
 
 // A pass deleter function, which wraps the default destructor of a pass type.
 template <typename PassT>
-__attribute((cdecl))
+// __attribute((cdecl))
 static void DeletePass(Pass* pass) {
   delete static_cast<PassT*>(pass);
 }

--- a/source/opt/pass_registry_impl.h
+++ b/source/opt/pass_registry_impl.h
@@ -1,0 +1,93 @@
+// Copyright (c) 2016 Google Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and/or associated documentation files (the
+// "Materials"), to deal in the Materials without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Materials, and to
+// permit persons to whom the Materials are furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Materials.
+//
+// MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS
+// KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS
+// SPECIFICATIONS AND HEADER INFORMATION ARE LOCATED AT
+//    https://www.khronos.org/registry/
+//
+// THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+#ifndef LIBSPIRV_OPT_PASS_REGISTRY_IMPL_H
+#define LIBSPIRV_OPT_PASS_REGISTRY_IMPL_H
+
+#include "pass_registry.h"
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+namespace spvtools {
+namespace opt {
+
+// PassRegtryImpl is the real implementation of pass registry that holds a
+// table of registered passes with their command line argument, pass maker
+// functions and pass deleter functions.
+class PassRegistryImpl {
+ protected:
+   // TODO(qining): These are left in protected section for testing.
+  PassRegistryImpl() : pass_create_info_() {}
+  ~PassRegistryImpl() {};
+
+  // The internal bookkeeping for all registered pass creating info.
+  std::unordered_map<std::string, std::pair<MakePassPfn, DeletePassPfn> >
+      pass_create_info_;
+
+ public:
+  // Registers a pass with its command line argument, pass maker function and
+  // pass deleter function. Returns true if succeeded, othwise false.
+  bool Register(const char* cmd_arg, MakePassPfn make_pass,
+                DeletePassPfn delete_pass) {
+    if (pass_create_info_.count(cmd_arg) != 0) {
+      return false;
+    }
+    pass_create_info_.insert({cmd_arg, std::make_pair(make_pass, delete_pass)});
+    return true;
+  }
+
+  // Lists the command line arguments of all the registered passes.
+  void List() {
+    std::cout << "Command arguments of registered passes:" << std::endl;
+    for (auto& p : pass_create_info_) {
+      std::cout << p.first << std::endl;
+    }
+  }
+
+  // Creates a pass instance with the given command line argument. Returns an
+  // unique pointer built with the pass deleter function if a pass can be found
+  // with the given command line argument, otherwise, returns a nullptr
+  // (wrapped as an unique_ptr).
+  std::unique_ptr<Pass, DeletePassPfn> GetPass(const char* cmd_arg) {
+    if (pass_create_info_.count(cmd_arg) == 0) {
+      return std::unique_ptr<Pass, DeletePassPfn>(nullptr, [](Pass*){});
+    }
+    auto& create_info = pass_create_info_[cmd_arg];
+    return std::unique_ptr<Pass, DeletePassPfn>(create_info.first(),
+                                                create_info.second);
+  }
+
+  // Get the pass registry impl instance, which is supposed to be a singleton.
+  static PassRegistryImpl* GetPassRegistryImpl();
+};
+}  // namespace opt
+}  // namespace spvtools
+
+#endif  // LIBSPIRV_OPT_PASS_REGISTRY_IMPL_H

--- a/source/opt/passes.cpp
+++ b/source/opt/passes.cpp
@@ -41,5 +41,8 @@ bool StripDebugInfoPass::Process(ir::Module* module) {
   return modified;
 }
 
+RegisterPass<NullPass> X("null");
+RegisterPass<StripDebugInfoPass> Y("strip-debug-arg");
+
 }  // namespace opt
 }  // namespace spvtools

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -43,3 +43,9 @@ add_spvtools_unittest(TARGET pass_utils
   SRCS test_utils.cpp pass_utils.cpp
   LIBS SPIRV-Tools-opt ${SPIRV_TOOLS}
 )
+
+add_spvtools_unittest(TARGET pass_registry
+  SRCS test_pass_registry.cpp
+  # Do not link with SPIRV-Tools-opt to avoid static object.
+  LIBS ${SPIRV_TOOLS}
+)

--- a/test/opt/test_pass_manager.cpp
+++ b/test/opt/test_pass_manager.cpp
@@ -48,6 +48,13 @@ TEST(PassManager, Interface) {
   EXPECT_STREQ("StripDebugInfo", manager.GetPass(0)->name());
   EXPECT_STREQ("Null", manager.GetPass(1)->name());
   EXPECT_STREQ("StripDebugInfo", manager.GetPass(2)->name());
+
+  // manager.AddPass(&opt::MakePass<opt::NullPass>);
+  // EXPECT_EQ(4u, manager.NumPasses());
+  // EXPECT_STREQ("StripDebugInfo", manager.GetPass(0)->name());
+  // EXPECT_STREQ("Null", manager.GetPass(1)->name());
+  // EXPECT_STREQ("StripDebugInfo", manager.GetPass(2)->name());
+  // EXPECT_STREQ("Null", manager.GetPass(3)->name());
 }
 
 // A pass that appends an OpNop instruction to the debug section.

--- a/test/opt/test_pass_registry.cpp
+++ b/test/opt/test_pass_registry.cpp
@@ -1,0 +1,114 @@
+// Copyright (c) 2016 Google Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and/or associated documentation files (the
+// "Materials"), to deal in the Materials without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Materials, and to
+// permit persons to whom the Materials are furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Materials.
+//
+// MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS
+// KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS
+// SPECIFICATIONS AND HEADER INFORMATION ARE LOCATED AT
+//    https://www.khronos.org/registry/
+//
+// THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+#include "opt/pass_registry_impl.h"
+
+#include <gtest/gtest.h>
+
+#include "pass_fixture.h"
+
+namespace spvtools {
+
+namespace {
+// A single-char-named empty pass for testing.
+template <const char CHAR>
+class SingleCharNamedSamplePass : public opt::Pass {
+ public:
+  SingleCharNamedSamplePass() : Pass(), c_(CHAR) {}
+  const char* name() const override { return &c_; }
+  bool Process(ir::Module*) { return false; }
+
+ private:
+  const char c_;
+};
+
+// A sample pass with "a" as its name.
+using SamplePassA = SingleCharNamedSamplePass<'a'>;
+// A sample pass with "b" as its name.
+using SamplePassB = SingleCharNamedSamplePass<'b'>;
+
+class PassRegistryForTest : public opt::PassRegistryImpl {
+ public:
+  size_t RegistrySize() { return pass_create_info_.size(); }
+};
+
+}  // anonymous namespace
+
+TEST(PassRegistry, RegisterSucceeded) {
+  PassRegistryForTest registry;
+  EXPECT_EQ(0u, registry.RegistrySize());
+  const char* cmd_arg_pass_a = "cmd_arg_pass_a";
+  EXPECT_EQ(true, registry.Register(cmd_arg_pass_a, &opt::MakePass<SamplePassA>,
+                                    &opt::DeletePass<SamplePassA>));
+  EXPECT_EQ(1u, registry.RegistrySize());
+  const char* cmd_arg_pass_b = "cmd_arg_pass_b";
+  EXPECT_EQ(true, registry.Register(cmd_arg_pass_b, &opt::MakePass<SamplePassA>,
+                                    opt::DeletePass<SamplePassB>));
+  EXPECT_EQ(2u, registry.RegistrySize());
+  // Valid to have same pass but registered with differnt command arguments.
+  const char* cmd_arg_pass_a_prime = "cmd_arg_pass_a_prime";
+  EXPECT_EQ(true, registry.Register(cmd_arg_pass_a_prime, &opt::MakePass<SamplePassA>,
+                                    &opt::DeletePass<SamplePassA>));
+  EXPECT_EQ(3u, registry.RegistrySize());
+}
+
+TEST(PassRegistry, RegisterFailed) {
+  PassRegistryForTest registry;
+  EXPECT_EQ(0u, registry.RegistrySize());
+  const char* cmd_arg_pass_a = "cmd_arg_pass_a";
+  EXPECT_EQ(true, registry.Register(cmd_arg_pass_a, &opt::MakePass<SamplePassA>,
+                                    &opt::DeletePass<SamplePassA>));
+  EXPECT_EQ(1u, registry.RegistrySize());
+  // Invalid to register with same name more than once, even though the passes
+  // to be registered are different.
+  const char* cmd_arg_pass_b_same_as_a = "cmd_arg_pass_a";
+  EXPECT_EQ(false,
+            registry.Register(cmd_arg_pass_b_same_as_a, opt::MakePass<SamplePassB>,
+                              opt::DeletePass<SamplePassB>));
+  EXPECT_EQ(1u, registry.RegistrySize());
+}
+
+TEST(PassRegistry, GetPassSucceeded) {
+  PassRegistryForTest registry;
+  registry.Register("pass_a", &opt::MakePass<SamplePassA>, &opt::DeletePass<SamplePassA>);
+  auto pass_a = registry.GetPass("pass_a");
+  auto pass_b = registry.GetPass("pass_b");
+  // The register should be able to find the passes.
+  EXPECT_NE(nullptr, pass_a);
+  EXPECT_EQ(nullptr, pass_b);
+  // The created pass instances' names should match.
+  EXPECT_EQ('a', *pass_a->name());
+  // EXPECT_EQ('b', *pass_b->name());
+}
+
+TEST(PassRegistry, GetPassFailed) {
+  PassRegistryForTest registry;
+  EXPECT_EQ(0u, registry.RegistrySize());
+  auto pass = registry.GetPass("no-registered pass");
+  EXPECT_EQ(nullptr, pass);
+}
+
+}  // namespace spvtools

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -46,7 +46,7 @@ if (NOT ${SPIRV_SKIP_EXECUTABLES})
   add_spvtools_tool(TARGET spirv-as SRCS as/as.cpp LIBS ${SPIRV_TOOLS})
   add_spvtools_tool(TARGET spirv-dis SRCS dis/dis.cpp LIBS ${SPIRV_TOOLS})
   add_spvtools_tool(TARGET spirv-val SRCS val/val.cpp LIBS ${SPIRV_TOOLS})
-  add_spvtools_tool(TARGET spirv-opt SRCS opt/opt.cpp LIBS SPIRV-Tools-opt ${SPIRV_TOOLS})
+  add_spvtools_tool(TARGET spirv-opt SRCS opt/opt.cpp LIBS SPIRV-Tools-opt ${SPIRV_TOOLS} ${CMAKE_DL_LIBS})
 
   set(SPIRV_INSTALL_TARGETS spirv-as spirv-dis spirv-val spirv-opt)
   install(TARGETS ${SPIRV_INSTALL_TARGETS}


### PR DESCRIPTION
Add PassRegistry to support out-of-source passes.

A `hello` pass:
```
#include "module.h"
// "pass.h" includes "pass_registry.h", which is supposed to be a public header
#include "pass.h"

#include <iostream>

namespace {

class HelloPass : public spvtools::opt::Pass {
 public:
  const char* name() const override { return "hello pass"; }
  bool Process(spvtools::ir::Module*) override {
    std::cerr << name() << std::endl;
    return false;
  }
};

// Register the pass to the registry
spvtools::opt::RegisterPass<HelloPass> X("hello");

}  // anonymous namespace
```

An example module with `hello` pass should be compiled with:
`-std=c++11 -fPIC -shared`

TODO:
Support Windows.
Tests for '-load <module>'.