### PR TITLE
validator: OpModuleProcessed allowed in layout section 7c

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -62,6 +62,10 @@ bool IsInstructionInLayoutSection(ModuleLayoutSection layout, SpvOp op) {
         default: break;
       }
       break;
+    case kLayoutDebug3:
+      // Only OpModuleProcessed is allowed here.
+      out = (op == SpvOpModuleProcessed);
+      break;
     case kLayoutAnnotations:
       switch (op) {
         case SpvOpDecorate:
@@ -110,6 +114,7 @@ bool IsInstructionInLayoutSection(ModuleLayoutSection layout, SpvOp op) {
         case SpvOpString:
         case SpvOpName:
         case SpvOpMemberName:
+        case SpvOpModuleProcessed:
         case SpvOpDecorate:
         case SpvOpMemberDecorate:
         case SpvOpGroupDecorate:

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -46,6 +46,7 @@ enum ModuleLayoutSection {
   kLayoutExecutionMode,         /// < Section 2.4 #6
   kLayoutDebug1,                /// < Section 2.4 #7 > 1
   kLayoutDebug2,                /// < Section 2.4 #7 > 2
+  kLayoutDebug3,                /// < Section 2.4 #7 > 3
   kLayoutAnnotations,           /// < Section 2.4 #8
   kLayoutTypes,                 /// < Section 2.4 #9
   kLayoutFunctionDeclarations,  /// < Section 2.4 #10

--- a/source/validate_layout.cpp
+++ b/source/validate_layout.cpp
@@ -50,7 +50,7 @@ spv_result_t ModuleScopedInstructions(ValidationState_t& _,
         }
         break;
       case kLayoutFunctionDeclarations:
-        // All module sections have been processed. Recursivly call
+        // All module sections have been processed. Recursively call
         // ModuleLayoutPass to process the next section of the module
         return libspirv::ModuleLayoutPass(_, inst);
       default:
@@ -190,6 +190,7 @@ spv_result_t ModuleLayoutPass(ValidationState_t& _,
     case kLayoutExecutionMode:
     case kLayoutDebug1:
     case kLayoutDebug2:
+    case kLayoutDebug3:
     case kLayoutAnnotations:
     case kLayoutTypes:
       if (auto error = ModuleScopedInstructions(_, inst, opcode)) return error;


### PR DESCRIPTION
Recent spec fix from SPIR Working group:
  Allow OpModuleProcessed after debug names, but before any
  annotation instructions.