### PR TITLE
Enable Visual Studio 2013 again

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,6 +9,7 @@ version: "{build}"
 os:
   - Visual Studio 2017
   - Visual Studio 2015
+  - Visual Studio 2013
 
 platform:
   - x64
@@ -35,6 +36,8 @@ matrix:
   exclude:
     - os: Visual Studio 2015
       configuration: Debug
+    - os: Visual Studio 2013
+      configuration: Debug
 
 # scripts that run after cloning repository
 install:
@@ -50,6 +53,7 @@ before_build:
   - git clone --depth=1 https://github.com/google/effcee.git external/effcee
   - git clone --depth=1 https://github.com/google/re2.git external/re2
   # Set path and environment variables for the current Visual Studio version
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2013" (call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86_amd64)
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" (call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64)
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" (call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64)
 
@@ -59,7 +63,7 @@ build:
 
 build_script:
   - mkdir build && cd build
-  - cmake -GNinja -DSPIRV_BUILD_COMPRESSION=ON -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DCMAKE_INSTALL_PREFIX=install ..
+  - cmake -GNinja -DSPIRV_BUILD_COMPRESSION=ON -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DCMAKE_INSTALL_PREFIX=install -DRE2_BUILD_TESTING=OFF ..
   - ninja install
 
 test_script:

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -66,43 +66,53 @@ if (NOT ${SPIRV_SKIP_TESTS})
     endforeach()
   endif()
 
-  # Find Effcee and RE2, for testing.
-  # Optional for now, but eventually we'll make this required.
-
-  # First find RE2, since Effcee depends on it.
-  # If already configured, then use that.  Otherwise, prefer to find it under 're2'
-  # in this directory.
-  if (NOT TARGET re2)
-    # If we are configuring RE2, then turn off its testing.  It takes a long time and
-    # does not add much value for us.  If an enclosing project configured RE2, then it
-    # has already chosen whether to enable RE2 tesitng.
-    set(RE2_BUILD_TESTING OFF CACHE STRING "Run RE2 Tests")
-    if (NOT RE2_SOURCE_DIR)
-      if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/re2)
-        set(RE2_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/re2" CACHE STRING "RE2 source dir" )
-      endif()
+  set(SPIRV_ENABLE_EFFCEE ON)
+  if (MSVC)
+    if (MSVC_VERSION LESS 1900)
+      message(STATUS "SPIRV-Tools: Need Visual Studio 2015 or later for Effcee and RE2")
+      set(SPIRV_ENABLE_EFFCEE OFF)
     endif()
   endif()
 
-  if (NOT TARGET effcee)
-    # Expect to find effcee in this directory.
-    if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/effcee)
-      # If we're configuring RE2 (via Effcee), then turn off RE2 testing.
-      if (NOT TARGET re2)
-        set(RE2_BUILD_TESTING OFF)
+  if (SPIRV_ENABLE_EFFCEE)
+    # Find Effcee and RE2, for testing.
+    # Optional for now, but eventually we'll make this required.
+
+    # First find RE2, since Effcee depends on it.
+    # If already configured, then use that.  Otherwise, prefer to find it under 're2'
+    # in this directory.
+    if (NOT TARGET re2)
+      # If we are configuring RE2, then turn off its testing.  It takes a long time and
+      # does not add much value for us.  If an enclosing project configured RE2, then it
+      # has already chosen whether to enable RE2 tesitng.
+      set(RE2_BUILD_TESTING OFF CACHE STRING "Run RE2 Tests")
+      if (NOT RE2_SOURCE_DIR)
+	if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/re2)
+	  set(RE2_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/re2" CACHE STRING "RE2 source dir" )
+	endif()
       endif()
-      if (MSVC)
-        # SPIRV-Tools uses the shared CRT with MSVC.  Tell Effcee to do the same.
-        set(EFFCEE_ENABLE_SHARED_CRT ON)
-      endif()
-      add_subdirectory(effcee)
-      set_property(TARGET effcee PROPERTY FOLDER Effcee)
-      # Turn off warnings for effcee and re2
-      set_property(TARGET effcee APPEND PROPERTY COMPILE_OPTIONS -w)
-      set_property(TARGET re2 APPEND PROPERTY COMPILE_OPTIONS -w)
     endif()
+
+    if (NOT TARGET effcee)
+      # Expect to find effcee in this directory.
+      if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/effcee)
+	# If we're configuring RE2 (via Effcee), then turn off RE2 testing.
+	if (NOT TARGET re2)
+	  set(RE2_BUILD_TESTING OFF)
+	endif()
+	if (MSVC)
+	  # SPIRV-Tools uses the shared CRT with MSVC.  Tell Effcee to do the same.
+	  set(EFFCEE_ENABLE_SHARED_CRT ON)
+	endif()
+	add_subdirectory(effcee)
+	set_property(TARGET effcee PROPERTY FOLDER Effcee)
+	# Turn off warnings for effcee and re2
+	set_property(TARGET effcee APPEND PROPERTY COMPILE_OPTIONS -w)
+	set_property(TARGET re2 APPEND PROPERTY COMPILE_OPTIONS -w)
+      endif()
+    endif()
+    # TODO(dneto): Eventually, require this.
   endif()
-  # TODO(dneto): Eventually, require this.
   if (TARGET effcee)
     message(STATUS "SPIRV-Tools: Effcee is configured")
   else()


### PR DESCRIPTION
Disable use of Effcee and RE2 with MSVC compilers older than VisualStudio 2015
since RE2 doesn't support them.