### PR TITLE
Add missing function parameters in libspirv.h

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -377,12 +377,12 @@ typedef const spv_validator_options_t* spv_const_validator_options;
 // Returns the SPIRV-Tools software version as a null-terminated string.
 // The contents of the underlying storage is valid for the remainder of
 // the process.
-SPIRV_TOOLS_EXPORT const char* spvSoftwareVersionString();
+SPIRV_TOOLS_EXPORT const char* spvSoftwareVersionString(void);
 // Returns a null-terminated string containing the name of the project,
 // the software version string, and commit details.
 // The contents of the underlying storage is valid for the remainder of
 // the process.
-SPIRV_TOOLS_EXPORT const char* spvSoftwareVersionDetailsString();
+SPIRV_TOOLS_EXPORT const char* spvSoftwareVersionDetailsString(void);
 
 // Certain target environments impose additional restrictions on SPIR-V, so it's
 // often necessary to specify which one applies.  SPV_ENV_UNIVERSAL means
@@ -438,7 +438,7 @@ SPIRV_TOOLS_EXPORT void spvContextDestroy(spv_context context);
 // Creates a Validator options object with default options. Returns a valid
 // options object. The object remains valid until it is passed into
 // spvValidatorOptionsDestroy.
-SPIRV_TOOLS_EXPORT spv_validator_options spvValidatorOptionsCreate();
+SPIRV_TOOLS_EXPORT spv_validator_options spvValidatorOptionsCreate(void);
 
 // Destroys the given Validator options object.
 SPIRV_TOOLS_EXPORT void spvValidatorOptionsDestroy(

--- a/source/software_version.cpp
+++ b/source/software_version.cpp
@@ -22,6 +22,6 @@ const char* kBuildVersions[] = {
 
 }  // anonymous namespace
 
-const char* spvSoftwareVersionString() { return kBuildVersions[0]; }
+const char* spvSoftwareVersionString(void) { return kBuildVersions[0]; }
 
-const char* spvSoftwareVersionDetailsString() { return kBuildVersions[1]; }
+const char* spvSoftwareVersionDetailsString(void) { return kBuildVersions[1]; }

--- a/source/spirv_validator_options.cpp
+++ b/source/spirv_validator_options.cpp
@@ -46,7 +46,7 @@ bool spvParseUniversalLimitsOptions(const char* s, spv_validator_limit* type) {
   return true;
 }
 
-spv_validator_options spvValidatorOptionsCreate() {
+spv_validator_options spvValidatorOptionsCreate(void) {
   return new spv_validator_options_t;
 }
 


### PR DESCRIPTION
When building C code with gcc and the
-Wstrict-prototypes option, function declarations
and definitions that don't specify their argument
types generate warnings.  Functions that don't
take parameters need to specify (void) as their
parameter list, rather than leaving it empty.

Note this only applies to C, so only the functions
exported in C-compatible headers need fixing.  In
C++ functions can't be declared/defined without a
parameter list, so C++ can safely allow an empty
parameter list to imply (void).