### PR TITLE
Fix uninitialized warning at -Os.

### DIFF
--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -60,7 +60,7 @@ void LocalSingleStoreElimPass::SingleStoreAnalyze(ir::Function* func) {
     uint32_t instIdx = 0;
     for (auto ii = bi->begin(); ii != bi->end(); ++ii, ++instIdx) {
       uint32_t varId = 0;
-      ir::Instruction* ptrInst;
+      ir::Instruction* ptrInst = nullptr;
       switch (ii->opcode()) {
         case SpvOpStore: {
           ptrInst = GetPtr(&*ii, &varId);


### PR DESCRIPTION
-Os is not smart enough to realize that this variable is actually never used uninitialized.  Added an initializer to help it.