### PR TITLE
Initial commit for spirv-reduce.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ compile_commands.json
 # Vim
 [._]*.s[a-w][a-z]
 *~
+
+# C-Lion
+.idea
+cmake-build-debug

--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -551,17 +551,16 @@ SPIRV_TOOLS_EXPORT void spvOptimizerOptionsSetMaxIdBound(
 SPIRV_TOOLS_EXPORT spv_reducer_options spvReducerOptionsCreate();
 
 // Destroys the given reducer options object.
-SPIRV_TOOLS_EXPORT void spvReducerOptionsDestroy(
-        spv_reducer_options options);
+SPIRV_TOOLS_EXPORT void spvReducerOptionsDestroy(spv_reducer_options options);
 
 // Records the maximum number of reduction steps that should run before the
 // reducer gives up.
 SPIRV_TOOLS_EXPORT void spvReducerOptionsSetStepLimit(
-        spv_reducer_options options, uint32_t step_limit);
+    spv_reducer_options options, uint32_t step_limit);
 
 // Sets seed for random number generation.
-SPIRV_TOOLS_EXPORT void spvReducerOptionsSetSeed(
-        spv_reducer_options options, uint32_t seed);
+SPIRV_TOOLS_EXPORT void spvReducerOptionsSetSeed(spv_reducer_options options,
+                                                 uint32_t seed);
 
 // Encodes the given SPIR-V assembly text to its binary representation. The
 // length parameter specifies the number of bytes for text. Encoded binary will

--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -368,6 +368,8 @@ typedef struct spv_validator_options_t spv_validator_options_t;
 
 typedef struct spv_optimizer_options_t spv_optimizer_options_t;
 
+typedef struct spv_reducer_options_t spv_reducer_options_t;
+
 // Type Definitions
 
 typedef spv_const_binary_t* spv_const_binary;
@@ -381,6 +383,8 @@ typedef spv_validator_options_t* spv_validator_options;
 typedef const spv_validator_options_t* spv_const_validator_options;
 typedef spv_optimizer_options_t* spv_optimizer_options;
 typedef const spv_optimizer_options_t* spv_const_optimizer_options;
+typedef spv_reducer_options_t* spv_reducer_options;
+typedef const spv_reducer_options_t* spv_const_reducer_options;
 
 // Platform API
 
