### PR TITLE
Enable precompiled headers for MSVC for spirv-tools-opt

### DIFF
--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(SPIRV-Tools-opt
+set(SPIRV_TOOLS_OPT_SOURCES
   aggressive_dead_code_elim_pass.h
   basic_block.h
   block_merge_pass.h
@@ -185,6 +185,18 @@ add_library(SPIRV-Tools-opt
   workaround1209.cpp
 )
 
+if(MSVC)
+  # Enable parallel builds across four cores for this lib
+  add_definitions(/MP4)
+
+  # Enable precompiled header
+  set_source_files_properties(${SPIRV_TOOLS_OPT_SOURCES} PROPERTIES COMPILE_FLAGS "/Yupch.h /FIpch.h /Fppch.pch" OBJECT_DEPENDS "pch.pch")
+  set_source_files_properties(pch.cpp PROPERTIES COMPILE_FLAGS "/Ycpch.h /Fppch.pch" OBJECT_OUTPUTS "pch.pch")
+  list(APPEND SPIRV_TOOLS_OPT_SOURCES "pch.cpp")
+endif()
+
+add_library(SPIRV-Tools-opt ${SPIRV_TOOLS_OPT_SOURCES})
+
 spvtools_default_compile_options(SPIRV-Tools-opt)
 target_include_directories(SPIRV-Tools-opt
   PUBLIC ${spirv-tools_SOURCE_DIR}/include
@@ -204,8 +216,3 @@ if(ENABLE_SPIRV_TOOLS_INSTALL)
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif(ENABLE_SPIRV_TOOLS_INSTALL)
-    
-if(MSVC)
-  # Enable parallel builds across four cores for this lib
-  add_definitions(/MP4)
-endif()

--- a/source/opt/pch.cpp
+++ b/source/opt/pch.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2018 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "pch.h"

--- a/source/opt/pch.h
+++ b/source/opt/pch.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2018 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <functional>
+#include <map>
+#include <queue>
+#include <stack>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+#include "source/opt/basic_block.h"
+#include "source/opt/decoration_manager.h"
+#include "source/opt/def_use_manager.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/mem_pass.h"
+#include "source/opt/module.h"
+#include "source/opt/pass.h"
+#include "source/util/hex_float.h"
+#include "source/util/make_unique.h"


### PR DESCRIPTION
This reduces build time for spirv-tools-opt by about 45 seconds on my system (after my previous /MP4 change to enable parallelism). This helps a lot with the spirv-tools bottleneck in the Vulkan CTS build.
