### PR TITLE
Adding OpPhi validation rules.

### DIFF
--- a/source/validate_id.cpp
+++ b/source/validate_id.cpp
@@ -1786,11 +1786,72 @@ bool idUsage::isValid<SpvOpVectorShuffle>(const spv_instruction_t* inst,
   return true;
 }
 
-#if 0
 template <>
-bool idUsage::isValid<OpPhi>(const spv_instruction_t *inst,
-                             const spv_opcode_desc opcodeEntry) {}
-#endif
+bool idUsage::isValid<SpvOpPhi>(const spv_instruction_t* inst,
+                                const spv_opcode_desc opcodeEntry) {
+  (void)opcodeEntry;
+  auto thisInst = module_.FindDef(inst->words[2]);
+  SpvOp typeOp = module_.GetIdOpcode(thisInst->type_id());
+  if (!spvOpcodeGeneratesType(typeOp)) {
+    DIAG(0) << "OpPhi's type <id> " << module_.getIdName(thisInst->type_id())
+            << " is not a type instruction.";
+    return false;
+  }
+
+  auto block = thisInst->block();
+  size_t numInOps = inst->words.size() - 3;
+  if (numInOps % 2 != 0) {
+    DIAG(0) << "OpPhi does not have an equal number of incoming values and "
+               "basic blocks.";
+    return false;
+  }
+
+  // Create an uniqued vector of predecessor ids for comparison against
+  // incoming values. OpBranchConditional %cond %label %label produces two
+  // predecessors in the CFG.
+  std::vector<uint32_t> predIds;
+  std::transform(block->predecessors()->begin(), block->predecessors()->end(),
+                 std::back_inserter(predIds),
+                 [](const libspirv::BasicBlock* b) { return b->id(); });
+  std::sort(predIds.begin(), predIds.end());
+  predIds.erase(std::unique(predIds.begin(), predIds.end()), predIds.end());
+
+  size_t numEdges = numInOps / 2;
+  if (numEdges != predIds.size()) {
+    DIAG(0) << "OpPhi's number of incoming blocks (" << numEdges
+            << ") does not match block's predecessor count ("
+            << block->predecessors()->size() << ").";
+    return false;
+  }
+
+  for (size_t i = 3; i < inst->words.size(); ++i) {
+    auto incId = inst->words[i];
+    auto incInst = module_.FindDef(incId);
+    if (i % 2 == 1) {
+      // Incoming value type must match the phi result type.
+      auto incType = module_.FindDef(incInst->type_id());
+      auto resType = inst->words[1];
+      if (resType != incType->id()) {
+        DIAG(i) << "OpPhi's result type <id> " << module_.getIdName(resType)
+                << " does not match incoming value <id> "
+                << module_.getIdName(incId) << " type <id> "
+                << module_.getIdName(incType->id()) << ".";
+        return false;
+      }
+    } else {
+      // Incoming basic block must be an immediate predecessor of the phi's
+      // block.
+      if (!std::binary_search(predIds.begin(), predIds.end(), incId)) {
+        DIAG(i) << "OpPhi's incoming basic block <id> "
+                << module_.getIdName(incId) << " is not a predecessor of <id> "
+                << module_.getIdName(block->id()) << ".";
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
 
 #if 0
 template <>
@@ -2357,7 +2418,7 @@ bool idUsage::isValid(const spv_instruction_t* inst) {
     // Bitwise opcodes are validated in validate_bitwise.cpp.
     // Logical opcodes are validated in validate_logicals.cpp.
     // Derivative opcodes are validated in validate_derivatives.cpp.
-    TODO(OpPhi)
+    CASE(OpPhi)
     TODO(OpLoopMerge)
     TODO(OpSelectionMerge)
     TODO(OpBranch)
@@ -2606,7 +2667,8 @@ spv_result_t CheckIdDefinitionDominateUse(const ValidationState_t& _) {
       const Instruction* variable = _.FindDef(phi->word(i));
       const BasicBlock* parent =
           phi->function()->GetBlock(phi->word(i + 1)).first;
-      if (variable->block() && !variable->block()->dominates(*parent)) {
+      if (variable->block() && parent->reachable() &&
+          !variable->block()->dominates(*parent)) {
         return _.diag(SPV_ERROR_INVALID_ID)
                << "In OpPhi instruction " << _.getIdName(phi->id()) << ", ID "
                << _.getIdName(variable->id())

--- a/test/opt/cfg_cleanup_test.cpp
+++ b/test/opt/cfg_cleanup_test.cpp
@@ -307,7 +307,7 @@ TEST_F(CFGCleanupTest, RemovePhiArgsFromFarBlocks) {
                OpStore %outparm %int_15
                OpBranch %16
          %16 = OpLabel
-         %30 = OpPhi %int %11 %41 %int_42 %13 %11 %14 %11 %15
+         %30 = OpPhi %int %11 %40 %int_42 %13 %11 %14 %11 %15
          %28 = OpIAdd %int %30 %int_5
                OpStore %outparm %28
                OpReturn
@@ -352,7 +352,7 @@ OpBranch %20
 OpStore %outparm %int_15
 OpBranch %20
 %20 = OpLabel
-%24 = OpPhi %int %int_42 %21 %26 %22 %26 %23
+%24 = OpPhi %int %26 %16 %int_42 %21 %26 %22 %26 %23
 %25 = OpIAdd %int %24 %int_5
 OpStore %outparm %25
 OpReturn

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -2827,7 +2827,8 @@ TEST_P(AccessChainInstructionTest, AccessChainBaseTypeNonPtrVariableBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" + instr +
+%entry = )" +
+                 instr +
                  R"( %_ptr_Private_float %_ptr_Private_float )" + elem +
                  R"(%int_0 %int_1
 OpReturn
@@ -2847,7 +2848,8 @@ TEST_P(AccessChainInstructionTest,
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" + instr +
+%entry = )" +
+                 instr +
                  R"( %_ptr_Function_float %my_matrix )" + elem +
                  R"(%int_0 %int_1
 OpReturn
@@ -2868,7 +2870,8 @@ TEST_P(AccessChainInstructionTest,
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" + instr +
+%entry = )" +
+                 instr +
                  R"( %_ptr_Private_float %my_float_var )" + elem + R"(%int_0
 OpReturn
 OpFunctionEnd
@@ -2887,7 +2890,8 @@ TEST_P(AccessChainInstructionTest, AccessChainNoIndexesGood) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" + instr +
+%entry = )" +
+                 instr +
                  R"( %_ptr_Private_float %my_float_var )" + elem + R"(
 OpReturn
 OpFunctionEnd
@@ -2902,7 +2906,8 @@ TEST_P(AccessChainInstructionTest, AccessChainNoIndexesBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" + instr +
+%entry = )" +
+                 instr +
                  R"( %_ptr_Private_mat4x3 %my_float_var )" + elem + R"(
 OpReturn
 OpFunctionEnd
@@ -3051,9 +3056,10 @@ TEST_P(AccessChainInstructionTest, CustomizedAccessChainTooManyIndexesBad) {
 TEST_P(AccessChainInstructionTest, AccessChainUndefinedIndexBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
-  string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
+  string spirv =
+      kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
 %entry = )" + instr +
-                 R"( %_ptr_Private_float %my_matrix )" + elem + R"(%float %int_1
+      R"( %_ptr_Private_float %my_matrix )" + elem + R"(%float %int_1
 OpReturn
 OpFunctionEnd
   )";
@@ -3070,8 +3076,8 @@ TEST_P(AccessChainInstructionTest, AccessChainStructIndexNotConstantBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%f = )" + instr + R"( %_ptr_Uniform_float %blockName_var )" +
-                 elem +
+%f = )" +
+                 instr + R"( %_ptr_Uniform_float %blockName_var )" + elem +
                  R"(%int_0 %spec_int %int_2
 OpReturn
 OpFunctionEnd
@@ -3090,7 +3096,8 @@ TEST_P(AccessChainInstructionTest,
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" + instr +
+%entry = )" +
+                 instr +
                  R"( %_ptr_Uniform_float %blockName_var )" + elem +
                  R"(%int_0 %int_1 %int_2
 OpReturn
@@ -3110,7 +3117,8 @@ TEST_P(AccessChainInstructionTest, AccessChainStructTooManyIndexesBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" + instr +
+%entry = )" +
+                 instr +
                  R"( %_ptr_Uniform_float %blockName_var )" + elem +
                  R"(%int_0 %int_2 %int_2
 OpReturn
@@ -3129,7 +3137,8 @@ TEST_P(AccessChainInstructionTest, AccessChainStructIndexOutOfBoundBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" + instr +
+%entry = )" +
+                 instr +
                  R"( %_ptr_Uniform_float %blockName_var )" + elem +
                  R"(%int_3 %int_2 %int_2
 OpReturn
@@ -3216,7 +3225,8 @@ TEST_P(AccessChainInstructionTest, AccessChainMatrixMoreArgsThanNeededBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" + instr +
+%entry = )" +
+                 instr +
                  R"( %_ptr_Private_float %my_matrix )" + elem +
                  R"(%int_0 %int_1 %int_0
 OpReturn
@@ -3236,7 +3246,8 @@ TEST_P(AccessChainInstructionTest,
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" + instr +
+%entry = )" +
+                 instr +
                  R"( %_ptr_Private_mat4x3 %my_matrix )" + elem +
                  R"(%int_0 %int_1
 OpReturn
@@ -3914,10 +3925,169 @@ TEST_F(ValidateIdWithMessage, OpVectorShuffleLiterals) {
 // TODO: OpDPdxCoarse
 // TODO: OpDPdyCoarse
 // TODO: OpFwidthCoarse
-// TODO: OpPhi
 // TODO: OpLoopMerge
 // TODO: OpSelectionMerge
 // TODO: OpBranch
+
+TEST_F(ValidateIdWithMessage, OpPhiNotAType) {
+  string spirv = kOpenCLMemoryModel32 + R"(
+%2 = OpTypeBool
+%3 = OpConstantTrue %2
+%4 = OpTypeVoid
+%5 = OpTypeFunction %4
+%6 = OpFunction %4 None %5
+%7 = OpLabel
+OpBranch %8
+%8 = OpLabel
+%9 = OpPhi %3 %3 %7
+OpReturn
+OpFunctionEnd
+  )";
+
+  CompileSuccessfully(spirv.c_str());
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpPhi's type <id> 3 is not a type instruction."));
+}
+
+TEST_F(ValidateIdWithMessage, OpPhiSamePredecessor) {
+  string spirv = kOpenCLMemoryModel32 + R"(
+%2 = OpTypeBool
+%3 = OpConstantTrue %2
+%4 = OpTypeVoid
+%5 = OpTypeFunction %4
+%6 = OpFunction %4 None %5
+%7 = OpLabel
+OpBranchConditional %3 %8 %8
+%8 = OpLabel
+%9 = OpPhi %2 %3 %7
+OpReturn
+OpFunctionEnd
+  )";
+
+  CompileSuccessfully(spirv.c_str());
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateIdWithMessage, OpPhiOddArgumentNumber) {
+  string spirv = kOpenCLMemoryModel32 + R"(
+%2 = OpTypeBool
+%3 = OpConstantTrue %2
+%4 = OpTypeVoid
+%5 = OpTypeFunction %4
+%6 = OpFunction %4 None %5
+%7 = OpLabel
+OpBranch %8
+%8 = OpLabel
+%9 = OpPhi %2 %3
+OpReturn
+OpFunctionEnd
+  )";
+
+  CompileSuccessfully(spirv.c_str());
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpPhi does not have an equal number of incoming "
+                        "values and basic blocks."));
+}
+
+TEST_F(ValidateIdWithMessage, OpPhiTooFewPredecessors) {
+  string spirv = kOpenCLMemoryModel32 + R"(
+%2 = OpTypeBool
+%3 = OpConstantTrue %2
+%4 = OpTypeVoid
+%5 = OpTypeFunction %4
+%6 = OpFunction %4 None %5
+%7 = OpLabel
+OpBranch %8
+%8 = OpLabel
+%9 = OpPhi %2
+OpReturn
+OpFunctionEnd
+  )";
+
+  CompileSuccessfully(spirv.c_str());
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpPhi's number of incoming blocks (0) does not match "
+                        "block's predecessor count (1)."));
+}
+
+TEST_F(ValidateIdWithMessage, OpPhiTooManyPredecessors) {
+  string spirv = kOpenCLMemoryModel32 + R"(
+%2 = OpTypeBool
+%3 = OpConstantTrue %2
+%4 = OpTypeVoid
+%5 = OpTypeFunction %4
+%6 = OpFunction %4 None %5
+%7 = OpLabel
+OpBranch %8
+%9 = OpLabel
+OpReturn
+%8 = OpLabel
+%10 = OpPhi %2 %3 %7 %3 %9
+OpReturn
+OpFunctionEnd
+  )";
+
+  CompileSuccessfully(spirv.c_str());
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpPhi's number of incoming blocks (2) does not match "
+                        "block's predecessor count (1)."));
+}
+
+TEST_F(ValidateIdWithMessage, OpPhiMismatchedTypes) {
+  string spirv = kOpenCLMemoryModel32 + R"(
+%2 = OpTypeBool
+%3 = OpConstantTrue %2
+%4 = OpTypeVoid
+%5 = OpTypeInt 32 0
+%6 = OpConstant %5 0
+%7 = OpTypeFunction %4
+%8 = OpFunction %4 None %7
+%9 = OpLabel
+OpBranchConditional %3 %10 %11
+%11 = OpLabel
+OpBranch %10
+%10 = OpLabel
+%12 = OpPhi %2 %3 %9 %6 %11
+OpReturn
+OpFunctionEnd
+  )";
+
+  CompileSuccessfully(spirv.c_str());
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpPhi's result type <id> 2 does not match incoming "
+                        "value <id> 6 type <id> 5."));
+}
+
+TEST_F(ValidateIdWithMessage, OpPhiNotAPredecessor) {
+  string spirv = kOpenCLMemoryModel32 + R"(
+%2 = OpTypeBool
+%3 = OpConstantTrue %2
+%4 = OpTypeVoid
+%5 = OpTypeFunction %4
+%6 = OpFunction %4 None %5
+%7 = OpLabel
+OpBranchConditional %3 %8 %9
+%9 = OpLabel
+OpBranch %11
+%11 = OpLabel
+OpBranch %8
+%8 = OpLabel
+%10 = OpPhi %2 %3 %7 %3 %9
+OpReturn
+OpFunctionEnd
+  )";
+
+  CompileSuccessfully(spirv.c_str());
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpPhi's incoming basic block <id> 9 is not a "
+                        "predecessor of <id> 8."));
+}
 
 TEST_F(ValidateIdWithMessage, OpBranchConditionalGood) {
   string spirv = BranchConditionalSetup + R"(

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -4063,6 +4063,32 @@ OpFunctionEnd
                         "value <id> 6 type <id> 5."));
 }
 
