### PR TITLE
Make sure the constant folder get the correct type.

### DIFF
--- a/source/opt/constants.cpp
+++ b/source/opt/constants.cpp
@@ -161,15 +161,19 @@ ir::Instruction* ConstantManager::BuildInstructionAndAddToModule(
 }
 
 ir::Instruction* ConstantManager::GetDefiningInstruction(
-    const Constant* c, ir::Module::inst_iterator* pos) {
+    const Constant* c, uint32_t type_id, ir::Module::inst_iterator* pos) {
+  assert(type_id == 0 ||
+         context()->get_type_mgr()->GetType(type_id) == c->type());
   uint32_t decl_id = FindDeclaredConstant(c);
   if (decl_id == 0) {
     auto iter = context()->types_values_end();
     if (pos == nullptr) pos = &iter;
-    return BuildInstructionAndAddToModule(c, pos);
+    return BuildInstructionAndAddToModule(c, pos, type_id);
   } else {
     auto def = context()->get_def_use_mgr()->GetDef(decl_id);
     assert(def != nullptr);
+    assert((type_id == 0 || def->type_id() == type_id) &&
+           "This constant already has an instruction with a different type.");
     return def;
   }
 }

--- a/source/opt/constants.h
+++ b/source/opt/constants.h
@@ -519,8 +519,17 @@ class ConstantManager {
   // optional |pos| is given, it will insert any newly created instructions at
   // the given instruction iterator position. Otherwise, it inserts the new
   // instruction at the end of the current module's types section.
+  //
+  // |type_id| is an optional argument for disambiguating equivalent types. If
+  // |type_id| is specified, it is used as the type of the constant when a new
+  // instruction is created. Otherwise the type of the constant is derived by
+  // getting an id from the type manager for |c|.
+  //
+  // When |type_id| is not zero, the type of |c| must be the type returned by
+  // type manager when given |type_id|.
   ir::Instruction* GetDefiningInstruction(
-      const Constant* c, ir::Module::inst_iterator* pos = nullptr);
+      const Constant* c, uint32_t type_id = 0,
+      ir::Module::inst_iterator* pos = nullptr);
 
   // Creates a constant defining instruction for the given Constant instance
   // and inserts the instruction at the position specified by the given
