### PR TITLE
Validator: FPRoundingMode decoration (#1482)

### DIFF
--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -902,15 +902,13 @@ spv_result_t CheckDecorationsOfConversions(ValidationState_t& vstate) {
                     "Object operand of an OpStore.";
         }
 
-        const auto object_id = store->word(use.second);
-        const auto ptr_id = store->GetOperandAs<uint32_t>(0);
-        if (object_id != inst->id() || ptr_id == inst->id()) {
+        if (use.second != 2) {
           return vstate.diag(SPV_ERROR_INVALID_ID, inst)
                  << "FPRoundingMode decoration can be applied only to the "
                     "Object operand of an OpStore.";
         }
 
-        const auto ptr_inst = vstate.FindDef(ptr_id);
+        const auto ptr_inst = vstate.FindDef(store->GetOperandAs<uint32_t>(0));
         const auto ptr_type =
             vstate.FindDef(ptr_inst->GetOperandAs<uint32_t>(0));
         const auto storage = ptr_type->GetOperandAs<uint32_t>(1);

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -902,14 +902,15 @@ spv_result_t CheckDecorationsOfConversions(ValidationState_t& vstate) {
                     "Object operand of an OpStore.";
         }
 
-        const auto object_id = store->GetOperandAs<uint32_t>(1);
-        if (object_id != inst->id()) {
+        const auto object_id = store->word(use.second);
+        const auto ptr_id = store->GetOperandAs<uint32_t>(0);
+        if (object_id != inst->id() || ptr_id == inst->id()) {
           return vstate.diag(SPV_ERROR_INVALID_ID, inst)
                  << "FPRoundingMode decoration can be applied only to the "
                     "Object operand of an OpStore.";
         }
 
-        const auto ptr_inst = vstate.FindDef(store->GetOperandAs<uint32_t>(0));
+        const auto ptr_inst = vstate.FindDef(ptr_id);
         const auto ptr_type =
             vstate.FindDef(ptr_inst->GetOperandAs<uint32_t>(0));
         const auto storage = ptr_type->GetOperandAs<uint32_t>(1);

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -864,7 +864,72 @@ spv_result_t CheckVulkanMemoryModelDeprecatedDecorations(
       }
     }
   }
+  return SPV_SUCCESS;
+}
 
+spv_result_t CheckDecorationsOfConversions(ValidationState_t& vstate) {
+  for (const auto& kv : vstate.id_decorations()) {
+    const uint32_t id = kv.first;
+    const auto& decorations = kv.second;
+    if (decorations.empty()) {
+      continue;
+    }
+
+    const Instruction* inst = vstate.FindDef(id);
+    assert(inst);
+
+    // Validates FPRoundingMode decoration
+    for (const auto& decoration : decorations) {
+      if (decoration.dec_type() != SpvDecorationFPRoundingMode) {
+        continue;
+      }
+
+      // Validates width-only conversion instruction for floating-point object
+      // i.e., OpFConvert
+      if (inst->opcode() != SpvOpFConvert) {
+        return vstate.diag(SPV_ERROR_INVALID_ID, inst)
+               << "FPRoundingMode decoration can be applied only to a "
+                  "width-only conversion instruction for floating-point "
+                  "object.";
+      }
+
+      // Validates Object operand of an OpStore
+      bool exist = false;
+      for (const auto& store : vstate.ordered_instructions()) {
+        if (store.opcode() == SpvOpStore) {
+          const auto object_id = store.GetOperandAs<uint32_t>(1);
+          if (object_id == inst->id()) {
+            const auto ptr_id = store.GetOperandAs<uint32_t>(0);
+            const auto ptr = vstate.FindDef(ptr_id);
+            const auto ptr_type_id = ptr->GetOperandAs<uint32_t>(0);
+            const auto ptr_type = vstate.FindDef(ptr_type_id);
+            const auto storage = ptr_type->GetOperandAs<uint32_t>(1);
+
+            // Validates storage class of the pointer to the OpStore
+            if (storage != SpvStorageClassStorageBuffer &&
+                storage != SpvStorageClassUniform &&
+                storage != SpvStorageClassPushConstant &&
+                storage != SpvStorageClassInput &&
+                storage != SpvStorageClassOutput) {
+              return vstate.diag(SPV_ERROR_INVALID_ID, inst)
+                     << "FPRoundingMode decoration can be applied only to the "
+                        "Object operand of an OpStore in the StorageBuffer, "
+                        "Uniform, PushConstant, Input, or Output Storage "
+                        "Classes.";
+            }
+            exist = true;
+            break;
+          }
+        }
+      }
+
+      if (!exist) {
+        return vstate.diag(SPV_ERROR_INVALID_ID, inst)
+               << "FPRoundingMode decoration can be applied only to the "
+                  "Object operand of an OpStore.";
+      }
+    }
+  }
   return SPV_SUCCESS;
 }
 
