### PR TITLE
Remove cfg_ field from SSAPropagator class - NFC.

### DIFF
--- a/source/opt/propagator.h
+++ b/source/opt/propagator.h
@@ -22,7 +22,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include "cfg.h"
 #include "ir_context.h"
 #include "module.h"
 
@@ -185,9 +184,8 @@ class SSAPropagator {
   using VisitFunction =
       std::function<PropStatus(ir::Instruction*, ir::BasicBlock**)>;
 
-  SSAPropagator(ir::IRContext* context, ir::CFG* cfg,
-                const VisitFunction& visit_fn)
-      : ctx_(context), cfg_(cfg), visit_fn_(visit_fn) {}
+  SSAPropagator(ir::IRContext* context, const VisitFunction& visit_fn)
+      : ctx_(context), visit_fn_(visit_fn) {}
 
   // Run the propagator on function |fn|. Returns true if changes were made to
   // the function. Otherwise, it returns false.
@@ -252,10 +250,6 @@ class SSAPropagator {
 
   // IR context to use.
   ir::IRContext* ctx_;
-
-  // CFG to propagate values on. TODO(dnovillo): The CFG should be part of
-  // IRContext.
-  ir::CFG* cfg_;
 
   // Function that visits instructions during simulation. The output of this
   // function is used to determine if the simulated instruction produced a value

--- a/test/opt/propagator_test.cpp
+++ b/test/opt/propagator_test.cpp
@@ -31,7 +31,6 @@ class PropagatorTest : public testing::Test {
  protected:
   virtual void TearDown() {
     ctx_.reset(nullptr);
-    cfg_.reset(nullptr);
     values_.clear();
     values_vec_.clear();
   }
@@ -40,11 +39,10 @@ class PropagatorTest : public testing::Test {
     ctx_ = BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, input);
     ASSERT_NE(nullptr, ctx_) << "Assembling failed for shader:\n"
                              << input << "\n";
-    cfg_.reset(new ir::CFG(ctx_->module()));
   }
 
   bool Propagate(const opt::SSAPropagator::VisitFunction& visit_fn) {
-    opt::SSAPropagator propagator(ctx_.get(), cfg_.get(), visit_fn);
+    opt::SSAPropagator propagator(ctx_.get(), visit_fn);
     bool retval = false;
     for (auto& fn : *ctx_->module()) {
       retval |= propagator.Run(&fn);
@@ -61,7 +59,6 @@ class PropagatorTest : public testing::Test {
   }
 
   std::unique_ptr<ir::IRContext> ctx_;
-  std::unique_ptr<ir::CFG> cfg_;
   std::map<uint32_t, uint32_t> values_;
   std::vector<uint32_t> values_vec_;
 };


### PR DESCRIPTION
When I moved the CFG into IRContext
(https://github.com/KhronosGroup/SPIRV-Tools/pull/1019), I forgot to
update SSAPropagator to stop requiring one.

Fixed with this patch.