### PR TITLE
Validator disallows unsupported Vulkan capabilities

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -197,6 +197,7 @@ set(SPIRV_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/text_handler.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/validate.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/validate_cfg.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/validate_capability.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/validate_id.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/validate_instruction.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/validate_datarules.cpp

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -171,6 +171,7 @@ spv_result_t ProcessInstruction(void* user_data,
   }
 
   DebugInstructionPass(_, inst);
+  if (auto error = CapabilityPass(_, inst)) return error;
   if (auto error = DataRulesPass(_, inst)) return error;
   if (auto error = IdPass(_, inst)) return error;
   if (auto error = ModuleLayoutPass(_, inst)) return error;

--- a/source/validate.h
+++ b/source/validate.h
@@ -159,6 +159,12 @@ spv_result_t ValidateDecorations(ValidationState_t& _);
 /// (see section 2.8 Types and Variables)
 spv_result_t TypeUniquePass(ValidationState_t& _,
                             const spv_parsed_instruction_t* inst);
+
+// Validates that capability declarations use operands allowed in the current
+// context.
+spv_result_t CapabilityPass(ValidationState_t& _,
+                            const spv_parsed_instruction_t* inst);
+
 }  // namespace libspirv
 
 /// @brief Validate the ID usage of the instruction stream

--- a/source/validate_capability.cpp
+++ b/source/validate_capability.cpp
@@ -84,6 +84,9 @@ bool IsEnabledByExtension(ValidationState_t& _, uint32_t capability) {
       SPV_OPERAND_TYPE_CAPABILITY, capability, &operand_desc);
 
   assert(lookup_result == SPV_SUCCESS);
+  if (!lookup_result)
+    return false;
+
   assert(operand_desc);
 
   if (operand_desc->extensions.IsEmpty())

--- a/source/validate_capability.cpp
+++ b/source/validate_capability.cpp
@@ -84,7 +84,7 @@ bool IsEnabledByExtension(ValidationState_t& _, uint32_t capability) {
       SPV_OPERAND_TYPE_CAPABILITY, capability, &operand_desc);
 
   assert(lookup_result == SPV_SUCCESS);
-  if (!lookup_result)
+  if (lookup_result != SPV_SUCCESS)
     return false;
 
   assert(operand_desc);

