### PR TITLE
Add --ftime-report

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -126,6 +126,10 @@ SPVTOOLS_OPT_SRC_FILES := \
 		source/opt/workaround1209.cpp
 
 # Locations of grammar files.
+#
+# TODO(dneto): Build a single set of tables that embeds versioning differences on
+# a per-item basis.  That must happen before SPIR-V 1.4, etc.
+# https://github.com/KhronosGroup/SPIRV-Tools/issues/1195
 SPV_CORE10_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/1.0/spirv.core.grammar.json
 SPV_CORE11_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/1.1/spirv.core.grammar.json
 SPV_CORE12_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/1.2/spirv.core.grammar.json
@@ -174,9 +178,26 @@ $(1)/core.insts-1.2.inc $(1)/operand.kinds-1.2.inc: \
 		                --core-insts-output=$(1)/core.insts-1.2.inc \
 		                --operand-kinds-output=$(1)/operand.kinds-1.2.inc
 		@echo "[$(TARGET_ARCH_ABI)] Grammar v1.2   : instructions & operands <= grammar JSON files"
-$(LOCAL_PATH)/source/opcode.cpp: $(1)/core.insts-1.0.inc $(1)/core.insts-1.1.inc $(1)/core.insts-1.2.inc
-$(LOCAL_PATH)/source/operand.cpp: $(1)/operand.kinds-1.0.inc $(1)/operand.kinds-1.1.inc $(1)/operand.kinds-1.2.inc
-$(LOCAL_PATH)/source/ext_inst.cpp: $(1)/glsl.std.450.insts.inc $(1)/opencl.std.insts.inc
+$(1)/core.insts-unified1.inc $(1)/operand.kinds-unified1.inc: \
+        $(LOCAL_PATH)/utils/generate_grammar_tables.py \
+        $(SPV_COREUNIFIED1_GRAMMAR) \
+        $(SPV_DEBUGINFO_GRAMMAR)
+		@$(HOST_PYTHON) $(LOCAL_PATH)/utils/generate_grammar_tables.py \
+		                --spirv-core-grammar=$(SPV_COREUNIFIED1_GRAMMAR) \
+		                --extinst-debuginfo-grammar=$(SPV_DEBUGINFO_GRAMMAR) \
+		                --core-insts-output=$(1)/core.insts-unified1.inc \
+		                --operand-kinds-output=$(1)/operand.kinds-unified1.inc
+		@echo "[$(TARGET_ARCH_ABI)] Grammar v1.3 (from unified1)  : instructions & operands <= grammar JSON files"
+$(LOCAL_PATH)/source/opcode.cpp: $(1)/core.insts-1.0.inc $(1)/core.insts-1.1.inc $(1)/core.insts-1.2.inc $(1)/core.insts-unified1.inc
+$(LOCAL_PATH)/source/operand.cpp: $(1)/operand.kinds-1.0.inc $(1)/operand.kinds-1.1.inc $(1)/operand.kinds-1.2.inc $(1)/operand.kinds-unified1.inc
+$(LOCAL_PATH)/source/ext_inst.cpp: \
+	$(1)/glsl.std.450.insts.inc \
+	$(1)/opencl.std.insts.inc \
+	$(1)/debuginfo.insts.inc \
+	$(1)/spv-amd-gcn-shader.insts.inc \
+	$(1)/spv-amd-shader-ballot.insts.inc \
+	$(1)/spv-amd-shader-explicit-vertex-parameter.insts.inc \
+	$(1)/spv-amd-shader-trinary-minmax.insts.inc
 endef
 $(eval $(call gen_spvtools_grammar_tables,$(SPVTOOLS_OUT_PATH)))
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 Revision history for SPIRV-Tools
 
+v2018.3-dev 2018-03-07
+ - Start v2018.3 development
+
 v2018.2 2018-03-07
  - General:
    - Support SPIR-V 1.3 and Vulkan 1.1.

--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,23 @@
 Revision history for SPIRV-Tools
 
-v2018.2-dev 2018-03-02
- - Start v2018.2 development
+v2018.2-dev 2018-03-07
+ - General:
+ - Support SPIR-V 1.3 and Vulkan 1.1.
+   - Default target environment is now SPIR-V 1.3.  For command-line tools,
+     use the --target-env option to override the default.  Examples:
+        # Generate a SPIR-V 1.0 binary instead of SPIR-V 1.3
+        spirv-as --target-env spv1.0 a.spvasm -o a.spv
+        spirv-as --target-env vulkan1.0 a.spvasm -o a.spv
+        # Validate as Vulkan 1.0
+        spirv-val --target-env vulkan1.0 a.spv
+   - Support SPV_GOOGLE_decorate_string and SPV_GOOGLE_hlsl_functionality1
+ - Fixes:
+   - Fix Android.mk build. Compilation was failing due to missing definitions of
+     SpvCapabilityFloat16ImageAMD and other enumerated values.
+   - Optimizer: Avoid generating duplicate names when merging types.
+   - #1375: Validator: SPV_AMD_gpu_shaer_half_float implicitly allows declaration
+     of the 16-bit floating point type.
+   - #1376: Optimizer: Avoid folding half-precision float.
 
 v2018.1 2018-03-02
  - General:

--- a/CHANGES
+++ b/CHANGES
@@ -1,15 +1,15 @@
 Revision history for SPIRV-Tools
 
-v2018.2-dev 2018-03-07
+v2018.2 2018-03-07
  - General:
- - Support SPIR-V 1.3 and Vulkan 1.1.
-   - Default target environment is now SPIR-V 1.3.  For command-line tools,
-     use the --target-env option to override the default.  Examples:
-        # Generate a SPIR-V 1.0 binary instead of SPIR-V 1.3
-        spirv-as --target-env spv1.0 a.spvasm -o a.spv
-        spirv-as --target-env vulkan1.0 a.spvasm -o a.spv
-        # Validate as Vulkan 1.0
-        spirv-val --target-env vulkan1.0 a.spv
+   - Support SPIR-V 1.3 and Vulkan 1.1.
+     - Default target environment is now SPIR-V 1.3.  For command-line tools,
+       use the --target-env option to override the default.  Examples:
+	  # Generate a SPIR-V 1.0 binary instead of SPIR-V 1.3
+	  spirv-as --target-env spv1.0 a.spvasm -o a.spv
+	  spirv-as --target-env vulkan1.0 a.spvasm -o a.spv
+	  # Validate as Vulkan 1.0
+	  spirv-val --target-env vulkan1.0 a.spv
    - Support SPV_GOOGLE_decorate_string and SPV_GOOGLE_hlsl_functionality1
  - Fixes:
    - Fix Android.mk build. Compilation was failing due to missing definitions of

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ version.  An API call reports the software version as a C-style string.
 
 ### Assembler, binary parser, and disassembler
 
-* Support for SPIR-V 1.0, 1.1, 1.2
+* Support for SPIR-V 1.0, 1.1, 1.2, and 1.3
   * Based on SPIR-V syntax described by JSON grammar files in the
     [SPIRV-Headers](spirv-headers) repository.
 * Support for extended instruction sets:

--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -409,6 +409,8 @@ typedef enum {
                                 // cl_khr_il_program, latest revision.
   SPV_ENV_OPENCL_EMBEDDED_2_1,  // OpenCL Embedded Profile 2.1 latest revision.
   SPV_ENV_OPENCL_EMBEDDED_2_2,  // OpenCL Embedded Profile 2.2 latest revision.
+  SPV_ENV_UNIVERSAL_1_3,  // SPIR-V 1.3 latest revision, no other restrictions.
+  SPV_ENV_VULKAN_1_1,     // Vulkan 1.0 latest revision.
 } spv_target_env;
 
 // SPIR-V Validator can be parameterized with the following Universal Limits.

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -119,6 +119,11 @@ class Optimizer {
   // output is sent to the |out| output stream.
   Optimizer& SetPrintAll(std::ostream* out);
 
+  // Sets the option to print the resource utilization of each pass. If |out|
+  // is null, then no output is generated. Otherwise, output is sent to the
+  // |out| output stream.
+  Optimizer& SetFTimeReport(std::ostream* out);
+
  private:
   struct Impl;                  // Opaque struct for holding internal data.
   std::unique_ptr<Impl> impl_;  // Unique pointer to internal data.

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -230,6 +230,7 @@ set(SPIRV_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/util/hex_float.h
   ${CMAKE_CURRENT_SOURCE_DIR}/util/parse_number.h
   ${CMAKE_CURRENT_SOURCE_DIR}/util/string_utils.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/util/timer.h
   ${CMAKE_CURRENT_SOURCE_DIR}/assembly_grammar.h
   ${CMAKE_CURRENT_SOURCE_DIR}/binary.h
   ${CMAKE_CURRENT_SOURCE_DIR}/cfa.h
@@ -263,6 +264,7 @@ set(SPIRV_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/util/bit_stream.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/util/parse_number.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/util/string_utils.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/util/timer.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/assembly_grammar.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/binary.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/diagnostic.cpp

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -131,9 +131,15 @@ macro(spvtools_extinst_lang_headers NAME GRAMMAR_FILE)
 endmacro(spvtools_extinst_lang_headers)
 
 
+# SPIR-V 1.3 support is in SPIRV-Headers include/spirv/unified1
+# Temporarily assume that's the last SPIR-V version in 'unified1'.
+# TODO(dneto): Build a single set of tables that embeds versioning
+# differences on a per-item basis.  That must happen before SPIR-V 1.4, etc.
+# https://github.com/KhronosGroup/SPIRV-Tools/issues/1195
 spvtools_core_tables("1.0")
 spvtools_core_tables("1.1")
 spvtools_core_tables("1.2")
+spvtools_core_tables("unified1")
 spvtools_enum_string_mapping("unified1")
 spvtools_opencl_tables("unified1")
 spvtools_glsl_tables("unified1")

--- a/source/ext_inst.cpp
+++ b/source/ext_inst.cpp
@@ -79,6 +79,8 @@ spv_result_t spvExtInstTableGet(spv_ext_inst_table* pExtInstTable,
     case SPV_ENV_OPENGL_4_2:
     case SPV_ENV_OPENGL_4_3:
     case SPV_ENV_OPENGL_4_5:
+    case SPV_ENV_UNIVERSAL_1_3:
+    case SPV_ENV_VULKAN_1_1:
       *pExtInstTable = &kTable_1_0;
       return SPV_SUCCESS;
     default:

--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -32,9 +32,15 @@ struct OpcodeDescPtrLen {
   uint32_t len;
 };
 
-#include "core.insts-1.0.inc"  // defines kOpcodeTableEntries_1_0
-#include "core.insts-1.1.inc"  // defines kOpcodeTableEntries_1_1
-#include "core.insts-1.2.inc"  // defines kOpcodeTableEntries_1_2
+// For now, assume unified1 contains up to SPIR-V 1.3 and no later
+// SPIR-V version.
+// TODO(dneto): Make one set of tables, but with version tags on a
+// per-item basis. https://github.com/KhronosGroup/SPIRV-Tools/issues/1195
+
+#include "core.insts-1.0.inc"       // defines kOpcodeTableEntries_1_0
+#include "core.insts-1.1.inc"       // defines kOpcodeTableEntries_1_1
+#include "core.insts-1.2.inc"       // defines kOpcodeTableEntries_1_2
+#include "core.insts-unified1.inc"  // defines kOpcodeTableEntries_1_3
 
 static const spv_opcode_table_t kTable_1_0 = {
     ARRAY_SIZE(kOpcodeTableEntries_1_0), kOpcodeTableEntries_1_0};
@@ -42,6 +48,8 @@ static const spv_opcode_table_t kTable_1_1 = {
     ARRAY_SIZE(kOpcodeTableEntries_1_1), kOpcodeTableEntries_1_1};
 static const spv_opcode_table_t kTable_1_2 = {
     ARRAY_SIZE(kOpcodeTableEntries_1_2), kOpcodeTableEntries_1_2};
+static const spv_opcode_table_t kTable_1_3 = {
+    ARRAY_SIZE(kOpcodeTableEntries_1_3), kOpcodeTableEntries_1_3};
 
 // Represents a vendor tool entry in the SPIR-V XML Regsitry.
 struct VendorTool {
@@ -111,6 +119,10 @@ spv_result_t spvOpcodeTableGet(spv_opcode_table* pInstTable,
     case SPV_ENV_OPENCL_2_2:
     case SPV_ENV_OPENCL_EMBEDDED_2_2:
       *pInstTable = &kTable_1_2;
+      return SPV_SUCCESS;
+    case SPV_ENV_UNIVERSAL_1_3:
+    case SPV_ENV_VULKAN_1_1:
+      *pInstTable = &kTable_1_3;
       return SPV_SUCCESS;
   }
   assert(0 && "Unknown spv_target_env in spvOpcodeTableGet()");
@@ -182,9 +194,9 @@ const char* spvOpcodeString(const SpvOp opcode) {
   // Use the latest SPIR-V version, which should be backward-compatible with all
   // previous ones.
 
-  const auto beg = kOpcodeTableEntries_1_2;
+  const auto beg = kOpcodeTableEntries_1_3;
   const auto end =
-      kOpcodeTableEntries_1_2 + ARRAY_SIZE(kOpcodeTableEntries_1_2);
+      kOpcodeTableEntries_1_3 + ARRAY_SIZE(kOpcodeTableEntries_1_3);
   spv_opcode_desc_t value{"", opcode, 0, nullptr, 0, {}, 0, 0};
   auto comp = [](const spv_opcode_desc_t& lhs, const spv_opcode_desc_t& rhs) {
     return lhs.opcode < rhs.opcode;

--- a/source/operand.cpp
+++ b/source/operand.cpp
@@ -20,9 +20,15 @@
 
 #include "macro.h"
 
+// For now, assume unified1 contains up to SPIR-V 1.3 and no later
+// SPIR-V version.
+// TODO(dneto): Make one set of tables, but with version tags on a
+// per-item basis. https://github.com/KhronosGroup/SPIRV-Tools/issues/1195
+
 #include "operand.kinds-1.0.inc"
 #include "operand.kinds-1.1.inc"
 #include "operand.kinds-1.2.inc"
+#include "operand.kinds-unified1.inc"
 
 static const spv_operand_table_t kTable_1_0 = {
     ARRAY_SIZE(pygen_variable_OperandInfoTable_1_0),
@@ -33,6 +39,9 @@ static const spv_operand_table_t kTable_1_1 = {
 static const spv_operand_table_t kTable_1_2 = {
     ARRAY_SIZE(pygen_variable_OperandInfoTable_1_2),
     pygen_variable_OperandInfoTable_1_2};
+static const spv_operand_table_t kTable_1_3 = {
+    ARRAY_SIZE(pygen_variable_OperandInfoTable_1_3),
+    pygen_variable_OperandInfoTable_1_3};
 
 spv_result_t spvOperandTableGet(spv_operand_table* pOperandTable,
                                 spv_target_env env) {
@@ -61,6 +70,10 @@ spv_result_t spvOperandTableGet(spv_operand_table* pOperandTable,
     case SPV_ENV_OPENCL_2_2:
     case SPV_ENV_OPENCL_EMBEDDED_2_2:
       *pOperandTable = &kTable_1_2;
+      return SPV_SUCCESS;
+    case SPV_ENV_UNIVERSAL_1_3:
+    case SPV_ENV_VULKAN_1_1:
+      *pOperandTable = &kTable_1_3;
       return SPV_SUCCESS;
   }
   assert(0 && "Unknown spv_target_env in spvOperandTableGet()");

--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -684,6 +684,12 @@ void AggressiveDCEPass::InitExtensions() {
       "SPV_AMD_gpu_shader_int16",
       "SPV_KHR_post_depth_coverage",
       "SPV_KHR_shader_atomic_counter_ops",
+      "SPV_EXT_shader_stencil_export",
+      "SPV_EXT_shader_viewport_index_layer",
+      "SPV_AMD_shader_image_load_store_lod",
+      "SPV_AMD_shader_fragment_mask",
+      "SPV_EXT_fragment_fully_covered",
+      "SPV_AMD_gpu_shader_half_float_fetch",
   });
 }
 

--- a/source/opt/block_merge_pass.cpp
+++ b/source/opt/block_merge_pass.cpp
@@ -180,6 +180,12 @@ void BlockMergePass::InitExtensions() {
       "SPV_AMD_gpu_shader_int16",
       "SPV_KHR_post_depth_coverage",
       "SPV_KHR_shader_atomic_counter_ops",
+      "SPV_EXT_shader_stencil_export",
+      "SPV_EXT_shader_viewport_index_layer",
+      "SPV_AMD_shader_image_load_store_lod",
+      "SPV_AMD_shader_fragment_mask",
+      "SPV_EXT_fragment_fully_covered",
+      "SPV_AMD_gpu_shader_half_float_fetch",
   });
 }
 

--- a/source/opt/common_uniform_elim_pass.cpp
+++ b/source/opt/common_uniform_elim_pass.cpp
@@ -564,6 +564,12 @@ void CommonUniformElimPass::InitExtensions() {
       "SPV_AMD_gpu_shader_int16",
       "SPV_KHR_post_depth_coverage",
       "SPV_KHR_shader_atomic_counter_ops",
+      "SPV_EXT_shader_stencil_export",
+      "SPV_EXT_shader_viewport_index_layer",
+      "SPV_AMD_shader_image_load_store_lod",
+      "SPV_AMD_shader_fragment_mask",
+      "SPV_EXT_fragment_fully_covered",
+      "SPV_AMD_gpu_shader_half_float_fetch",
   });
 }
 

--- a/source/opt/dead_branch_elim_pass.cpp
+++ b/source/opt/dead_branch_elim_pass.cpp
@@ -431,6 +431,12 @@ void DeadBranchElimPass::InitExtensions() {
       "SPV_AMD_gpu_shader_int16",
       "SPV_KHR_post_depth_coverage",
       "SPV_KHR_shader_atomic_counter_ops",
+      "SPV_EXT_shader_stencil_export",
+      "SPV_EXT_shader_viewport_index_layer",
+      "SPV_AMD_shader_image_load_store_lod",
+      "SPV_AMD_shader_fragment_mask",
+      "SPV_EXT_fragment_fully_covered",
+      "SPV_AMD_gpu_shader_half_float_fetch",
   });
 }
 

--- a/source/opt/dead_insert_elim_pass.cpp
+++ b/source/opt/dead_insert_elim_pass.cpp
@@ -303,6 +303,12 @@ void DeadInsertElimPass::InitExtensions() {
       "SPV_AMD_gpu_shader_int16",
       "SPV_KHR_post_depth_coverage",
       "SPV_KHR_shader_atomic_counter_ops",
+      "SPV_EXT_shader_stencil_export",
+      "SPV_EXT_shader_viewport_index_layer",
+      "SPV_AMD_shader_image_load_store_lod",
+      "SPV_AMD_shader_fragment_mask",
+      "SPV_EXT_fragment_fully_covered",
+      "SPV_AMD_gpu_shader_half_float_fetch",
   });
 }
 

