### PR TITLE
Fixed disassembly of signed 16 bit int

### DIFF
--- a/source/parsed_operand.cpp
+++ b/source/parsed_operand.cpp
@@ -32,10 +32,10 @@ void EmitNumericLiteral(std::ostream* out, const spv_parsed_instruction_t& inst,
   if (operand.num_words == 1) {
     switch (operand.number_kind) {
       case SPV_NUMBER_SIGNED_INT:
-        *out << int32_t(word);
+        *out << (int32_t(word << (32 - operand.number_bit_width)) >> (32 - operand.number_bit_width));
         break;
       case SPV_NUMBER_UNSIGNED_INT:
-        *out << word;
+        *out << (uint32_t(word << (32 - operand.number_bit_width)) >> (32 - operand.number_bit_width));
         break;
       case SPV_NUMBER_FLOATING:
         if (operand.number_bit_width == 16) {


### PR DESCRIPTION
A literal operand of 32 or fewer bits occupies a 32 bit word in binary
SPIR-V. The spec does not say that the remaining bits in the word have
to be any particular value, but the disassembler was assuming that they
were zero or sign extended as applicable to the signedness of the type.

I saw a SPIR-V binary that was affected by this; the spir-v generator
had set the extra bits to 0 for a negative signed 16 bit literal, and
the disassembler gave the wrong result:

           %6 = OpTypeInt 16 1
          %31 = OpConstant %6 65436

Assembling that disassembly causes an error.

With this commit, the disassembler assumes nothing about the extra bits,
and the disassembly is correct:

          %31 = OpConstant %6 -100