### PR TITLE
Add the decoration manager to the IRContext.

### DIFF
--- a/source/link/linker.cpp
+++ b/source/link/linker.cpp
@@ -227,16 +227,15 @@ spv_result_t Linker::Link(const uint32_t* const* binaries,
 
   // Phase 4: Find the import/export pairs
   LinkageTable linkings_to_do;
-  DecorationManager decoration_manager(linked_context.module());
-  res = GetImportExportPairs(consumer, linked_context,
-                             *linked_context.get_def_use_mgr(),
-                             decoration_manager, &linkings_to_do);
+  res = GetImportExportPairs(
+      consumer, linked_context, *linked_context.get_def_use_mgr(),
+      *linked_context.get_decoration_mgr(), &linkings_to_do);
   if (res != SPV_SUCCESS) return res;
 
   // Phase 5: Ensure the import and export have the same types and decorations.
   res = CheckImportExportCompatibility(consumer, linkings_to_do,
                                        *linked_context.get_def_use_mgr(),
-                                       decoration_manager);
+                                       *linked_context.get_decoration_mgr());
   if (res != SPV_SUCCESS) return res;
 
   // Phase 6: Remove duplicates
@@ -248,9 +247,9 @@ spv_result_t Linker::Link(const uint32_t* const* binaries,
 
   // Phase 7: Remove linkage specific instructions, such as import/export
   // attributes, linkage capability, etc. if applicable
-  res = RemoveLinkageSpecificInstructions(consumer, !options.GetCreateLibrary(),
-                                          linkings_to_do, &decoration_manager,
-                                          &linked_context);
+  res = RemoveLinkageSpecificInstructions(
+      consumer, !options.GetCreateLibrary(), linkings_to_do,
+      linked_context.get_decoration_mgr(), &linked_context);
   if (res != SPV_SUCCESS) return res;
 
   // Phase 8: Rematch import variables/functions to export variables/functions

--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -316,3 +316,17 @@ int32_t spvOpcodeGeneratesType(SpvOp op) {
   }
   return 0;
 }
+
+bool spvOpcodeIsDecoration(const SpvOp opcode) {
+  switch(opcode) {
+    case SpvOpDecorate:
+    case SpvOpDecorateId:
+    case SpvOpMemberDecorate:
+    case SpvOpGroupDecorate:
+    case SpvOpGroupMemberDecorate:
+      return true;
+    default:
+      break;
+  }
+  return false;
+}

--- a/source/opcode.h
+++ b/source/opcode.h
@@ -87,4 +87,7 @@ bool spvOpcodeReturnsLogicalVariablePointer(const SpvOp opcode);
 // non-zero otherwise.
 int32_t spvOpcodeGeneratesType(SpvOp opcode);
 
+// Returns true if the opcode add a decoration to an id.
+bool spvOpcodeIsDecoration(const SpvOp opcode);
+
 #endif  // LIBSPIRV_OPCODE_H_