+TEST_F(ValidateIdWithMessage, OpPhiPredecessorNotABlock) {
+  string spirv = kOpenCLMemoryModel32 + R"(
+%2 = OpTypeBool
+%3 = OpConstantTrue %2
+%4 = OpTypeVoid
+%5 = OpTypeFunction %4
+%6 = OpFunction %4 None %5
+%7 = OpLabel
+OpBranchConditional %3 %8 %9
+%9 = OpLabel
+OpBranch %11
+%11 = OpLabel
+OpBranch %8
+%8 = OpLabel
+%10 = OpPhi %2 %3 %7 %3 %3
+OpReturn
+OpFunctionEnd
+  )";
+
+  CompileSuccessfully(spirv.c_str());
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("OpPhi's incoming basic block <id> 3 is not an OpLabel."));
+}
+
 TEST_F(ValidateIdWithMessage, OpPhiNotAPredecessor) {
   string spirv = kOpenCLMemoryModel32 + R"(
 %2 = OpTypeBool


### PR DESCRIPTION
Checks:
* phi type is a type instruction
* incoming value types match result type
* number of incoming blocks matches CFG predecessors
* matched pairs of values and blocks
* incoming blocks are CFG predecessors

Changes:
* Added tests
* Fixes SSA check for unreachable phi parents
* Fixes invalid cfg cleanup test

I tried to match the style of the file, including diagnostic messages.