### PR TITLE
Added Huffman codec to utils

### DIFF
--- a/source/util/bit_stream.h
+++ b/source/util/bit_stream.h
@@ -17,6 +17,7 @@
 #ifndef LIBSPIRV_UTIL_BIT_STREAM_H_
 #define LIBSPIRV_UTIL_BIT_STREAM_H_
 
+#include <algorithm>
 #include <bitset>
 #include <cstdint>
 #include <string>

--- a/source/util/huffman_codec.h
+++ b/source/util/huffman_codec.h
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <functional>
 #include <queue>
 #include <iomanip>
 #include <map>

--- a/source/util/huffman_codec.h
+++ b/source/util/huffman_codec.h
@@ -42,6 +42,7 @@ class HuffmanCodec {
 
  public:
   // Creates Huffman codec from a histogramm.
+  // Histogramm counts must not be zero.
   explicit HuffmanCodec(const std::map<Val, uint32_t>& hist) {
     if (hist.empty()) return;
 
@@ -61,6 +62,7 @@ class HuffmanCodec {
       Node* node = CreateNode();
       node->val = pair.first;
       node->weight = pair.second;
+      assert(node->weight);
       queue.push(node);
     }
 
@@ -238,6 +240,9 @@ class HuffmanCodec {
       Context(Node* in_node, uint64_t in_bits, size_t in_depth)
           :  node(in_node), bits(in_bits), depth(in_depth) {}
       Node* node;
+      // Huffman tree depth cannot exceed 64 as histogramm counts are expected
+      // to be positive and limited by numeric_limits<uint32_t>::max().
+      // For practical applications tree depth would be much smaller than 64.
       uint64_t bits;
       size_t depth;
     };

--- a/source/util/huffman_codec.h
+++ b/source/util/huffman_codec.h
@@ -1,0 +1,243 @@
+// Copyright (c) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Contains utils for reading, writing and debug printing bit streams.
+
+#ifndef LIBSPIRV_UTIL_HUFFMAN_CODEC_H_
+#define LIBSPIRV_UTIL_HUFFMAN_CODEC_H_
+
+#include <cassert>
+#include <queue>
+#include <iomanip>
+#include <memory>
+#include <ostream>
+#include <stack>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+namespace spvutils {
+
+// Used to generate and apply a Huffman coding scheme.
+// |Val| is the type of variable being encoded (for example a string or a
+// literal).
+template <class Val>
+class HuffmanCodec {
+ public:
+  // Creates Huffman codec from a histogramm.
+  explicit HuffmanCodec(const std::unordered_map<Val, uint32_t>& hist) {
+    if (hist.empty()) return;
+
+    // Heuristic estimate.
+    all_nodes_.reserve(3 * hist.size());
+
+
+    // The queue is sorted in ascending order by weight.
+    std::vector<Node*> queue_vector;
+    queue_vector.reserve(hist.size());
+    std::priority_queue<Node*, std::vector<Node*>,
+        std::function<bool(const Node*, const Node*)>>
+	    queue(LeftIsBigger, std::move(queue_vector));
+
+    // Put all leaves in the queue.
+    for (const auto& pair : hist) {
+      std::unique_ptr<Node> node(new Node());
+      node->val = pair.first;
+      node->weight = pair.second;
+
+      queue.push(node.get());
+      all_nodes_.push_back(std::move(node));
+    }
+
+    // Form the tree by combining two subtrees with the least weight,
+    // and pushing the root of the new tree in the queue.
+    while (true) {
+      // We push a node at the end of each iteration, so the queue is never
+      // supposed to be empty at this point, unless there are no leaves, but
+      // that case was already handled.
+      assert(!queue.empty());
+      Node* right = queue.top();
+      queue.pop();
+
+      // If the queue is empty at this point, then the last node contains is
+      // the root of the complete Huffman tree.
+      if (queue.empty()) {
+        root_ = right;
+        break;
+      }
+
+      Node* left = queue.top();
+      queue.pop();
+
+      // Combile left and right into a new tree and push it into the queue.
+      std::unique_ptr<Node> parent(new Node());
+      parent->weight = right->weight + left->weight;
+      parent->left = left;
+      parent->right = right;
+      queue.push(parent.get());
+      all_nodes_.push_back(std::move(parent));
+    }
+
+    // Traverse the tree and form encoding table.
+    CreateEncodingTable();
+  }
+
+  // Prints the Huffman tree in the following format:
+  // w------w------'x'
+  //        w------'y'
+  // Where w stands for the weight of the node.
+  void PrintTree(std::ostream& out) {
+    PrintTreeInternal(out, root_, 0);
+  }
+
+  void PrintTable(std::ostream& out, bool print_weights = true) {
+    std::queue<std::pair<Node*, std::string>> queue;
+    queue.emplace(root_, "");
+
+    while (!queue.empty()) {
+      const Node* node = queue.front().first;
+      const std::string code = queue.front().second;
+      queue.pop();
+      if (!node->right && !node->left) {
+        out << node->val;
+        if (print_weights)
+            out << " " << node->weight;
+        out << " " << code << std::endl;
+      } else {
+        if (node->left)
+          queue.emplace(node->left, code + "0");
+
+        if (node->right)
+          queue.emplace(node->right, code + "1");
+      }
+    }
+  }
+
+  const std::unordered_map<Val, std::pair<uint64_t, size_t>>&
+      GetEncodingTable() const {
+    return encoding_table_;
+  }
+
+  // Encodes |val| and stores the value in the lower |num_bits| of |bits|.
+  bool Encode(const Val& val, uint64_t* bits, size_t* num_bits) {
+    auto it = encoding_table_.find(val);
+    if (it == encoding_table_.end())
+      return false;
+    *bits = it->second.first;
+    *num_bits = it->second.second;
+    return true;
+  }
+
+  // Reads bits one-by-one using callback |read_bit| until a match is found.
+  // Matching value is stored in |val|. Returns false if the stream terminates
+  // prematurely.
+  bool DecodeFromStream(const std::function<bool(bool*)>& read_bit, Val* val) {
+    Node* node = root_;
+    while (true) {
+      assert(node);
+
+      if (node->left == nullptr && node->right == nullptr) {
+        *val = node->val;
+        return true;
+      }
+
+      bool go_right;
+      if (!read_bit(&go_right))
+        return false;
+
+      if (go_right)
+        node = node->right;
+      else
+        node = node->left;
+    }
+
+    assert (0);
+    return false;
+  }
+
+ private:
+  // Huffman tree node.
+  struct Node {
+    Val val = Val();
+    uint32_t weight = 0;
+    Node* left = nullptr;
+    Node* right = nullptr;
+  };
+
+  static bool LeftIsBigger(const Node* left, const Node* right) {
+    if (left->weight == right->weight)
+      return left->val > right->val;
+    return left->weight > right->weight;
+  }
+
+  // Prints subtree (helper function used by PrintTree).
+  static void PrintTreeInternal(std::ostream& out, Node* node, size_t depth) {
+    if (!node)
+      return;
+
+    if (!node->right && !node->left) {
+      out << node->val << std::endl;
+    } else {
+      if (node->right) {
+        out << std::setfill('-') << std::left << std::setw(7) << node->right->weight;
+        PrintTreeInternal(out, node->right, depth + 1);
+      }
+
+      if (node->left) {
+        out << std::string(depth * 7, ' ');
+        out << std::setfill('-') << std::left << std::setw(7) << node->left->weight;
+        PrintTreeInternal(out, node->left, depth + 1);
+      }
+    }
+  }
+
+  // Traverses the Huffman tree and saves paths to the leaves as bit
+  // sequences to encoding_table_.
+  void CreateEncodingTable() {
+    std::queue<std::tuple<Node*, uint64_t, size_t>> queue;
+    queue.emplace(root_, 0, 0);
+
+    while (!queue.empty()) {
+      const Node* node = std::get<0>(queue.front());
+      const uint64_t bits = std::get<1>(queue.front());
+      const size_t depth = std::get<2>(queue.front());
+      queue.pop();
+      if (!node->right && !node->left) {
+        auto insertion_result = encoding_table_.emplace(
+            node->val, std::pair<uint64_t, size_t>(bits, depth));
+        assert(insertion_result.second);
+        (void)insertion_result;
+      } else {
+        if (node->left)
+          queue.emplace(node->left, bits, depth + 1);
+
+        if (node->right)
+          queue.emplace(node->right, bits | (1ULL << depth), depth + 1);
+      }
+    }
+  }
+
+  // Huffman tree root.
+  Node* root_ = nullptr;
+
+  // Huffman tree deleter.
+  std::vector<std::unique_ptr<Node>> all_nodes_;
+
+  // Encoding table value -> {bits, num_bits}.
+  std::unordered_map<Val, std::pair<uint64_t, size_t>> encoding_table_;
+};
+
+}  // namespace spvutils
+
+#endif  // LIBSPIRV_UTIL_HUFFMAN_CODEC_H_

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -169,6 +169,11 @@ add_spvtools_unittest(
   SRCS bit_stream.cpp
   LIBS ${SPIRV_TOOLS})
 
+add_spvtools_unittest(
+  TARGET huffman_codec
+  SRCS huffman_codec.cpp
+  LIBS ${SPIRV_TOOLS})
+
 add_subdirectory(opt)
 add_subdirectory(val)
 add_subdirectory(stats)

--- a/test/huffman_codec.cpp
+++ b/test/huffman_codec.cpp
@@ -14,7 +14,10 @@
 
 // Contains utils for reading, writing and debug printing bit streams.
 
+#include <map>
 #include <sstream>
+#include <string>
+#include <unordered_map>
 
 #include "util/huffman_codec.h"
 #include "util/bit_stream.h"
@@ -25,8 +28,8 @@ namespace {
 using spvutils::HuffmanCodec;
 using spvutils::BitsToStream;
 
-const std::unordered_map<std::string, uint32_t>& GetTestSet() {
-  static const std::unordered_map<std::string, uint32_t> hist = {
+const std::map<std::string, uint32_t>& GetTestSet() {
+  static const std::map<std::string, uint32_t> hist = {
     {"a", 4},
     {"e", 7},
     {"f", 3},
@@ -71,20 +74,20 @@ TEST(Huffman, PrintTree) {
 
   const std::string expected = std::string(R"(
 15-----7------e
-       8------4------2------o
-                     2------s
-              4------a
-19-----8------4------2------1------r
-                            1------u
-                     2------h
+       8------4------a
               4------2------m
                      2------n
-       11-----5------2------t
+19-----8------4------2------o
+                     2------s
+              4------2------t
+                     2------1------l
+                            1------p
+       11-----5------2------1------r
+                            1------u
+                     3------f
+              6------3------i
                      3------1------x
-                            2------1------l
-                                   1------p
-              6------3------f
-                     3------i
+                            2------h
 )").substr(1);
 
   EXPECT_EQ(expected, ss.str());
@@ -97,20 +100,20 @@ TEST(Huffman, PrintTable) {
 
   const std::string expected = std::string(R"(
 e 7 11
-a 4 100
-i 3 0000
-f 3 0001
-t 2 0011
-n 2 0100
-m 2 0101
-h 2 0110
-s 2 1010
-o 2 1011
-x 1 00101
-u 1 01110
-r 1 01111
-p 1 001000
-l 1 001001
+a 4 101
+i 3 0001
+f 3 0010
+t 2 0101
+s 2 0110
+o 2 0111
+n 2 1000
+m 2 1001
+h 2 00000
+x 1 00001
+u 1 00110
+r 1 00111
+p 1 01000
+l 1 01001
 )").substr(1);
 
   EXPECT_EQ(expected, ss.str());
@@ -148,18 +151,18 @@ TEST(Huffman, TestEncode) {
 
   EXPECT_TRUE(huffman.Encode("a", &bits, &num_bits));
   EXPECT_EQ(3u, num_bits);
-  EXPECT_EQ("100", BitsToStream(bits, num_bits));
+  EXPECT_EQ("101", BitsToStream(bits, num_bits));
 
   EXPECT_TRUE(huffman.Encode("x", &bits, &num_bits));
   EXPECT_EQ(5u, num_bits);
-  EXPECT_EQ("00101", BitsToStream(bits, num_bits));
+  EXPECT_EQ("00001", BitsToStream(bits, num_bits));
 
   EXPECT_FALSE(huffman.Encode("y", &bits, &num_bits));
 }
 
 TEST(Huffman, TestDecode) {
   HuffmanCodec<std::string> huffman(GetTestSet());
-  TestBitReader bit_reader("001001""0000""0100""01110""00101""00");
+  TestBitReader bit_reader("01001""0001""1000""00110""00001""00");
   auto read_bit = [&bit_reader](bool* bit) {
     return bit_reader.ReadBit(bit);
   };
@@ -185,11 +188,10 @@ TEST(Huffman, TestDecode) {
 }
 
 TEST(Huffman, TestDecodeNumbers) {
-  const std::unordered_map<uint32_t, uint32_t> hist =
-      { {1, 10}, {2, 5}, {3, 15} };
+  const std::map<uint32_t, uint32_t> hist = { {1, 10}, {2, 5}, {3, 15} };
   HuffmanCodec<uint32_t> huffman(hist);
 
-  TestBitReader bit_reader("0""0""11""10""11""0");
+  TestBitReader bit_reader("1""1""01""00""01""1");
   auto read_bit = [&bit_reader](bool* bit) {
     return bit_reader.ReadBit(bit);
   };

--- a/test/huffman_codec.cpp
+++ b/test/huffman_codec.cpp
@@ -1,0 +1,218 @@
+// Copyright (c) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Contains utils for reading, writing and debug printing bit streams.
+
+#include <sstream>
+
+#include "util/huffman_codec.h"
+#include "util/bit_stream.h"
+#include "gmock/gmock.h"
+
+namespace {
+
+using spvutils::HuffmanCodec;
+using spvutils::BitsToStream;
+
+const std::unordered_map<std::string, uint32_t>& GetTestSet() {
+  static const std::unordered_map<std::string, uint32_t> hist = {
+    {"a", 4},
+    {"e", 7},
+    {"f", 3},
+    {"h", 2},
+    {"i", 3},
+    {"m", 2},
+    {"n", 2},
+    {"s", 2},
+    {"t", 2},
+    {"l", 1},
+    {"o", 2},
+    {"p", 1},
+    {"r", 1},
+    {"u", 1},
+    {"x", 1},
+  };
+
+  return hist;
+}
+
+class TestBitReader {
+ public:
+  TestBitReader(const std::string& bits) : bits_(bits) {}
+
+  bool ReadBit(bool* bit) {
+    if (pos_ < bits_.length()) {
+      *bit = bits_[pos_++] == '0' ? false : true;
+      return true;
+    }
+    return false;
+  }
+
+ private:
+  std::string bits_;
+  size_t pos_ = 0;
+};
+
+TEST(Huffman, PrintTree) {
+  HuffmanCodec<std::string> huffman(GetTestSet());
+  std::stringstream ss;
+  huffman.PrintTree(ss);
+
+  const std::string expected = std::string(R"(
+15-----7------e
+       8------4------2------o
+                     2------s
+              4------a
+19-----8------4------2------1------r
+                            1------u
+                     2------h
+              4------2------m
+                     2------n
+       11-----5------2------t
+                     3------1------x
+                            2------1------l
+                                   1------p
+              6------3------f
+                     3------i
+)").substr(1);
+
+  EXPECT_EQ(expected, ss.str());
+}
+
+TEST(Huffman, PrintTable) {
+  HuffmanCodec<std::string> huffman(GetTestSet());
+  std::stringstream ss;
+  huffman.PrintTable(ss);
+
+  const std::string expected = std::string(R"(
+e 7 11
+a 4 100
+i 3 0000
+f 3 0001
+t 2 0011
+n 2 0100
+m 2 0101
+h 2 0110
+s 2 1010
+o 2 1011
+x 1 00101
+u 1 01110
+r 1 01111
+p 1 001000
+l 1 001001
+)").substr(1);
+
+  EXPECT_EQ(expected, ss.str());
+}
+
+TEST(Huffman, TestValidity) {
+  HuffmanCodec<std::string> huffman(GetTestSet());
+  const auto& encoding_table = huffman.GetEncodingTable();
+  std::vector<std::string> codes;
+  for (const auto& entry : encoding_table) {
+    codes.push_back(BitsToStream(entry.second.first, entry.second.second));
+  }
+
+  std::sort(codes.begin(), codes.end());
+
+  ASSERT_LT(codes.size(), 20u) << "Inefficient test ahead";
+
+  for (size_t i = 0; i < codes.size(); ++i) {
+    for (size_t j = i + 1; j < codes.size(); ++j) {
+      ASSERT_FALSE(codes[i] == codes[j].substr(0, codes[i].length()))
+          << codes[i] << " is prefix of " << codes[j];
+    }
+  }
+}
+
+TEST(Huffman, TestEncode) {
+  HuffmanCodec<std::string> huffman(GetTestSet());
+
+  uint64_t bits = 0;
+  size_t num_bits = 0;
+
+  EXPECT_TRUE(huffman.Encode("e", &bits, &num_bits));
+  EXPECT_EQ(2u, num_bits);
+  EXPECT_EQ("11", BitsToStream(bits, num_bits));
+
+  EXPECT_TRUE(huffman.Encode("a", &bits, &num_bits));
+  EXPECT_EQ(3u, num_bits);
+  EXPECT_EQ("100", BitsToStream(bits, num_bits));
+
+  EXPECT_TRUE(huffman.Encode("x", &bits, &num_bits));
+  EXPECT_EQ(5u, num_bits);
+  EXPECT_EQ("00101", BitsToStream(bits, num_bits));
+
+  EXPECT_FALSE(huffman.Encode("y", &bits, &num_bits));
+}
+
+TEST(Huffman, TestDecode) {
+  HuffmanCodec<std::string> huffman(GetTestSet());
+  TestBitReader bit_reader("001001""0000""0100""01110""00101""00");
+  auto read_bit = [&bit_reader](bool* bit) {
+    return bit_reader.ReadBit(bit);
+  };
+
+  std::string decoded;
+
+  ASSERT_TRUE(huffman.DecodeFromStream(read_bit, &decoded));
+  EXPECT_EQ("l", decoded);
+
+  ASSERT_TRUE(huffman.DecodeFromStream(read_bit, &decoded));
+  EXPECT_EQ("i", decoded);
+
+  ASSERT_TRUE(huffman.DecodeFromStream(read_bit, &decoded));
+  EXPECT_EQ("n", decoded);
+
+  ASSERT_TRUE(huffman.DecodeFromStream(read_bit, &decoded));
+  EXPECT_EQ("u", decoded);
+
+  ASSERT_TRUE(huffman.DecodeFromStream(read_bit, &decoded));
+  EXPECT_EQ("x", decoded);
+
+  ASSERT_FALSE(huffman.DecodeFromStream(read_bit, &decoded));
+}
+
+TEST(Huffman, TestDecodeNumbers) {
+  const std::unordered_map<uint32_t, uint32_t> hist =
+      { {1, 10}, {2, 5}, {3, 15} };
+  HuffmanCodec<uint32_t> huffman(hist);
+
+  TestBitReader bit_reader("0""0""11""10""11""0");
+  auto read_bit = [&bit_reader](bool* bit) {
+    return bit_reader.ReadBit(bit);
+  };
+
+  uint32_t decoded;
+
+  ASSERT_TRUE(huffman.DecodeFromStream(read_bit, &decoded));
+  EXPECT_EQ(3u, decoded);
+
+  ASSERT_TRUE(huffman.DecodeFromStream(read_bit, &decoded));
+  EXPECT_EQ(3u, decoded);
+
+  ASSERT_TRUE(huffman.DecodeFromStream(read_bit, &decoded));
+  EXPECT_EQ(2u, decoded);
+
+  ASSERT_TRUE(huffman.DecodeFromStream(read_bit, &decoded));
+  EXPECT_EQ(1u, decoded);
+
+  ASSERT_TRUE(huffman.DecodeFromStream(read_bit, &decoded));
+  EXPECT_EQ(2u, decoded);
+
+  ASSERT_TRUE(huffman.DecodeFromStream(read_bit, &decoded));
+  EXPECT_EQ(3u, decoded);
+}
+
+}  // anonymous namespace


### PR DESCRIPTION
The codec is intended to be used by compression tools and is designed to be compatible with bit_stream utils, but can be built and used independently.