### PR TITLE
MARK-V decoder supports extended instructions

### DIFF
--- a/source/comp/markv_codec.cpp
+++ b/source/comp/markv_codec.cpp
@@ -1061,7 +1061,7 @@ spv_result_t MarkvDecoder::DecodeOperand(
       if (grammar_.lookupExtInst(inst->ext_inst_type, word, &ext_inst))
         return vstate_.diag(SPV_ERROR_INVALID_BINARY)
             << "Invalid extended instruction number: " << word;
-      spvPrependOperandTypes(ext_inst->operandTypes, expected_operands);
+      spvPushOperandTypes(ext_inst->operandTypes, expected_operands);
       break;
     }
 

--- a/test/comp/markv_codec_test.cpp
+++ b/test/comp/markv_codec_test.cpp
@@ -410,4 +410,24 @@ OpDecorate %1 Uniform
 )");
 }
 
+TEST(Markv, WithExtInst) {
+  TestEncodeDecode(R"(
+OpCapability Addresses
+OpCapability Kernel
+OpCapability GenericPointer
+OpCapability Linkage
+%opencl = OpExtInstImport "OpenCL.std"
+OpMemoryModel Physical32 OpenCL
+%f32 = OpTypeFloat 32
+%void = OpTypeVoid
+%void_func = OpTypeFunction %void
+%100 = OpConstant %f32 1.1
+%main = OpFunction %void None %void_func
+%entry_main = OpLabel
+%200 = OpExtInst %f32 %opencl cos %100
+OpReturn
+OpFunctionEnd
+)");
+}
+
 }  // namespace


### PR DESCRIPTION
Fixes multiple TODOs in mark_codec.cpp.

This CL conflicts with recent changes in operand patterns:
https://github.com/KhronosGroup/SPIRV-Tools/pull/689