### PR TITLE
Updated capabilites for SampleMask

### DIFF
--- a/test/operand_capabilities_test.cpp
+++ b/test/operand_capabilities_test.cpp
@@ -514,7 +514,7 @@ INSTANTIATE_TEST_CASE_P(
             CASE1(BUILT_IN, BuiltInFrontFacing, Shader),
             CASE1(BUILT_IN, BuiltInSampleId, SampleRateShading),  // Bug 15234
             CASE1(BUILT_IN, BuiltInSamplePosition, SampleRateShading), // Bug 15234
-            CASE1(BUILT_IN, BuiltInSampleMask, SampleRateShading),  // Bug 15234
+            CASE1(BUILT_IN, BuiltInSampleMask, Shader),  // Bug 15234, Issue 182
             // Value 21 intentionally missing
             CASE1(BUILT_IN, BuiltInFragDepth, Shader),
             CASE1(BUILT_IN, BuiltInHelperInvocation, Shader),

--- a/test/val/val_capability_test.cpp
+++ b/test/val/val_capability_test.cpp
@@ -1213,7 +1213,7 @@ make_pair(string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
           "OpDecorate %intt BuiltIn SampleMask\n"
           "%intt = OpTypeInt 32 0\n" + string(kVoidFVoid),
-          vector<string>{"SampleRateShading"}),
+          ShaderDependencies()),
 make_pair(string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
           "OpDecorate %intt BuiltIn FragDepth\n"


### PR DESCRIPTION
SPIRV-Headers recently fixed the capability dependency
for SampleMask.  It depends on Shader, not SampleRateShading