### PR TITLE
Handle non-constant accesses in memory objects (copy prop arrays)

### DIFF
--- a/source/opt/type_manager.cpp
+++ b/source/opt/type_manager.cpp
@@ -676,6 +676,9 @@ const Type* TypeManager::GetMemberType(
       parent_type = struct_type->element_types()[element_index];
     } else if (const analysis::Array* array_type = parent_type->AsArray()) {
       parent_type = array_type->element_type();
+    } else if (const analysis::RuntimeArray* runtime_array_type =
+                   parent_type->AsRuntimeArray()) {
+      parent_type = runtime_array_type->element_type();
     } else if (const analysis::Vector* vector_type = parent_type->AsVector()) {
       parent_type = vector_type->element_type();
     } else if (const analysis::Matrix* matrix_type = parent_type->AsMatrix()) {

--- a/test/opt/copy_prop_array_test.cpp
+++ b/test/opt/copy_prop_array_test.cpp
@@ -74,7 +74,7 @@ OpDecorate %MyCBuffer Binding 0
 ; CHECK: OpFunction
 ; CHECK: OpLabel
 ; CHECK: OpVariable
-; CHECK: [[new_address:%\w+]] = OpAccessChain %_ptr_Uniform__arr_v4float_uint_8 %MyCBuffer %uint_0
+; CHECK: [[new_address:%\w+]] = OpAccessChain %_ptr_Uniform__arr_v4float_uint_8 %MyCBuffer %int_0
 %main = OpFunction %void None %13
 %22 = OpLabel
 %23 = OpVariable %_ptr_Function__arr_v4float_uint_8_0 Function
@@ -156,7 +156,8 @@ OpDecorate %MyCBuffer Binding 0
 ; CHECK: OpLabel
 ; CHECK: OpVariable
 ; CHECK: OpVariable
-; CHECK: [[new_address:%\w+]] = OpAccessChain %_ptr_Uniform__arr__arr_v4float_uint_2_uint_2 %MyCBuffer %uint_0
+; CHECK: OpAccessChain
+; CHECK: [[new_address:%\w+]] = OpAccessChain %_ptr_Uniform__arr__arr_v4float_uint_2_uint_2 %MyCBuffer %int_0
 %main = OpFunction %void None %14
 %25 = OpLabel
 %26 = OpVariable %_ptr_Function__arr_v4float_uint_2_0 Function
@@ -174,13 +175,14 @@ OpDecorate %MyCBuffer Binding 0
 %38 = OpCompositeConstruct %_arr_v4float_uint_2_0 %36 %37
 %39 = OpCompositeConstruct %_arr__arr_v4float_uint_2_0_uint_2 %34 %38
 ; CHECK: OpStore
-; CHECK: [[ac1:%\w+]] = OpAccessChain %_ptr_Uniform__arr_v4float_uint_2 [[new_address]] %28
-; CHECK: [[ac2:%\w+]] = OpAccessChain %_ptr_Uniform_v4float [[ac1]] %28
-; CHECK: OpLoad %v4float [[ac2]]
 OpStore %27 %39
 %40 = OpAccessChain %_ptr_Function__arr_v4float_uint_2_0 %27 %28
 %42 = OpAccessChain %_ptr_Function_v4float %40 %28
 %43 = OpLoad %v4float %42
+; CHECK: [[ac1:%\w+]] = OpAccessChain %_ptr_Uniform__arr_v4float_uint_2 [[new_address]] %28
+; CHECK: [[ac2:%\w+]] = OpAccessChain %_ptr_Uniform_v4float [[ac1]] %28
+; CHECK: [[load:%\w+]] = OpLoad %v4float [[ac2]]
+; CHECK: OpStore %out_var_SV_Target [[load]]
 OpStore %out_var_SV_Target %43
 OpReturn
 OpFunctionEnd


### PR DESCRIPTION
The first implementation of MemroyObject, which is used in copy
propagate arrays, forced the access chain to be like the access chains
in OpCompositeExtract.  This excluded the possibility of the memory
object from representing an array element that was extracted with a
variable index.   Looking at the code, that restriction is not
neccessary.  I also see some opportunities for doing this in some real
shaders.

Contributes to #1430.