### PR TITLE
Rename ForEachId for clarity

### DIFF
--- a/source/link/linker.cpp
+++ b/source/link/linker.cpp
@@ -165,7 +165,7 @@ spv_result_t ShiftIdsInModules(const MessageConsumer& consumer,
        ++module_iter) {
     Module* module = *module_iter;
     module->ForEachInst([&id_bound](Instruction* insn) {
-      insn->ForEachId([&id_bound](uint32_t* id) { *id += id_bound; });
+      insn->ForEachIdUpdateId([&id_bound](uint32_t* id) { *id += id_bound; });
     });
     id_bound += module->IdBound() - 1u;
     if (id_bound > 0x3FFFFF)

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -261,8 +261,7 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   // Runs the given function |f| on all operand ids.
   //
   // |f| should not transform an ID into 0, as 0 is an invalid ID.
-  inline void ForEachId(const std::function<void(uint32_t*)>& f);
-  inline void ForEachId(const std::function<void(const uint32_t*)>& f) const;
+  inline void ForEachIdUpdateId(const std::function<void(uint32_t*)>& f);
 
   // Runs the given function |f| on all "in" operand ids.
   inline void ForEachInId(const std::function<void(uint32_t*)>& f);
@@ -573,18 +572,13 @@ inline void Instruction::ForEachInst(
       run_on_debug_line_insts);
 }
 
-inline void Instruction::ForEachId(const std::function<void(uint32_t*)>& f) {
+inline void Instruction::ForEachIdUpdateId(
+    const std::function<void(uint32_t*)>& f) {
   for (auto& opnd : operands_)
     if (spvIsIdType(opnd.type)) f(&opnd.words[0]);
   if (type_id_ != 0u) type_id_ = GetSingleWordOperand(0u);
   if (result_id_ != 0u)
     result_id_ = GetSingleWordOperand(type_id_ == 0u ? 0u : 1u);
-}
-
-inline void Instruction::ForEachId(
-    const std::function<void(const uint32_t*)>& f) const {
-  for (const auto& opnd : operands_)
-    if (spvIsIdType(opnd.type)) f(&opnd.words[0]);
 }
 
 inline bool Instruction::WhileEachInId(


### PR DESCRIPTION
The ForEachId method has the side effect that it will also set the type
and result IDs. This CL renames the method to ForEachIdUpdateId to make
it to the effect clearer.

The non-const ForEachId is removed as it is unused.