### PR TITLE
DiagnosticStream move ctor moves output duties to new object

### DIFF
--- a/source/diagnostic.cpp
+++ b/source/diagnostic.cpp
@@ -17,6 +17,7 @@
 #include <cassert>
 #include <cstring>
 #include <iostream>
+#include <sstream>
 
 #include "table.h"
 
@@ -65,6 +66,19 @@ spv_result_t spvDiagnosticPrint(const spv_diagnostic diagnostic) {
 }
 
 namespace libspirv {
+
+DiagnosticStream::DiagnosticStream(DiagnosticStream&& other)
+    : stream_(),
+      position_(other.position_),
+      consumer_(other.consumer_),
+      error_(other.error_) {
+  // Prevent the other object from emitting output during destruction.
+  other.error_ = SPV_FAILED_MATCH;
+  // Some platforms are missing support for std::ostringstream functionality,
+  // including:  move constructor, swap method.  Either would have been a
+  // better choice than copying the string.
+  stream_ << other.stream_.str();
+}
 
 DiagnosticStream::~DiagnosticStream() {
   if (error_ != SPV_FAILED_MATCH && consumer_ != nullptr) {

--- a/source/diagnostic.h
+++ b/source/diagnostic.h
@@ -33,12 +33,14 @@ class DiagnosticStream {
                    spv_result_t error)
       : position_(position), consumer_(consumer), error_(error) {}
 
-  DiagnosticStream(DiagnosticStream&& other)
-      : stream_(other.stream_.str()),
-        position_(other.position_),
-        consumer_(other.consumer_),
-        error_(other.error_) {}
+  // Creates a DiagnosticStream from an expiring DiagnosticStream.
+  // The new object takes the contents of the other, and prevents the
+  // other from emitting anything during destruction.
+  DiagnosticStream(DiagnosticStream&& other);
 
+  // Destroys a DiagnosticStream.
+  // If its status code is something other than SPV_FAILED_MATCH
+  // then emit the accumulated message to the consumer.
   ~DiagnosticStream();
 
   // Adds the given value to the diagnostic message to be written.
@@ -52,9 +54,9 @@ class DiagnosticStream {
   operator spv_result_t() { return error_; }
 
  private:
-  std::stringstream stream_;
+  std::ostringstream stream_;
   spv_position_t position_;
-  const spvtools::MessageConsumer& consumer_;  // Message consumer callback.
+  spvtools::MessageConsumer consumer_;  // Message consumer callback.
   spv_result_t error_;
 };
 


### PR DESCRIPTION
… object

- Take over contents of the expiring message stream
- Prevent the expiring object from emitting anything during destruction