### PR TITLE
[WIP] Change Optimizer to build passes as late as possible.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ elseif(MSVC)
 endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/source)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/)
 
 option(SPIRV_COLOR_TERMINAL "Enable color terminal output" ON)
 if(${SPIRV_COLOR_TERMINAL})

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -24,10 +24,11 @@
 #include "libspirv.hpp"
 
 namespace spvtools {
-
 namespace opt {
-class Pass;
-}
+
+class PassToken;
+
+}  // namespace opt
 
 // C++ interface for SPIR-V optimization functionalities. It wraps the context
 // (including target environment and the corresponding SPIR-V grammar) and
@@ -49,7 +50,7 @@ class Optimizer {
     // below; for out-of-tree passes, use this constructor instead.
     // Note that this API isn't guaranteed to be stable and may change without
     // preserving source or binary compatibility in the future.
-    PassToken(std::unique_ptr<opt::Pass>&& pass);
+    PassToken(std::unique_ptr<opt::PassToken>&& pass);
 
     // Tokens can only be moved. Copying is disabled.
     PassToken(const PassToken&) = delete;

--- a/source/link/linker.cpp
+++ b/source/link/linker.cpp
@@ -735,31 +735,36 @@ spv_result_t Link(const Context& context, const uint32_t* const* binaries,
   if (res != SPV_SUCCESS) return res;
 
   // Phase 6: Remove duplicates
-  PassManager manager;
-  manager.SetMessageConsumer(consumer);
-  manager.AddPassToken<opt::RemoveDuplicatesPassToken>();
-  opt::Pass::Status pass_res = manager.Run(&linked_context);
-  if (pass_res == opt::Pass::Status::Failure) return SPV_ERROR_INVALID_DATA;
+  {
+    PassManager manager;
+    manager.SetMessageConsumer(consumer);
+    manager.AddPassToken<opt::RemoveDuplicatesPassToken>();
+    opt::Pass::Status pass_res = manager.Run(&linked_context);
+    if (pass_res == opt::Pass::Status::Failure) return SPV_ERROR_INVALID_DATA;
 
-  // Phase 7: Rematch import variables/functions to export variables/functions
-  for (const auto& linking_entry : linkings_to_do)
-    linked_context.ReplaceAllUsesWith(linking_entry.imported_symbol.id,
-                                      linking_entry.exported_symbol.id);
+    // Phase 7: Rematch import variables/functions to export variables/functions
+    for (const auto& linking_entry : linkings_to_do)
+      linked_context.ReplaceAllUsesWith(linking_entry.imported_symbol.id,
+                                        linking_entry.exported_symbol.id);
 
-  // Phase 8: Remove linkage specific instructions, such as import/export
-  // attributes, linkage capability, etc. if applicable
-  res = RemoveLinkageSpecificInstructions(consumer, options, linkings_to_do,
-                                          linked_context.get_decoration_mgr(),
-                                          &linked_context);
-  if (res != SPV_SUCCESS) return res;
+    // Phase 8: Remove linkage specific instructions, such as import/export
+    // attributes, linkage capability, etc. if applicable
+    res = RemoveLinkageSpecificInstructions(consumer, options, linkings_to_do,
+                                            linked_context.get_decoration_mgr(),
+                                            &linked_context);
+    if (res != SPV_SUCCESS) return res;
+  }
 
   // Phase 9: Compact the IDs used in the module
-  manager.AddPassToken<opt::CompactIdsPassToken>();
-  pass_res = manager.Run(&linked_context);
-  if (pass_res == opt::Pass::Status::Failure) return SPV_ERROR_INVALID_DATA;
+  {
+    PassManager manager;
+    manager.AddPassToken<opt::CompactIdsPassToken>();
+    opt::Pass::Status pass_res = manager.Run(&linked_context);
+    if (pass_res == opt::Pass::Status::Failure) return SPV_ERROR_INVALID_DATA;
 
-  // Phase 10: Output the module
-  linked_context.module()->ToBinary(linked_binary, true);
+    // Phase 10: Output the module
+    linked_context.module()->ToBinary(linked_binary, true);
+  }
 
   return SPV_SUCCESS;
 }

--- a/source/link/linker.cpp
+++ b/source/link/linker.cpp
@@ -22,6 +22,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "include/spirv-tools/libspirv.hpp"
 #include "source/assembly_grammar.h"
 #include "source/diagnostic.h"
 #include "source/opt/build_module.h"
@@ -32,7 +33,6 @@
 #include "source/opt/pass_manager.h"
 #include "source/opt/remove_duplicates_pass.h"
 #include "source/spirv_target_env.h"
-#include "include/spirv-tools/libspirv.hpp"
 
 namespace spvtools {
 namespace {

--- a/source/link/linker.cpp
+++ b/source/link/linker.cpp
@@ -12,28 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "spirv-tools/linker.hpp"
-
-#include <cstdio>
-#include <cstring>
+#include "include/spirv-tools/linker.hpp"
 
 #include <algorithm>
+#include <cstdio>
+#include <cstring>
 #include <iostream>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
-#include "assembly_grammar.h"
-#include "diagnostic.h"
-#include "opt/build_module.h"
-#include "opt/compact_ids_pass.h"
-#include "opt/decoration_manager.h"
-#include "opt/ir_loader.h"
-#include "opt/make_unique.h"
-#include "opt/pass_manager.h"
-#include "opt/remove_duplicates_pass.h"
-#include "spirv-tools/libspirv.hpp"
-#include "spirv_target_env.h"
+#include "source/assembly_grammar.h"
+#include "source/diagnostic.h"
+#include "source/opt/build_module.h"
+#include "source/opt/compact_ids_pass.h"
+#include "source/opt/decoration_manager.h"
+#include "source/opt/ir_loader.h"
+#include "source/opt/make_unique.h"
+#include "source/opt/pass_manager.h"
+#include "source/opt/remove_duplicates_pass.h"
+#include "source/spirv_target_env.h"
+#include "include/spirv-tools/libspirv.hpp"
 
 namespace spvtools {
 namespace {
@@ -738,7 +737,7 @@ spv_result_t Link(const Context& context, const uint32_t* const* binaries,
   // Phase 6: Remove duplicates
   PassManager manager;
   manager.SetMessageConsumer(consumer);
-  manager.AddPass<RemoveDuplicatesPass>();
+  manager.AddPassToken<opt::RemoveDuplicatesPassToken>();
   opt::Pass::Status pass_res = manager.Run(&linked_context);
   if (pass_res == opt::Pass::Status::Failure) return SPV_ERROR_INVALID_DATA;
 
@@ -755,7 +754,7 @@ spv_result_t Link(const Context& context, const uint32_t* const* binaries,
   if (res != SPV_SUCCESS) return res;
 
   // Phase 9: Compact the IDs used in the module
-  manager.AddPass<opt::CompactIdsPass>();
+  manager.AddPassToken<opt::CompactIdsPassToken>();
   pass_res = manager.Run(&linked_context);
   if (pass_res == opt::Pass::Status::Failure) return SPV_ERROR_INVALID_DATA;
 

--- a/source/opt/aggressive_dead_code_elim_pass.h
+++ b/source/opt/aggressive_dead_code_elim_pass.h
@@ -14,10 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_AGGRESSIVE_DCE_PASS_H_
-#define LIBSPIRV_OPT_AGGRESSIVE_DCE_PASS_H_
+#ifndef SOURCE_OPT_AGGRESSIVE_DCE_PASS_H_
+#define SOURCE_OPT_AGGRESSIVE_DCE_PASS_H_
 
-#include <util/bit_vector.h>
 #include <algorithm>
 #include <map>
 #include <queue>
@@ -25,10 +24,12 @@
 #include <unordered_set>
 #include <utility>
 
-#include "basic_block.h"
-#include "def_use_manager.h"
-#include "mem_pass.h"
-#include "module.h"
+#include "source/opt/basic_block.h"
+#include "source/opt/def_use_manager.h"
+#include "source/opt/mem_pass.h"
+#include "source/opt/module.h"
+#include "source/opt/pass_token.h"
+#include "source/util/bit_vector.h"
 
 namespace spvtools {
 namespace opt {
@@ -42,7 +43,6 @@ class AggressiveDCEPass : public MemPass {
       std::function<std::vector<opt::BasicBlock*>*(const opt::BasicBlock*)>;
 
   AggressiveDCEPass();
-  const char* name() const override { return "eliminate-dead-code-aggressive"; }
   Status Process(opt::IRContext* c) override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
@@ -186,7 +186,19 @@ class AggressiveDCEPass : public MemPass {
   std::unordered_set<std::string> extensions_whitelist_;
 };
 
+class AggressiveDCEPassToken : public PassToken {
+ public:
+  AggressiveDCEPassToken() = default;
+  ~AggressiveDCEPassToken() override = default;
+
+  const char* name() const override { return "eliminate-dead-code-aggressive"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<AggressiveDCEPass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_AGGRESSIVE_DCE_PASS_H_
+#endif  // SOURCE_OPT_AGGRESSIVE_DCE_PASS_H_

--- a/source/opt/block_merge_pass.h
+++ b/source/opt/block_merge_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_BLOCK_MERGE_PASS_H_
-#define LIBSPIRV_OPT_BLOCK_MERGE_PASS_H_
+#ifndef SOURCE_OPT_BLOCK_MERGE_PASS_H_
+#define SOURCE_OPT_BLOCK_MERGE_PASS_H_
 
 #include <algorithm>
 #include <map>
@@ -24,11 +24,12 @@
 #include <unordered_set>
 #include <utility>
 
-#include "basic_block.h"
-#include "def_use_manager.h"
-#include "ir_context.h"
-#include "module.h"
-#include "pass.h"
+#include "source/opt/basic_block.h"
+#include "source/opt/def_use_manager.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/module.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -37,7 +38,7 @@ namespace opt {
 class BlockMergePass : public Pass {
  public:
   BlockMergePass();
-  const char* name() const override { return "merge-blocks"; }
+
   Status Process(opt::IRContext*) override;
   virtual opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse |
@@ -68,7 +69,19 @@ class BlockMergePass : public Pass {
   Pass::Status ProcessImpl();
 };
 
+class BlockMergePassToken : public PassToken {
+ public:
+  BlockMergePassToken() = default;
+  ~BlockMergePassToken() override = default;
+
+  const char* name() const override { return "merge-blocks"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<BlockMergePass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_BLOCK_MERGE_PASS_H_
+#endif  // SOURCE_OPT_BLOCK_MERGE_PASS_H_

--- a/source/opt/ccp_pass.h
+++ b/source/opt/ccp_pass.h
@@ -12,15 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_CCP_PASS_H_
-#define LIBSPIRV_OPT_CCP_PASS_H_
+#ifndef SOURCE_OPT_CCP_PASS_H_
+#define SOURCE_OPT_CCP_PASS_H_
 
-#include "constants.h"
-#include "function.h"
-#include "ir_context.h"
-#include "mem_pass.h"
-#include "module.h"
-#include "propagator.h"
+#include "source/opt/constants.h"
+#include "source/opt/function.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/mem_pass.h"
+#include "source/opt/module.h"
+#include "source/opt/pass_token.h"
+#include "source/opt/propagator.h"
 
 namespace spvtools {
 namespace opt {
@@ -28,7 +29,7 @@ namespace opt {
 class CCPPass : public MemPass {
  public:
   CCPPass() = default;
-  const char* name() const override { return "ccp"; }
+
   Status Process(opt::IRContext* c) override;
   virtual opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse |
@@ -102,7 +103,19 @@ class CCPPass : public MemPass {
   std::unique_ptr<SSAPropagator> propagator_;
 };
 
+class CCPPassToken : public PassToken {
+ public:
+  CCPPassToken() = default;
+  ~CCPPassToken() override = default;
+
+  const char* name() const override { return "ccp"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<CCPPass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif
+#endif  // SOURCE_OPT_CCP_PASS_H_

--- a/source/opt/cfg_cleanup_pass.h
+++ b/source/opt/cfg_cleanup_pass.h
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_CFG_CLEANUP_PASS_H_
-#define LIBSPIRV_OPT_CFG_CLEANUP_PASS_H_
+#ifndef SOURCE_OPT_CFG_CLEANUP_PASS_H_
+#define SOURCE_OPT_CFG_CLEANUP_PASS_H_
 
-#include "function.h"
-#include "mem_pass.h"
-#include "module.h"
+#include "source/opt/function.h"
+#include "source/opt/mem_pass.h"
+#include "source/opt/module.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -25,7 +26,7 @@ namespace opt {
 class CFGCleanupPass : public MemPass {
  public:
   CFGCleanupPass() = default;
-  const char* name() const override { return "cfg-cleanup"; }
+
   Status Process(opt::IRContext* c) override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
@@ -37,7 +38,19 @@ class CFGCleanupPass : public MemPass {
   void Initialize(opt::IRContext* c);
 };
 
+class CFGCleanupPassToken : public PassToken {
+ public:
+  CFGCleanupPassToken() = default;
+  ~CFGCleanupPassToken() override = default;
+
+  const char* name() const override { return "cfg-cleanup"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<CFGCleanupPass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif
+#endif  // SOURCE_OPT_CFG_CLEANUP_PASS_H_

--- a/source/opt/common_uniform_elim_pass.h
+++ b/source/opt/common_uniform_elim_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_COMMON_UNIFORM_ELIM_PASS_H_
-#define LIBSPIRV_OPT_COMMON_UNIFORM_ELIM_PASS_H_
+#ifndef SOURCE_OPT_COMMON_UNIFORM_ELIM_PASS_H_
+#define SOURCE_OPT_COMMON_UNIFORM_ELIM_PASS_H_
 
 #include <algorithm>
 #include <map>
@@ -24,12 +24,13 @@
 #include <unordered_set>
 #include <utility>
 
-#include "basic_block.h"
-#include "decoration_manager.h"
-#include "def_use_manager.h"
-#include "ir_context.h"
-#include "module.h"
-#include "pass.h"
+#include "source/opt/basic_block.h"
+#include "source/opt/decoration_manager.h"
+#include "source/opt/def_use_manager.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/module.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -43,7 +44,7 @@ class CommonUniformElimPass : public Pass {
       std::function<std::vector<opt::BasicBlock*>*(const opt::BasicBlock*)>;
 
   CommonUniformElimPass();
-  const char* name() const override { return "eliminate-common-uniform"; }
+
   Status Process(opt::IRContext*) override;
 
  private:
@@ -205,7 +206,19 @@ class CommonUniformElimPass : public Pass {
       block2structured_succs_;
 };
 
+class CommonUniformElimPassToken : public PassToken {
+ public:
+  CommonUniformElimPassToken() = default;
+  ~CommonUniformElimPassToken() override = default;
+
+  const char* name() const override { return "eliminate-common-uniform"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<CommonUniformElimPass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_SSAMEM_PASS_H_
+#endif  // SOURCE_OPT_COMMON_UNIFORM_ELIM_PASS_H_

--- a/source/opt/compact_ids_pass.h
+++ b/source/opt/compact_ids_pass.h
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_COMPACT_IDS_PASS_H_
-#define LIBSPIRV_OPT_COMPACT_IDS_PASS_H_
+#ifndef SOURCE_OPT_COMPACT_IDS_PASS_H_
+#define SOURCE_OPT_COMPACT_IDS_PASS_H_
 
-#include "ir_context.h"
-#include "module.h"
-#include "pass.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/module.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -25,7 +26,6 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class CompactIdsPass : public Pass {
  public:
-  const char* name() const override { return "compact-ids"; }
   Status Process(opt::IRContext*) override;
 
   // Return the mask of preserved Analyses.
@@ -36,7 +36,19 @@ class CompactIdsPass : public Pass {
   }
 };
 
+class CompactIdsPassToken : public PassToken {
+ public:
+  CompactIdsPassToken() = default;
+  ~CompactIdsPassToken() override = default;
+
+  const char* name() const override { return "compact-ids"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<CompactIdsPass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_COMPACT_IDS_PASS_H_
+#endif  // SOURCE_OPT_COMPACT_IDS_PASS_H_

--- a/source/opt/copy_prop_arrays.h
+++ b/source/opt/copy_prop_arrays.h
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_COPY_PROP_H_
-#define LIBSPIRV_OPT_COPY_PROP_H_
+#ifndef SOURCE_OPT_COPY_PROP_ARRAYS_H_
+#define SOURCE_OPT_COPY_PROP_ARRAYS_H_
 
-#include "mem_pass.h"
+#include "source/opt/mem_pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -37,7 +38,6 @@ namespace opt {
 
 class CopyPropagateArrays : public MemPass {
  public:
-  const char* name() const override { return "copy-propagate-arrays"; }
   Status Process(opt::IRContext*) override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
@@ -226,7 +226,19 @@ class CopyPropagateArrays : public MemPass {
       const opt::Instruction* var_inst) const;
 };
 
+class CopyPropagateArraysToken : public PassToken {
+ public:
+  CopyPropagateArraysToken() = default;
+  ~CopyPropagateArraysToken() override = default;
+
+  const char* name() const override { return "copy-propagate-arrays"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<CopyPropagateArrays>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_COPY_PROP_H_
+#endif  // SOURCE_OPT_COPY_PROP_ARRAYS_H_

--- a/source/opt/dead_branch_elim_pass.h
+++ b/source/opt/dead_branch_elim_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_DEAD_BRANCH_ELIM_PASS_H_
-#define LIBSPIRV_OPT_DEAD_BRANCH_ELIM_PASS_H_
+#ifndef SOURCE_OPT_DEAD_BRANCH_ELIM_PASS_H_
+#define SOURCE_OPT_DEAD_BRANCH_ELIM_PASS_H_
 
 #include <algorithm>
 #include <map>
@@ -24,10 +24,11 @@
 #include <unordered_set>
 #include <utility>
 
-#include "basic_block.h"
-#include "def_use_manager.h"
-#include "mem_pass.h"
-#include "module.h"
+#include "source/opt/basic_block.h"
+#include "source/opt/def_use_manager.h"
+#include "source/opt/mem_pass.h"
+#include "source/opt/module.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -38,7 +39,7 @@ class DeadBranchElimPass : public MemPass {
 
  public:
   DeadBranchElimPass();
-  const char* name() const override { return "eliminate-dead-branches"; }
+
   Status Process(opt::IRContext* context) override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
@@ -133,7 +134,19 @@ class DeadBranchElimPass : public MemPass {
   Pass::Status ProcessImpl();
 };
 
+class DeadBranchElimPassToken : public PassToken {
+ public:
+  DeadBranchElimPassToken() = default;
+  ~DeadBranchElimPassToken() override = default;
+
+  const char* name() const override { return "eliminate-dead-branches"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<DeadBranchElimPass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_DEAD_BRANCH_ELIM_PASS_H_
+#endif  // SOURCE_OPT_DEAD_BRANCH_ELIM_PASS_H_

--- a/source/opt/dead_insert_elim_pass.h
+++ b/source/opt/dead_insert_elim_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_DEAD_INSERT_ELIM_PASS_H_
-#define LIBSPIRV_OPT_DEAD_INSERT_ELIM_PASS_H_
+#ifndef SOURCE_OPT_DEAD_INSERT_ELIM_PASS_H_
+#define SOURCE_OPT_DEAD_INSERT_ELIM_PASS_H_
 
 #include <algorithm>
 #include <map>
@@ -23,11 +23,12 @@
 #include <unordered_set>
 #include <utility>
 
-#include "basic_block.h"
-#include "def_use_manager.h"
-#include "ir_context.h"
-#include "mem_pass.h"
-#include "module.h"
+#include "source/opt/basic_block.h"
+#include "source/opt/def_use_manager.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/mem_pass.h"
+#include "source/opt/module.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -36,7 +37,7 @@ namespace opt {
 class DeadInsertElimPass : public MemPass {
  public:
   DeadInsertElimPass();
-  const char* name() const override { return "eliminate-dead-inserts"; }
+
   Status Process(opt::IRContext*) override;
   virtual opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse |
@@ -85,7 +86,19 @@ class DeadInsertElimPass : public MemPass {
   std::unordered_map<uint32_t, bool> visitedPhis_;
 };
 
+class DeadInsertElimPassToken : public PassToken {
+ public:
+  DeadInsertElimPassToken() = default;
+  ~DeadInsertElimPassToken() override = default;
+
+  const char* name() const override { return "eliminate-dead-inserts"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<DeadInsertElimPass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_DEAD_INSERT_ELIM_PASS_H_
+#endif  // SOURCE_OPT_DEAD_INSERT_ELIM_PASS_H_

--- a/source/opt/dead_variable_elimination.h
+++ b/source/opt/dead_variable_elimination.h
@@ -12,21 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SPIRV_TOOLS_DEAD_VARIABLE_ELIMINATION_H
-#define SPIRV_TOOLS_DEAD_VARIABLE_ELIMINATION_H
+#ifndef SOURCE_OPT_DEAD_VARIABLE_ELIMINATION_H
+#define SOURCE_OPT_DEAD_VARIABLE_ELIMINATION_H
 
 #include <climits>
 #include <unordered_map>
 
-#include "decoration_manager.h"
-#include "mem_pass.h"
+#include "source/opt/decoration_manager.h"
+#include "source/opt/mem_pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
 
 class DeadVariableElimination : public MemPass {
  public:
-  const char* name() const override { return "dead-variable-elimination"; }
   Status Process(opt::IRContext* c) override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
@@ -49,7 +49,19 @@ class DeadVariableElimination : public MemPass {
   enum { kMustKeep = INT_MAX };
 };
 
+class DeadVariableEliminationToken : public PassToken {
+ public:
+  DeadVariableEliminationToken() = default;
+  ~DeadVariableEliminationToken() override = default;
+
+  const char* name() const override { return "dead-variable-elimination"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<DeadVariableElimination>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // SPIRV_TOOLS_DEAD_VARIABLE_ELIMINATION_H
+#endif  // SOURCE_OPT_DEAD_VARIABLE_ELIMINATION_H

--- a/source/opt/eliminate_dead_constant_pass.h
+++ b/source/opt/eliminate_dead_constant_pass.h
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_ELIMINATE_DEAD_CONSTANT_PASS_H_
-#define LIBSPIRV_OPT_ELIMINATE_DEAD_CONSTANT_PASS_H_
+#ifndef SOURCE_OPT_ELIMINATE_DEAD_CONSTANT_PASS_H_
+#define SOURCE_OPT_ELIMINATE_DEAD_CONSTANT_PASS_H_
 
-#include "ir_context.h"
-#include "module.h"
-#include "pass.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/module.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -25,11 +26,22 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class EliminateDeadConstantPass : public Pass {
  public:
-  const char* name() const override { return "eliminate-dead-const"; }
   Status Process(opt::IRContext*) override;
+};
+
+class EliminateDeadConstantPassToken : public PassToken {
+ public:
+  EliminateDeadConstantPassToken() = default;
+  ~EliminateDeadConstantPassToken() override = default;
+
+  const char* name() const override { return "eliminate-dead-const"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<EliminateDeadConstantPass>();
+  }
 };
 
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_ELIMINATE_DEAD_CONSTANT_PASS_H_
+#endif  // SOURCE_OPT_ELIMINATE_DEAD_CONSTANT_PASS_H_

--- a/source/opt/eliminate_dead_functions_pass.h
+++ b/source/opt/eliminate_dead_functions_pass.h
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_ELIMINATE_DEAD_FUNCTIONS_PASS_H_
-#define LIBSPIRV_OPT_ELIMINATE_DEAD_FUNCTIONS_PASS_H_
+#ifndef SOURCE_OPT_ELIMINATE_DEAD_FUNCTIONS_PASS_H_
+#define SOURCE_OPT_ELIMINATE_DEAD_FUNCTIONS_PASS_H_
 
-#include "def_use_manager.h"
-#include "function.h"
-#include "mem_pass.h"
-#include "module.h"
+#include "source/opt/def_use_manager.h"
+#include "source/opt/function.h"
+#include "source/opt/mem_pass.h"
+#include "source/opt/module.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -26,7 +27,6 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class EliminateDeadFunctionsPass : public MemPass {
  public:
-  const char* name() const override { return "eliminate-dead-functions"; }
   Status Process(opt::IRContext* c) override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
@@ -37,7 +37,19 @@ class EliminateDeadFunctionsPass : public MemPass {
   void EliminateFunction(opt::Function* func);
 };
 
+class EliminateDeadFunctionsPassToken : public PassToken {
+ public:
+  EliminateDeadFunctionsPassToken() = default;
+  ~EliminateDeadFunctionsPassToken() override = default;
+
+  const char* name() const override { return "eliminate-dead-functions"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<EliminateDeadFunctionsPass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_ELIMINATE_DEAD_FUNCTIONS_PASS_H_
+#endif  // SOURCE_OPT_ELIMINATE_DEAD_FUNCTIONS_PASS_H_

--- a/source/opt/flatten_decoration_pass.h
+++ b/source/opt/flatten_decoration_pass.h
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_FLATTEN_DECORATION_PASS_H_
-#define LIBSPIRV_OPT_FLATTEN_DECORATION_PASS_H_
+#ifndef SOURCE_OPT_FLATTEN_DECORATION_PASS_H_
+#define SOURCE_OPT_FLATTEN_DECORATION_PASS_H_
 
-#include "ir_context.h"
-#include "module.h"
-#include "pass.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/module.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -25,11 +26,22 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class FlattenDecorationPass : public Pass {
  public:
-  const char* name() const override { return "flatten-decoration"; }
   Status Process(opt::IRContext*) override;
+};
+
+class FlattenDecorationPassToken : public PassToken {
+ public:
+  FlattenDecorationPassToken() = default;
+  ~FlattenDecorationPassToken() override = default;
+
+  const char* name() const override { return "flatten-decoration"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<FlattenDecorationPass>();
+  }
 };
 
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_FLATTEN_DECORATION_PASS_H_
+#endif  // SOURCE_OPT_FLATTEN_DECORATION_PASS_H_

--- a/source/opt/fold_spec_constant_op_and_composite_pass.h
+++ b/source/opt/fold_spec_constant_op_and_composite_pass.h
@@ -19,12 +19,13 @@
 #include <unordered_map>
 #include <vector>
 
-#include "constants.h"
-#include "def_use_manager.h"
-#include "ir_context.h"
-#include "module.h"
-#include "pass.h"
-#include "type_manager.h"
+#include "source/opt/constants.h"
+#include "source/opt/def_use_manager.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/module.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
+#include "source/opt/type_manager.h"
 
 namespace spvtools {
 namespace opt {
@@ -33,8 +34,6 @@ namespace opt {
 class FoldSpecConstantOpAndCompositePass : public Pass {
  public:
   FoldSpecConstantOpAndCompositePass() = default;
-
-  const char* name() const override { return "fold-spec-const-op-composite"; }
 
   Status Process(opt::IRContext* irContext) override;
 
@@ -85,6 +84,18 @@ class FoldSpecConstantOpAndCompositePass : public Pass {
   //
   // |type| must be a composite type.
   uint32_t GetTypeComponent(uint32_t type, uint32_t element) const;
+};
+
+class FoldSpecConstantOpAndCompositePassToken : public PassToken {
+ public:
+  FoldSpecConstantOpAndCompositePassToken() = default;
+  ~FoldSpecConstantOpAndCompositePassToken() override = default;
+
+  const char* name() const override { return "fold-spec-const-op-composite"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<FoldSpecConstantOpAndCompositePass>();
+  }
 };
 
 }  // namespace opt

--- a/source/opt/freeze_spec_constant_value_pass.h
+++ b/source/opt/freeze_spec_constant_value_pass.h
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_FREEZE_SPEC_CONSTANT_VALUE_PASS_H_
-#define LIBSPIRV_OPT_FREEZE_SPEC_CONSTANT_VALUE_PASS_H_
+#ifndef SOURCE_OPT_FREEZE_SPEC_CONSTANT_VALUE_PASS_H_
+#define SOURCE_OPT_FREEZE_SPEC_CONSTANT_VALUE_PASS_H_
 
-#include "ir_context.h"
-#include "module.h"
-#include "pass.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/module.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -25,11 +26,22 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class FreezeSpecConstantValuePass : public Pass {
  public:
-  const char* name() const override { return "freeze-spec-const"; }
   Status Process(opt::IRContext*) override;
+};
+
+class FreezeSpecConstantValuePassToken : public PassToken {
+ public:
+  FreezeSpecConstantValuePassToken() = default;
+  ~FreezeSpecConstantValuePassToken() override = default;
+
+  const char* name() const override { return "freeze-spec-const"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<FreezeSpecConstantValuePass>();
+  }
 };
 
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_FREEZE_SPEC_CONSTANT_VALUE_PASS_H_
+#endif  // SOURCE_OPT_FREEZE_SPEC_CONSTANT_VALUE_PASS_H_

--- a/source/opt/if_conversion.h
+++ b/source/opt/if_conversion.h
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_IF_CONVERSION_H_
-#define LIBSPIRV_OPT_IF_CONVERSION_H_
+#ifndef SOURCE_OPT_IF_CONVERSION_H_
+#define SOURCE_OPT_IF_CONVERSION_H_
 
-#include "basic_block.h"
-#include "ir_builder.h"
-#include "pass.h"
-#include "types.h"
+#include "source/opt/basic_block.h"
+#include "source/opt/ir_builder.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
+#include "source/opt/types.h"
 
 namespace spvtools {
 namespace opt {
@@ -26,7 +27,6 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class IfConversion : public Pass {
  public:
-  const char* name() const override { return "if-conversion"; }
   Status Process(opt::IRContext* context) override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
@@ -86,7 +86,19 @@ class IfConversion : public Pass {
                            DominatorAnalysis* dominators);
 };
 
+class IfConversionToken : public PassToken {
+ public:
+  IfConversionToken() = default;
+  ~IfConversionToken() override = default;
+
+  const char* name() const override { return "if-conversion"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<IfConversion>();
+  }
+};
+
 }  //  namespace opt
 }  //  namespace spvtools
 
-#endif  //  LIBSPIRV_OPT_IF_CONVERSION_H_
+#endif  // SOURCE_OPT_IF_CONVERSION_H_

--- a/source/opt/inline_exhaustive_pass.h
+++ b/source/opt/inline_exhaustive_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_INLINE_EXHAUSTIVE_PASS_H_
-#define LIBSPIRV_OPT_INLINE_EXHAUSTIVE_PASS_H_
+#ifndef SOURCE_OPT_INLINE_EXHAUSTIVE_PASS_H_
+#define SOURCE_OPT_INLINE_EXHAUSTIVE_PASS_H_
 
 #include <algorithm>
 #include <list>
@@ -23,9 +23,10 @@
 #include <unordered_map>
 #include <vector>
 
-#include "def_use_manager.h"
-#include "inline_pass.h"
-#include "module.h"
+#include "source/opt/def_use_manager.h"
+#include "source/opt/inline_pass.h"
+#include "source/opt/module.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -34,9 +35,8 @@ namespace opt {
 class InlineExhaustivePass : public InlinePass {
  public:
   InlineExhaustivePass();
-  Status Process(opt::IRContext* c) override;
 
-  const char* name() const override { return "inline-entry-points-exhaustive"; }
+  Status Process(opt::IRContext* c) override;
 
  private:
   // Exhaustively inline all function calls in func as well as in
@@ -47,7 +47,19 @@ class InlineExhaustivePass : public InlinePass {
   Pass::Status ProcessImpl();
 };
 
+class InlineExhaustivePassToken : public PassToken {
+ public:
+  InlineExhaustivePassToken() = default;
+  ~InlineExhaustivePassToken() override = default;
+
+  const char* name() const override { return "inline-entry-points-exhaustive"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<InlineExhaustivePass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_INLINE_EXHAUSTIVE_PASS_H_
+#endif  // SOURCE_OPT_INLINE_EXHAUSTIVE_PASS_H_

--- a/source/opt/inline_opaque_pass.h
+++ b/source/opt/inline_opaque_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_INLINE_OPAQUE_PASS_H_
-#define LIBSPIRV_OPT_INLINE_OPAQUE_PASS_H_
+#ifndef SOURCE_OPT_INLINE_OPAQUE_PASS_H_
+#define SOURCE_OPT_INLINE_OPAQUE_PASS_H_
 
 #include <algorithm>
 #include <list>
@@ -23,9 +23,10 @@
 #include <unordered_map>
 #include <vector>
 
-#include "def_use_manager.h"
-#include "inline_pass.h"
-#include "module.h"
+#include "source/opt/def_use_manager.h"
+#include "source/opt/inline_pass.h"
+#include "source/opt/module.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -34,9 +35,8 @@ namespace opt {
 class InlineOpaquePass : public InlinePass {
  public:
   InlineOpaquePass();
-  Status Process(opt::IRContext* c) override;
 
-  const char* name() const override { return "inline-entry-points-opaque"; }
+  Status Process(opt::IRContext* c) override;
 
  private:
   // Return true if |typeId| is or contains opaque type
@@ -54,7 +54,19 @@ class InlineOpaquePass : public InlinePass {
   Pass::Status ProcessImpl();
 };
 
+class InlineOpaquePassToken : public PassToken {
+ public:
+  InlineOpaquePassToken() = default;
+  ~InlineOpaquePassToken() override = default;
+
+  const char* name() const override { return "inline-entry-points-opaque"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<InlineOpaquePass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_INLINE_OPAQUE_PASS_H_
+#endif  // SOURCE_OPT_INLINE_OPAQUE_PASS_H_

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -38,10 +38,10 @@ class InlinePass : public Pass {
   using GetBlocksFunction =
       std::function<std::vector<opt::BasicBlock*>*(const opt::BasicBlock*)>;
 
-  InlinePass();
   virtual ~InlinePass() = default;
 
  protected:
+  InlinePass();
 
   // Add pointer to type to module and return resultId.
   uint32_t AddPointerToType(uint32_t type_id, SpvStorageClass storage_class);

--- a/source/opt/licm_pass.h
+++ b/source/opt/licm_pass.h
@@ -15,21 +15,21 @@
 #ifndef SOURCE_OPT_LICM_PASS_H_
 #define SOURCE_OPT_LICM_PASS_H_
 
-#include "opt/basic_block.h"
-#include "opt/instruction.h"
-#include "opt/loop_descriptor.h"
-#include "opt/pass.h"
-
 #include <queue>
+
+#include "source/opt/basic_block.h"
+#include "source/opt/instruction.h"
+#include "source/opt/loop_descriptor.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
 
 class LICMPass : public Pass {
  public:
-  LICMPass() {}
+  LICMPass() = default;
 
-  const char* name() const override { return "loop-invariant-code-motion"; }
   Status Process(opt::IRContext*) override;
 
  private:
@@ -60,6 +60,18 @@ class LICMPass : public Pass {
   // Move the instruction to the given BasicBlock
   // This method will update the instruction to block mapping for the context
   void HoistInstruction(opt::Loop* loop, opt::Instruction* inst);
+};
+
+class LICMPassToken : public PassToken {
+ public:
+  LICMPassToken() = default;
+  ~LICMPassToken() override = default;
+
+  const char* name() const override { return "loop-invariant-code-motion"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<LICMPass>();
+  }
 };
 
 }  // namespace opt

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_LOCAL_ACCESS_CHAIN_CONVERT_PASS_H_
-#define LIBSPIRV_OPT_LOCAL_ACCESS_CHAIN_CONVERT_PASS_H_
+#ifndef SOURCE_OPT_LOCAL_ACCESS_CHAIN_CONVERT_PASS_H_
+#define SOURCE_OPT_LOCAL_ACCESS_CHAIN_CONVERT_PASS_H_
 
 #include <algorithm>
 #include <map>
@@ -24,10 +24,11 @@
 #include <unordered_set>
 #include <utility>
 
-#include "basic_block.h"
-#include "def_use_manager.h"
-#include "mem_pass.h"
-#include "module.h"
+#include "source/opt/basic_block.h"
+#include "source/opt/def_use_manager.h"
+#include "source/opt/mem_pass.h"
+#include "source/opt/module.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -36,7 +37,7 @@ namespace opt {
 class LocalAccessChainConvertPass : public MemPass {
  public:
   LocalAccessChainConvertPass();
-  const char* name() const override { return "convert-local-access-chains"; }
+
   Status Process(opt::IRContext* c) override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
@@ -120,7 +121,19 @@ class LocalAccessChainConvertPass : public MemPass {
   std::unordered_set<std::string> extensions_whitelist_;
 };
 
+class LocalAccessChainConvertPassToken : public PassToken {
+ public:
+  LocalAccessChainConvertPassToken() = default;
+  ~LocalAccessChainConvertPassToken() override = default;
+
+  const char* name() const override { return "convert-local-access-chains"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<LocalAccessChainConvertPass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_LOCAL_ACCESS_CHAIN_CONVERT_PASS_H_
+#endif  // SOURCE_OPT_LOCAL_ACCESS_CHAIN_CONVERT_PASS_H_

--- a/source/opt/local_redundancy_elimination.h
+++ b/source/opt/local_redundancy_elimination.h
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_LOCAL_REDUNDANCY_ELIMINATION_H_
-#define LIBSPIRV_OPT_LOCAL_REDUNDANCY_ELIMINATION_H_
+#ifndef SOURCE_OPT_LOCAL_REDUNDANCY_ELIMINATION_H_
+#define SOURCE_OPT_LOCAL_REDUNDANCY_ELIMINATION_H_
 
-#include "ir_context.h"
-#include "pass.h"
-#include "value_number_table.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
+#include "source/opt/value_number_table.h"
 
 namespace spvtools {
 namespace opt {
@@ -31,7 +32,6 @@ namespace opt {
 // current instruction is deleted.
 class LocalRedundancyEliminationPass : public Pass {
  public:
-  const char* name() const override { return "local-redundancy-elimination"; }
   Status Process(opt::IRContext*) override;
   virtual opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse |
@@ -59,7 +59,19 @@ class LocalRedundancyEliminationPass : public Pass {
                                  std::map<uint32_t, uint32_t>* value_to_ids);
 };
 
+class LocalRedundancyEliminationPassToken : public PassToken {
+ public:
+  LocalRedundancyEliminationPassToken() = default;
+  ~LocalRedundancyEliminationPassToken() override = default;
+
+  const char* name() const override { return "local-redundancy-elimination"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<LocalRedundancyEliminationPass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_LOCAL_REDUNDANCY_ELIMINATION_H_
+#endif  // SOURCE_OPT_LOCAL_REDUNDANCY_ELIMINATION_H_

--- a/source/opt/local_single_block_elim_pass.h
+++ b/source/opt/local_single_block_elim_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_LOCAL_SINGLE_BLOCK_ELIM_PASS_H_
-#define LIBSPIRV_OPT_LOCAL_SINGLE_BLOCK_ELIM_PASS_H_
+#ifndef SOURCE_OPT_LOCAL_SINGLE_BLOCK_ELIM_PASS_H_
+#define SOURCE_OPT_LOCAL_SINGLE_BLOCK_ELIM_PASS_H_
 
 #include <algorithm>
 #include <map>
@@ -24,10 +24,11 @@
 #include <unordered_set>
 #include <utility>
 
-#include "basic_block.h"
-#include "def_use_manager.h"
-#include "mem_pass.h"
-#include "module.h"
+#include "source/opt/basic_block.h"
+#include "source/opt/def_use_manager.h"
+#include "source/opt/mem_pass.h"
+#include "source/opt/module.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -36,7 +37,7 @@ namespace opt {
 class LocalSingleBlockLoadStoreElimPass : public MemPass {
  public:
   LocalSingleBlockLoadStoreElimPass();
-  const char* name() const override { return "eliminate-local-single-block"; }
+
   Status Process(opt::IRContext* c) override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
@@ -98,7 +99,19 @@ class LocalSingleBlockLoadStoreElimPass : public MemPass {
   std::unordered_set<uint32_t> supported_ref_ptrs_;
 };
 
+class LocalSingleBlockLoadStoreElimPassToken : public PassToken {
+ public:
+  LocalSingleBlockLoadStoreElimPassToken() = default;
+  ~LocalSingleBlockLoadStoreElimPassToken() override = default;
+
+  const char* name() const override { return "eliminate-local-single-block"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<LocalSingleBlockLoadStoreElimPass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_LOCAL_SINGLE_BLOCK_ELIM_PASS_H_
+#endif  // SOURCE_OPT_LOCAL_SINGLE_BLOCK_ELIM_PASS_H_

--- a/source/opt/local_single_store_elim_pass.h
+++ b/source/opt/local_single_store_elim_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_LOCAL_SINGLE_STORE_ELIM_PASS_H_
-#define LIBSPIRV_OPT_LOCAL_SINGLE_STORE_ELIM_PASS_H_
+#ifndef SOURCE_OPT_LOCAL_SINGLE_STORE_ELIM_PASS_H_
+#define SOURCE_OPT_LOCAL_SINGLE_STORE_ELIM_PASS_H_
 
 #include <algorithm>
 #include <map>
@@ -24,10 +24,11 @@
 #include <unordered_set>
 #include <utility>
 
-#include "basic_block.h"
-#include "def_use_manager.h"
-#include "mem_pass.h"
-#include "module.h"
+#include "source/opt/basic_block.h"
+#include "source/opt/def_use_manager.h"
+#include "source/opt/mem_pass.h"
+#include "source/opt/module.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -38,7 +39,7 @@ class LocalSingleStoreElimPass : public Pass {
 
  public:
   LocalSingleStoreElimPass();
-  const char* name() const override { return "eliminate-local-single-store"; }
+
   Status Process(opt::IRContext* irContext) override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
@@ -95,7 +96,19 @@ class LocalSingleStoreElimPass : public Pass {
   std::unordered_set<std::string> extensions_whitelist_;
 };
 
+class LocalSingleStoreElimPassToken : public PassToken {
+ public:
+  LocalSingleStoreElimPassToken() = default;
+  ~LocalSingleStoreElimPassToken() override = default;
+
+  const char* name() const override { return "eliminate-local-single-store"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<LocalSingleStoreElimPass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_LOCAL_SINGLE_STORE_ELIM_PASS_H_
+#endif  // SOURCE_OPT_LOCAL_SINGLE_STORE_ELIM_PASS_H_

--- a/source/opt/local_ssa_elim_pass.h
+++ b/source/opt/local_ssa_elim_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_LOCAL_SSA_ELIM_PASS_H_
-#define LIBSPIRV_OPT_LOCAL_SSA_ELIM_PASS_H_
+#ifndef SOURCE_OPT_LOCAL_SSA_ELIM_PASS_H_
+#define SOURCE_OPT_LOCAL_SSA_ELIM_PASS_H_
 
 #include <algorithm>
 #include <map>
@@ -24,10 +24,11 @@
 #include <unordered_set>
 #include <utility>
 
-#include "basic_block.h"
-#include "def_use_manager.h"
-#include "mem_pass.h"
-#include "module.h"
+#include "source/opt/basic_block.h"
+#include "source/opt/def_use_manager.h"
+#include "source/opt/mem_pass.h"
+#include "source/opt/module.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -41,7 +42,7 @@ class LocalMultiStoreElimPass : public MemPass {
       std::function<std::vector<opt::BasicBlock*>*(const opt::BasicBlock*)>;
 
   LocalMultiStoreElimPass();
-  const char* name() const override { return "eliminate-local-multi-store"; }
+
   Status Process(opt::IRContext* c) override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
@@ -63,7 +64,19 @@ class LocalMultiStoreElimPass : public MemPass {
   std::unordered_set<std::string> extensions_whitelist_;
 };
 
+class LocalMultiStoreElimPassToken : public PassToken {
+ public:
+  LocalMultiStoreElimPassToken() = default;
+  ~LocalMultiStoreElimPassToken() override = default;
+
+  const char* name() const override { return "eliminate-local-multi-store"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<LocalMultiStoreElimPass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_LOCAL_SSA_ELIM_PASS_H_
+#endif  // SOURCE_OPT_LOCAL_SSA_ELIM_PASS_H_

--- a/source/opt/loop_fission.cpp
+++ b/source/opt/loop_fission.cpp
@@ -414,9 +414,7 @@ opt::Loop* LoopFissionImpl::SplitLoop() {
   return cloned_loop;
 }
 
-LoopFissionPass::LoopFissionPass(const size_t register_threshold_to_split,
-                                 bool split_multiple_times)
-    : split_multiple_times_(split_multiple_times) {
+LoopFissionPass::LoopFissionPass(const size_t register_threshold_to_split) {
   // Split if the number of registers in the loop exceeds
   // |register_threshold_to_split|.
   split_criteria_ =

--- a/source/opt/loop_fission.cpp
+++ b/source/opt/loop_fission.cpp
@@ -414,7 +414,9 @@ opt::Loop* LoopFissionImpl::SplitLoop() {
   return cloned_loop;
 }
 
-LoopFissionPass::LoopFissionPass(const size_t register_threshold_to_split) {
+LoopFissionPass::LoopFissionPass(const size_t register_threshold_to_split,
+                                 bool split_multiple_times)
+    : split_multiple_times_(split_multiple_times) {
   // Split if the number of registers in the loop exceeds
   // |register_threshold_to_split|.
   split_criteria_ =

--- a/source/opt/loop_fission.h
+++ b/source/opt/loop_fission.h
@@ -48,11 +48,13 @@ class LoopFissionPass : public Pass {
   // |register_threshold_to_split|. |split_multiple_times| flag determines
   // whether or not the pass should split loops after already splitting them
   // once.
-  LoopFissionPass(size_t register_threshold_to_split);
+  LoopFissionPass(size_t register_threshold_to_split,
+                  bool split_multiple_times = true);
 
   // Split loops whose register pressure meets the criteria of |functor|.
-  LoopFissionPass(FissionCriteriaFunction functor)
-      : split_criteria_(functor), split_multiple_times_(false) {}
+  LoopFissionPass(FissionCriteriaFunction functor,
+                  bool split_multiple_times = true)
+      : split_criteria_(functor), split_multiple_times_(split_multiple_times) {}
 
   Pass::Status Process(opt::IRContext* context) override;
 
@@ -66,23 +68,27 @@ class LoopFissionPass : public Pass {
 
   // Flag designating whether or not we should also split the result of
   // previously split loops if they meet the register presure criteria.
-  bool split_multiple_times_ = true;
+  bool split_multiple_times_;
 };
 
 class LoopFissionPassToken : public PassToken {
  public:
-  LoopFissionPassToken(size_t register_threshold_to_split)
-      : register_threshold_to_split_(register_threshold_to_split) {}
+  LoopFissionPassToken(size_t register_threshold_to_split,
+                       bool split_multiple_times = true)
+      : register_threshold_to_split_(register_threshold_to_split),
+        split_multiple_times_(split_multiple_times) {}
   ~LoopFissionPassToken() override = default;
 
   const char* name() const override { return "Loop Fission"; }
 
   std::unique_ptr<Pass> CreatePass() const override {
-    return MakeUnique<LoopFissionPass>(register_threshold_to_split_);
+    return MakeUnique<LoopFissionPass>(register_threshold_to_split_,
+                                       split_multiple_times_);
   }
 
  private:
   size_t register_threshold_to_split_;
+  bool split_multiple_times_;
 };
 
 }  // namespace opt

--- a/source/opt/loop_fusion.h
+++ b/source/opt/loop_fusion.h
@@ -19,10 +19,10 @@
 #include <set>
 #include <vector>
 
-#include "opt/ir_context.h"
-#include "opt/loop_descriptor.h"
-#include "opt/loop_utils.h"
-#include "opt/scalar_analysis.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/loop_descriptor.h"
+#include "source/opt/loop_utils.h"
+#include "source/opt/scalar_analysis.h"
 
 namespace spvtools {
 namespace opt {

--- a/source/opt/loop_fusion_pass.h
+++ b/source/opt/loop_fusion_pass.h
@@ -15,7 +15,8 @@
 #ifndef SOURCE_OPT_LOOP_FUSION_PASS_H_
 #define SOURCE_OPT_LOOP_FUSION_PASS_H_
 
-#include "opt/pass.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -29,8 +30,6 @@ class LoopFusionPass : public Pass {
   explicit LoopFusionPass(size_t max_registers_per_loop)
       : Pass(), max_registers_per_loop_(max_registers_per_loop) {}
 
-  const char* name() const override { return "loop-fusion"; }
-
   // Processes the given |module|. Returns Status::Failure if errors occur when
   // processing. Returns the corresponding Status::Success if processing is
   // succesful to indicate whether changes have been made to the modue.
@@ -42,6 +41,23 @@ class LoopFusionPass : public Pass {
   bool ProcessFunction(opt::Function* function);
 
   // The maximum number of registers a fused loop is allowed to use.
+  size_t max_registers_per_loop_;
+};
+
+class LoopFusionPassToken : public PassToken {
+ public:
+  LoopFusionPassToken(size_t max_registers_per_loop)
+      : max_registers_per_loop_(max_registers_per_loop) {}
+
+  ~LoopFusionPassToken() override = default;
+
+  const char* name() const override { return "loop-fusion"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<LoopFusionPass>(max_registers_per_loop_);
+  }
+
+ private:
   size_t max_registers_per_loop_;
 };
 

--- a/source/opt/loop_peeling.h
+++ b/source/opt/loop_peeling.h
@@ -246,9 +246,7 @@ class LoopPeelingPass : public Pass {
         peeled_loops_;
   };
 
-  LoopPeelingPass(LoopPeelingStats* stats) : stats_(stats) {}
-
-  LoopPeelingPass() = default;
+  LoopPeelingPass(LoopPeelingStats* stats = nullptr) : stats_(stats) {}
 
   // Sets the loop peeling growth threshold. If the code size increase is above
   // |code_grow_threshold|, the loop will not be peeled. The code size is

--- a/source/opt/loop_peeling.h
+++ b/source/opt/loop_peeling.h
@@ -23,11 +23,12 @@
 #include <utility>
 #include <vector>
 
-#include "opt/ir_context.h"
-#include "opt/loop_descriptor.h"
-#include "opt/loop_utils.h"
-#include "opt/pass.h"
-#include "opt/scalar_analysis.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/loop_descriptor.h"
+#include "source/opt/loop_utils.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
+#include "source/opt/scalar_analysis.h"
 
 namespace spvtools {
 namespace opt {
@@ -245,7 +246,9 @@ class LoopPeelingPass : public Pass {
         peeled_loops_;
   };
 
-  LoopPeelingPass(LoopPeelingStats* stats = nullptr) : stats_(stats) {}
+  LoopPeelingPass(LoopPeelingStats* stats) : stats_(stats) {}
+
+  LoopPeelingPass() = default;
 
   // Sets the loop peeling growth threshold. If the code size increase is above
   // |code_grow_threshold|, the loop will not be peeled. The code size is
@@ -256,8 +259,6 @@ class LoopPeelingPass : public Pass {
 
   // Returns the loop peeling code growth threshold.
   static size_t GetLoopPeelingThreshold() { return code_grow_threshold_; }
-
-  const char* name() const override { return "loop-peeling"; }
 
   // Processes the given |module|. Returns Status::Failure if errors occur when
   // processing. Returns the corresponding Status::Success if processing is
@@ -329,6 +330,18 @@ class LoopPeelingPass : public Pass {
 
   static size_t code_grow_threshold_;
   LoopPeelingStats* stats_;
+};
+
+class LoopPeelingPassToken : public PassToken {
+ public:
+  LoopPeelingPassToken() = default;
+  ~LoopPeelingPassToken() override = default;
+
+  const char* name() const override { return "loop-peeling"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<LoopPeelingPass>();
+  }
 };
 
 }  // namespace opt

--- a/source/opt/loop_unroller.h
+++ b/source/opt/loop_unroller.h
@@ -14,23 +14,40 @@
 
 #ifndef SOURCE_OPT_LOOP_UNROLLER_H_
 #define SOURCE_OPT_LOOP_UNROLLER_H_
-#include "opt/pass.h"
+
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
 
 class LoopUnroller : public Pass {
  public:
-  LoopUnroller() : Pass(), fully_unroll_(true), unroll_factor_(0) {}
   LoopUnroller(bool fully_unroll, int unroll_factor)
       : Pass(), fully_unroll_(fully_unroll), unroll_factor_(unroll_factor) {}
-
-  const char* name() const override { return "Loop unroller"; }
 
   Status Process(opt::IRContext* context) override;
 
  private:
   opt::IRContext* context_;
+  bool fully_unroll_;
+  int unroll_factor_;
+};
+
+class LoopUnrollerToken : public PassToken {
+ public:
+  LoopUnrollerToken(bool fully_unroll, int unroll_factor)
+    : fully_unroll_(fully_unroll), unroll_factor_(unroll_factor) {}
+
+  ~LoopUnrollerToken() override = default;
+
+  const char* name() const override { return "Loop unroller"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<LoopUnroller>(fully_unroll_, unroll_factor_);
+  }
+
+ private:
   bool fully_unroll_;
   int unroll_factor_;
 };

--- a/source/opt/loop_unroller.h
+++ b/source/opt/loop_unroller.h
@@ -36,8 +36,9 @@ class LoopUnroller : public Pass {
 
 class LoopUnrollerToken : public PassToken {
  public:
+  LoopUnrollerToken() : fully_unroll_(true), unroll_factor_(0) {}
   LoopUnrollerToken(bool fully_unroll, int unroll_factor)
-    : fully_unroll_(fully_unroll), unroll_factor_(unroll_factor) {}
+      : fully_unroll_(fully_unroll), unroll_factor_(unroll_factor) {}
 
   ~LoopUnrollerToken() override = default;
 

--- a/source/opt/loop_unswitch_pass.h
+++ b/source/opt/loop_unswitch_pass.h
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_LOOP_UNSWITCH_PASS_H_
-#define LIBSPIRV_OPT_LOOP_UNSWITCH_PASS_H_
+#ifndef SOURCE_OPT_LOOP_UNSWITCH_PASS_H_
+#define SOURCE_OPT_LOOP_UNSWITCH_PASS_H_
 
-#include "opt/loop_descriptor.h"
-#include "opt/pass.h"
+#include "source/opt/loop_descriptor.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -26,8 +27,6 @@ namespace opt {
 // constant within the loop and clones the loop for each branch.
 class LoopUnswitchPass : public Pass {
  public:
-  const char* name() const override { return "loop-unswitch"; }
-
   // Processes the given |module|. Returns Status::Failure if errors occur when
   // processing. Returns the corresponding Status::Success if processing is
   // succesful to indicate whether changes have been made to the modue.
@@ -37,7 +36,19 @@ class LoopUnswitchPass : public Pass {
   bool ProcessFunction(opt::Function* f);
 };
 
+class LoopUnswitchPassToken : public PassToken {
+ public:
+  LoopUnswitchPassToken() = default;
+  ~LoopUnswitchPassToken() override = default;
+
+  const char* name() const override { return "loop-unswitch"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<LoopUnswitchPass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // !LIBSPIRV_OPT_LOOP_UNSWITCH_PASS_H_
+#endif  // SOURCE_OPT_LOOP_UNSWITCH_PASS_H_

--- a/source/opt/mem_pass.h
+++ b/source/opt/mem_pass.h
@@ -38,7 +38,6 @@ namespace opt {
 // utility functions and supporting state.
 class MemPass : public Pass {
  public:
-  MemPass();
   virtual ~MemPass() = default;
 
   // Returns an undef value for the given |var_id|'s type.
@@ -69,6 +68,8 @@ class MemPass : public Pass {
   void CollectTargetVars(opt::Function* func);
 
  protected:
+  MemPass();
+
   // Returns true if |typeInst| is a scalar type
   // or a vector or matrix
   bool IsBaseTargetType(const opt::Instruction* typeInst) const;

--- a/source/opt/merge_return_pass.h
+++ b/source/opt/merge_return_pass.h
@@ -12,15 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_MERGE_RETURN_PASS_H_
-#define LIBSPIRV_OPT_MERGE_RETURN_PASS_H_
-
-#include "basic_block.h"
-#include "function.h"
-#include "mem_pass.h"
+#ifndef SOURCE_OPT_MERGE_RETURN_PASS_H_
+#define SOURCE_OPT_MERGE_RETURN_PASS_H_
 
 #include <unordered_set>
 #include <vector>
+
+#include "source/opt/basic_block.h"
+#include "source/opt/function.h"
+#include "source/opt/mem_pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -102,7 +103,6 @@ class MergeReturnPass : public MemPass {
         constant_true_(nullptr),
         final_return_block_(nullptr) {}
 
-  const char* name() const override { return "merge-return"; }
   Status Process(opt::IRContext*) override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
@@ -301,7 +301,19 @@ class MergeReturnPass : public MemPass {
   std::unordered_map<opt::BasicBlock*, opt::BasicBlock*> new_merge_nodes_;
 };
 
+class MergeReturnPassToken : public PassToken {
+ public:
+  MergeReturnPassToken() = default;
+  ~MergeReturnPassToken() override = default;
+
+  const char* name() const override { return "merge-return"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<MergeReturnPass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_MERGE_RETURN_PASS_H_
+#endif  // SOURCE_OPT_MERGE_RETURN_PASS_H_

--- a/source/opt/null_pass.h
+++ b/source/opt/null_pass.h
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_NULL_PASS_H_
-#define LIBSPIRV_OPT_NULL_PASS_H_
+#ifndef SOURCE_OPT_NULL_PASS_H_
+#define SOURCE_OPT_NULL_PASS_H_
 
-#include "module.h"
-#include "pass.h"
+#include "source/opt/module.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -24,13 +25,24 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class NullPass : public Pass {
  public:
-  const char* name() const override { return "null"; }
   Status Process(opt::IRContext*) override {
     return Status::SuccessWithoutChange;
+  }
+};
+
+class NullPassToken : public PassToken {
+ public:
+  NullPassToken() = default;
+  ~NullPassToken() override = default;
+
+  const char* name() const override { return "null"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<NullPass>();
   }
 };
 
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_NULL_PASS_H_
+#endif  // SOURCE_OPT_NULL_PASS_H_

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -24,17 +24,17 @@
 namespace spvtools {
 
 struct Optimizer::PassToken::Impl {
-  Impl(std::unique_ptr<opt::Pass> p) : pass(std::move(p)) {}
+  Impl(std::unique_ptr<opt::PassToken> p) : pass_token(std::move(p)) {}
 
-  std::unique_ptr<opt::Pass> pass;  // Internal implementation pass.
+  std::unique_ptr<opt::PassToken> pass_token;  // Internal implementation token.
 };
 
 Optimizer::PassToken::PassToken(
     std::unique_ptr<Optimizer::PassToken::Impl> impl)
     : impl_(std::move(impl)) {}
 
-Optimizer::PassToken::PassToken(std::unique_ptr<opt::Pass>&& pass)
-    : impl_(MakeUnique<Optimizer::PassToken::Impl>(std::move(pass))) {}
+Optimizer::PassToken::PassToken(std::unique_ptr<opt::PassToken>&& pass_token)
+    : impl_(MakeUnique<Optimizer::PassToken::Impl>(std::move(pass_token))) {}
 
 Optimizer::PassToken::PassToken(PassToken&& that)
     : impl_(std::move(that.impl_)) {}
@@ -44,7 +44,7 @@ Optimizer::PassToken& Optimizer::PassToken::operator=(PassToken&& that) {
   return *this;
 }
 
-Optimizer::PassToken::~PassToken() {}
+Optimizer::PassToken::~PassToken() = default;
 
 struct Optimizer::Impl {
   explicit Impl(spv_target_env env) : target_env(env), pass_manager() {}
@@ -55,20 +55,15 @@ struct Optimizer::Impl {
 
 Optimizer::Optimizer(spv_target_env env) : impl_(new Impl(env)) {}
 
-Optimizer::~Optimizer() {}
+Optimizer::~Optimizer() = default;
 
 void Optimizer::SetMessageConsumer(MessageConsumer c) {
-  // All passes' message consumer needs to be updated.
-  for (uint32_t i = 0; i < impl_->pass_manager.NumPasses(); ++i) {
-    impl_->pass_manager.GetPass(i)->SetMessageConsumer(c);
-  }
   impl_->pass_manager.SetMessageConsumer(std::move(c));
 }
 
 Optimizer& Optimizer::RegisterPass(PassToken&& p) {
   // Change to use the pass manager's consumer.
-  p.impl_->pass->SetMessageConsumer(impl_->pass_manager.consumer());
-  impl_->pass_manager.AddPass(std::move(p.impl_->pass));
+  impl_->pass_manager.AddPassToken(std::move(p.impl_->pass_token));
   return *this;
 }
 
@@ -231,249 +226,249 @@ Optimizer& Optimizer::SetTimeReport(std::ostream* out) {
   return *this;
 }
 
+std::vector<const char*> Optimizer::GetPassNames() const {
+  std::vector<const char*> v;
+  for (uint32_t i = 0; i < impl_->pass_manager.NumPasses(); i++) {
+    v.push_back(impl_->pass_manager.GetPassToken(i)->name());
+  }
+  return v;
+}
+
 Optimizer::PassToken CreateNullPass() {
-  return MakeUnique<Optimizer::PassToken::Impl>(MakeUnique<opt::NullPass>());
+  return MakeUnique<Optimizer::PassToken::Impl>(MakeUnique<opt::NullPassToken>());
 }
 
 Optimizer::PassToken CreateStripDebugInfoPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::StripDebugInfoPass>());
+      MakeUnique<opt::StripDebugInfoPassToken>());
 }
 
 Optimizer::PassToken CreateStripReflectInfoPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::StripReflectInfoPass>());
+      MakeUnique<opt::StripReflectInfoPassToken>());
 }
 
 Optimizer::PassToken CreateEliminateDeadFunctionsPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::EliminateDeadFunctionsPass>());
+      MakeUnique<opt::EliminateDeadFunctionsPassToken>());
 }
 
 Optimizer::PassToken CreateSetSpecConstantDefaultValuePass(
     const std::unordered_map<uint32_t, std::string>& id_value_map) {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::SetSpecConstantDefaultValuePass>(id_value_map));
+      MakeUnique<opt::SetSpecConstantDefaultValuePassToken>(id_value_map));
 }
 
 Optimizer::PassToken CreateSetSpecConstantDefaultValuePass(
     const std::unordered_map<uint32_t, std::vector<uint32_t>>& id_value_map) {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::SetSpecConstantDefaultValuePass>(id_value_map));
+      MakeUnique<opt::SetSpecConstantDefaultValuePassToken>(id_value_map));
 }
 
 Optimizer::PassToken CreateFlattenDecorationPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::FlattenDecorationPass>());
+      MakeUnique<opt::FlattenDecorationPassToken>());
 }
 
 Optimizer::PassToken CreateFreezeSpecConstantValuePass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::FreezeSpecConstantValuePass>());
+      MakeUnique<opt::FreezeSpecConstantValuePassToken>());
 }
 
 Optimizer::PassToken CreateFoldSpecConstantOpAndCompositePass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::FoldSpecConstantOpAndCompositePass>());
+      MakeUnique<opt::FoldSpecConstantOpAndCompositePassToken>());
 }
 
 Optimizer::PassToken CreateUnifyConstantPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::UnifyConstantPass>());
+      MakeUnique<opt::UnifyConstantPassToken>());
 }
 
 Optimizer::PassToken CreateEliminateDeadConstantPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::EliminateDeadConstantPass>());
+      MakeUnique<opt::EliminateDeadConstantPassToken>());
 }
 
 Optimizer::PassToken CreateDeadVariableEliminationPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::DeadVariableElimination>());
+      MakeUnique<opt::DeadVariableEliminationToken>());
 }
 
 Optimizer::PassToken CreateStrengthReductionPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::StrengthReductionPass>());
+      MakeUnique<opt::StrengthReductionPassToken>());
 }
 
 Optimizer::PassToken CreateBlockMergePass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::BlockMergePass>());
+      MakeUnique<opt::BlockMergePassToken>());
 }
 
 Optimizer::PassToken CreateInlineExhaustivePass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::InlineExhaustivePass>());
+      MakeUnique<opt::InlineExhaustivePassToken>());
 }
 
 Optimizer::PassToken CreateInlineOpaquePass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::InlineOpaquePass>());
+      MakeUnique<opt::InlineOpaquePassToken>());
 }
 
 Optimizer::PassToken CreateLocalAccessChainConvertPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::LocalAccessChainConvertPass>());
+      MakeUnique<opt::LocalAccessChainConvertPassToken>());
 }
 
 Optimizer::PassToken CreateLocalSingleBlockLoadStoreElimPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::LocalSingleBlockLoadStoreElimPass>());
+      MakeUnique<opt::LocalSingleBlockLoadStoreElimPassToken>());
 }
 
 Optimizer::PassToken CreateLocalSingleStoreElimPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::LocalSingleStoreElimPass>());
+      MakeUnique<opt::LocalSingleStoreElimPassToken>());
 }
 
 Optimizer::PassToken CreateInsertExtractElimPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::SimplificationPass>());
+      MakeUnique<opt::SimplificationPassToken>());
 }
 
 Optimizer::PassToken CreateDeadInsertElimPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::DeadInsertElimPass>());
+      MakeUnique<opt::DeadInsertElimPassToken>());
 }
 
 Optimizer::PassToken CreateDeadBranchElimPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::DeadBranchElimPass>());
+      MakeUnique<opt::DeadBranchElimPassToken>());
 }
 
 Optimizer::PassToken CreateLocalMultiStoreElimPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::LocalMultiStoreElimPass>());
+      MakeUnique<opt::LocalMultiStoreElimPassToken>());
 }
 
 Optimizer::PassToken CreateAggressiveDCEPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::AggressiveDCEPass>());
+      MakeUnique<opt::AggressiveDCEPassToken>());
 }
 
 Optimizer::PassToken CreateCommonUniformElimPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::CommonUniformElimPass>());
+      MakeUnique<opt::CommonUniformElimPassToken>());
 }
 
 Optimizer::PassToken CreateCompactIdsPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::CompactIdsPass>());
+      MakeUnique<opt::CompactIdsPassToken>());
 }
 
 Optimizer::PassToken CreateMergeReturnPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::MergeReturnPass>());
-}
-
-std::vector<const char*> Optimizer::GetPassNames() const {
-  std::vector<const char*> v;
-  for (uint32_t i = 0; i < impl_->pass_manager.NumPasses(); i++) {
-    v.push_back(impl_->pass_manager.GetPass(i)->name());
-  }
-  return v;
+      MakeUnique<opt::MergeReturnPassToken>());
 }
 
 Optimizer::PassToken CreateCFGCleanupPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::CFGCleanupPass>());
+      MakeUnique<opt::CFGCleanupPassToken>());
 }
 
 Optimizer::PassToken CreateLocalRedundancyEliminationPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::LocalRedundancyEliminationPass>());
+      MakeUnique<opt::LocalRedundancyEliminationPassToken>());
 }
 
 Optimizer::PassToken CreateLoopFissionPass(size_t threshold) {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::LoopFissionPass>(threshold));
