### PR TITLE
DeadBranchElim: Correctly handle loops in dead branches.

### DIFF
--- a/source/opt/basic_block.cpp
+++ b/source/opt/basic_block.cpp
@@ -41,6 +41,7 @@ void BasicBlock::ForMergeAndContinueLabel(
     const std::function<void(const uint32_t)>& f) {
   auto ii = insts_.end();
   --ii;
+  if (ii == insts_.begin()) return;
   --ii;
   if ((*ii)->opcode() == SpvOpSelectionMerge || 
       (*ii)->opcode() == SpvOpLoopMerge)

--- a/source/opt/basic_block.cpp
+++ b/source/opt/basic_block.cpp
@@ -37,6 +37,18 @@ void BasicBlock::ForEachSuccessorLabel(
   }
 }
 
+void BasicBlock::ForMergeAndContinueLabel(
+    const std::function<void(const uint32_t)>& f) {
+  auto ii = insts_.end();
+  --ii;
+  --ii;
+  if ((*ii)->opcode() == SpvOpSelectionMerge || 
+      (*ii)->opcode() == SpvOpLoopMerge)
+    (*ii)->ForEachInId([&f](const uint32_t* idp) {
+      f(*idp);
+    });
+}
+
 }  // namespace ir
 }  // namespace spvtools
 

--- a/source/opt/basic_block.h
+++ b/source/opt/basic_block.h
@@ -85,6 +85,10 @@ class BasicBlock {
   void ForEachSuccessorLabel(
       const std::function<void(const uint32_t)>& f);
 
+  // Runs the given function |f| on the merge and continue label, if any
+  void ForMergeAndContinueLabel(
+      const std::function<void(const uint32_t)>& f);
+
  private:
   // The enclosing function.
   Function* function_;

--- a/source/opt/dead_branch_elim_pass.cpp
+++ b/source/opt/dead_branch_elim_pass.cpp
@@ -236,6 +236,10 @@ bool DeadBranchElimPass::EliminateDeadBranches(ir::Function* func) {
         (*dbi)->ForEachSuccessorLabel([&liveLabIds](const uint32_t succId){
           liveLabIds.insert(succId);
         });
+        // Mark merge and continue blocks as live
+        (*dbi)->ForMergeAndContinueLabel([&liveLabIds](const uint32_t succId){
+          liveLabIds.insert(succId);
+        });
       }
       ++dbi;
       dLabId = (*dbi)->id();

--- a/source/opt/dead_branch_elim_pass.cpp
+++ b/source/opt/dead_branch_elim_pass.cpp
@@ -217,15 +217,25 @@ bool DeadBranchElimPass::EliminateDeadBranches(ir::Function* func) {
     def_use_mgr_->KillInst(br);
     def_use_mgr_->KillInst(mergeInst);
 
+    // Initialize live block set to the live label
+    std::unordered_set<uint32_t> liveLabIds;
+    liveLabIds.insert(liveLabId);
+
     // Iterate to merge block adding dead blocks to elimination set
     auto dbi = bi;
     ++dbi;
     uint32_t dLabId = (*dbi)->id();
     while (dLabId != mergeLabId) {
-      if (!HasNonPhiRef(dLabId)) {
+      if (liveLabIds.find(dLabId) == liveLabIds.end()) {
         // Kill use/def for all instructions and mark block for elimination
         KillAllInsts(*dbi);
         elimBlocks.insert(*dbi);
+      }
+      else {
+        // Mark all successors as live
+        (*dbi)->ForEachSuccessorLabel([&liveLabIds](const uint32_t succId){
+          liveLabIds.insert(succId);
+        });
       }
       ++dbi;
       dLabId = (*dbi)->id();


### PR DESCRIPTION
The backedge to a dead loop header was causing the algorithm to think the header was live. This new solution is identical to the previous solution except that it also ignores refs from blocks that have not been marked live, such as blocks that contain backedges.