### PR TITLE
Move spirv_stats into tools/stats.

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -275,7 +275,6 @@ set(SPIRV_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/print.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/software_version.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/spirv_endian.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/spirv_stats.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/spirv_target_env.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/spirv_validator_options.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/table.cpp

--- a/test/stats/CMakeLists.txt
+++ b/test/stats/CMakeLists.txt
@@ -19,6 +19,7 @@ set(VAL_TEST_COMMON_SRCS
 
 add_spvtools_unittest(TARGET stats_aggregate
 	SRCS stats_aggregate_test.cpp
+       ${CMAKE_CURRENT_SOURCE_DIR}/../../tools/stats/spirv_stats.cpp
        ${VAL_TEST_COMMON_SRCS}
   LIBS ${SPIRV_TOOLS}
 )

--- a/test/stats/stats_aggregate_test.cpp
+++ b/test/stats/stats_aggregate_test.cpp
@@ -17,11 +17,12 @@
 #include <string>
 #include <unordered_map>
 
-#include "source/spirv_stats.h"
 #include "test/test_fixture.h"
 #include "test/unit_spirv.h"
+#include "tools/stats/spirv_stats.h"
 
 namespace spvtools {
+namespace stats {
 namespace {
 
 using spvtest::ScopedContext;
@@ -482,4 +483,5 @@ OpMemoryModel Logical GLSL450
 }
 
 }  // namespace
+}  // namespace stats
 }  // namespace spvtools

--- a/test/stats/stats_analyzer_test.cpp
+++ b/test/stats/stats_analyzer_test.cpp
@@ -22,6 +22,7 @@
 #include "tools/stats/stats_analyzer.h"
 
 namespace spvtools {
+namespace stats {
 namespace {
 
 // Fills |stats| with some synthetic header stats, as if aggregated from 100
@@ -169,4 +170,5 @@ TEST(StatsAnalyzer, OpcodeMarkov) {
 }
 
 }  // namespace
+}  // namespace stats
 }  // namespace spvtools

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -45,7 +45,10 @@ if (NOT ${SPIRV_SKIP_EXECUTABLES})
   add_spvtools_tool(TARGET spirv-link SRCS link/linker.cpp LIBS SPIRV-Tools-link ${SPIRV_TOOLS})
   add_spvtools_tool(TARGET spirv-stats
 	            SRCS stats/stats.cpp
-		         stats/stats_analyzer.cpp
+		               stats/stats_analyzer.cpp
+                   stats/stats_analyzer.h
+                   stats/spirv_stats.cpp
+                   stats/spirv_stats.h
 		    LIBS ${SPIRV_TOOLS})
   add_spvtools_tool(TARGET spirv-cfg
                     SRCS cfg/cfg.cpp

--- a/tools/stats/spirv_stats.cpp
+++ b/tools/stats/spirv_stats.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "source/spirv_stats.h"
+#include "tools/stats/spirv_stats.h"
 
 #include <cassert>
 
@@ -33,6 +33,7 @@
 #include "spirv-tools/libspirv.h"
 
 namespace spvtools {
+namespace stats {
 namespace {
 
 // Helper class for stats aggregation. Receives as in/out parameter.
@@ -259,4 +260,5 @@ spv_result_t AggregateStats(const spv_context_t& context, const uint32_t* words,
   return SPV_SUCCESS;
 }
 
+}  // namespace stats
 }  // namespace spvtools

--- a/tools/stats/spirv_stats.h
+++ b/tools/stats/spirv_stats.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SOURCE_SPIRV_STATS_H_
-#define SOURCE_SPIRV_STATS_H_
+#ifndef TOOLS_STATS_SPIRV_STATS_H_
+#define TOOLS_STATS_SPIRV_STATS_H_
 
 #include <map>
 #include <string>
@@ -24,6 +24,7 @@
 #include "spirv-tools/libspirv.hpp"
 
 namespace spvtools {
+namespace stats {
 
 struct SpirvStats {
   // Version histogram, version_word -> count.
@@ -126,6 +127,7 @@ spv_result_t AggregateStats(const spv_context_t& context, const uint32_t* words,
                             const size_t num_words, spv_diagnostic* pDiagnostic,
                             SpirvStats* stats);
 
+}  // namespace stats
 }  // namespace spvtools
 
-#endif  // SOURCE_SPIRV_STATS_H_
+#endif  // TOOLS_STATS_SPIRV_STATS_H_

--- a/tools/stats/stats_analyzer.cpp
+++ b/tools/stats/stats_analyzer.cpp
@@ -33,14 +33,14 @@
 #include "source/operand.h"
 #include "source/spirv_constant.h"
 
+namespace spvtools {
+namespace stats {
 namespace {
-
-using spvtools::SpirvStats;
 
 // Signals that the value is not in the coding scheme and a fallback method
 // needs to be used.
 const uint64_t kMarkvNoneOfTheAbove =
-    spvtools::comp::MarkvModel::GetMarkvNoneOfTheAbove();
+    comp::MarkvModel::GetMarkvNoneOfTheAbove();
 
 std::string GetVersionString(uint32_t word) {
   std::stringstream ss;
@@ -58,7 +58,7 @@ std::string GetOpcodeString(uint32_t word) {
 }
 
 std::string GetCapabilityString(uint32_t word) {
-  return spvtools::CapabilityToString(static_cast<SpvCapability>(word));
+  return CapabilityToString(static_cast<SpvCapability>(word));
 }
 
 template <class T>
@@ -230,3 +230,6 @@ void StatsAnalyzer::WriteOpcodeMarkov(std::ostream& out) {
     }
   }
 }
+
+}  // namespace stats
+}  // namespace spvtools

--- a/tools/stats/stats_analyzer.h
+++ b/tools/stats/stats_analyzer.h
@@ -18,11 +18,14 @@
 #include <string>
 #include <unordered_map>
 
-#include "source/spirv_stats.h"
+#include "tools/stats/spirv_stats.h"
+
+namespace spvtools {
+namespace stats {
 
 class StatsAnalyzer {
  public:
-  explicit StatsAnalyzer(const spvtools::SpirvStats& stats);
+  explicit StatsAnalyzer(const SpirvStats& stats);
 
   // Writes respective histograms to |out|.
   void WriteVersion(std::ostream& out);
@@ -38,7 +41,7 @@ class StatsAnalyzer {
   void WriteOpcodeMarkov(std::ostream& out);
 
  private:
-  const spvtools::SpirvStats& stats_;
+  const SpirvStats& stats_;
 
   uint32_t num_modules_;
 
@@ -48,5 +51,8 @@ class StatsAnalyzer {
   std::unordered_map<std::string, double> extension_freq_;
   std::unordered_map<uint32_t, double> opcode_freq_;
 };
+
+}  // namespace stats
+}  // namespace spvtools
 
 #endif  // TOOLS_STATS_STATS_ANALYZER_H_


### PR DESCRIPTION
The spirv_stats code is only used by the tools/stats module. This CL
moves the code to that module.