### PR TITLE
Update memory model

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -155,6 +155,7 @@ SPVTOOLS_OPT_SRC_FILES := \
 		source/opt/type_manager.cpp \
 		source/opt/types.cpp \
 		source/opt/unify_const_pass.cpp \
+		source/opt/upgrade_memory_model.cpp \
 		source/opt/value_number_table.cpp \
 		source/opt/vector_dce.cpp \
 		source/opt/workaround1209.cpp

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -707,6 +707,12 @@ Optimizer::PassToken CreateCombineAccessChainsPass();
 Optimizer::PassToken CreateInstBindlessCheckPass(uint32_t desc_set,
                                                  uint32_t shader_id);
 
+// Create a pass to upgrade to the VulkanKHR memory model.
+// This pass upgrades the Logical GLSL450 memory model to Logical VulkanKHR.
+// Additionally, it modifies memory, image, atomic and barrier operations to
+// conform to that model's requirements.
+Optimizer::PassToken CreateUpgradeMemoryModelPass();
+
 }  // namespace spvtools
 
 #endif  // INCLUDE_SPIRV_TOOLS_OPTIMIZER_HPP_

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -99,6 +99,7 @@ set(SPIRV_TOOLS_OPT_SOURCES
   type_manager.h
   types.h
   unify_const_pass.h
+  upgrade_memory_model.h
   value_number_table.h
   vector_dce.h
   workaround1209.h
@@ -186,6 +187,7 @@ set(SPIRV_TOOLS_OPT_SOURCES
   type_manager.cpp
   types.cpp
   unify_const_pass.cpp
+  upgrade_memory_model.cpp
   value_number_table.cpp
   vector_dce.cpp
   workaround1209.cpp

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -408,6 +408,8 @@ bool Optimizer::RegisterPassFromFlag(const std::string& flag) {
     }
   } else if (pass_name == "loop-unroll") {
     RegisterPass(CreateLoopUnrollPass(true));
+  } else if (pass_name == "upgrade-memory-model") {
+    RegisterPass(CreateUpgradeMemoryModelPass());
   } else if (pass_name == "vector-dce") {
     RegisterPass(CreateVectorDCEPass());
   } else if (pass_name == "loop-unroll-partial") {
@@ -766,6 +768,10 @@ Optimizer::PassToken CreateReduceLoadSizePass() {
 Optimizer::PassToken CreateCombineAccessChainsPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::CombineAccessChains>());
+
+Optimizer::PassToken CreateUpgradeMemoryModelPass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::UpgradeMemoryModel>());
 }
 
 Optimizer::PassToken CreateInstBindlessCheckPass(uint32_t desc_set,

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -768,6 +768,7 @@ Optimizer::PassToken CreateReduceLoadSizePass() {
 Optimizer::PassToken CreateCombineAccessChainsPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::CombineAccessChains>());
+}
 
 Optimizer::PassToken CreateUpgradeMemoryModelPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -64,6 +64,7 @@
 #include "source/opt/strip_debug_info_pass.h"
 #include "source/opt/strip_reflect_info_pass.h"
 #include "source/opt/unify_const_pass.h"
+#include "source/opt/upgrade_memory_model.h"
 #include "source/opt/vector_dce.h"
 #include "source/opt/workaround1209.h"
 

