### PR TITLE
Validate OpForwardPointer

### DIFF
--- a/source/val/validate_type.cpp
+++ b/source/val/validate_type.cpp
@@ -191,11 +191,6 @@ spv_result_t ValidateTypeStruct(ValidationState_t& _, const Instruction* inst) {
              << _.getIdName(member_type_id) << ".";
     }
     if (_.IsForwardPointer(member_type_id)) {
-      if (member_type->opcode() != SpvOpTypePointer) {
-        return _.diag(SPV_ERROR_INVALID_ID, inst)
-               << "Found a forward reference to a non-pointer "
-                  "type in OpTypeStruct instruction.";
-      }
       // If we're dealing with a forward pointer:
       // Find out the type that the pointer is pointing to (must be struct)
       // word 3 is the <id> of the type being pointed to.

--- a/source/val/validate_type.cpp
+++ b/source/val/validate_type.cpp
@@ -297,7 +297,14 @@ spv_result_t ValidateTypeForwardPointer(ValidationState_t& _,
   const auto pointer_type_inst = _.FindDef(pointer_type_id);
   if (pointer_type_inst->opcode() != SpvOpTypePointer) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "Pointer type in OpForwardPointer is not a pointer type.";
+           << "Pointer type in OpTypeForwardPointer is not a pointer type.";
+  }
+
+  if (inst->GetOperandAs<uint32_t>(1) !=
+      pointer_type_inst->GetOperandAs<uint32_t>(1)) {
+    return _.diag(SPV_ERROR_INVALID_ID, inst)
+           << "Storage class in OpTypeForwardPointer does not match the "
+              "pointer definition.";
   }
 
   return SPV_SUCCESS;

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -618,8 +618,7 @@ TEST_F(ValidateData, ext_16bit_storage_caps_allow_free_fp_rounding_mode) {
         OpExtension "SPV_KHR_variable_pointers"
         OpExtension "SPV_KHR_16bit_storage"
         OpMemoryModel Logical GLSL450
-        OpDecorate %_ FPRoundingMode )" +
-                        mode + R"(
+        OpDecorate %_ FPRoundingMode )" + mode + R"(
         %half = OpTypeFloat 16
         %float = OpTypeFloat 32
         %float_1_25 = OpConstant %float 1.25

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -573,8 +573,8 @@ OpTypeForwardPointer %_ptr_Generic_struct_A Generic
   CompileSuccessfully(str.c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Found a forward reference to a non-pointer type in "
-                        "OpTypeStruct instruction."));
+              HasSubstr("Pointer type in OpForwardPointer is not a pointer "
+                        "type.\n  OpTypeForwardPointer %float Generic\n"));
 }
 
 TEST_F(ValidateData, forward_ref_points_to_non_struct) {
@@ -618,7 +618,8 @@ TEST_F(ValidateData, ext_16bit_storage_caps_allow_free_fp_rounding_mode) {
         OpExtension "SPV_KHR_variable_pointers"
         OpExtension "SPV_KHR_16bit_storage"
         OpMemoryModel Logical GLSL450
-        OpDecorate %_ FPRoundingMode )" + mode + R"(
+        OpDecorate %_ FPRoundingMode )" +
+                        mode + R"(
         %half = OpTypeFloat 16
         %float = OpTypeFloat 32
         %float_1_25 = OpConstant %float 1.25

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -573,7 +573,7 @@ OpTypeForwardPointer %_ptr_Generic_struct_A Generic
   CompileSuccessfully(str.c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Pointer type in OpForwardPointer is not a pointer "
+              HasSubstr("Pointer type in OpTypeForwardPointer is not a pointer "
                         "type.\n  OpTypeForwardPointer %float Generic\n"));
 }
 

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -6268,6 +6268,29 @@ TEST_F(ValidateIdWithMessage, UnreachableDefUsedInPhi) {
       HasSubstr("In OpPhi instruction 14, ID 13 definition does not dominate "
                 "its parent 7\n  %14 = OpPhi %float %11 %10 %13 %7"));
 }
+TEST_F(ValidateIdWithMessage, OpForwardPointerNotAPointerType) {
+  std::string spirv = R"(
+     OpCapability GenericPointer
+     OpCapability VariablePointersStorageBuffer
+     OpMemoryModel Logical GLSL450
+     OpEntryPoint Fragment %1 "main"
+     OpExecutionMode %1 OriginLowerLeft
+     OpTypeForwardPointer %2 CrossWorkgroup
+%2 = OpTypeVoid
+%3 = OpTypeFunction %2
+%1 = OpFunction %2 DontInline %3
+%4 = OpLabel
+     OpReturn
+     OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Pointer type in OpForwardPointer is not a pointer "
+                        "type.\n  OpTypeForwardPointer %void CrossWorkgroup"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
The validator does not have a a check that OpForwardPointer is giving
a forward reference to a pointer type.  We add that check.

https://crbug.com/910852