### PR TITLE
Change HexFloat to work with gcc8.

### DIFF
--- a/source/util/hex_float.h
+++ b/source/util/hex_float.h
@@ -672,7 +672,7 @@ class HexFloat {
 
     // If we are Nan or Inf we should pass that through.
     if (is_inf) {
-      other.set_value(BitwiseCast<typename other_T::underlying_type>(
+      other.set_value(typename other_T::underlying_type(
           static_cast<typename other_T::uint_type>(
               (negate ? other_T::sign_mask : 0) | other_T::exponent_mask)));
       return;
@@ -687,7 +687,7 @@ class HexFloat {
       // We are some sort of Nan. We try to keep the bit-pattern of the Nan
       // as close as possible. If we had to shift off bits so we are 0, then we
       // just set the last bit.
-      other.set_value(BitwiseCast<typename other_T::underlying_type>(
+      other.set_value(typename other_T::underlying_type(
           static_cast<typename other_T::uint_type>(
               (negate ? other_T::sign_mask : 0) | other_T::exponent_mask |
               (shifted_significand == 0 ? 0x1 : shifted_significand))));


### PR DESCRIPTION
When we want to set a the value of a HexFloat to inf or nan, we
construct the specific bit pattern in an appropriately sized integer.
That integer is copied to a FloatProxy object through a memcpy.  GCC8
complains about the memcpy because it is overwriting a private member of
the class.

The original solution worked well because the template to the HexFloat
could be anything.  However, we only used some instantiation of FloatProxy,
which has a construction from that takes its uint_type, so I decided to use
that constructor instead of the memcpy.  This puts an extra requirement
on the templace for HexFloat, but it will be fine for us.

Part of #1541.