### PR TITLE
Add generic folding function and use in CCP

### DIFF
--- a/source/opt/constants.h
+++ b/source/opt/constants.h
@@ -120,6 +120,31 @@ class IntConstant : public ScalarConstant {
   IntConstant* AsIntConstant() override { return this; }
   const IntConstant* AsIntConstant() const override { return this; }
 
+  int32_t GetS32BitValue() const {
+    // Relies on signed values smaller than 32-bit being sign extended.  See
+    // section 2.2.1 of the SPIR-V spec.
+    assert(words().size() == 1);
+    return words()[0];
+  }
+
+  uint32_t GetU32BitValue() const {
+    // Relies on unsigned values smaller than 32-bit being zero extended.  See
+    // section 2.2.1 of the SPIR-V spec.
+    assert(words().size() == 1);
+    return words()[0];
+  }
+
+  bool IsZero() const {
+    bool is_zero = true;
+    for (uint32_t v : words()) {
+      if (v != 0) {
+        is_zero = false;
+        break;
+      }
+    }
+    return is_zero;
+  }
+
   // Make a copy of this IntConstant instance.
   std::unique_ptr<IntConstant> CopyIntConstant() const {
     return MakeUnique<IntConstant>(type_->AsInteger(), words_);

--- a/source/opt/fold.cpp
+++ b/source/opt/fold.cpp
@@ -13,16 +13,30 @@
 // limitations under the License.
 
 #include "fold.h"
+
 #include "def_use_manager.h"
 #include "ir_context.h"
 
 #include <cassert>
+#include <cstdint>
 #include <vector>
 
 namespace spvtools {
 namespace opt {
 
 namespace {
+
+#ifndef INT32_MIN
+#define INT32_MIN (-2147483648)
+#endif
+
+#ifndef INT32_MAX
+#define INT32_MAX 2147483647
+#endif
+
+#ifndef UINT32_MAX
+#define UINT32_MAX 0xffffffff /* 4294967295U */
+#endif
 
 // Returns the single-word result from performing the given unary operation on
 // the operand value which is passed in as a 32-bit word.
@@ -195,6 +209,258 @@ uint32_t FoldScalars(SpvOp opcode,
   return OperateWords(opcode, operand_values_in_raw_words);
 }
 
+// Returns true if |inst| is a binary operation that takes two integers as
+// parameters and folds to a constant that can be represented as an unsigned
+// 32-bit value.  If |inst| can be folded, the resulting value is returned
+// in |*result|.  Valid result types for the instruction are any integer (signed
+// or unsigned) with 32-bits or less, or a boolean value.
+bool FoldBinaryIntegerOpToConstant(ir::Instruction* inst, uint32_t* result) {
+  SpvOp opcode = inst->opcode();
+  ir::IRContext* context = inst->context();
+  analysis::ConstantManager* const_manger = context->get_constant_mgr();
+
+  uint32_t ids[2];
+  const analysis::IntConstant* constants[2];
+  for (uint32_t i = 0; i < 2; i++) {
+    const ir::Operand* operand = &inst->GetInOperand(i);
+    if (operand->type != SPV_OPERAND_TYPE_ID) {
+      return false;
+    }
+    ids[i] = operand->words[0];
+    const analysis::Constant* constant =
+        const_manger->FindDeclaredConstant(ids[i]);
+    constants[i] = (constant != nullptr ? constant->AsIntConstant() : nullptr);
+  }
+
+  switch (opcode) {
+    // Arthimetics
+    case SpvOp::SpvOpIMul:
+      for (uint32_t i = 0; i < 2; i++) {
+        if (constants[i] != nullptr && constants[i]->IsZero()) {
+          *result = 0;
+          return true;
+        }
+      }
+      break;
+    case SpvOp::SpvOpUDiv:
+    case SpvOp::SpvOpSDiv:
+    case SpvOp::SpvOpSRem:
+    case SpvOp::SpvOpSMod:
+    case SpvOp::SpvOpUMod:
+      // This changes undefined behaviour (ie divide by 0) into a 0.
+      for (uint32_t i = 0; i < 2; i++) {
+        if (constants[i] != nullptr && constants[i]->IsZero()) {
+          *result = 0;
+          return true;
+        }
+      }
+      break;
+
+    // Shifting
+    case SpvOp::SpvOpShiftRightLogical:
+    case SpvOp::SpvOpShiftLeftLogical:
+      if (constants[1] != nullptr) {
+        // When shifting by a value larger than the size of the result, the
+        // result is undefined.  We are setting the undefined behaviour to a
+        // result of 0.
+        uint32_t shift_amount = constants[1]->GetU32BitValue();
+        if (shift_amount >= 32) {
+          *result = 0;
+          return true;
+        }
+      }
+      break;
+
+    // Bitwise operations
+    case SpvOp::SpvOpBitwiseOr:
+      for (uint32_t i = 0; i < 2; i++) {
+        if (constants[i] != nullptr) {
+          // TODO: Change the mask against a value based on the bit width of the
+          // instruction result type.  This way we can handle say 16-bit values
+          // as well.
+          uint32_t mask = constants[i]->GetU32BitValue();
+          if (mask == 0xFFFFFFFF) {
+            *result = 0xFFFFFFFF;
+            return true;
+          }
+        }
+      }
+      break;
+    case SpvOp::SpvOpBitwiseAnd:
+      for (uint32_t i = 0; i < 2; i++) {
+        if (constants[i] != nullptr) {
+          if (constants[i]->IsZero()) {
+            *result = 0;
+            return true;
+          }
+        }
+      }
+      break;
+
+    // Comparison
+    case SpvOp::SpvOpULessThan:
+      if (constants[0] != nullptr &&
+          constants[0]->GetU32BitValue() == UINT32_MAX) {
+        *result = false;
+        return true;
+      }
+      if (constants[1] != nullptr && constants[1]->GetU32BitValue() == 0) {
+        *result = false;
+        return true;
+      }
+      break;
+    case SpvOp::SpvOpSLessThan:
+      if (constants[0] != nullptr &&
+          constants[0]->GetS32BitValue() == INT32_MAX) {
+        *result = false;
+        return true;
+      }
+      if (constants[1] != nullptr &&
+          constants[1]->GetS32BitValue() == INT32_MIN) {
+        *result = false;
+        return true;
+      }
+      break;
+    case SpvOp::SpvOpUGreaterThan:
+      if (constants[0] != nullptr && constants[0]->IsZero()) {
+        *result = false;
+        return true;
+      }
+      if (constants[1] != nullptr &&
+          constants[1]->GetU32BitValue() == UINT32_MAX) {
+        *result = false;
+        return true;
+      }
+      break;
+    case SpvOp::SpvOpSGreaterThan:
+      if (constants[0] != nullptr &&
+          constants[0]->GetS32BitValue() == INT32_MIN) {
+        *result = false;
+        return true;
+      }
+      if (constants[1] != nullptr &&
+          constants[1]->GetS32BitValue() == INT32_MAX) {
+        *result = false;
+        return true;
+      }
+      break;
+    case SpvOp::SpvOpULessThanEqual:
+      if (constants[0] != nullptr && constants[0]->IsZero()) {
+        *result = true;
+        return true;
+      }
+      if (constants[1] != nullptr &&
+          constants[1]->GetU32BitValue() == UINT32_MAX) {
+        *result = true;
+        return true;
+      }
+      break;
+    case SpvOp::SpvOpSLessThanEqual:
+      if (constants[0] != nullptr &&
+          constants[0]->GetS32BitValue() == INT32_MIN) {
+        *result = true;
+        return true;
+      }
+      if (constants[1] != nullptr &&
+          constants[1]->GetS32BitValue() == INT32_MAX) {
+        *result = true;
+        return true;
+      }
+      break;
+    case SpvOp::SpvOpUGreaterThanEqual:
+      if (constants[0] != nullptr &&
+          constants[0]->GetU32BitValue() == UINT32_MAX) {
+        *result = true;
+        return true;
+      }
+      if (constants[1] != nullptr && constants[1]->GetU32BitValue() == 0) {
+        *result = true;
+        return true;
+      }
+      break;
+    case SpvOp::SpvOpSGreaterThanEqual:
+      if (constants[0] != nullptr &&
+          constants[0]->GetS32BitValue() == INT32_MAX) {
+        *result = true;
+        return true;
+      }
+      if (constants[1] != nullptr &&
+          constants[1]->GetS32BitValue() == INT32_MIN) {
+        *result = true;
+        return true;
+      }
+      break;
+    default:
+      break;
+  }
+  return false;
+}
+
+// Returns true if |inst| is a binary operation on two boolean values, and folds
+// to a constant boolean value.  If |inst| can be folded, the result value is
+// returned in |*result|.
+bool FoldBinaryBooleanOpToConstant(ir::Instruction* inst, uint32_t* result) {
+  SpvOp opcode = inst->opcode();
+  ir::IRContext* context = inst->context();
+  analysis::ConstantManager* const_manger = context->get_constant_mgr();
+
+  uint32_t ids[2];
+  const analysis::BoolConstant* constants[2];
+  for (uint32_t i = 0; i < 2; i++) {
+    const ir::Operand* operand = &inst->GetInOperand(i);
+    if (operand->type != SPV_OPERAND_TYPE_ID) {
+      return false;
+    }
+    ids[i] = operand->words[0];
+    const analysis::Constant* constant =
+        const_manger->FindDeclaredConstant(ids[i]);
+    constants[i] = (constant != nullptr ? constant->AsBoolConstant() : nullptr);
+  }
+
+  switch (opcode) {
+      // Logical
+    case SpvOp::SpvOpLogicalOr:
+      for (uint32_t i = 0; i < 2; i++) {
+        if (constants[i] != nullptr) {
+          if (constants[i]->value()) {
+            *result = true;
+            return true;
+          }
+        }
+      }
+      break;
+    case SpvOp::SpvOpLogicalAnd:
+      for (uint32_t i = 0; i < 2; i++) {
+        if (constants[i] != nullptr) {
+          if (!constants[i]->value()) {
+            *result = false;
+            return true;
+          }
+        }
+      }
+      break;
+
+    default:
+      break;
+  }
+  return false;
+}
+
+// Returns true if |inst| can be folded to an constant.  If it can, the value
+// is returned in |result|.  If not, |result| is unchanged.  It is assumed that
+// not all operands are constant.  Those cases are handled by |FoldScalar|.
+bool FoldIntegerOpToConstant(ir::Instruction* inst, uint32_t* result) {
+  assert(IsFoldableOpcode(inst->opcode()) &&
+         "Unhandled instruction opcode in FoldScalars");
+  switch (inst->NumInOperands()) {
+    case 2:
+      return FoldBinaryIntegerOpToConstant(inst, result) ||
+             FoldBinaryBooleanOpToConstant(inst, result);
+    default:
+      return false;
+  }
+}
+
 std::vector<uint32_t> FoldVectors(
     SpvOp opcode, uint32_t num_dims,
     const std::vector<const analysis::Constant*>& operands) {
@@ -314,15 +580,24 @@ ir::Instruction* FoldInstructionToConstant(
     constants.push_back(const_op);
   });
 
+  uint32_t result_val = 0;
+  bool successful = false;
   // If all parameters are constant, fold the instruction to a constant.
   if (!missing_constants) {
-    uint32_t result_val = FoldScalars(inst->opcode(), constants);
+    result_val = FoldScalars(inst->opcode(), constants);
+    successful = true;
+  }
+
+  if (!successful) {
+    successful = FoldIntegerOpToConstant(inst, &result_val);
+  }
+
+  if (successful) {
     const analysis::Constant* result_const =
         const_mgr->GetConstant(const_mgr->GetType(inst), {result_val});
     return const_mgr->GetDefiningInstruction(result_const);
   }
 
-  // TODO: Add other folding opportunities that will generate a constant.
   return nullptr;
 }
 
@@ -338,6 +613,7 @@ bool IsFoldableType(ir::Instruction* type_inst) {
   // Nothing else yet.
   return false;
 }
+
 ir::Instruction* FoldInstruction(ir::Instruction* inst,
                                  std::function<uint32_t(uint32_t)> id_map) {
   ir::Instruction* folded_inst = FoldInstructionToConstant(inst, id_map);

--- a/source/opt/fold.h
+++ b/source/opt/fold.h
@@ -93,7 +93,7 @@ ir::Instruction* FoldInstruction(ir::Instruction* inst,
 // The same as above when |id_map| is the identity function.
 inline ir::Instruction* FoldInstruction(ir::Instruction* inst) {
   auto identity_map = [](uint32_t id) { return id; };
-  return FoldInstructionToConstant(inst, identity_map);
+  return FoldInstruction(inst, identity_map);
 }
 
 }  // namespace opt

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -271,3 +271,8 @@ add_spvtools_unittest(TARGET ir_builder
   SRCS ir_builder.cpp
   LIBS SPIRV-Tools-opt
 )
+
+add_spvtools_unittest(TARGET instruction_folding
+  SRCS fold_test.cpp pass_utils.cpp
+  LIBS SPIRV-Tools-opt
+)


### PR DESCRIPTION
The current folding routines have a very cumbersome interface, make them
harder to use, and not a obvious how to extend.

This change is to create a new interface for the folding routines, and
show how it can be used by calling it from CCP.

This does not make a significant change to the behaviour of CCP.  In
general it should produce the same code as before; however it is
possible that an instruction that takes 32-bit integers as inputs and
the result is not a 32-bit integer or bool will not be folded as before.

Contributes to #1164 