### PR TITLE
Update error messages in validate_composites.

### DIFF
--- a/source/val/validate_composites.cpp
+++ b/source/val/validate_composites.cpp
@@ -209,8 +209,8 @@ spv_result_t ValidateCompositeConstruct(ValidationState_t& _,
           if (_.GetIdOpcode(operand_type) != SpvOpTypeVector ||
               _.GetComponentType(operand_type) != result_component_type) {
             return _.diag(SPV_ERROR_INVALID_DATA)
-                   << "Expected Constituents to be scalars or vectors of "
-                   << "the same type as Result Type components";
+                   << "Expected Constituents to be scalars or vectors of"
+                   << " the same type as Result Type components";
           }
 
           given_component_count += _.GetDimension(operand_type);

--- a/source/val/validate_composites.cpp
+++ b/source/val/validate_composites.cpp
@@ -52,8 +52,7 @@ spv_result_t GetExtractInsertValueType(ValidationState_t& _,
   *member_type = _.GetTypeId(inst->word(composite_id_index));
   if (*member_type == 0) {
     return _.diag(SPV_ERROR_INVALID_DATA)
-           << spvOpcodeString(opcode)
-           << ": expected Composite to be an object of composite type";
+           << "Expected Composite to be an object of composite type";
   }
 
   for (; word_index < num_words; ++word_index) {
@@ -66,8 +65,7 @@ spv_result_t GetExtractInsertValueType(ValidationState_t& _,
         const uint32_t vector_size = type_inst->word(3);
         if (component_index >= vector_size) {
           return _.diag(SPV_ERROR_INVALID_DATA)
-                 << spvOpcodeString(opcode)
-                 << ": vector access is out of bounds, vector size is "
+                 << "Vector access is out of bounds, vector size is "
                  << vector_size << ", but access index is " << component_index;
         }
         break;
@@ -77,8 +75,7 @@ spv_result_t GetExtractInsertValueType(ValidationState_t& _,
         const uint32_t num_cols = type_inst->word(3);
         if (component_index >= num_cols) {
           return _.diag(SPV_ERROR_INVALID_DATA)
-                 << spvOpcodeString(opcode)
-                 << ": matrix access is out of bounds, matrix has " << num_cols
+                 << "Matrix access is out of bounds, matrix has " << num_cols
                  << " columns, but access index is " << component_index;
         }
         break;
@@ -97,8 +94,7 @@ spv_result_t GetExtractInsertValueType(ValidationState_t& _,
         }
         if (component_index >= array_size) {
           return _.diag(SPV_ERROR_INVALID_DATA)
-                 << spvOpcodeString(opcode)
-                 << ": array access is out of bounds, array size is "
+                 << "Array access is out of bounds, array size is "
                  << array_size << ", but access index is " << component_index;
         }
         break;
@@ -112,11 +108,10 @@ spv_result_t GetExtractInsertValueType(ValidationState_t& _,
         const size_t num_struct_members = type_inst->words().size() - 2;
         if (component_index >= num_struct_members) {
           return _.diag(SPV_ERROR_INVALID_DATA)
-                 << "Index is out of bounds: Op" << spvOpcodeString(opcode)
-                 << " can not find index " << component_index
-                 << " into the structure <id> '" << type_inst->id()
-                 << "'. This structure has " << num_struct_members
-                 << " members. Largest valid index is "
+                 << "Index is out of bounds, can not find index "
+                 << component_index << " in the structure <id> '"
+                 << type_inst->id() << "'. This structure has "
+                 << num_struct_members << " members. Largest valid index is "
                  << num_struct_members - 1 << ".";
         }
         *member_type = type_inst->word(component_index + 2);
@@ -124,8 +119,7 @@ spv_result_t GetExtractInsertValueType(ValidationState_t& _,
       }
       default:
         return _.diag(SPV_ERROR_INVALID_DATA)
-               << "Op" << spvOpcodeString(opcode)
-               << " reached non-composite type while indexes still remain to "
+               << "Reached non-composite type while indexes still remain to "
                   "be traversed.";
     }
   }
@@ -135,74 +129,63 @@ spv_result_t GetExtractInsertValueType(ValidationState_t& _,
 
 spv_result_t ValidateVectorExtractDynamic(ValidationState_t& _,
                                           const Instruction* inst) {
-  const SpvOp opcode = inst->opcode();
   const uint32_t result_type = inst->type_id();
   const SpvOp result_opcode = _.GetIdOpcode(result_type);
   if (!spvOpcodeIsScalarType(result_opcode)) {
     return _.diag(SPV_ERROR_INVALID_DATA)
-           << spvOpcodeString(opcode)
-           << ": expected Result Type to be a scalar type";
+           << "Expected Result Type to be a scalar type";
   }
 
   const uint32_t vector_type = _.GetOperandTypeId(inst, 2);
   const SpvOp vector_opcode = _.GetIdOpcode(vector_type);
   if (vector_opcode != SpvOpTypeVector) {
     return _.diag(SPV_ERROR_INVALID_DATA)
-           << spvOpcodeString(opcode)
-           << ": expected Vector type to be OpTypeVector";
+           << "Expected Vector type to be OpTypeVector";
   }
 
   if (_.GetComponentType(vector_type) != result_type) {
     return _.diag(SPV_ERROR_INVALID_DATA)
-           << spvOpcodeString(opcode)
-           << ": expected Vector component type to be equal to Result Type";
+           << "Expected Vector component type to be equal to Result Type";
   }
 
   const uint32_t index_type = _.GetOperandTypeId(inst, 3);
   if (!_.IsIntScalarType(index_type)) {
-    return _.diag(SPV_ERROR_INVALID_DATA)
-           << spvOpcodeString(opcode) << ": expected Index to be int scalar";
+    return _.diag(SPV_ERROR_INVALID_DATA) << "Expected Index to be int scalar";
   }
   return SPV_SUCCESS;
 }
 
 spv_result_t ValidateVectorInsertDyanmic(ValidationState_t& _,
                                          const Instruction* inst) {
-  const SpvOp opcode = inst->opcode();
   const uint32_t result_type = inst->type_id();
   const SpvOp result_opcode = _.GetIdOpcode(result_type);
   if (result_opcode != SpvOpTypeVector) {
     return _.diag(SPV_ERROR_INVALID_DATA)
-           << spvOpcodeString(opcode)
-           << ": expected Result Type to be OpTypeVector";
+           << "Expected Result Type to be OpTypeVector";
   }
 
   const uint32_t vector_type = _.GetOperandTypeId(inst, 2);
   if (vector_type != result_type) {
     return _.diag(SPV_ERROR_INVALID_DATA)
-           << spvOpcodeString(opcode)
-           << ": expected Vector type to be equal to Result Type";
+           << "Expected Vector type to be equal to Result Type";
   }
 
   const uint32_t component_type = _.GetOperandTypeId(inst, 3);
   if (_.GetComponentType(result_type) != component_type) {
     return _.diag(SPV_ERROR_INVALID_DATA)
-           << spvOpcodeString(opcode)
-           << ": expected Component type to be equal to Result Type "
+           << "Expected Component type to be equal to Result Type "
            << "component type";
   }
 
   const uint32_t index_type = _.GetOperandTypeId(inst, 4);
   if (!_.IsIntScalarType(index_type)) {
-    return _.diag(SPV_ERROR_INVALID_DATA)
-           << spvOpcodeString(opcode) << ": expected Index to be int scalar";
+    return _.diag(SPV_ERROR_INVALID_DATA) << "Expected Index to be int scalar";
   }
   return SPV_SUCCESS;
 }
 
 spv_result_t ValidateCompositeConstruct(ValidationState_t& _,
                                         const Instruction* inst) {
-  const SpvOp opcode = inst->opcode();
   const uint32_t num_operands = static_cast<uint32_t>(inst->operands().size());
   const uint32_t result_type = inst->type_id();
   const SpvOp result_opcode = _.GetIdOpcode(result_type);
@@ -214,8 +197,7 @@ spv_result_t ValidateCompositeConstruct(ValidationState_t& _,
 
       if (num_operands <= 3) {
         return _.diag(SPV_ERROR_INVALID_DATA)
-               << spvOpcodeString(opcode)
-               << ": expected number of constituents to be at least 2";
+               << "Expected number of constituents to be at least 2";
       }
 
       for (uint32_t operand_index = 2; operand_index < num_operands;
@@ -227,8 +209,7 @@ spv_result_t ValidateCompositeConstruct(ValidationState_t& _,
           if (_.GetIdOpcode(operand_type) != SpvOpTypeVector ||
               _.GetComponentType(operand_type) != result_component_type) {
             return _.diag(SPV_ERROR_INVALID_DATA)
-                   << spvOpcodeString(opcode)
-                   << ": expected Constituents to be scalars or vectors of "
+                   << "Expected Constituents to be scalars or vectors of "
                    << "the same type as Result Type components";
           }
 
@@ -238,8 +219,7 @@ spv_result_t ValidateCompositeConstruct(ValidationState_t& _,
 
       if (num_result_components != given_component_count) {
         return _.diag(SPV_ERROR_INVALID_DATA)
-               << spvOpcodeString(opcode)
-               << ": expected total number of given components to be equal "
+               << "Expected total number of given components to be equal "
                << "to the size of Result Type vector";
       }
 
@@ -257,8 +237,7 @@ spv_result_t ValidateCompositeConstruct(ValidationState_t& _,
 
       if (result_num_cols + 2 != num_operands) {
         return _.diag(SPV_ERROR_INVALID_DATA)
-               << spvOpcodeString(opcode)
-               << ": expected total number of Constituents to be equal "
+               << "Expected total number of Constituents to be equal "
                << "to the number of columns of Result Type matrix";
       }
 
@@ -267,8 +246,7 @@ spv_result_t ValidateCompositeConstruct(ValidationState_t& _,
         const uint32_t operand_type = _.GetOperandTypeId(inst, operand_index);
         if (operand_type != result_col_type) {
           return _.diag(SPV_ERROR_INVALID_DATA)
-                 << spvOpcodeString(opcode)
-                 << ": expected Constituent type to be equal to the column "
+                 << "Expected Constituent type to be equal to the column "
                  << "type Result Type matrix";
         }
       }
@@ -293,8 +271,7 @@ spv_result_t ValidateCompositeConstruct(ValidationState_t& _,
 
       if (array_size + 2 != num_operands) {
         return _.diag(SPV_ERROR_INVALID_DATA)
-               << spvOpcodeString(opcode)
-               << ": expected total number of Constituents to be equal "
+               << "Expected total number of Constituents to be equal "
                << "to the number of elements of Result Type array";
       }
 
@@ -304,8 +281,7 @@ spv_result_t ValidateCompositeConstruct(ValidationState_t& _,
         const uint32_t operand_type = _.GetOperandTypeId(inst, operand_index);
         if (operand_type != result_component_type) {
           return _.diag(SPV_ERROR_INVALID_DATA)
-                 << spvOpcodeString(opcode)
-                 << ": expected Constituent type to be equal to the column "
+                 << "Expected Constituent type to be equal to the column "
                  << "type Result Type array";
         }
       }
@@ -319,8 +295,7 @@ spv_result_t ValidateCompositeConstruct(ValidationState_t& _,
 
       if (struct_inst->operands().size() + 1 != num_operands) {
         return _.diag(SPV_ERROR_INVALID_DATA)
-               << spvOpcodeString(opcode)
-               << ": expected total number of Constituents to be equal "
+               << "Expected total number of Constituents to be equal "
                << "to the number of members of Result Type struct";
       }
 
@@ -330,8 +305,7 @@ spv_result_t ValidateCompositeConstruct(ValidationState_t& _,
         const uint32_t member_type = struct_inst->word(operand_index);
         if (operand_type != member_type) {
           return _.diag(SPV_ERROR_INVALID_DATA)
-                 << spvOpcodeString(opcode)
-                 << ": expected Constituent type to be equal to the "
+                 << "Expected Constituent type to be equal to the "
                  << "corresponding member type of Result Type struct";
         }
       }
@@ -340,8 +314,7 @@ spv_result_t ValidateCompositeConstruct(ValidationState_t& _,
     }
     default: {
       return _.diag(SPV_ERROR_INVALID_DATA)
-             << spvOpcodeString(opcode)
-             << ": expected Result Type to be a composite type";
+             << "Expected Result Type to be a composite type";
     }
   }
   return SPV_SUCCESS;
@@ -357,11 +330,9 @@ spv_result_t ValidateCompositeExtract(ValidationState_t& _,
   const uint32_t result_type = inst->type_id();
   if (result_type != member_type) {
     return _.diag(SPV_ERROR_INVALID_DATA)
-           << "Op" << spvOpcodeString(inst->opcode()) << " result type (Op"
-           << spvOpcodeString(_.GetIdOpcode(result_type))
+           << "Result type (Op" << spvOpcodeString(_.GetIdOpcode(result_type))
            << ") does not match the type that results from indexing into "
-              "the "
-              "composite (Op"
+              "the composite (Op"
            << spvOpcodeString(_.GetIdOpcode(member_type)) << ").";
   }
   return SPV_SUCCESS;
@@ -388,34 +359,30 @@ spv_result_t ValidateCompositeInsert(ValidationState_t& _,
   if (object_type != member_type) {
     return _.diag(SPV_ERROR_INVALID_DATA)
            << "The Object type (Op"
-           << spvOpcodeString(_.GetIdOpcode(object_type)) << ") in Op"
-           << spvOpcodeString(opcode)
-           << " does not match the type that results from indexing into "
-              "the Composite (Op"
+           << spvOpcodeString(_.GetIdOpcode(object_type))
+           << ") does not match the type that results from indexing into the "
+              "Composite (Op"
            << spvOpcodeString(_.GetIdOpcode(member_type)) << ").";
   }
   return SPV_SUCCESS;
 }
 
 spv_result_t ValidateCopyObject(ValidationState_t& _, const Instruction* inst) {
-  const SpvOp opcode = inst->opcode();
   const uint32_t result_type = inst->type_id();
   if (!spvOpcodeGeneratesType(_.GetIdOpcode(result_type))) {
     return _.diag(SPV_ERROR_INVALID_DATA)
-           << spvOpcodeString(opcode) << ": expected Result Type to be a type";
+           << "Expected Result Type to be a type";
   }
 
   const uint32_t operand_type = _.GetOperandTypeId(inst, 2);
   if (operand_type != result_type) {
     return _.diag(SPV_ERROR_INVALID_DATA)
-           << spvOpcodeString(opcode)
-           << ": expected Result Type and Operand type to be the same";
+           << "Expected Result Type and Operand type to be the same";
   }
   return SPV_SUCCESS;
 }
 
 spv_result_t ValidateTranspose(ValidationState_t& _, const Instruction* inst) {
-  const SpvOp opcode = inst->opcode();
   uint32_t result_num_rows = 0;
   uint32_t result_num_cols = 0;
   uint32_t result_col_type = 0;
@@ -424,8 +391,7 @@ spv_result_t ValidateTranspose(ValidationState_t& _, const Instruction* inst) {
   if (!_.GetMatrixTypeInfo(result_type, &result_num_rows, &result_num_cols,
                            &result_col_type, &result_component_type)) {
     return _.diag(SPV_ERROR_INVALID_DATA)
-           << spvOpcodeString(opcode)
-           << ": expected Result Type to be a matrix type";
+           << "Expected Result Type to be a matrix type";
   }
 
   const uint32_t matrix_type = _.GetOperandTypeId(inst, 2);
@@ -436,22 +402,19 @@ spv_result_t ValidateTranspose(ValidationState_t& _, const Instruction* inst) {
   if (!_.GetMatrixTypeInfo(matrix_type, &matrix_num_rows, &matrix_num_cols,
                            &matrix_col_type, &matrix_component_type)) {
     return _.diag(SPV_ERROR_INVALID_DATA)
-           << spvOpcodeString(opcode)
-           << ": expected Matrix to be of type OpTypeMatrix";
+           << "Expected Matrix to be of type OpTypeMatrix";
   }
 
   if (result_component_type != matrix_component_type) {
     return _.diag(SPV_ERROR_INVALID_DATA)
-           << spvOpcodeString(opcode)
-           << ": expected component types of Matrix and Result Type to be "
+           << "Expected component types of Matrix and Result Type to be "
            << "identical";
   }
 
   if (result_num_rows != matrix_num_cols ||
       result_num_cols != matrix_num_rows) {
     return _.diag(SPV_ERROR_INVALID_DATA)
-           << spvOpcodeString(opcode)
-           << ": expected number of columns and the column size of Matrix "
+           << "Expected number of columns and the column size of Matrix "
            << "to be the reverse of those of Result Type";
   }
   return SPV_SUCCESS;

--- a/test/val/val_composites_test.cpp
+++ b/test/val/val_composites_test.cpp
@@ -187,8 +187,7 @@ TEST_F(ValidateComposites, VectorExtractDynamicWrongResultType) {
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("VectorExtractDynamic: "
-                        "expected Result Type to be a scalar type"));
+              HasSubstr("Expected Result Type to be a scalar type"));
 }
 
 TEST_F(ValidateComposites, VectorExtractDynamicNotVector) {
@@ -199,8 +198,7 @@ TEST_F(ValidateComposites, VectorExtractDynamicNotVector) {
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("VectorExtractDynamic: "
-                        "expected Vector type to be OpTypeVector"));
+              HasSubstr("Expected Vector type to be OpTypeVector"));
 }
 
 TEST_F(ValidateComposites, VectorExtractDynamicWrongVectorComponent) {
@@ -212,8 +210,7 @@ TEST_F(ValidateComposites, VectorExtractDynamicWrongVectorComponent) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("VectorExtractDynamic: "
-                "expected Vector component type to be equal to Result Type"));
+      HasSubstr("Expected Vector component type to be equal to Result Type"));
 }
 
 TEST_F(ValidateComposites, VectorExtractDynamicWrongIndexType) {
@@ -224,8 +221,7 @@ TEST_F(ValidateComposites, VectorExtractDynamicWrongIndexType) {
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("VectorExtractDynamic: "
-                        "expected Index to be int scalar"));
+              HasSubstr("Expected Index to be int scalar"));
 }
 
 TEST_F(ValidateComposites, VectorInsertDynamicSuccess) {
@@ -245,8 +241,7 @@ TEST_F(ValidateComposites, VectorInsertDynamicWrongResultType) {
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("VectorInsertDynamic: "
-                        "expected Result Type to be OpTypeVector"));
+              HasSubstr("Expected Result Type to be OpTypeVector"));
 }
 
 TEST_F(ValidateComposites, VectorInsertDynamicNotVector) {
@@ -257,8 +252,7 @@ TEST_F(ValidateComposites, VectorInsertDynamicNotVector) {
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("VectorInsertDynamic: "
-                        "expected Vector type to be equal to Result Type"));
+              HasSubstr("Expected Vector type to be equal to Result Type"));
 }
 
 TEST_F(ValidateComposites, VectorInsertDynamicWrongComponentType) {
@@ -269,8 +263,7 @@ TEST_F(ValidateComposites, VectorInsertDynamicWrongComponentType) {
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("VectorInsertDynamic: "
-                        "expected Component type to be equal to Result Type "
+              HasSubstr("Expected Component type to be equal to Result Type "
                         "component type"));
 }
 
@@ -282,8 +275,7 @@ TEST_F(ValidateComposites, VectorInsertDynamicWrongIndexType) {
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("VectorInsertDynamic: "
-                        "expected Index to be int scalar"));
+              HasSubstr("Expected Index to be int scalar"));
 }
 
 TEST_F(ValidateComposites, CompositeConstructNotComposite) {
@@ -294,8 +286,7 @@ TEST_F(ValidateComposites, CompositeConstructNotComposite) {
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("CompositeConstruct: "
-                        "expected Result Type to be a composite type"));
+              HasSubstr("Expected Result Type to be a composite type"));
 }
 
 TEST_F(ValidateComposites, CompositeConstructVectorSuccess) {
@@ -318,8 +309,7 @@ TEST_F(ValidateComposites, CompositeConstructVectorOnlyOneConstituent) {
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("CompositeConstruct: "
-                        "expected number of constituents to be at least 2"));
+              HasSubstr("Expected number of constituents to be at least 2"));
 }
 
 TEST_F(ValidateComposites, CompositeConstructVectorWrongConsituent1) {
@@ -331,8 +321,7 @@ TEST_F(ValidateComposites, CompositeConstructVectorWrongConsituent1) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("CompositeConstruct: "
-                "expected Constituents to be scalars or vectors of the same "
+      HasSubstr("Expected Constituents to be scalars or vectors of the same "
                 "type as Result Type components"));
 }
 
@@ -345,8 +334,7 @@ TEST_F(ValidateComposites, CompositeConstructVectorWrongConsituent2) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("CompositeConstruct: "
-                "expected Constituents to be scalars or vectors of the same "
+      HasSubstr("Expected Constituents to be scalars or vectors of the same "
                 "type as Result Type components"));
 }
 
@@ -359,8 +347,7 @@ TEST_F(ValidateComposites, CompositeConstructVectorWrongConsituent3) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("CompositeConstruct: "
-                "expected Constituents to be scalars or vectors of the same "
+      HasSubstr("Expected Constituents to be scalars or vectors of the same "
                 "type as Result Type components"));
 }
 
@@ -373,8 +360,7 @@ TEST_F(ValidateComposites, CompositeConstructVectorWrongComponentNumber1) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("CompositeConstruct: "
-                "expected total number of given components to be equal to the "
+      HasSubstr("Expected total number of given components to be equal to the "
                 "size of Result Type vector"));
 }
 
@@ -387,8 +373,7 @@ TEST_F(ValidateComposites, CompositeConstructVectorWrongComponentNumber2) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("CompositeConstruct: "
-                "expected total number of given components to be equal to the "
+      HasSubstr("Expected total number of given components to be equal to the "
                 "size of Result Type vector"));
 }
 
@@ -411,8 +396,7 @@ TEST_F(ValidateComposites, CompositeConstructVectorWrongConsituentNumber1) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("CompositeConstruct: "
-                "expected total number of Constituents to be equal to the "
+      HasSubstr("Expected total number of Constituents to be equal to the "
                 "number of columns of Result Type matrix"));
 }
 
