### PR TITLE
Allow duplicate pointer types

### DIFF
--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -377,11 +377,8 @@ uint32_t ScalarReplacementPass::GetOrCreatePointerType(uint32_t id) {
     if (global.opcode() == SpvOpTypePointer &&
         global.GetSingleWordInOperand(0u) == SpvStorageClassFunction &&
         global.GetSingleWordInOperand(1u) == id) {
-      if (!context()->get_feature_mgr()->HasExtension(
-              libspirv::Extension::kSPV_KHR_variable_pointers) ||
-          get_decoration_mgr()->GetDecorationsFor(id, false).empty()) {
-        // If variable pointers is enabled, only reuse a decoration-less
-        // pointer of the correct type.
+      if (get_decoration_mgr()->GetDecorationsFor(id, false).empty()) {
+        // Only reuse a decoration-less pointer of the correct type.
         ptrId = global.result_id();
         break;
       }

--- a/source/validate_type_unique.cpp
+++ b/source/validate_type_unique.cpp
@@ -37,14 +37,8 @@ spv_result_t TypeUniquePass(ValidationState_t& _,
 
   if (spvOpcodeGeneratesType(opcode)) {
     if (opcode == SpvOpTypeArray || opcode == SpvOpTypeRuntimeArray ||
-        opcode == SpvOpTypeStruct) {
+        opcode == SpvOpTypeStruct || opcode == SpvOpTypePointer) {
       // Duplicate declarations of aggregates are allowed.
-      return SPV_SUCCESS;
-    }
-
-    if (inst->opcode == SpvOpTypePointer &&
-        _.HasExtension(Extension::kSPV_KHR_variable_pointers)) {
-      // Duplicate pointer types are allowed with this extension.
       return SPV_SUCCESS;
     }
 

--- a/test/val/val_type_unique_test.cpp
+++ b/test/val/val_type_unique_test.cpp
@@ -245,9 +245,7 @@ OpMemoryModel Logical GLSL450
 %ptr2 = OpTypePointer Input %u32
 )";
   CompileSuccessfully(str.c_str());
-  ASSERT_EQ(kDuplicateTypeError, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr(GetErrorString(SpvOpTypePointer)));
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
 TEST_F(ValidateTypeUnique, DuplicatePointerTypesWithExtension) {


### PR DESCRIPTION
Fixes #1577

* Remove validation requiring unique pointer types unless variable
pointers extension enabled
* Modified scalar replacement to always look for an undecorated pointer