### PR TITLE
Move validation files to val/ directory

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -34,31 +34,31 @@ SPVTOOLS_SRC_FILES := \
 		source/val/function.cpp \
 		source/val/instruction.cpp \
 		source/val/validation_state.cpp \
-		source/validate.cpp \
-		source/validate_adjacency.cpp \
-		source/validate_arithmetics.cpp \
-		source/validate_atomics.cpp \
-		source/validate_barriers.cpp \
-		source/validate_bitwise.cpp \
-		source/validate_builtins.cpp \
-		source/validate_capability.cpp \
-		source/validate_cfg.cpp \
-		source/validate_composites.cpp \
-		source/validate_conversion.cpp \
-		source/validate_datarules.cpp \
-		source/validate_decorations.cpp \
-		source/validate_derivatives.cpp \
-		source/validate_ext_inst.cpp \
-		source/validate_id.cpp \
-		source/validate_image.cpp \
-		source/validate_interfaces.cpp \
-		source/validate_instruction.cpp \
-		source/validate_layout.cpp \
-		source/validate_literals.cpp \
-		source/validate_logicals.cpp \
-		source/validate_non_uniform.cpp \
-		source/validate_primitives.cpp \
-		source/validate_type_unique.cpp
+		source/val/validate.cpp \
+		source/val/validate_adjacency.cpp \
+		source/val/validate_arithmetics.cpp \
+		source/val/validate_atomics.cpp \
+		source/val/validate_barriers.cpp \
+		source/val/validate_bitwise.cpp \
+		source/val/validate_builtins.cpp \
+		source/val/validate_capability.cpp \
+		source/val/validate_cfg.cpp \
+		source/val/validate_composites.cpp \
+		source/val/validate_conversion.cpp \
+		source/val/validate_datarules.cpp \
+		source/val/validate_decorations.cpp \
+		source/val/validate_derivatives.cpp \
+		source/val/validate_ext_inst.cpp \
+		source/val/validate_id.cpp \
+		source/val/validate_image.cpp \
+		source/val/validate_interfaces.cpp \
+		source/val/validate_instruction.cpp \
+		source/val/validate_layout.cpp \
+		source/val/validate_literals.cpp \
+		source/val/validate_logicals.cpp \
+		source/val/validate_non_uniform.cpp \
+		source/val/validate_primitives.cpp \
+		source/val/validate_type_unique.cpp
 
 SPVTOOLS_OPT_SRC_FILES := \
 		source/opt/aggressive_dead_code_elim_pass.cpp \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ elseif(MSVC)
 endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/source)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/)
 
 option(SPIRV_COLOR_TERMINAL "Enable color terminal output" ON)
 if(${SPIRV_COLOR_TERMINAL})

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -252,7 +252,7 @@ set(SPIRV_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/table.h
   ${CMAKE_CURRENT_SOURCE_DIR}/text.h
   ${CMAKE_CURRENT_SOURCE_DIR}/text_handler.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate.h
 
   ${CMAKE_CURRENT_SOURCE_DIR}/util/bit_stream.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/util/bit_vector.cpp
@@ -281,31 +281,31 @@ set(SPIRV_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/table.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/text.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/text_handler.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_adjacency.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_arithmetics.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_atomics.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_barriers.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_bitwise.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_builtins.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_capability.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_cfg.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_composites.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_conversion.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_datarules.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_decorations.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_derivatives.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_ext_inst.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_id.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_image.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_interfaces.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_instruction.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_layout.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_literals.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_logicals.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_non_uniform.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_primitives.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/validate_type_unique.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_adjacency.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_arithmetics.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_atomics.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_barriers.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_bitwise.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_builtins.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_capability.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_cfg.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_composites.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_conversion.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_datarules.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_decorations.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_derivatives.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_ext_inst.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_id.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_image.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_interfaces.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_instruction.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_layout.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_literals.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_logicals.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_non_uniform.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_primitives.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_type_unique.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/val/decoration.h
   ${CMAKE_CURRENT_SOURCE_DIR}/val/basic_block.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/val/construct.cpp

--- a/source/comp/markv_codec.cpp
+++ b/source/comp/markv_codec.cpp
@@ -57,8 +57,8 @@
 #include "util/move_to_front.h"
 #include "util/parse_number.h"
 #include "val/instruction.h"
+#include "val/validate.h"
 #include "val/validation_state.h"
-#include "validate.h"
 
 namespace spvtools {
 namespace comp {

--- a/source/spirv_stats.cpp
+++ b/source/spirv_stats.cpp
@@ -33,8 +33,8 @@
 #include "spirv_endian.h"
 #include "spirv_validator_options.h"
 #include "val/instruction.h"
+#include "val/validate.h"
 #include "val/validation_state.h"
-#include "validate.h"
 
 namespace spvtools {
 namespace {

--- a/source/val/validate.cpp
+++ b/source/val/validate.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
 #include <cassert>
 #include <cstdio>
@@ -25,22 +25,22 @@
 #include <string>
 #include <vector>
 
-#include "binary.h"
-#include "diagnostic.h"
-#include "enum_string_mapping.h"
-#include "extensions.h"
-#include "instruction.h"
-#include "opcode.h"
-#include "operand.h"
+#include "source/binary.h"
+#include "source/diagnostic.h"
+#include "source/enum_string_mapping.h"
+#include "source/extensions.h"
+#include "source/instruction.h"
+#include "source/opcode.h"
+#include "source/operand.h"
+#include "source/spirv_constant.h"
+#include "source/spirv_endian.h"
+#include "source/spirv_target_env.h"
+#include "source/spirv_validator_options.h"
+#include "source/val/construct.h"
+#include "source/val/function.h"
+#include "source/val/instruction.h"
+#include "source/val/validation_state.h"
 #include "spirv-tools/libspirv.h"
-#include "spirv_constant.h"
-#include "spirv_endian.h"
-#include "spirv_target_env.h"
-#include "spirv_validator_options.h"
-#include "val/construct.h"
-#include "val/function.h"
-#include "val/instruction.h"
-#include "val/validation_state.h"
 
 using std::function;
 using std::ostream_iterator;

--- a/source/val/validate.h
+++ b/source/val/validate.h
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_VALIDATE_H_
-#define LIBSPIRV_VALIDATE_H_
+#ifndef SOURCE_VAL_VALIDATE_H_
+#define SOURCE_VAL_VALIDATE_H_
 
 #include <functional>
 #include <utility>
 #include <vector>
 
-#include "instruction.h"
-#include "message.h"
+#include "source/instruction.h"
+#include "source/message.h"
+#include "source/table.h"
 #include "spirv-tools/libspirv.h"
-#include "table.h"
 
 namespace spvtools {
 namespace val {
@@ -221,4 +221,4 @@ spv_result_t ValidateInstructionAndUpdateValidationState(
 }  // namespace val
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_VALIDATE_H_
+#endif  // SOURCE_VAL_VALIDATE_H_

--- a/source/val/validate_adjacency.cpp
+++ b/source/val/validate_adjacency.cpp
@@ -15,14 +15,14 @@
 // Validates correctness of the intra-block preconditions of SPIR-V
 // instructions.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
 #include <string>
 
-#include "diagnostic.h"
-#include "opcode.h"
-#include "val/instruction.h"
-#include "val/validation_state.h"
+#include "source/diagnostic.h"
+#include "source/opcode.h"
+#include "source/val/instruction.h"
+#include "source/val/validation_state.h"
 
 namespace spvtools {
 namespace val {

--- a/source/val/validate_arithmetics.cpp
+++ b/source/val/validate_arithmetics.cpp
@@ -14,12 +14,12 @@
 
 // Performs validation of arithmetic instructions.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
-#include "diagnostic.h"
-#include "opcode.h"
-#include "val/instruction.h"
-#include "val/validation_state.h"
+#include "source/diagnostic.h"
+#include "source/opcode.h"
+#include "source/val/instruction.h"
+#include "source/val/validation_state.h"
 
 namespace spvtools {
 namespace val {

--- a/source/val/validate_atomics.cpp
+++ b/source/val/validate_atomics.cpp
@@ -14,14 +14,14 @@
 
 // Validates correctness of atomic SPIR-V instructions.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
-#include "diagnostic.h"
-#include "opcode.h"
-#include "spirv_target_env.h"
-#include "util/bitutils.h"
-#include "val/instruction.h"
-#include "val/validation_state.h"
+#include "source/diagnostic.h"
+#include "source/opcode.h"
+#include "source/spirv_target_env.h"
+#include "source/util/bitutils.h"
+#include "source/val/instruction.h"
+#include "source/val/validation_state.h"
 
 namespace spvtools {
 namespace val {

--- a/source/val/validate_barriers.cpp
+++ b/source/val/validate_barriers.cpp
@@ -14,15 +14,15 @@
 
 // Validates correctness of barrier SPIR-V instructions.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
-#include "diagnostic.h"
-#include "opcode.h"
-#include "spirv_constant.h"
-#include "spirv_target_env.h"
-#include "util/bitutils.h"
-#include "val/instruction.h"
-#include "val/validation_state.h"
+#include "source/diagnostic.h"
+#include "source/opcode.h"
+#include "source/spirv_constant.h"
+#include "source/spirv_target_env.h"
+#include "source/util/bitutils.h"
+#include "source/val/instruction.h"
+#include "source/val/validation_state.h"
 
 namespace spvtools {
 namespace val {

--- a/source/val/validate_bitwise.cpp
+++ b/source/val/validate_bitwise.cpp
@@ -14,12 +14,12 @@
 
 // Validates correctness of bitwise instructions.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
-#include "diagnostic.h"
-#include "opcode.h"
-#include "val/instruction.h"
-#include "val/validation_state.h"
+#include "source/diagnostic.h"
+#include "source/opcode.h"
+#include "source/val/instruction.h"
+#include "source/val/validation_state.h"
 
 namespace spvtools {
 namespace val {

--- a/source/val/validate_builtins.cpp
+++ b/source/val/validate_builtins.cpp
@@ -14,7 +14,7 @@
 
 // Validates correctness of built-in variables.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
 #include <functional>
 #include <list>
@@ -25,12 +25,12 @@
 #include <unordered_map>
 #include <vector>
 
-#include "diagnostic.h"
-#include "opcode.h"
-#include "spirv_target_env.h"
-#include "util/bitutils.h"
-#include "val/instruction.h"
-#include "val/validation_state.h"
+#include "source/diagnostic.h"
+#include "source/opcode.h"
+#include "source/spirv_target_env.h"
+#include "source/util/bitutils.h"
+#include "source/val/instruction.h"
+#include "source/val/validation_state.h"
 
 namespace spvtools {
 namespace val {

--- a/source/val/validate_capability.cpp
+++ b/source/val/validate_capability.cpp
@@ -14,15 +14,15 @@
 
 // Validates OpCapability instruction.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
 #include <cassert>
 #include <unordered_set>
 
-#include "diagnostic.h"
-#include "opcode.h"
-#include "val/instruction.h"
-#include "val/validation_state.h"
+#include "source/diagnostic.h"
+#include "source/opcode.h"
+#include "source/val/instruction.h"
+#include "source/val/validation_state.h"
 
 namespace spvtools {
 namespace val {

--- a/source/val/validate_cfg.cpp
+++ b/source/val/validate_cfg.cpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "cfa.h"
-#include "validate.h"
+#include "source/val/validate.h"
 
 #include <algorithm>
 #include <cassert>
@@ -27,11 +26,12 @@
 #include <utility>
 #include <vector>
 
-#include "spirv_validator_options.h"
-#include "val/basic_block.h"
-#include "val/construct.h"
-#include "val/function.h"
-#include "val/validation_state.h"
+#include "source/cfa.h"
+#include "source/spirv_validator_options.h"
+#include "source/val/basic_block.h"
+#include "source/val/construct.h"
+#include "source/val/function.h"
+#include "source/val/validation_state.h"
 
 using std::find;
 using std::function;

--- a/source/val/validate_composites.cpp
+++ b/source/val/validate_composites.cpp
@@ -14,12 +14,12 @@
 
 // Validates correctness of composite SPIR-V instructions.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
-#include "diagnostic.h"
-#include "opcode.h"
-#include "val/instruction.h"
-#include "val/validation_state.h"
+#include "source/diagnostic.h"
+#include "source/opcode.h"
+#include "source/val/instruction.h"
+#include "source/val/validation_state.h"
 
 namespace spvtools {
 namespace val {

--- a/source/val/validate_conversion.cpp
+++ b/source/val/validate_conversion.cpp
@@ -14,12 +14,12 @@
 
 // Validates correctness of conversion instructions.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
-#include "diagnostic.h"
-#include "opcode.h"
-#include "val/instruction.h"
-#include "val/validation_state.h"
+#include "source/diagnostic.h"
+#include "source/opcode.h"
+#include "source/val/instruction.h"
+#include "source/val/validation_state.h"
 
 namespace spvtools {
 namespace val {

--- a/source/val/validate_datarules.cpp
+++ b/source/val/validate_datarules.cpp
@@ -14,17 +14,17 @@
 
 // Ensures Data Rules are followed according to the specifications.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
 #include <cassert>
 #include <sstream>
 #include <string>
 
-#include "diagnostic.h"
-#include "opcode.h"
-#include "operand.h"
-#include "val/instruction.h"
-#include "val/validation_state.h"
+#include "source/diagnostic.h"
+#include "source/opcode.h"
+#include "source/operand.h"
+#include "source/val/instruction.h"
+#include "source/val/validation_state.h"
 
 namespace spvtools {
 namespace val {

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
 #include <algorithm>
 #include <cassert>
@@ -20,11 +20,11 @@
 #include <unordered_map>
 #include <utility>
 
-#include "diagnostic.h"
-#include "opcode.h"
-#include "spirv_target_env.h"
-#include "spirv_validator_options.h"
-#include "val/validation_state.h"
+#include "source/diagnostic.h"
+#include "source/opcode.h"
+#include "source/spirv_target_env.h"
+#include "source/spirv_validator_options.h"
+#include "source/val/validation_state.h"
 
 namespace spvtools {
 namespace val {

--- a/source/val/validate_derivatives.cpp
+++ b/source/val/validate_derivatives.cpp
@@ -14,12 +14,12 @@
 
 // Validates correctness of derivative SPIR-V instructions.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
-#include "diagnostic.h"
-#include "opcode.h"
-#include "val/instruction.h"
-#include "val/validation_state.h"
+#include "source/diagnostic.h"
+#include "source/opcode.h"
+#include "source/val/instruction.h"
+#include "source/val/validation_state.h"
 
 namespace spvtools {
 namespace val {

--- a/source/val/validate_ext_inst.cpp
+++ b/source/val/validate_ext_inst.cpp
@@ -14,17 +14,16 @@
 
 // Validates correctness of ExtInst SPIR-V instructions.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
 #include <sstream>
 
-#include "latest_version_glsl_std_450_header.h"
-#include "latest_version_opencl_std_header.h"
-
-#include "diagnostic.h"
-#include "opcode.h"
-#include "val/instruction.h"
-#include "val/validation_state.h"
+#include "source/diagnostic.h"
+#include "source/latest_version_glsl_std_450_header.h"
+#include "source/latest_version_opencl_std_header.h"
+#include "source/opcode.h"
+#include "source/val/instruction.h"
+#include "source/val/validation_state.h"
 
 namespace spvtools {
 namespace val {

--- a/source/val/validate_id.cpp
+++ b/source/val/validate_id.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
 #include <cassert>
 
@@ -24,15 +24,15 @@
 #include <utility>
 #include <vector>
 
-#include "diagnostic.h"
-#include "instruction.h"
-#include "message.h"
-#include "opcode.h"
-#include "operand.h"
+#include "source/diagnostic.h"
+#include "source/instruction.h"
+#include "source/message.h"
+#include "source/opcode.h"
+#include "source/operand.h"
+#include "source/spirv_validator_options.h"
+#include "source/val/function.h"
+#include "source/val/validation_state.h"
 #include "spirv-tools/libspirv.h"
-#include "spirv_validator_options.h"
-#include "val/function.h"
-#include "val/validation_state.h"
 
 using std::function;
 using std::ignore;

--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -14,14 +14,14 @@
 
 // Validates correctness of image instructions.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
-#include "diagnostic.h"
-#include "opcode.h"
-#include "spirv_target_env.h"
-#include "util/bitutils.h"
-#include "val/instruction.h"
-#include "val/validation_state.h"
+#include "source/diagnostic.h"
+#include "source/opcode.h"
+#include "source/spirv_target_env.h"
+#include "source/util/bitutils.h"
+#include "source/val/instruction.h"
+#include "source/val/validation_state.h"
 
 namespace spvtools {
 namespace val {

--- a/source/val/validate_instruction.cpp
+++ b/source/val/validate_instruction.cpp
@@ -14,7 +14,7 @@
 
 // Performs validation on instructions that appear inside of a SPIR-V block.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
 #include <algorithm>
 #include <cassert>
@@ -22,20 +22,20 @@
 #include <sstream>
 #include <string>
 
-#include "binary.h"
-#include "diagnostic.h"
-#include "enum_set.h"
-#include "enum_string_mapping.h"
-#include "extensions.h"
-#include "opcode.h"
-#include "operand.h"
-#include "spirv_constant.h"
-#include "spirv_definition.h"
-#include "spirv_target_env.h"
-#include "spirv_validator_options.h"
-#include "util/string_utils.h"
-#include "val/function.h"
-#include "val/validation_state.h"
+#include "source/binary.h"
+#include "source/diagnostic.h"
+#include "source/enum_set.h"
+#include "source/enum_string_mapping.h"
+#include "source/extensions.h"
+#include "source/opcode.h"
+#include "source/operand.h"
+#include "source/spirv_constant.h"
+#include "source/spirv_definition.h"
+#include "source/spirv_target_env.h"
+#include "source/spirv_validator_options.h"
+#include "source/util/string_utils.h"
+#include "source/val/function.h"
+#include "source/val/validation_state.h"
 
 namespace spvtools {
 namespace val {

--- a/source/val/validate_interfaces.cpp
+++ b/source/val/validate_interfaces.cpp
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
 #include <algorithm>
 
-#include "diagnostic.h"
-#include "val/function.h"
-#include "val/instruction.h"
-#include "val/validation_state.h"
+#include "source/diagnostic.h"
+#include "source/val/function.h"
+#include "source/val/instruction.h"
+#include "source/val/validation_state.h"
 
 namespace spvtools {
 namespace val {

--- a/source/val/validate_layout.cpp
+++ b/source/val/validate_layout.cpp
@@ -14,17 +14,16 @@
 
 // Source code for logical layout validation as described in section 2.4
 
-#include "validate.h"
+#include "source/val/validate.h"
 
 #include <cassert>
 
-#include "diagnostic.h"
-#include "opcode.h"
-#include "operand.h"
-#include "spirv-tools/libspirv.h"
-#include "val/function.h"
-#include "val/instruction.h"
-#include "val/validation_state.h"
+#include "source/diagnostic.h"
+#include "source/opcode.h"
+#include "source/operand.h"
+#include "source/val/function.h"
+#include "source/val/instruction.h"
+#include "source/val/validation_state.h"
 
 namespace spvtools {
 namespace val {

--- a/source/val/validate_literals.cpp
+++ b/source/val/validate_literals.cpp
@@ -14,14 +14,14 @@
 
 // Validates literal numbers.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
 #include <cassert>
 
-#include "diagnostic.h"
-#include "opcode.h"
-#include "val/instruction.h"
-#include "val/validation_state.h"
+#include "source/diagnostic.h"
+#include "source/opcode.h"
+#include "source/val/instruction.h"
+#include "source/val/validation_state.h"
 
 namespace spvtools {
 namespace val {

--- a/source/val/validate_logicals.cpp
+++ b/source/val/validate_logicals.cpp
@@ -14,12 +14,12 @@
 
 // Validates correctness of logical SPIR-V instructions.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
-#include "diagnostic.h"
-#include "opcode.h"
-#include "val/instruction.h"
-#include "val/validation_state.h"
+#include "source/diagnostic.h"
+#include "source/opcode.h"
+#include "source/val/instruction.h"
+#include "source/val/validation_state.h"
 
 namespace spvtools {
 namespace val {

--- a/source/val/validate_non_uniform.cpp
+++ b/source/val/validate_non_uniform.cpp
@@ -14,15 +14,15 @@
 
 // Validates correctness of barrier SPIR-V instructions.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
-#include "diagnostic.h"
-#include "opcode.h"
-#include "spirv_constant.h"
-#include "spirv_target_env.h"
-#include "util/bitutils.h"
-#include "val/instruction.h"
-#include "val/validation_state.h"
+#include "source/diagnostic.h"
+#include "source/opcode.h"
+#include "source/spirv_constant.h"
+#include "source/spirv_target_env.h"
+#include "source/util/bitutils.h"
+#include "source/val/instruction.h"
+#include "source/val/validation_state.h"
 
 namespace spvtools {
 namespace val {

--- a/source/val/validate_primitives.cpp
+++ b/source/val/validate_primitives.cpp
@@ -14,14 +14,14 @@
 
 // Validates correctness of primitive SPIR-V instructions.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
 #include <string>
 
-#include "diagnostic.h"
-#include "opcode.h"
-#include "val/instruction.h"
-#include "val/validation_state.h"
+#include "source/diagnostic.h"
+#include "source/opcode.h"
+#include "source/val/instruction.h"
+#include "source/val/validation_state.h"
 
 namespace spvtools {
 namespace val {

--- a/source/val/validate_type_unique.cpp
+++ b/source/val/validate_type_unique.cpp
@@ -14,12 +14,12 @@
 
 // Ensures type declarations are unique unless allowed by the specification.
 
-#include "validate.h"
+#include "source/val/validate.h"
 
-#include "diagnostic.h"
-#include "opcode.h"
-#include "val/instruction.h"
-#include "val/validation_state.h"
+#include "source/diagnostic.h"
+#include "source/opcode.h"
+#include "source/val/instruction.h"
+#include "source/val/validation_state.h"
 
 namespace spvtools {
 namespace val {

--- a/test/unit_spirv.h
+++ b/test/unit_spirv.h
@@ -28,7 +28,7 @@
 #include "source/spirv_endian.h"
 #include "source/text.h"
 #include "source/text_handler.h"
-#include "source/validate.h"
+#include "source/val/validate.h"
 #include "spirv-tools/libspirv.h"
 
 #include <gtest/gtest.h>

--- a/test/val/val_cfg_test.cpp
+++ b/test/val/val_cfg_test.cpp
@@ -25,7 +25,7 @@
 #include "gmock/gmock.h"
 
 #include "source/diagnostic.h"
-#include "source/validate.h"
+#include "source/val/validate.h"
 #include "test_fixture.h"
 #include "unit_spirv.h"
 #include "val_fixtures.h"

--- a/test/val/val_state_test.cpp
+++ b/test/val/val_state_test.cpp
@@ -26,7 +26,7 @@
 #include "val/construct.h"
 #include "val/function.h"
 #include "val/validation_state.h"
-#include "validate.h"
+#include "val/validate.h"
 
 namespace spvtools {
 namespace val {


### PR DESCRIPTION
This CL moves the various validate files into the val/ directory with
the rest of the validation infrastructure. This matches how opt/ is
setup with the passes with the infrastructure.