### PR TITLE
Create a local redundancy elimination pass

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -76,10 +76,12 @@ SPVTOOLS_OPT_SRC_FILES := \
 		source/opt/ir_context.cpp \
 		source/opt/ir_loader.cpp \
 		source/opt/local_access_chain_convert_pass.cpp \
+		source/opt/local_redundancy_elimination.cpp \
 		source/opt/local_single_block_elim_pass.cpp \
 		source/opt/local_single_store_elim_pass.cpp \
 		source/opt/local_ssa_elim_pass.cpp \
 		source/opt/mem_pass.cpp \
+		source/opt/merge_return_pass.cpp \
 		source/opt/module.cpp \
 		source/opt/optimizer.cpp \
 		source/opt/pass.cpp \
@@ -91,7 +93,7 @@ SPVTOOLS_OPT_SRC_FILES := \
 		source/opt/type_manager.cpp \
 		source/opt/types.cpp \
 		source/opt/unify_const_pass.cpp \
-		source/opt/merge_return_pass.cpp
+		source/opt/value_number_table.cpp
 
 # Locations of grammar files.
 SPV_CORE10_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/1.0/spirv.core.grammar.json

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -418,6 +418,10 @@ Optimizer::PassToken CreateDeadVariableEliminationPass();
 // the shader capability is detected.
 Optimizer::PassToken CreateMergeReturnPass();
 
+// Create value numbering pass.
+// This pass will look for instructions in the same basic block that compute the
+// same value, and remove the redundant ones.
+Optimizer::PassToken CreateLocalRedundancyEliminationPass();
 }  // namespace spvtools
 
 #endif  // SPIRV_TOOLS_OPTIMIZER_HPP_

