### PR TITLE
Added fixed width encoding to bit_stream

### DIFF
--- a/source/util/bit_stream.cpp
+++ b/source/util/bit_stream.cpp
@@ -193,6 +193,41 @@ bool ReadVariableWidthSigned(BitReaderInterface* reader, T* val,
 
 }  // namespace
 
+size_t Log2U64(uint64_t val) {
+  size_t res = 0;
+
+  if (val & 0xFFFFFFFF00000000) {
+    val >>= 32;
+    res |= 32;
+  }
+
+  if (val & 0xFFFF0000) {
+    val >>= 16;
+    res |= 16;
+  }
+
+  if (val & 0xFF00) {
+    val >>= 8;
+    res |= 8;
+  }
+
+  if (val & 0xF0) {
+    val >>= 4;
+    res |= 4;
+  }
+
+  if (val & 0xC) {
+    val >>= 2;
+    res |= 2;
+  }
+
+  if (val & 0x2) {
+    res |= 1;
+  }
+
+  return res;
+}
+
 void BitWriterInterface::WriteVariableWidthU64(uint64_t val,
                                                size_t chunk_length) {
   WriteVariableWidthUnsigned(this, val, chunk_length);
@@ -235,6 +270,16 @@ void BitWriterInterface::WriteVariableWidthS8(int8_t val,
                                               size_t chunk_length,
                                               size_t zigzag_exponent) {
   WriteVariableWidthSigned(this, val, chunk_length, zigzag_exponent);
+}
+
+void BitWriterInterface::WriteFixedWidth(uint64_t val, uint64_t max_val) {
+  if (val > max_val) {
+    assert(0 && "WriteFixedWidth: value too wide");
+    return;
+  }
+
+  const size_t num_bits = 1 + Log2U64(max_val);
+  WriteBits(val, num_bits);
 }
 
 BitWriterWord64::BitWriterWord64(size_t reserve_bits) : end_(0) {
@@ -318,6 +363,11 @@ bool BitReaderInterface::ReadVariableWidthS8(int8_t* val,
                                              size_t chunk_length,
                                              size_t zigzag_exponent) {
   return ReadVariableWidthSigned(this, val, chunk_length, zigzag_exponent);
+}
+
+bool BitReaderInterface::ReadFixedWidth(uint64_t* val, uint64_t max_val) {
+  const size_t num_bits = 1 + Log2U64(max_val);
+  return ReadBits(val, num_bits) == num_bits;
 }
 
 BitReaderWord64::BitReaderWord64(std::vector<uint64_t>&& buffer)

--- a/source/util/bit_stream.h
+++ b/source/util/bit_stream.h
@@ -25,6 +25,9 @@
 
 namespace spvutils {
 
+// Returns rounded down log2(val). log2(0) is considered 0.
+size_t Log2U64(uint64_t val);
+
 // Terminology:
 // Bits - usually used for a uint64 word, first bit is the lowest.
 // Stream - std::string of '0' and '1', read left-to-right,
@@ -231,6 +234,18 @@ class BitWriterInterface {
   void WriteVariableWidthS8(
       int8_t val, size_t chunk_length, size_t zigzag_exponent);
 
+  // Writes |val| using fixed bit width. Bit width is determined by |max_val|:
+  // max_val 0 -> bit width 1
+  // max_val 1 -> bit width 1
+  // max_val 2 -> bit width 2
+  // max_val 3 -> bit width 2
+  // max_val 4 -> bit width 3
+  // max_val 5 -> bit width 3
+  // max_val 8 -> bit width 4
+  // max_val n -> bit width 1 + floor(log2(n))
+  // |val| needs to be <= |max_val|.
+  void WriteFixedWidth(uint64_t val, uint64_t max_val);
+
   // Returns number of bits written.
   virtual size_t GetNumBits() const = 0;
 
@@ -345,6 +360,10 @@ class BitReaderInterface {
       int16_t* val, size_t chunk_length, size_t zigzag_exponent);
   bool ReadVariableWidthS8(
       int8_t* val, size_t chunk_length, size_t zigzag_exponent);
+
+  // Reads value written by WriteFixedWidth (|max_val| needs to be the same).
+  // Returns true on success, false if the bit stream ends prematurely.
+  bool ReadFixedWidth(uint64_t* val, uint64_t max_val);
 
   BitReaderInterface(const BitReaderInterface&) = delete;
   BitReaderInterface& operator=(const BitReaderInterface&) = delete;

--- a/test/bit_stream.cpp
+++ b/test/bit_stream.cpp
@@ -36,6 +36,7 @@ using spvutils::StreamToBits;
 using spvutils::GetLowerBits;
 using spvutils::EncodeZigZag;
 using spvutils::DecodeZigZag;
+using spvutils::Log2U64;
 
 // A simple and inefficient implementatition of BitWriterInterface,
 // using std::stringstream. Intended for tests only.
@@ -100,6 +101,45 @@ class BitReaderFromString : public BitReaderInterface {
   std::string str_;
   size_t pos_;
 };
+
+TEST(Log2U16, Test) {
+  EXPECT_EQ(0u, Log2U64(0));
+  EXPECT_EQ(0u, Log2U64(1));
+  EXPECT_EQ(1u, Log2U64(2));
+  EXPECT_EQ(1u, Log2U64(3));
+  EXPECT_EQ(2u, Log2U64(4));
+  EXPECT_EQ(2u, Log2U64(5));
+  EXPECT_EQ(2u, Log2U64(6));
+  EXPECT_EQ(2u, Log2U64(7));
+  EXPECT_EQ(3u, Log2U64(8));
+  EXPECT_EQ(3u, Log2U64(9));
+  EXPECT_EQ(3u, Log2U64(10));
+  EXPECT_EQ(3u, Log2U64(11));
+  EXPECT_EQ(3u, Log2U64(12));
+  EXPECT_EQ(3u, Log2U64(13));
+  EXPECT_EQ(3u, Log2U64(14));
+  EXPECT_EQ(3u, Log2U64(15));
+  EXPECT_EQ(4u, Log2U64(16));
+  EXPECT_EQ(4u, Log2U64(17));
+  EXPECT_EQ(5u, Log2U64(35));
+  EXPECT_EQ(6u, Log2U64(72));
+  EXPECT_EQ(7u, Log2U64(255));
+  EXPECT_EQ(8u, Log2U64(256));
+  EXPECT_EQ(15u, Log2U64(65535));
+  EXPECT_EQ(16u, Log2U64(65536));
+  EXPECT_EQ(19u, Log2U64(0xFFFFF));
+  EXPECT_EQ(23u, Log2U64(0xFFFFFF));
+  EXPECT_EQ(27u, Log2U64(0xFFFFFFF));
+  EXPECT_EQ(31u, Log2U64(0xFFFFFFFF));
+  EXPECT_EQ(35u, Log2U64(0xFFFFFFFFF));
+  EXPECT_EQ(39u, Log2U64(0xFFFFFFFFFF));
+  EXPECT_EQ(43u, Log2U64(0xFFFFFFFFFFF));
+  EXPECT_EQ(47u, Log2U64(0xFFFFFFFFFFFF));
+  EXPECT_EQ(51u, Log2U64(0xFFFFFFFFFFFFF));
+  EXPECT_EQ(55u, Log2U64(0xFFFFFFFFFFFFFF));
+  EXPECT_EQ(59u, Log2U64(0xFFFFFFFFFFFFFFF));
+  EXPECT_EQ(63u, Log2U64(0xFFFFFFFFFFFFFFFF));
+}
 
 TEST(NumBitsToNumWords, Word8) {
   EXPECT_EQ(0u, NumBitsToNumWords<8>(0));
@@ -1133,6 +1173,70 @@ TEST(VariableWidthWriteRead, VariedNumbersChunkLength8) {
   }
 
   EXPECT_EQ(expected_values, actual_values);
+}
+
+TEST(FixedWidthWrite, Val0Max3) {
+  BitWriterStringStream writer;
+  writer.WriteFixedWidth(0, 3);
+  EXPECT_EQ("00", writer.GetStreamRaw());
+}
+
+TEST(FixedWidthWrite, Val0Max5) {
+  BitWriterStringStream writer;
+  writer.WriteFixedWidth(0, 5);
+  EXPECT_EQ("000", writer.GetStreamRaw());
+}
+
+TEST(FixedWidthWrite, Val0Max255) {
+  BitWriterStringStream writer;
+  writer.WriteFixedWidth(0, 255);
+  EXPECT_EQ("00000000", writer.GetStreamRaw());
+}
+
+TEST(FixedWidthWrite, Val3Max8) {
+  BitWriterStringStream writer;
+  writer.WriteFixedWidth(3, 8);
+  EXPECT_EQ("1100", writer.GetStreamRaw());
+}
+
+TEST(FixedWidthWrite, Val15Max127) {
+  BitWriterStringStream writer;
+  writer.WriteFixedWidth(15, 127);
+  EXPECT_EQ("1111000", writer.GetStreamRaw());
+}
+
+TEST(FixedWidthRead, Val0Max3) {
+  BitReaderFromString reader("0011111");
+  uint64_t val = 0;
+  ASSERT_TRUE(reader.ReadFixedWidth(&val, 3));
+  EXPECT_EQ(0u, val);
+}
+
+TEST(FixedWidthRead, Val0Max5) {
+  BitReaderFromString reader("0001010101");
+  uint64_t val = 0;
+  ASSERT_TRUE(reader.ReadFixedWidth(&val, 5));
+  EXPECT_EQ(0u, val);
+}
+
+TEST(FixedWidthRead, Val3Max8) {
+  BitReaderFromString reader("11001010101");
+  uint64_t val = 0;
+  ASSERT_TRUE(reader.ReadFixedWidth(&val, 8));
+  EXPECT_EQ(3u, val);
+}
+
+TEST(FixedWidthRead, Val15Max127) {
+  BitReaderFromString reader("111100010101");
+  uint64_t val = 0;
+  ASSERT_TRUE(reader.ReadFixedWidth(&val, 127));
+  EXPECT_EQ(15u, val);
+}
+
+TEST(FixedWidthRead, Fail) {
+  BitReaderFromString reader("111100");
+  uint64_t val = 0;
+  ASSERT_FALSE(reader.ReadFixedWidth(&val, 127));
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
Fixed width encoding is intended to be used for small unsigned integers
when the upper bound is known both to the encoder and the decoder
(for example move-to-front rank).