### PR TITLE
Fix copyright check when the build directory is in the source directory.

### DIFF
--- a/utils/check_copyright.py
+++ b/utils/check_copyright.py
@@ -76,7 +76,7 @@ def find(top, filename_glob, skip_glob_list):
 def filtered_descendants(glob):
     """Returns glob-matching filenames under the current directory, but skips
     some irrelevant paths."""
-    return find('.', glob, ['third_party', 'external', 'build*', 'out*'])
+    return find('.', glob, ['third_party', 'external', 'CompilerIdCXX', 'build*', 'out*'])
 
 
 def skip(line):


### PR DESCRIPTION
The IDE I am using places the cmake build directory inside the source
directory.  When that happens the copyright check fails because the
build process creates a file CMakeCXXCompilerId.cpp.  That file does
not have the copyright information, so the test fails.

I want this file to be ignored, so I added its directory, CompilerIdCXX,
to the list of directories to be ignored.