### PR TITLE
Strict validation of where type ids are acceptable

### DIFF
--- a/test/val/val_arithmetics_test.cpp
+++ b/test/val/val_arithmetics_test.cpp
@@ -605,10 +605,8 @@ TEST_F(ValidateArithmetics, DotNotVectorTypeOperand1) {
 )";
 
   CompileSuccessfully(GenerateCode(body).c_str());
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Expected float vector as operand: Dot operand index 2"));
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 6 cannot be a type"));
 }
 
 TEST_F(ValidateArithmetics, DotNotVectorTypeOperand2) {

--- a/test/val/val_atomics_test.cpp
+++ b/test/val/val_atomics_test.cpp
@@ -378,10 +378,8 @@ TEST_F(ValidateAtomics, AtomicLoadWrongPointerType) {
 )";
 
   CompileSuccessfully(GenerateKernelCode(body));
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("AtomicLoad: expected Pointer to be of type OpTypePointer"));
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 27 cannot be a type"));
 }
 
 TEST_F(ValidateAtomics, AtomicLoadWrongPointerDataType) {
@@ -623,11 +621,8 @@ TEST_F(ValidateAtomics, AtomicExchangeWrongPointerType) {
 )";
 
   CompileSuccessfully(GenerateKernelCode(body));
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr(
-          "AtomicExchange: expected Pointer to be of type OpTypePointer"));
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 33 cannot be a type"));
 }
 
 TEST_F(ValidateAtomics, AtomicExchangeWrongPointerDataType) {
@@ -739,10 +734,8 @@ TEST_F(ValidateAtomics, AtomicCompareExchangeWrongPointerType) {
 )";
 
   CompileSuccessfully(GenerateKernelCode(body));
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("AtomicCompareExchange: expected Pointer to be of type "
-                        "OpTypePointer"));
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 33 cannot be a type"));
 }
 
 TEST_F(ValidateAtomics, AtomicCompareExchangeWrongPointerDataType) {

--- a/test/val/val_barriers_test.cpp
+++ b/test/val/val_barriers_test.cpp
@@ -804,7 +804,8 @@ OpMemoryNamedBarrier %barrier %workgroup %acquire_and_release_uniform
 )";
 
   CompileSuccessfully(GenerateKernelCode(body), SPV_ENV_UNIVERSAL_1_1);
-  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_1));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA,
+            ValidateInstructions(SPV_ENV_UNIVERSAL_1_1));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("MemoryNamedBarrier: Memory Semantics can have at most "
                         "one of the following bits set: Acquire, Release, "
@@ -817,7 +818,7 @@ OpMemoryBarrier %u32 %u32_0
 )";
 
   CompileSuccessfully(GenerateKernelCode(body));
-  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 5 cannot be a type"));
 }
 

--- a/test/val/val_barriers_test.cpp
+++ b/test/val/val_barriers_test.cpp
@@ -804,8 +804,7 @@ OpMemoryNamedBarrier %barrier %workgroup %acquire_and_release_uniform
 )";
 
   CompileSuccessfully(GenerateKernelCode(body), SPV_ENV_UNIVERSAL_1_1);
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA,
-            ValidateInstructions(SPV_ENV_UNIVERSAL_1_1));
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_1));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("MemoryNamedBarrier: Memory Semantics can have at most "
                         "one of the following bits set: Acquire, Release, "
@@ -819,9 +818,7 @@ OpMemoryBarrier %u32 %u32_0
 
   CompileSuccessfully(GenerateKernelCode(body));
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("MemoryBarrier: expected Memory Scope to be a 32-bit int"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 5 cannot be a type"));
 }
 
 TEST_F(ValidateBarriers,

--- a/test/val/val_composites_test.cpp
+++ b/test/val/val_composites_test.cpp
@@ -320,11 +320,8 @@ TEST_F(ValidateComposites, CompositeConstructVectorWrongConsituent1) {
 )";
 
   CompileSuccessfully(GenerateShaderCode(body).c_str());
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Expected Constituents to be scalars or vectors of the same "
-                "type as Result Type components"));
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 5 cannot be a type"));
 }
 
 TEST_F(ValidateComposites, CompositeConstructVectorWrongConsituent2) {
@@ -660,10 +657,8 @@ TEST_F(ValidateComposites, CompositeExtractNotObject) {
 )";
 
   CompileSuccessfully(GenerateShaderCode(body));
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Expected Composite to be an object "
-                        "of composite type"));
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 11 cannot be a type"));
 }
 
 TEST_F(ValidateComposites, CompositeExtractNotComposite) {

--- a/test/val/val_conversion_test.cpp
+++ b/test/val/val_conversion_test.cpp
@@ -972,9 +972,8 @@ TEST_F(ValidateConversion, PtrCastToGenericWrongInputType) {
 )";
 
   CompileSuccessfully(GenerateKernelCode(body).c_str());
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Expected input to be a pointer: PtrCastToGeneric"));
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 4 cannot be a type"));
 }
 
 TEST_F(ValidateConversion, PtrCastToGenericWrongInputStorageClass) {
@@ -1208,9 +1207,8 @@ TEST_F(ValidateConversion, BitcastInputHasNoType) {
 )";
 
   CompileSuccessfully(GenerateKernelCode(body).c_str());
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Expected input to have a type: Bitcast"));
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 4 cannot be a type"));
 }
 
 TEST_F(ValidateConversion, BitcastWrongResultType) {
@@ -1297,9 +1295,8 @@ OpFunctionEnd
 )";
 
   CompileSuccessfully(spirv);
-  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Expected int scalar as input: ConvertUToPtr"));
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 1 cannot be a type"));
 }
 
 }  // namespace

