### PR TITLE
 Remove instruction_counter from ValidationState.

### DIFF
--- a/source/val/instruction.cpp
+++ b/source/val/instruction.cpp
@@ -39,7 +39,7 @@ Instruction::Instruction(const spv_parsed_instruction_t* inst,
       inst_({words_.data(), inst->num_words, inst->opcode, inst->ext_inst_type,
              inst->type_id, inst->result_id, operands_.data(),
              inst->num_operands}),
-      instruction_position_(0),
+      line_num_(0),
       function_(defining_function),
       block_(defining_block),
       uses_() {}

--- a/source/val/instruction.h
+++ b/source/val/instruction.h
@@ -94,14 +94,14 @@ class Instruction {
     return *reinterpret_cast<const T*>(&words_[o.offset]);
   }
 
-  int InstructionPosition() const { return instruction_position_; }
-  void SetInstructionPosition(int pos) { instruction_position_ = pos; }
+  size_t LineNum() const { return line_num_; }
+  void SetLineNum(size_t pos) { line_num_ = pos; }
 
  private:
   const std::vector<uint32_t> words_;
   const std::vector<spv_parsed_operand_t> operands_;
   spv_parsed_instruction_t inst_;
-  int instruction_position_;
+  size_t line_num_;
 
   /// The function in which this instruction was declared
   Function* function_;

--- a/source/val/validate.cpp
+++ b/source/val/validate.cpp
@@ -111,7 +111,6 @@ spv_result_t ProcessExtensions(void* user_data,
 spv_result_t ProcessInstruction(void* user_data,
                                 const spv_parsed_instruction_t* inst) {
   ValidationState_t& _ = *(reinterpret_cast<ValidationState_t*>(user_data));
-  _.increment_instruction_count();
   if (static_cast<SpvOp>(inst->opcode) == SpvOpEntryPoint) {
     const auto entry_point = inst->words[2];
     const SpvExecutionModel execution_model = SpvExecutionModel(inst->words[1]);

--- a/source/val/validate_id.cpp
+++ b/source/val/validate_id.cpp
@@ -100,7 +100,7 @@ class idUsage {
 };
 
 #define DIAG(inst)                                                          \
-  position->index = inst ? inst->InstructionPosition() : -1;                \
+  position->index = inst ? inst->LineNum() : -1;                            \
   std::string disassembly;                                                  \
   if (inst) {                                                               \
     disassembly = module_.Disassemble(                                      \

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -295,7 +295,7 @@ DiagnosticStream ValidationState_t::diag(spv_result_t error_code,
                                          const Instruction* inst) const {
   std::string disassembly;
   if (inst)
-    disassembly = Disassemble(ordered_instructions_[inst->LineNum() - 1]);
+    disassembly = Disassemble(*inst);
 
   return DiagnosticStream({0, 0, inst ? inst->LineNum() : 0},
                           context_->consumer, disassembly, error_code);

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -294,8 +294,7 @@ bool ValidationState_t::IsOpcodeInCurrentLayoutSection(SpvOp op) {
 DiagnosticStream ValidationState_t::diag(spv_result_t error_code,
                                          const Instruction* inst) const {
   std::string disassembly;
-  if (inst)
-    disassembly = Disassemble(*inst);
+  if (inst) disassembly = Disassemble(*inst);
 
   return DiagnosticStream({0, 0, inst ? inst->LineNum() : 0},
                           context_->consumer, disassembly, error_code);

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -155,7 +155,6 @@ ValidationState_t::ValidationState_t(const spv_const_context ctx,
       options_(opt),
       words_(words),
       num_words_(num_words),
-      instruction_counter_(0),
       unresolved_forward_ids_{},
       operand_names_{},
       current_layout_section_(kLayoutCapabilities),
@@ -276,11 +275,6 @@ Instruction* ValidationState_t::FindDef(uint32_t id) {
   return it->second;
 }
 
-// Increments the instruction count. Used for diagnostic
-int ValidationState_t::increment_instruction_count() {
-  return instruction_counter_++;
-}
-
 ModuleLayoutSection ValidationState_t::current_layout_section() const {
   return current_layout_section_;
 }
@@ -299,15 +293,12 @@ bool ValidationState_t::IsOpcodeInCurrentLayoutSection(SpvOp op) {
 
 DiagnosticStream ValidationState_t::diag(spv_result_t error_code,
                                          const Instruction* inst) const {
-  int instruction_counter = inst ? inst->InstructionPosition() : -1;
   std::string disassembly;
-  if (instruction_counter >= 0 && static_cast<size_t>(instruction_counter) <=
-                                      ordered_instructions_.size()) {
-    disassembly = Disassemble(ordered_instructions_[instruction_counter - 1]);
-  }
-  size_t pos = instruction_counter >= 0 ? instruction_counter : 0;
-  return DiagnosticStream({0, 0, pos}, context_->consumer, disassembly,
-                          error_code);
+  if (inst)
+    disassembly = Disassemble(ordered_instructions_[inst->LineNum() - 1]);
+
+  return DiagnosticStream({0, 0, inst ? inst->LineNum() : 0},
+                          context_->consumer, disassembly, error_code);
 }
 
 std::vector<Function>& ValidationState_t::functions() {
@@ -476,7 +467,7 @@ Instruction* ValidationState_t::AddOrderedInstruction(
   } else {
     ordered_instructions_.emplace_back(inst, nullptr, nullptr);
   }
-  ordered_instructions_.back().SetInstructionPosition(instruction_counter_);
+  ordered_instructions_.back().SetLineNum(ordered_instructions_.size());
   return &ordered_instructions_.back();
 }
 

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -140,9 +140,6 @@ class ValidationState_t {
   /// Returns true if the id has been defined
   bool IsDefinedId(uint32_t id) const;
 
-  /// Increments the instruction count. Used for diagnostic
-  int increment_instruction_count();
-
   /// Increments the total number of instructions in the file.
   void increment_total_instructions() { total_instructions_++; }
 
@@ -530,9 +527,6 @@ class ValidationState_t {
   size_t total_instructions_ = 0;
   /// The total number of functions in the binary.
   size_t total_functions_ = 0;
-
-  /// Tracks the number of instructions evaluated by the validator
-  int instruction_counter_;
 
   /// IDs which have been forward declared but have not been defined
   std::unordered_set<uint32_t> unresolved_forward_ids_;


### PR DESCRIPTION
The instruction counter is the same as the size of the
ordered_instruction list when we insert a new instruction. This Cl
removes instruction_counter_ and uses that instead.