### PR TITLE
Validate uses of OpTypeFunction.

### DIFF
--- a/source/val/validate_type.cpp
+++ b/source/val/validate_type.cpp
@@ -262,6 +262,17 @@ spv_result_t ValidateTypeFunction(ValidationState_t& _,
            << _.getIdName(inst->GetOperandAs<uint32_t>(0)) << "' has "
            << num_args << " arguments.";
   }
+
+  // The only valid uses of OpTypeFunction are in an OpFunction instruction.
+  for (auto& pair : inst->uses()) {
+    const auto* use = pair.first;
+    if (use->opcode() != SpvOpFunction) {
+      return _.diag(SPV_ERROR_INVALID_ID, use)
+             << "Invalid use of function type result id "
+             << _.getIdName(inst->id()) << ".";
+    }
+  }
+
   return SPV_SUCCESS;
 }
 

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -31,9 +31,9 @@ namespace spvtools {
 namespace val {
 namespace {
 
-using spvtest::ScopedContext;
 using ::testing::HasSubstr;
 using ::testing::ValuesIn;
+using spvtest::ScopedContext;
 
 using ValidateIdWithMessage = spvtest::ValidateBase<bool>;
 
@@ -3042,7 +3042,8 @@ TEST_P(AccessChainInstructionTest, AccessChainResultTypeBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%float_entry = )" + instr +
+%float_entry = )" +
+                      instr +
                       R"( %float %my_matrix )" + elem +
                       R"(%int_0 %int_1
 OpReturn
@@ -3062,8 +3063,8 @@ TEST_P(AccessChainInstructionTest, AccessChainBaseTypeVoidBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%float_entry = )" + instr +
-                      " %_ptr_Private_float %void " + elem +
+%float_entry = )" +
+                      instr + " %_ptr_Private_float %void " + elem +
                       R"(%int_0 %int_1
 OpReturn
 OpFunctionEnd
@@ -3081,7 +3082,8 @@ TEST_P(AccessChainInstructionTest, AccessChainBaseTypeNonPtrVariableBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" + instr + R"( %_ptr_Private_float %_ptr_Private_float )" +
+%entry = )" +
+                      instr + R"( %_ptr_Private_float %_ptr_Private_float )" +
                       elem +
                       R"(%int_0 %int_1
 OpReturn
@@ -3101,8 +3103,8 @@ TEST_P(AccessChainInstructionTest,
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" + instr + R"( %_ptr_Function_float %my_matrix )" +
-                      elem +
+%entry = )" +
+                      instr + R"( %_ptr_Function_float %my_matrix )" + elem +
                       R"(%int_0 %int_1
 OpReturn
 OpFunctionEnd
@@ -3122,8 +3124,8 @@ TEST_P(AccessChainInstructionTest,
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" + instr + R"( %_ptr_Private_float %my_float_var )" +
-                      elem +
+%entry = )" +
+                      instr + R"( %_ptr_Private_float %my_float_var )" + elem +
                       R"(%int_0
 OpReturn
 OpFunctionEnd
@@ -3142,8 +3144,8 @@ TEST_P(AccessChainInstructionTest, AccessChainNoIndexesGood) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" + instr + R"( %_ptr_Private_float %my_float_var )" +
-                      elem +
+%entry = )" +
+                      instr + R"( %_ptr_Private_float %my_float_var )" + elem +
                       R"(
 OpReturn
 OpFunctionEnd
@@ -3158,8 +3160,8 @@ TEST_P(AccessChainInstructionTest, AccessChainNoIndexesBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" + instr + R"( %_ptr_Private_mat4x3 %my_float_var )" +
-                      elem +
+%entry = )" +
+                      instr + R"( %_ptr_Private_mat4x3 %my_float_var )" + elem +
                       R"(
 OpReturn
 OpFunctionEnd
@@ -3309,8 +3311,8 @@ TEST_P(AccessChainInstructionTest, AccessChainUndefinedIndexBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" + instr + R"( %_ptr_Private_float %my_matrix )" +
-                      elem +
+%entry = )" +
+                      instr + R"( %_ptr_Private_float %my_matrix )" + elem +
                       R"(%float %int_1
 OpReturn
 OpFunctionEnd
@@ -3328,8 +3330,8 @@ TEST_P(AccessChainInstructionTest, AccessChainStructIndexNotConstantBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%f = )" + instr + R"( %_ptr_Uniform_float %blockName_var )" +
-                      elem +
+%f = )" +
+                      instr + R"( %_ptr_Uniform_float %blockName_var )" + elem +
                       R"(%int_0 %spec_int %int_2
 OpReturn
 OpFunctionEnd
