### PR TITLE
Register passes in the spirv-opt fuzzer.

### DIFF
--- a/testing/fuzzers/spvtools_opt_fuzzer.cpp
+++ b/testing/fuzzers/spvtools_opt_fuzzer.cpp
@@ -30,6 +30,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
                      (data[i + 3]) << 24;
   }
 
+  optimizer.RegisterPerformancePasses();
   optimizer.Run(input.data(), input.size(), &input);
 
   return 0;


### PR DESCRIPTION
The spirv-opt fuzzer is not registering any passes to run, so it is not
currently testing anything.  For now we will just register the
performance passes.

We should add different fuzzers for the legalization pass
(RegisterLegalizationPasses()), and the size passes
(RegisterSizePasses()).