### PR TITLE
Set the parent for basic blocks during inlining.

### DIFF
--- a/source/opt/inline_exhaustive_pass.cpp
+++ b/source/opt/inline_exhaustive_pass.cpp
@@ -40,6 +40,10 @@ bool InlineExhaustivePass::InlineExhaustive(ir::Function* func) {
         context()->KillNamesAndDecorates(&*ii);
 
         bi = bi.Erase();
+
+        for (auto& bb : newBlocks) {
+          bb->SetParent(func);
+        }
         bi = bi.InsertBefore(&newBlocks);
         // Insert new function variables.
         if (newVars.size() > 0)


### PR DESCRIPTION
Inlining is not setting the parent (function) for each basic block.
This can cause problems for later optimizations.  The solution is to set
the parent for each new block just before it is linked into the
function.

Fixes issue #1083.