### PR TITLE
Fixed the build for MSVC.

### DIFF
--- a/test/opt/assembly_builder.h
+++ b/test/opt/assembly_builder.h
@@ -28,6 +28,7 @@
 #define LIBSPIRV_TEST_OPT_ASSEMBLY_BUILDER
 
 #include <algorithm>
+#include <cstdint>
 #include <sstream>
 #include <string>
 #include <unordered_set>


### PR DESCRIPTION
assembly_builder was missing an include for cstdint.