@@ -425,8 +409,7 @@ TEST_F(ValidateComposites, CompositeConstructVectorWrongConsituentNumber2) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("CompositeConstruct: "
-                "expected total number of Constituents to be equal to the "
+      HasSubstr("Expected total number of Constituents to be equal to the "
                 "number of columns of Result Type matrix"));
 }
 
@@ -439,8 +422,7 @@ TEST_F(ValidateComposites, CompositeConstructVectorWrongConsituent) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("CompositeConstruct: "
-                "expected Constituent type to be equal to the column type "
+      HasSubstr("Expected Constituent type to be equal to the column type "
                 "Result Type matrix"));
 }
 
@@ -462,8 +444,7 @@ TEST_F(ValidateComposites, CompositeConstructArrayWrongConsituentNumber1) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("CompositeConstruct: "
-                "expected total number of Constituents to be equal to the "
+      HasSubstr("Expected total number of Constituents to be equal to the "
                 "number of elements of Result Type array"));
 }
 
@@ -476,8 +457,7 @@ TEST_F(ValidateComposites, CompositeConstructArrayWrongConsituentNumber2) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("CompositeConstruct: "
-                "expected total number of Constituents to be equal to the "
+      HasSubstr("Expected total number of Constituents to be equal to the "
                 "number of elements of Result Type array"));
 }
 
