### PR TITLE
Allow ViewportIndex & Layer to be used in VS/DS with extension

### DIFF
--- a/test/val/val_builtins_test.cpp
+++ b/test/val/val_builtins_test.cpp
@@ -756,8 +756,8 @@ INSTANTIATE_TEST_CASE_P(
     LayerAndViewportIndexExecutionModelEnabledByCapability,
     ValidateVulkanCombineBuiltInExecutionModelDataTypeResult,
     Combine(Values("Layer", "ViewportIndex"),
-            Values("Vertex", "TessellationEvaluation"),
-            Values("Output"), Values("%u32"),
+            Values("Vertex", "TessellationEvaluation"), Values("Output"),
+            Values("%u32"),
             Values(TestResult(
                 SPV_ERROR_INVALID_DATA,
                 "requires the ShaderViewportIndexLayerEXT capability"))), );

--- a/test/val/val_builtins_test.cpp
+++ b/test/val/val_builtins_test.cpp
@@ -744,14 +744,23 @@ INSTANTIATE_TEST_CASE_P(
 INSTANTIATE_TEST_CASE_P(
     LayerAndViewportIndexInvalidExecutionModel,
     ValidateVulkanCombineBuiltInExecutionModelDataTypeResult,
-    Combine(
-        Values("Layer", "ViewportIndex"),
-        Values("Vertex", "GLCompute", "TessellationControl",
-               "TessellationEvaluation"),
-        Values("Input"), Values("%u32"),
-        Values(TestResult(
-            SPV_ERROR_INVALID_DATA,
-            "to be used only with Fragment or Geometry execution models"))), );
+    Combine(Values("Layer", "ViewportIndex"),
+            Values("TessellationControl", "GLCompute"), Values("Input"),
+            Values("%u32"),
+            Values(TestResult(
+                SPV_ERROR_INVALID_DATA,
+                "to be used only with Vertex, TessellationEvaluation, "
+                "Geometry, or Fragment execution models"))), );
+
+INSTANTIATE_TEST_CASE_P(
+    LayerAndViewportIndexExecutionModelEnabledByCapability,
+    ValidateVulkanCombineBuiltInExecutionModelDataTypeResult,
+    Combine(Values("Layer", "ViewportIndex"),
+            Values("Vertex", "TessellationEvaluation"),
+            Values("Output"), Values("%u32"),
+            Values(TestResult(
+                SPV_ERROR_INVALID_DATA,
+                "requires the ShaderViewportIndexLayerEXT capability"))), );
 
 INSTANTIATE_TEST_CASE_P(
     LayerAndViewportIndexFragmentNotInput,
@@ -767,11 +776,13 @@ INSTANTIATE_TEST_CASE_P(
     LayerAndViewportIndexGeometryNotOutput,
     ValidateVulkanCombineBuiltInExecutionModelDataTypeResult,
     Combine(
-        Values("Layer", "ViewportIndex"), Values("Geometry"), Values("Input"),
+        Values("Layer", "ViewportIndex"),
+        Values("Vertex", "TessellationEvaluation", "Geometry"), Values("Input"),
         Values("%u32"),
         Values(TestResult(SPV_ERROR_INVALID_DATA,
-                          "Input storage class if execution model is Geometry",
-                          "which is called with execution model Geometry"))), );
+                          "Input storage class if execution model is Vertex, "
+                          "TessellationEvaluation, or Geometry",
+                          "which is called with execution model"))), );
 
 INSTANTIATE_TEST_CASE_P(
     LayerAndViewportIndexNotIntScalar,


### PR DESCRIPTION
SPV_EXT_shader_viewport_index_layer enables using ViewportIndex
and Layer in vertex and tessellation shaders.

Also, as per the Vulkan spec:

> The ViewportIndex decoration must be used only within vertex,
> tessellation evaluation, geometry, and fragment shaders.

> In a vertex, tessellation evaluation, or geometry shader, any
> variable decorated with ViewportIndex must be declared using
> the Output storage class.

> In a fragment shader, any variable decorated with ViewportIndex
> must be declared using the Input storage class.

Similarly for Layer.

Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/1563