### PR TITLE
Refactored validation_state, added new types

### DIFF
--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -255,6 +255,8 @@ int32_t spvOpcodeGeneratesType(SpvOp op) {
     case SpvOpTypeReserveId:
     case SpvOpTypeQueue:
     case SpvOpTypePipe:
+    case SpvOpTypePipeStorage:
+    case SpvOpTypeNamedBarrier:
       return true;
     default:
       // In particular, OpTypeForwardPointer does not generate a type,

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -16,6 +16,7 @@
 
 #include <cassert>
 
+#include "opcode.h"
 #include "val/basic_block.h"
 #include "val/construct.h"
 #include "val/function.h"
@@ -74,39 +75,12 @@ bool IsInstructionInLayoutSection(ModuleLayoutSection layout, SpvOp op) {
       }
       break;
     case kLayoutTypes:
+      if (spvOpcodeGeneratesType(op) || spvOpcodeIsConstant(op)) {
+        out = true;
+        break;
+      }
       switch (op) {
-        case SpvOpTypeVoid:
-        case SpvOpTypeBool:
-        case SpvOpTypeInt:
-        case SpvOpTypeFloat:
-        case SpvOpTypeVector:
-        case SpvOpTypeMatrix:
-        case SpvOpTypeImage:
-        case SpvOpTypeSampler:
-        case SpvOpTypeSampledImage:
-        case SpvOpTypeArray:
-        case SpvOpTypeRuntimeArray:
-        case SpvOpTypeStruct:
-        case SpvOpTypeOpaque:
-        case SpvOpTypePointer:
-        case SpvOpTypeFunction:
-        case SpvOpTypeEvent:
-        case SpvOpTypeDeviceEvent:
-        case SpvOpTypeReserveId:
-        case SpvOpTypeQueue:
-        case SpvOpTypePipe:
         case SpvOpTypeForwardPointer:
-        case SpvOpConstantTrue:
-        case SpvOpConstantFalse:
-        case SpvOpConstant:
-        case SpvOpConstantComposite:
-        case SpvOpConstantSampler:
-        case SpvOpConstantNull:
-        case SpvOpSpecConstantTrue:
-        case SpvOpSpecConstantFalse:
-        case SpvOpSpecConstant:
-        case SpvOpSpecConstantComposite:
-        case SpvOpSpecConstantOp:
         case SpvOpVariable:
         case SpvOpLine:
         case SpvOpNoLine:
@@ -119,6 +93,10 @@ bool IsInstructionInLayoutSection(ModuleLayoutSection layout, SpvOp op) {
     case kLayoutFunctionDeclarations:
     case kLayoutFunctionDefinitions:
       // NOTE: These instructions should NOT be in these layout sections
+      if (spvOpcodeGeneratesType(op) || spvOpcodeIsConstant(op)) {
+        out = false;
+        break;
+      }
       switch (op) {
         case SpvOpCapability:
         case SpvOpExtension:
@@ -137,38 +115,7 @@ bool IsInstructionInLayoutSection(ModuleLayoutSection layout, SpvOp op) {
         case SpvOpGroupDecorate:
         case SpvOpGroupMemberDecorate:
         case SpvOpDecorationGroup:
-        case SpvOpTypeVoid:
-        case SpvOpTypeBool:
-        case SpvOpTypeInt:
-        case SpvOpTypeFloat:
-        case SpvOpTypeVector:
-        case SpvOpTypeMatrix:
-        case SpvOpTypeImage:
-        case SpvOpTypeSampler:
-        case SpvOpTypeSampledImage:
-        case SpvOpTypeArray:
-        case SpvOpTypeRuntimeArray:
-        case SpvOpTypeStruct:
-        case SpvOpTypeOpaque:
-        case SpvOpTypePointer:
-        case SpvOpTypeFunction:
-        case SpvOpTypeEvent:
-        case SpvOpTypeDeviceEvent:
-        case SpvOpTypeReserveId:
-        case SpvOpTypeQueue:
-        case SpvOpTypePipe:
         case SpvOpTypeForwardPointer:
-        case SpvOpConstantTrue:
-        case SpvOpConstantFalse:
-        case SpvOpConstant:
-        case SpvOpConstantComposite:
-        case SpvOpConstantSampler:
-        case SpvOpConstantNull:
-        case SpvOpSpecConstantTrue:
-        case SpvOpSpecConstantFalse:
-        case SpvOpSpecConstant:
-        case SpvOpSpecConstantComposite:
-        case SpvOpSpecConstantOp:
           out = false;
           break;
       default:


### PR DESCRIPTION
- validation_state.cpp uses functions from opcode.h instead of in-place
switches which need to be updated.
- added new spirv 1.1 type declaration opcodes to a 'is op type
declaration' switch in opcode.cpp.