### PR TITLE
Fix Visual Studio size_t cast compiler warning

### DIFF
--- a/source/comp/markv_codec.cpp
+++ b/source/comp/markv_codec.cpp
@@ -1367,7 +1367,7 @@ spv_result_t MarkvDecoder::DecodeInstruction(spv_parsed_instruction_t* inst) {
 
   assert(inst->num_words == std::accumulate(
       parsed_operands_.begin(), parsed_operands_.end(), 1,
-      [](size_t num_words, const spv_parsed_operand_t& operand) {
+      [](int num_words, const spv_parsed_operand_t& operand) {
         return num_words += operand.num_words;
   }) && "num_words in instruction doesn't correspond to the sum of num_words"
         "in the operands");


### PR DESCRIPTION
Visual Studio was complaining about possible loss of data on 64-bit builds, due to an implicit cast from `size_t` to `int`. This changes the data to use an int all around.

Since the project is set to treat warnings as errors by default, this means that 64-bit builds of the repo were failing unless the user specifically disabled the `/Werror` flag.