--- a/source/validate_capability.cpp
+++ b/source/validate_capability.cpp
@@ -79,14 +79,12 @@ bool IsSupportOptionalVulkan_1_0(uint32_t capability) {
 
 // Checks if |capability| was enabled by extension.
 bool IsEnabledByExtension(ValidationState_t& _, uint32_t capability) {
-  spv_operand_desc operand_desc;
-  const spv_result_t lookup_result = _.grammar().lookupOperand(
+  spv_operand_desc operand_desc = nullptr;
+  _.grammar().lookupOperand(
       SPV_OPERAND_TYPE_CAPABILITY, capability, &operand_desc);
 
-  assert(lookup_result == SPV_SUCCESS);
-  if (lookup_result != SPV_SUCCESS)
-    return false;
-
+  // operand_desc is expected to be not null, otherwise validator would have
+  // failed at an earlier stage. This 'assert' is 'just in case'.
   assert(operand_desc);
 
   if (operand_desc->extensions.IsEmpty())

--- a/source/validate_capability.cpp
+++ b/source/validate_capability.cpp
@@ -1,0 +1,119 @@
+// Copyright (c) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Ensures type declarations are unique unless allowed by the specification.
+
+#include "validate.h"
+
+#include <cassert>
+#include <unordered_set>
+
+#include "diagnostic.h"
+#include "opcode.h"
+#include "val/instruction.h"
+#include "val/validation_state.h"
+
+namespace libspirv {
+
+namespace {
+
+bool IsSupportGuaranteedVulkan_1_0(uint32_t capability) {
+  switch (capability) {
+    case SpvCapabilityMatrix:
+    case SpvCapabilityShader:
+    case SpvCapabilityInputAttachment:
+    case SpvCapabilitySampled1D:
+    case SpvCapabilityImage1D:
+    case SpvCapabilitySampledBuffer:
+    case SpvCapabilityImageBuffer:
+    case SpvCapabilityImageQuery:
+    case SpvCapabilityDerivativeControl:
+      return true;
+  }
+  return false;
+}
+
+bool IsSupportOptionalVulkan_1_0(uint32_t capability) {
+  switch (capability) {
+    case SpvCapabilityGeometry:
+    case SpvCapabilityTessellation:
+    case SpvCapabilityFloat64:
+    case SpvCapabilityInt64:
+    case SpvCapabilityInt16:
+    case SpvCapabilityTessellationPointSize:
+    case SpvCapabilityGeometryPointSize:
+    case SpvCapabilityImageGatherExtended:
+    case SpvCapabilityStorageImageMultisample:
+    case SpvCapabilityUniformBufferArrayDynamicIndexing:
+    case SpvCapabilitySampledImageArrayDynamicIndexing:
+    case SpvCapabilityStorageBufferArrayDynamicIndexing:
+    case SpvCapabilityStorageImageArrayDynamicIndexing:
+    case SpvCapabilityClipDistance:
+    case SpvCapabilityCullDistance:
+    case SpvCapabilityImageCubeArray:
+    case SpvCapabilitySampleRateShading:
+    case SpvCapabilitySparseResidency:
+    case SpvCapabilityMinLod:
+    case SpvCapabilitySampledCubeArray:
+    case SpvCapabilityImageMSArray:
+    case SpvCapabilityStorageImageExtendedFormats:
+    case SpvCapabilityInterpolationFunction:
+    case SpvCapabilityStorageImageReadWithoutFormat:
+    case SpvCapabilityStorageImageWriteWithoutFormat:
+    case SpvCapabilityMultiViewport:
+      return true;
+  }
+  return false;
+}
+
+}  // namespace
+
+// Validates that capability declarations use operands allowed in the current
+// context.
+spv_result_t CapabilityPass(ValidationState_t& _,
+                           const spv_parsed_instruction_t* inst) {
+  const SpvOp opcode = static_cast<SpvOp>(inst->opcode);
+  if (opcode != SpvOpCapability)
+    return SPV_SUCCESS;
+
+  if (inst->num_operands != 1) {
+    return _.diag(SPV_ERROR_INVALID_CAPABILITY)
+        << "OpCapability must have exactly one operand.";
+  }
+
+  const spv_parsed_operand_t& operand = inst->operands[0];
+
+  if (operand.num_words != 1) {
+    return _.diag(SPV_ERROR_INVALID_CAPABILITY)
+        << "OpCapability operand must consist of exactly one word.";
+  }
+
+  assert(operand.offset < inst->num_words);
+
+  const uint32_t capability = inst->words[operand.offset];
+
+  const auto env = _.context()->target_env;
+  if (env == SPV_ENV_VULKAN_1_0) {
+    if (!IsSupportGuaranteedVulkan_1_0(capability) &&
+        !IsSupportOptionalVulkan_1_0(capability)) {
+      return _.diag(SPV_ERROR_INVALID_CAPABILITY)
+          << "Capability operand not allowed by Vulkan specification"
+          << " (SpvCapability " << capability <<").";
+    }
+  }
+
+  return SPV_SUCCESS;
+}
+
+}  // namespace libspirv

--- a/source/validate_capability.cpp
+++ b/source/validate_capability.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Ensures type declarations are unique unless allowed by the specification.
+// Validates OpCapability instruction.
 
 #include "validate.h"
 
@@ -117,8 +117,9 @@ spv_result_t CapabilityPass(ValidationState_t& _,
         !IsSupportOptionalVulkan_1_0(capability) &&
         !IsEnabledByExtension(_, capability)) {
       return _.diag(SPV_ERROR_INVALID_CAPABILITY)
-          << "Capability operand not allowed by Vulkan 1.0 specification "
-          << "(or requires extension): SpvCapability " << capability;
+          << "Capability value " << capability
+          << " is not allowed by Vulkan 1.0 specification"
+          << " (or requires extension)";
     }
   }
 

--- a/test/val/val_capability_test.cpp
+++ b/test/val/val_capability_test.cpp
@@ -1586,7 +1586,7 @@ OpMemoryModel Logical GLSL450
   EXPECT_EQ(SPV_ERROR_INVALID_CAPABILITY,
             ValidateInstructions(SPV_ENV_VULKAN_1_0));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Capability operand not allowed by Vulkan 1.0"));
+              HasSubstr("Capability value 5 is not allowed by Vulkan 1.0"));
 }
 
 TEST_F(ValidateCapability, Vulkan10EnabledByExtension) {
@@ -1618,7 +1618,7 @@ OpDecorate %intt BuiltIn PointSize
   EXPECT_EQ(SPV_ERROR_INVALID_CAPABILITY,
             ValidateInstructions(SPV_ENV_VULKAN_1_0));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Capability operand not allowed by Vulkan 1.0"));
+              HasSubstr("Capability value 4427 is not allowed by Vulkan 1.0"));
 }
 
 }  // namespace anonymous

--- a/test/val/val_capability_test.cpp
+++ b/test/val/val_capability_test.cpp
@@ -191,7 +191,7 @@ const vector<string>& AllCapabilities() {
   return *r;
 }
 
