### PR TITLE
Validation within function body when doing a FunctionCall.

### DIFF
--- a/source/val/validate.cpp
+++ b/source/val/validate.cpp
@@ -269,7 +269,7 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
       if (inst->opcode() == SpvOpFunctionCall) {
         if (!vstate->in_function_body()) {
           return vstate->diag(SPV_ERROR_INVALID_LAYOUT, &instruction)
-               << "A FunctionCall must happen within a function body.";
+                 << "A FunctionCall must happen within a function body.";
         }
 
         vstate->AddFunctionCallTarget(inst->GetOperandAs<uint32_t>(2));

--- a/source/val/validate.cpp
+++ b/source/val/validate.cpp
@@ -266,8 +266,14 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
         vstate->RegisterEntryPoint(entry_point, execution_model,
                                    std::move(desc));
       }
-      if (inst->opcode() == SpvOpFunctionCall)
+      if (inst->opcode() == SpvOpFunctionCall) {
+        if (!vstate->in_function_body()) {
+          return vstate->diag(SPV_ERROR_INVALID_LAYOUT)
+               << "A FunctionCall must happen within a function body.";
+        }
+
         vstate->AddFunctionCallTarget(inst->GetOperandAs<uint32_t>(2));
+      }
 
       if (vstate->in_function_body()) {
         inst->set_function(&(vstate->current_function()));

--- a/source/val/validate.cpp
+++ b/source/val/validate.cpp
@@ -268,7 +268,7 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
       }
       if (inst->opcode() == SpvOpFunctionCall) {
         if (!vstate->in_function_body()) {
-          return vstate->diag(SPV_ERROR_INVALID_LAYOUT)
+          return vstate->diag(SPV_ERROR_INVALID_LAYOUT, &instruction)
                << "A FunctionCall must happen within a function body.";
         }
 

--- a/test/val/val_layout_test.cpp
+++ b/test/val/val_layout_test.cpp
@@ -494,6 +494,21 @@ TEST_F(ValidateEntryPoint, FunctionIsTargetOfEntryPointAndFunctionCallBad) {
                 "instruction and an OpFunctionCall instruction."));
 }
 
+// Invalid. Must be within a function to make a function call.
+TEST_F(ValidateEntryPoint, FunctionCallOutsideFunctionBody) {
+  std::string spirv = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpName %variableName "variableName"
+         %34 = OpFunctionCall %variableName %1
+      )";
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("FunctionCall must happen within a function body."));
+}
+
 // Valid. Module with a function but no entry point is valid when Linkage
 // Capability is used.
 TEST_F(ValidateEntryPoint, NoEntryPointWithLinkageCapGood) {


### PR DESCRIPTION
When validating a FunctionCall we can trigger an assert if we are not
currently within a function body. This CL adds verification that we are
within a function before attempting to add a function call.

Issue 1789.