### PR TITLE
Fixing missing early exit from break identification

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -241,6 +241,7 @@ void AggressiveDCEPass::AddBreaksAndContinuesToWorklist(
       mergeId, [&loopMerge, this](ir::Instruction* user) {
         // A branch to the merge block can only be a break if it is nested in
         // the current loop
+        if (!user->IsBranch()) return;
         ir::Instruction* branchInst = user;
         while (true) {
           ir::BasicBlock* blk = context()->get_instr_block(branchInst);


### PR DESCRIPTION
Addresses #1210 

Previous commit 80b743a570a6a616484d9aa9233774fed6cc5463. It removed a check that the user was a branch or conditional branch. Should have been updated to say it was still a "branch" (branch, conditional branch or switch).