### PR TITLE
Add remaining opcodes to arithmetics validation

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -630,4 +630,24 @@ bool ValidationState_t::GetMatrixTypeInfo(
   return true;
 }
 
+bool ValidationState_t::GetStructMemberTypes(
+    uint32_t struct_type_id, std::vector<uint32_t>* member_types) const {
+  member_types->clear();
+  if (!struct_type_id)
+    return false;
+
+  const Instruction* inst = FindDef(struct_type_id);
+  assert(inst);
+  if (inst->opcode() != SpvOpTypeStruct)
+    return false;
+
+  *member_types = std::vector<uint32_t>(inst->words().cbegin() + 2,
+                                        inst->words().cend());
+
+ if (member_types->empty())
+   return false;
+
+  return true;
+}
+
 }  /// namespace libspirv

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -358,6 +358,12 @@ class ValidationState_t {
       uint32_t id, uint32_t* num_rows, uint32_t* num_cols,
       uint32_t* column_type, uint32_t* component_type) const;
 
+  // Collects struct member types into |member_types|.
+  // Returns false iff not struct type or has no members.
+  // Deletes prior contents of |member_types|.
+  bool GetStructMemberTypes(
+      uint32_t struct_type_id, std::vector<uint32_t>* member_types) const;
+
   // Returns true iff |id| is a type corresponding to the name of the function.
   // Only works for types not for objects.
   bool IsFloatScalarType(uint32_t id) const;


### PR DESCRIPTION
Add validation rules for:
- OpIAddCarry
- OpISubBorrow
- OpUMulExtended
- OpSMulExtended

Includes some refactoring of old code.