### PR TITLE
Fix type manager memory management

### DIFF
--- a/source/opt/remove_duplicates_pass.h
+++ b/source/opt/remove_duplicates_pass.h
@@ -37,8 +37,7 @@ class RemoveDuplicatesPass : public Pass {
   // Returns whether two types are equal, and have the same decorations.
   static bool AreTypesEqual(const ir::Instruction& inst1,
                             const ir::Instruction& inst2,
-                            const analysis::DefUseManager& defUseManager,
-                            const analysis::DecorationManager& decoManager);
+                            ir::IRContext* context);
 
  private:
   bool RemoveDuplicateCapabilities(ir::IRContext* irContext) const;

--- a/source/opt/type_manager.cpp
+++ b/source/opt/type_manager.cpp
@@ -40,7 +40,7 @@ TypeManager::TypeManager(const MessageConsumer& consumer,
 
 Type* TypeManager::GetType(uint32_t id) const {
   auto iter = id_to_type_.find(id);
-  if (iter != id_to_type_.end()) return (*iter).second.get();
+  if (iter != id_to_type_.end()) return (*iter).second;
   return nullptr;
 }
 
@@ -67,7 +67,6 @@ ForwardPointer* TypeManager::GetForwardPointer(uint32_t index) const {
 
 void TypeManager::AnalyzeTypes(const spvtools::ir::Module& module) {
   for (const auto* inst : module.GetTypes()) RecordIfTypeDefinition(*inst);
-  for (const auto& inst : module.annotations()) AttachIfTypeDecoration(inst);
 }
 
 void TypeManager::RemoveId(uint32_t id) {
@@ -81,17 +80,17 @@ void TypeManager::RemoveId(uint32_t id) {
     for (auto& pair : id_to_type_) {
       if (pair.first != id && *pair.second == *type) {
         // Equivalent ambiguous type, re-map type.
-        type_to_id_.erase(type.get());
-        type_to_id_[pair.second.get()] = pair.first;
+        type_to_id_.erase(type);
+        type_to_id_[pair.second] = pair.first;
         found = true;
         break;
       }
       // No equivalent ambiguous type, remove mapping.
-      if (!found) type_to_id_.erase(type.get());
+      if (!found) type_to_id_.erase(type);
     }
   } else {
     // Unique type, so just erase the entry.
-    type_to_id_.erase(type.get());
+    type_to_id_.erase(type);
   }
 
   // Erase the entry for |id|.
@@ -347,10 +346,10 @@ void TypeManager::CreateDecoration(uint32_t target,
 }
 
 void TypeManager::RegisterType(uint32_t id, const Type& type) {
-  auto& t = id_to_type_[id];
-  t.reset(type.Clone().release());
-  if (GetId(t.get()) == 0) {
-    type_to_id_[t.get()] = id;
+  auto pair = type_pool_.insert(std::move(type.Clone()));
+  id_to_type_[id] = pair.first->get();
+  if (GetId(pair.first->get()) == 0) {
+    type_to_id_[pair.first->get()] = id;
   }
 }
 
@@ -482,20 +481,23 @@ Type* TypeManager::RecordIfTypeDefinition(
   } else {
     SPIRV_ASSERT(consumer_, type != nullptr,
                  "type should not be nullptr at this point");
-    id_to_type_[id].reset(type);
-    type_to_id_[type] = id;
+    std::vector<ir::Instruction*> decorations =
+        context()->get_decoration_mgr()->GetDecorationsFor(id, true);
+    for (auto dec : decorations) {
+      AttachDecoration(*dec, type);
+    }
+    std::unique_ptr<Type> unique(type);
+    auto pair = type_pool_.insert(std::move(unique));
+    id_to_type_[id] = pair.first->get();
+    type_to_id_[pair.first->get()] = id;
   }
   return type;
 }
 
-void TypeManager::AttachIfTypeDecoration(const ir::Instruction& inst) {
+void TypeManager::AttachDecoration(const ir::Instruction& inst, Type* type) {
   const SpvOp opcode = inst.opcode();
   if (!ir::IsAnnotationInst(opcode)) return;
-  const uint32_t id = inst.GetSingleWordOperand(0);
-  // Do nothing if the id to be decorated is not for a known type.
-  if (!id_to_type_.count(id)) return;
 
-  Type* target_type = id_to_type_[id].get();
   switch (opcode) {
     case SpvOpDecorate: {
       const auto count = inst.NumOperands();
@@ -503,7 +505,7 @@ void TypeManager::AttachIfTypeDecoration(const ir::Instruction& inst) {
       for (uint32_t i = 1; i < count; ++i) {
         data.push_back(inst.GetSingleWordOperand(i));
       }
-      target_type->AddDecoration(std::move(data));
+      type->AddDecoration(std::move(data));
     } break;
     case SpvOpMemberDecorate: {
       const auto count = inst.NumOperands();
@@ -512,17 +514,12 @@ void TypeManager::AttachIfTypeDecoration(const ir::Instruction& inst) {
       for (uint32_t i = 2; i < count; ++i) {
         data.push_back(inst.GetSingleWordOperand(i));
       }
-      if (Struct* st = target_type->AsStruct()) {
+      if (Struct* st = type->AsStruct()) {
         st->AddMemberDecoration(index, std::move(data));
       } else {
         SPIRV_UNIMPLEMENTED(consumer_, "OpMemberDecorate non-struct type");
       }
     } break;
-    case SpvOpDecorationGroup:
-    case SpvOpGroupDecorate:
-    case SpvOpGroupMemberDecorate:
-      SPIRV_UNIMPLEMENTED(consumer_, "unhandled decoration");
-      break;
     default:
       SPIRV_UNREACHABLE(consumer_);
       break;

--- a/source/opt/type_manager.cpp
+++ b/source/opt/type_manager.cpp
@@ -75,7 +75,8 @@ void TypeManager::RemoveId(uint32_t id) {
 
   auto& type = iter->second;
   if (!type->IsUniqueType(true)) {
-    if (type_to_id_.count(type)) {
+    auto tIter = type_to_id_.find(type);
+    if (tIter != type_to_id_.end() && tIter->second == id) {
       // |type| currently maps to |id|.
       // Search for an equivalent type to re-map.
       bool found = false;
@@ -89,7 +90,7 @@ void TypeManager::RemoveId(uint32_t id) {
         }
       }
       // No equivalent ambiguous type, remove mapping.
-      if (!found) type_to_id_.erase(type);
+      if (!found) type_to_id_.erase(tIter);
     }
   } else {
     // Unique type, so just erase the entry.

--- a/source/opt/type_manager.cpp
+++ b/source/opt/type_manager.cpp
@@ -346,7 +346,7 @@ void TypeManager::CreateDecoration(uint32_t target,
 }
 
 void TypeManager::RegisterType(uint32_t id, const Type& type) {
-  auto pair = type_pool_.insert(std::move(type.Clone()));
+  auto pair = type_pool_.insert(type.Clone());
   id_to_type_[id] = pair.first->get();
   if (GetId(pair.first->get()) == 0) {
     type_to_id_[pair.first->get()] = id;

--- a/source/opt/type_manager.h
+++ b/source/opt/type_manager.h
@@ -118,7 +118,7 @@ class TypeManager {
 
   // Registers |id| to |type|.
   //
-  // If GetId(|type|) already returns a non-zero id, the return value will be
+  // If GetId(|type|) already returns a non-zero id, that mapping will be
   // unchanged.
   void RegisterType(uint32_t id, const Type& type);
 

--- a/source/opt/type_manager.h
+++ b/source/opt/type_manager.h
@@ -40,6 +40,12 @@ struct HashTypePointer {
     return type->HashValue();
   }
 };
+struct HashTypeUniquePointer {
+  size_t operator()(const std::unique_ptr<Type>& type) const {
+    assert(type);
+    return type->HashValue();
+  }
+};
 
 // Equality functor.
 //
@@ -52,11 +58,18 @@ struct CompareTypePointers {
     return lhs->IsSame(rhs);
   }
 };
+struct CompareTypeUniquePointers {
+  bool operator()(const std::unique_ptr<Type>& lhs,
+                  const std::unique_ptr<Type>& rhs) const {
+    assert(lhs && rhs);
+    return lhs->IsSame(rhs.get());
+  }
+};
 
 // A class for managing the SPIR-V type hierarchy.
 class TypeManager {
  public:
-  using IdToTypeMap = std::unordered_map<uint32_t, std::unique_ptr<Type>>;
+  using IdToTypeMap = std::unordered_map<uint32_t, Type*>;
 
   // Constructs a type manager from the given |module|. All internal messages
   // will be communicated to the outside via the given message |consumer|.
@@ -120,6 +133,9 @@ class TypeManager {
  private:
   using TypeToIdMap = std::unordered_map<const Type*, uint32_t, HashTypePointer,
                                          CompareTypePointers>;
+  using TypePool =
+      std::unordered_set<std::unique_ptr<Type>, HashTypeUniquePointer,
+                         CompareTypeUniquePointers>;
   using ForwardPointerVector = std::vector<std::unique_ptr<ForwardPointer>>;
 
   // Analyzes the types and decorations on types in the given |module|.
@@ -141,14 +157,16 @@ class TypeManager {
   // Creates and returns a type from the given SPIR-V |inst|. Returns nullptr if
   // the given instruction is not for defining a type.
   Type* RecordIfTypeDefinition(const spvtools::ir::Instruction& inst);
-  // Attaches the decoration encoded in |inst| to a type. Does nothing if the
-  // given instruction is not a decoration instruction or not decorating a type.
-  void AttachIfTypeDecoration(const spvtools::ir::Instruction& inst);
+  // Attaches the decoration encoded in |inst| to |type|. Does nothing if the
+  // given instruction is not a decoration instruction. Assumes the target is
+  // |type| (e.g. should be called in loop of |type|'s decorations).
+  void AttachDecoration(const spvtools::ir::Instruction& inst, Type* type);
 
   const MessageConsumer& consumer_;  // Message consumer.
   spvtools::ir::IRContext* context_;
   IdToTypeMap id_to_type_;  // Mapping from ids to their type representations.
   TypeToIdMap type_to_id_;  // Mapping from types to their defining ids.
+  TypePool type_pool_;      // Memory owner of type pointers.
   ForwardPointerVector forward_pointers_;  // All forward pointer declarations.
   // All unresolved forward pointer declarations.
   // Refers the contents in the above vector.

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -255,13 +255,3 @@ add_spvtools_unittest(TARGET pass_remove_duplicates
   SRCS pass_remove_duplicates_test.cpp
   LIBS SPIRV-Tools-opt
 )
-
-add_spvtools_unittest(TARGET decoration_manager
-  SRCS decoration_manager_test.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_remove_duplicates
-  SRCS pass_remove_duplicates_test.cpp
-  LIBS SPIRV-Tools-opt
-)

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -20,9 +20,9 @@ add_spvtools_unittest(TARGET instruction
 )
 
 add_spvtools_unittest(TARGET instruction_list
-        SRCS instruction_list_test.cpp
-        LIBS SPIRV-Tools-opt
-        )
+  SRCS instruction_list_test.cpp
+  LIBS SPIRV-Tools-opt
+)
 
 add_spvtools_unittest(TARGET ir_loader
   SRCS ir_loader_test.cpp
@@ -106,9 +106,9 @@ add_spvtools_unittest(TARGET pass_dead_branch_elim
 )
 
 add_spvtools_unittest(TARGET pass_dead_variable_elim
-        SRCS dead_variable_elim_test.cpp pass_utils.cpp
-        LIBS SPIRV-Tools-opt
-        )
+  SRCS dead_variable_elim_test.cpp pass_utils.cpp
+  LIBS SPIRV-Tools-opt
+)
 
 add_spvtools_unittest(TARGET pass_aggressive_dce
   SRCS aggressive_dead_code_elim_test.cpp pass_utils.cpp
@@ -256,3 +256,12 @@ add_spvtools_unittest(TARGET pass_remove_duplicates
   LIBS SPIRV-Tools-opt
 )
 
+add_spvtools_unittest(TARGET decoration_manager
+  SRCS decoration_manager_test.cpp
+  LIBS SPIRV-Tools-opt
+)
+
+add_spvtools_unittest(TARGET pass_remove_duplicates
+  SRCS pass_remove_duplicates_test.cpp
+  LIBS SPIRV-Tools-opt
+)

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -201,6 +201,9 @@ Options (in lexicographical order):
   --private-to-local
                Change the scope of private variables that are used in a single
                function to that function.
+  --remove-duplicates
+               Removes duplicate types, decorations, capabilities and extension
+               instructions.
   --redundancy-elimination
                Looks for instructions in the same function that compute the
                same value, and deletes the redundant ones.
@@ -413,6 +416,8 @@ OptStatus ParseFlags(int argc, const char** argv, Optimizer* optimizer,
         optimizer->RegisterPass(CreateRedundancyEliminationPass());
       } else if (0 == strcmp(cur_arg, "--private-to-local")) {
         optimizer->RegisterPass(CreatePrivateToLocalPass());
+      } else if (0 == strcmp(cur_arg, "--remove-duplicates")) {
+        optimizer->RegisterPass(CreateRemoveDuplicatesPass());
       } else if (0 == strcmp(cur_arg, "--relax-struct-store")) {
         options->relax_struct_store = true;
       } else if (0 == strcmp(cur_arg, "--skip-validation")) {


### PR DESCRIPTION
Addresses #1111.

Instead of mapping ids to unique_ptrs, the type manager now stores a pool of unique type pointers. The id to type map now maps to regular type pointers.

I made some modifications to RemoveDuplicatesPass to remove some (effectively) duplicated code comparing types. I also eliminated an instance of instruction being copied into a vector instead of instruction pointers.

I also made remove duplicates run-able from the command line.