### PR TITLE
Use nullptr as the default message consumer to ignore all messages.

### DIFF
--- a/source/message.h
+++ b/source/message.h
@@ -21,10 +21,6 @@
 
 namespace spvtools {
 
-// A message consumer that ignores all messages.
-inline void IgnoreMessage(spv_message_level_t, const char*,
-                          const spv_position_t&, const char*) {}
-
 // A helper function to compose and return a string from the message in the
 // following format:
 //   "<level>: <source>:<line>:<column>:<index>: <message>"

--- a/source/opt/pass.h
+++ b/source/opt/pass.h
@@ -42,7 +42,7 @@ class Pass {
   // The constructed instance will have an empty message consumer, which just
   // ignores all messages from the library. Use SetMessageConsumer() to supply
   // one if messages are of concern.
-  Pass() : consumer_(IgnoreMessage) {}
+  Pass() : consumer_(nullptr) {}
 
   // Returns a descriptive name for this pass.
   virtual const char* name() const = 0;

--- a/source/opt/pass_manager.h
+++ b/source/opt/pass_manager.h
@@ -36,7 +36,7 @@ class PassManager {
   // The constructed instance will have an empty message consumer, which just
   // ignores all messages from the library. Use SetMessageConsumer() to supply
   // one if messages are of concern.
-  PassManager() : consumer_(IgnoreMessage) {}
+  PassManager() : consumer_(nullptr) {}
 
   // Sets the message consumer to the given |consumer|.
   void SetMessageConsumer(MessageConsumer c) { consumer_ = std::move(c); }

--- a/test/opt/pass_fixture.h
+++ b/test/opt/pass_fixture.h
@@ -41,7 +41,7 @@ template <typename TestT>
 class PassTest : public TestT {
  public:
   PassTest()
-      : consumer_(IgnoreMessage),
+      : consumer_(nullptr),
         tools_(SPV_ENV_UNIVERSAL_1_1),
         manager_(new opt::PassManager()) {}
 
@@ -119,7 +119,7 @@ class PassTest : public TestT {
     assert(manager_->NumPasses());
 
     std::unique_ptr<ir::Module> module =
-        BuildModule(SPV_ENV_UNIVERSAL_1_1, IgnoreMessage, original);
+        BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, original);
     ASSERT_NE(nullptr, module);
 
     manager_->Run(module.get());

--- a/test/opt/test_def_use.cpp
+++ b/test/opt/test_def_use.cpp
@@ -129,11 +129,11 @@ TEST_P(ParseDefUseTest, Case) {
   // Build module.
   const std::vector<const char*> text = {tc.text};
   std::unique_ptr<ir::Module> module =
-      BuildModule(SPV_ENV_UNIVERSAL_1_1, IgnoreMessage, JoinAllInsts(text));
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, JoinAllInsts(text));
   ASSERT_NE(nullptr, module);
 
   // Analyze def and use.
-  opt::analysis::DefUseManager manager(IgnoreMessage, module.get());
+  opt::analysis::DefUseManager manager(nullptr, module.get());
 
   CheckDef(tc.du, manager.id_to_defs());
   CheckUse(tc.du, manager.id_to_uses());
@@ -510,11 +510,11 @@ TEST_P(ReplaceUseTest, Case) {
   // Build module.
   const std::vector<const char*> text = {tc.before};
   std::unique_ptr<ir::Module> module =
-      BuildModule(SPV_ENV_UNIVERSAL_1_1, IgnoreMessage, JoinAllInsts(text));
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, JoinAllInsts(text));
   ASSERT_NE(nullptr, module);
 
   // Analyze def and use.
-  opt::analysis::DefUseManager manager(IgnoreMessage, module.get());
+  opt::analysis::DefUseManager manager(nullptr, module.get());
 
   // Do the substitution.
   for (const auto& candiate : tc.candidates) {
@@ -812,11 +812,11 @@ TEST_P(KillDefTest, Case) {
   // Build module.
   const std::vector<const char*> text = {tc.before};
   std::unique_ptr<ir::Module> module =
-      BuildModule(SPV_ENV_UNIVERSAL_1_1, IgnoreMessage, JoinAllInsts(text));
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, JoinAllInsts(text));
   ASSERT_NE(nullptr, module);
 
   // Analyze def and use.
-  opt::analysis::DefUseManager manager(IgnoreMessage, module.get());
+  opt::analysis::DefUseManager manager(nullptr, module.get());
 
   // Do the substitution.
   for (const auto id : tc.ids_to_kill) manager.KillDef(id);
@@ -1062,11 +1062,11 @@ TEST(DefUseTest, OpSwitch) {
       "      OpFunctionEnd";
 
   std::unique_ptr<ir::Module> module =
-      BuildModule(SPV_ENV_UNIVERSAL_1_1, IgnoreMessage, original_text);
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, original_text);
   ASSERT_NE(nullptr, module);
 
   // Analyze def and use.
-  opt::analysis::DefUseManager manager(IgnoreMessage, module.get());
+  opt::analysis::DefUseManager manager(nullptr, module.get());
 
   // Do a bunch replacements.
   manager.ReplaceAllUsesWith(9, 900);    // to unused id
@@ -1185,11 +1185,11 @@ TEST_P(AnalyzeInstDefUseTest, Case) {
 
   // Build module.
   std::unique_ptr<ir::Module> module =
-      BuildModule(SPV_ENV_UNIVERSAL_1_1, IgnoreMessage, tc.module_text);
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, tc.module_text);
   ASSERT_NE(nullptr, module);
 
   // Analyze the instructions.
-  opt::analysis::DefUseManager manager(IgnoreMessage, module.get());
+  opt::analysis::DefUseManager manager(nullptr, module.get());
   for (ir::Instruction& inst : tc.insts) {
     manager.AnalyzeInstDefUse(&inst);
   }
@@ -1308,12 +1308,12 @@ TEST_P(KillInstTest, Case) {
 
   // Build module.
   std::unique_ptr<ir::Module> module =
-      BuildModule(SPV_ENV_UNIVERSAL_1_1, IgnoreMessage, tc.before);
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, tc.before);
   ASSERT_NE(nullptr, module);
 
   // KillInst
   uint32_t index = 0;
-  opt::analysis::DefUseManager manager(IgnoreMessage, module.get());
+  opt::analysis::DefUseManager manager(nullptr, module.get());
   module->ForEachInst([&index, &tc, &manager](ir::Instruction* inst) {
     if (tc.indices_for_inst_to_kill.count(index) != 0) {
       manager.KillInst(inst);
@@ -1416,11 +1416,11 @@ TEST_P(GetAnnotationsTest, Case) {
 
   // Build module.
   std::unique_ptr<ir::Module> module =
-      BuildModule(SPV_ENV_UNIVERSAL_1_1, IgnoreMessage, tc.code);
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, tc.code);
   ASSERT_NE(nullptr, module);
 
   // Get annotations
-  opt::analysis::DefUseManager manager(IgnoreMessage, module.get());
+  opt::analysis::DefUseManager manager(nullptr, module.get());
   auto insts = manager.GetAnnotations(tc.id);
 
   // Check

--- a/test/opt/test_ir_loader.cpp
+++ b/test/opt/test_ir_loader.cpp
@@ -26,7 +26,7 @@ using namespace spvtools;
 void DoRoundTripCheck(const std::string& text) {
   SpirvTools t(SPV_ENV_UNIVERSAL_1_1);
   std::unique_ptr<ir::Module> module =
-      BuildModule(SPV_ENV_UNIVERSAL_1_1, IgnoreMessage, text);
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text);
   ASSERT_NE(nullptr, module) << "Failed to assemble\n" << text;
 
   std::vector<uint32_t> binary;
@@ -213,7 +213,7 @@ TEST(IrBuilder, OpUndefOutsideFunction) {
 
   SpirvTools t(SPV_ENV_UNIVERSAL_1_1);
   std::unique_ptr<ir::Module> module =
-      BuildModule(SPV_ENV_UNIVERSAL_1_1, IgnoreMessage, text);
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text);
   ASSERT_NE(nullptr, module);
 
   const auto opundef_count = std::count_if(

--- a/test/opt/test_module.cpp
+++ b/test/opt/test_module.cpp
@@ -45,8 +45,7 @@ TEST(ModuleTest, SetIdBound) {
 // Returns a module formed by assembling the given text,
 // then loading the result.
 inline std::unique_ptr<Module> BuildModule(std::string text) {
-  return spvtools::BuildModule(SPV_ENV_UNIVERSAL_1_1, spvtools::IgnoreMessage,
-                               text);
+  return spvtools::BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text);
 }
 
 TEST(ModuleTest, ComputeIdBound) {

--- a/test/opt/test_type_manager.cpp
+++ b/test/opt/test_type_manager.cpp
@@ -89,8 +89,8 @@ TEST(TypeManager, TypeStrings) {
   };
 
   std::unique_ptr<ir::Module> module =
-      BuildModule(SPV_ENV_UNIVERSAL_1_1, IgnoreMessage, text);
-  opt::analysis::TypeManager manager(IgnoreMessage, *module);
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text);
+  opt::analysis::TypeManager manager(nullptr, *module);
 
   EXPECT_EQ(type_id_strs.size(), manager.NumTypes());
   EXPECT_EQ(2u, manager.NumForwardPointers());
@@ -119,8 +119,8 @@ TEST(Struct, DecorationOnStruct) {
     %struct7 = OpTypeStruct %f32      ; no decoration
   )";
   std::unique_ptr<ir::Module> module =
-      BuildModule(SPV_ENV_UNIVERSAL_1_1, IgnoreMessage, text);
-  opt::analysis::TypeManager manager(IgnoreMessage, *module);
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text);
+  opt::analysis::TypeManager manager(nullptr, *module);
 
   ASSERT_EQ(7u, manager.NumTypes());
   ASSERT_EQ(0u, manager.NumForwardPointers());
@@ -169,8 +169,8 @@ TEST(Struct, DecorationOnMember) {
     %struct10 = OpTypeStruct %u32 %f32 ; no member decoration
   )";
   std::unique_ptr<ir::Module> module =
-      BuildModule(SPV_ENV_UNIVERSAL_1_1, IgnoreMessage, text);
-  opt::analysis::TypeManager manager(IgnoreMessage, *module);
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text);
+  opt::analysis::TypeManager manager(nullptr, *module);
 
   ASSERT_EQ(10u, manager.NumTypes());
   ASSERT_EQ(0u, manager.NumForwardPointers());
@@ -207,8 +207,8 @@ TEST(Types, DecorationEmpty) {
     %struct5  = OpTypeStruct %f32
   )";
   std::unique_ptr<ir::Module> module =
-      BuildModule(SPV_ENV_UNIVERSAL_1_1, IgnoreMessage, text);
-  opt::analysis::TypeManager manager(IgnoreMessage, *module);
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text);
+  opt::analysis::TypeManager manager(nullptr, *module);
 
   ASSERT_EQ(5u, manager.NumTypes());
   ASSERT_EQ(0u, manager.NumForwardPointers());


### PR DESCRIPTION
There is no difference between the previous `IgnoreMessage()` function
and a null `std::function`, from functionality's perspective.
The user can set `nullptr` as the `MessageConsumer`, so need to guard
against `nullptr` before calling the consumer anyway. It's better
we use it internally so that it may expose problems by us instead
of the user.