### PR TITLE
Preserve inst-to-block and def-use in passes.

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -239,7 +239,8 @@ void AggressiveDCEPass::AddBranch(uint32_t labelId, ir::BasicBlock* bp) {
   std::unique_ptr<ir::Instruction> newBranch(new ir::Instruction(
       context(), SpvOpBranch, 0, 0,
       {{spv_operand_type_t::SPV_OPERAND_TYPE_ID, {labelId}}}));
-  get_def_use_mgr()->AnalyzeInstDefUse(&*newBranch);
+  context()->AnalyzeDefUse(&*newBranch);
+  context()->set_instr_block(&*newBranch, bp);
   bp->AddInstruction(std::move(newBranch));
 }
 

--- a/source/opt/aggressive_dead_code_elim_pass.h
+++ b/source/opt/aggressive_dead_code_elim_pass.h
@@ -46,7 +46,8 @@ class AggressiveDCEPass : public MemPass {
   Status Process(ir::IRContext* c) override;
 
   ir::IRContext::Analysis GetPreservedAnalyses() override {
-    return ir::IRContext::kAnalysisDefUse;
+    return ir::IRContext::kAnalysisDefUse |
+           ir::IRContext::kAnalysisInstrToBlockMapping;
   }
 
  private:

--- a/source/opt/block_merge_pass.cpp
+++ b/source/opt/block_merge_pass.cpp
@@ -94,7 +94,15 @@ bool BlockMergePass::MergeBlocks(ir::Function* func) {
     // If bi is sbi's only predecessor, it dominates sbi and thus
     // sbi must follow bi in func's ordering.
     assert(sbi != func->end());
+
+    // Update the inst-to-block mapping for the instructions in sbi.
+    for (auto& inst : *sbi) {
+      context()->set_instr_block(&inst, &*bi);
+    }
+
+    // Now actually move the instructions.
     bi->AddInstructions(&*sbi);
+
     if (merge_inst) {
       if (pred_is_header && lab_id == merge_inst->GetSingleWordInOperand(0u)) {
         // Merging the header and merge blocks, so remove the structured control

--- a/source/opt/block_merge_pass.h
+++ b/source/opt/block_merge_pass.h
@@ -39,6 +39,13 @@ class BlockMergePass : public Pass {
   BlockMergePass();
   const char* name() const override { return "merge-blocks"; }
   Status Process(ir::IRContext*) override;
+  virtual ir::IRContext::Analysis GetPreservedAnalyses() override {
+    return ir::IRContext::kAnalysisDefUse |
+           ir::IRContext::kAnalysisInstrToBlockMapping |
+           ir::IRContext::kAnalysisDecorations |
+           ir::IRContext::kAnalysisCombinators |
+           ir::IRContext::kAnalysisNameMap;
+  }
 
  private:
   // Kill any OpName instruction referencing |inst|, then kill |inst|.

--- a/source/opt/ccp_pass.h
+++ b/source/opt/ccp_pass.h
@@ -30,6 +30,14 @@ class CCPPass : public MemPass {
   CCPPass() = default;
   const char* name() const override { return "ccp"; }
   Status Process(ir::IRContext* c) override;
+  virtual ir::IRContext::Analysis GetPreservedAnalyses() override {
+    return ir::IRContext::kAnalysisDefUse |
+           ir::IRContext::kAnalysisInstrToBlockMapping |
+           ir::IRContext::kAnalysisDecorations |
+           ir::IRContext::kAnalysisCombinators | ir::IRContext::kAnalysisCFG |
+           ir::IRContext::kAnalysisDominatorAnalysis |
+           ir::IRContext::kAnalysisNameMap;
+  }
 
  private:
   // Initializes the pass.

--- a/source/opt/compact_ids_pass.h
+++ b/source/opt/compact_ids_pass.h
@@ -27,6 +27,15 @@ class CompactIdsPass : public Pass {
  public:
   const char* name() const override { return "compact-ids"; }
   Status Process(ir::IRContext*) override;
+
+  // Return the mask of preserved Analyses.
+  ir::IRContext::Analysis GetPreservedAnalyses() override {
+    return ir::IRContext::kAnalysisInstrToBlockMapping |
+           ir::IRContext::kAnalysisCombinators | ir::IRContext::kAnalysisCFG |
+           ir::IRContext::kAnalysisDominatorAnalysis |
+           ir::IRContext::kAnalysisLoopAnalysis |
+           ir::IRContext::kAnalysisNameMap;
+  }
 };
 
 }  // namespace opt

--- a/source/opt/dead_branch_elim_pass.cpp
+++ b/source/opt/dead_branch_elim_pass.cpp
@@ -77,7 +77,8 @@ void DeadBranchElimPass::AddBranch(uint32_t labelId, ir::BasicBlock* bp) {
   std::unique_ptr<ir::Instruction> newBranch(new ir::Instruction(
       context(), SpvOpBranch, 0, 0,
       {{spv_operand_type_t::SPV_OPERAND_TYPE_ID, {labelId}}}));
-  get_def_use_mgr()->AnalyzeInstDefUse(&*newBranch);
+  context()->AnalyzeDefUse(&*newBranch);
+  context()->set_instr_block(&*newBranch, bp);
   bp->AddInstruction(std::move(newBranch));
 }
 
@@ -316,6 +317,7 @@ bool DeadBranchElimPass::EraseDeadBlocks(
         ebi->AddInstruction(
             MakeUnique<ir::Instruction>(context(), SpvOpUnreachable, 0, 0,
                                         std::initializer_list<ir::Operand>{}));
+        context()->set_instr_block(&*ebi->tail(), &*ebi);
         modified = true;
       }
       ++ebi;
@@ -333,6 +335,7 @@ bool DeadBranchElimPass::EraseDeadBlocks(
                                         std::initializer_list<ir::Operand>{
                                             {SPV_OPERAND_TYPE_ID, {cont_id}}}));
         get_def_use_mgr()->AnalyzeInstUse(&*ebi->tail());
+        context()->set_instr_block(&*ebi->tail(), &*ebi);
         modified = true;
       }
       ++ebi;

--- a/source/opt/dead_branch_elim_pass.h
+++ b/source/opt/dead_branch_elim_pass.h
@@ -42,7 +42,8 @@ class DeadBranchElimPass : public MemPass {
   Status Process(ir::IRContext* context) override;
 
   ir::IRContext::Analysis GetPreservedAnalyses() override {
-    return ir::IRContext::kAnalysisDefUse;
+    return ir::IRContext::kAnalysisDefUse |
+           ir::IRContext::kAnalysisInstrToBlockMapping;
   }
 
  private:

--- a/source/opt/dead_insert_elim_pass.h
+++ b/source/opt/dead_insert_elim_pass.h
@@ -38,6 +38,14 @@ class DeadInsertElimPass : public MemPass {
   DeadInsertElimPass();
   const char* name() const override { return "eliminate-dead-inserts"; }
   Status Process(ir::IRContext*) override;
+  virtual ir::IRContext::Analysis GetPreservedAnalyses() override {
+    return ir::IRContext::kAnalysisDefUse |
+           ir::IRContext::kAnalysisInstrToBlockMapping |
+           ir::IRContext::kAnalysisDecorations |
+           ir::IRContext::kAnalysisCombinators | ir::IRContext::kAnalysisCFG |
+           ir::IRContext::kAnalysisDominatorAnalysis |
+           ir::IRContext::kAnalysisNameMap;
+  }
 
  private:
   // Return the number of subcomponents in the composite type |typeId|.

--- a/source/opt/local_single_block_elim_pass.h
+++ b/source/opt/local_single_block_elim_pass.h
@@ -40,7 +40,8 @@ class LocalSingleBlockLoadStoreElimPass : public MemPass {
   Status Process(ir::IRContext* c) override;
 
   ir::IRContext::Analysis GetPreservedAnalyses() override {
-    return ir::IRContext::kAnalysisDefUse;
+    return ir::IRContext::kAnalysisDefUse |
+           ir::IRContext::kAnalysisInstrToBlockMapping;
   }
 
  private:

--- a/source/opt/local_single_store_elim_pass.h
+++ b/source/opt/local_single_store_elim_pass.h
@@ -42,7 +42,8 @@ class LocalSingleStoreElimPass : public Pass {
   Status Process(ir::IRContext* irContext) override;
 
   ir::IRContext::Analysis GetPreservedAnalyses() override {
-    return ir::IRContext::kAnalysisDefUse;
+    return ir::IRContext::kAnalysisDefUse |
+           ir::IRContext::kAnalysisInstrToBlockMapping;
   }
 
  private:

--- a/source/opt/private_to_local_pass.cpp
+++ b/source/opt/private_to_local_pass.cpp
@@ -103,6 +103,7 @@ void PrivateToLocalPass::MoveVariable(ir::Instruction* variable,
 
   // Place the variable at the start of the first basic block.
   context()->AnalyzeUses(variable);
+  context()->set_instr_block(variable, &*function->begin());
   function->begin()->begin()->InsertBefore(move(var));
 
   // Update uses where the type may have changed.

--- a/source/opt/private_to_local_pass.h
+++ b/source/opt/private_to_local_pass.h
@@ -31,6 +31,7 @@ class PrivateToLocalPass : public Pass {
   Status Process(ir::IRContext*) override;
   ir::IRContext::Analysis GetPreservedAnalyses() override {
     return ir::IRContext::kAnalysisDefUse |
+           ir::IRContext::kAnalysisInstrToBlockMapping |
            ir::IRContext::kAnalysisDecorations |
            ir::IRContext::kAnalysisCombinators | ir::IRContext::kAnalysisCFG |
            ir::IRContext::kAnalysisDominatorAnalysis |

--- a/source/opt/reduce_load_size.h
+++ b/source/opt/reduce_load_size.h
@@ -30,7 +30,8 @@ class ReduceLoadSize : public Pass {
 
   // Return the mask of preserved Analyses.
   ir::IRContext::Analysis GetPreservedAnalyses() override {
-    return ir::IRContext::kAnalysisInstrToBlockMapping |
+    return ir::IRContext::kAnalysisDefUse |
+           ir::IRContext::kAnalysisInstrToBlockMapping |
            ir::IRContext::kAnalysisCombinators | ir::IRContext::kAnalysisCFG |
            ir::IRContext::kAnalysisDominatorAnalysis |
            ir::IRContext::kAnalysisLoopAnalysis |


### PR DESCRIPTION
The following passes are updated to preserve the inst-to-block and
def-use analysies:

	private-to-local
	aggressive dead-code elimination
	dead branch elimination
	local-single-block elimination
	local-single-store elimination
	reduce load size
	compact ids (inst-to-block only)
	merge block
	dead-insert elimination
	ccp

The one execption is that compact ids still kills the def-use manager.
This is because it changes so many ids it is faster to kill and rebuild.

Does everything in
https://github.com/KhronosGroup/SPIRV-Tools/issues/1593 except for the
changes to merge return.