### PR TITLE
Fixes in CCP for #1228

### DIFF
--- a/source/opt/ccp_pass.cpp
+++ b/source/opt/ccp_pass.cpp
@@ -62,7 +62,11 @@ SSAPropagator::PropStatus CCPPass::VisitPhi(ir::Instruction* phi) {
     if (it != values_.end()) {
       // We found an argument with a constant value.  Apply the meet operation
       // with the previous arguments.
-      if (meet_val_id == 0) {
+      if (it->second == kVaryingSSAId) {
+        // The "constant" value is actually a placeholder for varying. Return
+        // varying for this phi.
+        return MarkInstructionVarying(phi);
+      } else if (meet_val_id == 0) {
         // This is the first argument we find.  Initialize the result to its
         // constant value id.
         meet_val_id = it->second;

--- a/source/opt/propagator.h
+++ b/source/opt/propagator.h
@@ -259,7 +259,7 @@ class SSAPropagator {
   // be in def-use cycles with other Phi instructions, and (b) they are always
   // executed when a basic block is simulated (see the description of the Sparse
   // Conditional Constant algorithm in the original paper).
-  void AddSSAEdges(ir::Instruction* instr);
+  void AddSSAEdges(ir::Instruction* instr, bool traverse_phis = false);
 
   // IR context to use.
   ir::IRContext* ctx_;


### PR DESCRIPTION
Addresses #1228 

* Forces traversal of phis if the def has changed to varying
* Mark a phi as varying if all incoming values are varying
* added a test to catch the bug

I will wait for a review from @dnovillo before submitting.