### PR TITLE
Restrict capabilities to WebGPU spec

### DIFF
--- a/source/val/validate_capability.cpp
+++ b/source/val/validate_capability.cpp
@@ -220,6 +220,19 @@ bool IsEnabledByCapabilityOpenCL_2_0(ValidationState_t& _,
   return false;
 }
 
+bool IsSupportGuaranteedWebGPU(uint32_t capability) {
+  switch (capability) {
+    case SpvCapabilityMatrix:
+    case SpvCapabilityShader:
+    case SpvCapabilitySampled1D:
+    case SpvCapabilityImage1D:
+    case SpvCapabilityDerivativeControl:
+    case SpvCapabilityImageQuery:
+      return true;
+  }
+  return false;
+}
+
 }  // namespace
 
 // Validates that capability declarations use operands allowed in the current
@@ -302,6 +315,14 @@ spv_result_t CapabilityPass(ValidationState_t& _, const Instruction* inst) {
              << " is not allowed by OpenCL 2.2 " << opencl_profile
              << " Profile specification"
              << " (or requires extension or capability)";
+    }
+  } else if (env == SPV_ENV_WEBGPU_0) {
+    if (!IsSupportGuaranteedWebGPU(capability) &&
+        !IsEnabledByExtension(_, capability)) {
+      return _.diag(SPV_ERROR_INVALID_CAPABILITY, inst)
+             << "Capability " << capability_str()
+             << " is not allowed by WebGPU specification"
+             << " (or requires extension)";
     }
   }
 

--- a/test/val/val_capability_test.cpp
+++ b/test/val/val_capability_test.cpp
@@ -112,6 +112,8 @@ using ValidateCapabilityVulkan10 = spvtest::ValidateBase<CapTestParameter>;
 using ValidateCapabilityOpenGL40 = spvtest::ValidateBase<CapTestParameter>;
 // Always assembles using Vulkan 1.1.
 using ValidateCapabilityVulkan11 = spvtest::ValidateBase<CapTestParameter>;
+// Always assembles using WebGPU.
+using ValidateCapabilityWebGPU = spvtest::ValidateBase<CapTestParameter>;
 
 TEST_F(ValidateCapability, Default) {
   const char str[] = R"(
@@ -382,6 +384,18 @@ const std::vector<std::string>& AllVulkan11Capabilities() {
   return *r;
 }
 
+const std::vector<std::string>& AllWebGPUCapabilities() {
+  static const auto r = new std::vector<std::string>{
+    "",
+    "Shader",
+    "Matrix",
+    "Sampled1D",
+    "Image1D",
+    "ImageQuery",
+    "DerivativeControl"};
+    return *r;
+}
+
 const std::vector<std::string>& MatrixDependencies() {
   static const auto r = new std::vector<std::string>{
   "Matrix",
@@ -571,6 +585,12 @@ const char kOpenCLMemoryModel[] = \
 const char kGLSL450MemoryModel[] = \
   " OpCapability Shader"
   " OpMemoryModel Logical GLSL450 ";
+
+const char kVulkanMemoryModel[] = \
+  " OpCapability Shader"
+  " OpCapability VulkanMemoryModelKHR"
+  " OpExtension \"SPV_KHR_vulkan_memory_model\""
+  " OpMemoryModel Logical VulkanKHR ";
 
 const char kVoidFVoid[] = \
   " %void   = OpTypeVoid"
@@ -1529,6 +1549,16 @@ std::make_pair(std::string(kGLSL450MemoryModel) +
           AllSpirV10Capabilities())
 )),);
 
+INSTANTIATE_TEST_CASE_P(Capabilities, ValidateCapabilityWebGPU,
+                        Combine(
+                            // All capabilities to try.
+                            ValuesIn(AllCapabilities()),
+                            Values(
+std::make_pair(std::string(kVulkanMemoryModel) +
+          "OpEntryPoint Vertex %func \"shader\" \n" + std::string(kVoidFVoid),
+          AllWebGPUCapabilities())
+)),);
+
 INSTANTIATE_TEST_CASE_P(Capabilities, ValidateCapabilityVulkan11,
                         Combine(
                             // All capabilities to try.
@@ -1716,6 +1746,17 @@ TEST_P(ValidateCapabilityOpenGL40, Capability) {
     CompileSuccessfully(test_code, SPV_ENV_OPENGL_4_0);
     ASSERT_EQ(ExpectedResult(GetParam()),
               ValidateInstructions(SPV_ENV_OPENGL_4_0))
+        << test_code;
+  }
+}
+
+TEST_P(ValidateCapabilityWebGPU, Capability) {
+  const std::string capability = Capability(GetParam());
+  if (Exists(capability, SPV_ENV_WEBGPU_0)) {
+    const std::string test_code = MakeAssembly(GetParam());
+    CompileSuccessfully(test_code, SPV_ENV_WEBGPU_0);
+    ASSERT_EQ(ExpectedResult(GetParam()),
+              ValidateInstructions(SPV_ENV_WEBGPU_0))
         << test_code;
   }
 }
@@ -2352,92 +2393,6 @@ OpMemoryModel Logical GLSL450
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("VulkanMemoryModelKHR capability must only be "
                         "specified if the VulkanKHR memory model is used"));