@@ -490,8 +470,7 @@ TEST_F(ValidateComposites, CompositeConstructArrayWrongConsituent) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("CompositeConstruct: "
-                "expected Constituent type to be equal to the column type "
+      HasSubstr("Expected Constituent type to be equal to the column type "
                 "Result Type array"));
 }
 
@@ -513,8 +492,7 @@ TEST_F(ValidateComposites, CompositeConstructStructWrongConstituentNumber1) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("CompositeConstruct: "
-                "expected total number of Constituents to be equal to the "
+      HasSubstr("Expected total number of Constituents to be equal to the "
                 "number of members of Result Type struct"));
 }
 
@@ -527,8 +505,7 @@ TEST_F(ValidateComposites, CompositeConstructStructWrongConstituentNumber2) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("CompositeConstruct: "
-                "expected total number of Constituents to be equal to the "
+      HasSubstr("Expected total number of Constituents to be equal to the "
                 "number of members of Result Type struct"));
 }
 
@@ -540,8 +517,7 @@ TEST_F(ValidateComposites, CompositeConstructStructWrongConstituent) {
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("CompositeConstruct: "
-                        "expected Constituent type to be equal to the "
+              HasSubstr("Expected Constituent type to be equal to the "
                         "corresponding member type of Result Type struct"));
 }
 
