### PR TITLE
Do normal errors instead of asserts in IrLoader

### DIFF
--- a/source/opt/build_module.cpp
+++ b/source/opt/build_module.cpp
@@ -35,8 +35,10 @@ spv_result_t SetSpvHeader(void* builder, spv_endianness_t, uint32_t magic,
 // Processes a parsed instruction for IrLoader. Meets the interface requirement
 // of spvBinaryParse().
 spv_result_t SetSpvInst(void* builder, const spv_parsed_instruction_t* inst) {
-  reinterpret_cast<ir::IrLoader*>(builder)->AddInstruction(inst);
-  return SPV_SUCCESS;
+  if (reinterpret_cast<ir::IrLoader*>(builder)->AddInstruction(inst)) {
+    return SPV_SUCCESS;
+  }
+  return SPV_ERROR_INVALID_BINARY;
 };
 
 }  // annoymous namespace

--- a/source/opt/ir_loader.h
+++ b/source/opt/ir_loader.h
@@ -40,18 +40,20 @@ class IrLoader {
   // All internal messages will be communicated to the outside via the given
   // message |consumer|. This instance only keeps a reference to the |consumer|,
   // so the |consumer| should outlive this instance.
-  IrLoader(const MessageConsumer& consumer, Module* module)
-      : consumer_(consumer), module_(module) {}
+  IrLoader(const MessageConsumer& consumer, Module* module);
+
+  // Sets the source name of the module.
+  void SetSource(const std::string& src) { source_ = src; }
 
   // Sets the fields in the module's header to the given parameters.
   void SetModuleHeader(uint32_t magic, uint32_t version, uint32_t generator,
                        uint32_t bound, uint32_t reserved) {
     module_->SetHeader({magic, version, generator, bound, reserved});
   }
-  // Adds an instruction to the module. This method will properly capture and
-  // store the data provided in |inst| so that |inst| is no longer needed after
-  // returning.
-  void AddInstruction(const spv_parsed_instruction_t* inst);
+  // Adds an instruction to the module. Returns true if no error occurs. This
+  // method will properly capture and store the data provided in |inst| so that
+  // |inst| is no longer needed after returning.
+  bool AddInstruction(const spv_parsed_instruction_t* inst);
   // Finalizes the module construction. This must be called after the module
   // header has been set and all instructions have been added.  This is
   // forgiving in the case of a missing terminator instruction on a basic block,
@@ -63,6 +65,10 @@ class IrLoader {
   const MessageConsumer& consumer_;
   // The module to be built.
   Module* module_;
+  // The source name of the module.
+  std::string source_;
+  // The last used instruction index.
+  uint32_t inst_index_;
   // The current Function under construction.
   std::unique_ptr<Function> function_;
   // The current BasicBlock under construction.

--- a/source/opt/log.h
+++ b/source/opt/log.h
@@ -78,20 +78,20 @@
 namespace spvtools {
 
 // Calls the given |consumer| by supplying  the |message|. The |message| is from
-// the given |file| and |location| and of the given severity |level|.
+// the given |source| and |location| and of the given severity |level|.
 inline void Log(const MessageConsumer& consumer, spv_message_level_t level,
-                const char* file, const spv_position_t& position,
+                const char* source, const spv_position_t& position,
                 const char* message) {
-  if (consumer != nullptr) consumer(level, file, position, message);
+  if (consumer != nullptr) consumer(level, source, position, message);
 }
 
 // Calls the given |consumer| by supplying the message composed according to the
-// given |format|. The |message| is from the given |file| and |location| and of
-// the given severity |level|.
+// given |format|. The |message| is from the given |source| and |location| and
+// of the given severity |level|.
 template <typename... Args>
 void Logf(const MessageConsumer& consumer, spv_message_level_t level,
-          const char* file, const spv_position_t& position, const char* format,
-          Args&&... args) {
+          const char* source, const spv_position_t& position,
+          const char* format, Args&&... args) {
 #if defined(_MSC_VER) && _MSC_VER < 1900
 // Sadly, snprintf() is not supported until Visual Studio 2015!
 #define snprintf _snprintf
@@ -104,7 +104,7 @@ void Logf(const MessageConsumer& consumer, spv_message_level_t level,
       snprintf(message, kInitBufferSize, format, std::forward<Args>(args)...);
 
   if (size >= 0 && size < kInitBufferSize) {
-    Log(consumer, level, file, position, message);
+    Log(consumer, level, source, position, message);
     return;
   }
 
@@ -112,11 +112,11 @@ void Logf(const MessageConsumer& consumer, spv_message_level_t level,
     std::vector<char> longer_message(size + 1);
     snprintf(longer_message.data(), longer_message.size(), format,
              std::forward<Args>(args)...);
-    Log(consumer, level, file, position, longer_message.data());
+    Log(consumer, level, source, position, longer_message.data());
     return;
   }
 
-  Log(consumer, level, file, position, "cannot compose log message");
+  Log(consumer, level, source, position, "cannot compose log message");
 
 #if defined(_MSC_VER) && _MSC_VER < 1900
 #undef snprintf

--- a/source/opt/log.h
+++ b/source/opt/log.h
@@ -123,6 +123,24 @@ void Logf(const MessageConsumer& consumer, spv_message_level_t level,
 #endif
 }
 
+// Calls the given |consumer| by supplying  the given error |message|. The
+// |message| is from the given |source| and |location|.
+inline void Error(const MessageConsumer& consumer, const char* source,
+                  const spv_position_t& position, const char* message) {
+  Log(consumer, SPV_MSG_ERROR, source, position, message);
+}
+
+// Calls the given |consumer| by supplying the error message composed according
+// to the given |format|. The |message| is from the given |source| and
+// |location|.
+template <typename... Args>
+inline void Errorf(const MessageConsumer& consumer, const char* source,
+                   const spv_position_t& position, const char* format,
+                   Args&&... args) {
+  Logf(consumer, SPV_MSG_ERROR, source, position, format,
+       std::forward<Args>(args)...);
+}
+
 }  // namespace spvtools
 
 #define SPIRV_ASSERT_IMPL(consumer, ...)                             \

--- a/test/opt/test_ir_loader.cpp
+++ b/test/opt/test_ir_loader.cpp
@@ -298,4 +298,71 @@ TEST(IrBuilder, KeepLineDebugInfoBeforeFunctionEnd) {
   // clang-format on
 }
 
+// Checks the given |error_message| is reported when trying to build a module
+// from the given |assembly|.
+void DoErrorMessageCheck(const std::string& assembly,
+                         const std::string& error_message) {
+  auto consumer = [error_message](spv_message_level_t level, const char* source,
+                                  const spv_position_t& position,
+                                  const char* m) {
+    EXPECT_EQ(error_message, StringifyMessage(level, source, position, m));
+  };
+
+  SpirvTools t(SPV_ENV_UNIVERSAL_1_1);
+  std::unique_ptr<ir::Module> module =
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, std::move(consumer), assembly);
+  EXPECT_EQ(nullptr, module);
+}
+
+TEST(IrBuilder, FunctionInsideFunction) {
+  DoErrorMessageCheck("%2 = OpFunction %1 None %3\n%5 = OpFunction %4 None %6",
+                      "error: <instruction>:2:0:0: function inside function\n");
+}
+
+TEST(IrBuilder, MismatchOpFunctionEnd) {
+  DoErrorMessageCheck("OpFunctionEnd",
+                      "error: <instruction>:1:0:0: OpFunctionEnd without "
+                      "corresponding OpFunction\n");
+}
+
+TEST(IrBuilder, OpFunctionEndInsideBasicBlock) {
+  DoErrorMessageCheck(
+      "%2 = OpFunction %1 None %3\n"
+      "%4 = OpLabel\n"
+      "OpFunctionEnd",
+      "error: <instruction>:3:0:0: OpFunctionEnd inside basic block\n");
+}
+
+TEST(IrBuilder, BasicBlockOutsideFunction) {
+  DoErrorMessageCheck("OpCapability Shader\n%1 = OpLabel",
+                      "error: <instruction>:2:0:0: OpLabel outside function\n");
+}
+
+TEST(IrBuilder, OpLabelInsideBasicBlock) {
+  DoErrorMessageCheck(
+      "%2 = OpFunction %1 None %3\n"
+      "%4 = OpLabel\n"
+      "%5 = OpLabel",
+      "error: <instruction>:3:0:0: OpLabel inside basic block\n");
+}
+
+TEST(IrBuilder, TerminatorOutsideFunction) {
+  DoErrorMessageCheck(
+      "OpReturn",
+      "error: <instruction>:1:0:0: terminator instruction outside function\n");
+}
+
+TEST(IrBuilder, TerminatorOutsideBasicBlock) {
+  DoErrorMessageCheck("%2 = OpFunction %1 None %3\nOpReturn",
+                      "error: <instruction>:2:0:0: terminator instruction "
+                      "outside basic block\n");
+}
+
+TEST(IrBuilder, NotAllowedInstAppearingInFunction) {
+  DoErrorMessageCheck("%2 = OpFunction %1 None %3\n%5 = OpVariable %4 Function",
+                      "error: <instruction>:2:0:0: Non-OpFunctionParameter "
+                      "(opcode: 59) found inside function but outside basic "
+                      "block\n");
+}
+
 }  // anonymous namespace


### PR DESCRIPTION
* Add methods for getting positions of instructions and operands.
* Add SPIRV_ERROR() macro for returning user errors.