### PR TITLE
Adjust tests according to grammar change

### DIFF
--- a/test/operand_capabilities_test.cpp
+++ b/test/operand_capabilities_test.cpp
@@ -348,7 +348,7 @@ INSTANTIATE_TEST_CASE_P(
                 CASE0(OPTIONAL_IMAGE, ImageOperandsGradMask),
                 CASE0(OPTIONAL_IMAGE, ImageOperandsConstOffsetMask),
                 CASE1(OPTIONAL_IMAGE, ImageOperandsOffsetMask, ImageGatherExtended),
-                CASE0(OPTIONAL_IMAGE, ImageOperandsConstOffsetsMask),
+                CASE1(OPTIONAL_IMAGE, ImageOperandsConstOffsetsMask, ImageGatherExtended),
                 CASE0(OPTIONAL_IMAGE, ImageOperandsSampleMask),
                 CASE1(OPTIONAL_IMAGE, ImageOperandsMinLodMask, MinLod),
                 // clang-format on
@@ -687,7 +687,7 @@ INSTANTIATE_TEST_CASE_P(
             CASE1(CAPABILITY, CapabilityImageRect, SampledRect),
             CASE1(CAPABILITY, CapabilitySampledRect, Shader),
             CASE1(CAPABILITY, CapabilityGenericPointer, Addresses),
-            CASE1(CAPABILITY, CapabilityInt8, Kernel),
+            CASE0(CAPABILITY, CapabilityInt8),
             CASE1(CAPABILITY, CapabilityInputAttachment, Shader),
             CASE1(CAPABILITY, CapabilitySparseResidency, Shader),
             CASE1(CAPABILITY, CapabilityMinLod, Shader),

--- a/test/val/val_capability_test.cpp
+++ b/test/val/val_capability_test.cpp
@@ -409,7 +409,6 @@ const vector<string>& KernelDependencies() {
   "Pipes",
   "DeviceEnqueue",
   "LiteralSampler",
-  "Int8",
   "SubgroupDispatch",
   "NamedBarrier",
   "PipeStorage"};


### PR DESCRIPTION
* ConstOffsets now requires ImageGatherExtended
* Int8 does not require Kernel anymore

See https://github.com/KhronosGroup/SPIRV-Headers/commit/3a9bf0b12a5b1a0a4996b0066f1451345c293546