+      MakeUnique<opt::LoopFissionPassToken>(threshold));
 }
 
 Optimizer::PassToken CreateLoopFusionPass(size_t max_registers_per_loop) {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::LoopFusionPass>(max_registers_per_loop));
+      MakeUnique<opt::LoopFusionPassToken>(max_registers_per_loop));
 }
 
 Optimizer::PassToken CreateLoopInvariantCodeMotionPass() {
-  return MakeUnique<Optimizer::PassToken::Impl>(MakeUnique<opt::LICMPass>());
+  return MakeUnique<Optimizer::PassToken::Impl>(MakeUnique<opt::LICMPassToken>());
 }
 
 Optimizer::PassToken CreateLoopPeelingPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::LoopPeelingPass>());
+      MakeUnique<opt::LoopPeelingPassToken>());
 }
 
 Optimizer::PassToken CreateLoopUnswitchPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::LoopUnswitchPass>());
+      MakeUnique<opt::LoopUnswitchPassToken>());
 }
 
 Optimizer::PassToken CreateRedundancyEliminationPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::RedundancyEliminationPass>());
+      MakeUnique<opt::RedundancyEliminationPassToken>());
 }
 
 Optimizer::PassToken CreateRemoveDuplicatesPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::RemoveDuplicatesPass>());
+      MakeUnique<opt::RemoveDuplicatesPassToken>());
 }
 
 Optimizer::PassToken CreateScalarReplacementPass(uint32_t size_limit) {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::ScalarReplacementPass>(size_limit));
+      MakeUnique<opt::ScalarReplacementPassToken>(size_limit));
 }
 
 Optimizer::PassToken CreatePrivateToLocalPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::PrivateToLocalPass>());
+      MakeUnique<opt::PrivateToLocalPassToken>());
 }
 
 Optimizer::PassToken CreateCCPPass() {
-  return MakeUnique<Optimizer::PassToken::Impl>(MakeUnique<opt::CCPPass>());
+  return MakeUnique<Optimizer::PassToken::Impl>(MakeUnique<opt::CCPPassToken>());
 }
 
 Optimizer::PassToken CreateWorkaround1209Pass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::Workaround1209>());
+      MakeUnique<opt::Workaround1209Token>());
 }
 
 Optimizer::PassToken CreateIfConversionPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::IfConversion>());
+      MakeUnique<opt::IfConversionToken>());
 }
 
 Optimizer::PassToken CreateReplaceInvalidOpcodePass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::ReplaceInvalidOpcodePass>());
+      MakeUnique<opt::ReplaceInvalidOpcodePassToken>());
 }
 
 Optimizer::PassToken CreateSimplificationPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::SimplificationPass>());
+      MakeUnique<opt::SimplificationPassToken>());
 }
 
 Optimizer::PassToken CreateLoopUnrollPass(bool fully_unroll, int factor) {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::LoopUnroller>(fully_unroll, factor));
+      MakeUnique<opt::LoopUnrollerToken>(fully_unroll, factor));
 }
 
 Optimizer::PassToken CreateSSARewritePass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::SSARewritePass>());
+      MakeUnique<opt::SSARewritePassToken>());
 }
 
 Optimizer::PassToken CreateCopyPropagateArraysPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::CopyPropagateArrays>());
+      MakeUnique<opt::CopyPropagateArraysToken>());
 }
 
 Optimizer::PassToken CreateVectorDCEPass() {
-  return MakeUnique<Optimizer::PassToken::Impl>(MakeUnique<opt::VectorDCE>());
+  return MakeUnique<Optimizer::PassToken::Impl>(MakeUnique<opt::VectorDCEToken>());
 }
 
 Optimizer::PassToken CreateReduceLoadSizePass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::ReduceLoadSize>());
