### PR TITLE
Allow relaxing validation of pointers in logical addressing mode

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -441,6 +441,15 @@ void spvValidatorOptionsSetUniversalLimit(spv_validator_options options,
 void spvValidatorOptionsSetRelaxStoreStruct(spv_validator_options options,
                                             bool val);
 
+// Records whether or not the validator should relax the rules on pointer usage
+// in logical addressing mode.
+//
+// When relaxed, it will allow the following usage cases of pointers:
+// 1) OpVariable allocating an object whose type is a pointer type
+// 2) OpReturnValue returning a pointer value
+void spvValidatorOptionsSetRelaxLogicalPointer(spv_validator_options options,
+                                               bool val);
+
 // Encodes the given SPIR-V assembly text to its binary representation. The
 // length parameter specifies the number of bytes for text. Encoded binary will
 // be stored into *binary. Any error will be written into *diagnostic if

--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -81,6 +81,16 @@ class ValidatorOptions {
     spvValidatorOptionsSetRelaxStoreStruct(options_, val);
   }
 
+  // Records whether or not the validator should relax the rules on pointer
+  // usage in logical addressing mode.
+  //
+  // When relaxed, it will allow the following usage cases of pointers:
+  // 1) OpVariable allocating an object whose type is a pointer type
+  // 2) OpReturnValue returning a pointer value
+  void SetRelaxLogicalPointer(bool val) {
+    spvValidatorOptionsSetRelaxLogicalPointer(options_, val);
+  }
+
  private:
   spv_validator_options options_;
 };

--- a/source/spirv_validator_options.cpp
+++ b/source/spirv_validator_options.cpp
@@ -81,3 +81,8 @@ void spvValidatorOptionsSetRelaxStoreStruct(spv_validator_options options,
                                             bool val) {
   options->relax_struct_store = val;
 }
+
+void spvValidatorOptionsSetRelaxLogicalPointer(spv_validator_options options,
+                                               bool val) {
+  options->relax_logcial_pointer = val;
+}

--- a/source/spirv_validator_options.h
+++ b/source/spirv_validator_options.h
@@ -37,10 +37,14 @@ struct validator_universal_limits_t {
 // Manages command line options passed to the SPIR-V Validator. New struct
 // members may be added for any new option.
 struct spv_validator_options_t {
-  spv_validator_options_t() : universal_limits_(), relax_struct_store(false) {}
+  spv_validator_options_t()
+      : universal_limits_(),
+        relax_struct_store(false),
+        relax_logcial_pointer(false) {}
 
   validator_universal_limits_t universal_limits_;
   bool relax_struct_store;
+  bool relax_logcial_pointer;
 };
 
 #endif  // LIBSPIRV_SPIRV_VALIDATOR_OPTIONS_H_

--- a/source/validate_id.cpp
+++ b/source/validate_id.cpp
@@ -1879,16 +1879,20 @@ bool idUsage::isValid<SpvOpReturnValue>(const spv_instruction_t* inst,
                      << "' is missing or void.";
     return false;
   }
+
   const bool uses_variable_pointer =
       module_.features().variable_pointers ||
       module_.features().variable_pointers_storage_buffer;
+
   if (addressingModel == SpvAddressingModelLogical &&
-      SpvOpTypePointer == valueType->opcode() && !uses_variable_pointer) {
+      SpvOpTypePointer == valueType->opcode() && !uses_variable_pointer &&
+      !module_.options()->relax_logcial_pointer) {
     DIAG(valueIndex)
         << "OpReturnValue value's type <id> '" << value->type_id()
         << "' is a pointer, which is invalid in the Logical addressing model.";
     return false;
   }
+
   // NOTE: Find OpFunction
   const spv_instruction_t* function = inst - 1;
   while (firstInst != function) {

--- a/tools/val/val.cpp
+++ b/tools/val/val.cpp
@@ -44,6 +44,8 @@ Options:
   --max-function-args              <maximum number arguments allowed per function>
   --max-control-flow-nesting-depth <maximum Control Flow nesting depth allowed>
   --max-access-chain-indexes       <maximum number of indexes allowed to use for Access Chain instructions>
+  --relax-logcial-pointer          Allow allocating an object of a pointer type and returning
+                                   a pointer value from a function in logical addressing mode
   --relax-struct-store             Allow store from one struct type to a
                                    different type with compatible layout and
                                    members.
@@ -112,6 +114,8 @@ int main(int argc, char** argv) {
           continue_processing = false;
           return_code = 1;
         }
+      } else if (0 == strcmp(cur_arg, "--relax-logical-pointer")) {
+        options.SetRelaxLogicalPointer(true);
       } else if (0 == strcmp(cur_arg, "--relax-struct-store")) {
         options.SetRelaxStructStore(true);
       } else if (0 == cur_arg[1]) {


### PR DESCRIPTION
In HLSL structured buffer legalization, pointer to pointer types
are emitted to indicate a structured buffer variable should be
treated as an alias of some other variable. We need an option to
relax the check of pointer types in logical addressing mode to
catch other validation errors.