### PR TITLE
Inliner: Remap callee entry block id to single-trip loop header

### DIFF
--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -378,6 +378,10 @@ void InlinePass::GenInlineCode(
             new_blocks->push_back(std::move(new_blk_ptr));
             new_blk_ptr.reset(new ir::BasicBlock(NewLabel(postHeaderId)));
             multiBlocks = true;
+            // Reset the mapping of the callee's entry block to point to
+            // the post-header block.  Do this so we can fix up phis later
+            // on to satisfy dominance.
+            callee2caller[cpi->result_id()] = postHeaderId;
           }
         } else {
           multiBlocks = true;


### PR DESCRIPTION
Otherwise cloned phis can be invalid.

Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/790