### PR TITLE
Validate presence of OpMemoryModel.

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -158,6 +158,7 @@ ValidationState_t::ValidationState_t(const spv_const_context ctx,
       local_vars_(),
       struct_nesting_depth_(),
       grammar_(ctx),
+      has_memory_model_specified_(false),
       addressing_model_(SpvAddressingModelLogical),
       memory_model_(SpvMemoryModelSimple),
       in_function_(false) {
@@ -363,6 +364,7 @@ bool ValidationState_t::HasAnyOfExtensions(
 }
 
 void ValidationState_t::set_addressing_model(SpvAddressingModel am) {
+  has_memory_model_specified_ = true;
   addressing_model_ = am;
 }
 
@@ -371,6 +373,7 @@ SpvAddressingModel ValidationState_t::addressing_model() const {
 }
 
 void ValidationState_t::set_memory_model(SpvMemoryModel mm) {
+  has_memory_model_specified_ = true;
   memory_model_ = mm;
 }
 

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -262,6 +262,9 @@ class ValidationState_t {
   /// Sets the addressing model of this module (logical/physical).
   void set_addressing_model(SpvAddressingModel am);
 
+  /// Returns true if the OpMemoryModel was found.
+  bool has_memory_model_specified() const { return has_memory_model_specified_; }
+
   /// Returns the addressing model of this module, or Logical if uninitialized.
   SpvAddressingModel addressing_model() const;
 
@@ -544,6 +547,7 @@ class ValidationState_t {
 
   AssemblyGrammar grammar_;
 
+  bool has_memory_model_specified_ ;
   SpvAddressingModel addressing_model_;
   SpvMemoryModel memory_model_;
 

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -279,6 +279,10 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
                                   ProcessInstruction, pDiagnostic))
     return error;
 
+  if (!vstate->has_memory_model_specified())
+    return vstate->diag(SPV_ERROR_INVALID_LAYOUT)
+           << "Missing required OpMemoryModel instruction.";
+
   if (vstate->in_function_body())
     return vstate->diag(SPV_ERROR_INVALID_LAYOUT)
            << "Missing OpFunctionEnd at end of module.";

--- a/test/val/val_layout_test.cpp
+++ b/test/val/val_layout_test.cpp
@@ -220,7 +220,7 @@ TEST_P(ValidateLayout, Layout) {
   // clang-format on
 }
 
-TEST_F(ValidateLayout, MemoryModelMissing) {
+TEST_F(ValidateLayout, MemoryModelMissingBeforeEntryPoint) {
   string str = R"(
     OpCapability Matrix
     OpExtension "TestExtension"
@@ -235,6 +235,16 @@ TEST_F(ValidateLayout, MemoryModelMissing) {
       getDiagnosticString(),
       HasSubstr(
           "EntryPoint cannot appear before the memory model instruction"));
+}
+
+TEST_F(ValidateLayout, MemoryModelMissing) {
+  char str[] = R"(OpCapability Linkage)";
+  CompileSuccessfully(str, SPV_ENV_UNIVERSAL_1_1);
+  ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT,
+          ValidateInstructions(SPV_ENV_UNIVERSAL_1_1));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Missing required OpMemoryModel instruction"));
 }
 
 TEST_F(ValidateLayout, FunctionDefinitionBeforeDeclarationBad) {


### PR DESCRIPTION
According to the SPIR-V Spec, section 2.4 Logical Layout of a Module there
should be a single required OpMemoryModel instruction provided. This CL adds
validation that OpMemoryModel is provided to the SPIR-V validator.

Fixes #1207