### PR TITLE
Add validation checks for Execution Model

### DIFF
--- a/source/val/function.cpp
+++ b/source/val/function.cpp
@@ -17,6 +17,7 @@
 #include <cassert>
 
 #include <algorithm>
+#include <sstream>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -346,6 +347,27 @@ int Function::GetBlockDepth(BasicBlock* bb) {
     block_depth_[bb] = GetBlockDepth(bb_dom);
   }
   return block_depth_[bb];
+}
+
+bool Function::IsCompatibleWithExecutionModel(SpvExecutionModel model,
+                                              std::string* reason) const {
+  bool is_compatible = true;
+  std::stringstream ss_reason;
+
+  for (const auto& kv : execution_model_limitations_) {
+    if (kv.first != model) {
+      if (!reason)
+        return false;
+      is_compatible = false;
+      ss_reason << kv.second << "\n";
+    }
+  }
+
+  if (!is_compatible && reason) {
+    *reason = ss_reason.str();
+  }
+
+  return is_compatible;
 }
 
 }  /// namespace libspirv

--- a/source/val/function.h
+++ b/source/val/function.h
@@ -217,8 +217,8 @@ class Function {
                                       std::string* reason = nullptr) const;
 
   // Inserts id to the set of functions called from this function.
-  void AddFunctionCallTarget(const uint32_t id) {
-    function_call_targets_.insert(id);
+  void AddFunctionCallTarget(uint32_t call_target_id) {
+    function_call_targets_.insert(call_target_id);
   }
 
   // Returns a set with ids of all functions called from this function.

--- a/source/val/function.h
+++ b/source/val/function.h
@@ -17,6 +17,8 @@
 
 #include <functional>
 #include <list>
+#include <map>
+#include <set>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -200,6 +202,30 @@ class Function {
   /// Prints a directed graph of the CFG of the current funciton
   void PrintBlocks() const;
 
+  /// Registers execution model limitation such as "Feature X is only available
+  /// with Execution Model Y". Only the first message per model type is
+  /// registered.
+  void RegisterExecutionModelLimitation(SpvExecutionModel model,
+                                        const std::string& message) {
+    execution_model_limitations_.emplace(model, message);
+  }
+
+  /// Returns true if the given execution model passes the limitations stored in
+  /// execution_model_limitations_. Returns false otherwise and fills optional
+  /// |reason| parameter.
+  bool IsCompatibleWithExecutionModel(SpvExecutionModel model,
+                                      std::string* reason = nullptr) const;
+
+  // Inserts id to the set of functions called from this function.
+  void AddFunctionCallTarget(const uint32_t id) {
+    function_call_targets_.insert(id);
+  }
+
+  // Returns a set with ids of all functions called from this function.
+  const std::set<uint32_t> function_call_targets() const {
+    return function_call_targets_;
+  }
+
  private:
   // Computes the representation of the augmented CFG.
   // Populates augmented_successors_map_ and augmented_predecessors_map_.
@@ -310,6 +336,14 @@ class Function {
 
   /// Stores the control flow nesting depth of a given basic block
   std::unordered_map<BasicBlock*, int> block_depth_;
+
+  /// Stores execution model limitations imposed by instructions used within the
+  /// function. The string contains message explaining why the limitation was
+  /// imposed.
+  std::map<SpvExecutionModel, std::string> execution_model_limitations_;
+
+  /// Stores ids of all functions called from this function.
+  std::set<uint32_t> function_call_targets_;
 };
 
 }  /// namespace libspirv

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -264,6 +264,13 @@ const Function& ValidationState_t::current_function() const {
   return module_functions_.back();
 }
 
