### PR TITLE
Run dead variable elimination when using -O and -Os

### DIFF
--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -21,7 +21,7 @@ add_library(SPIRV-Tools-opt
   compact_ids_pass.h
   constants.h
   dead_branch_elim_pass.h
-        dead_variable_elimination.h
+  dead_variable_elimination.h
   decoration_manager.h
   def_use_manager.h
   eliminate_dead_constant_pass.h
@@ -67,7 +67,7 @@ add_library(SPIRV-Tools-opt
   decoration_manager.cpp
   def_use_manager.cpp
   dead_branch_elim_pass.cpp
-        dead_variable_elimination.cpp
+  dead_variable_elimination.cpp
   eliminate_dead_constant_pass.cpp
   flatten_decoration_pass.cpp
   fold.cpp
@@ -97,7 +97,7 @@ add_library(SPIRV-Tools-opt
   types.cpp
   type_manager.cpp
   unify_const_pass.cpp
-        instruction_list.cpp)
+  instruction_list.cpp)
 
 spvtools_default_compile_options(SPIRV-Tools-opt)
 target_include_directories(SPIRV-Tools-opt

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -77,7 +77,8 @@ Optimizer& Optimizer::RegisterPerformancePasses() {
       .RegisterPass(CreateBlockMergePass())
       .RegisterPass(CreateLocalMultiStoreElimPass())
       .RegisterPass(CreateInsertExtractElimPass())
-      .RegisterPass(CreateCommonUniformElimPass());
+      .RegisterPass(CreateCommonUniformElimPass())
+      .RegisterPass(CreateDeadVariableEliminationPass());
 }
 
 Optimizer& Optimizer::RegisterSizePasses() {
@@ -91,7 +92,8 @@ Optimizer& Optimizer::RegisterSizePasses() {
       .RegisterPass(CreateBlockMergePass())
       .RegisterPass(CreateLocalMultiStoreElimPass())
       .RegisterPass(CreateInsertExtractElimPass())
-      .RegisterPass(CreateCommonUniformElimPass());
+      .RegisterPass(CreateCommonUniformElimPass())
+      .RegisterPass(CreateDeadVariableEliminationPass());
 }
 
 bool Optimizer::Run(const uint32_t* original_binary,

--- a/source/util/ilist_node.h
+++ b/source/util/ilist_node.h
@@ -122,7 +122,9 @@ template<class NodeType>
 inline IntrusiveNodeBase<NodeType>& IntrusiveNodeBase<NodeType>::operator=(
     const IntrusiveNodeBase&) {
   assert(!is_sentinel_);
-  if (IsInAList()) RemoveFromList();
+  if (IsInAList()) {
+    RemoveFromList();
+  }
   return *this;
 }
 


### PR DESCRIPTION
We want to run the optimization when using -O and -Os, but it was not
added at part of https://github.com/KhronosGroup/SPIRV-Tools/pull/905.
This change will add that a well as some minor formatting changes
requested in that same pull request.