### PR TITLE
Remove the limit on struct size in SROA.

### DIFF
--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -515,8 +515,10 @@ Optimizer::PassToken CreateRedundancyEliminationPass();
 
 // Create scalar replacement pass.
 // This pass replaces composite function scope variables with variables for each
-// element if those elements are accessed individually.
-Optimizer::PassToken CreateScalarReplacementPass();
+// element if those elements are accessed individually.  The parameter is a
+// limit on the number of members in the composite variable that the pass will
+// consider replacing.
+Optimizer::PassToken CreateScalarReplacementPass(uint32_t size_limit = 100);
 
 // Create a private to local pass.
 // This pass looks for variables delcared in the private storage class that are

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -105,7 +105,7 @@ Optimizer& Optimizer::RegisterLegalizationPasses() {
           .RegisterPass(CreateLocalSingleStoreElimPass())
           .RegisterPass(CreateAggressiveDCEPass())
           // Split up aggragates so they are easier to deal with.
-          .RegisterPass(CreateScalarReplacementPass())
+          .RegisterPass(CreateScalarReplacementPass(0))
           // Remove loads and stores so everything is in intermediate values.
           // Takes care of copy propagation of non-members.
           .RegisterPass(CreateLocalSingleBlockLoadStoreElimPass())
@@ -416,9 +416,9 @@ Optimizer::PassToken CreateRemoveDuplicatesPass() {
       MakeUnique<opt::RemoveDuplicatesPass>());
 }
 
-Optimizer::PassToken CreateScalarReplacementPass() {
+Optimizer::PassToken CreateScalarReplacementPass(uint32_t size_limit) {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::ScalarReplacementPass>());
+      MakeUnique<opt::ScalarReplacementPass>(size_limit));
 }
 
 Optimizer::PassToken CreatePrivateToLocalPass() {

--- a/source/opt/scalar_replacement_pass.h
+++ b/source/opt/scalar_replacement_pass.h
@@ -15,6 +15,8 @@
 #ifndef LIBSPIRV_OPT_SCALAR_REPLACEMENT_PASS_H_
 #define LIBSPIRV_OPT_SCALAR_REPLACEMENT_PASS_H_
 
+#include <cstdio>
+
 #include "function.h"
 #include "pass.h"
 #include "type_manager.h"
@@ -26,10 +28,18 @@ namespace opt {
 
 // Documented in optimizer.hpp
 class ScalarReplacementPass : public Pass {
- public:
-  ScalarReplacementPass() = default;
+ private:
+  static const uint32_t kDefaultLimit = 100;
 
-  const char* name() const override { return "scalar-replacement"; }
+ public:
+  ScalarReplacementPass(uint32_t limit = kDefaultLimit)
+      : max_num_elements_(limit) {
+    name_[0] = '\0';
+    strcat(name_, "scalar-replacement=");
+    sprintf(&name_[strlen(name_)], "%d", max_num_elements_);
+  }
+
+  const char* name() const override { return name_; }
 
   // Attempts to scalarize all appropriate function scope variables. Returns
   // SuccessWithChange if any change is made.
@@ -207,6 +217,12 @@ class ScalarReplacementPass : public Pass {
 
   // Maps type id to OpConstantNull for that type.
   std::unordered_map<uint32_t, uint32_t> type_to_null_;
+
+  // Limit on the number of members in an object that will be replaced.
+  // 0 means there is no limit.
+  uint32_t max_num_elements_;
+  bool IsLargerThanSizeLimit(size_t length) const;
+  char name_[55];
 };
 
 }  // namespace opt

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -292,10 +292,12 @@ Options (in lexicographical order):
   --ssa-rewrite
                Replace loads and stores to function local variables with
                operations on SSA IDs.
-  --scalar-replacement
+  --scalar-replacement[=<n>]
                Replace aggregate function scope variables that are only accessed
                via their elements with new function variables representing each
-               element.
+               element.  <n> is a limit on the size of the aggragates that will
+               be replaced.  0 means there is no limit.  The default value is
+               100.
   --set-spec-const-default-value "<spec id>:<default value> ..."
                Set the default values of the specialization constants with
                <spec id>:<default value> pairs specified in a double-quoted
@@ -569,6 +571,9 @@ OptStatus ParseFlags(int argc, const char** argv, Optimizer* optimizer,
         optimizer->RegisterPass(CreateLoopUnswitchPass());
       } else if (0 == strcmp(cur_arg, "--scalar-replacement")) {
         optimizer->RegisterPass(CreateScalarReplacementPass());
+      } else if (0 == strncmp(cur_arg, "--scalar-replacement=", 21)) {
+        uint32_t limit = atoi(cur_arg + 21);
+        optimizer->RegisterPass(CreateScalarReplacementPass(limit));
       } else if (0 == strcmp(cur_arg, "--strength-reduction")) {
         optimizer->RegisterPass(CreateStrengthReductionPass());
       } else if (0 == strcmp(cur_arg, "--unify-const")) {


### PR DESCRIPTION
Removes the limit on scalar replacement because it has to happen for
legalization.

Part of #1494.