### PR TITLE
Issue1559

### DIFF
--- a/source/opt/reduce_load_size.cpp
+++ b/source/opt/reduce_load_size.cpp
@@ -133,12 +133,13 @@ bool ReduceLoadSize::ShouldReplaceExtract(ir::Instruction* inst) {
   bool all_elements_used = false;
   std::set<uint32_t> elements_used;
 
-  def_use_mgr->ForEachUser(
-      op_inst, [&elements_used, &all_elements_used](ir::Instruction* use) {
+  all_elements_used = !def_use_mgr->WhileEachUser(
+      op_inst, [&elements_used](ir::Instruction* use) {
         if (use->opcode() != SpvOpCompositeExtract) {
-          all_elements_used = true;
+          return false;
         }
         elements_used.insert(use->GetSingleWordInOperand(1));
+        return true;
       });
 
   bool should_replace = false;

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -272,9 +272,9 @@ Options (in lexicographical order):
   --private-to-local
                Change the scope of private variables that are used in a single
                function to that function.
-  --remove-duplicates
-               Removes duplicate types, decorations, capabilities and extension
-               instructions.
+  --reduce-load-size
+               Replaces loads of composite objects where not every component is
+               used by loads of just the elements that are used.
   --redundancy-elimination
                Looks for instructions in the same function that compute the
                same value, and deletes the redundant ones.
@@ -282,6 +282,9 @@ Options (in lexicographical order):
                Allow store from one struct type to a different type with
                compatible layout and members. This option is forwarded to the
                validator.
+  --remove-duplicates
+               Removes duplicate types, decorations, capabilities and extension
+               instructions.
   --replace-invalid-opcode
                Replaces instructions whose opcode is valid for shader modules,
                but not for the current shader stage.  To have an effect, all


### PR DESCRIPTION
Fixes #1559.

There is a load of an operand of an instruction that was suppose to be
only for the OpCompositeExtract case.  However, an error caused it to
be loaded for every opcode, even those that do not have an operand in
that position.

We fix up that bug, and a couple other things noticed that the same
time.