### PR TITLE
Don't assert on void function parameters.

### DIFF
--- a/source/opt/types.cpp
+++ b/source/opt/types.cpp
@@ -548,20 +548,10 @@ void Pointer::GetExtraHashWords(std::vector<uint32_t>* words,
 void Pointer::SetPointeeType(const Type* type) { pointee_type_ = type; }
 
 Function::Function(Type* ret_type, const std::vector<const Type*>& params)
-    : Type(kFunction), return_type_(ret_type), param_types_(params) {
-  for (auto* t : params) {
-    (void)t;
-    assert(!t->AsVoid());
-  }
-}
+    : Type(kFunction), return_type_(ret_type), param_types_(params) {}
 
 Function::Function(Type* ret_type, std::vector<const Type*>& params)
-    : Type(kFunction), return_type_(ret_type), param_types_(params) {
-  for (auto* t : params) {
-    (void)t;
-    assert(!t->AsVoid());
-  }
-}
+    : Type(kFunction), return_type_(ret_type), param_types_(params) {}
 
 bool Function::IsSameImpl(const Type* that, IsSameCache* seen) const {
   const Function* ft = that->AsFunction();


### PR DESCRIPTION
The type manager in spirv-opt currently asserts if a function parameter
has type void.  It is not exactly clear from the spec that this is
disallowed, even if it probably will be disallowed.  In either case,
asserts should be used to verify assumptions that will actually make a
difference to the code.  As far as the optimizer is concerned, a void
parameter does not matter.  I don't see the point of the assert.  I'll
just remove it and let the validator decide whether to accept it or not.

No test was added because it is not clear that it is legal, and should
not force us to accept it in the future unless the spec make it clear
that it is legal.

Fixes crbug.com/903088.