### PR TITLE
Re-format source tree - NFC.

### DIFF
--- a/source/val/decoration.h
+++ b/source/val/decoration.h
@@ -15,6 +15,7 @@
 #ifndef LIBSPIRV_VAL_DECORATION_H_
 #define LIBSPIRV_VAL_DECORATION_H_
 
+#include <cstdint>
 #include <unordered_map>
 #include <vector>
 


### PR DESCRIPTION
Re-formatted the source tree with the command:

$ /usr/bin/clang-format -style=file -i \
    $(find include source tools test utils -name '*.cpp' -or -name '*.h')

This required a fix to source/val/decoration.h.  It was not including
spirv.h, which broke builds when the #include headers were re-ordered by
clang-format.