### PR TITLE
Memory model deprecated decorations

### DIFF
--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -860,7 +860,7 @@ spv_result_t CheckVulkanMemoryModelDeprecatedDecorations(
           str << " (member index " << member << ")";
         }
         str << " is banned when using the Vulkan memory model.";
-        return vstate.diag(SPV_ERROR_INVALID_ID) << str.str();
+        return vstate.diag(SPV_ERROR_INVALID_ID, inst) << str.str();
       }
     }
   }

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -840,6 +840,34 @@ spv_result_t CheckDecorationsOfBuffers(ValidationState_t& vstate) {
   return SPV_SUCCESS;
 }
 
+spv_result_t CheckVulkanMemoryModelDeprecatedDecorations(
+    ValidationState_t& vstate) {
+  if (vstate.memory_model() != SpvMemoryModelVulkanKHR) return SPV_SUCCESS;
+
+  std::string msg;
+  std::ostringstream str(msg);
+  for (const auto& def : vstate.all_definitions()) {
+    const auto inst = def.second;
+    const auto id = inst->id();
+    for (const auto& dec : vstate.id_decorations(id)) {
+      const auto member = dec.struct_member_index();
+      if (dec.dec_type() == SpvDecorationCoherent ||
+          dec.dec_type() == SpvDecorationVolatile) {
+        str << (dec.dec_type() == SpvDecorationCoherent ? "Coherent"
+                                                        : "Volatile");
+        str << " decoration targeting " << vstate.getIdName(id);
+        if (member != Decoration::kInvalidMember) {
+          str << " (member index " << member << ")";
+        }
+        str << " is banned when using the Vulkan memory model.";
+        return vstate.diag(SPV_ERROR_INVALID_ID) << str.str();
+      }
+    }
+  }
+
+  return SPV_SUCCESS;
+}
+
 }  // namespace
 
 // Validates that decorations have been applied properly.
@@ -849,6 +877,8 @@ spv_result_t ValidateDecorations(ValidationState_t& vstate) {
   if (auto error = CheckDecorationsOfBuffers(vstate)) return error;
   if (auto error = CheckLinkageAttrOfFunctions(vstate)) return error;
   if (auto error = CheckDescriptorSetArrayOfArrays(vstate)) return error;
+  if (auto error = CheckVulkanMemoryModelDeprecatedDecorations(vstate))
+    return error;
   return SPV_SUCCESS;
 }
 

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -3034,7 +3034,7 @@ OpFunctionEnd
 }
 
 TEST_F(ValidateDecorations, VulkanMemoryModelNonCoherent) {
-  const string spirv = R"(
+  const std::string spirv = R"(
 OpCapability Shader
 OpCapability VulkanMemoryModelKHR
 OpCapability Linkage
@@ -3047,15 +3047,15 @@ OpDecorate %1 Coherent
 %1 = OpVariable %3 StorageBuffer
 )";
 
-  CompileSuccessfully(spirv);
-  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Coherent decoration targeting 1 is banned when using "
                         "the Vulkan memory model."));
 }
 
 TEST_F(ValidateDecorations, VulkanMemoryModelNoCoherentMember) {
-  const string spirv = R"(
+  const std::string spirv = R"(
 OpCapability Shader
 OpCapability VulkanMemoryModelKHR
 OpCapability Linkage
@@ -3066,8 +3066,8 @@ OpMemberDecorate %1 0 Coherent
 %1 = OpTypeStruct %2 %2
 )";
 
-  CompileSuccessfully(spirv);
-  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Coherent decoration targeting 1 (member index 0) is "
                         "banned when using "
@@ -3075,7 +3075,7 @@ OpMemberDecorate %1 0 Coherent
 }
 
 TEST_F(ValidateDecorations, VulkanMemoryModelNoVolatile) {
-  const string spirv = R"(
+  const std::string spirv = R"(
 OpCapability Shader
 OpCapability VulkanMemoryModelKHR
 OpCapability Linkage
@@ -3088,15 +3088,15 @@ OpDecorate %1 Volatile
 %1 = OpVariable %3 StorageBuffer
 )";
 
