### PR TITLE
Added Vulkan-specifc checks to image validation

### DIFF
--- a/source/spirv_target_env.cpp
+++ b/source/spirv_target_env.cpp
@@ -146,3 +146,28 @@ bool spvParseTargetEnv(const char* s, spv_target_env* env) {
     return false;
   }
 }
+
+bool spvIsVulkanEnv(spv_target_env env) {
+  switch (env) {
+    case SPV_ENV_UNIVERSAL_1_0:
+    case SPV_ENV_OPENCL_1_2:
+    case SPV_ENV_OPENCL_EMBEDDED_1_2:
+    case SPV_ENV_OPENCL_2_0:
+    case SPV_ENV_OPENCL_EMBEDDED_2_0:
+    case SPV_ENV_OPENCL_2_1:
+    case SPV_ENV_OPENCL_EMBEDDED_2_1:
+    case SPV_ENV_OPENGL_4_0:
+    case SPV_ENV_OPENGL_4_1:
+    case SPV_ENV_OPENGL_4_2:
+    case SPV_ENV_OPENGL_4_3:
+    case SPV_ENV_OPENGL_4_5:
+    case SPV_ENV_UNIVERSAL_1_1:
+    case SPV_ENV_UNIVERSAL_1_2:
+    case SPV_ENV_OPENCL_2_2:
+    case SPV_ENV_OPENCL_EMBEDDED_2_2:
+      return false;
+    case SPV_ENV_VULKAN_1_0:
+      return true;
+  }
+  return false;
+}

--- a/source/spirv_target_env.h
+++ b/source/spirv_target_env.h
@@ -21,4 +21,7 @@
 // false and sets *env to SPV_ENV_UNIVERSAL_1_0.
 bool spvParseTargetEnv(const char* s, spv_target_env* env);
 
+// Returns true if |env| is a VULKAN environment, false otherwise.
+bool spvIsVulkanEnv(spv_target_env env);
+
 #endif  // LIBSPIRV_SPIRV_TARGET_ENV_H_


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/1115
Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/1116

Implemented Vulkan-specific rules:
- OpTypeImage must declare a scalar 32-bit float or 32-bit integer type
for the “Sampled Type”.
- OpSampledImage must only consume an “Image” operand whose type has its
“Sampled” operand set to 1.