-const vector<string>& AllV10Capabilities() {
+const vector<string>& AllSpirV10Capabilities() {
   static const auto r = new vector<string>{
     "",
     "Matrix",
@@ -247,6 +247,47 @@ const vector<string>& AllV10Capabilities() {
     "InterpolationFunction",
     "TransformFeedback",
     "GeometryStreams",
+    "StorageImageReadWithoutFormat",
+    "StorageImageWriteWithoutFormat",
+    "MultiViewport"};
+  return *r;
+}
+
+const vector<string>& AllVulkan10Capabilities() {
+  static const auto r = new vector<string>{
+    "",
+    "Matrix",
+    "Shader",
+    "InputAttachment",
+    "Sampled1D",
+    "Image1D",
+    "SampledBuffer",
+    "ImageBuffer",
+    "ImageQuery",
+    "DerivativeControl",
+    "Geometry",
+    "Tessellation",
+    "Float64",
+    "Int64",
+    "Int16",
+    "TessellationPointSize",
+    "GeometryPointSize",
+    "ImageGatherExtended",
+    "StorageImageMultisample",
+    "UniformBufferArrayDynamicIndexing",
+    "SampledImageArrayDynamicIndexing",
+    "StorageBufferArrayDynamicIndexing",
+    "StorageImageArrayDynamicIndexing",
+    "ClipDistance",
+    "CullDistance",
+    "ImageCubeArray",
+    "SampleRateShading",
+    "SparseResidency",
+    "MinLod",
+    "SampledCubeArray",
+    "ImageMSArray",
+    "StorageImageExtendedFormats",
+    "InterpolationFunction",
     "StorageImageReadWithoutFormat",
     "StorageImageWriteWithoutFormat",
     "MultiViewport"};
@@ -1027,7 +1068,7 @@ make_pair(string(kGLSL450MemoryModel) +
 // clang-format on
 INSTANTIATE_TEST_CASE_P(
     DecorationSpecId, ValidateCapability,
-    Combine(ValuesIn(AllV10Capabilities()),
+    Combine(ValuesIn(AllSpirV10Capabilities()),
             Values(make_pair(string(kOpenCLMemoryModel) +
                                  "OpEntryPoint Vertex %func \"shader\" \n" +
                                  "OpDecorate %1 SpecId 1\n"
@@ -1296,46 +1337,47 @@ make_pair(string(kOpenCLMemoryModel) +
 // See https://github.com/KhronosGroup/SPIRV-Tools/issues/365
 INSTANTIATE_TEST_CASE_P(BuiltIn, ValidateCapabilityVulkan10,
                         Combine(
-                            // Vulkan 1.0 is based on SPIR-V 1.0
-                            ValuesIn(AllV10Capabilities()),
+                            // All capabilities to try.
+                            ValuesIn(AllSpirV10Capabilities()),
                             Values(
 make_pair(string(kGLSL450MemoryModel) +
           "OpEntryPoint Vertex %func \"shader\" \n" +
           "OpDecorate %intt BuiltIn PointSize\n"
           "%intt = OpTypeInt 32 0\n" + string(kVoidFVoid),
-          AllV10Capabilities()),
+          // Capabilities which should succeed.
+          AllVulkan10Capabilities()),
 make_pair(string(kGLSL450MemoryModel) +
           "OpEntryPoint Vertex %func \"shader\" \n" +
           "OpDecorate %intt BuiltIn ClipDistance\n"
           "%intt = OpTypeInt 32 0\n" + string(kVoidFVoid),
-          AllV10Capabilities()),
+          AllVulkan10Capabilities()),
 make_pair(string(kGLSL450MemoryModel) +
           "OpEntryPoint Vertex %func \"shader\" \n" +
           "OpDecorate %intt BuiltIn CullDistance\n"
           "%intt = OpTypeInt 32 0\n" + string(kVoidFVoid),
-          AllV10Capabilities())
+          AllVulkan10Capabilities())
 )),);
 
 INSTANTIATE_TEST_CASE_P(BuiltIn, ValidateCapabilityOpenGL40,
                         Combine(
                             // OpenGL 4.0 is based on SPIR-V 1.0
-                            ValuesIn(AllV10Capabilities()),
+                            ValuesIn(AllSpirV10Capabilities()),
                             Values(
 make_pair(string(kGLSL450MemoryModel) +
           "OpEntryPoint Vertex %func \"shader\" \n" +
           "OpDecorate %intt BuiltIn PointSize\n"
           "%intt = OpTypeInt 32 0\n" + string(kVoidFVoid),
-          AllV10Capabilities()),
+          AllSpirV10Capabilities()),
 make_pair(string(kGLSL450MemoryModel) +
           "OpEntryPoint Vertex %func \"shader\" \n" +
           "OpDecorate %intt BuiltIn ClipDistance\n"
           "%intt = OpTypeInt 32 0\n" + string(kVoidFVoid),
-          AllV10Capabilities()),
+          AllSpirV10Capabilities()),
 make_pair(string(kGLSL450MemoryModel) +
           "OpEntryPoint Vertex %func \"shader\" \n" +
           "OpDecorate %intt BuiltIn CullDistance\n"
           "%intt = OpTypeInt 32 0\n" + string(kVoidFVoid),
-          AllV10Capabilities())
+          AllSpirV10Capabilities())
 )),);
 
 // TODO(umar): Selection Control


### PR DESCRIPTION
If environment is SPV_ENV_VULKAN_1_0, dissalow OpCapability operands
which are not supported by Vulkan 1.0.

See https://github.com/KhronosGroup/SPIRV-Tools/issues/572