### PR TITLE
Export as package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,25 +226,16 @@ if(SPIRV_BUILD_COMPRESSION)
   set(SPIRV_LIBRARIES "${SPIRV_LIBRARIES} -lSPIRV-Tools-comp")
 endif(SPIRV_BUILD_COMPRESSION)
 
-
 # Build pkg-config file
-
-# First, retrieve the current version from CHANGES
-file(STRINGS CHANGES CHANGES_CONTENT)
-string(
-REGEX
-  MATCH "v[0-9]+(.[0-9]+)?(-dev)? [0-9]+-[0-9]+-[0-9]+"
-  FIRST_VERSION_LINE
-  ${CHANGES_CONTENT})
-string(
-REGEX
-  REPLACE "^v([^ ]+) .+$" "\\1"
-  CURRENT_VERSION
-  "${FIRST_VERSION_LINE}")
-# If this is a development version, replace "-dev" by ".0" as pkg-config nor
-# CMake support "-dev" in the version
-string(REGEX REPLACE "-dev" ".0" CURRENT_VERSION "${CURRENT_VERSION}")
-configure_file("./cmake/SPIRV-Tools.pc.in" "SPIRV-Tools.pc" @ONLY)
+# Use a first-class target so it's regenerated when relevant files are updated.
+add_custom_target(spirv-tools-pkg-config ALL
+        COMMAND cmake -DCHANGES_FILE=${CMAKE_CURRENT_SOURCE_DIR}/CHANGES
+                      -DTEMPLATE_FILE=${CMAKE_CURRENT_SOURCE_DIR}/cmake/SPIRV-Tools.pc.in
+                      -DOUT_FILE=${CMAKE_CURRENT_BINARY_DIR}/SPIRV-Tools.pc
+                      -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+                      -DSPIRV_LIBRARIES=${SPIRV_LIBRARIES}
+                      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/write_pkg_config.cmake
+        DEPENDS "CHANGES" "cmake/SPIRV-Tools.pc.in" "cmake/write_pkg_config.cmake")
 
 # Install pkg-config file
 if (ENABLE_SPIRV_TOOLS_INSTALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,3 +220,37 @@ if (NOT "${SPIRV_SKIP_TESTS}")
            COMMAND ${PYTHON_EXECUTABLE} utils/check_copyright.py
            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
+
+set(SPIRV_LIBRARIES "-lSPIRV-Tools -lSPIRV-Tools-link -lSPIRV-Tools-opt")
+if(SPIRV_BUILD_COMPRESSION)
+  set(SPIRV_LIBRARIES "${SPIRV_LIBRARIES} -lSPIRV-Tools-comp")
+endif(SPIRV_BUILD_COMPRESSION)
+
+
+# Build pkg-config file
+
+# First, retrieve the current version from CHANGES
+file(STRINGS CHANGES CHANGES_CONTENT)
+string(
+REGEX
+  MATCH "v[0-9]+(.[0-9]+)?(-dev)? [0-9]+-[0-9]+-[0-9]+"
+  FIRST_VERSION_LINE
+  ${CHANGES_CONTENT})
+string(
+REGEX
+  REPLACE "^v([^ ]+) .+$" "\\1"
+  CURRENT_VERSION
+  "${FIRST_VERSION_LINE}")
+# If this is a development version, replace "-dev" by ".0" as pkg-config nor
+# CMake support "-dev" in the version
+string(REGEX REPLACE "-dev" ".0" CURRENT_VERSION "${CURRENT_VERSION}")
+configure_file("./cmake/SPIRV-Tools.pc.in" "SPIRV-Tools.pc" @ONLY)
+
+# Install pkg-config file
+if (ENABLE_SPIRV_TOOLS_INSTALL)
+  install(
+    FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/SPIRV-Tools.pc
+    DESTINATION
+      ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+endif()

--- a/cmake/SPIRV-Tools.pc.in
+++ b/cmake/SPIRV-Tools.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/lib64
+includedir=${prefix}/include
+
+Name: SPIRV-Tools
+Description: Tools for SPIR-V
+Version: @CURRENT_VERSION@
+URL: https://github.com/KhronosGroup/SPIRV-Tools
+
+Libs: -L${libdir} @SPIRV_LIBRARIES@
+Cflags: -I${includedir}

--- a/cmake/write_pkg_config.cmake
+++ b/cmake/write_pkg_config.cmake
@@ -1,0 +1,31 @@
+# Copyright (c) 2017 Pierre Moreau
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# First, retrieve the current version from CHANGES
+file(STRINGS ${CHANGES_FILE} CHANGES_CONTENT)
+string(
+REGEX
+  MATCH "v[0-9]+(.[0-9]+)?(-dev)? [0-9]+-[0-9]+-[0-9]+"
+  FIRST_VERSION_LINE
+  ${CHANGES_CONTENT})
+string(
+REGEX
+  REPLACE "^v([^ ]+) .+$" "\\1"
+  CURRENT_VERSION
+  "${FIRST_VERSION_LINE}")
+# If this is a development version, replace "-dev" by ".0" as pkg-config nor
+# CMake support "-dev" in the version.
+# If it's not a "-dev" version then ensure it ends with ".1"
+string(REGEX REPLACE "-dev.1" ".0" CURRENT_VERSION "${CURRENT_VERSION}.1")
+configure_file(${TEMPLATE_FILE} ${OUT_FILE} @ONLY)


### PR DESCRIPTION
Based on #1079, but uses a new spirv-tools-pkg-config target to ensure precise dependencies.