### PR TITLE
Revert change and stop running remove duplicates

### DIFF
--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -137,8 +137,7 @@ Optimizer& Optimizer::RegisterLegalizationPasses() {
 }
 
 Optimizer& Optimizer::RegisterPerformancePasses() {
-  return RegisterPass(CreateRemoveDuplicatesPass())
-      .RegisterPass(CreateMergeReturnPass())
+  return RegisterPass(CreateMergeReturnPass())
       .RegisterPass(CreateInlineExhaustivePass())
       .RegisterPass(CreateAggressiveDCEPass())
       .RegisterPass(CreateLocalSingleBlockLoadStoreElimPass())
@@ -173,8 +172,7 @@ Optimizer& Optimizer::RegisterPerformancePasses() {
 }
 
 Optimizer& Optimizer::RegisterSizePasses() {
-  return RegisterPass(CreateRemoveDuplicatesPass())
-      .RegisterPass(CreateMergeReturnPass())
+  return RegisterPass(CreateMergeReturnPass())
       .RegisterPass(CreateInlineExhaustivePass())
       .RegisterPass(CreateAggressiveDCEPass())
       .RegisterPass(CreateScalarReplacementPass())

--- a/source/opt/remove_duplicates_pass.h
+++ b/source/opt/remove_duplicates_pass.h
@@ -59,11 +59,6 @@ class RemoveDuplicatesPass : public Pass {
   //
   // Returns true if the module was modified, false otherwise.
   bool RemoveDuplicateDecorations(ir::IRContext* ir_context) const;
-
-  // Adds |type_id| to |set_of_ids| if |type_id| is the id of a a structure.
-  // Adds any structures that are subtypes of |type_id| to |set_of_ids|.
-  void AddStructuresToSet(uint32_t type_id, ir::IRContext* ctx,
-                          std::unordered_set<uint32_t>* set_of_ids) const;
 };
 
 }  // namespace opt


### PR DESCRIPTION
Fixes #1655.

The change for commit 455186d5ab037c0a659cb50301c9f57ef1313cc6, was not correct, and must expanded to handle more cases or reverted.  The value in running remove duplicates was compile time and code size.  Turning it off does not effect compile time.  So I chose to revert my change and turn off remove duplicates in the -O and -Os paths.  The extra complication of the code is not worth the gains we are not seeing.