### PR TITLE
Relaxed OpImageRead validation rules

### DIFF
--- a/source/validate_image.cpp
+++ b/source/validate_image.cpp
@@ -948,18 +948,21 @@ spv_result_t ImagePass(ValidationState_t& _,
     }
 
     case SpvOpImageRead: {
-      if (!_.IsIntVectorType(result_type) &&
-          !_.IsFloatVectorType(result_type)) {
+      if (!_.IsIntScalarOrVectorType(result_type) &&
+          !_.IsFloatScalarOrVectorType(result_type)) {
         return _.diag(SPV_ERROR_INVALID_DATA)
-            << "Expected Result Type to be int or float vector type: "
+            << "Expected Result Type to be int or float scalar or vector type: "
             << spvOpcodeString(opcode);
       }
 
+#if 0
+      // TODO(atgoo@github.com) Disabled until the spec is clarified.
       if (_.GetDimension(result_type) != 4) {
         return _.diag(SPV_ERROR_INVALID_DATA)
             << "Expected Result Type to have 4 components: "
             << spvOpcodeString(opcode);
       }
+#endif
 
       const uint32_t image_type = _.GetOperandTypeId(inst, 2);
       if (_.GetIdOpcode(image_type) != SpvOpTypeImage) {

--- a/test/val/val_image_test.cpp
+++ b/test/val/val_image_test.cpp
@@ -2262,6 +2262,8 @@ TEST_F(ValidateImage, ReadNeedCapabilityImageCubeArray) {
       "ImageRead"));
 }
 
+#if 0
+// TODO(atgoo@github.com) Disabled until the spec is clarified.
 TEST_F(ValidateImage, ReadWrongResultType) {
   const std::string body = R"(
 %img = OpLoad %type_image_u32_2d_0000 %uniform_image_u32_2d_0000
@@ -2287,6 +2289,7 @@ TEST_F(ValidateImage, ReadWrongNumComponentsResultType) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr(
       "Expected Result Type to have 4 components: ImageRead"));
 }
+#endif
 
 TEST_F(ValidateImage, ReadNotImage) {
   const std::string body = R"(


### PR DESCRIPTION
Removed the check that result type of OpImageRead should be a vector4.
Will reenable/adapt once the spec is clarified on what the right
dimension should be.