@@ -558,6 +567,9 @@ class ConstantManager {
 
   // Returns the canonical constant that has the same structure and value as the
   // given Constant |cst|. If none is found, it returns nullptr.
+  //
+  // TODO: Should be able to give a type id to disambiguate types with the same
+  // structure.
   const Constant* FindConstant(const Constant* c) const {
     auto it = const_pool_.find(c);
     return (it != const_pool_.end()) ? *it : nullptr;

--- a/source/opt/fold.cpp
+++ b/source/opt/fold.cpp
@@ -628,7 +628,8 @@ ir::Instruction* FoldInstructionToConstant(
       folded_const = rule(inst, constants);
       if (folded_const != nullptr) {
         ir::Instruction* const_inst =
-            const_mgr->GetDefiningInstruction(folded_const);
+            const_mgr->GetDefiningInstruction(folded_const, inst->type_id());
+        assert(const_inst->type_id() == inst->type_id());
         // May be a new instruction that needs to be analysed.
         context->UpdateDefUse(const_inst);
         return const_inst;
@@ -651,7 +652,9 @@ ir::Instruction* FoldInstructionToConstant(
   if (successful) {
     const analysis::Constant* result_const =
         const_mgr->GetConstant(const_mgr->GetType(inst), {result_val});
-    return const_mgr->GetDefiningInstruction(result_const);
+    ir::Instruction* folded_inst =
+        const_mgr->GetDefiningInstruction(result_const, inst->type_id());
+    return folded_inst;
   }
   return nullptr;
 }

--- a/source/opt/ir_context.h
+++ b/source/opt/ir_context.h
@@ -795,7 +795,7 @@ void IRContext::AddAnnotationInst(std::unique_ptr<Instruction>&& a) {
 void IRContext::AddType(std::unique_ptr<Instruction>&& t) {
   module()->AddType(std::move(t));
   if (AreAnalysesValid(kAnalysisDefUse)) {
-    get_def_use_mgr()->AnalyzeInstDef(&*(--types_values_end()));
+    get_def_use_mgr()->AnalyzeInstDefUse(&*(--types_values_end()));
   }
 }
 

--- a/source/opt/private_to_local_pass.cpp
+++ b/source/opt/private_to_local_pass.cpp
@@ -117,6 +117,7 @@ uint32_t PrivateToLocalPass::GetNewType(uint32_t old_type_id) {
       old_type_inst->GetSingleWordInOperand(kSpvTypePointerTypeIdInIdx);
   uint32_t new_type_id =
       type_mgr->FindPointerToType(pointee_type_id, SpvStorageClassFunction);
+  context()->UpdateDefUse(context()->get_def_use_mgr()->GetDef(new_type_id));
   return new_type_id;
 }
 

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -800,7 +800,8 @@ ir::Instruction* ScalarReplacementPass::CreateNullConstant(uint32_t type_id) {
 
   const analysis::Type* type = type_mgr->GetType(type_id);
   const analysis::Constant* null_const = const_mgr->GetConstant(type, {});
-  ir::Instruction* null_inst = const_mgr->GetDefiningInstruction(null_const);
+  ir::Instruction* null_inst =
+      const_mgr->GetDefiningInstruction(null_const, type_id);
   context()->UpdateDefUse(null_inst);
   return null_inst;
 }

--- a/source/opt/type_manager.cpp
+++ b/source/opt/type_manager.cpp
@@ -378,11 +378,11 @@ uint32_t TypeManager::GetTypeInstruction(const Type* type) {
 
 uint32_t TypeManager::FindPointerToType(uint32_t type_id,
                                         SpvStorageClass storage_class) {
-  opt::analysis::Type* pointeeTy = context()->get_type_mgr()->GetType(type_id);
+  opt::analysis::Type* pointeeTy = GetType(type_id);
   opt::analysis::Pointer pointerTy(pointeeTy, storage_class);
-  if (type_id == context()->get_type_mgr()->GetId(pointeeTy)) {
+  if (pointeeTy->IsUniqueType(true)) {
     // Non-ambiguous type. Get the pointer type through the type manager.
-    return context()->get_type_mgr()->GetTypeInstruction(&pointerTy);
+    return GetTypeInstruction(&pointerTy);
   }
 
   // Ambiguous type, do a linear search.
@@ -405,7 +405,6 @@ uint32_t TypeManager::FindPointerToType(uint32_t type_id,
       {{spv_operand_type_t::SPV_OPERAND_TYPE_STORAGE_CLASS,
         {uint32_t(storage_class)}},
        {spv_operand_type_t::SPV_OPERAND_TYPE_ID, {type_id}}}));
-  context()->AnalyzeDefUse(type_inst.get());
   context()->AddType(std::move(type_inst));
   context()->get_type_mgr()->RegisterType(resultId, pointerTy);
   return resultId;

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -326,3 +326,9 @@ add_spvtools_unittest(TARGET reduce_load_size
   SRCS reduce_load_size_test.cpp pass_utils.cpp
   LIBS SPIRV-Tools-opt
 )
+
+add_spvtools_unittest(TARGET constant_manager
+  SRCS constant_manager_test.cpp
+  LIBS SPIRV-Tools-opt
+)
+

--- a/test/opt/constant_manager_test.cpp
+++ b/test/opt/constant_manager_test.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "opt/build_module.h"
+#include "opt/constants.h"
+#include "opt/ir_context.h"
+
+using namespace spvtools;
+using namespace spvtools::opt;
+using namespace spvtools::opt::analysis;
+
+using ConstantManagerTest = ::testing::Test;
+
+TEST_F(ConstantManagerTest, GetDefiningInstruction) {
+  const std::string text = R"(
+%int = OpTypeInt 32 0
+%1 = OpTypeStruct %int
+%2 = OpTypeStruct %int
+  )";
+
+  std::unique_ptr<ir::IRContext> context =
+      BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  ASSERT_NE(context, nullptr);
+
+  Type* struct_type_1 = context->get_type_mgr()->GetType(1);
+  StructConstant struct_const_1(struct_type_1->AsStruct());
+  ir::Instruction* const_inst_1 =
+      context->get_constant_mgr()->GetDefiningInstruction(&struct_const_1, 1);
+  EXPECT_EQ(const_inst_1->type_id(), 1);
+
+  Type* struct_type_2 = context->get_type_mgr()->GetType(2);
+  StructConstant struct_const_2(struct_type_2->AsStruct());
+  ir::Instruction* const_inst_2 =
+      context->get_constant_mgr()->GetDefiningInstruction(&struct_const_2, 2);
+  EXPECT_EQ(const_inst_2->type_id(), 2);
+}

--- a/test/opt/scalar_replacement_test.cpp
+++ b/test/opt/scalar_replacement_test.cpp
@@ -1356,6 +1356,97 @@ OpFunctionEnd
 
   SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
 }
+
+TEST_F(ScalarReplacementTest, CreateAmbiguousNullConstant1) {
+  const std::string text = R"(
+;
+; CHECK: [[uint:%\w+]] = OpTypeInt 32 0
+; CHECK: [[struct1:%\w+]] = OpTypeStruct [[uint]] [[struct_member:%\w+]]
+; CHECK: [[uint_ptr:%\w+]] = OpTypePointer Function [[uint]]
+; CHECK: [[const:%\w+]] = OpConstant [[uint]] 0
+; CHECK: [[null:%\w+]] = OpConstantNull [[struct_member]]
+; CHECK: [[var0a:%\w+]] = OpVariable [[uint_ptr]] Function
+; CHECK: [[var1:%\w+]] = OpVariable [[uint_ptr]] Function
+; CHECK: [[var0b:%\w+]] = OpVariable [[uint_ptr]] Function
+; CHECK-NOT: OpVariable
+; CHECK: OpStore [[var1]]
+; CHECK: [[l1:%\w+]] = OpLoad [[uint]] [[var1]]
+; CHECK: [[c1:%\w+]] = OpCompositeConstruct [[struct1]] [[l1]] [[null]]
+; CHECK: [[e1:%\w+]] = OpCompositeExtract [[uint]] [[c1]] 0
+;
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpName %func "replace_whole_load"
+%void = OpTypeVoid
+%uint = OpTypeInt 32 0
+%struct2 = OpTypeStruct %uint
+%struct3 = OpTypeStruct %uint
+%struct1 = OpTypeStruct %uint %struct2
+%uint_ptr = OpTypePointer Function %uint
+%struct1_ptr = OpTypePointer Function %struct1
+%uint_0 = OpConstant %uint 0
+%uint_1 = OpConstant %uint 1
+%func = OpTypeFunction %void
+%1 = OpFunction %void None %func
+%2 = OpLabel
+%var1 = OpVariable %struct1_ptr Function
+%var2 = OpVariable %struct1_ptr Function
+%load1 = OpLoad %struct1 %var1
+OpStore %var2 %load1
+%load2 = OpLoad %struct1 %var2
+%3 = OpCompositeExtract %uint %load2 0
+OpReturn
+OpFunctionEnd
+  )";
+
+  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+}
+
+TEST_F(ScalarReplacementTest, CreateAmbiguousNullConstant2) {
+  const std::string text = R"(
+;
+; CHECK: [[uint:%\w+]] = OpTypeInt 32 0
+; CHECK: [[struct1:%\w+]] = OpTypeStruct [[uint]] [[struct_member:%\w+]]
+; CHECK: [[uint_ptr:%\w+]] = OpTypePointer Function [[uint]]
+; CHECK: [[const:%\w+]] = OpConstant [[uint]] 0
+; CHECK: [[null:%\w+]] = OpConstantNull [[struct_member]]
+; CHECK: [[var0a:%\w+]] = OpVariable [[uint_ptr]] Function
+; CHECK: [[var1:%\w+]] = OpVariable [[uint_ptr]] Function
+; CHECK: [[var0b:%\w+]] = OpVariable [[uint_ptr]] Function
+; CHECK: OpStore [[var1]]
+; CHECK: [[l1:%\w+]] = OpLoad [[uint]] [[var1]]
+; CHECK: [[c1:%\w+]] = OpCompositeConstruct [[struct1]] [[l1]] [[null]]
+; CHECK: [[e1:%\w+]] = OpCompositeExtract [[uint]] [[c1]] 0
+;
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpName %func "replace_whole_load"
+%void = OpTypeVoid
+%uint = OpTypeInt 32 0
+%struct3 = OpTypeStruct %uint
+%struct2 = OpTypeStruct %uint
+%struct1 = OpTypeStruct %uint %struct2
+%uint_ptr = OpTypePointer Function %uint
+%struct1_ptr = OpTypePointer Function %struct1
+%uint_0 = OpConstant %uint 0
+%uint_1 = OpConstant %uint 1
+%func = OpTypeFunction %void
+%1 = OpFunction %void None %func
+%2 = OpLabel
+%var1 = OpVariable %struct1_ptr Function
+%var2 = OpVariable %struct1_ptr Function
+%load1 = OpLoad %struct1 %var1
+OpStore %var2 %load1
+%load2 = OpLoad %struct1 %var2
+%3 = OpCompositeExtract %uint %load2 0
+OpReturn
+OpFunctionEnd
+  )";
+
+  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+}
 #endif  // SPIRV_EFFCEE
 
 // Test that a struct of size 4 is not replaced when there is a limit of 2.


### PR DESCRIPTION
There are a few locations where we need to handle duplicate types.  We
cannot merge them because they may be needed for reflection.  When this
happens we need do some extra lookups in the type manager.

The specific fixes are:

1) When generating a constant through `GetDefiningInstruction` accept
and use an id for the desired type of the constant.  This will make sure
you get the type that is needed.

2) In Private-to-local, make sure we to update the def-use chains when a
new pointer type is created.

3) In the type manager, make sure that `FindPointerToType` returns a
pointer that points to the given type and not a duplicate type.

4) In scalar replacment, make sure the null constants that are created
are the correct type.