### PR TITLE
Reenable validate type unique pass

### DIFF
--- a/source/validate_type_unique.cpp
+++ b/source/validate_type_unique.cpp
@@ -49,11 +49,7 @@ spv_result_t TypeUniquePass(ValidationState_t& _,
     }
 
     if (!_.RegisterUniqueTypeDeclaration(*inst)) {
-      // TODO(atgoo@github) Error logging temporarily disabled because it's
-      // failing vulkancts tests. Message in the diagnostics is for unit tests.
-      // See https://github.com/KhronosGroup/SPIRV-Tools/issues/559
-      // return _.diag(SPV_ERROR_INVALID_DATA)
-      return _.diag(SPV_SUCCESS)
+      return _.diag(SPV_ERROR_INVALID_DATA)
           << "Duplicate non-aggregate type declarations are not allowed."
           << " Opcode: " << spvOpcodeString(SpvOp(inst->opcode))
           << " id: " << inst->result_id;

--- a/test/val/val_type_unique_test.cpp
+++ b/test/val/val_type_unique_test.cpp
@@ -29,10 +29,7 @@ using std::string;
 
 using ValidateTypeUnique = spvtest::ValidateBase<bool>;
 
-// TODO(atgoo@github) Error logging temporarily disabled because it's failing
-// vulkancts tests. See https://github.com/KhronosGroup/SPIRV-Tools/issues/559
-// const spv_result_t kDuplicateTypeError = SPV_ERROR_INVALID_DATA;
-const spv_result_t kDuplicateTypeError = SPV_SUCCESS;
+const spv_result_t kDuplicateTypeError = SPV_ERROR_INVALID_DATA;
 
 const string& GetHeader() {
   static const string header = R"(


### PR DESCRIPTION
Vulkan CTS patch fixing the instances of non-unique type declaration in
autogenerated code has recently been submitted.