### PR TITLE
Opt: Fix HasLoads to not interpret decoration as load.

### DIFF
--- a/source/opt/mem_pass.cpp
+++ b/source/opt/mem_pass.cpp
@@ -173,7 +173,7 @@ bool MemPass::HasLoads(uint32_t varId) const {
     // better handling of non-store/name.
     if (IsNonPtrAccessChain(op) || op == SpvOpCopyObject) {
       if (HasLoads(u.inst->result_id())) return true;
-    } else if (op != SpvOpStore && op != SpvOpName)
+    } else if (op != SpvOpStore && op != SpvOpName && !IsNonTypeDecorate(op))
       return true;
   }
   return false;

--- a/test/opt/local_ssa_elim_test.cpp
+++ b/test/opt/local_ssa_elim_test.cpp
@@ -847,6 +847,143 @@ OpFunctionEnd
       true, true);
 }
 
+TEST_F(LocalSSAElimTest, DecoratedVar) {
+  // SPIR-V hand edited to decorate v
+  // #version 450
+  // 
+  // layout (location=0) in vec4 BaseColor;
+  // layout (location=1) in float f;
+  // layout (location=0) out vec4 OutColor;
+  // 
+  // void main()
+  // {
+  //     vec4 v;
+  //     if (f >= 0)
+  //       v = BaseColor * 0.5;
+  //     else
+  //       v = BaseColor + vec4(0.1,0.1,0.1,0.1);
+  //     OutColor = v;
+  // }
+
+  const std::string predefs_before =
+      R"(OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %f %BaseColor %OutColor
+OpExecutionMode %main OriginUpperLeft
+OpSource GLSL 450
+OpName %main "main"
+OpName %f "f"
+OpName %v "v"
+OpName %BaseColor "BaseColor"
+OpName %OutColor "OutColor"
+OpDecorate %v RelaxedPrecision
+OpDecorate %f Location 1
+OpDecorate %BaseColor Location 0
+OpDecorate %OutColor Location 0
+%void = OpTypeVoid
+%8 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%_ptr_Input_float = OpTypePointer Input %float
+%f = OpVariable %_ptr_Input_float Input
+%float_0 = OpConstant %float 0
+%bool = OpTypeBool
+%v4float = OpTypeVector %float 4
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%BaseColor = OpVariable %_ptr_Input_v4float Input
+%float_0_5 = OpConstant %float 0.5
+%float_0_1 = OpConstant %float 0.1
+%18 = OpConstantComposite %v4float %float_0_1 %float_0_1 %float_0_1 %float_0_1
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%OutColor = OpVariable %_ptr_Output_v4float Output
+)";
+
+  const std::string predefs_after =
+      R"(OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %f %BaseColor %OutColor
+OpExecutionMode %main OriginUpperLeft
+OpSource GLSL 450
+OpName %main "main"
+OpName %f "f"
+OpName %BaseColor "BaseColor"
+OpName %OutColor "OutColor"
+OpDecorate %f Location 1
+OpDecorate %BaseColor Location 0
+OpDecorate %OutColor Location 0
+%void = OpTypeVoid
+%8 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%_ptr_Input_float = OpTypePointer Input %float
+%f = OpVariable %_ptr_Input_float Input
+%float_0 = OpConstant %float 0
+%bool = OpTypeBool
+%v4float = OpTypeVector %float 4
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%BaseColor = OpVariable %_ptr_Input_v4float Input
+%float_0_5 = OpConstant %float 0.5
+%float_0_1 = OpConstant %float 0.1
+%18 = OpConstantComposite %v4float %float_0_1 %float_0_1 %float_0_1 %float_0_1
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%OutColor = OpVariable %_ptr_Output_v4float Output
+)";
+
+  const std::string before =
+      R"(%main = OpFunction %void None %8
+%20 = OpLabel
+%v = OpVariable %_ptr_Function_v4float Function
+%21 = OpLoad %float %f
+%22 = OpFOrdGreaterThanEqual %bool %21 %float_0
+OpSelectionMerge %23 None
+OpBranchConditional %22 %24 %25 
+%24 = OpLabel
+%26 = OpLoad %v4float %BaseColor
+%27 = OpVectorTimesScalar %v4float %26 %float_0_5
+OpStore %v %27 
+OpBranch %23
+%25 = OpLabel
+%28 = OpLoad %v4float %BaseColor
+%29 = OpFAdd %v4float %28 %18
+OpStore %v %29 
+OpBranch %23
+%23 = OpLabel
+%30 = OpLoad %v4float %v
+OpStore %OutColor %30 
+OpReturn
+OpFunctionEnd
+)";
+
+  const std::string after =
+      R"(%main = OpFunction %void None %8
+%20 = OpLabel
+%21 = OpLoad %float %f
+%22 = OpFOrdGreaterThanEqual %bool %21 %float_0
+OpSelectionMerge %23 None
+OpBranchConditional %22 %24 %25
+%24 = OpLabel
+%26 = OpLoad %v4float %BaseColor
+%27 = OpVectorTimesScalar %v4float %26 %float_0_5
+OpBranch %23
+%25 = OpLabel
+%28 = OpLoad %v4float %BaseColor
+%29 = OpFAdd %v4float %28 %18
+OpBranch %23
+%23 = OpLabel
+%31 = OpPhi %v4float %27 %24 %29 %25
+OpStore %OutColor %31
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndCheck<opt::LocalMultiStoreElimPass>(
+      predefs_before + before,
+      predefs_after + after,
+      true, true);
+}
+
 TEST_F(LocalSSAElimTest, IfThen) {
   // #version 140
   // 


### PR DESCRIPTION
Multi-store elimination was aborting because HasLoads was incorrectly interpreting a variable decoration 
(RelaxedPrecision) as a load.

This was blocking use of spirv-opt in the Vulkan CTS.