### PR TITLE
Type manager improvements

### DIFF
--- a/source/opt/constants.cpp
+++ b/source/opt/constants.cpp
@@ -51,12 +51,12 @@ std::vector<const analysis::Constant*> ConstantManager::GetConstantsFromIds(
 
 ir::Instruction* ConstantManager::BuildInstructionAndAddToModule(
     std::unique_ptr<analysis::Constant> c, ir::Module::inst_iterator* pos,
-    uint32_t typeId) {
+    uint32_t type_id) {
   analysis::Constant* new_const = c.get();
   uint32_t new_id = context()->TakeNextId();
   const_val_to_id_[new_const] = new_id;
   id_to_const_val_[new_id] = std::move(c);
-  auto new_inst = CreateInstruction(new_id, new_const, typeId);
+  auto new_inst = CreateInstruction(new_id, new_const, type_id);
   if (!new_inst) return nullptr;
   auto* new_inst_ptr = new_inst.get();
   *pos = pos->InsertBefore(std::move(new_inst));
@@ -158,9 +158,9 @@ std::unique_ptr<analysis::Constant> ConstantManager::CreateConstantFromInst(
 }
 
 std::unique_ptr<ir::Instruction> ConstantManager::CreateInstruction(
-    uint32_t id, analysis::Constant* c, uint32_t typeId) const {
+    uint32_t id, analysis::Constant* c, uint32_t type_id) const {
   uint32_t type =
-      (typeId == 0) ? context()->get_type_mgr()->GetId(c->type()) : typeId;
+      (type_id == 0) ? context()->get_type_mgr()->GetId(c->type()) : type_id;
   if (c->AsNullConstant()) {
     return MakeUnique<ir::Instruction>(context(), SpvOp::SpvOpConstantNull,
                                        type, id,
@@ -183,7 +183,7 @@ std::unique_ptr<ir::Instruction> ConstantManager::CreateInstruction(
             spv_operand_type_t::SPV_OPERAND_TYPE_TYPED_LITERAL_NUMBER,
             fc->words())});
   } else if (analysis::CompositeConstant* cc = c->AsCompositeConstant()) {
-    return CreateCompositeInstruction(id, cc, typeId);
+    return CreateCompositeInstruction(id, cc, type_id);
   } else {
     return nullptr;
   }
@@ -191,7 +191,7 @@ std::unique_ptr<ir::Instruction> ConstantManager::CreateInstruction(
 
 std::unique_ptr<ir::Instruction> ConstantManager::CreateCompositeInstruction(
     uint32_t result_id, analysis::CompositeConstant* cc,
-    uint32_t typeId) const {
+    uint32_t type_id) const {
   std::vector<ir::Operand> operands;
   for (const analysis::Constant* component_const : cc->GetComponents()) {
     uint32_t id = FindRecordedConstant(component_const);
@@ -205,7 +205,7 @@ std::unique_ptr<ir::Instruction> ConstantManager::CreateCompositeInstruction(
                           std::initializer_list<uint32_t>{id});
   }
   uint32_t type =
-      (typeId == 0) ? context()->get_type_mgr()->GetId(cc->type()) : typeId;
+      (type_id == 0) ? context()->get_type_mgr()->GetId(cc->type()) : type_id;
   return MakeUnique<ir::Instruction>(context(), SpvOp::SpvOpConstantComposite,
                                      type, result_id, std::move(operands));
 }

--- a/source/opt/constants.cpp
+++ b/source/opt/constants.cpp
@@ -50,12 +50,13 @@ std::vector<const analysis::Constant*> ConstantManager::GetConstantsFromIds(
 }
 
 ir::Instruction* ConstantManager::BuildInstructionAndAddToModule(
-    std::unique_ptr<analysis::Constant> c, ir::Module::inst_iterator* pos) {
+    std::unique_ptr<analysis::Constant> c, ir::Module::inst_iterator* pos,
+    uint32_t typeId) {
   analysis::Constant* new_const = c.get();
   uint32_t new_id = context()->TakeNextId();
   const_val_to_id_[new_const] = new_id;
   id_to_const_val_[new_id] = std::move(c);
-  auto new_inst = CreateInstruction(new_id, new_const);
+  auto new_inst = CreateInstruction(new_id, new_const, typeId);
   if (!new_inst) return nullptr;
   auto* new_inst_ptr = new_inst.get();
   *pos = pos->InsertBefore(std::move(new_inst));
@@ -157,41 +158,40 @@ std::unique_ptr<analysis::Constant> ConstantManager::CreateConstantFromInst(
 }
 
 std::unique_ptr<ir::Instruction> ConstantManager::CreateInstruction(
-    uint32_t id, analysis::Constant* c) const {
+    uint32_t id, analysis::Constant* c, uint32_t typeId) const {
+  uint32_t type =
+      (typeId == 0) ? context()->get_type_mgr()->GetId(c->type()) : typeId;
   if (c->AsNullConstant()) {
-    return MakeUnique<ir::Instruction>(
-        context(), SpvOp::SpvOpConstantNull,
-        context()->get_type_mgr()->GetId(c->type()), id,
-        std::initializer_list<ir::Operand>{});
+    return MakeUnique<ir::Instruction>(context(), SpvOp::SpvOpConstantNull,
+                                       type, id,
+                                       std::initializer_list<ir::Operand>{});
   } else if (analysis::BoolConstant* bc = c->AsBoolConstant()) {
     return MakeUnique<ir::Instruction>(
         context(),
         bc->value() ? SpvOp::SpvOpConstantTrue : SpvOp::SpvOpConstantFalse,
-        context()->get_type_mgr()->GetId(c->type()), id,
-        std::initializer_list<ir::Operand>{});
+        type, id, std::initializer_list<ir::Operand>{});
   } else if (analysis::IntConstant* ic = c->AsIntConstant()) {
     return MakeUnique<ir::Instruction>(
-        context(), SpvOp::SpvOpConstant,
-        context()->get_type_mgr()->GetId(c->type()), id,
+        context(), SpvOp::SpvOpConstant, type, id,
         std::initializer_list<ir::Operand>{ir::Operand(
             spv_operand_type_t::SPV_OPERAND_TYPE_TYPED_LITERAL_NUMBER,
             ic->words())});
   } else if (analysis::FloatConstant* fc = c->AsFloatConstant()) {
     return MakeUnique<ir::Instruction>(
-        context(), SpvOp::SpvOpConstant,
-        context()->get_type_mgr()->GetId(c->type()), id,
+        context(), SpvOp::SpvOpConstant, type, id,
         std::initializer_list<ir::Operand>{ir::Operand(
             spv_operand_type_t::SPV_OPERAND_TYPE_TYPED_LITERAL_NUMBER,
             fc->words())});
   } else if (analysis::CompositeConstant* cc = c->AsCompositeConstant()) {
-    return CreateCompositeInstruction(id, cc);
+    return CreateCompositeInstruction(id, cc, typeId);
   } else {
     return nullptr;
   }
 }
 
 std::unique_ptr<ir::Instruction> ConstantManager::CreateCompositeInstruction(
-    uint32_t result_id, analysis::CompositeConstant* cc) const {
+    uint32_t result_id, analysis::CompositeConstant* cc,
+    uint32_t typeId) const {
   std::vector<ir::Operand> operands;
   for (const analysis::Constant* component_const : cc->GetComponents()) {
     uint32_t id = FindRecordedConstant(component_const);
@@ -204,10 +204,10 @@ std::unique_ptr<ir::Instruction> ConstantManager::CreateCompositeInstruction(
     operands.emplace_back(spv_operand_type_t::SPV_OPERAND_TYPE_ID,
                           std::initializer_list<uint32_t>{id});
   }
-  return MakeUnique<ir::Instruction>(
-      context(), SpvOp::SpvOpConstantComposite,
-      context()->get_type_mgr()->GetId(cc->type()), result_id,
-      std::move(operands));
+  uint32_t type =
+      (typeId == 0) ? context()->get_type_mgr()->GetId(cc->type()) : typeId;
+  return MakeUnique<ir::Instruction>(context(), SpvOp::SpvOpConstantComposite,
+                                     type, result_id, std::move(operands));
 }
 
 }  // namespace analysis

--- a/source/opt/constants.h
+++ b/source/opt/constants.h
@@ -325,22 +325,40 @@ class ConstantManager {
   // points to the same instruction before and after the insertion. This is the
   // only method that actually manages id creation/assignment and instruction
   // creation/insertion for a new Constant instance.
+  //
+  // |typeId| is an optional argument for disambiguating equivalent types. If
+  // |typeId| is specified, it is used as the type of the constant. Otherwise
+  // the type of the constant is derived by getting an id from the type manager
+  // for |c|.
   ir::Instruction* BuildInstructionAndAddToModule(
-      std::unique_ptr<analysis::Constant> c, ir::Module::inst_iterator* pos);
+      std::unique_ptr<analysis::Constant> c, ir::Module::inst_iterator* pos,
+      uint32_t typeId = 0);
 
   // Creates an instruction with the given result id to declare a constant
   // represented by the given Constant instance. Returns an unique pointer to
   // the created instruction if the instruction can be created successfully.
   // Otherwise, returns a null pointer.
-  std::unique_ptr<ir::Instruction> CreateInstruction(
-      uint32_t result_id, analysis::Constant* c) const;
+  //
+  // |typeId| is an optional argument for disambiguating equivalent types. If
+  // |typeId| is specified, it is used as the type of the constant. Otherwise
+  // the type of the constant is derived by getting an id from the type manager
+  // for |c|.
+  std::unique_ptr<ir::Instruction> CreateInstruction(uint32_t result_id,
+                                                     analysis::Constant* c,
+                                                     uint32_t typeId = 0) const;
 
   // Creates an OpConstantComposite instruction with the given result id and
   // the CompositeConst instance which represents a composite constant. Returns
   // an unique pointer to the created instruction if succeeded. Otherwise
   // returns a null pointer.
+  //
+  // |typeId| is an optional argument for disambiguating equivalent types. If
+  // |typeId| is specified, it is used as the type of the constant. Otherwise
+  // the type of the constant is derived by getting an id from the type manager
+  // for |c|.
   std::unique_ptr<ir::Instruction> CreateCompositeInstruction(
-      uint32_t result_id, analysis::CompositeConstant* cc) const;
+      uint32_t result_id, analysis::CompositeConstant* cc,
+      uint32_t typeId = 0) const;
 
   // A helper function to get the result type of the given instruction. Returns
   // nullptr if the instruction does not have a type id (type id is 0).

--- a/source/opt/constants.h
+++ b/source/opt/constants.h
@@ -326,39 +326,38 @@ class ConstantManager {
   // only method that actually manages id creation/assignment and instruction
   // creation/insertion for a new Constant instance.
   //
-  // |typeId| is an optional argument for disambiguating equivalent types. If
-  // |typeId| is specified, it is used as the type of the constant. Otherwise
+  // |type_id| is an optional argument for disambiguating equivalent types. If
+  // |type_id| is specified, it is used as the type of the constant. Otherwise
   // the type of the constant is derived by getting an id from the type manager
   // for |c|.
   ir::Instruction* BuildInstructionAndAddToModule(
       std::unique_ptr<analysis::Constant> c, ir::Module::inst_iterator* pos,
-      uint32_t typeId = 0);
+      uint32_t type_id = 0);
 
   // Creates an instruction with the given result id to declare a constant
   // represented by the given Constant instance. Returns an unique pointer to
   // the created instruction if the instruction can be created successfully.
   // Otherwise, returns a null pointer.
   //
-  // |typeId| is an optional argument for disambiguating equivalent types. If
-  // |typeId| is specified, it is used as the type of the constant. Otherwise
+  // |type_id| is an optional argument for disambiguating equivalent types. If
+  // |type_id| is specified, it is used as the type of the constant. Otherwise
   // the type of the constant is derived by getting an id from the type manager
   // for |c|.
-  std::unique_ptr<ir::Instruction> CreateInstruction(uint32_t result_id,
-                                                     analysis::Constant* c,
-                                                     uint32_t typeId = 0) const;
+  std::unique_ptr<ir::Instruction> CreateInstruction(
+      uint32_t result_id, analysis::Constant* c, uint32_t type_id = 0) const;
 
   // Creates an OpConstantComposite instruction with the given result id and
   // the CompositeConst instance which represents a composite constant. Returns
   // an unique pointer to the created instruction if succeeded. Otherwise
   // returns a null pointer.
   //
-  // |typeId| is an optional argument for disambiguating equivalent types. If
-  // |typeId| is specified, it is used as the type of the constant. Otherwise
+  // |type_id| is an optional argument for disambiguating equivalent types. If
+  // |type_id| is specified, it is used as the type of the constant. Otherwise
   // the type of the constant is derived by getting an id from the type manager
   // for |c|.
   std::unique_ptr<ir::Instruction> CreateCompositeInstruction(
       uint32_t result_id, analysis::CompositeConstant* cc,
-      uint32_t typeId = 0) const;
+      uint32_t type_id = 0) const;
 
   // A helper function to get the result type of the given instruction. Returns
   // nullptr if the instruction does not have a type id (type id is 0).

--- a/source/opt/fold_spec_constant_op_and_composite_pass.cpp
+++ b/source/opt/fold_spec_constant_op_and_composite_pass.cpp
@@ -160,6 +160,29 @@ bool FoldSpecConstantOpAndCompositePass::ProcessOpSpecConstantOp(
   return true;
 }
 
+uint32_t FoldSpecConstantOpAndCompositePass::GetTypeComponent(
+    uint32_t typeId, uint32_t element) const {
+  ir::Instruction* type = context()->get_def_use_mgr()->GetDef(typeId);
+  uint32_t subtype = 0;
+  switch (type->opcode()) {
+    case SpvOpTypeStruct:
+      subtype = type->GetSingleWordInOperand(element);
+      break;
+    case SpvOpTypeArray:
+    case SpvOpTypeRuntimeArray:
+    case SpvOpTypeVector:
+    case SpvOpTypeMatrix:
+      // These types all have uniform subtypes.
+      subtype = type->GetSingleWordInOperand(0u);
+      break;
+    default:
+      assert(false && "Non-composite type");
+      break;
+  }
+
+  return subtype;
+}
+
 ir::Instruction* FoldSpecConstantOpAndCompositePass::DoCompositeExtract(
     ir::Module::inst_iterator* pos) {
   ir::Instruction* inst = &**pos;
@@ -167,19 +190,24 @@ ir::Instruction* FoldSpecConstantOpAndCompositePass::DoCompositeExtract(
          "OpSpecConstantOp CompositeExtract requires at least two non-type "
          "non-opcode operands.");
   assert(inst->GetInOperand(1).type == SPV_OPERAND_TYPE_ID &&
-         "The vector operand must have a SPV_OPERAND_TYPE_ID type");
+         "The composite operand must have a SPV_OPERAND_TYPE_ID type");
   assert(
       inst->GetInOperand(2).type == SPV_OPERAND_TYPE_LITERAL_INTEGER &&
       "The literal operand must have a SPV_OPERAND_TYPE_LITERAL_INTEGER type");
 
   // Note that for OpSpecConstantOp, the second in-operand is the first id
   // operand. The first in-operand is the spec opcode.
+  uint32_t source = inst->GetSingleWordInOperand(1);
+  uint32_t type = context()->get_def_use_mgr()->GetDef(source)->type_id();
   analysis::Constant* first_operand_const =
-      context()->get_constant_mgr()->FindRecordedConstant(
-          inst->GetSingleWordInOperand(1));
+      context()->get_constant_mgr()->FindRecordedConstant(source);
   if (!first_operand_const) return nullptr;
 
   const analysis::Constant* current_const = first_operand_const;
+  for (uint32_t i = 2; i < inst->NumInOperands(); i++) {
+    uint32_t literal = inst->GetSingleWordInOperand(i);
+    type = GetTypeComponent(type, literal);
+  }
   for (uint32_t i = 2; i < inst->NumInOperands(); i++) {
     uint32_t literal = inst->GetSingleWordInOperand(i);
     if (const analysis::CompositeConstant* composite_const =
@@ -195,14 +223,14 @@ ir::Instruction* FoldSpecConstantOpAndCompositePass::DoCompositeExtract(
       return context()->get_constant_mgr()->BuildInstructionAndAddToModule(
           context()->get_constant_mgr()->CreateConstant(
               context()->get_constant_mgr()->GetType(inst), {}),
-          pos);
+          pos, type);
     } else {
       // Dereferencing a non-composite constant. Invalid case.
       return nullptr;
     }
   }
   return context()->get_constant_mgr()->BuildInstructionAndAddToModule(
-      current_const->Copy(), pos);
+      current_const->Copy(), pos, type);
 }
 
 ir::Instruction* FoldSpecConstantOpAndCompositePass::DoVectorShuffle(

--- a/source/opt/fold_spec_constant_op_and_composite_pass.cpp
+++ b/source/opt/fold_spec_constant_op_and_composite_pass.cpp
@@ -163,22 +163,8 @@ bool FoldSpecConstantOpAndCompositePass::ProcessOpSpecConstantOp(
 uint32_t FoldSpecConstantOpAndCompositePass::GetTypeComponent(
     uint32_t typeId, uint32_t element) const {
   ir::Instruction* type = context()->get_def_use_mgr()->GetDef(typeId);
-  uint32_t subtype = 0;
-  switch (type->opcode()) {
-    case SpvOpTypeStruct:
-      subtype = type->GetSingleWordInOperand(element);
-      break;
-    case SpvOpTypeArray:
-    case SpvOpTypeRuntimeArray:
-    case SpvOpTypeVector:
-    case SpvOpTypeMatrix:
-      // These types all have uniform subtypes.
-      subtype = type->GetSingleWordInOperand(0u);
-      break;
-    default:
-      assert(false && "Non-composite type");
-      break;
-  }
+  uint32_t subtype = type->GetTypeComponent(element);
+  assert(subtype != 0);
 
   return subtype;
 }

--- a/source/opt/fold_spec_constant_op_and_composite_pass.h
+++ b/source/opt/fold_spec_constant_op_and_composite_pass.h
@@ -79,6 +79,11 @@ class FoldSpecConstantOpAndCompositePass : public Pass {
   // if succeeded, otherwise return nullptr.
   ir::Instruction* DoComponentWiseOperation(
       ir::Module::inst_iterator* inst_iter_ptr);
+
+  // Returns the |element|'th subtype of |type|.
+  //
+  // |type| must be a composite type.
+  uint32_t GetTypeComponent(uint32_t type, uint32_t element) const;
 };
 
 }  // namespace opt

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -64,9 +64,7 @@ uint32_t InlinePass::AddPointerToType(uint32_t type_id,
   opt::analysis::Type* pointeeTy = context()->get_type_mgr()->GetType(type_id);
   context()->AddType(std::move(type_inst));
   opt::analysis::Pointer pointerTy(pointeeTy, storage_class);
-  if (context()->get_type_mgr()->GetId(&pointerTy) == 0) {
-    context()->get_type_mgr()->RegisterType(resultId, pointerTy);
-  }
+  context()->get_type_mgr()->RegisterType(resultId, pointerTy);
   return resultId;
 }
 

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -355,6 +355,26 @@ bool Instruction::IsReadOnlyVariableKernel() const {
   return storage_class == SpvStorageClassUniformConstant;
 }
 
+uint32_t Instruction::GetTypeComponent(uint32_t element) const {
+  uint32_t subtype = 0;
+  switch (opcode()) {
+    case SpvOpTypeStruct:
+      subtype = GetSingleWordInOperand(element);
+      break;
+    case SpvOpTypeArray:
+    case SpvOpTypeRuntimeArray:
+    case SpvOpTypeVector:
+    case SpvOpTypeMatrix:
+      // These types all have uniform subtypes.
+      subtype = GetSingleWordInOperand(0u);
+      break;
+    default:
+      break;
+  }
+
+  return subtype;
+}
+
 Instruction* Instruction::InsertBefore(
     std::vector<std::unique_ptr<Instruction>>&& list) {
   Instruction* first_node = list.front().get();

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -303,6 +303,10 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   // and return to its caller
   bool IsReturn() const { return spvOpcodeIsReturn(opcode()); }
 
+  // Returns the id for the |element|'th subtype. If the |this| is not a
+  // composite type, this function returns 0.
+  uint32_t GetTypeComponent(uint32_t element) const;
+
   // Returns true if this instruction is a basic block terminator.
   bool IsBlockTerminator() const {
     return spvOpcodeIsBlockTerminator(opcode());

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -469,6 +469,10 @@ void IRContext::InitializeCombinators() {
   valid_analyses_ |= kAnalysisCombinators;
 }
 
+// ir::Instruction* IRContext::GetTypeInstruction(const Type* type) {
+//
+//}
+
 // Gets the dominator analysis for function |f|.
 opt::DominatorAnalysis* IRContext::GetDominatorAnalysis(const ir::Function* f,
                                                         const ir::CFG& in_cfg) {

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -95,6 +95,10 @@ Instruction* IRContext::KillInst(ir::Instruction* inst) {
     }
   }
 
+  if (type_mgr_) {
+    type_mgr_->RemoveId(inst->result_id());
+  }
+
   Instruction* next_instruction = nullptr;
   if (inst->IsInAList()) {
     next_instruction = inst->NextNode();

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -469,10 +469,6 @@ void IRContext::InitializeCombinators() {
   valid_analyses_ |= kAnalysisCombinators;
 }
 
-// ir::Instruction* IRContext::GetTypeInstruction(const Type* type) {
-//
-//}
-
 // Gets the dominator analysis for function |f|.
 opt::DominatorAnalysis* IRContext::GetDominatorAnalysis(const ir::Function* f,
                                                         const ir::CFG& in_cfg) {

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -16,6 +16,8 @@
 #include "latest_version_glsl_std_450_header.h"
 #include "log.h"
 #include "mem_pass.h"
+#include "reflect.h"
+#include "spirv/1.0/GLSL.std.450.h"
 
 #include <cstring>
 
@@ -95,7 +97,7 @@ Instruction* IRContext::KillInst(ir::Instruction* inst) {
     }
   }
 
-  if (type_mgr_) {
+  if (type_mgr_ && ir::IsTypeInst(inst->opcode())) {
     type_mgr_->RemoveId(inst->result_id());
   }
 

--- a/source/opt/ir_context.h
+++ b/source/opt/ir_context.h
@@ -378,6 +378,13 @@ class IRContext {
     return feature_mgr_.get();
   }
 
+  // Returns an instruction for the instruction representing |type|.
+  //
+  // If an instruction already exists that matches |type|, then that
+  // instruction is returned, otherwise a new instruction is
+  // created.
+  // ir::Instruction* GetTypeInstruction(const Type* type);
+
  private:
   // Builds the def-use manager from scratch, even if it was already valid.
   void BuildDefUseManager() {

--- a/source/opt/ir_context.h
+++ b/source/opt/ir_context.h
@@ -378,13 +378,6 @@ class IRContext {
     return feature_mgr_.get();
   }
 
-  // Returns an instruction for the instruction representing |type|.
-  //
-  // If an instruction already exists that matches |type|, then that
-  // instruction is returned, otherwise a new instruction is
-  // created.
-  ir::Instruction* GetTypeInstruction(const opt::analysis::Type* type);
-
  private:
   // Builds the def-use manager from scratch, even if it was already valid.
   void BuildDefUseManager() {

--- a/source/opt/ir_context.h
+++ b/source/opt/ir_context.h
@@ -241,7 +241,7 @@ class IRContext {
   // is never re-built.
   opt::analysis::TypeManager* get_type_mgr() {
     if (!type_mgr_)
-      type_mgr_.reset(new opt::analysis::TypeManager(consumer(), *module()));
+      type_mgr_.reset(new opt::analysis::TypeManager(consumer(), this));
     return type_mgr_.get();
   }
 
@@ -383,7 +383,7 @@ class IRContext {
   // If an instruction already exists that matches |type|, then that
   // instruction is returned, otherwise a new instruction is
   // created.
-  // ir::Instruction* GetTypeInstruction(const Type* type);
+  ir::Instruction* GetTypeInstruction(const opt::analysis::Type* type);
 
  private:
   // Builds the def-use manager from scratch, even if it was already valid.

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -82,7 +82,8 @@ Optimizer& Optimizer::RegisterLegalizationPasses() {
 }
 
 Optimizer& Optimizer::RegisterPerformancePasses() {
-  return RegisterPass(CreateMergeReturnPass())
+  return RegisterPass(CreateRemoveDuplicatesPass())
+      .RegisterPass(CreateMergeReturnPass())
       .RegisterPass(CreateInlineExhaustivePass())
       .RegisterPass(CreateEliminateDeadFunctionsPass())
       .RegisterPass(CreateScalarReplacementPass())
@@ -102,7 +103,8 @@ Optimizer& Optimizer::RegisterPerformancePasses() {
 }
 
 Optimizer& Optimizer::RegisterSizePasses() {
-  return RegisterPass(CreateMergeReturnPass())
+  return RegisterPass(CreateRemoveDuplicatesPass())
+      .RegisterPass(CreateMergeReturnPass())
       .RegisterPass(CreateInlineExhaustivePass())
       .RegisterPass(CreateEliminateDeadFunctionsPass())
       .RegisterPass(CreateLocalAccessChainConvertPass())
@@ -287,6 +289,11 @@ Optimizer::PassToken CreateLocalRedundancyEliminationPass() {
 Optimizer::PassToken CreateRedundancyEliminationPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::RedundancyEliminationPass>());
+}
+
+Optimizer::PassToken CreateRemoveDuplicatesPass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::RemoveDuplicatesPass>());
 }
 
 Optimizer::PassToken CreateScalarReplacementPass() {

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -40,6 +40,7 @@
 #include "merge_return_pass.h"
 #include "null_pass.h"
 #include "redundancy_elimination.h"
+#include "remove_duplicates_pass.h"
 #include "scalar_replacement_pass.h"
 #include "set_spec_constant_default_value_pass.h"
 #include "strength_reduction_pass.h"

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -517,14 +517,14 @@ bool ScalarReplacementPass::CheckType(const ir::Instruction* typeInst) const {
     case SpvOpTypeArray:
       if (GetArrayLength(typeInst) > MAX_NUM_ELEMENTS) return false;
       return true;
-      // TODO(alanbaker): Develop some heuristics for when this should be
-      // re-enabled.
-      //// Specifically including matrix and vector in an attempt to reduce the
-      //// number of vector registers required.
-      // case SpvOpTypeMatrix:
-      // case SpvOpTypeVector:
-      //  if (GetNumElements(typeInst) > MAX_NUM_ELEMENTS) return false;
-      //  return true;
+    // TODO(alanbaker): Develop some heuristics for when this should be
+    // re-enabled.
+    //// Specifically including matrix and vector in an attempt to reduce the
+    //// number of vector registers required.
+    // case SpvOpTypeMatrix:
+    // case SpvOpTypeVector:
+    //  if (GetNumElements(typeInst) > MAX_NUM_ELEMENTS) return false;
+    //  return true;
 
     case SpvOpTypeRuntimeArray:
     default:

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -377,9 +377,7 @@ uint32_t ScalarReplacementPass::GetOrCreatePointerType(uint32_t id) {
   get_def_use_mgr()->AnalyzeInstDefUse(ptr);
   pointee_to_pointer_[id] = ptrId;
   // Register with the type manager if necessary.
-  if (context()->get_type_mgr()->GetId(&pointerTy) == 0) {
-    context()->get_type_mgr()->RegisterType(ptrId, pointerTy);
-  }
+  context()->get_type_mgr()->RegisterType(ptrId, pointerTy);
 
   return ptrId;
 }
@@ -519,14 +517,14 @@ bool ScalarReplacementPass::CheckType(const ir::Instruction* typeInst) const {
     case SpvOpTypeArray:
       if (GetArrayLength(typeInst) > MAX_NUM_ELEMENTS) return false;
       return true;
-    // TODO(alanbaker): Develop some heuristics for when this should be
-    // re-enabled.
-    //// Specifically including matrix and vector in an attempt to reduce the
-    //// number of vector registers required.
-    // case SpvOpTypeMatrix:
-    // case SpvOpTypeVector:
-    //  if (GetNumElements(typeInst) > MAX_NUM_ELEMENTS) return false;
-    //  return true;
+      // TODO(alanbaker): Develop some heuristics for when this should be
+      // re-enabled.
+      //// Specifically including matrix and vector in an attempt to reduce the
+      //// number of vector registers required.
+      // case SpvOpTypeMatrix:
+      // case SpvOpTypeVector:
+      //  if (GetNumElements(typeInst) > MAX_NUM_ELEMENTS) return false;
+      //  return true;
 
     case SpvOpTypeRuntimeArray:
     default:

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -335,8 +335,18 @@ uint32_t ScalarReplacementPass::GetOrCreatePointerType(uint32_t id) {
   auto iter = pointee_to_pointer_.find(id);
   if (iter != pointee_to_pointer_.end()) return iter->second;
 
-  // TODO(alanbaker): Make the type manager useful and then replace this code.
+  opt::analysis::Type* pointeeTy = context()->get_type_mgr()->GetType(id);
+  opt::analysis::Pointer pointerTy(pointeeTy, SpvStorageClassFunction);
   uint32_t ptrId = 0;
+  if (id == context()->get_type_mgr()->GetId(pointeeTy)) {
+    // Non-ambiguous type, just ask the type manager for an id.
+    ptrId = context()->get_type_mgr()->GetTypeInstruction(&pointerTy);
+    pointee_to_pointer_[id] = ptrId;
+    return ptrId;
+  }
+
+  // Ambiguous type. We must perform a linear search to try and find the right
+  // type.
   for (auto global : context()->types_values()) {
     if (global.opcode() == SpvOpTypePointer &&
         global.GetSingleWordInOperand(0u) == SpvStorageClassFunction &&
@@ -345,7 +355,7 @@ uint32_t ScalarReplacementPass::GetOrCreatePointerType(uint32_t id) {
               libspirv::Extension::kSPV_KHR_variable_pointers) ||
           get_decoration_mgr()->GetDecorationsFor(id, false).empty()) {
         // If variable pointers is enabled, only reuse a decoration-less
-        // pointer of the correct type
+        // pointer of the correct type.
         ptrId = global.result_id();
         break;
       }
@@ -366,6 +376,10 @@ uint32_t ScalarReplacementPass::GetOrCreatePointerType(uint32_t id) {
   ir::Instruction* ptr = &*--context()->types_values_end();
   get_def_use_mgr()->AnalyzeInstDefUse(ptr);
   pointee_to_pointer_[id] = ptrId;
+  // Register with the type manager if necessary.
+  if (context()->get_type_mgr()->GetId(&pointerTy) == 0) {
+    context()->get_type_mgr()->RegisterType(ptrId, pointerTy);
+  }
 
   return ptrId;
 }

--- a/source/opt/strength_reduction_pass.cpp
+++ b/source/opt/strength_reduction_pass.cpp
@@ -125,18 +125,13 @@ bool StrengthReductionPass::ReplaceMultiplyByPowerOf2(
 }
 
 void StrengthReductionPass::FindIntTypesAndConstants() {
+  opt::analysis::Integer int32(32, true);
+  int32_type_id_ = context()->get_type_mgr()->GetId(&int32);
+  opt::analysis::Integer uint32(32, false);
+  uint32_type_id_ = context()->get_type_mgr()->GetId(&uint32);
   for (auto iter = get_module()->types_values_begin();
        iter != get_module()->types_values_end(); ++iter) {
     switch (iter->opcode()) {
-      case SpvOp::SpvOpTypeInt:
-        if (iter->GetSingleWordOperand(1) == 32) {
-          if (iter->GetSingleWordOperand(2) == 1) {
-            int32_type_id_ = iter->result_id();
-          } else {
-            uint32_type_id_ = iter->result_id();
-          }
-        }
-        break;
       case SpvOp::SpvOpConstant:
         if (iter->type_id() == uint32_type_id_) {
           uint32_t value = iter->GetSingleWordOperand(2);
@@ -155,7 +150,8 @@ uint32_t StrengthReductionPass::GetConstantId(uint32_t val) {
 
   if (constant_ids_[val] == 0) {
     if (uint32_type_id_ == 0) {
-      uint32_type_id_ = CreateUint32Type();
+      opt::analysis::Integer uint(32, false);
+      uint32_type_id_ = context()->get_type_mgr()->GetTypeInstruction(&uint);
     }
 
     // Construct the constant.
@@ -197,18 +193,6 @@ bool StrengthReductionPass::ScanFunctions() {
     }
   }
   return modified;
-}
-
-uint32_t StrengthReductionPass::CreateUint32Type() {
-  uint32_t type_id = TakeNextId();
-  ir::Operand widthOperand(spv_operand_type_t::SPV_OPERAND_TYPE_LITERAL_INTEGER,
-                           {32});
-  ir::Operand signOperand(spv_operand_type_t::SPV_OPERAND_TYPE_LITERAL_INTEGER,
-                          {0});
-  std::unique_ptr<ir::Instruction> newType(new ir::Instruction(
-      context(), SpvOp::SpvOpTypeInt, type_id, 0, {widthOperand, signOperand}));
-  context()->AddType(std::move(newType));
-  return type_id;
 }
 
 }  // namespace opt

--- a/source/opt/strength_reduction_pass.cpp
+++ b/source/opt/strength_reduction_pass.cpp
@@ -125,9 +125,9 @@ bool StrengthReductionPass::ReplaceMultiplyByPowerOf2(
 }
 
 void StrengthReductionPass::FindIntTypesAndConstants() {
-  opt::analysis::Integer int32(32, true);
+  analysis::Integer int32(32, true);
   int32_type_id_ = context()->get_type_mgr()->GetId(&int32);
-  opt::analysis::Integer uint32(32, false);
+  analysis::Integer uint32(32, false);
   uint32_type_id_ = context()->get_type_mgr()->GetId(&uint32);
   for (auto iter = get_module()->types_values_begin();
        iter != get_module()->types_values_end(); ++iter) {
@@ -150,7 +150,7 @@ uint32_t StrengthReductionPass::GetConstantId(uint32_t val) {
 
   if (constant_ids_[val] == 0) {
     if (uint32_type_id_ == 0) {
-      opt::analysis::Integer uint(32, false);
+      analysis::Integer uint(32, false);
       uint32_type_id_ = context()->get_type_mgr()->GetTypeInstruction(&uint);
     }
 

--- a/source/opt/strength_reduction_pass.h
+++ b/source/opt/strength_reduction_pass.h
@@ -49,10 +49,6 @@ class StrengthReductionPass : public Pass {
   // ones. Returns true if something changed.
   bool ScanFunctions();
 
-  // Will create the type for an unsigned 32-bit integer and return the id.
-  // This functions assumes one does not already exist.
-  uint32_t CreateUint32Type();
-
   // Type ids for the types of interest, or 0 if they do not exist.
   uint32_t int32_type_id_;
   uint32_t uint32_type_id_;

--- a/source/opt/type_manager.cpp
+++ b/source/opt/type_manager.cpp
@@ -26,9 +26,9 @@ namespace opt {
 namespace analysis {
 
 TypeManager::TypeManager(const MessageConsumer& consumer,
-                         spvtools::ir::IRContext* context)
-    : consumer_(consumer), context_(context) {
-  AnalyzeTypes(*context->module());
+                         spvtools::ir::IRContext* c)
+    : consumer_(consumer), context_(c) {
+  AnalyzeTypes(*c->module());
 }
 
 Type* TypeManager::GetType(uint32_t id) const {

--- a/source/opt/type_manager.cpp
+++ b/source/opt/type_manager.cpp
@@ -14,14 +14,22 @@
 
 #include "type_manager.h"
 
+#include <cassert>
 #include <utility>
 
+#include "ir_context.h"
 #include "log.h"
 #include "reflect.h"
 
 namespace spvtools {
 namespace opt {
 namespace analysis {
+
+TypeManager::TypeManager(const MessageConsumer& consumer,
+                         spvtools::ir::IRContext* context)
+    : consumer_(consumer), context_(context) {
+  AnalyzeTypes(*context->module());
+}
 
 Type* TypeManager::GetType(uint32_t id) const {
   auto iter = id_to_type_.find(id);
@@ -43,6 +51,237 @@ ForwardPointer* TypeManager::GetForwardPointer(uint32_t index) const {
 void TypeManager::AnalyzeTypes(const spvtools::ir::Module& module) {
   for (const auto* inst : module.GetTypes()) RecordIfTypeDefinition(*inst);
   for (const auto& inst : module.annotations()) AttachIfTypeDecoration(inst);
+}
+
+uint32_t TypeManager::GetTypeInstruction(const Type* type) {
+  uint32_t id = GetId(type);
+  if (id != 0) return id;
+
+  std::unique_ptr<ir::Instruction> typeInst;
+  id = context()->TakeNextId();
+  RegisterType(id, *type);
+  switch (type->kind()) {
+#define DefineParameterlessCase(kind)                                          \
+  case Type::k##kind:                                                          \
+    typeInst.reset(new ir::Instruction(context(), SpvOpType##kind, 0, id,      \
+                                       std::initializer_list<ir::Operand>{})); \
+    break;
+    DefineParameterlessCase(Void);
+    DefineParameterlessCase(Bool);
+    DefineParameterlessCase(Sampler);
+    DefineParameterlessCase(Event);
+    DefineParameterlessCase(DeviceEvent);
+    DefineParameterlessCase(ReserveId);
+    DefineParameterlessCase(Queue);
+    DefineParameterlessCase(PipeStorage);
+    DefineParameterlessCase(NamedBarrier);
+#undef DefineParameterlessCase
+    case Type::kInteger:
+      typeInst.reset(new ir::Instruction(
+          context(), SpvOpTypeInt, 0, id,
+          std::initializer_list<ir::Operand>{
+              {SPV_OPERAND_TYPE_LITERAL_INTEGER, {type->AsInteger()->width()}},
+              {SPV_OPERAND_TYPE_LITERAL_INTEGER,
+               {(type->AsInteger()->IsSigned() ? 1u : 0u)}}}));
+      break;
+    case Type::kFloat:
+      typeInst.reset(new ir::Instruction(
+          context(), SpvOpTypeFloat, 0, id,
+          std::initializer_list<ir::Operand>{
+              {SPV_OPERAND_TYPE_LITERAL_INTEGER, {type->AsFloat()->width()}}}));
+      break;
+    case Type::kVector: {
+      uint32_t subtype = GetTypeInstruction(type->AsVector()->element_type());
+      typeInst.reset(
+          new ir::Instruction(context(), SpvOpTypeVector, 0, id,
+                              std::initializer_list<ir::Operand>{
+                                  {SPV_OPERAND_TYPE_ID, {subtype}},
+                                  {SPV_OPERAND_TYPE_LITERAL_INTEGER,
+                                   {type->AsVector()->element_count()}}}));
+      break;
+    }
+    case Type::kMatrix: {
+      uint32_t subtype = GetTypeInstruction(type->AsMatrix()->element_type());
+      typeInst.reset(
+          new ir::Instruction(context(), SpvOpTypeMatrix, 0, id,
+                              std::initializer_list<ir::Operand>{
+                                  {SPV_OPERAND_TYPE_ID, {subtype}},
+                                  {SPV_OPERAND_TYPE_LITERAL_INTEGER,
+                                   {type->AsMatrix()->element_count()}}}));
+      break;
+    }
+    case Type::kImage: {
+      const Image* image = type->AsImage();
+      uint32_t subtype = GetTypeInstruction(image->sampled_type());
+      typeInst.reset(new ir::Instruction(
+          context(), SpvOpTypeImage, 0, id,
+          std::initializer_list<ir::Operand>{
+              {SPV_OPERAND_TYPE_ID, {subtype}},
+              {SPV_OPERAND_TYPE_DIMENSIONALITY, {image->dim()}},
+              {SPV_OPERAND_TYPE_LITERAL_INTEGER, {image->depth()}},
+              {SPV_OPERAND_TYPE_LITERAL_INTEGER, {image->arrayed()}},
+              {SPV_OPERAND_TYPE_LITERAL_INTEGER, {image->ms()}},
+              {SPV_OPERAND_TYPE_LITERAL_INTEGER, {image->sampled()}},
+              {SPV_OPERAND_TYPE_SAMPLER_IMAGE_FORMAT, {image->format()}},
+              {SPV_OPERAND_TYPE_ACCESS_QUALIFIER,
+               {image->access_qualifier()}}}));
+      break;
+    }
+    case Type::kSampledImage: {
+      uint32_t subtype =
+          GetTypeInstruction(type->AsSampledImage()->image_type());
+      typeInst.reset(
+          new ir::Instruction(context(), SpvOpTypeSampledImage, 0, id,
+                              std::initializer_list<ir::Operand>{
+                                  {SPV_OPERAND_TYPE_ID, {subtype}}}));
+      break;
+    }
+    case Type::kArray: {
+      uint32_t subtype = GetTypeInstruction(type->AsArray()->element_type());
+      typeInst.reset(new ir::Instruction(
+          context(), SpvOpTypeArray, 0, id,
+          std::initializer_list<ir::Operand>{
+              {SPV_OPERAND_TYPE_ID, {subtype}},
+              {SPV_OPERAND_TYPE_ID, {type->AsArray()->LengthId()}}}));
+      break;
+    }
+    case Type::kRuntimeArray: {
+      uint32_t subtype =
+          GetTypeInstruction(type->AsRuntimeArray()->element_type());
+      typeInst.reset(
+          new ir::Instruction(context(), SpvOpTypeRuntimeArray, 0, id,
+                              std::initializer_list<ir::Operand>{
+                                  {SPV_OPERAND_TYPE_ID, {subtype}}}));
+      break;
+    }
+    case Type::kStruct: {
+      std::vector<ir::Operand> ops;
+      const Struct* structTy = type->AsStruct();
+      for (auto ty : structTy->element_types()) {
+        ops.push_back(
+            ir::Operand(SPV_OPERAND_TYPE_ID, {GetTypeInstruction(ty)}));
+      }
+      typeInst.reset(
+          new ir::Instruction(context(), SpvOpTypeStruct, 0, id, ops));
+      break;
+    }
+    case Type::kOpaque: {
+      std::vector<uint32_t> words;
+      uint32_t word = 0;
+      const Opaque* opaque = type->AsOpaque();
+      size_t size = opaque->name().size();
+      // Convert to null-terminated packed UTF-8 string.
+      for (size_t i = 0; i != size; ++i) {
+        word <<= 8;
+        word |= (opaque->name()[i] & 0xff);
+        if (i % 4 == 3) {
+          words.push_back(word);
+          word = 0;
+        }
+        if (i == size - 1) {
+          if (i % 4 == 3) {
+            words.push_back('\0' << 24);
+          } else {
+            words.back() <<= 8;
+            words.back() |= '\0';
+          }
+        }
+      }
+      typeInst.reset(
+          new ir::Instruction(context(), SpvOpTypeOpaque, 0, id,
+                              std::initializer_list<ir::Operand>{
+                                  {SPV_OPERAND_TYPE_LITERAL_STRING, words}}));
+      break;
+    }
+    case Type::kPointer: {
+      const Pointer* pointer = type->AsPointer();
+      uint32_t subtype = GetTypeInstruction(pointer->pointee_type());
+      typeInst.reset(new ir::Instruction(
+          context(), SpvOpTypePointer, 0, id,
+          std::initializer_list<ir::Operand>{
+              {SPV_OPERAND_TYPE_STORAGE_CLASS, {pointer->storage_class()}},
+              {SPV_OPERAND_TYPE_ID, {subtype}}}));
+      break;
+    }
+    case Type::kFunction: {
+      std::vector<ir::Operand> ops;
+      const Function* function = type->AsFunction();
+      ops.push_back(ir::Operand(SPV_OPERAND_TYPE_ID,
+                                {GetTypeInstruction(function->return_type())}));
+      for (auto ty : function->param_types()) {
+        ops.push_back(
+            ir::Operand(SPV_OPERAND_TYPE_ID, {GetTypeInstruction(ty)}));
+      }
+      typeInst.reset(
+          new ir::Instruction(context(), SpvOpTypeFunction, 0, id, ops));
+      break;
+    }
+    case Type::kPipe:
+      typeInst.reset(
+          new ir::Instruction(context(), SpvOpTypePipe, 0, id,
+                              std::initializer_list<ir::Operand>{
+                                  {SPV_OPERAND_TYPE_ACCESS_QUALIFIER,
+                                   {type->AsPipe()->access_qualifier()}}}));
+      break;
+    case Type::kForwardPointer:
+      typeInst.reset(new ir::Instruction(
+          context(), SpvOpTypeForwardPointer, 0, id,
+          std::initializer_list<ir::Operand>{
+              {SPV_OPERAND_TYPE_ID, {type->AsForwardPointer()->target_id()}},
+              {SPV_OPERAND_TYPE_STORAGE_CLASS,
+               {type->AsForwardPointer()->storage_class()}}}));
+      break;
+    default:
+      assert(false && "Unexpected type");
+      break;
+  }
+  context()->AddType(std::move(typeInst));
+  context()->get_def_use_mgr()->AnalyzeInstDefUse(
+      &*--context()->types_values_end());
+  AttachDecorations(id, type);
+
+  return id;
+}
+
+void TypeManager::AttachDecorations(uint32_t id, const Type* type) {
+  for (auto vec : type->decorations()) {
+    CreateDecoration(id, vec);
+  }
+  if (const Struct* structTy = type->AsStruct()) {
+    for (auto pair : structTy->element_decorations()) {
+      uint32_t element = pair.first;
+      for (auto vec : pair.second) {
+        CreateDecoration(id, vec, element);
+      }
+    }
+  }
+}
+
+void TypeManager::CreateDecoration(uint32_t target,
+                                   const std::vector<uint32_t>& decoration,
+                                   uint32_t element) {
+  std::vector<ir::Operand> ops;
+  ops.push_back(ir::Operand(SPV_OPERAND_TYPE_ID, {target}));
+  ops.push_back(ir::Operand(SPV_OPERAND_TYPE_ID, {decoration[0]}));
+  if (element != 0) {
+    ops.push_back(ir::Operand(SPV_OPERAND_TYPE_LITERAL_INTEGER, {element}));
+  }
+  for (size_t i = 1; i != decoration.size(); ++i) {
+    ops.push_back(
+        ir::Operand(SPV_OPERAND_TYPE_LITERAL_INTEGER, {decoration[i]}));
+  }
+  context()->AddAnnotationInst(MakeUnique<ir::Instruction>(
+      context(), (element == 0 ? SpvOpDecorate : SpvOpMemberDecorate), 0, 0,
+      ops));
+  ir::Instruction* inst = &*--context()->annotation_end();
+  context()->get_def_use_mgr()->AnalyzeInstUse(inst);
+  context()->get_decoration_mgr()->AddDecoration(inst);
+}
+
+void TypeManager::RegisterType(uint32_t id, const Type& type) {
+  auto& t = id_to_type_[id];
+  t = type.Clone();
+  type_to_id_[t.get()] = id;
 }
 
 Type* TypeManager::RecordIfTypeDefinition(

--- a/source/opt/type_manager.cpp
+++ b/source/opt/type_manager.cpp
@@ -20,6 +20,7 @@
 
 #include "ir_context.h"
 #include "log.h"
+#include "make_unique.h"
 #include "reflect.h"
 
 namespace spvtools {
@@ -36,6 +37,16 @@ Type* TypeManager::GetType(uint32_t id) const {
   auto iter = id_to_type_.find(id);
   if (iter != id_to_type_.end()) return (*iter).second.get();
   return nullptr;
+}
+
+std::pair<Type*, std::unique_ptr<Pointer>> TypeManager::GetTypeAndPointerType(
+    uint32_t id, SpvStorageClass sc) const {
+  Type* type = GetType(id);
+  if (type) {
+    return std::make_pair(type, MakeUnique<analysis::Pointer>(type, sc));
+  } else {
+    return std::make_pair(type, std::unique_ptr<analysis::Pointer>());
+  }
 }
 
 uint32_t TypeManager::GetId(const Type* type) const {

--- a/source/opt/type_manager.cpp
+++ b/source/opt/type_manager.cpp
@@ -187,7 +187,6 @@ void TypeManager::AttachIfTypeDecoration(const ir::Instruction& inst) {
   if (!id_to_type_.count(id)) return;
 
   Type* target_type = id_to_type_[id].get();
-  assert(!target_type->IsUniqueType());
   switch (opcode) {
     case SpvOpDecorate: {
       const auto count = inst.NumOperands();

--- a/source/opt/type_manager.cpp
+++ b/source/opt/type_manager.cpp
@@ -120,8 +120,10 @@ uint32_t TypeManager::GetTypeInstruction(const Type* type) {
               {SPV_OPERAND_TYPE_ID, {subtype}},
               {SPV_OPERAND_TYPE_DIMENSIONALITY, {image->dim()}},
               {SPV_OPERAND_TYPE_LITERAL_INTEGER, {image->depth()}},
-              {SPV_OPERAND_TYPE_LITERAL_INTEGER, {image->arrayed()}},
-              {SPV_OPERAND_TYPE_LITERAL_INTEGER, {image->ms()}},
+              {SPV_OPERAND_TYPE_LITERAL_INTEGER,
+               {(image->is_arrayed() ? 1u : 0u)}},
+              {SPV_OPERAND_TYPE_LITERAL_INTEGER,
+               {(image->is_multisampled() ? 1u : 0u)}},
               {SPV_OPERAND_TYPE_LITERAL_INTEGER, {image->sampled()}},
               {SPV_OPERAND_TYPE_SAMPLER_IMAGE_FORMAT, {image->format()}},
               {SPV_OPERAND_TYPE_ACCESS_QUALIFIER,
@@ -306,8 +308,8 @@ Type* TypeManager::RecordIfTypeDefinition(
       type = new Image(
           GetType(inst.GetSingleWordInOperand(0)),
           static_cast<SpvDim>(inst.GetSingleWordInOperand(1)),
-          inst.GetSingleWordInOperand(2), inst.GetSingleWordInOperand(3),
-          inst.GetSingleWordInOperand(4), inst.GetSingleWordInOperand(5),
+          inst.GetSingleWordInOperand(2), inst.GetSingleWordInOperand(3) == 1,
+          inst.GetSingleWordInOperand(4) == 1, inst.GetSingleWordInOperand(5),
           static_cast<SpvImageFormat>(inst.GetSingleWordInOperand(6)), access);
     } break;
     case SpvOpTypeSampler:

--- a/source/opt/type_manager.cpp
+++ b/source/opt/type_manager.cpp
@@ -118,16 +118,18 @@ uint32_t TypeManager::GetTypeInstruction(const Type* type) {
           context(), SpvOpTypeImage, 0, id,
           std::initializer_list<ir::Operand>{
               {SPV_OPERAND_TYPE_ID, {subtype}},
-              {SPV_OPERAND_TYPE_DIMENSIONALITY, {image->dim()}},
+              {SPV_OPERAND_TYPE_DIMENSIONALITY,
+               {static_cast<uint32_t>(image->dim())}},
               {SPV_OPERAND_TYPE_LITERAL_INTEGER, {image->depth()}},
               {SPV_OPERAND_TYPE_LITERAL_INTEGER,
                {(image->is_arrayed() ? 1u : 0u)}},
               {SPV_OPERAND_TYPE_LITERAL_INTEGER,
                {(image->is_multisampled() ? 1u : 0u)}},
               {SPV_OPERAND_TYPE_LITERAL_INTEGER, {image->sampled()}},
-              {SPV_OPERAND_TYPE_SAMPLER_IMAGE_FORMAT, {image->format()}},
+              {SPV_OPERAND_TYPE_SAMPLER_IMAGE_FORMAT,
+               {static_cast<uint32_t>(image->format())}},
               {SPV_OPERAND_TYPE_ACCESS_QUALIFIER,
-               {image->access_qualifier()}}}));
+               {static_cast<uint32_t>(image->access_qualifier())}}}));
       break;
     }
     case Type::kSampledImage: {
@@ -187,7 +189,8 @@ uint32_t TypeManager::GetTypeInstruction(const Type* type) {
       typeInst.reset(new ir::Instruction(
           context(), SpvOpTypePointer, 0, id,
           std::initializer_list<ir::Operand>{
-              {SPV_OPERAND_TYPE_STORAGE_CLASS, {pointer->storage_class()}},
+              {SPV_OPERAND_TYPE_STORAGE_CLASS,
+               {static_cast<uint32_t>(pointer->storage_class())}},
               {SPV_OPERAND_TYPE_ID, {subtype}}}));
       break;
     }
@@ -205,11 +208,11 @@ uint32_t TypeManager::GetTypeInstruction(const Type* type) {
       break;
     }
     case Type::kPipe:
-      typeInst.reset(
-          new ir::Instruction(context(), SpvOpTypePipe, 0, id,
-                              std::initializer_list<ir::Operand>{
-                                  {SPV_OPERAND_TYPE_ACCESS_QUALIFIER,
-                                   {type->AsPipe()->access_qualifier()}}}));
+      typeInst.reset(new ir::Instruction(
+          context(), SpvOpTypePipe, 0, id,
+          std::initializer_list<ir::Operand>{
+              {SPV_OPERAND_TYPE_ACCESS_QUALIFIER,
+               {static_cast<uint32_t>(type->AsPipe()->access_qualifier())}}}));
       break;
     case Type::kForwardPointer:
       typeInst.reset(new ir::Instruction(
@@ -217,7 +220,8 @@ uint32_t TypeManager::GetTypeInstruction(const Type* type) {
           std::initializer_list<ir::Operand>{
               {SPV_OPERAND_TYPE_ID, {type->AsForwardPointer()->target_id()}},
               {SPV_OPERAND_TYPE_STORAGE_CLASS,
-               {type->AsForwardPointer()->storage_class()}}}));
+               {static_cast<uint32_t>(
+                   type->AsForwardPointer()->storage_class())}}}));
       break;
     default:
       assert(false && "Unexpected type");

--- a/source/opt/type_manager.cpp
+++ b/source/opt/type_manager.cpp
@@ -187,6 +187,7 @@ void TypeManager::AttachIfTypeDecoration(const ir::Instruction& inst) {
   if (!id_to_type_.count(id)) return;
 
   Type* target_type = id_to_type_[id].get();
+  assert(!target_type->IsUniqueType());
   switch (opcode) {
     case SpvOpDecorate: {
       const auto count = inst.NumOperands();

--- a/source/opt/type_manager.h
+++ b/source/opt/type_manager.h
@@ -93,7 +93,10 @@ class TypeManager {
   // necessary to fully define |type|.
   uint32_t GetTypeInstruction(const Type* type);
 
-  // Registers |type| to |id|.
+  // Registers |id| to |type|.
+  //
+  // If GetId(|type|) already returns a non-zero id, the return value will be
+  // unchanged.
   void RegisterType(uint32_t id, const Type& type);
 
  private:

--- a/source/opt/type_manager.h
+++ b/source/opt/type_manager.h
@@ -62,8 +62,7 @@ class TypeManager {
   // will be communicated to the outside via the given message |consumer|.
   // This instance only keeps a reference to the |consumer|, so the |consumer|
   // should outlive this instance.
-  TypeManager(const MessageConsumer& consumer,
-              spvtools::ir::IRContext* context);
+  TypeManager(const MessageConsumer& consumer, spvtools::ir::IRContext* c);
 
   TypeManager(const TypeManager&) = delete;
   TypeManager(TypeManager&&) = delete;

--- a/source/opt/type_manager.h
+++ b/source/opt/type_manager.h
@@ -99,6 +99,11 @@ class TypeManager {
   // unchanged.
   void RegisterType(uint32_t id, const Type& type);
 
+  // Removes knowledge of |id| from the manager.
+  //
+  // If |id| is an ambiguous type, GetId for |id|'s type may return a new id.
+  void RemoveId(uint32_t id);
+
  private:
   using TypeToIdMap = std::unordered_map<const Type*, uint32_t, HashTypePointer,
                                          CompareTypePointers>;

--- a/source/opt/type_manager.h
+++ b/source/opt/type_manager.h
@@ -86,6 +86,12 @@ class TypeManager {
   // Returns the number of forward pointer types hold in this manager.
   size_t NumForwardPointers() const { return forward_pointers_.size(); }
 
+  // Returns a pair of the type and pointer to the type in |sc|.
+  //
+  // |id| must be a registered type.
+  std::pair<Type*, std::unique_ptr<Pointer>> GetTypeAndPointerType(
+      uint32_t id, SpvStorageClass sc) const;
+
   // Returns an id for a declaration representing |type|.
   //
   // If |type| is registered, then the registered id is returned. Otherwise,

--- a/source/opt/type_manager.h
+++ b/source/opt/type_manager.h
@@ -101,7 +101,10 @@ class TypeManager {
 
   // Removes knowledge of |id| from the manager.
   //
-  // If |id| is an ambiguous type, GetId for |id|'s type may return a new id.
+  // If |id| is an ambiguous type the multiple ids may be registered to |id|'s
+  // type (e.g. %struct1 and %struct1 might hash to the same type). In that
+  // case, calling GetId() with |id|'s type will return another suitable id
+  // defining that type.
   void RemoveId(uint32_t id);
 
  private:

--- a/source/opt/type_manager.h
+++ b/source/opt/type_manager.h
@@ -28,6 +28,28 @@ namespace spvtools {
 namespace opt {
 namespace analysis {
 
+// Hashing functor.
+//
+// All type pointers must be non-null.
+struct HashTypePointer {
+  size_t operator()(const Type* type) const {
+    assert(type);
+    return type->HashValue();
+  }
+};
+
+// Equality functor.
+//
+// Checks if two types pointers are the same type.
+//
+// All type pointers must be non-null.
+struct CompareTypePointers {
+  bool operator()(const Type* lhs, const Type* rhs) const {
+    assert(lhs && rhs);
+    return lhs->IsSame(rhs);
+  }
+};
+
 // A class for managing the SPIR-V type hierarchy.
 class TypeManager {
  public:
@@ -69,7 +91,8 @@ class TypeManager {
   void AnalyzeTypes(const spvtools::ir::Module& module);
 
  private:
-  using TypeToIdMap = std::unordered_map<const Type*, uint32_t>;
+  using TypeToIdMap = std::unordered_map<const Type*, uint32_t, HashTypePointer,
+                                         CompareTypePointers>;
   using ForwardPointerVector = std::vector<std::unique_ptr<ForwardPointer>>;
 
   // Creates and returns a type from the given SPIR-V |inst|. Returns nullptr if

--- a/source/opt/types.cpp
+++ b/source/opt/types.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
 #include <sstream>
 
 #include "types.h"
@@ -77,7 +78,98 @@ bool Type::HasSameDecorations(const Type* that) const {
   return CompareTwoVectors(decorations_, that->decorations_);
 }
 
-bool Integer::IsSame(Type* that) const {
+bool Type::operator==(const Type& other) const {
+  if (kind_ != other.kind_) return false;
+
+  switch (kind_) {
+#define DeclareKindCase(kind) \
+  case k##kind:               \
+    return As##kind()->IsSame(&other);
+    DeclareKindCase(Void);
+    DeclareKindCase(Bool);
+    DeclareKindCase(Integer);
+    DeclareKindCase(Float);
+    DeclareKindCase(Vector);
+    DeclareKindCase(Matrix);
+    DeclareKindCase(Image);
+    DeclareKindCase(Sampler);
+    DeclareKindCase(SampledImage);
+    DeclareKindCase(Array);
+    DeclareKindCase(RuntimeArray);
+    DeclareKindCase(Struct);
+    DeclareKindCase(Opaque);
+    DeclareKindCase(Pointer);
+    DeclareKindCase(Function);
+    DeclareKindCase(Event);
+    DeclareKindCase(DeviceEvent);
+    DeclareKindCase(ReserveId);
+    DeclareKindCase(Queue);
+    DeclareKindCase(Pipe);
+    DeclareKindCase(ForwardPointer);
+    DeclareKindCase(PipeStorage);
+    DeclareKindCase(NamedBarrier);
+#undef DeclareKindCase
+    default:
+      assert(false && "Unhandled type");
+      return false;
+  }
+}
+
+void Type::GetHashWords(std::vector<uint32_t>* words) const {
+  words->push_back(kind_);
+  for (auto d : decorations_) {
+    for (auto w : d) {
+      words->push_back(w);
+    }
+  }
+
+  switch (kind_) {
+#define DeclareKindCase(type)             \
+  case k##type:                           \
+    As##type()->GetExtraHashWords(words); \
+    break;
+    DeclareKindCase(Void);
+    DeclareKindCase(Bool);
+    DeclareKindCase(Integer);
+    DeclareKindCase(Float);
+    DeclareKindCase(Vector);
+    DeclareKindCase(Matrix);
+    DeclareKindCase(Image);
+    DeclareKindCase(Sampler);
+    DeclareKindCase(SampledImage);
+    DeclareKindCase(Array);
+    DeclareKindCase(RuntimeArray);
+    DeclareKindCase(Struct);
+    DeclareKindCase(Opaque);
+    DeclareKindCase(Pointer);
+    DeclareKindCase(Function);
+    DeclareKindCase(Event);
+    DeclareKindCase(DeviceEvent);
+    DeclareKindCase(ReserveId);
+    DeclareKindCase(Queue);
+    DeclareKindCase(Pipe);
+    DeclareKindCase(ForwardPointer);
+    DeclareKindCase(PipeStorage);
+    DeclareKindCase(NamedBarrier);
+#undef DeclareKindCase
+    default:
+      assert(false && "Unhandled type");
+      break;
+  }
+}
+
+size_t Type::HashValue() const {
+  std::u32string h;
+  std::vector<uint32_t> words;
+  GetHashWords(&words);
+  for (auto w : words) {
+    h.push_back(w);
+  }
+
+  return std::hash<std::u32string>()(h);
+}
+
+bool Integer::IsSame(const Type* that) const {
   const Integer* it = that->AsInteger();
   return it && width_ == it->width_ && signed_ == it->signed_ &&
          HasSameDecorations(that);
@@ -89,7 +181,12 @@ std::string Integer::str() const {
   return oss.str();
 }
 
-bool Float::IsSame(Type* that) const {
+void Integer::GetExtraHashWords(std::vector<uint32_t>* words) const {
+  words->push_back(width_);
+  words->push_back(signed_);
+}
+
+bool Float::IsSame(const Type* that) const {
   const Float* ft = that->AsFloat();
   return ft && width_ == ft->width_ && HasSameDecorations(that);
 }
@@ -100,12 +197,16 @@ std::string Float::str() const {
   return oss.str();
 }
 
+void Float::GetExtraHashWords(std::vector<uint32_t>* words) const {
+  words->push_back(width_);
+}
+
 Vector::Vector(Type* type, uint32_t count)
-    : element_type_(type), count_(count) {
+    : Type(kVector), element_type_(type), count_(count) {
   assert(type->AsBool() || type->AsInteger() || type->AsFloat());
 }
 
-bool Vector::IsSame(Type* that) const {
+bool Vector::IsSame(const Type* that) const {
   const Vector* vt = that->AsVector();
   if (!vt) return false;
   return count_ == vt->count_ && element_type_->IsSame(vt->element_type_) &&
@@ -118,12 +219,17 @@ std::string Vector::str() const {
   return oss.str();
 }
 
+void Vector::GetExtraHashWords(std::vector<uint32_t>* words) const {
+  element_type_->GetHashWords(words);
+  words->push_back(count_);
+}
+
 Matrix::Matrix(Type* type, uint32_t count)
-    : element_type_(type), count_(count) {
+    : Type(kMatrix), element_type_(type), count_(count) {
   assert(type->AsVector());
 }
 
-bool Matrix::IsSame(Type* that) const {
+bool Matrix::IsSame(const Type* that) const {
   const Matrix* mt = that->AsMatrix();
   if (!mt) return false;
   return count_ == mt->count_ && element_type_->IsSame(mt->element_type_) &&
@@ -136,10 +242,16 @@ std::string Matrix::str() const {
   return oss.str();
 }
 
+void Matrix::GetExtraHashWords(std::vector<uint32_t>* words) const {
+  element_type_->GetHashWords(words);
+  words->push_back(count_);
+}
+
 Image::Image(Type* sampled_type, SpvDim dim, uint32_t depth, uint32_t arrayed,
              uint32_t ms, uint32_t sampled, SpvImageFormat format,
              SpvAccessQualifier access_qualifier)
-    : sampled_type_(sampled_type),
+    : Type(kImage),
+      sampled_type_(sampled_type),
       dim_(dim),
       depth_(depth),
       arrayed_(arrayed),
@@ -150,7 +262,7 @@ Image::Image(Type* sampled_type, SpvDim dim, uint32_t depth, uint32_t arrayed,
   // TODO(antiagainst): check sampled_type
 }
 
-bool Image::IsSame(Type* that) const {
+bool Image::IsSame(const Type* that) const {
   const Image* it = that->AsImage();
   if (!it) return false;
   return dim_ == it->dim_ && depth_ == it->depth_ && arrayed_ == it->arrayed_ &&
@@ -167,7 +279,18 @@ std::string Image::str() const {
   return oss.str();
 }
 
-bool SampledImage::IsSame(Type* that) const {
+void Image::GetExtraHashWords(std::vector<uint32_t>* words) const {
+  sampled_type_->GetHashWords(words);
+  words->push_back(dim_);
+  words->push_back(depth_);
+  words->push_back(arrayed_);
+  words->push_back(ms_);
+  words->push_back(sampled_);
+  words->push_back(format_);
+  words->push_back(access_qualifier_);
+}
+
+bool SampledImage::IsSame(const Type* that) const {
   const SampledImage* sit = that->AsSampledImage();
   if (!sit) return false;
   return image_type_->IsSame(sit->image_type_) && HasSameDecorations(that);
@@ -179,12 +302,16 @@ std::string SampledImage::str() const {
   return oss.str();
 }
 
+void SampledImage::GetExtraHashWords(std::vector<uint32_t>* words) const {
+  image_type_->GetHashWords(words);
+}
+
 Array::Array(Type* type, uint32_t length_id)
-    : element_type_(type), length_id_(length_id) {
+    : Type(kArray), element_type_(type), length_id_(length_id) {
   assert(!type->AsVoid());
 }
 
-bool Array::IsSame(Type* that) const {
+bool Array::IsSame(const Type* that) const {
   const Array* at = that->AsArray();
   if (!at) return false;
   return length_id_ == at->length_id_ &&
@@ -197,11 +324,17 @@ std::string Array::str() const {
   return oss.str();
 }
 
-RuntimeArray::RuntimeArray(Type* type) : element_type_(type) {
+void Array::GetExtraHashWords(std::vector<uint32_t>* words) const {
+  element_type_->GetHashWords(words);
+  words->push_back(length_id_);
+}
+
+RuntimeArray::RuntimeArray(Type* type)
+    : Type(kRuntimeArray), element_type_(type) {
   assert(!type->AsVoid());
 }
 
-bool RuntimeArray::IsSame(Type* that) const {
+bool RuntimeArray::IsSame(const Type* that) const {
   const RuntimeArray* rat = that->AsRuntimeArray();
   if (!rat) return false;
   return element_type_->IsSame(rat->element_type_) && HasSameDecorations(that);
@@ -213,7 +346,12 @@ std::string RuntimeArray::str() const {
   return oss.str();
 }
 
-Struct::Struct(const std::vector<Type*>& types) : element_types_(types) {
+void RuntimeArray::GetExtraHashWords(std::vector<uint32_t>* words) const {
+  element_type_->GetHashWords(words);
+}
+
+Struct::Struct(const std::vector<Type*>& types)
+    : Type(kStruct), element_types_(types) {
   for (auto* t : types) {
     (void)t;
     assert(!t->AsVoid());
@@ -230,7 +368,7 @@ void Struct::AddMemberDecoration(uint32_t index,
   element_decorations_[index].push_back(std::move(decoration));
 }
 
-bool Struct::IsSame(Type* that) const {
+bool Struct::IsSame(const Type* that) const {
   const Struct* st = that->AsStruct();
   if (!st) return false;
   if (element_types_.size() != st->element_types_.size()) return false;
@@ -261,7 +399,21 @@ std::string Struct::str() const {
   return oss.str();
 }
 
-bool Opaque::IsSame(Type* that) const {
+void Struct::GetExtraHashWords(std::vector<uint32_t>* words) const {
+  for (auto t : element_types_) {
+    t->GetHashWords(words);
+  }
+  for (auto pair : element_decorations_) {
+    words->push_back(pair.first);
+    for (auto d : pair.second) {
+      for (auto w : d) {
+        words->push_back(w);
+      }
+    }
+  }
+}
+
+bool Opaque::IsSame(const Type* that) const {
   const Opaque* ot = that->AsOpaque();
   if (!ot) return false;
   return name_ == ot->name_ && HasSameDecorations(that);
@@ -273,12 +425,18 @@ std::string Opaque::str() const {
   return oss.str();
 }
 
+void Opaque::GetExtraHashWords(std::vector<uint32_t>* words) const {
+  for (auto c : name_) {
+    words->push_back(static_cast<char32_t>(c));
+  }
+}
+
 Pointer::Pointer(Type* type, SpvStorageClass storage_class)
-    : pointee_type_(type), storage_class_(storage_class) {
+    : Type(kPointer), pointee_type_(type), storage_class_(storage_class) {
   assert(!type->AsVoid());
 }
 
-bool Pointer::IsSame(Type* that) const {
+bool Pointer::IsSame(const Type* that) const {
   const Pointer* pt = that->AsPointer();
   if (!pt) return false;
   if (storage_class_ != pt->storage_class_) return false;
@@ -288,15 +446,20 @@ bool Pointer::IsSame(Type* that) const {
 
 std::string Pointer::str() const { return pointee_type_->str() + "*"; }
 
+void Pointer::GetExtraHashWords(std::vector<uint32_t>* words) const {
+  pointee_type_->GetHashWords(words);
+  words->push_back(storage_class_);
+}
+
 Function::Function(Type* return_type, const std::vector<Type*>& param_types)
-    : return_type_(return_type), param_types_(param_types) {
+    : Type(kFunction), return_type_(return_type), param_types_(param_types) {
   for (auto* t : param_types) {
     (void)t;
     assert(!t->AsVoid());
   }
 }
 
-bool Function::IsSame(Type* that) const {
+bool Function::IsSame(const Type* that) const {
   const Function* ft = that->AsFunction();
   if (!ft) return false;
   if (!return_type_->IsSame(ft->return_type_)) return false;
@@ -319,7 +482,14 @@ std::string Function::str() const {
   return oss.str();
 }
 
-bool Pipe::IsSame(Type* that) const {
+void Function::GetExtraHashWords(std::vector<uint32_t>* words) const {
+  return_type_->GetHashWords(words);
+  for (auto t : param_types_) {
+    t->GetHashWords(words);
+  }
+}
+
+bool Pipe::IsSame(const Type* that) const {
   const Pipe* pt = that->AsPipe();
   if (!pt) return false;
   return access_qualifier_ == pt->access_qualifier_ && HasSameDecorations(that);
@@ -331,7 +501,11 @@ std::string Pipe::str() const {
   return oss.str();
 }
 
-bool ForwardPointer::IsSame(Type* that) const {
+void Pipe::GetExtraHashWords(std::vector<uint32_t>* words) const {
+  words->push_back(access_qualifier_);
+}
+
+bool ForwardPointer::IsSame(const Type* that) const {
   const ForwardPointer* fpt = that->AsForwardPointer();
   if (!fpt) return false;
   return target_id_ == fpt->target_id_ &&
@@ -348,6 +522,12 @@ std::string ForwardPointer::str() const {
   }
   oss << ")";
   return oss.str();
+}
+
+void ForwardPointer::GetExtraHashWords(std::vector<uint32_t>* words) const {
+  words->push_back(target_id_);
+  words->push_back(storage_class_);
+  pointer_->GetHashWords(words);
 }
 
 }  // namespace analysis

--- a/source/opt/types.cpp
+++ b/source/opt/types.cpp
@@ -91,7 +91,7 @@ bool Type::IsUniqueType(bool allowVariablePointers) const {
   }
 }
 
-std::unique_ptr<Type> Type::RemoveDecorations() const {
+std::unique_ptr<Type> Type::Clone() const {
   std::unique_ptr<Type> type;
   switch (kind_) {
 #define DeclareKindCase(kind)                \
@@ -125,6 +125,11 @@ std::unique_ptr<Type> Type::RemoveDecorations() const {
     default:
       assert(false && "Unhandled type");
   }
+  return type;
+}
+
+std::unique_ptr<Type> Type::RemoveDecorations() const {
+  std::unique_ptr<Type> type(Clone());
   type->ClearDecorations();
   return type;
 }

--- a/source/opt/types.cpp
+++ b/source/opt/types.cpp
@@ -303,18 +303,18 @@ void Matrix::GetExtraHashWords(std::vector<uint32_t>* words) const {
   words->push_back(count_);
 }
 
-Image::Image(Type* sampled_type, SpvDim dim, uint32_t depth, uint32_t arrayed,
-             uint32_t ms, uint32_t sampled, SpvImageFormat format,
-             SpvAccessQualifier access_qualifier)
+Image::Image(Type* type, SpvDim dimen, uint32_t d, uint32_t array,
+             uint32_t multisample, uint32_t sampling, SpvImageFormat f,
+             SpvAccessQualifier qualifier)
     : Type(kImage),
-      sampled_type_(sampled_type),
-      dim_(dim),
-      depth_(depth),
-      arrayed_(arrayed),
-      ms_(ms),
-      sampled_(sampled),
-      format_(format),
-      access_qualifier_(access_qualifier) {
+      sampled_type_(type),
+      dim_(dimen),
+      depth_(d),
+      arrayed_(array),
+      ms_(multisample),
+      sampled_(sampling),
+      format_(f),
+      access_qualifier_(qualifier) {
   // TODO(antiagainst): check sampled_type
 }
 
@@ -487,8 +487,8 @@ void Opaque::GetExtraHashWords(std::vector<uint32_t>* words) const {
   }
 }
 
-Pointer::Pointer(Type* type, SpvStorageClass storage_class)
-    : Type(kPointer), pointee_type_(type), storage_class_(storage_class) {
+Pointer::Pointer(Type* type, SpvStorageClass sc)
+    : Type(kPointer), pointee_type_(type), storage_class_(sc) {
   assert(!type->AsVoid());
 }
 
@@ -507,9 +507,9 @@ void Pointer::GetExtraHashWords(std::vector<uint32_t>* words) const {
   words->push_back(storage_class_);
 }
 
-Function::Function(Type* return_type, const std::vector<Type*>& param_types)
-    : Type(kFunction), return_type_(return_type), param_types_(param_types) {
-  for (auto* t : param_types) {
+Function::Function(Type* ret_type, const std::vector<Type*>& params)
+    : Type(kFunction), return_type_(ret_type), param_types_(params) {
+  for (auto* t : params) {
     (void)t;
     assert(!t->AsVoid());
   }

--- a/source/opt/types.cpp
+++ b/source/opt/types.cpp
@@ -303,9 +303,8 @@ void Matrix::GetExtraHashWords(std::vector<uint32_t>* words) const {
   words->push_back(count_);
 }
 
-Image::Image(Type* type, SpvDim dimen, uint32_t d, uint32_t array,
-             uint32_t multisample, uint32_t sampling, SpvImageFormat f,
-             SpvAccessQualifier qualifier)
+Image::Image(Type* type, SpvDim dimen, uint32_t d, bool array, bool multisample,
+             uint32_t sampling, SpvImageFormat f, SpvAccessQualifier qualifier)
     : Type(kImage),
       sampled_type_(type),
       dim_(dimen),

--- a/source/opt/types.cpp
+++ b/source/opt/types.cpp
@@ -126,7 +126,7 @@ std::unique_ptr<Type> Type::RemoveDecorations() const {
       assert(false && "Unhandled type");
   }
   type->ClearDecorations();
-  return std::move(type);
+  return type;
 }
 
 bool Type::operator==(const Type& other) const {

--- a/source/opt/types.cpp
+++ b/source/opt/types.cpp
@@ -583,7 +583,7 @@ std::string ForwardPointer::str() const {
 void ForwardPointer::GetExtraHashWords(std::vector<uint32_t>* words) const {
   words->push_back(target_id_);
   words->push_back(storage_class_);
-  pointer_->GetHashWords(words);
+  if (pointer_) pointer_->GetHashWords(words);
 }
 
 }  // namespace analysis

--- a/source/opt/types.h
+++ b/source/opt/types.h
@@ -86,7 +86,7 @@ class Type {
     kNamedBarrier,
   };
 
-  Type(Kind kind) : kind_(kind) {}
+  Type(Kind k) : kind_(k) {}
 
   virtual ~Type() {}
 
@@ -264,9 +264,9 @@ class Matrix : public Type {
 
 class Image : public Type {
  public:
-  Image(Type* sampled_type, SpvDim dim, uint32_t depth, uint32_t arrayed,
-        uint32_t ms, uint32_t sampled, SpvImageFormat format,
-        SpvAccessQualifier access_qualifier = SpvAccessQualifierReadOnly);
+  Image(Type* type, SpvDim dimen, uint32_t d, uint32_t array,
+        uint32_t multisample, uint32_t sampling, SpvImageFormat f,
+        SpvAccessQualifier qualifier = SpvAccessQualifierReadOnly);
   Image(const Image&) = default;
 
   bool IsSame(const Type* that) const override;
@@ -299,8 +299,7 @@ class Image : public Type {
 
 class SampledImage : public Type {
  public:
-  SampledImage(Type* image_type)
-      : Type(kSampledImage), image_type_(image_type) {}
+  SampledImage(Type* image) : Type(kSampledImage), image_type_(image) {}
   SampledImage(const SampledImage&) = default;
 
   bool IsSame(const Type* that) const override;
@@ -396,7 +395,7 @@ class Struct : public Type {
 
 class Opaque : public Type {
  public:
-  Opaque(std::string name) : Type(kOpaque), name_(std::move(name)) {}
+  Opaque(std::string n) : Type(kOpaque), name_(std::move(n)) {}
   Opaque(const Opaque&) = default;
 
   bool IsSame(const Type* that) const override;
@@ -415,7 +414,7 @@ class Opaque : public Type {
 
 class Pointer : public Type {
  public:
-  Pointer(Type* pointee_type, SpvStorageClass storage_class);
+  Pointer(Type* pointee, SpvStorageClass sc);
   Pointer(const Pointer&) = default;
 
   bool IsSame(const Type* that) const override;
@@ -435,7 +434,7 @@ class Pointer : public Type {
 
 class Function : public Type {
  public:
-  Function(Type* return_type, const std::vector<Type*>& param_types);
+  Function(Type* ret_type, const std::vector<Type*>& params);
   Function(const Function&) = default;
 
   bool IsSame(const Type* that) const override;
@@ -456,8 +455,8 @@ class Function : public Type {
 
 class Pipe : public Type {
  public:
-  Pipe(SpvAccessQualifier access_qualifier)
-      : Type(kPipe), access_qualifier_(access_qualifier) {}
+  Pipe(SpvAccessQualifier qualifier)
+      : Type(kPipe), access_qualifier_(qualifier) {}
   Pipe(const Pipe&) = default;
 
   bool IsSame(const Type* that) const override;
@@ -476,10 +475,10 @@ class Pipe : public Type {
 
 class ForwardPointer : public Type {
  public:
-  ForwardPointer(uint32_t id, SpvStorageClass storage_class)
+  ForwardPointer(uint32_t id, SpvStorageClass sc)
       : Type(kForwardPointer),
         target_id_(id),
-        storage_class_(storage_class),
+        storage_class_(sc),
         pointer_(nullptr) {}
   ForwardPointer(const ForwardPointer&) = default;
 

--- a/source/opt/types.h
+++ b/source/opt/types.h
@@ -104,10 +104,18 @@ class Type {
   // Returns a human-readable string to represent this type.
   virtual std::string str() const = 0;
 
+  Kind kind() const { return kind_; }
+  const std::vector<std::vector<uint32_t>>& decorations() const {
+    return decorations_;
+  }
+
   // Returns true if there is no decoration on this type. For struct types,
   // returns true only when there is no decoration for both the struct type
   // and the struct members.
   virtual bool decoration_empty() const { return decorations_.empty(); }
+
+  // Creates a clone of |this|.
+  std::unique_ptr<Type> Clone() const;
 
   // Returns a clone of |this| minus any decorations.
   std::unique_ptr<Type> RemoveDecorations() const;
@@ -267,6 +275,15 @@ class Image : public Type {
   Image* AsImage() override { return this; }
   const Image* AsImage() const override { return this; }
 
+  const Type* sampled_type() const { return sampled_type_; }
+  SpvDim dim() const { return dim_; }
+  uint32_t depth() const { return depth_; }
+  uint32_t arrayed() const { return arrayed_; }
+  uint32_t ms() const { return ms_; }
+  uint32_t sampled() const { return sampled_; }
+  SpvImageFormat format() const { return format_; }
+  SpvAccessQualifier access_qualifier() const { return access_qualifier_; }
+
   void GetExtraHashWords(std::vector<uint32_t>* words) const override;
 
  private:
@@ -291,6 +308,8 @@ class SampledImage : public Type {
 
   SampledImage* AsSampledImage() override { return this; }
   const SampledImage* AsSampledImage() const override { return this; }
+
+  const Type* image_type() const { return image_type_; }
 
   void GetExtraHashWords(std::vector<uint32_t>* words) const override;
 
@@ -351,6 +370,10 @@ class Struct : public Type {
   bool decoration_empty() const override {
     return decorations_.empty() && element_decorations_.empty();
   }
+  const std::unordered_map<uint32_t, std::vector<std::vector<uint32_t>>>&
+  element_decorations() const {
+    return element_decorations_;
+  }
 
   Struct* AsStruct() override { return this; }
   const Struct* AsStruct() const override { return this; }
@@ -382,6 +405,8 @@ class Opaque : public Type {
   Opaque* AsOpaque() override { return this; }
   const Opaque* AsOpaque() const override { return this; }
 
+  const std::string& name() const { return name_; }
+
   void GetExtraHashWords(std::vector<uint32_t>* words) const override;
 
  private:
@@ -396,6 +421,7 @@ class Pointer : public Type {
   bool IsSame(const Type* that) const override;
   std::string str() const override;
   const Type* pointee_type() const { return pointee_type_; }
+  SpvStorageClass storage_class() const { return storage_class_; }
 
   Pointer* AsPointer() override { return this; }
   const Pointer* AsPointer() const override { return this; }
@@ -418,6 +444,9 @@ class Function : public Type {
   Function* AsFunction() override { return this; }
   const Function* AsFunction() const override { return this; }
 
+  const Type* return_type() const { return return_type_; }
+  const std::vector<Type*>& param_types() const { return param_types_; }
+
   void GetExtraHashWords(std::vector<uint32_t>* words) const override;
 
  private:
@@ -437,6 +466,8 @@ class Pipe : public Type {
   Pipe* AsPipe() override { return this; }
   const Pipe* AsPipe() const override { return this; }
 
+  SpvAccessQualifier access_qualifier() const { return access_qualifier_; }
+
   void GetExtraHashWords(std::vector<uint32_t>* words) const override;
 
  private:
@@ -454,6 +485,7 @@ class ForwardPointer : public Type {
 
   uint32_t target_id() const { return target_id_; }
   void SetTargetPointer(Pointer* pointer) { pointer_ = pointer; }
+  SpvStorageClass storage_class() const { return storage_class_; }
 
   bool IsSame(const Type* that) const override;
   std::string str() const override;

--- a/source/opt/types.h
+++ b/source/opt/types.h
@@ -358,7 +358,7 @@ class Struct : public Type {
   void GetExtraHashWords(std::vector<uint32_t>* words) const override;
 
  private:
-  void ClearDecorations() {
+  void ClearDecorations() override {
     decorations_.clear();
     element_decorations_.clear();
   }

--- a/source/opt/types.h
+++ b/source/opt/types.h
@@ -264,8 +264,8 @@ class Matrix : public Type {
 
 class Image : public Type {
  public:
-  Image(Type* type, SpvDim dimen, uint32_t d, uint32_t array,
-        uint32_t multisample, uint32_t sampling, SpvImageFormat f,
+  Image(Type* type, SpvDim dimen, uint32_t d, bool array, bool multisample,
+        uint32_t sampling, SpvImageFormat f,
         SpvAccessQualifier qualifier = SpvAccessQualifierReadOnly);
   Image(const Image&) = default;
 
@@ -278,8 +278,8 @@ class Image : public Type {
   const Type* sampled_type() const { return sampled_type_; }
   SpvDim dim() const { return dim_; }
   uint32_t depth() const { return depth_; }
-  uint32_t arrayed() const { return arrayed_; }
-  uint32_t ms() const { return ms_; }
+  bool is_arrayed() const { return arrayed_; }
+  bool is_multisampled() const { return ms_; }
   uint32_t sampled() const { return sampled_; }
   SpvImageFormat format() const { return format_; }
   SpvAccessQualifier access_qualifier() const { return access_qualifier_; }
@@ -290,8 +290,8 @@ class Image : public Type {
   Type* sampled_type_;
   SpvDim dim_;
   uint32_t depth_;
-  uint32_t arrayed_;
-  uint32_t ms_;
+  bool arrayed_;
+  bool ms_;
   uint32_t sampled_;
   SpvImageFormat format_;
   SpvAccessQualifier access_qualifier_;

--- a/test/opt/type_manager_test.cpp
+++ b/test/opt/type_manager_test.cpp
@@ -288,17 +288,17 @@ TEST(TypeManager, LookupType) {
   opt::analysis::TypeManager manager(nullptr, *context->module());
 
   opt::analysis::Void voidTy;
-  EXPECT_EQ(manager.GetId(&voidTy), 1);
+  EXPECT_EQ(manager.GetId(&voidTy), 1u);
 
   opt::analysis::Integer uintTy(32, false);
-  EXPECT_EQ(manager.GetId(&uintTy), 2);
+  EXPECT_EQ(manager.GetId(&uintTy), 2u);
 
   opt::analysis::Integer intTy(32, true);
-  EXPECT_EQ(manager.GetId(&intTy), 3);
+  EXPECT_EQ(manager.GetId(&intTy), 3u);
 
   opt::analysis::Integer intTy2(32, true);
-  opt::analysis::Vector vecTy(&intTy2, 2);
-  EXPECT_EQ(manager.GetId(&vecTy), 4);
+  opt::analysis::Vector vecTy(&intTy2, 2u);
+  EXPECT_EQ(manager.GetId(&vecTy), 4u);
 }
 
 }  // anonymous namespace

--- a/test/opt/type_manager_test.cpp
+++ b/test/opt/type_manager_test.cpp
@@ -595,7 +595,7 @@ OpMemoryModel Logical GLSL450
 
   Integer u32(32, false);
   Struct st({&u32, &u32});
-  st.AddDecoration({{10}});
+  st.AddDecoration({10});
   st.AddMemberDecoration(1, {{35, 4}});
   (void)context->get_def_use_mgr();
   context->get_type_mgr()->GetTypeInstruction(&st);

--- a/test/opt/type_manager_test.cpp
+++ b/test/opt/type_manager_test.cpp
@@ -90,7 +90,7 @@ TEST(TypeManager, TypeStrings) {
 
   std::unique_ptr<ir::IRContext> context =
       BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text);
-  opt::analysis::TypeManager manager(nullptr, *context->module());
+  opt::analysis::TypeManager manager(nullptr, context.get());
 
   EXPECT_EQ(type_id_strs.size(), manager.NumTypes());
   EXPECT_EQ(2u, manager.NumForwardPointers());
@@ -120,7 +120,7 @@ TEST(TypeManager, DecorationOnStruct) {
   )";
   std::unique_ptr<ir::IRContext> context =
       BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text);
-  opt::analysis::TypeManager manager(nullptr, *context->module());
+  opt::analysis::TypeManager manager(nullptr, context.get());
 
   ASSERT_EQ(7u, manager.NumTypes());
   ASSERT_EQ(0u, manager.NumForwardPointers());
@@ -170,7 +170,7 @@ TEST(TypeManager, DecorationOnMember) {
   )";
   std::unique_ptr<ir::IRContext> context =
       BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text);
-  opt::analysis::TypeManager manager(nullptr, *context->module());
+  opt::analysis::TypeManager manager(nullptr, context.get());
 
   ASSERT_EQ(10u, manager.NumTypes());
   ASSERT_EQ(0u, manager.NumForwardPointers());
@@ -208,7 +208,7 @@ TEST(TypeManager, DecorationEmpty) {
   )";
   std::unique_ptr<ir::IRContext> context =
       BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text);
-  opt::analysis::TypeManager manager(nullptr, *context->module());
+  opt::analysis::TypeManager manager(nullptr, context.get());
 
   ASSERT_EQ(5u, manager.NumTypes());
   ASSERT_EQ(0u, manager.NumForwardPointers());
@@ -230,7 +230,7 @@ TEST(TypeManager, BeginEndForEmptyModule) {
   const std::string text = "";
   std::unique_ptr<ir::IRContext> context =
       BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text);
-  opt::analysis::TypeManager manager(nullptr, *context->module());
+  opt::analysis::TypeManager manager(nullptr, context.get());
   ASSERT_EQ(0u, manager.NumTypes());
   ASSERT_EQ(0u, manager.NumForwardPointers());
 
@@ -247,7 +247,7 @@ TEST(TypeManager, BeginEnd) {
   )";
   std::unique_ptr<ir::IRContext> context =
       BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text);
-  opt::analysis::TypeManager manager(nullptr, *context->module());
+  opt::analysis::TypeManager manager(nullptr, context.get());
   ASSERT_EQ(5u, manager.NumTypes());
   ASSERT_EQ(0u, manager.NumForwardPointers());
 
@@ -285,7 +285,7 @@ TEST(TypeManager, LookupType) {
   std::unique_ptr<ir::IRContext> context =
       BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text);
   EXPECT_NE(context, nullptr);
-  opt::analysis::TypeManager manager(nullptr, *context->module());
+  opt::analysis::TypeManager manager(nullptr, context.get());
 
   opt::analysis::Void voidTy;
   EXPECT_EQ(manager.GetId(&voidTy), 1u);

--- a/test/opt/type_manager_test.cpp
+++ b/test/opt/type_manager_test.cpp
@@ -274,4 +274,31 @@ TEST(TypeManager, BeginEnd) {
   }
 }
 
+TEST(TypeManager, LookupType) {
+  const std::string text = R"(
+%void = OpTypeVoid
+%uint = OpTypeInt 32 0
+%int  = OpTypeInt 32 1
+%vec2 = OpTypeVector %int 2
+)";
+
+  std::unique_ptr<ir::IRContext> context =
+      BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text);
+  EXPECT_NE(context, nullptr);
+  opt::analysis::TypeManager manager(nullptr, *context->module());
+
+  opt::analysis::Void voidTy;
+  EXPECT_EQ(manager.GetId(&voidTy), 1);
+
+  opt::analysis::Integer uintTy(32, false);
+  EXPECT_EQ(manager.GetId(&uintTy), 2);
+
+  opt::analysis::Integer intTy(32, true);
+  EXPECT_EQ(manager.GetId(&intTy), 3);
+
+  opt::analysis::Integer intTy2(32, true);
+  opt::analysis::Vector vecTy(&intTy2, 2);
+  EXPECT_EQ(manager.GetId(&vecTy), 4);
+}
+
 }  // anonymous namespace

--- a/test/opt/types_test.cpp
+++ b/test/opt/types_test.cpp
@@ -89,7 +89,7 @@ TestMultipleInstancesOfTheSameType(PipeStorage);
 TestMultipleInstancesOfTheSameType(NamedBarrier);
 #undef TestMultipleInstanceOfTheSameType
 
-TEST(Types, AllTypes) {
+std::vector<std::unique_ptr<Type>> GenerateAllTypes() {
   // Types in this test case are only equal to themselves, nothing else.
   std::vector<std::unique_ptr<Type>> types;
 
@@ -196,6 +196,13 @@ TEST(Types, AllTypes) {
   types.emplace_back(new PipeStorage());
   types.emplace_back(new NamedBarrier());
 
+  return types;
+}
+
+TEST(Types, AllTypes) {
+  // Types in this test case are only equal to themselves, nothing else.
+  std::vector<std::unique_ptr<Type>> types = GenerateAllTypes();
+
   for (size_t i = 0; i < types.size(); ++i) {
     for (size_t j = 0; j < types.size(); ++j) {
       if (i == j) {
@@ -258,6 +265,73 @@ TEST(Types, MatrixElementCount) {
   for (uint32_t c : {1, 2, 3, 4, 10, 100}) {
     auto s32m = MakeUnique<Matrix>(s32v4.get(), c);
     EXPECT_EQ(c, s32m->element_count());
+  }
+}
+
+TEST(Types, IsUniqueType) {
+  std::vector<std::unique_ptr<Type>> types = GenerateAllTypes();
+
+  for (auto& t : types) {
+    bool expectation = true;
+    // Disallowing variable pointers.
+    switch (t->kind()) {
+      case Type::kArray:
+      case Type::kRuntimeArray:
+      case Type::kStruct:
+        expectation = false;
+        break;
+      default:
+        break;
+    }
+    EXPECT_EQ(t->IsUniqueType(false), expectation)
+        << "expected '" << t->str() << "' to be a "
+        << (expectation ? "" : "non-") << "unique type";
+
+    // Allowing variables pointers.
+    if (t->AsPointer()) expectation = false;
+    EXPECT_EQ(t->IsUniqueType(true), expectation)
+        << "expected '" << t->str() << "' to be a "
+        << (expectation ? "" : "non-") << "unique type";
+  }
+}
+
+std::vector<std::unique_ptr<Type>> GenerateAllTypesWithDecorations() {
+  std::vector<std::unique_ptr<Type>> types = GenerateAllTypes();
+  uint32_t elems = 1;
+  uint32_t decs = 1;
+  for (auto& t : types) {
+    for (uint32_t i = 0; i < (decs % 10); ++i) {
+      std::vector<uint32_t> decoration;
+      for (uint32_t j = 0; j < (elems % 4) + 1; ++j) {
+        decoration.push_back(j);
+      }
+      t->AddDecoration(std::move(decoration));
+      ++elems;
+      ++decs;
+    }
+  }
+
+  return types;
+}
+
+TEST(Types, Clone) {
+  std::vector<std::unique_ptr<Type>> types = GenerateAllTypesWithDecorations();
+  for (auto& t : types) {
+    auto clone = t->Clone();
+    EXPECT_TRUE(*t == *clone);
+    EXPECT_TRUE(t->HasSameDecorations(clone.get()));
+    EXPECT_NE(clone.get(), t.get());
+  }
+}
+
+TEST(Types, RemoveDecorations) {
+  std::vector<std::unique_ptr<Type>> types = GenerateAllTypesWithDecorations();
+  for (auto& t : types) {
+    auto decorationless = t->RemoveDecorations();
+    EXPECT_EQ(*t == *decorationless, t->decoration_empty());
+    EXPECT_EQ(t->HasSameDecorations(decorationless.get()),
+              t->decoration_empty());
+    EXPECT_NE(t.get(), decorationless.get());
   }
 }
 

--- a/test/opt/types_test.cpp
+++ b/test/opt/types_test.cpp
@@ -54,6 +54,9 @@ class SameTypeTest : public ::testing::Test {
         EXPECT_TRUE(types[i]->IsSame(types[j].get()))                     \
             << "expected '" << types[i]->str() << "' is the same as '"    \
             << types[j]->str() << "'";                                    \
+        EXPECT_TRUE(*types[i] == *types[j])                               \
+            << "expected '" << types[i]->str() << "' is the same as '"    \
+            << types[j]->str() << "'";                                    \
       }                                                                   \
     }                                                                     \
   }


### PR DESCRIPTION
Changes for #1071.

Changes TypeManager to hash types instead of type pointers. This allows lookup of arbitrarily created types. Users still must be careful when dealing with ambiguous types (e.g. multiple declarations of the same struct). To that end -O and -Os now run duplicate removal.

In general users should use TypeManager::GetTypeInstruction to get any type they need (with the caveat about ambiguous types). If the requested type already exists, it will be returned otherwise all the necessary instructions to define the input type will be added to the module. If users call AddType, they should also register that instruction with the TypeManager to keep it up-to-date. I have not made the type manager an analysis.

Because of ambiguous types, I've modified the constant manager to be able to provide an optional type override when necessary.