### PR TITLE
Fix gtest.h include in test/opt/pass_utils.h

### DIFF
--- a/test/opt/pass_utils.h
+++ b/test/opt/pass_utils.h
@@ -21,7 +21,7 @@
 #include <string>
 #include <vector>
 
-#include "external/googletest/googletest/include/gtest/gtest.h"
+#include "gtest/gtest.h"
 #include "include/spirv-tools/libspirv.h"
 #include "include/spirv-tools/libspirv.hpp"
 


### PR DESCRIPTION
Fixes builds where googletest is outside the SPIRV-Tools tree.