@@ -563,7 +539,7 @@ TEST_F(ValidateComposites, CopyObjectResultTypeNotType) {
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("CopyObject: expected Result Type to be a type"));
+              HasSubstr("Expected Result Type to be a type"));
 }
 
 TEST_F(ValidateComposites, CopyObjectWrongOperandType) {
@@ -575,8 +551,7 @@ TEST_F(ValidateComposites, CopyObjectWrongOperandType) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("CopyObject: "
-                "expected Result Type and Operand type to be the same"));
+      HasSubstr("Expected Result Type and Operand type to be the same"));
 }
 
 TEST_F(ValidateComposites, TransposeSuccess) {
@@ -597,7 +572,7 @@ TEST_F(ValidateComposites, TransposeResultTypeNotMatrix) {
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Transpose: expected Result Type to be a matrix type"));
+              HasSubstr("Expected Result Type to be a matrix type"));
 }
 
 TEST_F(ValidateComposites, TransposeDifferentComponentTypes) {
@@ -609,8 +584,7 @@ TEST_F(ValidateComposites, TransposeDifferentComponentTypes) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Transpose: "
-                "expected component types of Matrix and Result Type to be "
+      HasSubstr("Expected component types of Matrix and Result Type to be "
                 "identical"));
 }
 
@@ -621,10 +595,9 @@ TEST_F(ValidateComposites, TransposeIncompatibleDimensions1) {
 
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Transpose: expected number of columns and the column size "
-                "of Matrix to be the reverse of those of Result Type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Expected number of columns and the column size "
+                        "of Matrix to be the reverse of those of Result Type"));
 }
 
 TEST_F(ValidateComposites, TransposeIncompatibleDimensions2) {
@@ -634,10 +607,9 @@ TEST_F(ValidateComposites, TransposeIncompatibleDimensions2) {
 
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Transpose: expected number of columns and the column size "
-                "of Matrix to be the reverse of those of Result Type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Expected number of columns and the column size "
+                        "of Matrix to be the reverse of those of Result Type"));
 }
 
 TEST_F(ValidateComposites, TransposeIncompatibleDimensions3) {
@@ -647,10 +619,9 @@ TEST_F(ValidateComposites, TransposeIncompatibleDimensions3) {
 
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Transpose: expected number of columns and the column size "
-                "of Matrix to be the reverse of those of Result Type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Expected number of columns and the column size "
+                        "of Matrix to be the reverse of those of Result Type"));
 }
 
 TEST_F(ValidateComposites, CompositeExtractSuccess) {
@@ -690,7 +661,7 @@ TEST_F(ValidateComposites, CompositeExtractNotObject) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("CompositeExtract: expected Composite to be an object "
+              HasSubstr("Expected Composite to be an object "
                         "of composite type"));
 }
 
