### PR TITLE
Rewriting dead branch elimination.

### DIFF
--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -295,9 +295,8 @@ Optimizer::PassToken CreateLocalSingleBlockLoadStoreElimPass();
 // For all phi functions in merge block, replace all uses with the id
 // corresponding to the living predecessor.
 //
-// This pass only works on shaders (guaranteed to have structured control
-// flow). Note that some such branches and blocks may be left to avoid
-// creating invalid control flow. Improving this is left to future work.
+// Note that some branches and blocks may be left to avoid creating invalid
+// control flow. Improving this is left to future work.
 //
 // This pass is most effective when preceeded by passes which eliminate
 // local loads and stores, effectively propagating constant values where

--- a/source/opt/basic_block.cpp
+++ b/source/opt/basic_block.cpp
@@ -87,7 +87,7 @@ Instruction* BasicBlock::GetLoopMergeInst() {
 }
 
 void BasicBlock::ForEachSuccessorLabel(
-    const std::function<void(const uint32_t)>& f) {
+    const std::function<void(const uint32_t)>& f) const {
   const auto br = &insts_.back();
   switch (br->opcode()) {
     case SpvOpBranch: {
@@ -104,6 +104,15 @@ void BasicBlock::ForEachSuccessorLabel(
     default:
       break;
   }
+}
+
+bool BasicBlock::IsSuccessor(const ir::BasicBlock* block) const {
+  uint32_t succId = block->id();
+  bool isSuccessor = false;
+  ForEachSuccessorLabel([&isSuccessor, succId](const uint32_t label) {
+    if (label == succId) isSuccessor = true;
+  });
+  return isSuccessor;
 }
 
 void BasicBlock::ForMergeAndContinueLabel(

--- a/source/opt/basic_block.h
+++ b/source/opt/basic_block.h
@@ -116,7 +116,11 @@ class BasicBlock {
                              bool run_on_debug_line_insts = false);
 
   // Runs the given function |f| on each label id of each successor block
-  void ForEachSuccessorLabel(const std::function<void(const uint32_t)>& f);
+  void ForEachSuccessorLabel(
+      const std::function<void(const uint32_t)>& f) const;
+
+  // Returns true if |block| is a direct successor of |this|.
+  bool IsSuccessor(const ir::BasicBlock* block) const;
 
   // Runs the given function |f| on the merge and continue label, if any
   void ForMergeAndContinueLabel(const std::function<void(const uint32_t)>& f);

--- a/source/opt/dead_branch_elim_pass.cpp
+++ b/source/opt/dead_branch_elim_pass.cpp
@@ -213,7 +213,7 @@ bool DeadBranchElimPass::EliminateDeadBranches(ir::Function* func) {
                 std::initializer_list<uint32_t>{Type2Undef(inst->type_id())});
             operands.push_back(inst->GetInOperand(i));
             changed = true;
-          } else if (liveBlocks.count(inc)) {
+          } else if (liveBlocks.count(inc) && inc->IsSuccessor(&block)) {
             // Keep live incoming edge.
             operands.push_back(inst->GetInOperand(i - 1));
             operands.push_back(inst->GetInOperand(i));

--- a/source/opt/dead_branch_elim_pass.cpp
+++ b/source/opt/dead_branch_elim_pass.cpp
@@ -120,24 +120,20 @@ bool DeadBranchElimPass::EliminateDeadBranches(ir::Function* func) {
         // corresponding label, use default if not found.
         uint32_t icnt = 0;
         uint32_t caseVal;
-        terminator->ForEachInOperand([
-          &icnt,
-          &caseVal,
-          &selVal,
-          &liveLabId,
-        ](const uint32_t* idp) {
-          if (icnt == 1) {
-            // Start with default label.
-            liveLabId = *idp;
-          } else if (icnt > 1) {
-            if (icnt % 2 == 0) {
-              caseVal = *idp;
-            } else {
-              if (caseVal == selVal) liveLabId = *idp;
-            }
-          }
-          ++icnt;
-        });
+        terminator->ForEachInOperand(
+            [&icnt, &caseVal, &selVal, &liveLabId](const uint32_t* idp) {
+              if (icnt == 1) {
+                // Start with default label.
+                liveLabId = *idp;
+              } else if (icnt > 1) {
+                if (icnt % 2 == 0) {
+                  caseVal = *idp;
+                } else {
+                  if (caseVal == selVal) liveLabId = *idp;
+                }
+              }
+              ++icnt;
+            });
       }
     }
 

--- a/source/opt/dead_branch_elim_pass.cpp
+++ b/source/opt/dead_branch_elim_pass.cpp
@@ -120,8 +120,12 @@ bool DeadBranchElimPass::EliminateDeadBranches(ir::Function* func) {
         // corresponding label, use default if not found.
         uint32_t icnt = 0;
         uint32_t caseVal;
-        terminator->ForEachInOperand([&icnt, &caseVal, &selVal, &liveLabId,
-                                      get_parent_block](const uint32_t* idp) {
+        terminator->ForEachInOperand([
+          &icnt,
+          &caseVal,
+          &selVal,
+          &liveLabId,
+        ](const uint32_t* idp) {
           if (icnt == 1) {
             // Start with default label.
             liveLabId = *idp;
@@ -159,7 +163,7 @@ bool DeadBranchElimPass::EliminateDeadBranches(ir::Function* func) {
     } else {
       // All successors are live.
       block->ForEachSuccessorLabel(
-          [&stack, this, get_parent_block](const uint32_t label) {
+          [&stack, get_parent_block](const uint32_t label) {
             stack.push_back(get_parent_block(label));
           });
     }

--- a/source/opt/dead_branch_elim_pass.h
+++ b/source/opt/dead_branch_elim_pass.h
@@ -37,9 +37,6 @@ class DeadBranchElimPass : public MemPass {
   using cbb_ptr = const ir::BasicBlock*;
 
  public:
-  using GetBlocksFunction =
-      std::function<std::vector<ir::BasicBlock*>*(const ir::BasicBlock*)>;
-
   DeadBranchElimPass();
   const char* name() const override { return "eliminate-dead-branches"; }
   Status Process(ir::IRContext* context) override;
@@ -60,32 +57,12 @@ class DeadBranchElimPass : public MemPass {
   // Add branch to |labelId| to end of block |bp|.
   void AddBranch(uint32_t labelId, ir::BasicBlock* bp);
 
-  // Add selction merge of |labelId| to end of block |bp|.
-  void AddSelectionMerge(uint32_t labelId, ir::BasicBlock* bp);
-
-  // Add conditional branch of |condId|, |trueLabId| and |falseLabId| to end
-  // of block |bp|.
-  void AddBranchConditional(uint32_t condId, uint32_t trueLabId,
-                            uint32_t falseLabId, ir::BasicBlock* bp);
-
-  // If block |bp| contains conditional branch or switch preceeded by an
-  // OpSelctionMerge, return true and return branch and merge instructions
-  // in |branchInst| and |mergeInst| and the conditional id in |condId|.
-  bool GetSelectionBranch(ir::BasicBlock* bp, ir::Instruction** branchInst,
-                          ir::Instruction** mergeInst, uint32_t* condId);
-
-  // Return true if |labelId| has any non-phi, non-backedge references
-  bool HasNonPhiNonBackedgeRef(uint32_t labelId);
-
-  // Compute backedges for blocks in |structuredOrder|.
-  void ComputeBackEdges(std::list<ir::BasicBlock*>& structuredOrder);
-
   // For function |func|, look for BranchConditionals with constant condition
   // and convert to a Branch to the indicated label. Delete resulting dead
-  // blocks. Assumes only structured control flow in shader. Note some such
-  // branches and blocks may be left to avoid creating invalid control flow.
-  // TODO(greg-lunarg): Remove remaining constant conditional branches and
-  // dead blocks.
+  // blocks. Note some such branches and blocks may be left to avoid creating
+  // invalid control flow.
+  // TODO(greg-lunarg): Remove remaining constant conditional branches and dead
+  // blocks.
   bool EliminateDeadBranches(ir::Function* func);
 
   // Initialize extensions whitelist
@@ -96,9 +73,6 @@ class DeadBranchElimPass : public MemPass {
 
   void Initialize(ir::IRContext* c);
   Pass::Status ProcessImpl();
-
-  // All backedge branches in current function
-  std::unordered_set<ir::Instruction*> backedges_;
 
   // Extensions supported by this pass.
   std::unordered_set<std::string> extensions_whitelist_;

--- a/source/opt/mem_pass.cpp
+++ b/source/opt/mem_pass.cpp
@@ -138,8 +138,12 @@ bool MemPass::HasOnlyNamesAndDecorates(uint32_t id) const {
   return hasOnlyNamesAndDecorates;
 }
 
-void MemPass::KillAllInsts(ir::BasicBlock* bp) {
-  bp->ForEachInst([this](ir::Instruction* ip) { context()->KillInst(ip); });
+void MemPass::KillAllInsts(ir::BasicBlock* bp, bool killLabel) {
+  bp->ForEachInst([this, killLabel](ir::Instruction* ip) {
+    if (killLabel || ip->opcode() != SpvOpLabel) {
+      context()->KillInst(ip);
+    }
+  });
 }
 
 bool MemPass::HasLoads(uint32_t varId) const {

--- a/source/opt/mem_pass.h
+++ b/source/opt/mem_pass.h
@@ -70,8 +70,9 @@ class MemPass : public Pass {
   // Return true if all uses of |id| are only name or decorate ops.
   bool HasOnlyNamesAndDecorates(uint32_t id) const;
 
-  // Kill all instructions in block |bp|.
-  void KillAllInsts(ir::BasicBlock* bp);
+  // Kill all instructions in block |bp|. Whether or not to kill the label is
+  // indicated by |killLabel|.
+  void KillAllInsts(ir::BasicBlock* bp, bool killLabel = true);
 
   // Return true if any instruction loads from |varId|
   bool HasLoads(uint32_t varId) const;


### PR DESCRIPTION
Addresses #1157 

Pass now paints live blocks and fixes constant branches and switches as
it goes. No longer requires structured control flow. It also removes
unreachable blocks as a side effect. It fixes the IR (phis) before doing
any code removal (other than terminator changes).

Added several unit tests for updated/new functionality.