### PR TITLE
use Pass::Run to set the context on each pass.

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -500,13 +500,6 @@ bool AggressiveDCEPass::AggressiveDCE(opt::Function* func) {
   return modified;
 }
 
-void AggressiveDCEPass::Initialize(opt::IRContext* c) {
-  InitializeProcessing(c);
-
-  // Initialize extensions whitelist
-  InitExtensions();
-}
-
 void AggressiveDCEPass::InitializeModuleScopeLiveInstructions() {
   // Keep all execution modes.
   for (auto& exec : get_module()->execution_modes()) {
@@ -706,10 +699,11 @@ bool AggressiveDCEPass::ProcessGlobalValues() {
   return modified;
 }
 
-AggressiveDCEPass::AggressiveDCEPass() {}
+AggressiveDCEPass::AggressiveDCEPass() = default;
 
-Pass::Status AggressiveDCEPass::Process(opt::IRContext* c) {
-  Initialize(c);
+Pass::Status AggressiveDCEPass::Process() {
+  // Initialize extensions whitelist
+  InitExtensions();
   return ProcessImpl();
 }
 

--- a/source/opt/aggressive_dead_code_elim_pass.h
+++ b/source/opt/aggressive_dead_code_elim_pass.h
@@ -43,7 +43,7 @@ class AggressiveDCEPass : public MemPass {
 
   AggressiveDCEPass();
   const char* name() const override { return "eliminate-dead-code-aggressive"; }
-  Status Process(opt::IRContext* c) override;
+  Status Process() override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse |
@@ -138,7 +138,6 @@ class AggressiveDCEPass : public MemPass {
   // TODO(): Remove useless control constructs.
   bool AggressiveDCE(opt::Function* func);
 
-  void Initialize(opt::IRContext* c);
   Pass::Status ProcessImpl();
 
   // True if current function has a call instruction contained in it

--- a/source/opt/block_merge_pass.cpp
+++ b/source/opt/block_merge_pass.cpp
@@ -145,21 +145,14 @@ bool BlockMergePass::IsMerge(opt::BasicBlock* block) {
   return IsMerge(block->id());
 }
 
-void BlockMergePass::Initialize(opt::IRContext* c) { InitializeProcessing(c); }
-
-Pass::Status BlockMergePass::ProcessImpl() {
+Pass::Status BlockMergePass::Process() {
   // Process all entry point functions.
   ProcessFunction pfn = [this](opt::Function* fp) { return MergeBlocks(fp); };
   bool modified = ProcessEntryPointCallTree(pfn, get_module());
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 
-BlockMergePass::BlockMergePass() {}
-
-Pass::Status BlockMergePass::Process(opt::IRContext* c) {
-  Initialize(c);
-  return ProcessImpl();
-}
+BlockMergePass::BlockMergePass() = default;
 
 }  // namespace opt
 }  // namespace spvtools

--- a/source/opt/block_merge_pass.h
+++ b/source/opt/block_merge_pass.h
@@ -38,8 +38,9 @@ class BlockMergePass : public Pass {
  public:
   BlockMergePass();
   const char* name() const override { return "merge-blocks"; }
-  Status Process(opt::IRContext*) override;
-  virtual opt::IRContext::Analysis GetPreservedAnalyses() override {
+  Status Process() override;
+
+  opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse |
            opt::IRContext::kAnalysisInstrToBlockMapping |
            opt::IRContext::kAnalysisDecorations |
@@ -63,9 +64,6 @@ class BlockMergePass : public Pass {
   // instruction.
   bool IsMerge(opt::BasicBlock* block);
   bool IsMerge(uint32_t id);
-
-  void Initialize(opt::IRContext* c);
-  Pass::Status ProcessImpl();
 };
 
 }  // namespace opt

--- a/source/opt/ccp_pass.cpp
+++ b/source/opt/ccp_pass.cpp
@@ -296,9 +296,7 @@ bool CCPPass::PropagateConstants(opt::Function* fp) {
   return false;
 }
 
-void CCPPass::Initialize(opt::IRContext* c) {
-  InitializeProcessing(c);
-
+void CCPPass::Initialize() {
   const_mgr_ = context()->get_constant_mgr();
 
   // Populate the constant table with values from constant declarations in the
@@ -315,8 +313,8 @@ void CCPPass::Initialize(opt::IRContext* c) {
   }
 }
 
-Pass::Status CCPPass::Process(opt::IRContext* c) {
-  Initialize(c);
+Pass::Status CCPPass::Process() {
+  Initialize();
 
   // Process all entry point functions.
   ProcessFunction pfn = [this](opt::Function* fp) {

--- a/source/opt/ccp_pass.h
+++ b/source/opt/ccp_pass.h
@@ -28,9 +28,11 @@ namespace opt {
 class CCPPass : public MemPass {
  public:
   CCPPass() = default;
+
   const char* name() const override { return "ccp"; }
-  Status Process(opt::IRContext* c) override;
-  virtual opt::IRContext::Analysis GetPreservedAnalyses() override {
+  Status Process() override;
+
+  opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse |
            opt::IRContext::kAnalysisInstrToBlockMapping |
            opt::IRContext::kAnalysisDecorations |
@@ -41,7 +43,7 @@ class CCPPass : public MemPass {
 
  private:
   // Initializes the pass.
-  void Initialize(opt::IRContext* c);
+  void Initialize();
 
   // Runs constant propagation on the given function |fp|. Returns true if any
   // constants were propagated and the IR modified.

--- a/source/opt/cfg_cleanup_pass.cpp
+++ b/source/opt/cfg_cleanup_pass.cpp
@@ -27,11 +27,7 @@
 namespace spvtools {
 namespace opt {
 
-void CFGCleanupPass::Initialize(opt::IRContext* c) { InitializeProcessing(c); }
-
-Pass::Status CFGCleanupPass::Process(opt::IRContext* c) {
-  Initialize(c);
-
+Pass::Status CFGCleanupPass::Process() {
   // Process all entry point functions.
   ProcessFunction pfn = [this](opt::Function* fp) { return CFGCleanup(fp); };
   bool modified = ProcessReachableCallTree(pfn, context());

--- a/source/opt/cfg_cleanup_pass.h
+++ b/source/opt/cfg_cleanup_pass.h
@@ -25,16 +25,13 @@ namespace opt {
 class CFGCleanupPass : public MemPass {
  public:
   CFGCleanupPass() = default;
+
   const char* name() const override { return "cfg-cleanup"; }
-  Status Process(opt::IRContext* c) override;
+  Status Process() override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse;
   }
-
- private:
-  // Initialize the pass.
-  void Initialize(opt::IRContext* c);
 };
 
 }  // namespace opt

--- a/source/opt/common_uniform_elim_pass.cpp
+++ b/source/opt/common_uniform_elim_pass.cpp
@@ -489,9 +489,7 @@ bool CommonUniformElimPass::EliminateCommonUniform(opt::Function* func) {
   return modified;
 }
 
-void CommonUniformElimPass::Initialize(opt::IRContext* c) {
-  InitializeProcessing(c);
-
+void CommonUniformElimPass::Initialize() {
   // Clear collections.
   comp2idx2inst_.clear();
 
@@ -540,10 +538,10 @@ Pass::Status CommonUniformElimPass::ProcessImpl() {
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 
-CommonUniformElimPass::CommonUniformElimPass() {}
+CommonUniformElimPass::CommonUniformElimPass() = default;
 
-Pass::Status CommonUniformElimPass::Process(opt::IRContext* c) {
-  Initialize(c);
+Pass::Status CommonUniformElimPass::Process() {
+  Initialize();
   return ProcessImpl();
 }
 

--- a/source/opt/common_uniform_elim_pass.h
+++ b/source/opt/common_uniform_elim_pass.h
@@ -43,8 +43,9 @@ class CommonUniformElimPass : public Pass {
       std::function<std::vector<opt::BasicBlock*>*(const opt::BasicBlock*)>;
 
   CommonUniformElimPass();
+
   const char* name() const override { return "eliminate-common-uniform"; }
-  Status Process(opt::IRContext*) override;
+  Status Process() override;
 
  private:
   // Returns true if |opcode| is a non-ptr access chain op
@@ -184,7 +185,7 @@ class CommonUniformElimPass : public Pass {
     return false;
   }
 
-  void Initialize(opt::IRContext* c);
+  void Initialize();
   Pass::Status ProcessImpl();
 
   // Map from uniform variable id to its common load id

--- a/source/opt/compact_ids_pass.cpp
+++ b/source/opt/compact_ids_pass.cpp
@@ -24,13 +24,11 @@ namespace opt {
 using opt::Instruction;
 using opt::Operand;
 
-Pass::Status CompactIdsPass::Process(opt::IRContext* c) {
-  InitializeProcessing(c);
-
+Pass::Status CompactIdsPass::Process() {
   bool modified = false;
   std::unordered_map<uint32_t, uint32_t> result_id_mapping;
 
-  c->module()->ForEachInst(
+  context()->module()->ForEachInst(
       [&result_id_mapping, &modified](Instruction* inst) {
         auto operand = inst->begin();
         while (operand != inst->end()) {
@@ -64,7 +62,7 @@ Pass::Status CompactIdsPass::Process(opt::IRContext* c) {
       true);
 
   if (modified)
-    c->module()->SetIdBound(
+    context()->module()->SetIdBound(
         static_cast<uint32_t>(result_id_mapping.size() + 1));
 
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;

--- a/source/opt/compact_ids_pass.h
+++ b/source/opt/compact_ids_pass.h
@@ -26,7 +26,7 @@ namespace opt {
 class CompactIdsPass : public Pass {
  public:
   const char* name() const override { return "compact-ids"; }
-  Status Process(opt::IRContext*) override;
+  Status Process() override;
 
   // Return the mask of preserved Analyses.
   opt::IRContext::Analysis GetPreservedAnalyses() override {

--- a/source/opt/copy_prop_arrays.cpp
+++ b/source/opt/copy_prop_arrays.cpp
@@ -25,9 +25,7 @@ const uint32_t kCompositeExtractObjectInOperand = 0;
 namespace spvtools {
 namespace opt {
 
-Pass::Status CopyPropagateArrays::Process(opt::IRContext* ctx) {
-  InitializeProcessing(ctx);
-
+Pass::Status CopyPropagateArrays::Process() {
   bool modified = false;
   for (opt::Function& function : *get_module()) {
     opt::BasicBlock* entry_bb = &*function.begin();

--- a/source/opt/copy_prop_arrays.h
+++ b/source/opt/copy_prop_arrays.h
@@ -38,7 +38,7 @@ namespace opt {
 class CopyPropagateArrays : public MemPass {
  public:
   const char* name() const override { return "copy-propagate-arrays"; }
-  Status Process(opt::IRContext*) override;
+  Status Process() override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse | opt::IRContext::kAnalysisCFG |

--- a/source/opt/dead_branch_elim_pass.cpp
+++ b/source/opt/dead_branch_elim_pass.cpp
@@ -371,11 +371,7 @@ bool DeadBranchElimPass::EliminateDeadBranches(opt::Function* func) {
   return modified;
 }
 
-void DeadBranchElimPass::Initialize(opt::IRContext* c) {
-  InitializeProcessing(c);
-}
-
-Pass::Status DeadBranchElimPass::ProcessImpl() {
+Pass::Status DeadBranchElimPass::Process() {
   // Do not process if module contains OpGroupDecorate. Additional
   // support required in KillNamesAndDecorates().
   // TODO(greg-lunarg): Add support for OpGroupDecorate
@@ -387,13 +383,6 @@ Pass::Status DeadBranchElimPass::ProcessImpl() {
   };
   bool modified = ProcessReachableCallTree(pfn, context());
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
-}
-
-DeadBranchElimPass::DeadBranchElimPass() {}
-
-Pass::Status DeadBranchElimPass::Process(opt::IRContext* module) {
-  Initialize(module);
-  return ProcessImpl();
 }
 
 }  // namespace opt

--- a/source/opt/dead_branch_elim_pass.h
+++ b/source/opt/dead_branch_elim_pass.h
@@ -37,9 +37,10 @@ class DeadBranchElimPass : public MemPass {
   using cbb_ptr = const opt::BasicBlock*;
 
  public:
-  DeadBranchElimPass();
+  DeadBranchElimPass() = default;
+
   const char* name() const override { return "eliminate-dead-branches"; }
-  Status Process(opt::IRContext* context) override;
+  Status Process() override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse |
@@ -128,9 +129,6 @@ class DeadBranchElimPass : public MemPass {
       const std::unordered_set<opt::BasicBlock*>& unreachable_merges,
       const std::unordered_map<opt::BasicBlock*, opt::BasicBlock*>&
           unreachable_continues);
-
-  void Initialize(opt::IRContext* c);
-  Pass::Status ProcessImpl();
 };
 
 }  // namespace opt

--- a/source/opt/dead_insert_elim_pass.cpp
+++ b/source/opt/dead_insert_elim_pass.cpp
@@ -253,24 +253,13 @@ bool DeadInsertElimPass::EliminateDeadInsertsOnePass(opt::Function* func) {
   return modified;
 }
 
-void DeadInsertElimPass::Initialize(opt::IRContext* c) {
-  InitializeProcessing(c);
-}
-
-Pass::Status DeadInsertElimPass::ProcessImpl() {
+Pass::Status DeadInsertElimPass::Process() {
   // Process all entry point functions.
   ProcessFunction pfn = [this](opt::Function* fp) {
     return EliminateDeadInserts(fp);
   };
   bool modified = ProcessEntryPointCallTree(pfn, get_module());
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
-}
-
-DeadInsertElimPass::DeadInsertElimPass() {}
-
-Pass::Status DeadInsertElimPass::Process(opt::IRContext* c) {
-  Initialize(c);
-  return ProcessImpl();
 }
 
 }  // namespace opt

--- a/source/opt/dead_insert_elim_pass.h
+++ b/source/opt/dead_insert_elim_pass.h
@@ -35,10 +35,11 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class DeadInsertElimPass : public MemPass {
  public:
-  DeadInsertElimPass();
+  DeadInsertElimPass() = default;
+
   const char* name() const override { return "eliminate-dead-inserts"; }
-  Status Process(opt::IRContext*) override;
-  virtual opt::IRContext::Analysis GetPreservedAnalyses() override {
+  Status Process() override;
+  opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse |
            opt::IRContext::kAnalysisInstrToBlockMapping |
            opt::IRContext::kAnalysisDecorations |
@@ -74,9 +75,6 @@ class DeadInsertElimPass : public MemPass {
 
   // Return true if all extensions in this module are allowed by this pass.
   bool AllExtensionsSupported() const;
-
-  void Initialize(opt::IRContext* c);
-  Pass::Status ProcessImpl();
 
   // Live inserts
   std::unordered_set<uint32_t> liveInserts_;

--- a/source/opt/dead_variable_elimination.cpp
+++ b/source/opt/dead_variable_elimination.cpp
@@ -22,14 +22,11 @@ namespace opt {
 
 // This optimization removes global variables that are not needed because they
 // are definitely not accessed.
-Pass::Status DeadVariableElimination::Process(opt::IRContext* c) {
+Pass::Status DeadVariableElimination::Process() {
   // The algorithm will compute the reference count for every global variable.
   // Anything with a reference count of 0 will then be deleted.  For variables
   // that might have references that are not explicit in this context, we use
-  // the
-  // value kMustKeep as the reference count.
-  InitializeProcessing(c);
-
+  // the value kMustKeep as the reference count.
   std::vector<uint32_t> ids_to_remove;
 
   // Get the reference count for all of the global OpVariable instructions.

--- a/source/opt/dead_variable_elimination.h
+++ b/source/opt/dead_variable_elimination.h
@@ -27,7 +27,7 @@ namespace opt {
 class DeadVariableElimination : public MemPass {
  public:
   const char* name() const override { return "dead-variable-elimination"; }
-  Status Process(opt::IRContext* c) override;
+  Status Process() override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse;

--- a/source/opt/eliminate_dead_constant_pass.h
+++ b/source/opt/eliminate_dead_constant_pass.h
@@ -26,7 +26,7 @@ namespace opt {
 class EliminateDeadConstantPass : public Pass {
  public:
   const char* name() const override { return "eliminate-dead-const"; }
-  Status Process(opt::IRContext*) override;
+  Status Process() override;
 };
 
 }  // namespace opt

--- a/source/opt/eliminate_dead_functions_pass.cpp
+++ b/source/opt/eliminate_dead_functions_pass.cpp
@@ -20,9 +20,7 @@
 namespace spvtools {
 namespace opt {
 
-Pass::Status EliminateDeadFunctionsPass::Process(opt::IRContext* c) {
-  InitializeProcessing(c);
-
+Pass::Status EliminateDeadFunctionsPass::Process() {
   // Identify live functions first.  Those that are not live
   // are dead.
   std::unordered_set<const opt::Function*> live_function_set;

--- a/source/opt/eliminate_dead_functions_pass.h
+++ b/source/opt/eliminate_dead_functions_pass.h
@@ -27,7 +27,7 @@ namespace opt {
 class EliminateDeadFunctionsPass : public MemPass {
  public:
   const char* name() const override { return "eliminate-dead-functions"; }
-  Status Process(opt::IRContext* c) override;
+  Status Process() override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse;

--- a/source/opt/flatten_decoration_pass.cpp
+++ b/source/opt/flatten_decoration_pass.cpp
@@ -29,9 +29,7 @@ using opt::Operand;
 using Words = std::vector<uint32_t>;
 using OrderedUsesMap = std::unordered_map<uint32_t, Words>;
 
-Pass::Status FlattenDecorationPass::Process(opt::IRContext* c) {
-  InitializeProcessing(c);
-
+Pass::Status FlattenDecorationPass::Process() {
   bool modified = false;
 
   // The target Id of OpDecorationGroup instructions.

--- a/source/opt/flatten_decoration_pass.h
+++ b/source/opt/flatten_decoration_pass.h
@@ -26,7 +26,7 @@ namespace opt {
 class FlattenDecorationPass : public Pass {
  public:
   const char* name() const override { return "flatten-decoration"; }
-  Status Process(opt::IRContext*) override;
+  Status Process() override;
 };
 
 }  // namespace opt

--- a/source/opt/fold_spec_constant_op_and_composite_pass.cpp
+++ b/source/opt/fold_spec_constant_op_and_composite_pass.cpp
@@ -26,18 +26,7 @@
 namespace spvtools {
 namespace opt {
 
-Pass::Status FoldSpecConstantOpAndCompositePass::Process(
-    opt::IRContext* irContext) {
-  Initialize(irContext);
-  return ProcessImpl(irContext);
-}
-
-void FoldSpecConstantOpAndCompositePass::Initialize(opt::IRContext* irContext) {
-  InitializeProcessing(irContext);
-}
-
-Pass::Status FoldSpecConstantOpAndCompositePass::ProcessImpl(
-    opt::IRContext* irContext) {
+Pass::Status FoldSpecConstantOpAndCompositePass::Process() {
   bool modified = false;
   // Traverse through all the constant defining instructions. For Normal
   // Constants whose values are determined and do not depend on OpUndef
@@ -59,11 +48,11 @@ Pass::Status FoldSpecConstantOpAndCompositePass::ProcessImpl(
   // the dependee Spec Constants, all its dependent constants must have been
   // processed and all its dependent Spec Constants should have been folded if
   // possible.
-  opt::Module::inst_iterator next_inst = irContext->types_values_begin();
+  opt::Module::inst_iterator next_inst = context()->types_values_begin();
   for (opt::Module::inst_iterator inst_iter = next_inst;
        // Need to re-evaluate the end iterator since we may modify the list of
        // instructions in this section of the module as the process goes.
-       inst_iter != irContext->types_values_end(); inst_iter = next_inst) {
+       inst_iter != context()->types_values_end(); inst_iter = next_inst) {
     ++next_inst;
     opt::Instruction* inst = &*inst_iter;
     // Collect constant values of normal constants and process the

--- a/source/opt/fold_spec_constant_op_and_composite_pass.h
+++ b/source/opt/fold_spec_constant_op_and_composite_pass.h
@@ -36,20 +36,13 @@ class FoldSpecConstantOpAndCompositePass : public Pass {
 
   const char* name() const override { return "fold-spec-const-op-composite"; }
 
-  Status Process(opt::IRContext* irContext) override;
+  // Iterates through the types-constants-globals section of the given module,
+  // finds the Spec Constants defined with OpSpecConstantOp and
+  // OpSpecConstantComposite instructions. If the result value of those spec
+  // constants can be folded, fold them to their corresponding normal constants.
+  Status Process() override;
 
  private:
-  // Initializes the type manager, def-use manager and get the maximal id used
-  // in the module.
-  void Initialize(opt::IRContext* irContext);
-
-  // The real entry of processing. Iterates through the types-constants-globals
-  // section of the given module, finds the Spec Constants defined with
-  // OpSpecConstantOp and OpSpecConstantComposite instructions. If the result
-  // value of those spec constants can be folded, fold them to their
-  // corresponding normal constants.
-  Status ProcessImpl(opt::IRContext* irContext);
-
   // Processes the OpSpecConstantOp instruction pointed by the given
   // instruction iterator, folds it to normal constants if possible. Returns
   // true if the spec constant is folded to normal constants. New instructions

--- a/source/opt/freeze_spec_constant_value_pass.cpp
+++ b/source/opt/freeze_spec_constant_value_pass.cpp
@@ -18,34 +18,34 @@
 namespace spvtools {
 namespace opt {
 
-Pass::Status FreezeSpecConstantValuePass::Process(opt::IRContext* irContext) {
+Pass::Status FreezeSpecConstantValuePass::Process() {
   bool modified = false;
-  irContext->module()->ForEachInst(
-      [&modified, irContext](opt::Instruction* inst) {
-        switch (inst->opcode()) {
-          case SpvOp::SpvOpSpecConstant:
-            inst->SetOpcode(SpvOp::SpvOpConstant);
-            modified = true;
-            break;
-          case SpvOp::SpvOpSpecConstantTrue:
-            inst->SetOpcode(SpvOp::SpvOpConstantTrue);
-            modified = true;
-            break;
-          case SpvOp::SpvOpSpecConstantFalse:
-            inst->SetOpcode(SpvOp::SpvOpConstantFalse);
-            modified = true;
-            break;
-          case SpvOp::SpvOpDecorate:
-            if (inst->GetSingleWordInOperand(1) ==
-                SpvDecoration::SpvDecorationSpecId) {
-              irContext->KillInst(inst);
-              modified = true;
-            }
-            break;
-          default:
-            break;
+  auto ctx = context();
+  ctx->module()->ForEachInst([&modified, ctx](opt::Instruction* inst) {
+    switch (inst->opcode()) {
+      case SpvOp::SpvOpSpecConstant:
+        inst->SetOpcode(SpvOp::SpvOpConstant);
+        modified = true;
+        break;
+      case SpvOp::SpvOpSpecConstantTrue:
+        inst->SetOpcode(SpvOp::SpvOpConstantTrue);
+        modified = true;
+        break;
+      case SpvOp::SpvOpSpecConstantFalse:
+        inst->SetOpcode(SpvOp::SpvOpConstantFalse);
+        modified = true;
+        break;
+      case SpvOp::SpvOpDecorate:
+        if (inst->GetSingleWordInOperand(1) ==
+            SpvDecoration::SpvDecorationSpecId) {
+          ctx->KillInst(inst);
+          modified = true;
         }
-      });
+        break;
+      default:
+        break;
+    }
+  });
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 

--- a/source/opt/freeze_spec_constant_value_pass.h
+++ b/source/opt/freeze_spec_constant_value_pass.h
@@ -26,7 +26,7 @@ namespace opt {
 class FreezeSpecConstantValuePass : public Pass {
  public:
   const char* name() const override { return "freeze-spec-const"; }
-  Status Process(opt::IRContext*) override;
+  Status Process() override;
 };
 
 }  // namespace opt

--- a/source/opt/if_conversion.cpp
+++ b/source/opt/if_conversion.cpp
@@ -19,9 +19,7 @@
 namespace spvtools {
 namespace opt {
 
-Pass::Status IfConversion::Process(opt::IRContext* c) {
-  InitializeProcessing(c);
-
+Pass::Status IfConversion::Process() {
   const ValueNumberTable& vn_table = *context()->GetValueNumberTable();
   bool modified = false;
   std::vector<opt::Instruction*> to_kill;

--- a/source/opt/if_conversion.h
+++ b/source/opt/if_conversion.h
@@ -27,7 +27,7 @@ namespace opt {
 class IfConversion : public Pass {
  public:
   const char* name() const override { return "if-conversion"; }
-  Status Process(opt::IRContext* context) override;
+  Status Process() override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse |

--- a/source/opt/inline_exhaustive_pass.cpp
+++ b/source/opt/inline_exhaustive_pass.cpp
@@ -59,10 +59,6 @@ bool InlineExhaustivePass::InlineExhaustive(opt::Function* func) {
   return modified;
 }
 
-void InlineExhaustivePass::Initialize(opt::IRContext* c) {
-  InitializeInline(c);
-}
-
 Pass::Status InlineExhaustivePass::ProcessImpl() {
   // Attempt exhaustive inlining on each entry point function in module
   ProcessFunction pfn = [this](opt::Function* fp) {
@@ -72,10 +68,10 @@ Pass::Status InlineExhaustivePass::ProcessImpl() {
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 
-InlineExhaustivePass::InlineExhaustivePass() {}
+InlineExhaustivePass::InlineExhaustivePass() = default;
 
-Pass::Status InlineExhaustivePass::Process(opt::IRContext* c) {
-  Initialize(c);
+Pass::Status InlineExhaustivePass::Process() {
+  InitializeInline();
   return ProcessImpl();
 }
 

--- a/source/opt/inline_exhaustive_pass.h
+++ b/source/opt/inline_exhaustive_pass.h
@@ -34,7 +34,7 @@ namespace opt {
 class InlineExhaustivePass : public InlinePass {
  public:
   InlineExhaustivePass();
-  Status Process(opt::IRContext* c) override;
+  Status Process() override;
 
   const char* name() const override { return "inline-entry-points-exhaustive"; }
 
@@ -43,7 +43,7 @@ class InlineExhaustivePass : public InlinePass {
   // all code that is inlined into func. Return true if func is modified.
   bool InlineExhaustive(opt::Function* func);
 
-  void Initialize(opt::IRContext* c);
+  void Initialize();
   Pass::Status ProcessImpl();
 };
 

--- a/source/opt/inline_opaque_pass.cpp
+++ b/source/opt/inline_opaque_pass.cpp
@@ -92,7 +92,7 @@ bool InlineOpaquePass::InlineOpaque(opt::Function* func) {
   return modified;
 }
 
-void InlineOpaquePass::Initialize(opt::IRContext* c) { InitializeInline(c); }
+void InlineOpaquePass::Initialize() { InitializeInline(); }
 
 Pass::Status InlineOpaquePass::ProcessImpl() {
   // Do opaque inlining on each function in entry point call tree
@@ -101,10 +101,10 @@ Pass::Status InlineOpaquePass::ProcessImpl() {
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 
-InlineOpaquePass::InlineOpaquePass() {}
+InlineOpaquePass::InlineOpaquePass() = default;
 
-Pass::Status InlineOpaquePass::Process(opt::IRContext* c) {
-  Initialize(c);
+Pass::Status InlineOpaquePass::Process() {
+  Initialize();
   return ProcessImpl();
 }
 

--- a/source/opt/inline_opaque_pass.h
+++ b/source/opt/inline_opaque_pass.h
@@ -34,7 +34,7 @@ namespace opt {
 class InlineOpaquePass : public InlinePass {
  public:
   InlineOpaquePass();
-  Status Process(opt::IRContext* c) override;
+  Status Process() override;
 
   const char* name() const override { return "inline-entry-points-opaque"; }
 
@@ -50,7 +50,7 @@ class InlineOpaquePass : public InlinePass {
   // if func is modified.
   bool InlineOpaque(opt::Function* func);
 
-  void Initialize(opt::IRContext* c);
+  void Initialize();
   Pass::Status ProcessImpl();
 };
 

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -668,9 +668,7 @@ bool InlinePass::IsInlinableFunction(opt::Function* func) {
          no_return_in_loop_.cend();
 }
 
-void InlinePass::InitializeInline(opt::IRContext* c) {
-  InitializeProcessing(c);
-
+void InlinePass::InitializeInline() {
   false_id_ = 0;
 
   // clear collections

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -38,10 +38,10 @@ class InlinePass : public Pass {
   using GetBlocksFunction =
       std::function<std::vector<opt::BasicBlock*>*(const opt::BasicBlock*)>;
 
-  InlinePass();
   virtual ~InlinePass() = default;
 
  protected:
+  InlinePass();
 
   // Add pointer to type to module and return resultId.
   uint32_t AddPointerToType(uint32_t type_id, SpvStorageClass storage_class);
@@ -157,7 +157,7 @@ class InlinePass : public Pass {
       std::vector<std::unique_ptr<opt::BasicBlock>>& new_blocks);
 
   // Initialize state for optimization of |module|
-  void InitializeInline(opt::IRContext* c);
+  void InitializeInline();
 
   // Map from function's result id to function.
   std::unordered_map<uint32_t, opt::Function*> id2function_;

--- a/source/opt/licm_pass.cpp
+++ b/source/opt/licm_pass.cpp
@@ -22,15 +22,9 @@
 namespace spvtools {
 namespace opt {
 
-Pass::Status LICMPass::Process(opt::IRContext* c) {
-  InitializeProcessing(c);
-  bool modified = false;
-
-  if (c != nullptr) {
-    modified = ProcessIRContext();
-  }
-
-  return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
+Pass::Status LICMPass::Process() {
+  return ProcessIRContext() ? Status::SuccessWithChange
+                            : Status::SuccessWithoutChange;
 }
 
 bool LICMPass::ProcessIRContext() {

--- a/source/opt/licm_pass.h
+++ b/source/opt/licm_pass.h
@@ -30,7 +30,7 @@ class LICMPass : public Pass {
   LICMPass() {}
 
   const char* name() const override { return "loop-invariant-code-motion"; }
-  Status Process(opt::IRContext*) override;
+  Status Process() override;
 
  private:
   // Searches the IRContext for functions and processes each, moving invariants

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -245,9 +245,7 @@ bool LocalAccessChainConvertPass::ConvertLocalAccessChains(
   return modified;
 }
 
-void LocalAccessChainConvertPass::Initialize(opt::IRContext* c) {
-  InitializeProcessing(c);
-
+void LocalAccessChainConvertPass::Initialize() {
   // Initialize Target Variable Caches
   seen_target_vars_.clear();
   seen_non_target_vars_.clear();
@@ -294,8 +292,8 @@ Pass::Status LocalAccessChainConvertPass::ProcessImpl() {
 
 LocalAccessChainConvertPass::LocalAccessChainConvertPass() {}
 
-Pass::Status LocalAccessChainConvertPass::Process(opt::IRContext* c) {
-  Initialize(c);
+Pass::Status LocalAccessChainConvertPass::Process() {
+  Initialize();
   return ProcessImpl();
 }
 

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -36,8 +36,9 @@ namespace opt {
 class LocalAccessChainConvertPass : public MemPass {
  public:
   LocalAccessChainConvertPass();
+
   const char* name() const override { return "convert-local-access-chains"; }
-  Status Process(opt::IRContext* c) override;
+  Status Process() override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse;
@@ -109,7 +110,7 @@ class LocalAccessChainConvertPass : public MemPass {
   // Return true if all extensions in this module are allowed by this pass.
   bool AllExtensionsSupported() const;
 
-  void Initialize(opt::IRContext* c);
+  void Initialize();
   Pass::Status ProcessImpl();
 
   // Variables with only supported references, ie. loads and stores using

--- a/source/opt/local_redundancy_elimination.cpp
+++ b/source/opt/local_redundancy_elimination.cpp
@@ -19,9 +19,7 @@
 namespace spvtools {
 namespace opt {
 
-Pass::Status LocalRedundancyEliminationPass::Process(opt::IRContext* c) {
-  InitializeProcessing(c);
-
+Pass::Status LocalRedundancyEliminationPass::Process() {
   bool modified = false;
   ValueNumberTable vnTable(context());
 

--- a/source/opt/local_redundancy_elimination.h
+++ b/source/opt/local_redundancy_elimination.h
@@ -32,8 +32,9 @@ namespace opt {
 class LocalRedundancyEliminationPass : public Pass {
  public:
   const char* name() const override { return "local-redundancy-elimination"; }
-  Status Process(opt::IRContext*) override;
-  virtual opt::IRContext::Analysis GetPreservedAnalyses() override {
+  Status Process() override;
+
+  opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse |
            opt::IRContext::kAnalysisInstrToBlockMapping |
            opt::IRContext::kAnalysisDecorations |

--- a/source/opt/local_single_block_elim_pass.cpp
+++ b/source/opt/local_single_block_elim_pass.cpp
@@ -158,9 +158,7 @@ bool LocalSingleBlockLoadStoreElimPass::LocalSingleBlockLoadStoreElim(
   return modified;
 }
 
-void LocalSingleBlockLoadStoreElimPass::Initialize(opt::IRContext* c) {
-  InitializeProcessing(c);
-
+void LocalSingleBlockLoadStoreElimPass::Initialize() {
   // Initialize Target Type Caches
   seen_target_vars_.clear();
   seen_non_target_vars_.clear();
@@ -204,10 +202,11 @@ Pass::Status LocalSingleBlockLoadStoreElimPass::ProcessImpl() {
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 
-LocalSingleBlockLoadStoreElimPass::LocalSingleBlockLoadStoreElimPass() {}
+LocalSingleBlockLoadStoreElimPass::LocalSingleBlockLoadStoreElimPass() =
+    default;
 
-Pass::Status LocalSingleBlockLoadStoreElimPass::Process(opt::IRContext* c) {
-  Initialize(c);
+Pass::Status LocalSingleBlockLoadStoreElimPass::Process() {
+  Initialize();
   return ProcessImpl();
 }
 

--- a/source/opt/local_single_block_elim_pass.h
+++ b/source/opt/local_single_block_elim_pass.h
@@ -36,8 +36,9 @@ namespace opt {
 class LocalSingleBlockLoadStoreElimPass : public MemPass {
  public:
   LocalSingleBlockLoadStoreElimPass();
+
   const char* name() const override { return "eliminate-local-single-block"; }
-  Status Process(opt::IRContext* c) override;
+  Status Process() override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse |
@@ -66,7 +67,7 @@ class LocalSingleBlockLoadStoreElimPass : public MemPass {
   // Return true if all extensions in this module are supported by this pass.
   bool AllExtensionsSupported() const;
 
-  void Initialize(opt::IRContext* c);
+  void Initialize();
   Pass::Status ProcessImpl();
 
   // Map from function scope variable to a store of that variable in the

--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -45,11 +45,6 @@ bool LocalSingleStoreElimPass::LocalSingleStoreElim(opt::Function* func) {
   return modified;
 }
 
-void LocalSingleStoreElimPass::Initialize(opt::IRContext* irContext) {
-  InitializeProcessing(irContext);
-  InitExtensionWhiteList();
-}
-
 bool LocalSingleStoreElimPass::AllExtensionsSupported() const {
   // If any extension not in whitelist, return false
   for (auto& ei : get_module()->extensions()) {
@@ -76,10 +71,10 @@ Pass::Status LocalSingleStoreElimPass::ProcessImpl() {
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 
-LocalSingleStoreElimPass::LocalSingleStoreElimPass() {}
+LocalSingleStoreElimPass::LocalSingleStoreElimPass() = default;
 
-Pass::Status LocalSingleStoreElimPass::Process(opt::IRContext* irContext) {
-  Initialize(irContext);
+Pass::Status LocalSingleStoreElimPass::Process() {
+  InitExtensionWhiteList();
   return ProcessImpl();
 }
 

--- a/source/opt/local_single_store_elim_pass.h
+++ b/source/opt/local_single_store_elim_pass.h
@@ -38,8 +38,9 @@ class LocalSingleStoreElimPass : public Pass {
 
  public:
   LocalSingleStoreElimPass();
+
   const char* name() const override { return "eliminate-local-single-store"; }
-  Status Process(opt::IRContext* irContext) override;
+  Status Process() override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse |
@@ -59,7 +60,6 @@ class LocalSingleStoreElimPass : public Pass {
   // Return true if all extensions in this module are allowed by this pass.
   bool AllExtensionsSupported() const;
 
-  void Initialize(opt::IRContext* irContext);
   Pass::Status ProcessImpl();
 
   // If there is a single store to |var_inst|, and it covers the entire

--- a/source/opt/local_ssa_elim_pass.cpp
+++ b/source/opt/local_ssa_elim_pass.cpp
@@ -23,13 +23,6 @@
 namespace spvtools {
 namespace opt {
 
-void LocalMultiStoreElimPass::Initialize(opt::IRContext* c) {
-  InitializeProcessing(c);
-
-  // Initialize extension whitelist
-  InitExtensions();
-}
-
 bool LocalMultiStoreElimPass::AllExtensionsSupported() const {
   // If any extension not in whitelist, return false
   for (auto& ei : get_module()->extensions()) {
@@ -61,10 +54,11 @@ Pass::Status LocalMultiStoreElimPass::ProcessImpl() {
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 
-LocalMultiStoreElimPass::LocalMultiStoreElimPass() {}
+LocalMultiStoreElimPass::LocalMultiStoreElimPass() = default;
 
-Pass::Status LocalMultiStoreElimPass::Process(opt::IRContext* c) {
-  Initialize(c);
+Pass::Status LocalMultiStoreElimPass::Process() {
+  // Initialize extension whitelist
+  InitExtensions();
   return ProcessImpl();
 }
 

--- a/source/opt/local_ssa_elim_pass.h
+++ b/source/opt/local_ssa_elim_pass.h
@@ -41,8 +41,9 @@ class LocalMultiStoreElimPass : public MemPass {
       std::function<std::vector<opt::BasicBlock*>*(const opt::BasicBlock*)>;
 
   LocalMultiStoreElimPass();
+
   const char* name() const override { return "eliminate-local-multi-store"; }
-  Status Process(opt::IRContext* c) override;
+  Status Process() override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse |
@@ -56,7 +57,6 @@ class LocalMultiStoreElimPass : public MemPass {
   // Return true if all extensions in this module are allowed by this pass.
   bool AllExtensionsSupported() const;
 
-  void Initialize(opt::IRContext* c);
   Pass::Status ProcessImpl();
 
   // Extensions supported by this pass.

--- a/source/opt/loop_fission.h
+++ b/source/opt/loop_fission.h
@@ -57,7 +57,7 @@ class LoopFissionPass : public Pass {
 
   const char* name() const override { return "Loop Fission"; }
 
-  Pass::Status Process(opt::IRContext* context) override;
+  Pass::Status Process() override;
 
   // Checks if |loop| meets the register pressure criteria to be split.
   bool ShouldSplitLoop(const opt::Loop& loop, opt::IRContext* context);

--- a/source/opt/loop_fusion_pass.cpp
+++ b/source/opt/loop_fusion_pass.cpp
@@ -22,9 +22,9 @@
 namespace spvtools {
 namespace opt {
 
-Pass::Status LoopFusionPass::Process(opt::IRContext* c) {
+Pass::Status LoopFusionPass::Process() {
   bool modified = false;
-  opt::Module* module = c->module();
+  opt::Module* module = context()->module();
 
   // Process each function in the module
   for (opt::Function& f : *module) {

--- a/source/opt/loop_fusion_pass.h
+++ b/source/opt/loop_fusion_pass.h
@@ -34,7 +34,7 @@ class LoopFusionPass : public Pass {
   // Processes the given |module|. Returns Status::Failure if errors occur when
   // processing. Returns the corresponding Status::Success if processing is
   // succesful to indicate whether changes have been made to the modue.
-  Status Process(opt::IRContext* c) override;
+  Status Process() override;
 
  private:
   // Fuse loops in |function| if compatible, legal and the fused loop won't use

--- a/source/opt/loop_peeling.cpp
+++ b/source/opt/loop_peeling.cpp
@@ -572,11 +572,9 @@ void LoopPeeling::PeelAfter(uint32_t peel_factor) {
       opt::IRContext::kAnalysisLoopAnalysis | opt::IRContext::kAnalysisCFG);
 }
 
-Pass::Status LoopPeelingPass::Process(opt::IRContext* c) {
-  InitializeProcessing(c);
-
+Pass::Status LoopPeelingPass::Process() {
   bool modified = false;
-  opt::Module* module = c->module();
+  opt::Module* module = context()->module();
 
   // Process each function in the module
   for (opt::Function& f : *module) {

--- a/source/opt/loop_peeling.h
+++ b/source/opt/loop_peeling.h
@@ -262,7 +262,7 @@ class LoopPeelingPass : public Pass {
   // Processes the given |module|. Returns Status::Failure if errors occur when
   // processing. Returns the corresponding Status::Success if processing is
   // succesful to indicate whether changes have been made to the modue.
-  Pass::Status Process(opt::IRContext* context) override;
+  Pass::Status Process() override;
 
  private:
   // Describes the peeling direction.

--- a/source/opt/loop_unroller.cpp
+++ b/source/opt/loop_unroller.cpp
@@ -1040,13 +1040,12 @@ void LoopUtils::Finalize() {
  *
  */
 
-Pass::Status LoopUnroller::Process(opt::IRContext* c) {
-  context_ = c;
+Pass::Status LoopUnroller::Process() {
   bool changed = false;
-  for (opt::Function& f : *c->module()) {
-    opt::LoopDescriptor* LD = context_->GetLoopDescriptor(&f);
+  for (opt::Function& f : *context()->module()) {
+    opt::LoopDescriptor* LD = context()->GetLoopDescriptor(&f);
     for (opt::Loop& loop : *LD) {
-      LoopUtils loop_utils{c, &loop};
+      LoopUtils loop_utils{context(), &loop};
       if (!loop.HasUnrollLoopControl() || !loop_utils.CanPerformUnroll()) {
         continue;
       }

--- a/source/opt/loop_unroller.h
+++ b/source/opt/loop_unroller.h
@@ -27,10 +27,9 @@ class LoopUnroller : public Pass {
 
   const char* name() const override { return "Loop unroller"; }
 
-  Status Process(opt::IRContext* context) override;
+  Status Process() override;
 
  private:
-  opt::IRContext* context_;
   bool fully_unroll_;
   int unroll_factor_;
 };

--- a/source/opt/loop_unswitch_pass.cpp
+++ b/source/opt/loop_unswitch_pass.cpp
@@ -856,11 +856,9 @@ class LoopUnswitch {
 
 }  // namespace
 
-Pass::Status LoopUnswitchPass::Process(opt::IRContext* c) {
-  InitializeProcessing(c);
-
+Pass::Status LoopUnswitchPass::Process() {
   bool modified = false;
-  opt::Module* module = c->module();
+  opt::Module* module = context()->module();
 
   // Process each function in the module
   for (opt::Function& f : *module) {

--- a/source/opt/loop_unswitch_pass.h
+++ b/source/opt/loop_unswitch_pass.h
@@ -31,7 +31,7 @@ class LoopUnswitchPass : public Pass {
   // Processes the given |module|. Returns Status::Failure if errors occur when
   // processing. Returns the corresponding Status::Success if processing is
   // succesful to indicate whether changes have been made to the modue.
-  Pass::Status Process(opt::IRContext* context) override;
+  Pass::Status Process() override;
 
  private:
   bool ProcessFunction(opt::Function* f);

--- a/source/opt/mem_pass.h
+++ b/source/opt/mem_pass.h
@@ -38,7 +38,6 @@ namespace opt {
 // utility functions and supporting state.
 class MemPass : public Pass {
  public:
-  MemPass();
   virtual ~MemPass() = default;
 
   // Returns an undef value for the given |var_id|'s type.
@@ -69,6 +68,8 @@ class MemPass : public Pass {
   void CollectTargetVars(opt::Function* func);
 
  protected:
+  MemPass();
+
   // Returns true if |typeInst| is a scalar type
   // or a vector or matrix
   bool IsBaseTargetType(const opt::Instruction* typeInst) const;

--- a/source/opt/merge_return_pass.cpp
+++ b/source/opt/merge_return_pass.cpp
@@ -23,9 +23,7 @@
 namespace spvtools {
 namespace opt {
 
-Pass::Status MergeReturnPass::Process(opt::IRContext* irContext) {
-  InitializeProcessing(irContext);
-
+Pass::Status MergeReturnPass::Process() {
   bool modified = false;
   bool is_shader =
       context()->get_feature_mgr()->HasCapability(SpvCapabilityShader);

--- a/source/opt/merge_return_pass.h
+++ b/source/opt/merge_return_pass.h
@@ -103,7 +103,7 @@ class MergeReturnPass : public MemPass {
         final_return_block_(nullptr) {}
 
   const char* name() const override { return "merge-return"; }
-  Status Process(opt::IRContext*) override;
+  Status Process() override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
     // return opt::IRContext::kAnalysisDefUse;

--- a/source/opt/null_pass.h
+++ b/source/opt/null_pass.h
@@ -25,9 +25,7 @@ namespace opt {
 class NullPass : public Pass {
  public:
   const char* name() const override { return "null"; }
-  Status Process(opt::IRContext*) override {
-    return Status::SuccessWithoutChange;
-  }
+  Status Process() override { return Status::SuccessWithoutChange; }
 };
 
 }  // namespace opt

--- a/source/opt/pass.cpp
+++ b/source/opt/pass.cpp
@@ -109,7 +109,10 @@ Pass::Status Pass::Run(opt::IRContext* ctx) {
   }
   already_run_ = true;
 
-  Pass::Status status = Process(ctx);
+  context_ = ctx;
+  Pass::Status status = Process();
+  context_ = nullptr;
+
   if (status == Status::SuccessWithChange) {
     ctx->InvalidateAnalysesExceptFor(GetPreservedAnalyses());
   }

--- a/source/opt/pass.h
+++ b/source/opt/pass.h
@@ -47,13 +47,6 @@ class Pass {
 
   using ProcessFunction = std::function<bool(opt::Function*)>;
 
-  // Constructs a new pass.
-  //
-  // The constructed instance will have an empty message consumer, which just
-  // ignores all messages from the library. Use SetMessageConsumer() to supply
-  // one if messages are of concern.
-  Pass();
-
   // Destructs the pass.
   virtual ~Pass() = default;
 
@@ -88,6 +81,9 @@ class Pass {
 
   // Returns a pointer to the current module for this pass.
   opt::Module* get_module() const { return context_->module(); }
+
+  // Sets the pointer to the current context for this pass.
+  void SetContextForTesting(IRContext* ctx) { context_ = ctx; }
 
   // Returns a pointer to the current context for this pass.
   opt::IRContext* context() const { return context_; }
@@ -126,7 +122,7 @@ class Pass {
   //
   // It is an error if |Run| is called twice with the same instance of the pass.
   // If this happens the return value will be |Failure|.
-  virtual Status Run(opt::IRContext* ctx) final;
+  Status Run(opt::IRContext* ctx);
 
   // Returns the set of analyses that the pass is guaranteed to preserve.
   virtual opt::IRContext::Analysis GetPreservedAnalyses() {
@@ -137,14 +133,17 @@ class Pass {
   uint32_t GetPointeeTypeId(const opt::Instruction* ptrInst) const;
 
  protected:
-  // Initialize basic data structures for the pass. This sets up the def-use
-  // manager, module and other attributes.
-  virtual void InitializeProcessing(opt::IRContext* c) { context_ = c; }
+  // Constructs a new pass.
+  //
+  // The constructed instance will have an empty message consumer, which just
+  // ignores all messages from the library. Use SetMessageConsumer() to supply
+  // one if messages are of concern.
+  Pass();
 
   // Processes the given |module|. Returns Status::Failure if errors occur when
   // processing. Returns the corresponding Status::Success if processing is
   // succesful to indicate whether changes are made to the module.
-  virtual Status Process(opt::IRContext* context) = 0;
+  virtual Status Process() = 0;
 
   // Return the next available SSA id and increment it.
   uint32_t TakeNextId() { return context_->TakeNextId(); }

--- a/source/opt/private_to_local_pass.cpp
+++ b/source/opt/private_to_local_pass.cpp
@@ -24,8 +24,7 @@ const uint32_t kSpvTypePointerTypeIdInIdx = 1;
 namespace spvtools {
 namespace opt {
 
-Pass::Status PrivateToLocalPass::Process(opt::IRContext* c) {
-  InitializeProcessing(c);
+Pass::Status PrivateToLocalPass::Process() {
   bool modified = false;
 
   // Private variables require the shader capability.  If this is not a shader,

--- a/source/opt/private_to_local_pass.h
+++ b/source/opt/private_to_local_pass.h
@@ -28,7 +28,8 @@ namespace opt {
 class PrivateToLocalPass : public Pass {
  public:
   const char* name() const override { return "private-to-local"; }
-  Status Process(opt::IRContext*) override;
+  Status Process() override;
+
   opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse |
            opt::IRContext::kAnalysisInstrToBlockMapping |

--- a/source/opt/reduce_load_size.cpp
+++ b/source/opt/reduce_load_size.cpp
@@ -29,8 +29,7 @@ const double kThreshold = 0.9;
 namespace spvtools {
 namespace opt {
 
-Pass::Status ReduceLoadSize::Process(opt::IRContext* ctx) {
-  InitializeProcessing(ctx);
+Pass::Status ReduceLoadSize::Process() {
   bool modified = false;
 
   for (auto& func : *get_module()) {

--- a/source/opt/reduce_load_size.h
+++ b/source/opt/reduce_load_size.h
@@ -26,7 +26,7 @@ namespace opt {
 class ReduceLoadSize : public Pass {
  public:
   const char* name() const override { return "reduce-load-size"; }
-  Status Process(opt::IRContext* irContext) override;
+  Status Process() override;
 
   // Return the mask of preserved Analyses.
   opt::IRContext::Analysis GetPreservedAnalyses() override {

--- a/source/opt/redundancy_elimination.cpp
+++ b/source/opt/redundancy_elimination.cpp
@@ -19,9 +19,7 @@
 namespace spvtools {
 namespace opt {
 
-Pass::Status RedundancyEliminationPass::Process(opt::IRContext* c) {
-  InitializeProcessing(c);
-
+Pass::Status RedundancyEliminationPass::Process() {
   bool modified = false;
   ValueNumberTable vnTable(context());
 

--- a/source/opt/redundancy_elimination.h
+++ b/source/opt/redundancy_elimination.h
@@ -30,7 +30,7 @@ namespace opt {
 class RedundancyEliminationPass : public LocalRedundancyEliminationPass {
  public:
   const char* name() const override { return "redundancy-elimination"; }
-  Status Process(opt::IRContext*) override;
+  Status Process() override;
 
  protected:
   // Removes for all total redundancies in the function starting at |bb|.

--- a/source/opt/remove_duplicates_pass.h
+++ b/source/opt/remove_duplicates_pass.h
@@ -33,7 +33,8 @@ using IdDecorationsList =
 class RemoveDuplicatesPass : public Pass {
  public:
   const char* name() const override { return "remove-duplicates"; }
-  Status Process(opt::IRContext*) override;
+  Status Process() override;
+
   // TODO(pierremoreau): Move this function somewhere else (e.g. pass.h or
   // within the type manager)
   // Returns whether two types are equal, and have the same decorations.
@@ -42,23 +43,22 @@ class RemoveDuplicatesPass : public Pass {
                             opt::IRContext* context);
 
  private:
-  // Remove duplicate capabilities from the module attached to |ir_context|.
+  // Remove duplicate capabilities from the module
   //
   // Returns true if the module was modified, false otherwise.
-  bool RemoveDuplicateCapabilities(opt::IRContext* ir_context) const;
-  // Remove duplicate extended instruction imports from the module attached to
-  // |ir_context|.
+  bool RemoveDuplicateCapabilities() const;
+  // Remove duplicate extended instruction imports from the module
   //
   // Returns true if the module was modified, false otherwise.
-  bool RemoveDuplicatesExtInstImports(opt::IRContext* ir_context) const;
-  // Remove duplicate types from the module attached to |ir_context|.
+  bool RemoveDuplicatesExtInstImports() const;
+  // Remove duplicate types from the module
   //
   // Returns true if the module was modified, false otherwise.
-  bool RemoveDuplicateTypes(opt::IRContext* ir_context) const;
-  // Remove duplicate decorations from the module attached to |ir_context|.
+  bool RemoveDuplicateTypes() const;
+  // Remove duplicate decorations from the module
   //
   // Returns true if the module was modified, false otherwise.
-  bool RemoveDuplicateDecorations(opt::IRContext* ir_context) const;
+  bool RemoveDuplicateDecorations() const;
 };
 
 }  // namespace opt

--- a/source/opt/replace_invalid_opc.cpp
+++ b/source/opt/replace_invalid_opc.cpp
@@ -19,8 +19,7 @@
 namespace spvtools {
 namespace opt {
 
-Pass::Status ReplaceInvalidOpcodePass::Process(opt::IRContext* c) {
-  InitializeProcessing(c);
+Pass::Status ReplaceInvalidOpcodePass::Process() {
   bool modified = false;
 
   if (context()->get_feature_mgr()->HasCapability(SpvCapabilityLinkage)) {

--- a/source/opt/replace_invalid_opc.h
+++ b/source/opt/replace_invalid_opc.h
@@ -27,7 +27,7 @@ namespace opt {
 class ReplaceInvalidOpcodePass : public Pass {
  public:
   const char* name() const override { return "replace-invalid-opcodes"; }
-  Status Process(opt::IRContext*) override;
+  Status Process() override;
 
  private:
   // Returns the execution model that is used by every entry point in the

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -26,9 +26,7 @@
 namespace spvtools {
 namespace opt {
 
-Pass::Status ScalarReplacementPass::Process(opt::IRContext* c) {
-  InitializeProcessing(c);
-
+Pass::Status ScalarReplacementPass::Process() {
   Status status = Status::SuccessWithoutChange;
   for (auto& f : *get_module()) {
     Status functionStatus = ProcessFunction(&f);

--- a/source/opt/scalar_replacement_pass.h
+++ b/source/opt/scalar_replacement_pass.h
@@ -43,7 +43,7 @@ class ScalarReplacementPass : public Pass {
 
   // Attempts to scalarize all appropriate function scope variables. Returns
   // SuccessWithChange if any change is made.
-  Status Process(opt::IRContext* c) override;
+  Status Process() override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse |

--- a/source/opt/set_spec_constant_default_value_pass.cpp
+++ b/source/opt/set_spec_constant_default_value_pass.cpp
@@ -190,10 +190,7 @@ opt::Instruction* GetSpecIdTargetFromDecorationGroup(
 }
 }  // namespace
 
-Pass::Status SetSpecConstantDefaultValuePass::Process(
-    opt::IRContext* irContext) {
-  InitializeProcessing(irContext);
-
+Pass::Status SetSpecConstantDefaultValuePass::Process() {
   // The operand index of decoration target in an OpDecorate instruction.
   const uint32_t kTargetIdOperandIndex = 0;
   // The operand index of the decoration literal in an OpDecorate instruction.
@@ -216,7 +213,7 @@ Pass::Status SetSpecConstantDefaultValuePass::Process(
   // is found for a spec id, the string will be parsed according to the target
   // spec constant type. The parsed value will be used to replace the original
   // default value of the target spec constant.
-  for (opt::Instruction& inst : irContext->annotations()) {
+  for (opt::Instruction& inst : context()->annotations()) {
     // Only process 'OpDecorate SpecId' instructions
     if (inst.opcode() != SpvOp::SpvOpDecorate) continue;
     if (inst.NumOperands() != kOpDecorateSpecIdNumOperands) continue;

--- a/source/opt/set_spec_constant_default_value_pass.h
+++ b/source/opt/set_spec_constant_default_value_pass.h
@@ -56,7 +56,7 @@ class SetSpecConstantDefaultValuePass : public Pass {
         spec_id_to_value_bit_pattern_(std::move(default_values)) {}
 
   const char* name() const override { return "set-spec-const-default-value"; }
-  Status Process(opt::IRContext*) override;
+  Status Process() override;
 
   // Parses the given null-terminated C string to get a mapping from Spec Id to
   // default value strings. Returns a unique pointer of the mapping from spec

--- a/source/opt/simplification_pass.cpp
+++ b/source/opt/simplification_pass.cpp
@@ -23,8 +23,7 @@
 namespace spvtools {
 namespace opt {
 
-Pass::Status SimplificationPass::Process(opt::IRContext* c) {
-  InitializeProcessing(c);
+Pass::Status SimplificationPass::Process() {
   bool modified = false;
 
   for (opt::Function& function : *get_module()) {

--- a/source/opt/simplification_pass.h
+++ b/source/opt/simplification_pass.h
@@ -26,8 +26,9 @@ namespace opt {
 class SimplificationPass : public Pass {
  public:
   const char* name() const override { return "simplify-instructions"; }
-  Status Process(opt::IRContext*) override;
-  virtual opt::IRContext::Analysis GetPreservedAnalyses() override {
+  Status Process() override;
+
+  opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse |
            opt::IRContext::kAnalysisInstrToBlockMapping |
            opt::IRContext::kAnalysisDecorations |

--- a/source/opt/ssa_rewrite_pass.cpp
+++ b/source/opt/ssa_rewrite_pass.cpp
@@ -565,11 +565,7 @@ bool SSARewriter::RewriteFunctionIntoSSA(opt::Function* fp) {
   return modified;
 }
 
-void SSARewritePass::Initialize(opt::IRContext* c) { InitializeProcessing(c); }
-
-Pass::Status SSARewritePass::Process(opt::IRContext* c) {
-  Initialize(c);
-
+Pass::Status SSARewritePass::Process() {
   bool modified = false;
   for (auto& fn : *get_module()) {
     modified |= SSARewriter(this).RewriteFunctionIntoSSA(&fn);

--- a/source/opt/ssa_rewrite_pass.h
+++ b/source/opt/ssa_rewrite_pass.h
@@ -290,12 +290,9 @@ class SSARewriter {
 class SSARewritePass : public MemPass {
  public:
   SSARewritePass() = default;
-  const char* name() const override { return "ssa-rewrite"; }
-  Status Process(opt::IRContext* c) override;
 
- private:
-  // Initializes the pass.
-  void Initialize(opt::IRContext* c);
+  const char* name() const override { return "ssa-rewrite"; }
+  Status Process() override;
 };
 
 }  // namespace opt

--- a/source/opt/strength_reduction_pass.cpp
+++ b/source/opt/strength_reduction_pass.cpp
@@ -53,9 +53,7 @@ bool IsPowerOf2(uint32_t val) {
 namespace spvtools {
 namespace opt {
 
-Pass::Status StrengthReductionPass::Process(opt::IRContext* c) {
-  InitializeProcessing(c);
-
+Pass::Status StrengthReductionPass::Process() {
   // Initialize the member variables on a per module basis.
   bool modified = false;
   int32_type_id_ = 0;

--- a/source/opt/strength_reduction_pass.h
+++ b/source/opt/strength_reduction_pass.h
@@ -27,7 +27,7 @@ namespace opt {
 class StrengthReductionPass : public Pass {
  public:
   const char* name() const override { return "strength-reduction"; }
-  Status Process(opt::IRContext*) override;
+  Status Process() override;
 
  private:
   // Replaces multiple by power of 2 with an equivalent bit shift.

--- a/source/opt/strip_debug_info_pass.cpp
+++ b/source/opt/strip_debug_info_pass.cpp
@@ -18,13 +18,13 @@
 namespace spvtools {
 namespace opt {
 
-Pass::Status StripDebugInfoPass::Process(opt::IRContext* irContext) {
-  bool modified = !irContext->debugs1().empty() ||
-                  !irContext->debugs2().empty() ||
-                  !irContext->debugs3().empty();
-  irContext->debug_clear();
+Pass::Status StripDebugInfoPass::Process() {
+  bool modified = !context()->debugs1().empty() ||
+                  !context()->debugs2().empty() ||
+                  !context()->debugs3().empty();
+  context()->debug_clear();
 
-  irContext->module()->ForEachInst([&modified](opt::Instruction* inst) {
+  context()->module()->ForEachInst([&modified](opt::Instruction* inst) {
     modified |= !inst->dbg_line_insts().empty();
     inst->dbg_line_insts().clear();
   });

--- a/source/opt/strip_debug_info_pass.h
+++ b/source/opt/strip_debug_info_pass.h
@@ -26,7 +26,7 @@ namespace opt {
 class StripDebugInfoPass : public Pass {
  public:
   const char* name() const override { return "strip-debug"; }
-  Status Process(opt::IRContext* irContext) override;
+  Status Process() override;
 };
 
 }  // namespace opt

--- a/source/opt/strip_reflect_info_pass.cpp
+++ b/source/opt/strip_reflect_info_pass.cpp
@@ -24,13 +24,13 @@ namespace opt {
 
 using opt::Instruction;
 
-Pass::Status StripReflectInfoPass::Process(opt::IRContext* irContext) {
+Pass::Status StripReflectInfoPass::Process() {
   bool modified = false;
 
   std::vector<Instruction*> to_remove;
 
   bool other_uses_for_decorate_string = false;
-  for (auto& inst : irContext->module()->annotations()) {
+  for (auto& inst : context()->module()->annotations()) {
     switch (inst.opcode()) {
       case SpvOpDecorateStringGOOGLE:
         if (inst.GetSingleWordInOperand(1) == SpvDecorationHlslSemanticGOOGLE) {
@@ -52,7 +52,7 @@ Pass::Status StripReflectInfoPass::Process(opt::IRContext* irContext) {
     }
   }
 
-  for (auto& inst : irContext->module()->extensions()) {
+  for (auto& inst : context()->module()->extensions()) {
     const char* ext_name =
         reinterpret_cast<const char*>(&inst.GetInOperand(0).words[0]);
     if (0 == std::strcmp(ext_name, "SPV_GOOGLE_hlsl_functionality1")) {
@@ -65,7 +65,7 @@ Pass::Status StripReflectInfoPass::Process(opt::IRContext* irContext) {
 
   for (auto* inst : to_remove) {
     modified = true;
-    irContext->KillInst(inst);
+    context()->KillInst(inst);
   }
 
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;

--- a/source/opt/strip_reflect_info_pass.h
+++ b/source/opt/strip_reflect_info_pass.h
@@ -26,7 +26,7 @@ namespace opt {
 class StripReflectInfoPass : public Pass {
  public:
   const char* name() const override { return "strip-reflect"; }
-  Status Process(opt::IRContext* irContext) override;
+  Status Process() override;
 
   // Return the mask of preserved Analyses.
   opt::IRContext::Analysis GetPreservedAnalyses() override {

--- a/source/opt/unify_const_pass.cpp
+++ b/source/opt/unify_const_pass.cpp
@@ -103,8 +103,7 @@ class ResultIdTrie {
 };
 }  // anonymous namespace
 
-Pass::Status UnifyConstantPass::Process(opt::IRContext* c) {
-  InitializeProcessing(c);
+Pass::Status UnifyConstantPass::Process() {
   bool modified = false;
   ResultIdTrie defined_constants;
 

--- a/source/opt/unify_const_pass.h
+++ b/source/opt/unify_const_pass.h
@@ -26,7 +26,7 @@ namespace opt {
 class UnifyConstantPass : public Pass {
  public:
   const char* name() const override { return "unify-const"; }
-  Status Process(opt::IRContext*) override;
+  Status Process() override;
 };
 
 }  // namespace opt

--- a/source/opt/vector_dce.cpp
+++ b/source/opt/vector_dce.cpp
@@ -23,9 +23,7 @@ const uint32_t kInsertCompositeIdInIdx = 1;
 namespace spvtools {
 namespace opt {
 
-Pass::Status VectorDCE::Process(opt::IRContext* ctx) {
-  InitializeProcessing(ctx);
-
+Pass::Status VectorDCE::Process() {
   bool modified = false;
   for (opt::Function& function : *get_module()) {
     modified |= VectorDCEFunction(&function);

--- a/source/opt/vector_dce.h
+++ b/source/opt/vector_dce.h
@@ -37,14 +37,14 @@ class VectorDCE : public MemPass {
   };
 
  public:
-  const char* name() const override { return "vector-dce"; }
-  Status Process(opt::IRContext*) override;
-
   VectorDCE() : all_components_live_(kMaxVectorSize) {
     for (uint32_t i = 0; i < kMaxVectorSize; i++) {
       all_components_live_.Set(i);
     }
   }
+
+  const char* name() const override { return "vector-dce"; }
+  Status Process() override;
 
   opt::IRContext::Analysis GetPreservedAnalyses() override {
     return opt::IRContext::kAnalysisDefUse | opt::IRContext::kAnalysisCFG |

--- a/source/opt/workaround1209.cpp
+++ b/source/opt/workaround1209.cpp
@@ -20,8 +20,7 @@
 namespace spvtools {
 namespace opt {
 
-Pass::Status Workaround1209::Process(opt::IRContext* c) {
-  InitializeProcessing(c);
+Pass::Status Workaround1209::Process() {
   bool modified = false;
   modified = RemoveOpUnreachableInLoops();
   return (modified ? Status::SuccessWithChange : Status::SuccessWithoutChange);

--- a/source/opt/workaround1209.h
+++ b/source/opt/workaround1209.h
@@ -24,7 +24,7 @@ namespace opt {
 class Workaround1209 : public Pass {
  public:
   const char* name() const override { return "workaround-1209"; }
-  Status Process(opt::IRContext*) override;
+  Status Process() override;
 
  private:
   // There is at least one driver where an OpUnreachable found in a loop is not

--- a/test/opt/ir_context_test.cpp
+++ b/test/opt/ir_context_test.cpp
@@ -31,31 +31,40 @@ using ::testing::Each;
 class DummyPassPreservesNothing : public Pass {
  public:
   DummyPassPreservesNothing(Status s) : Pass(), status_to_return_(s) {}
+
   const char* name() const override { return "dummy-pass"; }
-  Status Process(IRContext*) override { return status_to_return_; }
+  Status Process() override { return status_to_return_; }
+
+ private:
   Status status_to_return_;
 };
 
 class DummyPassPreservesAll : public Pass {
  public:
   DummyPassPreservesAll(Status s) : Pass(), status_to_return_(s) {}
+
   const char* name() const override { return "dummy-pass"; }
-  Status Process(IRContext*) override { return status_to_return_; }
-  Status status_to_return_;
-  virtual Analysis GetPreservedAnalyses() override {
+  Status Process() override { return status_to_return_; }
+
+  Analysis GetPreservedAnalyses() override {
     return Analysis(IRContext::kAnalysisEnd - 1);
   }
+
+ private:
+  Status status_to_return_;
 };
 
 class DummyPassPreservesFirst : public Pass {
  public:
   DummyPassPreservesFirst(Status s) : Pass(), status_to_return_(s) {}
+
   const char* name() const override { return "dummy-pass"; }
-  Status Process(IRContext*) override { return status_to_return_; }
+  Status Process() override { return status_to_return_; }
+
+  Analysis GetPreservedAnalyses() override { return IRContext::kAnalysisBegin; }
+
+ private:
   Status status_to_return_;
-  virtual Analysis GetPreservedAnalyses() override {
-    return IRContext::kAnalysisBegin;
-  }
 };
 
 using IRContextTest = PassTest<::testing::Test>;

--- a/test/opt/line_debug_info_test.cpp
+++ b/test/opt/line_debug_info_test.cpp
@@ -23,9 +23,9 @@ namespace {
 class NopifyPass : public Pass {
  public:
   const char* name() const override { return "NopifyPass"; }
-  Status Process(IRContext* irContext) override {
+  Status Process() override {
     bool modified = false;
-    irContext->module()->ForEachInst(
+    context()->module()->ForEachInst(
         [&modified](Instruction* inst) {
           inst->ToNop();
           modified = true;

--- a/test/opt/loop_optimizations/loop_fission.cpp
+++ b/test/opt/loop_optimizations/loop_fission.cpp
@@ -2922,8 +2922,9 @@ OpFunctionEnd
 
   // Test that the loop descriptor is correctly maintained and updated by the
   // pass.
-  LoopFissionPass loop_fission{};
-  loop_fission.Process(context.get());
+  LoopFissionPass loop_fission;
+  loop_fission.SetContextForTesting(context.get());
+  loop_fission.Process();
 
   function = spvtest::GetFunction(module, 2);
   LoopDescriptor& post_pass_descriptor = *context->GetLoopDescriptor(function);
@@ -3179,8 +3180,9 @@ OpFunctionEnd
 
   // Test that the loop descriptor is correctly maintained and updated by the
   // pass.
-  LoopFissionPass loop_fission{};
-  loop_fission.Process(context.get());
+  LoopFissionPass loop_fission;
+  loop_fission.SetContextForTesting(context.get());
+  loop_fission.Process();
 
   function = spvtest::GetFunction(module, 2);
   LoopDescriptor& post_pass_descriptor = *context->GetLoopDescriptor(function);

--- a/test/opt/loop_optimizations/unroll_assumptions.cpp
+++ b/test/opt/loop_optimizations/unroll_assumptions.cpp
@@ -39,12 +39,12 @@ class PartialUnrollerTestPass : public Pass {
 
   const char* name() const override { return "Loop unroller"; }
 
-  Status Process(IRContext* context) override {
+  Status Process() override {
     bool changed = false;
-    for (Function& f : *context->module()) {
-      LoopDescriptor& loop_descriptor = *context->GetLoopDescriptor(&f);
+    for (Function& f : *context()->module()) {
+      LoopDescriptor& loop_descriptor = *context()->GetLoopDescriptor(&f);
       for (auto& loop : loop_descriptor) {
-        LoopUtils loop_utils{context, &loop};
+        LoopUtils loop_utils{context(), &loop};
         if (loop_utils.PartiallyUnroll(factor)) {
           changed = true;
         }

--- a/test/opt/loop_optimizations/unroll_simple.cpp
+++ b/test/opt/loop_optimizations/unroll_simple.cpp
@@ -201,11 +201,11 @@ class PartialUnrollerTestPass : public Pass {
 
   const char* name() const override { return "Loop unroller"; }
 
-  Status Process(IRContext* context) override {
-    for (Function& f : *context->module()) {
-      LoopDescriptor& loop_descriptor = *context->GetLoopDescriptor(&f);
+  Status Process() override {
+    for (Function& f : *context()->module()) {
+      LoopDescriptor& loop_descriptor = *context()->GetLoopDescriptor(&f);
       for (auto& loop : loop_descriptor) {
-        LoopUtils loop_utils{context, &loop};
+        LoopUtils loop_utils{context(), &loop};
         loop_utils.PartiallyUnroll(factor);
       }
     }
@@ -2934,7 +2934,8 @@ OpFunctionEnd
                   SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
 
   PartialUnrollerTestPass<3> unroller;
-  unroller.Process(context.get());
+  unroller.SetContextForTesting(context.get());
+  unroller.Process();
 
   Module* module = context->module();
   EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"

--- a/test/opt/pass_manager_test.cpp
+++ b/test/opt/pass_manager_test.cpp
@@ -75,8 +75,8 @@ TEST(PassManager, Interface) {
 class AppendOpNopPass : public Pass {
  public:
   const char* name() const override { return "AppendOpNop"; }
-  Status Process(IRContext* irContext) override {
-    irContext->AddDebug1Inst(MakeUnique<Instruction>(irContext));
+  Status Process() override {
+    context()->AddDebug1Inst(MakeUnique<Instruction>(context()));
     return Status::SuccessWithChange;
   }
 };
@@ -88,9 +88,9 @@ class AppendMultipleOpNopPass : public Pass {
   explicit AppendMultipleOpNopPass(uint32_t num_nop) : num_nop_(num_nop) {}
 
   const char* name() const override { return "AppendOpNop"; }
-  Status Process(IRContext* irContext) override {
+  Status Process() override {
     for (uint32_t i = 0; i < num_nop_; i++) {
-      irContext->AddDebug1Inst(MakeUnique<Instruction>(irContext));
+      context()->AddDebug1Inst(MakeUnique<Instruction>(context()));
     }
     return Status::SuccessWithChange;
   }
@@ -103,10 +103,10 @@ class AppendMultipleOpNopPass : public Pass {
 class DuplicateInstPass : public Pass {
  public:
   const char* name() const override { return "DuplicateInst"; }
-  Status Process(IRContext* irContext) override {
+  Status Process() override {
     auto inst =
-        MakeUnique<Instruction>(*(--irContext->debug1_end())->Clone(irContext));
-    irContext->AddDebug1Inst(std::move(inst));
+        MakeUnique<Instruction>(*(--context()->debug1_end())->Clone(context()));
+    context()->AddDebug1Inst(std::move(inst));
     return Status::SuccessWithChange;
   }
 };
@@ -141,10 +141,10 @@ class AppendTypeVoidInstPass : public Pass {
   explicit AppendTypeVoidInstPass(uint32_t result_id) : result_id_(result_id) {}
 
   const char* name() const override { return "AppendTypeVoidInstPass"; }
-  Status Process(IRContext* irContext) override {
-    auto inst = MakeUnique<Instruction>(irContext, SpvOpTypeVoid, 0, result_id_,
+  Status Process() override {
+    auto inst = MakeUnique<Instruction>(context(), SpvOpTypeVoid, 0, result_id_,
                                         std::vector<Operand>{});
-    irContext->AddType(std::move(inst));
+    context()->AddType(std::move(inst));
     return Status::SuccessWithChange;
   }
 

--- a/test/opt/pass_test.cpp
+++ b/test/opt/pass_test.cpp
@@ -29,9 +29,7 @@ namespace {
 class DummyPass : public Pass {
  public:
   const char* name() const override { return "dummy-pass"; }
-  Status Process(IRContext* irContext) override {
-    return irContext ? Status::SuccessWithoutChange : Status::Failure;
-  }
+  Status Process() override { return Status::SuccessWithoutChange; }
 };
 
 using ::testing::UnorderedElementsAre;


### PR DESCRIPTION
Currently the IRContext is passed into the Pass::Process method. It is
then up to the individual pass to store the context into the context_
variable. This CL changes the Run method to store the context before
calling Process which no-longer receives the context as a parameter.

Issue #1703 