### PR TITLE
3. Add MessageConsumer to PassManager, Pass, and analysis interfaces.

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -143,6 +143,7 @@ set(SPIRV_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/disassemble.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ext_inst.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/instruction.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/message.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/name_mapper.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/opcode.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/operand.cpp

--- a/source/message.cpp
+++ b/source/message.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "message.h"
+
+#include <sstream>
+
+namespace spvtools {
+
+std::string StringifyMessage(MessageLevel level, const char* source,
+                             const spv_position_t& position,
+                             const char* message) {
+  const char* level_string = nullptr;
+  switch (level) {
+    case MessageLevel::Fatal:
+      level_string = "fatal";
+      break;
+    case MessageLevel::InternalError:
+      level_string = "internal error";
+      break;
+    case MessageLevel::Error:
+      level_string = "error";
+      break;
+    case MessageLevel::Warning:
+      level_string = "warning";
+      break;
+    case MessageLevel::Info:
+      level_string = "info";
+      break;
+    case MessageLevel::Debug:
+      level_string = "debug";
+      break;
+  }
+  std::ostringstream oss;
+  oss << level_string << ": ";
+  if (source) oss << source << ":";
+  oss << position.line << ":" << position.column << ":";
+  oss << position.index << ": ";
+  if (message) oss << message;
+  oss << "\n";
+  return oss.str();
+}
+
+}  // namespace spvtools

--- a/source/message.h
+++ b/source/message.h
@@ -16,6 +16,7 @@
 #define SPIRV_TOOLS_MESSAGE_H_
 
 #include <functional>
+#include <string>
 
 #include "spirv-tools/libspirv.h"
 
@@ -41,6 +42,17 @@ using MessageConsumer = std::function<void(
     MessageLevel /* level */, const char* /* source */,
     const spv_position_t& /* position */, const char* /* message */
     )>;
+
+// A message consumer that ignores all messages.
+inline void IgnoreMessage(MessageLevel, const char*, const spv_position_t&,
+                          const char*) {}
+
+// A helper function to compose and return a string from the message in the
+// following format:
+//   "<level>: <source>:<line>:<column>:<index>: <message>"
+std::string StringifyMessage(MessageLevel level, const char* source,
+                             const spv_position_t& position,
+                             const char* message);
 
 }  // namespace spvtools
 

--- a/source/opt/def_use_manager.cpp
+++ b/source/opt/def_use_manager.cpp
@@ -14,10 +14,10 @@
 
 #include "def_use_manager.h"
 
-#include <cassert>
 #include <functional>
 
 #include "instruction.h"
+#include "log.h"
 #include "module.h"
 #include "reflect.h"
 
@@ -80,11 +80,10 @@ const UseList* DefUseManager::GetUses(uint32_t id) const {
   return &iter->second;
 }
 