@@ -702,8 +673,8 @@ TEST_F(ValidateComposites, CompositeExtractNotComposite) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpCompositeExtract reached non-composite type while "
-                        "indexes still remain to be traversed."));
+              HasSubstr("Reached non-composite type while indexes still remain "
+                        "to be traversed."));
 }
 
 TEST_F(ValidateComposites, CompositeExtractVectorOutOfBounds) {
@@ -714,7 +685,7 @@ TEST_F(ValidateComposites, CompositeExtractVectorOutOfBounds) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("CompositeExtract: vector access is out of bounds, "
+              HasSubstr("Vector access is out of bounds, "
                         "vector size is 4, but access index is 4"));
 }
 
@@ -726,7 +697,7 @@ TEST_F(ValidateComposites, CompositeExtractMatrixOutOfCols) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("CompositeExtract: matrix access is out of bounds, "
+              HasSubstr("Matrix access is out of bounds, "
                         "matrix has 3 columns, but access index is 3"));
 }
 
@@ -738,7 +709,7 @@ TEST_F(ValidateComposites, CompositeExtractMatrixOutOfRows) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("CompositeExtract: vector access is out of bounds, "
+              HasSubstr("Vector access is out of bounds, "
                         "vector size is 2, but access index is 5"));
 }
 
@@ -751,7 +722,7 @@ TEST_F(ValidateComposites, CompositeExtractArrayOutOfBounds) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("CompositeExtract: array access is out of bounds, "
+              HasSubstr("Array access is out of bounds, "
                         "array size is 3, but access index is 3"));
 }
 
