### PR TITLE
Remove use of SetContextMessageConsumer from binary_parse_test

### DIFF
--- a/test/binary_parse_test.cpp
+++ b/test/binary_parse_test.cpp
@@ -267,46 +267,42 @@ TEST_F(BinaryParseTest, NullDiagnosticsIsOkForBadParse) {
 TEST_F(BinaryParseTest, NullConsumerNullDiagnosticsForBadParse) {
   auto words = CompileSuccessfully("");
 
-  auto ctx = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
-  SetContextMessageConsumer(ctx, nullptr);
+  auto ctx = spvtools::Context(SPV_ENV_UNIVERSAL_1_1);
+  ctx.SetMessageConsumer(nullptr);
 
   words.push_back(0xffffffff);  // Certainly invalid instruction header.
   EXPECT_HEADER(1).WillOnce(Return(SPV_SUCCESS));
   EXPECT_CALL(client_, Instruction(_)).Times(0);  // No instruction callback.
   EXPECT_EQ(SPV_ERROR_INVALID_BINARY,
-            spvBinaryParse(ctx, &client_, words.data(), words.size(),
+            spvBinaryParse(ctx.CContext(), &client_, words.data(), words.size(),
                            invoke_header, invoke_instruction, nullptr));
-
-  spvContextDestroy(ctx);
 }
 
 TEST_F(BinaryParseTest, SpecifyConsumerNullDiagnosticsForGoodParse) {
   const auto words = CompileSuccessfully("");
 
-  auto ctx = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
+  auto ctx = spvtools::Context(SPV_ENV_UNIVERSAL_1_1);
   int invocation = 0;
-  SetContextMessageConsumer(
-      ctx, [&invocation](spv_message_level_t, const char*,
-                         const spv_position_t&, const char*) { ++invocation; });
+  ctx.SetMessageConsumer([&invocation](spv_message_level_t, const char*,
+                                       const spv_position_t&,
+                                       const char*) { ++invocation; });
 
   EXPECT_HEADER(1).WillOnce(Return(SPV_SUCCESS));
   EXPECT_CALL(client_, Instruction(_)).Times(0);  // No instruction callback.
   EXPECT_EQ(SPV_SUCCESS,
-            spvBinaryParse(ctx, &client_, words.data(), words.size(),
+            spvBinaryParse(ctx.CContext(), &client_, words.data(), words.size(),
                            invoke_header, invoke_instruction, nullptr));
   EXPECT_EQ(0, invocation);
-
-  spvContextDestroy(ctx);
 }
 
 TEST_F(BinaryParseTest, SpecifyConsumerNullDiagnosticsForBadParse) {
   auto words = CompileSuccessfully("");
 
-  auto ctx = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
+  auto ctx = spvtools::Context(SPV_ENV_UNIVERSAL_1_1);
   int invocation = 0;
-  SetContextMessageConsumer(
-      ctx, [&invocation](spv_message_level_t level, const char* source,
-                         const spv_position_t& position, const char* message) {
+  ctx.SetMessageConsumer(
+      [&invocation](spv_message_level_t level, const char* source,
+                    const spv_position_t& position, const char* message) {
         ++invocation;
         EXPECT_EQ(SPV_MSG_ERROR, level);
         EXPECT_STREQ("input", source);
@@ -320,52 +316,46 @@ TEST_F(BinaryParseTest, SpecifyConsumerNullDiagnosticsForBadParse) {
   EXPECT_HEADER(1).WillOnce(Return(SPV_SUCCESS));
   EXPECT_CALL(client_, Instruction(_)).Times(0);  // No instruction callback.
   EXPECT_EQ(SPV_ERROR_INVALID_BINARY,
-            spvBinaryParse(ctx, &client_, words.data(), words.size(),
+            spvBinaryParse(ctx.CContext(), &client_, words.data(), words.size(),
                            invoke_header, invoke_instruction, nullptr));
   EXPECT_EQ(1, invocation);
-
-  spvContextDestroy(ctx);
 }
 
 TEST_F(BinaryParseTest, SpecifyConsumerSpecifyDiagnosticsForGoodParse) {
   const auto words = CompileSuccessfully("");
 
-  auto ctx = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
+  auto ctx = spvtools::Context(SPV_ENV_UNIVERSAL_1_1);
   int invocation = 0;
-  SetContextMessageConsumer(
-      ctx, [&invocation](spv_message_level_t, const char*,
-                         const spv_position_t&, const char*) { ++invocation; });
+  ctx.SetMessageConsumer([&invocation](spv_message_level_t, const char*,
+                                       const spv_position_t&,
+                                       const char*) { ++invocation; });
 
   EXPECT_HEADER(1).WillOnce(Return(SPV_SUCCESS));
   EXPECT_CALL(client_, Instruction(_)).Times(0);  // No instruction callback.
   EXPECT_EQ(SPV_SUCCESS,
-            spvBinaryParse(ctx, &client_, words.data(), words.size(),
+            spvBinaryParse(ctx.CContext(), &client_, words.data(), words.size(),
                            invoke_header, invoke_instruction, &diagnostic_));
   EXPECT_EQ(0, invocation);
   EXPECT_EQ(nullptr, diagnostic_);
-
-  spvContextDestroy(ctx);
 }
 
 TEST_F(BinaryParseTest, SpecifyConsumerSpecifyDiagnosticsForBadParse) {
   auto words = CompileSuccessfully("");
 
-  auto ctx = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
+  auto ctx = spvtools::Context(SPV_ENV_UNIVERSAL_1_1);
   int invocation = 0;
-  SetContextMessageConsumer(
-      ctx, [&invocation](spv_message_level_t, const char*,
-                         const spv_position_t&, const char*) { ++invocation; });
+  ctx.SetMessageConsumer([&invocation](spv_message_level_t, const char*,
+                                       const spv_position_t&,
+                                       const char*) { ++invocation; });
 
   words.push_back(0xffffffff);  // Certainly invalid instruction header.
   EXPECT_HEADER(1).WillOnce(Return(SPV_SUCCESS));
   EXPECT_CALL(client_, Instruction(_)).Times(0);  // No instruction callback.
   EXPECT_EQ(SPV_ERROR_INVALID_BINARY,
-            spvBinaryParse(ctx, &client_, words.data(), words.size(),
+            spvBinaryParse(ctx.CContext(), &client_, words.data(), words.size(),
                            invoke_header, invoke_instruction, &diagnostic_));
   EXPECT_EQ(0, invocation);
   EXPECT_STREQ("Invalid opcode: 65535", diagnostic_->error);
-
-  spvContextDestroy(ctx);
 }
 
 TEST_F(BinaryParseTest,


### PR DESCRIPTION
This CL removes the use of SetContextMessageConsumer from the
binary_parse_test tests and creates a Context object and uses
SetMessageConsumer instead.