-  CompileSuccessfully(spirv);
-  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Volatile decoration targeting 1 is banned when using "
                         "the Vulkan memory model."));
 }
 
 TEST_F(ValidateDecorations, VulkanMemoryModelNoVolatileMember) {
-  const string spirv = R"(
+  const std::string spirv = R"(
 OpCapability Shader
 OpCapability VulkanMemoryModelKHR
 OpCapability Linkage
@@ -3107,13 +3107,12 @@ OpMemberDecorate %1 1 Volatile
 %1 = OpTypeStruct %2 %2
 )";
 
-  CompileSuccessfully(spirv);
-  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Volatile decoration targeting 1 (member index 1) is "
                         "banned when using "
                         "the Vulkan memory model."));
->>>>>>> Decoration validation for Vulkan memory model
 }
 }  // namespace
 }  // namespace val

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -3032,6 +3032,89 @@ OpFunctionEnd
                         "Storage Class of Input(1) or Output(3). Found Storage "
                         "Class 4 for Entry Point id 1."));
 }
+
+TEST_F(ValidateDecorations, VulkanMemoryModelNonCoherent) {
+  const string spirv = R"(
+OpCapability Shader
+OpCapability VulkanMemoryModelKHR
+OpCapability Linkage
+OpExtension "SPV_KHR_vulkan_memory_model"
+OpExtension "SPV_KHR_storage_buffer_storage_class"
+OpMemoryModel Logical VulkanKHR
+OpDecorate %1 Coherent
+%2 = OpTypeInt 32 0
+%3 = OpTypePointer StorageBuffer %2
+%1 = OpVariable %3 StorageBuffer
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Coherent decoration targeting 1 is banned when using "
+                        "the Vulkan memory model."));
+}
+
+TEST_F(ValidateDecorations, VulkanMemoryModelNoCoherentMember) {
+  const string spirv = R"(
+OpCapability Shader
+OpCapability VulkanMemoryModelKHR
+OpCapability Linkage
+OpExtension "SPV_KHR_vulkan_memory_model"
+OpMemoryModel Logical VulkanKHR
+OpMemberDecorate %1 0 Coherent
+%2 = OpTypeInt 32 0
+%1 = OpTypeStruct %2 %2
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Coherent decoration targeting 1 (member index 0) is "
+                        "banned when using "
+                        "the Vulkan memory model."));
+}
+
+TEST_F(ValidateDecorations, VulkanMemoryModelNoVolatile) {
+  const string spirv = R"(
+OpCapability Shader
+OpCapability VulkanMemoryModelKHR
+OpCapability Linkage
+OpExtension "SPV_KHR_vulkan_memory_model"
+OpExtension "SPV_KHR_storage_buffer_storage_class"
+OpMemoryModel Logical VulkanKHR
+OpDecorate %1 Volatile
+%2 = OpTypeInt 32 0
+%3 = OpTypePointer StorageBuffer %2
+%1 = OpVariable %3 StorageBuffer
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Volatile decoration targeting 1 is banned when using "
+                        "the Vulkan memory model."));
+}
+
+TEST_F(ValidateDecorations, VulkanMemoryModelNoVolatileMember) {
+  const string spirv = R"(
+OpCapability Shader
+OpCapability VulkanMemoryModelKHR
+OpCapability Linkage
+OpExtension "SPV_KHR_vulkan_memory_model"
+OpMemoryModel Logical VulkanKHR
+OpMemberDecorate %1 1 Volatile
+%2 = OpTypeInt 32 0
+%1 = OpTypeStruct %2 %2
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Volatile decoration targeting 1 (member index 1) is "
+                        "banned when using "
+                        "the Vulkan memory model."));
+>>>>>>> Decoration validation for Vulkan memory model
+}
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
Checks that Coherent and Volatile decorations cannot be used if the vulkan memory model is used.