### PR TITLE
Fixes infinite loop in ADCE

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.h
+++ b/source/opt/aggressive_dead_code_elim_pass.h
@@ -158,6 +158,9 @@ class AggressiveDCEPass : public MemPass {
   // of an enclosing construct's header, if one exists.
   std::unordered_map<ir::BasicBlock*, ir::Instruction*> block2headerBranch_;
 
+  // Maps basic block to their index in the structured order traversal.
+  std::unordered_map<ir::BasicBlock*, uint32_t> structured_order_index_;
+
   // Map from branch to its associated merge instruction, if any
   std::unordered_map<ir::Instruction*, ir::Instruction*> branch2merge_;
 


### PR DESCRIPTION
Addresses #1214 

* Addresses how breaks are indentified to prevent infinite loops when
back to back loop share a merge and header
* Added test to catch the bug

~~Note this will conflict with #1220. I'll rebase when #1220 is merged.~~