### PR TITLE
Remove asserts around environment determination.

### DIFF
--- a/source/ext_inst.cpp
+++ b/source/ext_inst.cpp
@@ -14,7 +14,6 @@
 
 #include "source/ext_inst.h"
 
-#include <cassert>
 #include <cstring>
 
 // DebugInfo extended instruction set.
@@ -85,7 +84,6 @@ spv_result_t spvExtInstTableGet(spv_ext_inst_table* pExtInstTable,
       *pExtInstTable = &kTable_1_0;
       return SPV_SUCCESS;
     default:
-      assert(0 && "Unknown spv_target_env in spvExtInstTableGet()");
       return SPV_ERROR_INVALID_TABLE;
   }
 }

--- a/source/spirv_target_env.cpp
+++ b/source/spirv_target_env.cpp
@@ -14,7 +14,6 @@
 
 #include "source/spirv_target_env.h"
 
-#include <cassert>
 #include <cstring>
 
 #include "source/spirv_constant.h"
@@ -63,7 +62,6 @@ const char* spvTargetEnvDescription(spv_target_env env) {
     case SPV_ENV_WEBGPU_0:
       return "SPIR-V 1.3 (under WIP WebGPU semantics)";
   }
-  assert(0 && "Unhandled SPIR-V target environment");
   return "";
 }
 
@@ -94,7 +92,6 @@ uint32_t spvVersionForTargetEnv(spv_target_env env) {
     case SPV_ENV_WEBGPU_0:
       return SPV_SPIRV_VERSION_WORD(1, 3);
   }
-  assert(0 && "Unhandled SPIR-V target environment");
   return SPV_SPIRV_VERSION_WORD(0, 0);
 }
 


### PR DESCRIPTION
This CL removes several asserts around determining the SPIR-V
environment. In each case we already return a default value if
assertions are compiled out, so just return the default value.