### PR TITLE
Fixed Validator adjacency bug for OpPhi (#1922)

### DIFF
--- a/source/val/validate.cpp
+++ b/source/val/validate.cpp
@@ -333,10 +333,12 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
     if (auto error = NonUniformPass(*vstate, &instruction)) return error;
 
     if (auto error = LiteralsPass(*vstate, &instruction)) return error;
-    // Validate the preconditions involving adjacent instructions. e.g. SpvOpPhi
-    // must only be preceeded by SpvOpLabel, SpvOpPhi, or SpvOpLine.
+    // Validate the preconditions involving adjacent instructions.
     if (auto error = ValidateAdjacency(*vstate, i)) return error;
   }
+
+  // SpvOpPhi must only be preceeded by SpvOpLabel, SpvOpPhi, or SpvOpLine.
+  if (auto error = ValidateAdjacencyForOpPhi(*vstate)) return error;
 
   if (auto error = ValidateEntryPoints(*vstate)) return error;
   // CFG checks are performed after the binary has been parsed

--- a/source/val/validate.cpp
+++ b/source/val/validate.cpp
@@ -333,12 +333,11 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
     if (auto error = NonUniformPass(*vstate, &instruction)) return error;
 
     if (auto error = LiteralsPass(*vstate, &instruction)) return error;
-    // Validate the preconditions involving adjacent instructions.
-    if (auto error = ValidateAdjacency(*vstate, i)) return error;
   }
 
-  // SpvOpPhi must only be preceeded by SpvOpLabel, SpvOpPhi, or SpvOpLine.
-  if (auto error = ValidateAdjacencyForOpPhi(*vstate)) return error;
+  // Validate the preconditions involving adjacent instructions. e.g. SpvOpPhi
+  // must only be preceeded by SpvOpLabel, SpvOpPhi, or SpvOpLine.
+  if (auto error = ValidateAdjacency(*vstate)) return error;
 
   if (auto error = ValidateEntryPoints(*vstate)) return error;
   // CFG checks are performed after the binary has been parsed

--- a/source/val/validate.h
+++ b/source/val/validate.h
@@ -69,20 +69,13 @@ spv_result_t CheckIdDefinitionDominateUse(const ValidationState_t& _);
 /// instructions.
 ///
 /// This function will iterate over all instructions and check for any required
-/// predecessor and/or successor instructions.
+/// predecessor and/or successor instructions. e.g. SpvOpPhi must only be
+/// preceeded by SpvOpLabel, SpvOpPhi, or SpvOpLine.
 ///
 /// @param[in] _ the validation state of the module
 ///
 /// @return SPV_SUCCESS if no errors are found. SPV_ERROR_INVALID_DATA otherwise
-spv_result_t ValidateAdjacency(ValidationState_t& _, size_t idx);
-
-/// @brief This function checks SpvOpPhi is only preceeded by SpvOpLabel,
-/// SpvOpPhi, or SpvOpLine.
-///
-/// @param[in] _ the validation state of the module
-///
-/// @return SPV_SUCCESS if no errors are found. SPV_ERROR_INVALID_DATA otherwise
-spv_result_t ValidateAdjacencyForOpPhi(ValidationState_t& _);
+spv_result_t ValidateAdjacency(ValidationState_t& _);
 
 /// @brief Validates static uses of input and output variables
 ///

--- a/source/val/validate.h
+++ b/source/val/validate.h
@@ -69,13 +69,20 @@ spv_result_t CheckIdDefinitionDominateUse(const ValidationState_t& _);
 /// instructions.
 ///
 /// This function will iterate over all instructions and check for any required
-/// predecessor and/or successor instructions. e.g. SpvOpPhi must only be
-/// preceeded by SpvOpLabel, SpvOpPhi, or SpvOpLine.
+/// predecessor and/or successor instructions.
 ///
 /// @param[in] _ the validation state of the module
 ///
 /// @return SPV_SUCCESS if no errors are found. SPV_ERROR_INVALID_DATA otherwise
 spv_result_t ValidateAdjacency(ValidationState_t& _, size_t idx);
+
+/// @brief This function checks SpvOpPhi is only preceeded by SpvOpLabel,
+/// SpvOpPhi, or SpvOpLine.
+///
+/// @param[in] _ the validation state of the module
+///
+/// @return SPV_SUCCESS if no errors are found. SPV_ERROR_INVALID_DATA otherwise
+spv_result_t ValidateAdjacencyForOpPhi(ValidationState_t& _);
 
 /// @brief Validates static uses of input and output variables
 ///