@@ -3348,8 +3350,8 @@ TEST_P(AccessChainInstructionTest,
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" + instr + R"( %_ptr_Uniform_float %blockName_var )" +
-                      elem +
+%entry = )" +
+                      instr + R"( %_ptr_Uniform_float %blockName_var )" + elem +
                       R"(%int_0 %int_1 %int_2
 OpReturn
 OpFunctionEnd
@@ -3368,8 +3370,8 @@ TEST_P(AccessChainInstructionTest, AccessChainStructTooManyIndexesBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" + instr + R"( %_ptr_Uniform_float %blockName_var )" +
-                      elem +
+%entry = )" +
+                      instr + R"( %_ptr_Uniform_float %blockName_var )" + elem +
                       R"(%int_0 %int_2 %int_2
 OpReturn
 OpFunctionEnd
@@ -3387,8 +3389,8 @@ TEST_P(AccessChainInstructionTest, AccessChainStructIndexOutOfBoundBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" + instr + R"( %_ptr_Uniform_float %blockName_var )" +
-                      elem +
+%entry = )" +
+                      instr + R"( %_ptr_Uniform_float %blockName_var )" + elem +
                       R"(%int_3 %int_2 %int_2
 OpReturn
 OpFunctionEnd
@@ -3472,8 +3474,8 @@ TEST_P(AccessChainInstructionTest, AccessChainMatrixMoreArgsThanNeededBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" + instr + R"( %_ptr_Private_float %my_matrix )" +
-                      elem +
+%entry = )" +
+                      instr + R"( %_ptr_Private_float %my_matrix )" + elem +
                       R"(%int_0 %int_1 %int_0
 OpReturn
 OpFunctionEnd
@@ -3492,8 +3494,8 @@ TEST_P(AccessChainInstructionTest,
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" + instr + R"( %_ptr_Private_mat4x3 %my_matrix )" +
-                      elem +
+%entry = )" +
+                      instr + R"( %_ptr_Private_mat4x3 %my_matrix )" + elem +
                       R"(%int_0 %int_1
 OpReturn
 OpFunctionEnd

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -2739,13 +2739,13 @@ TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSourceBad) {
 %7 = OpFunction %1 None %6
 %8 = OpLabel
 %9 = OpVariable %4 Function
-     OpCopyMemorySized %9 %6 %5 None
+     OpCopyMemorySized %9 %5 %5 None
      OpReturn
      OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Source operand <id> '6' is not a pointer."));
+              HasSubstr("Source operand <id> '5' is not a pointer."));
 }
 TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -3042,8 +3042,7 @@ TEST_P(AccessChainInstructionTest, AccessChainResultTypeBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%float_entry = )" +
-                      instr +
+%float_entry = )" + instr +
                       R"( %float %my_matrix )" + elem +
                       R"(%int_0 %int_1
 OpReturn
@@ -3063,8 +3062,8 @@ TEST_P(AccessChainInstructionTest, AccessChainBaseTypeVoidBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%float_entry = )" +
-                      instr + " %_ptr_Private_float %void " + elem +
+%float_entry = )" + instr +
+                      " %_ptr_Private_float %void " + elem +
                       R"(%int_0 %int_1
 OpReturn
 OpFunctionEnd
@@ -3082,8 +3081,7 @@ TEST_P(AccessChainInstructionTest, AccessChainBaseTypeNonPtrVariableBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" +
-                      instr + R"( %_ptr_Private_float %_ptr_Private_float )" +
+%entry = )" + instr + R"( %_ptr_Private_float %_ptr_Private_float )" +
                       elem +
                       R"(%int_0 %int_1
 OpReturn
@@ -3103,8 +3101,8 @@ TEST_P(AccessChainInstructionTest,
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" +
-                      instr + R"( %_ptr_Function_float %my_matrix )" + elem +
+%entry = )" + instr + R"( %_ptr_Function_float %my_matrix )" +
+                      elem +
                       R"(%int_0 %int_1
 OpReturn
 OpFunctionEnd
@@ -3124,8 +3122,8 @@ TEST_P(AccessChainInstructionTest,
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" +
-                      instr + R"( %_ptr_Private_float %my_float_var )" + elem +
+%entry = )" + instr + R"( %_ptr_Private_float %my_float_var )" +
+                      elem +
                       R"(%int_0
 OpReturn
 OpFunctionEnd
@@ -3144,8 +3142,8 @@ TEST_P(AccessChainInstructionTest, AccessChainNoIndexesGood) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" +
-                      instr + R"( %_ptr_Private_float %my_float_var )" + elem +
+%entry = )" + instr + R"( %_ptr_Private_float %my_float_var )" +
+                      elem +
                       R"(
 OpReturn
 OpFunctionEnd
