### PR TITLE
Fixing a bug in OpAccessChain validation code.

### DIFF
--- a/source/validate_id.cpp
+++ b/source/validate_id.cpp
@@ -1264,9 +1264,10 @@ bool idUsage::isValid<SpvOpAccessChain>(const spv_instruction_t* inst,
     switch (typePointedTo->opcode()) {
       case SpvOpTypeMatrix:
       case SpvOpTypeVector:
-      case SpvOpTypeArray: {
-        // In OpTypeMatrix, OpTypeArray, and OpTypeVector, word 2 is the
-        // Element Type.
+      case SpvOpTypeArray:
+      case SpvOpTypeRuntimeArray: {
+        // In OpTypeMatrix, OpTypeVector, OpTypeArray, and OpTypeRuntime Array,
+        // word 2 is the Element Type.
         typePointedTo = module_.FindDef(typePointedTo->word(2));
         break;
       }


### PR DESCRIPTION
The validation code for OpAccessChain was missing OpTypeRuntimeArray as
a possible type that can be indexed into.

This was caught by running the validator on VKCTS.

Also adding unit tests for it.