### PR TITLE
Ignore *.pyc files in git commands.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .clang_complete
 .ycm_extra_conf.py*
+*.pyc
 compile_commands.json
 /build/
 /buildtools/


### PR DESCRIPTION
This is needed for the new python testing harness added in #1802.