### PR TITLE
Add LoopDescriptor as an IRContext analysis.

### DIFF
--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -40,6 +40,9 @@ void IRContext::BuildInvalidAnalyses(IRContext::Analysis set) {
   if (set & kAnalysisDominatorAnalysis) {
     ResetDominatorAnalysis();
   }
+  if (set & kAnalysisLoopAnalysis) {
+    ResetLoopAnalysis();
+  }
 }
 
 void IRContext::InvalidateAnalysesExceptFor(
@@ -481,6 +484,21 @@ void IRContext::InitializeCombinators() {
   }
 
   valid_analyses_ |= kAnalysisCombinators;
+}
+
+ir::LoopDescriptor* IRContext::GetLoopDescriptor(const ir::Function* f) {
+  if (!AreAnalysesValid(kAnalysisLoopAnalysis)) {
+    ResetLoopAnalysis();
+  }
+
+  std::unordered_map<const ir::Function*, ir::LoopDescriptor>::iterator it =
+      loop_descriptors_.find(f);
+  if (it == loop_descriptors_.end()) {
+    return &loop_descriptors_.emplace(std::make_pair(f, ir::LoopDescriptor(f)))
+                .first->second;
+  }
+
+  return &it->second;
 }
 
 // Gets the dominator analysis for function |f|.

--- a/source/opt/loop_descriptor.cpp
+++ b/source/opt/loop_descriptor.cpp
@@ -18,6 +18,9 @@
 #include <utility>
 #include <vector>
 
+#include "opt/cfg.h"
+#include "opt/dominator_tree.h"
+#include "opt/ir_context.h"
 #include "opt/iterator.h"
 #include "opt/loop_descriptor.h"
 #include "opt/make_unique.h"
@@ -78,6 +81,26 @@ BasicBlock* Loop::FindLoopPreheader(IRContext* ir_context,
       });
   if (is_preheader) return loop_pred;
   return nullptr;
+}
+
+bool Loop::IsInsideLoop(Instruction* inst) const {
+  const BasicBlock* parent_block = inst->context()->get_instr_block(inst);
+  if (!parent_block) return false;
+  return IsInsideLoop(parent_block);
+}
+
+bool Loop::IsBasicBlockInLoopSlow(const BasicBlock* bb) {
+  assert(bb->GetParent() && "The basic block does not belong to a function");
+  IRContext* context = bb->GetParent()->GetParent()->context();
+
+  opt::DominatorAnalysis* dom_analysis =
+      context->GetDominatorAnalysis(bb->GetParent(), *context->cfg());
+  if (!dom_analysis->Dominates(GetHeaderBlock(), bb)) return false;
+
+  opt::PostDominatorAnalysis* postdom_analysis =
+      context->GetPostDominatorAnalysis(bb->GetParent(), *context->cfg());
+  if (!postdom_analysis->Dominates(GetMergeBlock(), bb)) return false;
+  return true;
 }
 
 LoopDescriptor::LoopDescriptor(const Function* f) { PopulateList(f); }

