### PR TITLE
Add GN rules to build spriv-as

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -228,6 +228,21 @@ action("spvtools_generators_inc") {
   ]
 }
 
+action("spvtools_build_version") {
+  script = "utils/update_build_version.py"
+
+  src_dir = "."
+  inc_file = "${target_gen_dir}/build-version.inc"
+
+  outputs = [
+    inc_file,
+  ]
+  args = [
+    rebase_path(src_dir, root_build_dir),
+    rebase_path(inc_file, root_build_dir),
+  ]
+}
+
 spvtools_core_tables("unified1") {
   version = "unified1"
 }
@@ -725,4 +740,16 @@ if (spirv_tools_standalone) {
       "test/fuzzers",
     ]
   }
+}
+
+executable("spirv-as") {
+  sources = [
+    "source/software_version.cpp",
+    "tools/as/as.cpp",
+  ]
+  deps = [
+    ":spvtools",
+    ":spvtools_build_version",
+  ]
+  configs += [ ":spvtools_config" ]
 }


### PR DESCRIPTION
This CL adds a target to build spirv-as through the GN build. Code was added to generate the build-version.inc file as well.