### PR TITLE
Clarify: Ok to pass null diagnostic to spvBinaryParse

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -430,10 +430,10 @@ typedef spv_result_t (*spv_parsed_instruction_fn_t)(
 // callback once for each instruction in the stream.  The user_data parameter
 // is supplied as context to the callbacks.  Returns SPV_SUCCESS on successful
 // parse where the callbacks always return SPV_SUCCESS.  For an invalid parse,
-// returns a status code other than SPV_SUCCESS and emits a diagnostic.  If a
-// callback returns anything other than SPV_SUCCESS, then that status code
-// is returned, no further callbacks are issued, and no additional diagnostics
-// are emitted.
+// returns a status code other than SPV_SUCCESS, and if diagnostic is non-null
+// also emits a diagnostic.  If a callback returns anything other than
+// SPV_SUCCESS, then that status code is returned, no further callbacks are
+// issued, and no additional diagnostics are emitted.
 spv_result_t spvBinaryParse(const spv_const_context context, void* user_data,
                             const uint32_t* words, const size_t num_words,
                             spv_parsed_header_fn_t parse_header,


### PR DESCRIPTION
It's a valid use case: I might mostly trust my binaries and I don't
care to to collect detailed diagnostic feedback.