### PR TITLE
 Add a loop peeling pass.

### DIFF
--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -483,6 +483,14 @@ Optimizer::PassToken CreateLocalRedundancyEliminationPass();
 // the loops preheader.
 Optimizer::PassToken CreateLoopInvariantCodeMotionPass();
 
+// Creates a loop peeling pass.
+// This pass will look for conditions inside a loop that are true or false only
+// for the N first or last iteration. For loop with such condition, those N
+// iterations of the loop will be executed outside of the main loop.
+// To limit code size explosion, the loop peeling can only happen if the code
+// size growth for each loop is under |code_growth_threshold|.
+Optimizer::PassToken CreateLoopPeelingPass();
+
 // Creates a loop unswitch pass.
 // This pass will look for loop independent branch conditions and move the
 // condition out of the loop and version the loop based on the taken branch.

--- a/source/opt/loop_descriptor.h
+++ b/source/opt/loop_descriptor.h
@@ -338,6 +338,9 @@ class Loop {
   // Returns nullptr if it can't be found.
   ir::Instruction* GetConditionInst() const;
 
+  // Returns the context associated this loop.
+  IRContext* GetContext() const { return context_; }
+
  private:
   IRContext* context_;
   // The block which marks the start of the loop.

--- a/source/opt/loop_peeling.h
+++ b/source/opt/loop_peeling.h
@@ -26,6 +26,8 @@
 #include "opt/ir_context.h"
 #include "opt/loop_descriptor.h"
 #include "opt/loop_utils.h"
+#include "opt/pass.h"
+#include "opt/scalar_analysis.h"
 
 namespace spvtools {
 namespace opt {
@@ -61,13 +63,6 @@ namespace opt {
 //   - The loop must not have any ambiguous iterators updates (see
 //     "CanPeelLoop").
 // The method "CanPeelLoop" checks that those constrained are met.
-//
-// FIXME(Victor): Allow the utility it accept an canonical induction variable
-// rather than automatically create one.
-// FIXME(Victor): When possible, evaluate the initial value of the second loop
-// iterating values rather than using the exit value of the first loop.
-// FIXME(Victor): Make the utility work-out the upper bound without having to
-// provide it. This should become easy once the scalar evolution is in.
 class LoopPeeling {
  public:
   // LoopPeeling constructor.
@@ -75,20 +70,33 @@ class LoopPeeling {
   // |loop_iteration_count| is the instruction holding the |loop| iteration
   // count, must be invariant for |loop| and must be of an int 32 type (signed
   // or unsigned).
-  LoopPeeling(ir::IRContext* context, ir::Loop* loop,
-              ir::Instruction* loop_iteration_count)
-      : context_(context),
-        loop_utils_(context, loop),
+  // |canonical_induction_variable| is an induction variable that can be used to
+  // count the number of iterations, must be of the same type as
+  // |loop_iteration_count| and start at 0 and increase by step of one at each
+  // iteration. The value nullptr is interpreted as no suitable variable exists
+  // and one will be created.
+  LoopPeeling(ir::Loop* loop, ir::Instruction* loop_iteration_count,
+              ir::Instruction* canonical_induction_variable = nullptr)
+      : context_(loop->GetContext()),
+        loop_utils_(loop->GetContext(), loop),
         loop_(loop),
         loop_iteration_count_(!loop->IsInsideLoop(loop_iteration_count)
                                   ? loop_iteration_count
                                   : nullptr),
         int_type_(nullptr),
+        original_loop_canonical_induction_variable_(
+            canonical_induction_variable),
         canonical_induction_variable_(nullptr) {
     if (loop_iteration_count_) {
       int_type_ = context_->get_type_mgr()
                       ->GetType(loop_iteration_count_->type_id())
                       ->AsInteger();
+      if (canonical_induction_variable_) {
+        assert(canonical_induction_variable_->type_id() ==
+                   loop_iteration_count_->type_id() &&
+               "loop_iteration_count and canonical_induction_variable do not "
+               "have the same type");
+      }
     }
     GetIteratingExitValues();
   }
@@ -164,11 +172,11 @@ class LoopPeeling {
   // This is set to true when the exit and back-edge branch instruction is the
   // same.
   bool do_while_form_;
-
+  // The canonical induction variable from the original loop if it exists.
+  ir::Instruction* original_loop_canonical_induction_variable_;
   // The canonical induction variable of the cloned loop. The induction variable
   // is initialized to 0 and incremented by step of 1.
   ir::Instruction* canonical_induction_variable_;
-
   // Map between loop iterators and exit values. Loop iterators
   std::unordered_map<uint32_t, ir::Instruction*> exit_value_;
 
@@ -179,7 +187,8 @@ class LoopPeeling {
 
   // Insert the canonical induction variable into the first loop as a simplified
   // counter.
-  void InsertCanonicalInductionVariable();
+  void InsertCanonicalInductionVariable(
+      LoopUtils::LoopCloningResult* clone_results);
 
   // Fixes the exit condition of the before loop. The function calls
   // |condition_builder| to get the condition to use in the conditional branch
@@ -215,6 +224,111 @@ class LoopPeeling {
   // The function returns the if block protecting the loop.
   ir::BasicBlock* ProtectLoop(ir::Loop* loop, ir::Instruction* condition,
                               ir::BasicBlock* if_merge);
+};
+
+// Implements a loop peeling optimization.
+// For each loop, the pass will try to peel it if there is conditions that
+// are true for the "N" first or last iterations of the loop.
+// To avoid code size explosion, too large loops will not be peeled.
+class LoopPeelingPass : public Pass {
+ public:
+  // Describes the peeling direction.
+  enum class PeelDirection {
+    kNone,    // Cannot peel
+    kBefore,  // Can peel before
+    kAfter    // Can peel last
+  };
+
+  // Holds some statistics about peeled function.
+  struct LoopPeelingStats {
+    std::vector<std::tuple<const ir::Loop*, PeelDirection, uint32_t>>
+        peeled_loops_;
+  };
+
+  LoopPeelingPass(LoopPeelingStats* stats = nullptr) : stats_(stats) {}
+
+  // Sets the loop peeling growth threshold. If the code size increase is above
+  // |code_grow_threshold|, the loop will not be peeled. The code size is
+  // measured in terms of SPIR-V instructions.
+  static void SetLoopPeelingThreshold(size_t code_grow_threshold) {
+    code_grow_threshold_ = code_grow_threshold;
+  }
+
+  // Returns the loop peeling code growth threshold.
+  static size_t GetLoopPeelingThreshold() { return code_grow_threshold_; }
+
+  const char* name() const override { return "loop-peeling"; }
+
+  // Processes the given |module|. Returns Status::Failure if errors occur when
+  // processing. Returns the corresponding Status::Success if processing is
+  // succesful to indicate whether changes have been made to the modue.
+  Pass::Status Process(ir::IRContext* context) override;
+
+ private:
+  // Describes the peeling direction.
+  enum class CmpOperator {
+    kLT,  // less than
+    kGT,  // greater than
+    kLE,  // less than or equal
+    kGE,  // greater than or equal
+  };
+
+  class LoopPeelingInfo {
+   public:
+    using Direction = std::pair<PeelDirection, uint32_t>;
+
+    LoopPeelingInfo(ir::Loop* loop, size_t loop_max_iterations,
+                    opt::ScalarEvolutionAnalysis* scev_analysis)
+        : context_(loop->GetContext()),
+          loop_(loop),
+          scev_analysis_(scev_analysis),
+          loop_max_iterations_(loop_max_iterations) {}
+
+    // Returns by how much and to which direction a loop should be peeled to
+    // make the conditional branch of the basic block |bb| an unconditional
+    // branch. If |bb|'s terminator is not a conditional branch or the condition
+    // is not workable then it returns PeelDirection::kNone and a 0 factor.
+    Direction GetPeelingInfo(ir::BasicBlock* bb) const;
+
+   private:
+    // Returns the id of the loop invariant operand of the conditional
+    // expression |condition|. It returns if no operand is invariant.
+    uint32_t GetFirstLoopInvariantOperand(ir::Instruction* condition) const;
+    // Returns the id of the non loop invariant operand of the conditional
+    // expression |condition|. It returns if all operands are invariant.
+    uint32_t GetFirstNonLoopInvariantOperand(ir::Instruction* condition) const;
+
+    // Returns the value of |rec| at the first loop iteration.
+    SExpression GetValueAtFirstIteration(SERecurrentNode* rec) const;
+    // Returns the value of |rec| at the given |iteration|.
+    SExpression GetValueAtIteration(SERecurrentNode* rec,
+                                    int64_t iteration) const;
+    // Returns the value of |rec| at the last loop iteration.
+    SExpression GetValueAtLastIteration(SERecurrentNode* rec) const;
+
+    bool EvalOperator(CmpOperator cmp_op, SExpression lhs, SExpression rhs,
+                      bool* result) const;
+
+    Direction HandleEquality(SExpression lhs, SExpression rhs) const;
+    Direction HandleInequality(CmpOperator cmp_op, SExpression lhs,
+                               SERecurrentNode* rhs) const;
+
+    static Direction GetNoneDirection() {
+      return Direction{LoopPeelingPass::PeelDirection::kNone, 0};
+    }
+    ir::IRContext* context_;
+    ir::Loop* loop_;
+    opt::ScalarEvolutionAnalysis* scev_analysis_;
+    size_t loop_max_iterations_;
+  };
+  // Peel profitable loops in |f|.
+  bool ProcessFunction(ir::Function* f);
+  // Peel |loop| if profitable.
+  std::pair<bool, ir::Loop*> ProcessLoop(ir::Loop* loop,
+                                         CodeMetrics* loop_size);
+
+  static size_t code_grow_threshold_;
+  LoopPeelingStats* stats_;
 };
 
 }  // namespace opt

--- a/source/opt/loop_utils.h
+++ b/source/opt/loop_utils.h
@@ -24,6 +24,19 @@ namespace spvtools {
 
 namespace opt {
 
+// Class to gather some metrics about a Region Of Interest (ROI).
+// So far it counts the number of instructions in a ROI (excluding debug
+// and label instructions) per basic block and in total.
+struct CodeMetrics {
+  void Analyze(const ir::Loop& loop);
+
+  // The number of instructions per basic block in the ROI.
+  std::unordered_map<uint32_t, size_t> block_sizes_;
+
+  // Number of instruction in the ROI.
+  size_t roi_size_;
+};
+
 // LoopUtils is used to encapsulte loop optimizations and from the passes which
 // use them. Any pass which needs a loop optimization should do it through this
 // or through a pass which is using this.

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -381,6 +381,11 @@ Optimizer::PassToken CreateLoopInvariantCodeMotionPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(MakeUnique<opt::LICMPass>());
 }
 
+Optimizer::PassToken CreateLoopPeelingPass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::LoopPeelingPass>());
+}
+
 Optimizer::PassToken CreateLoopUnswitchPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::LoopUnswitchPass>());

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -42,6 +42,7 @@
 #include "local_single_block_elim_pass.h"
 #include "local_single_store_elim_pass.h"
 #include "local_ssa_elim_pass.h"
+#include "loop_peeling.h"
 #include "loop_unroller.h"
 #include "loop_unswitch_pass.h"
 #include "merge_return_pass.h"

--- a/test/opt/loop_optimizations/CMakeLists.txt
+++ b/test/opt/loop_optimizations/CMakeLists.txt
@@ -91,6 +91,12 @@ add_spvtools_unittest(TARGET peeling_test
     LIBS SPIRV-Tools-opt
 )
 
+add_spvtools_unittest(TARGET peeling_pass_test
+    SRCS ../function_utils.h
+        peeling_pass.cpp
+    LIBS SPIRV-Tools-opt
+)
+
 add_spvtools_unittest(TARGET loop_dependence_analysis
     SRCS ../function_utils.h
         dependence_analysis.cpp

--- a/test/opt/loop_optimizations/peeling.cpp
+++ b/test/opt/loop_optimizations/peeling.cpp
@@ -134,7 +134,7 @@ TEST_F(PeelingTest, CannotPeel) {
       loop_count = builder.Add32BitSignedIntegerConstant(10);
     }
 
-    opt::LoopPeeling peel(context.get(), &*ld.begin(), loop_count);
+    opt::LoopPeeling peel(&*ld.begin(), loop_count);
     EXPECT_FALSE(peel.CanPeelLoop());
   };
   {
@@ -495,7 +495,7 @@ TEST_F(PeelingTest, SimplePeeling) {
     // Exit condition.
     ir::Instruction* ten_cst = builder.Add32BitSignedIntegerConstant(10);
 
-    opt::LoopPeeling peel(context.get(), &*ld.begin(), ten_cst);
+    opt::LoopPeeling peel(&*ld.begin(), ten_cst);
     EXPECT_TRUE(peel.CanPeelLoop());
     peel.PeelBefore(2);
 
@@ -549,7 +549,7 @@ CHECK-NEXT: OpLoopMerge
     // Exit condition.
     ir::Instruction* ten_cst = builder.Add32BitSignedIntegerConstant(10);
 
-    opt::LoopPeeling peel(context.get(), &*ld.begin(), ten_cst);
+    opt::LoopPeeling peel(&*ld.begin(), ten_cst);
     EXPECT_TRUE(peel.CanPeelLoop());
     peel.PeelAfter(2);
 
@@ -570,6 +570,114 @@ CHECK-NEXT: [[EXIT_COND:%\w+]] = OpSLessThan {{%\w+}} [[TMP]]
 CHECK-NEXT: OpBranchConditional [[EXIT_COND]] {{%\w+}} [[BEFORE_LOOP_MERGE]]
 CHECK:      [[I_1]] = OpIAdd {{%\w+}} [[I]]
 CHECK-NEXT: [[DUMMY_IT_1]] = OpIAdd {{%\w+}} [[DUMMY_IT]]
+CHECK-NEXT: OpBranch [[BEFORE_LOOP]]
+
+CHECK:      [[IF_MERGE]] = OpLabel
+CHECK-NEXT: [[TMP:%\w+]] = OpPhi {{%\w+}} [[I]] [[BEFORE_LOOP_MERGE]]
+CHECK-NEXT: OpBranch [[AFTER_LOOP:%\w+]]
+
+CHECK:      [[AFTER_LOOP]] = OpLabel
+CHECK-NEXT: OpPhi {{%\w+}} {{%\w+}} {{%\w+}} [[TMP]] [[IF_MERGE]]
+CHECK-NEXT: OpLoopMerge
+
+)";
+
+    Match(check, context.get());
+  }
+
+  // Same as above, but reuse the induction variable.
+  // Peel before.
+  {
+    SCOPED_TRACE("Peel before with IV reuse");
+
+    std::unique_ptr<ir::IRContext> context =
+        BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                    SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+    ir::Module* module = context->module();
+    EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
+                               << text << std::endl;
+    ir::Function& f = *module->begin();
+    ir::LoopDescriptor& ld = *context->GetLoopDescriptor(&f);
+
+    EXPECT_EQ(ld.NumLoops(), 1u);
+
+    opt::InstructionBuilder builder(context.get(), &*f.begin());
+    // Exit condition.
+    ir::Instruction* ten_cst = builder.Add32BitSignedIntegerConstant(10);
+
+    opt::LoopPeeling peel(&*ld.begin(), ten_cst,
+                          context->get_def_use_mgr()->GetDef(22));
+    EXPECT_TRUE(peel.CanPeelLoop());
+    peel.PeelBefore(2);
+
+    const std::string check = R"(
+CHECK: [[CST_TEN:%\w+]] = OpConstant {{%\w+}} 10
+CHECK: [[CST_TWO:%\w+]] = OpConstant {{%\w+}} 2
+CHECK:      OpFunction
+CHECK-NEXT: [[ENTRY:%\w+]] = OpLabel
+CHECK: [[MIN_LOOP_COUNT:%\w+]] = OpSLessThan {{%\w+}} [[CST_TWO]] [[CST_TEN]]
+CHECK-NEXT: [[LOOP_COUNT:%\w+]] = OpSelect {{%\w+}} [[MIN_LOOP_COUNT]] [[CST_TWO]] [[CST_TEN]]
+CHECK:      [[BEFORE_LOOP:%\w+]] = OpLabel
+CHECK-NEXT: [[i:%\w+]] = OpPhi {{%\w+}} {{%\w+}} [[ENTRY]] [[I_1:%\w+]] [[BE:%\w+]]
+CHECK-NEXT: OpLoopMerge [[AFTER_LOOP_PREHEADER:%\w+]] [[BE]] None
+CHECK:      [[COND_BLOCK:%\w+]] = OpLabel
+CHECK-NEXT: OpSLessThan
+CHECK-NEXT: [[EXIT_COND:%\w+]] = OpSLessThan {{%\w+}} [[i]]
+CHECK-NEXT: OpBranchConditional [[EXIT_COND]] {{%\w+}} [[AFTER_LOOP_PREHEADER]]
+CHECK:      [[I_1]] = OpIAdd {{%\w+}} [[i]]
+CHECK-NEXT: OpBranch [[BEFORE_LOOP]]
+
+CHECK: [[AFTER_LOOP_PREHEADER]] = OpLabel
+CHECK-NEXT: OpSelectionMerge [[IF_MERGE:%\w+]]
+CHECK-NEXT: OpBranchConditional [[MIN_LOOP_COUNT]] [[AFTER_LOOP:%\w+]] [[IF_MERGE]]
+
+CHECK:      [[AFTER_LOOP]] = OpLabel
+CHECK-NEXT: OpPhi {{%\w+}} {{%\w+}} {{%\w+}} [[i]] [[AFTER_LOOP_PREHEADER]]
+CHECK-NEXT: OpLoopMerge
+)";
+
+    Match(check, context.get());
+  }
+
+  // Peel after.
+  {
+    SCOPED_TRACE("Peel after IV reuse");
+
+    std::unique_ptr<ir::IRContext> context =
+        BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                    SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+    ir::Module* module = context->module();
+    EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
+                               << text << std::endl;
+    ir::Function& f = *module->begin();
+    ir::LoopDescriptor& ld = *context->GetLoopDescriptor(&f);
+
+    EXPECT_EQ(ld.NumLoops(), 1u);
+
+    opt::InstructionBuilder builder(context.get(), &*f.begin());
+    // Exit condition.
+    ir::Instruction* ten_cst = builder.Add32BitSignedIntegerConstant(10);
+
+    opt::LoopPeeling peel(&*ld.begin(), ten_cst,
+                          context->get_def_use_mgr()->GetDef(22));
+    EXPECT_TRUE(peel.CanPeelLoop());
+    peel.PeelAfter(2);
+
+    const std::string check = R"(
+CHECK:      OpFunction
+CHECK-NEXT: [[ENTRY:%\w+]] = OpLabel
+CHECK:      [[MIN_LOOP_COUNT:%\w+]] = OpSLessThan {{%\w+}}
+CHECK-NEXT: OpSelectionMerge [[IF_MERGE:%\w+]]
+CHECK-NEXT: OpBranchConditional [[MIN_LOOP_COUNT]] [[BEFORE_LOOP:%\w+]] [[IF_MERGE]]
+CHECK:      [[BEFORE_LOOP]] = OpLabel
+CHECK-NEXT: [[I:%\w+]] = OpPhi {{%\w+}} {{%\w+}} [[ENTRY]] [[I_1:%\w+]] [[BE:%\w+]]
+CHECK-NEXT: OpLoopMerge [[BEFORE_LOOP_MERGE:%\w+]] [[BE]] None
+CHECK:      [[COND_BLOCK:%\w+]] = OpLabel
+CHECK-NEXT: OpSLessThan
+CHECK-NEXT: [[TMP:%\w+]] = OpIAdd {{%\w+}} [[I]] {{%\w+}}
+CHECK-NEXT: [[EXIT_COND:%\w+]] = OpSLessThan {{%\w+}} [[TMP]]
+CHECK-NEXT: OpBranchConditional [[EXIT_COND]] {{%\w+}} [[BEFORE_LOOP_MERGE]]
+CHECK:      [[I_1]] = OpIAdd {{%\w+}} [[I]]
 CHECK-NEXT: OpBranch [[BEFORE_LOOP]]
 
 CHECK:      [[IF_MERGE]] = OpLabel
@@ -658,7 +766,7 @@ TEST_F(PeelingTest, PeelingUncountable) {
     ir::Instruction* loop_count = context->get_def_use_mgr()->GetDef(16);
     EXPECT_EQ(loop_count->opcode(), SpvOpLoad);
 
-    opt::LoopPeeling peel(context.get(), &*ld.begin(), loop_count);
+    opt::LoopPeeling peel(&*ld.begin(), loop_count);
     EXPECT_TRUE(peel.CanPeelLoop());
     peel.PeelBefore(1);
 
@@ -710,7 +818,7 @@ CHECK-NEXT: OpLoopMerge
     ir::Instruction* loop_count = context->get_def_use_mgr()->GetDef(16);
     EXPECT_EQ(loop_count->opcode(), SpvOpLoad);
 
-    opt::LoopPeeling peel(context.get(), &*ld.begin(), loop_count);
+    opt::LoopPeeling peel(&*ld.begin(), loop_count);
     EXPECT_TRUE(peel.CanPeelLoop());
     peel.PeelAfter(1);
 
@@ -811,7 +919,7 @@ TEST_F(PeelingTest, DoWhilePeeling) {
     // Exit condition.
     ir::Instruction* ten_cst = builder.Add32BitUnsignedIntegerConstant(10);
 
-    opt::LoopPeeling peel(context.get(), &*ld.begin(), ten_cst);
+    opt::LoopPeeling peel(&*ld.begin(), ten_cst);
     EXPECT_TRUE(peel.CanPeelLoop());
     peel.PeelBefore(2);
 
@@ -861,7 +969,7 @@ CHECK-NEXT: OpLoopMerge
     // Exit condition.
     ir::Instruction* ten_cst = builder.Add32BitUnsignedIntegerConstant(10);
 
-    opt::LoopPeeling peel(context.get(), &*ld.begin(), ten_cst);
+    opt::LoopPeeling peel(&*ld.begin(), ten_cst);
     EXPECT_TRUE(peel.CanPeelLoop());
     peel.PeelAfter(2);
 
@@ -983,7 +1091,7 @@ TEST_F(PeelingTest, PeelingLoopWithStore) {
     ir::Instruction* loop_count = context->get_def_use_mgr()->GetDef(15);
     EXPECT_EQ(loop_count->opcode(), SpvOpLoad);
 
-    opt::LoopPeeling peel(context.get(), &*ld.begin(), loop_count);
+    opt::LoopPeeling peel(&*ld.begin(), loop_count);
     EXPECT_TRUE(peel.CanPeelLoop());
     peel.PeelBefore(1);
 
@@ -1035,7 +1143,7 @@ CHECK-NEXT: OpLoopMerge
     ir::Instruction* loop_count = context->get_def_use_mgr()->GetDef(15);
     EXPECT_EQ(loop_count->opcode(), SpvOpLoad);
 
-    opt::LoopPeeling peel(context.get(), &*ld.begin(), loop_count);
+    opt::LoopPeeling peel(&*ld.begin(), loop_count);
     EXPECT_TRUE(peel.CanPeelLoop());
     peel.PeelAfter(1);
 

--- a/test/opt/loop_optimizations/peeling_pass.cpp
+++ b/test/opt/loop_optimizations/peeling_pass.cpp
@@ -1,0 +1,1095 @@
+// Copyright (c) 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include "../pass_fixture.h"
+#include "opt/ir_builder.h"
+#include "opt/loop_descriptor.h"
+#include "opt/loop_peeling.h"
+
+namespace {
+
+using namespace spvtools;
+
+class PeelingTest : public PassTest<::testing::Test> {
+ public:
+  // Generic routine to run the loop peeling pass and check
+  opt::LoopPeelingPass::LoopPeelingStats AssembleAndRunPeelingTest(
+      const std::string& text_head, const std::string& text_tail, SpvOp opcode,
+      const std::string& res_id, const std::string& op1,
+      const std::string& op2) {
+    std::string opcode_str;
+    switch (opcode) {
+      case SpvOpSLessThan:
+        opcode_str = "OpSLessThan";
+        break;
+      case SpvOpSGreaterThan:
+        opcode_str = "OpSGreaterThan";
+        break;
+      case SpvOpSLessThanEqual:
+        opcode_str = "OpSLessThanEqual";
+        break;
+      case SpvOpSGreaterThanEqual:
+        opcode_str = "OpSGreaterThanEqual";
+        break;
+      case SpvOpIEqual:
+        opcode_str = "OpIEqual";
+        break;
+      case SpvOpINotEqual:
+        opcode_str = "OpINotEqual";
+        break;
+      default:
+        assert(false && "Unhandled");
+        break;
+    }
+    std::string test_cond =
+        res_id + " = " + opcode_str + "  %bool " + op1 + " " + op2 + "\n";
+
+    opt::LoopPeelingPass::LoopPeelingStats stats;
+    SinglePassRunAndDisassemble<opt::LoopPeelingPass>(
+        text_head + test_cond + text_tail, true, true, &stats);
+
+    return stats;
+  }
+
+  // Generic routine to run the loop peeling pass and check
+  opt::LoopPeelingPass::LoopPeelingStats RunPeelingTest(
+      const std::string& text_head, const std::string& text_tail, SpvOp opcode,
+      const std::string& res_id, const std::string& op1, const std::string& op2,
+      size_t nb_of_loops) {
+    opt::LoopPeelingPass::LoopPeelingStats stats = AssembleAndRunPeelingTest(
+        text_head, text_tail, opcode, res_id, op1, op2);
+
+    ir::Function& f = *context()->module()->begin();
+    ir::LoopDescriptor& ld = *context()->GetLoopDescriptor(&f);
+    EXPECT_EQ(ld.NumLoops(), nb_of_loops);
+
+    return stats;
+  }
+
+  using PeelTraceType =
+      std::vector<std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t>>;
+
+  void BuildAndCheckTrace(const std::string& text_head,
+                          const std::string& text_tail, SpvOp opcode,
+                          const std::string& res_id, const std::string& op1,
+                          const std::string& op2,
+                          const PeelTraceType& expected_peel_trace,
+                          size_t expected_nb_of_loops) {
+    auto stats = RunPeelingTest(text_head, text_tail, opcode, res_id, op1, op2,
+                                expected_nb_of_loops);
+
+    EXPECT_EQ(stats.peeled_loops_.size(), expected_peel_trace.size());
+    if (stats.peeled_loops_.size() != expected_peel_trace.size()) {
+      return;
+    }
+
+    PeelTraceType::const_iterator expected_trace_it =
+        expected_peel_trace.begin();
+    decltype(stats.peeled_loops_)::const_iterator stats_it =
+        stats.peeled_loops_.begin();
+
+    while (expected_trace_it != expected_peel_trace.end()) {
+      EXPECT_EQ(expected_trace_it->first, std::get<1>(*stats_it));
+      EXPECT_EQ(expected_trace_it->second, std::get<2>(*stats_it));
+      ++expected_trace_it;
+      ++stats_it;
+    }
+  }
+};
+
+/*
+Test are derivation of the following generated test from the following GLSL +
+--eliminate-local-multi-store
+
+#version 330 core
+void main() {
+  int a = 0;
+  for(int i = 1; i < 10; i += 2) {
+    if (i < 3) {
+      a += 2;
+    }
+  }
+}
+
+The condition is interchanged to test < > <= >= == and peel before/after
+opportunities.
+*/
+TEST_F(PeelingTest, PeelingPassBasic) {
+  const std::string text_head = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginLowerLeft
+               OpSource GLSL 330
+               OpName %main "main"
+               OpName %a "a"
+               OpName %i "i"
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+       %bool = OpTypeBool
+     %int_20 = OpConstant %int 20
+     %int_19 = OpConstant %int 19
+     %int_18 = OpConstant %int 18
+     %int_17 = OpConstant %int 17
+     %int_16 = OpConstant %int 16
+     %int_15 = OpConstant %int 15
+     %int_14 = OpConstant %int 14
+     %int_13 = OpConstant %int 13
+     %int_12 = OpConstant %int 12
+     %int_11 = OpConstant %int 11
+     %int_10 = OpConstant %int 10
+      %int_9 = OpConstant %int 9
+      %int_8 = OpConstant %int 8
+      %int_7 = OpConstant %int 7
+      %int_6 = OpConstant %int 6
+      %int_5 = OpConstant %int 5
+      %int_4 = OpConstant %int 4
+      %int_3 = OpConstant %int 3
+      %int_2 = OpConstant %int 2
+      %int_1 = OpConstant %int 1
+      %int_0 = OpConstant %int 0
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %a = OpVariable %_ptr_Function_int Function
+          %i = OpVariable %_ptr_Function_int Function
+               OpStore %a %int_0
+               OpStore %i %int_0
+               OpBranch %11
+         %11 = OpLabel
+         %31 = OpPhi %int %int_0 %5 %33 %14
+         %32 = OpPhi %int %int_1 %5 %30 %14
+               OpLoopMerge %13 %14 None
+               OpBranch %15
+         %15 = OpLabel
+         %19 = OpSLessThan %bool %32 %int_20
+               OpBranchConditional %19 %12 %13
+         %12 = OpLabel
+  )";
+  const std::string text_tail = R"(
+               OpSelectionMerge %24 None
+               OpBranchConditional %22 %23 %24
+         %23 = OpLabel
+         %27 = OpIAdd %int %31 %int_2
+               OpStore %a %27
+               OpBranch %24
+         %24 = OpLabel
+         %33 = OpPhi %int %31 %12 %27 %23
+               OpBranch %14
+         %14 = OpLabel
+         %30 = OpIAdd %int %32 %int_2
+               OpStore %i %30
+               OpBranch %11
+         %13 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  auto run_test = [&text_head, &text_tail, this](SpvOp opcode,
+                                                 const std::string& op1,
+                                                 const std::string& op2) {
+    auto stats =
+        RunPeelingTest(text_head, text_tail, opcode, "%22", op1, op2, 2);
+
+    EXPECT_EQ(stats.peeled_loops_.size(), 1u);
+    if (stats.peeled_loops_.size() != 1u)
+      return std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t>{
+          opt::LoopPeelingPass::PeelDirection::kNone, 0};
+
+    return std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t>{
+        std::get<1>(*stats.peeled_loops_.begin()),
+        std::get<2>(*stats.peeled_loops_.begin())};
+  };
+
+  // Test LT
+  // Peel before by a factor of 2.
+  {
+    SCOPED_TRACE("Peel before iv < 4");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSLessThan, "%32", "%int_4");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kBefore);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel before 4 > iv");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSGreaterThan, "%int_4", "%32");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kBefore);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel before iv < 5");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSLessThan, "%32", "%int_5");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kBefore);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel before 5 > iv");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSGreaterThan, "%int_5", "%32");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kBefore);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+
+  // Peel after by a factor of 2.
+  {
+    SCOPED_TRACE("Peel after iv < 16");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSLessThan, "%32", "%int_16");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kAfter);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel after 16 > iv");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSGreaterThan, "%int_16", "%32");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kAfter);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel after iv < 17");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSLessThan, "%32", "%int_17");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kAfter);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel after 17 > iv");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSGreaterThan, "%int_17", "%32");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kAfter);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+
+  // Test GT
+  // Peel before by a factor of 2.
+  {
+    SCOPED_TRACE("Peel before iv > 5");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSGreaterThan, "%32", "%int_5");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kBefore);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel before 5 < iv");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSLessThan, "%int_5", "%32");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kBefore);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel before iv > 4");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSGreaterThan, "%32", "%int_4");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kBefore);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel before 4 < iv");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSLessThan, "%int_4", "%32");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kBefore);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+
+  // Peel after by a factor of 2.
+  {
+    SCOPED_TRACE("Peel after iv > 16");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSGreaterThan, "%32", "%int_16");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kAfter);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel after 16 < iv");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSLessThan, "%int_16", "%32");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kAfter);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel after iv > 17");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSGreaterThan, "%32", "%int_17");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kAfter);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel after 17 < iv");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSLessThan, "%int_17", "%32");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kAfter);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+
+  // Test LE
+  // Peel before by a factor of 2.
+  {
+    SCOPED_TRACE("Peel before iv <= 4");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSLessThanEqual, "%32", "%int_4");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kBefore);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel before 4 => iv");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSGreaterThanEqual, "%int_4", "%32");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kBefore);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel before iv <= 3");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSLessThanEqual, "%32", "%int_3");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kBefore);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel before 3 => iv");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSGreaterThanEqual, "%int_3", "%32");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kBefore);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+
+  // Peel after by a factor of 2.
+  {
+    SCOPED_TRACE("Peel after iv <= 16");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSLessThanEqual, "%32", "%int_16");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kAfter);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel after 16 => iv");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSGreaterThanEqual, "%int_16", "%32");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kAfter);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel after iv <= 15");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSLessThanEqual, "%32", "%int_15");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kAfter);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel after 15 => iv");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSGreaterThanEqual, "%int_15", "%32");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kAfter);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+
+  // Test GE
+  // Peel before by a factor of 2.
+  {
+    SCOPED_TRACE("Peel before iv >= 5");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSGreaterThanEqual, "%32", "%int_5");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kBefore);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel before 35 >= iv");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSLessThanEqual, "%int_5", "%32");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kBefore);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel before iv >= 4");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSGreaterThanEqual, "%32", "%int_4");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kBefore);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel before 4 <= iv");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSLessThanEqual, "%int_4", "%32");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kBefore);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+
+  // Peel after by a factor of 2.
+  {
+    SCOPED_TRACE("Peel after iv >= 17");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSGreaterThanEqual, "%32", "%int_17");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kAfter);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel after 17 <= iv");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSLessThanEqual, "%int_17", "%32");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kAfter);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel after iv >= 16");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSGreaterThanEqual, "%32", "%int_16");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kAfter);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+  {
+    SCOPED_TRACE("Peel after 16 <= iv");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpSLessThanEqual, "%int_16", "%32");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kAfter);
+    EXPECT_EQ(peel_info.second, 2u);
+  }
+
+  // Test EQ
+  // Peel before by a factor of 1.
+  {
+    SCOPED_TRACE("Peel before iv == 1");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpIEqual, "%32", "%int_1");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kBefore);
+    EXPECT_EQ(peel_info.second, 1u);
+  }
+  {
+    SCOPED_TRACE("Peel before 1 == iv");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpIEqual, "%int_1", "%32");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kBefore);
+    EXPECT_EQ(peel_info.second, 1u);
+  }
+
+  // Peel after by a factor of 1.
+  {
+    SCOPED_TRACE("Peel after iv == 19");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpIEqual, "%32", "%int_19");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kAfter);
+    EXPECT_EQ(peel_info.second, 1u);
+  }
+  {
+    SCOPED_TRACE("Peel after 19 == iv");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpIEqual, "%int_19", "%32");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kAfter);
+    EXPECT_EQ(peel_info.second, 1u);
+  }
+
+  // Test NE
+  // Peel before by a factor of 1.
+  {
+    SCOPED_TRACE("Peel before iv != 1");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpINotEqual, "%32", "%int_1");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kBefore);
+    EXPECT_EQ(peel_info.second, 1u);
+  }
+  {
+    SCOPED_TRACE("Peel before 1 != iv");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpINotEqual, "%int_1", "%32");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kBefore);
+    EXPECT_EQ(peel_info.second, 1u);
+  }
+
+  // Peel after by a factor of 1.
+  {
+    SCOPED_TRACE("Peel after iv != 19");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpINotEqual, "%32", "%int_19");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kAfter);
+    EXPECT_EQ(peel_info.second, 1u);
+  }
+  {
+    SCOPED_TRACE("Peel after 19 != iv");
+
+    std::pair<opt::LoopPeelingPass::PeelDirection, uint32_t> peel_info =
+        run_test(SpvOpINotEqual, "%int_19", "%32");
+    EXPECT_EQ(peel_info.first, opt::LoopPeelingPass::PeelDirection::kAfter);
+    EXPECT_EQ(peel_info.second, 1u);
+  }
+
+  // No peel.
+  {
+    SCOPED_TRACE("No Peel: 20 => iv");
+
+    auto stats = RunPeelingTest(text_head, text_tail, SpvOpSLessThanEqual,
+                                "%22", "%int_20", "%32", 1);
+
+    EXPECT_EQ(stats.peeled_loops_.size(), 0u);
+  }
+}
+
+/*
+Test are derivation of the following generated test from the following GLSL +
+--eliminate-local-multi-store
+
+#version 330 core
+void main() {
+  int a = 0;
+  for(int i = 0; i < 10; ++i) {
+    if (i < 3) {
+      a += 2;
+    }
+    if (i < 1) {
+      a += 2;
+    }
+  }
+}
+
+The condition is interchanged to test < > <= >= == and peel before/after
+opportunities.
+*/
+TEST_F(PeelingTest, MultiplePeelingPass) {
+  const std::string text_head = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginLowerLeft
+               OpSource GLSL 330
+               OpName %main "main"
+               OpName %a "a"
+               OpName %i "i"
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+       %bool = OpTypeBool
+     %int_10 = OpConstant %int 10
+      %int_9 = OpConstant %int 9
+      %int_8 = OpConstant %int 8
+      %int_7 = OpConstant %int 7
+      %int_6 = OpConstant %int 6
+      %int_5 = OpConstant %int 5
+      %int_4 = OpConstant %int 4
+      %int_3 = OpConstant %int 3
+      %int_2 = OpConstant %int 2
+      %int_1 = OpConstant %int 1
+      %int_0 = OpConstant %int 0
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %a = OpVariable %_ptr_Function_int Function
+          %i = OpVariable %_ptr_Function_int Function
+               OpStore %a %int_0
+               OpStore %i %int_0
+               OpBranch %11
+         %11 = OpLabel
+         %37 = OpPhi %int %int_0 %5 %40 %14
+         %38 = OpPhi %int %int_0 %5 %36 %14
+               OpLoopMerge %13 %14 None
+               OpBranch %15
+         %15 = OpLabel
+         %19 = OpSLessThan %bool %38 %int_10
+               OpBranchConditional %19 %12 %13
+         %12 = OpLabel
+  )";
+  const std::string text_tail = R"(
+               OpSelectionMerge %24 None
+               OpBranchConditional %22 %23 %24
+         %23 = OpLabel
+         %27 = OpIAdd %int %37 %int_2
+               OpStore %a %27
+               OpBranch %24
+         %24 = OpLabel
+         %39 = OpPhi %int %37 %12 %27 %23
+         %30 = OpSLessThan %bool %38 %int_1
+               OpSelectionMerge %32 None
+               OpBranchConditional %30 %31 %32
+         %31 = OpLabel
+         %34 = OpIAdd %int %39 %int_2
+               OpStore %a %34
+               OpBranch %32
+         %32 = OpLabel
+         %40 = OpPhi %int %39 %24 %34 %31
+               OpBranch %14
+         %14 = OpLabel
+         %36 = OpIAdd %int %38 %int_1
+               OpStore %i %36
+               OpBranch %11
+         %13 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  auto run_test = [&text_head, &text_tail, this](
+                      SpvOp opcode, const std::string& op1,
+                      const std::string& op2,
+                      const PeelTraceType& expected_peel_trace) {
+    BuildAndCheckTrace(text_head, text_tail, opcode, "%22", op1, op2,
+                       expected_peel_trace, expected_peel_trace.size() + 1);
+  };
+
+  // Test LT
+  // Peel before by a factor of 3.
+  {
+    SCOPED_TRACE("Peel before iv < 3");
+
+    run_test(SpvOpSLessThan, "%38", "%int_3",
+             {{opt::LoopPeelingPass::PeelDirection::kBefore, 3u}});
+  }
+  {
+    SCOPED_TRACE("Peel before 3 > iv");
+
+    run_test(SpvOpSGreaterThan, "%int_3", "%38",
+             {{opt::LoopPeelingPass::PeelDirection::kBefore, 3u}});
+  }
+
+  // Peel after by a factor of 2.
+  {
+    SCOPED_TRACE("Peel after iv < 8");
+
+    run_test(SpvOpSLessThan, "%38", "%int_8",
+             {{opt::LoopPeelingPass::PeelDirection::kAfter, 2u}});
+  }
+  {
+    SCOPED_TRACE("Peel after 8 > iv");
+
+    run_test(SpvOpSGreaterThan, "%int_8", "%38",
+             {{opt::LoopPeelingPass::PeelDirection::kAfter, 2u}});
+  }
+
+  // Test GT
+  // Peel before by a factor of 2.
+  {
+    SCOPED_TRACE("Peel before iv > 2");
+
+    run_test(SpvOpSGreaterThan, "%38", "%int_2",
+             {{opt::LoopPeelingPass::PeelDirection::kBefore, 2u}});
+  }
+  {
+    SCOPED_TRACE("Peel before 2 < iv");
+
+    run_test(SpvOpSLessThan, "%int_2", "%38",
+             {{opt::LoopPeelingPass::PeelDirection::kBefore, 2u}});
+  }
+
+  // Peel after by a factor of 3.
+  {
+    SCOPED_TRACE("Peel after iv > 7");
+
+    run_test(SpvOpSGreaterThan, "%38", "%int_7",
+             {{opt::LoopPeelingPass::PeelDirection::kAfter, 3u}});
+  }
+  {
+    SCOPED_TRACE("Peel after 7 < iv");
+
+    run_test(SpvOpSLessThan, "%int_7", "%38",
+             {{opt::LoopPeelingPass::PeelDirection::kAfter, 3u}});
+  }
+
+  // Test LE
+  // Peel before by a factor of 2.
+  {
+    SCOPED_TRACE("Peel before iv <= 1");
+
+    run_test(SpvOpSLessThanEqual, "%38", "%int_1",
+             {{opt::LoopPeelingPass::PeelDirection::kBefore, 2u}});
+  }
+  {
+    SCOPED_TRACE("Peel before 1 => iv");
+
+    run_test(SpvOpSGreaterThanEqual, "%int_1", "%38",
+             {{opt::LoopPeelingPass::PeelDirection::kBefore, 2u}});
+  }
+
+  // Peel after by a factor of 2.
+  {
+    SCOPED_TRACE("Peel after iv <= 7");
+
+    run_test(SpvOpSLessThanEqual, "%38", "%int_7",
+             {{opt::LoopPeelingPass::PeelDirection::kAfter, 2u}});
+  }
+  {
+    SCOPED_TRACE("Peel after 7 => iv");
+
+    run_test(SpvOpSGreaterThanEqual, "%int_7", "%38",
+             {{opt::LoopPeelingPass::PeelDirection::kAfter, 2u}});
+  }
+
+  // Test GE
+  // Peel before by a factor of 2.
+  {
+    SCOPED_TRACE("Peel before iv >= 2");
+
+    run_test(SpvOpSGreaterThanEqual, "%38", "%int_2",
+             {{opt::LoopPeelingPass::PeelDirection::kBefore, 2u}});
+  }
+  {
+    SCOPED_TRACE("Peel before 2 <= iv");
+
+    run_test(SpvOpSLessThanEqual, "%int_2", "%38",
+             {{opt::LoopPeelingPass::PeelDirection::kBefore, 2u}});
+  }
+
+  // Peel after by a factor of 2.
+  {
+    SCOPED_TRACE("Peel after iv >= 8");
+
+    run_test(SpvOpSGreaterThanEqual, "%38", "%int_8",
+             {{opt::LoopPeelingPass::PeelDirection::kAfter, 2u}});
+  }
+  {
+    SCOPED_TRACE("Peel after 8 <= iv");
+
+    run_test(SpvOpSLessThanEqual, "%int_8", "%38",
+             {{opt::LoopPeelingPass::PeelDirection::kAfter, 2u}});
+  }
+  // Test EQ
+  // Peel before by a factor of 1.
+  {
+    SCOPED_TRACE("Peel before iv == 0");
+
+    run_test(SpvOpIEqual, "%38", "%int_0",
+             {{opt::LoopPeelingPass::PeelDirection::kBefore, 1u}});
+  }
+  {
+    SCOPED_TRACE("Peel before 0 == iv");
+
+    run_test(SpvOpIEqual, "%int_0", "%38",
+             {{opt::LoopPeelingPass::PeelDirection::kBefore, 1u}});
+  }
+
+  // Peel after by a factor of 1.
+  {
+    SCOPED_TRACE("Peel after iv == 9");
+
+    run_test(SpvOpIEqual, "%38", "%int_9",
+             {{opt::LoopPeelingPass::PeelDirection::kBefore, 1u}});
+  }
+  {
+    SCOPED_TRACE("Peel after 9 == iv");
+
+    run_test(SpvOpIEqual, "%int_9", "%38",
+             {{opt::LoopPeelingPass::PeelDirection::kBefore, 1u}});
+  }
+
+  // Test NE
+  // Peel before by a factor of 1.
+  {
+    SCOPED_TRACE("Peel before iv != 0");
+
+    run_test(SpvOpINotEqual, "%38", "%int_0",
+             {{opt::LoopPeelingPass::PeelDirection::kBefore, 1u}});
+  }
+  {
+    SCOPED_TRACE("Peel before 0 != iv");
+
+    run_test(SpvOpINotEqual, "%int_0", "%38",
+             {{opt::LoopPeelingPass::PeelDirection::kBefore, 1u}});
+  }
+
+  // Peel after by a factor of 1.
+  {
+    SCOPED_TRACE("Peel after iv != 9");
+
+    run_test(SpvOpINotEqual, "%38", "%int_9",
+             {{opt::LoopPeelingPass::PeelDirection::kBefore, 1u}});
+  }
+  {
+    SCOPED_TRACE("Peel after 9 != iv");
+
+    run_test(SpvOpINotEqual, "%int_9", "%38",
+             {{opt::LoopPeelingPass::PeelDirection::kBefore, 1u}});
+  }
+}
+
+/*
+Test are derivation of the following generated test from the following GLSL +
+--eliminate-local-multi-store
+
+#version 330 core
+void main() {
+  int a = 0;
+  for (int i = 0; i < 10; i++) {
+    for (int j = 0; j < 10; j++) {
+      if (i < 3) {
+        a += 2;
+      }
+    }
+  }
+}
+*/
+TEST_F(PeelingTest, PeelingNestedPass) {
+  const std::string text_head = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginLowerLeft
+               OpSource GLSL 330
+               OpName %main "main"
+               OpName %a "a"
+               OpName %i "i"
+               OpName %j "j"
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+      %int_0 = OpConstant %int 0
+     %int_10 = OpConstant %int 10
+       %bool = OpTypeBool
+      %int_7 = OpConstant %int 7
+      %int_3 = OpConstant %int 3
+      %int_2 = OpConstant %int 2
+      %int_1 = OpConstant %int 1
+         %43 = OpUndef %int
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %a = OpVariable %_ptr_Function_int Function
+          %i = OpVariable %_ptr_Function_int Function
+          %j = OpVariable %_ptr_Function_int Function
+               OpStore %a %int_0
+               OpStore %i %int_0
+               OpBranch %11
+         %11 = OpLabel
+         %41 = OpPhi %int %int_0 %5 %45 %14
+         %42 = OpPhi %int %int_0 %5 %40 %14
+         %44 = OpPhi %int %43 %5 %46 %14
+               OpLoopMerge %13 %14 None
+               OpBranch %15
+         %15 = OpLabel
+         %19 = OpSLessThan %bool %42 %int_10
+               OpBranchConditional %19 %12 %13
+         %12 = OpLabel
+               OpStore %j %int_0
+               OpBranch %21
+         %21 = OpLabel
+         %45 = OpPhi %int %41 %12 %47 %24
+         %46 = OpPhi %int %int_0 %12 %38 %24
+               OpLoopMerge %23 %24 None
+               OpBranch %25
+         %25 = OpLabel
+         %27 = OpSLessThan %bool %46 %int_10
+               OpBranchConditional %27 %22 %23
+         %22 = OpLabel
+  )";
+
+  const std::string text_tail = R"(
+               OpSelectionMerge %32 None
+               OpBranchConditional %30 %31 %32
+         %31 = OpLabel
+         %35 = OpIAdd %int %45 %int_2
+               OpStore %a %35
+               OpBranch %32
+         %32 = OpLabel
+         %47 = OpPhi %int %45 %22 %35 %31
+               OpBranch %24
+         %24 = OpLabel
+         %38 = OpIAdd %int %46 %int_1
+               OpStore %j %38
+               OpBranch %21
+         %23 = OpLabel
+               OpBranch %14
+         %14 = OpLabel
+         %40 = OpIAdd %int %42 %int_1
+               OpStore %i %40
+               OpBranch %11
+         %13 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  auto run_test =
+      [&text_head, &text_tail, this](
+          SpvOp opcode, const std::string& op1, const std::string& op2,
+          const PeelTraceType& expected_peel_trace, size_t nb_of_loops) {
+        BuildAndCheckTrace(text_head, text_tail, opcode, "%30", op1, op2,
+                           expected_peel_trace, nb_of_loops);
+      };
+
+  // Peeling outer before by a factor of 3.
+  {
+    SCOPED_TRACE("Peel before iv_i < 3");
+
+    // Expect peel before by a factor of 3 and 4 loops at the end.
+    run_test(SpvOpSLessThan, "%42", "%int_3",
+             {{opt::LoopPeelingPass::PeelDirection::kBefore, 3u}}, 4);
+  }
+  // Peeling outer loop after by a factor of 3.
+  {
+    SCOPED_TRACE("Peel after iv_i < 7");
+
+    // Expect peel after by a factor of 3 and 4 loops at the end.
+    run_test(SpvOpSLessThan, "%42", "%int_7",
+             {{opt::LoopPeelingPass::PeelDirection::kAfter, 3u}}, 4);
+  }
+
+  // Peeling inner loop before by a factor of 3.
+  {
+    SCOPED_TRACE("Peel before iv_j < 3");
+
+    // Expect peel before by a factor of 3 and 3 loops at the end.
+    run_test(SpvOpSLessThan, "%46", "%int_3",
+             {{opt::LoopPeelingPass::PeelDirection::kBefore, 3u}}, 3);
+  }
+  // Peeling inner loop after by a factor of 3.
+  {
+    SCOPED_TRACE("Peel after iv_j < 7");
+
+    // Expect peel after by a factor of 3 and 3 loops at the end.
+    run_test(SpvOpSLessThan, "%46", "%int_7",
+             {{opt::LoopPeelingPass::PeelDirection::kAfter, 3u}}, 3);
+  }
+
+  // Not unworkable condition.
+  {
+    SCOPED_TRACE("No peel");
+
+    // Expect no peeling and 2 loops at the end.
+    run_test(SpvOpSLessThan, "%46", "%42", {}, 2);
+  }
+
+  // Could do a peeling of 3, but the goes over the threshold.
+  {
+    SCOPED_TRACE("Over threshold");
+
+    size_t current_threshold =
+        spvtools::opt::LoopPeelingPass::GetLoopPeelingThreshold();
+    spvtools::opt::LoopPeelingPass::SetLoopPeelingThreshold(1u);
+    // Expect no peeling and 2 loops at the end.
+    run_test(SpvOpSLessThan, "%46", "%int_7", {}, 2);
+    spvtools::opt::LoopPeelingPass::SetLoopPeelingThreshold(current_threshold);
+  }
+}
+/*
+Test are derivation of the following generated test from the following GLSL +
+--eliminate-local-multi-store
+
+#version 330 core
+void main() {
+  int a = 0;
+  for (int i = 0, j = 0; i < 10; j++, i++) {
+    if (i < j) {
+      a += 2;
+    }
+  }
+}
+*/
+TEST_F(PeelingTest, PeelingNoChanges) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginLowerLeft
+               OpSource GLSL 330
+               OpName %main "main"
+               OpName %a "a"
+               OpName %i "i"
+               OpName %j "j"
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+      %int_0 = OpConstant %int 0
+     %int_10 = OpConstant %int 10
+       %bool = OpTypeBool
+      %int_2 = OpConstant %int 2
+      %int_1 = OpConstant %int 1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %a = OpVariable %_ptr_Function_int Function
+          %i = OpVariable %_ptr_Function_int Function
+          %j = OpVariable %_ptr_Function_int Function
+               OpStore %a %int_0
+               OpStore %i %int_0
+               OpStore %j %int_0
+               OpBranch %12
+         %12 = OpLabel
+         %34 = OpPhi %int %int_0 %5 %37 %15
+         %35 = OpPhi %int %int_0 %5 %33 %15
+         %36 = OpPhi %int %int_0 %5 %31 %15
+               OpLoopMerge %14 %15 None
+               OpBranch %16
+         %16 = OpLabel
+         %20 = OpSLessThan %bool %35 %int_10
+               OpBranchConditional %20 %13 %14
+         %13 = OpLabel
+         %23 = OpSLessThan %bool %35 %36
+               OpSelectionMerge %25 None
+               OpBranchConditional %23 %24 %25
+         %24 = OpLabel
+         %28 = OpIAdd %int %34 %int_2
+               OpStore %a %28
+               OpBranch %25
+         %25 = OpLabel
+         %37 = OpPhi %int %34 %13 %28 %24
+               OpBranch %15
+         %15 = OpLabel
+         %31 = OpIAdd %int %36 %int_1
+               OpStore %j %31
+         %33 = OpIAdd %int %35 %int_1
+               OpStore %i %33
+               OpBranch %12
+         %14 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  {
+    auto result =
+        SinglePassRunAndDisassemble<opt::LoopPeelingPass>(text, true, false);
+
+    EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
+  }
+}
+
+}  // namespace


### PR DESCRIPTION
For each loop in a function, the pass walks the loops from inner to outer most loop
and tries to peel loop for which a certain amount of iteration can be done before or after the loop.

To limit code growth, peeling will not happen if the growth in code size goes above a configurable threshold.