+      MakeUnique<opt::ReduceLoadSizeToken>());
 }
 }  // namespace spvtools

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -235,7 +235,8 @@ std::vector<const char*> Optimizer::GetPassNames() const {
 }
 
 Optimizer::PassToken CreateNullPass() {
-  return MakeUnique<Optimizer::PassToken::Impl>(MakeUnique<opt::NullPassToken>());
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::NullPassToken>());
 }
 
 Optimizer::PassToken CreateStripDebugInfoPass() {
@@ -391,7 +392,8 @@ Optimizer::PassToken CreateLoopFusionPass(size_t max_registers_per_loop) {
 }
 
 Optimizer::PassToken CreateLoopInvariantCodeMotionPass() {
-  return MakeUnique<Optimizer::PassToken::Impl>(MakeUnique<opt::LICMPassToken>());
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::LICMPassToken>());
 }
 
 Optimizer::PassToken CreateLoopPeelingPass() {
@@ -425,7 +427,8 @@ Optimizer::PassToken CreatePrivateToLocalPass() {
 }
 
 Optimizer::PassToken CreateCCPPass() {
-  return MakeUnique<Optimizer::PassToken::Impl>(MakeUnique<opt::CCPPassToken>());
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::CCPPassToken>());
 }
 
 Optimizer::PassToken CreateWorkaround1209Pass() {
@@ -464,7 +467,8 @@ Optimizer::PassToken CreateCopyPropagateArraysPass() {
 }
 
 Optimizer::PassToken CreateVectorDCEPass() {
-  return MakeUnique<Optimizer::PassToken::Impl>(MakeUnique<opt::VectorDCEToken>());
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::VectorDCEToken>());
 }
 
 Optimizer::PassToken CreateReduceLoadSizePass() {

--- a/source/opt/pass.h
+++ b/source/opt/pass.h
@@ -47,23 +47,8 @@ class Pass {
 
   using ProcessFunction = std::function<bool(opt::Function*)>;
 
-  // Constructs a new pass.
-  //
-  // The constructed instance will have an empty message consumer, which just
-  // ignores all messages from the library. Use SetMessageConsumer() to supply
-  // one if messages are of concern.
-  Pass();
-
   // Destructs the pass.
   virtual ~Pass() = default;
-
-  // Returns a descriptive name for this pass.
-  //
-  // NOTE: When deriving a new pass class, make sure you make the name
-  // compatible with the corresponding spirv-opt command-line flag. For example,
-  // if you add the flag --my-pass to spirv-opt, make this function return
-  // "my-pass" (no leading hyphens).
-  virtual const char* name() const = 0;
 
   // Sets the message consumer to the given |consumer|. |consumer| which will be
   // invoked every time there is a message to be communicated to the outside.
@@ -137,6 +122,13 @@ class Pass {
   uint32_t GetPointeeTypeId(const opt::Instruction* ptrInst) const;
 
  protected:
+  // Constructs a new pass.
+  //
+  // The constructed instance will have an empty message consumer, which just
+  // ignores all messages from the library. Use SetMessageConsumer() to supply
+  // one if messages are of concern.
+  Pass();
+
   // Initialize basic data structures for the pass. This sets up the def-use
   // manager, module and other attributes.
   virtual void InitializeProcessing(opt::IRContext* c) { context_ = c; }

--- a/source/opt/pass_manager.cpp
+++ b/source/opt/pass_manager.cpp
@@ -30,28 +30,30 @@ Pass::Status PassManager::Run(opt::IRContext* context) {
 
   // If print_all_stream_ is not null, prints the disassembly of the module
   // to that stream, with the given preamble and optionally the pass name.
-  auto print_disassembly = [&context, this](const char* preamble, Pass* pass) {
+  auto print_disassembly = [&context, this](const char* preamble, PassToken* pass_token) {
     if (print_all_stream_) {
       std::vector<uint32_t> binary;
       context->module()->ToBinary(&binary, false);
       SpirvTools t(SPV_ENV_UNIVERSAL_1_2);
       std::string disassembly;
       t.Disassemble(binary, &disassembly, 0);
-      *print_all_stream_ << preamble << (pass ? pass->name() : "") << "\n"
+      *print_all_stream_ << preamble << (pass_token ? pass_token->name() : "") << "\n"
                          << disassembly << std::endl;
     }
   };
 
   SPIRV_TIMER_DESCRIPTION(time_report_stream_, /* measure_mem_usage = */ true);
-  for (auto& pass : passes_) {
-    print_disassembly("; IR before pass ", pass.get());
-    SPIRV_TIMER_SCOPED(time_report_stream_, (pass ? pass->name() : ""), true);
+  for (auto& pass_token : pass_tokens_) {
+    print_disassembly("; IR before pass ", pass_token.get());
+
+    SPIRV_TIMER_SCOPED(time_report_stream_, (pass_token ? pass_token->name() : ""), true);
+
+    std::unique_ptr<Pass> pass = pass_token->CreatePass();
+    pass->SetMessageConsumer(consumer_);
+
     const auto one_status = pass->Run(context);
     if (one_status == Pass::Status::Failure) return one_status;
     if (one_status == Pass::Status::SuccessWithChange) status = one_status;
-
-    // Reset the pass to free any memory used by the pass.
-    pass.reset(nullptr);
   }
   print_disassembly("; IR after last pass", nullptr);
 
@@ -62,7 +64,6 @@ Pass::Status PassManager::Run(opt::IRContext* context) {
   if (status == Pass::Status::SuccessWithChange) {
     context->module()->SetIdBound(context->module()->ComputeIdBound());
   }
-  passes_.clear();
   return status;
 }
 

--- a/source/opt/pass_manager.cpp
+++ b/source/opt/pass_manager.cpp
@@ -30,14 +30,16 @@ Pass::Status PassManager::Run(opt::IRContext* context) {
 
   // If print_all_stream_ is not null, prints the disassembly of the module
   // to that stream, with the given preamble and optionally the pass name.
-  auto print_disassembly = [&context, this](const char* preamble, PassToken* pass_token) {
+  auto print_disassembly = [&context, this](const char* preamble,
+                                            PassToken* pass_token) {
     if (print_all_stream_) {
       std::vector<uint32_t> binary;
       context->module()->ToBinary(&binary, false);
       SpirvTools t(SPV_ENV_UNIVERSAL_1_2);
       std::string disassembly;
       t.Disassemble(binary, &disassembly, 0);
-      *print_all_stream_ << preamble << (pass_token ? pass_token->name() : "") << "\n"
+      *print_all_stream_ << preamble << (pass_token ? pass_token->name() : "")
+                         << "\n"
                          << disassembly << std::endl;
     }
   };
@@ -46,7 +48,8 @@ Pass::Status PassManager::Run(opt::IRContext* context) {
   for (auto& pass_token : pass_tokens_) {
     print_disassembly("; IR before pass ", pass_token.get());
 
-    SPIRV_TIMER_SCOPED(time_report_stream_, (pass_token ? pass_token->name() : ""), true);
+    SPIRV_TIMER_SCOPED(time_report_stream_,
+                       (pass_token ? pass_token->name() : ""), true);
 
     std::unique_ptr<Pass> pass = pass_token->CreatePass();
     pass->SetMessageConsumer(consumer_);

--- a/source/opt/pass_manager.h
+++ b/source/opt/pass_manager.h
@@ -19,11 +19,11 @@
 #include <ostream>
 #include <vector>
 
+#include "source/opt/ir_context.h"
 #include "source/opt/log.h"
 #include "source/opt/module.h"
 #include "source/opt/pass.h"
 #include "source/opt/pass_token.h"
-#include "source/opt/ir_context.h"
 #include "spirv-tools/libspirv.hpp"
 
 namespace spvtools {

--- a/source/opt/pass_token.h
+++ b/source/opt/pass_token.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_OPT_PASS_TOKEN_H_
+#define SOURCE_OPT_PASS_TOKEN_H_
+
+#include <memory>
+
+namespace spvtools {
+namespace opt {
+
+class Pass;
+
+class PassToken {
+ public:
+  virtual ~PassToken() = default;
+
+  // Returns a descriptive name for this pass.
+  //
+  // NOTE: When deriving a new pass class, make sure you make the name
+  // compatible with the corresponding spirv-opt command-line flag. For example,
+  // if you add the flag --my-pass to spirv-opt, make this function return
+  // "my-pass" (no leading hyphens).
+  virtual const char* name() const = 0;
+
+  // Returns a new pass to be executed.
+  virtual std::unique_ptr<Pass> CreatePass() const = 0;
+
+ protected:
+  PassToken() = default;
+};
+
+}  // namespace opt
+}  // namespace spvtools
+
+#endif  // SOURCE_OPT_PASS_TOKEN_H_

--- a/source/opt/private_to_local_pass.h
+++ b/source/opt/private_to_local_pass.h
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_PRIVATE_TO_LOCAL_PASS_H_
-#define LIBSPIRV_OPT_PRIVATE_TO_LOCAL_PASS_H_
+#ifndef SOURCE_OPT_PRIVATE_TO_LOCAL_PASS_H_
+#define SOURCE_OPT_PRIVATE_TO_LOCAL_PASS_H_
 
-#include "ir_context.h"
-#include "pass.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -27,7 +28,6 @@ namespace opt {
 // that dominates inst, and also computes the same value.
 class PrivateToLocalPass : public Pass {
  public:
-  const char* name() const override { return "private-to-local"; }
   Status Process(opt::IRContext*) override;
   opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse |
@@ -66,7 +66,19 @@ class PrivateToLocalPass : public Pass {
   void UpdateUses(uint32_t id);
 };
 
+class PrivateToLocalPassToken : public PassToken {
+ public:
+  PrivateToLocalPassToken() = default;
+  ~PrivateToLocalPassToken() override = default;
+
+  const char* name() const override { return "private-to-local"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<PrivateToLocalPass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_PRIVATE_TO_LOCAL_PASS_H_
+#endif  // SOURCE_OPT_PRIVATE_TO_LOCAL_PASS_H_

--- a/source/opt/propagator.h
+++ b/source/opt/propagator.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_PROPAGATOR_H_
-#define LIBSPIRV_OPT_PROPAGATOR_H_
+#ifndef SOURCE_OPT_PROPAGATOR_H_
+#define SOURCE_OPT_PROPAGATOR_H_
 
 #include <functional>
 #include <queue>
@@ -22,8 +22,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include "ir_context.h"
-#include "module.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/module.h"
 
 namespace spvtools {
 namespace opt {
@@ -316,4 +316,4 @@ std::ostream& operator<<(std::ostream& str,
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_PROPAGATOR_H_
+#endif  // SOURCE_OPT_PROPAGATOR_H_

--- a/source/opt/reduce_load_size.h
+++ b/source/opt/reduce_load_size.h
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_REDUCE_LOAD_SIZE_H_
-#define LIBSPIRV_OPT_REDUCE_LOAD_SIZE_H_
+#ifndef SOURCE_OPT_REDUCE_LOAD_SIZE_H_
+#define SOURCE_OPT_REDUCE_LOAD_SIZE_H_
 
-#include "ir_context.h"
-#include "module.h"
-#include "pass.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/module.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -25,7 +26,6 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class ReduceLoadSize : public Pass {
  public:
-  const char* name() const override { return "reduce-load-size"; }
   Status Process(opt::IRContext* irContext) override;
 
   // Return the mask of preserved Analyses.
@@ -57,7 +57,19 @@ class ReduceLoadSize : public Pass {
   std::unordered_map<uint32_t, bool> should_replace_cache_;
 };
 
+class ReduceLoadSizeToken : public PassToken {
+ public:
+  ReduceLoadSizeToken() = default;
+  ~ReduceLoadSizeToken() override = default;
+
+  const char* name() const override { return "reduce-load-size"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<ReduceLoadSize>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_REDUCE_LOAD_SIZE_H_
+#endif  // SOURCE_OPT_REDUCE_LOAD_SIZE_H_

--- a/source/opt/redundancy_elimination.h
+++ b/source/opt/redundancy_elimination.h
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_REDUNDANCY_ELIMINATION_H_
-#define LIBSPIRV_OPT_REDUNDANCY_ELIMINATION_H_
+#ifndef SOURCE_OPT_REDUNDANCY_ELIMINATION_H_
+#define SOURCE_OPT_REDUNDANCY_ELIMINATION_H_
 
-#include "ir_context.h"
-#include "local_redundancy_elimination.h"
-#include "pass.h"
-#include "value_number_table.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/local_redundancy_elimination.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
+#include "source/opt/value_number_table.h"
 
 namespace spvtools {
 namespace opt {
@@ -29,7 +30,6 @@ namespace opt {
 // that dominates inst, and also computes the same value.
 class RedundancyEliminationPass : public LocalRedundancyEliminationPass {
  public:
-  const char* name() const override { return "redundancy-elimination"; }
   Status Process(opt::IRContext*) override;
 
  protected:
@@ -48,7 +48,19 @@ class RedundancyEliminationPass : public LocalRedundancyEliminationPass {
                                  std::map<uint32_t, uint32_t> value_to_ids);
 };
 
+class RedundancyEliminationPassToken : public PassToken {
+ public:
+  RedundancyEliminationPassToken() = default;
+  ~RedundancyEliminationPassToken() override = default;
+
+  const char* name() const override { return "redundancy-elimination"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<RedundancyEliminationPass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_REDUNDANCY_ELIMINATION_H_
+#endif  // SOURCE_OPT_REDUNDANCY_ELIMINATION_H_

--- a/source/opt/remove_duplicates_pass.h
+++ b/source/opt/remove_duplicates_pass.h
@@ -12,28 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_REMOVE_DUPLICATES_PASS_H_
-#define LIBSPIRV_OPT_REMOVE_DUPLICATES_PASS_H_
+#ifndef SOURCE_OPT_REMOVE_DUPLICATES_PASS_H_
+#define SOURCE_OPT_REMOVE_DUPLICATES_PASS_H_
 
 #include <unordered_map>
 
-#include "decoration_manager.h"
-#include "def_use_manager.h"
-#include "ir_context.h"
-#include "module.h"
-#include "pass.h"
+#include "source/opt/decoration_manager.h"
+#include "source/opt/def_use_manager.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/module.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
 
-using IdDecorationsList =
-    std::unordered_map<uint32_t, std::vector<opt::Instruction*>>;
-
 // See optimizer.hpp for documentation.
 class RemoveDuplicatesPass : public Pass {
  public:
-  const char* name() const override { return "remove-duplicates"; }
   Status Process(opt::IRContext*) override;
+
   // TODO(pierremoreau): Move this function somewhere else (e.g. pass.h or
   // within the type manager)
   // Returns whether two types are equal, and have the same decorations.
@@ -61,7 +59,19 @@ class RemoveDuplicatesPass : public Pass {
   bool RemoveDuplicateDecorations(opt::IRContext* ir_context) const;
 };
 
+class RemoveDuplicatesPassToken : public PassToken {
+ public:
+  RemoveDuplicatesPassToken() = default;
+  ~RemoveDuplicatesPassToken() override = default;
+
+  const char* name() const override { return "remove-duplicates"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<RemoveDuplicatesPass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_REMOVE_DUPLICATES_PASS_H_
+#endif  // SOURCE_OPT_REMOVE_DUPLICATES_PASS_H_

--- a/source/opt/replace_invalid_opc.h
+++ b/source/opt/replace_invalid_opc.h
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_REPLACE_INVALID_OPC_H_
-#define LIBSPIRV_OPT_REPLACE_INVALID_OPC_H_
+#ifndef SOURCE_OPT_REPLACE_INVALID_OPC_H_
+#define SOURCE_OPT_REPLACE_INVALID_OPC_H_
 
-#include "pass.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -26,7 +27,6 @@ namespace opt {
 // value, the instruction will simply be deleted.
 class ReplaceInvalidOpcodePass : public Pass {
  public:
-  const char* name() const override { return "replace-invalid-opcodes"; }
   Status Process(opt::IRContext*) override;
 
  private:
@@ -59,7 +59,19 @@ class ReplaceInvalidOpcodePass : public Pass {
   std::string BuildWarningMessage(SpvOp opcode);
 };
 
+class ReplaceInvalidOpcodePassToken : public PassToken {
+ public:
+  ReplaceInvalidOpcodePassToken() = default;
+  ~ReplaceInvalidOpcodePassToken() override = default;
+
+  const char* name() const override { return "replace-invalid-opcodes"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<ReplaceInvalidOpcodePass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_REPLACE_INVALID_OPC_H_
+#endif  // SOURCE_OPT_REPLACE_INVALID_OPC_H_

--- a/source/opt/scalar_replacement_pass.h
+++ b/source/opt/scalar_replacement_pass.h
@@ -219,15 +219,16 @@ class ScalarReplacementPass : public Pass {
 
 class ScalarReplacementPassToken : public PassToken {
  public:
-  static constexpr uint32_t kDefaultLimit = 100;
+  static const uint32_t kDefaultLimit = 100;
 
   ScalarReplacementPassToken(uint32_t limit = kDefaultLimit)
-      : max_num_elements_(limit),
-        name_("scalar-replacement=" + std::to_string(limit)) {}
+      : max_num_elements_(limit) {
+    snprintf(name_, 55, "scalar-replacement=%d", max_num_elements_);
+  }
 
   ~ScalarReplacementPassToken() override = default;
 
-  const char* name() const override { return name_.data(); }
+  const char* name() const override { return name_; }
 
   std::unique_ptr<Pass> CreatePass() const override {
     return MakeUnique<ScalarReplacementPass>(max_num_elements_);
@@ -235,7 +236,7 @@ class ScalarReplacementPassToken : public PassToken {
 
  private:
   uint32_t max_num_elements_;
-  std::string name_;
+  char name_[55];
 };
 
 }  // namespace opt

--- a/source/opt/scalar_replacement_pass.h
+++ b/source/opt/scalar_replacement_pass.h
@@ -223,7 +223,8 @@ class ScalarReplacementPassToken : public PassToken {
 
   ScalarReplacementPassToken(uint32_t limit = kDefaultLimit)
       : max_num_elements_(limit) {
-    snprintf(name_, 55, "scalar-replacement=%d", max_num_elements_);
+    name_[0] = '\0';
+    sprintf(&name_[0], "scalar-replacement=%d", max_num_elements_);
   }
 
   ~ScalarReplacementPassToken() override = default;

--- a/source/opt/scalar_replacement_pass.h
+++ b/source/opt/scalar_replacement_pass.h
@@ -16,6 +16,7 @@
 #define SOURCE_OPT_SCALAR_REPLACEMENT_PASS_H_
 
 #include <cstdio>
+#include <string>
 #include <queue>
 
 #include "source/opt/function.h"

--- a/source/opt/scalar_replacement_pass.h
+++ b/source/opt/scalar_replacement_pass.h
@@ -16,8 +16,8 @@
 #define SOURCE_OPT_SCALAR_REPLACEMENT_PASS_H_
 
 #include <cstdio>
-#include <string>
 #include <queue>
+#include <string>
 
 #include "source/opt/function.h"
 #include "source/opt/pass.h"
@@ -219,7 +219,9 @@ class ScalarReplacementPass : public Pass {
 
 class ScalarReplacementPassToken : public PassToken {
  public:
-  ScalarReplacementPassToken(uint32_t limit)
+  static constexpr uint32_t kDefaultLimit = 100;
+
+  ScalarReplacementPassToken(uint32_t limit = kDefaultLimit)
       : max_num_elements_(limit),
         name_("scalar-replacement=" + std::to_string(limit)) {}
 

--- a/source/opt/set_spec_constant_default_value_pass.h
+++ b/source/opt/set_spec_constant_default_value_pass.h
@@ -12,16 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_SET_SPEC_CONSTANT_DEFAULT_VALUE_PASS_H_
-#define LIBSPIRV_OPT_SET_SPEC_CONSTANT_DEFAULT_VALUE_PASS_H_
+#ifndef SOURCE_OPT_SET_SPEC_CONSTANT_DEFAULT_VALUE_PASS_H_
+#define SOURCE_OPT_SET_SPEC_CONSTANT_DEFAULT_VALUE_PASS_H_
 
 #include <memory>
 #include <string>
 #include <unordered_map>
 
-#include "ir_context.h"
-#include "module.h"
-#include "pass.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/module.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -32,16 +33,12 @@ class SetSpecConstantDefaultValuePass : public Pass {
   using SpecIdToValueStrMap = std::unordered_map<uint32_t, std::string>;
   using SpecIdToValueBitPatternMap =
       std::unordered_map<uint32_t, std::vector<uint32_t>>;
-  using SpecIdToInstMap = std::unordered_map<uint32_t, opt::Instruction*>;
 
   // Constructs a pass instance with a map from spec ids to default values
   // in the form of string.
   explicit SetSpecConstantDefaultValuePass(
       const SpecIdToValueStrMap& default_values)
       : spec_id_to_value_str_(default_values),
-        spec_id_to_value_bit_pattern_() {}
-  explicit SetSpecConstantDefaultValuePass(SpecIdToValueStrMap&& default_values)
-      : spec_id_to_value_str_(std::move(default_values)),
         spec_id_to_value_bit_pattern_() {}
 
   // Constructs a pass instance with a map from spec ids to default values in
@@ -50,12 +47,7 @@ class SetSpecConstantDefaultValuePass : public Pass {
       const SpecIdToValueBitPatternMap& default_values)
       : spec_id_to_value_str_(),
         spec_id_to_value_bit_pattern_(default_values) {}
-  explicit SetSpecConstantDefaultValuePass(
-      SpecIdToValueBitPatternMap&& default_values)
-      : spec_id_to_value_str_(),
-        spec_id_to_value_bit_pattern_(std::move(default_values)) {}
 
-  const char* name() const override { return "set-spec-const-default-value"; }
   Status Process(opt::IRContext*) override;
 
   // Parses the given null-terminated C string to get a mapping from Spec Id to
@@ -106,7 +98,37 @@ class SetSpecConstantDefaultValuePass : public Pass {
   const SpecIdToValueBitPatternMap spec_id_to_value_bit_pattern_;
 };
 
+class SetSpecConstantDefaultValuePassToken : public PassToken {
+ public:
+  explicit SetSpecConstantDefaultValuePassToken(
+      const SetSpecConstantDefaultValuePass::SpecIdToValueStrMap& default_values)
+      : spec_id_to_value_str_(default_values),
+        spec_id_to_value_bit_pattern_(),
+        have_string_values_(true) {}
+
+  explicit SetSpecConstantDefaultValuePassToken(
+      const SetSpecConstantDefaultValuePass::SpecIdToValueBitPatternMap& default_values)
+      : spec_id_to_value_str_(),
+        spec_id_to_value_bit_pattern_(default_values),
+        have_string_values_(false) {}
+
+  ~SetSpecConstantDefaultValuePassToken() override = default;
+
+  const char* name() const override { return "set-spec-const-default-value"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    if (have_string_values_)
+      return MakeUnique<SetSpecConstantDefaultValuePass>(spec_id_to_value_str_);
+    return MakeUnique<SetSpecConstantDefaultValuePass>(spec_id_to_value_bit_pattern_);
+  }
+
+ private:
+  const SetSpecConstantDefaultValuePass::SpecIdToValueStrMap spec_id_to_value_str_;
+  const SetSpecConstantDefaultValuePass::SpecIdToValueBitPatternMap spec_id_to_value_bit_pattern_;
+  bool have_string_values_;
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_SET_SPEC_CONSTANT_DEFAULT_VALUE_PASS_H_
+#endif  // SOURCE_OPT_SET_SPEC_CONSTANT_DEFAULT_VALUE_PASS_H_

--- a/source/opt/set_spec_constant_default_value_pass.h
+++ b/source/opt/set_spec_constant_default_value_pass.h
@@ -101,13 +101,15 @@ class SetSpecConstantDefaultValuePass : public Pass {
 class SetSpecConstantDefaultValuePassToken : public PassToken {
  public:
   explicit SetSpecConstantDefaultValuePassToken(
-      const SetSpecConstantDefaultValuePass::SpecIdToValueStrMap& default_values)
+      const SetSpecConstantDefaultValuePass::SpecIdToValueStrMap&
+          default_values)
       : spec_id_to_value_str_(default_values),
         spec_id_to_value_bit_pattern_(),
         have_string_values_(true) {}
 
   explicit SetSpecConstantDefaultValuePassToken(
-      const SetSpecConstantDefaultValuePass::SpecIdToValueBitPatternMap& default_values)
+      const SetSpecConstantDefaultValuePass::SpecIdToValueBitPatternMap&
+          default_values)
       : spec_id_to_value_str_(),
         spec_id_to_value_bit_pattern_(default_values),
         have_string_values_(false) {}
@@ -119,12 +121,15 @@ class SetSpecConstantDefaultValuePassToken : public PassToken {
   std::unique_ptr<Pass> CreatePass() const override {
     if (have_string_values_)
       return MakeUnique<SetSpecConstantDefaultValuePass>(spec_id_to_value_str_);
-    return MakeUnique<SetSpecConstantDefaultValuePass>(spec_id_to_value_bit_pattern_);
+    return MakeUnique<SetSpecConstantDefaultValuePass>(
+        spec_id_to_value_bit_pattern_);
   }
 
  private:
-  const SetSpecConstantDefaultValuePass::SpecIdToValueStrMap spec_id_to_value_str_;
-  const SetSpecConstantDefaultValuePass::SpecIdToValueBitPatternMap spec_id_to_value_bit_pattern_;
+  const SetSpecConstantDefaultValuePass::SpecIdToValueStrMap
+      spec_id_to_value_str_;
+  const SetSpecConstantDefaultValuePass::SpecIdToValueBitPatternMap
+      spec_id_to_value_bit_pattern_;
   bool have_string_values_;
 };
 

--- a/source/opt/simplification_pass.h
+++ b/source/opt/simplification_pass.h
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_SIMPLIFICATION_PASS_H_
-#define LIBSPIRV_OPT_SIMPLIFICATION_PASS_H_
+#ifndef SOURCE_OPT_SIMPLIFICATION_PASS_H_
+#define SOURCE_OPT_SIMPLIFICATION_PASS_H_
 
-#include "function.h"
-#include "ir_context.h"
-#include "pass.h"
+#include "source/opt/function.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -25,7 +26,6 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class SimplificationPass : public Pass {
  public:
-  const char* name() const override { return "simplify-instructions"; }
   Status Process(opt::IRContext*) override;
   virtual opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse |
@@ -43,7 +43,19 @@ class SimplificationPass : public Pass {
   bool SimplifyFunction(opt::Function* function);
 };
 
+class SimplificationPassToken : public PassToken {
+ public:
+  SimplificationPassToken() = default;
+  ~SimplificationPassToken() override = default;
+
+  const char* name() const override { return "simplify-instructions"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<SimplificationPass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_SIMPLIFICATION_PASS_H_
+#endif  // SOURCE_OPT_SIMPLIFICATION_PASS_H_

--- a/source/opt/ssa_rewrite_pass.h
+++ b/source/opt/ssa_rewrite_pass.h
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_SSA_REWRITE_PASS_H_
-#define LIBSPIRV_OPT_SSA_REWRITE_PASS_H_
-
-#include "basic_block.h"
-#include "ir_context.h"
-#include "mem_pass.h"
+#ifndef SOURCE_OPT_SSA_REWRITE_PASS_H_
+#define SOURCE_OPT_SSA_REWRITE_PASS_H_
 
 #include <unordered_map>
+
+#include "source/opt/basic_block.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/mem_pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -290,7 +291,7 @@ class SSARewriter {
 class SSARewritePass : public MemPass {
  public:
   SSARewritePass() = default;
-  const char* name() const override { return "ssa-rewrite"; }
+
   Status Process(opt::IRContext* c) override;
 
  private:
@@ -298,7 +299,19 @@ class SSARewritePass : public MemPass {
   void Initialize(opt::IRContext* c);
 };
 
+class SSARewritePassToken : public PassToken {
+ public:
+  SSARewritePassToken() = default;
+  ~SSARewritePassToken() override = default;
+
+  const char* name() const override { return "ssa-rewrite"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<SSARewritePass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_SSA_REWRITE_PASS_H_
+#endif  // SOURCE_OPT_SSA_REWRITE_PASS_H_

--- a/source/opt/strength_reduction_pass.h
+++ b/source/opt/strength_reduction_pass.h
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_STRENGTH_REDUCTION_PASS_H_
-#define LIBSPIRV_OPT_STRENGTH_REDUCTION_PASS_H_
+#ifndef SOURCE_OPT_STRENGTH_REDUCTION_PASS_H_
+#define SOURCE_OPT_STRENGTH_REDUCTION_PASS_H_
 
-#include "def_use_manager.h"
-#include "ir_context.h"
-#include "module.h"
-#include "pass.h"
+#include "source/opt/def_use_manager.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/module.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -26,7 +27,6 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class StrengthReductionPass : public Pass {
  public:
-  const char* name() const override { return "strength-reduction"; }
   Status Process(opt::IRContext*) override;
 
  private:
@@ -59,7 +59,19 @@ class StrengthReductionPass : public Pass {
   uint32_t constant_ids_[33];
 };
 
+class StrengthReductionPassToken : public PassToken {
+ public:
+  StrengthReductionPassToken() = default;
+  ~StrengthReductionPassToken() override = default;
+
+  const char* name() const override { return "strength-reduction"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<StrengthReductionPass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_STRENGTH_REDUCTION_PASS_H_
+#endif  // SOURCE_OPT_STRENGTH_REDUCTION_PASS_H_

--- a/source/opt/strip_debug_info_pass.h
+++ b/source/opt/strip_debug_info_pass.h
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_STRIP_DEBUG_INFO_PASS_H_
-#define LIBSPIRV_OPT_STRIP_DEBUG_INFO_PASS_H_
+#ifndef SOURCE_OPT_STRIP_DEBUG_INFO_PASS_H_
+#define SOURCE_OPT_STRIP_DEBUG_INFO_PASS_H_
 
-#include "ir_context.h"
-#include "module.h"
-#include "pass.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/module.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -25,11 +26,22 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class StripDebugInfoPass : public Pass {
  public:
-  const char* name() const override { return "strip-debug"; }
   Status Process(opt::IRContext* irContext) override;
+};
+
+class StripDebugInfoPassToken : public PassToken {
+ public:
+  StripDebugInfoPassToken() = default;
+  ~StripDebugInfoPassToken() override = default;
+
+  const char* name() const override { return "strip-debug"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<StripDebugInfoPass>();
+  }
 };
 
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_STRIP_DEBUG_INFO_PASS_H_
+#endif  // SOURCE_OPT_STRIP_DEBUG_INFO_PASS_H_

--- a/source/opt/strip_reflect_info_pass.h
+++ b/source/opt/strip_reflect_info_pass.h
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_STRIP_REFLECT_INFO_PASS_H_
-#define LIBSPIRV_OPT_STRIP_REFLECT_INFO_PASS_H_
+#ifndef SOURCE_OPT_STRIP_REFLECT_INFO_PASS_H_
+#define SOURCE_OPT_STRIP_REFLECT_INFO_PASS_H_
 
-#include "ir_context.h"
-#include "module.h"
-#include "pass.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/module.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -25,7 +26,6 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class StripReflectInfoPass : public Pass {
  public:
-  const char* name() const override { return "strip-reflect"; }
   Status Process(opt::IRContext* irContext) override;
 
   // Return the mask of preserved Analyses.
@@ -38,7 +38,19 @@ class StripReflectInfoPass : public Pass {
   }
 };
 
+class StripReflectInfoPassToken : public PassToken {
+ public:
+  StripReflectInfoPassToken() = default;
+  ~StripReflectInfoPassToken() override = default;
+
+  const char* name() const override { return "strip-reflect"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<StripReflectInfoPass>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_STRIP_REFLECT_INFO_PASS_H_
+#endif  // SOURCE_OPT_STRIP_REFLECT_INFO_PASS_H_

--- a/source/opt/unify_const_pass.h
+++ b/source/opt/unify_const_pass.h
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_UNIFY_CONSTANT_PASS_H_
-#define LIBSPIRV_OPT_UNIFY_CONSTANT_PASS_H_
+#ifndef SOURCE_OPT_UNIFY_CONSTANT_PASS_H_
+#define SOURCE_OPT_UNIFY_CONSTANT_PASS_H_
 
-#include "ir_context.h"
-#include "module.h"
-#include "pass.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/module.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -25,11 +26,22 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class UnifyConstantPass : public Pass {
  public:
-  const char* name() const override { return "unify-const"; }
   Status Process(opt::IRContext*) override;
+};
+
+class UnifyConstantPassToken : public PassToken {
+ public:
+  UnifyConstantPassToken() = default;
+  ~UnifyConstantPassToken() override = default;
+
+  const char* name() const override { return "unify-const"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<UnifyConstantPass>();
+  }
 };
 
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_UNIFY_CONSTANT_PASS_H_
+#endif  // SOURCE_OPT_UNIFY_CONSTANT_PASS_H_

--- a/source/opt/vector_dce.h
+++ b/source/opt/vector_dce.h
@@ -15,8 +15,9 @@
 #ifndef LIBSPIRV_OPT_VECTOR_DCE_H_
 #define LIBSPIRV_OPT_VECTOR_DCE_H_
 
-#include <util/bit_vector.h>
-#include "mem_pass.h"
+#include "source/opt/mem_pass.h"
+#include "source/opt/pass_token.h"
+#include "source/util/bit_vector.h"
 
 namespace spvtools {
 namespace opt {
@@ -37,14 +38,13 @@ class VectorDCE : public MemPass {
   };
 
  public:
-  const char* name() const override { return "vector-dce"; }
-  Status Process(opt::IRContext*) override;
-
   VectorDCE() : all_components_live_(kMaxVectorSize) {
     for (uint32_t i = 0; i < kMaxVectorSize; i++) {
       all_components_live_.Set(i);
     }
   }
+
+  Status Process(opt::IRContext*) override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse | opt::IRContext::kAnalysisCFG |
@@ -140,6 +140,18 @@ class VectorDCE : public MemPass {
   // A BitVector that can always be used to say that all components of a vector
   // are live.
   utils::BitVector all_components_live_;
+};
+
+class VectorDCEToken : public PassToken {
+ public:
+  VectorDCEToken() = default;
+  ~VectorDCEToken() override = default;
+
+  const char* name() const override { return "vector-dce"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<VectorDCE>();
+  }
 };
 
 }  // namespace opt

--- a/source/opt/workaround1209.h
+++ b/source/opt/workaround1209.h
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_WORKAROUND1209_H_
-#define LIBSPIRV_OPT_WORKAROUND1209_H_
+#ifndef SOURCE_OPT_WORKAROUND1209_H_
+#define SOURCE_OPT_WORKAROUND1209_H_
 
-#include "pass.h"
+#include "source/opt/pass.h"
+#include "source/opt/pass_token.h"
 
 namespace spvtools {
 namespace opt {
@@ -23,7 +24,6 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class Workaround1209 : public Pass {
  public:
-  const char* name() const override { return "workaround-1209"; }
   Status Process(opt::IRContext*) override;
 
  private:
@@ -35,7 +35,19 @@ class Workaround1209 : public Pass {
   bool RemoveOpUnreachableInLoops();
 };
 
+class Workaround1209Token : public PassToken {
+ public:
+  Workaround1209Token() = default;
+  ~Workaround1209Token() override = default;
+
+  const char* name() const override { return "workaround-1209"; }
+
+  std::unique_ptr<Pass> CreatePass() const override {
+    return MakeUnique<Workaround1209>();
+  }
+};
+
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_WORKAROUND1209_H_
+#endif  // SOURCE_OPT_WORKAROUND1209_H_

--- a/test/opt/aggressive_dead_code_elim_test.cpp
+++ b/test/opt/aggressive_dead_code_elim_test.cpp
@@ -103,7 +103,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(
       predefs1 + names_before + predefs2 + func_before,
       predefs1 + names_after + predefs2 + func_after, true, true);
 }
@@ -219,7 +219,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(
       predefs1 + names_before + predefs2_before + func_before,
       predefs1 + names_after + predefs2_after + func_after, true, true);
 }
@@ -321,7 +321,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(
       predefs1 + names_before + predefs2_before + func_before,
       predefs1 + names_after + predefs2_after + func_after, true, true);
 }
@@ -405,7 +405,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(
       predefs1 + names_before + predefs2 + func_before,
       predefs1 + names_after + predefs2 + func_after, true, true);
 }
@@ -490,7 +490,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(
       predefs1 + names_before + predefs2 + func_before,
       predefs1 + names_after + predefs2 + func_after, true, true);
 }
@@ -546,7 +546,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
 }
 
 TEST_F(AggressiveDCETest, ElimWithCall) {
@@ -672,7 +672,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(
       defs_before + func_before, defs_after + func_after, true, true);
 }
 
@@ -802,7 +802,7 @@ OpReturnValue %27
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(
       defs_before + func_before, defs_after + func_after, true, true);
 }
 
@@ -904,7 +904,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(
       defs_before + func_before, defs_after + func_after, true, true);
 }
 
@@ -975,7 +975,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
 }
 
 TEST_F(AggressiveDCETest, PrivateStoreElimInEntryNoCalls) {
@@ -1080,7 +1080,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(
       predefs_before + main_before, predefs_after + main_after, true, true);
 }
 
@@ -1135,7 +1135,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
 }
 
 TEST_F(AggressiveDCETest, NoPrivateStoreElimWithCall) {
@@ -1200,7 +1200,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
 }
 
 TEST_F(AggressiveDCETest, NoPrivateStoreElimInNonEntry) {
@@ -1265,7 +1265,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
 }
 
 TEST_F(AggressiveDCETest, WorkgroupStoreElimInEntryNoCalls) {
@@ -1370,7 +1370,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(
       predefs_before + main_before, predefs_after + main_after, true, true);
 }
 
@@ -1482,7 +1482,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(
       predefs_before + func_before, predefs_after + func_after, true, true);
 }
 
@@ -1586,7 +1586,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(
       predefs_before + func_before, predefs_after + func_after, true, true);
 }
 
@@ -1693,7 +1693,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(before, after, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(before, after, true, true);
 }
 
 TEST_F(AggressiveDCETest, EliminateDeadIfThenElseNested) {
@@ -1830,7 +1830,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(
       predefs_before + func_before, predefs_after + func_after, true, true);
 }
 
@@ -1905,7 +1905,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
 }
 
 TEST_F(AggressiveDCETest, NoEliminateLiveIfThenElseNested) {
@@ -2005,7 +2005,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
 }
 
 TEST_F(AggressiveDCETest, NoEliminateIfWithPhi) {
@@ -2071,7 +2071,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
 }
 
 TEST_F(AggressiveDCETest, NoEliminateIfBreak) {
@@ -2152,7 +2152,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
 }
 
 TEST_F(AggressiveDCETest, NoEliminateIfBreak2) {
@@ -2250,7 +2250,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
 }
 
 TEST_F(AggressiveDCETest, EliminateEntireUselessLoop) {
@@ -2394,7 +2394,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(
       predefs1 + names_before + predefs2_before + func_before,
       predefs1 + names_after + predefs2_after + func_after, true, true);
 }
@@ -2474,7 +2474,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
 }
 
 TEST_F(AggressiveDCETest, NoEliminateLiveLoop) {
@@ -2557,7 +2557,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
 }
 
 TEST_F(AggressiveDCETest, EliminateEntireFunctionBody) {
@@ -2661,7 +2661,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(
       predefs_before + func_before, predefs_after + func_after, true, true);
 }
 
@@ -2861,7 +2861,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(
       predefs_before + func_before, predefs_after + func_after, true, true);
 }
 
@@ -3021,7 +3021,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(
       predefs_before + func_before, predefs_after + func_after, true, true);
 }
 
@@ -3144,7 +3144,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(
       predefs_before + func_before, predefs_after + func_after, true, true);
 }
 
@@ -3274,7 +3274,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
 }
 
 TEST_F(AggressiveDCETest, NoEliminateIfContinue) {
@@ -3381,7 +3381,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
 }
 
 TEST_F(AggressiveDCETest, NoEliminateIfContinue2) {
@@ -3485,7 +3485,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
 }
 
 TEST_F(AggressiveDCETest, NoEliminateIfContinue3) {
@@ -3591,7 +3591,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
 }
 
 TEST_F(AggressiveDCETest, PointerVariable) {
@@ -3690,7 +3690,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(before, after, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(before, after, true, true);
 }
 
 // %dead is unused.  Make sure we remove it along with its name.
@@ -3734,7 +3734,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(before, after, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(before, after, true, true);
 }
 
 // Delete %dead because it is unreferenced.  Then %initializer becomes
@@ -3781,7 +3781,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(before, after, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(before, after, true, true);
 }
 
 // Keep %live because it is used, and its initializer.
@@ -3815,7 +3815,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(before, before, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(before, before, true, true);
 }
 
 // This test that the decoration associated with a variable are removed when the
@@ -3867,7 +3867,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(before, after, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(before, after, true, true);
 }
 
 #ifdef SPIRV_EFFCEE
@@ -3914,7 +3914,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::AggressiveDCEPass>(text, true);
+  SinglePassRunAndMatch<opt::AggressiveDCEPassToken>(text, true);
 }
 #endif  //  SPIRV_EFFCEE
 
@@ -3954,7 +3954,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(text, text, false, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(text, text, false, true);
 }
 
 TEST_F(AggressiveDCETest, BasicDeleteDeadFunction) {
@@ -3991,7 +3991,7 @@ TEST_F(AggressiveDCETest, BasicDeleteDeadFunction) {
   };
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(
       JoinAllInsts(Concat(common_code, dead_function)),
       JoinAllInsts(common_code), /* skip_nop = */ true);
 }
@@ -4028,7 +4028,7 @@ TEST_F(AggressiveDCETest, BasicKeepLiveFunction) {
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   std::string assembly = JoinAllInsts(text);
-  auto result = SinglePassRunAndDisassemble<opt::AggressiveDCEPass>(
+  auto result = SinglePassRunAndDisassemble<opt::AggressiveDCEPassToken>(
       assembly, /* skip_nop = */ true, /* do_validation = */ false);
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
   EXPECT_EQ(assembly, std::get<0>(result));
@@ -4088,7 +4088,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(text, expected_output,
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(text, expected_output,
                                                 /* skip_nop = */ true);
 }
 
@@ -4121,7 +4121,7 @@ TEST_F(AggressiveDCETest, BasicAllDeadConstants) {
                OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::AggressiveDCEPass>(text, true);
+  SinglePassRunAndMatch<opt::AggressiveDCEPassToken>(text, true);
 }
 #endif  // SPIRV_EFFCEE
 
@@ -4177,7 +4177,7 @@ TEST_F(AggressiveDCETest, BasicNoneDeadConstants) {
       // clang-format on
   };
   // All constants are used, so none of them should be eliminated.
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(
       JoinAllInsts(text), JoinAllInsts(text), /* skip_nop = */ true);
 }
 
@@ -4246,7 +4246,7 @@ TEST_P(EliminateDeadConstantTest, Custom) {
 
   // Do not enable validation. As the input code is invalid from the base
   // tests (ported from other passes).
-  SinglePassRunAndMatch<opt::AggressiveDCEPass>(assembly_with_dead_const,
+  SinglePassRunAndMatch<opt::AggressiveDCEPassToken>(assembly_with_dead_const,
                                                 false);
 }
 
@@ -5104,7 +5104,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::AggressiveDCEPass>(text, true);
+  SinglePassRunAndMatch<opt::AggressiveDCEPassToken>(text, true);
 }
 
 TEST_F(AggressiveDCETest, ParitallyDeadDecorationGroup) {
@@ -5138,7 +5138,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::AggressiveDCEPass>(text, true);
+  SinglePassRunAndMatch<opt::AggressiveDCEPassToken>(text, true);
 }
 
 TEST_F(AggressiveDCETest, ParitallyDeadDecorationGroupDifferentGroupDecorate) {
@@ -5174,7 +5174,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::AggressiveDCEPass>(text, true);
+  SinglePassRunAndMatch<opt::AggressiveDCEPassToken>(text, true);
 }
 
 TEST_F(AggressiveDCETest, DeadGroupMemberDecorate) {
@@ -5201,7 +5201,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::AggressiveDCEPass>(text, true);
+  SinglePassRunAndMatch<opt::AggressiveDCEPassToken>(text, true);
 }
 
 TEST_F(AggressiveDCETest, PartiallyDeadGroupMemberDecorate) {
@@ -5239,7 +5239,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::AggressiveDCEPass>(text, true);
+  SinglePassRunAndMatch<opt::AggressiveDCEPassToken>(text, true);
 }
 
 TEST_F(AggressiveDCETest,
@@ -5280,7 +5280,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::AggressiveDCEPass>(text, true);
+  SinglePassRunAndMatch<opt::AggressiveDCEPassToken>(text, true);
 }
 
 // Test for #1404
@@ -5305,7 +5305,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::AggressiveDCEPass>(text, true);
+  SinglePassRunAndMatch<opt::AggressiveDCEPassToken>(text, true);
 }
 #endif  // SPIRV_EFFCEE
 
@@ -5351,7 +5351,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(text, text, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(text, text, true, true);
 }
 
 TEST_F(AggressiveDCETest, BreaksDontVisitPhis) {
@@ -5393,7 +5393,7 @@ OpFunctionEnd
 )";
 
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange,
-            std::get<1>(SinglePassRunAndDisassemble<opt::AggressiveDCEPass>(
+            std::get<1>(SinglePassRunAndDisassemble<opt::AggressiveDCEPassToken>(
                 text, false, true)));
 }
 
@@ -5432,7 +5432,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(text, text, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(text, text, true, true);
 }
 
 // Test for #1212
@@ -5472,7 +5472,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(text, text, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(text, text, true, true);
 }
 
 TEST_F(AggressiveDCETest, AtomicAdd) {
@@ -5513,7 +5513,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(text, text, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(text, text, true, true);
 }
 
 TEST_F(AggressiveDCETest, SafelyRemoveDecorateString) {
@@ -5545,7 +5545,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(
       preamble + body_before, preamble + body_after, true, true);
 }
 
@@ -5584,7 +5584,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(test, test, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(test, test, true, true);
 }
 
 TEST_F(AggressiveDCETest, CopyMemoryToLocal) {
@@ -5625,7 +5625,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(test, test, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(test, test, true, true);
 }
 
 TEST_F(AggressiveDCETest, RemoveCopyMemoryToLocal) {
@@ -5691,7 +5691,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(test, result, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(test, result, true, true);
 }
 
 TEST_F(AggressiveDCETest, RemoveCopyMemoryToLocal2) {
@@ -5763,7 +5763,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::AggressiveDCEPass>(test, result, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(test, result, true, true);
 }
 // TODO(greg-lunarg): Add tests to verify handling of these cases:
 //

--- a/test/opt/aggressive_dead_code_elim_test.cpp
+++ b/test/opt/aggressive_dead_code_elim_test.cpp
@@ -546,7 +546,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true,
+                                                     true);
 }
 
 TEST_F(AggressiveDCETest, ElimWithCall) {
@@ -975,7 +976,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true,
+                                                     true);
 }
 
 TEST_F(AggressiveDCETest, PrivateStoreElimInEntryNoCalls) {
@@ -1135,7 +1137,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true,
+                                                     true);
 }
 
 TEST_F(AggressiveDCETest, NoPrivateStoreElimWithCall) {
@@ -1200,7 +1203,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true,
+                                                     true);
 }
 
 TEST_F(AggressiveDCETest, NoPrivateStoreElimInNonEntry) {
@@ -1265,7 +1269,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true,
+                                                     true);
 }
 
 TEST_F(AggressiveDCETest, WorkgroupStoreElimInEntryNoCalls) {
@@ -1905,7 +1910,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true,
+                                                     true);
 }
 
 TEST_F(AggressiveDCETest, NoEliminateLiveIfThenElseNested) {
@@ -2005,7 +2011,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true,
+                                                     true);
 }
 
 TEST_F(AggressiveDCETest, NoEliminateIfWithPhi) {
@@ -2071,7 +2078,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true,
+                                                     true);
 }
 
 TEST_F(AggressiveDCETest, NoEliminateIfBreak) {
@@ -2152,7 +2160,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true,
+                                                     true);
 }
 
 TEST_F(AggressiveDCETest, NoEliminateIfBreak2) {
@@ -2250,7 +2259,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true,
+                                                     true);
 }
 
 TEST_F(AggressiveDCETest, EliminateEntireUselessLoop) {
@@ -2474,7 +2484,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true,
+                                                     true);
 }
 
 TEST_F(AggressiveDCETest, NoEliminateLiveLoop) {
@@ -2557,7 +2568,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true,
+                                                     true);
 }
 
 TEST_F(AggressiveDCETest, EliminateEntireFunctionBody) {
@@ -3274,7 +3286,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true,
+                                                     true);
 }
 
 TEST_F(AggressiveDCETest, NoEliminateIfContinue) {
@@ -3381,7 +3394,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true,
+                                                     true);
 }
 
 TEST_F(AggressiveDCETest, NoEliminateIfContinue2) {
@@ -3485,7 +3499,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true,
+                                                     true);
 }
 
 TEST_F(AggressiveDCETest, NoEliminateIfContinue3) {
@@ -3591,7 +3606,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(assembly, assembly, true,
+                                                     true);
 }
 
 TEST_F(AggressiveDCETest, PointerVariable) {
@@ -3815,7 +3831,8 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(before, before, true, true);
+  SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(before, before, true,
+                                                     true);
 }
 
 // This test that the decoration associated with a variable are removed when the
@@ -4089,7 +4106,7 @@ OpFunctionEnd
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SinglePassRunAndCheck<opt::AggressiveDCEPassToken>(text, expected_output,
-                                                /* skip_nop = */ true);
+                                                     /* skip_nop = */ true);
 }
 
 #ifdef SPIRV_EFFCEE
@@ -4247,7 +4264,7 @@ TEST_P(EliminateDeadConstantTest, Custom) {
   // Do not enable validation. As the input code is invalid from the base
   // tests (ported from other passes).
   SinglePassRunAndMatch<opt::AggressiveDCEPassToken>(assembly_with_dead_const,
-                                                false);
+                                                     false);
 }
 
 INSTANTIATE_TEST_CASE_P(
@@ -5392,9 +5409,10 @@ OpReturn
 OpFunctionEnd
 )";
 
-  EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange,
-            std::get<1>(SinglePassRunAndDisassemble<opt::AggressiveDCEPassToken>(
-                text, false, true)));
+  EXPECT_EQ(
+      opt::Pass::Status::SuccessWithoutChange,
+      std::get<1>(SinglePassRunAndDisassemble<opt::AggressiveDCEPassToken>(
+          text, false, true)));
 }
 
 // Test for #1212

--- a/test/opt/assembly_builder_test.cpp
+++ b/test/opt/assembly_builder_test.cpp
@@ -44,7 +44,7 @@ TEST_F(AssemblyBuilderTest, MinimalShader) {
       // clang-format on
   };
 
-  SinglePassRunAndCheck<opt::NullPass>(builder.GetCode(),
+  SinglePassRunAndCheck<opt::NullPassToken>(builder.GetCode(),
                                        JoinAllInsts(expected),
                                        /* skip_nop = */ false);
 }
@@ -158,7 +158,7 @@ TEST_F(AssemblyBuilderTest, ShaderWithConstants) {
                 "OpFunctionEnd",
       // clang-format on
   };
-  SinglePassRunAndCheck<opt::NullPass>(builder.GetCode(),
+  SinglePassRunAndCheck<opt::NullPassToken>(builder.GetCode(),
                                        JoinAllInsts(expected),
                                        /* skip_nop = */ false);
 }
@@ -242,7 +242,7 @@ TEST_F(AssemblyBuilderTest, SpecConstants) {
       // clang-format on
   };
 
-  SinglePassRunAndCheck<opt::NullPass>(builder.GetCode(),
+  SinglePassRunAndCheck<opt::NullPassToken>(builder.GetCode(),
                                        JoinAllInsts(expected),
                                        /* skip_nop = */ false);
 }
@@ -276,7 +276,7 @@ TEST_F(AssemblyBuilderTest, AppendNames) {
       // clang-format on
   };
 
-  SinglePassRunAndCheck<opt::NullPass>(builder.GetCode(),
+  SinglePassRunAndCheck<opt::NullPassToken>(builder.GetCode(),
                                        JoinAllInsts(expected),
                                        /* skip_nop = */ false);
 }

--- a/test/opt/assembly_builder_test.cpp
+++ b/test/opt/assembly_builder_test.cpp
@@ -45,8 +45,8 @@ TEST_F(AssemblyBuilderTest, MinimalShader) {
   };
 
   SinglePassRunAndCheck<opt::NullPassToken>(builder.GetCode(),
-                                       JoinAllInsts(expected),
-                                       /* skip_nop = */ false);
+                                            JoinAllInsts(expected),
+                                            /* skip_nop = */ false);
 }
 
 TEST_F(AssemblyBuilderTest, ShaderWithConstants) {
@@ -159,8 +159,8 @@ TEST_F(AssemblyBuilderTest, ShaderWithConstants) {
       // clang-format on
   };
   SinglePassRunAndCheck<opt::NullPassToken>(builder.GetCode(),
-                                       JoinAllInsts(expected),
-                                       /* skip_nop = */ false);
+                                            JoinAllInsts(expected),
+                                            /* skip_nop = */ false);
 }
 
 TEST_F(AssemblyBuilderTest, SpecConstants) {
@@ -243,8 +243,8 @@ TEST_F(AssemblyBuilderTest, SpecConstants) {
   };
 
   SinglePassRunAndCheck<opt::NullPassToken>(builder.GetCode(),
-                                       JoinAllInsts(expected),
-                                       /* skip_nop = */ false);
+                                            JoinAllInsts(expected),
+                                            /* skip_nop = */ false);
 }
 
 TEST_F(AssemblyBuilderTest, AppendNames) {
@@ -277,8 +277,8 @@ TEST_F(AssemblyBuilderTest, AppendNames) {
   };
 
   SinglePassRunAndCheck<opt::NullPassToken>(builder.GetCode(),
-                                       JoinAllInsts(expected),
-                                       /* skip_nop = */ false);
+                                            JoinAllInsts(expected),
+                                            /* skip_nop = */ false);
 }
 
 }  // anonymous namespace

--- a/test/opt/block_merge_test.cpp
+++ b/test/opt/block_merge_test.cpp
@@ -84,8 +84,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::BlockMergePassToken>(predefs + before, predefs + after,
-                                             true, true);
+  SinglePassRunAndCheck<opt::BlockMergePassToken>(predefs + before,
+                                                  predefs + after, true, true);
 }
 
 TEST_F(BlockMergeTest, EmptyBlock) {
@@ -154,8 +154,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::BlockMergePassToken>(predefs + before, predefs + after,
-                                             true, true);
+  SinglePassRunAndCheck<opt::BlockMergePassToken>(predefs + before,
+                                                  predefs + after, true, true);
 }
 
 TEST_F(BlockMergeTest, NestedInControlFlow) {
@@ -267,8 +267,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::BlockMergePassToken>(predefs + before, predefs + after,
-                                             true, true);
+  SinglePassRunAndCheck<opt::BlockMergePassToken>(predefs + before,
+                                                  predefs + after, true, true);
 }
 
 #ifdef SPIRV_EFFCEE

--- a/test/opt/block_merge_test.cpp
+++ b/test/opt/block_merge_test.cpp
@@ -84,7 +84,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::BlockMergePass>(predefs + before, predefs + after,
+  SinglePassRunAndCheck<opt::BlockMergePassToken>(predefs + before, predefs + after,
                                              true, true);
 }
 
@@ -154,7 +154,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::BlockMergePass>(predefs + before, predefs + after,
+  SinglePassRunAndCheck<opt::BlockMergePassToken>(predefs + before, predefs + after,
                                              true, true);
 }
 
@@ -267,7 +267,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::BlockMergePass>(predefs + before, predefs + after,
+  SinglePassRunAndCheck<opt::BlockMergePassToken>(predefs + before, predefs + after,
                                              true, true);
 }
 
@@ -306,7 +306,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::BlockMergePass>(text, true);
+  SinglePassRunAndMatch<opt::BlockMergePassToken>(text, true);
 }
 
 TEST_F(BlockMergeTest, UpdateMergeInstruction) {
@@ -342,7 +342,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::BlockMergePass>(text, true);
+  SinglePassRunAndMatch<opt::BlockMergePassToken>(text, true);
 }
 
 TEST_F(BlockMergeTest, TwoMergeBlocksCannotBeMerged) {
@@ -383,7 +383,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::BlockMergePass>(text, true);
+  SinglePassRunAndMatch<opt::BlockMergePassToken>(text, true);
 }
 
 TEST_F(BlockMergeTest, MergeContinue) {
@@ -415,7 +415,7 @@ OpUnreachable
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::BlockMergePass>(text, true);
+  SinglePassRunAndMatch<opt::BlockMergePassToken>(text, true);
 }
 
 TEST_F(BlockMergeTest, TwoHeadersCannotBeMerged) {
@@ -452,7 +452,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::BlockMergePass>(text, true);
+  SinglePassRunAndMatch<opt::BlockMergePassToken>(text, true);
 }
 
 TEST_F(BlockMergeTest, RemoveStructuredDeclaration) {
@@ -516,7 +516,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::BlockMergePass>(assembly, true);
+  SinglePassRunAndMatch<opt::BlockMergePassToken>(assembly, true);
 }
 
 TEST_F(BlockMergeTest, DontMergeKill) {
@@ -548,7 +548,7 @@ OpUnreachable
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::BlockMergePass>(text, true);
+  SinglePassRunAndMatch<opt::BlockMergePassToken>(text, true);
 }
 
 TEST_F(BlockMergeTest, DontMergeUnreachable) {
@@ -580,7 +580,7 @@ OpUnreachable
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::BlockMergePass>(text, true);
+  SinglePassRunAndMatch<opt::BlockMergePassToken>(text, true);
 }
 
 TEST_F(BlockMergeTest, DontMergeReturn) {
@@ -612,7 +612,7 @@ OpUnreachable
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::BlockMergePass>(text, true);
+  SinglePassRunAndMatch<opt::BlockMergePassToken>(text, true);
 }
 
 TEST_F(BlockMergeTest, DontMergeSwitch) {
@@ -648,7 +648,7 @@ OpUnreachable
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::BlockMergePass>(text, true);
+  SinglePassRunAndMatch<opt::BlockMergePassToken>(text, true);
 }
 
 TEST_F(BlockMergeTest, DontMergeReturnValue) {
@@ -687,7 +687,7 @@ OpUnreachable
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::BlockMergePass>(text, true);
+  SinglePassRunAndMatch<opt::BlockMergePassToken>(text, true);
 }
 #endif  // SPIRV_EFFCEE
 

--- a/test/opt/ccp_test.cpp
+++ b/test/opt/ccp_test.cpp
@@ -82,7 +82,7 @@ TEST_F(CCPTest, PropagateThroughPhis) {
                OpFunctionEnd
                )";
 
-  SinglePassRunAndMatch<opt::CCPPass>(spv_asm, true);
+  SinglePassRunAndMatch<opt::CCPPassToken>(spv_asm, true);
 }
 
 TEST_F(CCPTest, SimplifyConditionals) {
@@ -139,7 +139,7 @@ TEST_F(CCPTest, SimplifyConditionals) {
                OpFunctionEnd
                )";
 
-  SinglePassRunAndMatch<opt::CCPPass>(spv_asm, true);
+  SinglePassRunAndMatch<opt::CCPPassToken>(spv_asm, true);
 }
 
 TEST_F(CCPTest, SimplifySwitches) {
@@ -188,7 +188,7 @@ TEST_F(CCPTest, SimplifySwitches) {
                OpFunctionEnd
                )";
 
-  SinglePassRunAndMatch<opt::CCPPass>(spv_asm, true);
+  SinglePassRunAndMatch<opt::CCPPassToken>(spv_asm, true);
 }
 
 TEST_F(CCPTest, SimplifySwitchesDefaultBranch) {
@@ -237,7 +237,7 @@ TEST_F(CCPTest, SimplifySwitchesDefaultBranch) {
                OpFunctionEnd
                )";
 
-  SinglePassRunAndMatch<opt::CCPPass>(spv_asm, true);
+  SinglePassRunAndMatch<opt::CCPPassToken>(spv_asm, true);
 }
 
 TEST_F(CCPTest, SimplifyIntVector) {
@@ -288,7 +288,7 @@ TEST_F(CCPTest, SimplifyIntVector) {
                OpFunctionEnd
                )";
 
-  SinglePassRunAndMatch<opt::CCPPass>(spv_asm, true);
+  SinglePassRunAndMatch<opt::CCPPassToken>(spv_asm, true);
 }
 
 TEST_F(CCPTest, BadSimplifyFloatVector) {
@@ -341,7 +341,7 @@ TEST_F(CCPTest, BadSimplifyFloatVector) {
                OpFunctionEnd
                )";
 
-  SinglePassRunAndMatch<opt::CCPPass>(spv_asm, true);
+  SinglePassRunAndMatch<opt::CCPPassToken>(spv_asm, true);
 }
 
 TEST_F(CCPTest, NoLoadStorePropagation) {
@@ -383,7 +383,7 @@ TEST_F(CCPTest, NoLoadStorePropagation) {
                OpFunctionEnd
                )";
 
-  SinglePassRunAndMatch<opt::CCPPass>(spv_asm, true);
+  SinglePassRunAndMatch<opt::CCPPassToken>(spv_asm, true);
 }
 
 TEST_F(CCPTest, HandleAbortInstructions) {
@@ -416,7 +416,7 @@ TEST_F(CCPTest, HandleAbortInstructions) {
                OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::CCPPass>(spv_asm, true);
+  SinglePassRunAndMatch<opt::CCPPassToken>(spv_asm, true);
 }
 
 TEST_F(CCPTest, SSAWebCycles) {
@@ -467,7 +467,7 @@ TEST_F(CCPTest, SSAWebCycles) {
   )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndMatch<opt::CCPPass>(spv_asm, true);
+  SinglePassRunAndMatch<opt::CCPPassToken>(spv_asm, true);
 }
 
 TEST_F(CCPTest, LoopInductionVariables) {
@@ -521,7 +521,7 @@ TEST_F(CCPTest, LoopInductionVariables) {
                OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::CCPPass>(spv_asm, true);
+  SinglePassRunAndMatch<opt::CCPPassToken>(spv_asm, true);
 }
 
 TEST_F(CCPTest, HandleCompositeWithUndef) {
@@ -552,7 +552,7 @@ TEST_F(CCPTest, HandleCompositeWithUndef) {
                OpFunctionEnd
   )";
 
-  auto res = SinglePassRunToBinary<opt::CCPPass>(spv_asm, true);
+  auto res = SinglePassRunToBinary<opt::CCPPassToken>(spv_asm, true);
   EXPECT_EQ(std::get<1>(res), opt::Pass::Status::SuccessWithoutChange);
 }
 
@@ -579,7 +579,7 @@ TEST_F(CCPTest, SkipSpecConstantInstrucitons) {
                OpFunctionEnd
   )";
 
-  auto res = SinglePassRunToBinary<opt::CCPPass>(spv_asm, true);
+  auto res = SinglePassRunToBinary<opt::CCPPassToken>(spv_asm, true);
   EXPECT_EQ(std::get<1>(res), opt::Pass::Status::SuccessWithoutChange);
 }
 
@@ -639,7 +639,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  auto res = SinglePassRunToBinary<opt::CCPPass>(text, true);
+  auto res = SinglePassRunToBinary<opt::CCPPassToken>(text, true);
   EXPECT_EQ(std::get<1>(res), opt::Pass::Status::SuccessWithoutChange);
 }
 
@@ -678,7 +678,7 @@ TEST_F(CCPTest, UndefInPhi) {
                OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::CCPPass>(text, true);
+  SinglePassRunAndMatch<opt::CCPPassToken>(text, true);
 }
 
 // Just test to make sure the constant fold rules are being used.  Will rely on
@@ -704,7 +704,7 @@ TEST_F(CCPTest, UseConstantFoldingRules) {
                OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::CCPPass>(text, true);
+  SinglePassRunAndMatch<opt::CCPPassToken>(text, true);
 }
 
 // Test for #1300. Previously value for %5 would not settle during simulation.
@@ -731,7 +731,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunToBinary<opt::CCPPass>(text, true);
+  SinglePassRunToBinary<opt::CCPPassToken>(text, true);
 }
 
 TEST_F(CCPTest, NullBranchCondition) {
@@ -762,7 +762,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::CCPPass>(text, true);
+  SinglePassRunAndMatch<opt::CCPPassToken>(text, true);
 }
 
 TEST_F(CCPTest, UndefBranchCondition) {
@@ -793,7 +793,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::CCPPass>(text, true);
+  SinglePassRunAndMatch<opt::CCPPassToken>(text, true);
 }
 
 TEST_F(CCPTest, NullSwitchCondition) {
@@ -823,7 +823,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::CCPPass>(text, true);
+  SinglePassRunAndMatch<opt::CCPPassToken>(text, true);
 }
 
 TEST_F(CCPTest, UndefSwitchCondition) {
@@ -853,7 +853,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::CCPPass>(text, true);
+  SinglePassRunAndMatch<opt::CCPPassToken>(text, true);
 }
 
 // Test for #1361.
@@ -888,7 +888,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::CCPPass>(text, true);
+  SinglePassRunAndMatch<opt::CCPPassToken>(text, true);
 }
 #endif
 

