### PR TITLE
Don't copy decorations twice when rebuilding a type.

### DIFF
--- a/source/opt/type_manager.cpp
+++ b/source/opt/type_manager.cpp
@@ -448,7 +448,8 @@ Type* TypeManager::RebuildType(const Type& type) {
 #define DefineNoSubtypeCase(kind)             \
   case Type::k##kind:                         \
     rebuilt_ty.reset(type.Clone().release()); \
-    break;
+    return type_pool_.insert(std::move(rebuilt_ty)).first->get();
+
     DefineNoSubtypeCase(Void);
     DefineNoSubtypeCase(Bool);
     DefineNoSubtypeCase(Integer);


### PR DESCRIPTION
In `TypeManager::RebuildType`, the base cases call `Clone`, which will
copy the decorations for the type.  After that it breaks out of the
switch statement and copies the decorations again.

This has not causes any real problems yet because none of those types
are allowed to have decorations.  However to make the code more robust
it is best to not copy twice because it should be empty.

This way if a new base type or decoration is added that changes this
rule the code will be correct.

https://crbug.com/873890