### PR TITLE
Support outputting ANSI color escape sequences in library

### DIFF
--- a/source/disassemble.cpp
+++ b/source/disassemble.cpp
@@ -45,8 +45,7 @@ class Disassembler {
                libspirv::NameMapper name_mapper)
       : grammar_(grammar),
         print_(spvIsInBitfield(SPV_BINARY_TO_TEXT_OPTION_PRINT, options)),
-        color_(print_ &&
-               spvIsInBitfield(SPV_BINARY_TO_TEXT_OPTION_COLOR, options)),
+        color_(spvIsInBitfield(SPV_BINARY_TO_TEXT_OPTION_COLOR, options)),
         indent_(spvIsInBitfield(SPV_BINARY_TO_TEXT_OPTION_INDENT, options)
                     ? kStandardIndent
                     : 0),
@@ -87,27 +86,27 @@ class Disassembler {
 
   // Resets the output color, if color is turned on.
   void ResetColor() {
-    if (color_) out_.get() << libspirv::clr::reset();
+    if (color_) out_.get() << libspirv::clr::reset{print_};
   }
   // Sets the output to grey, if color is turned on.
   void SetGrey() {
-    if (color_) out_.get() << libspirv::clr::grey();
+    if (color_) out_.get() << libspirv::clr::grey{print_};
   }
   // Sets the output to blue, if color is turned on.
   void SetBlue() {
-    if (color_) out_.get() << libspirv::clr::blue();
+    if (color_) out_.get() << libspirv::clr::blue{print_};
   }
   // Sets the output to yellow, if color is turned on.
   void SetYellow() {
-    if (color_) out_.get() << libspirv::clr::yellow();
+    if (color_) out_.get() << libspirv::clr::yellow{print_};
   }
   // Sets the output to red, if color is turned on.
   void SetRed() {
-    if (color_) out_.get() << libspirv::clr::red();
+    if (color_) out_.get() << libspirv::clr::red{print_};
   }
   // Sets the output to green, if color is turned on.
   void SetGreen() {
-    if (color_) out_.get() << libspirv::clr::green();
+    if (color_) out_.get() << libspirv::clr::green{print_};
   }
 
   const libspirv::AssemblyGrammar& grammar_;

--- a/source/print.cpp
+++ b/source/print.cpp
@@ -54,36 +54,55 @@ static void SetConsoleForegroundColor(WORD color) {
 }
 
 clr::reset::operator const char*() {
-  SetConsoleForegroundColor(0xf);
-  return "";
+  if (isPrint) {
+    SetConsoleForegroundColor(0xf);
+    return "";
+  }
+  return "\x1b[0m";
 }
 
 clr::grey::operator const char*() {
-  SetConsoleForegroundColor(FOREGROUND_INTENSITY);
-  return "";
+  if (isPrint) {
+    SetConsoleForegroundColor(FOREGROUND_INTENSITY);
+    return "";
+  }
+  return "\x1b[1;30m";
 }
 
 clr::red::operator const char*() {
-  SetConsoleForegroundColor(FOREGROUND_RED);
-  return "";
+  if (isPrint) {
+    SetConsoleForegroundColor(FOREGROUND_RED);
+    return "";
+  }
+  return "\x1b[31m";
 }
 
 clr::green::operator const char*() {
-  SetConsoleForegroundColor(FOREGROUND_GREEN);
-  return "";
+  if (isPrint) {
+    SetConsoleForegroundColor(FOREGROUND_GREEN);
+    return "";
+  }
+  return "\x1b[32m";
 }
 
 clr::yellow::operator const char*() {
-  SetConsoleForegroundColor(FOREGROUND_RED | FOREGROUND_GREEN);
-  return "";
+  if (isPrint) {
+    SetConsoleForegroundColor(FOREGROUND_RED | FOREGROUND_GREEN);
+    return "";
+  }
+  return "\x1b[33m";
 }
 
 clr::blue::operator const char*() {
   // Blue all by itself is hard to see against a black background (the
   // default on command shell), or a medium blue background (the default
   // on PowerShell).  So increase its intensity.
-  SetConsoleForegroundColor(FOREGROUND_BLUE | FOREGROUND_INTENSITY);
-  return "";
+
+  if (isPrint) {
+    SetConsoleForegroundColor(FOREGROUND_BLUE | FOREGROUND_INTENSITY);
+    return "";
+  }
+  return "\x1b[94m";
 }
 
 }  // namespace libspirv

--- a/source/print.h
+++ b/source/print.h
@@ -41,26 +41,32 @@ namespace clr {
 // Resets console color.
 struct reset {
   operator const char*();
+  bool isPrint;
 };
 // Sets console color to grey.
 struct grey {
   operator const char*();
+  bool isPrint;
 };
 // Sets console color to red.
 struct red {
   operator const char*();
+  bool isPrint;
 };
 // Sets console color to green.
 struct green {
   operator const char*();
+  bool isPrint;
 };
 // Sets console color to yellow.
 struct yellow {
   operator const char*();
+  bool isPrint;
 };
 // Sets console color to blue.
 struct blue {
   operator const char*();
+  bool isPrint;
 };
 }  // namespace clr
 


### PR DESCRIPTION
Previously we required _PRINT to enable _COLOR, which forbids
outputting colored disassembly into a string in library.

This commit will allow library users to request enabling
ANSI color escape sequences.