### PR TITLE
WIP built-ins tests and validation

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -259,6 +259,7 @@ set(SPIRV_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/validate_capability.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/validate_datarules.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/validate_decorations.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/validate_builtins.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/validate_id.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/validate_instruction.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/validate_layout.cpp

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -296,6 +296,7 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
   if (auto error = UpdateIdUse(*vstate)) return error;
   if (auto error = CheckIdDefinitionDominateUse(*vstate)) return error;
   if (auto error = ValidateDecorations(*vstate))  return error;
+  if (auto error = ValidateBuiltIns(*vstate))  return error;
 
   // Entry point validation. Based on 2.16.1 (Universal Validation Rules) of the
   // SPIRV spec:

--- a/source/validate.h
+++ b/source/validate.h
@@ -105,6 +105,9 @@ spv_result_t InstructionPass(ValidationState_t& _,
 /// Performs decoration validation.
 spv_result_t ValidateDecorations(ValidationState_t& _);
 
+/// Performs built-ins validation.
+spv_result_t ValidateBuiltIns(ValidationState_t& _);
+
 /// Validates that type declarations are unique, unless multiple declarations
 /// of the same data type are allowed by the specification.
 /// (see section 2.8 Types and Variables)

--- a/source/validate_builtins.cpp
+++ b/source/validate_builtins.cpp
@@ -21,6 +21,7 @@
 #include "opcode.h"
 #include "val/validation_state.h"
 
+using std::string;
 using libspirv::Decoration;
 using libspirv::DiagnosticStream;
 using libspirv::Instruction;
@@ -28,22 +29,40 @@ using libspirv::ValidationState_t;
 
 namespace { // utils
 
-bool isIncludedIn(uint32_t elem, std::vector<uint32_t> vec) {
-  return std::find(vec.begin(),vec.end(),elem) != vec.end();  
+struct ElemType {
+  SpvOp type; // Elemental type (e.g. int, float, bool)
+  int bits; // Bits number (e.g. 32, 16, 64), 0 means any number
+  int sign; // Signedness (0=unsigned, 1=signed, -1=no applicable)
+
+  ElemType(SpvOp type_, int bits_=0, int sign_=-1)
+    : type(type_), bits(bits_), sign(sign_) { }
+};
+
+struct CompType {
+  SpvOp type; // Composed type (e.g. vector, array)
+  int size; // Number of components, 0 means any number
+
+  CompType(SpvOp type_=SpvOpNop, int size_=0)
+    : type(type_), size(size_) { }
+};
+
+// Returns true if |elem| is in the given vector
+bool IsIncluded(uint32_t elem, const std::vector<uint32_t>& vec) {
+  return std::find(vec.begin(), vec.end(), elem) != vec.end();  
 }
 
-// Returns whether the given instruction has a BuiltIn decoration
-bool isBuiltIn(Instruction inst, ValidationState_t& vstate) {
-  const auto& decorations = vstate.id_decorations(inst.id());
+// Returns true if |inst| presents a BuiltIn decoration
+bool IsBuiltIn(const Instruction* inst, ValidationState_t& vstate) {
+  const auto& decorations = vstate.id_decorations(inst->id());
   return std::any_of(
       decorations.begin(), decorations.end(), [](const Decoration& d) {
         return SpvDecorationBuiltIn == d.dec_type();
       });
 }
 
-// Returns the SpvBuiltIn_enum of the first BuiltIn decoration of a instruction
-uint32_t getBuiltInEnum(Instruction inst, ValidationState_t& vstate) {
-  const auto& decorations = vstate.id_decorations(inst.id());
+// Returns the SpvBuiltIn enum of the first BuiltIn decoration of |inst|
+uint32_t GetBuiltInEnum(const Instruction* inst, ValidationState_t& vstate) {
+  const auto& decorations = vstate.id_decorations(inst->id());
   auto it = std::find_if(
       decorations.begin(), decorations.end(), [](const Decoration& d) {
         return SpvDecorationBuiltIn == d.dec_type();
@@ -52,121 +71,153 @@ uint32_t getBuiltInEnum(Instruction inst, ValidationState_t& vstate) {
   return it->params()[0];
 }
 
-// Returns the Storage class of the instruction
-uint32_t getStorageClass(Instruction inst) {
-  switch (inst.opcode()) {
-    case SpvOpTypePointer: return inst.words()[2];
-    case SpvOpTypeForwardPointer: return inst.words()[2];
-    case SpvOpVariable: return inst.words()[3];
-    case SpvOpGenericCastToPtrExplicit: return inst.words()[4];
+// Returns the Storage Class of the instruction |inst|
+uint32_t GetStorageClass(const Instruction* inst) {
+  switch (inst->opcode()) {
+    case SpvOpTypePointer: return inst->word(2);
+    case SpvOpTypeForwardPointer: return inst->word(2);
+    case SpvOpVariable: return inst->word(3);
+    case SpvOpGenericCastToPtrExplicit: return inst->word(4);
     default: return SpvStorageClassMax;
   }
 }
 
-// TODO(jcaraban): how to find the entry_points in a more direct way?
-// Returns the execution models of the entry points linked to the builtin
-std::vector<uint32_t> getExecutionModels(
-      ValidationState_t& vstate, Instruction inst) {
-  std::vector<uint32_t> exec_vec;
+std::vector<const Instruction*> getEntryPoints(
+      ValidationState_t& vstate, const Instruction* inst) {
+  std::vector<const Instruction*> entry_vec;
   // Walks the entry functions in the module
   for (auto entry_func : vstate.entry_points()) {
-    const auto &interfaces = vstate.entry_point_interfaces(entry_func);
-    // Filtering those interfacing the built-in of interest
-    if (isIncludedIn(inst.id(),interfaces)) {
-      auto func_inst = vstate.FindDef(entry_func);
+    const auto& interfaces = vstate.entry_point_interfaces(entry_func);
+    // Filters those interfacing the instruction of interest
+    if (IsIncluded(inst->id(),interfaces)) {
+      auto* func_inst = vstate.FindDef(entry_func);
       assert(func_inst);
-      // The entry function uses link to the entry points
+      // The entry function use-chains reveal the entry points
       for (auto pair : func_inst->uses()) {
         auto entry_point = pair.first;
         if (entry_point->opcode() == SpvOpEntryPoint) {
-          // The entry points contain the execution model
-          auto exec_model = entry_point->words()[1];
-          exec_vec.push_back(exec_model);
+          entry_vec.push_back(entry_point);
         }
       }
     }
   }
-  return exec_vec;
+  return entry_vec;
 }
 
-// Ensures the excution model is included in the list of compatible models
-spv_result_t checkExecutionModel(ValidationState_t& vstate,
-      uint32_t exec_model, std::vector<uint32_t> models) {
-  if (not isIncludedIn(exec_model,models)) {
-    return vstate.diag(SPV_ERROR_INVALID_ID)
-        << "Built-in variables are restricted to only certain"
-           "EXECUTION MODELS (see e.g. Vulkan specification)";
+// Returns the execution models of the entry points interfacing |inst|
+std::vector<uint32_t> getExecutionModels(
+      ValidationState_t& vstate, const Instruction* inst) {
+  // Gets and walks the entry points of |inst|
+  auto entry_vec = getEntryPoints(vstate,inst);
+  std::vector<uint32_t> model_vec;
+  for (auto entry_point : entry_vec) {
+    uint32_t exec_model = entry_point->word(1);
+    // Accumulates the execution models
+    model_vec.push_back(exec_model);
+  }
+  return model_vec;
+}
+
+// Returns the execution modes of the given |entry_point|
+#if 0
+std::vector<uint32_t> getExecutionModes(const Instruction* entry_point) {
+  // Follows the use-chains to the execution modes
+  std::vector<uint32_t> mode_vec;
+  for (auto pair : entry_point->uses()) {
+    auto mode_inst = pair.first;
+    if (mode_inst->opcode() == SpvOpExecutionMode) {
+      uint32_t exec_mode = mode_inst->word(2);
+      // Accumulates the execution modes of the entry
+      mode_vec.push_back(exec_mode);
+    }
+  }
+  return mode_vec;
+}
+#endif
+
+// Ensures |exec_model| is included in the list of compatible |models|
+spv_result_t CheckExecutionModel(ValidationState_t& vstate, const string& name,
+      uint32_t exec_model, const std::vector<uint32_t>& models) {
+  if (not IsIncluded(exec_model, models)) {
+    return vstate.diag(SPV_ERROR_INVALID_ID) << name
+        << " built-in is restricted to certain EXECUTION MODELS"
+           " (see SPIR-V, Vulkan, OpenGL, OpenCL specifications)";
   }
   return SPV_SUCCESS;
 }
 
-// Ensures the pair 'exec_model','storage_class' are compatible
-spv_result_t checkStorageClass(ValidationState_t& vstate,
-      uint32_t exec_model, uint32_t storage_class,
-      std::vector<uint32_t> models, std::vector<uint32_t> storages)
-{
-  // If 'exec_model' is included the list of 'models'
-  if (isIncludedIn(exec_model,models)) {
+// Ensures the pair |exec_model,storage_class| are compatible
+spv_result_t CheckStorageClass(ValidationState_t& vstate,
+      const string& name, uint32_t exec_model, uint32_t storage_class,
+      std::vector<uint32_t> models, std::vector<uint32_t> storages) {
+  // If 'exec_model' is included in the list of 'models'
+  if (IsIncluded(exec_model, models)) {
     // But 'storage_class' is not one of the compatible 'storages'
-    if (not isIncludedIn(storage_class,storages)) {
-      return vstate.diag(SPV_ERROR_INVALID_ID)
-          << "Built-in variables must match the STORAGE CLASS "
-             "of the built-in (see e.g. Vulkan specification)";
+    if (not IsIncluded(storage_class, storages)) {
+      return vstate.diag(SPV_ERROR_INVALID_ID) << name
+          << " built-in is restricted to certain STORAGE CLASSES,"
+             " depending on the execution model (see SPIR-V spec)";
     }
   }
   return SPV_SUCCESS;
 }
 
-// Ensures the variable type matches the built-in type
-spv_result_t checkBuiltInType(ValidationState_t& vstate, Instruction inst,
-      SpvOp elem_type, SpvOp comp_type=SpvOpNop, uint32_t comp_size=0)
-{
+// Ensures the variable type matches the built-in type, which could be an
+// elemental type (e.g. int, float) or composed (e.g. 4-componets vector)
+spv_result_t CheckBuiltInType(ValidationState_t& vstate,
+      const string& name, const Instruction* inst,
+      ElemType elem, CompType comp=CompType()) {
+  // Lambda returning the personalized type error
   auto error = [&](ValidationState_t& state) -> spv_result_t {
-    return state.diag(SPV_ERROR_INVALID_ID)
-        << "Built-in variables must match the DATA TYPE "
-           "of the built-in (see e.g. Vulkan specification)";
+    return state.diag(SPV_ERROR_INVALID_ID) << name
+        << " built-in must match the DATA TYPE defined"
+           " in the specification (see SPIR-V specification)";
   };
-  auto *curr_inst = &inst;
   // Gets instruction type
-  curr_inst = vstate.FindDef(curr_inst->type_id());
-  assert(curr_inst);
+  inst = vstate.FindDef(inst->type_id());
+  assert(inst);
   // The built-in variable must be of OpType Pointer
-  if (curr_inst->opcode() != SpvOpTypePointer) {
+  if (inst->opcode() != SpvOpTypePointer) {
     return error(vstate);
   }
-  // The Pointer type is stored in its 3rd word
-  curr_inst = vstate.FindDef(curr_inst->words()[3]);
-  assert(curr_inst);
+  // The type pointed to is given in word 3
+  inst = vstate.FindDef(inst->word(3));
+  assert(inst);
   // If the type is composed (i.e. Vector or Array)
-  if (comp_type != SpvOpNop) {
+  if (comp.type != SpvOpNop) {
     // It must match the composed type...
-    if (curr_inst->opcode() != comp_type) {
+    if (inst->opcode() != comp.type) {
       return error(vstate);
     }
     // ... and it must match the number of components / size
-    uint32_t size;
-    if (comp_type == SpvOpTypeVector) { // size as literal
-      size = curr_inst->words()[3];
-    } else if (comp_type == SpvOpTypeArray) { // size as constant
-      auto *size_inst = vstate.FindDef(curr_inst->words()[3]);
-      assert(size_inst);
-      size = size_inst->words()[3];
-      // if comp_size = 0, any size is ok
-      size = (comp_size == 0) ? 0 : size;
+    int size = -1;
+    if (comp.type == SpvOpTypeVector) { // size as literal
+      uint32_t literal = inst->word(3);
+      size = static_cast<int>(literal);
+    } else if (comp.type == SpvOpTypeArray) { // size as constant
+      auto* const_inst = vstate.FindDef(inst->word(3));
+      assert(const_inst);
+      uint32_t literal = const_inst->word(3);
+      size = static_cast<int>(literal);
     } else {
       assert(false);
     }
-    if (size != comp_size) {
-      return error(vstate);
-    }
-    // Gets primitive type
-    curr_inst = vstate.FindDef(curr_inst->words()[2]);
-    assert(curr_inst);
+    if (comp.size != 0) // 0 = any size ok
+      if (size != comp.size)
+        return error(vstate);
+    // Gets elemental type
+    inst = vstate.FindDef(inst->word(2));
+    assert(inst);
   }
-  // Composed or not, it must match the primitive type
-  if (curr_inst->opcode() != elem_type) {
+  // Composed or not, it must match the elemental type...
+  if (inst->opcode() != elem.type) {
     return error(vstate);
   }
+  // ... and it must match the number of bits
+  int size = static_cast<int>(inst->word(2));
+  if (elem.bits != 0) // 0 = any bits size ok
+    if (size != elem.bits)
+      return error(vstate);
   return SPV_SUCCESS;
 }
 
@@ -174,9 +225,10 @@ spv_result_t checkBuiltInType(ValidationState_t& vstate, Instruction inst,
 
 namespace { // built-in checks
 
-spv_result_t CheckPosition(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckPosition(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "Position";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // The Position decoration must be used only within vertex, tessellation
@@ -185,14 +237,14 @@ spv_result_t CheckPosition(ValidationState_t& vstate, Instruction inst,
                SpvExecutionModelTessellationControl,
                SpvExecutionModelTessellationEvaluation,
                SpvExecutionModelGeometry };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
   // In a vertex shader, any variable decorated with Position 
   // must be declared using the Output storage class.
   exec_vec = { SpvExecutionModelVertex };
   stor_vec = { SpvStorageClassOutput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
   
   // In a tessellation control, tessellation evaluation, or geometry shader,
@@ -203,23 +255,23 @@ spv_result_t CheckPosition(ValidationState_t& vstate, Instruction inst,
                SpvExecutionModelGeometry };
   stor_vec = { SpvStorageClassInput,
                SpvStorageClassOutput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
   // Any variable decorated with Position must be declared as a
   // four-component vector of 32-bit floating-point values.
-  SpvOp elem_type = SpvOpTypeFloat;
-  SpvOp comp_type = SpvOpTypeVector;
-  uint32_t comp_size = 4;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+  ElemType elem = { SpvOpTypeFloat, 32 };
+  CompType comp = { SpvOpTypeVector, 4 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp))
     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckPointSize(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckPointSize(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "PointSize";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // The Position decoration must be used only within vertex, tessellation
@@ -228,14 +280,14 @@ spv_result_t CheckPointSize(ValidationState_t& vstate, Instruction inst,
                SpvExecutionModelTessellationControl,
                SpvExecutionModelTessellationEvaluation,
                SpvExecutionModelGeometry };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
   // In a vertex shader, any variable decorated with Position 
   // must be declared using the Output storage class.
   exec_vec = { SpvExecutionModelVertex };
   stor_vec = { SpvStorageClassOutput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
   
   // In a tessellation control, tessellation evaluation, or geometry shader,
@@ -246,21 +298,22 @@ spv_result_t CheckPointSize(ValidationState_t& vstate, Instruction inst,
                SpvExecutionModelGeometry };
   stor_vec = { SpvStorageClassInput,
                SpvStorageClassOutput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
   // Any variable decorated with PointSize must be declared as a
   // scalar 32-bit floating-point value.
-  SpvOp elem_type = SpvOpTypeFloat;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type))
-    return error;
+  ElemType elem = { SpvOpTypeFloat, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckClipDistance(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckClipDistance(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {  
+  const string name = "ClipDistance";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // The ClipDistance decoration must be used only within vertex, fragment,
@@ -270,21 +323,21 @@ spv_result_t CheckClipDistance(ValidationState_t& vstate, Instruction inst,
                SpvExecutionModelTessellationControl,
                SpvExecutionModelTessellationEvaluation,
                SpvExecutionModelGeometry };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
   // In vertex shaders, any variable decorated with ClipDistance
   // must be declared using the Output storage class.
   exec_vec = { SpvExecutionModelVertex };
   stor_vec = { SpvStorageClassOutput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
   // In fragment shaders, any variable decorated with ClipDistance
   // must be declared using the Input storage class.
   exec_vec = { SpvExecutionModelFragment };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
   // In tessellation control, tessellation evaluation, or geometry shaders,
@@ -295,23 +348,23 @@ spv_result_t CheckClipDistance(ValidationState_t& vstate, Instruction inst,
                SpvExecutionModelGeometry };
   stor_vec = { SpvStorageClassInput,
                 SpvStorageClassOutput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
   // Any variable decorated with ClipDistance must be declared as
   // an array of 32-bit floating-point values.
-  SpvOp elem_type = SpvOpTypeFloat;
-  SpvOp comp_type = SpvOpTypeArray;
-  uint32_t comp_size = 0; // any size
-  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+  ElemType elem = { SpvOpTypeFloat, 32 };
+  CompType comp = { SpvOpTypeArray };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp))
     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckCullDistance(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckCullDistance(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "CullDistance";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // The CullDistance decoration must be used only within vertex, fragment,
@@ -321,21 +374,21 @@ spv_result_t CheckCullDistance(ValidationState_t& vstate, Instruction inst,
                SpvExecutionModelTessellationControl,
                SpvExecutionModelTessellationEvaluation,
                SpvExecutionModelGeometry };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
   // In vertex shaders, any variable decorated with CullDistance
   // must be declared using the Output storage class.
   exec_vec = { SpvExecutionModelVertex };
   stor_vec = { SpvStorageClassOutput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
   // In fragment shaders, any variable decorated with CullDistance
   // must be declared using the Input storage class.
   exec_vec = { SpvExecutionModelFragment };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
   // In tessellation control, tessellation evaluation, or geometry shaders,
@@ -346,71 +399,73 @@ spv_result_t CheckCullDistance(ValidationState_t& vstate, Instruction inst,
                SpvExecutionModelGeometry };
   stor_vec = { SpvStorageClassInput,
                 SpvStorageClassOutput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
   // Any variable decorated with CullDistance must be declared as
   // an array of 32-bit floating-point values.
-  SpvOp elem_type = SpvOpTypeFloat;
-  SpvOp comp_type = SpvOpTypeArray;
-  uint32_t comp_size = 0; // any size
-  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+  ElemType elem = { SpvOpTypeFloat, 32 };
+  CompType comp = { SpvOpTypeArray };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp))
     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckVertexId(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckVertexId(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "VertexId";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // The VertexId decoration must be used only within vertex shaders
   exec_vec = { SpvExecutionModelVertex };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
   // VertexId requires Vertex execution and Input storage class.
   exec_vec = { SpvExecutionModelVertex };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
     
   // VertexId must be declared as a scalar 32-bit integer.
-  SpvOp elem_type = SpvOpTypeInt;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type))
-    return error;
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckInstanceId(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckInstanceId(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "InstanceId";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // The InstanceId decoration must be used only within vertex shaders
   exec_vec = { SpvExecutionModelVertex };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
   // InstanceId requires Vertex execution and Input storage class.
   exec_vec = { SpvExecutionModelVertex };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
     
   // InstanceId must be declared as a scalar 32-bit integer.
-  SpvOp elem_type = SpvOpTypeFloat;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type))
-    return error;
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckPrimitiveId(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckPrimitiveId(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "PrimitiveId";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // If a geometry shader is present and the fragment shader reads from
@@ -418,7 +473,7 @@ spv_result_t CheckPrimitiveId(ValidationState_t& vstate, Instruction inst,
   // shader must write to an output variable decorated with PrimitiveId
   // in all execution paths.
 
-  // TODO (jcaraban)
+  // TODO (jcaraban): shall we check the above? how?
 
   // The PrimitiveId decoration must be used only within fragment,
   // tessellation control, tessellation evaluation, and geometry shaders.
@@ -426,16 +481,15 @@ spv_result_t CheckPrimitiveId(ValidationState_t& vstate, Instruction inst,
                SpvExecutionModelTessellationControl,
                SpvExecutionModelTessellationEvaluation,
                SpvExecutionModelGeometry };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
   // In a tessellation control or tessellation evaluation shader,
-  // any variable decorated with PrimitiveId must be declared
-  // using the Output storage class.
+  // any variable decorated with PrimitiveId must be declared using the Output storage class.
   exec_vec = { SpvExecutionModelTessellationControl,
                SpvExecutionModelTessellationEvaluation };
   stor_vec = { SpvStorageClassOutput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
   // In a geometry shader, any variable decorated with PrimitiveId must
@@ -443,22 +497,22 @@ spv_result_t CheckPrimitiveId(ValidationState_t& vstate, Instruction inst,
   exec_vec = { SpvExecutionModelGeometry };
   stor_vec = { SpvStorageClassInput,
                SpvStorageClassOutput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
   // In fragment shaders, any variable decorated with PrimitiveId
   // must be declared using the Input storage class ...
   exec_vec = { SpvExecutionModelFragment };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
     
   // ... and either the Geometry or Tessellation capability must also be declared.
 
-  // TODO(jcaraban): this part is covered by 'validate_instructions.cpp',
-  //                 but shouldn't it be treated in the built-ins file?
+  // TODO(jcaraban): this seems to be covered by 'validate_instructions.cpp',
+  //                 should it be tested in validate_builtins.cpp instead?
 
-  /*
+  #if 0
   if (not vstate.HasCapability(SpvCapabilityGeometry) &&
       not vstate.HasCapability(SpvCapabilityTessellation)) {
     return vstate.diag(SPV_ERROR_INVALID_ID)
@@ -466,917 +520,1707 @@ spv_result_t CheckPrimitiveId(ValidationState_t& vstate, Instruction inst,
            "PrimitiveId must be declared using the Input storage "
            "class, and either the Geometry or Tessellation "
            "capability must also be declared.";
-  }*/
+  }
+  #endif
 
-  // Any variable decorated with PrimitiveId must be declared as
-  // a scalar 32-bit integer.
-  SpvOp elem_type = SpvOpTypeInt;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type))
-    return error;
+  // PrimitiveId must be declared as a scalar 32-bit integer.
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+     return error;
 
   return SPV_SUCCESS; 
 }
 
-spv_result_t CheckInvocationId(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckInvocationId(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "InvocationId";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // The InvocationId decoration must be used only within
   // tessellation control and geometry shaders.
   exec_vec = { SpvExecutionModelTessellationControl,
                SpvExecutionModelGeometry };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
-  // The variable decorated with InvocationId must be declared
-  // using the Input storage class.
+  // InvocationId must be declared using the Input storage class.
   exec_vec = { SpvExecutionModelTessellationControl,
                SpvExecutionModelGeometry };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
-  // The variable decorated with InvocationId must be declared as
-  // a scalar 32-bit integer.
-  SpvOp elem_type = SpvOpTypeInt;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type))
-    return error;
+  // InvocationId must be declared as a scalar 32-bit integer.
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckLayer(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckLayer(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "Layer";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // If a vertex processing stage shader entry point’s interface includes a
   // variable decorated with Layer, it must write the same value to Layer
   // for all output vertices of a given primitive.
 
-  // TODO ?
+  // TODO(jcaraban): can this be checked here? how?
+
+  // Layer may also be used as output in the Vertex and Tessellation
+  // Execution Models under the ShaderViewportIndexLayerNV capability.
+  bool capable = vstate.HasCapability(SpvCapabilityShaderViewportIndexLayerNV);
 
   // The Layer decoration must be used only with geometry and fragment shaders
   exec_vec = { SpvExecutionModelGeometry,
                SpvExecutionModelFragment };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (capable) {
+    exec_vec.push_back( SpvExecutionModelVertex );
+    exec_vec.push_back( SpvExecutionModelTessellationControl );
+    exec_vec.push_back( SpvExecutionModelTessellationEvaluation );
+  }
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
   // In a geometry shader, any variable decorated with Layer
   // must be declared using the Output storage class.
   exec_vec = { SpvExecutionModelGeometry };
+  if (capable) {
+    exec_vec.push_back( SpvExecutionModelVertex );
+    exec_vec.push_back( SpvExecutionModelTessellationControl );
+    exec_vec.push_back( SpvExecutionModelTessellationEvaluation );
+  }
   stor_vec = { SpvStorageClassOutput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
   // In a fragment shader, any variable decorated with Layer
   // must be declared using the Input storage class.
   exec_vec = { SpvExecutionModelFragment };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
-  // Any variable decorated with Layer must be declared as
-  // a scalar 32-bit integer.
-  SpvOp elem_type = SpvOpTypeInt;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type))
-    return error;
+  // Layer must be declared as a scalar 32-bit integer.
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckViewportIndex(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckViewportIndex(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "ViewportIndex";
   std::vector<uint32_t> exec_vec, stor_vec;
 
+  // ViewportIndex may also be used as output in the Vertex and Tessellation
+  // Execution Models under the ShaderViewportIndexLayerNV capability.
+  bool capable = vstate.HasCapability(SpvCapabilityShaderViewportIndexLayerNV);
+  
   // The ViewportIndex decoration must be used only within
   // geometry, and fragment shaders.
   exec_vec = { SpvExecutionModelGeometry,
                SpvExecutionModelFragment };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (capable) {
+    exec_vec.push_back( SpvExecutionModelVertex );
+    exec_vec.push_back( SpvExecutionModelTessellationControl );
+    exec_vec.push_back( SpvExecutionModelTessellationEvaluation );
+  }
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
   // In a geometry shader, any variable decorated with ViewportIndex
   // must be declared using the Output storage class.
   exec_vec = { SpvExecutionModelGeometry };
+  if (capable) {
+    exec_vec.push_back( SpvExecutionModelVertex );
+    exec_vec.push_back( SpvExecutionModelTessellationControl );
+    exec_vec.push_back( SpvExecutionModelTessellationEvaluation );
+  }
   stor_vec = { SpvStorageClassOutput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
   // In a fragment shader, any variable decorated with ViewportIndex
   // must be declared using the Input storage class.
   exec_vec = { SpvExecutionModelFragment };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
     
-  // Any variable decorated with ViewportIndex must be declared as
-  // a scalar 32-bit integer.
-  SpvOp elem_type = SpvOpTypeInt;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type))
-    return error;
+  // ViewportIndex must be declared as a scalar 32-bit integer.
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckTessLevelOuter(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckTessLevelOuter(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "TessLevelOuter";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // The TessLevelOuter decoration must be used only within
   // tessellation control and tessellation evaluation shaders.
   exec_vec = { SpvExecutionModelTessellationControl,
                SpvExecutionModelTessellationEvaluation };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
   // In a tessellation control shader, any variable decorated with
   // TessLevelOuter must be declared using the Output storage class.
   exec_vec = { SpvExecutionModelTessellationControl };
   stor_vec = { SpvStorageClassOutput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
   // In a tessellation evaluation shader, any variable decorated with
   // TessLevelOuter must be declared using the Input storage class.
   exec_vec = { SpvExecutionModelTessellationEvaluation };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
   // Any variable decorated with TessLevelOuter must be declared as
   // an array of size four, containing 32-bit floating-point values.
-  SpvOp elem_type = SpvOpTypeFloat;
-  SpvOp comp_type = SpvOpTypeArray;
-  uint32_t comp_size = 4;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+  ElemType elem = { SpvOpTypeFloat, 32 };
+  CompType comp = { SpvOpTypeArray, 4 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp))
     return error; 
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckTessLevelInner(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckTessLevelInner(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "TessLevelInner";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // The TessLevelInner decoration must be used only within
   // tessellation control and tessellation evaluation shaders.
   exec_vec = { SpvExecutionModelTessellationControl,
                SpvExecutionModelTessellationEvaluation };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
   // In a tessellation control shader, any variable decorated with
   // TessLevelInner must be declared using the Output storage class.
   exec_vec = { SpvExecutionModelTessellationControl };
   stor_vec = { SpvStorageClassOutput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
   // In a tessellation evaluation shader, any variable decorated with
   // TessLevelInner must be declared using the Input storage class.
   exec_vec = { SpvExecutionModelTessellationEvaluation };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
   // Any variable decorated with TessLevelOuter must be declared as
   // an array of size two, containing 32-bit floating-point values.
-  SpvOp elem_type = SpvOpTypeFloat;
-  SpvOp comp_type = SpvOpTypeArray;
-  uint32_t comp_size = 2;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+  ElemType elem = { SpvOpTypeFloat, 32 };
+  CompType comp = { SpvOpTypeArray, 2 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp))
     return error; 
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckTessCoord(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckTessCoord(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "TessCoord";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // The TessCoord decoration must be used only within tessellation evaluation shaders.
   exec_vec = { SpvExecutionModelTessellationEvaluation };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
   
-  // The variable decorated with TessCoord must be declared using the Input storage class.
+  // TessCoord must be declared using the Input storage class.
   exec_vec = { SpvExecutionModelTessellationEvaluation };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
-  // The variable decorated with TessCoord must be declared as
-  // three-component vector of 32-bit floating-point values.
-  SpvOp elem_type = SpvOpTypeFloat;
-  SpvOp comp_type = SpvOpTypeVector;
-  uint32_t comp_size = 3;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+  // TessCoord must be declared as three-component vector of 32-bit floating-point values.
+  ElemType elem = { SpvOpTypeFloat, 32 };
+  CompType comp = { SpvOpTypeVector, 3 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp))
     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckPatchVertices(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckPatchVertices(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "PatchVertices";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // The PatchVertices decoration must be used only within
   // tessellation control and tessellation evaluation shaders.
   exec_vec = { SpvExecutionModelTessellationControl,
                SpvExecutionModelTessellationEvaluation };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
-  // The variable decorated with PatchVertices must be declared using the Input storage class.
+  // PatchVertices must be declared using the Input storage class.
   exec_vec = { SpvExecutionModelTessellationControl,
                SpvExecutionModelTessellationEvaluation };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
-  // The variable decorated with PatchVertices must be declared as
-  // a scalar 32-bit integer.
-  SpvOp elem_type = SpvOpTypeInt;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type))
-    return error;
+  // PatchVertices must be declared as a scalar 32-bit integer.
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckFragCoord(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckFragCoord(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "FragCoord";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // The FragCoord decoration must be used only within fragment shaders.
   exec_vec = { SpvExecutionModelFragment };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
-  // The variable decorated with FragCoord must be declared using the Input storage class.
+  // FragCoord must be declared using the Input storage class.
   exec_vec = { SpvExecutionModelFragment };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
-  // The variable decorated with FragCoord must be declared as
+  // FragCoord must be declared as 
   // a four-component vector of 32-bit floating-point values.
-  SpvOp elem_type = SpvOpTypeFloat;
-  SpvOp comp_type = SpvOpTypeVector;
-  uint32_t comp_size = 4;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+  ElemType elem = { SpvOpTypeFloat, 32 };
+  CompType comp = { SpvOpTypeVector, 4 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp))
     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckPointCoord(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckPointCoord(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "PointCoord";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // The PointCoord decoration must be used only within fragment shaders.
   exec_vec = { SpvExecutionModelFragment };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
-  // The variable decorated with PointCoord must be declared using the Input storage class.
+  // PointCoord must be declared using the Input storage class.
   exec_vec = { SpvExecutionModelFragment };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
-  //  The variable decorated with PointCoord must be declared as
+  // PointCoord must be declared as
   // two-component vector of 32-bit floating-point values.
-  SpvOp elem_type = SpvOpTypeFloat;
-  SpvOp comp_type = SpvOpTypeVector;
-  uint32_t comp_size = 2;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+  ElemType elem = { SpvOpTypeFloat, 32 };
+  CompType comp = { SpvOpTypeVector, 2 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp))
     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckFrontFacing(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckFrontFacing(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "FrontFacing";
   std::vector<uint32_t> exec_vec, stor_vec;
   
   // The FrontFacing decoration must be used only within fragment shaders.
   exec_vec = { SpvExecutionModelFragment };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
-  // The variable decorated with FrontFacing must be declared using the Input storage class.
+  // FrontFacing must be declared using the Input storage class.
   exec_vec = { SpvExecutionModelFragment };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
-  // The variable decorated with FrontFacing must be declared as a boolean.
-  SpvOp elem_type = SpvOpTypeBool;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type))
-    return error;
+  // FrontFacing must be declared as a boolean.
+  ElemType elem = { SpvOpTypeBool };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+     return error;
 
   return SPV_SUCCESS;  
 }
 
-spv_result_t CheckSampleId(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckSampleId(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "SampleId";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // The SampleId decoration must be used only within fragment shaders.
   exec_vec = { SpvExecutionModelFragment };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
-  // The variable decorated with SampleId must be declared using the Input storage class.
+  // SampleId must be declared using the Input storage class.
   exec_vec = { SpvExecutionModelFragment };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
-  // The variable decorated with SampleId must be declared as
-  // a scalar 32-bit.
-  SpvOp elem_type = SpvOpTypeInt;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type))
-    return error;
+  // SampleId must be declared as a scalar 32-bit.
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+     return error;
   
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckSamplePosition(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckSamplePosition(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "SamplePosition";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // The SamplePosition decoration must be used only within fragment shaders.
   exec_vec = { SpvExecutionModelFragment };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
-  // The variable decorated with SamplePosition must be
+  // SamplePosition must be
   // declared using the Input storage class.
   exec_vec = { SpvExecutionModelFragment };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
-  // The variable decorated with SamplePosition must be declared as
+  // SamplePosition must be declared as
   // a two-component vector of 32-bit floating-point values.
-  SpvOp elem_type = SpvOpTypeFloat;
-  SpvOp comp_type = SpvOpTypeVector;
-  uint32_t comp_size = 2;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+  ElemType elem = { SpvOpTypeFloat, 32 };
+  CompType comp = { SpvOpTypeVector, 2 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp))
     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckSampleMask(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckSampleMask(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "SampleMask";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // The SampleMask decoration must be used only within fragment shaders.
   exec_vec = { SpvExecutionModelFragment };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
-  // Any variable decorated with SampleMask must be declared
-  // using either the Input or Output storage class.
+  // Any variable decorated with SampleMask must be declared using either the Input or Output storage class.
   exec_vec = { SpvExecutionModelFragment };
   stor_vec = { SpvStorageClassInput,
                SpvStorageClassOutput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
-  // Any variable decorated with SampleMask must be declared as
-  // an array of 32-bit integers.
-  SpvOp elem_type = SpvOpTypeInt;
-  SpvOp comp_type = SpvOpTypeArray;
-  uint32_t comp_size = 0; // Any size
-  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+  // SampleMask must be declared as an array of 32-bit integers.
+  ElemType elem = { SpvOpTypeInt, 32 };
+  CompType comp = { SpvOpTypeArray };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp))
     return error; 
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckFragDepth(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckFragDepth(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "FragDepth";
   std::vector<uint32_t> exec_vec, stor_vec;
   
   // To write to FragDepth, a shader must declare the DepthReplacing execution mode.
 
-  // TODO (jcaraban)
+  // TODO(jcaraban): when exactly shall we check for DepthReplacing?
+  //                 when an OpStore targets the built-in variable?
+  #if 0
+  auto entry_vec = getEntryPoints(vstate,inst);
+  for (auto entry_point : entry_vec) {
+    auto mode_vec = getExecutionModes(entry_point);
+    if (not IsIncluded(SpvExecutionModeDepthReplacing,mode_vec)) {
+      return vstate.diag(SPV_ERROR_INVALID_ID)
+          << "To write to FragDepth, a shader must declare the "
+            "DepthReplacing execution mode (see Vulkan spec)";
+    }
+  }
+  #endif
 
   // The FragDepth decoration must be used only within fragment shaders.
   exec_vec = { SpvExecutionModelFragment };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
-  // The variable decorated with FragDepth must be declared
-  // using the Output storage class.
+  // FragDepth must be declared using the Output storage class.
   exec_vec = { SpvExecutionModelFragment };
   stor_vec = { SpvStorageClassOutput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
-  // The variable decorated with FragDepth must be declared as
-  // a scalar 32-bit floating-point value.
-  SpvOp elem_type = SpvOpTypeFloat;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type))
-    return error;
+  // FragDepth must be declared as a scalar 32-bit floating-point value.
+  ElemType elem = { SpvOpTypeFloat, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckHelperInvocation(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckHelperInvocation(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "HelperInvocation";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // The HelperInvocation decoration must be used only within fragment shaders
   exec_vec = { SpvExecutionModelFragment };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
-  // The variable decorated with HelperInvocation must be declared
-  // using the Input storage class.
+  // HelperInvocation must be declared using the Input storage class.
   exec_vec = { SpvExecutionModelFragment };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
-  // The variable decorated with HelperInvocation must be declared as a boolean
-  SpvOp elem_type = SpvOpTypeBool;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type))
-    return error;
+  // HelperInvocation must be declared as a boolean
+  ElemType elem = SpvOpTypeBool;
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckNumWorkgroups(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckNumWorkgroups(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "NumWorkgroups";
   std::vector<uint32_t> exec_vec, stor_vec; 
 
   // The NumWorkgroups decoration must be used only within compute shaders.
   exec_vec = { SpvExecutionModelGLCompute,
                SpvExecutionModelKernel };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
-  // The variable decorated with NumWorkgroups must be declared
-  // using the Input storage class.
+  // NumWorkgroups must be declared using the Input storage class.
   exec_vec = { SpvExecutionModelGLCompute,
                SpvExecutionModelKernel };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
-  // The variable decorated with NumWorkgroups must be declared as
+  // NumWorkgroups must be declared as
   // a three-component vector of 32-bit integers.
-  SpvOp elem_type = SpvOpTypeInt;
-  SpvOp comp_type = SpvOpTypeVector;
-  uint32_t comp_size = 3;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+  ElemType elem = { SpvOpTypeInt, 32 };
+  CompType comp = { SpvOpTypeVector, 3 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp))
     return error;
   
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckWorkgroupSize(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckWorkgroupSize(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "WorkgroupSize";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // If an object is decorated with the WorkgroupSize decoration,
   // this must take precedence over any execution mode set for LocalSize
 
-  // TODO(jcaraban)
+  // TODO(jcaraban): can this be verified now?
+  //                 i.e. is this a compile or runtime restriction?
 
-  // The WorkgroupSize decoration must be used only within compute shaders.
+  // The WorkgroupSize decoration must be used only within compute shaders
   exec_vec = { SpvExecutionModelGLCompute,
                SpvExecutionModelKernel };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
   // The object decorated with WorkgroupSize must be
   // a specialization constant or a constant.
-  storage_class = storage_class;
-  // TODO(jcaraban)
+  if (inst->opcode() != SpvOpConstantComposite &&
+      inst->opcode() != SpvOpSpecConstantComposite) {
+    return vstate.diag(SPV_ERROR_INVALID_ID)
+        << "The object decorated with WorkgroupSize must be "
+           "a specialization constant or a constant";
+  }
 
+  // WrokgroupSize should not have storage class, and if it does,
+  // other validation should complain before reaching this line
+  assert(storage_class == SpvStorageClassMax);
+  
   // The object decorated with WorkgroupSize must be declared as
   // a three-component vector of 32-bit integers.
-  SpvOp elem_type = SpvOpTypeInt;
-  SpvOp comp_type = SpvOpTypeVector;
-  uint32_t comp_size = 3;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+  ElemType elem = { SpvOpTypeInt, 32 };
+  CompType comp = { SpvOpTypeVector, 3 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp))
     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckWorkgroupId(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckWorkgroupId(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "WorkgroupId";
   std::vector<uint32_t> exec_vec, stor_vec;
   
   // The WorkgroupId decoration must be used only within compute shaders.
   exec_vec = { SpvExecutionModelGLCompute,
                SpvExecutionModelKernel };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
-  // The variable decorated with WorkgroupId must be declared
-  // using the Input storage class.
+  // WorkgroupId must be declared using the Input storage class.
   exec_vec = { SpvExecutionModelGLCompute,
                SpvExecutionModelKernel };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
-  // The variable decorated with WorkgroupId must be declared as
+  // WorkgroupId must be declared as
   // a three-component vector of 32-bit integers.
-  SpvOp elem_type = SpvOpTypeInt;
-  SpvOp comp_type = SpvOpTypeVector;
-  uint32_t comp_size = 3;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+  ElemType elem = { SpvOpTypeInt, 32 };
+  CompType comp = { SpvOpTypeVector, 3 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp))
     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckLocalInvocationId(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckLocalInvocationId(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "LocalInvocationId";
   std::vector<uint32_t> exec_vec, stor_vec;
   
   // The LocalInvocationId decoration must be used only within compute shaders.
   exec_vec = { SpvExecutionModelGLCompute,
                SpvExecutionModelKernel };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
-  // The variable decorated with LocalInvocationId must be declared using the Input storage class.
+  // LocalInvocationId must be declared using the Input storage class.
   exec_vec = { SpvExecutionModelGLCompute,
                SpvExecutionModelKernel };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
     
-  // The variable decorated with LocalInvocationId must be declared as
+  // LocalInvocationId must be declared as
   // a three-component vector of 32-bit integers.
-  SpvOp elem_type = SpvOpTypeInt;
-  SpvOp comp_type = SpvOpTypeVector;
-  uint32_t comp_size = 3;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+  ElemType elem = { SpvOpTypeInt, 32 };
+  CompType comp = { SpvOpTypeVector, 3 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp))
     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckGlobalInvocationId(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckGlobalInvocationId(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "GlobalInvocationId";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // The GlobalInvocationId decoration must be used only within compute shaders.
   exec_vec = { SpvExecutionModelGLCompute,
                SpvExecutionModelKernel };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
     
-  // The variable decorated with GlobalInvocationId must be declared using the Input storage class.
+  // GlobalInvocationId must be declared using the Input storage class.
   exec_vec = { SpvExecutionModelGLCompute,
                SpvExecutionModelKernel };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
-  // The variable decorated with GlobalInvocationId must be declared as
+  // GlobalInvocationId must be declared as
   // a three-component vector of 32-bit integers.
-  SpvOp elem_type = SpvOpTypeInt;
-  SpvOp comp_type = SpvOpTypeVector;
-  uint32_t comp_size = 3;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+  ElemType elem = { SpvOpTypeInt, 32 };
+  CompType comp = { SpvOpTypeVector, 3 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp))
     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckLocalInvocationIndex(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckLocalInvocationIndex(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "LocalInvocationIndex";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // The LocalInvocationIndex decoration must be used only within compute shaders.
   exec_vec = { SpvExecutionModelGLCompute,
                SpvExecutionModelKernel };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
     
-  // The variable decorated with LocalInvocationIndex must be declared using the Input storage class.
+  // LocalInvocationIndex must be declared using the Input storage class.
   exec_vec = { SpvExecutionModelGLCompute,
                SpvExecutionModelKernel };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
-  // The variable decorated with GlobalInvocationId must be declared as
-  // a scalar 32-bit integer.
-  SpvOp elem_type = SpvOpTypeInt;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type))
-    return error;
+  // GlobalInvocationId must be declared as a scalar 32-bit integer.
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+     return error;
 
   return SPV_SUCCESS;
 }
-/*
-spv_result_t CheckWorkDim(ValidationState_t& vstate, Instruction inst,
+
+spv_result_t CheckWorkDim(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "WorkDim";
   std::vector<uint32_t> exec_vec, stor_vec;
   
   // WorkDim is part of the OpenCL specification
   exec_vec = { SpvExecutionModelKernel };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
     
   // WorkDim is an input argument to the kernels
   exec_vec = { SpvExecutionModelKernel };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
   // WorkDim is a scalar 32-bit integer
-  SpvOp elem_type = SpvOpTypeInt;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type))
-    return error;
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckGlobalSize(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckGlobalSize(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "GlobalSize";
   std::vector<uint32_t> exec_vec, stor_vec;
   
   // GlobalSize is part of the OpenCL specification
   exec_vec = { SpvExecutionModelKernel };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
     
   // GlobalSize is an input argument to the kernels
   exec_vec = { SpvExecutionModelKernel };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
   // GlobalSize is a three-component vector of 32-bit integers
-  SpvOp elem_type = SpvOpTypeInt;
-  SpvOp comp_type = SpvOpTypeVector;
-  uint32_t comp_size = 3;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+  ElemType elem = { SpvOpTypeInt, 32 };
+  CompType comp = { SpvOpTypeVector, 3 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp))
     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckEnqueuedWorkgroupSize(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckEnqueuedWorkgroupSize(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  return CheckWorkgroupSize(vstate,inst,storage_class,exec_model);
+  const string name = "EnqueuedWorkgroupSize";
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // EnqueuedWorkgroupSize is part of the OpenCL specification
+  exec_vec = { SpvExecutionModelKernel };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+    
+  // EnqueuedWorkgroupSize is an input argument to the kernels
+  exec_vec = { SpvExecutionModelKernel };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // EnqueuedWorkgroupSize is a three-component vector of 32-bit integers
+  ElemType elem = { SpvOpTypeInt, 32 };
+  CompType comp = { SpvOpTypeVector, 3 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp))
+    return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckGlobalOffset(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckGlobalOffset(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  return checkGlobalSize(vstate,inst,storage_class,exec_model);
+  const string name = "GlobalOffset";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+    // GlobalOffset is part of the OpenCL specification
+    exec_vec = { SpvExecutionModelKernel };
+    if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+      return error;
+      
+    // GlobalOffset is an input argument to the kernels
+    exec_vec = { SpvExecutionModelKernel };
+    stor_vec = { SpvStorageClassInput };
+    if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+      return error;
+  
+    // GlobalOffset is a three-component vector of 32-bit integers
+    ElemType elem = { SpvOpTypeInt, 32 };
+    CompType comp = { SpvOpTypeVector, 3 };
+    if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp))
+      return error;
+  
+    return SPV_SUCCESS;
 }
 
-spv_result_t CheckGlobalLinearId(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckGlobalLinearId(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  return CheckLocalInvocationIndex(vstate,inst,storage_class,exec_model);
+  const string name = "GlobalLinearId";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // GlobalLinearId is part of the OpenCL specification
+  exec_vec = { SpvExecutionModelKernel };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+    
+  // GlobalLinearId is an input argument to the kernels
+  exec_vec = { SpvExecutionModelKernel };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // GlobalLinearId is a scalar 32-bit integer
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+     return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckSubgroupSize(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckSubgroupSize(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  return CheckWorkgroupSize(vstate,inst,storage_class,exec_model);
+  const string name = "SubgroupSize";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // SubgroupSize is part of the OpenCL specification
+  exec_vec = { SpvExecutionModelKernel };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+    
+  // SubgroupSize is an input argument to the kernels
+  exec_vec = { SpvExecutionModelKernel };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // SubgroupSize is a scalar 32-bit integer
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+    return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckSubgroupMaxSize(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckSubgroupMaxSize(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  return checkSubgroupSize(vstate,inst,storage_class,exec_model);
+  const string name = "SubgroupMaxSize";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // SubgroupMaxSize is part of the OpenCL specification
+  exec_vec = { SpvExecutionModelKernel };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+    
+  // SubgroupMaxSize is an input argument to the kernels
+  exec_vec = { SpvExecutionModelKernel };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // SubgroupMaxSize is a scalar 32-bit integer
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+    return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckNumSubgroups(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckNumSubgroups(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "NumSubgroups";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // NumSubgroups is part of the OpenCL specification
+  exec_vec = { SpvExecutionModelKernel };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+    
+  // NumSubgroups is an input argument to the kernels
+  exec_vec = { SpvExecutionModelKernel };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // NumSubgroups is a scalar 32-bit integer
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+    return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckNumEnqueuedSubgroups(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckNumEnqueuedSubgroups(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "NumEnqueuedSubgroups";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // NumEnqueuedSubgroups is part of the OpenCL specification
+  exec_vec = { SpvExecutionModelKernel };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+    
+  // NumEnqueuedSubgroups is an input argument to the kernels
+  exec_vec = { SpvExecutionModelKernel };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // NumEnqueuedSubgroups is a scalar 32-bit integer
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+    return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckSubgroupId(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckSubgroupId(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "SubgroupId";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // SubgroupId is part of the OpenCL specification
+  exec_vec = { SpvExecutionModelKernel };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+    
+  // SubgroupId is an input argument to the kernels
+  exec_vec = { SpvExecutionModelKernel };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // SubgroupId is a scalar 32-bit integer
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+    return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckSubgroupLocalInvocationId(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckSubgroupLocalInvocationId(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "SubgroupLocalInvocationId";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // SubgroupLocalInvocationId is part of the OpenCL specification
+  exec_vec = { SpvExecutionModelKernel };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+    
+  // SubgroupLocalInvocationId is an input argument to the kernels
+  exec_vec = { SpvExecutionModelKernel };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // SubgroupLocalInvocationId is a scalar 32-bit integer
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+    return error;
+
+  return SPV_SUCCESS;
 }
-*/
-spv_result_t CheckVertexIndex(ValidationState_t& vstate, Instruction inst,
+
+spv_result_t CheckVertexIndex(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
+  const string name = "VertexIndex";
   std::vector<uint32_t> exec_vec, stor_vec;
 
   // The VertexIndex decoration must be used only within vertex shaders.
   exec_vec = { SpvExecutionModelVertex };
-  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
     return error;
 
-  // The variable decorated with VertexIndex must be declared
-  // using the Input storage class.
+  // VertexIndex must be declared using the Input storage class.
   exec_vec = { SpvExecutionModelVertex };
   stor_vec = { SpvStorageClassInput };
-  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
     return error;
 
-  // The variable decorated with VertexIndex must be declared as
+  // VertexIndex must be declared as
   // a scalar 32-bit integer.
-  SpvOp elem_type = SpvOpTypeInt;
-  if (auto error = checkBuiltInType(vstate,inst,elem_type))
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+     return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckInstanceIndex(ValidationState_t& vstate, const Instruction* inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  const string name = "InstanceIndex";
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The VertexIndex decoration must be used only within vertex shaders.
+  exec_vec = { SpvExecutionModelVertex };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+
+  // VertexIndex must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelVertex };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // VertexIndex must be declared as
+  // a scalar 32-bit integer.
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+     return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckSubgroupEqMaskKHR(ValidationState_t& vstate, const Instruction* inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  const string name = "SubgroupEqMaskKHR";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // SubgroupEqMaskKHR is part of the SPV_KHR_shader_ballot extension
+  exec_vec = { SpvExecutionModelVertex,
+               SpvExecutionModelFragment,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+    
+  // SubgroupEqMaskKHR is an input argument
+  exec_vec = { SpvExecutionModelVertex,
+               SpvExecutionModelFragment,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // SubgroupEqMaskKHR is a four-components vector of 32-bit integers
+  ElemType elem = { SpvOpTypeInt, 32 };
+  CompType comp = { SpvOpTypeVector, 4 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp) )
     return error;
 
   return SPV_SUCCESS;
 }
 
-spv_result_t CheckInstanceIndex(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckSubgroupGeMaskKHR(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban): many built-ins show same logic, e.g. Vertex/InstanceIndex
-  return CheckVertexIndex(vstate,inst,storage_class,exec_model);
-}
-/*
-spv_result_t CheckSubgroupEqMaskKHR(ValidationState_t& vstate, Instruction inst,
-    uint32_t storage_class, uint32_t exec_model)
-{
-  // TODO(jcaraban)
+  const string name = "SubgroupGeMaskKHR";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // SubgroupGeMaskKHR is part of the SPV_KHR_shader_ballot extension
+  exec_vec = { SpvExecutionModelVertex,
+               SpvExecutionModelFragment,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+    
+  // SubgroupGeMaskKHR is an input argument
+  exec_vec = { SpvExecutionModelVertex,
+               SpvExecutionModelFragment,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // SubgroupGeMaskKHR is a four-components vector of 32-bit integers
+  ElemType elem = { SpvOpTypeInt, 32 };
+  CompType comp = { SpvOpTypeVector, 4 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp) )
+    return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckSubgroupGeMaskKHR(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckSubgroupGtMaskKHR(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "SubgroupGtMaskKHR";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // SubgroupGtMaskKHR is part of the SPV_KHR_shader_ballot extension
+  exec_vec = { SpvExecutionModelVertex,
+               SpvExecutionModelFragment,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+    
+  // SubgroupGtMaskKHR is an input argument
+  exec_vec = { SpvExecutionModelVertex,
+               SpvExecutionModelFragment,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // SubgroupGtMaskKHR is a four-components vector of 32-bit integers
+  ElemType elem = { SpvOpTypeInt, 32 };
+  CompType comp = { SpvOpTypeVector, 4 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp) )
+    return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckSubgroupGtMaskKHR(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckSubgroupLeMaskKHR(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "SubgroupLeMaskKHR";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // SubgroupLeMaskKHR is part of the SPV_KHR_shader_ballot extension
+  exec_vec = { SpvExecutionModelVertex,
+               SpvExecutionModelFragment,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+    
+  // SubgroupLeMaskKHR is an input argument
+  exec_vec = { SpvExecutionModelVertex,
+               SpvExecutionModelFragment,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // SubgroupLeMaskKHR is a four-components vector of 32-bit integers
+  ElemType elem = { SpvOpTypeInt, 32 };
+  CompType comp = { SpvOpTypeVector, 4 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp) )
+    return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckSubgroupLeMaskKHR(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckSubgroupLtMaskKHR(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "SubgroupLtMaskKHR";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // SubgroupLtMaskKHR is part of the SPV_KHR_shader_ballot extension
+  exec_vec = { SpvExecutionModelVertex,
+               SpvExecutionModelFragment,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+    
+  // SubgroupLtMaskKHR is an input argument
+  exec_vec = { SpvExecutionModelVertex,
+               SpvExecutionModelFragment,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // SubgroupLtMaskKHR is a four-components vector of 32-bit integers
+  ElemType elem = { SpvOpTypeInt, 32 };
+  CompType comp = { SpvOpTypeVector, 4 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp) )
+    return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckSubgroupLtMaskKHR(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckBaseVertex(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "BaseVertex";
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The BaseVertex decoration must be used only within vertex shaders.
+  exec_vec = { SpvExecutionModelVertex };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+
+  // BaseVertex must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelVertex };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // BaseVertex must be declared as a scalar 32-bit integer.
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+     return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckBaseVertex(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckBaseInstance(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "BaseInstance";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // The BaseInstance decoration must be used only within vertex shaders.
+  exec_vec = { SpvExecutionModelVertex };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+
+  // BaseInstance must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelVertex };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // BaseInstance must be declared as a scalar 32-bit integer.
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+      return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckBaseInstance(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckDrawIndex(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "DrawIndex";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // The DrawIndex decoration must be used only within vertex shaders.
+  exec_vec = { SpvExecutionModelVertex };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+
+  // DrawIndex must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelVertex };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // DrawIndex must be declared as a scalar 32-bit integer.
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+      return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckDrawIndex(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckDeviceIndex(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "DeviceIndex";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // The VertexIndex decoration must be used only within vertex shaders.
+  exec_vec = { SpvExecutionModelVertex,
+                SpvExecutionModelFragment,
+                SpvExecutionModelTessellationControl,
+                SpvExecutionModelTessellationEvaluation,
+                SpvExecutionModelGeometry,
+                SpvExecutionModelGLCompute };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+
+  // VertexIndex must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelVertex,
+                SpvExecutionModelFragment,
+                SpvExecutionModelTessellationControl,
+                SpvExecutionModelTessellationEvaluation,
+                SpvExecutionModelGeometry,
+                SpvExecutionModelGLCompute };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // VertexIndex must be declared as a scalar 32-bit integer.
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+      return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckDeviceIndex(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckViewIndex(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "ViewIndex";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // The VertexIndex decoration must be used only within vertex shaders.
+  exec_vec = { SpvExecutionModelVertex,
+                SpvExecutionModelFragment,
+                SpvExecutionModelTessellationControl,
+                SpvExecutionModelTessellationEvaluation,
+                SpvExecutionModelGeometry };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+
+  // VertexIndex must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelVertex,
+                SpvExecutionModelFragment,
+                SpvExecutionModelTessellationControl,
+                SpvExecutionModelTessellationEvaluation,
+                SpvExecutionModelGeometry };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // VertexIndex must be declared as a scalar 32-bit integer.
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+      return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckViewIndex(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckBaryCoordNoPerspAMD(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "BaryCoordNoPerspAMD";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // BaryCoordNoPerspAMD must be used only within fragment shaders.
+  exec_vec = { SpvExecutionModelFragment };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+
+  // BaryCoordNoPerspAMD must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelFragment };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // BaryCoordNoPerspAMD is a two-components vector of 32-bit floats
+  ElemType elem = { SpvOpTypeFloat, 32 };
+  CompType comp = { SpvOpTypeVector, 2 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp) )
+    return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckBaryCoordNoPerspAMD(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckBaryCoordNoPerspCentroidAMD(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "BaryCoordNoPerspCentroidAMD";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // BaryCoordNoPerspAMD must be used only within fragment shaders.
+  exec_vec = { SpvExecutionModelFragment };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+
+  // BaryCoordNoPerspAMD must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelFragment };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // BaryCoordNoPerspAMD is a two-components vector of 32-bit floats
+  ElemType elem = { SpvOpTypeFloat, 32 };
+  CompType comp = { SpvOpTypeVector, 2 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp) )
+    return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckBaryCoordNoPerspCentroidAMD(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckBaryCoordNoPerspSampleAMD(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "BaryCoordNoPerspSampleAMD";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // BaryCoordNoPerspAMD must be used only within fragment shaders.
+  exec_vec = { SpvExecutionModelFragment };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+
+  // BaryCoordNoPerspAMD must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelFragment };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // BaryCoordNoPerspAMD is a two-components vector of 32-bit floats
+  ElemType elem = { SpvOpTypeFloat, 32 };
+  CompType comp = { SpvOpTypeVector, 2 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp) )
+    return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckBaryCoordNoPerspSampleAMD(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckBaryCoordSmoothAMD(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "BaryCoordSmoothAMD";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // BaryCoordNoPerspAMD must be used only within fragment shaders.
+  exec_vec = { SpvExecutionModelFragment };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+
+  // BaryCoordNoPerspAMD must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelFragment };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // BaryCoordNoPerspAMD is a two-components vector of 32-bit floats
+  ElemType elem = { SpvOpTypeFloat, 32 };
+  CompType comp = { SpvOpTypeVector, 2 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp) )
+    return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckBaryCoordSmoothAMD(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckBaryCoordSmoothCentroidAMD(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "BaryCoordSmoothCentroidAMD";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // BaryCoordNoPerspAMD must be used only within fragment shaders.
+  exec_vec = { SpvExecutionModelFragment };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+
+  // BaryCoordNoPerspAMD must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelFragment };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // BaryCoordNoPerspAMD is a two-components vector of 32-bit floats
+  ElemType elem = { SpvOpTypeFloat, 32 };
+  CompType comp = { SpvOpTypeVector, 2 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp) )
+    return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckBaryCoordSmoothCentroidAMD(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckBaryCoordSmoothSampleAMD(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "BaryCoordSmoothSampleAMD";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // BaryCoordNoPerspAMD must be used only within fragment shaders.
+  exec_vec = { SpvExecutionModelFragment };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+
+  // BaryCoordNoPerspAMD must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelFragment };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // BaryCoordNoPerspAMD is a two-components vector of 32-bit floats
+  ElemType elem = { SpvOpTypeFloat, 32 };
+  CompType comp = { SpvOpTypeVector, 2 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp) )
+    return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckBaryCoordSmoothSampleAMD(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckBaryCoordPullModelAMD(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "BaryCoordPullModelAMD";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // BaryCoordNoPerspAMD must be used only within fragment shaders.
+  exec_vec = { SpvExecutionModelFragment };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+
+  // BaryCoordNoPerspAMD must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelFragment };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // BaryCoordNoPerspAMD is a three-components vector of 32-bit floats
+  ElemType elem = { SpvOpTypeFloat, 32 };
+  CompType comp = { SpvOpTypeVector, 3 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp) )
+    return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckBaryCoordPullModelAMD(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckFragStencilRefEXT(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "FragStencilRefEXT";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // FragStencilRefEXT must be used only within fragment shaders.
+  exec_vec = { SpvExecutionModelFragment };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+
+  // FragStencilRefEXT must be declared using the Output storage class.
+  exec_vec = { SpvExecutionModelFragment };
+  stor_vec = { SpvStorageClassOutput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // BaryCoordNoPerspAMD is a scalar integer of any-bits
+  ElemType elem = { SpvOpTypeInt };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+    return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckFragStencilRefEXT(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckViewportMaskNV(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "ViewportMaskNV";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // ViewportMaskNV must be used within Vertex, Tessellation or Geometry.
+  exec_vec = { SpvExecutionModelVertex,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+
+  // ViewportMaskNV must be declared using the Output storage class.
+  exec_vec = { SpvExecutionModelVertex,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  stor_vec = { SpvStorageClassOutput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // ViewportMaskNV must be declared as a scalar 32-bit integer.
+  ElemType elem = { SpvOpTypeInt, 32 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem) )
+    return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckViewportMaskNV(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckSecondaryPositionNV(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "SecondaryPositionNV";
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // SecondaryPositionNV must be used only within Vertex, Tessellation or Geometry.
+  exec_vec = { SpvExecutionModelVertex,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+
+  // SecondaryPositionNV must be Output within Vertex.
+  exec_vec = { SpvExecutionModelVertex };
+  stor_vec = { SpvStorageClassOutput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // SecondaryPositionNV must be Output within Tessellation and Geometry.
+  exec_vec = { SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  stor_vec = { SpvStorageClassInput,
+               SpvStorageClassOutput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // SecondaryPositionNV must be declared as a
+  // four-component vector of 32-bit floating-point values.
+  ElemType elem = { SpvOpTypeFloat, 32 };
+  CompType comp = { SpvOpTypeVector, 4 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp))
+    return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckSecondaryPositionNV(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckSecondaryViewportMaskNV(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "SecondaryViewportMaskNV";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // SecondaryViewportMaskNV must be used only within fragment shaders.
+  exec_vec = { SpvExecutionModelVertex,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+
+  // SecondaryViewportMaskNV must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelVertex,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  stor_vec = { SpvStorageClassOutput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // SecondaryViewportMaskNV must be declared as an array of 32-bit integers.
+  ElemType elem = { SpvOpTypeInt, 32 };
+  CompType comp = { SpvOpTypeArray };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp))
+    return error; 
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckSecondaryViewportMaskNV(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckPositionPerViewNV(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
+  const string name = "PositionPerViewNV";
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // PositionPerViewNV must be used only within Vertex, Tessellation or Geometry.
+  exec_vec = { SpvExecutionModelVertex,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
+
+  // PositionPerViewNV must be Output within Vertex.
+  exec_vec = { SpvExecutionModelVertex };
+  stor_vec = { SpvStorageClassOutput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // PositionPerViewNV must be Output within Tessellation and Geometry.
+  exec_vec = { SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  stor_vec = { SpvStorageClassInput,
+               SpvStorageClassOutput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // PositionPerViewNV must be declared as a
+  // four-component vector of 32-bit floating-point values.
+  ElemType elem = { SpvOpTypeFloat, 32 };
+  CompType comp = { SpvOpTypeVector, 4 };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp))
+    return error;
+
+  return SPV_SUCCESS;
 }
 
-spv_result_t CheckPositionPerViewNV(ValidationState_t& vstate, Instruction inst,
+spv_result_t CheckViewportMaskPerViewNV(ValidationState_t& vstate, const Instruction* inst,
     uint32_t storage_class, uint32_t exec_model)
 {
-  // TODO(jcaraban)
-}
+  const string name = "ViewportMaskPerViewNV";
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // ViewportMaskPerViewNV must be used only within fragment shaders.
+  exec_vec = { SpvExecutionModelVertex,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  if (auto error = CheckExecutionModel(vstate, name, exec_model, exec_vec))
+    return error;
 
-spv_result_t CheckViewportMaskPerViewNV(ValidationState_t& vstate, Instruction inst,
-    uint32_t storage_class, uint32_t exec_model)
-{
-  // TODO(jcaraban)
+  // ViewportMaskPerViewNV must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelVertex,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  stor_vec = { SpvStorageClassOutput };
+  if (auto error = CheckStorageClass(vstate, name, exec_model, storage_class, exec_vec, stor_vec))
+    return error;
+
+  // ViewportMaskPerViewNV must be declared as an array of 32-bit integers.
+  ElemType elem = { SpvOpTypeInt, 32 };
+  CompType comp = { SpvOpTypeArray };
+  if (auto error = CheckBuiltInType(vstate, name, inst, elem, comp))
+    return error; 
+
+  return SPV_SUCCESS;
 }
-*/
 
 }  // anonymous namespace
 
@@ -1387,15 +2231,17 @@ namespace libspirv {
     return Check ## bltin (_,inst,storage_class,execution_model);
 
 // Validates that decorations have been applied properly.
-spv_result_t ValidateBuiltIns(ValidationState_t& _) {
+spv_result_t ValidateBuiltIns(ValidationState_t& _)
+{
   // For every instruction decorated with a built-in...
-  for (const auto& inst : _.ordered_instructions()) {
-    if (not isBuiltIn(inst,_))
+  for (const auto& inst_ref : _.ordered_instructions()) {
+    const Instruction *inst = &inst_ref;
+    if (not IsBuiltIn(inst, _))
       continue;
-    auto storage_class = getStorageClass(inst);
-    auto built_in = getBuiltInEnum(inst,_);
+    auto storage_class = GetStorageClass(inst);
+    auto built_in = GetBuiltInEnum(inst, _);
     // For every 'execution model' affecting the built-in, check its validty
-    for (auto execution_model : getExecutionModels(_,inst)) {
+    for (auto execution_model : getExecutionModels(_, inst)) {
       switch (built_in) {
         BUILTIN_CASE( Position                    )
         BUILTIN_CASE( PointSize                   )
@@ -1425,43 +2271,42 @@ spv_result_t ValidateBuiltIns(ValidationState_t& _) {
         BUILTIN_CASE( LocalInvocationId           )
         BUILTIN_CASE( GlobalInvocationId          )
         BUILTIN_CASE( LocalInvocationIndex        )
-        // TODO(jcaraban): the built-ins below are not clearly documented
-        //BUILTIN_CASE( WorkDim                     )
-        //BUILTIN_CASE( GlobalSize                  )
-        //BUILTIN_CASE( EnqueuedWorkgroupSize       )
-        //BUILTIN_CASE( GlobalOffset                )
-        //BUILTIN_CASE( GlobalLinearId              )
-        //BUILTIN_CASE( SubgroupSize                )
-        //BUILTIN_CASE( SubgroupMaxSize             )
-        //BUILTIN_CASE( NumSubgroups                )
-        //BUILTIN_CASE( NumEnqueuedSubgroups        )
-        //BUILTIN_CASE( SubgroupId                  )
-        //BUILTIN_CASE( SubgroupLocalInvocationId   )
+        BUILTIN_CASE( WorkDim                     )
+        BUILTIN_CASE( GlobalSize                  )
+        BUILTIN_CASE( EnqueuedWorkgroupSize       )
+        BUILTIN_CASE( GlobalOffset                )
+        BUILTIN_CASE( GlobalLinearId              )
+        BUILTIN_CASE( SubgroupSize                )
+        BUILTIN_CASE( SubgroupMaxSize             )
+        BUILTIN_CASE( NumSubgroups                )
+        BUILTIN_CASE( NumEnqueuedSubgroups        )
+        BUILTIN_CASE( SubgroupId                  )
+        BUILTIN_CASE( SubgroupLocalInvocationId   )
         BUILTIN_CASE( VertexIndex                 )
         BUILTIN_CASE( InstanceIndex               )
-        //BUILTIN_CASE( SubgroupEqMaskKHR           )
-        //BUILTIN_CASE( SubgroupGeMaskKHR           )
-        //BUILTIN_CASE( SubgroupGtMaskKHR           )
-        //BUILTIN_CASE( SubgroupLeMaskKHR           )
-        //BUILTIN_CASE( SubgroupLtMaskKHR           )
-        //BUILTIN_CASE( BaseVertex                  )
-        //BUILTIN_CASE( BaseInstance                )
-        //BUILTIN_CASE( DrawIndex                   )
-        //BUILTIN_CASE( DeviceIndex                 )
-        //BUILTIN_CASE( ViewIndex                   )
-        //BUILTIN_CASE( BaryCoordNoPerspAMD         )
-        //BUILTIN_CASE( BaryCoordNoPerspCentroidAMD )
-        //BUILTIN_CASE( BaryCoordNoPerspSampleAMD   )
-        //BUILTIN_CASE( BaryCoordSmoothAMD          )
-        //BUILTIN_CASE( BaryCoordSmoothCentroidAMD  )
-        //BUILTIN_CASE( BaryCoordSmoothSampleAMD    )
-        //BUILTIN_CASE( BaryCoordPullModelAMD       )
-        //BUILTIN_CASE( FragStencilRefEXT           )
-        //BUILTIN_CASE( ViewportMaskNV              )
-        //BUILTIN_CASE( SecondaryPositionNV         )
-        //BUILTIN_CASE( SecondaryViewportMaskNV     )
-        //BUILTIN_CASE( PositionPerViewNV           )
-        //BUILTIN_CASE( ViewportMaskPerViewNV       )
+        BUILTIN_CASE( SubgroupEqMaskKHR           )
+        BUILTIN_CASE( SubgroupGeMaskKHR           )
+        BUILTIN_CASE( SubgroupGtMaskKHR           )
+        BUILTIN_CASE( SubgroupLeMaskKHR           )
+        BUILTIN_CASE( SubgroupLtMaskKHR           )
+        BUILTIN_CASE( BaseVertex                  )
+        BUILTIN_CASE( BaseInstance                )
+        BUILTIN_CASE( DrawIndex                   )
+        BUILTIN_CASE( DeviceIndex                 )
+        BUILTIN_CASE( ViewIndex                   )
+        BUILTIN_CASE( BaryCoordNoPerspAMD         )
+        BUILTIN_CASE( BaryCoordNoPerspCentroidAMD )
+        BUILTIN_CASE( BaryCoordNoPerspSampleAMD   )
+        BUILTIN_CASE( BaryCoordSmoothAMD          )
+        BUILTIN_CASE( BaryCoordSmoothCentroidAMD  )
+        BUILTIN_CASE( BaryCoordSmoothSampleAMD    )
+        BUILTIN_CASE( BaryCoordPullModelAMD       )
+        BUILTIN_CASE( FragStencilRefEXT           )
+        BUILTIN_CASE( ViewportMaskNV              )
+        BUILTIN_CASE( SecondaryPositionNV         )
+        BUILTIN_CASE( SecondaryViewportMaskNV     )
+        BUILTIN_CASE( PositionPerViewNV           )
+        BUILTIN_CASE( ViewportMaskPerViewNV       )
       }
     }
   }

--- a/source/validate_builtins.cpp
+++ b/source/validate_builtins.cpp
@@ -1,0 +1,1474 @@
+// Copyright (c) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "validate.h"
+
+#include <algorithm>
+#include <string>
+
+#include "diagnostic.h"
+#include "opcode.h"
+#include "val/validation_state.h"
+
+using libspirv::Decoration;
+using libspirv::DiagnosticStream;
+using libspirv::Instruction;
+using libspirv::ValidationState_t;
+
+namespace { // utils
+
+bool isIncludedIn(uint32_t elem, std::vector<uint32_t> vec) {
+  return std::find(vec.begin(),vec.end(),elem) != vec.end();  
+}
+
+// Returns whether the given instruction has a BuiltIn decoration
+bool isBuiltIn(Instruction inst, ValidationState_t& vstate) {
+  const auto& decorations = vstate.id_decorations(inst.id());
+  return std::any_of(
+      decorations.begin(), decorations.end(), [](const Decoration& d) {
+        return SpvDecorationBuiltIn == d.dec_type();
+      });
+}
+
+// Returns the SpvBuiltIn_enum of the first BuiltIn decoration of a instruction
+uint32_t getBuiltInEnum(Instruction inst, ValidationState_t& vstate) {
+  const auto& decorations = vstate.id_decorations(inst.id());
+  auto it = std::find_if(
+      decorations.begin(), decorations.end(), [](const Decoration& d) {
+        return SpvDecorationBuiltIn == d.dec_type();
+      });
+  assert(it != decorations.end());
+  return it->params()[0];
+}
+
+// Returns the Storage class of the instruction
+uint32_t getStorageClass(Instruction inst) {
+  switch (inst.opcode()) {
+    case SpvOpTypePointer: return inst.words()[2];
+    case SpvOpTypeForwardPointer: return inst.words()[2];
+    case SpvOpVariable: return inst.words()[3];
+    case SpvOpGenericCastToPtrExplicit: return inst.words()[4];
+    default: return SpvStorageClassMax;
+  }
+}
+
+// TODO(jcaraban): how to find the entry_points in a more direct way?
+// Returns the execution models of the entry points linked to the builtin
+std::vector<uint32_t> getExecutionModels(
+      ValidationState_t& vstate, Instruction inst) {
+  std::vector<uint32_t> exec_vec;
+  // Walks the entry functions in the module
+  for (auto entry_func : vstate.entry_points()) {
+    const auto &interfaces = vstate.entry_point_interfaces(entry_func);
+    // Filtering those interfacing the built-in of interest
+    if (isIncludedIn(inst.id(),interfaces)) {
+      auto func_inst = vstate.FindDef(entry_func);
+      assert(func_inst);
+      // The entry function uses link to the entry points
+      for (auto pair : func_inst->uses()) {
+        auto entry_point = pair.first;
+        if (entry_point->opcode() == SpvOpEntryPoint) {
+          // The entry points contain the execution model
+          auto exec_model = entry_point->words()[1];
+          exec_vec.push_back(exec_model);
+        }
+      }
+    }
+  }
+  return exec_vec;
+}
+
+// Ensures the excution model is included in the list of compatible models
+spv_result_t checkExecutionModel(ValidationState_t& vstate,
+      uint32_t exec_model, std::vector<uint32_t> models) {
+  if (not isIncludedIn(exec_model,models)) {
+    return vstate.diag(SPV_ERROR_INVALID_ID)
+        << "Built-in variables are restricted to only certain"
+           "EXECUTION MODELS (see e.g. Vulkan specification)";
+  }
+  return SPV_SUCCESS;
+}
+
+// Ensures the pair 'exec_model','storage_class' are compatible
+spv_result_t checkStorageClass(ValidationState_t& vstate,
+      uint32_t exec_model, uint32_t storage_class,
+      std::vector<uint32_t> models, std::vector<uint32_t> storages)
+{
+  // If 'exec_model' is included the list of 'models'
+  if (isIncludedIn(exec_model,models)) {
+    // But 'storage_class' is not one of the compatible 'storages'
+    if (not isIncludedIn(storage_class,storages)) {
+      return vstate.diag(SPV_ERROR_INVALID_ID)
+          << "Built-in variables must match the STORAGE CLASS "
+             "of the built-in (see e.g. Vulkan specification)";
+    }
+  }
+  return SPV_SUCCESS;
+}
+
+// Ensures the variable type matches the built-in type
+spv_result_t checkBuiltInType(ValidationState_t& vstate, Instruction inst,
+      SpvOp elem_type, SpvOp comp_type=SpvOpNop, uint32_t comp_size=0)
+{
+  auto error = [&](ValidationState_t& state) -> spv_result_t {
+    return state.diag(SPV_ERROR_INVALID_ID)
+        << "Built-in variables must match the DATA TYPE "
+           "of the built-in (see e.g. Vulkan specification)";
+  };
+  auto *curr_inst = &inst;
+  // Gets instruction type
+  curr_inst = vstate.FindDef(curr_inst->type_id());
+  assert(curr_inst);
+  // The built-in variable must be of OpType Pointer
+  if (curr_inst->opcode() != SpvOpTypePointer) {
+    return error(vstate);
+  }
+  // The Pointer type is stored in its 3rd word
+  curr_inst = vstate.FindDef(curr_inst->words()[3]);
+  assert(curr_inst);
+  // If the type is composed (i.e. Vector or Array)
+  if (comp_type != SpvOpNop) {
+    // It must match the composed type...
+    if (curr_inst->opcode() != comp_type) {
+      return error(vstate);
+    }
+    // ... and it must match the number of components / size
+    uint32_t size;
+    if (comp_type == SpvOpTypeVector) { // size as literal
+      size = curr_inst->words()[3];
+    } else if (comp_type == SpvOpTypeArray) { // size as constant
+      auto *size_inst = vstate.FindDef(curr_inst->words()[3]);
+      assert(size_inst);
+      size = size_inst->words()[3];
+      // if comp_size = 0, any size is ok
+      size = (comp_size == 0) ? 0 : size;
+    } else {
+      assert(false);
+    }
+    if (size != comp_size) {
+      return error(vstate);
+    }
+    // Gets primitive type
+    curr_inst = vstate.FindDef(curr_inst->words()[2]);
+    assert(curr_inst);
+  }
+  // Composed or not, it must match the primitive type
+  if (curr_inst->opcode() != elem_type) {
+    return error(vstate);
+  }
+  return SPV_SUCCESS;
+}
+
+} // anonymous namespace
+
+namespace { // built-in checks
+
+spv_result_t CheckPosition(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The Position decoration must be used only within vertex, tessellation
+  // control, tessellation evaluation, and geometry shaders.
+  exec_vec = { SpvExecutionModelVertex,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // In a vertex shader, any variable decorated with Position 
+  // must be declared using the Output storage class.
+  exec_vec = { SpvExecutionModelVertex };
+  stor_vec = { SpvStorageClassOutput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+  
+  // In a tessellation control, tessellation evaluation, or geometry shader,
+  // any variable decorated with Position must not be declared in a
+  // storage class other than Input or Output.
+  exec_vec = { SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  stor_vec = { SpvStorageClassInput,
+               SpvStorageClassOutput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // Any variable decorated with Position must be declared as a
+  // four-component vector of 32-bit floating-point values.
+  SpvOp elem_type = SpvOpTypeFloat;
+  SpvOp comp_type = SpvOpTypeVector;
+  uint32_t comp_size = 4;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckPointSize(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The Position decoration must be used only within vertex, tessellation
+  // control, tessellation evaluation, and geometry shaders.
+  exec_vec = { SpvExecutionModelVertex,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // In a vertex shader, any variable decorated with Position 
+  // must be declared using the Output storage class.
+  exec_vec = { SpvExecutionModelVertex };
+  stor_vec = { SpvStorageClassOutput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+  
+  // In a tessellation control, tessellation evaluation, or geometry shader,
+  // any variable decorated with Position must not be declared in a
+  // storage class other than Input or Output.
+  exec_vec = { SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  stor_vec = { SpvStorageClassInput,
+               SpvStorageClassOutput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // Any variable decorated with PointSize must be declared as a
+  // scalar 32-bit floating-point value.
+  SpvOp elem_type = SpvOpTypeFloat;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckClipDistance(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{  
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The ClipDistance decoration must be used only within vertex, fragment,
+  // tessellation control, tessellation evaluation, and geometry shaders.
+  exec_vec = { SpvExecutionModelVertex,
+               SpvExecutionModelFragment,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // In vertex shaders, any variable decorated with ClipDistance
+  // must be declared using the Output storage class.
+  exec_vec = { SpvExecutionModelVertex };
+  stor_vec = { SpvStorageClassOutput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // In fragment shaders, any variable decorated with ClipDistance
+  // must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelFragment };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // In tessellation control, tessellation evaluation, or geometry shaders,
+  // any variable decorated with ClipDistance must not be declared in a
+  // storage class other than Input or Output.
+  exec_vec = { SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  stor_vec = { SpvStorageClassInput,
+                SpvStorageClassOutput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // Any variable decorated with ClipDistance must be declared as
+  // an array of 32-bit floating-point values.
+  SpvOp elem_type = SpvOpTypeFloat;
+  SpvOp comp_type = SpvOpTypeArray;
+  uint32_t comp_size = 0; // any size
+  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckCullDistance(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The CullDistance decoration must be used only within vertex, fragment,
+  // tessellation control, tessellation evaluation, and geometry shaders.
+  exec_vec = { SpvExecutionModelVertex,
+               SpvExecutionModelFragment,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // In vertex shaders, any variable decorated with CullDistance
+  // must be declared using the Output storage class.
+  exec_vec = { SpvExecutionModelVertex };
+  stor_vec = { SpvStorageClassOutput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // In fragment shaders, any variable decorated with CullDistance
+  // must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelFragment };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // In tessellation control, tessellation evaluation, or geometry shaders,
+  // any variable decorated with CullDistance must not be declared in a
+  // storage class other than Input or Output.
+  exec_vec = { SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  stor_vec = { SpvStorageClassInput,
+                SpvStorageClassOutput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // Any variable decorated with CullDistance must be declared as
+  // an array of 32-bit floating-point values.
+  SpvOp elem_type = SpvOpTypeFloat;
+  SpvOp comp_type = SpvOpTypeArray;
+  uint32_t comp_size = 0; // any size
+  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckVertexId(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The VertexId decoration must be used only within vertex shaders
+  exec_vec = { SpvExecutionModelVertex };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // VertexId requires Vertex execution and Input storage class.
+  exec_vec = { SpvExecutionModelVertex };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+    
+  // VertexId must be declared as a scalar 32-bit integer.
+  SpvOp elem_type = SpvOpTypeInt;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckInstanceId(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The InstanceId decoration must be used only within vertex shaders
+  exec_vec = { SpvExecutionModelVertex };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // InstanceId requires Vertex execution and Input storage class.
+  exec_vec = { SpvExecutionModelVertex };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+    
+  // InstanceId must be declared as a scalar 32-bit integer.
+  SpvOp elem_type = SpvOpTypeFloat;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckPrimitiveId(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // If a geometry shader is present and the fragment shader reads from
+  // an input variable decorated with PrimitiveId, then the geometry
+  // shader must write to an output variable decorated with PrimitiveId
+  // in all execution paths.
+
+  // TODO (jcaraban)
+
+  // The PrimitiveId decoration must be used only within fragment,
+  // tessellation control, tessellation evaluation, and geometry shaders.
+  exec_vec = { SpvExecutionModelFragment,
+               SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation,
+               SpvExecutionModelGeometry };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // In a tessellation control or tessellation evaluation shader,
+  // any variable decorated with PrimitiveId must be declared
+  // using the Output storage class.
+  exec_vec = { SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation };
+  stor_vec = { SpvStorageClassOutput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // In a geometry shader, any variable decorated with PrimitiveId must
+  // be declared using either the Input or Output storage class.
+  exec_vec = { SpvExecutionModelGeometry };
+  stor_vec = { SpvStorageClassInput,
+               SpvStorageClassOutput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // In fragment shaders, any variable decorated with PrimitiveId
+  // must be declared using the Input storage class ...
+  exec_vec = { SpvExecutionModelFragment };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+    
+  // ... and either the Geometry or Tessellation capability must also be declared.
+
+  // TODO(jcaraban): this part is covered by 'validate_instructions.cpp',
+  //                 but shouldn't it be treated in the built-ins file?
+
+  /*
+  if (not vstate.HasCapability(SpvCapabilityGeometry) &&
+      not vstate.HasCapability(SpvCapabilityTessellation)) {
+    return vstate.diag(SPV_ERROR_INVALID_ID)
+        << "In a fragment shader, any variable decorated with "
+           "PrimitiveId must be declared using the Input storage "
+           "class, and either the Geometry or Tessellation "
+           "capability must also be declared.";
+  }*/
+
+  // Any variable decorated with PrimitiveId must be declared as
+  // a scalar 32-bit integer.
+  SpvOp elem_type = SpvOpTypeInt;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type))
+    return error;
+
+  return SPV_SUCCESS; 
+}
+
+spv_result_t CheckInvocationId(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The InvocationId decoration must be used only within
+  // tessellation control and geometry shaders.
+  exec_vec = { SpvExecutionModelTessellationControl,
+               SpvExecutionModelGeometry };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // The variable decorated with InvocationId must be declared
+  // using the Input storage class.
+  exec_vec = { SpvExecutionModelTessellationControl,
+               SpvExecutionModelGeometry };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // The variable decorated with InvocationId must be declared as
+  // a scalar 32-bit integer.
+  SpvOp elem_type = SpvOpTypeInt;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckLayer(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // If a vertex processing stage shader entry point’s interface includes a
+  // variable decorated with Layer, it must write the same value to Layer
+  // for all output vertices of a given primitive.
+
+  // TODO ?
+
+  // The Layer decoration must be used only with geometry and fragment shaders
+  exec_vec = { SpvExecutionModelGeometry,
+               SpvExecutionModelFragment };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // In a geometry shader, any variable decorated with Layer
+  // must be declared using the Output storage class.
+  exec_vec = { SpvExecutionModelGeometry };
+  stor_vec = { SpvStorageClassOutput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // In a fragment shader, any variable decorated with Layer
+  // must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelFragment };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // Any variable decorated with Layer must be declared as
+  // a scalar 32-bit integer.
+  SpvOp elem_type = SpvOpTypeInt;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckViewportIndex(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The ViewportIndex decoration must be used only within
+  // geometry, and fragment shaders.
+  exec_vec = { SpvExecutionModelGeometry,
+               SpvExecutionModelFragment };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // In a geometry shader, any variable decorated with ViewportIndex
+  // must be declared using the Output storage class.
+  exec_vec = { SpvExecutionModelGeometry };
+  stor_vec = { SpvStorageClassOutput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // In a fragment shader, any variable decorated with ViewportIndex
+  // must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelFragment };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+    
+  // Any variable decorated with ViewportIndex must be declared as
+  // a scalar 32-bit integer.
+  SpvOp elem_type = SpvOpTypeInt;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckTessLevelOuter(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The TessLevelOuter decoration must be used only within
+  // tessellation control and tessellation evaluation shaders.
+  exec_vec = { SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // In a tessellation control shader, any variable decorated with
+  // TessLevelOuter must be declared using the Output storage class.
+  exec_vec = { SpvExecutionModelTessellationControl };
+  stor_vec = { SpvStorageClassOutput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // In a tessellation evaluation shader, any variable decorated with
+  // TessLevelOuter must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelTessellationEvaluation };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // Any variable decorated with TessLevelOuter must be declared as
+  // an array of size four, containing 32-bit floating-point values.
+  SpvOp elem_type = SpvOpTypeFloat;
+  SpvOp comp_type = SpvOpTypeArray;
+  uint32_t comp_size = 4;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+    return error; 
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckTessLevelInner(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The TessLevelInner decoration must be used only within
+  // tessellation control and tessellation evaluation shaders.
+  exec_vec = { SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // In a tessellation control shader, any variable decorated with
+  // TessLevelInner must be declared using the Output storage class.
+  exec_vec = { SpvExecutionModelTessellationControl };
+  stor_vec = { SpvStorageClassOutput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // In a tessellation evaluation shader, any variable decorated with
+  // TessLevelInner must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelTessellationEvaluation };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // Any variable decorated with TessLevelOuter must be declared as
+  // an array of size two, containing 32-bit floating-point values.
+  SpvOp elem_type = SpvOpTypeFloat;
+  SpvOp comp_type = SpvOpTypeArray;
+  uint32_t comp_size = 2;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+    return error; 
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckTessCoord(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The TessCoord decoration must be used only within tessellation evaluation shaders.
+  exec_vec = { SpvExecutionModelTessellationEvaluation };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+  
+  // The variable decorated with TessCoord must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelTessellationEvaluation };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // The variable decorated with TessCoord must be declared as
+  // three-component vector of 32-bit floating-point values.
+  SpvOp elem_type = SpvOpTypeFloat;
+  SpvOp comp_type = SpvOpTypeVector;
+  uint32_t comp_size = 3;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckPatchVertices(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The PatchVertices decoration must be used only within
+  // tessellation control and tessellation evaluation shaders.
+  exec_vec = { SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // The variable decorated with PatchVertices must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelTessellationControl,
+               SpvExecutionModelTessellationEvaluation };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // The variable decorated with PatchVertices must be declared as
+  // a scalar 32-bit integer.
+  SpvOp elem_type = SpvOpTypeInt;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckFragCoord(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The FragCoord decoration must be used only within fragment shaders.
+  exec_vec = { SpvExecutionModelFragment };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // The variable decorated with FragCoord must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelFragment };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // The variable decorated with FragCoord must be declared as
+  // a four-component vector of 32-bit floating-point values.
+  SpvOp elem_type = SpvOpTypeFloat;
+  SpvOp comp_type = SpvOpTypeVector;
+  uint32_t comp_size = 4;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckPointCoord(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The PointCoord decoration must be used only within fragment shaders.
+  exec_vec = { SpvExecutionModelFragment };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // The variable decorated with PointCoord must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelFragment };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  //  The variable decorated with PointCoord must be declared as
+  // two-component vector of 32-bit floating-point values.
+  SpvOp elem_type = SpvOpTypeFloat;
+  SpvOp comp_type = SpvOpTypeVector;
+  uint32_t comp_size = 2;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckFrontFacing(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // The FrontFacing decoration must be used only within fragment shaders.
+  exec_vec = { SpvExecutionModelFragment };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // The variable decorated with FrontFacing must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelFragment };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // The variable decorated with FrontFacing must be declared as a boolean.
+  SpvOp elem_type = SpvOpTypeBool;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type))
+    return error;
+
+  return SPV_SUCCESS;  
+}
+
+spv_result_t CheckSampleId(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The SampleId decoration must be used only within fragment shaders.
+  exec_vec = { SpvExecutionModelFragment };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // The variable decorated with SampleId must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelFragment };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // The variable decorated with SampleId must be declared as
+  // a scalar 32-bit.
+  SpvOp elem_type = SpvOpTypeInt;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type))
+    return error;
+  
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckSamplePosition(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The SamplePosition decoration must be used only within fragment shaders.
+  exec_vec = { SpvExecutionModelFragment };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // The variable decorated with SamplePosition must be
+  // declared using the Input storage class.
+  exec_vec = { SpvExecutionModelFragment };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // The variable decorated with SamplePosition must be declared as
+  // a two-component vector of 32-bit floating-point values.
+  SpvOp elem_type = SpvOpTypeFloat;
+  SpvOp comp_type = SpvOpTypeVector;
+  uint32_t comp_size = 2;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckSampleMask(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The SampleMask decoration must be used only within fragment shaders.
+  exec_vec = { SpvExecutionModelFragment };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // Any variable decorated with SampleMask must be declared
+  // using either the Input or Output storage class.
+  exec_vec = { SpvExecutionModelFragment };
+  stor_vec = { SpvStorageClassInput,
+               SpvStorageClassOutput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // Any variable decorated with SampleMask must be declared as
+  // an array of 32-bit integers.
+  SpvOp elem_type = SpvOpTypeInt;
+  SpvOp comp_type = SpvOpTypeArray;
+  uint32_t comp_size = 0; // Any size
+  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+    return error; 
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckFragDepth(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // To write to FragDepth, a shader must declare the DepthReplacing execution mode.
+
+  // TODO (jcaraban)
+
+  // The FragDepth decoration must be used only within fragment shaders.
+  exec_vec = { SpvExecutionModelFragment };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // The variable decorated with FragDepth must be declared
+  // using the Output storage class.
+  exec_vec = { SpvExecutionModelFragment };
+  stor_vec = { SpvStorageClassOutput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // The variable decorated with FragDepth must be declared as
+  // a scalar 32-bit floating-point value.
+  SpvOp elem_type = SpvOpTypeFloat;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckHelperInvocation(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The HelperInvocation decoration must be used only within fragment shaders
+  exec_vec = { SpvExecutionModelFragment };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // The variable decorated with HelperInvocation must be declared
+  // using the Input storage class.
+  exec_vec = { SpvExecutionModelFragment };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // The variable decorated with HelperInvocation must be declared as a boolean
+  SpvOp elem_type = SpvOpTypeBool;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckNumWorkgroups(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec; 
+
+  // The NumWorkgroups decoration must be used only within compute shaders.
+  exec_vec = { SpvExecutionModelGLCompute,
+               SpvExecutionModelKernel };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // The variable decorated with NumWorkgroups must be declared
+  // using the Input storage class.
+  exec_vec = { SpvExecutionModelGLCompute,
+               SpvExecutionModelKernel };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // The variable decorated with NumWorkgroups must be declared as
+  // a three-component vector of 32-bit integers.
+  SpvOp elem_type = SpvOpTypeInt;
+  SpvOp comp_type = SpvOpTypeVector;
+  uint32_t comp_size = 3;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+    return error;
+  
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckWorkgroupSize(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // If an object is decorated with the WorkgroupSize decoration,
+  // this must take precedence over any execution mode set for LocalSize
+
+  // TODO(jcaraban)
+
+  // The WorkgroupSize decoration must be used only within compute shaders.
+  exec_vec = { SpvExecutionModelGLCompute,
+               SpvExecutionModelKernel };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // The object decorated with WorkgroupSize must be
+  // a specialization constant or a constant.
+  storage_class = storage_class;
+  // TODO(jcaraban)
+
+  // The object decorated with WorkgroupSize must be declared as
+  // a three-component vector of 32-bit integers.
+  SpvOp elem_type = SpvOpTypeInt;
+  SpvOp comp_type = SpvOpTypeVector;
+  uint32_t comp_size = 3;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckWorkgroupId(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // The WorkgroupId decoration must be used only within compute shaders.
+  exec_vec = { SpvExecutionModelGLCompute,
+               SpvExecutionModelKernel };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // The variable decorated with WorkgroupId must be declared
+  // using the Input storage class.
+  exec_vec = { SpvExecutionModelGLCompute,
+               SpvExecutionModelKernel };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // The variable decorated with WorkgroupId must be declared as
+  // a three-component vector of 32-bit integers.
+  SpvOp elem_type = SpvOpTypeInt;
+  SpvOp comp_type = SpvOpTypeVector;
+  uint32_t comp_size = 3;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckLocalInvocationId(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // The LocalInvocationId decoration must be used only within compute shaders.
+  exec_vec = { SpvExecutionModelGLCompute,
+               SpvExecutionModelKernel };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // The variable decorated with LocalInvocationId must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelGLCompute,
+               SpvExecutionModelKernel };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+    
+  // The variable decorated with LocalInvocationId must be declared as
+  // a three-component vector of 32-bit integers.
+  SpvOp elem_type = SpvOpTypeInt;
+  SpvOp comp_type = SpvOpTypeVector;
+  uint32_t comp_size = 3;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckGlobalInvocationId(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The GlobalInvocationId decoration must be used only within compute shaders.
+  exec_vec = { SpvExecutionModelGLCompute,
+               SpvExecutionModelKernel };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+    
+  // The variable decorated with GlobalInvocationId must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelGLCompute,
+               SpvExecutionModelKernel };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // The variable decorated with GlobalInvocationId must be declared as
+  // a three-component vector of 32-bit integers.
+  SpvOp elem_type = SpvOpTypeInt;
+  SpvOp comp_type = SpvOpTypeVector;
+  uint32_t comp_size = 3;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckLocalInvocationIndex(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The LocalInvocationIndex decoration must be used only within compute shaders.
+  exec_vec = { SpvExecutionModelGLCompute,
+               SpvExecutionModelKernel };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+    
+  // The variable decorated with LocalInvocationIndex must be declared using the Input storage class.
+  exec_vec = { SpvExecutionModelGLCompute,
+               SpvExecutionModelKernel };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // The variable decorated with GlobalInvocationId must be declared as
+  // a scalar 32-bit integer.
+  SpvOp elem_type = SpvOpTypeInt;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type))
+    return error;
+
+  return SPV_SUCCESS;
+}
+/*
+spv_result_t CheckWorkDim(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // WorkDim is part of the OpenCL specification
+  exec_vec = { SpvExecutionModelKernel };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+    
+  // WorkDim is an input argument to the kernels
+  exec_vec = { SpvExecutionModelKernel };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // WorkDim is a scalar 32-bit integer
+  SpvOp elem_type = SpvOpTypeInt;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckGlobalSize(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+  
+  // GlobalSize is part of the OpenCL specification
+  exec_vec = { SpvExecutionModelKernel };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+    
+  // GlobalSize is an input argument to the kernels
+  exec_vec = { SpvExecutionModelKernel };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // GlobalSize is a three-component vector of 32-bit integers
+  SpvOp elem_type = SpvOpTypeInt;
+  SpvOp comp_type = SpvOpTypeVector;
+  uint32_t comp_size = 3;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type,comp_type,comp_size))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckEnqueuedWorkgroupSize(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  return CheckWorkgroupSize(vstate,inst,storage_class,exec_model);
+}
+
+spv_result_t CheckGlobalOffset(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  return checkGlobalSize(vstate,inst,storage_class,exec_model);
+}
+
+spv_result_t CheckGlobalLinearId(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  return CheckLocalInvocationIndex(vstate,inst,storage_class,exec_model);
+}
+
+spv_result_t CheckSubgroupSize(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  return CheckWorkgroupSize(vstate,inst,storage_class,exec_model);
+}
+
+spv_result_t CheckSubgroupMaxSize(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  return checkSubgroupSize(vstate,inst,storage_class,exec_model);
+}
+
+spv_result_t CheckNumSubgroups(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckNumEnqueuedSubgroups(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckSubgroupId(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckSubgroupLocalInvocationId(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+*/
+spv_result_t CheckVertexIndex(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  std::vector<uint32_t> exec_vec, stor_vec;
+
+  // The VertexIndex decoration must be used only within vertex shaders.
+  exec_vec = { SpvExecutionModelVertex };
+  if (auto error = checkExecutionModel(vstate,exec_model,exec_vec))
+    return error;
+
+  // The variable decorated with VertexIndex must be declared
+  // using the Input storage class.
+  exec_vec = { SpvExecutionModelVertex };
+  stor_vec = { SpvStorageClassInput };
+  if (auto error = checkStorageClass(vstate,exec_model,storage_class,exec_vec,stor_vec))
+    return error;
+
+  // The variable decorated with VertexIndex must be declared as
+  // a scalar 32-bit integer.
+  SpvOp elem_type = SpvOpTypeInt;
+  if (auto error = checkBuiltInType(vstate,inst,elem_type))
+    return error;
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t CheckInstanceIndex(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban): many built-ins show same logic, e.g. Vertex/InstanceIndex
+  return CheckVertexIndex(vstate,inst,storage_class,exec_model);
+}
+/*
+spv_result_t CheckSubgroupEqMaskKHR(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckSubgroupGeMaskKHR(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckSubgroupGtMaskKHR(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckSubgroupLeMaskKHR(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckSubgroupLtMaskKHR(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckBaseVertex(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckBaseInstance(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckDrawIndex(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckDeviceIndex(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckViewIndex(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckBaryCoordNoPerspAMD(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckBaryCoordNoPerspCentroidAMD(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckBaryCoordNoPerspSampleAMD(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckBaryCoordSmoothAMD(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckBaryCoordSmoothCentroidAMD(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckBaryCoordSmoothSampleAMD(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckBaryCoordPullModelAMD(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckFragStencilRefEXT(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckViewportMaskNV(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckSecondaryPositionNV(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckSecondaryViewportMaskNV(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckPositionPerViewNV(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+
+spv_result_t CheckViewportMaskPerViewNV(ValidationState_t& vstate, Instruction inst,
+    uint32_t storage_class, uint32_t exec_model)
+{
+  // TODO(jcaraban)
+}
+*/
+
+}  // anonymous namespace
+
+namespace libspirv {
+
+#define BUILTIN_CASE(bltin) \
+  case SpvBuiltIn ## bltin: \
+    return Check ## bltin (_,inst,storage_class,execution_model);
+
+// Validates that decorations have been applied properly.
+spv_result_t ValidateBuiltIns(ValidationState_t& _) {
+  // For every instruction decorated with a built-in...
+  for (const auto& inst : _.ordered_instructions()) {
+    if (not isBuiltIn(inst,_))
+      continue;
+    auto storage_class = getStorageClass(inst);
+    auto built_in = getBuiltInEnum(inst,_);
+    // For every 'execution model' affecting the built-in, check its validty
+    for (auto execution_model : getExecutionModels(_,inst)) {
+      switch (built_in) {
+        BUILTIN_CASE( Position                    )
+        BUILTIN_CASE( PointSize                   )
+        BUILTIN_CASE( ClipDistance                )
+        BUILTIN_CASE( CullDistance                )
+        BUILTIN_CASE( VertexId                    )
+        BUILTIN_CASE( InstanceId                  )
+        BUILTIN_CASE( PrimitiveId                 )
+        BUILTIN_CASE( InvocationId                )
+        BUILTIN_CASE( Layer                       )
+        BUILTIN_CASE( ViewportIndex               )
+        BUILTIN_CASE( TessLevelOuter              )
+        BUILTIN_CASE( TessLevelInner              )
+        BUILTIN_CASE( TessCoord                   )
+        BUILTIN_CASE( PatchVertices               )
+        BUILTIN_CASE( FragCoord                   )
+        BUILTIN_CASE( PointCoord                  )
+        BUILTIN_CASE( FrontFacing                 )
+        BUILTIN_CASE( SampleId                    )
+        BUILTIN_CASE( SamplePosition              )
+        BUILTIN_CASE( SampleMask                  )
+        BUILTIN_CASE( FragDepth                   )
+        BUILTIN_CASE( HelperInvocation            )
+        BUILTIN_CASE( NumWorkgroups               )
+        BUILTIN_CASE( WorkgroupSize               )
+        BUILTIN_CASE( WorkgroupId                 )
+        BUILTIN_CASE( LocalInvocationId           )
+        BUILTIN_CASE( GlobalInvocationId          )
+        BUILTIN_CASE( LocalInvocationIndex        )
+        // TODO(jcaraban): the built-ins below are not clearly documented
+        //BUILTIN_CASE( WorkDim                     )
+        //BUILTIN_CASE( GlobalSize                  )
+        //BUILTIN_CASE( EnqueuedWorkgroupSize       )
+        //BUILTIN_CASE( GlobalOffset                )
+        //BUILTIN_CASE( GlobalLinearId              )
+        //BUILTIN_CASE( SubgroupSize                )
+        //BUILTIN_CASE( SubgroupMaxSize             )
+        //BUILTIN_CASE( NumSubgroups                )
+        //BUILTIN_CASE( NumEnqueuedSubgroups        )
+        //BUILTIN_CASE( SubgroupId                  )
+        //BUILTIN_CASE( SubgroupLocalInvocationId   )
+        BUILTIN_CASE( VertexIndex                 )
+        BUILTIN_CASE( InstanceIndex               )
+        //BUILTIN_CASE( SubgroupEqMaskKHR           )
+        //BUILTIN_CASE( SubgroupGeMaskKHR           )
+        //BUILTIN_CASE( SubgroupGtMaskKHR           )
+        //BUILTIN_CASE( SubgroupLeMaskKHR           )
+        //BUILTIN_CASE( SubgroupLtMaskKHR           )
+        //BUILTIN_CASE( BaseVertex                  )
+        //BUILTIN_CASE( BaseInstance                )
+        //BUILTIN_CASE( DrawIndex                   )
+        //BUILTIN_CASE( DeviceIndex                 )
+        //BUILTIN_CASE( ViewIndex                   )
+        //BUILTIN_CASE( BaryCoordNoPerspAMD         )
+        //BUILTIN_CASE( BaryCoordNoPerspCentroidAMD )
+        //BUILTIN_CASE( BaryCoordNoPerspSampleAMD   )
+        //BUILTIN_CASE( BaryCoordSmoothAMD          )
+        //BUILTIN_CASE( BaryCoordSmoothCentroidAMD  )
+        //BUILTIN_CASE( BaryCoordSmoothSampleAMD    )
+        //BUILTIN_CASE( BaryCoordPullModelAMD       )
+        //BUILTIN_CASE( FragStencilRefEXT           )
+        //BUILTIN_CASE( ViewportMaskNV              )
+        //BUILTIN_CASE( SecondaryPositionNV         )
+        //BUILTIN_CASE( SecondaryViewportMaskNV     )
+        //BUILTIN_CASE( PositionPerViewNV           )
+        //BUILTIN_CASE( ViewportMaskPerViewNV       )
+      }
+    }
+  }
+  return SPV_SUCCESS;
+}
+
+#undef BUILTIN_CASE
+
+}  // namespace libspirv
+

--- a/test/val/CMakeLists.txt
+++ b/test/val/CMakeLists.txt
@@ -110,6 +110,12 @@ add_spvtools_unittest(TARGET val_decoration
   LIBS ${SPIRV_TOOLS}
 )
 
+add_spvtools_unittest(TARGET val_builtins
+	SRCS val_builtins_test.cpp
+       ${VAL_TEST_COMMON_SRCS}
+  LIBS ${SPIRV_TOOLS}
+)
+
 add_spvtools_unittest(TARGET val_instructions
 	SRCS val_instructions_test.cpp
        ${VAL_TEST_COMMON_SRCS}

--- a/test/val/val_builtins_test.cpp
+++ b/test/val/val_builtins_test.cpp
@@ -180,7 +180,7 @@ string GenerateKernelCode(const BuiltInCase& bic)
 // PARAMETERIZED TESTS
 //
 
-TEST_P(ValidateBuiltIn, BuiltInValid) {
+TEST_P(ValidateBuiltIn, BuiltInGood) {
   CompileSuccessfully(GenerateShaderCode(GetParam()),SPV_ENV_VULKAN_1_0);
   EXPECT_EQ(SPV_SUCCESS, ValidateAndRetrieveValidationState());
 }
@@ -251,13 +251,13 @@ INSTANTIATE_TEST_CASE_P(ExtendedBuiltIn, ValidateBuiltIn,
   ));
 // clang-format on
 
-TEST_P(ValidateBuiltInCL, BuiltInCLOK) {
+TEST_P(ValidateBuiltInCL, BuiltInCLGood) {
   CompileSuccessfully(GenerateKernelCode(GetParam()),SPV_ENV_OPENCL_2_2);
   EXPECT_EQ(SPV_SUCCESS, ValidateAndRetrieveValidationState());
 }
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(BuiltInCLOK, ValidateBuiltInCL,
+INSTANTIATE_TEST_CASE_P(KernelBuiltIn, ValidateBuiltInCL,
   ::testing::Values(
        BuiltInCase{"NumWorkgroups","%vecu3","Input","Kernel"},
        // WorkgroupSize is tested individually
@@ -657,7 +657,7 @@ TEST_F(ValidateBuiltIn, FragDepthNeedsDepthReplacing) {
 }
 #endif
 
-TEST_F(ValidateBuiltIn, WorkgroupSizeOK) {
+TEST_F(ValidateBuiltIn, WorkgroupSizeGood) {
   string spirv = R"(
     OpCapability Shader
     OpCapability Linkage

--- a/test/val/val_builtins_test.cpp
+++ b/test/val/val_builtins_test.cpp
@@ -1,0 +1,324 @@
+// Copyright (c) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Common validation fixtures for unit tests
+
+#include "gmock/gmock.h"
+#include "unit_spirv.h"
+#include "val_fixtures.h"
+#include "source/val/decoration.h"
+
+namespace {
+
+using std::string;
+using std::vector;
+using std::tie;
+using std::tuple;
+using std::make_tuple;
+using ::testing::HasSubstr;
+using ::testing::Eq;
+using libspirv::Decoration;
+
+using tuple4string = tuple<string,string,string,string>;
+
+using ValidateBuiltInExecutionModel = spvtest::ValidateBase<tuple4string>;
+using ValidateBuiltInStorage = spvtest::ValidateBase<tuple4string>;
+using ValidateBuiltInType = spvtest::ValidateBase<tuple4string>;
+using ValidateBuiltIn = spvtest::ValidateBase<tuple4string>;
+
+
+string GenerateShaderCode(const tuple4string& tuple)
+{
+  string bltin, type, storage, exec;
+  tie(bltin,type,storage,exec) = tuple;
+  
+  string capabilities = R"(
+    OpCapability Shader
+    OpCapability Tessellation
+    OpCapability Geometry
+    OpCapability DrawParameters
+    OpCapability SampleRateShading
+    OpCapability DeviceGroup
+    OpCapability MultiView
+    OpCapability MultiViewport
+    OpCapability Linkage
+  )";
+  string extensions = R"(
+    OpExtension "SPV_KHR_shader_draw_parameters"
+    OpExtension "SPV_KHR_device_group"
+    OpExtension "SPV_KHR_multiview"
+  )";
+  string memory = R"(
+    OpMemoryModel Logical GLSL450
+  )";
+  string entries = R"(
+    OpEntryPoint )" + exec + R"( %entry "entry" %bltin
+  )";
+  string modes = "";
+  string decorations = R"(  
+    OpDecorate %bltin BuiltIn )" + bltin + R"(
+  )";
+  string types = R"(
+    %void    = OpTypeVoid
+    %bool    = OpTypeBool
+    %uint32  = OpTypeInt 32 0
+    %float   = OpTypeFloat 32
+    %vecu2   = OpTypeVector %uint32 2
+    %vecu3   = OpTypeVector %uint32 3
+    %vecu4   = OpTypeVector %uint32 4
+    %vecf2   = OpTypeVector %float 2
+    %vecf3   = OpTypeVector %float 3
+    %vecf4   = OpTypeVector %float 4
+    %const2  = OpConstant %uint32 2
+    %const3  = OpConstant %uint32 3
+    %const4  = OpConstant %uint32 4
+    %arru2   = OpTypeArray %uint32 %const2
+    %arru3   = OpTypeArray %uint32 %const3
+    %arru4   = OpTypeArray %uint32 %const4
+    %arrf2   = OpTypeArray %float %const2
+    %arrf3   = OpTypeArray %float %const3
+    %arrf4   = OpTypeArray %float %const4
+    %voidfun = OpTypeFunction %void
+  )";
+  string definitions = R"(
+    %ptr   = OpTypePointer )" + storage + " " + type + R"(
+    %bltin = OpVariable %ptr )" + storage + R"(
+    %entry = OpFunction %void None %voidfun
+    %label = OpLabel
+             OpReturn
+             OpFunctionEnd
+  )";
+
+  return capabilities + extensions + memory + entries
+         + modes + decorations + types + definitions;
+}
+
+// clang-format off
+#define BUILTIN(builtin,type,storage,exec) \
+  make_tuple(string(builtin),string(type),string(storage),string(exec))
+
+TEST_P(ValidateBuiltIn, BuiltInValid) {
+  CompileSuccessfully(GenerateShaderCode(GetParam()));
+  EXPECT_EQ(SPV_SUCCESS, ValidateAndRetrieveValidationState());
+}
+
+INSTANTIATE_TEST_CASE_P(BuiltInValid, ValidateBuiltIn,
+  ::testing::Values(
+       BUILTIN("Position","%vecf4","Output","Vertex"),
+       BUILTIN("PointSize","%float","Output","Vertex"),
+       BUILTIN("ClipDistance","%arrf2","Output","Vertex"),
+       BUILTIN("CullDistance","%arrf3","Output","Vertex"),
+       BUILTIN("VertexId","%uint32","Input","Vertex"),
+       BUILTIN("InstanceId","%float","Input","Vertex"),
+       BUILTIN("PrimitiveId","%uint32","Input","Fragment"),
+       BUILTIN("InvocationId","%uint32","Input","Geometry"),
+       BUILTIN("Layer","%uint32","Input","Fragment"),
+       BUILTIN("ViewportIndex","%uint32","Output","Geometry"),
+       BUILTIN("TessLevelOuter","%arrf4","Output","TessellationControl"),
+       BUILTIN("TessLevelInner","%arrf2","Input","TessellationEvaluation"),
+       BUILTIN("TessCoord","%vecf3","Input","TessellationEvaluation"),
+       BUILTIN("PatchVertices","%uint32","Input","TessellationControl"),
+       BUILTIN("FragCoord","%vecf4","Input","Fragment"),
+       BUILTIN("PointCoord","%vecf2","Input","Fragment"),
+       BUILTIN("FrontFacing","%bool","Input","Fragment"),
+       BUILTIN("SampleId","%uint32","Input","Fragment"),
+       BUILTIN("SamplePosition","%vecf2","Input","Fragment"),
+       BUILTIN("SampleMask","%arru2","Input","Fragment"),
+       BUILTIN("FragDepth","%float","Output","Fragment"),
+       BUILTIN("HelperInvocation","%bool","Input","Fragment"),
+       BUILTIN("NumWorkgroups","%vecu3","Input","GLCompute"),
+       //BUILTIN("WorkgroupSize","%vecu3","Uniform","GLCompute"),
+       BUILTIN("WorkgroupId","%vecu3","Input","GLCompute"),
+       BUILTIN("LocalInvocationId","%vecu3","Input","GLCompute"),
+       BUILTIN("GlobalInvocationId","%vecu3","Input","GLCompute"),
+       BUILTIN("LocalInvocationIndex","%uint32","Input","GLCompute"),
+       // WorkDim, GLobalSize, EnqueueWorkgroupSize, GLobalOffset
+       // GLobalLinearId, SubgroupSize, SubgroupMaxSize, NumSubgroups
+       // NumEnqueuedSubgroups, SubgroupId, SubroupLocalInvocationId,
+       BUILTIN("VertexIndex","%uint32","Input","Vertex"),
+       BUILTIN("InstanceIndex","%uint32","Input","Vertex")
+       // BaseVertex, BaseInstance, DrawIndex, DeviceIndex, ViewIndex
+  ), );
+
+
+TEST_P(ValidateBuiltInExecutionModel, BuiltInExecutionModel) {
+  CompileSuccessfully(GenerateShaderCode(GetParam()));
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Built-in variables are restricted to only certain"
+                        "EXECUTION MODELS (see e.g. Vulkan specification)"));
+}
+
+INSTANTIATE_TEST_CASE_P(BuiltInExecutionModel, ValidateBuiltInExecutionModel,
+  ::testing::Values(
+       BUILTIN("Position","%vecf4","Output","Fragment"),
+       BUILTIN("PointSize","%float","Output","GLCompute"),
+       BUILTIN("ClipDistance","%arrf2","Output","GLCompute"),
+       BUILTIN("CullDistance","%arrf3","Output","GLCompute"),
+       BUILTIN("VertexId","%uint32","Input","TessellationControl"),
+       BUILTIN("InstanceId","%float","Input","TessellationEvaluation"),
+       BUILTIN("PrimitiveId","%uint32","Input","Vertex"),
+       BUILTIN("InvocationId","%uint32","Input","Fragment"),
+       BUILTIN("Layer","%uint32","Input","GLCompute"),
+       BUILTIN("ViewportIndex","%uint32","Output","Vertex"),
+       BUILTIN("TessLevelOuter","%arrf4","Output","Geometry"),
+       BUILTIN("TessLevelInner","%arrf2","Input","Fragment"),
+       BUILTIN("TessCoord","%vecf3","Input","TessellationControl"),
+       BUILTIN("PatchVertices","%uint32","Input","Vertex"),
+       BUILTIN("FragCoord","%vecf4","Input","Geometry"),
+       BUILTIN("PointCoord","%vecf2","Input","GLCompute"),
+       BUILTIN("FrontFacing","%bool","Input","Vertex"),
+       BUILTIN("SampleId","%uint32","Input","GLCompute"),
+       BUILTIN("SamplePosition","%vecf2","Input","Geometry"),
+       BUILTIN("SampleMask","%arru2","Input","Vertex"),
+       BUILTIN("FragDepth","%float","Output","GLCompute"),
+       BUILTIN("HelperInvocation","%bool","Input","GLCompute"),
+       BUILTIN("NumWorkgroups","%vecu3","Input","Vertex"),
+       //BUILTIN("WorkgroupSize","%vecu3","Uniform","Fragment"),
+       BUILTIN("WorkgroupId","%vecu3","Input","TessellationControl"),
+       BUILTIN("LocalInvocationId","%vecu3","Input","TessellationEvaluation"),
+       BUILTIN("GlobalInvocationId","%vecu3","Input","Geometry"),
+       BUILTIN("LocalInvocationIndex","%uint32","Input","Vertex"),
+       // WorkDim, GLobalSize, EnqueueWorkgroupSize, GLobalOffset
+       // GLobalLinearId, SubgroupSize, SubgroupMaxSize, NumSubgroups
+       // NumEnqueuedSubgroups, SubgroupId, SubroupLocalInvocationId,
+       BUILTIN("VertexIndex","%uint32","Input","Fragment"),
+       BUILTIN("InstanceIndex","%uint32","Input","Geometry")
+       // BaseVertex, BaseInstance, DrawIndex, DeviceIndex, ViewIndex
+  ), );
+
+
+TEST_P(ValidateBuiltInStorage, BuiltInStorage) {
+  CompileSuccessfully(GenerateShaderCode(GetParam()));
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Built-in variables must match the STORAGE CLASS "
+                         "of the built-in (see e.g. Vulkan specification)"));
+}
+
+INSTANTIATE_TEST_CASE_P(BuiltInStorage, ValidateBuiltInStorage,
+  ::testing::Values(
+       BUILTIN("Position","%vecf4","Input","Vertex"),
+       BUILTIN("PointSize","%float","Input","Vertex"),
+       BUILTIN("ClipDistance","%arrf2","Input","Vertex"),
+       BUILTIN("CullDistance","%arrf3","Input","Vertex"),
+       BUILTIN("VertexId","%uint32","Output","Vertex"),
+       BUILTIN("InstanceId","%float","Output","Vertex"),
+       BUILTIN("PrimitiveId","%uint32","Output","Fragment"),
+       BUILTIN("InvocationId","%uint32","Output","Geometry"),
+       BUILTIN("Layer","%uint32","Output","Fragment"),
+       BUILTIN("ViewportIndex","%uint32","Input","Geometry"),
+       BUILTIN("TessLevelOuter","%arrf4","Input","TessellationControl"),
+       BUILTIN("TessLevelInner","%arrf2","Output","TessellationEvaluation"),
+       BUILTIN("TessCoord","%vecf3","Output","TessellationEvaluation"),
+       BUILTIN("PatchVertices","%uint32","Output","TessellationControl"),
+       BUILTIN("FragCoord","%vecf4","Output","Fragment"),
+       BUILTIN("PointCoord","%vecf2","Output","Fragment"),
+       BUILTIN("FrontFacing","%bool","Output","Fragment"),
+       BUILTIN("SampleId","%uint32","Output","Fragment"),
+       BUILTIN("SamplePosition","%vecf2","Output","Fragment"),
+       //BUILTIN("SampleMask","%arru2","Uniform","Fragment"),
+       BUILTIN("FragDepth","%float","Input","Fragment"),
+       BUILTIN("HelperInvocation","%bool","Output","Fragment"),
+       BUILTIN("NumWorkgroups","%vecu3","Output","GLCompute"),
+       //BUILTIN("WorkgroupSize","%vecu3","Uniform","GLCompute"),
+       BUILTIN("WorkgroupId","%vecu3","Output","GLCompute"),
+       BUILTIN("LocalInvocationId","%vecu3","Output","GLCompute"),
+       BUILTIN("GlobalInvocationId","%vecu3","Output","GLCompute"),
+       BUILTIN("LocalInvocationIndex","%uint32","Output","GLCompute"),
+       // WorkDim, GLobalSize, EnqueueWorkgroupSize, GLobalOffset
+       // GLobalLinearId, SubgroupSize, SubgroupMaxSize, NumSubgroups
+       // NumEnqueuedSubgroups, SubgroupId, SubroupLocalInvocationId,
+       BUILTIN("VertexIndex","%uint32","Output","Vertex"),
+       BUILTIN("InstanceIndex","%uint32","Output","Vertex")
+       // BaseVertex, BaseInstance, DrawIndex, DeviceIndex, ViewIndex
+  ), );
+
+
+TEST_P(ValidateBuiltInType, BuiltInType) {
+  CompileSuccessfully(GenerateShaderCode(GetParam()));
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Built-in variables must match the DATA TYPE "
+                        "of the built-in (see e.g. Vulkan specification)"));
+}
+
+INSTANTIATE_TEST_CASE_P(BuiltInType, ValidateBuiltInType,
+  ::testing::Values(
+       BUILTIN("Position","%uint32","Output","Vertex"),
+       BUILTIN("PointSize","%uint32","Output","Vertex"),
+       BUILTIN("ClipDistance","%vecf2","Output","Vertex"),
+       BUILTIN("CullDistance","%float","Output","Vertex"),
+       BUILTIN("VertexId","%arrf3","Input","Vertex"),
+       BUILTIN("InstanceId","%uint32","Input","Vertex"),
+       BUILTIN("PrimitiveId","%vecf4","Input","Fragment"),
+       BUILTIN("InvocationId","%float","Input","Geometry"),
+       BUILTIN("Layer","%arru3","Output","Geometry"),
+       BUILTIN("ViewportIndex","%vecu2","Input","Fragment"),
+       BUILTIN("TessLevelOuter","%uint32","Input","TessellationEvaluation"),
+       BUILTIN("TessLevelInner","%arrf4","Output","TessellationControl"),
+       BUILTIN("TessCoord","%vecu3","Input","TessellationEvaluation"),
+       BUILTIN("PatchVertices","%float","Input","TessellationControl"),
+       BUILTIN("FragCoord","%vecf2","Input","Fragment"),
+       BUILTIN("PointCoord","%vecf4","Input","Fragment"),
+       BUILTIN("FrontFacing","%void","Input","Fragment"),
+       BUILTIN("SampleId","%bool","Input","Fragment"),
+       BUILTIN("SamplePosition","%vecu2","Input","Fragment"),
+       BUILTIN("SampleMask","%arrf3","Input","Fragment"),
+       BUILTIN("FragDepth","%void","Output","Fragment"),
+       BUILTIN("HelperInvocation","%void","Input","Fragment"),
+       BUILTIN("NumWorkgroups","%arrf2","Input","GLCompute"),
+       //BUILTIN("WorkgroupSize","%vecu3","Uniform","GLCompute"),
+       BUILTIN("WorkgroupId","%vecf3","Input","GLCompute"),
+       BUILTIN("LocalInvocationId","%uint32","Input","GLCompute"),
+       BUILTIN("GlobalInvocationId","%float","Input","GLCompute"),
+       BUILTIN("LocalInvocationIndex","%vecu3","Input","GLCompute"),
+       // WorkDim, GLobalSize, EnqueueWorkgroupSize, GLobalOffset
+       // GLobalLinearId, SubgroupSize, SubgroupMaxSize, NumSubgroups
+       // NumEnqueuedSubgroups, SubgroupId, SubroupLocalInvocationId,
+       BUILTIN("VertexIndex","%vecf2","Input","Vertex"),
+       BUILTIN("InstanceIndex","%arru4","Input","Vertex")
+       // BaseVertex, BaseInstance, DrawIndex, DeviceIndex, ViewIndex
+       
+  ), );
+
+// clang-format on
+#undef BUILTIN
+
+TEST_F(ValidateBuiltIn, PrimitiveIdAsFragmentInput) {
+  string spirv = R"(
+    OpCapability Shader
+    OpCapability Linkage
+    OpMemoryModel Logical GLSL450
+    OpEntryPoint Fragment %entry "entry" %bltin
+    OpDecorate %bltin BuiltIn PrimitiveId
+    %void    = OpTypeVoid
+    %uint32  = OpTypeInt 32 0
+    %voidfun = OpTypeFunction %void
+    %ptr   = OpTypePointer Input %uint32
+    %bltin = OpVariable %ptr Input
+    %entry = OpFunction %void None %voidfun
+    %label = OpLabel
+             OpReturn
+             OpFunctionEnd)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_CAPABILITY,
+            ValidateAndRetrieveValidationState());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Decorate requires one of these capabilities: "
+                        "Geometry Tessellation"));
+}
+
+}  // anonymous namespace

--- a/test/val/val_builtins_test.cpp
+++ b/test/val/val_builtins_test.cpp
@@ -17,32 +17,38 @@
 #include "gmock/gmock.h"
 #include "unit_spirv.h"
 #include "val_fixtures.h"
-#include "source/val/decoration.h"
+
+namespace spvtest {
+  // TODO(jcaraban): what is a better place for this struct? val_fixtures.cpp?
+  struct BuiltInCase {
+    std::string name; // the builtin's name
+    std::string type; // its data type
+    std::string storage; // its storage class
+    std::string stage; // the shader stage
+  };
+  template class spvtest::ValidateBase<BuiltInCase>;
+}
 
 namespace {
 
 using std::string;
-using std::vector;
-using std::tie;
-using std::tuple;
-using std::make_tuple;
 using ::testing::HasSubstr;
 using ::testing::Eq;
-using libspirv::Decoration;
 
-using tuple4string = tuple<string,string,string,string>;
+using spvtest::BuiltInCase;
+using ValidateBuiltInStage = spvtest::ValidateBase<BuiltInCase>;
+using ValidateBuiltInStorage = spvtest::ValidateBase<BuiltInCase>;
+using ValidateBuiltInType = spvtest::ValidateBase<BuiltInCase>;
+using ValidateBuiltIn = spvtest::ValidateBase<BuiltInCase>;
 
-using ValidateBuiltInExecutionModel = spvtest::ValidateBase<tuple4string>;
-using ValidateBuiltInStorage = spvtest::ValidateBase<tuple4string>;
-using ValidateBuiltInType = spvtest::ValidateBase<tuple4string>;
-using ValidateBuiltIn = spvtest::ValidateBase<tuple4string>;
+using ValidateBuiltInStageCL = spvtest::ValidateBase<BuiltInCase>;
+using ValidateBuiltInStorageCL = spvtest::ValidateBase<BuiltInCase>;
+using ValidateBuiltInTypeCL = spvtest::ValidateBase<BuiltInCase>;
+using ValidateBuiltInCL = spvtest::ValidateBase<BuiltInCase>;
 
 
-string GenerateShaderCode(const tuple4string& tuple)
-{
-  string bltin, type, storage, exec;
-  tie(bltin,type,storage,exec) = tuple;
-  
+string GenerateShaderCode(const BuiltInCase& bic)
+{ 
   string capabilities = R"(
     OpCapability Shader
     OpCapability Tessellation
@@ -52,28 +58,94 @@ string GenerateShaderCode(const tuple4string& tuple)
     OpCapability DeviceGroup
     OpCapability MultiView
     OpCapability MultiViewport
-    OpCapability Linkage
+    OpCapability SubgroupBallotKHR
+    OpCapability StencilExportEXT
+    OpCapability ShaderViewportMaskNV
+    OpCapability ShaderStereoViewNV
+    OpCapability PerViewAttributesNV
   )";
   string extensions = R"(
     OpExtension "SPV_KHR_shader_draw_parameters"
     OpExtension "SPV_KHR_device_group"
     OpExtension "SPV_KHR_multiview"
+    OpExtension "SPV_KHR_shader_ballot"
+    OpExtension "SPV_AMD_shader_explicit_vertex_parameter"
+    OpExtension "SPV_EXT_shader_stencil_export"
+    OpExtension "SPV_NV_viewport_array2"
+    OpExtension "SPV_NV_stereo_view_rendering"
+    OpExtension "SPV_NVX_multiview_per_view_attributes"
   )";
   string memory = R"(
     OpMemoryModel Logical GLSL450
   )";
   string entries = R"(
-    OpEntryPoint )" + exec + R"( %entry "entry" %bltin
+    OpEntryPoint )" + bic.stage + R"( %entry "entry" %bltin
   )";
   string modes = "";
   string decorations = R"(  
-    OpDecorate %bltin BuiltIn )" + bltin + R"(
+    OpDecorate %bltin BuiltIn )" + bic.name + R"(
   )";
   string types = R"(
     %void    = OpTypeVoid
     %bool    = OpTypeBool
-    %uint32  = OpTypeInt 32 0
+    %int32   = OpTypeInt 32 1
     %float   = OpTypeFloat 32
+    %veci2   = OpTypeVector %int32 2
+    %veci3   = OpTypeVector %int32 3
+    %veci4   = OpTypeVector %int32 4
+    %vecf2   = OpTypeVector %float 2
+    %vecf3   = OpTypeVector %float 3
+    %vecf4   = OpTypeVector %float 4
+    %const2  = OpConstant %int32 2
+    %const3  = OpConstant %int32 3
+    %const4  = OpConstant %int32 4
+    %arri2   = OpTypeArray %int32 %const2
+    %arri3   = OpTypeArray %int32 %const3
+    %arri4   = OpTypeArray %int32 %const4
+    %arrf2   = OpTypeArray %float %const2
+    %arrf3   = OpTypeArray %float %const3
+    %arrf4   = OpTypeArray %float %const4
+    %voidfun = OpTypeFunction %void
+  )";
+  string definitions = R"(
+    %ptr   = OpTypePointer )" + bic.storage + " " + bic.type + R"(
+    %bltin = OpVariable %ptr )" + bic.storage + R"(
+    %entry = OpFunction %void None %voidfun
+    %label = OpLabel
+             OpReturn
+             OpFunctionEnd
+  )";
+
+  return capabilities + extensions + memory + entries
+         + modes + decorations + types + definitions;
+}
+
+string GenerateKernelCode(const BuiltInCase& bic)
+{ 
+  string capabilities = R"(
+    OpCapability Kernel
+    OpCapability Addresses
+    OpCapability Int64
+    OpCapability Shader
+    OpCapability Tessellation
+    OpCapability Geometry
+  )";
+  string extensions = "";
+  string memory = R"(
+    OpMemoryModel Physical64 OpenCL
+  )";
+  string entries = R"(
+    OpEntryPoint )" + bic.stage + R"( %entry "entry" %bltin
+  )";
+  string modes = "";
+  string decorations = R"(  
+    OpDecorate %bltin BuiltIn )" + bic.name + R"(
+  )";
+  string types = R"(
+    %void    = OpTypeVoid
+    %float   = OpTypeFloat 32
+    %uint32  = OpTypeInt 32 0
+    %uint64  = OpTypeInt 64 0
     %vecu2   = OpTypeVector %uint32 2
     %vecu3   = OpTypeVector %uint32 3
     %vecu4   = OpTypeVector %uint32 4
@@ -92,8 +164,8 @@ string GenerateShaderCode(const tuple4string& tuple)
     %voidfun = OpTypeFunction %void
   )";
   string definitions = R"(
-    %ptr   = OpTypePointer )" + storage + " " + type + R"(
-    %bltin = OpVariable %ptr )" + storage + R"(
+    %ptr   = OpTypePointer )" + bic.storage + " " + bic.type + R"(
+    %bltin = OpVariable %ptr )" + bic.storage + R"(
     %entry = OpFunction %void None %voidfun
     %label = OpLabel
              OpReturn
@@ -104,209 +176,444 @@ string GenerateShaderCode(const tuple4string& tuple)
          + modes + decorations + types + definitions;
 }
 
-// clang-format off
-#define BUILTIN(builtin,type,storage,exec) \
-  make_tuple(string(builtin),string(type),string(storage),string(exec))
+//
+// PARAMETERIZED TESTS
+//
 
 TEST_P(ValidateBuiltIn, BuiltInValid) {
-  CompileSuccessfully(GenerateShaderCode(GetParam()));
+  CompileSuccessfully(GenerateShaderCode(GetParam()),SPV_ENV_VULKAN_1_0);
   EXPECT_EQ(SPV_SUCCESS, ValidateAndRetrieveValidationState());
 }
 
-INSTANTIATE_TEST_CASE_P(BuiltInValid, ValidateBuiltIn,
+// clang-format off
+INSTANTIATE_TEST_CASE_P(BasicBuiltIn, ValidateBuiltIn,
   ::testing::Values(
-       BUILTIN("Position","%vecf4","Output","Vertex"),
-       BUILTIN("PointSize","%float","Output","Vertex"),
-       BUILTIN("ClipDistance","%arrf2","Output","Vertex"),
-       BUILTIN("CullDistance","%arrf3","Output","Vertex"),
-       BUILTIN("VertexId","%uint32","Input","Vertex"),
-       BUILTIN("InstanceId","%float","Input","Vertex"),
-       BUILTIN("PrimitiveId","%uint32","Input","Fragment"),
-       BUILTIN("InvocationId","%uint32","Input","Geometry"),
-       BUILTIN("Layer","%uint32","Input","Fragment"),
-       BUILTIN("ViewportIndex","%uint32","Output","Geometry"),
-       BUILTIN("TessLevelOuter","%arrf4","Output","TessellationControl"),
-       BUILTIN("TessLevelInner","%arrf2","Input","TessellationEvaluation"),
-       BUILTIN("TessCoord","%vecf3","Input","TessellationEvaluation"),
-       BUILTIN("PatchVertices","%uint32","Input","TessellationControl"),
-       BUILTIN("FragCoord","%vecf4","Input","Fragment"),
-       BUILTIN("PointCoord","%vecf2","Input","Fragment"),
-       BUILTIN("FrontFacing","%bool","Input","Fragment"),
-       BUILTIN("SampleId","%uint32","Input","Fragment"),
-       BUILTIN("SamplePosition","%vecf2","Input","Fragment"),
-       BUILTIN("SampleMask","%arru2","Input","Fragment"),
-       BUILTIN("FragDepth","%float","Output","Fragment"),
-       BUILTIN("HelperInvocation","%bool","Input","Fragment"),
-       BUILTIN("NumWorkgroups","%vecu3","Input","GLCompute"),
-       //BUILTIN("WorkgroupSize","%vecu3","Uniform","GLCompute"),
-       BUILTIN("WorkgroupId","%vecu3","Input","GLCompute"),
-       BUILTIN("LocalInvocationId","%vecu3","Input","GLCompute"),
-       BUILTIN("GlobalInvocationId","%vecu3","Input","GLCompute"),
-       BUILTIN("LocalInvocationIndex","%uint32","Input","GLCompute"),
-       // WorkDim, GLobalSize, EnqueueWorkgroupSize, GLobalOffset
-       // GLobalLinearId, SubgroupSize, SubgroupMaxSize, NumSubgroups
-       // NumEnqueuedSubgroups, SubgroupId, SubroupLocalInvocationId,
-       BUILTIN("VertexIndex","%uint32","Input","Vertex"),
-       BUILTIN("InstanceIndex","%uint32","Input","Vertex")
-       // BaseVertex, BaseInstance, DrawIndex, DeviceIndex, ViewIndex
-  ), );
+       BuiltInCase{"Position","%vecf4","Output","Vertex"},
+       BuiltInCase{"PointSize","%float","Output","Vertex"},
+       BuiltInCase{"ClipDistance","%arrf2","Output","Vertex"},
+       BuiltInCase{"CullDistance","%arrf3","Output","Vertex"},
+       BuiltInCase{"VertexId","%int32","Input","Vertex"},
+       BuiltInCase{"InstanceId","%int32","Input","Vertex"},
+       BuiltInCase{"PrimitiveId","%int32","Input","Fragment"},
+       BuiltInCase{"InvocationId","%int32","Input","Geometry"},
+       BuiltInCase{"Layer","%int32","Input","Fragment"},
+       BuiltInCase{"ViewportIndex","%int32","Output","Geometry"},
+       BuiltInCase{"TessLevelOuter","%arrf4","Output","TessellationControl"},
+       BuiltInCase{"TessLevelInner","%arrf2","Input","TessellationEvaluation"},
+       BuiltInCase{"TessCoord","%vecf3","Input","TessellationEvaluation"},
+       BuiltInCase{"PatchVertices","%int32","Input","TessellationControl"},
+       BuiltInCase{"FragCoord","%vecf4","Input","Fragment"},
+       BuiltInCase{"PointCoord","%vecf2","Input","Fragment"},
+       BuiltInCase{"FrontFacing","%bool","Input","Fragment"},
+       BuiltInCase{"SampleId","%int32","Input","Fragment"},
+       BuiltInCase{"SamplePosition","%vecf2","Input","Fragment"},
+       BuiltInCase{"SampleMask","%arri2","Input","Fragment"},
+       BuiltInCase{"FragDepth","%float","Output","Fragment"},
+       BuiltInCase{"HelperInvocation","%bool","Input","Fragment"},
+       BuiltInCase{"NumWorkgroups","%veci3","Input","GLCompute"},
+       // WorkgroupSize is tested individually
+       BuiltInCase{"WorkgroupId","%veci3","Input","GLCompute"},
+       BuiltInCase{"LocalInvocationId","%veci3","Input","GLCompute"},
+       BuiltInCase{"GlobalInvocationId","%veci3","Input","GLCompute"},
+       BuiltInCase{"LocalInvocationIndex","%int32","Input","GLCompute"},
+       BuiltInCase{"VertexIndex","%int32","Input","Vertex"},
+       BuiltInCase{"InstanceIndex","%int32","Input","Vertex"}
+  ));
 
+INSTANTIATE_TEST_CASE_P(ExtendedBuiltIn, ValidateBuiltIn,
+  ::testing::Values(
+       BuiltInCase{"SubgroupEqMaskKHR","%veci4","Input","Vertex"},
+       BuiltInCase{"SubgroupGeMaskKHR","%veci4","Input","Geometry"},
+       BuiltInCase{"SubgroupGtMaskKHR","%veci4","Input","TessellationControl"},
+       BuiltInCase{"SubgroupLeMaskKHR","%veci4","Input","TessellationEvaluation"},
+       BuiltInCase{"SubgroupLtMaskKHR","%veci4","Input","Fragment"},
 
-TEST_P(ValidateBuiltInExecutionModel, BuiltInExecutionModel) {
-  CompileSuccessfully(GenerateShaderCode(GetParam()));
-  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Built-in variables are restricted to only certain"
-                        "EXECUTION MODELS (see e.g. Vulkan specification)"));
+       BuiltInCase{"BaseVertex","%int32","Input","Vertex"},
+       BuiltInCase{"BaseInstance","%int32","Input","Vertex"},
+       BuiltInCase{"DrawIndex","%int32","Input","Vertex"},
+       BuiltInCase{"DeviceIndex","%int32","Input","GLCompute"},
+       BuiltInCase{"ViewIndex","%int32","Input","Fragment"},
+
+       BuiltInCase{"BaryCoordNoPerspAMD","%vecf2","Input","Fragment"},
+       BuiltInCase{"BaryCoordNoPerspCentroidAMD","%vecf2","Input","Fragment"},
+       BuiltInCase{"BaryCoordNoPerspSampleAMD","%vecf2","Input","Fragment"},
+       BuiltInCase{"BaryCoordSmoothAMD","%vecf2","Input","Fragment"},
+       BuiltInCase{"BaryCoordSmoothCentroidAMD","%vecf2","Input","Fragment"},
+       BuiltInCase{"BaryCoordSmoothSampleAMD","%vecf2","Input","Fragment"},
+       BuiltInCase{"BaryCoordPullModelAMD","%vecf3","Input","Fragment"},
+
+       BuiltInCase{"FragStencilRefEXT","%int32","Output","Fragment"},
+       BuiltInCase{"ViewportMaskNV","%int32","Output","Vertex"},
+       BuiltInCase{"SecondaryPositionNV","%vecf4","Input","Geometry"},
+       BuiltInCase{"SecondaryViewportMaskNV","%arri3","Output","Vertex"},
+       BuiltInCase{"PositionPerViewNV","%vecf4","Input","TessellationControl"},
+       BuiltInCase{"ViewportMaskPerViewNV","%arri4","Output","Geometry"}
+  ));
+// clang-format on
+
+TEST_P(ValidateBuiltInCL, BuiltInCLOK) {
+  CompileSuccessfully(GenerateKernelCode(GetParam()),SPV_ENV_OPENCL_2_2);
+  EXPECT_EQ(SPV_SUCCESS, ValidateAndRetrieveValidationState());
 }
 
-INSTANTIATE_TEST_CASE_P(BuiltInExecutionModel, ValidateBuiltInExecutionModel,
+// clang-format off
+INSTANTIATE_TEST_CASE_P(BuiltInCLOK, ValidateBuiltInCL,
   ::testing::Values(
-       BUILTIN("Position","%vecf4","Output","Fragment"),
-       BUILTIN("PointSize","%float","Output","GLCompute"),
-       BUILTIN("ClipDistance","%arrf2","Output","GLCompute"),
-       BUILTIN("CullDistance","%arrf3","Output","GLCompute"),
-       BUILTIN("VertexId","%uint32","Input","TessellationControl"),
-       BUILTIN("InstanceId","%float","Input","TessellationEvaluation"),
-       BUILTIN("PrimitiveId","%uint32","Input","Vertex"),
-       BUILTIN("InvocationId","%uint32","Input","Fragment"),
-       BUILTIN("Layer","%uint32","Input","GLCompute"),
-       BUILTIN("ViewportIndex","%uint32","Output","Vertex"),
-       BUILTIN("TessLevelOuter","%arrf4","Output","Geometry"),
-       BUILTIN("TessLevelInner","%arrf2","Input","Fragment"),
-       BUILTIN("TessCoord","%vecf3","Input","TessellationControl"),
-       BUILTIN("PatchVertices","%uint32","Input","Vertex"),
-       BUILTIN("FragCoord","%vecf4","Input","Geometry"),
-       BUILTIN("PointCoord","%vecf2","Input","GLCompute"),
-       BUILTIN("FrontFacing","%bool","Input","Vertex"),
-       BUILTIN("SampleId","%uint32","Input","GLCompute"),
-       BUILTIN("SamplePosition","%vecf2","Input","Geometry"),
-       BUILTIN("SampleMask","%arru2","Input","Vertex"),
-       BUILTIN("FragDepth","%float","Output","GLCompute"),
-       BUILTIN("HelperInvocation","%bool","Input","GLCompute"),
-       BUILTIN("NumWorkgroups","%vecu3","Input","Vertex"),
-       //BUILTIN("WorkgroupSize","%vecu3","Uniform","Fragment"),
-       BUILTIN("WorkgroupId","%vecu3","Input","TessellationControl"),
-       BUILTIN("LocalInvocationId","%vecu3","Input","TessellationEvaluation"),
-       BUILTIN("GlobalInvocationId","%vecu3","Input","Geometry"),
-       BUILTIN("LocalInvocationIndex","%uint32","Input","Vertex"),
-       // WorkDim, GLobalSize, EnqueueWorkgroupSize, GLobalOffset
-       // GLobalLinearId, SubgroupSize, SubgroupMaxSize, NumSubgroups
-       // NumEnqueuedSubgroups, SubgroupId, SubroupLocalInvocationId,
-       BUILTIN("VertexIndex","%uint32","Input","Fragment"),
-       BUILTIN("InstanceIndex","%uint32","Input","Geometry")
-       // BaseVertex, BaseInstance, DrawIndex, DeviceIndex, ViewIndex
-  ), );
+       BuiltInCase{"NumWorkgroups","%vecu3","Input","Kernel"},
+       // WorkgroupSize is tested individually
+       BuiltInCase{"WorkgroupId","%vecu3","Input","Kernel"},
+       BuiltInCase{"LocalInvocationId","%vecu3","Input","Kernel"},
+       BuiltInCase{"GlobalInvocationId","%vecu3","Input","Kernel"},
+       BuiltInCase{"LocalInvocationIndex","%uint32","Input","Kernel"},
 
+       BuiltInCase{"WorkDim","%uint32","Input","Kernel"},
+       BuiltInCase{"GlobalSize","%vecu3","Input","Kernel"},
+       BuiltInCase{"EnqueuedWorkgroupSize","%vecu3","Input","Kernel"},
+       BuiltInCase{"GlobalOffset","%vecu3","Input","Kernel"},
+       BuiltInCase{"GlobalLinearId","%uint32","Input","Kernel"},
+       BuiltInCase{"SubgroupSize","%uint32","Input","Kernel"},
+       BuiltInCase{"SubgroupMaxSize","%uint32","Input","Kernel"},
+       BuiltInCase{"NumSubgroups","%uint32","Input","Kernel"},
+       BuiltInCase{"NumEnqueuedSubgroups","%uint32","Input","Kernel"},
+       BuiltInCase{"SubgroupId","%uint32","Input","Kernel"},
+       BuiltInCase{"SubgroupLocalInvocationId","%uint32","Input","Kernel"}
+  ));
+// clang-format on
+
+TEST_P(ValidateBuiltInStage, BuiltInStage) {
+  CompileSuccessfully(GenerateShaderCode(GetParam()),SPV_ENV_VULKAN_1_0);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr( GetParam().name +
+                " built-in is restricted to certain EXECUTION MODELS "
+                "(see SPIR-V, Vulkan, OpenGL, OpenCL specifications)"));
+}
+
+// clang-format off
+INSTANTIATE_TEST_CASE_P(BasicBuiltIn, ValidateBuiltInStage,
+  ::testing::Values(
+       BuiltInCase{"Position","%vecf4","Output","Fragment"},
+       BuiltInCase{"PointSize","%float","Output","GLCompute"},
+       BuiltInCase{"ClipDistance","%arrf2","Output","GLCompute"},
+       BuiltInCase{"CullDistance","%arrf3","Output","GLCompute"},
+       BuiltInCase{"VertexId","%int32","Input","TessellationControl"},
+       BuiltInCase{"InstanceId","%int32","Input","TessellationEvaluation"},
+       BuiltInCase{"PrimitiveId","%int32","Input","Vertex"},
+       BuiltInCase{"InvocationId","%int32","Input","Fragment"},
+       BuiltInCase{"Layer","%int32","Input","GLCompute"},
+       BuiltInCase{"ViewportIndex","%int32","Output","GLCompute"},
+       BuiltInCase{"TessLevelOuter","%arrf4","Output","Geometry"},
+       BuiltInCase{"TessLevelInner","%arrf2","Input","Fragment"},
+       BuiltInCase{"TessCoord","%vecf3","Input","TessellationControl"},
+       BuiltInCase{"PatchVertices","%int32","Input","Vertex"},
+       BuiltInCase{"FragCoord","%vecf4","Input","Geometry"},
+       BuiltInCase{"PointCoord","%vecf2","Input","GLCompute"},
+       BuiltInCase{"FrontFacing","%bool","Input","Vertex"},
+       BuiltInCase{"SampleId","%int32","Input","GLCompute"},
+       BuiltInCase{"SamplePosition","%vecf2","Input","Geometry"},
+       BuiltInCase{"SampleMask","%arri2","Input","Vertex"},
+       BuiltInCase{"FragDepth","%float","Output","GLCompute"},
+       BuiltInCase{"HelperInvocation","%bool","Input","GLCompute"},
+       BuiltInCase{"NumWorkgroups","%veci3","Input","Vertex"},
+       // 25 = WorkgroupSize is tested individually
+       BuiltInCase{"WorkgroupId","%veci3","Input","TessellationControl"},
+       BuiltInCase{"LocalInvocationId","%veci3","Input","TessellationEvaluation"},
+       BuiltInCase{"GlobalInvocationId","%veci3","Input","Geometry"},
+       BuiltInCase{"LocalInvocationIndex","%int32","Input","Vertex"},
+       BuiltInCase{"VertexIndex","%int32","Input","Fragment"},
+       BuiltInCase{"InstanceIndex","%int32","Input","Geometry"}
+  ));
+
+INSTANTIATE_TEST_CASE_P(ExtendedBuiltIn, ValidateBuiltInStage,
+  ::testing::Values(
+       BuiltInCase{"SubgroupEqMaskKHR","%veci3","Input","GLCompute"},
+       BuiltInCase{"SubgroupGeMaskKHR","%veci3","Input","GLCompute"},
+       BuiltInCase{"SubgroupGtMaskKHR","%veci3","Input","GLCompute"},
+       BuiltInCase{"SubgroupLeMaskKHR","%veci3","Input","GLCompute"},
+       BuiltInCase{"SubgroupLtMaskKHR","%veci3","Input","GLCompute"},
+
+       BuiltInCase{"BaseVertex","%int32","Input","Fragment"},
+       BuiltInCase{"BaseInstance","%int32","Input","Geometry"},
+       BuiltInCase{"DrawIndex","%int32","Input","TessellationControl"},
+       // 4438 = DeviceIndex supports all shader stages, thus cannot fail
+       BuiltInCase{"ViewIndex","%int32","Input","GLCompute"},
+
+       BuiltInCase{"BaryCoordNoPerspAMD","%vecf2","Input","TessellationControl"},
+       BuiltInCase{"BaryCoordNoPerspCentroidAMD","%vecf2","Input","Geometry"},
+       BuiltInCase{"BaryCoordNoPerspSampleAMD","%vecf2","Input","GLCompute"},
+       BuiltInCase{"BaryCoordSmoothAMD","%vecf2","Input","TessellationEvaluation"},
+       BuiltInCase{"BaryCoordSmoothCentroidAMD","%vecf2","Input","Vertex"},
+       BuiltInCase{"BaryCoordSmoothSampleAMD","%vecf2","Input","GLCompute"},
+       BuiltInCase{"BaryCoordPullModelAMD","%vecf3","Input","TessellationControl"},
+
+       BuiltInCase{"FragStencilRefEXT","%int32","Output","TessellationEvaluation"},
+       BuiltInCase{"ViewportMaskNV","%int32","Output","Fragment"},
+       BuiltInCase{"SecondaryPositionNV","%vecf4","Input","GLCompute"},
+       BuiltInCase{"SecondaryViewportMaskNV","%arri3","Output","Fragment"},
+       BuiltInCase{"PositionPerViewNV","%vecf4","Input","Fragment"},
+       BuiltInCase{"ViewportMaskPerViewNV","%arri4","Output","GLCompute"}
+  ));
+// clang-format on
+
+TEST_P(ValidateBuiltInStageCL, BuiltInStageCL) {
+  CompileSuccessfully(GenerateKernelCode(GetParam()),SPV_ENV_OPENCL_2_2);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr( GetParam().name +
+                " built-in is restricted to certain EXECUTION MODELS "
+                "(see SPIR-V, Vulkan, OpenGL, OpenCL specifications)"));
+}
+
+// clang-format off
+INSTANTIATE_TEST_CASE_P(BuiltInStageCL, ValidateBuiltInStageCL,
+  ::testing::Values(
+       BuiltInCase{"NumWorkgroups","%vecu3","Input","Vertex"},
+       // 25 = WorkgroupSize is tested individually
+       BuiltInCase{"WorkgroupId","%vecu3","Input","TessellationControl"},
+       BuiltInCase{"LocalInvocationId","%vecu3","Input","TessellationEvaluation"},
+       BuiltInCase{"GlobalInvocationId","%vecu3","Input","Geometry"},
+       BuiltInCase{"LocalInvocationIndex","%uint32","Input","Vertex"},
+       
+       BuiltInCase{"WorkDim","%uint32","Input","Vertex"},
+       BuiltInCase{"GlobalSize","%vecu3","Input","Fragment"},
+       BuiltInCase{"EnqueuedWorkgroupSize","%vecu3","Input","Geometry"},
+       BuiltInCase{"GlobalOffset","%vecu3","Input","TessellationEvaluation"},
+       BuiltInCase{"GlobalLinearId","%uint32","Input","TessellationControl"},
+       BuiltInCase{"SubgroupSize","%uint32","Input","GLCompute"},
+       BuiltInCase{"SubgroupMaxSize","%uint32","Input","Vertex"},
+       BuiltInCase{"NumSubgroups","%uint32","Input","Fragment"},
+       BuiltInCase{"NumEnqueuedSubgroups","%uint32","Input","Geometry"},
+       BuiltInCase{"SubgroupId","%uint32","Input","TessellationEvaluation"},
+       BuiltInCase{"SubgroupLocalInvocationId","%uint32","Input","GLCompute"}
+  ));
+// clang-format on
 
 TEST_P(ValidateBuiltInStorage, BuiltInStorage) {
-  CompileSuccessfully(GenerateShaderCode(GetParam()));
+  CompileSuccessfully(GenerateShaderCode(GetParam()),SPV_ENV_VULKAN_1_0);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Built-in variables must match the STORAGE CLASS "
-                         "of the built-in (see e.g. Vulkan specification)"));
+              HasSubstr( GetParam().name +
+                " built-in is restricted to certain STORAGE CLASSES,"
+                " depending on the execution model (see SPIR-V spec)"));
 }
 
-INSTANTIATE_TEST_CASE_P(BuiltInStorage, ValidateBuiltInStorage,
+// clang-format off
+INSTANTIATE_TEST_CASE_P(BasicBuiltIn, ValidateBuiltInStorage,
   ::testing::Values(
-       BUILTIN("Position","%vecf4","Input","Vertex"),
-       BUILTIN("PointSize","%float","Input","Vertex"),
-       BUILTIN("ClipDistance","%arrf2","Input","Vertex"),
-       BUILTIN("CullDistance","%arrf3","Input","Vertex"),
-       BUILTIN("VertexId","%uint32","Output","Vertex"),
-       BUILTIN("InstanceId","%float","Output","Vertex"),
-       BUILTIN("PrimitiveId","%uint32","Output","Fragment"),
-       BUILTIN("InvocationId","%uint32","Output","Geometry"),
-       BUILTIN("Layer","%uint32","Output","Fragment"),
-       BUILTIN("ViewportIndex","%uint32","Input","Geometry"),
-       BUILTIN("TessLevelOuter","%arrf4","Input","TessellationControl"),
-       BUILTIN("TessLevelInner","%arrf2","Output","TessellationEvaluation"),
-       BUILTIN("TessCoord","%vecf3","Output","TessellationEvaluation"),
-       BUILTIN("PatchVertices","%uint32","Output","TessellationControl"),
-       BUILTIN("FragCoord","%vecf4","Output","Fragment"),
-       BUILTIN("PointCoord","%vecf2","Output","Fragment"),
-       BUILTIN("FrontFacing","%bool","Output","Fragment"),
-       BUILTIN("SampleId","%uint32","Output","Fragment"),
-       BUILTIN("SamplePosition","%vecf2","Output","Fragment"),
-       //BUILTIN("SampleMask","%arru2","Uniform","Fragment"),
-       BUILTIN("FragDepth","%float","Input","Fragment"),
-       BUILTIN("HelperInvocation","%bool","Output","Fragment"),
-       BUILTIN("NumWorkgroups","%vecu3","Output","GLCompute"),
-       //BUILTIN("WorkgroupSize","%vecu3","Uniform","GLCompute"),
-       BUILTIN("WorkgroupId","%vecu3","Output","GLCompute"),
-       BUILTIN("LocalInvocationId","%vecu3","Output","GLCompute"),
-       BUILTIN("GlobalInvocationId","%vecu3","Output","GLCompute"),
-       BUILTIN("LocalInvocationIndex","%uint32","Output","GLCompute"),
-       // WorkDim, GLobalSize, EnqueueWorkgroupSize, GLobalOffset
-       // GLobalLinearId, SubgroupSize, SubgroupMaxSize, NumSubgroups
-       // NumEnqueuedSubgroups, SubgroupId, SubroupLocalInvocationId,
-       BUILTIN("VertexIndex","%uint32","Output","Vertex"),
-       BUILTIN("InstanceIndex","%uint32","Output","Vertex")
-       // BaseVertex, BaseInstance, DrawIndex, DeviceIndex, ViewIndex
-  ), );
+       BuiltInCase{"Position","%vecf4","Input","Vertex"},
+       BuiltInCase{"PointSize","%float","Input","Vertex"},
+       BuiltInCase{"ClipDistance","%arrf2","Input","Vertex"},
+       BuiltInCase{"CullDistance","%arrf3","Input","Vertex"},
+       BuiltInCase{"VertexId","%int32","Output","Vertex"},
+       BuiltInCase{"InstanceId","%int32","Output","Vertex"},
+       BuiltInCase{"PrimitiveId","%int32","Output","Fragment"},
+       BuiltInCase{"InvocationId","%int32","Output","Geometry"},
+       BuiltInCase{"Layer","%int32","Output","Fragment"},
+       BuiltInCase{"ViewportIndex","%int32","Input","Geometry"},
+       BuiltInCase{"TessLevelOuter","%arrf4","Input","TessellationControl"},
+       BuiltInCase{"TessLevelInner","%arrf2","Output","TessellationEvaluation"},
+       BuiltInCase{"TessCoord","%vecf3","Output","TessellationEvaluation"},
+       BuiltInCase{"PatchVertices","%int32","Output","TessellationControl"},
+       BuiltInCase{"FragCoord","%vecf4","Output","Fragment"},
+       BuiltInCase{"PointCoord","%vecf2","Output","Fragment"},
+       BuiltInCase{"FrontFacing","%bool","Output","Fragment"},
+       BuiltInCase{"SampleId","%int32","Output","Fragment"},
+       BuiltInCase{"SamplePosition","%vecf2","Output","Fragment"},
+       // 20 = SampleMask allows Input/Output and cannot fail this test
+       BuiltInCase{"FragDepth","%float","Input","Fragment"},
+       BuiltInCase{"HelperInvocation","%bool","Output","Fragment"},
+       BuiltInCase{"NumWorkgroups","%veci3","Output","GLCompute"},
+       // 25 = WorkgroupSize is tested individually
+       BuiltInCase{"WorkgroupId","%veci3","Output","GLCompute"},
+       BuiltInCase{"LocalInvocationId","%veci3","Output","GLCompute"},
+       BuiltInCase{"GlobalInvocationId","%veci3","Output","GLCompute"},
+       BuiltInCase{"LocalInvocationIndex","%int32","Output","GLCompute"},
+       BuiltInCase{"VertexIndex","%int32","Output","Vertex"},
+       BuiltInCase{"InstanceIndex","%int32","Output","Vertex"}
+  ));
 
+INSTANTIATE_TEST_CASE_P(ExtendedBuiltIn, ValidateBuiltInStorage,
+  ::testing::Values(
+       BuiltInCase{"SubgroupEqMaskKHR","%veci3","Output","Vertex"},
+       BuiltInCase{"SubgroupGeMaskKHR","%veci3","Output","Geometry"},
+       BuiltInCase{"SubgroupGtMaskKHR","%veci3","Output","TessellationControl"},
+       BuiltInCase{"SubgroupLeMaskKHR","%veci3","Output","TessellationEvaluation"},
+       BuiltInCase{"SubgroupLtMaskKHR","%veci3","Output","Fragment"},
+
+       BuiltInCase{"BaseVertex","%int32","Output","Vertex"},
+       BuiltInCase{"BaseInstance","%int32","Output","Vertex"},
+       BuiltInCase{"DrawIndex","%int32","Output","Vertex"},
+       BuiltInCase{"DeviceIndex","%int32","Output","GLCompute"},
+       BuiltInCase{"ViewIndex","%int32","Output","Fragment"},
+
+       BuiltInCase{"BaryCoordNoPerspAMD","%vecf2","Output","Fragment"},
+       BuiltInCase{"BaryCoordNoPerspCentroidAMD","%vecf2","Output","Fragment"},
+       BuiltInCase{"BaryCoordNoPerspSampleAMD","%vecf2","Output","Fragment"},
+       BuiltInCase{"BaryCoordSmoothAMD","%vecf2","Output","Fragment"},
+       BuiltInCase{"BaryCoordSmoothCentroidAMD","%vecf2","Output","Fragment"},
+       BuiltInCase{"BaryCoordSmoothSampleAMD","%vecf2","Output","Fragment"},
+       BuiltInCase{"BaryCoordPullModelAMD","%vecf3","Output","Fragment"},
+
+       BuiltInCase{"FragStencilRefEXT","%int32","Input","Fragment"},
+       BuiltInCase{"ViewportMaskNV","%int32","Input","Vertex"},
+       BuiltInCase{"SecondaryPositionNV","%vecf4","Input","Vertex"},
+       BuiltInCase{"SecondaryViewportMaskNV","%arri3","Input","Geometry"},
+       BuiltInCase{"PositionPerViewNV","%vecf4","Input","Vertex"},
+       BuiltInCase{"ViewportMaskPerViewNV","%arri4","Input","Geometry"}
+  ));
+// clang-format on
+
+TEST_P(ValidateBuiltInStorageCL, BuiltInStorageCL) {
+  CompileSuccessfully(GenerateKernelCode(GetParam()),SPV_ENV_OPENCL_2_2);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr( GetParam().name +
+                " built-in is restricted to certain STORAGE CLASSES,"
+                " depending on the execution model (see SPIR-V spec)"));
+}
+
+// clang-format off
+INSTANTIATE_TEST_CASE_P(BuiltInStorageCL, ValidateBuiltInStorageCL,
+  ::testing::Values(
+       BuiltInCase{"NumWorkgroups","%vecu3","Output","Kernel"},
+       // 25 = WorkgroupSize is tested individually
+       BuiltInCase{"WorkgroupId","%vecu3","Output","Kernel"},
+       BuiltInCase{"LocalInvocationId","%vecu3","Output","Kernel"},
+       BuiltInCase{"GlobalInvocationId","%vecu3","Output","Kernel"},
+       BuiltInCase{"LocalInvocationIndex","%uint32","Output","Kernel"},
+       BuiltInCase{"WorkDim","%uint32","Output","Kernel"},
+       BuiltInCase{"GlobalSize","%vecu3","Output","Kernel"},
+       BuiltInCase{"EnqueuedWorkgroupSize","%vecu3","Output","Kernel"},
+       BuiltInCase{"GlobalOffset","%vecu3","Output","Kernel"},
+       BuiltInCase{"GlobalLinearId","%uint32","Output","Kernel"},
+       BuiltInCase{"SubgroupSize","%uint32","Output","Kernel"},
+       BuiltInCase{"SubgroupMaxSize","%uint32","Output","Kernel"},
+       BuiltInCase{"NumSubgroups","%uint32","Output","Kernel"},
+       BuiltInCase{"NumEnqueuedSubgroups","%uint32","Output","Kernel"},
+       BuiltInCase{"SubgroupId","%uint32","Output","Kernel"},
+       BuiltInCase{"SubgroupLocalInvocationId","%uint32","Output","Kernel"}
+  ));
+// clang-format on
 
 TEST_P(ValidateBuiltInType, BuiltInType) {
-  CompileSuccessfully(GenerateShaderCode(GetParam()));
+  CompileSuccessfully(GenerateShaderCode(GetParam()),SPV_ENV_VULKAN_1_0);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Built-in variables must match the DATA TYPE "
-                        "of the built-in (see e.g. Vulkan specification)"));
+              HasSubstr( GetParam().name +
+                " built-in must match the DATA TYPE defined"
+                " in the specification (see SPIR-V specification)"));
 }
 
-INSTANTIATE_TEST_CASE_P(BuiltInType, ValidateBuiltInType,
+// clang-format off
+INSTANTIATE_TEST_CASE_P(BasicBuiltIn, ValidateBuiltInType,
   ::testing::Values(
-       BUILTIN("Position","%uint32","Output","Vertex"),
-       BUILTIN("PointSize","%uint32","Output","Vertex"),
-       BUILTIN("ClipDistance","%vecf2","Output","Vertex"),
-       BUILTIN("CullDistance","%float","Output","Vertex"),
-       BUILTIN("VertexId","%arrf3","Input","Vertex"),
-       BUILTIN("InstanceId","%uint32","Input","Vertex"),
-       BUILTIN("PrimitiveId","%vecf4","Input","Fragment"),
-       BUILTIN("InvocationId","%float","Input","Geometry"),
-       BUILTIN("Layer","%arru3","Output","Geometry"),
-       BUILTIN("ViewportIndex","%vecu2","Input","Fragment"),
-       BUILTIN("TessLevelOuter","%uint32","Input","TessellationEvaluation"),
-       BUILTIN("TessLevelInner","%arrf4","Output","TessellationControl"),
-       BUILTIN("TessCoord","%vecu3","Input","TessellationEvaluation"),
-       BUILTIN("PatchVertices","%float","Input","TessellationControl"),
-       BUILTIN("FragCoord","%vecf2","Input","Fragment"),
-       BUILTIN("PointCoord","%vecf4","Input","Fragment"),
-       BUILTIN("FrontFacing","%void","Input","Fragment"),
-       BUILTIN("SampleId","%bool","Input","Fragment"),
-       BUILTIN("SamplePosition","%vecu2","Input","Fragment"),
-       BUILTIN("SampleMask","%arrf3","Input","Fragment"),
-       BUILTIN("FragDepth","%void","Output","Fragment"),
-       BUILTIN("HelperInvocation","%void","Input","Fragment"),
-       BUILTIN("NumWorkgroups","%arrf2","Input","GLCompute"),
-       //BUILTIN("WorkgroupSize","%vecu3","Uniform","GLCompute"),
-       BUILTIN("WorkgroupId","%vecf3","Input","GLCompute"),
-       BUILTIN("LocalInvocationId","%uint32","Input","GLCompute"),
-       BUILTIN("GlobalInvocationId","%float","Input","GLCompute"),
-       BUILTIN("LocalInvocationIndex","%vecu3","Input","GLCompute"),
-       // WorkDim, GLobalSize, EnqueueWorkgroupSize, GLobalOffset
-       // GLobalLinearId, SubgroupSize, SubgroupMaxSize, NumSubgroups
-       // NumEnqueuedSubgroups, SubgroupId, SubroupLocalInvocationId,
-       BUILTIN("VertexIndex","%vecf2","Input","Vertex"),
-       BUILTIN("InstanceIndex","%arru4","Input","Vertex")
-       // BaseVertex, BaseInstance, DrawIndex, DeviceIndex, ViewIndex
-       
-  ), );
+       BuiltInCase{"Position","%int32","Output","Vertex"},
+       BuiltInCase{"PointSize","%int32","Output","Vertex"},
+       BuiltInCase{"ClipDistance","%vecf2","Output","Vertex"},
+       BuiltInCase{"CullDistance","%float","Output","Vertex"},
+       BuiltInCase{"VertexId","%arrf3","Input","Vertex"},
+       BuiltInCase{"InstanceId","%float","Input","Vertex"},
+       BuiltInCase{"PrimitiveId","%vecf4","Input","Fragment"},
+       BuiltInCase{"InvocationId","%float","Input","Geometry"},
+       BuiltInCase{"Layer","%arri3","Output","Geometry"},
+       BuiltInCase{"ViewportIndex","%veci2","Input","Fragment"},
+       BuiltInCase{"TessLevelOuter","%int32","Input","TessellationEvaluation"},
+       BuiltInCase{"TessLevelInner","%arrf4","Output","TessellationControl"},
+       BuiltInCase{"TessCoord","%veci3","Input","TessellationEvaluation"},
+       BuiltInCase{"PatchVertices","%float","Input","TessellationControl"},
+       BuiltInCase{"FragCoord","%vecf2","Input","Fragment"},
+       BuiltInCase{"PointCoord","%vecf4","Input","Fragment"},
+       BuiltInCase{"FrontFacing","%void","Input","Fragment"},
+       BuiltInCase{"SampleId","%bool","Input","Fragment"},
+       BuiltInCase{"SamplePosition","%veci2","Input","Fragment"},
+       BuiltInCase{"SampleMask","%arrf3","Input","Fragment"},
+       BuiltInCase{"FragDepth","%void","Output","Fragment"},
+       BuiltInCase{"HelperInvocation","%void","Input","Fragment"},
+       BuiltInCase{"NumWorkgroups","%arrf2","Input","GLCompute"},
+       // 25 = WorkgroupSize is tested individually
+       BuiltInCase{"WorkgroupId","%vecf3","Input","GLCompute"},
+       BuiltInCase{"LocalInvocationId","%int32","Input","GLCompute"},
+       BuiltInCase{"GlobalInvocationId","%float","Input","GLCompute"},
+       BuiltInCase{"LocalInvocationIndex","%veci3","Input","GLCompute"},
+       BuiltInCase{"VertexIndex","%vecf2","Input","Vertex"},
+       BuiltInCase{"InstanceIndex","%arri4","Input","Vertex"}
+  ));
 
+INSTANTIATE_TEST_CASE_P(ExtendedBuiltIn, ValidateBuiltInType,
+  ::testing::Values(
+       BuiltInCase{"SubgroupEqMaskKHR","%int32","Input","Vertex"},
+       BuiltInCase{"SubgroupGeMaskKHR","%bool","Input","Geometry"},
+       BuiltInCase{"SubgroupGtMaskKHR","%float","Input","TessellationControl"},
+       BuiltInCase{"SubgroupLeMaskKHR","%vecf3","Input","TessellationEvaluation"},
+       BuiltInCase{"SubgroupLtMaskKHR","%arri3","Input","Fragment"},
+
+       BuiltInCase{"BaseVertex","%float","Input","Vertex"},
+       BuiltInCase{"BaseInstance","%veci3","Input","Vertex"},
+       BuiltInCase{"DrawIndex","%arrf2","Input","Vertex"},
+       BuiltInCase{"DeviceIndex","%void","Input","GLCompute"},
+       BuiltInCase{"ViewIndex","%bool","Input","Fragment"},
+
+       BuiltInCase{"BaryCoordNoPerspAMD","%vecf3","Input","Fragment"},
+       BuiltInCase{"BaryCoordNoPerspCentroidAMD","%vecf4","Input","Fragment"},
+       BuiltInCase{"BaryCoordNoPerspSampleAMD","%veci2","Input","Fragment"},
+       BuiltInCase{"BaryCoordSmoothAMD","%veci3","Input","Fragment"},
+       BuiltInCase{"BaryCoordSmoothCentroidAMD","%veci4","Input","Fragment"},
+       BuiltInCase{"BaryCoordSmoothSampleAMD","%float","Input","Fragment"},
+       BuiltInCase{"BaryCoordPullModelAMD","%arrf3","Input","Fragment"},
+
+       BuiltInCase{"FragStencilRefEXT","%bool","Output","Fragment"},
+       BuiltInCase{"ViewportMaskNV","%arrf4","Output","Vertex"},
+       BuiltInCase{"PositionPerViewNV","%arrf4","Input","TessellationControl"},
+       BuiltInCase{"ViewportMaskPerViewNV","%void","Output","Geometry"}
+  ));
 // clang-format on
-#undef BUILTIN
+
+TEST_P(ValidateBuiltInTypeCL, BuiltInTypeCL) {
+  CompileSuccessfully(GenerateKernelCode(GetParam()),SPV_ENV_OPENCL_2_2);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr( GetParam().name +
+                " built-in must match the DATA TYPE defined"
+                " in the specification (see SPIR-V specification)"));
+}
+
+// clang-format off
+INSTANTIATE_TEST_CASE_P(BuiltInTypeCL, ValidateBuiltInTypeCL,
+  ::testing::Values(
+       BuiltInCase{"NumWorkgroups","%arrf2","Input","Kernel"},
+       // 25 = WorkgroupSize is tested individually
+       BuiltInCase{"WorkgroupId","%vecf3","Input","Kernel"},
+       BuiltInCase{"LocalInvocationId","%uint32","Input","Kernel"},
+       BuiltInCase{"GlobalInvocationId","%float","Input","Kernel"},
+       BuiltInCase{"LocalInvocationIndex","%vecu3","Input","Kernel"},
+       BuiltInCase{"WorkDim","%float","Input","Kernel"},
+       BuiltInCase{"GlobalSize","%vecu2","Input","Kernel"},
+       BuiltInCase{"EnqueuedWorkgroupSize","%vecf3","Input","Kernel"},
+       BuiltInCase{"GlobalOffset","%vecu4","Input","Kernel"},
+       BuiltInCase{"GlobalLinearId","%float","Input","Kernel"},
+       BuiltInCase{"SubgroupSize","%void","Input","Kernel"},
+       BuiltInCase{"SubgroupMaxSize","%arru3","Input","Kernel"},
+       BuiltInCase{"NumSubgroups","%float","Input","Kernel"},
+       BuiltInCase{"NumEnqueuedSubgroups","%vecf4","Input","Kernel"},
+       BuiltInCase{"SubgroupId","%void","Input","Kernel"},
+       BuiltInCase{"SubgroupLocalInvocationId","%vecu3","Input","Kernel"}
+  ));
+// clang-format on
+
+//
+// INDIVIDUAL TESTS
+//
 
 TEST_F(ValidateBuiltIn, PrimitiveIdAsFragmentInput) {
   string spirv = R"(
     OpCapability Shader
-    OpCapability Linkage
     OpMemoryModel Logical GLSL450
     OpEntryPoint Fragment %entry "entry" %bltin
     OpDecorate %bltin BuiltIn PrimitiveId
     %void    = OpTypeVoid
-    %uint32  = OpTypeInt 32 0
+    %int32  = OpTypeInt 32 0
     %voidfun = OpTypeFunction %void
-    %ptr   = OpTypePointer Input %uint32
+    %ptr   = OpTypePointer Input %int32
     %bltin = OpVariable %ptr Input
     %entry = OpFunction %void None %voidfun
     %label = OpLabel
@@ -319,6 +626,93 @@ TEST_F(ValidateBuiltIn, PrimitiveIdAsFragmentInput) {
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Decorate requires one of these capabilities: "
                         "Geometry Tessellation"));
+}
+
+// TODO(jcaraban): DepthReplacing model needed when writing to FragDepth
+//                 more info in CheckFragDepth(), validate_builtins.cpp
+#if 0
+TEST_F(ValidateBuiltIn, FragDepthNeedsDepthReplacing) {
+  string spirv = R"(
+    OpCapability Shader
+    OpMemoryModel Logical GLSL450
+    OpEntryPoint Fragment %entry "entry" %bltin
+    OpDecorate %bltin BuiltIn FragDepth
+    %void  = OpTypeVoid
+    %float = OpTypeFloat 32
+    %voidf = OpTypeFunction %void
+    %1234f = OpConstant %float 1234
+    %ptr   = OpTypePointer Output %float
+    %bltin = OpVariable %ptr Output
+    %entry = OpFunction %void None %voidf
+    %label = OpLabel
+             OpStore %builtin %1234f
+             OpReturn
+             OpFunctionEnd)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID,ValidateAndRetrieveValidationState());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("To write to FragDepth, a shader must declare the "
+                        "DepthReplacing execution mode (see Vulkan spec)"));
+}
+#endif
+
+TEST_F(ValidateBuiltIn, WorkgroupSizeOK) {
+  string spirv = R"(
+    OpCapability Shader
+    OpCapability Linkage
+    OpMemoryModel Logical GLSL450
+    OpDecorate %bltin BuiltIn WorkgroupSize
+    %int   = OpTypeInt 32 1
+    %16i   = OpConstant %int 16
+    %1i    = OpConstant %int 1
+    %vec3i = OpTypeVector %int 3
+    %bltin = OpConstantComposite %vec3i %16i %16i %1i)";
+
+    CompileSuccessfully(spirv);
+    EXPECT_EQ(SPV_SUCCESS, ValidateAndRetrieveValidationState());
+}
+
+TEST_F(ValidateBuiltInCL, WorkgroupSizeCLOK) {
+  string spirv = R"(
+    OpCapability Kernel
+    OpCapability Addresses
+    OpCapability Linkage
+    OpMemoryModel Physical64 OpenCL
+    OpDecorate %bltin BuiltIn WorkgroupSize
+    %uint  = OpTypeInt 32 0
+    %16u   = OpConstant %uint 16
+    %1u    = OpConstant %uint 1
+    %vec3u = OpTypeVector %uint 3
+    %bltin = OpConstantComposite %vec3u %16u %16u %1u)";
+
+    CompileSuccessfully(spirv);
+    EXPECT_EQ(SPV_SUCCESS, ValidateAndRetrieveValidationState());
+}
+
+TEST_F(ValidateBuiltIn, WorkgroupSizeBAD) {
+  string spirv = R"(
+    OpCapability Shader
+    OpMemoryModel Logical GLSL450
+    OpEntryPoint GLCompute %entry "entry" %bltin
+    OpExecutionMode %entry LocalSize 32 32 1
+    OpDecorate %bltin BuiltIn WorkgroupSize
+    %void  = OpTypeVoid
+    %voidf = OpTypeFunction %void
+    %int   = OpTypeInt 32 0
+    %vec3u = OpTypeVector %int 3
+    %ptr   = OpTypePointer Input %vec3u
+    %bltin = OpVariable %ptr Input
+    %entry = OpFunction %void None %voidf
+    %label = OpLabel
+             OpReturn
+             OpFunctionEnd)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID,ValidateAndRetrieveValidationState());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("The object decorated with WorkgroupSize must be "
+                        "a specialization constant or a constant"));
 }
 
 }  // anonymous namespace

--- a/test/val/val_fixtures.cpp
+++ b/test/val/val_fixtures.cpp
@@ -107,6 +107,11 @@ template class spvtest::ValidateBase<
                                std::function<spv_result_t(int)>>>>;
 template class spvtest::ValidateBase<SpvCapability>;
 template class spvtest::ValidateBase<std::pair<std::string, std::string>>;
-template class spvtest::ValidateBase<
-    std::tuple<std::string, std::string, std::string,std::string>>;
+
+// TODO(jcaraban): what is a better place for this struct?
+struct BuiltInCase {
+  std::string name, type, storage, stage;
+};
+template class spvtest::ValidateBase<BuiltInCase>;
+
 }

--- a/test/val/val_fixtures.cpp
+++ b/test/val/val_fixtures.cpp
@@ -107,4 +107,6 @@ template class spvtest::ValidateBase<
                                std::function<spv_result_t(int)>>>>;
 template class spvtest::ValidateBase<SpvCapability>;
 template class spvtest::ValidateBase<std::pair<std::string, std::string>>;
+template class spvtest::ValidateBase<
+    std::tuple<std::string, std::string, std::string,std::string>>;
 }


### PR DESCRIPTION
This WIP PR incorporates tests and validation for built-in variables.
It started as a quick fix to #770 (check storage class of built-ins),
but I realized that built-ins require a whole section on their own.
Therefore I made some decisions, and I would like to hear if your opinion.

- Split the Built-ins validation and testing from the Decorations
- Used parameterized tests, because most validation logic is repetitive
- Used individual tests, for built-ins presenting exceptional conditions
- Structured the code to be easily extended with future built-ins

Also, the logic in validate_builtins.cpp is so repetitive,
that it could pay off to auto-generate it from some description.

Finally, I noticed that some related validations are happening in other files,
e.g., below this capabilities restrictions on PrimitiveId is checked in valdiate_instructions.cpp

_“In a fragment shader, any variable decorated with PrimitiveId must be declared using the Input storage class, and either the Geometry or Tessellation capability must also be declared.”_

**Note:** work in process, submitting to get early feedback