### PR TITLE
Add validator test for OpBranch

### DIFF
--- a/source/validate_cfg.cpp
+++ b/source/validate_cfg.cpp
@@ -261,11 +261,16 @@ spv_result_t PerformCfgChecks(ValidationState_t& _) {
     // Check all referenced blocks are defined within a function
     if (function.undefined_block_count() != 0) {
       string undef_blocks("{");
+      bool first = true;
       for (auto undefined_block : function.undefined_blocks()) {
-        undef_blocks += _.getIdName(undefined_block) + " ";
+        undef_blocks += _.getIdName(undefined_block);
+        if (!first) {
+          undef_blocks += " ";
+        }
+        first = false;
       }
       return _.diag(SPV_ERROR_INVALID_CFG)
-             << "Block(s) " << undef_blocks << "\b}"
+             << "Block(s) " << undef_blocks << "}"
              << " are referenced but not defined in function "
              << _.getIdName(function.id());
     }

--- a/source/validate_id.cpp
+++ b/source/validate_id.cpp
@@ -1870,12 +1870,6 @@ bool idUsage::isValid<OpSelectionMerge>(
     const spv_instruction_t *inst, const spv_opcode_desc opcodeEntry) {}
 #endif
 
-#if 0
-template <>
-bool idUsage::isValid<OpBranch>(const spv_instruction_t *inst,
-                                const spv_opcode_desc opcodeEntry) {}
-#endif
-
 template <>
 bool idUsage::isValid<SpvOpBranchConditional>(const spv_instruction_t* inst,
                                               const spv_opcode_desc) {
@@ -2426,7 +2420,8 @@ bool idUsage::isValid(const spv_instruction_t* inst) {
     CASE(OpPhi)
     TODO(OpLoopMerge)
     TODO(OpSelectionMerge)
-    TODO(OpBranch)
+    // OpBranch is validated in validate_cfg.cpp.
+    // See tests in test/val/val_cfg_test.cpp.
     CASE(OpBranchConditional)
     TODO(OpSwitch)
     CASE(OpReturnValue)

--- a/test/val/val_cfg_test.cpp
+++ b/test/val/val_cfg_test.cpp
@@ -453,7 +453,7 @@ TEST_P(ValidateCFG, MergeBlockTargetedByMultipleHeaderBlocksSelectionBad) {
   }
 }
 
-TEST_P(ValidateCFG, BranchTargetFirstBlockBad) {
+TEST_P(ValidateCFG, BranchTargetFirstBlockBadSinceEntryBlock) {
   Block entry("entry");
   Block bad("bad");
   Block end("end", SpvOpReturn);
@@ -471,6 +471,30 @@ TEST_P(ValidateCFG, BranchTargetFirstBlockBad) {
   EXPECT_THAT(getDiagnosticString(),
               MatchesRegex("First block .\\[entry\\] of function .\\[Main\\] "
                            "is targeted by block .\\[bad\\]"));
+}
+
+TEST_P(ValidateCFG, BranchTargetFirstBlockBadSinceValue) {
+  Block entry("entry");
+  Block bad("bad");
+  Block end("end", SpvOpReturn);
+  Block badvalue("func");  // This referenes the function name.
+  string str = header(GetParam()) +
+               nameOps("entry", "bad", make_pair("func", "Main")) +
+               types_consts() + "%func    = OpFunction %voidt None %funct\n";
+
+  str += entry >> bad;
+  str +=
+      bad >> badvalue;  // Check branch to a function value (it's not a block!)
+  str += end;
+  str += "OpFunctionEnd\n";
+
+  CompileSuccessfully(str);
+  ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      MatchesRegex("Block\\(s\\) \\{.\\[Main\\]} are referenced but not "
+                   "defined in function .\\[Main\\]"))
+      << str;
 }
 
 TEST_P(ValidateCFG, BranchConditionalTrueTargetFirstBlockBad) {
@@ -589,7 +613,7 @@ TEST_P(ValidateCFG, BranchToBlockInOtherFunctionBad) {
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      MatchesRegex("Block\\(s\\) \\{.\\[middle2\\] .\\} are referenced but not "
+      MatchesRegex("Block\\(s\\) \\{.\\[middle2\\]} are referenced but not "
                    "defined in function .\\[Main\\]"));
 }
 

--- a/test/val/val_cfg_test.cpp
+++ b/test/val/val_cfg_test.cpp
@@ -492,7 +492,7 @@ TEST_P(ValidateCFG, BranchTargetFirstBlockBadSinceValue) {
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      MatchesRegex("Block\\(s\\) \\{.\\[Main\\]} are referenced but not "
+      MatchesRegex("Block\\(s\\) \\{.\\[Main\\]\\} are referenced but not "
                    "defined in function .\\[Main\\]"))
       << str;
 }
@@ -613,7 +613,7 @@ TEST_P(ValidateCFG, BranchToBlockInOtherFunctionBad) {
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      MatchesRegex("Block\\(s\\) \\{.\\[middle2\\]} are referenced but not "
+      MatchesRegex("Block\\(s\\) \\{.\\[middle2\\]\\} are referenced but not "
                    "defined in function .\\[Main\\]"));
 }
 


### PR DESCRIPTION
Add test for case where OpBranch branches to a value (a function value).
Previous tests only checked a label value (name of a block.).

Update validate_id.cpp to remove the TODO for OpBranch and say that it
is already checked in validate_cfg.cpp

Also updates the message generation to avoid the extra space at the end and the backspace(!)