### PR TITLE
Fix infinite loop in dominance calculation.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,9 +4,13 @@ v2016.2-dev 2016-07-19
  - Start v2016.2
  - Validator is incomplete
    - Checks ID use block is dominated by definition block
- - Add optimization passes
+ - Add optimization passes (in API and spirv-opt command)
    - Strip debug info instructions
    - Freeze spec constant to their default values
+ - Fixes bugs:
+   #270: validator: crash when continue construct is unreachable
+   #279: validator: infinite loop when analyzing some degenerate control
+     flow graphs
 
 v2016.1 2016-07-19
  - Fix https://github.com/KhronosGroup/SPIRV-Tools/issues/261

--- a/source/val/BasicBlock.cpp
+++ b/source/val/BasicBlock.cpp
@@ -76,14 +76,6 @@ void BasicBlock::RegisterBranchInstruction(SpvOp branch_instruction) {
   return;
 }
 
-void BasicBlock::SetSuccessorsUnsafe(std::vector<BasicBlock*>&& others) {
-  successors_ = std::move(others);
-}
-
-void BasicBlock::SetPredecessorsUnsafe(std::vector<BasicBlock*>&& others) {
-  predecessors_ = std::move(others);
-}
-
 BasicBlock::DominatorIterator::DominatorIterator() : current_(nullptr) {}
 
 BasicBlock::DominatorIterator::DominatorIterator(

--- a/source/val/BasicBlock.h
+++ b/source/val/BasicBlock.h
@@ -121,14 +121,6 @@ class BasicBlock {
   /// Adds @p next BasicBlocks as successors of this BasicBlock
   void RegisterSuccessors(const std::vector<BasicBlock*>& next = {});
 
-  /// Set the successors to this block, without updating other internal state,
-  /// and without updating the other blocks.
-  void SetSuccessorsUnsafe(std::vector<BasicBlock*>&& others);
-
-  /// Set the predecessors to this block, without updating other internal state,
-  /// and without updating the other blocks.
-  void SetPredecessorsUnsafe(std::vector<BasicBlock*>&& others);
-
   /// Returns true if the id of the BasicBlock matches
   bool operator==(const BasicBlock& other) const { return other.id_ == id_; }
 

--- a/source/validate.h
+++ b/source/validate.h
@@ -57,6 +57,31 @@ class ValidationState_t;
 using get_blocks_func =
     std::function<const std::vector<BasicBlock*>*(const BasicBlock*)>;
 
+/// @brief Depth first traversal starting from the \p entry BasicBlock
+///
+/// This function performs a depth first traversal from the \p entry
+/// BasicBlock and calls the pre/postorder functions when it needs to process
+/// the node in pre order, post order. It also calls the backedge function
+/// when a back edge is encountered.
+///
+/// @param[in] entry      The root BasicBlock of a CFG
+/// @param[in] successor_func  A function which will return a pointer to the
+///                            successor nodes
+/// @param[in] preorder   A function that will be called for every block in a
+///                       CFG following preorder traversal semantics
+/// @param[in] postorder  A function that will be called for every block in a
+///                       CFG following postorder traversal semantics
+/// @param[in] backedge   A function that will be called when a backedge is
+///                       encountered during a traversal
+/// NOTE: The @p successor_func and predecessor_func each return a pointer to a
+/// collection such that iterators to that collection remain valid for the
+/// lifetime of the algorithm.
+void DepthFirstTraversal(
+    const BasicBlock* entry, get_blocks_func successor_func,
+    std::function<void(const BasicBlock*)> preorder,
+    std::function<void(const BasicBlock*)> postorder,
+    std::function<void(const BasicBlock*, const BasicBlock*)> backedge);
+
 /// @brief Calculates dominator edges for a set of blocks
 ///
 /// Computes dominators using the algorithm of Cooper, Harvey, and Kennedy


### PR DESCRIPTION
Ensure the dominance calculation visits all nodes in the CFG.
The successor list of the pseudo-entry node is augmented with
a single node in each cycle that otherwise would not be visited.
Similarly, the predecssors list of the pseduo-exit node is augmented
with the a single node in each cycle that otherwise would not
be visited.

Pulls DepthFirstSearch out so it's accessible outside of the dominator
calculation.

Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/279