### PR TITLE
AccessChainConvert: Add HasOnlySupportedRefs()

### DIFF
--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -41,6 +41,10 @@ class LocalAccessChainConvertPass : public MemPass {
   Status Process(ir::Module*) override;
 
  private:
+  // Return true if all refs through |ptrId| are only loads or stores and
+  // cache ptrId in supported_ref_ptrs_.
+  bool HasOnlySupportedRefs(uint32_t ptrId);
+
   // Search |func| and cache function scope variables of target type that are
   // not accessed with non-constant-index access chains. Also cache non-target
   // variables.
@@ -117,6 +121,10 @@ class LocalAccessChainConvertPass : public MemPass {
 
   // Map from function's result id to function
   std::unordered_map<uint32_t, ir::Function*> id2function_;
+
+  // Variables with only supported references, ie. loads and stores using
+  // variable directly or through non-ptr access chains.
+  std::unordered_set<uint32_t> supported_ref_ptrs_;
 
   // Extensions supported by this pass.
   std::unordered_set<std::string> extensions_whitelist_;

--- a/source/opt/local_single_block_elim_pass.cpp
+++ b/source/opt/local_single_block_elim_pass.cpp
@@ -37,7 +37,8 @@ bool LocalSingleBlockLoadStoreElimPass::HasOnlySupportedRefs(uint32_t ptrId) {
     SpvOp op = u.inst->opcode();
     if (IsNonPtrAccessChain(op) || op == SpvOpCopyObject) {
       if (!HasOnlySupportedRefs(u.inst->result_id())) return false;
-    } else if (op != SpvOpStore && op != SpvOpLoad && op != SpvOpName)
+    } else if (op != SpvOpStore && op != SpvOpLoad && op != SpvOpName &&
+               !IsNonTypeDecorate(op))
       return false;
   }
   supported_ref_ptrs_.insert(ptrId);

--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -42,7 +42,8 @@ bool LocalSingleStoreElimPass::HasOnlySupportedRefs(uint32_t ptrId) {
     SpvOp op = u.inst->opcode();
     if (IsNonPtrAccessChain(op) || op == SpvOpCopyObject) {
       if (!HasOnlySupportedRefs(u.inst->result_id())) return false;
-    } else if (op != SpvOpStore && op != SpvOpLoad && op != SpvOpName)
+    } else if (op != SpvOpStore && op != SpvOpLoad && op != SpvOpName &&
+               !IsNonTypeDecorate(op))
       return false;
   }
   supported_ref_ptrs_.insert(ptrId);

--- a/source/opt/local_ssa_elim_pass.cpp
+++ b/source/opt/local_ssa_elim_pass.cpp
@@ -42,7 +42,7 @@ bool LocalMultiStoreElimPass::HasOnlySupportedRefs(uint32_t varId) {
   for (auto u : *uses) {
     const SpvOp op = u.inst->opcode();
     if (op != SpvOpStore && op != SpvOpLoad && op != SpvOpName &&
-        !IsDecorate(op))
+        !IsNonTypeDecorate(op))
       return false;
   }
   supported_ref_vars_.insert(varId);

--- a/source/opt/local_ssa_elim_pass.h
+++ b/source/opt/local_ssa_elim_pass.h
@@ -136,11 +136,6 @@ class LocalMultiStoreElimPass : public MemPass {
   // the runtime and effectiveness of this function.
   bool EliminateMultiStoreLocal(ir::Function* func);
 
-  // Return true if |op| is decorate.
-  inline bool IsDecorate(uint32_t op) const {
-    return (op == SpvOpDecorate || op == SpvOpDecorateId);
-  }
-
   // Save next available id into |module|.
   inline void FinalizeNextId(ir::Module* module) {
     module->SetIdBound(next_id_);

--- a/source/opt/mem_pass.cpp
+++ b/source/opt/mem_pass.cpp
@@ -138,7 +138,7 @@ bool MemPass::HasOnlyNamesAndDecorates(uint32_t id) const {
     return false;
   for (auto u : *uses) {
     const SpvOp op = u.inst->opcode();
-    if (op != SpvOpName && !IsDecorate(op))
+    if (op != SpvOpName && !IsNonTypeDecorate(op))
       return false;
   }
   return true;
@@ -155,7 +155,7 @@ void MemPass::KillNamesAndDecorates(uint32_t id) {
   std::list<ir::Instruction*> killList;
   for (auto u : *uses) {
     const SpvOp op = u.inst->opcode();
-    if (op == SpvOpName || IsDecorate(op))
+    if (op == SpvOpName || IsNonTypeDecorate(op))
       killList.push_back(u.inst);
   }
   for (auto kip : killList)

--- a/source/opt/mem_pass.h
+++ b/source/opt/mem_pass.h
@@ -101,7 +101,7 @@ class MemPass : public Pass {
   void ReplaceAndDeleteLoad(ir::Instruction* loadInst, uint32_t replId);
 
   // Return true if |op| is supported decorate.
-  inline bool IsDecorate(uint32_t op) const {
+  inline bool IsNonTypeDecorate(uint32_t op) const {
     return (op == SpvOpDecorate || op == SpvOpDecorateId);
   }
 


### PR DESCRIPTION
This avoids conversion on variables which will not ultimately be optimized.
Also removed an obsolete restriction from FindTargetVars(). Also added
decorates to supported refs (eg. RelaxedPrecision). Also fixed name to
IsNonTypeDecorate().