--- a/source/opt/folding_rules.cpp
+++ b/source/opt/folding_rules.cpp
@@ -1465,7 +1465,7 @@ FoldingRule VectorShuffleFeedingExtract() {
 
     // Find the size of the first vector operand of the VectorShuffle
     ir::Instruction* first_input =
-        def_use_mgr->GetDef(inst->GetSingleWordInOperand(0));
+        def_use_mgr->GetDef(cinst->GetSingleWordInOperand(0));
     analysis::Type* first_input_type =
         type_mgr->GetType(first_input->type_id());
     assert(first_input_type->AsVector() &&

--- a/source/opt/insert_extract_elim.cpp
+++ b/source/opt/insert_extract_elim.cpp
@@ -258,6 +258,12 @@ void InsertExtractElimPass::InitExtensions() {
       "SPV_AMD_gpu_shader_int16",
       "SPV_KHR_post_depth_coverage",
       "SPV_KHR_shader_atomic_counter_ops",
+      "SPV_EXT_shader_stencil_export",
+      "SPV_EXT_shader_viewport_index_layer",
+      "SPV_AMD_shader_image_load_store_lod",
+      "SPV_AMD_shader_fragment_mask",
+      "SPV_EXT_fragment_fully_covered",
+      "SPV_AMD_gpu_shader_half_float_fetch",
   });
 }
 

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -324,6 +324,12 @@ void LocalAccessChainConvertPass::InitExtensions() {
       "SPV_AMD_gpu_shader_int16",
       "SPV_KHR_post_depth_coverage",
       "SPV_KHR_shader_atomic_counter_ops",
+      "SPV_EXT_shader_stencil_export",
+      "SPV_EXT_shader_viewport_index_layer",
+      "SPV_AMD_shader_image_load_store_lod",
+      "SPV_AMD_shader_fragment_mask",
+      "SPV_EXT_fragment_fully_covered",
+      "SPV_AMD_gpu_shader_half_float_fetch",
   });
 }
 

--- a/source/opt/local_single_block_elim_pass.cpp
+++ b/source/opt/local_single_block_elim_pass.cpp
@@ -204,6 +204,12 @@ void LocalSingleBlockLoadStoreElimPass::InitExtensions() {
       "SPV_AMD_gpu_shader_int16",
       "SPV_KHR_post_depth_coverage",
       "SPV_KHR_shader_atomic_counter_ops",
+      "SPV_EXT_shader_stencil_export",
+      "SPV_EXT_shader_viewport_index_layer",
+      "SPV_AMD_shader_image_load_store_lod",
+      "SPV_AMD_shader_fragment_mask",
+      "SPV_EXT_fragment_fully_covered",
+      "SPV_AMD_gpu_shader_half_float_fetch",
   });
 }
 

--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -307,6 +307,12 @@ void LocalSingleStoreElimPass::InitExtensions() {
       "SPV_AMD_gpu_shader_int16",
       "SPV_KHR_post_depth_coverage",
       "SPV_KHR_shader_atomic_counter_ops",
+      "SPV_EXT_shader_stencil_export",
+      "SPV_EXT_shader_viewport_index_layer",
+      "SPV_AMD_shader_image_load_store_lod",
+      "SPV_AMD_shader_fragment_mask",
+      "SPV_EXT_fragment_fully_covered",
+      "SPV_AMD_gpu_shader_half_float_fetch",
   });
 }
 

--- a/source/opt/local_ssa_elim_pass.cpp
+++ b/source/opt/local_ssa_elim_pass.cpp
@@ -97,6 +97,12 @@ void LocalMultiStoreElimPass::InitExtensions() {
       "SPV_AMD_gpu_shader_int16",
       "SPV_KHR_post_depth_coverage",
       "SPV_KHR_shader_atomic_counter_ops",
+      "SPV_EXT_shader_stencil_export",
+      "SPV_EXT_shader_viewport_index_layer",
+      "SPV_AMD_shader_image_load_store_lod",
+      "SPV_AMD_shader_fragment_mask",
+      "SPV_EXT_fragment_fully_covered",
+      "SPV_AMD_gpu_shader_half_float_fetch",
   });
 }
 

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -211,6 +211,11 @@ Optimizer& Optimizer::SetPrintAll(std::ostream* out) {
   return *this;
 }
 
+Optimizer& Optimizer::SetFTimeReport(std::ostream* out) {
+  impl_->pass_manager.SetFTimeReport(out);
+  return *this;
+}
+
 Optimizer::PassToken CreateNullPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(MakeUnique<opt::NullPass>());
 }

--- a/source/opt/pass_manager.cpp
+++ b/source/opt/pass_manager.cpp
@@ -17,16 +17,9 @@
 #include <iostream>
 #include <vector>
 
-#if defined(SPIRV_ANDROID) || defined(SPIRV_LINUX) || defined(SPIRV_MAC) || \
-    defined(SPIRV_FREEBSD)
-#include <iomanip>
-#include <sys/time.h>
-#include <sys/resource.h>
-#elif defined(SPIRV_WINDOWS)
-#endif
-
 #include "ir_context.h"
 #include "spirv-tools/libspirv.hpp"
+#include "util/timer.h"
 
 namespace spvtools {
 
@@ -49,64 +42,11 @@ Pass::Status PassManager::Run(ir::IRContext* context) {
     }
   };
 
-#if defined(SPIRV_ANDROID) || defined(SPIRV_LINUX) || defined(SPIRV_MAC) || \
-    defined(SPIRV_FREEBSD)
-  double (*get_time_difference)(const timeval&, const timeval&) = NULL;
-  if (ftime_report_stream_) {
-    *ftime_report_stream_<< std::setw(30) << "Pass Name"
-      << std::setw(16) << "CPU time"
-      << std::setw(16) << "WALL time"
-      << std::setw(16) << "SYS time"
-      << std::setw(16) << "Pagefaults"
-      << std::setw(16) << "RSS" << std::endl;
-    get_time_difference = [](const timeval& before, const timeval& after) -> double {
-      return static_cast<double>(after.tv_sec - before.tv_sec) +
-        static_cast<double>(after.tv_usec - before.tv_usec) * .000001;
-    };
-  }
-#endif
+  SPIRV_TIMER_DESCRIPTION(ftime_report_stream_);
   for (const auto& pass : passes_) {
     print_disassembly("; IR before pass ", pass.get());
-#if defined(SPIRV_ANDROID) || defined(SPIRV_LINUX) || defined(SPIRV_MAC) || \
-    defined(SPIRV_FREEBSD)
-    bool usage_fail = false;
-    rusage usage_before;
-    timeval wall_before;
-    if (ftime_report_stream_) {
-      if (getrusage(RUSAGE_CHILDREN, &usage_before) == -1) {
-        *ftime_report_stream_ << std::setw(30) << (pass ? pass->name() : "")
-          << " ERROR: calling getrusage() fails";
-        usage_fail = true;
-      } else if (gettimeofday(&wall_before, NULL) == -1) {
-        *ftime_report_stream_ << std::setw(30) << (pass ? pass->name() : "")
-          << " ERROR: calling gettimeofday() fails";
-        usage_fail = true;
-      }
-    }
-#endif
+    SPIRV_TIMER_SCROPED(ftime_report_stream_, (pass ? pass->name() : ""));
     const auto one_status = pass->Run(context);
-#if defined(SPIRV_ANDROID) || defined(SPIRV_LINUX) || defined(SPIRV_MAC) || \
-    defined(SPIRV_FREEBSD)
-    if (ftime_report_stream_ && !usage_fail) {
-      rusage usage_after;
-      timeval wall_after;
-      if (getrusage(RUSAGE_CHILDREN, &usage_after) == -1) {
-        *ftime_report_stream_ << std::setw(30) << (pass ? pass->name() : "")
-          << " ERROR: calling getrusage() fails";
-      } else if (gettimeofday(&wall_after, NULL) == -1) {
-        *ftime_report_stream_ << std::setw(30) << (pass ? pass->name() : "")
-          << " ERROR: calling gettimeofday() fails";
-      } else {
-        *ftime_report_stream_ << std::setw(30) << (pass ? pass->name() : "")
-          << std::setw(16) << get_time_difference(usage_before.ru_utime, usage_after.ru_utime)
-          << std::setw(16) << get_time_difference(wall_before, wall_after)
-          << std::setw(16) << get_time_difference(usage_before.ru_stime, usage_after.ru_stime)
-          << std::setw(16) << ((usage_after.ru_minflt - usage_before.ru_minflt)
-              + (usage_after.ru_majflt - usage_before.ru_majflt))
-          << std::setw(16) << (usage_after.ru_maxrss - usage_before.ru_maxrss) << std::endl;
-      }
-    }
-#endif
     if (one_status == Pass::Status::Failure) return one_status;
     if (one_status == Pass::Status::SuccessWithChange) status = one_status;
   }

--- a/source/opt/pass_manager.cpp
+++ b/source/opt/pass_manager.cpp
@@ -17,6 +17,14 @@
 #include <iostream>
 #include <vector>
 
+#if defined(SPIRV_ANDROID) || defined(SPIRV_LINUX) || defined(SPIRV_MAC) || \
+    defined(SPIRV_FREEBSD)
+#include <iomanip>
+#include <sys/time.h>
+#include <sys/resource.h>
+#elif defined(SPIRV_WINDOWS)
+#endif
+
 #include "ir_context.h"
 #include "spirv-tools/libspirv.hpp"
 
@@ -41,9 +49,64 @@ Pass::Status PassManager::Run(ir::IRContext* context) {
     }
   };
 
