### PR TITLE
Refactored compression debugger

### DIFF
--- a/source/comp/markv.h
+++ b/source/comp/markv.h
@@ -29,35 +29,48 @@
 
 namespace spvtools {
 
-struct MarkvEncoderOptions {
+struct MarkvCodecOptions {
   bool validate_spirv_binary = false;
 };
 
-struct MarkvDecoderOptions {
-  bool validate_spirv_binary = false;
-};
+// Debug callback. Called once per instruction.
+// |words| is instriuction SPIR-V words.
+// |bits| is a string of MARK-V bits used to encode the instruction.
+// |comment| contains all logs generated while processing the instruction.
+using MarkvDebugConsumer = std::function<bool(
+    const std::vector<uint32_t>& words, const std::string& bits,
+    const std::string& comment)>;
+
+// Logging callback. Called often (if decoder reads a single bit, the log
+// consumer will receive 1 character string with that bit).
+// This callback is more suitable for continous output than MarkvDebugConsumer,
+// for example if the codec crashes it would allow to pinpoint on which operand
+// or bit the crash happened.
+using MarkvLogConsumer = std::function<void(const std::string& snippet)>;
 
 // Encodes the given SPIR-V binary to MARK-V binary.
-// If |comments| is not nullptr, it would contain a textual description of
-// how encoding was done (with snippets of disassembly and bit sequences).
+// |log_consumer| is optional (pass MarkvLogConsumer() to disable).
+// |debug_consumer| is optional (pass MarkvDebugConsumer() to disable).
 spv_result_t SpirvToMarkv(spv_const_context context,
                           const std::vector<uint32_t>& spirv,
-                          const MarkvEncoderOptions& options,
+                          const MarkvCodecOptions& options,
                           const MarkvModel& markv_model,
                           MessageConsumer message_consumer,
-                          std::vector<uint8_t>* markv,
-                          std::string* comments);
+                          MarkvLogConsumer log_consumer,
+                          MarkvDebugConsumer debug_consumer,
+                          std::vector<uint8_t>* markv);
 
 // Decodes a SPIR-V binary from the given MARK-V binary.
-// If |comments| is not nullptr, it would contain a textual description of
-// how decoding was done (with snippets of disassembly and bit sequences).
+// |log_consumer| is optional (pass MarkvLogConsumer() to disable).
+// |debug_consumer| is optional (pass MarkvDebugConsumer() to disable).
 spv_result_t MarkvToSpirv(spv_const_context context,
                           const std::vector<uint8_t>& markv,
-                          const MarkvDecoderOptions& options,
+                          const MarkvCodecOptions& options,
                           const MarkvModel& markv_model,
                           MessageConsumer message_consumer,
-                          std::vector<uint32_t>* spirv,
-                          std::string* comments);
+                          MarkvLogConsumer log_consumer,
+                          MarkvDebugConsumer debug_consumer,
+                          std::vector<uint32_t>* spirv);
 
 }  // namespace spvtools
 

--- a/source/comp/markv.h
+++ b/source/comp/markv.h
@@ -34,8 +34,9 @@ struct MarkvCodecOptions {
 };
 
 // Debug callback. Called once per instruction.
-// |words| is instriuction SPIR-V words.
-// |bits| is a string of MARK-V bits used to encode the instruction.
+// |words| is instruction SPIR-V words.
+// |bits| is a textual representation of the MARK-V bit sequence used to encode
+// the instruction (char '0' for 0, char '1' for 1).
 // |comment| contains all logs generated while processing the instruction.
 using MarkvDebugConsumer = std::function<bool(
     const std::vector<uint32_t>& words, const std::string& bits,
@@ -46,6 +47,8 @@ using MarkvDebugConsumer = std::function<bool(
 // This callback is more suitable for continous output than MarkvDebugConsumer,
 // for example if the codec crashes it would allow to pinpoint on which operand
 // or bit the crash happened.
+// |snippet| could be any atomic fragment of text logged by the codec. It can
+// contain a paragraph of text with newlines, or can be just one character.
 using MarkvLogConsumer = std::function<void(const std::string& snippet)>;
 
 // Encodes the given SPIR-V binary to MARK-V binary.

--- a/source/util/bit_stream.cpp
+++ b/source/util/bit_stream.cpp
@@ -414,6 +414,7 @@ size_t BitReaderWord64::ReadBits(uint64_t* bits, size_t num_bits) {
 
   if (pos_ >= buffer_.size() * 64) {
     // Reached end of buffer_.
+    EmitSequence(*bits, num_read_from_first_word);
     return num_read_from_first_word;
   }
 
@@ -426,6 +427,7 @@ size_t BitReaderWord64::ReadBits(uint64_t* bits, size_t num_bits) {
 
   // We likely have written more bits than requested. Clear excessive bits.
   *bits = GetLowerBits(*bits, num_bits);
+  EmitSequence(*bits, num_bits);
   return num_bits;
 }
 

--- a/source/util/bit_stream.h
+++ b/source/util/bit_stream.h
@@ -436,9 +436,26 @@ class BitReaderWord64 : public BitReaderInterface {
   bool OnlyZeroesLeft() const override;
 
   BitReaderWord64() = delete;
+
+  // Sets callback to emit bit sequences after every read.
+  void SetCallback(std::function<void(const std::string&)> callback) {
+    callback_ = callback;
+  }
+
+ protected:
+  // Sends string generated from arguments to callback_ if defined.
+  void EmitSequence(uint64_t bits, size_t num_bits) const {
+    if (callback_)
+      callback_(BitsToStream(bits, num_bits));
+  }
+
  private:
   const std::vector<uint64_t> buffer_;
   size_t pos_;
+
+  // If not null, the reader will use the callback to emit the read bit
+  // sequence as a string of '0' and '1'.
+  std::function<void(const std::string&)> callback_;
 };
 
 }  // namespace spvutils

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -65,7 +65,7 @@ if (NOT ${SPIRV_SKIP_EXECUTABLES})
                       SRCS comp/markv.cpp
                            comp/markv_model_factory.cpp
                            comp/markv_model_shader_default.cpp
-	              LIBS SPIRV-Tools-comp ${SPIRV_TOOLS})
+	              LIBS SPIRV-Tools-comp SPIRV-Tools-opt ${SPIRV_TOOLS})
     target_include_directories(spirv-markv PRIVATE ${spirv-tools_SOURCE_DIR}
                                                    ${SPIRV_HEADER_INCLUDE_DIR})
     set(SPIRV_INSTALL_TARGETS ${SPIRV_INSTALL_TARGETS} spirv-markv)


### PR DESCRIPTION
Markv codec now receives two optional callbacks:
- LogConsumer for internal codec logging
- DebugConsumer for testing if encoding->decoding produces the original
results.

tools/comp/spirv-markv now has new task 't' which tests the codec on a given file
