### PR TITLE
Validate Ids before DataRules.

### DIFF
--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -174,8 +174,8 @@ spv_result_t ProcessInstruction(void* user_data,
 
   DebugInstructionPass(_, inst);
   if (auto error = CapabilityPass(_, inst)) return error;
-  // ID's must be validated before we do the DataRules validation as the
-  // DataRule validators expect to be able to call FindDefs.
+  // The IdPass check registers instructions and, therefore, must be called
+  // before any instruction lookups are performed.
   if (auto error = IdPass(_, inst)) return error;
   if (auto error = DataRulesPass(_, inst)) return error;
   if (auto error = ModuleLayoutPass(_, inst)) return error;

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -174,8 +174,10 @@ spv_result_t ProcessInstruction(void* user_data,
 
   DebugInstructionPass(_, inst);
   if (auto error = CapabilityPass(_, inst)) return error;
-  if (auto error = DataRulesPass(_, inst)) return error;
+  // ID's must be validated before we do the DataRules validation as the
+  // DataRule validators expect to be able to call FindDefs.
   if (auto error = IdPass(_, inst)) return error;
+  if (auto error = DataRulesPass(_, inst)) return error;
   if (auto error = ModuleLayoutPass(_, inst)) return error;
   if (auto error = CfgPass(_, inst)) return error;
   if (auto error = InstructionPass(_, inst)) return error;

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -343,6 +343,17 @@ TEST_F(ValidateData, matrix_data_type_float) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
+TEST_F(ValidateData, ids_should_be_validated_before_data) {
+  string str = header + R"(
+%f32    =  OpTypeFloat 32
+%mat33  =  OpTypeMatrix %vec3 3
+)";
+  CompileSuccessfully(str.c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("ID 3 has not been defined"));
+}
+
 TEST_F(ValidateData, matrix_bad_column_type) {
   string str = header + R"(
 %f32    =  OpTypeFloat 32

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -350,8 +350,7 @@ TEST_F(ValidateData, ids_should_be_validated_before_data) {
 )";
   CompileSuccessfully(str.c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("ID 3 has not been defined"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 3 has not been defined"));
 }
 
 TEST_F(ValidateData, matrix_bad_column_type) {


### PR DESCRIPTION
The DataRule validators call FindDefs with the assumption that they
definitions being looked at can be found. This may not be true if we
have not validated identifiers first.

This CL flips the IdPass and DataRulesPass to fix this issue.