### PR TITLE
Opt: Create InlineOpaquePass

### DIFF
--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -213,7 +213,8 @@ Optimizer::PassToken CreateInlineExhaustivePass();
 // Creates an opaque inline pass.
 // An opaque inline pass inlines all function calls in all functions in all
 // entry point call trees where the called function contains an opaque type
-// in either its parameters or return value. The intent is to enable, albeit
+// in either its parameter types or return type. An opaque type is currently
+// defined as Image, Sampler or SampledImage. The intent is to enable, albeit
 // through brute force, analysis and optimization across these function calls
 // by subsequent passes in order to remove the storing of opaque types which is // not legal in Vulkan. Functions that are not in the call tree of an entry
 // point are not changed.

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -201,14 +201,23 @@ Optimizer::PassToken CreateEliminateDeadConstantPass();
 // these is left for future improvements. 
 Optimizer::PassToken CreateBlockMergePass();
 
-// Creates an inline pass.
-// An inline pass exhaustively inlines all function calls in all functions
-// designated as an entry point. The intent is to enable, albeit through
-// brute force, analysis and optimization across function calls by subsequent
-// passes. As the inlining is exhaustive, there is no attempt to optimize for
-// size or runtime performance. Functions that are not designated as entry
-// points are not changed.
+// Creates an exhaustive inline pass.
+// An inline pass attempts to exhaustively inline all function calls in
+// all functions in an entry point call tree. The intent is to enable,
+// albeit through brute force, analysis and optimization across function
+// calls by subsequent optimization passes. As the inlining is exhaustive,
+// there is no attempt to optimize for size or runtime performance. Functions
+// that are not in the call tree of an entry point are not changed.
 Optimizer::PassToken CreateInlineExhaustivePass();
+  
+// Creates an opaque inline pass.
+// An inline pass inlines all function calls in all functions in an entry
+// point call tree. The intent is to enable, albeit through brute force,
+// analysis and optimization across these function calls by subsequent
+// passes in order to remove the storing of opaque types which is not
+// legal in Vulkan. Functions that are not in the call tree of an entry
+// point are not changed.
+Optimizer::PassToken CreateInlineOpaquePass();
   
 // Creates a single-block local variable load/store elimination pass.
 // For every entry point function, do single block memory optimization of 
@@ -228,6 +237,8 @@ Optimizer::PassToken CreateInlineExhaustivePass();
 // This pass is most effective if preceeded by Inlining and 
 // LocalAccessChainConvert. This pass will reduce the work needed to be done
 // by LocalSingleStoreElim and LocalMultiStoreElim.
+//
+// Only functions in the call tree of an entry point are processed.
 Optimizer::PassToken CreateLocalSingleBlockLoadStoreElimPass();
 
 // Create dead branch elimination pass.

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -202,8 +202,8 @@ Optimizer::PassToken CreateEliminateDeadConstantPass();
 Optimizer::PassToken CreateBlockMergePass();
 
 // Creates an exhaustive inline pass.
-// An inline pass attempts to exhaustively inline all function calls in
-// all functions in an entry point call tree. The intent is to enable,
+// An exhaustive inline pass attempts to exhaustively inline all function
+// calls in all functions in an entry point call tree. The intent is to enable,
 // albeit through brute force, analysis and optimization across function
 // calls by subsequent optimization passes. As the inlining is exhaustive,
 // there is no attempt to optimize for size or runtime performance. Functions
@@ -211,11 +211,11 @@ Optimizer::PassToken CreateBlockMergePass();
 Optimizer::PassToken CreateInlineExhaustivePass();
   
 // Creates an opaque inline pass.