--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -318,7 +318,7 @@ int32_t spvOpcodeGeneratesType(SpvOp op) {
 }
 
 bool spvOpcodeIsDecoration(const SpvOp opcode) {
-  switch(opcode) {
+  switch (opcode) {
     case SpvOpDecorate:
     case SpvOpDecorateId:
     case SpvOpMemberDecorate:
@@ -329,4 +329,59 @@ bool spvOpcodeIsDecoration(const SpvOp opcode) {
       break;
   }
   return false;
+}
+
+bool spvOpcodeIsLoad(const SpvOp opcode) {
+  switch (opcode) {
+    case SpvOpLoad:
+    case SpvOpImageSampleExplicitLod:
+    case SpvOpImageSampleImplicitLod:
+    case SpvOpImageSampleDrefImplicitLod:
+    case SpvOpImageSampleDrefExplicitLod:
+    case SpvOpImageSampleProjImplicitLod:
+    case SpvOpImageSampleProjExplicitLod:
+    case SpvOpImageSampleProjDrefImplicitLod:
+    case SpvOpImageSampleProjDrefExplicitLod:
+    case SpvOpImageFetch:
+    case SpvOpImageGather:
+    case SpvOpImageDrefGather:
+    case SpvOpImageRead:
+    case SpvOpImageSparseSampleImplicitLod:
+    case SpvOpImageSparseSampleExplicitLod:
+    case SpvOpImageSparseSampleDrefExplicitLod:
+    case SpvOpImageSparseSampleDrefImplicitLod:
+    case SpvOpImageSparseFetch:
+    case SpvOpImageSparseGather:
+    case SpvOpImageSparseDrefGather:
+    case SpvOpImageSparseRead:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool spvOpcodeIsAtomicOp(const SpvOp opcode) {
+  switch (opcode) {
+    case SpvOpAtomicLoad:
+    case SpvOpAtomicStore:
+    case SpvOpAtomicExchange:
+    case SpvOpAtomicCompareExchange:
+    case SpvOpAtomicCompareExchangeWeak:
+    case SpvOpAtomicIIncrement:
+    case SpvOpAtomicIDecrement:
+    case SpvOpAtomicIAdd:
+    case SpvOpAtomicISub:
+    case SpvOpAtomicSMin:
+    case SpvOpAtomicUMin:
+    case SpvOpAtomicSMax:
+    case SpvOpAtomicUMax:
+    case SpvOpAtomicAnd:
+    case SpvOpAtomicOr:
+    case SpvOpAtomicXor:
+    case SpvOpAtomicFlagTestAndSet:
+    case SpvOpAtomicFlagClear:
+      return true;
+    default:
+      return false;
+  }
 }

--- a/source/opcode.h
+++ b/source/opcode.h
@@ -87,7 +87,14 @@ bool spvOpcodeReturnsLogicalVariablePointer(const SpvOp opcode);
 // non-zero otherwise.
 int32_t spvOpcodeGeneratesType(SpvOp opcode);
 
-// Returns true if the opcode add a decoration to an id.
+// Returns true if the opcode adds a decoration to an id.
 bool spvOpcodeIsDecoration(const SpvOp opcode);
+
+// Returns true if the opcode is a load from memory into a result id.  This
+// function only considers core instructions.
+bool spvOpcodeIsLoad(const SpvOp opcode);
+
+// Returns true if the opcode is an atomic operation.
+bool spvOpcodeIsAtomicOp(const SpvOp opcode);
 
 #endif  // LIBSPIRV_OPCODE_H_

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(SPIRV-Tools-opt
   ir_loader.h
   ir_context.h
   local_access_chain_convert_pass.h
+  local_redundancy_elimination.h
   local_single_block_elim_pass.h
   local_single_store_elim_pass.h
   local_ssa_elim_pass.h
@@ -59,6 +60,7 @@ add_library(SPIRV-Tools-opt
   types.h
   type_manager.h
   unify_const_pass.h
+  value_number_table.h
 
   aggressive_dead_code_elim_pass.cpp
   basic_block.cpp
@@ -83,9 +85,11 @@ add_library(SPIRV-Tools-opt
   inline_opaque_pass.cpp
   insert_extract_elim.cpp
   instruction.cpp
+  instruction_list.cpp
   ir_loader.cpp
   ir_context.cpp
   local_access_chain_convert_pass.cpp
+  local_redundancy_elimination.cpp
   local_single_block_elim_pass.cpp
   local_single_store_elim_pass.cpp
   local_ssa_elim_pass.cpp
@@ -103,7 +107,7 @@ add_library(SPIRV-Tools-opt
   types.cpp
   type_manager.cpp
   unify_const_pass.cpp
-  instruction_list.cpp
+  value_number_table.cpp
 )
 
 spvtools_default_compile_options(SPIRV-Tools-opt)

--- a/source/opt/aggressive_dead_code_elim_pass.h
+++ b/source/opt/aggressive_dead_code_elim_pass.h
@@ -77,19 +77,6 @@ class AggressiveDCEPass : public MemPass {
   // to the live instruction worklist.
   void AddStores(uint32_t ptrId);
 
-  // Initialize combinator data structures
-  void InitCombinatorSets();
-
-  // Return true if core operator |op| has no side-effects. Currently returns
-  // true only for shader capability operations.
-  // TODO(greg-lunarg): Add kernel and other operators
-  bool IsCombinator(uint32_t op) const;
-
-  // Return true if OpExtInst |inst| has no side-effects. Currently returns
-  // true only for std.GLSL.450 extensions
-  // TODO(greg-lunarg): Add support for other extensions
-  bool IsCombinatorExt(ir::Instruction* inst) const;
-
   // Initialize extensions whitelist
   void InitExtensions();
 
@@ -180,23 +167,8 @@ class AggressiveDCEPass : public MemPass {
   // Dead instructions. Use for debug cleanup.
   std::unordered_set<const ir::Instruction*> dead_insts_;
 
-  // Opcodes of shader capability core executable instructions
-  // without side-effect. This is a whitelist of operators
-  // that can safely be left unmarked as live at the beginning of
-  // aggressive DCE.
-  std::unordered_set<uint32_t> combinator_ops_shader_;
-
-  // Opcodes of GLSL_std_450 extension executable instructions
-  // without side-effect. This is a whitelist of operators
-  // that can safely be left unmarked as live at the beginning of
-  // aggressive DCE.
-  std::unordered_set<uint32_t> combinator_ops_glsl_std_450_;
-
   // Extensions supported by this pass.
   std::unordered_set<std::string> extensions_whitelist_;
-
-  // Set id for glsl_std_450 extension instructions
-  uint32_t glsl_std_450_id_;
 };
 
 }  // namespace opt

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "ir_context.h"
+#include <spirv/1.0/GLSL.std.450.h>
+#include <cstring>
 #include "log.h"
 #include "mem_pass.h"
 
@@ -46,6 +48,9 @@ void IRContext::InvalidateAnalyses(IRContext::Analysis analyses_to_invalidate) {
   }
   if (analyses_to_invalidate & kAnalysisDecorations) {
     decoration_mgr_.reset(nullptr);
+  }
+  if (analyses_to_invalidate & kAnalysisCombinators) {
+    combinator_ops_.clear();
   }
   valid_analyses_ = Analysis(valid_analyses_ & ~analyses_to_invalidate);
 }
@@ -183,5 +188,249 @@ void IRContext::KillNamesAndDecorates(Instruction* inst) {
   KillNamesAndDecorates(rId);
 }
 
+void IRContext::AddCombinatorsForCapability(uint32_t capability) {
+  if (capability == SpvCapabilityShader) {
+    combinator_ops_[0].insert({
+        SpvOpNop,
+        SpvOpUndef,
+        SpvOpVariable,
+        SpvOpImageTexelPointer,
+        SpvOpLoad,
+        SpvOpAccessChain,
+        SpvOpInBoundsAccessChain,
+        SpvOpArrayLength,
+        SpvOpVectorExtractDynamic,
+        SpvOpVectorInsertDynamic,
+        SpvOpVectorShuffle,
+        SpvOpCompositeConstruct,
+        SpvOpCompositeExtract,
+        SpvOpCompositeInsert,
+        SpvOpCopyObject,
+        SpvOpTranspose,
+        SpvOpSampledImage,
+        SpvOpImageSampleImplicitLod,
+        SpvOpImageSampleExplicitLod,
+        SpvOpImageSampleDrefImplicitLod,
+        SpvOpImageSampleDrefExplicitLod,
+        SpvOpImageSampleProjImplicitLod,
+        SpvOpImageSampleProjExplicitLod,
+        SpvOpImageSampleProjDrefImplicitLod,
+        SpvOpImageSampleProjDrefExplicitLod,
+        SpvOpImageFetch,
+        SpvOpImageGather,
+        SpvOpImageDrefGather,
+        SpvOpImageRead,
+        SpvOpImage,
+        SpvOpConvertFToU,
+        SpvOpConvertFToS,
+        SpvOpConvertSToF,
+        SpvOpConvertUToF,
+        SpvOpUConvert,
+        SpvOpSConvert,
+        SpvOpFConvert,
+        SpvOpQuantizeToF16,
+        SpvOpBitcast,
+        SpvOpSNegate,
+        SpvOpFNegate,
+        SpvOpIAdd,
+        SpvOpFAdd,
+        SpvOpISub,
+        SpvOpFSub,
+        SpvOpIMul,
+        SpvOpFMul,
+        SpvOpUDiv,
+        SpvOpSDiv,
+        SpvOpFDiv,
+        SpvOpUMod,
+        SpvOpSRem,
+        SpvOpSMod,
+        SpvOpFRem,
+        SpvOpFMod,
+        SpvOpVectorTimesScalar,
+        SpvOpMatrixTimesScalar,
+        SpvOpVectorTimesMatrix,
+        SpvOpMatrixTimesVector,
+        SpvOpMatrixTimesMatrix,
+        SpvOpOuterProduct,
+        SpvOpDot,
+        SpvOpIAddCarry,
+        SpvOpISubBorrow,
+        SpvOpUMulExtended,
+        SpvOpSMulExtended,
+        SpvOpAny,
+        SpvOpAll,
+        SpvOpIsNan,
+        SpvOpIsInf,
+        SpvOpLogicalEqual,
+        SpvOpLogicalNotEqual,
+        SpvOpLogicalOr,
+        SpvOpLogicalAnd,
+        SpvOpLogicalNot,
+        SpvOpSelect,
+        SpvOpIEqual,
+        SpvOpINotEqual,
+        SpvOpUGreaterThan,
+        SpvOpSGreaterThan,
+        SpvOpUGreaterThanEqual,
+        SpvOpSGreaterThanEqual,
+        SpvOpULessThan,
+        SpvOpSLessThan,
+        SpvOpULessThanEqual,
+        SpvOpSLessThanEqual,
+        SpvOpFOrdEqual,
+        SpvOpFUnordEqual,
+        SpvOpFOrdNotEqual,
+        SpvOpFUnordNotEqual,
+        SpvOpFOrdLessThan,
+        SpvOpFUnordLessThan,
+        SpvOpFOrdGreaterThan,
+        SpvOpFUnordGreaterThan,
+        SpvOpFOrdLessThanEqual,
+        SpvOpFUnordLessThanEqual,
+        SpvOpFOrdGreaterThanEqual,
+        SpvOpFUnordGreaterThanEqual,
+        SpvOpShiftRightLogical,
+        SpvOpShiftRightArithmetic,
+        SpvOpShiftLeftLogical,
+        SpvOpBitwiseOr,
+        SpvOpBitwiseXor,
+        SpvOpBitwiseAnd,
+        SpvOpNot,
+        SpvOpBitFieldInsert,
+        SpvOpBitFieldSExtract,
+        SpvOpBitFieldUExtract,
+        SpvOpBitReverse,
+        SpvOpBitCount,
+        SpvOpDPdx,
+        SpvOpDPdy,
+        SpvOpFwidth,
+        SpvOpDPdxFine,
+        SpvOpDPdyFine,
+        SpvOpFwidthFine,
+        SpvOpDPdxCoarse,
+        SpvOpDPdyCoarse,
+        SpvOpFwidthCoarse,
+        SpvOpPhi,
+        SpvOpImageSparseSampleImplicitLod,
+        SpvOpImageSparseSampleExplicitLod,
+        SpvOpImageSparseSampleDrefImplicitLod,
+        SpvOpImageSparseSampleDrefExplicitLod,
+        SpvOpImageSparseSampleProjImplicitLod,
+        SpvOpImageSparseSampleProjExplicitLod,
+        SpvOpImageSparseSampleProjDrefImplicitLod,
+        SpvOpImageSparseSampleProjDrefExplicitLod,
+        SpvOpImageSparseFetch,
+        SpvOpImageSparseGather,
+        SpvOpImageSparseDrefGather,
+        SpvOpImageSparseTexelsResident,
+        SpvOpImageSparseRead,
+        SpvOpSizeOf
+        // TODO(dneto): Add instructions enabled by ImageQuery
+    });
+  }
+}
+
+void IRContext::AddCombinatorsForExtension(ir::Instruction* extension) {
+  assert(extension->opcode() == SpvOpExtInstImport &&
+         "Expecting an import of an extension's instruction set.");
+  const char* extension_name =
+      reinterpret_cast<const char*>(&extension->GetInOperand(0).words[0]);
+  if (!strcmp(extension_name, "GLSL.std.450")) {
+    combinator_ops_[extension->result_id()] = {GLSLstd450Round,
+                                               GLSLstd450RoundEven,
+                                               GLSLstd450Trunc,
+                                               GLSLstd450FAbs,
+                                               GLSLstd450SAbs,
+                                               GLSLstd450FSign,
+                                               GLSLstd450SSign,
+                                               GLSLstd450Floor,
+                                               GLSLstd450Ceil,
+                                               GLSLstd450Fract,
+                                               GLSLstd450Radians,
+                                               GLSLstd450Degrees,
+                                               GLSLstd450Sin,
+                                               GLSLstd450Cos,
+                                               GLSLstd450Tan,
+                                               GLSLstd450Asin,
+                                               GLSLstd450Acos,
+                                               GLSLstd450Atan,
+                                               GLSLstd450Sinh,
+                                               GLSLstd450Cosh,
+                                               GLSLstd450Tanh,
+                                               GLSLstd450Asinh,
+                                               GLSLstd450Acosh,
+                                               GLSLstd450Atanh,
+                                               GLSLstd450Atan2,
+                                               GLSLstd450Pow,
+                                               GLSLstd450Exp,
+                                               GLSLstd450Log,
+                                               GLSLstd450Exp2,
+                                               GLSLstd450Log2,
+                                               GLSLstd450Sqrt,
+                                               GLSLstd450InverseSqrt,
+                                               GLSLstd450Determinant,
+                                               GLSLstd450MatrixInverse,
+                                               GLSLstd450ModfStruct,
+                                               GLSLstd450FMin,
+                                               GLSLstd450UMin,
+                                               GLSLstd450SMin,
+                                               GLSLstd450FMax,
+                                               GLSLstd450UMax,
+                                               GLSLstd450SMax,
+                                               GLSLstd450FClamp,
+                                               GLSLstd450UClamp,
+                                               GLSLstd450SClamp,
+                                               GLSLstd450FMix,
+                                               GLSLstd450IMix,
+                                               GLSLstd450Step,
+                                               GLSLstd450SmoothStep,
+                                               GLSLstd450Fma,
+                                               GLSLstd450FrexpStruct,
+                                               GLSLstd450Ldexp,
+                                               GLSLstd450PackSnorm4x8,
+                                               GLSLstd450PackUnorm4x8,
+                                               GLSLstd450PackSnorm2x16,
+                                               GLSLstd450PackUnorm2x16,
+                                               GLSLstd450PackHalf2x16,
+                                               GLSLstd450PackDouble2x32,
+                                               GLSLstd450UnpackSnorm2x16,
+                                               GLSLstd450UnpackUnorm2x16,
+                                               GLSLstd450UnpackHalf2x16,
+                                               GLSLstd450UnpackSnorm4x8,
+                                               GLSLstd450UnpackUnorm4x8,
+                                               GLSLstd450UnpackDouble2x32,
+                                               GLSLstd450Length,
+                                               GLSLstd450Distance,
+                                               GLSLstd450Cross,
+                                               GLSLstd450Normalize,
+                                               GLSLstd450FaceForward,
+                                               GLSLstd450Reflect,
+                                               GLSLstd450Refract,
+                                               GLSLstd450FindILsb,
+                                               GLSLstd450FindSMsb,
+                                               GLSLstd450FindUMsb,
+                                               GLSLstd450InterpolateAtCentroid,
+                                               GLSLstd450InterpolateAtSample,
+                                               GLSLstd450InterpolateAtOffset,
+                                               GLSLstd450NMin,
+                                               GLSLstd450NMax,
+                                               GLSLstd450NClamp};
+  } else {
+    // Map the result id to the empty set.
+    combinator_ops_[extension->result_id()];
+  }
+}
+
+void IRContext::InitializeCombinators() {
+  for( auto& capability : module()->capabilities()) {
+    AddCombinatorsForCapability(capability.GetSingleWordInOperand(0));
+  }
+
+  for( auto& extension : module()->ext_inst_imports()) {
+    AddCombinatorsForExtension(&extension);
+  }
+
+  valid_analyses_ |= kAnalysisCombinators;
+}
 }  // namespace ir
 }  // namespace spvtools

--- a/source/opt/local_redundancy_elimination.cpp
+++ b/source/opt/local_redundancy_elimination.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "local_redundancy_elimination.h"
+
+#include "value_number_table.h"
+
+namespace spvtools {
+namespace opt {
+
+Pass::Status LocalRedundancyEliminationPass::Process(ir::IRContext* c) {
+  InitializeProcessing(c);
+
+  bool modified = false;
+
+  for (auto& func : *get_module()) {
+    for (auto& bb : func) {
+      // Resetting the value number table for every basic block because we just
+      // want the opportunities within a basic block. This will help keep
+      // register pressure down.
+      ValueNumberTable vnTable(context());
+
+      // Keeps track of all ids that contain a given value number. We keep
+      // track of multiple values because they could have the same value, but
+      // different decorations.
+      std::vector<std::vector<uint32_t>> value_to_ids;
+      if (EliminateRedundanciesInBB(&bb, &vnTable, &value_to_ids))
+        modified = true;
+    }
+  }
+
+  return (modified ? Status::SuccessWithChange : Status::SuccessWithoutChange);
+}
+
+bool LocalRedundancyEliminationPass::EliminateRedundanciesInBB(
+    ir::BasicBlock* block, ValueNumberTable* vnTable,
+    std::vector<std::vector<uint32_t>>* value_to_ids) {
+  bool modified = false;
+
+  auto func = [this, vnTable, &modified, value_to_ids](ir::Instruction* inst) {
+    if (inst->result_id() == 0) {
+      return;
+    }
+
+    uint32_t value = vnTable->GetValueNumber(inst);
+    if (value >= value_to_ids->size()) {
+      value_to_ids->resize(value + 1);
+    }
+
+    // Now that we have the value number of the instruction, we use
+    // |value_to_ids| to get other ids that contain the same value.  If we can
+    // find an id in that set which has the same decorations, we can replace all
+    // uses of the result of |inst| by that id.
+    std::vector<uint32_t>& candidate_set = (*value_to_ids)[value];
+    bool found_replacement = false;
+    for (uint32_t candidate_id : candidate_set) {
+      if (get_decoration_mgr()->HaveTheSameDecorations(inst->result_id(),
+                                                       candidate_id)) {
+        context()->KillNamesAndDecorates(inst);
+        context()->ReplaceAllUsesWith(inst->result_id(), candidate_id);
+        context()->KillInst(inst);
+        modified = true;
+        found_replacement = true;
+        break;
+      }
+    }
+
+    // If we did not find a replacement, then add it as a candidate for later
+    // instructions.
+    if (!found_replacement) {
+      candidate_set.push_back(inst->result_id());
+    }
+  };
+  block->ForEachInst(func);
+  return modified;
+}
+}  // namespace opt
+}  // namespace spvtools

--- a/source/opt/local_redundancy_elimination.h
+++ b/source/opt/local_redundancy_elimination.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBSPIRV_OPT_LOCAL_REDUNDANCY_ELIMINATION_H_
+#define LIBSPIRV_OPT_LOCAL_REDUNDANCY_ELIMINATION_H_
+
+#include "ir_context.h"
+#include "pass.h"
+#include "value_number_table.h"
+
+namespace spvtools {
+namespace opt {
+
+// This pass implements local redundancy elimination. Its goal is to reduce the
+// number of times the same value is computed. It works on each basic block
+// independently, ie local. For each instruction in a basic block, it gets the
+// value number for the result id, |id|, of the instruction. If that value
+// number has already been computed in the basic block, it tries to replace the
+// uses of |id| by the id that already contains the same value. Then the
+// current instruction is deleted.
+class LocalRedundancyEliminationPass : public Pass {
+ public:
+  const char* name() const override { return "local-redundancy-elimination"; }
+  Status Process(ir::IRContext*) override;
+
+ private:
+  // Deletes instructions in |block| whose value is in |vnTable| or is computed
+  // earlier in |block|. The values computed in |block| are added to |vnTable|.
+  // |value_to_ids| is a map from a value number to the result ids known to
+  // contain those values. The definition of the ids in value_to_ids must
+  // dominate |block|. One value needs to map to multiple ids because the ids
+  // may contain the same value, but have different decorations.  Returns true
+  // if the module is changed.
+  bool EliminateRedundanciesInBB(
+      ir::BasicBlock* block, ValueNumberTable* vnTable,
+      std::vector<std::vector<uint32_t>>* value_to_ids);
+};
+
+}  // namespace opt
+}  // namespace spvtools
+
+#endif  // LIBSPIRV_OPT_LOCAL_REDUNDANCY_ELIMINATION_H_

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -79,6 +79,7 @@ Optimizer& Optimizer::RegisterPerformancePasses() {
       .RegisterPass(CreateBlockMergePass())
       .RegisterPass(CreateLocalMultiStoreElimPass())
       .RegisterPass(CreateInsertExtractElimPass())
+      .RegisterPass(CreateLocalRedundancyEliminationPass())
       // Currently exposing driver bugs resulting in crashes (#946)
       // .RegisterPass(CreateCommonUniformElimPass())
       .RegisterPass(CreateDeadVariableEliminationPass());
@@ -97,6 +98,7 @@ Optimizer& Optimizer::RegisterSizePasses() {
       .RegisterPass(CreateBlockMergePass())
       .RegisterPass(CreateLocalMultiStoreElimPass())
       .RegisterPass(CreateInsertExtractElimPass())
+      .RegisterPass(CreateLocalRedundancyEliminationPass())
       // Currently exposing driver bugs resulting in crashes (#946)
       // .RegisterPass(CreateCommonUniformElimPass())
       .RegisterPass(CreateDeadVariableEliminationPass());
@@ -261,4 +263,8 @@ Optimizer::PassToken CreateCFGCleanupPass() {
       MakeUnique<opt::CFGCleanupPass>());
 }
 
+Optimizer::PassToken CreateLocalRedundancyEliminationPass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::LocalRedundancyEliminationPass>());
+}
 }  // namespace spvtools

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -41,7 +41,7 @@
 #include "strength_reduction_pass.h"
 #include "strip_debug_info_pass.h"
 #include "unify_const_pass.h"
-#include "eliminate_dead_functions_pass.h"
 #include "merge_return_pass.h"
+#include "local_redundancy_elimination.h"
 
 #endif  // LIBSPIRV_OPT_PASSES_H_

--- a/source/opt/value_number_table.cpp
+++ b/source/opt/value_number_table.cpp
@@ -1,0 +1,115 @@
+// Copyright (c) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "value_number_table.h"
+
+#include <algorithm>
+
+namespace spvtools {
+namespace opt {
+
+uint32_t ValueNumberTable::GetValueNumber(spvtools::ir::Instruction* inst) {
+  // TODO: Need to implement the substitution of operands by their value number
+  // before hashing.
+  // TODO: Implement a normal form for opcodes that commute like integer
+  // addition.  This will let us know that a+b is the same value as b+a.
+  assert(inst->result_id() != 0 &&
+         "inst must have a result id to get a value number.");
+
+  // Check if this instruction already has a value.
+  auto id_to_val = id_to_value_.find(inst->result_id());
+  if (id_to_val != id_to_value_.end()) {
+    return id_to_val->second;
+  }
+
+  // If the instruction has other side effects, then it must
+  // have its own value number.
+  if (!context()->IsCombinatorInstruction(inst)) {
+    uint32_t value_number = TakeNextValueNumber();
+    id_to_value_[inst->result_id()] = value_number;
+    return value_number;
+  }
+
+  // If it is a load from memory that can be modified, we have to assume the
+  // memory has been modified, so we give it a new value number.
+  //
+  // Note that this test will also handle volatile loads because they are not
+  // read only.  However, if this is ever relaxed because we analyze stores, we
+  // will have to add a new case for volatile loads.
+  if (inst->IsLoad() && !inst->IsReadOnlyLoad()) {
+    uint32_t value_number = TakeNextValueNumber();
+    id_to_value_[inst->result_id()] = value_number;
+    return value_number;
+  }
+
+  // Otherwise, we check if this value has been computed before.
+  auto value = instruction_to_value_.find(*inst);
+  if (value != instruction_to_value_.end()) {
+    uint32_t value_number = id_to_value_[value->first.result_id()];
+    id_to_value_[inst->result_id()] = value_number;
+    return value_number;
+  }
+
+  // If not, assign it a new value number.
+  uint32_t value_number = TakeNextValueNumber();
+  id_to_value_[inst->result_id()] = value_number;
+  instruction_to_value_[*inst] = value_number;
+  return value_number;
+}
+
+bool ComputeSameValue::operator()(const ir::Instruction& lhs,
+                                  const ir::Instruction& rhs) const {
+  if (lhs.result_id() == 0 || rhs.result_id() == 0) {
+    return false;
+  }
+
+  if (lhs.opcode() != rhs.opcode()) {
+    return false;
+  }
+
+  if (lhs.type_id() != rhs.type_id()) {
+    return false;
+  }
+
+  if (lhs.NumInOperands() != rhs.NumInOperands()) {
+    return false;
+  }
+
+  for (uint32_t i = 0; i < lhs.NumInOperands(); ++i) {
+    if (lhs.GetInOperand(i) != rhs.GetInOperand(i)) {
+      return false;
+    }
+  }
+
+  return lhs.context()->get_decoration_mgr()->HaveTheSameDecorations(lhs.result_id(), rhs.result_id());
+}
+
+std::size_t ValueTableHash::operator()(
+    const spvtools::ir::Instruction& inst) const {
+  // We hash the opcode and in-operands, not the result, because we want
+  // instructions that are the same except for the result to hash to the same
+  // value.
+  std::u32string h;
+  h.push_back(inst.opcode());
+  h.push_back(inst.type_id());
+  for (uint32_t i = 0; i < inst.NumInOperands(); ++i) {
+    const auto& opnd = inst.GetInOperand(i);
+    for (uint32_t word : opnd.words) {
+      h.push_back(word);
+    }
+  }
+  return std::hash<std::u32string>()(h);
+}
+}  // namespace opt
+}  // namespace spvtools

--- a/source/opt/value_number_table.h
+++ b/source/opt/value_number_table.h
@@ -1,0 +1,74 @@
+// Copyright (c) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBSPIRV_OPT_VALUE_NUMBER_TABLE_H_
+#define LIBSPIRV_OPT_VALUE_NUMBER_TABLE_H_
+
+#include <cstdint>
+#include <unordered_map>
+#include "instruction.h"
+#include "ir_context.h"
+
+namespace spvtools {
+namespace opt {
+
+// Returns true if the two instructions compute the same value.  Used by the
+// value number table to compare two instructions.
+class ComputeSameValue {
+ public:
+  bool operator()(const ir::Instruction& lhs, const ir::Instruction& rhs) const;
+};
+
+// The hash function used in the value number table.
+class ValueTableHash {
+ public:
+  std::size_t operator()(const spvtools::ir::Instruction& inst) const;
+};
+
+// This class implements the value number analysis.  It is using a hash-based
+// approach to value numbering.  For now, it is very simple, and computes value
+// numbers for instructions when they are asked for via |GetValueNumber|.  This
+// may change in the future and should not be relied on.
+class ValueNumberTable {
+ public:
+  ValueNumberTable(ir::IRContext* ctx) : context_(ctx), next_value_number_(1) {}
+
+  // Returns the value number of the value computed by |inst|.  |inst| must have
+  // a result id that will hold the computed value.
+  uint32_t GetValueNumber(spvtools::ir::Instruction* inst);
+
+  // Returns the value number of the value contain in |id|.
+  inline uint32_t GetValueNumber(uint32_t id);
+
+  ir::IRContext* context() { return context_; }
+
+ private:
+  std::unordered_map<spvtools::ir::Instruction, uint32_t, ValueTableHash,
+                     ComputeSameValue>
+      instruction_to_value_;
+  std::unordered_map<uint32_t, uint32_t> id_to_value_;
+  ir::IRContext* context_;
+  uint32_t next_value_number_;
+
+  uint32_t TakeNextValueNumber() { return next_value_number_++; }
+};
+
+uint32_t ValueNumberTable::GetValueNumber(uint32_t id) {
+  return GetValueNumber(context()->get_def_use_mgr()->GetDef(id));
+}
+
+}  // namespace opt
+}  // namespace spvtools
+
+#endif  // LIBSPIRV_OPT_VALUE_NUMBER_TABLE_H_

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -208,3 +208,13 @@ add_spvtools_unittest(TARGET pass_merge_return
   SRCS pass_merge_return_test.cpp pass_utils.cpp
   LIBS SPIRV-Tools-opt
 )
+
+add_spvtools_unittest(TARGET value_table
+  SRCS value_table_test.cpp pass_utils.cpp
+  LIBS SPIRV-Tools-opt
+)
+
+add_spvtools_unittest(TARGET local_redundancy_elimination
+  SRCS local_redundancy_elimination_test.cpp pass_utils.cpp
+  LIBS SPIRV-Tools-opt
+)

--- a/test/opt/local_redundancy_elimination_test.cpp
+++ b/test/opt/local_redundancy_elimination_test.cpp
@@ -1,0 +1,158 @@
+// Copyright (c) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "opt/value_number_table.h"
+
+#include "assembly_builder.h"
+#include "gmock/gmock.h"
+#include "opt/build_module.h"
+#include "pass_fixture.h"
+#include "pass_utils.h"
+
+namespace {
+
+using namespace spvtools;
+
+using ::testing::HasSubstr;
+using ::testing::MatchesRegex;
+
+using LocalRedundancyEliminationTest = PassTest<::testing::Test>;
+
+#ifdef SPIRV_EFFCEE
+// Remove an instruction when it was already computed.
+TEST_F(LocalRedundancyEliminationTest, RemoveRedundantAdd) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 430
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeFloat 32
+          %6 = OpTypePointer Function %5
+          %2 = OpFunction %3 None %4
+          %7 = OpLabel
+          %8 = OpVariable %6 Function
+          %9 = OpLoad %5 %8
+         %10 = OpFAdd %5 %9 %9
+; CHECK: OpFAdd
+; CHECK-NOT: OpFAdd
+         %11 = OpFAdd %5 %9 %9
+               OpReturn
+               OpFunctionEnd
+  )";
+SinglePassRunAndMatch<opt::LocalRedundancyEliminationPass>(text);
+}
+
+// Make sure we keep instruction that are different, but look similar.
+TEST_F(LocalRedundancyEliminationTest, KeepDifferentAdd) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 430
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeFloat 32
+          %6 = OpTypePointer Function %5
+          %2 = OpFunction %3 None %4
+          %7 = OpLabel
+          %8 = OpVariable %6 Function
+          %9 = OpLoad %5 %8
+         %10 = OpFAdd %5 %9 %9
+; CHECK: OpFAdd
+               OpStore %8 %10
+         %11 = OpLoad %5 %8
+; CHECK: %11 = OpLoad
+         %12 = OpFAdd %5 %11 %11
+; CHECK: OpFAdd [[:%\w+]] %11 %11
+               OpReturn
+               OpFunctionEnd
+  )";
+  SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  SinglePassRunAndMatch<opt::LocalRedundancyEliminationPass>(text);
+}
+
+// This test is check that the values are being propagated properly, and that
+// we are able to identify sequences of instruction that are not needed.
+TEST_F(LocalRedundancyEliminationTest, RemoveMultipleInstructions) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 430
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeFloat 32
+          %6 = OpTypePointer Uniform %5
+          %8 = OpVariable %6 Uniform
+          %2 = OpFunction %3 None %4
+          %7 = OpLabel
+; CHECK: [[r1:%\w+]] = OpLoad
+          %9 = OpLoad %5 %8
+; CHECK-NEXT: [[r2:%\w+]] = OpFAdd [[:%\w+]] [[r1]] [[r1]]
+         %10 = OpFAdd %5 %9 %9
+; CHECK-NEXT: [[r3:%\w+]] = OpFMul [[:%\w+]] [[r2]] [[r1]]
+         %11 = OpFMul %5 %10 %9
+; CHECK-NOT: OpLoad
+         %12 = OpLoad %5 %8
+; CHECK-NOT: OpFAdd [[:\w+]] %12 %12
+         %13 = OpFAdd %5 %12 %12
+; CHECK-NOT: OpFMul
+         %14 = OpFMul %5 %13 %12
+; CHECK-NEXT: [[:%\w+]] = OpFAdd [[:%\w+]] [[r3]] [[r3]]
+         %15 = OpFAdd %5 %14 %11
+               OpReturn
+               OpFunctionEnd
+  )";
+  SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  SinglePassRunAndMatch<opt::LocalRedundancyEliminationPass>(text);
+}
+
+// Redundant instructions in different blocks should be kept.
+TEST_F(LocalRedundancyEliminationTest, KeepInstructionsInDifferentBlocks) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 430
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeFloat 32
+          %6 = OpTypePointer Function %5
+          %2 = OpFunction %3 None %4
+        %bb1 = OpLabel
+          %8 = OpVariable %6 Function
+          %9 = OpLoad %5 %8
+         %10 = OpFAdd %5 %9 %9
+; CHECK: OpFAdd
+               OpBranch %bb2
+        %bb2 = OpLabel
+; CHECK: OpFAdd
+         %11 = OpFAdd %5 %9 %9
+               OpReturn
+               OpFunctionEnd
+  )";
+  SinglePassRunAndMatch<opt::LocalRedundancyEliminationPass>(text);
+}
+#endif
+}  // anonymous namespace

