### PR TITLE
Move SetContextMessageConsumer into libspirv namespace

### DIFF
--- a/source/comp/markv_codec.cpp
+++ b/source/comp/markv_codec.cpp
@@ -2846,7 +2846,7 @@ spv_result_t SpirvToMarkv(
     MessageConsumer message_consumer, MarkvLogConsumer log_consumer,
     MarkvDebugConsumer debug_consumer, std::vector<uint8_t>* markv) {
   spv_context_t hijack_context = *context;
-  SetContextMessageConsumer(&hijack_context, message_consumer);
+  libspirv::SetContextMessageConsumer(&hijack_context, message_consumer);
 
   spv_const_binary_t spirv_binary = {spirv.data(), spirv.size()};
 
@@ -2901,7 +2901,7 @@ spv_result_t MarkvToSpirv(
     MarkvDebugConsumer debug_consumer, std::vector<uint32_t>* spirv) {
   spv_position_t position = {};
   spv_context_t hijack_context = *context;
-  SetContextMessageConsumer(&hijack_context, message_consumer);
+  libspirv::SetContextMessageConsumer(&hijack_context, message_consumer);
 
   MarkvDecoder decoder(&hijack_context, markv, options, &markv_model);
 

--- a/source/diagnostic.cpp
+++ b/source/diagnostic.cpp
@@ -117,7 +117,7 @@ void UseDiagnosticAsMessageConsumer(spv_context context,
     spvDiagnosticDestroy(*diagnostic);  // Avoid memory leak.
     *diagnostic = spvDiagnosticCreate(&p, message);
   };
-  SetContextMessageConsumer(context, std::move(create_diagnostic));
+  libspirv::SetContextMessageConsumer(context, std::move(create_diagnostic));
 }
 
 std::string spvResultToString(spv_result_t res) {

--- a/source/libspirv.cpp
+++ b/source/libspirv.cpp
@@ -35,7 +35,7 @@ SpirvTools::SpirvTools(spv_target_env env) : impl_(new Impl(env)) {}
 SpirvTools::~SpirvTools() {}
 
 void SpirvTools::SetMessageConsumer(MessageConsumer consumer) {
-  SetContextMessageConsumer(impl_->context, std::move(consumer));
+  libspirv::SetContextMessageConsumer(impl_->context, std::move(consumer));
 }
 
 bool SpirvTools::Assemble(const std::string& text,

--- a/source/link/linker.cpp
+++ b/source/link/linker.cpp
@@ -162,7 +162,7 @@ Linker::Linker(spv_target_env env) : impl_(new Impl(env)) {}
 Linker::~Linker() {}
 
 void Linker::SetMessageConsumer(MessageConsumer consumer) {
-  SetContextMessageConsumer(impl_->context, std::move(consumer));
+  libspirv::SetContextMessageConsumer(impl_->context, std::move(consumer));
 }
 
 spv_result_t Linker::Link(const std::vector<std::vector<uint32_t>>& binaries,

--- a/source/opt/build_module.cpp
+++ b/source/opt/build_module.cpp
@@ -49,7 +49,7 @@ std::unique_ptr<ir::IRContext> BuildModule(spv_target_env env,
                                         const uint32_t* binary,
                                         const size_t size) {
   auto context = spvContextCreate(env);
-  SetContextMessageConsumer(context, consumer);
+  libspirv::SetContextMessageConsumer(context, consumer);
 
   auto irContext = MakeUnique<ir::IRContext>(consumer);
   ir::IrLoader loader(consumer, irContext->module());

--- a/source/table.cpp
+++ b/source/table.cpp
@@ -48,7 +48,7 @@ spv_context spvContextCreate(spv_target_env env) {
 
 void spvContextDestroy(spv_context context) { delete context; }
 
-void SetContextMessageConsumer(spv_context context,
-                               spvtools::MessageConsumer consumer) {
+void libspirv::SetContextMessageConsumer(spv_context context,
+                                         spvtools::MessageConsumer consumer) {
   context->consumer = std::move(consumer);
 }

--- a/source/table.h
+++ b/source/table.h
@@ -100,10 +100,12 @@ struct spv_context_t {
   spvtools::MessageConsumer consumer;
 };
 
+namespace libspirv {
 // Sets the message consumer to |consumer| in the given |context|. The original
 // message consumer will be overwritten.
 void SetContextMessageConsumer(spv_context context,
                                spvtools::MessageConsumer consumer);
+}  // namespace libspirv
 
 // Populates *table with entries for env.
 spv_result_t spvOpcodeTableGet(spv_opcode_table* table, spv_target_env env);

--- a/test/binary_parse_test.cpp
+++ b/test/binary_parse_test.cpp
@@ -35,6 +35,7 @@ static bool operator==(const spv_parsed_operand_t& a,
 
 namespace {
 
+using ::libspirv::SetContextMessageConsumer;
 using ::spvtest::Concatenate;
 using ::spvtest::MakeInstruction;
 using ::spvtest::MakeVector;

--- a/test/c_interface_test.cpp
+++ b/test/c_interface_test.cpp
@@ -22,6 +22,8 @@ namespace {
 
 using namespace spvtools;
 
+using libspirv::SetContextMessageConsumer;
+
 // The default consumer is a null std::function.
 TEST(CInterface, DefaultConsumerNullDiagnosticForValidInput) {
   auto context = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);

--- a/test/comp/markv_codec_test.cpp
+++ b/test/comp/markv_codec_test.cpp
@@ -26,6 +26,7 @@
 
 namespace {
 
+using libspirv::SetContextMessageConsumer;
 using spvtools::MarkvModelType;
 using spvtest::ScopedContext;
 using MarkvTest = ::testing::TestWithParam<MarkvModelType>;

--- a/test/stats/stats_aggregate_test.cpp
+++ b/test/stats/stats_aggregate_test.cpp
@@ -22,6 +22,7 @@
 
 namespace {
 
+using libspirv::SetContextMessageConsumer;
 using libspirv::SpirvStats;
 using spvtest::ScopedContext;
 

--- a/tools/stats/stats.cpp
+++ b/tools/stats/stats.cpp
@@ -181,7 +181,7 @@ int main(int argc, char** argv) {
   std::cerr << "Processing " << paths.size() << " files..." << std::endl;
 
   ScopedContext ctx(SPV_ENV_UNIVERSAL_1_1);
-  SetContextMessageConsumer(ctx.context, DiagnosticsMessageHandler);
+  libspirv::SetContextMessageConsumer(ctx.context, DiagnosticsMessageHandler);
 
   libspirv::SpirvStats stats;
   stats.opcode_markov_hist.resize(1);


### PR DESCRIPTION
Avoid polluting the global namespace.