### PR TITLE
Move the registration of decorations.

### DIFF
--- a/source/val/validate_annotation.cpp
+++ b/source/val/validate_annotation.cpp
@@ -128,6 +128,79 @@ spv_result_t ValidateGroupMemberDecorate(ValidationState_t& _,
   return SPV_SUCCESS;
 }
 
+// Registers necessary decoration(s) for the appropriate IDs based on the
+// instruction.
+spv_result_t RegisterDecorations(ValidationState_t& _,
+                                 const Instruction* inst) {
+  switch (inst->opcode()) {
+    case SpvOpDecorate: {
+      const uint32_t target_id = inst->word(1);
+      const SpvDecoration dec_type = static_cast<SpvDecoration>(inst->word(2));
+      std::vector<uint32_t> dec_params;
+      if (inst->words().size() > 3) {
+        dec_params.insert(dec_params.end(), inst->words().begin() + 3,
+                          inst->words().end());
+      }
+      _.RegisterDecorationForId(target_id, Decoration(dec_type, dec_params));
+      break;
+    }
+    case SpvOpMemberDecorate: {
+      const uint32_t struct_id = inst->word(1);
+      const uint32_t index = inst->word(2);
+      const SpvDecoration dec_type = static_cast<SpvDecoration>(inst->word(3));
+      std::vector<uint32_t> dec_params;
+      if (inst->words().size() > 4) {
+        dec_params.insert(dec_params.end(), inst->words().begin() + 4,
+                          inst->words().end());
+      }
+      _.RegisterDecorationForId(struct_id,
+                                Decoration(dec_type, dec_params, index));
+      break;
+    }
+    case SpvOpDecorationGroup: {
+      // We don't need to do anything right now. Assigning decorations to groups
+      // will be taken care of via OpGroupDecorate.
+      break;
+    }
+    case SpvOpGroupDecorate: {
+      // Word 1 is the group <id>. All subsequent words are target <id>s that
+      // are going to be decorated with the decorations.
+      const uint32_t decoration_group_id = inst->word(1);
+      std::vector<Decoration>& group_decorations =
+          _.id_decorations(decoration_group_id);
+      for (size_t i = 2; i < inst->words().size(); ++i) {
+        const uint32_t target_id = inst->word(i);
+        _.RegisterDecorationsForId(target_id, group_decorations.begin(),
+                                   group_decorations.end());
+      }
+      break;
+    }
+    case SpvOpGroupMemberDecorate: {
+      // Word 1 is the Decoration Group <id> followed by (struct<id>,literal)
+      // pairs. All decorations of the group should be applied to all the struct
+      // members that are specified in the instructions.
+      const uint32_t decoration_group_id = inst->word(1);
+      std::vector<Decoration>& group_decorations =
+          _.id_decorations(decoration_group_id);
+      // Grammar checks ensures that the number of arguments to this instruction
+      // is an odd number: 1 decoration group + (id,literal) pairs.
+      for (size_t i = 2; i + 1 < inst->words().size(); i = i + 2) {
+        const uint32_t struct_id = inst->word(i);
+        const uint32_t index = inst->word(i + 1);
+        // ID validation phase ensures this is in fact a struct instruction and
+        // that the index is not out of bound.
+        _.RegisterDecorationsForStructMember(struct_id, index,
+                                             group_decorations.begin(),
+                                             group_decorations.end());
+      }
+      break;
+    }
+    default:
+      break;
+  }
+  return SPV_SUCCESS;
+}
+
 }  // namespace
 
 spv_result_t AnnotationPass(ValidationState_t& _, const Instruction* inst) {
@@ -150,6 +223,10 @@ spv_result_t AnnotationPass(ValidationState_t& _, const Instruction* inst) {
     default:
       break;
   }
+
+  // In order to validate decoration rules, we need to know all the decorations
+  // that are applied to any given <id>.
+  RegisterDecorations(_, inst);
 
   return SPV_SUCCESS;
 }

--- a/source/val/validate_instruction.cpp
+++ b/source/val/validate_instruction.cpp
@@ -429,79 +429,6 @@ spv_result_t LimitCheckNumVars(ValidationState_t& _, const uint32_t var_id,
   return SPV_SUCCESS;
 }
 
