### PR TITLE
Use the default Xcode image on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,7 @@ os:
 sudo: required
 dist: trusty
 
-# Use OS X 10.11 with XCode 7.2
-# https://docs.travis-ci.com/user/osx-ci-environment/#OS-X-Version
-osx_image: xcode7.2
+# Use the default Xcode environment for Xcode.
 
 env:
   # Each line is a set of environment variables set before a build.


### PR DESCRIPTION
As of November 2016, the default OSX image is Xcode 7.3.1, which works.