### PR TITLE
ExtractInsert: Handle rudimentary Composite ops

### DIFF
--- a/source/opt/insert_extract_elim.h
+++ b/source/opt/insert_extract_elim.h
@@ -52,6 +52,9 @@ class InsertExtractElimPass : public Pass {
   bool ExtInsConflict(
     const ir::Instruction* extInst, const ir::Instruction* insInst) const;
 
+  // Return true if |typeId| is a vector type
+  bool IsVectorType(uint32_t typeId);
+
   // Look for OpExtract on sequence of OpInserts in |func|. If there is an
   // insert with identical indices, replace the extract with the value
   // that is inserted if possible. Specifically, replace if there is no


### PR DESCRIPTION
This optimizes a single index extract whose composite value terminates with a
CompositeConstruct (or ConstantComposite) by evaluating to the correct
component. This was needed for opaque legalization.

This highlights the need/opportunity to improve this optimization to deal
with more complex composite expressions including currently handled ops
plus Null ops and special vector composition. A TODO has been added.