### PR TITLE
Simplifying code for adding instructions to worklist

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.h
+++ b/source/opt/aggressive_dead_code_elim_pass.h
@@ -72,8 +72,7 @@ class AggressiveDCEPass : public MemPass {
 
   // Add |inst| to worklist_ and live_insts_.
   void AddToWorklist(ir::Instruction* inst) {
-    live_insts_.insert(inst);
-    worklist_.push(inst);
+    if (live_insts_.insert(inst).second) worklist_.push(inst);
   }
 
   // Add all store instruction which use |ptrId|, directly or indirectly,


### PR DESCRIPTION
Addresses #1212

* AddToWorklist can now be called unconditionally
 * It will only add instructions that have not already been marked as
 live
 * Fixes a case where a merge was not added to the worklist because the
 branch was already marked as live
* Added two similar tests that fail without the fix