### PR TITLE
Assembler supports Op999 syntax for unknown instructions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ v2016.7-dev 2017-01-06
      flow.
  - Optimizer: Add flattening of decoration groups.  Fixes #602
  - Optimizer: Add Id compaction (minimize Id bound).  Fixes #624
+ - Assembler: Support assembly of unknown instructions
  - Assembler: Add option to preserve numeric ids. Fixes #625
  - Add build target spirv-tools-vimsyntax to generate spvasm.vim, a SPIR-V
    assembly syntax file for Vim.

--- a/source/text_handler.cpp
+++ b/source/text_handler.cpp
@@ -135,13 +135,15 @@ spv_result_t getWord(spv_text text, spv_position position, std::string* word) {
 }
 
 // Returns true if the characters in the text as position represent
-// the start of an Opcode.
+// the start of an Opcode or Op followed by digits.  The latter case
+// supports assembly of unknown instructions.
 bool startsWithOp(spv_text text, spv_position position) {
   if (text->length < position->index + 3) return false;
   char ch0 = text->str[position->index];
   char ch1 = text->str[position->index + 1];
   char ch2 = text->str[position->index + 2];
-  return ('O' == ch0 && 'p' == ch1 && ('A' <= ch2 && ch2 <= 'Z'));
+  return ('O' == ch0 && 'p' == ch1 &&
+          (('A' <= ch2 && ch2 <= 'Z') || ('0' <= ch2 && ch2 <= '9')));
 }
 
 }  // anonymous namespace

--- a/source/text_handler.h
+++ b/source/text_handler.h
@@ -138,6 +138,9 @@ class AssemblyContext {
   spv_result_t getWord(std::string* word, spv_position next_position);
 
   // Returns true if the next word in the input is the start of a new Opcode.
+  // This permits both known instructions such as "OpTypeVoid" and also
+  // special syntax for an unknown opcode such as "Op999" for an opcode with
+  // numeric value 999.
   bool startsWithOp();
 
   // Returns true if the next word in the input is the start of a new

--- a/syntax.md
+++ b/syntax.md
@@ -24,6 +24,25 @@ Here is an example:
      OpFunctionEnd
 ```
 
+## Instruction set depends on target environment
+
+The instruction set understood by the assembler is determined by two factors:
+the version of the SPIRV-Headers compiled with SPIRV-Tools, and the target
+environment selected, e.g. SPIR-V 1.0 or SPIR-V 1.1.
+
+The instruction syntax is determined by the `spirv.core.grammar.json` file
+in the version-specific directory of SPIRV-Headers.  For example, if
+a target environment of SPIR-V 1.1 is selected, then we will use the
+instructions listed in SPIRV-Headers file
+`include/spirv/1.1/spirv.core.grammar.json`.
+
+A target environment may correspond to a client API.  In that case the
+environment specification for that client API version will determine the
+underying version of SPIR-V to use.  For example, Vulkan 1.0 specifies
+that SPIR-V 1.0 should be used.
+
+## Instruction syntax
+
 A module is a sequence of instructions, separated by whitespace.
 An instruction is an opcode name followed by operands, separated by
 whitespace.  Typically each instruction is presented on its own line,
@@ -61,6 +80,29 @@ the SPIR-V specification.  An operand is one of:
   is removed.  For example, the following indicates the use of an integer
   addition in a specialization constant computation:
   `%sum = OpSpecConstantOp %i32 IAdd %a %b`
+
+## Unknown instructions
+
+In addition to the standard instructions, the assembler can also process
+unknown instructions, with some restrictions.
+
+For example, the syntax for an unknown instruction with opcode 999 and no
+operands would be:
+
+```
+  Op999
+```
+
+One or more operands can be specified as literal numbers.  For example:
+
+```
+  Op1000 21 123 141
+```
+
+In general, the syntax for an unknown instruction is `Op` immediately
+followed by the opcode integer in decimal.  The opcode must be between 1
+and 65535.  Also, zero or more literal number operands may be specified.
+
 
 ## ID Definitions & Usage
 <a name="id"></a>


### PR DESCRIPTION
Working toward https://github.com/KhronosGroup/SPIRV-Tools/issues/597