### PR TITLE
Check strict domination of merge block

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,8 @@ v2016.7-dev 2017-01-06
    #508: Support compilation under CYGWIN
    #517: Fix validation when continue (or case) contstruct is also the head of a
      nested control construct.
+   #551: If a merge block is reachable, it must be *strictly* dominated by its
+     header.
 
 v2016.6 2016-12-13
  - Published the C++ interface for assembling, disassembling, validation, and

--- a/source/val/construct.h
+++ b/source/val/construct.h
@@ -85,6 +85,12 @@ class Construct {
   /// constructs which do not know the back-edge block during construction
   void set_exit(BasicBlock* exit_block);
 
+  // Returns whether the exit block of this construct is the merge block
+  // for an OpLoopMerge or OpSelectionMerge
+  bool ExitBlockIsMergeBlock() const {
+    return type_ == ConstructType::kLoop || type_ == ConstructType::kSelection;
+  }
+
  private:
   /// The type of the construct
   ConstructType type_;


### PR DESCRIPTION
If a merge block is reachable, then it must be *strictly* dominated
by its header.  Until now we've allowed the header and the merge
block to be the same.

Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/551

Also: Use dominates and postdominates methods on BasicBlock to
improve readability.