### PR TITLE
Check for invalid branches into construct body.

### DIFF
--- a/source/val/construct.h
+++ b/source/val/construct.h
@@ -15,10 +15,20 @@
 #ifndef LIBSPIRV_VAL_CONSTRUCT_H_
 #define LIBSPIRV_VAL_CONSTRUCT_H_
 
+#include "val/basic_block.h"
+
 #include <cstdint>
+#include <set>
 #include <vector>
 
 namespace libspirv {
+
+/// Functor for ordering BasicBlocks. BasicBlock pointers must not be null.
+struct less_than_id {
+  bool operator()(const BasicBlock* lhs, const BasicBlock* rhs) const {
+    return lhs->id() < rhs->id();
+  }
+};
 
 enum class ConstructType : int {
   kNone = 0,
@@ -38,8 +48,6 @@ enum class ConstructType : int {
   ///  the OpSwitch's corresponding merge block)
   kCase
 };
-
-class BasicBlock;
 
 /// @brief This class tracks the CFG constructs as defined in the SPIR-V spec
 class Construct {
@@ -90,6 +98,12 @@ class Construct {
   bool ExitBlockIsMergeBlock() const {
     return type_ == ConstructType::kLoop || type_ == ConstructType::kSelection;
   }
+
+  using ConstructBlockSet = std::set<BasicBlock*, less_than_id>;
+
+  // Returns the basic blocks in this construct. This function should not
+  // be called before the exit block is set.
+  ConstructBlockSet blocks() const;
 
  private:
   /// The type of the construct


### PR DESCRIPTION
Fixes #1281

* New structured cfg check: all non-construct header blocks'
predecessors must come from within the construct
* New function to calculate blocks in a construct
* New tests to cover invalid cases