### PR TITLE
Convert private variables to function scope.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -94,6 +94,7 @@ SPVTOOLS_OPT_SRC_FILES := \
 		source/opt/optimizer.cpp \
 		source/opt/pass.cpp \
 		source/opt/pass_manager.cpp \
+		source/opt/private_to_local_pass.cpp \
 		source/opt/propagator.cpp \
 		source/opt/redundancy_elimination.cpp \
 		source/opt/remove_duplicates_pass.cpp \

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -442,6 +442,12 @@ Optimizer::PassToken CreateRedundancyEliminationPass();
 // This pass replaces composite function scope variables with variables for each
 // element if those elements are accessed individually.
 Optimizer::PassToken CreateScalarReplacementPass();
+
+// Create a private to local pass.
+// This pass looks for variables delcared in the private storage class that are
+// used in only one function.  Those variables are moved to the function storage
+// class in the function that they are used.
+Optimizer::PassToken CreatePrivateToLocalPass();
 }  // namespace spvtools
 
 #endif  // SPIRV_TOOLS_OPTIMIZER_HPP_

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(SPIRV-Tools-opt
   passes.h
   pass.h
   pass_manager.h
+  private_to_local_pass.h
   propagator.h
   redundancy_elimination.h
   reflect.h
@@ -110,6 +111,7 @@ add_library(SPIRV-Tools-opt
   optimizer.cpp
   pass.cpp
   pass_manager.cpp
+  private_to_local_pass.cpp
   propagator.cpp
   redundancy_elimination.cpp
   remove_duplicates_pass.cpp

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -43,9 +43,6 @@ class InlinePass : public Pass {
   virtual ~InlinePass() = default;
 
  protected:
-  // Find pointer to type and storage in module, return its resultId,
-  // 0 if not found. TODO(greg-lunarg): Move this into type manager.
-  uint32_t FindPointerToType(uint32_t type_id, SpvStorageClass storage_class);
 
   // Add pointer to type to module and return resultId.
   uint32_t AddPointerToType(uint32_t type_id, SpvStorageClass storage_class);

--- a/source/opt/ir_context.h
+++ b/source/opt/ir_context.h
@@ -301,6 +301,10 @@ class IRContext {
   // actually valid.
   bool IsConsistent();
 
+  // The IRContext will look at the def and uses of |inst| and update any valid
+  // analyses will be updated accordingly.
+  inline void AnalyzeDefUse(Instruction* inst);
+
   // Informs the IRContext that the uses of |inst| are going to change, and that
   // is should forget everything it know about the current uses.  Any valid
   // analyses will be updated accordingly.
@@ -668,6 +672,12 @@ void IRContext::AddGlobalValue(std::unique_ptr<Instruction>&& v) {
 
 void IRContext::AddFunction(std::unique_ptr<Function>&& f) {
   module()->AddFunction(std::move(f));
+}
+
+void IRContext::AnalyzeDefUse(Instruction* inst) {
+  if (AreAnalysesValid(kAnalysisDefUse)) {
+    get_def_use_mgr()->AnalyzeInstDefUse(inst);
+  }
 }
 
 }  // namespace ir

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -300,4 +300,9 @@ Optimizer::PassToken CreateScalarReplacementPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::ScalarReplacementPass>());
 }
+
+Optimizer::PassToken CreatePrivateToLocalPass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::PrivateToLocalPass>());
+}
 }  // namespace spvtools

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -39,6 +39,7 @@
 #include "local_ssa_elim_pass.h"
 #include "merge_return_pass.h"
 #include "null_pass.h"
+#include "private_to_local_pass.h"
 #include "redundancy_elimination.h"
 #include "remove_duplicates_pass.h"
 #include "scalar_replacement_pass.h"

