### PR TITLE
Update validate interface to accept binary pointers

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -392,6 +392,12 @@ spv_result_t spvValidate(const spv_const_context context,
                          const spv_const_binary binary,
                          spv_diagnostic* diagnostic);
 
+// Validates a raw SPIR-V binary for correctness. Any errors will be written
+// into *diagnostic if diagnostic is non-null.
+spv_result_t spvValidateBinary(const spv_const_context context,
+                               const uint32_t* words, const size_t num_words,
+                               spv_diagnostic* diagnostic);
+
 // Creates a diagnostic object. The position parameter specifies the location in
 // the text/binary stream. The message parameter, copied into the diagnostic
 // object, contains the error message to display.

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -177,7 +177,15 @@ UNUSED(void PrintDotGraph(ValidationState_t& _, libspirv::Function func)) {
 spv_result_t spvValidate(const spv_const_context context,
                          const spv_const_binary binary,
                          spv_diagnostic* pDiagnostic) {
+  return spvValidateBinary(context, binary->code, binary->wordCount,
+                           pDiagnostic);
+}
+spv_result_t spvValidateBinary(const spv_const_context context,
+                               const uint32_t* words, const size_t num_words,
+                               spv_diagnostic* pDiagnostic) {
   spv_context_t hijack_context = *context;
+
+  spv_const_binary binary = new spv_const_binary_t{words, num_words};
   if (pDiagnostic) {
     *pDiagnostic = nullptr;
     libspirv::UseDiagnosticAsMessageConsumer(&hijack_context, pDiagnostic);
@@ -201,9 +209,8 @@ spv_result_t spvValidate(const spv_const_context context,
   // NOTE: Parse the module and perform inline validation checks. These
   // checks do not require the the knowledge of the whole module.
   ValidationState_t vstate(&hijack_context);
-  if (auto error = spvBinaryParse(&hijack_context, &vstate, binary->code,
-                                  binary->wordCount, setHeader,
-                                  ProcessInstruction, pDiagnostic))
+  if (auto error = spvBinaryParse(&hijack_context, &vstate, words, num_words,
+                                  setHeader, ProcessInstruction, pDiagnostic))
     return error;
 
   if (vstate.in_function_body())

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -180,6 +180,7 @@ spv_result_t spvValidate(const spv_const_context context,
   return spvValidateBinary(context, binary->code, binary->wordCount,
                            pDiagnostic);
 }
+
 spv_result_t spvValidateBinary(const spv_const_context context,
                                const uint32_t* words, const size_t num_words,
                                spv_diagnostic* pDiagnostic) {

--- a/test/val/CMakeLists.txt
+++ b/test/val/CMakeLists.txt
@@ -20,6 +20,11 @@ set(VAL_TEST_COMMON_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/ValidateFixtures.cpp
 )
 
+add_spvtools_unittest(TARGET val_api
+  SRCS ${CMAKE_CURRENT_SOURCE_DIR}/Validate.API.cpp
+       ${VAL_TEST_COMMON_SRCS}
+  LIBS ${SPIRV_TOOLS}
+)
 
 add_spvtools_unittest(TARGET val_capability
   SRCS ${CMAKE_CURRENT_SOURCE_DIR}/Validate.Capability.cpp

--- a/test/val/Validate.API.cpp
+++ b/test/val/Validate.API.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2015-2016 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../TestFixture.h"
+#include "UnitSPIRV.h"
+
+#include "spirv/1.0/spirv.h"
+#include "gmock/gmock.h"
+
+using std::vector;
+using spvtest::MakeInstruction;
+using spvtest::Concatenate;
+using spvtest::ScopedContext;
+
+spv_target_env env = SPV_ENV_UNIVERSAL_1_0;
+
+spv_result_t TestApi(const vector<uint32_t>& bytecode) {
+  spv_diagnostic const_binary_diagnostic;
+  spv_diagnostic separate_diagnostic;
+  std::unique_ptr<spv_const_binary_t> bin(
+      new spv_const_binary_t{bytecode.data(), bytecode.size()});
+
+  spv_result_t const_binary_result = spvValidate(
+      ScopedContext(env).context, bin.get(), &const_binary_diagnostic);
+
+  spv_result_t separate_result =
+      spvValidateBinary(ScopedContext(env).context,
+                        bytecode.data(), bytecode.size(), &separate_diagnostic);
+  EXPECT_EQ(const_binary_result, separate_result);
+  if (const_binary_diagnostic) {
+    EXPECT_STREQ(const_binary_diagnostic->error, separate_diagnostic->error);
+    EXPECT_EQ(const_binary_diagnostic->position.column,
+              separate_diagnostic->position.column);
+    EXPECT_EQ(const_binary_diagnostic->position.index,
+              separate_diagnostic->position.index);
+    EXPECT_EQ(const_binary_diagnostic->position.line,
+              separate_diagnostic->position.line);
+    EXPECT_EQ(const_binary_diagnostic->isTextSource,
+              separate_diagnostic->isTextSource);
+  }
+  return const_binary_result;
+}
+
+TEST(ValidateAPI, BinaryAPISuccess) {
+  uint32_t bound = 0;
+
+  auto bytecode = Concatenate(
+      {{SpvMagicNumber, SpvVersion,
+        SPV_GENERATOR_WORD(SPV_GENERATOR_KHRONOS_ASSEMBLER, 0), bound, 0},
+       MakeInstruction(SpvOpCapability, {SpvCapabilityKernel}),
+       MakeInstruction(SpvOpCapability, {SpvCapabilityAddresses}),
+       MakeInstruction(SpvOpMemoryModel,
+                       {SpvAddressingModelPhysical64, SpvMemoryModelOpenCL})});
+  ASSERT_EQ(SPV_SUCCESS, TestApi(bytecode));
+}
+
+TEST(ValidateAPI, BinaryAPIBad) {
+  char str[] = R"(
+          OpCapability Shader
+          OpMemoryModel Logical GLSL450
+          OpName %missing "missing"
+%voidt  = OpTypeVoid
+%vfunct = OpTypeFunction %voidt
+%func   = OpFunction %vfunct None %missing
+%flabel = OpLabel
+          OpReturn
+          OpFunctionEnd
+    )";
+
+  spv_diagnostic diagnostic = nullptr;
+  spv_binary binary;
+  EXPECT_EQ(SPV_SUCCESS,
+            spvTextToBinary(ScopedContext(env).context, str,
+                            sizeof(str), &binary, &diagnostic));
+
+  vector<uint32_t> words(binary->code, binary->code + binary->wordCount);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, TestApi(words));
+}


### PR DESCRIPTION
The current version of `spvValidate` accepts a `spv_const_binary` struct as one of its arguments. This works well when the module is created from the `spvTextToBinary` function but it is cumbersome when working vector of words.

This PR will create a new function `spvValidateBinary` which accepts a pointer to words instead of the `spv_const_binary` object.