### PR TITLE
Fix: Preserve decorations of inlined functions.

### DIFF
--- a/source/opt/decoration_manager.cpp
+++ b/source/opt/decoration_manager.cpp
@@ -262,8 +262,7 @@ void DecorationManager::CloneDecorations(uint32_t from, uint32_t to,
       case SpvOpGroupDecorate:
         f(*inst, false);
         // add |to| to list of decorated id's
-        inst->AddOperand(std::move(
-          ir::Operand(spv_operand_type_t::SPV_OPERAND_TYPE_ID, {to})));
+        inst->AddOperand(ir::Operand(spv_operand_type_t::SPV_OPERAND_TYPE_ID, {to}));
         id_to_decoration_insts_[to].push_back(inst);
         f(*inst, true);
         break;
@@ -274,8 +273,7 @@ void DecorationManager::CloneDecorations(uint32_t from, uint32_t to,
         for (uint32_t i = 1; i < num_operands; i += 2) {
           ir::Operand op = inst->GetOperand(i);
           if (op.words[0] == from) { // add new pair of operands: (to, literal)
-            inst->AddOperand(std::move(
-            ir::Operand(spv_operand_type_t::SPV_OPERAND_TYPE_ID, {to})));
+            inst->AddOperand(ir::Operand(spv_operand_type_t::SPV_OPERAND_TYPE_ID, {to}));
             op = inst->GetOperand(i + 1);
             inst->AddOperand(std::move(op));
           }

--- a/source/opt/decoration_manager.cpp
+++ b/source/opt/decoration_manager.cpp
@@ -15,6 +15,7 @@
 #include "decoration_manager.h"
 
 #include <stack>
+#include <iostream>
 
 namespace spvtools {
 namespace opt {
@@ -289,8 +290,8 @@ void DecorationManager::CloneDecorations(uint32_t from, uint32_t to,
         std::unique_ptr<ir::Instruction> new_inst(inst->Clone());
         new_inst->SetInOperand(0, {to});
         id_to_decoration_insts_[to].push_back(new_inst.get());
-        module_->AddAnnotationInst(std::move(new_inst));
         f(*new_inst, true);
+        module_->AddAnnotationInst(std::move(new_inst));
         break;
       }
       default:

--- a/source/opt/decoration_manager.cpp
+++ b/source/opt/decoration_manager.cpp
@@ -233,7 +233,7 @@ std::vector<T> DecorationManager::InternalGetDecorationsFor(
 void DecorationManager::ForEachDecoration(uint32_t id,
                                           uint32_t decoration,
                                           std::function<void(const ir::Instruction&)> f) {
-  for (const ir::Instruction* inst : GetDecorationsFor(id, false)) {
+  for (const ir::Instruction* inst : GetDecorationsFor(id, true)) {
     switch (inst->opcode()) {
       case SpvOpDecorate:
         if (inst->GetSingleWordInOperand(1) == decoration) {

--- a/source/opt/decoration_manager.h
+++ b/source/opt/decoration_manager.h
@@ -55,7 +55,8 @@ class DecorationManager {
                              const ir::Instruction* inst2) const;
 
   // |f| is run on each decoration instruction for |id| with decoration
-  // |decoration|.
+  // |decoration|. Processed are all decorations which target |id| either
+  // directly or indirectly by Decoration Groups.
   void ForEachDecoration(uint32_t id, uint32_t decoration,
                          std::function<void(const ir::Instruction& f)>);
 

--- a/source/opt/decoration_manager.h
+++ b/source/opt/decoration_manager.h
@@ -62,7 +62,7 @@ class DecorationManager {
   // Clone all decorations from one id |from|.
   // The cloned decorations are assigned to the given id |to| and are
   // added to the module. The purpose is to decorate cloned instructions.
-  // This function does not check, if the id |to| is already decorated.
+  // This function does not check if the id |to| is already decorated.
   void CloneDecorations(uint32_t from, uint32_t to);
 
  private:

--- a/source/opt/decoration_manager.h
+++ b/source/opt/decoration_manager.h
@@ -30,7 +30,10 @@ namespace analysis {
 class DecorationManager {
  public:
   // Constructs a decoration manager from the given |module|
-  DecorationManager(ir::Module* module) { AnalyzeDecorations(module); }
+  DecorationManager(ir::Module* module) {
+    AnalyzeDecorations(module);
+    module_ = module;
+  }
   // Removes all decorations from |id|, which should not be a group ID, except
   // for linkage decorations if |keep_linkage| is set.
   void RemoveDecorationsFrom(uint32_t id, bool keep_linkage);
@@ -54,7 +57,13 @@ class DecorationManager {
   // |f| is run on each decoration instruction for |id| with decoration
   // |decoration|.
   void ForEachDecoration(uint32_t id, uint32_t decoration,
-                         std::function<void(const ir::Instruction& f)>) const;
+                         std::function<void(const ir::Instruction& f)>);
+
+  // Clone all decorations from one id |from|.
+  // The cloned decorations are assigned to the given id |to| and are
+  // added to the module. The purpose is to decorate cloned instructions.
+  // This function does not check, if the id |to| is already decorated.
+  void CloneDecorations(uint32_t from, uint32_t to);
 
  private:
   using IdToDecorationInstsMap =
@@ -74,6 +83,8 @@ class DecorationManager {
   IdToDecorationInstsMap id_to_decoration_insts_;
   // Mapping from group ids to all the decoration instructions they apply.
   IdToDecorationInstsMap group_to_decoration_insts_;
+
+  ir::Module* module_;
 };
 
 }  // namespace analysis

--- a/source/opt/decoration_manager.h
+++ b/source/opt/decoration_manager.h
@@ -58,13 +58,16 @@ class DecorationManager {
   // |decoration|. Processed are all decorations which target |id| either
   // directly or indirectly by Decoration Groups.
   void ForEachDecoration(uint32_t id, uint32_t decoration,
-                         std::function<void(const ir::Instruction& f)>);
+                         std::function<void(const ir::Instruction&)> f);
 
   // Clone all decorations from one id |from|.
   // The cloned decorations are assigned to the given id |to| and are
   // added to the module. The purpose is to decorate cloned instructions.
   // This function does not check if the id |to| is already decorated.
-  void CloneDecorations(uint32_t from, uint32_t to);
+  // Function |f| can be used to update context information and is called
+  // with |false|, before an instruction is going to be changed and
+  // with |true| afterwards.
+  void CloneDecorations(uint32_t from, uint32_t to, std::function<void(ir::Instruction&, bool)> f);
 
  private:
   using IdToDecorationInstsMap =

--- a/source/opt/decoration_manager.h
+++ b/source/opt/decoration_manager.h
@@ -30,10 +30,11 @@ namespace analysis {
 class DecorationManager {
  public:
   // Constructs a decoration manager from the given |module|
-  DecorationManager(ir::Module* module) {
-    AnalyzeDecorations(module);
-    module_ = module;
+  explicit DecorationManager(ir::Module* module) : module_(module) {
+    AnalyzeDecorations();
   }
+  DecorationManager() = delete;
+
   // Removes all decorations from |id|, which should not be a group ID, except
   // for linkage decorations if |keep_linkage| is set.
   void RemoveDecorationsFrom(uint32_t id, bool keep_linkage);
@@ -74,7 +75,7 @@ class DecorationManager {
       std::unordered_map<uint32_t, std::vector<ir::Instruction*>>;
   // Analyzes the defs and uses in the given |module| and populates data
   // structures in this class. Does nothing if |module| is nullptr.
-  void AnalyzeDecorations(ir::Module* module);
+  void AnalyzeDecorations();
 
   template <typename T>
   std::vector<T> InternalGetDecorationsFor(uint32_t id, bool include_linkage);
@@ -87,7 +88,7 @@ class DecorationManager {
   IdToDecorationInstsMap id_to_decoration_insts_;
   // Mapping from group ids to all the decoration instructions they apply.
   IdToDecorationInstsMap group_to_decoration_insts_;
-
+  // The enclosing module.
   ir::Module* module_;
 };
 

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -145,7 +145,7 @@ void InlinePass::CloneAndMapLocals(
   while (callee_var_itr->opcode() == SpvOp::SpvOpVariable) {
     std::unique_ptr<ir::Instruction> var_inst(callee_var_itr->Clone());
     uint32_t newId = TakeNextId();
-    dec_mgr_->CloneDecorations(callee_var_itr->result_id(), newId, UpdateDefUseMgr);
+    dec_mgr_->CloneDecorations(callee_var_itr->result_id(), newId, update_def_use_mgr_);
     var_inst->SetResultId(newId);
     (*callee2caller)[callee_var_itr->result_id()] = newId;
     new_vars->push_back(std::move(var_inst));
@@ -174,7 +174,7 @@ uint32_t InlinePass::CreateReturnVar(
           {SpvStorageClassFunction}}}));
     new_vars->push_back(std::move(var_inst));
   }
-  dec_mgr_->CloneDecorations(calleeFn->result_id(), returnVarId, UpdateDefUseMgr);
+  dec_mgr_->CloneDecorations(calleeFn->result_id(), returnVarId, update_def_use_mgr_);
   return returnVarId;
 }
 
@@ -199,7 +199,7 @@ void InlinePass::CloneSameBlockOps(
             CloneSameBlockOps(&sb_inst, postCallSB, preCallSB, block_ptr);
             const uint32_t rid = sb_inst->result_id();
             const uint32_t nid = this->TakeNextId();
-            dec_mgr_->CloneDecorations(rid, nid, UpdateDefUseMgr);
+            dec_mgr_->CloneDecorations(rid, nid, update_def_use_mgr_);
             sb_inst->SetResultId(nid);
             (*postCallSB)[rid] = nid;
             *iid = nid;
@@ -479,7 +479,7 @@ void InlinePass::GenInlineCode(
             callee2caller[rid] = nid;
           }
           cp_inst->SetResultId(nid);
-          dec_mgr_->CloneDecorations(rid, nid, UpdateDefUseMgr);
+          dec_mgr_->CloneDecorations(rid, nid, update_def_use_mgr_);
         }
         new_blk_ptr->AddInstruction(std::move(cp_inst));
       } break;
@@ -647,7 +647,7 @@ void InlinePass::InitializeInline(ir::IRContext* c) {
   InitializeProcessing(c);
 
   dec_mgr_.reset(new analysis::DecorationManager(c->module()));
-  UpdateDefUseMgr = [this] (ir::Instruction& inst, bool has_changed) {
+  update_def_use_mgr_ = [this] (ir::Instruction& inst, bool has_changed) {
     if (has_changed)
       get_def_use_mgr()->AnalyzeInstDefUse(&inst);
   };

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -145,7 +145,7 @@ void InlinePass::CloneAndMapLocals(
   while (callee_var_itr->opcode() == SpvOp::SpvOpVariable) {
     std::unique_ptr<ir::Instruction> var_inst(callee_var_itr->Clone());
     uint32_t newId = TakeNextId();
-    dec_mgr_->CloneDecorations(callee_var_itr->result_id(), newId);
+    dec_mgr_->CloneDecorations(callee_var_itr->result_id(), newId, UpdateDefUseMgr);
     var_inst->SetResultId(newId);
     (*callee2caller)[callee_var_itr->result_id()] = newId;
     new_vars->push_back(std::move(var_inst));
@@ -174,7 +174,7 @@ uint32_t InlinePass::CreateReturnVar(
           {SpvStorageClassFunction}}}));
     new_vars->push_back(std::move(var_inst));
   }
-  dec_mgr_->CloneDecorations(calleeFn->result_id(), returnVarId);
+  dec_mgr_->CloneDecorations(calleeFn->result_id(), returnVarId, UpdateDefUseMgr);
   return returnVarId;
 }
 
@@ -199,7 +199,7 @@ void InlinePass::CloneSameBlockOps(
             CloneSameBlockOps(&sb_inst, postCallSB, preCallSB, block_ptr);
             const uint32_t rid = sb_inst->result_id();
             const uint32_t nid = this->TakeNextId();
-            dec_mgr_->CloneDecorations(rid, nid);
+            dec_mgr_->CloneDecorations(rid, nid, UpdateDefUseMgr);
             sb_inst->SetResultId(nid);
             (*postCallSB)[rid] = nid;
             *iid = nid;
@@ -479,7 +479,7 @@ void InlinePass::GenInlineCode(
             callee2caller[rid] = nid;
           }
           cp_inst->SetResultId(nid);
-          dec_mgr_->CloneDecorations(rid, nid);
+          dec_mgr_->CloneDecorations(rid, nid, UpdateDefUseMgr);
         }
         new_blk_ptr->AddInstruction(std::move(cp_inst));
       } break;
@@ -647,6 +647,10 @@ void InlinePass::InitializeInline(ir::IRContext* c) {
   InitializeProcessing(c);
 
   dec_mgr_.reset(new analysis::DecorationManager(c->module()));
+  UpdateDefUseMgr = [this] (ir::Instruction& inst, bool has_changed) {
+    if (has_changed)
+      get_def_use_mgr()->AnalyzeInstDefUse(&inst);
+  };
 
   false_id_ = 0;
 

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -174,6 +174,7 @@ uint32_t InlinePass::CreateReturnVar(
           {SpvStorageClassFunction}}}));
     new_vars->push_back(std::move(var_inst));
   }
+  dec_mgr_->CloneDecorations(calleeFn->result_id(), returnVarId);
   return returnVarId;
 }
 
@@ -477,8 +478,8 @@ void InlinePass::GenInlineCode(
             nid = this->TakeNextId();
             callee2caller[rid] = nid;
           }
-          dec_mgr_->CloneDecorations(rid, nid);
           cp_inst->SetResultId(nid);
+          dec_mgr_->CloneDecorations(rid, nid);
         }
         new_blk_ptr->AddInstruction(std::move(cp_inst));
       } break;

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -162,7 +162,10 @@ class InlinePass : public Pass {
   // Initialize state for optimization of |module|
   void InitializeInline(ir::IRContext* c);
 
-  // Decorations for the module we are processing. TODO: move this to ir_context as well
+  // Update the DefUseManager when cloning decorations.
+  std::function<void(ir::Instruction&, bool)> UpdateDefUseMgr;
+
+  // Decorations for the module we are processing TODO: move this to ir_context as well
   std::unique_ptr<analysis::DecorationManager> dec_mgr_;
 
   // Map from function's result id to function.

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "def_use_manager.h"
+#include "decoration_manager.h"
 #include "module.h"
 #include "pass.h"
 
@@ -160,6 +161,9 @@ class InlinePass : public Pass {
 
   // Initialize state for optimization of |module|
   void InitializeInline(ir::IRContext* c);
+
+  // Decorations for the module we are processing. TODO: move this to ir_context as well
+  std::unique_ptr<analysis::DecorationManager> dec_mgr_;
 
   // Map from function's result id to function.
   std::unordered_map<uint32_t, ir::Function*> id2function_;

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -163,7 +163,7 @@ class InlinePass : public Pass {
   void InitializeInline(ir::IRContext* c);
 
   // Update the DefUseManager when cloning decorations.
-  std::function<void(ir::Instruction&, bool)> UpdateDefUseMgr;
+  std::function<void(ir::Instruction&, bool)> update_def_use_mgr_;
 
   // Decorations for the module we are processing TODO: move this to ir_context as well
   std::unique_ptr<analysis::DecorationManager> dec_mgr_;

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -163,10 +163,6 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   }
   // Gets the |index|-th logical operand.
   inline const Operand& GetOperand(uint32_t index) const;
-  // Adds |operand| to the list of operands of this instruction.
-  // It is the responsibility of the caller to make sure
-  // that the instruction remains valid.
-  inline void AddOperand(Operand operand);
   // Gets the |index|-th logical operand as a single SPIR-V word. This method is
   // not expected to be used with logical operands consisting of multiple SPIR-V
   // words.
@@ -260,11 +256,6 @@ inline const Operand& Instruction::GetOperand(uint32_t index) const {
   assert(index < operands_.size() && "operand index out of bound");
   return operands_[index];
 };
-
-inline void Instruction::AddOperand(Operand operand) {
-  operands_.push_back(operand);
-  return;
-}
 
 inline void Instruction::SetInOperand(uint32_t index,
                                       std::vector<uint32_t>&& data) {

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -163,6 +163,10 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   }
   // Gets the |index|-th logical operand.
   inline const Operand& GetOperand(uint32_t index) const;
+  // Adds |operand| to the list of operands of this instruction.
+  // It is the responsibility of the caller to make sure
+  // that the instruction remains valid.
+  inline void AddOperand(Operand operand);
   // Gets the |index|-th logical operand as a single SPIR-V word. This method is
   // not expected to be used with logical operands consisting of multiple SPIR-V
   // words.
@@ -256,6 +260,11 @@ inline const Operand& Instruction::GetOperand(uint32_t index) const {
   assert(index < operands_.size() && "operand index out of bound");
   return operands_[index];
 };
+
+inline void Instruction::AddOperand(Operand operand) {
+  operands_.push_back(operand);
+  return;
+}
 
 inline void Instruction::SetInOperand(uint32_t index,
                                       std::vector<uint32_t>&& data) {

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -166,7 +166,7 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   // Adds |operand| to the list of operands of this instruction.
   // It is the responsibility of the caller to make sure
   // that the instruction remains valid.
-  inline void AddOperand(Operand operand);
+  inline void AddOperand(Operand &&operand);
   // Gets the |index|-th logical operand as a single SPIR-V word. This method is
   // not expected to be used with logical operands consisting of multiple SPIR-V
   // words.
@@ -261,7 +261,7 @@ inline const Operand& Instruction::GetOperand(uint32_t index) const {
   return operands_[index];
 };
 
-inline void Instruction::AddOperand(Operand operand) {
+inline void Instruction::AddOperand(Operand &&operand) {
   operands_.push_back(operand);
   return;
 }


### PR DESCRIPTION
Fixes issue #728.
(More test cases e.g. with group decorations are desirable.)
+small bugfix in ForEachDecoration()

