### PR TITLE
Stop asking for extensions if feature avaiable in core SPIR-V

### DIFF
--- a/source/validate_instruction.cpp
+++ b/source/validate_instruction.cpp
@@ -163,10 +163,15 @@ ExtensionSet RequiredExtensions(const ValidationState_t& state,
   if (state.grammar().lookupOperand(type, operand, &operand_desc) ==
       SPV_SUCCESS) {
     assert(operand_desc);
+    // If this operand is incorporated into core SPIR-V before or in the current
+    // target environment, we don't require extensions anymore.
+    if (static_cast<uint32_t>(state.context()->target_env) >=
+        operand_desc->minVersion)
+      return {};
     return {operand_desc->numExtensions, operand_desc->extensions};
   }
 
-  return ExtensionSet();
+  return {};
 }
 
 }  // namespace

--- a/source/validate_instruction.cpp
+++ b/source/validate_instruction.cpp
@@ -166,7 +166,7 @@ ExtensionSet RequiredExtensions(const ValidationState_t& state,
     assert(operand_desc);
     // If this operand is incorporated into core SPIR-V before or in the current
     // target environment, we don't require extensions anymore.
-    if (static_cast<uint32_t>(state.context()->target_env) >=
+    if (spvVersionForTargetEnv(state.grammar().target_env()) >=
         operand_desc->minVersion)
       return {};
     return {operand_desc->numExtensions, operand_desc->extensions};

--- a/test/val/val_extensions_test.cpp
+++ b/test/val/val_extensions_test.cpp
@@ -249,8 +249,7 @@ TEST_P(ValidateExtIntoCore, DoNotAskForExtensionInLaterVersion) {
                       GetParam().cap + R"(
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main" %builtin
-               OpDecorate %builtin BuiltIn )" +
-                      GetParam().builtin + R"(
+               OpDecorate %builtin BuiltIn )" + GetParam().builtin + R"(
        %void = OpTypeVoid
           %3 = OpTypeFunction %void
         %int = OpTypeInt 32 1


### PR DESCRIPTION
Migrating to unified grammar means we sometimes have two fields
for a certain feature: version and extensions. It means the feature
in question can be used either in SPIR-V of advanced-enough
versions or in any SPIR-V with with the specified extensions.

Validator now respects the above rules.