### PR TITLE
Add bit pattern interface for setting spec constants default values

### DIFF
--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -102,12 +102,21 @@ Optimizer::PassToken CreateNullPass();
 // Section 3.32.2 of the SPIR-V spec) of the SPIR-V module to be optimized.
 Optimizer::PassToken CreateStripDebugInfoPass();
 
-// Creates a set-spec-constant-default-value pass.
+// Creates a set-spec-constant-default-value pass from a mapping from spec-ids
+// to the default values in the form of string.
 // A set-spec-constant-default-value pass sets the default values for the
 // spec constants that have SpecId decorations (i.e., those defined by
 // OpSpecConstant{|True|False} instructions).
 Optimizer::PassToken CreateSetSpecConstantDefaultValuePass(
     const std::unordered_map<uint32_t, std::string>& id_value_map);
+
+// Creates a set-spec-constant-default-value pass from a mapping from spec-ids
+// to the default values in the form of bit pattern.
+// A set-spec-constant-default-value pass sets the default values for the
+// spec constants that have SpecId decorations (i.e., those defined by
+// OpSpecConstant{|True|False} instructions).
+Optimizer::PassToken CreateSetSpecConstantDefaultValuePass(
+    const std::unordered_map<uint32_t, std::vector<uint32_t>>& id_value_map);
 
 // Creates a flatten-decoration pass.
 // A flatten-decoration pass replaces grouped decorations with equivalent

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -101,6 +101,12 @@ Optimizer::PassToken CreateSetSpecConstantDefaultValuePass(
       MakeUnique<opt::SetSpecConstantDefaultValuePass>(id_value_map));
 }
 
+Optimizer::PassToken CreateSetSpecConstantDefaultValuePass(
+    const std::unordered_map<uint32_t, std::vector<uint32_t>>& id_value_map) {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::SetSpecConstantDefaultValuePass>(id_value_map));
+}
+
 Optimizer::PassToken CreateFlattenDecorationPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::FlattenDecorationPass>());

