### PR TITLE
Preserve SpvOpDecorationGroup when removing duplicates

### DIFF
--- a/source/opt/decoration_manager.cpp
+++ b/source/opt/decoration_manager.cpp
@@ -87,7 +87,8 @@ bool DecorationManager::AreDecorationsTheSame(
   ir::Instruction tmpA = *inst1, tmpB = *inst2;
   if (tmpA.opcode() != tmpB.opcode() ||
       tmpA.NumInOperands() != tmpB.NumInOperands() ||
-      tmpA.opcode() == SpvOpNop || tmpB.opcode() == SpvOpNop)
+      tmpA.opcode() == SpvOpNop ||
+      tmpA.opcode() == SpvOpDecorationGroup)
     return false;
 
   for (uint32_t i = (tmpA.opcode() == SpvOpDecorate) ? 1u : 2u;


### PR DESCRIPTION
Bugfix: The RemoveDuplicatesPass eliminated all Decoration Groups but one. This resulted in invalid SPIR-V modules, when there was previously more than one Decoration Group. Added a simple check if the opcode is SpvOpDecorationGroup to leave them inside.