### PR TITLE
Built in decorations

### DIFF
--- a/source/val/decoration.h
+++ b/source/val/decoration.h
@@ -61,6 +61,7 @@ class Decoration {
 
   void set_struct_member_index(uint32_t index) { struct_member_index_ = index; }
   int struct_member_index() { return struct_member_index_; }
+  int struct_member_index() const { return struct_member_index_; }
   SpvDecoration dec_type() { return dec_type_; }
   SpvDecoration dec_type() const { return dec_type_; }
   std::vector<uint32_t>& params() { return params_; }

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -130,6 +130,17 @@ class ValidationState_t {
   std::vector<uint32_t>& entry_points() { return entry_points_; }
   const std::vector<uint32_t>& entry_points() const { return entry_points_; }
 
+  /// Adds a new interface id to the interfaces of the given entry point.
+  void RegisterInterfaceForEntryPoint(uint32_t entry_point,
+                                      uint32_t interface) {
+    entry_point_interfaces_[entry_point].push_back(interface);
+  }
+
+  /// Returns the interfaces of a given entry point.
+  std::vector<uint32_t>& entry_point_interfaces(uint32_t entry_point) {
+    return entry_point_interfaces_[entry_point];
+  }
+
   /// Inserts an <id> to the set of functions that are target of OpFunctionCall.
   void AddFunctionCallTarget(const uint32_t id) {
     function_call_targets_.insert(id);
@@ -263,6 +274,15 @@ class ValidationState_t {
     return struct_nesting_depth_[id];
   }
 
+  /// Adds the structure to the set of BuiltIn structs.
+  void RegisterBuiltInStruct(uint32_t id) {
+    builtin_structs_.insert(id);
+  }
+
+  /// Returns whether or not a structure has the BuiltIn decoration.
+  bool IsBuiltInStruct(uint32_t id) const {
+    return (builtin_structs_.find(id) != builtin_structs_.end());
+  }
  private:
   ValidationState_t(const ValidationState_t&);
 
@@ -303,6 +323,9 @@ class ValidationState_t {
   /// IDs that are entry points, ie, arguments to OpEntryPoint.
   std::vector<uint32_t> entry_points_;
 
+  /// Maps an entry point id to its interfaces.
+  std::unordered_map<uint32_t, std::vector<uint32_t>> entry_point_interfaces_;
+
   /// Functions IDs that are target of OpFunctionCall.
   std::unordered_set<uint32_t> function_call_targets_;
 
@@ -314,6 +337,9 @@ class ValidationState_t {
 
   /// Set of Local Variable IDs ('Function' Storage Class)
   std::unordered_set<uint32_t> local_vars_;
+
+  /// Set of structures that have the BuiltIn decoration.
+  std::unordered_set<uint32_t> builtin_structs_;
 
   /// Structure Nesting Depth
   std::unordered_map<uint32_t, uint32_t> struct_nesting_depth_;

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -126,8 +126,13 @@ class ValidationState_t {
   /// instruction
   bool in_block() const;
 
+  /// Registers the given <id> as an Entry Point.
+  void RegisterEntryPointId(const uint32_t id) {
+    entry_points_.push_back(id);
+    entry_point_interfaces_.insert(std::make_pair(id, std::vector<uint32_t>()));
+  }
+
   /// Returns a list of entry point function ids
-  std::vector<uint32_t>& entry_points() { return entry_points_; }
   const std::vector<uint32_t>& entry_points() const { return entry_points_; }
 
   /// Adds a new interface id to the interfaces of the given entry point.
@@ -136,9 +141,11 @@ class ValidationState_t {
     entry_point_interfaces_[entry_point].push_back(interface);
   }
 
-  /// Returns the interfaces of a given entry point.
-  std::vector<uint32_t>& entry_point_interfaces(uint32_t entry_point) {
-    return entry_point_interfaces_[entry_point];
+  /// Returns the interfaces of a given entry point. If the given id is not a
+  /// valid Entry Point id, std::out_of_range exception is thrown.
+  const std::vector<uint32_t>& entry_point_interfaces(
+      uint32_t entry_point) const {
+    return entry_point_interfaces_.at(entry_point);
   }
 
   /// Inserts an <id> to the set of functions that are target of OpFunctionCall.

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -274,13 +274,13 @@ class ValidationState_t {
     return struct_nesting_depth_[id];
   }
 
-  /// Adds the structure to the set of BuiltIn structs.
-  void RegisterBuiltInStruct(uint32_t id) {
+  /// Records that the structure type has a member decorated with a built-in.
+  void RegisterStructTypeWithBuiltInMember(uint32_t id) {
     builtin_structs_.insert(id);
   }
 
-  /// Returns whether or not a structure has the BuiltIn decoration.
-  bool IsBuiltInStruct(uint32_t id) const {
+  /// Returns true if the struct type with the given Id has a BuiltIn member.
+  bool IsStructTypeWithBuiltInMember(uint32_t id) const {
     return (builtin_structs_.find(id) != builtin_structs_.end());
   }
  private:
@@ -338,7 +338,7 @@ class ValidationState_t {
   /// Set of Local Variable IDs ('Function' Storage Class)
   std::unordered_set<uint32_t> local_vars_;
 
-  /// Set of structures that have the BuiltIn decoration.
+  /// Set of struct types that have members with a BuiltIn decoration.
   std::unordered_set<uint32_t> builtin_structs_;
 
   /// Structure Nesting Depth

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -121,10 +121,11 @@ spv_result_t ProcessInstruction(void* user_data,
   ValidationState_t& _ = *(reinterpret_cast<ValidationState_t*>(user_data));
   _.increment_instruction_count();
   if (static_cast<SpvOp>(inst->opcode) == SpvOpEntryPoint) {
-    _.entry_points().push_back(inst->words[2]);
+    const auto entry_point = inst->words[2];
+    _.entry_points().push_back(entry_point);
     // Operand 3 and later are the <id> of interfaces for the entry point.
     for (int i = 3; i < inst->num_operands; ++i) {
-      _.RegisterInterfaceForEntryPoint(inst->words[2],
+      _.RegisterInterfaceForEntryPoint(entry_point,
                                        inst->words[inst->operands[i].offset]);
     }
   }

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -122,6 +122,11 @@ spv_result_t ProcessInstruction(void* user_data,
   _.increment_instruction_count();
   if (static_cast<SpvOp>(inst->opcode) == SpvOpEntryPoint) {
     _.entry_points().push_back(inst->words[2]);
+    // Operand 3 and later are the <id> of interfaces for the entry point.
+    for (int i = 3; i < inst->num_operands; ++i) {
+      _.RegisterInterfaceForEntryPoint(inst->words[2],
+                                       inst->words[inst->operands[i].offset]);
+    }
   }
   if (static_cast<SpvOp>(inst->opcode) == SpvOpFunctionCall) {
     _.AddFunctionCallTarget(inst->words[3]);

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -122,7 +122,7 @@ spv_result_t ProcessInstruction(void* user_data,
   _.increment_instruction_count();
   if (static_cast<SpvOp>(inst->opcode) == SpvOpEntryPoint) {
     const auto entry_point = inst->words[2];
-    _.entry_points().push_back(entry_point);
+    _.RegisterEntryPointId(entry_point);
     // Operand 3 and later are the <id> of interfaces for the entry point.
     for (int i = 3; i < inst->num_operands; ++i) {
       _.RegisterInterfaceForEntryPoint(entry_point,

--- a/source/validate_id.cpp
+++ b/source/validate_id.cpp
@@ -399,7 +399,7 @@ bool idUsage::isValid<SpvOpTypeStruct>(const spv_instruction_t* inst,
       return false;
     }
     if (SpvOpTypeStruct == memberType->opcode() &&
-        module_.IsBuiltInStruct(memberTypeId)) {
+        module_.IsStructTypeWithBuiltInMember(memberTypeId)) {
       DIAG(memberTypeIndex)
           << "Structure <id> " << memberTypeId
           << " contains members with BuiltIn decoration. Therefore this "
@@ -448,7 +448,7 @@ bool idUsage::isValid<SpvOpTypeStruct>(const spv_instruction_t* inst,
     return false;
   }
   if (num_builtin_members > 0) {
-    vstate.RegisterBuiltInStruct(inst->words[1]);
+    vstate.RegisterStructTypeWithBuiltInMember(inst->words[1]);
   }
   return true;
 }

--- a/source/validate_id.cpp
+++ b/source/validate_id.cpp
@@ -31,6 +31,7 @@
 #include "val/validation_state.h"
 
 using libspirv::ValidationState_t;
+using libspirv::Decoration;
 using std::function;
 using std::ignore;
 using std::make_pair;
@@ -386,6 +387,7 @@ bool idUsage::isValid<SpvOpTypeRuntimeArray>(const spv_instruction_t* inst,
 template <>
 bool idUsage::isValid<SpvOpTypeStruct>(const spv_instruction_t* inst,
                                        const spv_opcode_desc) {
+  ValidationState_t& vstate = const_cast<ValidationState_t&>(module_);
   for (size_t memberTypeIndex = 2; memberTypeIndex < inst->words.size();
        ++memberTypeIndex) {
     auto memberTypeId = inst->words[memberTypeIndex];
@@ -396,7 +398,18 @@ bool idUsage::isValid<SpvOpTypeStruct>(const spv_instruction_t* inst,
                             << "' is not a type.";
       return false;
     }
-    if (memberType && module_.IsForwardPointer(memberTypeId)) {
+    if (SpvOpTypeStruct == memberType->opcode() &&
+        module_.IsBuiltInStruct(memberTypeId)) {
+      DIAG(memberTypeIndex)
+          << "Structure <id> " << memberTypeId
+          << " contains members with BuiltIn decoration. Therefore this "
+             "structure may not be contained as a member of another structure "
+             "type. Structure <id> "
+          << inst->words[1] << " contains structure <id> " << memberTypeId
+          << ".";
+      return false;
+    }
+    if (module_.IsForwardPointer(memberTypeId)) {
       if (memberType->opcode() != SpvOpTypePointer) {
         DIAG(memberTypeIndex) << "Found a forward reference to a non-pointer "
                                  "type in OpTypeStruct instruction.";
@@ -417,6 +430,25 @@ bool idUsage::isValid<SpvOpTypeStruct>(const spv_instruction_t* inst,
         return false;
       }
     }
+  }
+  std::unordered_set<uint32_t> built_in_members;
+  for (auto decoration : vstate.id_decorations(inst->words[1])) {
+    if (decoration.dec_type() == SpvDecorationBuiltIn &&
+        decoration.struct_member_index() != Decoration::kInvalidMember) {
+      built_in_members.insert(decoration.struct_member_index());
+    }
+  }
+  int num_struct_members = static_cast<int>(inst->words.size() - 2);
+  int num_builtin_members = static_cast<int>(built_in_members.size());
+  if (num_builtin_members > 0 && num_builtin_members != num_struct_members) {
+    DIAG(0) << "When BuiltIn decoration is applied to a structure-type member, "
+               "all members of that structure type must also be decorated with "
+               "BuiltIn. (No allowed mixing of built-in variables and "
+               "non-built-in variables within a single structure.)";
+    return false;
+  }
+  if (num_builtin_members > 0) {
+    vstate.RegisterBuiltInStruct(inst->words[1]);
   }
   return true;
 }

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -208,12 +208,13 @@ TEST_F(ValidateDecorations, MixedBuiltInDecorationsBad) {
   )";
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("When BuiltIn decoration is applied to a "
-                        "structure-type member, all members of that structure "
-                        "type must also be decorated with BuiltIn. (No allowed "
-                        "mixing of built-in variables and non-built-in "
-                        "variables within a single structure.)"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("When BuiltIn decoration is applied to a structure-type "
+                "member, all members of that structure type must also be "
+                "decorated with BuiltIn (No allowed mixing of built-in "
+                "variables and non-built-in variables within a single "
+                "structure). Structure id 1 does not meet this requirement."));
 }
 
 TEST_F(ValidateDecorations, StructContainsBuiltInStructBad) {
@@ -311,6 +312,30 @@ TEST_F(ValidateDecorations,
   EXPECT_EQ(SPV_SUCCESS, ValidateAndRetrieveValidationState());
 }
 
+TEST_F(ValidateDecorations, NoBuiltInObjectsConsumedByOpEntryPointGood) {
+  string spirv = R"(
+               OpCapability Shader
+               OpCapability Geometry
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Geometry %main "main" %in_1 %out_1
+      %int = OpTypeInt 32 1
+     %void = OpTypeVoid
+     %func = OpTypeFunction %void
+    %float = OpTypeFloat 32
+ %struct_1 = OpTypeStruct %int
+ %struct_2 = OpTypeStruct %float
+%ptr_builtin_1 = OpTypePointer Input %struct_1
+%ptr_builtin_2 = OpTypePointer Output %struct_2
+%in_1 = OpVariable %ptr_builtin_1 Input
+%out_1 = OpVariable %ptr_builtin_2 Output
+       %main = OpFunction %void None %func
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_SUCCESS, ValidateAndRetrieveValidationState());
+}
 
 }  // anonymous namespace
 

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -373,7 +373,8 @@ TEST_F(ValidateIdWithMessage, OpEntryPointInterfaceStorageClassBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpEntryPoint interfaces must be OpVariables with "
-                        "Storage Class of Input(1) or Output(3). Found 2."));
+                        "Storage Class of Input(1) or Output(3). Found Storage "
+                        "Class 2 for Entry Point id 1."));
 }
 
 TEST_F(ValidateIdWithMessage, OpExecutionModeGood) {

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -326,6 +326,56 @@ TEST_F(ValidateIdWithMessage, OpEntryPointReturnTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
 }
 
+TEST_F(ValidateIdWithMessage, OpEntryPointInterfaceIsNotVariableTypeBad) {
+  string spirv = R"(
+               OpCapability Shader
+               OpCapability Geometry
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Geometry %main "main" %ptr_builtin_1
+               OpMemberDecorate %struct_1 0 BuiltIn InvocationId
+      %int = OpTypeInt 32 1
+     %void = OpTypeVoid
+     %func = OpTypeFunction %void
+ %struct_1 = OpTypeStruct %int
+%ptr_builtin_1 = OpTypePointer Input %struct_1
+       %main = OpFunction %void None %func
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Interfaces passed to OpEntryPoint must be of type "
+                        "OpTypeVariable. Found OpTypePointer."));
+}
+
+
+TEST_F(ValidateIdWithMessage, OpEntryPointInterfaceStorageClassBad) {
+  string spirv = R"(
+               OpCapability Shader
+               OpCapability Geometry
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Geometry %main "main" %in_1
+               OpMemberDecorate %struct_1 0 BuiltIn InvocationId
+      %int = OpTypeInt 32 1
+     %void = OpTypeVoid
+     %func = OpTypeFunction %void
+ %struct_1 = OpTypeStruct %int
+%ptr_builtin_1 = OpTypePointer Uniform %struct_1
+       %in_1 = OpVariable %ptr_builtin_1 Uniform
+       %main = OpFunction %void None %func
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpEntryPoint interfaces must be OpVariables with "
+                        "Storage Class of Input(1) or Output(3). Found 2."));
+}
+
 TEST_F(ValidateIdWithMessage, OpExecutionModeGood) {
   string spirv = kGLSL450MemoryModel + R"(
      OpEntryPoint GLCompute %3 ""


### PR DESCRIPTION
When applied to a structure-type member, all members of that structure
type must also be decorated with BuiltIn. (No allowed mixing of built-in
variables and non-built-in variables within a single structure.)

When applied to a structure-type member, that structure type cannot be
contained as a member of another structure type.

There is at most one object per Storage Class that can contain a
structure type containing members decorated with BuiltIn, consumed per
entry-point.

Passes VK CTS.