### PR TITLE
Fix compilation errors when building inside Chromium

### DIFF
--- a/source/val/BasicBlock.h
+++ b/source/val/BasicBlock.h
@@ -108,7 +108,7 @@ class BasicBlock {
   void RegisterBranchInstruction(SpvOp branch_instruction);
 
   /// Adds @p next BasicBlocks as successors of this BasicBlock
-  void RegisterSuccessors(const std::vector<BasicBlock*>& next = {});
+  void RegisterSuccessors(const std::vector<BasicBlock*>& next = std::vector<BasicBlock*>());
 
   /// Returns true if the id of the BasicBlock matches
   bool operator==(const BasicBlock& other) const { return other.id_ == id_; }

--- a/source/val/Construct.h
+++ b/source/val/Construct.h
@@ -46,7 +46,7 @@ class Construct {
  public:
   Construct(ConstructType type, BasicBlock* dominator,
             BasicBlock* exit = nullptr,
-            std::vector<Construct*> constructs = {});
+            std::vector<Construct*> constructs = std::vector<Construct*>());
 
   /// Returns the type of the construct
   ConstructType type() const;

--- a/source/validate_cfg.cpp
+++ b/source/validate_cfg.cpp
@@ -513,7 +513,7 @@ spv_result_t CfgPass(ValidationState_t& _,
     case SpvOpReturn:
     case SpvOpReturnValue:
     case SpvOpUnreachable:
-      _.current_function().RegisterBlockEnd({}, opcode);
+      _.current_function().RegisterBlockEnd(vector<uint32_t>(), opcode);
       break;
     default:
       break;


### PR DESCRIPTION
Example of an error:
    spirv-tools/source/validate_cfg.cpp:516:45: error: chosen constructor is
    explicit in copy-initialization:
      _.current_function().RegisterBlockEnd({}, opcode);