### PR TITLE
Separate pass.h from passes.h

### DIFF
--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(SPIRV-Tools-opt
   libspirv.hpp
   module.h
   reflect.h
+  pass.h
   passes.h
   pass_manager.h
 

--- a/source/opt/pass.h
+++ b/source/opt/pass.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2016 Google Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and/or associated documentation files (the
+// "Materials"), to deal in the Materials without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Materials, and to
+// permit persons to whom the Materials are furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Materials.
+//
+// MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS
+// KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS
+// SPECIFICATIONS AND HEADER INFORMATION ARE LOCATED AT
+//    https://www.khronos.org/registry/
+//
+// THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+#ifndef LIBSPIRV_OPT_PASS_H_
+#define LIBSPIRV_OPT_PASS_H_
+
+#include <memory>
+
+#include "module.h"
+
+namespace spvtools {
+namespace opt {
+
+// Abstract class of a pass. All passes should implement this abstract class
+// and all analysis and transformation is done via the Process() method.
+class Pass {
+ public:
+  // Returns a descriptive name for this pass.
+  virtual const char* name() const = 0;
+  // Processes the given |module| and returns true if the given |module| is
+  // modified for optimization.
+  virtual bool Process(ir::Module* module) = 0;
+};
+
+}  // namespace opt
+}  // namespace spvtools
+
+#endif  // LIBSPIRV_OPT_PASS_H_

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -30,19 +30,10 @@
 #include <memory>
 
 #include "module.h"
+#include "pass.h"
 
 namespace spvtools {
 namespace opt {
-
-// A pass. All analysis and transformation is done via the Process() method.
-class Pass {
- public:
-  // Returns a descriptive name for this pass.
-  virtual const char* name() const = 0;
-  // Processes the given |module| and returns true if the given |module| is
-  // modified for optimization.
-  virtual bool Process(ir::Module* module) = 0;
-};
 
 // A null pass that does nothing.
 class NullPass : public Pass {
@@ -78,9 +69,9 @@ class FreezeSpecConstantValuePass : public Pass {
 // OpSpecConstantComposite, OpSpecConstantTrue, OpSpecConstantFalse and
 // OpSpecConstantOp.
 class EliminateDeadConstantPass : public Pass {
-  public:
-    const char* name() const override { return "eliminate-dead-const"; }
-    bool Process(ir::Module*) override;
+ public:
+  const char* name() const override { return "eliminate-dead-const"; }
+  bool Process(ir::Module*) override;
 };
 
 }  // namespace opt


### PR DESCRIPTION
Future pass implementations should only need to include pass.h

This is also necessary for the implementation of pass registry to support -load=*.so in future.