### PR TITLE
add spirv-dis/spirv-as support for emacs when loading .spv binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,22 @@ This is experimental.
     export LESSOPEN='| spirv-lesspipe.sh "%s" --no-color --raw-id'
     ```
 
+* `50spirv-tools.el` - Automatically disassembles '.spv' binary files when
+  loaded into the emacs text editor, and re-assembles them when saved,
+  provided any modifications to the file are valid.  This functionality
+  must be explicitly requested by defining the symbol
+  SPIRV_TOOLS_INSTALL_EMACS_HELPERS as follows:
+  ```
+  cmake -DSPIRV_TOOLS_INSTALL_EMACS_HELPERS=true ...
+  ```
+
+  In addition, this helper is only installed if the directory /etc/emacs/site-start.d
+  exists, which is typically true if emacs is installed on the system.
+
+  Note that symbol IDs are not currently preserved through a load/edit/save operation.
+  This may change if the ability is added to spirv-as.
+
+
 ### Tests
 
 Tests are only built when googletest is found. Use `ctest` to run all the

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 add_subdirectory(lesspipe)
+add_subdirectory(emacs)
 
 # Add a SPIR-V Tools command line tool. Signature:
 #   add_spvtools_tool(

--- a/tools/emacs/50spirv-tools.el
+++ b/tools/emacs/50spirv-tools.el
@@ -1,0 +1,40 @@
+;; Copyright (c) 2016 LunarG Inc.
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+;; Upon loading a file with the .spv extension into emacs, the file
+;; will be disassembled using spirv-dis, and the result colorized with
+;; asm-mode in emacs.  The file may be edited within the constraints
+;; of validity, and when re-saved will be re-assembled using spirv-as.
+
+;; Note that symbol IDs are not preserved through a load/edit/save operation.
+;; This may change if the ability is added to spirv-as.
+
+;; It is required that those tools be in your PATH.  If that is not the case
+;; when starting emacs, the path can be modified as in this example:
+;; (setenv "PATH" (concat (getenv "PATH") ":/path/to/spirv/tools"))
+;;
+;; See https://github.com/KhronosGroup/SPIRV-Tools/issues/359
+
+(require 'jka-compr)
+(require 'asm-mode)
+
+(add-to-list 'jka-compr-compression-info-list
+             '["\\.spv\\'"
+               "Assembling SPIRV" "spirv-as" ("-o" "-")
+               "Disassembling SPIRV" "spirv-dis" ("--no-color" "--raw-id")
+               t nil "\003\002\043\007"])
+
+(add-to-list 'auto-mode-alist '("\\.spv\\'" . asm-mode))
+
+(jka-compr-update)

--- a/tools/emacs/CMakeLists.txt
+++ b/tools/emacs/CMakeLists.txt
@@ -1,0 +1,43 @@
+# Copyright (c) 2016 LunarG Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Install a script for use with the auto-compression feature of emacs(1).
+# Upon loading a file with the .spv extension, the file will be disassembled
+# using spirv-dis, and the result colorized with asm-mode in emacs.  The file
+# may be edited within the constraints of validity, and when re-saved will be
+# re-assembled using spirv-as.
+
+# It is required that those tools be in your PATH.  If that is not the case
+# when starting emacs, the path can be modified as in this example:
+# (setenv "PATH" (concat (getenv "PATH") ":/path/to/spirv/tools"))
+#
+# See https://github.com/KhronosGroup/SPIRV-Tools/issues/359
+
+# This is an absolute directory, and ignores CMAKE_INSTALL_PREFIX, or
+# it will not be found by emacs upon startup.  It is only installed if
+# both of the following are true:
+#   1. SPIRV_TOOLS_INSTALL_EMACS_HELPERS is defined
+#   2. The directory /etc/emacs/site-start.d already exists at the time of
+#      cmake invocation (not at the time of make install).  This is
+#      typically true if emacs is installed on the system.
+
+# Note that symbol IDs are not preserved through a load/edit/save operation.
+# This may change if the ability is added to spirv-as.
+
+if (DEFINED SPIRV_TOOLS_INSTALL_EMACS_HELPERS)
+  if(EXISTS /etc/emacs/site-start.d)
+    install(FILES 50spirv-tools.el DESTINATION /etc/emacs/site-start.d)
+  endif()
+endif()
+

--- a/utils/check_copyright.py
+++ b/utils/check_copyright.py
@@ -28,6 +28,7 @@ import sys
 
 # List of designated copyright owners.
 AUTHORS = ['The Khronos Group Inc.',
+           'LunarG Inc.',
            'Google Inc.']
 CURRENT_YEAR='2016'
 


### PR DESCRIPTION
I've marked this PR as WIP for the moment, since I've not submitted anything to SPIRV-Tools before, have probably mangled something, and it could use a good looking over.  This PR adds automatic spirv-dis and spirv-as support when saving and loading binaries in emacs, per discussion in #359.

Some particulars to note:

- Unlike the other tools, this installs into an absolute path (ignoring CMAKE_INSTALL_PREFIX), since that is the only way it will be found upon emacs startup.  This might be considered intrusive, and the functionality is a bit niche at any rate.  Unclear to me if it's worthwhile in the balance, given it's only useful to emacs users.  That's a choice for SPIRV-Tools maintainers.  It might be a stronger case with a vi version as well, but I don't know how to make that.

- It will only install the file into /etc/emacs/site-start.d if that directory already exists, which is typically the case on systems with emacs installed, and not otherwise.  This avoids extraneous pollution.  The condition is evaluated only at cmake invocation time, not at "make install" time.