--- a/source/opt/private_to_local_pass.cpp
+++ b/source/opt/private_to_local_pass.cpp
@@ -1,0 +1,181 @@
+// Copyright (c) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "private_to_local_pass.h"
+
+#include "ir_context.h"
+
+namespace {
+const uint32_t kVariableStorageClassInIdx = 0;
+const uint32_t kSpvTypePointerTypeIdInIdx = 1;
+}  // namespace
+
+namespace spvtools {
+namespace opt {
+
+Pass::Status PrivateToLocalPass::Process(ir::IRContext* c) {
+  InitializeProcessing(c);
+  bool modified = false;
+
+  // Private variables require the shader capability.  If this is not a shader,
+  // there is no work to do.
+  if (get_module()->HasCapability(SpvCapabilityAddresses))
+    return Status::SuccessWithoutChange;
+
+  std::vector<std::pair<ir::Instruction*, ir::Function*>> variables_to_move;
+  for (auto& inst : context()->types_values()) {
+    if (inst.opcode() != SpvOpVariable) {
+      continue;
+    }
+
+    if (inst.GetSingleWordInOperand(kVariableStorageClassInIdx) !=
+        SpvStorageClassPrivate) {
+      continue;
+    }
+
+    ir::Function* target_function = FindLocalFunction(inst);
+    if (target_function != nullptr) {
+      variables_to_move.push_back({&inst, target_function});
+    }
+  }
+
+  modified = !variables_to_move.empty();
+  for (auto p : variables_to_move) {
+    MoveVariable(p.first, p.second);
+  }
+
+  return (modified ? Status::SuccessWithChange : Status::SuccessWithoutChange);
+}
+
+ir::Function* PrivateToLocalPass::FindLocalFunction(
+    const ir::Instruction& inst) const {
+  bool found_first_use = false;
+  ir::Function* target_function = nullptr;
+  context()->get_def_use_mgr()->ForEachUser(
+      inst.result_id(),
+      [&target_function, &found_first_use, this](ir::Instruction* use) {
+        ir::BasicBlock* current_block = context()->get_instr_block(use);
+        if (current_block == nullptr) {
+          return;
+        }
+
+        if (!IsValidUse(use)) {
+          found_first_use = true;
+          target_function = nullptr;
+          return;
+        }
+        ir::Function* current_function = current_block->GetParent();
+        if (!found_first_use) {
+          found_first_use = true;
+          target_function = current_function;
+        } else if (target_function != current_function) {
+          target_function = nullptr;
+        }
+      });
+  return target_function;
+}  // namespace opt
+
+void PrivateToLocalPass::MoveVariable(ir::Instruction* variable,
+                                      ir::Function* function) {
+  // The variable needs to be removed from the global section, and placed in the
+  // header of the function.  First step remove from the global list.
+  variable->RemoveFromList();
+  std::unique_ptr<ir::Instruction> var(variable);  // Take ownership.
+  context()->ForgetUses(variable);
+
+  // Update the storage class of the variable.
+  variable->SetInOperand(kVariableStorageClassInIdx, {SpvStorageClassFunction});
+
+  // Update the type as well.
+  uint32_t new_type_id = GetNewType(variable->type_id());
+  variable->SetResultType(new_type_id);
+
+  // Place the variable at the start of the first basic block.
+  context()->AnalyzeUses(variable);
+  function->begin()->begin()->InsertBefore(move(var));
+
+  // Update uses where the type may have changed.
+  UpdateUses(variable->result_id());
+}
+
+uint32_t PrivateToLocalPass::GetNewType(uint32_t old_type_id) {
+  auto type_mgr = context()->get_type_mgr();
+  ir::Instruction* old_type_inst = get_def_use_mgr()->GetDef(old_type_id);
+  uint32_t pointee_type_id =
+      old_type_inst->GetSingleWordInOperand(kSpvTypePointerTypeIdInIdx);
+  uint32_t new_type_id =
+      type_mgr->FindPointerToType(pointee_type_id, SpvStorageClassFunction);
+  return new_type_id;
+}
+
+bool PrivateToLocalPass::IsValidUse(const ir::Instruction* inst) const {
+  // The cases in this switch have to match the cases in |UpdateUse|.
+  // If we don't know how to update it, it is not valid.
+  switch (inst->opcode()) {
+    case SpvOpLoad:
+    case SpvOpStore:
+      return true;
+    case SpvOpAccessChain: {
+      bool valid = true;
+      context()->get_def_use_mgr()->ForEachUser(
+          inst->result_id(), [this, &valid](const ir::Instruction* use) {
+            valid &= IsValidUse(use);
+          });
+      return valid;
+    }
+    case SpvOpName:
+      return true;
+    default:
+      return spvOpcodeIsDecoration(inst->opcode());
+  }
+}
+
+void PrivateToLocalPass::UpdateUse(ir::Instruction* inst) {
+  // The cases in this switch have to match the cases in |IsValidUse|.  If we
+  // don't think it is valid, the optimization will not view the variable as a
+  // candidate, and therefore the use will not be updated.
+  switch (inst->opcode()) {
+    case SpvOpLoad:
+    case SpvOpStore:
+      // The type is fine because it is the type pointed to, and that does not
+      // change.
+      break;
+    case SpvOpAccessChain:
+      context()->ForgetUses(inst);
+      inst->SetResultType(GetNewType(inst->type_id()));
+      context()->AnalyzeUses(inst);
+
+      // Update uses where the type may have changed.
+      UpdateUses(inst->result_id());
+      break;
+    case SpvOpName:
+      break;
+    default:
+      assert(spvOpcodeIsDecoration(inst->opcode()) &&
+             "Do not know how to update the type for this instruction.");
+      break;
+  }
+}
+void PrivateToLocalPass::UpdateUses(uint32_t id) {
+  std::vector<ir::Instruction*> uses;
+  this->context()->get_def_use_mgr()->ForEachUser(
+      id, [&uses](ir::Instruction* use) { uses.push_back(use); });
+
+  for (ir::Instruction* use : uses) {
+    UpdateUse(use);
+  }
+}
+
+}  // namespace opt
+}  // namespace spvtools

