### PR TITLE
Simplify validation ProcessInstruction

### DIFF
--- a/source/val/instruction.cpp
+++ b/source/val/instruction.cpp
@@ -19,33 +19,28 @@
 namespace spvtools {
 namespace val {
 
-#define OPERATOR(OP)                                                 \
-  bool operator OP(const Instruction& lhs, const Instruction& rhs) { \
-    return lhs.id() OP rhs.id();                                     \
-  }                                                                  \
-  bool operator OP(const Instruction& lhs, uint32_t rhs) {           \
-    return lhs.id() OP rhs;                                          \
-  }
-
-OPERATOR(<)
-OPERATOR(==)
-#undef OPERATOR
-
-Instruction::Instruction(const spv_parsed_instruction_t* inst,
-                         Function* defining_function,
-                         BasicBlock* defining_block)
+Instruction::Instruction(const spv_parsed_instruction_t* inst)
     : words_(inst->words, inst->words + inst->num_words),
       operands_(inst->operands, inst->operands + inst->num_operands),
       inst_({words_.data(), inst->num_words, inst->opcode, inst->ext_inst_type,
              inst->type_id, inst->result_id, operands_.data(),
-             inst->num_operands}),
-      line_num_(0),
-      function_(defining_function),
-      block_(defining_block),
-      uses_() {}
+             inst->num_operands}) {}
 
 void Instruction::RegisterUse(const Instruction* inst, uint32_t index) {
   uses_.push_back(std::make_pair(inst, index));
+}
+
+bool operator<(const Instruction& lhs, const Instruction& rhs) {
+  return lhs.id() < rhs.id();
+}
+bool operator<(const Instruction& lhs, uint32_t rhs) {
+  return lhs.id() < rhs;
+}
+bool operator==(const Instruction& lhs, const Instruction& rhs) {
+  return lhs.id() == rhs.id();
+}
+bool operator==(const Instruction& lhs, uint32_t rhs) {
+  return lhs.id() == rhs;
 }
 
 }  // namespace val

