### PR TITLE
CFG Cleanup pass - Remove unreachable blocks.

### DIFF
--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -393,6 +393,14 @@ Optimizer::PassToken CreateCompactIdsPass();
 // Creates a remove duplicate capabilities pass.
 Optimizer::PassToken CreateRemoveDuplicatesPass();
 
+// Creates a CFG cleanup pass.
+// This pass removes cruft from the control flow graph of functions that are
+// reachable from entry points and exported functions. It currently includes the
+// following functionality:
+//
+// - Removal of unreachable basic blocks.
+Optimizer::PassToken CreateCFGCleanupPass();
+
 }  // namespace spvtools
 
 #endif  // SPIRV_TOOLS_OPTIMIZER_HPP_

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(SPIRV-Tools-opt
   basic_block.h
   block_merge_pass.h
   build_module.h
+  cfg_cleanup_pass.h
   common_uniform_elim_pass.h
   compact_ids_pass.h
   constants.h
@@ -58,6 +59,7 @@ add_library(SPIRV-Tools-opt
   basic_block.cpp
   block_merge_pass.cpp
   build_module.cpp
+  cfg_cleanup_pass.cpp
   common_uniform_elim_pass.cpp
   compact_ids_pass.cpp
   decoration_manager.cpp

--- a/source/opt/basic_block.h
+++ b/source/opt/basic_block.h
@@ -113,6 +113,16 @@ class BasicBlock {
   void ForMergeAndContinueLabel(
       const std::function<void(const uint32_t)>& f);
 
+  // Returns true if this basic block has any Phi instructions.
+  bool HasPhiInstructions() {
+    int count = 0;
+    ForEachPhiInst([&count](ir::Instruction*) {
+      ++count;
+      return;
+    });
+    return count > 0;
+  }
+
  private:
   // The enclosing function.
   Function* function_;

--- a/source/opt/cfg_cleanup_pass.cpp
+++ b/source/opt/cfg_cleanup_pass.cpp
@@ -1,0 +1,287 @@
+// Copyright (c) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file implements a pass to cleanup the CFG to remove superfluous
+// constructs (e.g., unreachable basic blocks, empty control flow structures,
+// etc)
+
+#include <queue>
+#include <unordered_set>
+
+#include "cfg_cleanup_pass.h"
+
+#include "function.h"
+#include "module.h"
+
+namespace spvtools {
+namespace opt {
+
+uint32_t CFGCleanupPass::TypeToUndef(uint32_t type_id) {
+  const auto uitr = type2undefs_.find(type_id);
+  if (uitr != type2undefs_.end()) {
+    return uitr->second;
+  }
+
+  const uint32_t undefId = TakeNextId();
+  std::unique_ptr<ir::Instruction> undef_inst(
+      new ir::Instruction(SpvOpUndef, type_id, undefId, {}));
+  def_use_mgr_->AnalyzeInstDefUse(&*undef_inst);
+  module_->AddGlobalValue(std::move(undef_inst));
+  type2undefs_[type_id] = undefId;
+
+  return undefId;
+}
+
+// Remove all |phi| operands coming from unreachable blocks (i.e., blocks not in
+// |reachable_blocks|).  There are two types of removal that this function can
+// perform:
+//
+// 1- Any operand that comes directly from an unreachable block is completely
+//    removed.  Since the block is unreachable, the edge between the unreachable
+//    block and the block holding |phi| has been removed.
+//
+// 2- Any operand that comes via a live block and was defined at an unreachable
+//    block gets its value replaced with an OpUndef value. Since the argument
+//    was generated in an unreachable block, it no longer exists, so it cannot
+//    be referenced.  However, since the value does not reach |phi| directly
+//    from the unreachable block, the operand cannot be removed from |phi|.
+//    Therefore, we replace the argument value with OpUndef.
+//
+// For example, in the switch() below, assume that we want to remove the
+// argument with value %11 coming from block %41.
+//
+//          [ ... ]
+//          %41 = OpLabel                    <--- Unreachable block
+//          %11 = OpLoad %int %y
+//          [ ... ]
+//                OpSelectionMerge %16 None
+//                OpSwitch %12 %16 10 %13 13 %14 18 %15
+//          %13 = OpLabel
+//                OpBranch %16
+//          %14 = OpLabel
+//                OpStore %outparm %int_14
+//                OpBranch %16
+//          %15 = OpLabel
+//                OpStore %outparm %int_15
+//                OpBranch %16
+//          %16 = OpLabel
+//          %30 = OpPhi %int %11 %41 %int_42 %13 %11 %14 %11 %15
+//
+// Since %41 is now an unreachable block, the first operand of |phi| needs to
+// be removed completely.  But the operands (%11 %14) and (%11 %15) cannot be
+// removed because %14 and %15 are reachable blocks.  Since %11 no longer exist,
+// in those arguments, we replace all references to %11 with an OpUndef value.
+// This results in |phi| looking like:
+//
+//           %50 = OpUndef %int
+//           [ ... ]
+//           %30 = OpPhi %int %int_42 %13 %50 %14 %50 %15
+void CFGCleanupPass::RemovePhiOperands(
+    ir::Instruction* phi,
+    std::unordered_set<ir::BasicBlock*> reachable_blocks) {
+  std::vector<ir::Operand> keep_operands;
+  uint32_t type_id = 0;
+  uint32_t undef_id = 0;
+
+  // Traverse all the operands in |phi|. Build the new operand vector by adding
+  // all the original operands from |phi| except the unwanted ones.
+  bool undef_created = false;
+  for (uint32_t i = 0; i < phi->NumOperands();) {
+    if (i < 2) {
+      // The first two arguments are always preserved.
+      keep_operands.push_back(phi->GetOperand(i));
+      ++i;
+      continue;
+    }
+
+    // The remaining Phi arguments come in pairs. Index 'i' contains the
+    // variable id, index 'i + 1' is the originating block id.
+    assert(i % 2 == 0 && i < phi->NumOperands() - 1 &&
+           "malformed Phi arguments");
+
+    ir::BasicBlock *in_block = label2block_[phi->GetSingleWordOperand(i + 1)];
+    if (reachable_blocks.find(in_block) == reachable_blocks.end()) {
+      // If the incoming block is unreachable, remove both operands as this
+      // means that the |phi| has lost an incoming edge.
+      i += 2;
+      continue;
+    }
+
+    // In all other cases, the operand must be kept but may need to be changed.
+    uint32_t arg_id = phi->GetSingleWordOperand(i);
+    ir::BasicBlock *def_block = def_block_[arg_id];
+    if (def_block &&
+        reachable_blocks.find(def_block_[arg_id]) == reachable_blocks.end()) {
+      // If the current |phi| argument was defined in an unreachable block, it
+      // means that this |phi| argument is no longer defined. Replace it with
+      // |undef_id|.
+      if (!undef_created) {
+        type_id = def_use_mgr_->GetDef(arg_id)->type_id();
+        undef_id = TypeToUndef(type_id);
+        undef_created = true;
+      }
+      keep_operands.push_back(
+          ir::Operand(spv_operand_type_t::SPV_OPERAND_TYPE_ID, {undef_id}));
+    } else {
+      // Otherwise, the argument comes from a reachable block or from no block
+      // at all (meaning that it was defined in the global section of the
+      // program).  In both cases, keep the argument intact.
+      keep_operands.push_back(phi->GetOperand(i));
+    }
+
+    keep_operands.push_back(phi->GetOperand(i + 1));
+
+    i += 2;
+  }
+
+  phi->ReplaceOperands(keep_operands);
+}
+
+void CFGCleanupPass::RemoveBlock(ir::Function::iterator* bi) {
+  auto& rm_block = **bi;
+
+  // Remove instructions from the block.
+  rm_block.ForEachInst([&rm_block, this](ir::Instruction* inst) {
+    // Note that we do not kill the block label instruction here. The label
+    // instruction is needed to identify the block, which is needed by the
+    // removal of phi operands.
+    if (inst != rm_block.GetLabelInst()) {
+      KillNamesAndDecorates(inst);
+      def_use_mgr_->KillInst(inst);
+    }
+  });
+
+  // Remove the label instruction last.
+  auto label = rm_block.GetLabelInst();
+  KillNamesAndDecorates(label);
+  def_use_mgr_->KillInst(label);
+
+  *bi = bi->Erase();
+}
+
+bool CFGCleanupPass::RemoveUnreachableBlocks(ir::Function* func) {
+  bool modified = false;
+
+  // Mark reachable all blocks reachable from the function's entry block.
+  std::unordered_set<ir::BasicBlock*> reachable_blocks;
+  std::unordered_set<ir::BasicBlock*> visited_blocks;
+  std::queue<ir::BasicBlock*> worklist;
+  reachable_blocks.insert(func->entry().get());
+
+  // Initially mark the function entry point as reachable.
+  worklist.push(func->entry().get());
+
+  auto mark_reachable = [&reachable_blocks, &visited_blocks, &worklist,
+                         this](uint32_t label_id) {
+    auto successor = label2block_[label_id];
+    if (visited_blocks.count(successor) == 0) {
+      reachable_blocks.insert(successor);
+      worklist.push(successor);
+      visited_blocks.insert(successor);
+    }
+  };
+
+  // Transitively mark all blocks reachable from the entry as reachable.
+  while (!worklist.empty()) {
+    ir::BasicBlock* block = worklist.front();
+    worklist.pop();
+
+    // All the successors of a live block are also live.
+    block->ForEachSuccessorLabel(mark_reachable);
+
+    // All the Merge and ContinueTarget blocks of a live block are also live.
+    block->ForMergeAndContinueLabel(mark_reachable);
+  }
+
+  // Update operands of Phi nodes that reference unreachable blocks.
+  for (auto& block : *func) {
+    // If the block is about to be removed, don't bother updating its
+    // Phi instructions.
+    if (reachable_blocks.count(&block) == 0) {
+      continue;
+    }
+
+    // If the block is reachable and has Phi instructions, remove all
+    // operands from its Phi instructions that reference unreachable blocks.
+    if (block.HasPhiInstructions()) {
+      block.ForEachPhiInst(
+          [&block, &reachable_blocks, this](ir::Instruction* phi) {
+            RemovePhiOperands(phi, reachable_blocks);
+          });
+    }
+  }
+
+  // Erase unreachable blocks.
+  for (auto ebi = func->begin(); ebi != func->end();) {
+    if (reachable_blocks.count(&*ebi) == 0) {
+      RemoveBlock(&ebi);
+      modified = true;
+    } else {
+      ++ebi;
+    }
+  }
+
+  return modified;
+}
+
+bool CFGCleanupPass::CFGCleanup(ir::Function* func) {
+  bool modified = false;
+  modified |= RemoveUnreachableBlocks(func);
+  return modified;
+}
+
+void CFGCleanupPass::Initialize(ir::Module* module) {
+  // Initialize the DefUse manager. TODO(dnovillo): Re-factor all this into the
+  // module or some other context class for the optimizer.
+  module_ = module;
+  def_use_mgr_.reset(new analysis::DefUseManager(consumer(), module));
+  FindNamedOrDecoratedIds();
+
+  // Initialize next unused Id. TODO(dnovillo): Re-factor into the module or
+  // some other context class for the optimizer.
+  next_id_ = module_->id_bound();
+
+  // Initialize block lookup map.
+  label2block_.clear();
+  for (auto& fn : *module) {
+    for (auto& block : fn) {
+      label2block_[block.id()] = &block;
+
+      // Build a map between SSA names to the block they are defined in.
+      // TODO(dnovillo): This is expensive and unnecessary if ir::Instruction
+      // instances could figure out what basic block they belong to. Remove this
+      // once this is possible.
+      block.ForEachInst([this, &block](ir::Instruction* inst) {
+        uint32_t result_id = inst->result_id();
+        if (result_id > 0) {
+          def_block_[result_id] = &block;
+        }
+      });
+    }
+  }
+}
+
+Pass::Status CFGCleanupPass::Process(ir::Module* module) {
+  Initialize(module);
+
+  // Process all entry point functions.
+  ProcessFunction pfn = [this](ir::Function* fp) { return CFGCleanup(fp); };
+  bool modified = ProcessReachableCallTree(pfn, module);
+  FinalizeNextId(module_);
+  return modified ? Pass::Status::SuccessWithChange
+                  : Pass::Status::SuccessWithoutChange;
+}
+
+}  // namespace opt
+}  // namespace spvtools

--- a/source/opt/cfg_cleanup_pass.h
+++ b/source/opt/cfg_cleanup_pass.h
@@ -1,0 +1,88 @@
+// Copyright (c) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBSPIRV_OPT_CFG_CLEANUP_PASS_H_
+#define LIBSPIRV_OPT_CFG_CLEANUP_PASS_H_
+
+#include "function.h"
+#include "mem_pass.h"
+#include "module.h"
+
+namespace spvtools {
+namespace opt {
+
+class CFGCleanupPass : public MemPass {
+ public:
+  CFGCleanupPass() = default;
+  const char* name() const override { return "cfg-cleanup"; }
+  Status Process(ir::Module*) override;
+
+ private:
+  // Call all the cleanup helper functions on |func|.
+  bool CFGCleanup(ir::Function* func);
+
+  // Remove all the unreachable basic blocks in |func|.
+  bool RemoveUnreachableBlocks(ir::Function* func);
+
+  // Remove the block pointed by the iterator |*bi|. This also removes
+  // all the instructions in the pointed-to block.
+  void RemoveBlock(ir::Function::iterator* bi);
+
+  // Initialize the pass.
+  void Initialize(ir::Module* module);
+
+  // Remove Phi operands in |phi| that are coming from blocks not in
+  // |reachable_blocks|.
+  void RemovePhiOperands(ir::Instruction* phi,
+                         std::unordered_set<ir::BasicBlock*> reachable_blocks);
+
+  // Return the next available Id and increment it. TODO(dnovillo): Refactor
+  // into a new type pool manager to be used for all passes.
+  inline uint32_t TakeNextId() { return next_id_++; }
+
+  // Save next available id into |module|. TODO(dnovillo): Refactor
+  // into a new type pool manager to be used for all passes.
+  inline void FinalizeNextId(ir::Module* module) {
+    module->SetIdBound(next_id_);
+  }
+
+  // Return undef in function for type. Create and insert an undef after the
+  // first non-variable in the function if it doesn't already exist. Add
+  // undef to function undef map. TODO(dnovillo): Refactor into a new
+  // type pool manager to be used for all passes.
+  uint32_t TypeToUndef(uint32_t type_id);
+
+  // Map from block's label id to block. TODO(dnovillo): Basic blocks ought to
+  // have basic blocks in their pred/succ list.
+  std::unordered_map<uint32_t, ir::BasicBlock*> label2block_;
+
+  // Map from an instruction result ID to the block that holds it.
+  // TODO(dnovillo): This would be unnecessary if ir::Instruction instances
+  // knew what basic block they belong to.
+  std::unordered_map<uint32_t, ir::BasicBlock*> def_block_;
+
+  // Map from type to undef values. TODO(dnovillo): This is replicated from
+  // class LocalMultiStoreElimPass. It should be refactored into a type
+  // pool manager.
+  std::unordered_map<uint32_t, uint32_t> type2undefs_;
+
+  // Next unused ID. TODO(dnovillo): Refactor this to some common utility class.
+  // Seems to be implemented in very many passes.
+  uint32_t next_id_;
+};
+
+}  // namespace opt
+}  // namespace spvtools
+
+#endif

--- a/source/opt/function.h
+++ b/source/opt/function.h
@@ -70,6 +70,9 @@ class Function {
   // Returns function's return type id
   inline uint32_t type_id() const { return def_inst_->type_id(); }
 
+  // Returns the entry basic block for this function.
+  const std::unique_ptr<BasicBlock>& entry() const { return blocks_.front(); }
+
   iterator begin() { return iterator(&blocks_, blocks_.begin()); }
   iterator end() { return iterator(&blocks_, blocks_.end()); }
   const_iterator cbegin() const {

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -89,5 +89,11 @@ void Instruction::ToBinaryWithoutAttachedDebugInsts(
     binary->insert(binary->end(), operand.words.begin(), operand.words.end());
 }
 
+void Instruction::ReplaceOperands(const std::vector<Operand>& new_operands) {
+  operands_.clear();
+  operands_.insert(operands_.begin(), new_operands.begin(), new_operands.end());
+  operands_.shrink_to_fit();
+}
+
 }  // namespace ir
 }  // namespace spvtools

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -202,8 +202,13 @@ class Instruction {
   // Pushes the binary segments for this instruction into the back of *|binary|.
   void ToBinaryWithoutAttachedDebugInsts(std::vector<uint32_t>* binary) const;
 
+  // Replaces the operands to the instruction with |new_operands|. The caller
+  // is responsible for building a complete and valid list of operands for
+  // this instruction.
+  void ReplaceOperands(const std::vector<Operand>& new_operands);
+
  private:
-  // Returns the toal count of result type id and result id.
+  // Returns the total count of result type id and result id.
   uint32_t TypeResultIdCount() const {
     return (type_id_ != 0) + (result_id_ != 0);
   }

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -238,4 +238,9 @@ std::vector<const char*> Optimizer::GetPassNames() const {
   return v;
 }
 
+Optimizer::PassToken CreateCFGCleanupPass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::CFGCleanupPass>());
+}
+
 }  // namespace spvtools

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -18,6 +18,7 @@
 // A single header to include all passes.
 
 #include "block_merge_pass.h"
+#include "cfg_cleanup_pass.h"
 #include "common_uniform_elim_pass.h"
 #include "compact_ids_pass.h"
 #include "dead_branch_elim_pass.h"

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -183,3 +183,8 @@ add_spvtools_unittest(TARGET pass_strength_reduction
   SRCS strength_reduction_test.cpp pass_utils.cpp
   LIBS SPIRV-Tools-opt
 )
+
+add_spvtools_unittest(TARGET cfg_cleanup
+  SRCS cfg_cleanup_test.cpp pass_utils.cpp
+  LIBS SPIRV-Tools-opt
+)

--- a/test/opt/cfg_cleanup_test.cpp
+++ b/test/opt/cfg_cleanup_test.cpp
@@ -1,0 +1,448 @@
+// Copyright (c) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "pass_fixture.h"
+#include "pass_utils.h"
+
+namespace {
+
+using namespace spvtools;
+
+using CFGCleanupTest = PassTest<::testing::Test>;
+
+TEST_F(CFGCleanupTest, RemoveUnreachableBlocks) {
+  const std::string declarations = R"(OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %inf %outf4
+OpExecutionMode %main OriginUpperLeft
+OpSource GLSL 450
+OpName %main "main"
+OpName %inf "inf"
+OpName %outf4 "outf4"
+OpDecorate %inf Location 0
+OpDecorate %outf4 Location 0
+%void = OpTypeVoid
+%6 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%_ptr_Input_float = OpTypePointer Input %float
+%inf = OpVariable %_ptr_Input_float Input
+%float_2 = OpConstant %float 2
+%bool = OpTypeBool
+%v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%outf4 = OpVariable %_ptr_Output_v4float Output
+%float_n0_5 = OpConstant %float -0.5
+)";
+
+  const std::string body_before = R"(%main = OpFunction %void None %6
+%14 = OpLabel
+OpSelectionMerge %17 None
+OpBranch %18
+%19 = OpLabel
+%20 = OpLoad %float %inf
+%21 = OpCompositeConstruct %v4float %20 %20 %20 %20
+OpStore %outf4 %21
+OpBranch %17
+%18 = OpLabel
+%22 = OpLoad %float %inf
+%23 = OpFAdd %float %22 %float_n0_5
+%24 = OpCompositeConstruct %v4float %23 %23 %23 %23
+OpStore %outf4 %24
+OpBranch %17
+%17 = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  const std::string body_after = R"(%main = OpFunction %void None %6
+%14 = OpLabel
+OpSelectionMerge %15 None
+OpBranch %16
+%16 = OpLabel
+%20 = OpLoad %float %inf
+%21 = OpFAdd %float %20 %float_n0_5
+%22 = OpCompositeConstruct %v4float %21 %21 %21 %21
+OpStore %outf4 %22
+OpBranch %15
+%15 = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndCheck<opt::CFGCleanupPass>(
+      declarations + body_before, declarations + body_after, true, true);
+}
+
+TEST_F(CFGCleanupTest, RemoveDecorations) {
+  const std::string before = R"(
+                       OpCapability Shader
+                  %1 = OpExtInstImport "GLSL.std.450"
+                       OpMemoryModel Logical GLSL450
+                       OpEntryPoint Fragment %main "main"
+                       OpName %main "main"
+                       OpName %x "x"
+                       OpName %dead "dead"
+                       OpDecorate %x RelaxedPrecision
+                       OpDecorate %dead RelaxedPrecision
+               %void = OpTypeVoid
+                  %6 = OpTypeFunction %void
+              %float = OpTypeFloat 32
+%_ptr_Function_float = OpTypePointer Function %float
+            %float_2 = OpConstant %float 2
+            %float_4 = OpConstant %float 4
+
+               %main = OpFunction %void None %6
+                 %14 = OpLabel
+                  %x = OpVariable %_ptr_Function_float Function
+                       OpSelectionMerge %17 None
+                       OpBranch %18
+                 %19 = OpLabel
+               %dead = OpVariable %_ptr_Function_float Function
+                       OpStore %dead %float_2
+                       OpBranch %17
+                 %18 = OpLabel
+                       OpStore %x %float_4
+                       OpBranch %17
+                 %17 = OpLabel
+                       OpReturn
+                       OpFunctionEnd
+)";
+
+  const std::string after = R"(OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main"
+OpName %main "main"
+OpName %x "x"
+OpDecorate %x RelaxedPrecision
+%void = OpTypeVoid
+%6 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%_ptr_Function_float = OpTypePointer Function %float
+%float_2 = OpConstant %float 2
+%float_4 = OpConstant %float 4
+%main = OpFunction %void None %6
+%11 = OpLabel
+%x = OpVariable %_ptr_Function_float Function
+OpSelectionMerge %12 None
+OpBranch %13
+%13 = OpLabel
+OpStore %x %float_4
+OpBranch %12
+%12 = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndCheck<opt::CFGCleanupPass>(before, after, true, true);
+}
+
+
+TEST_F(CFGCleanupTest, UpdatePhis) {
+  const std::string before = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %y %outparm
+               OpName %main "main"
+               OpName %y "y"
+               OpName %outparm "outparm"
+               OpDecorate %y Flat
+               OpDecorate %y Location 0
+               OpDecorate %outparm Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+%_ptr_Input_int = OpTypePointer Input %int
+          %y = OpVariable %_ptr_Input_int Input
+     %int_10 = OpConstant %int 10
+       %bool = OpTypeBool
+     %int_42 = OpConstant %int 42
+     %int_23 = OpConstant %int 23
+      %int_5 = OpConstant %int 5
+%_ptr_Output_int = OpTypePointer Output %int
+    %outparm = OpVariable %_ptr_Output_int Output
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %11 = OpLoad %int %y
+               OpBranch %21
+         %16 = OpLabel
+         %20 = OpIAdd %int %11 %int_42
+               OpBranch %17
+         %21 = OpLabel
+         %24 = OpISub %int %11 %int_23
+               OpBranch %17
+         %17 = OpLabel
+         %31 = OpPhi %int %20 %16 %24 %21
+         %27 = OpIAdd %int %31 %int_5
+               OpStore %outparm %27
+               OpReturn
+               OpFunctionEnd
+)";
+
+  const std::string after = R"(OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %y %outparm
+OpName %main "main"
+OpName %y "y"
+OpName %outparm "outparm"
+OpDecorate %y Flat
+OpDecorate %y Location 0
+OpDecorate %outparm Location 0
+%void = OpTypeVoid
+%6 = OpTypeFunction %void
+%int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+%_ptr_Input_int = OpTypePointer Input %int
+%y = OpVariable %_ptr_Input_int Input
+%int_10 = OpConstant %int 10
+%bool = OpTypeBool
+%int_42 = OpConstant %int 42
+%int_23 = OpConstant %int 23
+%int_5 = OpConstant %int 5
+%_ptr_Output_int = OpTypePointer Output %int
+%outparm = OpVariable %_ptr_Output_int Output
+%main = OpFunction %void None %6
+%16 = OpLabel
+%17 = OpLoad %int %y
+OpBranch %18
+%18 = OpLabel
+%22 = OpISub %int %17 %int_23
+OpBranch %21
+%21 = OpLabel
+%23 = OpPhi %int %22 %18
+%24 = OpIAdd %int %23 %int_5
+OpStore %outparm %24
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndCheck<opt::CFGCleanupPass>(before, after, true, true);
+}
+
+TEST_F(CFGCleanupTest, RemoveNamedLabels) {
+  const std::string before = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main"
+               OpSource GLSL 430
+               OpName %main "main"
+               OpName %dead "dead"
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+       %main = OpFunction %void None %5
+          %6 = OpLabel
+               OpReturn
+       %dead = OpLabel
+               OpReturn
+               OpFunctionEnd)";
+
+    const std::string after = R"(OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Vertex %main "main"
+OpSource GLSL 430
+OpName %main "main"
+%void = OpTypeVoid
+%5 = OpTypeFunction %void
+%main = OpFunction %void None %5
+%6 = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndCheck<opt::CFGCleanupPass>(before, after, true, true);
+}
+
+TEST_F(CFGCleanupTest, RemovePhiArgsFromFarBlocks) {
+    const std::string before = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %y %outparm
+               OpName %main "main"
+               OpName %y "y"
+               OpName %outparm "outparm"
+               OpDecorate %y Flat
+               OpDecorate %y Location 0
+               OpDecorate %outparm Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+%_ptr_Input_int = OpTypePointer Input %int
+          %y = OpVariable %_ptr_Input_int Input
+     %int_42 = OpConstant %int 42
+%_ptr_Output_int = OpTypePointer Output %int
+    %outparm = OpVariable %_ptr_Output_int Output
+     %int_14 = OpConstant %int 14
+     %int_15 = OpConstant %int 15
+      %int_5 = OpConstant %int 5
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpBranch %40
+         %41 = OpLabel
+         %11 = OpLoad %int %y
+               OpBranch %40
+         %40 = OpLabel
+         %12 = OpLoad %int %y
+               OpSelectionMerge %16 None
+               OpSwitch %12 %16 10 %13 13 %14 18 %15
+         %13 = OpLabel
+               OpBranch %16
+         %14 = OpLabel
+               OpStore %outparm %int_14
+               OpBranch %16
+         %15 = OpLabel
+               OpStore %outparm %int_15
+               OpBranch %16
+         %16 = OpLabel
+         %30 = OpPhi %int %11 %41 %int_42 %13 %11 %14 %11 %15
+         %28 = OpIAdd %int %30 %int_5
+               OpStore %outparm %28
+               OpReturn
+               OpFunctionEnd)";
+
+    const std::string after = R"(OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %y %outparm
+OpName %main "main"
+OpName %y "y"
+OpName %outparm "outparm"
+OpDecorate %y Flat
+OpDecorate %y Location 0
+OpDecorate %outparm Location 0
+%void = OpTypeVoid
+%6 = OpTypeFunction %void
+%int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+%_ptr_Input_int = OpTypePointer Input %int
+%y = OpVariable %_ptr_Input_int Input
+%int_42 = OpConstant %int 42
+%_ptr_Output_int = OpTypePointer Output %int
+%outparm = OpVariable %_ptr_Output_int Output
+%int_14 = OpConstant %int 14
+%int_15 = OpConstant %int 15
+%int_5 = OpConstant %int 5
+%26 = OpUndef %int
+%main = OpFunction %void None %6
+%15 = OpLabel
+OpBranch %16
+%16 = OpLabel
+%19 = OpLoad %int %y
+OpSelectionMerge %20 None
+OpSwitch %19 %20 10 %21 13 %22 18 %23
+%21 = OpLabel
+OpBranch %20
+%22 = OpLabel
+OpStore %outparm %int_14
+OpBranch %20
+%23 = OpLabel
+OpStore %outparm %int_15
+OpBranch %20
+%20 = OpLabel
+%24 = OpPhi %int %int_42 %21 %26 %22 %26 %23
+%25 = OpIAdd %int %24 %int_5
+OpStore %outparm %25
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndCheck<opt::CFGCleanupPass>(before, after, true, true);
+}
+
+TEST_F(CFGCleanupTest, RemovePhiConstantArgs) {
+    const std::string before = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %y %outparm
+               OpName %main "main"
+               OpName %y "y"
+               OpName %outparm "outparm"
+               OpDecorate %y Flat
+               OpDecorate %y Location 0
+               OpDecorate %outparm Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Input_int = OpTypePointer Input %int
+          %y = OpVariable %_ptr_Input_int Input
+     %int_10 = OpConstant %int 10
+       %bool = OpTypeBool
+%_ptr_Function_int = OpTypePointer Function %int
+     %int_23 = OpConstant %int 23
+      %int_5 = OpConstant %int 5
+%_ptr_Output_int = OpTypePointer Output %int
+    %outparm = OpVariable %_ptr_Output_int Output
+         %24 = OpUndef %int
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpBranch %14
+         %40 = OpLabel
+          %9 = OpLoad %int %y
+         %12 = OpSGreaterThan %bool %9 %int_10
+               OpSelectionMerge %14 None
+               OpBranchConditional %12 %13 %14
+         %13 = OpLabel
+               OpBranch %14
+         %14 = OpLabel
+         %25 = OpPhi %int %24 %5 %int_23 %13
+         %20 = OpIAdd %int %25 %int_5
+               OpStore %outparm %20
+               OpReturn
+               OpFunctionEnd)";
+
+    const std::string after = R"(OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %y %outparm
+OpName %main "main"
+OpName %y "y"
+OpName %outparm "outparm"
+OpDecorate %y Flat
+OpDecorate %y Location 0
+OpDecorate %outparm Location 0
+%void = OpTypeVoid
+%6 = OpTypeFunction %void
+%int = OpTypeInt 32 1
+%_ptr_Input_int = OpTypePointer Input %int
+%y = OpVariable %_ptr_Input_int Input
+%int_10 = OpConstant %int 10
+%bool = OpTypeBool
+%_ptr_Function_int = OpTypePointer Function %int
+%int_23 = OpConstant %int 23
+%int_5 = OpConstant %int 5
+%_ptr_Output_int = OpTypePointer Output %int
+%outparm = OpVariable %_ptr_Output_int Output
+%15 = OpUndef %int
+%main = OpFunction %void None %6
+%16 = OpLabel
+OpBranch %17
+%17 = OpLabel
+%22 = OpPhi %int %15 %16
+%23 = OpIAdd %int %22 %int_5
+OpStore %outparm %23
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndCheck<opt::CFGCleanupPass>(before, after, true, true);
+}
+}  // anonymous namespace

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -192,6 +192,10 @@ Options:
                'spirv-opt --merge-blocks -O ...' applies the transformation
                --merge-blocks followed by all the transformations implied by
                -O.
