### PR TITLE
Add explicit void parameter in libspirv.h again

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -498,7 +498,7 @@ SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetSkipBlockLayout(
 // Creates an optimizer options object with default options. Returns a valid
 // options object. The object remains valid until it is passed into
 // |spvOptimizerOptionsDestroy|.
-SPIRV_TOOLS_EXPORT spv_optimizer_options spvOptimizerOptionsCreate();
+SPIRV_TOOLS_EXPORT spv_optimizer_options spvOptimizerOptionsCreate(void);
 
 // Destroys the given optimizer options object.
 SPIRV_TOOLS_EXPORT void spvOptimizerOptionsDestroy(

--- a/source/spirv_optimizer_options.cpp
+++ b/source/spirv_optimizer_options.cpp
@@ -17,7 +17,7 @@
 
 #include "source/spirv_optimizer_options.h"
 
-SPIRV_TOOLS_EXPORT spv_optimizer_options spvOptimizerOptionsCreate() {
+SPIRV_TOOLS_EXPORT spv_optimizer_options spvOptimizerOptionsCreate(void) {
   return new spv_optimizer_options_t();
 }
 


### PR DESCRIPTION
When building C code with gcc and the
-Wstrict-prototypes option, function declarations
and definitions that don't specify their argument
types generate warnings.  Functions that don't
take parameters need to specify (void) as their
parameter list, rather than leaving it empty.

Note this only applies to C, so only the functions
exported in C-compatible headers need fixing.  In
C++ functions can't be declared/defined without a
parameter list, so C++ can safely allow an empty
parameter list to imply (void).