### PR TITLE
Struct limits

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -425,4 +425,7 @@ void ValidationState_t::RegisterSampledImageConsumer(uint32_t sampled_image_id,
   sampled_image_consumers_[sampled_image_id].push_back(consumer_id);
 }
 
+uint32_t ValidationState_t::getIdBound() const { return id_bound_; }
+
+void ValidationState_t::setIdBound(const uint32_t bound) { id_bound_ = bound; }
 }  /// namespace libspirv

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -78,6 +78,12 @@ class ValidationState_t {
   /// the OpName instruction
   std::string getIdName(uint32_t id) const;
 
+  /// Accessor function for ID bound.
+  uint32_t getIdBound() const;
+
+  /// Mutator function for ID bound.
+  void setIdBound(uint32_t bound);
+
   /// Like getIdName but does not display the id if the \p id has a name
   std::string getIdOrName(uint32_t id) const;
 
@@ -226,6 +232,9 @@ class ValidationState_t {
 
   /// IDs that are entry points, ie, arguments to OpEntryPoint.
   std::vector<uint32_t> entry_points_;
+
+  /// ID Bound from the Header
+  uint32_t id_bound_;
 
   AssemblyGrammar grammar_;
 

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -69,14 +69,15 @@ spv_result_t spvValidateIDs(const spv_instruction_t* pInsts,
 namespace {
 
 // TODO(umar): Validate header
-// TODO(umar): The Id bound should be validated also. But you can only do that
-// after you've seen all the instructions in the module.
 // TODO(umar): The binary parser validates the magic word, and the length of the
 // header, but nothing else.
 spv_result_t setHeader(void* user_data, spv_endianness_t endian, uint32_t magic,
                        uint32_t version, uint32_t generator, uint32_t id_bound,
                        uint32_t reserved) {
-  (void)user_data;
+  // Record the ID bound so that the validator can ensure no ID is out of bound.
+  ValidationState_t& _ = *(reinterpret_cast<ValidationState_t*>(user_data));
+  _.setIdBound(id_bound);
+
   (void)endian;
   (void)magic;
   (void)version;

--- a/source/validate_instruction.cpp
+++ b/source/validate_instruction.cpp
@@ -151,6 +151,20 @@ spv_result_t LimitCheckIdBound(ValidationState_t& _,
   return SPV_SUCCESS;
 }
 
+// Checks that the number of OpTypeStruct members is within the limit.
+spv_result_t LimitCheckStruct(ValidationState_t& _,
+                              const spv_parsed_instruction_t* inst) {
+  // Number of members is the number of operands of the instruction minus 1.
+  // One operand is the result ID.
+  uint16_t limit = 0x3fff;
+  if (SpvOpTypeStruct == inst->opcode && inst->num_operands - 1 > limit) {
+    return _.diag(SPV_ERROR_INVALID_BINARY)
+           << "Number of OpTypeStruct members (" << inst->num_operands - 1
+           << ") has exceeded the limit (16,383).";
+  }
+  return SPV_SUCCESS;
+}
+
 spv_result_t InstructionPass(ValidationState_t& _,
                              const spv_parsed_instruction_t* inst) {
   const SpvOp opcode = static_cast<SpvOp>(inst->opcode);
@@ -192,6 +206,7 @@ spv_result_t InstructionPass(ValidationState_t& _,
 
   if (auto error = CapCheck(_, inst)) return error;
   if (auto error = LimitCheckIdBound(_, inst)) return error;
+  if (auto error = LimitCheckStruct(_, inst)) return error;
 
   // All instruction checks have passed.
   return SPV_SUCCESS;

--- a/source/validate_instruction.cpp
+++ b/source/validate_instruction.cpp
@@ -131,47 +131,13 @@ spv_result_t CapCheck(ValidationState_t& _,
   return SPV_SUCCESS;
 }
 
-// Checks that the number of characters in a string doesn't exceed the limit.
-spv_result_t LimitCheckString(ValidationState_t& _,
-                              const spv_parsed_instruction_t* inst) {
-  // By definition, num_words of an operand is a 16-bit unsigned which will not
-  // exceed the limit of characters for a string literal.
-  // This function checks that a NULL termination must be found before reaching
-  // the end of the string words.
-  for (int i = 0; i < inst->num_operands; ++i) {
-    auto operand = inst->operands[i];
-    if (SPV_OPERAND_TYPE_LITERAL_STRING == operand.type) {
-      bool null_terminated = false;
-      for (auto word_i = 0; !null_terminated && word_i < operand.num_words;
-           ++word_i) {
-        const uint32_t word = inst->words[operand.offset + word_i];
-        // check if any BYTE in the word is NULL.
-        if ((word & 0x000000ff) == 0 || (word & 0x0000ff00) == 0 ||
-            (word & 0x00ff0000) == 0 || (word & 0xff000000) == 0) {
-          null_terminated = true;
-        }
-      }
-      if (!null_terminated) {
-        return _.diag(SPV_ERROR_INVALID_BINARY)
-               << "Found a string that is not null-terminated.";
-      }
-    }
-  }
-  return SPV_SUCCESS;
-}
-
 // Checks that the Resuld <id> is within the valid bound.
 spv_result_t LimitCheckIdBound(ValidationState_t& _,
                                const spv_parsed_instruction_t* inst) {
   for (int i = 0; i < inst->num_operands; ++i) {
-    auto operand = inst->operands[i];
+    const auto& operand = inst->operands[i];
     if (SPV_OPERAND_TYPE_RESULT_ID == operand.type) {
       const uint32_t result_id = inst->words[operand.offset];
-      if (result_id <= 0) {
-        return _.diag(SPV_ERROR_INVALID_BINARY)
-               << "Result <id> '" << result_id
-               << "' is not a valid ID as it must be larger than 0.";
-      }
       if (result_id >= _.getIdBound()) {
         return _.diag(SPV_ERROR_INVALID_BINARY)
                << "Result <id> '" << result_id
@@ -182,14 +148,6 @@ spv_result_t LimitCheckIdBound(ValidationState_t& _,
       break;
     }
   }
-  return SPV_SUCCESS;
-}
-
-spv_result_t LimitCheck(ValidationState_t& _,
-                        const spv_parsed_instruction_t* inst) {
-  if (auto error = LimitCheckString(_, inst)) return error;
-  if (auto error = LimitCheckIdBound(_, inst)) return error;
-
   return SPV_SUCCESS;
 }
 
@@ -233,7 +191,7 @@ spv_result_t InstructionPass(ValidationState_t& _,
   }
 
   if (auto error = CapCheck(_, inst)) return error;
-  if (auto error = LimitCheck(_, inst)) return error;
+  if (auto error = LimitCheckIdBound(_, inst)) return error;
 
   // All instruction checks have passed.
   return SPV_SUCCESS;

--- a/source/validate_instruction.cpp
+++ b/source/validate_instruction.cpp
@@ -167,10 +167,16 @@ spv_result_t LimitCheckIdBound(ValidationState_t& _,
     auto operand = inst->operands[i];
     if (SPV_OPERAND_TYPE_RESULT_ID == operand.type) {
       const uint32_t result_id = inst->words[operand.offset];
-      if (result_id > _.getIdBound()) {
-        return _.diag(SPV_ERROR_INVALID_BINARY) << "Result <id> '" << result_id
-                                                << "' exceeds the ID bound '"
-                                                << _.getIdBound() << "'.";
+      if (result_id <= 0) {
+        return _.diag(SPV_ERROR_INVALID_BINARY)
+               << "Result <id> '" << result_id
+               << "' is not a valid ID as it must be larger than 0.";
+      }
+      if (result_id >= _.getIdBound()) {
+        return _.diag(SPV_ERROR_INVALID_BINARY)
+               << "Result <id> '" << result_id
+               << "' must be less than the ID bound '" << _.getIdBound()
+               << "'.";
       }
       // Each instruction has 1 result <id>, so we can exit the loop now.
       break;

--- a/test/val/CMakeLists.txt
+++ b/test/val/CMakeLists.txt
@@ -69,3 +69,9 @@ add_spvtools_unittest(TARGET val_data
   LIBS ${SPIRV_TOOLS}
 )
 
+add_spvtools_unittest(TARGET val_limits
+	SRCS val_limits_test.cpp
+       ${VAL_TEST_COMMON_SRCS}
+  LIBS ${SPIRV_TOOLS}
+)
+

--- a/test/val/val_capability_test.cpp
+++ b/test/val/val_capability_test.cpp
@@ -1228,7 +1228,7 @@ OpFunctionEnd
 
   CompileSuccessfully(str);
 
-  // Sine we are forcing usage of <id> 64, the "id bound" in the binary header
+  // Since we are forcing usage of <id> 64, the "id bound" in the binary header
   // must be overwritten so that <id> 64 is considered within bound.
   // ID Bound is at index 3 of the binary. Set it to 65.
   OverwriteAssembledBinary(3, 65);

--- a/test/val/val_capability_test.cpp
+++ b/test/val/val_capability_test.cpp
@@ -1227,6 +1227,12 @@ OpFunctionEnd
 )";
 
   CompileSuccessfully(str);
+
+  // Sine we are forcing usage of <id> 64, the "id bound" in the binary header
+  // must be overwritten so that <id> 64 is considered within bound.
+  // ID Bound is at index 3 of the binary. Set it to 65.
+  OverwriteAssembledBinary(3, 65);
+
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 

--- a/test/val/val_fixtures.cpp
+++ b/test/val/val_fixtures.cpp
@@ -54,6 +54,14 @@ void ValidateBase<T>::CompileSuccessfully(std::string code,
 }
 
 template <typename T>
+void ValidateBase<T>::OverwriteAssembledBinary(uint32_t index, uint32_t word) {
+  ASSERT_TRUE(index < binary_->wordCount)
+      << "OverwriteAssembledBinary: The given index is larger than the binary "
+         "word count.";
+  binary_->code[index] = word;
+}
+
+template <typename T>
 spv_result_t ValidateBase<T>::ValidateInstructions(spv_target_env env) {
   return spvValidate(ScopedContext(env).context, get_const_binary(),
                      &diagnostic_);

--- a/test/val/val_fixtures.h
+++ b/test/val/val_fixtures.h
@@ -35,6 +35,12 @@ class ValidateBase : public ::testing::Test,
   void CompileSuccessfully(std::string code,
                            spv_target_env env = SPV_ENV_UNIVERSAL_1_0);
 
+  // Overwrites the word at index 'index' with the given word.
+  // For testing purposes, it is often useful to be able to manipulate the
+  // assembled binary before running the validator on it.
+  // This function overwrites the word at the given index with a new word.
+  void OverwriteAssembledBinary(uint32_t index, uint32_t word);
+
   // Performs validation on the SPIR-V code and compares the result of the
   // spvValidate function
   spv_result_t ValidateInstructions(spv_target_env env = SPV_ENV_UNIVERSAL_1_0);

--- a/test/val/val_limits_test.cpp
+++ b/test/val/val_limits_test.cpp
@@ -76,3 +76,28 @@ TEST_F(ValidateLimits, idEqualToBoundBad) {
       HasSubstr("Result <id> '64' must be less than the ID bound '64'."));
 }
 
+TEST_F(ValidateLimits, structNumMembersGood) {
+  string str = header + R"(
+%1 = OpTypeInt 32 0
+%2 = OpTypeStruct)";
+  for (int i = 0; i < 16383; ++i) {
+    str += " %1";
+  }
+  CompileSuccessfully(str.c_str());
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateLimits, structNumMembersExceededBad) {
+  string str = header + R"(
+%1 = OpTypeInt 32 0
+%2 = OpTypeStruct)";
+  for (int i = 0; i < 16384; ++i) {
+    str += " %1";
+  }
+  CompileSuccessfully(str.c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_BINARY, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Number of OpTypeStruct members (16384) has exceeded "
+                        "the limit (16,383)."));
+}
+

--- a/test/val/val_limits_test.cpp
+++ b/test/val/val_limits_test.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Validation tests for Universal Limits. (Section 2.17 of the SPIR-V Spec)
+
+#include <sstream>
+#include <string>
+#include <utility>
+
+#include "gmock/gmock.h"
+#include "unit_spirv.h"
+#include "val_fixtures.h"
+
+using ::testing::HasSubstr;
+using ::testing::MatchesRegex;
+
+using std::string;
+
+using ValidateLimits = spvtest::ValidateBase<bool>;
+
+string header = R"(
+     OpCapability Shader
+     OpMemoryModel Logical GLSL450
+)";
+
+TEST_F(ValidateLimits, idBoundBad) {
+  string str = header + R"(
+;  %i32 has ID 1
+%i32    = OpTypeInt 32 1
+%c      = OpConstant %i32 100
+
+; Fake an instruction with 64 as the result id.
+; !64 = OpConstantNull %i32
+!0x3002e !1 !64
+)";
+
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_ERROR_INVALID_BINARY, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Result <id> '64' exceeds the ID bound '3'"));
+}
+


### PR DESCRIPTION
The number of members in a struct may not exceed 16,383.
Also Adding unit tests for Struct size limit check.