### PR TITLE
Relaxed OpImageWrite texel type check

### DIFF
--- a/source/validate_image.cpp
+++ b/source/validate_image.cpp
@@ -1065,19 +1065,24 @@ spv_result_t ImagePass(ValidationState_t& _,
             << spvOpcodeString(opcode);
       }
 
+      // TODO(atgoo@github.com) The spec doesn't explicitely say what the type
+      // of texel should be.
       const uint32_t texel_type = _.GetOperandTypeId(inst, 2);
-      if (!_.IsIntVectorType(texel_type) &&
-          !_.IsFloatVectorType(texel_type)) {
+      if (!_.IsIntScalarOrVectorType(texel_type) &&
+          !_.IsFloatScalarOrVectorType(texel_type)) {
         return _.diag(SPV_ERROR_INVALID_DATA)
             << "Expected Texel to be int or float vector or scalar: "
             << spvOpcodeString(opcode);
       }
 
+#if 0
+      // TODO: See above.
       if (_.GetDimension(texel_type) != 4) {
         return _.diag(SPV_ERROR_INVALID_DATA)
             << "Expected Texel to have 4 components: "
             << spvOpcodeString(opcode);
       }
+#endif
 
       if (_.GetIdOpcode(info.sampled_type) != SpvOpTypeVoid) {
         const uint32_t texel_component_type = _.GetComponentType(texel_type);

--- a/test/val/val_image_test.cpp
+++ b/test/val/val_image_test.cpp
@@ -2522,10 +2522,10 @@ TEST_F(ValidateImage, WriteCoordinateSizeTooSmall) {
       "ImageWrite"));
 }
 
-TEST_F(ValidateImage, WriteTexelNotVector) {
+TEST_F(ValidateImage, WriteTexelWrongType) {
   const std::string body = R"(
 %img = OpLoad %type_image_u32_2d_0000 %uniform_image_u32_2d_0000
-%res1 = OpImageWrite %img %u32vec2_01 %u32_0
+%res1 = OpImageWrite %img %u32vec2_01 %img
 )";
 
   const std::string extra = "\nOpCapability StorageImageWriteWithoutFormat\n";
@@ -2535,7 +2535,7 @@ TEST_F(ValidateImage, WriteTexelNotVector) {
       "Expected Texel to be int or float vector or scalar: ImageWrite"));
 }
 
-TEST_F(ValidateImage, WriteTexelNotVector4) {
+TEST_F(ValidateImage, DISABLED_WriteTexelNotVector4) {
   const std::string body = R"(
 %img = OpLoad %type_image_u32_2d_0000 %uniform_image_u32_2d_0000
 %res1 = OpImageWrite %img %u32vec2_01 %u32vec3_012


### PR DESCRIPTION
Relax texel type check in OpImageWrite until the spec is clarified.