### PR TITLE
fix assert during compact IDs pass

### DIFF
--- a/source/opt/compact_ids_pass.h
+++ b/source/opt/compact_ids_pass.h
@@ -31,10 +31,8 @@ class CompactIdsPass : public Pass {
   // Return the mask of preserved Analyses.
   ir::IRContext::Analysis GetPreservedAnalyses() override {
     return ir::IRContext::kAnalysisInstrToBlockMapping |
-           ir::IRContext::kAnalysisCombinators |
            ir::IRContext::kAnalysisDominatorAnalysis |
-           ir::IRContext::kAnalysisLoopAnalysis |
-           ir::IRContext::kAnalysisNameMap;
+           ir::IRContext::kAnalysisLoopAnalysis;
   }
 };
 

--- a/source/opt/compact_ids_pass.h
+++ b/source/opt/compact_ids_pass.h
@@ -31,7 +31,7 @@ class CompactIdsPass : public Pass {
   // Return the mask of preserved Analyses.
   ir::IRContext::Analysis GetPreservedAnalyses() override {
     return ir::IRContext::kAnalysisInstrToBlockMapping |
-           ir::IRContext::kAnalysisCombinators | ir::IRContext::kAnalysisCFG |
+           ir::IRContext::kAnalysisCombinators |
            ir::IRContext::kAnalysisDominatorAnalysis |
            ir::IRContext::kAnalysisLoopAnalysis |
            ir::IRContext::kAnalysisNameMap;

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -601,6 +601,9 @@ opt::PostDominatorAnalysis* IRContext::GetPostDominatorAnalysis(
 
 bool ir::IRContext::CheckCFG() {
   std::unordered_map<uint32_t, std::vector<uint32_t>> real_preds;
+  if (!AreAnalysesValid(kAnalysisCFG)) {
+    return true;
+  }
 
   for (ir::Function& function : *module()) {
     for (const auto& bb : function) {

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -601,9 +601,6 @@ opt::PostDominatorAnalysis* IRContext::GetPostDominatorAnalysis(
 
 bool ir::IRContext::CheckCFG() {
   std::unordered_map<uint32_t, std::vector<uint32_t>> real_preds;
-  if (!AreAnalysesValid(kAnalysisCFG)) {
-    return true;
-  }
 
   for (ir::Function& function : *module()) {
     for (const auto& bb : function) {


### PR DESCRIPTION
During the compact IDs optimization pass, the result IDs of some
basic blocks can change. In spite of this, GetPreservedAnalyses
indicated that the CFG was preserved. But the CFG relies on
the basic blocks having the same IDs. Simply removing this flag
resolves the issue by preventing the CFG check.

However, the CFG retrieval would update the CFG if this bit
is set. So it's not necessary to skip the CFG test even when it
has been changed. So I've removed that early exit too

Addresses https://github.com/KhronosGroup/SPIRV-Tools/issues/1648