### PR TITLE
Adding validation code for OpTypeStruct

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -207,6 +207,15 @@ spv_result_t ValidationState_t::RemoveIfForwardDeclared(uint32_t id) {
   return SPV_SUCCESS;
 }
 
+spv_result_t ValidationState_t::RegisterForwardPointer(uint32_t id) {
+  forward_pointer_ids_.insert(id);
+  return SPV_SUCCESS;
+}
+
+bool ValidationState_t::IsForwardPointer(uint32_t id) const {
+  return (forward_pointer_ids_.find(id) != forward_pointer_ids_.end());
+}
+
 void ValidationState_t::AssignNameToId(uint32_t id, string name) {
   operand_names_[id] = name;
 }

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -64,6 +64,12 @@ class ValidationState_t {
   /// Removes a forward declared ID if it has been defined
   spv_result_t RemoveIfForwardDeclared(uint32_t id);
 
+  /// Registers an ID as a forward pointer
+  spv_result_t RegisterForwardPointer(uint32_t id);
+
+  /// Returns whether or not an ID is a forward pointer
+  bool IsForwardPointer(uint32_t id) const;
+
   /// Assigns a name to an ID
   void AssignNameToId(uint32_t id, std::string name);
 
@@ -183,6 +189,9 @@ class ValidationState_t {
 
   /// IDs which have been forward declared but have not been defined
   std::unordered_set<uint32_t> unresolved_forward_ids_;
+
+  /// IDs that have been declared as forward pointers.
+  std::unordered_set<uint32_t> forward_pointer_ids_;
 
   /// A map of operand IDs and their names defined by the OpName instruction
   std::unordered_map<uint32_t, std::string> operand_names_;

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -230,7 +230,7 @@ spv_result_t spvValidateBinary(const spv_const_context context,
 
     auto id_str = ss.str();
     return vstate.diag(SPV_ERROR_INVALID_ID)
-           << "The following forward referenced IDs have not be defined:\n"
+           << "The following forward referenced IDs have not been defined:\n"
            << id_str.substr(0, id_str.size() - 1);
   }
 

--- a/source/validate_id.cpp
+++ b/source/validate_id.cpp
@@ -376,9 +376,9 @@ bool idUsage::isValid<SpvOpTypeStruct>(const spv_instruction_t* inst,
       if (typePointingTo && typePointingTo->opcode() != SpvOpTypeStruct) {
         // Forward declared operands of a struct may only point to a struct.
         DIAG(memberTypeIndex)
-            << "A forward reference operand in an "
-               "OpTypeStruct must be an OpTypePointer that "
-               "points to an OpTypeStruct. Found OpTypePointer that points to "
+            << "A forward reference operand in an OpTypeStruct must be an "
+               "OpTypePointer that points to an OpTypeStruct. "
+               "Found OpTypePointer that points to Op"
             << spvOpcodeString(static_cast<SpvOp>(typePointingTo->opcode()))
             << ".";
         return false;

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -446,7 +446,7 @@ OpTypeForwardPointer %_ptr_Generic_struct_A Generic
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("A forward reference operand in an OpTypeStruct must "
                         "be an OpTypePointer that points to an OpTypeStruct. "
-                        "Found OpTypePointer that points to TypeInt."));
+                        "Found OpTypePointer that points to OpTypeInt."));
 }
 
 TEST_F(ValidateData, struct_forward_pointer_good) {

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -399,8 +399,8 @@ TEST_F(ValidateData, specialize_boolean_to_int) {
 
 TEST_F(ValidateData, missing_forward_pointer_decl) {
   string str = header_with_addresses + R"(
-%2 = OpTypeInt 32 0
-%3 = OpTypeStruct %3 %4
+%uintt = OpTypeInt 32 0
+%3 = OpTypeStruct %fwd_ptrt %uintt
 )";
   CompileSuccessfully(str.c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());


### PR DESCRIPTION
According to the Data Rules section of 2.16.1. Universal Validation
Rules of the SPIR-V Spec:

Forward reference operands in an OpTypeStruct
* must be later declared with OpTypePointer
* the type pointed to must be an OpTypeStruct
* had an earlier OpTypeForwardPointer forward reference to the same <id>
