### PR TITLE
Add option to skip verifying block layout

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -475,8 +475,14 @@ SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetRelaxLogicalPointer(
 
 // Records whether or not the validator should relax the rules on block layout.
 //
-// When relaxed, it will skip checking standard uniform/storage buffer layout.
+// When relaxed, it will enable VK_KHR_relaxed_block_layout when validating
+// standard uniform/storage block layout.
 SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetRelaxBlockLayout(
+    spv_validator_options options, bool val);
+
+// Records whether or not the validator should skip validating standard
+// uniform/storage block layout.
+SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetSkipBlockLayout(
     spv_validator_options options, bool val);
 
 // Encodes the given SPIR-V assembly text to its binary representation. The

--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -81,8 +81,15 @@ class ValidatorOptions {
     spvValidatorOptionsSetRelaxStoreStruct(options_, val);
   }
 
+  // Enables VK_KHR_relaxed_block_layout when validating standard
+  // uniform/storage buffer layout.
   void SetRelaxBlockLayout(bool val) {
     spvValidatorOptionsSetRelaxBlockLayout(options_, val);
+  }
+
+  // Skips validating standard uniform/storage buffer layout.
+  void SetSkipBlockLayout(bool val) {
+    spvValidatorOptionsSetSkipBlockLayout(options_, val);
   }
 
   // Records whether or not the validator should relax the rules on pointer

--- a/source/spirv_validator_options.cpp
+++ b/source/spirv_validator_options.cpp
@@ -91,3 +91,8 @@ void spvValidatorOptionsSetRelaxBlockLayout(spv_validator_options options,
                                             bool val) {
   options->relax_block_layout = val;
 }
+
+void spvValidatorOptionsSetSkipBlockLayout(spv_validator_options options,
+                                           bool val) {
+  options->skip_block_layout = val;
+}

--- a/source/spirv_validator_options.h
+++ b/source/spirv_validator_options.h
@@ -41,12 +41,14 @@ struct spv_validator_options_t {
       : universal_limits_(),
         relax_struct_store(false),
         relax_logical_pointer(false),
-        relax_block_layout(false) {}
+        relax_block_layout(false),
+        skip_block_layout(false) {}
 
   validator_universal_limits_t universal_limits_;
   bool relax_struct_store;
   bool relax_logical_pointer;
   bool relax_block_layout;
+  bool skip_block_layout;
 };
 
 #endif  // LIBSPIRV_SPIRV_VALIDATOR_OPTIONS_H_

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -331,6 +331,8 @@ spv_result_t checkLayout(uint32_t struct_id, const char* storage_class_str,
                          const char* decoration_str, bool blockRules,
                          MemberConstraints& constraints,
                          ValidationState_t& vstate) {
+  if (vstate.options()->skip_block_layout) return SPV_SUCCESS;
+
   auto fail = [&vstate, struct_id, storage_class_str, decoration_str,
                blockRules](uint32_t member_idx) -> DiagnosticStream {
     DiagnosticStream ds =
@@ -342,6 +344,7 @@ spv_result_t checkLayout(uint32_t struct_id, const char* storage_class_str,
                   << " layout rules: member " << member_idx << " ");
     return ds;
   };
+
   const bool relaxed_block_layout = vstate.IsRelaxedBlockLayout();
   const auto& members = getStructMembers(struct_id, vstate);
 

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -2985,6 +2985,38 @@ TEST_F(ValidateDecorations, UniformBufferArraySizeCalculationPackBad) {
           "offset 60 overlaps previous member ending at offset 63"));
 }
 
+TEST_F(ValidateDecorations, LayoutNotCheckedWhenSkipBlockLayout) {
+  // Checks that block layout is not verified in skipping block layout mode.
+  // Even for obviously wrong layout.
+  string spirv = R"(
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main"
+               OpSource GLSL 450
+               OpMemberDecorate %S 0 Offset 3 ; wrong alignment
+               OpMemberDecorate %S 1 Offset 3 ; same offset as before!
+               OpDecorate %S Block
+               OpDecorate %B DescriptorSet 0
+               OpDecorate %B Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+          %S = OpTypeStruct %float %v3float
+%_ptr_Uniform_S = OpTypePointer Uniform %S
+          %B = OpVariable %_ptr_Uniform_S Uniform
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  CompileSuccessfully(spirv);
+  spvValidatorOptionsSetSkipBlockLayout(getValidatorOptions(), true);
+  EXPECT_EQ(SPV_SUCCESS,
+            ValidateAndRetrieveValidationState(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(), Eq(""));
+}
 }  // namespace
 }  // namespace val
 }  // namespace spvtools

--- a/tools/val/val.cpp
+++ b/tools/val/val.cpp
@@ -46,7 +46,10 @@ Options:
   --max-access-chain-indexes       <maximum number of indexes allowed to use for Access Chain instructions>
   --relax-logical-pointer          Allow allocating an object of a pointer type and returning
                                    a pointer value from a function in logical addressing mode
-  --relax-block-layout             Skips checking of standard uniform/storage buffer layout
+  --relax-block-layout             Enable VK_HR_relaxed_block_layout when checking standard
+                                   uniform/storage buffer layout
+  --skip-block-layout              Skip checking standard uniform/storage buffer layout
+                                   uniform/storage buffer layout
   --relax-struct-store             Allow store from one struct type to a
                                    different type with compatible layout and
                                    members.
@@ -124,6 +127,8 @@ int main(int argc, char** argv) {
         options.SetRelaxLogicalPointer(true);
       } else if (0 == strcmp(cur_arg, "--relax-block-layout")) {
         options.SetRelaxBlockLayout(true);
+      } else if (0 == strcmp(cur_arg, "--skip-block-layout")) {
+        options.SetSkipBlockLayout(true);
       } else if (0 == strcmp(cur_arg, "--relax-struct-store")) {
         options.SetRelaxStructStore(true);
       } else if (0 == cur_arg[1]) {


### PR DESCRIPTION
We need this to avoid emitting errors on DirectX layout rules.