@@ -764,9 +735,9 @@ TEST_F(ValidateComposites, CompositeExtractStructOutOfBounds) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Index is out of bounds: OpCompositeExtract can not "
-                        "find index 6 into the structure <id> '37'. This "
-                        "structure has 6 members. Largest valid index is 5."));
+              HasSubstr("Index is out of bounds, can not find index 6 in the "
+                        "structure <id> '37'. This structure has 6 members. "
+                        "Largest valid index is 5."));
 }
 
 TEST_F(ValidateComposites, CompositeExtractNestedVectorOutOfBounds) {
@@ -778,7 +749,7 @@ TEST_F(ValidateComposites, CompositeExtractNestedVectorOutOfBounds) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("CompositeExtract: vector access is out of bounds, "
+              HasSubstr("Vector access is out of bounds, "
                         "vector size is 2, but access index is 5"));
 }
 
@@ -791,7 +762,7 @@ TEST_F(ValidateComposites, CompositeExtractTooManyIndices) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpCompositeExtract reached non-composite type while "
+              HasSubstr("Reached non-composite type while "
                         "indexes still remain to be traversed."));
 }
 
@@ -806,8 +777,8 @@ TEST_F(ValidateComposites, CompositeExtractWrongType1) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpCompositeExtract result type (OpTypeVector) does not match the "
-          "type that results from indexing into the composite (OpTypeFloat)."));
+          "Result type (OpTypeVector) does not match the type that results "
+          "from indexing into the composite (OpTypeFloat)."));
 }
 
 TEST_F(ValidateComposites, CompositeExtractWrongType2) {
@@ -819,9 +790,9 @@ TEST_F(ValidateComposites, CompositeExtractWrongType2) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpCompositeExtract result type (OpTypeFloat) does not "
-                        "match the type that results from indexing into the "
-                        "composite (OpTypeVector)."));
+              HasSubstr("Result type (OpTypeFloat) does not match the type "
+                        "that results from indexing into the composite "
+                        "(OpTypeVector)."));
 }
 
 TEST_F(ValidateComposites, CompositeExtractWrongType3) {
@@ -833,9 +804,9 @@ TEST_F(ValidateComposites, CompositeExtractWrongType3) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpCompositeExtract result type (OpTypeFloat) does not "
-                        "match the type that results from indexing into the "
-                        "composite (OpTypeVector)."));
+              HasSubstr("Result type (OpTypeFloat) does not match the type "
+                        "that results from indexing into the composite "
+                        "(OpTypeVector)."));
 }
 
 TEST_F(ValidateComposites, CompositeExtractWrongType4) {
@@ -847,9 +818,9 @@ TEST_F(ValidateComposites, CompositeExtractWrongType4) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpCompositeExtract result type (OpTypeFloat) does not "
-                        "match the type that results from indexing into the "
-                        "composite (OpTypeVector)."));
+              HasSubstr("Result type (OpTypeFloat) does not match the type "
+                        "that results from indexing into the composite "
+                        "(OpTypeVector)."));
 }
 
 TEST_F(ValidateComposites, CompositeExtractWrongType5) {
@@ -863,7 +834,7 @@ TEST_F(ValidateComposites, CompositeExtractWrongType5) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpCompositeExtract result type (OpTypeFloat) does not match the "
+          "Result type (OpTypeFloat) does not match the "
           "type that results from indexing into the composite (OpTypeInt)."));
 }
 
