### PR TITLE
SROA: Do scalar replacement on structs with no partial references.

### DIFF
--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -592,9 +592,9 @@ bool ScalarReplacementPass::CheckUses(const ir::Instruction* inst) const {
   VariableStats stats = {0, 0};
   bool ok = CheckUses(inst, &stats);
 
-  // TODO(alanbaker): Extend this to some meaningful heuristics about when
-  // SRoA is valuable.
-  if (stats.num_partial_accesses == 0) ok = false;
+  // TODO(alanbaker/greg-lunarg): Add some meaningful heuristics about when
+  // SRoA is costly, such as when the structure has many (unaccessed?)
+  // members. 
 
   return ok;
 }

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -594,7 +594,7 @@ bool ScalarReplacementPass::CheckUses(const ir::Instruction* inst) const {
 
   // TODO(alanbaker/greg-lunarg): Add some meaningful heuristics about when
   // SRoA is costly, such as when the structure has many (unaccessed?)
-  // members. 
+  // members.
 
   return ok;
 }

--- a/test/opt/scalar_replacement_test.cpp
+++ b/test/opt/scalar_replacement_test.cpp
@@ -1139,7 +1139,7 @@ OpFunctionEnd
 #endif  // SPIRV_EFFCEE
 
 TEST_F(ScalarReplacementTest, ReplaceNoPartialRefs) {
-// Replace structs whose individual components are not referenced.
+  // Replace structs whose individual components are not referenced.
   const std::string before_predefs =
       R"(OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"

--- a/test/opt/scalar_replacement_test.cpp
+++ b/test/opt/scalar_replacement_test.cpp
@@ -1138,4 +1138,201 @@ OpFunctionEnd
 }
 #endif  // SPIRV_EFFCEE
 
