### PR TITLE
Fix sign mismatch warning

### DIFF
--- a/test/hex_float_test.cpp
+++ b/test/hex_float_test.cpp
@@ -673,11 +673,11 @@ TEST(HexFloatOperationTest, NormalizedSignificand) {
   // For denormalized numbers we expect the normalized significand to
   // shift as if it were normalized. This means, in practice that the
   // top_most set bit will be cut off. Looks very similar to above (on purpose)
-  EXPECT_EQ(bits_set({}), normalized_significand({0}, -127));
-  EXPECT_EQ(bits_set({3}), normalized_significand({0, 4}, -128));
-  EXPECT_EQ(bits_set({3}), normalized_significand({0, 4}, -127));
-  EXPECT_EQ(bits_set({}), normalized_significand({22}, -127));
-  EXPECT_EQ(bits_set({0}), normalized_significand({21, 22}, -127));
+  EXPECT_EQ(bits_set({}), normalized_significand({0}, static_cast<uint32_t>(-127)));
+  EXPECT_EQ(bits_set({3}), normalized_significand({0, 4}, static_cast<uint32_t>(-128)));
+  EXPECT_EQ(bits_set({3}), normalized_significand({0, 4}, static_cast<uint32_t>(-127)));
+  EXPECT_EQ(bits_set({}), normalized_significand({22}, static_cast<uint32_t>(-127)));
+  EXPECT_EQ(bits_set({0}), normalized_significand({21, 22}, static_cast<uint32_t>(-127)));
 }
 
 // Returns the 32-bit floating point value created by

--- a/test/hex_float_test.cpp
+++ b/test/hex_float_test.cpp
@@ -673,11 +673,16 @@ TEST(HexFloatOperationTest, NormalizedSignificand) {
   // For denormalized numbers we expect the normalized significand to
   // shift as if it were normalized. This means, in practice that the
   // top_most set bit will be cut off. Looks very similar to above (on purpose)
-  EXPECT_EQ(bits_set({}), normalized_significand({0}, static_cast<uint32_t>(-127)));
-  EXPECT_EQ(bits_set({3}), normalized_significand({0, 4}, static_cast<uint32_t>(-128)));
-  EXPECT_EQ(bits_set({3}), normalized_significand({0, 4}, static_cast<uint32_t>(-127)));
-  EXPECT_EQ(bits_set({}), normalized_significand({22}, static_cast<uint32_t>(-127)));
-  EXPECT_EQ(bits_set({0}), normalized_significand({21, 22}, static_cast<uint32_t>(-127)));
+  EXPECT_EQ(bits_set({}),
+            normalized_significand({0}, static_cast<uint32_t>(-127)));
+  EXPECT_EQ(bits_set({3}),
+            normalized_significand({0, 4}, static_cast<uint32_t>(-128)));
+  EXPECT_EQ(bits_set({3}),
+            normalized_significand({0, 4}, static_cast<uint32_t>(-127)));
+  EXPECT_EQ(bits_set({}),
+            normalized_significand({22}, static_cast<uint32_t>(-127)));
+  EXPECT_EQ(bits_set({0}),
+            normalized_significand({21, 22}, static_cast<uint32_t>(-127)));
 }
 
 // Returns the 32-bit floating point value created by


### PR DESCRIPTION
Cast negative ints to uint32_t to avoid int/uint comparison warning.