### PR TITLE
Opt: Add extension whitelists to size-reduction passes.

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -511,7 +511,8 @@ void AggressiveDCEPass::InitCombinatorSets() {
 }
 
 void AggressiveDCEPass::InitExtensions() {
-  extensions_whitelist_ = {
+  extensions_whitelist_.clear();
+  extensions_whitelist_.insert({
     "SPV_AMD_shader_explicit_vertex_parameter",
     "SPV_AMD_shader_trinary_minmax",
     "SPV_AMD_gcn_shader",
@@ -535,7 +536,7 @@ void AggressiveDCEPass::InitExtensions() {
     "SPV_AMD_gpu_shader_int16",
     "SPV_KHR_post_depth_coverage",
     "SPV_KHR_shader_atomic_counter_ops",
-  };
+  });
 }
 
 }  // namespace opt

--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -247,6 +247,9 @@ void AggressiveDCEPass::Initialize(ir::Module* module) {
 
   // TODO(greg-lunarg): Reuse def/use from previous passes
   def_use_mgr_.reset(new analysis::DefUseManager(consumer(), module_));
+
+  // Initialize extensions whitelist
+  InitExtensions();
 }
 
 Pass::Status AggressiveDCEPass::ProcessImpl() {
@@ -504,6 +507,34 @@ void AggressiveDCEPass::InitCombinatorSets() {
     GLSLstd450NMin,
     GLSLstd450NMax,
     GLSLstd450NClamp
+  };
+}
+
+void AggressiveDCEPass::InitExtensions() {
+  extensions_whitelist_ = {
+    "SPV_AMD_shader_explicit_vertex_parameter",
+    "SPV_AMD_shader_trinary_minmax",
+    "SPV_AMD_gcn_shader",
+    "SPV_KHR_shader_ballot",
+    "SPV_AMD_shader_ballot",
+    "SPV_AMD_gpu_shader_half_float",
+    "SPV_KHR_shader_draw_parameters",
+    "SPV_KHR_subgroup_vote",
+    "SPV_KHR_16bit_storage",
+    "SPV_KHR_device_group",
+    "SPV_KHR_multiview",
+    "SPV_NVX_multiview_per_view_attributes",
+    "SPV_NV_viewport_array2",
+    "SPV_NV_stereo_view_rendering",
+    "SPV_NV_sample_mask_override_coverage",
+    "SPV_NV_geometry_shader_passthrough",
+    "SPV_AMD_texture_gather_bias_lod",
+    "SPV_KHR_storage_buffer_storage_class",
+    // SPV_KHR_variable_pointers
+    //   Currently do not support extended pointer expressions
+    "SPV_AMD_gpu_shader_int16",
+    "SPV_KHR_post_depth_coverage",
+    "SPV_KHR_shader_atomic_counter_ops",
   };
 }
 

--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -247,9 +247,6 @@ void AggressiveDCEPass::Initialize(ir::Module* module) {
 
   // TODO(greg-lunarg): Reuse def/use from previous passes
   def_use_mgr_.reset(new analysis::DefUseManager(consumer(), module_));
-
-  // Initialize extensions whitelist
-  InitExtensions();
 }
 
 Pass::Status AggressiveDCEPass::ProcessImpl() {
@@ -507,34 +504,6 @@ void AggressiveDCEPass::InitCombinatorSets() {
     GLSLstd450NMin,
     GLSLstd450NMax,
     GLSLstd450NClamp
-  };
-}
-
-void AggressiveDCEPass::InitExtensions() {
-  extensions_whitelist_ = {
-    "SPV_AMD_shader_explicit_vertex_parameter",
-    "SPV_AMD_shader_trinary_minmax",
-    "SPV_AMD_gcn_shader",
-    "SPV_KHR_shader_ballot",
-    "SPV_AMD_shader_ballot",
-    "SPV_AMD_gpu_shader_half_float",
-    "SPV_KHR_shader_draw_parameters",
-    "SPV_KHR_subgroup_vote",
-    "SPV_KHR_16bit_storage",
-    "SPV_KHR_device_group",
-    "SPV_KHR_multiview",
-    "SPV_NVX_multiview_per_view_attributes",
-    "SPV_NV_viewport_array2",
-    "SPV_NV_stereo_view_rendering",
-    "SPV_NV_sample_mask_override_coverage",
-    "SPV_NV_geometry_shader_passthrough",
-    "SPV_AMD_texture_gather_bias_lod",
-    "SPV_KHR_storage_buffer_storage_class",
-    // SPV_KHR_variable_pointers
-    //   Currently do not support extended pointer expressions
-    "SPV_AMD_gpu_shader_int16",
-    "SPV_KHR_post_depth_coverage",
-    "SPV_KHR_shader_atomic_counter_ops",
   };
 }
 

