### PR TITLE
Move class CFG from namespace opt to namespace ir.

### DIFF
--- a/source/opt/cfg.cpp
+++ b/source/opt/cfg.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "cfa.h"
 #include "cfg.h"
+#include "cfa.h"
 #include "module.h"
 
 namespace spvtools {
-namespace opt {
+namespace ir {
 
 namespace {
 
@@ -44,7 +44,7 @@ CFG::CFG(ir::Module* module)
 }
 
 void CFG::ComputeStructuredOrder(ir::Function* func, ir::BasicBlock* root,
-                                  std::list<ir::BasicBlock*>* order) {
+                                 std::list<ir::BasicBlock*>* order) {
   assert(module_->HasCapability(SpvCapabilityShader) &&
          "This only works on structured control flow");
 
@@ -62,11 +62,10 @@ void CFG::ComputeStructuredOrder(ir::Function* func, ir::BasicBlock* root,
     order->push_front(const_cast<ir::BasicBlock*>(b));
   };
   spvtools::CFA<ir::BasicBlock>::DepthFirstTraversal(
-      root, get_structured_successors, ignore_block, post_order,
-      ignore_edge);
+      root, get_structured_successors, ignore_block, post_order, ignore_edge);
 }
 
-void CFG::ComputeStructuredSuccessors(ir::Function *func) {
+void CFG::ComputeStructuredSuccessors(ir::Function* func) {
   block2structured_succs_.clear();
   for (auto& blk : *func) {
     // If no predecessors in function, make successor to pseudo entry.
@@ -79,8 +78,7 @@ void CFG::ComputeStructuredSuccessors(ir::Function *func) {
     if (mbid != 0) {
       block2structured_succs_[&blk].push_back(id2block_[mbid]);
       uint32_t cbid = blk.ContinueBlockIdIfAny();
-      if (cbid != 0)
-        block2structured_succs_[&blk].push_back(id2block_[cbid]);
+      if (cbid != 0) block2structured_succs_[&blk].push_back(id2block_[cbid]);
     }
 
     // Add true successors.

--- a/source/opt/cfg.h
+++ b/source/opt/cfg.h
@@ -21,11 +21,11 @@
 #include <unordered_map>
 
 namespace spvtools {
-namespace opt {
+namespace ir {
 
 class CFG {
  public:
-  CFG(ir::Module *module);
+  CFG(ir::Module* module);
 
   // Return the module described by this CFG.
   ir::Module* get_module() const { return module_; }
@@ -83,7 +83,7 @@ class CFG {
   void ComputeStructuredSuccessors(ir::Function* func);
 
   // Module for this CFG.
-  ir::Module *module_;
+  ir::Module* module_;
 
   // Map from block to its structured successor blocks. See
   // ComputeStructuredSuccessors() for definition.

--- a/source/opt/pass.h
+++ b/source/opt/pass.h
@@ -87,7 +87,7 @@ class Pass {
 
   // Returns a pointer to the CFG for current module. TODO(dnovillo): This
   // should belong in IRContext.
-  CFG *cfg() const { return cfg_.get(); }
+  ir::CFG *cfg() const { return cfg_.get(); }
 
   // Add to |todo| all ids of functions called in |func|.
   void AddCalls(ir::Function* func, std::queue<uint32_t>* todo);
@@ -125,7 +125,7 @@ class Pass {
     context_ = c;
     next_id_ = context_->IdBound();
     def_use_mgr_.reset(new analysis::DefUseManager(consumer(), get_module()));
-    cfg_.reset(new CFG(get_module()));
+    cfg_.reset(new ir::CFG(get_module()));
   }
 
   // Return type id for |ptrInst|'s pointee
@@ -152,7 +152,7 @@ class Pass {
   ir::IRContext* context_;
 
   // The CFG for all the functions in this module.
-  std::unique_ptr<CFG> cfg_;
+  std::unique_ptr<ir::CFG> cfg_;
 };
 
 }  // namespace opt


### PR DESCRIPTION
It makes more sense to have the CFG inside the ir name space, as it is
descriptive of the representation.