### PR TITLE
Inline: Do not inline functions with multiple returns (for now)

### DIFF
--- a/source/opt/basic_block.h
+++ b/source/opt/basic_block.h
@@ -52,8 +52,12 @@ class BasicBlock {
 
   iterator begin() { return iterator(&insts_, insts_.begin()); }
   iterator end() { return iterator(&insts_, insts_.end()); }
-  const_iterator cbegin() { return const_iterator(&insts_, insts_.cbegin()); }
-  const_iterator cend() { return const_iterator(&insts_, insts_.cend()); }
+  const_iterator cbegin() const {
+    return const_iterator(&insts_, insts_.cbegin());
+  }
+  const_iterator cend() const {
+    return const_iterator(&insts_, insts_.cend());
+  }
 
   // Runs the given function |f| on each instruction in this basic block, and
   // optionally on the debug line instructions that might precede them.

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -120,6 +120,9 @@ class InlinePass : public Pass {
   // Returns true if |inst| is a function call that can be inlined.
   bool IsInlinableFunctionCall(const ir::Instruction* inst);
 
+  // Returns true if |func| is a function that can be inlined.
+  bool IsInlinableFunction(const ir::Function* func);
+
   // Exhaustively inline all function calls in func as well as in
   // all code that is inlined into func. Return true if func is modified.
   bool Inline(ir::Function* func);
@@ -135,6 +138,9 @@ class InlinePass : public Pass {
 
   // Map from block's label id to block.
   std::unordered_map<uint32_t, ir::BasicBlock*> id2block_;
+
+  // Set of ids of inlinable function 
+  std::set<uint32_t> inlinable_;
 
   // Next unused ID
   uint32_t next_id_;

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -62,7 +62,9 @@ Options:
   --unify-const
                Remove the duplicated constants.
   --inline-entry-points-all
-               Exhaustively inline all function calls in entry points
+               Exhaustively inline all function calls in entry point functions.
+               Currently does not inline calls to functions with multiple
+               returns.
   --flatten-decorations
                Replace decoration groups with repeated OpDecorate and
                OpMemberDecorate instructions.


### PR DESCRIPTION
Currently the exhaustive inliner is generating invalid SPIR-V when inlining functions with multiple returns. 

This fix will quickly stop generation of invalid SPIR-V by inhibiting inlining of any such functions.

I will follow this up shortly with inlining such functions where no return is in a loop. This is likely the majority of the cases.