### PR TITLE
Get KillNameAndDecorates to handle group decorations.

### DIFF
--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -107,9 +107,6 @@ Instruction* IRContext::KillInst(Instruction* inst) {
     instr_to_block_.erase(inst);
   }
   if (AreAnalysesValid(kAnalysisDecorations)) {
-    if (inst->result_id() != 0) {
-      decoration_mgr_->RemoveDecorationsFrom(inst->result_id());
-    }
     if (inst->IsDecoration()) {
       decoration_mgr_->RemoveDecoration(inst);
     }
@@ -258,12 +255,8 @@ void IRContext::AnalyzeUses(Instruction* inst) {
 }
 
 void IRContext::KillNamesAndDecorates(uint32_t id) {
-  std::vector<Instruction*> decorations =
-      get_decoration_mgr()->GetDecorationsFor(id, true);
-
-  for (Instruction* inst : decorations) {
-    KillInst(inst);
-  }
+  analysis::DecorationManager* dec_mgr = get_decoration_mgr();
+  dec_mgr->RemoveDecorationsFrom(id);
 
   std::vector<Instruction*> name_to_kill;
   for (auto name : GetNames(id)) {


### PR DESCRIPTION
It seems like the current implementation of KillNameAndDecorates does
not handle group decorations correctly.  The id being removed is not
removed from the OpGroupDecorate instructions.  Even worst, any
decorations that apply to that group are removed.

The solution is to use the function in the decoration manager that will
remove the decorations and update the instructions instead of doing the
work itself.

Part of #1916.