### PR TITLE
Fix build type for windows builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -61,7 +61,7 @@ build:
 
 build_script:
   - mkdir build && cd build
-  - cmake -GNinja -DSPIRV_BUILD_COMPRESSION=ON -DCMAKE_INSTALL_PREFIX=install ..
+  - cmake -GNinja -DSPIRV_BUILD_COMPRESSION=ON -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DCMAKE_INSTALL_PREFIX=install ..
   - ninja install
 
 test_script:


### PR DESCRIPTION
Windows builds are not using CMAKE_BUILD_TYPE.  Fixed with this patch.