### PR TITLE
Refactor Travis CI, add Android.mk build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,12 @@ script:
   - export NPROC=4;
   - mkdir build && cd build;
   - if [[ "$BUILD_ANDROID_MK" == "ON" ]]; then
-      $ANDROID_NDK/ndk-build -C ../android_test NDK_PROJECT_PATH=. NDK_APP_OUT=$(pwd) -j${NPROC};
+      export BUILD_DIR=$(pwd);
+      mkdir ${BUILD_DIR}/libs;
+      mkdir ${BUILD_DIR}/app;
+      $ANDROID_NDK/ndk-build -C ../android_test NDK_PROJECT_PATH=.
+                             NDK_LIBS_OUT=${BUILD_DIR}/libs
+                             NDK_APP_OUT=${BUILD_DIR}/app -j${NPROC};
     elif [[ "$BUILD_ANDROID_CMAKE" == "ON" ]]; then
       cmake -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_PATH}
             -DANDROID_NATIVE_API_LEVEL=android-9

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
   - export NPROC=4;
   - mkdir build && cd build;
   - if [[ "$BUILD_ANDROID_MK" == "ON" ]]; then
-      $ANDROID_NDK/ndk-build -C ../android_test NDK_PROJECT_PATH=. NDK_APP_OUT=$(pwd) -j4;
+      $ANDROID_NDK/ndk-build -C ../android_test NDK_PROJECT_PATH=. NDK_APP_OUT=$(pwd) -j${NPROC};
     elif [[ "$BUILD_ANDROID_CMAKE" == "ON" ]]; then
       cmake -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_PATH}
             -DANDROID_NATIVE_API_LEVEL=android-9

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,28 +57,24 @@ before_script:
   - git clone --depth=1 https://github.com/google/googletest          external/googletest
 
 script:
-  - mkdir build && cd build
-  - if [[ "$BUILD_ANDROID_CMAKE" == "ON" ]]; then
+  # Due to the limitation of Travis platform, we cannot start too many concurrent jobs.
+  # Otherwise GCC will panic with internal error, possibility because of memory issues.
+  # ctest with the current tests doesn't profit from using more than 4 threads.
+  - export NPROC=4;
+  - mkdir build && cd build;
+  - if [[ "$BUILD_ANDROID_MK" == "ON" ]]; then
+      $ANDROID_NDK/ndk-build -C ../android_test NDK_PROJECT_PATH=. NDK_APP_OUT=$(pwd) -j4;
+    elif [[ "$BUILD_ANDROID_CMAKE" == "ON" ]]; then
       cmake -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_PATH}
             -DANDROID_NATIVE_API_LEVEL=android-9
             -DCMAKE_BUILD_TYPE=Release
             -DANDROID_ABI="armeabi-v7a with NEON"
             -DSPIRV_BUILD_COMPRESSION=ON
             -DSPIRV_SKIP_TESTS=ON ..;
-    elif [[ "$BUILD_ANDROID_MK" == "ON" ]]; then
-      $ANDROID_NDK/ndk-build -C ../android_test NDK_PROJECT_PATH=. NDK_APP_OUT=$(pwd) -j4;
+      make -j${NPROC};
     else
       cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DSPIRV_BUILD_COMPRESSION=ON ..;
-    fi
-  # Due to the limitation of Travis platform, we cannot start too many concurrent jobs.
-  # Otherwise GCC will panic with internal error, possibility because of memory issues.
-  - make -j4
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      export NPROC=`nproc`;
-    else
-      export NPROC=`sysctl -n hw.ncpu`;
-    fi
-  - if [[ "$BUILD_ANDROID_CMAKE" != "ON" ]] && [[ "$BUILD_ANDROID_MK" != "ON" ]]; then
+      make -j${NPROC};
       ctest -j${NPROC} --output-on-failure --timeout 300;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,10 @@ compiler:
 matrix:
   fast_finish: true
   include:
-    # Additional build using Android NDK
-    - env: BUILD_NDK=ON
+    # Additional build using Android NDK with android-cmake
+    - env: BUILD_ANDROID_CMAKE=ON
+    # Additional build using Android NDK with Android.mk
+    - env: BUILD_ANDROID_MK=ON
   exclude:
     # Skip GCC builds on macOS.
     - os: osx
@@ -43,7 +45,7 @@ branches:
     - master
 
 before_install:
-  - if [[ "$BUILD_NDK" == "ON" ]]; then
+  - if [[ "$BUILD_ANDROID_CMAKE" == "ON" ]] || [[ "$BUILD_ANDROID_MK" == "ON" ]]; then
       git clone --depth=1 https://github.com/urho3d/android-ndk.git $HOME/android-ndk;
       export ANDROID_NDK=$HOME/android-ndk;
       git clone --depth=1 https://github.com/taka-no-me/android-cmake.git $HOME/android-cmake;
@@ -56,13 +58,15 @@ before_script:
 
 script:
   - mkdir build && cd build
-  - if [[ "$BUILD_NDK" == "ON" ]]; then
+  - if [[ "$BUILD_ANDROID_CMAKE" == "ON" ]]; then
       cmake -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_PATH}
             -DANDROID_NATIVE_API_LEVEL=android-9
             -DCMAKE_BUILD_TYPE=Release
             -DANDROID_ABI="armeabi-v7a with NEON"
             -DSPIRV_BUILD_COMPRESSION=ON
             -DSPIRV_SKIP_TESTS=ON ..;
+    elif [[ "$BUILD_ANDROID_MK" == "ON" ]]; then
+      $ANDROID_NDK/ndk-build -C ../android_test NDK_PROJECT_PATH=. NDK_APP_OUT=$(pwd) -j4;
     else
       cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DSPIRV_BUILD_COMPRESSION=ON ..;
     fi
@@ -74,12 +78,15 @@ script:
     else
       export NPROC=`sysctl -n hw.ncpu`;
     fi
-  - if [[ "$BUILD_NDK" != "ON" ]]; then ctest -j${NPROC} --output-on-failure --timeout 300; fi
+  - if [[ "$BUILD_ANDROID_CMAKE" != "ON" ]] && [[ "$BUILD_ANDROID_MK" != "ON" ]]; then
+      ctest -j${NPROC} --output-on-failure --timeout 300;
+    fi
 
 
 notifications:
   email:
     recipients:
+      - andreyt@google.com
       - antiagainst@google.com
       - awoloszyn@google.com
       - dneto@google.com


### PR DESCRIPTION
- Added Android.mk build.
- Hard-coded NPROC used for ctest to 4. More doesn't bring any improvement for the current tests.