### PR TITLE
Git should ignore external repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 /build*
 .ycm_extra_conf.py*
 compile_commands.json
-/external/googletest/
-/external/spirv-headers/
+/external/googletest
+/external/spirv-headers
+/external/effcee
+/external/re2
 /TAGS
 /.clang_complete
 


### PR DESCRIPTION
Ignore googletest, spirv-headers, effcee, and re2