### PR TITLE
Fix for old XCode: std::set has explicit ctor

### DIFF
--- a/source/opt/loop_dependence_helpers.cpp
+++ b/source/opt/loop_dependence_helpers.cpp
@@ -351,7 +351,7 @@ int64_t LoopDependenceAnalysis::CountInductionVariables(SENode* node) {
 std::set<const ir::Loop*> LoopDependenceAnalysis::CollectLoops(
     SENode* source, SENode* destination) {
   if (!source || !destination) {
-    return {};
+    return std::set<const ir::Loop*>{};
   }
 
   std::vector<SERecurrentNode*> source_nodes = source->CollectRecurrentNodes();


### PR DESCRIPTION
This is needed to fix the Android NDK build.