### PR TITLE
Small vector optimization for operands.

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -221,6 +221,7 @@ set(SPIRV_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/util/bit_vector.h
   ${CMAKE_CURRENT_SOURCE_DIR}/util/hex_float.h
   ${CMAKE_CURRENT_SOURCE_DIR}/util/parse_number.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/util/small_vector.h
   ${CMAKE_CURRENT_SOURCE_DIR}/util/string_utils.h
   ${CMAKE_CURRENT_SOURCE_DIR}/util/timer.h
   ${CMAKE_CURRENT_SOURCE_DIR}/assembly_grammar.h

--- a/source/opt/constants.h
+++ b/source/opt/constants.h
@@ -502,6 +502,12 @@ class ConstantManager {
   const Constant* GetConstant(
       const Type* type, const std::vector<uint32_t>& literal_words_or_ids);
 
+  template <class C>
+  const Constant* GetConstant(const Type* type, const C& literal_words_or_ids) {
+    return GetConstant(type, std::vector<uint32_t>(literal_words_or_ids.begin(),
+                                                   literal_words_or_ids.end()));
+  }
+
   // Gets or creates a Constant instance to hold the constant value of the given
   // instruction. It returns a pointer to a Constant instance or nullptr if it
   // could not create the constant.

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -68,8 +68,7 @@ Instruction::Instruction(IRContext* c, const spv_parsed_instruction_t& inst,
 }
 
 Instruction::Instruction(IRContext* c, SpvOp op, uint32_t ty_id,
-                         uint32_t res_id,
-                         const std::vector<Operand>& in_operands)
+                         uint32_t res_id, const OperandList& in_operands)
     : utils::IntrusiveNodeBase<Instruction>(),
       context_(c),
       opcode_(op),
@@ -139,10 +138,9 @@ void Instruction::ToBinaryWithoutAttachedDebugInsts(
     binary->insert(binary->end(), operand.words.begin(), operand.words.end());
 }
 
-void Instruction::ReplaceOperands(const std::vector<Operand>& new_operands) {
+void Instruction::ReplaceOperands(const OperandList& new_operands) {
   operands_.clear();
   operands_.insert(operands_.begin(), new_operands.begin(), new_operands.end());
-  operands_.shrink_to_fit();
 }
 
 bool Instruction::IsReadOnlyLoad() const {

--- a/source/opt/ir_builder.h
+++ b/source/opt/ir_builder.h
@@ -120,7 +120,7 @@ class InstructionBuilder {
   // well formed.
   ir::Instruction* AddSwitch(
       uint32_t selector_id, uint32_t default_id,
-      const std::vector<std::pair<std::vector<uint32_t>, uint32_t>>& targets,
+      const std::vector<std::pair<ir::Operand::OperandData, uint32_t>>& targets,
       uint32_t merge_id = kInvalidId,
       uint32_t selection_control = SpvSelectionControlMaskNone) {
     if (merge_id != kInvalidId) {

--- a/source/opt/loop_unswitch_pass.cpp
+++ b/source/opt/loop_unswitch_pass.cpp
@@ -424,7 +424,7 @@ class LoopUnswitch {
           constant_branch[0].second->id(),
           if_merge_block ? if_merge_block->id() : kInvalidId);
     } else {
-      std::vector<std::pair<std::vector<uint32_t>, uint32_t>> targets;
+      std::vector<std::pair<ir::Operand::OperandData, uint32_t>> targets;
       for (auto& t : constant_branch) {
         targets.emplace_back(t.first->GetInOperand(0).words, t.second->id());
       }

--- a/source/util/small_vector.h
+++ b/source/util/small_vector.h
@@ -1,0 +1,464 @@
+// Copyright (c) 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBSPIRV_UTILS_SMALL_VECTOR_H_
+#define LIBSPIRV_UTILS_SMALL_VECTOR_H_
+
+#include <cassert>
+#include <iostream>
+#include <vector>
+
+#include "opt/make_unique.h"
+
+namespace spvtools {
+namespace utils {
+
+// The |SmallVector| class is intended to be a drop-in replacement for
+// |std::vector|.  The difference is in the implementation. A |SmallVector| is
+// optimized for when the number of elements in the vector are small.  Small is
+// defined by the template parameter |small_size|.
+//
+// Note that |SmallVector| is not always faster than an |std::vector|, so you
+// should experiment with different values for |small_size| and compare to
+// using and |std::vector|.
+//
+// TODO: I have implemented the public member functions from |std::vector| that
+// I needed.  If others are needed they should be implemented. Do not implement
+// public member functions that are not defined by std::vector.
+template <class T, size_t small_size>
+class SmallVector {
+ public:
+  using iterator = T*;
+  using const_iterator = const T*;
+
+  SmallVector()
+      : size_(0),
+        small_data_(reinterpret_cast<T*>(buffer)),
+        large_data_(nullptr) {}
+
+  SmallVector(const SmallVector& that) : SmallVector() { *this = that; }
+
+  SmallVector(SmallVector&& that) : SmallVector() { *this = std::move(that); }
+
+  SmallVector(const std::vector<T>& vec) : SmallVector() {
+    if (vec.size() > small_size) {
+      large_data_.reset(new std::vector<T>(vec));
+    } else {
+      size_ = vec.size();
+      for (uint32_t i = 0; i < size_; i++) {
+        new (small_data_ + i) T(vec[i]);
+      }
+    }
+  }
+
+  SmallVector(std::vector<T>&& vec) : SmallVector() {
+    if (vec.size() > small_size) {
+      large_data_.reset(new std::vector<T>(std::move(vec)));
+    } else {
+      size_ = vec.size();
+      for (uint32_t i = 0; i < size_; i++) {
+        new (small_data_ + i) T(std::move(vec[i]));
+      }
+    }
+    vec.clear();
+  }
+
+  SmallVector(std::initializer_list<T> init_list) : SmallVector() {
+    if (init_list.size() < small_size) {
+      for (auto it = init_list.begin(); it != init_list.end(); ++it) {
+        new (small_data_ + (size_++)) T(std::move(*it));
+      }
+    } else {
+      large_data_.reset(new std::vector<T>(std::move(init_list)));
+    }
+  }
+
+  SmallVector(size_t s, const T& v) : SmallVector() { resize(s, v); }
+
+  virtual ~SmallVector() {
+    for (T* p = small_data_; p < small_data_ + size_; ++p) {
+      p->~T();
+    }
+  }
+
+  SmallVector& operator=(const SmallVector& that) {
+    assert(small_data_);
+    if (that.large_data_) {
+      if (large_data_) {
+        *large_data_ = *that.large_data_;
+      } else {
+        large_data_.reset(new std::vector<T>(*that.large_data_));
+      }
+    } else {
+      large_data_.reset(nullptr);
+      size_t i = 0;
+      // Do a copy for any element in |this| that is already constructed.
+      for (; i < size_ && i < that.size_; ++i) {
+        small_data_[i] = that.small_data_[i];
+      }
+
+      if (i >= that.size_) {
+        // If the size of |this| becomes smaller after the assignment, then
+        // destroy any extra elements.
+        for (; i < size_; ++i) {
+          small_data_[i].~T();
+        }
+      } else {
+        // If the size of |this| becomes larger after the assignement, copy
+        // construct the new elements that are needed.
+        for (; i < that.size_; ++i) {
+          new (small_data_ + i) T(that.small_data_[i]);
+        }
+      }
+      size_ = that.size_;
+    }
+    return *this;
+  }
+
+  SmallVector& operator=(SmallVector&& that) {
+    if (that.large_data_) {
+      large_data_.reset(that.large_data_.release());
+    } else {
+      large_data_.reset(nullptr);
+      size_t i = 0;
+      // Do a move for any element in |this| that is already constructed.
+      for (; i < size_ && i < that.size_; ++i) {
+        small_data_[i] = std::move(that.small_data_[i]);
+      }
+
+      if (i >= that.size_) {
+        // If the size of |this| becomes smaller after the assignment, then
+        // destroy any extra elements.
+        for (; i < size_; ++i) {
+          small_data_[i].~T();
+        }
+      } else {
+        // If the size of |this| becomes larger after the assignement, move
+        // construct the new elements that are needed.
+        for (; i < that.size_; ++i) {
+          new (small_data_ + i) T(std::move(that.small_data_[i]));
+        }
+      }
+      size_ = that.size_;
+    }
+
+    // Reset |that| because all of the data has been moved to |this|.
+    that.DestructSmallData();
+    return *this;
+  }
+
+  template <class OtherVector>
+  friend bool operator==(const SmallVector& lhs, const OtherVector& rhs) {
+    if (lhs.size() != rhs.size()) {
+      return false;
+    }
+
+    auto rit = rhs.begin();
+    for (auto lit = lhs.begin(); lit != lhs.end(); ++lit, ++rit) {
+      if (*lit != *rit) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  friend bool operator==(const std::vector<T>& lhs, const SmallVector& rhs) {
+    return rhs == lhs;
+  }
+
+  friend bool operator!=(const SmallVector& lhs, const std::vector<T>& rhs) {
+    return !(lhs == rhs);
+  }
+
+  friend bool operator!=(const std::vector<T>& lhs, const SmallVector& rhs) {
+    return rhs != lhs;
+  }
+
+  T& operator[](size_t i) {
+    if (!large_data_) {
+      return small_data_[i];
+    } else {
+      return (*large_data_)[i];
+    }
+  }
+
+  const T& operator[](size_t i) const {
+    if (!large_data_) {
+      return small_data_[i];
+    } else {
+      return (*large_data_)[i];
+    }
+  }
+
+  size_t size() const {
+    if (!large_data_) {
+      return size_;
+    } else {
+      return large_data_->size();
+    }
+  }
+
+  iterator begin() {
+    if (large_data_) {
+      return large_data_->data();
+    } else {
+      return small_data_;
+    }
+  }
+
+  const_iterator begin() const {
+    if (large_data_) {
+      return large_data_->data();
+    } else {
+      return small_data_;
+    }
+  }
+
+  const_iterator cbegin() const { return begin(); }
+
+  iterator end() {
+    if (large_data_) {
+      return large_data_->data() + large_data_->size();
+    } else {
+      return small_data_ + size_;
+    }
+  }
+
+  const_iterator end() const {
+    if (large_data_) {
+      return large_data_->data() + large_data_->size();
+    } else {
+      return small_data_ + size_;
+    }
+  }
+
+  const_iterator cend() const { return end(); }
+
+  T* data() { return begin(); }
+
+  const T* data() const { return cbegin(); }
+
+  T& front() { return (*this)[0]; }
+
+  const T& front() const { return (*this)[0]; }
+
+  iterator erase(const_iterator pos) { return erase(pos, pos + 1); }
+
+  iterator erase(const_iterator first, const_iterator last) {
+    if (large_data_) {
+      size_t start_index = first - large_data_->data();
+      size_t end_index = last - large_data_->data();
+      auto r = large_data_->erase(large_data_->begin() + start_index,
+                                  large_data_->begin() + end_index);
+      return large_data_->data() + (r - large_data_->begin());
+    }
+
+    // Since C++11, std::vector has |const_iterator| for the parameters, so I
+    // follow that.  However, I need iterators to modify the current container,
+    // which is not const.  This is why I cast away the const.
+    iterator f = const_cast<iterator>(first);
+    iterator l = const_cast<iterator>(last);
+    iterator e = end();
+
+    size_t num_of_del_elements = last - first;
+    iterator ret = f;
+    if (first == last) {
+      return ret;
+    }
+
+    // Move |last| and any elements after it their earlier position.
+    while (l != e) {
+      *f = std::move(*l);
+      ++f;
+      ++l;
+    }
+
+    // Destroy the elements that were supposed to be deleted.
+    while (f != l) {
+      f->~T();
+      ++f;
+    }
+
+    // Update the size.
+    size_ -= num_of_del_elements;
+    return ret;
+  }
+
+  void push_back(const T& value) {
+    if (!large_data_ && size_ == small_size) {
+      MoveToLargeData();
+    }
+
+    if (large_data_) {
+      large_data_->push_back(value);
+      return;
+    }
+
+    new (small_data_ + size_) T(value);
+    ++size_;
+  }
+
+  void push_back(T&& value) {
+    if (!large_data_ && size_ == small_size) {
+      MoveToLargeData();
+    }
+
+    if (large_data_) {
+      large_data_->push_back(std::move(value));
+      return;
+    }
+
+    new (small_data_ + size_) T(std::move(value));
+    ++size_;
+  }
+
+  template <class InputIt>
+  iterator insert(iterator pos, InputIt first, InputIt last) {
+    size_t element_idx = (pos - begin());
+    size_t num_of_new_elements = std::distance(first, last);
+    size_t new_size = size_ + num_of_new_elements;
+    if (!large_data_ && new_size > small_size) {
+      MoveToLargeData();
+    }
+
+    if (large_data_) {
+      typename std::vector<T>::iterator new_pos =
+          large_data_->begin() + element_idx;
+      large_data_->insert(new_pos, first, last);
+      return begin() + element_idx;
+    }
+
+    // Move |pos| and all of the elements after it over |num_of_new_elements|
+    // places.  We start at the end and work backwards, to make sure we do not
+    // overwrite data that we have not moved yet.
+    for (iterator i = begin() + new_size - 1, j = end() - 1; j >= pos;
+         --i, --j) {
+      if (i >= begin() + size_) {
+        new (i) T(std::move(*j));
+      } else {
+        *i = std::move(*j);
+      }
+    }
+
+    // Copy the new elements into position.
+    iterator p = pos;
+    for (; first != last; ++p, ++first) {
+      if (p >= small_data_ + size_) {
+        new (p) T(*first);
+      } else {
+        *p = *first;
+      }
+    }
+
+    // Upate the size.
+    size_ += num_of_new_elements;
+    return pos;
+  }
+
+  bool empty() const {
+    if (large_data_) {
+      return large_data_->empty();
+    }
+    return size_ == 0;
+  }
+
+  void clear() {
+    if (large_data_) {
+      large_data_->clear();
+    } else {
+      DestructSmallData();
+    }
+  }
+
+  template <class... Args>
+  void emplace_back(Args&&... args) {
+    if (!large_data_ && size_ == small_size) {
+      MoveToLargeData();
+    }
+
+    if (large_data_) {
+      large_data_->emplace_back(std::forward<Args>(args)...);
+    } else {
+      new (small_data_ + size_) T(std::forward<Args>(args)...);
+      ++size_;
+    }
+  }
+
+  void resize(size_t new_size, const T& v) {
+    if (!large_data_ && new_size > small_size) {
+      MoveToLargeData();
+    }
+
+    if (large_data_) {
+      large_data_->resize(new_size, v);
+      return;
+    }
+
+    // If |new_size| < |size_|, then destroy the extra elements.
+    for (size_t i = new_size; i < size_; ++i) {
+      small_data_[i].~T();
+    }
+
+    // If |new_size| > |size_|, the copy construct the new elements.
+    for (size_t i = size_; i < new_size; ++i) {
+      new (small_data_ + i) T(v);
+    }
+
+    // Update the size.
+    size_ = new_size;
+  }
+
+ private:
+  // Moves all of the element from |small_data_| into a new std::vector that can
+  // be access through |large_data|.
+  void MoveToLargeData() {
+    assert(!large_data_);
+    large_data_.reset(new std::vector<T>());
+    for (size_t i = 0; i < size_; ++i) {
+      large_data_->emplace_back(std::move(small_data_[i]));
+    }
+    DestructSmallData();
+  }
+
+  // Destroys all of the elements in |small_data_| that have been constructed.
+  void DestructSmallData() {
+    for (size_t i = 0; i < size_; ++i) {
+      small_data_[i].~T();
+    }
+    size_ = 0;
+  }
+
+  // The number of elements in |small_data_| that have been constructed.
+  size_t size_;
+
+  // The pointed used to access the array of elements when the number of
+  // elements is small.
+  T* small_data_;
+
+  // The actual data used to store the array elements.  It must never be used
+  // directly, but must only be accesed through |small_data_|.
+  typename std::aligned_storage<sizeof(T), std::alignment_of<T>::value>::type
+      buffer[small_size];
+
+  // A pointer to a vector that is used to store the elements of the vector when
+  // this size exceeds |small_size|.  If |large_data_| is nullptr, then the data
+  // is stored in |small_data_|.  Otherwise, the data is stored in
+  // |large_data_|.
+  std::unique_ptr<std::vector<T>> large_data_;
+};  // namespace utils
+
+}  // namespace utils
+}  // namespace spvtools
+
+#endif  // LIBSPIRV_UTILS_SMALL_VECTOR_H_

--- a/test/util/CMakeLists.txt
+++ b/test/util/CMakeLists.txt
@@ -20,3 +20,7 @@ add_spvtools_unittest(TARGET bit_vector
   SRCS bit_vector_test.cpp
   LIBS SPIRV-Tools-opt
 )
+
+add_spvtools_unittest(TARGET small_vector
+  SRCS small_vector_test.cpp
+)

--- a/test/util/small_vector_test.cpp
+++ b/test/util/small_vector_test.cpp
@@ -1,0 +1,594 @@
+// Copyright (c) 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+
+#include "gmock/gmock.h"
+
+#include "util/small_vector.h"
+
+namespace {
+
+using spvtools::utils::SmallVector;
+using SmallVectorTest = ::testing::Test;
+
+TEST(SmallVectorTest, Initialize_default) {
+  SmallVector<uint32_t, 2> vec;
+
+  EXPECT_TRUE(vec.empty());
+  EXPECT_EQ(vec.size(), 0);
+  EXPECT_EQ(vec.begin(), vec.end());
+}
+
+TEST(SmallVectorTest, Initialize_list1) {
+  SmallVector<uint32_t, 2> vec = {0, 1, 2, 3};
+
+  EXPECT_FALSE(vec.empty());
+  EXPECT_EQ(vec.size(), 4);
+
+  uint32_t result[] = {0, 1, 2, 3};
+  for (uint32_t i = 0; i < vec.size(); ++i) {
+    EXPECT_EQ(vec[i], result[i]);
+  }
+}
+
+TEST(SmallVectorTest, Initialize_list2) {
+  SmallVector<uint32_t, 6> vec = {0, 1, 2, 3};
+
+  EXPECT_FALSE(vec.empty());
+  EXPECT_EQ(vec.size(), 4);
+
+  uint32_t result[] = {0, 1, 2, 3};
+  for (uint32_t i = 0; i < vec.size(); ++i) {
+    EXPECT_EQ(vec[i], result[i]);
+  }
+}
+
+TEST(SmallVectorTest, Initialize_copy1) {
+  SmallVector<uint32_t, 6> vec1 = {0, 1, 2, 3};
+  SmallVector<uint32_t, 6> vec2(vec1);
+
+  EXPECT_EQ(vec2.size(), 4);
+
+  uint32_t result[] = {0, 1, 2, 3};
+  for (uint32_t i = 0; i < vec2.size(); ++i) {
+    EXPECT_EQ(vec2[i], result[i]);
+  }
+
+  EXPECT_EQ(vec1, vec2);
+}
+
+TEST(SmallVectorTest, Initialize_copy2) {
+  SmallVector<uint32_t, 2> vec1 = {0, 1, 2, 3};
+  SmallVector<uint32_t, 2> vec2(vec1);
+
+  EXPECT_EQ(vec2.size(), 4);
+
+  uint32_t result[] = {0, 1, 2, 3};
+  for (uint32_t i = 0; i < vec2.size(); ++i) {
+    EXPECT_EQ(vec2[i], result[i]);
+  }
+
+  EXPECT_EQ(vec1, vec2);
+}
+
+TEST(SmallVectorTest, Initialize_copy_vec1) {
+  std::vector<uint32_t> vec1 = {0, 1, 2, 3};
+  SmallVector<uint32_t, 6> vec2(vec1);
+
+  EXPECT_EQ(vec2.size(), 4);
+
+  uint32_t result[] = {0, 1, 2, 3};
+  for (uint32_t i = 0; i < vec2.size(); ++i) {
+    EXPECT_EQ(vec2[i], result[i]);
+  }
+
+  EXPECT_EQ(vec1, vec2);
+}
+
+TEST(SmallVectorTest, Initialize_copy_vec2) {
+  std::vector<uint32_t> vec1 = {0, 1, 2, 3};
+  SmallVector<uint32_t, 2> vec2(vec1);
+
+  EXPECT_EQ(vec2.size(), 4);
+
+  uint32_t result[] = {0, 1, 2, 3};
+  for (uint32_t i = 0; i < vec2.size(); ++i) {
+    EXPECT_EQ(vec2[i], result[i]);
+  }
+
+  EXPECT_EQ(vec1, vec2);
+}
+
+TEST(SmallVectorTest, Initialize_move1) {
+  SmallVector<uint32_t, 6> vec1 = {0, 1, 2, 3};
+  SmallVector<uint32_t, 6> vec2(std::move(vec1));
+
+  EXPECT_EQ(vec2.size(), 4);
+
+  uint32_t result[] = {0, 1, 2, 3};
+  for (uint32_t i = 0; i < vec2.size(); ++i) {
+    EXPECT_EQ(vec2[i], result[i]);
+  }
+  EXPECT_TRUE(vec1.empty());
+}
+
+TEST(SmallVectorTest, Initialize_move2) {
+  SmallVector<uint32_t, 2> vec1 = {0, 1, 2, 3};
+  SmallVector<uint32_t, 2> vec2(std::move(vec1));
+
+  EXPECT_EQ(vec2.size(), 4);
+
+  uint32_t result[] = {0, 1, 2, 3};
+  for (uint32_t i = 0; i < vec2.size(); ++i) {
+    EXPECT_EQ(vec2[i], result[i]);
+  }
+  EXPECT_TRUE(vec1.empty());
+}
+
+TEST(SmallVectorTest, Initialize_move_vec1) {
+  std::vector<uint32_t> vec1 = {0, 1, 2, 3};
+  SmallVector<uint32_t, 6> vec2(std::move(vec1));
+
+  EXPECT_EQ(vec2.size(), 4);
+
+  uint32_t result[] = {0, 1, 2, 3};
+  for (uint32_t i = 0; i < vec2.size(); ++i) {
+    EXPECT_EQ(vec2[i], result[i]);
+  }
+  EXPECT_TRUE(vec1.empty());
+}
+
+TEST(SmallVectorTest, Initialize_move_vec2) {
+  std::vector<uint32_t> vec1 = {0, 1, 2, 3};
+  SmallVector<uint32_t, 2> vec2(std::move(vec1));
+
+  EXPECT_EQ(vec2.size(), 4);
+
+  uint32_t result[] = {0, 1, 2, 3};
+  for (uint32_t i = 0; i < vec2.size(); ++i) {
+    EXPECT_EQ(vec2[i], result[i]);
+  }
+  EXPECT_TRUE(vec1.empty());
+}
+
+TEST(SmallVectorTest, Initialize_iterators1) {
+  SmallVector<uint32_t, 2> vec = {0, 1, 2, 3};
+
+  EXPECT_EQ(vec.size(), 4);
+  uint32_t result[] = {0, 1, 2, 3};
+
+  uint32_t i = 0;
+  for (uint32_t p : vec) {
+    EXPECT_EQ(p, result[i]);
+    i++;
+  }
+}
+
+TEST(SmallVectorTest, Initialize_iterators2) {
+  SmallVector<uint32_t, 6> vec = {0, 1, 2, 3};
+
+  EXPECT_EQ(vec.size(), 4);
+  uint32_t result[] = {0, 1, 2, 3};
+
+  uint32_t i = 0;
+  for (uint32_t p : vec) {
+    EXPECT_EQ(p, result[i]);
+    i++;
+  }
+}
+
+TEST(SmallVectorTest, Initialize_iterators3) {
+  SmallVector<uint32_t, 2> vec = {0, 1, 2, 3};
+
+  EXPECT_EQ(vec.size(), 4);
+  uint32_t result[] = {0, 1, 2, 3};
+
+  uint32_t i = 0;
+  for (SmallVector<uint32_t, 2>::iterator it = vec.begin(); it != vec.end();
+       ++it) {
+    EXPECT_EQ(*it, result[i]);
+    i++;
+  }
+}
+
+TEST(SmallVectorTest, Initialize_iterators4) {
+  SmallVector<uint32_t, 6> vec = {0, 1, 2, 3};
+
+  EXPECT_EQ(vec.size(), 4);
+  uint32_t result[] = {0, 1, 2, 3};
+
+  uint32_t i = 0;
+  for (SmallVector<uint32_t, 6>::iterator it = vec.begin(); it != vec.end();
+       ++it) {
+    EXPECT_EQ(*it, result[i]);
+    i++;
+  }
+}
+
+TEST(SmallVectorTest, Initialize_iterators_write1) {
+  SmallVector<uint32_t, 6> vec = {0, 1, 2, 3};
+
+  EXPECT_EQ(vec.size(), 4);
+  for (SmallVector<uint32_t, 6>::iterator it = vec.begin(); it != vec.end();
+       ++it) {
+    *it *= 2;
+  }
+
+  uint32_t result[] = {0, 2, 4, 6};
+
+  uint32_t i = 0;
+  for (SmallVector<uint32_t, 6>::iterator it = vec.begin(); it != vec.end();
+       ++it) {
+    EXPECT_EQ(*it, result[i]);
+    i++;
+  }
+}
+
+TEST(SmallVectorTest, Initialize_iterators_write2) {
+  SmallVector<uint32_t, 2> vec = {0, 1, 2, 3};
+
+  EXPECT_EQ(vec.size(), 4);
+  for (SmallVector<uint32_t, 2>::iterator it = vec.begin(); it != vec.end();
+       ++it) {
+    *it *= 2;
+  }
+
+  uint32_t result[] = {0, 2, 4, 6};
+
+  uint32_t i = 0;
+  for (SmallVector<uint32_t, 2>::iterator it = vec.begin(); it != vec.end();
+       ++it) {
+    EXPECT_EQ(*it, result[i]);
+    i++;
+  }
+}
+
+TEST(SmallVectorTest, Initialize_front) {
+  SmallVector<uint32_t, 2> vec = {0, 1, 2, 3};
+
+  EXPECT_EQ(vec.front(), 0);
+  for (SmallVector<uint32_t, 2>::iterator it = vec.begin(); it != vec.end();
+       ++it) {
+    *it += 2;
+  }
+  EXPECT_EQ(vec.front(), 2);
+}
+
+TEST(SmallVectorTest, Erase_element_front1) {
+  SmallVector<uint32_t, 2> vec = {0, 1, 2, 3};
+
+  EXPECT_EQ(vec.front(), 0);
+  EXPECT_EQ(vec.size(), 4);
+  vec.erase(vec.begin());
+  EXPECT_EQ(vec.front(), 1);
+  EXPECT_EQ(vec.size(), 3);
+}
+
+TEST(SmallVectorTest, Erase_element_front2) {
+  SmallVector<uint32_t, 6> vec = {0, 1, 2, 3};
+
+  EXPECT_EQ(vec.front(), 0);
+  EXPECT_EQ(vec.size(), 4);
+  vec.erase(vec.begin());
+  EXPECT_EQ(vec.front(), 1);
+  EXPECT_EQ(vec.size(), 3);
+}
+
+TEST(SmallVectorTest, Erase_element_back1) {
+  SmallVector<uint32_t, 2> vec = {0, 1, 2, 3};
+  SmallVector<uint32_t, 2> result = {0, 1, 2};
+
+  EXPECT_EQ(vec[3], 3);
+  EXPECT_EQ(vec.size(), 4);
+  vec.erase(vec.begin() + 3);
+  EXPECT_EQ(vec.size(), 3);
+  EXPECT_EQ(vec, result);
+}
+
+TEST(SmallVectorTest, Erase_element_back2) {
+  SmallVector<uint32_t, 6> vec = {0, 1, 2, 3};
+  SmallVector<uint32_t, 6> result = {0, 1, 2};
+
+  EXPECT_EQ(vec[3], 3);
+  EXPECT_EQ(vec.size(), 4);
+  vec.erase(vec.begin() + 3);
+  EXPECT_EQ(vec.size(), 3);
+  EXPECT_EQ(vec, result);
+}
+
+TEST(SmallVectorTest, Erase_element_middle1) {
+  SmallVector<uint32_t, 2> vec = {0, 1, 2, 3};
+  SmallVector<uint32_t, 2> result = {0, 1, 3};
+
+  EXPECT_EQ(vec.size(), 4);
+  vec.erase(vec.begin() + 2);
+  EXPECT_EQ(vec.size(), 3);
+  EXPECT_EQ(vec, result);
+}
+
+TEST(SmallVectorTest, Erase_element_middle2) {
+  SmallVector<uint32_t, 6> vec = {0, 1, 2, 3};
+  SmallVector<uint32_t, 6> result = {0, 1, 3};
+
+  EXPECT_EQ(vec.size(), 4);
+  vec.erase(vec.begin() + 2);
+  EXPECT_EQ(vec.size(), 3);
+  EXPECT_EQ(vec, result);
+}
+
+TEST(SmallVectorTest, Erase_range_1) {
+  SmallVector<uint32_t, 6> vec = {0, 1, 2, 3};
+  SmallVector<uint32_t, 6> result = {};
+
+  EXPECT_EQ(vec.size(), 4);
+  vec.erase(vec.begin(), vec.end());
+  EXPECT_EQ(vec.size(), 0);
+  EXPECT_EQ(vec, result);
+}
+
+TEST(SmallVectorTest, Erase_range_2) {
+  SmallVector<uint32_t, 2> vec = {0, 1, 2, 3};
+  SmallVector<uint32_t, 2> result = {};
+
+  EXPECT_EQ(vec.size(), 4);
+  vec.erase(vec.begin(), vec.end());
+  EXPECT_EQ(vec.size(), 0);
+  EXPECT_EQ(vec, result);
+}
+
+TEST(SmallVectorTest, Erase_range_3) {
+  SmallVector<uint32_t, 6> vec = {0, 1, 2, 3};
+  SmallVector<uint32_t, 6> result = {2, 3};
+
+  EXPECT_EQ(vec.size(), 4);
+  vec.erase(vec.begin(), vec.begin() + 2);
+  EXPECT_EQ(vec.size(), 2);
+  EXPECT_EQ(vec, result);
+}
+
+TEST(SmallVectorTest, Erase_range_4) {
+  SmallVector<uint32_t, 2> vec = {0, 1, 2, 3};
+  SmallVector<uint32_t, 2> result = {2, 3};
+
+  EXPECT_EQ(vec.size(), 4);
+  vec.erase(vec.begin(), vec.begin() + 2);
+  EXPECT_EQ(vec.size(), 2);
+  EXPECT_EQ(vec, result);
+}
+
+TEST(SmallVectorTest, Erase_range_5) {
+  SmallVector<uint32_t, 6> vec = {0, 1, 2, 3};
+  SmallVector<uint32_t, 6> result = {0, 3};
+
+  EXPECT_EQ(vec.size(), 4);
+  vec.erase(vec.begin() + 1, vec.begin() + 3);
+  EXPECT_EQ(vec.size(), 2);
+  EXPECT_EQ(vec, result);
+}
+
+TEST(SmallVectorTest, Erase_range_6) {
+  SmallVector<uint32_t, 2> vec = {0, 1, 2, 3};
+  SmallVector<uint32_t, 2> result = {0, 3};
+
+  EXPECT_EQ(vec.size(), 4);
+  vec.erase(vec.begin() + 1, vec.begin() + 3);
+  EXPECT_EQ(vec.size(), 2);
+  EXPECT_EQ(vec, result);
+}
+
+TEST(SmallVectorTest, Push_back) {
+  SmallVector<uint32_t, 2> vec;
+  SmallVector<uint32_t, 2> result = {0, 1, 2, 3};
+
+  EXPECT_EQ(vec.size(), 0);
+  vec.push_back(0);
+  EXPECT_EQ(vec.size(), 1);
+  vec.push_back(1);
+  EXPECT_EQ(vec.size(), 2);
+  vec.push_back(2);
+  EXPECT_EQ(vec.size(), 3);
+  vec.push_back(3);
+  EXPECT_EQ(vec.size(), 4);
+  EXPECT_EQ(vec, result);
+}
+
+TEST(SmallVectorTest, Emplace_back) {
+  SmallVector<uint32_t, 2> vec;
+  SmallVector<uint32_t, 2> result = {0, 1, 2, 3};
+
+  EXPECT_EQ(vec.size(), 0);
+  vec.emplace_back(0);
+  EXPECT_EQ(vec.size(), 1);
+  vec.emplace_back(1);
+  EXPECT_EQ(vec.size(), 2);
+  vec.emplace_back(2);
+  EXPECT_EQ(vec.size(), 3);
+  vec.emplace_back(3);
+  EXPECT_EQ(vec.size(), 4);
+  EXPECT_EQ(vec, result);
+}
+
+TEST(SmallVectorTest, Clear) {
+  SmallVector<uint32_t, 2> vec = {0, 1, 2, 3};
+  SmallVector<uint32_t, 2> result = {};
+
+  EXPECT_EQ(vec.size(), 4);
+  vec.clear();
+  EXPECT_EQ(vec.size(), 0);
+  EXPECT_EQ(vec, result);
+}
+
+TEST(SmallVectorTest, Insert1) {
+  SmallVector<uint32_t, 2> vec = {};
+  SmallVector<uint32_t, 2> insert_values = {10, 11};
+  SmallVector<uint32_t, 2> result = {10, 11};
+
+  EXPECT_EQ(vec.size(), 0);
+  auto ret =
+      vec.insert(vec.begin(), insert_values.begin(), insert_values.end());
+  EXPECT_EQ(vec.size(), 2);
+  EXPECT_EQ(vec, result);
+  EXPECT_EQ(*ret, 10);
+}
+
+TEST(SmallVectorTest, Insert2) {
+  SmallVector<uint32_t, 2> vec = {};
+  SmallVector<uint32_t, 2> insert_values = {10, 11, 12};
+  SmallVector<uint32_t, 2> result = {10, 11, 12};
+
+  EXPECT_EQ(vec.size(), 0);
+  auto ret =
+      vec.insert(vec.begin(), insert_values.begin(), insert_values.end());
+  EXPECT_EQ(vec.size(), 3);
+  EXPECT_EQ(vec, result);
+  EXPECT_EQ(*ret, 10);
+}
+
+TEST(SmallVectorTest, Insert3) {
+  SmallVector<uint32_t, 2> vec = {0};
+  SmallVector<uint32_t, 2> insert_values = {10, 11, 12};
+  SmallVector<uint32_t, 2> result = {10, 11, 12, 0};
+
+  EXPECT_EQ(vec.size(), 1);
+  auto ret =
+      vec.insert(vec.begin(), insert_values.begin(), insert_values.end());
+  EXPECT_EQ(vec.size(), 4);
+  EXPECT_EQ(vec, result);
+  EXPECT_EQ(*ret, 10);
+}
+
+TEST(SmallVectorTest, Insert4) {
+  SmallVector<uint32_t, 6> vec = {0};
+  SmallVector<uint32_t, 6> insert_values = {10, 11, 12};
+  SmallVector<uint32_t, 6> result = {10, 11, 12, 0};
+
+  EXPECT_EQ(vec.size(), 1);
+  auto ret =
+      vec.insert(vec.begin(), insert_values.begin(), insert_values.end());
+  EXPECT_EQ(vec.size(), 4);
+  EXPECT_EQ(vec, result);
+  EXPECT_EQ(*ret, 10);
+}
+
+TEST(SmallVectorTest, Insert5) {
+  SmallVector<uint32_t, 2> vec = {0, 1, 2};
+  SmallVector<uint32_t, 2> insert_values = {10, 11, 12};
+  SmallVector<uint32_t, 2> result = {0, 1, 2, 10, 11, 12};
+
+  EXPECT_EQ(vec.size(), 3);
+  auto ret = vec.insert(vec.end(), insert_values.begin(), insert_values.end());
+  EXPECT_EQ(vec.size(), 6);
+  EXPECT_EQ(vec, result);
+  EXPECT_EQ(*ret, 10);
+}
+
+TEST(SmallVectorTest, Insert6) {
+  SmallVector<uint32_t, 6> vec = {0, 1, 2};
+  SmallVector<uint32_t, 6> insert_values = {10, 11, 12};
+  SmallVector<uint32_t, 6> result = {0, 1, 2, 10, 11, 12};
+
+  EXPECT_EQ(vec.size(), 3);
+  auto ret = vec.insert(vec.end(), insert_values.begin(), insert_values.end());
+  EXPECT_EQ(vec.size(), 6);
+  EXPECT_EQ(vec, result);
+  EXPECT_EQ(*ret, 10);
+}
+
+TEST(SmallVectorTest, Insert7) {
+  SmallVector<uint32_t, 2> vec = {0, 1, 2};
+  SmallVector<uint32_t, 2> insert_values = {10, 11, 12};
+  SmallVector<uint32_t, 2> result = {0, 10, 11, 12, 1, 2};
+
+  EXPECT_EQ(vec.size(), 3);
+  auto ret =
+      vec.insert(vec.begin() + 1, insert_values.begin(), insert_values.end());
+  EXPECT_EQ(vec.size(), 6);
+  EXPECT_EQ(vec, result);
+  EXPECT_EQ(*ret, 10);
+}
+
+TEST(SmallVectorTest, Insert8) {
+  SmallVector<uint32_t, 6> vec = {0, 1, 2};
+  SmallVector<uint32_t, 6> insert_values = {10, 11, 12};
+  SmallVector<uint32_t, 6> result = {0, 10, 11, 12, 1, 2};
+
+  EXPECT_EQ(vec.size(), 3);
+  auto ret =
+      vec.insert(vec.begin() + 1, insert_values.begin(), insert_values.end());
+  EXPECT_EQ(vec.size(), 6);
+  EXPECT_EQ(vec, result);
+  EXPECT_EQ(*ret, 10);
+}
+
+TEST(SmallVectorTest, Resize1) {
+  SmallVector<uint32_t, 2> vec = {0, 1, 2};
+  SmallVector<uint32_t, 2> result = {0, 1, 2, 10, 10, 10};
+
+  EXPECT_EQ(vec.size(), 3);
+  vec.resize(6, 10);
+  EXPECT_EQ(vec.size(), 6);
+  EXPECT_EQ(vec, result);
+}
+
+TEST(SmallVectorTest, Resize2) {
+  SmallVector<uint32_t, 8> vec = {0, 1, 2};
+  SmallVector<uint32_t, 8> result = {0, 1, 2, 10, 10, 10};
+
+  EXPECT_EQ(vec.size(), 3);
+  vec.resize(6, 10);
+  EXPECT_EQ(vec.size(), 6);
+  EXPECT_EQ(vec, result);
+}
+
+TEST(SmallVectorTest, Resize3) {
+  SmallVector<uint32_t, 4> vec = {0, 1, 2};
+  SmallVector<uint32_t, 4> result = {0, 1, 2, 10, 10, 10};
+
+  EXPECT_EQ(vec.size(), 3);
+  vec.resize(6, 10);
+  EXPECT_EQ(vec.size(), 6);
+  EXPECT_EQ(vec, result);
+}
+
+TEST(SmallVectorTest, Resize4) {
+  SmallVector<uint32_t, 4> vec = {0, 1, 2, 10, 10, 10};
+  SmallVector<uint32_t, 4> result = {0, 1, 2};
+
+  EXPECT_EQ(vec.size(), 6);
+  vec.resize(3, 10);
+  EXPECT_EQ(vec.size(), 3);
+  EXPECT_EQ(vec, result);
+}
+
+TEST(SmallVectorTest, Resize5) {
+  SmallVector<uint32_t, 2> vec = {0, 1, 2, 10, 10, 10};
+  SmallVector<uint32_t, 2> result = {0, 1, 2};
+
+  EXPECT_EQ(vec.size(), 6);
+  vec.resize(3, 10);
+  EXPECT_EQ(vec.size(), 3);
+  EXPECT_EQ(vec, result);
+}
+
+TEST(SmallVectorTest, Resize6) {
+  SmallVector<uint32_t, 8> vec = {0, 1, 2, 10, 10, 10};
+  SmallVector<uint32_t, 8> result = {0, 1, 2};
+
+  EXPECT_EQ(vec.size(), 6);
+  vec.resize(3, 10);
+  EXPECT_EQ(vec.size(), 3);
+  EXPECT_EQ(vec, result);
+}
+}  // namespace


### PR DESCRIPTION
We replace the std::vector in the Operand class by a new class that does
a small size optimization.  This helps improve compile time on Windows.

Tested on three sets of shaders.  Trying various values for the small
vector.  The optimal value for the operand class was 2.  However, for
the Instruction class, using an std::vector was optimal.  Size of "0"
means that an std::vector was used.


<table>
  <tr>
   <td>OperandData Size
   </td>
   <td colspan="3" >OperandList size
   </td>
  </tr>
  <tr>
   <td>
   </td>
   <td>0
   </td>
   <td>4
   </td>
   <td>8
   </td>
  </tr>
  <tr>
   <td>0
   </td>
   <td>489s (baseline)    
   </td>
   <td>544s
   </td>
   <td>684s
   </td>
  </tr>
  <tr>
   <td>1
   </td>
   <td>593s    
   </td>
   <td>
   </td>
   <td>
   </td>
  </tr>
  <tr>
   <td>2
   </td>
   <td>469s
   </td>
   <td>487s
   </td>
   <td>
   </td>
  </tr>
  <tr>
   <td>4
   </td>
   <td>473s
   </td>
   <td>570s
   </td>
   <td>
   </td>
  </tr>
  <tr>
   <td>8
   </td>
   <td>505s
   </td>
   <td>
   </td>
   <td>
   </td>
  </tr>
</table>

This is a single thread run of ~120 shaders.  

For the multithreaded run the results were the similar.  The time went from ~62sec to ~38sec.  The
optimal configuration was an 2 for the OperandData and an
std::vector for the OperandList.  Similar
expiriments were done with other sets of shaders.  The compile time still
improved, but not as much.

Contributes to https://github.com/KhronosGroup/SPIRV-Tools/issues/1609.