### PR TITLE
Fix encode zero bits on word boundary bug

### DIFF
--- a/source/util/bit_stream.cpp
+++ b/source/util/bit_stream.cpp
@@ -300,6 +300,8 @@ void BitWriterWord64::WriteBits(uint64_t bits, size_t num_bits) {
   assert(is_little_endian && "Big-endian architecture support not implemented");
   if (!is_little_endian) return;
 
+  if (num_bits == 0) return;
+
   bits = GetLowerBits(bits, num_bits);
 
   EmitSequence(bits, num_bits);

--- a/test/bit_stream.cpp
+++ b/test/bit_stream.cpp
@@ -565,6 +565,25 @@ TEST(BitWriterWord64, WriteBits) {
   EXPECT_EQ(PadToWord<64>("110011100111001"), writer.GetStreamPadded64());
 }
 
+TEST(BitWriterWord64, WriteZeroBits) {
+  BitWriterWord64 writer;
+  writer.WriteBits(0, 0);
+  writer.WriteBits(1, 0);
+  EXPECT_EQ(0u, writer.GetNumBits());
+  writer.WriteBits(1, 1);
+  writer.WriteBits(0, 0);
+  EXPECT_EQ(PadToWord<64>("1"), writer.GetStreamPadded64());
+  writer.WriteBits(0, 63);
+  EXPECT_EQ(64u, writer.GetNumBits());
+  writer.WriteBits(0, 0);
+  writer.WriteBits(7, 3);
+  writer.WriteBits(0, 0);
+  EXPECT_EQ(PadToWord<64>(
+          "1"
+          "000000000000000000000000000000000000000000000000000000000000000"
+          "111"), writer.GetStreamPadded64());
+}
+
 TEST(BitWriterWord64, ComparisonTestWriteLotsOfBits) {
   BitWriterStringStream writer1;
   BitWriterWord64 writer2(16384);


### PR DESCRIPTION
Bit stream writer was manifesting incorrect behaviour when the following
two conditions were met:
- writer was on 64-bit word boundary
- WriteBits was invoked with num_bits=0 (can happen when a Huffman codec has only one
value)

The bug was causing very rare sporadic corruption which was detected by
tests after a random experimental change in MARK-V model.