### PR TITLE
 Validate within function body when doing a FunctionCall.

### DIFF
--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -154,6 +154,7 @@ spv_result_t ProcessExtensions(void* user_data,
 spv_result_t ProcessInstruction(void* user_data,
                                 const spv_parsed_instruction_t* inst) {
   ValidationState_t& _ = *(reinterpret_cast<ValidationState_t*>(user_data));
+
   _.increment_instruction_count();
   if (static_cast<SpvOp>(inst->opcode) == SpvOpEntryPoint) {
     const auto entry_point = inst->words[2];
@@ -169,6 +170,11 @@ spv_result_t ProcessInstruction(void* user_data,
     _.RegisterEntryPoint(entry_point, execution_model, std::move(desc));
   }
   if (static_cast<SpvOp>(inst->opcode) == SpvOpFunctionCall) {
+    if (!_.in_function_body()) {
+      return _.diag(SPV_ERROR_INVALID_LAYOUT)
+           << "A FunctionCall must happen within a function body.";
+    }
+
     _.AddFunctionCallTarget(inst->words[3]);
   }
 

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -154,7 +154,6 @@ spv_result_t ProcessExtensions(void* user_data,
 spv_result_t ProcessInstruction(void* user_data,
                                 const spv_parsed_instruction_t* inst) {
   ValidationState_t& _ = *(reinterpret_cast<ValidationState_t*>(user_data));
-
   _.increment_instruction_count();
   if (static_cast<SpvOp>(inst->opcode) == SpvOpEntryPoint) {
     const auto entry_point = inst->words[2];

--- a/test/val/val_layout_test.cpp
+++ b/test/val/val_layout_test.cpp
@@ -501,6 +501,21 @@ TEST_F(ValidateEntryPoint, FunctionIsTargetOfEntryPointAndFunctionCallBad) {
                 "instruction and an OpFunctionCall instruction."));
 }
 
+// Invalid. Must be within a function to make a function call.
+TEST_F(ValidateEntryPoint, FunctionCallOutsideFunctionBody) {
+  std::string spirv = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpName %variableName "variableName"
+         %34 = OpFunctionCall %variableName %1
+      )";
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("FunctionCall must happen within a function body."));
+}
+
 // Valid. Module with a function but no entry point is valid when Linkage
 // Capability is used.
 TEST_F(ValidateEntryPoint, NoEntryPointWithLinkageCapGood) {


### PR DESCRIPTION
When validating a FunctionCall we can trigger an assert if we are not
currently within a function body. This CL adds verification that we are
within a function before attempting to add a function call.