### PR TITLE
Update diag() calls in validate_cfg.

### DIFF
--- a/source/val/validate_cfg.cpp
+++ b/source/val/validate_cfg.cpp
@@ -193,7 +193,7 @@ spv_result_t FindCaseFallThrough(
           continue;
         }
 
-        return _.diag(SPV_ERROR_INVALID_CFG)
+        return _.diag(SPV_ERROR_INVALID_CFG, target_block->label())
                << "Case construct that targets "
                << _.getIdName(target_block->id())
                << " has invalid branch to block " << _.getIdName(block->id())
@@ -244,7 +244,7 @@ spv_result_t StructuredSwitchChecks(const ValidationState_t& _,
     // OpSwitch must dominate all its case constructs.
     if (header->reachable() && target_block->reachable() &&
         !header->dominates(*target_block)) {
-      return _.diag(SPV_ERROR_INVALID_CFG)
+      return _.diag(SPV_ERROR_INVALID_CFG, header->label())
              << "Selection header " << _.getIdName(header->id())
              << " does not dominate its case construct " << _.getIdName(target);
     }
@@ -330,7 +330,7 @@ spv_result_t StructuredControlFlowChecks(
     uint32_t header_block;
     tie(back_edge_block, header_block) = back_edge;
     if (!function->IsBlockType(header_block, kBlockTypeLoop)) {
-      return _.diag(SPV_ERROR_INVALID_CFG)
+      return _.diag(SPV_ERROR_INVALID_CFG, _.FindDef(back_edge_block))
              << "Back-edges (" << _.getIdName(back_edge_block) << " -> "
              << _.getIdName(header_block)
              << ") can only be formed between a block and a loop header.";

--- a/test/val/val_cfg_test.cpp
+++ b/test/val/val_cfg_test.cpp
@@ -963,7 +963,7 @@ TEST_P(ValidateCFG, BranchingToNonLoopHeaderBlockBad) {
         getDiagnosticString(),
         MatchesRegex("Back-edges \\(.\\[f\\] -> .\\[split\\]\\) can only "
                      "be formed between a block and a loop header.\n"
-                     "  OpFunctionEnd\n"));
+                     "  %f = OpLabel\n"));
   } else {
     ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
   }
@@ -993,7 +993,7 @@ TEST_P(ValidateCFG, BranchingToSameNonLoopHeaderBlockBad) {
                 MatchesRegex(
                     "Back-edges \\(.\\[split\\] -> .\\[split\\]\\) can only be "
                     "formed between a block and a loop header.\n"
-                    "  OpFunctionEnd\n"));
+                    "  %split = OpLabel\n"));
   } else {
     ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
   }


### PR DESCRIPTION
This CL updates the diag() calls in validate_cfg to provide the
associated instruction. This fixes a couple places where we output the
last line of the file instead of the instruction as the disassembly.