@@ -916,8 +887,8 @@ TEST_F(ValidateComposites, CompositeInsertNotComposite) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpCompositeInsert reached non-composite type while "
-                        "indexes still remain to be traversed."));
+              HasSubstr("Reached non-composite type while indexes still remain "
+                        "to be traversed."));
 }
 
 TEST_F(ValidateComposites, CompositeInsertVectorOutOfBounds) {
@@ -928,7 +899,7 @@ TEST_F(ValidateComposites, CompositeInsertVectorOutOfBounds) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("CompositeInsert: vector access is out of bounds, "
+              HasSubstr("Vector access is out of bounds, "
                         "vector size is 4, but access index is 4"));
 }
 
@@ -940,7 +911,7 @@ TEST_F(ValidateComposites, CompositeInsertMatrixOutOfCols) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("CompositeInsert: matrix access is out of bounds, "
+              HasSubstr("Matrix access is out of bounds, "
                         "matrix has 3 columns, but access index is 3"));
 }
 
@@ -952,7 +923,7 @@ TEST_F(ValidateComposites, CompositeInsertMatrixOutOfRows) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("CompositeInsert: vector access is out of bounds, "
+              HasSubstr("Vector access is out of bounds, "
                         "vector size is 2, but access index is 5"));
 }
 
@@ -965,7 +936,7 @@ TEST_F(ValidateComposites, CompositeInsertArrayOutOfBounds) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("CompositeInsert: array access is out of bounds, array "
+              HasSubstr("Array access is out of bounds, array "
                         "size is 3, but access index is 3"));
 }
 
@@ -978,9 +949,9 @@ TEST_F(ValidateComposites, CompositeInsertStructOutOfBounds) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Index is out of bounds: OpCompositeInsert can not "
-                        "find index 6 into the structure <id> '37'. This "
-                        "structure has 6 members. Largest valid index is 5."));
+              HasSubstr("Index is out of bounds, can not find index 6 in the "
+                        "structure <id> '37'. This structure has 6 members. "
+                        "Largest valid index is 5."));
 }
 
 TEST_F(ValidateComposites, CompositeInsertNestedVectorOutOfBounds) {
@@ -992,7 +963,7 @@ TEST_F(ValidateComposites, CompositeInsertNestedVectorOutOfBounds) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("CompositeInsert: vector access is out of bounds, "
+              HasSubstr("Vector access is out of bounds, "
                         "vector size is 2, but access index is 5"));
 }
 
@@ -1005,8 +976,8 @@ TEST_F(ValidateComposites, CompositeInsertTooManyIndices) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpCompositeInsert reached non-composite type while "
-                        "indexes still remain to be traversed."));
+              HasSubstr("Reached non-composite type while indexes still remain "
+                        "to be traversed."));
 }
 
 TEST_F(ValidateComposites, CompositeInsertWrongType1) {
@@ -1018,9 +989,9 @@ TEST_F(ValidateComposites, CompositeInsertWrongType1) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("The Object type (OpTypeVector) in OpCompositeInsert "
-                        "does not match the type that results from indexing "
-                        "into the Composite (OpTypeFloat)."));
+              HasSubstr("The Object type (OpTypeVector) does not match the "
+                        "type that results from indexing into the Composite "
+                        "(OpTypeFloat)."));
 }
 
 TEST_F(ValidateComposites, CompositeInsertWrongType2) {
@@ -1032,9 +1003,9 @@ TEST_F(ValidateComposites, CompositeInsertWrongType2) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("The Object type (OpTypeFloat) in OpCompositeInsert "
-                        "does not match the type that results from indexing "
-                        "into the Composite (OpTypeVector)."));
+              HasSubstr("The Object type (OpTypeFloat) does not match the type "
+                        "that results from indexing into the Composite "
+                        "(OpTypeVector)."));
 }
 
 TEST_F(ValidateComposites, CompositeInsertWrongType3) {
@@ -1046,9 +1017,9 @@ TEST_F(ValidateComposites, CompositeInsertWrongType3) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("The Object type (OpTypeFloat) in OpCompositeInsert "
-                        "does not match the type that results from indexing "
-                        "into the Composite (OpTypeVector)."));
+              HasSubstr("The Object type (OpTypeFloat) does not match the type "
+                        "that results from indexing into the Composite "
+                        "(OpTypeVector)."));
 }
 
 TEST_F(ValidateComposites, CompositeInsertWrongType4) {
@@ -1060,9 +1031,9 @@ TEST_F(ValidateComposites, CompositeInsertWrongType4) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("The Object type (OpTypeFloat) in OpCompositeInsert "
-                        "does not match the type that results from indexing "
-                        "into the Composite (OpTypeVector)."));
+              HasSubstr("The Object type (OpTypeFloat) does not match the type "
+                        "that results from indexing into the Composite "
+                        "(OpTypeVector)."));
 }
 
 TEST_F(ValidateComposites, CompositeInsertWrongType5) {
@@ -1074,9 +1045,9 @@ TEST_F(ValidateComposites, CompositeInsertWrongType5) {
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("The Object type (OpTypeFloat) in OpCompositeInsert "
-                        "does not match the type that results from indexing "
-                        "into the Composite (OpTypeInt)."));
+              HasSubstr("The Object type (OpTypeFloat) does not match the type "
+                        "that results from indexing into the Composite "
+                        "(OpTypeInt)."));
 }
 
 // Tests ported from val_id_test.cpp.
