### PR TITLE
Update build instructions: add effcee, re2

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ out code:
 ```sh
 cd <spirv-dir>
 git clone https://github.com/KhronosGroup/SPIRV-Headers.git external/spirv-headers
+git clone https://github.com/google/effcee.git external/effcee
+git clone https://github.com/google/re2.git external/re2
 git clone https://github.com/google/googletest.git external/googletest # optional
 
 mkdir build && cd build


### PR DESCRIPTION
Both effcee and re2 are now required dependencies, add their checkout in build instructions.