### PR TITLE
Revert "BUILD.gn: Make a better interface with dependents."

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -273,33 +273,17 @@ foreach(table, spvtools_vendor_tables) {
   }
 }
 
-config("spvtools_public_config") {
-  include_dirs = [ "include" ]
-}
-
-config("spvtools_internal_config") {
+config("spvtools_config") {
   include_dirs = [
     ".",
+    "include",
     "$target_gen_dir",
     "${spirv_headers}/include",
   ]
 
-  configs = [ ":spvtools_public_config" ]
-
   if (is_clang) {
     cflags = [ "-Wno-implicit-fallthrough" ]
   }
-}
-
-source_set("spvtools_headers") {
-  sources = [
-    "include/spirv-tools/libspirv.h",
-    "include/spirv-tools/libspirv.hpp",
-    "include/spirv-tools/linker.hpp",
-    "include/spirv-tools/optimizer.hpp",
-  ]
-
-  public_configs = [ ":spvtools_public_config" ]
 }
 
 static_library("spvtools") {
@@ -372,15 +356,9 @@ static_library("spvtools") {
     "source/util/timer.h",
   ]
 
-  public_deps = [
-    ":spvtools_headers",
-  ]
-
+  public_configs = [ ":spvtools_config" ]
   configs -= [ "//build/config/compiler:chromium_code" ]
-  configs += [
-    "//build/config/compiler:no_chromium_code",
-    ":spvtools_internal_config",
-  ]
+  configs += [ "//build/config/compiler:no_chromium_code" ]
 }
 
 static_library("spvtools_val") {
@@ -428,15 +406,10 @@ static_library("spvtools_val") {
   deps = [
     ":spvtools",
   ]
-  public_deps = [
-    ":spvtools_headers",
-  ]
 
+  public_configs = [ ":spvtools_config" ]
   configs -= [ "//build/config/compiler:chromium_code" ]
-  configs += [
-    "//build/config/compiler:no_chromium_code",
-    ":spvtools_internal_config",
-  ]
+  configs += [ "//build/config/compiler:no_chromium_code" ]
 }
 
 static_library("spvtools_opt") {
@@ -611,19 +584,13 @@ static_library("spvtools_opt") {
     "source/opt/workaround1209.cpp",
     "source/opt/workaround1209.h",
   ]
-
   deps = [
     ":spvtools",
   ]
-  public_deps = [
-    ":spvtools_headers",
-  ]
 
+  public_configs = [ ":spvtools_config" ]
   configs -= [ "//build/config/compiler:chromium_code" ]
-  configs += [
-    "//build/config/compiler:no_chromium_code",
-    ":spvtools_internal_config",
-  ]
+  configs += [ "//build/config/compiler:no_chromium_code" ]
 }
 
 group("SPIRV-Tools") {
@@ -671,6 +638,12 @@ if (!build_with_chromium) {
       "${googletest_dir}/googlemock/src/gmock-all.cc",
     ]
     public_configs = [ ":gmock_config" ]
+  }
+}
+
+config("spvtools_test_config") {
+  if (is_clang) {
+    cflags = [ "-Wno-self-assign" ]
   }
 }
 
@@ -755,11 +728,10 @@ test("spvtools_test") {
     sources += [ "${googletest_dir}/googletest/src/gtest_main.cc" ]
   }
 
-  if (is_clang) {
-    cflags_cc = [ "-Wno-self-assign" ]
-  }
-
-  configs += [ ":spvtools_internal_config" ]
+  configs += [
+    ":spvtools_config",
+    ":spvtools_test_config",
+  ]
 }
 
 if (spirv_tools_standalone) {
@@ -780,5 +752,5 @@ executable("spirv-as") {
     ":spvtools",
     ":spvtools_build_version",
   ]
-  configs += [ ":spvtools_internal_config" ]
+  configs += [ ":spvtools_config" ]
 }


### PR DESCRIPTION
Reverts KhronosGroup/SPIRV-Tools#1875

This breaks the Chrome roll:

ERROR Unresolved dependencies.
//third_party/SPIRV-Tools/src/test/fuzzers:fuzzer_config(//build/toolchain/linux:clang_x64)
  needs //third_party/SPIRV-Tools/src:spvtools_config(//build/toolchain/linux:clang_x64)
GN gen failed: 1