### PR TITLE
Unify memory instruction validation style

### DIFF
--- a/source/val/validate.cpp
+++ b/source/val/validate.cpp
@@ -313,8 +313,7 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
     if (auto error = ModeSettingPass(*vstate, &instruction)) return error;
     if (auto error = TypePass(*vstate, &instruction)) return error;
     if (auto error = ConstantPass(*vstate, &instruction)) return error;
-    if (auto error = ValidateMemoryInstructions(*vstate, &instruction))
-      return error;
+    if (auto error = MemoryPass(*vstate, &instruction)) return error;
     if (auto error = FunctionPass(*vstate, &instruction)) return error;
     if (auto error = ImagePass(*vstate, &instruction)) return error;
     if (auto error = ConversionPass(*vstate, &instruction)) return error;

--- a/source/val/validate.h
+++ b/source/val/validate.h
@@ -91,8 +91,7 @@ spv_result_t ValidateInterfaces(ValidationState_t& _);
 ///
 /// @param[in] _ the validation state of the module
 /// @return SPV_SUCCESS if no errors are found.
-spv_result_t ValidateMemoryInstructions(ValidationState_t& _,
-                                        const Instruction* inst);
+spv_result_t MemoryPass(ValidationState_t& _, const Instruction* inst);
 
 /// @brief Updates the immediate dominator for each of the block edges
 ///


### PR DESCRIPTION
* Rename ValidateMemoryInstructions to MemoryPass
* Changed functions to take pointer to an instruction instead of
reference

This makes the memory instruction validation consistent with other instruction validation.