@@ -879,6 +944,7 @@ spv_result_t ValidateDecorations(ValidationState_t& vstate) {
   if (auto error = CheckDescriptorSetArrayOfArrays(vstate)) return error;
   if (auto error = CheckVulkanMemoryModelDeprecatedDecorations(vstate))
     return error;
+  if (auto error = CheckDecorationsOfConversions(vstate)) return error;
   return SPV_SUCCESS;
 }
 

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -3210,7 +3210,7 @@ OpFunctionEnd
                         "object."));
 }
 
-TEST_F(ValidateDecorations, FPRoundingModeNotOperandOfOpStore) {
+TEST_F(ValidateDecorations, FPRoundingModeNoOpStoreGood) {
   std::string spirv = R"(
 OpCapability Shader
 OpCapability Linkage
@@ -3236,10 +3236,7 @@ OpFunctionEnd
   )";
 
   CompileSuccessfully(spirv);
-  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("FPRoundingMode decoration can be applied only to the "
-                        "Object operand of an OpStore."));
+  EXPECT_EQ(SPV_SUCCESS, ValidateAndRetrieveValidationState());
 }
 
 TEST_F(ValidateDecorations, FPRoundingModeBadStorageClass) {
@@ -3275,6 +3272,76 @@ OpFunctionEnd
       HasSubstr("FPRoundingMode decoration can be applied only to the "
                 "Object operand of an OpStore in the StorageBuffer, Uniform, "
                 "PushConstant, Input, or Output Storage Classes."));
+}
+
+TEST_F(ValidateDecorations, FPRoundingModeMultipleOpStoreGood) {
+  std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpCapability StorageBuffer16BitAccess
+OpExtension "SPV_KHR_storage_buffer_storage_class"
+OpExtension "SPV_KHR_variable_pointers"
+OpExtension "SPV_KHR_16bit_storage"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpDecorate %_ FPRoundingMode RTE
+%half = OpTypeFloat 16
+%float = OpTypeFloat 32
+%float_1_25 = OpConstant %float 1.25
+%half_ptr = OpTypePointer StorageBuffer %half
+%half_ptr_var_0 = OpVariable %half_ptr StorageBuffer
+%half_ptr_var_1 = OpVariable %half_ptr StorageBuffer
+%half_ptr_var_2 = OpVariable %half_ptr StorageBuffer
+%void = OpTypeVoid
+%func = OpTypeFunction %void
+%main = OpFunction %void None %func
+%main_entry = OpLabel
+%_ = OpFConvert %half %float_1_25
+OpStore %half_ptr_var_0 %_
+OpStore %half_ptr_var_1 %_
+OpStore %half_ptr_var_2 %_
+OpReturn
+OpFunctionEnd
+  )";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_SUCCESS, ValidateAndRetrieveValidationState());
+}
+
+TEST_F(ValidateDecorations, FPRoundingModeMultipleUsesBad) {
+  std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpCapability StorageBuffer16BitAccess
+OpExtension "SPV_KHR_storage_buffer_storage_class"
+OpExtension "SPV_KHR_variable_pointers"
+OpExtension "SPV_KHR_16bit_storage"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpDecorate %_ FPRoundingMode RTE
+%half = OpTypeFloat 16
+%float = OpTypeFloat 32
+%float_1_25 = OpConstant %float 1.25
+%half_ptr = OpTypePointer StorageBuffer %half
+%half_ptr_var_0 = OpVariable %half_ptr StorageBuffer
+%half_ptr_var_1 = OpVariable %half_ptr StorageBuffer
+%void = OpTypeVoid
+%func = OpTypeFunction %void
+%main = OpFunction %void None %func
+%main_entry = OpLabel
+%_ = OpFConvert %half %float_1_25
+OpStore %half_ptr_var_0 %_
+%result = OpFAdd %half %_ %_
+OpStore %half_ptr_var_1 %_
+OpReturn
+OpFunctionEnd
+  )";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("FPRoundingMode decoration can be applied only to the "
+                        "Object operand of an OpStore."));
 }
 
 }  // namespace


### PR DESCRIPTION
The following statement from SPIR-V spec is not checked by Validator:
The FPRoundingMode decoration can be applied only to a width-only conversion instruction that is used as the Object operand of an OpStore storing through a pointer to a 16-bit floating-point object in the StorageBuffer, Uniform, PushConstant, Input, or Output Storage Classes.