### PR TITLE
Check forbidden Annotation instructions for WebGPU env

### DIFF
--- a/source/val/validate_annotation.cpp
+++ b/source/val/validate_annotation.cpp
@@ -15,6 +15,7 @@
 #include "source/val/validate.h"
 
 #include "source/opcode.h"
+#include "source/spirv_target_env.h"
 #include "source/val/instruction.h"
 #include "source/val/validation_state.h"
 
@@ -63,6 +64,12 @@ spv_result_t ValidateMemberDecorate(ValidationState_t& _,
 
 spv_result_t ValidateDecorationGroup(ValidationState_t& _,
                                      const Instruction* inst) {
+  if (spvIsWebGPUEnv(_.context()->target_env)) {
+    return _.diag(SPV_ERROR_INVALID_BINARY, inst)
+           << "OpDecorationGroup is not allowed in the WebGPU execution "
+           << "environment.";
+  }
+
   const auto decoration_group_id = inst->GetOperandAs<uint32_t>(0);
   const auto decoration_group = _.FindDef(decoration_group_id);
   for (auto pair : decoration_group->uses()) {
@@ -81,6 +88,12 @@ spv_result_t ValidateDecorationGroup(ValidationState_t& _,
 
 spv_result_t ValidateGroupDecorate(ValidationState_t& _,
                                    const Instruction* inst) {
+  if (spvIsWebGPUEnv(_.context()->target_env)) {
+    return _.diag(SPV_ERROR_INVALID_BINARY, inst)
+           << "OpGroupDecorate is not allowed in the WebGPU execution "
+           << "environment.";
+  }
+
   const auto decoration_group_id = inst->GetOperandAs<uint32_t>(0);
   auto decoration_group = _.FindDef(decoration_group_id);
   if (!decoration_group || SpvOpDecorationGroup != decoration_group->opcode()) {
@@ -103,6 +116,12 @@ spv_result_t ValidateGroupDecorate(ValidationState_t& _,
 
 spv_result_t ValidateGroupMemberDecorate(ValidationState_t& _,
                                          const Instruction* inst) {
+  if (spvIsWebGPUEnv(_.context()->target_env)) {
+    return _.diag(SPV_ERROR_INVALID_BINARY, inst)
+           << "OpGroupMemberDecorate is not allowed in the WebGPU execution "
+           << "environment.";
+  }
+
   const auto decoration_group_id = inst->GetOperandAs<uint32_t>(0);
   const auto decoration_group = _.FindDef(decoration_group_id);
   if (!decoration_group || SpvOpDecorationGroup != decoration_group->opcode()) {

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -148,6 +148,42 @@ TEST_F(ValidateDecorations, ValidateGroupDecorateRegistration) {
   EXPECT_THAT(vstate_->id_decorations(4), Eq(expected_decorations));
 }
 
+TEST_F(ValidateDecorations, WebGPUOpDecorationGroupBad) {
+  std::string spirv = R"(
+               OpCapability Shader
+               OpCapability Linkage
+               OpMemoryModel Logical GLSL450
+               OpDecorate %1 DescriptorSet 0
+               OpDecorate %1 NonWritable
+               OpDecorate %1 Restrict
+          %1 = OpDecorationGroup
+               OpGroupDecorate %1 %2 %3
+               OpGroupDecorate %1 %4
+  %float = OpTypeFloat 32
+%_runtimearr_float = OpTypeRuntimeArray %float
+  %_struct_9 = OpTypeStruct %_runtimearr_float
+%_ptr_Uniform__struct_9 = OpTypePointer Uniform %_struct_9
+         %2 = OpVariable %_ptr_Uniform__struct_9 Uniform
+ %_struct_10 = OpTypeStruct %_runtimearr_float
+%_ptr_Uniform__struct_10 = OpTypePointer Uniform %_struct_10
+         %3 = OpVariable %_ptr_Uniform__struct_10 Uniform
+ %_struct_11 = OpTypeStruct %_runtimearr_float
+%_ptr_Uniform__struct_11 = OpTypePointer Uniform %_struct_11
+         %4 = OpVariable %_ptr_Uniform__struct_11 Uniform
+  )";
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_BINARY, ValidateInstructions(SPV_ENV_WEBGPU_0));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpDecorationGroup is not allowed in the WebGPU "
+                        "execution environment.\n  %1 = OpDecorationGroup\n"));
+}
+
+// For WebGPU, OpGroupDecorate does not have a test case, because it requires
+// being preceded by OpDecorationGroup, which will cause a validation error.
+
+// For WebGPU, OpGroupMemberDecorate does not have a test case, because it
+// requires being preceded by OpDecorationGroup, which will cause a validation error.
+
 TEST_F(ValidateDecorations, ValidateGroupMemberDecorateRegistration) {
   std::string spirv = R"(
                OpCapability Shader

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -182,7 +182,8 @@ TEST_F(ValidateDecorations, WebGPUOpDecorationGroupBad) {
 // being preceded by OpDecorationGroup, which will cause a validation error.
 
 // For WebGPU, OpGroupMemberDecorate does not have a test case, because it
-// requires being preceded by OpDecorationGroup, which will cause a validation error.
+// requires being preceded by OpDecorationGroup, which will cause a validation
+// error.
 
 TEST_F(ValidateDecorations, ValidateGroupMemberDecorateRegistration) {
   std::string spirv = R"(


### PR DESCRIPTION
From the WebGPU SPIR-V Execution Enviroment spec:
  OpDecorationGroup, OpGroupDecorate, OpGroupMemberDecorate are not
  allowed.

Fixes #2062