### PR TITLE
Fix forward reference issues with forward pointer

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,9 @@ Revision history for SPIRV-Tools
 v2016.6-dev 2016-09-16
  - Published the C++ interface for assembling, disassembling, validation, and
    optimization.
+ - Fixes issues:
+   #429: Validator: Allow OpTypeForwardPointer and OpTypeStruct to reference
+     undefined IDs
 
 v2016.5 2016-09-16
  - Support SPV_KHR_shader_ballot in assembler, disassembler, parser.

--- a/source/validate_id.cpp
+++ b/source/validate_id.cpp
@@ -2347,6 +2347,7 @@ function<bool(unsigned)> getCanBeForwardDeclaredFunction(SpvOp opcode) {
     case SpvOpSelectionMerge:
     case SpvOpDecorate:
     case SpvOpMemberDecorate:
+    case SpvOpTypeStruct:
     case SpvOpBranch:
     case SpvOpLoopMerge:
       out = [](unsigned) { return true; };
@@ -2383,7 +2384,9 @@ function<bool(unsigned)> getCanBeForwardDeclaredFunction(SpvOp opcode) {
       // The Invoke parameter.
       out = [](unsigned index) { return index == 2; };
       break;
-
+      case SpvOpTypeForwardPointer:
+        out = [](unsigned index) { return index == 0; };
+      break;
     default:
       out = [](unsigned) { return false; };
       break;


### PR DESCRIPTION
Fix for #429 

* Allows OpTypeForwardPointer to reference IDs not yet declared in
  the module
* Allows OpTypeStruct to reference IDs not yet declared in the
  module

Possible Issue: OpTypeStruct should only allow forward references
if the ID is a pointer that is referenced by a forward pointer. Need
Type support in Validator which is currently a work in progress.