### PR TITLE
Cleanup some pass code to get context directly.

### DIFF
--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -134,7 +134,7 @@ void InlinePass::CloneAndMapLocals(
   auto callee_var_itr = callee_block_itr->begin();
   while (callee_var_itr->opcode() == SpvOp::SpvOpVariable) {
     std::unique_ptr<opt::Instruction> var_inst(
-        callee_var_itr->Clone(callee_var_itr->context()));
+        callee_var_itr->Clone(context()));
     uint32_t newId = TakeNextId();
     get_decoration_mgr()->CloneDecorations(callee_var_itr->result_id(), newId);
     var_inst->SetResultId(newId);
@@ -185,8 +185,7 @@ void InlinePass::CloneSameBlockOps(
           if (mapItr2 != (*preCallSB).end()) {
             // Clone pre-call same-block ops, map result id.
             const opt::Instruction* inInst = mapItr2->second;
-            std::unique_ptr<opt::Instruction> sb_inst(
-                inInst->Clone(inInst->context()));
+            std::unique_ptr<opt::Instruction> sb_inst(inInst->Clone(context()));
             CloneSameBlockOps(&sb_inst, postCallSB, preCallSB, block_ptr);
             const uint32_t rid = sb_inst->result_id();
             const uint32_t nid = this->TakeNextId();

--- a/source/opt/private_to_local_pass.cpp
+++ b/source/opt/private_to_local_pass.cpp
@@ -170,7 +170,7 @@ void PrivateToLocalPass::UpdateUse(opt::Instruction* inst) {
 }
 void PrivateToLocalPass::UpdateUses(uint32_t id) {
   std::vector<opt::Instruction*> uses;
-  this->context()->get_def_use_mgr()->ForEachUser(
+  context()->get_def_use_mgr()->ForEachUser(
       id, [&uses](opt::Instruction* use) { uses.push_back(use); });
 
   for (opt::Instruction* use : uses) {

--- a/source/opt/reduce_load_size.cpp
+++ b/source/opt/reduce_load_size.cpp
@@ -48,9 +48,9 @@ Pass::Status ReduceLoadSize::Process() {
 bool ReduceLoadSize::ReplaceExtract(opt::Instruction* inst) {
   assert(inst->opcode() == SpvOpCompositeExtract &&
          "Wrong opcode.  Should be OpCompositeExtract.");
-  analysis::DefUseManager* def_use_mgr = inst->context()->get_def_use_mgr();
-  analysis::TypeManager* type_mgr = inst->context()->get_type_mgr();
-  analysis::ConstantManager* const_mgr = inst->context()->get_constant_mgr();
+  analysis::DefUseManager* def_use_mgr = context()->get_def_use_mgr();
+  analysis::TypeManager* type_mgr = context()->get_type_mgr();
+  analysis::ConstantManager* const_mgr = context()->get_constant_mgr();
 
   uint32_t composite_id =
       inst->GetSingleWordInOperand(kExtractCompositeIdInIdx);


### PR DESCRIPTION
Instead of going through the instruction we can access the context()
directly from the pass.

Issue #1703