### PR TITLE
check_symbol_exports on Python3, Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,8 +168,7 @@ endif()
 
 find_host_package(PythonInterp)
 
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux" OR "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin"
-                          OR "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows)
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux" OR "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
   macro(spvtools_check_symbol_exports TARGET)
     add_test(NAME spirv-tools-symbol-exports-${TARGET}
              COMMAND ${PYTHON_EXECUTABLE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,8 @@ endif()
 
 find_host_package(PythonInterp)
 
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux" OR "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin"
+                          OR "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows)
   macro(spvtools_check_symbol_exports TARGET)
     add_test(NAME spirv-tools-symbol-exports-${TARGET}
              COMMAND ${PYTHON_EXECUTABLE}

--- a/utils/check_symbol_exports.py
+++ b/utils/check_symbol_exports.py
@@ -35,7 +35,8 @@ def command_output(cmd, directory):
     p = subprocess.Popen(cmd,
                          cwd=directory,
                          stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE)
+                         stderr=subprocess.PIPE,
+                         universal_newlines=True)
     (stdout, _) = p.communicate()
     if p.returncode != 0:
         raise RuntimeError('Failed to run %s in %s' % (cmd, directory))


### PR DESCRIPTION
subprocess.Popen returns byte data by default. Python2 was happy
to try to execute string operations on such data and hope for the
best, but python3 is more persnickety. Luckily, there's a simple
way to indicate to the Popen class that text data is wanted that
benefits the script. Just specifying universal_newlines will cause
the returned data to be text and also convert any system-specific
newlines to '\n' which the script relies on anyway.

Enabled on Mac as an incidental change after confirming that the
script works there just as well as it does on Linux.

It probably works on FreeBSD too, but I retired my BSD system years
ago. So I have no way to check.

Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/1645