### PR TITLE
Wrap entire timer.cpp in SPIRV_TIMER_ENABLED.

### DIFF
--- a/source/util/timer.cpp
+++ b/source/util/timer.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if defined(SPIRV_TIMER_ENABLED)
+
 #include "util/timer.h"
 
 #include <sys/resource.h>
@@ -22,8 +24,6 @@
 
 namespace spvtools {
 namespace utils {
-
-#if defined(SPIRV_TIMER_ENABLED)
 
 void PrintTimerDescription(std::ostream* out, bool measure_mem_usage) {
   if (out) {
@@ -96,7 +96,7 @@ void Timer::Report(const char* tag) {
   *report_stream_ << std::endl;
 }
 
-#endif  // defined(SPIRV_TIMER_ENABLED)
-
 }  // namespace utils
 }  // namespace spvtools
+
+#endif  // defined(SPIRV_TIMER_ENABLED)


### PR DESCRIPTION
This CL moves the SPIRV_TIMER_ENABLED preprocesser guard to encompass
the includes along with the source. Currently we will try to pull in
sys/resource.h on machines which may not have the file available and the
build will fail. If we don't need timers, then we don't need the
includes as well.