### PR TITLE
Produce better error diagnostics in the CFG validation.

### DIFF
--- a/source/diagnostic.cpp
+++ b/source/diagnostic.cpp
@@ -59,8 +59,10 @@ spv_result_t spvDiagnosticPrint(const spv_diagnostic diagnostic) {
     return SPV_SUCCESS;
   } else {
     // NOTE: Assume this is a binary position
-    std::cerr << "error: " << diagnostic->position.index << ": "
-              << diagnostic->error << "\n";
+    std::cerr << "error: ";
+    if (diagnostic->position.index > 0)
+      std::cerr << diagnostic->position.index << ": ";
+    std::cerr << diagnostic->error << "\n";
     return SPV_SUCCESS;
   }
 }

--- a/source/val/basic_block.cpp
+++ b/source/val/basic_block.cpp
@@ -30,7 +30,7 @@ BasicBlock::BasicBlock(uint32_t label_id)
       successors_(),
       type_(0),
       reachable_(false),
-      initiator_(nullptr),
+      label_(nullptr),
       terminator_(nullptr) {}
 
 void BasicBlock::SetImmediateDominator(BasicBlock* dom_block) {

--- a/source/val/basic_block.cpp
+++ b/source/val/basic_block.cpp
@@ -29,7 +29,9 @@ BasicBlock::BasicBlock(uint32_t label_id)
       predecessors_(),
       successors_(),
       type_(0),
-      reachable_(false) {}
+      reachable_(false),
+      initiator_(nullptr),
+      terminator_(nullptr) {}
 
 void BasicBlock::SetImmediateDominator(BasicBlock* dom_block) {
   immediate_dominator_ = dom_block;

--- a/source/val/basic_block.h
+++ b/source/val/basic_block.h
@@ -109,11 +109,11 @@ class BasicBlock {
   /// Ends the block without a successor
   void RegisterBranchInstruction(SpvOp branch_instruction);
 
-  /// Returns the initiator instruction for the block.
-  const Instruction* initiator() const { return initiator_; }
+  /// Returns the label instruction for the block, or nullptr if not set.
+  const Instruction* label() const { return label_; }
 
-  //// Registers the initiator instruction for the block.
-  void set_initiator(const Instruction* t) { initiator_ = t; }
+  //// Registers the label instruction for the block.
+  void set_label(const Instruction* t) { label_ = t; }
 
   /// Registers the terminator instruction for the block.
   void set_terminator(const Instruction* t) { terminator_ = t; }
@@ -224,8 +224,8 @@ class BasicBlock {
   /// True if the block is reachable in the CFG
   bool reachable_;
 
-  /// Initiator of this block.
-  const Instruction* initiator_;
+  /// label of this block, if any.
+  const Instruction* label_;
 
   /// Terminator of this block.
   const Instruction* terminator_;

--- a/source/val/basic_block.h
+++ b/source/val/basic_block.h
@@ -109,6 +109,12 @@ class BasicBlock {
   /// Ends the block without a successor
   void RegisterBranchInstruction(SpvOp branch_instruction);
 
+  /// Returns the initiator instruction for the block.
+  const Instruction* initiator() const { return initiator_; }
+
+  //// Registers the initiator instruction for the block.
+  void set_initiator(const Instruction* t) { initiator_ = t; }
+
   /// Registers the terminator instruction for the block.
   void set_terminator(const Instruction* t) { terminator_ = t; }
 
@@ -217,6 +223,9 @@ class BasicBlock {
 
   /// True if the block is reachable in the CFG
   bool reachable_;
+
+  /// Initiator of this block.
+  const Instruction* initiator_;
 
   /// Terminator of this block.
   const Instruction* terminator_;

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -276,9 +276,9 @@ DiagnosticStream ValidationState_t::diag(spv_result_t error_code,
                                       ordered_instructions_.size()) {
     disassembly = Disassemble(ordered_instructions_[instruction_counter - 1]);
   }
-  return libspirv::DiagnosticStream(
-      {0, 0, static_cast<size_t>(instruction_counter)}, context_->consumer,
-      disassembly, error_code);
+  size_t pos = instruction_counter >= 0 ? instruction_counter : 0;
+  return libspirv::DiagnosticStream({0, 0, pos}, context_->consumer,
+                                    disassembly, error_code);
 }
 
 deque<Function>& ValidationState_t::functions() { return module_functions_; }

--- a/source/validate.cpp
+++ b/source/validate.cpp
@@ -39,6 +39,7 @@
 #include "spirv_validator_options.h"
 #include "val/construct.h"
 #include "val/function.h"
+#include "val/instruction.h"
 #include "val/validation_state.h"
 
 using std::function;
@@ -53,6 +54,7 @@ using libspirv::CfgPass;
 using libspirv::DataRulesPass;
 using libspirv::Extension;
 using libspirv::IdPass;
+using libspirv::Instruction;
 using libspirv::InstructionPass;
 using libspirv::LiteralsPass;
 using libspirv::ModuleLayoutPass;
@@ -177,9 +179,12 @@ spv_result_t ProcessInstruction(void* user_data,
   // The IdPass check registers instructions and, therefore, must be called
   // before any instruction lookups are performed.
   if (auto error = IdPass(_, inst)) return error;
+
+  const Instruction* instruction = &(_.ordered_instructions().back());
+
   if (auto error = DataRulesPass(_, inst)) return error;
   if (auto error = ModuleLayoutPass(_, inst)) return error;
-  if (auto error = CfgPass(_, inst)) return error;
+  if (auto error = CfgPass(_, instruction)) return error;
   if (auto error = InstructionPass(_, inst)) return error;
   if (auto error = TypeUniquePass(_, inst)) return error;
   if (auto error = ArithmeticsPass(_, inst)) return error;

--- a/source/validate.h
+++ b/source/validate.h
@@ -28,6 +28,7 @@ namespace libspirv {
 
 class ValidationState_t;
 class BasicBlock;
+class Instruction;
 
 /// A function that returns a vector of BasicBlocks given a BasicBlock. Used to
 /// get the successor and predecessor nodes of a CFG block
@@ -108,8 +109,7 @@ spv_result_t ModuleLayoutPass(ValidationState_t& _,
                               const spv_parsed_instruction_t* inst);
 
 /// Performs Control Flow Graph validation of a module
-spv_result_t CfgPass(ValidationState_t& _,
-                     const spv_parsed_instruction_t* inst);
+spv_result_t CfgPass(ValidationState_t& _, const Instruction* inst);
 
 /// Performs Id and SSA validation of a module
 spv_result_t IdPass(ValidationState_t& _, const spv_parsed_instruction_t* inst);

--- a/source/validate_cfg.cpp
+++ b/source/validate_cfg.cpp
@@ -202,8 +202,13 @@ spv_result_t FindCaseFallThrough(
       if (*case_fall_through == 0u) {
         *case_fall_through = block->id();
       } else if (*case_fall_through != block->id()) {
+        uint32_t instruction_id =
+            target_block->initiator()
+                ? target_block->initiator()->InstructionPosition()
+                : -1;
+
         // Case construct has at most one branch to another case construct.
-        return _.diag(SPV_ERROR_INVALID_CFG)
+        return _.diag(SPV_ERROR_INVALID_CFG, instruction_id)
                << "Case construct that targets "
                << _.getIdName(target_block->id())
                << " has branches to multiple other case construct targets "
@@ -290,13 +295,12 @@ spv_result_t StructuredSwitchChecks(const ValidationState_t& _,
         // must immediately precede T2 in the list of OpSwitch Target operands.
         if ((switch_inst->operands().size() < j + 2) ||
             (case_fall_through != switch_inst->GetOperandAs<uint32_t>(j + 2))) {
-          return _.diag(SPV_ERROR_INVALID_CFG)
+          return _.diag(SPV_ERROR_INVALID_CFG, -1)
                  << "Case construct that targets " << _.getIdName(target)
                  << " has branches to the case construct that targets "
                  << _.getIdName(case_fall_through)
                  << ", but does not immediately precede it in the "
-                    "OpSwitch's "
-                    "target list";
+                    "OpSwitch's target list";
         }
       }
     }
@@ -306,7 +310,8 @@ spv_result_t StructuredSwitchChecks(const ValidationState_t& _,
   // construct.
   for (const auto& pair : num_fall_through_targeted) {
     if (pair.second > 1) {
-      return _.diag(SPV_ERROR_INVALID_CFG)
+      return _.diag(SPV_ERROR_INVALID_CFG,
+                    _.FindDef(pair.first)->InstructionPosition())
              << "Multiple case constructs have branches to the case construct "
                 "that targets "
              << _.getIdName(pair.first);
@@ -410,7 +415,8 @@ spv_result_t StructuredControlFlowChecks(
           string construct_name, header_name, exit_name;
           tie(construct_name, header_name, exit_name) =
               ConstructNames(construct.type());
-          return _.diag(SPV_ERROR_INVALID_CFG)
+          return _.diag(SPV_ERROR_INVALID_CFG,
+                        _.FindDef(pred->id())->InstructionPosition())
                  << "block <ID> " << pred->id() << " branches to the "
                  << construct_name << " construct, but not to the "
                  << header_name << " <ID> " << header->id();
@@ -537,17 +543,18 @@ spv_result_t PerformCfgChecks(ValidationState_t& _) {
   return SPV_SUCCESS;
 }
 
-spv_result_t CfgPass(ValidationState_t& _,
-                     const spv_parsed_instruction_t* inst) {
-  SpvOp opcode = static_cast<SpvOp>(inst->opcode);
+spv_result_t CfgPass(ValidationState_t& _, const Instruction* inst) {
+  SpvOp opcode = static_cast<SpvOp>(inst->opcode());
   switch (opcode) {
     case SpvOpLabel:
-      if (auto error = _.current_function().RegisterBlock(inst->result_id))
+      if (auto error = _.current_function().RegisterBlock(inst->id()))
         return error;
+
+      _.current_function().current_block()->set_initiator(inst);
       break;
     case SpvOpLoopMerge: {
-      uint32_t merge_block = inst->words[inst->operands[0].offset];
-      uint32_t continue_block = inst->words[inst->operands[1].offset];
+      uint32_t merge_block = inst->GetOperandAs<uint32_t>(0);
+      uint32_t continue_block = inst->GetOperandAs<uint32_t>(1);
       CFG_ASSERT(MergeBlockAssert, merge_block);
 
       if (auto error = _.current_function().RegisterLoopMerge(merge_block,
@@ -555,21 +562,21 @@ spv_result_t CfgPass(ValidationState_t& _,
         return error;
     } break;
     case SpvOpSelectionMerge: {
-      uint32_t merge_block = inst->words[inst->operands[0].offset];
+      uint32_t merge_block = inst->GetOperandAs<uint32_t>(0);
       CFG_ASSERT(MergeBlockAssert, merge_block);
 
       if (auto error = _.current_function().RegisterSelectionMerge(merge_block))
         return error;
     } break;
     case SpvOpBranch: {
-      uint32_t target = inst->words[inst->operands[0].offset];
+      uint32_t target = inst->GetOperandAs<uint32_t>(0);
       CFG_ASSERT(FirstBlockAssert, target);
 
       _.current_function().RegisterBlockEnd({target}, opcode);
     } break;
     case SpvOpBranchConditional: {
-      uint32_t tlabel = inst->words[inst->operands[1].offset];
-      uint32_t flabel = inst->words[inst->operands[2].offset];
+      uint32_t tlabel = inst->GetOperandAs<uint32_t>(1);
+      uint32_t flabel = inst->GetOperandAs<uint32_t>(2);
       CFG_ASSERT(FirstBlockAssert, tlabel);
       CFG_ASSERT(FirstBlockAssert, flabel);
 
@@ -578,8 +585,8 @@ spv_result_t CfgPass(ValidationState_t& _,
 
     case SpvOpSwitch: {
       vector<uint32_t> cases;
-      for (int i = 1; i < inst->num_operands; i += 2) {
-        uint32_t target = inst->words[inst->operands[i].offset];
+      for (size_t i = 1; i < inst->operands().size(); i += 2) {
+        uint32_t target = inst->GetOperandAs<uint32_t>(i);
         CFG_ASSERT(FirstBlockAssert, target);
         cases.push_back(target);
       }
@@ -590,8 +597,7 @@ spv_result_t CfgPass(ValidationState_t& _,
       const Instruction* return_type_inst = _.FindDef(return_type);
       assert(return_type_inst);
       if (return_type_inst->opcode() != SpvOpTypeVoid)
-        return _.diag(SPV_ERROR_INVALID_CFG,
-                      return_type_inst->InstructionPosition())
+        return _.diag(SPV_ERROR_INVALID_CFG, inst->InstructionPosition())
                << "OpReturn can only be called from a function with void "
                << "return type.";
     }
@@ -611,4 +617,5 @@ spv_result_t CfgPass(ValidationState_t& _,
   }
   return SPV_SUCCESS;
 }
+
 }  // namespace libspirv

--- a/test/val/val_cfg_test.cpp
+++ b/test/val/val_cfg_test.cpp
@@ -1436,7 +1436,8 @@ TEST_F(ValidateCFG, OpReturnInNonVoidFunc) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpReturn can only be called from a function with void return type"));
+          "OpReturn can only be called from a function with void return type.\n"
+          "  OpReturn"));
 }
 
 TEST_F(ValidateCFG, StructuredCFGBranchIntoSelectionBody) {
@@ -1463,7 +1464,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("branches to the selection construct, but not to the "
-                        "selection header <ID>"));
+                        "selection header <ID> 6\n  %7 = OpLabel"));
 }
 
 TEST_F(ValidateCFG, SwitchDefaultOnly) {
@@ -1544,7 +1545,7 @@ OpFunctionEnd
       getDiagnosticString(),
       HasSubstr(
           "Case construct that targets 10 has branches to multiple other case "
-          "construct targets 12 and 11"));
+          "construct targets 12 and 11\n  %10 = OpLabel"));
 }
 
 TEST_F(ValidateCFG, MultipleFallThroughToDefault) {
@@ -1578,7 +1579,7 @@ OpFunctionEnd
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("Multiple case constructs have branches to the case construct "
-                "that targets 10"));
+                "that targets 10\n  %10 = OpLabel"));
 }
 
 TEST_F(ValidateCFG, MultipleFallThroughToNonDefault) {
@@ -1612,7 +1613,7 @@ OpFunctionEnd
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("Multiple case constructs have branches to the case construct "
-                "that targets 12"));
+                "that targets 12\n  %12 = OpLabel"));
 }
 
 TEST_F(ValidateCFG, DuplicateTargetWithFallThrough) {

--- a/test/val/val_cfg_test.cpp
+++ b/test/val/val_cfg_test.cpp
@@ -1676,7 +1676,8 @@ OpFunctionEnd
       getDiagnosticString(),
       HasSubstr("Case construct that targets 12 has branches to the case "
                 "construct that targets 11, but does not immediately "
-                "precede it in the OpSwitch's target list"));
+                "precede it in the OpSwitch's target list\n"
+                "  OpSwitch %uint_0 %10 0 %11 1 %12"));
 }
 
 TEST_F(ValidateCFG, WrongOperandListThroughDefault) {
@@ -1711,7 +1712,8 @@ OpFunctionEnd
       getDiagnosticString(),
       HasSubstr("Case construct that targets 12 has branches to the case "
                 "construct that targets 11, but does not immediately "
-                "precede it in the OpSwitch's target list"));
+                "precede it in the OpSwitch's target list\n"
+                "  OpSwitch %uint_0 %10 0 %11 1 %12"));
 }
 
 TEST_F(ValidateCFG, WrongOperandListNotLast) {
@@ -1748,7 +1750,8 @@ OpFunctionEnd
       getDiagnosticString(),
       HasSubstr("Case construct that targets 12 has branches to the case "
                 "construct that targets 11, but does not immediately "
-                "precede it in the OpSwitch's target list"));
+                "precede it in the OpSwitch's target list\n"
+                "  OpSwitch %uint_0 %10 0 %11 1 %12 2 %13"));
 }
 
 /// TODO(umar): Nested CFG constructs


### PR DESCRIPTION
This CL fixes up several issues with the diagnostic error line output
in the CFG validation code. For the cases where we can determine a
better line it has been output. For other cases, we removed the
diagnostic line and the error line number from the results.

Fixes #1657