--- a/source/opt/upgrade_memory_model.cpp
+++ b/source/opt/upgrade_memory_model.cpp
@@ -141,6 +141,7 @@ std::pair<bool, bool> UpgradeMemoryModel::TraceInstruction(
   if (!visited->insert(inst->result_id()).second)
     return std::make_pair(false, false);
 
+  // Initialize the cache before |indices| is (potentially) modified.
   auto& cached_result = cache_[std::make_pair(inst->result_id(), indices)];
   cached_result.first = false;
   cached_result.second = false;
@@ -186,6 +187,8 @@ std::pair<bool, bool> UpgradeMemoryModel::TraceInstruction(
     return std::make_pair(true, true);
   }
 
+  // Variables and function parameters are sources. Continue searching until we
+  // reach them.
   if (inst->opcode() != SpvOpVariable &&
       inst->opcode() != SpvOpFunctionParameter) {
     inst->ForEachInId([this, &is_coherent, &is_volatile, &indices,

--- a/source/opt/upgrade_memory_model.cpp
+++ b/source/opt/upgrade_memory_model.cpp
@@ -155,10 +155,9 @@ std::tuple<bool, bool, SpvScope> UpgradeMemoryModel::GetInstructionAttributes(
       def->ForEachInId([this, &stack, &indices](const uint32_t* id_ptr) {
         ir::Instruction* op_inst =
             context()->get_def_use_mgr()->GetDef(*id_ptr);
-        if (context()
-                ->get_type_mgr()
-                ->GetType(op_inst->type_id())
-                ->AsPointer()) {
+        const analysis::Type* type =
+            context()->get_type_mgr()->GetType(op_inst->type_id());
+        if (type && type->AsPointer()) {
           stack.push_back(std::make_pair(op_inst, indices));
         }
       });

--- a/source/opt/upgrade_memory_model.cpp
+++ b/source/opt/upgrade_memory_model.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "upgrade_memory_model.h"
+
+#include "make_unique.h"
+
+namespace spvtools {
+namespace opt {
+
+Pass::Status UpgradeMemoryModel::Process(ir::IRContext* context) {
+  InitializeProcessing(context);
+
+  ir::Instruction* memory_model = get_module()->GetMemoryModel();
+  if (memory_model->GetSingleWordInOperand(0u) != SpvAddressingModelLogical ||
+      memory_model->GetSingleWordInOperand(1u) != SpvMemoryModelGLSL450) {
+    return Pass::Status::SuccessWithoutChange;
+  }
+
+  // Overall changes necessary:
+  // 1. Add the OpExtension.
+  // 2. Add the OpCapability.
+  // 3. Modify the memory model.
+  get_module()->AddCapability(MakeUnique<ir::Instruction>(
+      context, SpvOpCapability, 0, 0,
+      std::initializer_list<ir::Operand>{
+          {SPV_OPERAND_TYPE_CAPABILITY, {SpvCapabilityVulkanMemoryModelKHR}}}));
+  const std::string extension = "SPV_KHR_vulkan_memory_model";
+  std::vector<uint32_t> words(extension.size() / 4 + 1, 0);
+  char* dst = reinterpret_cast<char*>(words.data());
+  strncpy(dst, extension.c_str(), extension.size());
+  get_module()->AddExtension(MakeUnique<ir::Instruction>(
+      context, SpvOpExtension, 0, 0,
+      std::initializer_list<ir::Operand>{
+          {SPV_OPERAND_TYPE_LITERAL_STRING, words}}));
+  memory_model->SetInOperand(1u, {SpvMemoryModelVulkanKHR});
+
+  return Pass::Status::SuccessWithChange;
+}
+
+}  // namespace opt
+}  // namespace spvtools

--- a/source/opt/upgrade_memory_model.cpp
+++ b/source/opt/upgrade_memory_model.cpp
@@ -564,14 +564,14 @@ bool UpgradeMemoryModel::IsDeviceScope(uint32_t scope_id) {
   assert(type->width() == 32 || type->width() == 64);
   if (type->width() == 32) {
     if (type->IsSigned())
-      return constant->GetS32() == SpvScopeDevice;
+      return static_cast<uint32_t>(constant->GetS32()) == SpvScopeDevice;
     else
-      return constant->GetU32() == SpvScopeDevice;
+      return static_cast<uint32_t>(constant->GetU32()) == SpvScopeDevice;
   } else {
     if (type->IsSigned())
-      return constant->GetS64() == SpvScopeDevice;
+      return static_cast<uint32_t>(constant->GetS64()) == SpvScopeDevice;
     else
-      return constant->GetU64() == SpvScopeDevice;
+      return static_cast<uint32_t>(constant->GetU64()) == SpvScopeDevice;
   }
 
   assert(false);

--- a/source/opt/upgrade_memory_model.cpp
+++ b/source/opt/upgrade_memory_model.cpp
@@ -22,18 +22,28 @@ namespace opt {
 Pass::Status UpgradeMemoryModel::Process(ir::IRContext* context) {
   InitializeProcessing(context);
 
+  // Only update Logical GLSL450 to Logical VulkanKHR.
   ir::Instruction* memory_model = get_module()->GetMemoryModel();
   if (memory_model->GetSingleWordInOperand(0u) != SpvAddressingModelLogical ||
       memory_model->GetSingleWordInOperand(1u) != SpvMemoryModelGLSL450) {
     return Pass::Status::SuccessWithoutChange;
   }
 
+  UpgradeMemoryModelInstruction();
+  UpgradeInstructions();
+  CleanupDecorations();
+
+  return Pass::Status::SuccessWithChange;
+}
+
+void UpgradeMemoryModel::UpgradeMemoryModelInstruction() {
   // Overall changes necessary:
   // 1. Add the OpExtension.
   // 2. Add the OpCapability.
   // 3. Modify the memory model.
+  ir::Instruction* memory_model = get_module()->GetMemoryModel();
   get_module()->AddCapability(MakeUnique<ir::Instruction>(
-      context, SpvOpCapability, 0, 0,
+      context(), SpvOpCapability, 0, 0,
       std::initializer_list<ir::Operand>{
           {SPV_OPERAND_TYPE_CAPABILITY, {SpvCapabilityVulkanMemoryModelKHR}}}));
   const std::string extension = "SPV_KHR_vulkan_memory_model";
@@ -41,12 +51,199 @@ Pass::Status UpgradeMemoryModel::Process(ir::IRContext* context) {
   char* dst = reinterpret_cast<char*>(words.data());
   strncpy(dst, extension.c_str(), extension.size());
   get_module()->AddExtension(MakeUnique<ir::Instruction>(
-      context, SpvOpExtension, 0, 0,
+      context(), SpvOpExtension, 0, 0,
       std::initializer_list<ir::Operand>{
           {SPV_OPERAND_TYPE_LITERAL_STRING, words}}));
   memory_model->SetInOperand(1u, {SpvMemoryModelVulkanKHR});
+}
 
-  return Pass::Status::SuccessWithChange;
+void UpgradeMemoryModel::UpgradeInstructions() {
+  // Coherent and Volatile decorations are deprecated. Remove them and replace
+  // with flags on the memory/image operations. The decorations can occur on
+  // OpVariable, OpFunctionParameter (of pointer type) and OpStructType (member
+  // decoration). Trace from the decoration target(s) to the final memory/image
+  // instructions. Additionally, Workgroup storage class variables and function
+  // parameters are implicitly coherent in GLSL450.
+
+  for (auto global : get_module()->types_values()) {
+    std::vector<ir::Instruction*> decorations =
+        get_decoration_mgr()->GetDecorationsFor(global.result_id(), false);
+    if (global.opcode() == SpvOpTypeStruct) {
+    } else if (global.opcode() == SpvOpVariable) {
+      bool is_coherent = false;
+      bool is_volatile = false;
+      for (auto dec : decorations) {
+        is_coherent |= dec->GetSingleWordInOperand(1u) == SpvDecorationCoherent;
+        is_volatile |= dec->GetSingleWordInOperand(1u) == SpvDecorationVolatile;
+      }
+
+      SpvScope scope = SpvScopeDevice;
+      SpvStorageClass storage_class =
+          static_cast<SpvStorageClass>(global.GetSingleWordInOperand(0u));
+      if (storage_class == SpvStorageClassWorkgroup) {
+        is_coherent = true;
+        scope = SpvScopeWorkgroup;
+      }
+
+      // Nothing to upgrade.
+      if (!is_coherent && !is_volatile) continue;
+
+      Tracker tracker(&global);
+      tracker.is_volatile = is_volatile;
+      tracker.is_coherent = is_coherent;
+      tracker.in_operand = 0u;
+      tracker.nesting = 0u;
+      tracker.member_index = -1;
+      tracker.scope = scope;
+      UpgradeInstruction(tracker);
+    }
+  }
+}
+
+void UpgradeMemoryModel::UpgradeInstruction(const Tracker& tracker) {
+  std::vector<Tracker> stack;
+  stack.push_back(tracker);
+
+  std::unordered_set<ir::Instruction*> visited;
+  while (!stack.empty()) {
+    Tracker current = stack.back();
+    stack.pop_back();
+
+    if (!visited.insert(current.inst).second) continue;
+
+    UpgradeFlags(current);
+    if (current.is_coherent) {
+      switch (current.inst->opcode()) {
+        case SpvOpLoad:
+        case SpvOpStore:
+        case SpvOpImageRead:
+        case SpvOpImageSparseRead:
+        case SpvOpImageWrite:
+          current.inst->AddOperand(
+              {SPV_OPERAND_TYPE_ID, {GetScopeConstant(current.scope)}});
+          break;
+        case SpvOpCopyMemory:
+        case SpvOpCopyMemorySized:
+        default:
+          break;
+      }
+    }
+  }
+}
+
+void UpgradeMemoryModel::UpgradeFlags(const Tracker& tracker) {
+  uint32_t flags = 0;
+  ir::Instruction* inst = tracker.inst;
+  if (tracker.is_volatile) {
+    switch (inst->opcode()) {
+      case SpvOpLoad:
+      case SpvOpStore:
+      case SpvOpCopyMemory:
+      case SpvOpCopyMemorySized:
+        flags |= SpvMemoryAccessVolatileMask;
+        break;
+      case SpvOpImageRead:
+      case SpvOpImageSparseRead:
+      case SpvOpImageWrite:
+        flags |= SpvImageOperandsVolatileTexelKHRMask;
+        break;
+      default:
+        break;
+    }
+  }
+
+  if (tracker.is_coherent) {
+    switch (inst->opcode()) {
+      case SpvOpLoad:
+        flags |= SpvMemoryAccessNonPrivatePointerKHRMask;
+        flags |= SpvMemoryAccessMakePointerAvailableKHRMask;
+        break;
+      case SpvOpStore:
+        flags |= SpvMemoryAccessNonPrivatePointerKHRMask;
+        flags |= SpvMemoryAccessMakePointerVisibleKHRMask;
+        break;
+      case SpvOpCopyMemory:
+      case SpvOpCopyMemorySized:
+        flags |= SpvMemoryAccessNonPrivatePointerKHRMask;
+        if (tracker.in_operand == 0u)
+          flags |= SpvMemoryAccessMakePointerAvailableKHRMask;
+        if (tracker.in_operand == 1u)
+          flags |= SpvMemoryAccessMakePointerVisibleKHRMask;
+        break;
+      case SpvOpImageRead:
+      case SpvOpImageSparseRead:
+        flags |= SpvImageOperandsNonPrivateTexelKHRMask;
+        flags |= SpvImageOperandsMakeTexelAvailableKHRMask;
+        break;
+      case SpvOpImageWrite:
+        flags |= SpvImageOperandsNonPrivateTexelKHRMask;
+        flags |= SpvImageOperandsMakeTexelVisibleKHRMask;
+        break;
+      default:
+        break;
+    }
+  }
+
+  switch (inst->opcode()) {
+    case SpvOpLoad:
+      flags |= inst->GetSingleWordInOperand(1u);
+      inst->SetInOperand(1u, {flags});
+      break;
+    case SpvOpStore:
+    case SpvOpCopyMemory:
+    case SpvOpImageRead:
+    case SpvOpImageSparseRead:
+      flags |= inst->GetSingleWordInOperand(2u);
+      inst->SetInOperand(2u, {flags});
+      break;
+    case SpvOpCopyMemorySized:
+    case SpvOpImageWrite:
+      flags |= inst->GetSingleWordInOperand(3u);
+      inst->SetInOperand(3u, {flags});
+      break;
+    default:
+      break;
+  }
+}
+
+uint32_t UpgradeMemoryModel::GetScopeConstant(SpvScope scope) {
+  analysis::Integer int_ty(32, false);
+  uint32_t int_id = context()->get_type_mgr()->GetTypeInstruction(&int_ty);
+  const analysis::Constant* constant =
+      context()->get_constant_mgr()->GetConstant(
+          context()->get_type_mgr()->GetType(int_id), {scope});
+  return context()
+      ->get_constant_mgr()
+      ->GetDefiningInstruction(constant)
+      ->result_id();
+}
+
+void UpgradeMemoryModel::CleanupDecorations() {
+  // All of the volatile and coherent decorations have been dealt with, so now
+  // we can just remove them.
+  get_module()->ForEachInst([this](ir::Instruction* inst) {
+    if (inst->result_id() != 0) {
+      context()->get_decoration_mgr()->RemoveDecorationsFrom(
+          inst->result_id(), [](const ir::Instruction& dec) {
+            switch (dec.opcode()) {
+              case SpvOpDecorate:
+              case SpvOpDecorateId:
+                if (dec.GetSingleWordInOperand(1u) == SpvDecorationCoherent ||
+                    dec.GetSingleWordInOperand(1u) == SpvDecorationVolatile)
+                  return true;
+                break;
+              case SpvOpMemberDecorate:
+                if (dec.GetSingleWordInOperand(2u) == SpvDecorationCoherent ||
+                    dec.GetSingleWordInOperand(2u) == SpvDecorationVolatile)
+                  return true;
+                break;
+              default:
+                break;
+            }
+            return false;
+          });
+    }
+  });
 }
 
 }  // namespace opt

--- a/source/opt/upgrade_memory_model.cpp
+++ b/source/opt/upgrade_memory_model.cpp
@@ -433,7 +433,8 @@ uint32_t UpgradeMemoryModel::GetScopeConstant(SpvScope scope) {
   uint32_t int_id = context()->get_type_mgr()->GetTypeInstruction(&int_ty);
   const analysis::Constant* constant =
       context()->get_constant_mgr()->GetConstant(
-          context()->get_type_mgr()->GetType(int_id), {scope});
+          context()->get_type_mgr()->GetType(int_id),
+          {static_cast<uint32_t>(scope)});
   return context()
       ->get_constant_mgr()
       ->GetDefiningInstruction(constant)

--- a/source/opt/upgrade_memory_model.h
+++ b/source/opt/upgrade_memory_model.h
@@ -17,6 +17,8 @@
 
 #include "pass.h"
 
+#include <tuple>
+
 namespace spvtools {
 namespace opt {
 
@@ -25,33 +27,13 @@ class UpgradeMemoryModel : public Pass {
   const char* name() const override { return "upgrade-memory-model"; }
   Status Process(ir::IRContext* context) override;
 
-  struct Tracker {
-    ir::Instruction* inst;
-    bool is_volatile;
-    bool is_coherent;
-    uint32_t in_operand;
-    uint32_t nesting;
-    int member_index;
-    SpvScope scope;
-
-    Tracker() = default;
-    Tracker(const Tracker&) = default;
-
-    Tracker(ir::Instruction* i)
-        : inst(i),
-          is_volatile(false),
-          is_coherent(false),
-          in_operand(0),
-          nesting(0),
-          member_index(-1),
-          scope(SpvScopeDevice) {}
-  };
-
  private:
   void UpgradeMemoryModelInstruction();
   void UpgradeInstructions();
-  void UpgradeInstruction(const Tracker& tracker);
-  void UpgradeFlags(const Tracker& tracker);
+  std::tuple<bool, bool, SpvScope> GetInstructionAttributes(uint32_t id);
+  void UpgradeFlags(ir::Instruction* inst, uint32_t in_operand,
+                    bool is_coherent, bool is_volatile, bool visible,
+                    bool is_memory);
   uint32_t GetScopeConstant(SpvScope scope);
   void CleanupDecorations();
 };

--- a/source/opt/upgrade_memory_model.h
+++ b/source/opt/upgrade_memory_model.h
@@ -23,6 +23,7 @@
 namespace spvtools {
 namespace opt {
 
+// Hashing functor for the memoized result store.
 struct CacheHash {
   size_t operator()(
       const std::pair<uint32_t, std::vector<uint32_t>>& item) const {
@@ -39,6 +40,13 @@ class UpgradeMemoryModel : public Pass {
   Status Process(ir::IRContext* context) override;
 
  private:
+  // Used to indicate whether the operation performs an availability or
+  // visibility operation.
+  enum OperationType { kVisibility, kAvailability };
+
+  // Used to indicate whether the instruction is a memory or image instruction.
+  enum InstructionType { kMemory, kImage };
+
   // Modifies the OpMemoryModel to use VulkanKHR. Adds the Vulkan memory model
   // capability and extension.
   void UpgradeMemoryModelInstruction();
@@ -74,12 +82,12 @@ class UpgradeMemoryModel : public Pass {
   std::pair<bool, bool> CheckAllTypes(const ir::Instruction* inst);
 
   // Modifies the flags of |inst| to include the new flags for the Vulkan
-  // memory model. |visible| indicates whether flags should use MakeVisible
-  // variants. |is_memory| indicates whether the Pointer variants of flags
-  // should be used.
+  // memory model. |operation_type| indicates whether flags should use
+  // MakeVisible or MakeAvailable variants. |inst_type| indicates whether the
+  // Pointer or Texel variants of flags should be used.
   void UpgradeFlags(ir::Instruction* inst, uint32_t in_operand,
-                    bool is_coherent, bool is_volatile, bool visible,
-                    bool is_memory);
+                    bool is_coherent, bool is_volatile,
+                    OperationType operation_type, InstructionType inst_type);
 
   // Returns the result id for a constant for |scope|.
   uint32_t GetScopeConstant(SpvScope scope);

--- a/source/opt/upgrade_memory_model.h
+++ b/source/opt/upgrade_memory_model.h
@@ -24,6 +24,36 @@ class UpgradeMemoryModel : public Pass {
  public:
   const char* name() const override { return "upgrade-memory-model"; }
   Status Process(ir::IRContext* context) override;
+
+  struct Tracker {
+    ir::Instruction* inst;
+    bool is_volatile;
+    bool is_coherent;
+    uint32_t in_operand;
+    uint32_t nesting;
+    int member_index;
+    SpvScope scope;
+
+    Tracker() = default;
+    Tracker(const Tracker&) = default;
+
+    Tracker(ir::Instruction* i)
+        : inst(i),
+          is_volatile(false),
+          is_coherent(false),
+          in_operand(0),
+          nesting(0),
+          member_index(-1),
+          scope(SpvScopeDevice) {}
+  };
+
+ private:
+  void UpgradeMemoryModelInstruction();
+  void UpgradeInstructions();
+  void UpgradeInstruction(const Tracker& tracker);
+  void UpgradeFlags(const Tracker& tracker);
+  uint32_t GetScopeConstant(SpvScope scope);
+  void CleanupDecorations();
 };
 }  // namespace opt
 }  // namespace spvtools

--- a/source/opt/upgrade_memory_model.h
+++ b/source/opt/upgrade_memory_model.h
@@ -31,6 +31,9 @@ class UpgradeMemoryModel : public Pass {
   void UpgradeMemoryModelInstruction();
   void UpgradeInstructions();
   std::tuple<bool, bool, SpvScope> GetInstructionAttributes(uint32_t id);
+  bool HasDecoration(const ir::Instruction* inst,
+                     const std::vector<uint32_t>& indices,
+                     SpvDecoration decoration);
   void UpgradeFlags(ir::Instruction* inst, uint32_t in_operand,
                     bool is_coherent, bool is_volatile, bool visible,
                     bool is_memory);

--- a/source/opt/upgrade_memory_model.h
+++ b/source/opt/upgrade_memory_model.h
@@ -34,6 +34,12 @@ struct CacheHash {
   }
 };
 
+// Upgrades the memory model from Logical GLSL450 to Logical VulkanKHR.
+//
+// This pass remove deprecated decorations (Volatile and Coherent) and replaces
+// them with new flags on individual instructions. It adds the Output storage
+// class semantic to control barriers in tessellation control shaders that have
+// an access to Output memory.
 class UpgradeMemoryModel : public Pass {
  public:
   const char* name() const override { return "upgrade-memory-model"; }
@@ -98,6 +104,11 @@ class UpgradeMemoryModel : public Pass {
 
   // Removes coherent and volatile decorations.
   void CleanupDecorations();
+
+  // For all tessellation control entry points, if there is an operation on
+  // Output storage class, then all barriers are modified to include the
+  // OutputMemoryKHR semantic.
+  void UpgradeBarriers();
 
   // Caches the result of TraceInstruction. For a given result id and set of
   // indices, stores whether that combination is coherent and/or volatile.

--- a/source/opt/upgrade_memory_model.h
+++ b/source/opt/upgrade_memory_model.h
@@ -39,24 +39,60 @@ class UpgradeMemoryModel : public Pass {
   Status Process(ir::IRContext* context) override;
 
  private:
+  // Modifies the OpMemoryModel to use VulkanKHR. Adds the Vulkan memory model
+  // capability and extension.
   void UpgradeMemoryModelInstruction();
+
+  // Upgrades memory, image and barrier instructions.
+  // Memory and image instructions convert coherent and volatile decorations
+  // into flags on the instruction. Barriers in tessellation shaders get the
+  // output storage semantic if appropriate.
   void UpgradeInstructions();
+
+  // Returns whether |id| is coherent and/or volatile.
   std::tuple<bool, bool, SpvScope> GetInstructionAttributes(uint32_t id);
+
+  // Traces |inst| to determine if it is coherent and/or volatile.
+  // |indices| tracks the access chain indices seen so far.
   std::pair<bool, bool> TraceInstruction(ir::Instruction* inst,
                                          std::vector<uint32_t> indices,
                                          std::unordered_set<uint32_t>* visited);
+
+  // Return true if |inst| is decorated with |decoration|.
+  // If |inst| is decorated by member decorations then either |value| must
+  // match the index or |value| must be a maximum allowable value. The max
+  // value allows any element to match.
   bool HasDecoration(const ir::Instruction* inst, uint32_t value,
                      SpvDecoration decoration);
+
+  // Returns whether |type_id| indexed via |indices| is coherent and/or
+  // volatile.
   std::pair<bool, bool> CheckType(uint32_t type_id,
                                   const std::vector<uint32_t>& indices);
+
+  // Returns whether any type/element under |inst| is coherent and/or volatile.
   std::pair<bool, bool> CheckAllTypes(const ir::Instruction* inst);
+
+  // Modifies the flags of |inst| to include the new flags for the Vulkan
+  // memory model. |visible| indicates whether flags should use MakeVisible
+  // variants. |is_memory| indicates whether the Pointer variants of flags
+  // should be used.
   void UpgradeFlags(ir::Instruction* inst, uint32_t in_operand,
                     bool is_coherent, bool is_volatile, bool visible,
                     bool is_memory);
+
+  // Returns the result id for a constant for |scope|.
   uint32_t GetScopeConstant(SpvScope scope);
+
+  // Returns the value of |index_inst|. |index_inst| must be an OpConstant of
+  // integer type.g
   uint64_t GetIndexValue(ir::Instruction* index_inst);
+
+  // Removes coherent and volatile decorations.
   void CleanupDecorations();
 
+  // Caches the result of TraceInstruction. For a given result id and set of
+  // indices, stores whether that combination is coherent and/or volatile.
   std::unordered_map<std::pair<uint32_t, std::vector<uint32_t>>,
                      std::pair<bool, bool>, CacheHash>
       cache_;

--- a/source/opt/upgrade_memory_model.h
+++ b/source/opt/upgrade_memory_model.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBSPIRV_OPT_UPGRADE_MEMORY_MODEL_H_
+#define LIBSPIRV_OPT_UPGRADE_MEMORY_MODEL_H_
+
+#include "pass.h"
+
+namespace spvtools {
+namespace opt {
+
+class UpgradeMemoryModel : public Pass {
+ public:
+  const char* name() const override { return "upgrade-memory-model"; }
+  Status Process(ir::IRContext* context) override;
+};
+}  // namespace opt
+}  // namespace spvtools
+#endif  // LIBSPIRV_OPT_UPGRADE_MEMORY_MODEL_H_

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -89,3 +89,7 @@ add_spvtools_unittest(TARGET opt
   PCH_FILE pch_test_opt
 )
 
+add_spvtools_unittest(TARGET upgrade_memory_model
+  SRCS upgrade_memory_model_test.cpp pass_utils.cpp
+  LIBS SPIRV-Tools-opt
+)

--- a/test/opt/pass_fixture.h
+++ b/test/opt/pass_fixture.h
@@ -45,7 +45,9 @@ template <typename TestT>
 class PassTest : public TestT {
  public:
   PassTest()
-      : consumer_(nullptr),
+      : consumer_(
+            [](spv_message_level_t, const char*, const spv_position_t&,
+               const char* message) { std::cerr << message << std::endl; }),
         context_(nullptr),
         tools_(SPV_ENV_UNIVERSAL_1_1),
         manager_(new PassManager()),

--- a/test/opt/upgrade_memory_model_test.cpp
+++ b/test/opt/upgrade_memory_model_test.cpp
@@ -21,7 +21,7 @@ namespace {
 
 using namespace spvtools;
 
-using UpgradeMemoryModelTest = PassTest<::testing::Test>;
+using UpgradeMemoryModelTest = opt::PassTest<::testing::Test>;
 
 #ifdef SPIRV_EFFCEE
 TEST_F(UpgradeMemoryModelTest, InvalidMemoryModelOpenCL) {
@@ -128,7 +128,7 @@ OpFunctionEnd
 TEST_F(UpgradeMemoryModelTest, SimpleUniformVariable) {
   const std::string text = R"(
 ; CHECK-NOT: OpDecorate
-; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 5
 ; CHECK: OpLoad {{%\w+}} {{%\w+}} Volatile|MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
 ; CHECK: OpStore {{%\w+}} {{%\w+}} Volatile|MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
 OpCapability Shader
@@ -155,7 +155,7 @@ OpFunctionEnd
 TEST_F(UpgradeMemoryModelTest, SimpleUniformFunctionParameter) {
   const std::string text = R"(
 ; CHECK-NOT: OpDecorate
-; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 5
 ; CHECK: OpLoad {{%\w+}} {{%\w+}} Volatile|MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
 ; CHECK: OpStore {{%\w+}} {{%\w+}} Volatile|MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
 OpCapability Shader
@@ -208,7 +208,7 @@ OpFunctionEnd
 TEST_F(UpgradeMemoryModelTest, SimpleUniformVariableCopied) {
   const std::string text = R"(
 ; CHECK-NOT: OpDecorate
-; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 5
 ; CHECK: OpLoad {{%\w+}} {{%\w+}} Volatile|MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
 ; CHECK: OpStore {{%\w+}} {{%\w+}} Volatile|MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
 OpCapability Shader
@@ -236,7 +236,7 @@ OpFunctionEnd
 TEST_F(UpgradeMemoryModelTest, SimpleUniformFunctionParameterCopied) {
   const std::string text = R"(
 ; CHECK-NOT: OpDecorate
-; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 5
 ; CHECK: OpLoad {{%\w+}} {{%\w+}} Volatile|MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
 ; CHECK: OpStore {{%\w+}} {{%\w+}} Volatile|MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
 OpCapability Shader
@@ -265,7 +265,7 @@ OpFunctionEnd
 TEST_F(UpgradeMemoryModelTest, SimpleUniformVariableAccessChain) {
   const std::string text = R"(
 ; CHECK-NOT: OpDecorate
-; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 5
 ; CHECK: OpLoad {{%\w+}} {{%\w+}} Volatile|MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
 ; CHECK: OpStore {{%\w+}} {{%\w+}} Volatile|MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
 OpCapability Shader
@@ -297,7 +297,7 @@ OpFunctionEnd
 TEST_F(UpgradeMemoryModelTest, SimpleUniformFunctionParameterAccessChain) {
   const std::string text = R"(
 ; CHECK-NOT: OpDecorate
-; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 5
 ; CHECK: OpLoad {{%\w+}} {{%\w+}} Volatile|MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
 ; CHECK: OpStore {{%\w+}} {{%\w+}} Volatile|MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
 OpCapability Shader
@@ -330,7 +330,7 @@ OpFunctionEnd
 TEST_F(UpgradeMemoryModelTest, VariablePointerSelect) {
   const std::string text = R"(
 ; CHECK-NOT: OpDecorate
-; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 5
 ; CHECK: OpLoad {{%\w+}} {{%\w+}} Volatile|MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
 ; CHECK: OpStore {{%\w+}} {{%\w+}} Volatile|MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
 OpCapability Shader
@@ -363,7 +363,7 @@ OpFunctionEnd
 TEST_F(UpgradeMemoryModelTest, VariablePointerSelectConservative) {
   const std::string text = R"(
 ; CHECK-NOT: OpDecorate
-; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 5
 ; CHECK: OpLoad {{%\w+}} {{%\w+}} Volatile|MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
 ; CHECK: OpStore {{%\w+}} {{%\w+}} Volatile|MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
 OpCapability Shader
@@ -396,7 +396,7 @@ OpFunctionEnd
 TEST_F(UpgradeMemoryModelTest, VariablePointerIncrement) {
   const std::string text = R"(
 ; CHECK-NOT: OpDecorate {{%\w+}} Coherent
-; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 5
 ; CHECK: OpLoad {{%\w+}} {{%\w+}} MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
 ; CHECK: OpStore {{%\w+}} {{%\w+}} MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
 OpCapability Shader
@@ -439,7 +439,7 @@ OpFunctionEnd
 TEST_F(UpgradeMemoryModelTest, CoherentStructElement) {
   const std::string text = R"(
 ; CHECK-NOT: OpMemberDecorate
-; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 5
 ; CHECK: OpLoad {{%\w+}} {{%\w+}} MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
 ; CHECK: OpStore {{%\w+}} {{%\w+}} MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
 OpCapability Shader
@@ -470,7 +470,7 @@ OpFunctionEnd
 TEST_F(UpgradeMemoryModelTest, CoherentElementFullStructAccess) {
   const std::string text = R"(
 ; CHECK-NOT: OpMemberDecorate
-; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 5
 ; CHECK: OpLoad {{%\w+}} {{%\w+}} MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
 ; CHECK: OpStore {{%\w+}} {{%\w+}} MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
 OpCapability Shader
@@ -529,7 +529,7 @@ OpFunctionEnd
 TEST_F(UpgradeMemoryModelTest, MultiIndexAccessCoherent) {
   const std::string text = R"(
 ; CHECK-NOT: OpMemberDecorate
-; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 5
 ; CHECK: OpLoad {{%\w+}} {{%\w+}} MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
 ; CHECK: OpStore {{%\w+}} {{%\w+}} MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
 OpCapability Shader
@@ -599,7 +599,7 @@ OpFunctionEnd
 TEST_F(UpgradeMemoryModelTest, ConsecutiveAccessChainCoherent) {
   const std::string text = R"(
 ; CHECK-NOT: OpMemberDecorate
-; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 5
 ; CHECK: OpLoad {{%\w+}} {{%\w+}} MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
 ; CHECK: OpStore {{%\w+}} {{%\w+}} MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
 OpCapability Shader
@@ -681,7 +681,7 @@ OpFunctionEnd
 TEST_F(UpgradeMemoryModelTest, CoherentStructElementAccess) {
   const std::string text = R"(
 ; CHECK-NOT: OpMemberDecorate
-; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 5
 ; CHECK: OpLoad {{%\w+}} {{%\w+}} MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
 ; CHECK: OpStore {{%\w+}} {{%\w+}} MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
 OpCapability Shader
@@ -722,7 +722,7 @@ OpFunctionEnd
 TEST_F(UpgradeMemoryModelTest, NonCoherentLoadCoherentStore) {
   const std::string text = R"(
 ; CHECK-NOT: OpMemberDecorate
-; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 5
 ; CHECK-NOT: MakePointerAvailableKHR
 ; CHECK: OpStore {{%\w+}} {{%\w+}} MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
 OpCapability Shader
@@ -763,9 +763,9 @@ OpFunctionEnd
 TEST_F(UpgradeMemoryModelTest, CopyMemory) {
   const std::string text = R"(
 ; CHECK-NOT: OpDecorate
-; CHECK: [[device:%\w+]] = OpConstant {{%\w+}} 1
-; CHECK: OpCopyMemory {{%\w+}} {{%\w+}} Volatile|MakePointerVisibleKHR|NonPrivatePointerKHR [[device]]
-; CHECK-NOT: [[device]]
+; CHECK: [[queuefamily:%\w+]] = OpConstant {{%\w+}} 5
+; CHECK: OpCopyMemory {{%\w+}} {{%\w+}} Volatile|MakePointerVisibleKHR|NonPrivatePointerKHR [[queuefamily]]
+; CHECK-NOT: [[queuefamily]]
 OpCapability Shader
 OpCapability Linkage
 OpExtension "SPV_KHR_storage_buffer_storage_class"
@@ -791,9 +791,9 @@ OpFunctionEnd
 TEST_F(UpgradeMemoryModelTest, CopyMemorySized) {
   const std::string text = R"(
 ; CHECK-NOT: OpDecorate
-; CHECK: [[device:%\w+]] = OpConstant {{%\w+}} 1
-; CHECK: OpCopyMemorySized {{%\w+}} {{%\w+}} {{%\w+}} Volatile|MakePointerAvailableKHR|NonPrivatePointerKHR [[device]]
-; CHECK-NOT: [[device]]
+; CHECK: [[queuefamily:%\w+]] = OpConstant {{%\w+}} 5
+; CHECK: OpCopyMemorySized {{%\w+}} {{%\w+}} {{%\w+}} Volatile|MakePointerAvailableKHR|NonPrivatePointerKHR [[queuefamily]]
+; CHECK-NOT: [[queuefamily]]
 OpCapability Shader
 OpCapability Linkage
 OpCapability Addresses
@@ -821,9 +821,9 @@ OpFunctionEnd
 TEST_F(UpgradeMemoryModelTest, CopyMemoryTwoScopes) {
   const std::string text = R"(
 ; CHECK-NOT: OpDecorate
-; CHECK-DAG: [[device:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK-DAG: [[queuefamily:%\w+]] = OpConstant {{%\w+}} 5
 ; CHECK-DAG: [[workgroup:%\w+]] = OpConstant {{%\w+}} 2
-; CHECK: OpCopyMemory {{%\w+}} {{%\w+}} MakePointerAvailableKHR|MakePointerVisibleKHR|NonPrivatePointerKHR [[device]] [[workgroup]]
+; CHECK: OpCopyMemory {{%\w+}} {{%\w+}} MakePointerAvailableKHR|MakePointerVisibleKHR|NonPrivatePointerKHR [[queuefamily]] [[workgroup]]
 OpCapability Shader
 OpCapability Linkage
 OpExtension "SPV_KHR_storage_buffer_storage_class"
@@ -882,7 +882,7 @@ OpFunctionEnd
 TEST_F(UpgradeMemoryModelTest, CoherentImageRead) {
   const std::string text = R"(
 ; CHECK-NOT: OpDecorate
-; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 5
 ; CHECK: OpLoad {{%\w+}} {{%\w+}} MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
 ; CHECK: OpImageRead {{%\w+}} {{%\w+}} {{%\w+}} MakeTexelAvailableKHR|NonPrivateTexelKHR [[scope]] 
 OpCapability Shader
@@ -916,7 +916,7 @@ TEST_F(UpgradeMemoryModelTest, CoherentImageReadExtractedFromSampledImage) {
   const std::string text = R"(
 ; CHECK-NOT: OpDecorate
 ; CHECK: [[image:%\w+]] = OpTypeImage
-; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 5
 ; CHECK: OpLoad [[image]] {{%\w+}} MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
 ; CHECK-NOT: NonPrivatePointerKHR
 ; CHECK: OpImageRead {{%\w+}} {{%\w+}} {{%\w+}} MakeTexelAvailableKHR|NonPrivateTexelKHR [[scope]]
@@ -989,7 +989,7 @@ OpFunctionEnd
 TEST_F(UpgradeMemoryModelTest, CoherentImageWrite) {
   const std::string text = R"(
 ; CHECK-NOT: OpDecorate
-; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 5
 ; CHECK: OpLoad {{%\w+}} {{%\w+}} MakePointerAvailableKHR|NonPrivatePointerKHR
 ; CHECK: OpImageWrite {{%\w+}} {{%\w+}} {{%\w+}} MakeTexelVisibleKHR|NonPrivateTexelKHR [[scope]]
 OpCapability Shader
@@ -1022,7 +1022,7 @@ OpFunctionEnd
 TEST_F(UpgradeMemoryModelTest, CoherentImageWriteExtractFromSampledImage) {
   const std::string text = R"(
 ; CHECK-NOT: OpDecorate
-; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 5
 ; CHECK: OpLoad {{%\w+}} {{%\w+}} MakePointerAvailableKHR|NonPrivatePointerKHR
 ; CHECK-NOT: NonPrivatePointerKHR
 ; CHECK: OpImageWrite {{%\w+}} {{%\w+}} {{%\w+}} MakeTexelVisibleKHR|NonPrivateTexelKHR [[scope]]
@@ -1097,7 +1097,7 @@ OpFunctionEnd
 TEST_F(UpgradeMemoryModelTest, CoherentImageSparseRead) {
   const std::string text = R"(
 ; CHECK-NOT: OpDecorate
-; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 5
 ; CHECK: OpLoad {{%\w+}} {{%\w+}} MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
 ; CHECK: OpImageSparseRead {{%\w+}} {{%\w+}} {{%\w+}} MakeTexelAvailableKHR|NonPrivateTexelKHR [[scope]] 
 OpCapability Shader
@@ -1134,7 +1134,7 @@ TEST_F(UpgradeMemoryModelTest,
   const std::string text = R"(
 ; CHECK-NOT: OpDecorate
 ; CHECK: [[image:%\w+]] = OpTypeImage
-; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 5
 ; CHECK: OpLoad [[image]] {{%\w+}} MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
 ; CHECK-NOT: NonPrivatePointerKHR
 ; CHECK: OpImageSparseRead {{%\w+}} {{%\w+}} {{%\w+}} MakeTexelAvailableKHR|NonPrivateTexelKHR [[scope]]
@@ -1322,6 +1322,107 @@ OpFunctionEnd
 %param = OpFunctionParameter %int
 %4 = OpLabel
 OpStore %var %param
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::UpgradeMemoryModel>(text, true);
+}
+
+TEST_F(UpgradeMemoryModelTest, ChangeControlBarrierMemoryScope) {
+  std::string text = R"(
+; CHECK: [[workgroup:%\w+]] = OpConstant {{%\w+}} 2
+; CHECK: [[queuefamily:%\w+]] = OpConstant {{%\w+}} 5
+; CHECK: OpControlBarrier [[workgroup]] [[queuefamily]]
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %func "func"
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%none = OpConstant %int 0
+%device = OpConstant %int 1
+%workgroup = OpConstant %int 2
+%func_ty = OpTypeFunction %void
+%func = OpFunction %void None %func_ty
+%1 = OpLabel
+OpControlBarrier %workgroup %device %none
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::UpgradeMemoryModel>(text, true);
+}
+
+TEST_F(UpgradeMemoryModelTest, ChangeMemoryBarrierMemoryScope) {
+  std::string text = R"(
+; CHECK: [[queuefamily:%\w+]] = OpConstant {{%\w+}} 5
+; CHECK: OpMemoryBarrier [[queuefamily]]
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %func "func"
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%none = OpConstant %int 0
+%device = OpConstant %int 1
+%func_ty = OpTypeFunction %void
+%func = OpFunction %void None %func_ty
+%1 = OpLabel
+OpMemoryBarrier %device %none
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::UpgradeMemoryModel>(text, true);
+}
+
+TEST_F(UpgradeMemoryModelTest, ChangeAtomicMemoryScope) {
+  std::string text = R"(
+; CHECK: [[int:%\w+]] = OpTypeInt
+; CHECK: [[var:%\w+]] = OpVariable
+; CHECK: [[qf:%\w+]] = OpConstant [[int]] 5
+; CHECK: OpAtomicLoad [[int]] [[var]] [[qf]]
+; CHECK: OpAtomicStore [[var]] [[qf]]
+; CHECK: OpAtomicExchange [[int]] [[var]] [[qf]]
+; CHECK: OpAtomicCompareExchange [[int]] [[var]] [[qf]]
+; CHECK: OpAtomicIIncrement [[int]] [[var]] [[qf]]
+; CHECK: OpAtomicIDecrement [[int]] [[var]] [[qf]]
+; CHECK: OpAtomicIAdd [[int]] [[var]] [[qf]]
+; CHECK: OpAtomicISub [[int]] [[var]] [[qf]]
+; CHECK: OpAtomicSMin [[int]] [[var]] [[qf]]
+; CHECK: OpAtomicSMax [[int]] [[var]] [[qf]]
+; CHECK: OpAtomicUMin [[int]] [[var]] [[qf]]
+; CHECK: OpAtomicUMax [[int]] [[var]] [[qf]]
+; CHECK: OpAtomicAnd [[int]] [[var]] [[qf]]
+; CHECK: OpAtomicOr [[int]] [[var]] [[qf]]
+; CHECK: OpAtomicXor [[int]] [[var]] [[qf]]
+OpCapability Shader
+OpExtension "SPV_KHR_storage_buffer_storage_class"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %func "func"
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%none = OpConstant %int 0
+%device = OpConstant %int 1
+%func_ty = OpTypeFunction %void
+%ptr_int_StorageBuffer = OpTypePointer StorageBuffer %int
+%var = OpVariable %ptr_int_StorageBuffer StorageBuffer
+%func = OpFunction %void None %func_ty
+%1 = OpLabel
+%ld = OpAtomicLoad %int %var %device %none
+OpAtomicStore %var %device %none %ld
+%ex = OpAtomicExchange %int %var %device %none %ld
+%cmp_ex = OpAtomicCompareExchange %int %var %device %none %none %ld %ld
+%inc = OpAtomicIIncrement %int %var %device %none
+%dec = OpAtomicIDecrement %int %var %device %none
+%add = OpAtomicIAdd %int %var %device %none %ld
+%sub = OpAtomicISub %int %var %device %none %ld
+%smin = OpAtomicSMin %int %var %device %none %ld
+%smax = OpAtomicSMax %int %var %device %none %ld
+%umin = OpAtomicUMin %int %var %device %none %ld
+%umax = OpAtomicUMax %int %var %device %none %ld
+%and = OpAtomicAnd %int %var %device %none %ld
+%or = OpAtomicOr %int %var %device %none %ld
+%xor = OpAtomicXor %int %var %device %none %ld
 OpReturn
 OpFunctionEnd
 )";

--- a/test/opt/upgrade_memory_model_test.cpp
+++ b/test/opt/upgrade_memory_model_test.cpp
@@ -235,6 +235,180 @@ OpFunctionEnd
 
   SinglePassRunAndMatch<opt::UpgradeMemoryModel>(text, true);
 }
+
+TEST_F(UpgradeMemoryModelTest, SimpleUniformVariableAccessChain) {
+  const std::string text = R"(
+; CHECK-NOT: OpDecorate
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: OpLoad {{%\w+}} {{%\w+}} Volatile|MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
+; CHECK: OpStore {{%\w+}} {{%\w+}} Volatile|MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %var Coherent
+OpDecorate %var Volatile
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%int0 = OpConstant %int 0
+%int3 = OpConstant %int 3
+%int_array_3 = OpTypeArray %int %int3
+%ptr_intarray_Uniform = OpTypePointer Uniform %int_array_3
+%ptr_int_Uniform = OpTypePointer Uniform %int
+%var = OpVariable %ptr_intarray_Uniform Uniform
+%func_ty = OpTypeFunction %void
+%func = OpFunction %void None %func_ty
+%1 = OpLabel
+%gep = OpAccessChain %ptr_int_Uniform %var %int0
+%ld = OpLoad %int %gep
+OpStore %gep %ld
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::UpgradeMemoryModel>(text, true);
+}
+
+TEST_F(UpgradeMemoryModelTest, SimpleUniformFunctionParameterAccessChain) {
+  const std::string text = R"(
+; CHECK-NOT: OpDecorate
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: OpLoad {{%\w+}} {{%\w+}} Volatile|MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
+; CHECK: OpStore {{%\w+}} {{%\w+}} Volatile|MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %param Coherent
+OpDecorate %param Volatile
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%int0 = OpConstant %int 0
+%int3 = OpConstant %int 3
+%int_array_3 = OpTypeArray %int %int3
+%ptr_intarray_Uniform = OpTypePointer Uniform %int_array_3
+%ptr_int_Uniform = OpTypePointer Uniform %int
+%func_ty = OpTypeFunction %void %ptr_intarray_Uniform
+%func = OpFunction %void None %func_ty
+%param = OpFunctionParameter %ptr_intarray_Uniform
+%1 = OpLabel
+%ld_gep = OpAccessChain %ptr_int_Uniform %param %int0
+%ld = OpLoad %int %ld_gep
+%st_gep = OpAccessChain %ptr_int_Uniform %param %int0
+OpStore %st_gep %ld
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::UpgradeMemoryModel>(text, true);
+}
+
+TEST_F(UpgradeMemoryModelTest, VariablePointerSelect) {
+  const std::string text = R"(
+; CHECK-NOT: OpDecorate
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: OpLoad {{%\w+}} {{%\w+}} Volatile|MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
+; CHECK: OpStore {{%\w+}} {{%\w+}} Volatile|MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
+OpCapability Shader
+OpCapability Linkage
+OpCapability VariablePointers
+OpExtension "SPV_KHR_variable_pointers"
+OpMemoryModel Logical GLSL450
+OpDecorate %var Coherent
+OpDecorate %var Volatile
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%bool = OpTypeBool
+%true = OpConstantTrue %bool
+%ptr_int_StorageBuffer = OpTypePointer StorageBuffer %int
+%null = OpConstantNull %ptr_int_StorageBuffer
+%var = OpVariable %ptr_int_StorageBuffer StorageBuffer
+%func_ty = OpTypeFunction %void
+%func = OpFunction %void None %func_ty
+%1 = OpLabel
+%select = OpSelect %ptr_int_StorageBuffer %true %var %null
+%ld = OpLoad %int %select
+OpStore %var %ld
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::UpgradeMemoryModel>(text, true);
+}
+
+TEST_F(UpgradeMemoryModelTest, VariablePointerSelectConservative) {
+  const std::string text = R"(
+; CHECK-NOT: OpDecorate
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: OpLoad {{%\w+}} {{%\w+}} Volatile|MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
+; CHECK: OpStore {{%\w+}} {{%\w+}} Volatile|MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
+OpCapability Shader
+OpCapability Linkage
+OpCapability VariablePointers
+OpExtension "SPV_KHR_variable_pointers"
+OpMemoryModel Logical GLSL450
+OpDecorate %var1 Coherent
+OpDecorate %var2 Volatile
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%bool = OpTypeBool
+%true = OpConstantTrue %bool
+%ptr_int_StorageBuffer = OpTypePointer StorageBuffer %int
+%var1 = OpVariable %ptr_int_StorageBuffer StorageBuffer
+%var2 = OpVariable %ptr_int_StorageBuffer StorageBuffer
+%func_ty = OpTypeFunction %void
+%func = OpFunction %void None %func_ty
+%1 = OpLabel
+%select = OpSelect %ptr_int_StorageBuffer %true %var1 %var2
+%ld = OpLoad %int %select
+OpStore %select %ld
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::UpgradeMemoryModel>(text, true);
+}
+
+TEST_F(UpgradeMemoryModelTest, VariablePointerIncrement) {
+  const std::string text = R"(
+; CHECK-NOT: OpDecorate {{%\w+}} Coherent
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: OpLoad {{%\w+}} {{%\w+}} MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
+; CHECK: OpStore {{%\w+}} {{%\w+}} MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
+OpCapability Shader
+OpCapability Linkage
+OpCapability VariablePointers
+OpExtension "SPV_KHR_variable_pointers"
+OpMemoryModel Logical GLSL450
+OpDecorate %param Coherent
+OpDecorate %param ArrayStride 4
+%void = OpTypeVoid
+%bool = OpTypeBool
+%int = OpTypeInt 32 0
+%int0 = OpConstant %int 0
+%int1 = OpConstant %int 1
+%int10 = OpConstant %int 10
+%ptr_int_StorageBuffer = OpTypePointer StorageBuffer %int
+%func_ty = OpTypeFunction %void %ptr_int_StorageBuffer
+%func = OpFunction %void None %func_ty
+%param = OpFunctionParameter %ptr_int_StorageBuffer
+%1 = OpLabel
+OpBranch %2
+%2 = OpLabel
+%phi = OpPhi %ptr_int_StorageBuffer %param %1 %ptr_next %2
+%iv = OpPhi %int %int0 %1 %inc %2
+%inc = OpIAdd %int %iv %int1
+%ptr_next = OpPtrAccessChain %ptr_int_StorageBuffer %phi %int1
+%cmp = OpIEqual %bool %iv %int10
+OpLoopMerge %3 %2 None
+OpBranchConditional %cmp %3 %2
+%3 = OpLabel
+%ld = OpLoad %int %phi
+OpStore %phi %ld
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::UpgradeMemoryModel>(text, true);
+}
 #endif
 
 }  // namespace

--- a/test/opt/upgrade_memory_model_test.cpp
+++ b/test/opt/upgrade_memory_model_test.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "assembly_builder.h"
+#include "gmock/gmock.h"
+#include "pass_fixture.h"
+#include "pass_utils.h"
+
+namespace {
+
+using namespace spvtools;
+
+using UpgradeMemoryModelTest = PassTest<::testing::Test>;
+
+#ifdef SPIRV_EFFCEE
+TEST_F(UpgradeMemoryModelTest, InvalidMemoryModelOpenCL) {
+  const std::string text = R"(
+; CHECK: OpMemoryModel Logical OpenCL
+OpCapability Kernel
+OpCapability Linkage
+OpMemoryModel Logical OpenCL
+)";
+
+  SinglePassRunAndMatch<opt::UpgradeMemoryModel>(text, true);
+}
+
+TEST_F(UpgradeMemoryModelTest, InvalidMemoryModelVulkanKHR) {
+  const std::string text = R"(
+; CHECK: OpMemoryModel Logical VulkanKHR
+OpCapability Shader
+OpCapability Linkage
+OpCapability VulkanMemoryModelKHR
+OpExtension "SPV_KHR_vulkan_memory_model"
+OpMemoryModel Logical VulkanKHR
+)";
+
+  SinglePassRunAndMatch<opt::UpgradeMemoryModel>(text, true);
+}
+
+TEST_F(UpgradeMemoryModelTest, JustMemoryModel) {
+  const std::string text = R"(
+; CHECK: OpCapability VulkanMemoryModelKHR
+; CHECK: OpExtension "SPV_KHR_vulkan_memory_model"
+; CHECK: OpMemoryModel Logical VulkanKHR
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+)";
+
+  SinglePassRunAndMatch<opt::UpgradeMemoryModel>(text, true);
+}
+
+TEST_F(UpgradeMemoryModelTest, RemoveDecorations) {
+  const std::string text = R"(
+; CHECK-NOT: OpDecorate
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %var Volatile
+OpDecorate %var Coherent
+%int = OpTypeInt 32 0
+%ptr_int_Uniform = OpTypePointer Uniform %int
+%var = OpVariable %ptr_int_Uniform Uniform
+)";
+
+  SinglePassRunAndMatch<opt::UpgradeMemoryModel>(text, true);
+}
+#endif
+
+}  // namespace

--- a/test/opt/upgrade_memory_model_test.cpp
+++ b/test/opt/upgrade_memory_model_test.cpp
@@ -124,6 +124,60 @@ OpFunctionEnd
 
   SinglePassRunAndMatch<opt::UpgradeMemoryModel>(text, true);
 }
+
+TEST_F(UpgradeMemoryModelTest, SimpleUniformVariable) {
+  const std::string text = R"(
+; CHECK-NOT: OpDecorate
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: OpLoad {{%\w+}} {{%\w+}} Volatile|MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
+; CHECK: OpStore {{%\w+}} {{%\w+}} Volatile|MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %var Coherent
+OpDecorate %var Volatile
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%ptr_int_Uniform = OpTypePointer Uniform %int
+%var = OpVariable %ptr_int_Uniform Uniform
+%func_ty = OpTypeFunction %void
+%func = OpFunction %void None %func_ty
+%1 = OpLabel
+%ld = OpLoad %int %var
+OpStore %var %ld
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::UpgradeMemoryModel>(text, true);
+}
+
+TEST_F(UpgradeMemoryModelTest, SimpleUniformFunctionParameter) {
+  const std::string text = R"(
+; CHECK-NOT: OpDecorate
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK: OpLoad {{%\w+}} {{%\w+}} Volatile|MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
+; CHECK: OpStore {{%\w+}} {{%\w+}} Volatile|MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %param Coherent
+OpDecorate %param Volatile
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%ptr_int_Uniform = OpTypePointer Uniform %int
+%func_ty = OpTypeFunction %void %ptr_int_Uniform
+%func = OpFunction %void None %func_ty
+%param = OpFunctionParameter %ptr_int_Uniform
+%1 = OpLabel
+%ld = OpLoad %int %param
+OpStore %param %ld
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::UpgradeMemoryModel>(text, true);
+}
 #endif
 
 }  // namespace

--- a/test/opt/upgrade_memory_model_test.cpp
+++ b/test/opt/upgrade_memory_model_test.cpp
@@ -79,9 +79,9 @@ OpDecorate %var Coherent
 
 TEST_F(UpgradeMemoryModelTest, WorkgroupVariable) {
   const std::string text = R"(
-; CHECK: [[scope:%\w+]] = OpConstant {{%w\+}} 2
-; CHECK: OpLoad {{%w\+}} {{%w\+}} MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
-; CHECK: OpStore {{%w\+}} {{%w\+}} MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 2
+; CHECK: OpLoad {{%\w+}} {{%\w+}} MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
+; CHECK: OpStore {{%\w+}} {{%\w+}} MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
 OpCapability Shader
 OpCapability Linkage
 OpMemoryModel Logical GLSL450
@@ -103,9 +103,9 @@ OpFunctionEnd
 
 TEST_F(UpgradeMemoryModelTest, WorkgroupFunctionParameter) {
   const std::string text = R"(
-; CHECK: [[scope:%\w+]] = OpConstant {{%w\+}} 2
-; CHECK: OpLoad {{%w\+}} {{%w\+}} MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
-; CHECK: OpStore {{%w\+}} {{%w\+}} MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
+; CHECK: [[scope:%\w+]] = OpConstant {{%\w+}} 2
+; CHECK: OpLoad {{%\w+}} {{%\w+}} MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
+; CHECK: OpStore {{%\w+}} {{%\w+}} MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
 OpCapability Shader
 OpCapability Linkage
 OpMemoryModel Logical GLSL450

--- a/test/opt/upgrade_memory_model_test.cpp
+++ b/test/opt/upgrade_memory_model_test.cpp
@@ -76,6 +76,54 @@ OpDecorate %var Coherent
 
   SinglePassRunAndMatch<opt::UpgradeMemoryModel>(text, true);
 }
+
+TEST_F(UpgradeMemoryModelTest, WorkgroupVariable) {
+  const std::string text = R"(
+; CHECK: [[scope:%\w+]] = OpConstant {{%w\+}} 2
+; CHECK: OpLoad {{%w\+}} {{%w\+}} MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
+; CHECK: OpStore {{%w\+}} {{%w\+}} MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%ptr_int_Workgroup = OpTypePointer Workgroup %int
+%var = OpVariable %ptr_int_Workgroup Workgroup
+%func_ty = OpTypeFunction %void
+%func = OpFunction %void None %func_ty
+%1 = OpLabel
+%ld = OpLoad %int %var
+%st = OpStore %var %ld
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::UpgradeMemoryModel>(text, true);
+}
+
+TEST_F(UpgradeMemoryModelTest, WorkgroupFunctionParameter) {
+  const std::string text = R"(
+; CHECK: [[scope:%\w+]] = OpConstant {{%w\+}} 2
+; CHECK: OpLoad {{%w\+}} {{%w\+}} MakePointerAvailableKHR|NonPrivatePointerKHR [[scope]]
+; CHECK: OpStore {{%w\+}} {{%w\+}} MakePointerVisibleKHR|NonPrivatePointerKHR [[scope]]
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%ptr_int_Workgroup = OpTypePointer Workgroup %int
+%func_ty = OpTypeFunction %void %ptr_int_Workgroup
+%func = OpFunction %void None %func_ty
+%param = OpFunctionParameter %ptr_int_Workgroup
+%1 = OpLabel
+%ld = OpLoad %int %param
+%st = OpStore %param %ld
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::UpgradeMemoryModel>(text, true);
+}
 #endif
 
 }  // namespace

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -342,6 +342,10 @@ Options (in lexicographical order):
                prints CPU/WALL/USR/SYS time (and RSS if possible), but note that
                USR/SYS time are returned by getrusage() and can have a small
                error.
+  --upgrade-memory-model
+               Upgrades the Logical GLSL450 memory model to Logical VulkanKHR.
+               Transforms memory, image, atomic and barrier operations to conform
+               to that model's requirements.
   --vector-dce
                This pass looks for components of vectors that are unused, and
                removes them from the vector.  Note this would still leave around


### PR DESCRIPTION
Updates from Logical GLSL450 memory model to Logical VulkanKHR memory model.

* Adds capability and extension
* changes memory model
* removes coherent and volatile decorations and adds them to individual instructions as operands
* adds output memory semantics to control barriers in tessellation control shaders
* changes device memory scope to queue family scope