### PR TITLE
Change handling of unknown extentions in validtor.

### DIFF
--- a/source/val/validate.cpp
+++ b/source/val/validate.cpp
@@ -42,6 +42,12 @@
 #include "source/val/validation_state.h"
 #include "spirv-tools/libspirv.h"
 
+namespace {
+// TODO(issue 1950): The validator only returns a single message anyway, so no
+// point in generating more than 1 warning.
+static uint32_t kDefaultMaxNumOfWarnings = 1;
+}
+
 namespace spvtools {
 namespace val {
 namespace {
@@ -370,7 +376,7 @@ spv_result_t ValidateBinaryAndKeepValidationState(
   }
 
   vstate->reset(
-      new ValidationState_t(&hijack_context, options, words, num_words));
+      new ValidationState_t(&hijack_context, options, words, num_words, kDefaultMaxNumOfWarnings));
 
   return ValidateBinaryUsingContextAndValidationState(
       hijack_context, words, num_words, pDiagnostic, vstate->get());
@@ -399,8 +405,8 @@ spv_result_t spvValidateBinary(const spv_const_context context,
   spv_validator_options default_options = spvValidatorOptionsCreate();
 
   // Create the ValidationState using the context and default options.
-  spvtools::val::ValidationState_t vstate(&hijack_context, default_options,
-                                          words, num_words);
+  spvtools::val::ValidationState_t
+      vstate(&hijack_context, default_options, words, num_words, kDefaultMaxNumOfWarnings);
 
   spv_result_t result =
       spvtools::val::ValidateBinaryUsingContextAndValidationState(
@@ -421,8 +427,8 @@ spv_result_t spvValidateWithOptions(const spv_const_context context,
   }
 
   // Create the ValidationState using the context.
-  spvtools::val::ValidationState_t vstate(&hijack_context, options,
-                                          binary->code, binary->wordCount);
+  spvtools::val::ValidationState_t
+      vstate(&hijack_context, options, binary->code, binary->wordCount, kDefaultMaxNumOfWarnings);
 
   return spvtools::val::ValidateBinaryUsingContextAndValidationState(
       hijack_context, binary->code, binary->wordCount, pDiagnostic, &vstate);

--- a/source/val/validate.cpp
+++ b/source/val/validate.cpp
@@ -46,7 +46,7 @@ namespace {
 // TODO(issue 1950): The validator only returns a single message anyway, so no
 // point in generating more than 1 warning.
 static uint32_t kDefaultMaxNumOfWarnings = 1;
-}
+}  // namespace
 
 namespace spvtools {
 namespace val {
@@ -375,8 +375,8 @@ spv_result_t ValidateBinaryAndKeepValidationState(
     UseDiagnosticAsMessageConsumer(&hijack_context, pDiagnostic);
   }
 
-  vstate->reset(
-      new ValidationState_t(&hijack_context, options, words, num_words, kDefaultMaxNumOfWarnings));
+  vstate->reset(new ValidationState_t(&hijack_context, options, words,
+                                      num_words, kDefaultMaxNumOfWarnings));
 
   return ValidateBinaryUsingContextAndValidationState(
       hijack_context, words, num_words, pDiagnostic, vstate->get());
@@ -405,8 +405,9 @@ spv_result_t spvValidateBinary(const spv_const_context context,
   spv_validator_options default_options = spvValidatorOptionsCreate();
 
   // Create the ValidationState using the context and default options.
-  spvtools::val::ValidationState_t
-      vstate(&hijack_context, default_options, words, num_words, kDefaultMaxNumOfWarnings);
+  spvtools::val::ValidationState_t vstate(&hijack_context, default_options,
+                                          words, num_words,
+                                          kDefaultMaxNumOfWarnings);
 
   spv_result_t result =
       spvtools::val::ValidateBinaryUsingContextAndValidationState(
@@ -427,8 +428,9 @@ spv_result_t spvValidateWithOptions(const spv_const_context context,
   }
 
   // Create the ValidationState using the context.
-  spvtools::val::ValidationState_t
-      vstate(&hijack_context, options, binary->code, binary->wordCount, kDefaultMaxNumOfWarnings);
+  spvtools::val::ValidationState_t vstate(&hijack_context, options,
+                                          binary->code, binary->wordCount,
+                                          kDefaultMaxNumOfWarnings);
 
   return spvtools::val::ValidateBinaryUsingContextAndValidationState(
       hijack_context, binary->code, binary->wordCount, pDiagnostic, &vstate);

--- a/source/val/validate.h
+++ b/source/val/validate.h
@@ -63,7 +63,7 @@ spv_result_t UpdateIdUse(ValidationState_t& _, const Instruction* inst);
 /// @param[in] _ the validation state of the module
 ///
 /// @return SPV_SUCCESS if no errors are found. SPV_ERROR_INVALID_ID otherwise
-spv_result_t CheckIdDefinitionDominateUse(const ValidationState_t& _);
+spv_result_t CheckIdDefinitionDominateUse(ValidationState_t& _);
 
 /// @brief This function checks for preconditions involving the adjacent
 /// instructions.
@@ -135,7 +135,7 @@ spv_result_t InstructionPass(ValidationState_t& _, const Instruction* inst);
 spv_result_t ValidateDecorations(ValidationState_t& _);
 
 /// Performs validation of built-in variables.
-spv_result_t ValidateBuiltIns(const ValidationState_t& _);
+spv_result_t ValidateBuiltIns(ValidationState_t& _);
 
 /// Validates type instructions.
 spv_result_t TypePass(ValidationState_t& _, const Instruction* inst);

--- a/source/val/validate_builtins.cpp
+++ b/source/val/validate_builtins.cpp
@@ -55,7 +55,7 @@ std::string GetIdDesc(const Instruction& inst) {
 // the Vulkan spec.
 // TODO: If non-Vulkan validation rules are added then it might need
 // to be refactored.
-spv_result_t GetUnderlyingType(const ValidationState_t& _,
+spv_result_t GetUnderlyingType(ValidationState_t& _,
                                const Decoration& decoration,
                                const Instruction& inst,
                                uint32_t* underlying_type) {
@@ -106,7 +106,7 @@ SpvStorageClass GetStorageClass(const Instruction& inst) {
 // ValidationState_t to be made available to other users.
 class BuiltInsValidator {
  public:
-  BuiltInsValidator(const ValidationState_t& vstate) : _(vstate) {}
+  BuiltInsValidator(ValidationState_t& vstate) : _(vstate) {}
 
   // Run validation.
   spv_result_t Run();
@@ -375,7 +375,7 @@ class BuiltInsValidator {
   // instruction.
   void Update(const Instruction& inst);
 
-  const ValidationState_t& _;
+  ValidationState_t& _;
 
   // Mapping id -> list of rules which validate instruction referencing the
   // id. Rules can create new rules and add them to this container.
@@ -2592,7 +2592,7 @@ spv_result_t BuiltInsValidator::Run() {
 }  // namespace
 
 // Validates correctness of built-in variables.
-spv_result_t ValidateBuiltIns(const ValidationState_t& _) {
+spv_result_t ValidateBuiltIns(ValidationState_t& _) {
   if (!spvIsVulkanEnv(_.context()->target_env)) {
     // Early return. All currently implemented rules are based on Vulkan spec.
     //

--- a/source/val/validate_cfg.cpp
+++ b/source/val/validate_cfg.cpp
@@ -296,9 +296,9 @@ std::string ConstructErrorString(const Construct& construct,
 // |case_fall_through|. Returns SPV_ERROR_INVALID_CFG if the case construct
 // headed by |target_block| branches to multiple case constructs.
 spv_result_t FindCaseFallThrough(
-    ValidationState_t& _, BasicBlock* target_block,
-    uint32_t* case_fall_through, const BasicBlock* merge,
-    const std::unordered_set<uint32_t>& case_targets, Function* function) {
+    ValidationState_t& _, BasicBlock* target_block, uint32_t* case_fall_through,
+    const BasicBlock* merge, const std::unordered_set<uint32_t>& case_targets,
+    Function* function) {
   std::vector<BasicBlock*> stack;
   stack.push_back(target_block);
   std::unordered_set<const BasicBlock*> visited;
@@ -352,8 +352,7 @@ spv_result_t FindCaseFallThrough(
   return SPV_SUCCESS;
 }
 
-spv_result_t StructuredSwitchChecks(ValidationState_t& _,
-                                    Function* function,
+spv_result_t StructuredSwitchChecks(ValidationState_t& _, Function* function,
                                     const Instruction* switch_inst,
                                     const BasicBlock* header,
                                     const BasicBlock* merge) {

--- a/source/val/validate_cfg.cpp
+++ b/source/val/validate_cfg.cpp
@@ -296,7 +296,7 @@ std::string ConstructErrorString(const Construct& construct,
 // |case_fall_through|. Returns SPV_ERROR_INVALID_CFG if the case construct
 // headed by |target_block| branches to multiple case constructs.
 spv_result_t FindCaseFallThrough(
-    const ValidationState_t& _, BasicBlock* target_block,
+    ValidationState_t& _, BasicBlock* target_block,
     uint32_t* case_fall_through, const BasicBlock* merge,
     const std::unordered_set<uint32_t>& case_targets, Function* function) {
   std::vector<BasicBlock*> stack;
@@ -352,7 +352,7 @@ spv_result_t FindCaseFallThrough(
   return SPV_SUCCESS;
 }
 
-spv_result_t StructuredSwitchChecks(const ValidationState_t& _,
+spv_result_t StructuredSwitchChecks(ValidationState_t& _,
                                     Function* function,
                                     const Instruction* switch_inst,
                                     const BasicBlock* header,
@@ -452,7 +452,7 @@ spv_result_t StructuredSwitchChecks(const ValidationState_t& _,
 }
 
 spv_result_t StructuredControlFlowChecks(
-    const ValidationState_t& _, Function* function,
+    ValidationState_t& _, Function* function,
     const std::vector<std::pair<uint32_t, uint32_t>>& back_edges) {
   /// Check all backedges target only loop headers and have exactly one
   /// back-edge branching to it

--- a/source/val/validate_id.cpp
+++ b/source/val/validate_id.cpp
@@ -58,7 +58,7 @@ spv_result_t UpdateIdUse(ValidationState_t& _, const Instruction* inst) {
 ///
 /// NOTE: This function does NOT check module scoped functions which are
 /// checked during the initial binary parse in the IdPass below
-spv_result_t CheckIdDefinitionDominateUse(const ValidationState_t& _) {
+spv_result_t CheckIdDefinitionDominateUse(ValidationState_t& _) {
   std::vector<const Instruction*> phi_instructions;
   std::unordered_set<uint32_t> phi_ids;
   for (const auto& inst : _.ordered_instructions()) {

--- a/source/val/validate_instruction.cpp
+++ b/source/val/validate_instruction.cpp
@@ -89,7 +89,7 @@ CapabilitySet EnablingCapabilitiesForOp(const ValidationState_t& state,
 // Returns SPV_SUCCESS if the given operand is enabled by capabilities declared
 // in the module.  Otherwise issues an error message and returns
 // SPV_ERROR_INVALID_CAPABILITY.
-spv_result_t CheckRequiredCapabilities(const ValidationState_t& state,
+spv_result_t CheckRequiredCapabilities(ValidationState_t& state,
                                        const Instruction* inst,
                                        size_t which_operand,
                                        spv_operand_type_t type,
@@ -430,14 +430,14 @@ spv_result_t LimitCheckNumVars(ValidationState_t& _, const uint32_t var_id,
 }
 
 // Parses OpExtension instruction and logs warnings if unsuccessful.
-void CheckIfKnownExtension(ValidationState_t& _, const Instruction* inst) {
+spv_result_t CheckIfKnownExtension(ValidationState_t& _, const Instruction* inst) {
   const std::string extension_str = GetExtensionString(&(inst->c_inst()));
   Extension extension;
   if (!GetExtensionFromString(extension_str.c_str(), &extension)) {
-    _.diag(SPV_ERROR_INVALID_BINARY, inst)
+    return _.diag(SPV_WARNING, inst)
         << "Found unrecognized extension " << extension_str;
-    return;
   }
+  return SPV_SUCCESS;
 }
 
 }  // namespace

--- a/source/val/validate_instruction.cpp
+++ b/source/val/validate_instruction.cpp
@@ -430,12 +430,13 @@ spv_result_t LimitCheckNumVars(ValidationState_t& _, const uint32_t var_id,
 }
 
 // Parses OpExtension instruction and logs warnings if unsuccessful.
-spv_result_t CheckIfKnownExtension(ValidationState_t& _, const Instruction* inst) {
+spv_result_t CheckIfKnownExtension(ValidationState_t& _,
+                                   const Instruction* inst) {
   const std::string extension_str = GetExtensionString(&(inst->c_inst()));
   Extension extension;
   if (!GetExtensionFromString(extension_str.c_str(), &extension)) {
     return _.diag(SPV_WARNING, inst)
-        << "Found unrecognized extension " << extension_str;
+           << "Found unrecognized extension " << extension_str;
   }
   return SPV_SUCCESS;
 }

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -89,10 +89,9 @@ class ValidationState_t {
   };
 
   ValidationState_t(const spv_const_context context,
-                      const spv_const_validator_options opt,
-                      const uint32_t* words,
-                      const size_t num_words,
-                      const uint32_t max_warnings);
+                    const spv_const_validator_options opt,
+                    const uint32_t* words, const size_t num_words,
+                    const uint32_t max_warnings);
 
   /// Returns the context
   spv_const_context context() const { return context_; }

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -89,8 +89,10 @@ class ValidationState_t {
   };
 
   ValidationState_t(const spv_const_context context,
-                    const spv_const_validator_options opt,
-                    const uint32_t* words, const size_t num_words);
+                      const spv_const_validator_options opt,
+                      const uint32_t* words,
+                      const size_t num_words,
+                      const uint32_t max_warnings);
 
   /// Returns the context
   spv_const_context context() const { return context_; }
@@ -169,7 +171,7 @@ class ValidationState_t {
   /// Determines if the op instruction is part of the current section
   bool IsOpcodeInCurrentLayoutSection(SpvOp op);
 
-  DiagnosticStream diag(spv_result_t error_code, const Instruction* inst) const;
+  DiagnosticStream diag(spv_result_t error_code, const Instruction* inst);
 
   /// Returns the function states
   std::vector<Function>& functions();
@@ -640,6 +642,10 @@ class ValidationState_t {
   /// module which can (indirectly) call the function.
   std::unordered_map<uint32_t, std::vector<uint32_t>> function_to_entry_points_;
   const std::vector<uint32_t> empty_ids_;
+
+  /// Variables used to reduce the number of diagnostic messages.
+  uint32_t num_of_warnings_;
+  uint32_t max_num_of_warnings_;
 };
 
 }  // namespace val

--- a/test/val/val_extensions_test.cpp
+++ b/test/val/val_extensions_test.cpp
@@ -107,7 +107,8 @@ TEST_F(ValidateUnknownExtensions, HitMaxNumOfWarnings) {
       "OpMemoryModel Logical GLSL450";
   CompileSuccessfully(str.c_str());
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Other warnings have been suppressed."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Other warnings have been suppressed."));
 }
 
 TEST_F(ValidateExtensionCapabilities, DeclCapabilitySuccess) {
@@ -273,8 +274,7 @@ TEST_P(ValidateExtIntoCore, DoNotAskForExtensionInLaterVersion) {
                            GetParam().cap + R"(
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main" %builtin
-               OpDecorate %builtin BuiltIn )" +
-                           GetParam().builtin + R"(
+               OpDecorate %builtin BuiltIn )" + GetParam().builtin + R"(
        %void = OpTypeVoid
           %3 = OpTypeFunction %void
         %int = OpTypeInt 32 1

--- a/test/val/val_extensions_test.cpp
+++ b/test/val/val_extensions_test.cpp
@@ -88,6 +88,28 @@ TEST_P(ValidateUnknownExtensions, FailSilently) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr(GetErrorString(extension)));
 }
 
+TEST_F(ValidateUnknownExtensions, HitMaxNumOfWarnings) {
+  const std::string str =
+      std::string("OpCapability Shader\n") + "OpCapability Linkage\n" +
+      "OpExtension \"bad_ext\"\n" + "OpExtension \"bad_ext\"\n" +
+      "OpExtension \"bad_ext\"\n" + "OpExtension \"bad_ext\"\n" +
+      "OpExtension \"bad_ext\"\n" + "OpExtension \"bad_ext\"\n" +
+      "OpExtension \"bad_ext\"\n" + "OpExtension \"bad_ext\"\n" +
+      "OpExtension \"bad_ext\"\n" + "OpExtension \"bad_ext\"\n" +
+      "OpExtension \"bad_ext\"\n" + "OpExtension \"bad_ext\"\n" +
+      "OpExtension \"bad_ext\"\n" + "OpExtension \"bad_ext\"\n" +
+      "OpExtension \"bad_ext\"\n" + "OpExtension \"bad_ext\"\n" +
+      "OpExtension \"bad_ext\"\n" + "OpExtension \"bad_ext\"\n" +
+      "OpExtension \"bad_ext\"\n" + "OpExtension \"bad_ext\"\n" +
+      "OpExtension \"bad_ext\"\n" + "OpExtension \"bad_ext\"\n" +
+      "OpExtension \"bad_ext\"\n" + "OpExtension \"bad_ext\"\n" +
+      "OpExtension \"bad_ext\"\n" + "OpExtension \"bad_ext\"\n" +
+      "OpMemoryModel Logical GLSL450";
+  CompileSuccessfully(str.c_str());
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Other warnings have been suppressed."));
+}
+
 TEST_F(ValidateExtensionCapabilities, DeclCapabilitySuccess) {
   const std::string str =
       "OpCapability Shader\nOpCapability Linkage\nOpCapability DeviceGroup\n"
@@ -251,7 +273,8 @@ TEST_P(ValidateExtIntoCore, DoNotAskForExtensionInLaterVersion) {
                            GetParam().cap + R"(
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main" %builtin
-               OpDecorate %builtin BuiltIn )" + GetParam().builtin + R"(
+               OpDecorate %builtin BuiltIn )" +
+                           GetParam().builtin + R"(
        %void = OpTypeVoid
           %3 = OpTypeFunction %void
         %int = OpTypeInt 32 1

--- a/test/val/val_state_test.cpp
+++ b/test/val/val_state_test.cpp
@@ -41,7 +41,7 @@ class ValidationStateTest : public testing::Test {
   ValidationStateTest()
       : context_(spvContextCreate(SPV_ENV_UNIVERSAL_1_0)),
         options_(spvValidatorOptionsCreate()),
-        state_(context_, options_, kFakeBinary, 0) {}
+        state_(context_, options_, kFakeBinary, 0, 1) {}
 
   ~ValidationStateTest() {
     spvContextDestroy(context_);


### PR DESCRIPTION
This commit will change the message for unknown extensions from an error
to a warning.

Code was added to limit the number of warning messages so that consummer
of the messages are not overwhelmed.  This is standard practice in
compilers.

Many other issues were found at while looking into this. They have been
documented in #1950.

Fixes http://crbug.com/875547.