### PR TITLE
DeadBranchElim: Simplify and fix dead block elimination

### DIFF
--- a/source/opt/dead_branch_elim_pass.cpp
+++ b/source/opt/dead_branch_elim_pass.cpp
@@ -204,6 +204,7 @@ void DeadBranchElimPass::ComputeBackEdges(
   std::unordered_set<uint32_t> visited;
   // In structured order, edges to visited blocks are back edges
   for (auto bi = structuredOrder.begin(); bi != structuredOrder.end(); ++bi) {
+    visited.insert((*bi)->id());
     auto ii = (*bi)->end();
     --ii;
     switch(ii->opcode()) {
@@ -228,7 +229,6 @@ void DeadBranchElimPass::ComputeBackEdges(
       default:
         break;
     }
-    visited.insert((*bi)->id());
   }
 }
 

--- a/source/opt/dead_branch_elim_pass.h
+++ b/source/opt/dead_branch_elim_pass.h
@@ -97,8 +97,11 @@ class DeadBranchElimPass : public MemPass {
   bool GetSelectionBranch(ir::BasicBlock* bp, ir::Instruction** branchInst,
     ir::Instruction** mergeInst, uint32_t *condId);
 
-  // Return true if |labelId| has any non-phi references
-  bool HasNonPhiRef(uint32_t labelId);
+  // Return true if |labelId| has any non-phi, non-backedge references
+  bool HasNonPhiNonBackedgeRef(uint32_t labelId);
+
+  // Compute backedges for blocks in |structuredOrder|.
+  void ComputeBackEdges(std::list<ir::BasicBlock*>& structuredOrder);
 
   // For function |func|, look for BranchConditionals with constant condition
   // and convert to a Branch to the indicated label. Delete resulting dead
@@ -125,6 +128,9 @@ class DeadBranchElimPass : public MemPass {
   std::unordered_map<const ir::BasicBlock*, std::vector<ir::BasicBlock*>>
       block2structured_succs_;
   
+  // All backedge branches in current function
+  std::unordered_set<ir::Instruction*> backedges_;
+
   // Extensions supported by this pass.
   std::unordered_set<std::string> extensions_whitelist_;
 };


### PR DESCRIPTION
  The previous algorithm would leave invalid code in the case of unreachable
  blocks pointing into a dead branch. It would leave the unreachable blocks
  branching to labels that no longer exist. The previous algorithm also left
  unreachable blocks in some cases (eg a loop dominated by an orphaned
  merge block). This fix also addresses that.
    
  This code will soon be replaced with the coming CFG cleanup, but in the meantime...