### PR TITLE
Fixup BUILD.gn to use a group for SPIRV-Tools

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -22,7 +22,7 @@ if (build_with_chromium) {
 }
 
 template("spvtools_core_tables") {
-  assert(defined(invoker.version), "Need version in $target_name generation.")
+  assert(defined(invoker.version), "Need version in $target_name generation")
 
   action("spvtools_core_tables_" + target_name) {
     script = "utils/generate_grammar_tables.py"

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -22,7 +22,7 @@ if (build_with_chromium) {
 }
 
 template("spvtools_core_tables") {
-  assert(defined(invoker.version), "Need version in $target_name generation")
+  assert(defined(invoker.version), "Need version in $target_name generation.")
 
   action("spvtools_core_tables_" + target_name) {
     script = "utils/generate_grammar_tables.py"

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -577,7 +577,7 @@ static_library("spvtools_opt") {
   configs += [ "//build/config/compiler:no_chromium_code" ]
 }
 
-static_library("SPIRV-Tools") {
+group("SPIRV-Tools") {
   deps = [
     ":spvtools",
     ":spvtools_opt",


### PR DESCRIPTION
The SPIRV-Tools target doesn't build anything, it just depends on the other libraries. As such, there is no static_library generated and this should be a group() instead.