-std::vector<ir::Instruction*> DefUseManager::GetAnnotations(
-    uint32_t id) const {
+std::vector<ir::Instruction*> DefUseManager::GetAnnotations(uint32_t id) const {
   std::vector<ir::Instruction*> annos;
   const auto* uses = GetUses(id);
-  if (!uses)  return annos;
+  if (!uses) return annos;
   for (const auto& c : *uses) {
     if (ir::IsAnnotationInst(c.inst->opcode())) {
       annos.push_back(c.inst);
@@ -121,11 +120,13 @@ bool DefUseManager::ReplaceAllUsesWith(uint32_t before, uint32_t after) {
       if (it->inst->type_id() != 0 && it->operand_index == 0) {
         it->inst->SetResultType(after);
       } else if (it->inst->type_id() == 0) {
-        assert(false &&
-               "Result type id considered as using while the instruction "
-               "doesn't have a result type id.");
+        SPIRV_ASSERT(consumer_, false,
+                     "Result type id considered as use while the instruction "
+                     "doesn't have a result type id.");
+        (void)consumer_;  // Makes the compiler happy for release build.
       } else {
-        assert(false && "Trying Setting the result id which is immutable.");
+        SPIRV_ASSERT(consumer_, false,
+                     "Trying setting the immutable result id.");
       }
     } else {
       // Update an in-operand.

--- a/source/opt/def_use_manager.h
+++ b/source/opt/def_use_manager.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "instruction.h"
+#include "message.h"
 #include "module.h"
 
 namespace spvtools {
@@ -45,7 +46,15 @@ class DefUseManager {
   using IdToDefMap = std::unordered_map<uint32_t, ir::Instruction*>;
   using IdToUsesMap = std::unordered_map<uint32_t, UseList>;
 
-  inline explicit DefUseManager(ir::Module* module) { AnalyzeDefUse(module); }
+  // Constructs a def-use manager from the given |module|. All internal messages
+  // will be communicated to the outside via the given message |consumer|. This
+  // instance only keeps a reference to the |consumer|, so the |consumer| should
+  // outlive this instance.
+  DefUseManager(const MessageConsumer& consumer, ir::Module* module)
+      : consumer_(consumer) {
+    AnalyzeDefUse(module);
+  }
+
   DefUseManager(const DefUseManager&) = delete;
   DefUseManager(DefUseManager&&) = delete;
   DefUseManager& operator=(const DefUseManager&) = delete;
@@ -106,8 +115,9 @@ class DefUseManager {
   // Erases the records that a given instruction uses its operand ids.
   void EraseUseRecordsOfOperandIds(const ir::Instruction* inst);
 
-  IdToDefMap id_to_def_;    // Mapping from ids to their definitions
-  IdToUsesMap id_to_uses_;  // Mapping from ids to their uses
+  const MessageConsumer& consumer_;  // Message consumer.
+  IdToDefMap id_to_def_;             // Mapping from ids to their definitions
+  IdToUsesMap id_to_uses_;           // Mapping from ids to their uses
   // Mapping from instructions to the ids used in the instructions generating
   // the result ids.
   InstToUsedIdsMap inst_to_used_ids_;

--- a/source/opt/eliminate_dead_constant_pass.cpp
+++ b/source/opt/eliminate_dead_constant_pass.cpp
@@ -19,13 +19,14 @@
 #include <unordered_set>
 
 #include "def_use_manager.h"
+#include "log.h"
 #include "reflect.h"
 
 namespace spvtools {
 namespace opt {
 
 bool EliminateDeadConstantPass::Process(ir::Module* module) {
-  analysis::DefUseManager def_use(module);
+  analysis::DefUseManager def_use(consumer(), module);
   std::unordered_set<ir::Instruction*> working_list;
   // Traverse all the instructions to get the initial set of dead constants as
   // working list and count number of real uses for constants. Uses in
@@ -73,7 +74,7 @@ bool EliminateDeadConstantPass::Process(ir::Module* module) {
           }
           // The number of uses should never be less then 0, so it can not be
           // less than 1 before it decreases.
-          assert(use_counts[def_inst] > 0);
+          SPIRV_ASSERT(consumer(), use_counts[def_inst] > 0);
           --use_counts[def_inst];
           if (!use_counts[def_inst]) {
             working_list.insert(def_inst);

--- a/source/opt/eliminate_dead_constant_pass.h
+++ b/source/opt/eliminate_dead_constant_pass.h
@@ -28,6 +28,8 @@ namespace opt {
 // OpSpecConstantOp.
 class EliminateDeadConstantPass : public Pass {
  public:
+  explicit EliminateDeadConstantPass(const MessageConsumer& c) : Pass(c) {}
+
   const char* name() const override { return "eliminate-dead-const"; }
   bool Process(ir::Module*) override;
 };

--- a/source/opt/fold_spec_constant_op_and_composite_pass.cpp
+++ b/source/opt/fold_spec_constant_op_and_composite_pass.cpp
@@ -242,6 +242,15 @@ std::vector<uint32_t> OperateVectors(
 }
 }  // anonymous namespace
 
+FoldSpecConstantOpAndCompositePass::FoldSpecConstantOpAndCompositePass(
+    const MessageConsumer& c)
+    : Pass(c),
+      max_id_(0),
+      module_(nullptr),
+      def_use_mgr_(nullptr),
+      type_mgr_(nullptr),
+      id_to_const_val_() {}
+
 bool FoldSpecConstantOpAndCompositePass::ProcessImpl(ir::Module* module) {
   bool modified = false;
   // Traverse through all the constant defining instructions. For Normal

--- a/source/opt/fold_spec_constant_op_and_composite_pass.h
+++ b/source/opt/fold_spec_constant_op_and_composite_pass.h
@@ -50,12 +50,8 @@ namespace opt {
 // TODO(qining): Add support for the operations listed above.
 class FoldSpecConstantOpAndCompositePass : public Pass {
  public:
-  FoldSpecConstantOpAndCompositePass()
-      : max_id_(0),
-        module_(nullptr),
-        def_use_mgr_(nullptr),
-        type_mgr_(nullptr),
-        id_to_const_val_() {}
+  explicit FoldSpecConstantOpAndCompositePass(const MessageConsumer& c);
+
   const char* name() const override { return "fold-spec-const-op-composite"; }
   bool Process(ir::Module* module) override {
     Initialize(module);
@@ -66,8 +62,8 @@ class FoldSpecConstantOpAndCompositePass : public Pass {
   // Initializes the type manager, def-use manager and get the maximal id used
   // in the module.
   void Initialize(ir::Module* module) {
-    type_mgr_.reset(new analysis::TypeManager(*module));
-    def_use_mgr_.reset(new analysis::DefUseManager(module));
+    type_mgr_.reset(new analysis::TypeManager(consumer(), *module));
+    def_use_mgr_.reset(new analysis::DefUseManager(consumer(), module));
     for (const auto& id_def : def_use_mgr_->id_to_defs()) {
       max_id_ = std::max(max_id_, id_def.first);
     }

--- a/source/opt/freeze_spec_constant_value_pass.h
+++ b/source/opt/freeze_spec_constant_value_pass.h
@@ -31,6 +31,8 @@ namespace opt {
 // other spec constants defined by OpSpecConstantComposite or OpSpecConstantOp.
 class FreezeSpecConstantValuePass : public Pass {
  public:
+  explicit FreezeSpecConstantValuePass(const MessageConsumer& c) : Pass(c) {}
+
   const char* name() const override { return "freeze-spec-const"; }
   bool Process(ir::Module*) override;
 };

--- a/source/opt/ir_loader.h
+++ b/source/opt/ir_loader.h
@@ -19,6 +19,7 @@
 
 #include "basic_block.h"
 #include "instruction.h"
+#include "message.h"
 #include "module.h"
 #include "spirv-tools/libspirv.h"
 
@@ -36,7 +37,11 @@ namespace ir {
 class IrLoader {
  public:
   // Instantiates a builder to construct the given |module| gradually.
-  IrLoader(Module* module) : module_(module) {}
+  // All internal messages will be communicated to the outside via the given
+  // message |consumer|. This instance only keeps a reference to the |consumer|,
+  // so the |consumer| should outlive this instance.
+  IrLoader(const MessageConsumer& consumer, Module* module)
+      : consumer_(consumer), module_(module) {}
 
   // Sets the fields in the module's header to the given parameters.
   void SetModuleHeader(uint32_t magic, uint32_t version, uint32_t generator,
@@ -54,6 +59,8 @@ class IrLoader {
   void EndModule();
 
  private:
+  // Consumer for communicating messages to outside.
+  const MessageConsumer& consumer_;
   // The module to be built.
   Module* module_;
   // The current Function under construction.

--- a/source/opt/libspirv.cpp
+++ b/source/opt/libspirv.cpp
@@ -83,7 +83,7 @@ std::unique_ptr<ir::Module> SpvTools::BuildModule(
   spv_diagnostic diagnostic = nullptr;
 
   auto module = MakeUnique<ir::Module>();
-  ir::IrLoader loader(module.get());
+  ir::IrLoader loader(context_->consumer, module.get());
 
   spv_result_t status =
       spvBinaryParse(context_, &loader, binary.data(), binary.size(),

--- a/source/opt/log.h
+++ b/source/opt/log.h
@@ -22,8 +22,9 @@
 
 #include "message.h"
 
-// Asserts the given condition is true. Otherwise, send a message to the
-// consumer. Accepts the following formats:
+// Asserts the given condition is true. Otherwise, sends a message to the
+// consumer and exits the problem with failure code. Accepts the following
+// formats:
 //
 // SPIRV_ASSERT(<message-consumer>, <condition-expression>);
 // SPIRV_ASSERT(<message-consumer>, <condition-expression>, <message>);
@@ -133,24 +134,30 @@ void Logf(const MessageConsumer& consumer, MessageLevel level, const char* file,
 
 #define SPIRV_ASSERT_1(consumer, condition)                             \
   do {                                                                  \
-    if (!(condition))                                                   \
+    if (!(condition)) {                                                 \
       spvtools::Log(consumer, MessageLevel::InternalError, __FILE__,    \
                     {__LINE__, 0, 0}, "assertion failed: " #condition); \
+      std::exit(EXIT_FAILURE);                                          \
+    }                                                                   \
   } while (0)
 
 #define SPIRV_ASSERT_2(consumer, condition, message)                 \
   do {                                                               \
-    if (!(condition))                                                \
+    if (!(condition)) {                                              \
       spvtools::Log(consumer, MessageLevel::InternalError, __FILE__, \
                     {__LINE__, 0, 0}, "assertion failed: " message); \
+      std::exit(EXIT_FAILURE);                                       \
+    }                                                                \
   } while (0)
 
 #define SPIRV_ASSERT_more(consumer, condition, format, ...)           \
   do {                                                                \
-    if (!(condition))                                                 \
+    if (!(condition)) {                                               \
       spvtools::Logf(consumer, MessageLevel::InternalError, __FILE__, \
                      {__LINE__, 0, 0}, "assertion failed: " format,   \
                      __VA_ARGS__);                                    \
+      std::exit(EXIT_FAILURE);                                        \
+    }                                                                 \
   } while (0)
 
 #define SPIRV_ASSERT_3(consumer, condition, format, ...) \

--- a/source/opt/null_pass.h
+++ b/source/opt/null_pass.h
@@ -23,6 +23,9 @@ namespace opt {
 
 // A null pass that does nothing.
 class NullPass : public Pass {
+ public:
+  explicit NullPass(const MessageConsumer& c) : Pass(c) {}
+
   const char* name() const override { return "null"; }
   bool Process(ir::Module*) override { return false; }
 };

--- a/source/opt/pass.h
+++ b/source/opt/pass.h
@@ -17,6 +17,7 @@
 
 #include <memory>
 
+#include "message.h"
 #include "module.h"
 
 namespace spvtools {
@@ -26,11 +27,24 @@ namespace opt {
 // and all analysis and transformation is done via the Process() method.
 class Pass {
  public:
+  // Constructs a new pass with the given message consumer, which will be
+  // invoked every time there is a message to be communicated to the outside.
+  //
+  // This pass just keeps a reference to the message consumer; so the message
+  // consumer should outlive this pass.
+  explicit Pass(const MessageConsumer& c) : consumer_(c) {}
+
   // Returns a descriptive name for this pass.
   virtual const char* name() const = 0;
+  // Returns the reference to the message consumer for this pass.
+  const MessageConsumer& consumer() const { return consumer_; }
+
   // Processes the given |module| and returns true if the given |module| is
   // modified for optimization.
   virtual bool Process(ir::Module* module) = 0;
+
+ private:
+  const MessageConsumer& consumer_;  // Message consumer.
 };
 
 }  // namespace opt

--- a/source/opt/set_spec_constant_default_value_pass.cpp
+++ b/source/opt/set_spec_constant_default_value_pass.cpp
@@ -14,8 +14,8 @@
 
 #include "set_spec_constant_default_value_pass.h"
 
-#include <cstring>
 #include <cctype>
+#include <cstring>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -164,8 +164,8 @@ bool SetSpecConstantDefaultValuePass::Process(ir::Module* module) {
   const uint32_t kOpSpecConstantLiteralInOperandIndex = 0;
 
   bool modified = false;
-  analysis::DefUseManager def_use_mgr(module);
-  analysis::TypeManager type_mgr(*module);
+  analysis::DefUseManager def_use_mgr(consumer(), module);
+  analysis::TypeManager type_mgr(consumer(), *module);
   // Scan through all the annotation instructions to find 'OpDecorate SpecId'
   // instructions. Then extract the decoration target of those instructions.
   // The decoration targets should be spec constant defining instructions with

--- a/source/opt/set_spec_constant_default_value_pass.h
+++ b/source/opt/set_spec_constant_default_value_pass.h
@@ -34,11 +34,12 @@ class SetSpecConstantDefaultValuePass : public Pass {
   using SpecIdToInstMap = std::unordered_map<uint32_t, ir::Instruction*>;
 
   // Constructs a pass instance with a map from spec ids to default values.
-  explicit SetSpecConstantDefaultValuePass(
-      const SpecIdToValueStrMap& default_values)
-      : Pass(), spec_id_to_value_(default_values) {}
-  explicit SetSpecConstantDefaultValuePass(SpecIdToValueStrMap&& default_values)
-      : Pass(), spec_id_to_value_(std::move(default_values)) {}
+  SetSpecConstantDefaultValuePass(const MessageConsumer& c,
+                                  const SpecIdToValueStrMap& default_values)
+      : Pass(c), spec_id_to_value_(default_values) {}
+  SetSpecConstantDefaultValuePass(const MessageConsumer& c,
+                                  SpecIdToValueStrMap&& default_values)
+      : Pass(c), spec_id_to_value_(std::move(default_values)) {}
 
   const char* name() const override { return "set-spec-const-default-value"; }
   bool Process(ir::Module*) override;

--- a/source/opt/strip_debug_info_pass.h
+++ b/source/opt/strip_debug_info_pass.h
@@ -25,6 +25,8 @@ namespace opt {
 // Section 3.32.2 of the SPIR-V spec).
 class StripDebugInfoPass : public Pass {
  public:
+  explicit StripDebugInfoPass(const MessageConsumer& c) : Pass(c) {}
+
   const char* name() const override { return "strip-debug"; }
   bool Process(ir::Module* module) override;
 };

--- a/source/opt/type_manager.cpp
+++ b/source/opt/type_manager.cpp
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include <algorithm>
-#include <cassert>
 
+#include "log.h"
 #include "reflect.h"
 #include "type_manager.h"
 
@@ -161,16 +161,17 @@ Type* TypeManager::RecordIfTypeDefinition(
       type = new NamedBarrier();
       break;
     default:
-      assert(0 && "unhandled type found");
+      SPIRV_UNIMPLEMENTED(consumer_, "unhandled type");
       break;
   }
 
   uint32_t id = inst.result_id();
   if (id == 0) {
-    assert(inst.opcode() == SpvOpTypeForwardPointer &&
-           "instruction without result id found");
+    SPIRV_ASSERT(consumer_, inst.opcode() == SpvOpTypeForwardPointer,
+                 "instruction without result id found");
   } else {
-    assert(type != nullptr && "type should not be nullptr at this point");
+    SPIRV_ASSERT(consumer_, type != nullptr,
+                 "type should not be nullptr at this point");
     id_to_type_[id].reset(type);
     type_to_id_[type] = id;
   }
@@ -204,16 +205,16 @@ void TypeManager::AttachIfTypeDecoration(const ir::Instruction& inst) {
       if (Struct* st = target_type->AsStruct()) {
         st->AddMemeberDecoration(index, std::move(data));
       } else {
-        assert(0 && "OpMemberDecorate on non-struct type");
+        SPIRV_UNIMPLEMENTED(consumer_, "OpMemberDecorate non-struct type");
       }
     } break;
     case SpvOpDecorationGroup:
     case SpvOpGroupDecorate:
     case SpvOpGroupMemberDecorate:
-      assert(0 && "unhandled decoration");
+      SPIRV_UNIMPLEMENTED(consumer_, "unhandled decoration");
       break;
     default:
-      assert(0 && "unreachable");
+      SPIRV_UNREACHABLE(consumer_);
       break;
   }
 }

--- a/source/opt/unify_const_pass.cpp
+++ b/source/opt/unify_const_pass.cpp
@@ -105,7 +105,7 @@ class ResultIdTrie {
 bool UnifyConstantPass::Process(ir::Module* module) {
   bool modified = false;
   ResultIdTrie defined_constants;
-  analysis::DefUseManager def_use_mgr(module);
+  analysis::DefUseManager def_use_mgr(consumer(), module);
 
   for (ir::Instruction& inst : module->types_values()) {
     // Do not handle the instruction when there are decorations upon the result

--- a/source/opt/unify_const_pass.h
+++ b/source/opt/unify_const_pass.h
@@ -36,6 +36,8 @@ namespace opt {
 //  3) NaN in float point format with different bit patterns are not unified.
 class UnifyConstantPass : public Pass {
  public:
+  explicit UnifyConstantPass(const MessageConsumer& c) : Pass(c) {}
+
   const char* name() const override { return "unify-const"; }
   bool Process(ir::Module*) override;
 };
@@ -43,4 +45,4 @@ class UnifyConstantPass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif // LIBSPIRV_OPT_UNIFY_CONSTANT_PASS_H_
+#endif  // LIBSPIRV_OPT_UNIFY_CONSTANT_PASS_H_

--- a/test/opt/test_def_use.cpp
+++ b/test/opt/test_def_use.cpp
@@ -132,7 +132,7 @@ TEST_P(ParseDefUseTest, Case) {
   ASSERT_NE(nullptr, module);
 
   // Analyze def and use.
-  opt::analysis::DefUseManager manager(module.get());
+  opt::analysis::DefUseManager manager(IgnoreMessage, module.get());
 
   CheckDef(tc.du, manager.id_to_defs());
   CheckUse(tc.du, manager.id_to_uses());
@@ -513,7 +513,7 @@ TEST_P(ReplaceUseTest, Case) {
   ASSERT_NE(nullptr, module);
 
   // Analyze def and use.
-  opt::analysis::DefUseManager manager(module.get());
+  opt::analysis::DefUseManager manager(IgnoreMessage, module.get());
 
   // Do the substitution.
   for (const auto& candiate : tc.candidates) {
@@ -815,7 +815,7 @@ TEST_P(KillDefTest, Case) {
   ASSERT_NE(nullptr, module);
 
   // Analyze def and use.
-  opt::analysis::DefUseManager manager(module.get());
+  opt::analysis::DefUseManager manager(IgnoreMessage, module.get());
 
   // Do the substitution.
   for (const auto id : tc.ids_to_kill) manager.KillDef(id);
@@ -1065,7 +1065,7 @@ TEST(DefUseTest, OpSwitch) {
   ASSERT_NE(nullptr, module);
 
   // Analyze def and use.
-  opt::analysis::DefUseManager manager(module.get());
+  opt::analysis::DefUseManager manager(IgnoreMessage, module.get());
 
   // Do a bunch replacements.
   manager.ReplaceAllUsesWith(9, 900);    // to unused id
@@ -1188,7 +1188,7 @@ TEST_P(AnalyzeInstDefUseTest, Case) {
   ASSERT_NE(nullptr, module);
 
   // Analyze the instructions.
-  opt::analysis::DefUseManager manager(module.get());
+  opt::analysis::DefUseManager manager(IgnoreMessage, module.get());
   for (ir::Instruction& inst : tc.insts) {
     manager.AnalyzeInstDefUse(&inst);
   }
@@ -1312,7 +1312,7 @@ TEST_P(KillInstTest, Case) {
 
   // KillInst
   uint32_t index = 0;
-  opt::analysis::DefUseManager manager(module.get());
+  opt::analysis::DefUseManager manager(IgnoreMessage, module.get());
   module->ForEachInst([&index, &tc, &manager](ir::Instruction* inst) {
     if (tc.indices_for_inst_to_kill.count(index) != 0) {
       manager.KillInst(inst);
@@ -1419,7 +1419,7 @@ TEST_P(GetAnnotationsTest, Case) {
   ASSERT_NE(nullptr, module);
 
   // Get annotations
-  opt::analysis::DefUseManager manager(module.get());
+  opt::analysis::DefUseManager manager(IgnoreMessage, module.get());
   auto insts = manager.GetAnnotations(tc.id);
 
   // Check

--- a/test/opt/test_line_debug_info.cpp
+++ b/test/opt/test_line_debug_info.cpp
@@ -22,6 +22,8 @@ using namespace spvtools;
 // A pass turning all none debug line instructions into Nop.
 class NopifyPass : public opt::Pass {
  public:
+  explicit NopifyPass(const MessageConsumer& c) : opt::Pass(c) {}
+
   const char* name() const override { return "NopifyPass"; }
   bool Process(ir::Module* module) override {
     module->ForEachInst([](ir::Instruction* inst) { inst->ToNop(); },

--- a/test/opt/test_type_manager.cpp
+++ b/test/opt/test_type_manager.cpp
@@ -90,7 +90,7 @@ TEST(TypeManager, TypeStrings) {
 
   std::unique_ptr<ir::Module> module =
       SpvTools(SPV_ENV_UNIVERSAL_1_1).BuildModule(text);
-  opt::analysis::TypeManager manager(*module);
+  opt::analysis::TypeManager manager(IgnoreMessage, *module);
 
   EXPECT_EQ(type_id_strs.size(), manager.NumTypes());
   EXPECT_EQ(2u, manager.NumForwardPointers());
@@ -120,7 +120,7 @@ TEST(Struct, DecorationOnStruct) {
   )";
   std::unique_ptr<ir::Module> module =
       SpvTools(SPV_ENV_UNIVERSAL_1_1).BuildModule(text);
-  opt::analysis::TypeManager manager(*module);
+  opt::analysis::TypeManager manager(IgnoreMessage, *module);
 
   ASSERT_EQ(7u, manager.NumTypes());
   ASSERT_EQ(0u, manager.NumForwardPointers());
@@ -170,7 +170,7 @@ TEST(Struct, DecorationOnMember) {
   )";
   std::unique_ptr<ir::Module> module =
       SpvTools(SPV_ENV_UNIVERSAL_1_1).BuildModule(text);
-  opt::analysis::TypeManager manager(*module);
+  opt::analysis::TypeManager manager(IgnoreMessage, *module);
 
   ASSERT_EQ(10u, manager.NumTypes());
   ASSERT_EQ(0u, manager.NumForwardPointers());
@@ -208,7 +208,7 @@ TEST(Types, DecorationEmpty) {
   )";
   std::unique_ptr<ir::Module> module =
       SpvTools(SPV_ENV_UNIVERSAL_1_1).BuildModule(text);
-  opt::analysis::TypeManager manager(*module);
+  opt::analysis::TypeManager manager(IgnoreMessage, *module);
 
   ASSERT_EQ(5u, manager.NumTypes());
   ASSERT_EQ(0u, manager.NumForwardPointers());

--- a/test/test_log.cpp
+++ b/test/test_log.cpp
@@ -23,63 +23,6 @@ namespace {
 using namespace spvtools;
 using ::testing::MatchesRegex;
 
-TEST(Log, AssertStatement) {
-  int invocation = 0;
-  auto consumer = [&invocation](MessageLevel level, const char* source,
-                                const spv_position_t&, const char* message) {
-    ++invocation;
-    EXPECT_EQ(MessageLevel::InternalError, level);
-    EXPECT_THAT(source, MatchesRegex(".*test_log.cpp$"));
-    EXPECT_STREQ("assertion failed: 1 + 2 == 5", message);
-  };
-
-  SPIRV_ASSERT(consumer, 1 + 2 == 5);
-#if defined(NDEBUG)
-  (void)consumer;
-  EXPECT_EQ(0, invocation);
-#else
-  EXPECT_EQ(1, invocation);
-#endif
-}
-
-TEST(Log, AssertMessage) {
-  int invocation = 0;
-  auto consumer = [&invocation](MessageLevel level, const char* source,
-                                const spv_position_t&, const char* message) {
-    ++invocation;
-    EXPECT_EQ(MessageLevel::InternalError, level);
-    EXPECT_THAT(source, MatchesRegex(".*test_log.cpp$"));
-    EXPECT_STREQ("assertion failed: happy asserting!", message);
-  };
-
-  SPIRV_ASSERT(consumer, 1 + 2 == 5, "happy asserting!");
-#if defined(NDEBUG)
-  (void)consumer;
-  EXPECT_EQ(0, invocation);
-#else
-  EXPECT_EQ(1, invocation);
-#endif
-}
-
-TEST(Log, AssertFormattedMessage) {
-  int invocation = 0;
-  auto consumer = [&invocation](MessageLevel level, const char* source,
-                                const spv_position_t&, const char* message) {
-    ++invocation;
-    EXPECT_EQ(MessageLevel::InternalError, level);
-    EXPECT_THAT(source, MatchesRegex(".*test_log.cpp$"));
-    EXPECT_STREQ("assertion failed: 1 + 2 actually is 3", message);
-  };
-
-  SPIRV_ASSERT(consumer, 1 + 2 == 5, "1 + 2 actually is %d", 1 + 2);
-#if defined(NDEBUG)
-  (void)consumer;
-  EXPECT_EQ(0, invocation);
-#else
-  EXPECT_EQ(1, invocation);
-#endif
-}
-
 TEST(Log, Unimplemented) {
   int invocation = 0;
   auto consumer = [&invocation](MessageLevel level, const char* source,

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -16,6 +16,7 @@
 #include <iostream>
 #include <vector>
 
+#include "message.h"
 #include "source/opt/ir_loader.h"
 #include "source/opt/libspirv.hpp"
 #include "source/opt/pass_manager.h"
@@ -62,7 +63,11 @@ int main(int argc, char** argv) {
 
   spv_target_env target_env = SPV_ENV_UNIVERSAL_1_1;
 
-  opt::PassManager pass_manager;
+  opt::PassManager pass_manager([](MessageLevel level, const char* source,
+                                   const spv_position_t& position,
+                                   const char* message) {
+    std::cerr << StringifyMessage(level, source, position, message);
+  });
 
   for (int argi = 1; argi < argc; ++argi) {
     const char* cur_arg = argv[argi];


### PR DESCRIPTION
Depends on #362.

Use the callback error-handling mechanism introduced in #401
in Pass, PassManager, and analyses.


Also convert some uses of assert() in optimization code to use
SPIRV_ASSERT(), SPIRV_UNIMPLEMENTED(), or SPIRV_UNREACHABLE()
accordingly introduced in #362 .