### PR TITLE
Fix VS2013 build failures.

### DIFF
--- a/source/opt/ssa_rewrite_pass.h
+++ b/source/opt/ssa_rewrite_pass.h
@@ -57,10 +57,6 @@ class SSARewriter {
           is_complete_(false),
           users_() {}
 
-    PhiCandidate(const PhiCandidate&) = delete;
-    PhiCandidate(PhiCandidate&&) = default;
-    PhiCandidate& operator=(const PhiCandidate&) = delete;
-
     uint32_t var_id() const { return var_id_; }
     uint32_t result_id() const { return result_id_; }
     ir::BasicBlock* bb() const { return bb_; }


### PR DESCRIPTION
VS 2013 does not accept defaulting the move constructor.  This fixes the build problems with it.