### PR TITLE
Remove Function::GetBlocks pushed by accident

### DIFF
--- a/source/opt/function.h
+++ b/source/opt/function.h
@@ -77,11 +77,6 @@ class Function {
   // Returns function's return type id
   inline uint32_t type_id() const { return def_inst_->type_id(); }
 
-  // Returns the basic block container for this function.
-  const std::vector<std::unique_ptr<BasicBlock>>* GetBlocks() const {
-    return &blocks_;
-  }
-
   // Returns the entry basic block for this function.
   const std::unique_ptr<BasicBlock>& entry() const { return blocks_.front(); }
 


### PR DESCRIPTION
@s-perron Asked me to remove this here https://github.com/KhronosGroup/SPIRV-Tools/pull/1292#discussion_r168240514, but it ended up being readded and pushed somehow...

So here the revert.