--- a/source/val/instruction.cpp
+++ b/source/val/instruction.cpp
@@ -33,9 +33,7 @@ void Instruction::RegisterUse(const Instruction* inst, uint32_t index) {
 bool operator<(const Instruction& lhs, const Instruction& rhs) {
   return lhs.id() < rhs.id();
 }
-bool operator<(const Instruction& lhs, uint32_t rhs) {
-  return lhs.id() < rhs;
-}
+bool operator<(const Instruction& lhs, uint32_t rhs) { return lhs.id() < rhs; }
 bool operator==(const Instruction& lhs, const Instruction& rhs) {
   return lhs.id() == rhs.id();
 }

--- a/source/val/instruction.h
+++ b/source/val/instruction.h
@@ -51,7 +51,7 @@ class Instruction {
   /// Returns the BasicBlock where the instruction was defined. nullptr if it
   /// was defined outside of a BasicBlock
   const BasicBlock* block() const { return block_; }
-  void set_block(BasicBlock* block) { block_ = block; }
+  void set_block(BasicBlock* b) { block_ = b; }
 
   /// Returns a vector of pairs of all references to this instruction's result
   /// id. The first element is the instruction in which this result id was

--- a/source/val/instruction.h
+++ b/source/val/instruction.h
@@ -34,9 +34,7 @@ class Function;
 /// instruction's result id
 class Instruction {
  public:
-  explicit Instruction(const spv_parsed_instruction_t* inst,
-                       Function* defining_function = nullptr,
-                       BasicBlock* defining_block = nullptr);
+  explicit Instruction(const spv_parsed_instruction_t* inst);
 
   /// Registers the use of the Instruction in instruction \p inst at \p index
   void RegisterUse(const Instruction* inst, uint32_t index);
@@ -48,10 +46,12 @@ class Instruction {
   /// Returns the Function where the instruction was defined. nullptr if it was
   /// defined outside of a Function
   const Function* function() const { return function_; }
+  void set_function(Function* func) { function_ = func; }
 
   /// Returns the BasicBlock where the instruction was defined. nullptr if it
   /// was defined outside of a BasicBlock
   const BasicBlock* block() const { return block_; }
+  void set_block(BasicBlock* block) { block_ = block; }
 
   /// Returns a vector of pairs of all references to this instruction's result
   /// id. The first element is the instruction in which this result id was
@@ -101,13 +101,13 @@ class Instruction {
   const std::vector<uint32_t> words_;
   const std::vector<spv_parsed_operand_t> operands_;
   spv_parsed_instruction_t inst_;
-  size_t line_num_;
+  size_t line_num_ = 0;
 
   /// The function in which this instruction was declared
-  Function* function_;
+  Function* function_ = nullptr;
 
   /// The basic block in which this instruction was declared
-  BasicBlock* block_;
+  BasicBlock* block_ = nullptr;
 
   /// This is a vector of pairs of all references to this instruction's result
   /// id. The first element is the instruction in which this result id was
@@ -116,13 +116,10 @@ class Instruction {
   std::vector<std::pair<const Instruction*, uint32_t>> uses_;
 };
 
-#define OPERATOR(OP)                                                \
-  bool operator OP(const Instruction& lhs, const Instruction& rhs); \
-  bool operator OP(const Instruction& lhs, uint32_t rhs)
-
-OPERATOR(<);
-OPERATOR(==);
-#undef OPERATOR
+bool operator<(const Instruction& lhs, const Instruction& rhs);
+bool operator<(const Instruction& lhs, uint32_t rhs);
+bool operator==(const Instruction& lhs, const Instruction& rhs);
+bool operator==(const Instruction& lhs, uint32_t rhs);
 
 }  // namespace val
 }  // namespace spvtools

--- a/source/val/validate.cpp
+++ b/source/val/validate.cpp
@@ -176,9 +176,9 @@ spv_result_t ValidateForwardDecls(ValidationState_t& _) {
 // Entry point validation. Based on 2.16.1 (Universal Validation Rules) of the
 // SPIRV spec:
 // * There is at least one OpEntryPoint instruction, unless the Linkage
-// capability is being used.
+//   capability is being used.
 // * No function can be targeted by both an OpEntryPoint instruction and an
-// OpFunctionCall instruction.
+//   OpFunctionCall instruction.
 spv_result_t ValidateEntryPoints(ValidationState_t& _) {
   _.ComputeFunctionToEntryPointMapping();
 

--- a/source/val/validate.cpp
+++ b/source/val/validate.cpp
@@ -107,46 +107,9 @@ spv_result_t ProcessExtensions(void* user_data,
 spv_result_t ProcessInstruction(void* user_data,
                                 const spv_parsed_instruction_t* inst) {
   ValidationState_t& _ = *(reinterpret_cast<ValidationState_t*>(user_data));
-  if (static_cast<SpvOp>(inst->opcode) == SpvOpEntryPoint) {
-    const auto entry_point = inst->words[2];
-    const SpvExecutionModel execution_model = SpvExecutionModel(inst->words[1]);
-    const char* str =
-        reinterpret_cast<const char*>(inst->words + inst->operands[2].offset);
-    ValidationState_t::EntryPointDescription desc;
-    desc.name = str;
-    std::vector<uint32_t> interfaces;
-    for (int i = 3; i < inst->num_operands; ++i) {
-      desc.interfaces.push_back(inst->words[inst->operands[i].offset]);
-    }
-    _.RegisterEntryPoint(entry_point, execution_model, std::move(desc));
-  }
-  if (static_cast<SpvOp>(inst->opcode) == SpvOpFunctionCall) {
-    _.AddFunctionCallTarget(inst->words[3]);
-  }
 
   auto* instruction = _.AddOrderedInstruction(inst);
   _.RegisterDebugInstruction(instruction);
-
-  if (auto error = CapabilityPass(_, instruction)) return error;
-  if (auto error = IdPass(_, instruction)) return error;
-  if (auto error = DataRulesPass(_, instruction)) return error;
-  if (auto error = ModuleLayoutPass(_, instruction)) return error;
-  if (auto error = CfgPass(_, instruction)) return error;
-  if (auto error = InstructionPass(_, instruction)) return error;
-  if (auto error = TypeUniquePass(_, instruction)) return error;
-  if (auto error = ArithmeticsPass(_, instruction)) return error;
-  if (auto error = CompositesPass(_, instruction)) return error;
-  if (auto error = ConversionPass(_, instruction)) return error;
-  if (auto error = DerivativesPass(_, instruction)) return error;
-  if (auto error = LogicalsPass(_, instruction)) return error;
-  if (auto error = BitwisePass(_, instruction)) return error;
-  if (auto error = ExtInstPass(_, instruction)) return error;
-  if (auto error = ImagePass(_, instruction)) return error;
-  if (auto error = AtomicsPass(_, instruction)) return error;
-  if (auto error = BarriersPass(_, instruction)) return error;
-  if (auto error = PrimitivesPass(_, instruction)) return error;
-  if (auto error = LiteralsPass(_, instruction)) return error;
-  if (auto error = NonUniformPass(_, instruction)) return error;
 
   return SPV_SUCCESS;
 }
@@ -193,6 +156,50 @@ UNUSED(void PrintDotGraph(ValidationState_t& _, Function func)) {
   }
 }
 
+spv_result_t ValidateForwardDecls(ValidationState_t& _) {
+  if (_.unresolved_forward_id_count() == 0)
+    return SPV_SUCCESS;
+
+  std::stringstream ss;
+  std::vector<uint32_t> ids = _.UnresolvedForwardIds();
+
+  std::transform(std::begin(ids), std::end(ids),
+                 std::ostream_iterator<std::string>(ss, " "),
+                 bind(&ValidationState_t::getIdName, std::ref(_),
+                      std::placeholders::_1));
+
+  auto id_str = ss.str();
+  return _.diag(SPV_ERROR_INVALID_ID, nullptr)
+         << "The following forward referenced IDs have not been defined:\n"
+         << id_str.substr(0, id_str.size() - 1);
+}
+
+// Entry point validation. Based on 2.16.1 (Universal Validation Rules) of the
+// SPIRV spec:
+// * There is at least one OpEntryPoint instruction, unless the Linkage
+// capability is being used.
+// * No function can be targeted by both an OpEntryPoint instruction and an
+// OpFunctionCall instruction.
+spv_result_t ValidateEntryPoints(ValidationState_t& _) {
+  _.ComputeFunctionToEntryPointMapping();
+
+  if (_.entry_points().empty() && !_.HasCapability(SpvCapabilityLinkage)) {
+    return _.diag(SPV_ERROR_INVALID_BINARY, nullptr)
+           << "No OpEntryPoint instruction was found. This is only allowed if "
+              "the Linkage capability is being used.";
+  }
+  for (const auto& entry_point : _.entry_points()) {
+    if (_.IsFunctionCallTarget(entry_point)) {
+      return _.diag(SPV_ERROR_INVALID_BINARY, _.FindDef(entry_point))
+             << "A function (" << entry_point
+             << ") may not be targeted by both an OpEntryPoint instruction and "
+                "an OpFunctionCall instruction.";
+    }
+  }
+
+  return SPV_SUCCESS;
+}
+
 spv_result_t ValidateBinaryUsingContextAndValidationState(
     const spv_context_t& context, const uint32_t* words, const size_t num_words,
     spv_diagnostic* pDiagnostic, ValidationState_t* vstate) {
@@ -237,7 +244,64 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
   }
 
   for (size_t i = 0; i < vstate->ordered_instructions().size(); ++i) {
-    const auto& instruction = vstate->ordered_instructions()[i];
+    auto& instruction = vstate->ordered_instructions()[i];
+
+    {
+      // In order to do this work outside of Process Instruction we need to be
+      // able to, briefly, de-const the instruction.
+      Instruction* inst = const_cast<Instruction*>(&instruction);
+
+      if (inst->opcode() == SpvOpEntryPoint) {
+        const auto entry_point = inst->GetOperandAs<uint32_t>(1);
+        const auto execution_model = inst->GetOperandAs<SpvExecutionModel>(0);
+        const char* str =
+            reinterpret_cast<const char*>(inst->words().data() + inst->operand(2).offset);
+
+        ValidationState_t::EntryPointDescription desc;
+        desc.name = str;
+
+        std::vector<uint32_t> interfaces;
+        for (size_t j = 3; j < inst->operands().size(); ++j)
+          desc.interfaces.push_back(inst->word(inst->operand(j).offset));
+
+        vstate->RegisterEntryPoint(entry_point, execution_model, std::move(desc));
+      }
+      if (inst->opcode() == SpvOpFunctionCall)
+        vstate->AddFunctionCallTarget(inst->GetOperandAs<uint32_t>(2));
+
+      if (vstate->in_function_body()) {
+
+        inst->set_function(&(vstate->current_function()));
+        inst->set_block(vstate->current_function().current_block());
+
+        if (vstate->in_block() &&
+            spvOpcodeIsBlockTerminator(inst->opcode())) {
+          vstate->current_function().current_block()->set_terminator(inst);
+        }
+      }
+
+      if (auto error = IdPass(*vstate, inst)) return error;
+    }
+
+    if (auto error = CapabilityPass(*vstate, &instruction)) return error;
+    if (auto error = DataRulesPass(*vstate, &instruction)) return error;
+    if (auto error = ModuleLayoutPass(*vstate, &instruction)) return error;
+    if (auto error = CfgPass(*vstate, &instruction)) return error;
+    if (auto error = InstructionPass(*vstate, &instruction)) return error;
+    if (auto error = TypeUniquePass(*vstate, &instruction)) return error;
+    if (auto error = ArithmeticsPass(*vstate, &instruction)) return error;
+    if (auto error = CompositesPass(*vstate, &instruction)) return error;
+    if (auto error = ConversionPass(*vstate, &instruction)) return error;
+    if (auto error = DerivativesPass(*vstate, &instruction)) return error;
+    if (auto error = LogicalsPass(*vstate, &instruction)) return error;
+    if (auto error = BitwisePass(*vstate, &instruction)) return error;
+    if (auto error = ExtInstPass(*vstate, &instruction)) return error;
+    if (auto error = ImagePass(*vstate, &instruction)) return error;
+    if (auto error = AtomicsPass(*vstate, &instruction)) return error;
+    if (auto error = BarriersPass(*vstate, &instruction)) return error;
+    if (auto error = PrimitivesPass(*vstate, &instruction)) return error;
+    if (auto error = LiteralsPass(*vstate, &instruction)) return error;
+    if (auto error = NonUniformPass(*vstate, &instruction)) return error;
 
     if (auto error = UpdateIdUse(*vstate, &instruction)) return error;
     if (auto error = ValidateMemoryInstructions(*vstate, &instruction))
@@ -256,25 +320,8 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
     return vstate->diag(SPV_ERROR_INVALID_LAYOUT, nullptr)
            << "Missing OpFunctionEnd at end of module.";
 
-  // TODO(umar): Add validation checks which require the parsing of the entire
-  // module. Use the information from the ProcessInstruction pass to make the
-  // checks.
-  if (vstate->unresolved_forward_id_count() > 0) {
-    std::stringstream ss;
-    std::vector<uint32_t> ids = vstate->UnresolvedForwardIds();
-
-    transform(std::begin(ids), std::end(ids),
-              std::ostream_iterator<std::string>(ss, " "),
-              bind(&ValidationState_t::getIdName, std::ref(*vstate),
-                   std::placeholders::_1));
-
-    auto id_str = ss.str();
-    return vstate->diag(SPV_ERROR_INVALID_ID, nullptr)
-           << "The following forward referenced IDs have not been defined:\n"
-           << id_str.substr(0, id_str.size() - 1);
-  }
-
-  vstate->ComputeFunctionToEntryPointMapping();
+  if (auto error = ValidateForwardDecls(*vstate)) return error;
+  if (auto error = ValidateEntryPoints(*vstate)) return error;
 
   // CFG checks are performed after the binary has been parsed
   // and the CFGPass has collected information about the control flow
@@ -282,29 +329,9 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
   if (auto error = CheckIdDefinitionDominateUse(*vstate)) return error;
   if (auto error = ValidateDecorations(*vstate)) return error;
   if (auto error = ValidateInterfaces(*vstate)) return error;
+  // TODO(dsinclair): Restructure ValidateBuiltins so we can move into the
+  // for() above as it loops over all ordered_instructions internally.
   if (auto error = ValidateBuiltIns(*vstate)) return error;
-
-  // Entry point validation. Based on 2.16.1 (Universal Validation Rules) of the
-  // SPIRV spec:
-  // * There is at least one OpEntryPoint instruction, unless the Linkage
-  // capability is being used.
-  // * No function can be targeted by both an OpEntryPoint instruction and an
-  // OpFunctionCall instruction.
-  if (vstate->entry_points().empty() &&
-      !vstate->HasCapability(SpvCapabilityLinkage)) {
-    return vstate->diag(SPV_ERROR_INVALID_BINARY, nullptr)
-           << "No OpEntryPoint instruction was found. This is only allowed if "
-              "the Linkage capability is being used.";
-  }
-  for (const auto& entry_point : vstate->entry_points()) {
-    if (vstate->IsFunctionCallTarget(entry_point)) {
-      return vstate->diag(SPV_ERROR_INVALID_BINARY,
-                          vstate->FindDef(entry_point))
-             << "A function (" << entry_point
-             << ") may not be targeted by both an OpEntryPoint instruction and "
-                "an OpFunctionCall instruction.";
-    }
-  }
 
   // NOTE: Copy each instruction for easier processing
   std::vector<spv_instruction_t> instructions;

--- a/source/val/validate.cpp
+++ b/source/val/validate.cpp
@@ -157,16 +157,15 @@ UNUSED(void PrintDotGraph(ValidationState_t& _, Function func)) {
 }
 
 spv_result_t ValidateForwardDecls(ValidationState_t& _) {
-  if (_.unresolved_forward_id_count() == 0)
-    return SPV_SUCCESS;
+  if (_.unresolved_forward_id_count() == 0) return SPV_SUCCESS;
 
   std::stringstream ss;
   std::vector<uint32_t> ids = _.UnresolvedForwardIds();
 
-  std::transform(std::begin(ids), std::end(ids),
-                 std::ostream_iterator<std::string>(ss, " "),
-                 bind(&ValidationState_t::getIdName, std::ref(_),
-                      std::placeholders::_1));
+  std::transform(
+      std::begin(ids), std::end(ids),
+      std::ostream_iterator<std::string>(ss, " "),
+      bind(&ValidationState_t::getIdName, std::ref(_), std::placeholders::_1));
 
   auto id_str = ss.str();
   return _.diag(SPV_ERROR_INVALID_ID, nullptr)
@@ -254,8 +253,8 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
       if (inst->opcode() == SpvOpEntryPoint) {
         const auto entry_point = inst->GetOperandAs<uint32_t>(1);
         const auto execution_model = inst->GetOperandAs<SpvExecutionModel>(0);
-        const char* str =
-            reinterpret_cast<const char*>(inst->words().data() + inst->operand(2).offset);
+        const char* str = reinterpret_cast<const char*>(
+            inst->words().data() + inst->operand(2).offset);
 
         ValidationState_t::EntryPointDescription desc;
         desc.name = str;
@@ -264,18 +263,17 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
         for (size_t j = 3; j < inst->operands().size(); ++j)
           desc.interfaces.push_back(inst->word(inst->operand(j).offset));
 
-        vstate->RegisterEntryPoint(entry_point, execution_model, std::move(desc));
+        vstate->RegisterEntryPoint(entry_point, execution_model,
+                                   std::move(desc));
       }
       if (inst->opcode() == SpvOpFunctionCall)
         vstate->AddFunctionCallTarget(inst->GetOperandAs<uint32_t>(2));
 
       if (vstate->in_function_body()) {
-
         inst->set_function(&(vstate->current_function()));
         inst->set_block(vstate->current_function().current_block());
 
-        if (vstate->in_block() &&
-            spvOpcodeIsBlockTerminator(inst->opcode())) {
+        if (vstate->in_block() && spvOpcodeIsBlockTerminator(inst->opcode())) {
           vstate->current_function().current_block()->set_terminator(inst);
         }
       }

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -455,17 +455,7 @@ spv_result_t ValidationState_t::RegisterFunctionEnd() {
 
 Instruction* ValidationState_t::AddOrderedInstruction(
     const spv_parsed_instruction_t* inst) {
-  if (in_function_body()) {
-    ordered_instructions_.emplace_back(inst, &current_function(),
-                                       current_function().current_block());
-    if (in_block() &&
-        spvOpcodeIsBlockTerminator(static_cast<SpvOp>(inst->opcode))) {
-      current_function().current_block()->set_terminator(
-          &ordered_instructions_.back());
-    }
-  } else {
-    ordered_instructions_.emplace_back(inst, nullptr, nullptr);
-  }
+  ordered_instructions_.emplace_back(inst);
   ordered_instructions_.back().SetLineNum(ordered_instructions_.size());
   return &ordered_instructions_.back();
 }


### PR DESCRIPTION
This CL moves most of the logic out of validation ProcessInstruction and
groups it into validate. This places all of the validation logic in the
same place making it clearer what is running.

The Instruction class is changed to allow setting the function and block
after creation.