### PR TITLE
Travis: mark MacOS builds as optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ compiler:
   - gcc
 
 matrix:
+  allow_failures:
+    - os: osx
   fast_finish: true
   include:
     # Additional build using Android NDK with android-cmake


### PR DESCRIPTION
MacOS support in Travis is flakey right now. MacOS build jobs
take a long time to start.

We have extensive checks for Linux and Windows, which should give
us confidence.