### PR TITLE
In copy-prop-arrays, indentify copies via OpCompositeInsert

### DIFF
--- a/source/opt/copy_prop_arrays.h
+++ b/source/opt/copy_prop_arrays.h
@@ -121,6 +121,10 @@ class CopyPropagateArrays : public MemPass {
       return pointer_type->storage_class();
     }
 
+    // Returns true if |other| represents memory that is contains inside of the
+    // memory represented by |this|.
+    bool Contains(MemoryObject* other);
+
    private:
     // The variable that owns this memory object.
     ir::Instruction* variable_inst_;
@@ -170,10 +174,19 @@ class CopyPropagateArrays : public MemPass {
 
   // Returns the memory object that at some point was equivalent to the result
   // of |construct_inst|.  If a memory object cannot be identified, the return
-  // value is |nullptr|.  The opcode of |extract_inst| must be
+  // value is |nullptr|.  The opcode of |constuct_inst| must be
   // |OpCompositeConstruct|.
   std::unique_ptr<MemoryObject> BuildMemoryObjectFromCompositeConstruct(
       ir::Instruction* conststruct_inst);
+
+  // Returns the memory object that at some point was equivalent to the result
+  // of |insert_inst|.  If a memory object cannot be identified, the return
+  // value is |nullptr\.  The opcode of |insert_inst| must be
+  // |OpCompositeInsert|.  This function looks for a series of
+  // |OpCompositeInsert| instructions that insert the elements one at a time in
+  // order from beginning to end.
+  std::unique_ptr<MemoryObject> BuildMemoryObjectFromInsert(
+      ir::Instruction* insert_inst);
 
   // Return true if |type_id| is a pointer type whose pointee type is an array.
   bool IsPointerToArrayType(uint32_t type_id);

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -153,6 +153,7 @@ Optimizer& Optimizer::RegisterPerformancePasses() {
       .RegisterPass(CreateDeadBranchElimPass())
       .RegisterPass(CreateSimplificationPass())
       .RegisterPass(CreateIfConversionPass())
+      .RegisterPass(CreateCopyPropagateArraysPass())
       .RegisterPass(CreateAggressiveDCEPass())
       .RegisterPass(CreateBlockMergePass())
       .RegisterPass(CreateRedundancyEliminationPass())


### PR DESCRIPTION
When the original code copies an entire array or struct one element at a
time, this turns into a series of OpCompositeInsert instruction followed
by a store of the whole array.  We currently miss opportunities in copy
propagate arrays because we do not recognize this as a copy.

This commit adds code to copy propagate arrays to identify this code
pattern.

Also updates the performance passed to run array copy propagation.