### PR TITLE
Image Operand Sample allows sparse image opcodes

### DIFF
--- a/source/validate_image.cpp
+++ b/source/validate_image.cpp
@@ -469,10 +469,12 @@ spv_result_t ValidateImageOperands(ValidationState_t& _,
 
   if (mask & SpvImageOperandsSampleMask) {
     if (opcode != SpvOpImageFetch && opcode != SpvOpImageRead &&
-        opcode != SpvOpImageWrite) {
+        opcode != SpvOpImageWrite && opcode != SpvOpImageSparseFetch &&
+        opcode != SpvOpImageSparseRead) {
       return _.diag(SPV_ERROR_INVALID_DATA)
              << "Image Operand Sample can only be used with OpImageFetch, "
-             << "OpImageRead and OpImageWrite: " << spvOpcodeString(opcode);
+             << "OpImageRead, OpImageWrite, OpImageSparseFetch and "
+             << "OpImageSparseRead: " << spvOpcodeString(opcode);
     }
 
     if (info.multisampled == 0) {

--- a/test/val/val_image_test.cpp
+++ b/test/val/val_image_test.cpp
@@ -2858,8 +2858,9 @@ TEST_F(ValidateImage, SampleWrongOpcode) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Image Operand Sample can only be used with "
-                        "OpImageFetch, OpImageRead "
-                        "and OpImageWrite: ImageSampleExplicitLod"));
+                        "OpImageFetch, OpImageRead, OpImageWrite, "
+                        "OpImageSparseFetch and OpImageSparseRead: "
+                        "ImageSampleExplicitLod"));
 }
 
 TEST_F(ValidateImage, SampleImageToImageSuccess) {


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/1100

@ehsannas had filed an issue against SPIR-V spec, concerning
Image Operands section (3.14):
Sample
A following operand is the sample number of the sample to use. Only
valid with OpImageFetch, OpImageRead, and OpImageWrite.

Relaxing the check to allow OpImageSparseRead and
OpImageSparseFetch to fix failing tests.