### PR TITLE
Sync spriv-headers

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -11,7 +11,7 @@ vars = {
   'googletest_revision': '98a0d007d7092b72eea0e501bb9ad17908a1a036',
   'testing_revision': '340252637e2e7c72c0901dcbeeacfff419e19b59',
   're2_revision': '6cf8ccd82dbaab2668e9b13596c68183c9ecd13f',
-  'spirv_headers_revision': 'd5b2e1255f706ce1f88812217e9a554f299848af',
+  'spirv_headers_revision': 'a2c529b5dda18838ab4b52f816acfebd774eaab3',
 }
 
 deps = {

--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -324,7 +324,7 @@ int32_t spvOpcodeGeneratesType(SpvOp op) {
     case SpvOpTypePipe:
     case SpvOpTypePipeStorage:
     case SpvOpTypeNamedBarrier:
-    case SpvOpTypeAccelerationStructureNVX:
+    case SpvOpTypeAccelerationStructureNV:
       return true;
     default:
       // In particular, OpTypeForwardPointer does not generate a type,

--- a/source/val/validate_builtins.cpp
+++ b/source/val/validate_builtins.cpp
@@ -1688,11 +1688,11 @@ spv_result_t BuiltInsValidator::ValidatePrimitiveIdAtReference(
         case SpvExecutionModelTessellationEvaluation:
         case SpvExecutionModelGeometry:
         case SpvExecutionModelMeshNV:
-        case SpvExecutionModelRayGenerationNVX:
-        case SpvExecutionModelIntersectionNVX:
-        case SpvExecutionModelAnyHitNVX:
-        case SpvExecutionModelClosestHitNVX:
-        case SpvExecutionModelMissNVX: {
+        case SpvExecutionModelRayGenerationNV:
+        case SpvExecutionModelIntersectionNV:
+        case SpvExecutionModelAnyHitNV:
+        case SpvExecutionModelClosestHitNV:
+        case SpvExecutionModelMissNV: {
           // Ok.
           break;
         }
@@ -2483,6 +2483,7 @@ spv_result_t BuiltInsValidator::ValidateSingleBuiltInAtDefinition(
     case SpvBuiltInPrimitiveIndicesNV:
     case SpvBuiltInClipDistancePerViewNV:
     case SpvBuiltInCullDistancePerViewNV:
+    case SpvBuiltInIncomingRayFlagsNV:
     case SpvBuiltInLayerPerViewNV:
     case SpvBuiltInMeshViewCountNV:
     case SpvBuiltInMeshViewIndicesNV:
@@ -2490,19 +2491,19 @@ spv_result_t BuiltInsValidator::ValidateSingleBuiltInAtDefinition(
     case SpvBuiltInBaryCoordNoPerspNV:
     case SpvBuiltInFragmentSizeNV:
     case SpvBuiltInInvocationsPerPixelNV:
-    case SpvBuiltInLaunchIdNVX:
-    case SpvBuiltInLaunchSizeNVX:
-    case SpvBuiltInWorldRayOriginNVX:
-    case SpvBuiltInWorldRayDirectionNVX:
-    case SpvBuiltInObjectRayOriginNVX:
-    case SpvBuiltInObjectRayDirectionNVX:
-    case SpvBuiltInRayTminNVX:
-    case SpvBuiltInRayTmaxNVX:
-    case SpvBuiltInInstanceCustomIndexNVX:
-    case SpvBuiltInObjectToWorldNVX:
-    case SpvBuiltInWorldToObjectNVX:
-    case SpvBuiltInHitTNVX:
-    case SpvBuiltInHitKindNVX: {
+    case SpvBuiltInLaunchIdNV:
+    case SpvBuiltInLaunchSizeNV:
+    case SpvBuiltInWorldRayOriginNV:
+    case SpvBuiltInWorldRayDirectionNV:
+    case SpvBuiltInObjectRayOriginNV:
+    case SpvBuiltInObjectRayDirectionNV:
+    case SpvBuiltInRayTminNV:
+    case SpvBuiltInRayTmaxNV:
+    case SpvBuiltInInstanceCustomIndexNV:
+    case SpvBuiltInObjectToWorldNV:
+    case SpvBuiltInWorldToObjectNV:
+    case SpvBuiltInHitTNV:
+    case SpvBuiltInHitKindNV: {
       // No validation rules (for the moment).
       break;
     }

--- a/test/operand_capabilities_test.cpp
+++ b/test/operand_capabilities_test.cpp
@@ -492,7 +492,7 @@ INSTANTIATE_TEST_CASE_P(
             CASE1(BUILT_IN, BuiltInVertexId, Shader),
             CASE1(BUILT_IN, BuiltInInstanceId, Shader),
             CASE3(BUILT_IN, BuiltInPrimitiveId, Geometry, Tessellation,
-                  RaytracingNVX),
+                  RayTracingNV),
             CASE2(BUILT_IN, BuiltInInvocationId, Geometry, Tessellation),
             CASE1(BUILT_IN, BuiltInLayer, Geometry),
             CASE1(BUILT_IN, BuiltInViewportIndex, MultiViewport),  // Bug 15234


### PR DESCRIPTION
This CL fixes the ray tracing opcode names to match the drop in the X
from NVX. This also adds the IncomingRay builtin and updates the name of
the extension to match the new RayTracing capitalization.

Fixes #2012