### PR TITLE
Added Markov chain analysis to stats

### DIFF
--- a/source/spirv_stats.cpp
+++ b/source/spirv_stats.cpp
@@ -37,8 +37,8 @@ namespace {
 struct StatsContext {
   SpirvStats* stats;
 
-  // Opcodes of already processed instructions. Used and updated in
-  // ProcessOpcode.
+  // Opcodes of already processed instructions in the order as they appear in
+  // the module.
   std::vector<uint32_t> opcodes;
 };
 
@@ -87,8 +87,6 @@ void ProcessOpcode(StatsContext* ctx,
     auto& hist = (*step_it)[*opcode_it];
     ++hist[opcode];
   }
-
-  ctx->opcodes.push_back(opcode);
 }
 
 // Collects opcode usage statistics and calls other collectors.
@@ -99,6 +97,9 @@ spv_result_t ProcessInstruction(
   ProcessOpcode(ctx, inst);
   ProcessCapability(ctx, inst);
   ProcessExtension(ctx, inst);
+
+  const SpvOp opcode = static_cast<SpvOp>(inst->opcode);
+  ctx->opcodes.push_back(opcode);
 
   return SPV_SUCCESS;
 }

--- a/source/spirv_stats.h
+++ b/source/spirv_stats.h
@@ -40,11 +40,13 @@ struct SpirvStats {
   std::unordered_map<uint32_t, uint32_t> opcode_hist;
 
   // Used to collect statistics on opcodes triggering other opcodes.
-  // Container scheme: leap -> cue_opcode -> finding_opcode -> count.
+  // Container scheme: gap between instructions -> cue opcode -> later opcode
+  // -> count.
   // For example opcode_markov_hist[2][OpFMul][OpFAdd] corresponds to
-  // the number of time OpFAdd has appered 2 instructions after OpFMul.
+  // the number of times an OpMul appears, followed by 2 other instructions,
+  // followed by OpFAdd.
   // opcode_markov_hist[0][OpFMul][OpFAdd] corresponds to how many times
-  // OpFAdd has appeared immediately after OpFMul.
+  // OpFMul appears, directly followed by OpFAdd.
   // The size of the outer std::vector also serves as an input parameter,
   // determining how many steps will be collected.
   // I.e. do opcode_markov_hist.resize(1) to collect data for one step only.

--- a/source/spirv_stats.h
+++ b/source/spirv_stats.h
@@ -38,6 +38,18 @@ struct SpirvStats {
 
   // Opcode histogram, SpvOpXXX -> count.
   std::unordered_map<uint32_t, uint32_t> opcode_hist;
+
+  // Used to collect statistics on opcodes triggering other opcodes.
+  // Container scheme: leap -> cue_opcode -> finding_opcode -> count.
+  // For example opcode_markov_hist[2][OpFMul][OpFAdd] corresponds to
+  // the number of time OpFAdd has appered 2 instructions after OpFMul.
+  // opcode_markov_hist[0][OpFMul][OpFAdd] corresponds to how many times
+  // OpFAdd has appeared immediately after OpFMul.
+  // The size of the outer std::vector also serves as an input parameter,
+  // determining how many steps will be collected.
+  // I.e. do opcode_markov_hist.resize(1) to collect data for one step only.
+  std::vector<std::unordered_map<uint32_t,
+      std::unordered_map<uint32_t, uint32_t>>> opcode_markov_hist;
 };
 
 // Aggregates existing |stats| with new stats extracted from |binary|.

--- a/test/stats/stats_aggregate_test.cpp
+++ b/test/stats/stats_aggregate_test.cpp
@@ -235,4 +235,85 @@ OpMemoryModel Logical GLSL450
   EXPECT_EQ(2u, stats.opcode_hist.at(SpvOpExtension));
 }
 
