### PR TITLE
WIP: Validator: duplicate type declaration check fails silently

### DIFF
--- a/source/validate_type_unique.cpp
+++ b/source/validate_type_unique.cpp
@@ -14,8 +14,6 @@
 
 // Ensures type declarations are unique unless allowed by the specification.
 
-#include <cstdio>
-
 #include "validate.h"
 
 #include "diagnostic.h"

--- a/source/validate_type_unique.cpp
+++ b/source/validate_type_unique.cpp
@@ -40,8 +40,7 @@ spv_result_t TypeUniquePass(ValidationState_t& _,
     if (!_.RegisterUniqueTypeDeclaration(*inst)) {
       // TODO(atgoo@github) Error logging temporarily disabled because it's
       // failing vulkancts tests. Message in the diagnostics is for unit tests.
-      fprintf(stderr, "WARNING: Duplicate non-aggregate type declarations are"
-              " not allowed. Opcode %d\n", inst->opcode);
+      // See https://github.com/KhronosGroup/SPIRV-Tools/issues/559
       // return _.diag(SPV_ERROR_INVALID_DATA)
       return _.diag(SPV_SUCCESS)
           << "Duplicate non-aggregate type declarations are not allowed."

--- a/source/validate_type_unique.cpp
+++ b/source/validate_type_unique.cpp
@@ -14,6 +14,8 @@
 
 // Ensures type declarations are unique unless allowed by the specification.
 
+#include <cstdio>
+
 #include "validate.h"
 
 #include "diagnostic.h"
@@ -36,7 +38,12 @@ spv_result_t TypeUniquePass(ValidationState_t& _,
     }
 
     if (!_.RegisterUniqueTypeDeclaration(*inst)) {
-      return _.diag(SPV_ERROR_INVALID_DATA)
+      // TODO(atgoo@github) Error logging temporarily disabled because it's
+      // failing vulkancts tests. Message in the diagnostics is for unit tests.
+      fprintf(stderr, "WARNING: Duplicate non-aggregate type declarations are"
+              " not allowed. Opcode %d\n", inst->opcode);
+      // return _.diag(SPV_ERROR_INVALID_DATA)
+      return _.diag(SPV_SUCCESS)
           << "Duplicate non-aggregate type declarations are not allowed."
           << " Opcode: " << inst->opcode;
     }

--- a/test/val/val_type_unique_test.cpp
+++ b/test/val/val_type_unique_test.cpp
@@ -29,9 +29,9 @@ using std::string;
 using ValidateTypeUnique = spvtest::ValidateBase<bool>;
 
 // TODO(atgoo@github) Error logging temporarily disabled because it's failing
-// vulkancts tests.
-// const spv_result_t g_duplicate_type_error = SPV_ERROR_INVALID_DATA;
-const spv_result_t g_duplicate_type_error = SPV_SUCCESS;
+// vulkancts tests. See https://github.com/KhronosGroup/SPIRV-Tools/issues/559
+// const spv_result_t kDuplicateTypeError = SPV_ERROR_INVALID_DATA;
+const spv_result_t kDuplicateTypeError = SPV_SUCCESS;
 
 const string& GetHeader() {
   static const string header = R"(
@@ -106,7 +106,7 @@ TEST_F(ValidateTypeUnique, duplicate_void) {
 %boolt2 = OpTypeVoid
 )" + GetBody();
   CompileSuccessfully(str.c_str());
-  ASSERT_EQ(g_duplicate_type_error, ValidateInstructions());
+  ASSERT_EQ(kDuplicateTypeError, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr(GetErrorString(SpvOpTypeVoid)));
 }
 
@@ -115,7 +115,7 @@ TEST_F(ValidateTypeUnique, duplicate_bool) {
 %boolt2 = OpTypeBool
 )" + GetBody();
   CompileSuccessfully(str.c_str());
-  ASSERT_EQ(g_duplicate_type_error, ValidateInstructions());
+  ASSERT_EQ(kDuplicateTypeError, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr(GetErrorString(SpvOpTypeBool)));
 }
 
@@ -124,7 +124,7 @@ TEST_F(ValidateTypeUnique, duplicate_int) {
 %uintt2 = OpTypeInt 32 0
 )" + GetBody();
   CompileSuccessfully(str.c_str());
-  ASSERT_EQ(g_duplicate_type_error, ValidateInstructions());
+  ASSERT_EQ(kDuplicateTypeError, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr(GetErrorString(SpvOpTypeInt)));
 }
 
