### PR TITLE
Increase the template nesting depth for clang.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,8 @@ function(spvtools_default_compile_options TARGET)
         target_compile_options(${TARGET} PRIVATE
           -fsanitize=${SPIRV_USE_SANITIZER})
       endif()
+      target_compile_options(${TARGET} PRIVATE
+         -ftemplate-depth=1024)
     else()
       target_compile_options(${TARGET} PRIVATE
          -Wno-missing-field-initializers)


### PR DESCRIPTION
We started hitting this limit, so increaseing from 256 to 1024.

Fixes #1994.