### PR TITLE
Add loop peeling utility

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -100,6 +100,7 @@ SPVTOOLS_OPT_SRC_FILES := \
 		source/opt/local_single_store_elim_pass.cpp \
 		source/opt/local_ssa_elim_pass.cpp \
 		source/opt/loop_descriptor.cpp \
+		source/opt/loop_peeling.cpp \
 		source/opt/loop_unroller.cpp \
 		source/opt/loop_unswitch_pass.cpp \
 		source/opt/loop_utils.cpp \

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(SPIRV-Tools-opt
   local_ssa_elim_pass.h
   log.h
   loop_descriptor.h
+  loop_peeling.h
   loop_unroller.h
   loop_utils.h
   loop_unswitch_pass.h
@@ -132,6 +133,7 @@ add_library(SPIRV-Tools-opt
   local_single_store_elim_pass.cpp
   local_ssa_elim_pass.cpp
   loop_descriptor.cpp
+  loop_peeling.cpp
   loop_utils.cpp
   loop_unroller.cpp
   loop_unswitch_pass.cpp

--- a/source/opt/function.h
+++ b/source/opt/function.h
@@ -15,6 +15,7 @@
 #ifndef LIBSPIRV_OPT_CONSTRUCTS_H_
 #define LIBSPIRV_OPT_CONSTRUCTS_H_
 
+#include <algorithm>
 #include <functional>
 #include <memory>
 #include <utility>
@@ -90,6 +91,13 @@ class Function {
   }
   const_iterator cend() const {
     return const_iterator(&blocks_, blocks_.cend());
+  }
+
+  // Returns an iterator to the basic block |id|.
+  iterator FindBlock(uint32_t bb_id) {
+    return std::find_if(begin(), end(), [bb_id](const ir::BasicBlock& it_bb) {
+      return bb_id == it_bb.id();
+    });
   }
 
   // Runs the given function |f| on each instruction in this function, and

--- a/source/opt/ir_builder.h
+++ b/source/opt/ir_builder.h
@@ -159,7 +159,7 @@ class InstructionBuilder {
     return AddInstruction(std::move(phi_inst));
   }
 
-  // Creates an addtion instruction.
+  // Creates an addition instruction.
   // The id |type| must be the id of the instruction's type, must be the same as
   // |op1| and |op2| types.
   // The id |op1| is the left hand side of the operation.
@@ -172,11 +172,9 @@ class InstructionBuilder {
   }
 
   // Creates a less than instruction for unsigned integer.
-  // The id |type| must be the id of an unsigned int and must be the same as
-  // |op1| and |op2| types.
   // The id |op1| is the left hand side of the operation.
   // The id |op2| is the right hand side of the operation.
-  // It is assumed that |type| represents the type of both operand as well.
+  // It is assumed that |op1| and |op2| have the same underlying type.
   ir::Instruction* AddULessThan(uint32_t op1, uint32_t op2) {
     analysis::Bool bool_type;
     uint32_t type = GetContext()->get_type_mgr()->GetId(&bool_type);
@@ -189,7 +187,7 @@ class InstructionBuilder {
   // Creates a less than instruction for signed integer.
   // The id |op1| is the left hand side of the operation.
   // The id |op2| is the right hand side of the operation.
-  // It is assumed that |type| represents the type of both operand as well.
+  // It is assumed that |op1| and |op2| have the same underlying type.
   ir::Instruction* AddSLessThan(uint32_t op1, uint32_t op2) {
     analysis::Bool bool_type;
     uint32_t type = GetContext()->get_type_mgr()->GetId(&bool_type);
@@ -199,11 +197,10 @@ class InstructionBuilder {
     return AddInstruction(std::move(inst));
   }
 
-  // Creates an OpILessThan or OpULessThen instruction depending on the signed
-  // of |type|. The |type| is the type of the instruction. The id |op1| is the
-  // left hand side of the operation. The id |op2| is the right hand side of the
-  // operation. It is assumed that |type| represents the type of both operand as
-  // well.
+  // Creates an OpILessThan or OpULessThen instruction depending on the sign of
+  // |op1|. The id |op1| is the left hand side of the operation. The id |op2| is
+  // the right hand side of the operation. It is assumed that |op1| and |op2|
+  // have the same underlying type.
   ir::Instruction* AddLessThan(uint32_t op1, uint32_t op2) {
     ir::Instruction* op1_insn = context_->get_def_use_mgr()->GetDef(op1);
     analysis::Type* type =

--- a/source/opt/loop_descriptor.cpp
+++ b/source/opt/loop_descriptor.cpp
@@ -289,13 +289,16 @@ void Loop::SetMergeBlock(BasicBlock* merge) {
 }
 
 void Loop::SetPreHeaderBlock(BasicBlock* preheader) {
-  assert(!IsInsideLoop(preheader) && "The preheader block is in the loop");
-  assert(preheader->tail()->opcode() == SpvOpBranch &&
-         "The preheader block does not unconditionally branch to the header "
-         "block");
-  assert(preheader->tail()->GetSingleWordOperand(0) == GetHeaderBlock()->id() &&
-         "The preheader block does not unconditionally branch to the header "
-         "block");
+  if (preheader) {
+    assert(!IsInsideLoop(preheader) && "The preheader block is in the loop");
+    assert(preheader->tail()->opcode() == SpvOpBranch &&
+           "The preheader block does not unconditionally branch to the header "
+           "block");
+    assert(preheader->tail()->GetSingleWordOperand(0) ==
+               GetHeaderBlock()->id() &&
+           "The preheader block does not unconditionally branch to the header "
+           "block");
+  }
   loop_preheader_ = preheader;
 }
 

--- a/source/opt/loop_peeling.cpp
+++ b/source/opt/loop_peeling.cpp
@@ -1,0 +1,303 @@
+// Copyright (c) 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "ir_builder.h"
+#include "ir_context.h"
+#include "loop_descriptor.h"
+#include "loop_peeling.h"
+#include "loop_utils.h"
+
+namespace spvtools {
+namespace opt {
+
+void LoopPeeling::DuplicateLoop() {
+  ir::CFG& cfg = *context_->cfg();
+
+  assert(CanPeelLoop() && "Cannot peel loop!");
+
+  LoopUtils::LoopCloningResult clone_results;
+
+  std::vector<ir::BasicBlock*> ordered_loop_blocks;
+  ir::BasicBlock* pre_header = loop_->GetOrCreatePreHeaderBlock();
+
+  loop_->ComputeLoopStructuredOrder(&ordered_loop_blocks);
+
+  new_loop_ = loop_utils_.CloneLoop(&clone_results, ordered_loop_blocks);
+
+  // Add the basic block to the function.
+  ir::Function::iterator it =
+      loop_utils_.GetFunction()->FindBlock(pre_header->id());
+  assert(it != loop_utils_.GetFunction()->end());
+  loop_utils_.GetFunction()->AddBasicBlocks(
+      clone_results.cloned_bb_.begin(), clone_results.cloned_bb_.end(), ++it);
+  // Make the |loop_|'s preheader the |new_loop| one.
+  ir::BasicBlock* clonedHeader = new_loop_->GetHeaderBlock();
+  pre_header->ForEachSuccessorLabel(
+      [clonedHeader](uint32_t* succ) { *succ = clonedHeader->id(); });
+  // Update cfg.
+  cfg.RemoveEdge(pre_header->id(), loop_->GetHeaderBlock()->id());
+  new_loop_->SetPreHeaderBlock(pre_header);
+  loop_->SetPreHeaderBlock(nullptr);
+
+  // When cloning the loop, we didn't cloned the merge block, so currently
+  // |new_loop| shares the same block as |loop_|.
+  // We mutate all branches form |new_loop| block to |loop_|'s merge into a
+  // branch to |loop_|'s header (so header will also be the merge of
+  // |new_loop|).
+  uint32_t after_loop_pred = 0;
+  for (uint32_t pred_id : cfg.preds(loop_->GetMergeBlock()->id())) {
+    if (loop_->IsInsideLoop(pred_id)) continue;
+    ir::BasicBlock* bb = cfg.block(pred_id);
+    assert(after_loop_pred == 0 && "Predecessor already registered");
+    after_loop_pred = bb->id();
+    bb->ForEachSuccessorLabel([this](uint32_t* succ) {
+      if (*succ == loop_->GetMergeBlock()->id())
+        *succ = loop_->GetHeaderBlock()->id();
+    });
+  }
+
+  // Update cfg.
+  cfg.RemoveNonExistingEdges(loop_->GetMergeBlock()->id());
+  cfg.AddEdge(after_loop_pred, loop_->GetHeaderBlock()->id());
+
+  // Set the merge block of the new loop as the old header block.
+  new_loop_->SetMergeBlock(loop_->GetHeaderBlock());
+
+  // Force the creation of a new preheader and patch the phi of the header.
+  loop_->GetHeaderBlock()->ForEachPhiInst(
+      [after_loop_pred, this](ir::Instruction* phi) {
+        for (uint32_t i = 1; i < phi->NumInOperands(); i += 2) {
+          if (!loop_->IsInsideLoop(phi->GetSingleWordInOperand(i))) {
+            phi->SetInOperand(i, {after_loop_pred});
+            return;
+          }
+        }
+      });
+
+  ConnectIterators(clone_results);
+}
+
+void LoopPeeling::InsertIterator(ir::Instruction* factor) {
+  analysis::Type* factor_type =
+      context_->get_type_mgr()->GetType(factor->type_id());
+  assert(factor_type->kind() == analysis::Type::kInteger);
+  analysis::Integer* int_type = factor_type->AsInteger();
+  assert(int_type->width() == 32);
+
+  InstructionBuilder builder(context_,
+                             &*GetBeforeLoop()->GetLatchBlock()->tail(),
+                             ir::IRContext::kAnalysisDefUse |
+                                 ir::IRContext::kAnalysisInstrToBlockMapping);
+  // Create the increment.
+  // Note that "factor->result_id()" is wrong, the proper id should the phi
+  // value but we don't have it yet. The operand will be set latter, leave
+  // "factor->result_id()" so that the id is a valid and so avoid any assert
+  // that's could be added.
+  ir::Instruction* iv_inc = builder.AddIAdd(
+      factor->type_id(), factor->result_id(),
+      builder.Add32BitConstantInteger<uint32_t>(1, int_type->IsSigned())
+          ->result_id());
+
+  builder.SetInsertPoint(&*GetBeforeLoop()->GetHeaderBlock()->begin());
+
+  extra_induction_variable_ = builder.AddPhi(
+      factor->type_id(),
+      {builder.Add32BitConstantInteger<uint32_t>(0, int_type->IsSigned())
+           ->result_id(),
+       GetBeforeLoop()->GetPreHeaderBlock()->id(), iv_inc->result_id(),
+       GetBeforeLoop()->GetLatchBlock()->id()});
+  // Connect everything.
+  iv_inc->SetInOperand(0, {extra_induction_variable_->result_id()});
+
+  // If do-while form, use the incremented value.
+  if (do_while_form_) {
+    extra_induction_variable_ = iv_inc;
+  }
+}
+
+void LoopPeeling::ConnectIterators(
+    const LoopUtils::LoopCloningResult& clone_results) {
+  ir::BasicBlock* header = loop_->GetHeaderBlock();
+  header->ForEachPhiInst([&clone_results, this](ir::Instruction* phi) {
+    for (uint32_t i = 0; i < phi->NumInOperands(); i += 2) {
+      uint32_t pred_id = phi->GetSingleWordInOperand(i + 1);
+      if (!loop_->IsInsideLoop(pred_id)) {
+        phi->SetInOperand(i,
+                          {clone_results.value_map_.at(
+                              exit_value_.at(phi->result_id())->result_id())});
+      }
+    }
+  });
+}
+
+void LoopPeeling::GetIteratorUpdateOperations(
+    const ir::Loop* loop, ir::Instruction* iterator,
+    std::unordered_set<ir::Instruction*>* operations) {
+  opt::analysis::DefUseManager* def_use_mgr = context_->get_def_use_mgr();
+  operations->insert(iterator);
+  iterator->ForEachInId([def_use_mgr, loop, operations, this](uint32_t* id) {
+    ir::Instruction* insn = def_use_mgr->GetDef(*id);
+    if (insn->opcode() == SpvOpLabel) {
+      return;
+    }
+    if (operations->count(insn)) {
+      return;
+    }
+    if (!loop->IsInsideLoop(insn)) {
+      return;
+    }
+    GetIteratorUpdateOperations(loop, insn, operations);
+  });
+}
+
+void LoopPeeling::GetIteratingExitValue() {
+  ir::CFG& cfg = *context_->cfg();
+
+  loop_->GetHeaderBlock()->ForEachPhiInst([this](ir::Instruction* phi) {
+    exit_value_[phi->result_id()] = nullptr;
+  });
+
+  if (!loop_->GetMergeBlock()) {
+    return;
+  }
+  if (cfg.preds(loop_->GetMergeBlock()->id()).size() != 1) {
+    return;
+  }
+  opt::analysis::DefUseManager* def_use_mgr = context_->get_def_use_mgr();
+
+  uint32_t condition_block_id = cfg.preds(loop_->GetMergeBlock()->id())[0];
+
+  auto& header_pred = cfg.preds(loop_->GetHeaderBlock()->id());
+  do_while_form_ = std::find(header_pred.begin(), header_pred.end(),
+                             condition_block_id) != header_pred.end();
+  if (do_while_form_) {
+    loop_->GetHeaderBlock()->ForEachPhiInst(
+        [condition_block_id, def_use_mgr, this](ir::Instruction* phi) {
+          std::unordered_set<ir::Instruction*> operations;
+
+          for (uint32_t i = 0; i < phi->NumInOperands(); i += 2) {
+            if (condition_block_id == phi->GetSingleWordInOperand(i + 1)) {
+              exit_value_[phi->result_id()] =
+                  def_use_mgr->GetDef(phi->GetSingleWordInOperand(i));
+            }
+          }
+        });
+  } else {
+    DominatorTree* dom_tree =
+        &context_->GetDominatorAnalysis(loop_utils_.GetFunction(), cfg)
+             ->GetDomTree();
+    ir::BasicBlock* condition_block = cfg.block(condition_block_id);
+
+    loop_->GetHeaderBlock()->ForEachPhiInst(
+        [dom_tree, condition_block, this](ir::Instruction* phi) {
+          std::unordered_set<ir::Instruction*> operations;
+
+          // Not the back-edge value, check if the phi instruction is the only
+          // possible candidate.
+          GetIteratorUpdateOperations(loop_, phi, &operations);
+
+          for (ir::Instruction* insn : operations) {
+            if (insn == phi) {
+              continue;
+            }
+            if (dom_tree->Dominates(context_->get_instr_block(insn),
+                                    condition_block)) {
+              return;
+            }
+          }
+          exit_value_[phi->result_id()] = phi;
+        });
+  }
+}
+
+void LoopPeeling::FixExitCondition(
+    const std::function<uint32_t(ir::BasicBlock*)>& condition_builder) {
+  ir::CFG& cfg = *context_->cfg();
+
+  uint32_t condition_block_id = 0;
+  for (uint32_t id : cfg.preds(GetAfterLoop()->GetHeaderBlock()->id())) {
+    if (!GetAfterLoop()->IsInsideLoop(id)) {
+      condition_block_id = id;
+    }
+  }
+  assert(condition_block_id != 0 && "2nd loop in improperly connected");
+
+  ir::BasicBlock* condition_block = cfg.block(condition_block_id);
+  assert(condition_block->terminator()->opcode() == SpvOpBranchConditional);
+  InstructionBuilder builder(context_, &*condition_block->tail(),
+                             ir::IRContext::kAnalysisDefUse |
+                                 ir::IRContext::kAnalysisInstrToBlockMapping);
+
+  condition_block->terminator()->SetInOperand(
+      0, {condition_builder(condition_block)});
+
+  uint32_t to_continue_block =
+      condition_block->terminator()->GetSingleWordInOperand(
+          condition_block->terminator()->GetSingleWordInOperand(1) ==
+                  GetAfterLoop()->GetHeaderBlock()->id()
+              ? 2
+              : 1);
+  condition_block->terminator()->SetInOperand(1, {to_continue_block});
+  condition_block->terminator()->SetInOperand(
+      2, {GetAfterLoop()->GetHeaderBlock()->id()});
+}
+
+void LoopPeeling::PeelBefore(ir::Instruction* factor) {
+  DuplicateLoop();
+
+  InsertIterator(factor);
+
+  FixExitCondition([factor, this](ir::BasicBlock* condition_block) {
+    InstructionBuilder builder(context_, &*condition_block->tail(),
+                               ir::IRContext::kAnalysisDefUse |
+                                   ir::IRContext::kAnalysisInstrToBlockMapping);
+    return builder
+        .AddLessThan(extra_induction_variable_->result_id(),
+                     factor->result_id())
+        ->result_id();
+  });
+}
+
+void LoopPeeling::PeelAfter(ir::Instruction* factor,
+                            ir::Instruction* iteration_count) {
+  DuplicateLoop();
+
+  InsertIterator(factor);
+
+  FixExitCondition([factor, iteration_count,
+                    this](ir::BasicBlock* condition_block) {
+    InstructionBuilder builder(context_, &*condition_block->tail(),
+                               ir::IRContext::kAnalysisDefUse |
+                                   ir::IRContext::kAnalysisInstrToBlockMapping);
+    // Build the following check: extra_induction_variable_ + factor <
+    // iteration_count
+    return builder
+        .AddLessThan(builder
+                         .AddIAdd(extra_induction_variable_->type_id(),
+                                  extra_induction_variable_->result_id(),
+                                  factor->result_id())
+                         ->result_id(),
+                     iteration_count->result_id())
+        ->result_id();
+  });
+}
+
+}  // namespace opt
+}  // namespace spvtools

--- a/source/opt/loop_peeling.cpp
+++ b/source/opt/loop_peeling.cpp
@@ -369,7 +369,7 @@ ir::BasicBlock* LoopPeeling::CreateBlockBefore(ir::BasicBlock* bb) {
                      ir::IRContext::kAnalysisDefUse |
                          ir::IRContext::kAnalysisInstrToBlockMapping)
       .AddBranch(bb->id());
-  cfg.AddEdge(new_bb->id(), bb->id());
+  cfg.RegisterBlock(new_bb.get());
 
   // Add the basic block to the function.
   ir::Function::iterator it = loop_utils_.GetFunction()->FindBlock(bb->id());

--- a/source/opt/loop_peeling.h
+++ b/source/opt/loop_peeling.h
@@ -184,9 +184,10 @@ class LoopPeeling {
   // Fixes the exit condition of the before loop. The function calls
   // |condition_builder| to get the condition to use in the conditional branch
   // of the loop exit. The loop will be exited if the condition evaluate to
-  // true.
+  // true. |condition_builder| takes an ir::Instruction* that represent the
+  // insertion point.
   void FixExitCondition(
-      const std::function<uint32_t(ir::BasicBlock*)>& condition_builder);
+      const std::function<uint32_t(ir::Instruction*)>& condition_builder);
 
   // Gathers all operations involved in the update of |iterator| into
   // |operations|.

--- a/source/opt/loop_peeling.h
+++ b/source/opt/loop_peeling.h
@@ -127,6 +127,9 @@ class LoopPeeling {
     if (cfg.preds(loop_->GetMergeBlock()->id()).size() != 1) {
       return false;
     }
+    if (!IsConditionCheckSideEffectFree()) {
+      return false;
+    }
 
     return !std::any_of(exit_value_.cbegin(), exit_value_.cend(),
                         [](std::pair<uint32_t, ir::Instruction*> it) {
@@ -196,6 +199,10 @@ class LoopPeeling {
   // SSA value when it exit the loop. If no exit value can be accurately found,
   // it is map to nullptr (see comment on CanPeelLoop).
   void GetIteratingExitValues();
+
+  // Returns true if a for-loop has no instruction with effects before the
+  // condition check.
+  bool IsConditionCheckSideEffectFree() const;
 
   // Creates a new basic block and insert it between |bb| and the predecessor of
   // |bb|.

--- a/source/opt/loop_peeling.h
+++ b/source/opt/loop_peeling.h
@@ -1,0 +1,159 @@
+// Copyright (c) 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_OPT_LOOP_PEELING_H_
+#define SOURCE_OPT_LOOP_PEELING_H_
+
+#include <algorithm>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "opt/ir_context.h"
+#include "opt/loop_descriptor.h"
+#include "opt/loop_utils.h"
+
+namespace spvtools {
+namespace opt {
+
+// Utility class to perform the actual peeling of a given loop.
+class LoopPeeling {
+ public:
+  LoopPeeling(ir::IRContext* context, ir::Loop* loop)
+      : context_(context),
+        loop_utils_(context, loop),
+        loop_(loop),
+        extra_induction_variable_(nullptr) {
+    assert(loop_->IsLCSSA() && "Loop is not in LCSSA form");
+    GetIteratingExitValue();
+  }
+
+  // Returns true if the loop can be peeled.
+  // To be peelable, all operation involved in the update of the loop iterators
+  // must not dominates the exit condition. This restriction is a work around to
+  // not miss compile code like:
+  //
+  //   for (int i = 0; i + 1 < N; i++) {}
+  //   for (int i = 0; ++i < N; i++) {}
+  //
+  // The increment will happen before the test on the exit condition leading to
+  // very look-a-like code.
+  //
+  // This restriction will not apply if a loop rotate is applied before (i.e.
+  // becomes a do-while loop).
+  bool CanPeelLoop() {
+    ir::CFG& cfg = *context_->cfg();
+
+    if (!loop_->GetMergeBlock()) {
+      return false;
+    }
+    if (cfg.preds(loop_->GetMergeBlock()->id()).size() != 1) {
+      return false;
+    }
+
+    return !std::any_of(exit_value_.cbegin(), exit_value_.cend(),
+                        [](std::pair<uint32_t, ir::Instruction*> it) {
+                          return it.second == nullptr;
+                        });
+  }
+
+  // Moves the execution of the |factor| first iterations of the loop into a
+  // dedicated loop.
+  void PeelBefore(ir::Instruction* factor);
+
+  // Moves the execution of the |factor| last iterations of the loop into a
+  // dedicated loop.
+  void PeelAfter(ir::Instruction* factor, ir::Instruction* iteration_count);
+
+  // Returns the first loop (peeled loop for PeelBefore).
+  ir::Loop* GetBeforeLoop() { return new_loop_; }
+  // Returns the second loop (peeled loop for PeelAfter).
+  ir::Loop* GetAfterLoop() { return loop_; }
+  // Returns the induction variable build and use to peel the loop.
+  ir::Instruction* GetExtraInductionVariable() {
+    return extra_induction_variable_;
+  }
+
+ private:
+  ir::IRContext* context_;
+  LoopUtils loop_utils_;
+  // The original loop.
+  ir::Loop* loop_;
+  // Peeled loop.
+  ir::Loop* new_loop_;
+  // This is set to true when the exit and back-edge branch instruction is the
+  // same.
+  bool do_while_form_;
+
+  ir::Instruction* extra_induction_variable_;
+
+  // Map between loop iterators and exit values.
+  std::unordered_map<uint32_t, ir::Instruction*> exit_value_;
+
+  // Duplicate |loop_| and place the new loop before the cloned loop.
+  // |loop_| must be in LCSSA form and have a merge block with a using
+  // incoming
+  // branch (i.e. must not contain a break).
+  void DuplicateLoop();
+
+  // Insert an induction variable into the first loop as a simplified counter.
+  // Fixme(Victor): with a scalar evolution, this can removed.
+  void InsertIterator(ir::Instruction* factor);
+
+  // Fixes the exit condition of the before loop. The function calls
+  // |condition_builder| to get the condition to use in the conditional branch
+  // of the loop exit. The loop will be exited if the condition evaluate to
+  // true.
+  void FixExitCondition(
+      const std::function<uint32_t(ir::BasicBlock*)>& condition_builder);
+
+  // Connects iterating values so that loop like
+  // int z = 0;
+  // for (int i = 0; i++ < M; i += cst1) {
+  //   if (cond)
+  //     z += cst2;
+  // }
+  //
+  // Becomes:
+  //
+  // int z = 0;
+  // int i = 0;
+  // for (; i++ < M; i += cst1) {
+  //   if (cond)
+  //     z += cst2;
+  // }
+  // for (; i++ < M; i += cst1) {
+  //   if (cond)
+  //     z += cst2;
+  // }
+  void ConnectIterators(const LoopUtils::LoopCloningResult& clone_results);
+
+  // Gathers all operations involved in the update of |iterator| into
+  // |operations|.
+  void GetIteratorUpdateOperations(
+      const ir::Loop* loop, ir::Instruction* iterator,
+      std::unordered_set<ir::Instruction*>* operations);
+
+  // Gathers exiting iterator values. The function builds a map between each
+  // iterating value in the loop (a phi instruction in the loop header) and its
+  // SSA value when it exit the loop. If no exit value can be accurately found,
+  // it is map to nullptr (see comment on CanPeelLoop).
+  void GetIteratingExitValue();
+};
+
+}  // namespace opt
+}  // namespace spvtools
+
+#endif  // SOURCE_OPT_LOOP_PEELING_H_

--- a/source/opt/loop_unswitch_pass.cpp
+++ b/source/opt/loop_unswitch_pass.cpp
@@ -88,9 +88,7 @@ class LoopUnswitch {
 
   // Return the iterator to the basic block |bb|.
   ir::Function::iterator FindBasicBlockPosition(ir::BasicBlock* bb_to_find) {
-    ir::Function::iterator it = std::find_if(
-        function_->begin(), function_->end(),
-        [bb_to_find](const ir::BasicBlock& bb) { return bb_to_find == &bb; });
+    ir::Function::iterator it = function_->FindBlock(bb_to_find->id());
     assert(it != function_->end() && "Basic Block not found");
     return it;
   }

--- a/source/opt/loop_utils.cpp
+++ b/source/opt/loop_utils.cpp
@@ -582,13 +582,20 @@ void LoopUtils::PopulateLoopDesc(
     new_loop->SetLatchBlock(
         cloning_result.old_to_new_bb_.at(old_loop->GetLatchBlock()->id()));
   if (old_loop->GetMergeBlock()) {
-    ir::BasicBlock* bb =
-        cloning_result.old_to_new_bb_.at(old_loop->GetMergeBlock()->id());
+    auto it =
+        cloning_result.old_to_new_bb_.find(old_loop->GetMergeBlock()->id());
+    ir::BasicBlock* bb = it != cloning_result.old_to_new_bb_.end()
+                             ? it->second
+                             : old_loop->GetMergeBlock();
     new_loop->SetMergeBlock(bb);
   }
-  if (old_loop->GetPreHeaderBlock())
-    new_loop->SetPreHeaderBlock(
-        cloning_result.old_to_new_bb_.at(old_loop->GetPreHeaderBlock()->id()));
+  if (old_loop->GetPreHeaderBlock()) {
+    auto it =
+        cloning_result.old_to_new_bb_.find(old_loop->GetPreHeaderBlock()->id());
+    if (it != cloning_result.old_to_new_bb_.end()) {
+      new_loop->SetPreHeaderBlock(it->second);
+    }
+  }
 }
 
 }  // namespace opt

--- a/source/opt/loop_utils.h
+++ b/source/opt/loop_utils.h
@@ -87,11 +87,14 @@ class LoopUtils {
 
   // Clone |loop_| and remap its instructions. Newly created blocks
   // will be added to the |cloning_result.cloned_bb_| list, correctly ordered to
-  // be inserted into a function. If the loop is structured, the merge construct
-  // will also be cloned. The function preserves the def/use, cfg and instr to
-  // block analyses.
+  // be inserted into a function.
+  // It is assumed that |ordered_loop_blocks| is compatible with the result of
+  // |Loop::ComputeLoopStructuredOrder|. If the preheader and merge block are in
+  // the list they will also be cloned. If not, the resulting loop will share
+  // them with the original loop.
+  // The function preserves the def/use, cfg and instr to block analyses.
   // The cloned loop nest will be added to the loop descriptor and will have
-  // owner ship.
+  // ownership.
   ir::Loop* CloneLoop(
       LoopCloningResult* cloning_result,
       const std::vector<ir::BasicBlock*>& ordered_loop_blocks) const;
@@ -124,6 +127,15 @@ class LoopUtils {
   // Maintains the loop descriptor object after the unroll functions have been
   // called, otherwise the analysis should be invalidated.
   void Finalize();
+
+  // Returns the context associate to |loop_|.
+  ir::IRContext* GetContext() { return context_; }
+  // Returns the loop descriptor owning |loop_|.
+  ir::LoopDescriptor* GetLoopDescriptor() { return loop_desc_; }
+  // Returns the loop on which the object operates on.
+  ir::Loop* GetLoop() { return loop_; }
+  // Returns the function that |loop_| belong to.
+  ir::Function* GetFunction() { return &function_; }
 
  private:
   ir::IRContext* context_;

--- a/source/opt/loop_utils.h
+++ b/source/opt/loop_utils.h
@@ -133,9 +133,9 @@ class LoopUtils {
   // Returns the loop descriptor owning |loop_|.
   ir::LoopDescriptor* GetLoopDescriptor() { return loop_desc_; }
   // Returns the loop on which the object operates on.
-  ir::Loop* GetLoop() { return loop_; }
+  ir::Loop* GetLoop() const { return loop_; }
   // Returns the function that |loop_| belong to.
-  ir::Function* GetFunction() { return &function_; }
+  ir::Function* GetFunction() const { return &function_; }
 
  private:
   ir::IRContext* context_;

--- a/test/opt/loop_optimizations/CMakeLists.txt
+++ b/test/opt/loop_optimizations/CMakeLists.txt
@@ -84,3 +84,9 @@ add_spvtools_unittest(TARGET unswitch_test
         unswitch.cpp
     LIBS SPIRV-Tools-opt
 )
+
+add_spvtools_unittest(TARGET peeling_test
+    SRCS ../function_utils.h
+        peeling.cpp
+    LIBS SPIRV-Tools-opt
+)

--- a/test/opt/loop_optimizations/peeling.cpp
+++ b/test/opt/loop_optimizations/peeling.cpp
@@ -1,0 +1,476 @@
+// Copyright (c) 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#ifdef SPIRV_EFFCEE
+#include "effcee/effcee.h"
+#endif
+
+#include "../pass_fixture.h"
+#include "opt/ir_builder.h"
+#include "opt/loop_descriptor.h"
+#include "opt/loop_peeling.h"
+
+namespace {
+
+using namespace spvtools;
+
+using PeelingTest = PassTest<::testing::Test>;
+
+bool Validate(const std::vector<uint32_t>& bin) {
+  spv_target_env target_env = SPV_ENV_UNIVERSAL_1_2;
+  spv_context spvContext = spvContextCreate(target_env);
+  spv_diagnostic diagnostic = nullptr;
+  spv_const_binary_t binary = {bin.data(), bin.size()};
+  spv_result_t error = spvValidate(spvContext, &binary, &diagnostic);
+  if (error != 0) spvDiagnosticPrint(diagnostic);
+  spvDiagnosticDestroy(diagnostic);
+  spvContextDestroy(spvContext);
+  return error == 0;
+}
+
+void Match(const std::string& checks, ir::IRContext* context) {
+  std::vector<uint32_t> bin;
+  context->module()->ToBinary(&bin, true);
+  EXPECT_TRUE(Validate(bin));
+#ifdef SPIRV_EFFCEE
+  std::string assembly;
+  SpirvTools tools(SPV_ENV_UNIVERSAL_1_2);
+  EXPECT_TRUE(
+      tools.Disassemble(bin, &assembly, SPV_BINARY_TO_TEXT_OPTION_NO_HEADER))
+      << "Disassembling failed for shader:\n"
+      << assembly << std::endl;
+  auto match_result = effcee::Match(assembly, checks);
+  EXPECT_EQ(effcee::Result::Status::Ok, match_result.status())
+      << match_result.message() << "\nChecking result:\n"
+      << assembly;
+#endif  // ! SPIRV_EFFCEE
+}
+
+/*
+Generated from the following GLSL + --eliminate-local-multi-store
+
+first test:
+#version 330 core
+void main() {
+  for(int i = 0; i < 10; ++i) {
+    if (i < 4)
+      break;
+  }
+}
+
+second test (with a common sub-expression elimination):
+#version 330 core
+void main() {
+  for(int i = 0; i + 1 < 10; ++i) {
+  }
+}
+*/
+TEST_F(PeelingTest, CannotPeel) {
+  {
+    SCOPED_TRACE("loop with break");
+
+    const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginLowerLeft
+               OpSource GLSL 330
+               OpName %main "main"
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+      %int_0 = OpConstant %int 0
+     %int_10 = OpConstant %int 10
+       %bool = OpTypeBool
+      %int_4 = OpConstant %int 4
+      %int_1 = OpConstant %int 1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpBranch %10
+         %10 = OpLabel
+         %28 = OpPhi %int %int_0 %5 %27 %13
+               OpLoopMerge %12 %13 None
+               OpBranch %14
+         %14 = OpLabel
+         %18 = OpSLessThan %bool %28 %int_10
+               OpBranchConditional %18 %11 %12
+         %11 = OpLabel
+         %21 = OpSLessThan %bool %28 %int_4
+               OpSelectionMerge %23 None
+               OpBranchConditional %21 %22 %23
+         %22 = OpLabel
+               OpBranch %12
+         %23 = OpLabel
+               OpBranch %13
+         %13 = OpLabel
+         %27 = OpIAdd %int %28 %int_1
+               OpBranch %10
+         %12 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+    std::unique_ptr<ir::IRContext> context =
+        BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                    SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+    ir::Module* module = context->module();
+    EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
+                               << text << std::endl;
+    ir::Function& f = *module->begin();
+    ir::LoopDescriptor& ld = *context->GetLoopDescriptor(&f);
+
+    EXPECT_EQ(ld.NumLoops(), 1u);
+
+    opt::InstructionBuilder builder(context.get(), &*f.begin());
+
+    opt::LoopPeeling peel(context.get(), &*ld.begin());
+    EXPECT_FALSE(peel.CanPeelLoop());
+  }
+
+  {
+    SCOPED_TRACE("Ambiguous iterator update");
+
+    const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginLowerLeft
+               OpSource GLSL 330
+               OpName %main "main"
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
+     %int_10 = OpConstant %int 10
+       %bool = OpTypeBool
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpBranch %10
+         %10 = OpLabel
+         %23 = OpPhi %int %int_0 %5 %17 %13
+               OpLoopMerge %12 %13 None
+               OpBranch %14
+         %14 = OpLabel
+         %17 = OpIAdd %int %23 %int_1
+         %20 = OpSLessThan %bool %17 %int_10
+               OpBranchConditional %20 %11 %12
+         %11 = OpLabel
+               OpBranch %13
+         %13 = OpLabel
+               OpBranch %10
+         %12 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+    std::unique_ptr<ir::IRContext> context =
+        BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                    SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+    ir::Module* module = context->module();
+    EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
+                               << text << std::endl;
+    ir::Function& f = *module->begin();
+    ir::LoopDescriptor& ld = *context->GetLoopDescriptor(&f);
+
+    EXPECT_EQ(ld.NumLoops(), 1u);
+
+    opt::InstructionBuilder builder(context.get(), &*f.begin());
+
+    opt::LoopPeeling peel(context.get(), &*ld.begin());
+    EXPECT_FALSE(peel.CanPeelLoop());
+  }
+}
+
+/*
+Generated from the following GLSL + --eliminate-local-multi-store
+
+#version 330 core
+void main() {
+  int i = 0;
+  for (; i < 10; i++) {}
+}
+*/
+TEST_F(PeelingTest, SimplePeeling) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginLowerLeft
+               OpSource GLSL 330
+               OpName %main "main"
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+      %int_0 = OpConstant %int 0
+     %int_10 = OpConstant %int 10
+       %bool = OpTypeBool
+      %int_1 = OpConstant %int 1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpBranch %10
+         %10 = OpLabel
+         %22 = OpPhi %int %int_0 %5 %21 %13
+               OpLoopMerge %12 %13 None
+               OpBranch %14
+         %14 = OpLabel
+         %18 = OpSLessThan %bool %22 %int_10
+               OpBranchConditional %18 %11 %12
+         %11 = OpLabel
+               OpBranch %13
+         %13 = OpLabel
+         %21 = OpIAdd %int %22 %int_1
+               OpBranch %10
+         %12 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  // Peel before.
+  {
+    SCOPED_TRACE("Peel before");
+
+    std::unique_ptr<ir::IRContext> context =
+        BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                    SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+    ir::Module* module = context->module();
+    EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
+                               << text << std::endl;
+    ir::Function& f = *module->begin();
+    ir::LoopDescriptor& ld = *context->GetLoopDescriptor(&f);
+
+    EXPECT_EQ(ld.NumLoops(), 1u);
+
+    opt::InstructionBuilder builder(context.get(), &*f.begin());
+    ir::Instruction* two_cst = builder.Add32BitSignedIntegerConstant(2);
+
+    opt::LoopPeeling peel(context.get(), &*ld.begin());
+    EXPECT_TRUE(peel.CanPeelLoop());
+    peel.PeelBefore(two_cst);
+
+    const std::string check = R"(
+CHECK:      OpFunction
+CHECK-NEXT: [[ENTRY:%\w+]] = OpLabel
+CHECK:      [[BEFORE_LOOP:%\w+]] = OpLabel
+CHECK-NEXT: [[DUMMY_IT:%\w+]] = OpPhi {{%\w+}} {{%\w+}} [[ENTRY]] [[DUMMY_IT_1:%\w+]] [[BE:%\w+]]
+CHECK-NEXT: [[i:%\w+]] = OpPhi {{%\w+}} {{%\w+}} [[ENTRY]] [[I_1:%\w+]] [[BE]]
+CHECK-NEXT: OpLoopMerge [[AFTER_LOOP:%\w+]] [[BE]] None
+CHECK:      [[COND_BLOCK:%\w+]] = OpLabel
+CHECK-NEXT: OpSLessThan
+CHECK-NEXT: [[EXIT_COND:%\w+]] = OpSLessThan {{%\w+}} [[DUMMY_IT]]
+CHECK-NEXT: OpBranchConditional [[EXIT_COND]] {{%\w+}} [[AFTER_LOOP]]
+CHECK:      [[I_1]] = OpIAdd {{%\w+}} [[i]]
+CHECK-NEXT: [[DUMMY_IT_1]] = OpIAdd {{%\w+}} [[DUMMY_IT]]
+CHECK-NEXT: OpBranch [[BEFORE_LOOP]]
+
+CHECK:      [[AFTER_LOOP]] = OpLabel
+CHECK-NEXT: OpPhi {{%\w+}} [[i]] [[COND_BLOCK]]
+CHECK-NEXT: OpLoopMerge
+)";
+
+    Match(check, context.get());
+  }
+
+  // Peel after.
+  {
+    SCOPED_TRACE("Peel after");
+
+    std::unique_ptr<ir::IRContext> context =
+        BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                    SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+    ir::Module* module = context->module();
+    EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
+                               << text << std::endl;
+    ir::Function& f = *module->begin();
+    ir::LoopDescriptor& ld = *context->GetLoopDescriptor(&f);
+
+    EXPECT_EQ(ld.NumLoops(), 1u);
+
+    opt::InstructionBuilder builder(context.get(), &*f.begin());
+    ir::Instruction* two_cst = builder.Add32BitSignedIntegerConstant(2);
+    ir::Instruction* loop_count = builder.Add32BitSignedIntegerConstant(10);
+
+    opt::LoopPeeling peel(context.get(), &*ld.begin());
+    EXPECT_TRUE(peel.CanPeelLoop());
+    peel.PeelAfter(two_cst, loop_count);
+
+    const std::string check = R"(
+CHECK:      OpFunction
+CHECK-NEXT: [[ENTRY:%\w+]] = OpLabel
+CHECK:      [[BEFORE_LOOP:%\w+]] = OpLabel
+CHECK-NEXT: [[DUMMY_IT:%\w+]] = OpPhi {{%\w+}} {{%\w+}} [[ENTRY]] [[DUMMY_IT_1:%\w+]] [[BE:%\w+]]
+CHECK-NEXT: [[i:%\w+]] = OpPhi {{%\w+}} {{%\w+}} [[ENTRY]] [[I_1:%\w+]] [[BE]]
+CHECK-NEXT: OpLoopMerge [[AFTER_LOOP:%\w+]] [[BE]] None
+CHECK:      [[COND_BLOCK:%\w+]] = OpLabel
+CHECK-NEXT: OpSLessThan
+CHECK-NEXT: [[TMP:%\w+]] = OpIAdd {{%\w+}} [[DUMMY_IT]] {{%\w+}}
+CHECK-NEXT: [[EXIT_COND:%\w+]] = OpSLessThan {{%\w+}} [[TMP]]
+CHECK-NEXT: OpBranchConditional [[EXIT_COND]] {{%\w+}} [[AFTER_LOOP]]
+CHECK:      [[I_1]] = OpIAdd {{%\w+}} [[i]]
+CHECK-NEXT: [[DUMMY_IT_1]] = OpIAdd {{%\w+}} [[DUMMY_IT]]
+CHECK-NEXT: OpBranch [[BEFORE_LOOP]]
+
+CHECK:      [[AFTER_LOOP]] = OpLabel
+CHECK-NEXT: OpPhi {{%\w+}} [[i]] [[COND_BLOCK]]
+CHECK-NEXT: OpLoopMerge
+)";
+
+    Match(check, context.get());
+  }
+}
+
+/*
+Generated from the following GLSL + --eliminate-local-multi-store
+
+#version 330 core
+void main() {
+  int i = 0;
+  do {
+    i++;
+  } while (i < 10);
+}
+*/
+TEST_F(PeelingTest, DoWhilePeeling) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginLowerLeft
+               OpSource GLSL 330
+               OpName %main "main"
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
+     %int_10 = OpConstant %int 10
+       %bool = OpTypeBool
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpBranch %10
+         %10 = OpLabel
+         %21 = OpPhi %int %int_0 %5 %16 %13
+               OpLoopMerge %12 %13 None
+               OpBranch %11
+         %11 = OpLabel
+         %16 = OpIAdd %int %21 %int_1
+               OpBranch %13
+         %13 = OpLabel
+         %20 = OpSLessThan %bool %16 %int_10
+               OpBranchConditional %20 %10 %12
+         %12 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  // Peel before.
+  {
+    SCOPED_TRACE("Peel before");
+
+    std::unique_ptr<ir::IRContext> context =
+        BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                    SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+    ir::Module* module = context->module();
+    EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
+                               << text << std::endl;
+    ir::Function& f = *module->begin();
+    ir::LoopDescriptor& ld = *context->GetLoopDescriptor(&f);
+
+    EXPECT_EQ(ld.NumLoops(), 1u);
+
+    opt::InstructionBuilder builder(context.get(), &*f.begin());
+    ir::Instruction* two_cst = builder.Add32BitSignedIntegerConstant(2);
+
+    opt::LoopPeeling peel(context.get(), &*ld.begin());
+    EXPECT_TRUE(peel.CanPeelLoop());
+    peel.PeelBefore(two_cst);
+
+    const std::string check = R"(
+CHECK:      OpFunction
+CHECK-NEXT: [[ENTRY:%\w+]] = OpLabel
+CHECK:      [[BEFORE_LOOP:%\w+]] = OpLabel
+CHECK-NEXT: [[DUMMY_IT:%\w+]] = OpPhi {{%\w+}} {{%\w+}} [[ENTRY]] [[DUMMY_IT_1:%\w+]] [[BE:%\w+]]
+CHECK-NEXT: [[i:%\w+]] = OpPhi {{%\w+}} {{%\w+}} [[ENTRY]] [[I_1:%\w+]] [[BE]]
+CHECK-NEXT: OpLoopMerge [[AFTER_LOOP:%\w+]] [[BE]] None
+CHECK:      [[I_1]] = OpIAdd {{%\w+}} [[i]]
+CHECK:      [[BE]] = OpLabel
+CHECK:      [[DUMMY_IT_1]] = OpIAdd {{%\w+}} [[DUMMY_IT]]
+CHECK-NEXT: [[EXIT_COND:%\w+]] = OpSLessThan {{%\w+}} [[DUMMY_IT_1]]
+CHECK-NEXT: OpBranchConditional [[EXIT_COND]] [[BEFORE_LOOP]] [[AFTER_LOOP]]
+
+CHECK:      [[AFTER_LOOP]] = OpLabel
+CHECK-NEXT: OpPhi {{%\w+}} [[I_1]] [[BE]]
+CHECK-NEXT: OpLoopMerge
+)";
+
+    Match(check, context.get());
+  }
+
+  // Peel after.
+  {
+    SCOPED_TRACE("Peel after");
+
+    std::unique_ptr<ir::IRContext> context =
+        BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                    SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+    ir::Module* module = context->module();
+    EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
+                               << text << std::endl;
+    ir::Function& f = *module->begin();
+    ir::LoopDescriptor& ld = *context->GetLoopDescriptor(&f);
+
+    EXPECT_EQ(ld.NumLoops(), 1u);
+
+    opt::InstructionBuilder builder(context.get(), &*f.begin());
+    ir::Instruction* two_cst = builder.Add32BitSignedIntegerConstant(2);
+    ir::Instruction* loop_count = builder.Add32BitSignedIntegerConstant(10);
+
+    opt::LoopPeeling peel(context.get(), &*ld.begin());
+    EXPECT_TRUE(peel.CanPeelLoop());
+    peel.PeelAfter(two_cst, loop_count);
+
+    const std::string check = R"(
+CHECK:      OpFunction
+CHECK-NEXT: [[ENTRY:%\w+]] = OpLabel
+CHECK:      [[BEFORE_LOOP:%\w+]] = OpLabel
+CHECK-NEXT: [[DUMMY_IT:%\w+]] = OpPhi {{%\w+}} {{%\w+}} [[ENTRY]] [[DUMMY_IT_1:%\w+]] [[BE:%\w+]]
+CHECK-NEXT: [[i:%\w+]] = OpPhi {{%\w+}} {{%\w+}} [[ENTRY]] [[I_1:%\w+]] [[BE]]
+CHECK-NEXT: OpLoopMerge [[AFTER_LOOP:%\w+]] [[BE]] None
+CHECK:      [[I_1]] = OpIAdd {{%\w+}} [[i]]
+CHECK:      [[BE]] = OpLabel
+CHECK:      [[DUMMY_IT_1]] = OpIAdd {{%\w+}} [[DUMMY_IT]]
+CHECK-NEXT: [[EXIT_VAL:%\w+]] = OpIAdd {{%\w+}} [[DUMMY_IT_1]]
+CHECK-NEXT: [[EXIT_COND:%\w+]] = OpSLessThan {{%\w+}} [[EXIT_VAL]]
+CHECK-NEXT: OpBranchConditional [[EXIT_COND]] [[BEFORE_LOOP]] [[AFTER_LOOP]]
+
+CHECK:      [[AFTER_LOOP]] = OpLabel
+CHECK-NEXT: OpPhi {{%\w+}} [[I_1]] [[BE]]
+CHECK-NEXT: OpLoopMerge
+)";
+
+    Match(check, context.get());
+  }
+}
+
+}  // namespace

--- a/test/opt/loop_optimizations/peeling.cpp
+++ b/test/opt/loop_optimizations/peeling.cpp
@@ -895,4 +895,181 @@ CHECK-NEXT: OpLoopMerge
   }
 }
 
+/*
+Generated from the following GLSL + --eliminate-local-multi-store
+
+#version 330 core
+void main() {
+  int a[10];
+  int n = a[0];
+  for(int i = 0; i < n; ++i) {}
+}
+*/
+TEST_F(PeelingTest, PeelingLoopWithStore) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %o %n
+               OpExecutionMode %main OriginLowerLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %o "o"
+               OpName %end "end"
+               OpName %n "n"
+               OpName %i "i"
+               OpDecorate %o Location 0
+               OpDecorate %n Flat
+               OpDecorate %n Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+%_ptr_Output_float = OpTypePointer Output %float
+          %o = OpVariable %_ptr_Output_float Output
+    %float_0 = OpConstant %float 0
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+%_ptr_Input_int = OpTypePointer Input %int
+          %n = OpVariable %_ptr_Input_int Input
+      %int_0 = OpConstant %int 0
+       %bool = OpTypeBool
+    %float_1 = OpConstant %float 1
+      %int_1 = OpConstant %int 1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+        %end = OpVariable %_ptr_Function_int Function
+          %i = OpVariable %_ptr_Function_int Function
+               OpStore %o %float_0
+         %15 = OpLoad %int %n
+               OpStore %end %15
+               OpStore %i %int_0
+               OpBranch %18
+         %18 = OpLabel
+         %33 = OpPhi %int %int_0 %5 %32 %21
+               OpLoopMerge %20 %21 None
+               OpBranch %22
+         %22 = OpLabel
+         %26 = OpSLessThan %bool %33 %15
+               OpBranchConditional %26 %19 %20
+         %19 = OpLabel
+         %28 = OpLoad %float %o
+         %29 = OpFAdd %float %28 %float_1
+               OpStore %o %29
+               OpBranch %21
+         %21 = OpLabel
+         %32 = OpIAdd %int %33 %int_1
+               OpStore %i %32
+               OpBranch %18
+         %20 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  // Peel before.
+  {
+    SCOPED_TRACE("Peel before");
+
+    std::unique_ptr<ir::IRContext> context =
+        BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                    SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+    ir::Module* module = context->module();
+    EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
+                               << text << std::endl;
+    ir::Function& f = *module->begin();
+    ir::LoopDescriptor& ld = *context->GetLoopDescriptor(&f);
+
+    EXPECT_EQ(ld.NumLoops(), 1u);
+
+    ir::Instruction* loop_count = context->get_def_use_mgr()->GetDef(15);
+    EXPECT_EQ(loop_count->opcode(), SpvOpLoad);
+
+    opt::LoopPeeling peel(context.get(), &*ld.begin(), loop_count);
+    EXPECT_TRUE(peel.CanPeelLoop());
+    peel.PeelBefore(1);
+
+    const std::string check = R"(
+CHECK:      OpFunction
+CHECK-NEXT: [[ENTRY:%\w+]] = OpLabel
+CHECK:      [[LOOP_COUNT:%\w+]] = OpLoad
+CHECK:      [[MIN_LOOP_COUNT:%\w+]] = OpSLessThan {{%\w+}} {{%\w+}} [[LOOP_COUNT]]
+CHECK-NEXT: [[LOOP_COUNT:%\w+]] = OpSelect {{%\w+}} [[MIN_LOOP_COUNT]] {{%\w+}} [[LOOP_COUNT]]
+CHECK:      [[BEFORE_LOOP:%\w+]] = OpLabel
+CHECK-NEXT: [[DUMMY_IT:%\w+]] = OpPhi {{%\w+}} {{%\w+}} [[ENTRY]] [[DUMMY_IT_1:%\w+]] [[BE:%\w+]]
+CHECK-NEXT: [[i:%\w+]] = OpPhi {{%\w+}} {{%\w+}} [[ENTRY]] [[I_1:%\w+]] [[BE]]
+CHECK-NEXT: OpLoopMerge [[AFTER_LOOP_PREHEADER:%\w+]] [[BE]] None
+CHECK:      [[COND_BLOCK:%\w+]] = OpLabel
+CHECK-NEXT: OpSLessThan
+CHECK-NEXT: [[EXIT_COND:%\w+]] = OpSLessThan {{%\w+}} [[DUMMY_IT]]
+CHECK-NEXT: OpBranchConditional [[EXIT_COND]] {{%\w+}} [[AFTER_LOOP_PREHEADER]]
+CHECK:      [[I_1]] = OpIAdd {{%\w+}} [[i]]
+CHECK:      [[DUMMY_IT_1]] = OpIAdd {{%\w+}} [[DUMMY_IT]]
+CHECK-NEXT: OpBranch [[BEFORE_LOOP]]
+
+CHECK: [[AFTER_LOOP_PREHEADER]] = OpLabel
+CHECK-NEXT: OpSelectionMerge [[IF_MERGE:%\w+]]
+CHECK-NEXT: OpBranchConditional [[MIN_LOOP_COUNT]] [[AFTER_LOOP:%\w+]] [[IF_MERGE]]
+
+CHECK:      [[AFTER_LOOP]] = OpLabel
+CHECK-NEXT: OpPhi {{%\w+}} {{%\w+}} {{%\w+}} [[i]] [[AFTER_LOOP_PREHEADER]]
+CHECK-NEXT: OpLoopMerge
+)";
+
+    Match(check, context.get());
+  }
+
+  // Peel after.
+  {
+    SCOPED_TRACE("Peel after");
+
+    std::unique_ptr<ir::IRContext> context =
+        BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                    SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+    ir::Module* module = context->module();
+    EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
+                               << text << std::endl;
+    ir::Function& f = *module->begin();
+    ir::LoopDescriptor& ld = *context->GetLoopDescriptor(&f);
+
+    EXPECT_EQ(ld.NumLoops(), 1u);
+
+    ir::Instruction* loop_count = context->get_def_use_mgr()->GetDef(15);
+    EXPECT_EQ(loop_count->opcode(), SpvOpLoad);
+
+    opt::LoopPeeling peel(context.get(), &*ld.begin(), loop_count);
+    EXPECT_TRUE(peel.CanPeelLoop());
+    peel.PeelAfter(1);
+
+    const std::string check = R"(
+CHECK:      OpFunction
+CHECK-NEXT: [[ENTRY:%\w+]] = OpLabel
+CHECK:      [[MIN_LOOP_COUNT:%\w+]] = OpSLessThan {{%\w+}}
+CHECK-NEXT: OpSelectionMerge [[IF_MERGE:%\w+]]
+CHECK-NEXT: OpBranchConditional [[MIN_LOOP_COUNT]] [[BEFORE_LOOP:%\w+]] [[IF_MERGE]]
+CHECK:      [[BEFORE_LOOP]] = OpLabel
+CHECK-NEXT: [[DUMMY_IT:%\w+]] = OpPhi {{%\w+}} {{%\w+}} [[ENTRY]] [[DUMMY_IT_1:%\w+]] [[BE:%\w+]]
+CHECK-NEXT: [[I:%\w+]] = OpPhi {{%\w+}} {{%\w+}} [[ENTRY]] [[I_1:%\w+]] [[BE]]
+CHECK-NEXT: OpLoopMerge [[BEFORE_LOOP_MERGE:%\w+]] [[BE]] None
+CHECK:      [[COND_BLOCK:%\w+]] = OpLabel
+CHECK-NEXT: OpSLessThan
+CHECK-NEXT: [[TMP:%\w+]] = OpIAdd {{%\w+}} [[DUMMY_IT]] {{%\w+}}
+CHECK-NEXT: [[EXIT_COND:%\w+]] = OpSLessThan {{%\w+}} [[TMP]]
+CHECK-NEXT: OpBranchConditional [[EXIT_COND]] {{%\w+}} [[BEFORE_LOOP_MERGE]]
+CHECK:      [[I_1]] = OpIAdd {{%\w+}} [[I]]
+CHECK:      [[DUMMY_IT_1]] = OpIAdd {{%\w+}} [[DUMMY_IT]]
+CHECK-NEXT: OpBranch [[BEFORE_LOOP]]
+
+CHECK:      [[IF_MERGE]] = OpLabel
+CHECK-NEXT: [[TMP:%\w+]] = OpPhi {{%\w+}} [[I]] [[BEFORE_LOOP_MERGE]]
+CHECK-NEXT: OpBranch [[AFTER_LOOP:%\w+]]
+
+CHECK:      [[AFTER_LOOP]] = OpLabel
+CHECK-NEXT: OpPhi {{%\w+}} {{%\w+}} {{%\w+}} [[TMP]] [[IF_MERGE]]
+CHECK-NEXT: OpLoopMerge
+
+)";
+
+    Match(check, context.get());
+  }
+}
+
 }  // namespace

--- a/test/opt/loop_optimizations/peeling.cpp
+++ b/test/opt/loop_optimizations/peeling.cpp
@@ -98,8 +98,11 @@ void main() {
 }
 */
 TEST_F(PeelingTest, CannotPeel) {
-  auto test_cannot_peel = [](const std::string& text,
-                             uint32_t loop_count_id = 0) {
+  // Build the given SPIR-V program in |text|, take the first loop in the first
+  // function and test that it is not peelable. |loop_count_id| is the id
+  // representing the loop count, if equals to 0, then the function build a 10
+  // constant as loop count.
+  auto test_cannot_peel = [](const std::string& text, uint32_t loop_count_id) {
     std::unique_ptr<ir::IRContext> context =
         BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
                     SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
@@ -168,7 +171,7 @@ TEST_F(PeelingTest, CannotPeel) {
                OpReturn
                OpFunctionEnd
   )";
-    test_cannot_peel(text);
+    test_cannot_peel(text, 0);
   }
 
   {
@@ -210,7 +213,7 @@ TEST_F(PeelingTest, CannotPeel) {
                OpFunctionEnd
   )";
 
-    test_cannot_peel(text);
+    test_cannot_peel(text, 0);
   }
 
   {


### PR DESCRIPTION
The loop peeler util takes a loop as input and create a new one before.
The iterator of the duplicated loop then set to accommodate the number
of iteration required for the peeling.

The loop peeling pass that decided to do the peeling and profitability
analysis is left for a follow-up PR.