### PR TITLE
Do not use SetOpCode() to freeze spec constants

### DIFF
--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -100,11 +100,6 @@ class Instruction {
   Instruction& operator=(Instruction&&);
 
   SpvOp opcode() const { return opcode_; }
-  // Sets the opcode of this instruction to a specific opcode. Note this may
-  // invalidate the instruction.
-  // TODO(qining): Remove this function when instruction building and insertion
-  // is well implemented.
-  void SetOpcode(SpvOp op) { opcode_ = op; }
   uint32_t type_id() const { return type_id_; }
   uint32_t result_id() const { return result_id_; }
   // Returns the vector of line-related debug instructions attached to this

--- a/test/opt/test_freeze_spec_const.cpp
+++ b/test/opt/test_freeze_spec_const.cpp
@@ -53,7 +53,7 @@ TEST_P(FreezeSpecConstantValueTypeTest, PrimaryType) {
       "OpCapability Shader", "OpMemoryModel Logical GLSL450",
       test_case.type_decl, test_case.expected_frozen_const};
   SinglePassRunAndCheck<opt::FreezeSpecConstantValuePass>(
-      JoinAllInsts(text), JoinAllInsts(expected));
+      JoinAllInsts(text), JoinAllInsts(expected), /* skip_nop = */ true);
 }
 
 // Test each primary type.


### PR DESCRIPTION
Remove the opt::ir::Instruction::SetOpCode() interface.

Spec constant freezing is done by adding new front-end constant
instructions and turning the original spec constant instruction to Nop.