### PR TITLE
ADCE: Fix combinator initialization

### DIFF
--- a/source/opt/feature_manager.h
+++ b/source/opt/feature_manager.h
@@ -41,6 +41,11 @@ class FeatureManager {
   // Analyzes |module| and records enabled extensions and capabilities.
   void Analyze(ir::Module* module);
 
+  libspirv::CapabilitySet* GetCapabilities() { return &capabilities_; }
+  const libspirv::CapabilitySet* GetCapabilities() const {
+    return &capabilities_;
+  }
+
  private:
   // Analyzes |module| and records enabled extensions.
   void AddExtensions(ir::Module* module);

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -474,9 +474,9 @@ void IRContext::AddCombinatorsForExtension(ir::Instruction* extension) {
 }
 
 void IRContext::InitializeCombinators() {
-  for (auto& capability : module()->capabilities()) {
-    AddCombinatorsForCapability(capability.GetSingleWordInOperand(0));
-  }
+  get_feature_mgr()->GetCapabilities()->ForEach([this](SpvCapability cap) {
+    AddCombinatorsForCapability(cap);
+  });
 
   for (auto& extension : module()->ext_inst_imports()) {
     AddCombinatorsForExtension(&extension);


### PR DESCRIPTION
The combinator initialization was only looking at the capabilities
in the original shader code and not the inferred capabilities.
Geometry and tessellation shaders compiled by glslang did not
have the Shader capability explicitly set in the original code as it
is inferred. So the combinator set was not initialized correctly
causing problems for ADCE.