### PR TITLE
Change BasicBlock to use InstructionList to hold instructions.

### DIFF
--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -91,7 +91,7 @@ add_library(SPIRV-Tools-opt
   types.cpp
   type_manager.cpp
   unify_const_pass.cpp
-)
+        instruction_list.cpp)
 
 spvtools_default_compile_options(SPIRV-Tools-opt)
 target_include_directories(SPIRV-Tools-opt

--- a/source/opt/basic_block.h
+++ b/source/opt/basic_block.h
@@ -126,7 +126,7 @@ inline void BasicBlock::AddInstruction(std::unique_ptr<Instruction> i) {
 
 inline void BasicBlock::AddInstructions(BasicBlock* bp) {
   auto bEnd = end();
-  (void)bEnd.InsertBefore(&bp->insts_);
+  (void) bEnd.MoveBefore(&bp->insts_);
 }
 
 inline void BasicBlock::ForEachInst(const std::function<void(Instruction*)>& f,

--- a/source/opt/basic_block.h
+++ b/source/opt/basic_block.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "instruction.h"
+#include "instruction_list.h"
 #include "iterator.h"
 
 namespace spvtools {
@@ -34,8 +35,8 @@ class Function;
 // A SPIR-V basic block.
 class BasicBlock {
  public:
-  using iterator = UptrVectorIterator<Instruction>;
-  using const_iterator = UptrVectorIterator<Instruction, true>;
+  using iterator = InstructionList::iterator;
+  using const_iterator = InstructionList::const_iterator;
 
   // Creates a basic block with the given starting |label|.
   inline explicit BasicBlock(std::unique_ptr<Instruction> label);
@@ -71,26 +72,22 @@ class BasicBlock {
   // Returns the id of the label at the top of this block
   inline uint32_t id() const { return label_->result_id(); }
 
-  iterator begin() { return iterator(&insts_, insts_.begin()); }
-  iterator end() { return iterator(&insts_, insts_.end()); }
-  const_iterator cbegin() const {
-    return const_iterator(&insts_, insts_.cbegin());
-  }
-  const_iterator cend() const {
-    return const_iterator(&insts_, insts_.cend());
-  }
+  iterator begin() { return insts_.begin(); }
+  iterator end() { return insts_.end(); }
+  const_iterator cbegin() const { return insts_.cbegin(); }
+  const_iterator cend() const { return insts_.cend(); }
 
   // Returns an iterator pointing to the last instruction.  This may only
   // be used if this block has an instruction other than the OpLabel
   // that defines it.
   iterator tail() {
     assert(!insts_.empty());
-    return iterator(&insts_, std::prev(insts_.end()));
+    return --end();
   }
   // Returns a const iterator, but othewrise similar to tail().
   const_iterator ctail() const {
     assert(!insts_.empty());
-    return const_iterator(&insts_, std::prev(insts_.cend()));
+    return --insts_.cend();
   }
 
   // Runs the given function |f| on each instruction in this basic block, and
@@ -106,12 +103,10 @@ class BasicBlock {
                              bool run_on_debug_line_insts = false);
 
   // Runs the given function |f| on each label id of each successor block
-  void ForEachSuccessorLabel(
-      const std::function<void(const uint32_t)>& f);
+  void ForEachSuccessorLabel(const std::function<void(const uint32_t)>& f);
 
   // Runs the given function |f| on the merge and continue label, if any
-  void ForMergeAndContinueLabel(
-      const std::function<void(const uint32_t)>& f);
+  void ForMergeAndContinueLabel(const std::function<void(const uint32_t)>& f);
 
  private:
   // The enclosing function.
@@ -119,25 +114,25 @@ class BasicBlock {
   // The label starting this basic block.
   std::unique_ptr<Instruction> label_;
   // Instructions inside this basic block, but not the OpLabel.
-  std::vector<std::unique_ptr<Instruction>> insts_;
+  InstructionList insts_;
 };
 
 inline BasicBlock::BasicBlock(std::unique_ptr<Instruction> label)
     : function_(nullptr), label_(std::move(label)) {}
 
 inline void BasicBlock::AddInstruction(std::unique_ptr<Instruction> i) {
-  insts_.emplace_back(std::move(i));
+  insts_.push_back(i.release());
 }
 
 inline void BasicBlock::AddInstructions(BasicBlock* bp) {
   auto bEnd = end();
-  (void) bEnd.InsertBefore(&bp->insts_);
+  (void)bEnd.InsertBefore(&bp->insts_);
 }
 
 inline void BasicBlock::ForEachInst(const std::function<void(Instruction*)>& f,
                                     bool run_on_debug_line_insts) {
   if (label_) label_->ForEachInst(f, run_on_debug_line_insts);
-  for (auto& inst : insts_) inst->ForEachInst(f, run_on_debug_line_insts);
+  for (auto& inst : insts_) inst.ForEachInst(f, run_on_debug_line_insts);
 }
 
 inline void BasicBlock::ForEachInst(
@@ -147,15 +142,15 @@ inline void BasicBlock::ForEachInst(
     static_cast<const Instruction*>(label_.get())
         ->ForEachInst(f, run_on_debug_line_insts);
   for (const auto& inst : insts_)
-    static_cast<const Instruction*>(inst.get())
+    static_cast<const Instruction*>(&inst)
         ->ForEachInst(f, run_on_debug_line_insts);
 }
 
 inline void BasicBlock::ForEachPhiInst(
     const std::function<void(Instruction*)>& f, bool run_on_debug_line_insts) {
   for (auto& inst : insts_) {
-    if (inst->opcode() != SpvOpPhi) break;
-    inst->ForEachInst(f, run_on_debug_line_insts);
+    if (inst.opcode() != SpvOpPhi) break;
+    inst.ForEachInst(f, run_on_debug_line_insts);
   }
 }
 

--- a/source/opt/common_uniform_elim_pass.cpp
+++ b/source/opt/common_uniform_elim_pass.cpp
@@ -306,7 +306,7 @@ bool CommonUniformElimPass::UniformAccessChainConvert(ir::Function* func) {
       GenACLoadRepl(ptrInst, &newInsts, &replId);
       ReplaceAndDeleteLoad(&*ii, replId, ptrInst);
       ++ii;
-      ii = ii.InsertBefore(&newInsts);
+      ii = ii.InsertBefore(std::move(newInsts));
       ++ii;
       modified = true;
     }

--- a/source/opt/inline_exhaustive_pass.cpp
+++ b/source/opt/inline_exhaustive_pass.cpp
@@ -37,7 +37,7 @@ bool InlineExhaustivePass::InlineExhaustive(ir::Function* func) {
         bi = bi.Erase();
         bi = bi.InsertBefore(&newBlocks);
         // Insert new function variables.
-        if (newVars.size() > 0) func->begin()->begin().InsertBefore(&newVars);
+        if (newVars.size() > 0) func->begin()->begin().InsertBefore(std::move(newVars));
         // Restart inlining at beginning of calling block.
         ii = bi->begin();
         modified = true;

--- a/source/opt/inline_opaque_pass.cpp
+++ b/source/opt/inline_opaque_pass.cpp
@@ -85,7 +85,7 @@ bool InlineOpaquePass::InlineOpaque(ir::Function* func) {
         bi = bi.Erase();
         bi = bi.InsertBefore(&newBlocks);
         // Insert new function variables.
-        if (newVars.size() > 0) func->begin()->begin().InsertBefore(&newVars);
+        if (newVars.size() > 0) func->begin()->begin().InsertBefore(std::move(newVars));
         // Restart inlining at beginning of calling block.
         ii = bi->begin();
         modified = true;

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -86,7 +86,7 @@ class InlinePass : public Pass {
 
   // Map callee params to caller args
   void MapParams(ir::Function* calleeFn,
-                 ir::UptrVectorIterator<ir::Instruction> call_inst_itr,
+                 ir::BasicBlock::iterator call_inst_itr,
                  std::unordered_map<uint32_t, uint32_t>* callee2caller);
 
   // Clone and map callee locals
@@ -131,7 +131,7 @@ class InlinePass : public Pass {
   // call_block_itr is replaced with new_blocks.
   void GenInlineCode(std::vector<std::unique_ptr<ir::BasicBlock>>* new_blocks,
                      std::vector<std::unique_ptr<ir::Instruction>>* new_vars,
-                     ir::UptrVectorIterator<ir::Instruction> call_inst_itr,
+                     ir::BasicBlock::iterator call_inst_itr,
                      ir::UptrVectorIterator<ir::BasicBlock> call_block_itr);
 
   // Return true if |inst| is a function call that can be inlined.

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -40,7 +40,8 @@ Instruction::Instruction(const spv_parsed_instruction_t& inst,
 
 Instruction::Instruction(SpvOp op, uint32_t ty_id, uint32_t res_id,
                          const std::vector<Operand>& in_operands)
-    : opcode_(op), type_id_(ty_id), result_id_(res_id), operands_() {
+    : utils::IntrusiveNodeBase<Instruction>(), opcode_(op), type_id_(ty_id),
+      result_id_(res_id), operands_() {
   if (type_id_ != 0) {
     operands_.emplace_back(spv_operand_type_t::SPV_OPERAND_TYPE_TYPE_ID,
                            std::initializer_list<uint32_t>{type_id_});
@@ -53,7 +54,8 @@ Instruction::Instruction(SpvOp op, uint32_t ty_id, uint32_t res_id,
 }
 
 Instruction::Instruction(Instruction&& that)
-    : opcode_(that.opcode_),
+    : utils::IntrusiveNodeBase<Instruction>(),
+      opcode_(that.opcode_),
       type_id_(that.type_id_),
       result_id_(that.result_id_),
       operands_(std::move(that.operands_)),
@@ -66,6 +68,16 @@ Instruction& Instruction::operator=(Instruction&& that) {
   operands_ = std::move(that.operands_);
   dbg_line_insts_ = std::move(that.dbg_line_insts_);
   return *this;
+}
+
+Instruction* Instruction::Clone() const {
+  Instruction * result = new Instruction();
+  result->opcode_ = opcode_;
+  result->type_id_ = type_id_;
+  result->result_id_ = result_id_;
+  result->operands_ = operands_;
+  result->dbg_line_insts_ = dbg_line_insts_;
+  return result;
 }
 
 uint32_t Instruction::GetSingleWordOperand(uint32_t index) const {

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -40,8 +40,11 @@ Instruction::Instruction(const spv_parsed_instruction_t& inst,
 
 Instruction::Instruction(SpvOp op, uint32_t ty_id, uint32_t res_id,
                          const std::vector<Operand>& in_operands)
-    : utils::IntrusiveNodeBase<Instruction>(), opcode_(op), type_id_(ty_id),
-      result_id_(res_id), operands_() {
+    : utils::IntrusiveNodeBase<Instruction>(),
+      opcode_(op),
+      type_id_(ty_id),
+      result_id_(res_id),
+      operands_() {
   if (type_id_ != 0) {
     operands_.emplace_back(spv_operand_type_t::SPV_OPERAND_TYPE_TYPE_ID,
                            std::initializer_list<uint32_t>{type_id_});
@@ -71,13 +74,13 @@ Instruction& Instruction::operator=(Instruction&& that) {
 }
 
 Instruction* Instruction::Clone() const {
-  Instruction * result = new Instruction();
-  result->opcode_ = opcode_;
-  result->type_id_ = type_id_;
-  result->result_id_ = result_id_;
-  result->operands_ = operands_;
-  result->dbg_line_insts_ = dbg_line_insts_;
-  return result;
+  Instruction* clone = new Instruction();
+  clone->opcode_ = opcode_;
+  clone->type_id_ = type_id_;
+  clone->result_id_ = result_id_;
+  clone->operands_ = operands_;
+  clone->dbg_line_insts_ = dbg_line_insts_;
+  return clone;
 }
 
 uint32_t Instruction::GetSingleWordOperand(uint32_t index) const {

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -117,7 +117,7 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
 
   virtual ~Instruction() = default;
 
-  // Return a newly allocated instruction that has the same operands, result,
+  // Returns a newly allocated instruction that has the same operands, result,
   // and type as |this|.  The new instruction is not linked into any list.
   // It is the responsibility of the caller to make sure that the storage is
   // removed. It is the caller's responsibility to make sure that there is only

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -38,7 +38,7 @@ class InstructionList;
 // In the SPIR-V specification, the term "operand" is used to mean any single
 // SPIR-V word following the leading wordcount-opcode word. Here, the term
 // "operand" is used to mean a *logical* operand. A logical operand may consist
-// of mulitple SPIR-V words, which together make up the same component. For
+// of multiple SPIR-V words, which together make up the same component. For
 // example, a logical operand of a 64-bit integer needs two words to express.
 //
 // Further, we categorize logical operands into *in* and *out* operands.
@@ -115,10 +115,12 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   Instruction(Instruction&&);
   Instruction& operator=(Instruction&&);
 
+  virtual ~Instruction() = default;
+
   // Return a newly allocated instruction that has the same operands, result,
   // and type as |this|.  The new instruction is not linked into any list.
   // It is the responsibility of the caller to make sure that the storage is
-  // remove. It is the caller's responsibility to make sure that there is only
+  // removed. It is the caller's responsibility to make sure that there is only
   // one instruction for each result id.
   Instruction* Clone() const;
 

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -139,7 +139,7 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
 
   // Same semantics as in the base class except the list the InstructionList
   // containing |pos| will now assume ownership of |this|.
-  // inline void InsertBefore(Instruction* pos);
+  // inline void MoveBefore(Instruction* pos);
   // inline void InsertAfter(Instruction* pos);
 
   // Begin and end iterators for operands.

--- a/source/opt/instruction_list.cpp
+++ b/source/opt/instruction_list.cpp
@@ -26,23 +26,6 @@ InstructionList::~InstructionList() {
 }
 
 InstructionList::iterator InstructionList::iterator::InsertBefore(
-    InstructionList* list) {
-  Instruction* first_node = list->sentinel_.next_node_;
-  Instruction* last_node = list->sentinel_.previous_node_;
-
-  this->node_->previous_node_->next_node_ = first_node;
-  first_node->previous_node_ = this->node_->previous_node_;
-
-  last_node->next_node_ = this->node_;
-  this->node_->previous_node_ = last_node;
-
-  list->sentinel_.next_node_ = &list->sentinel_;
-  list->sentinel_.previous_node_ = &list->sentinel_;
-
-  return iterator(first_node);
-}
-
-InstructionList::iterator InstructionList::iterator::InsertBefore(
     std::vector<std::unique_ptr<Instruction>>* list) {
   Instruction* first_node = list->front().get();
   for (auto& i : *list) {

--- a/source/opt/instruction_list.cpp
+++ b/source/opt/instruction_list.cpp
@@ -36,7 +36,7 @@ InstructionList::iterator InstructionList::iterator::InsertBefore(
 }
 
 InstructionList::iterator InstructionList::iterator::InsertBefore(
-    std::unique_ptr<Instruction> i) {
+    std::unique_ptr<Instruction>&& i) {
   i.get()->InsertBefore(node_);
   return iterator(i.release());
 }

--- a/source/opt/instruction_list.cpp
+++ b/source/opt/instruction_list.cpp
@@ -26,12 +26,12 @@ InstructionList::~InstructionList() {
 }
 
 InstructionList::iterator InstructionList::iterator::InsertBefore(
-    std::vector<std::unique_ptr<Instruction>>* list) {
-  Instruction* first_node = list->front().get();
-  for (auto& i : *list) {
+    std::vector<std::unique_ptr<Instruction>>&& list) {
+  Instruction* first_node = list.front().get();
+  for (auto& i : list) {
     i.release()->InsertBefore(node_);
   }
-  list->clear();
+  list.clear();
   return iterator(first_node);
 }
 
@@ -40,6 +40,5 @@ InstructionList::iterator InstructionList::iterator::InsertBefore(
   i.get()->InsertBefore(node_);
   return iterator(i.release());
 }
-
 }  // namespace ir
 }  // namespace spvtools

--- a/source/opt/instruction_list.cpp
+++ b/source/opt/instruction_list.cpp
@@ -1,0 +1,62 @@
+// Copyright (c) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "instruction_list.h"
+
+namespace spvtools {
+namespace ir {
+
+InstructionList::~InstructionList() {
+  while (!empty()) {
+    Instruction* inst = &front();
+    inst->RemoveFromList();
+    delete inst;
+  }
+}
+
+InstructionList::iterator InstructionList::iterator::InsertBefore(
+    InstructionList* list) {
+  Instruction* first_node = list->sentinel_.next_node_;
+  Instruction* last_node = list->sentinel_.previous_node_;
+
+  this->node_->previous_node_->next_node_ = first_node;
+  first_node->previous_node_ = this->node_->previous_node_;
+
+  last_node->next_node_ = this->node_;
+  this->node_->previous_node_ = last_node;
+
+  list->sentinel_.next_node_ = &list->sentinel_;
+  list->sentinel_.previous_node_ = &list->sentinel_;
+
+  return iterator(first_node);
+}
+
+InstructionList::iterator InstructionList::iterator::InsertBefore(
+    std::vector<std::unique_ptr<Instruction>>* list) {
+  Instruction* first_node = list->front().get();
+  for (auto& i : *list) {
+    i.release()->InsertBefore(node_);
+  }
+  list->clear();
+  return iterator(first_node);
+}
+
+InstructionList::iterator InstructionList::iterator::InsertBefore(
+    std::unique_ptr<Instruction> i) {
+  i.get()->InsertBefore(node_);
+  return iterator(i.release());
+}
+
+}  // namespace ir
+}  // namespace spvtools

--- a/source/opt/instruction_list.h
+++ b/source/opt/instruction_list.h
@@ -38,8 +38,8 @@ namespace ir {
 // TODO: Because there are a number of other data structures that will want
 // pointers to instruction, ownership should probably be moved to the module.
 // Because of that I have not made the ownership passing in this class fully
-// explicit.  For example, RemoveFromList takes ownership from the list, but does
-// not return an std::unique_ptr to signal that.  When we fully decide on
+// explicit.  For example, RemoveFromList takes ownership from the list, but
+// does not return an std::unique_ptr to signal that.  When we fully decide on
 // ownership, this will have to be fixed up one way or the other.
 class InstructionList : public utils::IntrusiveList<Instruction> {
  public:

--- a/source/opt/instruction_list.h
+++ b/source/opt/instruction_list.h
@@ -1,0 +1,82 @@
+
+// Copyright (c) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBSPIRV_OPT_INSTRUCTION_LIST_H_
+#define LIBSPIRV_OPT_INSTRUCTION_LIST_H_
+
+#include <cassert>
+#include <functional>
+#include <utility>
+#include <vector>
+
+#include "instruction.h"
+#include "operand.h"
+#include "util/ilist.h"
+
+#include "spirv-tools/libspirv.h"
+#include "spirv/1.2/spirv.h"
+
+namespace spvtools {
+namespace ir {
+
+// This class is intended to be the container for Instructions.  This container
+// owns the instructions that are in it.  When removing an Instruction from the
+// list, the caller is assumming responsibility for deleting the storage.
+class InstructionList : public utils::IntrusiveList<Instruction> {
+ public:
+  InstructionList() = default;
+  InstructionList(InstructionList&& that)
+      : utils::IntrusiveList<Instruction>(std::move(that)) {}
+  InstructionList& operator=(InstructionList&& that) {
+    auto p = static_cast<utils::IntrusiveList<Instruction>*>(this);
+    *p = std::move(that);
+    return *this;
+  }
+
+  class iterator : public utils::IntrusiveList<Instruction>::iterator {
+   public:
+    iterator(const utils::IntrusiveList<Instruction>::iterator& i)
+        : utils::IntrusiveList<Instruction>::iterator(&*i) {}
+    iterator(Instruction* i) : utils::IntrusiveList<Instruction>::iterator(i) {}
+
+    // The nodes in |list| will be moved to the list that |this| points to.  The
+    // positions of the nodes will be immediately before the element pointed to
+    // by the iterator.  The return value will be an iterator pointing to the
+    // first of the newly inserted elements.  Ownership if the elements in
+    // |list| is now pass on to the new list that contains them.
+    iterator InsertBefore(InstructionList* list);
+
+    // The nodes in |list| will be moved to the list that |this| points to.  The
+    // positions of the nodes will be immediately before the element pointed to
+    // by the iterator.  The return value will be an iterator pointing to the
+    // first of the newly inserted elements.  Ownership if the elements in
+    // |list| is now pass on to the new list that contains them.
+    iterator InsertBefore(
+        std::vector<std::unique_ptr<Instruction>>* list);
+
+    // The node |i| will be inserted immediatly before |this|. The return value
+    // will be an iterator pointing to the newly inserted node.  The owner of
+    // |*i| becomes the list that contains it.
+    iterator InsertBefore(std::unique_ptr<Instruction> i);
+  };
+
+  // Destroy this list and any instructions in the list.
+  virtual ~InstructionList();
+};
+
+}  // namespace ir
+}  // namespace spvtools
+
+#endif  // LIBSPIRV_OPT_INSTRUCTION_LIST_H_

--- a/source/opt/instruction_list.h
+++ b/source/opt/instruction_list.h
@@ -56,15 +56,7 @@ class InstructionList : public utils::IntrusiveList<Instruction> {
     // by the iterator.  The return value will be an iterator pointing to the
     // first of the newly inserted elements.  Ownership if the elements in
     // |list| is now pass on to the new list that contains them.
-    iterator InsertBefore(InstructionList* list);
-
-    // The nodes in |list| will be moved to the list that |this| points to.  The
-    // positions of the nodes will be immediately before the element pointed to
-    // by the iterator.  The return value will be an iterator pointing to the
-    // first of the newly inserted elements.  Ownership if the elements in
-    // |list| is now pass on to the new list that contains them.
-    iterator InsertBefore(
-        std::vector<std::unique_ptr<Instruction>>* list);
+    iterator InsertBefore(std::vector<std::unique_ptr<Instruction>>* list);
 
     // The node |i| will be inserted immediatly before |this|. The return value
     // will be an iterator pointing to the newly inserted node.  The owner of

--- a/source/opt/instruction_list.h
+++ b/source/opt/instruction_list.h
@@ -33,7 +33,14 @@ namespace ir {
 
 // This class is intended to be the container for Instructions.  This container
 // owns the instructions that are in it.  When removing an Instruction from the
-// list, the caller is assumming responsibility for deleting the storage.
+// list, the caller is assuming responsibility for deleting the storage.
+//
+// TODO: Because there are a number of other data structures that will want
+// pointers to instruction, owndership should probably be moved to the module.
+// Because of that I have not made the ownership passing in this class fully
+// explicit.  For example, RemoveFromList takes ownership from the list, but does
+// not return an std::unique_ptr to signal that.  When we fully decide on
+// ownership, this will have to be fixed up one way or the other.
 class InstructionList : public utils::IntrusiveList<Instruction> {
  public:
   InstructionList() = default;
@@ -45,27 +52,38 @@ class InstructionList : public utils::IntrusiveList<Instruction> {
     return *this;
   }
 
+  // Destroy this list and any instructions in the list.
+  virtual ~InstructionList();
+
   class iterator : public utils::IntrusiveList<Instruction>::iterator {
    public:
     iterator(const utils::IntrusiveList<Instruction>::iterator& i)
         : utils::IntrusiveList<Instruction>::iterator(&*i) {}
     iterator(Instruction* i) : utils::IntrusiveList<Instruction>::iterator(i) {}
 
+    // DEPRECATED: Please use MoveBefore with an InstructionList instead.
+    //
     // The nodes in |list| will be moved to the list that |this| points to.  The
     // positions of the nodes will be immediately before the element pointed to
     // by the iterator.  The return value will be an iterator pointing to the
-    // first of the newly inserted elements.  Ownership if the elements in
-    // |list| is now pass on to the new list that contains them.
+    // first of the newly inserted elements.  Ownership of the elements in
+    // |list| is now passed on to |*this|.
     iterator InsertBefore(std::vector<std::unique_ptr<Instruction>>* list);
 
-    // The node |i| will be inserted immediatly before |this|. The return value
+    // The node |i| will be inserted immediately before |this|. The return value
     // will be an iterator pointing to the newly inserted node.  The owner of
-    // |*i| becomes the list that contains it.
+    // |*i| becomes |*this|
     iterator InsertBefore(std::unique_ptr<Instruction> i);
   };
 
-  // Destroy this list and any instructions in the list.
-  virtual ~InstructionList();
+  iterator begin() { return utils::IntrusiveList<Instruction>::begin(); }
+  iterator end() { return utils::IntrusiveList<Instruction>::end(); }
+  const_iterator begin() const {
+    return utils::IntrusiveList<Instruction>::begin();
+  }
+  const_iterator end() const {
+    return utils::IntrusiveList<Instruction>::end();
+  }
 };
 
 }  // namespace ir

--- a/source/opt/instruction_list.h
+++ b/source/opt/instruction_list.h
@@ -63,12 +63,12 @@ class InstructionList : public utils::IntrusiveList<Instruction> {
 
     // DEPRECATED: Please use MoveBefore with an InstructionList instead.
     //
-    // The nodes in |list| will be moved to the list that |this| points to.  The
+    // Moves the nodes in |list| to the list that |this| points to.  The
     // positions of the nodes will be immediately before the element pointed to
     // by the iterator.  The return value will be an iterator pointing to the
     // first of the newly inserted elements.  Ownership of the elements in
     // |list| is now passed on to |*this|.
-    iterator InsertBefore(std::vector<std::unique_ptr<Instruction>>* list);
+    iterator InsertBefore(std::vector<std::unique_ptr<Instruction>>&& list);
 
     // The node |i| will be inserted immediately before |this|. The return value
     // will be an iterator pointing to the newly inserted node.  The owner of

--- a/source/opt/instruction_list.h
+++ b/source/opt/instruction_list.h
@@ -36,7 +36,7 @@ namespace ir {
 // list, the caller is assuming responsibility for deleting the storage.
 //
 // TODO: Because there are a number of other data structures that will want
-// pointers to instruction, owndership should probably be moved to the module.
+// pointers to instruction, ownership should probably be moved to the module.
 // Because of that I have not made the ownership passing in this class fully
 // explicit.  For example, RemoveFromList takes ownership from the list, but does
 // not return an std::unique_ptr to signal that.  When we fully decide on
@@ -73,7 +73,7 @@ class InstructionList : public utils::IntrusiveList<Instruction> {
     // The node |i| will be inserted immediately before |this|. The return value
     // will be an iterator pointing to the newly inserted node.  The owner of
     // |*i| becomes |*this|
-    iterator InsertBefore(std::unique_ptr<Instruction> i);
+    iterator InsertBefore(std::unique_ptr<Instruction>&& i);
   };
 
   iterator begin() { return utils::IntrusiveList<Instruction>::begin(); }

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -227,7 +227,7 @@ bool LocalAccessChainConvertPass::ConvertLocalAccessChains(ir::Function* func) {
             GenAccessChainLoadReplacement(ptrInst, &newInsts);
         ReplaceAndDeleteLoad(&*ii, replId);
         ++ii;
-        ii = ii.InsertBefore(&newInsts);
+        ii = ii.InsertBefore(std::move(newInsts));
         ++ii;
         modified = true;
       } break;
@@ -244,7 +244,7 @@ bool LocalAccessChainConvertPass::ConvertLocalAccessChains(ir::Function* func) {
         def_use_mgr_->KillInst(&*ii);
         DeleteIfUseless(ptrInst);
         ++ii;
-        ii = ii.InsertBefore(&newInsts);
+        ii = ii.InsertBefore(std::move(newInsts));
         ++ii;
         ++ii;
         modified = true;

--- a/source/util/ilist.h
+++ b/source/util/ilist.h
@@ -190,7 +190,6 @@ inline IntrusiveList<NodeType>::IntrusiveList() : sentinel_() {
   sentinel_.next_node_ = &sentinel_;
   sentinel_.previous_node_ = &sentinel_;
   sentinel_.is_sentinel_ = true;
-  Check(&sentinel_);
 }
 
 template <class NodeType>
@@ -199,13 +198,10 @@ IntrusiveList<NodeType>::IntrusiveList(IntrusiveList&& list) : sentinel_() {
   sentinel_.previous_node_ = &sentinel_;
   sentinel_.is_sentinel_ = true;
   list.sentinel_.ReplaceWith(&sentinel_);
-  Check(&sentinel_);
-  Check(&list.sentinel_);
 }
 
 template <class NodeType>
 IntrusiveList<NodeType>::~IntrusiveList() {
-  Check(&sentinel_);
   while (!empty()) {
     front().RemoveFromList();
   }
@@ -215,8 +211,6 @@ template <class NodeType>
 IntrusiveList<NodeType>& IntrusiveList<NodeType>::operator=(
     IntrusiveList<NodeType>&& list) {
   list.sentinel_.ReplaceWith(&sentinel_);
-  Check(&sentinel_);
-  Check(&list.sentinel_);
   return *this;
 }
 

--- a/source/util/ilist.h
+++ b/source/util/ilist.h
@@ -100,7 +100,7 @@ class IntrusiveList {
       return !(lhs == rhs);
     }
 
-    // The nodes in |list| will be moved to the list that |this| points to.  The
+    // Moves the nodes in |list| to the list that |this| points to.  The
     // positions of the nodes will be immediately before the element pointed to
     // by the iterator.  The return value will be an iterator pointing to the
     // first of the newly inserted elements.
@@ -157,7 +157,7 @@ class IntrusiveList {
   // will be removed from that list first.
   void push_back(NodeType* node);
 
-  // Return true if the list is empty.
+  // Returns true if the list is empty.
   bool empty() const;
 
   // Returns references to the first or last element in the list.  It is an

--- a/source/util/ilist.h
+++ b/source/util/ilist.h
@@ -100,6 +100,28 @@ class IntrusiveList {
       return !(lhs == rhs);
     }
 
+    // The nodes in |list| will be moved to the list that |this| points to.  The
+    // positions of the nodes will be immediately before the element pointed to
+    // by the iterator.  The return value will be an iterator pointing to the
+    // first of the newly inserted elements.
+    iterator_template MoveBefore(IntrusiveList* list) {
+      if (list->empty()) return *this;
+
+      NodeType* first_node = list->sentinel_.next_node_;
+      NodeType* last_node = list->sentinel_.previous_node_;
+
+      this->node_->previous_node_->next_node_ = first_node;
+      first_node->previous_node_ = this->node_->previous_node_;
+
+      last_node->next_node_ = this->node_;
+      this->node_->previous_node_ = last_node;
+
+      list->sentinel_.next_node_ = &list->sentinel_;
+      list->sentinel_.previous_node_ = &list->sentinel_;
+
+      return iterator(first_node);
+    }
+
    protected:
     iterator_template() = delete;
     inline iterator_template(T* node) { node_ = node; }

--- a/source/util/ilist.h
+++ b/source/util/ilist.h
@@ -16,7 +16,9 @@
 #define LIBSPIRV_OPT_ILIST_H_
 
 #include <cassert>
+#include <memory>
 #include <type_traits>
+#include <vector>
 
 #include "ilist_node.h"
 
@@ -59,7 +61,7 @@ class IntrusiveList {
 
   // Destorys the list.  Note that the elements of the list will not be deleted,
   // but they will be removed from the list.
-  ~IntrusiveList();
+  virtual ~IntrusiveList();
 
   // Moves all of the elements in the list on the RHS to the list on the LHS.
   IntrusiveList& operator=(IntrusiveList&&);
@@ -98,7 +100,7 @@ class IntrusiveList {
       return !(lhs == rhs);
     }
 
-   private:
+   protected:
     iterator_template() = delete;
     inline iterator_template(T* node) { node_ = node; }
     T* node_;
@@ -133,12 +135,26 @@ class IntrusiveList {
   // will be removed from that list first.
   void push_back(NodeType* node);
 
- private:
+  // Return true if the list is empty.
+  bool empty() const;
+
+  // Returns references to the first or last element in the list.  It is an
+  // error to call these functions on an empty list.
+  NodeType& front();
+  NodeType& back();
+  const NodeType& front() const;
+  const NodeType& back() const;
+
+ protected:
   // Doing a deep copy of the list does not make sense if the list does not own
   // the data.  It is not clear who will own the newly created data.  Making
   // copies illegal for that reason.
   IntrusiveList(const IntrusiveList&) = delete;
   IntrusiveList& operator=(const IntrusiveList&) = delete;
+
+  // This function will assert if it finds the list containing |node| is not in
+  // a valid state.
+  static void Check(NodeType* node);
 
   // A special node used to represent both the start and end of the list,
   // without being part of the list.
@@ -155,29 +171,23 @@ inline IntrusiveList<NodeType>::IntrusiveList() : sentinel_() {
 }
 
 template <class NodeType>
-IntrusiveList<NodeType>::IntrusiveList(IntrusiveList&& list) {
-  this->sentinel_ = list.sentinel_;
+IntrusiveList<NodeType>::IntrusiveList(IntrusiveList&& list) : sentinel_() {
+  this->sentinel_ = std::move(list.sentinel_);
   this->sentinel_.next_node_->previous_node_ = &this->sentinel_;
   this->sentinel_.previous_node_->next_node_ = &this->sentinel_;
-
-  list.sentinel_.next_node_ = &list.sentinel_;
-  list.sentinel_.previous_node_ = &list.sentinel_;
 }
 
 template <class NodeType>
 IntrusiveList<NodeType>::~IntrusiveList() {
-  for (auto i : *this) i.RemoveFromList();
+  while (!empty()) {
+    front().RemoveFromList();
+  }
 }
 
 template <class NodeType>
 IntrusiveList<NodeType>& IntrusiveList<NodeType>::operator=(
     IntrusiveList<NodeType>&& list) {
-  this->sentinel_ = list.sentinel_;
-  this->sentinel_.next_node_->previous_node_ = &this->sentinel_;
-  this->sentinel_.previous_node_->next_node_ = &this->sentinel_;
-
-  list.sentinel_.next_node_ = &list.sentinel_;
-  list.sentinel_.previous_node_ = &list.sentinel_;
+  this->sentinel_ = std::move(list.sentinel_);
   return *this;
 }
 
@@ -220,6 +230,53 @@ IntrusiveList<NodeType>::cend() const {
 template <class NodeType>
 void IntrusiveList<NodeType>::push_back(NodeType* node) {
   node->InsertBefore(&sentinel_);
+}
+
+template <class NodeType>
+bool IntrusiveList<NodeType>::empty() const {
+  return sentinel_.NextNode() == nullptr;
+}
+
+template <class NodeType>
+NodeType& IntrusiveList<NodeType>::front() {
+  NodeType* node = sentinel_.NextNode();
+  assert(node != nullptr && "Can't get the front of an empty list.");
+  return *node;
+}
+
+template <class NodeType>
+NodeType& IntrusiveList<NodeType>::back() {
+  NodeType* node = sentinel_.PreviousNode();
+  assert(node != nullptr && "Can't get the back of an empty list.");
+  return *node;
+}
+
+template <class NodeType>
+const NodeType& IntrusiveList<NodeType>::front() const {
+  NodeType* node = sentinel_.NextNode();
+  assert(node != nullptr && "Can't get the front of an empty list.");
+  return *node;
+}
+
+template <class NodeType>
+const NodeType& IntrusiveList<NodeType>::back() const {
+  NodeType* node = sentinel_.PreviousNode();
+  assert(node != nullptr && "Can't get the back of an empty list.");
+  return *node;
+}
+
+template <class NodeType>
+void IntrusiveList<NodeType>::Check(NodeType* start) {
+  for (NodeType* p = start->next_node_; p != start; p = p->next_node_) {
+    assert(p != nullptr);
+    assert(p->next_node_->previous_node_ == p);
+    assert(p->previous_node_->next_node_ == p);
+  }
+  for (NodeType* p = start->previous_node_; p != start; p = p->previous_node_) {
+    assert(p != nullptr);
+    assert(p->next_node_->previous_node_ == p);
+    assert(p->previous_node_->next_node_ == p);
+  }
 }
 
 }  // namespace utils

--- a/source/util/ilist_node.h
+++ b/source/util/ilist_node.h
@@ -35,8 +35,8 @@ class IntrusiveNodeBase {
   inline IntrusiveNodeBase& operator=(const IntrusiveNodeBase&);
   inline IntrusiveNodeBase(IntrusiveNodeBase&& that);
 
-  // Will destroy a node.  It is an error to destroy a node that is part of a
-  // list, unless it is an sentinel.
+  // Destroys a node.  It is an error to destroy a node that is part of a
+  // list, unless it is a sentinel.
   virtual ~IntrusiveNodeBase();
 
   IntrusiveNodeBase& operator=(IntrusiveNodeBase&& that);
@@ -76,7 +76,7 @@ class IntrusiveNodeBase {
   inline void RemoveFromList();
 
  protected:
-  // This function will replace |this| with |target|.  No nodes that are not
+  // Replaces |this| with |target|.  No nodes that are not
   // sentinels, |target| takes the place of |this|.  If the nodes are sentinels,
   // then it will cause all of the nodes to be move from one list to another.
   void ReplaceWith(NodeType* target);

--- a/source/util/ilist_node.h
+++ b/source/util/ilist_node.h
@@ -31,7 +31,7 @@ class IntrusiveNodeBase {
  public:
   // Creates a new node that is not in a list.
   inline IntrusiveNodeBase();
-  inline IntrusiveNodeBase(const IntrusiveNodeBase& that);
+  inline IntrusiveNodeBase(const IntrusiveNodeBase&);
   inline IntrusiveNodeBase& operator=(const IntrusiveNodeBase&);
   inline IntrusiveNodeBase(IntrusiveNodeBase&& that);
 
@@ -96,8 +96,7 @@ inline IntrusiveNodeBase<NodeType>::IntrusiveNodeBase()
 
 template<class NodeType>
 inline IntrusiveNodeBase<NodeType>::IntrusiveNodeBase(
-    const IntrusiveNodeBase& that) {
-  assert(!that.is_sentinel_);
+    const IntrusiveNodeBase&) {
   next_node_ = nullptr;
   previous_node_ = nullptr;
   is_sentinel_ = false;

--- a/source/util/ilist_node.h
+++ b/source/util/ilist_node.h
@@ -172,7 +172,9 @@ template <class NodeType>
 inline void IntrusiveNodeBase<NodeType>::InsertAfter(NodeType* pos) {
   assert(!this->is_sentinel_ && "Sentinel nodes cannot be moved around.");
   assert(pos->IsInAList() && "Pos should already be in a list.");
-  if (this->IsInAList()) this->RemoveFromList();
+  if (this->IsInAList()) {
+    this->RemoveFromList();
+  }
 
   this->previous_node_ = pos;
   this->next_node_ = pos->next_node_;

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -17,6 +17,11 @@ add_spvtools_unittest(TARGET instruction
   LIBS SPIRV-Tools-opt
 )
 
+add_spvtools_unittest(TARGET instruction_list
+        SRCS instruction_list_test.cpp
+        LIBS SPIRV-Tools-opt
+        )
+
 add_spvtools_unittest(TARGET ir_loader
   SRCS ir_loader_test.cpp
   LIBS SPIRV-Tools-opt

--- a/test/opt/instruction_list_test.cpp
+++ b/test/opt/instruction_list_test.cpp
@@ -99,7 +99,7 @@ TEST(InstructionListTest, InsertBefore2) {
     created_instructions.push_back(inst.get());
     new_instructions.push_back(std::move(inst));
   }
-  auto new_element = list.begin().InsertBefore(&new_instructions);
+  auto new_element = list.begin().InsertBefore(std::move(new_instructions));
   EXPECT_TRUE(new_instructions.empty());
   EXPECT_EQ(&*new_element, created_instructions.front());
 

--- a/test/opt/instruction_list_test.cpp
+++ b/test/opt/instruction_list_test.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "opt/instruction.h"
+#include "opt/instruction_list.h"
+
+namespace {
+
+using Instruction = spvtools::ir::Instruction;
+using InstructionList = spvtools::ir::InstructionList;
+using ::testing::ContainerEq;
+using ::testing::ElementsAre;
+using InstructionListTest = ::testing::Test;
+
+class TestInstruction : public Instruction {
+ public:
+  TestInstruction() : Instruction() {
+    created_instructions_.push_back(this);
+    static int counter = 0;
+    data = ++counter;
+  }
+
+  ~TestInstruction() { deleted_instructions_.push_back(this); }
+
+  int data;
+  static std::vector<TestInstruction*> created_instructions_;
+  static std::vector<TestInstruction*> deleted_instructions_;
+};
+
+std::vector<TestInstruction*> TestInstruction::created_instructions_;
+std::vector<TestInstruction*> TestInstruction::deleted_instructions_;
+
+// Test that the destructor for InstructionList is calling the destructor
+// for every element that is in the list.
+TEST(InstructionListTest, Destructor) {
+  InstructionList* list = new InstructionList();
+  list->push_back(new Instruction());
+  list->push_back(new Instruction());
+  delete list;
+
+  EXPECT_THAT(TestInstruction::created_instructions_,
+              ContainerEq(TestInstruction::deleted_instructions_));
+}
+
+// Test the |InsertBefore| with a single instruction in the iterator class.
+// Need to make sure the elements are inserted in the correct order, and the
+// return value points to the correct location.
+TEST(InstructionListTest, InsertBefore1) {
+  InstructionList list;
+  std::vector<Instruction*> created_instructions;
+  for (int i = 0; i < 4; i++) {
+    std::unique_ptr<Instruction> inst(new Instruction());
+    created_instructions.push_back(inst.get());
+    auto new_element = list.end().InsertBefore(std::move(inst));
+    EXPECT_THAT(&*new_element, created_instructions.back());
+  }
+
+  std::vector<Instruction*> output;
+  for (auto& i : list) {
+    output.push_back(&i);
+  }
+  EXPECT_THAT(output, ContainerEq(created_instructions));
+}
+
+// Test inserting an entire vector of instructions using InsertBefore.  Checking
+// the order of insertion and the return value.
+TEST(InstructionListTest, InsertBefore2) {
+  InstructionList list;
+  std::vector<std::unique_ptr<Instruction>> new_instructions;
+  std::vector<Instruction*> created_instructions;
+  for (int i = 0; i < 4; i++) {
+    std::unique_ptr<Instruction> inst(new Instruction());
+    created_instructions.push_back(inst.get());
+    new_instructions.push_back(std::move(inst));
+  }
+  auto new_element = list.begin().InsertBefore(&new_instructions);
+  EXPECT_TRUE(new_instructions.empty());
+  EXPECT_EQ(&*new_element, created_instructions.front());
+
+  std::vector<Instruction*> output;
+  for (auto& i : list) {
+    output.push_back(&i);
+  }
+  EXPECT_THAT(output, ContainerEq(created_instructions));
+}
+}  // namespace

--- a/test/util/ilist_test.cpp
+++ b/test/util/ilist_test.cpp
@@ -15,7 +15,6 @@
 #include <vector>
 
 #include "gmock/gmock.h"
-#include "gtest/gtest.h"
 
 #include "util/ilist.h"
 
@@ -35,8 +34,7 @@ class TestNode : public IntrusiveNodeBase<TestNode> {
 class TestList : public IntrusiveList<TestNode> {
  public:
   TestList() = default;
-  TestList(TestList&& that) : IntrusiveList<TestNode>(std::move(that)) {
-  }
+  TestList(TestList&& that) : IntrusiveList<TestNode>(std::move(that)) {}
   TestList& operator=(TestList&& that) {
     static_cast<IntrusiveList<TestNode>&>(*this) =
         static_cast<IntrusiveList<TestNode>&&>(that);

--- a/test/util/ilist_test.cpp
+++ b/test/util/ilist_test.cpp
@@ -28,7 +28,7 @@ using IListTest = ::testing::Test;
 class TestNode : public IntrusiveNodeBase<TestNode> {
  public:
   TestNode() : IntrusiveNodeBase<TestNode>() {}
-  int data;
+  int data_;
 };
 
 class TestList : public IntrusiveList<TestNode> {
@@ -44,17 +44,17 @@ class TestList : public IntrusiveList<TestNode> {
 
 // This test checks the push_back method, as well as using an iterator to
 // traverse the list from begin() to end().  This implicitly test the
-// PreviousNode and NextNode fucntions.
+// PreviousNode and NextNode functions.
 TEST(IListTest, PushBack) {
   TestNode nodes[10];
   TestList list;
   for (int i = 0; i < 10; i++) {
-    nodes[i].data = i;
+    nodes[i].data_ = i;
     list.push_back(&nodes[i]);
   }
 
   std::vector<int> output;
-  for (auto& i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data_);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
 }
@@ -64,7 +64,7 @@ TEST(IListTest, PushBack) {
 TestList BuildList(TestNode nodes[], int n) {
   TestList list;
   for (int i = 0; i < n; i++) {
-    nodes[i].data = i;
+    nodes[i].data_ = i;
     list.push_back(&nodes[i]);
   }
   return list;
@@ -81,7 +81,7 @@ TEST(IListTest, DecrementingBegin) {
 TEST(IListTest, IncrementingEnd1) {
   TestNode nodes[10];
   TestList list = BuildList(nodes, 10);
-  EXPECT_EQ((++list.end())->data, 0);
+  EXPECT_EQ((++list.end())->data_, 0);
 }
 
 // Test incrementing end() should equal begin()
@@ -95,7 +95,7 @@ TEST(IListTest, IncrementingEnd2) {
 TEST(IListTest, DecrementingEnd) {
   TestNode nodes[10];
   TestList list = BuildList(nodes, 10);
-  EXPECT_EQ((--list.end())->data, 9);
+  EXPECT_EQ((--list.end())->data_, 9);
 }
 
 // Test the move constructor for the list class.
@@ -103,7 +103,7 @@ TEST(IListTest, MoveConstructor) {
   TestNode nodes[10];
   TestList list = BuildList(nodes, 10);
   std::vector<int> output;
-  for (auto& i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data_);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
 }
@@ -113,7 +113,7 @@ TEST(IListTest, ConstIterator) {
   TestNode nodes[10];
   const TestList list = BuildList(nodes, 10);
   std::vector<int> output;
-  for (auto& i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data_);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
 }
@@ -124,7 +124,7 @@ TEST(IListTest, MoveAssignment) {
   TestList list;
   list = BuildList(nodes, 10);
   std::vector<int> output;
-  for (auto& i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data_);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
 }
@@ -135,11 +135,11 @@ TEST(IListTest, InsertAfter1) {
   TestNode nodes[10];
   TestList list = BuildList(nodes, 5);
 
-  nodes[5].data = 5;
+  nodes[5].data_ = 5;
   nodes[5].InsertAfter(&nodes[4]);
 
   std::vector<int> output;
-  for (auto& i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data_);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 3, 4, 5));
 }
@@ -150,11 +150,11 @@ TEST(IListTest, InsertAfter2) {
   TestNode nodes[10];
   TestList list = BuildList(nodes, 5);
 
-  nodes[5].data = 5;
+  nodes[5].data_ = 5;
   nodes[5].InsertAfter(&nodes[2]);
 
   std::vector<int> output;
-  for (auto& i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data_);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 5, 3, 4));
 }
@@ -168,7 +168,7 @@ TEST(IListTest, MoveUsingInsertAfter1) {
   nodes[5].InsertAfter(&nodes[2]);
 
   std::vector<int> output;
-  for (auto& i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data_);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 5, 3, 4));
 }
@@ -181,7 +181,7 @@ TEST(IListTest, MoveUsingInsertAfter2) {
   nodes[0].InsertAfter(&nodes[2]);
 
   std::vector<int> output;
-  for (auto& i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data_);
 
   EXPECT_THAT(output, ElementsAre(1, 2, 0, 3, 4, 5));
 }
@@ -194,7 +194,7 @@ TEST(IListTest, MoveUsingInsertAfter3) {
   nodes[2].InsertAfter(&nodes[5]);
 
   std::vector<int> output;
-  for (auto& i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data_);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 3, 4, 5, 2));
 }
@@ -207,7 +207,7 @@ TEST(IListTest, Remove1) {
   nodes[2].RemoveFromList();
 
   std::vector<int> output;
-  for (auto& i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data_);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 3, 4, 5));
 }
@@ -220,7 +220,7 @@ TEST(IListTest, Remove2) {
   nodes[0].RemoveFromList();
 
   std::vector<int> output;
-  for (auto& i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data_);
 
   EXPECT_THAT(output, ElementsAre(1, 2, 3, 4, 5));
 }
@@ -233,7 +233,7 @@ TEST(IListTest, Remove3) {
   nodes[5].RemoveFromList();
 
   std::vector<int> output;
-  for (auto& i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data_);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 3, 4));
 }
@@ -246,7 +246,7 @@ TEST(IListTest, IteratorEqual) {
   std::vector<int> output;
   for (auto i = list.begin(); i != list.end(); ++i)
     for (auto j = list.begin(); j != list.end(); ++j)
-      if (i == j) output.push_back(i->data);
+      if (i == j) output.push_back(i->data_);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 3, 4, 5));
 }
@@ -262,7 +262,8 @@ TEST(IListTest, MoveBefore1) {
   insertion_point.MoveBefore(&list2);
 
   std::vector<int> output;
-  for (auto i = list1.begin(); i != list1.end(); ++i) output.push_back(i->data);
+  for (auto i = list1.begin(); i != list1.end(); ++i)
+    output.push_back(i->data_);
 
   EXPECT_THAT(output, ElementsAre(0, 0, 1, 2, 1, 2, 3, 4, 5));
 }
@@ -277,7 +278,8 @@ TEST(IListTest, MoveBefore2) {
   insertion_point.MoveBefore(&list2);
 
   std::vector<int> output;
-  for (auto i = list1.begin(); i != list1.end(); ++i) output.push_back(i->data);
+  for (auto i = list1.begin(); i != list1.end(); ++i)
+    output.push_back(i->data_);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 0, 1, 2, 3, 4, 5));
 }
@@ -292,7 +294,8 @@ TEST(IListTest, MoveBefore3) {
   insertion_point.MoveBefore(&list2);
 
   std::vector<int> output;
-  for (auto i = list1.begin(); i != list1.end(); ++i) output.push_back(i->data);
+  for (auto i = list1.begin(); i != list1.end(); ++i)
+    output.push_back(i->data_);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 3, 4, 5, 0, 1, 2));
 }
@@ -307,7 +310,8 @@ TEST(IListTest, MoveBefore4) {
   insertion_point.MoveBefore(&list2);
 
   std::vector<int> output;
-  for (auto i = list1.begin(); i != list1.end(); ++i) output.push_back(i->data);
+  for (auto i = list1.begin(); i != list1.end(); ++i)
+    output.push_back(i->data_);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 3, 4, 5));
 }

--- a/test/util/ilist_test.cpp
+++ b/test/util/ilist_test.cpp
@@ -46,15 +46,15 @@ class TestList : public IntrusiveList<TestNode> {
 // traverse the list from begin() to end().  This implicitly test the
 // PreviousNode and NextNode fucntions.
 TEST(IListTest, PushBack) {
-  TestList list;
   TestNode nodes[10];
+  TestList list;
   for (int i = 0; i < 10; i++) {
     nodes[i].data = i;
     list.push_back(&nodes[i]);
   }
 
   std::vector<int> output;
-  for (auto i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
 }
@@ -75,7 +75,7 @@ TEST(IListTest, DecrementingBegin) {
   TestNode nodes[10];
   TestList list = BuildList(nodes, 10);
   std::vector<int> output;
-  for (auto i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data);
 
   EXPECT_EQ(--list.begin(), list.end());
 }
@@ -85,7 +85,7 @@ TEST(IListTest, IncrementingEnd1) {
   TestNode nodes[10];
   TestList list = BuildList(nodes, 10);
   std::vector<int> output;
-  for (auto i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data);
 
   EXPECT_EQ((++list.end())->data, 0);
 }
@@ -95,7 +95,7 @@ TEST(IListTest, IncrementingEnd2) {
   TestNode nodes[10];
   TestList list = BuildList(nodes, 10);
   std::vector<int> output;
-  for (auto i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data);
 
   EXPECT_EQ(++list.end(), list.begin());
 }
@@ -105,7 +105,7 @@ TEST(IListTest, DecrementingEnd) {
   TestNode nodes[10];
   TestList list = BuildList(nodes, 10);
   std::vector<int> output;
-  for (auto i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data);
 
   EXPECT_EQ((--list.end())->data, 9);
 }
@@ -115,7 +115,7 @@ TEST(IListTest, MoveConstructor) {
   TestNode nodes[10];
   TestList list = BuildList(nodes, 10);
   std::vector<int> output;
-  for (auto i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
 }
@@ -125,7 +125,7 @@ TEST(IListTest, ConstIterator) {
   TestNode nodes[10];
   const TestList list = BuildList(nodes, 10);
   std::vector<int> output;
-  for (auto i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
 }
@@ -136,7 +136,7 @@ TEST(IListTest, MoveAssignment) {
   TestList list;
   list = BuildList(nodes, 10);
   std::vector<int> output;
-  for (auto i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
 }
@@ -151,7 +151,7 @@ TEST(IListTest, InsertAfter1) {
   nodes[5].InsertAfter(&nodes[4]);
 
   std::vector<int> output;
-  for (auto i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 3, 4, 5));
 }
@@ -166,7 +166,7 @@ TEST(IListTest, InsertAfter2) {
   nodes[5].InsertAfter(&nodes[2]);
 
   std::vector<int> output;
-  for (auto i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 5, 3, 4));
 }
@@ -180,7 +180,7 @@ TEST(IListTest, MoveUsingInsertAfter1) {
   nodes[5].InsertAfter(&nodes[2]);
 
   std::vector<int> output;
-  for (auto i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 5, 3, 4));
 }
@@ -193,7 +193,7 @@ TEST(IListTest, MoveUsingInsertAfter2) {
   nodes[0].InsertAfter(&nodes[2]);
 
   std::vector<int> output;
-  for (auto i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data);
 
   EXPECT_THAT(output, ElementsAre(1, 2, 0, 3, 4, 5));
 }
@@ -206,7 +206,7 @@ TEST(IListTest, MoveUsingInsertAfter3) {
   nodes[2].InsertAfter(&nodes[5]);
 
   std::vector<int> output;
-  for (auto i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 3, 4, 5, 2));
 }
@@ -219,7 +219,7 @@ TEST(IListTest, Remove1) {
   nodes[2].RemoveFromList();
 
   std::vector<int> output;
-  for (auto i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 3, 4, 5));
 }
@@ -232,7 +232,7 @@ TEST(IListTest, Remove2) {
   nodes[0].RemoveFromList();
 
   std::vector<int> output;
-  for (auto i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data);
 
   EXPECT_THAT(output, ElementsAre(1, 2, 3, 4, 5));
 }
@@ -245,7 +245,7 @@ TEST(IListTest, Remove3) {
   nodes[5].RemoveFromList();
 
   std::vector<int> output;
-  for (auto i : list) output.push_back(i.data);
+  for (auto& i : list) output.push_back(i.data);
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 3, 4));
 }


### PR DESCRIPTION
This is the first step in replacing the std::vector of Instruction
pointers to using and intrusive linked list.

To this end, we created the InstructionList class.  It inherites from
the IntrusiveList class, but add the extra concept of ownership.  An
InstructionList owns the instruction that are in it.  This is to be
consistent with the current ownership rules where the vector owns the
instruction that are in it.

The other larger change is that the inst_ member of the BasicBlock class
was changed to using the InstructionList class.