--- a/source/opt/common_uniform_elim_pass.h
+++ b/source/opt/common_uniform_elim_pass.h
@@ -86,12 +86,6 @@ class CommonUniformElimPass : public Pass {
   // Return true if all uses of |id| are only name or decorate ops.
   bool HasOnlyNamesAndDecorates(uint32_t id) const;
 
-  // Kill all name and decorate ops using |inst|
-  void KillNamesAndDecorates(ir::Instruction* inst);
-
-  // Kill all name and decorate ops using |id|
-  void KillNamesAndDecorates(uint32_t id);
-
   // Delete inst if it has no uses. Assumes inst has a resultId.
   void DeleteIfUseless(ir::Instruction* inst);
 
@@ -177,9 +171,6 @@ class CommonUniformElimPass : public Pass {
 
   void Initialize(ir::IRContext* c);
   Pass::Status ProcessImpl();
-
-  // Decorations for the module we are processing
-  std::unique_ptr<analysis::DecorationManager> dec_mgr_;
 
   // Map from uniform variable id to its common load id
   std::unordered_map<uint32_t, uint32_t> uniform2load_id_;

--- a/source/opt/dead_branch_elim_pass.cpp
+++ b/source/opt/dead_branch_elim_pass.cpp
@@ -18,6 +18,7 @@
 
 #include "cfa.h"
 #include "iterator.h"
+#include "ir_context.h"
 
 namespace spvtools {
 namespace opt {
@@ -307,7 +308,7 @@ bool DeadBranchElimPass::EliminateDeadBranches(ir::Function* func) {
         ++pii;
       }
       const uint32_t phiId = pii->result_id();
-      KillNamesAndDecorates(phiId);
+      context()->KillNamesAndDecorates(phiId);
       (void)context()->ReplaceAllUsesWith(phiId, replId);
       context()->KillInst(&*pii);
     }

--- a/source/opt/dead_variable_elimination.cpp
+++ b/source/opt/dead_variable_elimination.cpp
@@ -15,6 +15,7 @@
 #include "dead_variable_elimination.h"
 
 #include "reflect.h"
+#include "ir_context.h"
 
 namespace spvtools {
 namespace opt {
@@ -29,9 +30,6 @@ Pass::Status DeadVariableElimination::Process(ir::IRContext* c) {
   // value kMustKeep as the reference count.
   InitializeProcessing(c);
 
-  //  Decoration manager to help organize decorations.
-  analysis::DecorationManager decoration_manager(context()->module());
-
   std::vector<uint32_t> ids_to_remove;
 
   // Get the reference count for all of the global OpVariable instructions.
@@ -45,7 +43,7 @@ Pass::Status DeadVariableElimination::Process(ir::IRContext* c) {
 
     // Check the linkage.  If it is exported, it could be reference somewhere
     // else, so we must keep the variable around.
-    decoration_manager.ForEachDecoration(
+    get_decoration_mgr()->ForEachDecoration(
         result_id, SpvDecorationLinkageAttributes,
         [&count](const ir::Instruction& linkage_instruction) {
           uint32_t last_operand = linkage_instruction.NumOperands() - 1;
@@ -109,7 +107,6 @@ void DeadVariableElimination::DeleteVariable(uint32_t result_id) {
       }
     }
   }
-  this->KillNamesAndDecorates(result_id);
   context()->KillDef(result_id);
 }
 }  // namespace opt

--- a/source/opt/decoration_manager.h
+++ b/source/opt/decoration_manager.h
@@ -35,9 +35,12 @@ class DecorationManager {
   }
   DecorationManager() = delete;
 
-  // Removes all decorations from |id|, which should not be a group ID, except
-  // for linkage decorations if |keep_linkage| is set.
-  void RemoveDecorationsFrom(uint32_t id, bool keep_linkage);
+  // Removes all decorations from |id|, which should not be a group ID.
+  void RemoveDecorationsFrom(uint32_t id);
+
+  // Removes all decorations from the result id of |inst|.
+  void RemoveDecoration(ir::Instruction* inst);
+
   // Returns a vector of all decorations affecting |id|. If a group is applied
   // to |id|, the decorations of that group are returned rather than the group
   // decoration instruction. If |include_linkage| is not set, linkage
@@ -70,7 +73,14 @@ class DecorationManager {
   // with |true| afterwards.
   void CloneDecorations(uint32_t from, uint32_t to, std::function<void(ir::Instruction&, bool)> f);
 
+  // Informs the decoration manager of a new decoration that it needs to track.
+  void AddDecoration(ir::Instruction* inst);
+
  private:
+  // Removes the instruction from the set of decorations targeting |target_id|.
+  void RemoveInstructionFromTarget(ir::Instruction* inst,
+                                   const uint32_t target_id);
+
   using IdToDecorationInstsMap =
       std::unordered_map<uint32_t, std::vector<ir::Instruction*>>;
   // Analyzes the defs and uses in the given |module| and populates data

--- a/source/opt/eliminate_dead_functions_pass.cpp
+++ b/source/opt/eliminate_dead_functions_pass.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "eliminate_dead_functions_pass.h"
+#include "ir_context.h"
 
 #include <unordered_set>
 
@@ -51,7 +52,6 @@ void EliminateDeadFunctionsPass::EliminateFunction(ir::Function* func) {
   // Remove all of the instruction in the function body
   func->ForEachInst(
       [this](ir::Instruction* inst) {
-        KillNamesAndDecorates(inst);
         context()->KillInst(inst);
       },
       true);

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -145,7 +145,7 @@ void InlinePass::CloneAndMapLocals(
   while (callee_var_itr->opcode() == SpvOp::SpvOpVariable) {
     std::unique_ptr<ir::Instruction> var_inst(callee_var_itr->Clone());
     uint32_t newId = TakeNextId();
-    dec_mgr_->CloneDecorations(callee_var_itr->result_id(), newId, update_def_use_mgr_);
+    get_decoration_mgr()->CloneDecorations(callee_var_itr->result_id(), newId, update_def_use_mgr_);
     var_inst->SetResultId(newId);
     (*callee2caller)[callee_var_itr->result_id()] = newId;
     new_vars->push_back(std::move(var_inst));
@@ -174,7 +174,7 @@ uint32_t InlinePass::CreateReturnVar(
           {SpvStorageClassFunction}}}));
     new_vars->push_back(std::move(var_inst));
   }
-  dec_mgr_->CloneDecorations(calleeFn->result_id(), returnVarId, update_def_use_mgr_);
+  get_decoration_mgr()->CloneDecorations(calleeFn->result_id(), returnVarId, update_def_use_mgr_);
   return returnVarId;
 }
 
@@ -199,7 +199,7 @@ void InlinePass::CloneSameBlockOps(
             CloneSameBlockOps(&sb_inst, postCallSB, preCallSB, block_ptr);
             const uint32_t rid = sb_inst->result_id();
             const uint32_t nid = this->TakeNextId();
-            dec_mgr_->CloneDecorations(rid, nid, update_def_use_mgr_);
+            get_decoration_mgr()->CloneDecorations(rid, nid, update_def_use_mgr_);
             sb_inst->SetResultId(nid);
             (*postCallSB)[rid] = nid;
             *iid = nid;
@@ -479,7 +479,7 @@ void InlinePass::GenInlineCode(
             callee2caller[rid] = nid;
           }
           cp_inst->SetResultId(nid);
-          dec_mgr_->CloneDecorations(rid, nid, update_def_use_mgr_);
+          get_decoration_mgr()->CloneDecorations(rid, nid, update_def_use_mgr_);
         }
         new_blk_ptr->AddInstruction(std::move(cp_inst));
       } break;
@@ -646,7 +646,6 @@ bool InlinePass::IsInlinableFunction(ir::Function* func) {
 void InlinePass::InitializeInline(ir::IRContext* c) {
   InitializeProcessing(c);
 
-  dec_mgr_.reset(new analysis::DecorationManager(c->module()));
   update_def_use_mgr_ = [this] (ir::Instruction& inst, bool has_changed) {
     if (has_changed)
       get_def_use_mgr()->AnalyzeInstDefUse(&inst);

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -165,9 +165,6 @@ class InlinePass : public Pass {
   // Update the DefUseManager when cloning decorations.
   std::function<void(ir::Instruction&, bool)> update_def_use_mgr_;
 
-  // Decorations for the module we are processing TODO: move this to ir_context as well
-  std::unique_ptr<analysis::DecorationManager> dec_mgr_;
-
   // Map from function's result id to function.
   std::unordered_map<uint32_t, ir::Function*> id2function_;
 

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -109,6 +109,5 @@ void Instruction::ReplaceOperands(const std::vector<Operand>& new_operands) {
   operands_.insert(operands_.begin(), new_operands.begin(), new_operands.end());
   operands_.shrink_to_fit();
 }
-
 }  // namespace ir
 }  // namespace spvtools

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -19,6 +19,7 @@
 #include <functional>
 #include <utility>
 #include <vector>
+#include <opcode.h>
 
 #include "operand.h"
 #include "util/ilist_node.h"
@@ -237,6 +238,9 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   // this instruction.
   void ReplaceOperands(const std::vector<Operand>& new_operands);
 
+  // Returns true if the instruction annotates an id with a decoration.
+  inline bool IsDecoration();
+
  private:
   // Returns the total count of result type id and result id.
   uint32_t TypeResultIdCount() const {
@@ -397,6 +401,10 @@ inline bool Instruction::HasLabels() const {
       break;
   }
   return false;
+}
+
+bool Instruction::IsDecoration() {
+  return spvOpcodeIsDecoration(opcode());
 }
 
 }  // namespace ir

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -17,6 +17,7 @@
 #include "local_access_chain_convert_pass.h"
 
 #include "iterator.h"
+#include "ir_context.h"
 
 namespace spvtools {
 namespace opt {
@@ -34,7 +35,6 @@ void LocalAccessChainConvertPass::DeleteIfUseless(ir::Instruction* inst) {
   const uint32_t resId = inst->result_id();
   assert(resId != 0);
   if (HasOnlyNamesAndDecorates(resId)) {
-    KillNamesAndDecorates(resId);
     context()->KillInst(inst);
   }
 }

--- a/source/opt/mem_pass.h
+++ b/source/opt/mem_pass.h
@@ -41,12 +41,6 @@ class MemPass : public Pass {
   virtual ~MemPass() = default;
 
  protected:
-  // Initialize basic data structures for the pass.
-  void InitializeProcessing(ir::IRContext* c) {
-    Pass::InitializeProcessing(c);
-    FindNamedOrDecoratedIds();
-  }
-
   // Returns true if |typeInst| is a scalar type
   // or a vector or matrix
   bool IsBaseTargetType(const ir::Instruction* typeInst) const;
@@ -74,17 +68,8 @@ class MemPass : public Pass {
   // Return true if all uses of |id| are only name or decorate ops.
   bool HasOnlyNamesAndDecorates(uint32_t id) const;
 
-  // Kill all name and decorate ops using |inst|
-  void KillNamesAndDecorates(ir::Instruction* inst);
-
-  // Kill all name and decorate ops using |id|
-  void KillNamesAndDecorates(uint32_t id);
-
   // Kill all instructions in block |bp|.
   void KillAllInsts(ir::BasicBlock* bp);
-
-  // Collect all named or decorated ids in module
-  void FindNamedOrDecoratedIds();
 
   // Return true if any instruction loads from |varId|
   bool HasLoads(uint32_t varId) const;
@@ -207,8 +192,6 @@ class MemPass : public Pass {
   // |reachable_blocks|.
   void RemovePhiOperands(ir::Instruction* phi,
                          std::unordered_set<ir::BasicBlock*> reachable_blocks);
-  // named or decorated ids
-  std::unordered_set<uint32_t> named_or_decorated_ids_;
 
   // Map from block's label id to a map of a variable to its value at the
   // end of the block.

--- a/source/opt/pass.h
+++ b/source/opt/pass.h
@@ -79,6 +79,10 @@ class Pass {
     return context()->get_def_use_mgr();
   }
 
+  analysis::DecorationManager* get_decoration_mgr() const {
+    return context()->get_decoration_mgr();
+  }
+
   // Returns a pointer to the current module for this pass.
   ir::Module* get_module() const { return context_->module(); }
 

--- a/source/opt/remove_duplicates_pass.cpp
+++ b/source/opt/remove_duplicates_pass.cpp
@@ -36,11 +36,9 @@ using opt::analysis::DefUseManager;
 using opt::analysis::DecorationManager;
 
 Pass::Status RemoveDuplicatesPass::Process(ir::IRContext* irContext) {
-  DecorationManager decManager(irContext->module());
-
   bool modified = RemoveDuplicateCapabilities(irContext);
   modified |= RemoveDuplicatesExtInstImports(irContext);
-  modified |= RemoveDuplicateTypes(irContext, decManager);
+  modified |= RemoveDuplicateTypes(irContext);
   modified |= RemoveDuplicateDecorations(irContext);
 
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
@@ -92,8 +90,7 @@ bool RemoveDuplicatesPass::RemoveDuplicatesExtInstImports(
   return modified;
 }
 
-bool RemoveDuplicatesPass::RemoveDuplicateTypes(
-    ir::IRContext* irContext, DecorationManager& decManager) const {
+bool RemoveDuplicatesPass::RemoveDuplicateTypes(ir::IRContext* irContext) const {
   bool modified = false;
 
   std::vector<Instruction> visitedTypes;
@@ -110,7 +107,7 @@ bool RemoveDuplicatesPass::RemoveDuplicateTypes(
     // Is the current type equal to one of the types we have aready visited?
     SpvId idToKeep = 0u;
     for (auto j : visitedTypes) {
-      if (AreTypesEqual(*i, j, *irContext->get_def_use_mgr(), decManager)) {
+      if (AreTypesEqual(*i, j, *irContext->get_def_use_mgr(), *irContext->get_decoration_mgr())) {
         idToKeep = j.result_id();
         break;
       }

--- a/source/opt/remove_duplicates_pass.h
+++ b/source/opt/remove_duplicates_pass.h
@@ -43,8 +43,7 @@ class RemoveDuplicatesPass : public Pass {
  private:
   bool RemoveDuplicateCapabilities(ir::IRContext* irContext) const;
   bool RemoveDuplicatesExtInstImports(ir::IRContext* irContext) const;
-  bool RemoveDuplicateTypes(ir::IRContext* irContext,
-                            analysis::DecorationManager& decManager) const;
+  bool RemoveDuplicateTypes(ir::IRContext* irContext) const;
   bool RemoveDuplicateDecorations(ir::IRContext* irContext) const;
 };
 


### PR DESCRIPTION
To make the decoration manger available everywhere, and to reduce the
number of times it needs to be build, I add one the IRContext.

As the same time, I move code that modifies decoration instruction into
the IRContext from mempass and the decoration manager.  This will make
it easier to keep everything up to date.

This should take care of issue #928.