-}
-
-TEST_F(ValidateCapability, WebGPUWhitelistCapabilitiesAllowed) {
-  const std::string spirv = R"(
-          OpCapability Matrix
-          OpCapability Shader
-          OpCapability Sampled1D
-          OpCapability Image1D
-          OpCapability DerivativeControl
-          OpCapability ImageQuery
-          OpCapability VulkanMemoryModelKHR
-          OpExtension "SPV_KHR_vulkan_memory_model"
-          OpMemoryModel Logical VulkanKHR
-          OpEntryPoint Vertex %func "shader"
-%void   = OpTypeVoid
-%void_f = OpTypeFunction %void
-%func   = OpFunction %void None %void_f
-%label  = OpLabel
-          OpReturn
-          OpFunctionEnd
-)";
-
-  CompileSuccessfully(spirv, SPV_ENV_WEBGPU_0);
-  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_WEBGPU_0))
-      << getDiagnosticString();
-}
-
-TEST_F(ValidateCapability, WebGPULinkageDisallowed) {
-  const std::string spirv = R"(
-          OpCapability Matrix
-          OpCapability Shader
-          OpCapability Sampled1D
-          OpCapability Image1D
-          OpCapability DerivativeControl
-          OpCapability ImageQuery
-          OpCapability VulkanMemoryModelKHR
-          OpCapability Linkage
-          OpExtension "SPV_KHR_vulkan_memory_model"
-          OpMemoryModel Logical VulkanKHR
-          OpEntryPoint Vertex %func "shader"
-%void   = OpTypeVoid
-%void_f = OpTypeFunction %void
-%func   = OpFunction %void None %void_f
-%label  = OpLabel
-          OpReturn
-          OpFunctionEnd
-)";
-
-  CompileSuccessfully(spirv, SPV_ENV_WEBGPU_0);
-  EXPECT_EQ(SPV_ERROR_INVALID_CAPABILITY,
-            ValidateInstructions(SPV_ENV_WEBGPU_0));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Capability Linkage is not allowed by WebGPU "
-                        "specification (or requires extension)\n"
-                        "  OpCapability Linkage\n"));
-}
-
-TEST_F(ValidateCapability, WebGPULinkageKernelDisallowed) {
-  const std::string spirv = R"(
-          OpCapability Matrix
-          OpCapability Shader
-          OpCapability Sampled1D
-          OpCapability Image1D
-          OpCapability DerivativeControl
-          OpCapability ImageQuery
-          OpCapability VulkanMemoryModelKHR
-          OpCapability Kernel
-          OpExtension "SPV_KHR_vulkan_memory_model"
-          OpMemoryModel Logical VulkanKHR
-          OpEntryPoint Vertex %func "shader"
-%void   = OpTypeVoid
-%void_f = OpTypeFunction %void
-%func   = OpFunction %void None %void_f
-%label  = OpLabel
-          OpReturn
-          OpFunctionEnd
-)";
-
-  CompileSuccessfully(spirv, SPV_ENV_WEBGPU_0);
-  EXPECT_EQ(SPV_ERROR_INVALID_CAPABILITY,
-            ValidateInstructions(SPV_ENV_WEBGPU_0));
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Capability Kernel is not allowed by WebGPU specification (or "
-                "requires extension)\n"
-                "  OpCapability Kernel\n"));
 }
 
 }  // namespace

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -151,7 +151,6 @@ TEST_F(ValidateDecorations, ValidateGroupDecorateRegistration) {
 TEST_F(ValidateDecorations, WebGPUOpDecorationGroupBad) {
   std::string spirv = R"(
                OpCapability Shader
-               OpCapability Linkage
                OpCapability VulkanMemoryModelKHR
                OpExtension "SPV_KHR_vulkan_memory_model"
                OpMemoryModel Logical VulkanKHR

--- a/test/val/val_webgpu_test.cpp
+++ b/test/val/val_webgpu_test.cpp
@@ -29,13 +29,19 @@ using ValidateWebGPU = spvtest::ValidateBase<bool>;
 
 TEST_F(ValidateWebGPU, OpUndefIsDisallowed) {
   std::string spirv = R"(
-    OpCapability Shader
-    OpCapability Linkage
-    OpCapability VulkanMemoryModelKHR
-    OpExtension "SPV_KHR_vulkan_memory_model"
-    OpMemoryModel Logical VulkanKHR
-    %float = OpTypeFloat 32
-    %1 = OpUndef %float
+          OpCapability Shader
+          OpCapability VulkanMemoryModelKHR
+          OpExtension "SPV_KHR_vulkan_memory_model"
+          OpMemoryModel Logical VulkanKHR
+          OpEntryPoint Vertex %func "shader"
+%float  = OpTypeFloat 32
+%1      = OpUndef %float
+%void   = OpTypeVoid
+%void_f = OpTypeFunction %void
+%func   = OpFunction %void None %void_f
+%label  = OpLabel
+          OpReturn
+          OpFunctionEnd
 )";
 
   CompileSuccessfully(spirv);
@@ -51,7 +57,6 @@ TEST_F(ValidateWebGPU, OpUndefIsDisallowed) {
 TEST_F(ValidateWebGPU, OpNameIsDisallowed) {
   std::string spirv = R"(
      OpCapability Shader
-     OpCapability Linkage
      OpCapability VulkanMemoryModelKHR
      OpExtension "SPV_KHR_vulkan_memory_model"
      OpMemoryModel Logical VulkanKHR
@@ -70,7 +75,6 @@ TEST_F(ValidateWebGPU, OpNameIsDisallowed) {
 TEST_F(ValidateWebGPU, OpMemberNameIsDisallowed) {
   std::string spirv = R"(
      OpCapability Shader
-     OpCapability Linkage
      OpCapability VulkanMemoryModelKHR
      OpExtension "SPV_KHR_vulkan_memory_model"
      OpMemoryModel Logical VulkanKHR
@@ -91,7 +95,6 @@ TEST_F(ValidateWebGPU, OpMemberNameIsDisallowed) {
 TEST_F(ValidateWebGPU, OpSourceIsDisallowed) {
   std::string spirv = R"(
      OpCapability Shader
-     OpCapability Linkage
      OpCapability VulkanMemoryModelKHR
      OpExtension "SPV_KHR_vulkan_memory_model"
      OpMemoryModel Logical VulkanKHR
@@ -112,7 +115,6 @@ TEST_F(ValidateWebGPU, OpSourceIsDisallowed) {
 TEST_F(ValidateWebGPU, OpSourceExtensionIsDisallowed) {
   std::string spirv = R"(
      OpCapability Shader
-     OpCapability Linkage
      OpCapability VulkanMemoryModelKHR
      OpExtension "SPV_KHR_vulkan_memory_model"
      OpMemoryModel Logical VulkanKHR
@@ -131,7 +133,6 @@ TEST_F(ValidateWebGPU, OpSourceExtensionIsDisallowed) {
 TEST_F(ValidateWebGPU, OpStringIsDisallowed) {
   std::string spirv = R"(
      OpCapability Shader
-     OpCapability Linkage
      OpCapability VulkanMemoryModelKHR
      OpExtension "SPV_KHR_vulkan_memory_model"
      OpMemoryModel Logical VulkanKHR
@@ -152,7 +153,6 @@ TEST_F(ValidateWebGPU, OpStringIsDisallowed) {
 TEST_F(ValidateWebGPU, OpNoLineDisallowed) {
   std::string spirv = R"(
      OpCapability Shader
-     OpCapability Linkage
      OpCapability VulkanMemoryModelKHR
      OpExtension "SPV_KHR_vulkan_memory_model"
      OpMemoryModel Logical VulkanKHR
@@ -169,11 +169,17 @@ TEST_F(ValidateWebGPU, OpNoLineDisallowed) {
 
 TEST_F(ValidateWebGPU, LogicalAddressingVulkanKHRMemoryGood) {
   std::string spirv = R"(
-     OpCapability Shader
-     OpCapability Linkage
-     OpCapability VulkanMemoryModelKHR
-     OpExtension "SPV_KHR_vulkan_memory_model"
-     OpMemoryModel Logical VulkanKHR
+          OpCapability Shader
+          OpCapability VulkanMemoryModelKHR
+          OpExtension "SPV_KHR_vulkan_memory_model"
+          OpMemoryModel Logical VulkanKHR
+          OpEntryPoint Vertex %func "shader"
+%void   = OpTypeVoid
+%void_f = OpTypeFunction %void
+%func   = OpFunction %void None %void_f
+%label  = OpLabel
+          OpReturn
+          OpFunctionEnd
 )";
 
   CompileSuccessfully(spirv);
@@ -184,7 +190,6 @@ TEST_F(ValidateWebGPU, LogicalAddressingVulkanKHRMemoryGood) {
 TEST_F(ValidateWebGPU, NonLogicalAddressingModelBad) {
   std::string spirv = R"(
      OpCapability Shader
-     OpCapability Linkage
      OpCapability VulkanMemoryModelKHR
      OpExtension "SPV_KHR_vulkan_memory_model"
      OpMemoryModel Physical32 VulkanKHR
@@ -202,7 +207,6 @@ TEST_F(ValidateWebGPU, NonLogicalAddressingModelBad) {
 TEST_F(ValidateWebGPU, NonVulkanKHRMemoryModelBad) {
   std::string spirv = R"(
      OpCapability Shader
-     OpCapability Linkage
      OpMemoryModel Logical GLSL450
      OpNoLine
 )";


### PR DESCRIPTION
This covers whitelisting Matrix, Shader, Sampled1D, Image1D,
DerivativeControl, and ImageQuery. These are the allowed capabilities
that don't require an extension. Whitelisting VulkanMemoryModelKHR
will be handled by whitelisting its extension in a seperate patch.

Fixes #2101