### PR TITLE
Replace calls to `ToNop` by `KillInst`.

### DIFF
--- a/source/opt/freeze_spec_constant_value_pass.cpp
+++ b/source/opt/freeze_spec_constant_value_pass.cpp
@@ -20,31 +20,32 @@ namespace opt {
 
 Pass::Status FreezeSpecConstantValuePass::Process(ir::IRContext* irContext) {
   bool modified = false;
-  irContext->module()->ForEachInst([&modified](ir::Instruction* inst) {
-    switch (inst->opcode()) {
-      case SpvOp::SpvOpSpecConstant:
-        inst->SetOpcode(SpvOp::SpvOpConstant);
-        modified = true;
-        break;
-      case SpvOp::SpvOpSpecConstantTrue:
-        inst->SetOpcode(SpvOp::SpvOpConstantTrue);
-        modified = true;
-        break;
-      case SpvOp::SpvOpSpecConstantFalse:
-        inst->SetOpcode(SpvOp::SpvOpConstantFalse);
-        modified = true;
-        break;
-      case SpvOp::SpvOpDecorate:
-        if (inst->GetSingleWordInOperand(1) ==
-            SpvDecoration::SpvDecorationSpecId) {
-          inst->ToNop();
-          modified = true;
+  irContext->module()->ForEachInst(
+      [&modified, irContext](ir::Instruction* inst) {
+        switch (inst->opcode()) {
+          case SpvOp::SpvOpSpecConstant:
+            inst->SetOpcode(SpvOp::SpvOpConstant);
+            modified = true;
+            break;
+          case SpvOp::SpvOpSpecConstantTrue:
+            inst->SetOpcode(SpvOp::SpvOpConstantTrue);
+            modified = true;
+            break;
+          case SpvOp::SpvOpSpecConstantFalse:
+            inst->SetOpcode(SpvOp::SpvOpConstantFalse);
+            modified = true;
+            break;
+          case SpvOp::SpvOpDecorate:
+            if (inst->GetSingleWordInOperand(1) ==
+                SpvDecoration::SpvDecorationSpecId) {
+              irContext->KillInst(inst);
+              modified = true;
+            }
+            break;
+          default:
+            break;
         }
-        break;
-      default:
-        break;
-    }
-  });
+      });
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 


### PR DESCRIPTION
Calling `ToNop` leaves around instructions that are pointless.  In
general it is better to remove the instruction completely.  That way
other optimizations will not need to look at them.

Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/1003.