### PR TITLE
Add analysis to compute mappings between instructions and basic blocks.

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -371,7 +371,6 @@ bool AggressiveDCEPass::AggressiveDCE(ir::Function* func) {
 
 void AggressiveDCEPass::Initialize(ir::IRContext* c) {
   InitializeProcessing(c);
-  InitializeCFGCleanup(c);
 
   // Clear collections
   worklist_ = std::queue<ir::Instruction*>{};

--- a/source/opt/cfg_cleanup_pass.cpp
+++ b/source/opt/cfg_cleanup_pass.cpp
@@ -29,7 +29,6 @@ namespace opt {
 
 void CFGCleanupPass::Initialize(ir::IRContext* c) {
   InitializeProcessing(c);
-  InitializeCFGCleanup(c);
 }
 
 Pass::Status CFGCleanupPass::Process(ir::IRContext* c) {

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -50,7 +50,8 @@ void IRContext::KillInst(ir::Instruction* inst) {
 
   if (AreAnalysesValid(kAnalysisDefUse)) {
     get_def_use_mgr()->ClearInst(inst);
-  } else if (AreAnalysesValid(kAnalysisInstrToBlockMapping)) {
+  }
+  if (AreAnalysesValid(kAnalysisInstrToBlockMapping)) {
     instr_to_block_.erase(inst);
   }
 

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -22,13 +22,23 @@ void IRContext::BuildInvalidAnalyses(IRContext::Analysis set) {
   if (set & kAnalysisDefUse) {
     BuildDefUseManager();
   }
+  if (set & kAnalysisInstrToBlockMapping) {
+    BuildInstrToBlockMapping();
+  }
 }
 
 void IRContext::InvalidateAnalysesExceptFor(
     IRContext::Analysis preserved_analyses) {
   uint32_t analyses_to_invalidate = valid_analyses_ & (~preserved_analyses);
+  InvalidateAnalyses(static_cast<IRContext::Analysis>(analyses_to_invalidate));
+}
+
+void IRContext::InvalidateAnalyses(IRContext::Analysis analyses_to_invalidate) {
   if (analyses_to_invalidate & kAnalysisDefUse) {
     def_use_mgr_.reset(nullptr);
+  }
+  if (analyses_to_invalidate & kAnalysisInstrToBlockMapping) {
+    instr_to_block_.clear();
   }
   valid_analyses_ = Analysis(valid_analyses_ & ~analyses_to_invalidate);
 }
@@ -40,7 +50,10 @@ void IRContext::KillInst(ir::Instruction* inst) {
 
   if (AreAnalysesValid(kAnalysisDefUse)) {
     get_def_use_mgr()->ClearInst(inst);
+  } else if (AreAnalysesValid(kAnalysisInstrToBlockMapping)) {
+    instr_to_block_.erase(inst);
   }
+
   inst->ToNop();
 }
 
@@ -118,5 +131,6 @@ void IRContext::AnalyzeUses(Instruction* inst) {
     get_def_use_mgr()->AnalyzeInstUse(inst);
   }
 }
+
 }  // namespace ir
 }  // namespace spvtools

--- a/source/opt/ir_context.h
+++ b/source/opt/ir_context.h
@@ -32,17 +32,17 @@ class IRContext {
   // 1. Enum values should be powers of 2. These are cast into uint32_t
   //    bitmasks, so we can have at most 31 analyses represented.
   //
-  // 2. Make sure it gets invalidated by IRContext methods that add or remove IR
-  //    elements (e.g., KillDef, KillInst, ReplaceAllUsesWith).
+  // 2. Make sure it gets invalidated or preserved by IRContext methods that add
+  //    or remove IR elements (e.g., KillDef, KillInst, ReplaceAllUsesWith).
   //
-  // 4. Add handling code in BuildInvalidAnalyses and
+  // 3. Add handling code in BuildInvalidAnalyses and
   //    InvalidateAnalysesExceptFor.
   enum Analysis {
     kAnalysisNone = 0 << 0,
     kAnalysisBegin = 1 << 0,
     kAnalysisDefUse = kAnalysisBegin,
     kAnalysisInstrToBlockMapping = 1 << 1,
-    kAnalysisEnd = kAnalysisInstrToBlockMapping
+    kAnalysisEnd = 1 << 2
   };
 
   friend inline Analysis operator|(Analysis lhs, Analysis rhs);

--- a/source/opt/mem_pass.h
+++ b/source/opt/mem_pass.h
@@ -109,9 +109,6 @@ class MemPass : public Pass {
   // |loadInst|.
   void ReplaceAndDeleteLoad(ir::Instruction* loadInst, uint32_t replId);
 
-  // Initialize CFG Cleanup variables
-  void InitializeCFGCleanup(ir::IRContext* context);
-
   // Call all the cleanup helper functions on |func|.
   bool CFGCleanup(ir::Function* func);
 
@@ -231,11 +228,6 @@ class MemPass : public Pass {
   // The Ids of OpPhi instructions that are in a loop header and which require
   // patching of the value for the loop back-edge.
   std::unordered_set<uint32_t> phis_to_patch_;
-
-  // Map from an instruction result ID to the block that holds it.
-  // TODO(dnovillo): This would be unnecessary if ir::Instruction instances
-  // knew what basic block they belong to.
-  std::unordered_map<uint32_t, ir::BasicBlock*> def_block_;
 };
 
 }  // namespace opt

--- a/test/opt/def_use_test.cpp
+++ b/test/opt/def_use_test.cpp
@@ -517,12 +517,13 @@ TEST_P(ReplaceUseTest, Case) {
   ASSERT_NE(nullptr, module);
   ir::IRContext context(std::move(module), spvtools::MessageConsumer());
 
-  // Analyze def and use.
-  context.BuildDefUseManager();
+  // Force a re-build of def-use manager.
+  context.InvalidateAnalyses(ir::IRContext::Analysis::kAnalysisDefUse);
+  (void)context.get_def_use_mgr();
 
   // Do the substitution.
-  for (const auto& candiate : tc.candidates) {
-    context.ReplaceAllUsesWith(candiate.first, candiate.second);
+  for (const auto& candidate : tc.candidates) {
+    context.ReplaceAllUsesWith(candidate.first, candidate.second);
   }
 
   EXPECT_EQ(tc.after, DisassembleModule(context.module()));
@@ -1071,8 +1072,9 @@ TEST(DefUseTest, OpSwitch) {
   ASSERT_NE(nullptr, module);
   ir::IRContext context(std::move(module), spvtools::MessageConsumer());
 
-  // Analyze def and use.
-  context.BuildDefUseManager();
+  // Force a re-build of def-use manager.
+  context.InvalidateAnalyses(ir::IRContext::Analysis::kAnalysisDefUse);
+  (void)context.get_def_use_mgr();
 
   // Do a bunch replacements.
   context.ReplaceAllUsesWith(9, 900);    // to unused id
@@ -1318,7 +1320,10 @@ TEST_P(KillInstTest, Case) {
       BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, tc.before);
   ASSERT_NE(nullptr, module);
   ir::IRContext context(std::move(module), spvtools::MessageConsumer());
-  context.BuildDefUseManager();
+
+  // Force a re-build of the def-use manager.
+  context.InvalidateAnalyses(ir::IRContext::Analysis::kAnalysisDefUse);
+  (void)context.get_def_use_mgr();
 
   // KillInst
   uint32_t index = 0;

--- a/test/opt/ir_context_test.cpp
+++ b/test/opt/ir_context_test.cpp
@@ -41,7 +41,7 @@ class DummyPassPreservesAll : public opt::Pass {
   Status Process(IRContext*) override { return status_to_return_; }
   Status status_to_return_;
   virtual Analysis GetPreservedAnalyses() override {
-    return Analysis(static_cast<uint32_t>(IRContext::kAnalysisEnd) - 1);
+    return Analysis(IRContext::kAnalysisEnd - 1);
   }
 };
 
@@ -144,7 +144,7 @@ TEST_F(IRContextTest, AllPreserveFirstOnlyAfterPassWithChange) {
     context.BuildInvalidAnalyses(i);
   }
 
-  DummyPassPreservesAll pass(opt::Pass::Status::SuccessWithChange);
+  DummyPassPreservesFirst pass(opt::Pass::Status::SuccessWithChange);
   opt::Pass::Status s = pass.Run(&context);
   EXPECT_EQ(s, opt::Pass::Status::SuccessWithChange);
   EXPECT_TRUE(context.AreAnalysesValid(IRContext::kAnalysisBegin));

--- a/test/opt/ir_context_test.cpp
+++ b/test/opt/ir_context_test.cpp
@@ -41,7 +41,7 @@ class DummyPassPreservesAll : public opt::Pass {
   Status Process(IRContext*) override { return status_to_return_; }
   Status status_to_return_;
   virtual Analysis GetPreservedAnalyses() override {
-    return Analysis(IRContext::kAnalysisEnd - 1);
+    return Analysis(static_cast<uint32_t>(IRContext::kAnalysisEnd) - 1);
   }
 };
 


### PR DESCRIPTION

Note that this is currently running into some testsuite failures.  I believe these should be fixed by #957.