### PR TITLE
Appveyor: stop testing on VS 2013

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,6 @@ version: "{build}"
 os:
   - Visual Studio 2017
   - Visual Studio 2015
-  - Visual Studio 2013
 
 platform:
   - x64
@@ -34,8 +33,6 @@ clone_depth: 1
 matrix:
   fast_finish: true # Show final status immediately if a test fails.
   exclude:
-    - os: Visual Studio 2013
-      configuration: Debug
     - os: Visual Studio 2015
       configuration: Debug
 
@@ -53,7 +50,6 @@ before_build:
   - git clone --depth=1 https://github.com/google/effcee.git external/effcee
   - git clone --depth=1 https://github.com/google/re2.git external/re2
   # Set path and environment variables for the current Visual Studio version
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2013" (call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86_amd64)
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" (call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64)
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" (call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64)
 


### PR DESCRIPTION
re2 requires VS2015 or later since:

https://github.com/google/re2/commit/97957299d1c9f7617cfe653f344536d733582d9e