### PR TITLE
O(log n) table lookup for opcodes

### DIFF
--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -140,13 +140,16 @@ spv_result_t spvOpcodeTableValueLookup(const spv_opcode_table table,
   if (!table) return SPV_ERROR_INVALID_TABLE;
   if (!pEntry) return SPV_ERROR_INVALID_POINTER;
 
-  // TODO: As above this lookup is not optimal.
-  for (uint64_t opcodeIndex = 0; opcodeIndex < table->count; ++opcodeIndex) {
-    if (opcode == table->entries[opcodeIndex].opcode) {
-      // NOTE: Found the Opcode!
-      *pEntry = &table->entries[opcodeIndex];
-      return SPV_SUCCESS;
-    }
+  auto beg = table->entries;
+  auto end = table->entries + table->count;
+  auto value = spv_opcode_desc_t{"", opcode, 0, nullptr, 0, {}, 0, 0};
+  auto comp = [](const spv_opcode_desc_t& lhs, const spv_opcode_desc_t& rhs) {
+    return lhs.opcode < rhs.opcode;
+  };
+  auto it = std::lower_bound(beg, end, value, comp);
+  if (it->opcode == opcode) {
+    *pEntry = it;
+    return SPV_SUCCESS;
   }
 
   return SPV_ERROR_INVALID_LOOKUP;

--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -175,9 +175,16 @@ void spvInstructionCopy(const uint32_t* words, const SpvOp opcode,
 const char* spvOpcodeString(const SpvOp opcode) {
   // Use the latest SPIR-V version, which should be backward-compatible with all
   // previous ones.
-  for (uint32_t i = 0; i < ARRAY_SIZE(kOpcodeTableEntries_1_2); ++i) {
-    if (kOpcodeTableEntries_1_2[i].opcode == opcode)
-      return kOpcodeTableEntries_1_2[i].name;
+
+  auto beg = kOpcodeTableEntries_1_2;
+  auto end = kOpcodeTableEntries_1_2 + ARRAY_SIZE(kOpcodeTableEntries_1_2);
+  auto value = spv_opcode_desc_t{"", opcode, 0, nullptr, 0, {}, 0, 0};
+  auto comp = [](const spv_opcode_desc_t& lhs, const spv_opcode_desc_t& rhs) {
+    return lhs.opcode < rhs.opcode;
+  };
+  auto it = std::lower_bound(beg, end, value, comp);
+  if (it->opcode == opcode) {
+    return it->name;
   }
 
   assert(0 && "Unreachable!");

--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -140,14 +140,14 @@ spv_result_t spvOpcodeTableValueLookup(const spv_opcode_table table,
   if (!table) return SPV_ERROR_INVALID_TABLE;
   if (!pEntry) return SPV_ERROR_INVALID_POINTER;
 
-  auto beg = table->entries;
-  auto end = table->entries + table->count;
-  auto value = spv_opcode_desc_t{"", opcode, 0, nullptr, 0, {}, 0, 0};
+  const auto beg = table->entries;
+  const auto end = table->entries + table->count;
+  spv_opcode_desc_t value{"", opcode, 0, nullptr, 0, {}, 0, 0};
   auto comp = [](const spv_opcode_desc_t& lhs, const spv_opcode_desc_t& rhs) {
     return lhs.opcode < rhs.opcode;
   };
   auto it = std::lower_bound(beg, end, value, comp);
-  if (it->opcode == opcode) {
+  if (it!=end && it->opcode == opcode) {
     *pEntry = it;
     return SPV_SUCCESS;
   }
@@ -176,14 +176,14 @@ const char* spvOpcodeString(const SpvOp opcode) {
   // Use the latest SPIR-V version, which should be backward-compatible with all
   // previous ones.
 
-  auto beg = kOpcodeTableEntries_1_2;
-  auto end = kOpcodeTableEntries_1_2 + ARRAY_SIZE(kOpcodeTableEntries_1_2);
-  auto value = spv_opcode_desc_t{"", opcode, 0, nullptr, 0, {}, 0, 0};
+  const auto beg = kOpcodeTableEntries_1_2;
+  const auto end = kOpcodeTableEntries_1_2 + ARRAY_SIZE(kOpcodeTableEntries_1_2);
+  spv_opcode_desc_t value{"", opcode, 0, nullptr, 0, {}, 0, 0};
   auto comp = [](const spv_opcode_desc_t& lhs, const spv_opcode_desc_t& rhs) {
     return lhs.opcode < rhs.opcode;
   };
   auto it = std::lower_bound(beg, end, value, comp);
-  if (it->opcode == opcode) {
+  if (it!=end && it->opcode == opcode) {
     return it->name;
   }
 

--- a/utils/generate_grammar_tables.py
+++ b/utils/generate_grammar_tables.py
@@ -327,12 +327,17 @@ def generate_instruction(inst, version, is_ext_inst):
 
 def generate_instruction_table(inst_table, version):
     """Returns the info table containing all SPIR-V instructions,
-    prefixed by capability arrays.
+    sorted by opcode, and prefixed by capability arrays.
+    
+    Note:
+      - the built-in sorted() function is guaranteed to be stable.
+        https://docs.python.org/3/library/functions.html#sorted
 
     Arguments:
-      - inst_table: a dict containing all SPIR-V instructions.
+      - inst_table: a list containing all SPIR-V instructions.
       - vesion: SPIR-V version.
     """
+    inst_table = sorted(inst_table, key=lambda k: k['opcode'])
     caps_arrays = generate_capability_arrays(
         [inst.get('capabilities', []) for inst in inst_table], version)
     insts = [generate_instruction(inst, version, False) for inst in inst_table]
@@ -344,12 +349,13 @@ def generate_instruction_table(inst_table, version):
 
 def generate_extended_instruction_table(inst_table, set_name, version):
     """Returns the info table containing all SPIR-V extended instructions,
-    prefixed by capability arrays.
+    sorted by opcode, and prefixed by capability arrays.
 
     Arguments:
-      - inst_table: a dict containing all SPIR-V instructions.
+      - inst_table: a list containing all SPIR-V instructions.
       - set_name: the name of the extended instruction set.
     """
+    inst_table = sorted(inst_table, key=lambda k: k['opcode'])
     caps = [inst.get('capabilities', []) for inst in inst_table]
     caps_arrays = generate_capability_arrays(caps, version)
     insts = [generate_instruction(inst, version, True) for inst in inst_table]


### PR DESCRIPTION
Submitting for feedback and discussion.

This MR does not solve issue #502 completely, because I didn't generate a second table sorted by the opcode string. #502 also asked to modify utils/generate_grammar_tables.py to sort the existing opcode table, but I found that the table is already ordered (am I right?).

Basically I changed the opcode-lookup (spvOpcodeTableValueLookup) and the opcode-to-string (spvOpcodeString) functions to use std::lower_bound instead than a linear for loop.
I did not change the opcode-name-lookup (spvOpcodeTableNameLookup) function.

I profiled spirv-val/dis/as for a series of shaders, and report for the largest (~250kb).
_Linear = O(n),  Sorted = O(log n),  debug = -O0,  release = -O3_

**spirv-val**:
- Linear [debug]: total 179ms,   opcode-lookup 15ms
- Sorted [debug]: total 170ms,   opcode-lookup 0ms (not measurable when sorted)
- Linear [release]: total 28ms,   opcode-lookup 3ms
- Sorted [release]: total 25ms,   opcode-lookup 0ms

**spirv-dis**:
- Linear [debug]: total 83ms,   opcode-lookup 11ms, opcode-to-string 5ms
- Sorted [debug]: total 73ms,   opcode-lookup 0ms, opcode-to-string 2ms
- Linear [release]: total 25ms,   opcode-lookup 2ms, opcode-to-string 0ms
- Sorted [release]: total 22ms,   opcode-lookup 1ms, opcode-to-string 0ms

**spirv-as**:
- Linear [debug]: total 68ms,   opcode-name-lookup 5ms
- Sorted [debug]: total 68ms,   opcode-name-lookup 5ms
- Linear [release]: total 22ms,   opcode-name-lookup 2ms
- Sorted [release]: total 22ms,   opcode-name-lookup 2ms

Also, in #502 I proposed to go a step further and use a hash table. Looking at the numbers,
the O(log n) lookup seems fast enough, so a hash table is not necessary for the moment.