### PR TITLE
Fixup readabilty/inheritance warnings

### DIFF
--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -23,7 +23,6 @@ LINT_FILTERS = [
   "-readability/braces",
   "-readability/casting",
   "-readability/fn_size",
-  "-readability/inheritance",
   "-readability/todo",
   "-runtime/explicit",
   "-runtime/int",

--- a/test/link/global_values_amount_test.cpp
+++ b/test/link/global_values_amount_test.cpp
@@ -26,7 +26,7 @@ class EntryPointsAmountTest : public spvtest::LinkerTest {
  public:
   EntryPointsAmountTest() { binaries.reserve(0xFFFF); }
 
-  virtual void SetUp() override {
+  void SetUp() override {
     binaries.push_back({SpvMagicNumber,
                         SpvVersion,
                         SPV_GENERATOR_CODEPLAY,
@@ -103,7 +103,7 @@ class EntryPointsAmountTest : public spvtest::LinkerTest {
       binaries.push_back(binary);
     }
   }
-  virtual void TearDown() override { binaries.clear(); }
+  void TearDown() override { binaries.clear(); }
 
   spvtest::Binaries binaries;
 };

--- a/test/link/linker_fixture.h
+++ b/test/link/linker_fixture.h
@@ -61,7 +61,7 @@ class LinkerTest : public ::testing::Test {
     tools_.SetMessageConsumer(consumer);
   }
 
-  virtual void TearDown() override { error_message_.clear(); }
+  void TearDown() override { error_message_.clear(); }
 
   // Assembles each of the given strings into SPIR-V binaries before linking
   // them together. SPV_ERROR_INVALID_TEXT is returned if the assembling failed

--- a/test/opt/decoration_manager_test.cpp
+++ b/test/opt/decoration_manager_test.cpp
@@ -63,7 +63,7 @@ class DecorationManagerTest : public ::testing::Test {
     tools_.SetMessageConsumer(consumer_);
   }
 
-  virtual void TearDown() override { error_message_.clear(); }
+  void TearDown() override { error_message_.clear(); }
 
   DecorationManager* GetDecorationManager(const std::string& text) {
     context_ = BuildModule(SPV_ENV_UNIVERSAL_1_2, consumer_, text);

--- a/test/opt/pass_remove_duplicates_test.cpp
+++ b/test/opt/pass_remove_duplicates_test.cpp
@@ -61,7 +61,7 @@ class RemoveDuplicatesTest : public ::testing::Test {
     tools_.SetMessageConsumer(consumer_);
   }
 
-  virtual void TearDown() override { error_message_.clear(); }
+  void TearDown() override { error_message_.clear(); }
 
   std::string RunPass(const std::string& text) {
     context_ = spvtools::BuildModule(SPV_ENV_UNIVERSAL_1_2, consumer_, text);

--- a/test/opt/types_test.cpp
+++ b/test/opt/types_test.cpp
@@ -28,7 +28,7 @@ namespace {
 // Fixture class providing some element types.
 class SameTypeTest : public ::testing::Test {
  protected:
-  virtual void SetUp() override {
+  void SetUp() override {
     void_t_.reset(new Void());
     u32_t_.reset(new Integer(32, false));
     f64_t_.reset(new Float(64));


### PR DESCRIPTION
This CL removes the un-needed virtual qualifiers from methods already
marked as override.