### PR TITLE
Define Disassemble only when Effcee is used in fold_test

### DIFF
--- a/test/opt/fold_test.cpp
+++ b/test/opt/fold_test.cpp
@@ -36,6 +36,7 @@ using ::testing::Contains;
 using namespace spvtools;
 using spvtools::opt::analysis::DefUseManager;
 
+#ifdef SPIRV_EFFCEE
 std::string Disassemble(const std::string& original, ir::IRContext* context,
                         uint32_t disassemble_options = 0) {
   std::vector<uint32_t> optimized_bin;
@@ -50,7 +51,6 @@ std::string Disassemble(const std::string& original, ir::IRContext* context,
   return optimized_asm;
 }
 
-#ifdef SPIRV_EFFCEE
 void Match(const std::string& original, ir::IRContext* context,
            uint32_t disassemble_options = 0) {
   std::string disassembly = Disassemble(original, context, disassemble_options);


### PR DESCRIPTION
Fixes compilation with clang 5.0, when SPIRV_WERROR is on.