+TEST(AggregateStats, OpcodeMarkovHistogram) {
+  const std::string code1 = R"(
+OpCapability Shader
+OpCapability Linkage
+OpExtension "SPV_NV_viewport_array2"
+OpMemoryModel Logical GLSL450
+)";
+
+  const std::string code2 = R"(
+OpCapability Addresses
+OpCapability Kernel
+OpCapability GenericPointer
+OpCapability Linkage
+OpMemoryModel Physical32 OpenCL
+%i32 = OpTypeInt 32 1
+%u32 = OpTypeInt 32 0
+%f32 = OpTypeFloat 32
+)";
+
+  SpirvStats stats;
+  stats.opcode_markov_hist.resize(2);
+
+  CompileAndAggregateStats(code1, &stats);
+  ASSERT_EQ(2u, stats.opcode_markov_hist.size());
+  EXPECT_EQ(2u, stats.opcode_markov_hist[0].size());
+  EXPECT_EQ(2u, stats.opcode_markov_hist[0].at(SpvOpCapability).size());
+  EXPECT_EQ(1u, stats.opcode_markov_hist[0].at(SpvOpExtension).size());
+  EXPECT_EQ(
+      1u, stats.opcode_markov_hist[0].at(SpvOpCapability).at(SpvOpCapability));
+  EXPECT_EQ(
+      1u, stats.opcode_markov_hist[0].at(SpvOpCapability).at(SpvOpExtension));
+  EXPECT_EQ(
+      1u, stats.opcode_markov_hist[0].at(SpvOpExtension).at(SpvOpMemoryModel));
+
+  EXPECT_EQ(1u, stats.opcode_markov_hist[1].size());
+  EXPECT_EQ(2u, stats.opcode_markov_hist[1].at(SpvOpCapability).size());
+  EXPECT_EQ(
+      1u, stats.opcode_markov_hist[1].at(SpvOpCapability).at(SpvOpExtension));
+  EXPECT_EQ(
+      1u, stats.opcode_markov_hist[1].at(SpvOpCapability).at(SpvOpMemoryModel));
+
+  CompileAndAggregateStats(code2, &stats);
+  ASSERT_EQ(2u, stats.opcode_markov_hist.size());
+  EXPECT_EQ(4u, stats.opcode_markov_hist[0].size());
+  EXPECT_EQ(3u, stats.opcode_markov_hist[0].at(SpvOpCapability).size());
+  EXPECT_EQ(1u, stats.opcode_markov_hist[0].at(SpvOpExtension).size());
+  EXPECT_EQ(1u, stats.opcode_markov_hist[0].at(SpvOpMemoryModel).size());
+  EXPECT_EQ(2u, stats.opcode_markov_hist[0].at(SpvOpTypeInt).size());
+  EXPECT_EQ(
+      4u, stats.opcode_markov_hist[0].at(SpvOpCapability).at(SpvOpCapability));
+  EXPECT_EQ(
+      1u, stats.opcode_markov_hist[0].at(SpvOpCapability).at(SpvOpExtension));
+  EXPECT_EQ(
+      1u, stats.opcode_markov_hist[0].at(SpvOpCapability).at(SpvOpMemoryModel));
+  EXPECT_EQ(
+      1u, stats.opcode_markov_hist[0].at(SpvOpExtension).at(SpvOpMemoryModel));
+  EXPECT_EQ(
+      1u, stats.opcode_markov_hist[0].at(SpvOpMemoryModel).at(SpvOpTypeInt));
+  EXPECT_EQ(
+      1u, stats.opcode_markov_hist[0].at(SpvOpTypeInt).at(SpvOpTypeInt));
+  EXPECT_EQ(
+      1u, stats.opcode_markov_hist[0].at(SpvOpTypeInt).at(SpvOpTypeFloat));
+
+  EXPECT_EQ(3u, stats.opcode_markov_hist[1].size());
+  EXPECT_EQ(4u, stats.opcode_markov_hist[1].at(SpvOpCapability).size());
+  EXPECT_EQ(1u, stats.opcode_markov_hist[1].at(SpvOpMemoryModel).size());
+  EXPECT_EQ(1u, stats.opcode_markov_hist[1].at(SpvOpTypeInt).size());
+  EXPECT_EQ(
+      2u, stats.opcode_markov_hist[1].at(SpvOpCapability).at(SpvOpCapability));
+  EXPECT_EQ(
+      1u, stats.opcode_markov_hist[1].at(SpvOpCapability).at(SpvOpExtension));
+  EXPECT_EQ(
+      2u, stats.opcode_markov_hist[1].at(SpvOpCapability).at(SpvOpMemoryModel));
+  EXPECT_EQ(
+      1u, stats.opcode_markov_hist[1].at(SpvOpCapability).at(SpvOpTypeInt));
+  EXPECT_EQ(
+      1u, stats.opcode_markov_hist[1].at(SpvOpMemoryModel).at(SpvOpTypeInt));
+  EXPECT_EQ(
+      1u, stats.opcode_markov_hist[1].at(SpvOpTypeInt).at(SpvOpTypeFloat));
+}
+
 }  // namespace

