### PR TITLE
Fix mingw build (source/print.cpp)

### DIFF
--- a/source/print.cpp
+++ b/source/print.cpp
@@ -42,7 +42,7 @@ static void SetConsoleForegroundColorPrimary(HANDLE hConsole, WORD color)
   GetConsoleScreenBufferInfo(hConsole, &bufInfo);
 
   // Get background color
-  color |= (bufInfo.wAttributes & 0xfff0);
+  color = WORD(color | (bufInfo.wAttributes & 0xfff0));
 
   // Set foreground color
   SetConsoleTextAttribute(hConsole, color);


### PR DESCRIPTION
source/print.cpp doesn't compile due to integer conversion.

Tested by @dneto0 on a Windows machine.