### PR TITLE
Force gtest to expose ::testing::Combine

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -39,6 +39,13 @@ if (NOT ${SPIRV_SKIP_TESTS})
   else()
     set(GMOCK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/googletest/googlemock)
     if(EXISTS ${GMOCK_DIR})
+      if(MSVC)
+        # Our tests use ::testing::Combine.  Work around a compiler
+        # detection problem in googletest, where that template is
+        # accidentally disabled for VS 2017.
+        # See https://github.com/google/googletest/issues/1352
+        add_definitions(-DGTEST_HAS_COMBINE=1)
+      endif()
       if(WIN32)
         option(gtest_force_shared_crt
           "Use shared (DLL) run-time lib even when Google Test is built as static lib."

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,6 +48,10 @@ function(add_spvtools_unittest)
       # We don't care much about that in test code.
       # Important to do since we have warnings-as-errors.
       target_compile_options(${target} PRIVATE /wd4503)
+      # Googletest accidentally turns off support for ::testing::Combine
+      # in VS 2017.  See https://github.com/google/googletest/issues/1352
+      # Forcibly turn it on again.
+      target_compile_options(${target} PRIVATE /DGTEST_HAS_COMBINE=1)
     endif()
     target_include_directories(${target} PRIVATE
       ${SPIRV_HEADER_INCLUDE_DIR}


### PR DESCRIPTION
Work around faulty logic in googletest, where ::testing::Combine
is accidentally disabled for VS 2017.
See https://github.com/google/googletest/issues/1352