### PR TITLE
Extension allows multiple same OpTypePointer types

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -15,7 +15,6 @@
 #include "val/validation_state.h"
 
 #include <cassert>
-#include <map>
 
 #include "opcode.h"
 #include "val/basic_block.h"

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -426,25 +426,6 @@ bool ValidationState_t::RegisterUniqueTypeDeclaration(
     key.insert(key.end(), inst.words + words_begin, inst.words + words_end);
   }
 
-  // If module has extension SPV_KHR_variable_pointers, then OpTypePointer
-  // is allowed to create identical types so long as their decorations differ.
-  if (inst.opcode == SpvOpTypePointer &&
-      HasExtension(Extension::kSPV_KHR_variable_pointers)) {
-    const std::vector<Decoration>& decorations = id_decorations(inst.result_id);
-    std::map<SpvDecoration, const std::vector<uint32_t>*> decoration_params;
-    for (const auto& decoration : decorations) {
-      decoration_params[decoration.dec_type()] = &decoration.params();
-    }
-    for (const auto& kv : decoration_params) {
-      // Append decoration data to the key, sorted by decoration type.
-      // Use magic number to separate unrelated chunks of data.
-      const uint32_t kMagicSeparator = 0xffff9296;
-      key.push_back(kMagicSeparator);
-      key.push_back(static_cast<uint32_t>(kv.first));
-      key.insert(key.end(), kv.second->begin(), kv.second->end());
-    }
-  }
-
   return unique_type_declarations_.insert(std::move(key)).second;
 }
 }  /// namespace libspirv

--- a/source/validate_type_unique.cpp
+++ b/source/validate_type_unique.cpp
@@ -49,7 +49,8 @@ spv_result_t TypeUniquePass(ValidationState_t& _,
       // return _.diag(SPV_ERROR_INVALID_DATA)
       return _.diag(SPV_SUCCESS)
           << "Duplicate non-aggregate type declarations are not allowed."
-          << " Opcode: " << spvOpcodeString(SpvOp(inst->opcode));
+          << " Opcode: " << spvOpcodeString(SpvOp(inst->opcode))
+          << " id: " << inst->result_id;
     }
   }
 

--- a/source/validate_type_unique.cpp
+++ b/source/validate_type_unique.cpp
@@ -42,6 +42,12 @@ spv_result_t TypeUniquePass(ValidationState_t& _,
       return SPV_SUCCESS;
     }
 
+    if (inst->opcode == SpvOpTypePointer &&
+        _.HasExtension(Extension::kSPV_KHR_variable_pointers)) {
+      // Duplicate pointer types are allowed with this extension.
+      return SPV_SUCCESS;
+    }
+
     if (!_.RegisterUniqueTypeDeclaration(*inst)) {
       // TODO(atgoo@github) Error logging temporarily disabled because it's
       // failing vulkancts tests. Message in the diagnostics is for unit tests.

--- a/source/validate_type_unique.cpp
+++ b/source/validate_type_unique.cpp
@@ -49,7 +49,7 @@ spv_result_t TypeUniquePass(ValidationState_t& _,
       // return _.diag(SPV_ERROR_INVALID_DATA)
       return _.diag(SPV_SUCCESS)
           << "Duplicate non-aggregate type declarations are not allowed."
-          << " Opcode: " << inst->opcode;
+          << " Opcode: " << spvOpcodeString(SpvOp(inst->opcode));
     }
   }
 

--- a/test/val/val_type_unique_test.cpp
+++ b/test/val/val_type_unique_test.cpp
@@ -238,7 +238,7 @@ OpMemoryModel Physical32 OpenCL
               Not(HasSubstr(GetErrorString(SpvOpTypeVoid))));
 }
 
-TEST_F(ValidateTypeUnique, PointerTypesSameArrayStrideNoExtension) {
+TEST_F(ValidateTypeUnique, PointerTypesDifferentArrayStrideNoExtension) {
   string str = R"(
 OpCapability Shader
 OpCapability Linkage
@@ -250,7 +250,7 @@ OpDecorate %ptr2 ArrayStride 8
 %ptr2 = OpTypePointer Input %u32
 )";
   CompileSuccessfully(str.c_str());
-  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+  ASSERT_EQ(kDuplicateTypeError, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr(GetErrorString(SpvOpTypePointer)));
 }
@@ -286,7 +286,7 @@ OpDecorate %ptr2 ArrayStride 4
 %ptr2 = OpTypePointer Input %u32
 )";
   CompileSuccessfully(str.c_str());
-  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+  ASSERT_EQ(kDuplicateTypeError, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr(GetErrorString(SpvOpTypePointer)));
 }

--- a/test/val/val_type_unique_test.cpp
+++ b/test/val/val_type_unique_test.cpp
@@ -238,13 +238,11 @@ OpMemoryModel Physical32 OpenCL
               Not(HasSubstr(GetErrorString(SpvOpTypeVoid))));
 }
 
