### PR TITLE
Validate PushConstants annotation and type

### DIFF
--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -796,12 +796,15 @@ spv_result_t CheckDecorationsOfBuffers(ValidationState_t& vstate) {
         ComputeMemberConstraintsForStruct(&constraints, id, LayoutConstraints(),
                                           vstate);
 
-        if (push_constant && !hasDecoration(id, SpvDecorationBlock, vstate)) {
-          return vstate.diag(SPV_ERROR_INVALID_ID, vstate.FindDef(id))
-                 << "PushConstant id '" << id
-                 << "' is missing Block decoration.\n"
-                 << "From Vulkan spec, section 14.5.1:\n"
-                 << "Such variables must be identified with a Block decoration";
+        // Vulkan 14.5.1: Check Block annotation for PushConstant variables.
+        if (spvIsVulkanEnv(vstate.context()->target_env)) {
+          if (push_constant && !hasDecoration(id, SpvDecorationBlock, vstate)) {
+            return vstate.diag(SPV_ERROR_INVALID_ID, vstate.FindDef(id))
+                << "PushConstant id '" << id
+                << "' is missing Block decoration.\n"
+                << "From Vulkan spec, section 14.5.1:\n"
+                << "Such variables must be identified with a Block decoration";
+          }
         }
 
         // Prepare for messages

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -795,6 +795,15 @@ spv_result_t CheckDecorationsOfBuffers(ValidationState_t& vstate) {
         MemberConstraints constraints;
         ComputeMemberConstraintsForStruct(&constraints, id, LayoutConstraints(),
                                           vstate);
+
+        if (push_constant && !hasDecoration(id, SpvDecorationBlock, vstate)) {
+          return vstate.diag(SPV_ERROR_INVALID_ID, vstate.FindDef(id))
+                 << "PushConstant id '" << id
+                 << "' is missing Block decoration.\n"
+                 << "From Vulkan spec, section 14.5.1:\n"
+                 << "Such variables must be identified with a Block decoration";
+        }
+
         // Prepare for messages
         const char* sc_str =
             uniform ? "Uniform"

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -800,10 +800,11 @@ spv_result_t CheckDecorationsOfBuffers(ValidationState_t& vstate) {
         if (spvIsVulkanEnv(vstate.context()->target_env)) {
           if (push_constant && !hasDecoration(id, SpvDecorationBlock, vstate)) {
             return vstate.diag(SPV_ERROR_INVALID_ID, vstate.FindDef(id))
-                << "PushConstant id '" << id
-                << "' is missing Block decoration.\n"
-                << "From Vulkan spec, section 14.5.1:\n"
-                << "Such variables must be identified with a Block decoration";
+                   << "PushConstant id '" << id
+                   << "' is missing Block decoration.\n"
+                   << "From Vulkan spec, section 14.5.1:\n"
+                   << "Such variables must be identified with a Block "
+                      "decoration";
           }
         }
 

--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -73,9 +73,9 @@ bool AreLayoutCompatibleStructs(ValidationState_t& _, const Instruction* type1,
 bool HaveLayoutCompatibleMembers(ValidationState_t& _, const Instruction* type1,
                                  const Instruction* type2) {
   assert(type1->opcode() == SpvOpTypeStruct &&
-         "type1 must be and OpTypeStruct instruction.");
+         "type1 must be an OpTypeStruct instruction.");
   assert(type2->opcode() == SpvOpTypeStruct &&
-         "type2 must be and OpTypeStruct instruction.");
+         "type2 must be an OpTypeStruct instruction.");
   const auto& type1_operands = type1->operands();
   const auto& type2_operands = type2->operands();
   if (type1_operands.size() != type2_operands.size()) {
@@ -100,9 +100,9 @@ bool HaveLayoutCompatibleMembers(ValidationState_t& _, const Instruction* type1,
 bool HaveSameLayoutDecorations(ValidationState_t& _, const Instruction* type1,
                                const Instruction* type2) {
   assert(type1->opcode() == SpvOpTypeStruct &&
-         "type1 must be and OpTypeStruct instruction.");
+         "type1 must be an OpTypeStruct instruction.");
   assert(type2->opcode() == SpvOpTypeStruct &&
-         "type2 must be and OpTypeStruct instruction.");
+         "type2 must be an OpTypeStruct instruction.");
   const std::vector<Decoration>& type1_decorations =
       _.id_decorations(type1->id());
   const std::vector<Decoration>& type2_decorations =
@@ -382,7 +382,7 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
                SpvOpTypeAccelerationStructureNV})) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
                << "UniformConstant OpVariable <id> '" << _.getIdName(inst->id())
-               << " 'has illegal type.\n"
+               << "' has illegal type.\n"
                << "From Vulkan spec, section 14.5.2:\n"
                << "Variables identified with the UniformConstant storage class "
                << "are used only as handles to refer to opaque resources. Such "
@@ -396,13 +396,24 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
       if (!IsAllowedTypeOrArrayOfSame(_, pointee, {SpvOpTypeStruct})) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
                << "Uniform OpVariable <id> '" << _.getIdName(inst->id())
-               << " 'has illegal type.\n"
+               << "' has illegal type.\n"
                << "From Vulkan spec, section 14.5.2:\n"
                << "Variables identified with the Uniform storage class are "
                   "used "
                << "to access transparent buffer backed resources. Such "
                   "variables "
                << "must be typed as OpTypeStruct, or an array of this type";
+      }
+    }
+
+    if (storage_class == SpvStorageClassPushConstant) {
+      if (!IsAllowedTypeOrArrayOfSame(_, pointee, {SpvOpTypeStruct})) {
+        return _.diag(SPV_ERROR_INVALID_ID, inst)
+               << "PushConstant OpVariable <id> '" << _.getIdName(inst->id())
+               << "' has illegal type.\n"
+               << "From Vulkan spec, section 14.5.1:\n"
+               << "Such variables must be typed as OpTypeStruct, "
+               << "or an array of this type";
       }
     }
   }

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -2219,6 +2219,38 @@ TEST_F(ValidateDecorations,
           "rules: member 1 at offset 4 is not aligned to 16"));
 }
 
+TEST_F(ValidateDecorations, PushConstantMissingBlockVulkanBad) {
+  std::string spirv = R"(
+            OpCapability Shader
+            OpMemoryModel Logical GLSL450
+            OpEntryPoint Fragment %1 "main"
+            OpExecutionMode %1 OriginUpperLeft
+
+            OpMemberDecorate %struct 0 Offset 0
+
+    %void = OpTypeVoid
+  %voidfn = OpTypeFunction %void
+   %float = OpTypeFloat 32
+  %struct = OpTypeStruct %float
+     %ptr = OpTypePointer PushConstant %struct
+      %pc = OpVariable %ptr PushConstant
+
+       %1 = OpFunction %void None %voidfn
+   %label = OpLabel
+            OpReturn
+            OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID,
+            ValidateAndRetrieveValidationState(SPV_ENV_VULKAN_1_1));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("PushConstant id '2' is missing Block decoration.\n"
+                        "From Vulkan spec, section 14.5.1:\n"
+                        "Such variables must be identified with a Block "
+                        "decoration"));
+}
+
 TEST_F(ValidateDecorations, StorageBufferStorageClassArrayBaseAlignmentGood) {
   // Spot check buffer rules when using StorageBuffer storage class with Block
   // decoration.


### PR DESCRIPTION
Check that PushConstant OpVariable is identified by Block decoration and type is struct or array of structs.