### PR TITLE
Don't install googletest and googlemock

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -40,7 +40,7 @@ if (NOT ${SPIRV_SKIP_EXECUTABLES})
           "Use shared (DLL) run-time lib even when Google Test is built as static lib."
           ON)
       endif()
-      add_subdirectory(${GMOCK_DIR})
+      add_subdirectory(${GMOCK_DIR} EXCLUDE_FROM_ALL)
     endif()
   endif()
   if (TARGET gmock)


### PR DESCRIPTION
When building with the Google Test framework in the external directory, calling `make install` would also install Google Test and Mock libraries and header files into my system.  This change prevents that.