### PR TITLE
Remove long running cfg limit test.

### DIFF
--- a/test/val/val_limits_test.cpp
+++ b/test/val/val_limits_test.cpp
@@ -713,14 +713,6 @@ void GenerateSpirvProgramWithCfgNestingDepth(std::string& str, int depth) {
 }
 // clang-format on
 
-// Valid: Control Flow Nesting depth is 1023.
-TEST_F(ValidateLimits, ControlFlowDepthGood) {
-  std::string spirv;
-  GenerateSpirvProgramWithCfgNestingDepth(spirv, 1023);
-  CompileSuccessfully(spirv);
-  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
-}
-
 // Invalid: Control Flow Nesting depth is 1024. (limit is 1023).
 TEST_F(ValidateLimits, ControlFlowDepthBad) {
   std::string spirv;


### PR DESCRIPTION
We had a test that checks that a spirv binary where the depth of the
deepest nested construct is just below the default limit.  This test
would take a long time causing a timeout in some builds.  We are
questioning the value of the test since we already have a test that can
tell us if we are within a custom limit.  We will remove the test.

Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/2079.