### PR TITLE
Add generic folding function and use in CCP

### DIFF
--- a/source/opt/fold.h
+++ b/source/opt/fold.h
@@ -59,6 +59,43 @@ bool IsFoldableOpcode(SpvOp opcode);
 // Returns true if |cst| is supported by FoldScalars and FoldVectors.
 bool IsFoldableConstant(const analysis::Constant* cst);
 
+// Returns true if |FoldInstructionToConstant| could fold an instruction whose
+// result type is |type_inst|.
+bool IsFoldableType(ir::Instruction* type_inst);
+
+// Tries to fold |inst| to a single constant, when the input ids to |inst| have
+// been substituted using |id_map|.  Returns a pointer to the OpConstant*
+// instruction if successful.  If necessary, a new constant instruction is
+// created and placed in the global values section.
+//
+// |id_map| is a function that takes one result id and returns another.  It can
+// be used for things like CCP where it is known that some ids contain a
+// constant, but the instruction itself has not been updated yet.  This can map
+// those ids to the appropriate constants.
+ir::Instruction* FoldInstructionToConstant(
+    ir::Instruction* inst, std::function<uint32_t(uint32_t)> id_map);
+
+// Tries to fold |inst| to a simpler instruction that computes the same value,
+// when the input ids to |inst| have been substituted using |id_map|.  Returns a
+// pointer to the simplified instruction if successful.  If necessary, a new
+// instruction is created and placed in the global values section, for
+// constants, or after |inst| for other instructions.
+//
+// |inst| must be an instruction that exists in the body of a function.
+//
+// |id_map| is a function that takes one result id and returns another.  It can
+// be used for things like CCP where it is known that some ids contain a
+// constant, but the instruction itself has not been updated yet.  This can map
+// those ids to the appropriate constants.
+ir::Instruction* FoldInstruction(ir::Instruction* inst,
+                                 std::function<uint32_t(uint32_t)> id_map);
+
+// The same as above when |id_map| is the identity function.
+inline ir::Instruction* FoldInstruction(ir::Instruction* inst) {
+  auto identity_map = [](uint32_t id) { return id; };
+  return FoldInstructionToConstant(inst, identity_map);
+}
+
 }  // namespace opt
 }  // namespace spvtools
 

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -468,7 +468,13 @@ bool Instruction::IsOpaqueType() const {
   }
 }
 
-bool Instruction::IsFoldable() const { return opt::IsFoldableOpcode(opcode()); }
+bool Instruction::IsFoldable() const {
+  if (!opt::IsFoldableOpcode(opcode())) {
+    return false;
+  }
+  Instruction* type = context()->get_def_use_mgr()->GetDef(type_id());
+  return opt::IsFoldableType(type);
+}
 
 }  // namespace ir
 }  // namespace spvtools

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -347,6 +347,10 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   Instruction* InsertBefore(std::unique_ptr<Instruction>&& i);
   using utils::IntrusiveNodeBase<Instruction>::InsertBefore;
 
+  // Returns true if |this| is an instruction defining a constant, but not a
+  // Spec constant.
+  inline bool IsConstant() const;
+
  private:
   // Returns the total count of result type id and result id.
   uint32_t TypeResultIdCount() const {
@@ -545,6 +549,11 @@ bool Instruction::IsDecoration() const {
 bool Instruction::IsLoad() const { return spvOpcodeIsLoad(opcode()); }
 
 bool Instruction::IsAtomicOp() const { return spvOpcodeIsAtomicOp(opcode()); }
+
+bool Instruction::IsConstant() const {
+  return spvOpcodeIsConstant(opcode()) &&
+         !spvOpcodeIsScalarSpecConstant(opcode());
+}
 }  // namespace ir
 }  // namespace spvtools
 


### PR DESCRIPTION
The current folding routines have a very cumbersome interface, make them
harder to use, and not a obvious how to extend.

This change is to create a new interface for the folding routines, and
show how it can be used by calling it from CCP.

This does not make a significant change to the behaviour of CCP.  In
general it should produce the same code as before; however it is
possible that an instruction that takes 32-bit integers as inputs and
the result is not a 32-bit integer or bool will not be folded as before.

Contributes to #1164.