### PR TITLE
Change IRContext::KillInst to delete instructions.

### DIFF
--- a/source/link/linker.cpp
+++ b/source/link/linker.cpp
@@ -705,9 +705,14 @@ static spv_result_t RemoveLinkageSpecificInstructions(
 
   // Remove declarations of imported variables
   for (const auto& linking_entry : linkings_to_do) {
-    for (auto& inst : linked_context->types_values())
-      if (inst.result_id() == linking_entry.imported_symbol.id)
-        linked_context->KillInst(&inst);
+    auto next = linked_context->types_values_begin();
+    for (auto inst = next; inst != linked_context->types_values_end();
+         inst = next) {
+      ++next;
+      if (inst->result_id() == linking_entry.imported_symbol.id) {
+        linked_context->KillInst(&*inst);
+      }
+    }
   }
 
   // Remove import linkage attributes

--- a/source/opt/aggressive_dead_code_elim_pass.h
+++ b/source/opt/aggressive_dead_code_elim_pass.h
@@ -78,9 +78,9 @@ class AggressiveDCEPass : public MemPass {
   // Return true if all extensions in this module are supported by this pass.
   bool AllExtensionsSupported() const;
 
-  // Kill debug or annotation |inst| if target operand is dead. Return true
-  // if inst killed.
-  bool KillInstIfTargetDead(ir::Instruction* inst);
+  // Returns true if |inst| is dead.  An instruction is dead if its result id
+  // is used in decoration or debug instructions only.
+  bool IsTargetDead(ir::Instruction* inst);
 
   // If |varId| is local, mark all stores of varId as live.
   void ProcessLoad(uint32_t varId);

--- a/source/opt/basic_block.h
+++ b/source/opt/basic_block.h
@@ -166,7 +166,16 @@ inline void BasicBlock::AddInstructions(BasicBlock* bp) {
 inline void BasicBlock::ForEachInst(const std::function<void(Instruction*)>& f,
                                     bool run_on_debug_line_insts) {
   if (label_) label_->ForEachInst(f, run_on_debug_line_insts);
-  for (auto& inst : insts_) inst.ForEachInst(f, run_on_debug_line_insts);
+  if (insts_.empty()) {
+    return;
+  }
+
+  Instruction* inst = &insts_.front();
+  while (inst != nullptr) {
+    Instruction* next_instruction = inst->NextNode();
+    inst->ForEachInst(f, run_on_debug_line_insts);
+    inst = next_instruction;
+  }
 }
 
 inline void BasicBlock::ForEachInst(

--- a/source/opt/common_uniform_elim_pass.h
+++ b/source/opt/common_uniform_elim_pass.h
@@ -91,8 +91,9 @@ class CommonUniformElimPass : public Pass {
 
   // Replace all instances of load's id with replId and delete load
   // and its access chain, if any
-  void ReplaceAndDeleteLoad(ir::Instruction* loadInst, uint32_t replId,
-                            ir::Instruction* ptrInst);
+  ir::Instruction* ReplaceAndDeleteLoad(ir::Instruction* loadInst,
+                                        uint32_t replId,
+                                        ir::Instruction* ptrInst);
 
   // For the (constant index) access chain ptrInst, create an
   // equivalent load and extract

--- a/source/opt/eliminate_dead_constant_pass.cpp
+++ b/source/opt/eliminate_dead_constant_pass.cpp
@@ -91,26 +91,9 @@ Pass::Status EliminateDeadConstantPass::Process(ir::IRContext* irContext) {
     working_list.erase(inst);
   }
 
-  // Find all annotation and debug instructions that are referencing dead
-  // constants.
-  std::unordered_set<ir::Instruction*> dead_others;
-  for (auto* dc : dead_consts) {
-    irContext->get_def_use_mgr()->ForEachUser(
-        dc, [&dead_others](ir::Instruction* user) {
-          SpvOp op = user->opcode();
-          if (ir::IsAnnotationInst(op) || ir::IsDebug1Inst(op) ||
-              ir::IsDebug2Inst(op) || ir::IsDebug3Inst(op)) {
-            dead_others.insert(user);
-          }
-        });
-  }
-
   // Turn all dead instructions and uses of them to nop
   for (auto* dc : dead_consts) {
     irContext->KillDef(dc->result_id());
-  }
-  for (auto* da : dead_others) {
-    irContext->KillInst(da);
   }
   return dead_consts.empty() ? Status::SuccessWithoutChange
                              : Status::SuccessWithChange;

--- a/source/opt/fold_spec_constant_op_and_composite_pass.cpp
+++ b/source/opt/fold_spec_constant_op_and_composite_pass.cpp
@@ -282,10 +282,12 @@ Pass::Status FoldSpecConstantOpAndCompositePass::ProcessImpl(
   // the dependee Spec Constants, all its dependent constants must have been
   // processed and all its dependent Spec Constants should have been folded if
   // possible.
-  for (ir::Module::inst_iterator inst_iter = irContext->types_values_begin();
+  ir::Module::inst_iterator next_inst = irContext->types_values_begin();
+  for (ir::Module::inst_iterator inst_iter = next_inst;
        // Need to re-evaluate the end iterator since we may modify the list of
        // instructions in this section of the module as the process goes.
-       inst_iter != irContext->types_values_end(); ++inst_iter) {
+       inst_iter != irContext->types_values_end(); inst_iter = next_inst) {
+    ++next_inst;
     ir::Instruction* inst = &*inst_iter;
     // Collect constant values of normal constants and process the
     // OpSpecConstantOp and OpSpecConstantComposite instructions if possible.

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -354,5 +354,20 @@ bool Instruction::IsReadOnlyVariableKernel() const {
   uint32_t storage_class = GetSingleWordInOperand(kVariableStorageClassIndex);
   return storage_class == SpvStorageClassUniformConstant;
 }
+
+Instruction* Instruction::InsertBefore(
+    std::vector<std::unique_ptr<Instruction>>&& list) {
+  Instruction* first_node = list.front().get();
+  for (auto& i : list) {
+    i.release()->InsertBefore(this);
+  }
+  list.clear();
+  return first_node;
+}
+
+Instruction* Instruction::InsertBefore(std::unique_ptr<Instruction>&& i) {
+  i.get()->InsertBefore(this);
+  return i.release();
+}
 }  // namespace ir
 }  // namespace spvtools

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -312,6 +312,10 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   inline bool operator!=(const Instruction&) const;
   inline bool operator<(const Instruction&) const;
 
+  Instruction* InsertBefore(std::vector<std::unique_ptr<Instruction>>&& list);
+  Instruction* InsertBefore(std::unique_ptr<Instruction>&& i);
+  using utils::IntrusiveNodeBase<Instruction>::InsertBefore;
+
  private:
   // Returns the total count of result type id and result id.
   uint32_t TypeResultIdCount() const {

--- a/source/opt/instruction_list.h
+++ b/source/opt/instruction_list.h
@@ -101,6 +101,18 @@ class InstructionList : public utils::IntrusiveList<Instruction> {
 
   // Same as in the base class, except it will delete the data as well.
   inline void clear();
+
+  // Runs the given function |f| on the instructions in the list and optionally
+  // on the preceding debug line instructions.
+  inline void ForEachInst(
+      const std::function<void(Instruction*)>& f,
+      bool run_on_debug_line_insts) {
+    auto next = begin();
+    for( auto i = next; i != end(); i = next ) {
+      ++next;
+      i->ForEachInst(f, run_on_debug_line_insts);
+    }
+  }
 };
 
 InstructionList::~InstructionList() { clear(); }

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -57,9 +57,6 @@ class LocalAccessChainConvertPass : public MemPass {
   // variables.
   void FindTargetVars(ir::Function* func);
 
-  // Delete |inst| if it has no uses. Assumes |inst| has a non-zero resultId.
-  void DeleteIfUseless(ir::Instruction* inst);
-
   // Build instruction from |opcode|, |typeId|, |resultId|, and |in_opnds|.
   // Append to |newInsts|.
   void BuildAndAppendInst(

--- a/source/opt/local_single_block_elim_pass.cpp
+++ b/source/opt/local_single_block_elim_pass.cpp
@@ -51,12 +51,15 @@ bool LocalSingleBlockLoadStoreElimPass::HasOnlySupportedRefs(uint32_t ptrId) {
 bool LocalSingleBlockLoadStoreElimPass::LocalSingleBlockLoadStoreElim(
     ir::Function* func) {
   // Perform local store/load and load/load elimination on each block
+  std::vector<ir::Instruction*> dead_instructions;
   bool modified = false;
   for (auto bi = func->begin(); bi != func->end(); ++bi) {
     var2store_.clear();
     var2load_.clear();
     pinned_vars_.clear();
-    for (auto ii = bi->begin(); ii != bi->end(); ++ii) {
+    auto next = bi->begin();
+    for (auto ii = next; ii != bi->end(); ii = next) {
+      ++next;
       switch (ii->opcode()) {
         case SpvOpStore: {
           // Verify store variable is target type
@@ -70,7 +73,7 @@ bool LocalSingleBlockLoadStoreElimPass::LocalSingleBlockLoadStoreElim(
             if (pinned_vars_.find(varId) == pinned_vars_.end()) {
               auto si = var2store_.find(varId);
               if (si != var2store_.end()) {
-                context()->KillInst(si->second);
+                dead_instructions.push_back(si->second);
               }
             }
             var2store_[varId] = &*ii;
@@ -102,7 +105,9 @@ bool LocalSingleBlockLoadStoreElimPass::LocalSingleBlockLoadStoreElim(
           }
           if (replId != 0) {
             // replace load's result id and delete load
-            ReplaceAndDeleteLoad(&*ii, replId);
+            context()->KillNamesAndDecorates(&*ii);
+            context()->ReplaceAllUsesWith(ii->result_id(), replId);
+            dead_instructions.push_back(&*ii);
             modified = true;
           } else {
             if (ptrInst->opcode() == SpvOpVariable)
@@ -121,12 +126,37 @@ bool LocalSingleBlockLoadStoreElimPass::LocalSingleBlockLoadStoreElim(
           break;
       }
     }
+
+    while (!dead_instructions.empty()) {
+      ir::Instruction* inst = dead_instructions.back();
+      dead_instructions.pop_back();
+      DCEInst(inst, [&dead_instructions](ir::Instruction* other_inst) {
+        auto i = std::find(dead_instructions.begin(), dead_instructions.end(),
+                           other_inst);
+        if (i != dead_instructions.end()) {
+          dead_instructions.erase(i);
+        }
+      });
+    }
+
     // Go back and delete useless stores in block
     // TODO(greg-lunarg): Consider moving DCE into separate pass
+    std::vector<ir::Instruction*> dead_stores;
     for (auto ii = bi->begin(); ii != bi->end(); ++ii) {
       if (ii->opcode() != SpvOpStore) continue;
       if (IsLiveStore(&*ii)) continue;
-      DCEInst(&*ii);
+      dead_stores.push_back(&*ii);
+    }
+
+    while (!dead_stores.empty()) {
+      ir::Instruction* inst = dead_stores.back();
+      dead_stores.pop_back();
+      DCEInst(inst, [&dead_stores](ir::Instruction* other_inst) {
+        auto i = std::find(dead_stores.begin(), dead_stores.end(), other_inst);
+        if (i != dead_stores.end()) {
+          dead_stores.erase(i);
+        }
+      });
     }
   }
   return modified;

--- a/source/opt/mem_pass.h
+++ b/source/opt/mem_pass.h
@@ -88,11 +88,8 @@ class MemPass : public Pass {
   // Delete |inst| and iterate DCE on all its operands if they are now
   // useless. If a load is deleted and its variable has no other loads,
   // delete all its variable's stores.
-  void DCEInst(ir::Instruction* inst);
-
-  // Replace all instances of |loadInst|'s id with |replId| and delete
-  // |loadInst|.
-  void ReplaceAndDeleteLoad(ir::Instruction* loadInst, uint32_t replId);
+  void DCEInst(ir::Instruction* inst,
+               const std::function<void(ir::Instruction * )>&);
 
   // Call all the cleanup helper functions on |func|.
   bool CFGCleanup(ir::Function* func);

--- a/source/opt/merge_return_pass.cpp
+++ b/source/opt/merge_return_pass.cpp
@@ -114,8 +114,10 @@ bool MergeReturnPass::MergeReturnBlocks(
   // Replace returns with branches
   for (auto block : returnBlocks) {
     context()->KillInst(&*block->tail());
-    block->tail()->SetOpcode(SpvOpBranch);
-    block->tail()->ReplaceOperands({{SPV_OPERAND_TYPE_ID, {returnId}}});
+    std::unique_ptr<ir::Instruction> new_instruction(
+        new ir::Instruction(context(), SpvOpBranch, 0,
+                            0, {{SPV_OPERAND_TYPE_ID, {returnId}}}));
+    block->AddInstruction(std::move(new_instruction));
     uses_to_update.push_back(&*block->tail());
     uses_to_update.push_back(block->GetLabelInst());
   }

--- a/source/opt/module.cpp
+++ b/source/opt/module.cpp
@@ -71,18 +71,18 @@ void Module::AddGlobalValue(SpvOp opcode, uint32_t result_id,
 
 void Module::ForEachInst(const std::function<void(Instruction*)>& f,
                          bool run_on_debug_line_insts) {
-#define DELEGATE(i) i.ForEachInst(f, run_on_debug_line_insts)
-  for (auto& i : capabilities_) DELEGATE(i);
-  for (auto& i : extensions_) DELEGATE(i);
-  for (auto& i : ext_inst_imports_) DELEGATE(i);
+#define DELEGATE(list) list.ForEachInst(f, run_on_debug_line_insts)
+  DELEGATE(capabilities_);
+  DELEGATE(extensions_);
+  DELEGATE(ext_inst_imports_);
   if (memory_model_) memory_model_->ForEachInst(f, run_on_debug_line_insts);
-  for (auto& i : entry_points_) DELEGATE(i);
-  for (auto& i : execution_modes_) DELEGATE(i);
-  for (auto& i : debugs1_) DELEGATE(i);
-  for (auto& i : debugs2_) DELEGATE(i);
-  for (auto& i : debugs3_) DELEGATE(i);
-  for (auto& i : annotations_) DELEGATE(i);
-  for (auto& i : types_values_) DELEGATE(i);
+  DELEGATE(entry_points_);
+  DELEGATE(execution_modes_);
+  DELEGATE(debugs1_);
+  DELEGATE(debugs2_);
+  DELEGATE(debugs3_);
+  DELEGATE(annotations_);
+  DELEGATE(types_values_);
   for (auto& i : functions_) i->ForEachInst(f, run_on_debug_line_insts);
 #undef DELEGATE
 }

--- a/test/opt/def_use_test.cpp
+++ b/test/opt/def_use_test.cpp
@@ -1014,11 +1014,8 @@ INSTANTIATE_TEST_CASE_P(
         "%5 = OpTypeMatrix %3 3 "
         "%6 = OpTypeMatrix %2 3",
         {1, 3, 5, 10}, // ids to kill
-        "OpNop\n"
         "%2 = OpTypeVector %1 2\n"
-        "OpNop\n"
         "%4 = OpTypeVector %1 4\n"
-        "OpNop\n"
         "%6 = OpTypeMatrix %2 3",
         {
           { // defs
@@ -1049,8 +1046,6 @@ INSTANTIATE_TEST_CASE_P(
 
          "%5 = OpLabel\n"
          "%7 = OpPhi %6 %8 %4 %9 %5\n"
-              "OpNop\n"
-              "OpNop\n"
         "%13 = OpFAdd %10 %11 %12\n"
         "%17 = OpSLessThan %16 %7 %18\n"
               "OpLoopMerge %19 %5 None\n"
@@ -1164,7 +1159,6 @@ INSTANTIATE_TEST_CASE_P(
         "%6 = OpLabel\n"
              "OpBranch %7\n"
         "%7 = OpLabel\n"
-             "OpNop\n"
              "OpBranch %7\n"
              "OpFunctionEnd",
         {
@@ -1484,7 +1478,6 @@ INSTANTIATE_TEST_CASE_P(
         "     OpReturn "
         "     OpFunctionEnd",
         {3, 5, 7},
-        "OpNop\n"
         "%1 = OpTypeFunction %3\n"
         "%2 = OpFunction %1 None %3\n"
         "%4 = OpLabel\n"


### PR DESCRIPTION
The current method of removing an instruction is to call ToNop.  The
problem with this is that it leaves around an instruction that later
passes will look at.  We should just delete the instruction.

First part of #1003.