### PR TITLE
Do not insert Phi nodes in CCP propagator.

### DIFF
--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -413,9 +413,13 @@ bool spvOpcodeIsReturn(SpvOp opcode) {
   }
 }
 
+bool spvOpcodeIsReturnOrAbort(SpvOp opcode) {
+  return spvOpcodeIsReturn(opcode) || opcode == SpvOpKill ||
+         opcode == SpvOpUnreachable;
+}
+
 bool spvOpcodeIsBlockTerminator(SpvOp opcode) {
-  return spvOpcodeIsBranch(opcode) || spvOpcodeIsReturn(opcode) ||
-         opcode == SpvOpKill || opcode == SpvOpUnreachable;
+  return spvOpcodeIsBranch(opcode) || spvOpcodeIsReturnOrAbort(opcode);
 }
 
 bool spvOpcodeIsBaseOpaqueType(SpvOp opcode) {

--- a/source/opcode.h
+++ b/source/opcode.h
@@ -103,6 +103,10 @@ bool spvOpcodeIsBranch(SpvOp opcode);
 // Returns true if the given opcode is a return instruction.
 bool spvOpcodeIsReturn(SpvOp opcode);
 
+// Returns true if the given opcode is a return instruction or it aborts
+// execution.
+bool spvOpcodeIsReturnOrAbort(SpvOp opcode);
+
 // Returns true if the given opcode is a basic block terminator.
 bool spvOpcodeIsBlockTerminator(SpvOp opcode);
 

--- a/source/opt/basic_block.h
+++ b/source/opt/basic_block.h
@@ -147,6 +147,9 @@ class BasicBlock {
   // caller.
   bool IsReturn() const { return ctail()->IsReturn(); }
 
+  // Returns true if this basic block exits this function or aborts execution.
+  bool IsReturnOrAbort() const { return ctail()->IsReturnOrAbort(); }
+
  private:
   // The enclosing function.
   Function* function_;

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -317,6 +317,9 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   // and return to its caller
   bool IsReturn() const { return spvOpcodeIsReturn(opcode()); }
 
+  // Returns true if this instruction exits this function or aborts execution.
+  bool IsReturnOrAbort() const { return spvOpcodeIsReturnOrAbort(opcode()); }
+
   // Returns the id for the |element|'th subtype. If the |this| is not a
   // composite type, this function returns 0.
   uint32_t GetTypeComponent(uint32_t element) const;

--- a/source/opt/propagator.cpp
+++ b/source/opt/propagator.cpp
@@ -193,7 +193,7 @@ void SSAPropagator::Initialize(ir::Function* fn) {
       bb_succs_[&block].push_back(Edge(&block, succ_bb));
       bb_preds_[succ_bb].push_back(Edge(succ_bb, &block));
     });
-    if (block.IsReturn()) {
+    if (block.IsReturnOrAbort()) {
       bb_succs_[&block].push_back(
           Edge(&block, ctx_->cfg()->pseudo_exit_block()));
       bb_preds_[ctx_->cfg()->pseudo_exit_block()].push_back(


### PR DESCRIPTION
In CCP we should not need to insert Phi nodes because CCP never looks at
loads/stores.  This required adjusting two tests that relied on Phi
instructions being inserted.  I changed the tests to have the Phi
instructions pre-inserted.

I also added a new test to make sure that CCP does not try to look
through stores and loads.

Although this is just an efficiency fix for CCP, it is
also working around a bug in Phi insertion.  When Phi instructions are
inserted, they are never associated a basic block.  This causes a
segfault when the propagator tries to lookup CFG edges when analyzing
Phi instructions.