### PR TITLE
Reduce number of test targets

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -175,6 +175,29 @@ add_spvtools_unittest(
   LIBS ${SPIRV_TOOLS})
 endif()
 
+
+add_spvtools_unittest(
+  TARGET bit_stream
+  SRCS bit_stream.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/../source/comp/bit_stream.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/../source/comp/bit_stream.h
+  LIBS ${SPIRV_TOOLS})
+
+ add_spvtools_unittest(
+  TARGET huffman_codec
+  SRCS huffman_codec.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/../source/comp/bit_stream.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/../source/comp/bit_stream.h
+      ${CMAKE_CURRENT_SOURCE_DIR}/../source/comp/huffman_codec.h
+  LIBS ${SPIRV_TOOLS})
+
+ add_spvtools_unittest(
+  TARGET move_to_front
+  SRCS move_to_front_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../source/comp/move_to_front.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/../source/comp/move_to_front.cpp
+  LIBS ${SPIRV_TOOLS})
+
 add_subdirectory(comp)
 add_subdirectory(link)
 add_subdirectory(opt)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -93,6 +93,7 @@ set(TEST_SOURCES
   binary_to_text_test.cpp
   binary_to_text.literal_test.cpp
   comment_test.cpp
+  diagnostic_test.cpp
   enum_string_mapping_test.cpp
   enum_set_test.cpp
   ext_inst.debuginfo_test.cpp
@@ -103,6 +104,7 @@ set(TEST_SOURCES
   hex_float_test.cpp
   immediate_int_test.cpp
   libspirv_macros_test.cpp
+  log_test.cpp
   named_id_test.cpp
   name_mapper_test.cpp
   opcode_make_test.cpp
@@ -112,7 +114,10 @@ set(TEST_SOURCES
   operand_capabilities_test.cpp
   operand_test.cpp
   operand_pattern_test.cpp
+  parse_number_test.cpp
+  preserve_numeric_ids_test.cpp
   software_version_test.cpp
+  string_utils_test.cpp
   target_env_test.cpp
   text_advance_test.cpp
   text_destroy_test.cpp
@@ -148,11 +153,6 @@ add_spvtools_unittest(
   LIBS ${SPIRV_TOOLS})
 
 add_spvtools_unittest(
-  TARGET diagnostic
-  SRCS diagnostic_test.cpp
-  LIBS ${SPIRV_TOOLS})
-
-add_spvtools_unittest(
   TARGET c_interface
   SRCS c_interface_test.cpp
   LIBS ${SPIRV_TOOLS})
@@ -168,54 +168,12 @@ add_spvtools_unittest(
   SRCS cpp_interface_test.cpp
   LIBS SPIRV-Tools-opt)
 
-add_spvtools_unittest(
-  TARGET parse_number
-  SRCS parse_number_test.cpp
-  LIBS ${SPIRV_TOOLS})
-
-add_spvtools_unittest(
-  TARGET string_utils
-  SRCS string_utils_test.cpp
-  LIBS ${SPIRV_TOOLS})
-
 if (${SPIRV_TIMER_ENABLED})
 add_spvtools_unittest(
   TARGET timer
   SRCS timer_test.cpp
   LIBS ${SPIRV_TOOLS})
 endif()
-
-add_spvtools_unittest(
-  TARGET log
-  SRCS log_test.cpp
-  LIBS ${SPIRV_TOOLS})
-
-add_spvtools_unittest(
-  TARGET preserve_numeric_ids
-  SRCS preserve_numeric_ids_test.cpp
-  LIBS ${SPIRV_TOOLS})
-
-add_spvtools_unittest(
-  TARGET bit_stream
-  SRCS bit_stream.cpp
-      ${CMAKE_CURRENT_SOURCE_DIR}/../source/comp/bit_stream.cpp
-      ${CMAKE_CURRENT_SOURCE_DIR}/../source/comp/bit_stream.h
-  LIBS ${SPIRV_TOOLS})
-
-add_spvtools_unittest(
-  TARGET huffman_codec
-  SRCS huffman_codec.cpp
-      ${CMAKE_CURRENT_SOURCE_DIR}/../source/comp/bit_stream.cpp
-      ${CMAKE_CURRENT_SOURCE_DIR}/../source/comp/bit_stream.h
-      ${CMAKE_CURRENT_SOURCE_DIR}/../source/comp/huffman_codec.h
-  LIBS ${SPIRV_TOOLS})
-
-add_spvtools_unittest(
-  TARGET move_to_front
-  SRCS move_to_front_test.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../source/comp/move_to_front.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/../source/comp/move_to_front.cpp
-  LIBS ${SPIRV_TOOLS})
 
 add_subdirectory(comp)
 add_subdirectory(link)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -183,7 +183,7 @@ add_spvtools_unittest(
       ${CMAKE_CURRENT_SOURCE_DIR}/../source/comp/bit_stream.h
   LIBS ${SPIRV_TOOLS})
 
- add_spvtools_unittest(
+add_spvtools_unittest(
   TARGET huffman_codec
   SRCS huffman_codec.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/../source/comp/bit_stream.cpp
@@ -191,7 +191,7 @@ add_spvtools_unittest(
       ${CMAKE_CURRENT_SOURCE_DIR}/../source/comp/huffman_codec.h
   LIBS ${SPIRV_TOOLS})
 
- add_spvtools_unittest(
+add_spvtools_unittest(
   TARGET move_to_front
   SRCS move_to_front_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../source/comp/move_to_front.h

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -15,330 +15,74 @@
 add_subdirectory(dominator_tree)
 add_subdirectory(loop_optimizations)
 
-add_spvtools_unittest(TARGET instruction
-  SRCS instruction_test.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET instruction_list
-  SRCS instruction_list_test.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET ir_loader
-  SRCS ir_loader_test.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_manager
-  SRCS module_utils.h
-       pass_manager_test.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET optimizer
-  SRCS optimizer_test.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_strip_debug_info
-  SRCS strip_debug_info_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_strip_reflect_info
-  SRCS strip_reflect_info_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_compact_ids
-  SRCS compact_ids_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_flatten_decoration
-  SRCS flatten_decoration_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_freeze_spec_const
-  SRCS freeze_spec_const_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_block_merge
-  SRCS block_merge_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_inline
-  SRCS inline_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_inline_opaque
-  SRCS inline_opaque_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_insert_extract_elim
-  SRCS insert_extract_elim_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_dead_insert_elim
-  SRCS dead_insert_elim_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_local_ssa_elim
-  SRCS local_ssa_elim_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_local_single_block_elim
-  SRCS local_single_block_elim.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_local_access_chain_convert
-  SRCS local_access_chain_convert_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_local_single_store_elim
-  SRCS local_single_store_elim_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_dead_branch_elim
-  SRCS dead_branch_elim_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_dead_variable_elim
-  SRCS dead_variable_elim_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_aggressive_dce
-  SRCS aggressive_dead_code_elim_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_common_uniform_elim
-  SRCS common_uniform_elim_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_eliminate_dead_const
-  SRCS eliminate_dead_const_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_eliminate_dead_functions
-  SRCS eliminate_dead_functions_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_pass
-  SRCS pass_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_utils
-  SRCS utils_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET def_use
-  SRCS def_use_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET assembly_builder
-  SRCS assembly_builder_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET types
-  SRCS types_test.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET type_manager
-  SRCS type_manager_test.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET iterator
-  SRCS iterator_test.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET module
-  SRCS module_utils.h
+add_spvtools_unittest(TARGET opt
+  SRCS aggressive_dead_code_elim_test.cpp
+       assembly_builder_test.cpp
+       block_merge_test.cpp
+       ccp_test.cpp
+       cfg_cleanup_test.cpp
+       combine_access_chains_test.cpp
+       common_uniform_elim_test.cpp
+       compact_ids_test.cpp
+       constant_manager_test.cpp
+       copy_prop_array_test.cpp
+       dead_branch_elim_test.cpp
+       dead_insert_elim_test.cpp
+       dead_variable_elim_test.cpp
+       decoration_manager_test.cpp
+       def_use_test.cpp
+       eliminate_dead_const_test.cpp
+       eliminate_dead_functions_test.cpp
+       feature_manager_test.cpp
+       flatten_decoration_test.cpp
+       fold_spec_const_op_composite_test.cpp
+       fold_test.cpp
+       freeze_spec_const_test.cpp
+       if_conversion_test.cpp
+       inline_opaque_test.cpp
+       inline_test.cpp
+       insert_extract_elim_test.cpp
+       instruction_list_test.cpp
+       instruction_test.cpp
+       ir_builder.cpp
+       ir_context_test.cpp
+       ir_loader_test.cpp
+       iterator_test.cpp
+       line_debug_info_test.cpp
+       local_access_chain_convert_test.cpp
+       local_redundancy_elimination_test.cpp
+       local_single_block_elim.cpp
+       local_single_store_elim_test.cpp
+       local_ssa_elim_test.cpp
        module_test.cpp
+       module_utils.h
+       optimizer_test.cpp
+       pass_manager_test.cpp
+       pass_merge_return_test.cpp
+       pass_remove_duplicates_test.cpp
+       pass_test.cpp pass_utils.cpp
+       pass_utils.cpp
+       private_to_local_test.cpp
+       propagator_test.cpp
+       reduce_load_size_test.cpp
+       redundancy_elimination_test.cpp
+       register_liveness.cpp
+       replace_invalid_opc_test.cpp
+       scalar_analysis.cpp
+       scalar_replacement_test.cpp
+       set_spec_const_default_value_test.cpp
+       simplification_test.cpp
+       strength_reduction_test.cpp
+       strip_debug_info_test.cpp
+       strip_reflect_info_test.cpp
+       struct_cfg_analysis_test.cpp
+       type_manager_test.cpp
+       types_test.cpp
+       unify_const_test.cpp
+       utils_test.cpp pass_utils.cpp
+       value_table_test.cpp
+       vector_dce_test.cpp
+       workaround1209_test.cpp
   LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_fold_spec_const_op_composite
-  SRCS fold_spec_const_op_composite_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_unify_const
-  SRCS unify_const_test.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_set_spec_const_default_value
-  SRCS set_spec_const_default_value_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET line_debug_info
-  SRCS line_debug_info_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_strength_reduction
-  SRCS strength_reduction_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_scalar_replacement
-  SRCS scalar_replacement_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET cfg_cleanup
-  SRCS cfg_cleanup_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET ir_context
-  SRCS ir_context_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET feature_manager
-  SRCS feature_manager_test.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_merge_return
-  SRCS pass_merge_return_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET value_table
-  SRCS value_table_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET local_redundancy_elimination
-  SRCS local_redundancy_elimination_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET propagator
-  SRCS propagator_test.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET redundancy_elimination
-  SRCS redundancy_elimination_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET private_to_local
-  SRCS private_to_local_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET decoration_manager
-  SRCS decoration_manager_test.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_remove_duplicates
-  SRCS pass_remove_duplicates_test.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET ccp
-  SRCS ccp_test.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_workaround1209
-  SRCS workaround1209_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET pass_if_conversion
-  SRCS if_conversion_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET ir_builder
-  SRCS ir_builder.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET instruction_folding
-  SRCS fold_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET replace_invalid_opc
-  SRCS replace_invalid_opc_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET register_liveness
-  SRCS register_liveness.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET simplification
-  SRCS simplification_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET copy_prop_array
-  SRCS copy_prop_array_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET scalar_analysis
-  SRCS scalar_analysis.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET vector_dce
-  SRCS vector_dce_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET reduce_load_size
-  SRCS reduce_load_size_test.cpp pass_utils.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET constant_manager
-  SRCS constant_manager_test.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET combine_access_chains
-  SRCS combine_access_chains_test.cpp
-  LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET struct_cfg_analysis
-        SRCS struct_cfg_analysis_test.cpp
-        LIBS SPIRV-Tools-opt
 )
 

--- a/test/opt/aggressive_dead_code_elim_test.cpp
+++ b/test/opt/aggressive_dead_code_elim_test.cpp
@@ -4180,7 +4180,7 @@ TEST_F(AggressiveDCETest, BasicNoneDeadConstants) {
       JoinAllInsts(text), JoinAllInsts(text), /* skip_nop = */ true);
 }
 
-struct EliminateDeadConstantTestCase {
+struct AggressiveEliminateDeadConstantTestCase {
   // Type declarations and constants that should be kept.
   std::vector<std::string> used_consts;
   // Instructions that refer to constants, this is added to create uses for
@@ -4192,7 +4192,8 @@ struct EliminateDeadConstantTestCase {
   std::vector<std::string> checks;
 };
 
-// All types that are potentially required in EliminateDeadConstantTest.
+// All types that are potentially required in
+// AggressiveEliminateDeadConstantTest.
 const std::vector<std::string> CommonTypes = {
     // clang-format off
     // scalar types
@@ -4228,10 +4229,10 @@ const std::vector<std::string> CommonTypes = {
     // clang-format on
 };
 
-using EliminateDeadConstantTest =
-    PassTest<::testing::TestWithParam<EliminateDeadConstantTestCase>>;
+using AggressiveEliminateDeadConstantTest =
+    PassTest<::testing::TestWithParam<AggressiveEliminateDeadConstantTestCase>>;
 
-TEST_P(EliminateDeadConstantTest, Custom) {
+TEST_P(AggressiveEliminateDeadConstantTest, Custom) {
   auto& tc = GetParam();
   AssemblyBuilder builder;
   builder.AppendTypesConstantsGlobals(CommonTypes)
@@ -4248,8 +4249,8 @@ TEST_P(EliminateDeadConstantTest, Custom) {
 }
 
 INSTANTIATE_TEST_CASE_P(
-    ScalarTypeConstants, EliminateDeadConstantTest,
-    ::testing::ValuesIn(std::vector<EliminateDeadConstantTestCase>({
+    ScalarTypeConstants, AggressiveEliminateDeadConstantTest,
+    ::testing::ValuesIn(std::vector<AggressiveEliminateDeadConstantTestCase>({
         // clang-format off
         // Scalar type constants, one dead constant and one used constant.
         {
@@ -4340,8 +4341,8 @@ INSTANTIATE_TEST_CASE_P(
     })));
 
 INSTANTIATE_TEST_CASE_P(
-    VectorTypeConstants, EliminateDeadConstantTest,
-    ::testing::ValuesIn(std::vector<EliminateDeadConstantTestCase>({
+    VectorTypeConstants, AggressiveEliminateDeadConstantTest,
+    ::testing::ValuesIn(std::vector<AggressiveEliminateDeadConstantTestCase>({
         // clang-format off
         // Tests eliminating dead constant type ivec2. One dead constant vector
         // and one used constant vector, each built from its own group of
@@ -4467,8 +4468,8 @@ INSTANTIATE_TEST_CASE_P(
     })));
 
 INSTANTIATE_TEST_CASE_P(
-    StructTypeConstants, EliminateDeadConstantTest,
-    ::testing::ValuesIn(std::vector<EliminateDeadConstantTestCase>({
+    StructTypeConstants, AggressiveEliminateDeadConstantTest,
+    ::testing::ValuesIn(std::vector<AggressiveEliminateDeadConstantTestCase>({
         // clang-format off
         // A plain struct type dead constants. All of its components are dead
         // constants too.
@@ -4638,8 +4639,8 @@ INSTANTIATE_TEST_CASE_P(
     })));
 
 INSTANTIATE_TEST_CASE_P(
-    ScalarTypeSpecConstants, EliminateDeadConstantTest,
-    ::testing::ValuesIn(std::vector<EliminateDeadConstantTestCase>({
+    ScalarTypeSpecConstants, AggressiveEliminateDeadConstantTest,
+    ::testing::ValuesIn(std::vector<AggressiveEliminateDeadConstantTestCase>({
         // clang-format off
         // All scalar type spec constants.
         {
@@ -4691,8 +4692,8 @@ INSTANTIATE_TEST_CASE_P(
     })));
 
 INSTANTIATE_TEST_CASE_P(
-    VectorTypeSpecConstants, EliminateDeadConstantTest,
-    ::testing::ValuesIn(std::vector<EliminateDeadConstantTestCase>({
+    VectorTypeSpecConstants, AggressiveEliminateDeadConstantTest,
+    ::testing::ValuesIn(std::vector<AggressiveEliminateDeadConstantTestCase>({
         // clang-format off
         // Bool vector type spec constants. One vector has all component dead,
         // another vector has one dead boolean and one used boolean.
@@ -4813,8 +4814,8 @@ INSTANTIATE_TEST_CASE_P(
     })));
 
 INSTANTIATE_TEST_CASE_P(
-    SpecConstantOp, EliminateDeadConstantTest,
-    ::testing::ValuesIn(std::vector<EliminateDeadConstantTestCase>({
+    SpecConstantOp, AggressiveEliminateDeadConstantTest,
+    ::testing::ValuesIn(std::vector<AggressiveEliminateDeadConstantTestCase>({
         // clang-format off
         // Cast operations: uint <-> int <-> bool
         {
@@ -4995,8 +4996,8 @@ INSTANTIATE_TEST_CASE_P(
     })));
 
 INSTANTIATE_TEST_CASE_P(
-    LongDefUseChain, EliminateDeadConstantTest,
-    ::testing::ValuesIn(std::vector<EliminateDeadConstantTestCase>({
+    LongDefUseChain, AggressiveEliminateDeadConstantTest,
+    ::testing::ValuesIn(std::vector<AggressiveEliminateDeadConstantTestCase>({
         // clang-format off
         // Long Def-Use chain with binary operations.
         {

--- a/test/stats/CMakeLists.txt
+++ b/test/stats/CMakeLists.txt
@@ -17,15 +17,10 @@ set(VAL_TEST_COMMON_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/../unit_spirv.h
 )
 
-add_spvtools_unittest(TARGET stats_aggregate
+add_spvtools_unittest(TARGET stats
 	SRCS stats_aggregate_test.cpp
+       stats_analyzer_test.cpp
        ${CMAKE_CURRENT_SOURCE_DIR}/../../tools/stats/spirv_stats.cpp
-       ${VAL_TEST_COMMON_SRCS}
-  LIBS ${SPIRV_TOOLS}
-)
-
-add_spvtools_unittest(TARGET stats_analyzer
-	SRCS stats_analyzer_test.cpp
 	     ${CMAKE_CURRENT_SOURCE_DIR}/../../tools/stats/stats_analyzer.cpp
        ${VAL_TEST_COMMON_SRCS}
   LIBS ${SPIRV_TOOLS}

--- a/test/tools/opt/CMakeLists.txt
+++ b/test/tools/opt/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 if(NOT ${SPIRV_SKIP_TESTS})
   if(${PYTHONINTERP_FOUND})
-    add_test(NAME spirv_opt_tests
+    add_test(NAME spirv_opt_cli_tools_tests
       COMMAND ${PYTHON_EXECUTABLE}
       ${CMAKE_CURRENT_SOURCE_DIR}/../spirv_test_framework.py
       $<TARGET_FILE:spirv-opt> $<TARGET_FILE:spirv-as> $<TARGET_FILE:spirv-dis>

--- a/test/util/CMakeLists.txt
+++ b/test/util/CMakeLists.txt
@@ -12,15 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_spvtools_unittest(TARGET util_intrusive_list
+add_spvtools_unittest(TARGET utils
   SRCS ilist_test.cpp
-)
-
-add_spvtools_unittest(TARGET bit_vector
-  SRCS bit_vector_test.cpp
+       bit_vector_test.cpp
+       small_vector_test.cpp
   LIBS SPIRV-Tools-opt
-)
-
-add_spvtools_unittest(TARGET small_vector
-  SRCS small_vector_test.cpp
 )


### PR DESCRIPTION
This CL combines a bunch of tests targets into single executables. This reduces the number of build targets and number of test suites to be run in ctest.