### PR TITLE
Fix infinite loop while folding OpVectorShuffle

### DIFF
--- a/source/opt/folding_rules.cpp
+++ b/source/opt/folding_rules.cpp
@@ -2086,7 +2086,12 @@ FoldingRule VectorShuffleFeedingShuffle() {
     }
 
     if (new_feeder_id == 0) {
-      new_feeder_id = inst->GetSingleWordInOperand(feeder_is_op0 ? 1 : 0);
+      analysis::ConstantManager* const_mgr = context->get_constant_mgr();
+      const analysis::Type* type =
+          type_mgr->GetType(feeding_shuffle_inst->type_id());
+      const analysis::Constant* null_const = const_mgr->GetConstant(type, {});
+      new_feeder_id =
+          const_mgr->GetDefiningInstruction(null_const, 0)->result_id();
     }
 
     if (feeder_is_op0) {

--- a/test/opt/fold_test.cpp
+++ b/test/opt/fold_test.cpp
@@ -5728,26 +5728,7 @@ INSTANTIATE_TEST_CASE_P(VectorShuffleMatchingTest, MatchingInstructionWithNoResu
             "OpReturn\n" +
             "OpFunctionEnd",
         9, true),
-    // Test case 4: Don't use feeder.
-    InstructionFoldingCase<bool>(
-        Header() +
-            "; CHECK: OpVectorShuffle\n" +
-            "; CHECK: OpVectorShuffle {{%\\w+}} %7 %7 2 3 0 1\n" +
-            "; CHECK: OpReturn\n" +
-            "%main = OpFunction %void None %void_func\n" +
-            "%main_lab = OpLabel\n" +
-            "%2 = OpVariable %_ptr_v4double Function\n" +
-            "%3 = OpVariable %_ptr_v4double Function\n" +
-            "%4 = OpVariable %_ptr_v4double Function\n" +
-            "%5 = OpLoad %v4double %2\n" +
-            "%6 = OpLoad %v4double %3\n" +
-            "%7 = OpLoad %v4double %4\n" +
-            "%8 = OpVectorShuffle %v4double %5 %6 2 3 4 5\n" +
-            "%9 = OpVectorShuffle %v4double %7 %8 2 3 0 1\n" +
-            "OpReturn\n" +
-            "OpFunctionEnd",
-        9, true),
-    // Test case 5: Don't fold, need both operands of the feeder.
+    // Test case 4: Don't fold, need both operands of the feeder.
     InstructionFoldingCase<bool>(
         Header() +
             "%main = OpFunction %void None %void_func\n" +
@@ -5763,7 +5744,7 @@ INSTANTIATE_TEST_CASE_P(VectorShuffleMatchingTest, MatchingInstructionWithNoResu
             "OpReturn\n" +
             "OpFunctionEnd",
         9, false),
-    // Test case 6: Don't fold, need both operands of the feeder.
+    // Test case 5: Don't fold, need both operands of the feeder.
     InstructionFoldingCase<bool>(
         Header() +
             "%main = OpFunction %void None %void_func\n" +
@@ -5779,7 +5760,7 @@ INSTANTIATE_TEST_CASE_P(VectorShuffleMatchingTest, MatchingInstructionWithNoResu
             "OpReturn\n" +
             "OpFunctionEnd",
         9, false),
-    // Test case 7: Fold, need both operands of the feeder, but they are the same.
+    // Test case 6: Fold, need both operands of the feeder, but they are the same.
     InstructionFoldingCase<bool>(
         Header() +
             "; CHECK: OpVectorShuffle\n" +
@@ -5798,7 +5779,7 @@ INSTANTIATE_TEST_CASE_P(VectorShuffleMatchingTest, MatchingInstructionWithNoResu
             "OpReturn\n" +
             "OpFunctionEnd",
         9, true),
-    // Test case 8: Fold, need both operands of the feeder, but they are the same.
+    // Test case 7: Fold, need both operands of the feeder, but they are the same.
     InstructionFoldingCase<bool>(
         Header() +
             "; CHECK: OpVectorShuffle\n" +
@@ -5817,7 +5798,7 @@ INSTANTIATE_TEST_CASE_P(VectorShuffleMatchingTest, MatchingInstructionWithNoResu
             "OpReturn\n" +
             "OpFunctionEnd",
         9, true),
-    // Test case 9: Replace first operand with a smaller vector.
+    // Test case 8: Replace first operand with a smaller vector.
     InstructionFoldingCase<bool>(
         Header() +
             "; CHECK: OpVectorShuffle\n" +
@@ -5836,7 +5817,7 @@ INSTANTIATE_TEST_CASE_P(VectorShuffleMatchingTest, MatchingInstructionWithNoResu
             "OpReturn\n" +
             "OpFunctionEnd",
         9, true),
-    // Test case 10: Replace first operand with a larger vector.
+    // Test case 9: Replace first operand with a larger vector.
     InstructionFoldingCase<bool>(
         Header() +
             "; CHECK: OpVectorShuffle\n" +
@@ -5852,6 +5833,70 @@ INSTANTIATE_TEST_CASE_P(VectorShuffleMatchingTest, MatchingInstructionWithNoResu
             "%7 = OpLoad %v4double %4\n" +
             "%8 = OpVectorShuffle %v2double %5 %5 0 3\n" +
             "%9 = OpVectorShuffle %v4double %8 %7 1 0 5 3\n" +
+            "OpReturn\n" +
+            "OpFunctionEnd",
+        9, true),
+    // Test case 10: Replace unused operand with null.
+    InstructionFoldingCase<bool>(
+        Header() +
+            "; CHECK: [[double:%\\w+]] = OpTypeFloat 64\n" +
+            "; CHECK: [[v4double:%\\w+]] = OpTypeVector [[double]] 2\n" +
+            "; CHECK: [[null:%\\w+]] = OpConstantNull [[v4double]]\n" +
+            "; CHECK: OpVectorShuffle\n" +
+            "; CHECK: OpVectorShuffle {{%\\w+}} [[null]] %7 4 2 5 3\n" +
+            "; CHECK: OpReturn\n" +
+            "%main = OpFunction %void None %void_func\n" +
+            "%main_lab = OpLabel\n" +
+            "%2 = OpVariable %_ptr_v4double Function\n" +
+            "%3 = OpVariable %_ptr_v4double Function\n" +
+            "%4 = OpVariable %_ptr_v4double Function\n" +
+            "%5 = OpLoad %v4double %2\n" +
+            "%6 = OpLoad %v4double %3\n" +
+            "%7 = OpLoad %v4double %4\n" +
+            "%8 = OpVectorShuffle %v2double %5 %5 0 3\n" +
+            "%9 = OpVectorShuffle %v4double %8 %7 4 2 5 3\n" +
+            "OpReturn\n" +
+            "OpFunctionEnd",
+        9, true),
+    // Test case 11: Replace unused operand with null.
+    InstructionFoldingCase<bool>(
+        Header() +
+            "; CHECK: [[double:%\\w+]] = OpTypeFloat 64\n" +
+            "; CHECK: [[v4double:%\\w+]] = OpTypeVector [[double]] 2\n" +
+            "; CHECK: [[null:%\\w+]] = OpConstantNull [[v4double]]\n" +
+            "; CHECK: OpVectorShuffle\n" +
+            "; CHECK: OpVectorShuffle {{%\\w+}} [[null]] %5 2 2 5 5\n" +
+            "; CHECK: OpReturn\n" +
+            "%main = OpFunction %void None %void_func\n" +
+            "%main_lab = OpLabel\n" +
+            "%2 = OpVariable %_ptr_v4double Function\n" +
+            "%3 = OpVariable %_ptr_v4double Function\n" +
+            "%5 = OpLoad %v4double %2\n" +
+            "%6 = OpLoad %v4double %3\n" +
+            "%8 = OpVectorShuffle %v2double %5 %5 0 3\n" +
+            "%9 = OpVectorShuffle %v4double %8 %8 2 2 3 3\n" +
+            "OpReturn\n" +
+            "OpFunctionEnd",
+        9, true),
+    // Test case 12: Replace unused operand with null.
+    InstructionFoldingCase<bool>(
+        Header() +
+            "; CHECK: [[double:%\\w+]] = OpTypeFloat 64\n" +
+            "; CHECK: [[v4double:%\\w+]] = OpTypeVector [[double]] 2\n" +
+            "; CHECK: [[null:%\\w+]] = OpConstantNull [[v4double]]\n" +
+            "; CHECK: OpVectorShuffle\n" +
+            "; CHECK: OpVectorShuffle {{%\\w+}} %7 [[null]] 2 0 1 3\n" +
+            "; CHECK: OpReturn\n" +
+            "%main = OpFunction %void None %void_func\n" +
+            "%main_lab = OpLabel\n" +
+            "%2 = OpVariable %_ptr_v4double Function\n" +
+            "%3 = OpVariable %_ptr_v4double Function\n" +
+            "%4 = OpVariable %_ptr_v4double Function\n" +
+            "%5 = OpLoad %v4double %2\n" +
+            "%6 = OpLoad %v4double %3\n" +
+            "%7 = OpLoad %v4double %4\n" +
+            "%8 = OpVectorShuffle %v2double %5 %5 0 3\n" +
+            "%9 = OpVectorShuffle %v4double %7 %8 2 0 1 3\n" +
             "OpReturn\n" +
             "OpFunctionEnd",
         9, true)


### PR DESCRIPTION
When folding an OpVectorShuffle where the first operand is defined by
an OpVectorShuffle, is unused, and is equal to the second, we end up
with an infinite loop.  This is because we think we change the
instruction, but it does not actually change.  So we keep trying to
folding the same instruction.

This commit fixes up that specific issue.  When the operand is unused,
we replace it with Null.