--- a/test/opt/cfg_cleanup_test.cpp
+++ b/test/opt/cfg_cleanup_test.cpp
@@ -79,7 +79,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::CFGCleanupPass>(
+  SinglePassRunAndCheck<opt::CFGCleanupPassToken>(
       declarations + body_before, declarations + body_after, true, true);
 }
 
@@ -142,7 +142,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::CFGCleanupPass>(before, after, true, true);
+  SinglePassRunAndCheck<opt::CFGCleanupPassToken>(before, after, true, true);
 }
 
 TEST_F(CFGCleanupTest, UpdatePhis) {
@@ -226,7 +226,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::CFGCleanupPass>(before, after, true, true);
+  SinglePassRunAndCheck<opt::CFGCleanupPassToken>(before, after, true, true);
 }
 
 TEST_F(CFGCleanupTest, RemoveNamedLabels) {
@@ -261,7 +261,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::CFGCleanupPass>(before, after, true, true);
+  SinglePassRunAndCheck<opt::CFGCleanupPassToken>(before, after, true, true);
 }
 
 TEST_F(CFGCleanupTest, RemovePhiArgsFromFarBlocks) {
@@ -359,7 +359,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::CFGCleanupPass>(before, after, true, true);
+  SinglePassRunAndCheck<opt::CFGCleanupPassToken>(before, after, true, true);
 }
 
 TEST_F(CFGCleanupTest, RemovePhiConstantArgs) {
@@ -438,6 +438,6 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::CFGCleanupPass>(before, after, true, true);
+  SinglePassRunAndCheck<opt::CFGCleanupPassToken>(before, after, true, true);
 }
 }  // anonymous namespace

--- a/test/opt/common_uniform_elim_test.cpp
+++ b/test/opt/common_uniform_elim_test.cpp
@@ -165,7 +165,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::CommonUniformElimPass>(
+  SinglePassRunAndCheck<opt::CommonUniformElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -329,7 +329,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::CommonUniformElimPass>(
+  SinglePassRunAndCheck<opt::CommonUniformElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -448,7 +448,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::CommonUniformElimPass>(
+  SinglePassRunAndCheck<opt::CommonUniformElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -659,7 +659,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::CommonUniformElimPass>(
+  SinglePassRunAndCheck<opt::CommonUniformElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -809,7 +809,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::CommonUniformElimPass>(
+  SinglePassRunAndCheck<opt::CommonUniformElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -919,7 +919,7 @@ OpFunctionEnd
 )";
 
   opt::Pass::Status res =
-      std::get<1>(SinglePassRunAndDisassemble<opt::CommonUniformElimPass>(
+      std::get<1>(SinglePassRunAndDisassemble<opt::CommonUniformElimPassToken>(
           text, true, false));
   EXPECT_EQ(res, opt::Pass::Status::SuccessWithoutChange);
 }
@@ -1037,7 +1037,7 @@ OpFunctionEnd
 )";
 
   opt::Pass::Status res =
-      std::get<1>(SinglePassRunAndDisassemble<opt::CommonUniformElimPass>(
+      std::get<1>(SinglePassRunAndDisassemble<opt::CommonUniformElimPassToken>(
           text, true, false));
   EXPECT_EQ(res, opt::Pass::Status::SuccessWithoutChange);
 }
@@ -1215,7 +1215,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::CommonUniformElimPass>(
+  SinglePassRunAndCheck<opt::CommonUniformElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -1327,7 +1327,7 @@ TEST_F(CommonUniformElimTest, MixedConstantAndNonConstantIndexes) {
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndMatch<opt::CommonUniformElimPass>(text, true);
+  SinglePassRunAndMatch<opt::CommonUniformElimPassToken>(text, true);
 }
 #endif  //  SPIRV_EFFCEE
 // TODO(greg-lunarg): Add tests to verify handling of these cases:

--- a/test/opt/compact_ids_test.cpp
+++ b/test/opt/compact_ids_test.cpp
@@ -43,7 +43,7 @@ OpMemoryModel Physical32 OpenCL
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::NullPass>(before, after, false, false);
+  SinglePassRunAndCheck<opt::NullPassToken>(before, after, false, false);
 }
 
 TEST_F(CompactIdsTest, PassOn) {
@@ -87,7 +87,7 @@ OpFunctionEnd
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::CompactIdsPass>(before, after, false, false);
+  SinglePassRunAndCheck<opt::CompactIdsPassToken>(before, after, false, false);
 }
 
 TEST(CompactIds, InstructionResultIsUpdated) {

--- a/test/opt/copy_prop_array_test.cpp
+++ b/test/opt/copy_prop_array_test.cpp
@@ -1266,6 +1266,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::CopyPropagateArraysToken>(before, after, true, true);
+  SinglePassRunAndCheck<opt::CopyPropagateArraysToken>(before, after, true,
+                                                       true);
 }
 }  // namespace

--- a/test/opt/copy_prop_array_test.cpp
+++ b/test/opt/copy_prop_array_test.cpp
@@ -105,7 +105,7 @@ OpFunctionEnd
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
                         SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
-  SinglePassRunAndMatch<opt::CopyPropagateArrays>(before, false);
+  SinglePassRunAndMatch<opt::CopyPropagateArraysToken>(before, false);
 }
 
 TEST_F(CopyPropArrayPassTest, BasicPropagateArrayWithName) {
@@ -185,7 +185,7 @@ OpFunctionEnd
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
                         SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
-  SinglePassRunAndMatch<opt::CopyPropagateArrays>(before, false);
+  SinglePassRunAndMatch<opt::CopyPropagateArraysToken>(before, false);
 }
 
 // Propagate 2d array.  This test identifying a copy through multiple levels.
@@ -274,7 +274,7 @@ OpFunctionEnd
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
                         SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
-  SinglePassRunAndMatch<opt::CopyPropagateArrays>(text, false);
+  SinglePassRunAndMatch<opt::CopyPropagateArraysToken>(text, false);
 }
 
 // Propagate 2d array.  This test identifying a copy through multiple levels.
@@ -361,7 +361,7 @@ OpFunctionEnd
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
                         SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
-  SinglePassRunAndMatch<opt::CopyPropagateArrays>(text, false);
+  SinglePassRunAndMatch<opt::CopyPropagateArraysToken>(text, false);
 }
 
 // Test decomposing an object when we need to "rewrite" a store.
@@ -446,7 +446,7 @@ TEST_F(CopyPropArrayPassTest, DecomposeObjectForArrayStore) {
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
                         SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
-  SinglePassRunAndMatch<opt::CopyPropagateArrays>(text, false);
+  SinglePassRunAndMatch<opt::CopyPropagateArraysToken>(text, false);
 }
 
 // Test decomposing an object when we need to "rewrite" a store.
@@ -534,7 +534,7 @@ TEST_F(CopyPropArrayPassTest, DecomposeObjectForStructStore) {
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
                         SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
-  SinglePassRunAndMatch<opt::CopyPropagateArrays>(text, false);
+  SinglePassRunAndMatch<opt::CopyPropagateArraysToken>(text, false);
 }
 
 TEST_F(CopyPropArrayPassTest, CopyViaInserts) {
@@ -621,7 +621,7 @@ OpFunctionEnd
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
                         SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
-  SinglePassRunAndMatch<opt::CopyPropagateArrays>(before, false);
+  SinglePassRunAndMatch<opt::CopyPropagateArraysToken>(before, false);
 }
 #endif  // SPIRV_EFFCEE
 
@@ -697,7 +697,7 @@ OpFunctionEnd
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
                         SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
-  auto result = SinglePassRunAndDisassemble<opt::CopyPropagateArrays>(
+  auto result = SinglePassRunAndDisassemble<opt::CopyPropagateArraysToken>(
       text, /* skip_nop = */ true, /* do_validation = */ false);
 
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
@@ -785,7 +785,7 @@ OpFunctionEnd
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
                         SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
-  auto result = SinglePassRunAndDisassemble<opt::CopyPropagateArrays>(
+  auto result = SinglePassRunAndDisassemble<opt::CopyPropagateArraysToken>(
       text, /* skip_nop = */ true, /* do_validation = */ false);
 
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
@@ -864,7 +864,7 @@ OpFunctionEnd
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
                         SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
-  auto result = SinglePassRunAndDisassemble<opt::CopyPropagateArrays>(
+  auto result = SinglePassRunAndDisassemble<opt::CopyPropagateArraysToken>(
       text, /* skip_nop = */ true, /* do_validation = */ false);
 
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
@@ -942,7 +942,7 @@ OpFunctionEnd
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
                         SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
-  auto result = SinglePassRunAndDisassemble<opt::CopyPropagateArrays>(
+  auto result = SinglePassRunAndDisassemble<opt::CopyPropagateArraysToken>(
       text, /* skip_nop = */ true, /* do_validation = */ false);
 
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
@@ -1024,7 +1024,7 @@ OpFunctionEnd
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
                         SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
-  auto result = SinglePassRunAndDisassemble<opt::CopyPropagateArrays>(
+  auto result = SinglePassRunAndDisassemble<opt::CopyPropagateArraysToken>(
       text, /* skip_nop = */ true, /* do_validation = */ false);
 
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
@@ -1106,7 +1106,7 @@ OpFunctionEnd
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
                         SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
-  auto result = SinglePassRunAndDisassemble<opt::CopyPropagateArrays>(
+  auto result = SinglePassRunAndDisassemble<opt::CopyPropagateArraysToken>(
       text, /* skip_nop = */ true, /* do_validation = */ false);
 
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
@@ -1186,7 +1186,7 @@ OpFunctionEnd
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
                         SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
-  auto result = SinglePassRunAndDisassemble<opt::CopyPropagateArrays>(
+  auto result = SinglePassRunAndDisassemble<opt::CopyPropagateArraysToken>(
       text, /* skip_nop = */ true, /* do_validation = */ false);
 
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
@@ -1266,6 +1266,6 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::CopyPropagateArrays>(before, after, true, true);
+  SinglePassRunAndCheck<opt::CopyPropagateArraysToken>(before, after, true, true);
 }
 }  // namespace

--- a/test/opt/dead_branch_elim_test.cpp
+++ b/test/opt/dead_branch_elim_test.cpp
@@ -99,8 +99,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
-                                                 predefs + after, true, true);
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(
+      predefs + before, predefs + after, true, true);
 }
 
 TEST_F(DeadBranchElimTest, IfThenElseFalse) {
@@ -180,8 +180,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
-                                                 predefs + after, true, true);
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(
+      predefs + before, predefs + after, true, true);
 }
 
 TEST_F(DeadBranchElimTest, IfThenTrue) {
@@ -262,8 +262,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
-                                                 predefs + after, true, true);
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(
+      predefs + before, predefs + after, true, true);
 }
 
 TEST_F(DeadBranchElimTest, IfThenFalse) {
@@ -339,8 +339,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
-                                                 predefs + after, true, true);
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(
+      predefs + before, predefs + after, true, true);
 }
 
 TEST_F(DeadBranchElimTest, IfThenElsePhiTrue) {
@@ -412,8 +412,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
-                                                 predefs + after, true, true);
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(
+      predefs + before, predefs + after, true, true);
 }
 
 TEST_F(DeadBranchElimTest, IfThenElsePhiFalse) {
@@ -485,8 +485,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
-                                                 predefs + after, true, true);
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(
+      predefs + before, predefs + after, true, true);
 }
 
 TEST_F(DeadBranchElimTest, CompoundIfThenElseFalse) {
@@ -620,8 +620,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
-                                                 predefs + after, true, true);
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(
+      predefs + before, predefs + after, true, true);
 }
 
 TEST_F(DeadBranchElimTest, PreventOrphanMerge) {
@@ -684,8 +684,8 @@ OpKill
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
-                                                 predefs + after, true, true);
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(
+      predefs + before, predefs + after, true, true);
 }
 
 TEST_F(DeadBranchElimTest, HandleOrphanMerge) {
@@ -745,8 +745,8 @@ OpReturnValue %13
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
-                                                 predefs + after, true, true);
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(
+      predefs + before, predefs + after, true, true);
 }
 
 TEST_F(DeadBranchElimTest, KeepContinueTargetWhenKillAfterMerge) {
@@ -843,8 +843,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
-                                                 predefs + after, true, true);
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(
+      predefs + before, predefs + after, true, true);
 }
 
 TEST_F(DeadBranchElimTest, DecorateDeleted) {
@@ -1053,8 +1053,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
-                                                 predefs + after, true, true);
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(
+      predefs + before, predefs + after, true, true);
 }
 
 TEST_F(DeadBranchElimTest, SwitchLiveCase) {
@@ -1146,8 +1146,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
-                                                 predefs + after, true, true);
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(
+      predefs + before, predefs + after, true, true);
 }
 
 TEST_F(DeadBranchElimTest, SwitchLiveDefault) {
@@ -1239,8 +1239,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
-                                                 predefs + after, true, true);
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(
+      predefs + before, predefs + after, true, true);
 }
 
 TEST_F(DeadBranchElimTest, SwitchLiveCaseBreakFromLoop) {
@@ -1342,8 +1342,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
-                                                 predefs + after, true, true);
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(
+      predefs + before, predefs + after, true, true);
 }
 
 #ifdef SPIRV_EFFCEE

--- a/test/opt/dead_branch_elim_test.cpp
+++ b/test/opt/dead_branch_elim_test.cpp
@@ -99,7 +99,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPass>(predefs + before,
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
                                                  predefs + after, true, true);
 }
 
@@ -180,7 +180,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPass>(predefs + before,
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
                                                  predefs + after, true, true);
 }
 
@@ -228,13 +228,13 @@ OpName %gl_FragColor "gl_FragColor"
 %17 = OpLabel
 %v = OpVariable %_ptr_Function_v4float Function
 %18 = OpLoad %v4float %BaseColor
-OpStore %v %18 
-OpSelectionMerge %19 None 
+OpStore %v %18
+OpSelectionMerge %19 None
 OpBranchConditional %true %20 %19
 %20 = OpLabel
 %21 = OpLoad %v4float %v
 %22 = OpFMul %v4float %21 %15
-OpStore %v %22 
+OpStore %v %22
 OpBranch %19
 %19 = OpLabel
 %23 = OpLoad %v4float %v
@@ -262,7 +262,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPass>(predefs + before,
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
                                                  predefs + after, true, true);
 }
 
