### PR TITLE
Fixes the compile errors generated by SPIRV_WARN_EVERYTHING and SPIRV_WERROR

### DIFF
--- a/source/cfa.h
+++ b/source/cfa.h
@@ -331,7 +331,7 @@ void CFA<BB>::ComputeAugmentedCFG(
     augmented_succ.push_back(pseudo_exit_block);
     augmented_succ.insert(augmented_succ.end(), succ->begin(), succ->end());
   }
-};
+}
 
 }  // namespace spvtools
 

--- a/source/opt/block_merge_pass.cpp
+++ b/source/opt/block_merge_pass.cpp
@@ -137,7 +137,7 @@ bool BlockMergePass::IsMerge(ir::BasicBlock* block) {
   return IsMerge(block->id());
 }
 
-void BlockMergePass::Initialize(ir::IRContext* c) { InitializeProcessing(c); };
+void BlockMergePass::Initialize(ir::IRContext* c) { InitializeProcessing(c); }
 
 Pass::Status BlockMergePass::ProcessImpl() {
   // Process all entry point functions.

--- a/source/opt/build_module.cpp
+++ b/source/opt/build_module.cpp
@@ -31,7 +31,7 @@ spv_result_t SetSpvHeader(void* builder, spv_endianness_t, uint32_t magic,
   reinterpret_cast<ir::IrLoader*>(builder)->SetModuleHeader(
       magic, version, generator, id_bound, reserved);
   return SPV_SUCCESS;
-};
+}
 
 // Processes a parsed instruction for IrLoader. Meets the interface requirement
 // of spvBinaryParse().
@@ -40,7 +40,7 @@ spv_result_t SetSpvInst(void* builder, const spv_parsed_instruction_t* inst) {
     return SPV_SUCCESS;
   }
   return SPV_ERROR_INVALID_BINARY;
-};
+}
 
 }  // namespace
 