--- a/source/opt/private_to_local_pass.h
+++ b/source/opt/private_to_local_pass.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBSPIRV_OPT_PRIVATE_TO_LOCAL_PASS_H_
+#define LIBSPIRV_OPT_PRIVATE_TO_LOCAL_PASS_H_
+
+#include "ir_context.h"
+#include "pass.h"
+
+namespace spvtools {
+namespace opt {
+
+// This pass implements total redundancy elimination.  This is the same as
+// local redundancy elimination except it looks across basic block boundaries.
+// An instruction, inst, is totally redundant if there is another instruction
+// that dominates inst, and also computes the same value.
+class PrivateToLocalPass : public Pass {
+ public:
+  const char* name() const override { return "private-to-local"; }
+  Status Process(ir::IRContext*) override;
+  ir::IRContext::Analysis GetPreservedAnalyses() override {
+    return ir::IRContext::kAnalysisDefUse |
+           ir::IRContext::kAnalysisDecorations |
+           ir::IRContext::kAnalysisCombinators | ir::IRContext::kAnalysisCFG |
+           ir::IRContext::kAnalysisDominatorAnalysis;
+  }
+
+ private:
+  // Moves |variable| from the private storage class to the function storage
+  // class of |function|.
+  void MoveVariable(ir::Instruction* variable, ir::Function* function);
+
+  // |inst| is an instruction declaring a varible.  If that variable is
+  // referenced in a single function and all of uses are valid as defined by
+  // |IsValidUse|, then that function is returned.  Otherwise, the return value
+  // is |nullptr|.
+  ir::Function* FindLocalFunction(const ir::Instruction& inst) const;
+
+  // Returns true is |inst| is a valid use of a pointer.  In this case, a valid
+  // use is one where the transformation is able to rewrite the type to match a
+  // change in storage class of the original variable.
+  bool IsValidUse(const ir::Instruction* inst) const;
+
+  // Given the result id of a pointer type, |old_type_id|, this function returns
+  // the id of a the same pointer type except the storage class has been changed
+  // to function.  If the type does not already exist, it will be created.
+  uint32_t GetNewType(uint32_t old_type_id);
+
+  // Updates |inst|, and any instruction dependent on |inst|, to reflect the
+  // change of the base pointer now pointing to the function storage class.
+  void UpdateUse(ir::Instruction* inst);
+  void UpdateUses(uint32_t id);
+};
+
+}  // namespace opt
+}  // namespace spvtools
+
+#endif  // LIBSPIRV_OPT_PRIVATE_TO_LOCAL_PASS_H_

