### PR TITLE
WIP:  Validator disassembles offending instruction during "inline" phase of validation

### DIFF
--- a/source/disassemble.cpp
+++ b/source/disassemble.cpp
@@ -67,6 +67,9 @@ class Disassembler {
                             uint32_t schema);
   // Emits the assembly text for the given instruction.
   spv_result_t HandleInstruction(const spv_parsed_instruction_t& inst);
+  // Updates internal bookkeeping implied by scanning this instruction,
+  // but does not emit the instruction.  Returns SPV_SUCCESS.
+  spv_result_t SkipInstruction(const spv_parsed_instruction_t& inst);
 
   // If not printing, populates text_result with the accumulated text.
   // Returns SPV_SUCCESS on success.
@@ -189,9 +192,14 @@ spv_result_t Disassembler::HandleInstruction(
     ResetColor();
   }
 
-  byte_offset_ += inst.num_words * sizeof(uint32_t);
-
   stream_ << "\n";
+
+  return SkipInstruction(inst);
+}
+
+spv_result_t Disassembler::SkipInstruction(
+    const spv_parsed_instruction_t& inst) {
+  byte_offset_ += inst.num_words * sizeof(uint32_t);
   return SPV_SUCCESS;
 }
 
@@ -396,7 +404,8 @@ spv_result_t DisassembleTargetInstruction(
       return error;
     return SPV_REQUESTED_TERMINATION;
   }
-  return SPV_SUCCESS;
+  // Keep byte offsets bookkeeping updated.
+  return wrapped->disassembler()->SkipInstruction(*parsed_instruction);
 }
 
 }  // anonymous namespace

