### PR TITLE
Transform multiple entry points

### DIFF
--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -626,7 +626,7 @@ Pass::Status InlinePass::ProcessImpl() {
   for (auto& e : module_->entry_points()) {
     ir::Function* fn =
         id2function_[e.GetSingleWordOperand(kSpvEntryPointFunctionId)];
-    modified = modified || Inline(fn);
+    modified = Inline(fn) || modified;
   }
 
   FinalizeNextId(module_);

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -348,7 +348,7 @@ Pass::Status LocalAccessChainConvertPass::ProcessImpl() {
   for (auto& e : module_->entry_points()) {
     ir::Function* fn =
         id2function_[e.GetSingleWordOperand(kSpvEntryPointFunctionId)];
-    modified = modified || ConvertLocalAccessChains(fn);
+    modified = ConvertLocalAccessChains(fn) || modified;
   }
 
   FinalizeNextId(module_);

--- a/source/opt/local_single_block_elim_pass.cpp
+++ b/source/opt/local_single_block_elim_pass.cpp
@@ -325,7 +325,7 @@ Pass::Status LocalSingleBlockLoadStoreElimPass::ProcessImpl() {
   for (auto& e : module_->entry_points()) {
     ir::Function* fn =
         id2function_[e.GetSingleWordOperand(kSpvEntryPointFunctionId)];
-    modified = modified || LocalSingleBlockLoadStoreElim(fn);
+    modified = LocalSingleBlockLoadStoreElim(fn) || modified;
   }
   FinalizeNextId(module_);
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;

--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -445,7 +445,7 @@ Pass::Status LocalSingleStoreElimPass::ProcessImpl() {
   for (auto& e : module_->entry_points()) {
     ir::Function* fn =
         id2function_[e.GetSingleWordOperand(kSpvEntryPointFunctionId)];
-    modified = modified || LocalSingleStoreElim(fn);
+    modified = LocalSingleStoreElim(fn) || modified;
   }
   FinalizeNextId(module_);
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;


### PR DESCRIPTION
Don't stop just after one because of short-circuiting logical-or.