### PR TITLE
Opt: Fix handling of CopyObject in GetPtr and its call sites

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -47,6 +47,10 @@ ir::Instruction* AggressiveDCEPass::GetPtr(
   *varId = ip->GetSingleWordInOperand(
       op == SpvOpStore ? kStorePtrIdInIdx : kLoadPtrIdInIdx);
   ir::Instruction* ptrInst = def_use_mgr_->GetDef(*varId);
+  while (ptrInst->opcode() == SpvOpCopyObject) {
+    *varId = ptrInst->GetSingleWordInOperand(kCopyObjectOperandInIdx);
+    ptrInst = def_use_mgr_->GetDef(*varId);
+  }
   ir::Instruction* varInst = ptrInst;
   while (varInst->opcode() != SpvOpVariable) {
     if (IsNonPtrAccessChain(varInst->opcode())) {

--- a/source/opt/local_ssa_elim_pass.cpp
+++ b/source/opt/local_ssa_elim_pass.cpp
@@ -82,6 +82,10 @@ ir::Instruction* LocalMultiStoreElimPass::GetPtr(
   *varId = ip->GetSingleWordInOperand(
       op == SpvOpStore ? kStorePtrIdInIdx : kLoadPtrIdInIdx);
   ir::Instruction* ptrInst = def_use_mgr_->GetDef(*varId);
+  while (ptrInst->opcode() == SpvOpCopyObject) {
+    *varId = ptrInst->GetSingleWordInOperand(kCopyObjectOperandInIdx);
+    ptrInst = def_use_mgr_->GetDef(*varId);
+  }
   ir::Instruction* varInst = ptrInst;
   while (varInst->opcode() != SpvOpVariable) {
     if (IsNonPtrAccessChain(varInst->opcode())) {


### PR DESCRIPTION
GetPtr now returns the first non-CopyObject in the pointer of a load or store.