### PR TITLE
Remove stats use of internal API

### DIFF
--- a/test/stats/stats_aggregate_test.cpp
+++ b/test/stats/stats_aggregate_test.cpp
@@ -51,13 +51,13 @@ void DiagnosticsMessageHandler(spv_message_level_t level, const char*,
 // Calls AggregateStats for binary compiled from |code|.
 void CompileAndAggregateStats(const std::string& code, SpirvStats* stats,
                               spv_target_env env = SPV_ENV_UNIVERSAL_1_1) {
-  ScopedContext ctx(env);
-  SetContextMessageConsumer(ctx.context, DiagnosticsMessageHandler);
+  spvtools::Context ctx(env);
+  ctx.SetMessageConsumer(DiagnosticsMessageHandler);
   spv_binary binary;
-  ASSERT_EQ(SPV_SUCCESS, spvTextToBinary(ctx.context, code.c_str(), code.size(),
-                                         &binary, nullptr));
+  ASSERT_EQ(SPV_SUCCESS, spvTextToBinary(ctx.CContext(), code.c_str(),
+                                         code.size(), &binary, nullptr));
 
-  ASSERT_EQ(SPV_SUCCESS, AggregateStats(*ctx.context, binary->code,
+  ASSERT_EQ(SPV_SUCCESS, AggregateStats(ctx.CContext(), binary->code,
                                         binary->wordCount, nullptr, stats));
   spvBinaryDestroy(binary);
 }

--- a/tools/stats/spirv_stats.cpp
+++ b/tools/stats/spirv_stats.cpp
@@ -147,13 +147,13 @@ class StatsAggregator {
 
 }  // namespace
 
-spv_result_t AggregateStats(const spv_context_t& context, const uint32_t* words,
+spv_result_t AggregateStats(const spv_context context, const uint32_t* words,
                             const size_t num_words, spv_diagnostic* pDiagnostic,
                             SpirvStats* stats) {
   std::unique_ptr<val::ValidationState_t> vstate;
   spv_validator_options_t options;
   spv_result_t result = ValidateBinaryAndKeepValidationState(
-      &context, &options, words, num_words, pDiagnostic, &vstate);
+      context, &options, words, num_words, pDiagnostic, &vstate);
   if (result != SPV_SUCCESS) return result;
 
   StatsAggregator stats_aggregator(stats, vstate.get());

--- a/tools/stats/spirv_stats.h
+++ b/tools/stats/spirv_stats.h
@@ -83,7 +83,7 @@ struct SpirvStats {
 };
 
 // Aggregates existing |stats| with new stats extracted from |binary|.
-spv_result_t AggregateStats(const spv_context_t& context, const uint32_t* words,
+spv_result_t AggregateStats(const spv_context context, const uint32_t* words,
                             const size_t num_words, spv_diagnostic* pDiagnostic,
                             SpirvStats* stats);
 

--- a/tools/stats/stats.cpp
+++ b/tools/stats/stats.cpp
@@ -19,19 +19,12 @@
 #include <unordered_map>
 #include <vector>
 
-#include "source/table.h"
 #include "spirv-tools/libspirv.h"
 #include "tools/io.h"
 #include "tools/stats/spirv_stats.h"
 #include "tools/stats/stats_analyzer.h"
 
 namespace {
-
-struct ScopedContext {
-  ScopedContext(spv_target_env env) : context(spvContextCreate(env)) {}
-  ~ScopedContext() { spvContextDestroy(context); }
-  spv_context context;
-};
 
 void PrintUsage(char* argv0) {
   printf(
@@ -120,9 +113,9 @@ int main(int argc, char** argv) {
 
   std::cerr << "Processing " << paths.size() << " files..." << std::endl;
 
-  ScopedContext ctx(SPV_ENV_UNIVERSAL_1_1);
-  spvtools::SetContextMessageConsumer(ctx.context, DiagnosticsMessageHandler);
-
+  spvtools::Context ctx(SPV_ENV_UNIVERSAL_1_1);
+  ctx->SetMessageConsumer(DiagnosticsMessageHandler);
+  
   spvtools::stats::SpirvStats stats;
   stats.opcode_markov_hist.resize(1);
 
@@ -138,7 +131,7 @@ int main(int argc, char** argv) {
     if (!ReadFile<uint32_t>(path, "rb", &contents)) return 1;
 
     if (SPV_SUCCESS !=
-        spvtools::stats::AggregateStats(*ctx.context, contents.data(),
+        spvtools::stats::AggregateStats(ctx->CContext(), contents.data(),
                                         contents.size(), nullptr, &stats)) {
       std::cerr << "error: Failed to aggregate stats for " << path << std::endl;
       return 1;

--- a/tools/stats/stats.cpp
+++ b/tools/stats/stats.cpp
@@ -114,7 +114,7 @@ int main(int argc, char** argv) {
   std::cerr << "Processing " << paths.size() << " files..." << std::endl;
 
   spvtools::Context ctx(SPV_ENV_UNIVERSAL_1_1);
-  ctx->SetMessageConsumer(DiagnosticsMessageHandler);
+  ctx.SetMessageConsumer(DiagnosticsMessageHandler);
 
   spvtools::stats::SpirvStats stats;
   stats.opcode_markov_hist.resize(1);
@@ -131,7 +131,7 @@ int main(int argc, char** argv) {
     if (!ReadFile<uint32_t>(path, "rb", &contents)) return 1;
 
     if (SPV_SUCCESS !=
-        spvtools::stats::AggregateStats(&(ctx.CContext()), contents.data(),
+        spvtools::stats::AggregateStats(ctx.CContext(), contents.data(),
                                         contents.size(), nullptr, &stats)) {
       std::cerr << "error: Failed to aggregate stats for " << path << std::endl;
       return 1;

--- a/tools/stats/stats.cpp
+++ b/tools/stats/stats.cpp
@@ -115,7 +115,7 @@ int main(int argc, char** argv) {
 
   spvtools::Context ctx(SPV_ENV_UNIVERSAL_1_1);
   ctx->SetMessageConsumer(DiagnosticsMessageHandler);
-  
+
   spvtools::stats::SpirvStats stats;
   stats.opcode_markov_hist.resize(1);
 
@@ -131,7 +131,7 @@ int main(int argc, char** argv) {
     if (!ReadFile<uint32_t>(path, "rb", &contents)) return 1;
 
     if (SPV_SUCCESS !=
-        spvtools::stats::AggregateStats(ctx->CContext(), contents.data(),
+        spvtools::stats::AggregateStats(ctx.CContext(), contents.data(),
                                         contents.size(), nullptr, &stats)) {
       std::cerr << "error: Failed to aggregate stats for " << path << std::endl;
       return 1;

--- a/tools/stats/stats.cpp
+++ b/tools/stats/stats.cpp
@@ -131,7 +131,7 @@ int main(int argc, char** argv) {
     if (!ReadFile<uint32_t>(path, "rb", &contents)) return 1;
 
     if (SPV_SUCCESS !=
-        spvtools::stats::AggregateStats(ctx.CContext(), contents.data(),
+        spvtools::stats::AggregateStats(&(ctx.CContext()), contents.data(),
                                         contents.size(), nullptr, &stats)) {
       std::cerr << "error: Failed to aggregate stats for " << path << std::endl;
       return 1;


### PR DESCRIPTION
Instead of using the source/table.h methods, this CL switches the stats
tool to use the spvtools::Context class and assign the message consumer
through the public API.