### PR TITLE
Fold fclamp feeding compare.

### DIFF
--- a/source/opt/constants.cpp
+++ b/source/opt/constants.cpp
@@ -44,6 +44,16 @@ double Constant::GetDouble() const {
   }
 }
 
+double Constant::GetValueAsDouble() const {
+  assert(type()->AsFloat() != nullptr);
+  if (type()->AsFloat()->width() == 32) {
+    return GetFloat();
+  } else {
+    assert(type()->AsFloat()->width() == 64);
+    return GetDouble();
+  }
+}
+
 uint32_t Constant::GetU32() const {
   assert(type()->AsInteger() != nullptr);
   assert(type()->AsInteger()->width() == 32);

--- a/source/opt/constants.h
+++ b/source/opt/constants.h
@@ -92,6 +92,10 @@ class Constant {
   // Float type.
   double GetDouble() const;
 
+  // Returns the double representation of the constant. Must be a 32-bit or
+  // 64-bit Float type.
+  double GetValueAsDouble() const;
+
   // Returns uint32_t representation of the constant. Must be a 32 bit
   // Integer type.
   uint32_t GetU32() const;


### PR DESCRIPTION
An FClamp instruction forces a values to be within a certain interval.
When the upper or lower bound of the FClamp is a constant and the value
being compared with is a constant, then in some case we can fold the
compared because the entire range is say less than the value.

Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/1549.