### PR TITLE
ForEachInst optionally runs on attached debug line insts

### DIFF
--- a/source/opt/function.cpp
+++ b/source/opt/function.cpp
@@ -29,18 +29,29 @@
 namespace spvtools {
 namespace ir {
 
-void Function::ForEachInst(const std::function<void(Instruction*)>& f) {
-  def_inst_->ForEachInst(f);
-  for (auto& param : params_) param->ForEachInst(f);
-  for (auto& bb : blocks_) bb->ForEachInst(f);
-  end_inst_.ForEachInst(f);
+void Function::ForEachInst(const std::function<void(Instruction*)>& f,
+                           bool run_on_debug_line_insts) {
+  def_inst_->ForEachInst(f, run_on_debug_line_insts);
+  for (auto& param : params_) param->ForEachInst(f, run_on_debug_line_insts);
+  for (auto& bb : blocks_) bb->ForEachInst(f, run_on_debug_line_insts);
+  end_inst_->ForEachInst(f, run_on_debug_line_insts);
 }
 
-void Function::ToBinary(std::vector<uint32_t>* binary, bool skip_nop) const {
-  def_inst_->ToBinary(binary, skip_nop);
-  for (const auto& param : params_) param->ToBinary(binary, skip_nop);
-  for (const auto& bb : blocks_) bb->ToBinary(binary, skip_nop);
-  end_inst_.ToBinary(binary, skip_nop);
+void Function::ForEachInst(const std::function<void(const Instruction*)>& f,
+                           bool run_on_debug_line_insts) const {
+  static_cast<const Instruction*>(def_inst_.get())
+      ->ForEachInst(f, run_on_debug_line_insts);
+
+  for (const auto& param : params_)
+    static_cast<const Instruction*>(param.get())
+        ->ForEachInst(f, run_on_debug_line_insts);
+
+  for (const auto& bb : blocks_)
+    static_cast<const BasicBlock*>(bb.get())->ForEachInst(
+        f, run_on_debug_line_insts);
+
+  static_cast<const Instruction*>(end_inst_.get())
+      ->ForEachInst(f, run_on_debug_line_insts);
 }
 
 }  // namespace ir

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -94,13 +94,8 @@ uint32_t Instruction::NumInOperandWords() const {
   return size;
 }
 
-void Instruction::ToBinary(std::vector<uint32_t>* binary, bool skip_nop) const {
-  for (const auto& dbg_line : dbg_line_insts_) {
-    dbg_line.ToBinary(binary, skip_nop);
-  }
-
-  if (skip_nop && IsNop()) return;
-
+void Instruction::ToBinaryWithoutAttachedDebugInsts(
+    std::vector<uint32_t>* binary) const {
   const uint32_t num_words = 1 + NumOperandWords();
   binary->push_back((num_words << 16) | static_cast<uint16_t>(opcode_));
   for (const auto& operand : operands_)

--- a/source/opt/ir_loader.cpp
+++ b/source/opt/ir_loader.cpp
@@ -52,6 +52,7 @@ void IrLoader::AddInstruction(const spv_parsed_instruction_t* inst) {
   } else if (opcode == SpvOpFunctionEnd) {
     assert(function_ != nullptr);
     assert(block_ == nullptr);
+    function_->SetFunctionEnd(std::move(spv_inst));
     module_->AddFunction(std::move(function_));
     function_ = nullptr;
   } else if (opcode == SpvOpLabel) {

--- a/source/opt/module.h
+++ b/source/opt/module.h
@@ -122,8 +122,12 @@ class Module {
   inline const_iterator cbegin() const;
   inline const_iterator cend() const;
 
-  // Invokes function |f| on all instructions in this module.
-  void ForEachInst(const std::function<void(Instruction*)>& f);
+  // Invokes function |f| on all instructions in this module, and optionally on
+  // the debug line instructions that precede them.
+  void ForEachInst(const std::function<void(Instruction*)>& f,
+                   bool run_on_debug_line_insts = false);
+  void ForEachInst(const std::function<void(const Instruction*)>& f,
+                   bool run_on_debug_line_insts = false) const;
 
   // Pushes the binary segments for this instruction into the back of *|binary|.
   // If |skip_nop| is true and this is a OpNop, do nothing.

--- a/test/opt/test_def_use.cpp
+++ b/test/opt/test_def_use.cpp
@@ -48,7 +48,7 @@ std::string DisassembleInst(ir::Instruction* inst) {
   std::vector<uint32_t> binary;
   // We need this to generate the necessary header in the binary.
   tools.Assemble("", &binary);
-  inst->ToBinary(&binary, /* skip_nop = */ false);
+  inst->ToBinaryWithoutAttachedDebugInsts(&binary);
 
   std::string text;
   // We'll need to check the underlying id numbers.


### PR DESCRIPTION
Also:
- Add const forms of ForEachInst
- Rewrite Module::ToBinary in terms of ForEachInst
- Add Instruction::ToBinaryWithoutAttachedDebugInsts
- Delete the ToBinary method on Function, BasicBlock, and Instruction
  since it can now be implemented with ForEachInst in a less confusing
  way, e.g. without recursion.
- Preserve debug line instructions on OpFunctionEnd (and store that
  instruction as a unique-pointer, for regularity).