### PR TITLE
Fixes issue #517

### DIFF
--- a/source/val/construct.h
+++ b/source/val/construct.h
@@ -21,7 +21,7 @@
 namespace libspirv {
 
 enum class ConstructType {
-  kNone,
+  kNone = 0,
   /// The set of blocks dominated by a selection header, minus the set of blocks
   /// dominated by the header's merge block
   kSelection,
@@ -122,5 +122,16 @@ class Construct {
 };
 
 }  /// namespace libspirv
+
+// Override std::hash for libspirv::ConstructType so that the enum can be used
+// as a key in an unordered_map.
+namespace std {
+template <>
+struct hash<libspirv::ConstructType> {
+  size_t operator()(const libspirv::ConstructType& e) const {
+    return hash<int>()(static_cast<int>(e));
+  }
+};
+}
 
 #endif  /// LIBSPIRV_VAL_CONSTRUCT_H_

--- a/source/val/construct.h
+++ b/source/val/construct.h
@@ -20,7 +20,7 @@
 
 namespace libspirv {
 
-enum class ConstructType {
+enum class ConstructType : int {
   kNone = 0,
   /// The set of blocks dominated by a selection header, minus the set of blocks
   /// dominated by the header's merge block
@@ -122,16 +122,5 @@ class Construct {
 };
 
 }  /// namespace libspirv
-
-// Override std::hash for libspirv::ConstructType so that the enum can be used
-// as a key in an unordered_map.
-namespace std {
-template <>
-struct hash<libspirv::ConstructType> {
-  size_t operator()(const libspirv::ConstructType& e) const {
-    return hash<int>()(static_cast<int>(e));
-  }
-};
-}
 
 #endif  /// LIBSPIRV_VAL_CONSTRUCT_H_

--- a/source/val/function.cpp
+++ b/source/val/function.cpp
@@ -363,15 +363,15 @@ void Function::ComputeAugmentedCFG() {
 Construct& Function::AddConstruct(const Construct& new_construct) {
   cfg_constructs_.push_back(new_construct);
   auto& result = cfg_constructs_.back();
-  entry_block_to_construct_[std::make_pair(
-      new_construct.entry_block(), int(new_construct.type()))] = &result;
+  entry_block_to_construct_[std::make_pair(new_construct.entry_block(),
+                                           new_construct.type())] = &result;
   return result;
 }
 
 Construct& Function::FindConstructForEntryBlock(const BasicBlock* entry_block,
                                                 ConstructType type) {
   auto where =
-      entry_block_to_construct_.find(std::make_pair(entry_block, int(type)));
+      entry_block_to_construct_.find(std::make_pair(entry_block, type));
   assert(where != entry_block_to_construct_.end());
   auto construct_ptr = (*where).second;
   assert(construct_ptr);
@@ -401,8 +401,8 @@ int Function::GetBlockDepth(BasicBlock* bb) {
     block_depth_[bb] = GetBlockDepth(header);
   } else if (bb->is_type(kBlockTypeContinue)) {
     // The depth of the continue block entry point is 1 + loop header depth.
-    Construct* continue_construct = entry_block_to_construct_[std::make_pair(
-        bb, int(ConstructType::kContinue))];
+    Construct* continue_construct =
+        entry_block_to_construct_[std::make_pair(bb, ConstructType::kContinue)];
     assert(continue_construct);
     // Continue construct has only 1 corresponding construct (loop header).
     Construct* loop_construct =

--- a/source/val/function.h
+++ b/source/val/function.h
@@ -296,7 +296,7 @@ class Function {
   /// Since a basic block may be the entry block of different types of
   /// constructs, the type of the construct should also be specified in order to
   /// get the unique construct.
-  std::unordered_map<std::pair<const BasicBlock*, int>, Construct*,
+  std::unordered_map<std::pair<const BasicBlock*, ConstructType>, Construct*,
                      libspirv::pair_hash>
       entry_block_to_construct_;
 

--- a/source/val/function.h
+++ b/source/val/function.h
@@ -28,11 +28,12 @@
 
 namespace libspirv {
 
-struct pair_hash {
-  template <class T1, class T2>
-  std::size_t operator()(const std::pair<T1, T2>& p) const {
-    auto h1 = std::hash<T1>{}(p.first);
-    auto h2 = std::hash<T2>{}(p.second);
+struct bb_constr_type_pair_hash {
+  std::size_t operator()(
+      const std::pair<const BasicBlock*, ConstructType>& p) const {
+    auto h1 = std::hash<const BasicBlock*>{}(p.first);
+    auto h2 = std::hash<std::underlying_type<ConstructType>::type>{}(
+        static_cast<std::underlying_type<ConstructType>::type>(p.second));
     return (h1 ^ h2);
   }
 };
@@ -297,7 +298,7 @@ class Function {
   /// constructs, the type of the construct should also be specified in order to
   /// get the unique construct.
   std::unordered_map<std::pair<const BasicBlock*, ConstructType>, Construct*,
-                     libspirv::pair_hash>
+                     libspirv::bb_constr_type_pair_hash>
       entry_block_to_construct_;
 
   /// This map provides the header block for a given merge block.


### PR DESCRIPTION
entry_block_to_construct_ maps an entry block to its construct. The key
in this map (the entry block) is not unique, and therefore the entry for
the continue construct gets overwritten when the selection construct is
discovered.

Since a given block may be the entry block of different types of
constructs, the (basic_block, construct_type) pair should be able to
uniquely identify the construct.