### PR TITLE
Validator checks OpReturn called from void func

### DIFF
--- a/source/val/function.h
+++ b/source/val/function.h
@@ -137,7 +137,7 @@ class Function {
   uint32_t id() const { return id_; }
 
   /// Returns return type id of the function
-  uint32_t result_type_id() const { return result_type_id_; }
+  uint32_t GetResultTypeId() const { return result_type_id_; }
 
   /// Returns the number of blocks in the current function being parsed
   size_t undefined_block_count() const;

--- a/source/val/function.h
+++ b/source/val/function.h
@@ -133,8 +133,11 @@ class Function {
   /// Returns the number of blocks in the current function being parsed
   size_t block_count() const;
 
-  /// Returns the id of the funciton
+  /// Returns the id of the function
   uint32_t id() const { return id_; }
+
+  /// Returns return type id of the function
+  uint32_t result_type_id() const { return result_type_id_; }
 
   /// Returns the number of blocks in the current function being parsed
   size_t undefined_block_count() const;

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -261,6 +261,11 @@ Function& ValidationState_t::current_function() {
   return module_functions_.back();
 }
 
+const Function& ValidationState_t::current_function() const {
+  assert(in_function_body());
+  return module_functions_.back();
+}
+
 bool ValidationState_t::in_function_body() const { return in_function_; }
 
 bool ValidationState_t::in_block() const {

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -138,6 +138,7 @@ class ValidationState_t {
 
   /// Returns the function states
   Function& current_function();
+  const Function& current_function() const;
 
   /// Returns true if the called after a function instruction but before the
   /// function end instruction

--- a/source/validate_cfg.cpp
+++ b/source/validate_cfg.cpp
@@ -402,7 +402,7 @@ spv_result_t CfgPass(ValidationState_t& _,
       _.current_function().RegisterBlockEnd({cases}, opcode);
     } break;
     case SpvOpReturn: {
-      const uint32_t return_type = _.current_function().result_type_id();
+      const uint32_t return_type = _.current_function().GetResultTypeId();
       const Instruction* return_type_inst = _.FindDef(return_type);
       assert(return_type_inst);
       if (return_type_inst->opcode() != SpvOpTypeVoid)

--- a/source/validate_cfg.cpp
+++ b/source/validate_cfg.cpp
@@ -401,8 +401,17 @@ spv_result_t CfgPass(ValidationState_t& _,
       }
       _.current_function().RegisterBlockEnd({cases}, opcode);
     } break;
+    case SpvOpReturn: {
+      const uint32_t return_type = _.current_function().result_type_id();
+      const Instruction* return_type_inst = _.FindDef(return_type);
+      assert(return_type_inst);
+      if (return_type_inst->opcode() != SpvOpTypeVoid)
+        return _.diag(SPV_ERROR_INVALID_CFG)
+            << "OpReturn can only be called from a function with void "
+            << "return type.";
+    }
+    // Fallthrough.
     case SpvOpKill:
-    case SpvOpReturn:
     case SpvOpReturnValue:
     case SpvOpUnreachable:
       _.current_function().RegisterBlockEnd(vector<uint32_t>(), opcode);

--- a/test/val/val_cfg_test.cpp
+++ b/test/val/val_cfg_test.cpp
@@ -1377,6 +1377,26 @@ TEST_F(ValidateCFG, BasicBlockIsEntryBlockOfTwoConstructsGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
+TEST_F(ValidateCFG, OpReturnInNonVoidFunc) {
+  std::string spirv = R"(
+               OpCapability Shader
+               OpCapability Linkage
+               OpMemoryModel Logical GLSL450
+        %int = OpTypeInt 32 1
+   %int_func = OpTypeFunction %int
+    %testfun = OpFunction %int None %int_func
+    %label_1 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+  CompileSuccessfully(spirv);
+  ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(
+          "OpReturn can only be called from a function with void return type"));
+}
+
 /// TODO(umar): Switch instructions
 /// TODO(umar): Nested CFG constructs
 }  /// namespace

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -330,10 +330,11 @@ TEST_F(ValidateIdWithMessage, OpEntryPointReturnTypeBad) {
   string spirv = kGLSL450MemoryModel + R"(
      OpEntryPoint GLCompute %3 ""
 %1 = OpTypeInt 32 0
+%ret = OpConstant %1 0
 %2 = OpTypeFunction %1
 %3 = OpFunction %1 None %2
 %4 = OpLabel
-     OpReturn
+     OpReturnValue %ret
      OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
@@ -2936,7 +2937,7 @@ TEST_F(ValidateIdWithMessage, OpFunctionResultTypeBad) {
 %4 = OpTypeFunction %1 %2 %2
 %5 = OpFunction %2 None %4
 %6 = OpLabel
-     OpReturn
+     OpReturnValue %3
      OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
@@ -4085,7 +4086,7 @@ OpDecorate %1 SpecId 200
 %1 = OpConstant %int 3
 %main = OpFunction %1 None %2
 %4 = OpLabel
-OpReturn
+OpReturnValue %1
 OpFunctionEnd
   )";
   CompileSuccessfully(spirv.c_str());
@@ -4107,7 +4108,7 @@ OpDecorate %1 SpecId 200
 %1 = OpSpecConstantOp %int IAdd %3 %4
 %main = OpFunction %1 None %2
 %6 = OpLabel
-OpReturn
+OpReturnValue %3
 OpFunctionEnd
   )";
   CompileSuccessfully(spirv.c_str());
@@ -4124,10 +4125,11 @@ OpDecorate %1 SpecId 200
 %void = OpTypeVoid
 %2 = OpTypeFunction %void
 %int = OpTypeInt 32 0
+%3 = OpConstant %int 1
 %1 = OpSpecConstantComposite %int
 %main = OpFunction %1 None %2
 %4 = OpLabel
-OpReturn
+OpReturnValue %3
 OpFunctionEnd
   )";
   CompileSuccessfully(spirv.c_str());


### PR DESCRIPTION
Added check into validate_cfg which checks that OpReturn is not called
from functions which are supposed to return a value.