### PR TITLE
Inliner: callee can have early return that isn't multi-return

### DIFF
--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -186,8 +186,8 @@ class InlinePass : public Pass {
   // Map from block's label id to block.
   std::unordered_map<uint32_t, ir::BasicBlock*> id2block_;
 
-  // Set of ids of functions with early returns
-  std::set<uint32_t> early_return_;
+  // Set of ids of functions with multiple returns.
+  std::set<uint32_t> multi_return_funcs_;
 
   // Set of ids of functions with no returns in loop
   std::set<uint32_t> no_return_in_loop_;


### PR DESCRIPTION
Avoid generating an invalid OpLabel.
Create the continue target for the single-trip loop only if
you actually created the header for the single-trip loop.

Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/755