### PR TITLE
Handle more cases in copy propagate arrays.

### DIFF
--- a/source/opt/copy_prop_arrays.h
+++ b/source/opt/copy_prop_arrays.h
@@ -185,6 +185,12 @@ class CopyPropagateArrays : public MemPass {
   // Return true if |UpdateUses| is able to change all of the uses of
   // |original_ptr_inst| to |type_id| and still have valid code.
   bool CanUpdateUses(ir::Instruction* original_ptr_inst, uint32_t type_id);
+
+  // Returns the id whose value is the same as |object_to_copy| except its type
+  // is |new_type_id|.  Any instructions need to generate this value will be
+  // inserted before |insertion_position|.
+  uint32_t GenerateCopy(ir::Instruction* object_to_copy, uint32_t new_type_id,
+                        ir::Instruction* insertion_position);
 };
 
 }  // namespace opt

--- a/test/opt/copy_prop_array_test.cpp
+++ b/test/opt/copy_prop_array_test.cpp
@@ -191,6 +191,179 @@ OpFunctionEnd
                         SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
   SinglePassRunAndMatch<opt::CopyPropagateArrays>(text, false);
 }
+
+// Test decomposing an object when we need to "rewrite" a store.
+TEST_F(CopyPropArrayPassTest, DecomposeObjectForArrayStore) {
+  const std::string text =
+      R"(               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %in_var_INDEX %out_var_SV_Target
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 600
+               OpName %type_MyCBuffer "type.MyCBuffer"
+               OpMemberName %type_MyCBuffer 0 "Data"
+               OpName %MyCBuffer "MyCBuffer"
+               OpName %main "main"
+               OpName %in_var_INDEX "in.var.INDEX"
+               OpName %out_var_SV_Target "out.var.SV_Target"
+               OpDecorate %_arr_v4float_uint_2 ArrayStride 16
+               OpDecorate %_arr__arr_v4float_uint_2_uint_2 ArrayStride 32
+               OpMemberDecorate %type_MyCBuffer 0 Offset 0
+               OpDecorate %type_MyCBuffer Block
+               OpDecorate %in_var_INDEX Flat
+               OpDecorate %in_var_INDEX Location 0
+               OpDecorate %out_var_SV_Target Location 0
+               OpDecorate %MyCBuffer DescriptorSet 0
+               OpDecorate %MyCBuffer Binding 0
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+       %uint = OpTypeInt 32 0
+     %uint_2 = OpConstant %uint 2
+%_arr_v4float_uint_2 = OpTypeArray %v4float %uint_2
+%_arr__arr_v4float_uint_2_uint_2 = OpTypeArray %_arr_v4float_uint_2 %uint_2
+%type_MyCBuffer = OpTypeStruct %_arr__arr_v4float_uint_2_uint_2
+%_ptr_Uniform_type_MyCBuffer = OpTypePointer Uniform %type_MyCBuffer
+       %void = OpTypeVoid
+         %14 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Input_int = OpTypePointer Input %int
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%_arr_v4float_uint_2_0 = OpTypeArray %v4float %uint_2
+%_arr__arr_v4float_uint_2_0_uint_2 = OpTypeArray %_arr_v4float_uint_2_0 %uint_2
+%_ptr_Function__arr__arr_v4float_uint_2_0_uint_2 = OpTypePointer Function %_arr__arr_v4float_uint_2_0_uint_2
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform__arr__arr_v4float_uint_2_uint_2 = OpTypePointer Uniform %_arr__arr_v4float_uint_2_uint_2
+%_ptr_Function__arr_v4float_uint_2_0 = OpTypePointer Function %_arr_v4float_uint_2_0
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+  %MyCBuffer = OpVariable %_ptr_Uniform_type_MyCBuffer Uniform
+%in_var_INDEX = OpVariable %_ptr_Input_int Input
+%out_var_SV_Target = OpVariable %_ptr_Output_v4float Output
+       %main = OpFunction %void None %14
+         %25 = OpLabel
+         %26 = OpVariable %_ptr_Function__arr_v4float_uint_2_0 Function
+         %27 = OpVariable %_ptr_Function__arr__arr_v4float_uint_2_0_uint_2 Function
+         %28 = OpLoad %int %in_var_INDEX
+         %29 = OpAccessChain %_ptr_Uniform__arr__arr_v4float_uint_2_uint_2 %MyCBuffer %int_0
+         %30 = OpLoad %_arr__arr_v4float_uint_2_uint_2 %29
+         %31 = OpCompositeExtract %_arr_v4float_uint_2 %30 0
+         %32 = OpCompositeExtract %v4float %31 0
+         %33 = OpCompositeExtract %v4float %31 1
+         %34 = OpCompositeConstruct %_arr_v4float_uint_2_0 %32 %33
+         %35 = OpCompositeExtract %_arr_v4float_uint_2 %30 1
+         %36 = OpCompositeExtract %v4float %35 0
+         %37 = OpCompositeExtract %v4float %35 1
+         %38 = OpCompositeConstruct %_arr_v4float_uint_2_0 %36 %37
+         %39 = OpCompositeConstruct %_arr__arr_v4float_uint_2_0_uint_2 %34 %38
+               OpStore %27 %39
+; CHECK: [[access_chain:%\w+]] = OpAccessChain %_ptr_Uniform__arr_v4float_uint_2
+         %40 = OpAccessChain %_ptr_Function__arr_v4float_uint_2_0 %27 %28
+; CHECK: [[load:%\w+]] = OpLoad %_arr_v4float_uint_2 [[access_chain]]
+         %41 = OpLoad %_arr_v4float_uint_2_0 %40
+; CHECK: [[extract1:%\w+]] = OpCompositeExtract %v4float [[load]] 0
+; CHECK: [[extract2:%\w+]] = OpCompositeExtract %v4float [[load]] 1
+; CHECK: [[construct:%\w+]] = OpCompositeConstruct %_arr_v4float_uint_2_0 [[extract1]] [[extract2]]
+; CHEKC: OpStore %26 [[construct]]
+               OpStore %26 %41
+         %42 = OpAccessChain %_ptr_Function_v4float %26 %28
+         %43 = OpLoad %v4float %42
+               OpStore %out_var_SV_Target %43
+               OpReturn
+               OpFunctionEnd
+)";
+
+  SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
+                        SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
+  SinglePassRunAndMatch<opt::CopyPropagateArrays>(text, false);
+}
+
+// Test decomposing an object when we need to "rewrite" a store.
+TEST_F(CopyPropArrayPassTest, DecomposeObjectForStructStore) {
+  const std::string text =
+      R"(               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %in_var_INDEX %out_var_SV_Target
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 600
+               OpName %type_MyCBuffer "type.MyCBuffer"
+               OpMemberName %type_MyCBuffer 0 "Data"
+               OpName %MyCBuffer "MyCBuffer"
+               OpName %main "main"
+               OpName %in_var_INDEX "in.var.INDEX"
+               OpName %out_var_SV_Target "out.var.SV_Target"
+               OpMemberDecorate %type_MyCBuffer 0 Offset 0
+               OpDecorate %type_MyCBuffer Block
+               OpDecorate %in_var_INDEX Flat
+               OpDecorate %in_var_INDEX Location 0
+               OpDecorate %out_var_SV_Target Location 0
+               OpDecorate %MyCBuffer DescriptorSet 0
+               OpDecorate %MyCBuffer Binding 0
+; CHECK: OpDecorate [[decorated_type:%\w+]] GLSLPacked
+               OpDecorate %struct GLSLPacked
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+       %uint = OpTypeInt 32 0
+     %uint_2 = OpConstant %uint 2
+; CHECK: [[decorated_type]] = OpTypeStruct
+%struct = OpTypeStruct %float %uint
+%_arr_struct_uint_2 = OpTypeArray %struct %uint_2
+%type_MyCBuffer = OpTypeStruct %_arr_struct_uint_2
+%_ptr_Uniform_type_MyCBuffer = OpTypePointer Uniform %type_MyCBuffer
+       %void = OpTypeVoid
+         %14 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Input_int = OpTypePointer Input %int
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+; CHECK: [[struct:%\w+]] = OpTypeStruct %float %uint
+%struct_0 = OpTypeStruct %float %uint
+%_arr_struct_0_uint_2 = OpTypeArray %struct_0 %uint_2
+%_ptr_Function__arr_struct_0_uint_2 = OpTypePointer Function %_arr_struct_0_uint_2
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform__arr_struct_uint_2 = OpTypePointer Uniform %_arr_struct_uint_2
+; CHECK: [[decorated_ptr:%\w+]] = OpTypePointer Uniform [[decorated_type]]
+%_ptr_Function_struct_0 = OpTypePointer Function %struct_0
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+  %MyCBuffer = OpVariable %_ptr_Uniform_type_MyCBuffer Uniform
+%in_var_INDEX = OpVariable %_ptr_Input_int Input
+%out_var_SV_Target = OpVariable %_ptr_Output_v4float Output
+       %main = OpFunction %void None %14
+         %25 = OpLabel
+         %26 = OpVariable %_ptr_Function_struct_0 Function
+         %27 = OpVariable %_ptr_Function__arr_struct_0_uint_2 Function
+         %28 = OpLoad %int %in_var_INDEX
+         %29 = OpAccessChain %_ptr_Uniform__arr_struct_uint_2 %MyCBuffer %int_0
+         %30 = OpLoad %_arr_struct_uint_2 %29
+         %31 = OpCompositeExtract %struct %30 0
+         %32 = OpCompositeExtract %v4float %31 0
+         %33 = OpCompositeExtract %v4float %31 1
+         %34 = OpCompositeConstruct %struct_0 %32 %33
+         %35 = OpCompositeExtract %struct %30 1
+         %36 = OpCompositeExtract %float %35 0
+         %37 = OpCompositeExtract %uint %35 1
+         %38 = OpCompositeConstruct %struct_0 %36 %37
+         %39 = OpCompositeConstruct %_arr_struct_0_uint_2 %34 %38
+               OpStore %27 %39
+; CHECK: [[access_chain:%\w+]] = OpAccessChain [[decorated_ptr]]
+         %40 = OpAccessChain %_ptr_Function_struct_0 %27 %28
+; CHECK: [[load:%\w+]] = OpLoad [[decorated_type]] [[access_chain]]
+         %41 = OpLoad %struct_0 %40
+; CHECK: [[extract1:%\w+]] = OpCompositeExtract %float [[load]] 0
+; CHECK: [[extract2:%\w+]] = OpCompositeExtract %uint [[load]] 1
+; CHECK: [[construct:%\w+]] = OpCompositeConstruct [[struct]] [[extract1]] [[extract2]]
+; CHEKC: OpStore %26 [[construct]]
+               OpStore %26 %41
+         %42 = OpAccessChain %_ptr_Function_v4float %26 %28
+         %43 = OpLoad %v4float %42
+               OpStore %out_var_SV_Target %43
+               OpReturn
+               OpFunctionEnd
+)";
+
+  SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
+                        SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
+  SinglePassRunAndMatch<opt::CopyPropagateArrays>(text, false);
+}
 #endif  // SPIRV_EFFCEE
 
 // This test will place a load before the store.  We cannot propagate in this
