### PR TITLE
Change when instruction is registered in validator.

### DIFF
--- a/source/val/validate.cpp
+++ b/source/val/validate.cpp
@@ -243,53 +243,52 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
   }
 
   for (auto& instruction : vstate->ordered_instructions()) {
-    {
-      // In order to do this work outside of Process Instruction we need to be
-      // able to, briefly, de-const the instruction.
-      Instruction* inst = const_cast<Instruction*>(&instruction);
+    // In order to do this work outside of Process Instruction we need to be
+    // able to, briefly, de-const the instruction.
+    Instruction* inst = const_cast<Instruction*>(&instruction);
 
-      if (inst->opcode() == SpvOpEntryPoint) {
-        const auto entry_point = inst->GetOperandAs<uint32_t>(1);
-        const auto execution_model = inst->GetOperandAs<SpvExecutionModel>(0);
-        const char* str = reinterpret_cast<const char*>(
-            inst->words().data() + inst->operand(2).offset);
+    if (inst->opcode() == SpvOpEntryPoint) {
+      const auto entry_point = inst->GetOperandAs<uint32_t>(1);
+      const auto execution_model = inst->GetOperandAs<SpvExecutionModel>(0);
+      const char* str = reinterpret_cast<const char*>(inst->words().data() +
+                                                      inst->operand(2).offset);
 
-        ValidationState_t::EntryPointDescription desc;
-        desc.name = str;
+      ValidationState_t::EntryPointDescription desc;
+      desc.name = str;
 
-        std::vector<uint32_t> interfaces;
-        for (size_t j = 3; j < inst->operands().size(); ++j)
-          desc.interfaces.push_back(inst->word(inst->operand(j).offset));
+      std::vector<uint32_t> interfaces;
+      for (size_t j = 3; j < inst->operands().size(); ++j)
+        desc.interfaces.push_back(inst->word(inst->operand(j).offset));
 
-        vstate->RegisterEntryPoint(entry_point, execution_model,
-                                   std::move(desc));
-      }
-      if (inst->opcode() == SpvOpFunctionCall) {
-        if (!vstate->in_function_body()) {
-          return vstate->diag(SPV_ERROR_INVALID_LAYOUT, &instruction)
-                 << "A FunctionCall must happen within a function body.";
-        }
-
-        vstate->AddFunctionCallTarget(inst->GetOperandAs<uint32_t>(2));
+      vstate->RegisterEntryPoint(entry_point, execution_model, std::move(desc));
+    }
+    if (inst->opcode() == SpvOpFunctionCall) {
+      if (!vstate->in_function_body()) {
+        return vstate->diag(SPV_ERROR_INVALID_LAYOUT, &instruction)
+               << "A FunctionCall must happen within a function body.";
       }
 
-      if (vstate->in_function_body()) {
-        inst->set_function(&(vstate->current_function()));
-        inst->set_block(vstate->current_function().current_block());
-
-        if (vstate->in_block() && spvOpcodeIsBlockTerminator(inst->opcode())) {
-          vstate->current_function().current_block()->set_terminator(inst);
-        }
-      }
-
-      if (auto error = IdPass(*vstate, inst)) return error;
+      vstate->AddFunctionCallTarget(inst->GetOperandAs<uint32_t>(2));
     }
 
+    if (vstate->in_function_body()) {
+      inst->set_function(&(vstate->current_function()));
+      inst->set_block(vstate->current_function().current_block());
+
+      if (vstate->in_block() && spvOpcodeIsBlockTerminator(inst->opcode())) {
+        vstate->current_function().current_block()->set_terminator(inst);
+      }
+    }
+
+    if (auto error = IdPass(*vstate, inst)) return error;
     if (auto error = CapabilityPass(*vstate, &instruction)) return error;
     if (auto error = DataRulesPass(*vstate, &instruction)) return error;
     if (auto error = ModuleLayoutPass(*vstate, &instruction)) return error;
     if (auto error = CfgPass(*vstate, &instruction)) return error;
     if (auto error = InstructionPass(*vstate, &instruction)) return error;
+
+    // Now that all of the checks are done, update the state.
+    vstate->RegisterInstruction(inst);
     if (auto error = UpdateIdUse(*vstate, &instruction)) return error;
   }
 

--- a/source/val/validate_id.cpp
+++ b/source/val/validate_id.cpp
@@ -817,8 +817,6 @@ spv_result_t IdPass(ValidationState_t& _, Instruction* inst) {
   }
   if (result_id) _.RemoveIfForwardDeclared(result_id);
 
-  _.RegisterInstruction(inst);
-
   return SPV_SUCCESS;
 }
 

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -529,6 +529,17 @@ TEST_F(ValidateData, missing_forward_pointer_decl) {
               HasSubstr("must first be declared using OpTypeForwardPointer"));
 }
 
+TEST_F(ValidateData, missing_forward_pointer_decl_self_reference) {
+  std::string str = header_with_addresses + R"(
+%uintt = OpTypeInt 32 0
+%3 = OpTypeStruct %3 %uintt
+)";
+  CompileSuccessfully(str.c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("must first be declared using OpTypeForwardPointer"));
+}
+
 TEST_F(ValidateData, forward_pointer_missing_definition) {
   std::string str = header_with_addresses + R"(
 OpTypeForwardPointer %_ptr_Generic_struct_A Generic


### PR DESCRIPTION
When doing the validator checks, an instruction is currently registered
at the end of IdPass.  This creates an inconsistency.  In IdPass, an
instruction that uses its own result will treat that use as a forward
reference.  Then in the following passes it will not because the
definition can be found.

It seems best to update the state after all of the check have been done
for the current instruction.  This makes it consistent for all of the
passes.

This makes a different when trying to verify OpTypeStruct.

Fixes https://crbug.com/874372.