@@ -310,13 +310,13 @@ OpName %gl_FragColor "gl_FragColor"
 %17 = OpLabel
 %v = OpVariable %_ptr_Function_v4float Function
 %18 = OpLoad %v4float %BaseColor
-OpStore %v %18 
-OpSelectionMerge %19 None 
+OpStore %v %18
+OpSelectionMerge %19 None
 OpBranchConditional %false %20 %19
 %20 = OpLabel
 %21 = OpLoad %v4float %v
 %22 = OpFMul %v4float %21 %15
-OpStore %v %22 
+OpStore %v %22
 OpBranch %19
 %19 = OpLabel
 %23 = OpLoad %v4float %v
@@ -339,7 +339,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPass>(predefs + before,
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
                                                  predefs + after, true, true);
 }
 
@@ -412,7 +412,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPass>(predefs + before,
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
                                                  predefs + after, true, true);
 }
 
@@ -485,7 +485,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPass>(predefs + before,
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
                                                  predefs + after, true, true);
 }
 
@@ -558,7 +558,7 @@ OpDecorate %_ DescriptorSet 0
 %25 = OpLabel
 %v = OpVariable %_ptr_Function_v4float Function
 OpSelectionMerge %26 None
-OpBranchConditional %false %27 %28 
+OpBranchConditional %false %27 %28
 %27 = OpLabel
 %29 = OpAccessChain %_ptr_Uniform_uint %_ %int_0
 %30 = OpLoad %uint %29
@@ -620,7 +620,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPass>(predefs + before,
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
                                                  predefs + after, true, true);
 }
 
@@ -684,7 +684,7 @@ OpKill
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPass>(predefs + before,
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
                                                  predefs + after, true, true);
 }
 
@@ -731,7 +731,7 @@ OpReturnValue %13
 %22 = OpLabel
 OpReturnValue %15
 %20 = OpLabel
-%23 = OpUndef %v4float 
+%23 = OpUndef %v4float
 OpReturnValue %23
 OpFunctionEnd
 )";
@@ -745,7 +745,7 @@ OpReturnValue %13
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPass>(predefs + before,
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
                                                  predefs + after, true, true);
 }
 
@@ -802,7 +802,7 @@ OpBranchConditional %17 %19 %18
 OpBranch %13
 %18 = OpLabel
 OpSelectionMerge %20 None
-OpBranchConditional %false %21 %20 
+OpBranchConditional %false %21 %20
 %21 = OpLabel
 OpBranch %13
 %20 = OpLabel
@@ -843,7 +843,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPass>(predefs + before,
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
                                                  predefs + after, true, true);
 }
 
@@ -919,13 +919,13 @@ OpName %gl_FragColor "gl_FragColor"
 %17 = OpLabel
 %v = OpVariable %_ptr_Function_v4float Function
 %18 = OpLoad %v4float %BaseColor
-OpStore %v %18 
-OpSelectionMerge %19 None 
+OpStore %v %18
+OpSelectionMerge %19 None
 OpBranchConditional %false %20 %19
 %20 = OpLabel
 %21 = OpLoad %v4float %v
 %22 = OpFMul %v4float %21 %15
-OpStore %v %22 
+OpStore %v %22
 OpBranch %19
 %19 = OpLabel
 %23 = OpLoad %v4float %v
@@ -948,7 +948,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPass>(
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(
       predefs_before + before, predefs_after + after, true, true);
 }
 
@@ -1008,7 +1008,7 @@ OpDecorate %OutColor Location 0
 %23 = OpLoad %v4float %BaseColor
 OpStore %v %23
 OpSelectionMerge %24 None
-OpBranchConditional %false %25 %24 
+OpBranchConditional %false %25 %24
 %25 = OpLabel
 OpStore %i %int_0
 OpBranch %26
@@ -1053,7 +1053,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPass>(predefs + before,
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
                                                  predefs + after, true, true);
 }
 
@@ -1115,20 +1115,20 @@ OpDecorate %BaseColor Location 0
   const std::string before =
       R"(%main = OpFunction %void None %6
 %21 = OpLabel
-OpSelectionMerge %22 None 
+OpSelectionMerge %22 None
 OpSwitch %int_1 %23 0 %24 1 %25 2 %26
 %23 = OpLabel
 OpStore %OutColor %19
-OpBranch %22 
+OpBranch %22
 %24 = OpLabel
 OpStore %OutColor %13
-OpBranch %22 
+OpBranch %22
 %25 = OpLabel
 OpStore %OutColor %15
-OpBranch %22 
+OpBranch %22
 %26 = OpLabel
 OpStore %OutColor %17
-OpBranch %22 
+OpBranch %22
 %22 = OpLabel
 OpReturn
 OpFunctionEnd
@@ -1146,7 +1146,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPass>(predefs + before,
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
                                                  predefs + after, true, true);
 }
 
@@ -1208,20 +1208,20 @@ OpDecorate %BaseColor Location 0
   const std::string before =
       R"(%main = OpFunction %void None %6
 %21 = OpLabel
-OpSelectionMerge %22 None 
+OpSelectionMerge %22 None
 OpSwitch %int_7 %23 0 %24 1 %25 2 %26
 %23 = OpLabel
 OpStore %OutColor %19
-OpBranch %22 
+OpBranch %22
 %24 = OpLabel
 OpStore %OutColor %13
-OpBranch %22 
+OpBranch %22
 %25 = OpLabel
 OpStore %OutColor %15
-OpBranch %22 
+OpBranch %22
 %26 = OpLabel
 OpStore %OutColor %17
-OpBranch %22 
+OpBranch %22
 %22 = OpLabel
 OpReturn
 OpFunctionEnd
@@ -1239,7 +1239,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPass>(predefs + before,
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
                                                  predefs + after, true, true);
 }
 
@@ -1304,13 +1304,13 @@ OpStore %oc %17
 OpBranch %28
 %33 = OpLabel
 OpStore %oc %19
-OpBranch %28 
+OpBranch %28
 %34 = OpLabel
 OpStore %oc %21
-OpBranch %28 
+OpBranch %28
 %31 = OpLabel
 OpStore %oc %23
-OpBranch %28 
+OpBranch %28
 %29 = OpLabel
 OpBranchConditional %false %27 %28
 %28 = OpLabel
@@ -1342,7 +1342,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadBranchElimPass>(predefs + before,
+  SinglePassRunAndCheck<opt::DeadBranchElimPassToken>(predefs + before,
                                                  predefs + after, true, true);
 }
 
@@ -1375,7 +1375,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::DeadBranchElimPass>(text, true);
+  SinglePassRunAndMatch<opt::DeadBranchElimPassToken>(text, true);
 }
 TEST_F(DeadBranchElimTest, LeaveContinueBackedgeExtraBlock) {
   const std::string text = R"(
@@ -1412,7 +1412,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::DeadBranchElimPass>(text, true);
+  SinglePassRunAndMatch<opt::DeadBranchElimPassToken>(text, true);
 }
 
 TEST_F(DeadBranchElimTest, RemovePhiWithUnreachableContinue) {
@@ -1453,7 +1453,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::DeadBranchElimPass>(text, true);
+  SinglePassRunAndMatch<opt::DeadBranchElimPassToken>(text, true);
 }
 
 TEST_F(DeadBranchElimTest, UnreachableLoopMergeAndContinueTargets) {
@@ -1502,7 +1502,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::DeadBranchElimPass>(text, true);
+  SinglePassRunAndMatch<opt::DeadBranchElimPassToken>(text, true);
 }
 TEST_F(DeadBranchElimTest, EarlyReconvergence) {
   const std::string text = R"(
@@ -1548,7 +1548,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::DeadBranchElimPass>(text, true);
+  SinglePassRunAndMatch<opt::DeadBranchElimPassToken>(text, true);
 }
 
 TEST_F(DeadBranchElimTest, RemoveUnreachableBlocksFloating) {
@@ -1572,7 +1572,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::DeadBranchElimPass>(text, true);
+  SinglePassRunAndMatch<opt::DeadBranchElimPassToken>(text, true);
 }
 
 TEST_F(DeadBranchElimTest, RemoveUnreachableBlocksFloatingJoin) {
@@ -1609,7 +1609,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::DeadBranchElimPass>(text, true);
+  SinglePassRunAndMatch<opt::DeadBranchElimPassToken>(text, true);
 }
 
 TEST_F(DeadBranchElimTest, RemoveUnreachableBlocksDeadPhi) {
@@ -1645,7 +1645,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::DeadBranchElimPass>(text, true);
+  SinglePassRunAndMatch<opt::DeadBranchElimPassToken>(text, true);
 }
 
 TEST_F(DeadBranchElimTest, RemoveUnreachableBlocksPartiallyDeadPhi) {
@@ -1687,7 +1687,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndMatch<opt::DeadBranchElimPass>(text, true);
+  SinglePassRunAndMatch<opt::DeadBranchElimPassToken>(text, true);
 }
 
 TEST_F(DeadBranchElimTest, LiveHeaderDeadPhi) {
@@ -1719,7 +1719,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::DeadBranchElimPass>(text, true);
+  SinglePassRunAndMatch<opt::DeadBranchElimPassToken>(text, true);
 }
 
 TEST_F(DeadBranchElimTest, ExtraBackedgeBlocksLive) {
@@ -1762,7 +1762,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::DeadBranchElimPass>(text, true);
+  SinglePassRunAndMatch<opt::DeadBranchElimPassToken>(text, true);
 }
 
 TEST_F(DeadBranchElimTest, ExtraBackedgeBlocksUnreachable) {
@@ -1804,7 +1804,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::DeadBranchElimPass>(text, true);
+  SinglePassRunAndMatch<opt::DeadBranchElimPassToken>(text, true);
 }
 
 TEST_F(DeadBranchElimTest, NoUnnecessaryChanges) {
@@ -1832,7 +1832,7 @@ OpUnreachable
 OpFunctionEnd
 )";
 
-  auto result = SinglePassRunToBinary<opt::DeadBranchElimPass>(text, true);
+  auto result = SinglePassRunToBinary<opt::DeadBranchElimPassToken>(text, true);
   EXPECT_EQ(std::get<1>(result), opt::Pass::Status::SuccessWithoutChange);
 }
 
@@ -1887,7 +1887,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::DeadBranchElimPass>(text, true);
+  SinglePassRunAndMatch<opt::DeadBranchElimPassToken>(text, true);
 }
 
 TEST_F(DeadBranchElimTest, UnreachableContinuePhiInMerge) {
@@ -1974,7 +1974,7 @@ TEST_F(DeadBranchElimTest, UnreachableContinuePhiInMerge) {
                OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::DeadBranchElimPass>(text, true);
+  SinglePassRunAndMatch<opt::DeadBranchElimPassToken>(text, true);
 }
 
 TEST_F(DeadBranchElimTest, NonStructuredIf) {
@@ -2000,7 +2000,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::DeadBranchElimPass>(text, true);
+  SinglePassRunAndMatch<opt::DeadBranchElimPassToken>(text, true);
 }
 #endif
 

--- a/test/opt/dead_insert_elim_test.cpp
+++ b/test/opt/dead_insert_elim_test.cpp
@@ -164,7 +164,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadInsertElimPass>(
+  SinglePassRunAndCheck<opt::DeadInsertElimPassToken>(
       before_predefs + before, after_predefs + after, true, true);
 }
 
@@ -343,7 +343,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadInsertElimPass>(
+  SinglePassRunAndCheck<opt::DeadInsertElimPassToken>(
       before_predefs + before, after_predefs + after, true, true);
 }
 
@@ -557,7 +557,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadInsertElimPass>(
+  SinglePassRunAndCheck<opt::DeadInsertElimPassToken>(
       before_predefs + before, after_predefs + after, true, true);
 }
 

--- a/test/opt/dead_variable_elim_test.cpp
+++ b/test/opt/dead_variable_elim_test.cpp
@@ -64,7 +64,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::DeadVariableElimination>(before, after, true,
+  SinglePassRunAndCheck<opt::DeadVariableEliminationToken>(before, after, true,
                                                       true);
 }
 
@@ -94,7 +94,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::DeadVariableElimination>(before, before, true,
+  SinglePassRunAndCheck<opt::DeadVariableEliminationToken>(before, before, true,
                                                       true);
 }
 
@@ -144,7 +144,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::DeadVariableElimination>(before, after, true,
+  SinglePassRunAndCheck<opt::DeadVariableEliminationToken>(before, after, true,
                                                       true);
 }
 
@@ -198,7 +198,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::DeadVariableElimination>(before, after, true,
+  SinglePassRunAndCheck<opt::DeadVariableEliminationToken>(before, after, true,
                                                       true);
 }
 
@@ -229,7 +229,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::DeadVariableElimination>(before, before, true,
+  SinglePassRunAndCheck<opt::DeadVariableEliminationToken>(before, before, true,
                                                       true);
 }
 
@@ -293,7 +293,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::DeadVariableElimination>(before, after, true,
+  SinglePassRunAndCheck<opt::DeadVariableEliminationToken>(before, after, true,
                                                       true);
 }
 }  // namespace

--- a/test/opt/dead_variable_elim_test.cpp
+++ b/test/opt/dead_variable_elim_test.cpp
@@ -65,7 +65,7 @@ OpFunctionEnd
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SinglePassRunAndCheck<opt::DeadVariableEliminationToken>(before, after, true,
-                                                      true);
+                                                           true);
 }
 
 // Since %dead is exported, make sure we keep it.  It could be referenced
@@ -95,7 +95,7 @@ OpFunctionEnd
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SinglePassRunAndCheck<opt::DeadVariableEliminationToken>(before, before, true,
-                                                      true);
+                                                           true);
 }
 
 // Delete %dead because it is unreferenced.  Then %initializer becomes
@@ -145,7 +145,7 @@ OpFunctionEnd
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SinglePassRunAndCheck<opt::DeadVariableEliminationToken>(before, after, true,
-                                                      true);
+                                                           true);
 }
 
 // Delete %dead because it is unreferenced.  In this case, the initialized has
@@ -199,7 +199,7 @@ OpFunctionEnd
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SinglePassRunAndCheck<opt::DeadVariableEliminationToken>(before, after, true,
-                                                      true);
+                                                           true);
 }
 
 // Keep %live because it is used, and its initializer.
@@ -230,7 +230,7 @@ OpFunctionEnd
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SinglePassRunAndCheck<opt::DeadVariableEliminationToken>(before, before, true,
-                                                      true);
+                                                           true);
 }
 
 // This test that the decoration associated with a variable are removed when the
@@ -294,6 +294,6 @@ OpFunctionEnd
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SinglePassRunAndCheck<opt::DeadVariableEliminationToken>(before, after, true,
-                                                      true);
+                                                           true);
 }
 }  // namespace

--- a/test/opt/eliminate_dead_const_test.cpp
+++ b/test/opt/eliminate_dead_const_test.cpp
@@ -73,7 +73,7 @@ TEST_F(EliminateDeadConstantBasicTest, BasicAllDeadConstants) {
             });
       });
 
-  SinglePassRunAndCheck<opt::EliminateDeadConstantPass>(
+  SinglePassRunAndCheck<opt::EliminateDeadConstantPassToken>(
       JoinAllInsts(text), expected_disassembly, /* skip_nop = */ true);
 }
 
@@ -129,7 +129,7 @@ TEST_F(EliminateDeadConstantBasicTest, BasicNoneDeadConstants) {
       // clang-format on
   };
   // All constants are used, so none of them should be eliminated.
-  SinglePassRunAndCheck<opt::EliminateDeadConstantPass>(
+  SinglePassRunAndCheck<opt::EliminateDeadConstantPassToken>(
       JoinAllInsts(text), JoinAllInsts(text), /* skip_nop = */ true);
 }
 
@@ -191,7 +191,7 @@ TEST_P(EliminateDeadConstantTest, Custom) {
   const std::string expected = builder.GetCode();
   builder.AppendTypesConstantsGlobals(tc.dead_consts);
   const std::string assembly_with_dead_const = builder.GetCode();
-  SinglePassRunAndCheck<opt::EliminateDeadConstantPass>(
+  SinglePassRunAndCheck<opt::EliminateDeadConstantPassToken>(
       assembly_with_dead_const, expected, /*  skip_nop = */ true);
 }
 

--- a/test/opt/eliminate_dead_functions_test.cpp
+++ b/test/opt/eliminate_dead_functions_test.cpp
@@ -98,8 +98,9 @@ TEST_F(EliminateDeadFunctionsBasicTest, BasicKeepLiveFunction) {
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   std::string assembly = JoinAllInsts(text);
-  auto result = SinglePassRunAndDisassemble<opt::EliminateDeadFunctionsPassToken>(
-      assembly, /* skip_nop = */ true, /* do_validation = */ false);
+  auto result =
+      SinglePassRunAndDisassemble<opt::EliminateDeadFunctionsPassToken>(
+          assembly, /* skip_nop = */ true, /* do_validation = */ false);
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
   EXPECT_EQ(assembly, std::get<0>(result));
 }
@@ -137,8 +138,9 @@ TEST_F(EliminateDeadFunctionsBasicTest, BasicKeepExportFunctions) {
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   std::string assembly = JoinAllInsts(text);
-  auto result = SinglePassRunAndDisassemble<opt::EliminateDeadFunctionsPassToken>(
-      assembly, /* skip_nop = */ true, /* do_validation = */ false);
+  auto result =
+      SinglePassRunAndDisassemble<opt::EliminateDeadFunctionsPassToken>(
+          assembly, /* skip_nop = */ true, /* do_validation = */ false);
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
   EXPECT_EQ(assembly, std::get<0>(result));
 }
@@ -200,7 +202,8 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::EliminateDeadFunctionsPassToken>(text, expected_output,
-                                                         /* skip_nop = */ true);
+  SinglePassRunAndCheck<opt::EliminateDeadFunctionsPassToken>(
+      text, expected_output,
+      /* skip_nop = */ true);
 }
 }  // anonymous namespace

--- a/test/opt/eliminate_dead_functions_test.cpp
+++ b/test/opt/eliminate_dead_functions_test.cpp
@@ -61,7 +61,7 @@ TEST_F(EliminateDeadFunctionsBasicTest, BasicDeleteDeadFunction) {
   };
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::EliminateDeadFunctionsPass>(
+  SinglePassRunAndCheck<opt::EliminateDeadFunctionsPassToken>(
       JoinAllInsts(Concat(common_code, dead_function)),
       JoinAllInsts(common_code), /* skip_nop = */ true);
 }
@@ -98,7 +98,7 @@ TEST_F(EliminateDeadFunctionsBasicTest, BasicKeepLiveFunction) {
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   std::string assembly = JoinAllInsts(text);
-  auto result = SinglePassRunAndDisassemble<opt::EliminateDeadFunctionsPass>(
+  auto result = SinglePassRunAndDisassemble<opt::EliminateDeadFunctionsPassToken>(
       assembly, /* skip_nop = */ true, /* do_validation = */ false);
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
   EXPECT_EQ(assembly, std::get<0>(result));
@@ -137,7 +137,7 @@ TEST_F(EliminateDeadFunctionsBasicTest, BasicKeepExportFunctions) {
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   std::string assembly = JoinAllInsts(text);
-  auto result = SinglePassRunAndDisassemble<opt::EliminateDeadFunctionsPass>(
+  auto result = SinglePassRunAndDisassemble<opt::EliminateDeadFunctionsPassToken>(
       assembly, /* skip_nop = */ true, /* do_validation = */ false);
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
   EXPECT_EQ(assembly, std::get<0>(result));
@@ -200,7 +200,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::EliminateDeadFunctionsPass>(text, expected_output,
+  SinglePassRunAndCheck<opt::EliminateDeadFunctionsPassToken>(text, expected_output,
                                                          /* skip_nop = */ true);
 }
 }  // anonymous namespace

--- a/test/opt/flatten_decoration_test.cpp
+++ b/test/opt/flatten_decoration_test.cpp
@@ -75,7 +75,7 @@ TEST_P(FlattenDecorationTest, TransformsDecorations) {
   const auto after =
       PreambleAssembly() + GetParam().expected + TypesAndFunctionsAssembly();
 
-  SinglePassRunAndCheck<opt::FlattenDecorationPass>(before, after, false, true);
+  SinglePassRunAndCheck<opt::FlattenDecorationPassToken>(before, after, false, true);
 }
 
 INSTANTIATE_TEST_CASE_P(NoUses, FlattenDecorationTest,

--- a/test/opt/flatten_decoration_test.cpp
+++ b/test/opt/flatten_decoration_test.cpp
@@ -75,7 +75,8 @@ TEST_P(FlattenDecorationTest, TransformsDecorations) {
   const auto after =
       PreambleAssembly() + GetParam().expected + TypesAndFunctionsAssembly();
 
-  SinglePassRunAndCheck<opt::FlattenDecorationPassToken>(before, after, false, true);
+  SinglePassRunAndCheck<opt::FlattenDecorationPassToken>(before, after, false,
+                                                         true);
 }
 
 INSTANTIATE_TEST_CASE_P(NoUses, FlattenDecorationTest,

--- a/test/opt/fold_spec_const_op_composite_test.cpp
+++ b/test/opt/fold_spec_const_op_composite_test.cpp
@@ -25,7 +25,7 @@ using namespace spvtools;
 using FoldSpecConstantOpAndCompositePassBasicTest = PassTest<::testing::Test>;
 
 TEST_F(FoldSpecConstantOpAndCompositePassBasicTest, Empty) {
-  SinglePassRunAndCheck<opt::FoldSpecConstantOpAndCompositePass>(
+  SinglePassRunAndCheck<opt::FoldSpecConstantOpAndCompositePassToken>(
       "", "", /* skip_nop = */ true);
 }
 
@@ -73,7 +73,7 @@ TEST_F(FoldSpecConstantOpAndCompositePassBasicTest, Basic) {
                     "OpFunctionEnd",
       // clang-format on
   };
-  SinglePassRunAndCheck<opt::FoldSpecConstantOpAndCompositePass>(
+  SinglePassRunAndCheck<opt::FoldSpecConstantOpAndCompositePassToken>(
       builder.GetCode(), JoinAllInsts(expected), /* skip_nop = */ true);
 }
 
@@ -99,7 +99,7 @@ TEST_F(FoldSpecConstantOpAndCompositePassBasicTest,
           // clang-format on
       });
 
-  SinglePassRunAndCheck<opt::FoldSpecConstantOpAndCompositePass>(
+  SinglePassRunAndCheck<opt::FoldSpecConstantOpAndCompositePassToken>(
       builder.GetCode(), builder.GetCode(), /* skip_nop = */ true);
 }
 
@@ -208,7 +208,7 @@ TEST_P(FoldSpecConstantOpAndCompositePassTest, ParamTestCase) {
   std::string optimized;
   auto status = opt::Pass::Status::SuccessWithoutChange;
   std::tie(optimized, status) =
-      SinglePassRunAndDisassemble<opt::FoldSpecConstantOpAndCompositePass>(
+      SinglePassRunAndDisassemble<opt::FoldSpecConstantOpAndCompositePassToken>(
           original, /* skip_nop = */ true, /* do_validation = */ false);
 
   // Check the optimized code, but ignore the OpName instructions.

--- a/test/opt/freeze_spec_const_test.cpp
+++ b/test/opt/freeze_spec_const_test.cpp
@@ -40,7 +40,7 @@ TEST_P(FreezeSpecConstantValueTypeTest, PrimaryType) {
   std::vector<const char*> expected = {
       "OpCapability Shader", "OpMemoryModel Logical GLSL450",
       test_case.type_decl, test_case.expected_frozen_const};
-  SinglePassRunAndCheck<opt::FreezeSpecConstantValuePass>(
+  SinglePassRunAndCheck<opt::FreezeSpecConstantValuePassToken>(
       JoinAllInsts(text), JoinAllInsts(expected), /* skip_nop = */ false);
 }
 
@@ -121,7 +121,7 @@ TEST_F(FreezeSpecConstantValueRemoveDecorationTest,
         << "replace_str:\n"
         << p.second << "\n";
   }
-  SinglePassRunAndCheck<opt::FreezeSpecConstantValuePass>(
+  SinglePassRunAndCheck<opt::FreezeSpecConstantValuePassToken>(
       JoinAllInsts(text), expected_disassembly,
       /* skip_nop = */ true);
 }

--- a/test/opt/if_conversion_test.cpp
+++ b/test/opt/if_conversion_test.cpp
@@ -58,7 +58,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::IfConversion>(text, true);
+  SinglePassRunAndMatch<opt::IfConversionToken>(text, true);
 }
 
 TEST_F(IfConversionTest, TestSimpleHalfIfTrue) {
@@ -93,7 +93,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::IfConversion>(text, true);
+  SinglePassRunAndMatch<opt::IfConversionToken>(text, true);
 }
 
 TEST_F(IfConversionTest, TestSimpleHalfIfExtraBlock) {
@@ -130,7 +130,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::IfConversion>(text, true);
+  SinglePassRunAndMatch<opt::IfConversionToken>(text, true);
 }
 
 TEST_F(IfConversionTest, TestSimpleHalfIfFalse) {
@@ -165,7 +165,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::IfConversion>(text, true);
+  SinglePassRunAndMatch<opt::IfConversionToken>(text, true);
 }
 
 TEST_F(IfConversionTest, TestVectorSplat) {
@@ -207,7 +207,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::IfConversion>(text, true);
+  SinglePassRunAndMatch<opt::IfConversionToken>(text, true);
 }
 
 TEST_F(IfConversionTest, CodeMotionSameValue) {
@@ -251,7 +251,7 @@ TEST_F(IfConversionTest, CodeMotionSameValue) {
                     OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::IfConversion>(text, true);
+  SinglePassRunAndMatch<opt::IfConversionToken>(text, true);
 }
 
 TEST_F(IfConversionTest, CodeMotionMultipleInstructions) {
@@ -298,7 +298,7 @@ TEST_F(IfConversionTest, CodeMotionMultipleInstructions) {
                     OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::IfConversion>(text, true);
+  SinglePassRunAndMatch<opt::IfConversionToken>(text, true);
 }
 #endif  // SPIRV_EFFCEE
 
@@ -325,7 +325,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::IfConversion>(text, text, true, true);
+  SinglePassRunAndCheck<opt::IfConversionToken>(text, text, true, true);
 }
 
 TEST_F(IfConversionTest, LoopUntouched) {
@@ -354,7 +354,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::IfConversion>(text, text, true, true);
+  SinglePassRunAndCheck<opt::IfConversionToken>(text, text, true, true);
 }
 
 TEST_F(IfConversionTest, TooManyPredecessors) {
@@ -387,7 +387,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::IfConversion>(text, text, true, true);
+  SinglePassRunAndCheck<opt::IfConversionToken>(text, text, true, true);
 }
 
 TEST_F(IfConversionTest, NoCodeMotion) {
@@ -417,7 +417,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::IfConversion>(text, text, true, true);
+  SinglePassRunAndCheck<opt::IfConversionToken>(text, text, true, true);
 }
 
 TEST_F(IfConversionTest, NoCodeMotionImmovableInst) {
@@ -464,7 +464,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::IfConversion>(text, text, true, true);
+  SinglePassRunAndCheck<opt::IfConversionToken>(text, text, true, true);
 }
 
 }  // anonymous namespace

--- a/test/opt/inline_opaque_test.cpp
+++ b/test/opt/inline_opaque_test.cpp
@@ -402,7 +402,8 @@ OpReturnValue %31
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::InlineOpaquePassToken>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::InlineOpaquePassToken>(assembly, assembly, true,
+                                                    true);
 }
 
 }  // anonymous namespace

--- a/test/opt/inline_opaque_test.cpp
+++ b/test/opt/inline_opaque_test.cpp
@@ -72,7 +72,7 @@ OpDecorate %sampler15 DescriptorSet 0
   const std::string before =
       R"(%main = OpFunction %void None %12
 %28 = OpLabel
-%s0 = OpVariable %_ptr_Function_S_t Function 
+%s0 = OpVariable %_ptr_Function_S_t Function
 %param = OpVariable %_ptr_Function_S_t Function
 %29 = OpLoad %v2float %texCoords
 %30 = OpAccessChain %_ptr_Function_v2float %s0 %int_0
@@ -80,7 +80,7 @@ OpStore %30 %29
 %31 = OpLoad %18 %sampler15
 %32 = OpAccessChain %_ptr_Function_18 %s0 %int_2
 OpStore %32 %31
-%33 = OpLoad %S_t %s0 
+%33 = OpLoad %S_t %s0
 OpStore %param %33
 %34 = OpFunctionCall %void %foo_struct_S_t_vf2_vf21_ %param
 OpReturn
@@ -124,7 +124,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::InlineOpaquePass>(
+  SinglePassRunAndCheck<opt::InlineOpaquePassToken>(
       predefs + before + post_defs, predefs + after + post_defs, true, true);
 }
 
@@ -172,7 +172,7 @@ OpDecorate %sampler16 DescriptorSet 0
   const std::string before =
       R"(%main = OpFunction %void None %9
 %24 = OpLabel
-%25 = OpVariable %_ptr_Function_20 Function 
+%25 = OpVariable %_ptr_Function_20 Function
 %26 = OpFunctionCall %20 %foo_
 OpStore %25 %26
 %27 = OpLoad %20 %25
@@ -214,7 +214,7 @@ OpReturnValue %33
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::InlineOpaquePass>(
+  SinglePassRunAndCheck<opt::InlineOpaquePassToken>(
       predefs + before + post_defs, predefs + after + post_defs, true, true);
 }
 
@@ -271,7 +271,7 @@ OpDecorate %sampler15 DescriptorSet 0
   const std::string before =
       R"(%main2 = OpFunction %void None %13
 %29 = OpLabel
-%s0 = OpVariable %_ptr_Function_S_t Function 
+%s0 = OpVariable %_ptr_Function_S_t Function
 %param = OpVariable %_ptr_Function_S_t Function
 %30 = OpLoad %v2float %texCoords
 %31 = OpAccessChain %_ptr_Function_v2float %s0 %int_0
@@ -279,7 +279,7 @@ OpStore %31 %30
 %32 = OpLoad %19 %sampler15
 %33 = OpAccessChain %_ptr_Function_19 %s0 %int_2
 OpStore %33 %32
-%34 = OpLoad %S_t %s0 
+%34 = OpLoad %S_t %s0
 OpStore %param %34
 %35 = OpFunctionCall %void %foo_struct_S_t_vf2_vf21_ %param
 OpReturn
@@ -328,7 +328,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::InlineOpaquePass>(
+  SinglePassRunAndCheck<opt::InlineOpaquePassToken>(
       predefs + before + post_defs, predefs + after + post_defs, true, true);
 }
 
@@ -402,7 +402,7 @@ OpReturnValue %31
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::InlineOpaquePass>(assembly, assembly, true, true);
+  SinglePassRunAndCheck<opt::InlineOpaquePassToken>(assembly, assembly, true, true);
 }
 
 }  // anonymous namespace

--- a/test/opt/inline_test.cpp
+++ b/test/opt/inline_test.cpp
@@ -1729,8 +1729,8 @@ OpReturnValue %41
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(assembly, assembly, false,
-                                                   true);
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(assembly, assembly,
+                                                        false, true);
 }
 
 TEST_F(InlineTest, ExternalFunctionIsNotInlined) {
@@ -1754,8 +1754,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(assembly, assembly, false,
-                                                   true);
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(assembly, assembly,
+                                                        false, true);
 }
 
 TEST_F(InlineTest, SingleBlockLoopCallsMultiBlockCallee) {
@@ -2546,7 +2546,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(before, after, false, true);
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(before, after, false,
+                                                        true);
 }
 
 TEST_F(InlineTest, SetParent) {

--- a/test/opt/inline_test.cpp
+++ b/test/opt/inline_test.cpp
@@ -126,7 +126,7 @@ TEST_F(InlineTest, Simple) {
                "OpFunctionEnd",
       // clang-format on
   };
-  SinglePassRunAndCheck<opt::InlineExhaustivePass>(
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(
       JoinAllInsts(Concat(Concat(predefs, before), nonEntryFuncs)),
       JoinAllInsts(Concat(Concat(predefs, after), nonEntryFuncs)),
       /* skip_nop = */ false, /* do_validate = */ true);
@@ -276,7 +276,7 @@ TEST_F(InlineTest, Nested) {
                "OpFunctionEnd",
       // clang-format on
   };
-  SinglePassRunAndCheck<opt::InlineExhaustivePass>(
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(
       JoinAllInsts(Concat(Concat(predefs, before), nonEntryFuncs)),
       JoinAllInsts(Concat(Concat(predefs, after), nonEntryFuncs)),
       /* skip_nop = */ false, /* do_validate = */ true);
@@ -405,7 +405,7 @@ TEST_F(InlineTest, InOutParameter) {
                "OpFunctionEnd",
       // clang-format on
   };
-  SinglePassRunAndCheck<opt::InlineExhaustivePass>(
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(
       JoinAllInsts(Concat(Concat(predefs, before), nonEntryFuncs)),
       JoinAllInsts(Concat(Concat(predefs, after), nonEntryFuncs)),
       /* skip_nop = */ false, /* do_validate = */ true);
@@ -541,7 +541,7 @@ TEST_F(InlineTest, BranchInCallee) {
                "OpFunctionEnd",
       // clang-format on
   };
-  SinglePassRunAndCheck<opt::InlineExhaustivePass>(
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(
       JoinAllInsts(Concat(Concat(predefs, before), nonEntryFuncs)),
       JoinAllInsts(Concat(Concat(predefs, after), nonEntryFuncs)),
       /* skip_nop = */ false, /* do_validate = */ true);
@@ -736,7 +736,7 @@ TEST_F(InlineTest, PhiAfterCall) {
                "OpFunctionEnd",
       // clang-format on
   };
-  SinglePassRunAndCheck<opt::InlineExhaustivePass>(
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(
       JoinAllInsts(Concat(Concat(predefs, before), nonEntryFuncs)),
       JoinAllInsts(Concat(Concat(predefs, after), nonEntryFuncs)),
       /* skip_nop = */ false, /* do_validate = */ true);
@@ -933,7 +933,7 @@ TEST_F(InlineTest, OpSampledImageOutOfBlock) {
                "OpFunctionEnd",
       // clang-format on
   };
-  SinglePassRunAndCheck<opt::InlineExhaustivePass>(
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(
       JoinAllInsts(Concat(Concat(predefs, before), nonEntryFuncs)),
       JoinAllInsts(Concat(Concat(predefs, after), nonEntryFuncs)),
       /* skip_nop = */ false, /* do_validate = */ true);
@@ -1139,7 +1139,7 @@ TEST_F(InlineTest, OpImageOutOfBlock) {
                "OpFunctionEnd",
       // clang-format on
   };
-  SinglePassRunAndCheck<opt::InlineExhaustivePass>(
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(
       JoinAllInsts(Concat(Concat(predefs, before), nonEntryFuncs)),
       JoinAllInsts(Concat(Concat(predefs, after), nonEntryFuncs)),
       /* skip_nop = */ false, /* do_validate = */ true);
@@ -1345,7 +1345,7 @@ TEST_F(InlineTest, OpImageAndOpSampledImageOutOfBlock) {
                "OpFunctionEnd",
       // clang-format on
   };
-  SinglePassRunAndCheck<opt::InlineExhaustivePass>(
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(
       JoinAllInsts(Concat(Concat(predefs, before), nonEntryFuncs)),
       JoinAllInsts(Concat(Concat(predefs, after), nonEntryFuncs)),
       /* skip_nop = */ false, /* do_validate = */ true);
@@ -1473,7 +1473,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::InlineExhaustivePass>(
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(
       predefs + before + nonEntryFuncs, predefs + after + nonEntryFuncs, false,
       true);
 }
@@ -1543,7 +1543,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::InlineExhaustivePass>(
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(
       predefs + nonEntryFuncs + before, predefs + nonEntryFuncs + after, false,
       true);
 }
@@ -1632,7 +1632,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::InlineExhaustivePass>(
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(
       predefs + nonEntryFuncs + before, predefs + nonEntryFuncs + after, false,
       true);
 }
@@ -1729,7 +1729,7 @@ OpReturnValue %41
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::InlineExhaustivePass>(assembly, assembly, false,
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(assembly, assembly, false,
                                                    true);
 }
 
@@ -1754,7 +1754,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::InlineExhaustivePass>(assembly, assembly, false,
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(assembly, assembly, false,
                                                    true);
 }
 
@@ -1826,7 +1826,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::InlineExhaustivePass>(
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(
       predefs + nonEntryFuncs + before, predefs + nonEntryFuncs + after, false,
       true);
 }
@@ -1903,7 +1903,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::InlineExhaustivePass>(
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(
       predefs + nonEntryFuncs + before, predefs + nonEntryFuncs + after, false,
       true);
 }
@@ -1992,7 +1992,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::InlineExhaustivePass>(
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(
       predefs + nonEntryFuncs + before, predefs + nonEntryFuncs + after, false,
       true);
 }
@@ -2073,7 +2073,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::InlineExhaustivePass>(
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(
       predefs + nonEntryFuncs + before, predefs + nonEntryFuncs + after, false,
       true);
 }
@@ -2164,7 +2164,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::InlineExhaustivePass>(
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(
       predefs + nonEntryFuncs + before, predefs + nonEntryFuncs + after, false,
       true);
 }
@@ -2246,7 +2246,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::InlineExhaustivePass>(
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(
       predefs + nonEntryFuncs + before, predefs + nonEntryFuncs + after, false,
       true);
 }
@@ -2370,7 +2370,7 @@ OpFunctionEnd
 OpReturnValue %9
 OpFunctionEnd
 )";
-  SinglePassRunAndCheck<opt::InlineExhaustivePass>(
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(
       predefs + before + nonEntryFuncs, predefs + after + nonEntryFuncs, false,
       true);
 }
@@ -2494,7 +2494,7 @@ OpFunctionEnd
 OpReturnValue %31
 OpFunctionEnd
 )";
-  SinglePassRunAndCheck<opt::InlineExhaustivePass>(
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(
       predefs + before + nonEntryFuncs, predefs + after + nonEntryFuncs, false,
       true);
 }
@@ -2546,7 +2546,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::InlineExhaustivePass>(before, after, false, true);
+  SinglePassRunAndCheck<opt::InlineExhaustivePassToken>(before, after, false, true);
 }
 
 TEST_F(InlineTest, SetParent) {
@@ -2612,7 +2612,7 @@ OpKill
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::InlineExhaustivePass>(text, true);
+  SinglePassRunAndMatch<opt::InlineExhaustivePassToken>(text, true);
 }
 
 TEST_F(InlineTest, OpKillWithTrailingInstructions) {
@@ -2646,7 +2646,7 @@ OpKill
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::InlineExhaustivePass>(text, true);
+  SinglePassRunAndMatch<opt::InlineExhaustivePassToken>(text, true);
 }
 
 TEST_F(InlineTest, OpKillInIf) {
@@ -2703,7 +2703,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::InlineExhaustivePass>(text, true);
+  SinglePassRunAndMatch<opt::InlineExhaustivePassToken>(text, true);
 }
 
 TEST_F(InlineTest, OpKillInLoop) {
@@ -2757,7 +2757,7 @@ OpBranch %10
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::InlineExhaustivePass>(text, true);
+  SinglePassRunAndMatch<opt::InlineExhaustivePassToken>(text, true);
 }
 
 TEST_F(InlineTest, OpVariableWithInit) {
@@ -2836,7 +2836,7 @@ TEST_F(InlineTest, OpVariableWithInit) {
                OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::InlineExhaustivePass>(text, true);
+  SinglePassRunAndMatch<opt::InlineExhaustivePassToken>(text, true);
 }
 #endif
 

--- a/test/opt/insert_extract_elim_test.cpp
+++ b/test/opt/insert_extract_elim_test.cpp
@@ -100,8 +100,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::SimplificationPassToken>(predefs + before,
-                                                 predefs + after, true, true);
+  SinglePassRunAndCheck<opt::SimplificationPassToken>(
+      predefs + before, predefs + after, true, true);
 }
 
 TEST_F(InsertExtractElimTest, OptimizeAcrossNonConflictingInsert) {
@@ -185,8 +185,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::SimplificationPassToken>(predefs + before,
-                                                 predefs + after, true, true);
+  SinglePassRunAndCheck<opt::SimplificationPassToken>(
+      predefs + before, predefs + after, true, true);
 }
 
 TEST_F(InsertExtractElimTest, OptimizeOpaque) {
@@ -267,8 +267,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::SimplificationPassToken>(predefs + before,
-                                                 predefs + after, true, true);
+  SinglePassRunAndCheck<opt::SimplificationPassToken>(
+      predefs + before, predefs + after, true, true);
 }
 
 TEST_F(InsertExtractElimTest, OptimizeNestedStruct) {
@@ -396,8 +396,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::SimplificationPassToken>(predefs + before,
-                                                 predefs + after, true, true);
+  SinglePassRunAndCheck<opt::SimplificationPassToken>(
+      predefs + before, predefs + after, true, true);
 }
 
 TEST_F(InsertExtractElimTest, ConflictingInsertPreventsOptimization) {
@@ -465,7 +465,7 @@ OpFunctionEnd
 )";
 
   SinglePassRunAndCheck<opt::SimplificationPassToken>(assembly, assembly, true,
-                                                 true);
+                                                      true);
 }
 
 TEST_F(InsertExtractElimTest, ConflictingInsertPreventsOptimization2) {
@@ -690,8 +690,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::SimplificationPassToken>(predefs + before,
-                                                 predefs + after, true, true);
+  SinglePassRunAndCheck<opt::SimplificationPassToken>(
+      predefs + before, predefs + after, true, true);
 }
 
 TEST_F(InsertExtractElimTest, VectorShuffle1) {

--- a/test/opt/insert_extract_elim_test.cpp
+++ b/test/opt/insert_extract_elim_test.cpp
@@ -100,7 +100,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::SimplificationPass>(predefs + before,
+  SinglePassRunAndCheck<opt::SimplificationPassToken>(predefs + before,
                                                  predefs + after, true, true);
 }
 
@@ -185,7 +185,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::SimplificationPass>(predefs + before,
+  SinglePassRunAndCheck<opt::SimplificationPassToken>(predefs + before,
                                                  predefs + after, true, true);
 }
 
@@ -236,9 +236,9 @@ OpDecorate %sampler15 DescriptorSet 0
   const std::string before =
       R"(%main = OpFunction %void None %9
 %25 = OpLabel
-%s0 = OpVariable %_ptr_Function_S_t Function 
+%s0 = OpVariable %_ptr_Function_S_t Function
 %26 = OpLoad %v2float %texCoords
-%27 = OpLoad %S_t %s0 
+%27 = OpLoad %S_t %s0
 %28 = OpCompositeInsert %S_t %26 %27 0
 %29 = OpLoad %15 %sampler15
 %30 = OpCompositeInsert %S_t %29 %28 2
@@ -267,7 +267,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::SimplificationPass>(predefs + before,
+  SinglePassRunAndCheck<opt::SimplificationPassToken>(predefs + before,
                                                  predefs + after, true, true);
 }
 
@@ -396,7 +396,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::SimplificationPass>(predefs + before,
+  SinglePassRunAndCheck<opt::SimplificationPassToken>(predefs + before,
                                                  predefs + after, true, true);
 }
 
@@ -464,7 +464,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::SimplificationPass>(assembly, assembly, true,
+  SinglePassRunAndCheck<opt::SimplificationPassToken>(assembly, assembly, true,
                                                  true);
 }
 
@@ -588,7 +588,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::SimplificationPass>(
+  SinglePassRunAndCheck<opt::SimplificationPassToken>(
       before_predefs + before, after_predefs + after, true, true);
 }
 
@@ -690,7 +690,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::SimplificationPass>(predefs + before,
+  SinglePassRunAndCheck<opt::SimplificationPassToken>(predefs + before,
                                                  predefs + after, true, true);
 }
 
@@ -774,7 +774,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::SimplificationPass>(
+  SinglePassRunAndCheck<opt::SimplificationPassToken>(
       predefs_before + before, predefs_after + after, true, true);
 }
 
@@ -887,7 +887,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::SimplificationPass>(
+  SinglePassRunAndCheck<opt::SimplificationPassToken>(
       predefs_before + before, predefs_after + after, true, true);
 }
 

--- a/test/opt/ir_context_test.cpp
+++ b/test/opt/ir_context_test.cpp
@@ -31,7 +31,6 @@ using ::testing::Each;
 class DummyPassPreservesNothing : public opt::Pass {
  public:
   DummyPassPreservesNothing(Status s) : opt::Pass(), status_to_return_(s) {}
-  const char* name() const override { return "dummy-pass"; }
   Status Process(IRContext*) override { return status_to_return_; }
   Status status_to_return_;
 };
@@ -39,7 +38,6 @@ class DummyPassPreservesNothing : public opt::Pass {
 class DummyPassPreservesAll : public opt::Pass {
  public:
   DummyPassPreservesAll(Status s) : opt::Pass(), status_to_return_(s) {}
-  const char* name() const override { return "dummy-pass"; }
   Status Process(IRContext*) override { return status_to_return_; }
   Status status_to_return_;
   virtual Analysis GetPreservedAnalyses() override {
@@ -50,7 +48,6 @@ class DummyPassPreservesAll : public opt::Pass {
 class DummyPassPreservesFirst : public opt::Pass {
  public:
   DummyPassPreservesFirst(Status s) : opt::Pass(), status_to_return_(s) {}
-  const char* name() const override { return "dummy-pass"; }
   Status Process(IRContext*) override { return status_to_return_; }
   Status status_to_return_;
   virtual Analysis GetPreservedAnalyses() override {

--- a/test/opt/line_debug_info_test.cpp
+++ b/test/opt/line_debug_info_test.cpp
@@ -102,7 +102,7 @@ TEST_F(PassTestForLineDebugInfo, KeepLineDebugInfo) {
       "OpNoLine\n"
       "OpNop\n";
   SinglePassRunAndCheck<NopifyPassToken>(text, result_keep_nop,
-                                    /* skip_nop = */ false);
+                                         /* skip_nop = */ false);
   const char* result_skip_nop =
       "OpNoLine\n"
       "OpLine %3 10 10\n"
@@ -116,7 +116,7 @@ TEST_F(PassTestForLineDebugInfo, KeepLineDebugInfo) {
       "OpLine %3 4 4\n"
       "OpNoLine\n";
   SinglePassRunAndCheck<NopifyPassToken>(text, result_skip_nop,
-                                    /* skip_nop = */ true);
+                                         /* skip_nop = */ true);
 }
 
 }  // anonymous namespace

--- a/test/opt/local_access_chain_convert_test.cpp
+++ b/test/opt/local_access_chain_convert_test.cpp
@@ -125,7 +125,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalAccessChainConvertPass>(
+  SinglePassRunAndCheck<opt::LocalAccessChainConvertPassToken>(
       predefs_before + before, predefs_after + after, true, true);
 }
 
@@ -232,7 +232,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalAccessChainConvertPass>(
+  SinglePassRunAndCheck<opt::LocalAccessChainConvertPassToken>(
       predefs_before + before, predefs_after + after, true, true);
 }
 
@@ -338,7 +338,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalAccessChainConvertPass>(
+  SinglePassRunAndCheck<opt::LocalAccessChainConvertPassToken>(
       predefs_before + before, predefs_after + after, true, true);
 }
 
@@ -392,7 +392,7 @@ OpDecorate %sampler15 DescriptorSet 0
   const std::string before =
       R"(%main = OpFunction %void None %12
 %28 = OpLabel
-%s0 = OpVariable %_ptr_Function_S_t Function 
+%s0 = OpVariable %_ptr_Function_S_t Function
 %param = OpVariable %_ptr_Function_S_t Function
 %29 = OpLoad %v2float %texCoords
 %30 = OpAccessChain %_ptr_Function_v2float %s0 %int_0
@@ -400,7 +400,7 @@ OpStore %30 %29
 %31 = OpLoad %18 %sampler15
 %32 = OpAccessChain %_ptr_Function_18 %s0 %int_2
 OpStore %32 %31
-%33 = OpLoad %S_t %s0 
+%33 = OpLoad %S_t %s0
 OpStore %param %33
 %34 = OpAccessChain %_ptr_Function_18 %param %int_2
 %35 = OpLoad %18 %34
@@ -451,7 +451,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalAccessChainConvertPass>(
+  SinglePassRunAndCheck<opt::LocalAccessChainConvertPassToken>(
       predefs + before + remain, predefs + after + remain, true, true);
 }
 
@@ -569,7 +569,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalAccessChainConvertPass>(
+  SinglePassRunAndCheck<opt::LocalAccessChainConvertPassToken>(
       predefs_before + before, predefs_after + after, true, true);
 }
 
@@ -645,7 +645,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalAccessChainConvertPass>(assembly, assembly,
+  SinglePassRunAndCheck<opt::LocalAccessChainConvertPassToken>(assembly, assembly,
                                                           false, true);
 }
 
@@ -706,7 +706,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalAccessChainConvertPass>(
+  SinglePassRunAndCheck<opt::LocalAccessChainConvertPassToken>(
       predefs + before, predefs + after, true, true);
 }
 

--- a/test/opt/local_access_chain_convert_test.cpp
+++ b/test/opt/local_access_chain_convert_test.cpp
@@ -645,8 +645,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalAccessChainConvertPassToken>(assembly, assembly,
-                                                          false, true);
+  SinglePassRunAndCheck<opt::LocalAccessChainConvertPassToken>(
+      assembly, assembly, false, true);
 }
 
 TEST_F(LocalAccessChainConvertTest, SomeAccessChainsHaveNoUse) {

--- a/test/opt/local_redundancy_elimination_test.cpp
+++ b/test/opt/local_redundancy_elimination_test.cpp
@@ -54,7 +54,7 @@ TEST_F(LocalRedundancyEliminationTest, RemoveRedundantAdd) {
                OpReturn
                OpFunctionEnd
   )";
-  SinglePassRunAndMatch<opt::LocalRedundancyEliminationPass>(text, false);
+  SinglePassRunAndMatch<opt::LocalRedundancyEliminationPassToken>(text, false);
 }
 
 // Make sure we keep instruction that are different, but look similar.
@@ -85,7 +85,7 @@ TEST_F(LocalRedundancyEliminationTest, KeepDifferentAdd) {
                OpFunctionEnd
   )";
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndMatch<opt::LocalRedundancyEliminationPass>(text, false);
+  SinglePassRunAndMatch<opt::LocalRedundancyEliminationPassToken>(text, false);
 }
 
 // This test is check that the values are being propagated properly, and that
@@ -123,7 +123,7 @@ TEST_F(LocalRedundancyEliminationTest, RemoveMultipleInstructions) {
                OpFunctionEnd
   )";
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndMatch<opt::LocalRedundancyEliminationPass>(text, false);
+  SinglePassRunAndMatch<opt::LocalRedundancyEliminationPassToken>(text, false);
 }
 
 // Redundant instructions in different blocks should be kept.
@@ -152,7 +152,7 @@ TEST_F(LocalRedundancyEliminationTest, KeepInstructionsInDifferentBlocks) {
                OpReturn
                OpFunctionEnd
   )";
-  SinglePassRunAndMatch<opt::LocalRedundancyEliminationPass>(text, false);
+  SinglePassRunAndMatch<opt::LocalRedundancyEliminationPassToken>(text, false);
 }
 #endif
 }  // anonymous namespace

--- a/test/opt/local_single_block_elim.cpp
+++ b/test/opt/local_single_block_elim.cpp
@@ -78,7 +78,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPassToken>(
       predefs_before + before, predefs_before + after, true, true);
 }
 
@@ -179,7 +179,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -251,7 +251,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPassToken>(
       predefs_before + before, predefs_before + after, true, true);
 }
 
@@ -357,7 +357,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -415,7 +415,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPassToken>(
       assembly, assembly, false, true);
 }
 
@@ -471,7 +471,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPassToken>(
       assembly, assembly, false, true);
 }
 
@@ -561,7 +561,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -613,17 +613,17 @@ OpDecorate %sampler15 DescriptorSet 0
   const std::string before =
       R"(%main = OpFunction %void None %12
 %28 = OpLabel
-%s0 = OpVariable %_ptr_Function_S_t Function 
+%s0 = OpVariable %_ptr_Function_S_t Function
 %param = OpVariable %_ptr_Function_S_t Function
 %29 = OpLoad %v2float %texCoords
-%30 = OpLoad %S_t %s0 
+%30 = OpLoad %S_t %s0
 %31 = OpCompositeInsert %S_t %29 %30 0
 OpStore %s0 %31
 %32 = OpLoad %18 %sampler15
-%33 = OpLoad %S_t %s0 
+%33 = OpLoad %S_t %s0
 %34 = OpCompositeInsert %S_t %32 %33 2
 OpStore %s0 %34
-%35 = OpLoad %S_t %s0 
+%35 = OpLoad %S_t %s0
 OpStore %param %35
 %36 = OpLoad %S_t %param
 %37 = OpCompositeExtract %18 %36 2
@@ -656,7 +656,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -763,7 +763,7 @@ OpReturnValue %27
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -864,7 +864,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPass>(before, after,
+  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPassToken>(before, after,
                                                                 true, true);
 }
 
@@ -920,7 +920,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPassToken>(
       predefs_before + before, predefs_before + after, true, true);
 }
 
@@ -978,7 +978,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPassToken>(
       predefs_before + before, predefs_before + after, true, true);
 }
 // TODO(greg-lunarg): Add tests to verify handling of these cases:

