### PR TITLE
Only try to create the directory tree if the output file is not on the current directory

### DIFF
--- a/utils/update_build_version.py
+++ b/utils/update_build_version.py
@@ -127,7 +127,9 @@ def main():
         sys.exit(1)
 
     output_file = sys.argv[2]
-    mkdir_p(os.path.dirname(output_file))
+    output_path = os.path.dirname(output_file)
+    if output_path:
+        mkdir_p(output_path)
 
     software_version = deduce_software_version(sys.argv[1])
     new_content = '"{}", "SPIRV-Tools {} {}"\n'.format(


### PR DESCRIPTION
I'm trying to run the update_build_version.py script, and it is failing if I try to generate the output file to the current directory.

With this, it will only try to create the directory tree if it is not empty (the result of os.path.dirname("file_in_current_dir")).