### PR TITLE
Fix a test failure in pass manager test

### DIFF
--- a/test/opt/test_pass_manager.cpp
+++ b/test/opt/test_pass_manager.cpp
@@ -41,12 +41,12 @@ TEST(PassManager, Interface) {
   manager.AddPass(std::unique_ptr<opt::NullPass>(new opt::NullPass));
   EXPECT_EQ(2u, manager.NumPasses());
   EXPECT_STREQ("strip-debug", manager.GetPass(0)->name());
-  EXPECT_STREQ("Null", manager.GetPass(1)->name());
+  EXPECT_STREQ("null", manager.GetPass(1)->name());
 
   manager.AddPass<opt::StripDebugInfoPass>();
   EXPECT_EQ(3u, manager.NumPasses());
   EXPECT_STREQ("strip-debug", manager.GetPass(0)->name());
-  EXPECT_STREQ("Null", manager.GetPass(1)->name());
+  EXPECT_STREQ("null", manager.GetPass(1)->name());
   EXPECT_STREQ("strip-debug", manager.GetPass(2)->name());
 }
 


### PR DESCRIPTION
Fix the test failure in a24506266bbdb849785678402d247c43acd234e7
Change "Null" to "null" in pass manager test