### PR TITLE
Fixup line number for OpVectorShuffle ID error.

### DIFF
--- a/source/val/validate_id.cpp
+++ b/source/val/validate_id.cpp
@@ -1781,9 +1781,12 @@ bool idUsage::isValid<SpvOpVectorShuffle>(const spv_instruction_t* inst,
   for (size_t i = firstLiteralIndex; i < inst->words.size(); ++i) {
     auto literal = inst->words[i];
     if (literal != 0xFFFFFFFF && literal >= N) {
-      DIAG(module_.FindDef(inst->words[0]))
-          << "Component literal value " << literal << " is greater than "
-          << N - 1 << ".";
+      // TODO(dsinclair): This should provide the line number of the
+      // OpVectorShuffle but need the spv_instruction_t to be an Instruction
+      // in order to provide that value.
+      DIAG(module_.FindDef(inst->words[1]))
+          << "Component index " << literal << " is out of range for a result "
+          << "vector of size " << N << ".";
       return false;
     }
   }

--- a/source/val/validate_id.cpp
+++ b/source/val/validate_id.cpp
@@ -1781,10 +1781,7 @@ bool idUsage::isValid<SpvOpVectorShuffle>(const spv_instruction_t* inst,
   for (size_t i = firstLiteralIndex; i < inst->words.size(); ++i) {
     auto literal = inst->words[i];
     if (literal != 0xFFFFFFFF && literal >= N) {
-      // TODO(dsinclair): This should provide the line number of the
-      // OpVectorShuffle but need the spv_instruction_t to be an Instruction
-      // in order to provide that value.
-      DIAG(module_.FindDef(inst->words[1]))
+      DIAG(module_.FindDef(inst->words[2]))
           << "Component index " << literal << " is out of range for a result "
           << "vector of size " << N << ".";
       return false;

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -3848,8 +3848,10 @@ TEST_F(ValidateIdWithMessage, OpVectorShuffleLiterals) {
      OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Component index 5 is out of range for a result vector of size 5."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(
+          "Component index 5 is out of range for a result vector of size 5."));
 }
 
 // TODO: OpCompositeConstruct
@@ -4727,7 +4729,8 @@ TEST_F(ValidateIdWithMessage, CorrectErrorForShuffle) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Component index 4 is out of range for a result vector of size 4."));
+      HasSubstr(
+          "Component index 4 is out of range for a result vector of size 4."));
 
   // TODO(dsinclair): This should be index 23 ...
   EXPECT_EQ(15, getErrorPosition().index);

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -4731,9 +4731,7 @@ TEST_F(ValidateIdWithMessage, CorrectErrorForShuffle) {
       getDiagnosticString(),
       HasSubstr(
           "Component index 4 is out of range for a result vector of size 4."));
-
-  // TODO(dsinclair): This should be index 23 ...
-  EXPECT_EQ(15, getErrorPosition().index);
+  EXPECT_EQ(23, getErrorPosition().index);
 }
 
 // TODO: OpLifetimeStart


### PR DESCRIPTION
This CL updates the code to pull a valid instruction for the line number
when outputting a component error in OpVectorShuffle. The error line
isn't the best at this point as it points at the component, but it's
better then a -1 (turning to max<size_t>) that was being output.

The error messages has been updated to better reflect what the error is
attempting to say.

Issue #1719.