### PR TITLE
Unify multiple DCE passes into ADCE

### DIFF
--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -394,8 +394,9 @@ Optimizer::PassToken CreateCommonUniformElimPass();
 // time cost over standard dead code elimination.
 //
 // This pass only processes entry point functions. It also only processes
-// shaders with logical addressing. It currently will not process functions
-// with function calls. Unreachable functions are deleted.
+// shaders with relaxed logical addressing (see opt/instruction.h). It
+// currently will not process functions with function calls. Unreachable
+// functions are deleted.
 //
 // This pass will be made more effective by first running passes that remove
 // dead control flow and inlines function calls.

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -386,7 +386,7 @@ Optimizer::PassToken CreateInsertExtractElimPass();
 Optimizer::PassToken CreateCommonUniformElimPass();
 
 // Create aggressive dead code elimination pass
-// This pass eliminates unused code from functions. In addition,
+// This pass eliminates unused code from the module. In addition,
 // it detects and eliminates code which may have spurious uses but which do
 // not contribute to the output of the function. The most common cause of
 // such code sequences is summations in loops whose result is no longer used
@@ -394,8 +394,8 @@ Optimizer::PassToken CreateCommonUniformElimPass();
 // time cost over standard dead code elimination.
 //
 // This pass only processes entry point functions. It also only processes
-// shaders with relaxed logical addressing (see opt/instruction.h). It currently
-// will not process functions with function calls.
+// shaders with logical addressing. It currently will not process functions
+// with function calls. Unreachable functions are deleted.
 //
 // This pass will be made more effective by first running passes that remove
 // dead control flow and inlines function calls.

--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -667,18 +667,27 @@ void AggressiveDCEPass::InitExtensions() {
   extensions_whitelist_.clear();
   extensions_whitelist_.insert({
       "SPV_AMD_shader_explicit_vertex_parameter",
-      "SPV_AMD_shader_trinary_minmax", "SPV_AMD_gcn_shader",
-      "SPV_KHR_shader_ballot", "SPV_AMD_shader_ballot",
-      "SPV_AMD_gpu_shader_half_float", "SPV_KHR_shader_draw_parameters",
-      "SPV_KHR_subgroup_vote", "SPV_KHR_16bit_storage", "SPV_KHR_device_group",
-      "SPV_KHR_multiview", "SPV_NVX_multiview_per_view_attributes",
-      "SPV_NV_viewport_array2", "SPV_NV_stereo_view_rendering",
+      "SPV_AMD_shader_trinary_minmax",
+      "SPV_AMD_gcn_shader",
+      "SPV_KHR_shader_ballot",
+      "SPV_AMD_shader_ballot",
+      "SPV_AMD_gpu_shader_half_float",
+      "SPV_KHR_shader_draw_parameters",
+      "SPV_KHR_subgroup_vote",
+      "SPV_KHR_16bit_storage",
+      "SPV_KHR_device_group",
+      "SPV_KHR_multiview",
+      "SPV_NVX_multiview_per_view_attributes",
+      "SPV_NV_viewport_array2",
+      "SPV_NV_stereo_view_rendering",
       "SPV_NV_sample_mask_override_coverage",
-      "SPV_NV_geometry_shader_passthrough", "SPV_AMD_texture_gather_bias_lod",
+      "SPV_NV_geometry_shader_passthrough",
+      "SPV_AMD_texture_gather_bias_lod",
       "SPV_KHR_storage_buffer_storage_class",
       // SPV_KHR_variable_pointers
       //   Currently do not support extended pointer expressions
-      "SPV_AMD_gpu_shader_int16", "SPV_KHR_post_depth_coverage",
+      "SPV_AMD_gpu_shader_int16",
+      "SPV_KHR_post_depth_coverage",
       "SPV_KHR_shader_atomic_counter_ops",
   });
 }

--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -690,7 +690,8 @@ void AggressiveDCEPass::InitExtensions() {
       "SPV_KHR_storage_buffer_storage_class",
       // SPV_KHR_variable_pointers
       //   Currently do not support extended pointer expressions
-      "SPV_AMD_gpu_shader_int16", "SPV_KHR_post_depth_coverage",
+      "SPV_AMD_gpu_shader_int16",
+      "SPV_KHR_post_depth_coverage",
       "SPV_KHR_shader_atomic_counter_ops",
   });
 }

--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -428,6 +428,15 @@ void AggressiveDCEPass::Initialize(ir::IRContext* c) {
   InitExtensions();
 }
 
