### PR TITLE
Add folding for redundant add/sub/mul/div/mix operations

### DIFF
--- a/source/opt/feature_manager.cpp
+++ b/source/opt/feature_manager.cpp
@@ -24,6 +24,7 @@ namespace opt {
 void FeatureManager::Analyze(ir::Module* module) {
   AddExtensions(module);
   AddCapabilities(module);
+  AddExtInstImportIds(module);
 }
 
 void FeatureManager::AddExtensions(ir::Module* module) {
@@ -54,6 +55,10 @@ void FeatureManager::AddCapabilities(ir::Module* module) {
   for (ir::Instruction& inst : module->capabilities()) {
     AddCapability(static_cast<SpvCapability>(inst.GetSingleWordInOperand(0)));
   }
+}
+
+void FeatureManager::AddExtInstImportIds(ir::Module* module) {
+  extinst_importid_GLSLstd450_ = module->GetExtInstImportId("GLSL.std.450");
 }
 
 }  // namespace opt

--- a/source/opt/feature_manager.h
+++ b/source/opt/feature_manager.h
@@ -46,6 +46,10 @@ class FeatureManager {
     return &capabilities_;
   }
 
+  uint32_t GetExtInstImportId_GLSLstd450() const {
+    return extinst_importid_GLSLstd450_;
+  }
+
  private:
   // Analyzes |module| and records enabled extensions.
   void AddExtensions(ir::Module* module);
@@ -57,6 +61,9 @@ class FeatureManager {
   // Analyzes |module| and records enabled capabilities.
   void AddCapabilities(ir::Module* module);
 
+  // Analyzes |module| and records imported external instruction sets.
+  void AddExtInstImportIds(ir::Module* module);
+
   // Auxiliary object for querying SPIR-V grammar facts.
   const libspirv::AssemblyGrammar& grammar_;
 
@@ -65,6 +72,9 @@ class FeatureManager {
 
   // The enabled capabilities.
   libspirv::CapabilitySet capabilities_;
+
+  // Common external instruction import ids, cached for performance.
+  uint32_t extinst_importid_GLSLstd450_ = 0;
 };
 
 }  // namespace opt

--- a/source/opt/folding_rules.cpp
+++ b/source/opt/folding_rules.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "folding_rules.h"
+#include "latest_version_glsl_std_450_header.h"
 
 namespace spvtools {
 namespace opt {
@@ -21,6 +22,10 @@ namespace {
 const uint32_t kExtractCompositeIdInIdx = 0;
 const uint32_t kInsertObjectIdInIdx = 0;
 const uint32_t kInsertCompositeIdInIdx = 1;
+const uint32_t kExtInstSetIdInIdx = 0;
+const uint32_t kExtInstInstructionInIdx = 1;
+const uint32_t kFMixXIdInIdx = 2;
+const uint32_t kFMixYIdInIdx = 3;
 
 FoldingRule IntMultipleBy1() {
   return [](ir::Instruction* inst,
@@ -326,6 +331,200 @@ FoldingRule RedundantSelect() {
     }
   };
 }
+
+enum class FloatConstantKind { Unknown, Zero, One };
+
+FloatConstantKind getFloatConstantKind(const analysis::Constant* constant) {
+  if (constant == nullptr) {
+    return FloatConstantKind::Unknown;
+  }
+
+  if (const analysis::VectorConstant* vc = constant->AsVectorConstant()) {
+    const std::vector<const analysis::Constant*>& components =
+        vc->GetComponents();
+    assert(!components.empty());
+
+    FloatConstantKind kind = getFloatConstantKind(components[0]);
+
+    for (size_t i = 1; i < components.size(); ++i) {
+      if (getFloatConstantKind(components[i]) != kind) {
+        return FloatConstantKind::Unknown;
+      }
+    }
+
+	return kind;
+  } else if (const analysis::FloatConstant* fc = constant->AsFloatConstant()) {
+    double value = (fc->type()->AsFloat()->width() == 64) ? fc->GetDoubleValue()
+                                                          : fc->GetFloatValue();
+
+    if (value == 0.0) {
+      return FloatConstantKind::Zero;
+    } else if (value == 1.0) {
+      return FloatConstantKind::One;
+    } else {
+      return FloatConstantKind::Unknown;
+    }
+  } else {
+	return FloatConstantKind::Unknown;
+  }
+}
+
+FoldingRule RedundantFAdd() {
+  return [](ir::Instruction* inst,
+            const std::vector<const analysis::Constant*>& constants) {
+    assert(inst->opcode() == SpvOpFAdd && "Wrong opcode.  Should be OpFAdd.");
+    assert(constants.size() == 2);
+
+    if (!inst->IsFloatingPointFoldingAllowed()) {
+      return false;
+    }
+
+    FloatConstantKind kind0 = getFloatConstantKind(constants[0]);
+    FloatConstantKind kind1 = getFloatConstantKind(constants[1]);
+
+    if (kind0 == FloatConstantKind::Zero || kind1 == FloatConstantKind::Zero) {
+      inst->SetOpcode(SpvOpCopyObject);
+      inst->SetInOperands({{SPV_OPERAND_TYPE_ID,
+                            {inst->GetSingleWordInOperand(
+                                kind0 == FloatConstantKind::Zero ? 1 : 0)}}});
+      return true;
+    }
+
+    return false;
+  };
+}
+
+FoldingRule RedundantFSub() {
+  return [](ir::Instruction* inst,
+            const std::vector<const analysis::Constant*>& constants) {
+    assert(inst->opcode() == SpvOpFSub && "Wrong opcode.  Should be OpFSub.");
+    assert(constants.size() == 2);
+
+    if (!inst->IsFloatingPointFoldingAllowed()) {
+      return false;
+    }
+
+    FloatConstantKind kind0 = getFloatConstantKind(constants[0]);
+    FloatConstantKind kind1 = getFloatConstantKind(constants[1]);
+
+    if (kind0 == FloatConstantKind::Zero) {
+      inst->SetOpcode(SpvOpFNegate);
+      inst->SetInOperands(
+          {{SPV_OPERAND_TYPE_ID, {inst->GetSingleWordInOperand(1)}}});
+      return true;
+    }
+
+    if (kind1 == FloatConstantKind::Zero) {
+      inst->SetOpcode(SpvOpCopyObject);
+      inst->SetInOperands(
+          {{SPV_OPERAND_TYPE_ID, {inst->GetSingleWordInOperand(0)}}});
+      return true;
+    }
+
+    return false;
+  };
+}
+
+FoldingRule RedundantFMul() {
+  return [](ir::Instruction* inst,
+            const std::vector<const analysis::Constant*>& constants) {
+    assert(inst->opcode() == SpvOpFMul && "Wrong opcode.  Should be OpFMul.");
+    assert(constants.size() == 2);
+
+    if (!inst->IsFloatingPointFoldingAllowed()) {
+      return false;
+    }
+
+    FloatConstantKind kind0 = getFloatConstantKind(constants[0]);
+    FloatConstantKind kind1 = getFloatConstantKind(constants[1]);
+
+    if (kind0 == FloatConstantKind::Zero || kind1 == FloatConstantKind::Zero) {
+      inst->SetOpcode(SpvOpCopyObject);
+      inst->SetInOperands({{SPV_OPERAND_TYPE_ID,
+                            {inst->GetSingleWordInOperand(
+                                kind0 == FloatConstantKind::Zero ? 0 : 1)}}});
+      return true;
+    }
+
+    if (kind0 == FloatConstantKind::One || kind1 == FloatConstantKind::One) {
+      inst->SetOpcode(SpvOpCopyObject);
+      inst->SetInOperands({{SPV_OPERAND_TYPE_ID,
+                            {inst->GetSingleWordInOperand(
+                                kind0 == FloatConstantKind::One ? 1 : 0)}}});
+      return true;
+    }
+
+    return false;
+  };
+}
+
+FoldingRule RedundantFDiv() {
+  return [](ir::Instruction* inst,
+            const std::vector<const analysis::Constant*>& constants) {
+    assert(inst->opcode() == SpvOpFDiv && "Wrong opcode.  Should be OpFDiv.");
+    assert(constants.size() == 2);
+
+    if (!inst->IsFloatingPointFoldingAllowed()) {
+      return false;
+    }
+
+    FloatConstantKind kind0 = getFloatConstantKind(constants[0]);
+    FloatConstantKind kind1 = getFloatConstantKind(constants[1]);
+
+    if (kind0 == FloatConstantKind::Zero) {
+      inst->SetOpcode(SpvOpCopyObject);
+      inst->SetInOperands({{SPV_OPERAND_TYPE_ID,
+                            {inst->GetSingleWordInOperand(0)}}});
+      return true;
+    }
+
+    if (kind1 == FloatConstantKind::One) {
+      inst->SetOpcode(SpvOpCopyObject);
+      inst->SetInOperands(
+          {{SPV_OPERAND_TYPE_ID, {inst->GetSingleWordInOperand(0)}}});
+      return true;
+    }
+
+    return false;
+  };
+}
+
+FoldingRule RedundantFMix() {
+  return [](ir::Instruction* inst,
+            const std::vector<const analysis::Constant*>& constants) {
+    assert(inst->opcode() == SpvOpExtInst &&
+           "Wrong opcode.  Should be OpExtInst.");
+
+    if (!inst->IsFloatingPointFoldingAllowed()) {
+      return false;
+    }
+
+	// TODO: This should be cached in module object
+    uint32_t instSetId =
+        inst->context()->module()->GetExtInstImportId("GLSL.std.450");
+
+    if (inst->GetSingleWordInOperand(kExtInstSetIdInIdx) == instSetId &&
+        inst->GetSingleWordInOperand(kExtInstInstructionInIdx) ==
+            GLSLstd450FMix) {
+      assert(constants.size() == 5);
+
+      FloatConstantKind kind4 = getFloatConstantKind(constants[4]);
+
+      if (kind4 == FloatConstantKind::Zero || kind4 == FloatConstantKind::One) {
+        inst->SetOpcode(SpvOpCopyObject);
+        inst->SetInOperands(
+            {{SPV_OPERAND_TYPE_ID,
+              {inst->GetSingleWordInOperand(kind4 == FloatConstantKind::Zero
+                                                ? kFMixXIdInIdx
+                                                : kFMixYIdInIdx)}}});
+        return true;
+      }
+    }
+
+    return false;
+  };
+}
+
 }  // namespace
 
 spvtools::opt::FoldingRules::FoldingRules() {
@@ -344,6 +543,14 @@ spvtools::opt::FoldingRules::FoldingRules() {
   rules_[SpvOpPhi].push_back(RedundantPhi());
 
   rules_[SpvOpSelect].push_back(RedundantSelect());
+
+  rules_[SpvOpFAdd].push_back(RedundantFAdd());
+  rules_[SpvOpFSub].push_back(RedundantFSub());
+  rules_[SpvOpFMul].push_back(RedundantFMul());
+  rules_[SpvOpFDiv].push_back(RedundantFDiv());
+
+  rules_[SpvOpExtInst].push_back(RedundantFMix());
 }
+
 }  // namespace opt
 }  // namespace spvtools

--- a/source/opt/folding_rules.cpp
+++ b/source/opt/folding_rules.cpp
@@ -352,7 +352,7 @@ FloatConstantKind getFloatConstantKind(const analysis::Constant* constant) {
       }
     }
 
-	return kind;
+    return kind;
   } else if (const analysis::FloatConstant* fc = constant->AsFloatConstant()) {
     double value = (fc->type()->AsFloat()->width() == 64) ? fc->GetDoubleValue()
                                                           : fc->GetFloatValue();
@@ -365,7 +365,7 @@ FloatConstantKind getFloatConstantKind(const analysis::Constant* constant) {
       return FloatConstantKind::Unknown;
     }
   } else {
-	return FloatConstantKind::Unknown;
+    return FloatConstantKind::Unknown;
   }
 }
 
