### PR TITLE
allow atomics on Function pointers for OpenCL

### DIFF
--- a/source/spirv_target_env.cpp
+++ b/source/spirv_target_env.cpp
@@ -195,3 +195,31 @@ bool spvIsVulkanEnv(spv_target_env env) {
   }
   return false;
 }
+
+bool spvIsOpenCLEnv(spv_target_env env) {
+  switch (env) {
+    case SPV_ENV_UNIVERSAL_1_0:
+    case SPV_ENV_VULKAN_1_0:
+    case SPV_ENV_UNIVERSAL_1_1:
+    case SPV_ENV_OPENGL_4_0:
+    case SPV_ENV_OPENGL_4_1:
+    case SPV_ENV_OPENGL_4_2:
+    case SPV_ENV_OPENGL_4_3:
+    case SPV_ENV_OPENGL_4_5:
+    case SPV_ENV_UNIVERSAL_1_2:
+    case SPV_ENV_UNIVERSAL_1_3:
+    case SPV_ENV_VULKAN_1_1:
+    case SPV_ENV_WEBGPU_0:
+      return false;
+    case SPV_ENV_OPENCL_1_2:
+    case SPV_ENV_OPENCL_EMBEDDED_1_2:
+    case SPV_ENV_OPENCL_2_0:
+    case SPV_ENV_OPENCL_EMBEDDED_2_0:
+    case SPV_ENV_OPENCL_EMBEDDED_2_1:
+    case SPV_ENV_OPENCL_EMBEDDED_2_2:
+    case SPV_ENV_OPENCL_2_1:
+    case SPV_ENV_OPENCL_2_2:
+      return true;
+  }
+  return false;
+}

--- a/source/spirv_target_env.h
+++ b/source/spirv_target_env.h
@@ -24,6 +24,9 @@ bool spvParseTargetEnv(const char* s, spv_target_env* env);
 // Returns true if |env| is a VULKAN environment, false otherwise.
 bool spvIsVulkanEnv(spv_target_env env);
 
+// Returns true if |env| is an OPENCL environment, false otherwise.
+bool spvIsOpenCLEnv(spv_target_env env);
+
 // Returns the version number for the given SPIR-V target environment.
 uint32_t spvVersionForTargetEnv(spv_target_env env);
 

--- a/source/val/validate_atomics.cpp
+++ b/source/val/validate_atomics.cpp
@@ -252,11 +252,21 @@ spv_result_t AtomicsPass(ValidationState_t& _, const Instruction* inst) {
         case SpvStorageClassStorageBuffer:
           break;
         default:
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << spvOpcodeString(opcode)
-                 << ": expected Pointer Storage Class to be Uniform, "
-                    "Workgroup, CrossWorkgroup, Generic, AtomicCounter, Image "
-                    "or StorageBuffer";
+          if (spvIsOpenCLEnv(_.context()->target_env)) {
+            if (storage_class != SpvStorageClassFunction) {
+              return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                     << spvOpcodeString(opcode)
+                     << ": expected Pointer Storage Class to be Uniform, "
+                        "Workgroup, CrossWorkgroup, Generic, AtomicCounter, "
+                        "Image, StorageBuffer or Function";
+            }
+          } else {
+            return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                   << spvOpcodeString(opcode)
+                   << ": expected Pointer Storage Class to be Uniform, "
+                      "Workgroup, CrossWorkgroup, Generic, AtomicCounter, "
+                      "Image or StorageBuffer";
+          }
       }
 
       if (opcode == SpvOpAtomicFlagTestAndSet ||


### PR DESCRIPTION
For OpenCL environments, an atomic operation on a *Pointer* to a **Function** *Storage Class* is valid, but the SPIR-V validator currently flags this as an invalid operation.  This change relaxes the SPIR-V validator for OpenCL environments only to allow atomic operations on *Pointers* to the **Function** *Storage Class*.  There is no change for other environments.