### PR TITLE
Update OpPhi instructions after splitting block.

### DIFF
--- a/source/opt/basic_block.cpp
+++ b/source/opt/basic_block.cpp
@@ -217,7 +217,7 @@ BasicBlock* BasicBlock::SplitBasicBlock(IRContext* context, uint32_t label_id,
   context->AnalyzeDefUse(new_block->GetLabelInst());
 
   // Update the phi nodes in the successor blocks to reference the new block id.
-  new_block->ForEachSuccessorLabel(
+  const_cast<const BasicBlock*>(new_block)->ForEachSuccessorLabel(
       [new_block, this, context](const uint32_t label) {
         BasicBlock* target_bb = context->get_instr_block(label);
         target_bb->ForEachPhiInst(

--- a/source/opt/merge_return_pass.cpp
+++ b/source/opt/merge_return_pass.cpp
@@ -321,7 +321,7 @@ void MergeReturnPass::PredicateBlock(
   // If this block is a header block, predicate the entire structured subgraph.
   // This can act recursively.
 
-  // If |block| is a loop head, then the back edge must jump to the original
+  // If |block| is a loop header, then the back edge must jump to the original
   // code, not the new header.
   if (block->GetLoopMergeInst()) {
     cfg()->SplitLoopHeader(block);
@@ -364,9 +364,7 @@ void MergeReturnPass::PredicateBlock(
   predicated->insert(new_merge);
   new_merge->SetParent(function_);
 
-  // Register the new labels.
-  get_def_use_mgr()->AnalyzeInstDef(old_body->GetLabelInst());
-  context()->set_instr_block(old_body->GetLabelInst(), old_body);
+  // Register the new label.
   get_def_use_mgr()->AnalyzeInstDef(new_merge->GetLabelInst());
   context()->set_instr_block(new_merge->GetLabelInst(), new_merge);
 


### PR DESCRIPTION
In the merge return pass, we will split a block, but not update the phi
instructions that reference the block.  Since the branch in the original
block is now part of the block with the new id, the phi nodes must be
updated.

This commit will change this.

I have also considered other places where an id of a basic block could
be referenced, and I don't think any of them need to change.

1) Branch and merge instructions: These jump to the start of the
original block, and so we want them to jump to the block that uses the
original id.  Nothing needs to change.

2) Names and decorations: I don't think it matters with block keeps the
name, and there are no decorations that apply to basic blocks.

Fixes #1736.