--- a/source/opt/set_spec_constant_default_value_pass.cpp
+++ b/source/opt/set_spec_constant_default_value_pass.cpp
@@ -241,34 +241,32 @@ Pass::Status SetSpecConstantDefaultValuePass::Process(ir::Module* module) {
     if (!spec_inst) continue;
 
     // Get the default value bit pattern for this spec id.
-    std::vector<uint32_t> bit_pattern = [this, &spec_inst, &spec_id,
-                                         &type_mgr]() {
-      std::vector<uint32_t> empty_bit_pattern;
-      if (spec_id_to_value_str_.size() != 0) {
-        // Search for the new string-form default value for this spec id.
-        auto iter = spec_id_to_value_str_.find(spec_id);
-        if (iter == spec_id_to_value_str_.end()) {
-          return empty_bit_pattern;
-        }
+    std::vector<uint32_t> bit_pattern;
 
-        // Gets the string of the default value and parses it to bit pattern
-        // with the type of the spec constant.
-        const std::string& default_value_str = iter->second;
-        return ParseDefaultValueStr(default_value_str.c_str(),
-                                    type_mgr.GetType(spec_inst->type_id()));
-
-      } else {
-        // Search for the new bit-pattern-form default value for this spec id.
-        auto iter = spec_id_to_value_bit_pattern_.find(spec_id);
-        if (iter == spec_id_to_value_bit_pattern_.end()) {
-          return empty_bit_pattern;
-        }
-
-        // Gets the bit-pattern of the default value from the map directly.
-        return ParseDefaultValueBitPattern(
-            iter->second, type_mgr.GetType(spec_inst->type_id()));
+    if (spec_id_to_value_str_.size() != 0) {
+      // Search for the new string-form default value for this spec id.
+      auto iter = spec_id_to_value_str_.find(spec_id);
+      if (iter == spec_id_to_value_str_.end()) {
+        continue;
       }
-    }();
+
+      // Gets the string of the default value and parses it to bit pattern
+      // with the type of the spec constant.
+      const std::string& default_value_str = iter->second;
+      bit_pattern = ParseDefaultValueStr(default_value_str.c_str(),
+                                  type_mgr.GetType(spec_inst->type_id()));
+
+    } else {
+      // Search for the new bit-pattern-form default value for this spec id.
+      auto iter = spec_id_to_value_bit_pattern_.find(spec_id);
+      if (iter == spec_id_to_value_bit_pattern_.end()) {
+        continue;
+      }
+
+      // Gets the bit-pattern of the default value from the map directly.
+      bit_pattern = ParseDefaultValueBitPattern(
+          iter->second, type_mgr.GetType(spec_inst->type_id()));
+    }
 
     if (bit_pattern.empty()) continue;
 

--- a/source/opt/set_spec_constant_default_value_pass.cpp
+++ b/source/opt/set_spec_constant_default_value_pass.cpp
@@ -74,6 +74,7 @@ std::vector<uint32_t> ParseDefaultValueStr(const char* text,
   }
   return result;
 }
+
 // Given a bit pattern and a type, checks if the bit pattern is compatible
 // with the type. If so, returns the bit pattern, otherwise returns an empty
 // bit pattern. If the given bit pattern is empty, returns an empty bit

--- a/source/opt/set_spec_constant_default_value_pass.cpp
+++ b/source/opt/set_spec_constant_default_value_pass.cpp
@@ -14,6 +14,7 @@
 
 #include "set_spec_constant_default_value_pass.h"
 
+#include <algorithm>
 #include <cctype>
 #include <cstring>
 #include <tuple>
@@ -44,9 +45,9 @@ using spvutils::ParseAndEncodeNumber;
 std::vector<uint32_t> ParseDefaultValueStr(const char* text,
                                            const analysis::Type* type) {
   std::vector<uint32_t> result;
-  if (!strcmp(text, "true")) {
+  if (!strcmp(text, "true") && type->AsBool()) {
     result.push_back(1u);
-  } else if (!strcmp(text, "false")) {
+  } else if (!strcmp(text, "false") && type->AsBool()) {
     result.push_back(0u);
   } else {
     NumberType number_type = {32, SPV_NUMBER_UNSIGNED_INT};
@@ -57,6 +58,11 @@ std::vector<uint32_t> ParseDefaultValueStr(const char* text,
     } else if (const auto* FT = type->AsFloat()) {
       number_type.bitwidth = FT->width();
       number_type.kind = SPV_NUMBER_FLOATING;
+    } else {
+      // Does not handle types other then boolean, integer or float. Returns
+      // empty vector.
+      result.clear();
+      return result;
     }
     EncodeNumberStatus rc = ParseAndEncodeNumber(
         text, number_type, [&result](uint32_t word) { result.push_back(word); },
@@ -66,6 +72,39 @@ std::vector<uint32_t> ParseDefaultValueStr(const char* text,
       result.clear();
     }
   }
+  return result;
+}
+// Given a bit pattern and a type, checks if the bit pattern is compatible
+// with the type. If so, returns the bit pattern, otherwise returns an empty
+// bit pattern. If the given bit pattern is empty, returns an empty bit
+// pattern. If the given type represents a SPIR-V Boolean type, the bit pattern
+// to be returned is determined with the following standard:
+//   If any words in the input bit pattern are non zero, returns a bit pattern
+//   with 0x1, which represents a 'true'.
+//   If all words in the bit pattern are zero, returns a bit pattern with 0x0,
+//   which represents a 'false'.
+std::vector<uint32_t> ParseDefaultValueBitPattern(
+    const std::vector<uint32_t>& input_bit_pattern,
+    const analysis::Type* type) {
+  std::vector<uint32_t> result;
+  if (type->AsBool()) {
+    if (std::any_of(input_bit_pattern.begin(), input_bit_pattern.end(),
+                    [](uint32_t i) { return i != 0; })) {
+      result.push_back(1u);
+    } else {
+      result.push_back(0u);
+    }
+    return result;
+  } else if (const auto* IT = type->AsInteger()) {
+    if (IT->width() == input_bit_pattern.size() * sizeof(uint32_t) * 8) {
+      return std::vector<uint32_t>(input_bit_pattern);
+    }
+  } else if (const auto* FT = type->AsFloat()) {
+    if (FT->width() == input_bit_pattern.size() * sizeof(uint32_t) * 8) {
+      return std::vector<uint32_t>(input_bit_pattern);
+    }
+  }
+  result.clear();
   return result;
 }
 
@@ -200,15 +239,36 @@ Pass::Status SetSpecConstantDefaultValuePass::Process(ir::Module* module) {
     }
     if (!spec_inst) continue;
 
-    // Search for the new default value for this spec id.
-    auto iter = spec_id_to_value_.find(spec_id);
-    if (iter == spec_id_to_value_.end()) continue;
+    // Get the default value bit pattern for this spec id.
+    std::vector<uint32_t> bit_pattern = [this, &spec_inst, &spec_id,
+                                         &type_mgr]() {
+      std::vector<uint32_t> empty_bit_pattern;
+      if (spec_id_to_value_str_.size() != 0) {
+        // Search for the new string-form default value for this spec id.
+        auto iter = spec_id_to_value_str_.find(spec_id);
+        if (iter == spec_id_to_value_str_.end()) {
+          return empty_bit_pattern;
+        }
 
-    // Gets the string of the default value and parses it to bit pattern
-    // with the type of the spec constant.
-    const std::string& default_value_str = iter->second;
-    std::vector<uint32_t> bit_pattern = ParseDefaultValueStr(
-        default_value_str.c_str(), type_mgr.GetType(spec_inst->type_id()));
+        // Gets the string of the default value and parses it to bit pattern
+        // with the type of the spec constant.
+        const std::string& default_value_str = iter->second;
+        return ParseDefaultValueStr(default_value_str.c_str(),
+                                    type_mgr.GetType(spec_inst->type_id()));
+
+      } else {
+        // Search for the new bit-pattern-form default value for this spec id.
+        auto iter = spec_id_to_value_bit_pattern_.find(spec_id);
+        if (iter == spec_id_to_value_bit_pattern_.end()) {
+          return empty_bit_pattern;
+        }
+
+        // Gets the bit-pattern of the default value from the map directly.
+        return ParseDefaultValueBitPattern(
+            iter->second, type_mgr.GetType(spec_inst->type_id()));
+      }
+    }();
+
     if (bit_pattern.empty()) continue;
 
     // Update the operand bit patterns of the spec constant defining

--- a/source/opt/set_spec_constant_default_value_pass.h
+++ b/source/opt/set_spec_constant_default_value_pass.h
@@ -29,14 +29,25 @@ namespace opt {
 class SetSpecConstantDefaultValuePass : public Pass {
  public:
   using SpecIdToValueStrMap = std::unordered_map<uint32_t, std::string>;
+  using SpecIdToValueBitPatternMap =
+      std::unordered_map<uint32_t, std::vector<uint32_t>>;
   using SpecIdToInstMap = std::unordered_map<uint32_t, ir::Instruction*>;
 
-  // Constructs a pass instance with a map from spec ids to default values.
+  // Constructs a pass instance with a map from spec ids to default values
+  // in the form of string.
   explicit SetSpecConstantDefaultValuePass(
       const SpecIdToValueStrMap& default_values)
-      : spec_id_to_value_(default_values) {}
+      : spec_id_to_value_str_(default_values), spec_id_to_value_bit_pattern_() {}
   explicit SetSpecConstantDefaultValuePass(SpecIdToValueStrMap&& default_values)
-      : spec_id_to_value_(std::move(default_values)) {}
+      : spec_id_to_value_str_(std::move(default_values)), spec_id_to_value_bit_pattern_() {}
+
+  // Constructs a pass instance with a map from spec ids to default values in
+  // the form of bit pattern.
+  explicit SetSpecConstantDefaultValuePass(
+      const SpecIdToValueBitPatternMap& default_values)
+      : spec_id_to_value_str_(), spec_id_to_value_bit_pattern_(default_values) {}
+  explicit SetSpecConstantDefaultValuePass(SpecIdToValueBitPatternMap&& default_values)
+      : spec_id_to_value_str_(), spec_id_to_value_bit_pattern_(std::move(default_values)) {}
 
   const char* name() const override { return "set-spec-const-default-value"; }
   Status Process(ir::Module*) override;
@@ -78,8 +89,10 @@ class SetSpecConstantDefaultValuePass : public Pass {
       const char* str);
 
  private:
-  // The mapping from spec ids to their default values to be set.
-  const SpecIdToValueStrMap spec_id_to_value_;
+  // The mapping from spec ids to their string-form default values to be set.
+  const SpecIdToValueStrMap spec_id_to_value_str_;
+  // The mapping from spec ids to their bitpattern-form default values to be set.
+  const SpecIdToValueBitPatternMap spec_id_to_value_bit_pattern_;
 };
 
 }  // namespace opt

--- a/source/opt/set_spec_constant_default_value_pass.h
+++ b/source/opt/set_spec_constant_default_value_pass.h
@@ -89,6 +89,10 @@ class SetSpecConstantDefaultValuePass : public Pass {
       const char* str);
 
  private:
+  // The mappings from spec ids to default values. Two maps are defined here,
+  // each to be used for one specific form of the default values. Only one of
+  // them will be populated in practice.
+
   // The mapping from spec ids to their string-form default values to be set.
   const SpecIdToValueStrMap spec_id_to_value_str_;
   // The mapping from spec ids to their bitpattern-form default values to be set.

--- a/test/opt/set_spec_const_default_value_test.cpp
+++ b/test/opt/set_spec_const_default_value_test.cpp
@@ -867,18 +867,18 @@ INSTANTIATE_TEST_CASE_P(
             "OpDecorate %2 SpecId 202\n"
             "%float = OpTypeFloat 32\n"
             "%double = OpTypeFloat 64\n"
-            "%1 = OpSpecConstant %float 3.25\n"
-            "%2 = OpSpecConstant %double 1.25\n",
+            "%1 = OpSpecConstant %float 3.14159\n"
+            "%2 = OpSpecConstant %double 0.142857\n",
             // default values
-            SpecIdToValueBitPatternMap{{201, {0x40500000}},
-                                       {202, {0x00000000, 0x3ff40000}}},
+            SpecIdToValueBitPatternMap{{201, {0x40490fd0}},
+                                       {202, {0x5f809918, 0x3fc24923}}},
             // expected
             "OpDecorate %1 SpecId 201\n"
             "OpDecorate %2 SpecId 202\n"
             "%float = OpTypeFloat 32\n"
             "%double = OpTypeFloat 64\n"
-            "%1 = OpSpecConstant %float 3.25\n"
-            "%2 = OpSpecConstant %double 1.25\n",
+            "%1 = OpSpecConstant %float 3.14159\n"
+            "%2 = OpSpecConstant %double 0.142857\n",
         },
         // 17. OpGroupDecorate may have multiple target ids defined by the same
         // eligible spec constant

--- a/test/opt/set_spec_const_default_value_test.cpp
+++ b/test/opt/set_spec_const_default_value_test.cpp
@@ -23,6 +23,8 @@ using testing::Eq;
 
 using SpecIdToValueStrMap =
     opt::SetSpecConstantDefaultValuePass::SpecIdToValueStrMap;
+using SpecIdToValueBitPatternMap =
+    opt::SetSpecConstantDefaultValuePass::SpecIdToValueBitPatternMap;
 
 struct DefaultValuesStringParsingTestCase {
   const char* default_values_str;
@@ -129,24 +131,25 @@ INSTANTIATE_TEST_CASE_P(
         {"0x3p10:200", false, SpecIdToValueStrMap{}},
     }));
 
-struct SetSpecConstantDefaultValueTestCase {
+struct SetSpecConstantDefaultValueInStringFormTestCase {
   const char* code;
   SpecIdToValueStrMap default_values;
   const char* expected;
 };
 
-using SetSpecConstantDefaultValueParamTest =
-    PassTest<::testing::TestWithParam<SetSpecConstantDefaultValueTestCase>>;
+using SetSpecConstantDefaultValueInStringFormParamTest = PassTest<
+    ::testing::TestWithParam<SetSpecConstantDefaultValueInStringFormTestCase>>;
 
-TEST_P(SetSpecConstantDefaultValueParamTest, TestCase) {
+TEST_P(SetSpecConstantDefaultValueInStringFormParamTest, TestCase) {
   const auto& tc = GetParam();
   SinglePassRunAndCheck<opt::SetSpecConstantDefaultValuePass>(
       tc.code, tc.expected, /* skip_nop = */ false, tc.default_values);
 }
 
 INSTANTIATE_TEST_CASE_P(
-    ValidCases, SetSpecConstantDefaultValueParamTest,
-    ::testing::ValuesIn(std::vector<SetSpecConstantDefaultValueTestCase>{
+    ValidCases, SetSpecConstantDefaultValueInStringFormParamTest,
+    ::testing::ValuesIn(std::vector<
+                        SetSpecConstantDefaultValueInStringFormTestCase>{
         // 0. Empty.
         {"", SpecIdToValueStrMap{}, ""},
         // 1. Empty with non-empty values to set.
@@ -439,8 +442,9 @@ INSTANTIATE_TEST_CASE_P(
     }));
 
 INSTANTIATE_TEST_CASE_P(
-    InvalidCases, SetSpecConstantDefaultValueParamTest,
-    ::testing::ValuesIn(std::vector<SetSpecConstantDefaultValueTestCase>{
+    InvalidCases, SetSpecConstantDefaultValueInStringFormParamTest,
+    ::testing::ValuesIn(std::vector<
+                        SetSpecConstantDefaultValueInStringFormTestCase>{
         // 0. Do not crash when decoration group is not used.
         {
             // code
@@ -536,6 +540,519 @@ INSTANTIATE_TEST_CASE_P(
             "OpGroupDecorate %1 %2\n"
             "%int = OpTypeInt 32 1\n"
             "%int_100 = OpConstant %int 100\n",
+        },
+        // 6. Boolean type spec constant cannot be set with numeric values in
+        // string form. i.e. only 'true' and 'false' are acceptable for setting
+        // boolean type spec constants. Nothing should be done if numeric values
+        // in string form are provided.
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %2 SpecId 101\n"
+            "OpDecorate %3 SpecId 102\n"
+            "OpDecorate %4 SpecId 103\n"
+            "OpDecorate %5 SpecId 104\n"
+            "OpDecorate %6 SpecId 105\n"
+            "%bool = OpTypeBool\n"
+            "%1 = OpSpecConstantTrue %bool\n"
+            "%2 = OpSpecConstantFalse %bool\n"
+            "%3 = OpSpecConstantTrue %bool\n"
+            "%4 = OpSpecConstantTrue %bool\n"
+            "%5 = OpSpecConstantTrue %bool\n"
+            "%6 = OpSpecConstantFalse %bool\n",
+            // default values
+            SpecIdToValueStrMap{{100, "0"},
+                                {101, "1"},
+                                {102, "0x0"},
+                                {103, "0.0"},
+                                {104, "-0.0"},
+                                {105, "0x12345678"}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %2 SpecId 101\n"
+            "OpDecorate %3 SpecId 102\n"
+            "OpDecorate %4 SpecId 103\n"
+            "OpDecorate %5 SpecId 104\n"
+            "OpDecorate %6 SpecId 105\n"
+            "%bool = OpTypeBool\n"
+            "%1 = OpSpecConstantTrue %bool\n"
+            "%2 = OpSpecConstantFalse %bool\n"
+            "%3 = OpSpecConstantTrue %bool\n"
+            "%4 = OpSpecConstantTrue %bool\n"
+            "%5 = OpSpecConstantTrue %bool\n"
+            "%6 = OpSpecConstantFalse %bool\n",
+        },
+    }));
+
+struct SetSpecConstantDefaultValueInBitPatternFormTestCase {
+  const char* code;
+  SpecIdToValueBitPatternMap default_values;
+  const char* expected;
+};
+
+using SetSpecConstantDefaultValueInBitPatternFormParamTest =
+    PassTest<::testing::TestWithParam<
+        SetSpecConstantDefaultValueInBitPatternFormTestCase>>;
+
+TEST_P(SetSpecConstantDefaultValueInBitPatternFormParamTest, TestCase) {
+  const auto& tc = GetParam();
+  SinglePassRunAndCheck<opt::SetSpecConstantDefaultValuePass>(
+      tc.code, tc.expected, /* skip_nop = */ false, tc.default_values);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    ValidCases, SetSpecConstantDefaultValueInBitPatternFormParamTest,
+    ::testing::ValuesIn(std::vector<
+                        SetSpecConstantDefaultValueInBitPatternFormTestCase>{
+        // 0. Empty.
+        {"", SpecIdToValueBitPatternMap{}, ""},
+        // 1. Empty with non-empty values to set.
+        {"", SpecIdToValueBitPatternMap{{1, {100}}, {2, {200}}}, ""},
+        // 2. Baisc bool type.
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %2 SpecId 101\n"
+            "%bool = OpTypeBool\n"
+            "%1 = OpSpecConstantTrue %bool\n"
+            "%2 = OpSpecConstantFalse %bool\n",
+            // default values
+            SpecIdToValueBitPatternMap{{100, {0x0}}, {101, {0x1}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %2 SpecId 101\n"
+            "%bool = OpTypeBool\n"
+            "%1 = OpSpecConstantFalse %bool\n"
+            "%2 = OpSpecConstantTrue %bool\n",
+        },
+        // 3. 32-bit int type.
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %2 SpecId 101\n"
+            "OpDecorate %3 SpecId 102\n"
+            "%int = OpTypeInt 32 1\n"
+            "%1 = OpSpecConstant %int 10\n"
+            "%2 = OpSpecConstant %int 11\n"
+            "%3 = OpSpecConstant %int 11\n",
+            // default values
+            SpecIdToValueBitPatternMap{
+                {100, {2147483647}}, {101, {0xffffffff}}, {102, {0xffffffd6}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %2 SpecId 101\n"
+            "OpDecorate %3 SpecId 102\n"
+            "%int = OpTypeInt 32 1\n"
+            "%1 = OpSpecConstant %int 2147483647\n"
+            "%2 = OpSpecConstant %int -1\n"
+            "%3 = OpSpecConstant %int -42\n",
+        },
+        // 4. 64-bit uint type.
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %2 SpecId 101\n"
+            "%ulong = OpTypeInt 64 0\n"
+            "%1 = OpSpecConstant %ulong 10\n"
+            "%2 = OpSpecConstant %ulong 11\n",
+            // default values
+            SpecIdToValueBitPatternMap{{100, {0xFFFFFFFE, 0xFFFFFFFF}},
+                                       {101, {0x100, 0x0}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %2 SpecId 101\n"
+            "%ulong = OpTypeInt 64 0\n"
+            "%1 = OpSpecConstant %ulong 18446744073709551614\n"
+            "%2 = OpSpecConstant %ulong 256\n",
+        },
+        // 5. 32-bit float type.
+        {
+            // code
+            "OpDecorate %1 SpecId 101\n"
+            "OpDecorate %2 SpecId 102\n"
+            "%float = OpTypeFloat 32\n"
+            "%1 = OpSpecConstant %float 200\n"
+            "%2 = OpSpecConstant %float 201\n",
+            // default values
+            SpecIdToValueBitPatternMap{{101, {0xffffffff}},
+                                       {102, {0x40200000}}},
+            // expected
+            "OpDecorate %1 SpecId 101\n"
+            "OpDecorate %2 SpecId 102\n"
+            "%float = OpTypeFloat 32\n"
+            "%1 = OpSpecConstant %float -0x1.fffffep+128\n"
+            "%2 = OpSpecConstant %float 2.5\n",
+        },
+        // 6. 64-bit float type.
+        {
+            // code
+            "OpDecorate %1 SpecId 201\n"
+            "OpDecorate %2 SpecId 202\n"
+            "%double = OpTypeFloat 64\n"
+            "%1 = OpSpecConstant %double 3.14159265358979\n"
+            "%2 = OpSpecConstant %double 0.142857\n",
+            // default values
+            SpecIdToValueBitPatternMap{{201, {0xffffffff, 0x7fffffff}},
+                                       {202, {0x00000000, 0xc0404000}}},
+            // expected
+            "OpDecorate %1 SpecId 201\n"
+            "OpDecorate %2 SpecId 202\n"
+            "%double = OpTypeFloat 64\n"
+            "%1 = OpSpecConstant %double 0x1.fffffffffffffp+1024\n"
+            "%2 = OpSpecConstant %double -32.5\n",
+        },
+        // 7. SpecId not found, expect no modification.
+        {
+            // code
+            "OpDecorate %1 SpecId 201\n"
+            "%double = OpTypeFloat 64\n"
+            "%1 = OpSpecConstant %double 3.14159265358979\n",
+            // default values
+            SpecIdToValueBitPatternMap{{8888, {0x0}}},
+            // expected
+            "OpDecorate %1 SpecId 201\n"
+            "%double = OpTypeFloat 64\n"
+            "%1 = OpSpecConstant %double 3.14159265358979\n",
+        },
+        // 8. Multiple types of spec constants.
+        {
+            // code
+            "OpDecorate %1 SpecId 201\n"
+            "OpDecorate %2 SpecId 202\n"
+            "OpDecorate %3 SpecId 203\n"
+            "%bool = OpTypeBool\n"
+            "%int = OpTypeInt 32 1\n"
+            "%double = OpTypeFloat 64\n"
+            "%1 = OpSpecConstant %double 3.14159265358979\n"
+            "%2 = OpSpecConstant %int 1024\n"
+            "%3 = OpSpecConstantTrue %bool\n",
+            // default values
+            SpecIdToValueBitPatternMap{
+                {201, {0xffffffff, 0x7fffffff}},
+                {202, {0x00000800}},
+                {203, {0x0}},
+            },
+            // expected
+            "OpDecorate %1 SpecId 201\n"
+            "OpDecorate %2 SpecId 202\n"
+            "OpDecorate %3 SpecId 203\n"
+            "%bool = OpTypeBool\n"
+            "%int = OpTypeInt 32 1\n"
+            "%double = OpTypeFloat 64\n"
+            "%1 = OpSpecConstant %double 0x1.fffffffffffffp+1024\n"
+            "%2 = OpSpecConstant %int 2048\n"
+            "%3 = OpSpecConstantFalse %bool\n",
+        },
+        // 9. Ignore other decorations.
+        {
+            // code
+            "OpDecorate %1 ArrayStride 4\n"
+            "%int = OpTypeInt 32 1\n"
+            "%1 = OpSpecConstant %int 100\n",
+            // default values
+            SpecIdToValueBitPatternMap{{4, {0x7fffffff}}},
+            // expected
+            "OpDecorate %1 ArrayStride 4\n"
+            "%int = OpTypeInt 32 1\n"
+            "%1 = OpSpecConstant %int 100\n",
+        },
+        // 10. Distinguish from other decorations.
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %1 ArrayStride 4\n"
+            "%int = OpTypeInt 32 1\n"
+            "%1 = OpSpecConstant %int 100\n",
+            // default values
+            SpecIdToValueBitPatternMap{{4, {0x7fffffff}}, {100, {0xffffffff}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %1 ArrayStride 4\n"
+            "%int = OpTypeInt 32 1\n"
+            "%1 = OpSpecConstant %int -1\n",
+        },
+        // 11. Decorate through decoration group.
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "%1 = OpDecorationGroup\n"
+            "OpGroupDecorate %1 %2\n"
+            "%int = OpTypeInt 32 1\n"
+            "%2 = OpSpecConstant %int 100\n",
+            // default values
+            SpecIdToValueBitPatternMap{{100, {0x7fffffff}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "%1 = OpDecorationGroup\n"
+            "OpGroupDecorate %1 %2\n"
+            "%int = OpTypeInt 32 1\n"
+            "%2 = OpSpecConstant %int 2147483647\n",
+        },
+        // 12. Ignore other decorations in decoration group.
+        {
+            // code
+            "OpDecorate %1 ArrayStride 4\n"
+            "%1 = OpDecorationGroup\n"
+            "OpGroupDecorate %1 %2\n"
+            "%int = OpTypeInt 32 1\n"
+            "%2 = OpSpecConstant %int 100\n",
+            // default values
+            SpecIdToValueBitPatternMap{{4, {0x7fffffff}}},
+            // expected
+            "OpDecorate %1 ArrayStride 4\n"
+            "%1 = OpDecorationGroup\n"
+            "OpGroupDecorate %1 %2\n"
+            "%int = OpTypeInt 32 1\n"
+            "%2 = OpSpecConstant %int 100\n",
+        },
+        // 13. Distinguish from other decorations in decoration group.
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %1 ArrayStride 4\n"
+            "%1 = OpDecorationGroup\n"
+            "OpGroupDecorate %1 %2\n"
+            "%int = OpTypeInt 32 1\n"
+            "%2 = OpSpecConstant %int 100\n",
+            // default values
+            SpecIdToValueBitPatternMap{{100, {0x7fffffff}}, {4, {0x00000001}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %1 ArrayStride 4\n"
+            "%1 = OpDecorationGroup\n"
+            "OpGroupDecorate %1 %2\n"
+            "%int = OpTypeInt 32 1\n"
+            "%2 = OpSpecConstant %int 2147483647\n",
+        },
+        // 14. Unchanged bool default value
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %2 SpecId 101\n"
+            "%bool = OpTypeBool\n"
+            "%1 = OpSpecConstantTrue %bool\n"
+            "%2 = OpSpecConstantFalse %bool\n",
+            // default values
+            SpecIdToValueBitPatternMap{{100, {0x1}}, {101, {0x0}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %2 SpecId 101\n"
+            "%bool = OpTypeBool\n"
+            "%1 = OpSpecConstantTrue %bool\n"
+            "%2 = OpSpecConstantFalse %bool\n",
+        },
+        // 15. Unchanged int default values
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %2 SpecId 101\n"
+            "%int = OpTypeInt 32 1\n"
+            "%ulong = OpTypeInt 64 0\n"
+            "%1 = OpSpecConstant %int 10\n"
+            "%2 = OpSpecConstant %ulong 11\n",
+            // default values
+            SpecIdToValueBitPatternMap{{100, {10}}, {101, {11, 0}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %2 SpecId 101\n"
+            "%int = OpTypeInt 32 1\n"
+            "%ulong = OpTypeInt 64 0\n"
+            "%1 = OpSpecConstant %int 10\n"
+            "%2 = OpSpecConstant %ulong 11\n",
+        },
+        // 16. Unchanged float default values
+        {
+            // code
+            "OpDecorate %1 SpecId 201\n"
+            "OpDecorate %2 SpecId 202\n"
+            "%float = OpTypeFloat 32\n"
+            "%double = OpTypeFloat 64\n"
+            "%1 = OpSpecConstant %float 3.14159\n"
+            "%2 = OpSpecConstant %double 0.142857\n",
+            // default values
+            SpecIdToValueBitPatternMap{{201, {0x40490fd0}},
+                                       {202, {0x5f809918, 0x3fc24923}}},
+            // expected
+            "OpDecorate %1 SpecId 201\n"
+            "OpDecorate %2 SpecId 202\n"
+            "%float = OpTypeFloat 32\n"
+            "%double = OpTypeFloat 64\n"
+            "%1 = OpSpecConstant %float 3.14159\n"
+            "%2 = OpSpecConstant %double 0.142857\n",
+        },
+        // 17. OpGroupDecorate may have multiple target ids defined by the same
+        // eligible spec constant
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "%1 = OpDecorationGroup\n"
+            "OpGroupDecorate %1 %2 %2 %2\n"
+            "%int = OpTypeInt 32 1\n"
+            "%2 = OpSpecConstant %int 100\n",
+            // default values
+            SpecIdToValueBitPatternMap{{100, {0xffffffff}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "%1 = OpDecorationGroup\n"
+            "OpGroupDecorate %1 %2 %2 %2\n"
+            "%int = OpTypeInt 32 1\n"
+            "%2 = OpSpecConstant %int -1\n",
+        },
+        // 18. For Boolean type spec constants,if any word in the bit pattern
+        // is not zero, it can be considered as a 'true', otherwise, it can be
+        // considered as a 'false'.
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %2 SpecId 101\n"
+            "OpDecorate %3 SpecId 102\n"
+            "%bool = OpTypeBool\n"
+            "%1 = OpSpecConstantTrue %bool\n"
+            "%2 = OpSpecConstantFalse %bool\n"
+            "%3 = OpSpecConstantFalse %bool\n",
+            // default values
+            SpecIdToValueBitPatternMap{
+                {100, {0x0, 0x0, 0x0, 0x0}},
+                {101, {0x10101010}},
+                {102, {0x0, 0x0, 0x0, 0x2}},
+            },
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %2 SpecId 101\n"
+            "OpDecorate %3 SpecId 102\n"
+            "%bool = OpTypeBool\n"
+            "%1 = OpSpecConstantFalse %bool\n"
+            "%2 = OpSpecConstantTrue %bool\n"
+            "%3 = OpSpecConstantTrue %bool\n",
+        },
+    }));
+
+INSTANTIATE_TEST_CASE_P(
+    InvalidCases, SetSpecConstantDefaultValueInBitPatternFormParamTest,
+    ::testing::ValuesIn(std::vector<
+                        SetSpecConstantDefaultValueInBitPatternFormTestCase>{
+        // 0. Do not crash when decoration group is not used.
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "%1 = OpDecorationGroup\n"
+            "%int = OpTypeInt 32 1\n"
+            "%3 = OpSpecConstant %int 100\n",
+            // default values
+            SpecIdToValueBitPatternMap{{100, {0x7fffffff}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "%1 = OpDecorationGroup\n"
+            "%int = OpTypeInt 32 1\n"
+            "%3 = OpSpecConstant %int 100\n",
+        },
+        // 1. Do not crash when target does not exist.
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "%int = OpTypeInt 32 1\n",
+            // default values
+            SpecIdToValueBitPatternMap{{100, {0x7fffffff}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "%int = OpTypeInt 32 1\n",
+        },
+        // 2. Do nothing when SpecId decoration is not attached to a
+        // non-spec-contant instruction.
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "%int = OpTypeInt 32 1\n"
+            "%int_101 = OpConstant %int 101\n",
+            // default values
+            SpecIdToValueBitPatternMap{{100, {0x7fffffff}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "%int = OpTypeInt 32 1\n"
+            "%int_101 = OpConstant %int 101\n",
+        },
+        // 3. Do nothing when SpecId decoration is not attached to a
+        // OpSpecConstant{|True|False} instruction.
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "%int = OpTypeInt 32 1\n"
+            "%3 = OpSpecConstant %int 101\n"
+            "%1 = OpSpecConstantOp %int IAdd %3 %3\n",
+            // default values
+            SpecIdToValueBitPatternMap{{100, {0x7fffffff}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "%int = OpTypeInt 32 1\n"
+            "%3 = OpSpecConstant %int 101\n"
+            "%1 = OpSpecConstantOp %int IAdd %3 %3\n",
+        },
+        // 4. Do not crash and do nothing when SpecId decoration is applied to
+        // multiple spec constants.
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "%1 = OpDecorationGroup\n"
+            "OpGroupDecorate %1 %2 %3 %4\n"
+            "%int = OpTypeInt 32 1\n"
+            "%2 = OpSpecConstant %int 100\n"
+            "%3 = OpSpecConstant %int 200\n"
+            "%4 = OpSpecConstant %int 300\n",
+            // default values
+            SpecIdToValueBitPatternMap{{100, {0xffffffff}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "%1 = OpDecorationGroup\n"
+            "OpGroupDecorate %1 %2 %3 %4\n"
+            "%int = OpTypeInt 32 1\n"
+            "%2 = OpSpecConstant %int 100\n"
+            "%3 = OpSpecConstant %int 200\n"
+            "%4 = OpSpecConstant %int 300\n",
+        },
+        // 5. Do not crash and do nothing when SpecId decoration is attached to
+        // non-spec-constants (invalid case).
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "%1 = OpDecorationGroup\n"
+            "OpGroupDecorate %1 %2\n"
+            "%int = OpTypeInt 32 1\n"
+            "%int_100 = OpConstant %int 100\n",
+            // default values
+            SpecIdToValueBitPatternMap{{100, {0xffffffff}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "%1 = OpDecorationGroup\n"
+            "OpGroupDecorate %1 %2\n"
+            "%int = OpTypeInt 32 1\n"
+            "%int_100 = OpConstant %int 100\n",
+        },
+        // 6. Incompatible input bit pattern with the type. Nothing should be
+        // done in such a case.
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %2 SpecId 101\n"
+            "OpDecorate %3 SpecId 102\n"
+            "%int = OpTypeInt 32 1\n"
+            "%ulong = OpTypeInt 64 0\n"
+            "%double = OpTypeFloat 64\n"
+            "%1 = OpSpecConstant %int 100\n"
+            "%2 = OpSpecConstant %ulong 200\n"
+            "%3 = OpSpecConstant %double 3.1415926\n",
+            // default values
+            SpecIdToValueBitPatternMap{
+                {100, {10, 0}}, {101, {11}}, {102, {0xffffffff}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %2 SpecId 101\n"
+            "OpDecorate %3 SpecId 102\n"
+            "%int = OpTypeInt 32 1\n"
+            "%ulong = OpTypeInt 64 0\n"
+            "%double = OpTypeFloat 64\n"
+            "%1 = OpSpecConstant %int 100\n"
+            "%2 = OpSpecConstant %ulong 200\n"
+            "%3 = OpSpecConstant %double 3.1415926\n",
         },
     }));
 

--- a/test/opt/set_spec_const_default_value_test.cpp
+++ b/test/opt/set_spec_const_default_value_test.cpp
@@ -472,7 +472,7 @@ INSTANTIATE_TEST_CASE_P(
             "%int = OpTypeInt 32 1\n",
         },
         // 2. Do nothing when SpecId decoration is not attached to a
-        // non-spec-contant instruction.
+        // non-spec-constant instruction.
         {
             // code
             "OpDecorate %1 SpecId 100\n"
@@ -958,7 +958,7 @@ INSTANTIATE_TEST_CASE_P(
             "%int = OpTypeInt 32 1\n",
         },
         // 2. Do nothing when SpecId decoration is not attached to a
-        // non-spec-contant instruction.
+        // non-spec-constant instruction.
         {
             // code
             "OpDecorate %1 SpecId 100\n"

--- a/test/opt/set_spec_const_default_value_test.cpp
+++ b/test/opt/set_spec_const_default_value_test.cpp
@@ -867,18 +867,18 @@ INSTANTIATE_TEST_CASE_P(
             "OpDecorate %2 SpecId 202\n"
             "%float = OpTypeFloat 32\n"
             "%double = OpTypeFloat 64\n"
-            "%1 = OpSpecConstant %float 3.14159\n"
-            "%2 = OpSpecConstant %double 0.142857\n",
+            "%1 = OpSpecConstant %float 3.25\n"
+            "%2 = OpSpecConstant %double 1.25\n",
             // default values
-            SpecIdToValueBitPatternMap{{201, {0x40490fd0}},
-                                       {202, {0x5f809918, 0x3fc24923}}},
+            SpecIdToValueBitPatternMap{{201, {0x40500000}},
+                                       {202, {0x00000000, 0x3ff40000}}},
             // expected
             "OpDecorate %1 SpecId 201\n"
             "OpDecorate %2 SpecId 202\n"
             "%float = OpTypeFloat 32\n"
             "%double = OpTypeFloat 64\n"
-            "%1 = OpSpecConstant %float 3.14159\n"
-            "%2 = OpSpecConstant %double 0.142857\n",
+            "%1 = OpSpecConstant %float 3.25\n"
+            "%2 = OpSpecConstant %double 1.25\n",
         },
         // 17. OpGroupDecorate may have multiple target ids defined by the same
         // eligible spec constant


### PR DESCRIPTION
Add another constructor which accepts map<spec_id, bit_pattern> as input argument. Bit patterns are fixed to vector<uint32_t> type.