### PR TITLE
Validator cfg fixes

### DIFF
--- a/source/val/Function.cpp
+++ b/source/val/Function.cpp
@@ -50,7 +50,9 @@ using libspirv::BasicBlock;
 
 // Computes a minimal set of root nodes required to traverse, in the forward
 // direction, the CFG represented by the given vector of blocks, and successor
-// and predecessor functions.
+// and predecessor functions.  When considering adding two nodes, each having
+// predecessors, favour using the one that appears earlier on the input blocks
+// list.
 std::vector<BasicBlock*> TraversalRoots(const std::vector<BasicBlock*>& blocks,
                                         libspirv::get_blocks_func succ_func,
                                         libspirv::get_blocks_func pred_func) {
@@ -200,7 +202,6 @@ void Function::RegisterBlockEnd(vector<uint32_t> next_list,
   assert(
       current_block_ &&
       "RegisterBlockEnd can only be called when parsing a binary in a block");
-
   vector<BasicBlock*> next_blocks;
   next_blocks.reserve(next_list.size());
 
@@ -213,6 +214,21 @@ void Function::RegisterBlockEnd(vector<uint32_t> next_list,
       undefined_blocks_.insert(successor_id);
     }
     next_blocks.push_back(&inserted_block->second);
+  }
+
+  if (current_block_->is_type(kBlockTypeLoop)) {
+    // For each loop header, record the set of its successors, and include
+    // its continue target if the continue target is not the loop header
+    // itself.
+    std::vector<BasicBlock*>& next_blocks_plus_continue_target =
+        loop_header_successors_plus_continue_target_map_[current_block_];
+    next_blocks_plus_continue_target = next_blocks;
+    // If this block is marked as Loop-type,  then the continue construct is
+    // the most recently created CFG construct.
+    auto continue_target = cfg_constructs_.back().entry_block();
+    if (continue_target != current_block_) {
+      next_blocks_plus_continue_target.push_back(continue_target);
+    }
   }
 
   current_block_->RegisterBranchInstruction(branch_instruction);
@@ -292,6 +308,16 @@ Function::GetBlocksFunction Function::AugmentedCFGSuccessorsFunction() const {
   };
 }
 
+Function::GetBlocksFunction
+Function::AugmentedCFGSuccessorsFunctionIncludingHeaderToContinueEdge() const {
+  return [this](const BasicBlock* block) {
+    auto where = loop_header_successors_plus_continue_target_map_.find(block);
+    return where == loop_header_successors_plus_continue_target_map_.end()
+               ? AugmentedCFGSuccessorsFunction()(block)
+               : &(*where).second;
+  };
+}
+
 Function::GetBlocksFunction Function::AugmentedCFGPredecessorsFunction() const {
   return [this](const BasicBlock* block) {
     auto where = augmented_predecessors_map_.find(block);
@@ -306,7 +332,21 @@ void Function::ComputeAugmentedCFG() {
   auto succ_func = [](const BasicBlock* b) { return b->successors(); };
   auto pred_func = [](const BasicBlock* b) { return b->predecessors(); };
   auto sources = TraversalRoots(ordered_blocks_, succ_func, pred_func);
-  auto sinks = TraversalRoots(ordered_blocks_, pred_func, succ_func);
+
+  // For the predecessor traversals, reverse the order of blocks.  This
+  // will affect the post-dominance calculation as follows:
+  //  - Suppose you have blocks A and B, with A appearing before B in
+  //    the list of blocks.
+  //  - Also, A branches only to B, and B branches only to A.
+  //  - We want to compute A as dominating B, and B as post-dominating B.
+  // By using reversed blocks for predecessor traversal roots discovery,
+  // we'll add an edge from B to the pseudo-exit node, rather than from A.
+  // All this is needed to correctly process the dominance/post-dominance
+  // constraint when A is a loop header that points to itself as its
+  // own continue target, and B is the latch block for the loop.
+  std::vector<BasicBlock*> reversed_blocks(ordered_blocks_.rbegin(),
+                                           ordered_blocks_.rend());
+  auto sinks = TraversalRoots(reversed_blocks, pred_func, succ_func);
 
   // Wire up the pseudo entry block.
   augmented_successors_map_[&pseudo_entry_block_] = sources;

--- a/source/val/Function.h
+++ b/source/val/Function.h
@@ -180,6 +180,9 @@ class Function {
       std::function<const std::vector<BasicBlock*>*(const BasicBlock*)>;
   /// Returns the block successors function for the augmented CFG.
   GetBlocksFunction AugmentedCFGSuccessorsFunction() const;
+  /// Like AugmentedCFGSuccessorsFunction, but also includes a forward edge from
+  /// a loop header block to its continue target, if they are different blocks.
+  GetBlocksFunction AugmentedCFGSuccessorsFunctionIncludingHeaderToContinueEdge() const;
   /// Returns the block predecessors function for the augmented CFG.
   GetBlocksFunction AugmentedCFGPredecessorsFunction() const;
 
@@ -261,6 +264,12 @@ class Function {
   // different from its predecessors in the ordinary CFG.
   std::unordered_map<const BasicBlock*, std::vector<BasicBlock*>>
       augmented_predecessors_map_;
+
+  // Maps a structured loop header to its CFG successors and also its
+  // continue target if that continue target is not the loop header
+  // itself. This might have duplicates.
+  std::unordered_map<const BasicBlock*, std::vector<BasicBlock*>>
+      loop_header_successors_plus_continue_target_map_;
 
   /// The constructs that are available in this function
   std::list<Construct> cfg_constructs_;

--- a/source/val/Function.h
+++ b/source/val/Function.h
@@ -197,6 +197,14 @@ class Function {
   // Populates augmented_successors_map_ and augmented_predecessors_map_.
   void ComputeAugmentedCFG();
 
+  // Adds a copy of the given Construct, and tracks it by its entry block.
+  // Returns a reference to the stored construct.
+  Construct& AddConstruct(const Construct& new_construct);
+
+  // Returns a reference to the construct corresponding to the given entry
+  // block.
+  Construct& FindConstructForEntryBlock(const BasicBlock* entry_block);
+
   /// The result id of the OpLabel that defined this block
   uint32_t id_;
 
@@ -279,6 +287,9 @@ class Function {
 
   /// The function parameter ids of the functions
   std::vector<uint32_t> parameter_ids_;
+
+  /// Maps a construct's entry block to the construct.
+  std::unordered_map<const BasicBlock*, Construct*> entry_block_to_construct_;
 };
 
 }  /// namespace libspirv


### PR DESCRIPTION
- Find unreachable continue targets.  Look for back edges
  with a DFS traversal separate from the dominance traversals,
  where we count the OpLoopMerge from the header to the continue
  target as an edge in the graph.

- It's ok for a loop to have multiple back edges, provided
  they are all from the same block, and we call that the latch block.
  This may require a clarification/fix in the SPIR-V spec.

- Compute postdominance correctly for infinite loop:
  Bias *predecessor* traversal root finding so that you use
  a later block in the original list.  This ensures that
  for certain simple infinite loops in the CFG where neither
  block branches to a node without successors, that we'll
  compute the loop header as dominating the latch block, and the
  latch block as postdominating the loop header.