### PR TITLE
Allow 0 as argument to scalar replacement.

### DIFF
--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -327,11 +327,11 @@ bool Optimizer::RegisterPassFromFlag(const std::string& flag) {
       RegisterPass(CreateScalarReplacementPass());
     } else {
       int limit = atoi(pass_args.c_str());
-      if (limit > 0) {
+      if (limit >= 0) {
         RegisterPass(CreateScalarReplacementPass(limit));
       } else {
         Error(consumer(), nullptr, {},
-              "--scalar-replacement must have no arguments or a positive "
+              "--scalar-replacement must have no arguments or a non-negative "
               "integer argument");
         return false;
       }

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -326,7 +326,11 @@ bool Optimizer::RegisterPassFromFlag(const std::string& flag) {
     if (pass_args.size() == 0) {
       RegisterPass(CreateScalarReplacementPass());
     } else {
-      int limit = atoi(pass_args.c_str());
+      int limit = -1;
+      if (pass_args.find_first_not_of("0123456789") == std::string::npos) {
+        limit = atoi(pass_args.c_str());
+      }
+
       if (limit >= 0) {
         RegisterPass(CreateScalarReplacementPass(limit));
       } else {

--- a/test/tools/opt/flags.py
+++ b/test/tools/opt/flags.py
@@ -256,7 +256,7 @@ class TestScalarReplacementArgsNegative(expect.ErrorMessageSubstr):
   """Tests invalid arguments to --scalar-replacement."""
 
   spirv_args = ['--scalar-replacement=-10']
-  expected_error_substr = 'must have no arguments or a positive integer argument'
+  expected_error_substr = 'must have no arguments or a non-negative integer argument'
 
 
 @inside_spirv_testsuite('SpirvOptFlags')
@@ -264,7 +264,7 @@ class TestScalarReplacementArgsInvalidNumber(expect.ErrorMessageSubstr):
   """Tests invalid arguments to --scalar-replacement."""
 
   spirv_args = ['--scalar-replacement=a10f']
-  expected_error_substr = 'must have no arguments or a positive integer argument'
+  expected_error_substr = 'must have no arguments or a non-negative integer argument'
 
 
 @inside_spirv_testsuite('SpirvOptFlags')


### PR DESCRIPTION
A limit of 0 for the scalar replacement options it used to indicate that
there is no limit.  The current implementation does not allow 0.  This
should be fixed.