### PR TITLE
WIP New spirv-1.3 rules for control barrier

### DIFF
--- a/source/spirv_target_env.cpp
+++ b/source/spirv_target_env.cpp
@@ -39,9 +39,9 @@ const char* spvTargetEnvDescription(spv_target_env env) {
     case SPV_ENV_OPENCL_EMBEDDED_2_1:
       return "SPIR-V 1.0 (under OpenCL 2.1 Embedded Profile semantics)";
     case SPV_ENV_OPENCL_2_2:
-      return "SPIR-V 1.1 (under OpenCL 2.2 Full Profile semantics)";
+      return "SPIR-V 1.2 (under OpenCL 2.2 Full Profile semantics)";
     case SPV_ENV_OPENCL_EMBEDDED_2_2:
-      return "SPIR-V 1.1 (under OpenCL 2.2 Embedded Profile semantics)";
+      return "SPIR-V 1.2 (under OpenCL 2.2 Embedded Profile semantics)";
     case SPV_ENV_OPENGL_4_0:
       return "SPIR-V 1.0 (under OpenCL 4.0 semantics)";
     case SPV_ENV_OPENGL_4_1:

--- a/test/val/val_barriers_test.cpp
+++ b/test/val/val_barriers_test.cpp
@@ -202,17 +202,28 @@ OpControlBarrier %workgroup %workgroup %acquire_release_uniform_workgroup
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_0));
 }
 
-TEST_F(ValidateBarriers, OpControlBarrierExecutionModelFragment) {
+TEST_F(ValidateBarriers, OpControlBarrierExecutionModelFragmentSpirv12) {
   const std::string body = R"(
 OpControlBarrier %device %device %none
 )";
 
-  CompileSuccessfully(GenerateShaderCode(body, "", "Fragment"));
-  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  CompileSuccessfully(GenerateShaderCode(body, "", "Fragment"),
+                      SPV_ENV_UNIVERSAL_1_2);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_2));
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("OpControlBarrier requires one of the following Execution "
                 "Models: TessellationControl, GLCompute or Kernel"));
+}
+
+TEST_F(ValidateBarriers, OpControlBarrierExecutionModelFragmentSpirv13) {
+  const std::string body = R"(
+OpControlBarrier %device %device %none
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, "", "Fragment"),
+                      SPV_ENV_UNIVERSAL_1_3);
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
 }
 
 TEST_F(ValidateBarriers, OpControlBarrierFloatExecutionScope) {


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/1427

Adjusting validation to the new rule:
"Before version 1.3, it is only valid to use this instruction with
TessellationControl, GLCompute, or Kernel execution models.
There is no such restriction starting with version 1.3."

Also fixed wrong version numbers in source/spirv_target_env.cpp.