### PR TITLE
1. Callback mechanism for error handling

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -340,14 +340,14 @@ typedef enum {
   SPV_ENV_UNIVERSAL_1_0,  // SPIR-V 1.0 latest revision, no other restrictions.
   SPV_ENV_VULKAN_1_0,     // Vulkan 1.0 latest revision.
   SPV_ENV_UNIVERSAL_1_1,  // SPIR-V 1.1 latest revision, no other restrictions.
-  SPV_ENV_OPENCL_2_1, // OpenCL 2.1 latest revision.
-  SPV_ENV_OPENCL_2_2, // OpenCL 2.2 latest revision.
-  SPV_ENV_OPENGL_4_0, // OpenGL 4.0 plus GL_ARB_gl_spirv, latest revisions.
-  SPV_ENV_OPENGL_4_1, // OpenGL 4.1 plus GL_ARB_gl_spirv, latest revisions.
-  SPV_ENV_OPENGL_4_2, // OpenGL 4.2 plus GL_ARB_gl_spirv, latest revisions.
-  SPV_ENV_OPENGL_4_3, // OpenGL 4.3 plus GL_ARB_gl_spirv, latest revisions.
+  SPV_ENV_OPENCL_2_1,     // OpenCL 2.1 latest revision.
+  SPV_ENV_OPENCL_2_2,     // OpenCL 2.2 latest revision.
+  SPV_ENV_OPENGL_4_0,     // OpenGL 4.0 plus GL_ARB_gl_spirv, latest revisions.
+  SPV_ENV_OPENGL_4_1,     // OpenGL 4.1 plus GL_ARB_gl_spirv, latest revisions.
+  SPV_ENV_OPENGL_4_2,     // OpenGL 4.2 plus GL_ARB_gl_spirv, latest revisions.
+  SPV_ENV_OPENGL_4_3,     // OpenGL 4.3 plus GL_ARB_gl_spirv, latest revisions.
   // There is no variant for OpenGL 4.4.
-  SPV_ENV_OPENGL_4_5, // OpenGL 4.5 plus GL_ARB_gl_spirv, latest revisions.
+  SPV_ENV_OPENGL_4_5,  // OpenGL 4.5 plus GL_ARB_gl_spirv, latest revisions.
 } spv_target_env;
 
 // Returns a string describing the given SPIR-V target environment.
@@ -361,8 +361,9 @@ void spvContextDestroy(spv_context context);
 
 // Encodes the given SPIR-V assembly text to its binary representation. The
 // length parameter specifies the number of bytes for text. Encoded binary will
-// be stored into *binary. Any error will be written into *diagnostic. The
-// generated binary is independent of the context and may outlive it.
+// be stored into *binary. Any error will be written into *diagnostic if
+// diagnostic is non-null. The generated binary is independent of the context
+// and may outlive it.
 spv_result_t spvTextToBinary(const spv_const_context context, const char* text,
                              const size_t length, spv_binary* binary,
                              spv_diagnostic* diagnostic);
@@ -374,7 +375,8 @@ void spvTextDestroy(spv_text text);
 // Decodes the given SPIR-V binary representation to its assembly text. The
 // word_count parameter specifies the number of words for binary. The options
 // parameter is a bit field of spv_binary_to_text_options_t. Decoded text will
