### PR TITLE
Apply EXCLUDE_FROM_ALL to effcee

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -84,7 +84,7 @@ if (NOT ${SPIRV_SKIP_TESTS})
         # SPIRV-Tools uses the shared CRT with MSVC.  Tell Effcee to do the same.
         set(EFFCEE_ENABLE_SHARED_CRT ON)
       endif()
-      add_subdirectory(effcee)
+      add_subdirectory(effcee EXCLUDE_FROM_ALL)
       set_property(TARGET effcee PROPERTY FOLDER Effcee)
       # Turn off warnings for effcee and re2
       set_property(TARGET effcee APPEND PROPERTY COMPILE_OPTIONS -w)


### PR DESCRIPTION
Saves us a few targets to build by default