### PR TITLE
Don't produce validation false negatives for spec constant sized arrays

### DIFF
--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -206,6 +206,19 @@ int32_t spvOpcodeIsScalarType(const SpvOp opcode) {
   }
 }
 
+int32_t spvOpcodeIsSpecConstant(const SpvOp opcode) {
+  switch (opcode) {
+    case SpvOpSpecConstantTrue:
+    case SpvOpSpecConstantFalse:
+    case SpvOpSpecConstant:
+    case SpvOpSpecConstantComposite:
+    case SpvOpSpecConstantOp:
+      return true;
+    default:
+      return false;
+  }
+}
+
 int32_t spvOpcodeIsConstant(const SpvOp opcode) {
   switch (opcode) {
     case SpvOpConstantTrue:

--- a/source/opcode.h
+++ b/source/opcode.h
@@ -63,6 +63,10 @@ const char* spvOpcodeString(const SpvOp opcode);
 // non-zero otherwise.
 int32_t spvOpcodeIsScalarType(const SpvOp opcode);
 
+// Determines if the given opcode is a specialization constant. Returns zero if
+// false, non-zero otherwise.
+int32_t spvOpcodeIsSpecConstant(const SpvOp opcode);
+
 // Determines if the given opcode is a constant. Returns zero if false, non-zero
 // otherwise.
 int32_t spvOpcodeIsConstant(const SpvOp opcode);


### PR DESCRIPTION
Fixes #1403

Don't validate composite insert, extract and construct instructions
against spec constant sized arrays.
* Added predicate for spec constant opcodes
* Added tests