### PR TITLE
Validator: unique type check allows runtime arrays

### DIFF
--- a/source/validate_type_unique.cpp
+++ b/source/validate_type_unique.cpp
@@ -30,7 +30,8 @@ spv_result_t TypeUniquePass(ValidationState_t& _,
                             const spv_parsed_instruction_t* inst) {
   const SpvOp opcode = static_cast<SpvOp>(inst->opcode);
   if (spvOpcodeGeneratesType(opcode)) {
-    if (opcode == SpvOpTypeArray || opcode == SpvOpTypeStruct) {
+    if (opcode == SpvOpTypeArray || opcode == SpvOpTypeRuntimeArray ||
+        opcode == SpvOpTypeStruct) {
       // Duplicate declarations of aggregates are allowed.
       return SPV_SUCCESS;
     }

--- a/test/val/val_type_unique_test.cpp
+++ b/test/val/val_type_unique_test.cpp
@@ -59,6 +59,8 @@ OpMemoryModel Logical GLSL450
 %struct2 = OpTypeStruct %floatt %floatt %vec3t
 %false = OpConstantFalse %boolt
 %true = OpConstantTrue %boolt
+%runtime_arrayt = OpTypeRuntimeArray %floatt
+%runtime_arrayt2 = OpTypeRuntimeArray %floatt
 )";
 
   return header;


### PR DESCRIPTION
OpTypeRuntimeArray is an aggregate and therefore can have duplicate
declarations.