### PR TITLE
Remove redundant passes from legalization passes

### DIFF
--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -107,11 +107,8 @@ Optimizer& Optimizer::RegisterLegalizationPasses() {
           // May need loop unrolling here see
           // https://github.com/Microsoft/DirectXShaderCompiler/pull/930
           .RegisterPass(CreateDeadBranchElimPass())
-          .RegisterPass(CreateCFGCleanupPass())
           // Get rid of unused code that leave traces of the illegal code.
-          .RegisterPass(CreateAggressiveDCEPass())
-          // TODO: Remove this once ADCE can do it.
-          .RegisterPass(CreateDeadVariableEliminationPass());
+          .RegisterPass(CreateAggressiveDCEPass());
 }
 
 Optimizer& Optimizer::RegisterPerformancePasses() {


### PR DESCRIPTION
With work that Alan has done, some passes have become redundant.  ADCE
now removed unused variables.  Dead branch elimination removes
unreachable blocks.  This means we can remove CFG Cleanup and dead
variable elimination.

Contributes to #1118.