### PR TITLE
Have the constant manager take ownership of constants.

### DIFF
--- a/source/opt/constants.h
+++ b/source/opt/constants.h
@@ -582,7 +582,7 @@ class ConstantManager {
     auto ret = const_pool_.insert(cst.get());
     if (ret.second) {
       owned_constants_.emplace_back(std::move(cst));
-    } // else delete |cst|.
+    }  // else delete |cst|.
     return *ret.first;
   }
 

--- a/source/opt/constants.h
+++ b/source/opt/constants.h
@@ -578,14 +578,18 @@ class ConstantManager {
   // Registers a new constant |cst| in the constant pool. If the constant
   // existed already, it returns a pointer to the previously existing Constant
   // in the pool. Otherwise, it returns |cst|.
-  const Constant* RegisterConstant(const Constant* cst) {
-    auto ret = const_pool_.insert(cst);
+  const Constant* RegisterConstant(std::unique_ptr<Constant> cst) {
+    auto ret = const_pool_.insert(cst.get());
+    if (ret.second) {
+      owned_constants_.emplace_back(std::move(cst));
+    } // else delete |cst|.
     return *ret.first;
   }
 
   // A helper function to get a vector of Constant instances with the specified
   // ids. If it can not find the Constant instance for any one of the ids,
   // it returns an empty vector.
+
   std::vector<const Constant*> GetConstantsFromIds(
       const std::vector<uint32_t>& ids) const;
 
@@ -633,7 +637,7 @@ class ConstantManager {
   // type, either Bool, Integer or Float. If any of the rules above failed, the
   // creation will fail and nullptr will be returned. If the vector is empty,
   // a NullConstant instance will be created with the given type.
-  const Constant* CreateConstant(
+  std::unique_ptr<Constant> CreateConstant(
       const Type* type,
       const std::vector<uint32_t>& literal_words_or_ids) const;
 
@@ -680,6 +684,10 @@ class ConstantManager {
 
   // The constant pool.  All created constants are registered here.
   std::unordered_set<const Constant*, ConstantHash, ConstantEqual> const_pool_;
+
+  // The constant that are owned by the constant manager.  Every constant in
+  // |const_pool_| should be in |owned_constants_| as well.
+  std::vector<std::unique_ptr<Constant>> owned_constants_;
 };
 
 }  // namespace analysis

--- a/source/opt/constants.h
+++ b/source/opt/constants.h
@@ -582,14 +582,13 @@ class ConstantManager {
     auto ret = const_pool_.insert(cst.get());
     if (ret.second) {
       owned_constants_.emplace_back(std::move(cst));
-    }  // else delete |cst|.
+    }
     return *ret.first;
   }
 
   // A helper function to get a vector of Constant instances with the specified
   // ids. If it can not find the Constant instance for any one of the ids,
   // it returns an empty vector.
-
   std::vector<const Constant*> GetConstantsFromIds(
       const std::vector<uint32_t>& ids) const;
 

--- a/source/opt/fold_spec_constant_op_and_composite_pass.cpp
+++ b/source/opt/fold_spec_constant_op_and_composite_pass.cpp
@@ -367,10 +367,10 @@ Instruction* FoldSpecConstantOpAndCompositePass::DoComponentWiseOperation(
         assert(false && "Failed to create constants with 32-bit word");
       }
     }
-    auto new_vec_const = MakeUnique<analysis::VectorConstant>(result_type->AsVector(),
-                                                      result_vector_components);
-    auto reg_vec_const =
-        context()->get_constant_mgr()->RegisterConstant(std::move(new_vec_const));
+    auto new_vec_const = MakeUnique<analysis::VectorConstant>(
+        result_type->AsVector(), result_vector_components);
+    auto reg_vec_const = context()->get_constant_mgr()->RegisterConstant(
+        std::move(new_vec_const));
     return context()->get_constant_mgr()->BuildInstructionAndAddToModule(
         reg_vec_const, pos);
   } else {

--- a/source/opt/fold_spec_constant_op_and_composite_pass.cpp
+++ b/source/opt/fold_spec_constant_op_and_composite_pass.cpp
@@ -279,11 +279,10 @@ Instruction* FoldSpecConstantOpAndCompositePass::DoVectorShuffle(
            "Literal index out of bound of the concatenated vector");
     selected_components.push_back(concatenated_components[literal]);
   }
-  auto new_vec_const =
-      new analysis::VectorConstant(result_vec_type, selected_components);
+  auto new_vec_const = MakeUnique<analysis::VectorConstant>(
+      result_vec_type, selected_components);
   auto reg_vec_const =
-      context()->get_constant_mgr()->RegisterConstant(new_vec_const);
-  if (reg_vec_const != new_vec_const) delete new_vec_const;
+      context()->get_constant_mgr()->RegisterConstant(std::move(new_vec_const));
   return context()->get_constant_mgr()->BuildInstructionAndAddToModule(
       reg_vec_const, pos);
 }
@@ -368,11 +367,10 @@ Instruction* FoldSpecConstantOpAndCompositePass::DoComponentWiseOperation(
         assert(false && "Failed to create constants with 32-bit word");
       }
     }
-    auto new_vec_const = new analysis::VectorConstant(result_type->AsVector(),
+    auto new_vec_const = MakeUnique<analysis::VectorConstant>(result_type->AsVector(),
                                                       result_vector_components);
     auto reg_vec_const =
-        context()->get_constant_mgr()->RegisterConstant(new_vec_const);
-    if (reg_vec_const != new_vec_const) delete new_vec_const;
+        context()->get_constant_mgr()->RegisterConstant(std::move(new_vec_const));
     return context()->get_constant_mgr()->BuildInstructionAndAddToModule(
         reg_vec_const, pos);
   } else {


### PR DESCRIPTION
Right now the owner of an object of type constant that is in the
|const_pool_| of the constant manager is unclear.  The constant
manager does not delete them, there is no other reasonable owner.  This
causes memory leaks.

This change fixes the memory leaks by having the constant manager
take ownership of the constant that is stores in |const_pool_|.  Other
changes include interface changes to make it explicit that the constant
manager takes ownership of the object when a constant is registered
with the constant manager.

Fixes #1865.