-// Registers necessary decoration(s) for the appropriate IDs based on the
-// instruction.
-spv_result_t RegisterDecorations(ValidationState_t& _,
-                                 const Instruction* inst) {
-  switch (inst->opcode()) {
-    case SpvOpDecorate: {
-      const uint32_t target_id = inst->word(1);
-      const SpvDecoration dec_type = static_cast<SpvDecoration>(inst->word(2));
-      std::vector<uint32_t> dec_params;
-      if (inst->words().size() > 3) {
-        dec_params.insert(dec_params.end(), inst->words().begin() + 3,
-                          inst->words().end());
-      }
-      _.RegisterDecorationForId(target_id, Decoration(dec_type, dec_params));
-      break;
-    }
-    case SpvOpMemberDecorate: {
-      const uint32_t struct_id = inst->word(1);
-      const uint32_t index = inst->word(2);
-      const SpvDecoration dec_type = static_cast<SpvDecoration>(inst->word(3));
-      std::vector<uint32_t> dec_params;
-      if (inst->words().size() > 4) {
-        dec_params.insert(dec_params.end(), inst->words().begin() + 4,
-                          inst->words().end());
-      }
-      _.RegisterDecorationForId(struct_id,
-                                Decoration(dec_type, dec_params, index));
-      break;
-    }
-    case SpvOpDecorationGroup: {
-      // We don't need to do anything right now. Assigning decorations to groups
-      // will be taken care of via OpGroupDecorate.
-      break;
-    }
-    case SpvOpGroupDecorate: {
-      // Word 1 is the group <id>. All subsequent words are target <id>s that
-      // are going to be decorated with the decorations.
-      const uint32_t decoration_group_id = inst->word(1);
-      std::vector<Decoration>& group_decorations =
-          _.id_decorations(decoration_group_id);
-      for (size_t i = 2; i < inst->words().size(); ++i) {
-        const uint32_t target_id = inst->word(i);
-        _.RegisterDecorationsForId(target_id, group_decorations.begin(),
-                                   group_decorations.end());
-      }
-      break;
-    }
-    case SpvOpGroupMemberDecorate: {
-      // Word 1 is the Decoration Group <id> followed by (struct<id>,literal)
-      // pairs. All decorations of the group should be applied to all the struct
-      // members that are specified in the instructions.
-      const uint32_t decoration_group_id = inst->word(1);
-      std::vector<Decoration>& group_decorations =
-          _.id_decorations(decoration_group_id);
-      // Grammar checks ensures that the number of arguments to this instruction
-      // is an odd number: 1 decoration group + (id,literal) pairs.
-      for (size_t i = 2; i + 1 < inst->words().size(); i = i + 2) {
-        const uint32_t struct_id = inst->word(i);
-        const uint32_t index = inst->word(i + 1);
-        // ID validation phase ensures this is in fact a struct instruction and
-        // that the index is not out of bound.
-        _.RegisterDecorationsForStructMember(struct_id, index,
-                                             group_decorations.begin(),
-                                             group_decorations.end());
-      }
-      break;
-    }
-    default:
-      break;
-  }
-  return SPV_SUCCESS;
-}
-
 // Parses OpExtension instruction and logs warnings if unsuccessful.
 void CheckIfKnownExtension(ValidationState_t& _, const Instruction* inst) {
   const std::string extension_str = GetExtensionString(&(inst->c_inst()));
@@ -571,10 +498,6 @@ spv_result_t InstructionPass(ValidationState_t& _, const Instruction* inst) {
               "must always be 0 when Kernel "
               "capability is used.";
   }
-
-  // In order to validate decoration rules, we need to know all the decorations
-  // that are applied to any given <id>.
-  RegisterDecorations(_, inst);
 
   if (auto error = ExtensionCheck(_, inst)) return error;
   if (auto error = ReservedCheck(_, inst)) return error;


### PR DESCRIPTION
We currently register decorations in the first pass through the
instructions.  This is a problem because the validator has not even
checked if the decoration instructions are valid yet.  This can lead to
unexpected behaviour from these side table.  For example, in
https://github.com/KhronosGroup/SPIRV-Tools/issues/1882, we use 5GB of
data to store 1 decoration for ids that are not even defined.

Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/1882.