--- a/test/opt/local_single_block_elim.cpp
+++ b/test/opt/local_single_block_elim.cpp
@@ -864,8 +864,8 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPassToken>(before, after,
-                                                                true, true);
+  SinglePassRunAndCheck<opt::LocalSingleBlockLoadStoreElimPassToken>(
+      before, after, true, true);
 }
 
 TEST_F(LocalSingleBlockLoadStoreElimTest, RedundantStore) {

--- a/test/opt/local_single_store_elim_test.cpp
+++ b/test/opt/local_single_store_elim_test.cpp
@@ -120,7 +120,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalSingleStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalSingleStoreElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -186,7 +186,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalSingleStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalSingleStoreElimPassToken>(
       predefs + before, predefs + before, true, true);
 }
 
@@ -290,7 +290,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalSingleStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalSingleStoreElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -368,7 +368,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalSingleStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalSingleStoreElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -423,7 +423,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalSingleStoreElimPass>(assembly, assembly, true,
+  SinglePassRunAndCheck<opt::LocalSingleStoreElimPassToken>(assembly, assembly, true,
                                                        true);
 }
 
@@ -526,7 +526,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalSingleStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalSingleStoreElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -606,7 +606,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalSingleStoreElimPass>(assembly, assembly, true,
+  SinglePassRunAndCheck<opt::LocalSingleStoreElimPassToken>(assembly, assembly, true,
                                                        true);
 }
 
@@ -665,7 +665,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalSingleStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalSingleStoreElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -766,7 +766,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::LocalSingleStoreElimPass>(before, after, true,
+  SinglePassRunAndCheck<opt::LocalSingleStoreElimPassToken>(before, after, true,
                                                        true);
 }
 

--- a/test/opt/local_single_store_elim_test.cpp
+++ b/test/opt/local_single_store_elim_test.cpp
@@ -423,8 +423,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalSingleStoreElimPassToken>(assembly, assembly, true,
-                                                       true);
+  SinglePassRunAndCheck<opt::LocalSingleStoreElimPassToken>(assembly, assembly,
+                                                            true, true);
 }
 
 TEST_F(LocalSingleStoreElimTest, ElimIfCopyObjectInFunction) {
@@ -606,8 +606,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalSingleStoreElimPassToken>(assembly, assembly, true,
-                                                       true);
+  SinglePassRunAndCheck<opt::LocalSingleStoreElimPassToken>(assembly, assembly,
+                                                            true, true);
 }
 
 TEST_F(LocalSingleStoreElimTest, OptInitializedVariableLikeStore) {
@@ -767,7 +767,7 @@ OpFunctionEnd
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SinglePassRunAndCheck<opt::LocalSingleStoreElimPassToken>(before, after, true,
-                                                       true);
+                                                            true);
 }
 
 // TODO(greg-lunarg): Add tests to verify handling of these cases:

--- a/test/opt/local_ssa_elim_test.cpp
+++ b/test/opt/local_ssa_elim_test.cpp
@@ -1329,7 +1329,7 @@ OpFunctionEnd
 )";
 
   SinglePassRunAndCheck<opt::LocalMultiStoreElimPassToken>(before, before, true,
-                                                      true);
+                                                           true);
 }
 
 TEST_F(LocalSSAElimTest, OptInitializedVariableLikeStore) {
@@ -1528,7 +1528,7 @@ OpFunctionEnd
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SinglePassRunAndCheck<opt::LocalMultiStoreElimPassToken>(before, after, true,
-                                                      true);
+                                                           true);
 }
 
 TEST_F(LocalSSAElimTest, VerifyInstToBlockMap) {

--- a/test/opt/local_ssa_elim_test.cpp
+++ b/test/opt/local_ssa_elim_test.cpp
@@ -135,7 +135,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalMultiStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalMultiStoreElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -277,7 +277,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalMultiStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalMultiStoreElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -423,7 +423,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalMultiStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalMultiStoreElimPassToken>(
       predefs + names + predefs2 + before, predefs + names + predefs2 + after,
       true, true);
 }
@@ -564,7 +564,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalMultiStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalMultiStoreElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -701,7 +701,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalMultiStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalMultiStoreElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -845,7 +845,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalMultiStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalMultiStoreElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -945,7 +945,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalMultiStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalMultiStoreElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -1034,7 +1034,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalMultiStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalMultiStoreElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -1165,7 +1165,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalMultiStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalMultiStoreElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -1297,7 +1297,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalMultiStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalMultiStoreElimPassToken>(
       predefs + before, predefs + after, true, true);
 }
 
@@ -1328,7 +1328,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalMultiStoreElimPass>(before, before, true,
+  SinglePassRunAndCheck<opt::LocalMultiStoreElimPassToken>(before, before, true,
                                                       true);
 }
 
@@ -1426,7 +1426,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LocalMultiStoreElimPass>(
+  SinglePassRunAndCheck<opt::LocalMultiStoreElimPassToken>(
       predefs + func_before, predefs + func_after, true, true);
 }
 
@@ -1527,7 +1527,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::LocalMultiStoreElimPass>(before, after, true,
+  SinglePassRunAndCheck<opt::LocalMultiStoreElimPassToken>(before, after, true,
                                                       true);
 }
 
@@ -1716,7 +1716,7 @@ TEST_F(LocalSSAElimTest, CompositeExtractProblem) {
                OpReturn
                OpFunctionEnd)";
 
-  SinglePassRunAndMatch<opt::SSARewritePass>(spv_asm, true);
+  SinglePassRunAndMatch<opt::SSARewritePassToken>(spv_asm, true);
 }
 #endif
 

--- a/test/opt/loop_optimizations/fusion_pass.cpp
+++ b/test/opt/loop_optimizations/fusion_pass.cpp
@@ -129,7 +129,7 @@ TEST_F(FusionPassTest, SimpleFusion) {
                OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::LoopFusionPass>(text, true, 20);
+  SinglePassRunAndMatch<opt::LoopFusionPassToken>(text, true, 20);
 }
 
 /*
@@ -266,7 +266,7 @@ TEST_F(FusionPassTest, ThreeLoopsFused) {
 
   )";
 
-  SinglePassRunAndMatch<opt::LoopFusionPass>(text, true, 20);
+  SinglePassRunAndMatch<opt::LoopFusionPassToken>(text, true, 20);
 }
 
 /*
@@ -416,7 +416,7 @@ TEST_F(FusionPassTest, NestedLoopsFused) {
                OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::LoopFusionPass>(text, true, 20);
+  SinglePassRunAndMatch<opt::LoopFusionPassToken>(text, true, 20);
 }
 
 /*
@@ -495,7 +495,7 @@ TEST_F(FusionPassTest, Incompatible) {
                OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::LoopFusionPass>(text, true, 20);
+  SinglePassRunAndMatch<opt::LoopFusionPassToken>(text, true, 20);
 }
 
 /*
@@ -607,7 +607,7 @@ TEST_F(FusionPassTest, Illegal) {
                OpFunctionEnd
     )";
 
-  SinglePassRunAndMatch<opt::LoopFusionPass>(text, true, 20);
+  SinglePassRunAndMatch<opt::LoopFusionPassToken>(text, true, 20);
 }
 
 /*
@@ -713,7 +713,7 @@ TEST_F(FusionPassTest, TooManyRegisters) {
                OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::LoopFusionPass>(text, true, 5);
+  SinglePassRunAndMatch<opt::LoopFusionPassToken>(text, true, 5);
 }
 
 #endif

--- a/test/opt/loop_optimizations/hoist_all_loop_types.cpp
+++ b/test/opt/loop_optimizations/hoist_all_loop_types.cpp
@@ -278,7 +278,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LICMPass>(before_hoist, after_hoist, true);
+  SinglePassRunAndCheck<opt::LICMPassToken>(before_hoist, after_hoist, true);
 }
 
 }  // namespace

--- a/test/opt/loop_optimizations/hoist_double_nested_loops.cpp
+++ b/test/opt/loop_optimizations/hoist_double_nested_loops.cpp
@@ -155,7 +155,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LICMPass>(before_hoist, after_hoist, true);
+  SinglePassRunAndCheck<opt::LICMPassToken>(before_hoist, after_hoist, true);
 }
 
 }  // namespace

--- a/test/opt/loop_optimizations/hoist_from_independent_loops.cpp
+++ b/test/opt/loop_optimizations/hoist_from_independent_loops.cpp
@@ -194,7 +194,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LICMPass>(before_hoist, after_hoist, true);
+  SinglePassRunAndCheck<opt::LICMPassToken>(before_hoist, after_hoist, true);
 }
 
 }  // namespace

--- a/test/opt/loop_optimizations/hoist_simple_case.cpp
+++ b/test/opt/loop_optimizations/hoist_simple_case.cpp
@@ -119,7 +119,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LICMPass>(before_hoist, after_hoist, true);
+  SinglePassRunAndCheck<opt::LICMPassToken>(before_hoist, after_hoist, true);
 }
 
 }  // namespace

--- a/test/opt/loop_optimizations/hoist_single_nested_loops.cpp
+++ b/test/opt/loop_optimizations/hoist_single_nested_loops.cpp
@@ -155,7 +155,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::LICMPass>(before_hoist, after_hoist, true);
+  SinglePassRunAndCheck<opt::LICMPassToken>(before_hoist, after_hoist, true);
 }
 
 }  // namespace

--- a/test/opt/loop_optimizations/hoist_without_preheader.cpp
+++ b/test/opt/loop_optimizations/hoist_without_preheader.cpp
@@ -116,7 +116,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::LICMPass>(text, false);
+  SinglePassRunAndMatch<opt::LICMPassToken>(text, false);
 }
 #endif
 

--- a/test/opt/loop_optimizations/loop_fission.cpp
+++ b/test/opt/loop_optimizations/loop_fission.cpp
@@ -60,6 +60,23 @@ void main(void) {
     }
 }
 */
