### PR TITLE
NFC: Speed up dead insert phi traversal on Windows.

### DIFF
--- a/source/opt/dead_insert_elim_pass.h
+++ b/source/opt/dead_insert_elim_pass.h
@@ -73,7 +73,7 @@ class DeadInsertElimPass : public MemPass {
   std::unordered_set<uint32_t> liveInserts_;
 
   // Visited phis as insert chain is traversed; used to avoid infinite loop
-  std::unordered_set<uint32_t> visitedPhis_;
+  std::unordered_map<uint32_t, bool> visitedPhis_;
 };
 
 }  // namespace opt


### PR DESCRIPTION
Found from an internal shader compiled via DXC. Compile was killed after 150 minutes on windows. With this fix, dead insert elim (and -O) complete in seconds.

Problematic case had many phis with the same incoming value for multiple edges. These phis formed long chains causing significant amounts of repeated work.

Changed the traversal to unique incoming values. Also changed the way visited phis are tracked to avoid numerous inserts and erases.

This should result in no functional changes.