### PR TITLE
Allow hoisting code in if-conversion. 

### DIFF
--- a/source/opt/if_conversion.h
+++ b/source/opt/if_conversion.h
@@ -68,6 +68,19 @@ class IfConversion : public Pass {
   // is terminated by a conditional branch.
   bool CheckBlock(ir::BasicBlock* block, DominatorAnalysis* dominators,
                   ir::BasicBlock** common);
+
+  // Moves |inst| to |target_block| if it does not already dominate the block.
+  // Any instructions that |inst| depends on are move if necessary.  It is
+  // assumed that |inst| can be hoisted to |target_block| as defined by
+  // |CanHoistInstruction|.  |dominators| is the dominator analysis for the
+  // function that contains |target_block|.
+  void HoistInstruction(ir::Instruction* inst, ir::BasicBlock* target_block,
+                        DominatorAnalysis* dominators);
+
+  // Returns true if it is legal to move |inst| and the instructions it depends
+  // on to |target_block| if they do not already dominate |target_block|.
+  bool CanHoistInstruction(ir::Instruction* inst, ir::BasicBlock* target_block,
+                           DominatorAnalysis* dominators);
 };
 
 }  //  namespace opt

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -523,9 +523,20 @@ std::ostream& operator<<(std::ostream& str, const ir::Instruction& inst) {
 
 bool Instruction::IsOpcodeCodeMotionSafe() const {
   switch (opcode_) {
+    case SpvOpNop:
+    case SpvOpUndef:
+    case SpvOpLoad:
+    case SpvOpAccessChain:
+    case SpvOpInBoundsAccessChain:
+    case SpvOpArrayLength:
     case SpvOpVectorExtractDynamic:
     case SpvOpVectorInsertDynamic:
     case SpvOpVectorShuffle:
+    case SpvOpCompositeConstruct:
+    case SpvOpCompositeExtract:
+    case SpvOpCompositeInsert:
+    case SpvOpCopyObject:
+    case SpvOpTranspose:
     case SpvOpConvertFToU:
     case SpvOpConvertFToS:
     case SpvOpConvertSToF:
@@ -556,11 +567,22 @@ bool Instruction::IsOpcodeCodeMotionSafe() const {
     case SpvOpVectorTimesMatrix:
     case SpvOpMatrixTimesVector:
     case SpvOpMatrixTimesMatrix:
+    case SpvOpOuterProduct:
+    case SpvOpDot:
+    case SpvOpIAddCarry:
+    case SpvOpISubBorrow:
+    case SpvOpUMulExtended:
+    case SpvOpSMulExtended:
+    case SpvOpAny:
+    case SpvOpAll:
+    case SpvOpIsNan:
+    case SpvOpIsInf:
     case SpvOpLogicalEqual:
     case SpvOpLogicalNotEqual:
     case SpvOpLogicalOr:
     case SpvOpLogicalAnd:
     case SpvOpLogicalNot:
+    case SpvOpSelect:
     case SpvOpIEqual:
     case SpvOpINotEqual:
     case SpvOpUGreaterThan:
@@ -590,10 +612,12 @@ bool Instruction::IsOpcodeCodeMotionSafe() const {
     case SpvOpBitwiseXor:
     case SpvOpBitwiseAnd:
     case SpvOpNot:
-    case SpvOpAccessChain:
-    case SpvOpInBoundsAccessChain:
-    case SpvOpPtrAccessChain:
-    case SpvOpInBoundsPtrAccessChain:
+    case SpvOpBitFieldInsert:
+    case SpvOpBitFieldSExtract:
+    case SpvOpBitFieldUExtract:
+    case SpvOpBitReverse:
+    case SpvOpBitCount:
+    case SpvOpSizeOf:
       return true;
     default:
       return false;

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -51,6 +51,9 @@ void IRContext::BuildInvalidAnalyses(IRContext::Analysis set) {
   if (set & kAnalysisRegisterPressure) {
     BuildRegPressureAnalysis();
   }
+  if (set & kAnalysisValueNumberTable) {
+    BuildValueNumberTable();
+  }
 }
 
 void IRContext::InvalidateAnalysesExceptFor(
@@ -81,6 +84,9 @@ void IRContext::InvalidateAnalyses(IRContext::Analysis analyses_to_invalidate) {
   }
   if (analyses_to_invalidate & kAnalysisNameMap) {
     id_to_name_.reset(nullptr);
+  }
+  if (analyses_to_invalidate & kAnalysisValueNumberTable) {
+    vn_table_.reset(nullptr);
   }
 
   valid_analyses_ = Analysis(valid_analyses_ & ~analyses_to_invalidate);

--- a/source/opt/value_number_table.cpp
+++ b/source/opt/value_number_table.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 
 #include "cfg.h"
+#include "ir_context.h"
 
 namespace spvtools {
 namespace opt {
@@ -32,6 +33,10 @@ uint32_t ValueNumberTable::GetValueNumber(
     return result_id_to_val->second;
   }
   return 0;
+}
+
+uint32_t ValueNumberTable::GetValueNumber(uint32_t id) const {
+  return GetValueNumber(context()->get_def_use_mgr()->GetDef(id));
 }
 
 uint32_t ValueNumberTable::AssignValueNumber(ir::Instruction* inst) {

--- a/source/opt/value_number_table.h
+++ b/source/opt/value_number_table.h
@@ -18,7 +18,12 @@
 #include <cstdint>
 #include <unordered_map>
 #include "instruction.h"
-#include "ir_context.h"
+
+namespace spvtools {
+namespace ir {
+class IRContext;
+}
+}  // namespace spvtools
 
 namespace spvtools {
 namespace opt {
@@ -60,7 +65,7 @@ class ValueNumberTable {
 
   // Returns the value number of the value contain in |id|.  Returns 0 if it
   // has not been assigned a value number.
-  inline uint32_t GetValueNumber(uint32_t id) const;
+  uint32_t GetValueNumber(uint32_t id) const;
 
   ir::IRContext* context() const { return context_; }
 
@@ -83,10 +88,6 @@ class ValueNumberTable {
   ir::IRContext* context_;
   uint32_t next_value_number_;
 };
-
-uint32_t ValueNumberTable::GetValueNumber(uint32_t id) const {
-  return GetValueNumber(context()->get_def_use_mgr()->GetDef(id));
-}
 
 }  // namespace opt
 }  // namespace spvtools


### PR DESCRIPTION
When doing if-conversion, we do not currently move code out of the side
nodes.  The reason for this is that it can increase the number of
instructions that get executed because both side nods will have to be
executed now.

In this commit, we add code to move an instruction, and all of the
instructions it depends on, out of a side node and into the header of
the selection construct.  However to keep the cost down, we only do it
when the two values in the OpPhi node compute the same value.  This way
we have to move only one of the instructions and the other becomes
unused most of the time.  So no real extra cost.

Fixes #1526.