--- a/source/opt/common_uniform_elim_pass.cpp
+++ b/source/opt/common_uniform_elim_pass.cpp
@@ -488,7 +488,7 @@ void CommonUniformElimPass::Initialize(ir::IRContext* c) {
 
   // Initialize extension whitelist
   InitExtensions();
-};
+}
 
 bool CommonUniformElimPass::AllExtensionsSupported() const {
   // If any extension not in whitelist, return false

--- a/source/opt/dead_branch_elim_pass.cpp
+++ b/source/opt/dead_branch_elim_pass.cpp
@@ -367,7 +367,7 @@ bool DeadBranchElimPass::EliminateDeadBranches(ir::Function* func) {
 
 void DeadBranchElimPass::Initialize(ir::IRContext* c) {
   InitializeProcessing(c);
-};
+}
 
 Pass::Status DeadBranchElimPass::ProcessImpl() {
   // Do not process if module contains OpGroupDecorate. Additional

--- a/source/opt/dead_insert_elim_pass.cpp
+++ b/source/opt/dead_insert_elim_pass.cpp
@@ -257,7 +257,7 @@ bool DeadInsertElimPass::EliminateDeadInsertsOnePass(ir::Function* func) {
 
 void DeadInsertElimPass::Initialize(ir::IRContext* c) {
   InitializeProcessing(c);
-};
+}
 
 Pass::Status DeadInsertElimPass::ProcessImpl() {
   // Process all entry point functions.

--- a/source/opt/folding_rules.cpp
+++ b/source/opt/folding_rules.cpp
@@ -234,7 +234,7 @@ FoldingRule ReciprocalFDiv() {
 
     return false;
   };
-};
+}
 
 // Elides consecutive negate instructions.
 FoldingRule MergeNegateArithmetic() {

--- a/source/opt/inline_exhaustive_pass.cpp
+++ b/source/opt/inline_exhaustive_pass.cpp
@@ -61,7 +61,7 @@ bool InlineExhaustivePass::InlineExhaustive(ir::Function* func) {
 
 void InlineExhaustivePass::Initialize(ir::IRContext* c) {
   InitializeInline(c);
-};
+}
 
 Pass::Status InlineExhaustivePass::ProcessImpl() {
   // Attempt exhaustive inlining on each entry point function in module

--- a/source/opt/inline_opaque_pass.cpp
+++ b/source/opt/inline_opaque_pass.cpp
@@ -92,7 +92,7 @@ bool InlineOpaquePass::InlineOpaque(ir::Function* func) {
   return modified;
 }
 
-void InlineOpaquePass::Initialize(ir::IRContext* c) { InitializeInline(c); };
+void InlineOpaquePass::Initialize(ir::IRContext* c) { InitializeInline(c); }
 
 Pass::Status InlineOpaquePass::ProcessImpl() {
   // Do opaque inlining on each function in entry point call tree

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -668,7 +668,7 @@ void InlinePass::InitializeInline(ir::IRContext* c) {
     // Compute inlinability
     if (IsInlinableFunction(&fn)) inlinable_.insert(fn.result_id());
   }
-};
+}
 
 InlinePass::InlinePass() {}
 

--- a/source/opt/insert_extract_elim.cpp
+++ b/source/opt/insert_extract_elim.cpp
@@ -199,7 +199,7 @@ bool InsertExtractElimPass::EliminateInsertExtract(ir::Function* func) {
 
 void InsertExtractElimPass::Initialize(ir::IRContext* c) {
   InitializeProcessing(c);
-};
+}
 
 Pass::Status InsertExtractElimPass::ProcessImpl() {
   // Process all entry point functions.

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -256,7 +256,7 @@ void LocalAccessChainConvertPass::Initialize(ir::IRContext* c) {
 
   // Initialize extension whitelist
   InitExtensions();
-};
+}
 
 bool LocalAccessChainConvertPass::AllExtensionsSupported() const {
   // If any extension not in whitelist, return false

--- a/source/opt/local_single_block_elim_pass.cpp
+++ b/source/opt/local_single_block_elim_pass.cpp
@@ -138,7 +138,7 @@ void LocalSingleBlockLoadStoreElimPass::Initialize(ir::IRContext* c) {
 
   // Initialize extensions whitelist
   InitExtensions();
-};
+}
 
 bool LocalSingleBlockLoadStoreElimPass::AllExtensionsSupported() const {
   // If any extension not in whitelist, return false

--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -242,7 +242,7 @@ void LocalSingleStoreElimPass::Initialize(ir::IRContext* irContext) {
 
   // Initialize extension whitelist
   InitExtensions();
-};
+}
 
 bool LocalSingleStoreElimPass::AllExtensionsSupported() const {
   // If any extension not in whitelist, return false

--- a/source/opt/local_ssa_elim_pass.cpp
+++ b/source/opt/local_ssa_elim_pass.cpp
@@ -27,7 +27,7 @@ void LocalMultiStoreElimPass::Initialize(ir::IRContext* c) {
 
   // Initialize extension whitelist
   InitExtensions();
-};
+}
 
 bool LocalMultiStoreElimPass::AllExtensionsSupported() const {
   // If any extension not in whitelist, return false

--- a/source/opt/module.cpp
+++ b/source/opt/module.cpp
@@ -30,7 +30,7 @@ std::vector<Instruction*> Module::GetTypes() {
     if (IsTypeInst(inst.opcode())) type_insts.push_back(&inst);
   }
   return type_insts;
-};
+}
 
 std::vector<const Instruction*> Module::GetTypes() const {
   std::vector<const Instruction*> type_insts;
@@ -38,7 +38,7 @@ std::vector<const Instruction*> Module::GetTypes() const {
     if (IsTypeInst(inst.opcode())) type_insts.push_back(&inst);
   }
   return type_insts;
-};
+}
 
 std::vector<Instruction*> Module::GetConstants() {
   std::vector<Instruction*> const_insts;
@@ -46,7 +46,7 @@ std::vector<Instruction*> Module::GetConstants() {
     if (IsConstantInst(inst.opcode())) const_insts.push_back(&inst);
   }
   return const_insts;
-};
+}
 
 std::vector<const Instruction*> Module::GetConstants() const {
   std::vector<const Instruction*> const_insts;
@@ -54,7 +54,7 @@ std::vector<const Instruction*> Module::GetConstants() const {
     if (IsConstantInst(inst.opcode())) const_insts.push_back(&inst);
   }
   return const_insts;
-};
+}
 
 uint32_t Module::GetGlobalValue(SpvOp opcode) const {
   for (auto& inst : types_values_) {

--- a/source/opt/set_spec_constant_default_value_pass.cpp
+++ b/source/opt/set_spec_constant_default_value_pass.cpp
@@ -188,7 +188,7 @@ ir::Instruction* GetSpecIdTargetFromDecorationGroup(
   }
   return target_inst;
 }
-};  // namespace
+}  // namespace
 
 Pass::Status SetSpecConstantDefaultValuePass::Process(
     ir::IRContext* irContext) {

--- a/source/opt/types.h
+++ b/source/opt/types.h
@@ -517,15 +517,15 @@ class ForwardPointer : public Type {
                                                                      \
     void GetExtraHashWords(std::vector<uint32_t>*) const override {} \
   };  // namespace analysis
-DefineParameterlessType(Void, void);
-DefineParameterlessType(Bool, bool);
-DefineParameterlessType(Sampler, sampler);
-DefineParameterlessType(Event, event);
-DefineParameterlessType(DeviceEvent, device_event);
-DefineParameterlessType(ReserveId, reserve_id);
-DefineParameterlessType(Queue, queue);
-DefineParameterlessType(PipeStorage, pipe_storage);
-DefineParameterlessType(NamedBarrier, named_barrier);
+DefineParameterlessType(Void, void)
+DefineParameterlessType(Bool, bool)
+DefineParameterlessType(Sampler, sampler)
+DefineParameterlessType(Event, event)
+DefineParameterlessType(DeviceEvent, device_event)
+DefineParameterlessType(ReserveId, reserve_id)
+DefineParameterlessType(Queue, queue)
+DefineParameterlessType(PipeStorage, pipe_storage)
+DefineParameterlessType(NamedBarrier, named_barrier)
 #undef DefineParameterlessType
 
 }  // namespace analysis

