### PR TITLE
Vulkan 1.1 barrier execution scope checks for OpControlBarrier

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -817,8 +817,8 @@ void ValidationState_t::ComputeFunctionToEntryPointMapping() {
 }
 
 const std::vector<uint32_t>& ValidationState_t::FunctionEntryPoints(
-    uint32_t function) const {
-  auto iter = function_to_entry_points_.find(function);
+    uint32_t func) const {
+  auto iter = function_to_entry_points_.find(func);
   if (iter == function_to_entry_points_.end()) {
     return empty_ids_;
   } else {

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -806,9 +806,11 @@ void ValidationState_t::ComputeFunctionToEntryPointMapping() {
       function_to_entry_points_[called_func_id].push_back(entry_point);
 
       const Function* called_func = function(called_func_id);
-      assert(called_func);
-      for (const uint32_t new_call : called_func->function_call_targets()) {
-        call_stack.push(new_call);
+      if (called_func) {
+        // Other checks should error out on this invalid SPIR-V.
+        for (const uint32_t new_call : called_func->function_call_targets()) {
+          call_stack.push(new_call);
+        }
       }
     }
   }

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -15,6 +15,7 @@
 #include "val/validation_state.h"
 
 #include <cassert>
+#include <stack>
 
 #include "opcode.h"
 #include "val/basic_block.h"
@@ -790,6 +791,37 @@ std::tuple<bool, bool, uint32_t> ValidationState_t::EvalInt32IfConst(
 
   assert(inst->words().size() == 4);
   return std::make_tuple(true, true, inst->word(3));
+}
+
+void ValidationState_t::ComputeFunctionToEntryPointMapping() {
+  for (const uint32_t entry_point : entry_points()) {
+    std::stack<uint32_t> call_stack;
+    std::set<uint32_t> visited;
+    call_stack.push(entry_point);
+    while (!call_stack.empty()) {
+      const uint32_t called_func_id = call_stack.top();
+      call_stack.pop();
+      if (!visited.insert(called_func_id).second) continue;
+
+      function_to_entry_points_[called_func_id].push_back(entry_point);
+
+      const Function* called_func = function(called_func_id);
+      assert(called_func);
+      for (const uint32_t new_call : called_func->function_call_targets()) {
+        call_stack.push(new_call);
+      }
+    }
+  }
+}
+
+const std::vector<uint32_t>& ValidationState_t::FunctionEntryPoints(
+    uint32_t function) const {
+  auto iter = function_to_entry_points_.find(function);
+  if (iter == function_to_entry_points_.end()) {
+    return empty_ids_;
+  } else {
+    return iter->second;
+  }
 }
 
 }  // namespace libspirv

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -212,8 +212,8 @@ class ValidationState_t {
   /// Note: called after fully parsing the binary.
   void ComputeFunctionToEntryPointMapping();
 
-  /// Returns all the entry points that can call |function|.
-  const std::vector<uint32_t>& FunctionEntryPoints(uint32_t function) const;
+  /// Returns all the entry points that can call |func|.
+  const std::vector<uint32_t>& FunctionEntryPoints(uint32_t func) const;
 
   /// Inserts an <id> to the set of functions that are target of OpFunctionCall.
   void AddFunctionCallTarget(const uint32_t id) {

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -208,6 +208,13 @@ class ValidationState_t {
     return &it->second;
   }
 
+  /// Traverses call tree and computes function_to_entry_points_.
+  /// Note: called after fully parsing the binary.
+  void ComputeFunctionToEntryPointMapping();
+
+  /// Returns all the entry points that can call |function|.
+  const std::vector<uint32_t>& FunctionEntryPoints(uint32_t function) const;
+
   /// Inserts an <id> to the set of functions that are target of OpFunctionCall.
   void AddFunctionCallTarget(const uint32_t id) {
     function_call_targets_.insert(id);
@@ -559,6 +566,11 @@ class ValidationState_t {
   /// Mapping entry point -> execution modes.
   std::unordered_map<uint32_t, std::set<SpvExecutionMode>>
       entry_point_to_execution_modes_;
+
+  /// Mapping function -> array of entry points inside this
+  /// module which can (indirectly) call the function.
+  std::unordered_map<uint32_t, std::vector<uint32_t>> function_to_entry_points_;
+  const std::vector<uint32_t> empty_ids_;
 };
 
 }  // namespace libspirv

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -298,6 +298,8 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
            << id_str.substr(0, id_str.size() - 1);
   }
 
+  vstate->ComputeFunctionToEntryPointMapping();
+
   // Validate the preconditions involving adjacent instructions. e.g. SpvOpPhi
   // must only be preceeded by SpvOpLabel, SpvOpPhi, or SpvOpLine.
   if (auto error = ValidateAdjacency(*vstate)) return error;
@@ -346,8 +348,6 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
     instructions.emplace_back(std::move(inst));
     index += wordCount;
   }
-
-  vstate->ComputeFunctionToEntryPointMapping();
 
   position.index = SPV_INDEX_INSTRUCTION;
   if (auto error = spvValidateIDs(instructions.data(), instructions.size(),

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -347,6 +347,8 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
     index += wordCount;
   }
 
+  vstate->ComputeFunctionToEntryPointMapping();
+
   position.index = SPV_INDEX_INSTRUCTION;
   if (auto error = spvValidateIDs(instructions.data(), instructions.size(),
                                   *vstate, &position))

--- a/source/validate_barriers.cpp
+++ b/source/validate_barriers.cpp
@@ -55,7 +55,24 @@ spv_result_t ValidateExecutionScope(ValidationState_t& _,
                 "Workgroup and Subgroup";
     }
 
-    if (_.context()->target_env != SPV_ENV_VULKAN_1_0) {
+    if (_.context()->target_env != SPV_ENV_VULKAN_1_0 &&
+        value != SpvScopeSubgroup) {
+      _.current_function().RegisterExecutionModelLimitation(
+          [](SpvExecutionModel model, std::string* message) {
+            if (model == SpvExecutionModelFragment ||
+                model == SpvExecutionModelVertex ||
+                model == SpvExecutionModelGeometry ||
+                model == SpvExecutionModelTessellationEvaluation) {
+              if (message) {
+                *message =
+                    "in Vulkan evironment, OpControlBarrier execution scope "
+                    "must be Subgroup for Fragment, Vertex, Geometry and "
+                    "TessellationEvaluation execution models";
+              }
+              return false;
+            }
+            return true;
+          });
     }
   }
 

--- a/source/validate_barriers.cpp
+++ b/source/validate_barriers.cpp
@@ -54,6 +54,9 @@ spv_result_t ValidateExecutionScope(ValidationState_t& _,
              << ": in Vulkan environment Execution Scope is limited to "
                 "Workgroup and Subgroup";
     }
+
+    if (_.context()->target_env != SPV_ENV_VULKAN_1_0) {
+    }
   }
 
   // TODO(atgoo@github.com) Add checks for OpenCL and OpenGL environments.

--- a/source/validate_builtins.cpp
+++ b/source/validate_builtins.cpp
@@ -349,9 +349,6 @@ class BuiltInsValidator {
   // instruction.
   void Update(const Instruction& inst);
 
-  // Traverses call tree and computes function_to_entry_points_.
-  void ComputeFunctionToEntryPointMapping();
-
   const ValidationState_t& _;
 
   // Mapping id -> list of rules which validate instruction referencing the
@@ -370,10 +367,6 @@ class BuiltInsValidator {
   const std::vector<uint32_t> no_entry_points;
   const std::vector<uint32_t>* entry_points_ = &no_entry_points;
 
-  // Mapping function -> array of entry points inside this
-  // module which can (indirectly) call the function.
-  std::unordered_map<uint32_t, std::vector<uint32_t>> function_to_entry_points_;
-
   // Execution models with which the current function can be called.
   std::set<SpvExecutionModel> execution_models_;
 };
@@ -385,17 +378,12 @@ void BuiltInsValidator::Update(const Instruction& inst) {
     assert(function_id_ == 0);
     function_id_ = inst.id();
     execution_models_.clear();
-    const auto it = function_to_entry_points_.find(function_id_);
-    if (it == function_to_entry_points_.end()) {
-      entry_points_ = &no_entry_points;
-    } else {
-      entry_points_ = &it->second;
-      // Collect execution models from all entry points from which the current
-      // function can be called.
-      for (const uint32_t entry_point : *entry_points_) {
-        if (const auto* models = _.GetExecutionModels(entry_point)) {
-          execution_models_.insert(models->begin(), models->end());
-        }
+    entry_points_ = &_.FunctionEntryPoints(function_id_);
+    // Collect execution models from all entry points from which the current
+    // function can be called.
+    for (const uint32_t entry_point : *entry_points_) {
+      if (const auto* models = _.GetExecutionModels(entry_point)) {
+        execution_models_.insert(models->begin(), models->end());
       }
     }
   }
@@ -406,28 +394,6 @@ void BuiltInsValidator::Update(const Instruction& inst) {
     function_id_ = 0;
     entry_points_ = &no_entry_points;
     execution_models_.clear();
-  }
-}
-
-void BuiltInsValidator::ComputeFunctionToEntryPointMapping() {
-  // TODO: Move this into validation_state.cpp.
-  for (const uint32_t entry_point : _.entry_points()) {
-    std::stack<uint32_t> call_stack;
-    std::set<uint32_t> visited;
-    call_stack.push(entry_point);
-    while (!call_stack.empty()) {
-      const uint32_t called_func_id = call_stack.top();
-      call_stack.pop();
-      if (!visited.insert(called_func_id).second) continue;
-
-      function_to_entry_points_[called_func_id].push_back(entry_point);
-
-      const Function* called_func = _.function(called_func_id);
-      assert(called_func);
-      for (const uint32_t new_call : called_func->function_call_targets()) {
-        call_stack.push(new_call);
-      }
-    }
   }
 }
 
@@ -2307,8 +2273,6 @@ spv_result_t BuiltInsValidator::Run() {
     // No validation tasks were seeded. Nothing else to do.
     return SPV_SUCCESS;
   }
-
-  ComputeFunctionToEntryPointMapping();
 
   // Second pass: validate every id reference in the module using
   // rules in id_to_at_reference_checks_.

--- a/test/val/val_barriers_test.cpp
+++ b/test/val/val_barriers_test.cpp
@@ -375,6 +375,167 @@ OpControlBarrier %workgroup %device %acquire_release_subgroup
           "Vulkan-supported storage class if Memory Semantics is not None"));
 }
 