@@ -518,6 +522,24 @@ SPIRV_TOOLS_EXPORT void spvOptimizerOptionsSetValidatorOptions(
 // Records the maximum possible value for the id bound.
 SPIRV_TOOLS_EXPORT void spvOptimizerOptionsSetMaxIdBound(
     spv_optimizer_options options, uint32_t val);
+
+// Creates a reducer options object with default options. Returns a valid
+// options object. The object remains valid until it is passed into
+// |spvReducerOptionsDestroy|.
+SPIRV_TOOLS_EXPORT spv_reducer_options spvReducerOptionsCreate();
+
+// Destroys the given reducer options object.
+SPIRV_TOOLS_EXPORT void spvReducerOptionsDestroy(
+        spv_reducer_options options);
+
+// Records the maximum number of reduction steps that should run before the
+// reducer gives up.
+SPIRV_TOOLS_EXPORT void spvReducerOptionsSetStepLimit(
+        spv_reducer_options options, uint32_t step_limit);
+
+// Sets seed for random number generation.
+SPIRV_TOOLS_EXPORT void spvReducerOptionsSetSeed(
+        spv_reducer_options options, uint32_t seed);
 
 // Encodes the given SPIR-V assembly text to its binary representation. The
 // length parameter specifies the number of bytes for text. Encoded binary will

--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -136,6 +136,30 @@ class OptimizerOptions {
   spv_optimizer_options options_;
 };
 
+// A C++ wrapper around a reducer options object.
+class ReducerOptions {
+public:
+  ReducerOptions() : options_(spvReducerOptionsCreate()) {}
+  ~ReducerOptions() { spvReducerOptionsDestroy(options_); }
+
+  // Allow implicit conversion to the underlying object.
+  operator spv_reducer_options() const { return options_; }
+
+  // Records the maximum number of reduction steps that should
+  // run before the reducer gives up.
+  void set_step_limit(uint32_t step_limit) {
+    spvReducerOptionsSetStepLimit(options_, step_limit);
+  }
+
+  // Sets a seed to be used for random number generation.
+  void set_seed(uint32_t seed) {
+    spvReducerOptionsSetSeed(options_, seed);
+  }
+
+private:
+  spv_reducer_options options_;
+};
+
 // C++ interface for SPIRV-Tools functionalities. It wraps the context
 // (including target environment and the corresponding SPIR-V grammar) and
 // provides methods for assembling, disassembling, and validating.

--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -146,7 +146,7 @@ class OptimizerOptions {
 
 // A C++ wrapper around a reducer options object.
 class ReducerOptions {
-public:
+ public:
   ReducerOptions() : options_(spvReducerOptionsCreate()) {}
   ~ReducerOptions() { spvReducerOptionsDestroy(options_); }
 
@@ -160,11 +160,9 @@ public:
   }
 
   // Sets a seed to be used for random number generation.
-  void set_seed(uint32_t seed) {
-    spvReducerOptionsSetSeed(options_, seed);
-  }
+  void set_seed(uint32_t seed) { spvReducerOptionsSetSeed(options_, seed); }
 
-private:
+ private:
   spv_reducer_options options_;
 };
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -216,6 +216,7 @@ set_source_files_properties(
 
 add_subdirectory(comp)
 add_subdirectory(opt)
+add_subdirectory(reduce)
 add_subdirectory(link)
 
 set(SPIRV_SOURCES
@@ -253,6 +254,7 @@ set(SPIRV_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/spirv_definition.h
   ${CMAKE_CURRENT_SOURCE_DIR}/spirv_endian.h
   ${CMAKE_CURRENT_SOURCE_DIR}/spirv_optimizer_options.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/spirv_reducer_options.h
   ${CMAKE_CURRENT_SOURCE_DIR}/spirv_target_env.h
   ${CMAKE_CURRENT_SOURCE_DIR}/spirv_validator_options.h
   ${CMAKE_CURRENT_SOURCE_DIR}/table.h
@@ -280,6 +282,7 @@ set(SPIRV_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/software_version.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/spirv_endian.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/spirv_optimizer_options.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/spirv_reducer_options.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/spirv_target_env.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/spirv_validator_options.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/table.cpp

--- a/source/reduce/CMakeLists.txt
+++ b/source/reduce/CMakeLists.txt
@@ -1,0 +1,68 @@
+# Copyright (c) 2018 Google Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set(SPIRV_TOOLS_REDUCE_SOURCES
+        change_operand_reduction_opportunity.h
+        operand_to_const_reduction_pass.h
+        reducer.h
+        reduction_opportunity.h
+        reduction_pass.h
+        remove_instruction_reduction_opportunity.h
+        remove_unreferenced_instruction_reduction_pass.h
+
+        change_operand_reduction_opportunity.cpp
+        operand_to_const_reduction_pass.cpp
+        reducer.cpp
+        reduction_opportunity.cpp
+        reduction_pass.cpp
+        remove_instruction_reduction_opportunity.cpp
+        remove_unreferenced_instruction_reduction_pass.cpp
+        )
+
+if(MSVC)
+    # Enable parallel builds across four cores for this lib
+    add_definitions(/MP4)
+
+    # Enable precompiled header
+    if (CMAKE_GENERATOR MATCHES "^Visual Studio")
+        set(PCH_NAME "$(IntDir)\\pch.pch")
+    else()
+        set(PCH_NAME "pch.pch")
+    endif()
+    set_source_files_properties(${SPIRV_TOOLS_REDUCE_SOURCES} PROPERTIES COMPILE_FLAGS "/Yupch.h /FIpch.h /Fp${PCH_NAME} /Zm300" OBJECT_DEPENDS "${PCH_NAME}")
+    set_source_files_properties(pch.cpp PROPERTIES COMPILE_FLAGS "/Ycpch.h /Fp${PCH_NAME} /Zm300" OBJECT_OUTPUTS "${PCH_NAME}")
+    list(APPEND SPIRV_TOOLS_REDUCE_SOURCES "pch.cpp")
+endif()
+
+add_library(SPIRV-Tools-reduce ${SPIRV_TOOLS_REDUCE_SOURCES})
+
+spvtools_default_compile_options(SPIRV-Tools-reduce)
+target_include_directories(SPIRV-Tools-reduce
+        PUBLIC ${spirv-tools_SOURCE_DIR}/include
+        PUBLIC ${SPIRV_HEADER_INCLUDE_DIR}
+        PRIVATE ${spirv-tools_BINARY_DIR}
+        )
+# The reducer reuses a lot of functionality from the SPIRV-Tools library.
+target_link_libraries(SPIRV-Tools-reduce
+        PUBLIC ${SPIRV_TOOLS}
+        PUBLIC SPIRV-Tools-opt)
+
+set_property(TARGET SPIRV-Tools-reduce PROPERTY FOLDER "SPIRV-Tools libraries")
+spvtools_check_symbol_exports(SPIRV-Tools-reduce)
+
+if(ENABLE_SPIRV_TOOLS_INSTALL)
+    install(TARGETS SPIRV-Tools-reduce
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif(ENABLE_SPIRV_TOOLS_INSTALL)

--- a/source/reduce/CMakeLists.txt
+++ b/source/reduce/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Google Inc.
+# Copyright (c) 2018 Google LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/reduce/CMakeLists.txt
+++ b/source/reduce/CMakeLists.txt
@@ -30,39 +30,31 @@ set(SPIRV_TOOLS_REDUCE_SOURCES
         )
 
 if(MSVC)
-    # Enable parallel builds across four cores for this lib
-    add_definitions(/MP4)
-
-    # Enable precompiled header
-    if (CMAKE_GENERATOR MATCHES "^Visual Studio")
-        set(PCH_NAME "$(IntDir)\\pch.pch")
-    else()
-        set(PCH_NAME "pch.pch")
-    endif()
-    set_source_files_properties(${SPIRV_TOOLS_REDUCE_SOURCES} PROPERTIES COMPILE_FLAGS "/Yupch.h /FIpch.h /Fp${PCH_NAME} /Zm300" OBJECT_DEPENDS "${PCH_NAME}")
-    set_source_files_properties(pch.cpp PROPERTIES COMPILE_FLAGS "/Ycpch.h /Fp${PCH_NAME} /Zm300" OBJECT_OUTPUTS "${PCH_NAME}")
-    list(APPEND SPIRV_TOOLS_REDUCE_SOURCES "pch.cpp")
+  # Enable parallel builds across four cores for this lib
+  add_definitions(/MP4)
 endif()
+
+spvtools_pch(SPIRV_TOOLS_REDUCE_SOURCES pch_source_reduce)
 
 add_library(SPIRV-Tools-reduce ${SPIRV_TOOLS_REDUCE_SOURCES})
 
 spvtools_default_compile_options(SPIRV-Tools-reduce)
 target_include_directories(SPIRV-Tools-reduce
-        PUBLIC ${spirv-tools_SOURCE_DIR}/include
-        PUBLIC ${SPIRV_HEADER_INCLUDE_DIR}
-        PRIVATE ${spirv-tools_BINARY_DIR}
-        )
+  PUBLIC ${spirv-tools_SOURCE_DIR}/include
+  PUBLIC ${SPIRV_HEADER_INCLUDE_DIR}
+  PRIVATE ${spirv-tools_BINARY_DIR}
+)
 # The reducer reuses a lot of functionality from the SPIRV-Tools library.
 target_link_libraries(SPIRV-Tools-reduce
-        PUBLIC ${SPIRV_TOOLS}
-        PUBLIC SPIRV-Tools-opt)
+  PUBLIC ${SPIRV_TOOLS}
+  PUBLIC SPIRV-Tools-opt)
 
 set_property(TARGET SPIRV-Tools-reduce PROPERTY FOLDER "SPIRV-Tools libraries")
 spvtools_check_symbol_exports(SPIRV-Tools-reduce)
 
 if(ENABLE_SPIRV_TOOLS_INSTALL)
-    install(TARGETS SPIRV-Tools-reduce
-            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  install(TARGETS SPIRV-Tools-reduce
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif(ENABLE_SPIRV_TOOLS_INSTALL)

--- a/source/reduce/change_operand_reduction_opportunity.cpp
+++ b/source/reduce/change_operand_reduction_opportunity.cpp
@@ -20,7 +20,8 @@ namespace reduce {
 bool ChangeOperandReductionOpportunity::PreconditionHolds() {
   // Check that the instruction still has the original operand.
   return inst_->NumOperands() > operand_index_ &&
-         inst_->GetOperand(operand_index_).words[0] == original_id_;
+         inst_->GetOperand(operand_index_).words[0] == original_id_ &&
+         inst_->GetOperand(operand_index_).type == original_type_;
 }
 
 void ChangeOperandReductionOpportunity::Apply() {

--- a/source/reduce/change_operand_reduction_opportunity.cpp
+++ b/source/reduce/change_operand_reduction_opportunity.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Google Inc.
+// Copyright (c) 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/reduce/change_operand_reduction_opportunity.cpp
+++ b/source/reduce/change_operand_reduction_opportunity.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "change_operand_reduction_opportunity.h"
+
+namespace spvtools {
+namespace reduce {
+
+bool ChangeOperandReductionOpportunity::PreconditionHolds() {
+  // Check that the instruction still has the original operand.
+  return inst_->NumOperands() > operand_index_ &&
+         inst_->GetOperand(operand_index_).words[0] == original_id_;
+}
+
+void ChangeOperandReductionOpportunity::Apply() {
+  inst_->SetOperand(operand_index_, {new_id_});
+}
+
+}  // namespace reduce
+}  // namespace spvtools

--- a/source/reduce/change_operand_reduction_opportunity.h
+++ b/source/reduce/change_operand_reduction_opportunity.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_REDUCE_CHANGE_OPERAND_REDUCTION_OPPORTUNITY_H_
+#define SOURCE_REDUCE_CHANGE_OPERAND_REDUCTION_OPPORTUNITY_H_
+
+#include "reduction_opportunity.h"
+#include "source/opt/instruction.h"
+
+namespace spvtools {
+namespace reduce {
+
+using namespace opt;
+
+class ChangeOperandReductionOpportunity : public ReductionOpportunity {
+ public:
+  ChangeOperandReductionOpportunity(Instruction* inst, uint32_t operand_index,
+                                    uint32_t original_id, uint32_t new_id)
+      : inst_(inst),
+        operand_index_(operand_index),
+        original_id_(original_id),
+        new_id_(new_id) {}
+
+  bool PreconditionHolds() override;
+
+ protected:
+  void Apply() override;
+
+ private:
+  Instruction* inst_;
+  uint32_t operand_index_;
+  uint32_t original_id_;
+  uint32_t new_id_;
+};
+
+}  // namespace reduce
+}  // namespace spvtools
+
+#endif  // SOURCE_REDUCE_CHANGE_OPERAND_REDUCTION_OPPORTUNITY_H_

--- a/source/reduce/change_operand_reduction_opportunity.h
+++ b/source/reduce/change_operand_reduction_opportunity.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Google Inc.
+// Copyright (c) 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/reduce/change_operand_reduction_opportunity.h
+++ b/source/reduce/change_operand_reduction_opportunity.h
@@ -17,6 +17,7 @@
 
 #include "reduction_opportunity.h"
 #include "source/opt/instruction.h"
+#include "spirv-tools/libspirv.h"
 
 namespace spvtools {
 namespace reduce {
@@ -34,6 +35,7 @@ class ChangeOperandReductionOpportunity : public ReductionOpportunity {
       : inst_(inst),
         operand_index_(operand_index),
         original_id_(original_id),
+        original_type_(inst->GetOperand(operand_index).type),
         new_id_(new_id) {}
 
   // Determines whether the opportunity can be applied; it may have been viable when discovered but later disabled
@@ -48,6 +50,7 @@ class ChangeOperandReductionOpportunity : public ReductionOpportunity {
   Instruction* inst_;
   uint32_t operand_index_;
   uint32_t original_id_;
+  spv_operand_type_t original_type_;
   uint32_t new_id_;
 };
 

--- a/source/reduce/change_operand_reduction_opportunity.h
+++ b/source/reduce/change_operand_reduction_opportunity.h
@@ -28,7 +28,6 @@ using namespace opt;
 // other id.
 class ChangeOperandReductionOpportunity : public ReductionOpportunity {
  public:
-
   // Constructs the opportunity to replace operand |operand_index| of |inst|
   // with |new_id|.
   ChangeOperandReductionOpportunity(Instruction* inst, uint32_t operand_index,

--- a/source/reduce/change_operand_reduction_opportunity.h
+++ b/source/reduce/change_operand_reduction_opportunity.h
@@ -24,11 +24,13 @@ namespace reduce {
 
 using namespace opt;
 
-// Captures the opportunity to change an id operand of an instruction to some other id.
+// Captures the opportunity to change an id operand of an instruction to some
+// other id.
 class ChangeOperandReductionOpportunity : public ReductionOpportunity {
  public:
 
-  // Constructs the opportunity to replace operand |operand_index| of |inst| with |new_id|.
+  // Constructs the opportunity to replace operand |operand_index| of |inst|
+  // with |new_id|.
   ChangeOperandReductionOpportunity(Instruction* inst, uint32_t operand_index,
                                     uint32_t new_id)
       : inst_(inst),
@@ -37,8 +39,9 @@ class ChangeOperandReductionOpportunity : public ReductionOpportunity {
         original_type_(inst->GetOperand(operand_index).type),
         new_id_(new_id) {}
 
-  // Determines whether the opportunity can be applied; it may have been viable when discovered but later disabled
-  // by the application of some other reduction opportunity.
+  // Determines whether the opportunity can be applied; it may have been viable
+  // when discovered but later disabled by the application of some other
+  // reduction opportunity.
   bool PreconditionHolds() override;
 
  protected:

--- a/source/reduce/change_operand_reduction_opportunity.h
+++ b/source/reduce/change_operand_reduction_opportunity.h
@@ -23,8 +23,12 @@ namespace reduce {
 
 using namespace opt;
 
+// Captures the opportunity to change an id operand of an instruction to some other id.
 class ChangeOperandReductionOpportunity : public ReductionOpportunity {
  public:
+
+  // Constructs the opportunity to replace operand |operand_index| of |inst| with |new_id|, given that it was
+  // previously set to |original_id|.
   ChangeOperandReductionOpportunity(Instruction* inst, uint32_t operand_index,
                                     uint32_t original_id, uint32_t new_id)
       : inst_(inst),
@@ -32,9 +36,12 @@ class ChangeOperandReductionOpportunity : public ReductionOpportunity {
         original_id_(original_id),
         new_id_(new_id) {}
 
+  // Determines whether the opportunity can be applied; it may have been viable when discovered but later disabled
+  // by the application of some other reduction opportunity.
   bool PreconditionHolds() override;
 
  protected:
+  // Apply the change of operand.
   void Apply() override;
 
  private:

--- a/source/reduce/change_operand_reduction_opportunity.h
+++ b/source/reduce/change_operand_reduction_opportunity.h
@@ -28,13 +28,12 @@ using namespace opt;
 class ChangeOperandReductionOpportunity : public ReductionOpportunity {
  public:
 
-  // Constructs the opportunity to replace operand |operand_index| of |inst| with |new_id|, given that it was
-  // previously set to |original_id|.
+  // Constructs the opportunity to replace operand |operand_index| of |inst| with |new_id|.
   ChangeOperandReductionOpportunity(Instruction* inst, uint32_t operand_index,
-                                    uint32_t original_id, uint32_t new_id)
+                                    uint32_t new_id)
       : inst_(inst),
         operand_index_(operand_index),
-        original_id_(original_id),
+        original_id_(inst_->GetOperand(operand_index_).words[0]),
         original_type_(inst->GetOperand(operand_index).type),
         new_id_(new_id) {}
 
@@ -47,11 +46,11 @@ class ChangeOperandReductionOpportunity : public ReductionOpportunity {
   void Apply() override;
 
  private:
-  Instruction* inst_;
-  uint32_t operand_index_;
-  uint32_t original_id_;
-  spv_operand_type_t original_type_;
-  uint32_t new_id_;
+  Instruction* const inst_;
+  const uint32_t operand_index_;
+  const uint32_t original_id_;
+  const spv_operand_type_t original_type_;
+  const uint32_t new_id_;
 };
 
 }  // namespace reduce

--- a/source/reduce/operand_to_const_reduction_pass.cpp
+++ b/source/reduce/operand_to_const_reduction_pass.cpp
@@ -27,24 +27,26 @@ OperandToConstReductionPass::GetAvailableOpportunities(
   std::vector<std::unique_ptr<ReductionOpportunity>> result;
   assert(result.empty());
 
-  // We first loop over all constants.  This means that all the reduction opportunities
-  // to replace an operand with a particular constant will be contiguous, and in particular
-  // it means that multiple, incompatible reduction opportunities that try to replace the
-  // same operand with distinct constants are likely to be discontiguous.  This is good
-  // because the reducer works in the spirit of delta debugging and tries applying large
-  // contiguous blocks of opportunities early on, and we want to avoid having a large block
-  // of incompatible opportunities if possible.
+  // We first loop over all constants.  This means that all the reduction
+  // opportunities to replace an operand with a particular constant will be
+  // contiguous, and in particular it means that multiple, incompatible
+  // reduction opportunities that try to replace the same operand with distinct
+  // constants are likely to be discontiguous.  This is good because the
+  // reducer works in the spirit of delta debugging and tries applying large
+  // contiguous blocks of opportunities early on, and we want to avoid having a
+  // large block of incompatible opportunities if possible.
   for (const auto& constant : context->GetConstants()) {
     for (auto& function : *context->module()) {
       for (auto& block : function) {
         for (auto& inst : block) {
-          // We iterate through the operands using an explicit index (rather than using a
-          // lambda) so that we use said index in the construction of a
-          // ChangeOperandReductionOpportunity
+          // We iterate through the operands using an explicit index (rather
+          // than using a lambda) so that we use said index in the construction
+          // of a ChangeOperandReductionOpportunity
           for (uint32_t index = 0; index < inst.NumOperands(); index++) {
             const auto &operand = inst.GetOperand(index);
             if (spvIsIdType(operand.type)) {
-              if (operand.type == SPV_OPERAND_TYPE_RESULT_ID || operand.type == SPV_OPERAND_TYPE_TYPE_ID) {
+              if (operand.type == SPV_OPERAND_TYPE_RESULT_ID
+                  || operand.type == SPV_OPERAND_TYPE_TYPE_ID) {
                 continue;
               }
               const auto id = operand.words[0];

--- a/source/reduce/operand_to_const_reduction_pass.cpp
+++ b/source/reduce/operand_to_const_reduction_pass.cpp
@@ -36,7 +36,7 @@ OperandToConstReductionPass::GetAvailableOpportunities(
             if (operand.type == SPV_OPERAND_TYPE_ID) {
               const auto id = operand.words[0];
               auto def = context->get_def_use_mgr()->GetDef(id);
-              if (context->get_constant_mgr()->GetConstantFromInst(def)) {
+              if (spvOpcodeIsConstant(def->opcode())) {
                 // The argument is already a constant.
                 continue;
               }

--- a/source/reduce/operand_to_const_reduction_pass.cpp
+++ b/source/reduce/operand_to_const_reduction_pass.cpp
@@ -58,7 +58,7 @@ OperandToConstReductionPass::GetAvailableOpportunities(
                 if (constant->type_id() == type_id) {
                   result.push_back(
                           MakeUnique<ChangeOperandReductionOpportunity>(
-                                  &inst, index, id, constant->result_id()));
+                                  &inst, index, constant->result_id()));
                 }
               }
             }

--- a/source/reduce/operand_to_const_reduction_pass.cpp
+++ b/source/reduce/operand_to_const_reduction_pass.cpp
@@ -42,8 +42,11 @@ OperandToConstReductionPass::GetAvailableOpportunities(
           // lambda) so that we use said index in the construction of a
           // ChangeOperandReductionOpportunity
           for (uint32_t index = 0; index < inst.NumOperands(); index++) {
-            const auto& operand = inst.GetOperand(index);
-            if (operand.type == SPV_OPERAND_TYPE_ID) {
+            const auto &operand = inst.GetOperand(index);
+            if (spvIsIdType(operand.type)) {
+              if (operand.type == SPV_OPERAND_TYPE_RESULT_ID || operand.type == SPV_OPERAND_TYPE_TYPE_ID) {
+                continue;
+              }
               const auto id = operand.words[0];
               auto def = context->get_def_use_mgr()->GetDef(id);
               if (spvOpcodeIsConstant(def->opcode())) {
@@ -54,8 +57,8 @@ OperandToConstReductionPass::GetAvailableOpportunities(
               if (type_id) {
                 if (constant->type_id() == type_id) {
                   result.push_back(
-                      MakeUnique<ChangeOperandReductionOpportunity>(
-                          &inst, index, id, constant->result_id()));
+                          MakeUnique<ChangeOperandReductionOpportunity>(
+                                  &inst, index, id, constant->result_id()));
                 }
               }
             }

--- a/source/reduce/operand_to_const_reduction_pass.cpp
+++ b/source/reduce/operand_to_const_reduction_pass.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "operand_to_const_reduction_pass.h"
+#include "change_operand_reduction_opportunity.h"
+#include "source/opt/instruction.h"
+
+namespace spvtools {
+namespace reduce {
+
+using namespace opt;
+
+std::vector<std::unique_ptr<ReductionOpportunity>>
+OperandToConstReductionPass::GetAvailableOpportunities(
+    opt::IRContext* context) const {
+  std::vector<std::unique_ptr<ReductionOpportunity>> result;
+  assert(result.empty());
+  for (const auto& constant : context->GetConstants()) {
+    for (auto& function : *context->module()) {
+      for (auto& block : function) {
+        for (auto& inst : block) {
+          for (uint32_t i = 0; i < inst.NumOperands(); i++) {
+            const auto& operand = inst.GetOperand(i);
+            if (operand.type == SPV_OPERAND_TYPE_ID) {
+              const auto id = operand.words[0];
+              auto def = context->get_def_use_mgr()->GetDef(id);
+              if (context->get_constant_mgr()->GetConstantFromInst(def)) {
+                // The argument is already a constant.
+                continue;
+              }
+              auto type_id = def->type_id();
+              if (type_id) {
+                if (constant->type_id() == type_id) {
+                  result.push_back(
+                      MakeUnique<ChangeOperandReductionOpportunity>(
+                          &inst, i, id, constant->result_id()));
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return result;
+}
+
+std::string OperandToConstReductionPass::GetName() const {
+  return "OperandToConstReductionPass";
+}
+
+}  // namespace reduce
+}  // namespace spvtools

--- a/source/reduce/operand_to_const_reduction_pass.cpp
+++ b/source/reduce/operand_to_const_reduction_pass.cpp
@@ -27,6 +27,13 @@ OperandToConstReductionPass::GetAvailableOpportunities(
   std::vector<std::unique_ptr<ReductionOpportunity>> result;
   assert(result.empty());
 
+  // We first loop over all constants.  This means that all the reduction opportunities
+  // to replace an operand with a particular constant will be contiguous, and in particular
+  // it means that multiple, incompatible reduction opportunities that try to replace the
+  // same operand with distinct constants are likely to be discontiguous.  This is good
+  // because the reducer works in the spirit of delta debugging and tries applying large
+  // contiguous blocks of opportunities early on, and we want to avoid having a large block
+  // of incompatible opportunities if possible.
   for (const auto& constant : context->GetConstants()) {
     for (auto& function : *context->module()) {
       for (auto& block : function) {

--- a/source/reduce/operand_to_const_reduction_pass.cpp
+++ b/source/reduce/operand_to_const_reduction_pass.cpp
@@ -55,6 +55,12 @@ OperandToConstReductionPass::GetAvailableOpportunities(
                 // The argument is already a constant.
                 continue;
               }
+              if (def->opcode() == SpvOpFunction) {
+                // The argument refers to a function, e.g. the function called
+                // by OpFunctionCall; avoid replacing this with a constant of
+                // the function's return type.
+                continue;
+              }
               auto type_id = def->type_id();
               if (type_id) {
                 if (constant->type_id() == type_id) {

--- a/source/reduce/operand_to_const_reduction_pass.cpp
+++ b/source/reduce/operand_to_const_reduction_pass.cpp
@@ -43,10 +43,10 @@ OperandToConstReductionPass::GetAvailableOpportunities(
           // than using a lambda) so that we use said index in the construction
           // of a ChangeOperandReductionOpportunity
           for (uint32_t index = 0; index < inst.NumOperands(); index++) {
-            const auto &operand = inst.GetOperand(index);
+            const auto& operand = inst.GetOperand(index);
             if (spvIsIdType(operand.type)) {
-              if (operand.type == SPV_OPERAND_TYPE_RESULT_ID
-                  || operand.type == SPV_OPERAND_TYPE_TYPE_ID) {
+              if (operand.type == SPV_OPERAND_TYPE_RESULT_ID ||
+                  operand.type == SPV_OPERAND_TYPE_TYPE_ID) {
                 continue;
               }
               const auto id = operand.words[0];
@@ -65,8 +65,8 @@ OperandToConstReductionPass::GetAvailableOpportunities(
               if (type_id) {
                 if (constant->type_id() == type_id) {
                   result.push_back(
-                          MakeUnique<ChangeOperandReductionOpportunity>(
-                                  &inst, index, constant->result_id()));
+                      MakeUnique<ChangeOperandReductionOpportunity>(
+                          &inst, index, constant->result_id()));
                 }
               }
             }

--- a/source/reduce/operand_to_const_reduction_pass.cpp
+++ b/source/reduce/operand_to_const_reduction_pass.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Google Inc.
+// Copyright (c) 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ OperandToConstReductionPass::GetAvailableOpportunities(
     opt::IRContext* context) const {
   std::vector<std::unique_ptr<ReductionOpportunity>> result;
   assert(result.empty());
+
   for (const auto& constant : context->GetConstants()) {
     for (auto& function : *context->module()) {
       for (auto& block : function) {

--- a/source/reduce/operand_to_const_reduction_pass.cpp
+++ b/source/reduce/operand_to_const_reduction_pass.cpp
@@ -38,8 +38,11 @@ OperandToConstReductionPass::GetAvailableOpportunities(
     for (auto& function : *context->module()) {
       for (auto& block : function) {
         for (auto& inst : block) {
-          for (uint32_t i = 0; i < inst.NumOperands(); i++) {
-            const auto& operand = inst.GetOperand(i);
+          // We iterate through the operands using an explicit index (rather than using a
+          // lambda) so that we use said index in the construction of a
+          // ChangeOperandReductionOpportunity
+          for (uint32_t index = 0; index < inst.NumOperands(); index++) {
+            const auto& operand = inst.GetOperand(index);
             if (operand.type == SPV_OPERAND_TYPE_ID) {
               const auto id = operand.words[0];
               auto def = context->get_def_use_mgr()->GetDef(id);
@@ -52,7 +55,7 @@ OperandToConstReductionPass::GetAvailableOpportunities(
                 if (constant->type_id() == type_id) {
                   result.push_back(
                       MakeUnique<ChangeOperandReductionOpportunity>(
-                          &inst, i, id, constant->result_id()));
+                          &inst, index, id, constant->result_id()));
                 }
               }
             }

--- a/source/reduce/operand_to_const_reduction_pass.h
+++ b/source/reduce/operand_to_const_reduction_pass.h
@@ -20,16 +20,22 @@
 namespace spvtools {
 namespace reduce {
 
+// A reduction pass for turning id operands of instructions into ids of constants.  This reduces the extent to which
+// ids of non-constants are used, paving the way for instructions that generate them to be eliminated by other passes.
 class OperandToConstReductionPass : public ReductionPass {
  public:
+
+  // Creates the reduction pass in the context of the given target environment |target_env|
   explicit OperandToConstReductionPass(const spv_target_env target_env)
       : ReductionPass(target_env) {}
 
   ~OperandToConstReductionPass() override = default;
 
+  // The name of this pass.
   std::string GetName() const final;
 
  protected:
+  // Finds all opportunities for replacing an operand with a constant in the given module.
   std::vector<std::unique_ptr<ReductionOpportunity>> GetAvailableOpportunities(
       opt::IRContext* context) const final;
 

--- a/source/reduce/operand_to_const_reduction_pass.h
+++ b/source/reduce/operand_to_const_reduction_pass.h
@@ -20,12 +20,15 @@
 namespace spvtools {
 namespace reduce {
 
-// A reduction pass for turning id operands of instructions into ids of constants.  This reduces the extent to which
-// ids of non-constants are used, paving the way for instructions that generate them to be eliminated by other passes.
+// A reduction pass for turning id operands of instructions into ids of
+// constants.  This reduces the extent to which ids of non-constants are used,
+// paving the way for instructions that generate them to be eliminated by other
+// passes.
 class OperandToConstReductionPass : public ReductionPass {
  public:
 
-  // Creates the reduction pass in the context of the given target environment |target_env|
+  // Creates the reduction pass in the context of the given target environment
+  // |target_env|
   explicit OperandToConstReductionPass(const spv_target_env target_env)
       : ReductionPass(target_env) {}
 
@@ -35,7 +38,8 @@ class OperandToConstReductionPass : public ReductionPass {
   std::string GetName() const final;
 
  protected:
-  // Finds all opportunities for replacing an operand with a constant in the given module.
+  // Finds all opportunities for replacing an operand with a constant in the
+  // given module.
   std::vector<std::unique_ptr<ReductionOpportunity>> GetAvailableOpportunities(
       opt::IRContext* context) const final;
 

--- a/source/reduce/operand_to_const_reduction_pass.h
+++ b/source/reduce/operand_to_const_reduction_pass.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Google Inc.
+// Copyright (c) 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/reduce/operand_to_const_reduction_pass.h
+++ b/source/reduce/operand_to_const_reduction_pass.h
@@ -26,7 +26,6 @@ namespace reduce {
 // passes.
 class OperandToConstReductionPass : public ReductionPass {
  public:
-
   // Creates the reduction pass in the context of the given target environment
   // |target_env|
   explicit OperandToConstReductionPass(const spv_target_env target_env)

--- a/source/reduce/operand_to_const_reduction_pass.h
+++ b/source/reduce/operand_to_const_reduction_pass.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_REDUCE_OPERAND_TO_CONST_REDUCTION_PASS_H_
+#define SOURCE_REDUCE_OPERAND_TO_CONST_REDUCTION_PASS_H_
+
+#include "reduction_pass.h"
+
+namespace spvtools {
+namespace reduce {
+
+class OperandToConstReductionPass : public ReductionPass {
+ public:
+  explicit OperandToConstReductionPass(const spv_target_env target_env)
+      : ReductionPass(target_env) {}
+
+  ~OperandToConstReductionPass() override = default;
+
+  std::string GetName() const final;
+
+ protected:
+  std::vector<std::unique_ptr<ReductionOpportunity>> GetAvailableOpportunities(
+      opt::IRContext* context) const final;
+
+ private:
+};
+
+}  // namespace reduce
+}  // namespace spvtools
+
+#endif  // SOURCE_REDUCE_OPERAND_TO_CONST_REDUCTION_PASS_H_

--- a/source/reduce/reducer.cpp
+++ b/source/reduce/reducer.cpp
@@ -59,15 +59,12 @@ bool Reducer::Run(std::vector<uint32_t>&& binary_in,
                   spv_const_reducer_options options) const {
   impl_->current_pass = impl_->passes.begin();
 
-  uint32_t current_step = 0;
-
   std::vector<uint32_t> current = std::move(binary_in);
 
   // Initial state should be interesting.
   assert(impl_->is_interesting(current));
 
-  for (;;) {
-    assert(current_step < options->step_limit);
+  for (uint32_t current_step = 0; current_step < options->step_limit; ++current_step) {
 
     {
       std::string msg = "Reduction step ";
@@ -91,11 +88,6 @@ bool Reducer::Run(std::vector<uint32_t>&& binary_in,
       current = std::move(reduction_step_result);
     } else {
       impl_->consumer(SPV_MSG_INFO, nullptr, {}, "Reduction step failed.");
-    }
-
-    ++current_step;
-    if (current_step == options->step_limit) {
-      break;
     }
   }
 

--- a/source/reduce/reducer.cpp
+++ b/source/reduce/reducer.cpp
@@ -29,7 +29,7 @@ struct Reducer::Impl {
 
   const spv_target_env target_env;  // Target environment.
   MessageConsumer consumer;         // Message consumer.
-  InterestingFunction is_interesting;
+  InterestingnessFunction interestingness_function;
   std::vector<std::unique_ptr<ReductionPass>> passes;
   std::vector<std::unique_ptr<ReductionPass>>::iterator current_pass;
   bool made_progress_this_round;
@@ -49,9 +49,9 @@ void Reducer::SetMessageConsumer(MessageConsumer c) {
   impl_->consumer = std::move(c);
 }
 
-void Reducer::SetInterestingFunction(
-    Reducer::InterestingFunction interestingFunction) {
-  impl_->is_interesting = std::move(interestingFunction);
+void Reducer::SetInterestingnessFunction(
+        Reducer::InterestingnessFunction interestingness_function) {
+  impl_->interestingness_function = std::move(interestingness_function);
 }
 
 bool Reducer::Run(std::vector<uint32_t>&& binary_in,
@@ -62,7 +62,7 @@ bool Reducer::Run(std::vector<uint32_t>&& binary_in,
   std::vector<uint32_t> current = std::move(binary_in);
 
   // Initial state should be interesting.
-  assert(impl_->is_interesting(current));
+  assert(impl_->interestingness_function(current));
 
   for (uint32_t current_step = 0; current_step < options->step_limit; ++current_step) {
 
@@ -78,7 +78,7 @@ bool Reducer::Run(std::vector<uint32_t>&& binary_in,
       break;
     }
 
-    if (impl_->is_interesting(reduction_step_result)) {
+    if (impl_->interestingness_function(reduction_step_result)) {
       // Interesting:
       impl_->made_progress_this_round = true;
       impl_->consumer(SPV_MSG_INFO, nullptr, {}, "Reduction step succeeded.");

--- a/source/reduce/reducer.cpp
+++ b/source/reduce/reducer.cpp
@@ -1,0 +1,164 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cassert>
+#include <sstream>
+
+#include "source/spirv_reducer_options.h"
+
+#include "reducer.h"
+#include "reduction_pass.h"
+
+namespace spvtools {
+namespace reduce {
+
+struct Reducer::Impl {
+  explicit Impl(spv_target_env env)
+      : target_env(env), made_progress_this_round(false) {}
+
+  const spv_target_env target_env;  // Target environment.
+  MessageConsumer consumer;         // Message consumer.
+  InterestingFunction is_interesting;
+  std::vector<std::unique_ptr<ReductionPass>> passes;
+  std::vector<std::unique_ptr<ReductionPass>>::iterator current_pass;
+  bool made_progress_this_round;
+
+  std::vector<uint32_t> ApplyReduction(const std::vector<uint32_t>& binary);
+  bool Finished();
+};
+
+Reducer::Reducer(spv_target_env env) : impl_(MakeUnique<Impl>(env)) {}
+
+Reducer::~Reducer() = default;
+
+void Reducer::SetMessageConsumer(MessageConsumer c) {
+  for (auto& pass : impl_->passes) {
+    pass->SetMessageConsumer(c);
+  }
+  impl_->consumer = std::move(c);
+}
+
+void Reducer::SetInterestingFunction(
+    Reducer::InterestingFunction interestingFunction) {
+  impl_->is_interesting = std::move(interestingFunction);
+}
+
+bool Reducer::Run(std::vector<uint32_t>&& binary_in,
+                  std::vector<uint32_t>& binary_out,
+                  spv_const_reducer_options options) const {
+  impl_->current_pass = impl_->passes.begin();
+
+  uint32_t current_step = 0;
+
+  std::vector<uint32_t> current = std::move(binary_in);
+
+  // Initial state should be interesting.
+  assert(impl_->is_interesting(current));
+
+  for (;;) {
+    assert(current_step < options->step_limit);
+
+    {
+      std::string msg = "Reduction step ";
+      msg += std::to_string(current_step);
+      impl_->consumer(SPV_MSG_INFO, nullptr, {}, msg.c_str());
+    }
+
+    std::vector<uint32_t> reduction_step_result =
+        impl_->ApplyReduction(current);
+
+    if (reduction_step_result.empty()) {
+      impl_->consumer(SPV_MSG_INFO, nullptr, {},
+                      "No more to reduce; stopping.");
+      break;
+    }
+
+    if (impl_->is_interesting(reduction_step_result)) {
+      // Interesting:
+      impl_->made_progress_this_round = true;
+      impl_->consumer(SPV_MSG_INFO, nullptr, {}, "Reduction step succeeded.");
+      current = std::move(reduction_step_result);
+    } else {
+      impl_->consumer(SPV_MSG_INFO, nullptr, {}, "Reduction step failed.");
+    }
+
+    ++current_step;
+    if (current_step == options->step_limit) {
+      break;
+    }
+  }
+
+  binary_out = std::move(current);
+
+  return true;
+}
+
+void Reducer::AddReductionPass(
+    std::unique_ptr<ReductionPass>&& reduction_pass) {
+  impl_->passes.push_back(std::move(reduction_pass));
+}
+
+std::vector<uint32_t> Reducer::Impl::ApplyReduction(
+    const std::vector<uint32_t>& binary) {
+  consumer(SPV_MSG_INFO, nullptr, {}, "Applying a reduction step.");
+  for (;;) {
+    assert(current_pass != passes.end());
+    while (current_pass != passes.end()) {
+      consumer(SPV_MSG_INFO, nullptr, {},
+               ("Trying pass " + (*current_pass)->GetName() + ".").c_str());
+      auto maybe_result = (*current_pass)->ApplyReduction(binary);
+      if (!maybe_result.empty()) {
+        consumer(
+            SPV_MSG_INFO, nullptr, {},
+            ("Pass " + (*current_pass)->GetName() + " made a reduction step.")
+                .c_str());
+        return maybe_result;
+      }
+      consumer(
+          SPV_MSG_INFO, nullptr, {},
+          ("Pass " + (*current_pass)->GetName() + " made no reduction step.")
+              .c_str());
+      ++current_pass;
+    }
+    consumer(SPV_MSG_INFO, nullptr, {}, "Completed a round of passes.");
+    if (Finished()) {
+      consumer(SPV_MSG_INFO, nullptr, {},
+               "No reduction step could be applied.");
+      return std::vector<uint32_t>();
+    }
+    made_progress_this_round = false;
+    current_pass = passes.begin();
+  }
+}
+
+bool Reducer::Impl::Finished() {
+  if (made_progress_this_round) {
+    consumer(SPV_MSG_INFO, nullptr, {},
+             "Not finished because some pass made progress last round.");
+    return false;
+  }
+  for (auto& pass : passes) {
+    if (!pass->ReachedMinimumGranularity()) {
+      consumer(SPV_MSG_INFO, nullptr, {},
+               ("Not finished because pass " + pass->GetName() +
+                " can be applied with finer granularity.")
+                   .c_str());
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace reduce
+}  // namespace spvtools

--- a/source/reduce/reducer.cpp
+++ b/source/reduce/reducer.cpp
@@ -24,8 +24,7 @@ namespace spvtools {
 namespace reduce {
 
 struct Reducer::Impl {
-  explicit Impl(spv_target_env env)
-      : target_env(env) {}
+  explicit Impl(spv_target_env env) : target_env(env) {}
 
   bool ReachedStepLimit(uint32_t current_step,
                         spv_const_reducer_options options);
@@ -48,13 +47,13 @@ void Reducer::SetMessageConsumer(MessageConsumer c) {
 }
 
 void Reducer::SetInterestingnessFunction(
-        Reducer::InterestingnessFunction interestingness_function) {
+    Reducer::InterestingnessFunction interestingness_function) {
   impl_->interestingness_function = std::move(interestingness_function);
 }
 
-Reducer::ReductionResultStatus Reducer::Run(std::vector<uint32_t>&& binary_in,
-                  std::vector<uint32_t>* binary_out,
-                  spv_const_reducer_options options) const {
+Reducer::ReductionResultStatus Reducer::Run(
+    std::vector<uint32_t>&& binary_in, std::vector<uint32_t>* binary_out,
+    spv_const_reducer_options options) const {
   std::vector<uint32_t> current_binary = binary_in;
 
   // Keeps track of how many reduction attempts have been tried.  Reduction
@@ -74,19 +73,18 @@ Reducer::ReductionResultStatus Reducer::Run(std::vector<uint32_t>&& binary_in,
 
   // Apply round after round of reduction passes until we hit the reduction
   // step limit, or deem that another round is not going to be worthwhile.
-  while(!impl_->ReachedStepLimit(reductions_applied, options)
-      && another_round_worthwhile) {
-
+  while (!impl_->ReachedStepLimit(reductions_applied, options) &&
+         another_round_worthwhile) {
     // At the start of a round of reduction passes, assume another round will
     // not be worthwhile unless we find evidence to the contrary.
     another_round_worthwhile = false;
 
     // Iterate through the available passes
-    for (auto &pass : impl_->passes) {
+    for (auto& pass : impl_->passes) {
       // Keep applying this pass at its current granularity until it stops
       // working or we hit the reduction step limit.
       impl_->consumer(SPV_MSG_INFO, nullptr, {},
-              ("Trying pass " + pass->GetName() + ".").c_str());
+                      ("Trying pass " + pass->GetName() + ".").c_str());
       do {
         auto maybe_result = pass->TryApplyReduction(current_binary);
         if (maybe_result.empty()) {
@@ -94,9 +92,10 @@ Reducer::ReductionResultStatus Reducer::Run(std::vector<uint32_t>&& binary_in,
           // If this pass hasn't reached its minimum granularity then it's
           // worth eventually doing another round of reductions, in order to
           // try this pass at a finer granularity.
-          impl_->consumer(SPV_MSG_INFO, nullptr, {},
-                  ("Pass " + pass->GetName()
-                  + " did not make a reduction step.").c_str());
+          impl_->consumer(
+              SPV_MSG_INFO, nullptr, {},
+              ("Pass " + pass->GetName() + " did not make a reduction step.")
+                  .c_str());
           another_round_worthwhile |= !pass->ReachedMinimumGranularity();
           break;
         }
@@ -106,13 +105,12 @@ Reducer::ReductionResultStatus Reducer::Run(std::vector<uint32_t>&& binary_in,
                      << reductions_applied << ".";
         impl_->consumer(SPV_MSG_INFO, nullptr, {},
                         (stringstream.str().c_str()));
-        if (impl_->interestingness_function(maybe_result,
-                reductions_applied)) {
+        if (impl_->interestingness_function(maybe_result, reductions_applied)) {
           // Success!  The binary produced by this reduction step is
           // interesting, so make it the binary of interest henceforth, and
           // note that it's worth doing another round of reduction passes.
           impl_->consumer(SPV_MSG_INFO, nullptr, {},
-                  "Reduction step succeeded.");
+                          "Reduction step succeeded.");
           current_binary = std::move(maybe_result);
           another_round_worthwhile = true;
         }
@@ -130,10 +128,8 @@ Reducer::ReductionResultStatus Reducer::Run(std::vector<uint32_t>&& binary_in,
                     "Reached reduction step limit; stopping.");
     return Reducer::ReductionResultStatus::kReachedStepLimit;
   }
-  impl_->consumer(SPV_MSG_INFO, nullptr, {},
-                  "No more to reduce; stopping.");
+  impl_->consumer(SPV_MSG_INFO, nullptr, {}, "No more to reduce; stopping.");
   return Reducer::ReductionResultStatus::kComplete;
-
 }
 
 void Reducer::AddReductionPass(
@@ -142,7 +138,7 @@ void Reducer::AddReductionPass(
 }
 
 bool Reducer::Impl::ReachedStepLimit(uint32_t current_step,
-        spv_const_reducer_options options) {
+                                     spv_const_reducer_options options) {
   return current_step >= options->step_limit;
 }
 

--- a/source/reduce/reducer.cpp
+++ b/source/reduce/reducer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Google Inc.
+// Copyright (c) 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/reduce/reducer.cpp
+++ b/source/reduce/reducer.cpp
@@ -66,13 +66,10 @@ bool Reducer::Run(std::vector<uint32_t>&& binary_in,
 
   for (uint32_t current_step = 0; current_step < options->step_limit; ++current_step) {
 
-    {
-      std::string msg = "Reduction step ";
-      msg += std::to_string(current_step);
-      impl_->consumer(SPV_MSG_INFO, nullptr, {}, msg.c_str());
-    }
+    impl_->consumer(SPV_MSG_INFO, nullptr, {},
+       ("Reduction step " + std::to_string(current_step)).c_str());
 
-    std::vector<uint32_t> reduction_step_result =
+    auto reduction_step_result =
         impl_->ApplyReduction(current);
 
     if (reduction_step_result.empty()) {
@@ -89,6 +86,7 @@ bool Reducer::Run(std::vector<uint32_t>&& binary_in,
     } else {
       impl_->consumer(SPV_MSG_INFO, nullptr, {}, "Reduction step failed.");
     }
+
   }
 
   binary_out = std::move(current);

--- a/source/reduce/reducer.cpp
+++ b/source/reduce/reducer.cpp
@@ -59,10 +59,10 @@ bool Reducer::Run(std::vector<uint32_t>&& binary_in,
                   spv_const_reducer_options options) const {
   impl_->current_pass = impl_->passes.begin();
 
-  std::vector<uint32_t> current = binary_in;
+  std::vector<uint32_t> current_binary = binary_in;
 
   // Initial state should be interesting.
-  assert(impl_->interestingness_function(current));
+  assert(impl_->interestingness_function(current_binary));
 
   for (uint32_t current_step = 0; current_step < options->step_limit; ++current_step) {
 
@@ -70,7 +70,7 @@ bool Reducer::Run(std::vector<uint32_t>&& binary_in,
        ("Reduction step " + std::to_string(current_step)).c_str());
 
     auto reduction_step_result =
-        impl_->ApplyReduction(current);
+        impl_->ApplyReduction(current_binary);
 
     if (reduction_step_result.empty()) {
       impl_->consumer(SPV_MSG_INFO, nullptr, {},
@@ -82,14 +82,14 @@ bool Reducer::Run(std::vector<uint32_t>&& binary_in,
       // Interesting:
       impl_->made_progress_this_round = true;
       impl_->consumer(SPV_MSG_INFO, nullptr, {}, "Reduction step succeeded.");
-      current = std::move(reduction_step_result);
+      current_binary = std::move(reduction_step_result);
     } else {
       impl_->consumer(SPV_MSG_INFO, nullptr, {}, "Reduction step failed.");
     }
 
   }
 
-  *binary_out = std::move(current);
+  *binary_out = std::move(current_binary);
 
   return true;
 }

--- a/source/reduce/reducer.cpp
+++ b/source/reduce/reducer.cpp
@@ -55,11 +55,11 @@ void Reducer::SetInterestingnessFunction(
 }
 
 bool Reducer::Run(std::vector<uint32_t>&& binary_in,
-                  std::vector<uint32_t>& binary_out,
+                  std::vector<uint32_t>* binary_out,
                   spv_const_reducer_options options) const {
   impl_->current_pass = impl_->passes.begin();
 
-  std::vector<uint32_t> current = std::move(binary_in);
+  std::vector<uint32_t> current = binary_in;
 
   // Initial state should be interesting.
   assert(impl_->interestingness_function(current));
@@ -89,7 +89,7 @@ bool Reducer::Run(std::vector<uint32_t>&& binary_in,
 
   }
 
-  binary_out = std::move(current);
+  *binary_out = std::move(current);
 
   return true;
 }

--- a/source/reduce/reducer.h
+++ b/source/reduce/reducer.h
@@ -1,0 +1,77 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_REDUCE_REDUCER_H_
+#define SOURCE_REDUCE_REDUCER_H_
+
+#include <functional>
+#include <string>
+
+#include "spirv-tools/libspirv.hpp"
+
+#include "reduction_pass.h"
+
+namespace spvtools {
+namespace reduce {
+
+class Reducer {
+ public:
+  using ErrorOrBool = std::pair<std::string, bool>;
+  using InterestingFunction = std::function<bool(const std::vector<uint32_t>&)>;
+
+  // Constructs an instance with the given target |env|, which is used to decode
+  // the binary to be reduced later.
+  //
+  // The constructed instance will have an empty message consumer, which just
+  // ignores all messages from the library. Use SetMessageConsumer() to supply
+  // one if messages are of concern.
+  explicit Reducer(spv_target_env env);
+
+  // Disables copy/move constructor/assignment operations.
+  Reducer(const Reducer&) = delete;
+  Reducer(Reducer&&) = delete;
+  Reducer& operator=(const Reducer&) = delete;
+  Reducer& operator=(Reducer&&) = delete;
+
+  // Destructs this instance.
+  ~Reducer();
+
+  // Sets the message consumer to the given |consumer|. The |consumer| will be
+  // invoked once for each message communicated from the library.
+  void SetMessageConsumer(MessageConsumer consumer);
+
+  // Sets the function that will be used to decide whether a reduced binary
+  // turned out to be interesting.
+  void SetInterestingFunction(InterestingFunction interesting_function);
+
+  // Adds a reduction pass to the sequence of passes that will be iterated
+  // over.
+  void AddReductionPass(std::unique_ptr<ReductionPass>&& reduction_pass);
+
+  // Reduces the given SPIR-V module |binary_out|.
+  // Returns true on successful reduction.  Returns false if errors
+  // occur when processing |binary_in|.
+  // The reduced binary ends up in |binary_out|.
+  bool Run(std::vector<uint32_t>&& binary_in, std::vector<uint32_t>& binary_out,
+           spv_const_reducer_options options) const;
+
+ private:
+  struct Impl;                  // Opaque struct for holding internal data.
+  std::unique_ptr<Impl> impl_;  // Unique pointer to internal data.
+};
+
+}  // namespace reduce
+}  // namespace spvtools
+
+#endif  // SOURCE_REDUCE_REDUCER_H_

--- a/source/reduce/reducer.h
+++ b/source/reduce/reducer.h
@@ -31,6 +31,13 @@ class Reducer {
 
  public:
 
+  // Possible statuses that can result from running a reduction.
+  enum ReductionResultStatus {
+    kInitialStateNotInteresting,
+    kReachedStepLimit,
+    kComplete
+  };
+
   // The type for a function that will take a binary and return true if and only if the binary is deemed interesting.
   // The notion of "interesting" depends on what properties of the binary or tools that process the binary we are
   // trying to maintain during reduction.
@@ -71,7 +78,8 @@ class Reducer {
 
   // Reduces the given SPIR-V module |binary_out|.
   // The reduced binary ends up in |binary_out|.
-  void Run(std::vector<uint32_t>&& binary_in,
+  // A status is returned.
+  ReductionResultStatus Run(std::vector<uint32_t>&& binary_in,
            std::vector<uint32_t>* binary_out,
            spv_const_reducer_options options) const;
 

--- a/source/reduce/reducer.h
+++ b/source/reduce/reducer.h
@@ -25,12 +25,10 @@
 namespace spvtools {
 namespace reduce {
 
-// This class manages the process of applying a reduction -- parameterized by a number of reduction passes and an
-// interestingness test, to a SPIR-V binary.
+// This class manages the process of applying a reduction -- parameterized by a
+// number of reduction passes and an interestingness test, to a SPIR-V binary.
 class Reducer {
-
  public:
-
   // Possible statuses that can result from running a reduction.
   enum ReductionResultStatus {
     kInitialStateNotInteresting,
@@ -46,7 +44,7 @@ class Reducer {
   // The notion of "interesting" depends on what properties of the binary or
   // tools that process the binary we are trying to maintain during reduction.
   using InterestingnessFunction =
-          std::function<bool(const std::vector<uint32_t>&, uint32_t)>;
+      std::function<bool(const std::vector<uint32_t>&, uint32_t)>;
 
   // Constructs an instance with the given target |env|, which is used to
   // decode the binary to be reduced later.
@@ -75,7 +73,7 @@ class Reducer {
   // Sets the function that will be used to decide whether a reduced binary
   // turned out to be interesting.
   void SetInterestingnessFunction(
-          InterestingnessFunction interestingness_function);
+      InterestingnessFunction interestingness_function);
 
   // Adds a reduction pass to the sequence of passes that will be iterated
   // over.
@@ -85,8 +83,8 @@ class Reducer {
   // The reduced binary ends up in |binary_out|.
   // A status is returned.
   ReductionResultStatus Run(std::vector<uint32_t>&& binary_in,
-           std::vector<uint32_t>* binary_out,
-           spv_const_reducer_options options) const;
+                            std::vector<uint32_t>* binary_out,
+                            spv_const_reducer_options options) const;
 
  private:
   struct Impl;                  // Opaque struct for holding internal data.

--- a/source/reduce/reducer.h
+++ b/source/reduce/reducer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Google Inc.
+// Copyright (c) 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/reduce/reducer.h
+++ b/source/reduce/reducer.h
@@ -25,10 +25,16 @@
 namespace spvtools {
 namespace reduce {
 
+// This class manages the process of applying a reduction -- parameterized by a number of reduction passes and an
+// interestingness test, to a SPIR-V binary.
 class Reducer {
+
  public:
-  using ErrorOrBool = std::pair<std::string, bool>;
-  using InterestingFunction = std::function<bool(const std::vector<uint32_t>&)>;
+
+  // The type for a function that will take a binary and return true if and only if the binary is deemed interesting.
+  // The notion of "interesting" depends on what properties of the binary or tools that process the binary we are
+  // trying to maintain during reduction.
+  using InterestingnessFunction = std::function<bool(const std::vector<uint32_t>&)>;
 
   // Constructs an instance with the given target |env|, which is used to decode
   // the binary to be reduced later.
@@ -36,6 +42,9 @@ class Reducer {
   // The constructed instance will have an empty message consumer, which just
   // ignores all messages from the library. Use SetMessageConsumer() to supply
   // one if messages are of concern.
+  //
+  // The constructed instance also needs to have an interestingness function set
+  // and some reduction passes added to it in order to be useful.
   explicit Reducer(spv_target_env env);
 
   // Disables copy/move constructor/assignment operations.
@@ -53,7 +62,7 @@ class Reducer {
 
   // Sets the function that will be used to decide whether a reduced binary
   // turned out to be interesting.
-  void SetInterestingFunction(InterestingFunction interesting_function);
+  void SetInterestingnessFunction(InterestingnessFunction interestingness_function);
 
   // Adds a reduction pass to the sequence of passes that will be iterated
   // over.

--- a/source/reduce/reducer.h
+++ b/source/reduce/reducer.h
@@ -69,10 +69,8 @@ class Reducer {
   void AddReductionPass(std::unique_ptr<ReductionPass>&& reduction_pass);
 
   // Reduces the given SPIR-V module |binary_out|.
-  // Returns true on successful reduction.  Returns false if errors
-  // occur when processing |binary_in|.
   // The reduced binary ends up in |binary_out|.
-  bool Run(std::vector<uint32_t>&& binary_in, std::vector<uint32_t>* binary_out,
+  void Run(std::vector<uint32_t>&& binary_in, std::vector<uint32_t>* binary_out,
            spv_const_reducer_options options) const;
 
  private:

--- a/source/reduce/reducer.h
+++ b/source/reduce/reducer.h
@@ -38,20 +38,25 @@ class Reducer {
     kComplete
   };
 
-  // The type for a function that will take a binary and return true if and only if the binary is deemed interesting.
-  // The notion of "interesting" depends on what properties of the binary or tools that process the binary we are
-  // trying to maintain during reduction.
-  using InterestingnessFunction = std::function<bool(const std::vector<uint32_t>&)>;
+  // The type for a function that will take a binary and return true if and
+  // only if the binary is deemed interesting. (The function also takes an
+  // integer argument that will be incremented each time the function is
+  // called; this is for debugging purposes).
+  //
+  // The notion of "interesting" depends on what properties of the binary or
+  // tools that process the binary we are trying to maintain during reduction.
+  using InterestingnessFunction =
+          std::function<bool(const std::vector<uint32_t>&, uint32_t)>;
 
-  // Constructs an instance with the given target |env|, which is used to decode
-  // the binary to be reduced later.
+  // Constructs an instance with the given target |env|, which is used to
+  // decode the binary to be reduced later.
   //
   // The constructed instance will have an empty message consumer, which just
   // ignores all messages from the library. Use SetMessageConsumer() to supply
   // one if messages are of concern.
   //
-  // The constructed instance also needs to have an interestingness function set
-  // and some reduction passes added to it in order to be useful.
+  // The constructed instance also needs to have an interestingness function
+  // set and some reduction passes added to it in order to be useful.
   explicit Reducer(spv_target_env env);
 
   // Disables copy/move constructor/assignment operations.

--- a/source/reduce/reducer.h
+++ b/source/reduce/reducer.h
@@ -62,7 +62,8 @@ class Reducer {
 
   // Sets the function that will be used to decide whether a reduced binary
   // turned out to be interesting.
-  void SetInterestingnessFunction(InterestingnessFunction interestingness_function);
+  void SetInterestingnessFunction(
+          InterestingnessFunction interestingness_function);
 
   // Adds a reduction pass to the sequence of passes that will be iterated
   // over.
@@ -70,7 +71,8 @@ class Reducer {
 
   // Reduces the given SPIR-V module |binary_out|.
   // The reduced binary ends up in |binary_out|.
-  void Run(std::vector<uint32_t>&& binary_in, std::vector<uint32_t>* binary_out,
+  void Run(std::vector<uint32_t>&& binary_in,
+           std::vector<uint32_t>* binary_out,
            spv_const_reducer_options options) const;
 
  private:

--- a/source/reduce/reducer.h
+++ b/source/reduce/reducer.h
@@ -72,7 +72,7 @@ class Reducer {
   // Returns true on successful reduction.  Returns false if errors
   // occur when processing |binary_in|.
   // The reduced binary ends up in |binary_out|.
-  bool Run(std::vector<uint32_t>&& binary_in, std::vector<uint32_t>& binary_out,
+  bool Run(std::vector<uint32_t>&& binary_in, std::vector<uint32_t>* binary_out,
            spv_const_reducer_options options) const;
 
  private:

--- a/source/reduce/reduction_opportunity.cpp
+++ b/source/reduce/reduction_opportunity.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Google Inc.
+// Copyright (c) 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/reduce/reduction_opportunity.cpp
+++ b/source/reduce/reduction_opportunity.cpp
@@ -17,10 +17,6 @@
 namespace spvtools {
 namespace reduce {
 
-ReductionOpportunity::ReductionOpportunity() = default;
-
-ReductionOpportunity::~ReductionOpportunity() = default;
-
 void ReductionOpportunity::TryToApply() {
   if (PreconditionHolds()) {
     Apply();

--- a/source/reduce/reduction_opportunity.cpp
+++ b/source/reduce/reduction_opportunity.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "reduction_opportunity.h"
+
+namespace spvtools {
+namespace reduce {
+
+ReductionOpportunity::ReductionOpportunity() = default;
+
+ReductionOpportunity::~ReductionOpportunity() = default;
+
+void ReductionOpportunity::TryToApply() {
+  if (PreconditionHolds()) {
+    Apply();
+  }
+}
+
+}  // namespace reduce
+}  // namespace spvtools

--- a/source/reduce/reduction_opportunity.h
+++ b/source/reduce/reduction_opportunity.h
@@ -20,17 +20,21 @@
 namespace spvtools {
 namespace reduce {
 
+// Abstract class capturing an opportunity to apply a reducing transformation.
 class ReductionOpportunity {
  public:
-  virtual ~ReductionOpportunity();
+  ReductionOpportunity() = default;
+  virtual ~ReductionOpportunity() = default;
 
-  ReductionOpportunity();
-
-  void TryToApply();
-
+  // Determines whether the opportunity can be applied; it may have been viable when discovered but later disabled
+  // by the application of some other reduction opportunity.
   virtual bool PreconditionHolds() = 0;
 
+  // A no-op if PreconditoinHolds() returns false; otherwise applies the opportunity.
+  void TryToApply();
+
  protected:
+  // Apply the reduction opportunity.
   virtual void Apply() = 0;
 };
 

--- a/source/reduce/reduction_opportunity.h
+++ b/source/reduce/reduction_opportunity.h
@@ -26,11 +26,13 @@ class ReductionOpportunity {
   ReductionOpportunity() = default;
   virtual ~ReductionOpportunity() = default;
 
-  // Determines whether the opportunity can be applied; it may have been viable when discovered but later disabled
-  // by the application of some other reduction opportunity.
+  // Determines whether the opportunity can be applied; it may have been viable
+  // when discovered but later disabled by the application of some other
+  // reduction opportunity.
   virtual bool PreconditionHolds() = 0;
 
-  // A no-op if PreconditoinHolds() returns false; otherwise applies the opportunity.
+  // A no-op if PreconditoinHolds() returns false; otherwise applies the
+  // opportunity.
   void TryToApply();
 
  protected:

--- a/source/reduce/reduction_opportunity.h
+++ b/source/reduce/reduction_opportunity.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Google Inc.
+// Copyright (c) 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/reduce/reduction_opportunity.h
+++ b/source/reduce/reduction_opportunity.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_REDUCE_REDUCTION_OPPORTUNITY_H_
+#define SOURCE_REDUCE_REDUCTION_OPPORTUNITY_H_
+
+#include "spirv-tools/libspirv.hpp"
+
+namespace spvtools {
+namespace reduce {
+
+class ReductionOpportunity {
+ public:
+  virtual ~ReductionOpportunity();
+
+  ReductionOpportunity();
+
+  void TryToApply();
+
+  virtual bool PreconditionHolds() = 0;
+
+ protected:
+  virtual void Apply() = 0;
+};
+
+}  // namespace reduce
+}  // namespace spvtools
+
+#endif  // SOURCE_REDUCE_REDUCTION_OPPORTUNITY_H_

--- a/source/reduce/reduction_pass.cpp
+++ b/source/reduce/reduction_pass.cpp
@@ -35,15 +35,15 @@ std::vector<uint32_t> ReductionPass::ApplyReduction(
     assert(index_ == 0);
     is_initialized_ = true;
     index_ = 0;
-    granularity_ = std::max((uint32_t)1, (uint32_t)opportunities.size());
+    granularity_ = (uint32_t) opportunities.size();
   }
-
-  assert(granularity_ > 0);
 
   if (opportunities.empty()) {
     granularity_ = 1;
     return std::vector<uint32_t>();
   }
+
+  assert(granularity_ > 0);
 
   if (index_ >= opportunities.size()) {
     index_ = 0;

--- a/source/reduce/reduction_pass.cpp
+++ b/source/reduce/reduction_pass.cpp
@@ -23,6 +23,14 @@ namespace reduce {
 
 std::vector<uint32_t> ReductionPass::ApplyReduction(
     const std::vector<uint32_t>& binary) {
+
+  // At present we prefer to build the module each time we apply a pass to ensure that the module is in a totally
+  // clean state before a pass is applied, to avoid any issues that might arise if a pass inadvertently leaves
+  // the module in an inconsistent state.
+  //
+  // This is for sanity purposes only; passes should be designed so that they do not leave the module in an
+  // inconsistent state.  If we find that module building ends up being a bottleneck we can consider keeping the module
+  // in memory as it is reduced.
   std::unique_ptr<opt::IRContext> context =
       BuildModule(target_env_, consumer_, binary.data(), binary.size());
   assert(context);

--- a/source/reduce/reduction_pass.cpp
+++ b/source/reduce/reduction_pass.cpp
@@ -73,7 +73,11 @@ void ReductionPass::SetMessageConsumer(MessageConsumer consumer) {
 }
 
 bool ReductionPass::ReachedMinimumGranularity() const {
-  assert (is_initialized_);
+  if (!is_initialized_) {
+    // Conceptually we can think that if the pass has not yet been initialized, it is operating at unbounded
+    // granularity.
+    return false;
+  }
   assert(granularity_ != 0);
   return granularity_ == 1;
 }

--- a/source/reduce/reduction_pass.cpp
+++ b/source/reduce/reduction_pass.cpp
@@ -22,8 +22,7 @@ namespace spvtools {
 namespace reduce {
 
 std::vector<uint32_t> ReductionPass::TryApplyReduction(
-        const std::vector<uint32_t> &binary) {
-
+    const std::vector<uint32_t>& binary) {
   // We represent modules as binaries because (a) attempts at reduction need to
   // end up in binary form to be passed on to SPIR-V-consuming tools, and (b)
   // when we apply a reduction step we need to do it on a fresh version of the
@@ -40,7 +39,7 @@ std::vector<uint32_t> ReductionPass::TryApplyReduction(
   if (!is_initialized_) {
     is_initialized_ = true;
     index_ = 0;
-    granularity_ = (uint32_t) opportunities.size();
+    granularity_ = (uint32_t)opportunities.size();
   }
 
   if (opportunities.empty()) {

--- a/source/reduce/reduction_pass.cpp
+++ b/source/reduce/reduction_pass.cpp
@@ -31,8 +31,6 @@ std::vector<uint32_t> ReductionPass::ApplyReduction(
       GetAvailableOpportunities(context.get());
 
   if (!is_initialized_) {
-    assert(granularity_ == 0);
-    assert(index_ == 0);
     is_initialized_ = true;
     index_ = 0;
     granularity_ = (uint32_t) opportunities.size();
@@ -65,10 +63,12 @@ std::vector<uint32_t> ReductionPass::ApplyReduction(
 }
 
 void ReductionPass::SetMessageConsumer(MessageConsumer consumer) {
+  assert (is_initialized_);
   consumer_ = std::move(consumer);
 }
 
 bool ReductionPass::ReachedMinimumGranularity() const {
+  assert (is_initialized_);
   assert(granularity_ != 0);
   return granularity_ == 1;
 }

--- a/source/reduce/reduction_pass.cpp
+++ b/source/reduce/reduction_pass.cpp
@@ -21,8 +21,8 @@
 namespace spvtools {
 namespace reduce {
 
-std::vector<uint32_t> ReductionPass::ApplyReduction(
-    const std::vector<uint32_t>& binary) {
+std::vector<uint32_t> ReductionPass::TryApplyReduction(
+        const std::vector<uint32_t> &binary) {
 
   // We represent modules as binaries because (a) attempts at reduction need to
   // end up in binary form to be passed on to SPIR-V-consuming tools, and (b)

--- a/source/reduce/reduction_pass.cpp
+++ b/source/reduce/reduction_pass.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Google Inc.
+// Copyright (c) 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/reduce/reduction_pass.cpp
+++ b/source/reduce/reduction_pass.cpp
@@ -24,13 +24,10 @@ namespace reduce {
 std::vector<uint32_t> ReductionPass::ApplyReduction(
     const std::vector<uint32_t>& binary) {
 
-  // At present we prefer to build the module each time we apply a pass to ensure that the module is in a totally
-  // clean state before a pass is applied, to avoid any issues that might arise if a pass inadvertently leaves
-  // the module in an inconsistent state.
-  //
-  // This is for sanity purposes only; passes should be designed so that they do not leave the module in an
-  // inconsistent state.  If we find that module building ends up being a bottleneck we can consider keeping the module
-  // in memory as it is reduced.
+  // We represent modules as binaries because (a) attempts at reduction need to end up in binary form to be passed on
+  // to SPIR-V-consuming tools, and (b) when we apply a reduction step we need to do it on a fresh version of the
+  // module as if the reduction step proves to be uninteresting we need to backtrack; re-parsing from binary provides
+  // a very clean way of cloning the module.
   std::unique_ptr<opt::IRContext> context =
       BuildModule(target_env_, consumer_, binary.data(), binary.size());
   assert(context);

--- a/source/reduce/reduction_pass.cpp
+++ b/source/reduce/reduction_pass.cpp
@@ -24,10 +24,12 @@ namespace reduce {
 std::vector<uint32_t> ReductionPass::ApplyReduction(
     const std::vector<uint32_t>& binary) {
 
-  // We represent modules as binaries because (a) attempts at reduction need to end up in binary form to be passed on
-  // to SPIR-V-consuming tools, and (b) when we apply a reduction step we need to do it on a fresh version of the
-  // module as if the reduction step proves to be uninteresting we need to backtrack; re-parsing from binary provides
-  // a very clean way of cloning the module.
+  // We represent modules as binaries because (a) attempts at reduction need to
+  // end up in binary form to be passed on to SPIR-V-consuming tools, and (b)
+  // when we apply a reduction step we need to do it on a fresh version of the
+  // module as if the reduction step proves to be uninteresting we need to
+  // backtrack; re-parsing from binary provides a very clean way of cloning the
+  // module.
   std::unique_ptr<opt::IRContext> context =
       BuildModule(target_env_, consumer_, binary.data(), binary.size());
   assert(context);
@@ -73,8 +75,8 @@ void ReductionPass::SetMessageConsumer(MessageConsumer consumer) {
 
 bool ReductionPass::ReachedMinimumGranularity() const {
   if (!is_initialized_) {
-    // Conceptually we can think that if the pass has not yet been initialized, it is operating at unbounded
-    // granularity.
+    // Conceptually we can think that if the pass has not yet been initialized,
+    // it is operating at unbounded granularity.
     return false;
   }
   assert(granularity_ != 0);

--- a/source/reduce/reduction_pass.cpp
+++ b/source/reduce/reduction_pass.cpp
@@ -68,7 +68,6 @@ std::vector<uint32_t> ReductionPass::ApplyReduction(
 }
 
 void ReductionPass::SetMessageConsumer(MessageConsumer consumer) {
-  assert (is_initialized_);
   consumer_ = std::move(consumer);
 }
 

--- a/source/reduce/reduction_pass.cpp
+++ b/source/reduce/reduction_pass.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+
+#include "reduction_pass.h"
+
+#include "source/opt/build_module.h"
+
+namespace spvtools {
+namespace reduce {
+
+std::vector<uint32_t> ReductionPass::ApplyReduction(
+    const std::vector<uint32_t>& binary) {
+  std::unique_ptr<opt::IRContext> context =
+      BuildModule(target_env_, consumer_, binary.data(), binary.size());
+  assert(context);
+
+  std::vector<std::unique_ptr<ReductionOpportunity>> opportunities =
+      GetAvailableOpportunities(context.get());
+
+  if (!is_initialized_) {
+    assert(granularity_ == 0);
+    assert(index_ == 0);
+    is_initialized_ = true;
+    index_ = 0;
+    granularity_ = std::max((uint32_t)1, (uint32_t)opportunities.size());
+  }
+
+  assert(granularity_ > 0);
+
+  if (opportunities.empty()) {
+    granularity_ = 1;
+    return std::vector<uint32_t>();
+  }
+
+  if (index_ >= opportunities.size()) {
+    index_ = 0;
+    granularity_ = std::max((uint32_t)1, granularity_ / 2);
+    return std::vector<uint32_t>();
+  }
+
+  for (uint32_t i = index_;
+       i < std::min(index_ + granularity_, (uint32_t)opportunities.size());
+       ++i) {
+    opportunities[i]->TryToApply();
+  }
+
+  index_ += granularity_;
+
+  std::vector<uint32_t> result;
+  context->module()->ToBinary(&result, false);
+  return result;
+}
+
+void ReductionPass::SetMessageConsumer(MessageConsumer consumer) {
+  consumer_ = std::move(consumer);
+}
+
+bool ReductionPass::ReachedMinimumGranularity() const {
+  assert(granularity_ != 0);
+  return granularity_ == 1;
+}
+
+}  // namespace reduce
+}  // namespace spvtools

--- a/source/reduce/reduction_pass.h
+++ b/source/reduce/reduction_pass.h
@@ -23,25 +23,36 @@
 namespace spvtools {
 namespace reduce {
 
+// Abstract class representing a reduction pass, which can be repeatedly invoked to find and apply particular reduction
+// opportunities to a SPIR-V binary.  In the spirit of delta debugging, a pass initially tries to apply large chunks
+// of reduction opportunities, iterating through available opportunities at a given granularity.  When an iteration
+// over available opportunities completes, the granularity is reduced and iteration starts again, until the minimum
+// granularity is reached.
 class ReductionPass {
  public:
+
+  // Constructs a reduction pass with a given target environment, |target_env|.  Initially the pass is uninitialized.
   explicit ReductionPass(const spv_target_env target_env)
       : target_env_(target_env),
-        is_initialized_(false),
-        index_(0),
-        granularity_(0) {}
+        is_initialized_(false) {}
 
   virtual ~ReductionPass() = default;
 
+  // Apply the reduction pass to the given binary.
   std::vector<uint32_t> ApplyReduction(const std::vector<uint32_t>& binary);
 
+  // Set a consumer to which relevant messages will be directed.
   void SetMessageConsumer(MessageConsumer consumer);
 
+  // Determines whether the granularity with which reduction opportunities are applied has reached a minimum.
   bool ReachedMinimumGranularity() const;
 
+  // Returns the name of the reduction pass (useful for monitoring reduction progress).
   virtual std::string GetName() const = 0;
 
  protected:
+
+  // Finds the reduction opportunities relevant to this pass that could be applied to a given SPIR-V module.
   virtual std::vector<std::unique_ptr<ReductionOpportunity>>
   GetAvailableOpportunities(opt::IRContext* context) const = 0;
 

--- a/source/reduce/reduction_pass.h
+++ b/source/reduce/reduction_pass.h
@@ -23,15 +23,18 @@
 namespace spvtools {
 namespace reduce {
 
-// Abstract class representing a reduction pass, which can be repeatedly invoked to find and apply particular reduction
-// opportunities to a SPIR-V binary.  In the spirit of delta debugging, a pass initially tries to apply large chunks
-// of reduction opportunities, iterating through available opportunities at a given granularity.  When an iteration
-// over available opportunities completes, the granularity is reduced and iteration starts again, until the minimum
-// granularity is reached.
+// Abstract class representing a reduction pass, which can be repeatedly
+// invoked to find and apply particular reduction opportunities to a SPIR-V
+// binary.  In the spirit of delta debugging, a pass initially tries to apply
+// large chunks of reduction opportunities, iterating through available
+// opportunities at a given granularity.  When an iteration over available
+// opportunities completes, the granularity is reduced and iteration starts
+// again, until the minimum granularity is reached.
 class ReductionPass {
  public:
 
-  // Constructs a reduction pass with a given target environment, |target_env|.  Initially the pass is uninitialized.
+  // Constructs a reduction pass with a given target environment, |target_env|.
+  // Initially the pass is uninitialized.
   explicit ReductionPass(const spv_target_env target_env)
       : target_env_(target_env),
         is_initialized_(false) {}
@@ -44,15 +47,18 @@ class ReductionPass {
   // Set a consumer to which relevant messages will be directed.
   void SetMessageConsumer(MessageConsumer consumer);
 
-  // Determines whether the granularity with which reduction opportunities are applied has reached a minimum.
+  // Determines whether the granularity with which reduction opportunities are
+  // applied has reached a minimum.
   bool ReachedMinimumGranularity() const;
 
-  // Returns the name of the reduction pass (useful for monitoring reduction progress).
+  // Returns the name of the reduction pass (useful for monitoring reduction
+  // progress).
   virtual std::string GetName() const = 0;
 
  protected:
 
-  // Finds the reduction opportunities relevant to this pass that could be applied to a given SPIR-V module.
+  // Finds the reduction opportunities relevant to this pass that could be
+  // applied to a given SPIR-V module.
   virtual std::vector<std::unique_ptr<ReductionOpportunity>>
   GetAvailableOpportunities(opt::IRContext* context) const = 0;
 

--- a/source/reduce/reduction_pass.h
+++ b/source/reduce/reduction_pass.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_REDUCE_REDUCTION_PASS_H_
+#define SOURCE_REDUCE_REDUCTION_PASS_H_
+
+#include "spirv-tools/libspirv.hpp"
+
+#include "reduction_opportunity.h"
+#include "source/opt/ir_context.h"
+
+namespace spvtools {
+namespace reduce {
+
+class ReductionPass {
+ public:
+  explicit ReductionPass(const spv_target_env target_env)
+      : target_env_(target_env),
+        is_initialized_(false),
+        index_(0),
+        granularity_(0) {}
+
+  virtual ~ReductionPass() = default;
+
+  std::vector<uint32_t> ApplyReduction(const std::vector<uint32_t>& binary);
+
+  void SetMessageConsumer(MessageConsumer consumer);
+
+  bool ReachedMinimumGranularity() const;
+
+  virtual std::string GetName() const = 0;
+
+ protected:
+  virtual std::vector<std::unique_ptr<ReductionOpportunity>>
+  GetAvailableOpportunities(opt::IRContext* context) const = 0;
+
+ private:
+  const spv_target_env target_env_;
+  MessageConsumer consumer_;
+  bool is_initialized_;
+  uint32_t index_;
+  uint32_t granularity_;
+};
+
+}  // namespace reduce
+}  // namespace spvtools
+
+#endif  // SOURCE_REDUCE_REDUCTION_PASS_H_

--- a/source/reduce/reduction_pass.h
+++ b/source/reduce/reduction_pass.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Google Inc.
+// Copyright (c) 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/reduce/reduction_pass.h
+++ b/source/reduce/reduction_pass.h
@@ -42,7 +42,7 @@ class ReductionPass {
   virtual ~ReductionPass() = default;
 
   // Apply the reduction pass to the given binary.
-  std::vector<uint32_t> ApplyReduction(const std::vector<uint32_t>& binary);
+  std::vector<uint32_t> TryApplyReduction(const std::vector<uint32_t> &binary);
 
   // Set a consumer to which relevant messages will be directed.
   void SetMessageConsumer(MessageConsumer consumer);

--- a/source/reduce/reduction_pass.h
+++ b/source/reduce/reduction_pass.h
@@ -32,17 +32,15 @@ namespace reduce {
 // again, until the minimum granularity is reached.
 class ReductionPass {
  public:
-
   // Constructs a reduction pass with a given target environment, |target_env|.
   // Initially the pass is uninitialized.
   explicit ReductionPass(const spv_target_env target_env)
-      : target_env_(target_env),
-        is_initialized_(false) {}
+      : target_env_(target_env), is_initialized_(false) {}
 
   virtual ~ReductionPass() = default;
 
   // Apply the reduction pass to the given binary.
-  std::vector<uint32_t> TryApplyReduction(const std::vector<uint32_t> &binary);
+  std::vector<uint32_t> TryApplyReduction(const std::vector<uint32_t>& binary);
 
   // Set a consumer to which relevant messages will be directed.
   void SetMessageConsumer(MessageConsumer consumer);
@@ -56,7 +54,6 @@ class ReductionPass {
   virtual std::string GetName() const = 0;
 
  protected:
-
   // Finds the reduction opportunities relevant to this pass that could be
   // applied to a given SPIR-V module.
   virtual std::vector<std::unique_ptr<ReductionOpportunity>>

--- a/source/reduce/remove_instruction_reduction_opportunity.cpp
+++ b/source/reduce/remove_instruction_reduction_opportunity.cpp
@@ -19,9 +19,7 @@
 namespace spvtools {
 namespace reduce {
 
-bool RemoveInstructionReductionOpportunity::PreconditionHolds() {
-  return true;
-}
+bool RemoveInstructionReductionOpportunity::PreconditionHolds() { return true; }
 
 void RemoveInstructionReductionOpportunity::Apply() {
   inst_->context()->KillInst(inst_);

--- a/source/reduce/remove_instruction_reduction_opportunity.cpp
+++ b/source/reduce/remove_instruction_reduction_opportunity.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/opt/ir_context.h"
+
+#include "remove_instruction_reduction_opportunity.h"
+
+namespace spvtools {
+namespace reduce {
+
+bool RemoveInstructionReductionOpportunity::PreconditionHolds() { return true; }
+
+void RemoveInstructionReductionOpportunity::Apply() {
+  inst_->context()->KillInst(inst_);
+}
+
+}  // namespace reduce
+}  // namespace spvtools

--- a/source/reduce/remove_instruction_reduction_opportunity.cpp
+++ b/source/reduce/remove_instruction_reduction_opportunity.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Google Inc.
+// Copyright (c) 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/reduce/remove_instruction_reduction_opportunity.cpp
+++ b/source/reduce/remove_instruction_reduction_opportunity.cpp
@@ -19,7 +19,9 @@
 namespace spvtools {
 namespace reduce {
 
-bool RemoveInstructionReductionOpportunity::PreconditionHolds() { return true; }
+bool RemoveInstructionReductionOpportunity::PreconditionHolds() {
+  return true;
+}
 
 void RemoveInstructionReductionOpportunity::Apply() {
   inst_->context()->KillInst(inst_);

--- a/source/reduce/remove_instruction_reduction_opportunity.h
+++ b/source/reduce/remove_instruction_reduction_opportunity.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_REDUCE_REMOVE_INSTRUCTION_REDUCTION_OPPORTUNITY_H_
+#define SOURCE_REDUCE_REMOVE_INSTRUCTION_REDUCTION_OPPORTUNITY_H_
+
+#include "reduction_opportunity.h"
+#include "source/opt/instruction.h"
+
+namespace spvtools {
+namespace reduce {
+
+using namespace opt;
+
+class RemoveInstructionReductionOpportunity : public ReductionOpportunity {
+ public:
+  explicit RemoveInstructionReductionOpportunity(Instruction* inst)
+      : inst_(inst) {}
+
+  bool PreconditionHolds() override;
+
+ protected:
+  void Apply() override;
+
+ private:
+  Instruction* inst_;
+};
+
+}  // namespace reduce
+}  // namespace spvtools
+
+#endif  // SOURCE_REDUCE_REMOVE_INSTRUCTION_REDUCTION_OPPORTUNITY_H_

--- a/source/reduce/remove_instruction_reduction_opportunity.h
+++ b/source/reduce/remove_instruction_reduction_opportunity.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Google Inc.
+// Copyright (c) 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/reduce/remove_instruction_reduction_opportunity.h
+++ b/source/reduce/remove_instruction_reduction_opportunity.h
@@ -26,7 +26,6 @@ using namespace opt;
 // Captures the opportunity to remove an instruction from the SPIR-V module.
 class RemoveInstructionReductionOpportunity : public ReductionOpportunity {
  public:
-
   // Constructs the opportunity to remove |inst|.
   explicit RemoveInstructionReductionOpportunity(Instruction* inst)
       : inst_(inst) {}

--- a/source/reduce/remove_instruction_reduction_opportunity.h
+++ b/source/reduce/remove_instruction_reduction_opportunity.h
@@ -23,14 +23,19 @@ namespace reduce {
 
 using namespace opt;
 
+// Captures the opportunity to remove an instruction from the SPIR-V module.
 class RemoveInstructionReductionOpportunity : public ReductionOpportunity {
  public:
+
+  // Constructs the opportunity to remove |inst|.
   explicit RemoveInstructionReductionOpportunity(Instruction* inst)
       : inst_(inst) {}
 
+  // This kind of opportunity can be unconditionally applied.
   bool PreconditionHolds() override;
 
  protected:
+  // Remove the instruction.
   void Apply() override;
 
  private:

--- a/source/reduce/remove_unreferenced_instruction_reduction_pass.cpp
+++ b/source/reduce/remove_unreferenced_instruction_reduction_pass.cpp
@@ -33,9 +33,9 @@ RemoveUnreferencedInstructionReductionPass::GetAvailableOpportunities(
         if (context->get_def_use_mgr()->NumUses(&inst) > 0) {
           continue;
         }
-        if (spvOpcodeIsBlockTerminator(inst.opcode())
-            || inst.opcode() == SpvOpSelectionMerge
-            || inst.opcode() == SpvOpLoopMerge) {
+        if (spvOpcodeIsBlockTerminator(inst.opcode()) ||
+            inst.opcode() == SpvOpSelectionMerge ||
+            inst.opcode() == SpvOpLoopMerge) {
           // In this reduction pass we do not want to affect static control
           // flow.
           continue;
@@ -45,7 +45,7 @@ RemoveUnreferencedInstructionReductionPass::GetAvailableOpportunities(
         // some straightforward instruction with an unused result, like an
         // arithmetic operation or function call.
         result.push_back(
-                MakeUnique<RemoveInstructionReductionOpportunity>(&inst));
+            MakeUnique<RemoveInstructionReductionOpportunity>(&inst));
       }
     }
   }

--- a/source/reduce/remove_unreferenced_instruction_reduction_pass.cpp
+++ b/source/reduce/remove_unreferenced_instruction_reduction_pass.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "remove_unreferenced_instruction_reduction_pass.h"
+#include "remove_instruction_reduction_opportunity.h"
+#include "source/opt/instruction.h"
+
+namespace spvtools {
+namespace reduce {
+
+using namespace opt;
+
+std::vector<std::unique_ptr<ReductionOpportunity>>
+RemoveUnreferencedInstructionReductionPass::GetAvailableOpportunities(
+    opt::IRContext* context) const {
+  std::vector<std::unique_ptr<ReductionOpportunity>> result;
+
+  for (auto& function : *context->module()) {
+    for (auto& block : function) {
+      for (auto& inst : block) {
+        if (context->get_def_use_mgr()->NumUses(&inst) == 0) {
+          switch (inst.opcode()) {
+            case SpvOpBranch:
+            case SpvOpBranchConditional:
+            case SpvOpLoopMerge:
+            case SpvOpSelectionMerge:
+            case SpvOpReturn:
+            case SpvOpSwitch:
+              // TODO: this should ultimately capture all opcodes that relate to
+              // control flow; we don't want to mess with these here.
+              break;
+            default:
+              // Given that we're in a block, we should only get here if the
+              // instruction is not directly related to control flow; i.e., it's
+              // some straightforward instruction with an unused result, like an
+              // arithmetic operation or function call.
+              result.push_back(
+                  MakeUnique<RemoveInstructionReductionOpportunity>(&inst));
+          }
+        }
+      }
+    }
+  }
+  return result;
+}
+
+std::string RemoveUnreferencedInstructionReductionPass::GetName() const {
+  return "RemoveUnreferencedInstructionReductionPass";
+}
+
+}  // namespace reduce
+}  // namespace spvtools

--- a/source/reduce/remove_unreferenced_instruction_reduction_pass.cpp
+++ b/source/reduce/remove_unreferenced_instruction_reduction_pass.cpp
@@ -36,8 +36,9 @@ RemoveUnreferencedInstructionReductionPass::GetAvailableOpportunities(
         if (spvOpcodeIsBlockTerminator(inst.opcode())
             || inst.opcode() == SpvOpSelectionMerge
             || inst.opcode() == SpvOpLoopMerge) {
-          // In this reduction pass we do not want to affect static control flow.
-            continue;
+          // In this reduction pass we do not want to affect static control
+          // flow.
+          continue;
         }
         // Given that we're in a block, we should only get here if the
         // instruction is not directly related to control flow; i.e., it's

--- a/source/reduce/remove_unreferenced_instruction_reduction_pass.h
+++ b/source/reduce/remove_unreferenced_instruction_reduction_pass.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_REDUCE_REMOVE_UNREFERENCED_INSTRUCTION_REDUCTION_PASS_H_
+#define SOURCE_REDUCE_REMOVE_UNREFERENCED_INSTRUCTION_REDUCTION_PASS_H_
+
+#include "reduction_pass.h"
+
+namespace spvtools {
+namespace reduce {
+
+class RemoveUnreferencedInstructionReductionPass : public ReductionPass {
+ public:
+  explicit RemoveUnreferencedInstructionReductionPass(
+      const spv_target_env target_env)
+      : ReductionPass(target_env) {}
+
+  ~RemoveUnreferencedInstructionReductionPass() override = default;
+
+  std::string GetName() const final;
+
+ protected:
+  std::vector<std::unique_ptr<ReductionOpportunity>> GetAvailableOpportunities(
+      opt::IRContext* context) const final;
+
+ private:
+};
+
+}  // namespace reduce
+}  // namespace spvtools
+
+#endif  // SOURCE_REDUCE_REMOVE_UNREFERENCED_INSTRUCTION_REDUCTION_PASS_H_

--- a/source/reduce/remove_unreferenced_instruction_reduction_pass.h
+++ b/source/reduce/remove_unreferenced_instruction_reduction_pass.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Google Inc.
+// Copyright (c) 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/reduce/remove_unreferenced_instruction_reduction_pass.h
+++ b/source/reduce/remove_unreferenced_instruction_reduction_pass.h
@@ -20,13 +20,16 @@
 namespace spvtools {
 namespace reduce {
 
-// A reduction pass for removing non-control-flow instructions in blocks in cases where the instruction's id is not
-// referenced.  As well as making the module smaller, removing an instruction that referenced particular ids may create
-// opportunities for subsequently removing the instructions that generated those ids.
+// A reduction pass for removing non-control-flow instructions in blocks in
+// cases where the instruction's id is not referenced.  As well as making the
+// module smaller, removing an instruction that referenced particular ids may
+// create opportunities for subsequently removing the instructions that
+// generated those ids.
 class RemoveUnreferencedInstructionReductionPass : public ReductionPass {
  public:
 
-  // Creates the reduction pass in the context of the given target environment |target_env|
+  // Creates the reduction pass in the context of the given target environment
+  // |target_env|
   explicit RemoveUnreferencedInstructionReductionPass(
       const spv_target_env target_env)
       : ReductionPass(target_env) {}
@@ -37,7 +40,8 @@ class RemoveUnreferencedInstructionReductionPass : public ReductionPass {
   std::string GetName() const final;
 
  protected:
-  // Finds all opportunities for removing unreferenced instructions in the given module.
+  // Finds all opportunities for removing unreferenced instructions in the
+  // given module.
   std::vector<std::unique_ptr<ReductionOpportunity>> GetAvailableOpportunities(
       opt::IRContext* context) const final;
 

--- a/source/reduce/remove_unreferenced_instruction_reduction_pass.h
+++ b/source/reduce/remove_unreferenced_instruction_reduction_pass.h
@@ -27,7 +27,6 @@ namespace reduce {
 // generated those ids.
 class RemoveUnreferencedInstructionReductionPass : public ReductionPass {
  public:
-
   // Creates the reduction pass in the context of the given target environment
   // |target_env|
   explicit RemoveUnreferencedInstructionReductionPass(

--- a/source/reduce/remove_unreferenced_instruction_reduction_pass.h
+++ b/source/reduce/remove_unreferenced_instruction_reduction_pass.h
@@ -20,17 +20,24 @@
 namespace spvtools {
 namespace reduce {
 
+// A reduction pass for removing non-control-flow instructions in blocks in cases where the instruction's id is not
+// referenced.  As well as making the module smaller, removing an instruction that referenced particular ids may create
+// opportunities for subsequently removing the instructions that generated those ids.
 class RemoveUnreferencedInstructionReductionPass : public ReductionPass {
  public:
+
+  // Creates the reduction pass in the context of the given target environment |target_env|
   explicit RemoveUnreferencedInstructionReductionPass(
       const spv_target_env target_env)
       : ReductionPass(target_env) {}
 
   ~RemoveUnreferencedInstructionReductionPass() override = default;
 
+  // The name of this pass.
   std::string GetName() const final;
 
  protected:
+  // Finds all opportunities for removing unreferenced instructions in the given module.
   std::vector<std::unique_ptr<ReductionOpportunity>> GetAvailableOpportunities(
       opt::IRContext* context) const final;
 

--- a/source/spirv_reducer_options.cpp
+++ b/source/spirv_reducer_options.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cassert>
+#include <cstring>
+#include <optional>
+
+#include "source/spirv_reducer_options.h"
+
+SPIRV_TOOLS_EXPORT spv_reducer_options spvReducerOptionsCreate() {
+    return new spv_reducer_options_t();
+}
+
+SPIRV_TOOLS_EXPORT void spvReducerOptionsDestroy(
+        spv_reducer_options options) {
+    delete options;
+}
+
+SPIRV_TOOLS_EXPORT void spvReducerOptionsSetStepLimit(
+        spv_reducer_options options, uint32_t step_limit) {
+    options->step_limit = step_limit;
+}

--- a/source/spirv_reducer_options.cpp
+++ b/source/spirv_reducer_options.cpp
@@ -18,15 +18,14 @@
 #include "source/spirv_reducer_options.h"
 
 SPIRV_TOOLS_EXPORT spv_reducer_options spvReducerOptionsCreate() {
-    return new spv_reducer_options_t();
+  return new spv_reducer_options_t();
 }
 
-SPIRV_TOOLS_EXPORT void spvReducerOptionsDestroy(
-        spv_reducer_options options) {
-    delete options;
+SPIRV_TOOLS_EXPORT void spvReducerOptionsDestroy(spv_reducer_options options) {
+  delete options;
 }
 
 SPIRV_TOOLS_EXPORT void spvReducerOptionsSetStepLimit(
-        spv_reducer_options options, uint32_t step_limit) {
-    options->step_limit = step_limit;
+    spv_reducer_options options, uint32_t step_limit) {
+  options->step_limit = step_limit;
 }

--- a/source/spirv_reducer_options.cpp
+++ b/source/spirv_reducer_options.cpp
@@ -14,7 +14,6 @@
 
 #include <cassert>
 #include <cstring>
-#include <optional>
 
 #include "source/spirv_reducer_options.h"
 

--- a/source/spirv_reducer_options.h
+++ b/source/spirv_reducer_options.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_SPIRV_REDUCER_OPTIONS_H_
+#define SOURCE_SPIRV_REDUCER_OPTIONS_H_
+
+#include "spirv-tools/libspirv.h"
+
+#include <string>
+#include <utility>
+
+// The default maximum number of steps for the reducer to run before giving up.
+const uint32_t kDefaultStepLimit = 250;
+
+// Manages command line options passed to the SPIR-V Reducer. New struct
+// members may be added for any new option.
+struct spv_reducer_options_t {
+    spv_reducer_options_t()
+            : step_limit(kDefaultStepLimit){}
+
+    // The number of steps the reducer will run for before giving up.
+    uint32_t step_limit;
+};
+
+
+#endif //SOURCE_SPIRV_REDUCER_OPTIONS_H_

--- a/source/spirv_reducer_options.h
+++ b/source/spirv_reducer_options.h
@@ -26,12 +26,10 @@ const uint32_t kDefaultStepLimit = 250;
 // Manages command line options passed to the SPIR-V Reducer. New struct
 // members may be added for any new option.
 struct spv_reducer_options_t {
-    spv_reducer_options_t()
-            : step_limit(kDefaultStepLimit){}
+  spv_reducer_options_t() : step_limit(kDefaultStepLimit) {}
 
-    // The number of steps the reducer will run for before giving up.
-    uint32_t step_limit;
+  // The number of steps the reducer will run for before giving up.
+  uint32_t step_limit;
 };
 
-
-#endif //SOURCE_SPIRV_REDUCER_OPTIONS_H_
+#endif  // SOURCE_SPIRV_REDUCER_OPTIONS_H_

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -207,6 +207,7 @@ add_spvtools_unittest(
 add_subdirectory(comp)
 add_subdirectory(link)
 add_subdirectory(opt)
+add_subdirectory(reduce)
 add_subdirectory(stats)
 add_subdirectory(tools)
 add_subdirectory(util)

--- a/test/reduce/CMakeLists.txt
+++ b/test/reduce/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (c) 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_spvtools_unittest(TARGET reduce
+        SRCS operand_to_constant_reduction_pass_test.cpp
+        reduce_test_util.cpp
+        reduce_test_util.h
+        reducer_test.cpp
+        remove_unreferenced_instruction_reduction_pass_test.cpp
+        LIBS SPIRV-Tools-reduce
+        )
+

--- a/test/reduce/CMakeLists.txt
+++ b/test/reduce/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Google Inc.
+# Copyright (c) 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/reduce/operand_to_constant_reduction_pass_test.cpp
+++ b/test/reduce/operand_to_constant_reduction_pass_test.cpp
@@ -112,7 +112,6 @@ TEST(OperandToConstantReductionPassTest, BasicCheck) {
   CheckEqual(env, expected, context.get());
 }
 
-
 TEST(OperandToConstantReductionPassTest, WithCalledFunction) {
   std::string shader = R"(
                OpCapability Shader
@@ -146,7 +145,7 @@ TEST(OperandToConstantReductionPassTest, WithCalledFunction) {
   const auto env = SPV_ENV_UNIVERSAL_1_3;
   const auto consumer = nullptr;
   const auto context =
-          BuildModule(env, consumer, shader, kReduceAssembleOption);
+      BuildModule(env, consumer, shader, kReduceAssembleOption);
   const auto pass = TestSubclass<OperandToConstReductionPass>(env);
   const auto ops = pass.WrapGetAvailableOpportunities(context.get());
   ASSERT_EQ(0, ops.size());

--- a/test/reduce/operand_to_constant_reduction_pass_test.cpp
+++ b/test/reduce/operand_to_constant_reduction_pass_test.cpp
@@ -1,0 +1,117 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "reduce_test_util.h"
+#include "source/opt/build_module.h"
+#include "source/reduce/operand_to_const_reduction_pass.h"
+
+namespace spvtools {
+namespace reduce {
+namespace {
+
+TEST(OperandToConstantReductionPassTest, BasicCheck) {
+  std::string prologue = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main" %37
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %9 "buf1"
+               OpMemberName %9 0 "f"
+               OpName %11 ""
+               OpName %24 "buf2"
+               OpMemberName %24 0 "i"
+               OpName %26 ""
+               OpName %37 "_GLF_color"
+               OpMemberDecorate %9 0 Offset 0
+               OpDecorate %9 Block
+               OpDecorate %11 DescriptorSet 0
+               OpDecorate %11 Binding 1
+               OpMemberDecorate %24 0 Offset 0
+               OpDecorate %24 Block
+               OpDecorate %26 DescriptorSet 0
+               OpDecorate %26 Binding 2
+               OpDecorate %37 Location 0
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeFloat 32
+          %9 = OpTypeStruct %6
+         %10 = OpTypePointer Uniform %9
+         %11 = OpVariable %10 Uniform
+         %12 = OpTypeInt 32 1
+         %13 = OpConstant %12 0
+         %14 = OpTypePointer Uniform %6
+         %20 = OpConstant %6 2
+         %24 = OpTypeStruct %12
+         %25 = OpTypePointer Uniform %24
+         %26 = OpVariable %25 Uniform
+         %27 = OpTypePointer Uniform %12
+         %33 = OpConstant %12 3
+         %35 = OpTypeVector %6 4
+         %36 = OpTypePointer Output %35
+         %37 = OpVariable %36 Output
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %15 = OpAccessChain %14 %11 %13
+         %16 = OpLoad %6 %15
+         %19 = OpFAdd %6 %16 %16
+         %21 = OpFAdd %6 %19 %20
+         %28 = OpAccessChain %27 %26 %13
+         %29 = OpLoad %12 %28
+  )";
+
+  std::string epilogue = R"(
+         %45 = OpConvertSToF %6 %34
+         %46 = OpCompositeConstruct %35 %16 %21 %43 %45
+               OpStore %37 %46
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  std::string original = prologue + R"(
+         %32 = OpIAdd %12 %29 %29
+         %34 = OpIAdd %12 %32 %33
+         %43 = OpConvertSToF %6 %29
+  )" + epilogue;
+
+  std::string expected = prologue + R"(
+         %32 = OpIAdd %12 %13 %13 ; %29 -> %13 x 2
+         %34 = OpIAdd %12 %13 %33 ; %32 -> %13
+         %43 = OpConvertSToF %6 %13 ; %29 -> %13
+  )" + epilogue;
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context =
+      BuildModule(env, consumer, original, kReduceAssembleOption);
+  const auto pass = TestSubclass<OperandToConstReductionPass>(env);
+  const auto ops = pass.WrapGetAvailableOpportunities(context.get());
+  ASSERT_EQ(17, ops.size());
+  ASSERT_TRUE(ops[0]->PreconditionHolds());
+  ops[0]->TryToApply();
+  ASSERT_TRUE(ops[1]->PreconditionHolds());
+  ops[1]->TryToApply();
+  ASSERT_TRUE(ops[2]->PreconditionHolds());
+  ops[2]->TryToApply();
+  ASSERT_TRUE(ops[3]->PreconditionHolds());
+  ops[3]->TryToApply();
+
+  CheckEqual(env, expected, context.get());
+}
+
+}  // namespace
+}  // namespace reduce
+}  // namespace spvtools

--- a/test/reduce/operand_to_constant_reduction_pass_test.cpp
+++ b/test/reduce/operand_to_constant_reduction_pass_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Google Inc.
+// Copyright (c) 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/reduce/reduce_test_util.cpp
+++ b/test/reduce/reduce_test_util.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "reduce_test_util.h"
+
+namespace spvtools {
+namespace reduce {
+
+void CheckEqual(const spv_target_env env,
+                const std::vector<uint32_t>& expected_binary,
+                const std::vector<uint32_t>& actual_binary) {
+  if (expected_binary != actual_binary) {
+    SpirvTools t(env);
+    std::string expected_disassembled;
+    std::string actual_disassembled;
+    ASSERT_TRUE(t.Disassemble(expected_binary, &expected_disassembled,
+                              kReduceDisassembleOption));
+    ASSERT_TRUE(t.Disassemble(actual_binary, &actual_disassembled,
+                              kReduceDisassembleOption));
+    ASSERT_EQ(expected_disassembled, actual_disassembled);
+  }
+}
+
+void CheckEqual(const spv_target_env env, const std::string& expected_text,
+                const std::vector<uint32_t>& actual_binary) {
+  std::vector<uint32_t> expected_binary;
+  SpirvTools t(env);
+  ASSERT_TRUE(
+      t.Assemble(expected_text, &expected_binary, kReduceAssembleOption));
+  CheckEqual(env, expected_binary, actual_binary);
+}
+
+void CheckEqual(const spv_target_env env, const std::string& expected_text,
+                const opt::IRContext* actual_ir) {
+  std::vector<uint32_t> actual_binary;
+  actual_ir->module()->ToBinary(&actual_binary, false);
+  CheckEqual(env, expected_text, actual_binary);
+}
+
+}  // namespace reduce
+}  // namespace spvtools

--- a/test/reduce/reduce_test_util.cpp
+++ b/test/reduce/reduce_test_util.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Google Inc.
+// Copyright (c) 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/reduce/reduce_test_util.h
+++ b/test/reduce/reduce_test_util.h
@@ -24,12 +24,15 @@
 namespace spvtools {
 namespace reduce {
 
+// A helper class that subclasses a given reduction pass class in order to provide a wrapper for its protected methods.
 template <class ReductionPassT>
 class TestSubclass : public ReductionPassT {
  public:
+  // Creates an instance of the reduction pass subclass with respect to target environment |env|.
   explicit TestSubclass(const spv_target_env env) : ReductionPassT(env) {}
   ~TestSubclass() = default;
 
+  // A wrapper for GetAvailableOpportunities(...)
   std::vector<std::unique_ptr<ReductionOpportunity>>
   WrapGetAvailableOpportunities(opt::IRContext* context) const {
     return ReductionPassT::GetAvailableOpportunities(context);
@@ -51,8 +54,10 @@ void CheckEqual(spv_target_env env, const std::string& expected_text,
 void CheckEqual(spv_target_env env, const std::string& expected_text,
                 const opt::IRContext* actual_ir);
 
+// Assembly options for writing reduction tests.  It simplifies matters if numeric ids do not change.
 const uint32_t kReduceAssembleOption =
     SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS;
+// Disassembly options for writing reduction tests.
 const uint32_t kReduceDisassembleOption =
     SPV_BINARY_TO_TEXT_OPTION_NO_HEADER | SPV_BINARY_TO_TEXT_OPTION_INDENT;
 

--- a/test/reduce/reduce_test_util.h
+++ b/test/reduce/reduce_test_util.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TEST_REDUCE_REDUCE_TEST_UTIL_H_
+#define TEST_REDUCE_REDUCE_TEST_UTIL_H_
+
+#include "gtest/gtest.h"
+
+#include "source/opt/ir_context.h"
+#include "source/reduce/reduction_opportunity.h"
+#include "spirv-tools/libspirv.h"
+
+namespace spvtools {
+namespace reduce {
+
+template <class ReductionPassT>
+class TestSubclass : public ReductionPassT {
+ public:
+  explicit TestSubclass(const spv_target_env env) : ReductionPassT(env) {}
+  ~TestSubclass() = default;
+
+  std::vector<std::unique_ptr<ReductionOpportunity>>
+  WrapGetAvailableOpportunities(opt::IRContext* context) const {
+    return ReductionPassT::GetAvailableOpportunities(context);
+  }
+};
+
+// Checks whether the given binaries are bit-wise equal.
+void CheckEqual(spv_target_env env,
+                const std::vector<uint32_t>& expected_binary,
+                const std::vector<uint32_t>& actual_binary);
+
+// Assembles the given text and check whether the resulting binary is bit-wise
+// equal to the given binary.
+void CheckEqual(spv_target_env env, const std::string& expected_text,
+                const std::vector<uint32_t>& actual_binary);
+
+// Assembles the given text and turns the given IR into binary, then checks
+// whether the resulting binaries are bit-wise equal.
+void CheckEqual(spv_target_env env, const std::string& expected_text,
+                const opt::IRContext* actual_ir);
+
+const uint32_t kReduceAssembleOption =
+    SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS;
+const uint32_t kReduceDisassembleOption =
+    SPV_BINARY_TO_TEXT_OPTION_NO_HEADER | SPV_BINARY_TO_TEXT_OPTION_INDENT;
+
+}  // namespace reduce
+}  // namespace spvtools
+
+#endif  // TEST_REDUCE_REDUCE_TEST_UTIL_H_

--- a/test/reduce/reduce_test_util.h
+++ b/test/reduce/reduce_test_util.h
@@ -24,11 +24,13 @@
 namespace spvtools {
 namespace reduce {
 
-// A helper class that subclasses a given reduction pass class in order to provide a wrapper for its protected methods.
+// A helper class that subclasses a given reduction pass class in order to
+// provide a wrapper for its protected methods.
 template <class ReductionPassT>
 class TestSubclass : public ReductionPassT {
  public:
-  // Creates an instance of the reduction pass subclass with respect to target environment |env|.
+  // Creates an instance of the reduction pass subclass with respect to target
+  // environment |env|.
   explicit TestSubclass(const spv_target_env env) : ReductionPassT(env) {}
   ~TestSubclass() = default;
 

--- a/test/reduce/reduce_test_util.h
+++ b/test/reduce/reduce_test_util.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Google Inc.
+// Copyright (c) 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/reduce/reduce_test_util.h
+++ b/test/reduce/reduce_test_util.h
@@ -54,7 +54,8 @@ void CheckEqual(spv_target_env env, const std::string& expected_text,
 void CheckEqual(spv_target_env env, const std::string& expected_text,
                 const opt::IRContext* actual_ir);
 
-// Assembly options for writing reduction tests.  It simplifies matters if numeric ids do not change.
+// Assembly options for writing reduction tests.  It simplifies matters if
+// numeric ids do not change.
 const uint32_t kReduceAssembleOption =
     SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS;
 // Disassembly options for writing reduction tests.

--- a/test/reduce/reducer_test.cpp
+++ b/test/reduce/reducer_test.cpp
@@ -218,9 +218,9 @@ TEST(ReducerTest, ExprToConstantAndRemoveUnreferenced) {
   PingPongInteresting ping_pong_interesting(10);
   reducer.SetMessageConsumer(NopDiagnostic);
   reducer.SetInterestingnessFunction(
-          [&](const std::vector<uint32_t> &binary, uint32_t) -> bool {
-            return ping_pong_interesting.IsInteresting(binary);
-          });
+      [&](const std::vector<uint32_t>& binary, uint32_t) -> bool {
+        return ping_pong_interesting.IsInteresting(binary);
+      });
   reducer.AddReductionPass(MakeUnique<OperandToConstReductionPass>(env));
   reducer.AddReductionPass(
       MakeUnique<RemoveUnreferencedInstructionReductionPass>(env));

--- a/test/reduce/reducer_test.cpp
+++ b/test/reduce/reducer_test.cpp
@@ -1,0 +1,243 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "reduce_test_util.h"
+
+#include "source/reduce/operand_to_const_reduction_pass.h"
+#include "source/reduce/reducer.h"
+#include "source/reduce/remove_unreferenced_instruction_reduction_pass.h"
+
+namespace spvtools {
+namespace reduce {
+namespace {
+
+// Don't print reducer info during testing.
+void NopDiagnostic(spv_message_level_t /*level*/, const char* /*source*/,
+                   const spv_position_t& /*position*/,
+                   const char* /*message*/) {}
+
+// This changes is its mind each time IsInteresting is invoked as to whether the
+// binary is interesting, until some limit is reached after which the binary is
+// always deemed interesting.  This is useful to test that reduction passes
+// interleave in interesting ways for a while, and then always succeed after
+// some point; the latter is important to end up with a predictable final
+// reduced binary for tests.
+class PingPongInteresting {
+ public:
+  explicit PingPongInteresting(uint32_t always_interesting_after)
+      : is_interesting_(true),
+        always_interesting_after_(always_interesting_after),
+        count_(0) {}
+
+  bool IsInteresting(const std::vector<uint32_t>&) {
+    bool result;
+    if (count_ > always_interesting_after_) {
+      result = true;
+    } else {
+      result = is_interesting_;
+      is_interesting_ = !is_interesting_;
+    }
+    count_++;
+    return result;
+  }
+
+ private:
+  bool is_interesting_;
+  const uint32_t always_interesting_after_;
+  uint32_t count_;
+};
+
+TEST(ReducerTest, ExprToConstantAndRemoveUnreferenced) {
+  std::string original = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main" %60
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %16 "buf2"
+               OpMemberName %16 0 "i"
+               OpName %18 ""
+               OpName %25 "buf1"
+               OpMemberName %25 0 "f"
+               OpName %27 ""
+               OpName %60 "_GLF_color"
+               OpMemberDecorate %16 0 Offset 0
+               OpDecorate %16 Block
+               OpDecorate %18 DescriptorSet 0
+               OpDecorate %18 Binding 2
+               OpMemberDecorate %25 0 Offset 0
+               OpDecorate %25 Block
+               OpDecorate %27 DescriptorSet 0
+               OpDecorate %27 Binding 1
+               OpDecorate %60 Location 0
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %9 = OpConstant %6 0
+         %16 = OpTypeStruct %6
+         %17 = OpTypePointer Uniform %16
+         %18 = OpVariable %17 Uniform
+         %19 = OpTypePointer Uniform %6
+         %22 = OpTypeBool
+        %100 = OpConstantTrue %22
+         %24 = OpTypeFloat 32
+         %25 = OpTypeStruct %24
+         %26 = OpTypePointer Uniform %25
+         %27 = OpVariable %26 Uniform
+         %28 = OpTypePointer Uniform %24
+         %31 = OpConstant %24 2
+         %56 = OpConstant %6 1
+         %58 = OpTypeVector %24 4
+         %59 = OpTypePointer Output %58
+         %60 = OpVariable %59 Output
+         %72 = OpUndef %24
+         %74 = OpUndef %6
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpBranch %10
+         %10 = OpLabel
+         %73 = OpPhi %6 %74 %5 %77 %34
+         %71 = OpPhi %24 %72 %5 %76 %34
+         %70 = OpPhi %6 %9 %5 %57 %34
+         %20 = OpAccessChain %19 %18 %9
+         %21 = OpLoad %6 %20
+         %23 = OpSLessThan %22 %70 %21
+               OpLoopMerge %12 %34 None
+               OpBranchConditional %23 %11 %12
+         %11 = OpLabel
+         %29 = OpAccessChain %28 %27 %9
+         %30 = OpLoad %24 %29
+         %32 = OpFOrdGreaterThan %22 %30 %31
+               OpSelectionMerge %34 None
+               OpBranchConditional %32 %33 %46
+         %33 = OpLabel
+         %40 = OpFAdd %24 %71 %30
+         %45 = OpISub %6 %73 %21
+               OpBranch %34
+         %46 = OpLabel
+         %50 = OpFMul %24 %71 %30
+         %54 = OpSDiv %6 %73 %21
+               OpBranch %34
+         %34 = OpLabel
+         %77 = OpPhi %6 %45 %33 %54 %46
+         %76 = OpPhi %24 %40 %33 %50 %46
+         %57 = OpIAdd %6 %70 %56
+               OpBranch %10
+         %12 = OpLabel
+         %61 = OpAccessChain %28 %27 %9
+         %62 = OpLoad %24 %61
+         %66 = OpConvertSToF %24 %21
+         %68 = OpConvertSToF %24 %73
+         %69 = OpCompositeConstruct %58 %62 %71 %66 %68
+               OpStore %60 %69
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  std::string expected = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main" %60
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %16 "buf2"
+               OpMemberName %16 0 "i"
+               OpName %18 ""
+               OpName %25 "buf1"
+               OpMemberName %25 0 "f"
+               OpName %27 ""
+               OpName %60 "_GLF_color"
+               OpMemberDecorate %16 0 Offset 0
+               OpDecorate %16 Block
+               OpDecorate %18 DescriptorSet 0
+               OpDecorate %18 Binding 2
+               OpMemberDecorate %25 0 Offset 0
+               OpDecorate %25 Block
+               OpDecorate %27 DescriptorSet 0
+               OpDecorate %27 Binding 1
+               OpDecorate %60 Location 0
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %9 = OpConstant %6 0
+         %16 = OpTypeStruct %6
+         %17 = OpTypePointer Uniform %16
+         %18 = OpVariable %17 Uniform
+         %19 = OpTypePointer Uniform %6
+         %22 = OpTypeBool
+        %100 = OpConstantTrue %22
+         %24 = OpTypeFloat 32
+         %25 = OpTypeStruct %24
+         %26 = OpTypePointer Uniform %25
+         %27 = OpVariable %26 Uniform
+         %28 = OpTypePointer Uniform %24
+         %31 = OpConstant %24 2
+         %56 = OpConstant %6 1
+         %58 = OpTypeVector %24 4
+         %59 = OpTypePointer Output %58
+         %60 = OpVariable %59 Output
+         %72 = OpUndef %24
+         %74 = OpUndef %6
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpBranch %10
+         %10 = OpLabel
+               OpLoopMerge %12 %34 None
+               OpBranchConditional %100 %11 %12
+         %11 = OpLabel
+               OpSelectionMerge %34 None
+               OpBranchConditional %100 %33 %46
+         %33 = OpLabel
+               OpBranch %34
+         %46 = OpLabel
+               OpBranch %34
+         %34 = OpLabel
+               OpBranch %10
+         %12 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  spv_target_env env = SPV_ENV_UNIVERSAL_1_3;
+  Reducer reducer(env);
+  PingPongInteresting ping_pong_interesting(10);
+  reducer.SetMessageConsumer(NopDiagnostic);
+  reducer.SetInterestingFunction(
+      [&](const std::vector<uint32_t>& binary) -> bool {
+        return ping_pong_interesting.IsInteresting(binary);
+      });
+  reducer.AddReductionPass(MakeUnique<OperandToConstReductionPass>(env));
+  reducer.AddReductionPass(
+      MakeUnique<RemoveUnreferencedInstructionReductionPass>(env));
+
+  std::vector<uint32_t> binary_in;
+  SpirvTools t(env);
+
+  ASSERT_TRUE(t.Assemble(original, &binary_in, kReduceAssembleOption));
+  std::vector<uint32_t> binary_out;
+  spvtools::ReducerOptions reducer_options;
+  reducer_options.set_step_limit(500);
+
+  reducer.Run(std::move(binary_in), binary_out, reducer_options);
+
+  CheckEqual(env, expected, binary_out);
+}
+
+}  // namespace
+}  // namespace reduce
+}  // namespace spvtools

--- a/test/reduce/reducer_test.cpp
+++ b/test/reduce/reducer_test.cpp
@@ -233,7 +233,7 @@ TEST(ReducerTest, ExprToConstantAndRemoveUnreferenced) {
   spvtools::ReducerOptions reducer_options;
   reducer_options.set_step_limit(500);
 
-  reducer.Run(std::move(binary_in), binary_out, reducer_options);
+  reducer.Run(std::move(binary_in), &binary_out, reducer_options);
 
   CheckEqual(env, expected, binary_out);
 }

--- a/test/reduce/reducer_test.cpp
+++ b/test/reduce/reducer_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Google Inc.
+// Copyright (c) 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/reduce/reducer_test.cpp
+++ b/test/reduce/reducer_test.cpp
@@ -217,10 +217,10 @@ TEST(ReducerTest, ExprToConstantAndRemoveUnreferenced) {
   Reducer reducer(env);
   PingPongInteresting ping_pong_interesting(10);
   reducer.SetMessageConsumer(NopDiagnostic);
-  reducer.SetInterestingFunction(
-      [&](const std::vector<uint32_t>& binary) -> bool {
-        return ping_pong_interesting.IsInteresting(binary);
-      });
+  reducer.SetInterestingnessFunction(
+          [&](const std::vector<uint32_t> &binary) -> bool {
+            return ping_pong_interesting.IsInteresting(binary);
+          });
   reducer.AddReductionPass(MakeUnique<OperandToConstReductionPass>(env));
   reducer.AddReductionPass(
       MakeUnique<RemoveUnreferencedInstructionReductionPass>(env));

--- a/test/reduce/reducer_test.cpp
+++ b/test/reduce/reducer_test.cpp
@@ -218,7 +218,7 @@ TEST(ReducerTest, ExprToConstantAndRemoveUnreferenced) {
   PingPongInteresting ping_pong_interesting(10);
   reducer.SetMessageConsumer(NopDiagnostic);
   reducer.SetInterestingnessFunction(
-          [&](const std::vector<uint32_t> &binary) -> bool {
+          [&](const std::vector<uint32_t> &binary, uint32_t) -> bool {
             return ping_pong_interesting.IsInteresting(binary);
           });
   reducer.AddReductionPass(MakeUnique<OperandToConstReductionPass>(env));

--- a/test/reduce/remove_unreferenced_instruction_reduction_pass_test.cpp
+++ b/test/reduce/remove_unreferenced_instruction_reduction_pass_test.cpp
@@ -139,12 +139,12 @@ TEST(RemoveUnreferencedInstructionReductionPassTest, ApplyReduction) {
     const std::string expected_reduced = prologue + R"(
          %15 = OpLoad %6 %8
     )" + epilogue;
-    auto reduced_binary = pass.ApplyReduction(binary);
+    auto reduced_binary = pass.TryApplyReduction(binary);
     CheckEqual(env, expected_reduced, reduced_binary);
   }
 
   // Attempt 2 should fail as pass with granularity 4 got to end.
-  ASSERT_EQ(0, pass.ApplyReduction(binary).size());
+  ASSERT_EQ(0, pass.TryApplyReduction(binary).size());
 
   {
     // Attempt 3 should remove first two removable statements.
@@ -153,7 +153,7 @@ TEST(RemoveUnreferencedInstructionReductionPassTest, ApplyReduction) {
          %15 = OpLoad %6 %8
                OpStore %14 %15
     )" + epilogue;
-    auto reduced_binary = pass.ApplyReduction(binary);
+    auto reduced_binary = pass.TryApplyReduction(binary);
     CheckEqual(env, expected_reduced, reduced_binary);
   }
 
@@ -164,12 +164,12 @@ TEST(RemoveUnreferencedInstructionReductionPassTest, ApplyReduction) {
                OpStore %10 %11
          %15 = OpLoad %6 %8
     )" + epilogue;
-    auto reduced_binary = pass.ApplyReduction(binary);
+    auto reduced_binary = pass.TryApplyReduction(binary);
     CheckEqual(env, expected_reduced, reduced_binary);
   }
 
   // Attempt 5 should fail as pass with granularity 2 got to end.
-  ASSERT_EQ(0, pass.ApplyReduction(binary).size());
+  ASSERT_EQ(0, pass.TryApplyReduction(binary).size());
 
   {
     // Attempt 6 should remove first removable statement.
@@ -179,7 +179,7 @@ TEST(RemoveUnreferencedInstructionReductionPassTest, ApplyReduction) {
          %15 = OpLoad %6 %8
                OpStore %14 %15
     )" + epilogue;
-    auto reduced_binary = pass.ApplyReduction(binary);
+    auto reduced_binary = pass.TryApplyReduction(binary);
     CheckEqual(env, expected_reduced, reduced_binary);
   }
 
@@ -191,7 +191,7 @@ TEST(RemoveUnreferencedInstructionReductionPassTest, ApplyReduction) {
          %15 = OpLoad %6 %8
                OpStore %14 %15
     )" + epilogue;
-    auto reduced_binary = pass.ApplyReduction(binary);
+    auto reduced_binary = pass.TryApplyReduction(binary);
     CheckEqual(env, expected_reduced, reduced_binary);
   }
 
@@ -203,7 +203,7 @@ TEST(RemoveUnreferencedInstructionReductionPassTest, ApplyReduction) {
          %15 = OpLoad %6 %8
                OpStore %14 %15
     )" + epilogue;
-    auto reduced_binary = pass.ApplyReduction(binary);
+    auto reduced_binary = pass.TryApplyReduction(binary);
     CheckEqual(env, expected_reduced, reduced_binary);
   }
 
@@ -215,12 +215,12 @@ TEST(RemoveUnreferencedInstructionReductionPassTest, ApplyReduction) {
                OpStore %12 %13
          %15 = OpLoad %6 %8
     )" + epilogue;
-    auto reduced_binary = pass.ApplyReduction(binary);
+    auto reduced_binary = pass.TryApplyReduction(binary);
     CheckEqual(env, expected_reduced, reduced_binary);
   }
 
   // Attempt 10 should fail as pass with granularity 1 got to end.
-  ASSERT_EQ(0, pass.ApplyReduction(binary).size());
+  ASSERT_EQ(0, pass.TryApplyReduction(binary).size());
 
   ASSERT_TRUE(pass.ReachedMinimumGranularity());
 }

--- a/test/reduce/remove_unreferenced_instruction_reduction_pass_test.cpp
+++ b/test/reduce/remove_unreferenced_instruction_reduction_pass_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Google Inc.
+// Copyright (c) 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/reduce/remove_unreferenced_instruction_reduction_pass_test.cpp
+++ b/test/reduce/remove_unreferenced_instruction_reduction_pass_test.cpp
@@ -1,0 +1,230 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "reduce_test_util.h"
+
+#include "source/opt/build_module.h"
+#include "source/reduce/reduction_opportunity.h"
+#include "source/reduce/remove_unreferenced_instruction_reduction_pass.h"
+
+namespace spvtools {
+namespace reduce {
+namespace {
+
+TEST(RemoveUnreferencedInstructionReductionPassTest, RemoveStores) {
+  const std::string prologue = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %8 "a"
+               OpName %10 "b"
+               OpName %12 "c"
+               OpName %14 "d"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Function %6
+          %9 = OpConstant %6 10
+         %11 = OpConstant %6 20
+         %13 = OpConstant %6 30
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+          %8 = OpVariable %7 Function
+         %10 = OpVariable %7 Function
+         %12 = OpVariable %7 Function
+         %14 = OpVariable %7 Function
+  )";
+
+  const std::string epilogue = R"(
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const std::string original = prologue + R"(
+               OpStore %8 %9
+               OpStore %10 %11
+               OpStore %12 %13
+         %15 = OpLoad %6 %8
+               OpStore %14 %15
+  )" + epilogue;
+
+  const std::string expected = prologue + R"(
+               OpStore %12 %13
+         %15 = OpLoad %6 %8
+               OpStore %14 %15
+  )" + epilogue;
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context =
+      BuildModule(env, consumer, original, kReduceAssembleOption);
+  const auto pass =
+      TestSubclass<RemoveUnreferencedInstructionReductionPass>(env);
+  const auto ops = pass.WrapGetAvailableOpportunities(context.get());
+  ASSERT_EQ(4, ops.size());
+  ASSERT_TRUE(ops[0]->PreconditionHolds());
+  ops[0]->TryToApply();
+  ASSERT_TRUE(ops[1]->PreconditionHolds());
+  ops[1]->TryToApply();
+
+  CheckEqual(env, expected, context.get());
+}
+
+TEST(RemoveUnreferencedInstructionReductionPassTest, ApplyReduction) {
+  const std::string prologue = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %8 "a"
+               OpName %10 "b"
+               OpName %12 "c"
+               OpName %14 "d"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Function %6
+          %9 = OpConstant %6 10
+         %11 = OpConstant %6 20
+         %13 = OpConstant %6 30
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+          %8 = OpVariable %7 Function
+         %10 = OpVariable %7 Function
+         %12 = OpVariable %7 Function
+         %14 = OpVariable %7 Function
+  )";
+
+  const std::string epilogue = R"(
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const std::string original = prologue + R"(
+               OpStore %8 %9
+               OpStore %10 %11
+               OpStore %12 %13
+         %15 = OpLoad %6 %8
+               OpStore %14 %15
+  )" + epilogue;
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+
+  std::vector<uint32_t> binary;
+  SpirvTools t(env);
+  ASSERT_TRUE(t.Assemble(original, &binary, kReduceAssembleOption));
+
+  auto pass = TestSubclass<RemoveUnreferencedInstructionReductionPass>(env);
+
+  {
+    // Attempt 1 should remove everything removable.
+    const std::string expected_reduced = prologue + R"(
+         %15 = OpLoad %6 %8
+    )" + epilogue;
+    auto reduced_binary = pass.ApplyReduction(binary);
+    CheckEqual(env, expected_reduced, reduced_binary);
+  }
+
+  // Attempt 2 should fail as pass with granularity 4 got to end.
+  ASSERT_EQ(0, pass.ApplyReduction(binary).size());
+
+  {
+    // Attempt 3 should remove first two removable statements.
+    const std::string expected_reduced = prologue + R"(
+               OpStore %12 %13
+         %15 = OpLoad %6 %8
+               OpStore %14 %15
+    )" + epilogue;
+    auto reduced_binary = pass.ApplyReduction(binary);
+    CheckEqual(env, expected_reduced, reduced_binary);
+  }
+
+  {
+    // Attempt 4 should remove last two removable statements.
+    const std::string expected_reduced = prologue + R"(
+               OpStore %8 %9
+               OpStore %10 %11
+         %15 = OpLoad %6 %8
+    )" + epilogue;
+    auto reduced_binary = pass.ApplyReduction(binary);
+    CheckEqual(env, expected_reduced, reduced_binary);
+  }
+
+  // Attempt 5 should fail as pass with granularity 2 got to end.
+  ASSERT_EQ(0, pass.ApplyReduction(binary).size());
+
+  {
+    // Attempt 6 should remove first removable statement.
+    const std::string expected_reduced = prologue + R"(
+               OpStore %10 %11
+               OpStore %12 %13
+         %15 = OpLoad %6 %8
+               OpStore %14 %15
+    )" + epilogue;
+    auto reduced_binary = pass.ApplyReduction(binary);
+    CheckEqual(env, expected_reduced, reduced_binary);
+  }
+
+  {
+    // Attempt 7 should remove second removable statement.
+    const std::string expected_reduced = prologue + R"(
+               OpStore %8 %9
+               OpStore %12 %13
+         %15 = OpLoad %6 %8
+               OpStore %14 %15
+    )" + epilogue;
+    auto reduced_binary = pass.ApplyReduction(binary);
+    CheckEqual(env, expected_reduced, reduced_binary);
+  }
+
+  {
+    // Attempt 8 should remove third removable statement.
+    const std::string expected_reduced = prologue + R"(
+               OpStore %8 %9
+               OpStore %10 %11
+         %15 = OpLoad %6 %8
+               OpStore %14 %15
+    )" + epilogue;
+    auto reduced_binary = pass.ApplyReduction(binary);
+    CheckEqual(env, expected_reduced, reduced_binary);
+  }
+
+  {
+    // Attempt 9 should remove fourth removable statement.
+    const std::string expected_reduced = prologue + R"(
+               OpStore %8 %9
+               OpStore %10 %11
+               OpStore %12 %13
+         %15 = OpLoad %6 %8
+    )" + epilogue;
+    auto reduced_binary = pass.ApplyReduction(binary);
+    CheckEqual(env, expected_reduced, reduced_binary);
+  }
+
+  // Attempt 10 should fail as pass with granularity 1 got to end.
+  ASSERT_EQ(0, pass.ApplyReduction(binary).size());
+
+  ASSERT_TRUE(pass.ReachedMinimumGranularity());
+}
+
+}  // namespace
+}  // namespace reduce
+}  // namespace spvtools

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -42,6 +42,7 @@ if (NOT ${SPIRV_SKIP_EXECUTABLES})
   add_spvtools_tool(TARGET spirv-dis SRCS dis/dis.cpp LIBS ${SPIRV_TOOLS})
   add_spvtools_tool(TARGET spirv-val SRCS val/val.cpp util/cli_consumer.cpp LIBS ${SPIRV_TOOLS})
   add_spvtools_tool(TARGET spirv-opt SRCS opt/opt.cpp util/cli_consumer.cpp LIBS SPIRV-Tools-opt ${SPIRV_TOOLS})
+  add_spvtools_tool(TARGET spirv-reduce SRCS reduce/reduce.cpp util/cli_consumer.cpp LIBS SPIRV-Tools-reduce ${SPIRV_TOOLS})
   add_spvtools_tool(TARGET spirv-link SRCS link/linker.cpp LIBS SPIRV-Tools-link ${SPIRV_TOOLS})
   add_spvtools_tool(TARGET spirv-stats
 	            SRCS stats/stats.cpp
@@ -61,7 +62,7 @@ if (NOT ${SPIRV_SKIP_EXECUTABLES})
                                                  ${SPIRV_HEADER_INCLUDE_DIR})
 
   set(SPIRV_INSTALL_TARGETS spirv-as spirv-dis spirv-val spirv-opt spirv-stats
-                            spirv-cfg spirv-link)
+                            spirv-cfg spirv-link spirv-reduce)
 
   if(SPIRV_BUILD_COMPRESSION)
     add_spvtools_tool(TARGET spirv-markv

--- a/tools/reduce/reduce.cpp
+++ b/tools/reduce/reduce.cpp
@@ -188,9 +188,15 @@ int main(int argc, const char** argv) {
 
   Reducer reducer(target_env);
 
-  const std::string command = std::string(interestingness_test) + " temp.spv";
-  reducer.SetInterestingnessFunction([&](std::vector<uint32_t> binary) -> bool {
-    assert(WriteFile("temp.spv", "wb", &binary[0], binary.size()));
+  reducer.SetInterestingnessFunction([&](std::vector<uint32_t> binary,
+          uint32_t reductions_applied) -> bool {
+    std::stringstream ss;
+    ss << "temp_" << std::setw(4) << std::setfill('0') << reductions_applied
+        << ".spv";
+    const auto spv_file = ss.str();
+    const std::string command = std::string(interestingness_test) + " "
+            + spv_file;
+    assert(WriteFile(spv_file.c_str(), "wb", &binary[0], binary.size()));
     return ExecuteCommand(command) == 0;
   });
 

--- a/tools/reduce/reduce.cpp
+++ b/tools/reduce/reduce.cpp
@@ -44,10 +44,14 @@ bool CheckExecuteCommand() {
 // Execute a command using the shell. Redirects to stdout.txt and stderr.txt in
 // |temp_dir|. |temp_dir| should end with a slash.
 int ExecuteCommand(const std::string& command) {
+#ifndef SPIRV_ANDROID
   errno = 0;
+#endif
   int status = std::system(command.c_str());
 
+#ifndef SPIRV_ANDROID
   assert(errno == 0 && "failed to execute command");
+#endif
 
 #ifdef SPIRV_WINDOWS
   return status;

--- a/tools/reduce/reduce.cpp
+++ b/tools/reduce/reduce.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cassert>
+#include <cerrno>
 #include <cstring>
 #include <functional>
 
@@ -44,14 +45,9 @@ bool CheckExecuteCommand() {
 // Execute a command using the shell. Redirects to stdout.txt and stderr.txt in
 // |temp_dir|. |temp_dir| should end with a slash.
 int ExecuteCommand(const std::string& command) {
-#ifndef SPIRV_ANDROID
   errno = 0;
-#endif
   int status = std::system(command.c_str());
-
-#ifndef SPIRV_ANDROID
   assert(errno == 0 && "failed to execute command");
-#endif
 
 #ifdef SPIRV_WINDOWS
   return status;

--- a/tools/reduce/reduce.cpp
+++ b/tools/reduce/reduce.cpp
@@ -1,0 +1,215 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cassert>
+#include <cstring>
+#include <functional>
+
+#include "source/opt/build_module.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/log.h"
+#include "source/reduce/operand_to_const_reduction_pass.h"
+#include "source/reduce/reducer.h"
+#include "source/reduce/remove_unreferenced_instruction_reduction_pass.h"
+#include "source/spirv_reducer_options.h"
+#include "source/util/make_unique.h"
+#include "source/util/string_utils.h"
+#include "spirv-tools/libspirv.hpp"
+#include "tools/io.h"
+#include "tools/util/cli_consumer.h"
+
+using namespace spvtools::reduce;
+
+namespace {
+
+using ErrorOrInt = std::pair<std::string, int>;
+
+// Check that the std::system function can actually be used.
+bool CheckExecuteCommand() {
+  int res = std::system(nullptr);
+  return res != 0;
+}
+
+// Execute a command using the shell. Redirects to stdout.txt and stderr.txt in
+// |temp_dir|. |temp_dir| should end with a slash.
+int ExecuteCommand(const std::string& command) {
+  errno = 0;
+  int status = std::system(command.c_str());
+
+  assert(errno == 0 && "failed to execute command");
+
+#ifdef SPIRV_WINDOWS
+  return status;
+#else
+  return WEXITSTATUS(status);  // NOLINT
+#endif
+}
+
+// Status and actions to perform after parsing command-line arguments.
+enum ReduceActions { REDUCE_CONTINUE, REDUCE_STOP };
+
+struct ReduceStatus {
+  ReduceActions action;
+  int code;
+};
+
+void PrintUsage(const char* program) {
+  // NOTE: Please maintain flags in lexicographical order.
+  printf(
+      R"(%s - Reduce a SPIR-V binary file with respect to a user-provided interestingness test.
+
+USAGE: %s [options] <input>
+
+The SPIR-V binary is read from <input>.
+
+NOTE: The reducer is a work in progress.
+
+Options (in lexicographical order):
+  -h, --help
+               Print this help.
+  --step-limit
+               32-bit unsigned integer specifying maximum number of
+               steps the reducer will take before giving up.
+  --version
+               Display reducer version information.
+)",
+      program, program);
+}
+
+// Message consumer for this tool.  Used to emit diagnostics during
+// initialization and setup. Note that |source| and |position| are irrelevant
+// here because we are still not processing a SPIR-V input file.
+void ReduceDiagnostic(spv_message_level_t level, const char* /*source*/,
+                      const spv_position_t& /*position*/, const char* message) {
+  if (level == SPV_MSG_ERROR) {
+    fprintf(stderr, "error: ");
+  }
+  fprintf(stderr, "%s\n", message);
+}
+
+ReduceStatus ParseFlags(int argc, const char** argv, const char** in_file,
+                        const char** interestingness_test,
+                        spvtools::ReducerOptions* reducer_options) {
+  uint32_t positional_arg_index = 0;
+
+  for (int argi = 1; argi < argc; ++argi) {
+    const char* cur_arg = argv[argi];
+    if ('-' == cur_arg[0]) {
+      if (0 == strcmp(cur_arg, "--version")) {
+        spvtools::Logf(ReduceDiagnostic, SPV_MSG_INFO, nullptr, {}, "%s\n",
+                       spvSoftwareVersionDetailsString());
+        return {REDUCE_STOP, 0};
+      } else if (0 == strcmp(cur_arg, "--help") || 0 == strcmp(cur_arg, "-h")) {
+        PrintUsage(argv[0]);
+        return {REDUCE_STOP, 0};
+      } else if ('\0' == cur_arg[1]) {
+        // We do not support reduction from standard input.  We could support
+        // this if there was a compelling use case.
+        PrintUsage(argv[0]);
+        return {REDUCE_STOP, 0};
+      } else if (0 == strncmp(cur_arg,
+                              "--step-limit=", sizeof("--step-limit=") - 1)) {
+        const auto split_flag = spvtools::utils::SplitFlagArgs(cur_arg);
+        char* end = nullptr;
+        errno = 0;
+        const auto step_limit =
+            static_cast<uint32_t>(strtol(split_flag.second.c_str(), &end, 10));
+        assert(end != split_flag.second.c_str() && errno == 0);
+        reducer_options->set_step_limit(step_limit);
+      }
+    } else if (positional_arg_index == 0) {
+      // Input file name
+      assert(!*in_file);
+      *in_file = cur_arg;
+      positional_arg_index++;
+    } else if (positional_arg_index == 1) {
+      assert(!*interestingness_test);
+      *interestingness_test = cur_arg;
+      positional_arg_index++;
+    } else {
+      spvtools::Error(ReduceDiagnostic, nullptr, {},
+                      "Too many positional arguments specified");
+      return {REDUCE_STOP, 1};
+    }
+  }
+
+  if (!*in_file) {
+    spvtools::Error(ReduceDiagnostic, nullptr, {}, "No input file specified");
+    return {REDUCE_STOP, 1};
+  }
+
+  if (!*interestingness_test) {
+    spvtools::Error(ReduceDiagnostic, nullptr, {},
+                    "No interestingness test specified");
+    return {REDUCE_STOP, 1};
+  }
+
+  return {REDUCE_CONTINUE, 0};
+}
+
+}  // namespace
+
+const auto kDefaultEnvironment = SPV_ENV_UNIVERSAL_1_3;
+
+int main(int argc, const char** argv) {
+  const char* in_file = nullptr;
+  const char* interestingness_test = nullptr;
+
+  spv_target_env target_env = kDefaultEnvironment;
+  spvtools::ReducerOptions reducer_options;
+
+  ReduceStatus status =
+      ParseFlags(argc, argv, &in_file, &interestingness_test, &reducer_options);
+
+  if (status.action == REDUCE_STOP) {
+    return status.code;
+  }
+
+  if (!CheckExecuteCommand()) {
+    std::cerr << "could not find shell interpreter for executing a command"
+              << std::endl;
+    return 2;
+  }
+
+  Reducer reducer(target_env);
+  reducer.SetMessageConsumer(spvtools::utils::CLIMessageConsumer);
+
+  const std::string command = std::string(interestingness_test) + " temp.spv";
+  reducer.SetInterestingFunction([&](std::vector<uint32_t> binary) -> bool {
+    assert(WriteFile("temp.spv", "wb", &binary[0], binary.size()));
+    return ExecuteCommand(command) == 0;
+  });
+
+  reducer.AddReductionPass(
+      spvtools::MakeUnique<OperandToConstReductionPass>(target_env));
+  reducer.AddReductionPass(
+      spvtools::MakeUnique<RemoveUnreferencedInstructionReductionPass>(
+          target_env));
+
+  std::vector<uint32_t> binary_in;
+  if (!ReadFile<uint32_t>(in_file, "rb", &binary_in)) {
+    return 1;
+  }
+
+  std::vector<uint32_t> binary_out;
+  const bool ok =
+      reducer.Run(std::move(binary_in), binary_out, reducer_options);
+
+  if (!ok || !WriteFile<uint32_t>("_reduced_final.spv", "wb", binary_out.data(),
+                                  binary_out.size())) {
+    return 1;
+  }
+
+  return 0;
+}

--- a/tools/reduce/reduce.cpp
+++ b/tools/reduce/reduce.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Google Inc.
+// Copyright (c) 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/reduce/reduce.cpp
+++ b/tools/reduce/reduce.cpp
@@ -199,6 +199,7 @@ int main(int argc, const char** argv) {
             std::string(interestingness_test) + " " + spv_file;
         auto write_file_succeeded =
             WriteFile(spv_file.c_str(), "wb", &binary[0], binary.size());
+        (void)(write_file_succeeded);
         assert(write_file_succeeded);
         return ExecuteCommand(command) == 0;
       });

--- a/tools/reduce/reduce.cpp
+++ b/tools/reduce/reduce.cpp
@@ -188,19 +188,20 @@ int main(int argc, const char** argv) {
 
   Reducer reducer(target_env);
 
-  reducer.SetInterestingnessFunction([interestingness_test]
-  (std::vector<uint32_t> binary, uint32_t reductions_applied) -> bool {
-    std::stringstream ss;
-    ss << "temp_" << std::setw(4) << std::setfill('0') << reductions_applied
-        << ".spv";
-    const auto spv_file = ss.str();
-    const std::string command = std::string(interestingness_test) + " "
-            + spv_file;
-    auto write_file_succeeded =
+  reducer.SetInterestingnessFunction(
+      [interestingness_test](std::vector<uint32_t> binary,
+                             uint32_t reductions_applied) -> bool {
+        std::stringstream ss;
+        ss << "temp_" << std::setw(4) << std::setfill('0') << reductions_applied
+           << ".spv";
+        const auto spv_file = ss.str();
+        const std::string command =
+            std::string(interestingness_test) + " " + spv_file;
+        auto write_file_succeeded =
             WriteFile(spv_file.c_str(), "wb", &binary[0], binary.size());
-    assert(write_file_succeeded);
-    return ExecuteCommand(command) == 0;
-  });
+        assert(write_file_succeeded);
+        return ExecuteCommand(command) == 0;
+      });
 
   reducer.AddReductionPass(
       spvtools::MakeUnique<OperandToConstReductionPass>(target_env));
@@ -217,13 +218,12 @@ int main(int argc, const char** argv) {
 
   std::vector<uint32_t> binary_out;
   const auto reduction_status =
-          reducer.Run(std::move(binary_in), &binary_out, reducer_options);
+      reducer.Run(std::move(binary_in), &binary_out, reducer_options);
 
   if (reduction_status ==
-      Reducer::ReductionResultStatus::kInitialStateNotInteresting
-      ||
+          Reducer::ReductionResultStatus::kInitialStateNotInteresting ||
       !WriteFile<uint32_t>("_reduced_final.spv", "wb", binary_out.data(),
-                                  binary_out.size())) {
+                           binary_out.size())) {
     return 1;
   }
 

--- a/tools/reduce/reduce.cpp
+++ b/tools/reduce/reduce.cpp
@@ -67,11 +67,15 @@ struct ReduceStatus {
 void PrintUsage(const char* program) {
   // NOTE: Please maintain flags in lexicographical order.
   printf(
-      R"(%s - Reduce a SPIR-V binary file with respect to a user-provided interestingness test.
+      R"(%s - Reduce a SPIR-V binary file with respect to a user-provided
+              interestingness test.
 
-USAGE: %s [options] <input>
+USAGE: %s [options] <input> <interestingness-test>
 
 The SPIR-V binary is read from <input>.
+
+Whether a binary is interesting is determined by <interestingness-test>, which
+is typically a script.
 
 NOTE: The reducer is a work in progress.
 
@@ -204,10 +208,13 @@ int main(int argc, const char** argv) {
   }
 
   std::vector<uint32_t> binary_out;
-  const bool ok =
-      reducer.Run(std::move(binary_in), binary_out, reducer_options);
+  const auto reduction_status =
+          reducer.Run(std::move(binary_in), &binary_out, reducer_options);
 
-  if (!ok || !WriteFile<uint32_t>("_reduced_final.spv", "wb", binary_out.data(),
+  if (reduction_status ==
+      Reducer::ReductionResultStatus::kInitialStateNotInteresting
+      ||
+      !WriteFile<uint32_t>("_reduced_final.spv", "wb", binary_out.data(),
                                   binary_out.size())) {
     return 1;
   }

--- a/tools/reduce/reduce.cpp
+++ b/tools/reduce/reduce.cpp
@@ -186,7 +186,7 @@ int main(int argc, const char** argv) {
   reducer.SetMessageConsumer(spvtools::utils::CLIMessageConsumer);
 
   const std::string command = std::string(interestingness_test) + " temp.spv";
-  reducer.SetInterestingFunction([&](std::vector<uint32_t> binary) -> bool {
+  reducer.SetInterestingnessFunction([&](std::vector<uint32_t> binary) -> bool {
     assert(WriteFile("temp.spv", "wb", &binary[0], binary.size()));
     return ExecuteCommand(command) == 0;
   });

--- a/tools/reduce/reduce.cpp
+++ b/tools/reduce/reduce.cpp
@@ -188,15 +188,17 @@ int main(int argc, const char** argv) {
 
   Reducer reducer(target_env);
 
-  reducer.SetInterestingnessFunction([&](std::vector<uint32_t> binary,
-          uint32_t reductions_applied) -> bool {
+  reducer.SetInterestingnessFunction([interestingness_test]
+  (std::vector<uint32_t> binary, uint32_t reductions_applied) -> bool {
     std::stringstream ss;
     ss << "temp_" << std::setw(4) << std::setfill('0') << reductions_applied
         << ".spv";
     const auto spv_file = ss.str();
     const std::string command = std::string(interestingness_test) + " "
             + spv_file;
-    assert(WriteFile(spv_file.c_str(), "wb", &binary[0], binary.size()));
+    auto write_file_succeeded =
+            WriteFile(spv_file.c_str(), "wb", &binary[0], binary.size());
+    assert(write_file_succeeded);
     return ExecuteCommand(command) == 0;
   });
 

--- a/tools/reduce/reduce.cpp
+++ b/tools/reduce/reduce.cpp
@@ -183,7 +183,6 @@ int main(int argc, const char** argv) {
   }
 
   Reducer reducer(target_env);
-  reducer.SetMessageConsumer(spvtools::utils::CLIMessageConsumer);
 
   const std::string command = std::string(interestingness_test) + " temp.spv";
   reducer.SetInterestingnessFunction([&](std::vector<uint32_t> binary) -> bool {
@@ -196,6 +195,8 @@ int main(int argc, const char** argv) {
   reducer.AddReductionPass(
       spvtools::MakeUnique<RemoveUnreferencedInstructionReductionPass>(
           target_env));
+
+  reducer.SetMessageConsumer(spvtools::utils::CLIMessageConsumer);
 
   std::vector<uint32_t> binary_in;
   if (!ReadFile<uint32_t>(in_file, "rb", &binary_in)) {


### PR DESCRIPTION
This PR contributes the design of a new tool, spirv-reduce, for shrinking down a SPIR-V binary according to some user-defined "interestingness test" (inspired by the interestingness tests used by C-Reduce).

Currently only a couple of reduction passes are implemented - one that replaces a non-constant operand id with a constant, and another that removes an instruction whose id is not used.

I have re-used infrastructure from spirv-opt where possible, but have not tried to over-unify things; e.g. a reduction pass is fundamentally different from an optimization pass.