### PR TITLE
Change parameter to Mempass::RemovePhiOperands

### DIFF
--- a/source/opt/mem_pass.cpp
+++ b/source/opt/mem_pass.cpp
@@ -312,7 +312,7 @@ bool MemPass::IsTargetVar(uint32_t varId) {
 //           %30 = OpPhi %int %int_42 %13 %50 %14 %50 %15
 void MemPass::RemovePhiOperands(
     ir::Instruction* phi,
-    std::unordered_set<ir::BasicBlock*> reachable_blocks) {
+    const unordered_set<ir::BasicBlock*>& reachable_blocks) {
   std::vector<ir::Operand> keep_operands;
   uint32_t type_id = 0;
   // The id of an undefined value we've generated.

--- a/source/opt/mem_pass.h
+++ b/source/opt/mem_pass.h
@@ -149,8 +149,9 @@ class MemPass : public Pass {
 
   // Remove Phi operands in |phi| that are coming from blocks not in
   // |reachable_blocks|.
-  void RemovePhiOperands(ir::Instruction* phi,
-                         std::unordered_set<ir::BasicBlock*> reachable_blocks);
+  void RemovePhiOperands(
+      ir::Instruction* phi,
+      const std::unordered_set<ir::BasicBlock*>& reachable_blocks);
 
   // Map from type to undef
   std::unordered_map<uint32_t, uint32_t> type2undefs_;


### PR DESCRIPTION
Pass a hashtable by const ref instead of by value.  Big impact on
compile time.

Contributes to https://github.com/KhronosGroup/SPIRV-Tools/issues/1328.