### PR TITLE
Validate static uses of interfaces

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -51,6 +51,7 @@ SPVTOOLS_SRC_FILES := \
 		source/validate_ext_inst.cpp \
 		source/validate_id.cpp \
 		source/validate_image.cpp \
+		source/validate_interfaces.cpp \
 		source/validate_instruction.cpp \
 		source/validate_layout.cpp \
 		source/validate_literals.cpp \

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -298,6 +298,7 @@ set(SPIRV_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/validate_ext_inst.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/validate_id.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/validate_image.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/validate_interfaces.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/validate_instruction.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/validate_layout.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/validate_literals.cpp

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -155,12 +155,17 @@ class ValidationState_t {
   /// instruction
   bool in_block() const;
 
+  struct EntryPointDescription {
+    std::string name;
+    std::vector<uint32_t> interfaces;
+  };
+
   /// Registers |id| as an entry point with |execution_model| and |interfaces|.
   void RegisterEntryPoint(const uint32_t id, SpvExecutionModel execution_model,
-                          std::vector<uint32_t>&& interfaces) {
+                          EntryPointDescription&& desc) {
     entry_points_.push_back(id);
     entry_point_to_execution_models_[id].insert(execution_model);
-    entry_point_interfaces_[id].emplace_back(interfaces);
+    entry_point_descriptions_[id].emplace_back(desc);
   }
 
   /// Returns a list of entry point function ids
@@ -172,11 +177,10 @@ class ValidationState_t {
     entry_point_to_execution_modes_[entry_point].insert(execution_mode);
   }
 
-  /// Returns the interface lists of a given entry point. If the given id is not
-  /// a valid Entry Point id, std::out_of_range exception is thrown.
-  const std::vector<std::vector<uint32_t>>& entry_point_interfaces(
-      uint32_t entry_point) const {
-    return entry_point_interfaces_.at(entry_point);
+  /// Returns the interface descriptions of a given entry point.
+  const std::vector<EntryPointDescription>& entry_point_descriptions(
+      uint32_t entry_point) {
+    return entry_point_descriptions_.at(entry_point);
   }
 
   /// Returns Execution Models for the given Entry Point.
@@ -512,9 +516,9 @@ class ValidationState_t {
   /// IDs that are entry points, ie, arguments to OpEntryPoint.
   std::vector<uint32_t> entry_points_;
 
-  /// Maps an entry point id to its interface lists.
-  std::unordered_map<uint32_t, std::vector<std::vector<uint32_t>>>
-      entry_point_interfaces_;
+  /// Maps an entry point id to its desciptions.
+  std::unordered_map<uint32_t, std::vector<EntryPointDescription>>
+      entry_point_descriptions_;
 
   /// Functions IDs that are target of OpFunctionCall.
   std::unordered_set<uint32_t> function_call_targets_;

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -155,22 +155,16 @@ class ValidationState_t {
   /// instruction
   bool in_block() const;
 
-  /// Registers the given <id> as an Entry Point with |execution_model|.
-  void RegisterEntryPointId(const uint32_t id,
-                            SpvExecutionModel execution_model) {
+  /// Registers |id| as an entry point with |execution_model| and |interfaces|.
+  void RegisterEntryPoint(const uint32_t id, SpvExecutionModel execution_model,
+                          std::vector<uint32_t>&& interfaces) {
     entry_points_.push_back(id);
-    entry_point_interfaces_.emplace(id, std::vector<uint32_t>());
     entry_point_to_execution_models_[id].insert(execution_model);
+    entry_point_interfaces_[id].emplace_back(interfaces);
   }
 
   /// Returns a list of entry point function ids
   const std::vector<uint32_t>& entry_points() const { return entry_points_; }
-
-  /// Adds a new interface id to the interfaces of the given entry point.
-  void RegisterInterfaceForEntryPoint(uint32_t entry_point,
-                                      uint32_t interface) {
-    entry_point_interfaces_[entry_point].push_back(interface);
-  }
 
   /// Registers execution mode for the given entry point.
   void RegisterExecutionModeForEntryPoint(uint32_t entry_point,
@@ -178,9 +172,9 @@ class ValidationState_t {
     entry_point_to_execution_modes_[entry_point].insert(execution_mode);
   }
 
-  /// Returns the interfaces of a given entry point. If the given id is not a
-  /// valid Entry Point id, std::out_of_range exception is thrown.
-  const std::vector<uint32_t>& entry_point_interfaces(
+  /// Returns the interface lists of a given entry point. If the given id is not
+  /// a valid Entry Point id, std::out_of_range exception is thrown.
+  const std::vector<std::vector<uint32_t>>& entry_point_interfaces(
       uint32_t entry_point) const {
     return entry_point_interfaces_.at(entry_point);
   }
@@ -518,8 +512,9 @@ class ValidationState_t {
   /// IDs that are entry points, ie, arguments to OpEntryPoint.
   std::vector<uint32_t> entry_points_;
 
-  /// Maps an entry point id to its interfaces.
-  std::unordered_map<uint32_t, std::vector<uint32_t>> entry_point_interfaces_;
+  /// Maps an entry point id to its interface lists.
+  std::unordered_map<uint32_t, std::vector<std::vector<uint32_t>>>
+      entry_point_interfaces_;
 
   /// Functions IDs that are target of OpFunctionCall.
   std::unordered_set<uint32_t> function_call_targets_;

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -158,11 +158,15 @@ spv_result_t ProcessInstruction(void* user_data,
   if (static_cast<SpvOp>(inst->opcode) == SpvOpEntryPoint) {
     const auto entry_point = inst->words[2];
     const SpvExecutionModel execution_model = SpvExecutionModel(inst->words[1]);
+    const char* str =
+        reinterpret_cast<const char*>(inst->words + inst->operands[2].offset);
+    ValidationState_t::EntryPointDescription desc;
+    desc.name = str;
     std::vector<uint32_t> interfaces;
     for (int i = 3; i < inst->num_operands; ++i) {
-      interfaces.push_back(inst->words[inst->operands[i].offset]);
+      desc.interfaces.push_back(inst->words[inst->operands[i].offset]);
     }
-    _.RegisterEntryPoint(entry_point, execution_model, std::move(interfaces));
+    _.RegisterEntryPoint(entry_point, execution_model, std::move(desc));
   }
   if (static_cast<SpvOp>(inst->opcode) == SpvOpFunctionCall) {
     _.AddFunctionCallTarget(inst->words[3]);

--- a/source/validate.h
+++ b/source/validate.h
@@ -75,6 +75,16 @@ spv_result_t CheckIdDefinitionDominateUse(const ValidationState_t& _);
 /// @return SPV_SUCCESS if no errors are found. SPV_ERROR_INVALID_DATA otherwise
 spv_result_t ValidateAdjacency(ValidationState_t& _);
 
+/// @brief Validates static uses of input and output variables
+///
+/// Checks that any entry point that uses a input or output variable lists that
+/// variable in its interface.
+///
+/// @param[in] _ the validation state of the module
+///
+/// @return SPV_SUCCESS if no errors are found.
+spv_result_t ValidateInterfaces(ValidationState_t& _);
+
 /// @brief Updates the immediate dominator for each of the block edges
 ///
 /// Updates the immediate dominator of the blocks for each of the edges

--- a/source/validate_decorations.cpp
+++ b/source/validate_decorations.cpp
@@ -119,12 +119,11 @@ spv_result_t CheckBuiltInVariable(uint32_t var_id, ValidationState_t& vstate) {
 // Checks whether proper decorations have been appied to the entry points.
 spv_result_t CheckDecorationsOfEntryPoints(ValidationState_t& vstate) {
   for (uint32_t entry_point : vstate.entry_points()) {
-    const auto& interfaces = vstate.entry_point_interfaces(entry_point);
+    const auto& descs = vstate.entry_point_descriptions(entry_point);
     int num_builtin_inputs = 0;
     int num_builtin_outputs = 0;
-    for (const auto& interface_list : interfaces) {
-      // for (auto interface : interfaces) {
-      for (auto interface : interface_list) {
+    for (const auto& desc : descs) {
+      for (auto interface : desc.interfaces) {
         Instruction* var_instr = vstate.FindDef(interface);
         if (SpvOpVariable != var_instr->opcode()) {
           return vstate.diag(SPV_ERROR_INVALID_ID)

--- a/source/validate_interfaces.cpp
+++ b/source/validate_interfaces.cpp
@@ -73,9 +73,9 @@ spv_result_t check_interface_variable(ValidationState_t& _, Instruction* var) {
                      entry_points.end());
 
   for (auto id : entry_points) {
-    for (const auto& interface_list : _.entry_point_interfaces(id)) {
+    for (const auto& desc : _.entry_point_descriptions(id)) {
       bool found = false;
-      for (auto interface : interface_list) {
+      for (auto interface : desc.interfaces) {
         if (var->id() == interface) {
           found = true;
           break;
@@ -84,8 +84,8 @@ spv_result_t check_interface_variable(ValidationState_t& _, Instruction* var) {
       if (!found) {
         return _.diag(SPV_ERROR_INVALID_ID)
                << (var->word(3u) == SpvStorageClassInput ? "Input" : "Output")
-               << " variable id <" << var->id()
-               << "> is used by entry point id <" << id
+               << " variable id <" << var->id() << "> is used by entry point '"
+               << desc.name << "' id <" << id
                << ">, but is not listed as an interface";
       }
     }

--- a/source/validate_interfaces.cpp
+++ b/source/validate_interfaces.cpp
@@ -1,0 +1,112 @@
+// Copyright (c) 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "validate.h"
+
+#include <algorithm>
+
+#include "diagnostic.h"
+#include "val/function.h"
+#include "val/instruction.h"
+#include "val/validation_state.h"
+
+namespace libspirv {
+
+namespace {
+
+// Returns true if \c inst is an input or output variable.
+bool is_interface_variable(const Instruction* inst) {
+  return inst->opcode() == SpvOpVariable &&
+         (inst->word(3u) == SpvStorageClassInput ||
+          inst->word(3u) == SpvStorageClassOutput);
+}
+
+// Checks that \c var is listed as an interface in all the entry points that use
+// it.
+spv_result_t check_interface_variable(ValidationState_t& _, Instruction* var) {
+  std::vector<const Function*> functions;
+  std::vector<const Instruction*> uses;
+  for (auto use : var->uses()) {
+    uses.push_back(use.first);
+  }
+  for (uint32_t i = 0; i < uses.size(); ++i) {
+    const auto user = uses[i];
+    if (const Function* func = user->function()) {
+      functions.push_back(func);
+    } else {
+      // In the rare case that the variable is used by another instruction in
+      // the global scope, continue searching for an instruction used in a
+      // function.
+      for (auto use : user->uses()) {
+        uses.push_back(use.first);
+      }
+    }
+  }
+
+  std::sort(functions.begin(), functions.end(),
+            [](const Function* lhs, const Function* rhs) {
+              return lhs->id() < rhs->id();
+            });
+  functions.erase(std::unique(functions.begin(), functions.end()),
+                  functions.end());
+
+  std::vector<uint32_t> entry_points;
+  for (const auto func : functions) {
+    for (auto id : _.FunctionEntryPoints(func->id())) {
+      entry_points.push_back(id);
+    }
+  }
+
+  std::sort(entry_points.begin(), entry_points.end());
+  entry_points.erase(std::unique(entry_points.begin(), entry_points.end()),
+                     entry_points.end());
+
+  for (auto id : entry_points) {
+    for (const auto& interface_list : _.entry_point_interfaces(id)) {
+      bool found = false;
+      for (auto interface : interface_list) {
+        if (var->id() == interface) {
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        return _.diag(SPV_ERROR_INVALID_ID)
+               << (var->word(3u) == SpvStorageClassInput ? "Input" : "Output")
+               << " variable id <" << var->id()
+               << "> is used by entry point id <" << id
+               << ">, but is not listed as an interface";
+      }
+    }
+  }
+
+  return SPV_SUCCESS;
+}
+
+}  // namespace
+
+spv_result_t ValidateInterfaces(ValidationState_t& _) {
+  for (auto pair : _.all_definitions()) {
+    auto inst = pair.second;
+    if (is_interface_variable(inst)) {
+      if (auto error = check_interface_variable(_, inst)) {
+        return error;
+      }
+    }
+  }
+
+  return SPV_SUCCESS;
+}
+
+}  // namespace libspirv

--- a/test/opt/aggressive_dead_code_elim_test.cpp
+++ b/test/opt/aggressive_dead_code_elim_test.cpp
@@ -3921,7 +3921,7 @@ OpFunctionEnd
 TEST_F(AggressiveDCETest, LiveNestedSwitch) {
   const std::string text = R"(OpCapability Shader
 OpMemoryModel Logical GLSL450
-OpEntryPoint Fragment %func "func" %3
+OpEntryPoint Fragment %func "func" %3 %10
 OpExecutionMode %func OriginUpperLeft
 OpName %func "func"
 %void = OpTypeVoid

--- a/test/opt/local_ssa_elim_test.cpp
+++ b/test/opt/local_ssa_elim_test.cpp
@@ -1630,7 +1630,7 @@ TEST_F(LocalSSAElimTest, CompositeExtractProblem) {
                OpCapability Tessellation
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
-               OpEntryPoint TessellationControl %2 "main"
+               OpEntryPoint TessellationControl %2 "main" %16 %17 %18 %20 %22 %26 %27 %30 %31
        %void = OpTypeVoid
           %4 = OpTypeFunction %void
       %float = OpTypeFloat 32

--- a/test/val/CMakeLists.txt
+++ b/test/val/CMakeLists.txt
@@ -49,6 +49,7 @@ add_spvtools_unittest(TARGET val_ijklmnop
   SRCS
        val_id_test.cpp
        val_image_test.cpp
+       val_interfaces_test.cpp
        val_layout_test.cpp
        val_literals_test.cpp
        val_logicals_test.cpp

--- a/test/val/val_builtins_test.cpp
+++ b/test/val/val_builtins_test.cpp
@@ -57,6 +57,7 @@ struct EntryPoint {
   std::string execution_model;
   std::string execution_modes;
   std::string body;
+  std::string interfaces;
 };
 
 class CodeGenerator {
@@ -82,7 +83,8 @@ std::string CodeGenerator::Build() const {
 
   for (const EntryPoint& entry_point : entry_points_) {
     ss << "OpEntryPoint " << entry_point.execution_model << " %"
-       << entry_point.name << " \"" << entry_point.name << "\"\n";
+       << entry_point.name << " \"" << entry_point.name << "\" "
+       << entry_point.interfaces << "\n";
   }
 
   for (const EntryPoint& entry_point : entry_points_) {
@@ -228,6 +230,10 @@ TEST_P(ValidateVulkanCombineBuiltInExecutionModelDataTypeResult, InMain) {
   EntryPoint entry_point;
   entry_point.name = "main";
   entry_point.execution_model = execution_model;
+  if (strncmp(storage_class, "Input", 5) == 0 ||
+      strncmp(storage_class, "Output", 6) == 0) {
+    entry_point.interfaces = "%built_in_var";
+  }
 
   std::ostringstream execution_modes;
   if (0 == std::strcmp(execution_model, "Fragment")) {
@@ -281,6 +287,10 @@ TEST_P(ValidateVulkanCombineBuiltInExecutionModelDataTypeResult, InFunction) {
   EntryPoint entry_point;
   entry_point.name = "main";
   entry_point.execution_model = execution_model;
+  if (strncmp(storage_class, "Input", 5) == 0 ||
+      strncmp(storage_class, "Output", 6) == 0) {
+    entry_point.interfaces = "%built_in_var";
+  }
 
   std::ostringstream execution_modes;
   if (0 == std::strcmp(execution_model, "Fragment")) {
@@ -339,6 +349,10 @@ TEST_P(ValidateVulkanCombineBuiltInExecutionModelDataTypeResult, Variable) {
   EntryPoint entry_point;
   entry_point.name = "main";
   entry_point.execution_model = execution_model;
+  if (strncmp(storage_class, "Input", 5) == 0 ||
+      strncmp(storage_class, "Output", 6) == 0) {
+    entry_point.interfaces = "%built_in_var";
+  }
   // Any kind of reference would do.
   entry_point.body = R"(
 %val = OpBitcast %u64 %built_in_var
@@ -1514,6 +1528,7 @@ TEST_P(ValidateVulkanCombineBuiltInArrayedVariable, Variable) {
   EntryPoint entry_point;
   entry_point.name = "main";
   entry_point.execution_model = execution_model;
+  entry_point.interfaces = "%built_in_var";
   // Any kind of reference would do.
   entry_point.body = R"(
 %val = OpBitcast %u64 %built_in_var
@@ -1842,6 +1857,7 @@ OpMemberDecorate %output_type 0 BuiltIn Position
   EntryPoint entry_point;
   entry_point.name = "main";
   entry_point.execution_model = "Geometry";
+  entry_point.interfaces = "%input %output";
   entry_point.body = R"(
 %input_pos = OpAccessChain %input_f32vec4_ptr %input %u32_0 %u32_0
 %output_pos = OpAccessChain %output_f32vec4_ptr %output %u32_0 %u32_0
@@ -1876,6 +1892,7 @@ OpMemberDecorate %output_type 0 BuiltIn Position
   EntryPoint entry_point;
   entry_point.name = "main";
   entry_point.execution_model = "Geometry";
+  entry_point.interfaces = "%input %output";
   entry_point.body = R"(
 %input_pos = OpAccessChain %input_f32vec4_ptr %input %u32_0
 %output_pos = OpAccessChain %output_f32vec4_ptr %output %u32_0
@@ -1913,6 +1930,7 @@ OpMemberDecorate %output_type 0 BuiltIn FragCoord
   EntryPoint entry_point;
   entry_point.name = "main";
   entry_point.execution_model = "Geometry";
+  entry_point.interfaces = "%input %output";
   entry_point.body = R"(
 %input_pos = OpAccessChain %input_f32vec4_ptr %input %u32_0
 %output_pos = OpAccessChain %output_f32vec4_ptr %output %u32_0
@@ -1942,6 +1960,7 @@ OpDecorate %position BuiltIn Position
   EntryPoint entry_point;
   entry_point.name = "main";
   entry_point.execution_model = "Vertex";
+  entry_point.interfaces = "%position";
   entry_point.body = R"(
 OpStore %position %f32vec4_0123
 )";
@@ -1967,6 +1986,7 @@ OpMemberDecorate %output_type 0 BuiltIn Position
   EntryPoint entry_point;
   entry_point.name = "vmain";
   entry_point.execution_model = "Vertex";
+  entry_point.interfaces = "%output";
   entry_point.body = R"(
 %val1 = OpFunctionCall %void %foo
 )";
@@ -1974,6 +1994,7 @@ OpMemberDecorate %output_type 0 BuiltIn Position
 
   entry_point.name = "fmain";
   entry_point.execution_model = "Fragment";
+  entry_point.interfaces = "%output";
   entry_point.execution_modes = "OpExecutionMode %fmain OriginUpperLeft";
   entry_point.body = R"(
 %val2 = OpFunctionCall %void %foo
@@ -2015,6 +2036,7 @@ OpMemberDecorate %output_type 0 BuiltIn FragDepth
   EntryPoint entry_point;
   entry_point.name = "main";
   entry_point.execution_model = "Fragment";
+  entry_point.interfaces = "%output";
   entry_point.execution_modes = "OpExecutionMode %main OriginUpperLeft";
   entry_point.body = R"(
 %val2 = OpFunctionCall %void %foo
@@ -2053,6 +2075,7 @@ OpMemberDecorate %output_type 0 BuiltIn FragDepth
   EntryPoint entry_point;
   entry_point.name = "main_d_r";
   entry_point.execution_model = "Fragment";
+  entry_point.interfaces = "%output";
   entry_point.execution_modes =
       "OpExecutionMode %main_d_r OriginUpperLeft\n"
       "OpExecutionMode %main_d_r DepthReplacing";
@@ -2063,6 +2086,7 @@ OpMemberDecorate %output_type 0 BuiltIn FragDepth
 
   entry_point.name = "main_no_d_r";
   entry_point.execution_model = "Fragment";
+  entry_point.interfaces = "%output";
   entry_point.execution_modes = "OpExecutionMode %main_no_d_r OriginUpperLeft";
   entry_point.body = R"(
 %val3 = OpFunctionCall %void %foo

--- a/test/val/val_derivatives_test.cpp
+++ b/test/val/val_derivatives_test.cpp
@@ -38,7 +38,10 @@ OpCapability DerivativeControl
 
   ss << capabilities_and_extensions;
   ss << "OpMemoryModel Logical GLSL450\n";
-  ss << "OpEntryPoint " << execution_model << " %main \"main\"\n";
+  ss << "OpEntryPoint " << execution_model << " %main \"main\""
+     << " %f32_var_input"
+     << " %f32vec4_var_input"
+     << "\n";
 
   ss << R"(
 %void = OpTypeVoid

--- a/test/val/val_ext_inst_test.cpp
+++ b/test/val/val_ext_inst_test.cpp
@@ -91,7 +91,18 @@ OpCapability Int64
   ss << capabilities_and_extensions;
   ss << "%extinst = OpExtInstImport \"GLSL.std.450\"\n";
   ss << "OpMemoryModel Logical GLSL450\n";
-  ss << "OpEntryPoint " << execution_model << " %main \"main\"\n";
+  ss << "OpEntryPoint " << execution_model << " %main \"main\""
+     << " %f32_output"
+     << " %f32vec2_output"
+     << " %u32_output"
+     << " %u32vec2_output"
+     << " %u64_output"
+     << " %f32_input"
+     << " %f32vec2_input"
+     << " %u32_input"
+     << " %u32vec2_input"
+     << " %u64_input"
+     << "\n";
 
   ss << R"(
 %void = OpTypeVoid
@@ -477,16 +488,8 @@ TEST_P(ValidateGlslStd450SqrtLike, IntOperand) {
 
 INSTANTIATE_TEST_CASE_P(AllSqrtLike, ValidateGlslStd450SqrtLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "Round",
-                            "RoundEven",
-                            "FAbs",
-                            "Trunc",
-                            "FSign",
-                            "Floor",
-                            "Ceil",
-                            "Fract",
-                            "Sqrt",
-                            "InverseSqrt",
+                            "Round", "RoundEven", "FAbs", "Trunc", "FSign",
+                            "Floor", "Ceil", "Fract", "Sqrt", "InverseSqrt",
                             "Normalize",
                         }), );
 
@@ -544,12 +547,7 @@ TEST_P(ValidateGlslStd450FMinLike, IntOperand2) {
 
 INSTANTIATE_TEST_CASE_P(AllFMinLike, ValidateGlslStd450FMinLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "FMin",
-                            "FMax",
-                            "Step",
-                            "Reflect",
-                            "NMin",
-                            "NMax",
+                            "FMin", "FMax", "Step", "Reflect", "NMin", "NMax",
                         }), );
 
 TEST_P(ValidateGlslStd450FClampLike, Success) {
@@ -619,12 +617,8 @@ TEST_P(ValidateGlslStd450FClampLike, IntOperand3) {
 
 INSTANTIATE_TEST_CASE_P(AllFClampLike, ValidateGlslStd450FClampLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "FClamp",
-                            "FMix",
-                            "SmoothStep",
-                            "Fma",
-                            "FaceForward",
-                            "NClamp",
+                            "FClamp", "FMix", "SmoothStep", "Fma",
+                            "FaceForward", "NClamp",
                         }), );
 
 TEST_P(ValidateGlslStd450SAbsLike, Success) {
@@ -700,11 +694,7 @@ TEST_P(ValidateGlslStd450SAbsLike, WrongBitWidthOperand) {
 
 INSTANTIATE_TEST_CASE_P(AllSAbsLike, ValidateGlslStd450SAbsLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "SAbs",
-                            "SSign",
-                            "FindILsb",
-                            "FindUMsb",
-                            "FindSMsb",
+                            "SAbs", "SSign", "FindILsb", "FindUMsb", "FindSMsb",
                         }), );
 
 TEST_F(ValidateExtInst, FindUMsbNot32Bit) {
@@ -849,10 +839,7 @@ TEST_P(ValidateGlslStd450UMinLike, WrongBitWidthOperand2) {
 
 INSTANTIATE_TEST_CASE_P(AllUMinLike, ValidateGlslStd450UMinLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "UMin",
-                            "SMin",
-                            "UMax",
-                            "SMax",
+                            "UMin", "SMin", "UMax", "SMax",
                         }), );
 
 TEST_P(ValidateGlslStd450UClampLike, Success) {
@@ -1012,8 +999,7 @@ TEST_P(ValidateGlslStd450UClampLike, WrongBitWidthOperand3) {
 
 INSTANTIATE_TEST_CASE_P(AllUClampLike, ValidateGlslStd450UClampLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "UClamp",
-                            "SClamp",
+                            "UClamp", "SClamp",
                         }), );
 
 TEST_P(ValidateGlslStd450SinLike, Success) {
@@ -1067,24 +1053,9 @@ TEST_P(ValidateGlslStd450SinLike, IntOperand) {
 
 INSTANTIATE_TEST_CASE_P(AllSinLike, ValidateGlslStd450SinLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "Radians",
-                            "Degrees",
-                            "Sin",
-                            "Cos",
-                            "Tan",
-                            "Asin",
-                            "Acos",
-                            "Atan",
-                            "Sinh",
-                            "Cosh",
-                            "Tanh",
-                            "Asinh",
-                            "Acosh",
-                            "Atanh",
-                            "Exp",
-                            "Exp2",
-                            "Log",
-                            "Log2",
+                            "Radians", "Degrees", "Sin", "Cos", "Tan", "Asin",
+                            "Acos", "Atan", "Sinh", "Cosh", "Tanh", "Asinh",
+                            "Acosh", "Atanh", "Exp", "Exp2", "Log", "Log2",
                         }), );
 
 TEST_P(ValidateGlslStd450PowLike, Success) {
@@ -1152,8 +1123,7 @@ TEST_P(ValidateGlslStd450PowLike, IntOperand2) {
 
 INSTANTIATE_TEST_CASE_P(AllPowLike, ValidateGlslStd450PowLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "Atan2",
-                            "Pow",
+                            "Atan2", "Pow",
                         }), );
 
 TEST_F(ValidateExtInst, GlslStd450DeterminantSuccess) {
@@ -1779,11 +1749,8 @@ TEST_P(ValidateGlslStd450Pack, VWrongSizeVector) {
 
 INSTANTIATE_TEST_CASE_P(AllPack, ValidateGlslStd450Pack,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "PackSnorm4x8",
-                            "PackUnorm4x8",
-                            "PackSnorm2x16",
-                            "PackUnorm2x16",
-                            "PackHalf2x16",
+                            "PackSnorm4x8", "PackUnorm4x8", "PackSnorm2x16",
+                            "PackUnorm2x16", "PackHalf2x16",
                         }), );
 
 TEST_F(ValidateExtInst, PackDouble2x32Success) {
@@ -2018,10 +1985,8 @@ TEST_P(ValidateGlslStd450Unpack, ResultPWrongBitWidth) {
 
 INSTANTIATE_TEST_CASE_P(AllUnpack, ValidateGlslStd450Unpack,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "UnpackSnorm4x8",
-                            "UnpackUnorm4x8",
-                            "UnpackSnorm2x16",
-                            "UnpackUnorm2x16",
+                            "UnpackSnorm4x8", "UnpackUnorm4x8",
+                            "UnpackSnorm2x16", "UnpackUnorm2x16",
                             "UnpackHalf2x16",
                         }), );
 
@@ -2956,11 +2921,7 @@ TEST_P(ValidateOpenCLStdFClampLike, IntOperand3) {
 
 INSTANTIATE_TEST_CASE_P(AllFClampLike, ValidateOpenCLStdFClampLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "fma",
-                            "mad",
-                            "fclamp",
-                            "mix",
-                            "smoothstep",
+                            "fma", "mad", "fclamp", "mix", "smoothstep",
                         }), );
 
 TEST_P(ValidateOpenCLStdSAbsLike, Success) {
@@ -3023,11 +2984,7 @@ TEST_P(ValidateOpenCLStdSAbsLike, U64Operand) {
 
 INSTANTIATE_TEST_CASE_P(AllSAbsLike, ValidateOpenCLStdSAbsLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "s_abs",
-                            "clz",
-                            "ctz",
-                            "popcount",
-                            "u_abs",
+                            "s_abs", "clz", "ctz", "popcount", "u_abs",
                         }), );
 
 TEST_P(ValidateOpenCLStdUMinLike, Success) {
@@ -3122,23 +3079,10 @@ TEST_P(ValidateOpenCLStdUMinLike, U64Operand2) {
 
 INSTANTIATE_TEST_CASE_P(AllUMinLike, ValidateOpenCLStdUMinLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "s_max",
-                            "u_max",
-                            "s_min",
-                            "u_min",
-                            "s_abs_diff",
-                            "s_add_sat",
-                            "u_add_sat",
-                            "s_mul_hi",
-                            "rotate",
-                            "s_sub_sat",
-                            "u_sub_sat",
-                            "s_hadd",
-                            "u_hadd",
-                            "s_rhadd",
-                            "u_rhadd",
-                            "u_abs_diff",
-                            "u_mul_hi",
+                            "s_max", "u_max", "s_min", "u_min", "s_abs_diff",
+                            "s_add_sat", "u_add_sat", "s_mul_hi", "rotate",
+                            "s_sub_sat", "u_sub_sat", "s_hadd", "u_hadd",
+                            "s_rhadd", "u_rhadd", "u_abs_diff", "u_mul_hi",
                         }), );
 
 TEST_P(ValidateOpenCLStdUClampLike, Success) {
@@ -3259,12 +3203,8 @@ TEST_P(ValidateOpenCLStdUClampLike, U64Operand3) {
 
 INSTANTIATE_TEST_CASE_P(AllUClampLike, ValidateOpenCLStdUClampLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "s_clamp",
-                            "u_clamp",
-                            "s_mad_hi",
-                            "u_mad_sat",
-                            "s_mad_sat",
-                            "u_mad_hi",
+                            "s_clamp", "u_clamp", "s_mad_hi", "u_mad_sat",
+                            "s_mad_sat", "u_mad_hi",
                         }), );
 
 // -------------------------------------------------------------
@@ -3373,8 +3313,7 @@ TEST_P(ValidateOpenCLStdUMul24Like, U64Operand2) {
 
 INSTANTIATE_TEST_CASE_P(AllUMul24Like, ValidateOpenCLStdUMul24Like,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "s_mul24",
-                            "u_mul24",
+                            "s_mul24", "u_mul24",
                         }), );
 
 TEST_P(ValidateOpenCLStdUMad24Like, Success) {
@@ -3508,8 +3447,7 @@ TEST_P(ValidateOpenCLStdUMad24Like, U64Operand3) {
 
 INSTANTIATE_TEST_CASE_P(AllUMad24Like, ValidateOpenCLStdUMad24Like,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "s_mad24",
-                            "u_mad24",
+                            "s_mad24", "u_mad24",
                         }), );
 
 TEST_F(ValidateExtInst, OpenCLStdCrossSuccess) {
@@ -3637,8 +3575,7 @@ TEST_P(ValidateOpenCLStdLengthLike, DifferentType) {
 
 INSTANTIATE_TEST_CASE_P(AllLengthLike, ValidateOpenCLStdLengthLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "length",
-                            "fast_length",
+                            "length", "fast_length",
                         }), );
 
 TEST_P(ValidateOpenCLStdDistanceLike, Success) {
@@ -3726,8 +3663,7 @@ TEST_P(ValidateOpenCLStdDistanceLike, DifferentOperands) {
 
 INSTANTIATE_TEST_CASE_P(AllDistanceLike, ValidateOpenCLStdDistanceLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "distance",
-                            "fast_distance",
+                            "distance", "fast_distance",
                         }), );
 
 TEST_P(ValidateOpenCLStdNormalizeLike, Success) {
@@ -3786,8 +3722,7 @@ TEST_P(ValidateOpenCLStdNormalizeLike, DifferentType) {
 
 INSTANTIATE_TEST_CASE_P(AllNormalizeLike, ValidateOpenCLStdNormalizeLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "normalize",
-                            "fast_normalize",
+                            "normalize", "fast_normalize",
                         }), );
 
 TEST_F(ValidateExtInst, OpenCLStdBitselectSuccess) {
@@ -4184,11 +4119,8 @@ TEST_P(ValidateOpenCLStdVStoreHalfLike, PDataTypeFloat32) {
 
 INSTANTIATE_TEST_CASE_P(AllVStoreHalfLike, ValidateOpenCLStdVStoreHalfLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "vstore_half",
-                            "vstore_half_r",
-                            "vstore_halfn",
-                            "vstore_halfn_r",
-                            "vstorea_halfn",
+                            "vstore_half", "vstore_half_r", "vstore_halfn",
+                            "vstore_halfn_r", "vstorea_halfn",
                             "vstorea_halfn_r",
                         }), );
 
@@ -4352,8 +4284,7 @@ TEST_P(ValidateOpenCLStdVLoadHalfLike, WrongN) {
 
 INSTANTIATE_TEST_CASE_P(AllVLoadHalfLike, ValidateOpenCLStdVLoadHalfLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "vload_halfn",
-                            "vloada_halfn",
+                            "vload_halfn", "vloada_halfn",
                         }), );
 
 TEST_F(ValidateExtInst, VLoadNSuccessFloatPhysical32) {
@@ -5277,9 +5208,7 @@ TEST_P(ValidateOpenCLStdFractLike, PointerWrongDataType) {
 
 INSTANTIATE_TEST_CASE_P(AllFractLike, ValidateOpenCLStdFractLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "fract",
-                            "modf",
-                            "sincos",
+                            "fract", "modf", "sincos",
                         }), );
 
 TEST_F(ValidateExtInst, OpenCLStdRemquoSuccess) {
@@ -5496,8 +5425,7 @@ TEST_P(ValidateOpenCLStdFrexpLike, PointerDataTypeDiffSize) {
 
 INSTANTIATE_TEST_CASE_P(AllFrexpLike, ValidateOpenCLStdFrexpLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "frexp",
-                            "lgamma_r",
+                            "frexp", "lgamma_r",
                         }), );
 
 TEST_F(ValidateExtInst, OpenCLStdIlogbSuccess) {
@@ -5694,9 +5622,7 @@ TEST_P(ValidateOpenCLStdLdexpLike, ExponentWrongSize) {
 
 INSTANTIATE_TEST_CASE_P(AllLdexpLike, ValidateOpenCLStdLdexpLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "ldexp",
-                            "pown",
-                            "rootn",
+                            "ldexp", "pown", "rootn",
                         }), );
 
 TEST_P(ValidateOpenCLStdUpsampleLike, Success) {
@@ -5786,8 +5712,7 @@ TEST_P(ValidateOpenCLStdUpsampleLike, HiLoWrongBitWidth) {
 
 INSTANTIATE_TEST_CASE_P(AllUpsampleLike, ValidateOpenCLStdUpsampleLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "u_upsample",
-                            "s_upsample",
+                            "u_upsample", "s_upsample",
                         }), );
 
 }  // anonymous namespace

--- a/test/val/val_ext_inst_test.cpp
+++ b/test/val/val_ext_inst_test.cpp
@@ -488,8 +488,16 @@ TEST_P(ValidateGlslStd450SqrtLike, IntOperand) {
 
 INSTANTIATE_TEST_CASE_P(AllSqrtLike, ValidateGlslStd450SqrtLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "Round", "RoundEven", "FAbs", "Trunc", "FSign",
-                            "Floor", "Ceil", "Fract", "Sqrt", "InverseSqrt",
+                            "Round",
+                            "RoundEven",
+                            "FAbs",
+                            "Trunc",
+                            "FSign",
+                            "Floor",
+                            "Ceil",
+                            "Fract",
+                            "Sqrt",
+                            "InverseSqrt",
                             "Normalize",
                         }), );
 
@@ -547,7 +555,12 @@ TEST_P(ValidateGlslStd450FMinLike, IntOperand2) {
 
 INSTANTIATE_TEST_CASE_P(AllFMinLike, ValidateGlslStd450FMinLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "FMin", "FMax", "Step", "Reflect", "NMin", "NMax",
+                            "FMin",
+                            "FMax",
+                            "Step",
+                            "Reflect",
+                            "NMin",
+                            "NMax",
                         }), );
 
 TEST_P(ValidateGlslStd450FClampLike, Success) {
@@ -617,8 +630,12 @@ TEST_P(ValidateGlslStd450FClampLike, IntOperand3) {
 
 INSTANTIATE_TEST_CASE_P(AllFClampLike, ValidateGlslStd450FClampLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "FClamp", "FMix", "SmoothStep", "Fma",
-                            "FaceForward", "NClamp",
+                            "FClamp",
+                            "FMix",
+                            "SmoothStep",
+                            "Fma",
+                            "FaceForward",
+                            "NClamp",
                         }), );
 
 TEST_P(ValidateGlslStd450SAbsLike, Success) {
@@ -694,7 +711,11 @@ TEST_P(ValidateGlslStd450SAbsLike, WrongBitWidthOperand) {
 
 INSTANTIATE_TEST_CASE_P(AllSAbsLike, ValidateGlslStd450SAbsLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "SAbs", "SSign", "FindILsb", "FindUMsb", "FindSMsb",
+                            "SAbs",
+                            "SSign",
+                            "FindILsb",
+                            "FindUMsb",
+                            "FindSMsb",
                         }), );
 
 TEST_F(ValidateExtInst, FindUMsbNot32Bit) {
@@ -839,7 +860,10 @@ TEST_P(ValidateGlslStd450UMinLike, WrongBitWidthOperand2) {
 
 INSTANTIATE_TEST_CASE_P(AllUMinLike, ValidateGlslStd450UMinLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "UMin", "SMin", "UMax", "SMax",
+                            "UMin",
+                            "SMin",
+                            "UMax",
+                            "SMax",
                         }), );
 
 TEST_P(ValidateGlslStd450UClampLike, Success) {
@@ -999,7 +1023,8 @@ TEST_P(ValidateGlslStd450UClampLike, WrongBitWidthOperand3) {
 
 INSTANTIATE_TEST_CASE_P(AllUClampLike, ValidateGlslStd450UClampLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "UClamp", "SClamp",
+                            "UClamp",
+                            "SClamp",
                         }), );
 
 TEST_P(ValidateGlslStd450SinLike, Success) {
@@ -1053,9 +1078,24 @@ TEST_P(ValidateGlslStd450SinLike, IntOperand) {
 
 INSTANTIATE_TEST_CASE_P(AllSinLike, ValidateGlslStd450SinLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "Radians", "Degrees", "Sin", "Cos", "Tan", "Asin",
-                            "Acos", "Atan", "Sinh", "Cosh", "Tanh", "Asinh",
-                            "Acosh", "Atanh", "Exp", "Exp2", "Log", "Log2",
+                            "Radians",
+                            "Degrees",
+                            "Sin",
+                            "Cos",
+                            "Tan",
+                            "Asin",
+                            "Acos",
+                            "Atan",
+                            "Sinh",
+                            "Cosh",
+                            "Tanh",
+                            "Asinh",
+                            "Acosh",
+                            "Atanh",
+                            "Exp",
+                            "Exp2",
+                            "Log",
+                            "Log2",
                         }), );
 
 TEST_P(ValidateGlslStd450PowLike, Success) {
@@ -1123,7 +1163,8 @@ TEST_P(ValidateGlslStd450PowLike, IntOperand2) {
 
 INSTANTIATE_TEST_CASE_P(AllPowLike, ValidateGlslStd450PowLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "Atan2", "Pow",
+                            "Atan2",
+                            "Pow",
                         }), );
 
 TEST_F(ValidateExtInst, GlslStd450DeterminantSuccess) {
@@ -1749,8 +1790,11 @@ TEST_P(ValidateGlslStd450Pack, VWrongSizeVector) {
 
 INSTANTIATE_TEST_CASE_P(AllPack, ValidateGlslStd450Pack,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "PackSnorm4x8", "PackUnorm4x8", "PackSnorm2x16",
-                            "PackUnorm2x16", "PackHalf2x16",
+                            "PackSnorm4x8",
+                            "PackUnorm4x8",
+                            "PackSnorm2x16",
+                            "PackUnorm2x16",
+                            "PackHalf2x16",
                         }), );
 
 TEST_F(ValidateExtInst, PackDouble2x32Success) {
@@ -1985,8 +2029,10 @@ TEST_P(ValidateGlslStd450Unpack, ResultPWrongBitWidth) {
 
 INSTANTIATE_TEST_CASE_P(AllUnpack, ValidateGlslStd450Unpack,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "UnpackSnorm4x8", "UnpackUnorm4x8",
-                            "UnpackSnorm2x16", "UnpackUnorm2x16",
+                            "UnpackSnorm4x8",
+                            "UnpackUnorm4x8",
+                            "UnpackSnorm2x16",
+                            "UnpackUnorm2x16",
                             "UnpackHalf2x16",
                         }), );
 
@@ -2921,7 +2967,11 @@ TEST_P(ValidateOpenCLStdFClampLike, IntOperand3) {
 
 INSTANTIATE_TEST_CASE_P(AllFClampLike, ValidateOpenCLStdFClampLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "fma", "mad", "fclamp", "mix", "smoothstep",
+                            "fma",
+                            "mad",
+                            "fclamp",
+                            "mix",
+                            "smoothstep",
                         }), );
 
 TEST_P(ValidateOpenCLStdSAbsLike, Success) {
@@ -2984,7 +3034,11 @@ TEST_P(ValidateOpenCLStdSAbsLike, U64Operand) {
 
 INSTANTIATE_TEST_CASE_P(AllSAbsLike, ValidateOpenCLStdSAbsLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "s_abs", "clz", "ctz", "popcount", "u_abs",
+                            "s_abs",
+                            "clz",
+                            "ctz",
+                            "popcount",
+                            "u_abs",
                         }), );
 
 TEST_P(ValidateOpenCLStdUMinLike, Success) {
@@ -3079,10 +3133,23 @@ TEST_P(ValidateOpenCLStdUMinLike, U64Operand2) {
 
 INSTANTIATE_TEST_CASE_P(AllUMinLike, ValidateOpenCLStdUMinLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "s_max", "u_max", "s_min", "u_min", "s_abs_diff",
-                            "s_add_sat", "u_add_sat", "s_mul_hi", "rotate",
-                            "s_sub_sat", "u_sub_sat", "s_hadd", "u_hadd",
-                            "s_rhadd", "u_rhadd", "u_abs_diff", "u_mul_hi",
+                            "s_max",
+                            "u_max",
+                            "s_min",
+                            "u_min",
+                            "s_abs_diff",
+                            "s_add_sat",
+                            "u_add_sat",
+                            "s_mul_hi",
+                            "rotate",
+                            "s_sub_sat",
+                            "u_sub_sat",
+                            "s_hadd",
+                            "u_hadd",
+                            "s_rhadd",
+                            "u_rhadd",
+                            "u_abs_diff",
+                            "u_mul_hi",
                         }), );
 
 TEST_P(ValidateOpenCLStdUClampLike, Success) {
@@ -3203,8 +3270,12 @@ TEST_P(ValidateOpenCLStdUClampLike, U64Operand3) {
 
 INSTANTIATE_TEST_CASE_P(AllUClampLike, ValidateOpenCLStdUClampLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "s_clamp", "u_clamp", "s_mad_hi", "u_mad_sat",
-                            "s_mad_sat", "u_mad_hi",
+                            "s_clamp",
+                            "u_clamp",
+                            "s_mad_hi",
+                            "u_mad_sat",
+                            "s_mad_sat",
+                            "u_mad_hi",
                         }), );
 
 // -------------------------------------------------------------
@@ -3313,7 +3384,8 @@ TEST_P(ValidateOpenCLStdUMul24Like, U64Operand2) {
 
 INSTANTIATE_TEST_CASE_P(AllUMul24Like, ValidateOpenCLStdUMul24Like,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "s_mul24", "u_mul24",
+                            "s_mul24",
+                            "u_mul24",
                         }), );
 
 TEST_P(ValidateOpenCLStdUMad24Like, Success) {
@@ -3447,7 +3519,8 @@ TEST_P(ValidateOpenCLStdUMad24Like, U64Operand3) {
 
 INSTANTIATE_TEST_CASE_P(AllUMad24Like, ValidateOpenCLStdUMad24Like,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "s_mad24", "u_mad24",
+                            "s_mad24",
+                            "u_mad24",
                         }), );
 
 TEST_F(ValidateExtInst, OpenCLStdCrossSuccess) {
@@ -3575,7 +3648,8 @@ TEST_P(ValidateOpenCLStdLengthLike, DifferentType) {
 
 INSTANTIATE_TEST_CASE_P(AllLengthLike, ValidateOpenCLStdLengthLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "length", "fast_length",
+                            "length",
+                            "fast_length",
                         }), );
 
 TEST_P(ValidateOpenCLStdDistanceLike, Success) {
@@ -3663,7 +3737,8 @@ TEST_P(ValidateOpenCLStdDistanceLike, DifferentOperands) {
 
 INSTANTIATE_TEST_CASE_P(AllDistanceLike, ValidateOpenCLStdDistanceLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "distance", "fast_distance",
+                            "distance",
+                            "fast_distance",
                         }), );
 
 TEST_P(ValidateOpenCLStdNormalizeLike, Success) {
@@ -3722,7 +3797,8 @@ TEST_P(ValidateOpenCLStdNormalizeLike, DifferentType) {
 
 INSTANTIATE_TEST_CASE_P(AllNormalizeLike, ValidateOpenCLStdNormalizeLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "normalize", "fast_normalize",
+                            "normalize",
+                            "fast_normalize",
                         }), );
 
 TEST_F(ValidateExtInst, OpenCLStdBitselectSuccess) {
@@ -4119,8 +4195,11 @@ TEST_P(ValidateOpenCLStdVStoreHalfLike, PDataTypeFloat32) {
 
 INSTANTIATE_TEST_CASE_P(AllVStoreHalfLike, ValidateOpenCLStdVStoreHalfLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "vstore_half", "vstore_half_r", "vstore_halfn",
-                            "vstore_halfn_r", "vstorea_halfn",
+                            "vstore_half",
+                            "vstore_half_r",
+                            "vstore_halfn",
+                            "vstore_halfn_r",
+                            "vstorea_halfn",
                             "vstorea_halfn_r",
                         }), );
 
@@ -4284,7 +4363,8 @@ TEST_P(ValidateOpenCLStdVLoadHalfLike, WrongN) {
 
 INSTANTIATE_TEST_CASE_P(AllVLoadHalfLike, ValidateOpenCLStdVLoadHalfLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "vload_halfn", "vloada_halfn",
+                            "vload_halfn",
+                            "vloada_halfn",
                         }), );
 
 TEST_F(ValidateExtInst, VLoadNSuccessFloatPhysical32) {
@@ -5208,7 +5288,9 @@ TEST_P(ValidateOpenCLStdFractLike, PointerWrongDataType) {
 
 INSTANTIATE_TEST_CASE_P(AllFractLike, ValidateOpenCLStdFractLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "fract", "modf", "sincos",
+                            "fract",
+                            "modf",
+                            "sincos",
                         }), );
 
 TEST_F(ValidateExtInst, OpenCLStdRemquoSuccess) {
@@ -5425,7 +5507,8 @@ TEST_P(ValidateOpenCLStdFrexpLike, PointerDataTypeDiffSize) {
 
 INSTANTIATE_TEST_CASE_P(AllFrexpLike, ValidateOpenCLStdFrexpLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "frexp", "lgamma_r",
+                            "frexp",
+                            "lgamma_r",
                         }), );
 
 TEST_F(ValidateExtInst, OpenCLStdIlogbSuccess) {
@@ -5622,7 +5705,9 @@ TEST_P(ValidateOpenCLStdLdexpLike, ExponentWrongSize) {
 
 INSTANTIATE_TEST_CASE_P(AllLdexpLike, ValidateOpenCLStdLdexpLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "ldexp", "pown", "rootn",
+                            "ldexp",
+                            "pown",
+                            "rootn",
                         }), );
 
 TEST_P(ValidateOpenCLStdUpsampleLike, Success) {
@@ -5712,7 +5797,8 @@ TEST_P(ValidateOpenCLStdUpsampleLike, HiLoWrongBitWidth) {
 
 INSTANTIATE_TEST_CASE_P(AllUpsampleLike, ValidateOpenCLStdUpsampleLike,
                         ::testing::ValuesIn(std::vector<std::string>{
-                            "u_upsample", "s_upsample",
+                            "u_upsample",
+                            "s_upsample",
                         }), );
 
 }  // anonymous namespace

--- a/test/val/val_interfaces_test.cpp
+++ b/test/val/val_interfaces_test.cpp
@@ -1,0 +1,153 @@
+// Copyright (c) 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gmock/gmock.h"
+#include "unit_spirv.h"
+#include "val_fixtures.h"
+
+namespace {
+
+using ::testing::HasSubstr;
+
+using ValidateInterfacesTest = spvtest::ValidateBase<bool>;
+
+TEST_F(ValidateInterfacesTest, EntryPointMissingInput) {
+  std::string text = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %1 "func"
+%2 = OpTypeVoid
+%3 = OpTypeInt 32 0
+%4 = OpTypePointer Input %3
+%5 = OpVariable %4 Input
+%6 = OpTypeFunction %2
+%1 = OpFunction %2 None %6
+%7 = OpLabel
+%8 = OpLoad %3 %5
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Input variable id <5> is used by entry point id <1>, "
+                        "but is not listed as an interface"));
+}
+
+TEST_F(ValidateInterfacesTest, EntryPointMissingOutput) {
+  std::string text = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %1 "func"
+%2 = OpTypeVoid
+%3 = OpTypeInt 32 0
+%4 = OpTypePointer Output %3
+%5 = OpVariable %4 Output
+%6 = OpTypeFunction %2
+%1 = OpFunction %2 None %6
+%7 = OpLabel
+%8 = OpLoad %3 %5
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Output variable id <5> is used by entry point id <1>, "
+                        "but is not listed as an interface"));
+}
+
+TEST_F(ValidateInterfacesTest, InterfaceMissingUseInSubfunction) {
+  std::string text = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %1 "func"
+%2 = OpTypeVoid
+%3 = OpTypeInt 32 0
+%4 = OpTypePointer Input %3
+%5 = OpVariable %4 Input
+%6 = OpTypeFunction %2
+%1 = OpFunction %2 None %6
+%7 = OpLabel
+%8 = OpFunctionCall %2 %9
+OpReturn
+OpFunctionEnd
+%9 = OpFunction %2 None %6
+%10 = OpLabel
+%11 = OpLoad %3 %5
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Input variable id <5> is used by entry point id <1>, "
+                        "but is not listed as an interface"));
+}
+
+TEST_F(ValidateInterfacesTest, TwoEntryPointsOneFunction) {
+  std::string text = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %1 "func" %2
+OpEntryPoint Fragment %1 "func2"
+%3 = OpTypeVoid
+%4 = OpTypeInt 32 0
+%5 = OpTypePointer Input %4
+%2 = OpVariable %5 Input
+%6 = OpTypeFunction %3
+%1 = OpFunction %3 None %6
+%7 = OpLabel
+%8 = OpLoad %4 %2
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Input variable id <2> is used by entry point id <1>, "
+                        "but is not listed as an interface"));
+}
+
+TEST_F(ValidateInterfacesTest, MissingInterfaceThroughInitializer) {
+  const std::string text = R"(
+OpCapability Shader
+OpCapability VariablePointers
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %1 "func"
+%2 = OpTypeVoid
+%3 = OpTypeInt 32 0
+%4 = OpTypePointer Input %3
+%5 = OpTypePointer Function %4
+%6 = OpVariable %4 Input
+%7 = OpTypeFunction %2
+%1 = OpFunction %2 None %7
+%8 = OpLabel
+%9 = OpVariable %5 Function %6
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_UNIVERSAL_1_3);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Input variable id <6> is used by entry point id <1>, "
+                        "but is not listed as an interface"));
+}
+
+}  // namespace

--- a/test/val/val_interfaces_test.cpp
+++ b/test/val/val_interfaces_test.cpp
@@ -41,9 +41,10 @@ OpFunctionEnd
 
   CompileSuccessfully(text);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Input variable id <5> is used by entry point id <1>, "
-                        "but is not listed as an interface"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Input variable id <5> is used by entry point 'func' id <1>, "
+                "but is not listed as an interface"));
 }
 
 TEST_F(ValidateInterfacesTest, EntryPointMissingOutput) {
@@ -65,9 +66,10 @@ OpFunctionEnd
 
   CompileSuccessfully(text);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Output variable id <5> is used by entry point id <1>, "
-                        "but is not listed as an interface"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Output variable id <5> is used by entry point 'func' id <1>, "
+                "but is not listed as an interface"));
 }
 
 TEST_F(ValidateInterfacesTest, InterfaceMissingUseInSubfunction) {
@@ -94,9 +96,10 @@ OpFunctionEnd
 
   CompileSuccessfully(text);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Input variable id <5> is used by entry point id <1>, "
-                        "but is not listed as an interface"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Input variable id <5> is used by entry point 'func' id <1>, "
+                "but is not listed as an interface"));
 }
 
 TEST_F(ValidateInterfacesTest, TwoEntryPointsOneFunction) {
@@ -119,9 +122,10 @@ OpFunctionEnd
 
   CompileSuccessfully(text);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Input variable id <2> is used by entry point id <1>, "
-                        "but is not listed as an interface"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Input variable id <2> is used by entry point 'func2' id <1>, "
+                "but is not listed as an interface"));
 }
 
 TEST_F(ValidateInterfacesTest, MissingInterfaceThroughInitializer) {
@@ -145,9 +149,10 @@ OpFunctionEnd
 
   CompileSuccessfully(text, SPV_ENV_UNIVERSAL_1_3);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Input variable id <6> is used by entry point id <1>, "
-                        "but is not listed as an interface"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Input variable id <6> is used by entry point 'func' id <1>, "
+                "but is not listed as an interface"));
 }
 
 }  // namespace


### PR DESCRIPTION
Fixes #1120

Checks that all static uses of the Input and Output variables are listed
as interfaces in each corresponding entry point declaration.
 * Changed validation state to track interface lists
 * updated many tests