### PR TITLE
Inline: Inline early return function if no returns in loop.

### DIFF
--- a/source/opt/basic_block.h
+++ b/source/opt/basic_block.h
@@ -48,7 +48,7 @@ class BasicBlock {
   Instruction& Label() { return *label_; }
 
   // Returns the id of the label at the top of this block
-  inline uint32_t label_id() const { return label_->result_id(); }
+  inline uint32_t id() const { return label_->result_id(); }
 
   iterator begin() { return iterator(&insts_, insts_.begin()); }
   iterator end() { return iterator(&insts_, insts_.end()); }

--- a/source/opt/function.h
+++ b/source/opt/function.h
@@ -85,7 +85,7 @@ class Function {
   std::unique_ptr<Instruction> def_inst_;
   // All parameters to this function.
   std::vector<std::unique_ptr<Instruction>> params_;
-  // All basic blocks inside this function.
+  // All basic blocks inside this function in specification order
   std::vector<std::unique_ptr<BasicBlock>> blocks_;
   // The OpFunctionEnd instruction.
   std::unique_ptr<Instruction> end_inst_;

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -507,7 +507,7 @@ void InlinePass::ComputeStructuredSuccessors(ir::Function* func) {
   }
 }
 
-InlinePass::GetBlocksFunction InlinePass::SuccessorsFunction() {
+InlinePass::GetBlocksFunction InlinePass::StructuredSuccessorsFunction() {
   return [this](const ir::BasicBlock* block) {
     return &(block2structuredSuccs_[block]);
   };
@@ -526,7 +526,7 @@ bool InlinePass::hasNoReturnInLoop(ir::Function* func) {
   auto ignore_edge = [](cbb_ptr, cbb_ptr) {};
   std::list<const ir::BasicBlock*> structuredOrder;
   spvtools::CFA<ir::BasicBlock>::DepthFirstTraversal(
-    &*func->begin(), SuccessorsFunction(), ignore_block,
+    &*func->begin(), StructuredSuccessorsFunction(), ignore_block,
     [&](cbb_ptr b) { structuredOrder.push_front(b); }, ignore_edge);
   // Search for returns in loops. Only need to track outermost loop
   bool return_in_loop = false;

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -27,7 +27,6 @@ static const int kSpvTypePointerStorageClass = 1;
 static const int kSpvTypePointerTypeId = 2;
 static const int kSpvLoopMergeMergeBlockId = 0;
 static const int kSpvSelectionMergeMergeBlockId = 0;
-static const int kSpvBranchTargetLabelId = 0;
 
 namespace spvtools {
 namespace opt {

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -530,7 +530,7 @@ bool InlinePass::HasNoReturnInLoop(ir::Function* func) {
     return false;
   // Compute structured block order. This order has the property
   // that dominators are before all blocks they dominate and merge blocks
-  // are after all blocks that are in the control construct their header.
+  // are after all blocks that are in the control constructs of their header.
   ComputeStructuredSuccessors(func);
   auto ignore_block = [](cbb_ptr) {};
   auto ignore_edge = [](cbb_ptr, cbb_ptr) {};

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -388,7 +388,7 @@ void InlinePass::GenInlineCode(
           const auto mapItr = callee2caller.find(*iid);
           if (mapItr != callee2caller.end()) {
             *iid = mapItr->second;
-          } else if (cpi->has_labels()) {
+          } else if (cpi->HasLabels()) {
             const ir::Instruction* inst =
                 def_use_mgr_->id_to_defs().find(*iid)->second;
             if (inst->opcode() == SpvOpLabel) {
@@ -468,7 +468,7 @@ bool InlinePass::Inline(ir::Function* func) {
   return modified;
 }
 
-bool InlinePass::hasMultipleReturns(ir::Function* func) {
+bool InlinePass::HasMultipleReturns(ir::Function* func) {
   bool seenReturn = false;
   bool multipleReturns = false;
   for (auto& blk : *func) {
@@ -513,10 +513,10 @@ InlinePass::GetBlocksFunction InlinePass::StructuredSuccessorsFunction() {
   };
 }
 
-bool InlinePass::hasNoReturnInLoop(ir::Function* func) {
+bool InlinePass::HasNoReturnInLoop(ir::Function* func) {
   // If control not structured, do not do loop/return analysis
   // TODO: Analyze returns in non-structured control flow
-  if (!module_->hasCapability(SpvCapabilityShader))
+  if (!module_->HasCapability(SpvCapabilityShader))
     return false;
   // Compute structured block order. This order has the property
   // that dominators are before all blocks they dominate and merge blocks
@@ -557,13 +557,13 @@ bool InlinePass::hasNoReturnInLoop(ir::Function* func) {
 
 void InlinePass::ReturnAnalysis(ir::Function* func) {
   // Look for multiple returns
-  if (!hasMultipleReturns(func)) {
+  if (!HasMultipleReturns(func)) {
     no_return_in_loop_.insert(func->result_id());
     return;
   }
   early_return_.insert(func->result_id());
   // If multiple returns, see if any are in a loop
-  if (hasNoReturnInLoop(func))
+  if (HasNoReturnInLoop(func))
     no_return_in_loop_.insert(func->result_id());
 }
 

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -504,17 +504,17 @@ void InlinePass::ComputeStructuredSuccessors(ir::Function* func) {
   for (auto& blk : *func) {
     uint32_t mbid = MergeBlockIdIfAny(blk);
     if (mbid != 0)
-      block2structuredSuccs_[&blk].push_back(id2block_[mbid]);
+      block2structured_succs_[&blk].push_back(id2block_[mbid]);
     // add true successors
     blk.ForEachSuccessorLabel([&blk, this](uint32_t sbid) {
-      block2structuredSuccs_[&blk].push_back(id2block_[sbid]);
+      block2structured_succs_[&blk].push_back(id2block_[sbid]);
     });
   }
 }
 
 InlinePass::GetBlocksFunction InlinePass::StructuredSuccessorsFunction() {
   return [this](const ir::BasicBlock* block) {
-    return &(block2structuredSuccs_[block]);
+    return &(block2structured_succs_[block]);
   };
 }
 
@@ -599,7 +599,7 @@ void InlinePass::Initialize(ir::Module* module) {
 
   id2function_.clear();
   id2block_.clear();
-  block2structuredSuccs_.clear();
+  block2structured_succs_.clear();
   inlinable_.clear();
   for (auto& fn : *module_) {
     // Initialize function and block maps.

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -525,7 +525,7 @@ bool InlinePass::HasNoReturnInLoop(ir::Function* func) {
     return false;
   // Compute structured block order. This order has the property
   // that dominators are before all blocks they dominate and merge blocks
-  // are after all blocks that are control dependent on their header.
+  // are after all blocks that are in the control construct their header.
   ComputeStructuredSuccessors(func);
   auto ignore_block = [](cbb_ptr) {};
   auto ignore_edge = [](cbb_ptr, cbb_ptr) {};

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -555,7 +555,7 @@ bool InlinePass::HasNoReturnInLoop(ir::Function* func) {
   return !return_in_loop;
 }
 
-void InlinePass::ReturnAnalysis(ir::Function* func) {
+void InlinePass::AnalyzeReturns(ir::Function* func) {
   // Look for multiple returns
   if (!HasMultipleReturns(func)) {
     no_return_in_loop_.insert(func->result_id());
@@ -576,7 +576,7 @@ bool InlinePass::IsInlinableFunction(ir::Function* func) {
   // the returns as a branch to the loop's merge block. However, this can only
   // done validly if the return was not in a loop in the original function.
   // Also remember functions with multiple (early) returns.
-  ReturnAnalysis(func);
+  AnalyzeReturns(func);
   const auto ci = no_return_in_loop_.find(func->result_id());
   return ci != no_return_in_loop_.cend();
 }

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -108,19 +108,19 @@ std::unique_ptr<ir::Instruction> InlinePass::NewLabel(uint32_t label_id) {
 }
 
 uint32_t InlinePass::GetFalseId() {
-  if (falseId != 0)
-    return falseId;
-  falseId = module_->GetGlobalValue(SpvOpConstantFalse);
-  if (falseId != 0)
-    return falseId;
+  if (false_id_ != 0)
+    return false_id_;
+  false_id_ = module_->GetGlobalValue(SpvOpConstantFalse);
+  if (false_id_ != 0)
+    return false_id_;
   uint32_t boolId = module_->GetGlobalValue(SpvOpTypeBool);
   if (boolId == 0) {
     boolId = TakeNextId();
     module_->AddGlobalValue(SpvOpTypeBool, boolId, 0);
   }
-  falseId = TakeNextId();
-  module_->AddGlobalValue(SpvOpConstantFalse, falseId, boolId);
-  return falseId;
+  false_id_ = TakeNextId();
+  module_->AddGlobalValue(SpvOpConstantFalse, false_id_, boolId);
+  return false_id_;
 }
 
 void InlinePass::MapParams(
@@ -590,7 +590,7 @@ void InlinePass::Initialize(ir::Module* module) {
   // Save module.
   module_ = module;
 
-  falseId = 0;
+  false_id_ = 0;
 
   id2function_.clear();
   id2block_.clear();

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -133,7 +133,7 @@ void InlinePass::MapParams(
         const uint32_t pid = cpi->result_id();
         (*callee2caller)[pid] = call_inst_itr->GetSingleWordOperand(
             kSpvFunctionCallArgumentId + param_idx);
-        param_idx++;
+        ++param_idx;
       });
 }
 
@@ -150,7 +150,7 @@ void InlinePass::CloneAndMapLocals(
     var_inst->SetResultId(newId);
     (*callee2caller)[callee_var_itr->result_id()] = newId;
     new_vars->push_back(std::move(var_inst));
-    callee_var_itr++;
+    ++callee_var_itr;
   }
 }
 
@@ -294,7 +294,7 @@ void InlinePass::GenInlineCode(
         if (firstBlock) {
           // Copy contents of original caller block up to call instruction.
           for (auto cii = call_block_itr->begin(); cii != call_inst_itr;
-               cii++) {
+               ++cii) {
             std::unique_ptr<ir::Instruction> cp_inst(new ir::Instruction(*cii));
             // Remember same-block ops for possible regeneration.
             if (IsSameBlockOp(&*cp_inst)) {
@@ -364,7 +364,7 @@ void InlinePass::GenInlineCode(
         }
         // Copy remaining instructions from caller block.
         auto cii = call_inst_itr;
-        for (cii++; cii != call_block_itr->end(); cii++) {
+        for (++cii; cii != call_block_itr->end(); ++cii) {
           std::unique_ptr<ir::Instruction> cp_inst(new ir::Instruction(*cii));
           // If multiple blocks generated, regenerate any same-block
           // instruction that has not been seen in this last block.
@@ -428,7 +428,7 @@ bool InlinePass::IsInlinableFunctionCall(const ir::Instruction* inst) {
 bool InlinePass::Inline(ir::Function* func) {
   bool modified = false;
   // Using block iterators here because of block erasures and insertions.
-  for (auto bi = func->begin(); bi != func->end(); bi++) {
+  for (auto bi = func->begin(); bi != func->end(); ++bi) {
     for (auto ii = bi->begin(); ii != bi->end();) {
       if (IsInlinableFunctionCall(&*ii)) {
         // Inline call.
@@ -461,7 +461,7 @@ bool InlinePass::Inline(ir::Function* func) {
         ii = bi->begin();
         modified = true;
       } else {
-        ii++;
+        ++ii;
       }
     }
   }
@@ -473,7 +473,7 @@ bool InlinePass::HasMultipleReturns(ir::Function* func) {
   bool multipleReturns = false;
   for (auto& blk : *func) {
     auto lii = blk.cend();
-    lii--;
+    --lii;
     if (lii->opcode() == SpvOpReturn || lii->opcode() == SpvOpReturnValue) {
       if (seenReturn) {
         multipleReturns = true;
@@ -487,10 +487,10 @@ bool InlinePass::HasMultipleReturns(ir::Function* func) {
 
 uint32_t InlinePass::MergeBlockIdIfAny(const ir::BasicBlock& blk) {
   auto mii = blk.cend();
-  mii--;
+  --mii;
   uint32_t mbid = 0;
   if (mii != blk.cbegin()) {
-    mii--;
+    --mii;
     if (mii->opcode() == SpvOpLoopMerge)
       mbid = mii->GetSingleWordOperand(kSpvLoopMergeMergeBlockId);
     else if (mii->opcode() == SpvOpSelectionMerge)
@@ -542,7 +542,7 @@ bool InlinePass::HasNoReturnInLoop(ir::Function* func) {
       outerLoopMergeId = 0;
     // Return block
     auto lii = blk->cend();
-    lii--;
+    --lii;
     if (lii->opcode() == SpvOpReturn || lii->opcode() == SpvOpReturnValue) {
       if (outerLoopMergeId != 0) {
         return_in_loop = true;
@@ -551,7 +551,7 @@ bool InlinePass::HasNoReturnInLoop(ir::Function* func) {
     }
     else if (lii != blk->cbegin()) {
       auto mii = lii;
-      mii--;
+      --mii;
       // Entering outermost loop
       if (mii->opcode() == SpvOpLoopMerge && outerLoopMergeId == 0)
         outerLoopMergeId = mii->GetSingleWordOperand(kSpvLoopMergeMergeBlockId);

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -82,6 +82,8 @@ class InlinePass : public Pass {
   // Return new label.
   std::unique_ptr<ir::Instruction> NewLabel(uint32_t label_id);
 
+  // Returns the id for the boolean false value. Looks in the module first
+  // and creates it if not found. Remembers it for future calls.
   uint32_t GetFalseId();
 
   // Map callee params to caller args
@@ -189,7 +191,7 @@ class InlinePass : public Pass {
   std::unordered_map<const ir::BasicBlock*, std::vector<ir::BasicBlock*>> block2structuredSuccs_;
 
   // result id for OpConstantFalse
-  uint32_t falseId;
+  uint32_t false_id_;
 
   // Next unused ID
   uint32_t next_id_;

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -197,7 +197,7 @@ class InlinePass : public Pass {
   // Map from block to its structured successor blocks. See 
   // ComputeStructuredSuccessors() for definition.
   std::unordered_map<const ir::BasicBlock*, std::vector<ir::BasicBlock*>>
-      block2structuredSuccs_;
+      block2structured_succs_;
 
   // result id for OpConstantFalse
   uint32_t false_id_;

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include <unordered_map>
 #include <vector>
+#include <list>
 
 #include "def_use_manager.h"
 #include "module.h"
@@ -31,7 +32,13 @@ namespace opt {
 
 // See optimizer.hpp for documentation.
 class InlinePass : public Pass {
+
+  using cbb_ptr = const ir::BasicBlock*;
+
  public:
+   using GetBlocksFunction =
+     std::function<std::vector<ir::BasicBlock*>*(const ir::BasicBlock*)>;
+
   InlinePass();
   Status Process(ir::Module*) override;
 
@@ -56,6 +63,14 @@ class InlinePass : public Pass {
   // Add unconditional branch to labelId to end of block block_ptr.
   void AddBranch(uint32_t labelId, std::unique_ptr<ir::BasicBlock>* block_ptr);
 
+  // Add conditional branch to end of block |block_ptr|.
+  void AddBranchCond(uint32_t cond_id, uint32_t true_id,
+    uint32_t false_id, std::unique_ptr<ir::BasicBlock>* block_ptr);
+
+  // Add unconditional branch to labelId to end of block block_ptr.
+  void AddLoopMerge(uint32_t merge_id, uint32_t continue_id,
+                    std::unique_ptr<ir::BasicBlock>* block_ptr);
+
   // Add store of valId to ptrId to end of block block_ptr.
   void AddStore(uint32_t ptrId, uint32_t valId,
                 std::unique_ptr<ir::BasicBlock>* block_ptr);
@@ -66,6 +81,8 @@ class InlinePass : public Pass {
 
   // Return new label.
   std::unique_ptr<ir::Instruction> NewLabel(uint32_t label_id);
+
+  uint32_t GetFalseId();
 
   // Map callee params to caller args
   void MapParams(ir::Function* calleeFn,
@@ -117,11 +134,31 @@ class InlinePass : public Pass {
                      ir::UptrVectorIterator<ir::Instruction> call_inst_itr,
                      ir::UptrVectorIterator<ir::BasicBlock> call_block_itr);
 
-  // Returns true if |inst| is a function call that can be inlined.
+  // Return true if |inst| is a function call that can be inlined.
   bool IsInlinableFunctionCall(const ir::Instruction* inst);
 
-  // Returns true if |func| is a function that can be inlined.
-  bool IsInlinableFunction(const ir::Function* func);
+  // Compute structured successors for function |func|.
+  // A block's structured successors are preceded by its
+  // merge block if its a header. This assures correct depth
+  // first search in the presence of early returns and kills.
+  void ComputeStructuredSuccessors(ir::Function* func);
+  
+  // Return function to return successors for a given block
+  GetBlocksFunction SuccessorsFunction();
+
+  // Return true if |func| has multiple returns
+  bool hasMultipleReturns(ir::Function* func);
+
+  // Return true if |func| has no return in a loop. The current analysis
+  // requires structured control flow, so return false if control flow not
+  // structured ie. module is not a shader.
+  bool hasNoReturnInLoop(ir::Function* func);
+
+  // Find all functions with multiple returns and no returns in loops
+  void ReturnAnalysis(ir::Function* func);
+
+  // Return true if |func| is a function that can be inlined.
+  bool IsInlinableFunction(ir::Function* func);
 
   // Exhaustively inline all function calls in func as well as in
   // all code that is inlined into func. Return true if func is modified.
@@ -139,8 +176,20 @@ class InlinePass : public Pass {
   // Map from block's label id to block.
   std::unordered_map<uint32_t, ir::BasicBlock*> id2block_;
 
-  // Set of ids of inlinable function 
+  // Set of ids of functions with early returns
+  std::set<uint32_t> early_return_;
+
+  // Set of ids of functions with no returns in loop
+  std::set<uint32_t> no_return_in_loop_;
+
+  // Set of ids of inlinable functions
   std::set<uint32_t> inlinable_;
+
+  // Map from block to its structured successor blocks
+  std::unordered_map<const ir::BasicBlock*, std::vector<ir::BasicBlock*>> block2structuredSuccs_;
+
+  // result id for OpConstantFalse
+  uint32_t falseId;
 
   // Next unused ID
   uint32_t next_id_;

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -160,7 +160,7 @@ class InlinePass : public Pass {
   bool HasNoReturnInLoop(ir::Function* func);
 
   // Find all functions with multiple returns and no returns in loops
-  void ReturnAnalysis(ir::Function* func);
+  void AnalyzeReturns(ir::Function* func);
 
   // Return true if |func| is a function that can be inlined.
   bool IsInlinableFunction(ir::Function* func);

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -148,7 +148,8 @@ class InlinePass : public Pass {
   // together with its declared merge block if it has one.
   // When order matters, the merge block always appears first.
   // This assures correct depth first search in the presence of early 
-  // returns and kills.
+  // returns and kills. If the successor vector contain duplicates
+  // if the merge block, they are safely ignored by DFS.
   void ComputeStructuredSuccessors(ir::Function* func);
   
   // Return function to return ordered structure successors for a given block

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -139,6 +139,10 @@ class InlinePass : public Pass {
   // Return true if |inst| is a function call that can be inlined.
   bool IsInlinableFunctionCall(const ir::Instruction* inst);
 
+  // Returns the id of the merge block declared by a merge instruction in 
+  // this block, if any.  If none, returns zero.
+  uint32_t MergeBlockIdIfAny(const ir::BasicBlock& blk);
+
   // Compute structured successors for function |func|.
   // A block's structured successors are the blocks it branches to
   // together with its declared merge block if it has one.

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -140,13 +140,16 @@ class InlinePass : public Pass {
   bool IsInlinableFunctionCall(const ir::Instruction* inst);
 
   // Compute structured successors for function |func|.
-  // A block's structured successors are preceded by its
-  // merge block if its a header. This assures correct depth
-  // first search in the presence of early returns and kills.
+  // A block's structured successors are the blocks it branches to
+  // together with its declared merge block if it has one.
+  // When order matters, the merge block always appears first.
+  // This assures correct depth first search in the presence of early 
+  // returns and kills.
   void ComputeStructuredSuccessors(ir::Function* func);
   
-  // Return function to return successors for a given block
-  GetBlocksFunction SuccessorsFunction();
+  // Return function to return ordered structure successors for a given block
+  // Assumes ComputeStructuredSuccessors() has been called.
+  GetBlocksFunction StructuredSuccessorsFunction();
 
   // Return true if |func| has multiple returns
   bool hasMultipleReturns(ir::Function* func);

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -152,12 +152,12 @@ class InlinePass : public Pass {
   GetBlocksFunction StructuredSuccessorsFunction();
 
   // Return true if |func| has multiple returns
-  bool hasMultipleReturns(ir::Function* func);
+  bool HasMultipleReturns(ir::Function* func);
 
   // Return true if |func| has no return in a loop. The current analysis
   // requires structured control flow, so return false if control flow not
   // structured ie. module is not a shader.
-  bool hasNoReturnInLoop(ir::Function* func);
+  bool HasNoReturnInLoop(ir::Function* func);
 
   // Find all functions with multiple returns and no returns in loops
   void ReturnAnalysis(ir::Function* func);

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -194,8 +194,10 @@ class InlinePass : public Pass {
   // Set of ids of inlinable functions
   std::set<uint32_t> inlinable_;
 
-  // Map from block to its structured successor blocks
-  std::unordered_map<const ir::BasicBlock*, std::vector<ir::BasicBlock*>> block2structuredSuccs_;
+  // Map from block to its structured successor blocks. See 
+  // ComputeStructuredSuccessors() for definition.
+  std::unordered_map<const ir::BasicBlock*, std::vector<ir::BasicBlock*>>
+      block2structuredSuccs_;
 
   // result id for OpConstantFalse
   uint32_t false_id_;

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -171,7 +171,7 @@ class Instruction {
   inline void ForEachInId(const std::function<void(const uint32_t*)>& f) const;
 
   // Returns true if any operands can be labels
-  inline bool has_labels() const;
+  inline bool HasLabels() const;
 
   // Pushes the binary segments for this instruction into the back of *|binary|.
   void ToBinaryWithoutAttachedDebugInsts(std::vector<uint32_t>* binary) const;
@@ -257,7 +257,7 @@ inline void Instruction::ForEachInId(
     if (opnd.type == SPV_OPERAND_TYPE_ID) f(&opnd.words[0]);
 }
 
-inline bool Instruction::has_labels() const {
+inline bool Instruction::HasLabels() const {
   switch (opcode_) {
     case SpvOpSelectionMerge:
     case SpvOpBranch:

--- a/source/opt/module.cpp
+++ b/source/opt/module.cpp
@@ -58,6 +58,21 @@ std::vector<const Instruction*> Module::GetConstants() const {
   return insts;
 };
 
+uint32_t Module::GetGlobalValue(SpvOp opcode) const {
+  for (uint32_t i = 0; i < types_values_.size(); ++i) {
+    if (types_values_[i]->opcode() == opcode)
+      return types_values_[i]->result_id();
+  }
+  return 0;
+}
+
+void Module::AddGlobalValue(SpvOp opcode, uint32_t result_id,
+                            uint32_t type_id) {
+  std::unique_ptr<ir::Instruction> newGlobal(new ir::Instruction(
+    opcode, type_id, result_id, {}));
+  AddGlobalValue(std::move(newGlobal));
+}
+
 void Module::ForEachInst(const std::function<void(Instruction*)>& f,
                          bool run_on_debug_line_insts) {
 #define DELEGATE(i) i->ForEachInst(f, run_on_debug_line_insts)
@@ -121,6 +136,16 @@ uint32_t Module::ComputeIdBound() const {
   }, true /* scan debug line insts as well */);
 
   return highest + 1;
+}
+
+bool Module::hasCapability(uint32_t cap) {
+  for (auto& ci : capabilities_) {
+    uint32_t tcap = ci->GetSingleWordOperand(0);
+    if (tcap == cap) {
+      return true;
+    }
+  }
+  return false;
 }
 
 }  // namespace ir

--- a/source/opt/module.cpp
+++ b/source/opt/module.cpp
@@ -138,7 +138,7 @@ uint32_t Module::ComputeIdBound() const {
   return highest + 1;
 }
 
-bool Module::hasCapability(uint32_t cap) {
+bool Module::HasCapability(uint32_t cap) {
   for (auto& ci : capabilities_) {
     uint32_t tcap = ci->GetSingleWordOperand(0);
     if (tcap == cap) {

--- a/source/opt/module.h
+++ b/source/opt/module.h
@@ -143,7 +143,7 @@ class Module {
   uint32_t ComputeIdBound() const;
 
   // Returns true if module has capability |cap|
-  bool hasCapability(uint32_t cap);
+  bool HasCapability(uint32_t cap);
 
  private:
   ModuleHeader header_;  // Module header

--- a/source/opt/module.h
+++ b/source/opt/module.h
@@ -105,10 +105,6 @@ class Module {
   inline IteratorRange<inst_iterator> entry_points();
   inline IteratorRange<const_inst_iterator> entry_points() const;
 
-  // Iterators for capability instructions contained in this module
-  //inline IteratorRange<inst_iterator> capabilities();
-  //inline IteratorRange<const_inst_iterator> capabilities() const;
-
   // Clears all debug instructions (excluding OpLine & OpNoLine).
   void debug_clear() { debugs_.clear(); }
 

--- a/source/opt/module.h
+++ b/source/opt/module.h
@@ -86,6 +86,12 @@ class Module {
   std::vector<Instruction*> GetConstants();
   std::vector<const Instruction*> GetConstants() const;
 
+  // Return result id of global value with |opcode|, 0 if not present.
+  uint32_t GetGlobalValue(SpvOp opcode) const;
+
+  // Add global value with |opcode|, |result_id| and |type_id|
+  void AddGlobalValue(SpvOp opcode, uint32_t result_id, uint32_t type_id);
+
   inline uint32_t id_bound() const { return header_.bound; }
 
   // Iterators for debug instructions (excluding OpLine & OpNoLine) contained in
@@ -98,6 +104,10 @@ class Module {
   // Iterators for entry point instructions contained in this module
   inline IteratorRange<inst_iterator> entry_points();
   inline IteratorRange<const_inst_iterator> entry_points() const;
+
+  // Iterators for capability instructions contained in this module
+  //inline IteratorRange<inst_iterator> capabilities();
+  //inline IteratorRange<const_inst_iterator> capabilities() const;
 
   // Clears all debug instructions (excluding OpLine & OpNoLine).
   void debug_clear() { debugs_.clear(); }
@@ -131,6 +141,9 @@ class Module {
 
   // Returns 1 more than the maximum Id value mentioned in the module.
   uint32_t ComputeIdBound() const;
+
+  // Returns true if module has capability |cap|
+  bool hasCapability(uint32_t cap);
 
  private:
   ModuleHeader header_;  // Module header

--- a/test/opt/inline_test.cpp
+++ b/test/opt/inline_test.cpp
@@ -1358,7 +1358,7 @@ TEST_F(InlineTest, OpImageAndOpSampledImageOutOfBlock) {
       /* skip_nop = */ false, /* do_validate = */ true);
 }
 
-TEST_F(InlineTest, EarlyReturnFunctionIsNotInlined) {
+TEST_F(InlineTest, EarlyReturnFunctionInlined) {
   // #version 140
   // 
   // in vec4 BaseColor;
@@ -1376,7 +1376,7 @@ TEST_F(InlineTest, EarlyReturnFunctionIsNotInlined) {
   //     gl_FragColor = color; 
   // }
 
-  const std::string assembly =
+  const std::string predefs =
       R"(OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
@@ -1405,20 +1405,10 @@ OpName %gl_FragColor "gl_FragColor"
 %BaseColor = OpVariable %_ptr_Input_v4float Input
 %_ptr_Output_v4float = OpTypePointer Output %v4float
 %gl_FragColor = OpVariable %_ptr_Output_v4float Output
-%main = OpFunction %void None %10
-%22 = OpLabel
-%color = OpVariable %_ptr_Function_v4float Function
-%param = OpVariable %_ptr_Function_v4float Function
-%23 = OpLoad %v4float %BaseColor
-OpStore %param %23
-%24 = OpFunctionCall %float %foo_vf4_ %param
-%25 = OpCompositeConstruct %v4float %24 %24 %24 %24
-OpStore %color %25
-%26 = OpLoad %v4float %color
-OpStore %gl_FragColor %26
-OpReturn
-OpFunctionEnd
-%foo_vf4_ = OpFunction %float None %14
+)";
+
+  const std::string nonEntryFuncs =
+      R"(%foo_vf4_ = OpFunction %float None %14
 %bar = OpFunctionParameter %_ptr_Function_v4float
 %27 = OpLabel
 %28 = OpAccessChain %_ptr_Function_float %bar %uint_0
@@ -1432,6 +1422,156 @@ OpReturnValue %float_0
 %33 = OpAccessChain %_ptr_Function_float %bar %uint_0
 %34 = OpLoad %float %33
 OpReturnValue %34
+OpFunctionEnd
+)";
+
+  const std::string before =
+      R"(%main = OpFunction %void None %10
+%22 = OpLabel
+%color = OpVariable %_ptr_Function_v4float Function
+%param = OpVariable %_ptr_Function_v4float Function
+%23 = OpLoad %v4float %BaseColor
+OpStore %param %23
+%24 = OpFunctionCall %float %foo_vf4_ %param
+%25 = OpCompositeConstruct %v4float %24 %24 %24 %24
+OpStore %color %25
+%26 = OpLoad %v4float %color
+OpStore %gl_FragColor %26
+OpReturn
+OpFunctionEnd
+)";
+
+  const std::string after =
+      R"(%false = OpConstantFalse %bool
+%main = OpFunction %void None %10
+%22 = OpLabel
+%35 = OpVariable %_ptr_Function_float Function
+%color = OpVariable %_ptr_Function_v4float Function
+%param = OpVariable %_ptr_Function_v4float Function
+%23 = OpLoad %v4float %BaseColor
+OpStore %param %23
+OpBranch %36
+%36 = OpLabel
+OpLoopMerge %37 %38 None
+OpBranch %39
+%39 = OpLabel
+%40 = OpAccessChain %_ptr_Function_float %param %uint_0
+%41 = OpLoad %float %40
+%42 = OpFOrdLessThan %bool %41 %float_0
+OpSelectionMerge %43 None
+OpBranchConditional %42 %44 %43
+%44 = OpLabel
+OpStore %35 %float_0
+OpBranch %37
+%43 = OpLabel
+%45 = OpAccessChain %_ptr_Function_float %param %uint_0
+%46 = OpLoad %float %45
+OpStore %35 %46
+OpBranch %37
+%38 = OpLabel
+OpBranchConditional %false %36 %37
+%37 = OpLabel
+%24 = OpLoad %float %35
+%25 = OpCompositeConstruct %v4float %24 %24 %24 %24
+OpStore %color %25
+%26 = OpLoad %v4float %color
+OpStore %gl_FragColor %26
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndCheck<opt::InlinePass>(predefs + before + nonEntryFuncs, 
+      predefs + after + nonEntryFuncs, false, true);
+}
+TEST_F(InlineTest, EarlyReturnInLoopIsNotInlined) {
+  // #version 140
+  // 
+  // in vec4 BaseColor;
+  // 
+  // float foo(vec4 bar)
+  // {
+  //     while (true) {
+  //         if (bar.x < 0.0)
+  //             return 0.0;
+  //         return bar.x;
+  //     }
+  // }
+  // 
+  // void main()
+  // {
+  //     vec4 color = vec4(foo(BaseColor));
+  //     gl_FragColor = color; 
+  // }
+
+  const std::string assembly =
+      R"(OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %BaseColor %gl_FragColor
+OpExecutionMode %main OriginUpperLeft
+OpSource GLSL 140
+OpName %main "main"
+OpName %foo_vf4_ "foo(vf4;"
+OpName %bar "bar"
+OpName %color "color"
+OpName %BaseColor "BaseColor"
+OpName %param "param"
+OpName %gl_FragColor "gl_FragColor"
+%void = OpTypeVoid
+%10 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%v4float = OpTypeVector %float 4
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+%14 = OpTypeFunction %float %_ptr_Function_v4float
+%bool = OpTypeBool
+%true = OpConstantTrue %bool
+%uint = OpTypeInt 32 0
+%uint_0 = OpConstant %uint 0
+%_ptr_Function_float = OpTypePointer Function %float
+%float_0 = OpConstant %float 0
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%BaseColor = OpVariable %_ptr_Input_v4float Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%gl_FragColor = OpVariable %_ptr_Output_v4float Output
+%main = OpFunction %void None %10
+%23 = OpLabel
+%color = OpVariable %_ptr_Function_v4float Function
+%param = OpVariable %_ptr_Function_v4float Function
+%24 = OpLoad %v4float %BaseColor
+OpStore %param %24
+%25 = OpFunctionCall %float %foo_vf4_ %param
+%26 = OpCompositeConstruct %v4float %25 %25 %25 %25
+OpStore %color %26
+%27 = OpLoad %v4float %color
+OpStore %gl_FragColor %27
+OpReturn
+OpFunctionEnd
+%foo_vf4_ = OpFunction %float None %14
+%bar = OpFunctionParameter %_ptr_Function_v4float
+%28 = OpLabel
+OpBranch %29
+%29 = OpLabel
+OpLoopMerge %30 %31 None
+OpBranch %32
+%32 = OpLabel
+OpBranchConditional %true %33 %30
+%33 = OpLabel
+%34 = OpAccessChain %_ptr_Function_float %bar %uint_0
+%35 = OpLoad %float %34
+%36 = OpFOrdLessThan %bool %35 %float_0
+OpSelectionMerge %37 None
+OpBranchConditional %36 %38 %37
+%38 = OpLabel
+OpReturnValue %float_0
+%37 = OpLabel
+%39 = OpAccessChain %_ptr_Function_float %bar %uint_0
+%40 = OpLoad %float %39
+OpReturnValue %40
+%31 = OpLabel
+OpBranch %29
+%30 = OpLabel
+%41 = OpUndef %float
+OpReturnValue %41
 OpFunctionEnd
 )";
 


### PR DESCRIPTION
This creates a one-trip loop around the callee code before it is inlined. Returns are converted to branches to the loop's merge block. If a callee has any returns in a loop it is not inlined.