### PR TITLE
validate_instruction: Use spv_result_t instead of bool

### DIFF
--- a/source/validate_instruction.cpp
+++ b/source/validate_instruction.cpp
@@ -286,7 +286,7 @@ spv_result_t VersionCheck(ValidationState_t& _,
                           const spv_parsed_instruction_t* inst) {
   const auto opcode = static_cast<SpvOp>(inst->opcode);
   spv_opcode_desc inst_desc;
-  const bool r = _.grammar().lookupOpcode(opcode, &inst_desc);
+  const spv_result_t r = _.grammar().lookupOpcode(opcode, &inst_desc);
   assert(r == SPV_SUCCESS);
   (void)r;
 


### PR DESCRIPTION
Using bool is confusing here, and results in an MSVC warning about an
implicit cast to bool.