### PR TITLE
Opt: Add ScalarReplacement to RegisterSizePasses

### DIFF
--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -145,6 +145,7 @@ Optimizer& Optimizer::RegisterSizePasses() {
       .RegisterPass(CreateMergeReturnPass())
       .RegisterPass(CreateInlineExhaustivePass())
       .RegisterPass(CreateAggressiveDCEPass())
+      .RegisterPass(CreateScalarReplacementPass())
       .RegisterPass(CreateLocalAccessChainConvertPass())
       .RegisterPass(CreateLocalSingleBlockLoadStoreElimPass())
       .RegisterPass(CreateLocalSingleStoreElimPass())


### PR DESCRIPTION
While it is theoretically possible for SROA to increase the SPIR-V size of a shader, in practice we are seeing the opposite. Over a variety of shaders, adding SROA is not increasing size for any, and over half are seeing reductions in size, many significantly (over 10%) and some as high as 20-30%. The main benefit comes from dead code elimination whose analysis is improved by breaking structs into components.

This fixes #1249. While the benefit for this shader is modest, it exemplifies how SROA simplifies analysis and  allows other passes (eg DeadInsertElim) to operate better.
