### PR TITLE
Fix spirv.h include to rely on include paths

### DIFF
--- a/source/opt/const_folding_rules.h
+++ b/source/opt/const_folding_rules.h
@@ -17,12 +17,12 @@
 
 #include <vector>
 
-#include "../../external/spirv-headers/include/spirv/1.2/spirv.h"
 #include "constants.h"
 #include "def_use_manager.h"
 #include "folding_rules.h"
 #include "ir_builder.h"
 #include "ir_context.h"
+#include "spirv/1.2/spirv.h"
 
 namespace spvtools {
 namespace opt {


### PR DESCRIPTION
This is important when SPIRV-Headers are not checked out to external/
folder and mirrors other places in the code where spirv.h is included.