### PR TITLE
Fix Instruction::IsFloatingPointFoldingAllowed()

### DIFF
--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -513,7 +513,7 @@ bool Instruction::IsFloatingPointFoldingAllowed() const {
 
   bool is_nocontract = false;
   context_->get_decoration_mgr()->WhileEachDecoration(
-      opcode_, SpvDecorationNoContraction,
+      result_id(), SpvDecorationNoContraction,
       [&is_nocontract](const Instruction&) {
         is_nocontract = true;
         return false;


### PR DESCRIPTION
Was looking for decorations based on opcode. Should use result_id.