### PR TITLE
Fixed typo that leaked to the binary

### DIFF
--- a/source/opt/def_use_manager.h
+++ b/source/opt/def_use_manager.h
@@ -76,7 +76,7 @@ struct UserEntryLess {
     if (!lhs.first && rhs.first) return true;
     if (lhs.first && !rhs.first) return false;
 
-    // If neither defintion is null, then compare unique ids.
+    // If neither definition is null, then compare unique ids.
     if (lhs.first && rhs.first) {
       if (lhs.first->unique_id() < rhs.first->unique_id()) return true;
       if (rhs.first->unique_id() < lhs.first->unique_id()) return false;

--- a/source/opt/ir_loader.cpp
+++ b/source/opt/ir_loader.cpp
@@ -114,7 +114,7 @@ bool IrLoader::AddInstruction(const spv_parsed_instruction_t* inst) {
         module_->AddGlobalValue(std::move(spv_inst));
       } else {
         SPIRV_UNIMPLEMENTED(consumer_,
-                            "unhandled inst type outside function defintion");
+                            "unhandled inst type outside function definition");
       }
     } else {
       if (block_ == nullptr) {  // Inside function but outside blocks


### PR DESCRIPTION
I fixed a typo that leaks to the binary and might leak to users.

The typo was found by lintian when I was packaging glslang.