### PR TITLE
More re-factoring to simplify pass initialization.

### DIFF
--- a/source/opt/cfg_cleanup_pass.cpp
+++ b/source/opt/cfg_cleanup_pass.cpp
@@ -225,7 +225,6 @@ bool CFGCleanupPass::CFGCleanup(ir::Function* func) {
 
 void CFGCleanupPass::Initialize(ir::Module* module) {
   InitializeProcessing(module);
-  FindNamedOrDecoratedIds();
 
   // Initialize block lookup map.
   label2block_.clear();
@@ -253,7 +252,6 @@ Pass::Status CFGCleanupPass::Process(ir::Module* module) {
   // Process all entry point functions.
   ProcessFunction pfn = [this](ir::Function* fp) { return CFGCleanup(fp); };
   bool modified = ProcessReachableCallTree(pfn, module);
-  FinalizeNextId();
   return modified ? Pass::Status::SuccessWithChange
                   : Pass::Status::SuccessWithoutChange;
 }

--- a/source/opt/common_uniform_elim_pass.cpp
+++ b/source/opt/common_uniform_elim_pass.cpp
@@ -593,7 +593,6 @@ Pass::Status CommonUniformElimPass::ProcessImpl() {
     return EliminateCommonUniform(fp);
   };
   bool modified = ProcessEntryPointCallTree(pfn, get_module());
-  FinalizeNextId();
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 

--- a/source/opt/dead_branch_elim_pass.cpp
+++ b/source/opt/dead_branch_elim_pass.cpp
@@ -393,14 +393,11 @@ Pass::Status DeadBranchElimPass::ProcessImpl() {
   // Do not process if any disallowed extensions are enabled
   if (!AllExtensionsSupported())
     return Status::SuccessWithoutChange;
-  // Collect all named and decorated ids
-  FindNamedOrDecoratedIds();
   // Process all entry point functions
   ProcessFunction pfn = [this](ir::Function* fp) {
     return EliminateDeadBranches(fp);
   };
   bool modified = ProcessEntryPointCallTree(pfn, get_module());
-  FinalizeNextId();
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 

--- a/source/opt/dead_variable_elimination.cpp
+++ b/source/opt/dead_variable_elimination.cpp
@@ -27,7 +27,6 @@ Pass::Status DeadVariableElimination::Process(spvtools::ir::Module* module) {
   // that might have references that are not explicit in this module, we use the
   // value kMustKeep as the reference count.
   InitializeProcessing(module);
-  FindNamedOrDecoratedIds();
 
   //  Decoration manager to help organize decorations.
   analysis::DecorationManager decoration_manager(module);

--- a/source/opt/eliminate_dead_functions_pass.cpp
+++ b/source/opt/eliminate_dead_functions_pass.cpp
@@ -31,7 +31,6 @@ Pass::Status EliminateDeadFunctionsPass::Process(ir::Module* module) {
   };
   ProcessReachableCallTree(mark_live, module);
 
-  FindNamedOrDecoratedIds();
   bool modified = false;
   for (auto funcIter = module->begin(); funcIter != module->end();) {
     if (live_function_set.count(&*funcIter) == 0) {

--- a/source/opt/inline_exhaustive_pass.cpp
+++ b/source/opt/inline_exhaustive_pass.cpp
@@ -59,7 +59,6 @@ Pass::Status InlineExhaustivePass::ProcessImpl() {
     return InlineExhaustive(fp);
   };
   bool modified = ProcessEntryPointCallTree(pfn, get_module());
-  FinalizeNextId();
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 

--- a/source/opt/inline_opaque_pass.cpp
+++ b/source/opt/inline_opaque_pass.cpp
@@ -107,7 +107,6 @@ Pass::Status InlineOpaquePass::ProcessImpl() {
     return InlineOpaque(fp);
   };
   bool modified = ProcessEntryPointCallTree(pfn, get_module());
-  FinalizeNextId();
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -290,14 +290,11 @@ Pass::Status LocalAccessChainConvertPass::ProcessImpl() {
   // Do not process if any disallowed extensions are enabled
   if (!AllExtensionsSupported())
     return Status::SuccessWithoutChange;
-  // Collect all named and decorated ids
-  FindNamedOrDecoratedIds();
   // Process all entry point functions.
   ProcessFunction pfn = [this](ir::Function* fp) {
     return ConvertLocalAccessChains(fp);
   };
   bool modified = ProcessEntryPointCallTree(pfn, get_module());
-  FinalizeNextId();
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 

--- a/source/opt/local_single_block_elim_pass.cpp
+++ b/source/opt/local_single_block_elim_pass.cpp
@@ -176,14 +176,11 @@ Pass::Status LocalSingleBlockLoadStoreElimPass::ProcessImpl() {
   // return unmodified. 
   if (!AllExtensionsSupported())
     return Status::SuccessWithoutChange;
-  // Collect all named and decorated ids
-  FindNamedOrDecoratedIds();
   // Process all entry point functions
   ProcessFunction pfn = [this](ir::Function* fp) {
     return LocalSingleBlockLoadStoreElim(fp);
   };
   bool modified = ProcessEntryPointCallTree(pfn, get_module());
-  FinalizeNextId();
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 

--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -279,14 +279,11 @@ Pass::Status LocalSingleStoreElimPass::ProcessImpl() {
   // Do not process if any disallowed extensions are enabled
   if (!AllExtensionsSupported())
     return Status::SuccessWithoutChange;
-  // Collect all named and decorated ids
-  FindNamedOrDecoratedIds();
   // Process all entry point functions
   ProcessFunction pfn = [this](ir::Function* fp) {
     return LocalSingleStoreElim(fp);
   };
   bool modified = ProcessEntryPointCallTree(pfn, get_module());
-  FinalizeNextId();
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 

--- a/source/opt/local_ssa_elim_pass.cpp
+++ b/source/opt/local_ssa_elim_pass.cpp
@@ -82,14 +82,11 @@ Pass::Status LocalMultiStoreElimPass::ProcessImpl() {
   // Do not process if any disallowed extensions are enabled
   if (!AllExtensionsSupported())
     return Status::SuccessWithoutChange;
-  // Collect all named and decorated ids
-  FindNamedOrDecoratedIds();
   // Process functions
   ProcessFunction pfn = [this](ir::Function* fp) {
     return EliminateMultiStoreLocal(fp);
   };
   bool modified = ProcessEntryPointCallTree(pfn, get_module());
-  FinalizeNextId();
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 

--- a/source/opt/mem_pass.h
+++ b/source/opt/mem_pass.h
@@ -41,6 +41,12 @@ class MemPass : public Pass {
   virtual ~MemPass() = default;
 
  protected:
+  // Initialize basic data structures for the pass.
+  void InitializeProcessing(ir::Module* module) {
+    Pass::InitializeProcessing(module);
+    FindNamedOrDecoratedIds();
+  }
+
   // Returns true if |typeInst| is a scalar type
   // or a vector or matrix
   bool IsBaseTargetType(const ir::Instruction* typeInst) const;
@@ -73,9 +79,6 @@ class MemPass : public Pass {
 
   // Kill all name and decorate ops using |id|
   void KillNamesAndDecorates(uint32_t id);
-
-  // Collect all named or decorated ids in module
-  void FindNamedOrDecoratedIds();
 
   // Return true if any instruction loads from |varId|
   bool HasLoads(uint32_t varId) const;
@@ -183,6 +186,9 @@ class MemPass : public Pass {
   // Return true if variable is loaded in block with |label| or in any
   // succeeding block in structured order.
   bool IsLiveAfter(uint32_t var_id, uint32_t label) const;
+
+  // Collect all named or decorated ids in module.
+  void FindNamedOrDecoratedIds();
 
   // named or decorated ids
   std::unordered_set<uint32_t> named_or_decorated_ids_;

--- a/source/opt/pass.h
+++ b/source/opt/pass.h
@@ -113,7 +113,7 @@ class Pass {
   // manager, module and other attributes. TODO(dnovillo): Some of this should
   // be done during pass instantiation. Other things should be outside the pass
   // altogether (e.g., def-use manager).
-  void InitializeProcessing(ir::Module* module) {
+  virtual void InitializeProcessing(ir::Module* module) {
     module_ = module;
     next_id_ = module_->IdBound();
     def_use_mgr_.reset(new analysis::DefUseManager(consumer(), get_module()));
@@ -151,12 +151,11 @@ class Pass {
   uint32_t GetPointeeTypeId(const ir::Instruction* ptrInst) const;
 
   // Return the next available Id and increment it.
-  inline uint32_t TakeNextId() { return next_id_++; }
-
-  // Write the next available Id back to the module.
-  inline void FinalizeNextId() {
-    assert(module_);
+  inline uint32_t TakeNextId() {
+    assert(module_ && next_id_ > 0);
+    uint32_t retval = next_id_++;
     module_->SetIdBound(next_id_);
+    return retval;
   }
 
   // Returns the id of the merge block declared by a merge instruction in this

--- a/source/opt/strength_reduction_pass.cpp
+++ b/source/opt/strength_reduction_pass.cpp
@@ -63,8 +63,6 @@ Pass::Status StrengthReductionPass::Process(ir::Module* module) {
 
   FindIntTypesAndConstants();
   modified = ScanFunctions();
-  // Have to reset the id bound.
-  FinalizeNextId();
   return (modified ? Status::SuccessWithChange : Status::SuccessWithoutChange);
 }
 


### PR DESCRIPTION
This implements two cleanups suggested by @s-perron
(https://github.com/KhronosGroup/SPIRV-Tools/pull/921):

- Move FindNamedOrDecoratedIds() into MemPass::InitializeProcessing().
- Remove FinalizeNextId(). Always call SetIdBound() from
  Pass::TakeNextId().