### PR TITLE
Change Release builds to Release with debug info on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   matrix:
     # Each line is a set of environment variables set before a build.
     # Thus each line represents a different build configuration.
-    - BUILD_TYPE=Release
+    - BUILD_TYPE=RelWithDebInfo
     - BUILD_TYPE=Debug
 
 compiler:


### PR DESCRIPTION
For Linux builds, we want to add debug information on the generated binary (for timing and profiling purposes).  This patch changes Release builds to RelWithDebInfo.