+
+class LoopFissionPassTokenForTest : public opt::PassToken {
+ public:
+  LoopFissionPassTokenForTest(spvtools::opt::LoopFissionPass::FissionCriteriaFunction functor)
+      : functor_(functor) {}
+  ~LoopFissionPassTokenForTest() override = default;
+
+  const char* name() const override { return "Loop Fission"; }
+
+  std::unique_ptr<spvtools::opt::Pass> CreatePass() const override {
+    return MakeUnique<spvtools::opt::LoopFissionPass>(functor_);
+  }
+
+ private:
+  spvtools::opt::LoopFissionPass::FissionCriteriaFunction functor_;
+};
+
 TEST_F(FissionClassTest, SimpleFission) {
   // clang-format off
   // With opt::LocalMultiStoreElimPass
@@ -195,11 +212,11 @@ EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
                            << source << std::endl;
 
 SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-SinglePassRunAndCheck<opt::LoopFissionPass>(source, expected, true);
+SinglePassRunAndCheck<opt::LoopFissionPassToken>(source, expected, true, false, true);
 
 // Check that the loop will NOT be split when provided with a pass-through
 // register pressure functor which just returns false.
-SinglePassRunAndCheck<opt::LoopFissionPass>(
+SinglePassRunAndCheck<LoopFissionPassTokenForTest>(
     source, source, true,
     [](const opt::RegisterLiveness::RegionRegisterLiveness&) { return false; });
 }
@@ -289,7 +306,7 @@ OpFunctionEnd
                              << source << std::endl;
 
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopFissionPass>(source, source, true);
+  SinglePassRunAndCheck<opt::LoopFissionPassToken>(source, source, true, false, true);
 }
 
 /*
@@ -376,7 +393,7 @@ EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
                            << source << std::endl;
 
 SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-SinglePassRunAndCheck<opt::LoopFissionPass>(source, source, true);
+SinglePassRunAndCheck<opt::LoopFissionPassToken>(source, source, true, false, true);
 }
 
 /*
@@ -688,13 +705,13 @@ EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
                            << source << std::endl;
 
 SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-SinglePassRunAndCheck<opt::LoopFissionPass>(source, expected, true);
+SinglePassRunAndCheck<opt::LoopFissionPassToken>(source, expected, true, false, true);
 
 // By passing 1 as argument we are using the constructor which makes the
 // critera to split the loop be if the registers in the loop exceede 1. By
 // using this constructor we are also enabling multiple passes (disabled by
 // default).
-SinglePassRunAndCheck<opt::LoopFissionPass>(source, expected_multiple_passes,
+SinglePassRunAndCheck<opt::LoopFissionPassToken>(source, expected_multiple_passes,
                                             true, 1);
 }
 
@@ -872,7 +889,7 @@ OpFunctionEnd
                              << source << std::endl;
 
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopFissionPass>(source, expected, true);
+  SinglePassRunAndCheck<opt::LoopFissionPassToken>(source, expected, true, false, true);
 }
 
 /*
@@ -1058,7 +1075,7 @@ OpFunctionEnd
                              << source << std::endl;
 
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopFissionPass>(source, expected, true);
+  SinglePassRunAndCheck<opt::LoopFissionPassToken>(source, expected, true, false, true);
 }
 
 /*
@@ -1272,7 +1289,7 @@ OpFunctionEnd
                              << source << std::endl;
 
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopFissionPass>(source, expected, true);
+  SinglePassRunAndCheck<opt::LoopFissionPassToken>(source, expected, true, false, true);
 }
 
 /*
@@ -1376,7 +1393,7 @@ EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
                            << source << std::endl;
 
 SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-SinglePassRunAndCheck<opt::LoopFissionPass>(source, source, true);
+SinglePassRunAndCheck<opt::LoopFissionPassToken>(source, source, true, false, true);
 }
 
 /*
@@ -1598,7 +1615,7 @@ OpFunctionEnd
                              << source << std::endl;
 
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopFissionPass>(source, expected, true);
+  SinglePassRunAndCheck<opt::LoopFissionPassToken>(source, expected, true, false, true);
 }
 
 /*
@@ -1873,7 +1890,7 @@ OpFunctionEnd
                              << source << std::endl;
 
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopFissionPass>(source, expected, true, 1);
+  SinglePassRunAndCheck<opt::LoopFissionPassToken>(source, expected, true, 1);
 }
 
 /*
@@ -1967,7 +1984,7 @@ EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
                            << source << std::endl;
 
 SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-SinglePassRunAndCheck<opt::LoopFissionPass>(source, source, true);
+SinglePassRunAndCheck<opt::LoopFissionPassToken>(source, source, true, false, true);
 }
 
 /*
@@ -2059,7 +2076,7 @@ EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
                            << source << std::endl;
 
 SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-SinglePassRunAndCheck<opt::LoopFissionPass>(source, source, true);
+SinglePassRunAndCheck<opt::LoopFissionPassToken>(source, source, true, false, true);
 }
 
 /*
@@ -2250,7 +2267,7 @@ EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
                            << source << std::endl;
 
 SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-SinglePassRunAndCheck<opt::LoopFissionPass>(source, expected, true);
+SinglePassRunAndCheck<opt::LoopFissionPassToken>(source, expected, true, false, true);
 }
 
 /*
@@ -2416,7 +2433,7 @@ EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
                            << source << std::endl;
 
 SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-SinglePassRunAndCheck<opt::LoopFissionPass>(source, expected, true);
+SinglePassRunAndCheck<opt::LoopFissionPassToken>(source, expected, true, false, true);
 }
 
 /*
@@ -2523,7 +2540,7 @@ EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
                            << source << std::endl;
 
 SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-SinglePassRunAndCheck<opt::LoopFissionPass>(source, source, true);
+SinglePassRunAndCheck<opt::LoopFissionPassToken>(source, source, true, false, true);
 }
 
 /*
@@ -2633,7 +2650,7 @@ EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
                            << source << std::endl;
 
 SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-SinglePassRunAndCheck<opt::LoopFissionPass>(source, source, true);
+SinglePassRunAndCheck<opt::LoopFissionPassToken>(source, source, true, false, true);
 }
 
 /*
@@ -2918,7 +2935,7 @@ EXPECT_EQ(pre_pass_descriptor.pre_begin()->NumImmediateChildren(), 2u);
 
 // Test that the pass transforms the ir into the expected output.
 SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-SinglePassRunAndCheck<opt::LoopFissionPass>(source, expected, true);
+SinglePassRunAndCheck<opt::LoopFissionPassToken>(source, expected, true, false, true);
 
 // Test that the loop descriptor is correctly maintained and updated by the
 // pass.
@@ -3167,7 +3184,7 @@ EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
                            << source << std::endl;
 
 SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-SinglePassRunAndCheck<opt::LoopFissionPass>(source, expected, true);
+SinglePassRunAndCheck<opt::LoopFissionPassToken>(source, expected, true, false, true);
 
 const opt::Function* function = spvtest::GetFunction(module, 2);
 opt::LoopDescriptor& pre_pass_descriptor =
@@ -3177,7 +3194,7 @@ EXPECT_EQ(pre_pass_descriptor.pre_begin()->NumImmediateChildren(), 0u);
 
 // Test that the pass transforms the ir into the expected output.
 SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-SinglePassRunAndCheck<opt::LoopFissionPass>(source, expected, true);
+SinglePassRunAndCheck<opt::LoopFissionPassToken>(source, expected, true, false, true);
 
 // Test that the loop descriptor is correctly maintained and updated by the
 // pass.
@@ -3283,7 +3300,7 @@ EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
                            << source << std::endl;
 
 SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-SinglePassRunAndCheck<opt::LoopFissionPass>(source, source, true);
+SinglePassRunAndCheck<opt::LoopFissionPassToken>(source, source, true, false, true);
 }
 
 /*
@@ -3484,7 +3501,7 @@ EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
                            << source << std::endl;
 
 SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-SinglePassRunAndCheck<opt::LoopFissionPass>(source, expected, true);
+SinglePassRunAndCheck<opt::LoopFissionPassToken>(source, expected, true, false, true);
 }
 
 }  // namespace

--- a/test/opt/loop_optimizations/peeling_pass.cpp
+++ b/test/opt/loop_optimizations/peeling_pass.cpp
@@ -1100,8 +1100,8 @@ TEST_F(PeelingPassTest, PeelingNoChanges) {
   )";
 
   {
-    auto result =
-        SinglePassRunAndDisassemble<opt::LoopPeelingPassToken>(text, true, false);
+    auto result = SinglePassRunAndDisassemble<opt::LoopPeelingPassToken>(
+        text, true, false);
 
     EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
   }

--- a/test/opt/loop_optimizations/peeling_pass.cpp
+++ b/test/opt/loop_optimizations/peeling_pass.cpp
@@ -23,6 +23,21 @@ namespace {
 
 using namespace spvtools;
 
+class LoopPeelingPassTokenForTest : public opt::LoopPeelingPassToken {
+ public:
+  LoopPeelingPassTokenForTest(opt::LoopPeelingPass::LoopPeelingStats* stats)
+      : stats_(stats) {}
+
+  ~LoopPeelingPassTokenForTest() override = default;
+
+  std::unique_ptr<opt::Pass> CreatePass() const override {
+    return MakeUnique<opt::LoopPeelingPass>(stats_);
+  }
+
+ private:
+  opt::LoopPeelingPass::LoopPeelingStats* stats_;
+};
+
 class PeelingPassTest : public PassTest<::testing::Test> {
  public:
   // Generic routine to run the loop peeling pass and check
@@ -58,7 +73,7 @@ class PeelingPassTest : public PassTest<::testing::Test> {
         res_id + " = " + opcode_str + "  %bool " + op1 + " " + op2 + "\n";
 
     opt::LoopPeelingPass::LoopPeelingStats stats;
-    SinglePassRunAndDisassemble<opt::LoopPeelingPass>(
+    SinglePassRunAndDisassemble<LoopPeelingPassTokenForTest>(
         text_head + test_cond + text_tail, true, true, &stats);
 
     return stats;
@@ -1086,7 +1101,7 @@ TEST_F(PeelingPassTest, PeelingNoChanges) {
 
   {
     auto result =
-        SinglePassRunAndDisassemble<opt::LoopPeelingPass>(text, true, false);
+        SinglePassRunAndDisassemble<opt::LoopPeelingPassToken>(text, true, false);
 
     EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
   }

--- a/test/opt/loop_optimizations/unroll_assumptions.cpp
+++ b/test/opt/loop_optimizations/unroll_assumptions.cpp
@@ -143,7 +143,7 @@ OpFunctionEnd
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
 
   // Make sure the pass doesn't run
-  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false, false, true, 0);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false);
   SinglePassRunAndCheck<PartialUnrollerTestPassToken<1>>(text, text, false);
   SinglePassRunAndCheck<PartialUnrollerTestPassToken<2>>(text, text, false);
 }
@@ -240,7 +240,7 @@ OpFunctionEnd
                              << text << std::endl;
 
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false, false, true, 0);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false);
 }
 
 /*
@@ -320,7 +320,7 @@ EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
                            << text << std::endl;
 
 SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false, false, true, 0);
+SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false);
 }
 
 /*
@@ -400,7 +400,7 @@ EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
                            << text << std::endl;
 
 SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false, false, true, 0);
+SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false);
 }
 
 /*
@@ -473,7 +473,7 @@ OpFunctionEnd
 )";
   // clang-format on
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false, false, true, 0);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false);
 }
 
 /*
@@ -538,7 +538,7 @@ OpFunctionEnd
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
 
   // Make sure the pass doesn't run
-  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false, false, true, 0);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false);
   SinglePassRunAndCheck<PartialUnrollerTestPassToken<1>>(text, text, false);
   SinglePassRunAndCheck<PartialUnrollerTestPassToken<2>>(text, text, false);
 }
@@ -609,7 +609,7 @@ OpFunctionEnd
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
 
   // Make sure the pass doesn't run
-  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false, false, true, 0);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false);
   SinglePassRunAndCheck<PartialUnrollerTestPassToken<1>>(text, text, false);
   SinglePassRunAndCheck<PartialUnrollerTestPassToken<2>>(text, text, false);
 }
@@ -679,7 +679,7 @@ OpFunctionEnd
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
 
   // Make sure the pass doesn't run
-  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false, false, true, 0);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false);
   SinglePassRunAndCheck<PartialUnrollerTestPassToken<1>>(text, text, false);
   SinglePassRunAndCheck<PartialUnrollerTestPassToken<2>>(text, text, false);
 }
@@ -755,7 +755,7 @@ OpFunctionEnd
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
 
   // Make sure the pass doesn't run
-  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false, false, true, 0);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false);
   SinglePassRunAndCheck<PartialUnrollerTestPassToken<1>>(text, text, false);
   SinglePassRunAndCheck<PartialUnrollerTestPassToken<2>>(text, text, false);
 }
@@ -972,7 +972,7 @@ OpFunctionEnd
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
 
   // Make sure the pass doesn't run
-  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false, false, true, 0);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false);
   SinglePassRunAndCheck<PartialUnrollerTestPassToken<1>>(text, text, false);
   SinglePassRunAndCheck<PartialUnrollerTestPassToken<2>>(text, text, false);
 }
@@ -1045,7 +1045,7 @@ OpFunctionEnd
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
 
   // Make sure the pass doesn't run
-  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false, false, true, 0);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false);
   SinglePassRunAndCheck<PartialUnrollerTestPassToken<1>>(text, text, false);
   SinglePassRunAndCheck<PartialUnrollerTestPassToken<2>>(text, text, false);
 }
@@ -1124,7 +1124,7 @@ EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
 SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
 
 // Make sure the pass doesn't run
-SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false, false, true, 0);
+SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false);
 SinglePassRunAndCheck<PartialUnrollerTestPassToken<1>>(text, text, false);
 SinglePassRunAndCheck<PartialUnrollerTestPassToken<2>>(text, text, false);
 }
@@ -1202,7 +1202,7 @@ EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
 SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
 
 // Make sure the pass doesn't run
-SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false, false, true, 0);
+SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false);
 SinglePassRunAndCheck<PartialUnrollerTestPassToken<1>>(text, text, false);
 SinglePassRunAndCheck<PartialUnrollerTestPassToken<2>>(text, text, false);
 }
@@ -1280,7 +1280,7 @@ EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
 SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
 
 // Make sure the pass doesn't run
-SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false, false, true, 0);
+SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false);
 SinglePassRunAndCheck<PartialUnrollerTestPassToken<1>>(text, text, false);
 SinglePassRunAndCheck<PartialUnrollerTestPassToken<2>>(text, text, false);
 }
@@ -1358,7 +1358,7 @@ EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
 SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
 
 // Make sure the pass doesn't run
-SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false, false, true, 0);
+SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false);
 SinglePassRunAndCheck<PartialUnrollerTestPassToken<1>>(text, text, false);
 SinglePassRunAndCheck<PartialUnrollerTestPassToken<2>>(text, text, false);
 }
@@ -1436,7 +1436,7 @@ EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
 SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
 
 // Make sure the pass doesn't run
-SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false, false, true, 0);
+SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, text, false);
 SinglePassRunAndCheck<PartialUnrollerTestPassToken<1>>(text, text, false);
 SinglePassRunAndCheck<PartialUnrollerTestPassToken<2>>(text, text, false);
 }

--- a/test/opt/loop_optimizations/unroll_simple.cpp
+++ b/test/opt/loop_optimizations/unroll_simple.cpp
@@ -190,7 +190,7 @@ OpFunctionEnd
                              << text << std::endl;
 
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, output, false, false, true, 0);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, output, false);
 }
 
 class PartialUnrollerTestPass : public opt::Pass {
@@ -972,7 +972,7 @@ OpFunctionEnd
                              << text << std::endl;
 
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, output, false, false, true, 0);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, output, false);
 }
 
 /*
@@ -1097,7 +1097,7 @@ OpFunctionEnd
                              << text << std::endl;
 
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  // SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, expected, false, false, true, 0);
+  // SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, expected, false);
 
   opt::Function* f = spvtest::GetFunction(module, 4);
 
@@ -1121,7 +1121,7 @@ OpFunctionEnd
   EXPECT_TRUE(loop.FindNumberOfIterations(induction, &*condition->ctail(),
                                           &iterations));
   EXPECT_EQ(iterations, 2u);
-  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, expected, false, false, true, 0);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, expected, false);
 }
 
 /*
@@ -1596,7 +1596,7 @@ OpFunctionEnd
                              << text << std::endl;
 
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, output, false, false, true, 0);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, output, false);
 }
 
 /*
@@ -1736,7 +1736,7 @@ OpFunctionEnd
                              << text << std::endl;
 
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, output, false, false, true, 0);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, output, false);
 }
 
 /*
@@ -1875,7 +1875,7 @@ OpFunctionEnd
                              << text << std::endl;
 
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, output, false, false, true, 0);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, output, false);
 }
 
 /*
@@ -2027,7 +2027,7 @@ OpFunctionEnd
                              << text << std::endl;
 
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, output, false, false, true, 0);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, output, false);
 }
 
 // With opt::LocalMultiStoreElimPass
@@ -2202,8 +2202,8 @@ OpFunctionEnd
                              << multiple_phi_shader << std::endl;
 
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<PartialUnrollerTestPassToken<4>>(multiple_phi_shader, output,
-                                                    false);
+  SinglePassRunAndCheck<PartialUnrollerTestPassToken<4>>(multiple_phi_shader,
+                                                         output, false);
 }
 
 TEST_F(PassClassTest, PartiallyUnrollMultipleInductionVariables) {
@@ -2277,8 +2277,8 @@ OpFunctionEnd
                              << multiple_phi_shader << std::endl;
 
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<PartialUnrollerTestPassToken<2>>(multiple_phi_shader, output,
-                                                    false);
+  SinglePassRunAndCheck<PartialUnrollerTestPassToken<2>>(multiple_phi_shader,
+                                                         output, false);
 }
 
 TEST_F(PassClassTest, FullyUnrollMultipleInductionVariables) {
@@ -2400,7 +2400,8 @@ OpFunctionEnd
                              << multiple_phi_shader << std::endl;
 
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopUnrollerToken>(multiple_phi_shader, output, false, false, true, 0);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(multiple_phi_shader, output,
+                                                false);
 }
 
 /*
@@ -2560,7 +2561,7 @@ OpFunctionEnd
                              << text << std::endl;
 
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, output, false, false, true, 0);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, output, false);
 }
 
 // With opt::LocalMultiStoreElimPass
@@ -2668,7 +2669,8 @@ OpFunctionEnd
                              << condition_in_header << std::endl;
 
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopUnrollerToken>(condition_in_header, output, false, false, true, 0);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(condition_in_header, output,
+                                                false);
 }
 
 TEST_F(PassClassTest, PartiallyUnrollResidualConditionIsInHeaderBlock) {
@@ -2747,8 +2749,8 @@ OpFunctionEnd
                              << condition_in_header << std::endl;
 
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<PartialUnrollerTestPassToken<2>>(condition_in_header, output,
-                                                    false);
+  SinglePassRunAndCheck<PartialUnrollerTestPassToken<2>>(condition_in_header,
+                                                         output, false);
 }
 
 /*

--- a/test/opt/loop_optimizations/unroll_simple.cpp
+++ b/test/opt/loop_optimizations/unroll_simple.cpp
@@ -189,28 +189,40 @@ OpFunctionEnd
   EXPECT_NE(nullptr, module) << "Assembling failed for ushader:\n"
                              << text << std::endl;
 
-  opt::LoopUnroller loop_unroller;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopUnroller>(text, output, false);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, output, false, false, true, 0);
 }
 
-template <int factor>
 class PartialUnrollerTestPass : public opt::Pass {
  public:
-  PartialUnrollerTestPass() : Pass() {}
-
-  const char* name() const override { return "Loop unroller"; }
+  PartialUnrollerTestPass(int factor) : Pass(), factor_(factor) {}
 
   Status Process(opt::IRContext* context) override {
     for (opt::Function& f : *context->module()) {
       opt::LoopDescriptor& loop_descriptor = *context->GetLoopDescriptor(&f);
       for (auto& loop : loop_descriptor) {
         opt::LoopUtils loop_utils{context, &loop};
-        loop_utils.PartiallyUnroll(factor);
+        loop_utils.PartiallyUnroll(factor_);
       }
     }
 
     return Pass::Status::SuccessWithChange;
+  }
+
+ private:
+  int factor_;
+};
+
+template <int factor>
+class PartialUnrollerTestPassToken : public opt::PassToken {
+ public:
+  PartialUnrollerTestPassToken() = default;
+  ~PartialUnrollerTestPassToken() = default;
+
+  const char* name() const override { return "Loop unroller"; }
+
+  std::unique_ptr<opt::Pass> CreatePass() const override {
+    return MakeUnique<PartialUnrollerTestPass>(factor);
   }
 };
 
@@ -349,9 +361,8 @@ OpFunctionEnd
   EXPECT_NE(nullptr, module) << "Assembling failed for ushader:\n"
                              << text << std::endl;
 
-  opt::LoopUnroller loop_unroller;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<PartialUnrollerTestPass<2>>(text, output, false);
+  SinglePassRunAndCheck<PartialUnrollerTestPassToken<2>>(text, output, false);
 }
 
 /*
@@ -520,12 +531,11 @@ OpFunctionEnd
   EXPECT_NE(nullptr, module) << "Assembling failed for ushader:\n"
                              << text << std::endl;
 
-  opt::LoopUnroller loop_unroller;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
   // By unrolling by a factor that doesn't divide evenly into the number of loop
   // iterations we perfom an additional transform when partially unrolling to
   // account for the remainder.
-  SinglePassRunAndCheck<PartialUnrollerTestPass<3>>(text, output, false);
+  SinglePassRunAndCheck<PartialUnrollerTestPassToken<3>>(text, output, false);
 }
 
 /* Generated from
@@ -960,9 +970,9 @@ OpFunctionEnd
   opt::Module* module = context->module();
   EXPECT_NE(nullptr, module) << "Assembling failed for ushader:\n"
                              << text << std::endl;
-  opt::LoopUnroller loop_unroller;
+
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopUnroller>(text, output, false);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, output, false, false, true, 0);
 }
 
 /*
@@ -1086,9 +1096,8 @@ OpFunctionEnd
   EXPECT_NE(nullptr, module) << "Assembling failed for ushader:\n"
                              << text << std::endl;
 
-  opt::LoopUnroller loop_unroller;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  // SinglePassRunAndCheck<opt::LoopUnroller>(text, expected, false);
+  // SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, expected, false, false, true, 0);
 
   opt::Function* f = spvtest::GetFunction(module, 4);
 
@@ -1112,7 +1121,7 @@ OpFunctionEnd
   EXPECT_TRUE(loop.FindNumberOfIterations(induction, &*condition->ctail(),
                                           &iterations));
   EXPECT_EQ(iterations, 2u);
-  SinglePassRunAndCheck<opt::LoopUnroller>(text, expected, false);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, expected, false, false, true, 0);
 }
 
 /*
@@ -1258,7 +1267,6 @@ OpFunctionEnd
   EXPECT_NE(nullptr, module) << "Assembling failed for ushader:\n"
                              << text << std::endl;
 
-  opt::LoopUnroller loop_unroller;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
 
   opt::Function* f = spvtest::GetFunction(module, 4);
@@ -1283,7 +1291,7 @@ OpFunctionEnd
   EXPECT_TRUE(loop.FindNumberOfIterations(induction, &*condition->ctail(),
                                           &iterations));
   EXPECT_EQ(iterations, 9u);
-  SinglePassRunAndCheck<PartialUnrollerTestPass<2>>(text, expected, false);
+  SinglePassRunAndCheck<PartialUnrollerTestPassToken<2>>(text, expected, false);
 }
 
 /*
@@ -1587,9 +1595,8 @@ OpFunctionEnd
   EXPECT_NE(nullptr, module) << "Assembling failed for ushader:\n"
                              << text << std::endl;
 
-  opt::LoopUnroller loop_unroller;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopUnroller>(text, output, false);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, output, false, false, true, 0);
 }
 
 /*
@@ -1728,9 +1735,8 @@ OpFunctionEnd
   EXPECT_NE(nullptr, module) << "Assembling failed for ushader:\n"
                              << text << std::endl;
 
-  opt::LoopUnroller loop_unroller;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopUnroller>(text, output, false);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, output, false, false, true, 0);
 }
 
 /*
@@ -1868,9 +1874,8 @@ OpFunctionEnd
   EXPECT_NE(nullptr, module) << "Assembling failed for ushader:\n"
                              << text << std::endl;
 
-  opt::LoopUnroller loop_unroller;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopUnroller>(text, output, false);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, output, false, false, true, 0);
 }
 
 /*
@@ -2021,9 +2026,8 @@ OpFunctionEnd
   EXPECT_NE(nullptr, module) << "Assembling failed for ushader:\n"
                              << text << std::endl;
 
-  opt::LoopUnroller loop_unroller;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopUnroller>(text, output, false);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, output, false, false, true, 0);
 }
 
 // With opt::LocalMultiStoreElimPass
@@ -2197,9 +2201,8 @@ OpFunctionEnd
   EXPECT_NE(nullptr, module) << "Assembling failed for ushader:\n"
                              << multiple_phi_shader << std::endl;
 
-  opt::LoopUnroller loop_unroller;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<PartialUnrollerTestPass<4>>(multiple_phi_shader, output,
+  SinglePassRunAndCheck<PartialUnrollerTestPassToken<4>>(multiple_phi_shader, output,
                                                     false);
 }
 
@@ -2273,9 +2276,8 @@ OpFunctionEnd
   EXPECT_NE(nullptr, module) << "Assembling failed for ushader:\n"
                              << multiple_phi_shader << std::endl;
 
-  opt::LoopUnroller loop_unroller;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<PartialUnrollerTestPass<2>>(multiple_phi_shader, output,
+  SinglePassRunAndCheck<PartialUnrollerTestPassToken<2>>(multiple_phi_shader, output,
                                                     false);
 }
 
@@ -2397,9 +2399,8 @@ OpFunctionEnd
   EXPECT_NE(nullptr, module) << "Assembling failed for ushader:\n"
                              << multiple_phi_shader << std::endl;
 
-  opt::LoopUnroller loop_unroller;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopUnroller>(multiple_phi_shader, output, false);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(multiple_phi_shader, output, false, false, true, 0);
 }
 
 /*
@@ -2558,9 +2559,8 @@ OpFunctionEnd
   EXPECT_NE(nullptr, module) << "Assembling failed for ushader:\n"
                              << text << std::endl;
 
-  opt::LoopUnroller loop_unroller;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopUnroller>(text, output, false);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(text, output, false, false, true, 0);
 }
 
 // With opt::LocalMultiStoreElimPass
@@ -2667,9 +2667,8 @@ OpFunctionEnd
   EXPECT_NE(nullptr, module) << "Assembling failed for ushader:\n"
                              << condition_in_header << std::endl;
 
-  opt::LoopUnroller loop_unroller;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::LoopUnroller>(condition_in_header, output, false);
+  SinglePassRunAndCheck<opt::LoopUnrollerToken>(condition_in_header, output, false, false, true, 0);
 }
 
 TEST_F(PassClassTest, PartiallyUnrollResidualConditionIsInHeaderBlock) {
@@ -2747,9 +2746,8 @@ OpFunctionEnd
   EXPECT_NE(nullptr, module) << "Assembling failed for ushader:\n"
                              << condition_in_header << std::endl;
 
-  opt::LoopUnroller loop_unroller;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<PartialUnrollerTestPass<2>>(condition_in_header, output,
+  SinglePassRunAndCheck<PartialUnrollerTestPassToken<2>>(condition_in_header, output,
                                                     false);
 }
 
@@ -2925,7 +2923,7 @@ OpFunctionEnd
 )";
 
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<PartialUnrollerTestPass<3>>(text, expected, true);
+  SinglePassRunAndCheck<PartialUnrollerTestPassToken<3>>(text, expected, true);
 
   // Make sure the latch block information is preserved and propagated correctly
   // by the pass.
@@ -2933,7 +2931,7 @@ OpFunctionEnd
       BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
                   SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
 
-  PartialUnrollerTestPass<3> unroller;
+  PartialUnrollerTestPass unroller(3);
   unroller.Process(context.get());
 
   opt::Module* module = context->module();

--- a/test/opt/loop_optimizations/unswitch.cpp
+++ b/test/opt/loop_optimizations/unswitch.cpp
@@ -905,8 +905,8 @@ TEST_F(UnswitchTest, UnswitchNotUniform) {
                OpFunctionEnd
   )";
 
-  auto result =
-      SinglePassRunAndDisassemble<opt::LoopUnswitchPassToken>(text, true, false);
+  auto result = SinglePassRunAndDisassemble<opt::LoopUnswitchPassToken>(
+      text, true, false);
 
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
 }

--- a/test/opt/loop_optimizations/unswitch.cpp
+++ b/test/opt/loop_optimizations/unswitch.cpp
@@ -151,7 +151,7 @@ TEST_F(UnswitchTest, SimpleUnswitch) {
                OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::LoopUnswitchPass>(text, true);
+  SinglePassRunAndMatch<opt::LoopUnswitchPassToken>(text, true);
 }
 
 /*
@@ -257,7 +257,7 @@ TEST_F(UnswitchTest, UnswitchExit) {
                OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::LoopUnswitchPass>(text, true);
+  SinglePassRunAndMatch<opt::LoopUnswitchPassToken>(text, true);
 }
 
 /*
@@ -373,7 +373,7 @@ TEST_F(UnswitchTest, UnswitchContinue) {
                OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::LoopUnswitchPass>(text, true);
+  SinglePassRunAndMatch<opt::LoopUnswitchPassToken>(text, true);
 }
 
 /*
@@ -479,7 +479,7 @@ TEST_F(UnswitchTest, UnswitchKillLoop) {
                OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::LoopUnswitchPass>(text, true);
+  SinglePassRunAndMatch<opt::LoopUnswitchPassToken>(text, true);
 }
 
 /*
@@ -605,7 +605,7 @@ TEST_F(UnswitchTest, UnswitchSwitch) {
                OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::LoopUnswitchPass>(text, true);
+  SinglePassRunAndMatch<opt::LoopUnswitchPassToken>(text, true);
 }
 
 /*
@@ -806,7 +806,7 @@ TEST_F(UnswitchTest, UnSwitchNested) {
                OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::LoopUnswitchPass>(text, true);
+  SinglePassRunAndMatch<opt::LoopUnswitchPassToken>(text, true);
 }
 #endif  // SPIRV_EFFCEE
 
@@ -906,7 +906,7 @@ TEST_F(UnswitchTest, UnswitchNotUniform) {
   )";
 
   auto result =
-      SinglePassRunAndDisassemble<opt::LoopUnswitchPass>(text, true, false);
+      SinglePassRunAndDisassemble<opt::LoopUnswitchPassToken>(text, true, false);
 
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
 }

--- a/test/opt/pass_manager_test.cpp
+++ b/test/opt/pass_manager_test.cpp
@@ -26,13 +26,13 @@ using namespace spvtools;
 using spvtest::GetIdBound;
 using ::testing::Eq;
 
-// A null pass whose construtors accept arguments
-class NullPassWithArgs : public opt::NullPass {
+// A null pass whose constructors accept arguments
+class NullPassWithArgsToken : public opt::NullPassToken {
  public:
-  NullPassWithArgs(uint32_t) {}
-  NullPassWithArgs(std::string) {}
-  NullPassWithArgs(const std::vector<int>&) {}
-  NullPassWithArgs(const std::vector<int>&, uint32_t) {}
+  NullPassWithArgsToken(uint32_t) {}
+  NullPassWithArgsToken(std::string) {}
+  NullPassWithArgsToken(const std::vector<int>&) {}
+  NullPassWithArgsToken(const std::vector<int>&, uint32_t) {}
 
   const char* name() const override { return "null-with-args"; }
 };
@@ -41,42 +41,53 @@ TEST(PassManager, Interface) {
   opt::PassManager manager;
   EXPECT_EQ(0u, manager.NumPasses());
 
-  manager.AddPass<opt::StripDebugInfoPass>();
+  manager.AddPassToken<opt::StripDebugInfoPassToken>();
   EXPECT_EQ(1u, manager.NumPasses());
-  EXPECT_STREQ("strip-debug", manager.GetPass(0)->name());
+  EXPECT_STREQ("strip-debug", manager.GetPassToken(0)->name());
 
-  manager.AddPass(MakeUnique<opt::NullPass>());
+  manager.AddPassToken(MakeUnique<opt::NullPassToken>());
   EXPECT_EQ(2u, manager.NumPasses());
-  EXPECT_STREQ("strip-debug", manager.GetPass(0)->name());
-  EXPECT_STREQ("null", manager.GetPass(1)->name());
+  EXPECT_STREQ("strip-debug", manager.GetPassToken(0)->name());
+  EXPECT_STREQ("null", manager.GetPassToken(1)->name());
 
-  manager.AddPass<opt::StripDebugInfoPass>();
+  manager.AddPassToken<opt::StripDebugInfoPassToken>();
   EXPECT_EQ(3u, manager.NumPasses());
-  EXPECT_STREQ("strip-debug", manager.GetPass(0)->name());
-  EXPECT_STREQ("null", manager.GetPass(1)->name());
-  EXPECT_STREQ("strip-debug", manager.GetPass(2)->name());
+  EXPECT_STREQ("strip-debug", manager.GetPassToken(0)->name());
+  EXPECT_STREQ("null", manager.GetPassToken(1)->name());
+  EXPECT_STREQ("strip-debug", manager.GetPassToken(2)->name());
 
-  manager.AddPass<NullPassWithArgs>(1u);
-  manager.AddPass<NullPassWithArgs>("null pass args");
-  manager.AddPass<NullPassWithArgs>(std::initializer_list<int>{1, 2});
-  manager.AddPass<NullPassWithArgs>(std::initializer_list<int>{1, 2}, 3);
+  manager.AddPassToken<NullPassWithArgsToken>(1u);
+  manager.AddPassToken<NullPassWithArgsToken>("null pass args");
+  manager.AddPassToken<NullPassWithArgsToken>(std::initializer_list<int>{1, 2});
+  manager.AddPassToken<NullPassWithArgsToken>(std::initializer_list<int>{1, 2}, 3);
   EXPECT_EQ(7u, manager.NumPasses());
-  EXPECT_STREQ("strip-debug", manager.GetPass(0)->name());
-  EXPECT_STREQ("null", manager.GetPass(1)->name());
-  EXPECT_STREQ("strip-debug", manager.GetPass(2)->name());
-  EXPECT_STREQ("null-with-args", manager.GetPass(3)->name());
-  EXPECT_STREQ("null-with-args", manager.GetPass(4)->name());
-  EXPECT_STREQ("null-with-args", manager.GetPass(5)->name());
-  EXPECT_STREQ("null-with-args", manager.GetPass(6)->name());
+  EXPECT_STREQ("strip-debug", manager.GetPassToken(0)->name());
+  EXPECT_STREQ("null", manager.GetPassToken(1)->name());
+  EXPECT_STREQ("strip-debug", manager.GetPassToken(2)->name());
+  EXPECT_STREQ("null-with-args", manager.GetPassToken(3)->name());
+  EXPECT_STREQ("null-with-args", manager.GetPassToken(4)->name());
+  EXPECT_STREQ("null-with-args", manager.GetPassToken(5)->name());
+  EXPECT_STREQ("null-with-args", manager.GetPassToken(6)->name());
 }
 
 // A pass that appends an OpNop instruction to the debug1 section.
 class AppendOpNopPass : public opt::Pass {
  public:
-  const char* name() const override { return "AppendOpNop"; }
   Status Process(opt::IRContext* irContext) override {
     irContext->AddDebug1Inst(MakeUnique<opt::Instruction>(irContext));
     return Status::SuccessWithChange;
+  }
+};
+
+class AppendOpNopPassToken : public opt::PassToken {
+ public:
+  AppendOpNopPassToken() = default;
+  ~AppendOpNopPassToken() = default;
+
+  const char* name() const override { return "AppendOpNop"; }
+
+  std::unique_ptr<opt::Pass> CreatePass() const override {
+    return MakeUnique<AppendOpNopPass>();
   }
 };
 
@@ -86,7 +97,6 @@ class AppendMultipleOpNopPass : public opt::Pass {
  public:
   explicit AppendMultipleOpNopPass(uint32_t num_nop) : num_nop_(num_nop) {}
 
-  const char* name() const override { return "AppendOpNop"; }
   Status Process(opt::IRContext* irContext) override {
     for (uint32_t i = 0; i < num_nop_; i++) {
       irContext->AddDebug1Inst(MakeUnique<opt::Instruction>(irContext));
@@ -98,10 +108,24 @@ class AppendMultipleOpNopPass : public opt::Pass {
   uint32_t num_nop_;
 };
 
+class AppendMultipleOpNopPassToken : public opt::PassToken {
+ public:
+  explicit AppendMultipleOpNopPassToken(uint32_t num_nop) : num_nop_(num_nop) {}
+  ~AppendMultipleOpNopPassToken() = default;
+
+  const char* name() const override { return "AppendOpNop"; }
+
+  std::unique_ptr<opt::Pass> CreatePass() const override {
+    return MakeUnique<AppendMultipleOpNopPass>(num_nop_);
+  }
+
+ private:
+  uint32_t num_nop_;
+};
+
 // A pass that duplicates the last instruction in the debug1 section.
 class DuplicateInstPass : public opt::Pass {
  public:
-  const char* name() const override { return "DuplicateInst"; }
   Status Process(opt::IRContext* irContext) override {
     auto inst = MakeUnique<opt::Instruction>(
         *(--irContext->debug1_end())->Clone(irContext));
@@ -110,27 +134,39 @@ class DuplicateInstPass : public opt::Pass {
   }
 };
 
+class DuplicateInstPassToken : public opt::PassToken {
+ public:
+  DuplicateInstPassToken() = default;
+  ~DuplicateInstPassToken() = default;
+
+  const char* name() const override { return "DuplicateInst"; }
+
+  std::unique_ptr<opt::Pass> CreatePass() const override {
+    return MakeUnique<DuplicateInstPass>();
+  }
+};
+
 using PassManagerTest = PassTest<::testing::Test>;
 
 TEST_F(PassManagerTest, Run) {
   const std::string text = "OpMemoryModel Logical GLSL450\nOpSource ESSL 310\n";
 
-  AddPass<AppendOpNopPass>();
-  AddPass<AppendOpNopPass>();
+  AddPassToken<AppendOpNopPassToken>();
+  AddPassToken<AppendOpNopPassToken>();
   RunAndCheck(text.c_str(), (text + "OpNop\nOpNop\n").c_str());
 
   RenewPassManger();
-  AddPass<AppendOpNopPass>();
-  AddPass<DuplicateInstPass>();
+  AddPassToken<AppendOpNopPassToken>();
+  AddPassToken<DuplicateInstPassToken>();
   RunAndCheck(text.c_str(), (text + "OpNop\nOpNop\n").c_str());
 
   RenewPassManger();
-  AddPass<DuplicateInstPass>();
-  AddPass<AppendOpNopPass>();
+  AddPassToken<DuplicateInstPassToken>();
+  AddPassToken<AppendOpNopPassToken>();
   RunAndCheck(text.c_str(), (text + "OpSource ESSL 310\nOpNop\n").c_str());
 
   RenewPassManger();
-  AddPass<AppendMultipleOpNopPass>(3);
+  AddPassToken<AppendMultipleOpNopPassToken>(3);
   RunAndCheck(text.c_str(), (text + "OpNop\nOpNop\nOpNop\n").c_str());
 }
 
@@ -139,12 +175,26 @@ class AppendTypeVoidInstPass : public opt::Pass {
  public:
   explicit AppendTypeVoidInstPass(uint32_t result_id) : result_id_(result_id) {}
 
-  const char* name() const override { return "AppendTypeVoidInstPass"; }
   Status Process(opt::IRContext* irContext) override {
     auto inst = MakeUnique<opt::Instruction>(
         irContext, SpvOpTypeVoid, 0, result_id_, std::vector<opt::Operand>{});
     irContext->AddType(std::move(inst));
     return Status::SuccessWithChange;
+  }
+
+ private:
+  uint32_t result_id_;
+};
+
+class AppendTypeVoidInstPassToken : public opt::PassToken {
+ public:
+  AppendTypeVoidInstPassToken(uint32_t result_id) : result_id_(result_id) {}
+  ~AppendTypeVoidInstPassToken() = default;
+
+  const char* name() const override { return "AppendTypeVoidInstPass"; }
+
+  std::unique_ptr<opt::Pass> CreatePass() const override {
+    return MakeUnique<AppendTypeVoidInstPass>(result_id_);
   }
 
  private:
@@ -159,12 +209,12 @@ TEST(PassManager, RecomputeIdBoundAutomatically) {
   EXPECT_THAT(GetIdBound(*context.module()), Eq(0u));
 
   manager.Run(&context);
-  manager.AddPass<AppendOpNopPass>();
+  manager.AddPassToken<AppendOpNopPassToken>();
   // With no ID changes, the ID bound does not change.
   EXPECT_THAT(GetIdBound(*context.module()), Eq(0u));
 
   // Now we force an Id of 100 to be used.
-  manager.AddPass(MakeUnique<AppendTypeVoidInstPass>(100));
+  manager.AddPassToken(MakeUnique<AppendTypeVoidInstPassToken>(100));
   EXPECT_THAT(GetIdBound(*context.module()), Eq(0u));
   manager.Run(&context);
   // The Id has been updated automatically, even though the pass
@@ -172,12 +222,12 @@ TEST(PassManager, RecomputeIdBoundAutomatically) {
   EXPECT_THAT(GetIdBound(*context.module()), Eq(101u));
 
   // Try one more time!
-  manager.AddPass(MakeUnique<AppendTypeVoidInstPass>(200));
+  manager.AddPassToken(MakeUnique<AppendTypeVoidInstPassToken>(200));
   manager.Run(&context);
   EXPECT_THAT(GetIdBound(*context.module()), Eq(201u));
 
   // Add another pass, but which uses a lower Id.
-  manager.AddPass(MakeUnique<AppendTypeVoidInstPass>(10));
+  manager.AddPassToken(MakeUnique<AppendTypeVoidInstPassToken>(10));
   manager.Run(&context);
   // The Id stays high.
   EXPECT_THAT(GetIdBound(*context.module()), Eq(201u));

--- a/test/opt/pass_manager_test.cpp
+++ b/test/opt/pass_manager_test.cpp
@@ -59,7 +59,8 @@ TEST(PassManager, Interface) {
   manager.AddPassToken<NullPassWithArgsToken>(1u);
   manager.AddPassToken<NullPassWithArgsToken>("null pass args");
   manager.AddPassToken<NullPassWithArgsToken>(std::initializer_list<int>{1, 2});
-  manager.AddPassToken<NullPassWithArgsToken>(std::initializer_list<int>{1, 2}, 3);
+  manager.AddPassToken<NullPassWithArgsToken>(std::initializer_list<int>{1, 2},
+                                              3);
   EXPECT_EQ(7u, manager.NumPasses());
   EXPECT_STREQ("strip-debug", manager.GetPassToken(0)->name());
   EXPECT_STREQ("null", manager.GetPassToken(1)->name());

--- a/test/opt/pass_merge_return_test.cpp
+++ b/test/opt/pass_merge_return_test.cpp
@@ -46,7 +46,7 @@ OpFunctionEnd
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::MergeReturnPass>(before, after, false, true);
+  SinglePassRunAndCheck<opt::MergeReturnPassToken>(before, after, false, true);
 }
 
 TEST_F(MergeReturnPassTest, TwoReturnsNoValue) {
@@ -96,7 +96,7 @@ OpFunctionEnd
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::MergeReturnPass>(before, after, false, true);
+  SinglePassRunAndCheck<opt::MergeReturnPassToken>(before, after, false, true);
 }
 
 TEST_F(MergeReturnPassTest, TwoReturnsWithValues) {
@@ -145,7 +145,7 @@ OpFunctionEnd
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::MergeReturnPass>(before, after, false, true);
+  SinglePassRunAndCheck<opt::MergeReturnPassToken>(before, after, false, true);
 }
 
 TEST_F(MergeReturnPassTest, UnreachableReturnsNoValue) {
@@ -199,7 +199,7 @@ OpFunctionEnd
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::MergeReturnPass>(before, after, false, true);
+  SinglePassRunAndCheck<opt::MergeReturnPassToken>(before, after, false, true);
 }
 
 TEST_F(MergeReturnPassTest, UnreachableReturnsWithValues) {
@@ -254,7 +254,7 @@ OpFunctionEnd
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  SinglePassRunAndCheck<opt::MergeReturnPass>(before, after, false, true);
+  SinglePassRunAndCheck<opt::MergeReturnPassToken>(before, after, false, true);
 }
 
 #ifdef SPIRV_EFFCEE
@@ -296,7 +296,7 @@ OpUnreachable
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::MergeReturnPass>(before, false);
+  SinglePassRunAndMatch<opt::MergeReturnPassToken>(before, false);
 }
 
 TEST_F(MergeReturnPassTest, StructuredControlFlowAddPhi) {
@@ -345,7 +345,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::MergeReturnPass>(before, false);
+  SinglePassRunAndMatch<opt::MergeReturnPassToken>(before, false);
 }
 #endif
 
@@ -429,7 +429,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::MergeReturnPass>(before, after, false, true);
+  SinglePassRunAndCheck<opt::MergeReturnPassToken>(before, after, false, true);
 }
 
 TEST_F(MergeReturnPassTest, NestedSelectionMerge) {
@@ -519,7 +519,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::MergeReturnPass>(before, after, false, true);
+  SinglePassRunAndCheck<opt::MergeReturnPassToken>(before, after, false, true);
 }
 
 // This is essentially the same as NestedSelectionMerge, except
@@ -612,7 +612,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::MergeReturnPass>(before, after, false, true);
+  SinglePassRunAndCheck<opt::MergeReturnPassToken>(before, after, false, true);
 }
 
 TEST_F(MergeReturnPassTest, NestedSelectionMerge3) {
@@ -701,6 +701,6 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::MergeReturnPass>(before, after, false, true);
+  SinglePassRunAndCheck<opt::MergeReturnPassToken>(before, after, false, true);
 }
 }  // anonymous namespace

--- a/test/opt/pass_remove_duplicates_test.cpp
+++ b/test/opt/pass_remove_duplicates_test.cpp
@@ -29,6 +29,7 @@ using spvtools::opt::IRContext;
 using spvtools::opt::Instruction;
 using spvtools::opt::PassManager;
 using spvtools::opt::RemoveDuplicatesPass;
+using spvtools::opt::RemoveDuplicatesPassToken;
 
 class RemoveDuplicatesTest : public ::testing::Test {
  public:
@@ -70,7 +71,7 @@ class RemoveDuplicatesTest : public ::testing::Test {
 
     PassManager manager;
     manager.SetMessageConsumer(consumer_);
-    manager.AddPass<RemoveDuplicatesPass>();
+    manager.AddPassToken<RemoveDuplicatesPassToken>();
 
     spvtools::opt::Pass::Status pass_res = manager.Run(context_.get());
     if (pass_res == spvtools::opt::Pass::Status::Failure) return std::string();

--- a/test/opt/pass_test.cpp
+++ b/test/opt/pass_test.cpp
@@ -26,7 +26,6 @@ namespace {
 using namespace spvtools;
 class DummyPass : public opt::Pass {
  public:
-  const char* name() const override { return "dummy-pass"; }
   Status Process(opt::IRContext* irContext) override {
     return irContext ? Status::SuccessWithoutChange : Status::Failure;
   }

--- a/test/opt/private_to_local_test.cpp
+++ b/test/opt/private_to_local_test.cpp
@@ -57,7 +57,7 @@ TEST_F(PrivateToLocalTest, ChangeToLocal) {
                OpReturn
                OpFunctionEnd
   )";
-  SinglePassRunAndMatch<opt::PrivateToLocalPass>(text, false);
+  SinglePassRunAndMatch<opt::PrivateToLocalPassToken>(text, false);
 }
 
 TEST_F(PrivateToLocalTest, ReuseExistingType) {
@@ -89,7 +89,7 @@ TEST_F(PrivateToLocalTest, ReuseExistingType) {
                OpReturn
                OpFunctionEnd
   )";
-  SinglePassRunAndMatch<opt::PrivateToLocalPass>(text, false);
+  SinglePassRunAndMatch<opt::PrivateToLocalPassToken>(text, false);
 }
 
 TEST_F(PrivateToLocalTest, UpdateAccessChain) {
@@ -127,7 +127,7 @@ TEST_F(PrivateToLocalTest, UpdateAccessChain) {
                OpReturn
                OpFunctionEnd
   )";
-  SinglePassRunAndMatch<opt::PrivateToLocalPass>(text, false);
+  SinglePassRunAndMatch<opt::PrivateToLocalPassToken>(text, false);
 }
 
 TEST_F(PrivateToLocalTest, UseTexelPointer) {
@@ -172,7 +172,7 @@ OpCapability SampledBuffer
                OpReturn
                OpFunctionEnd
   )";
-  SinglePassRunAndMatch<opt::PrivateToLocalPass>(text, false);
+  SinglePassRunAndMatch<opt::PrivateToLocalPassToken>(text, false);
 }
 
 TEST_F(PrivateToLocalTest, UsedInTwoFunctions) {
@@ -200,7 +200,7 @@ TEST_F(PrivateToLocalTest, UsedInTwoFunctions) {
                OpReturn
                OpFunctionEnd
   )";
-  auto result = SinglePassRunAndDisassemble<opt::StrengthReductionPass>(
+  auto result = SinglePassRunAndDisassemble<opt::StrengthReductionPassToken>(
       text, /* skip_nop = */ true, /* do_validation = */ false);
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
 }