--- a/source/spirv_stats.cpp
+++ b/source/spirv_stats.cpp
@@ -48,9 +48,11 @@ namespace {
 // instruction.
 class StatsAggregator {
  public:
-  StatsAggregator(SpirvStats* in_out_stats, const spv_const_context context) {
+  StatsAggregator(SpirvStats* in_out_stats, const spv_const_context context,
+                  const uint32_t* words, size_t num_words) {
     stats_ = in_out_stats;
-    vstate_.reset(new ValidationState_t(context, &validator_options_));
+    vstate_.reset(
+        new ValidationState_t(context, &validator_options_, words, num_words));
   }
 
   // Collects header statistics and sets correct id_bound.
@@ -316,7 +318,7 @@ spv_result_t AggregateStats(const spv_context_t& context, const uint32_t* words,
            << "Invalid SPIR-V header.";
   }
 
-  StatsAggregator stats_aggregator(stats, &context);
+  StatsAggregator stats_aggregator(stats, &context, words, num_words);
 
   return spvBinaryParse(&context, &stats_aggregator, words, num_words,
                         ProcessHeader, ProcessInstruction, pDiagnostic);

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -16,6 +16,7 @@
 
 #include <cassert>
 
+#include "disassemble.h"
 #include "opcode.h"
 #include "val/basic_block.h"
 #include "val/construct.h"
@@ -774,6 +775,17 @@ bool ValidationState_t::GetConstantValUint64(uint32_t id, uint64_t* val) const {
     *val |= uint64_t(inst->word(4)) << 32;
   }
   return true;
+}
+
+std::string ValidationState_t::Disassemble(const Instruction& inst) {
+  const spv_parsed_instruction_t& c_inst(inst.c_inst());
+  uint32_t disassembly_options = SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
+                                 SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES |
+                                 SPV_BINARY_TO_TEXT_OPTION_SHOW_BYTE_OFFSET;
+
+  return spvtools::spvInstructionBinaryToText(
+      context()->target_env, c_inst.words, c_inst.num_words, words_, num_words_,
+      disassembly_options);
 }
 
 }  // namespace libspirv

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -139,6 +139,7 @@ ValidationState_t::ValidationState_t(const spv_const_context ctx,
     : context_(ctx),
       options_(opt),
       instruction_counter_(0),
+      diag_suffix_generator_(nullptr),
       unresolved_forward_ids_{},
       operand_names_{},
       current_layout_section_(kLayoutCapabilities),
@@ -246,10 +247,13 @@ bool ValidationState_t::IsOpcodeInCurrentLayoutSection(SpvOp op) {
   return IsInstructionInLayoutSection(current_layout_section_, op);
 }
 
-DiagnosticStream ValidationState_t::diag(spv_result_t error_code) const {
-  return libspirv::DiagnosticStream(
-      {0, 0, static_cast<size_t>(instruction_counter_)}, context_->consumer,
-      error_code);
+SuffixableDiagnosticStream ValidationState_t::diag(
+    spv_result_t error_code) const {
+  return SuffixableDiagnosticStream(
+      libspirv::DiagnosticStream(
+          {0, 0, static_cast<size_t>(instruction_counter_)}, context_->consumer,
+          error_code),
+      diag_suffix_generator_);
 }
 
 deque<Function>& ValidationState_t::functions() { return module_functions_; }

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -135,9 +135,13 @@ bool IsInstructionInLayoutSection(ModuleLayoutSection layout, SpvOp op) {
 }  // anonymous namespace
 
 ValidationState_t::ValidationState_t(const spv_const_context ctx,
-                                     const spv_const_validator_options opt)
+                                     const spv_const_validator_options opt,
+                                     const uint32_t* words,
+                                     const size_t num_words)
     : context_(ctx),
       options_(opt),
+      words_(words),
+      num_words_(num_words),
       instruction_counter_(0),
       diag_suffix_generator_(nullptr),
       unresolved_forward_ids_{},

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -392,7 +392,7 @@ spv_result_t ValidationState_t::RegisterFunctionEnd() {
   return SPV_SUCCESS;
 }
 
-void ValidationState_t::RegisterInstruction(
+Instruction* ValidationState_t::RegisterInstruction(
     const spv_parsed_instruction_t& inst) {
   if (in_function_body()) {
     ordered_instructions_.emplace_back(&inst, &current_function(),
@@ -400,13 +400,9 @@ void ValidationState_t::RegisterInstruction(
   } else {
     ordered_instructions_.emplace_back(&inst, nullptr, nullptr);
   }
-  uint32_t id = ordered_instructions_.back().id();
-  if (id) {
-    all_definitions_.insert(make_pair(id, &ordered_instructions_.back()));
-  }
 
-  // If the instruction is using an OpTypeSampledImage as an operand, it should
-  // be recorded. The validator will ensure that all usages of an
+  // If the instruction is using an OpSampledImage result as an operand, it
+  // should be recorded. The validator will ensure that all usages of an
   // OpTypeSampledImage and its definition are in the same basic block.
   for (uint16_t i = 0; i < inst.num_operands; ++i) {
     const spv_parsed_operand_t& operand = inst.operands[i];
@@ -418,6 +414,12 @@ void ValidationState_t::RegisterInstruction(
       }
     }
   }
+
+  return &(ordered_instructions_.back());
+}
+
+void ValidationState_t::RegisterDefinition(uint32_t id, Instruction* inst) {
+  all_definitions_.insert(make_pair(id, inst));
 }
 
 std::vector<uint32_t> ValidationState_t::getSampledImageConsumers(

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -452,6 +452,9 @@ class ValidationState_t {
   bool GetPointerTypeInfo(uint32_t id, uint32_t* data_type,
                           uint32_t* storage_class) const;
 
+  // Returns the disassembly string for the given instruction.
+  std::string Disassemble(const Instruction&);
+
  private:
   ValidationState_t(const ValidationState_t&);
 

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -103,7 +103,9 @@ class ValidationState_t {
   };
 
   ValidationState_t(const spv_const_context context,
-                    const spv_const_validator_options opt);
+                    const spv_const_validator_options opt,
+                    const uint32_t* words,
+                    const size_t num_words);
 
   /// Returns the context
   spv_const_context context() const { return context_; }
@@ -457,6 +459,10 @@ class ValidationState_t {
 
   /// Stores the Validator command line options. Must be a valid options object.
   const spv_const_validator_options options_;
+
+  /// The SPIR-V binary module we're validating.
+  const uint32_t* words_;
+  const size_t num_words_;
 
   /// Tracks the number of instructions evaluated by the validator
   int instruction_counter_;

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -234,8 +234,8 @@ class ValidationState_t {
 
   const AssemblyGrammar& grammar() const { return grammar_; }
 
-  /// Registers the instruction
-  void RegisterInstruction(const spv_parsed_instruction_t& inst);
+  /// Registers the instruction.  Returns the internal representation.
+  Instruction* RegisterInstruction(const spv_parsed_instruction_t& inst);
 
   /// Registers the decoration for the given <id>
   void RegisterDecorationForId(uint32_t id, const Decoration& dec) {
@@ -288,6 +288,9 @@ class ValidationState_t {
   const std::unordered_map<uint32_t, Instruction*>& all_definitions() const {
     return all_definitions_;
   }
+
+  // Records the instruction defining |result_id|.
+  void RegisterDefinition(uint32_t result_id, Instruction* inst);
 
   /// Returns a vector containing the Ids of instructions that consume the given
   /// SampledImage id.

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -366,7 +366,7 @@ spv_result_t spvValidateBinary(const spv_const_context context,
   spv_validator_options default_options = spvValidatorOptionsCreate();
 
   // Create the ValidationState using the context and default options.
-  ValidationState_t vstate(&hijack_context, default_options);
+  ValidationState_t vstate(&hijack_context, default_options, words, num_words);
 
   spv_result_t result = ValidateBinaryUsingContextAndValidationState(
       hijack_context, words, num_words, pDiagnostic, &vstate);
@@ -386,7 +386,8 @@ spv_result_t spvValidateWithOptions(const spv_const_context context,
   }
 
   // Create the ValidationState using the context.
-  ValidationState_t vstate(&hijack_context, options);
+  ValidationState_t vstate(&hijack_context, options, binary->code,
+                           binary->wordCount);
 
   return ValidateBinaryUsingContextAndValidationState(
       hijack_context, binary->code, binary->wordCount, pDiagnostic, &vstate);
@@ -404,7 +405,8 @@ spv_result_t ValidateBinaryAndKeepValidationState(
     libspirv::UseDiagnosticAsMessageConsumer(&hijack_context, pDiagnostic);
   }
 
-  vstate->reset(new ValidationState_t(&hijack_context, options));
+  vstate->reset(
+      new ValidationState_t(&hijack_context, options, words, num_words));
 
   return ValidateBinaryUsingContextAndValidationState(
       hijack_context, words, num_words, pDiagnostic, vstate->get());

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -270,9 +270,16 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
 
   // NOTE: Parse the module and perform inline validation checks. These
   // checks do not require the the knowledge of the whole module.
+  // First set up a hook to print the at-fault instruction right after
+  // the error message.
+  vstate->SetDiagnosticSuffixGenerator([vstate]() {
+    return std::string("\n") +
+           vstate->Disassemble(vstate->ordered_instructions().back());
+  });
   if (auto error = spvBinaryParse(&context, vstate, words, num_words, setHeader,
                                   ProcessInstruction, pDiagnostic))
     return error;
+  vstate->SetDiagnosticSuffixGenerator(nullptr);
 
   if (vstate->in_function_body())
     return vstate->diag(SPV_ERROR_INVALID_LAYOUT)

--- a/source/validate.h
+++ b/source/validate.h
@@ -26,8 +26,9 @@
 
 namespace libspirv {
 
-class ValidationState_t;
 class BasicBlock;
+class Instruction;
+class ValidationState_t;
 
 /// A function that returns a vector of BasicBlocks given a BasicBlock. Used to
 /// get the successor and predecessor nodes of a CFG block
@@ -89,8 +90,11 @@ spv_result_t ModuleLayoutPass(ValidationState_t& _,
 spv_result_t CfgPass(ValidationState_t& _,
                      const spv_parsed_instruction_t* inst);
 
-/// Performs Id and SSA validation of a module
-spv_result_t IdPass(ValidationState_t& _, const spv_parsed_instruction_t* inst);
+/// Performs Id and SSA validation of a module.  If |inst| is a definition,
+/// then also record |internal_instruction| as the internal representation
+/// of the its instruction.
+spv_result_t IdPass(ValidationState_t& _, const spv_parsed_instruction_t* inst,
+                    Instruction* internal_instruction);
 
 /// Performs validation of the Data Rules subsection of 2.16.1 Universal
 /// Validation Rules.

--- a/test/c_interface_test.cpp
+++ b/test/c_interface_test.cpp
@@ -183,8 +183,10 @@ TEST(CInterface, SpecifyConsumerNullDiagnosticForValidating) {
         // TODO(antiagainst): what validation reports is not a word offset here.
         // It is inconsistent with diassembler. Should be fixed.
         EXPECT_EQ(1u, position.index);
-        EXPECT_STREQ("Nop cannot appear before the memory model instruction",
-                     message);
+        EXPECT_STREQ(
+            "Nop cannot appear before the memory model instruction"
+            "\nOpNop ; 0x00000014",
+            message);
       });
 
   spv_binary binary = nullptr;
@@ -274,8 +276,10 @@ TEST(CInterface, SpecifyConsumerSpecifyDiagnosticForValidating) {
   EXPECT_EQ(SPV_ERROR_INVALID_LAYOUT, spvValidate(context, &b, &diagnostic));
 
   EXPECT_EQ(0, invocation);  // Consumer should not be invoked at all.
-  EXPECT_STREQ("Nop cannot appear before the memory model instruction",
-               diagnostic->error);
+  EXPECT_STREQ(
+      "Nop cannot appear before the memory model instruction"
+      "\nOpNop ; 0x00000014",
+      diagnostic->error);
 
   spvDiagnosticDestroy(diagnostic);
   spvBinaryDestroy(binary);

--- a/test/cpp_interface_test.cpp
+++ b/test/cpp_interface_test.cpp
@@ -42,7 +42,10 @@ TEST(CppInterface, SuccessfulRoundTrip) {
     EXPECT_EQ(0u, position.line);
     EXPECT_EQ(0u, position.column);
     EXPECT_EQ(1u, position.index);
-    EXPECT_STREQ("ID 1 has not been defined", message);
+    EXPECT_STREQ(
+        "ID 1 has not been defined\n"
+        "%2 = OpSizeOf %1 %3 ; 0x00000014",
+        message);
   });
   EXPECT_FALSE(t.Validate(binary));
 

--- a/test/val/val_cfg_test.cpp
+++ b/test/val/val_cfg_test.cpp
@@ -413,7 +413,7 @@ TEST_P(ValidateCFG, MergeBlockTargetedByMultipleHeaderBlocksBad) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(getDiagnosticString(),
                 MatchesRegex("Block .\\[merge\\] is already a merge block "
-                             "for another header"));
+                             "for another header.*"));
   } else {
     ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
   }
@@ -447,7 +447,7 @@ TEST_P(ValidateCFG, MergeBlockTargetedByMultipleHeaderBlocksSelectionBad) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(getDiagnosticString(),
                 MatchesRegex("Block .\\[merge\\] is already a merge block "
-                             "for another header"));
+                             "for another header.*"));
   } else {
     ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
   }
@@ -470,7 +470,7 @@ TEST_P(ValidateCFG, BranchTargetFirstBlockBad) {
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               MatchesRegex("First block .\\[entry\\] of function .\\[Main\\] "
-                           "is targeted by block .\\[bad\\]"));
+                           "is targeted by block .\\[bad\\].*"));
 }
 
 TEST_P(ValidateCFG, BranchConditionalTrueTargetFirstBlockBad) {
@@ -494,7 +494,7 @@ TEST_P(ValidateCFG, BranchConditionalTrueTargetFirstBlockBad) {
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               MatchesRegex("First block .\\[entry\\] of function .\\[Main\\] "
-                           "is targeted by block .\\[bad\\]"));
+                           "is targeted by block .\\[bad\\].*"));
 }
 
 TEST_P(ValidateCFG, BranchConditionalFalseTargetFirstBlockBad) {
@@ -521,7 +521,7 @@ TEST_P(ValidateCFG, BranchConditionalFalseTargetFirstBlockBad) {
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               MatchesRegex("First block .\\[entry\\] of function .\\[Main\\] "
-                           "is targeted by block .\\[bad\\]"));
+                           "is targeted by block .\\[bad\\].*"));
 }
 
 TEST_P(ValidateCFG, SwitchTargetFirstBlockBad) {
@@ -555,7 +555,7 @@ TEST_P(ValidateCFG, SwitchTargetFirstBlockBad) {
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               MatchesRegex("First block .\\[entry\\] of function .\\[Main\\] "
-                           "is targeted by block .\\[bad\\]"));
+                           "is targeted by block .\\[bad\\].*"));
 }
 
 TEST_P(ValidateCFG, BranchToBlockInOtherFunctionBad) {

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -24,6 +24,7 @@
 
 namespace {
 
+using ::testing::Eq;
 using ::testing::HasSubstr;
 using ::testing::MatchesRegex;
 
@@ -161,6 +162,21 @@ TEST_F(ValidateData, vec5) {
   CompileSuccessfully(str.c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr(invalid_comp_error));
+}
+
+TEST_F(ValidateData, vec5_disassembles_instruction) {
+  // This tests that a validation failure during initial "inline" processing
+  // of instructions will disassemble the offending instruction.
+  string str = header + R"(
+%1 = OpTypeFloat 32
+%2 = OpTypeVector %1 5
+)";
+  CompileSuccessfully(str.c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              Eq(std::string(invalid_comp_error) +
+                 " (5) for TypeVector\n"
+                 "%v5float = OpTypeVector %float 5 ; 0x0000003c"));
 }
 
 TEST_F(ValidateData, vec8) {

--- a/test/val/val_ssa_test.cpp
+++ b/test/val/val_ssa_test.cpp
@@ -119,7 +119,8 @@ TEST_F(ValidateSSA, DominateUsageWithinBlockBad) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("ID .\\[bad\\] has not been defined"));
+              MatchesRegex("ID .\\[bad\\] has not been defined\n"
+                           "%8 = OpIAdd %uint %uint_1 %bad ; 0x0000008c"));
 }
 
 TEST_F(ValidateSSA, DominateUsageSameInstructionBad) {
@@ -141,7 +142,8 @@ TEST_F(ValidateSSA, DominateUsageSameInstructionBad) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("ID .\\[sum\\] has not been defined"));
+              MatchesRegex("ID .\\[sum\\] has not been defined\n"
+                           "%sum = OpIAdd %uint %uint_1 %sum ; 0x0000008c"));
 }
 
 TEST_F(ValidateSSA, ForwardNameGood) {
@@ -1185,7 +1187,8 @@ TEST_F(ValidateSSA,
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("ID .\\[inew\\] has not been defined"));
+              MatchesRegex("ID .\\[inew\\] has not been defined\n"
+                           "%19 = OpIAdd %uint %inew %uint_1 ; 0x0000013c"));
 }
 
 TEST_F(ValidateSSA, PhiUseMayComeFromNonDominatingBlockGood) {

--- a/test/val/val_state_test.cpp
+++ b/test/val/val_state_test.cpp
@@ -35,13 +35,17 @@ using libspirv::ExtensionSet;
 using libspirv::ValidationState_t;
 using std::vector;
 
+
+// This is all we need for these tests.
+static uint32_t kFakeBinary[] = {0};
+
 // A test with a ValidationState_t member transparently.
 class ValidationStateTest : public testing::Test {
  public:
   ValidationStateTest()
       : context_(spvContextCreate(SPV_ENV_UNIVERSAL_1_0)),
         options_(spvValidatorOptionsCreate()),
-        state_(context_, options_) {}
+        state_(context_, options_, kFakeBinary, 0) {}
 
   ~ValidationStateTest() {
     spvContextDestroy(context_);

--- a/test/val/val_validation_state_test.cpp
+++ b/test/val/val_validation_state_test.cpp
@@ -25,6 +25,7 @@ namespace {
 
 using std::string;
 using ::testing::HasSubstr;
+using ::testing::Eq;
 
 using ValidationStateTest = spvtest::ValidateBase<bool>;
 
@@ -150,6 +151,24 @@ TEST_F(ValidationStateTest, CheckAccessChainIndexesLimitOption) {
   spvValidatorOptionsSetUniversalLimit(
       options_, spv_validator_limit_max_access_chain_indexes, 100u);
   EXPECT_EQ(100u, options_->universal_limits_.max_access_chain_indexes);
+}
+
+TEST_F(ValidationStateTest, DisassembleCapabilityInst) {
+  CompileSuccessfully("OpCapability Kernel");
+  ValidateAndRetrieveValidationState();
+  auto disassembly =
+      vstate_->Disassemble(vstate_->ordered_instructions().front());
+  EXPECT_THAT(disassembly, Eq("OpCapability Kernel ; 0x00000014"));
+}
+
+TEST_F(ValidationStateTest, DisassembleLastInstTypeUintGetsFriendlyName) {
+  string spirv =
+      string(header) + "%float = OpTypeFloat 32 %a_type = OpTypeInt 32 0";
+  CompileSuccessfully(spirv);
+  ValidateAndRetrieveValidationState();
+  auto disassembly =
+      vstate_->Disassemble(vstate_->ordered_instructions().back());
+  EXPECT_THAT(disassembly, Eq("%uint = OpTypeInt 32 0 ; 0x0000003c"));
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
This has a few moving parts, separated into different commits in this PR.  In reverse order:


   Disassemble the bad instruction during "inline" validation phase

   Add ValidationState_t method to disassemble an instruction
    
      Fixes byte offset accounting when disassembling just a single
      instruction.

    Validator state object holds a reference to the SPIR-V binary

    Validator uses SuffixableDiagnosticGenerator for diagnostics
    
       Currently no suffix is ever offered.

    validator: Register instructions early in the flow
    
       This is a step toward disassembling the at-fault instruction
       for any validation error.