--- a/source/val/validate_adjacency.cpp
+++ b/source/val/validate_adjacency.cpp
@@ -33,13 +33,14 @@ spv_result_t ValidateAdjacency(ValidationState_t& _, size_t idx) {
 
   switch (inst.opcode()) {
     case SpvOpPhi:
+      while (idx > 0 && instructions[idx - 1].opcode() == SpvOpLine) --idx;
       if (idx > 0) {
         switch (instructions[idx - 1].opcode()) {
           case SpvOpLabel:
           case SpvOpPhi:
-          case SpvOpLine:
             break;
           default:
+            assert(instructions[idx - 1].opcode() != SpvOpLine);
             return _.diag(SPV_ERROR_INVALID_DATA, &inst)
                    << "OpPhi must appear before all non-OpPhi instructions "
                    << "(except for OpLine, which can be mixed with OpPhi).";

--- a/source/val/validate_adjacency.cpp
+++ b/source/val/validate_adjacency.cpp
@@ -27,70 +27,73 @@
 namespace spvtools {
 namespace val {
 
-spv_result_t ValidateAdjacencyForOpPhi(ValidationState_t& _) {
+enum {
+  IN_NEW_FUNCTION,
+  IN_ENTRY_BLOCK,
+  PHI_VALID,
+  PHI_INVALID,
+};
+
+spv_result_t ValidateAdjacency(ValidationState_t& _) {
   const auto& instructions = _.ordered_instructions();
-  bool valid_to_place = false;
+  int phi_check = PHI_INVALID;
 
   for (size_t i = 0; i < instructions.size(); ++i) {
     const auto& inst = instructions[i];
     switch (inst.opcode()) {
+      case SpvOpFunction:
+      case SpvOpFunctionParameter:
+        phi_check = IN_NEW_FUNCTION;
+        break;
       case SpvOpLabel:
-        valid_to_place = true;
+        phi_check = phi_check == IN_NEW_FUNCTION ? IN_ENTRY_BLOCK : PHI_VALID;
         break;
       case SpvOpPhi:
-        if (!valid_to_place) {
+        if (phi_check != PHI_VALID) {
           return _.diag(SPV_ERROR_INVALID_DATA, &inst)
-                 << "OpPhi must appear before all non-OpPhi instructions "
+                 << "OpPhi must appear within a non-entry block before all "
+                 << "non-OpPhi instructions "
                  << "(except for OpLine, which can be mixed with OpPhi).";
         }
         break;
       case SpvOpLine:
         break;
+      case SpvOpLoopMerge:
+        phi_check = PHI_INVALID;
+        if (i != (instructions.size() - 1)) {
+          switch (instructions[i + 1].opcode()) {
+            case SpvOpBranch:
+            case SpvOpBranchConditional:
+              break;
+            default:
+              return _.diag(SPV_ERROR_INVALID_DATA, &inst)
+                     << "OpLoopMerge must immediately precede either an "
+                     << "OpBranch or OpBranchConditional instruction. "
+                     << "OpLoopMerge must be the second-to-last instruction in "
+                     << "its block.";
+          }
+        }
+        break;
+      case SpvOpSelectionMerge:
+        phi_check = PHI_INVALID;
+        if (i != (instructions.size() - 1)) {
+          switch (instructions[i + 1].opcode()) {
+            case SpvOpBranchConditional:
+            case SpvOpSwitch:
+              break;
+            default:
+              return _.diag(SPV_ERROR_INVALID_DATA, &inst)
+                     << "OpSelectionMerge must immediately precede either an "
+                     << "OpBranchConditional or OpSwitch instruction. "
+                     << "OpSelectionMerge must be the second-to-last "
+                     << "instruction in its block.";
+          }
+        }
+        break;
       default:
-        valid_to_place = false;
+        phi_check = PHI_INVALID;
         break;
     }
-  }
-
-  return SPV_SUCCESS;
-}
-
-spv_result_t ValidateAdjacency(ValidationState_t& _, size_t idx) {
-  const auto& instructions = _.ordered_instructions();
-  const auto& inst = instructions[idx];
-
-  switch (inst.opcode()) {
-    case SpvOpLoopMerge:
-      if (idx != (instructions.size() - 1)) {
-        switch (instructions[idx + 1].opcode()) {
-          case SpvOpBranch:
-          case SpvOpBranchConditional:
-            break;
-          default:
-            return _.diag(SPV_ERROR_INVALID_DATA, &inst)
-                   << "OpLoopMerge must immediately precede either an "
-                   << "OpBranch or OpBranchConditional instruction. "
-                   << "OpLoopMerge must be the second-to-last instruction in "
-                   << "its block.";
-        }
-      }
-      break;
-    case SpvOpSelectionMerge:
-      if (idx != (instructions.size() - 1)) {
-        switch (instructions[idx + 1].opcode()) {
-          case SpvOpBranchConditional:
-          case SpvOpSwitch:
-            break;
-          default:
-            return _.diag(SPV_ERROR_INVALID_DATA, &inst)
-                   << "OpSelectionMerge must immediately precede either an "
-                   << "OpBranchConditional or OpSwitch instruction. "
-                   << "OpSelectionMerge must be the second-to-last "
-                   << "instruction in its block.";
-        }
-      }
-    default:
-      break;
   }
 
   return SPV_SUCCESS;

--- a/test/val/val_adjacency_test.cpp
+++ b/test/val/val_adjacency_test.cpp
@@ -194,7 +194,8 @@ OpNop
   CompileSuccessfully(GenerateShaderCode(body));
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpPhi must appear before all non-OpPhi instructions"));
+              HasSubstr("OpPhi must appear within a non-entry block before all "
+                        "non-OpPhi instructions"));
 }
 
 TEST_F(ValidateAdjacency, OpPhiPreceededByOpLineAndBadOpFail) {
@@ -214,7 +215,8 @@ OpLine %string 1 1
   CompileSuccessfully(GenerateShaderCode(body));
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpPhi must appear before all non-OpPhi instructions"));
+              HasSubstr("OpPhi must appear within a non-entry block before all "
+                        "non-OpPhi instructions"));
 }
 
 TEST_F(ValidateAdjacency, OpPhiFollowedByOpLineGood) {
@@ -260,7 +262,8 @@ OpLine %string 3 1
   CompileSuccessfully(GenerateShaderCode(body));
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpPhi must appear before all non-OpPhi instructions"));
+              HasSubstr("OpPhi must appear within a non-entry block before all "
+                        "non-OpPhi instructions"));
 }
 
 TEST_F(ValidateAdjacency, OpPhiMultipleOpLineAndOpPhiGood) {
@@ -285,6 +288,23 @@ OpNop
 
   CompileSuccessfully(GenerateShaderCode(body));
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateAdjacency, OpPhiInEntryBlockBad) {
+  const std::string body = R"(
+OpLine %string 1 1
+%value = OpPhi %int
+OpLine %string 2 1
+OpNop
+OpLine %string 3 1
+OpNop
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body));
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpPhi must appear within a non-entry block before all "
+                        "non-OpPhi instructions"));
 }
 
 TEST_F(ValidateAdjacency, OpLoopMergePreceedsOpBranchSuccess) {

--- a/test/val/val_adjacency_test.cpp
+++ b/test/val/val_adjacency_test.cpp
@@ -196,6 +196,26 @@ OpNop
               HasSubstr("OpPhi must appear before all non-OpPhi instructions"));
 }
 
+TEST_F(ValidateAdjacency, OpPhiPreceededByOpLineAndBadOpFail) {
+  const std::string body = R"(
+OpSelectionMerge %end_label None
+OpBranchConditional %true %true_label %false_label
+%true_label = OpLabel
+OpBranch %end_label
+%false_label = OpLabel
+OpBranch %end_label
+%end_label = OpLabel
+OpNop
+OpLine %string 1 1
+%result = OpPhi %bool %true %true_label %false %false_label
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body));
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpPhi must appear before all non-OpPhi instructions"));
+}
+
 TEST_F(ValidateAdjacency, OpLoopMergePreceedsOpBranchSuccess) {
   const std::string body = R"(
 OpBranch %loop


### PR DESCRIPTION
OpPhi instruction must appear before all non-OpPhi instructions
except for OpLine. Without this commit, Validator does not check
the case that an OpPhi is preceeded by an OpLine and the OpLine is
preceeded by a non-OpPhi instruction that is not OpLine.