### PR TITLE
Fix test inclusion when Effcee is absent

### DIFF
--- a/test/opt/type_manager_test.cpp
+++ b/test/opt/type_manager_test.cpp
@@ -62,6 +62,8 @@ void Match(const std::string& original, ir::IRContext* context,
       << assembly;
 }
 
+#endif
+
 std::vector<std::unique_ptr<Type>> GenerateAllTypes() {
   // Types in this test case are only equal to themselves, nothing else.
   std::vector<std::unique_ptr<Type>> types;
@@ -167,8 +169,6 @@ std::vector<std::unique_ptr<Type>> GenerateAllTypes() {
 
   return types;
 }
-
-#endif
 
 TEST(TypeManager, TypeStrings) {
   const std::string text = R"(


### PR DESCRIPTION
Without this fix, the build breaks when the Effcee source is absent or Effcee is not configured to build:

type_manager_test.cpp:682:63: error: ‘GenerateAllTypes’ was not declared in this scope                                                    
   std::vector<std::unique_ptr<Type>> types = GenerateAllTypes();       
