### PR TITLE
Rewrite include guards

### DIFF
--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -19,7 +19,6 @@ for more details about the presubmit API built into depot_tools.
 """
 
 LINT_FILTERS = [
-  "-build/header_guard",
   "-build/include",
   "-build/include_order",
   "-build/include_what_you_use",

--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SPIRV_TOOLS_LIBSPIRV_H_
-#define SPIRV_TOOLS_LIBSPIRV_H_
+#ifndef INCLUDE_SPIRV_TOOLS_LIBSPIRV_H_
+#define INCLUDE_SPIRV_TOOLS_LIBSPIRV_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -596,4 +596,4 @@ SPIRV_TOOLS_EXPORT spv_result_t spvBinaryParse(
 }
 #endif
 
-#endif  // SPIRV_TOOLS_LIBSPIRV_H_
+#endif  // INCLUDE_SPIRV_TOOLS_LIBSPIRV_H_

--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SPIRV_TOOLS_LIBSPIRV_HPP_
-#define SPIRV_TOOLS_LIBSPIRV_HPP_
+#ifndef INCLUDE_SPIRV_TOOLS_LIBSPIRV_HPP_
+#define INCLUDE_SPIRV_TOOLS_LIBSPIRV_HPP_
 
 #include <functional>
 #include <memory>
@@ -182,4 +182,4 @@ class SpirvTools {
 
 }  // namespace spvtools
 
-#endif  // SPIRV_TOOLS_LIBSPIRV_HPP_
+#endif  // INCLUDE_SPIRV_TOOLS_LIBSPIRV_HPP_

--- a/include/spirv-tools/linker.hpp
+++ b/include/spirv-tools/linker.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SPIRV_TOOLS_LINKER_HPP_
-#define SPIRV_TOOLS_LINKER_HPP_
+#ifndef INCLUDE_SPIRV_TOOLS_LINKER_HPP_
+#define INCLUDE_SPIRV_TOOLS_LINKER_HPP_
 
 #include <cstdint>
 
@@ -94,4 +94,4 @@ spv_result_t Link(const Context& context, const uint32_t* const* binaries,
 
 }  // namespace spvtools
 
-#endif  // SPIRV_TOOLS_LINKER_HPP_
+#endif  // INCLUDE_SPIRV_TOOLS_LINKER_HPP_

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SPIRV_TOOLS_OPTIMIZER_HPP_
-#define SPIRV_TOOLS_OPTIMIZER_HPP_
+#ifndef INCLUDE_SPIRV_TOOLS_OPTIMIZER_HPP_
+#define INCLUDE_SPIRV_TOOLS_OPTIMIZER_HPP_
 
 #include <memory>
 #include <ostream>
@@ -643,4 +643,4 @@ Optimizer::PassToken CreateCombineAccessChainsPass();
 
 }  // namespace spvtools
 
-#endif  // SPIRV_TOOLS_OPTIMIZER_HPP_
+#endif  // INCLUDE_SPIRV_TOOLS_OPTIMIZER_HPP_

--- a/source/assembly_grammar.h
+++ b/source/assembly_grammar.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_ASSEMBLY_GRAMMAR_H_
-#define LIBSPIRV_ASSEMBLY_GRAMMAR_H_
+#ifndef SOURCE_ASSEMBLY_GRAMMAR_H_
+#define SOURCE_ASSEMBLY_GRAMMAR_H_
 
 #include "enum_set.h"
 #include "latest_version_spirv_header.h"
@@ -135,4 +135,4 @@ class AssemblyGrammar {
 
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_ASSEMBLY_GRAMMAR_H_
+#endif  // SOURCE_ASSEMBLY_GRAMMAR_H_

--- a/source/binary.h
+++ b/source/binary.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_BINARY_H_
-#define LIBSPIRV_BINARY_H_
+#ifndef SOURCE_BINARY_H_
+#define SOURCE_BINARY_H_
 
 #include "spirv-tools/libspirv.h"
 #include "spirv_definition.h"
@@ -33,4 +33,4 @@ spv_result_t spvBinaryHeaderGet(const spv_const_binary binary,
 // replacement for C11's strnlen_s which might not exist in all environments.
 size_t spv_strnlen_s(const char* str, size_t strsz);
 
-#endif  // LIBSPIRV_BINARY_H_
+#endif  // SOURCE_BINARY_H_

--- a/source/cfa.h
+++ b/source/cfa.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SPVTOOLS_CFA_H_
-#define SPVTOOLS_CFA_H_
+#ifndef SOURCE_CFA_H_
+#define SOURCE_CFA_H_
 
 #include <algorithm>
 #include <cassert>
@@ -344,4 +344,4 @@ void CFA<BB>::ComputeAugmentedCFG(
 
 }  // namespace spvtools
 
-#endif  // SPVTOOLS_CFA_H_
+#endif  // SOURCE_CFA_H_

--- a/source/comp/markv.h
+++ b/source/comp/markv.h
@@ -18,8 +18,8 @@
 // make it more similar to other compressed SPIR-V files to further improve
 // compression of the dataset.
 
-#ifndef SPIRV_TOOLS_MARKV_HPP_
-#define SPIRV_TOOLS_MARKV_HPP_
+#ifndef SOURCE_COMP_MARKV_H_
+#define SOURCE_COMP_MARKV_H_
 
 #include <string>
 #include <vector>
@@ -73,4 +73,4 @@ spv_result_t MarkvToSpirv(
 }  // namespace comp
 }  // namespace spvtools
 
-#endif  // SPIRV_TOOLS_MARKV_HPP_
+#endif  // SOURCE_COMP_MARKV_H_

--- a/source/comp/markv_model.h
+++ b/source/comp/markv_model.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_COMP_MARKV_MODEL_H_
-#define LIBSPIRV_COMP_MARKV_MODEL_H_
+#ifndef SOURCE_COMP_MARKV_MODEL_H_
+#define SOURCE_COMP_MARKV_MODEL_H_
 
 #include <map>
 #include <unordered_set>
@@ -231,4 +231,4 @@ class MarkvModel {
 }  // namespace comp
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_COMP_MARKV_MODEL_H_
+#endif  // SOURCE_COMP_MARKV_MODEL_H_

--- a/source/diagnostic.h
+++ b/source/diagnostic.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_DIAGNOSTIC_H_
-#define LIBSPIRV_DIAGNOSTIC_H_
+#ifndef SOURCE_DIAGNOSTIC_H_
+#define SOURCE_DIAGNOSTIC_H_
 
 #include <sstream>
 #include <string>
@@ -76,4 +76,4 @@ std::string spvResultToString(spv_result_t res);
 
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_DIAGNOSTIC_H_
+#endif  // SOURCE_DIAGNOSTIC_H_

--- a/source/disassemble.h
+++ b/source/disassemble.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SPIRV_TOOLS_DISASSEMBLE_H_
-#define SPIRV_TOOLS_DISASSEMBLE_H_
+#ifndef SOURCE_DISASSEMBLE_H_
+#define SOURCE_DISASSEMBLE_H_
 
 #include <string>
 
@@ -35,4 +35,4 @@ std::string spvInstructionBinaryToText(const spv_target_env env,
 
 }  // namespace spvtools
 
-#endif  // SPIRV_TOOLS_DISASSEMBLE_H_
+#endif  // SOURCE_DISASSEMBLE_H_

--- a/source/enum_set.h
+++ b/source/enum_set.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_ENUM_SET_H
-#define LIBSPIRV_ENUM_SET_H
+#ifndef SOURCE_ENUM_SET_H_
+#define SOURCE_ENUM_SET_H_
 
 #include <cstdint>
 #include <functional>
@@ -169,4 +169,4 @@ using CapabilitySet = EnumSet<SpvCapability>;
 
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_ENUM_SET_H
+#endif  // SOURCE_ENUM_SET_H_

--- a/source/enum_string_mapping.h
+++ b/source/enum_string_mapping.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_ENUM_STRING_MAPPING_H_
-#define LIBSPIRV_ENUM_STRING_MAPPING_H_
+#ifndef SOURCE_ENUM_STRING_MAPPING_H_
+#define SOURCE_ENUM_STRING_MAPPING_H_
 
 #include <string>
 
@@ -33,4 +33,4 @@ const char* CapabilityToString(SpvCapability capability);
 
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_ENUM_STRING_MAPPING_H_
+#endif  // SOURCE_ENUM_STRING_MAPPING_H_

--- a/source/ext_inst.h
+++ b/source/ext_inst.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_EXT_INST_H_
-#define LIBSPIRV_EXT_INST_H_
+#ifndef SOURCE_EXT_INST_H_
+#define SOURCE_EXT_INST_H_
 
 #include "spirv-tools/libspirv.h"
 #include "table.h"
@@ -37,4 +37,4 @@ spv_result_t spvExtInstTableValueLookup(const spv_ext_inst_table table,
                                         const uint32_t value,
                                         spv_ext_inst_desc* pEntry);
 
-#endif  // LIBSPIRV_EXT_INST_H_
+#endif  // SOURCE_EXT_INST_H_

--- a/source/extensions.h
+++ b/source/extensions.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_EXTENSIONS_H_
-#define LIBSPIRV_EXTENSIONS_H_
+#ifndef SOURCE_EXTENSIONS_H_
+#define SOURCE_EXTENSIONS_H_
 
 #include <string>
 
@@ -37,4 +37,4 @@ std::string ExtensionSetToString(const ExtensionSet& extensions);
 
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_EXTENSIONS_H_
+#endif  // SOURCE_EXTENSIONS_H_

--- a/source/id_descriptor.h
+++ b/source/id_descriptor.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_ID_DESCRIPTOR_H_
-#define LIBSPIRV_ID_DESCRIPTOR_H_
+#ifndef SOURCE_ID_DESCRIPTOR_H_
+#define SOURCE_ID_DESCRIPTOR_H_
 
 #include <unordered_map>
 #include <vector>
@@ -60,4 +60,4 @@ class IdDescriptorCollection {
 
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_ID_DESCRIPTOR_H_
+#endif  // SOURCE_ID_DESCRIPTOR_H_

--- a/source/instruction.h
+++ b/source/instruction.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_INSTRUCTION_H_
-#define LIBSPIRV_INSTRUCTION_H_
+#ifndef SOURCE_INSTRUCTION_H_
+#define SOURCE_INSTRUCTION_H_
 
 #include <cstdint>
 #include <vector>
@@ -46,4 +46,4 @@ inline void spvInstructionAddWord(spv_instruction_t* inst, uint32_t value) {
   inst->words.push_back(value);
 }
 
-#endif  // LIBSPIRV_INSTRUCTION_H_
+#endif  // SOURCE_INSTRUCTION_H_

--- a/source/latest_version_glsl_std_450_header.h
+++ b/source/latest_version_glsl_std_450_header.h
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_LATEST_VERSION_GLSL_STD_450_HEADER_H_
-#define LIBSPIRV_LATEST_VERSION_GLSL_STD_450_HEADER_H_
+#ifndef SOURCE_LATEST_VERSION_GLSL_STD_450_HEADER_H_
+#define SOURCE_LATEST_VERSION_GLSL_STD_450_HEADER_H_
 
 #include "spirv/unified1/GLSL.std.450.h"
 
-#endif  // LIBSPIRV_LATEST_VERSION_GLSL_STD_450_HEADER_H_
+#endif  // SOURCE_LATEST_VERSION_GLSL_STD_450_HEADER_H_

--- a/source/latest_version_opencl_std_header.h
+++ b/source/latest_version_opencl_std_header.h
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_LATEST_VERSION_OPENCL_STD_HEADER_H_
-#define LIBSPIRV_LATEST_VERSION_OPENCL_STD_HEADER_H_
+#ifndef SOURCE_LATEST_VERSION_OPENCL_STD_HEADER_H_
+#define SOURCE_LATEST_VERSION_OPENCL_STD_HEADER_H_
 
 #include "spirv/unified1/OpenCL.std.h"
 
-#endif  // LIBSPIRV_LATEST_VERSION_OPENCL_STD_HEADER_H_
+#endif  // SOURCE_LATEST_VERSION_OPENCL_STD_HEADER_H_

--- a/source/latest_version_spirv_header.h
+++ b/source/latest_version_spirv_header.h
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_LATEST_VERSION_SPIRV_HEADER_H_
-#define LIBSPIRV_LATEST_VERSION_SPIRV_HEADER_H_
+#ifndef SOURCE_LATEST_VERSION_SPIRV_HEADER_H_
+#define SOURCE_LATEST_VERSION_SPIRV_HEADER_H_
 
 #include "spirv/unified1/spirv.h"
 
-#endif  // LIBSPIRV_LATEST_VERSION_SPIRV_HEADER_H_
+#endif  // SOURCE_LATEST_VERSION_SPIRV_HEADER_H_

--- a/source/macro.h
+++ b/source/macro.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_MACRO_H_
-#define LIBSPIRV_MACRO_H_
+#ifndef SOURCE_MACRO_H_
+#define SOURCE_MACRO_H_
 
 // Evaluates to the number of elements of array A.
 //
@@ -22,4 +22,4 @@
 // std::array::size.
 #define ARRAY_SIZE(A) (static_cast<uint32_t>(sizeof(A) / sizeof(A[0])))
 
-#endif  // LIBSPIRV_MACRO_H_
+#endif  // SOURCE_MACRO_H_

--- a/source/message.h
+++ b/source/message.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SPIRV_TOOLS_MESSAGE_H_
-#define SPIRV_TOOLS_MESSAGE_H_
+#ifndef SOURCE_MESSAGE_H_
+#define SOURCE_MESSAGE_H_
 
 #include <string>
 
@@ -30,4 +30,4 @@ std::string StringifyMessage(spv_message_level_t level, const char* source,
 
 }  // namespace spvtools
 
-#endif  // SPIRV_TOOLS_MESSAGE_H_
+#endif  // SOURCE_MESSAGE_H_

--- a/source/name_mapper.h
+++ b/source/name_mapper.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_NAME_MAPPER_H_
-#define LIBSPIRV_NAME_MAPPER_H_
+#ifndef SOURCE_NAME_MAPPER_H_
+#define SOURCE_NAME_MAPPER_H_
 
 #include <functional>
 #include <string>
@@ -119,4 +119,4 @@ class FriendlyNameMapper {
 
 }  // namespace spvtools
 
-#endif  // _LIBSPIRV_NAME_MAPPER_H_
+#endif  // SOURCE_NAME_MAPPER_H_

--- a/source/opcode.h
+++ b/source/opcode.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPCODE_H_
-#define LIBSPIRV_OPCODE_H_
+#ifndef SOURCE_OPCODE_H_
+#define SOURCE_OPCODE_H_
 
 #include "instruction.h"
 #include "latest_version_spirv_header.h"
@@ -125,4 +125,4 @@ bool spvOpcodeIsNonUniformGroupOperation(SpvOp opcode);
 // Returns true if the opcode with vector inputs could be divided into a series
 // of independent scalar operations that would give the same result.
 bool spvOpcodeIsScalarizable(SpvOp opcode);
-#endif  // LIBSPIRV_OPCODE_H_
+#endif  // SOURCE_OPCODE_H_

--- a/source/operand.h
+++ b/source/operand.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPERAND_H_
-#define LIBSPIRV_OPERAND_H_
+#ifndef SOURCE_OPERAND_H_
+#define SOURCE_OPERAND_H_
 
 #include <functional>
 
@@ -137,4 +137,4 @@ bool spvIsIdType(spv_operand_type_t type);
 std::function<bool(unsigned)> spvOperandCanBeForwardDeclaredFunction(
     SpvOp opcode);
 
-#endif  // LIBSPIRV_OPERAND_H_
+#endif  // SOURCE_OPERAND_H_

--- a/source/opt/aggressive_dead_code_elim_pass.h
+++ b/source/opt/aggressive_dead_code_elim_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_AGGRESSIVE_DCE_PASS_H_
-#define LIBSPIRV_OPT_AGGRESSIVE_DCE_PASS_H_
+#ifndef SOURCE_OPT_AGGRESSIVE_DEAD_CODE_ELIM_PASS_H_
+#define SOURCE_OPT_AGGRESSIVE_DEAD_CODE_ELIM_PASS_H_
 
 #include <util/bit_vector.h>
 #include <algorithm>
@@ -186,4 +186,4 @@ class AggressiveDCEPass : public MemPass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_AGGRESSIVE_DCE_PASS_H_
+#endif  // SOURCE_OPT_AGGRESSIVE_DEAD_CODE_ELIM_PASS_H_

--- a/source/opt/basic_block.h
+++ b/source/opt/basic_block.h
@@ -15,8 +15,8 @@
 // This file defines the language constructs for representing a SPIR-V
 // module in memory.
 
-#ifndef LIBSPIRV_OPT_BASIC_BLOCK_H_
-#define LIBSPIRV_OPT_BASIC_BLOCK_H_
+#ifndef SOURCE_OPT_BASIC_BLOCK_H_
+#define SOURCE_OPT_BASIC_BLOCK_H_
 
 #include <functional>
 #include <iterator>
@@ -316,4 +316,4 @@ inline void BasicBlock::ForEachPhiInst(
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_BASIC_BLOCK_H_
+#endif  // SOURCE_OPT_BASIC_BLOCK_H_

--- a/source/opt/block_merge_pass.h
+++ b/source/opt/block_merge_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_BLOCK_MERGE_PASS_H_
-#define LIBSPIRV_OPT_BLOCK_MERGE_PASS_H_
+#ifndef SOURCE_OPT_BLOCK_MERGE_PASS_H_
+#define SOURCE_OPT_BLOCK_MERGE_PASS_H_
 
 #include <algorithm>
 #include <map>
@@ -68,4 +68,4 @@ class BlockMergePass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_BLOCK_MERGE_PASS_H_
+#endif  // SOURCE_OPT_BLOCK_MERGE_PASS_H_

--- a/source/opt/build_module.h
+++ b/source/opt/build_module.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SPIRV_TOOLS_OPT_BUILD_MODULE_H_
-#define SPIRV_TOOLS_OPT_BUILD_MODULE_H_
+#ifndef SOURCE_OPT_BUILD_MODULE_H_
+#define SOURCE_OPT_BUILD_MODULE_H_
 
 #include <memory>
 #include <string>
@@ -43,4 +43,4 @@ std::unique_ptr<opt::IRContext> BuildModule(
 
 }  // namespace spvtools
 
-#endif  // SPIRV_TOOLS_OPT_BUILD_MODULE_H_
+#endif  // SOURCE_OPT_BUILD_MODULE_H_

--- a/source/opt/ccp_pass.h
+++ b/source/opt/ccp_pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_CCP_PASS_H_
-#define LIBSPIRV_OPT_CCP_PASS_H_
+#ifndef SOURCE_OPT_CCP_PASS_H_
+#define SOURCE_OPT_CCP_PASS_H_
 
 #include "constants.h"
 #include "function.h"
@@ -106,4 +106,4 @@ class CCPPass : public MemPass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif
+#endif  // SOURCE_OPT_CCP_PASS_H_

--- a/source/opt/cfg.h
+++ b/source/opt/cfg.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_CFG_H_
-#define LIBSPIRV_OPT_CFG_H_
+#ifndef SOURCE_OPT_CFG_H_
+#define SOURCE_OPT_CFG_H_
 
 #include "basic_block.h"
 
@@ -167,4 +167,4 @@ class CFG {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_CFG_H_
+#endif  // SOURCE_OPT_CFG_H_

--- a/source/opt/cfg_cleanup_pass.h
+++ b/source/opt/cfg_cleanup_pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_CFG_CLEANUP_PASS_H_
-#define LIBSPIRV_OPT_CFG_CLEANUP_PASS_H_
+#ifndef SOURCE_OPT_CFG_CLEANUP_PASS_H_
+#define SOURCE_OPT_CFG_CLEANUP_PASS_H_
 
 #include "function.h"
 #include "mem_pass.h"
@@ -37,4 +37,4 @@ class CFGCleanupPass : public MemPass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif
+#endif  // SOURCE_OPT_CFG_CLEANUP_PASS_H_

--- a/source/opt/combine_access_chains.h
+++ b/source/opt/combine_access_chains.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_COMBINE_ACCESS_CHAINS_H_
-#define LIBSPIRV_OPT_COMBINE_ACCESS_CHAINS_H_
+#ifndef SOURCE_OPT_COMBINE_ACCESS_CHAINS_H_
+#define SOURCE_OPT_COMBINE_ACCESS_CHAINS_H_
 
 #include "pass.h"
 
@@ -77,4 +77,4 @@ class CombineAccessChains : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_COMBINE_ACCESS_CHAINS_H_
+#endif  // SOURCE_OPT_COMBINE_ACCESS_CHAINS_H_

--- a/source/opt/common_uniform_elim_pass.h
+++ b/source/opt/common_uniform_elim_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_COMMON_UNIFORM_ELIM_PASS_H_
-#define LIBSPIRV_OPT_COMMON_UNIFORM_ELIM_PASS_H_
+#ifndef SOURCE_OPT_COMMON_UNIFORM_ELIM_PASS_H_
+#define SOURCE_OPT_COMMON_UNIFORM_ELIM_PASS_H_
 
 #include <algorithm>
 #include <map>
@@ -206,4 +206,4 @@ class CommonUniformElimPass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_SSAMEM_PASS_H_
+#endif  // SOURCE_OPT_COMMON_UNIFORM_ELIM_PASS_H_

--- a/source/opt/compact_ids_pass.h
+++ b/source/opt/compact_ids_pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_COMPACT_IDS_PASS_H_
-#define LIBSPIRV_OPT_COMPACT_IDS_PASS_H_
+#ifndef SOURCE_OPT_COMPACT_IDS_PASS_H_
+#define SOURCE_OPT_COMPACT_IDS_PASS_H_
 
 #include "ir_context.h"
 #include "module.h"
@@ -39,4 +39,4 @@ class CompactIdsPass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_COMPACT_IDS_PASS_H_
+#endif  // SOURCE_OPT_COMPACT_IDS_PASS_H_

--- a/source/opt/composite.h
+++ b/source/opt/composite.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_UTIL_COMPOSITE_PASS_H_
-#define LIBSPIRV_UTIL_COMPOSITE_PASS_H_
+#ifndef SOURCE_OPT_COMPOSITE_H_
+#define SOURCE_OPT_COMPOSITE_H_
 
 #include <algorithm>
 #include <map>
@@ -47,4 +47,4 @@ bool ExtInsConflict(const std::vector<uint32_t>& extIndices,
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_UTIL_COMPOSITE_PASS_H_
+#endif  // SOURCE_OPT_COMPOSITE_H_

--- a/source/opt/const_folding_rules.h
+++ b/source/opt/const_folding_rules.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_CONST_FOLDING_RULES_H_
-#define LIBSPIRV_OPT_CONST_FOLDING_RULES_H_
+#ifndef SOURCE_OPT_CONST_FOLDING_RULES_H_
+#define SOURCE_OPT_CONST_FOLDING_RULES_H_
 
 #include <vector>
 
@@ -76,4 +76,4 @@ class ConstantFoldingRules {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_CONST_FOLDING_RULES_H_
+#endif  // SOURCE_OPT_CONST_FOLDING_RULES_H_

--- a/source/opt/constants.h
+++ b/source/opt/constants.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_CONSTANTS_H_
-#define LIBSPIRV_OPT_CONSTANTS_H_
+#ifndef SOURCE_OPT_CONSTANTS_H_
+#define SOURCE_OPT_CONSTANTS_H_
 
 #include <cinttypes>
 #include <memory>
@@ -684,4 +684,4 @@ class ConstantManager {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_CONSTANTS_H_
+#endif  // SOURCE_OPT_CONSTANTS_H_

--- a/source/opt/copy_prop_arrays.h
+++ b/source/opt/copy_prop_arrays.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_COPY_PROP_H_
-#define LIBSPIRV_OPT_COPY_PROP_H_
+#ifndef SOURCE_OPT_COPY_PROP_ARRAYS_H_
+#define SOURCE_OPT_COPY_PROP_ARRAYS_H_
 
 #include "mem_pass.h"
 
@@ -225,4 +225,4 @@ class CopyPropagateArrays : public MemPass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_COPY_PROP_H_
+#endif  // SOURCE_OPT_COPY_PROP_ARRAYS_H_

--- a/source/opt/dead_branch_elim_pass.h
+++ b/source/opt/dead_branch_elim_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_DEAD_BRANCH_ELIM_PASS_H_
-#define LIBSPIRV_OPT_DEAD_BRANCH_ELIM_PASS_H_
+#ifndef SOURCE_OPT_DEAD_BRANCH_ELIM_PASS_H_
+#define SOURCE_OPT_DEAD_BRANCH_ELIM_PASS_H_
 
 #include <algorithm>
 #include <map>
@@ -134,4 +134,4 @@ class DeadBranchElimPass : public MemPass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_DEAD_BRANCH_ELIM_PASS_H_
+#endif  // SOURCE_OPT_DEAD_BRANCH_ELIM_PASS_H_

--- a/source/opt/dead_insert_elim_pass.h
+++ b/source/opt/dead_insert_elim_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_DEAD_INSERT_ELIM_PASS_H_
-#define LIBSPIRV_OPT_DEAD_INSERT_ELIM_PASS_H_
+#ifndef SOURCE_OPT_DEAD_INSERT_ELIM_PASS_H_
+#define SOURCE_OPT_DEAD_INSERT_ELIM_PASS_H_
 
 #include <algorithm>
 #include <map>
@@ -85,4 +85,4 @@ class DeadInsertElimPass : public MemPass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_DEAD_INSERT_ELIM_PASS_H_
+#endif  // SOURCE_OPT_DEAD_INSERT_ELIM_PASS_H_

--- a/source/opt/dead_variable_elimination.h
+++ b/source/opt/dead_variable_elimination.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SPIRV_TOOLS_DEAD_VARIABLE_ELIMINATION_H
-#define SPIRV_TOOLS_DEAD_VARIABLE_ELIMINATION_H
+#ifndef SOURCE_OPT_DEAD_VARIABLE_ELIMINATION_H_
+#define SOURCE_OPT_DEAD_VARIABLE_ELIMINATION_H_
 
 #include <climits>
 #include <unordered_map>
@@ -52,4 +52,4 @@ class DeadVariableElimination : public MemPass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // SPIRV_TOOLS_DEAD_VARIABLE_ELIMINATION_H
+#endif  // SOURCE_OPT_DEAD_VARIABLE_ELIMINATION_H_

--- a/source/opt/decoration_manager.h
+++ b/source/opt/decoration_manager.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_DECORATION_MANAGER_H_
-#define LIBSPIRV_OPT_DECORATION_MANAGER_H_
+#ifndef SOURCE_OPT_DECORATION_MANAGER_H_
+#define SOURCE_OPT_DECORATION_MANAGER_H_
 
 #include <functional>
 #include <unordered_map>
@@ -133,4 +133,4 @@ class DecorationManager {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_DECORATION_MANAGER_H_
+#endif  // SOURCE_OPT_DECORATION_MANAGER_H_

--- a/source/opt/def_use_manager.h
+++ b/source/opt/def_use_manager.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_DEF_USE_MANAGER_H_
-#define LIBSPIRV_OPT_DEF_USE_MANAGER_H_
+#ifndef SOURCE_OPT_DEF_USE_MANAGER_H_
+#define SOURCE_OPT_DEF_USE_MANAGER_H_
 
 #include <list>
 #include <set>
@@ -252,4 +252,4 @@ class DefUseManager {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_DEF_USE_MANAGER_H_
+#endif  // SOURCE_OPT_DEF_USE_MANAGER_H_

--- a/source/opt/dominator_analysis.h
+++ b/source/opt/dominator_analysis.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_DOMINATOR_ANALYSIS_PASS_H_
-#define LIBSPIRV_OPT_DOMINATOR_ANALYSIS_PASS_H_
+#ifndef SOURCE_OPT_DOMINATOR_ANALYSIS_H_
+#define SOURCE_OPT_DOMINATOR_ANALYSIS_H_
 
 #include <cstdint>
 #include <map>
@@ -135,4 +135,4 @@ class PostDominatorAnalysis : public DominatorAnalysisBase {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_DOMINATOR_ANALYSIS_PASS_H_
+#endif  // SOURCE_OPT_DOMINATOR_ANALYSIS_H_

--- a/source/opt/dominator_tree.h
+++ b/source/opt/dominator_tree.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_DOMINATOR_ANALYSIS_TREE_H_
-#define LIBSPIRV_OPT_DOMINATOR_ANALYSIS_TREE_H_
+#ifndef SOURCE_OPT_DOMINATOR_TREE_H_
+#define SOURCE_OPT_DOMINATOR_TREE_H_
 
 #include <algorithm>
 #include <cstdint>
@@ -302,4 +302,4 @@ class DominatorTree {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_DOMINATOR_ANALYSIS_TREE_H_
+#endif  // SOURCE_OPT_DOMINATOR_TREE_H_

--- a/source/opt/eliminate_dead_constant_pass.h
+++ b/source/opt/eliminate_dead_constant_pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_ELIMINATE_DEAD_CONSTANT_PASS_H_
-#define LIBSPIRV_OPT_ELIMINATE_DEAD_CONSTANT_PASS_H_
+#ifndef SOURCE_OPT_ELIMINATE_DEAD_CONSTANT_PASS_H_
+#define SOURCE_OPT_ELIMINATE_DEAD_CONSTANT_PASS_H_
 
 #include "ir_context.h"
 #include "module.h"
@@ -32,4 +32,4 @@ class EliminateDeadConstantPass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_ELIMINATE_DEAD_CONSTANT_PASS_H_
+#endif  // SOURCE_OPT_ELIMINATE_DEAD_CONSTANT_PASS_H_

--- a/source/opt/eliminate_dead_functions_pass.h
+++ b/source/opt/eliminate_dead_functions_pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_ELIMINATE_DEAD_FUNCTIONS_PASS_H_
-#define LIBSPIRV_OPT_ELIMINATE_DEAD_FUNCTIONS_PASS_H_
+#ifndef SOURCE_OPT_ELIMINATE_DEAD_FUNCTIONS_PASS_H_
+#define SOURCE_OPT_ELIMINATE_DEAD_FUNCTIONS_PASS_H_
 
 #include "def_use_manager.h"
 #include "function.h"
@@ -40,4 +40,4 @@ class EliminateDeadFunctionsPass : public MemPass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_ELIMINATE_DEAD_FUNCTIONS_PASS_H_
+#endif  // SOURCE_OPT_ELIMINATE_DEAD_FUNCTIONS_PASS_H_

--- a/source/opt/feature_manager.h
+++ b/source/opt/feature_manager.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_FEATURE_MANAGER_H_
-#define LIBSPIRV_OPT_FEATURE_MANAGER_H_
+#ifndef SOURCE_OPT_FEATURE_MANAGER_H_
+#define SOURCE_OPT_FEATURE_MANAGER_H_
 
 #include "assembly_grammar.h"
 #include "extensions.h"
@@ -75,4 +75,4 @@ class FeatureManager {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_FEATURE_MANAGER_H_
+#endif  // SOURCE_OPT_FEATURE_MANAGER_H_

--- a/source/opt/flatten_decoration_pass.h
+++ b/source/opt/flatten_decoration_pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_FLATTEN_DECORATION_PASS_H_
-#define LIBSPIRV_OPT_FLATTEN_DECORATION_PASS_H_
+#ifndef SOURCE_OPT_FLATTEN_DECORATION_PASS_H_
+#define SOURCE_OPT_FLATTEN_DECORATION_PASS_H_
 
 #include "ir_context.h"
 #include "module.h"
@@ -32,4 +32,4 @@ class FlattenDecorationPass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_FLATTEN_DECORATION_PASS_H_
+#endif  // SOURCE_OPT_FLATTEN_DECORATION_PASS_H_

--- a/source/opt/fold.h
+++ b/source/opt/fold.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_UTIL_FOLD_H_
-#define LIBSPIRV_UTIL_FOLD_H_
+#ifndef SOURCE_OPT_FOLD_H_
+#define SOURCE_OPT_FOLD_H_
 
 #include <cstdint>
 #include <vector>
@@ -168,4 +168,4 @@ class InstructionFolder {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_UTIL_FOLD_H_
+#endif  // SOURCE_OPT_FOLD_H_

--- a/source/opt/fold_spec_constant_op_and_composite_pass.h
+++ b/source/opt/fold_spec_constant_op_and_composite_pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_FOLD_SPEC_CONSTANT_OP_AND_COMPOSITE_PASS_H_
-#define LIBSPIRV_OPT_FOLD_SPEC_CONSTANT_OP_AND_COMPOSITE_PASS_H_
+#ifndef SOURCE_OPT_FOLD_SPEC_CONSTANT_OP_AND_COMPOSITE_PASS_H_
+#define SOURCE_OPT_FOLD_SPEC_CONSTANT_OP_AND_COMPOSITE_PASS_H_
 
 #include <memory>
 #include <unordered_map>
@@ -81,4 +81,4 @@ class FoldSpecConstantOpAndCompositePass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_FOLD_SPEC_CONSTANT_OP_AND_COMPOSITE_PASS_H_
+#endif  // SOURCE_OPT_FOLD_SPEC_CONSTANT_OP_AND_COMPOSITE_PASS_H_

--- a/source/opt/folding_rules.h
+++ b/source/opt/folding_rules.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_UTIL_FOLDING_RULES_H_
-#define LIBSPIRV_UTIL_FOLDING_RULES_H_
+#ifndef SOURCE_OPT_FOLDING_RULES_H_
+#define SOURCE_OPT_FOLDING_RULES_H_
 
 #include <cstdint>
 #include <vector>
@@ -75,4 +75,4 @@ class FoldingRules {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_UTIL_FOLDING_RULES_H_
+#endif  // SOURCE_OPT_FOLDING_RULES_H_

--- a/source/opt/freeze_spec_constant_value_pass.h
+++ b/source/opt/freeze_spec_constant_value_pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_FREEZE_SPEC_CONSTANT_VALUE_PASS_H_
-#define LIBSPIRV_OPT_FREEZE_SPEC_CONSTANT_VALUE_PASS_H_
+#ifndef SOURCE_OPT_FREEZE_SPEC_CONSTANT_VALUE_PASS_H_
+#define SOURCE_OPT_FREEZE_SPEC_CONSTANT_VALUE_PASS_H_
 
 #include "ir_context.h"
 #include "module.h"
@@ -32,4 +32,4 @@ class FreezeSpecConstantValuePass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_FREEZE_SPEC_CONSTANT_VALUE_PASS_H_
+#endif  // SOURCE_OPT_FREEZE_SPEC_CONSTANT_VALUE_PASS_H_

--- a/source/opt/function.h
+++ b/source/opt/function.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_CONSTRUCTS_H_
-#define LIBSPIRV_OPT_CONSTRUCTS_H_
+#ifndef SOURCE_OPT_FUNCTION_H_
+#define SOURCE_OPT_FUNCTION_H_
 
 #include <algorithm>
 #include <functional>
@@ -186,4 +186,4 @@ inline void Function::SetFunctionEnd(std::unique_ptr<Instruction> end_inst) {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_CONSTRUCTS_H_
+#endif  // SOURCE_OPT_FUNCTION_H_

--- a/source/opt/if_conversion.h
+++ b/source/opt/if_conversion.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_IF_CONVERSION_H_
-#define LIBSPIRV_OPT_IF_CONVERSION_H_
+#ifndef SOURCE_OPT_IF_CONVERSION_H_
+#define SOURCE_OPT_IF_CONVERSION_H_
 
 #include "basic_block.h"
 #include "ir_builder.h"
@@ -85,4 +85,4 @@ class IfConversion : public Pass {
 }  //  namespace opt
 }  //  namespace spvtools
 
-#endif  //  LIBSPIRV_OPT_IF_CONVERSION_H_
+#endif  //  SOURCE_OPT_IF_CONVERSION_H_

--- a/source/opt/inline_exhaustive_pass.h
+++ b/source/opt/inline_exhaustive_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_INLINE_EXHAUSTIVE_PASS_H_
-#define LIBSPIRV_OPT_INLINE_EXHAUSTIVE_PASS_H_
+#ifndef SOURCE_OPT_INLINE_EXHAUSTIVE_PASS_H_
+#define SOURCE_OPT_INLINE_EXHAUSTIVE_PASS_H_
 
 #include <algorithm>
 #include <list>
@@ -50,4 +50,4 @@ class InlineExhaustivePass : public InlinePass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_INLINE_EXHAUSTIVE_PASS_H_
+#endif  // SOURCE_OPT_INLINE_EXHAUSTIVE_PASS_H_

--- a/source/opt/inline_opaque_pass.h
+++ b/source/opt/inline_opaque_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_INLINE_OPAQUE_PASS_H_
-#define LIBSPIRV_OPT_INLINE_OPAQUE_PASS_H_
+#ifndef SOURCE_OPT_INLINE_OPAQUE_PASS_H_
+#define SOURCE_OPT_INLINE_OPAQUE_PASS_H_
 
 #include <algorithm>
 #include <list>
@@ -57,4 +57,4 @@ class InlineOpaquePass : public InlinePass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_INLINE_OPAQUE_PASS_H_
+#endif  // SOURCE_OPT_INLINE_OPAQUE_PASS_H_

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_INLINE_PASS_H_
-#define LIBSPIRV_OPT_INLINE_PASS_H_
+#ifndef SOURCE_OPT_INLINE_PASS_H_
+#define SOURCE_OPT_INLINE_PASS_H_
 
 #include <algorithm>
 #include <list>
@@ -185,4 +185,4 @@ class InlinePass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_INLINE_PASS_H_
+#endif  // SOURCE_OPT_INLINE_PASS_H_

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_INSTRUCTION_H_
-#define LIBSPIRV_OPT_INSTRUCTION_H_
+#ifndef SOURCE_OPT_INSTRUCTION_H_
+#define SOURCE_OPT_INSTRUCTION_H_
 
 #include <cassert>
 #include <functional>
@@ -730,4 +730,4 @@ bool Instruction::IsConstant() const {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_INSTRUCTION_H_
+#endif  // SOURCE_OPT_INSTRUCTION_H_

--- a/source/opt/instruction_list.h
+++ b/source/opt/instruction_list.h
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_INSTRUCTION_LIST_H_
-#define LIBSPIRV_OPT_INSTRUCTION_LIST_H_
+#ifndef SOURCE_OPT_INSTRUCTION_LIST_H_
+#define SOURCE_OPT_INSTRUCTION_LIST_H_
 
 #include <cassert>
 #include <functional>
@@ -127,4 +127,4 @@ void InstructionList::clear() {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_INSTRUCTION_LIST_H_
+#endif  // SOURCE_OPT_INSTRUCTION_LIST_H_

--- a/source/opt/ir_builder.h
+++ b/source/opt/ir_builder.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_IR_BUILDER_H_
-#define LIBSPIRV_OPT_IR_BUILDER_H_
+#ifndef SOURCE_OPT_IR_BUILDER_H_
+#define SOURCE_OPT_IR_BUILDER_H_
 
 #include "opt/basic_block.h"
 #include "opt/constants.h"
@@ -413,4 +413,4 @@ class InstructionBuilder {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_IR_BUILDER_H_
+#endif  // SOURCE_OPT_IR_BUILDER_H_

--- a/source/opt/ir_context.h
+++ b/source/opt/ir_context.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SPIRV_TOOLS_IR_CONTEXT_H
-#define SPIRV_TOOLS_IR_CONTEXT_H
+#ifndef SOURCE_OPT_IR_CONTEXT_H_
+#define SOURCE_OPT_IR_CONTEXT_H_
 
 #include "assembly_grammar.h"
 #include "cfg.h"
@@ -849,4 +849,4 @@ IRContext::GetNames(uint32_t id) {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // SPIRV_TOOLS_IR_CONTEXT_H
+#endif  // SOURCE_OPT_IR_CONTEXT_H_

--- a/source/opt/ir_loader.h
+++ b/source/opt/ir_loader.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_IR_LOADER_H_
-#define LIBSPIRV_OPT_IR_LOADER_H_
+#ifndef SOURCE_OPT_IR_LOADER_H_
+#define SOURCE_OPT_IR_LOADER_H_
 
 #include <memory>
 
@@ -81,4 +81,4 @@ class IrLoader {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_IR_LOADER_H_
+#endif  // SOURCE_OPT_IR_LOADER_H_

--- a/source/opt/iterator.h
+++ b/source/opt/iterator.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_ITERATOR_H_
-#define LIBSPIRV_OPT_ITERATOR_H_
+#ifndef SOURCE_OPT_ITERATOR_H_
+#define SOURCE_OPT_ITERATOR_H_
 
 #include <cstddef>  // for ptrdiff_t
 #include <iterator>
@@ -354,4 +354,4 @@ inline
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_ITERATOR_H_
+#endif  // SOURCE_OPT_ITERATOR_H_

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_LOCAL_ACCESS_CHAIN_CONVERT_PASS_H_
-#define LIBSPIRV_OPT_LOCAL_ACCESS_CHAIN_CONVERT_PASS_H_
+#ifndef SOURCE_OPT_LOCAL_ACCESS_CHAIN_CONVERT_PASS_H_
+#define SOURCE_OPT_LOCAL_ACCESS_CHAIN_CONVERT_PASS_H_
 
 #include <algorithm>
 #include <map>
@@ -123,4 +123,4 @@ class LocalAccessChainConvertPass : public MemPass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_LOCAL_ACCESS_CHAIN_CONVERT_PASS_H_
+#endif  // SOURCE_OPT_LOCAL_ACCESS_CHAIN_CONVERT_PASS_H_

--- a/source/opt/local_redundancy_elimination.h
+++ b/source/opt/local_redundancy_elimination.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_LOCAL_REDUNDANCY_ELIMINATION_H_
-#define LIBSPIRV_OPT_LOCAL_REDUNDANCY_ELIMINATION_H_
+#ifndef SOURCE_OPT_LOCAL_REDUNDANCY_ELIMINATION_H_
+#define SOURCE_OPT_LOCAL_REDUNDANCY_ELIMINATION_H_
 
 #include "ir_context.h"
 #include "pass.h"
@@ -62,4 +62,4 @@ class LocalRedundancyEliminationPass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_LOCAL_REDUNDANCY_ELIMINATION_H_
+#endif  // SOURCE_OPT_LOCAL_REDUNDANCY_ELIMINATION_H_

--- a/source/opt/local_single_block_elim_pass.h
+++ b/source/opt/local_single_block_elim_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_LOCAL_SINGLE_BLOCK_ELIM_PASS_H_
-#define LIBSPIRV_OPT_LOCAL_SINGLE_BLOCK_ELIM_PASS_H_
+#ifndef SOURCE_OPT_LOCAL_SINGLE_BLOCK_ELIM_PASS_H_
+#define SOURCE_OPT_LOCAL_SINGLE_BLOCK_ELIM_PASS_H_
 
 #include <algorithm>
 #include <map>
@@ -101,4 +101,4 @@ class LocalSingleBlockLoadStoreElimPass : public MemPass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_LOCAL_SINGLE_BLOCK_ELIM_PASS_H_
+#endif  // SOURCE_OPT_LOCAL_SINGLE_BLOCK_ELIM_PASS_H_

--- a/source/opt/local_single_store_elim_pass.h
+++ b/source/opt/local_single_store_elim_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_LOCAL_SINGLE_STORE_ELIM_PASS_H_
-#define LIBSPIRV_OPT_LOCAL_SINGLE_STORE_ELIM_PASS_H_
+#ifndef SOURCE_OPT_LOCAL_SINGLE_STORE_ELIM_PASS_H_
+#define SOURCE_OPT_LOCAL_SINGLE_STORE_ELIM_PASS_H_
 
 #include <algorithm>
 #include <map>
@@ -96,4 +96,4 @@ class LocalSingleStoreElimPass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_LOCAL_SINGLE_STORE_ELIM_PASS_H_
+#endif  // SOURCE_OPT_LOCAL_SINGLE_STORE_ELIM_PASS_H_

--- a/source/opt/local_ssa_elim_pass.h
+++ b/source/opt/local_ssa_elim_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_LOCAL_SSA_ELIM_PASS_H_
-#define LIBSPIRV_OPT_LOCAL_SSA_ELIM_PASS_H_
+#ifndef SOURCE_OPT_LOCAL_SSA_ELIM_PASS_H_
+#define SOURCE_OPT_LOCAL_SSA_ELIM_PASS_H_
 
 #include <algorithm>
 #include <map>
@@ -65,4 +65,4 @@ class LocalMultiStoreElimPass : public MemPass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_LOCAL_SSA_ELIM_PASS_H_
+#endif  // SOURCE_OPT_LOCAL_SSA_ELIM_PASS_H_

--- a/source/opt/log.h
+++ b/source/opt/log.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SPIRV_TOOLS_LOG_H_
-#define SPIRV_TOOLS_LOG_H_
+#ifndef SOURCE_OPT_LOG_H_
+#define SOURCE_OPT_LOG_H_
 
 #include <cstdio>
 #include <cstdlib>
@@ -228,4 +228,4 @@ static_assert(PP_NARGS(0, 0, 0, 0, 0) == 5, "PP_NARGS macro error");
 static_assert(PP_NARGS(1 + 1, 2, 3 / 3) == 3, "PP_NARGS macro error");
 static_assert(PP_NARGS((1, 1), 2, (3, 3)) == 3, "PP_NARGS macro error");
 
-#endif  // SPIRV_TOOLS_LOG_H_
+#endif  // SOURCE_OPT_LOG_H_

--- a/source/opt/loop_dependence.h
+++ b/source/opt/loop_dependence.h
@@ -555,4 +555,4 @@ class LoopDependenceAnalysis {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // SOURCE_OPT_LOOP_DEPENDENCE_H__
+#endif  // SOURCE_OPT_LOOP_DEPENDENCE_H_

--- a/source/opt/loop_descriptor.h
+++ b/source/opt/loop_descriptor.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_LOOP_DESCRIPTORS_H_
-#define LIBSPIRV_OPT_LOOP_DESCRIPTORS_H_
+#ifndef SOURCE_OPT_LOOP_DESCRIPTOR_H_
+#define SOURCE_OPT_LOOP_DESCRIPTOR_H_
 
 #include <algorithm>
 #include <cstdint>
@@ -568,4 +568,4 @@ class LoopDescriptor {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_LOOP_DESCRIPTORS_H_
+#endif  // SOURCE_OPT_LOOP_DESCRIPTOR_H_

--- a/source/opt/loop_fission.h
+++ b/source/opt/loop_fission.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_LOOP_FISSION_H_
-#define LIBSPIRV_OPT_LOOP_FISSION_H_
+#ifndef SOURCE_OPT_LOOP_FISSION_H_
+#define SOURCE_OPT_LOOP_FISSION_H_
 
 #include <algorithm>
 #include <cstdint>
@@ -75,4 +75,4 @@ class LoopFissionPass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_LOOP_FISSION_H_
+#endif  // SOURCE_OPT_LOOP_FISSION_H_

--- a/source/opt/loop_unswitch_pass.h
+++ b/source/opt/loop_unswitch_pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_LOOP_UNSWITCH_PASS_H_
-#define LIBSPIRV_OPT_LOOP_UNSWITCH_PASS_H_
+#ifndef SOURCE_OPT_LOOP_UNSWITCH_PASS_H_
+#define SOURCE_OPT_LOOP_UNSWITCH_PASS_H_
 
 #include "opt/loop_descriptor.h"
 #include "opt/pass.h"
@@ -40,4 +40,4 @@ class LoopUnswitchPass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // !LIBSPIRV_OPT_LOOP_UNSWITCH_PASS_H_
+#endif  // SOURCE_OPT_LOOP_UNSWITCH_PASS_H_

--- a/source/opt/make_unique.h
+++ b/source/opt/make_unique.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_MAKE_UNIQUE_H_
-#define LIBSPIRV_OPT_MAKE_UNIQUE_H_
+#ifndef SOURCE_OPT_MAKE_UNIQUE_H_
+#define SOURCE_OPT_MAKE_UNIQUE_H_
 
 #include <memory>
 #include <utility>
@@ -27,4 +27,4 @@ std::unique_ptr<T> MakeUnique(Args&&... args) {
 
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_MAKE_UNIQUE_H_
+#endif  // SOURCE_OPT_MAKE_UNIQUE_H_

--- a/source/opt/mem_pass.h
+++ b/source/opt/mem_pass.h
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_MEM_PASS_H_
-#define LIBSPIRV_OPT_MEM_PASS_H_
+#ifndef SOURCE_OPT_MEM_PASS_H_
+#define SOURCE_OPT_MEM_PASS_H_
 
 #include <algorithm>
 #include <list>
@@ -160,4 +160,4 @@ class MemPass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_MEM_PASS_H_
+#endif  // SOURCE_OPT_MEM_PASS_H_

--- a/source/opt/merge_return_pass.h
+++ b/source/opt/merge_return_pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_MERGE_RETURN_PASS_H_
-#define LIBSPIRV_OPT_MERGE_RETURN_PASS_H_
+#ifndef SOURCE_OPT_MERGE_RETURN_PASS_H_
+#define SOURCE_OPT_MERGE_RETURN_PASS_H_
 
 #include "basic_block.h"
 #include "function.h"
@@ -302,4 +302,4 @@ class MergeReturnPass : public MemPass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_MERGE_RETURN_PASS_H_
+#endif  // SOURCE_OPT_MERGE_RETURN_PASS_H_

--- a/source/opt/module.h
+++ b/source/opt/module.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_MODULE_H_
-#define LIBSPIRV_OPT_MODULE_H_
+#ifndef SOURCE_OPT_MODULE_H_
+#define SOURCE_OPT_MODULE_H_
 
 #include <functional>
 #include <memory>
@@ -473,4 +473,4 @@ inline Module::const_iterator Module::cend() const {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_MODULE_H_
+#endif  // SOURCE_OPT_MODULE_H_

--- a/source/opt/null_pass.h
+++ b/source/opt/null_pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_NULL_PASS_H_
-#define LIBSPIRV_OPT_NULL_PASS_H_
+#ifndef SOURCE_OPT_NULL_PASS_H_
+#define SOURCE_OPT_NULL_PASS_H_
 
 #include "module.h"
 #include "pass.h"
@@ -31,4 +31,4 @@ class NullPass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_NULL_PASS_H_
+#endif  // SOURCE_OPT_NULL_PASS_H_

--- a/source/opt/pass.h
+++ b/source/opt/pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_PASS_H_
-#define LIBSPIRV_OPT_PASS_H_
+#ifndef SOURCE_OPT_PASS_H_
+#define SOURCE_OPT_PASS_H_
 
 #include <algorithm>
 #include <map>
@@ -162,4 +162,4 @@ class Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_PASS_H_
+#endif  // SOURCE_OPT_PASS_H_

--- a/source/opt/pass_manager.h
+++ b/source/opt/pass_manager.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_PASS_MANAGER_H_
-#define LIBSPIRV_OPT_PASS_MANAGER_H_
+#ifndef SOURCE_OPT_PASS_MANAGER_H_
+#define SOURCE_OPT_PASS_MANAGER_H_
 
 #include <memory>
 #include <ostream>
@@ -127,4 +127,4 @@ inline const MessageConsumer& PassManager::consumer() const {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_PASS_MANAGER_H_
+#endif  // SOURCE_OPT_PASS_MANAGER_H_

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_PASSES_H_
-#define LIBSPIRV_OPT_PASSES_H_
+#ifndef SOURCE_OPT_PASSES_H_
+#define SOURCE_OPT_PASSES_H_
 
 // A single header to include all passes.
 
@@ -63,4 +63,4 @@
 #include "unify_const_pass.h"
 #include "vector_dce.h"
 #include "workaround1209.h"
-#endif  // LIBSPIRV_OPT_PASSES_H_
+#endif  // SOURCE_OPT_PASSES_H_

--- a/source/opt/private_to_local_pass.h
+++ b/source/opt/private_to_local_pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_PRIVATE_TO_LOCAL_PASS_H_
-#define LIBSPIRV_OPT_PRIVATE_TO_LOCAL_PASS_H_
+#ifndef SOURCE_OPT_PRIVATE_TO_LOCAL_PASS_H_
+#define SOURCE_OPT_PRIVATE_TO_LOCAL_PASS_H_
 
 #include "ir_context.h"
 #include "pass.h"
@@ -69,4 +69,4 @@ class PrivateToLocalPass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_PRIVATE_TO_LOCAL_PASS_H_
+#endif  // SOURCE_OPT_PRIVATE_TO_LOCAL_PASS_H_

--- a/source/opt/propagator.h
+++ b/source/opt/propagator.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_PROPAGATOR_H_
-#define LIBSPIRV_OPT_PROPAGATOR_H_
+#ifndef SOURCE_OPT_PROPAGATOR_H_
+#define SOURCE_OPT_PROPAGATOR_H_
 
 #include <functional>
 #include <queue>
@@ -313,4 +313,4 @@ std::ostream& operator<<(std::ostream& str,
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_PROPAGATOR_H_
+#endif  // SOURCE_OPT_PROPAGATOR_H_

--- a/source/opt/reduce_load_size.h
+++ b/source/opt/reduce_load_size.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_REDUCE_LOAD_SIZE_H_
-#define LIBSPIRV_OPT_REDUCE_LOAD_SIZE_H_
+#ifndef SOURCE_OPT_REDUCE_LOAD_SIZE_H_
+#define SOURCE_OPT_REDUCE_LOAD_SIZE_H_
 
 #include "ir_context.h"
 #include "module.h"
@@ -59,4 +59,4 @@ class ReduceLoadSize : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_REDUCE_LOAD_SIZE_H_
+#endif  // SOURCE_OPT_REDUCE_LOAD_SIZE_H_

--- a/source/opt/redundancy_elimination.h
+++ b/source/opt/redundancy_elimination.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_REDUNDANCY_ELIMINATION_H_
-#define LIBSPIRV_OPT_REDUNDANCY_ELIMINATION_H_
+#ifndef SOURCE_OPT_REDUNDANCY_ELIMINATION_H_
+#define SOURCE_OPT_REDUNDANCY_ELIMINATION_H_
 
 #include "ir_context.h"
 #include "local_redundancy_elimination.h"
@@ -51,4 +51,4 @@ class RedundancyEliminationPass : public LocalRedundancyEliminationPass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_REDUNDANCY_ELIMINATION_H_
+#endif  // SOURCE_OPT_REDUNDANCY_ELIMINATION_H_

--- a/source/opt/reflect.h
+++ b/source/opt/reflect.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_REFLECT_H_
-#define LIBSPIRV_OPT_REFLECT_H_
+#ifndef SOURCE_OPT_REFLECT_H_
+#define SOURCE_OPT_REFLECT_H_
 
 #include "latest_version_spirv_header.h"
 
@@ -62,4 +62,4 @@ inline bool IsTerminatorInst(SpvOp opcode) {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_REFLECT_H_
+#endif  // SOURCE_OPT_REFLECT_H_

--- a/source/opt/register_pressure.h
+++ b/source/opt/register_pressure.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_REGISTER_PRESSURE_H_
-#define LIBSPIRV_OPT_REGISTER_PRESSURE_H_
+#ifndef SOURCE_OPT_REGISTER_PRESSURE_H_
+#define SOURCE_OPT_REGISTER_PRESSURE_H_
 
 #include <unordered_map>
 #include <unordered_set>
@@ -193,4 +193,4 @@ class LivenessAnalysis {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // ! LIBSPIRV_OPT_REGISTER_PRESSURE_H_
+#endif  // SOURCE_OPT_REGISTER_PRESSURE_H_

--- a/source/opt/remove_duplicates_pass.h
+++ b/source/opt/remove_duplicates_pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_REMOVE_DUPLICATES_PASS_H_
-#define LIBSPIRV_OPT_REMOVE_DUPLICATES_PASS_H_
+#ifndef SOURCE_OPT_REMOVE_DUPLICATES_PASS_H_
+#define SOURCE_OPT_REMOVE_DUPLICATES_PASS_H_
 
 #include <unordered_map>
 
@@ -63,4 +63,4 @@ class RemoveDuplicatesPass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_REMOVE_DUPLICATES_PASS_H_
+#endif  // SOURCE_OPT_REMOVE_DUPLICATES_PASS_H_

--- a/source/opt/replace_invalid_opc.h
+++ b/source/opt/replace_invalid_opc.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_REPLACE_INVALID_OPC_H_
-#define LIBSPIRV_OPT_REPLACE_INVALID_OPC_H_
+#ifndef SOURCE_OPT_REPLACE_INVALID_OPC_H_
+#define SOURCE_OPT_REPLACE_INVALID_OPC_H_
 
 #include "pass.h"
 
@@ -62,4 +62,4 @@ class ReplaceInvalidOpcodePass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_REPLACE_INVALID_OPC_H_
+#endif  // SOURCE_OPT_REPLACE_INVALID_OPC_H_

--- a/source/opt/scalar_analysis.h
+++ b/source/opt/scalar_analysis.h
@@ -310,4 +310,4 @@ inline std::pair<SExpression, int64_t> operator/(SENode* lhs, SExpression rhs) {
 
 }  // namespace opt
 }  // namespace spvtools
-#endif  // SOURCE_OPT_SCALAR_ANALYSIS_H__
+#endif  // SOURCE_OPT_SCALAR_ANALYSIS_H_

--- a/source/opt/scalar_replacement_pass.h
+++ b/source/opt/scalar_replacement_pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_SCALAR_REPLACEMENT_PASS_H_
-#define LIBSPIRV_OPT_SCALAR_REPLACEMENT_PASS_H_
+#ifndef SOURCE_OPT_SCALAR_REPLACEMENT_PASS_H_
+#define SOURCE_OPT_SCALAR_REPLACEMENT_PASS_H_
 
 #include <cstdio>
 
@@ -226,4 +226,4 @@ class ScalarReplacementPass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_SCALAR_REPLACEMENT_PASS_H_
+#endif  // SOURCE_OPT_SCALAR_REPLACEMENT_PASS_H_

--- a/source/opt/set_spec_constant_default_value_pass.h
+++ b/source/opt/set_spec_constant_default_value_pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_SET_SPEC_CONSTANT_DEFAULT_VALUE_PASS_H_
-#define LIBSPIRV_OPT_SET_SPEC_CONSTANT_DEFAULT_VALUE_PASS_H_
+#ifndef SOURCE_OPT_SET_SPEC_CONSTANT_DEFAULT_VALUE_PASS_H_
+#define SOURCE_OPT_SET_SPEC_CONSTANT_DEFAULT_VALUE_PASS_H_
 
 #include <memory>
 #include <string>
@@ -109,4 +109,4 @@ class SetSpecConstantDefaultValuePass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_SET_SPEC_CONSTANT_DEFAULT_VALUE_PASS_H_
+#endif  // SOURCE_OPT_SET_SPEC_CONSTANT_DEFAULT_VALUE_PASS_H_

--- a/source/opt/simplification_pass.h
+++ b/source/opt/simplification_pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_SIMPLIFICATION_PASS_H_
-#define LIBSPIRV_OPT_SIMPLIFICATION_PASS_H_
+#ifndef SOURCE_OPT_SIMPLIFICATION_PASS_H_
+#define SOURCE_OPT_SIMPLIFICATION_PASS_H_
 
 #include "function.h"
 #include "ir_context.h"
@@ -46,4 +46,4 @@ class SimplificationPass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_SIMPLIFICATION_PASS_H_
+#endif  // SOURCE_OPT_SIMPLIFICATION_PASS_H_

--- a/source/opt/ssa_rewrite_pass.h
+++ b/source/opt/ssa_rewrite_pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_SSA_REWRITE_PASS_H_
-#define LIBSPIRV_OPT_SSA_REWRITE_PASS_H_
+#ifndef SOURCE_OPT_SSA_REWRITE_PASS_H_
+#define SOURCE_OPT_SSA_REWRITE_PASS_H_
 
 #include "basic_block.h"
 #include "ir_context.h"
@@ -296,4 +296,4 @@ class SSARewritePass : public MemPass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_SSA_REWRITE_PASS_H_
+#endif  // SOURCE_OPT_SSA_REWRITE_PASS_H_

--- a/source/opt/strength_reduction_pass.h
+++ b/source/opt/strength_reduction_pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_STRENGTH_REDUCTION_PASS_H_
-#define LIBSPIRV_OPT_STRENGTH_REDUCTION_PASS_H_
+#ifndef SOURCE_OPT_STRENGTH_REDUCTION_PASS_H_
+#define SOURCE_OPT_STRENGTH_REDUCTION_PASS_H_
 
 #include "def_use_manager.h"
 #include "ir_context.h"
@@ -62,4 +62,4 @@ class StrengthReductionPass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_STRENGTH_REDUCTION_PASS_H_
+#endif  // SOURCE_OPT_STRENGTH_REDUCTION_PASS_H_

--- a/source/opt/strip_debug_info_pass.h
+++ b/source/opt/strip_debug_info_pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_STRIP_DEBUG_INFO_PASS_H_
-#define LIBSPIRV_OPT_STRIP_DEBUG_INFO_PASS_H_
+#ifndef SOURCE_OPT_STRIP_DEBUG_INFO_PASS_H_
+#define SOURCE_OPT_STRIP_DEBUG_INFO_PASS_H_
 
 #include "ir_context.h"
 #include "module.h"
@@ -32,4 +32,4 @@ class StripDebugInfoPass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_STRIP_DEBUG_INFO_PASS_H_
+#endif  // SOURCE_OPT_STRIP_DEBUG_INFO_PASS_H_

--- a/source/opt/strip_reflect_info_pass.h
+++ b/source/opt/strip_reflect_info_pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_STRIP_REFLECT_INFO_PASS_H_
-#define LIBSPIRV_OPT_STRIP_REFLECT_INFO_PASS_H_
+#ifndef SOURCE_OPT_STRIP_REFLECT_INFO_PASS_H_
+#define SOURCE_OPT_STRIP_REFLECT_INFO_PASS_H_
 
 #include "ir_context.h"
 #include "module.h"
@@ -40,4 +40,4 @@ class StripReflectInfoPass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_STRIP_REFLECT_INFO_PASS_H_
+#endif  // SOURCE_OPT_STRIP_REFLECT_INFO_PASS_H_

--- a/source/opt/tree_iterator.h
+++ b/source/opt/tree_iterator.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_TREE_ITERATOR_H_
-#define LIBSPIRV_OPT_TREE_ITERATOR_H_
+#ifndef SOURCE_OPT_TREE_ITERATOR_H_
+#define SOURCE_OPT_TREE_ITERATOR_H_
 
 #include <stack>
 #include <type_traits>
@@ -243,4 +243,4 @@ class PostOrderTreeDFIterator {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_TREE_ITERATOR_H_
+#endif  // SOURCE_OPT_TREE_ITERATOR_H_

--- a/source/opt/type_manager.h
+++ b/source/opt/type_manager.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_TYPE_MANAGER_H_
-#define LIBSPIRV_OPT_TYPE_MANAGER_H_
+#ifndef SOURCE_OPT_TYPE_MANAGER_H_
+#define SOURCE_OPT_TYPE_MANAGER_H_
 
 #include <memory>
 #include <unordered_map>
@@ -214,4 +214,4 @@ class TypeManager {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_TYPE_MANAGER_H_
+#endif  // SOURCE_OPT_TYPE_MANAGER_H_

--- a/source/opt/types.h
+++ b/source/opt/types.h
@@ -14,8 +14,8 @@
 
 // This file provides a class hierarchy for representing SPIR-V types.
 
-#ifndef LIBSPIRV_OPT_TYPES_H_
-#define LIBSPIRV_OPT_TYPES_H_
+#ifndef SOURCE_OPT_TYPES_H_
+#define SOURCE_OPT_TYPES_H_
 
 #include <map>
 #include <memory>
@@ -599,4 +599,4 @@ DefineParameterlessType(NamedBarrier, named_barrier);
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_TYPES_H_
+#endif  // SOURCE_OPT_TYPES_H_

--- a/source/opt/unify_const_pass.h
+++ b/source/opt/unify_const_pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_UNIFY_CONSTANT_PASS_H_
-#define LIBSPIRV_OPT_UNIFY_CONSTANT_PASS_H_
+#ifndef SOURCE_OPT_UNIFY_CONST_PASS_H_
+#define SOURCE_OPT_UNIFY_CONST_PASS_H_
 
 #include "ir_context.h"
 #include "module.h"
@@ -32,4 +32,4 @@ class UnifyConstantPass : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_UNIFY_CONSTANT_PASS_H_
+#endif  // SOURCE_OPT_UNIFY_CONST_PASS_H_

--- a/source/opt/value_number_table.h
+++ b/source/opt/value_number_table.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_VALUE_NUMBER_TABLE_H_
-#define LIBSPIRV_OPT_VALUE_NUMBER_TABLE_H_
+#ifndef SOURCE_OPT_VALUE_NUMBER_TABLE_H_
+#define SOURCE_OPT_VALUE_NUMBER_TABLE_H_
 
 #include <cstdint>
 #include <unordered_map>
@@ -87,4 +87,4 @@ class ValueNumberTable {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_VALUE_NUMBER_TABLE_H_
+#endif  // SOURCE_OPT_VALUE_NUMBER_TABLE_H_

--- a/source/opt/vector_dce.h
+++ b/source/opt/vector_dce.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_VECTOR_DCE_H_
-#define LIBSPIRV_OPT_VECTOR_DCE_H_
+#ifndef SOURCE_OPT_VECTOR_DCE_H_
+#define SOURCE_OPT_VECTOR_DCE_H_
 
 #include <util/bit_vector.h>
 #include "mem_pass.h"
@@ -143,4 +143,4 @@ class VectorDCE : public MemPass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_VECTOR_DCE_H_
+#endif  // SOURCE_OPT_VECTOR_DCE_H_

--- a/source/opt/workaround1209.h
+++ b/source/opt/workaround1209.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_WORKAROUND1209_H_
-#define LIBSPIRV_OPT_WORKAROUND1209_H_
+#ifndef SOURCE_OPT_WORKAROUND1209_H_
+#define SOURCE_OPT_WORKAROUND1209_H_
 
 #include "pass.h"
 
@@ -38,4 +38,4 @@ class Workaround1209 : public Pass {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_WORKAROUND1209_H_
+#endif  // SOURCE_OPT_WORKAROUND1209_H_

--- a/source/parsed_operand.h
+++ b/source/parsed_operand.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_PARSED_OPERAND_H_
-#define LIBSPIRV_PARSED_OPERAND_H_
+#ifndef SOURCE_PARSED_OPERAND_H_
+#define SOURCE_PARSED_OPERAND_H_
 
 #include <ostream>
 #include "spirv-tools/libspirv.h"
@@ -29,4 +29,4 @@ void EmitNumericLiteral(std::ostream* out, const spv_parsed_instruction_t& inst,
 
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_BINARY_H_
+#endif  // SOURCE_PARSED_OPERAND_H_

--- a/source/print.h
+++ b/source/print.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_PRINT_H_
-#define LIBSPIRV_PRINT_H_
+#ifndef SOURCE_PRINT_H_
+#define SOURCE_PRINT_H_
 
 #include <iostream>
 #include <sstream>
@@ -72,4 +72,4 @@ struct blue {
 
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_PRINT_H_
+#endif  // SOURCE_PRINT_H_

--- a/source/spirv_constant.h
+++ b/source/spirv_constant.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_SPIRV_CONSTANT_H_
-#define LIBSPIRV_SPIRV_CONSTANT_H_
+#ifndef SOURCE_SPIRV_CONSTANT_H_
+#define SOURCE_SPIRV_CONSTANT_H_
 
 #include "latest_version_spirv_header.h"
 #include "spirv-tools/libspirv.h"
@@ -97,4 +97,4 @@ typedef enum spv_generator_t {
 // Returns the misc part of the generator word.
 #define SPV_GENERATOR_MISC_PART(WORD) (uint32_t(WORD) & 0xFFFF)
 
-#endif  // LIBSPIRV_SPIRV_CONSTANT_H_
+#endif  // SOURCE_SPIRV_CONSTANT_H_

--- a/source/spirv_definition.h
+++ b/source/spirv_definition.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_SPIRV_DEFINITION_H_
-#define LIBSPIRV_SPIRV_DEFINITION_H_
+#ifndef SOURCE_SPIRV_DEFINITION_H_
+#define SOURCE_SPIRV_DEFINITION_H_
 
 #include <cstdint>
 
@@ -30,4 +30,4 @@ typedef struct spv_header_t {
   const uint32_t* instructions;  // NOTE: Unfixed pointer to instruciton stream
 } spv_header_t;
 
-#endif  // LIBSPIRV_SPIRV_DEFINITION_H_
+#endif  // SOURCE_SPIRV_DEFINITION_H_

--- a/source/spirv_endian.h
+++ b/source/spirv_endian.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_SPIRV_ENDIAN_H_
-#define LIBSPIRV_SPIRV_ENDIAN_H_
+#ifndef SOURCE_SPIRV_ENDIAN_H_
+#define SOURCE_SPIRV_ENDIAN_H_
 
 #include "spirv-tools/libspirv.h"
 
@@ -34,4 +34,4 @@ spv_result_t spvBinaryEndianness(const spv_const_binary binary,
 // Returns true if the given endianness matches the host's native endiannes.
 bool spvIsHostEndian(spv_endianness_t endian);
 
-#endif  // LIBSPIRV_SPIRV_ENDIAN_H_
+#endif  // SOURCE_SPIRV_ENDIAN_H_

--- a/source/spirv_stats.h
+++ b/source/spirv_stats.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_SPIRV_STATS_H_
-#define LIBSPIRV_SPIRV_STATS_H_
+#ifndef SOURCE_SPIRV_STATS_H_
+#define SOURCE_SPIRV_STATS_H_
 
 #include <map>
 #include <string>
@@ -127,4 +127,4 @@ spv_result_t AggregateStats(const spv_context_t& context, const uint32_t* words,
 
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_SPIRV_STATS_H_
+#endif  // SOURCE_SPIRV_STATS_H_

--- a/source/spirv_target_env.h
+++ b/source/spirv_target_env.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_SPIRV_TARGET_ENV_H_
-#define LIBSPIRV_SPIRV_TARGET_ENV_H_
+#ifndef SOURCE_SPIRV_TARGET_ENV_H_
+#define SOURCE_SPIRV_TARGET_ENV_H_
 
 #include "spirv-tools/libspirv.h"
 
@@ -27,4 +27,4 @@ bool spvIsVulkanEnv(spv_target_env env);
 // Returns the version number for the given SPIR-V target environment.
 uint32_t spvVersionForTargetEnv(spv_target_env env);
 
-#endif  // LIBSPIRV_SPIRV_TARGET_ENV_H_
+#endif  // SOURCE_SPIRV_TARGET_ENV_H_

--- a/source/spirv_validator_options.h
+++ b/source/spirv_validator_options.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_SPIRV_VALIDATOR_OPTIONS_H_
-#define LIBSPIRV_SPIRV_VALIDATOR_OPTIONS_H_
+#ifndef SOURCE_SPIRV_VALIDATOR_OPTIONS_H_
+#define SOURCE_SPIRV_VALIDATOR_OPTIONS_H_
 
 #include "spirv-tools/libspirv.h"
 
@@ -51,4 +51,4 @@ struct spv_validator_options_t {
   bool skip_block_layout;
 };
 
-#endif  // LIBSPIRV_SPIRV_VALIDATOR_OPTIONS_H_
+#endif  // SOURCE_SPIRV_VALIDATOR_OPTIONS_H_

--- a/source/table.h
+++ b/source/table.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_TABLE_H_
-#define LIBSPIRV_TABLE_H_
+#ifndef SOURCE_TABLE_H_
+#define SOURCE_TABLE_H_
 
 #include "latest_version_spirv_header.h"
 
@@ -130,4 +130,4 @@ spv_result_t spvOperandTableGet(spv_operand_table* table, spv_target_env env);
 // Populates *table with entries for env.
 spv_result_t spvExtInstTableGet(spv_ext_inst_table* table, spv_target_env env);
 
-#endif  // LIBSPIRV_TABLE_H_
+#endif  // SOURCE_TABLE_H_

--- a/source/text.h
+++ b/source/text.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_TEXT_H_
-#define LIBSPIRV_TEXT_H_
+#ifndef SOURCE_TEXT_H_
+#define SOURCE_TEXT_H_
 
 #include <string>
 
@@ -50,4 +50,4 @@ typedef struct spv_literal_t {
 // which are then stripped.
 spv_result_t spvTextToLiteral(const char* text, spv_literal_t* literal);
 
-#endif  // LIBSPIRV_TEXT_H_
+#endif  // SOURCE_TEXT_H_

--- a/source/text_handler.h
+++ b/source/text_handler.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_TEXT_HANDLER_H_
-#define LIBSPIRV_TEXT_HANDLER_H_
+#ifndef SOURCE_TEXT_HANDLER_H_
+#define SOURCE_TEXT_HANDLER_H_
 
 #include <iomanip>
 #include <sstream>
@@ -259,4 +259,4 @@ class AssemblyContext {
 
 }  // namespace spvtools
 
-#endif  // _LIBSPIRV_TEXT_HANDLER_H_
+#endif  // SOURCE_TEXT_HANDLER_H_

--- a/source/util/bit_stream.h
+++ b/source/util/bit_stream.h
@@ -14,8 +14,8 @@
 
 // Contains utils for reading, writing and debug printing bit streams.
 
-#ifndef LIBSPIRV_UTIL_BIT_STREAM_H_
-#define LIBSPIRV_UTIL_BIT_STREAM_H_
+#ifndef SOURCE_UTIL_BIT_STREAM_H_
+#define SOURCE_UTIL_BIT_STREAM_H_
 
 #include <algorithm>
 #include <bitset>
@@ -446,4 +446,4 @@ class BitReaderWord64 : public BitReaderInterface {
 }  // namespace utils
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_UTIL_BIT_STREAM_H_
+#endif  // SOURCE_UTIL_BIT_STREAM_H_

--- a/source/util/bit_vector.h
+++ b/source/util/bit_vector.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_UTILS_BIT_VECTOR_H_
-#define LIBSPIRV_UTILS_BIT_VECTOR_H_
+#ifndef SOURCE_UTIL_BIT_VECTOR_H_
+#define SOURCE_UTIL_BIT_VECTOR_H_
 
 #include <cstdint>
 #include <iosfwd>
@@ -116,4 +116,4 @@ class BitVector {
 }  // namespace utils
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_UTILS_BIT_VECTOR_H_
+#endif  // SOURCE_UTIL_BIT_VECTOR_H_

--- a/source/util/bitutils.h
+++ b/source/util/bitutils.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_UTIL_BITUTILS_H_
-#define LIBSPIRV_UTIL_BITUTILS_H_
+#ifndef SOURCE_UTIL_BITUTILS_H_
+#define SOURCE_UTIL_BITUTILS_H_
 
 #include <cstdint>
 #include <cstring>
@@ -93,4 +93,4 @@ size_t CountSetBits(T word) {
 }  // namespace utils
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_UTIL_BITUTILS_H_
+#endif  // SOURCE_UTIL_BITUTILS_H_

--- a/source/util/hex_float.h
+++ b/source/util/hex_float.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_UTIL_HEX_FLOAT_H_
-#define LIBSPIRV_UTIL_HEX_FLOAT_H_
+#ifndef SOURCE_UTIL_HEX_FLOAT_H_
+#define SOURCE_UTIL_HEX_FLOAT_H_
 
 #include <cassert>
 #include <cctype>
@@ -1147,4 +1147,4 @@ inline std::ostream& operator<<<Float16>(std::ostream& os,
 }  // namespace utils
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_UTIL_HEX_FLOAT_H_
+#endif  // SOURCE_UTIL_HEX_FLOAT_H_

--- a/source/util/huffman_codec.h
+++ b/source/util/huffman_codec.h
@@ -14,8 +14,8 @@
 
 // Contains utils for reading, writing and debug printing bit streams.
 
-#ifndef LIBSPIRV_UTIL_HUFFMAN_CODEC_H_
-#define LIBSPIRV_UTIL_HUFFMAN_CODEC_H_
+#ifndef SOURCE_UTIL_HUFFMAN_CODEC_H_
+#define SOURCE_UTIL_HUFFMAN_CODEC_H_
 
 #include <algorithm>
 #include <cassert>
@@ -384,4 +384,4 @@ class HuffmanCodec {
 }  // namespace utils
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_UTIL_HUFFMAN_CODEC_H_
+#endif  // SOURCE_UTIL_HUFFMAN_CODEC_H_

--- a/source/util/ilist.h
+++ b/source/util/ilist.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_ILIST_H_
-#define LIBSPIRV_OPT_ILIST_H_
+#ifndef SOURCE_UTIL_ILIST_H_
+#define SOURCE_UTIL_ILIST_H_
 
 #include <cassert>
 #include <memory>
@@ -362,4 +362,4 @@ void IntrusiveList<NodeType>::Check(NodeType* start) {
 }  // namespace utils
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_ILIST_H_
+#endif  // SOURCE_UTIL_ILIST_H_

--- a/source/util/ilist_node.h
+++ b/source/util/ilist_node.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_OPT_ILIST_NODE_H_
-#define LIBSPIRV_OPT_ILIST_NODE_H_
+#ifndef SOURCE_UTIL_ILIST_NODE_H_
+#define SOURCE_UTIL_ILIST_NODE_H_
 
 #include <cassert>
 
@@ -262,4 +262,4 @@ bool IntrusiveNodeBase<NodeType>::IsEmptyList() {
 }  // namespace utils
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_OPT_ILIST_NODE_H_
+#endif  // SOURCE_UTIL_ILIST_NODE_H_

--- a/source/util/move_to_front.h
+++ b/source/util/move_to_front.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_UTIL_MOVE_TO_FRONT_H_
-#define LIBSPIRV_UTIL_MOVE_TO_FRONT_H_
+#ifndef SOURCE_UTIL_MOVE_TO_FRONT_H_
+#define SOURCE_UTIL_MOVE_TO_FRONT_H_
 
 #include <algorithm>
 #include <cassert>
@@ -824,4 +824,4 @@ void MoveToFront<Val>::UpdateNode(uint32_t node) {
 }  // namespace utils
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_UTIL_MOVE_TO_FRONT_H_
+#endif  // SOURCE_UTIL_MOVE_TO_FRONT_H_

--- a/source/util/parse_number.h
+++ b/source/util/parse_number.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_UTIL_PARSE_NUMBER_H_
-#define LIBSPIRV_UTIL_PARSE_NUMBER_H_
+#ifndef SOURCE_UTIL_PARSE_NUMBER_H_
+#define SOURCE_UTIL_PARSE_NUMBER_H_
 
 #include <functional>
 #include <string>
@@ -249,4 +249,4 @@ EncodeNumberStatus ParseAndEncodeNumber(const char* text,
 }  // namespace utils
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_UTIL_PARSE_NUMBER_H_
+#endif  // SOURCE_UTIL_PARSE_NUMBER_H_

--- a/source/util/small_vector.h
+++ b/source/util/small_vector.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_UTILS_SMALL_VECTOR_H_
-#define LIBSPIRV_UTILS_SMALL_VECTOR_H_
+#ifndef SOURCE_UTIL_SMALL_VECTOR_H_
+#define SOURCE_UTIL_SMALL_VECTOR_H_
 
 #include <cassert>
 #include <iostream>
@@ -461,4 +461,4 @@ class SmallVector {
 }  // namespace utils
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_UTILS_SMALL_VECTOR_H_
+#endif  // SOURCE_UTIL_SMALL_VECTOR_H_

--- a/source/util/string_utils.h
+++ b/source/util/string_utils.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_UTIL_STRING_UTILS_H_
-#define LIBSPIRV_UTIL_STRING_UTILS_H_
+#ifndef SOURCE_UTIL_STRING_UTILS_H_
+#define SOURCE_UTIL_STRING_UTILS_H_
 
 #include <sstream>
 #include <string>
@@ -40,4 +40,4 @@ std::string CardinalToOrdinal(size_t cardinal);
 }  // namespace utils
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_UTIL_STRING_UTILS_H_
+#endif  // SOURCE_UTIL_STRING_UTILS_H_

--- a/source/util/timer.h
+++ b/source/util/timer.h
@@ -14,8 +14,8 @@
 
 // Contains utils for getting resource utilization
 
-#ifndef LIBSPIRV_UTIL_TIMER_H_
-#define LIBSPIRV_UTIL_TIMER_H_
+#ifndef SOURCE_UTIL_TIMER_H_
+#define SOURCE_UTIL_TIMER_H_
 
 #if defined(SPIRV_TIMER_ENABLED)
 
@@ -389,4 +389,4 @@ class CumulativeTimer : public Timer {
 
 #endif  // defined(SPIRV_TIMER_ENABLED)
 
-#endif  // LIBSPIRV_UTIL_TIMER_H_
+#endif  // SOURCE_UTIL_TIMER_H_

--- a/source/val/basic_block.h
+++ b/source/val/basic_block.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_VAL_BASICBLOCK_H_
-#define LIBSPIRV_VAL_BASICBLOCK_H_
+#ifndef SOURCE_VAL_BASIC_BLOCK_H_
+#define SOURCE_VAL_BASIC_BLOCK_H_
 
 #include "latest_version_spirv_header.h"
 
@@ -245,4 +245,4 @@ bool operator!=(const BasicBlock::DominatorIterator& lhs,
 }  // namespace val
 }  // namespace spvtools
 
-#endif  /// LIBSPIRV_VAL_BASICBLOCK_H_
+#endif  // SOURCE_VAL_BASIC_BLOCK_H_

--- a/source/val/construct.h
+++ b/source/val/construct.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_VAL_CONSTRUCT_H_
-#define LIBSPIRV_VAL_CONSTRUCT_H_
+#ifndef SOURCE_VAL_CONSTRUCT_H_
+#define SOURCE_VAL_CONSTRUCT_H_
 
 #include "val/basic_block.h"
 
@@ -148,4 +148,4 @@ class Construct {
 }  // namespace val
 }  // namespace spvtools
 
-#endif  /// LIBSPIRV_VAL_CONSTRUCT_H_
+#endif  // SOURCE_VAL_CONSTRUCT_H_

--- a/source/val/decoration.h
+++ b/source/val/decoration.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_VAL_DECORATION_H_
-#define LIBSPIRV_VAL_DECORATION_H_
+#ifndef SOURCE_VAL_DECORATION_H_
+#define SOURCE_VAL_DECORATION_H_
 
 #include <cstdint>
 #include <unordered_map>
@@ -86,4 +86,4 @@ class Decoration {
 }  // namespace val
 }  // namespace spvtools
 
-#endif  /// LIBSPIRV_VAL_DECORATION_H_
+#endif  // SOURCE_VAL_DECORATION_H_

--- a/source/val/function.h
+++ b/source/val/function.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_VAL_FUNCTION_H_
-#define LIBSPIRV_VAL_FUNCTION_H_
+#ifndef SOURCE_VAL_FUNCTION_H_
+#define SOURCE_VAL_FUNCTION_H_
 
 #include <functional>
 #include <list>
@@ -355,4 +355,4 @@ class Function {
 }  // namespace val
 }  // namespace spvtools
 
-#endif  /// LIBSPIRV_VAL_FUNCTION_H_
+#endif  // SOURCE_VAL_FUNCTION_H_

--- a/source/val/instruction.h
+++ b/source/val/instruction.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_VAL_INSTRUCTION_H_
-#define LIBSPIRV_VAL_INSTRUCTION_H_
+#ifndef SOURCE_VAL_INSTRUCTION_H_
+#define SOURCE_VAL_INSTRUCTION_H_
 
 #include <cassert>
 #include <cstdint>
@@ -137,4 +137,4 @@ struct hash<spvtools::val::Instruction> {
 
 }  // namespace std
 
-#endif  // LIBSPIRV_VAL_INSTRUCTION_H_
+#endif  // SOURCE_VAL_INSTRUCTION_H_

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_VAL_VALIDATIONSTATE_H_
-#define LIBSPIRV_VAL_VALIDATIONSTATE_H_
+#ifndef SOURCE_VAL_VALIDATION_STATE_H_
+#define SOURCE_VAL_VALIDATION_STATE_H_
 
 #include <set>
 #include <string>
@@ -647,4 +647,4 @@ class ValidationState_t {
 }  // namespace val
 }  // namespace spvtools
 
-#endif  /// LIBSPIRV_VAL_VALIDATIONSTATE_H_
+#endif  // SOURCE_VAL_VALIDATION_STATE_H_

--- a/test/link/linker_fixture.h
+++ b/test/link/linker_fixture.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_TEST_LINK_LINK_TEST
-#define LIBSPIRV_TEST_LINK_LINK_TEST
+#ifndef TEST_LINK_LINKER_FIXTURE_H_
+#define TEST_LINK_LINKER_FIXTURE_H_
 
 #include <iostream>
 
@@ -121,4 +121,4 @@ class LinkerTest : public ::testing::Test {
 
 }  // namespace spvtest
 
-#endif  // LIBSPIRV_TEST_LINK_LINK_TEST
+#endif  // TEST_LINK_LINKER_FIXTURE_H_

--- a/test/opt/assembly_builder.h
+++ b/test/opt/assembly_builder.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_TEST_OPT_ASSEMBLY_BUILDER
-#define LIBSPIRV_TEST_OPT_ASSEMBLY_BUILDER
+#ifndef TEST_OPT_ASSEMBLY_BUILDER_H_
+#define TEST_OPT_ASSEMBLY_BUILDER_H_
 
 #include <algorithm>
 #include <cstdint>
@@ -263,4 +263,4 @@ class AssemblyBuilder {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_TEST_OPT_ASSEMBLY_BUILDER
+#endif  // TEST_OPT_ASSEMBLY_BUILDER_H_

--- a/test/opt/fold_test.cpp
+++ b/test/opt/fold_test.cpp
@@ -5767,7 +5767,7 @@ TEST_P(MatchingInstructionWithNoResultFoldingTest, Case) {
   // Fold the instruction to test.
   Instruction* inst = nullptr;
   Function* func = &*context->module()->begin();
-  for(auto& bb : *func) {
+  for (auto& bb : *func) {
     Instruction* terminator = bb.terminator();
     if (terminator->IsReturnOrAbort()) {
       inst = terminator->PreviousNode();

--- a/test/opt/function_utils.h
+++ b/test/opt/function_utils.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_TEST_OPT_FUNCTION_UTILS_H_
-#define LIBSPIRV_TEST_OPT_FUNCTION_UTILS_H_
+#ifndef TEST_OPT_FUNCTION_UTILS_H_
+#define TEST_OPT_FUNCTION_UTILS_H_
 
 #include "opt/function.h"
 #include "opt/module.h"
@@ -52,4 +52,4 @@ inline const spvtools::opt::BasicBlock* GetBasicBlock(
 
 }  // namespace spvtest
 
-#endif  // LIBSPIRV_TEST_OPT_FUNCTION_UTILS_H_
+#endif  // TEST_OPT_FUNCTION_UTILS_H_

--- a/test/opt/module_utils.h
+++ b/test/opt/module_utils.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_TEST_OPT_MODULE_UTILS_H_
-#define LIBSPIRV_TEST_OPT_MODULE_UTILS_H_
+#ifndef TEST_OPT_MODULE_UTILS_H_
+#define TEST_OPT_MODULE_UTILS_H_
 
 #include <vector>
 #include "opt/module.h"
@@ -31,4 +31,4 @@ inline uint32_t GetIdBound(const spvtools::opt::Module& m) {
 
 }  // namespace spvtest
 
-#endif  // LIBSPIRV_TEST_OPT_MODULE_UTILS_H_
+#endif  // TEST_OPT_MODULE_UTILS_H_

--- a/test/opt/pass_fixture.h
+++ b/test/opt/pass_fixture.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_TEST_OPT_PASS_FIXTURE_H_
-#define LIBSPIRV_TEST_OPT_PASS_FIXTURE_H_
+#ifndef TEST_OPT_PASS_FIXTURE_H_
+#define TEST_OPT_PASS_FIXTURE_H_
 
 #include <iostream>
 #include <string>
@@ -242,4 +242,4 @@ class PassTest : public TestT {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_TEST_OPT_PASS_FIXTURE_H_
+#endif  // TEST_OPT_PASS_FIXTURE_H_

--- a/test/opt/pass_utils.h
+++ b/test/opt/pass_utils.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_TEST_OPT_PASS_UTILS_H_
-#define LIBSPIRV_TEST_OPT_PASS_UTILS_H_
+#ifndef TEST_OPT_PASS_UTILS_H_
+#define TEST_OPT_PASS_UTILS_H_
 
 #include <functional>
 #include <iterator>
@@ -64,4 +64,4 @@ std::vector<T> Concat(const std::vector<T>& a, const std::vector<T>& b) {
 }  // namespace opt
 }  // namespace spvtools
 
-#endif  // LIBSPIRV_TEST_OPT_PASS_UTILS_H_
+#endif  // TEST_OPT_PASS_UTILS_H_

--- a/test/test_fixture.h
+++ b/test/test_fixture.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_TEST_TEST_FIXTURE_H_
-#define LIBSPIRV_TEST_TEST_FIXTURE_H_
+#ifndef TEST_TEST_FIXTURE_H_
+#define TEST_TEST_FIXTURE_H_
 
 #include "unit_spirv.h"
 
@@ -179,4 +179,4 @@ using TextToBinaryTest = TextToBinaryTestBase<::testing::Test>;
 using RoundTripTest =
     spvtest::TextToBinaryTestBase<::testing::TestWithParam<std::string>>;
 
-#endif  // LIBSPIRV_TEST_TEST_FIXTURE_H_
+#endif  // TEST_TEST_FIXTURE_H_

--- a/test/unit_spirv.h
+++ b/test/unit_spirv.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_TEST_UNITSPIRV_H_
-#define LIBSPIRV_TEST_UNITSPIRV_H_
+#ifndef TEST_UNIT_SPIRV_H_
+#define TEST_UNIT_SPIRV_H_
 
 #include <stdint.h>
 
@@ -231,4 +231,4 @@ inline std::vector<SpvCapability> ElementsIn(
 }
 
 }  // namespace spvtest
-#endif  // LIBSPIRV_TEST_UNITSPIRV_H_
+#endif  // TEST_UNIT_SPIRV_H_

--- a/test/val/val_fixtures.h
+++ b/test/val/val_fixtures.h
@@ -14,8 +14,8 @@
 
 // Common validation fixtures for unit tests
 
-#ifndef LIBSPIRV_TEST_VALIDATE_FIXTURES_H_
-#define LIBSPIRV_TEST_VALIDATE_FIXTURES_H_
+#ifndef TEST_VAL_VAL_FIXTURES_H_
+#define TEST_VAL_VAL_FIXTURES_H_
 
 #include "source/val/validation_state.h"
 #include "test_fixture.h"
@@ -136,4 +136,5 @@ spv_position_t ValidateBase<T>::getErrorPosition() {
 }
 
 }  // namespace spvtest
-#endif
+
+#endif  // TEST_VAL_VAL_FIXTURES_H_

--- a/tools/cfg/bin_to_dot.h
+++ b/tools/cfg/bin_to_dot.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef BIN_TO_DOT_H_
-#define BIN_TO_DOT_H_
+#ifndef TOOLS_CFG_BIN_TO_DOT_H_
+#define TOOLS_CFG_BIN_TO_DOT_H_
 
 #include <iostream>
 #include "spirv-tools/libspirv.h"
@@ -24,4 +24,4 @@ spv_result_t BinaryToDot(const spv_const_context context, const uint32_t* words,
                          size_t num_words, std::iostream* out,
                          spv_diagnostic* diagnostic);
 
-#endif  // BIN_TO_DOT_H_
+#endif  // TOOLS_CFG_BIN_TO_DOT_H_

--- a/tools/comp/markv_model_factory.h
+++ b/tools/comp/markv_model_factory.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SPIRV_TOOLS_COMP_MARKV_MODEL_FACTORY_H_
-#define SPIRV_TOOLS_COMP_MARKV_MODEL_FACTORY_H_
+#ifndef TOOLS_COMP_MARKV_MODEL_FACTORY_H_
+#define TOOLS_COMP_MARKV_MODEL_FACTORY_H_
 
 #include <memory>
 
@@ -34,4 +34,4 @@ std::unique_ptr<MarkvModel> CreateMarkvModel(MarkvModelType type);
 }  // namespace comp
 }  // namespace spvtools
 
-#endif  // SPIRV_TOOLS_COMP_MARKV_MODEL_FACTORY_H_
+#endif  // TOOLS_COMP_MARKV_MODEL_FACTORY_H_

--- a/tools/comp/markv_model_shader.h
+++ b/tools/comp/markv_model_shader.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SPIRV_TOOLS_MARKV_MODEL_SHADER_H_
-#define SPIRV_TOOLS_MARKV_MODEL_SHADER_H_
+#ifndef TOOLS_COMP_MARKV_MODEL_SHADER_H_
+#define TOOLS_COMP_MARKV_MODEL_SHADER_H_
 
 #include "source/comp/markv_model.h"
 
@@ -44,4 +44,4 @@ class MarkvModelShaderMax : public MarkvModel {
 }  // namespace comp
 }  // namespace spvtools
 
-#endif  // SPIRV_TOOLS_MARKV_MODEL_SHADER_H_
+#endif  // TOOLS_COMP_MARKV_MODEL_SHADER_H_

--- a/tools/io.h
+++ b/tools/io.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_TOOLS_IO_H_
-#define LIBSPIRV_TOOLS_IO_H_
+#ifndef TOOLS_IO_H_
+#define TOOLS_IO_H_
 
 #include <cstdint>
 #include <cstdio>
@@ -79,4 +79,4 @@ bool WriteFile(const char* filename, const char* mode, const T* data,
   return true;
 }
 
-#endif  // LIBSPIRV_TOOLS_IO_H_
+#endif  // TOOLS_IO_H_

--- a/tools/stats/stats_analyzer.h
+++ b/tools/stats/stats_analyzer.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef LIBSPIRV_TOOLS_STATS_STATS_ANALYZER_H_
-#define LIBSPIRV_TOOLS_STATS_STATS_ANALYZER_H_
+#ifndef TOOLS_STATS_STATS_ANALYZER_H_
+#define TOOLS_STATS_STATS_ANALYZER_H_
 
 #include <unordered_map>
 
@@ -77,4 +77,4 @@ class StatsAnalyzer {
   std::unordered_map<uint32_t, double> opcode_freq_;
 };
 
-#endif  // LIBSPIRV_TOOLS_STATS_STATS_ANALYZER_H_
+#endif  // TOOLS_STATS_STATS_ANALYZER_H_


### PR DESCRIPTION
This CL rewrites the include guards to make PRESUBMIT.py include guard
check happy.