### PR TITLE
Validator: fix logicals pass for OpSelect pointers

### DIFF
--- a/source/validate_logicals.cpp
+++ b/source/validate_logicals.cpp
@@ -179,10 +179,11 @@ spv_result_t LogicalsPass(ValidationState_t& _,
         const SpvOp type_opcode = type_inst->opcode();
         switch (type_opcode) {
           case SpvOpTypePointer: {
-            if (!_.features().variable_pointers)
+            if (!_.features().variable_pointers &&
+                !_.features().variable_pointers_storage_buffer)
               return _.diag(SPV_ERROR_INVALID_DATA)
                   << "Using pointers with OpSelect requires capability "
-                  << "VariablePointers";
+                  << "VariablePointers or VariablePointersStorageBuffer";
             break;
           }
 

--- a/test/val/val_logicals_test.cpp
+++ b/test/val/val_logicals_test.cpp
@@ -570,10 +570,11 @@ OpStore %y %f32vec4_1234
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr(
-      "Using pointers with OpSelect requires capability VariablePointers"));
+      "Using pointers with OpSelect requires capability VariablePointers "
+      "or VariablePointersStorageBuffer"));
 }
 
-TEST_F(ValidateLogicals, OpSelectPointerWithCapability) {
+TEST_F(ValidateLogicals, OpSelectPointerWithCapability1) {
   const std::string body = R"(
 %x = OpVariable %f32vec4ptr Function
 %y = OpVariable %f32vec4ptr Function
@@ -584,6 +585,24 @@ OpStore %y %f32vec4_1234
 
   const std::string extra_cap_ext = R"(
 OpCapability VariablePointers
+OpExtension "SPV_KHR_variable_pointers"
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, extra_cap_ext).c_str());
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateLogicals, OpSelectPointerWithCapability2) {
+  const std::string body = R"(
+%x = OpVariable %f32vec4ptr Function
+%y = OpVariable %f32vec4ptr Function
+OpStore %x %f32vec4_0123
+OpStore %y %f32vec4_1234
+%val1 = OpSelect %f32vec4ptr %true %x %y
+)";
+
+  const std::string extra_cap_ext = R"(
+OpCapability VariablePointersStorageBuffer
 OpExtension "SPV_KHR_variable_pointers"
 )";
 


### PR DESCRIPTION
OpSelect works with pointers also when capability
VariablePointersStorageBuffer is declared (before worked only with
capability VariablePointers).