### PR TITLE
Add recent Google extensions to optimizer whitelists

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -701,6 +701,8 @@ void AggressiveDCEPass::InitExtensions() {
       "SPV_AMD_shader_fragment_mask",
       "SPV_EXT_fragment_fully_covered",
       "SPV_AMD_gpu_shader_half_float_fetch",
+      "SPV_GOOGLE_decorate_string",
+      "SPV_GOOGLE_hlsl_functionality1",
   });
 }
 

--- a/source/opt/common_uniform_elim_pass.cpp
+++ b/source/opt/common_uniform_elim_pass.cpp
@@ -570,6 +570,8 @@ void CommonUniformElimPass::InitExtensions() {
       "SPV_AMD_shader_fragment_mask",
       "SPV_EXT_fragment_fully_covered",
       "SPV_AMD_gpu_shader_half_float_fetch",
+      "SPV_GOOGLE_decorate_string",
+      "SPV_GOOGLE_hlsl_functionality1",
   });
 }
 

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -330,6 +330,8 @@ void LocalAccessChainConvertPass::InitExtensions() {
       "SPV_AMD_shader_fragment_mask",
       "SPV_EXT_fragment_fully_covered",
       "SPV_AMD_gpu_shader_half_float_fetch",
+      "SPV_GOOGLE_decorate_string",
+      "SPV_GOOGLE_hlsl_functionality1",
   });
 }
 

--- a/source/opt/local_single_block_elim_pass.cpp
+++ b/source/opt/local_single_block_elim_pass.cpp
@@ -210,6 +210,8 @@ void LocalSingleBlockLoadStoreElimPass::InitExtensions() {
       "SPV_AMD_shader_fragment_mask",
       "SPV_EXT_fragment_fully_covered",
       "SPV_AMD_gpu_shader_half_float_fetch",
+      "SPV_GOOGLE_decorate_string",
+      "SPV_GOOGLE_hlsl_functionality1",
   });
 }
 

--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -313,6 +313,8 @@ void LocalSingleStoreElimPass::InitExtensions() {
       "SPV_AMD_shader_fragment_mask",
       "SPV_EXT_fragment_fully_covered",
       "SPV_AMD_gpu_shader_half_float_fetch",
+      "SPV_GOOGLE_decorate_string",
+      "SPV_GOOGLE_hlsl_functionality1",
   });
 }
 

--- a/source/opt/local_ssa_elim_pass.cpp
+++ b/source/opt/local_ssa_elim_pass.cpp
@@ -103,6 +103,8 @@ void LocalMultiStoreElimPass::InitExtensions() {
       "SPV_AMD_shader_fragment_mask",
       "SPV_EXT_fragment_fully_covered",
       "SPV_AMD_gpu_shader_half_float_fetch",
+      "SPV_GOOGLE_decorate_string",
+      "SPV_GOOGLE_hlsl_functionality1",
   });
 }
 


### PR DESCRIPTION
Optimizations should work in the presence of recent
SPV_GOOGLE_decorate_string and SPV_GOOGLE_hlsl_functionality1

SPV_GOOGLE_decorate_string:
- Adds operation OpDecorateStringGOOGLE to decorate an object with decorations
  having string operands.

SPV_GOOGLE_hlsl_functionality1:
- Adds HlslSemanticGOOGLE, used to decorate an interface variable with
  an HLSL semantic string.  Optimizations already preserve those variables
  as required because they are interface variables (with uses), independent
  of whether they have HLSL decorations.

- Adds HlslCounterBufferGOOGLE, used to associate a buffer with a
  counter variable.

Fixes #1391