### PR TITLE
Change to use enum instead of enum class for MessageLevel.

### DIFF
--- a/source/diagnostic.cpp
+++ b/source/diagnostic.cpp
@@ -71,22 +71,22 @@ namespace libspirv {
 DiagnosticStream::~DiagnosticStream() {
   using spvtools::MessageLevel;
   if (error_ != SPV_FAILED_MATCH && consumer_ != nullptr) {
-    auto level = MessageLevel::Error;
+    auto level = MessageLevel::kError;
     switch (error_) {
       case SPV_SUCCESS:
       case SPV_REQUESTED_TERMINATION:  // Essentially success.
-        level = MessageLevel::Info;
+        level = MessageLevel::kInfo;
         break;
       case SPV_WARNING:
-        level = MessageLevel::Warning;
+        level = MessageLevel::kWarning;
         break;
       case SPV_UNSUPPORTED:
       case SPV_ERROR_INTERNAL:
       case SPV_ERROR_INVALID_TABLE:
-        level = MessageLevel::InternalError;
+        level = MessageLevel::kInternalError;
         break;
       case SPV_ERROR_OUT_OF_MEMORY:
-        level = MessageLevel::Fatal;
+        level = MessageLevel::kFatal;
         break;
       default:
         break;

--- a/source/diagnostic.cpp
+++ b/source/diagnostic.cpp
@@ -69,24 +69,23 @@ spv_result_t spvDiagnosticPrint(const spv_diagnostic diagnostic) {
 namespace libspirv {
 
 DiagnosticStream::~DiagnosticStream() {
-  using spvtools::MessageLevel;
   if (error_ != SPV_FAILED_MATCH && consumer_ != nullptr) {
-    auto level = MessageLevel::kError;
+    auto level = spvtools::SPV_MSG_ERROR;
     switch (error_) {
       case SPV_SUCCESS:
       case SPV_REQUESTED_TERMINATION:  // Essentially success.
-        level = MessageLevel::kInfo;
+        level = spvtools::SPV_MSG_INFO;
         break;
       case SPV_WARNING:
-        level = MessageLevel::kWarning;
+        level = spvtools::SPV_MSG_WARNINING;
         break;
       case SPV_UNSUPPORTED:
       case SPV_ERROR_INTERNAL:
       case SPV_ERROR_INVALID_TABLE:
-        level = MessageLevel::kInternalError;
+        level = spvtools::SPV_MSG_INTERNAL_ERROR;
         break;
       case SPV_ERROR_OUT_OF_MEMORY:
-        level = MessageLevel::kFatal;
+        level = spvtools::SPV_MSG_FATAL;
         break;
       default:
         break;
@@ -99,9 +98,9 @@ void UseDiagnosticAsMessageConsumer(spv_context context,
                                     spv_diagnostic* diagnostic) {
   assert(diagnostic && *diagnostic == nullptr);
 
-  auto create_diagnostic = [diagnostic](spvtools::MessageLevel, const char*,
-                                        const spv_position_t& position,
-                                        const char* message) {
+  auto create_diagnostic = [diagnostic](
+      spvtools::spv_message_level_t, const char*,
+      const spv_position_t& position, const char* message) {
     auto p = position;
     spvDiagnosticDestroy(*diagnostic);  // Avoid memory leak.
     *diagnostic = spvDiagnosticCreate(&p, message);

--- a/source/message.cpp
+++ b/source/message.cpp
@@ -23,22 +23,22 @@ std::string StringifyMessage(MessageLevel level, const char* source,
                              const char* message) {
   const char* level_string = nullptr;
   switch (level) {
-    case MessageLevel::Fatal:
+    case MessageLevel::kFatal:
       level_string = "fatal";
       break;
-    case MessageLevel::InternalError:
+    case MessageLevel::kInternalError:
       level_string = "internal error";
       break;
-    case MessageLevel::Error:
+    case MessageLevel::kError:
       level_string = "error";
       break;
-    case MessageLevel::Warning:
+    case MessageLevel::kWarning:
       level_string = "warning";
       break;
-    case MessageLevel::Info:
+    case MessageLevel::kInfo:
       level_string = "info";
       break;
-    case MessageLevel::Debug:
+    case MessageLevel::kDebug:
       level_string = "debug";
       break;
   }

--- a/source/message.cpp
+++ b/source/message.cpp
@@ -18,27 +18,27 @@
 
 namespace spvtools {
 
-std::string StringifyMessage(MessageLevel level, const char* source,
+std::string StringifyMessage(spv_message_level_t level, const char* source,
                              const spv_position_t& position,
                              const char* message) {
   const char* level_string = nullptr;
   switch (level) {
-    case MessageLevel::kFatal:
+    case SPV_MSG_FATAL:
       level_string = "fatal";
       break;
-    case MessageLevel::kInternalError:
+    case SPV_MSG_INTERNAL_ERROR:
       level_string = "internal error";
       break;
-    case MessageLevel::kError:
+    case SPV_MSG_ERROR:
       level_string = "error";
       break;
-    case MessageLevel::kWarning:
+    case SPV_MSG_WARNINING:
       level_string = "warning";
       break;
-    case MessageLevel::kInfo:
+    case SPV_MSG_INFO:
       level_string = "info";
       break;
-    case MessageLevel::kDebug:
+    case SPV_MSG_DEBUG:
       level_string = "debug";
       break;
   }

--- a/source/message.h
+++ b/source/message.h
@@ -25,34 +25,35 @@ namespace spvtools {
 // TODO(antiagainst): This eventually should be in the C++ interface.
 
 // Severity levels of messages communicated to the consumer.
-enum MessageLevel {
-  kFatal,          // Unrecoverable error due to environment.
-                   // Will exit the program immediately. E.g.,
-                   // out of memory.
-  kInternalError,  // Unrecoverable error due to SPIRV-Tools internals.
-                   // Will exit the program immediately. E.g.,
-                   // unimplemented feature.
-  kError,          // Normal error due to user input.
-  kWarning,        // Warning information.
-  kInfo,           // General information.
-  kDebug,          // Debug information.
-};
+typedef enum spv_message_level_t {
+  SPV_MSG_FATAL,           // Unrecoverable error due to environment.
+                           // Will exit the program immediately. E.g.,
+                           // out of memory.
+  SPV_MSG_INTERNAL_ERROR,  // Unrecoverable error due to SPIRV-Tools
+                           // internals.
+                           // Will exit the program immediately. E.g.,
+                           // unimplemented feature.
+  SPV_MSG_ERROR,           // Normal error due to user input.
+  SPV_MSG_WARNINING,       // Warning information.
+  SPV_MSG_INFO,            // General information.
+  SPV_MSG_DEBUG,           // Debug information.
+} spv_message_level_t;
 
 // Message consumer. The C strings for source and message are only alive for the
 // specific invocation.
 using MessageConsumer = std::function<void(
-    MessageLevel /* level */, const char* /* source */,
+    spv_message_level_t /* level */, const char* /* source */,
     const spv_position_t& /* position */, const char* /* message */
     )>;
 
 // A message consumer that ignores all messages.
-inline void IgnoreMessage(MessageLevel, const char*, const spv_position_t&,
-                          const char*) {}
+inline void IgnoreMessage(spv_message_level_t, const char*,
+                          const spv_position_t&, const char*) {}
 
 // A helper function to compose and return a string from the message in the
 // following format:
 //   "<level>: <source>:<line>:<column>:<index>: <message>"
-std::string StringifyMessage(MessageLevel level, const char* source,
+std::string StringifyMessage(spv_message_level_t level, const char* source,
                              const spv_position_t& position,
                              const char* message);
 

--- a/source/message.h
+++ b/source/message.h
@@ -25,15 +25,17 @@ namespace spvtools {
 // TODO(antiagainst): This eventually should be in the C++ interface.
 
 // Severity levels of messages communicated to the consumer.
-enum class MessageLevel {
-  Fatal,  // Unrecoverable error due to environment. Will abort the program
-          // immediately. E.g., out of memory.
-  InternalError,  // Unrecoverable error due to SPIRV-Tools internals. Will
-                  // abort the program immediately. E.g., unimplemented feature.
-  Error,          // Normal error due to user input.
-  Warning,        // Warning information.
-  Info,           // General information.
-  Debug,          // Debug information.
+enum MessageLevel {
+  kFatal,          // Unrecoverable error due to environment.
+                   // Will exit the program immediately. E.g.,
+                   // out of memory.
+  kInternalError,  // Unrecoverable error due to SPIRV-Tools internals.
+                   // Will exit the program immediately. E.g.,
+                   // unimplemented feature.
+  kError,          // Normal error due to user input.
+  kWarning,        // Warning information.
+  kInfo,           // General information.
+  kDebug,          // Debug information.
 };
 
 // Message consumer. The C strings for source and message are only alive for the

--- a/source/opt/log.h
+++ b/source/opt/log.h
@@ -54,18 +54,18 @@
 
 // Logs an error message to the consumer saying the given feature is
 // unimplemented.
-#define SPIRV_UNIMPLEMENTED(consumer, feature)                      \
-  do {                                                              \
-    spvtools::Log(consumer, MessageLevel::kInternalError, __FILE__, \
-                  {__LINE__, 0, 0}, "unimplemented: " feature);     \
+#define SPIRV_UNIMPLEMENTED(consumer, feature)                  \
+  do {                                                          \
+    spvtools::Log(consumer, SPV_MSG_INTERNAL_ERROR, __FILE__,   \
+                  {__LINE__, 0, 0}, "unimplemented: " feature); \
   } while (0)
 
 // Logs an error message to the consumer saying the code location
 // should be unreachable.
-#define SPIRV_UNREACHABLE(consumer)                                 \
-  do {                                                              \
-    spvtools::Log(consumer, MessageLevel::kInternalError, __FILE__, \
-                  {__LINE__, 0, 0}, "unreachable");                 \
+#define SPIRV_UNREACHABLE(consumer)                           \
+  do {                                                        \
+    spvtools::Log(consumer, SPV_MSG_INTERNAL_ERROR, __FILE__, \
+                  {__LINE__, 0, 0}, "unreachable");           \
   } while (0)
 
 // Helper macros for concatenating arguments.
@@ -79,7 +79,7 @@ namespace spvtools {
 
 // Calls the given |consumer| by supplying  the |message|. The |message| is from
 // the given |file| and |location| and of the given severity |level|.
-inline void Log(const MessageConsumer& consumer, MessageLevel level,
+inline void Log(const MessageConsumer& consumer, spv_message_level_t level,
                 const char* file, const spv_position_t& position,
                 const char* message) {
   if (consumer != nullptr) consumer(level, file, position, message);
@@ -89,8 +89,9 @@ inline void Log(const MessageConsumer& consumer, MessageLevel level,
 // given |format|. The |message| is from the given |file| and |location| and of
 // the given severity |level|.
 template <typename... Args>
-void Logf(const MessageConsumer& consumer, MessageLevel level, const char* file,
-          const spv_position_t& position, const char* format, Args&&... args) {
+void Logf(const MessageConsumer& consumer, spv_message_level_t level,
+          const char* file, const spv_position_t& position, const char* format,
+          Args&&... args) {
 #if defined(_MSC_VER) && _MSC_VER < 1900
 // Sadly, snprintf() is not supported until Visual Studio 2015!
 #define snprintf _snprintf
@@ -135,29 +136,29 @@ void Logf(const MessageConsumer& consumer, MessageLevel level, const char* file,
 #define SPIRV_ASSERT_1(consumer, condition)                             \
   do {                                                                  \
     if (!(condition)) {                                                 \
-      spvtools::Log(consumer, MessageLevel::kInternalError, __FILE__,   \
+      spvtools::Log(consumer, SPV_MSG_INTERNAL_ERROR, __FILE__,         \
                     {__LINE__, 0, 0}, "assertion failed: " #condition); \
       std::exit(EXIT_FAILURE);                                          \
     }                                                                   \
   } while (0)
 
-#define SPIRV_ASSERT_2(consumer, condition, message)                  \
-  do {                                                                \
-    if (!(condition)) {                                               \
-      spvtools::Log(consumer, MessageLevel::kInternalError, __FILE__, \
-                    {__LINE__, 0, 0}, "assertion failed: " message);  \
-      std::exit(EXIT_FAILURE);                                        \
-    }                                                                 \
+#define SPIRV_ASSERT_2(consumer, condition, message)                 \
+  do {                                                               \
+    if (!(condition)) {                                              \
+      spvtools::Log(consumer, SPV_MSG_INTERNAL_ERROR, __FILE__,      \
+                    {__LINE__, 0, 0}, "assertion failed: " message); \
+      std::exit(EXIT_FAILURE);                                       \
+    }                                                                \
   } while (0)
 
-#define SPIRV_ASSERT_more(consumer, condition, format, ...)            \
-  do {                                                                 \
-    if (!(condition)) {                                                \
-      spvtools::Logf(consumer, MessageLevel::kInternalError, __FILE__, \
-                     {__LINE__, 0, 0}, "assertion failed: " format,    \
-                     __VA_ARGS__);                                     \
-      std::exit(EXIT_FAILURE);                                         \
-    }                                                                  \
+#define SPIRV_ASSERT_more(consumer, condition, format, ...)         \
+  do {                                                              \
+    if (!(condition)) {                                             \
+      spvtools::Logf(consumer, SPV_MSG_INTERNAL_ERROR, __FILE__,    \
+                     {__LINE__, 0, 0}, "assertion failed: " format, \
+                     __VA_ARGS__);                                  \
+      std::exit(EXIT_FAILURE);                                      \
+    }                                                               \
   } while (0)
 
 #define SPIRV_ASSERT_3(consumer, condition, format, ...) \
@@ -169,16 +170,16 @@ void Logf(const MessageConsumer& consumer, MessageLevel level, const char* file,
 #define SPIRV_ASSERT_5(consumer, condition, format, ...) \
   SPIRV_ASSERT_more(consumer, condition, format, __VA_ARGS__)
 
-#define SPIRV_DEBUG_1(consumer, message)                                     \
-  do {                                                                       \
-    spvtools::Log(consumer, MessageLevel::Debug, __FILE__, {__LINE__, 0, 0}, \
-                  message);                                                  \
+#define SPIRV_DEBUG_1(consumer, message)                               \
+  do {                                                                 \
+    spvtools::Log(consumer, SPV_MSG_DEBUG, __FILE__, {__LINE__, 0, 0}, \
+                  message);                                            \
   } while (0)
 
-#define SPIRV_DEBUG_more(consumer, format, ...)                               \
-  do {                                                                        \
-    spvtools::Logf(consumer, MessageLevel::Debug, __FILE__, {__LINE__, 0, 0}, \
-                   format, __VA_ARGS__);                                      \
+#define SPIRV_DEBUG_more(consumer, format, ...)                         \
+  do {                                                                  \
+    spvtools::Logf(consumer, SPV_MSG_DEBUG, __FILE__, {__LINE__, 0, 0}, \
+                   format, __VA_ARGS__);                                \
   } while (0)
 
 #define SPIRV_DEBUG_2(consumer, format, ...) \

--- a/source/opt/log.h
+++ b/source/opt/log.h
@@ -54,18 +54,18 @@
 
 // Logs an error message to the consumer saying the given feature is
 // unimplemented.
-#define SPIRV_UNIMPLEMENTED(consumer, feature)                     \
-  do {                                                             \
-    spvtools::Log(consumer, MessageLevel::InternalError, __FILE__, \
-                  {__LINE__, 0, 0}, "unimplemented: " feature);    \
+#define SPIRV_UNIMPLEMENTED(consumer, feature)                      \
+  do {                                                              \
+    spvtools::Log(consumer, MessageLevel::kInternalError, __FILE__, \
+                  {__LINE__, 0, 0}, "unimplemented: " feature);     \
   } while (0)
 
 // Logs an error message to the consumer saying the code location
 // should be unreachable.
-#define SPIRV_UNREACHABLE(consumer)                                \
-  do {                                                             \
-    spvtools::Log(consumer, MessageLevel::InternalError, __FILE__, \
-                  {__LINE__, 0, 0}, "unreachable");                \
+#define SPIRV_UNREACHABLE(consumer)                                 \
+  do {                                                              \
+    spvtools::Log(consumer, MessageLevel::kInternalError, __FILE__, \
+                  {__LINE__, 0, 0}, "unreachable");                 \
   } while (0)
 
 // Helper macros for concatenating arguments.
@@ -135,29 +135,29 @@ void Logf(const MessageConsumer& consumer, MessageLevel level, const char* file,
 #define SPIRV_ASSERT_1(consumer, condition)                             \
   do {                                                                  \
     if (!(condition)) {                                                 \
-      spvtools::Log(consumer, MessageLevel::InternalError, __FILE__,    \
+      spvtools::Log(consumer, MessageLevel::kInternalError, __FILE__,   \
                     {__LINE__, 0, 0}, "assertion failed: " #condition); \
       std::exit(EXIT_FAILURE);                                          \
     }                                                                   \
   } while (0)
 
-#define SPIRV_ASSERT_2(consumer, condition, message)                 \
-  do {                                                               \
-    if (!(condition)) {                                              \
-      spvtools::Log(consumer, MessageLevel::InternalError, __FILE__, \
-                    {__LINE__, 0, 0}, "assertion failed: " message); \
-      std::exit(EXIT_FAILURE);                                       \
-    }                                                                \
-  } while (0)
-
-#define SPIRV_ASSERT_more(consumer, condition, format, ...)           \
+#define SPIRV_ASSERT_2(consumer, condition, message)                  \
   do {                                                                \
     if (!(condition)) {                                               \
-      spvtools::Logf(consumer, MessageLevel::InternalError, __FILE__, \
-                     {__LINE__, 0, 0}, "assertion failed: " format,   \
-                     __VA_ARGS__);                                    \
+      spvtools::Log(consumer, MessageLevel::kInternalError, __FILE__, \
+                    {__LINE__, 0, 0}, "assertion failed: " message);  \
       std::exit(EXIT_FAILURE);                                        \
     }                                                                 \
+  } while (0)
+
+#define SPIRV_ASSERT_more(consumer, condition, format, ...)            \
+  do {                                                                 \
+    if (!(condition)) {                                                \
+      spvtools::Logf(consumer, MessageLevel::kInternalError, __FILE__, \
+                     {__LINE__, 0, 0}, "assertion failed: " format,    \
+                     __VA_ARGS__);                                     \
+      std::exit(EXIT_FAILURE);                                         \
+    }                                                                  \
   } while (0)
 
 #define SPIRV_ASSERT_3(consumer, condition, format, ...) \

--- a/test/BinaryParse.cpp
+++ b/test/BinaryParse.cpp
@@ -306,7 +306,7 @@ TEST_F(BinaryParseTest, SpecifyConsumerNullDiagnosticsForBadParse) {
       ctx, [&invocation](spvtools::MessageLevel level, const char* source,
                          const spv_position_t& position, const char* message) {
         ++invocation;
-        EXPECT_EQ(spvtools::MessageLevel::Error, level);
+        EXPECT_EQ(spvtools::MessageLevel::kError, level);
         EXPECT_STREQ("input", source);
         EXPECT_EQ(0u, position.line);
         EXPECT_EQ(0u, position.column);

--- a/test/BinaryParse.cpp
+++ b/test/BinaryParse.cpp
@@ -284,7 +284,7 @@ TEST_F(BinaryParseTest, SpecifyConsumerNullDiagnosticsForGoodParse) {
   auto ctx = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
   int invocation = 0;
   SetContextMessageConsumer(
-      ctx, [&invocation](spvtools::MessageLevel, const char*,
+      ctx, [&invocation](spvtools::spv_message_level_t, const char*,
                          const spv_position_t&, const char*) { ++invocation; });
 
   EXPECT_HEADER(1).WillOnce(Return(SPV_SUCCESS));
@@ -303,10 +303,11 @@ TEST_F(BinaryParseTest, SpecifyConsumerNullDiagnosticsForBadParse) {
   auto ctx = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
   int invocation = 0;
   SetContextMessageConsumer(
-      ctx, [&invocation](spvtools::MessageLevel level, const char* source,
-                         const spv_position_t& position, const char* message) {
+      ctx,
+      [&invocation](spvtools::spv_message_level_t level, const char* source,
+                    const spv_position_t& position, const char* message) {
         ++invocation;
-        EXPECT_EQ(spvtools::MessageLevel::kError, level);
+        EXPECT_EQ(spvtools::SPV_MSG_ERROR, level);
         EXPECT_STREQ("input", source);
         EXPECT_EQ(0u, position.line);
         EXPECT_EQ(0u, position.column);
@@ -331,7 +332,7 @@ TEST_F(BinaryParseTest, SpecifyConsumerSpecifyDiagnosticsForGoodParse) {
   auto ctx = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
   int invocation = 0;
   SetContextMessageConsumer(
-      ctx, [&invocation](spvtools::MessageLevel, const char*,
+      ctx, [&invocation](spvtools::spv_message_level_t, const char*,
                          const spv_position_t&, const char*) { ++invocation; });
 
   EXPECT_HEADER(1).WillOnce(Return(SPV_SUCCESS));
@@ -351,7 +352,7 @@ TEST_F(BinaryParseTest, SpecifyConsumerSpecifyDiagnosticsForBadParse) {
   auto ctx = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
   int invocation = 0;
   SetContextMessageConsumer(
-      ctx, [&invocation](spvtools::MessageLevel, const char*,
+      ctx, [&invocation](spvtools::spv_message_level_t, const char*,
                          const spv_position_t&, const char*) { ++invocation; });
 
   words.push_back(0xffffffff);  // Certainly invalid instruction header.

--- a/test/TextLiteral.cpp
+++ b/test/TextLiteral.cpp
@@ -169,7 +169,7 @@ std::vector<uint32_t> successfulEncode(const TextLiteralCase& test,
                                        libspirv::IdTypeClass type) {
   spv_instruction_t inst;
   std::string message;
-  auto capture_message = [&message](spvtools::MessageLevel, const char*,
+  auto capture_message = [&message](spvtools::spv_message_level_t, const char*,
                                     const spv_position_t&,
                                     const char* m) { message = m; };
   libspirv::IdType expected_type{test.bitwidth, test.is_signed, type};
@@ -185,7 +185,7 @@ std::string failedEncode(const TextLiteralCase& test,
                          libspirv::IdTypeClass type) {
   spv_instruction_t inst;
   std::string message;
-  auto capture_message = [&message](spvtools::MessageLevel, const char*,
+  auto capture_message = [&message](spvtools::spv_message_level_t, const char*,
                                     const spv_position_t&,
                                     const char* m) { message = m; };
   libspirv::IdType expected_type{test.bitwidth, test.is_signed, type};

--- a/test/c_interface.cpp
+++ b/test/c_interface.cpp
@@ -109,7 +109,7 @@ TEST(CInterface, SpecifyConsumerNullDiagnosticForAssembling) {
       [&invocation](MessageLevel level, const char* source,
                     const spv_position_t& position, const char* message) {
         ++invocation;
-        EXPECT_EQ(MessageLevel::Error, level);
+        EXPECT_EQ(MessageLevel::kError, level);
         // The error happens at scanning the begining of second line.
         EXPECT_STREQ("input", source);
         EXPECT_EQ(1u, position.line);
@@ -137,7 +137,7 @@ TEST(CInterface, SpecifyConsumerNullDiagnosticForDisassembling) {
       [&invocation](MessageLevel level, const char* source,
                     const spv_position_t& position, const char* message) {
         ++invocation;
-        EXPECT_EQ(MessageLevel::Error, level);
+        EXPECT_EQ(MessageLevel::kError, level);
         EXPECT_STREQ("input", source);
         EXPECT_EQ(0u, position.line);
         EXPECT_EQ(0u, position.column);
@@ -172,7 +172,7 @@ TEST(CInterface, SpecifyConsumerNullDiagnosticForValidating) {
       [&invocation](MessageLevel level, const char* source,
                     const spv_position_t& position, const char* message) {
         ++invocation;
-        EXPECT_EQ(MessageLevel::Error, level);
+        EXPECT_EQ(MessageLevel::kError, level);
         EXPECT_STREQ("input", source);
         EXPECT_EQ(0u, position.line);
         EXPECT_EQ(0u, position.column);

--- a/test/c_interface.cpp
+++ b/test/c_interface.cpp
@@ -106,10 +106,10 @@ TEST(CInterface, SpecifyConsumerNullDiagnosticForAssembling) {
   // TODO(antiagainst): Use public C API for setting the consumer once exists.
   SetContextMessageConsumer(
       context,
-      [&invocation](MessageLevel level, const char* source,
+      [&invocation](spv_message_level_t level, const char* source,
                     const spv_position_t& position, const char* message) {
         ++invocation;
-        EXPECT_EQ(MessageLevel::kError, level);
+        EXPECT_EQ(SPV_MSG_ERROR, level);
         // The error happens at scanning the begining of second line.
         EXPECT_STREQ("input", source);
         EXPECT_EQ(1u, position.line);
@@ -134,10 +134,10 @@ TEST(CInterface, SpecifyConsumerNullDiagnosticForDisassembling) {
   int invocation = 0;
   SetContextMessageConsumer(
       context,
-      [&invocation](MessageLevel level, const char* source,
+      [&invocation](spv_message_level_t level, const char* source,
                     const spv_position_t& position, const char* message) {
         ++invocation;
-        EXPECT_EQ(MessageLevel::kError, level);
+        EXPECT_EQ(SPV_MSG_ERROR, level);
         EXPECT_STREQ("input", source);
         EXPECT_EQ(0u, position.line);
         EXPECT_EQ(0u, position.column);
@@ -169,10 +169,10 @@ TEST(CInterface, SpecifyConsumerNullDiagnosticForValidating) {
   int invocation = 0;
   SetContextMessageConsumer(
       context,
-      [&invocation](MessageLevel level, const char* source,
+      [&invocation](spv_message_level_t level, const char* source,
                     const spv_position_t& position, const char* message) {
         ++invocation;
-        EXPECT_EQ(MessageLevel::kError, level);
+        EXPECT_EQ(SPV_MSG_ERROR, level);
         EXPECT_STREQ("input", source);
         EXPECT_EQ(0u, position.line);
         EXPECT_EQ(0u, position.column);
@@ -203,8 +203,9 @@ TEST(CInterface, SpecifyConsumerSpecifyDiagnosticForAssembling) {
   auto context = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
   int invocation = 0;
   SetContextMessageConsumer(
-      context, [&invocation](MessageLevel, const char*, const spv_position_t&,
-                             const char*) { ++invocation; });
+      context,
+      [&invocation](spv_message_level_t, const char*, const spv_position_t&,
+                    const char*) { ++invocation; });
 
   spv_binary binary = nullptr;
   spv_diagnostic diagnostic = nullptr;
@@ -225,8 +226,9 @@ TEST(CInterface, SpecifyConsumerSpecifyDiagnosticForDisassembling) {
   auto context = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
   int invocation = 0;
   SetContextMessageConsumer(
-      context, [&invocation](MessageLevel, const char*, const spv_position_t&,
-                             const char*) { ++invocation; });
+      context,
+      [&invocation](spv_message_level_t, const char*, const spv_position_t&,
+                    const char*) { ++invocation; });
 
   spv_binary binary = nullptr;
   ASSERT_EQ(SPV_SUCCESS, spvTextToBinary(context, input_text,
@@ -255,8 +257,9 @@ TEST(CInterface, SpecifyConsumerSpecifyDiagnosticForValidating) {
   auto context = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
   int invocation = 0;
   SetContextMessageConsumer(
-      context, [&invocation](MessageLevel, const char*, const spv_position_t&,
-                             const char*) { ++invocation; });
+      context,
+      [&invocation](spv_message_level_t, const char*, const spv_position_t&,
+                    const char*) { ++invocation; });
 
   spv_binary binary = nullptr;
   ASSERT_EQ(SPV_SUCCESS, spvTextToBinary(context, input_text,

--- a/test/cpp_interface.cpp
+++ b/test/cpp_interface.cpp
@@ -36,7 +36,7 @@ TEST(CppInterface, SuccessfulRoundTrip) {
   // This cannot pass validation since %1 is not defined.
   t.SetMessageConsumer([](MessageLevel level, const char* source,
                           const spv_position_t& position, const char* message) {
-    EXPECT_EQ(MessageLevel::Error, level);
+    EXPECT_EQ(MessageLevel::kError, level);
     EXPECT_STREQ("input", source);
     EXPECT_EQ(0u, position.line);
     EXPECT_EQ(0u, position.column);
@@ -68,7 +68,7 @@ TEST(CppInterface, AssembleWithWrongTargetEnv) {
       [&invocation_count](MessageLevel level, const char* source,
                           const spv_position_t& position, const char* message) {
         ++invocation_count;
-        EXPECT_EQ(MessageLevel::Error, level);
+        EXPECT_EQ(MessageLevel::kError, level);
         EXPECT_STREQ("input", source);
         EXPECT_EQ(0u, position.line);
         EXPECT_EQ(5u, position.column);
@@ -90,7 +90,7 @@ TEST(CppInterface, DisassembleEmptyModule) {
       [&invocation_count](MessageLevel level, const char* source,
                           const spv_position_t& position, const char* message) {
         ++invocation_count;
-        EXPECT_EQ(MessageLevel::Error, level);
+        EXPECT_EQ(MessageLevel::kError, level);
         EXPECT_STREQ("input", source);
         EXPECT_EQ(0u, position.line);
         EXPECT_EQ(0u, position.column);
@@ -111,7 +111,7 @@ TEST(CppInterface, DisassembleWithWrongTargetEnv) {
       [&invocation_count](MessageLevel level, const char* source,
                           const spv_position_t& position, const char* message) {
         ++invocation_count;
-        EXPECT_EQ(MessageLevel::Error, level);
+        EXPECT_EQ(MessageLevel::kError, level);
         EXPECT_STREQ("input", source);
         EXPECT_EQ(0u, position.line);
         EXPECT_EQ(0u, position.column);
@@ -149,7 +149,7 @@ TEST(CppInterface, ValidateEmptyModule) {
       [&invocation_count](MessageLevel level, const char* source,
                           const spv_position_t& position, const char* message) {
         ++invocation_count;
-        EXPECT_EQ(MessageLevel::Error, level);
+        EXPECT_EQ(MessageLevel::kError, level);
         EXPECT_STREQ("input", source);
         EXPECT_EQ(0u, position.line);
         EXPECT_EQ(0u, position.column);

--- a/test/cpp_interface.cpp
+++ b/test/cpp_interface.cpp
@@ -34,9 +34,9 @@ TEST(CppInterface, SuccessfulRoundTrip) {
   EXPECT_EQ(SpvVersion, binary[1]);
 
   // This cannot pass validation since %1 is not defined.
-  t.SetMessageConsumer([](MessageLevel level, const char* source,
+  t.SetMessageConsumer([](spv_message_level_t level, const char* source,
                           const spv_position_t& position, const char* message) {
-    EXPECT_EQ(MessageLevel::kError, level);
+    EXPECT_EQ(SPV_MSG_ERROR, level);
     EXPECT_STREQ("input", source);
     EXPECT_EQ(0u, position.line);
     EXPECT_EQ(0u, position.column);
@@ -65,10 +65,10 @@ TEST(CppInterface, AssembleWithWrongTargetEnv) {
   SpvTools t(SPV_ENV_UNIVERSAL_1_0);
   int invocation_count = 0;
   t.SetMessageConsumer(
-      [&invocation_count](MessageLevel level, const char* source,
+      [&invocation_count](spv_message_level_t level, const char* source,
                           const spv_position_t& position, const char* message) {
         ++invocation_count;
-        EXPECT_EQ(MessageLevel::kError, level);
+        EXPECT_EQ(SPV_MSG_ERROR, level);
         EXPECT_STREQ("input", source);
         EXPECT_EQ(0u, position.line);
         EXPECT_EQ(5u, position.column);
@@ -87,10 +87,10 @@ TEST(CppInterface, DisassembleEmptyModule) {
   SpvTools t(SPV_ENV_UNIVERSAL_1_1);
   int invocation_count = 0;
   t.SetMessageConsumer(
-      [&invocation_count](MessageLevel level, const char* source,
+      [&invocation_count](spv_message_level_t level, const char* source,
                           const spv_position_t& position, const char* message) {
         ++invocation_count;
-        EXPECT_EQ(MessageLevel::kError, level);
+        EXPECT_EQ(SPV_MSG_ERROR, level);
         EXPECT_STREQ("input", source);
         EXPECT_EQ(0u, position.line);
         EXPECT_EQ(0u, position.column);
@@ -108,10 +108,10 @@ TEST(CppInterface, DisassembleWithWrongTargetEnv) {
   SpvTools t10(SPV_ENV_UNIVERSAL_1_0);
   int invocation_count = 0;
   t10.SetMessageConsumer(
-      [&invocation_count](MessageLevel level, const char* source,
+      [&invocation_count](spv_message_level_t level, const char* source,
                           const spv_position_t& position, const char* message) {
         ++invocation_count;
-        EXPECT_EQ(MessageLevel::kError, level);
+        EXPECT_EQ(SPV_MSG_ERROR, level);
         EXPECT_STREQ("input", source);
         EXPECT_EQ(0u, position.line);
         EXPECT_EQ(0u, position.column);
@@ -132,9 +132,10 @@ TEST(CppInterface, SuccessfulValidation) {
       "OpCapability Shader\nOpMemoryModel Logical GLSL450";
   SpvTools t(SPV_ENV_UNIVERSAL_1_1);
   int invocation_count = 0;
-  t.SetMessageConsumer(
-      [&invocation_count](MessageLevel, const char*, const spv_position_t&,
-                          const char*) { ++invocation_count; });
+  t.SetMessageConsumer([&invocation_count](spv_message_level_t, const char*,
+                                           const spv_position_t&, const char*) {
+    ++invocation_count;
+  });
 
   std::vector<uint32_t> binary;
   EXPECT_TRUE(t.Assemble(input_text, &binary));
@@ -146,10 +147,10 @@ TEST(CppInterface, ValidateEmptyModule) {
   SpvTools t(SPV_ENV_UNIVERSAL_1_1);
   int invocation_count = 0;
   t.SetMessageConsumer(
-      [&invocation_count](MessageLevel level, const char* source,
+      [&invocation_count](spv_message_level_t level, const char* source,
                           const spv_position_t& position, const char* message) {
         ++invocation_count;
-        EXPECT_EQ(MessageLevel::kError, level);
+        EXPECT_EQ(SPV_MSG_ERROR, level);
         EXPECT_STREQ("input", source);
         EXPECT_EQ(0u, position.line);
         EXPECT_EQ(0u, position.column);

--- a/test/test_log.cpp
+++ b/test/test_log.cpp
@@ -28,7 +28,7 @@ TEST(Log, Unimplemented) {
   auto consumer = [&invocation](MessageLevel level, const char* source,
                                 const spv_position_t&, const char* message) {
     ++invocation;
-    EXPECT_EQ(MessageLevel::InternalError, level);
+    EXPECT_EQ(MessageLevel::kInternalError, level);
     EXPECT_THAT(source, MatchesRegex(".*test_log.cpp$"));
     EXPECT_STREQ("unimplemented: the-ultimite-feature", message);
   };
@@ -42,7 +42,7 @@ TEST(Log, Unreachable) {
   auto consumer = [&invocation](MessageLevel level, const char* source,
                                 const spv_position_t&, const char* message) {
     ++invocation;
-    EXPECT_EQ(MessageLevel::InternalError, level);
+    EXPECT_EQ(MessageLevel::kInternalError, level);
     EXPECT_THAT(source, MatchesRegex(".*test_log.cpp$"));
     EXPECT_STREQ("unreachable", message);
   };

--- a/test/test_log.cpp
+++ b/test/test_log.cpp
@@ -25,10 +25,10 @@ using ::testing::MatchesRegex;
 
 TEST(Log, Unimplemented) {
   int invocation = 0;
-  auto consumer = [&invocation](MessageLevel level, const char* source,
+  auto consumer = [&invocation](spv_message_level_t level, const char* source,
                                 const spv_position_t&, const char* message) {
     ++invocation;
-    EXPECT_EQ(MessageLevel::kInternalError, level);
+    EXPECT_EQ(SPV_MSG_INTERNAL_ERROR, level);
     EXPECT_THAT(source, MatchesRegex(".*test_log.cpp$"));
     EXPECT_STREQ("unimplemented: the-ultimite-feature", message);
   };
@@ -39,10 +39,10 @@ TEST(Log, Unimplemented) {
 
 TEST(Log, Unreachable) {
   int invocation = 0;
-  auto consumer = [&invocation](MessageLevel level, const char* source,
+  auto consumer = [&invocation](spv_message_level_t level, const char* source,
                                 const spv_position_t&, const char* message) {
     ++invocation;
-    EXPECT_EQ(MessageLevel::kInternalError, level);
+    EXPECT_EQ(SPV_MSG_INTERNAL_ERROR, level);
     EXPECT_THAT(source, MatchesRegex(".*test_log.cpp$"));
     EXPECT_STREQ("unreachable", message);
   };

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -65,11 +65,11 @@ int main(int argc, char** argv) {
   spv_target_env target_env = SPV_ENV_UNIVERSAL_1_1;
 
   opt::PassManager pass_manager;
-  pass_manager.SetMessageConsumer([](MessageLevel level, const char* source,
-                                     const spv_position_t& position,
-                                     const char* message) {
-    std::cerr << StringifyMessage(level, source, position, message);
-  });
+  pass_manager.SetMessageConsumer(
+      [](spv_message_level_t level, const char* source,
+         const spv_position_t& position, const char* message) {
+        std::cerr << StringifyMessage(level, source, position, message);
+      });
 
   for (int argi = 1; argi < argc; ++argi) {
     const char* cur_arg = argv[argi];


### PR DESCRIPTION
This allows us to create C interface with `MessageLevel` later.