### PR TITLE
Freeze spec consts to their default value

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,9 @@ v2016.2-dev 2016-07-19
  - Start v2016.2
  - Validator is incomplete
    - Checks ID use block is dominated by definition block
+ - Add optimization passes
+   - Strip debug info instructions
+   - Freeze spec constant to their default values
 
 v2016.1 2016-07-19
  - Fix https://github.com/KhronosGroup/SPIRV-Tools/issues/261

--- a/source/assembly_grammar.cpp
+++ b/source/assembly_grammar.cpp
@@ -150,7 +150,6 @@ const SpecConstantOpcodeEntry kOpSpecConstantOpcodes[] = {
     CASE(Select),
     // Comparison
     CASE(IEqual),
-    CASE(INotEqual),
     CASE(ULessThan),
     CASE(SLessThan),
     CASE(UGreaterThan),
@@ -167,7 +166,7 @@ const SpecConstantOpcodeEntry kOpSpecConstantOpcodes[] = {
 };
 
 // The 58 is determined by counting the opcodes listed in the spec.
-static_assert(59 == sizeof(kOpSpecConstantOpcodes)/sizeof(kOpSpecConstantOpcodes[0]),
+static_assert(58 == sizeof(kOpSpecConstantOpcodes)/sizeof(kOpSpecConstantOpcodes[0]),
               "OpSpecConstantOp opcode table is incomplete");
 #undef CASE
 // clang-format on

--- a/source/assembly_grammar.cpp
+++ b/source/assembly_grammar.cpp
@@ -150,6 +150,7 @@ const SpecConstantOpcodeEntry kOpSpecConstantOpcodes[] = {
     CASE(Select),
     // Comparison
     CASE(IEqual),
+    CASE(INotEqual),
     CASE(ULessThan),
     CASE(SLessThan),
     CASE(UGreaterThan),
@@ -166,7 +167,7 @@ const SpecConstantOpcodeEntry kOpSpecConstantOpcodes[] = {
 };
 
 // The 58 is determined by counting the opcodes listed in the spec.
-static_assert(58 == sizeof(kOpSpecConstantOpcodes)/sizeof(kOpSpecConstantOpcodes[0]),
+static_assert(59 == sizeof(kOpSpecConstantOpcodes)/sizeof(kOpSpecConstantOpcodes[0]),
               "OpSpecConstantOp opcode table is incomplete");
 #undef CASE
 // clang-format on

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -86,6 +86,7 @@ class Instruction {
               std::vector<Instruction>&& dbg_line = {});
 
   SpvOp opcode() const { return opcode_; }
+  void SetOpcode(SpvOp opcode) { opcode_ = opcode; }
   uint32_t type_id() const { return type_id_; }
   uint32_t result_id() const { return result_id_; }
   // Returns the vector of line-related debug instructions attached to this

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -90,7 +90,7 @@ class Instruction {
   // make the instruction to be invalid.
   // TODO(qining): Remove this function when instruction building and insertion
   // is well implemented.
-  void SetOpcode(SpvOp opcode) { opcode_ = opcode; }
+  void SetOpcode(SpvOp op) { opcode_ = op; }
   uint32_t type_id() const { return type_id_; }
   uint32_t result_id() const { return result_id_; }
   // Returns the vector of line-related debug instructions attached to this

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -86,6 +86,10 @@ class Instruction {
               std::vector<Instruction>&& dbg_line = {});
 
   SpvOp opcode() const { return opcode_; }
+  // Sets the opcode of this instruction to a specific opcode. Note this may
+  // make the instruction to be invalid.
+  // TODO(qining): Remove this function when instruction building and insertion
+  // is well implemented.
   void SetOpcode(SpvOp opcode) { opcode_ = opcode; }
   uint32_t type_id() const { return type_id_; }
   uint32_t result_id() const { return result_id_; }

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -87,7 +87,7 @@ class Instruction {
 
   SpvOp opcode() const { return opcode_; }
   // Sets the opcode of this instruction to a specific opcode. Note this may
-  // make the instruction to be invalid.
+  // invalidate the instruction.
   // TODO(qining): Remove this function when instruction building and insertion
   // is well implemented.
   void SetOpcode(SpvOp op) { opcode_ = op; }

--- a/source/opt/passes.cpp
+++ b/source/opt/passes.cpp
@@ -53,6 +53,11 @@ bool FreezeSpecConstantValuePass::Process(ir::Module* module) {
     } else if (inst->opcode() == SpvOp::SpvOpSpecConstantFalse) {
       inst->SetOpcode(SpvOp::SpvOpConstantFalse);
       modified = true;
+    } else if (inst->opcode() == SpvOp::SpvOpDecorate &&
+        inst->GetInOperand(1).words[0] == SpvDecoration::SpvDecorationSpecId) {
+      // If this is a decoration instrution and the decoration is Spec ID, we
+      // should remove the instrution.
+      inst->ToNop();
     }
   });
   return modified;

--- a/source/opt/passes.cpp
+++ b/source/opt/passes.cpp
@@ -41,5 +41,22 @@ bool StripDebugInfoPass::Process(ir::Module* module) {
   return modified;
 }
 
+bool FreezeSpecConstantValuePass::Process(ir::Module* module) {
+  bool modified = false;
+  module->ForEachInst([&modified](ir::Instruction* inst) {
+    if (inst->opcode() == SpvOp::SpvOpSpecConstant) {
+      inst->SetOpcode(SpvOp::SpvOpConstant);
+      modified = true;
+    } else if (inst->opcode() == SpvOp::SpvOpSpecConstantTrue) {
+      inst->SetOpcode(SpvOp::SpvOpConstantTrue);
+      modified = true;
+    } else if (inst->opcode() == SpvOp::SpvOpSpecConstantFalse) {
+      inst->SetOpcode(SpvOp::SpvOpConstantFalse);
+      modified = true;
+    }
+  });
+  return modified;
+}
+
 }  // namespace opt
 }  // namespace spvtools

--- a/source/opt/passes.cpp
+++ b/source/opt/passes.cpp
@@ -44,20 +44,28 @@ bool StripDebugInfoPass::Process(ir::Module* module) {
 bool FreezeSpecConstantValuePass::Process(ir::Module* module) {
   bool modified = false;
   module->ForEachInst([&modified](ir::Instruction* inst) {
-    if (inst->opcode() == SpvOp::SpvOpSpecConstant) {
-      inst->SetOpcode(SpvOp::SpvOpConstant);
-      modified = true;
-    } else if (inst->opcode() == SpvOp::SpvOpSpecConstantTrue) {
-      inst->SetOpcode(SpvOp::SpvOpConstantTrue);
-      modified = true;
-    } else if (inst->opcode() == SpvOp::SpvOpSpecConstantFalse) {
-      inst->SetOpcode(SpvOp::SpvOpConstantFalse);
-      modified = true;
-    } else if (inst->opcode() == SpvOp::SpvOpDecorate &&
-        inst->GetInOperand(1).words[0] == SpvDecoration::SpvDecorationSpecId) {
-      // If this is a decoration instrution and the decoration is Spec ID, we
-      // should remove the instrution.
-      inst->ToNop();
+    switch (inst->opcode()) {
+      case SpvOp::SpvOpSpecConstant:
+        inst->SetOpcode(SpvOp::SpvOpConstant);
+        modified = true;
+        break;
+      case SpvOp::SpvOpSpecConstantTrue:
+        inst->SetOpcode(SpvOp::SpvOpConstantTrue);
+        modified = true;
+        break;
+      case SpvOp::SpvOpSpecConstantFalse:
+        inst->SetOpcode(SpvOp::SpvOpConstantFalse);
+        modified = true;
+        break;
+      case SpvOp::SpvOpDecorate:
+        if (inst->GetSingleWordInOperand(1) ==
+            SpvDecoration::SpvDecorationSpecId) {
+          inst->ToNop();
+          modified = true;
+        }
+        break;
+      default:
+        break;
     }
   });
   return modified;

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -58,6 +58,14 @@ class StripDebugInfoPass : public Pass {
   bool Process(ir::Module* module) override;
 };
 
+class FreezeSpecConstantValuePass : public Pass {
+ public:
+  const char* name() const override {
+    return "Freeze spec constants to their default value";
+  }
+  bool Process(ir::Module*) override;
+};
+
 }  // namespace opt
 }  // namespace spvtools
 

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -54,15 +54,13 @@ class NullPass : public Pass {
 // Section 3.32.2 of the SPIR-V spec).
 class StripDebugInfoPass : public Pass {
  public:
-  const char* name() const override { return "StripDebugInfo"; }
+  const char* name() const override { return "strip-debug"; }
   bool Process(ir::Module* module) override;
 };
 
 class FreezeSpecConstantValuePass : public Pass {
  public:
-  const char* name() const override {
-    return "Freeze spec constants to their default value";
-  }
+  const char* name() const override { return "freeze-spec-const"; }
   bool Process(ir::Module*) override;
 };
 

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -46,7 +46,7 @@ class Pass {
 
 // A null pass that does nothing.
 class NullPass : public Pass {
-  const char* name() const override { return "Null"; }
+  const char* name() const override { return "null"; }
   bool Process(ir::Module*) override { return false; }
 };
 

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -39,6 +39,11 @@ add_spvtools_unittest(TARGET pass_strip_debug_info
   LIBS SPIRV-Tools-opt ${SPIRV_TOOLS}
 )
 
+add_spvtools_unittest(TARGET pass_freeze_spec_const
+  SRCS test_freeze_spec_const.cpp pass_utils.cpp
+  LIBS SPIRV-Tools-opt ${SPIRV_TOOLS}
+)
+
 add_spvtools_unittest(TARGET pass_utils
   SRCS test_utils.cpp pass_utils.cpp
   LIBS SPIRV-Tools-opt ${SPIRV_TOOLS}

--- a/test/opt/pass_fixture.h
+++ b/test/opt/pass_fixture.h
@@ -29,6 +29,7 @@
 
 #include <memory>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -52,26 +53,50 @@ class PassTest : public TestT {
   PassTest()
       : tools_(SPV_ENV_UNIVERSAL_1_1), manager_(new opt::PassManager()) {}
 
+  // Runs the given |pass| on the binary assembled from the |assembly|, and
+  // disassebles the optimized binary. Returns a tuple of disassembly string
+  // and the boolean value returned from pass Process() function.
+  std::tuple<std::string, bool> GetOptimizedDisassembly(
+      opt::Pass* pass, const std::string& original, bool skip_nop = false) {
+    std::unique_ptr<ir::Module> module = tools_.BuildModule(original);
+    EXPECT_NE(nullptr, module);
+    if (!module) {
+      return std::make_tuple(std::string(), false);
+    }
+
+    const bool modified = pass->Process(module.get());
+
+    std::vector<uint32_t> binary;
+    module->ToBinary(&binary, skip_nop);
+    std::string optimized;
+    EXPECT_EQ(SPV_SUCCESS, tools_.Disassemble(binary, &optimized));
+    return std::make_tuple(optimized, modified);
+  }
+
+  // Runs a single pass of class |PassT| on the binary assembled from the
+  // |assembly|, disassebles the optimized binary. Returns a tuple of
+  // disassembly string and the boolean value from the pass Process() function.
+  template <typename PassT>
+  std::tuple<std::string, bool> SinglePassRunAndGetDisassembly(
+      const std::string& assembly, bool skip_nop = false) {
+    auto pass = std::unique_ptr<PassT>(new PassT);
+    return GetOptimizedDisassembly(pass.get(), assembly, skip_nop);
+  }
+
   // Runs a single pass of class |PassT| on the binary assembled from the
   // |original| assembly, and checks whether the optimized binary can be
   // disassembled to the |expected| assembly. This does *not* involve pass
   // manager. Callers are suggested to use SCOPED_TRACE() for better messages.
   template <typename PassT>
   void SinglePassRunAndCheck(const std::string& original,
-                             const std::string& expected) {
-    std::unique_ptr<ir::Module> module = tools_.BuildModule(original);
-    ASSERT_NE(nullptr, module);
-
-    const bool modified =
-        std::unique_ptr<PassT>(new PassT)->Process(module.get());
+                             const std::string& expected,
+                             bool skip_nop = false) {
+    std::string optimized;
+    bool modified = false;
+    std::tie(optimized, modified) =
+        SinglePassRunAndGetDisassembly<PassT>(original, skip_nop);
     // Check whether the pass returns the correct modification indication.
     EXPECT_EQ(original != expected, modified);
-
-    std::vector<uint32_t> binary;
-    module->ToBinary(&binary, /* skip_nop = */ false);
-
-    std::string optimized;
-    EXPECT_EQ(SPV_SUCCESS, tools_.Disassemble(binary, &optimized));
     EXPECT_EQ(expected, optimized);
   }
 

--- a/test/opt/pass_fixture.h
+++ b/test/opt/pass_fixture.h
@@ -56,7 +56,7 @@ class PassTest : public TestT {
   // Runs the given |pass| on the binary assembled from the |assembly|, and
   // disassebles the optimized binary. Returns a tuple of disassembly string
   // and the boolean value returned from pass Process() function.
-  std::tuple<std::string, bool> GetOptimizedDisassembly(
+  std::tuple<std::string, bool> OptimizeAndDisassemble(
       opt::Pass* pass, const std::string& original, bool skip_nop = false) {
     std::unique_ptr<ir::Module> module = tools_.BuildModule(original);
     EXPECT_NE(nullptr, module);
@@ -74,13 +74,13 @@ class PassTest : public TestT {
   }
 
   // Runs a single pass of class |PassT| on the binary assembled from the
-  // |assembly|, disassebles the optimized binary. Returns a tuple of
+  // |assembly|, disassembles the optimized binary. Returns a tuple of
   // disassembly string and the boolean value from the pass Process() function.
   template <typename PassT>
-  std::tuple<std::string, bool> SinglePassRunAndGetDisassembly(
+  std::tuple<std::string, bool> SinglePassRunAndDisassemble(
       const std::string& assembly, bool skip_nop = false) {
     auto pass = std::unique_ptr<PassT>(new PassT);
-    return GetOptimizedDisassembly(pass.get(), assembly, skip_nop);
+    return OptimizeAndDisassemble(pass.get(), assembly, skip_nop);
   }
 
   // Runs a single pass of class |PassT| on the binary assembled from the
@@ -94,7 +94,7 @@ class PassTest : public TestT {
     std::string optimized;
     bool modified = false;
     std::tie(optimized, modified) =
-        SinglePassRunAndGetDisassembly<PassT>(original, skip_nop);
+        SinglePassRunAndDisassemble<PassT>(original, skip_nop);
     // Check whether the pass returns the correct modification indication.
     EXPECT_EQ(original != expected, modified);
     EXPECT_EQ(expected, optimized);

--- a/test/opt/test_freeze_spec_const.cpp
+++ b/test/opt/test_freeze_spec_const.cpp
@@ -29,10 +29,31 @@
 
 #include <algorithm>
 #include <tuple>
+#include <vector>
 
 namespace {
 
 using namespace spvtools;
+
+// A utility function for in-place string replacement. Find the |find_str| in
+// the |main_str| and replace the found substring with |replace_str|. Returns
+// true if replacement is done correctly, otherwise returns false.
+bool string_replace(std::string* main_str, const std::string find_str,
+                    const std::string replace_str) {
+  // The replace_string should not have the find_string inside.
+  if (replace_str.find(find_str) != std::string::npos) {
+    return false;
+  }
+  for (size_t i = 0; i < main_str->length(); i++) {
+    i = main_str->find(find_str);
+    if (i != std::string::npos) {
+      main_str->replace(i, find_str.length(), replace_str);
+    } else {
+      break;
+    }
+  }
+  return true;
+}
 
 using FreezeSpecConstantValueTypeTest = PassTest<::testing::TestWithParam<
     std::tuple<const char*, const char*, const char*>>>;
@@ -52,25 +73,25 @@ TEST_P(FreezeSpecConstantValueTypeTest, PrimaryType) {
 // Test each primary type.
 INSTANTIATE_TEST_CASE_P(
     PrimaryTypeSpecConst, FreezeSpecConstantValueTypeTest,
-    ::testing::ValuesIn(
-        std::vector<std::tuple<const char*, const char*, const char*>>({
-            // Type, original spec constant definition, expected frozen spec
-            // constants.
-            std::make_tuple("%1 = OpTypeInt 32 1", "%2 = OpSpecConstant %1 1",
-                            "%2 = OpConstant %1 1"),
-            std::make_tuple("%1 = OpTypeInt 32 0", "%2 = OpSpecConstant %1 1",
-                            "%2 = OpConstant %1 1"),
-            std::make_tuple("%1 = OpTypeFloat 32",
-                            "%2 = OpSpecConstant %1 3.14",
-                            "%2 = OpConstant %1 3.14"),
-            std::make_tuple("%1 = OpTypeFloat 64",
-                            "%2 = OpSpecConstant %1 3.1415926",
-                            "%2 = OpConstant %1 3.1415926"),
-            std::make_tuple("%1 = OpTypeBool", "%2 = OpSpecConstantTrue %1",
-                            "%2 = OpConstantTrue %1"),
-            std::make_tuple("%1 = OpTypeBool", "%2 = OpSpecConstantFalse %1",
-                            "%2 = OpConstantFalse %1"),
-        })));
+    ::testing::ValuesIn(std::vector<
+                        std::tuple<const char*, const char*, const char*>>({
+        // Type declaration, original spec constant definition, expected frozen
+        // spec constants.
+        std::make_tuple("%int = OpTypeInt 32 1", "%2 = OpSpecConstant %int 1",
+                        "%2 = OpConstant %int 1"),
+        std::make_tuple("%uint = OpTypeInt 32 0", "%2 = OpSpecConstant %uint 1",
+                        "%2 = OpConstant %uint 1"),
+        std::make_tuple("%float = OpTypeFloat 32",
+                        "%2 = OpSpecConstant %float 3.14",
+                        "%2 = OpConstant %float 3.14"),
+        std::make_tuple("%double = OpTypeFloat 64",
+                        "%2 = OpSpecConstant %double 3.1415926",
+                        "%2 = OpConstant %double 3.1415926"),
+        std::make_tuple("%bool = OpTypeBool", "%2 = OpSpecConstantTrue %bool",
+                        "%2 = OpConstantTrue %bool"),
+        std::make_tuple("%bool = OpTypeBool", "%2 = OpSpecConstantFalse %bool",
+                        "%2 = OpConstantFalse %bool"),
+    })));
 
 using FreezeSpecConstantValueRemoveDecorationTest = PassTest<::testing::Test>;
 
@@ -82,46 +103,44 @@ TEST_F(FreezeSpecConstantValueRemoveDecorationTest,
                "OpCapability Float64",
           "%1 = OpExtInstImport \"GLSL.std.450\"",
                "OpMemoryModel Logical GLSL450",
-               "OpEntryPoint Vertex %4 \"main\"",
+               "OpEntryPoint Vertex %main \"main\"",
                "OpSource GLSL 450",
                "OpSourceExtension \"GL_GOOGLE_cpp_style_line_directive\"",
                "OpSourceExtension \"GL_GOOGLE_include_directive\"",
-               "OpName %4 \"main\"",
-               "OpDecorate %7 SpecId 200",
-               "OpDecorate %9 SpecId 201",
-               "OpDecorate %11 SpecId 202",
-               "OpDecorate %13 SpecId 203",
-          "%2 = OpTypeVoid",
-          "%3 = OpTypeFunction %2",
-          "%6 = OpTypeInt 32 1",
-          "%7 = OpSpecConstant %6 3",
-          "%8 = OpTypeFloat 32",
-          "%9 = OpSpecConstant %8 3.14",
-         "%10 = OpTypeFloat 64",
-         "%11 = OpSpecConstant %10 3.14159265358979",
-         "%12 = OpTypeBool",
-         "%13 = OpSpecConstantTrue %12",
-          "%4 = OpFunction %2 None %3",
-          "%5 = OpLabel",
+               "OpName %main \"main\"",
+               "OpDecorate %3 SpecId 200",
+               "OpDecorate %4 SpecId 201",
+               "OpDecorate %5 SpecId 202",
+               "OpDecorate %6 SpecId 203",
+       "%void = OpTypeVoid",
+          "%8 = OpTypeFunction %void",
+        "%int = OpTypeInt 32 1",
+          "%3 = OpSpecConstant %int 3",
+      "%float = OpTypeFloat 32",
+          "%4 = OpSpecConstant %float 3.14",
+     "%double = OpTypeFloat 64",
+          "%5 = OpSpecConstant %double 3.14159265358979",
+       "%bool = OpTypeBool",
+          "%6 = OpSpecConstantTrue %bool",
+       "%main = OpFunction %void None %8",
+         "%13 = OpLabel",
                "OpReturn",
                "OpFunctionEnd",
       // clang-format on
   };
-  std::string optimized;
-  bool modified = false;
-  std::tie(optimized, modified) =
-      SinglePassRunAndGetDisassembly<opt::FreezeSpecConstantValuePass>(
-          JoinAllInsts(text));
-  EXPECT_EQ(JoinAllInsts(text) != optimized, modified);
-  const char* removed_keywords[] = {
-      "OpSpecConstant", "SpecId",
+  std::string expected_disassembly = SelectiveJoin(text, [](const char* line) {
+    return std::string(line).find("SpecId") != std::string::npos;
+  });
+  std::vector<std::pair<const char*, const char*>> opcode_replacement_pairs = {
+      {" OpSpecConstant ", " OpConstant "},
+      {" OpSpecConstantTrue ", " OpConstantTrue "},
+      {" OpSpecConstantFalse ", " OpConstantFalse "},
   };
-  bool contain_removed_keywords =
-      std::any_of(std::begin(removed_keywords), std::end(removed_keywords),
-                  [&optimized](const char* keyword) {
-                    return optimized.find(keyword) != std::string::npos;
-                  });
-  EXPECT_FALSE(contain_removed_keywords);
+  for (auto& p : opcode_replacement_pairs) {
+    EXPECT_TRUE(string_replace(&expected_disassembly, p.first, p.second));
+  }
+  SinglePassRunAndCheck<opt::FreezeSpecConstantValuePass>(
+      JoinAllInsts(text), expected_disassembly,
+      /* skip_nop = */ true);
 }
-
 }  // anonymous namespace

--- a/test/opt/test_freeze_spec_const.cpp
+++ b/test/opt/test_freeze_spec_const.cpp
@@ -121,7 +121,7 @@ TEST_F(FreezeSpecConstantValueRemoveDecorationTest,
                   [&optimized](const char* keyword) {
                     return optimized.find(keyword) != std::string::npos;
                   });
-  EXPECT_EQ(false, contain_removed_keywords);
+  EXPECT_FALSE(contain_removed_keywords);
 }
 
 }  // anonymous namespace

--- a/test/opt/test_freeze_spec_const.cpp
+++ b/test/opt/test_freeze_spec_const.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2016 Google Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and/or associated documentation files (the
+// "Materials"), to deal in the Materials without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Materials, and to
+// permit persons to whom the Materials are furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Materials.
+//
+// MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS
+// KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS
+// SPECIFICATIONS AND HEADER INFORMATION ARE LOCATED AT
+//    https://www.khronos.org/registry/
+//
+// THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+#include "pass_fixture.h"
+#include "pass_utils.h"
+
+#include <tuple>
+
+namespace {
+
+using namespace spvtools;
+
+using FreezeSpecConstantValueTest = PassTest<::testing::TestWithParam<
+    std::tuple<const char*, const char*, const char*>>>;
+
+TEST_P(FreezeSpecConstantValueTest, PrimaryType) {
+  auto& test_case = GetParam();
+  std::vector<const char*> text = {
+      "OpCapability Shader", "OpMemoryModel Logical GLSL450",
+      std::get<0>(test_case), std::get<1>(test_case)};
+  std::vector<const char*> expected = {
+      "OpCapability Shader", "OpMemoryModel Logical GLSL450",
+      std::get<0>(test_case), std::get<2>(test_case)};
+  SinglePassRunAndCheck<opt::FreezeSpecConstantValuePass>(
+      JoinAllInsts(text), JoinAllInsts(expected));
+}
+
+// Test each primary type.
+INSTANTIATE_TEST_CASE_P(
+    PrimaryTypeSpecConst, FreezeSpecConstantValueTest,
+    ::testing::ValuesIn(
+        std::vector<std::tuple<const char*, const char*, const char*>>({
+            // Type, original spec constant definition, expected frozen spec
+            // constants.
+            std::make_tuple("%1 = OpTypeInt 32 1", "%2 = OpSpecConstant %1 1",
+                            "%2 = OpConstant %1 1"),
+            std::make_tuple("%1 = OpTypeInt 32 0", "%2 = OpSpecConstant %1 1",
+                            "%2 = OpConstant %1 1"),
+            std::make_tuple("%1 = OpTypeFloat 32",
+                            "%2 = OpSpecConstant %1 3.14",
+                            "%2 = OpConstant %1 3.14"),
+            std::make_tuple("%1 = OpTypeFloat 64",
+                            "%2 = OpSpecConstant %1 3.1415926",
+                            "%2 = OpConstant %1 3.1415926"),
+            std::make_tuple("%1 = OpTypeBool", "%2 = OpSpecConstantTrue %1",
+                            "%2 = OpConstantTrue %1"),
+        })));
+
+}  // anonymous namespace

--- a/test/opt/test_pass_manager.cpp
+++ b/test/opt/test_pass_manager.cpp
@@ -36,18 +36,18 @@ TEST(PassManager, Interface) {
 
   manager.AddPass<opt::StripDebugInfoPass>();
   EXPECT_EQ(1u, manager.NumPasses());
-  EXPECT_STREQ("StripDebugInfo", manager.GetPass(0)->name());
+  EXPECT_STREQ("strip-debug", manager.GetPass(0)->name());
 
   manager.AddPass(std::unique_ptr<opt::NullPass>(new opt::NullPass));
   EXPECT_EQ(2u, manager.NumPasses());
-  EXPECT_STREQ("StripDebugInfo", manager.GetPass(0)->name());
+  EXPECT_STREQ("strip-debug", manager.GetPass(0)->name());
   EXPECT_STREQ("Null", manager.GetPass(1)->name());
 
   manager.AddPass<opt::StripDebugInfoPass>();
   EXPECT_EQ(3u, manager.NumPasses());
-  EXPECT_STREQ("StripDebugInfo", manager.GetPass(0)->name());
+  EXPECT_STREQ("strip-debug", manager.GetPass(0)->name());
   EXPECT_STREQ("Null", manager.GetPass(1)->name());
-  EXPECT_STREQ("StripDebugInfo", manager.GetPass(2)->name());
+  EXPECT_STREQ("strip-debug", manager.GetPass(2)->name());
 }
 
 // A pass that appends an OpNop instruction to the debug section.

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -51,6 +51,9 @@ NOTE: The optimizer is a work in progress.
 Options:
   --strip-debug
                Remove all debug instructions.
+  --freeze-spec-const
+               Freeze the values of specialization constants to their default
+               values.
   -h, --help   Print this help.
   --version    Display optimizer version information.
 )",

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -83,6 +83,8 @@ int main(int argc, char** argv) {
         }
       } else if (0 == strcmp(cur_arg, "--strip-debug")) {
         pass_manager.AddPass<opt::StripDebugInfoPass>();
+      } else if (0 == strcmp(cur_arg, "--freeze-spec-const")) {
+        pass_manager.AddPass<opt::FreezeSpecConstantValuePass>();
       } else if ('\0' == cur_arg[1]) {
         // Setting a filename of "-" to indicate stdin.
         if (!in_file) {


### PR DESCRIPTION
Add a pass to freeze spec constants their default value. This pass does
not fold the frozen spec constants so does not handle SpecConstantOp
instructions and SpecConstantComposite instructions.

Work in progress as this CL add OpINotEqual to the whitelist of
supported opcodes of OpSpecConstantOp.