### PR TITLE
Avoid using global static variables

### DIFF
--- a/source/ext_inst.cpp
+++ b/source/ext_inst.cpp
@@ -23,33 +23,34 @@
 
 #include "macro.h"
 
-static const spv_ext_inst_desc_t glslStd450Entries_1_0[] = {
-#include "glsl.std.450.insts-1.0.inc"
-};
-
-static const spv_ext_inst_desc_t openclEntries_1_0[] = {
-#include "opencl.std.insts-1.0.inc"
-};
-
-static const spv_ext_inst_desc_t spv_amd_shader_explicit_vertex_parameter_entries[] = {
-#include "spv-amd-shader-explicit-vertex-parameter.insts.inc"
-};
-
-static const spv_ext_inst_desc_t spv_amd_shader_trinary_minmax_entries[] = {
-#include "spv-amd-shader-trinary-minmax.insts.inc"
-};
-
-static const spv_ext_inst_desc_t spv_amd_gcn_shader_entries[] = {
-#include "spv-amd-gcn-shader.insts.inc"
-};
-
-static const spv_ext_inst_desc_t spv_amd_shader_ballot_entries[] = {
-#include "spv-amd-shader-ballot.insts.inc"
-};
-
 spv_result_t spvExtInstTableGet(spv_ext_inst_table* pExtInstTable,
                                 spv_target_env env) {
   if (!pExtInstTable) return SPV_ERROR_INVALID_POINTER;
+
+  static const spv_ext_inst_desc_t glslStd450Entries_1_0[] = {
+#include "glsl.std.450.insts-1.0.inc"
+  };
+
+  static const spv_ext_inst_desc_t openclEntries_1_0[] = {
+#include "opencl.std.insts-1.0.inc"
+  };
+
+  static const spv_ext_inst_desc_t
+      spv_amd_shader_explicit_vertex_parameter_entries[] = {
+#include "spv-amd-shader-explicit-vertex-parameter.insts.inc"
+      };
+
+  static const spv_ext_inst_desc_t spv_amd_shader_trinary_minmax_entries[] = {
+#include "spv-amd-shader-trinary-minmax.insts.inc"
+  };
+
+  static const spv_ext_inst_desc_t spv_amd_gcn_shader_entries[] = {
+#include "spv-amd-gcn-shader.insts.inc"
+  };
+
+  static const spv_ext_inst_desc_t spv_amd_shader_ballot_entries[] = {
+#include "spv-amd-shader-ballot.insts.inc"
+  };
 
   static const spv_ext_inst_group_t groups_1_0[] = {
       {SPV_EXT_INST_TYPE_GLSL_STD_450, ARRAY_SIZE(glslStd450Entries_1_0),
@@ -57,13 +58,16 @@ spv_result_t spvExtInstTableGet(spv_ext_inst_table* pExtInstTable,
       {SPV_EXT_INST_TYPE_OPENCL_STD, ARRAY_SIZE(openclEntries_1_0),
        openclEntries_1_0},
       {SPV_EXT_INST_TYPE_SPV_AMD_SHADER_EXPLICIT_VERTEX_PARAMETER,
-       ARRAY_SIZE(spv_amd_shader_explicit_vertex_parameter_entries), spv_amd_shader_explicit_vertex_parameter_entries},
+       ARRAY_SIZE(spv_amd_shader_explicit_vertex_parameter_entries),
+       spv_amd_shader_explicit_vertex_parameter_entries},
       {SPV_EXT_INST_TYPE_SPV_AMD_SHADER_TRINARY_MINMAX,
-       ARRAY_SIZE(spv_amd_shader_trinary_minmax_entries), spv_amd_shader_trinary_minmax_entries},
+       ARRAY_SIZE(spv_amd_shader_trinary_minmax_entries),
+       spv_amd_shader_trinary_minmax_entries},
       {SPV_EXT_INST_TYPE_SPV_AMD_GCN_SHADER,
        ARRAY_SIZE(spv_amd_gcn_shader_entries), spv_amd_gcn_shader_entries},
       {SPV_EXT_INST_TYPE_SPV_AMD_SHADER_BALLOT,
-       ARRAY_SIZE(spv_amd_shader_ballot_entries), spv_amd_shader_ballot_entries},
+       ARRAY_SIZE(spv_amd_shader_ballot_entries),
+       spv_amd_shader_ballot_entries},
   };
 
   static const spv_ext_inst_table_t table_1_0 = {ARRAY_SIZE(groups_1_0),

--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -27,25 +27,25 @@
 #include "spirv_endian.h"
 
 namespace {
+struct OpcodeDescPtrLen {
+  const spv_opcode_desc_t* ptr;
+  uint32_t len;
+};
 
-// Descriptions of each opcode.  Each entry describes the format of the
-// instruction that follows a particular opcode.
-const spv_opcode_desc_t opcodeTableEntries_1_0[] = {
-#include "core.insts-1.0.inc"
-};
-const spv_opcode_desc_t opcodeTableEntries_1_1[] = {
-#include "core.insts-1.1.inc"
-};
-const spv_opcode_desc_t opcodeTableEntries_1_2[] = {
+OpcodeDescPtrLen getOpcodeTableEntries_1_2() {
+  static const spv_opcode_desc_t opcodeTableEntries_1_2[] = {
 #include "core.insts-1.2.inc"
-};
+  };
+
+  return {opcodeTableEntries_1_2, ARRAY_SIZE(opcodeTableEntries_1_2)};
+}
 
 // Represents a vendor tool entry in the SPIR-V XML Regsitry.
 struct VendorTool {
   uint32_t value;
   const char* vendor;
-  const char* tool; // Might be empty string.
-  const char* vendor_tool; // Combiantion of vendor and tool.
+  const char* tool;         // Might be empty string.
+  const char* vendor_tool;  // Combiantion of vendor and tool.
 };
 
 const VendorTool vendor_tools[] = {
@@ -82,12 +82,22 @@ spv_result_t spvOpcodeTableGet(spv_opcode_table* pInstTable,
                                spv_target_env env) {
   if (!pInstTable) return SPV_ERROR_INVALID_POINTER;
 
+  // Descriptions of each opcode.  Each entry describes the format of the
+  // instruction that follows a particular opcode.
+  static const spv_opcode_desc_t opcodeTableEntries_1_0[] = {
+#include "core.insts-1.0.inc"
+  };
+  static const spv_opcode_desc_t opcodeTableEntries_1_1[] = {
+#include "core.insts-1.1.inc"
+  };
+
+  const auto ptr_len = getOpcodeTableEntries_1_2();
+
   static const spv_opcode_table_t table_1_0 = {
       ARRAY_SIZE(opcodeTableEntries_1_0), opcodeTableEntries_1_0};
   static const spv_opcode_table_t table_1_1 = {
       ARRAY_SIZE(opcodeTableEntries_1_1), opcodeTableEntries_1_1};
-  static const spv_opcode_table_t table_1_2 = {
-      ARRAY_SIZE(opcodeTableEntries_1_2), opcodeTableEntries_1_2};
+  static const spv_opcode_table_t table_1_2 = {ptr_len.len, ptr_len.ptr};
 
   switch (env) {
     case SPV_ENV_UNIVERSAL_1_0:
@@ -173,10 +183,12 @@ void spvInstructionCopy(const uint32_t* words, const SpvOp opcode,
 const char* spvOpcodeString(const SpvOp opcode) {
   // Use the latest SPIR-V version, which should be backward-compatible with all
   // previous ones.
-  for (uint32_t i = 0; i < ARRAY_SIZE(opcodeTableEntries_1_2); ++i) {
-    if (opcodeTableEntries_1_2[i].opcode == opcode)
-      return opcodeTableEntries_1_2[i].name;
+  const auto entries = getOpcodeTableEntries_1_2();
+
+  for (uint32_t i = 0; i < entries.len; ++i) {
+    if (entries.ptr[i].opcode == opcode) return entries.ptr[i].name;
   }
+
   assert(0 && "Unreachable!");
   return "unknown";
 }

--- a/source/operand.cpp
+++ b/source/operand.cpp
@@ -20,30 +20,23 @@
 
 #include "macro.h"
 
-// Pull in operand info tables automatically generated from JSON grammar.
-namespace v1_0 {
-#include "operand.kinds-1.0.inc"
-}  // namespace v1_0
-namespace v1_1 {
-#include "operand.kinds-1.1.inc"
-}  // namespace v1_1
-namespace v1_2 {
-#include "operand.kinds-1.2.inc"
-}  // namespace v1_2
-
 spv_result_t spvOperandTableGet(spv_operand_table* pOperandTable,
                                 spv_target_env env) {
   if (!pOperandTable) return SPV_ERROR_INVALID_POINTER;
 
+#include "operand.kinds-1.0.inc"
+#include "operand.kinds-1.1.inc"
+#include "operand.kinds-1.2.inc"
+
   static const spv_operand_table_t table_1_0 = {
-      ARRAY_SIZE(v1_0::pygen_variable_OperandInfoTable),
-      v1_0::pygen_variable_OperandInfoTable};
+      ARRAY_SIZE(pygen_variable_OperandInfoTable_1_0),
+      pygen_variable_OperandInfoTable_1_0};
   static const spv_operand_table_t table_1_1 = {
-      ARRAY_SIZE(v1_1::pygen_variable_OperandInfoTable),
-      v1_1::pygen_variable_OperandInfoTable};
+      ARRAY_SIZE(pygen_variable_OperandInfoTable_1_1),
+      pygen_variable_OperandInfoTable_1_1};
   static const spv_operand_table_t table_1_2 = {
-      ARRAY_SIZE(v1_2::pygen_variable_OperandInfoTable),
-      v1_2::pygen_variable_OperandInfoTable};
+      ARRAY_SIZE(pygen_variable_OperandInfoTable_1_2),
+      pygen_variable_OperandInfoTable_1_2};
 
   switch (env) {
     case SPV_ENV_UNIVERSAL_1_0:
@@ -225,7 +218,7 @@ void spvPushOperandTypes(const spv_operand_type_t* types,
   for (endTypes = types; *endTypes != SPV_OPERAND_TYPE_NONE; ++endTypes)
     ;
   while (endTypes-- != types) {
-      pattern->push_back(*endTypes);
+    pattern->push_back(*endTypes);
   }
 }
 
@@ -235,7 +228,8 @@ void spvPushOperandTypesForMask(const spv_operand_table operandTable,
                                 spv_operand_pattern_t* pattern) {
   // Scan from highest bits to lowest bits because we will append in LIFO
   // fashion, and we need the operands for lower order bits to be consumed first
-  for (uint32_t candidate_bit = (1u << 31u); candidate_bit; candidate_bit >>= 1) {
+  for (uint32_t candidate_bit = (1u << 31u); candidate_bit;
+       candidate_bit >>= 1) {
     if (candidate_bit & mask) {
       spv_operand_desc entry = nullptr;
       if (SPV_SUCCESS == spvOperandTableValueLookup(operandTable, type,
@@ -304,16 +298,17 @@ spv_operand_type_t spvTakeFirstMatchableOperand(
 
 spv_operand_pattern_t spvAlternatePatternFollowingImmediate(
     const spv_operand_pattern_t& pattern) {
-
-  auto it = std::find(pattern.crbegin(), pattern.crend(), SPV_OPERAND_TYPE_RESULT_ID);
+  auto it =
+      std::find(pattern.crbegin(), pattern.crend(), SPV_OPERAND_TYPE_RESULT_ID);
   if (it != pattern.crend()) {
-    spv_operand_pattern_t alternatePattern(it - pattern.crbegin() + 2, SPV_OPERAND_TYPE_OPTIONAL_CIV);
+    spv_operand_pattern_t alternatePattern(it - pattern.crbegin() + 2,
+                                           SPV_OPERAND_TYPE_OPTIONAL_CIV);
     alternatePattern[1] = SPV_OPERAND_TYPE_RESULT_ID;
     return alternatePattern;
   }
 
   // No result-id found, so just expect CIVs.
-  return{ SPV_OPERAND_TYPE_OPTIONAL_CIV };
+  return {SPV_OPERAND_TYPE_OPTIONAL_CIV};
 }
 
 bool spvIsIdType(spv_operand_type_t type) {


### PR DESCRIPTION
Previously we have several grammar tables defined as global static
variables and these grammar table entries contains non-POD struct
fields (CapabilitySet/ExtensionSet). The initialization of these
non-POD struct fields may require calling operator new. If used
as a library and the caller defines its own operator new, things
can screw up.

This pull request changes all global static variables into
function static variables, which is lazy evaluated in a thread
safe way as guaranteed by C++11.