-// be stored into *text. Any error will be written into *diagnostic.
+// be stored into *text. Any error will be written into *diagnostic if
+// diagnostic is non-null.
 spv_result_t spvBinaryToText(const spv_const_context context,
                              const uint32_t* binary, const size_t word_count,
                              const uint32_t options, spv_text* text,
@@ -385,7 +387,7 @@ spv_result_t spvBinaryToText(const spv_const_context context,
 void spvBinaryDestroy(spv_binary binary);
 
 // Validates a SPIR-V binary for correctness. Any errors will be written into
-// *diagnostic.
+// *diagnostic if diagnostic is non-null.
 spv_result_t spvValidate(const spv_const_context context,
                          const spv_const_binary binary,
                          spv_diagnostic* diagnostic);

--- a/source/message.h
+++ b/source/message.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SPIRV_TOOLS_MESSAGE_H_
+#define SPIRV_TOOLS_MESSAGE_H_
+
+#include <functional>
+
+#include "spirv-tools/libspirv.h"
+
+namespace spvtools {
+
+// TODO(antiagainst): This eventually should be in the C++ interface.
+
+// Severity levels of messages communicated to the consumer.
+enum class MessageLevel {
+  Fatal,  // Unrecoverable error due to environment. Will abort the program
+          // immediately. E.g., out of memory.
+  InternalError,  // Unrecoverable error due to SPIRV-Tools internals. Will
+                  // abort the program immediately. E.g., unimplemented feature.
+  Error,          // Normal error due to user input.
+  Warning,        // Warning information.
+  Info,           // General information.
+  Debug,          // Debug information.
+};
+
+// Message consumer. The C strings for source and message are only alive for the
+// specific invocation.
+using MessageConsumer = std::function<void(
+    MessageLevel /* level */, const char* /* source */,
+    const spv_position_t& /* position */, const char* /* message */
+    )>;
+
+}  // namespace spvtools
+
+#endif  // SPIRV_TOOLS_MESSAGE_H_

--- a/source/opt/libspirv.cpp
+++ b/source/opt/libspirv.cpp
@@ -16,6 +16,7 @@
 
 #include "ir_loader.h"
 #include "make_unique.h"
+#include "table.h"
 
 namespace spvtools {
 
@@ -38,6 +39,10 @@ spv_result_t SetSpvInst(void* builder, const spv_parsed_instruction_t* inst) {
 };
 
 }  // annoymous namespace
+
+void SpvTools::SetMessageConsumer(MessageConsumer consumer) {
+  SetContextMessageConsumer(context_, std::move(consumer));
+}
 
 spv_result_t SpvTools::Assemble(const std::string& text,
                                 std::vector<uint32_t>* binary) {

--- a/source/opt/libspirv.hpp
+++ b/source/opt/libspirv.hpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include "message.h"
 #include "module.h"
 #include "spirv-tools/libspirv.h"
 
@@ -36,7 +37,8 @@ class SpvTools {
 
   ~SpvTools() { spvContextDestroy(context_); }
 
-  // TODO(antiagainst): handle error message in the following APIs.
+  // Sets the message consumer to the given |consumer|.
+  void SetMessageConsumer(MessageConsumer consumer);
 
   // Assembles the given assembly |text| and writes the result to |binary|.
   // Returns SPV_SUCCESS on successful assembling.

--- a/source/table.cpp
+++ b/source/table.cpp
@@ -41,7 +41,13 @@ spv_context spvContextCreate(spv_target_env env) {
   spvOperandTableGet(&operand_table, env);
   spvExtInstTableGet(&ext_inst_table, env);
 
-  return new spv_context_t{env, opcode_table, operand_table, ext_inst_table};
+  return new spv_context_t{env, opcode_table, operand_table, ext_inst_table,
+                           nullptr /* a null default consumer */};
 }
 
 void spvContextDestroy(spv_context context) { delete context; }
+
+void SetContextMessageConsumer(spv_context context,
+                               spvtools::MessageConsumer consumer) {
+  context->consumer = std::move(consumer);
+}

--- a/source/table.h
+++ b/source/table.h
@@ -18,6 +18,7 @@
 #include "spirv/1.1/spirv.h"
 
 #include "enum_set.h"
+#include "message.h"
 #include "spirv-tools/libspirv.h"
 
 typedef struct spv_opcode_desc_t {
@@ -87,7 +88,13 @@ struct spv_context_t {
   const spv_opcode_table opcode_table;
   const spv_operand_table operand_table;
   const spv_ext_inst_table ext_inst_table;
+  spvtools::MessageConsumer consumer;
 };
+
+// Sets the message consumer to |consumer| in the given |context|. The original
+// message consumer will be overwritten.
+void SetContextMessageConsumer(spv_context context,
+                               spvtools::MessageConsumer consumer);
 
 // Populates *table with entries for env.
 spv_result_t spvOpcodeTableGet(spv_opcode_table* table, spv_target_env env);

--- a/source/val/ValidationState.cpp
+++ b/source/val/ValidationState.cpp
@@ -182,9 +182,8 @@ bool IsInstructionInLayoutSection(ModuleLayoutSection layout, SpvOp op) {
 
 }  // anonymous namespace
 
-ValidationState_t::ValidationState_t(spv_diagnostic* diagnostic,
-                                     const spv_const_context context)
-    : diagnostic_(diagnostic),
+ValidationState_t::ValidationState_t(const spv_const_context ctx)
+    : context_(ctx),
       instruction_counter_(0),
       unresolved_forward_ids_{},
       operand_names_{},
@@ -193,7 +192,7 @@ ValidationState_t::ValidationState_t(spv_diagnostic* diagnostic,
       module_capabilities_(),
       ordered_instructions_(),
       all_definitions_(),
-      grammar_(context),
+      grammar_(ctx),
       addressing_model_(SpvAddressingModelLogical),
       memory_model_(SpvMemoryModelSimple),
       in_function_(false) {}
@@ -290,7 +289,7 @@ bool ValidationState_t::IsOpcodeInCurrentLayoutSection(SpvOp op) {
 
 DiagnosticStream ValidationState_t::diag(spv_result_t error_code) const {
   return libspirv::DiagnosticStream(
-      {0, 0, static_cast<size_t>(instruction_counter_)}, diagnostic_,
+      {0, 0, static_cast<size_t>(instruction_counter_)}, context_->consumer,
       error_code);
 }
 
@@ -377,8 +376,8 @@ spv_result_t ValidationState_t::RegisterFunctionEnd() {
 void ValidationState_t::RegisterInstruction(
     const spv_parsed_instruction_t& inst) {
   if (in_function_body()) {
-    ordered_instructions_.emplace_back(
-        &inst, &current_function(), current_function().current_block());
+    ordered_instructions_.emplace_back(&inst, &current_function(),
+                                       current_function().current_block());
   } else {
     ordered_instructions_.emplace_back(&inst, nullptr, nullptr);
   }

--- a/source/val/ValidationState.h
+++ b/source/val/ValidationState.h
@@ -53,8 +53,10 @@ enum ModuleLayoutSection {
 /// This class manages the state of the SPIR-V validation as it is being parsed.
 class ValidationState_t {
  public:
-  ValidationState_t(spv_diagnostic* diagnostic,
-                    const spv_const_context context);
+  ValidationState_t(const spv_const_context context);
+
+  /// Returns the context
+  spv_const_context context() const { return context_; }
 
   /// Forward declares the id in the module
   spv_result_t ForwardDeclareId(uint32_t id);
@@ -174,7 +176,8 @@ class ValidationState_t {
  private:
   ValidationState_t(const ValidationState_t&);
 
-  spv_diagnostic* diagnostic_;
+  const spv_const_context context_;
+
   /// Tracks the number of instructions evaluated by the validator
   int instruction_counter_;
 
@@ -191,7 +194,8 @@ class ValidationState_t {
   std::deque<Function> module_functions_;
 
   /// The capabilities available in the module
-  libspirv::CapabilitySet module_capabilities_;  /// Module's declared capabilities.
+  libspirv::CapabilitySet
+      module_capabilities_;  /// Module's declared capabilities.
 
   /// List of all instructions in the order they appear in the binary
   std::deque<Instruction> ordered_instructions_;

--- a/source/validate.h
+++ b/source/validate.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "instruction.h"
+#include "message.h"
 #include "spirv-tools/libspirv.h"
 #include "table.h"
 
@@ -154,7 +155,6 @@ spv_result_t InstructionPass(ValidationState_t& _,
 /// @param[in] operandTable table of specified operands
 /// @param[in] usedefs use-def info from module parsing
 /// @param[in,out] position current position in the stream
-/// @param[out] pDiag contains diagnostic on failure
 ///
 /// @return result code
 spv_result_t spvValidateInstructionIDs(const spv_instruction_t* pInsts,
@@ -163,8 +163,7 @@ spv_result_t spvValidateInstructionIDs(const spv_instruction_t* pInsts,
                                        const spv_operand_table operandTable,
                                        const spv_ext_inst_table extInstTable,
                                        const libspirv::ValidationState_t& state,
-                                       spv_position position,
-                                       spv_diagnostic* pDiag);
+                                       spv_position position);
 
 /// @brief Validate the ID's within a SPIR-V binary
 ///
@@ -174,7 +173,7 @@ spv_result_t spvValidateInstructionIDs(const spv_instruction_t* pInsts,
 /// @param[in] opcodeTable table of specified Opcodes
 /// @param[in] operandTable table of specified operands
 /// @param[in,out] position current word in the binary
-/// @param[out] pDiagnostic contains diagnostic on failure
+/// @param[in] consumer message consumer callback
 ///
 /// @return result code
 spv_result_t spvValidateIDs(const spv_instruction_t* pInstructions,
@@ -182,6 +181,7 @@ spv_result_t spvValidateIDs(const spv_instruction_t* pInstructions,
                             const spv_opcode_table opcodeTable,
                             const spv_operand_table operandTable,
                             const spv_ext_inst_table extInstTable,
-                            spv_position position, spv_diagnostic* pDiagnostic);
+                            spv_position position,
+                            const spvtools::MessageConsumer& consumer);
 
 #endif  // LIBSPIRV_VALIDATE_H_

--- a/test/BinaryToText.cpp
+++ b/test/BinaryToText.cpp
@@ -149,13 +149,6 @@ TEST_F(BinaryToText, InvalidMagicNumber) {
   spvDiagnosticDestroy(diagnostic);
 }
 
-TEST_F(BinaryToText, InvalidDiagnostic) {
-  spv_text text;
-  ASSERT_EQ(SPV_ERROR_INVALID_DIAGNOSTIC,
-            spvBinaryToText(context, binary->code, binary->wordCount,
-                            SPV_BINARY_TO_TEXT_OPTION_NONE, &text, nullptr));
-}
-
 struct FailedDecodeCase {
   std::string source_text;
   std::vector<uint32_t> appended_instruction;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -130,6 +130,11 @@ add_spvtools_unittest(
   LIBS ${SPIRV_TOOLS})
 
 add_spvtools_unittest(
+  TARGET c_interface
+  SRCS c_interface.cpp
+  LIBS ${SPIRV_TOOLS})
+
+add_spvtools_unittest(
   TARGET cpp_interface
   SRCS cpp_interface.cpp
   LIBS SPIRV-Tools-opt ${SPIRV_TOOLS})

--- a/test/TextToBinary.cpp
+++ b/test/TextToBinary.cpp
@@ -126,14 +126,6 @@ TEST_F(TextToBinaryTest, InvalidPointer) {
                             nullptr, &diagnostic));
 }
 
-TEST_F(TextToBinaryTest, InvalidDiagnostic) {
-  SetText(
-      "OpEntryPoint Kernel 0 \"\"\nOpExecutionMode 0 LocalSizeHint 1 1 1\n");
-  ASSERT_EQ(SPV_ERROR_INVALID_DIAGNOSTIC,
-            spvTextToBinary(ScopedContext().context, text.str, text.length,
-                            &binary, nullptr));
-}
-
 TEST_F(TextToBinaryTest, InvalidPrefix) {
   EXPECT_EQ(
       "Expected <opcode> or <result-id> at the beginning of an instruction, "

--- a/test/c_interface.cpp
+++ b/test/c_interface.cpp
@@ -1,0 +1,278 @@
+// Copyright (c) 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "message.h"
+#include "spirv-tools/libspirv.h"
+#include "table.h"
+
+namespace {
+
+using namespace spvtools;
+
+// The default consumer is a null std::function.
+TEST(CInterface, DefaultConsumerNullDiagnosticForValidInput) {
+  auto context = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
+  const char input_text[] =
+      "OpCapability Shader\nOpMemoryModel Logical GLSL450";
+
+  spv_binary binary = nullptr;
+  EXPECT_EQ(SPV_SUCCESS, spvTextToBinary(context, input_text,
+                                         sizeof(input_text), &binary, nullptr));
+
+  {
+    // Sadly the compiler don't allow me to feed binary directly to
+    // spvValidate().
+    spv_const_binary_t b{binary->code, binary->wordCount};
+    EXPECT_EQ(SPV_SUCCESS, spvValidate(context, &b, nullptr));
+  }
+
+  spv_text text = nullptr;
+  EXPECT_EQ(SPV_SUCCESS, spvBinaryToText(context, binary->code,
+                                         binary->wordCount, 0, &text, nullptr));
+
+  spvTextDestroy(text);
+  spvBinaryDestroy(binary);
+  spvContextDestroy(context);
+}
+
+// The default consumer is a null std::function.
+TEST(CInterface, DefaultConsumerNullDiagnosticForInvalidAssembling) {
+  auto context = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
+  const char input_text[] = "%1 = OpName";
+
+  spv_binary binary = nullptr;
+  EXPECT_EQ(SPV_ERROR_INVALID_TEXT,
+            spvTextToBinary(context, input_text, sizeof(input_text), &binary,
+                            nullptr));
+  spvBinaryDestroy(binary);
+  spvContextDestroy(context);
+}
+
+// The default consumer is a null std::function.
+TEST(CInterface, DefaultConsumerNullDiagnosticForInvalidDiassembling) {
+  auto context = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
+  const char input_text[] = "OpNop";
+
+  spv_binary binary = nullptr;
+  ASSERT_EQ(SPV_SUCCESS, spvTextToBinary(context, input_text,
+                                         sizeof(input_text), &binary, nullptr));
+  // Change OpNop to an invalid (wordcount|opcode) word.
+  binary->code[binary->wordCount - 1] = 0xffffffff;
+
+  spv_text text = nullptr;
+  EXPECT_EQ(SPV_ERROR_INVALID_BINARY,
+            spvBinaryToText(context, binary->code, binary->wordCount, 0, &text,
+                            nullptr));
+
+  spvTextDestroy(text);
+  spvBinaryDestroy(binary);
+  spvContextDestroy(context);
+}
+
+// The default consumer is a null std::function.
+TEST(CInterface, DefaultConsumerNullDiagnosticForInvalidValidating) {
+  auto context = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
+  const char input_text[] = "OpNop";
+
+  spv_binary binary = nullptr;
+  ASSERT_EQ(SPV_SUCCESS, spvTextToBinary(context, input_text,
+                                         sizeof(input_text), &binary, nullptr));
+
+  spv_const_binary_t b{binary->code, binary->wordCount};
+  EXPECT_EQ(SPV_ERROR_INVALID_LAYOUT, spvValidate(context, &b, nullptr));
+
+  spvBinaryDestroy(binary);
+  spvContextDestroy(context);
+}
+
+TEST(CInterface, SpecifyConsumerNullDiagnosticForAssembling) {
+  const char input_text[] = "%1 = OpName\n";
+
+  auto context = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
+  int invocation = 0;
+  // TODO(antiagainst): Use public C API for setting the consumer once exists.
+  SetContextMessageConsumer(
+      context,
+      [&invocation](MessageLevel level, const char* source,
+                    const spv_position_t& position, const char* message) {
+        ++invocation;
+        EXPECT_EQ(MessageLevel::Error, level);
+        // The error happens at scanning the begining of second line.
+        EXPECT_STREQ("", source);
+        EXPECT_EQ(1u, position.line);
+        EXPECT_EQ(0u, position.column);
+        EXPECT_EQ(12u, position.index);
+        EXPECT_STREQ("Expected operand, found end of stream.", message);
+      });
+
+  spv_binary binary = nullptr;
+  EXPECT_EQ(SPV_ERROR_INVALID_TEXT,
+            spvTextToBinary(context, input_text, sizeof(input_text), &binary,
+                            nullptr));
+  EXPECT_EQ(1, invocation);
+  spvBinaryDestroy(binary);
+  spvContextDestroy(context);
+}
+
+TEST(CInterface, SpecifyConsumerNullDiagnosticForDisassembling) {
+  const char input_text[] = "OpNop";
+
+  auto context = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
+  int invocation = 0;
+  SetContextMessageConsumer(
+      context,
+      [&invocation](MessageLevel level, const char* source,
+                    const spv_position_t& position, const char* message) {
+        ++invocation;
+        EXPECT_EQ(MessageLevel::Error, level);
+        EXPECT_STREQ("", source);
+        EXPECT_EQ(0u, position.line);
+        EXPECT_EQ(0u, position.column);
+        EXPECT_EQ(5u, position.index);
+        EXPECT_STREQ("Invalid opcode: 65535", message);
+      });
+
+  spv_binary binary = nullptr;
+  ASSERT_EQ(SPV_SUCCESS, spvTextToBinary(context, input_text,
+                                         sizeof(input_text), &binary, nullptr));
+  // Change OpNop to an invalid (wordcount|opcode) word.
+  binary->code[binary->wordCount - 1] = 0xffffffff;
+
+  spv_text text = nullptr;
+  EXPECT_EQ(SPV_ERROR_INVALID_BINARY,
+            spvBinaryToText(context, binary->code, binary->wordCount, 0, &text,
+                            nullptr));
+  EXPECT_EQ(1, invocation);
+
+  spvTextDestroy(text);
+  spvBinaryDestroy(binary);
+  spvContextDestroy(context);
+}
+
+TEST(CInterface, SpecifyConsumerNullDiagnosticForValidating) {
+  const char input_text[] = "OpNop";
+
+  auto context = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
+  int invocation = 0;
+  SetContextMessageConsumer(
+      context,
+      [&invocation](MessageLevel level, const char* source,
+                    const spv_position_t& position, const char* message) {
+        ++invocation;
+        EXPECT_EQ(MessageLevel::Error, level);
+        EXPECT_STREQ("", source);
+        EXPECT_EQ(0u, position.line);
+        EXPECT_EQ(0u, position.column);
+        // TODO(antiagainst): what validation reports is not a word offset here.
+        // It is inconsistent with diassembler. Should be fixed.
+        EXPECT_EQ(1u, position.index);
+        EXPECT_STREQ("Nop cannot appear before the memory model instruction",
+                     message);
+      });
+
+  spv_binary binary = nullptr;
+  ASSERT_EQ(SPV_SUCCESS, spvTextToBinary(context, input_text,
+                                         sizeof(input_text), &binary, nullptr));
+
+  spv_const_binary_t b{binary->code, binary->wordCount};
+  EXPECT_EQ(SPV_ERROR_INVALID_LAYOUT, spvValidate(context, &b, nullptr));
+  EXPECT_EQ(1, invocation);
+
+  spvBinaryDestroy(binary);
+  spvContextDestroy(context);
+}
+
+// When having both a consumer and an diagnostic object, the diagnostic object
+// should take priority.
+TEST(CInterface, SpecifyConsumerSpecifyDiagnosticForAssembling) {
+  const char input_text[] = "%1 = OpName";
+
+  auto context = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
+  int invocation = 0;
+  SetContextMessageConsumer(
+      context, [&invocation](MessageLevel, const char*, const spv_position_t&,
+                             const char*) { ++invocation; });
+
+  spv_binary binary = nullptr;
+  spv_diagnostic diagnostic = nullptr;
+  EXPECT_EQ(SPV_ERROR_INVALID_TEXT,
+            spvTextToBinary(context, input_text, sizeof(input_text), &binary,
+                            &diagnostic));
+  EXPECT_EQ(0, invocation);  // Consumer should not be invoked at all.
+  EXPECT_STREQ("Expected operand, found end of stream.", diagnostic->error);
+
+  spvDiagnosticDestroy(diagnostic);
+  spvBinaryDestroy(binary);
+  spvContextDestroy(context);
+}
+
+TEST(CInterface, SpecifyConsumerSpecifyDiagnosticForDisassembling) {
+  const char input_text[] = "OpNop";
+
+  auto context = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
+  int invocation = 0;
+  SetContextMessageConsumer(
+      context, [&invocation](MessageLevel, const char*, const spv_position_t&,
+                             const char*) { ++invocation; });
+
+  spv_binary binary = nullptr;
+  ASSERT_EQ(SPV_SUCCESS, spvTextToBinary(context, input_text,
+                                         sizeof(input_text), &binary, nullptr));
+  // Change OpNop to an invalid (wordcount|opcode) word.
+  binary->code[binary->wordCount - 1] = 0xffffffff;
+
+  spv_diagnostic diagnostic = nullptr;
+  spv_text text = nullptr;
+  EXPECT_EQ(SPV_ERROR_INVALID_BINARY,
+            spvBinaryToText(context, binary->code, binary->wordCount, 0, &text,
+                            &diagnostic));
+
+  EXPECT_EQ(0, invocation);  // Consumer should not be invoked at all.
+  EXPECT_STREQ("Invalid opcode: 65535", diagnostic->error);
+
+  spvTextDestroy(text);
+  spvDiagnosticDestroy(diagnostic);
+  spvBinaryDestroy(binary);
+  spvContextDestroy(context);
+}
+
+TEST(CInterface, SpecifyConsumerSpecifyDiagnosticForValidating) {
+  const char input_text[] = "OpNop";
+
+  auto context = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
+  int invocation = 0;
+  SetContextMessageConsumer(
+      context, [&invocation](MessageLevel, const char*, const spv_position_t&,
+                             const char*) { ++invocation; });
+
+  spv_binary binary = nullptr;
+  ASSERT_EQ(SPV_SUCCESS, spvTextToBinary(context, input_text,
+                                         sizeof(input_text), &binary, nullptr));
+
+  spv_diagnostic diagnostic = nullptr;
+  spv_const_binary_t b{binary->code, binary->wordCount};
+  EXPECT_EQ(SPV_ERROR_INVALID_LAYOUT, spvValidate(context, &b, &diagnostic));
+
+  EXPECT_EQ(0, invocation);  // Consumer should not be invoked at all.
+  EXPECT_STREQ("Nop cannot appear before the memory model instruction",
+               diagnostic->error);
+
+  spvDiagnosticDestroy(diagnostic);
+  spvBinaryDestroy(binary);
+  spvContextDestroy(context);
+}
+
+}  // anonymous namespace

--- a/test/diagnostic.cpp
+++ b/test/diagnostic.cpp
@@ -63,16 +63,16 @@ TEST(Diagnostic, PrintInvalidDiagnostic) {
 TEST(DiagnosticStream, ConversionToResultType) {
   // Check after the DiagnosticStream object is destroyed.
   spv_result_t value;
-  { value = DiagnosticStream({}, 0, SPV_ERROR_INVALID_TEXT); }
+  { value = DiagnosticStream({}, nullptr, SPV_ERROR_INVALID_TEXT); }
   EXPECT_EQ(SPV_ERROR_INVALID_TEXT, value);
 
   // Check implicit conversion via plain assignment.
-  value = DiagnosticStream({}, 0, SPV_SUCCESS);
+  value = DiagnosticStream({}, nullptr, SPV_SUCCESS);
   EXPECT_EQ(SPV_SUCCESS, value);
 
   // Check conversion via constructor.
   EXPECT_EQ(SPV_FAILED_MATCH,
-            spv_result_t(DiagnosticStream({}, 0, SPV_FAILED_MATCH)));
+            spv_result_t(DiagnosticStream({}, nullptr, SPV_FAILED_MATCH)));
 }
 
 }  // anonymous namespace

--- a/test/val/ValidationState.cpp
+++ b/test/val/ValidationState.cpp
@@ -36,11 +36,9 @@ using std::vector;
 class ValidationStateTest : public testing::Test {
  public:
   ValidationStateTest()
-      : context_(spvContextCreate(SPV_ENV_UNIVERSAL_1_0)),
-        state_(&diag_, context_) {}
+      : context_(spvContextCreate(SPV_ENV_UNIVERSAL_1_0)), state_(context_) {}
 
  protected:
-  spv_diagnostic diag_;
   spv_context context_;
   ValidationState_t state_;
 };


### PR DESCRIPTION
Every time an event happens in the library that the user should be
aware of, the callback will be invoked.

The existing diagnostic mechanism is hijacked internally by a
callback that creates an diagnostic object each time an event
happens.