--- a/source/opt/type_manager.h
+++ b/source/opt/type_manager.h
@@ -99,6 +99,10 @@ class TypeManager {
   // necessary to fully define |type|.
   uint32_t GetTypeInstruction(const Type* type);
 
+  // Find pointer to type and storage in module, return its resultId.  If it is
+  // not found, a new type is created, and its id is returned.
+  uint32_t FindPointerToType(uint32_t type_id, SpvStorageClass storage_class);
+
   // Registers |id| to |type|.
   //
   // If GetId(|type|) already returns a non-zero id, the return value will be

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -241,3 +241,8 @@ add_spvtools_unittest(TARGET redundancy_elimination
   LIBS SPIRV-Tools-opt
 )
 
+add_spvtools_unittest(TARGET private_to_local
+  SRCS private_to_local_test.cpp pass_utils.cpp
+  LIBS SPIRV-Tools-opt
+)
+

--- a/test/opt/private_to_local_test.cpp
+++ b/test/opt/private_to_local_test.cpp
@@ -1,0 +1,197 @@
+// Copyright (c) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "opt/value_number_table.h"
+
+#include "assembly_builder.h"
+#include "gmock/gmock.h"
+#include "opt/build_module.h"
+#include "pass_fixture.h"
+#include "pass_utils.h"
+
+namespace {
+
+using namespace spvtools;
+
+using ::testing::HasSubstr;
+using ::testing::MatchesRegex;
+
+using PrivateToLocalTest = PassTest<::testing::Test>;
+
+#ifdef SPIRV_EFFCEE
+TEST_F(PrivateToLocalTest, ChangeToLocal) {
+  // Change the private variable to a local, and change the types accordingly.
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 430
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+; CHECK: [[float:%[a-zA-Z_\d]+]] = OpTypeFloat 32
+          %5 = OpTypeFloat 32
+; CHECK: [[newtype:%[a-zA-Z_\d]+]] = OpTypePointer Function [[float]]
+          %6 = OpTypePointer Private %5
+; CHECK-NOT: OpVariable [[.+]] Private
+          %8 = OpVariable %6 Private
+; CHECK: OpFunction
+          %2 = OpFunction %3 None %4
+; CHECK: OpLabel
+          %7 = OpLabel
+; CHECK-NEXT: [[newvar:%[a-zA-Z_\d]+]] = OpVariable [[newtype]] Function
+; CHECK: OpLoad [[float]] [[newvar]]
+          %9 = OpLoad %5 %8
+               OpReturn
+               OpFunctionEnd
+  )";
+  SinglePassRunAndMatch<opt::PrivateToLocalPass>(text, false);
+}
+
+TEST_F(PrivateToLocalTest, ReuseExistingType) {
+  // Change the private variable to a local, and change the types accordingly.
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 430
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+; CHECK: [[float:%[a-zA-Z_\d]+]] = OpTypeFloat 32
+          %5 = OpTypeFloat 32
+        %func_ptr = OpTypePointer Function %5
+; CHECK: [[newtype:%[a-zA-Z_\d]+]] = OpTypePointer Function [[float]]
+; CHECK-NOT: [[%[a-zA-Z_\d]+]] = OpTypePointer Function [[float]]
+          %6 = OpTypePointer Private %5
+; CHECK-NOT: OpVariable [[.+]] Private
+          %8 = OpVariable %6 Private
+; CHECK: OpFunction
+          %2 = OpFunction %3 None %4
+; CHECK: OpLabel
+          %7 = OpLabel
+; CHECK-NEXT: [[newvar:%[a-zA-Z_\d]+]] = OpVariable [[newtype]] Function
+; CHECK: OpLoad [[float]] [[newvar]]
+          %9 = OpLoad %5 %8
+               OpReturn
+               OpFunctionEnd
+  )";
+  SinglePassRunAndMatch<opt::PrivateToLocalPass>(text, false);
+}
+
+TEST_F(PrivateToLocalTest, UpdateAccessChain) {
+  // Change the private variable to a local, and change the AccessChain.
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 430
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+       %void = OpTypeVoid
+          %6 = OpTypeFunction %void
+; CHECK: [[float:%[a-zA-Z_\d]+]] = OpTypeFloat
+      %float = OpTypeFloat 32
+; CHECK: [[struct:%[a-zA-Z_\d]+]] = OpTypeStruct
+  %_struct_8 = OpTypeStruct %float
+%_ptr_Private_float = OpTypePointer Private %float
+; CHECK: [[new_struct_type:%[a-zA-Z_\d]+]] = OpTypePointer Function [[struct]]
+; CHECK: [[new_float_type:%[a-zA-Z_\d]+]] = OpTypePointer Function [[float]]
+%_ptr_Private__struct_8 = OpTypePointer Private %_struct_8
+; CHECK-NOT: OpVariable [[.+]] Private
+         %11 = OpVariable %_ptr_Private__struct_8 Private
+; CHECK: OpFunction
+          %2 = OpFunction %void None %6
+; CHECK: OpLabel
+         %12 = OpLabel
+; CHECK-NEXT: [[newvar:%[a-zA-Z_\d]+]] = OpVariable [[new_struct_type]] Function
+; CHECK: [[member:%[a-zA-Z_\d]+]] = OpAccessChain [[new_float_type]] [[newvar]]
+         %13 = OpAccessChain %_ptr_Private_float %11 %uint_0
+; CHECK: OpLoad [[float]] [[member]]
+         %14 = OpLoad %float %13
+               OpReturn
+               OpFunctionEnd
+  )";
+  SinglePassRunAndMatch<opt::PrivateToLocalPass>(text, false);
+}
+
+TEST_F(PrivateToLocalTest, UsedInTwoFunctions) {
+  // Should not change because it is used in multiple functions.
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 430
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeFloat 32
+          %6 = OpTypePointer Private %5
+          %8 = OpVariable %6 Private
+          %2 = OpFunction %3 None %4
+          %7 = OpLabel
+          %9 = OpLoad %5 %8
+               OpReturn
+               OpFunctionEnd
+         %10 = OpFunction %3 None %4
+         %11 = OpLabel
+         %12 = OpLoad %5 %8
+               OpReturn
+               OpFunctionEnd
+  )";
+  auto result = SinglePassRunAndDisassemble<opt::StrengthReductionPass>(
+      text, /* skip_nop = */ true, /* do_validation = */ false);
+  EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
+}
+
+TEST_F(PrivateToLocalTest, UsedInFunctionCall) {
+  // Should not change because it is used in a function call.  Changing the
+  // signature of the function would require cloning the function, which is not
+  // worth it.
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 430
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+%_ptr_Private_float = OpTypePointer Private %float
+          %7 = OpTypeFunction %void %_ptr_Private_float
+          %8 = OpVariable %_ptr_Private_float Private
+          %2 = OpFunction %void None %4
+          %9 = OpLabel
+         %10 = OpFunctionCall %void %11 %8
+               OpReturn
+               OpFunctionEnd
+         %11 = OpFunction %void None %7
+         %12 = OpFunctionParameter %_ptr_Private_float
+         %13 = OpLabel
+         %14 = OpLoad %float %12
+               OpReturn
+               OpFunctionEnd
+  )";
+  auto result = SinglePassRunAndDisassemble<opt::StrengthReductionPass>(
+      text, /* skip_nop = */ true, /* do_validation = */ false);
+  EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
+}
+#endif
+}  // anonymous namespace

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -198,6 +198,9 @@ Options (in lexicographical order):
                'spirv-opt --merge-blocks -O ...' applies the transformation
                --merge-blocks followed by all the transformations implied by
                -O.
+  --private-to-local
+               Change the scope of private variables that are used in a single
+               function to that function.
   --redundancy-elimination
                Looks for instructions in the same function that compute the
                same value, and deletes the redundant ones.
@@ -408,6 +411,8 @@ OptStatus ParseFlags(int argc, const char** argv, Optimizer* optimizer,
         optimizer->RegisterPass(CreateLocalRedundancyEliminationPass());
       } else if (0 == strcmp(cur_arg, "--redundancy-elimination")) {
         optimizer->RegisterPass(CreateRedundancyEliminationPass());
+      } else if (0 == strcmp(cur_arg, "--private-to-local")) {
+        optimizer->RegisterPass(CreatePrivateToLocalPass());
       } else if (0 == strcmp(cur_arg, "--relax-struct-store")) {
         options->relax_struct_store = true;
       } else if (0 == strcmp(cur_arg, "--skip-validation")) {


### PR DESCRIPTION
When a private variable is used in a single function, it can be
converted to a function scope variable in that function.  This adds a
pass that does that.  The pass can be enabled using the option
`--private-to-local`.

This transformation allows other transformations to act on these
variables.

Also moved `FindPointerToType` from the inline class to the type manager.

Fixes issue #1086.