### PR TITLE
Fix type manager memory management for multi-level types

### DIFF
--- a/source/opt/type_manager.h
+++ b/source/opt/type_manager.h
@@ -162,6 +162,11 @@ class TypeManager {
   // |type| (e.g. should be called in loop of |type|'s decorations).
   void AttachDecoration(const spvtools::ir::Instruction& inst, Type* type);
 
+  // Returns an equivalent pointer to |type| built in terms of pointers owned by
+  // |type_pool_|. For example, if |type| is a vec3 of bool, it will be rebuilt
+  // replacing the bool subtype with one owned by |type_pool_|.
+  Type* RebuildType(const Type& type);
+
   const MessageConsumer& consumer_;  // Message consumer.
   spvtools::ir::IRContext* context_;
   IdToTypeMap id_to_type_;  // Mapping from ids to their type representations.

--- a/source/opt/types.h
+++ b/source/opt/types.h
@@ -485,6 +485,7 @@ class ForwardPointer : public Type {
   uint32_t target_id() const { return target_id_; }
   void SetTargetPointer(Pointer* pointer) { pointer_ = pointer; }
   SpvStorageClass storage_class() const { return storage_class_; }
+  const Pointer* target_pointer() const { return pointer_; }
 
   bool IsSame(const Type* that) const override;
   std::string str() const override;

--- a/test/opt/type_manager_test.cpp
+++ b/test/opt/type_manager_test.cpp
@@ -649,7 +649,7 @@ TEST(TypeManager, RegisterAndRemoveId) {
 OpCapability Shader
 OpMemoryModel Logical GLSL450
 %1 = OpTypeInt 32 0
-  )";
+)";
 
   std::unique_ptr<ir::IRContext> context =
       BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text,
@@ -662,6 +662,60 @@ OpMemoryModel Logical GLSL450
     Integer u32(32, false);
     Struct st({&u32});
     context->get_type_mgr()->RegisterType(id, st);
+  }
+
+  context->get_type_mgr()->RemoveId(id);
+  EXPECT_EQ(nullptr, context->get_type_mgr()->GetType(id));
+}
+
+TEST(TypeManager, RegisterAndRemoveIdAllTypes) {
+  const std::string text = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+)";
+
+  std::unique_ptr<ir::IRContext> context =
+      BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  EXPECT_NE(context, nullptr);
+
+  std::vector<std::unique_ptr<Type>> types = GenerateAllTypes();
+  uint32_t id = 1u;
+  for (auto& t : types) {
+    context->get_type_mgr()->RegisterType(id, *t);
+    EXPECT_EQ(*t, *context->get_type_mgr()->GetType(id));
+  }
+  types.clear();
+
+  for (; id > 0; --id) {
+    context->get_type_mgr()->RemoveId(id);
+    EXPECT_EQ(nullptr, context->get_type_mgr()->GetType(id));
+  }
+}
+
+TEST(TypeManager, RegisterAndRemoveIdWithDecorations) {
+  const std::string text = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+%1 = OpTypeInt 32 0
+)";
+
+  std::unique_ptr<ir::IRContext> context =
+      BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  EXPECT_NE(context, nullptr);
+
+  uint32_t id = 2u;
+  {
+    Integer u32(32, false);
+    Struct st({&u32, &u32});
+    st.AddDecoration({10});
+    st.AddDecoration({11});
+    st.AddMemberDecoration(0, {{35, 4}});
+    st.AddMemberDecoration(1, {{35, 4}});
+    st.AddMemberDecoration(1, {{36, 5}});
+    context->get_type_mgr()->RegisterType(id, st);
+    EXPECT_EQ(st, *context->get_type_mgr()->GetType(id));
   }
 
   context->get_type_mgr()->RemoveId(id);

--- a/test/opt/type_manager_test.cpp
+++ b/test/opt/type_manager_test.cpp
@@ -644,6 +644,30 @@ OpMemoryModel Logical GLSL450
   EXPECT_TRUE(type->IsSame(&st));
 }
 
+TEST(TypeManager, RegisterAndRemoveId) {
+  const std::string text = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+%1 = OpTypeInt 32 0
+  )";
+
+  std::unique_ptr<ir::IRContext> context =
+      BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  EXPECT_NE(context, nullptr);
+
+  uint32_t id = 2u;
+  {
+    // Ensure that u32 goes out of scope.
+    Integer u32(32, false);
+    Struct st({&u32});
+    context->get_type_mgr()->RegisterType(id, st);
+  }
+
+  context->get_type_mgr()->RemoveId(id);
+  EXPECT_EQ(nullptr, context->get_type_mgr()->GetType(id));
+}
+
 #ifdef SPIRV_EFFCEE
 TEST(TypeManager, GetTypeInstructionInt) {
   const std::string text = R"(


### PR DESCRIPTION
Fixes #1265 

The type manager now rebuilds component types in terms of memory it owns in addition to the input type. The allows the usage that follows to be safe if that type is later removed during subsequent optimizations.
```
Bool bool_ty;
Vector vec_ty(&bool_ty, 3);
uint32_t id = context()->get_type_mgr()->GetTypeInstruction(&vec_ty);
```