### PR TITLE
Validator test: artificially lower limit on local var limit

### DIFF
--- a/test/val/val_limits_test.cpp
+++ b/test/val/val_limits_test.cpp
@@ -406,8 +406,11 @@ TEST_F(ValidateLimits, CustomizedNumGlobalVarsBad) {
 }
 
 // Valid: module has 524,287 local variables.
-TEST_F(ValidateLimits, NumLocalVarsGood) {
-  int num_locals = 524287;
+// Note: AppVeyor limits process time to 300s.  For a VisualStudio Debug
+// build, going up to 524287 local variables gets too close to that
+// limit.  So test with an artificially lowered limit.
+TEST_F(ValidateLimits, NumLocalVarsGoodArtificiallyLowLimit5K) {
+  int num_locals = 5000;
   std::ostringstream spirv;
   spirv << header << R"(
  %int      = OpTypeInt 32 0
@@ -428,12 +431,16 @@ TEST_F(ValidateLimits, NumLocalVarsGood) {
   )";
 
   CompileSuccessfully(spirv.str());
+  // Artificially limit it.
+  spvValidatorOptionsSetUniversalLimit(
+      options_, spv_validator_limit_max_local_variables, num_locals);
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
 // Invalid: module has 524,288 local variables (limit is 524,287).
-TEST_F(ValidateLimits, NumLocalVarsBad) {
-  int num_locals = 524288;
+// Artificially limit the check to 5001.
+TEST_F(ValidateLimits, NumLocalVarsBadArtificiallyLowLimit5K) {
+  int num_locals = 5001;
   std::ostringstream spirv;
   spirv << header << R"(
  %int      = OpTypeInt 32 0
@@ -454,10 +461,12 @@ TEST_F(ValidateLimits, NumLocalVarsBad) {
   )";
 
   CompileSuccessfully(spirv.str());
+  spvValidatorOptionsSetUniversalLimit(
+      options_, spv_validator_limit_max_local_variables, 5000u);
   EXPECT_EQ(SPV_ERROR_INVALID_BINARY, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Number of local variables ('Function' Storage Class) "
-                        "exceeded the valid limit (524287)."));
+                        "exceeded the valid limit (5000)."));
 }
 
 // Valid: module has 100 local variables (limit is 100).


### PR DESCRIPTION
We need this to reduce the test time on Visual Studio debug builds.
AppVeyor times out at 300s for a process.

Artificially lower the local variable limit check for testing purposes.
We don't get much value from using the full 500K+ variables.
Use a limit of 5000 instead.

Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/1632