### PR TITLE
Add more tests and KillInst() to DefUseManager

### DIFF
--- a/source/opt/def_use_manager.cpp
+++ b/source/opt/def_use_manager.cpp
@@ -50,7 +50,7 @@ void DefUseManager::AnalyzeInstDefUse(ir::Instruction* inst) {
   if (def_id != 0) {
     // If the new instruction defines an existing result id, clear the records
     // of the existing id first.
-    ClearDef(def_id);
+    // ClearDef(def_id);
     id_to_def_[def_id] = inst;
   }
 
@@ -125,13 +125,13 @@ void DefUseManager::ClearDef(uint32_t def_id) {
 void DefUseManager::ClearInst(ir::Instruction* inst) {
   // Do nothing if the instruction is a nullptr or it has not been analyzed
   // before.
-  if (!inst || analyzed_insts_.count(inst) == 0) return;
+  if (!inst) return;
 
   EraseInstUsesOfOperands(*inst);
   // If a result id is defined by this instruction, remove the use records of
   // the id.
   if (inst->result_id() != 0) {
-    assert(id_to_def_[inst->result_id()] == inst);
+    // assert(id_to_def_[inst->result_id()] == inst);
     id_to_uses_.erase(inst->result_id());  // Remove all uses of this id.
     id_to_def_.erase(inst->result_id());
   }

--- a/source/opt/def_use_manager.cpp
+++ b/source/opt/def_use_manager.cpp
@@ -91,8 +91,17 @@ bool DefUseManager::ReplaceAllUsesWith(uint32_t before, uint32_t after) {
 
   for (auto it = id_to_uses_[before].cbegin(); it != id_to_uses_[before].cend();
        ++it) {
-    // Make the modification in the instruction.
-    it->inst->SetOperand(it->operand_index, {after});
+    uint32_t type_result_id_count =
+        (it->inst->result_id() != 0) + (it->inst->type_id() != 0);
+    if (it->inst->type_id() != 0 && it->operand_index == 0) {
+      it->inst->SetResultType(after);
+    } else {
+      assert(it->operand_index >= type_result_id_count &&
+             "the operand to be set is not an in-operand.");
+      uint32_t in_operand_pos = it->operand_index - type_result_id_count;
+      // Make the modification in the instruction.
+      it->inst->SetInOperand(in_operand_pos, {after});
+    }
     // Register the use of |after| id into id_to_uses_.
     // TODO(antiagainst): de-duplication.
     id_to_uses_[after].push_back({it->inst, it->operand_index});

--- a/source/opt/def_use_manager.cpp
+++ b/source/opt/def_use_manager.cpp
@@ -55,7 +55,7 @@ void DefUseManager::AnalyzeInstDefUse(ir::Instruction* inst) {
   }
 
   for (uint32_t i = 0; i < inst->NumOperands(); ++i) {
-    if (ShouldRecord(inst->GetOperand(i))) {
+    if (IsIdUse(inst->GetOperand(i))) {
       uint32_t use_id = inst->GetSingleWordOperand(i);
       // use_id is used by this instruction.
       id_to_uses_[use_id].push_back({inst, i});
@@ -113,8 +113,13 @@ bool DefUseManager::ReplaceAllUsesWith(uint32_t before, uint32_t after) {
 }
 
 void DefUseManager::ClearDef(uint32_t def_id) {
-  if (id_to_def_.count(def_id) == 0) return;
-  ClearInst(id_to_def_.at(def_id));
+  const auto& iter = id_to_def_.find(def_id);
+  if (iter == id_to_def_.end()) return;
+  EraseInstUsesOfOperands(*iter->second);
+  // If a result id is defined by this instruction, remove the use records of
+  // the id.
+  id_to_uses_.erase(def_id);  // Remove all uses of this id.
+  id_to_def_.erase(def_id);
 }
 
 void DefUseManager::ClearInst(ir::Instruction* inst) {
@@ -122,18 +127,7 @@ void DefUseManager::ClearInst(ir::Instruction* inst) {
   // before.
   if (!inst || analyzed_insts_.count(inst) == 0) return;
 
-  // Go through all ids, except the result id, used by this instruction, remove
-  // this instruction's uses of those ids.
-  for (uint32_t i = 0; i < inst->NumOperands(); i++) {
-    if (ShouldRecord(inst->GetOperand(i))) {
-      uint32_t operand_id = inst->GetSingleWordOperand(i);
-      // Skip if the operand id is not recorded.
-      if (id_to_uses_.count(operand_id) == 0) {
-        continue;
-      }
-      EraseInstUseIdRecord(*inst, operand_id);
-    }
-  }
+  EraseInstUsesOfOperands(*inst);
   // If a result id is defined by this instruction, remove the use records of
   // the id.
   if (inst->result_id() != 0) {
@@ -143,7 +137,7 @@ void DefUseManager::ClearInst(ir::Instruction* inst) {
   }
 }
 
-bool DefUseManager::ShouldRecord(const ir::Operand& operand) const {
+bool DefUseManager::IsIdUse(const ir::Operand& operand) const {
   switch (operand.type) {
     // For any id type but result id type
     case SPV_OPERAND_TYPE_ID:
@@ -156,17 +150,26 @@ bool DefUseManager::ShouldRecord(const ir::Operand& operand) const {
   }
 }
 
-void DefUseManager::EraseInstUseIdRecord(const ir::Instruction& user,
-                                         uint32_t used_id) {
-  auto& uses = id_to_uses_[used_id];
-  for (auto it = uses.begin(); it != uses.end();) {
-    if (it->inst == &user) {
-      it = uses.erase(it);
-    } else {
-      ++it;
+void DefUseManager::EraseInstUsesOfOperands(const ir::Instruction& inst) {
+  // Go through all ids, except the result id, used by this instruction, remove
+  // this instruction's uses of those ids.
+  for (uint32_t i = 0; i < inst.NumOperands(); i++) {
+    if (IsIdUse(inst.GetOperand(i))) {
+      uint32_t operand_id = inst.GetSingleWordOperand(i);
+      auto iter = id_to_uses_.find(operand_id);
+      if (iter != id_to_uses_.end()) {
+        auto& uses = iter->second;
+        for (auto it = uses.begin(); it != uses.end();) {
+          if (it->inst == &inst) {
+            it = uses.erase(it);
+          } else {
+            ++it;
+          }
+        }
+        if (uses.empty()) id_to_uses_.erase(operand_id);
+      }
     }
   }
-  if (uses.empty()) id_to_uses_.erase(used_id);
 }
 
 }  // namespace analysis

--- a/source/opt/def_use_manager.h
+++ b/source/opt/def_use_manager.h
@@ -113,12 +113,13 @@ class DefUseManager {
   // function does nothing even though |inst| may define an existing result id.
   void ClearInst(ir::Instruction* inst);
 
-  // Returns true if the operand's id should be recorded, otherwise returns
-  // false;
-  bool ShouldRecord(const ir::Operand& operand) const;
+  // Returns true if the operand's id is an use.
+  bool IsIdUse(const ir::Operand& operand) const;
 
-  // Erases the record that: instruction |user| uses id |used_id|.
-  void EraseInstUseIdRecord(const ir::Instruction& user, uint32_t used_id);
+  // Erases the records that instruction |inst| uses the ids in its operands.
+  // Does nothing if all the operands are not ids or the instruction does not
+  // have operands.
+  void EraseInstUsesOfOperands(const ir::Instruction& inst);
 
   // Resets the internal records
   void Reset() {

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -128,8 +128,10 @@ class Instruction {
   // not expected to be used with logical operands consisting of multiple SPIR-V
   // words.
   uint32_t GetSingleWordOperand(uint32_t index) const;
-  // Sets the |index|-th operand's data to the given |data|.
-  inline void SetOperand(uint32_t index, std::vector<uint32_t>&& data);
+  // Sets the |index|-th in-operand's data to the given |data|.
+  inline void SetInOperand(uint32_t index, std::vector<uint32_t>&& data);
+  // Sets the result type id.
+  inline void SetResultType(uint32_t ty_id);
 
   // The following methods are similar to the above, but are for in operands.
   uint32_t NumInOperands() const {
@@ -179,10 +181,18 @@ inline const Operand& Instruction::GetOperand(uint32_t index) const {
   return operands_[index];
 };
 
-inline void Instruction::SetOperand(uint32_t index,
-                                    std::vector<uint32_t>&& data) {
-  assert(index < operands_.size() && "operand index out of bound");
-  operands_[index].words = std::move(data);
+inline void Instruction::SetInOperand(uint32_t index,
+                                      std::vector<uint32_t>&& data) {
+  assert(index + TypeResultIdCount() < operands_.size() &&
+         "operand index out of bound");
+  operands_[index + TypeResultIdCount()].words = std::move(data);
+}
+
+inline void Instruction::SetResultType(uint32_t ty_id) {
+  if (type_id_ != 0) {
+    type_id_ = ty_id;
+    operands_[0] = {SPV_OPERAND_TYPE_TYPE_ID, {ty_id}};
+  }
 }
 
 inline bool Instruction::IsNop() const {

--- a/test/opt/test_def_use.cpp
+++ b/test/opt/test_def_use.cpp
@@ -25,6 +25,7 @@
 // MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 
 #include <memory>
+#include <unordered_set>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -52,6 +53,7 @@ std::string DisassembleInst(ir::Instruction* inst) {
   std::string text;
   // We'll need to check the underlying id numbers.
   // So turn off friendly names for ids.
+
   tools.Disassemble(binary, &text, SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
   while (!text.empty() && text.back() == '\n') text.pop_back();
   return text;
@@ -1153,6 +1155,273 @@ TEST(DefUseTest, OpSwitch) {
     EXPECT_EQ(1u, use_list->size());
     EXPECT_EQ(SpvOpSwitch, use_list->front().inst->opcode());
   }
+}
+
+// Creates an |result_id| = OpTypeInt 32 1 instruction.
+ir::Instruction OpTypeIntInstruction(uint32_t result_id) {
+  return ir::Instruction(SpvOp::SpvOpTypeInt, 0, result_id,
+                         {ir::Operand(SPV_OPERAND_TYPE_LITERAL_INTEGER, {32}),
+                          ir::Operand(SPV_OPERAND_TYPE_LITERAL_INTEGER, {1})});
+}
+
+// Creates an |result_id| = OpConstantTrue/Flase |type_id| instruction.
+ir::Instruction ConstantBoolInstruction(bool value, uint32_t type_id,
+                                        uint32_t result_id) {
+  return ir::Instruction(
+      value ? SpvOp::SpvOpConstantTrue : SpvOp::SpvOpConstantFalse, type_id,
+      result_id, {});
+}
+
+// Creates an |result_id| = OpLabel instruction.
+ir::Instruction LabelInstruction(uint32_t result_id) {
+  return ir::Instruction(SpvOp::SpvOpLabel, 0, result_id, {});
+}
+
+// Creates an OpBranch |target_id| instruction.
+ir::Instruction BranchInstruction(uint32_t target_id) {
+  return ir::Instruction(SpvOp::SpvOpBranch, 0, 0,
+                         {
+                             ir::Operand(SPV_OPERAND_TYPE_ID, {target_id}),
+                         });
+}
+
+struct AnalyzeInstDefUseTestCase {
+  std::vector<ir::Instruction> insts;
+  InstDefUse du;
+};
+
+using AnalyzeInstDefUseTest =
+    ::testing::TestWithParam<AnalyzeInstDefUseTestCase>;
+
+TEST_P(AnalyzeInstDefUseTest, Case) {
+  auto tc = GetParam();
+
+  // Analyze the instructions.
+  opt::analysis::DefUseManager manager;
+  for (ir::Instruction& inst : tc.insts) {
+    manager.AnalyzeInstDefUse(&inst);
+  }
+
+  CheckDef(tc.du, manager.id_to_defs());
+  CheckUse(tc.du, manager.id_to_uses());
+}
+
+// clang-format off
+INSTANTIATE_TEST_CASE_P(
+    TestCase, AnalyzeInstDefUseTest,
+    ::testing::ValuesIn(std::vector<AnalyzeInstDefUseTestCase>{
+      { // A type declaring instruction.
+        {OpTypeIntInstruction(1),},
+        {
+          // defs
+          {{1, "%1 = OpTypeInt 32 1"},},
+          {}, // no uses
+        },
+      },
+      { // A type declaring instruction and a constant value.
+        {
+          OpTypeIntInstruction(1),
+          ConstantBoolInstruction(true, 1, 2),
+        },
+        {
+          { // defs
+            {1, "%1 = OpTypeInt 32 1"},
+            {2, "%2 = OpConstantTrue %1"},
+          },
+          { // uses
+            {1,{"%2 = OpConstantTrue %1",}},
+          },
+        },
+      },
+      { // Analyze two instrutions that have same result id.
+        {
+          ConstantBoolInstruction(true, 1, 2),
+          // The def-use info of the following instruction should overwrite the
+          // records of the above one.
+          ConstantBoolInstruction(false, 3, 2),
+        },
+        {
+          // defs
+          {{2, "%2 = OpConstantFalse %3"},},
+          // uses
+          {{3, {"%2 = OpConstantFalse %3",}},}
+        }
+      },
+      { // Analyze forward reference instruction, also instruction that does
+        // not have result id.
+        {
+          BranchInstruction(2),
+          LabelInstruction(2),
+        },
+        {
+          // defs
+          {{2, "%2 = OpLabel"},},
+          // uses
+          {{2, {"OpBranch %2",}},},
+        }
+      }
+      }));
+// clang-format on
+
+struct KillInstTestCase {
+  const char* before;
+  std::unordered_set<uint32_t> indices_inst_to_kill;
+  const char* after;
+  InstDefUse du;
+};
+
+using KillInstTest = ::testing::TestWithParam<KillInstTestCase>;
+
+TEST_P(KillInstTest, Case) {
+  auto tc = GetParam();
+
+  // Build module.
+  const std::vector<const char*> text = {tc.before};
+  std::unique_ptr<ir::Module> module =
+      SpvTools(SPV_ENV_UNIVERSAL_1_1).BuildModule(JoinAllInsts(text));
+  ASSERT_NE(nullptr, module);
+
+  // KillInst
+  uint32_t index = 0;
+  opt::analysis::DefUseManager manager;
+  manager.AnalyzeDefUse(module.get());
+  module->ForEachInst([&index, &tc, &manager](ir::Instruction* inst) {
+    if (tc.indices_inst_to_kill.count(index) != 0) {
+      manager.KillInst(inst);
+    }
+    index++;
+  });
+
+  EXPECT_EQ(tc.after, DisassembleModule(module.get()));
+  CheckDef(tc.du, manager.id_to_defs());
+  CheckUse(tc.du, manager.id_to_uses());
+}
+
+// clang-format off
+INSTANTIATE_TEST_CASE_P(
+    TestCase, KillInstTest,
+    ::testing::ValuesIn(std::vector<KillInstTestCase>{
+      // Kill id defining instrutions.
+      {
+        "%2 = OpFunction %1 None %3 "
+        "%4 = OpLabel "
+        "     OpBranch %5 "
+        "%5 = OpLabel "
+        "     OpBranch %6 "
+        "%6 = OpLabel "
+        "     OpBranch %4 "
+        "%7 = OpLabel "
+        "     OpReturn "
+        "     OpFunctionEnd",
+        {0, 1, 3, 5, 7},
+        "OpNop\n"
+        "OpNop\n"
+        "OpBranch %5\n"
+        "OpNop\n"
+        "OpBranch %6\n"
+        "OpNop\n"
+        "OpBranch %4\n"
+        "OpNop\n"
+        "OpReturn\n"
+        "OpFunctionEnd",
+        {
+          // no defs
+          {},
+          // no uses
+          {}
+        }
+      },
+      // Kill instructions that do not have result ids.
+      {
+        "%2 = OpFunction %1 None %3 "
+        "%4 = OpLabel "
+        "     OpBranch %5 "
+        "%5 = OpLabel "
+        "     OpBranch %6 "
+        "%6 = OpLabel "
+        "     OpBranch %4 "
+        "%7 = OpLabel "
+        "     OpReturn "
+        "     OpFunctionEnd",
+        {2, 4, 6},
+        "%2 = OpFunction %1 None %3\n"
+        "%4 = OpLabel\n"
+             "OpNop\n"
+        "%5 = OpLabel\n"
+             "OpNop\n"
+        "%6 = OpLabel\n"
+             "OpNop\n"
+        "%7 = OpLabel\n"
+             "OpReturn\n"
+             "OpFunctionEnd",
+        {
+          // defs
+          {
+            {2, "%2 = OpFunction %1 None %3"},
+            {4, "%4 = OpLabel"},
+            {5, "%5 = OpLabel"},
+            {6, "%6 = OpLabel"},
+            {7, "%7 = OpLabel"},
+          },
+          // uses
+          {
+            {1, {"%2 = OpFunction %1 None %3",}},
+            {3, {"%2 = OpFunction %1 None %3",}},
+          }
+        }
+      },
+      }));
+// clang-format on
+
+// DefUseManager should only contains the def-use info of the latest analyzed
+// module.
+TEST(AnalyzeDefUseTest, OnlyContainInfoOfLastAnalyzedModule) {
+  const std::vector<const char*> t1 = {
+      "%1 = OpTypeBool", "%2 = OpConstantTrue %1",
+  };
+  // clang-format off
+  InstDefUse du1 = {
+    {
+      {1, "%1 = OpTypeBool"},
+      {2, "%2 = OpConstantTrue %1"},
+    },
+    {
+      {1,{"%2 = OpConstantTrue %1",}},
+    }
+  };
+  // clang-format on
+  const std::vector<const char*> t2 = {
+      "%1 = OpTypeInt 32 1", "%2 = OpTypeBool", "%3 = OpConstantFalse %2",
+  };
+  // clang-format off
+  InstDefUse du2 = {
+    {
+      {1, "%1 = OpTypeInt 32 1"},
+      {2, "%2 = OpTypeBool"},
+      {3, "%3 = OpConstantFalse %2"},
+    },
+    {
+      {2,{"%3 = OpConstantFalse %2",}},
+    }
+  };
+  // clang-format on
+
+  // Build module.
+  std::unique_ptr<ir::Module> m1 =
+      SpvTools(SPV_ENV_UNIVERSAL_1_1).BuildModule(JoinAllInsts(t1));
+  ASSERT_NE(nullptr, m1);
+  std::unique_ptr<ir::Module> m2 =
+      SpvTools(SPV_ENV_UNIVERSAL_1_1).BuildModule(JoinAllInsts(t2));
+  ASSERT_NE(nullptr, m2);
+
+  // Analyze
+  opt::analysis::DefUseManager manager;
+  manager.AnalyzeDefUse(m1.get());
+  CheckDef(du1, manager.id_to_defs());
+  CheckUse(du1, manager.id_to_uses());
+  manager.AnalyzeDefUse(m2.get());
+  CheckDef(du2, manager.id_to_defs());
+  CheckUse(du2, manager.id_to_uses());
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
Add KillInst() so that def-use manager can handle instrutions that do
not have result ids.

Add ClearDef() and ClearInst() two private functions.

Add tests for AnalyzeInstDefUse().

Add tests for KillInst().

Add a test that call AnalyzeDefUse() on two different modules.