### PR TITLE
Validation code for Control Flow Nesting depth.

### DIFF
--- a/source/val/function.h
+++ b/source/val/function.h
@@ -180,6 +180,10 @@ class Function {
   /// Prints a directed graph of the CFG of the current funciton
   void PrintBlocks() const;
 
+  // Returns a reference to the construct corresponding to the given entry
+  // block.
+  Construct& FindConstructForEntryBlock(const BasicBlock* entry_block);
+
  private:
   // Computes the representation of the augmented CFG.
   // Populates augmented_successors_map_ and augmented_predecessors_map_.
@@ -189,9 +193,6 @@ class Function {
   // Returns a reference to the stored construct.
   Construct& AddConstruct(const Construct& new_construct);
 
-  // Returns a reference to the construct corresponding to the given entry
-  // block.
-  Construct& FindConstructForEntryBlock(const BasicBlock* entry_block);
 
   /// The result id of the OpLabel that defined this block
   uint32_t id_;

--- a/source/validate_cfg.cpp
+++ b/source/validate_cfg.cpp
@@ -456,9 +456,8 @@ spv_result_t PerformCfgChecks(ValidationState_t& _) {
               block_depth[merge_block] = depth;
               block_depth[continue_block] = depth + 1;
               ++depth;
-            }
-            // Header block of a selection.
-            else if (b->is_type(kBlockTypeHeader)) {
+            } else if (b->is_type(kBlockTypeHeader)) {
+              // Header block of a selection.
               const auto& construct = function.FindConstructForEntryBlock(b);
               const auto& merge_block = construct.exit_block();
               block_depth[b] = depth;

--- a/source/validate_cfg.cpp
+++ b/source/validate_cfg.cpp
@@ -403,7 +403,7 @@ spv_result_t PerformCfgChecks(ValidationState_t& _) {
     auto ignore_block = [](cbb_ptr) {};
     auto ignore_edge = [](cbb_ptr, cbb_ptr) {};
     if (!function.ordered_blocks().empty()) {
-      /// calculate dominators
+      /// Calculate dominators
       DepthFirstTraversal(
           function.first_block(), function.AugmentedCFGSuccessorsFunction(),
           ignore_block, [&](cbb_ptr b) { postorder.push_back(b); },
@@ -414,7 +414,7 @@ spv_result_t PerformCfgChecks(ValidationState_t& _) {
         edge.first->SetImmediateDominator(edge.second);
       }
 
-      /// calculate post dominators
+      /// Calculate post dominators
       DepthFirstTraversal(
           function.pseudo_exit_block(),
           function.AugmentedCFGPredecessorsFunction(), ignore_block,
@@ -424,7 +424,7 @@ spv_result_t PerformCfgChecks(ValidationState_t& _) {
       for (auto edge : postdom_edges) {
         edge.first->SetImmediatePostDominator(edge.second);
       }
-      /// calculate back edges.
+      /// Calculate back edges.
       DepthFirstTraversal(
           function.pseudo_entry_block(),
           function
@@ -432,6 +432,56 @@ spv_result_t PerformCfgChecks(ValidationState_t& _) {
           ignore_block, ignore_block, [&](cbb_ptr from, cbb_ptr to) {
             back_edges.emplace_back(from->id(), to->id());
           });
+
+      // Perform a DepthFirstTraversal that ensures CFG nesting depth is valid.
+      const int cfg_depth_limit = 1023;
+      bool cfg_depth_limit_violated = false;
+      int depth = 0;
+      std::unordered_map<cbb_ptr, int> block_depth;
+      DepthFirstTraversal(
+          function.first_block(), function.AugmentedCFGSuccessorsFunction(),
+          [&](cbb_ptr b) {
+            // Header block of a loop.
+            if (b->is_type(kBlockTypeLoop)) {
+              // at this point we can set the depth for the merge block and
+              // continue block of the loop.
+              const auto& construct = function.FindConstructForEntryBlock(b);
+              const auto& merge_block = construct.exit_block();
+              // since it's a loop, the corresponding construct is just the
+              // continue construct: A vector with 1 element.
+              const auto& continue_construct =
+                  construct.corresponding_constructs()[0];
+              const auto& continue_block = continue_construct->entry_block();
+              block_depth[b] = depth;
+              block_depth[merge_block] = depth;
+              block_depth[continue_block] = depth + 1;
+              ++depth;
+            }
+            // Header block of a selection.
+            else if (b->is_type(kBlockTypeHeader)) {
+              const auto& construct = function.FindConstructForEntryBlock(b);
+              const auto& merge_block = construct.exit_block();
+              block_depth[b] = depth;
+              block_depth[merge_block] = depth;
+              ++depth;
+            } else if (block_depth.find(b) == block_depth.end()) {
+              block_depth[b] = depth;
+            }
+            if (block_depth[b] > cfg_depth_limit) {
+              cfg_depth_limit_violated = true;
+            }
+          },
+          [&](cbb_ptr b) {
+            if (b->is_type(kBlockTypeLoop) || b->is_type(kBlockTypeHeader)) {
+              --depth;
+            }
+          },
+          ignore_edge);
+
+      if (cfg_depth_limit_violated) {
+        return _.diag(SPV_ERROR_INVALID_CFG)
+               << "Maximum Control Flow nesting depth exceeded.";
+      }
     }
     UpdateContinueConstructExitBlocks(function, back_edges);
 

--- a/test/val/val_limits_test.cpp
+++ b/test/val/val_limits_test.cpp
@@ -22,9 +22,10 @@
 #include "unit_spirv.h"
 #include "val_fixtures.h"
 
+namespace {
+
 using ::testing::HasSubstr;
 using ::testing::MatchesRegex;
-
 using std::string;
 
 using ValidateLimits = spvtest::ValidateBase<bool>;
@@ -34,7 +35,7 @@ string header = R"(
      OpMemoryModel Logical GLSL450
 )";
 
-TEST_F(ValidateLimits, idLargerThanBoundBad) {
+TEST_F(ValidateLimits, IdLargerThanBoundBad) {
   string str = header + R"(
 ;  %i32 has ID 1
 %i32    = OpTypeInt 32 1
@@ -52,7 +53,7 @@ TEST_F(ValidateLimits, idLargerThanBoundBad) {
       HasSubstr("Result <id> '64' must be less than the ID bound '3'."));
 }
 
-TEST_F(ValidateLimits, idEqualToBoundBad) {
+TEST_F(ValidateLimits, IdEqualToBoundBad) {
   string str = header + R"(
 ;  %i32 has ID 1
 %i32    = OpTypeInt 32 1
@@ -76,7 +77,7 @@ TEST_F(ValidateLimits, idEqualToBoundBad) {
       HasSubstr("Result <id> '64' must be less than the ID bound '64'."));
 }
 
-TEST_F(ValidateLimits, structNumMembersGood) {
+TEST_F(ValidateLimits, StructNumMembersGood) {
   std::ostringstream spirv;
   spirv << header << R"(
 %1 = OpTypeInt 32 0
@@ -88,7 +89,7 @@ TEST_F(ValidateLimits, structNumMembersGood) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateLimits, structNumMembersExceededBad) {
+TEST_F(ValidateLimits, StructNumMembersExceededBad) {
   std::ostringstream spirv;
   spirv << header << R"(
 %1 = OpTypeInt 32 0
@@ -104,7 +105,7 @@ TEST_F(ValidateLimits, structNumMembersExceededBad) {
 }
 
 // Valid: Switch statement has 16,383 branches.
-TEST_F(ValidateLimits, switchNumBranchesGood) {
+TEST_F(ValidateLimits, SwitchNumBranchesGood) {
   std::ostringstream spirv;
   spirv << header << R"(
 %1 = OpTypeVoid
@@ -132,7 +133,7 @@ OpFunctionEnd
 }
 
 // Invalid: Switch statement has 16,384 branches.
-TEST_F(ValidateLimits, switchNumBranchesBad) {
+TEST_F(ValidateLimits, SwitchNumBranchesBad) {
   std::ostringstream spirv;
   spirv << header << R"(
 %1 = OpTypeVoid
@@ -320,3 +321,71 @@ TEST_F(ValidateLimits, StructNestingDepthBad) {
       HasSubstr(
           "Structure Nesting Depth may not be larger than 255. Found 256."));
 }
+
+// clang-format off
+// Generates an SPIRV program with the given control flow nesting depth
+void GenerateSpirvProgramWithCfgNestingDepth(std::string& str, int depth) {
+  std::ostringstream spirv;
+  spirv << header << R"(
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %bool = OpTypeBool
+         %12 = OpConstantTrue %bool
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpBranch %6
+          %6 = OpLabel
+               OpLoopMerge %8 %9 None
+               OpBranch %10
+         %10 = OpLabel
+               OpBranchConditional %12 %7 %8
+          %7 = OpLabel
+  )";
+  int first_id = 13;
+  int last_id = 14;
+  // We already have 1 level of nesting due to the Loop.
+  int num_if_conditions = depth-1;
+  int largest_index = first_id + 2*num_if_conditions - 2;
+  for (int i = first_id; i <= largest_index; i = i + 2) {
+    spirv << "OpSelectionMerge %" << i+1 << " None" << "\n";
+    spirv << "OpBranchConditional %12 " << "%" << i << " %" << i+1 << "\n";
+    spirv << "%" << i << " = OpLabel" << "\n";
+  }
+  spirv << "OpBranch %9" << "\n";
+
+  for (int i = largest_index+1; i > last_id; i = i - 2) {
+    spirv << "%" << i << " = OpLabel" << "\n";
+    spirv << "OpBranch %" << i-2 << "\n";
+  }
+  spirv << "%" << last_id << " = OpLabel" << "\n";
+  spirv << "OpBranch %9" << "\n";
+  spirv << R"(
+    %9 = OpLabel
+    OpBranch %6
+    %8 = OpLabel
+    OpReturn
+    OpFunctionEnd
+  )";
+  str = spirv.str();
+}
+// clang-format on
+
+// Valid: Control Flow Nesting depth is 1023.
+TEST_F(ValidateLimits, ControlFlowDepthGood) {
+  std::string spirv;
+  GenerateSpirvProgramWithCfgNestingDepth(spirv, 1023);
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+// Invalid: Control Flow Nesting depth is 1024. (limit is 1023).
+TEST_F(ValidateLimits, ControlFlowDepthBad) {
+  std::string spirv;
+  GenerateSpirvProgramWithCfgNestingDepth(spirv, 1024);
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Maximum Control Flow nesting depth exceeded."));
+}
+
+}  // anonymous namespace


### PR DESCRIPTION
According to Universal Limits section (2.17) of SPIRV Spec, the
control-flow nesting depth may not exceed 1023.

We can check this by utilizing the existing DepthFirstTraversal code
that operates on the control-flow graph.

Also added 2 unit tests.