@@ -133,7 +133,7 @@ TEST_F(ValidateTypeUnique, duplicate_float) {
 %floatt2 = OpTypeFloat 32
 )" + GetBody();
   CompileSuccessfully(str.c_str());
-  ASSERT_EQ(g_duplicate_type_error, ValidateInstructions());
+  ASSERT_EQ(kDuplicateTypeError, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr(GetErrorString(SpvOpTypeFloat)));
 }
 
@@ -142,7 +142,7 @@ TEST_F(ValidateTypeUnique, duplicate_vec3) {
 %vec3t2 = OpTypeVector %floatt 3
 )" + GetBody();
   CompileSuccessfully(str.c_str());
-  ASSERT_EQ(g_duplicate_type_error, ValidateInstructions());
+  ASSERT_EQ(kDuplicateTypeError, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr(GetErrorString(SpvOpTypeVector)));
 }
@@ -152,7 +152,7 @@ TEST_F(ValidateTypeUnique, duplicate_mat33) {
 %mat33t2 = OpTypeMatrix %vec3t 3
 )" + GetBody();
   CompileSuccessfully(str.c_str());
-  ASSERT_EQ(g_duplicate_type_error, ValidateInstructions());
+  ASSERT_EQ(kDuplicateTypeError, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr(GetErrorString(SpvOpTypeMatrix)));
 }
@@ -162,7 +162,7 @@ TEST_F(ValidateTypeUnique, duplicate_vfunc) {
 %vfunct2 = OpTypeFunction %voidt
 )" + GetBody();
   CompileSuccessfully(str.c_str());
-  ASSERT_EQ(g_duplicate_type_error, ValidateInstructions());
+  ASSERT_EQ(kDuplicateTypeError, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr(GetErrorString(SpvOpTypeFunction)));
 }
@@ -179,8 +179,7 @@ OpMemoryModel Physical32 OpenCL
 %ps2 = OpTypePipeStorage
 )";
   CompileSuccessfully(str.c_str(), SPV_ENV_UNIVERSAL_1_1);
-  ASSERT_EQ(g_duplicate_type_error,
-            ValidateInstructions(SPV_ENV_UNIVERSAL_1_1));
+  ASSERT_EQ(kDuplicateTypeError, ValidateInstructions(SPV_ENV_UNIVERSAL_1_1));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr(GetErrorString(SpvOpTypePipeStorage)));
 }
@@ -196,8 +195,7 @@ OpMemoryModel Physical32 OpenCL
 %nb2 = OpTypeNamedBarrier
 )";
   CompileSuccessfully(str.c_str(), SPV_ENV_UNIVERSAL_1_1);
-  ASSERT_EQ(g_duplicate_type_error,
-            ValidateInstructions(SPV_ENV_UNIVERSAL_1_1));
+  ASSERT_EQ(kDuplicateTypeError, ValidateInstructions(SPV_ENV_UNIVERSAL_1_1));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr(GetErrorString(SpvOpTypeNamedBarrier)));
 }

