### PR TITLE
Derivative opcodes require Fragment exec model

### DIFF
--- a/source/validate_derivatives.cpp
+++ b/source/validate_derivatives.cpp
@@ -52,8 +52,10 @@ spv_result_t DerivativesPass(ValidationState_t& _,
                << spvOpcodeString(opcode);
       }
 
-      // All derivative opcodes require Fragment execution model.
-      // This needs to be checked elsewhere.
+      _.current_function().RegisterExecutionModelLimitation(
+          SpvExecutionModelFragment, std::string(
+              "Derivative instructions require Fragment execution model: ") +
+          spvOpcodeString(opcode));
       break;
     }
 


### PR DESCRIPTION
Added validator check that all derivative opcodes require Fragment
execution model.

Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/1001