### PR TITLE
Ensure correct Addressing and Memory model set for WebGPU

### DIFF
--- a/source/val/validate_instruction.cpp
+++ b/source/val/validate_instruction.cpp
@@ -463,6 +463,17 @@ spv_result_t InstructionPass(ValidationState_t& _, const Instruction* inst) {
              << "VulkanMemoryModelKHR capability must only be specified if the "
                 "VulkanKHR memory model is used.";
     }
+
+    if (spvIsWebGPUEnv(_.context()->target_env)) {
+      if (_.addressing_model() != SpvAddressingModelLogical) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << "Addressing model must be Logical for WebGPU environment.";
+      }
+      if (_.memory_model() != SpvMemoryModelVulkanKHR) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << "Memory model must be VulkanKHR for WebGPU environment.";
+      }
+    }
   } else if (opcode == SpvOpExecutionMode) {
     const uint32_t entry_point = inst->word(1);
     _.RegisterExecutionModeForEntryPoint(entry_point,

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -152,7 +152,9 @@ TEST_F(ValidateDecorations, WebGPUOpDecorationGroupBad) {
   std::string spirv = R"(
                OpCapability Shader
                OpCapability Linkage
-               OpMemoryModel Logical GLSL450
+               OpCapability VulkanMemoryModelKHR
+               OpExtension "SPV_KHR_vulkan_memory_model"
+               OpMemoryModel Logical VulkanKHR
                OpDecorate %1 DescriptorSet 0
                OpDecorate %1 NonWritable
                OpDecorate %1 Restrict

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -4316,7 +4316,9 @@ TEST_F(ValidateIdWithMessage, OpVectorShuffleLiterals) {
 TEST_F(ValidateIdWithMessage, WebGPUOpVectorShuffle0xFFFFFFFFLiteralBad) {
   std::string spirv = R"(
     OpCapability Shader
-    OpMemoryModel Logical GLSL450
+    OpCapability VulkanMemoryModelKHR
+    OpExtension "SPV_KHR_vulkan_memory_model"
+    OpMemoryModel Logical VulkanKHR
 %float = OpTypeFloat 32
 %vec2 = OpTypeVector %float 2
 %vec3 = OpTypeVector %float 3

--- a/test/val/val_version_test.cpp
+++ b/test/val/val_version_test.cpp
@@ -40,6 +40,21 @@ OpReturn
 OpFunctionEnd
 )";
 
+const std::string webgpu_spirv = R"(
+OpCapability Shader
+OpCapability VulkanMemoryModelKHR
+OpExtension "SPV_KHR_vulkan_memory_model"
+OpMemoryModel Logical VulkanKHR
+OpEntryPoint Fragment %func "func"
+OpExecutionMode %func OriginUpperLeft
+%void = OpTypeVoid
+%functy = OpTypeFunction %void
+%func = OpFunction %void None %functy
+%1 = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
 const std::string opencl_spirv = R"(
 OpCapability Kernel
 OpCapability Linkage
@@ -107,7 +122,7 @@ INSTANTIATE_TEST_CASE_P(Universal, ValidateVersion,
     std::make_tuple(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_OPENGL_4_2,    vulkan_spirv, true),
     std::make_tuple(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_OPENGL_4_3,    vulkan_spirv, true),
     std::make_tuple(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_OPENGL_4_5,    vulkan_spirv, true),
-    std::make_tuple(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_WEBGPU_0,      vulkan_spirv, true),
+    std::make_tuple(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_WEBGPU_0,      webgpu_spirv, true),
 
     std::make_tuple(SPV_ENV_UNIVERSAL_1_1, SPV_ENV_UNIVERSAL_1_0, vulkan_spirv, false),
     std::make_tuple(SPV_ENV_UNIVERSAL_1_1, SPV_ENV_UNIVERSAL_1_1, vulkan_spirv, true),
@@ -120,7 +135,7 @@ INSTANTIATE_TEST_CASE_P(Universal, ValidateVersion,
     std::make_tuple(SPV_ENV_UNIVERSAL_1_1, SPV_ENV_OPENGL_4_2,    vulkan_spirv, false),
     std::make_tuple(SPV_ENV_UNIVERSAL_1_1, SPV_ENV_OPENGL_4_3,    vulkan_spirv, false),
     std::make_tuple(SPV_ENV_UNIVERSAL_1_1, SPV_ENV_OPENGL_4_5,    vulkan_spirv, false),
-    std::make_tuple(SPV_ENV_UNIVERSAL_1_1, SPV_ENV_WEBGPU_0,      vulkan_spirv, true),
+    std::make_tuple(SPV_ENV_UNIVERSAL_1_1, SPV_ENV_WEBGPU_0,      webgpu_spirv, true),
 
     std::make_tuple(SPV_ENV_UNIVERSAL_1_2, SPV_ENV_UNIVERSAL_1_0, vulkan_spirv, false),
     std::make_tuple(SPV_ENV_UNIVERSAL_1_2, SPV_ENV_UNIVERSAL_1_1, vulkan_spirv, false),
@@ -133,7 +148,7 @@ INSTANTIATE_TEST_CASE_P(Universal, ValidateVersion,
     std::make_tuple(SPV_ENV_UNIVERSAL_1_2, SPV_ENV_OPENGL_4_2,    vulkan_spirv, false),
     std::make_tuple(SPV_ENV_UNIVERSAL_1_2, SPV_ENV_OPENGL_4_3,    vulkan_spirv, false),
     std::make_tuple(SPV_ENV_UNIVERSAL_1_2, SPV_ENV_OPENGL_4_5,    vulkan_spirv, false),
-    std::make_tuple(SPV_ENV_UNIVERSAL_1_2, SPV_ENV_WEBGPU_0,      vulkan_spirv, true),
+    std::make_tuple(SPV_ENV_UNIVERSAL_1_2, SPV_ENV_WEBGPU_0,      webgpu_spirv, true),
 
     std::make_tuple(SPV_ENV_UNIVERSAL_1_3, SPV_ENV_UNIVERSAL_1_0, vulkan_spirv, false),
     std::make_tuple(SPV_ENV_UNIVERSAL_1_3, SPV_ENV_UNIVERSAL_1_1, vulkan_spirv, false),
@@ -146,7 +161,7 @@ INSTANTIATE_TEST_CASE_P(Universal, ValidateVersion,
     std::make_tuple(SPV_ENV_UNIVERSAL_1_3, SPV_ENV_OPENGL_4_2,    vulkan_spirv, false),
     std::make_tuple(SPV_ENV_UNIVERSAL_1_3, SPV_ENV_OPENGL_4_3,    vulkan_spirv, false),
     std::make_tuple(SPV_ENV_UNIVERSAL_1_3, SPV_ENV_OPENGL_4_5,    vulkan_spirv, false),
-    std::make_tuple(SPV_ENV_UNIVERSAL_1_3, SPV_ENV_WEBGPU_0,      vulkan_spirv, true)
+    std::make_tuple(SPV_ENV_UNIVERSAL_1_3, SPV_ENV_WEBGPU_0,      webgpu_spirv, true)
   )
 );
 


### PR DESCRIPTION
Adding validation that the addressing declared by OpMemoryModel is
Logical and the memory model declared is VulkanKHR. Updating a bunch
of tests that were broken by this.

Fixes #2060 