### PR TITLE
Making the unit tests more robust.

### DIFF
--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -147,13 +147,13 @@ TEST_F(ValidateIdWithMessage, OpLineGood) {
 }
 TEST_F(ValidateIdWithMessage, OpLineFileBad) {
   string spirv = kGLSL450MemoryModel + R"(
-     OpLine %2 0 0
-%2 = OpTypeInt 32 0
-%3 = OpTypePointer Input %2
-%4 = OpVariable %3 Input)";
+  %1 = OpTypeInt 32 0
+     OpLine %1 0 0
+  )";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 1 has not been defined"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpLine Target <id> '1' is not an OpString."));
 }
 
 TEST_F(ValidateIdWithMessage, OpDecorateGood) {
@@ -555,7 +555,7 @@ class OpTypeArrayLengthTest
   ~OpTypeArrayLengthTest() { spvDiagnosticDestroy(diagnostic_); }
 
   // Runs spvValidate() on v, printing any errors via spvDiagnosticPrint().
-  spv_result_t Val(const SpirvVector& v, const char* expected_err = "") {
+  spv_result_t Val(const SpirvVector& v, const std::string &expected_err = "") {
     spv_const_binary_t cbinary{v.data(), v.size()};
     const auto status =
         spvValidate(ScopedContext().context, &cbinary, &diagnostic_);

--- a/test/val/val_layout_test.cpp
+++ b/test/val/val_layout_test.cpp
@@ -225,6 +225,10 @@ TEST_F(ValidateLayout, MemoryModelMissing) {
 
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(
+          "EntryPoint cannot appear before the memory model instruction"));
 }
 
 TEST_F(ValidateLayout, FunctionDefinitionBeforeDeclarationBad) {
@@ -249,6 +253,10 @@ TEST_F(ValidateLayout, FunctionDefinitionBeforeDeclarationBad) {
 
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(
+          "Function declarations must appear before function definitions."));
 }
 
 // TODO(umar): Passes but gives incorrect error message. Should be fixed after
@@ -273,6 +281,9 @@ TEST_F(ValidateLayout, LabelBeforeFunctionParameterBad) {
 
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Function parameters must only appear immediately "
+                        "after the function definition"));
 }
 
 TEST_F(ValidateLayout, FuncParameterNotImmediatlyAfterFuncBad) {
@@ -298,6 +309,9 @@ TEST_F(ValidateLayout, FuncParameterNotImmediatlyAfterFuncBad) {
 
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Function parameters must only appear immediately "
+                        "after the function definition"));
 }
 
 TEST_F(ValidateLayout, OpUndefCanAppearInTypeDeclarationSection) {

--- a/test/val/val_storage_test.cpp
+++ b/test/val/val_storage_test.cpp
@@ -21,6 +21,8 @@
 #include "gmock/gmock.h"
 #include "val_fixtures.h"
 
+using ::testing::HasSubstr;
+
 using ValidateStorage = spvtest::ValidateBase<std::string>;
 
 namespace {
@@ -63,6 +65,9 @@ TEST_F(ValidateStorage, FunctionStorageOutsideFunction) {
 
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Variables can not have a function[7] storage class "
+                        "outside of a function"));
 }
 
 TEST_F(ValidateStorage, OtherStorageOutsideFunction) {
@@ -118,6 +123,8 @@ TEST_P(ValidateStorage, OtherStorageInsideFunction) {
 
   CompileSuccessfully(ss.str());
   ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr(
+      "Variables must have a function[7] storage class inside of a function"));
 }
 
 INSTANTIATE_TEST_CASE_P(MatrixOp, ValidateStorage,
@@ -144,6 +151,8 @@ TEST_F(ValidateStorage, GenericVariableOutsideFunction) {
 )";
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_BINARY, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpVariable storage class cannot be Generic"));
 }
 
 TEST_F(ValidateStorage, GenericVariableInsideFunction) {
@@ -163,5 +172,7 @@ TEST_F(ValidateStorage, GenericVariableInsideFunction) {
 )";
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_BINARY, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpVariable storage class cannot be Generic"));
 }
 }


### PR DESCRIPTION
It is best to check the error messages of unit tests that fail
validation. This will ensure that a validation failure is due to what we
expect and not due to some secondary reason.

In this CL, I have updated the tests in val_id_test.cpp.