--- a/source/opt/aggressive_dead_code_elim_pass.h
+++ b/source/opt/aggressive_dead_code_elim_pass.h
@@ -73,9 +73,6 @@ class AggressiveDCEPass : public Pass {
   // TODO(greg-lunarg): Add support for other extensions
   bool IsCombinatorExt(ir::Instruction* inst) const;
 
-  // Initialize extensions whitelist
-  void InitExtensions();
-
   // Return true if all extensions in this module are supported by this pass.
   bool AllExtensionsSupported() const;
 
@@ -134,7 +131,31 @@ class AggressiveDCEPass : public Pass {
   std::unordered_set<uint32_t> combinator_ops_glsl_std_450_;
 
   // Extensions supported by this pass.
-  std::unordered_set<std::string> extensions_whitelist_;
+  std::unordered_set<std::string> extensions_whitelist_ {
+    "SPV_AMD_shader_explicit_vertex_parameter",
+    "SPV_AMD_shader_trinary_minmax",
+    "SPV_AMD_gcn_shader",
+    "SPV_KHR_shader_ballot",
+    "SPV_AMD_shader_ballot",
+    "SPV_AMD_gpu_shader_half_float",
+    "SPV_KHR_shader_draw_parameters",
+    "SPV_KHR_subgroup_vote",
+    "SPV_KHR_16bit_storage",
+    "SPV_KHR_device_group",
+    "SPV_KHR_multiview",
+    "SPV_NVX_multiview_per_view_attributes",
+    "SPV_NV_viewport_array2",
+    "SPV_NV_stereo_view_rendering",
+    "SPV_NV_sample_mask_override_coverage",
+    "SPV_NV_geometry_shader_passthrough",
+    "SPV_AMD_texture_gather_bias_lod",
+    "SPV_KHR_storage_buffer_storage_class",
+    // SPV_KHR_variable_pointers
+    //   Currently do not support extended pointer expressions
+    "SPV_AMD_gpu_shader_int16",
+    "SPV_KHR_post_depth_coverage",
+    "SPV_KHR_shader_atomic_counter_ops",
+};
 
   // Set id for glsl_std_450 extension instructions
   uint32_t glsl_std_450_id_;

--- a/source/opt/aggressive_dead_code_elim_pass.h
+++ b/source/opt/aggressive_dead_code_elim_pass.h
@@ -73,6 +73,9 @@ class AggressiveDCEPass : public Pass {
   // TODO(greg-lunarg): Add support for other extensions
   bool IsCombinatorExt(ir::Instruction* inst) const;
 
+  // Initialize extensions whitelist
+  void InitExtensions();
+
   // Return true if all extensions in this module are supported by this pass.
   bool AllExtensionsSupported() const;
 
@@ -131,31 +134,7 @@ class AggressiveDCEPass : public Pass {
   std::unordered_set<uint32_t> combinator_ops_glsl_std_450_;
 
   // Extensions supported by this pass.
-  std::unordered_set<std::string> extensions_whitelist_ {
-    "SPV_AMD_shader_explicit_vertex_parameter",
-    "SPV_AMD_shader_trinary_minmax",
-    "SPV_AMD_gcn_shader",
-    "SPV_KHR_shader_ballot",
-    "SPV_AMD_shader_ballot",
-    "SPV_AMD_gpu_shader_half_float",
-    "SPV_KHR_shader_draw_parameters",
-    "SPV_KHR_subgroup_vote",
-    "SPV_KHR_16bit_storage",
-    "SPV_KHR_device_group",
-    "SPV_KHR_multiview",
-    "SPV_NVX_multiview_per_view_attributes",
-    "SPV_NV_viewport_array2",
-    "SPV_NV_stereo_view_rendering",
-    "SPV_NV_sample_mask_override_coverage",
-    "SPV_NV_geometry_shader_passthrough",
-    "SPV_AMD_texture_gather_bias_lod",
-    "SPV_KHR_storage_buffer_storage_class",
-    // SPV_KHR_variable_pointers
-    //   Currently do not support extended pointer expressions
-    "SPV_AMD_gpu_shader_int16",
-    "SPV_KHR_post_depth_coverage",
-    "SPV_KHR_shader_atomic_counter_ops",
-};
+  std::unordered_set<std::string> extensions_whitelist_;
 
   // Set id for glsl_std_450 extension instructions
   uint32_t glsl_std_450_id_;

--- a/source/opt/aggressive_dead_code_elim_pass.h
+++ b/source/opt/aggressive_dead_code_elim_pass.h
@@ -73,10 +73,11 @@ class AggressiveDCEPass : public Pass {
   // TODO(greg-lunarg): Add support for other extensions
   bool IsCombinatorExt(ir::Instruction* inst) const;
 
+  // Initialize extensions whitelist
+  void InitExtensions();
+
   // Return true if all extensions in this module are supported by this pass.
-  // Currently, no extensions are supported. glsl_std_450 extended instructions
-  // are allowed.
-  bool AllExtensionsSupported();
+  bool AllExtensionsSupported() const;
 
   // Kill debug or annotation |inst| if target operand is dead.
   void KillInstIfTargetDead(ir::Instruction* inst);
@@ -131,6 +132,9 @@ class AggressiveDCEPass : public Pass {
   // that can safely be left unmarked as live at the beginning of
   // aggressive DCE.
   std::unordered_set<uint32_t> combinator_ops_glsl_std_450_;
+
+  // Extensions supported by this pass.
+  std::unordered_set<std::string> extensions_whitelist_;
 
   // Set id for glsl_std_450 extension instructions
   uint32_t glsl_std_450_id_;

--- a/source/opt/block_merge_pass.cpp
+++ b/source/opt/block_merge_pass.cpp
@@ -157,7 +157,8 @@ Pass::Status BlockMergePass::Process(ir::Module* module) {
 }
 
 void BlockMergePass::InitExtensions() {
-  extensions_whitelist_ = {
+  extensions_whitelist_.clear();
+  extensions_whitelist_.insert({
     "SPV_AMD_shader_explicit_vertex_parameter",
     "SPV_AMD_shader_trinary_minmax",
     "SPV_AMD_gcn_shader",
@@ -180,7 +181,7 @@ void BlockMergePass::InitExtensions() {
     "SPV_AMD_gpu_shader_int16",
     "SPV_KHR_post_depth_coverage",
     "SPV_KHR_shader_atomic_counter_ops",
-  };
+  });
 }
 
 }  // namespace opt

--- a/source/opt/block_merge_pass.h
+++ b/source/opt/block_merge_pass.h
@@ -53,6 +53,12 @@ class BlockMergePass : public Pass {
   // with no other predecessors. Merge these blocks into a single block.
   bool MergeBlocks(ir::Function* func);
 
+  // Initialize extensions whitelist
+  void InitExtensions();
+
+  // Return true if all extensions in this module are allowed by this pass.
+  bool AllExtensionsSupported() const;
+
   void Initialize(ir::Module* module);
   Pass::Status ProcessImpl();
 
@@ -64,6 +70,9 @@ class BlockMergePass : public Pass {
 
   // Map from function's result id to function
   std::unordered_map<uint32_t, ir::Function*> id2function_;
+
+  // Extensions supported by this pass.
+  std::unordered_set<std::string> extensions_whitelist_;
 };
 
 }  // namespace opt

--- a/source/opt/dead_branch_elim_pass.cpp
+++ b/source/opt/dead_branch_elim_pass.cpp
@@ -342,7 +342,8 @@ Pass::Status DeadBranchElimPass::Process(ir::Module* module) {
 }
 
 void DeadBranchElimPass::InitExtensions() {
-  extensions_whitelist_ = {
+  extensions_whitelist_.clear();
+  extensions_whitelist_.insert({
     "SPV_AMD_shader_explicit_vertex_parameter",
     "SPV_AMD_shader_trinary_minmax",
     "SPV_AMD_gcn_shader",
@@ -365,7 +366,7 @@ void DeadBranchElimPass::InitExtensions() {
     "SPV_AMD_gpu_shader_int16",
     "SPV_KHR_post_depth_coverage",
     "SPV_KHR_shader_atomic_counter_ops",
-  };
+  });
 }
 
 }  // namespace opt

--- a/source/opt/dead_branch_elim_pass.cpp
+++ b/source/opt/dead_branch_elim_pass.cpp
@@ -297,15 +297,33 @@ void DeadBranchElimPass::Initialize(ir::Module* module) {
     }
   }
 
+  // TODO(greg-lunarg): Reuse def/use from previous passes
   def_use_mgr_.reset(new analysis::DefUseManager(consumer(), module_));
+
+  // Initialize extension whitelist
+  InitExtensions();
 };
+
+bool DeadBranchElimPass::AllExtensionsSupported() const {
+  // If any extension not in whitelist, return false
+  for (auto& ei : module_->extensions()) {
+    const char* extName = reinterpret_cast<const char*>(
+        &ei.GetInOperand(0).words[0]);
+    if (extensions_whitelist_.find(extName) == extensions_whitelist_.end())
+      return false;
+  }
+  return true;
+}
 
 Pass::Status DeadBranchElimPass::ProcessImpl() {
   // Current functionality assumes structured control flow. 
   // TODO(greg-lunarg): Handle non-structured control-flow.
   if (!module_->HasCapability(SpvCapabilityShader))
     return Status::SuccessWithoutChange;
-
+  // Do not process if any disallowed extensions are enabled
+  if (!AllExtensionsSupported())
+    return Status::SuccessWithoutChange;
+  // Process all entry point functions
   bool modified = false;
   for (const auto& e : module_->entry_points()) {
     ir::Function* fn =
@@ -321,6 +339,33 @@ DeadBranchElimPass::DeadBranchElimPass()
 Pass::Status DeadBranchElimPass::Process(ir::Module* module) {
   Initialize(module);
   return ProcessImpl();
+}
+
+void DeadBranchElimPass::InitExtensions() {
+  extensions_whitelist_ = {
+    "SPV_AMD_shader_explicit_vertex_parameter",
+    "SPV_AMD_shader_trinary_minmax",
+    "SPV_AMD_gcn_shader",
+    "SPV_KHR_shader_ballot",
+    "SPV_AMD_shader_ballot",
+    "SPV_AMD_gpu_shader_half_float",
+    "SPV_KHR_shader_draw_parameters",
+    "SPV_KHR_subgroup_vote",
+    "SPV_KHR_16bit_storage",
+    "SPV_KHR_device_group",
+    "SPV_KHR_multiview",
+    "SPV_NVX_multiview_per_view_attributes",
+    "SPV_NV_viewport_array2",
+    "SPV_NV_stereo_view_rendering",
+    "SPV_NV_sample_mask_override_coverage",
+    "SPV_NV_geometry_shader_passthrough",
+    "SPV_AMD_texture_gather_bias_lod",
+    "SPV_KHR_storage_buffer_storage_class",
+    "SPV_KHR_variable_pointers",
+    "SPV_AMD_gpu_shader_int16",
+    "SPV_KHR_post_depth_coverage",
+    "SPV_KHR_shader_atomic_counter_ops",
+  };
 }
 
 }  // namespace opt

--- a/source/opt/dead_branch_elim_pass.h
+++ b/source/opt/dead_branch_elim_pass.h
@@ -105,6 +105,12 @@ class DeadBranchElimPass : public Pass {
   // dead blocks.
   bool EliminateDeadBranches(ir::Function* func);
 
+  // Initialize extensions whitelist
+  void InitExtensions();
+
+  // Return true if all extensions in this module are allowed by this pass.
+  bool AllExtensionsSupported() const;
+
   void Initialize(ir::Module* module);
   Pass::Status ProcessImpl();
 
@@ -124,6 +130,9 @@ class DeadBranchElimPass : public Pass {
   // ComputeStructuredSuccessors() for definition.
   std::unordered_map<const ir::BasicBlock*, std::vector<ir::BasicBlock*>>
       block2structured_succs_;
+
+  // Extensions supported by this pass.
+  std::unordered_set<std::string> extensions_whitelist_;
 };
 
 }  // namespace opt

--- a/source/opt/insert_extract_elim.cpp
+++ b/source/opt/insert_extract_elim.cpp
@@ -137,7 +137,8 @@ Pass::Status InsertExtractElimPass::Process(ir::Module* module) {
 }
 
 void InsertExtractElimPass::InitExtensions() {
-  extensions_whitelist_ = {
+  extensions_whitelist_.clear();
+  extensions_whitelist_.insert({
     "SPV_AMD_shader_explicit_vertex_parameter",
     "SPV_AMD_shader_trinary_minmax",
     "SPV_AMD_gcn_shader",
@@ -160,7 +161,7 @@ void InsertExtractElimPass::InitExtensions() {
     "SPV_AMD_gpu_shader_int16",
     "SPV_KHR_post_depth_coverage",
     "SPV_KHR_shader_atomic_counter_ops",
-  };
+  });
 }
 
 }  // namespace opt

--- a/source/opt/insert_extract_elim.cpp
+++ b/source/opt/insert_extract_elim.cpp
@@ -97,12 +97,28 @@ void InsertExtractElimPass::Initialize(ir::Module* module) {
 
   // Do def/use on whole module
   def_use_mgr_.reset(new analysis::DefUseManager(consumer(), module_));
+
+  // Initialize extension whitelist
+  InitExtensions();
 };
 
-Pass::Status InsertExtractElimPass::ProcessImpl() {
-  bool modified = false;
+bool InsertExtractElimPass::AllExtensionsSupported() const {
+  // If any extension not in whitelist, return false
+  for (auto& ei : module_->extensions()) {
+    const char* extName = reinterpret_cast<const char*>(
+        &ei.GetInOperand(0).words[0]);
+    if (extensions_whitelist_.find(extName) == extensions_whitelist_.end())
+      return false;
+  }
+  return true;
+}
 
+Pass::Status InsertExtractElimPass::ProcessImpl() {
+  // Do not process if any disallowed extensions are enabled
+  if (!AllExtensionsSupported())
+    return Status::SuccessWithoutChange;
   // Process all entry point functions.
+  bool modified = false;
   for (auto& e : module_->entry_points()) {
     ir::Function* fn =
         id2function_[e.GetSingleWordOperand(kSpvEntryPointFunctionId)];
@@ -118,6 +134,33 @@ InsertExtractElimPass::InsertExtractElimPass()
 Pass::Status InsertExtractElimPass::Process(ir::Module* module) {
   Initialize(module);
   return ProcessImpl();
+}
+
+void InsertExtractElimPass::InitExtensions() {
+  extensions_whitelist_ = {
+    "SPV_AMD_shader_explicit_vertex_parameter",
+    "SPV_AMD_shader_trinary_minmax",
+    "SPV_AMD_gcn_shader",
+    "SPV_KHR_shader_ballot",
+    "SPV_AMD_shader_ballot",
+    "SPV_AMD_gpu_shader_half_float",
+    "SPV_KHR_shader_draw_parameters",
+    "SPV_KHR_subgroup_vote",
+    "SPV_KHR_16bit_storage",
+    "SPV_KHR_device_group",
+    "SPV_KHR_multiview",
+    "SPV_NVX_multiview_per_view_attributes",
+    "SPV_NV_viewport_array2",
+    "SPV_NV_stereo_view_rendering",
+    "SPV_NV_sample_mask_override_coverage",
+    "SPV_NV_geometry_shader_passthrough",
+    "SPV_AMD_texture_gather_bias_lod",
+    "SPV_KHR_storage_buffer_storage_class",
+    "SPV_KHR_variable_pointers",
+    "SPV_AMD_gpu_shader_int16",
+    "SPV_KHR_post_depth_coverage",
+    "SPV_KHR_shader_atomic_counter_ops",
+  };
 }
 
 }  // namespace opt

--- a/source/opt/insert_extract_elim.h
+++ b/source/opt/insert_extract_elim.h
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <map>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 #include "basic_block.h"
@@ -57,6 +58,12 @@ class InsertExtractElimPass : public Pass {
   // intervening insert which conflicts.
   bool EliminateInsertExtract(ir::Function* func);
 
+  // Initialize extensions whitelist
+  void InitExtensions();
+
+  // Return true if all extensions in this module are allowed by this pass.
+  bool AllExtensionsSupported() const;
+
   void Initialize(ir::Module* module);
   Pass::Status ProcessImpl();
 
@@ -68,6 +75,9 @@ class InsertExtractElimPass : public Pass {
 
   // Map from function's result id to function
   std::unordered_map<uint32_t, ir::Function*> id2function_;
+
+  // Extensions supported by this pass.
+  std::unordered_set<std::string> extensions_whitelist_;
 };
 
 }  // namespace opt

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -334,7 +334,21 @@ void LocalAccessChainConvertPass::Initialize(ir::Module* module) {
 
   // Initialize next unused Id.
   next_id_ = module->id_bound();
+
+  // Initialize extension whitelist
+  InitExtensions();
 };
+
+bool LocalAccessChainConvertPass::AllExtensionsSupported() const {
+  // If any extension not in whitelist, return false
+  for (auto& ei : module_->extensions()) {
+    const char* extName = reinterpret_cast<const char*>(
+        &ei.GetInOperand(0).words[0]);
+    if (extensions_whitelist_.find(extName) == extensions_whitelist_.end())
+      return false;
+  }
+  return true;
+}
 
 Pass::Status LocalAccessChainConvertPass::ProcessImpl() {
   // If non-32-bit integer type in module, terminate processing
@@ -343,6 +357,9 @@ Pass::Status LocalAccessChainConvertPass::ProcessImpl() {
     if (inst.opcode() == SpvOpTypeInt &&
         inst.GetSingleWordInOperand(kSpvTypeIntWidth) != 32)
       return Status::SuccessWithoutChange;
+  // Do not process if any disallowed extensions are enabled
+  if (!AllExtensionsSupported())
+    return Status::SuccessWithoutChange;
   // Process all entry point functions.
   bool modified = false;
   for (auto& e : module_->entry_points()) {
@@ -362,6 +379,34 @@ LocalAccessChainConvertPass::LocalAccessChainConvertPass()
 Pass::Status LocalAccessChainConvertPass::Process(ir::Module* module) {
   Initialize(module);
   return ProcessImpl();
+}
+
+void LocalAccessChainConvertPass::InitExtensions() {
+  extensions_whitelist_ = {
+    "SPV_AMD_shader_explicit_vertex_parameter",
+    "SPV_AMD_shader_trinary_minmax",
+    "SPV_AMD_gcn_shader",
+    "SPV_KHR_shader_ballot",
+    "SPV_AMD_shader_ballot",
+    "SPV_AMD_gpu_shader_half_float",
+    "SPV_KHR_shader_draw_parameters",
+    "SPV_KHR_subgroup_vote",
+    "SPV_KHR_16bit_storage",
+    "SPV_KHR_device_group",
+    "SPV_KHR_multiview",
+    "SPV_NVX_multiview_per_view_attributes",
+    "SPV_NV_viewport_array2",
+    "SPV_NV_stereo_view_rendering",
+    "SPV_NV_sample_mask_override_coverage",
+    "SPV_NV_geometry_shader_passthrough",
+    "SPV_AMD_texture_gather_bias_lod",
+    "SPV_KHR_storage_buffer_storage_class",
+    // SPV_KHR_variable_pointers
+    //   Currently do not support extended pointer expressions
+    "SPV_AMD_gpu_shader_int16",
+    "SPV_KHR_post_depth_coverage",
+    "SPV_KHR_shader_atomic_counter_ops",
+  };
 }
 
 }  // namespace opt

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -382,7 +382,8 @@ Pass::Status LocalAccessChainConvertPass::Process(ir::Module* module) {
 }
 
 void LocalAccessChainConvertPass::InitExtensions() {
-  extensions_whitelist_ = {
+  extensions_whitelist_.clear();
+  extensions_whitelist_.insert({
     "SPV_AMD_shader_explicit_vertex_parameter",
     "SPV_AMD_shader_trinary_minmax",
     "SPV_AMD_gcn_shader",
@@ -406,7 +407,7 @@ void LocalAccessChainConvertPass::InitExtensions() {
     "SPV_AMD_gpu_shader_int16",
     "SPV_KHR_post_depth_coverage",
     "SPV_KHR_shader_atomic_counter_ops",
-  };
+  });
 }
 
 }  // namespace opt

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -128,6 +128,12 @@ class LocalAccessChainConvertPass : public Pass {
   // converted.
   bool ConvertLocalAccessChains(ir::Function* func);
 
+  // Initialize extensions whitelist
+  void InitExtensions();
+
+  // Return true if all extensions in this module are allowed by this pass.
+  bool AllExtensionsSupported() const;
+
   // Save next available id into |module|.
   inline void FinalizeNextId(ir::Module* module) {
     module->SetIdBound(next_id_);
@@ -155,6 +161,9 @@ class LocalAccessChainConvertPass : public Pass {
 
   // Cache of verified non-target vars
   std::unordered_set<uint32_t> seen_non_target_vars_;
+
+  // Extensions supported by this pass.
+  std::unordered_set<std::string> extensions_whitelist_;
 
   // Next unused ID
   uint32_t next_id_;

--- a/source/opt/local_single_block_elim_pass.cpp
+++ b/source/opt/local_single_block_elim_pass.cpp
@@ -357,7 +357,8 @@ Pass::Status LocalSingleBlockLoadStoreElimPass::Process(ir::Module* module) {
 }
 
 void LocalSingleBlockLoadStoreElimPass::InitExtensions() {
-  extensions_whitelist_ = {
+  extensions_whitelist_.clear();
+  extensions_whitelist_.insert({
     "SPV_AMD_shader_explicit_vertex_parameter",
     "SPV_AMD_shader_trinary_minmax",
     "SPV_AMD_gcn_shader",
@@ -381,7 +382,7 @@ void LocalSingleBlockLoadStoreElimPass::InitExtensions() {
     "SPV_AMD_gpu_shader_int16",
     "SPV_KHR_post_depth_coverage",
     "SPV_KHR_shader_atomic_counter_ops",
-  };
+  });
 }
 
 }  // namespace opt

--- a/source/opt/local_single_block_elim_pass.h
+++ b/source/opt/local_single_block_elim_pass.h
@@ -103,6 +103,12 @@ class LocalSingleBlockLoadStoreElimPass : public Pass {
     return next_id_++;
   }
 
+  // Initialize extensions whitelist
+  void InitExtensions();
+
+  // Return true if all extensions in this module are supported by this pass.
+  bool AllExtensionsSupported() const;
+
   void Initialize(ir::Module* module);
   Pass::Status ProcessImpl();
 
@@ -141,6 +147,9 @@ class LocalSingleBlockLoadStoreElimPass : public Pass {
   // for example, a load through an access chain. A variable is removed
   // from this set each time a new store of that variable is encountered.
   std::unordered_set<uint32_t> pinned_vars_;
+
+  // Extensions supported by this pass.
+  std::unordered_set<std::string> extensions_whitelist_;
 
   // Next unused ID
   uint32_t next_id_;

--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -434,14 +434,31 @@ void LocalSingleStoreElimPass::Initialize(ir::Module* module) {
 
   // Initialize next unused Id
   next_id_ = module_->id_bound();
+
+  // Initialize extension whitelist
+  InitExtensions();
 };
+
+bool LocalSingleStoreElimPass::AllExtensionsSupported() const {
+  // If any extension not in whitelist, return false
+  for (auto& ei : module_->extensions()) {
+    const char* extName = reinterpret_cast<const char*>(
+        &ei.GetInOperand(0).words[0]);
+    if (extensions_whitelist_.find(extName) == extensions_whitelist_.end())
+      return false;
+  }
+  return true;
+}
 
 Pass::Status LocalSingleStoreElimPass::ProcessImpl() {
   // Assumes logical addressing only
   if (module_->HasCapability(SpvCapabilityAddresses))
     return Status::SuccessWithoutChange;
+  // Do not process if any disallowed extensions are enabled
+  if (!AllExtensionsSupported())
+    return Status::SuccessWithoutChange;
+  // Process all entry point functions
   bool modified = false;
-  // Call Mem2Reg on all remaining functions.
   for (auto& e : module_->entry_points()) {
     ir::Function* fn =
         id2function_[e.GetSingleWordOperand(kSpvEntryPointFunctionId)];
@@ -462,6 +479,34 @@ LocalSingleStoreElimPass::LocalSingleStoreElimPass()
 Pass::Status LocalSingleStoreElimPass::Process(ir::Module* module) {
   Initialize(module);
   return ProcessImpl();
+}
+
+void LocalSingleStoreElimPass::InitExtensions() {
+  extensions_whitelist_ = {
+    "SPV_AMD_shader_explicit_vertex_parameter",
+    "SPV_AMD_shader_trinary_minmax",
+    "SPV_AMD_gcn_shader",
+    "SPV_KHR_shader_ballot",
+    "SPV_AMD_shader_ballot",
+    "SPV_AMD_gpu_shader_half_float",
+    "SPV_KHR_shader_draw_parameters",
+    "SPV_KHR_subgroup_vote",
+    "SPV_KHR_16bit_storage",
+    "SPV_KHR_device_group",
+    "SPV_KHR_multiview",
+    "SPV_NVX_multiview_per_view_attributes",
+    "SPV_NV_viewport_array2",
+    "SPV_NV_stereo_view_rendering",
+    "SPV_NV_sample_mask_override_coverage",
+    "SPV_NV_geometry_shader_passthrough",
+    "SPV_AMD_texture_gather_bias_lod",
+    "SPV_KHR_storage_buffer_storage_class",
+    // SPV_KHR_variable_pointers
+    //   Currently do not support extended pointer expressions
+    "SPV_AMD_gpu_shader_int16",
+    "SPV_KHR_post_depth_coverage",
+    "SPV_KHR_shader_atomic_counter_ops",
+  };
 }
 
 }  // namespace opt

--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -482,7 +482,8 @@ Pass::Status LocalSingleStoreElimPass::Process(ir::Module* module) {
 }
 
 void LocalSingleStoreElimPass::InitExtensions() {
-  extensions_whitelist_ = {
+  extensions_whitelist_.clear();
+  extensions_whitelist_.insert({
     "SPV_AMD_shader_explicit_vertex_parameter",
     "SPV_AMD_shader_trinary_minmax",
     "SPV_AMD_gcn_shader",
@@ -506,7 +507,7 @@ void LocalSingleStoreElimPass::InitExtensions() {
     "SPV_AMD_gpu_shader_int16",
     "SPV_KHR_post_depth_coverage",
     "SPV_KHR_shader_atomic_counter_ops",
-  };
+  });
 }
 
 }  // namespace opt

--- a/source/opt/local_single_store_elim_pass.h
+++ b/source/opt/local_single_store_elim_pass.h
@@ -135,6 +135,12 @@ class LocalSingleStoreElimPass : public Pass {
   // any resulting dead code.
   bool LocalSingleStoreElim(ir::Function* func);
 
+  // Initialize extensions whitelist
+  void InitExtensions();
+
+  // Return true if all extensions in this module are allowed by this pass.
+  bool AllExtensionsSupported() const;
+
   // Save next available id into |module|.
   inline void FinalizeNextId(ir::Module* module) {
     module->SetIdBound(next_id_);
@@ -207,6 +213,9 @@ class LocalSingleStoreElimPass : public Pass {
   // Immediate Dominator Map
   // If block has no idom it points to itself.
   std::unordered_map<ir::BasicBlock*, ir::BasicBlock*> idom_;
+
+  // Extensions supported by this pass.
+  std::unordered_set<std::string> extensions_whitelist_;
 
   // Next unused ID
   uint32_t next_id_;

--- a/source/opt/local_ssa_elim_pass.cpp
+++ b/source/opt/local_ssa_elim_pass.cpp
@@ -775,7 +775,8 @@ Pass::Status LocalMultiStoreElimPass::Process(ir::Module* module) {
 }
 
 void LocalMultiStoreElimPass::InitExtensions() {
-  extensions_whitelist_ = {
+  extensions_whitelist_.clear();
+  extensions_whitelist_.insert({
     "SPV_AMD_shader_explicit_vertex_parameter",
     "SPV_AMD_shader_trinary_minmax",
     "SPV_AMD_gcn_shader",
@@ -799,7 +800,7 @@ void LocalMultiStoreElimPass::InitExtensions() {
     "SPV_AMD_gpu_shader_int16",
     "SPV_KHR_post_depth_coverage",
     "SPV_KHR_shader_atomic_counter_ops",
-  };
+  });
 }
 
 }  // namespace opt

--- a/source/opt/local_ssa_elim_pass.cpp
+++ b/source/opt/local_ssa_elim_pass.cpp
@@ -718,18 +718,18 @@ void LocalMultiStoreElimPass::Initialize(ir::Module* module) {
 
   // Start new ids with next availablein module
   next_id_ = module_->id_bound();
+
+  // Initialize extension whitelist
+  InitExtensions();
 };
 
 bool LocalMultiStoreElimPass::AllExtensionsSupported() const {
-  // Currently disallows all extensions. This is just super conservative
-  // to allow this to go public and many can likely be allowed with little
-  // to no additional coding. One exception is SPV_KHR_variable_pointers
-  // which will require some additional work around HasLoads, AddStores
-  // and generally DCEInst.
-  // TODO(greg-lunarg): Enable more extensions.
+  // If any extension not in whitelist, return false
   for (auto& ei : module_->extensions()) {
-    (void) ei;
-    return false;
+    const char* extName = reinterpret_cast<const char*>(
+        &ei.GetInOperand(0).words[0]);
+    if (extensions_whitelist_.find(extName) == extensions_whitelist_.end())
+      return false;
   }
   return true;
 }
@@ -751,7 +751,7 @@ Pass::Status LocalMultiStoreElimPass::ProcessImpl() {
       return Status::SuccessWithoutChange;
   // Do not process if any disallowed extensions are enabled
   if (!AllExtensionsSupported())
-      return Status::SuccessWithoutChange;
+    return Status::SuccessWithoutChange;
   // Process functions
   bool modified = false;
   for (auto& e : module_->entry_points()) {
@@ -772,6 +772,34 @@ LocalMultiStoreElimPass::LocalMultiStoreElimPass()
 Pass::Status LocalMultiStoreElimPass::Process(ir::Module* module) {
   Initialize(module);
   return ProcessImpl();
+}
+
+void LocalMultiStoreElimPass::InitExtensions() {
+  extensions_whitelist_ = {
+    "SPV_AMD_shader_explicit_vertex_parameter",
+    "SPV_AMD_shader_trinary_minmax",
+    "SPV_AMD_gcn_shader",
+    "SPV_KHR_shader_ballot",
+    "SPV_AMD_shader_ballot",
+    "SPV_AMD_gpu_shader_half_float",
+    "SPV_KHR_shader_draw_parameters",
+    "SPV_KHR_subgroup_vote",
+    "SPV_KHR_16bit_storage",
+    "SPV_KHR_device_group",
+    "SPV_KHR_multiview",
+    "SPV_NVX_multiview_per_view_attributes",
+    "SPV_NV_viewport_array2",
+    "SPV_NV_stereo_view_rendering",
+    "SPV_NV_sample_mask_override_coverage",
+    "SPV_NV_geometry_shader_passthrough",
+    "SPV_AMD_texture_gather_bias_lod",
+    "SPV_KHR_storage_buffer_storage_class",
+    // SPV_KHR_variable_pointers
+    //   Currently do not support extended pointer expressions
+    "SPV_AMD_gpu_shader_int16",
+    "SPV_KHR_post_depth_coverage",
+    "SPV_KHR_shader_atomic_counter_ops",
+  };
 }
 
 }  // namespace opt

--- a/source/opt/local_ssa_elim_pass.h
+++ b/source/opt/local_ssa_elim_pass.h
@@ -172,9 +172,10 @@ class LocalMultiStoreElimPass : public Pass {
   // which corresponds to that variable in the predecessor map.
   void PatchPhis(uint32_t header_id, uint32_t back_id);
 
+  // Initialize extensions whitelist
+  void InitExtensions();
+
   // Return true if all extensions in this module are allowed by this pass.
-  // Currently, no extensions are supported.
-  // TODO(greg-lunarg): Add extensions to supported list.
   bool AllExtensionsSupported() const;
 
   // Remove remaining loads and stores of function scope variables only
@@ -247,6 +248,9 @@ class LocalMultiStoreElimPass : public Pass {
   // Extra block whose successors are all blocks with no predecessors
   // in function.
   ir::BasicBlock pseudo_entry_block_;
+
+  // Extensions supported by this pass.
+  std::unordered_set<std::string> extensions_whitelist_;
 
   // Next unused ID
   uint32_t next_id_;


### PR DESCRIPTION
Because extensions change validation rules it is prudent to keep white-lists
of approved extensions for each pass.

Currently only SPV_KHR_variable_pointers is disallowed in passes which
do pointer analysis. Positive and negative tests of the general extensions
white-list mechanism were added to aggressive_dce but cover all passes.