+void AggressiveDCEPass::InitializeModuleScopeLiveInstructions() {
+  for (auto& exec : get_module()->execution_modes()) {
+    AddToWorklist(&exec);
+  }
+  for (auto& entry : get_module()->entry_points()) {
+    AddToWorklist(&entry);
+  }
+}
+
 Pass::Status AggressiveDCEPass::ProcessImpl() {
   // Current functionality assumes shader capability
   // TODO(greg-lunarg): Handle additional capabilities
@@ -442,12 +451,7 @@ Pass::Status AggressiveDCEPass::ProcessImpl() {
   // return unmodified.
   if (!AllExtensionsSupported()) return Status::SuccessWithoutChange;
 
-  for (auto& exec : get_module()->execution_modes()) {
-    AddToWorklist(&exec);
-  }
-  for (auto& entry : get_module()->entry_points()) {
-    AddToWorklist(&entry);
-  }
+  InitializeModuleScopeLiveInstructions();
 
   // Process all entry point functions
   ProcessFunction pfn = [this](ir::Function* fp) { return AggressiveDCE(fp); };

--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -518,7 +518,8 @@ Pass::Status AggressiveDCEPass::ProcessImpl() {
   ProcessFunction pfn = [this](ir::Function* fp) { return AggressiveDCE(fp); };
   modified |= ProcessEntryPointCallTree(pfn, get_module());
 
-  // Process module-level instructions.
+  // Process module-level instructions. Now that all live instructions have
+  // been marked, it is safe to remove dead global values.
   modified |= ProcessGlobalValues();
 
   // Kill all dead instructions.

--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -36,7 +36,7 @@ const uint32_t kLoopMergeContinueBlockIdInIdx = 1;
 
 // Sorting functor to present annotation instructions in an easy-to-process
 // order. The functor orders by opcode first and falls back on unique id
-// orderingif both instructions have the same opcode.
+// ordering if both instructions have the same opcode.
 //
 // Desired priority:
 // SpvOpGroupDecorate

--- a/source/opt/aggressive_dead_code_elim_pass.h
+++ b/source/opt/aggressive_dead_code_elim_pass.h
@@ -98,9 +98,6 @@ class AggressiveDCEPass : public MemPass {
   // to order blocks.
   void ComputeBlock2HeaderMaps(std::list<ir::BasicBlock*>& structuredOrder);
 
-  // Initialize inst2block_ for |func|.
-  void ComputeInst2BlockMap(ir::Function* func);
-
   // Add branch to |labelId| to end of block |bp|.
   void AddBranch(uint32_t labelId, ir::BasicBlock* bp);
 
@@ -146,9 +143,6 @@ class AggressiveDCEPass : public MemPass {
 
   // Map from branch to its associated merge instruction, if any
   std::unordered_map<ir::Instruction*, ir::Instruction*> branch2merge_;
-
-  // Map from instruction containing block
-  std::unordered_map<ir::Instruction*, ir::BasicBlock*> inst2block_;
 
   // Map from block's label id to block.
   std::unordered_map<uint32_t, ir::BasicBlock*> id2block_;

--- a/source/opt/aggressive_dead_code_elim_pass.h
+++ b/source/opt/aggressive_dead_code_elim_pass.h
@@ -29,7 +29,6 @@
 #include "mem_pass.h"
 #include "module.h"
 
-#include <iostream>
 namespace spvtools {
 namespace opt {
 
@@ -73,7 +72,6 @@ class AggressiveDCEPass : public MemPass {
 
   // Add |inst| to worklist_ and live_insts_.
   void AddToWorklist(ir::Instruction* inst) {
-    // std::cerr << " Adding " << inst << std::endl;
     live_insts_.insert(inst);
     worklist_.push(inst);
   }

--- a/source/opt/aggressive_dead_code_elim_pass.h
+++ b/source/opt/aggressive_dead_code_elim_pass.h
@@ -118,10 +118,16 @@ class AggressiveDCEPass : public MemPass {
   // removal (e.g. types, constants and variables).
   bool ProcessGlobalValues();
 
+  // Erases unreachable functions from the module.
+  bool EliminateDeadFunctions();
+
+  // Removes |func| from the module and deletes all its instructions.
+  void EliminateFunction(ir::Function* func);
+
   // For function |func|, mark all Stores to non-function-scope variables
   // and block terminating instructions as live. Recursively mark the values
-  // they use. When complete, delete any non-live instructions. Return true
-  // if the function has been modified.
+  // they use. When complete, mark any non-live instructions to be deleted.
+  // Returns true if the function has been modified.
   //
   // Note: This function does not delete useless control structures. All
   // existing control structures will remain. This can leave not-insignificant

--- a/source/opt/aggressive_dead_code_elim_pass.h
+++ b/source/opt/aggressive_dead_code_elim_pass.h
@@ -56,15 +56,20 @@ class AggressiveDCEPass : public MemPass {
 
   // Return true if |varId| is variable of function storage class or is
   // private variable and privates can be optimized like locals (see
-  // privates_like_local_)
+  // privates_like_local_).
   bool IsLocalVar(uint32_t varId);
 
-  // Return true if |inst| is marked live
+  // Return true if |inst| is marked live.
   bool IsLive(const ir::Instruction* inst) const {
     return live_insts_.find(inst) != live_insts_.end();
   }
 
+  // Returns true if |inst| is dead.
   bool IsDead(ir::Instruction* inst);
+
+  // Adds entry points and execution modes to the worklist for processing with
+  // the first function.
+  void InitializeModuleScopeLiveInstructions();
 
   // Add |inst| to worklist_ and live_insts_.
   void AddToWorklist(ir::Instruction* inst) {

--- a/source/opt/aggressive_dead_code_elim_pass.h
+++ b/source/opt/aggressive_dead_code_elim_pass.h
@@ -87,7 +87,8 @@ class AggressiveDCEPass : public MemPass {
   bool AllExtensionsSupported() const;
 
   // Returns true if the target of |inst| is dead.  An instruction is dead if
-  // its result id is used in decoration or debug instructions only.
+  // its result id is used in decoration or debug instructions only. |inst| is
+  // assumed to be OpName, OpMemberName or an annotation instruction.
   bool IsTargetDead(ir::Instruction* inst);
 
   // If |varId| is local, mark all stores of varId as live.
@@ -96,6 +97,8 @@ class AggressiveDCEPass : public MemPass {
   // If |bp| is structured if or loop header block, return true and set
   // |mergeInst| to the merge instruction, |branchInst| to the conditional
   // branch and |mergeBlockId| to the merge block if they are not nullptr.
+  // Any of |mergeInst|, |branchInst| or |mergeBlockId| may be a null pointer.
+  // Returns false if |bp| is a null pointer.
   bool IsStructuredIfOrLoopHeader(ir::BasicBlock* bp,
                                   ir::Instruction** mergeInst,
                                   ir::Instruction** branchInst,

--- a/source/opt/aggressive_dead_code_elim_pass.h
+++ b/source/opt/aggressive_dead_code_elim_pass.h
@@ -86,8 +86,8 @@ class AggressiveDCEPass : public MemPass {
   // Return true if all extensions in this module are supported by this pass.
   bool AllExtensionsSupported() const;
 
-  // Returns true if |inst| is dead.  An instruction is dead if its result id
-  // is used in decoration or debug instructions only.
+  // Returns true if the target of |inst| is dead.  An instruction is dead if
+  // its result id is used in decoration or debug instructions only.
   bool IsTargetDead(ir::Instruction* inst);
 
   // If |varId| is local, mark all stores of varId as live.
@@ -116,7 +116,7 @@ class AggressiveDCEPass : public MemPass {
   // removal (e.g. types, constants and variables).
   bool ProcessGlobalValues();
 
-  // Erases unreachable functions from the module.
+  // Erases functions that are unreachable from the entry points of the module.
   bool EliminateDeadFunctions();
 
   // Removes |func| from the module and deletes all its instructions.
@@ -178,6 +178,8 @@ class AggressiveDCEPass : public MemPass {
   // Live Local Variables
   std::unordered_set<uint32_t> live_local_vars_;
 
+  // List of instructions to delete. Deletion is delayed until debug and
+  // annotation instructions are processed.
   std::vector<ir::Instruction*> to_kill_;
 
   // Extensions supported by this pass.

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -133,8 +133,8 @@ Optimizer& Optimizer::RegisterPerformancePasses() {
       .RegisterPass(CreateInsertExtractElimPass())
       .RegisterPass(CreateRedundancyEliminationPass())
       .RegisterPass(CreateCFGCleanupPass());
-      // Currently exposing driver bugs resulting in crashes (#946)
-      // .RegisterPass(CreateCommonUniformElimPass())
+  // Currently exposing driver bugs resulting in crashes (#946)
+  // .RegisterPass(CreateCommonUniformElimPass())
 }
 
 Optimizer& Optimizer::RegisterSizePasses() {
@@ -155,8 +155,8 @@ Optimizer& Optimizer::RegisterSizePasses() {
       .RegisterPass(CreateInsertExtractElimPass())
       .RegisterPass(CreateRedundancyEliminationPass())
       .RegisterPass(CreateCFGCleanupPass());
-      // Currently exposing driver bugs resulting in crashes (#946)
-      // .RegisterPass(CreateCommonUniformElimPass())
+  // Currently exposing driver bugs resulting in crashes (#946)
+  // .RegisterPass(CreateCommonUniformElimPass())
 }
 
 bool Optimizer::Run(const uint32_t* original_binary,

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -118,7 +118,6 @@ Optimizer& Optimizer::RegisterPerformancePasses() {
   return RegisterPass(CreateRemoveDuplicatesPass())
       .RegisterPass(CreateMergeReturnPass())
       .RegisterPass(CreateInlineExhaustivePass())
-      .RegisterPass(CreateEliminateDeadFunctionsPass())
       .RegisterPass(CreateScalarReplacementPass())
       .RegisterPass(CreateLocalAccessChainConvertPass())
       .RegisterPass(CreateLocalSingleBlockLoadStoreElimPass())
@@ -133,17 +132,15 @@ Optimizer& Optimizer::RegisterPerformancePasses() {
       .RegisterPass(CreateBlockMergePass())
       .RegisterPass(CreateInsertExtractElimPass())
       .RegisterPass(CreateRedundancyEliminationPass())
-      .RegisterPass(CreateCFGCleanupPass())
+      .RegisterPass(CreateCFGCleanupPass());
       // Currently exposing driver bugs resulting in crashes (#946)
       // .RegisterPass(CreateCommonUniformElimPass())
-      .RegisterPass(CreateDeadVariableEliminationPass());
 }
 
 Optimizer& Optimizer::RegisterSizePasses() {
   return RegisterPass(CreateRemoveDuplicatesPass())
       .RegisterPass(CreateMergeReturnPass())
       .RegisterPass(CreateInlineExhaustivePass())
-      .RegisterPass(CreateEliminateDeadFunctionsPass())
       .RegisterPass(CreateLocalAccessChainConvertPass())
       .RegisterPass(CreateLocalSingleBlockLoadStoreElimPass())
       .RegisterPass(CreateLocalSingleStoreElimPass())
@@ -157,10 +154,9 @@ Optimizer& Optimizer::RegisterSizePasses() {
       .RegisterPass(CreateBlockMergePass())
       .RegisterPass(CreateInsertExtractElimPass())
       .RegisterPass(CreateRedundancyEliminationPass())
-      .RegisterPass(CreateCFGCleanupPass())
+      .RegisterPass(CreateCFGCleanupPass());
       // Currently exposing driver bugs resulting in crashes (#946)
       // .RegisterPass(CreateCommonUniformElimPass())
-      .RegisterPass(CreateDeadVariableEliminationPass());
 }
 
 bool Optimizer::Run(const uint32_t* original_binary,

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -118,6 +118,7 @@ Optimizer& Optimizer::RegisterPerformancePasses() {
   return RegisterPass(CreateRemoveDuplicatesPass())
       .RegisterPass(CreateMergeReturnPass())
       .RegisterPass(CreateInlineExhaustivePass())
+      .RegisterPass(CreateAggressiveDCEPass())
       .RegisterPass(CreateScalarReplacementPass())
       .RegisterPass(CreateLocalAccessChainConvertPass())
       .RegisterPass(CreateLocalSingleBlockLoadStoreElimPass())
@@ -132,15 +133,17 @@ Optimizer& Optimizer::RegisterPerformancePasses() {
       .RegisterPass(CreateBlockMergePass())
       .RegisterPass(CreateInsertExtractElimPass())
       .RegisterPass(CreateRedundancyEliminationPass())
-      .RegisterPass(CreateCFGCleanupPass());
-  // Currently exposing driver bugs resulting in crashes (#946)
-  // .RegisterPass(CreateCommonUniformElimPass())
+      .RegisterPass(CreateCFGCleanupPass())
+      // Currently exposing driver bugs resulting in crashes (#946)
+      // .RegisterPass(CreateCommonUniformElimPass())
+      .RegisterPass(CreateAggressiveDCEPass());
 }
 
 Optimizer& Optimizer::RegisterSizePasses() {
   return RegisterPass(CreateRemoveDuplicatesPass())
       .RegisterPass(CreateMergeReturnPass())
       .RegisterPass(CreateInlineExhaustivePass())
+      .RegisterPass(CreateAggressiveDCEPass())
       .RegisterPass(CreateLocalAccessChainConvertPass())
       .RegisterPass(CreateLocalSingleBlockLoadStoreElimPass())
       .RegisterPass(CreateLocalSingleStoreElimPass())
@@ -154,9 +157,10 @@ Optimizer& Optimizer::RegisterSizePasses() {
       .RegisterPass(CreateBlockMergePass())
       .RegisterPass(CreateInsertExtractElimPass())
       .RegisterPass(CreateRedundancyEliminationPass())
-      .RegisterPass(CreateCFGCleanupPass());
-  // Currently exposing driver bugs resulting in crashes (#946)
-  // .RegisterPass(CreateCommonUniformElimPass())
+      .RegisterPass(CreateCFGCleanupPass())
+      // Currently exposing driver bugs resulting in crashes (#946)
+      // .RegisterPass(CreateCommonUniformElimPass())
+      .RegisterPass(CreateAggressiveDCEPass());
 }
 
 bool Optimizer::Run(const uint32_t* original_binary,

--- a/test/opt/aggressive_dead_code_elim_test.cpp
+++ b/test/opt/aggressive_dead_code_elim_test.cpp
@@ -3557,13 +3557,9 @@ OpMemberDecorate %_struct_3 0 Offset 0
 OpDecorate %_runtimearr__struct_3 ArrayStride 16
 OpMemberDecorate %_struct_5 0 Offset 0
 OpDecorate %_struct_5 BufferBlock
-OpMemberDecorate %_struct_6 0 Offset 0
-OpDecorate %_struct_6 BufferBlock
 OpDecorate %2 Location 0
 OpDecorate %7 DescriptorSet 0
 OpDecorate %7 Binding 0
-OpDecorate %8 DescriptorSet 0
-OpDecorate %8 Binding 1
 %void = OpTypeVoid
 %10 = OpTypeFunction %void
 %int = OpTypeInt 32 1
@@ -3576,15 +3572,11 @@ OpDecorate %8 Binding 1
 %_runtimearr__struct_3 = OpTypeRuntimeArray %_struct_3
 %_struct_5 = OpTypeStruct %_runtimearr__struct_3
 %_ptr_Uniform__struct_5 = OpTypePointer Uniform %_struct_5
-%_struct_6 = OpTypeStruct %int
-%_ptr_Uniform__struct_6 = OpTypePointer Uniform %_struct_6
 %_ptr_Function__ptr_Uniform__struct_5 = OpTypePointer Function %_ptr_Uniform__struct_5
-%_ptr_Function__ptr_Uniform__struct_6 = OpTypePointer Function %_ptr_Uniform__struct_6
 %int_0 = OpConstant %int 0
 %uint_0 = OpConstant %uint 0
 %2 = OpVariable %_ptr_Output_v4float Output
 %7 = OpVariable %_ptr_Uniform__struct_5 Uniform
-%8 = OpVariable %_ptr_Uniform__struct_6 Uniform
 %1 = OpFunction %void None %10
 %23 = OpLabel
 %24 = OpVariable %_ptr_Function__ptr_Uniform__struct_5 Function
@@ -3672,49 +3664,6 @@ OpFunctionEnd
 
   const std::string after =
       R"(OpCapability Shader
-OpMemoryModel Logical GLSL450
-OpEntryPoint Fragment %1 "main" %2
-OpExecutionMode %1 OriginUpperLeft
-OpMemberDecorate %_struct_3 0 Offset 0
-OpDecorate %_runtimearr__struct_3 ArrayStride 16
-OpMemberDecorate %_struct_5 0 Offset 0
-OpDecorate %_struct_5 BufferBlock
-OpMemberDecorate %_struct_6 0 Offset 0
-OpDecorate %_struct_6 BufferBlock
-OpDecorate %2 Location 0
-OpDecorate %7 DescriptorSet 0
-OpDecorate %7 Binding 0
-OpDecorate %8 DescriptorSet 0
-OpDecorate %8 Binding 1
-%void = OpTypeVoid
-%10 = OpTypeFunction %void
-%int = OpTypeInt 32 1
-%uint = OpTypeInt 32 0
-%float = OpTypeFloat 32
-%v4float = OpTypeVector %float 4
-%_ptr_Output_v4float = OpTypePointer Output %v4float
-%_ptr_Uniform_v4float = OpTypePointer Uniform %v4float
-%_struct_3 = OpTypeStruct %v4float
-%_runtimearr__struct_3 = OpTypeRuntimeArray %_struct_3
-%_struct_5 = OpTypeStruct %_runtimearr__struct_3
-%_ptr_Uniform__struct_5 = OpTypePointer Uniform %_struct_5
-%_struct_6 = OpTypeStruct %int
-%_ptr_Uniform__struct_6 = OpTypePointer Uniform %_struct_6
-%_ptr_Function__ptr_Uniform__struct_5 = OpTypePointer Function %_ptr_Uniform__struct_5
-%_ptr_Function__ptr_Uniform__struct_6 = OpTypePointer Function %_ptr_Uniform__struct_6
-%int_0 = OpConstant %int 0
-%uint_0 = OpConstant %uint 0
-%2 = OpVariable %_ptr_Output_v4float Output
-%7 = OpVariable %_ptr_Uniform__struct_5 Uniform
-%8 = OpVariable %_ptr_Uniform__struct_6 Uniform
-%1 = OpFunction %void None %10
-%23 = OpLabel
-%24 = OpVariable %_ptr_Function__ptr_Uniform__struct_5 Function
-OpStore %24 %7
-%25 = OpLoad %_ptr_Uniform__struct_5 %24
-%26 = OpAccessChain %_ptr_Uniform_v4float %25 %int_0 %uint_0 %int_0
-%27 = OpLoad %v4float %26
-OpStore %2 %27
 OpCapability Linkage
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450

--- a/test/opt/aggressive_dead_code_elim_test.cpp
+++ b/test/opt/aggressive_dead_code_elim_test.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "assembly_builder.h"
 #include "pass_fixture.h"
 #include "pass_utils.h"
 
@@ -3818,6 +3819,995 @@ OpFunctionEnd
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SinglePassRunAndCheck<opt::AggressiveDCEPass>(before, after, true, true);
 }
+
+#ifdef SPIRV_EFFCEE
+TEST_F(AggressiveDCETest, BasicAllDeadConstants) {
+  const std::string text = R"(
+  ; CHECK-NOT: OpConstant
+               OpCapability Shader
+               OpCapability Float64
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main"
+               OpName %main "main"
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+       %bool = OpTypeBool
+       %true = OpConstantTrue %bool
+      %false = OpConstantFalse %bool
+        %int = OpTypeInt 32 1
+          %9 = OpConstant %int 1
+       %uint = OpTypeInt 32 0
+         %11 = OpConstant %uint 2
+      %float = OpTypeFloat 32
+         %13 = OpConstant %float 3.14
+     %double = OpTypeFloat 64
+         %15 = OpConstant %double 3.14159265358979
+       %main = OpFunction %void None %4
+         %16 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  SinglePassRunAndMatch<opt::AggressiveDCEPass>(text, true);
+}
+#endif  // SPIRV_EFFCEE
+
+TEST_F(AggressiveDCETest, BasicNoneDeadConstants) {
+  const std::vector<const char*> text = {
+      // clang-format off
+                "OpCapability Shader",
+                "OpCapability Float64",
+           "%1 = OpExtInstImport \"GLSL.std.450\"",
+                "OpMemoryModel Logical GLSL450",
+                "OpEntryPoint Vertex %main \"main\" %btv %bfv %iv %uv %fv %dv",
+                "OpName %main \"main\"",
+                "OpName %btv \"btv\"",
+                "OpName %bfv \"bfv\"",
+                "OpName %iv \"iv\"",
+                "OpName %uv \"uv\"",
+                "OpName %fv \"fv\"",
+                "OpName %dv \"dv\"",
+        "%void = OpTypeVoid",
+          "%10 = OpTypeFunction %void",
+        "%bool = OpTypeBool",
+ "%_ptr_Output_bool = OpTypePointer Output %bool",
+        "%true = OpConstantTrue %bool",
+       "%false = OpConstantFalse %bool",
+         "%int = OpTypeInt 32 1",
+ "%_ptr_Output_int = OpTypePointer Output %int",
+       "%int_1 = OpConstant %int 1",
+        "%uint = OpTypeInt 32 0",
+ "%_ptr_Output_uint = OpTypePointer Output %uint",
+      "%uint_2 = OpConstant %uint 2",
+       "%float = OpTypeFloat 32",
+ "%_ptr_Output_float = OpTypePointer Output %float",
+  "%float_3_14 = OpConstant %float 3.14",
+      "%double = OpTypeFloat 64",
+ "%_ptr_Output_double = OpTypePointer Output %double",
+ "%double_3_14159265358979 = OpConstant %double 3.14159265358979",
+         "%btv = OpVariable %_ptr_Output_bool Output",
+         "%bfv = OpVariable %_ptr_Output_bool Output",
+          "%iv = OpVariable %_ptr_Output_int Output",
+          "%uv = OpVariable %_ptr_Output_uint Output",
+          "%fv = OpVariable %_ptr_Output_float Output",
+          "%dv = OpVariable %_ptr_Output_double Output",
+        "%main = OpFunction %void None %10",
+          "%27 = OpLabel",
+                "OpStore %btv %true",
+                "OpStore %bfv %false",
+                "OpStore %iv %int_1",
+                "OpStore %uv %uint_2",
+                "OpStore %fv %float_3_14",
+                "OpStore %dv %double_3_14159265358979",
+                "OpReturn",
+                "OpFunctionEnd",
+      // clang-format on
+  };
+  // All constants are used, so none of them should be eliminated.
+  SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+      JoinAllInsts(text), JoinAllInsts(text), /* skip_nop = */ true);
+}
+
+struct EliminateDeadConstantTestCase {
+  // Type declarations and constants that should be kept.
+  std::vector<std::string> used_consts;
+  // Instructions that refer to constants, this is added to create uses for
+  // some constants so they won't be treated as dead constants.
+  std::vector<std::string> main_insts;
+  // Dead constants that should be removed.
+  std::vector<std::string> dead_consts;
+  // Expectations
+  std::vector<std::string> checks;
+};
+
+// All types that are potentially required in EliminateDeadConstantTest.
+const std::vector<std::string> CommonTypes = {
+    // clang-format off
+    // scalar types
+    "%bool = OpTypeBool",
+    "%uint = OpTypeInt 32 0",
+    "%int = OpTypeInt 32 1",
+    "%float = OpTypeFloat 32",
+    "%double = OpTypeFloat 64",
+    // vector types
+    "%v2bool = OpTypeVector %bool 2",
+    "%v2uint = OpTypeVector %uint 2",
+    "%v2int = OpTypeVector %int 2",
+    "%v3int = OpTypeVector %int 3",
+    "%v4int = OpTypeVector %int 4",
+    "%v2float = OpTypeVector %float 2",
+    "%v3float = OpTypeVector %float 3",
+    "%v2double = OpTypeVector %double 2",
+    // variable pointer types
+    "%_pf_bool = OpTypePointer Output %bool",
+    "%_pf_uint = OpTypePointer Output %uint",
+    "%_pf_int = OpTypePointer Output %int",
+    "%_pf_float = OpTypePointer Output %float",
+    "%_pf_double = OpTypePointer Output %double",
+    "%_pf_v2int = OpTypePointer Output %v2int",
+    "%_pf_v3int = OpTypePointer Output %v3int",
+    "%_pf_v2float = OpTypePointer Output %v2float",
+    "%_pf_v3float = OpTypePointer Output %v3float",
+    "%_pf_v2double = OpTypePointer Output %v2double",
+    // struct types
+    "%inner_struct = OpTypeStruct %bool %int %float %double",
+    "%outer_struct = OpTypeStruct %inner_struct %int %double",
+    "%flat_struct = OpTypeStruct %bool %int %float %double",
+    // clang-format on
+};
+
+using EliminateDeadConstantTest =
+    PassTest<::testing::TestWithParam<EliminateDeadConstantTestCase>>;
+
+#ifdef SPIRV_EFFCEE
+TEST_P(EliminateDeadConstantTest, Custom) {
+  auto& tc = GetParam();
+  AssemblyBuilder builder;
+  builder.AppendTypesConstantsGlobals(CommonTypes)
+      .AppendTypesConstantsGlobals(tc.used_consts)
+      .AppendInMain(tc.main_insts);
+  const std::string expected = builder.GetCode();
+  builder.AppendTypesConstantsGlobals(tc.dead_consts);
+  builder.PrependPreamble(tc.checks);
+  const std::string assembly_with_dead_const = builder.GetCode();
+
+  // Do not enable validation.
+  // SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+  //    assembly_with_dead_const, expected, /*  skip_nop = */ true);
+  SinglePassRunAndMatch<opt::AggressiveDCEPass>(assembly_with_dead_const,
+                                                false);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    ScalarTypeConstants, EliminateDeadConstantTest,
+    ::testing::ValuesIn(std::vector<EliminateDeadConstantTestCase>({
+        // clang-format off
+        // Scalar type constants, one dead constant and one used constant.
+        {
+            /* .used_consts = */
+            {
+              "%used_const_int = OpConstant %int 1",
+            },
+            /* .main_insts = */
+            {
+              "%int_var = OpVariable %_pf_int Output",
+              "OpStore %int_var %used_const_int",
+            },
+            /* .dead_consts = */
+            {
+              "%dead_const_int = OpConstant %int 1",
+            },
+            /* .checks = */
+            {
+              "; CHECK: [[const:%\\w+]] = OpConstant %int 1",
+              "; CHECK-NOT: OpConstant",
+              "; CHECK: OpStore {{%\\w+}} [[const]]",
+            },
+        },
+        {
+            /* .used_consts = */
+            {
+              "%used_const_uint = OpConstant %uint 1",
+            },
+            /* .main_insts = */
+            {
+              "%uint_var = OpVariable %_pf_uint Output",
+              "OpStore %uint_var %used_const_uint",
+            },
+            /* .dead_consts = */
+            {
+              "%dead_const_uint = OpConstant %uint 1",
+            },
+            /* .checks = */
+            {
+              "; CHECK: [[const:%\\w+]] = OpConstant %uint 1",
+              "; CHECK-NOT: OpConstant",
+              "; CHECK: OpStore {{%\\w+}} [[const]]",
+            },
+        },
+        {
+            /* .used_consts = */
+            {
+              "%used_const_float = OpConstant %float 3.14",
+            },
+            /* .main_insts = */
+            {
+              "%float_var = OpVariable %_pf_float Output",
+              "OpStore %float_var %used_const_float",
+            },
+            /* .dead_consts = */
+            {
+              "%dead_const_float = OpConstant %float 3.14",
+            },
+            /* .checks = */
+            {
+              "; CHECK: [[const:%\\w+]] = OpConstant %float 3.14",
+              "; CHECK-NOT: OpConstant",
+              "; CHECK: OpStore {{%\\w+}} [[const]]",
+            },
+        },
+        {
+            /* .used_consts = */
+            {
+              "%used_const_double = OpConstant %double 3.14",
+            },
+            /* .main_insts = */
+            {
+              "%double_var = OpVariable %_pf_double Output",
+              "OpStore %double_var %used_const_double",
+            },
+            /* .dead_consts = */
+            {
+              "%dead_const_double = OpConstant %double 3.14",
+            },
+            /* .checks = */
+            {
+              "; CHECK: [[const:%\\w+]] = OpConstant %double 3.14",
+              "; CHECK-NOT: OpConstant",
+              "; CHECK: OpStore {{%\\w+}} [[const]]",
+            },
+        },
+        // clang-format on
+    })));
+
+INSTANTIATE_TEST_CASE_P(
+    VectorTypeConstants, EliminateDeadConstantTest,
+    ::testing::ValuesIn(std::vector<EliminateDeadConstantTestCase>({
+        // clang-format off
+        // Tests eliminating dead constant type ivec2. One dead constant vector
+        // and one used constant vector, each built from its own group of
+        // scalar constants.
+        {
+            /* .used_consts = */
+            {
+              "%used_int_x = OpConstant %int 1",
+              "%used_int_y = OpConstant %int 2",
+              "%used_v2int = OpConstantComposite %v2int %used_int_x %used_int_y",
+            },
+            /* .main_insts = */
+            {
+              "%v2int_var = OpVariable %_pf_v2int Output",
+              "OpStore %v2int_var %used_v2int",
+            },
+            /* .dead_consts = */
+            {
+              "%dead_int_x = OpConstant %int 1",
+              "%dead_int_y = OpConstant %int 2",
+              "%dead_v2int = OpConstantComposite %v2int %dead_int_x %dead_int_y",
+            },
+            /* .checks = */
+            {
+              "; CHECK: [[constx:%\\w+]] = OpConstant %int 1",
+              "; CHECK: [[consty:%\\w+]] = OpConstant %int 2",
+              "; CHECK: [[const:%\\w+]] = OpConstantComposite %v2int [[constx]] [[consty]]",
+              "; CHECK-NOT: OpConstant",
+              "; CHECK: OpStore {{%\\w+}} [[const]]",
+            },
+        },
+        // Tests eliminating dead constant ivec3. One dead constant vector and
+        // one used constant vector. But both built from a same group of
+        // scalar constants.
+        {
+            /* .used_consts = */
+            {
+              "%used_int_x = OpConstant %int 1",
+              "%used_int_y = OpConstant %int 2",
+              "%used_int_z = OpConstant %int 3",
+              "%used_v3int = OpConstantComposite %v3int %used_int_x %used_int_y %used_int_z",
+            },
+            /* .main_insts = */
+            {
+              "%v3int_var = OpVariable %_pf_v3int Output",
+              "OpStore %v3int_var %used_v3int",
+            },
+            /* .dead_consts = */
+            {
+              "%dead_v3int = OpConstantComposite %v3int %used_int_x %used_int_y %used_int_z",
+            },
+            /* .checks = */
+            {
+              "; CHECK: [[constx:%\\w+]] = OpConstant %int 1",
+              "; CHECK: [[consty:%\\w+]] = OpConstant %int 2",
+              "; CHECK: [[constz:%\\w+]] = OpConstant %int 3",
+              "; CHECK: [[const:%\\w+]] = OpConstantComposite %v3int [[constx]] [[consty]] [[constz]]",
+              "; CHECK-NOT: OpConstant",
+              "; CHECK: OpStore {{%\\w+}} [[const]]",
+            },
+        },
+        // Tests eliminating dead constant vec2. One dead constant vector and
+        // one used constant vector. Each built from its own group of scalar
+        // constants.
+        {
+            /* .used_consts = */
+            {
+              "%used_float_x = OpConstant %float 3.14",
+              "%used_float_y = OpConstant %float 4.13",
+              "%used_v2float = OpConstantComposite %v2float %used_float_x %used_float_y",
+            },
+            /* .main_insts = */
+            {
+              "%v2float_var = OpVariable %_pf_v2float Output",
+              "OpStore %v2float_var %used_v2float",
+            },
+            /* .dead_consts = */
+            {
+              "%dead_float_x = OpConstant %float 3.14",
+              "%dead_float_y = OpConstant %float 4.13",
+              "%dead_v2float = OpConstantComposite %v2float %dead_float_x %dead_float_y",
+            },
+            /* .checks = */
+            {
+              "; CHECK: [[constx:%\\w+]] = OpConstant %float 3.14",
+              "; CHECK: [[consty:%\\w+]] = OpConstant %float 4.13",
+              "; CHECK: [[const:%\\w+]] = OpConstantComposite %v2float [[constx]] [[consty]]",
+              "; CHECK-NOT: OpConstant",
+              "; CHECK: OpStore {{%\\w+}} [[const]]",
+            },
+        },
+        // Tests eliminating dead constant vec3. One dead constant vector and
+        // one used constant vector. Both built from a same group of scalar
+        // constants.
+        {
+            /* .used_consts = */
+            {
+              "%used_float_x = OpConstant %float 3.14",
+              "%used_float_y = OpConstant %float 4.13",
+              "%used_float_z = OpConstant %float 4.31",
+              "%used_v3float = OpConstantComposite %v3float %used_float_x %used_float_y %used_float_z",
+            },
+            /* .main_insts = */
+            {
+              "%v3float_var = OpVariable %_pf_v3float Output",
+              "OpStore %v3float_var %used_v3float",
+            },
+            /* .dead_consts = */
+            {
+              "%dead_v3float = OpConstantComposite %v3float %used_float_x %used_float_y %used_float_z",
+            },
+            /* .checks = */
+            {
+              "; CHECK: [[constx:%\\w+]] = OpConstant %float 3.14",
+              "; CHECK: [[consty:%\\w+]] = OpConstant %float 4.13",
+              "; CHECK: [[constz:%\\w+]] = OpConstant %float 4.31",
+              "; CHECK: [[const:%\\w+]] = OpConstantComposite %v3float [[constx]] [[consty]]",
+              "; CHECK-NOT: OpConstant",
+              "; CHECK: OpStore {{%\\w+}} [[const]]",
+            },
+        },
+        // clang-format on
+    })));
+
+INSTANTIATE_TEST_CASE_P(
+    StructTypeConstants, EliminateDeadConstantTest,
+    ::testing::ValuesIn(std::vector<EliminateDeadConstantTestCase>({
+        // clang-format off
+        // A plain struct type dead constants. All of its components are dead
+        // constants too.
+        {
+            /* .used_consts = */ {},
+            /* .main_insts = */ {},
+            /* .dead_consts = */
+            {
+              "%dead_bool = OpConstantTrue %bool",
+              "%dead_int = OpConstant %int 1",
+              "%dead_float = OpConstant %float 2.5",
+              "%dead_double = OpConstant %double 3.14159265358979",
+              "%dead_struct = OpConstantComposite %flat_struct %dead_bool %dead_int %dead_float %dead_double",
+            },
+            /* .checks = */
+            {
+              "; CHECK-NOT: OpConstant",
+            },
+        },
+        // A plain struct type dead constants. Some of its components are dead
+        // constants while others are not.
+        {
+            /* .used_consts = */
+            {
+                "%used_int = OpConstant %int 1",
+                "%used_double = OpConstant %double 3.14159265358979",
+            },
+            /* .main_insts = */
+            {
+                "%int_var = OpVariable %_pf_int Output",
+                "OpStore %int_var %used_int",
+                "%double_var = OpVariable %_pf_double Output",
+                "OpStore %double_var %used_double",
+            },
+            /* .dead_consts = */
+            {
+                "%dead_bool = OpConstantTrue %bool",
+                "%dead_float = OpConstant %float 2.5",
+                "%dead_struct = OpConstantComposite %flat_struct %dead_bool %used_int %dead_float %used_double",
+            },
+            /* .checks = */
+            {
+              "; CHECK: [[int:%\\w+]] = OpConstant %int 1",
+              "; CHECK: [[double:%\\w+]] = OpConstant %double 3.14159265358979",
+              "; CHECK-NOT: OpConstant",
+              "; CHECK: OpStore {{%\\w+}} [[int]]",
+              "; CHECK: OpStore {{%\\w+}} [[double]]",
+            },
+        },
+        // A nesting struct type dead constants. All components of both outer
+        // and inner structs are dead and should be removed after dead constant
+        // elimination.
+        {
+            /* .used_consts = */ {},
+            /* .main_insts = */ {},
+            /* .dead_consts = */
+            {
+              "%dead_bool = OpConstantTrue %bool",
+              "%dead_int = OpConstant %int 1",
+              "%dead_float = OpConstant %float 2.5",
+              "%dead_double = OpConstant %double 3.1415926535",
+              "%dead_inner_struct = OpConstantComposite %inner_struct %dead_bool %dead_int %dead_float %dead_double",
+              "%dead_int2 = OpConstant %int 2",
+              "%dead_double2 = OpConstant %double 1.428571428514",
+              "%dead_outer_struct = OpConstantComposite %outer_struct %dead_inner_struct %dead_int2 %dead_double2",
+            },
+            /* .checks = */
+            {
+              "; CHECK-NOT: OpConstant",
+            },
+        },
+        // A nesting struct type dead constants. Some of its components are
+        // dead constants while others are not.
+        {
+            /* .used_consts = */
+            {
+              "%used_int = OpConstant %int 1",
+              "%used_double = OpConstant %double 3.14159265358979",
+            },
+            /* .main_insts = */
+            {
+              "%int_var = OpVariable %_pf_int Output",
+              "OpStore %int_var %used_int",
+              "%double_var = OpVariable %_pf_double Output",
+              "OpStore %double_var %used_double",
+            },
+            /* .dead_consts = */
+            {
+              "%dead_bool = OpConstantTrue %bool",
+              "%dead_float = OpConstant %float 2.5",
+              "%dead_inner_struct = OpConstantComposite %inner_struct %dead_bool %used_int %dead_float %used_double",
+              "%dead_int = OpConstant %int 2",
+              "%dead_outer_struct = OpConstantComposite %outer_struct %dead_inner_struct %dead_int %used_double",
+            },
+            /* .checks = */
+            {
+              "; CHECK: [[int:%\\w+]] = OpConstant %int 1",
+              "; CHECK: [[double:%\\w+]] = OpConstant %double 3.14159265358979",
+              "; CHECK-NOT: OpConstant",
+              "; CHECK: OpStore {{%\\w+}} [[int]]",
+              "; CHECK: OpStore {{%\\w+}} [[double]]",
+            },
+        },
+        // A nesting struct case. The inner struct is used while the outer struct is not
+        {
+          /* .used_const = */
+          {
+            "%used_bool = OpConstantTrue %bool",
+            "%used_int = OpConstant %int 1",
+            "%used_float = OpConstant %float 1.23",
+            "%used_double = OpConstant %double 1.2345678901234",
+            "%used_inner_struct = OpConstantComposite %inner_struct %used_bool %used_int %used_float %used_double",
+          },
+          /* .main_insts = */
+          {
+            "%bool_var = OpVariable %_pf_bool Output",
+            "%bool_from_inner_struct = OpCompositeExtract %bool %used_inner_struct 0",
+            "OpStore %bool_var %bool_from_inner_struct",
+          },
+          /* .dead_consts = */
+          {
+            "%dead_int = OpConstant %int 2",
+            "%dead_outer_struct = OpConstantComposite %outer_struct %used_inner_struct %dead_int %used_double"
+          },
+          /* .checks = */
+          {
+            "; CHECK: [[bool:%\\w+]] = OpConstantTrue",
+            "; CHECK: [[int:%\\w+]] = OpConstant %int 1",
+            "; CHECK: [[float:%\\w+]] = OpConstant %float 1.23",
+            "; CHECK: [[double:%\\w+]] = OpConstant %double 1.2345678901234",
+            "; CHECK: [[struct:%\\w+]] = OpConstantComposite %inner_struct [[bool]] [[int]] [[float]] [[double]]",
+            "; CHECK-NOT: OpConstant",
+            "; CHECK: OpCompositeExtract %bool [[struct]]",
+          }
+        },
+        // A nesting struct case. The outer struct is used, so the inner struct should not
+        // be removed even though it is not used anywhere.
+        {
+          /* .used_const = */
+          {
+            "%used_bool = OpConstantTrue %bool",
+            "%used_int = OpConstant %int 1",
+            "%used_float = OpConstant %float 1.23",
+            "%used_double = OpConstant %double 1.2345678901234",
+            "%used_inner_struct = OpConstantComposite %inner_struct %used_bool %used_int %used_float %used_double",
+            "%used_outer_struct = OpConstantComposite %outer_struct %used_inner_struct %used_int %used_double"
+          },
+          /* .main_insts = */
+          {
+            "%int_var = OpVariable %_pf_int Output",
+            "%int_from_outer_struct = OpCompositeExtract %int %used_outer_struct 1",
+            "OpStore %int_var %int_from_outer_struct",
+          },
+          /* .dead_consts = */ {},
+          /* .checks = */
+          {
+            "; CHECK: [[bool:%\\w+]] = OpConstantTrue %bool",
+            "; CHECK: [[int:%\\w+]] = OpConstant %int 1",
+            "; CHECK: [[float:%\\w+]] = OpConstant %float 1.23",
+            "; CHECK: [[double:%\\w+]] = OpConstant %double 1.2345678901234",
+            "; CHECK: [[inner_struct:%\\w+]] = OpConstantComposite %inner_struct %used_bool %used_int %used_float %used_double",
+            "; CHECK: [[outer_struct:%\\w+]] = OpConstantComposite %outer_struct %used_inner_struct %used_int %used_double",
+            "; CHECK: OpCompositeExtract %int [[outer_struct]]",
+          },
+        },
+        // clang-format on
+    })));
+
+INSTANTIATE_TEST_CASE_P(
+    ScalarTypeSpecConstants, EliminateDeadConstantTest,
+    ::testing::ValuesIn(std::vector<EliminateDeadConstantTestCase>({
+        // clang-format off
+        // All scalar type spec constants.
+        {
+            /* .used_consts = */
+            {
+              "%used_bool = OpSpecConstantTrue %bool",
+              "%used_uint = OpSpecConstant %uint 2",
+              "%used_int = OpSpecConstant %int 2",
+              "%used_float = OpSpecConstant %float 2.5",
+              "%used_double = OpSpecConstant %double 1.428571428514",
+            },
+            /* .main_insts = */
+            {
+              "%bool_var = OpVariable %_pf_bool Output",
+              "%uint_var = OpVariable %_pf_uint Output",
+              "%int_var = OpVariable %_pf_int Output",
+              "%float_var = OpVariable %_pf_float Output",
+              "%double_var = OpVariable %_pf_double Output",
+              "OpStore %bool_var %used_bool",
+              "OpStore %uint_var %used_uint",
+              "OpStore %int_var %used_int",
+              "OpStore %float_var %used_float",
+              "OpStore %double_var %used_double",
+            },
+            /* .dead_consts = */
+            {
+              "%dead_bool = OpSpecConstantTrue %bool",
+              "%dead_uint = OpSpecConstant %uint 2",
+              "%dead_int = OpSpecConstant %int 2",
+              "%dead_float = OpSpecConstant %float 2.5",
+              "%dead_double = OpSpecConstant %double 1.428571428514",
+            },
+            /* .checks = */
+            {
+              "; CHECK: [[bool:%\\w+]] = OpSpecConstantTrue %bool",
+              "; CHECK: [[uint:%\\w+]] = OpSpecConstant %uint 2",
+              "; CHECK: [[int:%\\w+]] = OpSpecConstant %int 2",
+              "; CHECK: [[float:%\\w+]] = OpSpecConstant %float 2.5",
+              "; CHECK: [[double:%\\w+]] = OpSpecConstant %double 1.428571428514",
+              "; CHECK-NOT: OpSpecConstant",
+              "; CHECK: OpStore {{%\\w+}} [[bool]]",
+              "; CHECK: OpStore {{%\\w+}} [[uint]]",
+              "; CHECK: OpStore {{%\\w+}} [[int]]",
+              "; CHECK: OpStore {{%\\w+}} [[float]]",
+              "; CHECK: OpStore {{%\\w+}} [[double]]",
+            },
+        },
+        // clang-format on
+    })));
+
+INSTANTIATE_TEST_CASE_P(
+    VectorTypeSpecConstants, EliminateDeadConstantTest,
+    ::testing::ValuesIn(std::vector<EliminateDeadConstantTestCase>({
+        // clang-format off
+        // Bool vector type spec constants. One vector has all component dead,
+        // another vector has one dead boolean and one used boolean.
+        {
+            /* .used_consts = */
+            {
+              "%used_bool = OpSpecConstantTrue %bool",
+            },
+            /* .main_insts = */
+            {
+              "%bool_var = OpVariable %_pf_bool Output",
+              "OpStore %bool_var %used_bool",
+            },
+            /* .dead_consts = */
+            {
+              "%dead_bool = OpSpecConstantFalse %bool",
+              "%dead_bool_vec1 = OpSpecConstantComposite %v2bool %dead_bool %dead_bool",
+              "%dead_bool_vec2 = OpSpecConstantComposite %v2bool %dead_bool %used_bool",
+            },
+            /* .checks = */
+            {
+              "; CHECK: [[bool:%\\w+]] = OpSpecConstantTrue %bool",
+              "; CHECK-NOT: OpSpecConstant",
+              "; CHECK: OpStore {{%\\w+}} [[bool]]",
+            },
+        },
+
+        // Uint vector type spec constants. One vector has all component dead,
+        // another vector has one dead unsigend integer and one used unsigned
+        // integer.
+        {
+            /* .used_consts = */
+            {
+              "%used_uint = OpSpecConstant %uint 3",
+            },
+            /* .main_insts = */
+            {
+              "%uint_var = OpVariable %_pf_uint Output",
+              "OpStore %uint_var %used_uint",
+            },
+            /* .dead_consts = */
+            {
+              "%dead_uint = OpSpecConstant %uint 1",
+              "%dead_uint_vec1 = OpSpecConstantComposite %v2uint %dead_uint %dead_uint",
+              "%dead_uint_vec2 = OpSpecConstantComposite %v2uint %dead_uint %used_uint",
+            },
+            /* .checks = */
+            {
+              "; CHECK: [[uint:%\\w+]] = OpSpecConstant %uint 3",
+              "; CHECK-NOT: OpSpecConstant",
+              "; CHECK: OpStore {{%\\w+}} [[uint]]",
+            },
+        },
+
+        // Int vector type spec constants. One vector has all component dead,
+        // another vector has one dead integer and one used integer.
+        {
+            /* .used_consts = */
+            {
+              "%used_int = OpSpecConstant %int 3",
+            },
+            /* .main_insts = */
+            {
+              "%int_var = OpVariable %_pf_int Output",
+              "OpStore %int_var %used_int",
+            },
+            /* .dead_consts = */
+            {
+              "%dead_int = OpSpecConstant %int 1",
+              "%dead_int_vec1 = OpSpecConstantComposite %v2int %dead_int %dead_int",
+              "%dead_int_vec2 = OpSpecConstantComposite %v2int %dead_int %used_int",
+            },
+            /* .checks = */
+            {
+              "; CHECK: [[int:%\\w+]] = OpSpecConstant %int 3",
+              "; CHECK-NOT: OpSpecConstant",
+              "; CHECK: OpStore {{%\\w+}} [[int]]",
+            },
+        },
+
+        // Int vector type spec constants built with both spec constants and
+        // front-end constants.
+        {
+            /* .used_consts = */
+            {
+              "%used_spec_int = OpSpecConstant %int 3",
+              "%used_front_end_int = OpConstant %int 3",
+            },
+            /* .main_insts = */
+            {
+              "%int_var1 = OpVariable %_pf_int Output",
+              "OpStore %int_var1 %used_spec_int",
+              "%int_var2 = OpVariable %_pf_int Output",
+              "OpStore %int_var2 %used_front_end_int",
+            },
+            /* .dead_consts = */
+            {
+              "%dead_spec_int = OpSpecConstant %int 1",
+              "%dead_front_end_int = OpConstant %int 1",
+              // Dead front-end and dead spec constants
+              "%dead_int_vec1 = OpSpecConstantComposite %v2int %dead_spec_int %dead_front_end_int",
+              // Used front-end and dead spec constants
+              "%dead_int_vec2 = OpSpecConstantComposite %v2int %dead_spec_int %used_front_end_int",
+              // Dead front-end and used spec constants
+              "%dead_int_vec3 = OpSpecConstantComposite %v2int %dead_front_end_int %used_spec_int",
+            },
+            /* .checks = */
+            {
+              "; CHECK: [[int1:%\\w+]] = OpSpecConstant %int 3",
+              "; CHECK: [[int2:%\\w+]] = OpConstant %int 3",
+              "; CHECK-NOT: OpSpecConstant",
+              "; CHECK-NOT: OpConstant",
+              "; CHECK: OpStore {{%\\w+}} [[int1]]",
+              "; CHECK: OpStore {{%\\w+}} [[int2]]",
+            },
+        },
+        // clang-format on
+    })));
+
+INSTANTIATE_TEST_CASE_P(
+    SpecConstantOp, EliminateDeadConstantTest,
+    ::testing::ValuesIn(std::vector<EliminateDeadConstantTestCase>({
+        // clang-format off
+        // Cast operations: uint <-> int <-> bool
+        {
+            /* .used_consts = */ {},
+            /* .main_insts = */ {},
+            /* .dead_consts = */
+            {
+              // Assistant constants, only used in dead spec constant
+              // operations.
+              "%signed_zero = OpConstant %int 0",
+              "%signed_zero_vec = OpConstantComposite %v2int %signed_zero %signed_zero",
+              "%unsigned_zero = OpConstant %uint 0",
+              "%unsigned_zero_vec = OpConstantComposite %v2uint %unsigned_zero %unsigned_zero",
+              "%signed_one = OpConstant %int 1",
+              "%signed_one_vec = OpConstantComposite %v2int %signed_one %signed_one",
+              "%unsigned_one = OpConstant %uint 1",
+              "%unsigned_one_vec = OpConstantComposite %v2uint %unsigned_one %unsigned_one",
+
+              // Spec constants that support casting to each other.
+              "%dead_bool = OpSpecConstantTrue %bool",
+              "%dead_uint = OpSpecConstant %uint 1",
+              "%dead_int = OpSpecConstant %int 2",
+              "%dead_bool_vec = OpSpecConstantComposite %v2bool %dead_bool %dead_bool",
+              "%dead_uint_vec = OpSpecConstantComposite %v2uint %dead_uint %dead_uint",
+              "%dead_int_vec = OpSpecConstantComposite %v2int %dead_int %dead_int",
+
+              // Scalar cast to boolean spec constant.
+              "%int_to_bool = OpSpecConstantOp %bool INotEqual %dead_int %signed_zero",
+              "%uint_to_bool = OpSpecConstantOp %bool INotEqual %dead_uint %unsigned_zero",
+
+              // Vector cast to boolean spec constant.
+              "%int_to_bool_vec = OpSpecConstantOp %v2bool INotEqual %dead_int_vec %signed_zero_vec",
+              "%uint_to_bool_vec = OpSpecConstantOp %v2bool INotEqual %dead_uint_vec %unsigned_zero_vec",
+
+              // Scalar cast to int spec constant.
+              "%bool_to_int = OpSpecConstantOp %int Select %dead_bool %signed_one %signed_zero",
+              "%uint_to_int = OpSpecConstantOp %uint IAdd %dead_uint %unsigned_zero",
+
+              // Vector cast to int spec constant.
+              "%bool_to_int_vec = OpSpecConstantOp %v2int Select %dead_bool_vec %signed_one_vec %signed_zero_vec",
+              "%uint_to_int_vec = OpSpecConstantOp %v2uint IAdd %dead_uint_vec %unsigned_zero_vec",
+
+              // Scalar cast to uint spec constant.
+              "%bool_to_uint = OpSpecConstantOp %uint Select %dead_bool %unsigned_one %unsigned_zero",
+              "%int_to_uint_vec = OpSpecConstantOp %uint IAdd %dead_int %signed_zero",
+
+              // Vector cast to uint spec constant.
+              "%bool_to_uint_vec = OpSpecConstantOp %v2uint Select %dead_bool_vec %unsigned_one_vec %unsigned_zero_vec",
+              "%int_to_uint = OpSpecConstantOp %v2uint IAdd %dead_int_vec %signed_zero_vec",
+            },
+            /* .checks = */
+            {
+              "; CHECK-NOT: OpConstant",
+              "; CHECK-NOT: OpSpecConstant",
+            },
+        },
+
+        // Add, sub, mul, div, rem.
+        {
+            /* .used_consts = */ {},
+            /* .main_insts = */ {},
+            /* .dead_consts = */
+            {
+              "%dead_spec_int_a = OpSpecConstant %int 1",
+              "%dead_spec_int_a_vec = OpSpecConstantComposite %v2int %dead_spec_int_a %dead_spec_int_a",
+
+              "%dead_spec_int_b = OpSpecConstant %int 2",
+              "%dead_spec_int_b_vec = OpSpecConstantComposite %v2int %dead_spec_int_b %dead_spec_int_b",
+
+              "%dead_const_int_c = OpConstant %int 3",
+              "%dead_const_int_c_vec = OpConstantComposite %v2int %dead_const_int_c %dead_const_int_c",
+
+              // Add
+              "%add_a_b = OpSpecConstantOp %int IAdd %dead_spec_int_a %dead_spec_int_b",
+              "%add_a_b_vec = OpSpecConstantOp %v2int IAdd %dead_spec_int_a_vec %dead_spec_int_b_vec",
+
+              // Sub
+              "%sub_a_b = OpSpecConstantOp %int ISub %dead_spec_int_a %dead_spec_int_b",
+              "%sub_a_b_vec = OpSpecConstantOp %v2int ISub %dead_spec_int_a_vec %dead_spec_int_b_vec",
+
+              // Mul
+              "%mul_a_b = OpSpecConstantOp %int IMul %dead_spec_int_a %dead_spec_int_b",
+              "%mul_a_b_vec = OpSpecConstantOp %v2int IMul %dead_spec_int_a_vec %dead_spec_int_b_vec",
+
+              // Div
+              "%div_a_b = OpSpecConstantOp %int SDiv %dead_spec_int_a %dead_spec_int_b",
+              "%div_a_b_vec = OpSpecConstantOp %v2int SDiv %dead_spec_int_a_vec %dead_spec_int_b_vec",
+
+              // Bitwise Xor
+              "%xor_a_b = OpSpecConstantOp %int BitwiseXor %dead_spec_int_a %dead_spec_int_b",
+              "%xor_a_b_vec = OpSpecConstantOp %v2int BitwiseXor %dead_spec_int_a_vec %dead_spec_int_b_vec",
+
+              // Scalar Comparison
+              "%less_a_b = OpSpecConstantOp %bool SLessThan %dead_spec_int_a %dead_spec_int_b",
+            },
+            /* .checks = */
+            {
+              "; CHECK-NOT: OpConstant",
+              "; CHECK-NOT: OpSpecConstant",
+            },
+        },
+
+        // Vectors without used swizzles should be removed.
+        {
+            /* .used_consts = */
+            {
+              "%used_int = OpConstant %int 3",
+            },
+            /* .main_insts = */
+            {
+              "%int_var = OpVariable %_pf_int Output",
+              "OpStore %int_var %used_int",
+            },
+            /* .dead_consts = */
+            {
+              "%dead_int = OpConstant %int 3",
+
+              "%dead_spec_int_a = OpSpecConstant %int 1",
+              "%vec_a = OpSpecConstantComposite %v4int %dead_spec_int_a %dead_spec_int_a %dead_int %dead_int",
+
+              "%dead_spec_int_b = OpSpecConstant %int 2",
+              "%vec_b = OpSpecConstantComposite %v4int %dead_spec_int_b %dead_spec_int_b %used_int %used_int",
+
+              // Extract scalar
+              "%a_x = OpSpecConstantOp %int CompositeExtract %vec_a 0",
+              "%b_x = OpSpecConstantOp %int CompositeExtract %vec_b 0",
+
+              // Extract vector
+              "%a_xy = OpSpecConstantOp %v2int VectorShuffle %vec_a %vec_a 0 1",
+              "%b_xy = OpSpecConstantOp %v2int VectorShuffle %vec_b %vec_b 0 1",
+            },
+            /* .checks = */
+            {
+              "; CHECK: [[int:%\\w+]] = OpConstant %int 3",
+              "; CHECK-NOT: OpConstant",
+              "; CHECK-NOT: OpSpecConstant",
+              "; CHECK: OpStore {{%\\w+}} [[int]]",
+            },
+        },
+        // Vectors with used swizzles should not be removed.
+        {
+            /* .used_consts = */
+            {
+              "%used_int = OpConstant %int 3",
+              "%used_spec_int_a = OpSpecConstant %int 1",
+              "%used_spec_int_b = OpSpecConstant %int 2",
+              // Create vectors
+              "%vec_a = OpSpecConstantComposite %v4int %used_spec_int_a %used_spec_int_a %used_int %used_int",
+              "%vec_b = OpSpecConstantComposite %v4int %used_spec_int_b %used_spec_int_b %used_int %used_int",
+              // Extract vector
+              "%a_xy = OpSpecConstantOp %v2int VectorShuffle %vec_a %vec_a 0 1",
+              "%b_xy = OpSpecConstantOp %v2int VectorShuffle %vec_b %vec_b 0 1",
+            },
+            /* .main_insts = */
+            {
+              "%v2int_var_a = OpVariable %_pf_v2int Output",
+              "%v2int_var_b = OpVariable %_pf_v2int Output",
+              "OpStore %v2int_var_a %a_xy",
+              "OpStore %v2int_var_b %b_xy",
+            },
+            /* .dead_consts = */ {},
+            /* .checks = */
+            {
+              "; CHECK: [[int:%\\w+]] = OpConstant %int 3",
+              "; CHECK: [[a:%\\w+]] = OpSpecConstant %int 1",
+              "; CHECK: [[b:%\\w+]] = OpSpecConstant %int 2",
+              "; CHECK: [[veca:%\\w+]] = OpSpecConstantComposite %v4int [[a]] [[a]] [[int]] [[int]]",
+              "; CHECK: [[vecb:%\\w+]] = OpSpecConstantComposite %v4int [[b]] [[b]] [[int]] [[int]]",
+              "; CHECK: [[exa:%\\w+]] = OpSpecConstantOp %v2int VectorShuffle [[veca]] [[veca]] 0 1",
+              "; CHECK: [[exb:%\\w+]] = OpSpecConstantOp %v2int VectorShuffle [[vecb]] [[vecb]] 0 1",
+              "; CHECK-NOT: OpConstant",
+              "; CHECK-NOT: OpSpecConstant",
+              "; CHECK: OpStore {{%\\w+}} [[exa]]",
+              "; CHECK: OpStore {{%\\w+}} [[exb]]",
+            },
+        },
+        // clang-format on
+    })));
+
+INSTANTIATE_TEST_CASE_P(
+    LongDefUseChain, EliminateDeadConstantTest,
+    ::testing::ValuesIn(std::vector<EliminateDeadConstantTestCase>({
+        // clang-format off
+        // Long Def-Use chain with binary operations.
+        {
+            /* .used_consts = */
+            {
+              "%array_size = OpConstant %int 4",
+              "%type_arr_int_4 = OpTypeArray %int %array_size",
+              "%used_int_0 = OpConstant %int 100",
+              "%used_int_1 = OpConstant %int 1",
+              "%used_int_2 = OpSpecConstantOp %int IAdd %used_int_0 %used_int_1",
+              "%used_int_3 = OpSpecConstantOp %int ISub %used_int_0 %used_int_2",
+              "%used_int_4 = OpSpecConstantOp %int IAdd %used_int_0 %used_int_3",
+              "%used_int_5 = OpSpecConstantOp %int ISub %used_int_0 %used_int_4",
+              "%used_int_6 = OpSpecConstantOp %int IAdd %used_int_0 %used_int_5",
+              "%used_int_7 = OpSpecConstantOp %int ISub %used_int_0 %used_int_6",
+              "%used_int_8 = OpSpecConstantOp %int IAdd %used_int_0 %used_int_7",
+              "%used_int_9 = OpSpecConstantOp %int ISub %used_int_0 %used_int_8",
+              "%used_int_10 = OpSpecConstantOp %int IAdd %used_int_0 %used_int_9",
+              "%used_int_11 = OpSpecConstantOp %int ISub %used_int_0 %used_int_10",
+              "%used_int_12 = OpSpecConstantOp %int IAdd %used_int_0 %used_int_11",
+              "%used_int_13 = OpSpecConstantOp %int ISub %used_int_0 %used_int_12",
+              "%used_int_14 = OpSpecConstantOp %int IAdd %used_int_0 %used_int_13",
+              "%used_int_15 = OpSpecConstantOp %int ISub %used_int_0 %used_int_14",
+              "%used_int_16 = OpSpecConstantOp %int ISub %used_int_0 %used_int_15",
+              "%used_int_17 = OpSpecConstantOp %int IAdd %used_int_0 %used_int_16",
+              "%used_int_18 = OpSpecConstantOp %int ISub %used_int_0 %used_int_17",
+              "%used_int_19 = OpSpecConstantOp %int IAdd %used_int_0 %used_int_18",
+              "%used_int_20 = OpSpecConstantOp %int ISub %used_int_0 %used_int_19",
+              "%used_vec_a = OpSpecConstantComposite %v2int %used_int_18 %used_int_19",
+              "%used_vec_b = OpSpecConstantOp %v2int IMul %used_vec_a %used_vec_a",
+              "%used_int_21 = OpSpecConstantOp %int CompositeExtract %used_vec_b 0",
+              "%used_array = OpConstantComposite %type_arr_int_4 %used_int_20 %used_int_20 %used_int_21 %used_int_21",
+            },
+            /* .main_insts = */
+            {
+              "%int_var = OpVariable %_pf_int Output",
+              "%used_array_2 = OpCompositeExtract %int %used_array 2",
+              "OpStore %int_var %used_array_2",
+            },
+            /* .dead_consts = */
+            {
+              "%dead_int_1 = OpConstant %int 2",
+              "%dead_int_2 = OpSpecConstantOp %int IAdd %used_int_0 %dead_int_1",
+              "%dead_int_3 = OpSpecConstantOp %int ISub %used_int_0 %dead_int_2",
+              "%dead_int_4 = OpSpecConstantOp %int IAdd %used_int_0 %dead_int_3",
+              "%dead_int_5 = OpSpecConstantOp %int ISub %used_int_0 %dead_int_4",
+              "%dead_int_6 = OpSpecConstantOp %int IAdd %used_int_0 %dead_int_5",
+              "%dead_int_7 = OpSpecConstantOp %int ISub %used_int_0 %dead_int_6",
+              "%dead_int_8 = OpSpecConstantOp %int IAdd %used_int_0 %dead_int_7",
+              "%dead_int_9 = OpSpecConstantOp %int ISub %used_int_0 %dead_int_8",
+              "%dead_int_10 = OpSpecConstantOp %int IAdd %used_int_0 %dead_int_9",
+              "%dead_int_11 = OpSpecConstantOp %int ISub %used_int_0 %dead_int_10",
+              "%dead_int_12 = OpSpecConstantOp %int IAdd %used_int_0 %dead_int_11",
+              "%dead_int_13 = OpSpecConstantOp %int ISub %used_int_0 %dead_int_12",
+              "%dead_int_14 = OpSpecConstantOp %int IAdd %used_int_0 %dead_int_13",
+              "%dead_int_15 = OpSpecConstantOp %int ISub %used_int_0 %dead_int_14",
+              "%dead_int_16 = OpSpecConstantOp %int ISub %used_int_0 %dead_int_15",
+              "%dead_int_17 = OpSpecConstantOp %int IAdd %used_int_0 %dead_int_16",
+              "%dead_int_18 = OpSpecConstantOp %int ISub %used_int_0 %dead_int_17",
+              "%dead_int_19 = OpSpecConstantOp %int IAdd %used_int_0 %dead_int_18",
+              "%dead_int_20 = OpSpecConstantOp %int ISub %used_int_0 %dead_int_19",
+              "%dead_vec_a = OpSpecConstantComposite %v2int %dead_int_18 %dead_int_19",
+              "%dead_vec_b = OpSpecConstantOp %v2int IMul %dead_vec_a %dead_vec_a",
+              "%dead_int_21 = OpSpecConstantOp %int CompositeExtract %dead_vec_b 0",
+              "%dead_array = OpConstantComposite %type_arr_int_4 %dead_int_20 %used_int_20 %dead_int_19 %used_int_19",
+            },
+            /* .checks = */
+            {
+              "; CHECK: OpConstant %int 4",
+              "; CHECK: [[array:%\\w+]] = OpConstantComposite %type_arr_int_4 %used_int_20 %used_int_20 %used_int_21 %used_int_21",
+              "; CHECK-NOT: OpConstant",
+              "; CHECK-NOT: OpSpecConstant",
+              "; CHECK: OpStore {{%\\w+}} [[array]]",
+            },
+        },
+        // Long Def-Use chain with swizzle
+        // clang-format on
+    })));
+#endif  // SPIRV_EFFCEE
 
 // TODO(greg-lunarg): Add tests to verify handling of these cases:
 //

--- a/test/opt/aggressive_dead_code_elim_test.cpp
+++ b/test/opt/aggressive_dead_code_elim_test.cpp
@@ -4056,9 +4056,8 @@ TEST_P(EliminateDeadConstantTest, Custom) {
   builder.PrependPreamble(tc.checks);
   const std::string assembly_with_dead_const = builder.GetCode();
 
-  // Do not enable validation.
-  // SinglePassRunAndCheck<opt::AggressiveDCEPass>(
-  //    assembly_with_dead_const, expected, /*  skip_nop = */ true);
+  // Do not enable validation. As the input code is invalid from the base
+  // tests (ported from other passes).
   SinglePassRunAndMatch<opt::AggressiveDCEPass>(assembly_with_dead_const,
                                                 false);
 }
@@ -4893,6 +4892,8 @@ INSTANTIATE_TEST_CASE_P(
     })));
 
 TEST_F(AggressiveDCETest, DeadDecorationGroup) {
+  // The decoration group should be eliminated because the target of group
+  // decorate is dead.
   const std::string text = R"(
 ; CHECK-NOT: OpDecorat
 ; CHECK-NOT: OpGroupDecorate

--- a/test/opt/assembly_builder.h
+++ b/test/opt/assembly_builder.h
@@ -154,9 +154,18 @@ class AssemblyBuilder {
     return *this;
   }
 
+  // Pre-pends string to the preamble of the module. Useful for EFFCEE checks.
+  AssemblyBuilder& PrependPreamble(const std::vector<std::string>& preamble) {
+    preamble_.insert(preamble_.end(), preamble.begin(), preamble.end());
+    return *this;
+  }
+
   // Get the SPIR-V assembly code as string.
   std::string GetCode() const {
     std::ostringstream ss;
+    for (const auto& line : preamble_) {
+      ss << line << std::endl;
+    }
     for (const auto& line : global_preamble_) {
       ss << line << std::endl;
     }
@@ -230,6 +239,8 @@ class AssemblyBuilder {
   }
 
   uint32_t spec_id_counter_;
+  // User-defined preamble.
+  std::vector<std::string> preamble_;
   // The vector that contains common preambles shared across all test SPIR-V
   // code.
   std::vector<std::string> global_preamble_;


### PR DESCRIPTION
Addresses #906.

The merges the functionality of dead variable elimination, dead constant elimination and dead function elimination into ADCE. I have ported the tests applicable tests from those passes into ADCE's tests. Some changes were made (see code comments) because ADCE only supports shader capability right now. Support for general modules should be handled in separate pull request.

I removed the dead insts set and replaced it with a vector. Dead instructions are now calculated instead of queried because of the change to how ADCE operates (more globally).
