### PR TITLE
Make sure all instructions are in the ordered list.

### DIFF
--- a/source/val/validate.h
+++ b/source/val/validate.h
@@ -112,7 +112,7 @@ spv_result_t ModuleLayoutPass(ValidationState_t& _, const Instruction* inst);
 spv_result_t CfgPass(ValidationState_t& _, const Instruction* inst);
 
 /// Performs Id and SSA validation of a module
-spv_result_t IdPass(ValidationState_t& _, const spv_parsed_instruction_t* inst);
+spv_result_t IdPass(ValidationState_t& _, Instruction* inst);
 
 /// Performs validation of the Data Rules subsection of 2.16.1 Universal
 /// Validation Rules.
@@ -171,8 +171,7 @@ spv_result_t NonUniformPass(ValidationState_t& _, const Instruction* inst);
 
 // Validates that capability declarations use operands allowed in the current
 // context.
-spv_result_t CapabilityPass(ValidationState_t& _,
-                            const spv_parsed_instruction_t* inst);
+spv_result_t CapabilityPass(ValidationState_t& _, const Instruction* inst);
 
 /// Validates correctness of primitive instructions.
 spv_result_t PrimitivesPass(ValidationState_t& _, const Instruction* inst);

--- a/source/val/validate_capability.cpp
+++ b/source/val/validate_capability.cpp
@@ -220,19 +220,17 @@ bool IsEnabledByCapabilityOpenCL_2_0(ValidationState_t& _,
 
 // Validates that capability declarations use operands allowed in the current
 // context.
-spv_result_t CapabilityPass(ValidationState_t& _,
-                            const spv_parsed_instruction_t* inst) {
-  const SpvOp opcode = static_cast<SpvOp>(inst->opcode);
-  if (opcode != SpvOpCapability) return SPV_SUCCESS;
+spv_result_t CapabilityPass(ValidationState_t& _, const Instruction* inst) {
+  if (inst->opcode() != SpvOpCapability) return SPV_SUCCESS;
 
-  assert(inst->num_operands == 1);
+  assert(inst->operands().size() == 1);
 
-  const spv_parsed_operand_t& operand = inst->operands[0];
+  const spv_parsed_operand_t& operand = inst->operand(0);
 
   assert(operand.num_words == 1);
-  assert(operand.offset < inst->num_words);
+  assert(operand.offset < inst->words().size());
 
-  const uint32_t capability = inst->words[operand.offset];
+  const uint32_t capability = inst->word(operand.offset);
   const auto capability_str = [&_, capability]() {
     spv_operand_desc desc = nullptr;
     if (_.grammar().lookupOperand(SPV_OPERAND_TYPE_CAPABILITY, capability,

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -296,8 +296,15 @@ class ValidationState_t {
 
   const AssemblyGrammar& grammar() const { return grammar_; }
 
-  /// Registers the instruction
-  void RegisterInstruction(const spv_parsed_instruction_t& inst);
+  /// Inserts the instruction into the list of ordered instructions in the file.
+  Instruction* AddOrderedInstruction(const spv_parsed_instruction_t* inst);
+
+  /// Registers the instruction. This will add the instruction to the list of
+  /// definitions and register sampled image consumers.
+  void RegisterInstruction(Instruction* inst);
+
+  /// Registers the debug instruction information.
+  void RegisterDebugInstruction(const Instruction* inst);
 
   /// Registers the decoration for the given <id>
   void RegisterDecorationForId(uint32_t id, const Decoration& dec) {

--- a/test/cpp_interface_test.cpp
+++ b/test/cpp_interface_test.cpp
@@ -42,7 +42,7 @@ TEST(CppInterface, SuccessfulRoundTrip) {
     EXPECT_EQ(0u, position.line);
     EXPECT_EQ(0u, position.column);
     EXPECT_EQ(1u, position.index);
-    EXPECT_STREQ("ID 1 has not been defined", message);
+    EXPECT_STREQ("ID 1 has not been defined\n  %2 = OpSizeOf %1 %3\n", message);
   });
   EXPECT_FALSE(t.Validate(binary));
 

--- a/test/val/val_ssa_test.cpp
+++ b/test/val/val_ssa_test.cpp
@@ -122,7 +122,8 @@ TEST_F(ValidateSSA, DominateUsageWithinBlockBad) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("ID .\\[bad\\] has not been defined"));
+              MatchesRegex("ID .\\[bad\\] has not been defined\n"
+                           "  %8 = OpIAdd %uint %uint_1 %bad\n"));
 }
 
 TEST_F(ValidateSSA, DominateUsageSameInstructionBad) {
@@ -144,7 +145,8 @@ TEST_F(ValidateSSA, DominateUsageSameInstructionBad) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("ID .\\[sum\\] has not been defined"));
+              MatchesRegex("ID .\\[sum\\] has not been defined\n"
+                           "  %sum = OpIAdd %uint %uint_1 %sum\n"));
 }
 
 TEST_F(ValidateSSA, ForwardNameGood) {
@@ -1186,7 +1188,8 @@ TEST_F(ValidateSSA,
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("ID .\\[inew\\] has not been defined"));
+              MatchesRegex("ID .\\[inew\\] has not been defined\n"
+                           "  %19 = OpIAdd %uint %inew %uint_1\n"));
 }
 
 TEST_F(ValidateSSA, PhiUseMayComeFromNonDominatingBlockGood) {


### PR DESCRIPTION
Currently, some instructions will be missing from the list of
ordered_instructions. This will cause issues due to the debug change
which passed the last instruction into subsequent passes.

This CL moves the addition to the ordered list out of the
RegisterInstruction method into AddOrderedInstruction. This method is
called first in ProcessInstruction and the CapabilitiesPass and IdPass
are updated to take an Instruction parameter.