--- a/source/opt/loop_descriptor.h
+++ b/source/opt/loop_descriptor.h
@@ -30,7 +30,7 @@ namespace spvtools {
 namespace opt {
 class DominatorAnalysis;
 struct DominatorTreeNode;
-}
+}  // namespace opt
 namespace ir {
 class IRContext;
 class CFG;

--- a/source/opt/loop_descriptor.h
+++ b/source/opt/loop_descriptor.h
@@ -23,12 +23,16 @@
 #include <unordered_set>
 #include <vector>
 
-#include "opt/module.h"
-#include "opt/pass.h"
+#include "opt/basic_block.h"
 #include "opt/tree_iterator.h"
 
 namespace spvtools {
+namespace opt {
+class DominatorAnalysis;
+struct DominatorTreeNode;
+}
 namespace ir {
+class IRContext;
 class CFG;
 class LoopDescriptor;
 
@@ -128,26 +132,12 @@ class Loop {
   }
 
   // Returns true if the instruction |inst| is inside this loop.
-  inline bool IsInsideLoop(Instruction* inst) const {
-    const BasicBlock* parent_block = inst->context()->get_instr_block(inst);
-    if (!parent_block) return true;
-    return IsInsideLoop(parent_block);
-  }
+  bool IsInsideLoop(Instruction* inst) const;
 
   // Adds the Basic Block |bb| this loop and its parents.
   void AddBasicBlockToLoop(const BasicBlock* bb) {
-#ifndef NDEBUG
-    assert(bb->GetParent() && "The basic block does not belong to a function");
-    IRContext* context = bb->GetParent()->GetParent()->context();
-
-    opt::DominatorAnalysis* dom_analysis =
-        context->GetDominatorAnalysis(bb->GetParent(), *context->cfg());
-    assert(dom_analysis->Dominates(GetHeaderBlock(), bb));
-
-    opt::PostDominatorAnalysis* postdom_analysis =
-        context->GetPostDominatorAnalysis(bb->GetParent(), *context->cfg());
-    assert(postdom_analysis->Dominates(GetMergeBlock(), bb));
-#endif  // NDEBUG
+    assert(IsBasicBlockInLoopSlow(bb) &&
+           "Basic block does not belong to the loop");
 
     for (Loop* loop = this; loop != nullptr; loop = loop->parent_) {
       loop_basic_blocks_.insert(bb->id());
@@ -176,6 +166,11 @@ class Loop {
   // A set of all the basic blocks which comprise the loop structure. Will be
   // computed only when needed on demand.
   BasicBlockListTy loop_basic_blocks_;
+
+  // Check that |bb| is inside the loop using domination properties.
+  // Note: this is for assertion purposes only, IsInsideLoop should be used
+  // instead.
+  bool IsBasicBlockInLoopSlow(const BasicBlock* bb);
 
   // Sets the parent loop of this loop, that is, a loop which contains this loop
   // as a nested child loop.

--- a/test/opt/loop_optimizations/loop_descriptions.cpp
+++ b/test/opt/loop_optimizations/loop_descriptions.cpp
@@ -97,7 +97,7 @@ TEST_F(PassClassTest, BasicVisitFromEntryPoint) {
   EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
                              << text << std::endl;
   const ir::Function* f = spvtest::GetFunction(module, 2);
-  ir::LoopDescriptor ld{f};
+  ir::LoopDescriptor& ld = *context->GetLoopDescriptor(f);
 
   EXPECT_EQ(ld.NumLoops(), 1u);
 
@@ -194,7 +194,7 @@ TEST_F(PassClassTest, LoopWithNoPreHeader) {
   EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
                              << text << std::endl;
   const ir::Function* f = spvtest::GetFunction(module, 2);
-  ir::LoopDescriptor ld{f};
+  ir::LoopDescriptor& ld = *context->GetLoopDescriptor(f);
 
   EXPECT_EQ(ld.NumLoops(), 2u);
 

--- a/test/opt/loop_optimizations/nested_loops.cpp
+++ b/test/opt/loop_optimizations/nested_loops.cpp
@@ -145,7 +145,7 @@ TEST_F(PassClassTest, BasicVisitFromEntryPoint) {
   EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
                              << text << std::endl;
   const ir::Function* f = spvtest::GetFunction(module, 2);
-  ir::LoopDescriptor ld{f};
+  ir::LoopDescriptor& ld = *context->GetLoopDescriptor(f);
 
   EXPECT_EQ(ld.NumLoops(), 3u);
 
@@ -331,7 +331,7 @@ TEST_F(PassClassTest, TripleNestedLoop) {
   EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
                              << text << std::endl;
   const ir::Function* f = spvtest::GetFunction(module, 2);
-  ir::LoopDescriptor ld{f};
+  ir::LoopDescriptor& ld = *context->GetLoopDescriptor(f);
 
   EXPECT_EQ(ld.NumLoops(), 4u);
 
@@ -555,7 +555,7 @@ TEST_F(PassClassTest, LoopParentTest) {
   EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
                              << text << std::endl;
   const ir::Function* f = spvtest::GetFunction(module, 2);
-  ir::LoopDescriptor ld{f};
+  ir::LoopDescriptor& ld = *context->GetLoopDescriptor(f);
 
   EXPECT_EQ(ld.NumLoops(), 4u);
 


### PR DESCRIPTION
This patch the loop descriptors an analysis.

Some function definitions were moved from header to source to avoid circular definition.