### PR TITLE
Capturing value table by reference in local redundancy elim

### DIFF
--- a/source/opt/local_redundancy_elimination.cpp
+++ b/source/opt/local_redundancy_elimination.cpp
@@ -43,7 +43,7 @@ bool LocalRedundancyEliminationPass::EliminateRedundanciesInBB(
     std::map<uint32_t, uint32_t>* value_to_ids) {
   bool modified = false;
 
-  auto func = [this, vnTable, &modified, value_to_ids](ir::Instruction* inst) {
+  auto func = [this, &vnTable, &modified, value_to_ids](ir::Instruction* inst) {
     if (inst->result_id() == 0) {
       return;
     }


### PR DESCRIPTION
Value table was being copied instead of getting passed by reference. Profiling showed a reduction in runtime from ~90sec to ~23sec.