### PR TITLE
Fix block ordering in dead branch elim

### DIFF
--- a/source/cfa.h
+++ b/source/cfa.h
@@ -246,21 +246,20 @@ vector<pair<BB*, BB*>> CFA<BB>::CalculateDominators(
   }
 
   // Sort by postorder index to generate a deterministic ordering of edges.
-  std::sort(out.begin(), out.end(),
-            [&idoms](const pair<bb_ptr, bb_ptr>& lhs,
-                     const pair<bb_ptr, bb_ptr>& rhs) {
-              assert(lhs.first);
-              assert(lhs.second);
-              assert(rhs.first);
-              assert(rhs.second);
-              auto lhs_first_index = idoms[lhs.first].postorder_index;
-              auto lhs_second_index = idoms[lhs.second].postorder_index;
-              auto rhs_first_index = idoms[rhs.first].postorder_index;
-              auto rhs_second_index = idoms[rhs.second].postorder_index;
-              if (lhs_first_index < rhs_first_index) return true;
-              if (rhs_first_index < lhs_first_index) return false;
-              return lhs_second_index < rhs_second_index;
-            });
+  std::sort(
+      out.begin(), out.end(),
+      [&idoms](const pair<bb_ptr, bb_ptr>& lhs,
+               const pair<bb_ptr, bb_ptr>& rhs) {
+        assert(lhs.first);
+        assert(lhs.second);
+        assert(rhs.first);
+        assert(rhs.second);
+        auto lhs_indices = std::make_pair(idoms[lhs.first].postorder_index,
+                                          idoms[lhs.second].postorder_index);
+        auto rhs_indices = std::make_pair(idoms[rhs.first].postorder_index,
+                                          idoms[rhs.second].postorder_index);
+        return lhs_indices < rhs_indices;
+      });
   return out;
 }
 

--- a/source/cfa.h
+++ b/source/cfa.h
@@ -244,6 +244,23 @@ vector<pair<BB*, BB*>> CFA<BB>::CalculateDominators(
     out.push_back({const_cast<BB*>(get<0>(idom)),
                    const_cast<BB*>(postorder[get<1>(idom).dominator])});
   }
+
+  // Sort by postorder index to generate a deterministic ordering of edges.
+  std::sort(out.begin(), out.end(),
+            [&idoms](const pair<bb_ptr, bb_ptr>& lhs,
+                     const pair<bb_ptr, bb_ptr>& rhs) {
+              assert(lhs.first);
+              assert(lhs.second);
+              assert(rhs.first);
+              assert(rhs.second);
+              auto lhs_first_index = idoms[lhs.first].postorder_index;
+              auto lhs_second_index = idoms[lhs.second].postorder_index;
+              auto rhs_first_index = idoms[rhs.first].postorder_index;
+              auto rhs_second_index = idoms[rhs.second].postorder_index;
+              if (lhs_first_index < rhs_first_index) return true;
+              if (rhs_first_index < lhs_first_index) return false;
+              return lhs_second_index < rhs_second_index;
+            });
   return out;
 }
 

--- a/source/opt/dead_branch_elim_pass.h
+++ b/source/opt/dead_branch_elim_pass.h
@@ -125,6 +125,10 @@ class DeadBranchElimPass : public MemPass {
       const std::unordered_set<BasicBlock*>& unreachable_merges,
       const std::unordered_map<BasicBlock*, BasicBlock*>&
           unreachable_continues);
+
+  // Reorders blocks in reachable functions so that they satisfy dominator
+  // block ordering rules.
+  void FixBlockOrder();
 };
 
 }  // namespace opt


### PR DESCRIPTION
Fixes #1727

* If the pass finds any dead branches it can optimize then at the end of
the pass it reorders basic blocks to ensure they satisfy block ordering
requirements
 * Added some new tests
* While investigating this issue, found and fixed a non-deterministic
ordering of dominators
 * Now the edges used to construct the dominator tree are sorted
 according to posorder traversal indices

Note: including multiple ordering functions limited the number of test updates required and kept disassembly reading more naturally.