### PR TITLE
Search for "SPIRV-Headers", as to work on case-sensitive file systems.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,7 @@ matrix:
 
 # scripts that run after cloning repository
 install:
-  - git clone https://github.com/KhronosGroup/SPIRV-Headers.git external/spirv-headers
+  - git clone https://github.com/KhronosGroup/SPIRV-Headers.git external/SPIRV-Headers
   - git clone https://github.com/google/googletest.git external/googletest
 
 build:

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .ycm_extra_conf.py*
 compile_commands.json
 /external/googletest/
-/external/spirv-headers/
+/external/SPIRV-Headers/
 /TAGS
 /.clang_complete
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_install:
     fi
 
 before_script:
-  - git clone https://github.com/KhronosGroup/SPIRV-Headers.git external/spirv-headers
+  - git clone https://github.com/KhronosGroup/SPIRV-Headers.git external/SPIRV-Headers
   - git clone https://github.com/google/googletest.git external/googletest
 
 script:

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ We intend to maintain a linear history on the GitHub `master` branch.
 * `external/googletest`: Intended location for the
   [googletest][googletest] sources, not provided
 * `include/`: API clients should add this directory to the include search path
-* `external/spirv-headers`: Intended location for
-  [SPIR-V headers][spirv-headers], not provided
+* `external/SPIRV-Headers`: Intended location for
+  [SPIR-V headers][SPIRV-Headers], not provided
 * `include/spirv-tools/libspirv.h`: C API public interface
 * `source/`: API implementation
 * `test/`: Tests, using the [googletest][googletest] framework
@@ -128,7 +128,7 @@ out code:
 
 ```sh
 cd <spirv-dir>
-git clone https://github.com/KhronosGroup/SPIRV-Headers.git external/spirv-headers
+git clone https://github.com/KhronosGroup/SPIRV-Headers.git external/SPIRV-Headers
 git clone https://github.com/google/googletest.git external/googletest # optional
 
 mkdir build && cd build
@@ -348,7 +348,7 @@ limitations under the License.
 ```
 
 [spirv-registry]: https://www.khronos.org/registry/spir-v/
-[spirv-headers]: https://github.com/KhronosGroup/SPIRV-Headers
+[SPIRV-Headers]: https://github.com/KhronosGroup/SPIRV-Headers
 [googletest]: https://github.com/google/googletest
 [googletest-pull-612]: https://github.com/google/googletest/pull/612
 [googletest-issue-610]: https://github.com/google/googletest/issues/610

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -17,7 +17,7 @@ if (DEFINED SPIRV-Headers_SOURCE_DIR)
   # This allows flexible position of the SPIRV-Headers repo.
   set(SPIRV_HEADER_DIR ${SPIRV-Headers_SOURCE_DIR})
 else()
-  set(SPIRV_HEADER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/spirv-headers)
+  set(SPIRV_HEADER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/SPIRV-Headers)
 endif()
 
 if (IS_DIRECTORY ${SPIRV_HEADER_DIR})


### PR DESCRIPTION
The name of the repository with the SPIRV headers is "SPIRV-Headers" and so the name of the directory will be as such. On a case-sensitive filesystem, the existing CMake code would fail to find the repository.