### PR TITLE
enum_set: Fix bool performance warning.

### DIFF
--- a/source/enum_set.h
+++ b/source/enum_set.h
@@ -84,7 +84,7 @@ class EnumSet {
   bool Contains(uint32_t word) const {
     // We shouldn't call Overflow() since this is a const method.
     if (auto bits = AsMask(word)) {
-      return mask_ & bits;
+      return (mask_ & bits) != 0;
     } else if (auto overflow = overflow_.get()) {
       return overflow->find(word) != overflow->end();
     }


### PR DESCRIPTION
Implicit casts from int to bool cause a warning in visual studio.

PTAL