### PR TITLE
No need to install cmake for new osx images.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ addons:
 
 before_install:
   # Install cmake & ninja on Mac OS X.
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install cmake ninja; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install ninja; fi
   - if [[ "$BUILD_NDK" == "ON" ]]; then
       git clone --depth=1 https://github.com/urho3d/android-ndk.git $HOME/android-ndk;
       export ANDROID_NDK=$HOME/android-ndk;


### PR DESCRIPTION
It seems that the osx image has been updated and already includes ctest.
As a result, all jobs fail with this error:
Error: cmake-3.6.2 already installed