### PR TITLE
Add Local Access Chain Convert pass

### DIFF
--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -201,8 +201,9 @@ Optimizer::PassToken CreateInlinePass();
 // variables into equivalent sequences of loads, stores, extracts and inserts.
 //
 // This pass only processes entry point functions. It currently only converts
-// non-nested, non-ptr access chains. It does process modules with non-32-bit
-// integer types present.
+// non-nested, non-ptr access chains. It does not process modules with
+// non-32-bit integer types present. Optional memory access options on loads
+// and stores are ignored as we are only processing function scope variables.
 //
 // This pass unifies access to these variables to a single mode and simplifies
 // subsequent analysis and elimination of these variables along with their

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -201,7 +201,8 @@ Optimizer::PassToken CreateInlinePass();
 // variables into equivalent sequences of loads, stores, extracts and inserts.
 //
 // This pass only processes entry point functions. It currently only converts
-// non-ptr access chains.
+// non-nested, non-ptr access chains. It does process modules with non-32-bit
+// integer types present.
 //
 // This pass unifies access to these variables to a single mode and simplifies
 // subsequent analysis and elimination of these variables along with their

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -199,9 +199,13 @@ Optimizer::PassToken CreateInlinePass();
 // variables which are accessed only with loads, stores and access chains
 // with constant indices. It then converts all loads and stores of such
 // variables into equivalent sequences of loads, stores, extracts and inserts.
-// This unifies access to these variables to a single mode and simplifies
-// subsequent analysis and elimination of these variables along with loads
-// and stores allowing values to propagate further.
+//
+// This pass only processes entry point functions.
+//
+// This pass unifies access to these variables to a single mode and simplifies
+// subsequent analysis and elimination of these variables along with their
+// loads and stores allowing values to propagate to their points of use where
+// possible.
 Optimizer::PassToken CreateLocalAccessChainConvertPass();
 
 // Creates a compact ids pass.

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -200,7 +200,8 @@ Optimizer::PassToken CreateInlinePass();
 // with constant indices. It then converts all loads and stores of such
 // variables into equivalent sequences of loads, stores, extracts and inserts.
 //
-// This pass only processes entry point functions.
+// This pass only processes entry point functions. It currently only converts
+// non-ptr access chains.
 //
 // This pass unifies access to these variables to a single mode and simplifies
 // subsequent analysis and elimination of these variables along with their

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -194,6 +194,16 @@ Optimizer::PassToken CreateEliminateDeadConstantPass();
 // points are not changed.
 Optimizer::PassToken CreateInlinePass();
 
