### PR TITLE
Validate the number of global and local variables.

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -192,6 +192,8 @@ ValidationState_t::ValidationState_t(const spv_const_context ctx)
       module_capabilities_(),
       ordered_instructions_(),
       all_definitions_(),
+      num_global_vars_(0),
+      num_local_vars_(0),
       grammar_(ctx),
       addressing_model_(SpvAddressingModelLogical),
       memory_model_(SpvMemoryModelSimple),

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -193,6 +193,18 @@ class ValidationState_t {
   void RegisterSampledImageConsumer(uint32_t sampled_image_id,
                                     uint32_t cons_id);
 
+  /// Returns the number of Global Variables
+  uint32_t num_global_vars() { return num_global_vars_; }
+
+  /// Returns the number of Local Variables
+  uint32_t num_local_vars() { return num_local_vars_; }
+
+  /// Increments the number of Global Variables
+  void incrementNumGlobalVars() { ++num_global_vars_; }
+
+  /// Increments the number of Local Variables
+  void incrementNumLocalVars() { ++num_local_vars_; }
+
  private:
   ValidationState_t(const ValidationState_t&);
 
@@ -235,6 +247,12 @@ class ValidationState_t {
 
   /// ID Bound from the Header
   uint32_t id_bound_;
+
+  /// Number of Global Variables (Storage Class other than 'Function')
+  uint32_t num_global_vars_;
+
+  /// Number of Local Variables ('Function' Storage Class)
+  uint32_t num_local_vars_;
 
   AssemblyGrammar grammar_;
 

--- a/test/val/val_limits_test.cpp
+++ b/test/val/val_limits_test.cpp
@@ -162,3 +162,95 @@ OpFunctionEnd
                         "exceeds the limit (16383)."));
 }
 
+// Valid: module has 65,535 global variables.
+TEST_F(ValidateLimits, numGlobalVarsGood) {
+  int num_globals = 65535;
+  std::ostringstream spirv;
+  spirv << header << R"(
+     %int = OpTypeInt 32 0
+%_ptr_int = OpTypePointer Input %int
+  )";
+
+  for (int i = 0; i < num_globals; ++i) {
+    spirv << "%var_" << i << " = OpVariable %_ptr_int Input\n";
+  }
+
+  CompileSuccessfully(spirv.str());
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+// Invalid: module has 65,536 global variables (limit is 65,535).
+TEST_F(ValidateLimits, numGlobalVarsBad) {
+  int num_globals = 65536;
+  std::ostringstream spirv;
+  spirv << header << R"(
+     %int = OpTypeInt 32 0
+%_ptr_int = OpTypePointer Input %int
+  )";
+
+  for (int i = 0; i < num_globals; ++i) {
+    spirv << "%var_" << i << " = OpVariable %_ptr_int Input\n";
+  }
+
+  CompileSuccessfully(spirv.str());
+  EXPECT_EQ(SPV_ERROR_INVALID_BINARY, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Number of Global Variables (Storage Class other than "
+                        "'Function') exceeded the valid limit (65535)."));
+}
+
+// Valid: module has 524,287 local variables.
+TEST_F(ValidateLimits, numLocalVarsGood) {
+  int num_locals = 524287;
+  std::ostringstream spirv;
+  spirv << header << R"(
+ %int      = OpTypeInt 32 0
+ %_ptr_int = OpTypePointer Function %int
+ %voidt    = OpTypeVoid
+ %funct    = OpTypeFunction %voidt
+ %main     = OpFunction %voidt None %funct
+ %entry    = OpLabel
+  )";
+
+  for (int i = 0; i < num_locals; ++i) {
+    spirv << "%var_" << i << " = OpVariable %_ptr_int Function\n";
+  }
+
+  spirv << R"(
+    OpReturn
+    OpFunctionEnd
+  )";
+
+  CompileSuccessfully(spirv.str());
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+// Invalid: module has 524,288 local variables (limit is 524,287).
+TEST_F(ValidateLimits, numLocalVarsBad) {
+  int num_locals = 524288;
+  std::ostringstream spirv;
+  spirv << header << R"(
+ %int      = OpTypeInt 32 0
+ %_ptr_int = OpTypePointer Function %int
+ %voidt    = OpTypeVoid
+ %funct    = OpTypeFunction %voidt
+ %main     = OpFunction %voidt None %funct
+ %entry    = OpLabel
+  )";
+
+  for (int i = 0; i < num_locals; ++i) {
+    spirv << "%var_" << i << " = OpVariable %_ptr_int Function\n";
+  }
+
+  spirv << R"(
+    OpReturn
+    OpFunctionEnd
+  )";
+
+  CompileSuccessfully(spirv.str());
+  EXPECT_EQ(SPV_ERROR_INVALID_BINARY, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Number of local variables ('Function' Storage Class) "
+                        "exceeded the valid limit (524287)."));
+}
+


### PR DESCRIPTION
According to the Universal Limits section of the SPIR-V Spec (2.17), the
number of global variables may not exceed 65,535 and the number of local
variables may not exceed 524,287.

Also added unit tests for each one.