### PR TITLE
Android.mk: Generate enum mappings from unified1 grammar

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -129,7 +129,8 @@ SPVTOOLS_OPT_SRC_FILES := \
 SPV_CORE10_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/1.0/spirv.core.grammar.json
 SPV_CORE11_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/1.1/spirv.core.grammar.json
 SPV_CORE12_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/1.2/spirv.core.grammar.json
-SPV_CORELATEST_GRAMMAR=$(SPV_CORE12_GRAMMAR)
+SPV_COREUNIFIED1_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/unified1/spirv.core.grammar.json
+SPV_CORELATEST_GRAMMAR=$(SPV_COREUNIFIED1_GRAMMAR)
 SPV_GLSL_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/1.2/extinst.glsl.std.450.grammar.json
 SPV_OPENCL_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/1.2/extinst.opencl.std.100.grammar.json
 # TODO(dneto): I expect the DebugInfo grammar file to eventually migrate to SPIRV-Headers


### PR DESCRIPTION
Some tokens are only showing up in the unified1 grammar.
So enum string mappings have to be generated from that grammar, not
the grammar from the (deprecated) include/spirv/1.2 grammar.

Example: capabilities FragmentFullyCovered, Float16ImageAMD