+const Function* ValidationState_t::function(uint32_t id) const {
+  const auto it = id_to_function_.find(id);
+  if (it == id_to_function_.end())
+    return nullptr;
+  return it->second;
+}
+
 bool ValidationState_t::in_function_body() const { return in_function_; }
 
 bool ValidationState_t::in_block() const {
@@ -352,6 +359,7 @@ spv_result_t ValidationState_t::RegisterFunction(
   in_function_ = true;
   module_functions_.emplace_back(id, ret_type_id, function_control,
                                  function_type_id);
+  id_to_function_.emplace(id, &current_function());
 
   // TODO(umar): validate function type and type_id
 

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -140,6 +140,9 @@ class ValidationState_t {
   Function& current_function();
   const Function& current_function() const;
 
+  /// Returns function state with the given id, or nullptr if no such function.
+  const Function* function(uint32_t id) const;
+
   /// Returns true if the called after a function instruction but before the
   /// function end instruction
   bool in_function_body() const;
@@ -173,6 +176,7 @@ class ValidationState_t {
   /// Inserts an <id> to the set of functions that are target of OpFunctionCall.
   void AddFunctionCallTarget(const uint32_t id) {
     function_call_targets_.insert(id);
+    current_function().AddFunctionCallTarget(id);
   }
 
   /// Returns whether or not a function<id> is the target of OpFunctionCall.
@@ -433,7 +437,9 @@ class ValidationState_t {
   /// The section of the code being processed
   ModuleLayoutSection current_layout_section_;
 
-  /// A list of functions in the module
+  /// A list of functions in the module.
+  /// Pointers to objects in this container are guaranteed to be stable and
+  /// valid until the end of lifetime of the validation state.
   std::deque<Function> module_functions_;
 
   /// Capabilities declared in the module
@@ -443,6 +449,8 @@ class ValidationState_t {
   libspirv::ExtensionSet module_extensions_;
 
   /// List of all instructions in the order they appear in the binary
+  /// Pointers to objects in this container are guaranteed to be stable and
+  /// valid until the end of lifetime of the validation state.
   std::deque<Instruction> ordered_instructions_;
 
   /// Instructions that can be referenced by Ids
@@ -489,9 +497,12 @@ class ValidationState_t {
   /// NOTE: See correspoding getter functions
   bool in_function_;
 
-  // The state of optional features.  These are determined by capabilities
-  // declared by the module.
+  /// The state of optional features.  These are determined by capabilities
+  /// declared by the module.
   Feature features_;
+
+  /// Maps function ids to function stat objects.
+  std::unordered_map<uint32_t, Function*> id_to_function_;
 };
 
 }  /// namespace libspirv

--- a/source/validate_cfg.cpp
+++ b/source/validate_cfg.cpp
@@ -416,6 +416,11 @@ spv_result_t CfgPass(ValidationState_t& _,
     case SpvOpReturnValue:
     case SpvOpUnreachable:
       _.current_function().RegisterBlockEnd(vector<uint32_t>(), opcode);
+      if (opcode == SpvOpKill) {
+        _.current_function().RegisterExecutionModelLimitation(
+            SpvExecutionModelFragment,
+            "OpKill requires Fragment execution model");
+      }
       break;
     default:
       break;

--- a/source/validate_id.cpp
+++ b/source/validate_id.cpp
@@ -304,10 +304,12 @@ bool idUsage::isValid<SpvOpEntryPoint>(const spv_instruction_t* inst,
   }
 
   std::stack<uint32_t> call_stack;
+  std::set<uint32_t> visited;
   call_stack.push(entryPoint->id());
   while (!call_stack.empty()) {
     const uint32_t called_func_id = call_stack.top();
     call_stack.pop();
+    if (!visited.insert(called_func_id).second) continue;
 
     const Function* called_func = module_.function(called_func_id);
     assert(called_func);

--- a/source/validate_image.cpp
+++ b/source/validate_image.cpp
@@ -587,6 +587,12 @@ spv_result_t ImagePass(ValidationState_t& _,
   const SpvOp opcode = static_cast<SpvOp>(inst->opcode);
   const uint32_t result_type = inst->type_id;
 
+  if (IsImplicitLod(opcode)) {
+    _.current_function().RegisterExecutionModelLimitation(
+        SpvExecutionModelFragment,
+        "ImplicitLod instructions require Fragment execution model");
+  }
+
   switch (opcode) {
     case SpvOpSampledImage: {
       if (_.GetIdOpcode(result_type) != SpvOpTypeSampledImage) {
@@ -1276,6 +1282,10 @@ spv_result_t ImagePass(ValidationState_t& _,
     }
 
     case SpvOpImageQueryLod: {
+      _.current_function().RegisterExecutionModelLimitation(
+          SpvExecutionModelFragment,
+          "OpImageQueryLod requires Fragment execution model");
+
       if (!_.IsFloatVectorType(result_type)) {
         return _.diag(SPV_ERROR_INVALID_DATA)
             << "Expected Result Type to be float vector type: "

--- a/test/val/val_image_test.cpp
+++ b/test/val/val_image_test.cpp
@@ -14,6 +14,7 @@
 
 // Tests for unique type declaration rules validator.
 
+#include <sstream>
 #include <string>
 
 #include "gmock/gmock.h"
@@ -29,21 +30,24 @@ using ValidateImage = spvtest::ValidateBase<bool>;
 
 std::string GenerateShaderCode(
     const std::string& body,
-    const std::string& capabilities_and_extensions = "") {
-  const std::string capabilities =
-R"(
+    const std::string& capabilities_and_extensions = "",
+    const std::string& execution_model = "Fragment") {
+  std::stringstream ss;
+  ss << R"(
 OpCapability Shader
 OpCapability InputAttachment
 OpCapability ImageGatherExtended
 OpCapability MinLod
 OpCapability Sampled1D
 OpCapability SampledRect
-OpCapability ImageQuery)";
+OpCapability ImageQuery
+)";
 
-  const std::string after_extension_before_body =
-R"(
-OpMemoryModel Logical GLSL450
-OpEntryPoint Fragment %main "main"
+  ss << capabilities_and_extensions;
+  ss << "OpMemoryModel Logical GLSL450\n";
+  ss << "OpEntryPoint " << execution_model << " %main \"main\"\n";
+
+  ss << R"(
 %void = OpTypeVoid
 %func = OpTypeFunction %void
 %bool = OpTypeBool
@@ -199,32 +203,34 @@ OpEntryPoint Fragment %main "main"
 %uniform_sampler = OpVariable %ptr_sampler UniformConstant
 
 %main = OpFunction %void None %func
-%main_entry = OpLabel)";
+%main_entry = OpLabel
+)";
 
-  const std::string after_body =
-R"(
+  ss << body;
+
+  ss << R"(
 OpReturn
 OpFunctionEnd)";
 
-  return capabilities + capabilities_and_extensions +
-      after_extension_before_body + body + after_body;
+  return ss.str();
 }
 
 std::string GenerateKernelCode(
     const std::string& body,
     const std::string& capabilities_and_extensions = "") {
-  const std::string capabilities =
-R"(
+  std::stringstream ss;
+  ss << R"(
 OpCapability Addresses
 OpCapability Kernel
 OpCapability Linkage
 OpCapability ImageQuery
 OpCapability ImageGatherExtended
 OpCapability InputAttachment
-OpCapability SampledRect)";
+OpCapability SampledRect
+)";
 
-  const std::string after_extension_before_body =
-R"(
+  ss << capabilities_and_extensions;
+  ss << R"(
 OpMemoryModel Physical32 OpenCL
 %void = OpTypeVoid
 %func = OpTypeFunction %void
@@ -293,15 +299,15 @@ OpMemoryModel Physical32 OpenCL
 %uniform_sampler = OpVariable %ptr_sampler UniformConstant
 
 %main = OpFunction %void None %func
-%main_entry = OpLabel)";
+%main_entry = OpLabel
+)";
 
-  const std::string after_body =
-R"(
+  ss << body;
+  ss << R"(
 OpReturn
 OpFunctionEnd)";
 
-  return capabilities + capabilities_and_extensions +
-      after_extension_before_body + body + after_body;
+  return ss.str();
 }
 
 TEST_F(ValidateImage, SampledImageSuccess) {
@@ -3035,6 +3041,53 @@ TEST_F(ValidateImage, QuerySamplesNotMultisampled) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr(
       "Image 'MS' must be 1: ImageQuerySamples"));
+}
+
+TEST_F(ValidateImage, QueryLodWrongExecutionModel) {
+  const std::string body = R"(
+%img = OpLoad %type_image_f32_2d_0001 %uniform_image_f32_2d_0001
+%sampler = OpLoad %type_sampler %uniform_sampler
+%simg = OpSampledImage %type_sampled_image_f32_2d_0001 %img %sampler
+%res1 = OpImageQueryLod %f32vec2 %simg %f32vec2_hh
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, "", "Vertex").c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr(
+      "OpImageQueryLod requires Fragment execution model"));
+}
+
+TEST_F(ValidateImage, QueryLodWrongExecutionModelWithFunc) {
+  const std::string body = R"(
+%call_ret = OpFunctionCall %void %my_func
+OpReturn
+OpFunctionEnd
+%my_func = OpFunction %void None %func
+%my_func_entry = OpLabel
+%img = OpLoad %type_image_f32_2d_0001 %uniform_image_f32_2d_0001
+%sampler = OpLoad %type_sampler %uniform_sampler
+%simg = OpSampledImage %type_sampled_image_f32_2d_0001 %img %sampler
+%res1 = OpImageQueryLod %f32vec2 %simg %f32vec2_hh
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, "", "Vertex").c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr(
+      "OpImageQueryLod requires Fragment execution model"));
+}
+
+TEST_F(ValidateImage, ImplicitLodWrongExecutionModel) {
+  const std::string body = R"(
+%img = OpLoad %type_image_f32_2d_0001 %uniform_image_f32_2d_0001
+%sampler = OpLoad %type_sampler %uniform_sampler
+%simg = OpSampledImage %type_sampled_image_f32_2d_0001 %img %sampler
+%res1 = OpImageSampleImplicitLod %f32vec4 %simg %f32vec2_hh
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, "", "Vertex").c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr(
+      "ImplicitLod instructions require Fragment execution model"));
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
Currently checks that these instructions are called from entry points
with Fragment execution model.
OpImageImplicit*
OpImageQueryLod
OpKill