### PR TITLE
WIP: Process OpModule processed as embedded debug instruction like OpLine, OpNoLine

### DIFF
--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -26,9 +26,10 @@ Instruction::Instruction(const spv_parsed_instruction_t& inst,
     : opcode_(static_cast<SpvOp>(inst.opcode)),
       type_id_(inst.type_id),
       result_id_(inst.result_id),
-      dbg_line_insts_(std::move(dbg_line)) {
-  assert((!IsDebugLineInst(opcode_) || dbg_line.empty()) &&
-         "Op(No)Line attaching to Op(No)Line found");
+      embedded_debug_insts_(std::move(dbg_line)) {
+  assert((!IsEmbeddedDebugInst(opcode_) || dbg_line.empty()) &&
+         "OpLine/OpNoLine/OpModuleProcessed attaching to "
+         "OpLine/OpNoLine/OpModuleProcessed found");
   for (uint32_t i = 0; i < inst.num_operands; ++i) {
     const auto& current_payload = inst.operands[i];
     std::vector<uint32_t> words(
@@ -57,14 +58,14 @@ Instruction::Instruction(Instruction&& that)
       type_id_(that.type_id_),
       result_id_(that.result_id_),
       operands_(std::move(that.operands_)),
-      dbg_line_insts_(std::move(that.dbg_line_insts_)) {}
+      embedded_debug_insts_(std::move(that.embedded_debug_insts_)) {}
 
 Instruction& Instruction::operator=(Instruction&& that) {
   opcode_ = that.opcode_;
   type_id_ = that.type_id_;
   result_id_ = that.result_id_;
   operands_ = std::move(that.operands_);
-  dbg_line_insts_ = std::move(that.dbg_line_insts_);
+  embedded_debug_insts_ = std::move(that.embedded_debug_insts_);
   return *this;
 }
 

--- a/source/opt/ir_loader.cpp
+++ b/source/opt/ir_loader.cpp
@@ -29,14 +29,14 @@ IrLoader::IrLoader(const MessageConsumer& consumer, Module* module)
 bool IrLoader::AddInstruction(const spv_parsed_instruction_t* inst) {
   ++inst_index_;
   const auto opcode = static_cast<SpvOp>(inst->opcode);
-  if (IsDebugLineInst(opcode)) {
-    dbg_line_info_.push_back(Instruction(*inst));
+  if (IsEmbeddedDebugInst(opcode)) {
+    embedded_debug_insts_.push_back(Instruction(*inst));
     return true;
   }
 
   std::unique_ptr<Instruction> spv_inst(
-      new Instruction(*inst, std::move(dbg_line_info_)));
-  dbg_line_info_.clear();
+      new Instruction(*inst, std::move(embedded_debug_insts_)));
+  embedded_debug_insts_.clear();
 
   const char* src = source_.c_str();
   spv_position_t loc = {inst_index_, 0, 0};

--- a/source/opt/ir_loader.h
+++ b/source/opt/ir_loader.h
@@ -72,8 +72,10 @@ class IrLoader {
   std::unique_ptr<Function> function_;
   // The current BasicBlock under construction.
   std::unique_ptr<BasicBlock> block_;
-  // Line related debug instructions accumulated thus far.
-  std::vector<Instruction> dbg_line_info_;
+  // Embedded debug instructions accumulated thus far.
+  // An "embedded" debug instruction may appear anywhere in the module.
+  // These include OpLine, OpNoLine, and OpModuleProcessed instructions.
+  std::vector<Instruction> embedded_debug_insts_;
 };
 
 }  // namespace ir

--- a/source/opt/reflect.h
+++ b/source/opt/reflect.h
@@ -28,8 +28,9 @@ inline bool IsDebugInst(SpvOp opcode) {
   return (opcode >= SpvOpSourceContinued && opcode <= SpvOpLine) ||
          opcode == SpvOpNoLine || opcode == SpvOpModuleProcessed;
 }
-inline bool IsDebugLineInst(SpvOp opcode) {
-  return opcode == SpvOpLine || opcode == SpvOpNoLine;
+inline bool IsEmbeddedDebugInst(SpvOp opcode) {
+  return opcode == SpvOpLine || opcode == SpvOpNoLine ||
+         opcode == SpvOpModuleProcessed;
 }
 inline bool IsAnnotationInst(SpvOp opcode) {
   return opcode >= SpvOpDecorate && opcode <= SpvOpGroupMemberDecorate;

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -17,6 +17,7 @@
 #include <cassert>
 
 #include "opcode.h"
+#include "spirv_constant.h"
 #include "val/basic_block.h"
 #include "val/construct.h"
 #include "val/function.h"
@@ -240,6 +241,13 @@ void ValidationState_t::ProgressToNextLayoutSectionOrder() {
 }
 
 bool ValidationState_t::IsOpcodeInCurrentLayoutSection(SpvOp op) {
+  // OpModuleProcessed can go anywhwere, starting with SPIR-V 1.1.
+  if (op == SpvOpModuleProcessed &&
+      (spvVersionForTargetEnv(SPV_ENV_UNIVERSAL_1_0) !=
+       spvVersionForTargetEnv(context_->target_env))) {
+    return true;
+  }
+  // Otherwise, use a table to look it up.
   return IsInstructionInLayoutSection(current_layout_section_, op);
 }
 

--- a/source/validate_layout.cpp
+++ b/source/validate_layout.cpp
@@ -129,6 +129,7 @@ spv_result_t FunctionScopedInstructions(ValidationState_t& _,
 
       case SpvOpLine:
       case SpvOpNoLine:
+      case SpvOpModuleProcessed:
         break;
       case SpvOpLabel:
         // If the label is encountered then the current function is a

--- a/test/opt/pass_fixture.h
+++ b/test/opt/pass_fixture.h
@@ -181,6 +181,9 @@ class PassTest : public TestT {
     EXPECT_EQ(expected, optimized);
   }
 
+  // Sets the message consumer.
+  void SetMessageConsumer(MessageConsumer consumer) { consumer_ = consumer; }
+
   void SetAssembleOptions(uint32_t assemble_options) {
     assemble_options_ = assemble_options;
   }

--- a/test/opt/strip_debug_info_test.cpp
+++ b/test/opt/strip_debug_info_test.cpp
@@ -94,7 +94,6 @@ INSTANTIATE_TEST_CASE_P(
         "OpName %main \"main\"",
         "OpMemberName %struct 0 \"field\"",
         "%1 = OpString \"name.vert\"",
-        "OpModuleProcessed \"42\"",
     })));
 // clang-format on
 


### PR DESCRIPTION
    Optimizer: OpModuleProcessed is like OpLine, OpNoLine
    
    It is a debug instruction that can appear anywhere.
    Optimizer classes should store and process it like OpLine
    and OpNoLine, which have the same properties.
    
Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/802

Builds on https://github.com/KhronosGroup/SPIRV-Tools/pull/797