@@ -473,8 +473,8 @@ FoldingRule RedundantFDiv() {
 
     if (kind0 == FloatConstantKind::Zero) {
       inst->SetOpcode(SpvOpCopyObject);
-      inst->SetInOperands({{SPV_OPERAND_TYPE_ID,
-                            {inst->GetSingleWordInOperand(0)}}});
+      inst->SetInOperands(
+          {{SPV_OPERAND_TYPE_ID, {inst->GetSingleWordInOperand(0)}}});
       return true;
     }
 
@@ -499,9 +499,8 @@ FoldingRule RedundantFMix() {
       return false;
     }
 
-	// TODO: This should be cached in module object
     uint32_t instSetId =
-        inst->context()->module()->GetExtInstImportId("GLSL.std.450");
+        inst->context()->get_feature_mgr()->GetExtInstImportId_GLSLstd450();
 
     if (inst->GetSingleWordInOperand(kExtInstSetIdInIdx) == instSetId &&
         inst->GetSingleWordInOperand(kExtInstInstructionInIdx) ==

--- a/source/opt/folding_rules.cpp
+++ b/source/opt/folding_rules.cpp
@@ -537,18 +537,18 @@ spvtools::opt::FoldingRules::FoldingRules() {
   rules_[SpvOpCompositeExtract].push_back(InsertFeedingExtract());
   rules_[SpvOpCompositeExtract].push_back(CompositeConstructFeedingExtract());
 
+  rules_[SpvOpExtInst].push_back(RedundantFMix());
+
+  rules_[SpvOpFAdd].push_back(RedundantFAdd());
+  rules_[SpvOpFDiv].push_back(RedundantFDiv());
+  rules_[SpvOpFMul].push_back(RedundantFMul());
+  rules_[SpvOpFSub].push_back(RedundantFSub());
+
   rules_[SpvOpIMul].push_back(IntMultipleBy1());
 
   rules_[SpvOpPhi].push_back(RedundantPhi());
 
   rules_[SpvOpSelect].push_back(RedundantSelect());
-
-  rules_[SpvOpFAdd].push_back(RedundantFAdd());
-  rules_[SpvOpFSub].push_back(RedundantFSub());
-  rules_[SpvOpFMul].push_back(RedundantFMul());
-  rules_[SpvOpFDiv].push_back(RedundantFDiv());
-
-  rules_[SpvOpExtInst].push_back(RedundantFMix());
 }
 
 }  // namespace opt

--- a/source/opt/insert_extract_elim.cpp
+++ b/source/opt/insert_extract_elim.cpp
@@ -96,7 +96,7 @@ uint32_t InsertExtractElimPass::DoExtract(ir::Instruction* compInst,
       }
     } else if (cinst->opcode() == SpvOpExtInst &&
                cinst->GetSingleWordInOperand(kExtInstSetIdInIdx) ==
-                   get_module()->GetExtInstImportId("GLSL.std.450") &&
+                   get_feature_mgr()->GetExtInstImportId_GLSLstd450() &&
                cinst->GetSingleWordInOperand(kExtInstInstructionInIdx) ==
                    GLSLstd450FMix) {
       // If mixing value component is 0 or 1 we just match with x or y.

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -483,6 +483,22 @@ bool Instruction::IsFoldableByFoldScalar() const {
   return opt::IsFoldableType(type);
 }
 
+bool Instruction::IsFloatingPointFoldingAllowed() const {
+  // TODO: Add the rules for kernels.  For now it will be pessimistic.
+  if (!context_->get_feature_mgr()->HasCapability(SpvCapabilityShader)) {
+    return false;
+  }
+
+  bool is_nocontract = false;
+  context_->get_decoration_mgr()->WhileEachDecoration(
+      opcode_, SpvDecorationNoContraction,
+      [&is_nocontract](const ir::Instruction&) {
+        is_nocontract = true;
+        return false;
+      });
+  return !is_nocontract;
+}
+
 std::string Instruction::PrettyPrint(uint32_t options) const {
   // Convert the module to binary.
   std::vector<uint32_t> module_binary;

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -372,6 +372,11 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   // constant value by |FoldScalar|.
   bool IsFoldableByFoldScalar() const;
 
+  // Returns true if we are allowed to fold or otherwise manipulate the
+  // instruction that defines |id| in the given context. This includes not
+  // handling NaN values.
+  bool IsFloatingPointFoldingAllowed() const;
+
   inline bool operator==(const Instruction&) const;
   inline bool operator!=(const Instruction&) const;
   inline bool operator<(const Instruction&) const;

--- a/source/opt/pass.h
+++ b/source/opt/pass.h
@@ -82,6 +82,10 @@ class Pass {
     return context()->get_decoration_mgr();
   }
 
+  FeatureManager* get_feature_mgr() const {
+    return context()->get_feature_mgr();
+  }
+
   // Returns a pointer to the current module for this pass.
   ir::Module* get_module() const { return context_->module(); }
 


### PR DESCRIPTION
This change implements instruction folding for arithmetic operations
that are redundant, specifically:

- x + 0 = 0 + x = x
- x - 0 = x
- 0 - x = -x
- x * 0 = 0 * x = 0
- x * 1 = 1 * x = x
- 0 / x = 0
- x / 1 = x
- mix(a, b, 0) = a
- mix(a, b, 1) = b