### PR TITLE
BUILD.gn: Make a better interface with dependents.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -273,17 +273,33 @@ foreach(table, spvtools_vendor_tables) {
   }
 }
 
-config("spvtools_config") {
+config("spvtools_public_config") {
+  include_dirs = [ "include" ]
+}
+
+config("spvtools_internal_config") {
   include_dirs = [
     ".",
-    "include",
     "$target_gen_dir",
     "${spirv_headers}/include",
   ]
 
+  configs = [ ":spvtools_public_config" ]
+
   if (is_clang) {
     cflags = [ "-Wno-implicit-fallthrough" ]
   }
+}
+
+source_set("spvtools_headers") {
+  sources = [
+    "include/spirv-tools/libspirv.h",
+    "include/spirv-tools/libspirv.hpp",
+    "include/spirv-tools/linker.hpp",
+    "include/spirv-tools/optimizer.hpp",
+  ]
+
+  public_configs = [ ":spvtools_public_config" ]
 }
 
 static_library("spvtools") {
@@ -356,9 +372,15 @@ static_library("spvtools") {
     "source/util/timer.h",
   ]
 
-  public_configs = [ ":spvtools_config" ]
+  public_deps = [
+    ":spvtools_headers",
+  ]
+
   configs -= [ "//build/config/compiler:chromium_code" ]
-  configs += [ "//build/config/compiler:no_chromium_code" ]
+  configs += [
+    "//build/config/compiler:no_chromium_code",
+    ":spvtools_internal_config",
+  ]
 }
 
 static_library("spvtools_val") {
@@ -406,10 +428,15 @@ static_library("spvtools_val") {
   deps = [
     ":spvtools",
   ]
+  public_deps = [
+    ":spvtools_headers",
+  ]
 
-  public_configs = [ ":spvtools_config" ]
   configs -= [ "//build/config/compiler:chromium_code" ]
-  configs += [ "//build/config/compiler:no_chromium_code" ]
+  configs += [
+    "//build/config/compiler:no_chromium_code",
+    ":spvtools_internal_config",
+  ]
 }
 
 static_library("spvtools_opt") {
@@ -584,13 +611,19 @@ static_library("spvtools_opt") {
     "source/opt/workaround1209.cpp",
     "source/opt/workaround1209.h",
   ]
+
   deps = [
     ":spvtools",
   ]
+  public_deps = [
+    ":spvtools_headers",
+  ]
 
-  public_configs = [ ":spvtools_config" ]
   configs -= [ "//build/config/compiler:chromium_code" ]
-  configs += [ "//build/config/compiler:no_chromium_code" ]
+  configs += [
+    "//build/config/compiler:no_chromium_code",
+    ":spvtools_internal_config",
+  ]
 }
 
 group("SPIRV-Tools") {
@@ -638,12 +671,6 @@ if (!build_with_chromium) {
       "${googletest_dir}/googlemock/src/gmock-all.cc",
     ]
     public_configs = [ ":gmock_config" ]
-  }
-}
-
-config("spvtools_test_config") {
-  if (is_clang) {
-    cflags = [ "-Wno-self-assign" ]
   }
 }
 
@@ -728,10 +755,11 @@ test("spvtools_test") {
     sources += [ "${googletest_dir}/googletest/src/gtest_main.cc" ]
   }
 
-  configs += [
-    ":spvtools_config",
-    ":spvtools_test_config",
-  ]
+  if (is_clang) {
+    cflags_cc = [ "-Wno-self-assign" ]
+  }
+
+  configs += [ ":spvtools_internal_config" ]
 }
 
 if (spirv_tools_standalone) {
@@ -752,5 +780,5 @@ executable("spirv-as") {
     ":spvtools",
     ":spvtools_build_version",
   ]
-  configs += [ ":spvtools_config" ]
+  configs += [ ":spvtools_internal_config" ]
 }


### PR DESCRIPTION
This splits the spvtools_config into a public and private part to avoid
leaking internal bits to dependents. A new target is added for the
public headers so that "gn check" works for dependents.

PTAL @dj2