### PR TITLE
Remove diag() overloads.

### DIFF
--- a/source/val/validate_id.cpp
+++ b/source/val/validate_id.cpp
@@ -2086,7 +2086,7 @@ spv_result_t CheckIdDefinitionDominateUse(const ValidationState_t& _) {
             if (use->opcode() == SpvOpPhi) {
               phi_instructions.insert(use);
             } else if (!block->dominates(*use->block())) {
-              return _.diag(SPV_ERROR_INVALID_ID)
+              return _.diag(SPV_ERROR_INVALID_ID, use_block->label())
                      << "ID " << _.getIdName(definition.first)
                      << " defined in block " << _.getIdName(block->id())
                      << " does not dominate its use in block "
@@ -2101,7 +2101,7 @@ spv_result_t CheckIdDefinitionDominateUse(const ValidationState_t& _) {
         for (auto use : definition.second->uses()) {
           const Instruction* inst = use.first;
           if (inst->function() && inst->function() != func) {
-            return _.diag(SPV_ERROR_INVALID_ID)
+            return _.diag(SPV_ERROR_INVALID_ID, _.FindDef(func->id()))
                    << "ID " << _.getIdName(definition.first)
                    << " used in function "
                    << _.getIdName(inst->function()->id())
@@ -2125,7 +2125,7 @@ spv_result_t CheckIdDefinitionDominateUse(const ValidationState_t& _) {
           phi->function()->GetBlock(phi->word(i + 1)).first;
       if (variable->block() && parent->reachable() &&
           !variable->block()->dominates(*parent)) {
-        return _.diag(SPV_ERROR_INVALID_ID)
+        return _.diag(SPV_ERROR_INVALID_ID, phi)
                << "In OpPhi instruction " << _.getIdName(phi->id()) << ", ID "
                << _.getIdName(variable->id())
                << " definition does not dominate its parent "
@@ -2180,7 +2180,7 @@ spv_result_t IdPass(ValidationState_t& _, Instruction* inst) {
         } else if (can_have_forward_declared_ids(i)) {
           ret = _.ForwardDeclareId(operand_word);
         } else {
-          ret = _.diag(SPV_ERROR_INVALID_ID)
+          ret = _.diag(SPV_ERROR_INVALID_ID, inst)
                 << "ID " << _.getIdName(operand_word)
                 << " has not been defined";
         }

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -297,18 +297,9 @@ bool ValidationState_t::IsOpcodeInCurrentLayoutSection(SpvOp op) {
   return IsInstructionInLayoutSection(current_layout_section_, op);
 }
 
-DiagnosticStream ValidationState_t::diag(spv_result_t error_code) const {
-  return diag(error_code, instruction_counter_);
-}
-
 DiagnosticStream ValidationState_t::diag(spv_result_t error_code,
                                          const Instruction* inst) const {
   int instruction_counter = inst ? inst->InstructionPosition() : -1;
-  return diag(error_code, instruction_counter);
-}
-
-DiagnosticStream ValidationState_t::diag(spv_result_t error_code,
-                                         int instruction_counter) const {
   std::string disassembly;
   if (instruction_counter >= 0 && static_cast<size_t>(instruction_counter) <=
                                       ordered_instructions_.size()) {

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -163,7 +163,6 @@ class ValidationState_t {
   /// Determines if the op instruction is part of the current section
   bool IsOpcodeInCurrentLayoutSection(SpvOp op);
 
-  DiagnosticStream diag(spv_result_t error_code) const;
   DiagnosticStream diag(spv_result_t error_code, const Instruction* inst) const;
 
   /// Returns the function states
@@ -517,9 +516,6 @@ class ValidationState_t {
 
  private:
   ValidationState_t(const ValidationState_t&);
-
-  /// Deprecated.  Use the Instruction variant instead.
-  DiagnosticStream diag(spv_result_t error_code, int instruction_counter) const;
 
   const spv_const_context context_;
 

--- a/test/val/val_ssa_test.cpp
+++ b/test/val/val_ssa_test.cpp
@@ -1130,7 +1130,7 @@ TEST_F(ValidateSSA, IdDoesNotDominateItsUseBad) {
       getDiagnosticString(),
       MatchesRegex("ID .\\[eleven\\] defined in block .\\[true_block\\] does "
                    "not dominate its use in block .\\[false_block\\]\n"
-                   "  OpFunctionEnd\n"));
+                   "  %false_block = OpLabel\n"));
 }
 
 TEST_F(ValidateSSA, PhiUseDoesntDominateDefinitionGood) {
@@ -1272,7 +1272,8 @@ TEST_F(ValidateSSA, PhiVariableDefNotDominatedByParentBlockBad) {
       getDiagnosticString(),
       MatchesRegex("In OpPhi instruction .\\[phi\\], ID .\\[true_copy\\] "
                    "definition does not dominate its parent .\\[if_false\\]\n"
-                   "  OpFunctionEnd\n"));
+                   "  %phi = OpPhi %bool %true_copy %if_false %false_copy "
+                   "%if_true\n"));
 }
 
 TEST_F(ValidateSSA, PhiVariableDefDominatesButNotDefinedInParentBlock) {
@@ -1398,7 +1399,7 @@ TEST_F(ValidateSSA, UseFunctionParameterFromOtherFunctionBad) {
       getDiagnosticString(),
       MatchesRegex("ID .\\[first\\] used in function .\\[func2\\] is used "
                    "outside of it's defining function .\\[func\\]\n"
-                   "  OpFunctionEnd\n"));
+                   "  %func = OpFunction %void None %14\n"));
 }
 
 TEST_F(ValidateSSA, TypeForwardPointerForwardReference) {


### PR DESCRIPTION
This CL removes the two diag() overloads and leaves only the version
which accepts an Instruction. This is safer as we never use the
implicit location from the validation state.