### PR TITLE
Kill names and decoration in inlining.

### DIFF
--- a/source/opt/inline_exhaustive_pass.cpp
+++ b/source/opt/inline_exhaustive_pass.cpp
@@ -33,6 +33,12 @@ bool InlineExhaustivePass::InlineExhaustive(ir::Function* func) {
         // succeeding phis at new last block.
         if (newBlocks.size() > 1) UpdateSucceedingPhis(newBlocks);
         // Replace old calling block with new block(s).
+
+        // We need to kill the name and decorations for the call, which
+        // will be deleted.  Other instructions in the block will be moved to
+        // newBlocks.  We don't need to do anything with those.
+        context()->KillNamesAndDecorates(&*ii);
+
         bi = bi.Erase();
         bi = bi.InsertBefore(&newBlocks);
         // Insert new function variables.

--- a/test/opt/inline_test.cpp
+++ b/test/opt/inline_test.cpp
@@ -2498,6 +2498,57 @@ OpFunctionEnd
       predefs + before + nonEntryFuncs, predefs + after + nonEntryFuncs, false,
       true);
 }
+
+TEST_F(InlineTest, DeleteName) {
+  // Test that the name of the result id of the call is deleted.
+  const std::string before =
+      R"(
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main"
+               OpName %main "main"
+               OpName %main_entry "main_entry"
+               OpName %foo_result "foo_result"
+               OpName %void_fn "void_fn"
+               OpName %foo "foo"
+               OpName %foo_entry "foo_entry"
+       %void = OpTypeVoid
+    %void_fn = OpTypeFunction %void
+        %foo = OpFunction %void None %void_fn
+  %foo_entry = OpLabel
+               OpReturn
+               OpFunctionEnd
+       %main = OpFunction %void None %void_fn
+ %main_entry = OpLabel
+ %foo_result = OpFunctionCall %void %foo
+               OpReturn
+               OpFunctionEnd
+)";
+
+  const std::string after =
+      R"(OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Vertex %main "main"
+OpName %main "main"
+OpName %main_entry "main_entry"
+OpName %void_fn "void_fn"
+OpName %foo "foo"
+OpName %foo_entry "foo_entry"
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%foo = OpFunction %void None %void_fn
+%foo_entry = OpLabel
+OpReturn
+OpFunctionEnd
+%main = OpFunction %void None %void_fn
+%main_entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndCheck<opt::InlineExhaustivePass>(before, after, false, true);
+}
+
 // TODO(greg-lunarg): Add tests to verify handling of these cases:
 //
 //    Empty modules


### PR DESCRIPTION
Currently when inlining a call, the name and decorations for the result of the call is not deleted.  This should be changed.  Just before deleting the basic block that contains the call, we delete the name and decorations for the call.

This fixes issue #622.