+#if defined(SPIRV_ANDROID) || defined(SPIRV_LINUX) || defined(SPIRV_MAC) || \
+    defined(SPIRV_FREEBSD)
+  double (*get_time_difference)(const timeval&, const timeval&) = NULL;
+  if (ftime_report_stream_) {
+    *ftime_report_stream_<< std::setw(30) << "Pass Name"
+      << std::setw(16) << "CPU time"
+      << std::setw(16) << "WALL time"
+      << std::setw(16) << "SYS time"
+      << std::setw(16) << "Pagefaults"
+      << std::setw(16) << "RSS" << std::endl;
+    get_time_difference = [](const timeval& before, const timeval& after) -> double {
+      return static_cast<double>(after.tv_sec - before.tv_sec) +
+        static_cast<double>(after.tv_usec - before.tv_usec) * .000001;
+    };
+  }
+#endif
   for (const auto& pass : passes_) {
     print_disassembly("; IR before pass ", pass.get());
+#if defined(SPIRV_ANDROID) || defined(SPIRV_LINUX) || defined(SPIRV_MAC) || \
+    defined(SPIRV_FREEBSD)
+    bool usage_fail = false;
+    rusage usage_before;
+    timeval wall_before;
+    if (ftime_report_stream_) {
+      if (getrusage(RUSAGE_CHILDREN, &usage_before) == -1) {
+        *ftime_report_stream_ << std::setw(30) << (pass ? pass->name() : "")
+          << " ERROR: calling getrusage() fails";
+        usage_fail = true;
+      } else if (gettimeofday(&wall_before, NULL) == -1) {
+        *ftime_report_stream_ << std::setw(30) << (pass ? pass->name() : "")
+          << " ERROR: calling gettimeofday() fails";
+        usage_fail = true;
+      }
+    }
+#endif
     const auto one_status = pass->Run(context);
+#if defined(SPIRV_ANDROID) || defined(SPIRV_LINUX) || defined(SPIRV_MAC) || \
+    defined(SPIRV_FREEBSD)
+    if (ftime_report_stream_ && !usage_fail) {
+      rusage usage_after;
+      timeval wall_after;
+      if (getrusage(RUSAGE_CHILDREN, &usage_after) == -1) {
+        *ftime_report_stream_ << std::setw(30) << (pass ? pass->name() : "")
+          << " ERROR: calling getrusage() fails";
+      } else if (gettimeofday(&wall_after, NULL) == -1) {
+        *ftime_report_stream_ << std::setw(30) << (pass ? pass->name() : "")
+          << " ERROR: calling gettimeofday() fails";
+      } else {
+        *ftime_report_stream_ << std::setw(30) << (pass ? pass->name() : "")
+          << std::setw(16) << get_time_difference(usage_before.ru_utime, usage_after.ru_utime)
+          << std::setw(16) << get_time_difference(wall_before, wall_after)
+          << std::setw(16) << get_time_difference(usage_before.ru_stime, usage_after.ru_stime)
+          << std::setw(16) << ((usage_after.ru_minflt - usage_before.ru_minflt)
+              + (usage_after.ru_majflt - usage_before.ru_majflt))
+          << std::setw(16) << (usage_after.ru_maxrss - usage_before.ru_maxrss) << std::endl;
+      }
+    }
+#endif
     if (one_status == Pass::Status::Failure) return one_status;
     if (one_status == Pass::Status::SuccessWithChange) status = one_status;
   }

