### PR TITLE
Do not gitignore source/opt/build_module.*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-build*
+/build*
 .ycm_extra_conf.py*
 compile_commands.json
 /external/googletest/


### PR DESCRIPTION
Modifications to e.g. ``source/opt/build_module.cpp`` are ignored due to the content of .gitignore.