+  --cfg-cleanup
+               Cleanup the control flow graph. This will remove any unnecessary
+               code from the CFG like unreachable code. Performed on entry
+               point call tree functions and exported functions.
   -h, --help
                Print this help.
   --version
@@ -369,6 +373,8 @@ OptStatus ParseFlags(int argc, const char** argv, Optimizer* optimizer,
         if (status.action != OPT_CONTINUE) {
           return status;
         }
+      } else if (0 == strcmp(cur_arg, "--cfg-cleanup")) {
+        optimizer->RegisterPass(CreateCFGCleanupPass());
       } else if ('\0' == cur_arg[1]) {
         // Setting a filename of "-" to indicate stdin.
         if (!*in_file) {


### PR DESCRIPTION
This change adds a new CFG cleanup pass to spirv-opt.  The intent of the pass is to act as a repository of a variety of common CFG cleanup actions (straightening, removal of unreachable code, etc).

It's my first change to SPIRV-Tools, so I'm sure it's full of inconsistencies and missing bits.  One of the things I've been thinking is that it may make sense to coalesce other existing CFG cleanup passes into this one in the hopes of reducing the number of CFG/IR traversals needed during cleanup.

Or, perhaps, it's preferable to keep these passes separate.  I understand that compile time is not an issue now, but I'm not sure if this might be challenging in the future (in my experience, this tends to be true at some point).

The code works and passes the trivial test I've added.  I need to add more, but I want a first review pass so I can learn preferred idioms and ways of structuring the code.

Thanks.