-// An inline pass inlines all function calls in all functions in an entry
-// point call tree. The intent is to enable, albeit through brute force,
-// analysis and optimization across these function calls by subsequent
-// passes in order to remove the storing of opaque types which is not
-// legal in Vulkan. Functions that are not in the call tree of an entry
+// An opaque inline pass inlines all function calls in all functions in all
+// entry point call trees where the called function contains an opaque type
+// in either its parameters or return value. The intent is to enable, albeit
+// through brute force, analysis and optimization across these function calls
+// by subsequent passes in order to remove the storing of opaque types which is // not legal in Vulkan. Functions that are not in the call tree of an entry
 // point are not changed.
 Optimizer::PassToken CreateInlineOpaquePass();
   

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(SPIRV-Tools-opt
   freeze_spec_constant_value_pass.h
   inline_pass.h
   inline_exhaustive_pass.h
+  inline_opaque_pass.h
   insert_extract_elim.h
   instruction.h
   ir_loader.h
@@ -64,6 +65,7 @@ add_library(SPIRV-Tools-opt
   freeze_spec_constant_value_pass.cpp
   inline_pass.cpp
   inline_exhaustive_pass.cpp
+  inline_opaque_pass.cpp
   insert_extract_elim.cpp
   instruction.cpp
   ir_loader.cpp

--- a/source/opt/inline_opaque_pass.cpp
+++ b/source/opt/inline_opaque_pass.cpp
@@ -38,6 +38,7 @@ bool InlineOpaquePass::IsOpaqueType(uint32_t typeId) {
     default:
       break;
   }
+  // TODO(greg-lunarg): Handle arrays containing opaque type
   if (typeInst->opcode() != SpvOpTypeStruct)
     return false;
   // Return true if any member is opaque

--- a/source/opt/inline_opaque_pass.cpp
+++ b/source/opt/inline_opaque_pass.cpp
@@ -1,0 +1,121 @@
+// Copyright (c) 2017 The Khronos Group Inc.
+// Copyright (c) 2017 Valve Corporation
+// Copyright (c) 2017 LunarG Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "inline_opaque_pass.h"
+
+namespace spvtools {
+namespace opt {
+
+namespace {
+
+  const uint32_t kTypePointerTypeIdInIdx = 1;
+
+} // anonymous namespace
+
+bool InlineOpaquePass::IsOpaqueType(uint32_t typeId) {
+  const ir::Instruction* typeInst = def_use_mgr_->GetDef(typeId);
+  switch (typeInst->opcode()) {
+    case SpvOpTypeSampler:
+    case SpvOpTypeImage:
+    case SpvOpTypeSampledImage:
+      return true;
+    case SpvOpTypePointer:
+      return IsOpaqueType(typeInst->GetSingleWordInOperand(
+          kTypePointerTypeIdInIdx));
+    default:
+      break;
+  }
+  if (typeInst->opcode() != SpvOpTypeStruct)
+    return false;
+  // Return true if any member is opaque
+  int ocnt = 0;
+  typeInst->ForEachInId([&ocnt,this](const uint32_t* tid) {
+    if (ocnt == 0 && IsOpaqueType(*tid)) ++ocnt;
+  });
+  return ocnt > 0;
+}
+
+bool InlineOpaquePass::HasOpaqueArgsOrReturn(const ir::Instruction* callInst) {
+  // Check return type
+  if (IsOpaqueType(callInst->type_id()))
+    return true;
+  // Check args
+  int icnt = 0;
+  int ocnt = 0;
+  callInst->ForEachInId([&icnt,&ocnt,this](const uint32_t *iid) {
+    if (icnt > 0) {
+      const ir::Instruction* argInst = def_use_mgr_->GetDef(*iid);
+      if (IsOpaqueType(argInst->type_id()))
+        ++ocnt;
+    }
+    ++icnt;
+  });
+  return ocnt > 0;
+}
+
+bool InlineOpaquePass::InlineOpaque(ir::Function* func) {
+  bool modified = false;
+  // Using block iterators here because of block erasures and insertions.
+  for (auto bi = func->begin(); bi != func->end(); ++bi) {
+    for (auto ii = bi->begin(); ii != bi->end();) {
+      if (IsInlinableFunctionCall(&*ii) && HasOpaqueArgsOrReturn(&*ii)) {
+        // Inline call.
+        std::vector<std::unique_ptr<ir::BasicBlock>> newBlocks;
+        std::vector<std::unique_ptr<ir::Instruction>> newVars;
+        GenInlineCode(&newBlocks, &newVars, ii, bi);
+        // If call block is replaced with more than one block, point
+        // succeeding phis at new last block.
+        if (newBlocks.size() > 1)
+          UpdateSucceedingPhis(newBlocks);
+        // Replace old calling block with new block(s).
+        bi = bi.Erase();
+        bi = bi.InsertBefore(&newBlocks);
+        // Insert new function variables.
+        if (newVars.size() > 0) func->begin()->begin().InsertBefore(&newVars);
+        // Restart inlining at beginning of calling block.
+        ii = bi->begin();
+        modified = true;
+      } else {
+        ++ii;
+      }
+    }
+  }
+  return modified;
+}
+
+void InlineOpaquePass::Initialize(ir::Module* module) {
+  InitializeInline(module);
+};
+
+Pass::Status InlineOpaquePass::ProcessImpl() {
+  // Do opaque inlining on each function in entry point call tree
+  ProcessFunction pfn = [this](ir::Function* fp) {
+    return InlineOpaque(fp);
+  };
+  bool modified = ProcessEntryPointCallTree(pfn, module_);
+  FinalizeNextId(module_);
+  return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
+}
+
+InlineOpaquePass::InlineOpaquePass() {}
+
+Pass::Status InlineOpaquePass::Process(ir::Module* module) {
+  Initialize(module);
+  return ProcessImpl();
+}
+
+}  // namespace opt
+}  // namespace spvtools

--- a/source/opt/inline_opaque_pass.h
+++ b/source/opt/inline_opaque_pass.h
@@ -37,7 +37,7 @@ class InlineOpaquePass : public InlinePass {
   InlineOpaquePass();
   Status Process(ir::Module*) override;
 
-  const char* name() const override { return "inline-exhaustive"; }
+  const char* name() const override { return "inline-opaque"; }
 
  private:
   // Return true if |typeId| is or contains opaque type

--- a/source/opt/inline_opaque_pass.h
+++ b/source/opt/inline_opaque_pass.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2017 The Khronos Group Inc.
+// Copyright (c) 2017 Valve Corporation
+// Copyright (c) 2017 LunarG Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBSPIRV_OPT_INLINE_OPAQUE_PASS_H_
+#define LIBSPIRV_OPT_INLINE_OPAQUE_PASS_H_
+
+#include <algorithm>
+#include <list>
+#include <memory>
+#include <vector>
+#include <unordered_map>
+
+#include "def_use_manager.h"
+#include "module.h"
+#include "inline_pass.h"
+
+namespace spvtools {
+namespace opt {
+
+// See optimizer.hpp for documentation.
+class InlineOpaquePass : public InlinePass {
+
+ public:
+  InlineOpaquePass();
+  Status Process(ir::Module*) override;
+
+  const char* name() const override { return "inline-exhaustive"; }
+
+ private:
+  // Return true if |typeId| is or contains opaque type
+  bool IsOpaqueType(uint32_t typeId);
+
+  // Return true if function call |callInst| has opaque argument or return type
+  bool HasOpaqueArgsOrReturn(const ir::Instruction* callInst);
+
+  // Inline all function calls in |func| that have opaque params or return
+  // type. Inline similarly all code that is inlined into func. Return true
+  // if func is modified.
+  bool InlineOpaque(ir::Function* func);
+
+  void Initialize(ir::Module* module);
+  Pass::Status ProcessImpl();
+};
+
+}  // namespace opt
+}  // namespace spvtools
+
+#endif  // LIBSPIRV_OPT_INLINE_OPAQUE_PASS_H_

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -172,6 +172,7 @@ class InlinePass : public Pass {
   void UpdateSucceedingPhis(
       std::vector<std::unique_ptr<ir::BasicBlock>>& new_blocks);
 
+  // Initialize state for optimization of |module|
   void InitializeInline(ir::Module* module);
 
   // Module being processed by this pass

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -142,6 +142,11 @@ Optimizer::PassToken CreateInlineExhaustivePass() {
       MakeUnique<opt::InlineExhaustivePass>());
 }
   
+Optimizer::PassToken CreateInlineOpaquePass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::InlineOpaquePass>());
+}
+  
 Optimizer::PassToken CreateLocalAccessChainConvertPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::LocalAccessChainConvertPass>());

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -25,6 +25,7 @@
 #include "flatten_decoration_pass.h"
 #include "fold_spec_constant_op_and_composite_pass.h"
 #include "inline_exhaustive_pass.h"
