### PR TITLE
Invoke cmake via CMAKE_COMMAND variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,8 @@ endif(SPIRV_BUILD_COMPRESSION)
 # Build pkg-config file
 # Use a first-class target so it's regenerated when relevant files are updated.
 add_custom_target(spirv-tools-pkg-config ALL
-        COMMAND cmake -DCHANGES_FILE=${CMAKE_CURRENT_SOURCE_DIR}/CHANGES
+        COMMAND ${CMAKE_COMMAND}
+                      -DCHANGES_FILE=${CMAKE_CURRENT_SOURCE_DIR}/CHANGES
                       -DTEMPLATE_FILE=${CMAKE_CURRENT_SOURCE_DIR}/cmake/SPIRV-Tools.pc.in
                       -DOUT_FILE=${CMAKE_CURRENT_BINARY_DIR}/SPIRV-Tools.pc
                       -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
@@ -240,7 +241,8 @@ add_custom_target(spirv-tools-pkg-config ALL
                       -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/write_pkg_config.cmake
         DEPENDS "CHANGES" "cmake/SPIRV-Tools.pc.in" "cmake/write_pkg_config.cmake")
 add_custom_target(spirv-tools-shared-pkg-config ALL
-        COMMAND cmake -DCHANGES_FILE=${CMAKE_CURRENT_SOURCE_DIR}/CHANGES
+        COMMAND ${CMAKE_COMMAND}
+                      -DCHANGES_FILE=${CMAKE_CURRENT_SOURCE_DIR}/CHANGES
                       -DTEMPLATE_FILE=${CMAKE_CURRENT_SOURCE_DIR}/cmake/SPIRV-Tools-shared.pc.in
                       -DOUT_FILE=${CMAKE_CURRENT_BINARY_DIR}/SPIRV-Tools-shared.pc
                       -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}


### PR DESCRIPTION
Need to do this in case cmake is not on the path.
This should fix the Android NDK build, as in when building the NDK
itself.