### PR TITLE
Address remaining comments from the linker pull request

### DIFF
--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -31,6 +31,10 @@ using MessageConsumer = std::function<void(
     const spv_position_t& /* position */, const char* /* message */
     )>;
 
+// Create a context with the targeted environemnt |env| and set its message
+// consumer to |consumer|.
+spv_context CreateContext(spv_target_env env, MessageConsumer consumer);
+
 // A RAII wrapper around a validator options object.
 class ValidatorOptions {
  public:

--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -31,9 +31,38 @@ using MessageConsumer = std::function<void(
     const spv_position_t& /* position */, const char* /* message */
     )>;
 
-// Create a context with the targeted environemnt |env| and set its message
-// consumer to |consumer|.
-spv_context CreateContext(spv_target_env env, MessageConsumer consumer);
+// C++ RAII wrapper around the C context object spv_context.
+class Context {
+ public:
+  // Constructs a context targeting the given environment |env|.
+  //
+  // The constructed instance will have an empty message consumer, which just
+  // ignores all messages from the library. Use SetMessageConsumer() to supply
+  // one if messages are of concern.
+  explicit Context(spv_target_env env);
+
+  // Enables move constructor/assignment operations.
+  Context(Context&& other);
+  Context& operator=(Context&& other);
+
+  // Disables copy constructor/assignment operations.
+  Context(const Context&) = delete;
+  Context& operator=(const Context&) = delete;
+
+  // Destructs this instance.
+  ~Context();
+
+  // Sets the message consumer to the given |consumer|. The |consumer| will be
+  // invoked once for each message communicated from the library.
+  void SetMessageConsumer(MessageConsumer consumer);
+
+  // Returns the underlying spv_context.
+  spv_context& CContext();
+  const spv_context& CContext() const;
+
+ private:
+  spv_context context_;
+};
 
 // A RAII wrapper around a validator options object.
 class ValidatorOptions {

--- a/include/spirv-tools/linker.hpp
+++ b/include/spirv-tools/linker.hpp
@@ -26,7 +26,7 @@ namespace spvtools {
 
 class LinkerOptions {
  public:
-  LinkerOptions() : createLibrary_(false), verifyIds_(false) {}
+  LinkerOptions() : create_library_(false), verify_ids_(false) {}
 
   // Returns whether a library or an executable should be produced by the
   // linking phase.
@@ -35,24 +35,24 @@ class LinkerOptions {
   // be removed when creating an executable.
   // The returned value will be true if creating a library, and false if
   // creating an executable.
-  bool GetCreateLibrary() const { return createLibrary_; }
+  bool GetCreateLibrary() const { return create_library_; }
 
   // Sets whether a library or an executable should be produced.
   void SetCreateLibrary(bool create_library) {
-    createLibrary_ = create_library;
+    create_library_ = create_library;
   }
 
   // Returns whether to verify the uniqueness of the unique ids in the merged
   // context.
-  bool GetVerifyIds() const { return verifyIds_; }
+  bool GetVerifyIds() const { return verify_ids_; }
 
   // Sets whether to verify the uniqueness of the unique ids in the merged
   // context.
-  void SetVerifyIds(bool verifyIds) { verifyIds_ = verifyIds; }
+  void SetVerifyIds(bool verify_ids) { verify_ids_ = verify_ids; }
 
  private:
-  bool createLibrary_;
-  bool verifyIds_;
+  bool create_library_;
+  bool verify_ids_;
 };
 
 // Links one or more SPIR-V modules into a new SPIR-V module. That is, combine

--- a/include/spirv-tools/linker.hpp
+++ b/include/spirv-tools/linker.hpp
@@ -26,9 +26,7 @@ namespace spvtools {
 
 class LinkerOptions {
  public:
-  LinkerOptions()
-      : createLibrary_(false),
-        verifyIds_(false) {}
+  LinkerOptions() : createLibrary_(false), verifyIds_(false) {}
 
   // Returns whether a library or an executable should be produced by the
   // linking phase.
@@ -50,62 +48,35 @@ class LinkerOptions {
 
   // Sets whether to verify the uniqueness of the unique ids in the merged
   // context.
-  void SetVerifyIds(bool verifyIds) {
-    verifyIds_ = verifyIds;
-  }
+  void SetVerifyIds(bool verifyIds) { verifyIds_ = verifyIds; }
 
  private:
   bool createLibrary_;
   bool verifyIds_;
 };
 
-class Linker {
- public:
-  // Constructs an instance targeting the given environment |env|.
-  //
-  // The constructed instance will have an empty message consumer, which just
-  // ignores all messages from the library. Use SetMessageConsumer() to supply
-  // one if messages are of concern.
-  explicit Linker(spv_target_env env);
-
-  // Disables copy/move constructor/assignment operations.
-  Linker(const Linker&) = delete;
-  Linker(Linker&&) = delete;
-  Linker& operator=(const Linker&) = delete;
-  Linker& operator=(Linker&&) = delete;
-
-  // Destructs this instance.
-  ~Linker();
-
-  // Sets the message consumer to the given |consumer|. The |consumer| will be
-  // invoked once for each message communicated from the library.
-  void SetMessageConsumer(MessageConsumer consumer);
-
-  // Links one or more SPIR-V modules into a new SPIR-V module. That is,
-  // combine several SPIR-V modules into one, resolving link dependencies
-  // between them.
-  //
-  // At least one binary has to be provided in |binaries|. Those binaries do
-  // not have to be valid, but they should be at least parseable.
-  // The functions can fail due to the following:
-  // * No input modules were given;
-  // * One or more of those modules were not parseable;
-  // * The input modules used different addressing or memory models;
-  // * The ID or global variable number limit were exceeded;
-  // * Some entry points were defined multiple times;
-  // * Some imported symbols did not have an exported counterpart;
-  // * Possibly other reasons.
-  spv_result_t Link(const std::vector<std::vector<uint32_t>>& binaries,
-                    std::vector<uint32_t>& linked_binary,
-                    const LinkerOptions& options = LinkerOptions()) const;
-  spv_result_t Link(const uint32_t* const* binaries, const size_t* binary_sizes,
-                    size_t num_binaries, std::vector<uint32_t>& linked_binary,
-                    const LinkerOptions& options = LinkerOptions()) const;
-
- private:
-  struct Impl;  // Opaque struct for holding the data fields used by this class.
-  std::unique_ptr<Impl> impl_;  // Unique pointer to implementation data.
-};
+// Links one or more SPIR-V modules into a new SPIR-V module. That is, combine
+// several SPIR-V modules into one, resolving link dependencies between them.
+//
+// At least one binary has to be provided in |binaries|. Those binaries do not
+// have to be valid, but they should be at least parseable.
+// The functions can fail due to the following:
+// * The given context was not initialised using `spvContextCreate()`;
+// * No input modules were given;
+// * One or more of those modules were not parseable;
+// * The input modules used different addressing or memory models;
+// * The ID or global variable number limit were exceeded;
+// * Some entry points were defined multiple times;
+// * Some imported symbols did not have an exported counterpart;
+// * Possibly other reasons.
+spv_result_t Link(const spv_context& context,
+                  const std::vector<std::vector<uint32_t>>& binaries,
+                  std::vector<uint32_t>* linked_binary,
+                  const LinkerOptions& options = LinkerOptions());
+spv_result_t Link(const spv_context& context, const uint32_t* const* binaries,
+                  const size_t* binary_sizes, size_t num_binaries,
+                  std::vector<uint32_t>* linked_binary,
+                  const LinkerOptions& options = LinkerOptions());
 
 }  // namespace spvtools
 

--- a/include/spirv-tools/linker.hpp
+++ b/include/spirv-tools/linker.hpp
@@ -69,11 +69,11 @@ class LinkerOptions {
 // * Some entry points were defined multiple times;
 // * Some imported symbols did not have an exported counterpart;
 // * Possibly other reasons.
-spv_result_t Link(const spv_context& context,
+spv_result_t Link(const Context& context,
                   const std::vector<std::vector<uint32_t>>& binaries,
                   std::vector<uint32_t>* linked_binary,
                   const LinkerOptions& options = LinkerOptions());
-spv_result_t Link(const spv_context& context, const uint32_t* const* binaries,
+spv_result_t Link(const Context& context, const uint32_t* const* binaries,
                   const size_t* binary_sizes, size_t num_binaries,
                   std::vector<uint32_t>* linked_binary,
                   const LinkerOptions& options = LinkerOptions());

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -404,7 +404,12 @@ Optimizer::PassToken CreateAggressiveDCEPass();
 // The pass remaps result ids to a compact and gapless range starting from %1.
 Optimizer::PassToken CreateCompactIdsPass();
 
-// Creates a remove duplicate capabilities pass.
+// Creates a remove duplicate pass.
+// This pass removes various duplicates:
+// * duplicate capabilities;
+// * duplicate extended instruction imports;
+// * duplicate types;
+// * duplicate decorations.
 Optimizer::PassToken CreateRemoveDuplicatesPass();
 
 // Creates a CFG cleanup pass.

--- a/source/libspirv.cpp
+++ b/source/libspirv.cpp
@@ -18,6 +18,30 @@
 
 namespace spvtools {
 
+Context::Context(spv_target_env env) : context_(spvContextCreate(env)) {}
+
+Context::Context(Context&& other) : context_(other.context_) {
+  other.context_ = nullptr;
+}
+
+Context& Context::operator=(Context&& other) {
+  spvContextDestroy(context_);
+  context_ = other.context_;
+  other.context_ = nullptr;
+
+  return *this;
+}
+
+Context::~Context() { spvContextDestroy(context_); }
+
+void Context::SetMessageConsumer(MessageConsumer consumer) {
+  libspirv::SetContextMessageConsumer(context_, std::move(consumer));
+}
+
+spv_context& Context::CContext() { return context_; }
+
+const spv_context& Context::CContext() const { return context_; }
+
 // Structs for holding the data members for SpvTools.
 struct SpirvTools::Impl {
   explicit Impl(spv_target_env env) : context(spvContextCreate(env)) {

--- a/source/link/linker.cpp
+++ b/source/link/linker.cpp
@@ -165,8 +165,7 @@ spv_result_t Link(const spv_context& context, const uint32_t* const* binaries,
                   const size_t* binary_sizes, size_t num_binaries,
                   std::vector<uint32_t>* linked_binary,
                   const LinkerOptions& options) {
-  if (context == nullptr)
-    return SPV_ERROR_INVALID_POINTER;
+  if (context == nullptr) return SPV_ERROR_INVALID_POINTER;
 
   spv_position_t position = {};
   const MessageConsumer& consumer = context->consumer;
@@ -616,21 +615,9 @@ static spv_result_t CheckImportExportCompatibility(
              << linking_entry.exported_symbol.id << ".";
     // TODO(pierremoreau): Decorations on function parameters should probably
     //                     match, except for FuncParamAttr if I understand the
-    //                     spec correctly, which makes the code more
-    //                     complicated.
-    //    for (uint32_t i = 0u; i <
-    //    linking_entry.imported_symbol.parameter_ids.size(); ++i)
-    //      if
-    //      (!decoration_manager.HaveTheSameDecorations(linking_entry.imported_symbol.parameter_ids[i],
-    //      linking_entry.exported_symbol.parameter_ids[i]))
-    //          return libspirv::DiagnosticStream(position,
-    //          impl_->context->consumer,
-    //                                            SPV_ERROR_INVALID_BINARY)
-    //                 << "Decorations mismatch between imported function %" <<
-    //                 linking_entry.imported_symbol.id << "'s"
-    //                 << " and exported function %" <<
-    //                 linking_entry.exported_symbol.id << "'s " << (i + 1u) <<
-    //                 "th parameter.";
+    //                     spec correctly.
+    // TODO(pierremoreau): Decorations on the function return type should
+    //                     match, except for FuncParamAttr.
   }
 
   return SPV_SUCCESS;
@@ -654,6 +641,9 @@ static spv_result_t RemoveLinkageSpecificInstructions(
                                       SPV_ERROR_INVALID_DATA)
            << "|linked_module| of RemoveLinkageSpecificInstructions should not "
               "be empty.";
+
+  // TODO(pierremoreau): Remove FuncParamAttr decorations of imported
+  // functions' return type.
 
   // Remove FuncParamAttr decorations of imported functions' parameters.
   // From the SPIR-V specification, Sec. 2.13:

--- a/source/link/linker.cpp
+++ b/source/link/linker.cpp
@@ -566,11 +566,11 @@ static spv_result_t GetImportExportPairs(
     if (possible_exports.empty())
       return libspirv::DiagnosticStream(position, consumer,
                                         SPV_ERROR_INVALID_BINARY)
-             << "No export linkage was found for \"" << import.name << "\".";
+             << "Unresolved external reference to \"" << import.name << "\".";
     else if (possible_exports.size() > 1u)
       return libspirv::DiagnosticStream(position, consumer,
                                         SPV_ERROR_INVALID_BINARY)
-             << "Too many export linkages, " << possible_exports.size()
+             << "Too many external references, " << possible_exports.size()
              << ", were found for \"" << import.name << "\".";
 
     linkings_to_do->emplace_back(import, possible_exports.front());
@@ -594,7 +594,9 @@ static spv_result_t CheckImportExportCompatibility(
             context))
       return libspirv::DiagnosticStream(position, consumer,
                                         SPV_ERROR_INVALID_BINARY)
-             << "Type mismatch between imported variable/function %"
+             << "Type mismatch on symbol \""
+             << linking_entry.imported_symbol.name
+             << "\" between imported variable/function %"
              << linking_entry.imported_symbol.id
              << " and exported variable/function %"
              << linking_entry.exported_symbol.id << ".";
@@ -606,7 +608,9 @@ static spv_result_t CheckImportExportCompatibility(
             linking_entry.imported_symbol.id, linking_entry.exported_symbol.id))
       return libspirv::DiagnosticStream(position, consumer,
                                         SPV_ERROR_INVALID_BINARY)
-             << "Decorations mismatch between imported variable/function %"
+             << "Decorations mismatch on symbol \""
+             << linking_entry.imported_symbol.name
+             << "\" between imported variable/function %"
              << linking_entry.imported_symbol.id
              << " and exported variable/function %"
              << linking_entry.exported_symbol.id << ".";

--- a/source/link/linker.cpp
+++ b/source/link/linker.cpp
@@ -89,12 +89,12 @@ static spv_result_t GenerateHeader(const MessageConsumer& consumer,
                                    uint32_t max_id_bound,
                                    ir::ModuleHeader* header);
 
-// Merge all the modules from |inModules| into a single module owned by
+// Merge all the modules from |in_modules| into a single module owned by
 // |linked_context|.
 //
 // |linked_context| should not be null.
 static spv_result_t MergeModules(const MessageConsumer& consumer,
-                                 const std::vector<Module*>& inModules,
+                                 const std::vector<Module*>& in_modules,
                                  const libspirv::AssemblyGrammar& grammar,
                                  IRContext* linked_context);
 
@@ -177,7 +177,7 @@ spv_result_t Link(const spv_context& context, const uint32_t* const* binaries,
                                       SPV_ERROR_INVALID_BINARY)
            << "No modules were given.";
 
-  std::vector<std::unique_ptr<IRContext>> irContexts;
+  std::vector<std::unique_ptr<IRContext>> ir_contexts;
   std::vector<Module*> modules;
   modules.reserve(num_binaries);
   for (size_t i = 0u; i < num_binaries; ++i) {
@@ -189,14 +189,14 @@ spv_result_t Link(const spv_context& context, const uint32_t* const* binaries,
              << "Schema is non-zero for module " << i << ".";
     }
 
-    std::unique_ptr<IRContext> irContext = BuildModule(
+    std::unique_ptr<IRContext> ir_context = BuildModule(
         context->target_env, consumer, binaries[i], binary_sizes[i]);
-    if (irContext == nullptr)
+    if (ir_context == nullptr)
       return libspirv::DiagnosticStream(position, consumer,
                                         SPV_ERROR_INVALID_BINARY)
-             << "Failed to build a module out of " << irContexts.size() << ".";
-    modules.push_back(irContext->module());
-    irContexts.push_back(std::move(irContext));
+             << "Failed to build a module out of " << ir_contexts.size() << ".";
+    modules.push_back(ir_context->module());
+    ir_contexts.push_back(std::move(ir_context));
   }
 
   // Phase 1: Shift the IDs used in each binary so that they occupy a disjoint

--- a/source/link/linker.cpp
+++ b/source/link/linker.cpp
@@ -633,9 +633,7 @@ static spv_result_t RemoveLinkageSpecificInstructions(
     return libspirv::DiagnosticStream(position, consumer,
                                       SPV_ERROR_INVALID_DATA)
            << "|decoration_manager| of RemoveLinkageSpecificInstructions "
-              "should "
-              "not "
-              "be empty.";
+              "should not be empty.";
   if (linked_context == nullptr)
     return libspirv::DiagnosticStream(position, consumer,
                                       SPV_ERROR_INVALID_DATA)

--- a/source/opt/basic_block.cpp
+++ b/source/opt/basic_block.cpp
@@ -31,7 +31,7 @@ const uint32_t kSelectionMergeMergeBlockIdInIdx = 0;
 
 BasicBlock* BasicBlock::Clone(IRContext* context) const {
   BasicBlock* clone = new BasicBlock(
-      std::unique_ptr<Instruction>(GetLabelInst().Clone(context)));
+      std::unique_ptr<Instruction>(GetLabelInst()->Clone(context)));
   for (const auto& inst : insts_)
     // Use the incoming context
     clone->AddInstruction(std::unique_ptr<Instruction>(inst.Clone(context)));

--- a/source/opt/basic_block.h
+++ b/source/opt/basic_block.h
@@ -64,7 +64,7 @@ class BasicBlock {
 
   // The label starting this basic block.
   Instruction* GetLabelInst() { return label_.get(); }
-  const Instruction& GetLabelInst() const { return *label_; }
+  const Instruction* GetLabelInst() const { return label_.get(); }
 
   // Returns the merge instruction in this basic block, if it exists.
   // Otherwise return null.  May be used whenever tail() can be used.

--- a/source/opt/function.cpp
+++ b/source/opt/function.cpp
@@ -37,7 +37,7 @@ Function* Function::Clone(IRContext* context) const {
   }
 
   clone->SetFunctionEnd(
-      std::unique_ptr<Instruction>(end_inst()->Clone(context)));
+      std::unique_ptr<Instruction>(EndInst()->Clone(context)));
   return clone;
 }
 

--- a/source/opt/function.cpp
+++ b/source/opt/function.cpp
@@ -37,7 +37,7 @@ Function* Function::Clone(IRContext* context) const {
   }
 
   clone->SetFunctionEnd(
-      std::unique_ptr<Instruction>(function_end().Clone(context)));
+      std::unique_ptr<Instruction>(end_inst()->Clone(context)));
   return clone;
 }
 

--- a/source/opt/function.h
+++ b/source/opt/function.h
@@ -64,8 +64,8 @@ class Function {
   inline void SetFunctionEnd(std::unique_ptr<Instruction> end_inst);
 
   // Returns the given function end instruction.
-  inline Instruction* function_end() { return end_inst_.get(); }
-  inline const Instruction& function_end() const { return *end_inst_; }
+  inline Instruction* end_inst() { return end_inst_.get(); }
+  inline const Instruction* end_inst() const { return end_inst_.get(); }
 
   // Returns function's id
   inline uint32_t result_id() const { return def_inst_->result_id(); }

--- a/source/opt/function.h
+++ b/source/opt/function.h
@@ -64,8 +64,8 @@ class Function {
   inline void SetFunctionEnd(std::unique_ptr<Instruction> end_inst);
 
   // Returns the given function end instruction.
-  inline Instruction* end_inst() { return end_inst_.get(); }
-  inline const Instruction* end_inst() const { return end_inst_.get(); }
+  inline Instruction* EndInst() { return end_inst_.get(); }
+  inline const Instruction* EndInst() const { return end_inst_.get(); }
 
   // Returns function's id
   inline uint32_t result_id() const { return def_inst_->result_id(); }

--- a/source/opt/remove_duplicates_pass.cpp
+++ b/source/opt/remove_duplicates_pass.cpp
@@ -36,25 +36,25 @@ using ir::Operand;
 using opt::analysis::DecorationManager;
 using opt::analysis::DefUseManager;
 
-Pass::Status RemoveDuplicatesPass::Process(ir::IRContext* irContext) {
-  bool modified = RemoveDuplicateCapabilities(irContext);
-  modified |= RemoveDuplicatesExtInstImports(irContext);
-  modified |= RemoveDuplicateTypes(irContext);
-  modified |= RemoveDuplicateDecorations(irContext);
+Pass::Status RemoveDuplicatesPass::Process(ir::IRContext* ir_context) {
+  bool modified = RemoveDuplicateCapabilities(ir_context);
+  modified |= RemoveDuplicatesExtInstImports(ir_context);
+  modified |= RemoveDuplicateTypes(ir_context);
+  modified |= RemoveDuplicateDecorations(ir_context);
 
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 
 bool RemoveDuplicatesPass::RemoveDuplicateCapabilities(
-    ir::IRContext* irContext) const {
+    ir::IRContext* ir_context) const {
   bool modified = false;
 
-  if (irContext->capabilities().empty()) {
+  if (ir_context->capabilities().empty()) {
     return modified;
   }
 
   std::unordered_set<uint32_t> capabilities;
-  for (auto* i = &*irContext->capability_begin(); i;) {
+  for (auto* i = &*ir_context->capability_begin(); i;) {
     auto res = capabilities.insert(i->GetSingleWordOperand(0u));
 
     if (res.second) {
@@ -62,7 +62,7 @@ bool RemoveDuplicatesPass::RemoveDuplicateCapabilities(
       i = i->NextNode();
     } else {
       // It's a duplicate, remove it.
-      i = irContext->KillInst(i);
+      i = ir_context->KillInst(i);
       modified = true;
     }
   }
@@ -71,16 +71,16 @@ bool RemoveDuplicatesPass::RemoveDuplicateCapabilities(
 }
 
 bool RemoveDuplicatesPass::RemoveDuplicatesExtInstImports(
-    ir::IRContext* irContext) const {
+    ir::IRContext* ir_context) const {
   bool modified = false;
 
-  if (irContext->ext_inst_imports().empty()) {
+  if (ir_context->ext_inst_imports().empty()) {
     return modified;
   }
 
-  std::unordered_map<std::string, SpvId> extInstImports;
-  for (auto* i = &*irContext->ext_inst_import_begin(); i;) {
-    auto res = extInstImports.emplace(
+  std::unordered_map<std::string, SpvId> ext_inst_imports;
+  for (auto* i = &*ir_context->ext_inst_import_begin(); i;) {
+    auto res = ext_inst_imports.emplace(
         reinterpret_cast<const char*>(i->GetInOperand(0u).words.data()),
         i->result_id());
     if (res.second) {
@@ -88,8 +88,8 @@ bool RemoveDuplicatesPass::RemoveDuplicatesExtInstImports(
       i = i->NextNode();
     } else {
       // It's a duplicate, remove it.
-      irContext->ReplaceAllUsesWith(i->result_id(), res.first->second);
-      i = irContext->KillInst(i);
+      ir_context->ReplaceAllUsesWith(i->result_id(), res.first->second);
+      i = ir_context->KillInst(i);
       modified = true;
     }
   }
@@ -98,16 +98,16 @@ bool RemoveDuplicatesPass::RemoveDuplicatesExtInstImports(
 }
 
 bool RemoveDuplicatesPass::RemoveDuplicateTypes(
-    ir::IRContext* irContext) const {
+    ir::IRContext* ir_context) const {
   bool modified = false;
 
-  if (irContext->types_values().empty()) {
+  if (ir_context->types_values().empty()) {
     return modified;
   }
 
-  std::vector<Instruction*> visitedTypes;
-  std::vector<Instruction*> toDelete;
-  for (auto* i = &*irContext->types_values_begin(); i; i = i->NextNode()) {
+  std::vector<Instruction*> visited_types;
+  std::vector<Instruction*> to_delete;
+  for (auto* i = &*ir_context->types_values_begin(); i; i = i->NextNode()) {
     // We only care about types.
     if (!spvOpcodeGeneratesType((i->opcode())) &&
         i->opcode() != SpvOpTypeForwardPointer) {
@@ -115,29 +115,29 @@ bool RemoveDuplicatesPass::RemoveDuplicateTypes(
     }
 
     // Is the current type equal to one of the types we have aready visited?
-    SpvId idToKeep = 0u;
+    SpvId id_to_keep = 0u;
     // TODO(dneto0): Use a trie to avoid quadratic behaviour? Extract the
     // ResultIdTrie from unify_const_pass.cpp for this.
-    for (auto j : visitedTypes) {
-      if (AreTypesEqual(*i, *j, irContext)) {
-        idToKeep = j->result_id();
+    for (auto j : visited_types) {
+      if (AreTypesEqual(*i, *j, ir_context)) {
+        id_to_keep = j->result_id();
         break;
       }
     }
 
-    if (idToKeep == 0u) {
+    if (id_to_keep == 0u) {
       // This is a never seen before type, keep it around.
-      visitedTypes.emplace_back(i);
+      visited_types.emplace_back(i);
     } else {
       // The same type has already been seen before, remove this one.
-      irContext->ReplaceAllUsesWith(i->result_id(), idToKeep);
+      ir_context->ReplaceAllUsesWith(i->result_id(), id_to_keep);
       modified = true;
-      toDelete.emplace_back(i);
+      to_delete.emplace_back(i);
     }
   }
 
-  for (auto i : toDelete) {
-    irContext->KillInst(i);
+  for (auto i : to_delete) {
+    ir_context->KillInst(i);
   }
 
   return modified;
@@ -153,33 +153,33 @@ bool RemoveDuplicatesPass::RemoveDuplicateTypes(
 //     OpGroupDecorate %2 %4
 // group %2 could be removed.
 bool RemoveDuplicatesPass::RemoveDuplicateDecorations(
-    ir::IRContext* irContext) const {
+    ir::IRContext* ir_context) const {
   bool modified = false;
 
-  std::vector<const Instruction*> visitedDecorations;
+  std::vector<const Instruction*> visited_decorations;
 
-  opt::analysis::DecorationManager decorationManager(irContext->module());
-  for (auto* i = &*irContext->annotation_begin(); i;) {
+  opt::analysis::DecorationManager decoration_manager(ir_context->module());
+  for (auto* i = &*ir_context->annotation_begin(); i;) {
     // Is the current decoration equal to one of the decorations we have aready
     // visited?
-    bool alreadyVisited = false;
+    bool already_visited = false;
     // TODO(dneto0): Use a trie to avoid quadratic behaviour? Extract the
     // ResultIdTrie from unify_const_pass.cpp for this.
-    for (const Instruction* j : visitedDecorations) {
-      if (decorationManager.AreDecorationsTheSame(&*i, j, false)) {
-        alreadyVisited = true;
+    for (const Instruction* j : visited_decorations) {
+      if (decoration_manager.AreDecorationsTheSame(&*i, j, false)) {
+        already_visited = true;
         break;
       }
     }
 
-    if (!alreadyVisited) {
+    if (!already_visited) {
       // This is a never seen before decoration, keep it around.
-      visitedDecorations.emplace_back(&*i);
+      visited_decorations.emplace_back(&*i);
       i = i->NextNode();
     } else {
       // The same decoration has already been seen before, remove this one.
       modified = true;
-      i = irContext->KillInst(i);
+      i = ir_context->KillInst(i);
     }
   }
 

--- a/source/opt/remove_duplicates_pass.cpp
+++ b/source/opt/remove_duplicates_pass.cpp
@@ -116,6 +116,8 @@ bool RemoveDuplicatesPass::RemoveDuplicateTypes(
 
     // Is the current type equal to one of the types we have aready visited?
     SpvId idToKeep = 0u;
+    // TODO(dneto0): Use a trie to avoid quadratic behaviour? Extract the
+    // ResultIdTrie from unify_const_pass.cpp for this.
     for (auto j : visitedTypes) {
       if (AreTypesEqual(*i, *j, irContext)) {
         idToKeep = j->result_id();
@@ -161,6 +163,8 @@ bool RemoveDuplicatesPass::RemoveDuplicateDecorations(
     // Is the current decoration equal to one of the decorations we have aready
     // visited?
     bool alreadyVisited = false;
+    // TODO(dneto0): Use a trie to avoid quadratic behaviour? Extract the
+    // ResultIdTrie from unify_const_pass.cpp for this.
     for (const Instruction* j : visitedDecorations) {
       if (decorationManager.AreDecorationsTheSame(&*i, j, false)) {
         alreadyVisited = true;

--- a/source/opt/remove_duplicates_pass.h
+++ b/source/opt/remove_duplicates_pass.h
@@ -34,16 +34,31 @@ class RemoveDuplicatesPass : public Pass {
  public:
   const char* name() const override { return "remove-duplicates"; }
   Status Process(ir::IRContext*) override;
+  // TODO(pierremoreau): Move this function somewhere else (e.g. pass.h or
+  // within the type manager)
   // Returns whether two types are equal, and have the same decorations.
   static bool AreTypesEqual(const ir::Instruction& inst1,
                             const ir::Instruction& inst2,
                             ir::IRContext* context);
 
  private:
-  bool RemoveDuplicateCapabilities(ir::IRContext* irContext) const;
-  bool RemoveDuplicatesExtInstImports(ir::IRContext* irContext) const;
-  bool RemoveDuplicateTypes(ir::IRContext* irContext) const;
-  bool RemoveDuplicateDecorations(ir::IRContext* irContext) const;
+  // Remove duplicate capabilities from the module attached to |ir_context|.
+  //
+  // Returns true if the module was modified, false otherwise.
+  bool RemoveDuplicateCapabilities(ir::IRContext* ir_context) const;
+  // Remove duplicate extended instruction imports from the module attached to
+  // |ir_context|.
+  //
+  // Returns true if the module was modified, false otherwise.
+  bool RemoveDuplicatesExtInstImports(ir::IRContext* ir_context) const;
+  // Remove duplicate types from the module attached to |ir_context|.
+  //
+  // Returns true if the module was modified, false otherwise.
+  bool RemoveDuplicateTypes(ir::IRContext* ir_context) const;
+  // Remove duplicate decorations from the module attached to |ir_context|.
+  //
+  // Returns true if the module was modified, false otherwise.
+  bool RemoveDuplicateDecorations(ir::IRContext* ir_context) const;
 };
 
 }  // namespace opt

--- a/source/table.cpp
+++ b/source/table.cpp
@@ -59,7 +59,8 @@ void libspirv::SetContextMessageConsumer(spv_context context,
   context->consumer = std::move(consumer);
 }
 
-spv_context spvtools::CreateContext(spv_target_env env, spvtools::MessageConsumer consumer) {
+spv_context spvtools::CreateContext(spv_target_env env,
+                                    spvtools::MessageConsumer consumer) {
   spv_context context = spvContextCreate(env);
   libspirv::SetContextMessageConsumer(context, consumer);
   return context;

--- a/source/table.cpp
+++ b/source/table.cpp
@@ -58,10 +58,3 @@ void libspirv::SetContextMessageConsumer(spv_context context,
                                          spvtools::MessageConsumer consumer) {
   context->consumer = std::move(consumer);
 }
-
-spv_context spvtools::CreateContext(spv_target_env env,
-                                    spvtools::MessageConsumer consumer) {
-  spv_context context = spvContextCreate(env);
-  libspirv::SetContextMessageConsumer(context, consumer);
-  return context;
-}

--- a/source/table.cpp
+++ b/source/table.cpp
@@ -58,3 +58,9 @@ void libspirv::SetContextMessageConsumer(spv_context context,
                                          spvtools::MessageConsumer consumer) {
   context->consumer = std::move(consumer);
 }
+
+spv_context spvtools::CreateContext(spv_target_env env, spvtools::MessageConsumer consumer) {
+  spv_context context = spvContextCreate(env);
+  libspirv::SetContextMessageConsumer(context, consumer);
+  return context;
+}

--- a/test/link/binary_version_test.cpp
+++ b/test/link/binary_version_test.cpp
@@ -50,7 +50,7 @@ TEST_F(BinaryVersion, LinkerChoosesMaxSpirvVersion) {
   ASSERT_EQ(SPV_SUCCESS, Link(binaries, &linked_binary));
   EXPECT_THAT(GetErrorMessage(), std::string());
 
-  ASSERT_EQ(0x00000600u, linked_binary[1]);
+  EXPECT_EQ(0x00000600u, linked_binary[1]);
 }
 
 }  // anonymous namespace

--- a/test/link/entry_points_test.cpp
+++ b/test/link/entry_points_test.cpp
@@ -38,7 +38,7 @@ OpFunctionEnd
 )";
 
   spvtest::Binary linked_binary;
-  ASSERT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary));
+  EXPECT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary));
   EXPECT_THAT(GetErrorMessage(), std::string());
 }
 
@@ -59,7 +59,7 @@ OpFunctionEnd
 )";
 
   spvtest::Binary linked_binary;
-  ASSERT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary));
+  EXPECT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary));
   EXPECT_THAT(GetErrorMessage(), std::string());
 }
 
@@ -80,7 +80,7 @@ OpFunctionEnd
 )";
 
   spvtest::Binary linked_binary;
-  ASSERT_EQ(SPV_ERROR_INTERNAL,
+  EXPECT_EQ(SPV_ERROR_INTERNAL,
             AssembleAndLink({body1, body2}, &linked_binary));
   EXPECT_THAT(GetErrorMessage(),
               HasSubstr("The entry point \"foo\", with execution model "

--- a/test/link/global_values_amount_test.cpp
+++ b/test/link/global_values_amount_test.cpp
@@ -108,7 +108,7 @@ class EntryPoints : public spvtest::LinkerTest {
 TEST_F(EntryPoints, UnderLimit) {
   spvtest::Binary linked_binary;
 
-  ASSERT_EQ(SPV_SUCCESS, Link(binaries, &linked_binary));
+  EXPECT_EQ(SPV_SUCCESS, Link(binaries, &linked_binary));
   EXPECT_THAT(GetErrorMessage(), std::string());
 }
 
@@ -140,7 +140,7 @@ TEST_F(EntryPoints, OverLimit) {
 
   spvtest::Binary linked_binary;
 
-  ASSERT_EQ(SPV_ERROR_INTERNAL, Link(binaries, &linked_binary));
+  EXPECT_EQ(SPV_ERROR_INTERNAL, Link(binaries, &linked_binary));
   EXPECT_THAT(GetErrorMessage(),
               HasSubstr("The limit of global values, 65535, was exceeded; "
                         "65536 global values were found."));

--- a/test/link/ids_limit_test.cpp
+++ b/test/link/ids_limit_test.cpp
@@ -37,7 +37,7 @@ TEST_F(IdsLimit, UnderLimit) {
 
   ASSERT_EQ(SPV_SUCCESS, Link(binaries, &linked_binary));
   EXPECT_THAT(GetErrorMessage(), std::string());
-  ASSERT_EQ(0x3FFFFEu, linked_binary[3]);
+  EXPECT_EQ(0x3FFFFEu, linked_binary[3]);
 }
 
 TEST_F(IdsLimit, OverLimit) {
@@ -60,7 +60,7 @@ TEST_F(IdsLimit, OverLimit) {
 
   spvtest::Binary linked_binary;
 
-  ASSERT_EQ(SPV_ERROR_INVALID_ID, Link(binaries, &linked_binary));
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, Link(binaries, &linked_binary));
   EXPECT_THAT(GetErrorMessage(),
               HasSubstr("The limit of IDs, 4194303, was exceeded: 4194304 is "
                         "the current ID bound."));

--- a/test/link/linker_fixture.h
+++ b/test/link/linker_fixture.h
@@ -30,7 +30,7 @@ using Binaries = std::vector<Binary>;
 class LinkerTest : public ::testing::Test {
  public:
   LinkerTest()
-      : context_(spvContextCreate(SPV_ENV_UNIVERSAL_1_2)),
+      : context_(SPV_ENV_UNIVERSAL_1_2),
         tools_(SPV_ENV_UNIVERSAL_1_2),
         assemble_options_(spvtools::SpirvTools::kDefaultAssembleOption),
         disassemble_options_(spvtools::SpirvTools::kDefaultDisassembleOption) {
@@ -56,11 +56,9 @@ class LinkerTest : public ::testing::Test {
       }
       error_message_ += ": " + std::to_string(position.index) + ": " + message;
     };
-    libspirv::SetContextMessageConsumer(context_, std::move(consumer));
+    context_.SetMessageConsumer(consumer);
     tools_.SetMessageConsumer(consumer);
   }
-
-  ~LinkerTest() { spvContextDestroy(context_); }
 
   virtual void TearDown() override { error_message_.clear(); }
 
@@ -113,7 +111,7 @@ class LinkerTest : public ::testing::Test {
   std::string GetErrorMessage() const { return error_message_; }
 
  private:
-  spv_context context_;
+  spvtools::Context context_;
   spvtools::SpirvTools
       tools_;  // An instance for calling SPIRV-Tools functionalities.
   uint32_t assemble_options_;

--- a/test/link/linker_fixture.h
+++ b/test/link/linker_fixture.h
@@ -30,8 +30,8 @@ using Binaries = std::vector<Binary>;
 class LinkerTest : public ::testing::Test {
  public:
   LinkerTest()
-      : tools_(SPV_ENV_UNIVERSAL_1_2),
-        linker_(SPV_ENV_UNIVERSAL_1_2),
+      : context_(spvContextCreate(SPV_ENV_UNIVERSAL_1_2)),
+        tools_(SPV_ENV_UNIVERSAL_1_2),
         assemble_options_(spvtools::SpirvTools::kDefaultAssembleOption),
         disassemble_options_(spvtools::SpirvTools::kDefaultDisassembleOption) {
     const auto consumer = [this](spv_message_level_t level, const char*,
@@ -56,9 +56,11 @@ class LinkerTest : public ::testing::Test {
       }
       error_message_ += ": " + std::to_string(position.index) + ": " + message;
     };
+    libspirv::SetContextMessageConsumer(context_, std::move(consumer));
     tools_.SetMessageConsumer(consumer);
-    linker_.SetMessageConsumer(consumer);
   }
+
+  ~LinkerTest() { spvContextDestroy(context_); }
 
   virtual void TearDown() override { error_message_.clear(); }
 
@@ -76,7 +78,7 @@ class LinkerTest : public ::testing::Test {
       if (!tools_.Assemble(bodies[i], binaries.data() + i, assemble_options_))
         return SPV_ERROR_INVALID_TEXT;
 
-    return linker_.Link(binaries, *linked_binary, options);
+    return spvtools::Link(context_, binaries, linked_binary, options);
   }
 
   // Links the given SPIR-V binaries together; SPV_ERROR_INVALID_POINTER is
@@ -85,7 +87,7 @@ class LinkerTest : public ::testing::Test {
       const spvtest::Binaries& binaries, spvtest::Binary* linked_binary,
       spvtools::LinkerOptions options = spvtools::LinkerOptions()) {
     if (!linked_binary) return SPV_ERROR_INVALID_POINTER;
-    return linker_.Link(binaries, *linked_binary, options);
+    return spvtools::Link(context_, binaries, linked_binary, options);
   }
 
   // Disassembles |binary| and outputs the result in |text|. If |text| is a
@@ -111,9 +113,9 @@ class LinkerTest : public ::testing::Test {
   std::string GetErrorMessage() const { return error_message_; }
 
  private:
+  spv_context context_;
   spvtools::SpirvTools
       tools_;  // An instance for calling SPIRV-Tools functionalities.
-  spvtools::Linker linker_;
   uint32_t assemble_options_;
   uint32_t disassemble_options_;
   std::string error_message_;

--- a/test/link/matching_imports_to_exports_test.cpp
+++ b/test/link/matching_imports_to_exports_test.cpp
@@ -37,7 +37,7 @@ OpDecorate %1 LinkageAttributes "foo" Export
 )";
 
   spvtest::Binary linked_binary;
-  ASSERT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary))
+  EXPECT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary))
       << GetErrorMessage();
 
   const std::string expected_res = R"(%1 = OpTypeFloat 32
@@ -47,9 +47,9 @@ OpDecorate %1 LinkageAttributes "foo" Export
 )";
   std::string res_body;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  ASSERT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
+  EXPECT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
       << GetErrorMessage();
-  ASSERT_EQ(expected_res, res_body);
+  EXPECT_EQ(expected_res, res_body);
 }
 
 TEST_F(MatchingImportsToExports, NotALibraryExtraExports) {
@@ -61,7 +61,7 @@ OpDecorate %1 LinkageAttributes "foo" Export
 )";
 
   spvtest::Binary linked_binary;
-  ASSERT_EQ(SPV_SUCCESS, AssembleAndLink({body}, &linked_binary))
+  EXPECT_EQ(SPV_SUCCESS, AssembleAndLink({body}, &linked_binary))
       << GetErrorMessage();
 
   const std::string expected_res = R"(%1 = OpTypeFloat 32
@@ -69,9 +69,9 @@ OpDecorate %1 LinkageAttributes "foo" Export
 )";
   std::string res_body;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  ASSERT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
+  EXPECT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
       << GetErrorMessage();
-  ASSERT_EQ(expected_res, res_body);
+  EXPECT_EQ(expected_res, res_body);
 }
 
 TEST_F(MatchingImportsToExports, LibraryExtraExports) {
@@ -85,7 +85,7 @@ OpDecorate %1 LinkageAttributes "foo" Export
   spvtest::Binary linked_binary;
   spvtools::LinkerOptions options;
   options.SetCreateLibrary(true);
-  ASSERT_EQ(SPV_SUCCESS, AssembleAndLink({body}, &linked_binary, options))
+  EXPECT_EQ(SPV_SUCCESS, AssembleAndLink({body}, &linked_binary, options))
       << GetErrorMessage();
 
   const std::string expected_res = R"(OpCapability Linkage
@@ -95,9 +95,9 @@ OpDecorate %1 LinkageAttributes "foo" Export
 )";
   std::string res_body;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  ASSERT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
+  EXPECT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
       << GetErrorMessage();
-  ASSERT_EQ(expected_res, res_body);
+  EXPECT_EQ(expected_res, res_body);
 }
 
 TEST_F(MatchingImportsToExports, UnresolvedImports) {
@@ -110,10 +110,10 @@ OpDecorate %1 LinkageAttributes "foo" Import
   const std::string body2 = R"()";
 
   spvtest::Binary linked_binary;
-  ASSERT_EQ(SPV_ERROR_INVALID_BINARY,
+  EXPECT_EQ(SPV_ERROR_INVALID_BINARY,
             AssembleAndLink({body1, body2}, &linked_binary));
   EXPECT_THAT(GetErrorMessage(),
-              HasSubstr("No export linkage was found for \"foo\"."));
+              HasSubstr("Unresolved external reference to \"foo\"."));
 }
 
 TEST_F(MatchingImportsToExports, TypeMismatch) {
@@ -133,12 +133,13 @@ OpDecorate %1 LinkageAttributes "foo" Export
 )";
 
   spvtest::Binary linked_binary;
-  ASSERT_EQ(SPV_ERROR_INVALID_BINARY,
+  EXPECT_EQ(SPV_ERROR_INVALID_BINARY,
             AssembleAndLink({body1, body2}, &linked_binary))
       << GetErrorMessage();
-  EXPECT_THAT(GetErrorMessage(),
-              HasSubstr("Type mismatch between imported variable/function %1 "
-                        "and exported variable/function %4"));
+  EXPECT_THAT(
+      GetErrorMessage(),
+      HasSubstr("Type mismatch on symbol \"foo\" between imported "
+                "variable/function %1 and exported variable/function %4"));
 }
 
 TEST_F(MatchingImportsToExports, MultipleDefinitions) {
@@ -165,12 +166,12 @@ OpDecorate %1 LinkageAttributes "foo" Export
 )";
 
   spvtest::Binary linked_binary;
-  ASSERT_EQ(SPV_ERROR_INVALID_BINARY,
+  EXPECT_EQ(SPV_ERROR_INVALID_BINARY,
             AssembleAndLink({body1, body2, body3}, &linked_binary))
       << GetErrorMessage();
-  EXPECT_THAT(
-      GetErrorMessage(),
-      HasSubstr("Too many export linkages, 2, were found for \"foo\"."));
+  EXPECT_THAT(GetErrorMessage(),
+              HasSubstr("Too many external references, 2, were found "
+                        "for \"foo\"."));
 }
 
 TEST_F(MatchingImportsToExports, SameNameDifferentTypes) {
@@ -197,12 +198,12 @@ OpDecorate %1 LinkageAttributes "foo" Export
 )";
 
   spvtest::Binary linked_binary;
-  ASSERT_EQ(SPV_ERROR_INVALID_BINARY,
+  EXPECT_EQ(SPV_ERROR_INVALID_BINARY,
             AssembleAndLink({body1, body2, body3}, &linked_binary))
       << GetErrorMessage();
-  EXPECT_THAT(
-      GetErrorMessage(),
-      HasSubstr("Too many export linkages, 2, were found for \"foo\"."));
+  EXPECT_THAT(GetErrorMessage(),
+              HasSubstr("Too many external references, 2, were found "
+                        "for \"foo\"."));
 }
 
 TEST_F(MatchingImportsToExports, DecorationMismatch) {
@@ -223,15 +224,16 @@ OpDecorate %1 LinkageAttributes "foo" Export
 )";
 
   spvtest::Binary linked_binary;
-  ASSERT_EQ(SPV_ERROR_INVALID_BINARY,
+  EXPECT_EQ(SPV_ERROR_INVALID_BINARY,
             AssembleAndLink({body1, body2}, &linked_binary))
       << GetErrorMessage();
-  EXPECT_THAT(GetErrorMessage(),
-              HasSubstr("Type mismatch between imported variable/function %1 "
-                        "and exported variable/function %4."));
+  EXPECT_THAT(
+      GetErrorMessage(),
+      HasSubstr("Type mismatch on symbol \"foo\" between imported "
+                "variable/function %1 and exported variable/function %4"));
 }
 
-TEST_F(MatchingImportsToExports, FuncParamAttr) {
+TEST_F(MatchingImportsToExports, FuncParamAttrDifferButStillMatchExportToImport) {
   const std::string body1 = R"(
 OpCapability Kernel
 OpCapability Linkage
@@ -260,7 +262,7 @@ OpFunctionEnd
 )";
 
   spvtest::Binary linked_binary;
-  ASSERT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary))
+  EXPECT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary))
       << GetErrorMessage();
 
   const std::string expected_res = R"(OpCapability Kernel
@@ -276,9 +278,9 @@ OpFunctionEnd
 )";
   std::string res_body;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  ASSERT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
+  EXPECT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
       << GetErrorMessage();
-  ASSERT_EQ(expected_res, res_body);
+  EXPECT_EQ(expected_res, res_body);
 }
 
 TEST_F(MatchingImportsToExports, FunctionCtrl) {
@@ -304,7 +306,7 @@ OpFunctionEnd
 )";
 
   spvtest::Binary linked_binary;
-  ASSERT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary))
+  EXPECT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary))
       << GetErrorMessage();
 
   const std::string expected_res = R"(%1 = OpTypeVoid
@@ -318,9 +320,9 @@ OpFunctionEnd
 )";
   std::string res_body;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  ASSERT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
+  EXPECT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
       << GetErrorMessage();
-  ASSERT_EQ(expected_res, res_body);
+  EXPECT_EQ(expected_res, res_body);
 }
 
 }  // anonymous namespace

--- a/test/link/matching_imports_to_exports_test.cpp
+++ b/test/link/matching_imports_to_exports_test.cpp
@@ -233,7 +233,8 @@ OpDecorate %1 LinkageAttributes "foo" Export
                 "variable/function %1 and exported variable/function %4"));
 }
 
-TEST_F(MatchingImportsToExports, FuncParamAttrDifferButStillMatchExportToImport) {
+TEST_F(MatchingImportsToExports,
+       FuncParamAttrDifferButStillMatchExportToImport) {
   const std::string body1 = R"(
 OpCapability Kernel
 OpCapability Linkage

--- a/test/link/memory_model_test.cpp
+++ b/test/link/memory_model_test.cpp
@@ -33,8 +33,8 @@ OpMemoryModel Logical Simple
   ASSERT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary));
   EXPECT_THAT(GetErrorMessage(), std::string());
 
-  ASSERT_EQ(SpvAddressingModelLogical, linked_binary[6]);
-  ASSERT_EQ(SpvMemoryModelSimple, linked_binary[7]);
+  EXPECT_EQ(SpvAddressingModelLogical, linked_binary[6]);
+  EXPECT_EQ(SpvMemoryModelSimple, linked_binary[7]);
 }
 
 TEST_F(MemoryModel, AddressingMismatch) {
@@ -46,7 +46,7 @@ OpMemoryModel Physical32 Simple
 )";
 
   spvtest::Binary linked_binary;
-  ASSERT_EQ(SPV_ERROR_INTERNAL,
+  EXPECT_EQ(SPV_ERROR_INTERNAL,
             AssembleAndLink({body1, body2}, &linked_binary));
   EXPECT_THAT(
       GetErrorMessage(),
@@ -62,7 +62,7 @@ OpMemoryModel Logical GLSL450
 )";
 
   spvtest::Binary linked_binary;
-  ASSERT_EQ(SPV_ERROR_INTERNAL,
+  EXPECT_EQ(SPV_ERROR_INTERNAL,
             AssembleAndLink({body1, body2}, &linked_binary));
   EXPECT_THAT(GetErrorMessage(),
               HasSubstr("Conflicting memory models: Simple vs GLSL450."));

--- a/tools/link/linker.cpp
+++ b/tools/link/linker.cpp
@@ -139,17 +139,15 @@ int main(int argc, char** argv) {
         break;
     }
   };
-  spv_context context = spvtools::CreateContext(target_env, consumer);
+  spvtools::Context context(target_env);
+  context.SetMessageConsumer(consumer);
 
   std::vector<uint32_t> linkingResult;
   spv_result_t status = Link(context, contents, &linkingResult, options);
 
   if (!WriteFile<uint32_t>(outFile, "wb", linkingResult.data(),
-                           linkingResult.size())) {
-    spvContextDestroy(context);
+                           linkingResult.size()))
     return 1;
-  }
-  spvContextDestroy(context);
 
   return status == SPV_SUCCESS ? 0 : 1;
 }

--- a/tools/link/linker.cpp
+++ b/tools/link/linker.cpp
@@ -117,9 +117,10 @@ int main(int argc, char** argv) {
     if (!ReadFile<uint32_t>(inFiles[i], "rb", &contents[i])) return 1;
   }
 
-  const spvtools::MessageConsumer consumer = [](spv_message_level_t level, const char*,
-                               const spv_position_t& position,
-                               const char* message) {
+  const spvtools::MessageConsumer consumer = [](spv_message_level_t level,
+                                                const char*,
+                                                const spv_position_t& position,
+                                                const char* message) {
     switch (level) {
       case SPV_MSG_FATAL:
       case SPV_MSG_INTERNAL_ERROR:


### PR DESCRIPTION
As very little information was kept in the Linker class, we can get rid of the whole class and have the `Link()` as free functions instead; the environment target as well as the consumer are passed along through an `spv_context` object.
The resulting linked_binary is passed as a pointer rather than a reference to follow the Google C++ Style guidelines; variables were also renamed to follow Google’s C++ Style guidelines.
The remaining changes are mostly about adding comments and TODOs, and some other formatting.

Addresses remaining comments from https://github.com/KhronosGroup/SPIRV-Tools/issues/693
Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/768
Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/1139
  