### PR TITLE
Validator: restricted some atomic ops for shaders

### DIFF
--- a/source/validate_atomics.cpp
+++ b/source/validate_atomics.cpp
@@ -48,8 +48,9 @@ spv_result_t AtomicsPass(ValidationState_t& _,
     case SpvOpAtomicXor:
     case SpvOpAtomicFlagTestAndSet:
     case SpvOpAtomicFlagClear: {
-      if (opcode == SpvOpAtomicLoad || opcode == SpvOpAtomicExchange ||
-          opcode == SpvOpAtomicCompareExchange) {
+      if (_.HasCapability(SpvCapabilityKernel) &&
+          (opcode == SpvOpAtomicLoad || opcode == SpvOpAtomicExchange ||
+           opcode == SpvOpAtomicCompareExchange)) {
         if (!_.IsFloatScalarType(result_type) &&
             !_.IsIntScalarType(result_type)) {
           return _.diag(SPV_ERROR_INVALID_DATA)


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/1091

Ban floating point case for OpAtomicLoad, OpAtomicExchange,
OpAtomicCompareExchange. In graphics (Shader) environments, these
instructions only operate on scalar integers. Ban the floating point
case. OpenCL supports atomic_float.