@@ -1210,9 +1181,9 @@ TEST_F(ValidateComposites, CompositeExtractNoIndexesBad) {
   CompileSuccessfully(spirv.str());
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpCompositeExtract result type (OpTypeFloat) does not "
-                        "match the type that results from indexing into the "
-                        "composite (OpTypeMatrix)."));
+              HasSubstr("Result type (OpTypeFloat) does not match the type "
+                        "that results from indexing into the composite "
+                        "(OpTypeMatrix)."));
 }
 
 // Valid: No Indexes were passed to OpCompositeInsert, and the type of the
@@ -1243,9 +1214,9 @@ TEST_F(ValidateComposites, CompositeInsertMissingIndexesBad) {
   CompileSuccessfully(spirv.str());
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("The Object type (OpTypeInt) in OpCompositeInsert does "
-                        "not match the type that results from indexing into "
-                        "the Composite (OpTypeMatrix)."));
+              HasSubstr("The Object type (OpTypeInt) does not match the type "
+                        "that results from indexing into the Composite "
+                        "(OpTypeMatrix)."));
 }
 
 // Valid: Tests that we can index into Struct, Array, Matrix, and Vector!
@@ -1299,8 +1270,8 @@ TEST_F(ValidateComposites, CompositeExtractReachedScalarBad) {
   CompileSuccessfully(spirv.str());
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpCompositeExtract reached non-composite type while "
-                        "indexes still remain to be traversed."));
+              HasSubstr("Reached non-composite type while indexes still remain "
+                        "to be traversed."));
 }
 
 // Invalid. More indexes are provided than needed for OpCompositeInsert.
@@ -1323,8 +1294,8 @@ TEST_F(ValidateComposites, CompositeInsertReachedScalarBad) {
   CompileSuccessfully(spirv.str());
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpCompositeInsert reached non-composite type while "
-                        "indexes still remain to be traversed."));
+              HasSubstr("Reached non-composite type while indexes still remain "
+                        "to be traversed."));
 }
 
 // Invalid. Result type doesn't match the type we get from indexing into
@@ -1348,9 +1319,9 @@ TEST_F(ValidateComposites,
   CompileSuccessfully(spirv.str());
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpCompositeExtract result type (OpTypeInt) does not "
-                        "match the type that results from indexing into the "
-                        "composite (OpTypeFloat)."));
+              HasSubstr("Result type (OpTypeInt) does not match the type that "
+                        "results from indexing into the composite "
+                        "(OpTypeFloat)."));
 }
 
 // Invalid. Given object type doesn't match the type we get from indexing into
@@ -1374,9 +1345,9 @@ TEST_F(ValidateComposites, CompositeInsertObjectTypeDoesntMatchIndexedTypeBad) {
   CompileSuccessfully(spirv.str());
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("he Object type (OpTypeInt) in OpCompositeInsert does "
-                        "not match the type that results from indexing into "
-                        "the Composite (OpTypeFloat)."));
+              HasSubstr("The Object type (OpTypeInt) does not match the type "
+                        "that results from indexing into the Composite "
+                        "(OpTypeFloat)."));
 }
 
 // Invalid. Index into a struct is larger than the number of struct members.
@@ -1393,9 +1364,9 @@ TEST_F(ValidateComposites, CompositeExtractStructIndexOutOfBoundBad) {
   CompileSuccessfully(spirv.str());
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Index is out of bounds: OpCompositeExtract can not "
-                        "find index 3 into the structure <id> '26'. This "
-                        "structure has 3 members. Largest valid index is 2."));
+              HasSubstr("Index is out of bounds, can not find index 3 in the "
+                        "structure <id> '26'. This structure has 3 members. "
+                        "Largest valid index is 2."));
 }
 
 // Invalid. Index into a struct is larger than the number of struct members.
@@ -1414,9 +1385,9 @@ TEST_F(ValidateComposites, CompositeInsertStructIndexOutOfBoundBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Index is out of bounds: OpCompositeInsert can not find "
-                "index 3 into the structure <id> '26'. This structure "
-                "has 3 members. Largest valid index is 2."));
+      HasSubstr("Index is out of bounds, can not find index 3 in the structure "
+                "<id> '26'. This structure has 3 members. Largest valid index "
+                "is 2."));
 }
 
 // #1403: Ensure that the default spec constant value is not used to check the


### PR DESCRIPTION
This CL removes the redundant operator name from the error messages in
validate_composites. The operator will be printed on the next line with
the disassembly.