### PR TITLE
Add ~ConstantManager() to avoid memory leak.

### DIFF
--- a/source/opt/constants.cpp
+++ b/source/opt/constants.cpp
@@ -112,6 +112,12 @@ ConstantManager::ConstantManager(IRContext* ctx) : ctx_(ctx) {
   }
 }
 
+ConstantManager::~ConstantManager() {
+  for (auto it = const_pool_.begin(); it != const_pool_.end(); ++it) {
+    delete *it;
+  }
+}
+
 Type* ConstantManager::GetType(const Instruction* inst) const {
   return context()->get_type_mgr()->GetType(inst->type_id());
 }

--- a/source/opt/constants.h
+++ b/source/opt/constants.h
@@ -494,6 +494,7 @@ struct ConstantEqual {
 class ConstantManager {
  public:
   ConstantManager(IRContext* ctx);
+  ~ConstantManager();
 
   IRContext* context() const { return ctx_; }
 


### PR DESCRIPTION
Our ASAN build detected a memory leak due to the ConstantManager never destroying the entries in constant_pool_