+#include "inline_opaque_pass.h"
 #include "insert_extract_elim.h"
 #include "local_single_block_elim_pass.h"
 #include "local_single_store_elim_pass.h"

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -63,6 +63,11 @@ add_spvtools_unittest(TARGET pass_inline
   LIBS SPIRV-Tools-opt
 )
 
+add_spvtools_unittest(TARGET pass_inline_opaque
+  SRCS inline_opaque_test.cpp pass_utils.cpp
+  LIBS SPIRV-Tools-opt
+)
+
 add_spvtools_unittest(TARGET pass_insert_extract_elim
   SRCS insert_extract_elim_test.cpp pass_utils.cpp
   LIBS SPIRV-Tools-opt

--- a/test/opt/inline_opaque_test.cpp
+++ b/test/opt/inline_opaque_test.cpp
@@ -1,0 +1,412 @@
+// Copyright (c) 2017 Valve Corporation
+// Copyright (c) 2017 LunarG Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "pass_fixture.h"
+#include "pass_utils.h"
+
+namespace {
+
+using namespace spvtools;
+
+using InlineOpaqueTest = PassTest<::testing::Test>;
+
+TEST_F(InlineOpaqueTest, InlineOpaqueArg) {
+  // Function with opaque argument is inlined.
+  // TODO(greg-lunarg): Add HLSL code
+
+  const std::string predefs =
+      R"(OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %outColor %texCoords
+OpExecutionMode %main OriginUpperLeft
+OpSource GLSL 140
+OpName %main "main"
+OpName %S_t "S_t"
+OpMemberName %S_t 0 "v0"
+OpMemberName %S_t 1 "v1"
+OpMemberName %S_t 2 "smp"
+OpName %foo_struct_S_t_vf2_vf21_ "foo(struct-S_t-vf2-vf21;"
+OpName %s "s"
+OpName %outColor "outColor"
+OpName %sampler15 "sampler15"
+OpName %s0 "s0"
+OpName %texCoords "texCoords"
+OpName %param "param"
+OpDecorate %sampler15 DescriptorSet 0
+%void = OpTypeVoid
+%12 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%v2float = OpTypeVector %float 2
+%v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%outColor = OpVariable %_ptr_Output_v4float Output
+%17 = OpTypeImage %float 2D 0 0 0 1 Unknown
+%18 = OpTypeSampledImage %17
+%S_t = OpTypeStruct %v2float %v2float %18
+%_ptr_Function_S_t = OpTypePointer Function %S_t
+%20 = OpTypeFunction %void %_ptr_Function_S_t
+%_ptr_UniformConstant_18 = OpTypePointer UniformConstant %18
+%_ptr_Function_18 = OpTypePointer Function %18
+%sampler15 = OpVariable %_ptr_UniformConstant_18 UniformConstant
+%int = OpTypeInt 32 1
+%int_0 = OpConstant %int 0
+%int_2 = OpConstant %int 2
+%_ptr_Function_v2float = OpTypePointer Function %v2float
+%_ptr_Input_v2float = OpTypePointer Input %v2float
+%texCoords = OpVariable %_ptr_Input_v2float Input
+)";
+
+  const std::string before =
+      R"(%main = OpFunction %void None %12
+%28 = OpLabel
+%s0 = OpVariable %_ptr_Function_S_t Function 
+%param = OpVariable %_ptr_Function_S_t Function
+%29 = OpLoad %v2float %texCoords
+%30 = OpAccessChain %_ptr_Function_v2float %s0 %int_0
+OpStore %30 %29
+%31 = OpLoad %18 %sampler15
+%32 = OpAccessChain %_ptr_Function_18 %s0 %int_2
+OpStore %32 %31
+%33 = OpLoad %S_t %s0 
+OpStore %param %33
+%34 = OpFunctionCall %void %foo_struct_S_t_vf2_vf21_ %param
+OpReturn
+OpFunctionEnd
+)";
+
+  const std::string after =
+      R"(%main = OpFunction %void None %12
+%28 = OpLabel
+%s0 = OpVariable %_ptr_Function_S_t Function
+%param = OpVariable %_ptr_Function_S_t Function
+%29 = OpLoad %v2float %texCoords
+%30 = OpAccessChain %_ptr_Function_v2float %s0 %int_0
+OpStore %30 %29
+%31 = OpLoad %18 %sampler15
+%32 = OpAccessChain %_ptr_Function_18 %s0 %int_2
+OpStore %32 %31
+%33 = OpLoad %S_t %s0
+OpStore %param %33
+%41 = OpAccessChain %_ptr_Function_18 %param %int_2
+%42 = OpLoad %18 %41
+%43 = OpAccessChain %_ptr_Function_v2float %param %int_0
+%44 = OpLoad %v2float %43
+%45 = OpImageSampleImplicitLod %v4float %42 %44
+OpStore %outColor %45
+OpReturn
+OpFunctionEnd
+)";
+
+  const std::string post_defs =
+      R"(%foo_struct_S_t_vf2_vf21_ = OpFunction %void None %20
+%s = OpFunctionParameter %_ptr_Function_S_t
+%35 = OpLabel
+%36 = OpAccessChain %_ptr_Function_18 %s %int_2
+%37 = OpLoad %18 %36
+%38 = OpAccessChain %_ptr_Function_v2float %s %int_0
+%39 = OpLoad %v2float %38
+%40 = OpImageSampleImplicitLod %v4float %37 %39
+OpStore %outColor %40
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndCheck<opt::InlineOpaquePass>(
+      predefs + before + post_defs,
+      predefs + after + post_defs, true, true);
+}
+
+TEST_F(InlineOpaqueTest, InlineOpaqueReturn) {
+  // Function with opaque return value is inlined.
+  // TODO(greg-lunarg): Add HLSL code
+
+  const std::string predefs =
+      R"(OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %texCoords %outColor
+OpExecutionMode %main OriginUpperLeft
+OpSource GLSL 140
+OpName %main "main"
+OpName %foo_ "foo("
+OpName %texCoords "texCoords"
+OpName %outColor "outColor"
+OpName %sampler15 "sampler15"
+OpName %sampler16 "sampler16"
+OpDecorate %sampler15 DescriptorSet 0
+OpDecorate %sampler16 DescriptorSet 0
+%void = OpTypeVoid
+%9 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%v2float = OpTypeVector %float 2
+%bool = OpTypeBool
+%false = OpConstantFalse %bool
+%_ptr_Input_v2float = OpTypePointer Input %v2float
+%texCoords = OpVariable %_ptr_Input_v2float Input
+%float_0 = OpConstant %float 0
+%16 = OpConstantComposite %v2float %float_0 %float_0
+%v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%outColor = OpVariable %_ptr_Output_v4float Output
+%19 = OpTypeImage %float 2D 0 0 0 1 Unknown
+%20 = OpTypeSampledImage %19
+%21 = OpTypeFunction %20
+%_ptr_UniformConstant_20 = OpTypePointer UniformConstant %20
+%_ptr_Function_20 = OpTypePointer Function %20
+%sampler15 = OpVariable %_ptr_UniformConstant_20 UniformConstant
+%sampler16 = OpVariable %_ptr_UniformConstant_20 UniformConstant
+)";
+
+  const std::string before =
+      R"(%main = OpFunction %void None %9
+%24 = OpLabel
+%25 = OpVariable %_ptr_Function_20 Function 
+%26 = OpFunctionCall %20 %foo_
+OpStore %25 %26
+%27 = OpLoad %20 %25
+%28 = OpLoad %v2float %texCoords
+%29 = OpImageSampleImplicitLod %v4float %27 %28
+OpStore %outColor %29
+OpReturn
+OpFunctionEnd
+)";
+
+  const std::string after =
+      R"(%main = OpFunction %void None %9
+%24 = OpLabel
+%34 = OpVariable %_ptr_Function_20 Function
+%35 = OpVariable %_ptr_Function_20 Function
+%25 = OpVariable %_ptr_Function_20 Function
+%36 = OpLoad %20 %sampler16
+OpStore %34 %36
+%37 = OpLoad %20 %34
+OpStore %35 %37
+%26 = OpLoad %20 %35
+OpStore %25 %26
+%27 = OpLoad %20 %25
+%28 = OpLoad %v2float %texCoords
+%29 = OpImageSampleImplicitLod %v4float %27 %28
+OpStore %outColor %29
+OpReturn
+OpFunctionEnd
+)";
+
+  const std::string post_defs =
+      R"(%foo_ = OpFunction %20 None %21
+%30 = OpLabel
+%31 = OpVariable %_ptr_Function_20 Function
+%32 = OpLoad %20 %sampler16
+OpStore %31 %32
+%33 = OpLoad %20 %31
+OpReturnValue %33
+OpFunctionEnd
+)";
+
+  SinglePassRunAndCheck<opt::InlineOpaquePass>(
+      predefs + before + post_defs,
+      predefs + after + post_defs, true, true);
+}
+
+TEST_F(InlineOpaqueTest, InlineInNonEntryPointFunction) {
+  // This demonstrates opaque inlining in a function that is not
+  // an entry point function (main2) but is in the call tree of an
+  // entry point function (main).
+  // TODO(greg-lunarg): Add HLSL code
+
+  const std::string predefs =
+      R"(OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %outColor %texCoords
+OpExecutionMode %main OriginUpperLeft
+OpSource GLSL 140
+OpName %main "main"
+OpName %main2 "main2"
+OpName %S_t "S_t"
+OpMemberName %S_t 0 "v0"
+OpMemberName %S_t 1 "v1"
+OpMemberName %S_t 2 "smp"
+OpName %foo_struct_S_t_vf2_vf21_ "foo(struct-S_t-vf2-vf21;"
+OpName %s "s"
+OpName %outColor "outColor"
+OpName %sampler15 "sampler15"
+OpName %s0 "s0"
+OpName %texCoords "texCoords"
+OpName %param "param"
+OpDecorate %sampler15 DescriptorSet 0
+%void = OpTypeVoid
+%13 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%v2float = OpTypeVector %float 2
+%v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%outColor = OpVariable %_ptr_Output_v4float Output
+%18 = OpTypeImage %float 2D 0 0 0 1 Unknown
+%19 = OpTypeSampledImage %18
+%S_t = OpTypeStruct %v2float %v2float %19
+%_ptr_Function_S_t = OpTypePointer Function %S_t
+%21 = OpTypeFunction %void %_ptr_Function_S_t
+%_ptr_UniformConstant_19 = OpTypePointer UniformConstant %19
+%_ptr_Function_19 = OpTypePointer Function %19
+%sampler15 = OpVariable %_ptr_UniformConstant_19 UniformConstant
+%int = OpTypeInt 32 1
+%int_0 = OpConstant %int 0
+%int_2 = OpConstant %int 2
+%_ptr_Function_v2float = OpTypePointer Function %v2float
+%_ptr_Input_v2float = OpTypePointer Input %v2float
+%texCoords = OpVariable %_ptr_Input_v2float Input
+)";
+
+  const std::string before =
+      R"(%main2 = OpFunction %void None %13
+%29 = OpLabel
+%s0 = OpVariable %_ptr_Function_S_t Function 
+%param = OpVariable %_ptr_Function_S_t Function
+%30 = OpLoad %v2float %texCoords
+%31 = OpAccessChain %_ptr_Function_v2float %s0 %int_0
+OpStore %31 %30
+%32 = OpLoad %19 %sampler15
+%33 = OpAccessChain %_ptr_Function_19 %s0 %int_2
+OpStore %33 %32
+%34 = OpLoad %S_t %s0 
+OpStore %param %34
+%35 = OpFunctionCall %void %foo_struct_S_t_vf2_vf21_ %param
+OpReturn
+OpFunctionEnd
+)";
+
+  const std::string after =
+      R"(%main2 = OpFunction %void None %13
+%29 = OpLabel
+%s0 = OpVariable %_ptr_Function_S_t Function
+%param = OpVariable %_ptr_Function_S_t Function
+%30 = OpLoad %v2float %texCoords
+%31 = OpAccessChain %_ptr_Function_v2float %s0 %int_0
+OpStore %31 %30
+%32 = OpLoad %19 %sampler15
+%33 = OpAccessChain %_ptr_Function_19 %s0 %int_2
+OpStore %33 %32
+%34 = OpLoad %S_t %s0
+OpStore %param %34
+%44 = OpAccessChain %_ptr_Function_19 %param %int_2
+%45 = OpLoad %19 %44
+%46 = OpAccessChain %_ptr_Function_v2float %param %int_0
+%47 = OpLoad %v2float %46
+%48 = OpImageSampleImplicitLod %v4float %45 %47
+OpStore %outColor %48
+OpReturn
+OpFunctionEnd
+)";
+
+  const std::string post_defs =
+      R"(%main = OpFunction %void None %13
+%36 = OpLabel
+%37 = OpFunctionCall %void %main2
+OpReturn
+OpFunctionEnd
+%foo_struct_S_t_vf2_vf21_ = OpFunction %void None %21
+%s = OpFunctionParameter %_ptr_Function_S_t
+%38 = OpLabel
+%39 = OpAccessChain %_ptr_Function_19 %s %int_2
+%40 = OpLoad %19 %39
+%41 = OpAccessChain %_ptr_Function_v2float %s %int_0
+%42 = OpLoad %v2float %41
+%43 = OpImageSampleImplicitLod %v4float %40 %42
+OpStore %outColor %43
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndCheck<opt::InlineOpaquePass>(
+      predefs + before + post_defs,
+      predefs + after + post_defs, true, true);
+}
+
+TEST_F(InlineOpaqueTest, NoInlineNoOpaque) {
+  // Function without opaque interface is not inlined.
+  // #version 140
+  // 
+  // in vec4 BaseColor;
+  // 
+  // float foo(vec4 bar)
+  // {
+  //     return bar.x + bar.y;
+  // }
+  // 
+  // void main()
+  // {
+  //     vec4 color = vec4(foo(BaseColor));
+  //     gl_FragColor = color;
+  // }
+
+  const std::string assembly =
+      R"(OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %BaseColor %gl_FragColor
+OpExecutionMode %main OriginUpperLeft
+OpSource GLSL 140
+OpName %main "main"
+OpName %foo_vf4_ "foo(vf4;"
+OpName %bar "bar"
+OpName %color "color"
+OpName %BaseColor "BaseColor"
+OpName %param "param"
+OpName %gl_FragColor "gl_FragColor"
+%void = OpTypeVoid
+%10 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%v4float = OpTypeVector %float 4
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+%14 = OpTypeFunction %float %_ptr_Function_v4float
+%uint = OpTypeInt 32 0
+%uint_0 = OpConstant %uint 0
+%_ptr_Function_float = OpTypePointer Function %float
+%uint_1 = OpConstant %uint 1
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%BaseColor = OpVariable %_ptr_Input_v4float Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%gl_FragColor = OpVariable %_ptr_Output_v4float Output
+%main = OpFunction %void None %10
+%21 = OpLabel
+%color = OpVariable %_ptr_Function_v4float Function
+%param = OpVariable %_ptr_Function_v4float Function
+%22 = OpLoad %v4float %BaseColor
+OpStore %param %22
+%23 = OpFunctionCall %float %foo_vf4_ %param
+%24 = OpCompositeConstruct %v4float %23 %23 %23 %23
+OpStore %color %24
+%25 = OpLoad %v4float %color
+OpStore %gl_FragColor %25
+OpReturn
+OpFunctionEnd
+%foo_vf4_ = OpFunction %float None %14
+%bar = OpFunctionParameter %_ptr_Function_v4float
+%26 = OpLabel
+%27 = OpAccessChain %_ptr_Function_float %bar %uint_0
+%28 = OpLoad %float %27
+%29 = OpAccessChain %_ptr_Function_float %bar %uint_1
+%30 = OpLoad %float %29
+%31 = OpFAdd %float %28 %30
+OpReturnValue %31
+OpFunctionEnd
+)";
+
+  SinglePassRunAndCheck<opt::InlineOpaquePass>(
+      assembly, assembly, true, true);
+}
+
+}  // anonymous namespace

