### PR TITLE
Allow struct members of type void.

### DIFF
--- a/source/opt/types.cpp
+++ b/source/opt/types.cpp
@@ -434,12 +434,7 @@ void RuntimeArray::ReplaceElementType(const Type* type) {
 }
 
 Struct::Struct(const std::vector<const Type*>& types)
-    : Type(kStruct), element_types_(types) {
-  for (const auto* t : types) {
-    (void)t;
-    assert(!t->AsVoid());
-  }
-}
+    : Type(kStruct), element_types_(types) {}
 
 void Struct::AddMemberDecoration(uint32_t index,
                                  std::vector<uint32_t>&& decoration) {


### PR DESCRIPTION
For some reason there is an assert the ensures that the member of a
struct is not of type void.  Looking at the spec it seems like this is
wrong.

When defining abstract type it says:

> Abstract Type: An OpTypeVoid or OpTypeBool, or OpTypePointer when
using the Logical addressing model, or any aggregate type containing
any of these.

This seems to imply it is possible.  I cannot find anything that would
forbid it.

I think all we need to do is remove the assert.  I've look at other code in the `Struct` class, and everything should still work when we have a void member.