### PR TITLE
Improve vector-dce compile time.

### DIFF
--- a/source/opt/vector_dce.h
+++ b/source/opt/vector_dce.h
@@ -23,7 +23,7 @@ namespace opt {
 
 class VectorDCE : public MemPass {
  private:
-  using LiveComponentMap = std::unordered_map<uint32_t, utils::BitVector>;
+  using LiveComponentMap = std::vector<std::unique_ptr<utils::BitVector>>;
 
   // According to the SPEC the maximum size for a vector is 16.  See the data
   // rules in the universal validation rules (section 2.16.1).


### PR DESCRIPTION
The compile time for vector dce can be pretty long.  The first problem
is that we are passing a large map by value to a lambda.  That was
intended to be by reference.

The second change is to implement the map using a vector of BitVectors
instead of an std::unordered_map.  The std::unordered_map implementation
can be slow, and as we saw with ADCE, the vector is not so sparse that
the vector becomes slow.

Contributes to https://github.com/KhronosGroup/SPIRV-Tools/issues/1328.