### PR TITLE
Don't allow an instance of a pass to be run multiple times.

### DIFF
--- a/source/opt/pass.cpp
+++ b/source/opt/pass.cpp
@@ -28,7 +28,7 @@ const uint32_t kTypePointerTypeIdInIdx = 1;
 
 }  // namespace
 
-Pass::Pass() : consumer_(nullptr), context_(nullptr) {}
+Pass::Pass() : consumer_(nullptr), context_(nullptr), already_run_(false) {}
 
 void Pass::AddCalls(ir::Function* func, std::queue<uint32_t>* todo) {
   for (auto bi = func->begin(); bi != func->end(); ++bi)
@@ -103,6 +103,11 @@ bool Pass::ProcessCallTreeFromRoots(
 }
 
 Pass::Status Pass::Run(ir::IRContext* ctx) {
+  if (already_run_) {
+    return Status::Failure;
+  }
+  already_run_ = true;
+
   Pass::Status status = Process(ctx);
   if (status == Status::SuccessWithChange) {
     ctx->InvalidateAnalysesExceptFor(GetPreservedAnalyses());

--- a/source/opt/pass.h
+++ b/source/opt/pass.h
@@ -118,11 +118,13 @@ class Pass {
       std::queue<uint32_t>* roots);
 
   // Run the pass on the given |module|. Returns Status::Failure if errors occur
-  // when
-  // processing. Returns the corresponding Status::Success if processing is
+  // when processing. Returns the corresponding Status::Success if processing is
   // successful to indicate whether changes are made to the module.  If there
   // were any changes it will also invalidate the analyses in the IRContext
   // that are not preserved.
+  //
+  // It is an error if |Run| is called twice with the same instance of the pass.
+  // If this happens the return value will be |Failure|.
   virtual Status Run(ir::IRContext* ctx) final;
 
   // Returns the set of analyses that the pass is guaranteed to preserve.
@@ -151,6 +153,11 @@ class Pass {
 
   // The context that this pass belongs to.
   ir::IRContext* context_;
+
+  // An instance of a pass can only be run once because it is too hard to
+  // enforce proper resetting of internal state for each instance.  This member
+  // is used to check that we do not run the same instance twice.
+  bool already_run_;
 };
 
 }  // namespace opt

--- a/source/opt/pass_manager.cpp
+++ b/source/opt/pass_manager.cpp
@@ -43,12 +43,15 @@ Pass::Status PassManager::Run(ir::IRContext* context) {
   };
 
   SPIRV_TIMER_DESCRIPTION(time_report_stream_, /* measure_mem_usage = */ true);
-  for (const auto& pass : passes_) {
+  for (auto& pass : passes_) {
     print_disassembly("; IR before pass ", pass.get());
     SPIRV_TIMER_SCOPED(time_report_stream_, (pass ? pass->name() : ""), true);
     const auto one_status = pass->Run(context);
     if (one_status == Pass::Status::Failure) return one_status;
     if (one_status == Pass::Status::SuccessWithChange) status = one_status;
+
+    // Reset the pass to free any memory used by the pass.
+    pass.reset(nullptr);
   }
   print_disassembly("; IR after last pass", nullptr);
 


### PR DESCRIPTION
Many passes contain state information in the pass.  In general, we have not been careful to make sure that state gets reset when the pass is run.  It will also be hard to keep correct in the future.  To fix this problem we will enforce a rule that an instance of a pass can only be run once.

At the same time, we will destroy the passes in the pass manager immediately after they are run.  This way we can reduce the peak memory usage.