### PR TITLE
Fix https://github.com/KhronosGroup/SPIRV-Tools/issues/1130

### DIFF
--- a/source/opt/constants.h
+++ b/source/opt/constants.h
@@ -356,8 +356,8 @@ class ConstantManager {
       const Type* type, const std::vector<uint32_t>& literal_words_or_ids);
 
   // Gets or creates a Constant instance to hold the constant value of the given
-  // instruction. It returns a pointer to the Constant's defining instruction or
-  // nullptr if it could not create the constant.
+  // instruction. It returns a pointer to a Constant instance or nullptr if it
+  // could not create the constant.
   const Constant* GetConstantFromInst(ir::Instruction* inst);
 
   // Gets or creates a constant defining instruction for the given Constant |c|.

--- a/source/opt/fold.h
+++ b/source/opt/fold.h
@@ -24,14 +24,40 @@
 namespace spvtools {
 namespace opt {
 
+// Returns the result of folding a scalar instruction with the given |opcode|
+// and |operands|. Each entry in |operands| is a pointer to an
+// analysis::Constant instance, which should've been created with the constant
+// manager (See IRContext::get_constant_mgr).
+//
+// It is an error to call this function with an opcode that does not pass the
+// IsFoldableOpcode test. If any error occurs during folding, the folder will
+// faill with a call to assert.
 uint32_t FoldScalars(SpvOp opcode,
                      const std::vector<const analysis::Constant*>& operands);
 
+// Returns the result of performing an operation with the given |opcode| over
+// constant vectors with |num_dims| dimensions.  Each entry in |operands| is a
+// pointer to an analysis::Constant instance, which should've been created with
+// the constant manager (See IRContext::get_constant_mgr).
+//
+// This function iterates through the given vector type constant operands and
+// calculates the result for each element of the result vector to return.
+// Vectors with longer than 32-bit scalar components are not accepted in this
+// function.
+//
+// It is an error to call this function with an opcode that does not pass the
+// IsFoldableOpcode test. If any error occurs during folding, the folder will
+// faill with a call to assert.
 std::vector<uint32_t> FoldVectors(
     SpvOp opcode, uint32_t num_dims,
     const std::vector<const analysis::Constant*>& operands);
 
+// Returns true if |opcode| represents an operation handled by FoldScalars or
+// FoldVectors.
 bool IsFoldableOpcode(SpvOp opcode);
+
+// Returns true if |cst| is supported by FoldScalars and FoldVectors.
+bool IsFoldableConstant(const analysis::Constant* cst);
 
 }  // namespace opt
 }  // namespace spvtools

--- a/source/opt/propagator.h
+++ b/source/opt/propagator.h
@@ -192,7 +192,8 @@ class SSAPropagator {
   bool Run(ir::Function* fn);
 
   // Returns true if the |i|th argument for |phi| comes through a CFG edge that
-  // has been marked executable.
+  // has been marked executable. |i| should be an index value accepted by
+  // Instruction::GetSingleWordOperand.
   bool IsPhiArgExecutable(ir::Instruction* phi, uint32_t i) const;
 
  private:


### PR DESCRIPTION
This addresses review feedback for the CCP implementation (which fixes
https://github.com/KhronosGroup/SPIRV-Tools/issues/889).

This adds more protection around the folding of instructions that would
not be supported by the folder.

@dneto0, there are more extensions that should be added to CCP.  Notably, 64-bit integer operations (#1132) and floating point operations (#943).

I will handle these in the coming days.