--- a/test/opt/inline_opaque_test.cpp
+++ b/test/opt/inline_opaque_test.cpp
@@ -22,7 +22,7 @@ using namespace spvtools;
 
 using InlineOpaqueTest = PassTest<::testing::Test>;
 
-TEST_F(InlineOpaqueTest, InlineOpaqueArg) {
+TEST_F(InlineOpaqueTest, InlineCallWithStructArgContainingSampledImage) {
   // Function with opaque argument is inlined.
   // TODO(greg-lunarg): Add HLSL code
 

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -73,9 +73,10 @@ Options:
                early return in a loop.
   --inline-entry-points-opaque
                Inline all function calls in entry point call tree functions
-               where the callee has opaque type parameters or return value.
-               Currently will not inline calls to functions with early return
-               in a loop.
+               where the callee's parameters or return type contain an opaque
+               type. Opaque type is currently defined as Image, Sampler or
+               SampledImage. Currently will not inline calls to functions with
+               early return in a loop.
   --convert-local-access-chains
                Convert constant index access chain loads/stores into
                equivalent load/stores with inserts and extracts. Performed

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -68,46 +68,55 @@ Options:
                Remap result ids to a compact range starting from %%1 and without
                any gaps.
   --inline-entry-points-exhaustive
-               Exhaustively inline all function calls in entry point functions.
-               Currently does not inline calls to functions with early return
+               Exhaustively inline all function calls in entry point call tree
+               functions. Currently does not inline calls to functions with
+               early return in a loop.
+  --inline-entry-points-opaque
+               Inline all function calls in entry point call tree functions
+               where the callee has opaque type parameters or return value.
+               Currently will not inline calls to functions with early return
                in a loop.
   --convert-local-access-chains
                Convert constant index access chain loads/stores into
                equivalent load/stores with inserts and extracts. Performed
                on function scope variables referenced only with load, store,
-               and constant index access chains.
+               and constant index access chains in entry point call tree
+               functions.
   --eliminate-common-uniform
                Perform load/load elimination for duplicate uniform values.
                Converts any constant index access chain uniform loads into
                its equivalent load and extract. Some loads will be moved
                to facilitate sharing. Performed only on entry point
-               functions.
+               call tree functions.
   --eliminate-local-single-block
                Perform single-block store/load and load/load elimination.
                Performed only on function scope variables in entry point
-               functions.
+               call tree functions.
   --eliminate-local-single-store
                Replace stores and loads of function scope variables that are
                only stored once. Performed on variables referenceed only with
-               loads and stores. Performed only on entry point functions.
+               loads and stores. Performed only on entry point call tree
+               functions.
   --eliminate-local-multi-store
                Replace stores and loads of function scope variables that are
                stored multiple times. Performed on variables referenceed only
-               with loads and stores. Performed only on entry point functions.
+               with loads and stores. Performed only on entry point call tree
+               functions.
   --eliminate-insert-extract
                Replace extract from a sequence of inserts with the
-               corresponding value. Performed only on entry point functions.
+               corresponding value. Performed only on entry point call tree
+               functions.
   --eliminate-dead-code-aggressive
                Delete instructions which do not contribute to a function's
-               output. Performed only on entry point functions.
+               output. Performed only on entry point call tree functions.
   --eliminate-dead-branches
                Convert conditional branches with constant condition to the
                indicated unconditional brranch. Delete all resulting dead
-               code. Performed only on entry point functions.
+               code. Performed only on entry point call tree functions.
   --merge-blocks
                Join two blocks into a single block if the second has the
                first as its only predecessor. Performed only on entry point
-               functions.
+               call tree functions.
   -h, --help   
                Print this help.
   --version    
@@ -172,6 +181,8 @@ int main(int argc, char** argv) {
         optimizer.RegisterPass(CreateFreezeSpecConstantValuePass());
       } else if (0 == strcmp(cur_arg, "--inline-entry-points-exhaustive")) {
         optimizer.RegisterPass(CreateInlineExhaustivePass());
+      } else if (0 == strcmp(cur_arg, "--inline-entry-points-opaque")) {
+        optimizer.RegisterPass(CreateInlineOpaquePass());
       } else if (0 == strcmp(cur_arg, "--convert-local-access-chains")) {
         optimizer.RegisterPass(CreateLocalAccessChainConvertPass());
       } else if (0 == strcmp(cur_arg, "--eliminate-dead-code-aggressive")) {


### PR DESCRIPTION
Only inline calls to functions with opaque params or return ie only inline calls needed to complete opaque propagation. This is in support of opaque propagation needed by glslang.