### PR TITLE
Fixes handling of kill and unreachable ops in inlining.

### DIFF
--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -289,6 +289,16 @@ void InlinePass::GenInlineCode(
       case SpvOpVariable:
         // Already processed
         break;
+      case SpvOpUnreachable:
+      case SpvOpKill: {
+        // Generate a return label so that we split the block with the function
+        // call. Copy the terminator into the new block.
+        if (returnLabelId == 0) returnLabelId = this->TakeNextId();
+        std::unique_ptr<ir::Instruction> terminator(
+            new ir::Instruction(context(), cpi->opcode(), 0, 0, {}));
+        new_blk_ptr->AddInstruction(std::move(terminator));
+        break;
+      }
       case SpvOpLabel: {
         // If previous instruction was early return, insert branch
         // instruction to return block.

--- a/test/opt/inline_test.cpp
+++ b/test/opt/inline_test.cpp
@@ -2587,6 +2587,126 @@ TEST_F(InlineTest, SetParent) {
   }
 }
 
+#ifdef SPIRV_EFFCEE
+TEST_F(InlineTest, OpKill) {
+  const std::string text = R"(
+; CHECK: OpFunction
+; CHECK-NEXT: OpLabel
+; CHECK-NEXT: OpKill
+; CHECK-NEXT: OpLabel
+; CHECK-NEXT: OpReturn
+; CHECK-NEXT: OpFunctionEnd
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main"
+%void = OpTypeVoid
+%voidfuncty = OpTypeFunction %void
+%main = OpFunction %void None %voidfuncty
+%1 = OpLabel
+%2 = OpFunctionCall %void %func
+OpReturn
+OpFunctionEnd
+%func = OpFunction %void None %voidfuncty
+%3 = OpLabel
+OpKill
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::InlineExhaustivePass>(text, true);
+}
+
+TEST_F(InlineTest, OpKillWithTrailingInstructions) {
+  const std::string text = R"(
+; CHECK: OpFunction
+; CHECK-NEXT: OpLabel
+; CHECK-NEXT: [[var:%\w+]] = OpVariable
+; CHECK-NEXT: OpKill
+; CHECK-NEXT: OpLabel
+; CHECK-NEXT: OpStore [[var]]
+; CHECK-NEXT: OpReturn
+; CHECK-NEXT: OpFunctionEnd
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main"
+%void = OpTypeVoid
+%bool = OpTypeBool
+%true = OpConstantTrue %bool
+%bool_func_ptr = OpTypePointer Function %bool
+%voidfuncty = OpTypeFunction %void
+%main = OpFunction %void None %voidfuncty
+%1 = OpLabel
+%2 = OpVariable %bool_func_ptr Function
+%3 = OpFunctionCall %void %func
+OpStore %2 %true
+OpReturn
+OpFunctionEnd
+%func = OpFunction %void None %voidfuncty
+%4 = OpLabel
+OpKill
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::InlineExhaustivePass>(text, true);
+}
+
+TEST_F(InlineTest, OpKillInIf) {
+  const std::string text = R"(
+; CHECK: OpFunction
+; CHECK: OpLabel
+; CHECK: [[var:%\w+]] = OpVariable
+; CHECK-NEXT: [[ld:%\w+]] = OpLoad {{%\w+}} [[var]]
+; CHECK-NEXT: OpBranch [[label:%\w+]]
+; CHECK-NEXT: [[label]] = OpLabel
+; CHECK-NEXT: OpLoopMerge [[loop_merge:%\w+]] [[continue:%\w+]] None
+; CHECK-NEXT: OpBranch [[label:%\w+]]
+; CHECK-NEXT: [[label]] = OpLabel
+; CHECK-NEXT: OpSelectionMerge [[sel_merge:%\w+]] None
+; CHECK-NEXT: OpBranchConditional {{%\w+}} [[kill_label:%\w+]] [[label:%\w+]]
+; CHECK-NEXT: [[kill_label]] = OpLabel
+; CHECK-NEXT: OpKill
+; CHECK-NEXT: [[label]] = OpLabel
+; CHECK-NEXT: OpBranch [[loop_merge]]
+; CHECK-NEXT: [[sel_merge]] = OpLabel
+; CHECK-NEXT: OpBranch [[loop_merge]]
+; CHECK-NEXT: [[continue]] = OpLabel
+; CHECK-NEXT: OpBranchConditional
+; CHECK-NEXT: [[loop_merge]] = OpLabel
+; CHECK-NEXT: OpStore [[var]] [[ld]]
+; CHECK-NEXT: OpReturn
+; CHECK-NEXT: OpFunctionEnd
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main"
+%void = OpTypeVoid
+%bool = OpTypeBool
+%true = OpConstantTrue %bool
+%bool_func_ptr = OpTypePointer Function %bool
+%voidfuncty = OpTypeFunction %void
+%main = OpFunction %void None %voidfuncty
+%1 = OpLabel
+%2 = OpVariable %bool_func_ptr Function
+%3 = OpLoad %bool %2
+%4 = OpFunctionCall %void %func
+OpStore %2 %3
+OpReturn
+OpFunctionEnd
+%func = OpFunction %void None %voidfuncty
+%5 = OpLabel
+OpSelectionMerge %6 None
+OpBranchConditional %true %7 %8
+%7 = OpLabel
+OpKill
+%8 = OpLabel
+OpReturn
+%6 = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::InlineExhaustivePass>(text, true);
+}
+#endif
+
 // TODO(greg-lunarg): Add tests to verify handling of these cases:
 //
 //    Empty modules

--- a/test/opt/inline_test.cpp
+++ b/test/opt/inline_test.cpp
@@ -2705,6 +2705,60 @@ OpFunctionEnd
 
   SinglePassRunAndMatch<opt::InlineExhaustivePass>(text, true);
 }
