### PR TITLE
Preserve analysies in the simplification pass

### DIFF
--- a/source/opt/simplification_pass.h
+++ b/source/opt/simplification_pass.h
@@ -27,6 +27,14 @@ class SimplificationPass : public Pass {
  public:
   const char* name() const override { return "simplify-instructions"; }
   Status Process(ir::IRContext*) override;
+  virtual ir::IRContext::Analysis GetPreservedAnalyses() override {
+    return ir::IRContext::kAnalysisDefUse |
+           ir::IRContext::kAnalysisInstrToBlockMapping |
+           ir::IRContext::kAnalysisDecorations |
+           ir::IRContext::kAnalysisCombinators | ir::IRContext::kAnalysisCFG |
+           ir::IRContext::kAnalysisDominatorAnalysis |
+           ir::IRContext::kAnalysisNameMap;
+  }
 
  private:
   // Returns true if the module was changed.  The simplifier is called on every


### PR DESCRIPTION
Building the def-use chains is very expensive, so we do not want to
invalidate them it if is not necessary.  At the moment, it seems like
most optimizatoins are good at not invalidating the def-use chains, but
simplification does.

This PR get the simlification pass to keep the analysies valid.

Contributes to #1328.