### PR TITLE
Make clear that we are using ptrdiff_t as the iterator difference type.

### DIFF
--- a/source/opt/iterator.h
+++ b/source/opt/iterator.h
@@ -41,9 +41,10 @@ namespace ir {
 // std::vector<|ValueType|>.
 template <typename ValueType, bool IsConst = false>
 class UptrVectorIterator
-    : public std::iterator<std::random_access_iterator_tag,
-                           typename std::conditional<IsConst, const ValueType,
-                                                     ValueType>::type> {
+    : public std::iterator<
+          std::random_access_iterator_tag,
+          typename std::conditional<IsConst, const ValueType, ValueType>::type,
+          ptrdiff_t> {
  public:
   using super = std::iterator<
       std::random_access_iterator_tag,
@@ -51,6 +52,7 @@ class UptrVectorIterator
 
   using pointer = typename super::pointer;
   using reference = typename super::reference;
+  using difference_type = typename super::difference_type;
 
   // Type aliases. We need to apply constness properly if |IsConst| is true.
   using Uptr = std::unique_ptr<ValueType>;

--- a/test/opt/test_ir_loader.cpp
+++ b/test/opt/test_ir_loader.cpp
@@ -216,7 +216,7 @@ TEST(IrBuilder, OpUndefOutsideFunction) {
   const auto opundef_count = std::count_if(
       module->types_values_begin(), module->types_values_end(),
       [](const ir::Instruction& inst) { return inst.opcode() == SpvOpUndef; });
-  EXPECT_EQ(3u, opundef_count);
+  EXPECT_EQ(3, opundef_count);
 
   std::vector<uint32_t> binary;
   module->ToBinary(&binary, /* skip_nop = */ false);


### PR DESCRIPTION
And `ptrdiff_t` is a implementation defined signed type. Comparing it
with unsigned number literal causes compiler warnings.