### PR TITLE
DCEInst kill the same instruction twice.

### DIFF
--- a/source/opt/mem_pass.cpp
+++ b/source/opt/mem_pass.cpp
@@ -184,7 +184,7 @@ void MemPass::AddStores(uint32_t ptr_id, std::queue<ir::Instruction*>* insts) {
 }
 
 void MemPass::DCEInst(ir::Instruction* inst,
-                      const function<void(ir::Instruction * )>& call_back) {
+                      const function<void(ir::Instruction*)>& call_back) {
   std::queue<ir::Instruction*> deadInsts;
   deadInsts.push(inst);
   while (!deadInsts.empty()) {
@@ -195,8 +195,8 @@ void MemPass::DCEInst(ir::Instruction* inst,
       continue;
     }
     // Remember operands
-    std::vector<uint32_t> ids;
-    di->ForEachInId([&ids](uint32_t* iid) { ids.push_back(*iid); });
+    std::set<uint32_t> ids;
+    di->ForEachInId([&ids](uint32_t* iid) { ids.insert(*iid); });
     uint32_t varId = 0;
     // Remember variable if dead load
     if (di->opcode() == SpvOpLoad) (void)GetPtr(di, &varId);


### PR DESCRIPTION
In DCEInst, it is possible that the same instruction ends up in the
queue multiple times, if the same id is used multiple times in the
same instruction.

The solution is to keep the ids in a set, to ensure no duplication in
the list.

Fixes issue #1051 