### PR TITLE
Cleanup CFG header.

### DIFF
--- a/source/opt/cfg.cpp
+++ b/source/opt/cfg.cpp
@@ -22,6 +22,8 @@ namespace spvtools {
 namespace opt {
 namespace {
 
+using cbb_ptr = const opt::BasicBlock*;
+
 // Universal Limit of ResultID + 1
 const int kMaxResultId = 0x400000;
 
@@ -308,14 +310,6 @@ BasicBlock* CFG::SplitLoopHeader(opt::BasicBlock* bb) {
     }
   }
   return new_header;
-}
-
-unordered_set<BasicBlock*> CFG::FindReachableBlocks(BasicBlock* start) {
-  std::unordered_set<BasicBlock*> reachable_blocks;
-  ForEachBlockInReversePostOrder(start, [&reachable_blocks](BasicBlock* bb) {
-    reachable_blocks.insert(bb);
-  });
-  return reachable_blocks;
 }
 
 }  // namespace opt

--- a/source/opt/cfg.h
+++ b/source/opt/cfg.h
@@ -27,10 +27,7 @@ namespace opt {
 
 class CFG {
  public:
-  CFG(opt::Module* module);
-
-  // Return the module described by this CFG.
-  opt::Module* get_module() const { return module_; }
+  explicit CFG(opt::Module* module);
 
   // Return the list of predecesors for basic block with label |blkid|.
   // TODO(dnovillo): Move this to opt::BasicBlock.
@@ -132,11 +129,7 @@ class CFG {
   // Returns a pointer to the new loop header.
   BasicBlock* SplitLoopHeader(opt::BasicBlock* bb);
 
-  std::unordered_set<BasicBlock*> FindReachableBlocks(BasicBlock* start);
-
  private:
-  using cbb_ptr = const opt::BasicBlock*;
-
   // Compute structured successors for function |func|. A block's structured
   // successors are the blocks it branches to together with its declared merge
   // block and continue block if it has them. When order matters, the merge


### PR DESCRIPTION
This CL removes some unused methods from CFG, makes the constructor
explicit and moves the using statement to the cpp file where it's used.