### PR TITLE
Opt: Remove unused lambda captures

### DIFF
--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -651,7 +651,7 @@ void InlinePass::InitializeInline(ir::IRContext* c) {
   InitializeProcessing(c);
 
   // Don't bother updating the DefUseManger
-  update_def_use_mgr_ = [this](ir::Instruction&, bool) {};
+  update_def_use_mgr_ = [](ir::Instruction&, bool) {};
 
   false_id_ = 0;
 

--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -125,7 +125,7 @@ void LocalSingleStoreElimPass::CalculateImmediateDominators(
   successors_map_.clear();
   for (auto& blk : *func) {
     ordered_blocks.push_back(&blk);
-    blk.ForEachSuccessorLabel([&blk, &ordered_blocks, this](uint32_t sbid) {
+    blk.ForEachSuccessorLabel([&blk, this](uint32_t sbid) {
       successors_map_[&blk].push_back(label2block_[sbid]);
       predecessors_map_[label2block_[sbid]].push_back(&blk);
     });

--- a/source/opt/mem_pass.cpp
+++ b/source/opt/mem_pass.cpp
@@ -795,10 +795,9 @@ bool MemPass::RemoveUnreachableBlocks(ir::Function* func) {
     // If the block is reachable and has Phi instructions, remove all
     // operands from its Phi instructions that reference unreachable blocks.
     // If the block has no Phi instructions, this is a no-op.
-    block.ForEachPhiInst(
-        [&block, &reachable_blocks, this](ir::Instruction* phi) {
-          RemovePhiOperands(phi, reachable_blocks);
-        });
+    block.ForEachPhiInst([&reachable_blocks, this](ir::Instruction* phi) {
+      RemovePhiOperands(phi, reachable_blocks);
+    });
   }
 
   // Erase unreachable blocks.


### PR DESCRIPTION
Those are reported as errors by clang 5.0.0, due to the flags -Werror and -Wunused-lambda-capture.