### PR TITLE
[Validator] AMD_gpu_shader_half_float_fetch allow float16 (#1393)

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -390,6 +390,7 @@ void ValidationState_t::RegisterExtension(Extension ext) {
 
   switch (ext) {
     case kSPV_AMD_gpu_shader_half_float:
+    case kSPV_AMD_gpu_shader_half_float_fetch:
       // SPV_AMD_gpu_shader_half_float enables float16 type.
       // https://github.com/KhronosGroup/SPIRV-Tools/issues/1375
       features_.declare_float16_type = true;

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -290,6 +290,17 @@ TEST_F(ValidateData, storage_input_output_16_good) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
+TEST_F(ValidateData, amd_gpu_shader_half_float_fetch_16_good) {
+  std::string str = R"(
+     OpCapability Shader
+     OpCapability Linkage
+     OpExtension "SPV_AMD_gpu_shader_half_float_fetch"
+     OpMemoryModel Logical GLSL450
+     %2 = OpTypeFloat 16)";
+  CompileSuccessfully(str.c_str());
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
 TEST_F(ValidateData, int16_bad) {
   std::string str = header + "%2 = OpTypeInt 16 1";
   CompileSuccessfully(str.c_str());


### PR DESCRIPTION
SPV_AMD_gpu_shader_half_float_fetch extension should implicitly
allow declaring 16bit float.