### PR TITLE
Add Module::ComputeIdBound

### DIFF
--- a/source/opt/module.h
+++ b/source/opt/module.h
@@ -133,6 +133,9 @@ class Module {
   // If |skip_nop| is true and this is a OpNop, do nothing.
   void ToBinary(std::vector<uint32_t>* binary, bool skip_nop) const;
 
+  // Returns 1 more than the maximum Id value mentioned in the module.
+  uint32_t ComputeIdBound() const;
+
  private:
   ModuleHeader header_;  // Module header
 


### PR DESCRIPTION
When IDs change, something should use this utility method
and Module::SetIdBound before writing out the binary.

ForEachInst is more forgiving of cases where a basic block doesn't
have a label, and when a function doesn't have a defining instruction
or end instruction.