### PR TITLE
Only run merge-returnon reachable functions.

### DIFF
--- a/test/opt/pass_merge_return_test.cpp
+++ b/test/opt/pass_merge_return_test.cpp
@@ -104,6 +104,7 @@ TEST_F(MergeReturnPassTest, TwoReturnsWithValues) {
       R"(OpCapability Linkage
 OpCapability Kernel
 OpMemoryModel Logical OpenCL
+OpDecorate %7 LinkageAttributes "simple_kernel" Export
 %1 = OpTypeInt 32 0
 %2 = OpTypeBool
 %3 = OpConstantFalse %2
@@ -124,6 +125,7 @@ OpFunctionEnd
       R"(OpCapability Linkage
 OpCapability Kernel
 OpMemoryModel Logical OpenCL
+OpDecorate %7 LinkageAttributes "simple_kernel" Export
 %1 = OpTypeInt 32 0
 %2 = OpTypeBool
 %3 = OpConstantFalse %2
@@ -207,6 +209,7 @@ TEST_F(MergeReturnPassTest, UnreachableReturnsWithValues) {
       R"(OpCapability Linkage
 OpCapability Kernel
 OpMemoryModel Logical OpenCL
+OpDecorate %7 LinkageAttributes "simple_kernel" Export
 %1 = OpTypeInt 32 0
 %2 = OpTypeBool
 %3 = OpConstantFalse %2
@@ -230,6 +233,7 @@ OpFunctionEnd
       R"(OpCapability Linkage
 OpCapability Kernel
 OpMemoryModel Logical OpenCL
+OpDecorate %7 LinkageAttributes "simple_kernel" Export
 %1 = OpTypeInt 32 0
 %2 = OpTypeBool
 %3 = OpConstantFalse %2
@@ -1004,6 +1008,7 @@ OpDecorate %7 RelaxedPrecision
 %13 = OpTypeFunction %12
 %11 = OpFunction %12 None %13
 %l1 = OpLabel
+%fc = OpFunctionCall %1 %7
 OpReturn
 OpFunctionEnd
 %7 = OpFunction %1 None %6


### PR DESCRIPTION
We currently run merge-return on all functions, but
dead-branch-elimination only runs on function reachable from an entry
point or exported function.  Since dead-branch-elimination is needed for
merge-return, they have to match.

Fixes #1976.