--- a/test/val/val_derivatives_test.cpp
+++ b/test/val/val_derivatives_test.cpp
@@ -119,11 +119,8 @@ TEST_F(ValidateDerivatives, OpDPdxWrongResultType) {
 )";
 
   CompileSuccessfully(GenerateShaderCode(body).c_str());
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Expected Result Type to be float scalar or vector type: "
-                "DPdx"));
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 10 cannot be a type"));
 }
 
 TEST_F(ValidateDerivatives, OpDPdxWrongPType) {

--- a/test/val/val_ext_inst_test.cpp
+++ b/test/val/val_ext_inst_test.cpp
@@ -3335,7 +3335,7 @@ TEST_P(ValidateOpenCLStdUMul24Like, FloatResultType) {
 TEST_P(ValidateOpenCLStdUMul24Like, U64ResultType) {
   const std::string ext_inst_name = GetParam();
   const std::string body =
-      "%val1 = OpExtInst %u64 %extinst " + ext_inst_name + " %u64_0 %u64\n";
+      "%val1 = OpExtInst %u64 %extinst " + ext_inst_name + " %u64_0 %u64_0\n";
 
   CompileSuccessfully(GenerateKernelCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
@@ -4133,10 +4133,8 @@ TEST_P(ValidateOpenCLStdVStoreHalfLike, PNotPointer) {
   }
 
   CompileSuccessfully(GenerateKernelCode(ss.str()));
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpenCL.std " + ext_inst_name +
-                        ": expected operand P to be a pointer"));
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 89 cannot be a type"));
 }
 
 TEST_P(ValidateOpenCLStdVStoreHalfLike, ConstPointer) {
@@ -4306,10 +4304,8 @@ TEST_P(ValidateOpenCLStdVLoadHalfLike, PNotPointer) {
      << " %u32_1 %f16_ptr_workgroup 2\n";
 
   CompileSuccessfully(GenerateKernelCode(ss.str()));
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpenCL.std " + ext_inst_name +
-                        ": expected operand P to be a pointer"));
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 89 cannot be a type"));
 }
 
 TEST_P(ValidateOpenCLStdVLoadHalfLike, OffsetWrongStorageType) {
@@ -4479,10 +4475,8 @@ TEST_F(ValidateExtInst, VLoadNPNotPointer) {
         "%f32_ptr_uniform_constant 2\n";
 
   CompileSuccessfully(GenerateKernelCode(ss.str()));
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpenCL.std vloadn: expected operand P to be a pointer"));
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 120 cannot be a type"));
 }
 
 TEST_F(ValidateExtInst, VLoadNWrongStorageClass) {
@@ -4592,10 +4586,8 @@ TEST_F(ValidateExtInst, VLoadHalfPNotPointer) {
         "%f16_ptr_uniform_constant\n";
 
   CompileSuccessfully(GenerateKernelCode(ss.str()));
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpenCL.std vload_half: expected operand P to be a pointer"));
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 114 cannot be a type"));
 }
 
 TEST_F(ValidateExtInst, VLoadHalfWrongStorageClass) {
@@ -4746,10 +4738,8 @@ TEST_F(ValidateExtInst, VStoreNPNotPointer) {
         "%f32_ptr_generic\n";
 
   CompileSuccessfully(GenerateKernelCode(ss.str()));
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpenCL.std vstoren: expected operand P to be a pointer"));
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 124 cannot be a type"));
 }
 
 TEST_F(ValidateExtInst, VStoreNPNotGeneric) {
@@ -5061,10 +5051,8 @@ TEST_F(ValidateExtInst, OpenCLStdPrintfFormatNotPointer) {
 )";
 
   CompileSuccessfully(GenerateKernelCode(body));
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpenCL.std printf: expected operand Format to be a pointer"));
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 134 cannot be a type"));
 }
 
 TEST_F(ValidateExtInst, OpenCLStdPrintfFormatNotUniformConstStorageClass) {
@@ -5154,10 +5142,8 @@ TEST_F(ValidateExtInst, OpenCLStdPrefetchPtrNotPointer) {
 )";
 
   CompileSuccessfully(GenerateKernelCode(body));
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpenCL.std prefetch: expected operand Ptr to be a pointer"));
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 99 cannot be a type"));
 }
 
 TEST_F(ValidateExtInst, OpenCLStdPrefetchPtrNotCrossWorkgroup) {

--- a/test/val/val_image_test.cpp
+++ b/test/val/val_image_test.cpp
@@ -671,9 +671,8 @@ TEST_F(ValidateImage, ImageTexelPointerImageNotResultTypePointer) {
 )";
 
   CompileSuccessfully(GenerateShaderCode(body).c_str());
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Expected Image to be OpTypePointer"));
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 136 cannot be a type"));
 }
 
 TEST_F(ValidateImage, ImageTexelPointerImageNotImage) {

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -838,6 +838,29 @@ TEST_F(ValidateMemory, ArrayLenIndexNotPointerToStruct) {
           "The Struture's type in OpArrayLength <id> '12' must be a pointer to "
           "an OpTypeStruct.\n  %12 = OpArrayLength %uint %11 0\n"));
 }
+
+TEST_F(ValidateMemory, ArrayLenPointerIsAType) {
+  std::string spirv = R"(
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %1 "main"
+               OpExecutionMode %1 OriginUpperLeft
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+       %uint = OpTypeInt 32 0
+          %1 = OpFunction %void None %3
+          %9 = OpLabel
+         %12 = OpArrayLength %uint %float 0
+               OpReturn
+               OpFunctionEnd
+
+)";
+
+  CompileSuccessfully(spirv.c_str());
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 4 cannot be a type"));
+}
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
Catches many places earlier in validation where type is incorrectly used. #2137 will make the message easier to understand.

Whitelists sets of instructions that can take a type as regular id reference.