### PR TITLE
Fix unused param errors when Effcee not present

### DIFF
--- a/test/opt/loop_optimizations/fusion_legal.cpp
+++ b/test/opt/loop_optimizations/fusion_legal.cpp
@@ -61,7 +61,9 @@ void Match(const std::string& checks, ir::IRContext* context) {
   EXPECT_EQ(effcee::Result::Status::Ok, match_result.status())
       << match_result.message() << "\nChecking result:\n"
       << assembly;
-#endif  // ! SPIRV_EFFCEE
+#else  // ! SPIRV_EFFCEE
+  (void)checks;
+#endif
 }
 
 /*

--- a/test/opt/loop_optimizations/peeling.cpp
+++ b/test/opt/loop_optimizations/peeling.cpp
@@ -56,7 +56,9 @@ void Match(const std::string& checks, ir::IRContext* context) {
   EXPECT_EQ(effcee::Result::Status::Ok, match_result.status())
       << match_result.message() << "\nChecking result:\n"
       << assembly;
-#endif  // ! SPIRV_EFFCEE
+#else  // ! SPIRV_EFFCEE
+  (void)checks;
+#endif
 }
 
 /*


### PR DESCRIPTION
Since `-Werror` is enabled, without Effcee the project fails to build.  This fixes that.