### PR TITLE
spriv-dis: Use max_digits10 instead of digits10 for float output precision

### DIFF
--- a/source/util/hex_float.h
+++ b/source/util/hex_float.h
@@ -1089,7 +1089,7 @@ std::ostream& operator<<(std::ostream& os, const FloatProxy<T>& value) {
     case FP_ZERO:
     case FP_NORMAL: {
       auto saved_precision = os.precision();
-      os.precision(std::numeric_limits<T>::digits10);
+      os.precision(std::numeric_limits<T>::max_digits10);
       os << float_val;
       os.precision(saved_precision);
     } break;

--- a/test/binary_to_text_test.cpp
+++ b/test/binary_to_text_test.cpp
@@ -255,13 +255,14 @@ INSTANTIATE_TEST_CASE_P(
                 "%1 = OpTypeFloat 16\n%2 = OpConstant %1 0x1.ff4p+16\n",
                 "%1 = OpTypeFloat 16\n%2 = OpConstant %1 -0x1.d2cp-10\n",
                 // 32-bit floats
-                "%1 = OpTypeFloat 32\n%2 = OpConstant %1 -3.275\n",
+                "%1 = OpTypeFloat 32\n%2 = OpConstant %1 -3.2750001\n",
+                "%1 = OpTypeFloat 32\n%2 = OpConstant %1 16777215\n",
                 "%1 = OpTypeFloat 32\n%2 = OpConstant %1 0x1.8p+128\n", // NaN
                 "%1 = OpTypeFloat 32\n%2 = OpConstant %1 -0x1.0002p+128\n", // NaN
                 "%1 = OpTypeFloat 32\n%2 = OpConstant %1 0x1p+128\n", // Inf
                 "%1 = OpTypeFloat 32\n%2 = OpConstant %1 -0x1p+128\n", // -Inf
                 // 64-bit floats
-                "%1 = OpTypeFloat 64\n%2 = OpConstant %1 -3.275\n",
+                "%1 = OpTypeFloat 64\n%2 = OpConstant %1 -3.2749999999999999\n",
                 "%1 = OpTypeFloat 64\n%2 = OpConstant %1 0x1.ffffffffffffap-1023\n", // small normal
                 "%1 = OpTypeFloat 64\n%2 = OpConstant %1 -0x1.ffffffffffffap-1023\n",
                 "%1 = OpTypeFloat 64\n%2 = OpConstant %1 0x1.8p+1024\n", // NaN

--- a/test/hex_float_test.cpp
+++ b/test/hex_float_test.cpp
@@ -478,8 +478,8 @@ INSTANTIATE_TEST_CASE_P(
         {1000.0f, "1000"},
 
         // Still normal numbers, but with large magnitude exponents.
-        {float(ldexp(1.f, 126)), "8.50706e+37"},
-        {float(ldexp(-1.f, -126)), "-1.17549e-38"},
+        {float(ldexp(1.f, 126)), "8.50705917e+37"},
+        {float(ldexp(-1.f, -126)), "-1.17549435e-38"},
 
         // denormalized values are printed as hex floats.
         {float(ldexp(1.0f, -127)), "0x1p-127"},
@@ -509,18 +509,18 @@ INSTANTIATE_TEST_CASE_P(
             {1000.0, "1000"},
 
             // Large outside the range of normal floats
-            {ldexp(1.0, 128), "3.40282366920938e+38"},
-            {ldexp(1.5, 129), "1.02084710076282e+39"},
-            {ldexp(-1.0, 128), "-3.40282366920938e+38"},
-            {ldexp(-1.5, 129), "-1.02084710076282e+39"},
+            {ldexp(1.0, 128), "3.4028236692093846e+38"},
+            {ldexp(1.5, 129), "1.0208471007628154e+39"},
+            {ldexp(-1.0, 128), "-3.4028236692093846e+38"},
+            {ldexp(-1.5, 129), "-1.0208471007628154e+39"},
 
             // Small outside the range of normal floats
-            {ldexp(1.5, -129), "2.20405190779179e-39"},
-            {ldexp(-1.5, -129), "-2.20405190779179e-39"},
+            {ldexp(1.5, -129), "2.2040519077917891e-39"},
+            {ldexp(-1.5, -129), "-2.2040519077917891e-39"},
 
             // lowest non-denorm
-            {ldexp(1.0, -1022), "2.2250738585072e-308"},
-            {ldexp(-1.0, -1022), "-2.2250738585072e-308"},
+            {ldexp(1.0, -1022), "2.2250738585072014e-308"},
+            {ldexp(-1.0, -1022), "-2.2250738585072014e-308"},
 
             // Denormalized values
             {ldexp(1.125, -1023), "0x1.2p-1023"},

--- a/test/name_mapper_test.cpp
+++ b/test/name_mapper_test.cpp
@@ -311,7 +311,8 @@ INSTANTIATE_TEST_CASE_P(
         {"%1 = OpTypeFloat 16\n%2 = OpConstant %1 -0x1.d2cp-10", 2,
          "half_n0x1_d2cpn10"},
         // 32-bit floats
-        {"%1 = OpTypeFloat 32\n%2 = OpConstant %1 -3.275", 2, "float_n3_275"},
+        {"%1 = OpTypeFloat 32\n%2 = OpConstant %1 -3.275", 2,
+         "float_n3_2750001"},
         {"%1 = OpTypeFloat 32\n%2 = OpConstant %1 0x1.8p+128", 2,
          "float_0x1_8p_128"},  // NaN
         {"%1 = OpTypeFloat 32\n%2 = OpConstant %1 -0x1.0002p+128", 2,
@@ -321,7 +322,8 @@ INSTANTIATE_TEST_CASE_P(
         {"%1 = OpTypeFloat 32\n%2 = OpConstant %1 -0x1p+128", 2,
          "float_n0x1p_128"},  // -Inf
                               // 64-bit floats
-        {"%1 = OpTypeFloat 64\n%2 = OpConstant %1 -3.275", 2, "double_n3_275"},
+        {"%1 = OpTypeFloat 64\n%2 = OpConstant %1 -3.275", 2,
+         "double_n3_2749999999999999"},
         {"%1 = OpTypeFloat 64\n%2 = OpConstant %1 0x1.ffffffffffffap-1023", 2,
          "double_0x1_ffffffffffffapn1023"},  // small normal
         {"%1 = OpTypeFloat 64\n%2 = OpConstant %1 -0x1.ffffffffffffap-1023", 2,

--- a/test/text_to_binary.constant_test.cpp
+++ b/test/text_to_binary.constant_test.cpp
@@ -518,8 +518,8 @@ INSTANTIATE_TEST_CASE_P(
         "%1 = OpTypeFloat 32\n%2 = OpConstant %1 -12.5\n",
         // 64-bit float
         "%1 = OpTypeFloat 64\n%2 = OpConstant %1 0\n",
-        "%1 = OpTypeFloat 64\n%2 = OpConstant %1 1.79769e+308\n",
-        "%1 = OpTypeFloat 64\n%2 = OpConstant %1 -1.79769e+308\n",
+        "%1 = OpTypeFloat 64\n%2 = OpConstant %1 1.7976900000000001e+308\n",
+        "%1 = OpTypeFloat 64\n%2 = OpConstant %1 -1.7976900000000001e+308\n",
     }), );
 
 INSTANTIATE_TEST_CASE_P(
@@ -628,8 +628,8 @@ INSTANTIATE_TEST_CASE_P(
         "%1 = OpTypeFloat 32\n%2 = OpSpecConstant %1 -12.5\n",
         // 64-bit float
         "%1 = OpTypeFloat 64\n%2 = OpSpecConstant %1 0\n",
-        "%1 = OpTypeFloat 64\n%2 = OpSpecConstant %1 1.79769e+308\n",
-        "%1 = OpTypeFloat 64\n%2 = OpSpecConstant %1 -1.79769e+308\n",
+        "%1 = OpTypeFloat 64\n%2 = OpSpecConstant %1 1.7976900000000001e+308\n",
+        "%1 = OpTypeFloat 64\n%2 = OpSpecConstant %1 -1.7976900000000001e+308\n",
     }), );
 
 // Test OpSpecConstantOp


### PR DESCRIPTION
max_digits10 is needed for binary->text->binary, essentially, when one wants to disassemble and (re)assemble. digits10 is not sufficient and was causing lossiness for this process. One only need try the float32 value 16777215 which should be exactly representable but was getting truncated by spirv-dis. A test has been added for this value. A number of other tests needed to be "fixed" to take this new output precision into account.