### PR TITLE
CMake: allow both SPIRV-Headers and spirv-headers

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -17,7 +17,11 @@ if (DEFINED SPIRV-Headers_SOURCE_DIR)
   # This allows flexible position of the SPIRV-Headers repo.
   set(SPIRV_HEADER_DIR ${SPIRV-Headers_SOURCE_DIR})
 else()
-  set(SPIRV_HEADER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/spirv-headers)
+  if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/SPIRV-Headers)
+    set(SPIRV_HEADER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/SPIRV-Headers)
+  else()
+    set(SPIRV_HEADER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/spirv-headers)
+  endif()
 endif()
 
 if (IS_DIRECTORY ${SPIRV_HEADER_DIR})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,7 +23,7 @@ if (NOT "${SPIRV_SKIP_TESTS}")
   if (TARGET gmock_main)
     message(STATUS "Found Google Mock, building tests.")
   else()
-    message(STATUS "Did not find googletest, tests will not be built."
+    message(STATUS "Did not find googletest, tests will not be built. "
       "To enable tests place googletest in '<spirv-dir>/external/googletest'.")
   endif()
 endif()


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/1057