### PR TITLE
Added C++ code generation to spirv-stats

### DIFF
--- a/tools/stats/stats_analyzer.h
+++ b/tools/stats/stats_analyzer.h
@@ -36,6 +36,30 @@ class StatsAnalyzer {
   // level.
   void WriteOpcodeMarkov(std::ostream& out);
 
+  // Writes C++ code containing a function returning opcode histogram.
+  void WriteCodegenOpcodeHist(std::ostream& out);
+
+  // Writes C++ code containing a function returning opcode_and_num_operands
+  // histogram.
+  void WriteCodegenOpcodeAndNumOperandsHist(std::ostream& out);
+
+  // Writes C++ code containing a function returning a map of Huffman codecs
+  // for opcode_and_num_operands. Each Huffman codec is created for a specific
+  // previous opcode.
+  // TODO(atgoo@github.com) Write code which would contain pregenerated Huffman
+  // codecs, instead of code which would generate them every time.
+  void WriteCodegenOpcodeAndNumOperandsMarkovHuffmanCodecs(std::ostream& out);
+
+  // Writes C++ code containing a function returning a map of Huffman codecs
+  // for literal strings. Each Huffman codec is created for a specific opcode.
+  // I.e. OpExtension and OpExtInstImport would use different codecs.
+  void WriteCodegenLiteralStringHuffmanCodecs(std::ostream& out);
+
+  // Writes C++ code containing a function returning a map of Huffman codecs
+  // for single-word non-id operands. Each Huffman codec is created for a
+  // specific operand slot (opcode and operand number).
+  void WriteCodegenNonIdWordHuffmanCodecs(std::ostream& out);
+
  private:
   const libspirv::SpirvStats& stats_;
 


### PR DESCRIPTION
The tool can now generate C++ code returning some of the histograms and
Huffman codecs generated from those histograms.