### PR TITLE
Add option to relax validation of store types.

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -425,10 +425,10 @@ void spvValidatorOptionsSetUniversalLimit(spv_validator_options options,
 // the types are structs with the same layout.  Two structs have the same layout
 // if
 //
-// 1) The members of the struct are either the same type or are structs with
-// same layout.
+// 1) the members of the structs are either the same type or are structs with
+// same layout, and
 //
-// 2) The decorations that affect the memory layout are identical for both
+// 2) the decorations that affect the memory layout are identical for both
 // types.  Other decorations are not relevant.
 void spvValidatorOptionsSetRelaxStoreStruct(spv_validator_options options,
                                             bool val);

--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -421,9 +421,15 @@ void spvValidatorOptionsSetUniversalLimit(spv_validator_options options,
                                           uint32_t limit);
 
 // Record whether or not the validator should relax the rules on types for
-// stores to structs.  When relaxed, it will allows a type mismatch between the
-// value being stored and the variable being stored to as long as the types are
-// defined the same.
+// stores to structs.  When relaxed, it will allow a type mismatch as long as
+// the types are structs with the same layout.  Two structs have the same layout
+// if
+//
+// 1) The members of the struct are either the same type or are structs with
+// same layout.
+//
+// 2) The decorations that affect the memory layout are identical for both
+// types.  Other decorations are not relevant.
 void spvValidatorOptionsSetRelaxStoreStruct(spv_validator_options options,
                                             bool val);
 

--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -420,6 +420,13 @@ void spvValidatorOptionsSetUniversalLimit(spv_validator_options options,
                                           spv_validator_limit limit_type,
                                           uint32_t limit);
 
+// Record whether or not the validator should relax the rules on types for
+// stores to structs.  When relaxed, it will allows a type mismatch between the
+// value being stored and the variable being stored to as long as the types are
+// defined the same.
+void spvValidatorOptionsSetRelaxStoreStruct(spv_validator_options options,
+                                            bool val);
+
 // Encodes the given SPIR-V assembly text to its binary representation. The
 // length parameter specifies the number of bytes for text. Encoded binary will
 // be stored into *binary. Any error will be written into *diagnostic if
@@ -432,9 +439,11 @@ spv_result_t spvTextToBinary(const spv_const_context context, const char* text,
 // Encodes the given SPIR-V assembly text to its binary representation. Same as
 // spvTextToBinary but with options. The options parameter is a bit field of
 // spv_text_to_binary_options_t.
-spv_result_t spvTextToBinaryWithOptions(
-    const spv_const_context context, const char* text, const size_t length,
-    const uint32_t options, spv_binary* binary, spv_diagnostic* diagnostic);
+spv_result_t spvTextToBinaryWithOptions(const spv_const_context context,
+                                        const char* text, const size_t length,
+                                        const uint32_t options,
+                                        spv_binary* binary,
+                                        spv_diagnostic* diagnostic);
 
 // Frees an allocated text stream. This is a no-op if the text parameter
 // is a null pointer.

--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -44,6 +44,10 @@ class ValidatorOptions {
     spvValidatorOptionsSetUniversalLimit(options_, limit_type, limit);
   }
 
+  void SetRelaxStructStore(bool val) {
+    spvValidatorOptionsSetRelaxStoreStruct(options_, val);
+  }
+
  private:
   spv_validator_options options_;
 };

--- a/source/spirv_validator_options.cpp
+++ b/source/spirv_validator_options.cpp
@@ -58,20 +58,26 @@ void spvValidatorOptionsSetUniversalLimit(spv_validator_options options,
                                           spv_validator_limit limit_type,
                                           uint32_t limit) {
   assert(options && "Validator options object may not be Null");
-  switch(limit_type) {
+  switch (limit_type) {
 #define LIMIT(TYPE, FIELD)                    \
-    case TYPE:                                \
-      options->universal_limits_.FIELD = limit; \
-      break;
-  LIMIT(spv_validator_limit_max_struct_members, max_struct_members)
-  LIMIT(spv_validator_limit_max_struct_depth, max_struct_depth)
-  LIMIT(spv_validator_limit_max_local_variables, max_local_variables)
-  LIMIT(spv_validator_limit_max_global_variables, max_global_variables)
-  LIMIT(spv_validator_limit_max_switch_branches, max_switch_branches)
-  LIMIT(spv_validator_limit_max_function_args, max_function_args)
-  LIMIT(spv_validator_limit_max_control_flow_nesting_depth,
-        max_control_flow_nesting_depth)
-  LIMIT(spv_validator_limit_max_access_chain_indexes, max_access_chain_indexes)
+  case TYPE:                                  \
+    options->universal_limits_.FIELD = limit; \
+    break;
+    LIMIT(spv_validator_limit_max_struct_members, max_struct_members)
+    LIMIT(spv_validator_limit_max_struct_depth, max_struct_depth)
+    LIMIT(spv_validator_limit_max_local_variables, max_local_variables)
+    LIMIT(spv_validator_limit_max_global_variables, max_global_variables)
+    LIMIT(spv_validator_limit_max_switch_branches, max_switch_branches)
+    LIMIT(spv_validator_limit_max_function_args, max_function_args)
+    LIMIT(spv_validator_limit_max_control_flow_nesting_depth,
+          max_control_flow_nesting_depth)
+    LIMIT(spv_validator_limit_max_access_chain_indexes,
+          max_access_chain_indexes)
 #undef LIMIT
   }
+}
+
+void spvValidatorOptionsSetRelaxStoreStruct(spv_validator_options options,
+                                            bool val) {
+  options->relax_struct_store = val;
 }

--- a/source/spirv_validator_options.h
+++ b/source/spirv_validator_options.h
@@ -38,10 +38,10 @@ struct validator_universal_limits_t {
 // members may be added for any new option.
 struct spv_validator_options_t {
   spv_validator_options_t()
-      : universal_limits_() {}
+      : universal_limits_(), relax_struct_store(false) {}
 
   validator_universal_limits_t universal_limits_;
-  bool relax_struct_store{false};
+  bool relax_struct_store;
 };
 
 #endif  // LIBSPIRV_SPIRV_VALIDATOR_OPTIONS_H_

--- a/source/spirv_validator_options.h
+++ b/source/spirv_validator_options.h
@@ -41,6 +41,7 @@ struct spv_validator_options_t {
       : universal_limits_() {}
 
   validator_universal_limits_t universal_limits_;
+  bool relax_struct_store{false};
 };
 
 #endif  // LIBSPIRV_SPIRV_VALIDATOR_OPTIONS_H_

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -260,6 +260,9 @@ class ValidationState_t {
   std::vector<Decoration>& id_decorations(uint32_t id) {
     return id_decorations_[id];
   }
+  const std::vector<Decoration>& id_decorations(uint32_t id) const {
+    return id_decorations_.at(id);
+  }
 
   /// Finds id's def, if it exists.  If found, returns the definition otherwise
   /// nullptr

--- a/source/validate_id.cpp
+++ b/source/validate_id.cpp
@@ -207,8 +207,8 @@ bool idUsage::isValid<SpvOpGroupDecorate>(const spv_instruction_t* inst,
   auto decorationGroup = module_.FindDef(inst->words[decorationGroupIndex]);
   if (!decorationGroup || SpvOpDecorationGroup != decorationGroup->opcode()) {
     DIAG(decorationGroupIndex)
-        << "OpGroupDecorate Decoration group <id> '"
-        << inst->words[decorationGroupIndex] << "' is not a decoration group.";
+    << "OpGroupDecorate Decoration group <id> '"
+    << inst->words[decorationGroupIndex] << "' is not a decoration group.";
     return false;
   }
   return true;
@@ -275,8 +275,8 @@ bool idUsage::isValid<SpvOpEntryPoint>(const spv_instruction_t* inst,
     auto entryPointType = module_.FindDef(entryPoint->words()[4]);
     if (!entryPointType || 3 != entryPointType->words().size()) {
       DIAG(entryPointIndex)
-          << "OpEntryPoint Entry Point <id> '" << inst->words[entryPointIndex]
-          << "'s function parameter count is not zero.";
+      << "OpEntryPoint Entry Point <id> '" << inst->words[entryPointIndex]
+      << "'s function parameter count is not zero.";
       return false;
     }
   }
@@ -436,8 +436,8 @@ bool idUsage::isValid<SpvOpTypeStruct>(const spv_instruction_t* inst,
     auto memberType = module_.FindDef(memberTypeId);
     if (!memberType || !spvOpcodeGeneratesType(memberType->opcode())) {
       DIAG(memberTypeIndex)
-          << "OpTypeStruct Member Type <id> '" << inst->words[memberTypeIndex]
-          << "' is not a type.";
+      << "OpTypeStruct Member Type <id> '" << inst->words[memberTypeIndex]
+      << "' is not a type.";
       return false;
     }
     if (SpvOpTypeStruct == memberType->opcode() &&
@@ -617,10 +617,10 @@ bool idUsage::isValid<SpvOpConstantComposite>(const spv_instruction_t* inst,
         if (!constituentResultType ||
             componentType->opcode() != constituentResultType->opcode()) {
           DIAG(constituentIndex)
-              << "OpConstantComposite Constituent <id> '"
-              << inst->words[constituentIndex]
-              << "'s type does not match Result Type <id> '" << resultType->id()
-              << "'s vector element type.";
+          << "OpConstantComposite Constituent <id> '"
+          << inst->words[constituentIndex]
+          << "'s type does not match Result Type <id> '" << resultType->id()
+          << "'s vector element type.";
           return false;
         }
       }
@@ -646,7 +646,7 @@ bool idUsage::isValid<SpvOpConstantComposite>(const spv_instruction_t* inst,
            constituentIndex++) {
         auto constituent = module_.FindDef(inst->words[constituentIndex]);
         if (!constituent || !(SpvOpConstantComposite == constituent->opcode() ||
-                              SpvOpUndef == constituent->opcode())) {
+            SpvOpUndef == constituent->opcode())) {
           // The message says "... or undef" because the spec does not say
           // undef is a constant.
           DIAG(constituentIndex) << "OpConstantComposite Constituent <id> '"
@@ -658,10 +658,10 @@ bool idUsage::isValid<SpvOpConstantComposite>(const spv_instruction_t* inst,
         assert(vector);
         if (columnType->opcode() != vector->opcode()) {
           DIAG(constituentIndex)
-              << "OpConstantComposite Constituent <id> '"
-              << inst->words[constituentIndex]
-              << "' type does not match Result Type <id> '" << resultType->id()
-              << "'s matrix column type.";
+          << "OpConstantComposite Constituent <id> '"
+          << inst->words[constituentIndex]
+          << "' type does not match Result Type <id> '" << resultType->id()
+          << "'s matrix column type.";
           return false;
         }
         auto vectorComponentType = module_.FindDef(vector->words()[2]);
@@ -710,10 +710,10 @@ bool idUsage::isValid<SpvOpConstantComposite>(const spv_instruction_t* inst,
         assert(constituentType);
         if (elementType->id() != constituentType->id()) {
           DIAG(constituentIndex)
-              << "OpConstantComposite Constituent <id> '"
-              << inst->words[constituentIndex]
-              << "'s type does not match Result Type <id> '" << resultType->id()
-              << "'s array element type.";
+          << "OpConstantComposite Constituent <id> '"
+          << inst->words[constituentIndex]
+          << "'s type does not match Result Type <id> '" << resultType->id()
+          << "'s array element type.";
           return false;
         }
       }
@@ -871,13 +871,13 @@ bool idUsage::isValid<SpvOpSampledImage>(const spv_instruction_t* inst,
       auto consumer_opcode = consumer_instr->opcode();
       if (consumer_instr->block() != sampledImageInstr->block()) {
         DIAG(resultTypeIndex)
-            << "All OpSampledImage instructions must be in the same block in "
+        << "All OpSampledImage instructions must be in the same block in "
                "which their Result <id> are consumed. OpSampledImage Result "
                "Type <id> '"
-            << resultID
-            << "' has a consumer in a different basic "
-               "block. The consumer instruction <id> is '"
-            << consumer_id << "'.";
+        << resultID
+        << "' has a consumer in a different basic "
+            "block. The consumer instruction <id> is '"
+        << consumer_id << "'.";
         return false;
       }
       // TODO: The following check is incomplete. We should also check that the
@@ -945,10 +945,10 @@ bool idUsage::isValid<SpvOpSpecConstantComposite>(const spv_instruction_t* inst,
         if (!constituentResultType ||
             componentType->opcode() != constituentResultType->opcode()) {
           DIAG(constituentIndex)
-              << "OpSpecConstantComposite Constituent <id> '"
-              << inst->words[constituentIndex]
-              << "'s type does not match Result Type <id> '" << resultType->id()
-              << "'s vector element type.";
+          << "OpSpecConstantComposite Constituent <id> '"
+          << inst->words[constituentIndex]
+          << "'s type does not match Result Type <id> '" << resultType->id()
+          << "'s vector element type.";
           return false;
         }
       }
@@ -975,8 +975,8 @@ bool idUsage::isValid<SpvOpSpecConstantComposite>(const spv_instruction_t* inst,
         auto constituent = module_.FindDef(inst->words[constituentIndex]);
         auto constituentOpCode = constituent->opcode();
         if (!constituent || !(SpvOpSpecConstantComposite == constituentOpCode ||
-                              SpvOpConstantComposite == constituentOpCode ||
-                              SpvOpUndef == constituentOpCode)) {
+            SpvOpConstantComposite == constituentOpCode ||
+            SpvOpUndef == constituentOpCode)) {
           // The message says "... or undef" because the spec does not say
           // undef is a constant.
           DIAG(constituentIndex) << "OpSpecConstantComposite Constituent <id> '"
@@ -988,10 +988,10 @@ bool idUsage::isValid<SpvOpSpecConstantComposite>(const spv_instruction_t* inst,
         assert(vector);
         if (columnType->opcode() != vector->opcode()) {
           DIAG(constituentIndex)
-              << "OpSpecConstantComposite Constituent <id> '"
-              << inst->words[constituentIndex]
-              << "' type does not match Result Type <id> '" << resultType->id()
-              << "'s matrix column type.";
+          << "OpSpecConstantComposite Constituent <id> '"
+          << inst->words[constituentIndex]
+          << "' type does not match Result Type <id> '" << resultType->id()
+          << "'s matrix column type.";
           return false;
         }
         auto vectorComponentType = module_.FindDef(vector->words()[2]);
@@ -1041,10 +1041,10 @@ bool idUsage::isValid<SpvOpSpecConstantComposite>(const spv_instruction_t* inst,
         assert(constituentType);
         if (elementType->id() != constituentType->id()) {
           DIAG(constituentIndex)
-              << "OpSpecConstantComposite Constituent <id> '"
-              << inst->words[constituentIndex]
-              << "'s type does not match Result Type <id> '" << resultType->id()
-              << "'s array element type.";
+          << "OpSpecConstantComposite Constituent <id> '"
+          << inst->words[constituentIndex]
+          << "'s type does not match Result Type <id> '" << resultType->id()
+          << "'s array element type.";
           return false;
         }
       }
@@ -1118,8 +1118,8 @@ bool idUsage::isValid<SpvOpVariable>(const spv_instruction_t* inst,
         initialiser && spvOpcodeIsConstant(initialiser->opcode());
     if (!initialiser || !(is_constant || is_module_scope_var)) {
       DIAG(initialiserIndex)
-          << "OpVariable Initializer <id> '" << inst->words[initialiserIndex]
-          << "' is not a constant or module-scope variable.";
+      << "OpVariable Initializer <id> '" << inst->words[initialiserIndex]
+      << "' is not a constant or module-scope variable.";
       return false;
     }
   }
@@ -1218,9 +1218,9 @@ bool idUsage::isValid<SpvOpStore>(const spv_instruction_t* inst,
   }
 
   if (type->id() != objectType->id()) {
-    if (!module_.options()->relax_struct_store ||
-        type->opcode() != SpvOpTypeStruct ||
-        objectType->opcode() != SpvOpTypeStruct) {
+    if (!module_.options()->relax_struct_store
+        || type->opcode() != SpvOpTypeStruct
+        || objectType->opcode() != SpvOpTypeStruct) {
       DIAG(pointerIndex) << "OpStore Pointer <id> '"
                          << inst->words[pointerIndex]
                          << "'s type does not match Object <id> '"
@@ -1454,7 +1454,7 @@ bool idUsage::isValid<SpvOpAccessChain>(const spv_instruction_t* inst,
         // Give an error. reached non-composite type while indexes still remain.
         DIAG(i) << instr_name
                 << " reached non-composite type while indexes "
-                   "still remain to be traversed.";
+                    "still remain to be traversed.";
         return false;
       }
     }
@@ -1530,8 +1530,8 @@ bool idUsage::isValid<SpvOpFunction>(const spv_instruction_t* inst,
   auto functionType = module_.FindDef(inst->words[functionTypeIndex]);
   if (!functionType || SpvOpTypeFunction != functionType->opcode()) {
     DIAG(functionTypeIndex)
-        << "OpFunction Function Type <id> '" << inst->words[functionTypeIndex]
-        << "' is not a function type.";
+    << "OpFunction Function Type <id> '" << inst->words[functionTypeIndex]
+    << "' is not a function type.";
     return false;
   }
   auto returnType = module_.FindDef(functionType->words()[2]);
@@ -1714,7 +1714,7 @@ bool walkCompositeTypeHierarchy(
         // Give an error. reached non-composite type while indexes still remain.
         *error << instr_name()
                << " reached non-composite type while indexes "
-                  "still remain to be traversed.";
+                   "still remain to be traversed.";
         return false;
       }
     }
@@ -1839,13 +1839,13 @@ bool idUsage::isValid<SpvOpCompositeInsert>(const spv_instruction_t* inst,
   auto objectTypeInstr = module_.FindDef(objectInstr->type_id());
   if (indexedTypeInstr->id() != objectTypeInstr->id()) {
     DIAG(objectIdIndex)
-        << "The Object type (Op"
-        << spvOpcodeString(static_cast<SpvOp>(objectTypeInstr->opcode()))
-        << ") in " << instr_name()
-        << " does not match the type that results "
-           "from indexing into the Composite (Op"
-        << spvOpcodeString(static_cast<SpvOp>(indexedTypeInstr->opcode()))
-        << ").";
+    << "The Object type (Op"
+    << spvOpcodeString(static_cast<SpvOp>(objectTypeInstr->opcode()))
+    << ") in " << instr_name()
+    << " does not match the type that results "
+        "from indexing into the Composite (Op"
+    << spvOpcodeString(static_cast<SpvOp>(indexedTypeInstr->opcode()))
+    << ").";
     return false;
   }
 
@@ -2573,9 +2573,9 @@ bool idUsage::HaveLayoutCompatibleMembers(const libspirv::Instruction* type1,
 bool idUsage::HaveSameLayoutDecorations(const libspirv::Instruction* type1,
                                         const libspirv::Instruction* type2) {
   assert(type1->opcode() == SpvOpTypeStruct &&
-         "type1 must be and OpTypeStruct instruction.");
+      "type1 must be and OpTypeStruct instruction.");
   assert(type2->opcode() == SpvOpTypeStruct &&
-         "type2 must be and OpTypeStruct instruction.");
+      "type2 must be and OpTypeStruct instruction.");
   const std::vector<Decoration>& type1_decorations =
       module_.id_decorations(type1->id());
   const std::vector<Decoration>& type2_decorations =
@@ -2589,6 +2589,7 @@ bool idUsage::HaveSameLayoutDecorations(const libspirv::Instruction* type1,
 
   return true;
 }
+
 bool idUsage::HasConflictingMemberOffsets(
     const vector<Decoration>& type1_decorations,
     const vector<Decoration>& type2_decorations) const {
@@ -2764,8 +2765,8 @@ spv_result_t IdPass(ValidationState_t& _,
           ret = _.ForwardDeclareId(operand_word);
         } else {
           ret = _.diag(SPV_ERROR_INVALID_ID)
-                << "ID " << _.getIdName(operand_word)
-                << " has not been defined";
+              << "ID " << _.getIdName(operand_word)
+              << " has not been defined";
         }
         break;
       default:

--- a/source/validate_id.cpp
+++ b/source/validate_id.cpp
@@ -27,13 +27,13 @@
 #include "message.h"
 #include "opcode.h"
 #include "operand.h"
-#include "spirv_validator_options.h"
 #include "spirv-tools/libspirv.h"
+#include "spirv_validator_options.h"
 #include "val/function.h"
 #include "val/validation_state.h"
 
-using libspirv::ValidationState_t;
 using libspirv::Decoration;
+using libspirv::ValidationState_t;
 using std::function;
 using std::ignore;
 using std::make_pair;
@@ -82,6 +82,23 @@ class idUsage {
   const spvtools::MessageConsumer& consumer_;
   const ValidationState_t& module_;
   vector<uint32_t> entry_points_;
+
+  // Returns true if the two instructions represent structs that, as far as the
+  // validator can tell, have the exact same data layout.
+  bool AreInterchangeableSructs(const libspirv::Instruction* type1,
+                                const libspirv::Instruction* type2);
+
+  // Returns true if the operands to the OpTypeStruct instruction defining  the
+  // types are the same or are interchangeable types. |type1| and |type2| must
+  // be OpTypeStruct instructions.
+  bool HaveSameOpTypeStruct(const libspirv::Instruction* type1,
+                            const libspirv::Instruction* type2);
+
+  // Returns true if all decorations that effect the data layout of the struct
+  // (like Offset), are the same for the two types. |type1| and |type2| must be
+  // OpTypeStruct instructions.
+  bool HaveSameLayoutDecorations(const libspirv::Instruction* type1,
+                                 const libspirv::Instruction* type2);
 };
 
 #define DIAG(INDEX)                                                \
@@ -186,17 +203,17 @@ bool idUsage::isValid<SpvOpGroupDecorate>(const spv_instruction_t* inst,
   auto decorationGroupIndex = 1;
   auto decorationGroup = module_.FindDef(inst->words[decorationGroupIndex]);
   if (!decorationGroup || SpvOpDecorationGroup != decorationGroup->opcode()) {
-    DIAG(decorationGroupIndex) << "OpGroupDecorate Decoration group <id> '"
-                               << inst->words[decorationGroupIndex]
-                               << "' is not a decoration group.";
+    DIAG(decorationGroupIndex)
+    << "OpGroupDecorate Decoration group <id> '"
+    << inst->words[decorationGroupIndex] << "' is not a decoration group.";
     return false;
   }
   return true;
 }
 
 template <>
-bool idUsage::isValid<SpvOpGroupMemberDecorate>(
-    const spv_instruction_t* inst, const spv_opcode_desc) {
+bool idUsage::isValid<SpvOpGroupMemberDecorate>(const spv_instruction_t* inst,
+                                                const spv_opcode_desc) {
   auto decorationGroupIndex = 1;
   auto decorationGroup = module_.FindDef(inst->words[decorationGroupIndex]);
   if (!decorationGroup || SpvOpDecorationGroup != decorationGroup->opcode()) {
@@ -254,9 +271,9 @@ bool idUsage::isValid<SpvOpEntryPoint>(const spv_instruction_t* inst,
     // to change
     auto entryPointType = module_.FindDef(entryPoint->words()[4]);
     if (!entryPointType || 3 != entryPointType->words().size()) {
-      DIAG(entryPointIndex) << "OpEntryPoint Entry Point <id> '"
-                            << inst->words[entryPointIndex]
-                            << "'s function parameter count is not zero.";
+      DIAG(entryPointIndex)
+      << "OpEntryPoint Entry Point <id> '" << inst->words[entryPointIndex]
+      << "'s function parameter count is not zero.";
       return false;
     }
   }
@@ -415,9 +432,9 @@ bool idUsage::isValid<SpvOpTypeStruct>(const spv_instruction_t* inst,
     auto memberTypeId = inst->words[memberTypeIndex];
     auto memberType = module_.FindDef(memberTypeId);
     if (!memberType || !spvOpcodeGeneratesType(memberType->opcode())) {
-      DIAG(memberTypeIndex) << "OpTypeStruct Member Type <id> '"
-                            << inst->words[memberTypeIndex]
-                            << "' is not a type.";
+      DIAG(memberTypeIndex)
+      << "OpTypeStruct Member Type <id> '" << inst->words[memberTypeIndex]
+      << "' is not a type.";
       return false;
     }
     if (SpvOpTypeStruct == memberType->opcode() &&
@@ -596,11 +613,11 @@ bool idUsage::isValid<SpvOpConstantComposite>(const spv_instruction_t* inst,
         auto constituentResultType = module_.FindDef(constituent->type_id());
         if (!constituentResultType ||
             componentType->opcode() != constituentResultType->opcode()) {
-          DIAG(constituentIndex) << "OpConstantComposite Constituent <id> '"
-                                 << inst->words[constituentIndex]
-                                 << "'s type does not match Result Type <id> '"
-                                 << resultType->id()
-                                 << "'s vector element type.";
+          DIAG(constituentIndex)
+          << "OpConstantComposite Constituent <id> '"
+          << inst->words[constituentIndex]
+          << "'s type does not match Result Type <id> '" << resultType->id()
+          << "'s vector element type.";
           return false;
         }
       }
@@ -625,9 +642,8 @@ bool idUsage::isValid<SpvOpConstantComposite>(const spv_instruction_t* inst,
       for (size_t constituentIndex = 3; constituentIndex < inst->words.size();
            constituentIndex++) {
         auto constituent = module_.FindDef(inst->words[constituentIndex]);
-        if (!constituent ||
-            !(SpvOpConstantComposite == constituent->opcode() ||
-              SpvOpUndef == constituent->opcode())) {
+        if (!constituent || !(SpvOpConstantComposite == constituent->opcode() ||
+            SpvOpUndef == constituent->opcode())) {
           // The message says "... or undef" because the spec does not say
           // undef is a constant.
           DIAG(constituentIndex) << "OpConstantComposite Constituent <id> '"
@@ -638,11 +654,11 @@ bool idUsage::isValid<SpvOpConstantComposite>(const spv_instruction_t* inst,
         auto vector = module_.FindDef(constituent->type_id());
         assert(vector);
         if (columnType->opcode() != vector->opcode()) {
-          DIAG(constituentIndex) << "OpConstantComposite Constituent <id> '"
-                                 << inst->words[constituentIndex]
-                                 << "' type does not match Result Type <id> '"
-                                 << resultType->id()
-                                 << "'s matrix column type.";
+          DIAG(constituentIndex)
+          << "OpConstantComposite Constituent <id> '"
+          << inst->words[constituentIndex]
+          << "' type does not match Result Type <id> '" << resultType->id()
+          << "'s matrix column type.";
           return false;
         }
         auto vectorComponentType = module_.FindDef(vector->words()[2]);
@@ -690,11 +706,11 @@ bool idUsage::isValid<SpvOpConstantComposite>(const spv_instruction_t* inst,
         auto constituentType = module_.FindDef(constituent->type_id());
         assert(constituentType);
         if (elementType->id() != constituentType->id()) {
-          DIAG(constituentIndex) << "OpConstantComposite Constituent <id> '"
-                                 << inst->words[constituentIndex]
-                                 << "'s type does not match Result Type <id> '"
-                                 << resultType->id()
-                                 << "'s array element type.";
+          DIAG(constituentIndex)
+          << "OpConstantComposite Constituent <id> '"
+          << inst->words[constituentIndex]
+          << "'s type does not match Result Type <id> '" << resultType->id()
+          << "'s array element type.";
           return false;
         }
       }
@@ -852,12 +868,13 @@ bool idUsage::isValid<SpvOpSampledImage>(const spv_instruction_t* inst,
       auto consumer_opcode = consumer_instr->opcode();
       if (consumer_instr->block() != sampledImageInstr->block()) {
         DIAG(resultTypeIndex)
-            << "All OpSampledImage instructions must be in the same block in "
+        << "All OpSampledImage instructions must be in the same block in "
                "which their Result <id> are consumed. OpSampledImage Result "
                "Type <id> '"
-            << resultID << "' has a consumer in a different basic "
-                           "block. The consumer instruction <id> is '"
-            << consumer_id << "'.";
+        << resultID
+        << "' has a consumer in a different basic "
+            "block. The consumer instruction <id> is '"
+        << consumer_id << "'.";
         return false;
       }
       // TODO: The following check is incomplete. We should also check that the
@@ -924,11 +941,11 @@ bool idUsage::isValid<SpvOpSpecConstantComposite>(const spv_instruction_t* inst,
         auto constituentResultType = module_.FindDef(constituent->type_id());
         if (!constituentResultType ||
             componentType->opcode() != constituentResultType->opcode()) {
-          DIAG(constituentIndex) << "OpSpecConstantComposite Constituent <id> '"
-                                 << inst->words[constituentIndex]
-                                 << "'s type does not match Result Type <id> '"
-                                 << resultType->id()
-                                 << "'s vector element type.";
+          DIAG(constituentIndex)
+          << "OpSpecConstantComposite Constituent <id> '"
+          << inst->words[constituentIndex]
+          << "'s type does not match Result Type <id> '" << resultType->id()
+          << "'s vector element type.";
           return false;
         }
       }
@@ -954,10 +971,9 @@ bool idUsage::isValid<SpvOpSpecConstantComposite>(const spv_instruction_t* inst,
            constituentIndex++) {
         auto constituent = module_.FindDef(inst->words[constituentIndex]);
         auto constituentOpCode = constituent->opcode();
-        if (!constituent ||
-            !(SpvOpSpecConstantComposite == constituentOpCode ||
-              SpvOpConstantComposite == constituentOpCode ||
-              SpvOpUndef == constituentOpCode)) {
+        if (!constituent || !(SpvOpSpecConstantComposite == constituentOpCode ||
+            SpvOpConstantComposite == constituentOpCode ||
+            SpvOpUndef == constituentOpCode)) {
           // The message says "... or undef" because the spec does not say
           // undef is a constant.
           DIAG(constituentIndex) << "OpSpecConstantComposite Constituent <id> '"
@@ -968,11 +984,11 @@ bool idUsage::isValid<SpvOpSpecConstantComposite>(const spv_instruction_t* inst,
         auto vector = module_.FindDef(constituent->type_id());
         assert(vector);
         if (columnType->opcode() != vector->opcode()) {
-          DIAG(constituentIndex) << "OpSpecConstantComposite Constituent <id> '"
-                                 << inst->words[constituentIndex]
-                                 << "' type does not match Result Type <id> '"
-                                 << resultType->id()
-                                 << "'s matrix column type.";
+          DIAG(constituentIndex)
+          << "OpSpecConstantComposite Constituent <id> '"
+          << inst->words[constituentIndex]
+          << "' type does not match Result Type <id> '" << resultType->id()
+          << "'s matrix column type.";
           return false;
         }
         auto vectorComponentType = module_.FindDef(vector->words()[2]);
@@ -1021,11 +1037,11 @@ bool idUsage::isValid<SpvOpSpecConstantComposite>(const spv_instruction_t* inst,
         auto constituentType = module_.FindDef(constituent->type_id());
         assert(constituentType);
         if (elementType->id() != constituentType->id()) {
-          DIAG(constituentIndex) << "OpSpecConstantComposite Constituent <id> '"
-                                 << inst->words[constituentIndex]
-                                 << "'s type does not match Result Type <id> '"
-                                 << resultType->id()
-                                 << "'s array element type.";
+          DIAG(constituentIndex)
+          << "OpSpecConstantComposite Constituent <id> '"
+          << inst->words[constituentIndex]
+          << "'s type does not match Result Type <id> '" << resultType->id()
+          << "'s array element type.";
           return false;
         }
       }
@@ -1098,9 +1114,9 @@ bool idUsage::isValid<SpvOpVariable>(const spv_instruction_t* inst,
     const auto is_constant =
         initialiser && spvOpcodeIsConstant(initialiser->opcode());
     if (!initialiser || !(is_constant || is_module_scope_var)) {
-      DIAG(initialiserIndex) << "OpVariable Initializer <id> '"
-                             << inst->words[initialiserIndex]
-                             << "' is not a constant or module-scope variable.";
+      DIAG(initialiserIndex)
+      << "OpVariable Initializer <id> '" << inst->words[initialiserIndex]
+      << "' is not a constant or module-scope variable.";
       return false;
     }
   }
@@ -1199,10 +1215,14 @@ bool idUsage::isValid<SpvOpStore>(const spv_instruction_t* inst,
   }
 
   if (type->id() != objectType->id()) {
-    DIAG(pointerIndex) << "OpStore Pointer <id> '" << inst->words[pointerIndex]
-                       << "'s type does not match Object <id> '"
-                       << objectType->id() << "'s type.";
-    return false;
+    if (!module_.options()->relax_struct_store ||
+        !AreInterchangeableSructs(type, objectType)) {
+      DIAG(pointerIndex) << "OpStore Pointer <id> '"
+                         << inst->words[pointerIndex]
+                         << "'s type does not match Object <id> '"
+                         << objectType->id() << "'s type.";
+      return false;
+    }
   }
   return true;
 }
@@ -1419,8 +1439,9 @@ bool idUsage::isValid<SpvOpAccessChain>(const spv_instruction_t* inst,
       }
       default: {
         // Give an error. reached non-composite type while indexes still remain.
-        DIAG(i) << instr_name << " reached non-composite type while indexes "
-                                 "still remain to be traversed.";
+        DIAG(i) << instr_name
+                << " reached non-composite type while indexes "
+                    "still remain to be traversed.";
         return false;
       }
     }
@@ -1495,9 +1516,9 @@ bool idUsage::isValid<SpvOpFunction>(const spv_instruction_t* inst,
   auto functionTypeIndex = 4;
   auto functionType = module_.FindDef(inst->words[functionTypeIndex]);
   if (!functionType || SpvOpTypeFunction != functionType->opcode()) {
-    DIAG(functionTypeIndex) << "OpFunction Function Type <id> '"
-                            << inst->words[functionTypeIndex]
-                            << "' is not a function type.";
+    DIAG(functionTypeIndex)
+    << "OpFunction Function Type <id> '" << inst->words[functionTypeIndex]
+    << "' is not a function type.";
     return false;
   }
   auto returnType = module_.FindDef(functionType->words()[2]);
@@ -1678,8 +1699,9 @@ bool walkCompositeTypeHierarchy(
       }
       default: {
         // Give an error. reached non-composite type while indexes still remain.
-        *error << instr_name() << " reached non-composite type while indexes "
-                                  "still remain to be traversed.";
+        *error << instr_name()
+               << " reached non-composite type while indexes "
+                   "still remain to be traversed.";
         return false;
       }
     }
@@ -1804,12 +1826,13 @@ bool idUsage::isValid<SpvOpCompositeInsert>(const spv_instruction_t* inst,
   auto objectTypeInstr = module_.FindDef(objectInstr->type_id());
   if (indexedTypeInstr->id() != objectTypeInstr->id()) {
     DIAG(objectIdIndex)
-        << "The Object type (Op"
-        << spvOpcodeString(static_cast<SpvOp>(objectTypeInstr->opcode()))
-        << ") in " << instr_name() << " does not match the type that results "
-                                      "from indexing into the Composite (Op"
-        << spvOpcodeString(static_cast<SpvOp>(indexedTypeInstr->opcode()))
-        << ").";
+    << "The Object type (Op"
+    << spvOpcodeString(static_cast<SpvOp>(objectTypeInstr->opcode()))
+    << ") in " << instr_name()
+    << " does not match the type that results "
+        "from indexing into the Composite (Op"
+    << spvOpcodeString(static_cast<SpvOp>(indexedTypeInstr->opcode()))
+    << ").";
     return false;
   }
 
@@ -2495,6 +2518,75 @@ bool idUsage::isValid(const spv_instruction_t* inst) {
 #undef TODO
 #undef CASE
 }
+bool idUsage::AreInterchangeableSructs(const libspirv::Instruction* type1,
+                                       const libspirv::Instruction* type2) {
+  if (type1->opcode() != SpvOpTypeStruct) {
+    return false;
+  }
+  if (type2->opcode() != SpvOpTypeStruct) {
+    return false;
+  }
+
+  if (!HaveSameOpTypeStruct(type1, type2)) return false;
+
+  return HaveSameLayoutDecorations(type1, type2);
+}
+bool idUsage::HaveSameOpTypeStruct(const libspirv::Instruction* type1,
+                                   const libspirv::Instruction* type2) {
+  assert(type1->opcode() == SpvOpTypeStruct &&
+      "type1 must be and OpTypeStruct instruction.");
+  assert(type2->opcode() == SpvOpTypeStruct &&
+      "type2 must be and OpTypeStruct instruction.");
+  const auto& type1_operands = type1->operands();
+  const auto& type2_operands = type2->operands();
+  if (type1_operands.size() != type2_operands.size()) {
+    return false;
+  }
+
+  for (size_t operand = 2; operand < type1_operands.size(); ++operand) {
+    if (type1->word(operand) != type2->word(operand)) {
+      auto def1 = module_.FindDef(type1->word(operand));
+      auto def2 = module_.FindDef(type2->word(operand));
+      if (!AreInterchangeableSructs(def1, def2)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+bool idUsage::HaveSameLayoutDecorations(const libspirv::Instruction* type1,
+                                        const libspirv::Instruction* type2) {
+  assert(type1->opcode() == SpvOpTypeStruct &&
+      "type1 must be and OpTypeStruct instruction.");
+  assert(type2->opcode() == SpvOpTypeStruct &&
+      "type2 must be and OpTypeStruct instruction.");
+  const std::vector<Decoration>& type1_decorations =
+      module_.id_decorations(type1->id());
+  const std::vector<Decoration>& type2_decorations =
+      module_.id_decorations(type2->id());
+
+  for (const Decoration& decoration : type1_decorations) {
+    switch (decoration.dec_type()) {
+      case SpvDecorationArrayStride:
+      case SpvDecorationOffset:
+      case SpvDecorationMatrixStride:
+      case SpvDecorationRowMajor:
+      case SpvDecorationColMajor:
+        // Since these effect the layout of the struct, they must be present in
+        // both structs.
+        if (std::find(type2_decorations.begin(), type2_decorations.end(),
+                      decoration) == type2_decorations.end()) {
+          return false;
+        }
+        break;
+      default:
+        // This decoration does not effect the layout of the structure, so just
+        // moving on.
+        break;
+    }
+  }
+  return true;
+}
 }  // anonymous namespace
 
 namespace libspirv {
@@ -2632,9 +2724,9 @@ spv_result_t IdPass(ValidationState_t& _,
         } else if (can_have_forward_declared_ids(i)) {
           ret = _.ForwardDeclareId(operand_word);
         } else {
-          ret = _.diag(SPV_ERROR_INVALID_ID) << "ID "
-                                             << _.getIdName(operand_word)
-                                             << " has not been defined";
+          ret = _.diag(SPV_ERROR_INVALID_ID)
+              << "ID " << _.getIdName(operand_word)
+              << " has not been defined";
         }
         break;
       default:

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -2159,7 +2159,7 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpStore Pointer <id> '7's type does not match Object "
-                        "<id> '3's type."));
+                            "<id> '6's type."));
 }
 
 // The next series of test check test a relaxation of the rules for stores to
@@ -2174,11 +2174,11 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeBadStruct) {
 %3 = OpTypeVoid
 %4 = OpTypeFloat 32
 %1 = OpTypeStruct %4 %4
-%5 = OpTypePointer UniformConstant %1
+%5 = OpTypePointer Uniform %1
 %2 = OpTypeStruct %4 %4
 %6 = OpTypeFunction %3
 %7 = OpConstant %4 3.14
-%8 = OpVariable %5 UniformConstant
+%8 = OpVariable %5 Uniform
 %9 = OpFunction %3 None %6
 %10 = OpLabel
 %11 = OpCompositeConstruct %2 %7 %7
@@ -2189,7 +2189,7 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeBadStruct) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpStore Pointer <id> '8's type does not match Object "
-                            "<id> '2's type."));
+                            "<id> '11's type."));
 }
 
 // Same code as the last test.  The difference is that we relax the rule.
@@ -2203,11 +2203,11 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeRelaxedStruct) {
 %3 = OpTypeVoid
 %4 = OpTypeFloat 32
 %1 = OpTypeStruct %4 %4
-%5 = OpTypePointer UniformConstant %1
+%5 = OpTypePointer Uniform %1
 %2 = OpTypeStruct %4 %4
 %6 = OpTypeFunction %3
 %7 = OpConstant %4 3.14
-%8 = OpVariable %5 UniformConstant
+%8 = OpVariable %5 Uniform
 %9 = OpFunction %3 None %6
 %10 = OpLabel
 %11 = OpCompositeConstruct %2 %7 %7
@@ -2236,13 +2236,13 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeRelaxedNestedStruct) {
 %7 = OpTypeFloat 32
 %1 = OpTypeStruct %7 %6
 %2 = OpTypeStruct %1 %1
-%8 = OpTypePointer UniformConstant %2
+%8 = OpTypePointer Uniform %2
 %3 = OpTypeStruct %7 %6
 %4 = OpTypeStruct %3 %3
 %9 = OpTypeFunction %5
 %10 = OpConstant %6 7
 %11 = OpConstant %7 3.14
-%12 = OpVariable %8 UniformConstant
+%12 = OpVariable %8 Uniform
 %13 = OpFunction %5 None %9
 %14 = OpLabel
 %15 = OpCompositeConstruct %3 %11 %6
@@ -2272,13 +2272,13 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeBadRelaxedStruct1) {
 %7 = OpTypeFloat 32
 %1 = OpTypeStruct %6 %7
 %2 = OpTypeStruct %1 %1
-%8 = OpTypePointer UniformConstant %2
+%8 = OpTypePointer Uniform %2
 %3 = OpTypeStruct %7 %6
 %4 = OpTypeStruct %3 %3
 %9 = OpTypeFunction %5
 %10 = OpConstant %6 7
 %11 = OpConstant %7 3.14
-%12 = OpVariable %8 UniformConstant
+%12 = OpVariable %8 Uniform
 %13 = OpFunction %5 None %9
 %14 = OpLabel
 %15 = OpCompositeConstruct %3 %11 %6
@@ -2289,9 +2289,10 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeBadRelaxedStruct1) {
   spvValidatorOptionsSetRelaxStoreStruct(options_, true);
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpStore Pointer <id> '12's type does not match Object "
-                            "<id> '4's type."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("OpStore Pointer <id> '12's layout does not match Object "
+                    "<id> '16's layout."));
 }
 
 // This test check that the even with the relaxed rules an error is identified
@@ -2311,13 +2312,13 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeBadRelaxedStruct2) {
 %7 = OpTypeFloat 32
 %1 = OpTypeStruct %7 %6
 %2 = OpTypeStruct %1 %1
-%8 = OpTypePointer UniformConstant %2
+%8 = OpTypePointer Uniform %2
 %3 = OpTypeStruct %7 %6
 %4 = OpTypeStruct %3 %3
 %9 = OpTypeFunction %5
 %10 = OpConstant %6 7
 %11 = OpConstant %7 3.14
-%12 = OpVariable %8 UniformConstant
+%12 = OpVariable %8 Uniform
 %13 = OpFunction %5 None %9
 %14 = OpLabel
 %15 = OpCompositeConstruct %3 %11 %6
@@ -2328,9 +2329,10 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeBadRelaxedStruct2) {
   spvValidatorOptionsSetRelaxStoreStruct(options_, true);
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpStore Pointer <id> '12's type does not match Object "
-                            "<id> '4's type."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("OpStore Pointer <id> '12's layout does not match Object "
+                    "<id> '16's layout."));
 }
 
 TEST_F(ValidateIdWithMessage, OpStoreVoid) {

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -157,8 +157,8 @@ Options:
   --eliminate-dead-variables
                Deletes module scope variables that are not referenced.
   --relax-store-struct
-               Allow store from one struct type to a different, but 
-               interchangeable, type.  This option is forwarded to the 
+               Allow store from one struct type to a different type with
+               compatible layout and members. This option is forwarded to the
                validator.
   -O
                Optimize for performance. Apply a sequence of transformations

--- a/tools/val/val.cpp
+++ b/tools/val/val.cpp
@@ -44,6 +44,7 @@ Options:
   --max-function-args              <maximum number arguments allowed per function>
   --max-control-flow-nesting-depth <maximum Control Flow nesting depth allowed>
   --max-access-chain-indexes       <maximum number of indexes allowed to use for Access Chain instructions>
+  --relax-struct-store             Allow store from one struct type to a different, but interchangeable, type.
   --version                        Display validator version information.
   --target-env                     {vulkan1.0|spv1.0|spv1.1|spv1.2}
                                    Use Vulkan1.0/SPIR-V1.0/SPIR-V1.1/SPIR-V1.2 validation rules.
@@ -109,6 +110,8 @@ int main(int argc, char** argv) {
           continue_processing = false;
           return_code = 1;
         }
+      } else if (0 == strcmp(cur_arg, "--relax-struct-store")) {
+        options.SetRelaxStructStore(true);
       } else if (0 == cur_arg[1]) {
         // Setting a filename of "-" to indicate stdin.
         if (!inFile) {

--- a/tools/val/val.cpp
+++ b/tools/val/val.cpp
@@ -44,7 +44,9 @@ Options:
   --max-function-args              <maximum number arguments allowed per function>
   --max-control-flow-nesting-depth <maximum Control Flow nesting depth allowed>
   --max-access-chain-indexes       <maximum number of indexes allowed to use for Access Chain instructions>
-  --relax-struct-store             Allow store from one struct type to a different type with compatible layout and members.
+  --relax-struct-store             Allow store from one struct type to a
+                                   different type with compatible layout and
+                                   members.
   --version                        Display validator version information.
   --target-env                     {vulkan1.0|spv1.0|spv1.1|spv1.2}
                                    Use Vulkan1.0/SPIR-V1.0/SPIR-V1.1/SPIR-V1.2 validation rules.

--- a/tools/val/val.cpp
+++ b/tools/val/val.cpp
@@ -44,7 +44,7 @@ Options:
   --max-function-args              <maximum number arguments allowed per function>
   --max-control-flow-nesting-depth <maximum Control Flow nesting depth allowed>
   --max-access-chain-indexes       <maximum number of indexes allowed to use for Access Chain instructions>
-  --relax-struct-store             Allow store from one struct type to a different, but interchangeable, type.
+  --relax-struct-store             Allow store from one struct type to a different type with compatible layout and members.
   --version                        Display validator version information.
   --target-env                     {vulkan1.0|spv1.0|spv1.1|spv1.2}
                                    Use Vulkan1.0/SPIR-V1.0/SPIR-V1.1/SPIR-V1.2 validation rules.


### PR DESCRIPTION
There are a number of users of spriv-opt that are hitting errors
because of stores with different types.  In general, this is wrong, but,
in these cases, the types are the exact same except for decorations.

The proper solution to the problem is being discussed, but in the
meantime I would add an option to accept these cases.

The options is "--relax-store-struct", and it can be used with the
validator or the optimizer.