### PR TITLE
Add id to name map

### DIFF
--- a/source/opt/if_conversion.h
+++ b/source/opt/if_conversion.h
@@ -33,7 +33,7 @@ class IfConversion : public Pass {
     return ir::IRContext::kAnalysisDefUse |
            ir::IRContext::kAnalysisDominatorAnalysis |
            ir::IRContext::kAnalysisInstrToBlockMapping |
-           ir::IRContext::kAnalysisCFG;
+           ir::IRContext::kAnalysisCFG | ir::IRContext::kAnalysisNameMap;
   }
 
  private:

--- a/source/opt/local_redundancy_elimination.h
+++ b/source/opt/local_redundancy_elimination.h
@@ -38,7 +38,8 @@ class LocalRedundancyEliminationPass : public Pass {
            ir::IRContext::kAnalysisInstrToBlockMapping |
            ir::IRContext::kAnalysisDecorations |
            ir::IRContext::kAnalysisCombinators | ir::IRContext::kAnalysisCFG |
-           ir::IRContext::kAnalysisDominatorAnalysis;
+           ir::IRContext::kAnalysisDominatorAnalysis |
+           ir::IRContext::kAnalysisNameMap;
   }
 
  protected:

--- a/source/opt/private_to_local_pass.h
+++ b/source/opt/private_to_local_pass.h
@@ -33,7 +33,8 @@ class PrivateToLocalPass : public Pass {
     return ir::IRContext::kAnalysisDefUse |
            ir::IRContext::kAnalysisDecorations |
            ir::IRContext::kAnalysisCombinators | ir::IRContext::kAnalysisCFG |
-           ir::IRContext::kAnalysisDominatorAnalysis;
+           ir::IRContext::kAnalysisDominatorAnalysis |
+           ir::IRContext::kAnalysisNameMap;
   }
 
  private:
@@ -43,18 +44,19 @@ class PrivateToLocalPass : public Pass {
 
   // |inst| is an instruction declaring a varible.  If that variable is
   // referenced in a single function and all of uses are valid as defined by
-  // |IsValidUse|, then that function is returned.  Otherwise, the return value
-  // is |nullptr|.
+  // |IsValidUse|, then that function is returned.  Otherwise, the return
+  // value is |nullptr|.
   ir::Function* FindLocalFunction(const ir::Instruction& inst) const;
 
-  // Returns true is |inst| is a valid use of a pointer.  In this case, a valid
-  // use is one where the transformation is able to rewrite the type to match a
-  // change in storage class of the original variable.
+  // Returns true is |inst| is a valid use of a pointer.  In this case, a
+  // valid use is one where the transformation is able to rewrite the type to
+  // match a change in storage class of the original variable.
   bool IsValidUse(const ir::Instruction* inst) const;
 
-  // Given the result id of a pointer type, |old_type_id|, this function returns
-  // the id of a the same pointer type except the storage class has been changed
-  // to function.  If the type does not already exist, it will be created.
+  // Given the result id of a pointer type, |old_type_id|, this function
+  // returns the id of a the same pointer type except the storage class has
+  // been changed to function.  If the type does not already exist, it will be
+  // created.
   uint32_t GetNewType(uint32_t old_type_id);
 
   // Updates |inst|, and any instruction dependent on |inst|, to reflect the

--- a/source/opt/scalar_replacement_pass.h
+++ b/source/opt/scalar_replacement_pass.h
@@ -39,7 +39,8 @@ class ScalarReplacementPass : public Pass {
     return ir::IRContext::kAnalysisDefUse |
            ir::IRContext::kAnalysisInstrToBlockMapping |
            ir::IRContext::kAnalysisDecorations |
-           ir::IRContext::kAnalysisCombinators | ir::IRContext::kAnalysisCFG;
+           ir::IRContext::kAnalysisCombinators | ir::IRContext::kAnalysisCFG |
+           ir::IRContext::kAnalysisNameMap;
   }
 
  private:


### PR DESCRIPTION
Adding a map from an id to it set of OpName and OpMemberName
instructions.  This will be used in KillNameAndDecorates to kill the
names for the ids that are being removed.

In my test, the compile time for 50 shaders went from 1m57s to 55s.
This was on linux using the release build.

Fixes #1290.