+TEST_F(ScalarReplacementTest, ReplaceNoPartialRefs) {
+// Replace structs whose individual components are not referenced.
+  const std::string before_predefs =
+      R"(OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %fo
+OpExecutionMode %main OriginUpperLeft
+OpSource GLSL 430
+OpName %main "main"
+OpName %S "S"
+OpMemberName %S 0 "x"
+OpMemberName %S 1 "y"
+OpName %ts1 "ts1"
+OpName %S_0 "S"
+OpMemberName %S_0 0 "x"
+OpMemberName %S_0 1 "y"
+OpName %U_t "U_t"
+OpMemberName %U_t 0 "g_s1"
+OpMemberName %U_t 1 "g_s2"
+OpMemberName %U_t 2 "g_s3"
+OpName %_ ""
+OpName %ts2 "ts2"
+OpName %_Globals_ "_Globals_"
+OpMemberName %_Globals_ 0 "g_b"
+OpName %__0 ""
+OpName %ts3 "ts3"
+OpName %ts4 "ts4"
+OpName %fo "fo"
+OpMemberDecorate %S_0 0 Offset 0
+OpMemberDecorate %S_0 1 Offset 4
+OpMemberDecorate %U_t 0 Offset 0
+OpMemberDecorate %U_t 1 Offset 8
+OpMemberDecorate %U_t 2 Offset 16
+OpDecorate %U_t BufferBlock
+OpDecorate %_ DescriptorSet 0
+OpMemberDecorate %_Globals_ 0 Offset 0
+OpDecorate %_Globals_ Block
+OpDecorate %__0 DescriptorSet 0
+OpDecorate %__0 Binding 0
+OpDecorate %fo Location 0
+%void = OpTypeVoid
+%15 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%S = OpTypeStruct %float %float
+%_ptr_Function_S = OpTypePointer Function %S
+%S_0 = OpTypeStruct %float %float
+%U_t = OpTypeStruct %S_0 %S_0 %S_0
+%_ptr_Uniform_U_t = OpTypePointer Uniform %U_t
+%_ = OpVariable %_ptr_Uniform_U_t Uniform
+%int = OpTypeInt 32 1
+%int_0 = OpConstant %int 0
+%_ptr_Uniform_S_0 = OpTypePointer Uniform %S_0
+%_ptr_Function_float = OpTypePointer Function %float
+%int_1 = OpConstant %int 1
+%uint = OpTypeInt 32 0
+%_Globals_ = OpTypeStruct %uint
+%_ptr_Uniform__Globals_ = OpTypePointer Uniform %_Globals_
+%__0 = OpVariable %_ptr_Uniform__Globals_ Uniform
+%_ptr_Uniform_uint = OpTypePointer Uniform %uint
+%bool = OpTypeBool
+%uint_0 = OpConstant %uint 0
+%_ptr_Output_float = OpTypePointer Output %float
+%fo = OpVariable %_ptr_Output_float Output
+)";
+
+  const std::string after_predefs =
+      R"(OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %fo
+OpExecutionMode %main OriginUpperLeft
+OpSource GLSL 430
+OpName %main "main"
+OpName %S "S"
+OpMemberName %S 0 "x"
+OpMemberName %S 1 "y"
+OpName %U_t "U_t"
+OpMemberName %U_t 0 "g_s1"
+OpMemberName %U_t 1 "g_s2"
+OpMemberName %U_t 2 "g_s3"
+OpName %_ ""
+OpName %_Globals_ "_Globals_"
+OpMemberName %_Globals_ 0 "g_b"
+OpName %__0 ""
+OpName %fo "fo"
+OpMemberDecorate %S 0 Offset 0
+OpMemberDecorate %S 1 Offset 4
+OpMemberDecorate %U_t 0 Offset 0
+OpMemberDecorate %U_t 1 Offset 8
+OpMemberDecorate %U_t 2 Offset 16
+OpDecorate %U_t BufferBlock
+OpDecorate %_ DescriptorSet 0
+OpMemberDecorate %_Globals_ 0 Offset 0
+OpDecorate %_Globals_ Block
+OpDecorate %__0 DescriptorSet 0
+OpDecorate %__0 Binding 0
+OpDecorate %fo Location 0
+%void = OpTypeVoid
+%15 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%S = OpTypeStruct %float %float
+%U_t = OpTypeStruct %S %S %S
+%_ptr_Uniform_U_t = OpTypePointer Uniform %U_t
+%_ = OpVariable %_ptr_Uniform_U_t Uniform
+%int = OpTypeInt 32 1
+%int_0 = OpConstant %int 0
+%_ptr_Uniform_S = OpTypePointer Uniform %S
+%int_1 = OpConstant %int 1
+%uint = OpTypeInt 32 0
+%_Globals_ = OpTypeStruct %uint
+%_ptr_Uniform__Globals_ = OpTypePointer Uniform %_Globals_
+%__0 = OpVariable %_ptr_Uniform__Globals_ Uniform
+%_ptr_Uniform_uint = OpTypePointer Uniform %uint
+%bool = OpTypeBool
+%uint_0 = OpConstant %uint 0
+%_ptr_Output_float = OpTypePointer Output %float
+%fo = OpVariable %_ptr_Output_float Output
+)";
+
+  const std::string before_func =
+      R"(%main = OpFunction %void None %15
+%30 = OpLabel
+%ts1 = OpVariable %_ptr_Function_S Function
+%ts2 = OpVariable %_ptr_Function_S Function
+%ts3 = OpVariable %_ptr_Function_S Function
+%ts4 = OpVariable %_ptr_Function_S Function
+%31 = OpAccessChain %_ptr_Uniform_S_0 %_ %int_0
+%32 = OpLoad %S_0 %31
+%33 = OpCompositeExtract %float %32 0
+%34 = OpAccessChain %_ptr_Function_float %ts1 %int_0
+OpStore %34 %33
+%35 = OpCompositeExtract %float %32 1
+%36 = OpAccessChain %_ptr_Function_float %ts1 %int_1
+OpStore %36 %35
+%37 = OpAccessChain %_ptr_Uniform_S_0 %_ %int_1
+%38 = OpLoad %S_0 %37
+%39 = OpCompositeExtract %float %38 0
+%40 = OpAccessChain %_ptr_Function_float %ts2 %int_0
+OpStore %40 %39
+%41 = OpCompositeExtract %float %38 1
+%42 = OpAccessChain %_ptr_Function_float %ts2 %int_1
+OpStore %42 %41
+%43 = OpAccessChain %_ptr_Uniform_uint %__0 %int_0
+%44 = OpLoad %uint %43
+%45 = OpINotEqual %bool %44 %uint_0
+OpSelectionMerge %46 None
+OpBranchConditional %45 %47 %48
+%47 = OpLabel
+%49 = OpLoad %S %ts1
+OpStore %ts3 %49
+OpBranch %46
+%48 = OpLabel
+%50 = OpLoad %S %ts2
+OpStore %ts3 %50
+OpBranch %46
+%46 = OpLabel
+%51 = OpLoad %S %ts3
+OpStore %ts4 %51
+%52 = OpAccessChain %_ptr_Function_float %ts4 %int_1
+%53 = OpLoad %float %52
+OpStore %fo %53
+OpReturn
+OpFunctionEnd
+)";
+
+  const std::string after_func =
+      R"(%main = OpFunction %void None %15
+%30 = OpLabel
+%31 = OpAccessChain %_ptr_Uniform_S %_ %int_0
+%32 = OpLoad %S %31
+%35 = OpCompositeExtract %float %32 1
+%37 = OpAccessChain %_ptr_Uniform_S %_ %int_1
+%38 = OpLoad %S %37
+%41 = OpCompositeExtract %float %38 1
+%43 = OpAccessChain %_ptr_Uniform_uint %__0 %int_0
+%44 = OpLoad %uint %43
+%45 = OpINotEqual %bool %44 %uint_0
+OpSelectionMerge %46 None
+OpBranchConditional %45 %47 %48
+%47 = OpLabel
+OpBranch %46
+%48 = OpLabel
+OpBranch %46
+%46 = OpLabel
+%78 = OpPhi %float %35 %47 %41 %48
+OpStore %fo %78
+OpReturn
+OpFunctionEnd
+)";
+
+  AddPass<opt::ScalarReplacementPass>();
+  AddPass<opt::LocalMultiStoreElimPass>();
+  AddPass<opt::InsertExtractElimPass>();
+  AddPass<opt::AggressiveDCEPass>();
+  RunAndCheck(before_predefs + before_func, after_predefs + after_func);
+}
 }  // namespace


### PR DESCRIPTION
This change allows for scalar replacement of structs with no references to their individual components. This was previously disabled, likely due to concern about increasing shader size.

While theoretically one might be able to write a shader for which this change may cause the shader to become larger when optimized, in practice all the shaders observed did not get larger, and a few shaders experienced moderate to large size decreases. This is because SROA allows better analysis of struct references enabling improved dead code detection, among other optimizations.

The new test in this commit demonstrates the code pattern which benefits from this change. It is a pattern similar to that generated when a struct valued function with early returns is inlined. This test also demonstrates how such a pattern can mask dead code and how this change allows for its deletion by subsequent passes.