--- a/test/stats/stats_analyzer_test.cpp
+++ b/test/stats/stats_analyzer_test.cpp
@@ -161,10 +161,10 @@ TEST(StatsAnalyzer, OpcodeMarkov) {
   analyzer.WriteOpcodeMarkov(ss);
   const std::string output = ss.str();
   const std::string expected_output =
-      "FMul -> FSub 75% (base rate 40%, pair occurances 300)\n"
-      "FMul -> FAdd 25% (base rate 20%, pair occurances 100)\n"
-      "FAdd -> FAdd 50% (base rate 20%, pair occurances 100)\n"
-      "FAdd -> FMul 50% (base rate 40%, pair occurances 100)\n";
+      "FMul -> FSub 75% (base rate 40%, pair occurrences 300)\n"
+      "FMul -> FAdd 25% (base rate 20%, pair occurrences 100)\n"
+      "FAdd -> FAdd 50% (base rate 20%, pair occurrences 100)\n"
+      "FAdd -> FMul 50% (base rate 40%, pair occurrences 100)\n";
 
   EXPECT_EQ(expected_output, output);
 }

--- a/test/stats/stats_analyzer_test.cpp
+++ b/test/stats/stats_analyzer_test.cpp
@@ -161,10 +161,10 @@ TEST(StatsAnalyzer, OpcodeMarkov) {
   analyzer.WriteOpcodeMarkov(ss);
   const std::string output = ss.str();
   const std::string expected_output =
-      "FAdd -> FAdd 50% (base rate 20%, pair occurances 100)\n"
-      "FAdd -> FMul 50% (base rate 40%, pair occurances 100)\n"
       "FMul -> FSub 75% (base rate 40%, pair occurances 300)\n"
-      "FMul -> FAdd 25% (base rate 20%, pair occurances 100)\n";
+      "FMul -> FAdd 25% (base rate 20%, pair occurances 100)\n"
+      "FAdd -> FAdd 50% (base rate 20%, pair occurances 100)\n"
+      "FAdd -> FMul 50% (base rate 40%, pair occurances 100)\n";
 
   EXPECT_EQ(expected_output, output);
 }

--- a/tools/stats/stats.cpp
+++ b/tools/stats/stats.cpp
@@ -105,13 +105,13 @@ int main(int argc, char** argv) {
     return return_code;
   }
 
-  std::cerr << "Processing " << paths.size()
-            << " files..." << std::endl;
+  std::cerr << "Processing " << paths.size() << " files..." << std::endl;
 
   ScopedContext ctx(SPV_ENV_UNIVERSAL_1_1);
   SetContextMessageConsumer(ctx.context, DiagnosticsMessageHandler);
 
   libspirv::SpirvStats stats;
+  stats.opcode_markov_hist.resize(1);
 
   for (size_t index = 0; index < paths.size(); ++index) {
     const size_t kMilestonePeriod = 1000;
@@ -147,6 +147,9 @@ int main(int argc, char** argv) {
 
   out << std::endl;
   analyzer.WriteOpcode(out);
+
+  out << std::endl;
+  analyzer.WriteOpcodeMarkov(out);
 
   return 0;
 }

--- a/tools/stats/stats_analyzer.h
+++ b/tools/stats/stats_analyzer.h
@@ -23,11 +23,16 @@ class StatsAnalyzer {
  public:
   explicit StatsAnalyzer(const libspirv::SpirvStats& stats);
 
+  // Writes respective histograms to |out|.
   void WriteVersion(std::ostream& out);
   void WriteGenerator(std::ostream& out);
   void WriteCapability(std::ostream& out);
   void WriteExtension(std::ostream& out);
   void WriteOpcode(std::ostream& out);
+
+  // Writes first order Markov analysis to |out|.
+  // stats_.opcode_markov_hist needs to contain raw data for at least one
+  // level.
   void WriteOpcodeMarkov(std::ostream& out);
 
  private:

--- a/tools/stats/stats_analyzer.h
+++ b/tools/stats/stats_analyzer.h
@@ -28,6 +28,7 @@ class StatsAnalyzer {
   void WriteCapability(std::ostream& out);
   void WriteExtension(std::ostream& out);
   void WriteOpcode(std::ostream& out);
+  void WriteOpcodeMarkov(std::ostream& out);
 
  private:
   const libspirv::SpirvStats& stats_;


### PR DESCRIPTION
Added data structure to SpirvStats which is used to collect statistics
on opcodes following other opcodes.

Added a simple analysis print-out to spirv-stats.