### PR TITLE
Opt: Remove commented out duplicated type_id() function

### DIFF
--- a/source/opt/function.h
+++ b/source/opt/function.h
@@ -70,10 +70,6 @@ class Function {
   // Returns function's id
   inline uint32_t result_id() const { return def_inst_->result_id(); }
 
-  //  // Returns function's type id
-  //  inline uint32_t type_id() const { return
-  //  def_inst_->GetSingleWordInOperand(1u); }
-
   // Returns function's return type id
   inline uint32_t type_id() const { return def_inst_->type_id(); }
 


### PR DESCRIPTION
This code was wrongly added by #693.