### PR TITLE
Add constant folding rules for floating-point comparison

### DIFF
--- a/source/opt/const_folding_rules.cpp
+++ b/source/opt/const_folding_rules.cpp
@@ -281,14 +281,14 @@ bool CompareFloatingPoint(bool op_result, bool op_unordered,
       float fb = GetFloatFromConst(b);                                    \
       bool result = CompareFloatingPoint(                                 \
           fa op fb, std::isnan(fa) || std::isnan(fb), ord);               \
-      std::vector<uint32_t> words = {result};                             \
+      std::vector<uint32_t> words = {uint32_t(result)};                   \
       return const_mgr->GetConstant(result_type, words);                  \
     } else if (float_type->width() == 64) {                               \
       double fa = GetDoubleFromConst(a);                                  \
       double fb = GetDoubleFromConst(b);                                  \
       bool result = CompareFloatingPoint(                                 \
           fa op fb, std::isnan(fa) || std::isnan(fb), ord);               \
-      std::vector<uint32_t> words = {result};                             \
+      std::vector<uint32_t> words = {uint32_t(result)};                   \
       return const_mgr->GetConstant(result_type, words);                  \
     }                                                                     \
     return nullptr;                                                       \

--- a/source/opt/const_folding_rules.cpp
+++ b/source/opt/const_folding_rules.cpp
@@ -156,18 +156,18 @@ ConstantFoldingRule FoldFloatingPointOp(FloatScalarFoldingRule scalar_rule) {
     }
 
     if (vector_type != nullptr) {
-      std::vector<const analysis::Constant*> a_componenets;
-      std::vector<const analysis::Constant*> b_componenets;
+      std::vector<const analysis::Constant*> a_components;
+      std::vector<const analysis::Constant*> b_components;
       std::vector<const analysis::Constant*> results_components;
 
-      a_componenets = GetVectorComponents(constants[0], const_mgr);
-      b_componenets = GetVectorComponents(constants[1], const_mgr);
+      a_components = GetVectorComponents(constants[0], const_mgr);
+      b_components = GetVectorComponents(constants[1], const_mgr);
 
       // Fold each component of the vector.
-      for (uint32_t i = 0; i < a_componenets.size(); ++i) {
+      for (uint32_t i = 0; i < a_components.size(); ++i) {
         results_components.push_back(scalar_rule(vector_type->element_type(),
-                                                 a_componenets[i],
-                                                 b_componenets[i], const_mgr));
+                                                 a_components[i],
+                                                 b_components[i], const_mgr));
         if (results_components[i] == nullptr) {
           return nullptr;
         }

--- a/source/opt/const_folding_rules.cpp
+++ b/source/opt/const_folding_rules.cpp
@@ -105,8 +105,8 @@ ConstantFoldingRule FoldCompositeWithConstants() {
 // The interface for a function that returns the result of applying a scalar
 // floating-point binary operation on |a| and |b|.  The type of the return value
 // will be |type|.  The input constants must also be of type |type|.
-using FloatScalarFoldingRule = std::function<const analysis::FloatConstant*(
-    const analysis::Float* type, const analysis::Constant* a,
+using FloatScalarFoldingRule = std::function<const analysis::Constant*(
+    const analysis::Type* result_type, const analysis::Constant* a,
     const analysis::Constant* b, analysis::ConstantManager*)>;
 
 // Returns an std::vector containing the elements of |constant|.  The type of
@@ -146,7 +146,6 @@ ConstantFoldingRule FoldFloatingPointOp(FloatScalarFoldingRule scalar_rule) {
     analysis::TypeManager* type_mgr = context->get_type_mgr();
     const analysis::Type* result_type = type_mgr->GetType(inst->type_id());
     const analysis::Vector* vector_type = result_type->AsVector();
-    const analysis::Float* float_type = nullptr;
 
     if (!CanFoldFloatingPoint(context, inst->result_id())) {
       return nullptr;
@@ -159,30 +158,29 @@ ConstantFoldingRule FoldFloatingPointOp(FloatScalarFoldingRule scalar_rule) {
     if (vector_type != nullptr) {
       std::vector<const analysis::Constant*> a_componenets;
       std::vector<const analysis::Constant*> b_componenets;
-      std::vector<const analysis::FloatConstant*> results_componenets;
+      std::vector<const analysis::Constant*> results_components;
 
-      float_type = vector_type->element_type()->AsFloat();
       a_componenets = GetVectorComponents(constants[0], const_mgr);
       b_componenets = GetVectorComponents(constants[1], const_mgr);
 
       // Fold each component of the vector.
       for (uint32_t i = 0; i < a_componenets.size(); ++i) {
-        results_componenets.push_back(scalar_rule(float_type, a_componenets[i],
-                                                  b_componenets[i], const_mgr));
-        if (results_componenets[i] == nullptr) {
+        results_components.push_back(scalar_rule(vector_type->element_type(),
+                                                 a_componenets[i],
+                                                 b_componenets[i], const_mgr));
+        if (results_components[i] == nullptr) {
           return nullptr;
         }
       }
 
       // Build the constant object and return it.
       std::vector<uint32_t> ids;
-      for (const analysis::FloatConstant* member : results_componenets) {
+      for (const analysis::Constant* member : results_components) {
         ids.push_back(const_mgr->GetDefiningInstruction(member)->result_id());
       }
       return const_mgr->GetConstant(vector_type, ids);
     } else {
-      float_type = result_type->AsFloat();
-      return scalar_rule(float_type, constants[0], constants[1], const_mgr);
+      return scalar_rule(result_type, constants[0], constants[1], const_mgr);
     }
   };
 }
@@ -217,33 +215,123 @@ double GetDoubleFromConst(const analysis::Constant* c) {
 
 // This macro defines a |FloatScalarFoldingRule| that applies |op|.  The
 // operator |op| must work for both float and double, and use syntax "f1 op f2".
-#define FOLD_OP(op)                                                            \
-  [](const analysis::Float* type, const analysis::Constant* a,                 \
-     const analysis::Constant* b,                                              \
-     analysis::ConstantManager* const_mgr) -> const analysis::FloatConstant* { \
-    assert(type != nullptr && a != nullptr && b != nullptr);                   \
-    if (type->width() == 32) {                                                 \
-      float fa = GetFloatFromConst(a);                                         \
-      float fb = GetFloatFromConst(b);                                         \
-      spvutils::FloatProxy<float> result(fa op fb);                            \
-      std::vector<uint32_t> words = {result.data()};                           \
-      return const_mgr->GetConstant(type, words)->AsFloatConstant();           \
-    } else if (type->width() == 64) {                                          \
-      double fa = GetDoubleFromConst(a);                                       \
-      double fb = GetDoubleFromConst(b);                                       \
-      spvutils::FloatProxy<double> result(fa op fb);                           \
-      std::vector<uint32_t> words(ExtractInts(result.data()));                 \
-      return const_mgr->GetConstant(type, words)->AsFloatConstant();           \
-    }                                                                          \
-    return nullptr;                                                            \
+#define FOLD_FPARITH_OP(op)                                               \
+  [](const analysis::Type* result_type, const analysis::Constant* a,      \
+     const analysis::Constant* b,                                         \
+     analysis::ConstantManager* const_mgr) -> const analysis::Constant* { \
+    assert(result_type != nullptr && a != nullptr && b != nullptr);       \
+    assert(result_type == a->type() && result_type == b->type());         \
+    const analysis::Float* float_type = result_type->AsFloat();           \
+    assert(float_type != nullptr);                                        \
+    if (float_type->width() == 32) {                                      \
+      float fa = GetFloatFromConst(a);                                    \
+      float fb = GetFloatFromConst(b);                                    \
+      spvutils::FloatProxy<float> result(fa op fb);                       \
+      std::vector<uint32_t> words = {result.data()};                      \
+      return const_mgr->GetConstant(result_type, words);                  \
+    } else if (float_type->width() == 64) {                               \
+      double fa = GetDoubleFromConst(a);                                  \
+      double fb = GetDoubleFromConst(b);                                  \
+      spvutils::FloatProxy<double> result(fa op fb);                      \
+      std::vector<uint32_t> words(ExtractInts(result.data()));            \
+      return const_mgr->GetConstant(result_type, words);                  \
+    }                                                                     \
+    return nullptr;                                                       \
   }
 
 // Define the folding rules for subtraction, addition, multiplication, and
 // division for floating point values.
-ConstantFoldingRule FoldFSub() { return FoldFloatingPointOp(FOLD_OP(-)); }
-ConstantFoldingRule FoldFAdd() { return FoldFloatingPointOp(FOLD_OP(+)); }
-ConstantFoldingRule FoldFMul() { return FoldFloatingPointOp(FOLD_OP(*)); }
-ConstantFoldingRule FoldFDiv() { return FoldFloatingPointOp(FOLD_OP(/)); }
+ConstantFoldingRule FoldFSub() {
+  return FoldFloatingPointOp(FOLD_FPARITH_OP(-));
+}
+ConstantFoldingRule FoldFAdd() {
+  return FoldFloatingPointOp(FOLD_FPARITH_OP(+));
+}
+ConstantFoldingRule FoldFMul() {
+  return FoldFloatingPointOp(FOLD_FPARITH_OP(*));
+}
+ConstantFoldingRule FoldFDiv() {
+  return FoldFloatingPointOp(FOLD_FPARITH_OP(/));
+}
+
+bool CompareFloatingPoint(bool op_result, bool op_unordered,
+                          bool need_ordered) {
+  if (need_ordered) {
+    // operands are ordered and Operand 1 is |op| Operand 2
+    return !op_unordered && op_result;
+  } else {
+    // operands are unordered or Operand 1 is |op| Operand 2
+    return op_unordered || op_result;
+  }
+}
+
+// This macro defines a |FloatScalarFoldingRule| that applies |op|.  The
+// operator |op| must work for both float and double, and use syntax "f1 op f2".
+#define FOLD_FPCMP_OP(op, ord)                                            \
+  [](const analysis::Type* result_type, const analysis::Constant* a,      \
+     const analysis::Constant* b,                                         \
+     analysis::ConstantManager* const_mgr) -> const analysis::Constant* { \
+    assert(result_type != nullptr && a != nullptr && b != nullptr);       \
+    assert(result_type->AsBool());                                        \
+    assert(a->type() == b->type());                                       \
+    const analysis::Float* float_type = a->type()->AsFloat();             \
+    assert(float_type != nullptr);                                        \
+    if (float_type->width() == 32) {                                      \
+      float fa = GetFloatFromConst(a);                                    \
+      float fb = GetFloatFromConst(b);                                    \
+      bool result = CompareFloatingPoint(                                 \
+          fa op fb, std::isnan(fa) || std::isnan(fb), ord);               \
+      std::vector<uint32_t> words = {result};                             \
+      return const_mgr->GetConstant(result_type, words);                  \
+    } else if (float_type->width() == 64) {                               \
+      double fa = GetDoubleFromConst(a);                                  \
+      double fb = GetDoubleFromConst(b);                                  \
+      bool result = CompareFloatingPoint(                                 \
+          fa op fb, std::isnan(fa) || std::isnan(fb), ord);               \
+      std::vector<uint32_t> words = {result};                             \
+      return const_mgr->GetConstant(result_type, words);                  \
+    }                                                                     \
+    return nullptr;                                                       \
+  }
+
+// Define the folding rules for ordered and unordered comparison for floating
+// point values.
+ConstantFoldingRule FoldFOrdEqual() {
+  return FoldFloatingPointOp(FOLD_FPCMP_OP(==, true));
+}
+ConstantFoldingRule FoldFUnordEqual() {
+  return FoldFloatingPointOp(FOLD_FPCMP_OP(==, false));
+}
+ConstantFoldingRule FoldFOrdNotEqual() {
+  return FoldFloatingPointOp(FOLD_FPCMP_OP(!=, true));
+}
+ConstantFoldingRule FoldFUnordNotEqual() {
+  return FoldFloatingPointOp(FOLD_FPCMP_OP(!=, false));
+}
+ConstantFoldingRule FoldFOrdLessThan() {
+  return FoldFloatingPointOp(FOLD_FPCMP_OP(<, true));
+}
+ConstantFoldingRule FoldFUnordLessThan() {
+  return FoldFloatingPointOp(FOLD_FPCMP_OP(<, false));
+}
+ConstantFoldingRule FoldFOrdGreaterThan() {
+  return FoldFloatingPointOp(FOLD_FPCMP_OP(>, true));
+}
+ConstantFoldingRule FoldFUnordGreaterThan() {
+  return FoldFloatingPointOp(FOLD_FPCMP_OP(>, false));
+}
+ConstantFoldingRule FoldFOrdLessThanEqual() {
+  return FoldFloatingPointOp(FOLD_FPCMP_OP(<=, true));
+}
+ConstantFoldingRule FoldFUnordLessThanEqual() {
+  return FoldFloatingPointOp(FOLD_FPCMP_OP(<=, false));
+}
+ConstantFoldingRule FoldFOrdGreaterThanEqual() {
+  return FoldFloatingPointOp(FOLD_FPCMP_OP(>=, true));
+}
+ConstantFoldingRule FoldFUnordGreaterThanEqual() {
+  return FoldFloatingPointOp(FOLD_FPCMP_OP(>=, false));
+}
 }  // namespace
 
 spvtools::opt::ConstantFoldingRules::ConstantFoldingRules() {
@@ -260,6 +348,19 @@ spvtools::opt::ConstantFoldingRules::ConstantFoldingRules() {
   rules_[SpvOpFDiv].push_back(FoldFDiv());
   rules_[SpvOpFMul].push_back(FoldFMul());
   rules_[SpvOpFSub].push_back(FoldFSub());
+
+  rules_[SpvOpFOrdEqual].push_back(FoldFOrdEqual());
+  rules_[SpvOpFUnordEqual].push_back(FoldFUnordEqual());
+  rules_[SpvOpFOrdNotEqual].push_back(FoldFOrdNotEqual());
+  rules_[SpvOpFUnordNotEqual].push_back(FoldFUnordNotEqual());
+  rules_[SpvOpFOrdLessThan].push_back(FoldFOrdLessThan());
+  rules_[SpvOpFUnordLessThan].push_back(FoldFUnordLessThan());
+  rules_[SpvOpFOrdGreaterThan].push_back(FoldFOrdGreaterThan());
+  rules_[SpvOpFUnordGreaterThan].push_back(FoldFUnordGreaterThan());
+  rules_[SpvOpFOrdLessThanEqual].push_back(FoldFOrdLessThanEqual());
+  rules_[SpvOpFUnordLessThanEqual].push_back(FoldFUnordLessThanEqual());
+  rules_[SpvOpFOrdGreaterThanEqual].push_back(FoldFOrdGreaterThanEqual());
+  rules_[SpvOpFUnordGreaterThanEqual].push_back(FoldFUnordGreaterThanEqual());
 }
 }  // namespace opt
 }  // namespace spvtools

--- a/test/opt/fold_test.cpp
+++ b/test/opt/fold_test.cpp
@@ -839,6 +839,38 @@ INSTANTIATE_TEST_CASE_P(DoubleOrderedCompareConstantFoldingTest, BooleanInstruct
           "%2 = OpFOrdGreaterThanEqual %bool %double_1 %double_1\n" +
           "OpReturn\n" +
           "OpFunctionEnd",
+      2, true),
+  // Test case 12: fold 2.0 < 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdLessThan %bool %double_2 %double_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 13: fold 2.0 > 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdGreaterThan %bool %double_2 %double_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 14: fold 2.0 <= 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdLessThanEqual %bool %double_2 %double_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 15: fold 2.0 >= 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdGreaterThanEqual %bool %double_2 %double_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
       2, true)
 ));
 
@@ -937,6 +969,38 @@ INSTANTIATE_TEST_CASE_P(DoubleUnorderedCompareConstantFoldingTest, BooleanInstru
       Header() + "%main = OpFunction %void None %void_func\n" +
           "%main_lab = OpLabel\n" +
           "%2 = OpFUnordGreaterThanEqual %bool %double_1 %double_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 12: fold 2.0 < 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordLessThan %bool %double_2 %double_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 13: fold 2.0 > 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordGreaterThan %bool %double_2 %double_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 14: fold 2.0 <= 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordLessThanEqual %bool %double_2 %double_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 15: fold 2.0 >= 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordGreaterThanEqual %bool %double_2 %double_1\n" +
           "OpReturn\n" +
           "OpFunctionEnd",
       2, true)
@@ -1039,6 +1103,38 @@ INSTANTIATE_TEST_CASE_P(FloatOrderedCompareConstantFoldingTest, BooleanInstructi
           "%2 = OpFOrdGreaterThanEqual %bool %float_1 %float_1\n" +
           "OpReturn\n" +
           "OpFunctionEnd",
+      2, true),
+  // Test case 12: fold 2.0 < 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdLessThan %bool %float_2 %float_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 13: fold 2.0 > 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdGreaterThan %bool %float_2 %float_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 14: fold 2.0 <= 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdLessThanEqual %bool %float_2 %float_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 15: fold 2.0 >= 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdGreaterThanEqual %bool %float_2 %float_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
       2, true)
 ));
 
