### PR TITLE
Remove std::deque in favour of std::vector.

### DIFF
--- a/source/comp/markv_codec.cpp
+++ b/source/comp/markv_codec.cpp
@@ -49,6 +49,7 @@
 #include "markv_model.h"
 #include "opcode.h"
 #include "operand.h"
+#include "source/assembly_grammar.h"
 #include "spirv-tools/libspirv.h"
 #include "spirv_endian.h"
 #include "spirv_validator_options.h"
@@ -58,7 +59,6 @@
 #include "util/parse_number.h"
 #include "val/instruction.h"
 #include "val/validate.h"
-#include "val/validation_state.h"
 
 namespace spvtools {
 namespace comp {

--- a/source/operand.h
+++ b/source/operand.h
@@ -15,7 +15,6 @@
 #ifndef LIBSPIRV_OPERAND_H_
 #define LIBSPIRV_OPERAND_H_
 
-#include <deque>
 #include <functional>
 
 #include "spirv-tools/libspirv.h"

--- a/source/spirv_stats.cpp
+++ b/source/spirv_stats.cpp
@@ -220,9 +220,11 @@ class StatsAggregator {
   void ProcessConstant() {
     const val::Instruction& inst = GetCurrentInstruction();
     if (inst.opcode() != SpvOpConstant) return;
+
     const uint32_t type_id = inst.GetOperandAs<uint32_t>(0);
     const auto type_decl_it = vstate_->all_definitions().find(type_id);
     assert(type_decl_it != vstate_->all_definitions().end());
+
     const val::Instruction& type_decl_inst = *type_decl_it->second;
     const SpvOp type_op = type_decl_inst.opcode();
     if (type_op == SpvOpTypeInt) {

--- a/source/val/validate.cpp
+++ b/source/val/validate.cpp
@@ -238,16 +238,16 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
   }
 
   // Look for OpExtension instructions and register extensions.
-  // Diagnostics if any will be produced in the next pass (ProcessInstruction).
   spvBinaryParse(&context, vstate, words, num_words,
                  /* parsed_header = */ nullptr, ProcessExtensions,
                  /* diagnostic = */ nullptr);
 
-  // NOTE: Parse the module and perform inline validation checks. These
-  // checks do not require the the knowledge of the whole module.
+  // Parse the module and perform inline validation checks. These checks do
+  // not require the the knowledge of the whole module.
   if (auto error = spvBinaryParse(&context, vstate, words, num_words, setHeader,
-                                  ProcessInstruction, pDiagnostic))
+                                  ProcessInstruction, pDiagnostic)) {
     return error;
+  }
 
   if (!vstate->has_memory_model_specified())
     return vstate->diag(SPV_ERROR_INVALID_LAYOUT, nullptr)

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -15,7 +15,6 @@
 #ifndef LIBSPIRV_VAL_VALIDATIONSTATE_H_
 #define LIBSPIRV_VAL_VALIDATIONSTATE_H_
 
-#include <deque>
 #include <set>
 #include <string>
 #include <tuple>
@@ -144,6 +143,17 @@ class ValidationState_t {
   /// Increments the instruction count. Used for diagnostic
   int increment_instruction_count();
 
+  /// Increments the total number of instructions in the file.
+  void increment_total_instructions() { total_instructions_++; }
+
+  /// Increments the total number of functions in the file.
+  void increment_total_functions() { total_functions_++; }
+
+  /// Allocates internal storage. Note, calling this will invalidate any
+  /// pointers to |ordered_instructions_| or |module_functions_| and, hence,
+  /// should only be called at the beginning of validation.
+  void preallocateStorage();
+
   /// Returns the current layout section which is being processed
   ModuleLayoutSection current_layout_section() const;
 
@@ -157,7 +167,7 @@ class ValidationState_t {
   DiagnosticStream diag(spv_result_t error_code, const Instruction* inst) const;
 
   /// Returns the function states
-  std::deque<Function>& functions();
+  std::vector<Function>& functions();
 
   /// Returns the function states
   Function& current_function();
@@ -355,8 +365,8 @@ class ValidationState_t {
   /// nullptr
   Instruction* FindDef(uint32_t id);
 
-  /// Returns a deque of instructions in the order they appear in the binary
-  const std::deque<Instruction>& ordered_instructions() const {
+  /// Returns the instructions in the order they appear in the binary
+  const std::vector<Instruction>& ordered_instructions() const {
     return ordered_instructions_;
   }
 
@@ -520,6 +530,11 @@ class ValidationState_t {
   const uint32_t* words_;
   const size_t num_words_;
 
+  /// The total number of instructions in the binary.
+  size_t total_instructions_ = 0;
+  /// The total number of functions in the binary.
+  size_t total_functions_ = 0;
+
   /// Tracks the number of instructions evaluated by the validator
   int instruction_counter_;
 
@@ -542,7 +557,7 @@ class ValidationState_t {
   /// A list of functions in the module.
   /// Pointers to objects in this container are guaranteed to be stable and
   /// valid until the end of lifetime of the validation state.
-  std::deque<Function> module_functions_;
+  std::vector<Function> module_functions_;
 
   /// Capabilities declared in the module
   CapabilitySet module_capabilities_;
@@ -551,9 +566,7 @@ class ValidationState_t {
   ExtensionSet module_extensions_;
 
   /// List of all instructions in the order they appear in the binary
-  /// Pointers to objects in this container are guaranteed to be stable and
-  /// valid until the end of lifetime of the validation state.
-  std::deque<Instruction> ordered_instructions_;
+  std::vector<Instruction> ordered_instructions_;
 
   /// Instructions that can be referenced by Ids
   std::unordered_map<uint32_t, Instruction*> all_definitions_;


### PR DESCRIPTION
This CL removes the two deque's from ValidationState and converts them
into std::vectors. In order to maintain the stability of instructions we
walk over the binary and counter the instructions and functions in the
ValidationState constructor and reserve the required number of items in
the module_functions_ and ordered_instructions_ vectors.

Issue #1176.