### PR TITLE
Validate that only a single OpMemoryModel is provided.

### DIFF
--- a/source/validate_instruction.cpp
+++ b/source/validate_instruction.cpp
@@ -488,6 +488,10 @@ spv_result_t InstructionPass(ValidationState_t& _,
     _.RegisterCapability(
         static_cast<SpvCapability>(inst->words[inst->operands[0].offset]));
   } else if (opcode == SpvOpMemoryModel) {
+    if (_.has_memory_model_specified()) {
+      return _.diag(SPV_ERROR_INVALID_LAYOUT)
+             << "OpMemoryModel should only be provided once.";
+    }
     _.set_addressing_model(
         static_cast<SpvAddressingModel>(inst->words[inst->operands[0].offset]));
     _.set_memory_model(

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -37,7 +37,7 @@ using ::testing::ValuesIn;
 
 using ValidateIdWithMessage = spvtest::ValidateBase<bool>;
 
-string kGLSL450MemoryModel = R"(
+string kOpCapabilitySetup = R"(
      OpCapability Shader
      OpCapability Linkage
      OpCapability Addresses
@@ -49,6 +49,9 @@ string kGLSL450MemoryModel = R"(
      OpCapability Int16
      OpCapability Int64
      OpCapability Float64
+)";
+
+string kGLSL450MemoryModel = kOpCapabilitySetup + R"(
      OpMemoryModel Logical GLSL450
 )";
 
@@ -4316,7 +4319,7 @@ TEST_F(ValidateIdWithMessage, OpReturnValueIsVoid) {
 
 TEST_F(ValidateIdWithMessage, OpReturnValueIsVariableInPhysical) {
   // It's valid to return a pointer in a physical addressing model.
-  string spirv = kGLSL450MemoryModel + R"(
+  string spirv = kOpCapabilitySetup + R"(
      OpMemoryModel Physical32 OpenCL
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -4333,7 +4336,7 @@ TEST_F(ValidateIdWithMessage, OpReturnValueIsVariableInPhysical) {
 
 TEST_F(ValidateIdWithMessage, OpReturnValueIsVariableInLogical) {
   // It's invalid to return a pointer in a physical addressing model.
-  string spirv = kGLSL450MemoryModel + R"(
+  string spirv = kOpCapabilitySetup + R"(
      OpMemoryModel Logical GLSL450
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0

--- a/test/val/val_layout_test.cpp
+++ b/test/val/val_layout_test.cpp
@@ -246,6 +246,21 @@ TEST_F(ValidateLayout, MemoryModelMissing) {
               HasSubstr("Missing required OpMemoryModel instruction"));
 }
 
+TEST_F(ValidateLayout, MemoryModelSpecifiedTwice) {
+  char str[] = R"(
+    OpCapability Linkage
+    OpCapability Shader
+    OpMemoryModel Logical Simple
+    OpMemoryModel Logical Simple
+    )";
+
+  CompileSuccessfully(str, SPV_ENV_UNIVERSAL_1_1);
+  ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT,
+            ValidateInstructions(SPV_ENV_UNIVERSAL_1_1));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpMemoryModel should only be provided once"));
+}
+
 TEST_F(ValidateLayout, FunctionDefinitionBeforeDeclarationBad) {
   char str[] = R"(
            OpCapability Shader


### PR DESCRIPTION
This CL adds validation that only a single OpMemoryModel is provided in the
SPIR-V binary.
    
Fixes #1574