-TEST_F(ValidateTypeUnique, PointerTypesDifferentArrayStrideNoExtension) {
+TEST_F(ValidateTypeUnique, DuplicatePointerTypesNoExtension) {
   string str = R"(
 OpCapability Shader
 OpCapability Linkage
 OpMemoryModel Logical GLSL450
-OpDecorate %ptr1 ArrayStride 4
-OpDecorate %ptr2 ArrayStride 8
 %u32 = OpTypeInt 32 0
 %ptr1 = OpTypePointer Input %u32
 %ptr2 = OpTypePointer Input %u32
@@ -255,14 +253,12 @@ OpDecorate %ptr2 ArrayStride 8
               HasSubstr(GetErrorString(SpvOpTypePointer)));
 }
 
-TEST_F(ValidateTypeUnique, PointerTypesDifferentArrayStride) {
+TEST_F(ValidateTypeUnique, DuplicatePointerTypesWithExtension) {
   string str = R"(
 OpCapability Shader
 OpCapability Linkage
 OpExtension "SPV_KHR_variable_pointers"
 OpMemoryModel Logical GLSL450
-OpDecorate %ptr1 ArrayStride 4
-OpDecorate %ptr2 ArrayStride 8
 %u32 = OpTypeInt 32 0
 %ptr1 = OpTypePointer Input %u32
 %ptr2 = OpTypePointer Input %u32
@@ -271,24 +267,6 @@ OpDecorate %ptr2 ArrayStride 8
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               Not(HasSubstr(GetErrorString(SpvOpTypePointer))));
-}
-
-TEST_F(ValidateTypeUnique, PointerTypesSameArrayStride) {
-  string str = R"(
-OpCapability Shader
-OpCapability Linkage
-OpExtension "SPV_KHR_variable_pointers"
-OpMemoryModel Logical GLSL450
-OpDecorate %ptr1 ArrayStride 4
-OpDecorate %ptr2 ArrayStride 4
-%u32 = OpTypeInt 32 0
-%ptr1 = OpTypePointer Input %u32
-%ptr2 = OpTypePointer Input %u32
-)";
-  CompileSuccessfully(str.c_str());
-  ASSERT_EQ(kDuplicateTypeError, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr(GetErrorString(SpvOpTypePointer)));
 }
 
 }  // anonymous namespace

--- a/test/val/val_type_unique_test.cpp
+++ b/test/val/val_type_unique_test.cpp
@@ -95,7 +95,7 @@ OpFunctionEnd
 // declaration.
 string GetErrorString(SpvOp opcode) {
   return "Duplicate non-aggregate type declarations are not allowed. Opcode: "
-      + std::to_string(opcode);
+      + std::string(spvOpcodeString(opcode));
 }
 
 TEST_F(ValidateTypeUnique, success) {
@@ -236,6 +236,59 @@ OpMemoryModel Physical32 OpenCL
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               Not(HasSubstr(GetErrorString(SpvOpTypeVoid))));
+}
+
+TEST_F(ValidateTypeUnique, PointerTypesSameArrayStrideNoExtension) {
+  string str = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %ptr1 ArrayStride 4
+OpDecorate %ptr2 ArrayStride 8
+%u32 = OpTypeInt 32 0
+%ptr1 = OpTypePointer Input %u32
+%ptr2 = OpTypePointer Input %u32
+)";
+  CompileSuccessfully(str.c_str());
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(GetErrorString(SpvOpTypePointer)));
+}
+
+TEST_F(ValidateTypeUnique, PointerTypesDifferentArrayStride) {
+  string str = R"(
+OpCapability Shader
+OpCapability Linkage
+OpExtension "SPV_KHR_variable_pointers"
+OpMemoryModel Logical GLSL450
+OpDecorate %ptr1 ArrayStride 4
+OpDecorate %ptr2 ArrayStride 8
+%u32 = OpTypeInt 32 0
+%ptr1 = OpTypePointer Input %u32
+%ptr2 = OpTypePointer Input %u32
+)";
+  CompileSuccessfully(str.c_str());
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              Not(HasSubstr(GetErrorString(SpvOpTypePointer))));
+}
+
+TEST_F(ValidateTypeUnique, PointerTypesSameArrayStride) {
+  string str = R"(
+OpCapability Shader
+OpCapability Linkage
+OpExtension "SPV_KHR_variable_pointers"
+OpMemoryModel Logical GLSL450
+OpDecorate %ptr1 ArrayStride 4
+OpDecorate %ptr2 ArrayStride 4
+%u32 = OpTypeInt 32 0
+%ptr1 = OpTypePointer Input %u32
+%ptr2 = OpTypePointer Input %u32
+)";
+  CompileSuccessfully(str.c_str());
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(GetErrorString(SpvOpTypePointer)));
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
SPV_KHR_variable_pointers allows OpTypePointer to declare multiple
identical types

https://github.com/KhronosGroup/SPIRV-Tools/issues/781