### PR TITLE
Fix #1034 - Give Edge::operator<() weak ordering semantics.

### DIFF
--- a/source/opt/propagator.h
+++ b/source/opt/propagator.h
@@ -18,6 +18,7 @@
 #include <functional>
 #include <queue>
 #include <set>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -36,7 +37,8 @@ struct Edge {
   ir::BasicBlock* source;
   ir::BasicBlock* dest;
   bool operator<(const Edge& o) const {
-    return source->id() + dest->id() < o.source->id() + o.dest->id();
+    return std::make_pair(source->id(), dest->id()) <
+           std::make_pair(o.source->id(), o.dest->id());
   }
 };
 

--- a/source/opt/propagator.h
+++ b/source/opt/propagator.h
@@ -18,7 +18,6 @@
 #include <functional>
 #include <queue>
 #include <set>
-#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>

--- a/source/opt/propagator.h
+++ b/source/opt/propagator.h
@@ -36,7 +36,7 @@ struct Edge {
   ir::BasicBlock* source;
   ir::BasicBlock* dest;
   bool operator<(const Edge& o) const {
-    return source < o.source || dest < o.dest;
+    return source->id() + dest->id() < o.source->id() + o.dest->id();
   }
 };
 


### PR DESCRIPTION
This should fix #1034.  It changes the predicate on operator< to use
label IDs from each block and add them together to define a weak
ordering for std::set.

NOTE: This bug is happening on Windows, I do not have a Windows machine yet, so I'll wait for the bots to finish to make sure that the bug is properly fixed.