### PR TITLE
Manually create move the constructor/assignment for Instruction.

### DIFF
--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -50,6 +50,22 @@ Instruction::Instruction(const spv_parsed_instruction_t& inst,
   }
 }
 
+Instruction::Instruction(Instruction&& that)
+    : opcode_(that.opcode_),
+      type_id_(that.type_id_),
+      result_id_(that.result_id_),
+      operands_(std::move(that.operands_)),
+      dbg_line_insts_(std::move(that.dbg_line_insts_)) {}
+
+Instruction& Instruction::operator=(Instruction&& that) {
+  opcode_ = that.opcode_;
+  type_id_ = that.type_id_;
+  result_id_ = that.result_id_;
+  operands_ = std::move(that.operands_);
+  dbg_line_insts_ = std::move(that.dbg_line_insts_);
+  return *this;
+}
+
 uint32_t Instruction::GetSingleWordOperand(uint32_t index) const {
   const auto& words = GetOperand(index).words;
   assert(words.size() == 1 && "expected the operand only taking one word");

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -88,8 +88,8 @@ class Instruction {
   Instruction(const Instruction&) = default;
   Instruction& operator=(const Instruction&) = default;
 
-  Instruction(Instruction&&) = default;
-  Instruction& operator=(Instruction&&) = default;
+  Instruction(Instruction&&);
+  Instruction& operator=(Instruction&&);
 
   SpvOp opcode() const { return opcode_; }
   // Sets the opcode of this instruction to a specific opcode. Note this may


### PR DESCRIPTION
This is because some old visual studio versions (e.g., 2013) do
not support automatically generating move constructors/assignments.