### PR TITLE
Improved error message in val capabilities

### DIFF
--- a/source/validate_capability.cpp
+++ b/source/validate_capability.cpp
@@ -195,6 +195,15 @@ spv_result_t CapabilityPass(ValidationState_t& _,
   assert(operand.offset < inst->num_words);
 
   const uint32_t capability = inst->words[operand.offset];
+  const auto capability_str = [&_, capability]() {
+    spv_operand_desc desc = nullptr;
+    if (_.grammar().lookupOperand(SPV_OPERAND_TYPE_CAPABILITY, capability,
+                                  &desc) != SPV_SUCCESS ||
+        !desc) {
+      return std::string("Unknown");
+    }
+    return std::string(desc->name);
+  };
 
   const auto env = _.context()->target_env;
   const bool opencl_embedded = env == SPV_ENV_OPENCL_EMBEDDED_1_2 ||
@@ -207,7 +216,7 @@ spv_result_t CapabilityPass(ValidationState_t& _,
         !IsSupportOptionalVulkan_1_0(capability) &&
         !IsEnabledByExtension(_, capability)) {
       return _.diag(SPV_ERROR_INVALID_CAPABILITY)
-             << "Capability value " << capability
+             << "Capability " << capability_str()
              << " is not allowed by Vulkan 1.0 specification"
              << " (or requires extension)";
     }
@@ -217,7 +226,7 @@ spv_result_t CapabilityPass(ValidationState_t& _,
         !IsEnabledByExtension(_, capability) &&
         !IsEnabledByCapabilityOpenCL_1_2(_, capability)) {
       return _.diag(SPV_ERROR_INVALID_CAPABILITY)
-             << "Capability value " << capability
+             << "Capability " << capability_str()
              << " is not allowed by OpenCL 1.2 " << opencl_profile
              << " Profile specification"
              << " (or requires extension or capability)";
@@ -229,7 +238,7 @@ spv_result_t CapabilityPass(ValidationState_t& _,
         !IsEnabledByExtension(_, capability) &&
         !IsEnabledByCapabilityOpenCL_2_0(_, capability)) {
       return _.diag(SPV_ERROR_INVALID_CAPABILITY)
-             << "Capability value " << capability
+             << "Capability " << capability_str()
              << " is not allowed by OpenCL 2.0/2.1 " << opencl_profile
              << " Profile specification"
              << " (or requires extension or capability)";
@@ -240,7 +249,7 @@ spv_result_t CapabilityPass(ValidationState_t& _,
         !IsEnabledByExtension(_, capability) &&
         !IsEnabledByCapabilityOpenCL_2_0(_, capability)) {
       return _.diag(SPV_ERROR_INVALID_CAPABILITY)
-             << "Capability value " << capability
+             << "Capability " << capability_str()
              << " is not allowed by OpenCL 2.2 " << opencl_profile
              << " Profile specification"
              << " (or requires extension or capability)";

--- a/test/val/val_capability_test.cpp
+++ b/test/val/val_capability_test.cpp
@@ -1591,7 +1591,7 @@ OpMemoryModel Logical GLSL450
   EXPECT_EQ(SPV_ERROR_INVALID_CAPABILITY,
             ValidateInstructions(SPV_ENV_VULKAN_1_0));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Capability value 5 is not allowed by Vulkan 1.0"));
+              HasSubstr("Capability Linkage is not allowed by Vulkan 1.0"));
 }
 
 TEST_F(ValidateCapability, Vulkan10EnabledByExtension) {
@@ -1622,8 +1622,9 @@ OpDecorate %intt BuiltIn PointSize
   CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_0);
   EXPECT_EQ(SPV_ERROR_INVALID_CAPABILITY,
             ValidateInstructions(SPV_ENV_VULKAN_1_0));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Capability value 4427 is not allowed by Vulkan 1.0"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Capability DrawParameters is not allowed by Vulkan 1.0"));
 }
 
 TEST_F(ValidateCapability, NonOpenCL12FullCapability) {
@@ -1640,8 +1641,7 @@ OpMemoryModel Physical64 OpenCL
             ValidateInstructions(SPV_ENV_OPENCL_1_2));
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr(
-          "Capability value 17 is not allowed by OpenCL 1.2 Full Profile"));
+      HasSubstr("Capability Pipes is not allowed by OpenCL 1.2 Full Profile"));
 }
 
 TEST_F(ValidateCapability, OpenCL12FullEnabledByCapability) {
@@ -1675,7 +1675,7 @@ OpMemoryModel Physical64 OpenCL
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "Capability value 43 is not allowed by OpenCL 1.2 Full Profile"));
+          "Capability Sampled1D is not allowed by OpenCL 1.2 Full Profile"));
 }
 
 TEST_F(ValidateCapability, NonOpenCL12EmbeddedCapability) {
@@ -1693,7 +1693,7 @@ OpMemoryModel Physical64 OpenCL
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "Capability value 11 is not allowed by OpenCL 1.2 Embedded Profile"));
+          "Capability Int64 is not allowed by OpenCL 1.2 Embedded Profile"));
 }
 
 TEST_F(ValidateCapability, OpenCL12EmbeddedEnabledByCapability) {
@@ -1724,10 +1724,9 @@ OpMemoryModel Physical64 OpenCL
   CompileSuccessfully(spirv, SPV_ENV_OPENCL_EMBEDDED_1_2);
   EXPECT_EQ(SPV_ERROR_INVALID_CAPABILITY,
             ValidateInstructions(SPV_ENV_OPENCL_EMBEDDED_1_2));
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr(
-          "Capability value 43 is not allowed by OpenCL 1.2 Embedded Profile"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Capability Sampled1D is not allowed by OpenCL 1.2 "
+                        "Embedded Profile"));
 }
 
 TEST_F(ValidateCapability, OpenCL20FullCapability) {
@@ -1758,7 +1757,7 @@ OpMemoryModel Physical64 OpenCL
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "Capability value 0 is not allowed by OpenCL 2.0/2.1 Full Profile"));
+          "Capability Matrix is not allowed by OpenCL 2.0/2.1 Full Profile"));
 }
 
 TEST_F(ValidateCapability, OpenCL20FullEnabledByCapability) {
@@ -1789,10 +1788,9 @@ OpMemoryModel Physical64 OpenCL
   CompileSuccessfully(spirv, SPV_ENV_OPENCL_2_0);
   EXPECT_EQ(SPV_ERROR_INVALID_CAPABILITY,
             ValidateInstructions(SPV_ENV_OPENCL_2_0));
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr(
-          "Capability value 43 is not allowed by OpenCL 2.0/2.1 Full Profile"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Capability Sampled1D is not allowed by OpenCL 2.0/2.1 "
+                        "Full Profile"));
 }
 
 TEST_F(ValidateCapability, NonOpenCL20EmbeddedCapability) {
@@ -1808,7 +1806,7 @@ OpMemoryModel Physical64 OpenCL
   EXPECT_EQ(SPV_ERROR_INVALID_CAPABILITY,
             ValidateInstructions(SPV_ENV_OPENCL_EMBEDDED_2_0));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Capability value 11 is not allowed by OpenCL 2.0/2.1 "
+              HasSubstr("Capability Int64 is not allowed by OpenCL 2.0/2.1 "
                         "Embedded Profile"));
 }
 