@@ -3160,8 +3158,8 @@ TEST_P(AccessChainInstructionTest, AccessChainNoIndexesBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" +
-                      instr + R"( %_ptr_Private_mat4x3 %my_float_var )" + elem +
+%entry = )" + instr + R"( %_ptr_Private_mat4x3 %my_float_var )" +
+                      elem +
                       R"(
 OpReturn
 OpFunctionEnd
@@ -3311,8 +3309,8 @@ TEST_P(AccessChainInstructionTest, AccessChainUndefinedIndexBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" +
-                      instr + R"( %_ptr_Private_float %my_matrix )" + elem +
+%entry = )" + instr + R"( %_ptr_Private_float %my_matrix )" +
+                      elem +
                       R"(%float %int_1
 OpReturn
 OpFunctionEnd
@@ -3330,8 +3328,8 @@ TEST_P(AccessChainInstructionTest, AccessChainStructIndexNotConstantBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%f = )" +
-                      instr + R"( %_ptr_Uniform_float %blockName_var )" + elem +
+%f = )" + instr + R"( %_ptr_Uniform_float %blockName_var )" +
+                      elem +
                       R"(%int_0 %spec_int %int_2
 OpReturn
 OpFunctionEnd
@@ -3350,8 +3348,8 @@ TEST_P(AccessChainInstructionTest,
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" +
-                      instr + R"( %_ptr_Uniform_float %blockName_var )" + elem +
+%entry = )" + instr + R"( %_ptr_Uniform_float %blockName_var )" +
+                      elem +
                       R"(%int_0 %int_1 %int_2
 OpReturn
 OpFunctionEnd
@@ -3370,8 +3368,8 @@ TEST_P(AccessChainInstructionTest, AccessChainStructTooManyIndexesBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" +
-                      instr + R"( %_ptr_Uniform_float %blockName_var )" + elem +
+%entry = )" + instr + R"( %_ptr_Uniform_float %blockName_var )" +
+                      elem +
                       R"(%int_0 %int_2 %int_2
 OpReturn
 OpFunctionEnd
@@ -3389,8 +3387,8 @@ TEST_P(AccessChainInstructionTest, AccessChainStructIndexOutOfBoundBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" +
-                      instr + R"( %_ptr_Uniform_float %blockName_var )" + elem +
+%entry = )" + instr + R"( %_ptr_Uniform_float %blockName_var )" +
+                      elem +
                       R"(%int_3 %int_2 %int_2
 OpReturn
 OpFunctionEnd
@@ -3474,8 +3472,8 @@ TEST_P(AccessChainInstructionTest, AccessChainMatrixMoreArgsThanNeededBad) {
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" +
-                      instr + R"( %_ptr_Private_float %my_matrix )" + elem +
+%entry = )" + instr + R"( %_ptr_Private_float %my_matrix )" +
+                      elem +
                       R"(%int_0 %int_1 %int_0
 OpReturn
 OpFunctionEnd
@@ -3494,8 +3492,8 @@ TEST_P(AccessChainInstructionTest,
   const std::string instr = GetParam();
   const std::string elem = AccessChainRequiresElemId(instr) ? "%int_0 " : "";
   std::string spirv = kGLSL450MemoryModel + kDeeplyNestedStructureSetup + R"(
-%entry = )" +
-                      instr + R"( %_ptr_Private_mat4x3 %my_matrix )" + elem +
+%entry = )" + instr + R"( %_ptr_Private_mat4x3 %my_matrix )" +
+                      elem +
                       R"(%int_0 %int_1
 OpReturn
 OpFunctionEnd
@@ -4987,6 +4985,22 @@ TEST_F(ValidateIdWithMessage, VoidStructMember) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Structures cannot contain a void type."));
+}
+
+TEST_F(ValidateIdWithMessage, TypeFunctionBadUse) {
+  std::string spirv = kGLSL450MemoryModel + R"(
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%3 = OpTypePointer Function %2
+%4 = OpFunction %1 None %2
+%5 = OpLabel
+     OpReturn
+     OpFunctionEnd)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Invalid use of function type result id 2."));
 }
 
 // TODO: OpLifetimeStart


### PR DESCRIPTION
In the specification of `OpTypeFunction`, it says

> OpFunction is the only valid use of OpTypeFunction.

This commit add a check in the validator for this rule.  I followed the pattern used in #1834.

A test started to fail because the new check happens before the check
the test case is testing.  Updated the test case to still fail the
check it was suppose to fail originally.

http://crbug.com/874571