--- a/test/opt/value_table_test.cpp
+++ b/test/opt/value_table_test.cpp
@@ -1,0 +1,370 @@
+// Copyright (c) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "opt/value_number_table.h"
+
+#include "assembly_builder.h"
+#include "gmock/gmock.h"
+#include "opt/build_module.h"
+#include "pass_fixture.h"
+
+namespace {
+
+using namespace spvtools;
+
+using ::testing::HasSubstr;
+using ::testing::MatchesRegex;
+
+using ValueTableTest = PassTest<::testing::Test>;
+
+TEST_F(ValueTableTest, SameInstructionSameValue) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 430
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeFloat 32
+          %6 = OpTypePointer Function %5
+          %2 = OpFunction %3 None %4
+          %7 = OpLabel
+          %8 = OpVariable %6 Function
+          %9 = OpLoad %5 %8
+         %10 = OpFAdd %5 %9 %9
+               OpReturn
+               OpFunctionEnd
+  )";
+  auto context = BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text);
+  opt::ValueNumberTable vtable(context.get());
+  ir::Instruction* inst = context->get_def_use_mgr()->GetDef(10);
+  EXPECT_EQ(vtable.GetValueNumber(inst), vtable.GetValueNumber(inst));
+}
+
+TEST_F(ValueTableTest, DifferentInstructionSameValue) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 430
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeFloat 32
+          %6 = OpTypePointer Function %5
+          %2 = OpFunction %3 None %4
+          %7 = OpLabel
+          %8 = OpVariable %6 Function
+          %9 = OpLoad %5 %8
+         %10 = OpFAdd %5 %9 %9
+         %11 = OpFAdd %5 %9 %9
+               OpReturn
+               OpFunctionEnd
+  )";
+  auto context = BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text);
+  opt::ValueNumberTable vtable(context.get());
+  ir::Instruction* inst1 = context->get_def_use_mgr()->GetDef(10);
+  ir::Instruction* inst2 = context->get_def_use_mgr()->GetDef(11);
+  EXPECT_EQ(vtable.GetValueNumber(inst1), vtable.GetValueNumber(inst2));
+}
+
+TEST_F(ValueTableTest, DifferentValue) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 430
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeFloat 32
+          %6 = OpTypePointer Function %5
+          %2 = OpFunction %3 None %4
+          %7 = OpLabel
+          %8 = OpVariable %6 Function
+          %9 = OpLoad %5 %8
+         %10 = OpFAdd %5 %9 %9
+         %11 = OpFAdd %5 %9 %10
+               OpReturn
+               OpFunctionEnd
+  )";
+  auto context = BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text);
+  opt::ValueNumberTable vtable(context.get());
+  ir::Instruction* inst1 = context->get_def_use_mgr()->GetDef(10);
+  ir::Instruction* inst2 = context->get_def_use_mgr()->GetDef(11);
+  EXPECT_NE(vtable.GetValueNumber(inst1), vtable.GetValueNumber(inst2));
+}
+
+TEST_F(ValueTableTest, SameLoad) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 430
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeFloat 32
+          %6 = OpTypePointer Function %5
+          %2 = OpFunction %3 None %4
+          %7 = OpLabel
+          %8 = OpVariable %6 Function
+          %9 = OpLoad %5 %8
+               OpReturn
+               OpFunctionEnd
+  )";
+  auto context = BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text);
+  opt::ValueNumberTable vtable(context.get());
+  ir::Instruction* inst = context->get_def_use_mgr()->GetDef(9);
+  EXPECT_EQ(vtable.GetValueNumber(inst), vtable.GetValueNumber(inst));
+}
+
+// Two different loads, even from the same memory, must given different value
+// numbers if the memory is not read-only.
+TEST_F(ValueTableTest, DifferentFunctionLoad) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 430
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeFloat 32
+          %6 = OpTypePointer Function %5
+          %2 = OpFunction %3 None %4
+          %7 = OpLabel
+          %8 = OpVariable %6 Function
+          %9 = OpLoad %5 %8
+          %10 = OpLoad %5 %8
+               OpReturn
+               OpFunctionEnd
+  )";
+  auto context = BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text);
+  opt::ValueNumberTable vtable(context.get());
+  ir::Instruction* inst1 = context->get_def_use_mgr()->GetDef(9);
+  ir::Instruction* inst2 = context->get_def_use_mgr()->GetDef(10);
+  EXPECT_NE(vtable.GetValueNumber(inst1), vtable.GetValueNumber(inst2));
+}
+
+TEST_F(ValueTableTest, DifferentUniformLoad) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 430
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeFloat 32
+          %6 = OpTypePointer Uniform %5
+          %8 = OpVariable %6 Uniform
+          %2 = OpFunction %3 None %4
+          %7 = OpLabel
+          %9 = OpLoad %5 %8
+          %10 = OpLoad %5 %8
+               OpReturn
+               OpFunctionEnd
+  )";
+  auto context = BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text);
+  opt::ValueNumberTable vtable(context.get());
+  ir::Instruction* inst1 = context->get_def_use_mgr()->GetDef(9);
+  ir::Instruction* inst2 = context->get_def_use_mgr()->GetDef(10);
+  EXPECT_EQ(vtable.GetValueNumber(inst1), vtable.GetValueNumber(inst2));
+}
+
+TEST_F(ValueTableTest, DifferentInputLoad) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 430
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeFloat 32
+          %6 = OpTypePointer Input %5
+          %8 = OpVariable %6 Input
+          %2 = OpFunction %3 None %4
+          %7 = OpLabel
+          %9 = OpLoad %5 %8
+          %10 = OpLoad %5 %8
+               OpReturn
+               OpFunctionEnd
+  )";
+  auto context = BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text);
+  opt::ValueNumberTable vtable(context.get());
+  ir::Instruction* inst1 = context->get_def_use_mgr()->GetDef(9);
+  ir::Instruction* inst2 = context->get_def_use_mgr()->GetDef(10);
+  EXPECT_EQ(vtable.GetValueNumber(inst1), vtable.GetValueNumber(inst2));
+}
+
+TEST_F(ValueTableTest, DifferentUniformConstantLoad) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 430
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeFloat 32
+          %6 = OpTypePointer UniformConstant %5
+          %8 = OpVariable %6 UniformConstant
+          %2 = OpFunction %3 None %4
+          %7 = OpLabel
+          %9 = OpLoad %5 %8
+          %10 = OpLoad %5 %8
+               OpReturn
+               OpFunctionEnd
+  )";
+  auto context = BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text);
+  opt::ValueNumberTable vtable(context.get());
+  ir::Instruction* inst1 = context->get_def_use_mgr()->GetDef(9);
+  ir::Instruction* inst2 = context->get_def_use_mgr()->GetDef(10);
+  EXPECT_EQ(vtable.GetValueNumber(inst1), vtable.GetValueNumber(inst2));
+}
+
+TEST_F(ValueTableTest, DifferentPushConstantLoad) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 430
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeFloat 32
+          %6 = OpTypePointer PushConstant %5
+          %8 = OpVariable %6 PushConstant
+          %2 = OpFunction %3 None %4
+          %7 = OpLabel
+          %9 = OpLoad %5 %8
+          %10 = OpLoad %5 %8
+               OpReturn
+               OpFunctionEnd
+  )";
+  auto context = BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text);
+  opt::ValueNumberTable vtable(context.get());
+  ir::Instruction* inst1 = context->get_def_use_mgr()->GetDef(9);
+  ir::Instruction* inst2 = context->get_def_use_mgr()->GetDef(10);
+  EXPECT_EQ(vtable.GetValueNumber(inst1), vtable.GetValueNumber(inst2));
+}
+
+TEST_F(ValueTableTest, SameCall) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 430
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeFloat 32
+          %6 = OpTypeFunction %5
+          %7 = OpTypePointer Function %5
+          %8 = OpVariable %7 Private
+          %2 = OpFunction %3 None %4
+          %9 = OpLabel
+         %10 = OpFunctionCall %5 %11
+               OpReturn
+               OpFunctionEnd
+         %11 = OpFunction %5 None %6
+         %12 = OpLabel
+         %13 = OpLoad %5 %8
+               OpReturnValue %13
+               OpFunctionEnd
+  )";
+  auto context = BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text);
+  opt::ValueNumberTable vtable(context.get());
+  ir::Instruction* inst= context->get_def_use_mgr()->GetDef(10);
+  EXPECT_EQ(vtable.GetValueNumber(inst), vtable.GetValueNumber(inst));
+}
+
+// Function calls should be given a new value number, even if they are the same.
+TEST_F(ValueTableTest, DifferentCall) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 430
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeFloat 32
+          %6 = OpTypeFunction %5
+          %7 = OpTypePointer Function %5
+          %8 = OpVariable %7 Private
+          %2 = OpFunction %3 None %4
+          %9 = OpLabel
+         %10 = OpFunctionCall %5 %11
+         %12 = OpFunctionCall %5 %11
+               OpReturn
+               OpFunctionEnd
+         %11 = OpFunction %5 None %6
+         %13 = OpLabel
+         %14 = OpLoad %5 %8
+               OpReturnValue %14
+               OpFunctionEnd
+  )";
+  auto context = BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text);
+  opt::ValueNumberTable vtable(context.get());
+  ir::Instruction* inst1= context->get_def_use_mgr()->GetDef(10);
+  ir::Instruction* inst2 = context->get_def_use_mgr()->GetDef(12);
+  EXPECT_NE(vtable.GetValueNumber(inst1), vtable.GetValueNumber(inst2));
+}
+
+// It is possible to have two instruction that compute the same numerical value,
+// but with different types.  They should have different value numbers.
+TEST_F(ValueTableTest, DifferentTypes) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 430
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeInt 32 0
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Function %5
+          %2 = OpFunction %3 None %4
+          %8 = OpLabel
+          %9 = OpVariable %7 Function
+         %10 = OpLoad %5 %9
+         %11 = OpIAdd %5 %10 %10
+         %12 = OpIAdd %6 %10 %10
+               OpReturn
+               OpFunctionEnd
+  )";
+  auto context = BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text);
+  opt::ValueNumberTable vtable(context.get());
+  ir::Instruction* inst1= context->get_def_use_mgr()->GetDef(11);
+  ir::Instruction* inst2 = context->get_def_use_mgr()->GetDef(12);
+  EXPECT_NE(vtable.GetValueNumber(inst1), vtable.GetValueNumber(inst2));
+}
+}  // anonymous namespace

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -162,6 +162,9 @@ Options:
                Replaces instructions with equivalent and less expensive ones.
   --eliminate-dead-variables
                Deletes module scope variables that are not referenced.
+  --local-redundancy-elimination
+               Looks for instructions in the same basic block that compute the
+               same value, and deletes the redundant ones.
   --relax-store-struct
                Allow store from one struct type to a different type with
                compatible layout and members. This option is forwarded to the
@@ -384,6 +387,8 @@ OptStatus ParseFlags(int argc, const char** argv, Optimizer* optimizer,
         optimizer->RegisterPass(CreateCompactIdsPass());
       } else if (0 == strcmp(cur_arg, "--cfg-cleanup")) {
         optimizer->RegisterPass(CreateCFGCleanupPass());
+      } else if (0 == strcmp(cur_arg, "--local-redundancy-elimination")) {
+        optimizer->RegisterPass(CreateLocalRedundancyEliminationPass());
       } else if (0 == strcmp(cur_arg, "--relax-store-struct")) {
         options->relax_struct_store = true;
       } else if (0 == strcmp(cur_arg, "-O")) {


### PR DESCRIPTION
Creates a pass that removes redundant instructions within the same basic
block.  This will be implemented using a hash based value numbering
algorithm.  This is the first part of the fix for #960.