@@ -1137,6 +1233,38 @@ INSTANTIATE_TEST_CASE_P(FloatUnorderedCompareConstantFoldingTest, BooleanInstruc
       Header() + "%main = OpFunction %void None %void_func\n" +
           "%main_lab = OpLabel\n" +
           "%2 = OpFUnordGreaterThanEqual %bool %float_1 %float_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 12: fold 2.0 < 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordLessThan %bool %float_2 %float_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 13: fold 2.0 > 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordGreaterThan %bool %float_2 %float_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 14: fold 2.0 <= 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordLessThanEqual %bool %float_2 %float_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 15: fold 2.0 >= 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordGreaterThanEqual %bool %float_2 %float_1\n" +
           "OpReturn\n" +
           "OpFunctionEnd",
       2, true)

--- a/test/opt/fold_test.cpp
+++ b/test/opt/fold_test.cpp
@@ -738,6 +738,409 @@ INSTANTIATE_TEST_CASE_P(DoubleConstantFoldingTest, DoubleInstructionFoldingTest,
             2, -std::numeric_limits<double>::infinity())
 ));
 // clang-format on
+
+// clang-format off
+INSTANTIATE_TEST_CASE_P(DoubleOrderedCompareConstantFoldingTest, BooleanInstructionFoldingTest,
+                        ::testing::Values(
+  // Test case 0: fold 1.0 == 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdEqual %bool %double_1 %double_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 1: fold 1.0 != 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdNotEqual %bool %double_1 %double_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 2: fold 1.0 < 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdLessThan %bool %double_1 %double_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 3: fold 1.0 > 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdGreaterThan %bool %double_1 %double_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 4: fold 1.0 <= 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdLessThanEqual %bool %double_1 %double_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 5: fold 1.0 >= 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdGreaterThanEqual %bool %double_1 %double_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 6: fold 1.0 == 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdEqual %bool %double_1 %double_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 7: fold 1.0 != 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdNotEqual %bool %double_1 %double_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 8: fold 1.0 < 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdLessThan %bool %double_1 %double_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 9: fold 1.0 > 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdGreaterThan %bool %double_1 %double_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 10: fold 1.0 <= 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdLessThanEqual %bool %double_1 %double_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 11: fold 1.0 >= 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdGreaterThanEqual %bool %double_1 %double_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true)
+));
+
+INSTANTIATE_TEST_CASE_P(DoubleUnorderedCompareConstantFoldingTest, BooleanInstructionFoldingTest,
+                        ::testing::Values(
+  // Test case 0: fold 1.0 == 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordEqual %bool %double_1 %double_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 1: fold 1.0 != 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordNotEqual %bool %double_1 %double_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 2: fold 1.0 < 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordLessThan %bool %double_1 %double_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 3: fold 1.0 > 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordGreaterThan %bool %double_1 %double_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 4: fold 1.0 <= 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordLessThanEqual %bool %double_1 %double_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 5: fold 1.0 >= 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordGreaterThanEqual %bool %double_1 %double_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 6: fold 1.0 == 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordEqual %bool %double_1 %double_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 7: fold 1.0 != 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordNotEqual %bool %double_1 %double_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 8: fold 1.0 < 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordLessThan %bool %double_1 %double_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 9: fold 1.0 > 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordGreaterThan %bool %double_1 %double_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 10: fold 1.0 <= 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordLessThanEqual %bool %double_1 %double_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 11: fold 1.0 >= 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordGreaterThanEqual %bool %double_1 %double_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true)
+));
+
+INSTANTIATE_TEST_CASE_P(FloatOrderedCompareConstantFoldingTest, BooleanInstructionFoldingTest,
+                        ::testing::Values(
+  // Test case 0: fold 1.0 == 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdEqual %bool %float_1 %float_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 1: fold 1.0 != 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdNotEqual %bool %float_1 %float_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 2: fold 1.0 < 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdLessThan %bool %float_1 %float_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 3: fold 1.0 > 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdGreaterThan %bool %float_1 %float_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 4: fold 1.0 <= 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdLessThanEqual %bool %float_1 %float_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 5: fold 1.0 >= 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdGreaterThanEqual %bool %float_1 %float_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 6: fold 1.0 == 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdEqual %bool %float_1 %float_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 7: fold 1.0 != 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdNotEqual %bool %float_1 %float_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 8: fold 1.0 < 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdLessThan %bool %float_1 %float_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 9: fold 1.0 > 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdGreaterThan %bool %float_1 %float_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 10: fold 1.0 <= 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdLessThanEqual %bool %float_1 %float_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 11: fold 1.0 >= 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdGreaterThanEqual %bool %float_1 %float_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true)
+));
+
+INSTANTIATE_TEST_CASE_P(FloatUnorderedCompareConstantFoldingTest, BooleanInstructionFoldingTest,
+                        ::testing::Values(
+  // Test case 0: fold 1.0 == 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordEqual %bool %float_1 %float_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 1: fold 1.0 != 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordNotEqual %bool %float_1 %float_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 2: fold 1.0 < 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordLessThan %bool %float_1 %float_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 3: fold 1.0 > 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordGreaterThan %bool %float_1 %float_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 4: fold 1.0 <= 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordLessThanEqual %bool %float_1 %float_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 5: fold 1.0 >= 2.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordGreaterThanEqual %bool %float_1 %float_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 6: fold 1.0 == 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordEqual %bool %float_1 %float_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 7: fold 1.0 != 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordNotEqual %bool %float_1 %float_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 8: fold 1.0 < 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordLessThan %bool %float_1 %float_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 9: fold 1.0 > 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordGreaterThan %bool %float_1 %float_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 10: fold 1.0 <= 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordLessThanEqual %bool %float_1 %float_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 11: fold 1.0 >= 1.0
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordGreaterThanEqual %bool %float_1 %float_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true)
+));
+// clang-format on
+
 template <class ResultType>
 struct InstructionFoldingCaseWithMap {
   InstructionFoldingCaseWithMap(const std::string& tb, uint32_t id,

--- a/test/opt/fold_test.cpp
+++ b/test/opt/fold_test.cpp
@@ -140,6 +140,8 @@ OpName %main "main"
 %double_1 = OpConstant %double 1
 %double_2 = OpConstant %double 2
 %double_3 = OpConstant %double 3
+%float_nan = OpConstant %float -0x1.8p+128
+%double_nan = OpConstant %double -0x1.8p+1024
 )";
 
   return header;
@@ -1135,6 +1137,78 @@ INSTANTIATE_TEST_CASE_P(FloatUnorderedCompareConstantFoldingTest, BooleanInstruc
       Header() + "%main = OpFunction %void None %void_func\n" +
           "%main_lab = OpLabel\n" +
           "%2 = OpFUnordGreaterThanEqual %bool %float_1 %float_1\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true)
+));
+
+INSTANTIATE_TEST_CASE_P(DoubleNaNCompareConstantFoldingTest, BooleanInstructionFoldingTest,
+                        ::testing::Values(
+  // Test case 0: fold NaN == 0 (ord)
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdEqual %bool %double_nan %double_0\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 1: fold NaN == NaN (unord)
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordEqual %bool %double_nan %double_0\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 2: fold NaN != NaN (ord)
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdNotEqual %bool %double_nan %double_0\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 3: fold NaN != NaN (unord)
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordNotEqual %bool %double_nan %double_0\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true)
+));
+
+INSTANTIATE_TEST_CASE_P(FloatNaNCompareConstantFoldingTest, BooleanInstructionFoldingTest,
+                        ::testing::Values(
+  // Test case 0: fold NaN == 0 (ord)
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdEqual %bool %float_nan %float_0\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 1: fold NaN == NaN (unord)
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordEqual %bool %float_nan %float_0\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, true),
+  // Test case 2: fold NaN != NaN (ord)
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFOrdNotEqual %bool %float_nan %float_0\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, false),
+  // Test case 3: fold NaN != NaN (unord)
+  InstructionFoldingCase<bool>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpFUnordNotEqual %bool %float_nan %float_0\n" +
           "OpReturn\n" +
           "OpFunctionEnd",
       2, true)


### PR DESCRIPTION
This change handles all 6 regular comparison types in two variations,
ordered (true if values are ordered *and* comparison is true) and
unordered (true if values are unordered *or* comparison is true).

Ordered comparison matches the default floating-point behavior on host
but we use std::isnan to check ordering explicitly anyway.

This change also slightly reworks the floating-point folding support
code to make it possible to define a folding operation that returns
boolean instead of floating point.