### PR TITLE
Remove context() method from opt::Function

### DIFF
--- a/source/opt/cfg.cpp
+++ b/source/opt/cfg.cpp
@@ -158,7 +158,7 @@ BasicBlock* CFG::SplitLoopHeader(opt::BasicBlock* bb) {
   assert(bb->GetLoopMergeInst() && "Expecting bb to be the header of a loop.");
 
   Function* fn = bb->GetParent();
-  IRContext* context = fn->context();
+  IRContext* context = module_->context();
 
   // Find the insertion point for the new bb.
   Function::iterator header_it = std::find_if(

--- a/source/opt/dominator_analysis.h
+++ b/source/opt/dominator_analysis.h
@@ -30,8 +30,8 @@ class DominatorAnalysisBase {
   explicit DominatorAnalysisBase(bool is_post_dom) : tree_(is_post_dom) {}
 
   // Calculates the dominator (or postdominator) tree for given function |f|.
-  inline void InitializeTree(const opt::Function* f) {
-    tree_.InitializeTree(f);
+  inline void InitializeTree(const CFG& cfg, const opt::Function* f) {
+    tree_.InitializeTree(cfg, f);
   }
 
   // Returns true if BasicBlock |a| dominates BasicBlock |b|.

--- a/source/opt/dominator_tree.cpp
+++ b/source/opt/dominator_tree.cpp
@@ -321,14 +321,13 @@ void DominatorTree::GetDominatorEdges(
       CFA<opt::BasicBlock>::CalculateDominators(postorder, predecessor_functor);
 }
 
-void DominatorTree::InitializeTree(const opt::Function* f) {
+void DominatorTree::InitializeTree(const CFG& cfg, const opt::Function* f) {
   ClearTree();
 
   // Skip over empty functions.
   if (f->cbegin() == f->cend()) {
     return;
   }
-  const opt::CFG& cfg = *f->context()->cfg();
 
   const opt::BasicBlock* dummy_start_node =
       postdominator_ ? cfg.pseudo_exit_block() : cfg.pseudo_entry_block();

--- a/source/opt/dominator_tree.h
+++ b/source/opt/dominator_tree.h
@@ -157,7 +157,7 @@ class DominatorTree {
   void DumpTreeAsDot(std::ostream& out_stream) const;
 
   // Build the (post-)dominator tree for the given control flow graph
-  // |cfg| and the function |f|. |f| must exist in the |cfg|. Any 
+  // |cfg| and the function |f|. |f| must exist in the |cfg|. Any
   // existing data in the dominator tree will be overwritten
   void InitializeTree(const CFG& cfg, const opt::Function* f);
 

--- a/source/opt/dominator_tree.h
+++ b/source/opt/dominator_tree.h
@@ -158,7 +158,7 @@ class DominatorTree {
 
   // Build the (post-)dominator tree for the function |f|
   // Any existing data will be overwritten
-  void InitializeTree(const opt::Function* f);
+  void InitializeTree(const CFG& cfg, const opt::Function* f);
 
   // Check if the basic block |a| dominates the basic block |b|.
   bool Dominates(const opt::BasicBlock* a, const opt::BasicBlock* b) const;

--- a/source/opt/dominator_tree.h
+++ b/source/opt/dominator_tree.h
@@ -156,8 +156,9 @@ class DominatorTree {
   // Dumps the tree in the graphvis dot format into the |out_stream|.
   void DumpTreeAsDot(std::ostream& out_stream) const;
 
-  // Build the (post-)dominator tree for the function |f|
-  // Any existing data will be overwritten
+  // Build the (post-)dominator tree for the given control flow graph
+  // |cfg| and the function |f|. |f| must exist in the |cfg|. Any 
+  // existing data in the dominator tree will be overwritten
   void InitializeTree(const CFG& cfg, const opt::Function* f);
 
   // Check if the basic block |a| dominates the basic block |b|.

--- a/source/opt/function.h
+++ b/source/opt/function.h
@@ -119,9 +119,6 @@ class Function {
   void ForEachParam(const std::function<void(const Instruction*)>& f,
                     bool run_on_debug_line_insts = false) const;
 
-  // Returns the context of the current function.
-  IRContext* context() const { return def_inst_->context(); }
-
   BasicBlock* InsertBasicBlockAfter(
       std::unique_ptr<opt::BasicBlock>&& new_block, BasicBlock* position);
 

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -580,7 +580,7 @@ opt::DominatorAnalysis* IRContext::GetDominatorAnalysis(
   }
 
   if (dominator_trees_.find(f) == dominator_trees_.end()) {
-    dominator_trees_[f].InitializeTree(f);
+    dominator_trees_[f].InitializeTree(*cfg(), f);
   }
 
   return &dominator_trees_[f];
@@ -594,7 +594,7 @@ opt::PostDominatorAnalysis* IRContext::GetPostDominatorAnalysis(
   }
 
   if (post_dominator_trees_.find(f) == post_dominator_trees_.end()) {
-    post_dominator_trees_[f].InitializeTree(f);
+    post_dominator_trees_[f].InitializeTree(*cfg(), f);
   }
 
   return &post_dominator_trees_[f];

--- a/source/opt/loop_fusion_pass.cpp
+++ b/source/opt/loop_fusion_pass.cpp
@@ -35,8 +35,7 @@ Pass::Status LoopFusionPass::Process() {
 }
 
 bool LoopFusionPass::ProcessFunction(opt::Function* function) {
-  auto c = function->context();
-  opt::LoopDescriptor& ld = *c->GetLoopDescriptor(function);
+  opt::LoopDescriptor& ld = *context()->GetLoopDescriptor(function);
 
   // If a loop doesn't have a preheader needs then it needs to be created. Make
   // sure to return Status::SuccessWithChange in that case.
@@ -46,10 +45,10 @@ bool LoopFusionPass::ProcessFunction(opt::Function* function) {
   // picked out so don't have to check every loop
   for (auto& loop_0 : ld) {
     for (auto& loop_1 : ld) {
-      LoopFusion fusion(c, &loop_0, &loop_1);
+      LoopFusion fusion(context(), &loop_0, &loop_1);
 
       if (fusion.AreCompatible() && fusion.IsLegal()) {
-        RegisterLiveness liveness(c, function);
+        RegisterLiveness liveness(context(), function);
         RegisterLiveness::RegionRegisterLiveness reg_pressure{};
         liveness.SimulateFusion(loop_0, loop_1, &reg_pressure);
 

--- a/test/opt/dominator_tree/generated.cpp
+++ b/test/opt/dominator_tree/generated.cpp
@@ -122,8 +122,8 @@ TEST_F(PassClassTest, DominatorSimpleCFG) {
   // Test normal dominator tree
   {
     DominatorAnalysis dom_tree;
-    dom_tree.InitializeTree(fn);
     const CFG& cfg = *context->cfg();
+    dom_tree.InitializeTree(cfg, fn);
 
     // Inspect the actual tree
     DominatorTree& tree = dom_tree.GetDomTree();
@@ -187,8 +187,8 @@ TEST_F(PassClassTest, DominatorSimpleCFG) {
   // Test post dominator tree
   {
     PostDominatorAnalysis dom_tree;
-    dom_tree.InitializeTree(fn);
     const CFG& cfg = *context->cfg();
+    dom_tree.InitializeTree(cfg, fn);
 
     // Inspect the actual tree
     DominatorTree& tree = dom_tree.GetDomTree();
@@ -289,8 +289,8 @@ TEST_F(PassClassTest, DominatorIrreducibleCFG) {
   // Check normal dominator tree
   {
     DominatorAnalysis dom_tree;
-    dom_tree.InitializeTree(fn);
     const CFG& cfg = *context->cfg();
+    dom_tree.InitializeTree(cfg, fn);
 
     // Inspect the actual tree
     DominatorTree& tree = dom_tree.GetDomTree();
@@ -331,8 +331,8 @@ TEST_F(PassClassTest, DominatorIrreducibleCFG) {
   // Check post dominator tree
   {
     PostDominatorAnalysis dom_tree;
-    dom_tree.InitializeTree(fn);
     const CFG& cfg = *context->cfg();
+    dom_tree.InitializeTree(cfg, fn);
 
     // Inspect the actual tree
     DominatorTree& tree = dom_tree.GetDomTree();
@@ -410,8 +410,8 @@ TEST_F(PassClassTest, DominatorLoopToSelf) {
   // Check normal dominator tree
   {
     DominatorAnalysis dom_tree;
-    dom_tree.InitializeTree(fn);
     const CFG& cfg = *context->cfg();
+    dom_tree.InitializeTree(cfg, fn);
 
     // Inspect the actual tree
     DominatorTree& tree = dom_tree.GetDomTree();
@@ -486,8 +486,8 @@ TEST_F(PassClassTest, DominatorLoopToSelf) {
   // Check post dominator tree
   {
     PostDominatorAnalysis dom_tree;
-    dom_tree.InitializeTree(fn);
     const CFG& cfg = *context->cfg();
+    dom_tree.InitializeTree(cfg, fn);
 
     // Inspect the actual tree
     DominatorTree& tree = dom_tree.GetDomTree();
@@ -607,8 +607,8 @@ TEST_F(PassClassTest, DominatorUnreachableInLoop) {
   // Check normal dominator tree
   {
     DominatorAnalysis dom_tree;
-    dom_tree.InitializeTree(fn);
     const CFG& cfg = *context->cfg();
+    dom_tree.InitializeTree(cfg, fn);
 
     // Inspect the actual tree
     DominatorTree& tree = dom_tree.GetDomTree();
@@ -658,8 +658,8 @@ TEST_F(PassClassTest, DominatorUnreachableInLoop) {
   // Check post dominator tree.
   {
     PostDominatorAnalysis dom_tree;
-    dom_tree.InitializeTree(fn);
     const CFG& cfg = *context->cfg();
+    dom_tree.InitializeTree(cfg, fn);
 
     // (strict) dominance checks.
     for (uint32_t id : {10, 11, 12, 13, 14, 15})
@@ -737,8 +737,8 @@ TEST_F(PassClassTest, DominatorInfinitLoop) {
   // Check normal dominator tree
   {
     DominatorAnalysis dom_tree;
-    dom_tree.InitializeTree(fn);
     const CFG& cfg = *context->cfg();
+    dom_tree.InitializeTree(cfg, fn);
 
     // Inspect the actual tree
     DominatorTree& tree = dom_tree.GetDomTree();
@@ -772,8 +772,8 @@ TEST_F(PassClassTest, DominatorInfinitLoop) {
   // Check post dominator tree
   {
     PostDominatorAnalysis dom_tree;
-    dom_tree.InitializeTree(fn);
     const CFG& cfg = *context->cfg();
+    dom_tree.InitializeTree(cfg, fn);
 
     // Inspect the actual tree
     DominatorTree& tree = dom_tree.GetDomTree();
@@ -842,8 +842,9 @@ TEST_F(PassClassTest, DominatorUnreachableFromEntry) {
   // Check dominator tree
   {
     DominatorAnalysis dom_tree;
-    dom_tree.InitializeTree(fn);
     const CFG& cfg = *context->cfg();
+    dom_tree.InitializeTree(cfg, fn);
+
     // Inspect the actual tree
     DominatorTree& tree = dom_tree.GetDomTree();
     EXPECT_EQ(tree.GetRoot()->bb_, cfg.pseudo_entry_block());
@@ -870,8 +871,8 @@ TEST_F(PassClassTest, DominatorUnreachableFromEntry) {
   // Check post dominator tree
   {
     PostDominatorAnalysis dom_tree;
-    dom_tree.InitializeTree(fn);
     const CFG& cfg = *context->cfg();
+    dom_tree.InitializeTree(cfg, fn);
 
     // Inspect the actual tree
     DominatorTree& tree = dom_tree.GetDomTree();


### PR DESCRIPTION
This CL removes the context() method from opt::Function. In the places
where the context() was used we can retrieve, or provide, the context in
another fashion.

#1703