### PR TITLE
Remove CCP from size and performance recipes, pending bugfixes

### DIFF
--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -125,7 +125,9 @@ Optimizer& Optimizer::RegisterPerformancePasses() {
       .RegisterPass(CreateLocalSingleStoreElimPass())
       .RegisterPass(CreateInsertExtractElimPass())
       .RegisterPass(CreateLocalMultiStoreElimPass())
-      .RegisterPass(CreateCCPPass())
+      // TODO(dneto): Disable CCP until it optimizes loops correctly
+      // https://github.com/KhronosGroup/SPIRV-Tools/issues/1143
+      //.RegisterPass(CreateCCPPass())
       .RegisterPass(CreateAggressiveDCEPass())
       .RegisterPass(CreateDeadBranchElimPass())
       .RegisterPass(CreateBlockMergePass())
@@ -147,7 +149,9 @@ Optimizer& Optimizer::RegisterSizePasses() {
       .RegisterPass(CreateLocalSingleStoreElimPass())
       .RegisterPass(CreateInsertExtractElimPass())
       .RegisterPass(CreateLocalMultiStoreElimPass())
-      .RegisterPass(CreateCCPPass())
+      // TODO(dneto): Disable CCP until it optimizes loops correctly
+      // https://github.com/KhronosGroup/SPIRV-Tools/issues/1143
+      //.RegisterPass(CreateCCPPass())
       .RegisterPass(CreateAggressiveDCEPass())
       .RegisterPass(CreateDeadBranchElimPass())
       .RegisterPass(CreateBlockMergePass())


### PR DESCRIPTION
Currently CCP is incorrectly optimizing loops.
See https://github.com/KhronosGroup/SPIRV-Tools/issues/1143