### PR TITLE
Validator: correct out of bound check for OpMemberDecorate (#1881)

### DIFF
--- a/source/val/validate_annotation.cpp
+++ b/source/val/validate_annotation.cpp
@@ -50,7 +50,7 @@ spv_result_t ValidateMemberDecorate(ValidationState_t& _,
   const auto member = inst->GetOperandAs<uint32_t>(1);
   const auto member_count =
       static_cast<uint32_t>(struct_type->words().size() - 2);
-  if (member_count < member) {
+  if (member_count <= member) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
            << "Index " << member
            << " provided in OpMemberDecorate for struct <id> "

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -85,6 +85,29 @@ TEST_F(ValidateDecorations, ValidateOpMemberDecorateRegistration) {
                                  Decoration(SpvDecorationBufferBlock)}));
 }
 
+TEST_F(ValidateDecorations, ValidateOpMemberDecorateOutOfBound) {
+  std::string spirv = R"(
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %1 "Main"
+               OpMemberDecorate %_struct_2 1 RelaxedPrecision
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+  %_struct_2 = OpTypeStruct %float
+          %1 = OpFunction %void None %4
+          %6 = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Index 1 provided in OpMemberDecorate for struct <id> "
+                        "2 is out of bounds. The structure has 1 members. "
+                        "Largest valid index is 0."));
+}
+
 TEST_F(ValidateDecorations, ValidateGroupDecorateRegistration) {
   std::string spirv = R"(
                OpCapability Shader


### PR DESCRIPTION
The number that indicates a member in OpMemberDecorate must be less
than the number of total members of struct.