@@ -505,89 +678,6 @@ OpStore %23 %35
 OpStore %out_var_SV_Target %37
 OpReturn
 OpFunctionEnd
-)";
-
-  SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
-                        SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
-  auto result = SinglePassRunAndDisassemble<opt::CopyPropagateArrays>(
-      text, /* skip_nop = */ true, /* do_validation = */ false);
-
-  EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
-}
-
-// This test is okay except that we would have to change type of the store
-// "OpStore %26 %41".  We don't handle this yet.
-TEST_F(CopyPropArrayPassTest, CantRewriteStore) {
-  const std::string text =
-      R"(               OpCapability Shader
-               OpMemoryModel Logical GLSL450
-               OpEntryPoint Fragment %main "main" %in_var_INDEX %out_var_SV_Target
-               OpExecutionMode %main OriginUpperLeft
-               OpSource HLSL 600
-               OpName %type_MyCBuffer "type.MyCBuffer"
-               OpMemberName %type_MyCBuffer 0 "Data"
-               OpName %MyCBuffer "MyCBuffer"
-               OpName %main "main"
-               OpName %in_var_INDEX "in.var.INDEX"
-               OpName %out_var_SV_Target "out.var.SV_Target"
-               OpDecorate %_arr_v4float_uint_2 ArrayStride 16
-               OpDecorate %_arr__arr_v4float_uint_2_uint_2 ArrayStride 32
-               OpMemberDecorate %type_MyCBuffer 0 Offset 0
-               OpDecorate %type_MyCBuffer Block
-               OpDecorate %in_var_INDEX Flat
-               OpDecorate %in_var_INDEX Location 0
-               OpDecorate %out_var_SV_Target Location 0
-               OpDecorate %MyCBuffer DescriptorSet 0
-               OpDecorate %MyCBuffer Binding 0
-      %float = OpTypeFloat 32
-    %v4float = OpTypeVector %float 4
-       %uint = OpTypeInt 32 0
-     %uint_2 = OpConstant %uint 2
-%_arr_v4float_uint_2 = OpTypeArray %v4float %uint_2
-%_arr__arr_v4float_uint_2_uint_2 = OpTypeArray %_arr_v4float_uint_2 %uint_2
-%type_MyCBuffer = OpTypeStruct %_arr__arr_v4float_uint_2_uint_2
-%_ptr_Uniform_type_MyCBuffer = OpTypePointer Uniform %type_MyCBuffer
-       %void = OpTypeVoid
-         %14 = OpTypeFunction %void
-        %int = OpTypeInt 32 1
-%_ptr_Input_int = OpTypePointer Input %int
-%_ptr_Output_v4float = OpTypePointer Output %v4float
-%_arr_v4float_uint_2_0 = OpTypeArray %v4float %uint_2
-%_arr__arr_v4float_uint_2_0_uint_2 = OpTypeArray %_arr_v4float_uint_2_0 %uint_2
-%_ptr_Function__arr__arr_v4float_uint_2_0_uint_2 = OpTypePointer Function %_arr__arr_v4float_uint_2_0_uint_2
-      %int_0 = OpConstant %int 0
-%_ptr_Uniform__arr__arr_v4float_uint_2_uint_2 = OpTypePointer Uniform %_arr__arr_v4float_uint_2_uint_2
-%_ptr_Function__arr_v4float_uint_2_0 = OpTypePointer Function %_arr_v4float_uint_2_0
-%_ptr_Function_v4float = OpTypePointer Function %v4float
-  %MyCBuffer = OpVariable %_ptr_Uniform_type_MyCBuffer Uniform
-%in_var_INDEX = OpVariable %_ptr_Input_int Input
-%out_var_SV_Target = OpVariable %_ptr_Output_v4float Output
-       %main = OpFunction %void None %14
-         %25 = OpLabel
-         %26 = OpVariable %_ptr_Function__arr_v4float_uint_2_0 Function
-         %27 = OpVariable %_ptr_Function__arr__arr_v4float_uint_2_0_uint_2 Function
-         %28 = OpLoad %int %in_var_INDEX
-         %29 = OpAccessChain %_ptr_Uniform__arr__arr_v4float_uint_2_uint_2 %MyCBuffer %int_0
-         %30 = OpLoad %_arr__arr_v4float_uint_2_uint_2 %29
-         %31 = OpCompositeExtract %_arr_v4float_uint_2 %30 0
-         %32 = OpCompositeExtract %v4float %31 0
-         %33 = OpCompositeExtract %v4float %31 1
-         %34 = OpCompositeConstruct %_arr_v4float_uint_2_0 %32 %33
-         %35 = OpCompositeExtract %_arr_v4float_uint_2 %30 1
-         %36 = OpCompositeExtract %v4float %35 0
-         %37 = OpCompositeExtract %v4float %35 1
-         %38 = OpCompositeConstruct %_arr_v4float_uint_2_0 %36 %37
-         %39 = OpCompositeConstruct %_arr__arr_v4float_uint_2_0_uint_2 %34 %38
-               OpStore %27 %39
-         %40 = OpAccessChain %_ptr_Function__arr_v4float_uint_2_0 %27 %28
-         %41 = OpLoad %_arr_v4float_uint_2_0 %40
-               OpStore %26 %41
-         %42 = OpAccessChain %_ptr_Function_v4float %26 %28
-         %43 = OpLoad %v4float %42
-               OpStore %out_var_SV_Target %43
-               OpReturn
-               OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);


### PR DESCRIPTION
When we change the type of an object that gets stored, we do not want to
change the type of the memory location being stored to.  In order to
still be able to do the rewrite, we will decompose and rebuild the
object so it is the type that can be stored.