### PR TITLE
Use proper #include guard in mem-pass.h

### DIFF
--- a/source/opt/mem_pass.h
+++ b/source/opt/mem_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_OPT_PASS_H_
-#define LIBSPIRV_OPT_OPT_PASS_H_
+#ifndef LIBSPIRV_OPT_MEM_PASS_H_
+#define LIBSPIRV_OPT_MEM_PASS_H_
 
 #include <algorithm>
 #include <list>
@@ -216,4 +216,4 @@ class MemPass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_OPT_PASS_H_
+#endif  // LIBSPIRV_OPT_MEM_PASS_H_


### PR DESCRIPTION
This header file was using the wrong include guard.  NFC.