### PR TITLE
Validate ArrayLength with a type for in place of the struct.

### DIFF
--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -891,6 +891,13 @@ spv_result_t ValidateArrayLength(ValidationState_t& state,
   // The structure that is passed in must be an pointer to a structure, whose
   // last element is a runtime array.
   auto pointer = state.FindDef(inst->GetOperandAs<uint32_t>(2));
+  if (pointer->type_id() == 0) {
+    return state.diag(SPV_ERROR_INVALID_ID, inst)
+           << "The Struture's type in " << instr_name << " <id> '"
+           << state.getIdName(inst->id())
+           << "' must be a pointer to an OpTypeStruct.";
+  }
+
   auto pointer_type = state.FindDef(pointer->type_id());
   if (pointer_type->opcode() != SpvOpTypePointer) {
     return state.diag(SPV_ERROR_INVALID_ID, inst)

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -839,6 +839,32 @@ TEST_F(ValidateMemory, ArrayLenIndexNotPointerToStruct) {
           "an OpTypeStruct.\n  %12 = OpArrayLength %uint %11 0\n"));
 }
 
+TEST_F(ValidateMemory, ArrayLenStructIsAType) {
+  std::string spirv = R"(
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %1 "main"
+               OpExecutionMode %1 OriginUpperLeft
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+     %uint = OpTypeInt 32 0
+          %1 = OpFunction %void None %3
+          %5 = OpLabel
+         %6 = OpArrayLength %uint %uint 0
+               OpReturn
+               OpFunctionEnd
+
+)";
+
+  CompileSuccessfully(spirv.c_str());
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(
+          "The Struture's type in OpArrayLength <id> '6' must be a pointer to "
+          "an OpTypeStruct.\n  %6 = OpArrayLength %uint %uint 0\n"));
+}
+
 TEST_F(ValidateMemory, PushConstantNotStructGood) {
   std::string spirv = R"(
             OpCapability Shader


### PR DESCRIPTION
The current checks for OpArrayLength assumes that there is a type it in
the instruction that defines what is suppose to be pointer to the
structure.  However, if there is an id of a type in that position there
is not.  This can lead to a segmentation fault.

We just need to check for that case.

Fixes https://crbug.com/910013.