+TEST_F(ValidateBarriers, OpControlBarrierSubgroupExecutionFragment1p1) {
+  const std::string body = R"(
+OpControlBarrier %subgroup %subgroup %acquire_release_subgroup
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, "", "Fragment"),
+                      SPV_ENV_VULKAN_1_1);
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_1));
+}
+
+TEST_F(ValidateBarriers, OpControlBarrierWorkgroupExecutionFragment1p1) {
+  const std::string body = R"(
+OpControlBarrier %workgroup %workgroup %acquire_release
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, "", "Fragment"),
+                      SPV_ENV_VULKAN_1_1);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_1));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpControlBarrier execution scope must be Subgroup for "
+                        "Fragment, Vertex, Geometry and TessellationEvaluation "
+                        "execution models"));
+}
+
+TEST_F(ValidateBarriers, OpControlBarrierSubgroupExecutionFragment1p0) {
+  const std::string body = R"(
+OpControlBarrier %subgroup %workgroup %acquire_release
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, "", "Fragment"),
+                      SPV_ENV_VULKAN_1_0);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("OpControlBarrier requires one of the following Execution "
+                "Models: TessellationControl, GLCompute or Kernel"));
+}
+
+TEST_F(ValidateBarriers, OpControlBarrierSubgroupExecutionVertex1p1) {
+  const std::string body = R"(
+OpControlBarrier %subgroup %subgroup %acquire_release_subgroup
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, "", "Vertex"),
+                      SPV_ENV_VULKAN_1_1);
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_1));
+}
+
+TEST_F(ValidateBarriers, OpControlBarrierWorkgroupExecutionVertex1p1) {
+  const std::string body = R"(
+OpControlBarrier %workgroup %workgroup %acquire_release
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, "", "Vertex"),
+                      SPV_ENV_VULKAN_1_1);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_1));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpControlBarrier execution scope must be Subgroup for "
+                        "Fragment, Vertex, Geometry and TessellationEvaluation "
+                        "execution models"));
+}
+
+TEST_F(ValidateBarriers, OpControlBarrierSubgroupExecutionVertex1p0) {
+  const std::string body = R"(
+OpControlBarrier %subgroup %workgroup %acquire_release
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, "", "Vertex"),
+                      SPV_ENV_VULKAN_1_0);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("OpControlBarrier requires one of the following Execution "
+                "Models: TessellationControl, GLCompute or Kernel"));
+}
+
+TEST_F(ValidateBarriers, OpControlBarrierSubgroupExecutionGeometry1p1) {
+  const std::string body = R"(
+OpControlBarrier %subgroup %subgroup %acquire_release_subgroup
+)";
+
+  CompileSuccessfully(
+      GenerateShaderCode(body, "OpCapability Geometry\n", "Geometry"),
+      SPV_ENV_VULKAN_1_1);
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_1));
+}
+
+TEST_F(ValidateBarriers, OpControlBarrierWorkgroupExecutionGeometry1p1) {
+  const std::string body = R"(
+OpControlBarrier %workgroup %workgroup %acquire_release
+)";
+
+  CompileSuccessfully(
+      GenerateShaderCode(body, "OpCapability Geometry\n", "Geometry"),
+      SPV_ENV_VULKAN_1_1);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_1));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpControlBarrier execution scope must be Subgroup for "
+                        "Fragment, Vertex, Geometry and TessellationEvaluation "
+                        "execution models"));
+}
+
+TEST_F(ValidateBarriers, OpControlBarrierSubgroupExecutionGeometry1p0) {
+  const std::string body = R"(
+OpControlBarrier %subgroup %workgroup %acquire_release
+)";
+
+  CompileSuccessfully(
+      GenerateShaderCode(body, "OpCapability Geometry\n", "Geometry"),
+      SPV_ENV_VULKAN_1_0);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("OpControlBarrier requires one of the following Execution "
+                "Models: TessellationControl, GLCompute or Kernel"));
+}
+
+TEST_F(ValidateBarriers,
+       OpControlBarrierSubgroupExecutionTessellationEvaluation1p1) {
+  const std::string body = R"(
+OpControlBarrier %subgroup %subgroup %acquire_release_subgroup
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, "OpCapability Tessellation\n",
+                                         "TessellationEvaluation"),
+                      SPV_ENV_VULKAN_1_1);
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_1));
+}
+
+TEST_F(ValidateBarriers,
+       OpControlBarrierWorkgroupExecutionTessellationEvaluation1p1) {
+  const std::string body = R"(
+OpControlBarrier %workgroup %workgroup %acquire_release
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, "OpCapability Tessellation\n",
+                                         "TessellationEvaluation"),
+                      SPV_ENV_VULKAN_1_1);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_1));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpControlBarrier execution scope must be Subgroup for "
+                        "Fragment, Vertex, Geometry and TessellationEvaluation "
+                        "execution models"));
+}
+
+TEST_F(ValidateBarriers,
+       OpControlBarrierSubgroupExecutionTessellationEvaluation1p0) {
+  const std::string body = R"(
+OpControlBarrier %subgroup %workgroup %acquire_release
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, "OpCapability Tessellation\n",
+                                         "TessellationEvaluation"),
+                      SPV_ENV_VULKAN_1_0);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("OpControlBarrier requires one of the following Execution "
+                "Models: TessellationControl, GLCompute or Kernel"));
+}
+
 TEST_F(ValidateBarriers, OpMemoryBarrierSuccess) {
   const std::string body = R"(
 OpMemoryBarrier %cross_device %acquire_release_uniform_workgroup


### PR DESCRIPTION
Fixes #1483 

Refactored the function -> entry point callers out of builtin validation and into validation state. Removed on-the-fly construction of an entry point's call tree during validation in favour of the newly maintained map. Execution model limitations are now checked in the function instead of the entry point.

Added checks that for Vulkan 1.1, subgroup execution scope must be used for Fragment, Vertex, Geometry and TessellationEvaluation models for OpControlBarrier.

Added tests.