### PR TITLE
Fix EvalInt32IfConst to fail on type instructions.

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -862,7 +862,7 @@ std::tuple<bool, bool, uint32_t> ValidationState_t::EvalInt32IfConst(
   assert(inst);
   const uint32_t type = inst->type_id();
 
-  if (!IsIntScalarType(type) || GetBitWidth(type) != 32) {
+  if (type == 0 || !IsIntScalarType(type) || GetBitWidth(type) != 32) {
     return std::make_tuple(false, false, 0);
   }
 

--- a/test/val/val_barriers_test.cpp
+++ b/test/val/val_barriers_test.cpp
@@ -804,6 +804,18 @@ OpMemoryNamedBarrier %barrier %workgroup %acquire_and_release_uniform
                         "AcquireRelease or SequentiallyConsistent"));
 }
 
+TEST_F(ValidateBarriers, TypeAsMemoryScope) {
+  const std::string body = R"(
+OpMemoryBarrier %u32 %u32_0
+)";
+
+  CompileSuccessfully(GenerateKernelCode(body));
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("MemoryBarrier: expected Memory Scope to be a 32-bit int"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
Fixes https://crbug.com/875842

* EvalInt32IfConst dereferenced a null pointer if a type instruction was
sent as the id