+// Creates a local access chain conversion pass.
+// A local access chain conversion pass identifies all function scope
+// variables which are accessed only with loads, stores and access chains
+// with constant indices. It then converts all loads and stores of such
+// variables into equivalent sequences of loads, stores, extracts and inserts.
+// This unifies access to these variables to a single mode and simplifies
+// subsequent analysis and elimination of these variables along with loads
+// and stores allowing values to propagate further.
+Optimizer::PassToken CreateLocalAccessChainConvertPass();
+
 // Creates a compact ids pass.
 // The pass remaps result ids to a compact and gapless range starting from %1.
 Optimizer::PassToken CreateCompactIdsPass();

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(SPIRV-Tools-opt
   inline_pass.h
   instruction.h
   ir_loader.h
+  local_access_chain_convert_pass.h
   log.h
   module.h
   null_pass.h
@@ -50,6 +51,7 @@ add_library(SPIRV-Tools-opt
   inline_pass.cpp
   instruction.cpp
   ir_loader.cpp
+  local_access_chain_convert_pass.cpp
   module.cpp
   set_spec_constant_default_value_pass.cpp
   optimizer.cpp

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -29,10 +29,6 @@
 */
 
 static const int kSpvEntryPointFunctionId = 1;
-static const int kSpvFunctionCallFunctionId = 0;
-static const int kSpvDecorationTargetId = 0;
-static const int kSpvDecorationDecoration = 1;
-static const int kSpvDecorationLinkageType = 3;
 static const int kSpvStorePtrId = 0;
 static const int kSpvStoreValId = 1;
 static const int kSpvLoadPtrId = 0;
@@ -40,18 +36,6 @@ static const int kSpvAccessChainPtrId = 0;
 static const int kSpvTypePointerStorageClass = 0;
 static const int kSpvTypePointerTypeId = 1;
 static const int kSpvConstantValue = 0;
-static const int kSpvExtractCompositeId = 0;
-static const int kSpvExtractIdx0 = 1;
-static const int kSpvInsertObjectId = 0;
-static const int kSpvInsertCompositeId = 1;
-static const int kSpvBranchCondConditionalId = 0;
-static const int kSpvBranchCondTrueLabId = 1;
-static const int kSpvBranchCondFalseLabId = 2;
-static const int kSpvSelectionMergeMergeBlockId = 0;
-static const int kSpvPhiVal0Id = 0;
-static const int kSpvPhiLab0Id = 1;
-static const int kSpvPhiVal1Id = 2;
-static const int kSpvLoopMergeMergeBlockId = 0;
 
 namespace spvtools {
 namespace opt {

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -267,7 +267,7 @@ void LocalAccessChainConvertPass::FindTargetVars(ir::Function* func) {
   }
 }
 
-bool LocalAccessChainConvertPass::LocalAccessChainConvert(ir::Function* func) {
+bool LocalAccessChainConvertPass::ConvertLocalAccessChains(ir::Function* func) {
   FindTargetVars(func);
   // Replace access chains of all targeted variables with equivalent
   // extract and insert sequences
@@ -348,7 +348,7 @@ Pass::Status LocalAccessChainConvertPass::ProcessImpl() {
   for (auto& e : module_->entry_points()) {
     ir::Function* fn =
         id2function_[e.GetSingleWordOperand(kSpvEntryPointFunctionId)];
-    modified = modified || LocalAccessChainConvert(fn);
+    modified = modified || ConvertLocalAccessChains(fn);
   }
 
   FinalizeNextId(module_);

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -67,9 +67,8 @@ bool LocalAccessChainConvertPass::IsTargetType(
 ir::Instruction* LocalAccessChainConvertPass::GetPtr(
     ir::Instruction* ip,
     uint32_t* varId) {
-  const uint32_t ptrId = ip->opcode() == SpvOpStore ?
-      ip->GetSingleWordInOperand(kSpvStorePtrId) :
-      ip->GetSingleWordInOperand(kSpvLoadPtrId);
+  const uint32_t ptrId = ip->GetSingleWordInOperand(
+    ip->opcode() == SpvOpStore ? kSpvStorePtrId : kSpvLoadPtrId);
   ir::Instruction* ptrInst = def_use_mgr_->GetDef(ptrId);
   *varId = IsNonPtrAccessChain(ptrInst->opcode()) ?
     ptrInst->GetSingleWordInOperand(kSpvAccessChainPtrId) :

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -175,10 +175,8 @@ void LocalAccessChainConvertPass::GenAccessChainLoadReplacement(
   // Build and append Extract
   const uint32_t extResultId = TakeNextId();
   const uint32_t ptrPteTypeId = GetPteTypeId(ptrInst);
-  std::vector<ir::Operand> ext_in_opnds;
-  ext_in_opnds.push_back(
-    ir::Operand(spv_operand_type_t::SPV_OPERAND_TYPE_ID,
-      std::initializer_list<uint32_t>{ldResultId}));
+  std::vector<ir::Operand> ext_in_opnds = 
+      {{spv_operand_type_t::SPV_OPERAND_TYPE_ID, {ldResultId}}};
   uint32_t iidIdx = 0;
   ptrInst->ForEachInId([&iidIdx, &ext_in_opnds, this](const uint32_t *iid) {
     if (iidIdx > 0) {
@@ -210,13 +208,9 @@ void LocalAccessChainConvertPass::GenAccessChainStoreReplacement(
 
   // Build and append Insert
   const uint32_t insResultId = TakeNextId();
-  std::vector<ir::Operand> ins_in_opnds;
-  ins_in_opnds.push_back(
-      ir::Operand(spv_operand_type_t::SPV_OPERAND_TYPE_ID,
-      std::initializer_list<uint32_t>{valId}));
-  ins_in_opnds.push_back(
-      ir::Operand(spv_operand_type_t::SPV_OPERAND_TYPE_ID,
-      std::initializer_list<uint32_t>{ldResultId}));
+  std::vector<ir::Operand> ins_in_opnds = 
+      {{spv_operand_type_t::SPV_OPERAND_TYPE_ID, {valId}}, 
+       {spv_operand_type_t::SPV_OPERAND_TYPE_ID, {ldResultId}}};
   uint32_t iidIdx = 0;
   ptrInst->ForEachInId([&iidIdx, &ins_in_opnds, this](const uint32_t *iid) {
     if (iidIdx > 0) {

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -225,10 +225,10 @@ void LocalAccessChainConvertPass::GenAccessChainStoreReplacement(
 }
 
 bool LocalAccessChainConvertPass::IsConstantIndexAccessChain(
-    ir::Instruction* acp) const {
+    const ir::Instruction* acp) const {
   uint32_t inIdx = 0;
   uint32_t nonConstCnt = 0;
-  acp->ForEachInId([&inIdx, &nonConstCnt, this](uint32_t* tid) {
+  acp->ForEachInId([&inIdx, &nonConstCnt, this](const uint32_t* tid) {
     if (inIdx > 0) {
       ir::Instruction* opInst = def_use_mgr_->GetDef(*tid);
       if (opInst->opcode() != SpvOpConstant) ++nonConstCnt;

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -51,14 +51,14 @@ bool LocalAccessChainConvertPass::IsTargetType(
     const ir::Instruction* typeInst) {
   if (IsMathType(typeInst))
     return true;
-  if (typeInst->opcode() != SpvOpTypeStruct &&
-      typeInst->opcode() != SpvOpTypeArray)
+  if (typeInst->opcode() == SpvOpTypeArray)
+    return IsMathType(def_use_mgr_->GetDef(typeInst->GetSingleWordOperand(1)));
+  if (typeInst->opcode() != SpvOpTypeStruct)
     return false;
+  // All struct members must be math type
   int nonMathComp = 0;
   typeInst->ForEachInId([&nonMathComp,this](const uint32_t* tid) {
     ir::Instruction* compTypeInst = def_use_mgr_->GetDef(*tid);
-    // Ignore length operand in Array type
-    if (compTypeInst->opcode() == SpvOpConstant) return;
     if (!IsMathType(compTypeInst)) ++nonMathComp;
   });
   return nonMathComp == 0;

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -127,7 +127,7 @@ void LocalAccessChainConvertPass::ReplaceAndDeleteLoad(
   }
 }
 
-uint32_t LocalAccessChainConvertPass::GetPteTypeId(
+uint32_t LocalAccessChainConvertPass::GetPointeeTypeId(
     const ir::Instruction* ptrInst) const {
   const uint32_t ptrTypeId = ptrInst->type_id();
   const ir::Instruction* ptrTypeInst = def_use_mgr_->GetDef(ptrTypeId);
@@ -155,7 +155,7 @@ uint32_t LocalAccessChainConvertPass::BuildAndAppendVarLoad(
   *varId = ptrInst->GetSingleWordInOperand(kSpvAccessChainPtrId);
   const ir::Instruction* varInst = def_use_mgr_->GetDef(*varId);
   assert(varInst->opcode() == SpvOpVariable);
-  *varPteTypeId = GetPteTypeId(varInst);
+  *varPteTypeId = GetPointeeTypeId(varInst);
   BuildAndAppendInst(SpvOpLoad, *varPteTypeId, ldResultId,
       {{spv_operand_type_t::SPV_OPERAND_TYPE_ID, {*varId}}}, newInsts);
   return ldResultId;
@@ -188,7 +188,7 @@ uint32_t LocalAccessChainConvertPass::GenAccessChainLoadReplacement(
 
   // Build and append Extract
   const uint32_t extResultId = TakeNextId();
-  const uint32_t ptrPteTypeId = GetPteTypeId(ptrInst);
+  const uint32_t ptrPteTypeId = GetPointeeTypeId(ptrInst);
   std::vector<ir::Operand> ext_in_opnds = 
       {{spv_operand_type_t::SPV_OPERAND_TYPE_ID, {ldResultId}}};
   AppendConstantOperands(ptrInst, &ext_in_opnds);

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -30,11 +30,13 @@ static const int kSpvTypeIntWidth = 0;
 namespace spvtools {
 namespace opt {
 
-bool LocalAccessChainConvertPass::IsNonPtrAccessChain(const SpvOp opcode) {
+bool LocalAccessChainConvertPass::IsNonPtrAccessChain(
+    const SpvOp opcode) const {
   return opcode == SpvOpAccessChain || opcode == SpvOpInBoundsAccessChain;
 }
 
-bool LocalAccessChainConvertPass::IsMathType(const ir::Instruction* typeInst) {
+bool LocalAccessChainConvertPass::IsMathType(
+    const ir::Instruction* typeInst) const {
   switch (typeInst->opcode()) {
   case SpvOpTypeInt:
   case SpvOpTypeFloat:
@@ -49,7 +51,7 @@ bool LocalAccessChainConvertPass::IsMathType(const ir::Instruction* typeInst) {
 }
 
 bool LocalAccessChainConvertPass::IsTargetType(
-    const ir::Instruction* typeInst) {
+    const ir::Instruction* typeInst) const {
   if (IsMathType(typeInst))
     return true;
   if (typeInst->opcode() == SpvOpTypeArray)
@@ -126,7 +128,7 @@ void LocalAccessChainConvertPass::ReplaceAndDeleteLoad(
 }
 
 uint32_t LocalAccessChainConvertPass::GetPteTypeId(
-    const ir::Instruction* ptrInst) {
+    const ir::Instruction* ptrInst) const {
   const uint32_t ptrTypeId = ptrInst->type_id();
   const ir::Instruction* ptrTypeInst = def_use_mgr_->GetDef(ptrTypeId);
   return ptrTypeInst->GetSingleWordInOperand(kSpvTypePointerTypeId);
@@ -223,7 +225,7 @@ void LocalAccessChainConvertPass::GenAccessChainStoreReplacement(
 }
 
 bool LocalAccessChainConvertPass::IsConstantIndexAccessChain(
-    ir::Instruction* acp) {
+    ir::Instruction* acp) const {
   uint32_t inIdx = 0;
   uint32_t nonConstCnt = 0;
   acp->ForEachInId([&inIdx, &nonConstCnt, this](uint32_t* tid) {

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -1,0 +1,397 @@
+// Copyright (c) 2016 The Khronos Group Inc.
+// Copyright (c) 2016 Valve Corporation
+// Copyright (c) 2016 LunarG Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "local_access_chain_convert_pass.h"
+#include "iterator.h"
+
+/*
+#define SPV_FUNCTION_CALL_FUNCTION_ID 2
+#define SPV_FUNCTION_CALL_ARGUMENT_ID 3
+#define SPV_FUNCTION_PARAMETER_RESULT_ID 1
+#define SPV_STORE_POINTER_ID 0
+#define SPV_STORE_OBJECT_ID 1
+#define SPV_RETURN_VALUE_ID 0
+#define SPV_TYPE_POINTER_STORAGE_CLASS 1
+#define SPV_TYPE_POINTER_TYPE_ID 2
+*/
+
+static const int kSpvEntryPointFunctionId = 1;
+static const int kSpvFunctionCallFunctionId = 0;
+static const int kSpvDecorationTargetId = 0;
+static const int kSpvDecorationDecoration = 1;
+static const int kSpvDecorationLinkageType = 3;
+static const int kSpvStorePtrId = 0;
+static const int kSpvStoreValId = 1;
+static const int kSpvLoadPtrId = 0;
+static const int kSpvAccessChainPtrId = 0;
+static const int kSpvTypePointerStorageClass = 0;
+static const int kSpvTypePointerTypeId = 1;
+static const int kSpvConstantValue = 0;
+static const int kSpvExtractCompositeId = 0;
+static const int kSpvExtractIdx0 = 1;
+static const int kSpvInsertObjectId = 0;
+static const int kSpvInsertCompositeId = 1;
+static const int kSpvBranchCondConditionalId = 0;
+static const int kSpvBranchCondTrueLabId = 1;
+static const int kSpvBranchCondFalseLabId = 2;
+static const int kSpvSelectionMergeMergeBlockId = 0;
+static const int kSpvPhiVal0Id = 0;
+static const int kSpvPhiLab0Id = 1;
+static const int kSpvPhiVal1Id = 2;
+static const int kSpvLoopMergeMergeBlockId = 0;
+
+namespace spvtools {
+namespace opt {
+
+bool LocalAccessChainConvertPass::IsMathType(const ir::Instruction* typeInst) {
+  switch (typeInst->opcode()) {
+  case SpvOpTypeInt:
+  case SpvOpTypeFloat:
+  case SpvOpTypeBool:
+  case SpvOpTypeVector:
+  case SpvOpTypeMatrix:
+    return true;
+  default:
+    break;
+  }
+  return false;
+}
+
+bool LocalAccessChainConvertPass::IsTargetType(
+    const ir::Instruction* typeInst) {
+  if (IsMathType(typeInst))
+    return true;
+  if (typeInst->opcode() != SpvOpTypeStruct &&
+      typeInst->opcode() != SpvOpTypeArray)
+    return false;
+  int nonMathComp = 0;
+  typeInst->ForEachInId([&nonMathComp,this](const uint32_t* tid) {
+    ir::Instruction* compTypeInst =
+        def_use_mgr_->id_to_defs().find(*tid)->second;
+    // Ignore length operand in Array type
+    if (compTypeInst->opcode() == SpvOpConstant) return;
+    if (!IsMathType(compTypeInst)) ++nonMathComp;
+  });
+  return nonMathComp == 0;
+}
+
+ir::Instruction* LocalAccessChainConvertPass::GetPtr(
+    ir::Instruction* ip,
+    uint32_t* varId) {
+  const uint32_t ptrId = ip->opcode() == SpvOpStore ?
+      ip->GetInOperand(kSpvStorePtrId).words[0] :
+      ip->GetInOperand(kSpvLoadPtrId).words[0];
+  ir::Instruction* ptrInst =
+    def_use_mgr_->id_to_defs().find(ptrId)->second;
+  *varId = ptrInst->opcode() == SpvOpAccessChain ?
+    ptrInst->GetInOperand(kSpvAccessChainPtrId).words[0] :
+    ptrId;
+  return ptrInst;
+}
+
+bool LocalAccessChainConvertPass::IsTargetVar(uint32_t varId) {
+  if (seen_non_target_vars_.find(varId) != seen_non_target_vars_.end())
+    return false;
+  if (seen_target_vars_.find(varId) != seen_target_vars_.end())
+    return true;
+  const ir::Instruction* varInst =
+    def_use_mgr_->id_to_defs().find(varId)->second;
+  assert(varInst->opcode() == SpvOpVariable);
+  const uint32_t varTypeId = varInst->type_id();
+  const ir::Instruction* varTypeInst =
+    def_use_mgr_->id_to_defs().find(varTypeId)->second;
+  if (varTypeInst->GetInOperand(kSpvTypePointerStorageClass).words[0] !=
+    SpvStorageClassFunction) {
+    seen_non_target_vars_.insert(varId);
+    return false;
+  }
+  const uint32_t varPteTypeId =
+    varTypeInst->GetInOperand(kSpvTypePointerTypeId).words[0];
+  ir::Instruction* varPteTypeInst =
+    def_use_mgr_->id_to_defs().find(varPteTypeId)->second;
+  if (!IsTargetType(varPteTypeInst)) {
+    seen_non_target_vars_.insert(varId);
+    return false;
+  }
+  seen_target_vars_.insert(varId);
+  return true;
+}
+
+void LocalAccessChainConvertPass::DeleteIfUseless(ir::Instruction* inst) {
+  const uint32_t resId = inst->result_id();
+  assert(resId != 0);
+  analysis::UseList* uses = def_use_mgr_->GetUses(resId);
+  if (uses == nullptr)
+    def_use_mgr_->KillInst(inst);
+}
+
+void LocalAccessChainConvertPass::ReplaceAndDeleteLoad(
+    ir::Instruction* loadInst,
+    uint32_t replId,
+    ir::Instruction* ptrInst) {
+  const uint32_t loadId = loadInst->result_id();
+  (void) def_use_mgr_->ReplaceAllUsesWith(loadId, replId);
+  // remove load instruction
+  def_use_mgr_->KillInst(loadInst);
+  // if access chain, see if it can be removed as well
+  if (ptrInst->opcode() == SpvOpAccessChain) {
+    DeleteIfUseless(ptrInst);
+  }
+}
+
+uint32_t LocalAccessChainConvertPass::GetPteTypeId(const ir::Instruction* ptrInst) {
+  const uint32_t ptrTypeId = ptrInst->type_id();
+  const ir::Instruction* ptrTypeInst =
+      def_use_mgr_->id_to_defs().find(ptrTypeId)->second;
+  return ptrTypeInst->GetInOperand(kSpvTypePointerTypeId).words[0];
+}
+
+void LocalAccessChainConvertPass::GenAccessChainLoadReplacement(
+    const ir::Instruction* ptrInst,
+    std::vector<std::unique_ptr<ir::Instruction>>& newInsts,
+    uint32_t& resultId) {
+
+  // Build and append Load
+  const uint32_t ldResultId = TakeNextId();
+  const uint32_t varId =
+    ptrInst->GetInOperand(kSpvAccessChainPtrId).words[0];
+  const ir::Instruction* varInst = def_use_mgr_->GetDef(varId);
+  assert(varInst->opcode() == SpvOpVariable);
+  const uint32_t varPteTypeId = GetPteTypeId(varInst);
+  std::vector<ir::Operand> load_in_operands;
+  load_in_operands.push_back(
+      ir::Operand(spv_operand_type_t::SPV_OPERAND_TYPE_ID,
+      std::initializer_list<uint32_t>{varId}));
+  std::unique_ptr<ir::Instruction> newLoad(new ir::Instruction(SpvOpLoad,
+    varPteTypeId, ldResultId, load_in_operands));
+  def_use_mgr_->AnalyzeInstDefUse(&*newLoad);
+  newInsts.emplace_back(std::move(newLoad));
+
+  // Build and append Extract
+  const uint32_t extResultId = TakeNextId();
+  const uint32_t ptrPteTypeId = GetPteTypeId(ptrInst);
+  std::vector<ir::Operand> ext_in_opnds;
+  ext_in_opnds.push_back(
+    ir::Operand(spv_operand_type_t::SPV_OPERAND_TYPE_ID,
+      std::initializer_list<uint32_t>{ldResultId}));
+  uint32_t iidIdx = 0;
+  ptrInst->ForEachInId([&iidIdx, &ext_in_opnds, this](const uint32_t *iid) {
+    if (iidIdx > 0) {
+      const ir::Instruction* cInst = def_use_mgr_->GetDef(*iid);
+      uint32_t val = cInst->GetInOperand(kSpvConstantValue).words[0];
+      ext_in_opnds.push_back(
+        ir::Operand(spv_operand_type_t::SPV_OPERAND_TYPE_LITERAL_INTEGER,
+          std::initializer_list<uint32_t>{val}));
+    }
+    ++iidIdx;
+  });
+  std::unique_ptr<ir::Instruction> newExt(new ir::Instruction(
+    SpvOpCompositeExtract, ptrPteTypeId, extResultId, ext_in_opnds));
+  def_use_mgr_->AnalyzeInstDefUse(&*newExt);
+  newInsts.emplace_back(std::move(newExt));
+  resultId = extResultId;
+}
+
+void LocalAccessChainConvertPass::GenAccessChainStoreReplacement(
+    const ir::Instruction* ptrInst,
+    uint32_t valId,
+    std::vector<std::unique_ptr<ir::Instruction>>& newInsts) {
+
+  // Build and append Load
+  const uint32_t ldResultId = TakeNextId();
+  const uint32_t varId =
+    ptrInst->GetInOperand(kSpvAccessChainPtrId).words[0];
+  const ir::Instruction* varInst = def_use_mgr_->GetDef(varId);
+  assert(varInst->opcode() == SpvOpVariable);
+  const uint32_t varPteTypeId = GetPteTypeId(varInst);
+  std::vector<ir::Operand> load_in_operands;
+  load_in_operands.push_back(
+    ir::Operand(spv_operand_type_t::SPV_OPERAND_TYPE_ID,
+      std::initializer_list<uint32_t>{varId}));
+  std::unique_ptr<ir::Instruction> newLoad(new ir::Instruction(SpvOpLoad,
+    varPteTypeId, ldResultId, load_in_operands));
+  def_use_mgr_->AnalyzeInstDefUse(&*newLoad);
+  newInsts.emplace_back(std::move(newLoad));
+
+  // Build and append Insert
+  const uint32_t insResultId = TakeNextId();
+  std::vector<ir::Operand> ins_in_opnds;
+  ins_in_opnds.push_back(
+      ir::Operand(spv_operand_type_t::SPV_OPERAND_TYPE_ID,
+      std::initializer_list<uint32_t>{valId}));
+  ins_in_opnds.push_back(
+      ir::Operand(spv_operand_type_t::SPV_OPERAND_TYPE_ID,
+      std::initializer_list<uint32_t>{ldResultId}));
+  uint32_t iidIdx = 0;
+  ptrInst->ForEachInId([&iidIdx, &ins_in_opnds, this](const uint32_t *iid) {
+    if (iidIdx > 0) {
+      const ir::Instruction* cInst = def_use_mgr_->GetDef(*iid);
+      uint32_t val = cInst->GetInOperand(kSpvConstantValue).words[0];
+      ins_in_opnds.push_back(
+        ir::Operand(spv_operand_type_t::SPV_OPERAND_TYPE_LITERAL_INTEGER,
+          std::initializer_list<uint32_t>{val}));
+    }
+    ++iidIdx;
+  });
+  std::unique_ptr<ir::Instruction> newIns(new ir::Instruction(
+    SpvOpCompositeInsert, varPteTypeId, insResultId, ins_in_opnds));
+  def_use_mgr_->AnalyzeInstDefUse(&*newIns);
+  newInsts.emplace_back(std::move(newIns));
+
+  // Build and append Store
+  std::vector<ir::Operand> store_in_operands;
+  store_in_operands.push_back(
+    ir::Operand(spv_operand_type_t::SPV_OPERAND_TYPE_ID,
+      std::initializer_list<uint32_t>{varId}));
+  store_in_operands.push_back(
+    ir::Operand(spv_operand_type_t::SPV_OPERAND_TYPE_ID,
+      std::initializer_list<uint32_t>{insResultId}));
+  std::unique_ptr<ir::Instruction> newStore(new ir::Instruction(SpvOpStore,
+      0, 0, store_in_operands));
+  def_use_mgr_->AnalyzeInstDefUse(&*newStore);
+  newInsts.emplace_back(std::move(newStore));
+}
+
+bool LocalAccessChainConvertPass::IsConstantIndexAccessChain(
+    ir::Instruction* acp) {
+  uint32_t inIdx = 0;
+  uint32_t nonConstCnt = 0;
+  acp->ForEachInId([&inIdx, &nonConstCnt, this](uint32_t* tid) {
+    if (inIdx > 0) {
+      ir::Instruction* opInst = def_use_mgr_->GetDef(*tid);
+      if (opInst->opcode() != SpvOpConstant) ++nonConstCnt;
+    }
+    ++inIdx;
+  });
+  return nonConstCnt == 0;
+}
+
+bool LocalAccessChainConvertPass::LocalAccessChainConvert(ir::Function* func) {
+  // Rule out variables accessed with non-constant indices
+  for (auto bi = func->begin(); bi != func->end(); ++bi) {
+    for (auto ii = bi->begin(); ii != bi->end(); ++ii) {
+      switch (ii->opcode()) {
+      case SpvOpStore:
+      case SpvOpLoad: {
+        uint32_t varId;
+        ir::Instruction* ptrInst = GetPtr(&*ii, &varId);
+        if (ptrInst->opcode() != SpvOpAccessChain)
+          break;
+        if (!IsTargetVar(varId))
+          break;
+        if (!IsConstantIndexAccessChain(ptrInst)) {
+          seen_non_target_vars_.insert(varId);
+          seen_target_vars_.erase(varId);
+          break;
+        }
+      } break;
+      default:
+        break;
+      }
+    }
+  }
+  // Replace access chains of all targeted variables with equivalent
+  // extract and insert sequences
+  bool modified = false;
+  for (auto bi = func->begin(); bi != func->end(); ++bi) {
+    for (auto ii = bi->begin(); ii != bi->end(); ++ii) {
+      switch (ii->opcode()) {
+      case SpvOpLoad: {
+        uint32_t varId;
+        ir::Instruction* ptrInst = GetPtr(&*ii, &varId);
+        if (ptrInst->opcode() != SpvOpAccessChain)
+          break;
+        if (!IsTargetVar(varId))
+          break;
+        std::vector<std::unique_ptr<ir::Instruction>> newInsts;
+        uint32_t replId;
+        GenAccessChainLoadReplacement(ptrInst, newInsts, replId);
+        ReplaceAndDeleteLoad(&*ii, replId, ptrInst);
+        ++ii;
+        ii = ii.InsertBefore(&newInsts);
+        ++ii;
+        modified = true;
+      } break;
+      case SpvOpStore: {
+        uint32_t varId;
+        ir::Instruction* ptrInst = GetPtr(&*ii, &varId);
+        if (ptrInst->opcode() != SpvOpAccessChain)
+          break;
+        if (!IsTargetVar(varId))
+          break;
+        std::vector<std::unique_ptr<ir::Instruction>> newInsts;
+        uint32_t valId = ii->GetInOperand(kSpvStoreValId).words[0];
+        GenAccessChainStoreReplacement(ptrInst, valId, newInsts);
+        def_use_mgr_->KillInst(&*ii);
+        DeleteIfUseless(ptrInst);
+        ++ii;
+        ii = ii.InsertBefore(&newInsts);
+        ++ii;
+        ++ii;
+        modified = true;
+      } break;
+      default:
+        break;
+      }
+    }
+  }
+  return modified;
+}
+
+void LocalAccessChainConvertPass::Initialize(ir::Module* module) {
+
+  module_ = module;
+
+  // Initialize function and block maps
+  id2function_.clear();
+  for (auto& fn : *module_) 
+    id2function_[fn.result_id()] = &fn;
+
+  // Initialize Target Variable Caches
+  seen_target_vars_.clear();
+  seen_non_target_vars_.clear();
+
+  def_use_mgr_.reset(new analysis::DefUseManager(consumer(), module_));
+
+  // Initialize next unused Id.
+  next_id_ = module->id_bound();
+};
+
+Pass::Status LocalAccessChainConvertPass::ProcessImpl() {
+  bool modified = false;
+  // Process all entry point functions.
+  for (auto& e : module_->entry_points()) {
+    ir::Function* fn =
+        id2function_[e.GetOperand(kSpvEntryPointFunctionId).words[0]];
+    modified = modified || LocalAccessChainConvert(fn);
+  }
+
+  FinalizeNextId(module_);
+
+  return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
+}
+
+LocalAccessChainConvertPass::LocalAccessChainConvertPass()
+    : module_(nullptr), def_use_mgr_(nullptr), next_id_(0) {}
+
+Pass::Status LocalAccessChainConvertPass::Process(ir::Module* module) {
+  Initialize(module);
+  return ProcessImpl();
+}
+
+}  // namespace opt
+}  // namespace spvtools
+

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -236,8 +236,7 @@ bool LocalAccessChainConvertPass::IsConstantIndexAccessChain(
   return nonConstCnt == 0;
 }
 
-bool LocalAccessChainConvertPass::LocalAccessChainConvert(ir::Function* func) {
-  // Rule out variables accessed with non-constant indices
+void LocalAccessChainConvertPass::FindTargetVars(ir::Function* func) {
   for (auto bi = func->begin(); bi != func->end(); ++bi) {
     for (auto ii = bi->begin(); ii != bi->end(); ++ii) {
       switch (ii->opcode()) {
@@ -252,6 +251,7 @@ bool LocalAccessChainConvertPass::LocalAccessChainConvert(ir::Function* func) {
         // TODO(): Convert nested access chains
         if (!IsTargetVar(varId))
           break;
+        // Rule out variables accessed with non-constant indices
         if (!IsConstantIndexAccessChain(ptrInst)) {
           seen_non_target_vars_.insert(varId);
           seen_target_vars_.erase(varId);
@@ -263,6 +263,10 @@ bool LocalAccessChainConvertPass::LocalAccessChainConvert(ir::Function* func) {
       }
     }
   }
+}
+
+bool LocalAccessChainConvertPass::LocalAccessChainConvert(ir::Function* func) {
+  FindTargetVars(func);
   // Replace access chains of all targeted variables with equivalent
   // extract and insert sequences
   bool modified = false;

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -82,7 +82,8 @@ bool LocalAccessChainConvertPass::IsTargetVar(uint32_t varId) {
   if (seen_target_vars_.find(varId) != seen_target_vars_.end())
     return true;
   const ir::Instruction* varInst = def_use_mgr_->GetDef(varId);
-  assert(varInst->opcode() == SpvOpVariable);
+  if (varInst->opcode() != SpvOpVariable)
+    return false;;
   const uint32_t varTypeId = varInst->type_id();
   const ir::Instruction* varTypeInst = def_use_mgr_->GetDef(varTypeId);
   if (varTypeInst->GetSingleWordInOperand(kSpvTypePointerStorageClass) !=
@@ -243,8 +244,11 @@ bool LocalAccessChainConvertPass::LocalAccessChainConvert(ir::Function* func) {
       case SpvOpLoad: {
         uint32_t varId;
         ir::Instruction* ptrInst = GetPtr(&*ii, &varId);
+        // For now, only convert non-ptr access chains
         if (!IsNonPtrAccessChain(ptrInst->opcode()))
           break;
+        // For now, only convert non-nested access chains
+        // TODO(): Convert nested access chains
         if (!IsTargetVar(varId))
           break;
         if (!IsConstantIndexAccessChain(ptrInst)) {

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "local_access_chain_convert_pass.h"
 #include "iterator.h"
+#include "local_access_chain_convert_pass.h"
 
 static const int kSpvEntryPointFunctionId = 1;
 static const int kSpvStorePtrId = 0;

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -153,12 +153,9 @@ uint32_t LocalAccessChainConvertPass::BuildAndAppendVarLoad(
   const ir::Instruction* varInst = def_use_mgr_->GetDef(*varId);
   assert(varInst->opcode() == SpvOpVariable);
   *varPteTypeId = GetPteTypeId(varInst);
-  std::vector<ir::Operand> load_in_operands;
-  load_in_operands.push_back(
-      ir::Operand(spv_operand_type_t::SPV_OPERAND_TYPE_ID,
-      std::initializer_list<uint32_t>{*varId}));
   std::unique_ptr<ir::Instruction> newLoad(new ir::Instruction(SpvOpLoad,
-    *varPteTypeId, ldResultId, load_in_operands));
+      *varPteTypeId, ldResultId,
+      {{spv_operand_type_t::SPV_OPERAND_TYPE_ID, {*varId}}}));
   def_use_mgr_->AnalyzeInstDefUse(&*newLoad);
   newInsts.emplace_back(std::move(newLoad));
   return ldResultId;
@@ -237,15 +234,9 @@ void LocalAccessChainConvertPass::GenAccessChainStoreReplacement(
   newInsts.emplace_back(std::move(newIns));
 
   // Build and append Store
-  std::vector<ir::Operand> store_in_operands;
-  store_in_operands.push_back(
-    ir::Operand(spv_operand_type_t::SPV_OPERAND_TYPE_ID,
-      std::initializer_list<uint32_t>{varId}));
-  store_in_operands.push_back(
-    ir::Operand(spv_operand_type_t::SPV_OPERAND_TYPE_ID,
-      std::initializer_list<uint32_t>{insResultId}));
   std::unique_ptr<ir::Instruction> newStore(new ir::Instruction(SpvOpStore,
-      0, 0, store_in_operands));
+      0, 0, {{spv_operand_type_t::SPV_OPERAND_TYPE_ID, {varId}}, 
+      {spv_operand_type_t::SPV_OPERAND_TYPE_ID, {insResultId}}}));
   def_use_mgr_->AnalyzeInstDefUse(&*newStore);
   newInsts.emplace_back(std::move(newStore));
 }

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -51,13 +51,19 @@ class LocalAccessChainConvertPass : public Pass {
 
   // Returns true if |typeInst| is a math type or a struct or array
   // of a math type.
+  // TODO(): Add more complex types to convert
   bool IsTargetType(const ir::Instruction* typeInst);
 
   // Given a load or store |ip|, return the pointer instruction.
   // Also return the variable's id in |varId|.
   ir::Instruction* GetPtr(ir::Instruction* ip, uint32_t* varId);
 
-  // Return true if |varId| is function scope variable of targeted type.
+  // Search |func| and cache function scope variables of target type that are
+  // not accessed with non-constant-index access chains.
+  void FindTargetVars(ir::Function* func);
+
+  // Return true if |varId| is a target variable. See FindTargetVars()
+  // for definition.
   bool IsTargetVar(uint32_t varId);
 
   // Delete |inst| if it has no uses. Assumes |inst| has a non-zero resultId.

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -115,7 +115,7 @@ class LocalAccessChainConvertPass : public Pass {
       std::vector<std::unique_ptr<ir::Instruction>>* newInsts);
 
   // Return true if all indices of access chain |acp| are OpConstant integers
-  bool IsConstantIndexAccessChain(ir::Instruction* acp) const;
+  bool IsConstantIndexAccessChain(const ir::Instruction* acp) const;
 
   // Identify all function scope variables of target type which are 
   // accessed only with loads, stores and access chains with constant

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -71,16 +71,15 @@ class LocalAccessChainConvertPass : public Pass {
   // or a vector or matrix
   bool IsMathType(const ir::Instruction* typeInst);
 
-  // Returns true if type is a scalar, vector, matrix
-  // or struct of only those types
+  // Returns true if type is a math type or a struct or array
+  // of a math type.
   bool IsTargetType(const ir::Instruction* typeInst);
 
   // Given a load or store pointed at by |ip|, return the pointer
   // instruction. Also return the variable's id in |varId|.
   ir::Instruction* GetPtr(ir::Instruction* ip, uint32_t* varId);
 
-  // Return true if variable is math type, or vector or matrix
-  // of target type, or struct or array of target type
+  // Return true if variable is function scope variable of targeted type.
   bool IsTargetVar(uint32_t varId);
 
   // Delete inst if it has no uses. Assumes inst has a resultId.
@@ -110,11 +109,12 @@ class LocalAccessChainConvertPass : public Pass {
   // Return true if all indices are constant
   bool IsConstantIndexAccessChain(ir::Instruction* acp);
 
-  // Identify all function scope variables which are accessed only
-  // with loads, stores and access chains with constant indices.
-  // Convert all loads and stores of such variables into equivalent
+  // Identify all function scope variables of target type which are 
+  // accessed only with loads, stores and access chains with constant
+  // indices. Convert all loads and stores of such variables into equivalent
   // loads, stores, extracts and inserts. This unifies access to these
   // variables to a single mode and simplifies analysis and optimization.
+  // See IsTargetType() for targeted types.
   bool LocalAccessChainConvert(ir::Function* func);
 
   void Initialize(ir::Module* module);

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -94,6 +94,12 @@ class LocalAccessChainConvertPass : public Pass {
   // Return type id for pointer's pointee
   uint32_t GetPteTypeId(const ir::Instruction* ptrInst);
 
+  // Build load of variable in |ptrInst| and append to |newInsts|.
+  // Return var in |varId| and its pointee type in |varPteTypeId|.
+  uint32_t BuildAndAppendVarLoad(const ir::Instruction* ptrInst,
+    uint32_t* varId, uint32_t* varPteTypeId,
+    std::vector<std::unique_ptr<ir::Instruction>>& newInsts);
+
   // Create a load/insert/store equivalent to a store of
   // valId through ptrInst.
   void GenAccessChainStoreReplacement(const ir::Instruction* ptrInst,

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -18,16 +18,16 @@
 #define LIBSPIRV_OPT_LOCAL_ACCESS_CHAIN_CONVERT_PASS_H_
 
 
+#include <algorithm>
+#include <map>
+#include <queue>
 #include <unordered_map>
 #include <unordered_set>
-#include <map>
-#include <algorithm>
 #include <utility>
-#include <queue>
 
+#include "basic_block.h"
 #include "def_use_manager.h"
 #include "module.h"
-#include "basic_block.h"
 #include "pass.h"
 
 namespace spvtools {

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -100,6 +100,11 @@ class LocalAccessChainConvertPass : public Pass {
     uint32_t* varId, uint32_t* varPteTypeId,
     std::vector<std::unique_ptr<ir::Instruction>>& newInsts);
 
+  // Append constant operands from access chain |ptrInst| to
+  // |in_opnds|. Assumes all indices in access chain are constants.
+  void AppendConstantOperands( const ir::Instruction* ptrInst,
+    std::vector<ir::Operand>* in_opnds);
+
   // Create a load/insert/store equivalent to a store of
   // valId through ptrInst.
   void GenAccessChainStoreReplacement(const ir::Instruction* ptrInst,

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -96,8 +96,9 @@ class LocalAccessChainConvertPass : public Pass {
     uint32_t* varId, uint32_t* varPteTypeId,
     std::vector<std::unique_ptr<ir::Instruction>>* newInsts);
 
-  // Append constant operands from access chain |ptrInst| to
-  // |in_opnds|. Assumes all indices in access chain are constants.
+  // Append literal integer operands to |in_opnds| corresponding to constant
+  // integer operands from access chain |ptrInst|. Assumes all indices in
+  // access chains are OpConstant.
   void AppendConstantOperands( const ir::Instruction* ptrInst,
     std::vector<ir::Operand>* in_opnds);
 

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -55,7 +55,8 @@ class LocalAccessChainConvertPass : public Pass {
   bool IsTargetType(const ir::Instruction* typeInst);
 
   // Given a load or store |ip|, return the pointer instruction.
-  // Also return the variable's id in |varId|.
+  // If the pointer is an access chain, |*varId| is its base id.
+  // Otherwise it is the id of the pointer of the load/store.
   ir::Instruction* GetPtr(ir::Instruction* ip, uint32_t* varId);
 
   // Search |func| and cache function scope variables of target type that are

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -82,7 +82,7 @@ class LocalAccessChainConvertPass : public Pass {
     ir::Instruction* ptrInst);
 
   // Return type id for |ptrInst|'s pointee
-  uint32_t GetPteTypeId(const ir::Instruction* ptrInst) const;
+  uint32_t GetPointeeTypeId(const ir::Instruction* ptrInst) const;
 
   // Build instruction from |opcode|, |typeId|, |resultId|, and |in_opnds|.
   // Append to |newInsts|.

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -94,6 +94,12 @@ class LocalAccessChainConvertPass : public Pass {
   // Return type id for pointer's pointee
   uint32_t GetPteTypeId(const ir::Instruction* ptrInst);
 
+  // Build instruction from |opcode|, |typeId|, |resultId|, and |in_opnds|.
+  // Append to |newInsts|.
+  void BuildAndAppendInst(SpvOp opcode, uint32_t typeId, uint32_t resultId,
+    const std::vector<ir::Operand>& in_opnds,
+    std::vector<std::unique_ptr<ir::Instruction>>& newInsts);
+
   // Build load of variable in |ptrInst| and append to |newInsts|.
   // Return var in |varId| and its pointee type in |varPteTypeId|.
   uint32_t BuildAndAppendVarLoad(const ir::Instruction* ptrInst,

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -1,6 +1,6 @@
-// Copyright (c) 2016 The Khronos Group Inc.
-// Copyright (c) 2016 Valve Corporation
-// Copyright (c) 2016 LunarG Inc.
+// Copyright (c) 2017 The Khronos Group Inc.
+// Copyright (c) 2017 Valve Corporation
+// Copyright (c) 2017 LunarG Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_SSAMEM_PASS_H_
-#define LIBSPIRV_OPT_SSAMEM_PASS_H_
+#ifndef LIBSPIRV_OPT_LOCAL_ACCESS_CHAIN_CONVERT_PASS_H_
+#define LIBSPIRV_OPT_LOCAL_ACCESS_CHAIN_CONVERT_PASS_H_
 
 
 #include <unordered_map>
@@ -143,5 +143,5 @@ class LocalAccessChainConvertPass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_SSAMEM_PASS_H_
+#endif  // LIBSPIRV_OPT_LOCAL_ACCESS_CHAIN_CONVERT_PASS_H_
 

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -59,11 +59,16 @@ class LocalAccessChainConvertPass : public Pass {
   ir::Instruction* GetPtr(ir::Instruction* ip, uint32_t* varId);
 
   // Search |func| and cache function scope variables of target type that are
-  // not accessed with non-constant-index access chains.
+  // not accessed with non-constant-index access chains. Also cache non-target
+  // variables.
   void FindTargetVars(ir::Function* func);
 
-  // Return true if |varId| is a target variable. See FindTargetVars()
-  // for definition.
+  // Return true if |varId| is a previously identified target variable.
+  // Return false if |varId| is a previously identified non-target variable.
+  // See FindTargetVars() for definition of target variable. If variable is
+  // not cached, return true if variable is a function scope variable of
+  // target type, false otherwise. Updates caches of target and non-target
+  // variables.
   bool IsTargetVar(uint32_t varId);
 
   // Delete |inst| if it has no uses. Assumes |inst| has a non-zero resultId.

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -138,6 +138,9 @@ class LocalAccessChainConvertPass : public Pass {
   // loads, stores, extracts and inserts. This unifies access to these
   // variables to a single mode and simplifies analysis and optimization.
   // See IsTargetType() for targeted types.
+  //
+  // Nested access chains and pointer access chains are not currently
+  // converted.
   bool LocalAccessChainConvert(ir::Function* func);
 
   void Initialize(ir::Module* module);

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -69,7 +69,8 @@ class LocalAccessChainConvertPass : public Pass {
     return next_id_++;
   }
 
-  // Returns true if |opcode| is a non-ptr access chain op
+  // Returns true if |opcode| is a non-pointer access chain op
+  // TODO(): Support conversion of pointer access chains.
   bool IsNonPtrAccessChain(const SpvOp opcode);
 
   // Returns true if |typeInst| is a scalar type

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -1,0 +1,128 @@
+// Copyright (c) 2016 The Khronos Group Inc.
+// Copyright (c) 2016 Valve Corporation
+// Copyright (c) 2016 LunarG Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBSPIRV_OPT_SSAMEM_PASS_H_
+#define LIBSPIRV_OPT_SSAMEM_PASS_H_
+
+
+#include <unordered_map>
+#include <unordered_set>
+#include <map>
+#include <algorithm>
+#include <utility>
+#include <queue>
+
+#include "def_use_manager.h"
+#include "module.h"
+#include "basic_block.h"
+#include "pass.h"
+
+namespace spvtools {
+namespace opt {
+
+// See optimizer.hpp for documentation.
+class LocalAccessChainConvertPass : public Pass {
+ public:
+  LocalAccessChainConvertPass();
+  const char* name() const override { return "sroa"; }
+  Status Process(ir::Module*) override;
+
+ private:
+   // Module this pass is processing
+   ir::Module* module_;
+
+   // Def-Uses for the module we are processing
+   std::unique_ptr<analysis::DefUseManager> def_use_mgr_;
+
+  // Map from function's result id to function
+  std::unordered_map<uint32_t, ir::Function*> id2function_;
+
+  // Set of verified target types
+  std::unordered_set<uint32_t> seen_target_vars_;
+
+  // Set of verified non-target types
+  std::unordered_set<uint32_t> seen_non_target_vars_;
+
+  // Next unused ID
+  uint32_t next_id_;
+
+  inline void FinalizeNextId(ir::Module* module) {
+    module->SetIdBound(next_id_);
+  }
+
+  inline uint32_t TakeNextId() {
+    return next_id_++;
+  }
+
+  // Returns true if type is a scalar type
+  // or a vector or matrix
+  bool IsMathType(const ir::Instruction* typeInst);
+
+  // Returns true if type is a scalar, vector, matrix
+  // or struct of only those types
+  bool IsTargetType(const ir::Instruction* typeInst);
+
+  // Given a load or store pointed at by |ip|, return the pointer
+  // instruction. Also return the variable's id in |varId|.
+  ir::Instruction* GetPtr(ir::Instruction* ip, uint32_t* varId);
+
+  // Return true if variable is math type, or vector or matrix
+  // of target type, or struct or array of target type
+  bool IsTargetVar(uint32_t varId);
+
+  // Delete inst if it has no uses. Assumes inst has a resultId.
+  void DeleteIfUseless(ir::Instruction* inst);
+
+  // Replace all instances of load's id with replId and delete load
+  // and its access chain, if any
+  void ReplaceAndDeleteLoad(ir::Instruction* loadInst,
+    uint32_t replId,
+    ir::Instruction* ptrInst);
+
+  // Return type id for pointer's pointee
+  uint32_t GetPteTypeId(const ir::Instruction* ptrInst);
+
+  // Create a load/insert/store equivalent to a store of
+  // valId through ptrInst.
+  void GenAccessChainStoreReplacement(const ir::Instruction* ptrInst,
+      uint32_t valId,
+      std::vector<std::unique_ptr<ir::Instruction>>& newInsts);
+
+  // For the (constant index) access chain ptrInst, create an
+  // equivalent load and extract
+  void GenAccessChainLoadReplacement(const ir::Instruction* ptrInst,
+      std::vector<std::unique_ptr<ir::Instruction>>& newInsts,
+      uint32_t& resultId);
+
+  // Return true if all indices are constant
+  bool IsConstantIndexAccessChain(ir::Instruction* acp);
+
+  // Identify all function scope variables which are accessed only
+  // with loads, stores and access chains with constant indices.
+  // Convert all loads and stores of such variables into equivalent
+  // loads, stores, extracts and inserts. This unifies access to these
+  // variables to a single mode and simplifies analysis and optimization.
+  bool LocalAccessChainConvert(ir::Function* func);
+
+  void Initialize(ir::Module* module);
+  Pass::Status ProcessImpl();
+};
+
+}  // namespace opt
+}  // namespace spvtools
+
+#endif  // LIBSPIRV_OPT_SSAMEM_PASS_H_
+

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -41,34 +41,6 @@ class LocalAccessChainConvertPass : public Pass {
   Status Process(ir::Module*) override;
 
  private:
-  // Module this pass is processing
-  ir::Module* module_;
-
-  // Def-Uses for the module we are processing
-  std::unique_ptr<analysis::DefUseManager> def_use_mgr_;
-
-  // Map from function's result id to function
-  std::unordered_map<uint32_t, ir::Function*> id2function_;
-
-  // Set of verified target types
-  std::unordered_set<uint32_t> seen_target_vars_;
-
-  // Set of verified non-target types
-  std::unordered_set<uint32_t> seen_non_target_vars_;
-
-  // Next unused ID
-  uint32_t next_id_;
-
-  // Save next available id into |module|.
-  inline void FinalizeNextId(ir::Module* module) {
-    module->SetIdBound(next_id_);
-  }
-
-  // Return next available id and calculate next.
-  inline uint32_t TakeNextId() {
-    return next_id_++;
-  }
-
   // Returns true if |opcode| is a non-pointer access chain op
   // TODO(): Support conversion of pointer access chains.
   bool IsNonPtrAccessChain(const SpvOp opcode);
@@ -143,8 +115,36 @@ class LocalAccessChainConvertPass : public Pass {
   // converted.
   bool LocalAccessChainConvert(ir::Function* func);
 
+  // Save next available id into |module|.
+  inline void FinalizeNextId(ir::Module* module) {
+    module->SetIdBound(next_id_);
+  }
+
+  // Return next available id and calculate next.
+  inline uint32_t TakeNextId() {
+    return next_id_++;
+  }
+
   void Initialize(ir::Module* module);
   Pass::Status ProcessImpl();
+
+  // Module this pass is processing
+  ir::Module* module_;
+
+  // Def-Uses for the module we are processing
+  std::unique_ptr<analysis::DefUseManager> def_use_mgr_;
+
+  // Map from function's result id to function
+  std::unordered_map<uint32_t, ir::Function*> id2function_;
+
+  // Cache of verified target vars
+  std::unordered_set<uint32_t> seen_target_vars_;
+
+  // Cache of verified non-target vars
+  std::unordered_set<uint32_t> seen_non_target_vars_;
+
+  // Next unused ID
+  uint32_t next_id_;
 };
 
 }  // namespace opt

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -41,11 +41,11 @@ class LocalAccessChainConvertPass : public Pass {
   Status Process(ir::Module*) override;
 
  private:
-   // Module this pass is processing
-   ir::Module* module_;
+  // Module this pass is processing
+  ir::Module* module_;
 
-   // Def-Uses for the module we are processing
-   std::unique_ptr<analysis::DefUseManager> def_use_mgr_;
+  // Def-Uses for the module we are processing
+  std::unique_ptr<analysis::DefUseManager> def_use_mgr_;
 
   // Map from function's result id to function
   std::unordered_map<uint32_t, ir::Function*> id2function_;

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -37,7 +37,7 @@ namespace opt {
 class LocalAccessChainConvertPass : public Pass {
  public:
   LocalAccessChainConvertPass();
-  const char* name() const override { return "sroa"; }
+  const char* name() const override { return "convert-local-access-chains"; }
   Status Process(ir::Module*) override;
 
  private:

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -69,6 +69,9 @@ class LocalAccessChainConvertPass : public Pass {
     return next_id_++;
   }
 
+  // Returns true if |opcode| is a non-ptr access chain op
+  bool IsNonPtrAccessChain(const SpvOp opcode);
+
   // Returns true if |typeInst| is a scalar type
   // or a vector or matrix
   bool IsMathType(const ir::Instruction* typeInst);

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -126,7 +126,7 @@ class LocalAccessChainConvertPass : public Pass {
   //
   // Nested access chains and pointer access chains are not currently
   // converted.
-  bool LocalAccessChainConvert(ir::Function* func);
+  bool ConvertLocalAccessChains(ir::Function* func);
 
   // Save next available id into |module|.
   inline void FinalizeNextId(ir::Module* module) {

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -43,16 +43,16 @@ class LocalAccessChainConvertPass : public Pass {
  private:
   // Returns true if |opcode| is a non-pointer access chain op
   // TODO(): Support conversion of pointer access chains.
-  bool IsNonPtrAccessChain(const SpvOp opcode);
+  bool IsNonPtrAccessChain(const SpvOp opcode) const;
 
   // Returns true if |typeInst| is a scalar type
   // or a vector or matrix
-  bool IsMathType(const ir::Instruction* typeInst);
+  bool IsMathType(const ir::Instruction* typeInst) const;
 
   // Returns true if |typeInst| is a math type or a struct or array
   // of a math type.
   // TODO(): Add more complex types to convert
-  bool IsTargetType(const ir::Instruction* typeInst);
+  bool IsTargetType(const ir::Instruction* typeInst) const;
 
   // Given a load or store |ip|, return the pointer instruction.
   // If the pointer is an access chain, |*varId| is its base id.
@@ -82,7 +82,7 @@ class LocalAccessChainConvertPass : public Pass {
     ir::Instruction* ptrInst);
 
   // Return type id for |ptrInst|'s pointee
-  uint32_t GetPteTypeId(const ir::Instruction* ptrInst);
+  uint32_t GetPteTypeId(const ir::Instruction* ptrInst) const;
 
   // Build instruction from |opcode|, |typeId|, |resultId|, and |in_opnds|.
   // Append to |newInsts|.
@@ -114,8 +114,8 @@ class LocalAccessChainConvertPass : public Pass {
   uint32_t GenAccessChainLoadReplacement(const ir::Instruction* ptrInst,
       std::vector<std::unique_ptr<ir::Instruction>>* newInsts);
 
-  // Return true if all indices of access chain |acp| are constant
-  bool IsConstantIndexAccessChain(ir::Instruction* acp);
+  // Return true if all indices of access chain |acp| are OpConstant integers
+  bool IsConstantIndexAccessChain(ir::Instruction* acp) const;
 
   // Identify all function scope variables of target type which are 
   // accessed only with loads, stores and access chains with constant

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -59,39 +59,41 @@ class LocalAccessChainConvertPass : public Pass {
   // Next unused ID
   uint32_t next_id_;
 
+  // Save next available id into |module|.
   inline void FinalizeNextId(ir::Module* module) {
     module->SetIdBound(next_id_);
   }
 
+  // Return next available id and calculate next.
   inline uint32_t TakeNextId() {
     return next_id_++;
   }
 
-  // Returns true if type is a scalar type
+  // Returns true if |typeInst| is a scalar type
   // or a vector or matrix
   bool IsMathType(const ir::Instruction* typeInst);
 
-  // Returns true if type is a math type or a struct or array
+  // Returns true if |typeInst| is a math type or a struct or array
   // of a math type.
   bool IsTargetType(const ir::Instruction* typeInst);
 
-  // Given a load or store pointed at by |ip|, return the pointer
-  // instruction. Also return the variable's id in |varId|.
+  // Given a load or store |ip|, return the pointer instruction.
+  // Also return the variable's id in |varId|.
   ir::Instruction* GetPtr(ir::Instruction* ip, uint32_t* varId);
 
-  // Return true if variable is function scope variable of targeted type.
+  // Return true if |varId| is function scope variable of targeted type.
   bool IsTargetVar(uint32_t varId);
 
-  // Delete inst if it has no uses. Assumes inst has a resultId.
+  // Delete |inst| if it has no uses. Assumes |inst| has a non-zero resultId.
   void DeleteIfUseless(ir::Instruction* inst);
 
-  // Replace all instances of load's id with replId and delete load
-  // and its access chain, if any
+  // Replace all instances of |loadInst|'s id with |replId| and delete
+  // |loadInst| and its pointer |ptrInst| if it is a useless access chain.
   void ReplaceAndDeleteLoad(ir::Instruction* loadInst,
     uint32_t replId,
     ir::Instruction* ptrInst);
 
-  // Return type id for pointer's pointee
+  // Return type id for |ptrInst|'s pointee
   uint32_t GetPteTypeId(const ir::Instruction* ptrInst);
 
   // Build instruction from |opcode|, |typeId|, |resultId|, and |in_opnds|.
@@ -112,17 +114,18 @@ class LocalAccessChainConvertPass : public Pass {
     std::vector<ir::Operand>* in_opnds);
 
   // Create a load/insert/store equivalent to a store of
-  // valId through ptrInst.
+  // |valId| through (constant index) access chaing |ptrInst|.
+  // Append to |newInsts|.
   void GenAccessChainStoreReplacement(const ir::Instruction* ptrInst,
       uint32_t valId,
       std::vector<std::unique_ptr<ir::Instruction>>* newInsts);
 
-  // For the (constant index) access chain ptrInst, create an
-  // equivalent load and extract
+  // For the (constant index) access chain |ptrInst|, create an
+  // equivalent load and extract. Append to |newInsts|.
   uint32_t GenAccessChainLoadReplacement(const ir::Instruction* ptrInst,
       std::vector<std::unique_ptr<ir::Instruction>>* newInsts);
 
-  // Return true if all indices are constant
+  // Return true if all indices of access chain |acp| are constant
   bool IsConstantIndexAccessChain(ir::Instruction* acp);
 
   // Identify all function scope variables of target type which are 

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -98,13 +98,13 @@ class LocalAccessChainConvertPass : public Pass {
   // Append to |newInsts|.
   void BuildAndAppendInst(SpvOp opcode, uint32_t typeId, uint32_t resultId,
     const std::vector<ir::Operand>& in_opnds,
-    std::vector<std::unique_ptr<ir::Instruction>>& newInsts);
+    std::vector<std::unique_ptr<ir::Instruction>>* newInsts);
 
   // Build load of variable in |ptrInst| and append to |newInsts|.
   // Return var in |varId| and its pointee type in |varPteTypeId|.
   uint32_t BuildAndAppendVarLoad(const ir::Instruction* ptrInst,
     uint32_t* varId, uint32_t* varPteTypeId,
-    std::vector<std::unique_ptr<ir::Instruction>>& newInsts);
+    std::vector<std::unique_ptr<ir::Instruction>>* newInsts);
 
   // Append constant operands from access chain |ptrInst| to
   // |in_opnds|. Assumes all indices in access chain are constants.
@@ -115,13 +115,12 @@ class LocalAccessChainConvertPass : public Pass {
   // valId through ptrInst.
   void GenAccessChainStoreReplacement(const ir::Instruction* ptrInst,
       uint32_t valId,
-      std::vector<std::unique_ptr<ir::Instruction>>& newInsts);
+      std::vector<std::unique_ptr<ir::Instruction>>* newInsts);
 
   // For the (constant index) access chain ptrInst, create an
   // equivalent load and extract
-  void GenAccessChainLoadReplacement(const ir::Instruction* ptrInst,
-      std::vector<std::unique_ptr<ir::Instruction>>& newInsts,
-      uint32_t& resultId);
+  uint32_t GenAccessChainLoadReplacement(const ir::Instruction* ptrInst,
+      std::vector<std::unique_ptr<ir::Instruction>>* newInsts);
 
   // Return true if all indices are constant
   bool IsConstantIndexAccessChain(ir::Instruction* acp);

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -136,6 +136,11 @@ Optimizer::PassToken CreateInlinePass() {
   return MakeUnique<Optimizer::PassToken::Impl>(MakeUnique<opt::InlinePass>());
 }
 
+Optimizer::PassToken CreateLocalAccessChainConvertPass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::LocalAccessChainConvertPass>());
+}
+
 Optimizer::PassToken CreateCompactIdsPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::CompactIdsPass>());

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -23,6 +23,7 @@
 #include "fold_spec_constant_op_and_composite_pass.h"
 #include "inline_pass.h"
 #include "freeze_spec_constant_value_pass.h"
+#include "local_access_chain_convert_pass.h"
 #include "null_pass.h"
 #include "set_spec_constant_default_value_pass.h"
 #include "strip_debug_info_pass.h"

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -58,6 +58,11 @@ add_spvtools_unittest(TARGET pass_inline
   LIBS SPIRV-Tools-opt
 )
 
+add_spvtools_unittest(TARGET pass_local_access_chain_convert
+  SRCS local_access_chain_convert_test.cpp pass_utils.cpp
+  LIBS SPIRV-Tools-opt
+)
+
 add_spvtools_unittest(TARGET pass_eliminate_dead_const
   SRCS eliminate_dead_const_test.cpp pass_utils.cpp
   LIBS SPIRV-Tools-opt

--- a/test/opt/local_access_chain_convert_test.cpp
+++ b/test/opt/local_access_chain_convert_test.cpp
@@ -257,6 +257,7 @@ OpFunctionEnd
 //    Assorted struct array types
 //    Assorted scalar types
 //    Assorted non-target types
+//    OpInBoundsAccessChain
 //    Others?
 
 }  // anonymous namespace

--- a/test/opt/local_access_chain_convert_test.cpp
+++ b/test/opt/local_access_chain_convert_test.cpp
@@ -102,6 +102,85 @@ OpFunctionEnd
       predefs + before, predefs + after, true, true);
 }
 
+TEST_F(LocalAccessChainConvertTest, TwoUsesofSingleChainConverted) {
+
+  //  #version 140
+  //  
+  //  in vec4 BaseColor;
+  //  
+  //  struct S_t {
+  //      vec4 v0;
+  //      vec4 v1;
+  //  };
+  //  
+  //  void main()
+  //  {
+  //      S_t s0;
+  //      s0.v1 = BaseColor;
+  //      gl_FragColor = s0.v1;
+  //  }
+
+  const std::string predefs =
+      R"(OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %BaseColor %gl_FragColor
+OpExecutionMode %main OriginUpperLeft
+OpSource GLSL 140
+OpName %main "main"
+OpName %S_t "S_t"
+OpMemberName %S_t 0 "v0"
+OpMemberName %S_t 1 "v1"
+OpName %s0 "s0"
+OpName %BaseColor "BaseColor"
+OpName %gl_FragColor "gl_FragColor"
+%void = OpTypeVoid
+%8 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%v4float = OpTypeVector %float 4
+%S_t = OpTypeStruct %v4float %v4float
+%_ptr_Function_S_t = OpTypePointer Function %S_t
+%int = OpTypeInt 32 1
+%int_1 = OpConstant %int 1
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%BaseColor = OpVariable %_ptr_Input_v4float Input
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%gl_FragColor = OpVariable %_ptr_Output_v4float Output
+)";
+
+  const std::string before =
+      R"(%main = OpFunction %void None %8
+%17 = OpLabel
+%s0 = OpVariable %_ptr_Function_S_t Function
+%18 = OpLoad %v4float %BaseColor
+%19 = OpAccessChain %_ptr_Function_v4float %s0 %int_1
+OpStore %19 %18
+%20 = OpLoad %v4float %19
+OpStore %gl_FragColor %20
+OpReturn
+OpFunctionEnd
+)";
+
+  const std::string after =
+      R"(%main = OpFunction %void None %8
+%17 = OpLabel
+%s0 = OpVariable %_ptr_Function_S_t Function
+%18 = OpLoad %v4float %BaseColor
+%21 = OpLoad %S_t %s0
+%22 = OpCompositeInsert %S_t %18 %21 1
+OpStore %s0 %22
+%23 = OpLoad %S_t %s0
+%24 = OpCompositeExtract %v4float %23 1
+OpStore %gl_FragColor %24
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndCheck<opt::LocalAccessChainConvertPass>(
+      predefs + before, predefs + after, true, true);
+}
+
 TEST_F(LocalAccessChainConvertTest, 
        UntargetedTypeNotConverted) {
 

--- a/test/opt/local_access_chain_convert_test.cpp
+++ b/test/opt/local_access_chain_convert_test.cpp
@@ -102,6 +102,86 @@ OpFunctionEnd
       predefs + before, predefs + after, true, true);
 }
 
+TEST_F(LocalAccessChainConvertTest, InBoundsAccessChainsConverted) {
+
+  //  #version 140
+  //  
+  //  in vec4 BaseColor;
+  //  
+  //  struct S_t {
+  //      vec4 v0;
+  //      vec4 v1;
+  //  };
+  //  
+  //  void main()
+  //  {
+  //      S_t s0;
+  //      s0.v1 = BaseColor;
+  //      gl_FragColor = s0.v1;
+  //  }
+
+  const std::string predefs =
+      R"(OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %BaseColor %gl_FragColor
+OpExecutionMode %main OriginUpperLeft
+OpSource GLSL 140
+OpName %main "main"
+OpName %S_t "S_t"
+OpMemberName %S_t 0 "v0"
+OpMemberName %S_t 1 "v1"
+OpName %s0 "s0"
+OpName %BaseColor "BaseColor"
+OpName %gl_FragColor "gl_FragColor"
+%void = OpTypeVoid
+%8 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%v4float = OpTypeVector %float 4
+%S_t = OpTypeStruct %v4float %v4float
+%_ptr_Function_S_t = OpTypePointer Function %S_t
+%int = OpTypeInt 32 1
+%int_1 = OpConstant %int 1
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%BaseColor = OpVariable %_ptr_Input_v4float Input
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%gl_FragColor = OpVariable %_ptr_Output_v4float Output
+)";
+
+  const std::string before =
+      R"(%main = OpFunction %void None %8
+%17 = OpLabel
+%s0 = OpVariable %_ptr_Function_S_t Function
+%18 = OpLoad %v4float %BaseColor
+%19 = OpInBoundsAccessChain %_ptr_Function_v4float %s0 %int_1
+OpStore %19 %18
+%20 = OpInBoundsAccessChain %_ptr_Function_v4float %s0 %int_1
+%21 = OpLoad %v4float %20
+OpStore %gl_FragColor %21
+OpReturn
+OpFunctionEnd
+)";
+
+  const std::string after =
+      R"(%main = OpFunction %void None %8
+%17 = OpLabel
+%s0 = OpVariable %_ptr_Function_S_t Function
+%18 = OpLoad %v4float %BaseColor
+%22 = OpLoad %S_t %s0
+%23 = OpCompositeInsert %S_t %18 %22 1
+OpStore %s0 %23
+%24 = OpLoad %S_t %s0
+%25 = OpCompositeExtract %v4float %24 1
+OpStore %gl_FragColor %25
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndCheck<opt::LocalAccessChainConvertPass>(
+      predefs + before, predefs + after, true, true);
+}
+
 TEST_F(LocalAccessChainConvertTest, TwoUsesofSingleChainConverted) {
 
   //  #version 140

--- a/test/opt/local_access_chain_convert_test.cpp
+++ b/test/opt/local_access_chain_convert_test.cpp
@@ -1,0 +1,262 @@
+// Copyright (c) 2017 Valve Corporation
+// Copyright (c) 2017 LunarG Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "pass_fixture.h"
+#include "pass_utils.h"
+
+namespace {
+
+using namespace spvtools;
+
+using LocalAccessChainConvertTest = PassTest<::testing::Test>;
+
+TEST_F(LocalAccessChainConvertTest, StructOfVecsOfFloatConverted) {
+
+  //  #version 140
+  //  
+  //  in vec4 BaseColor;
+  //  
+  //  struct S_t {
+  //      vec4 v0;
+  //      vec4 v1;
+  //  };
+  //  
+  //  void main()
+  //  {
+  //      S_t s0;
+  //      s0.v1 = BaseColor;
+  //      gl_FragColor = s0.v1;
+  //  }
+
+  const std::string predefs =
+      R"(OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %BaseColor %gl_FragColor
+OpExecutionMode %main OriginUpperLeft
+OpSource GLSL 140
+OpName %main "main"
+OpName %S_t "S_t"
+OpMemberName %S_t 0 "v0"
+OpMemberName %S_t 1 "v1"
+OpName %s0 "s0"
+OpName %BaseColor "BaseColor"
+OpName %gl_FragColor "gl_FragColor"
+%void = OpTypeVoid
+%8 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%v4float = OpTypeVector %float 4
+%S_t = OpTypeStruct %v4float %v4float
+%_ptr_Function_S_t = OpTypePointer Function %S_t
+%int = OpTypeInt 32 1
+%int_1 = OpConstant %int 1
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%BaseColor = OpVariable %_ptr_Input_v4float Input
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%gl_FragColor = OpVariable %_ptr_Output_v4float Output
+)";
+
+  const std::string before =
+      R"(%main = OpFunction %void None %8
+%17 = OpLabel
+%s0 = OpVariable %_ptr_Function_S_t Function
+%18 = OpLoad %v4float %BaseColor
+%19 = OpAccessChain %_ptr_Function_v4float %s0 %int_1
+OpStore %19 %18
+%20 = OpAccessChain %_ptr_Function_v4float %s0 %int_1
+%21 = OpLoad %v4float %20
+OpStore %gl_FragColor %21
+OpReturn
+OpFunctionEnd
+)";
+
+  const std::string after =
+      R"(%main = OpFunction %void None %8
+%17 = OpLabel
+%s0 = OpVariable %_ptr_Function_S_t Function
+%18 = OpLoad %v4float %BaseColor
+%22 = OpLoad %S_t %s0
+%23 = OpCompositeInsert %S_t %18 %22 1
+OpStore %s0 %23
+%24 = OpLoad %S_t %s0
+%25 = OpCompositeExtract %v4float %24 1
+OpStore %gl_FragColor %25
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndCheck<opt::LocalAccessChainConvertPass>(
+      predefs + before, predefs + after, true, true);
+}
+
+TEST_F(LocalAccessChainConvertTest, 
+       UntargetedTypeNotConverted) {
+
+  //  #version 140
+  //  
+  //  in vec4 BaseColor;
+  //  
+  //  struct S1_t {
+  //      vec4 v1;
+  //  };
+  //  
+  //  struct S2_t {
+  //      vec4 v2;
+  //      S1_t s1;
+  //  };
+  //  
+  //  void main()
+  //  {
+  //      S2_t s2;
+  //      s2.s1.v1 = BaseColor;
+  //      gl_FragColor = s2.s1.v1;
+  //  }
+
+  const std::string assembly =
+      R"(OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %BaseColor %gl_FragColor
+OpExecutionMode %main OriginUpperLeft
+OpSource GLSL 140
+OpName %main "main"
+OpName %S1_t "S1_t"
+OpMemberName %S1_t 0 "v1"
+OpName %S2_t "S2_t"
+OpMemberName %S2_t 0 "v2"
+OpMemberName %S2_t 1 "s1"
+OpName %s2 "s2"
+OpName %BaseColor "BaseColor"
+OpName %gl_FragColor "gl_FragColor"
+%void = OpTypeVoid
+%9 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%v4float = OpTypeVector %float 4
+%S1_t = OpTypeStruct %v4float
+%S2_t = OpTypeStruct %v4float %S1_t
+%_ptr_Function_S2_t = OpTypePointer Function %S2_t
+%int = OpTypeInt 32 1
+%int_1 = OpConstant %int 1
+%int_0 = OpConstant %int 0
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%BaseColor = OpVariable %_ptr_Input_v4float Input
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%gl_FragColor = OpVariable %_ptr_Output_v4float Output
+%main = OpFunction %void None %9
+%19 = OpLabel
+%s2 = OpVariable %_ptr_Function_S2_t Function
+%20 = OpLoad %v4float %BaseColor
+%21 = OpAccessChain %_ptr_Function_v4float %s2 %int_1 %int_0
+OpStore %21 %20
+%22 = OpAccessChain %_ptr_Function_v4float %s2 %int_1 %int_0
+%23 = OpLoad %v4float %22
+OpStore %gl_FragColor %23
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndCheck<opt::LocalAccessChainConvertPass>(
+      assembly, assembly, false, true);
+}
+
+TEST_F(LocalAccessChainConvertTest, 
+       DynamicallyIndexedVarNotConverted) {
+
+  //  #version 140
+  //  
+  //  in vec4 BaseColor;
+  //  flat in int Idx;
+  //  in float Bi;
+  //
+  //  struct S_t {
+  //      vec4 v0;
+  //      vec4 v1;
+  //  };
+  //  
+  //  void main()
+  //  {
+  //      S_t s0;
+  //      s0.v1 = BaseColor;
+  //      s0.v1[Idx] = Bi;
+  //      gl_FragColor = s0.v1;
+  //  }
+
+  const std::string assembly =
+      R"(OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %BaseColor %Idx %Bi %gl_FragColor
+OpExecutionMode %main OriginUpperLeft
+OpSource GLSL 140
+OpName %main "main"
+OpName %S_t "S_t"
+OpMemberName %S_t 0 "v0"
+OpMemberName %S_t 1 "v1"
+OpName %s0 "s0"
+OpName %BaseColor "BaseColor"
+OpName %Idx "Idx"
+OpName %Bi "Bi"
+OpName %gl_FragColor "gl_FragColor"
+OpDecorate %Idx Flat
+%void = OpTypeVoid
+%10 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%v4float = OpTypeVector %float 4
+%S_t = OpTypeStruct %v4float %v4float
+%_ptr_Function_S_t = OpTypePointer Function %S_t
+%int = OpTypeInt 32 1
+%int_1 = OpConstant %int 1
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%BaseColor = OpVariable %_ptr_Input_v4float Input
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+%_ptr_Input_int = OpTypePointer Input %int
+%Idx = OpVariable %_ptr_Input_int Input
+%_ptr_Input_float = OpTypePointer Input %float
+%Bi = OpVariable %_ptr_Input_float Input
+%_ptr_Function_float = OpTypePointer Function %float
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%gl_FragColor = OpVariable %_ptr_Output_v4float Output
+%main = OpFunction %void None %10
+%22 = OpLabel
+%s0 = OpVariable %_ptr_Function_S_t Function
+%23 = OpLoad %v4float %BaseColor
+%24 = OpAccessChain %_ptr_Function_v4float %s0 %int_1
+OpStore %24 %23
+%25 = OpLoad %int %Idx
+%26 = OpLoad %float %Bi
+%27 = OpAccessChain %_ptr_Function_float %s0 %int_1 %25
+OpStore %27 %26
+%28 = OpAccessChain %_ptr_Function_v4float %s0 %int_1
+%29 = OpLoad %v4float %28
+OpStore %gl_FragColor %29
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndCheck<opt::LocalAccessChainConvertPass>(
+      assembly, assembly, false, true);
+}
+
+// TODO(greg-lunarg): Add tests to verify handling of these cases:
+//
+//    Assorted vector and matrix types
+//    Assorted struct array types
+//    Assorted scalar types
+//    Assorted non-target types
+//    Others?
+
+}  // anonymous namespace

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -133,6 +133,8 @@ int main(int argc, char** argv) {
         optimizer.RegisterPass(CreateFreezeSpecConstantValuePass());
       } else if (0 == strcmp(cur_arg, "--inline-entry-points-exhaustive")) {
         optimizer.RegisterPass(CreateInlinePass());
+      } else if (0 == strcmp(cur_arg, "--convert-local-access-chains")) {
+        optimizer.RegisterPass(CreateLocalAccessChainConvertPass());
       } else if (0 == strcmp(cur_arg, "--eliminate-dead-const")) {
         optimizer.RegisterPass(CreateEliminateDeadConstantPass());
       } else if (0 == strcmp(cur_arg, "--fold-spec-const-op-composite")) {


### PR DESCRIPTION
This pass is the next in a series of passes designed to reduce the size of SPIR-V files.

This pass targets function scope variables of math type (scalar, vector, matrix) or structs or arrays of math type. It further focuses on variables which are accessed only with loads, stores, and access chains with constant indices. It then converts all loads and stores of such  variables into equivalent sequences of loads, stores, extracts and inserts. This unifies access to these variables to a single mode, simplifying subsequent analysis and elimination of these variables along with loads and stores and allowing values to propagate further for better subsequent analysis and optimization.

I will add tests shortly. Just wanted to get this next pass moving into the review pipeline.

I have not "advertised" this option yet in the spirv-opt usage message. I was thinking it might be better to hold off advertising until we have checked in enough passes so that users can actually see a reduction in SPIR-V file size using these passes.