### PR TITLE
Use standard SPIR-V version scheme for version requirement

### DIFF
--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -106,7 +106,7 @@ spv_result_t spvOpcodeTableNameLookup(spv_target_env env,
     // Note that the second rule assumes the extension enabling this instruction
     // is indeed requested in the SPIR-V code; checking that should be
     // validator's work.
-    if ((static_cast<uint32_t>(env) >= entry.minVersion ||
+    if ((spvVersionForTargetEnv(env) >= entry.minVersion ||
          entry.numExtensions > 0u) &&
         nameLength == strlen(entry.name) &&
         !strncmp(name, entry.name, nameLength)) {
@@ -151,7 +151,7 @@ spv_result_t spvOpcodeTableValueLookup(spv_target_env env,
     // Note that the second rule assumes the extension enabling this instruction
     // is indeed requested in the SPIR-V code; checking that should be
     // validator's work.
-    if (static_cast<uint32_t>(env) >= it->minVersion ||
+    if (spvVersionForTargetEnv(env) >= it->minVersion ||
         it->numExtensions > 0u) {
       *pEntry = it;
       return SPV_SUCCESS;

--- a/source/operand.cpp
+++ b/source/operand.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 
 #include "macro.h"
+#include "spirv_constant.h"
 
 // For now, assume unified1 contains up to SPIR-V 1.3 and no later
 // SPIR-V version.
@@ -61,7 +62,7 @@ spv_result_t spvOperandTableNameLookup(spv_target_env env,
       // Note that the second rule assumes the extension enabling this operand
       // is indeed requested in the SPIR-V code; checking that should be
       // validator's work.
-      if ((static_cast<uint32_t>(env) >= entry.minVersion ||
+      if ((spvVersionForTargetEnv(env) >= entry.minVersion ||
            entry.numExtensions > 0u) &&
           nameLength == strlen(entry.name) &&
           !strncmp(entry.name, name, nameLength)) {
@@ -115,7 +116,7 @@ spv_result_t spvOperandTableValueLookup(spv_target_env env,
       // Note that the second rule assumes the extension enabling this operand
       // is indeed requested in the SPIR-V code; checking that should be
       // validator's work.
-      if (static_cast<uint32_t>(env) >= it->minVersion ||
+      if (spvVersionForTargetEnv(env) >= it->minVersion ||
           it->numExtensions > 0u) {
         *pEntry = it;
         return SPV_SUCCESS;

--- a/source/validate_instruction.cpp
+++ b/source/validate_instruction.cpp
@@ -29,6 +29,7 @@
 #include "extensions.h"
 #include "opcode.h"
 #include "operand.h"
+#include "spirv_constant.h"
 #include "spirv_definition.h"
 #include "spirv_target_env.h"
 #include "spirv_validator_options.h"
@@ -254,7 +255,7 @@ spv_result_t VersionCheck(ValidationState_t& _,
              << spvOpcodeString(opcode) << " is reserved for future use.";
     }
 
-    if (static_cast<uint32_t>(_.grammar().target_env()) < min_version) {
+    if (spvVersionForTargetEnv(_.grammar().target_env()) < min_version) {
       return _.diag(SPV_ERROR_WRONG_VERSION)
              << spvOpcodeString(opcode) << " requires "
              << spvTargetEnvDescription(

--- a/utils/generate_grammar_tables.py
+++ b/utils/generate_grammar_tables.py
@@ -81,10 +81,10 @@ def convert_min_required_version(version):
     """Converts the minimal required SPIR-V version encoded in the
     grammar to the symbol in SPIRV-Tools"""
     if version is None:
-        return 'SPV_ENV_UNIVERSAL_1_0'
+        return 'SPV_SPIRV_VERSION_WORD(1, 0)'
     if version == 'None':
         return '0xffffffffu'
-    return 'SPV_ENV_UNIVERSAL_{}'.format(version.replace('.', '_'))
+    return 'SPV_SPIRV_VERSION_WORD({})'.format(version.replace('.', ','))
 
 
 def compose_capability_list(caps):


### PR DESCRIPTION
Previously we use symbols in spv_target_env as the minimum version
requirements for features. That makes version check implicitly
relies on the order of entries in the spv_target_env enum, which
also contains client APIs. Instead, we should use the standard
scheme for constructing SPIR-V version; and by doing that we can
also map client API entries to universial SPIR-V versions.