@@ -1841,7 +1839,7 @@ OpMemoryModel Physical64 OpenCL
   EXPECT_EQ(SPV_ERROR_INVALID_CAPABILITY,
             ValidateInstructions(SPV_ENV_OPENCL_EMBEDDED_2_0));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Capability value 43 is not allowed by OpenCL 2.0/2.1 "
+              HasSubstr("Capability Sampled1D is not allowed by OpenCL 2.0/2.1 "
                         "Embedded Profile"));
 }
 
@@ -1872,8 +1870,7 @@ OpMemoryModel Physical64 OpenCL
             ValidateInstructions(SPV_ENV_OPENCL_2_2));
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr(
-          "Capability value 0 is not allowed by OpenCL 2.2 Full Profile"));
+      HasSubstr("Capability Matrix is not allowed by OpenCL 2.2 Full Profile"));
 }
 
 TEST_F(ValidateCapability, OpenCL22FullEnabledByCapability) {
@@ -1907,7 +1904,7 @@ OpMemoryModel Physical64 OpenCL
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "Capability value 43 is not allowed by OpenCL 2.2 Full Profile"));
+          "Capability Sampled1D is not allowed by OpenCL 2.2 Full Profile"));
 }
 
 TEST_F(ValidateCapability, NonOpenCL22EmbeddedCapability) {
@@ -1925,7 +1922,7 @@ OpMemoryModel Physical64 OpenCL
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "Capability value 11 is not allowed by OpenCL 2.2 Embedded Profile"));
+          "Capability Int64 is not allowed by OpenCL 2.2 Embedded Profile"));
 }
 
 TEST_F(ValidateCapability, OpenCL22EmbeddedEnabledByCapability) {
@@ -1956,10 +1953,9 @@ OpMemoryModel Physical64 OpenCL
   CompileSuccessfully(spirv, SPV_ENV_OPENCL_EMBEDDED_2_2);
   EXPECT_EQ(SPV_ERROR_INVALID_CAPABILITY,
             ValidateInstructions(SPV_ENV_OPENCL_EMBEDDED_2_2));
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr(
-          "Capability value 43 is not allowed by OpenCL 2.2 Embedded Profile"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Capability Sampled1D is not allowed by OpenCL 2.2 "
+                        "Embedded Profile"));
 }
 
 }  // namespace


### PR DESCRIPTION
The message was printing value of capability instead of a corresponding string.