### PR TITLE
Disambiguate between const and nonconst ForEachSuccessorLabel

### DIFF
--- a/source/opt/cfg.h
+++ b/source/opt/cfg.h
@@ -77,14 +77,7 @@ class CFG {
   }
 
   // Registers |blk| to all of its successors.
-  void AddEdges(ir::BasicBlock* blk) {
-    uint32_t blk_id = blk->id();
-    // Force the creation of an entry, not all basic block have predecessors
-    // (such as the entry blocks and some unreachables).
-    label2preds_[blk_id];
-    blk->ForEachSuccessorLabel(
-        [blk_id, this](uint32_t succ_id) { AddEdge(blk_id, succ_id); });
-  }
+  void AddEdges(ir::BasicBlock* blk);
 
   // Registers the basic block id |pred_blk_id| as being a predecessor of the
   // basic block id |succ_blk_id|.

--- a/source/opt/common_uniform_elim_pass.cpp
+++ b/source/opt/common_uniform_elim_pass.cpp
@@ -307,7 +307,8 @@ void CommonUniformElimPass::ComputeStructuredSuccessors(ir::Function* func) {
       }
     }
     // add true successors
-    blk.ForEachSuccessorLabel([&blk, this](uint32_t sbid) {
+    const auto& const_blk = blk;
+    const_blk.ForEachSuccessorLabel([&blk, this](const uint32_t sbid) {
       block2structured_succs_[&blk].push_back(cfg()->block(sbid));
     });
   }

--- a/source/opt/dead_branch_elim_pass.cpp
+++ b/source/opt/dead_branch_elim_pass.cpp
@@ -159,7 +159,8 @@ bool DeadBranchElimPass::MarkLiveBlocks(
       stack.push_back(GetParentBlock(live_lab_id));
     } else {
       // All successors are live.
-      block->ForEachSuccessorLabel([&stack, this](const uint32_t label) {
+      const auto* const_block = block;
+      const_block->ForEachSuccessorLabel([&stack, this](const uint32_t label) {
         stack.push_back(GetParentBlock(label));
       });
     }

--- a/source/opt/dominator_tree.cpp
+++ b/source/opt/dominator_tree.cpp
@@ -180,7 +180,8 @@ void BasicBlockSuccessorHelper<BBType>::CreateSuccessorMap(
     for (BasicBlock& bb : f) {
       if (bb.hasSuccessor()) {
         BasicBlockListTy& pred_list = predecessors_[&bb];
-        bb.ForEachSuccessorLabel(
+        const auto& const_bb = bb;
+        const_bb.ForEachSuccessorLabel(
             [this, &pred_list, &bb,
              &GetSuccessorBasicBlock](const uint32_t successor_id) {
               BasicBlock* succ = GetSuccessorBasicBlock(successor_id);
@@ -203,7 +204,8 @@ void BasicBlockSuccessorHelper<BBType>::CreateSuccessorMap(
     for (BasicBlock& bb : f) {
       BasicBlockListTy& succ_list = successors_[&bb];
 
-      bb.ForEachSuccessorLabel([&](const uint32_t successor_id) {
+      const auto& const_bb = bb;
+      const_bb.ForEachSuccessorLabel([&](const uint32_t successor_id) {
         BasicBlock* succ = GetSuccessorBasicBlock(successor_id);
         succ_list.push_back(succ);
         predecessors_[succ].push_back(&bb);

--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -134,7 +134,8 @@ void LocalSingleStoreElimPass::CalculateImmediateDominators(
   successors_map_.clear();
   for (auto& blk : *func) {
     ordered_blocks.push_back(&blk);
-    blk.ForEachSuccessorLabel([&blk, this](uint32_t sbid) {
+    const auto& const_blk = blk;
+    const_blk.ForEachSuccessorLabel([&blk, this](const uint32_t sbid) {
       successors_map_[&blk].push_back(label2block_[sbid]);
       predecessors_map_[label2block_[sbid]].push_back(&blk);
     });

--- a/source/opt/loop_descriptor.cpp
+++ b/source/opt/loop_descriptor.cpp
@@ -75,7 +75,8 @@ BasicBlock* Loop::FindLoopPreheader(IRContext* ir_context,
   // preheader.
   bool is_preheader = true;
   uint32_t loop_header_id = loop_header_->id();
-  loop_pred->ForEachSuccessorLabel(
+  const auto* const_loop_pred = loop_pred;
+  const_loop_pred->ForEachSuccessorLabel(
       [&is_preheader, loop_header_id](const uint32_t id) {
         if (id != loop_header_id) is_preheader = false;
       });
@@ -205,7 +206,8 @@ void Loop::SetLatchBlock(BasicBlock* latch) {
 #ifndef NDEBUG
   assert(latch->GetParent() && "The basic block does not belong to a function");
 
-  latch->ForEachSuccessorLabel([this](uint32_t id) {
+  const auto* const_latch = latch;
+  const_latch->ForEachSuccessorLabel([this](uint32_t id) {
     assert((!IsInsideLoop(id) || id == GetHeaderBlock()->id()) &&
            "A predecessor of the continue block does not belong to the loop");
   });

--- a/source/opt/mem_pass.cpp
+++ b/source/opt/mem_pass.cpp
@@ -640,7 +640,8 @@ Pass::Status MemPass::InsertPhiInstructions(ir::Function* func) {
     // Look for successor backedge and patch phis in loop header
     // if found.
     uint32_t header = 0;
-    bp->ForEachSuccessorLabel([&header, this](uint32_t succ) {
+    const auto* const_bp = bp;
+    const_bp->ForEachSuccessorLabel([&header, this](uint32_t succ) {
       if (visitedBlocks_.find(succ) == visitedBlocks_.end()) return;
       assert(header == 0);
       header = succ;
@@ -806,7 +807,8 @@ bool MemPass::RemoveUnreachableBlocks(ir::Function* func) {
     worklist.pop();
 
     // All the successors of a live block are also live.
-    block->ForEachSuccessorLabel(mark_reachable);
+    static_cast<const ir::BasicBlock*>(block)->ForEachSuccessorLabel(
+        mark_reachable);
 
     // All the Merge and ContinueTarget blocks of a live block are also live.
     block->ForMergeAndContinueLabel(mark_reachable);

--- a/source/opt/propagator.cpp
+++ b/source/opt/propagator.cpp
@@ -200,7 +200,8 @@ void SSAPropagator::Initialize(ir::Function* fn) {
       Edge(ctx_->cfg()->pseudo_entry_block(), fn->entry().get()));
 
   for (auto& block : *fn) {
-    block.ForEachSuccessorLabel([this, &block](uint32_t label_id) {
+    const auto& const_block = block;
+    const_block.ForEachSuccessorLabel([this, &block](const uint32_t label_id) {
       ir::BasicBlock* succ_bb =
           ctx_->get_instr_block(get_def_use_mgr()->GetDef(label_id));
       bb_succs_[&block].push_back(Edge(&block, succ_bb));


### PR DESCRIPTION
This helps VisualStudio 2013 compile the code.

Contributes to #1262