### PR TITLE
Reimplement the DecorationManager

### DIFF
--- a/source/opt/decoration_manager.cpp
+++ b/source/opt/decoration_manager.cpp
@@ -23,7 +23,7 @@ namespace opt {
 namespace analysis {
 
 void DecorationManager::RemoveDecorationsFrom(uint32_t id) {
-  auto const ids_iter = id_to_decoration_insts_.find(id);
+  const auto ids_iter = id_to_decoration_insts_.find(id);
   if (ids_iter == id_to_decoration_insts_.end()) return;
   id_to_decoration_insts_.erase(ids_iter);
 }
@@ -44,32 +44,32 @@ bool DecorationManager::HaveTheSameDecorations(uint32_t id1,
   using InstructionList = std::vector<const ir::Instruction*>;
   using DecorationSet = std::set<std::u32string>;
 
-  const InstructionList decorationsFor1 = GetDecorationsFor(id1, false);
-  const InstructionList decorationsFor2 = GetDecorationsFor(id2, false);
+  const InstructionList decorations_for1 = GetDecorationsFor(id1, false);
+  const InstructionList decorations_for2 = GetDecorationsFor(id2, false);
 
   // This function splits the decoration instructions into different sets,
   // based on their opcode; only OpDecorate, OpDecorateId and OpMemberDecorate
   // are considered, the other opcodes are ignored.
   const auto fillDecorationSets =
-      [](const InstructionList& decorationList, DecorationSet* decorateSet,
-         DecorationSet* decorateIdSet, DecorationSet* memberDecorateSet) {
-        for (const ir::Instruction* inst : decorationList) {
-          std::u32string decorationPayload;
+      [](const InstructionList& decoration_list, DecorationSet* decorate_set,
+         DecorationSet* decorate_id_set, DecorationSet* member_decorate_set) {
+        for (const ir::Instruction* inst : decoration_list) {
+          std::u32string decoration_payload;
           // Ignore the opcode and the target as we do not want them to be
           // compared.
           for (uint32_t i = 1u; i < inst->NumInOperands(); ++i)
             for (uint32_t word : inst->GetInOperand(i).words)
-              decorationPayload.push_back(word);
+              decoration_payload.push_back(word);
 
           switch (inst->opcode()) {
             case SpvOpDecorate:
-              decorateSet->emplace(std::move(decorationPayload));
+              decorate_set->emplace(std::move(decoration_payload));
               break;
             case SpvOpMemberDecorate:
-              memberDecorateSet->emplace(std::move(decorationPayload));
+              member_decorate_set->emplace(std::move(decoration_payload));
               break;
             case SpvOpDecorateId:
-              decorateIdSet->emplace(std::move(decorationPayload));
+              decorate_id_set->emplace(std::move(decoration_payload));
               break;
             default:
               break;
@@ -77,21 +77,21 @@ bool DecorationManager::HaveTheSameDecorations(uint32_t id1,
         }
       };
 
-  DecorationSet decorateSetFor1;
-  DecorationSet decorateIdSetFor1;
-  DecorationSet memberDecorateSetFor1;
-  fillDecorationSets(decorationsFor1, &decorateSetFor1, &decorateIdSetFor1,
-                     &memberDecorateSetFor1);
+  DecorationSet decorate_set_for1;
+  DecorationSet decorate_id_set_for1;
+  DecorationSet member_decorate_set_for1;
+  fillDecorationSets(decorations_for1, &decorate_set_for1, &decorate_id_set_for1,
+                     &member_decorate_set_for1);
 
-  DecorationSet decorateSetFor2;
-  DecorationSet decorateIdSetFor2;
-  DecorationSet memberDecorateSetFor2;
-  fillDecorationSets(decorationsFor2, &decorateSetFor2, &decorateIdSetFor2,
-                     &memberDecorateSetFor2);
+  DecorationSet decorate_set_for2;
+  DecorationSet decorate_id_set_for2;
+  DecorationSet member_decorate_set_for2;
+  fillDecorationSets(decorations_for2, &decorate_set_for2, &decorate_id_set_for2,
+                     &member_decorate_set_for2);
 
-  return decorateSetFor1 == decorateSetFor2 &&
-         decorateIdSetFor1 == decorateIdSetFor2 &&
-         memberDecorateSetFor1 == memberDecorateSetFor2;
+  return decorate_set_for1 == decorate_set_for2 &&
+         decorate_id_set_for1 == decorate_id_set_for2 &&
+         member_decorate_set_for1 == member_decorate_set_for2;
 }
 
 // TODO(pierremoreau): If OpDecorateId is referencing an OpConstant, one could
@@ -143,8 +143,8 @@ void DecorationManager::AddDecoration(ir::Instruction* inst) {
     case SpvOpDecorate:
     case SpvOpDecorateId:
     case SpvOpMemberDecorate: {
-      auto const target_id = inst->GetSingleWordInOperand(0u);
-      auto const group_iter = group_to_decoration_insts_.find(target_id);
+      const auto target_id = inst->GetSingleWordInOperand(0u);
+      const auto group_iter = group_to_decoration_insts_.find(target_id);
       if (group_iter != group_to_decoration_insts_.end())
         group_iter->second.push_back(inst);
       else
@@ -153,8 +153,8 @@ void DecorationManager::AddDecoration(ir::Instruction* inst) {
     }
     case SpvOpGroupDecorate:
       for (uint32_t i = 1u; i < inst->NumInOperands(); ++i) {
-        auto const target_id = inst->GetSingleWordInOperand(i);
-        auto const group_iter = group_to_decoration_insts_.find(target_id);
+        const auto target_id = inst->GetSingleWordInOperand(i);
+        const auto group_iter = group_to_decoration_insts_.find(target_id);
         if (group_iter != group_to_decoration_insts_.end())
           group_iter->second.push_back(inst);
         else
@@ -163,8 +163,8 @@ void DecorationManager::AddDecoration(ir::Instruction* inst) {
       break;
     case SpvOpGroupMemberDecorate:
       for (uint32_t i = 1u; i < inst->NumInOperands(); i += 2u) {
-        auto const target_id = inst->GetSingleWordInOperand(i);
-        auto const group_iter = group_to_decoration_insts_.find(target_id);
+        const auto target_id = inst->GetSingleWordInOperand(i);
+        const auto group_iter = group_to_decoration_insts_.find(target_id);
         if (group_iter != group_to_decoration_insts_.end())
           group_iter->second.push_back(inst);
         else
@@ -260,7 +260,7 @@ void DecorationManager::ForEachDecoration(
 void DecorationManager::CloneDecorations(
     uint32_t from, uint32_t to, std::function<void(ir::Instruction&, bool)> f) {
   assert(f && "Missing function parameter f");
-  auto const decoration_list = id_to_decoration_insts_.find(from);
+  const auto decoration_list = id_to_decoration_insts_.find(from);
   if (decoration_list == id_to_decoration_insts_.end()) return;
   for (ir::Instruction* inst : decoration_list->second) {
     switch (inst->opcode()) {
@@ -313,18 +313,18 @@ void DecorationManager::RemoveDecoration(ir::Instruction* inst) {
     case SpvOpDecorate:
     case SpvOpDecorateId:
     case SpvOpMemberDecorate: {
-      auto const target_id = inst->GetSingleWordInOperand(0u);
+      const auto target_id = inst->GetSingleWordInOperand(0u);
       RemoveInstructionFromTarget(inst, target_id);
     } break;
     case SpvOpGroupDecorate:
       for (uint32_t i = 1u; i < inst->NumInOperands(); ++i) {
-        auto const target_id = inst->GetSingleWordInOperand(i);
+        const auto target_id = inst->GetSingleWordInOperand(i);
         RemoveInstructionFromTarget(inst, target_id);
       }
       break;
     case SpvOpGroupMemberDecorate:
       for (uint32_t i = 1u; i < inst->NumInOperands(); i += 2u) {
-        auto const target_id = inst->GetSingleWordInOperand(i);
+        const auto target_id = inst->GetSingleWordInOperand(i);
         RemoveInstructionFromTarget(inst, target_id);
       }
       break;

--- a/source/opt/decoration_manager.h
+++ b/source/opt/decoration_manager.h
@@ -17,6 +17,7 @@
 
 #include <functional>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "instruction.h"
@@ -35,10 +36,16 @@ class DecorationManager {
   }
   DecorationManager() = delete;
 
-  // Removes all decorations from |id|, which should not be a group ID.
-  void RemoveDecorationsFrom(uint32_t id);
+  // Removes all decorations from |id| for which |pred| returns true.
+  // |id| should not be a group ID.
+  void RemoveDecorationsFrom(uint32_t id,
+                             std::function<bool(const ir::Instruction&)> pred =
+                                 [](const ir::Instruction&) { return true; });
 
   // Removes all decorations from the result id of |inst|.
+  //
+  // NOTE: This is only meant to be called from ir_context, as only metadata
+  // will be removed, and no actual instruction.
   void RemoveDecoration(ir::Instruction* inst);
 
   // Returns a vector of all decorations affecting |id|. If a group is applied
@@ -90,12 +97,6 @@ class DecorationManager {
   void AddDecoration(ir::Instruction* inst);
 
  private:
-  // Removes the instruction from the set of decorations targeting |target_id|.
-  void RemoveInstructionFromTarget(ir::Instruction* inst,
-                                   const uint32_t target_id);
-
-  using IdToDecorationInstsMap =
-      std::unordered_map<uint32_t, std::vector<ir::Instruction*>>;
   // Analyzes the defs and uses in the given |module| and populates data
   // structures in this class. Does nothing if |module| is nullptr.
   void AnalyzeDecorations();
@@ -103,14 +104,29 @@ class DecorationManager {
   template <typename T>
   std::vector<T> InternalGetDecorationsFor(uint32_t id, bool include_linkage);
 
-  // Mapping from ids to the instructions applying a decoration to them. In
-  // other words, for each id you get all decoration instructions referencing
-  // that id, be it directly (SpvOpDecorate, SpvOpMemberDecorate and
-  // SpvOpDecorateId), or indirectly (SpvOpGroupDecorate,
+  // Tracks decoration information of an ID.
+  struct TargetData {
+    std::vector<ir::Instruction*> direct_decorations;    // All decorate
+                                                         // instructions applied
+                                                         // to the tracked ID.
+    std::vector<ir::Instruction*> indirect_decorations;  // All instructions
+                                                         // applying a group to
+                                                         // the tracked ID.
+    std::vector<ir::Instruction*> decorate_insts;  // All decorate instructions
+                                                   // applying the decorations
+                                                   // of the tracked ID to
+                                                   // targets.
+                                                   // It is empty if the
+                                                   // tracked ID is not a
+                                                   // group.
+  };
+
+  // Mapping from ids to the instructions applying a decoration to those ids.
+  // In other words, for each id you get all decoration instructions
+  // referencing that id, be it directly (SpvOpDecorate, SpvOpMemberDecorate
+  // and SpvOpDecorateId), or indirectly (SpvOpGroupDecorate,
   // SpvOpMemberGroupDecorate).
-  IdToDecorationInstsMap id_to_decoration_insts_;
-  // Mapping from group ids to all the decoration instructions they apply.
-  IdToDecorationInstsMap group_to_decoration_insts_;
+  std::unordered_map<uint32_t, TargetData> id_to_decoration_insts_;
   // The enclosing module.
   ir::Module* module_;
 };

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -461,7 +461,7 @@ inline bool Instruction::operator<(const Instruction& other) const {
 inline const Operand& Instruction::GetOperand(uint32_t index) const {
   assert(index < operands_.size() && "operand index out of bound");
   return operands_[index];
-};
+}
 
 inline void Instruction::AddOperand(Operand&& operand) {
   operands_.push_back(std::move(operand));

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -186,6 +186,7 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
     return NumInOperandWords() + TypeResultIdCount();
   }
   // Gets the |index|-th logical operand.
+  inline Operand& GetOperand(uint32_t index);
   inline const Operand& GetOperand(uint32_t index) const;
   // Adds |operand| to the list of operands of this instruction.
   // It is the responsibility of the caller to make sure
@@ -218,6 +219,9 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
     return static_cast<uint32_t>(operands_.size() - TypeResultIdCount());
   }
   uint32_t NumInOperandWords() const;
+  Operand& GetInOperand(uint32_t index) {
+    return GetOperand(index + TypeResultIdCount());
+  }
   const Operand& GetInOperand(uint32_t index) const {
     return GetOperand(index + TypeResultIdCount());
   }
@@ -456,6 +460,11 @@ inline bool Instruction::operator!=(const Instruction& other) const {
 
 inline bool Instruction::operator<(const Instruction& other) const {
   return unique_id() < other.unique_id();
+}
+
+inline Operand& Instruction::GetOperand(uint32_t index) {
+  assert(index < operands_.size() && "operand index out of bound");
+  return operands_[index];
 }
 
 inline const Operand& Instruction::GetOperand(uint32_t index) const {

--- a/test/opt/decoration_manager_test.cpp
+++ b/test/opt/decoration_manager_test.cpp
@@ -223,6 +223,165 @@ TEST_F(DecorationManagerTest,
   EXPECT_FALSE(decoManager->AreDecorationsTheSame(&inst1, &inst2, false));
 }
 
+TEST_F(DecorationManagerTest, RemoveDecorationFromVariable) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %1 Constant
+OpDecorate %2 Restrict
+%2      = OpDecorationGroup
+OpGroupDecorate %2 %1 %3
+OpDecorate %4 Invariant
+%4      = OpDecorationGroup
+OpGroupDecorate %4 %2
+OpDecorate %1 Restrict
+%uint   = OpTypeInt 32 0
+%1      = OpVariable %uint Uniform
+%3      = OpVariable %uint Uniform
+)";
+  DecorationManager* decoManager = GetDecorationManager(spirv);
+  EXPECT_THAT(GetErrorMessage(), "");
+  decoManager->RemoveDecorationsFrom(1u);
+  auto decorations = decoManager->GetDecorationsFor(1u, false);
+  EXPECT_THAT(GetErrorMessage(), "");
+  EXPECT_TRUE(decorations.empty());
+  decorations = decoManager->GetDecorationsFor(3u, false);
+  EXPECT_THAT(GetErrorMessage(), "");
+  EXPECT_THAT(ToText(decorations),
+              R"(OpDecorate %4 Invariant
+OpDecorate %2 Restrict
+)");
+  EXPECT_THAT(ModuleToText(),
+              R"(OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %2 Restrict
+%2 = OpDecorationGroup
+OpGroupDecorate %2 %3
+OpDecorate %4 Invariant
+%4 = OpDecorationGroup
+OpGroupDecorate %4 %2
+%uint = OpTypeInt 32 0
+%1 = OpVariable %uint Uniform
+%3 = OpVariable %uint Uniform
+)");
+}
+
+TEST_F(DecorationManagerTest, RemoveDecorationFromDecorationGroup) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %1 Constant
+OpDecorate %2 Restrict
+%2      = OpDecorationGroup
+OpGroupDecorate %2 %1 %3
+OpDecorate %4 Invariant
+%4      = OpDecorationGroup
+OpGroupDecorate %4 %2 %5
+OpDecorate %1 Restrict
+%uint   = OpTypeInt 32 0
+%1      = OpVariable %uint Uniform
+%3      = OpVariable %uint Uniform
+%5      = OpVariable %uint Uniform
+)";
+  DecorationManager* decoManager = GetDecorationManager(spirv);
+  EXPECT_THAT(GetErrorMessage(), "");
+  decoManager->RemoveDecorationsFrom(2u);
+  auto decorations = decoManager->GetDecorationsFor(2u, false);
+  EXPECT_THAT(GetErrorMessage(), "");
+  EXPECT_TRUE(decorations.empty());
+  decorations = decoManager->GetDecorationsFor(1u, false);
+  EXPECT_THAT(GetErrorMessage(), "");
+  EXPECT_THAT(ToText(decorations), R"(OpDecorate %1 Constant
+OpDecorate %1 Restrict
+)");
+  decorations = decoManager->GetDecorationsFor(3u, false);
+  EXPECT_THAT(GetErrorMessage(), "");
+  EXPECT_THAT(ToText(decorations), "");
+  EXPECT_THAT(ModuleToText(),
+              R"(OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %1 Constant
+OpDecorate %4 Invariant
+%4 = OpDecorationGroup
+OpGroupDecorate %4 %5
+OpDecorate %1 Restrict
+%uint = OpTypeInt 32 0
+%1 = OpVariable %uint Uniform
+%3 = OpVariable %uint Uniform
+%5 = OpVariable %uint Uniform
+)");
+}
+
+TEST_F(DecorationManagerTest, RemoveDecorationFromDecorationGroupKeepDeadDecorations) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %1 Constant
+OpDecorate %2 Restrict
+%2      = OpDecorationGroup
+OpGroupDecorate %2 %1 %3
+OpDecorate %4 Invariant
+%4      = OpDecorationGroup
+OpGroupDecorate %4 %2
+OpDecorate %1 Restrict
+%uint   = OpTypeInt 32 0
+%1      = OpVariable %uint Uniform
+%3      = OpVariable %uint Uniform
+)";
+  DecorationManager* decoManager = GetDecorationManager(spirv);
+  EXPECT_THAT(GetErrorMessage(), "");
+  decoManager->RemoveDecorationsFrom(2u);
+  auto decorations = decoManager->GetDecorationsFor(2u, false);
+  EXPECT_THAT(GetErrorMessage(), "");
+  EXPECT_TRUE(decorations.empty());
+  decorations = decoManager->GetDecorationsFor(1u, false);
+  EXPECT_THAT(GetErrorMessage(), "");
+  EXPECT_THAT(ToText(decorations), R"(OpDecorate %1 Constant
+OpDecorate %1 Restrict
+)");
+  decorations = decoManager->GetDecorationsFor(3u, false);
+  EXPECT_THAT(GetErrorMessage(), "");
+  EXPECT_THAT(ToText(decorations), "");
+  EXPECT_THAT(ModuleToText(),
+              R"(OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %1 Constant
+OpDecorate %4 Invariant
+%4 = OpDecorationGroup
+OpDecorate %1 Restrict
+%uint = OpTypeInt 32 0
+%1 = OpVariable %uint Uniform
+%3 = OpVariable %uint Uniform
+)");
+}
+
+TEST_F(DecorationManagerTest, RemoveDecorationDecorate) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %1 Constant
+OpDecorate %1 Restrict
+%u32    = OpTypeInt 32 0
+%1      = OpVariable %u32 Uniform
+)";
+  DecorationManager* decoManager = GetDecorationManager(spirv);
+  EXPECT_THAT(GetErrorMessage(), "");
+  auto decorations = decoManager->GetDecorationsFor(1u, false);
+  decoManager->RemoveDecoration(decorations.front());
+  decorations = decoManager->GetDecorationsFor(1u, false);
+  EXPECT_THAT(GetErrorMessage(), "");
+  EXPECT_THAT(ToText(decorations),
+              R"(OpDecorate %1 Restrict
+)");
+}
+
 TEST_F(DecorationManagerTest, HaveTheSameDecorationsWithoutGroupsTrue) {
   const std::string spirv = R"(
 OpCapability Shader


### PR DESCRIPTION
This reimplementation fixes several issues when removing decorations associated to an ID (partially addresses #1174 and gives tools for fixing #898), as well as making it easier to remove groups; a few additional tests have been added.

`DecorationManager::RemoveDecoration()` will still not delete dead decorations it created, but I do not think it is its job either; given the following input

```
OpCapability Shader
OpCapability Linkage
OpMemoryModel Logical GLSL450
OpDecorate %2 Restrict
%2      = OpDecorationGroup
OpGroupDecorate %2 %1 %3
OpDecorate %4 Invariant
%4      = OpDecorationGroup
OpGroupDecorate %4 %2
%uint   = OpTypeInt 32 0
%1      = OpVariable %uint Uniform
%3      = OpVariable %uint Uniform
```

which of the following two outputs would you expect `RemoveDecoration(2)` to produce:

```
OpCapability Shader
OpCapability Linkage
OpMemoryModel Logical GLSL450
%uint = OpTypeInt 32 0
%1 = OpVariable %uint Uniform
%3 = OpVariable %uint Uniform
```

or

```
OpCapability Shader
OpCapability Linkage
OpMemoryModel Logical GLSL450
OpDecorate %4 Invariant
%4      = OpDecorationGroup
%uint   = OpTypeInt 32 0
%1      = OpVariable %uint Uniform
%3      = OpVariable %uint Uniform
```