### PR TITLE
Fold OpVectorTimesScalar and OpPhi better.

### DIFF
--- a/source/opt/constants.cpp
+++ b/source/opt/constants.cpp
@@ -306,16 +306,6 @@ const Constant* ConstantManager::GetConstant(
   return cst ? RegisterConstant(cst) : nullptr;
 }
 
-bool VectorConstant::IsZero() const {
-  for (const Constant* component : GetComponents()) {
-    if (!component->AsNullConstant() &&
-        !component->AsScalarConstant()->IsZero()) {
-      return false;
-    }
-  }
-  return true;
-}
-
 std::vector<const analysis::Constant*> Constant::GetVectorComponents(
     analysis::ConstantManager* const_mgr) const {
   std::vector<const analysis::Constant*> components;

--- a/source/opt/folding_rules.cpp
+++ b/source/opt/folding_rules.cpp
@@ -1504,22 +1504,12 @@ FoldingRule RedundantPhi() {
       [](ir::Instruction* inst, const std::vector<const analysis::Constant*>&) {
         assert(inst->opcode() == SpvOpPhi && "Wrong opcode.  Should be OpPhi.");
 
-        ir::IRContext* context = inst->context();
-        analysis::DefUseManager* def_use_mgr = context->get_def_use_mgr();
-
         uint32_t incoming_value = 0;
 
         for (uint32_t i = 0; i < inst->NumInOperands(); i += 2) {
           uint32_t op_id = inst->GetSingleWordInOperand(i);
           if (op_id == inst->result_id()) {
             continue;
-          }
-
-          ir::Instruction* op_inst = def_use_mgr->GetDef(op_id);
-          if (op_inst->opcode() == SpvOpUndef) {
-            // TODO: We should be able to still use op_id if we know that
-            // the definition of op_id dominates |inst|.
-            return false;
           }
 
           if (incoming_value == 0) {

--- a/test/opt/fold_test.cpp
+++ b/test/opt/fold_test.cpp
@@ -3855,14 +3855,13 @@ INSTANTIATE_TEST_CASE_P(MergeMulTest, MatchingInstructionFoldingTest,
       "OpFunctionEnd",
     2, true),
   // Test case 19: Fold OpVectorTimesScalar
-  // {-0,-0} = OpVectorTimesScalar v2float v2float_null -1
+  // {0,0} = OpVectorTimesScalar v2float v2float_null -1
   InstructionFoldingCase<bool>(
     Header() +
       "; CHECK: [[float:%\\w+]] = OpTypeFloat 32\n" +
       "; CHECK: [[v2float:%\\w+]] = OpTypeVector [[float]] 2\n" +
-      "; CHECK: [[float_n0:%\\w+]] = OpConstant [[float]] -0\n" +
-      "; CHECK: [[v2float_n0_n0:%\\w+]] = OpConstantComposite [[v2float]] [[float_n0]] [[float_n0]]\n" +
-      "; CHECK: %2 = OpCopyObject [[v2float]] [[v2float_n0_n0]]\n" +
+      "; CHECK: [[v2float_null:%\\w+]] = OpConstantNull [[v2float]]\n" +
+      "; CHECK: %2 = OpCopyObject [[v2float]] [[v2float_null]]\n" +
       "%main = OpFunction %void None %void_func\n" +
       "%main_lab = OpLabel\n" +
       "%2 = OpVectorTimesScalar %v2float %v2float_null %float_n1\n" +
@@ -3883,6 +3882,40 @@ INSTANTIATE_TEST_CASE_P(MergeMulTest, MatchingInstructionFoldingTest,
       "%2 = OpVectorTimesScalar %v2double %v2double_2_2 %double_2\n" +
       "OpReturn\n" +
       "OpFunctionEnd",
+    2, true),
+  // Test case 21: Fold OpVectorTimesScalar
+  // {0,0} = OpVectorTimesScalar v2double {0,0} n
+  InstructionFoldingCase<bool>(
+    Header() +
+        "; CHECK: [[double:%\\w+]] = OpTypeFloat 64\n" +
+        "; CHECK: [[v2double:%\\w+]] = OpTypeVector [[double]] 2\n" +
+        "; CHECK: {{%\\w+}} = OpConstant [[double]] 0\n" +
+        "; CHECK: [[double_0:%\\w+]] = OpConstant [[double]] 0\n" +
+        "; CHECK: [[v2double_0_0:%\\w+]] = OpConstantComposite [[v2double]] [[double_0]] [[double_0]]\n" +
+        "; CHECK: %2 = OpCopyObject [[v2double]] [[v2double_0_0]]\n" +
+        "%main = OpFunction %void None %void_func\n" +
+        "%main_lab = OpLabel\n" +
+        "%n = OpVariable %_ptr_double Function\n" +
+        "%load = OpLoad %double %n\n" +
+        "%2 = OpVectorTimesScalar %v2double %v2double_0_0 %load\n" +
+        "OpReturn\n" +
+        "OpFunctionEnd",
+    2, true),
+  // Test case 22: Fold OpVectorTimesScalar
+  // {0,0} = OpVectorTimesScalar v2double n 0
+  InstructionFoldingCase<bool>(
+    Header() +
+        "; CHECK: [[double:%\\w+]] = OpTypeFloat 64\n" +
+        "; CHECK: [[v2double:%\\w+]] = OpTypeVector [[double]] 2\n" +
+        "; CHECK: [[v2double_null:%\\w+]] = OpConstantNull [[v2double]]\n" +
+        "; CHECK: %2 = OpCopyObject [[v2double]] [[v2double_null]]\n" +
+        "%main = OpFunction %void None %void_func\n" +
+        "%main_lab = OpLabel\n" +
+        "%n = OpVariable %_ptr_v2double Function\n" +
+        "%load = OpLoad %v2double %n\n" +
+        "%2 = OpVectorTimesScalar %v2double %load %double_0\n" +
+        "OpReturn\n" +
+        "OpFunctionEnd",
     2, true)
 ));
 


### PR DESCRIPTION
If one of the operands to an OpVectorTimesScalar instruction is zero,
then the result will be the 0 vector.  Currently we do not fold the
insturction unless both operands are constants.  This change fixes that.

We also allow folding of OpPhi instructions where the incoming values
are either an OpUndef or the OpPhi instruction itself.  As with other
cases, this can be simplified to the OpUndef.

Contributes to #709.