### PR TITLE
Clean uses of EvalInt32IfConst

### DIFF
--- a/source/val/validate_atomics.cpp
+++ b/source/val/validate_atomics.cpp
@@ -45,11 +45,11 @@ spv_result_t ValidateMemorySemantics(ValidationState_t& _,
   }
 
   if (!is_const_int32) {
-    return SPV_SUCCESS;
-  }
-
-  if (spvOpcodeIsSpecConstant(_.FindDef(memory_semantics_id)->opcode())) {
-    // We cannot assume the value of the spec constant.
+    if (_.HasCapability(SpvCapabilityShader)) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "Memory Semantics ids must be OpConstant when Shader "
+                "capability is present";
+    }
     return SPV_SUCCESS;
   }
 

--- a/source/val/validate_barriers.cpp
+++ b/source/val/validate_barriers.cpp
@@ -46,11 +46,11 @@ spv_result_t ValidateMemorySemantics(ValidationState_t& _,
   }
 
   if (!is_const_int32) {
-    return SPV_SUCCESS;
-  }
-
-  if (spvOpcodeIsSpecConstant(_.FindDef(id)->opcode())) {
-    // We cannot assume the value of the spec constant.
+    if (_.HasCapability(SpvCapabilityShader)) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "Memory Semantics ids must be OpConstant when Shader "
+                "capability is present";
+    }
     return SPV_SUCCESS;
   }
 

--- a/source/val/validate_constants.cpp
+++ b/source/val/validate_constants.cpp
@@ -174,8 +174,7 @@ spv_result_t ValidateConstantComposite(ValidationState_t& _,
       bool is_const;
       uint32_t value;
       std::tie(is_int32, is_const, value) = _.EvalInt32IfConst(length->id());
-      if (is_int32 && is_const && !spvOpcodeIsSpecConstant(length->opcode()) &&
-          value != constituent_count) {
+      if (is_int32 && is_const && value != constituent_count) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
                << opcode_name
                << " Constituent count does not match "

--- a/source/val/validate_scopes.cpp
+++ b/source/val/validate_scopes.cpp
@@ -36,6 +36,11 @@ spv_result_t ValidateExecutionScope(ValidationState_t& _,
   }
 
   if (!is_const_int32) {
+    if (_.HasCapability(SpvCapabilityShader)) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst) << "Scope ids must be "
+                                                     "OpConstant when Shader "
+                                                     "capability is present";
+    }
     return SPV_SUCCESS;
   }
 
@@ -114,6 +119,11 @@ spv_result_t ValidateMemoryScope(ValidationState_t& _, const Instruction* inst,
   }
 
   if (!is_const_int32) {
+    if (_.HasCapability(SpvCapabilityShader)) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst) << "Scope ids must be "
+                                                     "OpConstant when Shader "
+                                                     "capability is present";
+    }
     return SPV_SUCCESS;
   }
 

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -888,7 +888,10 @@ std::tuple<bool, bool, uint32_t> ValidationState_t::EvalInt32IfConst(
     return std::make_tuple(false, false, 0);
   }
 
-  if (!spvOpcodeIsConstant(inst->opcode())) {
+  // Spec constant values cannot be evaluated so don't consider constant for
+  // the purpose of this method.
+  if (!spvOpcodeIsConstant(inst->opcode()) ||
+      spvOpcodeIsSpecConstant(inst->opcode())) {
     return std::make_tuple(true, false, 0);
   }
 

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -531,6 +531,8 @@ class ValidationState_t {
 
   // Tries to evaluate a 32-bit signed or unsigned scalar integer constant.
   // Returns tuple <is_int32, is_const_int32, value>.
+  // OpSpecConstant* return |is_const_int32| as false since their values cannot
+  // be relied upon during validation.
   std::tuple<bool, bool, uint32_t> EvalInt32IfConst(uint32_t id);
 
   // Returns the disassembly string for the given instruction.

--- a/test/val/val_barriers_test.cpp
+++ b/test/val/val_barriers_test.cpp
@@ -1071,6 +1071,106 @@ OpFunctionEnd
                         "storage class"));
 }
 
+TEST_F(ValidateBarriers, SemanticsSpecConstantShader) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %func "func"
+OpExecutionMode %func OriginUpperLeft
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%ptr_int_workgroup = OpTypePointer Workgroup %int
+%var = OpVariable %ptr_int_workgroup Workgroup
+%voidfn = OpTypeFunction %void
+%spec_const = OpSpecConstant %int 0
+%workgroup = OpConstant %int 2
+%func = OpFunction %void None %voidfn
+%entry = OpLabel
+OpMemoryBarrier %workgroup %spec_const
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Memory Semantics ids must be OpConstant when Shader "
+                        "capability is present"));
+}
+
+TEST_F(ValidateBarriers, SemanticsSpecConstantKernel) {
+  const std::string spirv = R"(
+OpCapability Kernel
+OpCapability Linkage
+OpMemoryModel Logical OpenCL
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%ptr_int_workgroup = OpTypePointer Workgroup %int
+%var = OpVariable %ptr_int_workgroup Workgroup
+%voidfn = OpTypeFunction %void
+%spec_const = OpSpecConstant %int 0
+%workgroup = OpConstant %int 2
+%func = OpFunction %void None %voidfn
+%entry = OpLabel
+OpMemoryBarrier %workgroup %spec_const
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateBarriers, ScopeSpecConstantShader) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %func "func"
+OpExecutionMode %func OriginUpperLeft
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%ptr_int_workgroup = OpTypePointer Workgroup %int
+%var = OpVariable %ptr_int_workgroup Workgroup
+%voidfn = OpTypeFunction %void
+%spec_const = OpSpecConstant %int 0
+%relaxed = OpConstant %int 0
+%func = OpFunction %void None %voidfn
+%entry = OpLabel
+OpMemoryBarrier %spec_const %relaxed
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Scope ids must be OpConstant when Shader "
+                        "capability is present"));
+}
+
+TEST_F(ValidateBarriers, ScopeSpecConstantKernel) {
+  const std::string spirv = R"(
+OpCapability Kernel
+OpCapability Linkage
+OpMemoryModel Logical OpenCL
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%ptr_int_workgroup = OpTypePointer Workgroup %int
+%var = OpVariable %ptr_int_workgroup Workgroup
+%voidfn = OpTypeFunction %void
+%spec_const = OpSpecConstant %int 0
+%relaxed = OpConstant %int 0
+%func = OpFunction %void None %voidfn
+%entry = OpLabel
+OpMemoryBarrier %spec_const %relaxed
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
Fixes #2133

* Don't return OpSpecConstant* as constants in that method
 * cleaned up uses
* added tests to catch shader semantics and scope bugs