### PR TITLE
Don't "break" from selection constructs.

### DIFF
--- a/source/opt/merge_return_pass.cpp
+++ b/source/opt/merge_return_pass.cpp
@@ -315,7 +315,11 @@ void MergeReturnPass::PredicateBlocks(
         state++;
       }
       BreakFromConstruct(block, next, predicated, order);
-    } else if (state->InStructuredFlow()) {
+    } else if (false && state->InStructuredFlow()) {
+      // TODO(#1861): This is disabled until drivers are fixed to accept
+      // conditional exits from a selection construct.  Reenable tests when
+      // this code is turned back on.
+
       next = context()->get_instr_block(state->CurrentMergeId());
       state++;
       BreakFromConstruct(block, next, predicated, order);

--- a/test/opt/pass_merge_return_test.cpp
+++ b/test/opt/pass_merge_return_test.cpp
@@ -489,6 +489,9 @@ TEST_F(MergeReturnPassTest, SplitBlockUsedInPhi) {
   SinglePassRunAndMatch<MergeReturnPass>(before, false);
 }
 
+// TODO(#1861): Reenable these test when the breaks from selection constructs
+// are reenabled.
+/*
 TEST_F(MergeReturnPassTest, UpdateOrderWhenPredicating) {
   const std::string before =
       R"(
@@ -553,6 +556,7 @@ TEST_F(MergeReturnPassTest, UpdateOrderWhenPredicating) {
 
   SinglePassRunAndMatch<MergeReturnPass>(before, false);
 }
+*/
 #endif
 
 TEST_F(MergeReturnPassTest, StructuredControlFlowBothMergeAndHeader) {
@@ -638,6 +642,9 @@ OpFunctionEnd
   SinglePassRunAndCheck<MergeReturnPass>(before, after, false, true);
 }
 
+// TODO(#1861): Reenable these test when the breaks from selection constructs
+// are reenabled.
+/*
 TEST_F(MergeReturnPassTest, NestedSelectionMerge) {
   const std::string before =
       R"(
@@ -917,6 +924,7 @@ OpFunctionEnd
 
   SinglePassRunAndCheck<MergeReturnPass>(before, after, false, true);
 }
+*/
 
 TEST_F(MergeReturnPassTest, NestedLoopMerge) {
   const std::string before =


### PR DESCRIPTION
If seems like at least 1 driver does not like a condition jump to the end
of a selection construct.  We are generating these in the merge return
pass.  This change stops merge return from generating this sequence.

Part of #1861.