### PR TITLE
Vulkan permits non-monotonic offsets for block members

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -18,6 +18,7 @@
 #include <stack>
 
 #include "opcode.h"
+#include "spirv_target_env.h"
 #include "val/basic_block.h"
 #include "val/construct.h"
 #include "val/function.h"
@@ -168,6 +169,8 @@ ValidationState_t::ValidationState_t(const spv_const_context ctx,
       in_function_(false) {
   assert(opt && "Validator options may not be Null.");
 
+  features_.non_monotonic_struct_member_offsets =
+      spvIsVulkanEnv(context_->target_env);
   switch (context_->target_env) {
     case SPV_ENV_WEBGPU_0:
       features_.bans_op_undef = true;

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -81,6 +81,10 @@ class ValidationState_t {
 
     // Allow OpTypeInt with 8 bit width?
     bool declare_int8_type = false;
+
+    // Allow non-monotonic offsets for struct members?
+    // Vulkan permits this.
+    bool non_monotonic_struct_member_offsets = false;
   };
 
   ValidationState_t(const spv_const_context context,


### PR DESCRIPTION
Other environments do not.
Add tests for OpenGL 4.5 and SPIR-V universal 1.0 to ensure
they still check monotonic layout.

For universal 1.0, we're assuming it otherwise follows Vulkan
rules for block layout.

Fixes #1685