### PR TITLE
Keep analyses live in unrolling

### DIFF
--- a/source/opt/basic_block.cpp
+++ b/source/opt/basic_block.cpp
@@ -35,9 +35,18 @@ const uint32_t kSelectionMergeMergeBlockIdInIdx = 0;
 BasicBlock* BasicBlock::Clone(IRContext* context) const {
   BasicBlock* clone = new BasicBlock(
       std::unique_ptr<Instruction>(GetLabelInst()->Clone(context)));
-  for (const auto& inst : insts_)
+  for (const auto& inst : insts_) {
     // Use the incoming context
     clone->AddInstruction(std::unique_ptr<Instruction>(inst.Clone(context)));
+  }
+
+  if (context->AreAnalysesValid(
+          IRContext::Analysis::kAnalysisInstrToBlockMapping)) {
+    for (auto& inst : *clone) {
+      context->set_instr_block(&inst, clone);
+    }
+  }
+
   return clone;
 }
 

--- a/source/opt/basic_block.h
+++ b/source/opt/basic_block.h
@@ -54,6 +54,9 @@ class BasicBlock {
   //
   // The parent function will default to null and needs to be explicitly set by
   // the user.
+  //
+  // If the inst-to-block map in |context| is valid, then the new instructions
+  // will be inserted into the map.
   BasicBlock* Clone(IRContext*) const;
 
   // Sets the enclosing function for this basic block.

--- a/source/opt/loop_unroller.cpp
+++ b/source/opt/loop_unroller.cpp
@@ -746,9 +746,9 @@ void LoopUnrollerUtilsImpl::CloseUnrolledLoop(Loop* loop) {
 
   // Remove the final backedge to the header and make it point instead to the
   // merge block.
-  state_.previous_latch_block_->terminator()->SetInOperand(
-      0, {loop->GetMergeBlock()->id()});
-  context_->UpdateDefUse(state_.previous_latch_block_->terminator());
+  Instruction* latch_instruction = state_.previous_latch_block_->terminator();
+  latch_instruction->SetInOperand(0, {loop->GetMergeBlock()->id()});
+  context_->UpdateDefUse(latch_instruction);
 
   // Remove all induction variables as the phis will now be invalid. Replace all
   // uses with the constant initializer value (all uses of phis will be in

--- a/source/opt/loop_unroller.h
+++ b/source/opt/loop_unroller.h
@@ -30,6 +30,13 @@ class LoopUnroller : public Pass {
 
   Status Process() override;
 
+  IRContext::Analysis GetPreservedAnalyses() override {
+    return IRContext::kAnalysisDefUse |
+           IRContext::kAnalysisInstrToBlockMapping |
+           IRContext::kAnalysisDecorations | IRContext::kAnalysisCombinators |
+           IRContext::kAnalysisNameMap;
+  }
+
  private:
   bool fully_unroll_;
   int unroll_factor_;


### PR DESCRIPTION
Add code to keep the def-use manger and the inst-to-block mapping up-to-date.  This means we do not have to rebuild them later.

To make this work, we will have to have to find places to update the
def-use manager.  Updating the def-use manager is not straight forward
because we are unrolling loops, and we have circular references.

This forces one pass to register all of the definitions.  A second one
to analyze the uses.  Also because there will be references to the new
instructions in the old code, we want to register the definitions of the
new instructions early, so we can update the uses of the older code as
we go along.

The inst-to-block mapping is not too difficult.  It can be done as instructions are created.

Fixes #1928.