--- a/source/opt/pass_manager.h
+++ b/source/opt/pass_manager.h
@@ -39,7 +39,7 @@ class PassManager {
   // The constructed instance will have an empty message consumer, which just
   // ignores all messages from the library. Use SetMessageConsumer() to supply
   // one if messages are of concern.
-  PassManager() : consumer_(nullptr), print_all_stream_(nullptr) {}
+  PassManager() : consumer_(nullptr), print_all_stream_(nullptr), ftime_report_stream_(nullptr) {}
 
   // Sets the message consumer to the given |consumer|.
   void SetMessageConsumer(MessageConsumer c) { consumer_ = std::move(c); }
@@ -77,6 +77,14 @@ class PassManager {
     return *this;
   }
 
+  // Sets the option to print the resource utilization of each pass. Output is
+  // written to |out| if that is not null. No output is generated if |out| is
+  // null.
+  PassManager& SetFTimeReport(std::ostream* out) {
+    ftime_report_stream_ = out;
+    return *this;
+  }
+
  private:
   // Consumer for messages.
   MessageConsumer consumer_;
@@ -85,6 +93,9 @@ class PassManager {
   // The output stream to write disassembly to before each pass, and after
   // the last pass.  If this is null, no output is generated.
   std::ostream* print_all_stream_;
+  // The output stream to write the resource utilization of each pass. If this
+  // is null, no output is generated.
+  std::ostream* ftime_report_stream_;
 };
 
 inline void PassManager::AddPass(std::unique_ptr<Pass> pass) {

--- a/source/opt/pass_manager.h
+++ b/source/opt/pass_manager.h
@@ -39,7 +39,10 @@ class PassManager {
   // The constructed instance will have an empty message consumer, which just
   // ignores all messages from the library. Use SetMessageConsumer() to supply
   // one if messages are of concern.
-  PassManager() : consumer_(nullptr), print_all_stream_(nullptr), ftime_report_stream_(nullptr) {}
+  PassManager()
+      : consumer_(nullptr),
+        print_all_stream_(nullptr),
+        ftime_report_stream_(nullptr) {}
 
   // Sets the message consumer to the given |consumer|.
   void SetMessageConsumer(MessageConsumer c) { consumer_ = std::move(c); }

--- a/source/spirv_target_env.cpp
+++ b/source/spirv_target_env.cpp
@@ -54,6 +54,10 @@ const char* spvTargetEnvDescription(spv_target_env env) {
       return "SPIR-V 1.0 (under OpenCL 4.5 semantics)";
     case SPV_ENV_UNIVERSAL_1_2:
       return "SPIR-V 1.2";
+    case SPV_ENV_UNIVERSAL_1_3:
+      return "SPIR-V 1.3";
+    case SPV_ENV_VULKAN_1_1:
+      return "SPIR-V 1.3 (under Vulkan 1.1 semantics)";
   }
   assert(0 && "Unhandled SPIR-V target environment");
   return "";
@@ -81,6 +85,9 @@ uint32_t spvVersionForTargetEnv(spv_target_env env) {
     case SPV_ENV_OPENCL_2_2:
     case SPV_ENV_OPENCL_EMBEDDED_2_2:
       return SPV_SPIRV_VERSION_WORD(1, 2);
+    case SPV_ENV_UNIVERSAL_1_3:
+    case SPV_ENV_VULKAN_1_1:
+      return SPV_SPIRV_VERSION_WORD(1, 3);
   }
   assert(0 && "Unhandled SPIR-V target environment");
   return SPV_SPIRV_VERSION_WORD(0, 0);
@@ -93,6 +100,9 @@ bool spvParseTargetEnv(const char* s, spv_target_env* env) {
   if (match("vulkan1.0")) {
     if (env) *env = SPV_ENV_VULKAN_1_0;
     return true;
+  } else if (match("vulkan1.1")) {
+    if (env) *env = SPV_ENV_VULKAN_1_1;
+    return true;
   } else if (match("spv1.0")) {
     if (env) *env = SPV_ENV_UNIVERSAL_1_0;
     return true;
@@ -101,6 +111,9 @@ bool spvParseTargetEnv(const char* s, spv_target_env* env) {
     return true;
   } else if (match("spv1.2")) {
     if (env) *env = SPV_ENV_UNIVERSAL_1_2;
+    return true;
+  } else if (match("spv1.3")) {
+    if (env) *env = SPV_ENV_UNIVERSAL_1_3;
     return true;
   } else if (match("opencl1.2embedded")) {
     if (env) *env = SPV_ENV_OPENCL_EMBEDDED_1_2;
@@ -165,8 +178,10 @@ bool spvIsVulkanEnv(spv_target_env env) {
     case SPV_ENV_UNIVERSAL_1_2:
     case SPV_ENV_OPENCL_2_2:
     case SPV_ENV_OPENCL_EMBEDDED_2_2:
+    case SPV_ENV_UNIVERSAL_1_3:
       return false;
     case SPV_ENV_VULKAN_1_0:
+    case SPV_ENV_VULKAN_1_1:
       return true;
   }
   return false;

--- a/source/table.cpp
+++ b/source/table.cpp
@@ -35,6 +35,8 @@ spv_context spvContextCreate(spv_target_env env) {
     case SPV_ENV_OPENGL_4_3:
     case SPV_ENV_OPENGL_4_5:
     case SPV_ENV_UNIVERSAL_1_2:
+    case SPV_ENV_UNIVERSAL_1_3:
+    case SPV_ENV_VULKAN_1_1:
       break;
     default:
       return nullptr;

--- a/source/util/timer.cpp
+++ b/source/util/timer.cpp
@@ -1,0 +1,105 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sys/resource.h>
+#include <sys/time.h>
+#include <iomanip>
+#include <iostream>
+
+#include "util/timer.h"
+
+namespace spvutils {
+
+#if defined(SPIRV_TIMER_ENABLED)
+
+namespace {
+inline double TimeDifference(const timeval& before, const timeval& after) {
+  return static_cast<double>(after.tv_sec - before.tv_sec) +
+         static_cast<double>((after.tv_usec - before.tv_usec) / 10000) * .01;
+}
+}  // namespace
+
+void TimerPrintDescription(std::ostream* out) {
+  if (out) {
+    *out << std::setw(30) << "PASS name" << std::setw(12) << "USR time"
+         << std::setw(12) << "WALL time" << std::setw(12) << "SYS time"
+#if defined(SPIRV_MEMORY_MEASUREMENT_ENABLED)
+         << std::setw(12) << "RSS" << std::setw(12) << "Pagefault"
+#endif  // defined(SPIRV_MEMORY_MEASUREMENT_ENABLED)
+         << std::endl;
+  }
+}
+
+void Timer::Start() {
+  if (report_stream_) {
+    if (getrusage(RUSAGE_SELF, &usage_before) == -1) {
+      usage_fail = kGetrusageFail;
+    } else if (gettimeofday(&wall_before, NULL) == -1) {
+      usage_fail = kGettimeofdayFail;
+    }
+  }
+}
+
+void Timer::Stop() {
+  if (report_stream_ && usage_fail == kNotFailed) {
+    if (getrusage(RUSAGE_SELF, &usage_after) == -1) {
+      usage_fail = kGetrusageFail;
+    } else if (gettimeofday(&wall_after, NULL) == -1) {
+      usage_fail = kGettimeofdayFail;
+    }
+  }
+}
+
+void Timer::Report(const char* tag) {
+  switch (usage_fail) {
+    case kGetrusageFail:
+      *report_stream_ << std::setw(30) << tag
+                      << " ERROR: calling getrusage() fails";
+      return;
+    case kGettimeofdayFail:
+      *report_stream_ << std::setw(30) << tag
+                      << " ERROR: calling gettimeofday() fails";
+      return;
+    default:
+      break;
+  }
+
+  if (report_stream_) {
+    report_stream_->precision(2);
+    *report_stream_ << std::fixed << std::setw(30) << tag << std::setw(12)
+                    << TimeDifference(usage_before.ru_utime,
+                                      usage_after.ru_utime)
+                    << std::setw(12) << TimeDifference(wall_before, wall_after)
+                    << std::setw(12)
+                    << TimeDifference(usage_before.ru_stime,
+                                      usage_after.ru_stime)
+#if defined(SPIRV_MEMORY_MEASUREMENT_ENABLED)
+                    << std::setw(12)
+                    << (usage_after.ru_maxrss - usage_before.ru_maxrss)
+                    << std::setw(12)
+                    << ((usage_after.ru_minflt - usage_before.ru_minflt) +
+                        (usage_after.ru_majflt - usage_before.ru_majflt))
+#endif  // defined(SPIRV_MEMORY_MEASUREMENT_ENABLED)
+                    << std::endl;
+  }
+}
+
+void Timer::StopAndReport(const char* tag) {
+  Stop();
+  Report(tag);
+}
+
+#endif  // defined(SPIRV_TIMER_ENABLED)
+
+}  // namespace spvutils

--- a/source/util/timer.h
+++ b/source/util/timer.h
@@ -1,0 +1,79 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Contains utils for getting resource utilization
+
+#ifndef LIBSPIRV_UTIL_TIMER_H_
+#define LIBSPIRV_UTIL_TIMER_H_
+
+#if defined(SPIRV_ANDROID) || defined(SPIRV_LINUX) || defined(SPIRV_MAC) || \
+    defined(SPIRV_FREEBSD)
+
+#define SPIRV_TIMER_ENABLED
+#define SPIRV_TIMER_DESCRIPTION(out) spvutils::TimerPrintDescription(out)
+#define SPIRV_TIMER_SCROPED(out, tag) \
+  spvutils::ScropedTimer timer##__LINE__(out, tag)
+
+#if defined(SPIRV_LINUX)
+#define SPIRV_MEMORY_MEASUREMENT_ENABLED
+#endif  // defined(SPIRV_LINUX)
+
+#include <sys/resource.h>
+
+namespace spvutils {
+
+void TimerPrintDescription(std::ostream* out);
+
+class Timer {
+ public:
+  Timer(std::ostream* out) : report_stream_(out), usage_fail(kNotFailed) {}
+  void Start();
+  void Stop();
+  void Report(const char* tag);
+  void StopAndReport(const char* tag);
+
+ private:
+  std::ostream* report_stream_;
+
+  enum { kGetrusageFail, kGettimeofdayFail, kNotFailed } usage_fail;
+
+  rusage usage_before;
+  rusage usage_after;
+  timeval wall_before;
+  timeval wall_after;
+};
+
+class ScropedTimer : Timer {
+ public:
+  ScropedTimer(std::ostream* out, const char* tag) : Timer(out), tag_(tag) {
+    Start();
+  }
+  ~ScropedTimer() { StopAndReport(tag_); }
+
+ private:
+  const char* tag_;
+};
+
+}  // namespace spvutils
+
+#elif  // defined(SPIRV_ANDROID) || defined(SPIRV_LINUX) ||
+       // defined(SPIRV_MAC) || defined(SPIRV_FREEBSD)
+
+#define SPIRV_TIMER_DESCRIPTION(out)
+#define SPIRV_TIMER_SCROPED(out, tag)
+
+#endif  // defined(SPIRV_ANDROID) || defined(SPIRV_LINUX) ||
+        // defined(SPIRV_MAC) || defined(SPIRV_FREEBSD)
+
+#endif  // LIBSPIRV_UTIL_TIMER_H_

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -331,6 +331,11 @@ void ValidationState_t::RegisterExtension(Extension ext) {
   module_extensions_.Add(ext);
 
   switch (ext) {
+    case kSPV_AMD_gpu_shader_half_float:
+      // SPV_AMD_gpu_shader_half_float enables float16 type.
+      // https://github.com/KhronosGroup/SPIRV-Tools/issues/1375
+      features_.declare_float16_type = true;
+      break;
     case kSPV_AMD_shader_ballot:
       // The grammar doesn't encode the fact that SPV_AMD_shader_ballot
       // enables the use of group operations Reduce, InclusiveScan,

--- a/test/binary_header_get_test.cpp
+++ b/test/binary_header_get_test.cpp
@@ -50,7 +50,7 @@ TEST_F(BinaryHeaderGet, Default) {
   ASSERT_EQ(SPV_SUCCESS, spvBinaryHeaderGet(&const_bin, endian, &header));
 
   ASSERT_EQ(static_cast<uint32_t>(SpvMagicNumber), header.magic);
-  ASSERT_EQ(0x00010200u, header.version);
+  ASSERT_EQ(0x00010300u, header.version);
   ASSERT_EQ(static_cast<uint32_t>(SPV_GENERATOR_CODEPLAY), header.generator);
   ASSERT_EQ(1u, header.bound);
   ASSERT_EQ(0u, header.schema);

--- a/test/binary_to_text_test.cpp
+++ b/test/binary_to_text_test.cpp
@@ -240,7 +240,7 @@ INSTANTIATE_TEST_CASE_P(
     NumericLiterals, RoundTripInstructionsTest,
     // This test is independent of environment, so just test the one.
     Combine(::testing::Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1,
-                              SPV_ENV_UNIVERSAL_1_2),
+                              SPV_ENV_UNIVERSAL_1_2, SPV_ENV_UNIVERSAL_1_3),
             ::testing::ValuesIn(std::vector<std::string>{
                 "%1 = OpTypeInt 12 0\n%2 = OpConstant %1 1867\n",
                 "%1 = OpTypeInt 12 1\n%2 = OpConstant %1 1867\n",
@@ -274,7 +274,7 @@ INSTANTIATE_TEST_CASE_P(
 INSTANTIATE_TEST_CASE_P(
     MemoryAccessMasks, RoundTripInstructionsTest,
     Combine(::testing::Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1,
-                              SPV_ENV_UNIVERSAL_1_2),
+                              SPV_ENV_UNIVERSAL_1_2, SPV_ENV_UNIVERSAL_1_3),
             ::testing::ValuesIn(std::vector<std::string>{
                 "OpStore %1 %2\n",       // 3 words long.
                 "OpStore %1 %2 None\n",  // 4 words long, explicit final 0.
@@ -291,7 +291,7 @@ INSTANTIATE_TEST_CASE_P(
     FPFastMathModeMasks, RoundTripInstructionsTest,
     Combine(
         ::testing::Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1,
-                          SPV_ENV_UNIVERSAL_1_2),
+                          SPV_ENV_UNIVERSAL_1_2, SPV_ENV_UNIVERSAL_1_3),
         ::testing::ValuesIn(std::vector<std::string>{
             "OpDecorate %1 FPFastMathMode None\n",
             "OpDecorate %1 FPFastMathMode NotNaN\n",
@@ -305,54 +305,55 @@ INSTANTIATE_TEST_CASE_P(
             "OpDecorate %1 FPFastMathMode NotNaN|NotInf|NSZ|AllowRecip|Fast\n",
         })), );
 
-INSTANTIATE_TEST_CASE_P(LoopControlMasks, RoundTripInstructionsTest,
-                        Combine(::testing::Values(SPV_ENV_UNIVERSAL_1_0,
-                                                  SPV_ENV_UNIVERSAL_1_1,
-                                                  SPV_ENV_UNIVERSAL_1_2),
-                                ::testing::ValuesIn(std::vector<std::string>{
-                                    "OpLoopMerge %1 %2 None\n",
-                                    "OpLoopMerge %1 %2 Unroll\n",
-                                    "OpLoopMerge %1 %2 DontUnroll\n",
-                                    "OpLoopMerge %1 %2 Unroll|DontUnroll\n",
-                                })), );
+INSTANTIATE_TEST_CASE_P(
+    LoopControlMasks, RoundTripInstructionsTest,
+    Combine(::testing::Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1,
+                              SPV_ENV_UNIVERSAL_1_3, SPV_ENV_UNIVERSAL_1_2),
+            ::testing::ValuesIn(std::vector<std::string>{
+                "OpLoopMerge %1 %2 None\n",
+                "OpLoopMerge %1 %2 Unroll\n",
+                "OpLoopMerge %1 %2 DontUnroll\n",
+                "OpLoopMerge %1 %2 Unroll|DontUnroll\n",
+            })), );
 
 INSTANTIATE_TEST_CASE_P(LoopControlMasksV11, RoundTripInstructionsTest,
                         Combine(::testing::Values(SPV_ENV_UNIVERSAL_1_1,
-                                                  SPV_ENV_UNIVERSAL_1_2),
+                                                  SPV_ENV_UNIVERSAL_1_2,
+                                                  SPV_ENV_UNIVERSAL_1_3),
                                 ::testing::ValuesIn(std::vector<std::string>{
                                     "OpLoopMerge %1 %2 DependencyInfinite\n",
                                     "OpLoopMerge %1 %2 DependencyLength 8\n",
                                 })), );
 
-INSTANTIATE_TEST_CASE_P(SelectionControlMasks, RoundTripInstructionsTest,
-                        Combine(::testing::Values(SPV_ENV_UNIVERSAL_1_0,
-                                                  SPV_ENV_UNIVERSAL_1_1,
-                                                  SPV_ENV_UNIVERSAL_1_2),
-                                ::testing::ValuesIn(std::vector<std::string>{
-                                    "OpSelectionMerge %1 None\n",
-                                    "OpSelectionMerge %1 Flatten\n",
-                                    "OpSelectionMerge %1 DontFlatten\n",
-                                    "OpSelectionMerge %1 Flatten|DontFlatten\n",
-                                })), );
+INSTANTIATE_TEST_CASE_P(
+    SelectionControlMasks, RoundTripInstructionsTest,
+    Combine(::testing::Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1,
+                              SPV_ENV_UNIVERSAL_1_3, SPV_ENV_UNIVERSAL_1_2),
+            ::testing::ValuesIn(std::vector<std::string>{
+                "OpSelectionMerge %1 None\n",
+                "OpSelectionMerge %1 Flatten\n",
+                "OpSelectionMerge %1 DontFlatten\n",
+                "OpSelectionMerge %1 Flatten|DontFlatten\n",
+            })), );
 
-INSTANTIATE_TEST_CASE_P(FunctionControlMasks, RoundTripInstructionsTest,
-                        Combine(::testing::Values(SPV_ENV_UNIVERSAL_1_0,
-                                                  SPV_ENV_UNIVERSAL_1_1,
-                                                  SPV_ENV_UNIVERSAL_1_2),
-                                ::testing::ValuesIn(std::vector<std::string>{
-                                    "%2 = OpFunction %1 None %3\n",
-                                    "%2 = OpFunction %1 Inline %3\n",
-                                    "%2 = OpFunction %1 DontInline %3\n",
-                                    "%2 = OpFunction %1 Pure %3\n",
-                                    "%2 = OpFunction %1 Const %3\n",
-                                    "%2 = OpFunction %1 Inline|Pure|Const %3\n",
-                                    "%2 = OpFunction %1 DontInline|Const %3\n",
-                                })), );
+INSTANTIATE_TEST_CASE_P(
+    FunctionControlMasks, RoundTripInstructionsTest,
+    Combine(::testing::Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1,
+                              SPV_ENV_UNIVERSAL_1_2, SPV_ENV_UNIVERSAL_1_3),
+            ::testing::ValuesIn(std::vector<std::string>{
+                "%2 = OpFunction %1 None %3\n",
+                "%2 = OpFunction %1 Inline %3\n",
+                "%2 = OpFunction %1 DontInline %3\n",
+                "%2 = OpFunction %1 Pure %3\n",
+                "%2 = OpFunction %1 Const %3\n",
+                "%2 = OpFunction %1 Inline|Pure|Const %3\n",
+                "%2 = OpFunction %1 DontInline|Const %3\n",
+            })), );
 
 INSTANTIATE_TEST_CASE_P(
     ImageMasks, RoundTripInstructionsTest,
     Combine(::testing::Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1,
-                              SPV_ENV_UNIVERSAL_1_2),
+                              SPV_ENV_UNIVERSAL_1_2, SPV_ENV_UNIVERSAL_1_3),
             ::testing::ValuesIn(std::vector<std::string>{
                 "%2 = OpImageFetch %1 %3 %4\n",
                 "%2 = OpImageFetch %1 %3 %4 None\n",
@@ -374,7 +375,7 @@ INSTANTIATE_TEST_CASE_P(
 
 INSTANTIATE_TEST_CASE_P(
     NewInstructionsInSPIRV1_2, RoundTripInstructionsTest,
-    Combine(::testing::Values(SPV_ENV_UNIVERSAL_1_2),
+    Combine(::testing::Values(SPV_ENV_UNIVERSAL_1_2, SPV_ENV_UNIVERSAL_1_3),
             ::testing::ValuesIn(std::vector<std::string>{
                 "OpExecutionModeId %1 SubgroupsPerWorkgroupId %2\n",
                 "OpExecutionModeId %1 LocalSizeId %2 %3 %4\n",
@@ -546,5 +547,7 @@ INSTANTIATE_TEST_CASE_P(GeneratorStrings, GeneratorStringTest,
                             {1000, 18, "Unknown(1000); 18"},
                             {65535, 32767, "Unknown(65535); 32767"},
                         }), );
+
+// TODO(dneto): Test new instructions and enums in SPIR-V 1.3
 
 }  // anonymous namespace

--- a/test/opt/fold_test.cpp
+++ b/test/opt/fold_test.cpp
@@ -153,6 +153,7 @@ OpName %main "main"
 %_ptr_half = OpTypePointer Function %half
 %_ptr_long = OpTypePointer Function %long
 %_ptr_v2int = OpTypePointer Function %v2int
+%_ptr_v4int = OpTypePointer Function %v4int
 %_ptr_v4float = OpTypePointer Function %v4float
 %_ptr_v4double = OpTypePointer Function %v4double
 %_ptr_struct_v2int_int_int = OpTypePointer Function %struct_v2int_int_int
@@ -4414,6 +4415,56 @@ INSTANTIATE_TEST_CASE_P(SelectFoldingTest, MatchingInstructionFoldingTest,
           "OpReturn\n" +
           "OpFunctionEnd",
       4, true)
+));
+
+INSTANTIATE_TEST_CASE_P(CompositeExtractMatchingTest, MatchingInstructionFoldingTest,
+::testing::Values(
+    // Test case 0: Extracting from result of consecutive shuffles of differing
+    // size.
+    InstructionFoldingCase<bool>(
+        Header() +
+            "; CHECK: [[int:%\\w+]] = OpTypeInt 32 1\n" +
+            "; CHECK: %5 = OpCompositeExtract [[int]] %2 2\n" +
+            "%main = OpFunction %void None %void_func\n" +
+            "%main_lab = OpLabel\n" +
+            "%n = OpVariable %_ptr_v4int Function\n" +
+            "%2 = OpLoad %v4int %n\n" +
+            "%3 = OpVectorShuffle %v2int %2 %2 2 3\n" +
+            "%4 = OpVectorShuffle %v4int %2 %3 0 4 2 5\n" +
+            "%5 = OpCompositeExtract %int %4 1\n" +
+            "OpReturn\n" +
+            "OpFunctionEnd",
+        5, true),
+    // Test case 1: Extracting from result of vector shuffle of differing
+    // input and result sizes.
+    InstructionFoldingCase<bool>(
+        Header() +
+            "; CHECK: [[int:%\\w+]] = OpTypeInt 32 1\n" +
+            "; CHECK: %4 = OpCompositeExtract [[int]] %2 2\n" +
+            "%main = OpFunction %void None %void_func\n" +
+            "%main_lab = OpLabel\n" +
+            "%n = OpVariable %_ptr_v4int Function\n" +
+            "%2 = OpLoad %v4int %n\n" +
+            "%3 = OpVectorShuffle %v2int %2 %2 2 3\n" +
+            "%4 = OpCompositeExtract %int %3 0\n" +
+            "OpReturn\n" +
+            "OpFunctionEnd",
+        4, true),
+    // Test case 2: Extracting from result of vector shuffle of differing
+    // input and result sizes.
+    InstructionFoldingCase<bool>(
+        Header() +
+            "; CHECK: [[int:%\\w+]] = OpTypeInt 32 1\n" +
+            "; CHECK: %4 = OpCompositeExtract [[int]] %2 3\n" +
+            "%main = OpFunction %void None %void_func\n" +
+            "%main_lab = OpLabel\n" +
+            "%n = OpVariable %_ptr_v4int Function\n" +
+            "%2 = OpLoad %v4int %n\n" +
+            "%3 = OpVectorShuffle %v2int %2 %2 2 3\n" +
+            "%4 = OpCompositeExtract %int %3 1\n" +
+            "OpReturn\n" +
+            "OpFunctionEnd",
+        4, true)
 ));
 #endif
 }  // anonymous namespace

--- a/test/target_env_test.cpp
+++ b/test/target_env_test.cpp
@@ -41,7 +41,7 @@ TEST_P(TargetEnvTest, ValidDescription) {
 
 TEST_P(TargetEnvTest, ValidSpirvVersion) {
   auto spirv_version = spvVersionForTargetEnv(GetParam());
-  ASSERT_THAT(spirv_version, AnyOf(0x10000, 0x10100, 0x10200));
+  ASSERT_THAT(spirv_version, AnyOf(0x10000, 0x10100, 0x10200, 0x10300));
 }
 
 INSTANTIATE_TEST_CASE_P(AllTargetEnvs, TargetEnvTest,
@@ -49,7 +49,7 @@ INSTANTIATE_TEST_CASE_P(AllTargetEnvs, TargetEnvTest,
 
 TEST(GetContextTest, InvalidTargetEnvProducesNull) {
   // Use a value beyond the last valid enum value.
-  spv_context context = spvContextCreate(static_cast<spv_target_env>(17));
+  spv_context context = spvContextCreate(static_cast<spv_target_env>(30));
   EXPECT_EQ(context, nullptr);
 }
 
@@ -75,7 +75,9 @@ INSTANTIATE_TEST_CASE_P(
         {"spv1.0", true, SPV_ENV_UNIVERSAL_1_0},
         {"spv1.1", true, SPV_ENV_UNIVERSAL_1_1},
         {"spv1.2", true, SPV_ENV_UNIVERSAL_1_2},
+        {"spv1.3", true, SPV_ENV_UNIVERSAL_1_3},
         {"vulkan1.0", true, SPV_ENV_VULKAN_1_0},
+        {"vulkan1.1", true, SPV_ENV_VULKAN_1_1},
         {"opencl2.1", true, SPV_ENV_OPENCL_2_1},
         {"opencl2.2", true, SPV_ENV_OPENCL_2_2},
         {"opengl4.0", true, SPV_ENV_OPENGL_4_0},
@@ -89,6 +91,10 @@ INSTANTIATE_TEST_CASE_P(
         {"opencl2.0embedded", true, SPV_ENV_OPENCL_EMBEDDED_2_0},
         {"opencl2.1embedded", true, SPV_ENV_OPENCL_EMBEDDED_2_1},
         {"opencl2.2embedded", true, SPV_ENV_OPENCL_EMBEDDED_2_2},
+        {"opencl2.3", false, SPV_ENV_UNIVERSAL_1_0},
+        {"opencl3.0", false, SPV_ENV_UNIVERSAL_1_0},
+        {"vulkan1.2", false, SPV_ENV_UNIVERSAL_1_0},
+        {"vulkan2.0", false, SPV_ENV_UNIVERSAL_1_0},
         {nullptr, false, SPV_ENV_UNIVERSAL_1_0},
         {"", false, SPV_ENV_UNIVERSAL_1_0},
         {"abc", false, SPV_ENV_UNIVERSAL_1_0},

--- a/test/text_to_binary.extension_test.cpp
+++ b/test/text_to_binary.extension_test.cpp
@@ -33,6 +33,12 @@ using spvtest::MakeInstruction;
 using spvtest::MakeVector;
 using spvtest::TextToBinaryTest;
 
+// Returns a generator of common Vulkan environment values to be tested.
+std::vector<spv_target_env> CommonVulkanEnvs() {
+  return {SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1, SPV_ENV_UNIVERSAL_1_2,
+          SPV_ENV_UNIVERSAL_1_3, SPV_ENV_VULKAN_1_0,    SPV_ENV_VULKAN_1_1};
+}
+
 TEST_F(TextToBinaryTest, InvalidExtInstImportName) {
   EXPECT_THAT(CompileFailure("%1 = OpExtInstImport \"Haskell.std\""),
               Eq("Invalid extended instruction import 'Haskell.std'"));
@@ -155,6 +161,61 @@ INSTANTIATE_TEST_CASE_P(
                                                  SpvBuiltInSubgroupLtMaskKHR})},
             })), );
 
+INSTANTIATE_TEST_CASE_P(
+    SPV_KHR_shader_ballot_vulkan_1_1, ExtensionRoundTripTest,
+    // In SPIR-V 1.3 and Vulkan 1.1 we can drop the KHR suffix on the
+    // builtin enums.
+    Combine(Values(SPV_ENV_UNIVERSAL_1_3, SPV_ENV_VULKAN_1_1),
+            ValuesIn(std::vector<AssemblyCase>{
+                {"OpCapability SubgroupBallotKHR\n",
+                 MakeInstruction(SpvOpCapability,
+                                 {SpvCapabilitySubgroupBallotKHR})},
+                {"%2 = OpSubgroupBallotKHR %1 %3\n",
+                 MakeInstruction(SpvOpSubgroupBallotKHR, {1, 2, 3})},
+                {"%2 = OpSubgroupFirstInvocationKHR %1 %3\n",
+                 MakeInstruction(SpvOpSubgroupFirstInvocationKHR, {1, 2, 3})},
+                {"OpDecorate %1 BuiltIn SubgroupEqMask\n",
+                 MakeInstruction(SpvOpDecorate, {1, SpvDecorationBuiltIn,
+                                                 SpvBuiltInSubgroupEqMask})},
+                {"OpDecorate %1 BuiltIn SubgroupGeMask\n",
+                 MakeInstruction(SpvOpDecorate, {1, SpvDecorationBuiltIn,
+                                                 SpvBuiltInSubgroupGeMask})},
+                {"OpDecorate %1 BuiltIn SubgroupGtMask\n",
+                 MakeInstruction(SpvOpDecorate, {1, SpvDecorationBuiltIn,
+                                                 SpvBuiltInSubgroupGtMask})},
+                {"OpDecorate %1 BuiltIn SubgroupLeMask\n",
+                 MakeInstruction(SpvOpDecorate, {1, SpvDecorationBuiltIn,
+                                                 SpvBuiltInSubgroupLeMask})},
+                {"OpDecorate %1 BuiltIn SubgroupLtMask\n",
+                 MakeInstruction(SpvOpDecorate, {1, SpvDecorationBuiltIn,
+                                                 SpvBuiltInSubgroupLtMask})},
+            })), );
+
+// The old builtin names (with KHR suffix) still work in the assmebler, and
+// map to the enums without the KHR.
+INSTANTIATE_TEST_CASE_P(
+    SPV_KHR_shader_ballot_vulkan_1_1_alias_check, ExtensionAssemblyTest,
+    // In SPIR-V 1.3 and Vulkan 1.1 we can drop the KHR suffix on the
+    // builtin enums.
+    Combine(Values(SPV_ENV_UNIVERSAL_1_3, SPV_ENV_VULKAN_1_1),
+            ValuesIn(std::vector<AssemblyCase>{
+                {"OpDecorate %1 BuiltIn SubgroupEqMaskKHR\n",
+                 MakeInstruction(SpvOpDecorate, {1, SpvDecorationBuiltIn,
+                                                 SpvBuiltInSubgroupEqMask})},
+                {"OpDecorate %1 BuiltIn SubgroupGeMaskKHR\n",
+                 MakeInstruction(SpvOpDecorate, {1, SpvDecorationBuiltIn,
+                                                 SpvBuiltInSubgroupGeMask})},
+                {"OpDecorate %1 BuiltIn SubgroupGtMaskKHR\n",
+                 MakeInstruction(SpvOpDecorate, {1, SpvDecorationBuiltIn,
+                                                 SpvBuiltInSubgroupGtMask})},
+                {"OpDecorate %1 BuiltIn SubgroupLeMaskKHR\n",
+                 MakeInstruction(SpvOpDecorate, {1, SpvDecorationBuiltIn,
+                                                 SpvBuiltInSubgroupLeMask})},
+                {"OpDecorate %1 BuiltIn SubgroupLtMaskKHR\n",
+                 MakeInstruction(SpvOpDecorate, {1, SpvDecorationBuiltIn,
+                                                 SpvBuiltInSubgroupLtMask})},
+            })), );
+
 // SPV_KHR_shader_draw_parameters
 
 INSTANTIATE_TEST_CASE_P(
@@ -162,8 +223,7 @@ INSTANTIATE_TEST_CASE_P(
     // We'll get coverage over operand tables by trying the universal
     // environments, and at least one specific environment.
     Combine(
-        Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1,
-               SPV_ENV_VULKAN_1_0),
+        ValuesIn(CommonVulkanEnvs()),
         ValuesIn(std::vector<AssemblyCase>{
             {"OpCapability DrawParameters\n",
              MakeInstruction(SpvOpCapability, {SpvCapabilityDrawParameters})},
@@ -184,8 +244,7 @@ INSTANTIATE_TEST_CASE_P(
     SPV_KHR_subgroup_vote, ExtensionRoundTripTest,
     // We'll get coverage over operand tables by trying the universal
     // environments, and at least one specific environment.
-    Combine(Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1,
-                   SPV_ENV_VULKAN_1_0),
+    Combine(ValuesIn(CommonVulkanEnvs()),
             ValuesIn(std::vector<AssemblyCase>{
                 {"OpCapability SubgroupVoteKHR\n",
                  MakeInstruction(SpvOpCapability,
@@ -204,8 +263,7 @@ INSTANTIATE_TEST_CASE_P(
     SPV_KHR_16bit_storage, ExtensionRoundTripTest,
     // We'll get coverage over operand tables by trying the universal
     // environments, and at least one specific environment.
-    Combine(Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1,
-                   SPV_ENV_VULKAN_1_0),
+    Combine(ValuesIn(CommonVulkanEnvs()),
             ValuesIn(std::vector<AssemblyCase>{
                 {"OpCapability StorageBuffer16BitAccess\n",
                  MakeInstruction(SpvOpCapability,
@@ -230,8 +288,7 @@ INSTANTIATE_TEST_CASE_P(
 
 INSTANTIATE_TEST_CASE_P(
     SPV_KHR_16bit_storage_alias_check, ExtensionAssemblyTest,
-    Combine(Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1,
-                   SPV_ENV_VULKAN_1_0),
+    Combine(ValuesIn(CommonVulkanEnvs()),
             ValuesIn(std::vector<AssemblyCase>{
                 // The old name maps to the new enum.
                 {"OpCapability StorageUniformBufferBlock16\n",
@@ -250,8 +307,7 @@ INSTANTIATE_TEST_CASE_P(
     SPV_KHR_device_group, ExtensionRoundTripTest,
     // We'll get coverage over operand tables by trying the universal
     // environments, and at least one specific environment.
-    Combine(Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1,
-                   SPV_ENV_VULKAN_1_0),
+    Combine(ValuesIn(CommonVulkanEnvs()),
             ValuesIn(std::vector<AssemblyCase>{
                 {"OpCapability DeviceGroup\n",
                  MakeInstruction(SpvOpCapability, {SpvCapabilityDeviceGroup})},

--- a/test/unit_spirv.h
+++ b/test/unit_spirv.h
@@ -208,15 +208,18 @@ inline std::string MakeLongUTF8String(size_t num_4_byte_chars) {
 
 // Returns a vector of all valid target environment enums.
 inline std::vector<spv_target_env> AllTargetEnvironments() {
-  return {SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1,
-          SPV_ENV_OPENCL_1_2,    SPV_ENV_OPENCL_EMBEDDED_1_2,
-          SPV_ENV_OPENCL_2_0,    SPV_ENV_OPENCL_EMBEDDED_2_0,
-          SPV_ENV_OPENCL_2_1,    SPV_ENV_OPENCL_EMBEDDED_2_1,
-          SPV_ENV_OPENCL_2_2,    SPV_ENV_OPENCL_EMBEDDED_2_2,
-          SPV_ENV_VULKAN_1_0,    SPV_ENV_OPENGL_4_0,
-          SPV_ENV_OPENGL_4_1,    SPV_ENV_OPENGL_4_2,
-          SPV_ENV_OPENGL_4_3,    SPV_ENV_OPENGL_4_5,
-          SPV_ENV_UNIVERSAL_1_2};
+  return {
+      SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1,
+      SPV_ENV_OPENCL_1_2,    SPV_ENV_OPENCL_EMBEDDED_1_2,
+      SPV_ENV_OPENCL_2_0,    SPV_ENV_OPENCL_EMBEDDED_2_0,
+      SPV_ENV_OPENCL_2_1,    SPV_ENV_OPENCL_EMBEDDED_2_1,
+      SPV_ENV_OPENCL_2_2,    SPV_ENV_OPENCL_EMBEDDED_2_2,
+      SPV_ENV_VULKAN_1_0,    SPV_ENV_OPENGL_4_0,
+      SPV_ENV_OPENGL_4_1,    SPV_ENV_OPENGL_4_2,
+      SPV_ENV_OPENGL_4_3,    SPV_ENV_OPENGL_4_5,
+      SPV_ENV_UNIVERSAL_1_2, SPV_ENV_UNIVERSAL_1_3,
+      SPV_ENV_VULKAN_1_1,
+  };
 }
 
 // Returns the capabilities in a CapabilitySet as an ordered vector.

--- a/tools/as/as.cpp
+++ b/tools/as/as.cpp
@@ -41,13 +41,14 @@ Options:
                   Numeric IDs in the binary will have the same values as in the
                   source. Non-numeric IDs are allocated by filling in the gaps,
                   starting with 1 and going up.
-  --target-env {vulkan1.0|spv1.0|spv1.1|spv1.2}
-                  Use Vulkan1.0/SPIR-V1.0/SPIR-V1.1/SPIR-V1.2
+  --target-env {vulkan1.0|vulkan1.1|spv1.0|spv1.1|spv1.2|spv1.3}
+                  Use Vulkan 1.0, Vulkan 1.1, SPIR-V 1.0, SPIR-V 1.1,
+                  SPIR-V 1.2, or SPIR-V 1.3
 )",
       argv0, argv0);
 }
 
-static const auto kDefaultEnvironment = SPV_ENV_UNIVERSAL_1_2;
+static const auto kDefaultEnvironment = SPV_ENV_UNIVERSAL_1_3;
 
 int main(int argc, char** argv) {
   const char* inFile = nullptr;

--- a/tools/dis/dis.cpp
+++ b/tools/dis/dis.cpp
@@ -60,7 +60,7 @@ Options:
       argv0, argv0);
 }
 
-static const auto kDefaultEnvironment = SPV_ENV_UNIVERSAL_1_2;
+static const auto kDefaultEnvironment = SPV_ENV_UNIVERSAL_1_3;
 
 int main(int argc, char** argv) {
   const char* inFile = nullptr;

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -237,6 +237,9 @@ Options (in lexicographical order):
   --print-all
                Print SPIR-V assembly to standard error output before each pass
                and after the last pass.
+  --ftime-report
+               Print the resource utilization of each pass (e.g., CPU time,
+               RSS).
   --private-to-local
                Change the scope of private variables that are used in a single
                function to that function.
@@ -526,6 +529,8 @@ OptStatus ParseFlags(int argc, const char** argv, Optimizer* optimizer,
         optimizer->RegisterPass(CreateCCPPass());
       } else if (0 == strcmp(cur_arg, "--print-all")) {
         optimizer->SetPrintAll(&std::cerr);
+      } else if (0 == strcmp(cur_arg, "--ftime-report")) {
+        optimizer->SetFTimeReport(&std::cerr);
       } else if ('\0' == cur_arg[1]) {
         // Setting a filename of "-" to indicate stdin.
         if (!*in_file) {

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -48,20 +48,22 @@ std::string GetListOfPassesAsString(const spvtools::Optimizer& optimizer) {
   return ss.str();
 }
 
+const auto kDefaultEnvironment = SPV_ENV_UNIVERSAL_1_3;
+
 std::string GetLegalizationPasses() {
-  spvtools::Optimizer optimizer(SPV_ENV_UNIVERSAL_1_2);
+  spvtools::Optimizer optimizer(kDefaultEnvironment);
   optimizer.RegisterLegalizationPasses();
   return GetListOfPassesAsString(optimizer);
 }
 
 std::string GetOptimizationPasses() {
-  spvtools::Optimizer optimizer(SPV_ENV_UNIVERSAL_1_2);
+  spvtools::Optimizer optimizer(kDefaultEnvironment);
   optimizer.RegisterPerformancePasses();
   return GetListOfPassesAsString(optimizer);
 }
 
 std::string GetSizePasses() {
-  spvtools::Optimizer optimizer(SPV_ENV_UNIVERSAL_1_2);
+  spvtools::Optimizer optimizer(kDefaultEnvironment);
   optimizer.RegisterSizePasses();
   return GetListOfPassesAsString(optimizer);
 }
@@ -566,7 +568,7 @@ int main(int argc, const char** argv) {
   const char* out_file = nullptr;
   bool skip_validator = false;
 
-  spv_target_env target_env = SPV_ENV_UNIVERSAL_1_2;
+  spv_target_env target_env = kDefaultEnvironment;
   spv_validator_options options = spvValidatorOptionsCreate();
 
   spvtools::Optimizer optimizer(target_env);

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -239,9 +239,10 @@ Options (in lexicographical order):
   --print-all
                Print SPIR-V assembly to standard error output before each pass
                and after the last pass.
-  --ftime-report
+  -ftime-report
                Print the resource utilization of each pass (e.g., CPU time,
-               RSS).
+               RSS). Currently it supports only Unix systems. This option is
+               same with -ftime-report in GCC.
   --private-to-local
                Change the scope of private variables that are used in a single
                function to that function.
@@ -531,7 +532,7 @@ OptStatus ParseFlags(int argc, const char** argv, Optimizer* optimizer,
         optimizer->RegisterPass(CreateCCPPass());
       } else if (0 == strcmp(cur_arg, "--print-all")) {
         optimizer->SetPrintAll(&std::cerr);
-      } else if (0 == strcmp(cur_arg, "--ftime-report")) {
+      } else if (0 == strcmp(cur_arg, "-ftime-report")) {
         optimizer->SetFTimeReport(&std::cerr);
       } else if ('\0' == cur_arg[1]) {
         // Setting a filename of "-" to indicate stdin.

--- a/tools/val/val.cpp
+++ b/tools/val/val.cpp
@@ -58,7 +58,7 @@ Options:
 
 int main(int argc, char** argv) {
   const char* inFile = nullptr;
-  spv_target_env target_env = SPV_ENV_UNIVERSAL_1_2;
+  spv_target_env target_env = SPV_ENV_UNIVERSAL_1_3;
   spvtools::ValidatorOptions options;
   bool continue_processing = true;
   int return_code = 0;
@@ -90,11 +90,14 @@ int main(int argc, char** argv) {
         }
       } else if (0 == strcmp(cur_arg, "--version")) {
         printf("%s\n", spvSoftwareVersionDetailsString());
-        // TODO(dneto): Add OpenCL 2.2 at least.
-        printf("Targets:\n  %s\n  %s\n  %s\n",
+        printf("Targets:\n  %s\n  %s\n  %s\n  %s\n  %s\n  %s\n  %s\n",
+               spvTargetEnvDescription(SPV_ENV_UNIVERSAL_1_0),
                spvTargetEnvDescription(SPV_ENV_UNIVERSAL_1_1),
+               spvTargetEnvDescription(SPV_ENV_UNIVERSAL_1_2),
+               spvTargetEnvDescription(SPV_ENV_UNIVERSAL_1_3),
+               spvTargetEnvDescription(SPV_ENV_OPENCL_2_2),
                spvTargetEnvDescription(SPV_ENV_VULKAN_1_0),
-               spvTargetEnvDescription(SPV_ENV_UNIVERSAL_1_2));
+               spvTargetEnvDescription(SPV_ENV_VULKAN_1_1));
         continue_processing = false;
         return_code = 0;
       } else if (0 == strcmp(cur_arg, "--help") || 0 == strcmp(cur_arg, "-h")) {

--- a/utils/generate_grammar_tables.py
+++ b/utils/generate_grammar_tables.py
@@ -53,6 +53,8 @@ SPV_EXT_shader_stencil_export
 SPV_EXT_shader_viewport_index_layer
 SPV_AMD_shader_image_load_store_lod
 SPV_AMD_shader_fragment_mask
+SPV_EXT_fragment_fully_covered
+SPV_AMD_gpu_shader_half_float_fetch
 SPV_GOOGLE_decorate_string
 SPV_GOOGLE_hlsl_functionality1
 """


### PR DESCRIPTION
Add --ftime-report to spirv-opt

To check the resource utilization of each optimization pass, I add --ftime-report command line option.

Related issue: #1378

