### PR TITLE
ADCE: Add support for function calls

### DIFF
--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -376,18 +376,6 @@ Optimizer::PassToken CreateCommonUniformElimPass();
 // eliminated with standard dead code elimination.
 Optimizer::PassToken CreateAggressiveDCEPass();
 
-// Creates a pass to consolidate uniform references.
-// For each entry point function in the module, first change all constant index
-// access chain loads into equivalent composite extracts. Then consolidate 
-// identical uniform loads into one uniform load. Finally, consolidate
-// identical uniform extracts into one uniform extract. This may require
-// moving a load or extract to a point which dominates all uses.
-//
-// This pass requires a module to have structured control flow ie shader
-// capability. It also requires logical addressing ie Addresses capability
-// is not enabled. It also currently does not support any extensions.
-Optimizer::PassToken CreateCommonUniformElimPass();
-
 // Creates a compact ids pass.
 // The pass remaps result ids to a compact and gapless range starting from %1.
 Optimizer::PassToken CreateCompactIdsPass();

--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -54,7 +54,7 @@ void AggressiveDCEPass::AddStores(uint32_t ptrId) {
       } break;
       case SpvOpLoad:
         break;
-      // Assume it stores eg frexp, modf
+      // Assume it stores eg frexp, modf, function call
       case SpvOpStore:
       default: {
         if (live_insts_.find(u.inst) == live_insts_.end())
@@ -90,11 +90,27 @@ bool AggressiveDCEPass::AllExtensionsSupported() const {
   return true;
 }
 
-void AggressiveDCEPass::KillInstIfTargetDead(ir::Instruction* inst) {
+bool AggressiveDCEPass::KillInstIfTargetDead(ir::Instruction* inst) {
   const uint32_t tId = inst->GetSingleWordInOperand(0);
   const ir::Instruction* tInst = def_use_mgr_->GetDef(tId);
-  if (dead_insts_.find(tInst) != dead_insts_.end())
+  if (dead_insts_.find(tInst) != dead_insts_.end()) {
     def_use_mgr_->KillInst(inst);
+    return true;
+  }
+  return false;
+}
+
+void AggressiveDCEPass::ProcessLoad(uint32_t varId) {
+  // Only process locals
+  if (!IsLocalVar(varId))
+    return;
+  // Return if already processed
+  if (live_local_vars_.find(varId) != live_local_vars_.end()) 
+    return;
+  // Mark all stores to varId as live
+  AddStores(varId);
+  // Cache varId as processed
+  live_local_vars_.insert(varId);
 }
 
 bool AggressiveDCEPass::AggressiveDCE(ir::Function* func) {
@@ -102,8 +118,6 @@ bool AggressiveDCEPass::AggressiveDCE(ir::Function* func) {
   // Add all control flow and instructions with external side effects 
   // to worklist
   // TODO(greg-lunarg): Handle Frexp, Modf more optimally
-  // TODO(greg-lunarg): Handle FunctionCall more optimally
-  // TODO(greg-lunarg): Handle CopyMemory more optimally
   for (auto& blk : *func) {
     for (auto& inst : blk) {
       uint32_t op = inst.opcode();
@@ -121,12 +135,9 @@ bool AggressiveDCEPass::AggressiveDCE(ir::Function* func) {
           if (!IsCombinatorExt(&inst))
             worklist_.push(&inst);
         } break;
-        case SpvOpCopyMemory:
-        case SpvOpFunctionCall: {
-          return false;
-        } break;
         default: {
           // eg. control flow, function call, atomics
+          // TODO(greg-lunarg): function calls live only if write to non-local
           if (!IsCombinator(op))
             worklist_.push(&inst);
         } break;
@@ -154,12 +165,17 @@ bool AggressiveDCEPass::AggressiveDCE(ir::Function* func) {
     if (liveInst->opcode() == SpvOpLoad) {
       uint32_t varId;
       (void) GetPtr(liveInst, &varId);
-      if (IsLocalVar(varId)) {
-        if (live_local_vars_.find(varId) == live_local_vars_.end()) {
-          AddStores(varId);
-          live_local_vars_.insert(varId);
-        }
-      }
+      ProcessLoad(varId);
+    }
+    // If function call, treat as if it loads from all pointer arguments
+    else if (liveInst->opcode() == SpvOpFunctionCall) {
+      liveInst->ForEachInId([this](const uint32_t* iid) {
+        // Skip non-ptr args
+        if (!IsPtr(*iid)) return;
+        uint32_t varId;
+        (void) GetPtr(*iid, &varId);
+        ProcessLoad(varId);
+      });
     }
     worklist_.pop();
   }
@@ -177,14 +193,14 @@ bool AggressiveDCEPass::AggressiveDCE(ir::Function* func) {
   for (auto& di : module_->debugs()) {
     if (di.opcode() != SpvOpName)
       continue;
-    KillInstIfTargetDead(&di);
-    modified = true;
+    if (KillInstIfTargetDead(&di))
+      modified = true;
   }
   for (auto& ai : module_->annotations()) {
     if (ai.opcode() != SpvOpDecorate && ai.opcode() != SpvOpDecorateId)
       continue;
-    KillInstIfTargetDead(&ai);
-    modified = true;
+    if (KillInstIfTargetDead(&ai))
+      modified = true;
   }
   // Kill dead instructions
   for (auto& blk : *func) {

--- a/source/opt/aggressive_dead_code_elim_pass.h
+++ b/source/opt/aggressive_dead_code_elim_pass.h
@@ -72,8 +72,12 @@ class AggressiveDCEPass : public MemPass {
   // Return true if all extensions in this module are supported by this pass.
   bool AllExtensionsSupported() const;
 
-  // Kill debug or annotation |inst| if target operand is dead.
-  void KillInstIfTargetDead(ir::Instruction* inst);
+  // Kill debug or annotation |inst| if target operand is dead. Return true
+  // if inst killed.
+  bool KillInstIfTargetDead(ir::Instruction* inst);
+
+  // If |varId| is local, mark all stores of varId as live.
+  void ProcessLoad(uint32_t varId);
 
   // For function |func|, mark all Stores to non-function-scope variables
   // and block terminating instructions as live. Recursively mark the values

--- a/source/opt/mem_pass.h
+++ b/source/opt/mem_pass.h
@@ -53,6 +53,14 @@ class MemPass : public Pass {
   // Returns true if |opcode| is a non-ptr access chain op
   bool IsNonPtrAccessChain(const SpvOp opcode) const;
 
+  // Given the id |ptrId|, return true if the top-most non-CopyObj is
+  // a pointer. 
+  bool IsPtr(uint32_t ptrId);
+
+  // Given the id of a pointer |ptrId|, return the top-most non-CopyObj.
+  // Also return the base variable's id in |varId|.
+  ir::Instruction* GetPtr(uint32_t ptrId, uint32_t* varId);
+
   // Given a load or store |ip|, return the pointer instruction.
   // Also return the base variable's id in |varId|.
   ir::Instruction* GetPtr(ir::Instruction* ip, uint32_t* varId);


### PR DESCRIPTION
ADCE will now generate correct code in the presence of function calls.
This is needed for opaque type optimization needed by glslang. Currently
all function calls are marked as live. TODO: mark calls live only if they
write a non-local.

Also remove duplicate declaration from optimizer.hpp