### PR TITLE
Have PredicateBlocks jump the existing merge blocks.

### DIFF
--- a/source/opt/merge_return_pass.cpp
+++ b/source/opt/merge_return_pass.cpp
@@ -220,9 +220,6 @@ void MergeReturnPass::UpdatePhiNodes(BasicBlock* new_source, BasicBlock* target)
 void MergeReturnPass::CreatePhiNodesForInst(BasicBlock* merge_block,
                                             uint32_t predecessor,
                                             Instruction& inst) {
-
-  std::cerr << "Adding new phi nodes for inst " << inst.PrettyPrint(SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES) << std::endl;
-
   DominatorAnalysis* dom_tree =
       context()->GetDominatorAnalysis(merge_block->GetParent());
   BasicBlock* inst_bb = context()->get_instr_block(&inst);
@@ -784,10 +781,8 @@ void MergeReturnPass::AddNewPhiNodes(BasicBlock* bb, BasicBlock* pred,
   // Insert as a stopping point.  We do not have to add anything in the block
   // or above because the header dominates |bb|.
 
-      std::cerr << "In AddNewPhiNodes, bb=" << bb->id() << "\n";
   BasicBlock* current_bb = pred;
   while (current_bb != nullptr && current_bb->id() != header_id) {
-    std::cerr << "\t- current_bb=" << current_bb->id() << "\n";
     for (Instruction& inst : *current_bb) {
       CreatePhiNodesForInst(bb, pred->id(), inst);
     }

--- a/source/opt/merge_return_pass.cpp
+++ b/source/opt/merge_return_pass.cpp
@@ -104,7 +104,7 @@ void MergeReturnPass::ProcessStructured(
     // Predicate successors of the original return blocks as necessary.
     if (std::find(return_blocks.begin(), return_blocks.end(), block) !=
         return_blocks.end()) {
-      PredicateBlocks(block, order, &predicated);
+      PredicateBlocks(block, &predicated);
     }
 
     // Generate state for next block
@@ -277,8 +277,7 @@ void MergeReturnPass::CreatePhiNodesForInst(BasicBlock* merge_block,
 }
 
 void MergeReturnPass::PredicateBlocks(
-    BasicBlock* return_block, const std::list<BasicBlock*>& order,
-    std::unordered_set<BasicBlock*>* predicated) {
+    BasicBlock* return_block, std::unordered_set<BasicBlock*>* predicated) {
   // The CFG is being modified as the function proceeds so avoid caching
   // successors.
 
@@ -296,8 +295,6 @@ void MergeReturnPass::PredicateBlocks(
   assert(block &&
          "Return blocks should have returns already replaced by a single "
          "unconditional branch.");
-
-  (void)(order);
 
   auto state = state_.rbegin();
   std::unordered_set<BasicBlock*> seen;

--- a/source/opt/merge_return_pass.cpp
+++ b/source/opt/merge_return_pass.cpp
@@ -200,7 +200,8 @@ void MergeReturnPass::BranchToBlock(BasicBlock* block, uint32_t target) {
   cfg()->AddEdge(block->id(), target);
 }
 
-void MergeReturnPass::UpdatePhiNodes(BasicBlock* new_source, BasicBlock* target) {
+void MergeReturnPass::UpdatePhiNodes(BasicBlock* new_source,
+                                     BasicBlock* target) {
   // A new edge is being added from |new_source| to |target|, so go through
   // |target|'s phi nodes add an undef incoming value for |new_source|.
   target->ForEachPhiInst([this, new_source](Instruction* inst) {
@@ -212,8 +213,7 @@ void MergeReturnPass::UpdatePhiNodes(BasicBlock* new_source, BasicBlock* target)
 
   const auto& target_pred = cfg()->preds(target->id());
   if (target_pred.size() == 1) {
-    MarkForNewPhiNodes(target,
-                       context()->get_instr_block(target_pred[0]));
+    MarkForNewPhiNodes(target, context()->get_instr_block(target_pred[0]));
   }
 }
 
@@ -287,14 +287,15 @@ void MergeReturnPass::PredicateBlocks(
   }
 
   BasicBlock* block = nullptr;
-    const BasicBlock* const_block = const_cast<const BasicBlock*>(return_block);
-    const_block->ForEachSuccessorLabel(
-        [this, &block](const uint32_t idx) {
-          BasicBlock* succ_block = context()->get_instr_block(idx);
-          assert(block == nullptr);
-          block = succ_block;
-        });
-  assert(block && "Return blocks should have returns already replaced by a single unconditional branch.");
+  const BasicBlock* const_block = const_cast<const BasicBlock*>(return_block);
+  const_block->ForEachSuccessorLabel([this, &block](const uint32_t idx) {
+    BasicBlock* succ_block = context()->get_instr_block(idx);
+    assert(block == nullptr);
+    block = succ_block;
+  });
+  assert(block &&
+         "Return blocks should have returns already replaced by a single "
+         "unconditional branch.");
 
   (void)(order);
 
@@ -333,15 +334,15 @@ void MergeReturnPass::PredicateBlocks(
       // block because, if |block| == |tail|, then |tail| will have multiple
       // successors.
       next = nullptr;
-      tail->ForEachSuccessorLabel(
-          [this, &next](const uint32_t idx) {
-            BasicBlock* succ_block = context()->get_instr_block(idx);
-            assert(next == nullptr && "Found block with multiple successors and no merge instruction.");
-            next = succ_block;
-          });
+      tail->ForEachSuccessorLabel([this, &next](const uint32_t idx) {
+        BasicBlock* succ_block = context()->get_instr_block(idx);
+        assert(
+            next == nullptr &&
+            "Found block with multiple successors and no merge instruction.");
+        next = succ_block;
+      });
 
       PredicateBlock(block, tail, predicated);
-
     }
     block = next;
   }
@@ -581,7 +582,6 @@ void MergeReturnPass::BreakFromConstruct(
 
   assert(old_body->begin() != old_body->end());
   assert(block->begin() != block->end());
-
 }
 
 void MergeReturnPass::RecordReturned(BasicBlock* block) {

--- a/source/opt/merge_return_pass.h
+++ b/source/opt/merge_return_pass.h
@@ -300,8 +300,7 @@ class MergeReturnPass : public MemPass {
   // it is mapped to it original single predcessor.  It is assumed there are no
   // values that will need a phi on the new edges.
   std::unordered_map<BasicBlock*, BasicBlock*> new_merge_nodes_;
-  void BreakFromConstruct(BasicBlock* block,
-                          BasicBlock* merge_block,
+  void BreakFromConstruct(BasicBlock* block, BasicBlock* merge_block,
                           std::unordered_set<BasicBlock*>* predicated);
   void UpdatePhiNodes(BasicBlock* new_source, BasicBlock* target);
 };

--- a/source/opt/merge_return_pass.h
+++ b/source/opt/merge_return_pass.h
@@ -221,7 +221,6 @@ class MergeReturnPass : public MemPass {
   // involves adding new selections constructs to jump around these
   // instructions.
   void PredicateBlocks(BasicBlock* return_block,
-                       const std::list<BasicBlock*>& predicated,
                        std::unordered_set<BasicBlock*>* pSet);
 
   // Add the predication code (see |PredicateBlocks|) to |tail_block| if it

--- a/source/opt/merge_return_pass.h
+++ b/source/opt/merge_return_pass.h
@@ -221,7 +221,8 @@ class MergeReturnPass : public MemPass {
   // involves adding new selections constructs to jump around these
   // instructions.
   void PredicateBlocks(BasicBlock* return_block,
-                       std::unordered_set<BasicBlock*>* predicated);
+                       const std::list<BasicBlock*>& predicated,
+                       std::unordered_set<BasicBlock*>* pSet);
 
   // Add the predication code (see |PredicateBlocks|) to |tail_block| if it
   // requires predication.  |tail_block| and any new blocks that are known to
@@ -299,6 +300,10 @@ class MergeReturnPass : public MemPass {
   // it is mapped to it original single predcessor.  It is assumed there are no
   // values that will need a phi on the new edges.
   std::unordered_map<BasicBlock*, BasicBlock*> new_merge_nodes_;
+  void BreakFromConstruct(BasicBlock* block,
+                          BasicBlock* merge_block,
+                          std::unordered_set<BasicBlock*>* predicated);
+  void UpdatePhiNodes(BasicBlock* new_source, BasicBlock* target);
 };
 
 }  // namespace opt

--- a/source/opt/merge_return_pass.h
+++ b/source/opt/merge_return_pass.h
@@ -220,7 +220,8 @@ class MergeReturnPass : public MemPass {
   // not be executed because the original code would have already returned. This
   // involves adding new selections constructs to jump around these
   // instructions.
-  void PredicateBlocks(const std::vector<BasicBlock*>& return_blocks);
+  void PredicateBlocks(BasicBlock* return_block,
+                       std::unordered_set<BasicBlock*>* predicated);
 
   // Add the predication code (see |PredicateBlocks|) to |tail_block| if it
   // requires predication.  |tail_block| and any new blocks that are known to

--- a/test/opt/pass_merge_return_test.cpp
+++ b/test/opt/pass_merge_return_test.cpp
@@ -296,6 +296,7 @@ OpUnreachable
 OpFunctionEnd
 )";
 
+  SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SinglePassRunAndMatch<MergeReturnPass>(before, false);
 }
 
@@ -344,6 +345,7 @@ OpReturn
 OpFunctionEnd
 )";
 
+  SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SinglePassRunAndMatch<MergeReturnPass>(before, false);
 }
 
@@ -593,16 +595,16 @@ TEST_F(MergeReturnPassTest, NestedSelectionMerge) {
                OpReturn
          %11 = OpLabel
                OpSelectionMerge %12 None
-               OpBranchConditional %false %14 %15
-         %14 = OpLabel
-         %16 = OpIAdd %uint %uint_0 %uint_0
+               OpBranchConditional %false %13 %14
+         %13 = OpLabel
+         %15 = OpIAdd %uint %uint_0 %uint_0
                OpBranch %12
-         %15 = OpLabel
+         %14 = OpLabel
                OpReturn
          %12 = OpLabel
                OpBranch %9
           %9 = OpLabel
-         %17 = OpIAdd %uint %16 %16
+         %16 = OpIAdd %uint %15 %15
                OpReturn
                OpFunctionEnd
 )";
@@ -621,7 +623,7 @@ OpEntryPoint GLCompute %1 "simple_shader"
 %7 = OpTypeFunction %void
 %_ptr_Function_bool = OpTypePointer Function %bool
 %true = OpConstantTrue %bool
-%24 = OpUndef %uint
+%26 = OpUndef %uint
 %1 = OpFunction %void None %7
 %8 = OpLabel
 %19 = OpVariable %_ptr_Function_bool Function %false
@@ -640,24 +642,28 @@ OpBranch %12
 OpStore %19 %true
 OpBranch %12
 %12 = OpLabel
-%25 = OpPhi %uint %15 %13 %24 %14
+%27 = OpPhi %uint %15 %13 %26 %14
+%22 = OpLoad %bool %19
+OpBranchConditional %22 %9 %21
+%21 = OpLabel
 OpBranch %9
 %9 = OpLabel
-%26 = OpPhi %uint %25 %12 %24 %10
-%23 = OpLoad %bool %19
-OpSelectionMerge %22 None
-OpBranchConditional %23 %22 %21
-%21 = OpLabel
-%16 = OpIAdd %uint %26 %26
+%28 = OpPhi %uint %27 %21 %26 %10 %26 %12
+%25 = OpLoad %bool %19
+OpSelectionMerge %24 None
+OpBranchConditional %25 %24 %23
+%23 = OpLabel
+%16 = OpIAdd %uint %28 %28
 OpStore %19 %true
-OpBranch %22
-%22 = OpLabel
+OpBranch %24
+%24 = OpLabel
 OpBranch %17
 %17 = OpLabel
 OpReturn
 OpFunctionEnd
 )";
 
+  SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SinglePassRunAndCheck<MergeReturnPass>(before, after, false, true);
 }
 
@@ -666,8 +672,7 @@ OpFunctionEnd
 // work even if the order of the traversals change.
 TEST_F(MergeReturnPassTest, NestedSelectionMerge2) {
   const std::string before =
-      R"(
-               OpCapability Addresses
+      R"(      OpCapability Addresses
                OpCapability Shader
                OpCapability Linkage
                OpMemoryModel Logical GLSL450
@@ -686,16 +691,16 @@ TEST_F(MergeReturnPassTest, NestedSelectionMerge2) {
                OpReturn
          %10 = OpLabel
                OpSelectionMerge %12 None
-               OpBranchConditional %false %14 %15
-         %14 = OpLabel
-         %16 = OpIAdd %uint %uint_0 %uint_0
+               OpBranchConditional %false %13 %14
+         %13 = OpLabel
+         %15 = OpIAdd %uint %uint_0 %uint_0
                OpBranch %12
-         %15 = OpLabel
+         %14 = OpLabel
                OpReturn
          %12 = OpLabel
                OpBranch %9
           %9 = OpLabel
-         %17 = OpIAdd %uint %16 %16
+         %16 = OpIAdd %uint %15 %15
                OpReturn
                OpFunctionEnd
 )";
@@ -714,7 +719,7 @@ OpEntryPoint GLCompute %1 "simple_shader"
 %7 = OpTypeFunction %void
 %_ptr_Function_bool = OpTypePointer Function %bool
 %true = OpConstantTrue %bool
-%24 = OpUndef %uint
+%26 = OpUndef %uint
 %1 = OpFunction %void None %7
 %8 = OpLabel
 %19 = OpVariable %_ptr_Function_bool Function %false
@@ -733,15 +738,18 @@ OpBranch %12
 OpStore %19 %true
 OpBranch %12
 %12 = OpLabel
-%25 = OpPhi %uint %15 %13 %24 %14
+%27 = OpPhi %uint %15 %13 %26 %14
+%25 = OpLoad %bool %19
+OpBranchConditional %25 %9 %24
+%24 = OpLabel
 OpBranch %9
 %9 = OpLabel
-%26 = OpPhi %uint %25 %12 %24 %11
+%28 = OpPhi %uint %27 %24 %26 %11 %26 %12
 %23 = OpLoad %bool %19
 OpSelectionMerge %22 None
 OpBranchConditional %23 %22 %21
 %21 = OpLabel
-%16 = OpIAdd %uint %26 %26
+%16 = OpIAdd %uint %28 %28
 OpStore %19 %true
 OpBranch %22
 %22 = OpLabel
@@ -756,8 +764,7 @@ OpFunctionEnd
 
 TEST_F(MergeReturnPassTest, NestedSelectionMerge3) {
   const std::string before =
-      R"(
-               OpCapability Addresses
+      R"(      OpCapability Addresses
                OpCapability Shader
                OpCapability Linkage
                OpMemoryModel Logical GLSL450
@@ -775,17 +782,17 @@ TEST_F(MergeReturnPassTest, NestedSelectionMerge3) {
          %11 = OpLabel
                OpReturn
          %10 = OpLabel
-         %16 = OpIAdd %uint %uint_0 %uint_0
-               OpSelectionMerge %12 None
+         %12 = OpIAdd %uint %uint_0 %uint_0
+               OpSelectionMerge %13 None
                OpBranchConditional %false %14 %15
          %14 = OpLabel
-               OpBranch %12
+               OpBranch %13
          %15 = OpLabel
                OpReturn
-         %12 = OpLabel
+         %13 = OpLabel
                OpBranch %9
           %9 = OpLabel
-         %17 = OpIAdd %uint %16 %16
+         %16 = OpIAdd %uint %12 %12
                OpReturn
                OpFunctionEnd
 )";
@@ -804,7 +811,7 @@ OpEntryPoint GLCompute %1 "simple_shader"
 %7 = OpTypeFunction %void
 %_ptr_Function_bool = OpTypePointer Function %bool
 %true = OpConstantTrue %bool
-%24 = OpUndef %uint
+%26 = OpUndef %uint
 %1 = OpFunction %void None %7
 %8 = OpLabel
 %19 = OpVariable %_ptr_Function_bool Function %false
@@ -823,14 +830,17 @@ OpBranch %13
 OpStore %19 %true
 OpBranch %13
 %13 = OpLabel
+%25 = OpLoad %bool %19
+OpBranchConditional %25 %9 %24
+%24 = OpLabel
 OpBranch %9
 %9 = OpLabel
-%25 = OpPhi %uint %12 %13 %24 %11
+%27 = OpPhi %uint %12 %24 %26 %11 %26 %13
 %23 = OpLoad %bool %19
 OpSelectionMerge %22 None
 OpBranchConditional %23 %22 %21
 %21 = OpLabel
-%16 = OpIAdd %uint %25 %25
+%16 = OpIAdd %uint %27 %27
 OpStore %19 %true
 OpBranch %22
 %22 = OpLabel


### PR DESCRIPTION
In PredicateBlocks, we currently skip instructions with side effects,
but it still follows the same control flow (sort-of).  This causes a
problem, when we are trying to predicate code in a loop.  We skip all
of the code with side effects (IV increment), but still follow the
same control flow (jump back the start of the loop).  This creates an
infinite loop because the code will keep jumping back to the start of
the loop without changing the values that effect the exit condition.

This is a large change to merge-return.  When predicating a block that
is in a loop or merge construct, it will jump to the merge block of the
construct.  Once out of all constructs we will generate code as we did
before.

Fixes #1845.