--- a/test/val/val_type_unique_test.cpp
+++ b/test/val/val_type_unique_test.cpp
@@ -25,9 +25,13 @@ namespace {
 using ::testing::HasSubstr;
 
 using std::string;
-using std::pair;
 
 using ValidateTypeUnique = spvtest::ValidateBase<bool>;
+
+// TODO(atgoo@github) Error logging temporarily disabled because it's failing
+// vulkancts tests.
+// const spv_result_t g_duplicate_type_error = SPV_ERROR_INVALID_DATA;
+const spv_result_t g_duplicate_type_error = SPV_SUCCESS;
 
 const string& GetHeader() {
   static const string header = R"(
@@ -102,7 +106,7 @@ TEST_F(ValidateTypeUnique, duplicate_void) {
 %boolt2 = OpTypeVoid
 )" + GetBody();
   CompileSuccessfully(str.c_str());
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  ASSERT_EQ(g_duplicate_type_error, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr(GetErrorString(SpvOpTypeVoid)));
 }
 
@@ -111,7 +115,7 @@ TEST_F(ValidateTypeUnique, duplicate_bool) {
 %boolt2 = OpTypeBool
 )" + GetBody();
   CompileSuccessfully(str.c_str());
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  ASSERT_EQ(g_duplicate_type_error, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr(GetErrorString(SpvOpTypeBool)));
 }
 
@@ -120,7 +124,7 @@ TEST_F(ValidateTypeUnique, duplicate_int) {
 %uintt2 = OpTypeInt 32 0
 )" + GetBody();
   CompileSuccessfully(str.c_str());
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  ASSERT_EQ(g_duplicate_type_error, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr(GetErrorString(SpvOpTypeInt)));
 }
 
@@ -129,7 +133,7 @@ TEST_F(ValidateTypeUnique, duplicate_float) {
 %floatt2 = OpTypeFloat 32
 )" + GetBody();
   CompileSuccessfully(str.c_str());
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  ASSERT_EQ(g_duplicate_type_error, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr(GetErrorString(SpvOpTypeFloat)));
 }
 
@@ -138,7 +142,7 @@ TEST_F(ValidateTypeUnique, duplicate_vec3) {
 %vec3t2 = OpTypeVector %floatt 3
 )" + GetBody();
   CompileSuccessfully(str.c_str());
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  ASSERT_EQ(g_duplicate_type_error, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr(GetErrorString(SpvOpTypeVector)));
 }
@@ -148,7 +152,7 @@ TEST_F(ValidateTypeUnique, duplicate_mat33) {
 %mat33t2 = OpTypeMatrix %vec3t 3
 )" + GetBody();
   CompileSuccessfully(str.c_str());
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  ASSERT_EQ(g_duplicate_type_error, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr(GetErrorString(SpvOpTypeMatrix)));
 }
@@ -158,7 +162,7 @@ TEST_F(ValidateTypeUnique, duplicate_vfunc) {
 %vfunct2 = OpTypeFunction %voidt
 )" + GetBody();
   CompileSuccessfully(str.c_str());
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  ASSERT_EQ(g_duplicate_type_error, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr(GetErrorString(SpvOpTypeFunction)));
 }
@@ -175,7 +179,7 @@ OpMemoryModel Physical32 OpenCL
 %ps2 = OpTypePipeStorage
 )";
   CompileSuccessfully(str.c_str(), SPV_ENV_UNIVERSAL_1_1);
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA,
+  ASSERT_EQ(g_duplicate_type_error,
             ValidateInstructions(SPV_ENV_UNIVERSAL_1_1));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr(GetErrorString(SpvOpTypePipeStorage)));
@@ -192,7 +196,7 @@ OpMemoryModel Physical32 OpenCL
 %nb2 = OpTypeNamedBarrier
 )";
   CompileSuccessfully(str.c_str(), SPV_ENV_UNIVERSAL_1_1);
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA,
+  ASSERT_EQ(g_duplicate_type_error,
             ValidateInstructions(SPV_ENV_UNIVERSAL_1_1));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr(GetErrorString(SpvOpTypeNamedBarrier)));


### PR DESCRIPTION
Validator check for uniqueness of type declarations
(commit 0e9c24fdd112e7742b9b5dcff35aee32e71a66fd)
was causing failures in vulkancts tests.

See https://github.com/KhronosGroup/SPIRV-Tools/issues/559

This check will now fail silently (return SPV_SUCCESS even if it fails).