### PR TITLE
Enable /MP4 (parallel build across 4 cores for MSVC) for SPIRV-Tools/source[/opt]

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -371,3 +371,8 @@ if(ENABLE_SPIRV_TOOLS_INSTALL)
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif(ENABLE_SPIRV_TOOLS_INSTALL)
+
+if(MSVC)
+  # Enable parallel builds across four cores for this lib
+  add_definitions(/MP4)
+endif()

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -205,3 +205,7 @@ if(ENABLE_SPIRV_TOOLS_INSTALL)
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif(ENABLE_SPIRV_TOOLS_INSTALL)
     
+if(MSVC)
+  # Enable parallel builds across four cores for this lib
+  add_definitions(/MP4)
+endif()


### PR DESCRIPTION
cmake builds using MSVC normally get parallelism by building N projects in parallel, with each project using 1-2 CPU cores. But as spirv-tools has grown, it has become a serial bottleneck in CTS and glslang builds. Most other projects depend on it (unclear whether it is a real dependency or artificial) and it gets no parallelism.

Applying /MP (parallelize to N cores) risks using N^2 cores if N projects are doing it. This is intended to be a conservative change that uses a modest number of cores and only in the two libraries with the longest compile times. And N=4 solves 75% of the problem, the rest is diminishing returns ;-)

Some build times from my system:
SPIRV-Tools release build: 8m32s -> 4m57s
glslang release build: 6m59s -> 3m15s
Vulkan CTS release build (rough estimate): 12m -> 10m
