### PR TITLE
Change the sections in the module to use the InstructionList class.

### DIFF
--- a/source/opt/basic_block.h
+++ b/source/opt/basic_block.h
@@ -131,7 +131,7 @@ inline BasicBlock::BasicBlock(std::unique_ptr<Instruction> label)
     : function_(nullptr), label_(std::move(label)) {}
 
 inline void BasicBlock::AddInstruction(std::unique_ptr<Instruction> i) {
-  insts_.push_back(i.release());
+  insts_.push_back(std::move(i));
 }
 
 inline void BasicBlock::AddInstructions(BasicBlock* bp) {

--- a/source/opt/fold_spec_constant_op_and_composite_pass.cpp
+++ b/source/opt/fold_spec_constant_op_and_composite_pass.cpp
@@ -592,7 +592,7 @@ FoldSpecConstantOpAndCompositePass::BuildInstructionAndAddToModule(
   if (!new_inst) return nullptr;
   auto* new_inst_ptr = new_inst.get();
   *pos = pos->InsertBefore(std::move(new_inst));
-  (*pos)++;
+  ++(*pos);
   def_use_mgr_->AnalyzeInstDefUse(new_inst_ptr);
   return new_inst_ptr;
 }

--- a/source/opt/instruction_list.cpp
+++ b/source/opt/instruction_list.cpp
@@ -17,13 +17,6 @@
 namespace spvtools {
 namespace ir {
 
-InstructionList::~InstructionList() {
-  while (!empty()) {
-    Instruction* inst = &front();
-    inst->RemoveFromList();
-    delete inst;
-  }
-}
 
 InstructionList::iterator InstructionList::iterator::InsertBefore(
     std::vector<std::unique_ptr<Instruction>>&& list) {

--- a/source/opt/iterator.h
+++ b/source/opt/iterator.h
@@ -121,9 +121,23 @@ class IteratorRange {
   IteratorType end_;
 };
 
+// Returns a (begin, end) iterator pair for the given iterators.
+// The iterators must belong to the same container.
+template<typename IteratorType>
+inline IteratorRange<IteratorType> make_range(IteratorType& begin, IteratorType& end) {
+  return {begin, end};
+}
+
+// Returns a (begin, end) iterator pair for the given iterators.
+// The iterators must belong to the same container.
+template<typename IteratorType>
+inline IteratorRange<IteratorType> make_range(IteratorType&& begin, IteratorType&& end) {
+  return {begin, end};
+}
+
 // Returns a (begin, end) iterator pair for the given container.
-template <typename ValueType,
-          class IteratorType = UptrVectorIterator<ValueType>>
+template<typename ValueType,
+    class IteratorType = UptrVectorIterator<ValueType>>
 inline IteratorRange<IteratorType> make_range(
     std::vector<std::unique_ptr<ValueType>>& container) {
   return {IteratorType(&container, container.begin()),

--- a/source/opt/module.h
+++ b/source/opt/module.h
@@ -42,8 +42,8 @@ class Module {
  public:
   using iterator = UptrVectorIterator<Function>;
   using const_iterator = UptrVectorIterator<Function, true>;
-  using inst_iterator = UptrVectorIterator<Instruction>;
-  using const_inst_iterator = UptrVectorIterator<Instruction, true>;
+  using inst_iterator = InstructionList::iterator;
+  using const_inst_iterator = InstructionList::const_iterator;
 
   // Creates an empty module with zero'd header.
   Module() : header_({}) {}
@@ -119,7 +119,9 @@ class Module {
 
   // Return the memory model instruction contained inthis module.
   inline Instruction* GetMemoryModel() { return memory_model_.get(); }
-  inline const Instruction* GetMemoryModel() const { return memory_model_.get(); }
+  inline const Instruction* GetMemoryModel() const {
+    return memory_model_.get();
+  }
 
   // There are several kinds of debug instructions, according to where they can
   // appear in the logical layout of a module:
@@ -161,7 +163,11 @@ class Module {
   inline IteratorRange<const_inst_iterator> execution_modes() const;
 
   // Clears all debug instructions (excluding OpLine & OpNoLine).
-  void debug_clear() { debug1_clear(); debug2_clear(); debug3_clear(); }
+  void debug_clear() {
+    debug1_clear();
+    debug2_clear();
+    debug3_clear();
+  }
 
   // Clears all debug 1 instructions (excluding OpLine & OpNoLine).
   void debug1_clear() { debugs1_.clear(); }
@@ -222,32 +228,32 @@ class Module {
 
   // The following fields respect the "Logical Layout of a Module" in
   // Section 2.4 of the SPIR-V specification.
-  std::vector<std::unique_ptr<Instruction>> capabilities_;
-  std::vector<std::unique_ptr<Instruction>> extensions_;
-  std::vector<std::unique_ptr<Instruction>> ext_inst_imports_;
+  InstructionList capabilities_;
+  InstructionList extensions_;
+  InstructionList ext_inst_imports_;
   // A module only has one memory model instruction.
   std::unique_ptr<Instruction> memory_model_;
-  std::vector<std::unique_ptr<Instruction>> entry_points_;
-  std::vector<std::unique_ptr<Instruction>> execution_modes_;
-  std::vector<std::unique_ptr<Instruction>> debugs1_;
-  std::vector<std::unique_ptr<Instruction>> debugs2_;
-  std::vector<std::unique_ptr<Instruction>> debugs3_;
-  std::vector<std::unique_ptr<Instruction>> annotations_;
+  InstructionList entry_points_;
+  InstructionList execution_modes_;
+  InstructionList debugs1_;
+  InstructionList debugs2_;
+  InstructionList debugs3_;
+  InstructionList annotations_;
   // Type declarations, constants, and global variable declarations.
-  std::vector<std::unique_ptr<Instruction>> types_values_;
+  InstructionList types_values_;
   std::vector<std::unique_ptr<Function>> functions_;
 };
 
 inline void Module::AddCapability(std::unique_ptr<Instruction> c) {
-  capabilities_.emplace_back(std::move(c));
+  capabilities_.push_back(std::move(c));
 }
 
 inline void Module::AddExtension(std::unique_ptr<Instruction> e) {
-  extensions_.emplace_back(std::move(e));
+  extensions_.push_back(std::move(e));
 }
 
 inline void Module::AddExtInstImport(std::unique_ptr<Instruction> e) {
-  ext_inst_imports_.emplace_back(std::move(e));
+  ext_inst_imports_.push_back(std::move(e));
 }
 
 inline void Module::SetMemoryModel(std::unique_ptr<Instruction> m) {
@@ -255,35 +261,35 @@ inline void Module::SetMemoryModel(std::unique_ptr<Instruction> m) {
 }
 
 inline void Module::AddEntryPoint(std::unique_ptr<Instruction> e) {
-  entry_points_.emplace_back(std::move(e));
+  entry_points_.push_back(std::move(e));
 }
 
 inline void Module::AddExecutionMode(std::unique_ptr<Instruction> e) {
-  execution_modes_.emplace_back(std::move(e));
+  execution_modes_.push_back(std::move(e));
 }
 
 inline void Module::AddDebug1Inst(std::unique_ptr<Instruction> d) {
-  debugs1_.emplace_back(std::move(d));
+  debugs1_.push_back(std::move(d));
 }
 
 inline void Module::AddDebug2Inst(std::unique_ptr<Instruction> d) {
-  debugs2_.emplace_back(std::move(d));
+  debugs2_.push_back(std::move(d));
 }
 
 inline void Module::AddDebug3Inst(std::unique_ptr<Instruction> d) {
-  debugs3_.emplace_back(std::move(d));
+  debugs3_.push_back(std::move(d));
 }
 
 inline void Module::AddAnnotationInst(std::unique_ptr<Instruction> a) {
-  annotations_.emplace_back(std::move(a));
+  annotations_.push_back(std::move(a));
 }
 
 inline void Module::AddType(std::unique_ptr<Instruction> t) {
-  types_values_.emplace_back(std::move(t));
+  types_values_.push_back(std::move(t));
 }
 
 inline void Module::AddGlobalValue(std::unique_ptr<Instruction> v) {
-  types_values_.emplace_back(std::move(v));
+  types_values_.push_back(std::move(v));
 }
 
 inline void Module::AddFunction(std::unique_ptr<Function> f) {
@@ -291,147 +297,137 @@ inline void Module::AddFunction(std::unique_ptr<Function> f) {
 }
 
 inline Module::inst_iterator Module::capability_begin() {
-  return inst_iterator(&capabilities_, capabilities_.begin());
+  return capabilities_.begin();
 }
 inline Module::inst_iterator Module::capability_end() {
-  return inst_iterator(&capabilities_, capabilities_.end());
+  return capabilities_.end();
 }
 
 inline IteratorRange<Module::inst_iterator> Module::capabilities() {
-  return make_range(capabilities_);
+  return make_range(capabilities_.begin(), capabilities_.end());
 }
 
 inline IteratorRange<Module::const_inst_iterator> Module::capabilities() const {
-  return make_const_range(capabilities_);
+  return make_range(capabilities_.begin(), capabilities_.end());
 }
 
 inline Module::inst_iterator Module::ext_inst_import_begin() {
-  return inst_iterator(&ext_inst_imports_, ext_inst_imports_.begin());
+  return ext_inst_imports_.begin();
 }
 inline Module::inst_iterator Module::ext_inst_import_end() {
-  return inst_iterator(&ext_inst_imports_, ext_inst_imports_.end());
+  return ext_inst_imports_.end();
 }
 
 inline IteratorRange<Module::inst_iterator> Module::ext_inst_imports() {
-  return make_range(ext_inst_imports_);
+  return make_range(ext_inst_imports_.begin(), ext_inst_imports_.end());
 }
 
-inline IteratorRange<Module::const_inst_iterator> Module::ext_inst_imports() const {
-  return make_const_range(ext_inst_imports_);
+inline IteratorRange<Module::const_inst_iterator> Module::ext_inst_imports()
+const {
+  return make_range(ext_inst_imports_.begin(), ext_inst_imports_.end());
 }
 
-inline Module::inst_iterator Module::debug1_begin() {
-  return inst_iterator(&debugs1_, debugs1_.begin());
-}
-inline Module::inst_iterator Module::debug1_end() {
-  return inst_iterator(&debugs1_, debugs1_.end());
-}
+inline Module::inst_iterator Module::debug1_begin() { return debugs1_.begin(); }
+inline Module::inst_iterator Module::debug1_end() { return debugs1_.end(); }
 
 inline IteratorRange<Module::inst_iterator> Module::debugs1() {
-  return make_range(debugs1_);
+  return make_range(debugs1_.begin(), debugs1_.end());
 }
 
 inline IteratorRange<Module::const_inst_iterator> Module::debugs1() const {
-  return make_const_range(debugs1_);
+  return make_range(debugs1_.begin(), debugs1_.end());
 }
 
-inline Module::inst_iterator Module::debug2_begin() {
-  return inst_iterator(&debugs2_, debugs2_.begin());
-}
-inline Module::inst_iterator Module::debug2_end() {
-  return inst_iterator(&debugs2_, debugs2_.end());
-}
+inline Module::inst_iterator Module::debug2_begin() { return debugs2_.begin(); }
+inline Module::inst_iterator Module::debug2_end() { return debugs2_.end(); }
 
 inline IteratorRange<Module::inst_iterator> Module::debugs2() {
-  return make_range(debugs2_);
+  return make_range(debugs2_.begin(), debugs2_.end());
 }
 
 inline IteratorRange<Module::const_inst_iterator> Module::debugs2() const {
-  return make_const_range(debugs2_);
+  return make_range(debugs2_.begin(), debugs2_.end());
 }
 
-inline Module::inst_iterator Module::debug3_begin() {
-  return inst_iterator(&debugs3_, debugs3_.begin());
-}
-inline Module::inst_iterator Module::debug3_end() {
-  return inst_iterator(&debugs3_, debugs3_.end());
-}
+inline Module::inst_iterator Module::debug3_begin() { return debugs3_.begin(); }
+inline Module::inst_iterator Module::debug3_end() { return debugs3_.end(); }
 
 inline IteratorRange<Module::inst_iterator> Module::debugs3() {
-  return make_range(debugs3_);
+  return make_range(debugs3_.begin(), debugs3_.end());
 }
 
 inline IteratorRange<Module::const_inst_iterator> Module::debugs3() const {
-  return make_const_range(debugs3_);
+  return make_range(debugs3_.begin(), debugs3_.end());
 }
 
 inline IteratorRange<Module::inst_iterator> Module::entry_points() {
-  return make_range(entry_points_);
+  return make_range(entry_points_.begin(), entry_points_.end());
 }
 
 inline IteratorRange<Module::const_inst_iterator> Module::entry_points() const {
-  return make_const_range(entry_points_);
+  return make_range(entry_points_.begin(), entry_points_.end());
 }
 
 inline Module::inst_iterator Module::execution_mode_begin() {
-  return inst_iterator(&execution_modes_, execution_modes_.begin());
+  return execution_modes_.begin();
 }
 inline Module::inst_iterator Module::execution_mode_end() {
-  return inst_iterator(&execution_modes_, execution_modes_.end());
+  return execution_modes_.end();
 }
 
 inline IteratorRange<Module::inst_iterator> Module::execution_modes() {
-  return make_range(execution_modes_);
+  return make_range(execution_modes_.begin(), execution_modes_.end());
 }
 
-inline IteratorRange<Module::const_inst_iterator> Module::execution_modes() const {
-  return make_const_range(execution_modes_);
+inline IteratorRange<Module::const_inst_iterator> Module::execution_modes()
+const {
+  return make_range(execution_modes_.begin(), execution_modes_.end());
 }
 
 inline Module::inst_iterator Module::annotation_begin() {
-  return inst_iterator(&annotations_, annotations_.begin());
+  return annotations_.begin();
 }
 inline Module::inst_iterator Module::annotation_end() {
-  return inst_iterator(&annotations_, annotations_.end());
+  return annotations_.end();
 }
 
 inline IteratorRange<Module::inst_iterator> Module::annotations() {
-  return make_range(annotations_);
+  return make_range(annotations_.begin(), annotations_.end());
 }
 
 inline IteratorRange<Module::const_inst_iterator> Module::annotations() const {
-  return make_const_range(annotations_);
+  return make_range(annotations_.begin(), annotations_.end());
 }
 
 inline Module::inst_iterator Module::extension_begin() {
-  return inst_iterator(&extensions_, extensions_.begin());
+  return extensions_.begin();
 }
 inline Module::inst_iterator Module::extension_end() {
-  return inst_iterator(&extensions_, extensions_.end());
+  return extensions_.end();
 }
 
 inline IteratorRange<Module::inst_iterator> Module::extensions() {
-  return make_range(extensions_);
+  return make_range(extensions_.begin(), extensions_.end());
 }
 
 inline IteratorRange<Module::const_inst_iterator> Module::extensions() const {
-  return make_const_range(extensions_);
+  return make_range(extensions_.begin(), extensions_.end());
 }
 
 inline Module::inst_iterator Module::types_values_begin() {
-  return inst_iterator(&types_values_, types_values_.begin());
+  return types_values_.begin();
 }
 
 inline Module::inst_iterator Module::types_values_end() {
-  return inst_iterator(&types_values_, types_values_.end());
+  return types_values_.end();
 }
 
 inline IteratorRange<Module::inst_iterator> Module::types_values() {
-  return make_range(types_values_);
+  return make_range(types_values_.begin(), types_values_.end());
 }
 
 inline IteratorRange<Module::const_inst_iterator> Module::types_values() const {
-  return make_const_range(types_values_);
+  return make_range(types_values_.begin(), types_values_.end());
 }
 
 inline Module::const_iterator Module::cbegin() const {

--- a/source/opt/remove_duplicates_pass.cpp
+++ b/source/opt/remove_duplicates_pass.cpp
@@ -96,7 +96,6 @@ bool RemoveDuplicatesPass::RemoveDuplicateTypes(
   bool modified = false;
 
   std::vector<Instruction> visitedTypes;
-  visitedTypes.reserve(module->types_values().size());
 
   for (auto i = module->types_values_begin();
        i != module->types_values_end();) {
@@ -142,7 +141,6 @@ bool RemoveDuplicatesPass::RemoveDuplicateDecorations(
     if (i.opcode() == SpvOpConstant) constants[i.result_id()] = &i;
 
   std::vector<const Instruction*> visitedDecorations;
-  visitedDecorations.reserve(module->annotations().size());
 
   opt::analysis::DecorationManager decorationManager(module);
   for (auto i = module->annotation_begin(); i != module->annotation_end();) {

--- a/source/util/ilist.h
+++ b/source/util/ilist.h
@@ -122,6 +122,17 @@ class IntrusiveList {
       return iterator(first_node);
     }
 
+    // Define standard iterator types needs so this class can be
+    // used with <algorithms>.
+    using iterator_category = std::bidirectional_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = T;
+    using pointer = T*;
+    using const_pointer = const T*;
+    using reference = T&;
+    using const_reference = const T&;
+    using size_type = size_t;
+
    protected:
     iterator_template() = delete;
     inline iterator_template(T* node) { node_ = node; }
@@ -159,6 +170,9 @@ class IntrusiveList {
 
   // Returns true if the list is empty.
   bool empty() const;
+
+  // Makes the current list empty.
+  inline void clear();
 
   // Returns references to the first or last element in the list.  It is an
   // error to call these functions on an empty list.
@@ -202,9 +216,7 @@ IntrusiveList<NodeType>::IntrusiveList(IntrusiveList&& list) : sentinel_() {
 
 template <class NodeType>
 IntrusiveList<NodeType>::~IntrusiveList() {
-  while (!empty()) {
-    front().RemoveFromList();
-  }
+  clear();
 }
 
 template <class NodeType>
@@ -258,6 +270,13 @@ void IntrusiveList<NodeType>::push_back(NodeType* node) {
 template <class NodeType>
 bool IntrusiveList<NodeType>::empty() const {
   return sentinel_.NextNode() == nullptr;
+}
+
+template<class NodeType>
+void IntrusiveList<NodeType>::clear() {
+  while (!empty()) {
+    front().RemoveFromList();
+  }
 }
 
 template <class NodeType>

--- a/test/opt/instruction_list_test.cpp
+++ b/test/opt/instruction_list_test.cpp
@@ -48,8 +48,8 @@ std::vector<TestInstruction*> TestInstruction::deleted_instructions_;
 // for every element that is in the list.
 TEST(InstructionListTest, Destructor) {
   InstructionList* list = new InstructionList();
-  list->push_back(new Instruction());
-  list->push_back(new Instruction());
+  list->push_back(std::unique_ptr<Instruction>(new Instruction()));
+  list->push_back(std::unique_ptr<Instruction>(new Instruction()));
   delete list;
 
   // Sorting because we do not care if the order of create and destruction is

--- a/test/util/ilist_test.cpp
+++ b/test/util/ilist_test.cpp
@@ -262,8 +262,9 @@ TEST(IListTest, MoveBefore1) {
   insertion_point.MoveBefore(&list2);
 
   std::vector<int> output;
-  for (auto i = list1.begin(); i != list1.end(); ++i)
+  for (auto i = list1.begin(); i != list1.end(); ++i) {
     output.push_back(i->data_);
+  }
 
   EXPECT_THAT(output, ElementsAre(0, 0, 1, 2, 1, 2, 3, 4, 5));
 }
@@ -278,8 +279,9 @@ TEST(IListTest, MoveBefore2) {
   insertion_point.MoveBefore(&list2);
 
   std::vector<int> output;
-  for (auto i = list1.begin(); i != list1.end(); ++i)
+  for (auto i = list1.begin(); i != list1.end(); ++i) {
     output.push_back(i->data_);
+  }
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 0, 1, 2, 3, 4, 5));
 }
@@ -294,8 +296,9 @@ TEST(IListTest, MoveBefore3) {
   insertion_point.MoveBefore(&list2);
 
   std::vector<int> output;
-  for (auto i = list1.begin(); i != list1.end(); ++i)
+  for (auto i = list1.begin(); i != list1.end(); ++i) {
     output.push_back(i->data_);
+  }
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 3, 4, 5, 0, 1, 2));
 }
@@ -310,8 +313,9 @@ TEST(IListTest, MoveBefore4) {
   insertion_point.MoveBefore(&list2);
 
   std::vector<int> output;
-  for (auto i = list1.begin(); i != list1.end(); ++i)
+  for (auto i = list1.begin(); i != list1.end(); ++i) {
     output.push_back(i->data_);
+  }
 
   EXPECT_THAT(output, ElementsAre(0, 1, 2, 3, 4, 5));
 }


### PR DESCRIPTION
This change will replace a number of the
std::vector<std::unique_ptr<Instruction>> member of the module to
InstructionList.  This is for consistency and to make it easier to
delete instructions that are no longer needed.