### PR TITLE
CFG: force the creation of a predecessor entry for all basic block.

### DIFF
--- a/source/opt/cfg.cpp
+++ b/source/opt/cfg.cpp
@@ -37,6 +37,9 @@ CFG::CFG(ir::Module* module)
     for (auto& blk : fn) {
       uint32_t blkId = blk.id();
       id2block_[blkId] = &blk;
+      // Force the creation of an entry, not all basic block have predecessors
+      // (such as the entry block and some unreachables)
+      label2preds_[blkId];
       blk.ForEachSuccessorLabel([&blkId, this](uint32_t sbid) {
         label2preds_[sbid].push_back(blkId);
       });


### PR DESCRIPTION
This ensure that all basic blocks in a function have a valid entry the CFG object.

The entry block has no predecessors but remains a valid basic block
for which we might want to query the number of predecessors. Because it has no predecessor, no entry were created in the `label2preds_` map.

Some unreachable basic blocks may not have predecessors as well.