### PR TITLE
Introduce an instruction builder helper class.

### DIFF
--- a/source/opt/ir_builder.h
+++ b/source/opt/ir_builder.h
@@ -27,7 +27,7 @@ namespace opt {
 constexpr uint32_t kInvalidId = (uint32_t)-1;
 
 // Helper class to abstract instruction construction and insertion.
-// |AnalysisToPreserve| ask the InstructionBuilder to preserve requested
+// |AnalysisToPreserve| asks the InstructionBuilder to preserve requested
 // analysis.
 // Supported analysis:
 //   - Def-use analysis
@@ -54,7 +54,7 @@ class InstructionBuilder {
   }
 
   // Creates a new branch instruction to |label_id|.
-  // Note that the user is responsible of making sure the final basic block is
+  // Note that the user must makes sure the final basic block is
   // well formed.
   ir::Instruction* AddBranch(uint32_t label_id) {
     std::unique_ptr<ir::Instruction> new_branch(new ir::Instruction(
@@ -63,15 +63,18 @@ class InstructionBuilder {
     return AddInstruction(std::move(new_branch));
   }
 
-  // Creates a new conditional instruction.
-  // The id |cond_id| is the condition, must be of type bool.
-  // The id |true_id| is the basic block id to branch to is the condition is
+  // Creates a new conditional instruction and the associated selection merge
+  // instruction if requested.
+  // The id |cond_id| is the id to the the condition instruction, must be of
+  // type bool.
+  // The id |true_id| is the basic block id to branch to if the condition is
   // true.
-  // The id |false_id| is the basic block id to branch to is the condition is
+  // The id |false_id| is the basic block id to branch to if the condition is
   // false.
-  // The id |merge_id| is the merge basic block id (for structured CFG), if
-  // |merge_id| equals kInvalidId then no
-  // Note that the user is responsible of making sure the final basic block is
+  // The id |merge_id| is the merge basic block id for the selection merge
+  // instruction. If |merge_id| equals kInvalidId then no selection merge
+  // instruction will be created.
+  // Note that the user must makes sure the final basic block is
   // well formed.
   ir::Instruction* AddBranchCond(uint32_t cond_id, uint32_t true_id,
                                  uint32_t false_id,
@@ -89,8 +92,8 @@ class InstructionBuilder {
 
   // Creates a phi instruction.
   // The id |type| must be the id of the phi instruction's type.
-  // The vector |incomings| must be a sequence of pairs of <def id, parent
-  // id>.
+  // The vector |incomings| must be a sequence of pairs of <definition id,
+  // parent id>.
   ir::Instruction* AddPhi(uint32_t type,
                           const std::vector<uint32_t>& incomings) {
     assert(incomings.size() % 2 == 0 && "A sequence of pairs is expected");
@@ -118,7 +121,7 @@ class InstructionBuilder {
   ir::IRContext* GetContext() const { return context_; }
 
  private:
-  // Returns true if the users requested to update an analysis.
+  // Returns true if the users requested to update |analysis|.
   inline static constexpr bool IsAnalysisUpdateRequested(
       ir::IRContext::Analysis analysis) {
     return AnalysisToPreserve & analysis;

--- a/source/opt/ir_builder.h
+++ b/source/opt/ir_builder.h
@@ -1,0 +1,141 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBSPIRV_OPT_IR_BUILDER_H_
+#define LIBSPIRV_OPT_IR_BUILDER_H_
+
+#include "opt/basic_block.h"
+#include "opt/instruction.h"
+#include "opt/ir_context.h"
+
+namespace spvtools {
+namespace opt {
+
+// In SPIR-V, ids are encoded as uint16_t, this id is guarantied to be always
+// invalid.
+constexpr uint32_t kInvalidId = (uint32_t)-1;
+
+// Helper class to abstract instruction construction and insertion.
+// |AnalysisToPreserve| ask the InstructionBuilder to preserve requested
+// analysis.
+// Supported analysis:
+//   - Def-use analysis
+template <ir::IRContext::Analysis AnalysisToPreserve =
+              ir::IRContext::kAnalysisNone>
+class InstructionBuilder {
+  static_assert(!(AnalysisToPreserve & ~ir::IRContext::kAnalysisDefUse),
+                "Only Def-use analysis update is supported");
+
+ public:
+  using InsertionPointTy = spvtools::ir::BasicBlock::iterator;
+
+  InstructionBuilder(ir::IRContext* context, InsertionPointTy insert_before)
+      : context_(context), insert_before_(insert_before) {}
+
+  // Creates a new selection merge instruction.
+  // The id |merge_id| is the merge basic block id.
+  ir::Instruction* AddSelectionMerge(uint32_t merge_id) {
+    std::unique_ptr<ir::Instruction> new_branch_merge(new ir::Instruction(
+        GetContext(), SpvOpSelectionMerge, 0, 0,
+        {{spv_operand_type_t::SPV_OPERAND_TYPE_ID, {merge_id}},
+         {spv_operand_type_t::SPV_OPERAND_TYPE_LITERAL_INTEGER, {0}}}));
+    return AddInstruction(std::move(new_branch_merge));
+  }
+
+  // Creates a new branch instruction to |label_id|.
+  // Note that the user is responsible of making sure the final basic block is
+  // well formed.
+  ir::Instruction* AddBranch(uint32_t label_id) {
+    std::unique_ptr<ir::Instruction> new_branch(new ir::Instruction(
+        GetContext(), SpvOpBranch, 0, 0,
+        {{spv_operand_type_t::SPV_OPERAND_TYPE_ID, {label_id}}}));
+    return AddInstruction(std::move(new_branch));
+  }
+
+  // Creates a new conditional instruction.
+  // The id |cond_id| is the condition, must be of type bool.
+  // The id |true_id| is the basic block id to branch to is the condition is
+  // true.
+  // The id |false_id| is the basic block id to branch to is the condition is
+  // false.
+  // The id |merge_id| is the merge basic block id (for structured CFG), if
+  // |merge_id| equals kInvalidId then no
+  // Note that the user is responsible of making sure the final basic block is
+  // well formed.
+  ir::Instruction* AddBranchCond(uint32_t cond_id, uint32_t true_id,
+                                 uint32_t false_id,
+                                 uint32_t merge_id = kInvalidId) {
+    if (merge_id != kInvalidId) {
+      AddSelectionMerge(merge_id);
+    }
+    std::unique_ptr<ir::Instruction> new_branch(new ir::Instruction(
+        GetContext(), SpvOpBranchConditional, 0, 0,
+        {{spv_operand_type_t::SPV_OPERAND_TYPE_ID, {cond_id}},
+         {spv_operand_type_t::SPV_OPERAND_TYPE_ID, {true_id}},
+         {spv_operand_type_t::SPV_OPERAND_TYPE_ID, {false_id}}}));
+    return AddInstruction(std::move(new_branch));
+  }
+
+  // Creates a phi instruction.
+  // The id |type| must be the id of the phi instruction's type.
+  // The vector |incomings| must be a sequence of pairs of <def id, parent
+  // id>.
+  ir::Instruction* AddPhi(uint32_t type,
+                          const std::vector<uint32_t>& incomings) {
+    assert(incomings.size() % 2 == 0 && "A sequence of pairs is expected");
+    std::vector<ir::Operand> phi_ops;
+    for (size_t i = 0; i < incomings.size(); i += 2) {
+      phi_ops.push_back({SPV_OPERAND_TYPE_ID, {incomings[i]}});
+      phi_ops.push_back({SPV_OPERAND_TYPE_ID, {incomings[i + 1]}});
+    }
+    std::unique_ptr<ir::Instruction> phi_inst(new ir::Instruction(
+        GetContext(), SpvOpPhi, type, GetContext()->TakeNextId(), phi_ops));
+    return AddInstruction(std::move(phi_inst));
+  }
+
+  // Inserts the new instruction before the insertion point.
+  ir::Instruction* AddInstruction(std::unique_ptr<ir::Instruction>&& insn) {
+    ir::Instruction* insn_ptr = &*insert_before_.InsertBefore(std::move(insn));
+    UpdateDefUseMgr(insn_ptr);
+    return insn_ptr;
+  }
+
+  // Returns the insertion point iterator.
+  InsertionPointTy GetInsertPoint() { return insert_before_; }
+
+  // Returns the context which instructions are constructed for.
+  ir::IRContext* GetContext() const { return context_; }
+
+ private:
+  // Returns true if the users requested to update an analysis.
+  inline static constexpr bool IsAnalysisUpdateRequested(
+      ir::IRContext::Analysis analysis) {
+    return AnalysisToPreserve & analysis;
+  }
+
+  // Updates the def/use manager if the user requested it. If he did not request
+  // an update, this function does nothing.
+  inline void UpdateDefUseMgr(ir::Instruction* insn) {
+    if (IsAnalysisUpdateRequested(ir::IRContext::kAnalysisDefUse))
+      GetContext()->get_def_use_mgr()->AnalyzeInstDefUse(insn);
+  }
+
+  ir::IRContext* context_;
+  InsertionPointTy insert_before_;
+};
+
+}  // namespace spvtools
+}  // namespace opt
+
+#endif  // LIBSPIRV_OPT_IR_BUILDER_H_

--- a/source/opt/ir_builder.h
+++ b/source/opt/ir_builder.h
@@ -108,9 +108,10 @@ class InstructionBuilder {
                           const std::vector<uint32_t>& incomings) {
     assert(incomings.size() % 2 == 0 && "A sequence of pairs is expected");
     std::vector<ir::Operand> phi_ops;
-    for (size_t i = 0; i < incomings.size(); i += 2) {
+    for (size_t i = 0; i < incomings.size(); i++) {
       phi_ops.push_back({SPV_OPERAND_TYPE_ID, {incomings[i]}});
-      phi_ops.push_back({SPV_OPERAND_TYPE_ID, {incomings[i + 1]}});
+      i++;
+      phi_ops.push_back({SPV_OPERAND_TYPE_ID, {incomings[i]}});
     }
     std::unique_ptr<ir::Instruction> phi_inst(new ir::Instruction(
         GetContext(), SpvOpPhi, type, GetContext()->TakeNextId(), phi_ops));

--- a/source/opt/ir_context.h
+++ b/source/opt/ir_context.h
@@ -58,9 +58,9 @@ class IRContext {
     kAnalysisEnd = 1 << 6
   };
 
-  friend inline Analysis operator|(Analysis lhs, Analysis rhs);
+  friend inline constexpr Analysis operator|(Analysis lhs, Analysis rhs);
   friend inline Analysis& operator|=(Analysis& lhs, Analysis rhs);
-  friend inline Analysis operator<<(Analysis a, int shift);
+  friend inline constexpr Analysis operator<<(Analysis a, int shift);
   friend inline Analysis& operator<<=(Analysis& a, int shift);
 
   // Creates an |IRContext| that contains an owned |Module|
@@ -506,8 +506,8 @@ class IRContext {
   std::unique_ptr<opt::analysis::TypeManager> type_mgr_;
 };
 
-inline ir::IRContext::Analysis operator|(ir::IRContext::Analysis lhs,
-                                         ir::IRContext::Analysis rhs) {
+inline constexpr ir::IRContext::Analysis operator|(
+    ir::IRContext::Analysis lhs, ir::IRContext::Analysis rhs) {
   return static_cast<ir::IRContext::Analysis>(static_cast<int>(lhs) |
                                               static_cast<int>(rhs));
 }
@@ -519,8 +519,8 @@ inline ir::IRContext::Analysis& operator|=(ir::IRContext::Analysis& lhs,
   return lhs;
 }
 
-inline ir::IRContext::Analysis operator<<(ir::IRContext::Analysis a,
-                                          int shift) {
+inline constexpr ir::IRContext::Analysis operator<<(ir::IRContext::Analysis a,
+                                                    int shift) {
   return static_cast<ir::IRContext::Analysis>(static_cast<int>(a) << shift);
 }
 

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -261,3 +261,8 @@ add_spvtools_unittest(TARGET ccp
   SRCS ccp_test.cpp
   LIBS SPIRV-Tools-opt
 )
+
+add_spvtools_unittest(TARGET ir_builder
+  SRCS ir_builder.cpp
+  LIBS SPIRV-Tools-opt
+)

--- a/test/opt/ir_builder.cpp
+++ b/test/opt/ir_builder.cpp
@@ -1,0 +1,221 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <vector>
+
+#ifdef SPIRV_EFFCEE
+#include "effcee/effcee.h"
+#endif
+
+#include "opt/basic_block.h"
+#include "opt/ir_builder.h"
+
+#include "opt/build_module.h"
+#include "opt/instruction.h"
+#include "opt/type_manager.h"
+#include "spirv-tools/libspirv.hpp"
+
+namespace {
+
+using namespace spvtools;
+using ir::IRContext;
+using Analysis = IRContext::Analysis;
+
+#ifdef SPIRV_EFFCEE
+
+using IRBuilderTest = ::testing::Test;
+
+bool Validate(const std::vector<uint32_t>& bin) {
+  spv_target_env target_env = SPV_ENV_UNIVERSAL_1_2;
+  spv_context spvContext = spvContextCreate(target_env);
+  spv_diagnostic diagnostic = nullptr;
+  spv_const_binary_t binary = {bin.data(), bin.size()};
+  spv_result_t error = spvValidate(spvContext, &binary, &diagnostic);
+  if (error != 0) spvDiagnosticPrint(diagnostic);
+  spvDiagnosticDestroy(diagnostic);
+  spvContextDestroy(spvContext);
+  return error == 0;
+}
+
+void Match(const std::string& original, ir::IRContext* context,
+           bool do_validation = true) {
+  std::vector<uint32_t> bin;
+  context->module()->ToBinary(&bin, true);
+  if (do_validation) {
+    EXPECT_TRUE(Validate(bin));
+  }
+  std::string assembly;
+  SpirvTools tools(SPV_ENV_UNIVERSAL_1_2);
+  EXPECT_TRUE(
+      tools.Disassemble(bin, &assembly, SpirvTools::kDefaultDisassembleOption))
+      << "Disassembling failed for shader:\n"
+      << assembly << std::endl;
+  auto match_result = effcee::Match(assembly, original);
+  EXPECT_EQ(effcee::Result::Status::Ok, match_result.status())
+      << match_result.message() << "\nChecking result:\n"
+      << assembly;
+}
+
+TEST_F(IRBuilderTest, TestInsnAddition) {
+  const std::string text = R"(
+; CHECK: %18 = OpLabel
+; CHECK: OpPhi %int %int_0 %14
+; CHECK: OpPhi %bool %16 %14
+; CHECK: OpBranch %17
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main" %3
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 330
+               OpName %2 "main"
+               OpName %4 "i"
+               OpName %3 "c"
+               OpDecorate %3 Location 0
+          %5 = OpTypeVoid
+          %6 = OpTypeFunction %5
+          %7 = OpTypeInt 32 1
+          %8 = OpTypePointer Function %7
+          %9 = OpConstant %7 0
+         %10 = OpTypeBool
+         %11 = OpTypeFloat 32
+         %12 = OpTypeVector %11 4
+         %13 = OpTypePointer Output %12
+          %3 = OpVariable %13 Output
+          %2 = OpFunction %5 None %6
+         %14 = OpLabel
+          %4 = OpVariable %8 Function
+               OpStore %4 %9
+         %15 = OpLoad %7 %4
+         %16 = OpINotEqual %10 %15 %9
+               OpSelectionMerge %17 None
+               OpBranchConditional %16 %18 %17
+         %18 = OpLabel
+               OpBranch %17
+         %17 = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+
+  {
+    std::unique_ptr<ir::IRContext> context =
+        BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text);
+
+    ir::BasicBlock* bb = context->cfg()->block(18);
+
+    // Build the def/use manager.
+    context->get_def_use_mgr();
+
+    opt::InstructionBuilder<> builder(context.get(), bb->begin());
+    ir::Instruction* phi1 = builder.AddPhi(7, {9, 14});
+    ir::Instruction* phi2 = builder.AddPhi(10, {16, 14});
+
+    // Make sure the InstructionBuilder did not update the def/use manager.
+    EXPECT_EQ(context->get_def_use_mgr()->GetDef(phi1->result_id()), nullptr);
+    EXPECT_EQ(context->get_def_use_mgr()->GetDef(phi2->result_id()), nullptr);
+
+    Match(text, context.get());
+  }
+
+  {
+    std::unique_ptr<ir::IRContext> context =
+        BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text);
+
+    ir::BasicBlock* bb = context->cfg()->block(18);
+    opt::InstructionBuilder<ir::IRContext::kAnalysisDefUse> builder(
+        context.get(), bb->begin());
+    ir::Instruction* phi1 = builder.AddPhi(7, {9, 14});
+    ir::Instruction* phi2 = builder.AddPhi(10, {16, 14});
+
+    // Make sure InstructionBuilder updated the def/use manager
+    EXPECT_NE(context->get_def_use_mgr()->GetDef(phi1->result_id()), nullptr);
+    EXPECT_NE(context->get_def_use_mgr()->GetDef(phi2->result_id()), nullptr);
+
+    Match(text, context.get());
+  }
+}
+
+TEST_F(IRBuilderTest, TestCondBranchAddition) {
+  const std::string text = R"(
+; CHECK: %main = OpFunction %void None %6
+; CHECK-NEXT: %15 = OpLabel
+; CHECK-NEXT: OpSelectionMerge %13 None
+; CHECK-NEXT: OpBranchConditional %true %14 %13
+; CHECK-NEXT: %14 = OpLabel
+; CHECK-NEXT: OpBranch %13
+; CHECK-NEXT: %13 = OpLabel
+; CHECK-NEXT: OpReturn
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main" %3
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 330
+               OpName %2 "main"
+               OpName %4 "i"
+               OpName %3 "c"
+               OpDecorate %3 Location 0
+          %5 = OpTypeVoid
+          %6 = OpTypeFunction %5
+          %7 = OpTypeBool
+          %8 = OpTypePointer Function %7
+          %9 = OpConstantTrue %7
+         %10 = OpTypeFloat 32
+         %11 = OpTypeVector %10 4
+         %12 = OpTypePointer Output %11
+          %3 = OpVariable %12 Output
+          %4 = OpVariable %8 Private
+          %2 = OpFunction %5 None %6
+         %13 = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+
+  {
+    std::unique_ptr<ir::IRContext> context =
+        BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text);
+
+    ir::Function& fn = *context->module()->begin();
+
+    ir::BasicBlock& bb_merge = *fn.begin();
+
+    fn.begin().InsertBefore(std::unique_ptr<ir::BasicBlock>(
+        new ir::BasicBlock(std::unique_ptr<ir::Instruction>(new ir::Instruction(
+            context.get(), SpvOpLabel, 0, context->TakeNextId(), {})))));
+    ir::BasicBlock& bb_true = *fn.begin();
+    {
+      opt::InstructionBuilder<> builder(context.get(), bb_true.begin());
+      builder.AddBranch(bb_merge.id());
+    }
+
+    fn.begin().InsertBefore(std::unique_ptr<ir::BasicBlock>(
+        new ir::BasicBlock(std::unique_ptr<ir::Instruction>(new ir::Instruction(
+            context.get(), SpvOpLabel, 0, context->TakeNextId(), {})))));
+    ir::BasicBlock& bb_cond = *fn.begin();
+
+    opt::InstructionBuilder<> builder(context.get(), bb_cond.begin());
+    // This also test consecutive instruction insertion: merge selection +
+    // branch.
+    builder.AddBranchCond(9, bb_true.id(), bb_merge.id(), bb_merge.id());
+
+    Match(text, context.get());
+  }
+}
+
+#endif  // SPIRV_EFFCEE
+
+}  // anonymous namespace

--- a/test/opt/ir_builder.cpp
+++ b/test/opt/ir_builder.cpp
@@ -121,7 +121,7 @@ TEST_F(IRBuilderTest, TestInsnAddition) {
     context->get_def_use_mgr();
     context->get_instr_block(nullptr);
 
-    opt::InstructionBuilder<> builder(context.get(), bb, bb->begin());
+    opt::InstructionBuilder<> builder(context.get(), &*bb->begin());
     ir::Instruction* phi1 = builder.AddPhi(7, {9, 14});
     ir::Instruction* phi2 = builder.AddPhi(10, {16, 14});
 
@@ -145,7 +145,7 @@ TEST_F(IRBuilderTest, TestInsnAddition) {
     ir::BasicBlock* bb = context->cfg()->block(18);
     opt::InstructionBuilder<ir::IRContext::kAnalysisDefUse |
                             ir::IRContext::kAnalysisInstrToBlockMapping>
-        builder(context.get(), bb, bb->begin());
+        builder(context.get(), &*bb->begin());
     ir::Instruction* phi1 = builder.AddPhi(7, {9, 14});
     ir::Instruction* phi2 = builder.AddPhi(10, {16, 14});
 
@@ -208,8 +208,7 @@ TEST_F(IRBuilderTest, TestCondBranchAddition) {
             context.get(), SpvOpLabel, 0, context->TakeNextId(), {})))));
     ir::BasicBlock& bb_true = *fn.begin();
     {
-      opt::InstructionBuilder<> builder(context.get(), &bb_true,
-                                        bb_true.begin());
+      opt::InstructionBuilder<> builder(context.get(), &*bb_true.begin());
       builder.AddBranch(bb_merge.id());
     }
 
@@ -218,7 +217,7 @@ TEST_F(IRBuilderTest, TestCondBranchAddition) {
             context.get(), SpvOpLabel, 0, context->TakeNextId(), {})))));
     ir::BasicBlock& bb_cond = *fn.begin();
 
-    opt::InstructionBuilder<> builder(context.get(), &bb_cond, bb_cond.begin());
+    opt::InstructionBuilder<> builder(context.get(), &bb_cond);
     // This also test consecutive instruction insertion: merge selection +
     // branch.
     builder.AddConditionalBranch(9, bb_true.id(), bb_merge.id(), bb_merge.id());


### PR DESCRIPTION
The idea is to have a common place to abstract the instruction building and insertion process and allow automatic update of some analysis. Analysis are updated only if the user request it.

So far, the class can only construct the instructions I needed for the work I'm doing (so very little):
  - Phi instructions;
  - Conditional and unconditional branches;
  - Merge selection instructions.

Only the def-use manager updates are implemented.