--- a/source/opt/types.h
+++ b/source/opt/types.h
@@ -516,16 +516,16 @@ class ForwardPointer : public Type {
     const type* As##type() const override { return this; }           \
                                                                      \
     void GetExtraHashWords(std::vector<uint32_t>*) const override {} \
-  };  // namespace analysis
-DefineParameterlessType(Void, void)
-DefineParameterlessType(Bool, bool)
-DefineParameterlessType(Sampler, sampler)
-DefineParameterlessType(Event, event)
-DefineParameterlessType(DeviceEvent, device_event)
-DefineParameterlessType(ReserveId, reserve_id)
-DefineParameterlessType(Queue, queue)
-DefineParameterlessType(PipeStorage, pipe_storage)
-DefineParameterlessType(NamedBarrier, named_barrier)
+  }
+DefineParameterlessType(Void, void);
+DefineParameterlessType(Bool, bool);
+DefineParameterlessType(Sampler, sampler);
+DefineParameterlessType(Event, event);
+DefineParameterlessType(DeviceEvent, device_event);
+DefineParameterlessType(ReserveId, reserve_id);
+DefineParameterlessType(Queue, queue);
+DefineParameterlessType(PipeStorage, pipe_storage);
+DefineParameterlessType(NamedBarrier, named_barrier);
 #undef DefineParameterlessType
 
 }  // namespace analysis

--- a/source/val/function.cpp
+++ b/source/val/function.cpp
@@ -279,7 +279,7 @@ void Function::ComputeAugmentedCFG() {
       ordered_blocks_, &pseudo_entry_block_, &pseudo_exit_block_,
       &augmented_successors_map_, &augmented_predecessors_map_, succ_func,
       pred_func);
-};
+}
 
 Construct& Function::AddConstruct(const Construct& new_construct) {
   cfg_constructs_.push_back(new_construct);

--- a/tools/val/val.cpp
+++ b/tools/val/val.cpp
@@ -71,7 +71,7 @@ int main(int argc, char** argv) {
           spv_validator_limit limit_type;
           if (spvParseUniversalLimitsOptions(cur_arg, &limit_type)) {
             uint32_t limit = 0;
-            if (sscanf(argv[++argi], "%d", &limit)) {
+            if (sscanf(argv[++argi], "%u", &limit)) {
               options.SetUniversalLimit(limit_type, limit);
             } else {
               fprintf(stderr, "error: missing argument to %s\n", cur_arg);


### PR DESCRIPTION
This patch fixes the compile errors generated when the options
SPIRV_WARN_EVERYTHING and SPIRV_WERROR (that force -Wpedantic) are
set to CMake.