### PR TITLE
OpGroupDecorate may not target OpDecorationGroup

### DIFF
--- a/source/val/validate_annotation.cpp
+++ b/source/val/validate_annotation.cpp
@@ -89,6 +89,15 @@ spv_result_t ValidateGroupDecorate(ValidationState_t& _,
            << _.getIdName(decoration_group_id)
            << "' is not a decoration group.";
   }
+  for (unsigned i = 1; i < inst->operands().size(); ++i) {
+    auto target_id = inst->GetOperandAs<uint32_t>(i);
+    auto target = _.FindDef(target_id);
+    if (!target || target->opcode() == SpvOpDecorationGroup) {
+      return _.diag(SPV_ERROR_INVALID_ID, inst)
+             << "OpGroupDecorate may not target OpDecorationGroup <id> '"
+             << _.getIdName(target_id) << "'";
+    }
+  }
   return SPV_SUCCESS;
 }
 

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -3444,6 +3444,39 @@ OpFunctionEnd
                         "Object operand of an OpStore."));
 }
 
+TEST_F(ValidateDecorations, GroupDecorateTargetsDecorationGroup) {
+  std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+%1 = OpDecorationGroup
+OpGroupDecorate %1 %1
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("OpGroupDecorate may not target OpDecorationGroup <id> '1'"));
+}
+
+TEST_F(ValidateDecorations, GroupDecorateTargetsDecorationGroup2) {
+  std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+%1 = OpDecorationGroup
+OpGroupDecorate %1 %2 %1
+%2 = OpTypeVoid
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("OpGroupDecorate may not target OpDecorationGroup <id> '1'"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
Fixes https://crbug.com/896200

* Adds a check to validation of OpGroupDecorate that OpDecorationGroup
cannot be targeted