### PR TITLE
Validation for OpSampledImage instruction.

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -398,23 +398,24 @@ void ValidationState_t::RegisterInstruction(
   // If the instruction is using an OpTypeSampledImage as an operand, it should
   // be recorded. The validator will ensure that all usages of an
   // OpTypeSampledImage and its definition are in the same basic block.
-  for (auto i = 0; i < inst.num_operands; ++i) {
-    auto operand = inst.words[inst.operands[i].offset];
-    auto operand_inst = FindDef(operand);
-    if (operand_inst && SpvOpSampledImage == operand_inst->opcode()) {
-      RegisterSampledImageConsumer(operand, inst.result_id);
+  for (uint16_t i = 0; i < inst.num_operands; ++i) {
+    const spv_parsed_operand_t& operand = inst.operands[i];
+    const uint32_t operand_word = inst.words[operand.offset];
+    if (SPV_OPERAND_TYPE_ID == operand.type) {
+      Instruction* operand_inst = FindDef(operand_word);
+      if (operand_inst && SpvOpSampledImage == operand_inst->opcode()) {
+        RegisterSampledImageConsumer(operand_word, inst.result_id);
+      }
     }
   }
 }
 
-std::vector<uint32_t> ValidationState_t::getSampledImageConsumers(
+const std::vector<uint32_t> ValidationState_t::getSampledImageConsumers(
     uint32_t sampled_image_id) const {
   std::vector<uint32_t> result;
   auto iter = sampled_image_consumers_.find(sampled_image_id);
   if (iter != sampled_image_consumers_.end()) {
-    for (auto id : iter->second) {
-      result.push_back(id);
-    }
+    result = iter->second;
   }
   return result;
 }

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -400,8 +400,8 @@ void ValidationState_t::RegisterInstruction(
   // OpTypeSampledImage and its definition are in the same basic block.
   for (uint16_t i = 0; i < inst.num_operands; ++i) {
     const spv_parsed_operand_t& operand = inst.operands[i];
-    const uint32_t operand_word = inst.words[operand.offset];
     if (SPV_OPERAND_TYPE_ID == operand.type) {
+      const uint32_t operand_word = inst.words[operand.offset];
       Instruction* operand_inst = FindDef(operand_word);
       if (operand_inst && SpvOpSampledImage == operand_inst->opcode()) {
         RegisterSampledImageConsumer(operand_word, inst.result_id);
@@ -410,7 +410,7 @@ void ValidationState_t::RegisterInstruction(
   }
 }
 
-const std::vector<uint32_t> ValidationState_t::getSampledImageConsumers(
+std::vector<uint32_t> ValidationState_t::getSampledImageConsumers(
     uint32_t sampled_image_id) const {
   std::vector<uint32_t> result;
   auto iter = sampled_image_consumers_.find(sampled_image_id);

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -181,7 +181,7 @@ class ValidationState_t {
 
   /// Returns a vector containing the Ids of instructions that consume the given
   /// SampledImage id.
-  const std::vector<uint32_t> getSampledImageConsumers(uint32_t id) const;
+  std::vector<uint32_t> getSampledImageConsumers(uint32_t id) const;
 
   /// Records cons_id as a consumer of sampled_image_id.
   void RegisterSampledImageConsumer(uint32_t sampled_image_id,

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -181,7 +181,7 @@ class ValidationState_t {
 
   /// Returns a vector containing the Ids of instructions that consume the given
   /// SampledImage id.
-  std::vector<uint32_t> getSampledImageConsumers(uint32_t id) const;
+  const std::vector<uint32_t> getSampledImageConsumers(uint32_t id) const;
 
   /// Records cons_id as a consumer of sampled_image_id.
   void RegisterSampledImageConsumer(uint32_t sampled_image_id,

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -179,6 +179,14 @@ class ValidationState_t {
     return all_definitions_;
   }
 
+  /// Returns a vector containing the Ids of instructions that consume the given
+  /// SampledImage id.
+  std::vector<uint32_t> getSampledImageConsumers(uint32_t id) const;
+
+  /// Records cons_id as a consumer of sampled_image_id.
+  void RegisterSampledImageConsumer(uint32_t sampled_image_id,
+                                    uint32_t cons_id);
+
  private:
   ValidationState_t(const ValidationState_t&);
 
@@ -192,6 +200,10 @@ class ValidationState_t {
 
   /// IDs that have been declared as forward pointers.
   std::unordered_set<uint32_t> forward_pointer_ids_;
+
+  /// Stores a vector of instructions that use the result of a given
+  /// OpSampledImage instruction.
+  std::unordered_map<uint32_t, std::vector<uint32_t>> sampled_image_consumers_;
 
   /// A map of operand IDs and their names defined by the OpName instruction
   std::unordered_map<uint32_t, std::string> operand_names_;

--- a/source/validate_id.cpp
+++ b/source/validate_id.cpp
@@ -746,7 +746,8 @@ bool idUsage::isValid<SpvOpSampledImage>(const spv_instruction_t* inst,
   // to OpPhi instructions or OpSelect instructions, or any instructions other
   // than the image lookup and query instructions specified to take an operand
   // whose type is OpTypeSampledImage.
-  std::vector<uint32_t> consumers = module_.getSampledImageConsumers(resultID);
+  const std::vector<uint32_t> consumers =
+      module_.getSampledImageConsumers(resultID);
   if (!consumers.empty()) {
     for (auto consumer_id : consumers) {
       auto consumer_instr = module_.FindDef(consumer_id);
@@ -761,6 +762,11 @@ bool idUsage::isValid<SpvOpSampledImage>(const spv_instruction_t* inst,
             << consumer_id << "'.";
         return false;
       }
+      // TODO: The following check is incomplete. We should also check that the
+      // Sampled Image is not used by instructions that should not take
+      // SampledImage as an argument. We could find the list of valid
+      // instructions by scanning for "Sampled Image" in the operand description
+      // field in the grammar file.
       if (consumer_opcode == SpvOpPhi || consumer_opcode == SpvOpSelect) {
         DIAG(resultTypeIndex)
             << "Result <id> from OpSampledImage instruction must not appear as "

--- a/source/validate_id.cpp
+++ b/source/validate_id.cpp
@@ -746,7 +746,7 @@ bool idUsage::isValid<SpvOpSampledImage>(const spv_instruction_t* inst,
   // to OpPhi instructions or OpSelect instructions, or any instructions other
   // than the image lookup and query instructions specified to take an operand
   // whose type is OpTypeSampledImage.
-  const std::vector<uint32_t> consumers =
+  std::vector<uint32_t> consumers =
       module_.getSampledImageConsumers(resultID);
   if (!consumers.empty()) {
     for (auto consumer_id : consumers) {

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -1925,6 +1925,169 @@ TEST_F(ValidateIdWithMessage, OpFunctionCallArgumentTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
 }
+
+// Valid: OpSampledImage result <id> is used in the same block by
+// OpImageSampleImplictLod
+TEST_F(ValidateIdWithMessage, OpSampledImageGood) {
+  string spirv = kGLSL450MemoryModel + R"(
+       %void             = OpTypeVoid
+          %3             = OpTypeFunction %void
+      %float             = OpTypeFloat 32
+    %v4float             = OpTypeVector %float 4
+%_ptr_Function_v4float   = OpTypePointer Function %v4float
+         %10             = OpTypeImage %float 2D 0 0 0 1 Unknown
+%_ptr_UniformConstant_10 = OpTypePointer UniformConstant %10
+        %tex             = OpVariable %_ptr_UniformConstant_10 UniformConstant
+         %14             = OpTypeSampler
+%_ptr_UniformConstant_14 = OpTypePointer UniformConstant %14
+          %s             = OpVariable %_ptr_UniformConstant_14 UniformConstant
+         %18             = OpTypeSampledImage %10
+    %v2float             = OpTypeVector %float 2
+    %float_1             = OpConstant %float 1
+         %23             = OpConstantComposite %v2float %float_1 %float_1
+       %main             = OpFunction %void None %3
+          %5             = OpLabel
+          %x             = OpVariable %_ptr_Function_v4float Function
+         %13             = OpLoad %10 %tex
+         %17             = OpLoad %14 %s
+         %19             = OpSampledImage %18 %13 %17
+         %24             = OpImageSampleImplicitLod %v4float %19 %23
+         OpStore %x %24
+         OpReturn
+         OpFunctionEnd)";
+  CompileSuccessfully(spirv.c_str());
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+// Invalid: OpSampledImage result <id> is defined in one block and used in a
+// different block.
+TEST_F(ValidateIdWithMessage, OpSampledImageUsedInDifferentBlockBad) {
+  string spirv = kGLSL450MemoryModel + R"(
+       %void             = OpTypeVoid
+          %3             = OpTypeFunction %void
+      %float             = OpTypeFloat 32
+    %v4float             = OpTypeVector %float 4
+%_ptr_Function_v4float   = OpTypePointer Function %v4float
+         %10             = OpTypeImage %float 2D 0 0 0 1 Unknown
+%_ptr_UniformConstant_10 = OpTypePointer UniformConstant %10
+        %tex             = OpVariable %_ptr_UniformConstant_10 UniformConstant
+         %14             = OpTypeSampler
+%_ptr_UniformConstant_14 = OpTypePointer UniformConstant %14
+          %s             = OpVariable %_ptr_UniformConstant_14 UniformConstant
+         %18             = OpTypeSampledImage %10
+    %v2float             = OpTypeVector %float 2
+    %float_1             = OpConstant %float 1
+    %float_2             = OpConstant %float 2
+         %23             = OpConstantComposite %v2float %float_1 %float_1
+         %24             = OpConstantComposite %v2float %float_2 %float_2
+         %40             = OpTypeBool
+         %41             = OpSpecConstantTrue %40
+       %main             = OpFunction %void None %3
+          %5             = OpLabel
+          %x             = OpVariable %_ptr_Function_v4float Function
+         %13             = OpLoad %10 %tex
+         %17             = OpLoad %14 %s
+         %25             = OpSampledImage %18 %13 %17
+         OpBranchConditional %41 %50 %70
+         %50             = OpLabel
+         %28             = OpImageSampleImplicitLod %v4float %25 %23
+         OpBranch %70
+         %70             = OpLabel
+         OpReturn
+         OpFunctionEnd)";
+  CompileSuccessfully(spirv.c_str());
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("All OpSampledImage instructions must be in the same block in "
+                "which their Result <id> are consumed. OpSampledImage Result "
+                "Type <id> '25' has a consumer in a different basic block. The "
+                "consumer instruction <id> is '28'."));
+}
+
+// Invalid: OpSampledImage result <id> is used by OpSelect
+// Note: According to the Spec, OpSelect parameters must be either a scalar or a
+// vector. Therefore, OpTypeSampledImage is an illegal parameter for OpSelect.
+// However, the OpSelect validation does not catch this today. Therefore, it is
+// caught by the OpSampledImage validation. If the OpSelect validation code is
+// updated, the error message for this test may change.
+TEST_F(ValidateIdWithMessage, OpSampledImageUsedInOpSelectBad) {
+  string spirv = kGLSL450MemoryModel + R"(
+       %void             = OpTypeVoid
+          %3             = OpTypeFunction %void
+      %float             = OpTypeFloat 32
+    %v4float             = OpTypeVector %float 4
+%_ptr_Function_v4float   = OpTypePointer Function %v4float
+         %10             = OpTypeImage %float 2D 0 0 0 1 Unknown
+%_ptr_UniformConstant_10 = OpTypePointer UniformConstant %10
+        %tex             = OpVariable %_ptr_UniformConstant_10 UniformConstant
+         %14             = OpTypeSampler
+%_ptr_UniformConstant_14 = OpTypePointer UniformConstant %14
+          %s             = OpVariable %_ptr_UniformConstant_14 UniformConstant
+         %18             = OpTypeSampledImage %10
+    %v2float             = OpTypeVector %float 2
+    %float_1             = OpConstant %float 1
+    %float_2             = OpConstant %float 2
+         %23             = OpConstantComposite %v2float %float_1 %float_1
+         %24             = OpConstantComposite %v2float %float_2 %float_2
+         %40             = OpTypeBool
+         %41             = OpSpecConstantTrue %40
+       %main             = OpFunction %void None %3
+          %5             = OpLabel
+          %x             = OpVariable %_ptr_Function_v4float Function
+         %13             = OpLoad %10 %tex
+         %17             = OpLoad %14 %s
+         %25             = OpSampledImage %18 %13 %17
+         %26             = OpSelect %18 %41 %25 %25
+         OpReturn
+         OpFunctionEnd)";
+  CompileSuccessfully(spirv.c_str());
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Result <id> from OpSampledImage instruction must not "
+                        "appear as operands of OpSelect. Found result <id> "
+                        "'25' as an operand of <id> '26'."));
+}
+
+// Invalid: OpSampledImage result <id> is used by OpPhi
+TEST_F(ValidateIdWithMessage, OpSampledImageUsedInOpPhiBad) {
+  string spirv = kGLSL450MemoryModel + R"(
+       %void             = OpTypeVoid
+          %3             = OpTypeFunction %void
+      %float             = OpTypeFloat 32
+    %v4float             = OpTypeVector %float 4
+%_ptr_Function_v4float   = OpTypePointer Function %v4float
+         %10             = OpTypeImage %float 2D 0 0 0 1 Unknown
+%_ptr_UniformConstant_10 = OpTypePointer UniformConstant %10
+        %tex             = OpVariable %_ptr_UniformConstant_10 UniformConstant
+         %14             = OpTypeSampler
+%_ptr_UniformConstant_14 = OpTypePointer UniformConstant %14
+          %s             = OpVariable %_ptr_UniformConstant_14 UniformConstant
+         %18             = OpTypeSampledImage %10
+    %v2float             = OpTypeVector %float 2
+    %float_1             = OpConstant %float 1
+    %float_2             = OpConstant %float 2
+         %23             = OpConstantComposite %v2float %float_1 %float_1
+         %24             = OpConstantComposite %v2float %float_2 %float_2
+         %40             = OpTypeBool
+         %41             = OpSpecConstantTrue %40
+       %main             = OpFunction %void None %3
+          %5             = OpLabel
+          %x             = OpVariable %_ptr_Function_v4float Function
+         %13             = OpLoad %10 %tex
+         %17             = OpLoad %14 %s
+         %25             = OpSampledImage %18 %13 %17
+         %26             = OpPhi %18 %25 %5
+         OpReturn
+         OpFunctionEnd)";
+  CompileSuccessfully(spirv.c_str());
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Result <id> from OpSampledImage instruction must not "
+                        "appear as operands of OpPhi. Found result <id> '25' "
+                        "as an operand of <id> '26'."));
+}
+
 #if 0
 TEST_F(ValidateIdWithMessage, OpFunctionCallArgumentCountBar) {
   const char *spirv = R"(
@@ -1950,7 +2113,6 @@ TEST_F(ValidateIdWithMessage, OpFunctionCallArgumentCountBar) {
 }
 #endif
 
-// TODO: OpSampledImage
 // TODO: The many things that changed with how images are used.
 // TODO: OpTextureSample
 // TODO: OpTextureSampleDref

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -1966,7 +1966,7 @@ TEST_F(ValidateIdWithMessage, OpSampledImageGood) {
 // Invalid: OpSampledImage result <id> is defined in one block and used in a
 // different block.
 TEST_F(ValidateIdWithMessage, OpSampledImageUsedInDifferentBlockBad) {
-  string spirv = kGLSL450MemoryModel + sampledImageSetup  + R"(
+  string spirv = kGLSL450MemoryModel + sampledImageSetup + R"(
 %smpld_img = OpSampledImage %sampled_image_type %image_inst %sampler_inst
 OpBranch %label_2
 %label_2 = OpLabel


### PR DESCRIPTION
This change implements the validation for usages of OpSampledImage
instruction as described in the Data Rules section of the Universal
Validation Rules of the SPIR-V Spec.

All OpSampledImage instructions must be in the same block in which their Result <id> are consumed. Result <id> from OpSampledImage instructions must not appear as operands to OpPhi instructions or OpSelect instructions, or any instructions other than the image lookup and query instructions specified to take an operand whose type is OpTypeSampledImage.