### PR TITLE
Use NEW behavior for policy CMP0054.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,13 @@
 # MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 
 cmake_minimum_required(VERSION 2.8.12)
+if (POLICY CMP0054)
+  # Avoid dereferencing variables or interpret keywords that have been
+  # quoted or bracketed.
+  # https://cmake.org/cmake/help/v3.1/policy/CMP0054.html
+  cmake_policy(SET CMP0054 NEW)
+endif()
+
 project(spirv-tools)
 enable_testing()
 set(SPIRV_TOOLS "SPIRV-Tools")
@@ -49,7 +56,7 @@ if ("${CMAKE_BUILD_TYPE}" STREQUAL "")
 endif()
 
 option(SPIRV_WERROR "Enable error on warning" ON)
-if((${CMAKE_CXX_COMPILER_ID} MATCHES "GNU") OR (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang"))
+if(("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang"))
   set(COMPILER_IS_LIKE_GNU TRUE)
 endif()
 if(${COMPILER_IS_LIKE_GNU})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,7 +51,7 @@ function(add_spvtools_unittest)
     if(${COMPILER_IS_LIKE_GNU})
       target_compile_options(${ARG_TARGET} PRIVATE -Wno-undef)
     endif()
-    if(${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
       # Disable C4503 "decorated name length exceeded" warning,
       # triggered by some heavily templated types.
       # We don't care much about that in test code.


### PR DESCRIPTION
The NEW behavior is to not dereference variables or interpret keywords
that have been quoted or bracketed.

For more information, see
https://cmake.org/cmake/help/v3.1/policy/CMP0054.html.

This is to suppress a warning when using CMake 3.1.3+.