### PR TITLE
Be more explicit about SPIRV_WERROR option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ The following CMake options are supported:
   See [`CMakeLists.txt`](CMakeLists.txt) for details.
 * `SPIRV_WERROR={ON|OFF}`, default `ON` - Forces a compilation error on any
   warnings encountered by enabling the compiler-specific compiler front-end
-  option.
+  option.  No compiler front-end options are enabled when this option is OFF.
 
 Additionally, you can pass additional C preprocessor definitions to SPIRV-Tools
 via setting `SPIRV_TOOLS_EXTRA_DEFINITIONS`. For example, by setting it to


### PR DESCRIPTION
There was some confusion about the SPIRV_WERROR option when it is turned
off.  When the option is off nothing is done.  That is, we do not add
-Wno-error.  This means that if the parent project added -Werorr to the
C flags or CXX flags, then warnings will still be treated as errors.

I've updated the README.md to make this explicit.

Fixes #2121.