### PR TITLE
Instruction::GetBaseAddress to handle OpPtrAccessChain

### DIFF
--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -156,6 +156,7 @@ bool Instruction::IsReadOnlyLoad() const {
 
 Instruction* Instruction::GetBaseAddress() const {
   assert((IsLoad() || opcode() == SpvOpStore || opcode() == SpvOpAccessChain ||
+          opcode() == SpvOpPtrAccessChain ||
           opcode() == SpvOpInBoundsAccessChain || opcode() == SpvOpCopyObject ||
           opcode() == SpvOpImageTexelPointer) &&
          "GetBaseAddress should only be called on instructions that take a "
@@ -187,6 +188,7 @@ Instruction* Instruction::GetBaseAddress() const {
     case SpvOpStore:
     case SpvOpAccessChain:
     case SpvOpInBoundsAccessChain:
+    case SpvOpPtrAccessChain:
     case SpvOpImageTexelPointer:
     case SpvOpCopyObject:
       // A load or store through a pointer.

--- a/test/opt/instruction_test.cpp
+++ b/test/opt/instruction_test.cpp
@@ -622,6 +622,35 @@ TEST_F(GetBaseTest, SampleImage) {
   EXPECT_TRUE(load->GetBaseAddress() == base);
 }
 
+TEST_F(GetBaseTest, PtrAccessChain) {
+  const std::string text = R"(
+               OpCapability VariablePointers
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %1 "PSMain" %2
+               OpExecutionMode %1 OriginUpperLeft
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+        %int = OpTypeInt 32 8388353
+      %int_0 = OpConstant %int 0
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+          %2 = OpVariable %_ptr_Function_v4float Input
+          %1 = OpFunction %void None %4
+         %10 = OpLabel
+         %11 = OpPtrAccessChain %_ptr_Function_v4float %2 %int_0
+         %12 = OpLoad %v4float %11
+               OpReturn
+               OpFunctionEnd
+)";
+
+  std::unique_ptr<IRContext> context =
+      BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text);
+  Instruction* load = context->get_def_use_mgr()->GetDef(12);
+  Instruction* base = context->get_def_use_mgr()->GetDef(2);
+  EXPECT_TRUE(load->GetBaseAddress() == base);
+}
+
 TEST_F(GetBaseTest, ImageRead) {
   const std::string text = R"(
                OpCapability Shader


### PR DESCRIPTION
That function currently only handled OpPtrAccessChain if it was in the
middle of the chain, but not at the start.  Fixing that up.

Fixes crbug.com/905271.