+
+TEST_F(InlineTest, OpKillInLoop) {
+  const std::string text = R"(
+; CHECK: OpFunction
+; CHECK: OpLabel
+; CHECK: [[var:%\w+]] = OpVariable
+; CHECK-NEXT: [[ld:%\w+]] = OpLoad {{%\w+}} [[var]]
+; CHECK-NEXT: OpBranch [[loop:%\w+]]
+; CHECK-NEXT: [[loop]] = OpLabel
+; CHECK-NEXT: OpLoopMerge [[loop_merge:%\w+]] [[continue:%\w+]] None
+; CHECK-NEXT: OpBranch [[label:%\w+]]
+; CHECK-NEXT: [[label]] = OpLabel
+; CHECK-NEXT: OpKill
+; CHECK-NEXT: [[loop_merge]] = OpLabel
+; CHECK-NEXT: OpBranch [[label:%\w+]]
+; CHECK-NEXT: [[continue]] = OpLabel
+; CHECK-NEXT: OpBranch [[loop]]
+; CHECK-NEXT: [[label]] = OpLabel
+; CHECK-NEXT: OpStore [[var]] [[ld]]
+; CHECK-NEXT: OpReturn
+; CHECK-NEXT: OpFunctionEnd
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main"
+%void = OpTypeVoid
+%bool = OpTypeBool
+%true = OpConstantTrue %bool
+%voidfuncty = OpTypeFunction %void
+%bool_func_ptr = OpTypePointer Function %bool
+%main = OpFunction %void None %voidfuncty
+%1 = OpLabel
+%2 = OpVariable %bool_func_ptr Function
+%3 = OpLoad %bool %2
+%4 = OpFunctionCall %void %func
+OpStore %2 %3
+OpReturn
+OpFunctionEnd
+%func = OpFunction %void None %voidfuncty
+%5 = OpLabel
+OpBranch %10
+%10 = OpLabel
+OpLoopMerge %6 %7 None
+OpBranch %8
+%8 = OpLabel
+OpKill
+%6 = OpLabel
+OpReturn
+%7 = OpLabel
+OpBranch %10
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::InlineExhaustivePass>(text, true);
+}
 #endif
 
 // TODO(greg-lunarg): Add tests to verify handling of these cases:


### PR DESCRIPTION
Fixes #1527

* Adds handling for copying OpKill and OpUnreachable and forces the
generation of a new basic block
* Adds tests to check