### PR TITLE
Tooling - CMake - Export symbol when creating shared library on Windows

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -24,6 +24,8 @@ extern "C" {
 #include <stddef.h>
 #include <stdint.h>
 
+#include "spirv-tools_export.h"
+
 // Helpers
 
 #define SPV_BIT(shift) (1 << (shift))
@@ -360,12 +362,12 @@ typedef const spv_validator_options_t* spv_const_validator_options;
 // Returns the SPIRV-Tools software version as a null-terminated string.
 // The contents of the underlying storage is valid for the remainder of
 // the process.
-const char* spvSoftwareVersionString();
+SPIRV_TOOLS_EXPORT const char* spvSoftwareVersionString();
 // Returns a null-terminated string containing the name of the project,
 // the software version string, and commit details.
 // The contents of the underlying storage is valid for the remainder of
 // the process.
-const char* spvSoftwareVersionDetailsString();
+SPIRV_TOOLS_EXPORT const char* spvSoftwareVersionDetailsString();
 
 // Certain target environments impose additional restrictions on SPIR-V, so it's
 // often necessary to specify which one applies.  SPV_ENV_UNIVERSAL means
@@ -398,25 +400,25 @@ typedef enum {
 } spv_validator_limit;
 
 // Returns a string describing the given SPIR-V target environment.
-const char* spvTargetEnvDescription(spv_target_env env);
+SPIRV_TOOLS_EXPORT const char* spvTargetEnvDescription(spv_target_env env);
 
 // Creates a context object.  Returns null if env is invalid.
-spv_context spvContextCreate(spv_target_env env);
+SPIRV_TOOLS_EXPORT spv_context spvContextCreate(spv_target_env env);
 
 // Destroys the given context object.
-void spvContextDestroy(spv_context context);
+SPIRV_TOOLS_EXPORT void spvContextDestroy(spv_context context);
 
 // Creates a Validator options object with default options. Returns a valid
 // options object. The object remains valid until it is passed into
 // spvValidatorOptionsDestroy.
-spv_validator_options spvValidatorOptionsCreate();
+SPIRV_TOOLS_EXPORT spv_validator_options spvValidatorOptionsCreate();
 
 // Destroys the given Validator options object.
-void spvValidatorOptionsDestroy(spv_validator_options options);
+SPIRV_TOOLS_EXPORT void spvValidatorOptionsDestroy(spv_validator_options options);
 
 // Records the maximum Universal Limit that is considered valid in the given
 // Validator options object. <options> argument must be a valid options object.
-void spvValidatorOptionsSetUniversalLimit(spv_validator_options options,
+SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetUniversalLimit(spv_validator_options options,
                                           spv_validator_limit limit_type,
                                           uint32_t limit);
 
@@ -438,14 +440,14 @@ void spvValidatorOptionsSetRelaxStoreStruct(spv_validator_options options,
 // be stored into *binary. Any error will be written into *diagnostic if
 // diagnostic is non-null. The generated binary is independent of the context
 // and may outlive it.
-spv_result_t spvTextToBinary(const spv_const_context context, const char* text,
+SPIRV_TOOLS_EXPORT spv_result_t spvTextToBinary(const spv_const_context context, const char* text,
                              const size_t length, spv_binary* binary,
                              spv_diagnostic* diagnostic);
 
 // Encodes the given SPIR-V assembly text to its binary representation. Same as
 // spvTextToBinary but with options. The options parameter is a bit field of
 // spv_text_to_binary_options_t.
-spv_result_t spvTextToBinaryWithOptions(const spv_const_context context,
+SPIRV_TOOLS_EXPORT spv_result_t spvTextToBinaryWithOptions(const spv_const_context context,
                                         const char* text, const size_t length,
                                         const uint32_t options,
                                         spv_binary* binary,
@@ -453,54 +455,54 @@ spv_result_t spvTextToBinaryWithOptions(const spv_const_context context,
 
 // Frees an allocated text stream. This is a no-op if the text parameter
 // is a null pointer.
-void spvTextDestroy(spv_text text);
+SPIRV_TOOLS_EXPORT void spvTextDestroy(spv_text text);
 
 // Decodes the given SPIR-V binary representation to its assembly text. The
 // word_count parameter specifies the number of words for binary. The options
 // parameter is a bit field of spv_binary_to_text_options_t. Decoded text will
 // be stored into *text. Any error will be written into *diagnostic if
 // diagnostic is non-null.
-spv_result_t spvBinaryToText(const spv_const_context context,
+SPIRV_TOOLS_EXPORT spv_result_t spvBinaryToText(const spv_const_context context,
                              const uint32_t* binary, const size_t word_count,
                              const uint32_t options, spv_text* text,
                              spv_diagnostic* diagnostic);
 
 // Frees a binary stream from memory. This is a no-op if binary is a null
 // pointer.
-void spvBinaryDestroy(spv_binary binary);
+SPIRV_TOOLS_EXPORT void spvBinaryDestroy(spv_binary binary);
 
 // Validates a SPIR-V binary for correctness. Any errors will be written into
 // *diagnostic if diagnostic is non-null.
-spv_result_t spvValidate(const spv_const_context context,
+SPIRV_TOOLS_EXPORT spv_result_t spvValidate(const spv_const_context context,
                          const spv_const_binary binary,
                          spv_diagnostic* diagnostic);
 
 // Validates a SPIR-V binary for correctness. Uses the provided Validator
 // options. Any errors will be written into *diagnostic if diagnostic is
 // non-null.
-spv_result_t spvValidateWithOptions(const spv_const_context context,
+SPIRV_TOOLS_EXPORT spv_result_t spvValidateWithOptions(const spv_const_context context,
                                     const spv_const_validator_options options,
                                     const spv_const_binary binary,
                                     spv_diagnostic* diagnostic);
 
 // Validates a raw SPIR-V binary for correctness. Any errors will be written
 // into *diagnostic if diagnostic is non-null.
-spv_result_t spvValidateBinary(const spv_const_context context,
+SPIRV_TOOLS_EXPORT spv_result_t spvValidateBinary(const spv_const_context context,
                                const uint32_t* words, const size_t num_words,
                                spv_diagnostic* diagnostic);
 
 // Creates a diagnostic object. The position parameter specifies the location in
 // the text/binary stream. The message parameter, copied into the diagnostic
 // object, contains the error message to display.
-spv_diagnostic spvDiagnosticCreate(const spv_position position,
+SPIRV_TOOLS_EXPORT spv_diagnostic spvDiagnosticCreate(const spv_position position,
                                    const char* message);
 
 // Destroys a diagnostic object.  This is a no-op if diagnostic is a null
 // pointer.
-void spvDiagnosticDestroy(spv_diagnostic diagnostic);
+SPIRV_TOOLS_EXPORT void spvDiagnosticDestroy(spv_diagnostic diagnostic);
 
 // Prints the diagnostic to stderr.
-spv_result_t spvDiagnosticPrint(const spv_diagnostic diagnostic);
+SPIRV_TOOLS_EXPORT spv_result_t spvDiagnosticPrint(const spv_diagnostic diagnostic);
 
 // The binary parser interface.
 
@@ -533,7 +535,7 @@ typedef spv_result_t (*spv_parsed_instruction_fn_t)(
 // also emits a diagnostic.  If a callback returns anything other than
 // SPV_SUCCESS, then that status code is returned, no further callbacks are
 // issued, and no additional diagnostics are emitted.
-spv_result_t spvBinaryParse(const spv_const_context context, void* user_data,
+SPIRV_TOOLS_EXPORT spv_result_t spvBinaryParse(const spv_const_context context, void* user_data,
                             const uint32_t* words, const size_t num_words,
                             spv_parsed_header_fn_t parse_header,
                             spv_parsed_instruction_fn_t parse_instruction,

--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -22,6 +22,8 @@
 
 #include "spirv-tools/libspirv.h"
 
+#include "spirv-tools_export.h"
+
 namespace spvtools {
 
 // Message consumer. The C strings for source and message are only alive for the
@@ -32,7 +34,7 @@ using MessageConsumer = std::function<void(
     )>;
 
 // A RAII wrapper around a validator options object.
-class ValidatorOptions {
+class SPIRV_TOOLS_EXPORT ValidatorOptions {
  public:
   ValidatorOptions() : options_(spvValidatorOptionsCreate()) {}
   ~ValidatorOptions() { spvValidatorOptionsDestroy(options_); }
@@ -75,50 +77,50 @@ class SpirvTools {
   // The constructed instance will have an empty message consumer, which just
   // ignores all messages from the library. Use SetMessageConsumer() to supply
   // one if messages are of concern.
-  explicit SpirvTools(spv_target_env env);
+  SPIRV_TOOLS_EXPORT explicit SpirvTools(spv_target_env env);
 
   // Disables copy/move constructor/assignment operations.
-  SpirvTools(const SpirvTools&) = delete;
-  SpirvTools(SpirvTools&&) = delete;
-  SpirvTools& operator=(const SpirvTools&) = delete;
-  SpirvTools& operator=(SpirvTools&&) = delete;
+  SPIRV_TOOLS_EXPORT SpirvTools(const SpirvTools&) = delete;
+  SPIRV_TOOLS_EXPORT SpirvTools(SpirvTools&&) = delete;
+  SPIRV_TOOLS_EXPORT SpirvTools& operator=(const SpirvTools&) = delete;
+  SPIRV_TOOLS_EXPORT SpirvTools& operator=(SpirvTools&&) = delete;
 
   // Destructs this instance.
-  ~SpirvTools();
+  SPIRV_TOOLS_EXPORT ~SpirvTools();
 
   // Sets the message consumer to the given |consumer|. The |consumer| will be
   // invoked once for each message communicated from the library.
-  void SetMessageConsumer(MessageConsumer consumer);
+  SPIRV_TOOLS_EXPORT void SetMessageConsumer(MessageConsumer consumer);
 
   // Assembles the given assembly |text| and writes the result to |binary|.
   // Returns true on successful assembling. |binary| will be kept untouched if
   // assembling is unsuccessful.
-  bool Assemble(const std::string& text, std::vector<uint32_t>* binary,
+  SPIRV_TOOLS_EXPORT bool Assemble(const std::string& text, std::vector<uint32_t>* binary,
                 uint32_t options = kDefaultAssembleOption) const;
   // |text_size| specifies the number of bytes in |text|. A terminating null
   // character is not required to present in |text| as long as |text| is valid.
-  bool Assemble(const char* text, size_t text_size,
+  SPIRV_TOOLS_EXPORT bool Assemble(const char* text, size_t text_size,
                 std::vector<uint32_t>* binary,
                 uint32_t options = kDefaultAssembleOption) const;
 
   // Disassembles the given SPIR-V |binary| with the given |options| and writes
   // the assembly to |text|. Returns ture on successful disassembling. |text|
   // will be kept untouched if diassembling is unsuccessful.
-  bool Disassemble(const std::vector<uint32_t>& binary, std::string* text,
+  SPIRV_TOOLS_EXPORT bool Disassemble(const std::vector<uint32_t>& binary, std::string* text,
                    uint32_t options = kDefaultDisassembleOption) const;
   // |binary_size| specifies the number of words in |binary|.
-  bool Disassemble(const uint32_t* binary, size_t binary_size,
+  SPIRV_TOOLS_EXPORT bool Disassemble(const uint32_t* binary, size_t binary_size,
                    std::string* text,
                    uint32_t options = kDefaultDisassembleOption) const;
 
   // Validates the given SPIR-V |binary|. Returns true if no issues are found.
   // Otherwise, returns false and communicates issues via the message consumer
   // registered.
-  bool Validate(const std::vector<uint32_t>& binary) const;
+  SPIRV_TOOLS_EXPORT bool Validate(const std::vector<uint32_t>& binary) const;
   // |binary_size| specifies the number of words in |binary|.
-  bool Validate(const uint32_t* binary, size_t binary_size) const;
+  SPIRV_TOOLS_EXPORT bool Validate(const uint32_t* binary, size_t binary_size) const;
   // Like the previous overload, but takes an options object.
-  bool Validate(const uint32_t* binary, size_t binary_size,
+  SPIRV_TOOLS_EXPORT bool Validate(const uint32_t* binary, size_t binary_size,
                 const ValidatorOptions& options) const;
 
  private:

--- a/include/spirv-tools/linker.hpp
+++ b/include/spirv-tools/linker.hpp
@@ -22,9 +22,11 @@
 
 #include "libspirv.hpp"
 
+#include "spirv-tools-link_export.h"
+
 namespace spvtools {
 
-class LinkerOptions {
+class SPIRV_TOOLS_LINK_EXPORT LinkerOptions {
  public:
   LinkerOptions() : createLibrary_(false) {}
 
@@ -52,20 +54,20 @@ class Linker {
   // The constructed instance will have an empty message consumer, which just
   // ignores all messages from the library. Use SetMessageConsumer() to supply
   // one if messages are of concern.
-  explicit Linker(spv_target_env env);
+  SPIRV_TOOLS_LINK_EXPORT explicit Linker(spv_target_env env);
 
   // Disables copy/move constructor/assignment operations.
-  Linker(const Linker&) = delete;
-  Linker(Linker&&) = delete;
-  Linker& operator=(const Linker&) = delete;
-  Linker& operator=(Linker&&) = delete;
+  SPIRV_TOOLS_LINK_EXPORT Linker(const Linker&) = delete;
+  SPIRV_TOOLS_LINK_EXPORT Linker(Linker&&) = delete;
+  SPIRV_TOOLS_LINK_EXPORT Linker& operator=(const Linker&) = delete;
+  SPIRV_TOOLS_LINK_EXPORT Linker& operator=(Linker&&) = delete;
 
   // Destructs this instance.
-  ~Linker();
+  SPIRV_TOOLS_LINK_EXPORT ~Linker();
 
   // Sets the message consumer to the given |consumer|. The |consumer| will be
   // invoked once for each message communicated from the library.
-  void SetMessageConsumer(MessageConsumer consumer);
+  SPIRV_TOOLS_LINK_EXPORT void SetMessageConsumer(MessageConsumer consumer);
 
   // Links one or more SPIR-V modules into a new SPIR-V module. That is,
   // combine several SPIR-V modules into one, resolving link dependencies
@@ -81,10 +83,10 @@ class Linker {
   // * Some entry points were defined multiple times;
   // * Some imported symbols did not have an exported counterpart;
   // * Possibly other reasons.
-  spv_result_t Link(const std::vector<std::vector<uint32_t>>& binaries,
+  SPIRV_TOOLS_LINK_EXPORT spv_result_t Link(const std::vector<std::vector<uint32_t>>& binaries,
                     std::vector<uint32_t>& linked_binary,
                     const LinkerOptions& options = LinkerOptions()) const;
-  spv_result_t Link(const uint32_t* const* binaries, const size_t* binary_sizes,
+  SPIRV_TOOLS_LINK_EXPORT spv_result_t Link(const uint32_t* const* binaries, const size_t* binary_sizes,
                     size_t num_binaries, std::vector<uint32_t>& linked_binary,
                     const LinkerOptions& options = LinkerOptions()) const;
 

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -22,6 +22,8 @@
 
 #include "libspirv.hpp"
 
+#include "spirv-tools-opt_export.h"
+
 namespace spvtools {
 
 // C++ interface for SPIR-V optimization functionalities. It wraps the context
@@ -38,15 +40,15 @@ class Optimizer {
   struct PassToken {
     struct Impl;  // Opaque struct for holding inernal data.
 
-    PassToken(std::unique_ptr<Impl>);
+    SPIRV_TOOLS_OPT_EXPORT PassToken(std::unique_ptr<Impl>);
 
     // Tokens can only be moved. Copying is disabled.
-    PassToken(const PassToken&) = delete;
-    PassToken(PassToken&&);
-    PassToken& operator=(const PassToken&) = delete;
-    PassToken& operator=(PassToken&&);
+    SPIRV_TOOLS_OPT_EXPORT PassToken(const PassToken&) = delete;
+    SPIRV_TOOLS_OPT_EXPORT PassToken(PassToken&&);
+    SPIRV_TOOLS_OPT_EXPORT PassToken& operator=(const PassToken&) = delete;
+    SPIRV_TOOLS_OPT_EXPORT PassToken& operator=(PassToken&&);
 
-    ~PassToken();
+    SPIRV_TOOLS_OPT_EXPORT ~PassToken();
 
     std::unique_ptr<Impl> impl_;  // Unique pointer to internal data.
   };
@@ -57,25 +59,25 @@ class Optimizer {
   // The constructed instance will have an empty message consumer, which just
   // ignores all messages from the library. Use SetMessageConsumer() to supply
   // one if messages are of concern.
-  explicit Optimizer(spv_target_env env);
+  SPIRV_TOOLS_OPT_EXPORT explicit Optimizer(spv_target_env env);
 
   // Disables copy/move constructor/assignment operations.
-  Optimizer(const Optimizer&) = delete;
-  Optimizer(Optimizer&&) = delete;
-  Optimizer& operator=(const Optimizer&) = delete;
-  Optimizer& operator=(Optimizer&&) = delete;
+  SPIRV_TOOLS_OPT_EXPORT Optimizer(const Optimizer&) = delete;
+  SPIRV_TOOLS_OPT_EXPORT Optimizer(Optimizer&&) = delete;
+  SPIRV_TOOLS_OPT_EXPORT Optimizer& operator=(const Optimizer&) = delete;
+  SPIRV_TOOLS_OPT_EXPORT Optimizer& operator=(Optimizer&&) = delete;
 
   // Destructs this instance.
-  ~Optimizer();
+ SPIRV_TOOLS_OPT_EXPORT  ~Optimizer();
 
   // Sets the message consumer to the given |consumer|. The |consumer| will be
   // invoked once for each message communicated from the library.
-  void SetMessageConsumer(MessageConsumer consumer);
+  SPIRV_TOOLS_OPT_EXPORT void SetMessageConsumer(MessageConsumer consumer);
 
   // Registers the given |pass| to this optimizer. Passes will be run in the
   // exact order of registration. The token passed in will be consumed by this
   // method.
-  Optimizer& RegisterPass(PassToken&& pass);
+  SPIRV_TOOLS_OPT_EXPORT Optimizer& RegisterPass(PassToken&& pass);
 
   // Registers passes that attempt to improve performance of generated code.
   // This sequence of passes is subject to constant review and will change
@@ -95,7 +97,7 @@ class Optimizer {
   // executed and the contents in |optimized_binary| may be invalid.
   //
   // It's allowed to alias |original_binary| to the start of |optimized_binary|.
-  bool Run(const uint32_t* original_binary, size_t original_binary_size,
+  SPIRV_TOOLS_OPT_EXPORT bool Run(const uint32_t* original_binary, size_t original_binary_size,
            std::vector<uint32_t>* optimized_binary) const;
 
   // Returns a vector of strings with all the pass names added to this
@@ -110,25 +112,25 @@ class Optimizer {
 
 // Creates a null pass.
 // A null pass does nothing to the SPIR-V module to be optimized.
-Optimizer::PassToken CreateNullPass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateNullPass();
 
 // Creates a strip-debug-info pass.
 // A strip-debug-info pass removes all debug instructions (as documented in
 // Section 3.32.2 of the SPIR-V spec) of the SPIR-V module to be optimized.
-Optimizer::PassToken CreateStripDebugInfoPass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateStripDebugInfoPass();
 
 // Creates an eliminate-dead-functions pass.
 // An eliminate-dead-functions pass will remove all functions that are not in
 // the call trees rooted at entry points and exported functions.  These
 // functions are not needed because they will never be called.
-Optimizer::PassToken CreateEliminateDeadFunctionsPass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateEliminateDeadFunctionsPass();
 
 // Creates a set-spec-constant-default-value pass from a mapping from spec-ids
 // to the default values in the form of string.
 // A set-spec-constant-default-value pass sets the default values for the
 // spec constants that have SpecId decorations (i.e., those defined by
 // OpSpecConstant{|True|False} instructions).
-Optimizer::PassToken CreateSetSpecConstantDefaultValuePass(
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateSetSpecConstantDefaultValuePass(
     const std::unordered_map<uint32_t, std::string>& id_value_map);
 
 // Creates a set-spec-constant-default-value pass from a mapping from spec-ids
@@ -136,7 +138,7 @@ Optimizer::PassToken CreateSetSpecConstantDefaultValuePass(
 // A set-spec-constant-default-value pass sets the default values for the
 // spec constants that have SpecId decorations (i.e., those defined by
 // OpSpecConstant{|True|False} instructions).
-Optimizer::PassToken CreateSetSpecConstantDefaultValuePass(
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateSetSpecConstantDefaultValuePass(
     const std::unordered_map<uint32_t, std::vector<uint32_t>>& id_value_map);
 
 // Creates a flatten-decoration pass.
@@ -146,7 +148,7 @@ Optimizer::PassToken CreateSetSpecConstantDefaultValuePass(
 // instructions with equivalent OpDecorate and OpMemberDecorate instructions.
 // The pass does not attempt to preserve debug information for instructions
 // it removes.
-Optimizer::PassToken CreateFlattenDecorationPass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateFlattenDecorationPass();
 
 // Creates a freeze-spec-constant-value pass.
 // A freeze-spec-constant pass specializes the value of spec constants to
@@ -158,7 +160,7 @@ Optimizer::PassToken CreateFlattenDecorationPass();
 // pass does not fold the newly added normal constants and does not process
 // other spec constants defined by OpSpecConstantComposite or
 // OpSpecConstantOp.
-Optimizer::PassToken CreateFreezeSpecConstantValuePass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateFreezeSpecConstantValuePass();
 
 // Creates a fold-spec-constant-op-and-composite pass.
 // A fold-spec-constant-op-and-composite pass folds spec constants defined by
@@ -180,7 +182,7 @@ Optimizer::PassToken CreateFreezeSpecConstantValuePass();
 //   OpSConvert, OpFConvert, OpQuantizeToF16 and
 //   all the operations under Kernel capability.
 // TODO(qining): Add support for the operations listed above.
-Optimizer::PassToken CreateFoldSpecConstantOpAndCompositePass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateFoldSpecConstantOpAndCompositePass();
 
 // Creates a unify-constant pass.
 // A unify-constant pass de-duplicates the constants. Constants with the exact
@@ -196,7 +198,7 @@ Optimizer::PassToken CreateFoldSpecConstantOpAndCompositePass();
 //  constant won't be handled, which means, it won't be used to replace any
 //  other constants, neither can other constants replace it.
 //  3) NaN in float point format with different bit patterns are not unified.
-Optimizer::PassToken CreateUnifyConstantPass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateUnifyConstantPass();
 
 // Creates a eliminate-dead-constant pass.
 // A eliminate-dead-constant pass removes dead constants, including normal
@@ -204,13 +206,13 @@ Optimizer::PassToken CreateUnifyConstantPass();
 // OpConstantFalse and spec constants defined by OpSpecConstant,
 // OpSpecConstantComposite, OpSpecConstantTrue, OpSpecConstantFalse or
 // OpSpecConstantOp.
-Optimizer::PassToken CreateEliminateDeadConstantPass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateEliminateDeadConstantPass();
 
 // Creates a strength-reduction pass.
 // A strength-reduction pass will look for opportunities to replace an
 // instruction with an equivalent and less expensive one.  For example,
 // multiplying by a power of 2 can be replaced by a bit shift.
-Optimizer::PassToken CreateStrengthReductionPass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateStrengthReductionPass();
 
 // Creates a block merge pass.
 // This pass searches for blocks with a single Branch to a block with no
@@ -226,7 +228,7 @@ Optimizer::PassToken CreateStrengthReductionPass();
 //
 // Presence of phi instructions can inhibit this optimization. Handling
 // these is left for future improvements.
-Optimizer::PassToken CreateBlockMergePass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateBlockMergePass();
 
 // Creates an exhaustive inline pass.
 // An exhaustive inline pass attempts to exhaustively inline all function
@@ -235,7 +237,7 @@ Optimizer::PassToken CreateBlockMergePass();
 // calls by subsequent optimization passes. As the inlining is exhaustive,
 // there is no attempt to optimize for size or runtime performance. Functions
 // that are not in the call tree of an entry point are not changed.
-Optimizer::PassToken CreateInlineExhaustivePass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateInlineExhaustivePass();
 
 // Creates an opaque inline pass.
 // An opaque inline pass inlines all function calls in all functions in all
@@ -246,7 +248,7 @@ Optimizer::PassToken CreateInlineExhaustivePass();
 // by subsequent passes in order to remove the storing of opaque types which is
 // not legal in Vulkan. Functions that are not in the call tree of an entry
 // point are not changed.
-Optimizer::PassToken CreateInlineOpaquePass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateInlineOpaquePass();
 
 // Creates a single-block local variable load/store elimination pass.
 // For every entry point function, do single block memory optimization of
@@ -268,7 +270,7 @@ Optimizer::PassToken CreateInlineOpaquePass();
 // by LocalSingleStoreElim and LocalMultiStoreElim.
 //
 // Only functions in the call tree of an entry point are processed.
-Optimizer::PassToken CreateLocalSingleBlockLoadStoreElimPass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateLocalSingleBlockLoadStoreElimPass();
 
 // Create dead branch elimination pass.
 // For each entry point function, this pass will look for SelectionMerge
@@ -285,7 +287,7 @@ Optimizer::PassToken CreateLocalSingleBlockLoadStoreElimPass();
 // This pass is most effective when preceeded by passes which eliminate
 // local loads and stores, effectively propagating constant values where
 // possible.
-Optimizer::PassToken CreateDeadBranchElimPass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateDeadBranchElimPass();
 
 // Creates an SSA local variable load/store elimination pass.
 // For every entry point function, eliminate all loads and stores of function
@@ -302,7 +304,7 @@ Optimizer::PassToken CreateDeadBranchElimPass();
 // This pass is most effective if preceeded by Inlining and
 // LocalAccessChainConvert. LocalSingleStoreElim and LocalSingleBlockElim
 // will reduce the work that this pass has to do.
-Optimizer::PassToken CreateLocalMultiStoreElimPass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateLocalMultiStoreElimPass();
 
 // Creates a local access chain conversion pass.
 // A local access chain conversion pass identifies all function scope
@@ -319,7 +321,7 @@ Optimizer::PassToken CreateLocalMultiStoreElimPass();
 // subsequent analysis and elimination of these variables along with their
 // loads and stores allowing values to propagate to their points of use where
 // possible.
-Optimizer::PassToken CreateLocalAccessChainConvertPass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateLocalAccessChainConvertPass();
 
 // Creates a local single store elimination pass.
 // For each entry point function, this pass eliminates loads and stores for
@@ -337,7 +339,7 @@ Optimizer::PassToken CreateLocalAccessChainConvertPass();
 // This pass will reduce the work needed to be done by LocalSingleBlockElim
 // and LocalMultiStoreElim and can improve the effectiveness of other passes
 // such as DeadBranchElimination which depend on values for their analysis.
-Optimizer::PassToken CreateLocalSingleStoreElimPass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateLocalSingleStoreElimPass();
 
 // Creates an insert/extract elimination pass.
 // This pass processes each entry point function in the module, searching for
@@ -349,7 +351,7 @@ Optimizer::PassToken CreateLocalSingleStoreElimPass();
 // Besides removing extracts this pass enables subsequent dead code elimination
 // passes to delete the inserts. This pass performs best after access chains are
 // converted to inserts and extracts and local loads and stores are eliminated.
-Optimizer::PassToken CreateInsertExtractElimPass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateInsertExtractElimPass();
 
 // Creates a pass to consolidate uniform references.
 // For each entry point function in the module, first change all constant index
@@ -363,7 +365,7 @@ Optimizer::PassToken CreateInsertExtractElimPass();
 // is not enabled. It also currently does not support any extensions.
 //
 // This pass currently only optimizes loads with a single index.
-Optimizer::PassToken CreateCommonUniformElimPass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateCommonUniformElimPass();
 
 // Create aggressive dead code elimination pass
 // This pass eliminates unused code from functions. In addition,
@@ -384,14 +386,14 @@ Optimizer::PassToken CreateCommonUniformElimPass();
 // Conversion, which tends to cause cycles of dead code to be left after
 // Store/Load elimination passes are completed. These cycles cannot be
 // eliminated with standard dead code elimination.
-Optimizer::PassToken CreateAggressiveDCEPass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateAggressiveDCEPass();
 
 // Creates a compact ids pass.
 // The pass remaps result ids to a compact and gapless range starting from %1.
-Optimizer::PassToken CreateCompactIdsPass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateCompactIdsPass();
 
 // Creates a remove duplicate capabilities pass.
-Optimizer::PassToken CreateRemoveDuplicatesPass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateRemoveDuplicatesPass();
 
 // Creates a CFG cleanup pass.
 // This pass removes cruft from the control flow graph of functions that are

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -82,12 +82,12 @@ class Optimizer {
   // Registers passes that attempt to improve performance of generated code.
   // This sequence of passes is subject to constant review and will change
   // from time to time.
-  Optimizer& RegisterPerformancePasses();
+  SPIRV_TOOLS_OPT_EXPORT Optimizer& RegisterPerformancePasses();
 
   // Registers passes that attempt to improve the size of generated code.
   // This sequence of passes is subject to constant review and will change
   // from time to time.
-  Optimizer& RegisterSizePasses();
+  SPIRV_TOOLS_OPT_EXPORT Optimizer& RegisterSizePasses();
 
   // Optimizes the given SPIR-V module |original_binary| and writes the
   // optimized binary into |optimized_binary|.
@@ -103,7 +103,7 @@ class Optimizer {
   // Returns a vector of strings with all the pass names added to this
   // optimizer's pass manager. These strings are valid until the associated
   // pass manager is destroyed.
-  std::vector<const char*> GetPassNames() const;
+  SPIRV_TOOLS_OPT_EXPORT std::vector<const char*> GetPassNames() const;
 
  private:
   struct Impl;                  // Opaque struct for holding internal data.
@@ -401,12 +401,12 @@ SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateRemoveDuplicatesPass();
 // following functionality:
 //
 // - Removal of unreachable basic blocks.
-Optimizer::PassToken CreateCFGCleanupPass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateCFGCleanupPass();
 
 // Create dead variable elimination pass.
 // This pass will delete module scope variables, along with their decorations,
 // that are not referenced.
-Optimizer::PassToken CreateDeadVariableEliminationPass();
+SPIRV_TOOLS_OPT_EXPORT Optimizer::PassToken CreateDeadVariableEliminationPass();
 
 }  // namespace spvtools
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -188,89 +188,61 @@ add_custom_target(spirv-tools-build-version
    DEPENDS ${SPIRV_TOOLS_BUILD_VERSION_INC})
 set_property(TARGET spirv-tools-build-version PROPERTY FOLDER "SPIRV-Tools build")
 
-add_subdirectory(comp)
-add_subdirectory(opt)
-add_subdirectory(link)
+add_library(${SPIRV_TOOLS} "")
 
-set(SPIRV_SOURCES
-  ${spirv-tools_SOURCE_DIR}/include/spirv-tools/libspirv.h
+include(GenerateExportHeader)
+generate_export_header(${SPIRV_TOOLS}
+  BASE_NAME spirv-tools)
 
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/bitutils.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/bit_stream.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/hex_float.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/parse_number.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/string_utils.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/assembly_grammar.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/binary.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/cfa.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/diagnostic.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/enum_set.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/enum_string_mapping.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/ext_inst.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/extensions.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/id_descriptor.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/instruction.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/macro.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/name_mapper.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/opcode.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/operand.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsed_operand.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/print.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/spirv_constant.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/spirv_definition.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/spirv_endian.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/spirv_target_env.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/spirv_validator_options.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/table.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/text.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/text_handler.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate.h
-
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/bit_stream.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/parse_number.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/util/string_utils.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/assembly_grammar.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/binary.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/diagnostic.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/disassemble.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/enum_string_mapping.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/ext_inst.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/extensions.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/id_descriptor.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/libspirv.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/message.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/name_mapper.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/opcode.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/operand.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/parsed_operand.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/print.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/software_version.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/spirv_endian.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/spirv_stats.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/spirv_target_env.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/spirv_validator_options.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/table.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/text.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/text_handler.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_arithmetics.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_bitwise.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_capability.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_cfg.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_conversion.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_datarules.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_decorations.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_id.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_instruction.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_layout.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_logicals.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_type_unique.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/val/decoration.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/val/basic_block.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/val/construct.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/val/function.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/val/instruction.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/val/validation_state.cpp)
+target_sources(${SPIRV_TOOLS}
+  PRIVATE
+    "${CMAKE_CURRENT_BINARY_DIR}/spirv-tools_export.h"
+    "${spirv-tools_SOURCE_DIR}/include/spirv-tools/libspirv.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/util/bit_stream.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/util/parse_number.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/util/string_utils.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/assembly_grammar.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/binary.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/diagnostic.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/disassemble.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/enum_string_mapping.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/ext_inst.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/extensions.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/id_descriptor.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/libspirv.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/message.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/name_mapper.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/opcode.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/operand.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/parsed_operand.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/print.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/software_version.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/spirv_endian.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/spirv_stats.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/spirv_target_env.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/spirv_validator_options.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/table.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/text.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/text_handler.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/validate.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/validate_arithmetics.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/validate_bitwise.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/validate_capability.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/validate_cfg.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/validate_conversion.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/validate_datarules.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/validate_decorations.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/validate_id.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/validate_instruction.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/validate_layout.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/validate_logicals.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/validate_type_unique.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/val/decoration.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/val/basic_block.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/val/construct.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/val/function.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/val/instruction.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/val/validation_state.cpp")
 
 # The software_version.cpp file includes build-version.inc.
 # Rebuild the software_version.cpp object file if it is older than
@@ -287,18 +259,32 @@ set_source_files_properties(
   ${CMAKE_CURRENT_SOURCE_DIR}/software_version.cpp
   PROPERTIES OBJECT_DEPENDS "${SPIRV_TOOLS_BUILD_VERSION_INC}")
 
-add_library(${SPIRV_TOOLS} ${SPIRV_SOURCES})
 spvtools_default_compile_options(${SPIRV_TOOLS})
 target_include_directories(${SPIRV_TOOLS}
-  PUBLIC ${spirv-tools_SOURCE_DIR}/include
-  PRIVATE ${spirv-tools_BINARY_DIR}
-  PRIVATE ${SPIRV_HEADER_INCLUDE_DIR}
-  )
+  PUBLIC
+    ${spirv-tools_SOURCE_DIR}/include
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  PRIVATE
+    ${spirv-tools_BINARY_DIR}
+    ${SPIRV_HEADER_INCLUDE_DIR}
+)
 set_property(TARGET ${SPIRV_TOOLS} PROPERTY FOLDER "SPIRV-Tools libraries")
+
+add_subdirectory(comp)
+add_subdirectory(opt)
+add_subdirectory(link)
 
 if(ENABLE_SPIRV_TOOLS_INSTALL)
   install(TARGETS ${SPIRV_TOOLS}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  )
+
+  install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/spirv-tools_export.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/spirv-tools
+  )
 endif(ENABLE_SPIRV_TOOLS_INSTALL)

--- a/source/assembly_grammar.h
+++ b/source/assembly_grammar.h
@@ -24,7 +24,7 @@ namespace libspirv {
 
 // Encapsulates the grammar to use for SPIR-V assembly.
 // Contains methods to query for valid instructions and operands.
-class AssemblyGrammar {
+class SPIRV_TOOLS_EXPORT AssemblyGrammar {
  public:
   explicit AssemblyGrammar(const spv_const_context context)
       : target_env_(context->target_env),

--- a/source/binary.h
+++ b/source/binary.h
@@ -23,7 +23,7 @@
 // Grabs the header from the SPIR-V module given in the binary parameter. The
 // endian parameter specifies the endianness of the binary module. On success,
 // returns SPV_SUCCESS and writes the parsed header into *header.
-spv_result_t spvBinaryHeaderGet(const spv_const_binary binary,
+SPIRV_TOOLS_EXPORT spv_result_t spvBinaryHeaderGet(const spv_const_binary binary,
                                 const spv_endianness_t endian,
                                 spv_header_t* header);
 
@@ -31,6 +31,6 @@ spv_result_t spvBinaryHeaderGet(const spv_const_binary binary,
 // character, or strsz if there is no null character.  Examines at most the
 // first strsz characters in str.  Returns 0 if str is nullptr.  This is a
 // replacement for C11's strnlen_s which might not exist in all environments.
-size_t spv_strnlen_s(const char* str, size_t strsz);
+SPIRV_TOOLS_EXPORT size_t spv_strnlen_s(const char* str, size_t strsz);
 
 #endif  // LIBSPIRV_BINARY_H_

--- a/source/comp/CMakeLists.txt
+++ b/source/comp/CMakeLists.txt
@@ -13,13 +13,26 @@
 # limitations under the License.
 
 if(SPIRV_BUILD_COMPRESSION)
-  add_library(SPIRV-Tools-comp markv_codec.cpp)
+  add_library(SPIRV-Tools-comp "")
+
+  include(GenerateExportHeader)
+  generate_export_header(SPIRV-Tools-comp)
+
+  target_sources(SPIRV-Tools-comp
+    PRIVATE
+      "markv_codec.cpp"
+      "${CMAKE_CURRENT_BINARY_DIR}/spirv-tools-comp_export.h"
+  )
 
   spvtools_default_compile_options(SPIRV-Tools-comp)
   target_include_directories(SPIRV-Tools-comp
-    PUBLIC ${spirv-tools_SOURCE_DIR}/include
-    PUBLIC ${SPIRV_HEADER_INCLUDE_DIR}
-    PRIVATE ${spirv-tools_BINARY_DIR}
+    PUBLIC
+      ${spirv-tools_SOURCE_DIR}/include
+      ${SPIRV_HEADER_INCLUDE_DIR}
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+    PRIVATE
+      ${spirv-tools_BINARY_DIR}
   )
 
   target_link_libraries(SPIRV-Tools-comp
@@ -31,7 +44,13 @@ if(SPIRV_BUILD_COMPRESSION)
     install(TARGETS SPIRV-Tools-comp
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    )
+
+    install(
+      FILES ${CMAKE_CURRENT_BINARY_DIR}/spirv-tools-comp_export.h
+      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/spirv-tools
+    )
   endif(ENABLE_SPIRV_TOOLS_INSTALL)
 
 endif(SPIRV_BUILD_COMPRESSION)

--- a/source/comp/markv.h
+++ b/source/comp/markv.h
@@ -27,6 +27,8 @@
 #include "markv_model.h"
 #include "spirv-tools/libspirv.hpp"
 
+#include "spirv-tools-comp_export.h"
+
 namespace spvtools {
 
 struct MarkvCodecOptions {
@@ -54,7 +56,7 @@ using MarkvLogConsumer = std::function<void(const std::string& snippet)>;
 // Encodes the given SPIR-V binary to MARK-V binary.
 // |log_consumer| is optional (pass MarkvLogConsumer() to disable).
 // |debug_consumer| is optional (pass MarkvDebugConsumer() to disable).
-spv_result_t SpirvToMarkv(spv_const_context context,
+SPIRV_TOOLS_COMP_EXPORT spv_result_t SpirvToMarkv(spv_const_context context,
                           const std::vector<uint32_t>& spirv,
                           const MarkvCodecOptions& options,
                           const MarkvModel& markv_model,
@@ -66,7 +68,7 @@ spv_result_t SpirvToMarkv(spv_const_context context,
 // Decodes a SPIR-V binary from the given MARK-V binary.
 // |log_consumer| is optional (pass MarkvLogConsumer() to disable).
 // |debug_consumer| is optional (pass MarkvDebugConsumer() to disable).
-spv_result_t MarkvToSpirv(spv_const_context context,
+SPIRV_TOOLS_COMP_EXPORT spv_result_t MarkvToSpirv(spv_const_context context,
                           const std::vector<uint8_t>& markv,
                           const MarkvCodecOptions& options,
                           const MarkvModel& markv_model,

--- a/source/diagnostic.h
+++ b/source/diagnostic.h
@@ -28,7 +28,7 @@ namespace libspirv {
 // emitted during the destructor.
 class DiagnosticStream {
  public:
-  DiagnosticStream(spv_position_t position,
+  SPIRV_TOOLS_EXPORT DiagnosticStream(spv_position_t position,
                    const spvtools::MessageConsumer& consumer,
                    spv_result_t error)
       : position_(position), consumer_(consumer), error_(error) {}
@@ -36,12 +36,12 @@ class DiagnosticStream {
   // Creates a DiagnosticStream from an expiring DiagnosticStream.
   // The new object takes the contents of the other, and prevents the
   // other from emitting anything during destruction.
-  DiagnosticStream(DiagnosticStream&& other);
+  SPIRV_TOOLS_EXPORT DiagnosticStream(DiagnosticStream&& other);
 
   // Destroys a DiagnosticStream.
   // If its status code is something other than SPV_FAILED_MATCH
   // then emit the accumulated message to the consumer.
-  ~DiagnosticStream();
+  SPIRV_TOOLS_EXPORT ~DiagnosticStream();
 
   // Adds the given value to the diagnostic message to be written.
   template <typename T>
@@ -65,10 +65,10 @@ class DiagnosticStream {
 //
 // This function expects that |diagnostic| is not nullptr and its content is a
 // nullptr.
-void UseDiagnosticAsMessageConsumer(spv_context context,
+SPIRV_TOOLS_EXPORT void UseDiagnosticAsMessageConsumer(spv_context context,
                                     spv_diagnostic* diagnostic);
 
-std::string spvResultToString(spv_result_t res);
+SPIRV_TOOLS_EXPORT std::string spvResultToString(spv_result_t res);
 
 }  // namespace libspirv
 

--- a/source/enum_string_mapping.h
+++ b/source/enum_string_mapping.h
@@ -24,13 +24,13 @@
 namespace libspirv {
 
 // Finds Extension enum corresponding to |str|. Returns false if not found.
-bool GetExtensionFromString(const std::string& str, Extension* extension);
+SPIRV_TOOLS_EXPORT bool GetExtensionFromString(const std::string& str, Extension* extension);
 
 // Returns text string corresponding to |extension|.
-std::string ExtensionToString(Extension extension);
+SPIRV_TOOLS_EXPORT std::string ExtensionToString(Extension extension);
 
 // Returns text string corresponding to |capability|.
-std::string CapabilityToString(SpvCapability capability);
+SPIRV_TOOLS_EXPORT std::string CapabilityToString(SpvCapability capability);
 
 }  // namespace libspirv
 

--- a/source/ext_inst.h
+++ b/source/ext_inst.h
@@ -19,12 +19,12 @@
 #include "table.h"
 
 // Gets the type of the extended instruction set with the specified name.
-spv_ext_inst_type_t spvExtInstImportTypeGet(const char* name);
+SPIRV_TOOLS_EXPORT spv_ext_inst_type_t spvExtInstImportTypeGet(const char* name);
 
 // Finds the named extented instruction of the given type in the given extended
 // instruction table. On success, returns SPV_SUCCESS and writes a handle of
 // the instruction entry into *entry.
-spv_result_t spvExtInstTableNameLookup(const spv_ext_inst_table table,
+SPIRV_TOOLS_EXPORT spv_result_t spvExtInstTableNameLookup(const spv_ext_inst_table table,
                                        const spv_ext_inst_type_t type,
                                        const char* name,
                                        spv_ext_inst_desc* entry);
@@ -32,7 +32,7 @@ spv_result_t spvExtInstTableNameLookup(const spv_ext_inst_table table,
 // Finds the extented instruction of the given type in the given extended
 // instruction table by value. On success, returns SPV_SUCCESS and writes a
 // handle of the instruction entry into *entry.
-spv_result_t spvExtInstTableValueLookup(const spv_ext_inst_table table,
+SPIRV_TOOLS_EXPORT spv_result_t spvExtInstTableValueLookup(const spv_ext_inst_table table,
                                         const spv_ext_inst_type_t type,
                                         const uint32_t value,
                                         spv_ext_inst_desc* pEntry);

--- a/source/extensions.h
+++ b/source/extensions.h
@@ -30,10 +30,10 @@ enum Extension {
 using ExtensionSet = EnumSet<Extension>;
 
 // Returns literal string operand of OpExtension instruction.
-std::string GetExtensionString(const spv_parsed_instruction_t* inst);
+SPIRV_TOOLS_EXPORT std::string GetExtensionString(const spv_parsed_instruction_t* inst);
 
 // Returns text string listing |extensions| separated by whitespace.
-std::string ExtensionSetToString(const ExtensionSet& extensions);
+SPIRV_TOOLS_EXPORT std::string ExtensionSetToString(const ExtensionSet& extensions);
 
 }  // namespace libspirv
 

--- a/source/id_descriptor.h
+++ b/source/id_descriptor.h
@@ -28,6 +28,7 @@ namespace libspirv {
 // were substituted with previously computed descriptors.
 class IdDescriptorCollection {
  public:
+  inline
   IdDescriptorCollection() {
     words_.reserve(16);
   }
@@ -36,9 +37,10 @@ class IdDescriptorCollection {
   // registers it in id_to_descriptor_. Returns the computed descriptor.
   // This function needs to be sequentially called for every instruction in the
   // module.
-  uint32_t ProcessInstruction(const spv_parsed_instruction_t& inst);
+  SPIRV_TOOLS_EXPORT uint32_t ProcessInstruction(const spv_parsed_instruction_t& inst);
 
   // Returns a previously computed descriptor id.
+  inline
   uint32_t GetDescriptor(uint32_t id) const {
     const auto it = id_to_descriptor_.find(id);
     if (it == id_to_descriptor_.end())

--- a/source/instruction.h
+++ b/source/instruction.h
@@ -42,7 +42,8 @@ struct spv_instruction_t {
 };
 
 // Appends a word to an instruction, without checking for overflow.
-inline void spvInstructionAddWord(spv_instruction_t* inst, uint32_t value) {
+inline
+void spvInstructionAddWord(spv_instruction_t* inst, uint32_t value) {
   inst->words.push_back(value);
 }
 

--- a/source/link/CMakeLists.txt
+++ b/source/link/CMakeLists.txt
@@ -11,15 +11,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(SPIRV-Tools-link
-  linker.cpp
+
+add_library(SPIRV-Tools-link "")
+
+include(GenerateExportHeader)
+generate_export_header(SPIRV-Tools-link)
+
+target_sources(SPIRV-Tools-link
+  PRIVATE
+    "${CMAKE_CURRENT_BINARY_DIR}/spirv-tools-link_export.h"
+    "linker.cpp"
 )
 
 spvtools_default_compile_options(SPIRV-Tools-link)
 target_include_directories(SPIRV-Tools-link
-  PUBLIC ${spirv-tools_SOURCE_DIR}/include
-  PUBLIC ${SPIRV_HEADER_INCLUDE_DIR}
-  PRIVATE ${spirv-tools_BINARY_DIR}
+  PUBLIC
+    ${spirv-tools_SOURCE_DIR}/include
+    ${SPIRV_HEADER_INCLUDE_DIR}
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  PRIVATE
+    ${spirv-tools_BINARY_DIR}
 )
 # We need the IR functionnalities from the optimizer
 target_link_libraries(SPIRV-Tools-link
@@ -31,5 +43,12 @@ if(ENABLE_SPIRV_TOOLS_INSTALL)
   install(TARGETS SPIRV-Tools-link
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  )
+
+  install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/spirv-tools-link_export.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/spirv-tools
+  )
 endif(ENABLE_SPIRV_TOOLS_INSTALL)

--- a/source/message.h
+++ b/source/message.h
@@ -24,7 +24,7 @@ namespace spvtools {
 // A helper function to compose and return a string from the message in the
 // following format:
 //   "<level>: <source>:<line>:<column>:<index>: <message>"
-std::string StringifyMessage(spv_message_level_t level, const char* source,
+SPIRV_TOOLS_EXPORT std::string StringifyMessage(spv_message_level_t level, const char* source,
                              const spv_position_t& position,
                              const char* message);
 

--- a/source/name_mapper.h
+++ b/source/name_mapper.h
@@ -63,11 +63,12 @@ class FriendlyNameMapper {
   // Construct a friendly name mapper, and determine friendly names for each
   // defined Id in the specified module.  The module is specified by the code
   // wordCount, and should be parseable in the specified context.
-  FriendlyNameMapper(const spv_const_context context, const uint32_t* code,
+  SPIRV_TOOLS_EXPORT FriendlyNameMapper(const spv_const_context context, const uint32_t* code,
                      const size_t wordCount);
 
   // Returns a NameMapper which maps ids to the friendly names parsed from the
   // module provided to the constructor.
+  inline
   NameMapper GetNameMapper() {
     return [this](uint32_t id) { return this->NameForId(id); };
   }
@@ -75,7 +76,7 @@ class FriendlyNameMapper {
   // Returns the friendly name for the given id.  If the module parsed during
   // construction is valid, then the mapping satisfies the rules for a
   // NameMapper.
-  std::string NameForId(uint32_t id);
+  SPIRV_TOOLS_EXPORT std::string NameForId(uint32_t id);
 
  private:
   // Transforms the given string so that it is acceptable as an Id name in

--- a/source/name_mapper.h
+++ b/source/name_mapper.h
@@ -31,7 +31,7 @@ namespace libspirv {
 using NameMapper = std::function<std::string(uint32_t)>;
 
 // Returns a NameMapper which always maps an Id to its decimal representation.
-NameMapper GetTrivialNameMapper();
+SPIRV_TOOLS_EXPORT NameMapper GetTrivialNameMapper();
 
 // A FriendlyNameMapper parses a module upon construction.  If the parse is
 // successful, then the NameForId method maps an Id to a friendly name

--- a/source/opcode.h
+++ b/source/opcode.h
@@ -26,23 +26,23 @@
 // word in the SPIR-V module header.
 //
 // See the registry at https://www.khronos.org/registry/spir-v/api/spir-v.xml.
-const char* spvGeneratorStr(uint32_t generator);
+SPIRV_TOOLS_EXPORT const char* spvGeneratorStr(uint32_t generator);
 
 // Combines word_count and opcode enumerant in single word.
-uint32_t spvOpcodeMake(uint16_t word_count, SpvOp opcode);
+SPIRV_TOOLS_EXPORT uint32_t spvOpcodeMake(uint16_t word_count, SpvOp opcode);
 
 // Splits word into into two constituent parts: word_count and opcode.
-void spvOpcodeSplit(const uint32_t word, uint16_t* word_count,
+SPIRV_TOOLS_EXPORT void spvOpcodeSplit(const uint32_t word, uint16_t* word_count,
                     uint16_t* opcode);
 
 // Finds the named opcode in the given opcode table. On success, returns
 // SPV_SUCCESS and writes a handle of the table entry into *entry.
-spv_result_t spvOpcodeTableNameLookup(const spv_opcode_table table,
+SPIRV_TOOLS_EXPORT spv_result_t spvOpcodeTableNameLookup(const spv_opcode_table table,
                                       const char* name, spv_opcode_desc* entry);
 
 // Finds the opcode by enumerant in the given opcode table. On success, returns
 // SPV_SUCCESS and writes a handle of the table entry into *entry.
-spv_result_t spvOpcodeTableValueLookup(const spv_opcode_table table,
+SPIRV_TOOLS_EXPORT spv_result_t spvOpcodeTableValueLookup(const spv_opcode_table table,
                                        const SpvOp opcode,
                                        spv_opcode_desc* entry);
 
@@ -50,41 +50,41 @@ spv_result_t spvOpcodeTableValueLookup(const spv_opcode_table table,
 // source instruction's stream/opcode/endianness is in the words/opcode/endian
 // parameter. The word_count parameter specifies the number of words to copy.
 // Writes copied instruction into *inst.
-void spvInstructionCopy(const uint32_t* words, const SpvOp opcode,
+SPIRV_TOOLS_EXPORT void spvInstructionCopy(const uint32_t* words, const SpvOp opcode,
                         const uint16_t word_count,
                         const spv_endianness_t endian, spv_instruction_t* inst);
 
 // Gets the name of an instruction, without the "Op" prefix.
-const char* spvOpcodeString(const SpvOp opcode);
+SPIRV_TOOLS_EXPORT const char* spvOpcodeString(const SpvOp opcode);
 
 // Determine if the given opcode is a scalar type. Returns zero if false,
 // non-zero otherwise.
-int32_t spvOpcodeIsScalarType(const SpvOp opcode);
+SPIRV_TOOLS_EXPORT int32_t spvOpcodeIsScalarType(const SpvOp opcode);
 
 // Determines if the given opcode is a constant. Returns zero if false, non-zero
 // otherwise.
-int32_t spvOpcodeIsConstant(const SpvOp opcode);
+SPIRV_TOOLS_EXPORT int32_t spvOpcodeIsConstant(const SpvOp opcode);
 
 // Returns true if the given opcode is a constant or undef.
-bool spvOpcodeIsConstantOrUndef(const SpvOp opcode);
+SPIRV_TOOLS_EXPORT bool spvOpcodeIsConstantOrUndef(const SpvOp opcode);
 
 // Returns true if the given opcode is a scalar specialization constant.
-bool spvOpcodeIsScalarSpecConstant(const SpvOp opcode);
+SPIRV_TOOLS_EXPORT bool spvOpcodeIsScalarSpecConstant(const SpvOp opcode);
 
 // Determines if the given opcode is a composite type. Returns zero if false,
 // non-zero otherwise.
-int32_t spvOpcodeIsComposite(const SpvOp opcode);
+SPIRV_TOOLS_EXPORT int32_t spvOpcodeIsComposite(const SpvOp opcode);
 
 // Determines if the given opcode results in a pointer when using the logical
 // addressing model. Returns zero if false, non-zero otherwise.
-int32_t spvOpcodeReturnsLogicalPointer(const SpvOp opcode);
+SPIRV_TOOLS_EXPORT int32_t spvOpcodeReturnsLogicalPointer(const SpvOp opcode);
 
 // Returns whether the given opcode could result in a pointer or a variable
 // pointer when using the logical addressing model.
-bool spvOpcodeReturnsLogicalVariablePointer(const SpvOp opcode);
+SPIRV_TOOLS_EXPORT bool spvOpcodeReturnsLogicalVariablePointer(const SpvOp opcode);
 
 // Determines if the given opcode generates a type. Returns zero if false,
 // non-zero otherwise.
-int32_t spvOpcodeGeneratesType(SpvOp opcode);
+SPIRV_TOOLS_EXPORT int32_t spvOpcodeGeneratesType(SpvOp opcode);
 
 #endif  // LIBSPIRV_OPCODE_H_

--- a/source/operand.h
+++ b/source/operand.h
@@ -38,7 +38,7 @@ using spv_operand_pattern_t = std::vector<spv_operand_type_t>;
 // Finds the named operand in the table. The type parameter specifies the
 // operand's group. A handle of the operand table entry for this operand will
 // be written into *entry.
-spv_result_t spvOperandTableNameLookup(const spv_operand_table table,
+SPIRV_TOOLS_EXPORT spv_result_t spvOperandTableNameLookup(const spv_operand_table table,
                                        const spv_operand_type_t type,
                                        const char* name,
                                        const size_t name_length,
@@ -47,31 +47,31 @@ spv_result_t spvOperandTableNameLookup(const spv_operand_table table,
 // Finds the operand with value in the table. The type parameter specifies the
 // operand's group. A handle of the operand table entry for this operand will
 // be written into *entry.
-spv_result_t spvOperandTableValueLookup(const spv_operand_table table,
+SPIRV_TOOLS_EXPORT spv_result_t spvOperandTableValueLookup(const spv_operand_table table,
                                         const spv_operand_type_t type,
                                         const uint32_t value,
                                         spv_operand_desc* entry);
 
 // Gets the name string of the non-variable operand type.
-const char* spvOperandTypeStr(spv_operand_type_t type);
+SPIRV_TOOLS_EXPORT const char* spvOperandTypeStr(spv_operand_type_t type);
 
 // Returns true if the given type is a concrete and also a mask.
-bool spvOperandIsConcreteMask(spv_operand_type_t type);
+SPIRV_TOOLS_EXPORT bool spvOperandIsConcreteMask(spv_operand_type_t type);
 
 // Returns true if an operand of the given type is optional.
-bool spvOperandIsOptional(spv_operand_type_t type);
+SPIRV_TOOLS_EXPORT bool spvOperandIsOptional(spv_operand_type_t type);
 
 // Returns true if an operand type represents zero or more logical operands.
 //
 // Note that a single logical operand may still be a variable number of words.
 // For example, a literal string may be many words, but is just one logical
 // operand.
-bool spvOperandIsVariable(spv_operand_type_t type);
+SPIRV_TOOLS_EXPORT bool spvOperandIsVariable(spv_operand_type_t type);
 
 // Append a list of operand types to the end of the pattern vector.
 // The types parameter specifies the source array of types, ending with
 // SPV_OPERAND_TYPE_NONE.
-void spvPushOperandTypes(const spv_operand_type_t* types,
+SPIRV_TOOLS_EXPORT void spvPushOperandTypes(const spv_operand_type_t* types,
                          spv_operand_pattern_t* pattern);
 
 // Appends the operands expected after the given typed mask onto the
@@ -82,7 +82,7 @@ void spvPushOperandTypes(const spv_operand_type_t* types,
 // appear after operands for a more significant bit.
 //
 // If a set bit is unknown, then we assume it has no operands.
-void spvPushOperandTypesForMask(const spv_operand_table operand_table,
+SPIRV_TOOLS_EXPORT void spvPushOperandTypesForMask(const spv_operand_table operand_table,
                                 const spv_operand_type_t mask_type,
                                 const uint32_t mask,
                                 spv_operand_pattern_t* pattern);
@@ -106,7 +106,7 @@ void spvPushOperandTypesForMask(const spv_operand_table operand_table,
 // non-optional.
 //
 // Returns true if we modified the pattern.
-bool spvExpandOperandSequenceOnce(spv_operand_type_t type,
+SPIRV_TOOLS_EXPORT bool spvExpandOperandSequenceOnce(spv_operand_type_t type,
                                   spv_operand_pattern_t* pattern);
 
 // Expands the first element in the pattern until it is a matchable operand
@@ -115,21 +115,21 @@ bool spvExpandOperandSequenceOnce(spv_operand_type_t type,
 //
 // A matchable operand type is anything other than a zero-or-more-items
 // operand type.
-spv_operand_type_t spvTakeFirstMatchableOperand(spv_operand_pattern_t* pattern);
+SPIRV_TOOLS_EXPORT spv_operand_type_t spvTakeFirstMatchableOperand(spv_operand_pattern_t* pattern);
 
 // Calculates the corresponding post-immediate alternate pattern, which allows
 // a limited set of operand types.
-spv_operand_pattern_t spvAlternatePatternFollowingImmediate(
+SPIRV_TOOLS_EXPORT spv_operand_pattern_t spvAlternatePatternFollowingImmediate(
     const spv_operand_pattern_t& pattern);
 
 // Is the operand an ID?
-bool spvIsIdType(spv_operand_type_t type);
+SPIRV_TOOLS_EXPORT bool spvIsIdType(spv_operand_type_t type);
 
 // Takes the opcode of an instruction and returns
 // a function object that will return true if the index
 // of the operand can be forward declared. This function will
 // used in the SSA validation stage of the pipeline
-std::function<bool(unsigned)> spvOperandCanBeForwardDeclaredFunction(
+SPIRV_TOOLS_EXPORT std::function<bool(unsigned)> spvOperandCanBeForwardDeclaredFunction(
     SpvOp opcode);
 
 #endif  // LIBSPIRV_OPERAND_H_

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -11,99 +11,112 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(SPIRV-Tools-opt
-  aggressive_dead_code_elim_pass.h
-  basic_block.h
-  block_merge_pass.h
-  build_module.h
-  cfg_cleanup_pass.h
-  common_uniform_elim_pass.h
-  compact_ids_pass.h
-  constants.h
-  dead_branch_elim_pass.h
-  dead_variable_elimination.h
-  decoration_manager.h
-  def_use_manager.h
-  eliminate_dead_constant_pass.h
-  flatten_decoration_pass.h
-  function.h
-  fold.h
-  fold_spec_constant_op_and_composite_pass.h
-  freeze_spec_constant_value_pass.h
-  inline_pass.h
-  inline_exhaustive_pass.h
-  inline_opaque_pass.h
-  insert_extract_elim.h
-  instruction.h
-  ir_loader.h
-  local_access_chain_convert_pass.h
-  local_single_block_elim_pass.h
-  local_single_store_elim_pass.h
-  local_ssa_elim_pass.h
-  log.h
-  module.h
-  null_pass.h
-  reflect.h
-  mem_pass.h
-  pass.h
-  passes.h
-  pass_manager.h
-  eliminate_dead_functions_pass.h
-  remove_duplicates_pass.h
-  set_spec_constant_default_value_pass.h
-  strength_reduction_pass.h
-  strip_debug_info_pass.h
-  types.h
-  type_manager.h
-  unify_const_pass.h
 
-  aggressive_dead_code_elim_pass.cpp
-  basic_block.cpp
-  block_merge_pass.cpp
-  build_module.cpp
-  cfg_cleanup_pass.cpp
-  common_uniform_elim_pass.cpp
-  compact_ids_pass.cpp
-  decoration_manager.cpp
-  def_use_manager.cpp
-  dead_branch_elim_pass.cpp
-  dead_variable_elimination.cpp
-  eliminate_dead_constant_pass.cpp
-  flatten_decoration_pass.cpp
-  fold.cpp
-  fold_spec_constant_op_and_composite_pass.cpp
-  freeze_spec_constant_value_pass.cpp
-  function.cpp
-  inline_pass.cpp
-  inline_exhaustive_pass.cpp
-  inline_opaque_pass.cpp
-  insert_extract_elim.cpp
-  instruction.cpp
-  ir_loader.cpp
-  local_access_chain_convert_pass.cpp
-  local_single_block_elim_pass.cpp
-  local_single_store_elim_pass.cpp
-  local_ssa_elim_pass.cpp
-  module.cpp
-  eliminate_dead_functions_pass.cpp
-  remove_duplicates_pass.cpp
-  set_spec_constant_default_value_pass.cpp
-  optimizer.cpp
-  mem_pass.cpp
-  pass.cpp
-  pass_manager.cpp
-  strength_reduction_pass.cpp
-  strip_debug_info_pass.cpp
-  types.cpp
-  type_manager.cpp
-  unify_const_pass.cpp
-  instruction_list.cpp)
+add_library(SPIRV-Tools-opt "")
+
+include(GenerateExportHeader)
+generate_export_header(SPIRV-Tools-opt)
+
+target_sources(SPIRV-Tools-opt
+  PRIVATE
+    "${CMAKE_CURRENT_BINARY_DIR}/spirv-tools-opt_export.h"
+    aggressive_dead_code_elim_pass.h
+    basic_block.h
+    block_merge_pass.h
+    build_module.h
+    cfg_cleanup_pass.h
+    common_uniform_elim_pass.h
+    compact_ids_pass.h
+    constants.h
+    dead_branch_elim_pass.h
+    dead_variable_elimination.h
+    decoration_manager.h
+    def_use_manager.h
+    eliminate_dead_constant_pass.h
+    flatten_decoration_pass.h
+    function.h
+    fold.h
+    fold_spec_constant_op_and_composite_pass.h
+    freeze_spec_constant_value_pass.h
+    inline_pass.h
+    inline_exhaustive_pass.h
+    inline_opaque_pass.h
+    insert_extract_elim.h
+    instruction.h
+    ir_loader.h
+    local_access_chain_convert_pass.h
+    local_single_block_elim_pass.h
+    local_single_store_elim_pass.h
+    local_ssa_elim_pass.h
+    log.h
+    module.h
+    null_pass.h
+    reflect.h
+    mem_pass.h
+    pass.h
+    passes.h
+    pass_manager.h
+    eliminate_dead_functions_pass.h
+    remove_duplicates_pass.h
+    set_spec_constant_default_value_pass.h
+    strength_reduction_pass.h
+    strip_debug_info_pass.h
+    types.h
+    type_manager.h
+    unify_const_pass.h
+
+    aggressive_dead_code_elim_pass.cpp
+    basic_block.cpp
+    block_merge_pass.cpp
+    build_module.cpp
+    cfg_cleanup_pass.cpp
+    common_uniform_elim_pass.cpp
+    compact_ids_pass.cpp
+    decoration_manager.cpp
+    def_use_manager.cpp
+    dead_branch_elim_pass.cpp
+    dead_variable_elimination.cpp
+    eliminate_dead_constant_pass.cpp
+    flatten_decoration_pass.cpp
+    fold.cpp
+    fold_spec_constant_op_and_composite_pass.cpp
+    freeze_spec_constant_value_pass.cpp
+    function.cpp
+    inline_pass.cpp
+    inline_exhaustive_pass.cpp
+    inline_opaque_pass.cpp
+    insert_extract_elim.cpp
+    instruction.cpp
+    ir_loader.cpp
+    local_access_chain_convert_pass.cpp
+    local_single_block_elim_pass.cpp
+    local_single_store_elim_pass.cpp
+    local_ssa_elim_pass.cpp
+    module.cpp
+    eliminate_dead_functions_pass.cpp
+    remove_duplicates_pass.cpp
+    set_spec_constant_default_value_pass.cpp
+    optimizer.cpp
+    mem_pass.cpp
+    pass.cpp
+    pass_manager.cpp
+    strength_reduction_pass.cpp
+    strip_debug_info_pass.cpp
+    types.cpp
+    type_manager.cpp
+    unify_const_pass.cpp
+    instruction_list.cpp
+)
 
 spvtools_default_compile_options(SPIRV-Tools-opt)
 target_include_directories(SPIRV-Tools-opt
-  PUBLIC ${spirv-tools_SOURCE_DIR}/include
-  PUBLIC ${SPIRV_HEADER_INCLUDE_DIR}
-  PRIVATE ${spirv-tools_BINARY_DIR}
+  PUBLIC
+    ${spirv-tools_SOURCE_DIR}/include
+    ${SPIRV_HEADER_INCLUDE_DIR}
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  PRIVATE
+    ${spirv-tools_BINARY_DIR}
 )
 # We need the assembling and disassembling functionalities in the main library.
 target_link_libraries(SPIRV-Tools-opt
@@ -115,6 +128,13 @@ if(ENABLE_SPIRV_TOOLS_INSTALL)
   install(TARGETS SPIRV-Tools-opt
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  )
+
+  install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/spirv-tools-opt_export.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/spirv-tools
+  )
 endif(ENABLE_SPIRV_TOOLS_INSTALL)
-    
+

--- a/source/opt/aggressive_dead_code_elim_pass.h
+++ b/source/opt/aggressive_dead_code_elim_pass.h
@@ -41,9 +41,9 @@ class AggressiveDCEPass : public MemPass {
    using GetBlocksFunction =
      std::function<std::vector<ir::BasicBlock*>*(const ir::BasicBlock*)>;
 
-  AggressiveDCEPass();
-  const char* name() const override { return "eliminate-dead-code-aggressive"; }
-  Status Process(ir::Module*) override;
+  SPIRV_TOOLS_OPT_EXPORT AggressiveDCEPass();
+  inline const char* name() const override { return "eliminate-dead-code-aggressive"; }
+  SPIRV_TOOLS_OPT_EXPORT Status Process(ir::Module*) override;
 
  private:
   // Return true if |varId| is variable of |storageClass|.
@@ -88,7 +88,7 @@ class AggressiveDCEPass : public MemPass {
   // and block terminating instructions as live. Recursively mark the values
   // they use. When complete, delete any non-live instructions. Return true
   // if the function has been modified.
-  // 
+  //
   // Note: This function does not delete useless control structures. All
   // existing control structures will remain. This can leave not-insignificant
   // sequences of ultimately useless code.

--- a/source/opt/block_merge_pass.h
+++ b/source/opt/block_merge_pass.h
@@ -35,9 +35,9 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class BlockMergePass : public Pass {
  public:
-  BlockMergePass();
-  const char* name() const override { return "merge-blocks"; }
-  Status Process(ir::Module*) override;
+  SPIRV_TOOLS_OPT_EXPORT BlockMergePass();
+  inline const char* name() const override { return "merge-blocks"; }
+  SPIRV_TOOLS_OPT_EXPORT Status Process(ir::Module*) override;
 
  private:
   // Return true if |labId| has multiple refs. Do not count OpName.

--- a/source/opt/build_module.h
+++ b/source/opt/build_module.h
@@ -21,20 +21,22 @@
 #include "module.h"
 #include "spirv-tools/libspirv.hpp"
 
+#include "spirv-tools-opt_export.h"
+
 namespace spvtools {
 
 // Builds and returns an ir::Module from the given SPIR-V |binary|. |size|
 // specifies number of words in |binary|. The |binary| will be decoded
 // according to the given target |env|. Returns nullptr if erors occur and
 // sends the errors to |consumer|.
-std::unique_ptr<ir::Module> BuildModule(
+SPIRV_TOOLS_OPT_EXPORT std::unique_ptr<ir::Module> BuildModule(
     spv_target_env env, MessageConsumer consumer, const uint32_t* binary,
     size_t size);
 
 // Builds and returns an ir::Module from the given SPIR-V assembly |text|.
 // The |text| will be encoded according to the given target |env|. Returns
 // nullptr if erors occur and sends the errors to |consumer|.
-std::unique_ptr<ir::Module> BuildModule(
+SPIRV_TOOLS_OPT_EXPORT std::unique_ptr<ir::Module> BuildModule(
     spv_target_env env, MessageConsumer consumer, const std::string& text,
     uint32_t assemble_options = SpirvTools::kDefaultAssembleOption);
 

--- a/source/opt/common_uniform_elim_pass.h
+++ b/source/opt/common_uniform_elim_pass.h
@@ -41,9 +41,9 @@ class CommonUniformElimPass : public Pass {
    using GetBlocksFunction =
      std::function<std::vector<ir::BasicBlock*>*(const ir::BasicBlock*)>;
 
-  CommonUniformElimPass();
-  const char* name() const override { return "eliminate-common-uniform"; }
-  Status Process(ir::Module*) override;
+  SPIRV_TOOLS_OPT_EXPORT CommonUniformElimPass();
+  inline const char* name() const override { return "eliminate-common-uniform"; }
+  SPIRV_TOOLS_OPT_EXPORT Status Process(ir::Module*) override;
 
  private:
   // Returns true if |opcode| is a non-ptr access chain op
@@ -149,11 +149,11 @@ class CommonUniformElimPass : public Pass {
   bool CommonExtractElimination(ir::Function* func);
 
   // For function |func|, first change all uniform constant index
-  // access chain loads into equivalent composite extracts. Then consolidate 
+  // access chain loads into equivalent composite extracts. Then consolidate
   // identical uniform loads into one uniform load. Finally, consolidate
   // identical uniform extracts into one uniform extract. This may require
   // moving a load or extract to a point which dominates all uses.
-  // Return true if func is modified. 
+  // Return true if func is modified.
   //
   // This pass requires the function to have structured control flow ie shader
   // capability. It also requires logical addressing ie Addresses capability

--- a/source/opt/compact_ids_pass.h
+++ b/source/opt/compact_ids_pass.h
@@ -24,8 +24,8 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class CompactIdsPass : public Pass {
  public:
-  const char* name() const override { return "compact-ids"; }
-  Status Process(ir::Module*) override;
+  inline const char* name() const override { return "compact-ids"; }
+  SPIRV_TOOLS_OPT_EXPORT Status Process(ir::Module*) override;
 };
 
 }  // namespace opt

--- a/source/opt/dead_branch_elim_pass.h
+++ b/source/opt/dead_branch_elim_pass.h
@@ -42,9 +42,9 @@ class DeadBranchElimPass : public MemPass {
    using GetBlocksFunction =
      std::function<std::vector<ir::BasicBlock*>*(const ir::BasicBlock*)>;
 
-  DeadBranchElimPass();
-  const char* name() const override { return "eliminate-dead-branches"; }
-  Status Process(ir::Module*) override;
+  SPIRV_TOOLS_OPT_EXPORT DeadBranchElimPass();
+  inline const char* name() const override { return "eliminate-dead-branches"; }
+  SPIRV_TOOLS_OPT_EXPORT Status Process(ir::Module*) override;
 
  private:
   // If |condId| is boolean constant, return conditional value in |condVal| and
@@ -71,7 +71,7 @@ class DeadBranchElimPass : public MemPass {
 
   // If block |bp| contains conditional branch or switch preceeded by an
   // OpSelctionMerge, return true and return branch and merge instructions
-  // in |branchInst| and |mergeInst| and the conditional id in |condId|. 
+  // in |branchInst| and |mergeInst| and the conditional id in |condId|.
   bool GetSelectionBranch(ir::BasicBlock* bp, ir::Instruction** branchInst,
     ir::Instruction** mergeInst, uint32_t *condId);
 

--- a/source/opt/decoration_manager.h
+++ b/source/opt/decoration_manager.h
@@ -22,6 +22,8 @@
 #include "instruction.h"
 #include "module.h"
 
+#include "spirv-tools-opt_export.h"
+
 namespace spvtools {
 namespace opt {
 namespace analysis {
@@ -30,25 +32,25 @@ namespace analysis {
 class DecorationManager {
  public:
   // Constructs a decoration manager from the given |module|
-  DecorationManager(ir::Module* module) { AnalyzeDecorations(module); }
+  inline DecorationManager(ir::Module* module) { AnalyzeDecorations(module); }
   // Removes all decorations from |id|, which should not be a group ID, except
   // for linkage decorations if |keep_linkage| is set.
-  void RemoveDecorationsFrom(uint32_t id, bool keep_linkage);
+  SPIRV_TOOLS_OPT_EXPORT void RemoveDecorationsFrom(uint32_t id, bool keep_linkage);
   // Returns a vector of all decorations affecting |id|. If a group is applied
   // to |id|, the decorations of that group are returned rather than the group
   // decoration instruction. If |include_linkage| is not set, linkage
   // decorations won't be returned.
-  std::vector<ir::Instruction*> GetDecorationsFor(uint32_t id,
+  SPIRV_TOOLS_OPT_EXPORT std::vector<ir::Instruction*> GetDecorationsFor(uint32_t id,
                                                   bool include_linkage);
-  std::vector<const ir::Instruction*> GetDecorationsFor(
+  SPIRV_TOOLS_OPT_EXPORT std::vector<const ir::Instruction*> GetDecorationsFor(
       uint32_t id, bool include_linkage) const;
   // Returns whether two IDs have the same decorations. Two SpvOpGroupDecorate
   // instructions that apply the same decorations but to different IDs, still
   // count as being the same.
-  bool HaveTheSameDecorations(uint32_t id1, uint32_t id2) const;
+  SPIRV_TOOLS_OPT_EXPORT bool HaveTheSameDecorations(uint32_t id1, uint32_t id2) const;
   // Returns whether two decorations are the same. SpvOpDecorateId is currently
   // not handled and will return false no matter what.
-  bool AreDecorationsTheSame(const ir::Instruction* inst1,
+  SPIRV_TOOLS_OPT_EXPORT bool AreDecorationsTheSame(const ir::Instruction* inst1,
                              const ir::Instruction* inst2) const;
 
   // |f| is run on each decoration instruction for |id| with decoration
@@ -61,7 +63,7 @@ class DecorationManager {
       std::unordered_map<uint32_t, std::vector<ir::Instruction*>>;
   // Analyzes the defs and uses in the given |module| and populates data
   // structures in this class. Does nothing if |module| is nullptr.
-  void AnalyzeDecorations(ir::Module* module);
+  SPIRV_TOOLS_OPT_EXPORT void AnalyzeDecorations(ir::Module* module);
 
   template <typename T>
   std::vector<T> InternalGetDecorationsFor(uint32_t id, bool include_linkage);

--- a/source/opt/def_use_manager.h
+++ b/source/opt/def_use_manager.h
@@ -23,6 +23,8 @@
 #include "module.h"
 #include "spirv-tools/libspirv.hpp"
 
+#include "spirv-tools-opt_export.h"
+
 namespace spvtools {
 namespace opt {
 namespace analysis {
@@ -49,59 +51,59 @@ class DefUseManager {
   // will be communicated to the outside via the given message |consumer|. This
   // instance only keeps a reference to the |consumer|, so the |consumer| should
   // outlive this instance.
-  DefUseManager(const MessageConsumer& consumer, ir::Module* module)
+  inline DefUseManager(const MessageConsumer& consumer, ir::Module* module)
       : consumer_(consumer) {
     AnalyzeDefUse(module);
   }
 
-  DefUseManager(const DefUseManager&) = delete;
-  DefUseManager(DefUseManager&&) = delete;
-  DefUseManager& operator=(const DefUseManager&) = delete;
-  DefUseManager& operator=(DefUseManager&&) = delete;
+  SPIRV_TOOLS_OPT_EXPORT DefUseManager(const DefUseManager&) = delete;
+  SPIRV_TOOLS_OPT_EXPORT DefUseManager(DefUseManager&&) = delete;
+  SPIRV_TOOLS_OPT_EXPORT DefUseManager& operator=(const DefUseManager&) = delete;
+  SPIRV_TOOLS_OPT_EXPORT DefUseManager& operator=(DefUseManager&&) = delete;
 
   // Analyzes the defs in the given |inst|.
-  void AnalyzeInstDef(ir::Instruction* inst);
+  SPIRV_TOOLS_OPT_EXPORT void AnalyzeInstDef(ir::Instruction* inst);
 
   // Analyzes the uses in the given |inst|.
-  void AnalyzeInstUse(ir::Instruction* inst);
+  SPIRV_TOOLS_OPT_EXPORT void AnalyzeInstUse(ir::Instruction* inst);
 
   // Analyzes the defs and uses in the given |inst|.
-  void AnalyzeInstDefUse(ir::Instruction* inst);
+  SPIRV_TOOLS_OPT_EXPORT void AnalyzeInstDefUse(ir::Instruction* inst);
 
   // Returns the def instruction for the given |id|. If there is no instruction
   // defining |id|, returns nullptr.
-  ir::Instruction* GetDef(uint32_t id);
-  const ir::Instruction* GetDef(uint32_t id) const;
+  SPIRV_TOOLS_OPT_EXPORT ir::Instruction* GetDef(uint32_t id);
+  SPIRV_TOOLS_OPT_EXPORT const ir::Instruction* GetDef(uint32_t id) const;
   // Returns the use instructions for the given |id|. If there is no uses of
   // |id|, returns nullptr.
-  UseList* GetUses(uint32_t id);
-  const UseList* GetUses(uint32_t id) const;
+  SPIRV_TOOLS_OPT_EXPORT UseList* GetUses(uint32_t id);
+  SPIRV_TOOLS_OPT_EXPORT const UseList* GetUses(uint32_t id) const;
   // Returns the annotation instrunctions which are a direct use of the given
   // |id|. This means when the decorations are applied through decoration
   // group(s), this function will just return the OpGroupDecorate
   // instrcution(s) which refer to the given id as an operand. The OpDecorate
   // instructions which decorate the decoration group will not be returned.
-  std::vector<ir::Instruction*> GetAnnotations(uint32_t id) const;
+  SPIRV_TOOLS_OPT_EXPORT std::vector<ir::Instruction*> GetAnnotations(uint32_t id) const;
 
   // Returns the map from ids to their def instructions.
-  const IdToDefMap& id_to_defs() const { return id_to_def_; }
+  inline const IdToDefMap& id_to_defs() const { return id_to_def_; }
   // Returns the map from ids to their uses in instructions.
-  const IdToUsesMap& id_to_uses() const { return id_to_uses_; }
+  inline const IdToUsesMap& id_to_uses() const { return id_to_uses_; }
 
   // Turns the instruction defining the given |id| into a Nop. Returns true on
   // success, false if the given |id| is not defined at all. This method also
   // erases both the uses of |id| and the information of this |id|-generating
   // instruction's uses of its operands.
-  bool KillDef(uint32_t id);
+  SPIRV_TOOLS_OPT_EXPORT bool KillDef(uint32_t id);
   // Turns the given instruction |inst| to a Nop. This method erases the
   // information of the given instruction's uses of its operands. If |inst|
   // defines an result id, the uses of the result id will also be erased.
-  void KillInst(ir::Instruction* inst);
+  SPIRV_TOOLS_OPT_EXPORT void KillInst(ir::Instruction* inst);
   // Replaces all uses of |before| id with |after| id. Returns true if any
   // replacement happens. This method does not kill the definition of the
   // |before| id. If |after| is the same as |before|, does nothing and returns
   // false.
-  bool ReplaceAllUsesWith(uint32_t before, uint32_t after);
+  SPIRV_TOOLS_OPT_EXPORT bool ReplaceAllUsesWith(uint32_t before, uint32_t after);
 
  private:
   using InstToUsedIdsMap =
@@ -109,7 +111,7 @@ class DefUseManager {
 
   // Analyzes the defs and uses in the given |module| and populates data
   // structures in this class. Does nothing if |module| is nullptr.
-  void AnalyzeDefUse(ir::Module* module);
+  SPIRV_TOOLS_OPT_EXPORT void AnalyzeDefUse(ir::Module* module);
 
   // Clear the internal def-use record of the given instruction |inst|. This
   // method will update the use information of the operand ids of |inst|. The

--- a/source/opt/eliminate_dead_constant_pass.h
+++ b/source/opt/eliminate_dead_constant_pass.h
@@ -24,8 +24,8 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class EliminateDeadConstantPass : public Pass {
  public:
-  const char* name() const override { return "eliminate-dead-const"; }
-  Status Process(ir::Module*) override;
+  inline const char* name() const override { return "eliminate-dead-const"; }
+  SPIRV_TOOLS_OPT_EXPORT Status Process(ir::Module*) override;
 };
 
 }  // namespace opt

--- a/source/opt/eliminate_dead_functions_pass.h
+++ b/source/opt/eliminate_dead_functions_pass.h
@@ -26,8 +26,8 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class EliminateDeadFunctionsPass : public MemPass {
  public:
-  const char* name() const override { return "eliminate-dead-functions"; }
-  Status Process(ir::Module*) override;
+  inline const char* name() const override { return "eliminate-dead-functions"; }
+  SPIRV_TOOLS_OPT_EXPORT Status Process(ir::Module*) override;
 
  private:
   void EliminateFunction(ir::Function* func);

--- a/source/opt/flatten_decoration_pass.h
+++ b/source/opt/flatten_decoration_pass.h
@@ -24,8 +24,8 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class FlattenDecorationPass : public Pass {
  public:
-  const char* name() const override { return "flatten-decoration"; }
-  Status Process(ir::Module*) override;
+  inline const char* name() const override { return "flatten-decoration"; }
+  SPIRV_TOOLS_OPT_EXPORT Status Process(ir::Module*) override;
 };
 
 }  // namespace opt

--- a/source/opt/fold_spec_constant_op_and_composite_pass.h
+++ b/source/opt/fold_spec_constant_op_and_composite_pass.h
@@ -31,11 +31,11 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class FoldSpecConstantOpAndCompositePass : public Pass {
  public:
-  FoldSpecConstantOpAndCompositePass();
+  SPIRV_TOOLS_OPT_EXPORT FoldSpecConstantOpAndCompositePass();
 
-  const char* name() const override { return "fold-spec-const-op-composite"; }
+  inline const char* name() const override { return "fold-spec-const-op-composite"; }
 
-  Status Process(ir::Module* module) override;
+  SPIRV_TOOLS_OPT_EXPORT Status Process(ir::Module* module) override;
 
  private:
   // Initializes the type manager, def-use manager and get the maximal id used

--- a/source/opt/freeze_spec_constant_value_pass.h
+++ b/source/opt/freeze_spec_constant_value_pass.h
@@ -24,8 +24,8 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class FreezeSpecConstantValuePass : public Pass {
  public:
-  const char* name() const override { return "freeze-spec-const"; }
-  Status Process(ir::Module*) override;
+  inline const char* name() const override { return "freeze-spec-const"; }
+  SPIRV_TOOLS_OPT_EXPORT Status Process(ir::Module*) override;
 };
 
 }  // namespace opt

--- a/source/opt/function.h
+++ b/source/opt/function.h
@@ -24,6 +24,8 @@
 #include "instruction.h"
 #include "iterator.h"
 
+#include "spirv-tools-opt_export.h"
+
 namespace spvtools {
 namespace ir {
 
@@ -42,13 +44,13 @@ class Function {
   //
   // The parent module will default to null and needs to be explicitly set by
   // the user.
-  explicit Function(const Function& f);
+  SPIRV_TOOLS_OPT_EXPORT explicit Function(const Function& f);
   // The OpFunction instruction that begins the definition of this function.
-  Instruction& DefInst() { return *def_inst_; }
-  const Instruction& DefInst() const { return *def_inst_; }
+  inline Instruction& DefInst() { return *def_inst_; }
+  inline const Instruction& DefInst() const { return *def_inst_; }
 
   // Sets the enclosing module for this function.
-  void SetParent(Module* module) { module_ = module; }
+  inline void SetParent(Module* module) { module_ = module; }
   // Appends a parameter to this function.
   inline void AddParameter(std::unique_ptr<Instruction> p);
   // Appends a basic block to this function.
@@ -71,27 +73,27 @@ class Function {
   inline uint32_t type_id() const { return def_inst_->type_id(); }
 
   // Returns the entry basic block for this function.
-  const std::unique_ptr<BasicBlock>& entry() const { return blocks_.front(); }
+  inline const std::unique_ptr<BasicBlock>& entry() const { return blocks_.front(); }
 
-  iterator begin() { return iterator(&blocks_, blocks_.begin()); }
-  iterator end() { return iterator(&blocks_, blocks_.end()); }
-  const_iterator cbegin() const {
+  inline iterator begin() { return iterator(&blocks_, blocks_.begin()); }
+  inline iterator end() { return iterator(&blocks_, blocks_.end()); }
+  inline const_iterator cbegin() const {
     return const_iterator(&blocks_, blocks_.cbegin());
   }
-  const_iterator cend() const {
+  inline const_iterator cend() const {
     return const_iterator(&blocks_, blocks_.cend());
   }
 
   // Runs the given function |f| on each instruction in this function, and
   // optionally on debug line instructions that might precede them.
-  void ForEachInst(const std::function<void(Instruction*)>& f,
+  SPIRV_TOOLS_OPT_EXPORT void ForEachInst(const std::function<void(Instruction*)>& f,
                    bool run_on_debug_line_insts = false);
-  void ForEachInst(const std::function<void(const Instruction*)>& f,
+  SPIRV_TOOLS_OPT_EXPORT void ForEachInst(const std::function<void(const Instruction*)>& f,
                    bool run_on_debug_line_insts = false) const;
 
   // Runs the given function |f| on each parameter instruction in this function,
   // and optionally on debug line instructions that might precede them.
-  void ForEachParam(const std::function<void(const Instruction*)>& f,
+  SPIRV_TOOLS_OPT_EXPORT void ForEachParam(const std::function<void(const Instruction*)>& f,
                     bool run_on_debug_line_insts = false) const;
 
  private:

--- a/source/opt/inline_exhaustive_pass.h
+++ b/source/opt/inline_exhaustive_pass.h
@@ -34,10 +34,10 @@ namespace opt {
 class InlineExhaustivePass : public InlinePass {
 
  public:
-  InlineExhaustivePass();
-  Status Process(ir::Module*) override;
+  SPIRV_TOOLS_OPT_EXPORT InlineExhaustivePass();
+  SPIRV_TOOLS_OPT_EXPORT Status Process(ir::Module*) override;
 
-  const char* name() const override { return "inline-entry-points-exhaustive"; }
+  inline const char* name() const override { return "inline-entry-points-exhaustive"; }
 
  private:
   // Exhaustively inline all function calls in func as well as in

--- a/source/opt/inline_opaque_pass.h
+++ b/source/opt/inline_opaque_pass.h
@@ -34,10 +34,10 @@ namespace opt {
 class InlineOpaquePass : public InlinePass {
 
  public:
-  InlineOpaquePass();
-  Status Process(ir::Module*) override;
+  SPIRV_TOOLS_OPT_EXPORT InlineOpaquePass();
+  SPIRV_TOOLS_OPT_EXPORT Status Process(ir::Module*) override;
 
-  const char* name() const override { return "inline-entry-points-opaque"; }
+  inline const char* name() const override { return "inline-entry-points-opaque"; }
 
  private:
   // Return true if |typeId| is or contains opaque type

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -39,69 +39,69 @@ class InlinePass : public Pass {
    using GetBlocksFunction =
      std::function<std::vector<ir::BasicBlock*>*(const ir::BasicBlock*)>;
 
-  InlinePass();
-  virtual ~InlinePass() = default;
+  SPIRV_TOOLS_OPT_EXPORT InlinePass();
+  SPIRV_TOOLS_OPT_EXPORT virtual ~InlinePass() = default;
 
  protected:
   // Find pointer to type and storage in module, return its resultId,
   // 0 if not found. TODO(greg-lunarg): Move this into type manager.
-  uint32_t FindPointerToType(uint32_t type_id, SpvStorageClass storage_class);
+  SPIRV_TOOLS_OPT_EXPORT uint32_t FindPointerToType(uint32_t type_id, SpvStorageClass storage_class);
 
   // Add pointer to type to module and return resultId.
-  uint32_t AddPointerToType(uint32_t type_id, SpvStorageClass storage_class);
+  SPIRV_TOOLS_OPT_EXPORT uint32_t AddPointerToType(uint32_t type_id, SpvStorageClass storage_class);
 
   // Add unconditional branch to labelId to end of block block_ptr.
-  void AddBranch(uint32_t labelId, std::unique_ptr<ir::BasicBlock>* block_ptr);
+  SPIRV_TOOLS_OPT_EXPORT void AddBranch(uint32_t labelId, std::unique_ptr<ir::BasicBlock>* block_ptr);
 
   // Add conditional branch to end of block |block_ptr|.
-  void AddBranchCond(uint32_t cond_id, uint32_t true_id,
+  SPIRV_TOOLS_OPT_EXPORT void AddBranchCond(uint32_t cond_id, uint32_t true_id,
     uint32_t false_id, std::unique_ptr<ir::BasicBlock>* block_ptr);
 
   // Add unconditional branch to labelId to end of block block_ptr.
-  void AddLoopMerge(uint32_t merge_id, uint32_t continue_id,
+  SPIRV_TOOLS_OPT_EXPORT void AddLoopMerge(uint32_t merge_id, uint32_t continue_id,
                     std::unique_ptr<ir::BasicBlock>* block_ptr);
 
   // Add store of valId to ptrId to end of block block_ptr.
-  void AddStore(uint32_t ptrId, uint32_t valId,
+  SPIRV_TOOLS_OPT_EXPORT void AddStore(uint32_t ptrId, uint32_t valId,
                 std::unique_ptr<ir::BasicBlock>* block_ptr);
 
   // Add load of ptrId into resultId to end of block block_ptr.
-  void AddLoad(uint32_t typeId, uint32_t resultId, uint32_t ptrId,
+  SPIRV_TOOLS_OPT_EXPORT void AddLoad(uint32_t typeId, uint32_t resultId, uint32_t ptrId,
                std::unique_ptr<ir::BasicBlock>* block_ptr);
 
   // Return new label.
-  std::unique_ptr<ir::Instruction> NewLabel(uint32_t label_id);
+  SPIRV_TOOLS_OPT_EXPORT std::unique_ptr<ir::Instruction> NewLabel(uint32_t label_id);
 
   // Returns the id for the boolean false value. Looks in the module first
   // and creates it if not found. Remembers it for future calls.
-  uint32_t GetFalseId();
+  SPIRV_TOOLS_OPT_EXPORT uint32_t GetFalseId();
 
   // Map callee params to caller args
-  void MapParams(ir::Function* calleeFn,
+  SPIRV_TOOLS_OPT_EXPORT void MapParams(ir::Function* calleeFn,
                  ir::BasicBlock::iterator call_inst_itr,
                  std::unordered_map<uint32_t, uint32_t>* callee2caller);
 
   // Clone and map callee locals
-  void CloneAndMapLocals(
+  SPIRV_TOOLS_OPT_EXPORT void CloneAndMapLocals(
       ir::Function* calleeFn,
       std::vector<std::unique_ptr<ir::Instruction>>* new_vars,
       std::unordered_map<uint32_t, uint32_t>* callee2caller);
 
   // Create return variable for callee clone code if needed. Return id
   // if created, otherwise 0.
-  uint32_t CreateReturnVar(
+  SPIRV_TOOLS_OPT_EXPORT uint32_t CreateReturnVar(
       ir::Function* calleeFn,
       std::vector<std::unique_ptr<ir::Instruction>>* new_vars);
 
   // Return true if instruction must be in the same block that its result
   // is used.
-  bool IsSameBlockOp(const ir::Instruction* inst) const;
+  SPIRV_TOOLS_OPT_EXPORT bool IsSameBlockOp(const ir::Instruction* inst) const;
 
   // Clone operands which must be in same block as consumer instructions.
   // Look in preCallSB for instructions that need cloning. Look in
   // postCallSB for instructions already cloned. Add cloned instruction
   // to postCallSB.
-  void CloneSameBlockOps(
+  SPIRV_TOOLS_OPT_EXPORT void CloneSameBlockOps(
       std::unique_ptr<ir::Instruction>* inst,
       std::unordered_map<uint32_t, uint32_t>* postCallSB,
       std::unordered_map<uint32_t, ir::Instruction*>* preCallSB,
@@ -121,47 +121,47 @@ class InlinePass : public Pass {
   // Also return in new_vars additional OpVariable instructions required by
   // and to be inserted into the caller function after the block at
   // call_block_itr is replaced with new_blocks.
-  void GenInlineCode(std::vector<std::unique_ptr<ir::BasicBlock>>* new_blocks,
+  SPIRV_TOOLS_OPT_EXPORT void GenInlineCode(std::vector<std::unique_ptr<ir::BasicBlock>>* new_blocks,
                      std::vector<std::unique_ptr<ir::Instruction>>* new_vars,
                      ir::BasicBlock::iterator call_inst_itr,
                      ir::UptrVectorIterator<ir::BasicBlock> call_block_itr);
 
   // Return true if |inst| is a function call that can be inlined.
-  bool IsInlinableFunctionCall(const ir::Instruction* inst);
+  SPIRV_TOOLS_OPT_EXPORT bool IsInlinableFunctionCall(const ir::Instruction* inst);
 
   // Compute structured successors for function |func|.
   // A block's structured successors are the blocks it branches to
   // together with its declared merge block if it has one.
   // When order matters, the merge block always appears first.
-  // This assures correct depth first search in the presence of early 
+  // This assures correct depth first search in the presence of early
   // returns and kills. If the successor vector contain duplicates
   // if the merge block, they are safely ignored by DFS.
-  void ComputeStructuredSuccessors(ir::Function* func);
-  
+  SPIRV_TOOLS_OPT_EXPORT void ComputeStructuredSuccessors(ir::Function* func);
+
   // Return function to return ordered structure successors for a given block
   // Assumes ComputeStructuredSuccessors() has been called.
-  GetBlocksFunction StructuredSuccessorsFunction();
+  SPIRV_TOOLS_OPT_EXPORT GetBlocksFunction StructuredSuccessorsFunction();
 
   // Return true if |func| has multiple returns
-  bool HasMultipleReturns(ir::Function* func);
+  SPIRV_TOOLS_OPT_EXPORT bool HasMultipleReturns(ir::Function* func);
 
   // Return true if |func| has no return in a loop. The current analysis
   // requires structured control flow, so return false if control flow not
   // structured ie. module is not a shader.
-  bool HasNoReturnInLoop(ir::Function* func);
+  SPIRV_TOOLS_OPT_EXPORT bool HasNoReturnInLoop(ir::Function* func);
 
   // Find all functions with multiple returns and no returns in loops
-  void AnalyzeReturns(ir::Function* func);
+  SPIRV_TOOLS_OPT_EXPORT void AnalyzeReturns(ir::Function* func);
 
   // Return true if |func| is a function that can be inlined.
-  bool IsInlinableFunction(ir::Function* func);
+  SPIRV_TOOLS_OPT_EXPORT bool IsInlinableFunction(ir::Function* func);
 
   // Update phis in succeeding blocks to point to new last block
-  void UpdateSucceedingPhis(
+  SPIRV_TOOLS_OPT_EXPORT void UpdateSucceedingPhis(
       std::vector<std::unique_ptr<ir::BasicBlock>>& new_blocks);
 
   // Initialize state for optimization of |module|
-  void InitializeInline(ir::Module* module);
+  SPIRV_TOOLS_OPT_EXPORT void InitializeInline(ir::Module* module);
 
   // Map from function's result id to function.
   std::unordered_map<uint32_t, ir::Function*> id2function_;

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -26,6 +26,8 @@
 #include "spirv-tools/libspirv.h"
 #include "spirv/1.2/spirv.h"
 
+#include "spirv-tools-opt_export.h"
+
 namespace spvtools {
 namespace ir {
 
@@ -51,15 +53,16 @@ class InstructionList;
 // A *logical* operand to a SPIR-V instruction. It can be the type id, result
 // id, or other additional operands carried in an instruction.
 struct Operand {
-  Operand(spv_operand_type_t t, std::vector<uint32_t>&& w)
+  SPIRV_TOOLS_OPT_EXPORT Operand(spv_operand_type_t t, std::vector<uint32_t>&& w)
       : type(t), words(std::move(w)) {}
 
-  Operand(spv_operand_type_t t, const std::vector<uint32_t>& w)
+  SPIRV_TOOLS_OPT_EXPORT Operand(spv_operand_type_t t, const std::vector<uint32_t>& w)
       : type(t), words(w) {}
 
   spv_operand_type_t type;      // Type of this logical operand.
   std::vector<uint32_t> words;  // Binary segments of this logical operand.
 
+  inline
   friend bool operator==(const Operand& o1, const Operand& o2) {
     return o1.type == o2.type && o1.words == o2.words;
   }
@@ -83,14 +86,14 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   using const_iterator = std::vector<Operand>::const_iterator;
 
   // Creates a default OpNop instruction.
-  Instruction()
+  inline Instruction()
       : utils::IntrusiveNodeBase<Instruction>(),
         opcode_(SpvOpNop),
         type_id_(0),
         result_id_(0) {}
   // Creates an instruction with the given opcode |op| and no additional logical
   // operands.
-  Instruction(SpvOp op)
+  inline Instruction(SpvOp op)
       : utils::IntrusiveNodeBase<Instruction>(),
         opcode_(op),
         type_id_(0),
@@ -99,21 +102,21 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   // the data inside |inst| will be copied and owned in this instance. And keep
   // record of line-related debug instructions |dbg_line| ahead of this
   // instruction, if any.
-  Instruction(const spv_parsed_instruction_t& inst,
+  SPIRV_TOOLS_OPT_EXPORT Instruction(const spv_parsed_instruction_t& inst,
               std::vector<Instruction>&& dbg_line = {});
 
   // Creates an instruction with the given opcode |op|, type id: |ty_id|,
   // result id: |res_id| and input operands: |in_operands|.
-  Instruction(SpvOp op, uint32_t ty_id, uint32_t res_id,
+  SPIRV_TOOLS_OPT_EXPORT Instruction(SpvOp op, uint32_t ty_id, uint32_t res_id,
               const std::vector<Operand>& in_operands);
 
   // TODO: I will want to remove these, but will first have to remove the use of
   // std::vector<Instruction>.
-  Instruction(const Instruction&) = default;
-  Instruction& operator=(const Instruction&) = default;
+  SPIRV_TOOLS_OPT_EXPORT Instruction(const Instruction&) = default;
+  SPIRV_TOOLS_OPT_EXPORT Instruction& operator=(const Instruction&) = default;
 
-  Instruction(Instruction&&);
-  Instruction& operator=(Instruction&&);
+  SPIRV_TOOLS_OPT_EXPORT Instruction(Instruction&&);
+  SPIRV_TOOLS_OPT_EXPORT Instruction& operator=(Instruction&&);
 
   virtual ~Instruction() = default;
 
@@ -122,19 +125,20 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   // It is the responsibility of the caller to make sure that the storage is
   // removed. It is the caller's responsibility to make sure that there is only
   // one instruction for each result id.
-  Instruction* Clone() const;
+  SPIRV_TOOLS_OPT_EXPORT Instruction* Clone() const;
 
-  SpvOp opcode() const { return opcode_; }
+  inline SpvOp opcode() const { return opcode_; }
   // Sets the opcode of this instruction to a specific opcode. Note this may
   // invalidate the instruction.
   // TODO(qining): Remove this function when instruction building and insertion
   // is well implemented.
-  void SetOpcode(SpvOp op) { opcode_ = op; }
-  uint32_t type_id() const { return type_id_; }
-  uint32_t result_id() const { return result_id_; }
+  inline void SetOpcode(SpvOp op) { opcode_ = op; }
+  inline uint32_t type_id() const { return type_id_; }
+  inline uint32_t result_id() const { return result_id_; }
   // Returns the vector of line-related debug instructions attached to this
   // instruction and the caller can directly modify them.
-  std::vector<Instruction>& dbg_line_insts() { return dbg_line_insts_; }
+  inline std::vector<Instruction>& dbg_line_insts() { return dbg_line_insts_; }
+  inline
   const std::vector<Instruction>& dbg_line_insts() const {
     return dbg_line_insts_;
   }
@@ -145,19 +149,21 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   // inline void InsertAfter(Instruction* pos);
 
   // Begin and end iterators for operands.
-  iterator begin() { return operands_.begin(); }
-  iterator end() { return operands_.end(); }
-  const_iterator begin() const { return operands_.cbegin(); }
-  const_iterator end() const { return operands_.cend(); }
+  inline iterator begin() { return operands_.begin(); }
+  inline iterator end() { return operands_.end(); }
+  inline const_iterator begin() const { return operands_.cbegin(); }
+  inline const_iterator end() const { return operands_.cend(); }
   // Const begin and end iterators for operands.
-  const_iterator cbegin() const { return operands_.cbegin(); }
-  const_iterator cend() const { return operands_.cend(); }
+  inline const_iterator cbegin() const { return operands_.cbegin(); }
+  inline const_iterator cend() const { return operands_.cend(); }
 
   // Gets the number of logical operands.
+  inline
   uint32_t NumOperands() const {
     return static_cast<uint32_t>(operands_.size());
   }
   // Gets the number of SPIR-V words occupied by all logical operands.
+  inline
   uint32_t NumOperandWords() const {
     return NumInOperandWords() + TypeResultIdCount();
   }
@@ -166,7 +172,7 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   // Gets the |index|-th logical operand as a single SPIR-V word. This method is
   // not expected to be used with logical operands consisting of multiple SPIR-V
   // words.
-  uint32_t GetSingleWordOperand(uint32_t index) const;
+  SPIRV_TOOLS_OPT_EXPORT uint32_t GetSingleWordOperand(uint32_t index) const;
   // Sets the |index|-th in-operand's data to the given |data|.
   inline void SetInOperand(uint32_t index, std::vector<uint32_t>&& data);
   // Sets the result type id.
@@ -174,21 +180,31 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   // Sets the result id
   inline void SetResultId(uint32_t res_id);
   // Remove the |index|-th operand
+  inline
   void RemoveOperand(uint32_t index) {
     operands_.erase(operands_.begin() + index);
   }
 
   // The following methods are similar to the above, but are for in operands.
+
+  inline
   uint32_t NumInOperands() const {
     return static_cast<uint32_t>(operands_.size() - TypeResultIdCount());
   }
-  uint32_t NumInOperandWords() const;
+
+  SPIRV_TOOLS_OPT_EXPORT uint32_t NumInOperandWords() const;
+
+  inline
   const Operand& GetInOperand(uint32_t index) const {
     return GetOperand(index + TypeResultIdCount());
   }
+
+  inline
   uint32_t GetSingleWordInOperand(uint32_t index) const {
     return GetSingleWordOperand(index + TypeResultIdCount());
   }
+
+  inline
   void RemoveInOperand(uint32_t index) {
     operands_.erase(operands_.begin() + index + TypeResultIdCount());
   }
@@ -226,7 +242,7 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   inline bool HasLabels() const;
 
   // Pushes the binary segments for this instruction into the back of *|binary|.
-  void ToBinaryWithoutAttachedDebugInsts(std::vector<uint32_t>* binary) const;
+  SPIRV_TOOLS_OPT_EXPORT void ToBinaryWithoutAttachedDebugInsts(std::vector<uint32_t>* binary) const;
 
   // Replaces the operands to the instruction with |new_operands|. The caller
   // is responsible for building a complete and valid list of operands for

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -36,9 +36,9 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class LocalAccessChainConvertPass : public MemPass {
  public:
-  LocalAccessChainConvertPass();
-  const char* name() const override { return "convert-local-access-chains"; }
-  Status Process(ir::Module*) override;
+  SPIRV_TOOLS_OPT_EXPORT LocalAccessChainConvertPass();
+  inline const char* name() const override { return "convert-local-access-chains"; }
+  SPIRV_TOOLS_OPT_EXPORT Status Process(ir::Module*) override;
 
   using ProcessFunction = std::function<bool(ir::Function*)>;
 
@@ -90,7 +90,7 @@ class LocalAccessChainConvertPass : public MemPass {
   // Return true if all indices of access chain |acp| are OpConstant integers
   bool IsConstantIndexAccessChain(const ir::Instruction* acp) const;
 
-  // Identify all function scope variables of target type which are 
+  // Identify all function scope variables of target type which are
   // accessed only with loads, stores and access chains with constant
   // indices. Convert all loads and stores of such variables into equivalent
   // loads, stores, extracts and inserts. This unifies access to these

--- a/source/opt/local_single_block_elim_pass.h
+++ b/source/opt/local_single_block_elim_pass.h
@@ -36,9 +36,9 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class LocalSingleBlockLoadStoreElimPass : public MemPass {
  public:
-  LocalSingleBlockLoadStoreElimPass();
-  const char* name() const override { return "eliminate-local-single-block"; }
-  Status Process(ir::Module*) override;
+  SPIRV_TOOLS_OPT_EXPORT LocalSingleBlockLoadStoreElimPass();
+  inline const char* name() const override { return "eliminate-local-single-block"; }
+  SPIRV_TOOLS_OPT_EXPORT Status Process(ir::Module*) override;
 
  private:
   // Return true if all uses of |varId| are only through supported reference

--- a/source/opt/local_single_store_elim_pass.h
+++ b/source/opt/local_single_store_elim_pass.h
@@ -30,6 +30,8 @@
 #include "module.h"
 #include "mem_pass.h"
 
+#include "spirv-tools-opt_export.h"
+
 namespace spvtools {
 namespace opt {
 
@@ -38,9 +40,9 @@ class LocalSingleStoreElimPass : public MemPass {
   using cbb_ptr = const ir::BasicBlock*;
 
  public:
-  LocalSingleStoreElimPass();
-  const char* name() const override { return "eliminate-local-single-store"; }
-  Status Process(ir::Module*) override;
+  SPIRV_TOOLS_OPT_EXPORT LocalSingleStoreElimPass();
+  inline const char* name() const override { return "eliminate-local-single-store"; }
+  SPIRV_TOOLS_OPT_EXPORT Status Process(ir::Module*) override;
 
  private:
   // Return true if all refs through |ptrId| are only loads or stores and
@@ -69,7 +71,7 @@ class LocalSingleStoreElimPass : public MemPass {
   // Calculate immediate dominators for |func|'s CFG. Leaves result
   // in idom_. Entries for augmented CFG (pseudo blocks) are not created.
   void CalculateImmediateDominators(ir::Function* func);
-  
+
   // Return true if instruction in |blk0| at ordinal position |idx0|
   // dominates instruction in |blk1| at position |idx1|.
   bool Dominates(ir::BasicBlock* blk0, uint32_t idx0,

--- a/source/opt/local_ssa_elim_pass.h
+++ b/source/opt/local_ssa_elim_pass.h
@@ -30,6 +30,8 @@
 #include "module.h"
 #include "mem_pass.h"
 
+#include "spirv-tools-opt_export.h"
+
 namespace spvtools {
 namespace opt {
 
@@ -41,9 +43,9 @@ class LocalMultiStoreElimPass : public MemPass {
    using GetBlocksFunction =
      std::function<std::vector<ir::BasicBlock*>*(const ir::BasicBlock*)>;
 
-  LocalMultiStoreElimPass();
-  const char* name() const override { return "eliminate-local-multi-store"; }
-  Status Process(ir::Module*) override;
+  SPIRV_TOOLS_OPT_EXPORT LocalMultiStoreElimPass();
+  inline const char* name() const override { return "eliminate-local-multi-store"; }
+  SPIRV_TOOLS_OPT_EXPORT Status Process(ir::Module*) override;
 
  private:
   // Initialize extensions whitelist

--- a/source/opt/module.h
+++ b/source/opt/module.h
@@ -24,6 +24,8 @@
 #include "instruction.h"
 #include "iterator.h"
 
+#include "spirv-tools-opt_export.h"
+
 namespace spvtools {
 namespace ir {
 
@@ -46,14 +48,14 @@ class Module {
   using const_inst_iterator = InstructionList::const_iterator;
 
   // Creates an empty module with zero'd header.
-  Module() : header_({}) {}
+  inline Module() : header_({}) {}
 
   // Sets the header to the given |header|.
-  void SetHeader(const ModuleHeader& header) { header_ = header; }
+  inline void SetHeader(const ModuleHeader& header) { header_ = header; }
   // Sets the Id bound.
-  void SetIdBound(uint32_t bound) { header_.bound = bound; }
+  inline void SetIdBound(uint32_t bound) { header_.bound = bound; }
   // Returns the Id bound.
-  uint32_t IdBound() { return header_.bound; }
+  inline uint32_t IdBound() { return header_.bound; }
   // Appends a capability instruction to this module.
   inline void AddCapability(std::unique_ptr<Instruction> c);
   // Appends an extension instruction to this module.
@@ -88,18 +90,18 @@ class Module {
 
   // Returns a vector of pointers to type-declaration instructions in this
   // module.
-  std::vector<Instruction*> GetTypes();
-  std::vector<const Instruction*> GetTypes() const;
+  SPIRV_TOOLS_OPT_EXPORT std::vector<Instruction*> GetTypes();
+  SPIRV_TOOLS_OPT_EXPORT std::vector<const Instruction*> GetTypes() const;
   // Returns a vector of pointers to constant-creation instructions in this
   // module.
-  std::vector<Instruction*> GetConstants();
-  std::vector<const Instruction*> GetConstants() const;
+  SPIRV_TOOLS_OPT_EXPORT std::vector<Instruction*> GetConstants();
+  SPIRV_TOOLS_OPT_EXPORT std::vector<const Instruction*> GetConstants() const;
 
   // Return result id of global value with |opcode|, 0 if not present.
-  uint32_t GetGlobalValue(SpvOp opcode) const;
+  SPIRV_TOOLS_OPT_EXPORT uint32_t GetGlobalValue(SpvOp opcode) const;
 
   // Add global value with |opcode|, |result_id| and |type_id|
-  void AddGlobalValue(SpvOp opcode, uint32_t result_id, uint32_t type_id);
+  SPIRV_TOOLS_OPT_EXPORT void AddGlobalValue(SpvOp opcode, uint32_t result_id, uint32_t type_id);
 
   inline uint32_t id_bound() const { return header_.bound; }
 
@@ -163,32 +165,32 @@ class Module {
   inline IteratorRange<const_inst_iterator> execution_modes() const;
 
   // Clears all debug instructions (excluding OpLine & OpNoLine).
-  void debug_clear() {
+  inline void debug_clear() {
     debug1_clear();
     debug2_clear();
     debug3_clear();
   }
 
   // Clears all debug 1 instructions (excluding OpLine & OpNoLine).
-  void debug1_clear() { debugs1_.clear(); }
+  inline void debug1_clear() { debugs1_.clear(); }
 
   // Clears all debug 2 instructions (excluding OpLine & OpNoLine).
-  void debug2_clear() { debugs2_.clear(); }
+  inline void debug2_clear() { debugs2_.clear(); }
 
   // Clears all debug 3 instructions (excluding OpLine & OpNoLine).
-  void debug3_clear() { debugs3_.clear(); }
+  inline void debug3_clear() { debugs3_.clear(); }
 
   // Iterators for annotation instructions contained in this module.
   inline inst_iterator annotation_begin();
   inline inst_iterator annotation_end();
-  IteratorRange<inst_iterator> annotations();
-  IteratorRange<const_inst_iterator> annotations() const;
+  inline IteratorRange<inst_iterator> annotations();
+  inline IteratorRange<const_inst_iterator> annotations() const;
 
   // Iterators for extension instructions contained in this module.
   inline inst_iterator extension_begin();
   inline inst_iterator extension_end();
-  IteratorRange<inst_iterator> extensions();
-  IteratorRange<const_inst_iterator> extensions() const;
+  inline IteratorRange<inst_iterator> extensions();
+  inline IteratorRange<const_inst_iterator> extensions() const;
 
   // Iterators for types, constants and global variables instructions.
   inline inst_iterator types_values_begin();
@@ -197,31 +199,31 @@ class Module {
   inline IteratorRange<const_inst_iterator> types_values() const;
 
   // Iterators for functions contained in this module.
-  iterator begin() { return iterator(&functions_, functions_.begin()); }
-  iterator end() { return iterator(&functions_, functions_.end()); }
+  inline iterator begin() { return iterator(&functions_, functions_.begin()); }
+  inline iterator end() { return iterator(&functions_, functions_.end()); }
   inline const_iterator cbegin() const;
   inline const_iterator cend() const;
 
   // Invokes function |f| on all instructions in this module, and optionally on
   // the debug line instructions that precede them.
-  void ForEachInst(const std::function<void(Instruction*)>& f,
+  SPIRV_TOOLS_OPT_EXPORT void ForEachInst(const std::function<void(Instruction*)>& f,
                    bool run_on_debug_line_insts = false);
-  void ForEachInst(const std::function<void(const Instruction*)>& f,
+  SPIRV_TOOLS_OPT_EXPORT void ForEachInst(const std::function<void(const Instruction*)>& f,
                    bool run_on_debug_line_insts = false) const;
 
   // Pushes the binary segments for this instruction into the back of *|binary|.
   // If |skip_nop| is true and this is a OpNop, do nothing.
-  void ToBinary(std::vector<uint32_t>* binary, bool skip_nop) const;
+  SPIRV_TOOLS_OPT_EXPORT void ToBinary(std::vector<uint32_t>* binary, bool skip_nop) const;
 
   // Returns 1 more than the maximum Id value mentioned in the module.
-  uint32_t ComputeIdBound() const;
+  SPIRV_TOOLS_OPT_EXPORT uint32_t ComputeIdBound() const;
 
   // Returns true if module has capability |cap|
-  bool HasCapability(uint32_t cap);
+  SPIRV_TOOLS_OPT_EXPORT bool HasCapability(uint32_t cap);
 
   // Returns id for OpExtInst instruction for extension |extstr|.
   // Returns 0 if not found.
-  uint32_t GetExtInstImportId(const char* extstr);
+  SPIRV_TOOLS_OPT_EXPORT uint32_t GetExtInstImportId(const char* extstr);
 
  private:
   ModuleHeader header_;  // Module header

--- a/source/opt/pass.h
+++ b/source/opt/pass.h
@@ -28,6 +28,8 @@
 #include "spirv-tools/libspirv.hpp"
 #include "basic_block.h"
 
+#include "spirv-tools-opt_export.h"
+
 namespace spvtools {
 namespace opt {
 
@@ -52,10 +54,10 @@ class Pass {
   // The constructed instance will have an empty message consumer, which just
   // ignores all messages from the library. Use SetMessageConsumer() to supply
   // one if messages are of concern.
-  Pass();
+  SPIRV_TOOLS_OPT_EXPORT Pass();
 
   // Destructs the pass.
-  virtual ~Pass() = default;
+  SPIRV_TOOLS_OPT_EXPORT virtual ~Pass() = default;
 
   // Returns a descriptive name for this pass.
   //
@@ -63,42 +65,42 @@ class Pass {
   // compatible with the corresponding spirv-opt command-line flag. For example,
   // if you add the flag --my-pass to spirv-opt, make this function return
   // "my-pass" (no leading hyphens).
-  virtual const char* name() const = 0;
+  SPIRV_TOOLS_OPT_EXPORT virtual const char* name() const = 0;
 
   // Sets the message consumer to the given |consumer|. |consumer| which will be
   // invoked every time there is a message to be communicated to the outside.
-  void SetMessageConsumer(MessageConsumer c) { consumer_ = std::move(c); }
+  inline void SetMessageConsumer(MessageConsumer c) { consumer_ = std::move(c); }
 
   // Returns the reference to the message consumer for this pass.
-  const MessageConsumer& consumer() const { return consumer_; }
+  inline const MessageConsumer& consumer() const { return consumer_; }
 
   // Returns the def-use manager used for this pass. TODO(dnovillo): This should
   // be handled by the pass manager.
-  analysis::DefUseManager* get_def_use_mgr() const {
+  inline analysis::DefUseManager* get_def_use_mgr() const {
     return def_use_mgr_.get();
   }
 
   // Returns a pointer to the current module for this pass.
-  ir::Module* get_module() const { return module_; }
+  inline ir::Module* get_module() const { return module_; }
 
   // Add to |todo| all ids of functions called in |func|.
-  void AddCalls(ir::Function* func, std::queue<uint32_t>* todo);
+  SPIRV_TOOLS_OPT_EXPORT void AddCalls(ir::Function* func, std::queue<uint32_t>* todo);
 
   // Applies |pfn| to every function in the call trees that are rooted at the
   // entry points.  Returns true if any call |pfn| returns true.  By convention
   // |pfn| should return true if it modified the module.
-  bool ProcessEntryPointCallTree(ProcessFunction& pfn, ir::Module* module);
+  SPIRV_TOOLS_OPT_EXPORT bool ProcessEntryPointCallTree(ProcessFunction& pfn, ir::Module* module);
 
   // Applies |pfn| to every function in the call trees rooted at the entry
   // points and exported functions.  Returns true if any call |pfn| returns
   // true.  By convention |pfn| should return true if it modified the module.
-  bool ProcessReachableCallTree(ProcessFunction& pfn, ir::Module* module);
+  SPIRV_TOOLS_OPT_EXPORT bool ProcessReachableCallTree(ProcessFunction& pfn, ir::Module* module);
 
   // Applies |pfn| to every function in the call trees rooted at the elements of
   // |roots|.  Returns true if any call to |pfn| returns true.  By convention
   // |pfn| should return true if it modified the module.  After returning
   // |roots| will be empty.
-  bool ProcessCallTreeFromRoots(
+  SPIRV_TOOLS_OPT_EXPORT bool ProcessCallTreeFromRoots(
       ProcessFunction& pfn,
       const std::unordered_map<uint32_t, ir::Function*>& id2function,
       std::queue<uint32_t>* roots);
@@ -106,13 +108,14 @@ class Pass {
   // Processes the given |module|. Returns Status::Failure if errors occur when
   // processing. Returns the corresponding Status::Success if processing is
   // succesful to indicate whether changes are made to the module.
-  virtual Status Process(ir::Module* module) = 0;
+  SPIRV_TOOLS_OPT_EXPORT virtual Status Process(ir::Module* module) = 0;
 
  protected:
   // Initialize basic data structures for the pass. This sets up the def-use
   // manager, module and other attributes. TODO(dnovillo): Some of this should
   // be done during pass instantiation. Other things should be outside the pass
   // altogether (e.g., def-use manager).
+  inline
   void InitializeProcessing(ir::Module* module) {
     module_ = module;
     next_id_ = module_->IdBound();
@@ -129,7 +132,7 @@ class Pass {
 
   // Return true if |block_ptr| points to a loop header block. TODO(dnovillo)
   // This belongs in a CFG class.
-  bool IsLoopHeader(ir::BasicBlock* block_ptr) const;
+  SPIRV_TOOLS_OPT_EXPORT bool IsLoopHeader(ir::BasicBlock* block_ptr) const;
 
   // Compute structured successors for function |func|. A block's structured
   // successors are the blocks it branches to together with its declared merge
@@ -138,17 +141,17 @@ class Pass {
   // returns and kills. If the successor vector contain duplicates if the merge
   // block, they are safely ignored by DFS. TODO(dnovillo): This belongs in a
   // CFG class.
-  void ComputeStructuredSuccessors(ir::Function* func);
+  SPIRV_TOOLS_OPT_EXPORT void ComputeStructuredSuccessors(ir::Function* func);
 
   // Compute structured block order for |func| into |structuredOrder|. This
   // order has the property that dominators come before all blocks they
   // dominate and merge blocks come after all blocks that are in the control
   // constructs of their header. TODO(dnovillo): This belongs in a CFG class.
-  void ComputeStructuredOrder(ir::Function* func,
+  SPIRV_TOOLS_OPT_EXPORT void ComputeStructuredOrder(ir::Function* func,
                               std::list<ir::BasicBlock*>* order);
 
   // Return type id for |ptrInst|'s pointee
-  uint32_t GetPointeeTypeId(const ir::Instruction* ptrInst) const;
+  SPIRV_TOOLS_OPT_EXPORT uint32_t GetPointeeTypeId(const ir::Instruction* ptrInst) const;
 
   // Return the next available Id and increment it.
   inline uint32_t TakeNextId() { return next_id_++; }
@@ -161,7 +164,7 @@ class Pass {
 
   // Returns the id of the merge block declared by a merge instruction in this
   // block, if any.  If none, returns zero.
-  uint32_t MergeBlockIdIfAny(const ir::BasicBlock& blk, uint32_t* cbid);
+  SPIRV_TOOLS_OPT_EXPORT uint32_t MergeBlockIdIfAny(const ir::BasicBlock& blk, uint32_t* cbid);
 
   // Map from block to its structured successor blocks. See
   // ComputeStructuredSuccessors() for definition.

--- a/source/opt/pass_manager.h
+++ b/source/opt/pass_manager.h
@@ -24,6 +24,8 @@
 
 #include "spirv-tools/libspirv.hpp"
 
+#include "spirv-tools-opt_export.h"
+
 namespace spvtools {
 namespace opt {
 
@@ -37,13 +39,13 @@ class PassManager {
   // The constructed instance will have an empty message consumer, which just
   // ignores all messages from the library. Use SetMessageConsumer() to supply
   // one if messages are of concern.
-  PassManager() : consumer_(nullptr) {}
+  inline PassManager() : consumer_(nullptr) {}
 
   // Sets the message consumer to the given |consumer|.
-  void SetMessageConsumer(MessageConsumer c) { consumer_ = std::move(c); }
+  inline void SetMessageConsumer(MessageConsumer c) { consumer_ = std::move(c); }
 
   // Adds an externally constructed pass.
-  void AddPass(std::unique_ptr<Pass> pass);
+  SPIRV_TOOLS_OPT_EXPORT void AddPass(std::unique_ptr<Pass> pass);
   // Uses the argument |args| to construct a pass instance of type |T|, and adds
   // the pass instance to this pass manger. The pass added will use this pass
   // manager's message consumer.
@@ -51,7 +53,7 @@ class PassManager {
   void AddPass(Args&&... args);
 
   // Returns the number of passes added.
-  uint32_t NumPasses() const;
+  SPIRV_TOOLS_OPT_EXPORT uint32_t NumPasses() const;
   // Returns a pointer to the |index|th pass added.
   inline Pass* GetPass(uint32_t index) const;
 
@@ -65,7 +67,7 @@ class PassManager {
   // whether changes are made to the module.
   //
   // After running all the passes, they are removed from the list.
-  Pass::Status Run(ir::Module* module);
+  SPIRV_TOOLS_OPT_EXPORT Pass::Status Run(ir::Module* module);
 
  private:
   // Consumer for messages.
@@ -79,7 +81,7 @@ inline void PassManager::AddPass(std::unique_ptr<Pass> pass) {
 }
 
 template <typename T, typename... Args>
-inline void PassManager::AddPass(Args&&... args) {
+void PassManager::AddPass(Args&&... args) {
   passes_.emplace_back(new T(std::forward<Args>(args)...));
   passes_.back()->SetMessageConsumer(consumer_);
 }

--- a/source/opt/remove_duplicates_pass.h
+++ b/source/opt/remove_duplicates_pass.h
@@ -31,10 +31,10 @@ using IdDecorationsList =
 // See optimizer.hpp for documentation.
 class RemoveDuplicatesPass : public Pass {
  public:
-  const char* name() const override { return "remove-duplicates"; }
-  Status Process(ir::Module*) override;
+  inline const char* name() const override { return "remove-duplicates"; }
+  SPIRV_TOOLS_OPT_EXPORT Status Process(ir::Module*) override;
   // Returns whether two types are equal, and have the same decorations.
-  static bool AreTypesEqual(const ir::Instruction& inst1,
+  SPIRV_TOOLS_OPT_EXPORT static bool AreTypesEqual(const ir::Instruction& inst1,
                             const ir::Instruction& inst2,
                             const analysis::DefUseManager& defUseManager,
                             const analysis::DecorationManager& decoManager);

--- a/source/opt/set_spec_constant_default_value_pass.h
+++ b/source/opt/set_spec_constant_default_value_pass.h
@@ -35,22 +35,22 @@ class SetSpecConstantDefaultValuePass : public Pass {
 
   // Constructs a pass instance with a map from spec ids to default values
   // in the form of string.
-  explicit SetSpecConstantDefaultValuePass(
+  inline explicit SetSpecConstantDefaultValuePass(
       const SpecIdToValueStrMap& default_values)
       : spec_id_to_value_str_(default_values), spec_id_to_value_bit_pattern_() {}
-  explicit SetSpecConstantDefaultValuePass(SpecIdToValueStrMap&& default_values)
+  inline explicit SetSpecConstantDefaultValuePass(SpecIdToValueStrMap&& default_values)
       : spec_id_to_value_str_(std::move(default_values)), spec_id_to_value_bit_pattern_() {}
 
   // Constructs a pass instance with a map from spec ids to default values in
   // the form of bit pattern.
-  explicit SetSpecConstantDefaultValuePass(
+  inline explicit SetSpecConstantDefaultValuePass(
       const SpecIdToValueBitPatternMap& default_values)
       : spec_id_to_value_str_(), spec_id_to_value_bit_pattern_(default_values) {}
-  explicit SetSpecConstantDefaultValuePass(SpecIdToValueBitPatternMap&& default_values)
+  inline explicit SetSpecConstantDefaultValuePass(SpecIdToValueBitPatternMap&& default_values)
       : spec_id_to_value_str_(), spec_id_to_value_bit_pattern_(std::move(default_values)) {}
 
-  const char* name() const override { return "set-spec-const-default-value"; }
-  Status Process(ir::Module*) override;
+  inline const char* name() const override { return "set-spec-const-default-value"; }
+  SPIRV_TOOLS_OPT_EXPORT Status Process(ir::Module*) override;
 
   // Parses the given null-terminated C string to get a mapping from Spec Id to
   // default value strings. Returns a unique pointer of the mapping from spec
@@ -85,7 +85,7 @@ class SetSpecConstantDefaultValuePass : public Pass {
   //    Spaces before and after default value text is allowed.
   //    Spaces within the text is not allowed.
   //    Empty <default value> is not allowed.
-  static std::unique_ptr<SpecIdToValueStrMap> ParseDefaultValuesString(
+  SPIRV_TOOLS_OPT_EXPORT static std::unique_ptr<SpecIdToValueStrMap> ParseDefaultValuesString(
       const char* str);
 
  private:

--- a/source/opt/strength_reduction_pass.h
+++ b/source/opt/strength_reduction_pass.h
@@ -25,8 +25,8 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class StrengthReductionPass : public Pass {
  public:
-  const char* name() const override { return "strength-reduction"; }
-  Status Process(ir::Module*) override;
+  inline const char* name() const override { return "strength-reduction"; }
+  SPIRV_TOOLS_OPT_EXPORT Status Process(ir::Module*) override;
 
  private:
   // Replaces multiple by power of 2 with an equivalent bit shift.

--- a/source/opt/strip_debug_info_pass.h
+++ b/source/opt/strip_debug_info_pass.h
@@ -24,8 +24,8 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class StripDebugInfoPass : public Pass {
  public:
-  const char* name() const override { return "strip-debug"; }
-  Status Process(ir::Module* module) override;
+  inline const char* name() const override { return "strip-debug"; }
+  SPIRV_TOOLS_OPT_EXPORT Status Process(ir::Module* module) override;
 };
 
 }  // namespace opt

--- a/source/opt/unify_const_pass.h
+++ b/source/opt/unify_const_pass.h
@@ -24,8 +24,8 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class UnifyConstantPass : public Pass {
  public:
-  const char* name() const override { return "unify-const"; }
-  Status Process(ir::Module*) override;
+  inline const char* name() const override { return "unify-const"; }
+  SPIRV_TOOLS_OPT_EXPORT Status Process(ir::Module*) override;
 };
 
 }  // namespace opt

--- a/source/parsed_operand.h
+++ b/source/parsed_operand.h
@@ -24,7 +24,7 @@ namespace libspirv {
 // to the stream.  The operand must be of numeric type.  If integral it may
 // be up to 64 bits wide.  If floating point, then it must be 16, 32, or 64
 // bits wide.
-void EmitNumericLiteral(std::ostream* out, const spv_parsed_instruction_t& inst,
+SPIRV_TOOLS_EXPORT void EmitNumericLiteral(std::ostream* out, const spv_parsed_instruction_t& inst,
                         const spv_parsed_operand_t& operand);
 
 }  // namespace libspirv

--- a/source/spirv_endian.h
+++ b/source/spirv_endian.h
@@ -18,20 +18,20 @@
 #include "spirv-tools/libspirv.h"
 
 // Converts a word in the specified endianness to the host native endianness.
-uint32_t spvFixWord(const uint32_t word, const spv_endianness_t endianness);
+SPIRV_TOOLS_EXPORT uint32_t spvFixWord(const uint32_t word, const spv_endianness_t endianness);
 
 // Converts a pair of words in the specified endianness to the host native
 // endianness.
-uint64_t spvFixDoubleWord(const uint32_t low, const uint32_t high,
+SPIRV_TOOLS_EXPORT uint64_t spvFixDoubleWord(const uint32_t low, const uint32_t high,
                           const spv_endianness_t endianness);
 
 // Gets the endianness of the SPIR-V module given in the binary parameter.
 // Returns SPV_ENDIANNESS_UNKNOWN if the SPIR-V magic number is invalid,
 // otherwise writes the determined endianness into *endian.
-spv_result_t spvBinaryEndianness(const spv_const_binary binary,
+SPIRV_TOOLS_EXPORT spv_result_t spvBinaryEndianness(const spv_const_binary binary,
                                  spv_endianness_t* endian);
 
 // Returns true if the given endianness matches the host's native endiannes.
-bool spvIsHostEndian(spv_endianness_t endian);
+SPIRV_TOOLS_EXPORT bool spvIsHostEndian(spv_endianness_t endian);
 
 #endif  // LIBSPIRV_SPIRV_ENDIAN_H_

--- a/source/spirv_stats.h
+++ b/source/spirv_stats.h
@@ -119,7 +119,7 @@ struct SpirvStats {
 };
 
 // Aggregates existing |stats| with new stats extracted from |binary|.
-spv_result_t AggregateStats(
+SPIRV_TOOLS_EXPORT spv_result_t AggregateStats(
     const spv_context_t& context, const uint32_t* words, const size_t num_words,
     spv_diagnostic* pDiagnostic, SpirvStats* stats);
 

--- a/source/spirv_target_env.cpp
+++ b/source/spirv_target_env.cpp
@@ -17,6 +17,7 @@
 
 #include "spirv-tools/libspirv.h"
 #include "spirv_constant.h"
+#include "spirv_target_env.h"
 
 const char* spvTargetEnvDescription(spv_target_env env) {
   switch (env) {

--- a/source/spirv_target_env.h
+++ b/source/spirv_target_env.h
@@ -19,6 +19,6 @@
 
 // Parses s into *env and returns true if successful.  If unparsable, returns
 // false and sets *env to SPV_ENV_UNIVERSAL_1_0.
-bool spvParseTargetEnv(const char* s, spv_target_env* env);
+SPIRV_TOOLS_EXPORT bool spvParseTargetEnv(const char* s, spv_target_env* env);
 
 #endif  // LIBSPIRV_SPIRV_TARGET_ENV_H_

--- a/source/spirv_validator_options.h
+++ b/source/spirv_validator_options.h
@@ -19,7 +19,7 @@
 
 // Return true if the command line option for the validator limit is valid (Also
 // returns the Enum for option in this case). Returns false otherwise.
-bool spvParseUniversalLimitsOptions(const char* s, spv_validator_limit* limit);
+SPIRV_TOOLS_EXPORT bool spvParseUniversalLimitsOptions(const char* s, spv_validator_limit* limit);
 
 // Default initialization of this structure is to the default Universal Limits
 // described in the SPIR-V Spec.
@@ -37,6 +37,7 @@ struct validator_universal_limits_t {
 // Manages command line options passed to the SPIR-V Validator. New struct
 // members may be added for any new option.
 struct spv_validator_options_t {
+  inline
   spv_validator_options_t()
       : universal_limits_(), relax_struct_store(false) {}
 

--- a/source/table.h
+++ b/source/table.h
@@ -102,16 +102,16 @@ struct spv_context_t {
 
 // Sets the message consumer to |consumer| in the given |context|. The original
 // message consumer will be overwritten.
-void SetContextMessageConsumer(spv_context context,
+SPIRV_TOOLS_EXPORT void SetContextMessageConsumer(spv_context context,
                                spvtools::MessageConsumer consumer);
 
 // Populates *table with entries for env.
-spv_result_t spvOpcodeTableGet(spv_opcode_table* table, spv_target_env env);
+SPIRV_TOOLS_EXPORT spv_result_t spvOpcodeTableGet(spv_opcode_table* table, spv_target_env env);
 
 // Populates *table with entries for env.
-spv_result_t spvOperandTableGet(spv_operand_table* table, spv_target_env env);
+SPIRV_TOOLS_EXPORT spv_result_t spvOperandTableGet(spv_operand_table* table, spv_target_env env);
 
 // Populates *table with entries for env.
-spv_result_t spvExtInstTableGet(spv_ext_inst_table* table, spv_target_env env);
+SPIRV_TOOLS_EXPORT spv_result_t spvExtInstTableGet(spv_ext_inst_table* table, spv_target_env env);
 
 #endif  // LIBSPIRV_TABLE_H_

--- a/source/text_handler.h
+++ b/source/text_handler.h
@@ -119,8 +119,12 @@ class AssemblyContext {
  public:
   AssemblyContext(spv_text text, const spvtools::MessageConsumer& consumer,
                   std::set<uint32_t>&& ids_to_preserve = std::set<uint32_t>())
-      : current_position_({}), consumer_(consumer), text_(text), bound_(1),
-        next_id_(1), ids_to_preserve_(std::move(ids_to_preserve))  {}
+      : current_position_({}),
+        consumer_(consumer),
+        text_(text),
+        bound_(1),
+        next_id_(1),
+        ids_to_preserve_(std::move(ids_to_preserve)) {}
 
   // Assigns a new integer value to the given text ID, or returns the previously
   // assigned integer value if the ID has been seen before.

--- a/source/util/bit_stream.h
+++ b/source/util/bit_stream.h
@@ -25,6 +25,8 @@
 #include <sstream>
 #include <vector>
 
+#include <spirv-tools_export.h>
+
 namespace spvutils {
 
 // Returns rounded down log2(val). log2(0) is considered 0.
@@ -193,10 +195,10 @@ inline std::string BitsToStream(uint64_t bits, size_t num_bits = 64) {
 }
 
 // Base class for writing sequences of bits.
-class BitWriterInterface {
+class SPIRV_TOOLS_EXPORT BitWriterInterface {
  public:
-  BitWriterInterface() {}
-  virtual ~BitWriterInterface() {}
+  inline BitWriterInterface() {}
+  inline virtual ~BitWriterInterface() {}
 
   // Writes lower |num_bits| in |bits| to the stream.
   // |num_bits| must be no greater than 64.
@@ -267,7 +269,7 @@ class BitWriterInterface {
   }
 
   // Returns buffer size in bytes.
-  size_t GetDataSizeBytes() const {
+  inline size_t GetDataSizeBytes() const {
     return NumBitsToNumWords<8>(GetNumBits());
   }
 
@@ -282,35 +284,41 @@ class BitWriterInterface {
 // std::vector<uint64_t> to store written bits.
 class BitWriterWord64 : public BitWriterInterface {
  public:
-  explicit BitWriterWord64(size_t reserve_bits = 64);
+  SPIRV_TOOLS_EXPORT explicit BitWriterWord64(size_t reserve_bits = 64);
 
-  void WriteBits(uint64_t bits, size_t num_bits) override;
+  SPIRV_TOOLS_EXPORT void WriteBits(uint64_t bits, size_t num_bits) override;
 
+  inline
   size_t GetNumBits() const override {
     return end_;
   }
 
+  inline
   const uint8_t* GetData() const override {
     return reinterpret_cast<const uint8_t*>(buffer_.data());
   }
 
+  inline
   std::vector<uint8_t> GetDataCopy() const override {
     return std::vector<uint8_t>(GetData(), GetData() + GetDataSizeBytes());
   }
 
   // Returns written stream as std::string, padded with zeroes so that the
   // length is a multiple of 64.
+  inline
   std::string GetStreamPadded64() const {
     return BufferToStream(buffer_);
   }
 
   // Sets callback to emit bit sequences after every write.
+  inline
   void SetCallback(std::function<void(const std::string&)> callback) {
     callback_ = callback;
   }
 
  protected:
   // Sends string generated from arguments to callback_ if defined.
+  inline
   void EmitSequence(uint64_t bits, size_t num_bits) const {
     if (callback_)
       callback_(BitsToStream(bits, num_bits));
@@ -327,10 +335,10 @@ class BitWriterWord64 : public BitWriterInterface {
 };
 
 // Base class for reading sequences of bits.
-class BitReaderInterface {
+class SPIRV_TOOLS_EXPORT BitReaderInterface {
  public:
-  BitReaderInterface() {}
-  virtual ~BitReaderInterface() {}
+  inline BitReaderInterface() {}
+  inline virtual ~BitReaderInterface() {}
 
   // Reads |num_bits| from the stream, stores them in |bits|.
   // Returns number of read bits. |num_bits| must be no greater than 64.
@@ -351,6 +359,7 @@ class BitReaderInterface {
   // Reads |num_bits| from the stream, returns string in left-to-right order.
   // The length of the returned string may be less than |num_bits| if end was
   // reached.
+  inline
   std::string ReadStream(size_t num_bits) {
     uint64_t bits = 0;
     size_t num_read = ReadBits(&bits, num_bits);
@@ -384,7 +393,7 @@ class BitReaderInterface {
   // the buffer stream ends with padding zeroes, and would accept this as a
   // 'soft' EOF. Implementations of this class do not necessarily need to
   // implement this, default behavior can simply delegate to ReachedEnd().
-  virtual bool OnlyZeroesLeft() const {
+  inline virtual bool OnlyZeroesLeft() const {
     return ReachedEnd();
   }
 
@@ -418,32 +427,35 @@ class BitReaderInterface {
 class BitReaderWord64 : public BitReaderInterface {
  public:
   // Consumes and owns the buffer.
-  explicit BitReaderWord64(std::vector<uint64_t>&& buffer);
+  SPIRV_TOOLS_EXPORT explicit BitReaderWord64(std::vector<uint64_t>&& buffer);
 
   // Copies the buffer and casts it to uint64.
   // Consuming the original buffer and casting it to uint64 is difficult,
   // as it would potentially cause data misalignment and poor performance.
-  explicit BitReaderWord64(const std::vector<uint8_t>& buffer);
-  BitReaderWord64(const void* buffer, size_t num_bytes);
+  SPIRV_TOOLS_EXPORT explicit BitReaderWord64(const std::vector<uint8_t>& buffer);
+  SPIRV_TOOLS_EXPORT BitReaderWord64(const void* buffer, size_t num_bytes);
 
-  size_t ReadBits(uint64_t* bits, size_t num_bits) override;
+  SPIRV_TOOLS_EXPORT size_t ReadBits(uint64_t* bits, size_t num_bits) override;
 
+  inline
   size_t GetNumReadBits() const override {
     return pos_;
   }
 
-  bool ReachedEnd() const override;
-  bool OnlyZeroesLeft() const override;
+  SPIRV_TOOLS_EXPORT bool ReachedEnd() const override;
+  SPIRV_TOOLS_EXPORT bool OnlyZeroesLeft() const override;
 
   BitReaderWord64() = delete;
 
   // Sets callback to emit bit sequences after every read.
+  inline
   void SetCallback(std::function<void(const std::string&)> callback) {
     callback_ = callback;
   }
 
  protected:
   // Sends string generated from arguments to callback_ if defined.
+  inline
   void EmitSequence(uint64_t bits, size_t num_bits) const {
     if (callback_)
       callback_(BitsToStream(bits, num_bits));

--- a/source/util/parse_number.h
+++ b/source/util/parse_number.h
@@ -214,7 +214,7 @@ enum class EncodeNumberStatus {
 // a nullptr, it will be overwritten with error messages in case of failure. In
 // case of success, |error_msg| will not be touched. Integers up to 64 bits are
 // supported.
-EncodeNumberStatus ParseAndEncodeIntegerNumber(
+SPIRV_TOOLS_EXPORT EncodeNumberStatus ParseAndEncodeIntegerNumber(
     const char* text, const NumberType& type,
     std::function<void(uint32_t)> emit, std::string* error_msg);
 
@@ -227,7 +227,7 @@ EncodeNumberStatus ParseAndEncodeIntegerNumber(
 // a nullptr, it will be overwritten with error messages in case of failure. In
 // case of success, |error_msg| will not be touched. Only 16, 32 and 64 bit
 // floating point numbers are supported.
-EncodeNumberStatus ParseAndEncodeFloatingPointNumber(
+SPIRV_TOOLS_EXPORT EncodeNumberStatus ParseAndEncodeFloatingPointNumber(
     const char* text, const NumberType& type,
     std::function<void(uint32_t)> emit, std::string* error_msg);
 
@@ -240,7 +240,7 @@ EncodeNumberStatus ParseAndEncodeFloatingPointNumber(
 // a nullptr, it will be overwritten with error messages in case of failure. In
 // case of success, |error_msg| will not be touched. Integers up to 64 bits
 // and 16/32/64 bit floating point values are supported.
-EncodeNumberStatus ParseAndEncodeNumber(const char* text,
+SPIRV_TOOLS_EXPORT EncodeNumberStatus ParseAndEncodeNumber(const char* text,
                                         const NumberType& type,
                                         std::function<void(uint32_t)> emit,
                                         std::string* error_msg);

--- a/source/val/instruction.h
+++ b/source/val/instruction.h
@@ -33,46 +33,46 @@ class Function;
 /// instruction's result id
 class Instruction {
  public:
-  explicit Instruction(const spv_parsed_instruction_t* inst,
+  SPIRV_TOOLS_EXPORT explicit Instruction(const spv_parsed_instruction_t* inst,
                        Function* defining_function = nullptr,
                        BasicBlock* defining_block = nullptr);
 
   /// Registers the use of the Instruction in instruction \p inst at \p index
-  void RegisterUse(const Instruction* inst, uint32_t index);
+  SPIRV_TOOLS_EXPORT void RegisterUse(const Instruction* inst, uint32_t index);
 
-  uint32_t id() const { return inst_.result_id; }
-  uint32_t type_id() const { return inst_.type_id; }
-  SpvOp opcode() const { return static_cast<SpvOp>(inst_.opcode); }
+  inline uint32_t id() const { return inst_.result_id; }
+  inline uint32_t type_id() const { return inst_.type_id; }
+  inline SpvOp opcode() const { return static_cast<SpvOp>(inst_.opcode); }
 
   /// Returns the Function where the instruction was defined. nullptr if it was
   /// defined outside of a Function
-  const Function* function() const { return function_; }
+  inline const Function* function() const { return function_; }
 
   /// Returns the BasicBlock where the instruction was defined. nullptr if it
   /// was defined outside of a BasicBlock
-  const BasicBlock* block() const { return block_; }
+  inline const BasicBlock* block() const { return block_; }
 
   /// Returns a vector of pairs of all references to this instruction's result
   /// id. The first element is the instruction in which this result id was
   /// referenced and the second is the index of the word in that instruction
   /// where this result id appeared
-  const std::vector<std::pair<const Instruction*, uint32_t>>& uses() const {
+  inline const std::vector<std::pair<const Instruction*, uint32_t>>& uses() const {
     return uses_;
   }
 
   /// The word used to define the Instruction
-  uint32_t word(size_t index) const { return words_[index]; }
+  inline uint32_t word(size_t index) const { return words_[index]; }
 
   /// The words used to define the Instruction
-  const std::vector<uint32_t>& words() const { return words_; }
+  inline const std::vector<uint32_t>& words() const { return words_; }
 
   /// The operands of the Instruction
-  const std::vector<spv_parsed_operand_t>& operands() const {
+  inline const std::vector<spv_parsed_operand_t>& operands() const {
     return operands_;
   }
 
   /// Provides direct access to the stored C instruction object.
-  const spv_parsed_instruction_t& c_inst() const {
+  inline const spv_parsed_instruction_t& c_inst() const {
     return inst_;
   }
 

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -57,7 +57,7 @@ enum ModuleLayoutSection {
 class ValidationState_t {
  public:
   // Features that can optionally be turned on by a capability.
-  struct Feature {
+  struct SPIRV_TOOLS_EXPORT Feature {
     bool declare_int16_type = false;     // Allow OpTypeInt with 16 bit width?
     bool declare_float16_type = false;   // Allow OpTypeFloat with 16 bit width?
     bool free_fp_rounding_mode = false;  // Allow the FPRoundingMode decoration
@@ -71,167 +71,167 @@ class ValidationState_t {
     bool variable_pointers_storage_buffer = false;
   };
 
-  ValidationState_t(const spv_const_context context,
+  SPIRV_TOOLS_EXPORT ValidationState_t(const spv_const_context context,
                     const spv_const_validator_options opt);
 
   /// Returns the context
-  spv_const_context context() const { return context_; }
+  inline spv_const_context context() const { return context_; }
 
   /// Returns the command line options
-  spv_const_validator_options options() const { return options_; }
+  inline spv_const_validator_options options() const { return options_; }
 
   /// Forward declares the id in the module
-  spv_result_t ForwardDeclareId(uint32_t id);
+  SPIRV_TOOLS_EXPORT spv_result_t ForwardDeclareId(uint32_t id);
 
   /// Removes a forward declared ID if it has been defined
-  spv_result_t RemoveIfForwardDeclared(uint32_t id);
+  SPIRV_TOOLS_EXPORT spv_result_t RemoveIfForwardDeclared(uint32_t id);
 
   /// Registers an ID as a forward pointer
-  spv_result_t RegisterForwardPointer(uint32_t id);
+  SPIRV_TOOLS_EXPORT spv_result_t RegisterForwardPointer(uint32_t id);
 
   /// Returns whether or not an ID is a forward pointer
-  bool IsForwardPointer(uint32_t id) const;
+  SPIRV_TOOLS_EXPORT bool IsForwardPointer(uint32_t id) const;
 
   /// Assigns a name to an ID
-  void AssignNameToId(uint32_t id, std::string name);
+  SPIRV_TOOLS_EXPORT void AssignNameToId(uint32_t id, std::string name);
 
   /// Returns a string representation of the ID in the format <id>[Name] where
   /// the <id> is the numeric valid of the id and the Name is a name assigned by
   /// the OpName instruction
-  std::string getIdName(uint32_t id) const;
+  SPIRV_TOOLS_EXPORT std::string getIdName(uint32_t id) const;
 
   /// Accessor function for ID bound.
-  uint32_t getIdBound() const;
+  SPIRV_TOOLS_EXPORT uint32_t getIdBound() const;
 
   /// Mutator function for ID bound.
-  void setIdBound(uint32_t bound);
+  SPIRV_TOOLS_EXPORT void setIdBound(uint32_t bound);
 
   /// Like getIdName but does not display the id if the \p id has a name
-  std::string getIdOrName(uint32_t id) const;
+  SPIRV_TOOLS_EXPORT std::string getIdOrName(uint32_t id) const;
 
   /// Returns the number of ID which have been forward referenced but not
   /// defined
-  size_t unresolved_forward_id_count() const;
+  SPIRV_TOOLS_EXPORT size_t unresolved_forward_id_count() const;
 
   /// Returns a vector of unresolved forward ids.
-  std::vector<uint32_t> UnresolvedForwardIds() const;
+  SPIRV_TOOLS_EXPORT std::vector<uint32_t> UnresolvedForwardIds() const;
 
   /// Returns true if the id has been defined
-  bool IsDefinedId(uint32_t id) const;
+  SPIRV_TOOLS_EXPORT bool IsDefinedId(uint32_t id) const;
 
   /// Increments the instruction count. Used for diagnostic
-  int increment_instruction_count();
+  SPIRV_TOOLS_EXPORT int increment_instruction_count();
 
   /// Returns the current layout section which is being processed
-  ModuleLayoutSection current_layout_section() const;
+  SPIRV_TOOLS_EXPORT ModuleLayoutSection current_layout_section() const;
 
   /// Increments the module_layout_order_section_
-  void ProgressToNextLayoutSectionOrder();
+  SPIRV_TOOLS_EXPORT void ProgressToNextLayoutSectionOrder();
 
   /// Determines if the op instruction is part of the current section
-  bool IsOpcodeInCurrentLayoutSection(SpvOp op);
+  SPIRV_TOOLS_EXPORT bool IsOpcodeInCurrentLayoutSection(SpvOp op);
 
-  libspirv::DiagnosticStream diag(spv_result_t error_code) const;
-
-  /// Returns the function states
-  std::deque<Function>& functions();
+  SPIRV_TOOLS_EXPORT libspirv::DiagnosticStream diag(spv_result_t error_code) const;
 
   /// Returns the function states
-  Function& current_function();
-  const Function& current_function() const;
+  SPIRV_TOOLS_EXPORT std::deque<Function>& functions();
+
+  /// Returns the function states
+  SPIRV_TOOLS_EXPORT Function& current_function();
+  SPIRV_TOOLS_EXPORT const Function& current_function() const;
 
   /// Returns true if the called after a function instruction but before the
   /// function end instruction
-  bool in_function_body() const;
+  SPIRV_TOOLS_EXPORT bool in_function_body() const;
 
   /// Returns true if called after a label instruction but before a branch
   /// instruction
-  bool in_block() const;
+  SPIRV_TOOLS_EXPORT bool in_block() const;
 
   /// Registers the given <id> as an Entry Point.
-  void RegisterEntryPointId(const uint32_t id) {
+  inline void RegisterEntryPointId(const uint32_t id) {
     entry_points_.push_back(id);
     entry_point_interfaces_.insert(std::make_pair(id, std::vector<uint32_t>()));
   }
 
   /// Returns a list of entry point function ids
-  const std::vector<uint32_t>& entry_points() const { return entry_points_; }
+  inline const std::vector<uint32_t>& entry_points() const { return entry_points_; }
 
   /// Adds a new interface id to the interfaces of the given entry point.
-  void RegisterInterfaceForEntryPoint(uint32_t entry_point,
+  inline void RegisterInterfaceForEntryPoint(uint32_t entry_point,
                                       uint32_t interface) {
     entry_point_interfaces_[entry_point].push_back(interface);
   }
 
   /// Returns the interfaces of a given entry point. If the given id is not a
   /// valid Entry Point id, std::out_of_range exception is thrown.
-  const std::vector<uint32_t>& entry_point_interfaces(
+  inline const std::vector<uint32_t>& entry_point_interfaces(
       uint32_t entry_point) const {
     return entry_point_interfaces_.at(entry_point);
   }
 
   /// Inserts an <id> to the set of functions that are target of OpFunctionCall.
-  void AddFunctionCallTarget(const uint32_t id) {
+  inline void AddFunctionCallTarget(const uint32_t id) {
     function_call_targets_.insert(id);
   }
 
   /// Returns whether or not a function<id> is the target of OpFunctionCall.
-  bool IsFunctionCallTarget(const uint32_t id) {
+  inline bool IsFunctionCallTarget(const uint32_t id) {
     return (function_call_targets_.find(id) != function_call_targets_.end());
   }
 
   /// Registers the capability and its dependent capabilities
-  void RegisterCapability(SpvCapability cap);
+  SPIRV_TOOLS_EXPORT void RegisterCapability(SpvCapability cap);
 
   /// Registers the extension.
-  void RegisterExtension(Extension ext);
+  SPIRV_TOOLS_EXPORT void RegisterExtension(Extension ext);
 
   /// Registers the function in the module. Subsequent instructions will be
   /// called against this function
-  spv_result_t RegisterFunction(uint32_t id, uint32_t ret_type_id,
+  SPIRV_TOOLS_EXPORT spv_result_t RegisterFunction(uint32_t id, uint32_t ret_type_id,
                                 SpvFunctionControlMask function_control,
                                 uint32_t function_type_id);
 
   /// Register a function end instruction
-  spv_result_t RegisterFunctionEnd();
+  SPIRV_TOOLS_EXPORT spv_result_t RegisterFunctionEnd();
 
   /// Returns true if the capability is enabled in the module.
-  bool HasCapability(SpvCapability cap) const {
+  inline bool HasCapability(SpvCapability cap) const {
     return module_capabilities_.Contains(cap);
   }
 
   /// Returns true if the extension is enabled in the module.
-  bool HasExtension(Extension ext) const {
+  inline bool HasExtension(Extension ext) const {
     return module_extensions_.Contains(ext);
   }
 
   /// Returns true if any of the capabilities is enabled, or if |capabilities|
   /// is an empty set.
-  bool HasAnyOfCapabilities(const libspirv::CapabilitySet& capabilities) const;
+  SPIRV_TOOLS_EXPORT bool HasAnyOfCapabilities(const libspirv::CapabilitySet& capabilities) const;
 
   /// Returns true if any of the extensions is enabled, or if |extensions|
   /// is an empty set.
-  bool HasAnyOfExtensions(const libspirv::ExtensionSet& extensions) const;
+  SPIRV_TOOLS_EXPORT bool HasAnyOfExtensions(const libspirv::ExtensionSet& extensions) const;
 
   /// Sets the addressing model of this module (logical/physical).
-  void set_addressing_model(SpvAddressingModel am);
+  SPIRV_TOOLS_EXPORT void set_addressing_model(SpvAddressingModel am);
 
   /// Returns the addressing model of this module, or Logical if uninitialized.
-  SpvAddressingModel addressing_model() const;
+  SPIRV_TOOLS_EXPORT SpvAddressingModel addressing_model() const;
 
   /// Sets the memory model of this module.
-  void set_memory_model(SpvMemoryModel mm);
+  SPIRV_TOOLS_EXPORT void set_memory_model(SpvMemoryModel mm);
 
   /// Returns the memory model of this module, or Simple if uninitialized.
-  SpvMemoryModel memory_model() const;
+  SPIRV_TOOLS_EXPORT SpvMemoryModel memory_model() const;
 
-  const AssemblyGrammar& grammar() const { return grammar_; }
+  inline const AssemblyGrammar& grammar() const { return grammar_; }
 
   /// Registers the instruction
-  void RegisterInstruction(const spv_parsed_instruction_t& inst);
+  SPIRV_TOOLS_EXPORT void RegisterInstruction(const spv_parsed_instruction_t& inst);
 
   /// Registers the decoration for the given <id>
-  void RegisterDecorationForId(uint32_t id, const Decoration& dec) {
+  inline void RegisterDecorationForId(uint32_t id, const Decoration& dec) {
     id_decorations_[id].push_back(dec);
   }
 
@@ -257,7 +257,7 @@ class ValidationState_t {
   /// Returns all the decorations for the given <id>. If no decorations exist
   /// for the <id>, it registers an empty vector for it in the map and
   /// returns the empty vector.
-  std::vector<Decoration>& id_decorations(uint32_t id) {
+  inline std::vector<Decoration>& id_decorations(uint32_t id) {
     return id_decorations_[id];
   }
   const std::vector<Decoration>& id_decorations(uint32_t id) const {
@@ -266,80 +266,80 @@ class ValidationState_t {
 
   /// Finds id's def, if it exists.  If found, returns the definition otherwise
   /// nullptr
-  const Instruction* FindDef(uint32_t id) const;
+  SPIRV_TOOLS_EXPORT const Instruction* FindDef(uint32_t id) const;
 
   /// Finds id's def, if it exists.  If found, returns the definition otherwise
   /// nullptr
-  Instruction* FindDef(uint32_t id);
+  SPIRV_TOOLS_EXPORT Instruction* FindDef(uint32_t id);
 
   /// Returns a deque of instructions in the order they appear in the binary
-  const std::deque<Instruction>& ordered_instructions() const {
+  inline const std::deque<Instruction>& ordered_instructions() const {
     return ordered_instructions_;
   }
 
   /// Returns a map of instructions mapped by their result id
-  const std::unordered_map<uint32_t, Instruction*>& all_definitions() const {
+  inline const std::unordered_map<uint32_t, Instruction*>& all_definitions() const {
     return all_definitions_;
   }
 
   /// Returns a vector containing the Ids of instructions that consume the given
   /// SampledImage id.
-  std::vector<uint32_t> getSampledImageConsumers(uint32_t id) const;
+  SPIRV_TOOLS_EXPORT std::vector<uint32_t> getSampledImageConsumers(uint32_t id) const;
 
   /// Records cons_id as a consumer of sampled_image_id.
-  void RegisterSampledImageConsumer(uint32_t sampled_image_id,
+  SPIRV_TOOLS_EXPORT void RegisterSampledImageConsumer(uint32_t sampled_image_id,
                                     uint32_t cons_id);
 
   /// Returns the set of Global Variables.
-  std::unordered_set<uint32_t>& global_vars() { return global_vars_; }
+  inline std::unordered_set<uint32_t>& global_vars() { return global_vars_; }
 
   /// Returns the set of Local Variables.
-  std::unordered_set<uint32_t>& local_vars() { return local_vars_; }
+  inline std::unordered_set<uint32_t>& local_vars() { return local_vars_; }
 
   /// Returns the number of Global Variables.
-  size_t num_global_vars() { return global_vars_.size(); }
+  inline size_t num_global_vars() { return global_vars_.size(); }
 
   /// Returns the number of Local Variables.
-  size_t num_local_vars() { return local_vars_.size(); }
+  inline size_t num_local_vars() { return local_vars_.size(); }
 
   /// Inserts a new <id> to the set of Global Variables.
-  void registerGlobalVariable(const uint32_t id) { global_vars_.insert(id); }
+  inline void registerGlobalVariable(const uint32_t id) { global_vars_.insert(id); }
 
   /// Inserts a new <id> to the set of Local Variables.
-  void registerLocalVariable(const uint32_t id) { local_vars_.insert(id); }
+  inline void registerLocalVariable(const uint32_t id) { local_vars_.insert(id); }
 
   /// Sets the struct nesting depth for a given struct ID
-  void set_struct_nesting_depth(uint32_t id, uint32_t depth) {
+  inline void set_struct_nesting_depth(uint32_t id, uint32_t depth) {
     struct_nesting_depth_[id] = depth;
   }
 
   /// Returns the nesting depth of a given structure ID
-  uint32_t struct_nesting_depth(uint32_t id) {
+  inline uint32_t struct_nesting_depth(uint32_t id) {
     return struct_nesting_depth_[id];
   }
 
   /// Records that the structure type has a member decorated with a built-in.
-  void RegisterStructTypeWithBuiltInMember(uint32_t id) {
+  inline void RegisterStructTypeWithBuiltInMember(uint32_t id) {
     builtin_structs_.insert(id);
   }
 
   /// Returns true if the struct type with the given Id has a BuiltIn member.
-  bool IsStructTypeWithBuiltInMember(uint32_t id) const {
+  inline bool IsStructTypeWithBuiltInMember(uint32_t id) const {
     return (builtin_structs_.find(id) != builtin_structs_.end());
   }
 
   // Returns the state of optional features.
-  const Feature& features() const { return features_; }
+  inline const Feature& features() const { return features_; }
 
   /// Adds the instruction data to unique_type_declarations_.
   /// Returns false if an identical type declaration already exists.
-  bool RegisterUniqueTypeDeclaration(const spv_parsed_instruction_t& inst);
+  SPIRV_TOOLS_EXPORT bool RegisterUniqueTypeDeclaration(const spv_parsed_instruction_t& inst);
 
   // Returns type_id of the scalar component of |id|.
   // |id| can be either
   // - scalar, vector or matrix type
   // - object of either scalar, vector or matrix type
-  uint32_t GetComponentType(uint32_t id) const;
+  SPIRV_TOOLS_EXPORT uint32_t GetComponentType(uint32_t id) const;
 
   // Returns
   // - 1 for scalar types or objects
@@ -347,44 +347,44 @@ class ValidationState_t {
   // - num columns for matrix types or objects
   // Should not be called with any other arguments (will return zero and invoke
   // assertion).
-  uint32_t GetDimension(uint32_t id) const;
+  SPIRV_TOOLS_EXPORT uint32_t GetDimension(uint32_t id) const;
 
   // Returns bit width of scalar or component.
   // |id| can be
   // - scalar, vector or matrix type
   // - object of either scalar, vector or matrix type
   // Will invoke assertion and return 0 if |id| is none of the above.
-  uint32_t GetBitWidth(uint32_t id) const;
+  SPIRV_TOOLS_EXPORT uint32_t GetBitWidth(uint32_t id) const;
 
   // Provides detailed information on matrix type.
   // Returns false iff |id| is not matrix type.
-  bool GetMatrixTypeInfo(
+  SPIRV_TOOLS_EXPORT bool GetMatrixTypeInfo(
       uint32_t id, uint32_t* num_rows, uint32_t* num_cols,
       uint32_t* column_type, uint32_t* component_type) const;
 
   // Collects struct member types into |member_types|.
   // Returns false iff not struct type or has no members.
   // Deletes prior contents of |member_types|.
-  bool GetStructMemberTypes(
+  SPIRV_TOOLS_EXPORT bool GetStructMemberTypes(
       uint32_t struct_type_id, std::vector<uint32_t>* member_types) const;
 
   // Returns true iff |id| is a type corresponding to the name of the function.
   // Only works for types not for objects.
-  bool IsFloatScalarType(uint32_t id) const;
-  bool IsFloatVectorType(uint32_t id) const;
-  bool IsFloatMatrixType(uint32_t id) const;
-  bool IsIntScalarType(uint32_t id) const;
-  bool IsIntVectorType(uint32_t id) const;
-  bool IsUnsignedIntScalarType(uint32_t id) const;
-  bool IsUnsignedIntVectorType(uint32_t id) const;
-  bool IsSignedIntScalarType(uint32_t id) const;
-  bool IsSignedIntVectorType(uint32_t id) const;
-  bool IsBoolScalarType(uint32_t id) const;
-  bool IsBoolVectorType(uint32_t id) const;
-  bool IsPointerType(uint32_t id) const;
+  SPIRV_TOOLS_EXPORT bool IsFloatScalarType(uint32_t id) const;
+  SPIRV_TOOLS_EXPORT bool IsFloatVectorType(uint32_t id) const;
+  SPIRV_TOOLS_EXPORT bool IsFloatMatrixType(uint32_t id) const;
+  SPIRV_TOOLS_EXPORT bool IsIntScalarType(uint32_t id) const;
+  SPIRV_TOOLS_EXPORT bool IsIntVectorType(uint32_t id) const;
+  SPIRV_TOOLS_EXPORT bool IsUnsignedIntScalarType(uint32_t id) const;
+  SPIRV_TOOLS_EXPORT bool IsUnsignedIntVectorType(uint32_t id) const;
+  SPIRV_TOOLS_EXPORT bool IsSignedIntScalarType(uint32_t id) const;
+  SPIRV_TOOLS_EXPORT bool IsSignedIntVectorType(uint32_t id) const;
+  SPIRV_TOOLS_EXPORT bool IsBoolScalarType(uint32_t id) const;
+  SPIRV_TOOLS_EXPORT bool IsBoolVectorType(uint32_t id) const;
+  SPIRV_TOOLS_EXPORT bool IsPointerType(uint32_t id) const;
 
   // Returns type_id if id has type or zero otherwise.
-  uint32_t GetTypeId(uint32_t id) const;
+  SPIRV_TOOLS_EXPORT uint32_t GetTypeId(uint32_t id) const;
 
   // Returns type_id for given id operand if it has a type or zero otherwise.
   // |operand_index| is expected to be pointing towards an operand which is an

--- a/source/validate.h
+++ b/source/validate.h
@@ -39,7 +39,7 @@ using get_blocks_func =
 /// @param[in] _ the validation state of the module
 ///
 /// @return SPV_SUCCESS if no errors are found. SPV_ERROR_INVALID_CFG otherwise
-spv_result_t PerformCfgChecks(ValidationState_t& _);
+SPIRV_TOOLS_EXPORT spv_result_t PerformCfgChecks(ValidationState_t& _);
 
 /// @brief Updates the use vectors of all instructions that can be referenced
 ///
@@ -49,7 +49,7 @@ spv_result_t PerformCfgChecks(ValidationState_t& _);
 /// @param[in] _ the validation state of the module
 ///
 /// @return SPV_SUCCESS if no errors are found.
-spv_result_t UpdateIdUse(ValidationState_t& _);
+SPIRV_TOOLS_EXPORT spv_result_t UpdateIdUse(ValidationState_t& _);
 
 /// @brief This function checks all ID definitions dominate their use in the
 /// CFG.
@@ -61,7 +61,7 @@ spv_result_t UpdateIdUse(ValidationState_t& _);
 /// @param[in] _ the validation state of the module
 ///
 /// @return SPV_SUCCESS if no errors are found. SPV_ERROR_INVALID_ID otherwise
-spv_result_t CheckIdDefinitionDominateUse(const ValidationState_t& _);
+SPIRV_TOOLS_EXPORT spv_result_t CheckIdDefinitionDominateUse(const ValidationState_t& _);
 
 /// @brief Updates the immediate dominator for each of the block edges
 ///
@@ -71,48 +71,48 @@ spv_result_t CheckIdDefinitionDominateUse(const ValidationState_t& _);
 /// @param[in,out] dom_edges The edges of the dominator tree
 /// @param[in] set_func This function will be called to updated the Immediate
 ///                     dominator
-void UpdateImmediateDominators(
+SPIRV_TOOLS_EXPORT void UpdateImmediateDominators(
     const std::vector<std::pair<BasicBlock*, BasicBlock*>>& dom_edges,
     std::function<void(BasicBlock*, BasicBlock*)> set_func);
 
 /// @brief Prints all of the dominators of a BasicBlock
 ///
 /// @param[in] block The dominators of this block will be printed
-void printDominatorList(BasicBlock& block);
+SPIRV_TOOLS_EXPORT void printDominatorList(BasicBlock& block);
 
 /// Performs logical layout validation as described in section 2.4 of the SPIR-V
 /// spec.
-spv_result_t ModuleLayoutPass(ValidationState_t& _,
+SPIRV_TOOLS_EXPORT spv_result_t ModuleLayoutPass(ValidationState_t& _,
                               const spv_parsed_instruction_t* inst);
 
 /// Performs Control Flow Graph validation of a module
-spv_result_t CfgPass(ValidationState_t& _,
+SPIRV_TOOLS_EXPORT spv_result_t CfgPass(ValidationState_t& _,
                      const spv_parsed_instruction_t* inst);
 
 /// Performs Id and SSA validation of a module
-spv_result_t IdPass(ValidationState_t& _, const spv_parsed_instruction_t* inst);
+SPIRV_TOOLS_EXPORT spv_result_t IdPass(ValidationState_t& _, const spv_parsed_instruction_t* inst);
 
 /// Performs validation of the Data Rules subsection of 2.16.1 Universal
 /// Validation Rules.
 /// TODO(ehsann): add more comments here as more validation code is added.
-spv_result_t DataRulesPass(ValidationState_t& _,
+SPIRV_TOOLS_EXPORT spv_result_t DataRulesPass(ValidationState_t& _,
                            const spv_parsed_instruction_t* inst);
 
 /// Performs instruction validation.
-spv_result_t InstructionPass(ValidationState_t& _,
+SPIRV_TOOLS_EXPORT spv_result_t InstructionPass(ValidationState_t& _,
                              const spv_parsed_instruction_t* inst);
 
 /// Performs decoration validation.
-spv_result_t ValidateDecorations(ValidationState_t& _);
+SPIRV_TOOLS_EXPORT spv_result_t ValidateDecorations(ValidationState_t& _);
 
 /// Validates that type declarations are unique, unless multiple declarations
 /// of the same data type are allowed by the specification.
 /// (see section 2.8 Types and Variables)
-spv_result_t TypeUniquePass(ValidationState_t& _,
+SPIRV_TOOLS_EXPORT spv_result_t TypeUniquePass(ValidationState_t& _,
                             const spv_parsed_instruction_t* inst);
 
 /// Validates correctness of arithmetic instructions.
-spv_result_t ArithmeticsPass(ValidationState_t& _,
+SPIRV_TOOLS_EXPORT spv_result_t ArithmeticsPass(ValidationState_t& _,
                             const spv_parsed_instruction_t* inst);
 
 /// Validates correctness of conversion instructions.
@@ -120,16 +120,16 @@ spv_result_t ConversionPass(ValidationState_t& _,
                             const spv_parsed_instruction_t* inst);
 
 /// Validates correctness of logical instructions.
-spv_result_t LogicalsPass(ValidationState_t& _,
+SPIRV_TOOLS_EXPORT spv_result_t LogicalsPass(ValidationState_t& _,
                           const spv_parsed_instruction_t* inst);
 
 /// Validates correctness of bitwise instructions.
-spv_result_t BitwisePass(ValidationState_t& _,
+SPIRV_TOOLS_EXPORT spv_result_t BitwisePass(ValidationState_t& _,
                          const spv_parsed_instruction_t* inst);
 
 // Validates that capability declarations use operands allowed in the current
 // context.
-spv_result_t CapabilityPass(ValidationState_t& _,
+SPIRV_TOOLS_EXPORT spv_result_t CapabilityPass(ValidationState_t& _,
                             const spv_parsed_instruction_t* inst);
 
 }  // namespace libspirv
@@ -144,7 +144,7 @@ spv_result_t CapabilityPass(ValidationState_t& _,
 /// @param[in,out] position current position in the stream
 ///
 /// @return result code
-spv_result_t spvValidateInstructionIDs(const spv_instruction_t* pInsts,
+SPIRV_TOOLS_EXPORT spv_result_t spvValidateInstructionIDs(const spv_instruction_t* pInsts,
                                        const uint64_t instCount,
                                        const spv_opcode_table opcodeTable,
                                        const spv_operand_table operandTable,
@@ -163,7 +163,7 @@ spv_result_t spvValidateInstructionIDs(const spv_instruction_t* pInsts,
 /// @param[in] consumer message consumer callback
 ///
 /// @return result code
-spv_result_t spvValidateIDs(const spv_instruction_t* pInstructions,
+SPIRV_TOOLS_EXPORT spv_result_t spvValidateIDs(const spv_instruction_t* pInstructions,
                             const uint64_t count, const uint32_t bound,
                             const spv_opcode_table opcodeTable,
                             const spv_operand_table operandTable,
@@ -176,14 +176,14 @@ namespace spvtools {
 // The main difference between this API and spvValidateBinary is that the
 // "Validation State" is not destroyed upon function return; it lives on and is
 // pointed to by the vstate unique_ptr.
-spv_result_t ValidateBinaryAndKeepValidationState(
+SPIRV_TOOLS_EXPORT spv_result_t ValidateBinaryAndKeepValidationState(
     const spv_const_context context, spv_const_validator_options options,
     const uint32_t* words, const size_t num_words, spv_diagnostic* pDiagnostic,
     std::unique_ptr<libspirv::ValidationState_t>* vstate);
 
 // Performs validation for a single instruction and updates given validation
 // state.
-spv_result_t ValidateInstructionAndUpdateValidationState(
+SPIRV_TOOLS_EXPORT spv_result_t ValidateInstructionAndUpdateValidationState(
     libspirv::ValidationState_t* vstate, const spv_parsed_instruction_t* inst);
 
 }  // namespace spvtools


### PR DESCRIPTION
Hello people,

Not sure if that be useful for anyone, but I am experimenting with this project and noticed that no symbols gets exported when creating a shared library on Windows.

So I modified build script and headers to select what should be exported or not.
The approach should be quite portable as I rely on CMake ``GenerateExportHeader`` module.

I haven*t touched travis or appveyor file to add windows shared library build to CI as I don't know what this is the recommended way to do so, but if merged it should go there to verify shared library correctly generate export symbol

Let me know what you think of it and if it worth a merge to upstream.