### PR TITLE
Validator: TaskNV can use LocalSize or LocalSizeId

### DIFF
--- a/source/val/validate_mode_setting.cpp
+++ b/source/val/validate_mode_setting.cpp
@@ -376,6 +376,7 @@ spv_result_t ValidateExecutionMode(ValidationState_t& _,
                            case SpvExecutionModelKernel:
                            case SpvExecutionModelGLCompute:
                              return true;
+                           case SpvExecutionModelTaskNV:
                            case SpvExecutionModelMeshNV:
                              return _.HasCapability(SpvCapabilityMeshShadingNV);
                            default:
@@ -384,8 +385,8 @@ spv_result_t ValidateExecutionMode(ValidationState_t& _,
                        })) {
         if (_.HasCapability(SpvCapabilityMeshShadingNV)) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << "Execution mode can only be used with a Kernel, GLCompute "
-                    "or MeshNV execution model.";
+                 << "Execution mode can only be used with a Kernel, GLCompute, "
+                    "MeshNV, or TaskNV execution model.";
         } else {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << "Execution mode can only be used with a Kernel or "

--- a/test/val/val_modes_test.cpp
+++ b/test/val/val_modes_test.cpp
@@ -720,6 +720,20 @@ OpExecutionMode %main LocalSize 1 1 1
   EXPECT_THAT(SPV_SUCCESS, ValidateInstructions());
 }
 
+TEST_F(ValidateModeExecution, TaskNVLocalSize) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability MeshShadingNV
+OpExtension "SPV_NV_mesh_shader"
+OpMemoryModel Logical GLSL450
+OpEntryPoint TaskNV %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+)" + kVoidFunction;
+
+  CompileSuccessfully(spirv);
+  EXPECT_THAT(SPV_SUCCESS, ValidateInstructions());
+}
+
 TEST_F(ValidateModeExecution, MeshNVOutputPoints) {
   const std::string spirv = R"(
 OpCapability Shader
@@ -755,6 +769,23 @@ OpCapability MeshShadingNV
 OpExtension "SPV_NV_mesh_shader"
 OpMemoryModel Logical GLSL450
 OpEntryPoint MeshNV %main "main"
+OpExecutionModeId %main LocalSizeId %int_1 %int_1 %int_1
+%int = OpTypeInt 32 0
+%int_1 = OpConstant %int 1
+)" + kVoidFunction;
+
+  spv_target_env env = SPV_ENV_UNIVERSAL_1_3;
+  CompileSuccessfully(spirv, env);
+  EXPECT_THAT(SPV_SUCCESS, ValidateInstructions(env));
+}
+
+TEST_F(ValidateModeExecution, TaskNVLocalSizeId) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability MeshShadingNV
+OpExtension "SPV_NV_mesh_shader"
+OpMemoryModel Logical GLSL450
+OpEntryPoint TaskNV %main "main"
 OpExecutionModeId %main LocalSizeId %int_1 %int_1 %int_1
 %int = OpTypeInt 32 0
 %int_1 = OpConstant %int 1


### PR DESCRIPTION
Correponds to the update to Rev2 of SPV_NV_mesh_shader

Fixes #1968