### PR TITLE
Appveyor: Stop testing VS 2013/2015 Debug

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,6 +24,11 @@ clone_depth: 5
 
 matrix:
   fast_finish: true # Show final status immediately if a test fails.
+  exclude:
+    - os: Visual Studio 2013
+      configuration: Debug
+    - os: Visual Studio 2015
+      configuration: Debug
 
 # scripts that run after cloning repository
 install:


### PR DESCRIPTION
VS2017 Debug tests should suffice for intresting Debug cases.
This will save us ~30min of waiting time for each build job.

For #959