### PR TITLE
Rename PCH macro to spvtools_pch to avoid conflicts with other projects.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,7 @@ if (${SPIRV_CHECK_CONTEXT})
 endif()
 
 # Precompiled header macro. Parameters are source file list and filename for pch cpp file.
-macro(PCH SRCS PCHPREFIX)
+macro(spvtools_pch SRCS PCHPREFIX)
   if(MSVC AND CMAKE_GENERATOR MATCHES "^Visual Studio")
     set(PCH_NAME "$(IntDir)\\${PCHPREFIX}.pch")
     # make source files use/depend on PCH_NAME
@@ -222,7 +222,7 @@ macro(PCH SRCS PCHPREFIX)
     set_source_files_properties("${PCHPREFIX}.cpp" PROPERTIES COMPILE_FLAGS "/Yc${PCHPREFIX}.h /Fp${PCH_NAME} /Zm300" OBJECT_OUTPUTS "${PCH_NAME}")
     list(APPEND ${SRCS} "${PCHPREFIX}.cpp")
   endif()
-endmacro(PCH)
+endmacro(spvtools_pch)
 
 add_subdirectory(external)
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -345,7 +345,7 @@ set_source_files_properties(
   ${CMAKE_CURRENT_SOURCE_DIR}/software_version.cpp
   PROPERTIES OBJECT_DEPENDS "${SPIRV_TOOLS_BUILD_VERSION_INC}")
 
-PCH(SPIRV_SOURCES pch_source)
+spvtools_pch(SPIRV_SOURCES pch_source)
 
 add_library(${SPIRV_TOOLS} ${SPIRV_SOURCES})
 spvtools_default_compile_options(${SPIRV_TOOLS})

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -190,7 +190,7 @@ if(MSVC)
   add_definitions(/MP4)
 endif()
 
-PCH(SPIRV_TOOLS_OPT_SOURCES pch_source_opt)
+spvtools_pch(SPIRV_TOOLS_OPT_SOURCES pch_source_opt)
 
 add_library(SPIRV-Tools-opt ${SPIRV_TOOLS_OPT_SOURCES})
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,7 +37,7 @@ function(add_spvtools_unittest)
     set(target test_${ARG_TARGET})
     set(SRC_COPY ${ARG_SRCS})
     if (DEFINED ARG_PCH_FILE)
-      PCH(SRC_COPY ${ARG_PCH_FILE})
+      spvtools_pch(SRC_COPY ${ARG_PCH_FILE})
     endif()
     add_executable(${target} ${SRC_COPY})
     spvtools_default_compile_options(${target})
@@ -151,7 +151,7 @@ set(TEST_SOURCES
   unit_spirv.cpp
 )
 
-PCH(TEST_SOURCES pch_test)
+spvtools_pch(TEST_SOURCES pch_test)
 
 add_spvtools_unittest(
   TARGET spirv_unit_tests

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -84,5 +84,6 @@ add_spvtools_unittest(TARGET opt
        vector_dce_test.cpp
        workaround1209_test.cpp
   LIBS SPIRV-Tools-opt
+  PCH_FILE pch_test_opt
 )
 

--- a/test/opt/pch_test_opt.cpp
+++ b/test/opt/pch_test_opt.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2018 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "pch_test_opt.h"

--- a/test/opt/pch_test_opt.h
+++ b/test/opt/pch_test_opt.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2018 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gmock/gmock.h"
+#include "source/opt/iterator.h"
+#include "source/opt/loop_dependence.h"
+#include "source/opt/loop_descriptor.h"
+#include "source/opt/pass.h"
+#include "source/opt/scalar_analysis.h"
+#include "source/opt/tree_iterator.h"
+#include "test/opt/assembly_builder.h"
+#include "test/opt/function_utils.h"
+#include "test/opt/pass_fixture.h"
+#include "test/opt/pass_utils.h"


### PR DESCRIPTION
When trying to pull precompiled header support into glslang I realized that the macro names conflict and since they have slightly different behavior they need to have different names. This PR changes the name to match the naming convention for the other spvtools macros.

Also add pch to test/opt. Not sure how I missed this, or if it was lost in one of the cleanups.