### PR TITLE
Add external/SPIRV-Headers to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .ycm_extra_conf.py*
 compile_commands.json
 /external/googletest
+/external/SPIRV-Headers
 /external/spirv-headers
 /external/effcee
 /external/re2


### PR DESCRIPTION
b93c066b allowed for both SPIRV-Headers and spirv-headers as valid paths, but only the latter is being ignored by Git.