### PR TITLE
Make fewer test executables

### DIFF
--- a/test/link/CMakeLists.txt
+++ b/test/link/CMakeLists.txt
@@ -12,42 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_spvtools_unittest(TARGET link_binary_version
-  SRCS binary_version_test.cpp
-  LIBS SPIRV-Tools-opt SPIRV-Tools-link
-)
 
-add_spvtools_unittest(TARGET link_memory_model
-  SRCS memory_model_test.cpp
-  LIBS SPIRV-Tools-opt SPIRV-Tools-link
-)
-
-add_spvtools_unittest(TARGET link_entry_points
-  SRCS entry_points_test.cpp
-  LIBS SPIRV-Tools-opt SPIRV-Tools-link
-)
-
-add_spvtools_unittest(TARGET link_global_values_amount
-  SRCS global_values_amount_test.cpp
-  LIBS SPIRV-Tools-opt SPIRV-Tools-link
-)
-
-add_spvtools_unittest(TARGET link_ids_limit
-  SRCS ids_limit_test.cpp
-  LIBS SPIRV-Tools-opt SPIRV-Tools-link
-)
-
-add_spvtools_unittest(TARGET link_matching_imports_to_exports
-  SRCS matching_imports_to_exports_test.cpp
-  LIBS SPIRV-Tools-opt SPIRV-Tools-link
-)
-
-add_spvtools_unittest(TARGET link_unique_ids
-  SRCS unique_ids_test.cpp
-  LIBS SPIRV-Tools-opt SPIRV-Tools-link
-)
-
-add_spvtools_unittest(TARGET link_partial_linkage
-  SRCS partial_linkage_test.cpp
+add_spvtools_unittest(TARGET link
+  SRCS
+       binary_version_test.cpp
+       entry_points_test.cpp
+       global_values_amount_test.cpp
+       ids_limit_test.cpp
+       matching_imports_to_exports_test.cpp
+       memory_model_test.cpp
+       partial_linkage_test.cpp
+       unique_ids_test.cpp
   LIBS SPIRV-Tools-opt SPIRV-Tools-link
 )

--- a/test/link/global_values_amount_test.cpp
+++ b/test/link/global_values_amount_test.cpp
@@ -19,9 +19,9 @@ namespace {
 
 using ::testing::HasSubstr;
 
-class EntryPoints : public spvtest::LinkerTest {
+class EntryPointsAmountTest : public spvtest::LinkerTest {
  public:
-  EntryPoints() { binaries.reserve(0xFFFF); }
+  EntryPointsAmountTest() { binaries.reserve(0xFFFF); }
 
   virtual void SetUp() override {
     binaries.push_back({SpvMagicNumber,
@@ -105,14 +105,14 @@ class EntryPoints : public spvtest::LinkerTest {
   spvtest::Binaries binaries;
 };
 
-TEST_F(EntryPoints, UnderLimit) {
+TEST_F(EntryPointsAmountTest, UnderLimit) {
   spvtest::Binary linked_binary;
 
   EXPECT_EQ(SPV_SUCCESS, Link(binaries, &linked_binary));
   EXPECT_THAT(GetErrorMessage(), std::string());
 }
 
-TEST_F(EntryPoints, OverLimit) {
+TEST_F(EntryPointsAmountTest, OverLimit) {
   binaries.push_back({SpvMagicNumber,
                       SpvVersion,
                       SPV_GENERATOR_CODEPLAY,

--- a/test/opt/dominator_tree/CMakeLists.txt
+++ b/test/opt/dominator_tree/CMakeLists.txt
@@ -13,67 +13,18 @@
 # limitations under the License.
 
 
-add_spvtools_unittest(TARGET dominator_analysis_simple
-    SRCS ../function_utils.h
-         simple.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET dominator_analysis_post
-    SRCS ../function_utils.h
-         post.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET dominator_analysis_nested_ifs
-    SRCS ../function_utils.h
-         nested_ifs.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET dominator_analysis_nested_ifs_post
-    SRCS ../function_utils.h
-         nested_ifs_post.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET dominator_analysis_nested_loops
-    SRCS ../function_utils.h
-         nested_loops.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET dominator_analysis_nested_loops_with_unreachables
-    SRCS ../function_utils.h
-         nested_loops_with_unreachables.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET dominator_analysis_switch_case_fallthrough
-    SRCS ../function_utils.h
-         switch_case_fallthrough.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET dominator_analysis_unreachable_for
-    SRCS ../function_utils.h
-         unreachable_for.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET dominator_analysis_unreachable_for_post
-    SRCS ../function_utils.h
-         unreachable_for_post.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET dominator_generated
-    SRCS ../function_utils.h
-         generated.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET dominator_common_dominators
-    SRCS common_dominators.cpp
-    LIBS SPIRV-Tools-opt
+add_spvtools_unittest(TARGET dominator_analysis
+  SRCS ../function_utils.h
+       common_dominators.cpp
+       generated.cpp
+       nested_ifs.cpp
+       nested_ifs_post.cpp
+       nested_loops.cpp
+       nested_loops_with_unreachables.cpp
+       post.cpp
+       simple.cpp
+       switch_case_fallthrough.cpp
+       unreachable_for.cpp
+       unreachable_for_post.cpp
+  LIBS SPIRV-Tools-opt
 )

--- a/test/opt/function_utils.h
+++ b/test/opt/function_utils.h
@@ -20,7 +20,8 @@
 
 namespace spvtest {
 
-spvtools::ir::Function* GetFunction(spvtools::ir::Module* module, uint32_t id) {
+inline spvtools::ir::Function* GetFunction(spvtools::ir::Module* module,
+                                           uint32_t id) {
   for (spvtools::ir::Function& f : *module) {
     if (f.result_id() == id) {
       return &f;
@@ -29,8 +30,8 @@ spvtools::ir::Function* GetFunction(spvtools::ir::Module* module, uint32_t id) {
   return nullptr;
 }
 
-const spvtools::ir::Function* GetFunction(const spvtools::ir::Module* module,
-                                          uint32_t id) {
+inline const spvtools::ir::Function* GetFunction(
+    const spvtools::ir::Module* module, uint32_t id) {
   for (const spvtools::ir::Function& f : *module) {
     if (f.result_id() == id) {
       return &f;
@@ -39,8 +40,8 @@ const spvtools::ir::Function* GetFunction(const spvtools::ir::Module* module,
   return nullptr;
 }
 
-const spvtools::ir::BasicBlock* GetBasicBlock(const spvtools::ir::Function* fn,
-                                              uint32_t id) {
+inline const spvtools::ir::BasicBlock* GetBasicBlock(
+    const spvtools::ir::Function* fn, uint32_t id) {
   for (const spvtools::ir::BasicBlock& bb : *fn) {
     if (bb.id() == id) {
       return &bb;

--- a/test/opt/loop_optimizations/CMakeLists.txt
+++ b/test/opt/loop_optimizations/CMakeLists.txt
@@ -13,128 +13,28 @@
 # limitations under the License.
 
 
-add_spvtools_unittest(TARGET loop_descriptor_simple
-    SRCS ../function_utils.h
-        loop_descriptions.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET loop_descriptor_nested
-    SRCS ../function_utils.h
-        nested_loops.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET lcssa_test
-    SRCS ../function_utils.h
-        lcssa.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET licm_all_loop_types
-    SRCS ../function_utils.h
-        hoist_all_loop_types.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET licm_hoist_independent_loops
-    SRCS ../function_utils.h
-        hoist_from_independent_loops.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET licm_hoist_double_nested_loops
-    SRCS ../function_utils.h
-        hoist_double_nested_loops.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET licm_hoist_single_nested_loops
-    SRCS ../function_utils.h
-        hoist_single_nested_loops.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET licm_hoist_simple_case
-    SRCS ../function_utils.h
-        hoist_simple_case.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET licm_hoist_no_preheader
-    SRCS ../function_utils.h
-        hoist_without_preheader.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET loop_unroll_simple
-    SRCS ../function_utils.h
-        unroll_simple.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET loop_unroll_assumtion_checks
-    SRCS ../function_utils.h
-        unroll_assumptions.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET unswitch_test
-    SRCS ../function_utils.h
-        unswitch.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET peeling_test
-    SRCS ../function_utils.h
-        peeling.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET peeling_pass_test
-    SRCS ../function_utils.h
-        peeling_pass.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET loop_dependence_analysis
-    SRCS ../function_utils.h
-        dependence_analysis.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET loop_dependence_analysis_helpers
-    SRCS ../function_utils.h
-        dependence_analysis_helpers.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET loop_fission
+add_spvtools_unittest(TARGET opt_loops
   SRCS ../function_utils.h
-      loop_fission.cpp
+       dependence_analysis.cpp
+       dependence_analysis_helpers.cpp
+       fusion_compatibility.cpp
+       fusion_illegal.cpp
+       fusion_legal.cpp
+       fusion_pass.cpp
+       hoist_all_loop_types.cpp
+       hoist_double_nested_loops.cpp
+       hoist_from_independent_loops.cpp
+       hoist_simple_case.cpp
+       hoist_single_nested_loops.cpp
+       hoist_without_preheader.cpp
+       lcssa.cpp
+       loop_descriptions.cpp
+       loop_fission.cpp
+       nested_loops.cpp
+       peeling.cpp
+       peeling_pass.cpp
+       unroll_assumptions.cpp
+       unroll_simple.cpp
+       unswitch.cpp
   LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET fusion_compatibility
-    SRCS ../function_utils.h
-        fusion_compatibility.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET fusion_illegal
-    SRCS ../function_utils.h
-        fusion_illegal.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET fusion_legal
-    SRCS ../function_utils.h
-        fusion_legal.cpp
-    LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET fusion_pass
-    SRCS ../function_utils.h
-        fusion_pass.cpp
-    LIBS SPIRV-Tools-opt
 )

--- a/test/opt/loop_optimizations/peeling_pass.cpp
+++ b/test/opt/loop_optimizations/peeling_pass.cpp
@@ -23,7 +23,7 @@ namespace {
 
 using namespace spvtools;
 
-class PeelingTest : public PassTest<::testing::Test> {
+class PeelingPassTest : public PassTest<::testing::Test> {
  public:
   // Generic routine to run the loop peeling pass and check
   opt::LoopPeelingPass::LoopPeelingStats AssembleAndRunPeelingTest(
@@ -127,7 +127,7 @@ void main() {
 The condition is interchanged to test < > <= >= == and peel before/after
 opportunities.
 */
-TEST_F(PeelingTest, PeelingPassBasic) {
+TEST_F(PeelingPassTest, PeelingPassBasic) {
   const std::string text_head = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
@@ -597,7 +597,7 @@ void main() {
 The condition is interchanged to test < > <= >= == and peel before/after
 opportunities.
 */
-TEST_F(PeelingTest, MultiplePeelingPass) {
+TEST_F(PeelingPassTest, MultiplePeelingPass) {
   const std::string text_head = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
@@ -867,7 +867,7 @@ void main() {
   }
 }
 */
-TEST_F(PeelingTest, PeelingNestedPass) {
+TEST_F(PeelingPassTest, PeelingNestedPass) {
   const std::string text_head = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
@@ -1023,7 +1023,7 @@ void main() {
   }
 }
 */
-TEST_F(PeelingTest, PeelingNoChanges) {
+TEST_F(PeelingPassTest, PeelingNoChanges) {
   const std::string text = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"

--- a/test/val/CMakeLists.txt
+++ b/test/val/CMakeLists.txt
@@ -18,177 +18,54 @@ set(VAL_TEST_COMMON_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/val_fixtures.h
 )
 
-
-add_spvtools_unittest(TARGET val_capability
-  SRCS val_capability_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_cfg
-  SRCS val_cfg_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_id
-  SRCS val_id_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_layout
-  SRCS val_layout_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_ssa
-  SRCS val_ssa_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_storage
-  SRCS val_storage_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_state
-  SRCS val_state_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_data
-	SRCS val_data_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_type_unique
-	SRCS val_type_unique_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_arithmetics
-	SRCS val_arithmetics_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_composites
-	SRCS val_composites_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_conversion
-	SRCS val_conversion_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_derivatives
-	SRCS val_derivatives_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_logicals
-	SRCS val_logicals_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_bitwise
-	SRCS val_bitwise_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_builtins
-	SRCS val_builtins_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_image
-	SRCS val_image_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_atomics
-	SRCS val_atomics_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_barriers
-	SRCS val_barriers_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_primitives
-        SRCS val_primitives_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_ext_inst
-	SRCS val_ext_inst_test.cpp
+add_spvtools_unittest(TARGET val_abcde
+  SRCS
+       val_adjacency_test.cpp
+       val_arithmetics_test.cpp
+       val_atomics_test.cpp
+       val_barriers_test.cpp
+       val_bitwise_test.cpp
+       val_builtins_test.cpp
+       val_capability_test.cpp
+       val_cfg_test.cpp
+       val_composites_test.cpp
+       val_conversion_test.cpp
+       val_data_test.cpp
+       val_decoration_test.cpp
+       val_derivatives_test.cpp
+       val_extensions_test.cpp
+       val_ext_inst_test.cpp
        ${VAL_TEST_COMMON_SRCS}
   LIBS ${SPIRV_TOOLS}
 )
 
 add_spvtools_unittest(TARGET val_limits
-	SRCS val_limits_test.cpp
+  SRCS val_limits_test.cpp
        ${VAL_TEST_COMMON_SRCS}
   LIBS ${SPIRV_TOOLS}
 )
 
-add_spvtools_unittest(TARGET val_validation_state
-	SRCS val_validation_state_test.cpp
+add_spvtools_unittest(TARGET val_ijklmnop
+  SRCS
+       val_id_test.cpp
+       val_image_test.cpp
+       val_layout_test.cpp
+       val_literals_test.cpp
+       val_logicals_test.cpp
+       val_non_uniform_test.cpp
+       val_primitives_test.cpp
        ${VAL_TEST_COMMON_SRCS}
   LIBS ${SPIRV_TOOLS}
 )
 
-add_spvtools_unittest(TARGET val_decoration
-	SRCS val_decoration_test.cpp
+add_spvtools_unittest(TARGET val_stuv
+  SRCS
+       val_ssa_test.cpp
+       val_state_test.cpp
+       val_storage_test.cpp
+       val_type_unique_test.cpp
+       val_validation_state_test.cpp
+       val_version_test.cpp
        ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_literals
-	SRCS val_literals_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_extensions
-	SRCS val_extensions_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_adjacency
-        SRCS val_adjacency_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_version
-        SRCS val_version_test.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET val_non_uniform
-        SRCS val_non_uniform_test.cpp
-        ${VAL_TEST_COMMON_SRCS}
   LIBS ${SPIRV_TOOLS}
 )


### PR DESCRIPTION
Try to reduce the amount of disk space used by especially by debug builds,
which may be contributing to AppVeyor failures.

Collapses tests in categories:
- validator
- loop optimizations
- dominator analysis
- linker

Contributes to #1615