@@ -234,7 +234,7 @@ TEST_F(PrivateToLocalTest, UsedInFunctionCall) {
                OpReturn
                OpFunctionEnd
   )";
-  auto result = SinglePassRunAndDisassemble<opt::StrengthReductionPass>(
+  auto result = SinglePassRunAndDisassemble<opt::StrengthReductionPassToken>(
       text, /* skip_nop = */ true, /* do_validation = */ false);
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
 }
@@ -271,7 +271,7 @@ TEST_F(PrivateToLocalTest, CreatePointerToAmbiguousStruct1) {
                OpReturn
                OpFunctionEnd
   )";
-  SinglePassRunAndMatch<opt::PrivateToLocalPass>(text, false);
+  SinglePassRunAndMatch<opt::PrivateToLocalPassToken>(text, false);
 }
 
 TEST_F(PrivateToLocalTest, CreatePointerToAmbiguousStruct2) {
@@ -306,7 +306,7 @@ TEST_F(PrivateToLocalTest, CreatePointerToAmbiguousStruct2) {
                OpReturn
                OpFunctionEnd
   )";
-  SinglePassRunAndMatch<opt::PrivateToLocalPass>(text, false);
+  SinglePassRunAndMatch<opt::PrivateToLocalPassToken>(text, false);
 }
 #endif
 }  // anonymous namespace

--- a/test/opt/reduce_load_size_test.cpp
+++ b/test/opt/reduce_load_size_test.cpp
@@ -103,7 +103,7 @@ TEST_F(ReduceLoadSizeTest, cbuffer_load_extract) {
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
                         SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
-  SinglePassRunAndMatch<opt::ReduceLoadSize>(test, false);
+  SinglePassRunAndMatch<opt::ReduceLoadSizeToken>(test, false);
 }
 #endif
 
@@ -182,7 +182,7 @@ OpFunctionEnd
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
                         SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
-  SinglePassRunAndCheck<opt::ReduceLoadSize>(test, test, true, false);
+  SinglePassRunAndCheck<opt::ReduceLoadSizeToken>(test, test, true, false);
 }
 
 TEST_F(ReduceLoadSizeTest, cbuffer_load_5_extract) {
@@ -253,7 +253,7 @@ OpFunctionEnd
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
                         SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
-  SinglePassRunAndCheck<opt::ReduceLoadSize>(test, test, true, false);
+  SinglePassRunAndCheck<opt::ReduceLoadSizeToken>(test, test, true, false);
 }
 
 TEST_F(ReduceLoadSizeTest, cbuffer_load_fully_used) {
@@ -318,7 +318,7 @@ OpFunctionEnd
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
                         SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
-  SinglePassRunAndCheck<opt::ReduceLoadSize>(test, test, true, false);
+  SinglePassRunAndCheck<opt::ReduceLoadSizeToken>(test, test, true, false);
 }
 
 }  // anonymous namespace

--- a/test/opt/redundancy_elimination_test.cpp
+++ b/test/opt/redundancy_elimination_test.cpp
@@ -55,7 +55,7 @@ TEST_F(RedundancyEliminationTest, RemoveRedundantLocalAdd) {
                OpReturn
                OpFunctionEnd
   )";
-  SinglePassRunAndMatch<opt::RedundancyEliminationPass>(text, false);
+  SinglePassRunAndMatch<opt::RedundancyEliminationPassToken>(text, false);
 }
 
 // Remove a redundant add across basic blocks.
@@ -84,7 +84,7 @@ TEST_F(RedundancyEliminationTest, RemoveRedundantAdd) {
                OpReturn
                OpFunctionEnd
   )";
-  SinglePassRunAndMatch<opt::RedundancyEliminationPass>(text, false);
+  SinglePassRunAndMatch<opt::RedundancyEliminationPassToken>(text, false);
 }
 
 // Remove a redundant add going through a multiple basic blocks.
@@ -120,7 +120,7 @@ TEST_F(RedundancyEliminationTest, RemoveRedundantAddDiamond) {
                OpFunctionEnd
 
   )";
-  SinglePassRunAndMatch<opt::RedundancyEliminationPass>(text, false);
+  SinglePassRunAndMatch<opt::RedundancyEliminationPassToken>(text, false);
 }
 
 // Remove a redundant add in a side node.
@@ -156,7 +156,7 @@ TEST_F(RedundancyEliminationTest, RemoveRedundantAddInSideNode) {
                OpFunctionEnd
 
   )";
-  SinglePassRunAndMatch<opt::RedundancyEliminationPass>(text, false);
+  SinglePassRunAndMatch<opt::RedundancyEliminationPassToken>(text, false);
 }
 
 // Remove a redundant add whose value is in the result of a phi node.
@@ -196,7 +196,7 @@ TEST_F(RedundancyEliminationTest, RemoveRedundantAddWithPhi) {
                OpFunctionEnd
 
   )";
-  SinglePassRunAndMatch<opt::RedundancyEliminationPass>(text, false);
+  SinglePassRunAndMatch<opt::RedundancyEliminationPassToken>(text, false);
 }
 
 // Keep the add because it is redundant on some paths, but not all paths.
@@ -230,7 +230,7 @@ TEST_F(RedundancyEliminationTest, KeepPartiallyRedundantAdd) {
                OpFunctionEnd
 
   )";
-  auto result = SinglePassRunAndDisassemble<opt::RedundancyEliminationPass>(
+  auto result = SinglePassRunAndDisassemble<opt::RedundancyEliminationPassToken>(
       text, /* skip_nop = */ true, /* do_validation = */ false);
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
 }
@@ -268,7 +268,7 @@ TEST_F(RedundancyEliminationTest, KeepRedundantAddWithoutPhi) {
                OpFunctionEnd
 
   )";
-  auto result = SinglePassRunAndDisassemble<opt::RedundancyEliminationPass>(
+  auto result = SinglePassRunAndDisassemble<opt::RedundancyEliminationPassToken>(
       text, /* skip_nop = */ true, /* do_validation = */ false);
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
 }

--- a/test/opt/redundancy_elimination_test.cpp
+++ b/test/opt/redundancy_elimination_test.cpp
@@ -230,8 +230,9 @@ TEST_F(RedundancyEliminationTest, KeepPartiallyRedundantAdd) {
                OpFunctionEnd
 
   )";
-  auto result = SinglePassRunAndDisassemble<opt::RedundancyEliminationPassToken>(
-      text, /* skip_nop = */ true, /* do_validation = */ false);
+  auto result =
+      SinglePassRunAndDisassemble<opt::RedundancyEliminationPassToken>(
+          text, /* skip_nop = */ true, /* do_validation = */ false);
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
 }
 
@@ -268,8 +269,9 @@ TEST_F(RedundancyEliminationTest, KeepRedundantAddWithoutPhi) {
                OpFunctionEnd
 
   )";
-  auto result = SinglePassRunAndDisassemble<opt::RedundancyEliminationPassToken>(
-      text, /* skip_nop = */ true, /* do_validation = */ false);
+  auto result =
+      SinglePassRunAndDisassemble<opt::RedundancyEliminationPassToken>(
+          text, /* skip_nop = */ true, /* do_validation = */ false);
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
 }
 #endif

--- a/test/opt/replace_invalid_opc_test.cpp
+++ b/test/opt/replace_invalid_opc_test.cpp
@@ -77,7 +77,7 @@ TEST_F(ReplaceInvalidOpcodeTest, ReplaceInstruction) {
                OpReturn
                OpFunctionEnd)";
 
-  SinglePassRunAndMatch<opt::ReplaceInvalidOpcodePass>(text, false);
+  SinglePassRunAndMatch<opt::ReplaceInvalidOpcodePassToken>(text, false);
 }
 
 TEST_F(ReplaceInvalidOpcodeTest, ReplaceInstructionInNonEntryPoint) {
@@ -137,7 +137,7 @@ TEST_F(ReplaceInvalidOpcodeTest, ReplaceInstructionInNonEntryPoint) {
                OpReturn
                OpFunctionEnd)";
 
-  SinglePassRunAndMatch<opt::ReplaceInvalidOpcodePass>(text, false);
+  SinglePassRunAndMatch<opt::ReplaceInvalidOpcodePassToken>(text, false);
 }
 
 TEST_F(ReplaceInvalidOpcodeTest, ReplaceInstructionMultipleEntryPoints) {
@@ -206,7 +206,7 @@ TEST_F(ReplaceInvalidOpcodeTest, ReplaceInstructionMultipleEntryPoints) {
                OpReturn
                OpFunctionEnd)";
 
-  SinglePassRunAndMatch<opt::ReplaceInvalidOpcodePass>(text, false);
+  SinglePassRunAndMatch<opt::ReplaceInvalidOpcodePassToken>(text, false);
 }
 TEST_F(ReplaceInvalidOpcodeTest, DontReplaceInstruction) {
   const std::string text = R"(
@@ -256,7 +256,7 @@ TEST_F(ReplaceInvalidOpcodeTest, DontReplaceInstruction) {
                OpReturn
                OpFunctionEnd)";
 
-  auto result = SinglePassRunAndDisassemble<opt::ReplaceInvalidOpcodePass>(
+  auto result = SinglePassRunAndDisassemble<opt::ReplaceInvalidOpcodePassToken>(
       text, /* skip_nop = */ true, /* do_validation = */ false);
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
 }
@@ -321,7 +321,7 @@ TEST_F(ReplaceInvalidOpcodeTest, MultipleEntryPointsDifferentStage) {
                OpReturn
                OpFunctionEnd)";
 
-  auto result = SinglePassRunAndDisassemble<opt::ReplaceInvalidOpcodePass>(
+  auto result = SinglePassRunAndDisassemble<opt::ReplaceInvalidOpcodePassToken>(
       text, /* skip_nop = */ true, /* do_validation = */ false);
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
 }
@@ -375,7 +375,7 @@ TEST_F(ReplaceInvalidOpcodeTest, DontReplaceLinkage) {
                OpReturn
                OpFunctionEnd)";
 
-  auto result = SinglePassRunAndDisassemble<opt::ReplaceInvalidOpcodePass>(
+  auto result = SinglePassRunAndDisassemble<opt::ReplaceInvalidOpcodePassToken>(
       text, /* skip_nop = */ true, /* do_validation = */ false);
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
 }
@@ -402,7 +402,7 @@ TEST_F(ReplaceInvalidOpcodeTest, BarrierDontReplace) {
             OpReturn
             OpFunctionEnd)";
 
-  auto result = SinglePassRunAndDisassemble<opt::ReplaceInvalidOpcodePass>(
+  auto result = SinglePassRunAndDisassemble<opt::ReplaceInvalidOpcodePassToken>(
       text, /* skip_nop = */ true, /* do_validation = */ false);
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
 }
@@ -430,7 +430,7 @@ TEST_F(ReplaceInvalidOpcodeTest, BarrierReplace) {
             OpReturn
             OpFunctionEnd)";
 
-  SinglePassRunAndMatch<opt::ReplaceInvalidOpcodePass>(text, false);
+  SinglePassRunAndMatch<opt::ReplaceInvalidOpcodePassToken>(text, false);
 }
 
 struct Message {
@@ -516,7 +516,7 @@ TEST_F(ReplaceInvalidOpcodeTest, MessageTest) {
        "Removing ImageSampleImplicitLod instruction because of incompatible "
        "execution model."}};
   SetMessageConsumer(GetTestMessageConsumer(messages));
-  auto result = SinglePassRunAndDisassemble<opt::ReplaceInvalidOpcodePass>(
+  auto result = SinglePassRunAndDisassemble<opt::ReplaceInvalidOpcodePassToken>(
       text, /* skip_nop = */ true, /* do_validation = */ false);
   EXPECT_EQ(opt::Pass::Status::SuccessWithChange, std::get<1>(result));
 }
@@ -582,7 +582,7 @@ TEST_F(ReplaceInvalidOpcodeTest, MultipleMessageTest) {
        "incompatible "
        "execution model."}};
   SetMessageConsumer(GetTestMessageConsumer(messages));
-  auto result = SinglePassRunAndDisassemble<opt::ReplaceInvalidOpcodePass>(
+  auto result = SinglePassRunAndDisassemble<opt::ReplaceInvalidOpcodePassToken>(
       text, /* skip_nop = */ true, /* do_validation = */ false);
   EXPECT_EQ(opt::Pass::Status::SuccessWithChange, std::get<1>(result));
 }

--- a/test/opt/scalar_replacement_test.cpp
+++ b/test/opt/scalar_replacement_test.cpp
@@ -71,7 +71,7 @@ OpReturnValue %19
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, StructInitialization) {
@@ -125,7 +125,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, SpecConstantInitialization) {
@@ -169,7 +169,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 // TODO(alanbaker): Re-enable when vector and matrix scalarization is supported.
@@ -224,7 +224,7 @@ OpFunctionEnd
 //  OpFunctionEnd
 //   )";
 //
-//   SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+//   SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 // }
 //
 //  TEST_F(ScalarReplacementTest, MatrixInitialization) {
@@ -283,7 +283,7 @@ OpFunctionEnd
 //  OpFunctionEnd
 //   )";
 //
-//   SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+//   SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 // }
 
 TEST_F(ScalarReplacementTest, ElideAccessChain) {
@@ -317,7 +317,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, ElideMultipleAccessChains) {
@@ -355,7 +355,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, ReplaceAccessChain) {
@@ -397,7 +397,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, ArrayInitialization) {
@@ -448,7 +448,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, NonUniformCompositeInitialization) {
@@ -529,7 +529,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, ElideUncombinedAccessChains) {
@@ -565,7 +565,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, ElideSingleUncombinedAccessChains) {
@@ -605,7 +605,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, ReplaceWholeLoad) {
@@ -645,7 +645,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, ReplaceWholeLoadCopyMemoryAccess) {
@@ -681,7 +681,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, ReplaceWholeStore) {
@@ -718,7 +718,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, ReplaceWholeStoreCopyMemoryAccess) {
@@ -756,7 +756,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, DontTouchVolatileLoad) {
@@ -788,7 +788,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, DontTouchVolatileStore) {
@@ -820,7 +820,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, DontTouchSpecNonFunctionVariable) {
@@ -852,7 +852,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, DontTouchSpecConstantAccessChain) {
@@ -886,7 +886,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, NoPartialAccesses) {
@@ -916,7 +916,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, DontTouchPtrAccessChain) {
@@ -950,7 +950,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, false);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, DontTouchInBoundsPtrAccessChain) {
@@ -984,7 +984,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, false);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, DonTouchAliasedDecoration) {
@@ -1017,7 +1017,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, CopyRestrictDecoration) {
@@ -1059,7 +1059,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, DontClobberDecoratesOnSubtypes) {
@@ -1097,7 +1097,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, DontCopyMemberDecorate) {
@@ -1134,7 +1134,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, NoPartialAccesses2) {
@@ -1258,7 +1258,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, ReplaceWholeLoadAndStore) {
@@ -1304,7 +1304,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, ReplaceWholeLoadAndStore2) {
@@ -1353,7 +1353,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, CreateAmbiguousNullConstant1) {
@@ -1399,7 +1399,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 
 TEST_F(ScalarReplacementTest, CreateAmbiguousNullConstant2) {
@@ -1444,7 +1444,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPass>(text, true);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
 }
 #endif  // SPIRV_EFFCEE
 
@@ -1478,7 +1478,7 @@ OpReturnValue %19
 OpFunctionEnd
   )";
 
-  auto result = SinglePassRunAndDisassemble<opt::ScalarReplacementPass>(
+  auto result = SinglePassRunAndDisassemble<opt::ScalarReplacementPassToken>(
       text, true, false, 2);
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
 }
@@ -1515,7 +1515,7 @@ OpReturnValue %19
 OpFunctionEnd
   )";
 
-  auto result = SinglePassRunAndDisassemble<opt::ScalarReplacementPass>(
+  auto result = SinglePassRunAndDisassemble<opt::ScalarReplacementPassToken>(
       text, true, false, 0);
   EXPECT_EQ(opt::Pass::Status::SuccessWithChange, std::get<1>(result));
 }

--- a/test/opt/scalar_replacement_test.cpp
+++ b/test/opt/scalar_replacement_test.cpp
@@ -950,7 +950,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<ScalarReplacementPassToken>(text, true);
+  SinglePassRunAndMatch<ScalarReplacementPassToken>(text, false);
 }
 
 TEST_F(ScalarReplacementTest, DontTouchInBoundsPtrAccessChain) {
@@ -984,7 +984,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<ScalarReplacementPassToken>(text, true);
+  SinglePassRunAndMatch<ScalarReplacementPassToken>(text, false);
 }
 
 TEST_F(ScalarReplacementTest, DonTouchAliasedDecoration) {

--- a/test/opt/scalar_replacement_test.cpp
+++ b/test/opt/scalar_replacement_test.cpp
@@ -71,7 +71,7 @@ OpReturnValue %19
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, StructInitialization) {
@@ -125,7 +125,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, SpecConstantInitialization) {
@@ -169,7 +169,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 // TODO(alanbaker): Re-enable when vector and matrix scalarization is supported.
@@ -224,7 +224,7 @@ OpFunctionEnd
 //  OpFunctionEnd
 //   )";
 //
-//   SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+//   SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 // }
 //
 //  TEST_F(ScalarReplacementTest, MatrixInitialization) {
@@ -283,7 +283,7 @@ OpFunctionEnd
 //  OpFunctionEnd
 //   )";
 //
-//   SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+//   SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 // }
 
 TEST_F(ScalarReplacementTest, ElideAccessChain) {
@@ -317,7 +317,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, ElideMultipleAccessChains) {
@@ -355,7 +355,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, ReplaceAccessChain) {
@@ -397,7 +397,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, ArrayInitialization) {
@@ -448,7 +448,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, NonUniformCompositeInitialization) {
@@ -529,7 +529,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, ElideUncombinedAccessChains) {
@@ -565,7 +565,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, ElideSingleUncombinedAccessChains) {
@@ -605,7 +605,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, ReplaceWholeLoad) {
@@ -645,7 +645,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, ReplaceWholeLoadCopyMemoryAccess) {
@@ -681,7 +681,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, ReplaceWholeStore) {
@@ -718,7 +718,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, ReplaceWholeStoreCopyMemoryAccess) {
@@ -756,7 +756,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, DontTouchVolatileLoad) {
@@ -788,7 +788,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, DontTouchVolatileStore) {
@@ -820,7 +820,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, DontTouchSpecNonFunctionVariable) {
@@ -852,7 +852,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, DontTouchSpecConstantAccessChain) {
@@ -886,7 +886,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, NoPartialAccesses) {
@@ -916,7 +916,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, DontTouchPtrAccessChain) {
@@ -950,7 +950,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, DontTouchInBoundsPtrAccessChain) {
@@ -984,7 +984,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, DonTouchAliasedDecoration) {
@@ -1017,7 +1017,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, CopyRestrictDecoration) {
@@ -1059,7 +1059,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, DontClobberDecoratesOnSubtypes) {
@@ -1097,7 +1097,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, DontCopyMemberDecorate) {
@@ -1134,7 +1134,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, NoPartialAccesses2) {
@@ -1258,7 +1258,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, ReplaceWholeLoadAndStore) {
@@ -1304,7 +1304,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, ReplaceWholeLoadAndStore2) {
@@ -1353,7 +1353,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, CreateAmbiguousNullConstant1) {
@@ -1399,7 +1399,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 
 TEST_F(ScalarReplacementTest, CreateAmbiguousNullConstant2) {
@@ -1444,7 +1444,7 @@ OpReturn
 OpFunctionEnd
   )";
 
-  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true, 100);
+  SinglePassRunAndMatch<opt::ScalarReplacementPassToken>(text, true);
 }
 #endif  // SPIRV_EFFCEE
 

--- a/test/opt/set_spec_const_default_value_test.cpp
+++ b/test/opt/set_spec_const_default_value_test.cpp
@@ -144,7 +144,7 @@ using SetSpecConstantDefaultValueInStringFormParamTest = PassTest<
 
 TEST_P(SetSpecConstantDefaultValueInStringFormParamTest, TestCase) {
   const auto& tc = GetParam();
-  SinglePassRunAndCheck<opt::SetSpecConstantDefaultValuePass>(
+  SinglePassRunAndCheck<opt::SetSpecConstantDefaultValuePassToken>(
       tc.code, tc.expected, /* skip_nop = */ false, tc.default_values);
 }
 
@@ -606,7 +606,7 @@ using SetSpecConstantDefaultValueInBitPatternFormParamTest =
 
 TEST_P(SetSpecConstantDefaultValueInBitPatternFormParamTest, TestCase) {
   const auto& tc = GetParam();
-  SinglePassRunAndCheck<opt::SetSpecConstantDefaultValuePass>(
+  SinglePassRunAndCheck<opt::SetSpecConstantDefaultValuePassToken>(
       tc.code, tc.expected, /* skip_nop = */ false, tc.default_values);
 }
 

--- a/test/opt/simplification_test.cpp
+++ b/test/opt/simplification_test.cpp
@@ -68,7 +68,7 @@ TEST_F(SimplificationTest, StraightLineTest) {
                OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::SimplificationPass>(text, false);
+  SinglePassRunAndMatch<opt::SimplificationPassToken>(text, false);
 }
 
 TEST_F(SimplificationTest, AcrossBasicBlocks) {
@@ -132,7 +132,7 @@ TEST_F(SimplificationTest, AcrossBasicBlocks) {
 
 )";
 
-  SinglePassRunAndMatch<opt::SimplificationPass>(text, false);
+  SinglePassRunAndMatch<opt::SimplificationPassToken>(text, false);
 }
 
 TEST_F(SimplificationTest, ThroughLoops) {
@@ -199,7 +199,7 @@ TEST_F(SimplificationTest, ThroughLoops) {
                OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::SimplificationPass>(text, false);
+  SinglePassRunAndMatch<opt::SimplificationPassToken>(text, false);
 }
 #endif
 }  // anonymous namespace

--- a/test/opt/strength_reduction_test.cpp
+++ b/test/opt/strength_reduction_test.cpp
@@ -54,7 +54,7 @@ TEST_F(StrengthReductionBasicTest, BasicReplaceMulBy8) {
       // clang-format on
   };
 
-  auto result = SinglePassRunAndDisassemble<opt::StrengthReductionPass>(
+  auto result = SinglePassRunAndDisassemble<opt::StrengthReductionPassToken>(
       JoinAllInsts(text), /* skip_nop = */ true, /* do_validation = */ false);
 
   EXPECT_EQ(opt::Pass::Status::SuccessWithChange, std::get<1>(result));
@@ -99,7 +99,7 @@ TEST_F(StrengthReductionBasicTest, BasicReplaceMulBy16) {
 ; CHECK: OpFunctionEnd
                OpFunctionEnd)";
 
-  SinglePassRunAndMatch<opt::StrengthReductionPass>(text, false);
+  SinglePassRunAndMatch<opt::StrengthReductionPassToken>(text, false);
 }
 #endif
 
@@ -126,7 +126,7 @@ TEST_F(StrengthReductionBasicTest, BasicTwoPowersOf2) {
           OpFunctionEnd
 )";
   // clang-format on
-  auto result = SinglePassRunAndDisassemble<opt::StrengthReductionPass>(
+  auto result = SinglePassRunAndDisassemble<opt::StrengthReductionPassToken>(
       text, /* skip_nop = */ true, /* do_validation = */ false);
 
   EXPECT_EQ(opt::Pass::Status::SuccessWithChange, std::get<1>(result));
@@ -157,7 +157,7 @@ TEST_F(StrengthReductionBasicTest, BasicDontReplace0) {
       // clang-format on
   };
 
-  auto result = SinglePassRunAndDisassemble<opt::StrengthReductionPass>(
+  auto result = SinglePassRunAndDisassemble<opt::StrengthReductionPassToken>(
       JoinAllInsts(text), /* skip_nop = */ true, /* do_validation = */ false);
 
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
@@ -186,7 +186,7 @@ TEST_F(StrengthReductionBasicTest, BasicNoChange) {
       // clang-format on
   };
 
-  auto result = SinglePassRunAndDisassemble<opt::StrengthReductionPass>(
+  auto result = SinglePassRunAndDisassemble<opt::StrengthReductionPassToken>(
       JoinAllInsts(text), /* skip_nop = */ true, /* do_validation = */ false);
 
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
@@ -214,7 +214,7 @@ TEST_F(StrengthReductionBasicTest, NoDuplicateConstantsAndTypes) {
       // clang-format on
   };
 
-  auto result = SinglePassRunAndDisassemble<opt::StrengthReductionPass>(
+  auto result = SinglePassRunAndDisassemble<opt::StrengthReductionPassToken>(
       JoinAllInsts(text), /* skip_nop = */ true, /* do_validation = */ false);
 
   EXPECT_EQ(opt::Pass::Status::SuccessWithChange, std::get<1>(result));
@@ -248,7 +248,7 @@ TEST_F(StrengthReductionBasicTest, BasicCreateOneConst) {
       // clang-format on
   };
 
-  auto result = SinglePassRunAndDisassemble<opt::StrengthReductionPass>(
+  auto result = SinglePassRunAndDisassemble<opt::StrengthReductionPassToken>(
       JoinAllInsts(text), /* skip_nop = */ true, /* do_validation = */ false);
 
   EXPECT_EQ(opt::Pass::Status::SuccessWithChange, std::get<1>(result));
@@ -339,7 +339,7 @@ TEST_F(StrengthReductionBasicTest, BasicCheckPositionAndReplacement) {
   };
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::StrengthReductionPass>(
+  SinglePassRunAndCheck<opt::StrengthReductionPassToken>(
       JoinAllInsts(Concat(common_text, foo_before)),
       JoinAllInsts(Concat(common_text, foo_after)),
       /* skip_nop = */ true, /* do_validate = */ true);
@@ -428,7 +428,7 @@ TEST_F(StrengthReductionBasicTest, BasicTestMultipleReplacements) {
   };
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::StrengthReductionPass>(
+  SinglePassRunAndCheck<opt::StrengthReductionPassToken>(
       JoinAllInsts(Concat(common_text, foo_before)),
       JoinAllInsts(Concat(common_text, foo_after)),
       /* skip_nop = */ true, /* do_validate = */ true);

--- a/test/opt/strip_debug_info_test.cpp
+++ b/test/opt/strip_debug_info_test.cpp
@@ -52,8 +52,8 @@ TEST_F(StripLineDebugInfoTest, LineNoLine) {
       // clang-format on
   };
   SinglePassRunAndCheck<opt::StripDebugInfoPassToken>(JoinAllInsts(text),
-                                                 JoinNonDebugInsts(text),
-                                                 /* skip_nop = */ false);
+                                                      JoinNonDebugInsts(text),
+                                                      /* skip_nop = */ false);
 
   // Let's add more debug instruction before the "OpString" instruction.
   const std::vector<const char*> more_text = {
@@ -68,8 +68,8 @@ TEST_F(StripLineDebugInfoTest, LineNoLine) {
   };
   text.insert(text.begin() + 4, more_text.cbegin(), more_text.cend());
   SinglePassRunAndCheck<opt::StripDebugInfoPassToken>(JoinAllInsts(text),
-                                                 JoinNonDebugInsts(text),
-                                                 /* skip_nop = */ false);
+                                                      JoinNonDebugInsts(text),
+                                                      /* skip_nop = */ false);
 }
 
 using StripDebugInfoTest = PassTest<::testing::TestWithParam<const char*>>;
@@ -81,8 +81,8 @@ TEST_P(StripDebugInfoTest, Kind) {
       GetParam(),
   };
   SinglePassRunAndCheck<opt::StripDebugInfoPassToken>(JoinAllInsts(text),
-                                                 JoinNonDebugInsts(text),
-                                                 /* skip_nop = */ false);
+                                                      JoinNonDebugInsts(text),
+                                                      /* skip_nop = */ false);
 }
 
 // Test each possible non-line debug instruction.

--- a/test/opt/strip_debug_info_test.cpp
+++ b/test/opt/strip_debug_info_test.cpp
@@ -51,7 +51,7 @@ TEST_F(StripLineDebugInfoTest, LineNoLine) {
                "OpFunctionEnd",
       // clang-format on
   };
-  SinglePassRunAndCheck<opt::StripDebugInfoPass>(JoinAllInsts(text),
+  SinglePassRunAndCheck<opt::StripDebugInfoPassToken>(JoinAllInsts(text),
                                                  JoinNonDebugInsts(text),
                                                  /* skip_nop = */ false);
 
@@ -67,7 +67,7 @@ TEST_F(StripLineDebugInfoTest, LineNoLine) {
       "OpName %2 \"main\"",
   };
   text.insert(text.begin() + 4, more_text.cbegin(), more_text.cend());
-  SinglePassRunAndCheck<opt::StripDebugInfoPass>(JoinAllInsts(text),
+  SinglePassRunAndCheck<opt::StripDebugInfoPassToken>(JoinAllInsts(text),
                                                  JoinNonDebugInsts(text),
                                                  /* skip_nop = */ false);
 }
@@ -80,7 +80,7 @@ TEST_P(StripDebugInfoTest, Kind) {
       "OpMemoryModel Logical GLSL450",
       GetParam(),
   };
-  SinglePassRunAndCheck<opt::StripDebugInfoPass>(JoinAllInsts(text),
+  SinglePassRunAndCheck<opt::StripDebugInfoPassToken>(JoinAllInsts(text),
                                                  JoinNonDebugInsts(text),
                                                  /* skip_nop = */ false);
 }

--- a/test/opt/strip_reflect_info_test.cpp
+++ b/test/opt/strip_reflect_info_test.cpp
@@ -40,7 +40,7 @@ OpMemoryModel Logical Simple
 %float = OpTypeFloat 32
 )";
 
-  SinglePassRunAndCheck<opt::StripReflectInfoPass>(before, after, false);
+  SinglePassRunAndCheck<opt::StripReflectInfoPassToken>(before, after, false);
 }
 
 TEST_F(StripLineReflectInfoTest, StripHlslCounterBuffer) {
@@ -59,7 +59,7 @@ OpMemoryModel Logical Simple
 %float = OpTypeFloat 32
 )";
 
-  SinglePassRunAndCheck<opt::StripReflectInfoPass>(before, after, false);
+  SinglePassRunAndCheck<opt::StripReflectInfoPassToken>(before, after, false);
 }
 
 }  // anonymous namespace

--- a/test/opt/unify_const_test.cpp
+++ b/test/opt/unify_const_test.cpp
@@ -116,7 +116,7 @@ class UnifyConstantTest : public PassTest<T> {
     std::string optimized_before_strip;
     auto status = opt::Pass::Status::SuccessWithoutChange;
     std::tie(optimized_before_strip, status) =
-        this->template SinglePassRunAndDisassemble<opt::UnifyConstantPass>(
+        this->template SinglePassRunAndDisassemble<opt::UnifyConstantPassToken>(
             test_builder.GetCode(),
             /* skip_nop = */ true, /* do_validation = */ false);
     std::string optimized_without_opnames;

--- a/test/opt/vector_dce_test.cpp
+++ b/test/opt/vector_dce_test.cpp
@@ -167,7 +167,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::VectorDCE>(before_predefs + before,
+  SinglePassRunAndCheck<opt::VectorDCEToken>(before_predefs + before,
                                         after_predefs + after, true, true);
 }
 
@@ -350,7 +350,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::VectorDCE>(before_predefs + before,
+  SinglePassRunAndCheck<opt::VectorDCEToken>(before_predefs + before,
                                         after_predefs + after, true, true);
 }
 
@@ -564,7 +564,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadInsertElimPass>(
+  SinglePassRunAndCheck<opt::DeadInsertElimPassToken>(
       before_predefs + before, after_predefs + after, true, true);
 }
 
@@ -606,7 +606,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::DeadInsertElimPass>(before, before, true, true);
+  SinglePassRunAndCheck<opt::DeadInsertElimPassToken>(before, before, true, true);
 }
 
 #ifdef SPIRV_EFFCEE
@@ -729,7 +729,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::VectorDCE>(assembly, true);
+  SinglePassRunAndMatch<opt::VectorDCEToken>(assembly, true);
 }
 
 TEST_F(VectorDCETest, DeadLoadFeedingCompositeConstruct) {
@@ -810,7 +810,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::VectorDCE>(assembly, true);
+  SinglePassRunAndMatch<opt::VectorDCEToken>(assembly, true);
 }
 
 TEST_F(VectorDCETest, DeadLoadFeedingVectorShuffle) {
@@ -894,7 +894,7 @@ TEST_F(VectorDCETest, DeadLoadFeedingVectorShuffle) {
                OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::VectorDCE>(assembly, true);
+  SinglePassRunAndMatch<opt::VectorDCEToken>(assembly, true);
 }
 
 TEST_F(VectorDCETest, DeadInstThroughShuffle) {
@@ -984,7 +984,7 @@ TEST_F(VectorDCETest, DeadInstThroughShuffle) {
                OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::VectorDCE>(assembly, true);
+  SinglePassRunAndMatch<opt::VectorDCEToken>(assembly, true);
 }
 
 TEST_F(VectorDCETest, DeadInsertThroughOtherInst) {
@@ -1074,7 +1074,7 @@ TEST_F(VectorDCETest, DeadInsertThroughOtherInst) {
                OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<opt::VectorDCE>(assembly, true);
+  SinglePassRunAndMatch<opt::VectorDCEToken>(assembly, true);
 }
 #endif
 
@@ -1148,7 +1148,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<opt::DeadInsertElimPass>(text, text, true, true);
+  SinglePassRunAndCheck<opt::DeadInsertElimPassToken>(text, text, true, true);
 }
 
 }  // anonymous namespace

--- a/test/opt/vector_dce_test.cpp
+++ b/test/opt/vector_dce_test.cpp
@@ -168,7 +168,7 @@ OpFunctionEnd
 )";
 
   SinglePassRunAndCheck<opt::VectorDCEToken>(before_predefs + before,
-                                        after_predefs + after, true, true);
+                                             after_predefs + after, true, true);
 }
 
 TEST_F(VectorDCETest, DeadInsertInChainWithPhi) {
@@ -351,7 +351,7 @@ OpFunctionEnd
 )";
 
   SinglePassRunAndCheck<opt::VectorDCEToken>(before_predefs + before,
-                                        after_predefs + after, true, true);
+                                             after_predefs + after, true, true);
 }
 
 TEST_F(VectorDCETest, DeadInsertWithScalars) {
@@ -606,7 +606,8 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<opt::DeadInsertElimPassToken>(before, before, true, true);
+  SinglePassRunAndCheck<opt::DeadInsertElimPassToken>(before, before, true,
+                                                      true);
 }
 
 #ifdef SPIRV_EFFCEE

--- a/test/opt/workaround1209_test.cpp
+++ b/test/opt/workaround1209_test.cpp
@@ -119,7 +119,7 @@ TEST_F(Workaround1209Test, RemoveOpUnreachableInLoop) {
                OpReturn
                OpFunctionEnd)";
 
-  SinglePassRunAndMatch<opt::Workaround1209>(text, false);
+  SinglePassRunAndMatch<opt::Workaround1209Token>(text, false);
 }
 
 TEST_F(Workaround1209Test, RemoveOpUnreachableInNestedLoop) {
@@ -219,7 +219,7 @@ TEST_F(Workaround1209Test, RemoveOpUnreachableInNestedLoop) {
                OpReturn
                OpFunctionEnd)";
 
-  SinglePassRunAndMatch<opt::Workaround1209>(text, false);
+  SinglePassRunAndMatch<opt::Workaround1209Token>(text, false);
 }
 
 TEST_F(Workaround1209Test, RemoveOpUnreachableInAdjacentLoops) {
@@ -333,7 +333,7 @@ TEST_F(Workaround1209Test, RemoveOpUnreachableInAdjacentLoops) {
                OpReturn
                OpFunctionEnd)";
 
-  SinglePassRunAndMatch<opt::Workaround1209>(text, false);
+  SinglePassRunAndMatch<opt::Workaround1209Token>(text, false);
 }
 
 TEST_F(Workaround1209Test, LeaveUnreachableNotInLoop) {
@@ -415,7 +415,7 @@ TEST_F(Workaround1209Test, LeaveUnreachableNotInLoop) {
                OpUnreachable
                OpFunctionEnd)";
 
-  SinglePassRunAndMatch<opt::Workaround1209>(text, false);
+  SinglePassRunAndMatch<opt::Workaround1209Token>(text, false);
 }
 #endif
 }  // anonymous namespace


### PR DESCRIPTION
Currently the Optimizer pass objects are created during the Optimizer
setup, before Run is executed. This means we don't have access to the
IRContext when creating the passes.

In order to pass the IRContext to the Pass constructors we need to
create the pass later in the pipeline. This CL changes the Optimizer to
create PassTokens instead of Pass objects. The PassTokens are stored in
the PassManager and the token creates the real Pass object when we're
running all of the passes.

This has the side effect that we now tear down the passes after they're
used, and we don't have to clear the pass list for the optimizer as it
can be re-run on a different binary without re-creating the state.

#1703 