### PR TITLE
Appveyor: auto deploy build artifacts to GitHub Releases

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ os:
   - Visual Studio 2017
 
 platform:
-  - Any CPU
+  - x64
 
 configuration:
   - Debug
@@ -36,8 +36,31 @@ build:
 
 build_script:
   - mkdir build && cd build
-  - cmake -DSPIRV_BUILD_COMPRESSION=ON ..
-  - cmake --build . --config %CONFIGURATION%
+  - cmake -DSPIRV_BUILD_COMPRESSION=ON -DCMAKE_INSTALL_PREFIX=install ..
+  - cmake --build . --config %CONFIGURATION% --target install
 
 test_script:
   - ctest -C %CONFIGURATION% --output-on-failure --timeout 300
+
+after_test:
+  # Zip build artifacts for uploading and deploying
+  - cd install
+  - 7z a SPIRV-Tools-master-windows-"%PLATFORM%"-"%CONFIGURATION%".zip *\*
+
+artifacts:
+  - path: build\install\*.zip
+    name: artifacts-zip
+
+deploy:
+  - provider: GitHub
+    auth_token:
+      secure: TMfcScKzzFIm1YgeV/PwCRXFDCw8Xm0wY2Vb2FU6WKlbzb5eUITTpr6I5vHPnAxS
+    release: master-tot
+    description: "Continuous build of the latest master branch by Appveyor and Travis CI"
+    artifact: artifacts-zip
+    draft: false
+    prerelease: false
+    force_update: true
+    on:
+      branch: master
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017


### PR DESCRIPTION
Pushing a commit to the master branch will trigger a build on
Appveyor. If the build is successful, the artifacts will be
collected and pushed to GitHub Releases, under the "master-tot"
release.