### PR TITLE
[val] Fixup id name output

### DIFF
--- a/source/val/validate.cpp
+++ b/source/val/validate.cpp
@@ -116,18 +116,18 @@ void printDot(const ValidationState_t& _, const BasicBlock& other) {
     block_string += "end ";
   } else {
     for (auto block : *other.successors()) {
-      block_string += _.getIdOrName(block->id()) + " ";
+      block_string += _.getIdName(block->id()) + " ";
     }
   }
-  printf("%10s -> {%s\b}\n", _.getIdOrName(other.id()).c_str(),
+  printf("%10s -> {%s\b}\n", _.getIdName(other.id()).c_str(),
          block_string.c_str());
 }
 
 void PrintBlocks(ValidationState_t& _, Function func) {
   assert(func.first_block());
 
-  printf("%10s -> %s\n", _.getIdOrName(func.id()).c_str(),
-         _.getIdOrName(func.first_block()->id()).c_str());
+  printf("%10s -> %s\n", _.getIdName(func.id()).c_str(),
+         _.getIdName(func.first_block()->id()).c_str());
   for (const auto& block : func.ordered_blocks()) {
     printDot(_, *block);
   }
@@ -145,7 +145,7 @@ void PrintBlocks(ValidationState_t& _, Function func) {
 
 UNUSED(void PrintDotGraph(ValidationState_t& _, Function func)) {
   if (func.first_block()) {
-    std::string func_name(_.getIdOrName(func.id()));
+    std::string func_name(_.getIdName(func.id()));
     printf("digraph %s {\n", func_name.c_str());
     PrintBlocks(_, func);
     printf("}\n");

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -210,7 +210,7 @@ ValidationState_t::ValidationState_t(const spv_const_context ctx,
   }
 
   friendly_mapper_ = spvtools::MakeUnique<spvtools::FriendlyNameMapper>(
-        context_, words_, num_words_);
+      context_, words_, num_words_);
   name_mapper_ = friendly_mapper_->GetNameMapper();
 }
 

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -208,6 +208,10 @@ ValidationState_t::ValidationState_t(const spv_const_context ctx,
                    /* diagnostic = */ nullptr);
     preallocateStorage();
   }
+
+  friendly_mapper_ = spvtools::MakeUnique<spvtools::FriendlyNameMapper>(
+        context_, words_, num_words_);
+  name_mapper_ = friendly_mapper_->GetNameMapper();
 }
 
 void ValidationState_t::preallocateStorage() {
@@ -239,21 +243,10 @@ void ValidationState_t::AssignNameToId(uint32_t id, std::string name) {
 }
 
 std::string ValidationState_t::getIdName(uint32_t id) const {
-  std::stringstream out;
-  out << id;
-  if (operand_names_.find(id) != end(operand_names_)) {
-    out << "[" << operand_names_.at(id) << "]";
-  }
-  return out.str();
-}
+  const std::string id_name = name_mapper_(id);
 
-std::string ValidationState_t::getIdOrName(uint32_t id) const {
   std::stringstream out;
-  if (operand_names_.find(id) != std::end(operand_names_)) {
-    out << operand_names_.at(id);
-  } else {
-    out << id;
-  }
+  out << id << "[%" << id_name << "]";
   return out.str();
 }
 

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -28,6 +28,7 @@
 #include "source/disassemble.h"
 #include "source/enum_set.h"
 #include "source/latest_version_spirv_header.h"
+#include "source/name_mapper.h"
 #include "source/spirv_definition.h"
 #include "source/spirv_validator_options.h"
 #include "source/val/decoration.h"
@@ -153,9 +154,6 @@ class ValidationState_t {
 
   /// Mutator function for ID bound.
   void setIdBound(uint32_t bound);
-
-  /// Like getIdName but does not display the id if the \p id has a name
-  std::string getIdOrName(uint32_t id) const;
 
   /// Returns the number of ID which have been forward referenced but not
   /// defined
@@ -660,6 +658,10 @@ class ValidationState_t {
   /// module which can (indirectly) call the function.
   std::unordered_map<uint32_t, std::vector<uint32_t>> function_to_entry_points_;
   const std::vector<uint32_t> empty_ids_;
+
+  /// Maps ids to friendly names.
+  std::unique_ptr<spvtools::FriendlyNameMapper> friendly_mapper_;
+  spvtools::NameMapper name_mapper_;
 
   /// Variables used to reduce the number of diagnostic messages.
   uint32_t num_of_warnings_;

--- a/test/cpp_interface_test.cpp
+++ b/test/cpp_interface_test.cpp
@@ -58,8 +58,8 @@ TEST(CppInterface, SuccessfulRoundTrip) {
     EXPECT_EQ(0u, position.line);
     EXPECT_EQ(0u, position.column);
     EXPECT_EQ(1u, position.index);
-    EXPECT_STREQ(
-        "ID 1[%1] has not been defined\n  %2 = OpSizeOf %1 %3\n", message);
+    EXPECT_STREQ("ID 1[%1] has not been defined\n  %2 = OpSizeOf %1 %3\n",
+                 message);
   });
   EXPECT_FALSE(t.Validate(binary));
 

--- a/test/cpp_interface_test.cpp
+++ b/test/cpp_interface_test.cpp
@@ -58,8 +58,8 @@ TEST(CppInterface, SuccessfulRoundTrip) {
     EXPECT_EQ(0u, position.line);
     EXPECT_EQ(0u, position.column);
     EXPECT_EQ(1u, position.index);
-    EXPECT_STREQ("ID 1[%1] has not been defined\n  "
-                 "%2 = OpSizeOf %1 %3\n", message);
+    EXPECT_STREQ(
+        "ID 1[%1] has not been defined\n  %2 = OpSizeOf %1 %3\n", message);
   });
   EXPECT_FALSE(t.Validate(binary));
 

--- a/test/cpp_interface_test.cpp
+++ b/test/cpp_interface_test.cpp
@@ -58,7 +58,8 @@ TEST(CppInterface, SuccessfulRoundTrip) {
     EXPECT_EQ(0u, position.line);
     EXPECT_EQ(0u, position.column);
     EXPECT_EQ(1u, position.index);
-    EXPECT_STREQ("ID 1 has not been defined\n  %2 = OpSizeOf %1 %3\n", message);
+    EXPECT_STREQ("ID 1[%1] has not been defined\n  "
+                 "%2 = OpSizeOf %1 %3\n", message);
   });
   EXPECT_FALSE(t.Validate(binary));
 

--- a/test/val/val_adjacency_test.cpp
+++ b/test/val/val_adjacency_test.cpp
@@ -53,7 +53,8 @@ OpFunctionEnd
 
   CompileSuccessfully(module);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 1 has not been defined"));
+  EXPECT_THAT(getDiagnosticString(),
+      HasSubstr("ID 1[%bool] has not been defined"));
 }
 
 TEST_F(ValidateAdjacency, OpLoopMergeEndsModuleFail) {

--- a/test/val/val_adjacency_test.cpp
+++ b/test/val/val_adjacency_test.cpp
@@ -54,7 +54,7 @@ OpFunctionEnd
   CompileSuccessfully(module);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-      HasSubstr("ID 1[%bool] has not been defined"));
+              HasSubstr("ID 1[%bool] has not been defined"));
 }
 
 TEST_F(ValidateAdjacency, OpLoopMergeEndsModuleFail) {

--- a/test/val/val_arithmetics_test.cpp
+++ b/test/val/val_arithmetics_test.cpp
@@ -606,7 +606,8 @@ TEST_F(ValidateArithmetics, DotNotVectorTypeOperand1) {
 
   CompileSuccessfully(GenerateCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 6 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 6[\%float] cannot be a "
+                                               "type"));
 }
 
 TEST_F(ValidateArithmetics, DotNotVectorTypeOperand2) {

--- a/test/val/val_arithmetics_test.cpp
+++ b/test/val/val_arithmetics_test.cpp
@@ -606,7 +606,7 @@ TEST_F(ValidateArithmetics, DotNotVectorTypeOperand1) {
 
   CompileSuccessfully(GenerateCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 6[\%float] cannot be a "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 6[%float] cannot be a "
                                                "type"));
 }
 

--- a/test/val/val_atomics_test.cpp
+++ b/test/val/val_atomics_test.cpp
@@ -380,7 +380,8 @@ TEST_F(ValidateAtomics, AtomicLoadWrongPointerType) {
 
   CompileSuccessfully(GenerateKernelCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 27 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
+        "27[\%_ptr_Workgroup_float] cannot be a type"));
 }
 
 TEST_F(ValidateAtomics, AtomicLoadWrongPointerDataType) {
@@ -623,7 +624,8 @@ TEST_F(ValidateAtomics, AtomicExchangeWrongPointerType) {
 
   CompileSuccessfully(GenerateKernelCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 33 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
+        "33[\%_ptr_Workgroup_v4float] cannot be a type"));
 }
 
 TEST_F(ValidateAtomics, AtomicExchangeWrongPointerDataType) {
@@ -736,7 +738,8 @@ TEST_F(ValidateAtomics, AtomicCompareExchangeWrongPointerType) {
 
   CompileSuccessfully(GenerateKernelCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 33 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
+        "33[\%_ptr_Workgroup_v4float] cannot be a type"));
 }
 
 TEST_F(ValidateAtomics, AtomicCompareExchangeWrongPointerDataType) {

--- a/test/val/val_atomics_test.cpp
+++ b/test/val/val_atomics_test.cpp
@@ -380,8 +380,8 @@ TEST_F(ValidateAtomics, AtomicLoadWrongPointerType) {
 
   CompileSuccessfully(GenerateKernelCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
-        "27[%_ptr_Workgroup_float] cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand 27[%_ptr_Workgroup_float] cannot be a type"));
 }
 
 TEST_F(ValidateAtomics, AtomicLoadWrongPointerDataType) {
@@ -624,8 +624,9 @@ TEST_F(ValidateAtomics, AtomicExchangeWrongPointerType) {
 
   CompileSuccessfully(GenerateKernelCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
-        "33[%_ptr_Workgroup_v4float] cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand 33[%_ptr_Workgroup_v4float] cannot be a "
+                        "type"));
 }
 
 TEST_F(ValidateAtomics, AtomicExchangeWrongPointerDataType) {
@@ -738,8 +739,9 @@ TEST_F(ValidateAtomics, AtomicCompareExchangeWrongPointerType) {
 
   CompileSuccessfully(GenerateKernelCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
-        "33[%_ptr_Workgroup_v4float] cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand 33[%_ptr_Workgroup_v4float] cannot be a "
+                        "type"));
 }
 
 TEST_F(ValidateAtomics, AtomicCompareExchangeWrongPointerDataType) {

--- a/test/val/val_atomics_test.cpp
+++ b/test/val/val_atomics_test.cpp
@@ -381,7 +381,7 @@ TEST_F(ValidateAtomics, AtomicLoadWrongPointerType) {
   CompileSuccessfully(GenerateKernelCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
-        "27[\%_ptr_Workgroup_float] cannot be a type"));
+        "27[%_ptr_Workgroup_float] cannot be a type"));
 }
 
 TEST_F(ValidateAtomics, AtomicLoadWrongPointerDataType) {
@@ -625,7 +625,7 @@ TEST_F(ValidateAtomics, AtomicExchangeWrongPointerType) {
   CompileSuccessfully(GenerateKernelCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
-        "33[\%_ptr_Workgroup_v4float] cannot be a type"));
+        "33[%_ptr_Workgroup_v4float] cannot be a type"));
 }
 
 TEST_F(ValidateAtomics, AtomicExchangeWrongPointerDataType) {
@@ -739,7 +739,7 @@ TEST_F(ValidateAtomics, AtomicCompareExchangeWrongPointerType) {
   CompileSuccessfully(GenerateKernelCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
-        "33[\%_ptr_Workgroup_v4float] cannot be a type"));
+        "33[%_ptr_Workgroup_v4float] cannot be a type"));
 }
 
 TEST_F(ValidateAtomics, AtomicCompareExchangeWrongPointerDataType) {

--- a/test/val/val_barriers_test.cpp
+++ b/test/val/val_barriers_test.cpp
@@ -875,7 +875,8 @@ OpMemoryBarrier %u32 %u32_0
 
   CompileSuccessfully(GenerateKernelCode(body));
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 5 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 5[\%uint] cannot be a "
+                                               "type"));
 }
 
 TEST_F(ValidateBarriers,

--- a/test/val/val_barriers_test.cpp
+++ b/test/val/val_barriers_test.cpp
@@ -875,7 +875,7 @@ OpMemoryBarrier %u32 %u32_0
 
   CompileSuccessfully(GenerateKernelCode(body));
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 5[\%uint] cannot be a "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 5[%uint] cannot be a "
                                                "type"));
 }
 

--- a/test/val/val_cfg_test.cpp
+++ b/test/val/val_cfg_test.cpp
@@ -378,8 +378,8 @@ TEST_P(ValidateCFG, BlockAppearsBeforeDominatorBad) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("Block .\\[cont\\] appears in the binary "
-                           "before its dominator .\\[branch\\]\n"
+              MatchesRegex("Block .\\[%cont\\] appears in the binary "
+                           "before its dominator .\\[%branch\\]\n"
                            "  %branch = OpLabel\n"));
 }
 
@@ -410,7 +410,7 @@ TEST_P(ValidateCFG, MergeBlockTargetedByMultipleHeaderBlocksBad) {
   if (is_shader) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(getDiagnosticString(),
-                MatchesRegex("Block .\\[merge\\] is already a merge block "
+                MatchesRegex("Block .\\[%merge\\] is already a merge block "
                              "for another header\n"
                              "  %Main = OpFunction %void None %9\n"));
   } else {
@@ -445,7 +445,7 @@ TEST_P(ValidateCFG, MergeBlockTargetedByMultipleHeaderBlocksSelectionBad) {
   if (is_shader) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(getDiagnosticString(),
-                MatchesRegex("Block .\\[merge\\] is already a merge block "
+                MatchesRegex("Block .\\[%merge\\] is already a merge block "
                              "for another header\n"
                              "  %Main = OpFunction %void None %9\n"));
   } else {
@@ -470,8 +470,8 @@ TEST_P(ValidateCFG, BranchTargetFirstBlockBadSinceEntryBlock) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("First block .\\[entry\\] of function .\\[Main\\] "
-                           "is targeted by block .\\[bad\\]\n"
+              MatchesRegex("First block .\\[\%entry\\] of function "
+                           ".\\[\%Main\\] is targeted by block .\\[\%bad\\]\n"
                            "  %Main = OpFunction %void None %10\n"));
 }
 
@@ -495,8 +495,8 @@ TEST_P(ValidateCFG, BranchTargetFirstBlockBadSinceValue) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("Block\\(s\\) \\{..\\} are referenced but not "
-                           "defined in function .\\[Main\\]\n"
+              MatchesRegex("Block\\(s\\) \\{11\\[%11\\]\\} are referenced but not "
+                           "defined in function .\\[\%Main\\]\n"
                            "  %Main = OpFunction %void None %10\n"))
       << str;
 }
@@ -522,8 +522,8 @@ TEST_P(ValidateCFG, BranchConditionalTrueTargetFirstBlockBad) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("First block .\\[entry\\] of function .\\[Main\\] "
-                           "is targeted by block .\\[bad\\]\n"
+              MatchesRegex("First block .\\[\%entry\\] of function .\\[\%Main\\] "
+                           "is targeted by block .\\[\%bad\\]\n"
                            "  %Main = OpFunction %void None %10\n"));
 }
 
@@ -551,8 +551,8 @@ TEST_P(ValidateCFG, BranchConditionalFalseTargetFirstBlockBad) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("First block .\\[entry\\] of function .\\[Main\\] "
-                           "is targeted by block .\\[bad\\]\n"
+              MatchesRegex("First block .\\[\%entry\\] of function .\\[\%Main\\] "
+                           "is targeted by block .\\[\%bad\\]\n"
                            "  %Main = OpFunction %void None %10\n"));
 }
 
@@ -587,8 +587,8 @@ TEST_P(ValidateCFG, SwitchTargetFirstBlockBad) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("First block .\\[entry\\] of function .\\[Main\\] "
-                           "is targeted by block .\\[bad\\]\n"
+              MatchesRegex("First block .\\[\%entry\\] of function .\\[\%Main\\] "
+                           "is targeted by block .\\[\%bad\\]\n"
                            "  %Main = OpFunction %void None %10\n"));
 }
 
@@ -623,8 +623,8 @@ TEST_P(ValidateCFG, BranchToBlockInOtherFunctionBad) {
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      MatchesRegex("Block\\(s\\) \\{.\\[middle2\\]\\} are referenced but not "
-                   "defined in function .\\[Main\\]\n"
+      MatchesRegex("Block\\(s\\) \\{.\\[\%middle2\\]\\} are referenced but not "
+                   "defined in function .\\[\%Main\\]\n"
                    "  %Main = OpFunction %void None %9\n"));
 }
 
@@ -656,8 +656,8 @@ TEST_P(ValidateCFG, HeaderDoesntDominatesMergeBad) {
     EXPECT_THAT(
         getDiagnosticString(),
         MatchesRegex("The selection construct with the selection header "
-                     ".\\[head\\] does not dominate the merge block "
-                     ".\\[merge\\]\n  %merge = OpLabel\n"));
+                     ".\\[\%head\\] does not dominate the merge block "
+                     ".\\[\%merge\\]\n  %merge = OpLabel\n"));
   } else {
     ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
   }
@@ -689,8 +689,8 @@ TEST_P(ValidateCFG, HeaderDoesntStrictlyDominateMergeBad) {
     EXPECT_THAT(
         getDiagnosticString(),
         MatchesRegex("The selection construct with the selection header "
-                     ".\\[head\\] does not strictly dominate the merge block "
-                     ".\\[head\\]\n  %head = OpLabel\n"));
+                     ".\\[\%head\\] does not strictly dominate the merge block "
+                     ".\\[\%head\\]\n  %head = OpLabel\n"));
   } else {
     ASSERT_EQ(SPV_SUCCESS, ValidateInstructions()) << str;
   }
@@ -940,8 +940,8 @@ TEST_P(ValidateCFG, BackEdgeBlockDoesntPostDominateContinueTargetBad) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(getDiagnosticString(),
                 MatchesRegex("The continue construct with the continue target "
-                             ".\\[loop2_merge\\] is not post dominated by the "
-                             "back-edge block .\\[be_block\\]\n"
+                             ".\\[\%loop2_merge\\] is not post dominated by the "
+                             "back-edge block .\\[\%be_block\\]\n"
                              "  %be_block = OpLabel\n"));
   } else {
     ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
@@ -975,7 +975,7 @@ TEST_P(ValidateCFG, BranchingToNonLoopHeaderBlockBad) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(
         getDiagnosticString(),
-        MatchesRegex("Back-edges \\(.\\[f\\] -> .\\[split\\]\\) can only "
+        MatchesRegex("Back-edges \\(.\\[\%f\\] -> .\\[\%split\\]\\) can only "
                      "be formed between a block and a loop header.\n"
                      "  %f = OpLabel\n"));
   } else {
@@ -1005,7 +1005,7 @@ TEST_P(ValidateCFG, BranchingToSameNonLoopHeaderBlockBad) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(getDiagnosticString(),
                 MatchesRegex(
-                    "Back-edges \\(.\\[split\\] -> .\\[split\\]\\) can only be "
+                    "Back-edges \\(.\\[\%split\\] -> .\\[\%split\\]\\) can only be "
                     "formed between a block and a loop header.\n"
                     "  %split = OpLabel\n"));
   } else {
@@ -1040,7 +1040,7 @@ TEST_P(ValidateCFG, MultipleBackEdgeBlocksToLoopHeaderBad) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(getDiagnosticString(),
                 MatchesRegex(
-                    "Loop header .\\[loop\\] is targeted by 2 back-edge blocks "
+                    "Loop header .\\[\%loop\\] is targeted by 2 back-edge blocks "
                     "but the standard requires exactly one\n"
                     "  %loop = OpLabel\n"))
         << str;
@@ -1078,8 +1078,8 @@ TEST_P(ValidateCFG, ContinueTargetMustBePostDominatedByBackEdge) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(getDiagnosticString(),
                 MatchesRegex("The continue construct with the continue target "
-                             ".\\[cheader\\] is not post dominated by the "
-                             "back-edge block .\\[be_block\\]\n"
+                             ".\\[\%cheader\\] is not post dominated by the "
+                             "back-edge block .\\[\%be_block\\]\n"
                              "  %be_block = OpLabel\n"));
   } else {
     ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
@@ -1111,8 +1111,8 @@ TEST_P(ValidateCFG, BranchOutOfConstructToMergeBad) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(getDiagnosticString(),
                 MatchesRegex("The continue construct with the continue target "
-                             ".\\[loop\\] is not post dominated by the "
-                             "back-edge block .\\[cont\\]\n"
+                             ".\\[\%loop\\] is not post dominated by the "
+                             "back-edge block .\\[\%cont\\]\n"
                              "  %cont = OpLabel\n"))
         << str;
   } else {
@@ -1147,8 +1147,8 @@ TEST_P(ValidateCFG, BranchOutOfConstructBad) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(getDiagnosticString(),
                 MatchesRegex("The continue construct with the continue target "
-                             ".\\[loop\\] is not post dominated by the "
-                             "back-edge block .\\[cont\\]\n"
+                             ".\\[\%loop\\] is not post dominated by the "
+                             "back-edge block .\\[\%cont\\]\n"
                              "  %cont = OpLabel\n"));
   } else {
     ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
@@ -1222,7 +1222,7 @@ TEST_F(ValidateCFG, LoopWithZeroBackEdgesBad) {
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      MatchesRegex("Loop header .\\[loop\\] is targeted by "
+      MatchesRegex("Loop header .\\[\\%loop\\] is targeted by "
                    "0 back-edge blocks but the standard requires exactly "
                    "one\n  %loop = OpLabel\n"));
 }
@@ -1567,8 +1567,8 @@ OpFunctionEnd
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "Case construct that targets 10 has branches to multiple other case "
-          "construct targets 12 and 11\n  %10 = OpLabel"));
+          "Case construct that targets 10[%10] has branches to multiple other "
+          "case construct targets 12[%12] and 11[%11]\n  %10 = OpLabel"));
 }
 
 TEST_F(ValidateCFG, MultipleFallThroughToDefault) {
@@ -1602,7 +1602,7 @@ OpFunctionEnd
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("Multiple case constructs have branches to the case construct "
-                "that targets 10\n  %10 = OpLabel"));
+                "that targets 10[%10]\n  %10 = OpLabel"));
 }
 
 TEST_F(ValidateCFG, MultipleFallThroughToNonDefault) {
@@ -1636,7 +1636,7 @@ OpFunctionEnd
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("Multiple case constructs have branches to the case construct "
-                "that targets 12\n  %12 = OpLabel"));
+                "that targets 12[%12]\n  %12 = OpLabel"));
 }
 
 TEST_F(ValidateCFG, DuplicateTargetWithFallThrough) {
@@ -1697,8 +1697,8 @@ OpFunctionEnd
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Case construct that targets 12 has branches to the case "
-                "construct that targets 11, but does not immediately "
+      HasSubstr("Case construct that targets 12[%12] has branches to the case "
+                "construct that targets 11[%11], but does not immediately "
                 "precede it in the OpSwitch's target list\n"
                 "  OpSwitch %uint_0 %10 0 %11 1 %12"));
 }
@@ -1733,8 +1733,8 @@ OpFunctionEnd
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Case construct that targets 12 has branches to the case "
-                "construct that targets 11, but does not immediately "
+      HasSubstr("Case construct that targets 12[%12] has branches to the case "
+                "construct that targets 11[%11], but does not immediately "
                 "precede it in the OpSwitch's target list\n"
                 "  OpSwitch %uint_0 %10 0 %11 1 %12"));
 }
@@ -1771,8 +1771,8 @@ OpFunctionEnd
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Case construct that targets 12 has branches to the case "
-                "construct that targets 11, but does not immediately "
+      HasSubstr("Case construct that targets 12[%12] has branches to the case "
+                "construct that targets 11[%11], but does not immediately "
                 "precede it in the OpSwitch's target list\n"
                 "  OpSwitch %uint_0 %10 0 %11 1 %12 2 %13"));
 }
@@ -1839,9 +1839,10 @@ OpFunctionEnd
   CompileSuccessfully(text);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Case construct that targets 8 has invalid branch to "
-                        "block 10 (not another case construct, corresponding "
-                        "merge, outer loop merge or outer loop continue"));
+              HasSubstr("Case construct that targets 8[%8] has invalid branch "
+                        "to block 10[%10] (not another case construct, "
+                        "corresponding merge, outer loop merge or outer loop "
+                        "continue)"));
 }
 
 TEST_F(ValidateCFG, GoodCaseExitsToOuterConstructs) {

--- a/test/val/val_cfg_test.cpp
+++ b/test/val/val_cfg_test.cpp
@@ -494,10 +494,11 @@ TEST_P(ValidateCFG, BranchTargetFirstBlockBadSinceValue) {
 
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("Block\\(s\\) \\{11\\[%11\\]\\} are referenced but not "
-                           "defined in function .\\[%Main\\]\n"
-                           "  %Main = OpFunction %void None %10\n"))
+  EXPECT_THAT(
+      getDiagnosticString(),
+      MatchesRegex("Block\\(s\\) \\{11\\[%11\\]\\} are referenced but not "
+                   "defined in function .\\[%Main\\]\n  %Main = OpFunction "
+                   "%void None %10\n"))
       << str;
 }
 
@@ -1003,11 +1004,11 @@ TEST_P(ValidateCFG, BranchingToSameNonLoopHeaderBlockBad) {
   CompileSuccessfully(str);
   if (is_shader) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
-    EXPECT_THAT(getDiagnosticString(),
-                MatchesRegex(
-                    "Back-edges \\(.\\[%split\\] -> .\\[%split\\]\\) can only be "
-                    "formed between a block and a loop header.\n"
-                    "  %split = OpLabel\n"));
+    EXPECT_THAT(
+        getDiagnosticString(),
+        MatchesRegex(
+            "Back-edges \\(.\\[%split\\] -> .\\[%split\\]\\) can only be "
+            "formed between a block and a loop header.\n  %split = OpLabel\n"));
   } else {
     ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
   }
@@ -1038,11 +1039,11 @@ TEST_P(ValidateCFG, MultipleBackEdgeBlocksToLoopHeaderBad) {
   CompileSuccessfully(str);
   if (is_shader) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
-    EXPECT_THAT(getDiagnosticString(),
-                MatchesRegex(
-                    "Loop header .\\[%loop\\] is targeted by 2 back-edge blocks "
-                    "but the standard requires exactly one\n"
-                    "  %loop = OpLabel\n"))
+    EXPECT_THAT(
+        getDiagnosticString(),
+        MatchesRegex(
+            "Loop header .\\[%loop\\] is targeted by 2 back-edge blocks but "
+            "the standard requires exactly one\n  %loop = OpLabel\n"))
         << str;
   } else {
     ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());

--- a/test/val/val_cfg_test.cpp
+++ b/test/val/val_cfg_test.cpp
@@ -470,8 +470,8 @@ TEST_P(ValidateCFG, BranchTargetFirstBlockBadSinceEntryBlock) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("First block .\\[\%entry\\] of function "
-                           ".\\[\%Main\\] is targeted by block .\\[\%bad\\]\n"
+              MatchesRegex("First block .\\[%entry\\] of function "
+                           ".\\[%Main\\] is targeted by block .\\[%bad\\]\n"
                            "  %Main = OpFunction %void None %10\n"));
 }
 
@@ -496,7 +496,7 @@ TEST_P(ValidateCFG, BranchTargetFirstBlockBadSinceValue) {
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               MatchesRegex("Block\\(s\\) \\{11\\[%11\\]\\} are referenced but not "
-                           "defined in function .\\[\%Main\\]\n"
+                           "defined in function .\\[%Main\\]\n"
                            "  %Main = OpFunction %void None %10\n"))
       << str;
 }
@@ -522,8 +522,8 @@ TEST_P(ValidateCFG, BranchConditionalTrueTargetFirstBlockBad) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("First block .\\[\%entry\\] of function .\\[\%Main\\] "
-                           "is targeted by block .\\[\%bad\\]\n"
+              MatchesRegex("First block .\\[%entry\\] of function .\\[%Main\\] "
+                           "is targeted by block .\\[%bad\\]\n"
                            "  %Main = OpFunction %void None %10\n"));
 }
 
@@ -551,8 +551,8 @@ TEST_P(ValidateCFG, BranchConditionalFalseTargetFirstBlockBad) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("First block .\\[\%entry\\] of function .\\[\%Main\\] "
-                           "is targeted by block .\\[\%bad\\]\n"
+              MatchesRegex("First block .\\[%entry\\] of function .\\[%Main\\] "
+                           "is targeted by block .\\[%bad\\]\n"
                            "  %Main = OpFunction %void None %10\n"));
 }
 
@@ -587,8 +587,8 @@ TEST_P(ValidateCFG, SwitchTargetFirstBlockBad) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("First block .\\[\%entry\\] of function .\\[\%Main\\] "
-                           "is targeted by block .\\[\%bad\\]\n"
+              MatchesRegex("First block .\\[%entry\\] of function .\\[%Main\\] "
+                           "is targeted by block .\\[%bad\\]\n"
                            "  %Main = OpFunction %void None %10\n"));
 }
 
@@ -623,8 +623,8 @@ TEST_P(ValidateCFG, BranchToBlockInOtherFunctionBad) {
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      MatchesRegex("Block\\(s\\) \\{.\\[\%middle2\\]\\} are referenced but not "
-                   "defined in function .\\[\%Main\\]\n"
+      MatchesRegex("Block\\(s\\) \\{.\\[%middle2\\]\\} are referenced but not "
+                   "defined in function .\\[%Main\\]\n"
                    "  %Main = OpFunction %void None %9\n"));
 }
 
@@ -656,8 +656,8 @@ TEST_P(ValidateCFG, HeaderDoesntDominatesMergeBad) {
     EXPECT_THAT(
         getDiagnosticString(),
         MatchesRegex("The selection construct with the selection header "
-                     ".\\[\%head\\] does not dominate the merge block "
-                     ".\\[\%merge\\]\n  %merge = OpLabel\n"));
+                     ".\\[%head\\] does not dominate the merge block "
+                     ".\\[%merge\\]\n  %merge = OpLabel\n"));
   } else {
     ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
   }
@@ -689,8 +689,8 @@ TEST_P(ValidateCFG, HeaderDoesntStrictlyDominateMergeBad) {
     EXPECT_THAT(
         getDiagnosticString(),
         MatchesRegex("The selection construct with the selection header "
-                     ".\\[\%head\\] does not strictly dominate the merge block "
-                     ".\\[\%head\\]\n  %head = OpLabel\n"));
+                     ".\\[%head\\] does not strictly dominate the merge block "
+                     ".\\[%head\\]\n  %head = OpLabel\n"));
   } else {
     ASSERT_EQ(SPV_SUCCESS, ValidateInstructions()) << str;
   }
@@ -940,8 +940,8 @@ TEST_P(ValidateCFG, BackEdgeBlockDoesntPostDominateContinueTargetBad) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(getDiagnosticString(),
                 MatchesRegex("The continue construct with the continue target "
-                             ".\\[\%loop2_merge\\] is not post dominated by the "
-                             "back-edge block .\\[\%be_block\\]\n"
+                             ".\\[%loop2_merge\\] is not post dominated by the "
+                             "back-edge block .\\[%be_block\\]\n"
                              "  %be_block = OpLabel\n"));
   } else {
     ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
@@ -975,7 +975,7 @@ TEST_P(ValidateCFG, BranchingToNonLoopHeaderBlockBad) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(
         getDiagnosticString(),
-        MatchesRegex("Back-edges \\(.\\[\%f\\] -> .\\[\%split\\]\\) can only "
+        MatchesRegex("Back-edges \\(.\\[%f\\] -> .\\[%split\\]\\) can only "
                      "be formed between a block and a loop header.\n"
                      "  %f = OpLabel\n"));
   } else {
@@ -1005,7 +1005,7 @@ TEST_P(ValidateCFG, BranchingToSameNonLoopHeaderBlockBad) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(getDiagnosticString(),
                 MatchesRegex(
-                    "Back-edges \\(.\\[\%split\\] -> .\\[\%split\\]\\) can only be "
+                    "Back-edges \\(.\\[%split\\] -> .\\[%split\\]\\) can only be "
                     "formed between a block and a loop header.\n"
                     "  %split = OpLabel\n"));
   } else {
@@ -1040,7 +1040,7 @@ TEST_P(ValidateCFG, MultipleBackEdgeBlocksToLoopHeaderBad) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(getDiagnosticString(),
                 MatchesRegex(
-                    "Loop header .\\[\%loop\\] is targeted by 2 back-edge blocks "
+                    "Loop header .\\[%loop\\] is targeted by 2 back-edge blocks "
                     "but the standard requires exactly one\n"
                     "  %loop = OpLabel\n"))
         << str;
@@ -1078,8 +1078,8 @@ TEST_P(ValidateCFG, ContinueTargetMustBePostDominatedByBackEdge) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(getDiagnosticString(),
                 MatchesRegex("The continue construct with the continue target "
-                             ".\\[\%cheader\\] is not post dominated by the "
-                             "back-edge block .\\[\%be_block\\]\n"
+                             ".\\[%cheader\\] is not post dominated by the "
+                             "back-edge block .\\[%be_block\\]\n"
                              "  %be_block = OpLabel\n"));
   } else {
     ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
@@ -1111,8 +1111,8 @@ TEST_P(ValidateCFG, BranchOutOfConstructToMergeBad) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(getDiagnosticString(),
                 MatchesRegex("The continue construct with the continue target "
-                             ".\\[\%loop\\] is not post dominated by the "
-                             "back-edge block .\\[\%cont\\]\n"
+                             ".\\[%loop\\] is not post dominated by the "
+                             "back-edge block .\\[%cont\\]\n"
                              "  %cont = OpLabel\n"))
         << str;
   } else {
@@ -1147,8 +1147,8 @@ TEST_P(ValidateCFG, BranchOutOfConstructBad) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(getDiagnosticString(),
                 MatchesRegex("The continue construct with the continue target "
-                             ".\\[\%loop\\] is not post dominated by the "
-                             "back-edge block .\\[\%cont\\]\n"
+                             ".\\[%loop\\] is not post dominated by the "
+                             "back-edge block .\\[%cont\\]\n"
                              "  %cont = OpLabel\n"));
   } else {
     ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
@@ -1222,7 +1222,7 @@ TEST_F(ValidateCFG, LoopWithZeroBackEdgesBad) {
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      MatchesRegex("Loop header .\\[\\%loop\\] is targeted by "
+      MatchesRegex("Loop header .\\[%loop\\] is targeted by "
                    "0 back-edge blocks but the standard requires exactly "
                    "one\n  %loop = OpLabel\n"));
 }

--- a/test/val/val_composites_test.cpp
+++ b/test/val/val_composites_test.cpp
@@ -321,7 +321,8 @@ TEST_F(ValidateComposites, CompositeConstructVectorWrongConsituent1) {
 
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 5 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 5[\%float] cannot be a "
+                                               "type"));
 }
 
 TEST_F(ValidateComposites, CompositeConstructVectorWrongConsituent2) {
@@ -537,7 +538,8 @@ TEST_F(ValidateComposites, CopyObjectResultTypeNotType) {
 
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 19 is not a type id"));
+  EXPECT_THAT(getDiagnosticString(),
+      HasSubstr("ID 19[\%float_0] is not a type id"));
 }
 
 TEST_F(ValidateComposites, CopyObjectWrongOperandType) {
@@ -658,7 +660,8 @@ TEST_F(ValidateComposites, CompositeExtractNotObject) {
 
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 11 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 11[\%v4float] cannot "
+                                               "be a type"));
 }
 
 TEST_F(ValidateComposites, CompositeExtractNotComposite) {

--- a/test/val/val_composites_test.cpp
+++ b/test/val/val_composites_test.cpp
@@ -321,7 +321,7 @@ TEST_F(ValidateComposites, CompositeConstructVectorWrongConsituent1) {
 
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 5[\%float] cannot be a "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 5[%float] cannot be a "
                                                "type"));
 }
 
@@ -539,7 +539,7 @@ TEST_F(ValidateComposites, CopyObjectResultTypeNotType) {
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-      HasSubstr("ID 19[\%float_0] is not a type id"));
+      HasSubstr("ID 19[%float_0] is not a type id"));
 }
 
 TEST_F(ValidateComposites, CopyObjectWrongOperandType) {
@@ -660,7 +660,7 @@ TEST_F(ValidateComposites, CompositeExtractNotObject) {
 
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 11[\%v4float] cannot "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 11[%v4float] cannot "
                                                "be a type"));
 }
 

--- a/test/val/val_composites_test.cpp
+++ b/test/val/val_composites_test.cpp
@@ -539,7 +539,7 @@ TEST_F(ValidateComposites, CopyObjectResultTypeNotType) {
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-      HasSubstr("ID 19[%float_0] is not a type id"));
+              HasSubstr("ID 19[%float_0] is not a type id"));
 }
 
 TEST_F(ValidateComposites, CopyObjectWrongOperandType) {

--- a/test/val/val_conversion_test.cpp
+++ b/test/val/val_conversion_test.cpp
@@ -973,7 +973,7 @@ TEST_F(ValidateConversion, PtrCastToGenericWrongInputType) {
 
   CompileSuccessfully(GenerateKernelCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 4[\%float] cannot be a "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 4[%float] cannot be a "
                                                "type"));
 }
 
@@ -1209,7 +1209,7 @@ TEST_F(ValidateConversion, BitcastInputHasNoType) {
 
   CompileSuccessfully(GenerateKernelCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 4[\%float] cannot be a "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 4[%float] cannot be a "
                                                "type"));
 }
 
@@ -1298,7 +1298,7 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 1[\%uint] cannot be a "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 1[%uint] cannot be a "
                                                "type"));
 }
 

--- a/test/val/val_conversion_test.cpp
+++ b/test/val/val_conversion_test.cpp
@@ -973,7 +973,8 @@ TEST_F(ValidateConversion, PtrCastToGenericWrongInputType) {
 
   CompileSuccessfully(GenerateKernelCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 4 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 4[\%float] cannot be a "
+                                               "type"));
 }
 
 TEST_F(ValidateConversion, PtrCastToGenericWrongInputStorageClass) {
@@ -1208,7 +1209,8 @@ TEST_F(ValidateConversion, BitcastInputHasNoType) {
 
   CompileSuccessfully(GenerateKernelCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 4 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 4[\%float] cannot be a "
+                                               "type"));
 }
 
 TEST_F(ValidateConversion, BitcastWrongResultType) {
@@ -1296,7 +1298,8 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 1 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 1[\%uint] cannot be a "
+                                               "type"));
 }
 
 }  // namespace

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -686,7 +686,7 @@ TEST_F(ValidateData, void_array) {
   CompileSuccessfully(str.c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpTypeArray Element Type <id> '1[\%void]' is a void type."));
+              HasSubstr("OpTypeArray Element Type <id> '1[%void]' is a void type."));
 }
 
 TEST_F(ValidateData, void_runtime_array) {
@@ -699,7 +699,7 @@ TEST_F(ValidateData, void_runtime_array) {
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpTypeRuntimeArray Element Type <id> '1[\%void]' is a void type."));
+      HasSubstr("OpTypeRuntimeArray Element Type <id> '1[%void]' is a void type."));
 }
 }  // namespace
 }  // namespace val

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -386,7 +386,8 @@ TEST_F(ValidateData, ids_should_be_validated_before_data) {
 )";
   CompileSuccessfully(str.c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 3 has not been defined"));
+  EXPECT_THAT(getDiagnosticString(),
+      HasSubstr("ID 3[%3] has not been defined"));
 }
 
 TEST_F(ValidateData, matrix_bad_column_type) {
@@ -685,7 +686,7 @@ TEST_F(ValidateData, void_array) {
   CompileSuccessfully(str.c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpTypeArray Element Type <id> '1' is a void type."));
+              HasSubstr("OpTypeArray Element Type <id> '1[\%void]' is a void type."));
 }
 
 TEST_F(ValidateData, void_runtime_array) {
@@ -698,7 +699,7 @@ TEST_F(ValidateData, void_runtime_array) {
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpTypeRuntimeArray Element Type <id> '1' is a void type."));
+      HasSubstr("OpTypeRuntimeArray Element Type <id> '1[\%void]' is a void type."));
 }
 }  // namespace
 }  // namespace val

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -387,7 +387,7 @@ TEST_F(ValidateData, ids_should_be_validated_before_data) {
   CompileSuccessfully(str.c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-      HasSubstr("ID 3[%3] has not been defined"));
+              HasSubstr("ID 3[%3] has not been defined"));
 }
 
 TEST_F(ValidateData, matrix_bad_column_type) {
@@ -685,8 +685,9 @@ TEST_F(ValidateData, void_array) {
 
   CompileSuccessfully(str.c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpTypeArray Element Type <id> '1[%void]' is a void type."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("OpTypeArray Element Type <id> '1[%void]' is a void type."));
 }
 
 TEST_F(ValidateData, void_runtime_array) {
@@ -699,7 +700,8 @@ TEST_F(ValidateData, void_runtime_array) {
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpTypeRuntimeArray Element Type <id> '1[%void]' is a void type."));
+      HasSubstr(
+          "OpTypeRuntimeArray Element Type <id> '1[%void]' is a void type."));
 }
 }  // namespace
 }  // namespace val

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -105,7 +105,7 @@ TEST_F(ValidateDecorations, ValidateOpMemberDecorateOutOfBound) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Index 1 provided in OpMemberDecorate for struct <id> "
-                        "2[\%_struct_2] is out of bounds. The structure has 1 "
+                        "2[%_struct_2] is out of bounds. The structure has 1 "
                         "members. Largest valid index is 0."));
 }
 
@@ -300,11 +300,11 @@ TEST_F(ValidateDecorations, StructContainsBuiltInStructBad) {
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Structure <id> 1[\%_struct_1] contains members with "
+              HasSubstr("Structure <id> 1[%_struct_1] contains members with "
                         "BuiltIn decoration. Therefore this structure may not "
                         "be contained as a member of another structure type. "
-                        "Structure <id> 4[\%_struct_4] contains structure <id> "
-                        "1[\%_struct_1]."));
+                        "Structure <id> 4[%_struct_4] contains structure <id> "
+                        "1[%_struct_1]."));
 }
 
 TEST_F(ValidateDecorations, StructContainsNonBuiltInStructGood) {
@@ -3342,7 +3342,7 @@ OpMemberDecorate %1 0 Coherent
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Coherent decoration targeting 1[\%_struct_1] (member "
+              HasSubstr("Coherent decoration targeting 1[%_struct_1] (member "
                         "index 0) is banned when using the Vulkan memory model."));
 }
 
@@ -3382,7 +3382,7 @@ OpMemberDecorate %1 1 Volatile
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Volatile decoration targeting 1[\%_struct_1] (member "
+              HasSubstr("Volatile decoration targeting 1[%_struct_1] (member "
                         "index 1) is banned when using the Vulkan memory "
                         "model."));
 }

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -105,8 +105,8 @@ TEST_F(ValidateDecorations, ValidateOpMemberDecorateOutOfBound) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Index 1 provided in OpMemberDecorate for struct <id> "
-                        "2 is out of bounds. The structure has 1 members. "
-                        "Largest valid index is 0."));
+                        "2[\%_struct_2] is out of bounds. The structure has 1 "
+                        "members. Largest valid index is 0."));
 }
 
 TEST_F(ValidateDecorations, ValidateGroupDecorateRegistration) {
@@ -300,10 +300,11 @@ TEST_F(ValidateDecorations, StructContainsBuiltInStructBad) {
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Structure <id> 1 contains members with BuiltIn "
-                        "decoration. Therefore this structure may not be "
-                        "contained as a member of another structure type. "
-                        "Structure <id> 4 contains structure <id> 1."));
+              HasSubstr("Structure <id> 1[\%_struct_1] contains members with "
+                        "BuiltIn decoration. Therefore this structure may not "
+                        "be contained as a member of another structure type. "
+                        "Structure <id> 4[\%_struct_4] contains structure <id> "
+                        "1[\%_struct_1]."));
 }
 
 TEST_F(ValidateDecorations, StructContainsNonBuiltInStructGood) {
@@ -3322,8 +3323,8 @@ OpDecorate %1 Coherent
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Coherent decoration targeting 1 is banned when using "
-                        "the Vulkan memory model."));
+              HasSubstr("Coherent decoration targeting 1[%1] is "
+                        "banned when using the Vulkan memory model."));
 }
 
 TEST_F(ValidateDecorations, VulkanMemoryModelNoCoherentMember) {
@@ -3341,9 +3342,8 @@ OpMemberDecorate %1 0 Coherent
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Coherent decoration targeting 1 (member index 0) is "
-                        "banned when using "
-                        "the Vulkan memory model."));
+              HasSubstr("Coherent decoration targeting 1[\%_struct_1] (member "
+                        "index 0) is banned when using the Vulkan memory model."));
 }
 
 TEST_F(ValidateDecorations, VulkanMemoryModelNoVolatile) {
@@ -3363,8 +3363,8 @@ OpDecorate %1 Volatile
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Volatile decoration targeting 1 is banned when using "
-                        "the Vulkan memory model."));
+              HasSubstr("Volatile decoration targeting 1[%1] is banned when "
+                        "using the Vulkan memory model."));
 }
 
 TEST_F(ValidateDecorations, VulkanMemoryModelNoVolatileMember) {
@@ -3382,9 +3382,9 @@ OpMemberDecorate %1 1 Volatile
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Volatile decoration targeting 1 (member index 1) is "
-                        "banned when using "
-                        "the Vulkan memory model."));
+              HasSubstr("Volatile decoration targeting 1[\%_struct_1] (member "
+                        "index 1) is banned when using the Vulkan memory "
+                        "model."));
 }
 
 TEST_F(ValidateDecorations, FPRoundingModeGood) {
@@ -3698,7 +3698,8 @@ OpGroupDecorate %1 %1
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpGroupDecorate may not target OpDecorationGroup <id> '1'"));
+      HasSubstr("OpGroupDecorate may not target OpDecorationGroup <id> "
+                "'1[%1]'"));
 }
 
 TEST_F(ValidateDecorations, GroupDecorateTargetsDecorationGroup2) {
@@ -3715,7 +3716,8 @@ OpGroupDecorate %1 %2 %1
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpGroupDecorate may not target OpDecorationGroup <id> '1'"));
+      HasSubstr("OpGroupDecorate may not target OpDecorationGroup <id> "
+                "'1[%1]'"));
 }
 
 TEST_F(ValidateDecorations, RecurseThroughRuntimeArray) {

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -3699,7 +3699,7 @@ OpGroupDecorate %1 %1
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpGroupDecorate may not target OpDecorationGroup <id> "
-                "'1[%1]'"));
+                        "'1[%1]'"));
 }
 
 TEST_F(ValidateDecorations, GroupDecorateTargetsDecorationGroup2) {
@@ -3716,7 +3716,7 @@ OpGroupDecorate %1 %2 %1
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpGroupDecorate may not target OpDecorationGroup <id> "
-                "'1[%1]'"));
+                        "'1[%1]'"));
 }
 
 TEST_F(ValidateDecorations, RecurseThroughRuntimeArray) {

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -3341,9 +3341,10 @@ OpMemberDecorate %1 0 Coherent
 
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Coherent decoration targeting 1[%_struct_1] (member "
-                        "index 0) is banned when using the Vulkan memory model."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Coherent decoration targeting 1[%_struct_1] (member index 0) "
+                "is banned when using the Vulkan memory model."));
 }
 
 TEST_F(ValidateDecorations, VulkanMemoryModelNoVolatile) {
@@ -3696,9 +3697,8 @@ OpGroupDecorate %1 %1
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpGroupDecorate may not target OpDecorationGroup <id> "
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpGroupDecorate may not target OpDecorationGroup <id> "
                 "'1[%1]'"));
 }
 
@@ -3714,9 +3714,8 @@ OpGroupDecorate %1 %2 %1
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpGroupDecorate may not target OpDecorationGroup <id> "
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpGroupDecorate may not target OpDecorationGroup <id> "
                 "'1[%1]'"));
 }
 

--- a/test/val/val_derivatives_test.cpp
+++ b/test/val/val_derivatives_test.cpp
@@ -120,7 +120,7 @@ TEST_F(ValidateDerivatives, OpDPdxWrongResultType) {
 
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 10[\%v4float] cannot "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 10[%v4float] cannot "
                                                "be a type"));
 }
 

--- a/test/val/val_derivatives_test.cpp
+++ b/test/val/val_derivatives_test.cpp
@@ -120,7 +120,8 @@ TEST_F(ValidateDerivatives, OpDPdxWrongResultType) {
 
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 10 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 10[\%v4float] cannot "
+                                               "be a type"));
 }
 
 TEST_F(ValidateDerivatives, OpDPdxWrongPType) {

--- a/test/val/val_ext_inst_test.cpp
+++ b/test/val/val_ext_inst_test.cpp
@@ -4134,8 +4134,8 @@ TEST_P(ValidateOpenCLStdVStoreHalfLike, PNotPointer) {
 
   CompileSuccessfully(GenerateKernelCode(ss.str()));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
-        "89[%_ptr_Workgroup_half] cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand 89[%_ptr_Workgroup_half] cannot be a type"));
 }
 
 TEST_P(ValidateOpenCLStdVStoreHalfLike, ConstPointer) {
@@ -4306,8 +4306,8 @@ TEST_P(ValidateOpenCLStdVLoadHalfLike, PNotPointer) {
 
   CompileSuccessfully(GenerateKernelCode(ss.str()));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
-        "89[%_ptr_Workgroup_half] cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand 89[%_ptr_Workgroup_half] cannot be a type"));
 }
 
 TEST_P(ValidateOpenCLStdVLoadHalfLike, OffsetWrongStorageType) {
@@ -4478,8 +4478,9 @@ TEST_F(ValidateExtInst, VLoadNPNotPointer) {
 
   CompileSuccessfully(GenerateKernelCode(ss.str()));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
-        "120[%_ptr_UniformConstant_float] cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand 120[%_ptr_UniformConstant_float] cannot be a "
+                        "type"));
 }
 
 TEST_F(ValidateExtInst, VLoadNWrongStorageClass) {
@@ -4590,8 +4591,9 @@ TEST_F(ValidateExtInst, VLoadHalfPNotPointer) {
 
   CompileSuccessfully(GenerateKernelCode(ss.str()));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
-        "114[%_ptr_UniformConstant_half] cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand 114[%_ptr_UniformConstant_half] cannot be a "
+                        "type"));
 }
 
 TEST_F(ValidateExtInst, VLoadHalfWrongStorageClass) {
@@ -4743,8 +4745,8 @@ TEST_F(ValidateExtInst, VStoreNPNotPointer) {
 
   CompileSuccessfully(GenerateKernelCode(ss.str()));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
-        "124[%_ptr_Generic_float] cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand 124[%_ptr_Generic_float] cannot be a type"));
 }
 
 TEST_F(ValidateExtInst, VStoreNPNotGeneric) {
@@ -5057,8 +5059,9 @@ TEST_F(ValidateExtInst, OpenCLStdPrintfFormatNotPointer) {
 
   CompileSuccessfully(GenerateKernelCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
-        "134[%_ptr_UniformConstant_uchar] cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand 134[%_ptr_UniformConstant_uchar] cannot be a "
+                        "type"));
 }
 
 TEST_F(ValidateExtInst, OpenCLStdPrintfFormatNotUniformConstStorageClass) {
@@ -5149,8 +5152,9 @@ TEST_F(ValidateExtInst, OpenCLStdPrefetchPtrNotPointer) {
 
   CompileSuccessfully(GenerateKernelCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
-        "99[%_ptr_CrossWorkgroup_uint] cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand 99[%_ptr_CrossWorkgroup_uint] cannot be a "
+                        "type"));
 }
 
 TEST_F(ValidateExtInst, OpenCLStdPrefetchPtrNotCrossWorkgroup) {

--- a/test/val/val_ext_inst_test.cpp
+++ b/test/val/val_ext_inst_test.cpp
@@ -4134,7 +4134,8 @@ TEST_P(ValidateOpenCLStdVStoreHalfLike, PNotPointer) {
 
   CompileSuccessfully(GenerateKernelCode(ss.str()));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 89 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
+        "89[\%_ptr_Workgroup_half] cannot be a type"));
 }
 
 TEST_P(ValidateOpenCLStdVStoreHalfLike, ConstPointer) {
@@ -4305,7 +4306,8 @@ TEST_P(ValidateOpenCLStdVLoadHalfLike, PNotPointer) {
 
   CompileSuccessfully(GenerateKernelCode(ss.str()));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 89 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
+        "89[\%_ptr_Workgroup_half] cannot be a type"));
 }
 
 TEST_P(ValidateOpenCLStdVLoadHalfLike, OffsetWrongStorageType) {
@@ -4476,7 +4478,8 @@ TEST_F(ValidateExtInst, VLoadNPNotPointer) {
 
   CompileSuccessfully(GenerateKernelCode(ss.str()));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 120 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
+        "120[\%_ptr_UniformConstant_float] cannot be a type"));
 }
 
 TEST_F(ValidateExtInst, VLoadNWrongStorageClass) {
@@ -4587,7 +4590,8 @@ TEST_F(ValidateExtInst, VLoadHalfPNotPointer) {
 
   CompileSuccessfully(GenerateKernelCode(ss.str()));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 114 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
+        "114[\%_ptr_UniformConstant_half] cannot be a type"));
 }
 
 TEST_F(ValidateExtInst, VLoadHalfWrongStorageClass) {
@@ -4739,7 +4743,8 @@ TEST_F(ValidateExtInst, VStoreNPNotPointer) {
 
   CompileSuccessfully(GenerateKernelCode(ss.str()));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 124 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
+        "124[\%_ptr_Generic_float] cannot be a type"));
 }
 
 TEST_F(ValidateExtInst, VStoreNPNotGeneric) {
@@ -5052,7 +5057,8 @@ TEST_F(ValidateExtInst, OpenCLStdPrintfFormatNotPointer) {
 
   CompileSuccessfully(GenerateKernelCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 134 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
+        "134[\%_ptr_UniformConstant_uchar] cannot be a type"));
 }
 
 TEST_F(ValidateExtInst, OpenCLStdPrintfFormatNotUniformConstStorageClass) {
@@ -5143,7 +5149,8 @@ TEST_F(ValidateExtInst, OpenCLStdPrefetchPtrNotPointer) {
 
   CompileSuccessfully(GenerateKernelCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 99 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
+        "99[\%_ptr_CrossWorkgroup_uint] cannot be a type"));
 }
 
 TEST_F(ValidateExtInst, OpenCLStdPrefetchPtrNotCrossWorkgroup) {

--- a/test/val/val_ext_inst_test.cpp
+++ b/test/val/val_ext_inst_test.cpp
@@ -4135,7 +4135,7 @@ TEST_P(ValidateOpenCLStdVStoreHalfLike, PNotPointer) {
   CompileSuccessfully(GenerateKernelCode(ss.str()));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
-        "89[\%_ptr_Workgroup_half] cannot be a type"));
+        "89[%_ptr_Workgroup_half] cannot be a type"));
 }
 
 TEST_P(ValidateOpenCLStdVStoreHalfLike, ConstPointer) {
@@ -4307,7 +4307,7 @@ TEST_P(ValidateOpenCLStdVLoadHalfLike, PNotPointer) {
   CompileSuccessfully(GenerateKernelCode(ss.str()));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
-        "89[\%_ptr_Workgroup_half] cannot be a type"));
+        "89[%_ptr_Workgroup_half] cannot be a type"));
 }
 
 TEST_P(ValidateOpenCLStdVLoadHalfLike, OffsetWrongStorageType) {
@@ -4479,7 +4479,7 @@ TEST_F(ValidateExtInst, VLoadNPNotPointer) {
   CompileSuccessfully(GenerateKernelCode(ss.str()));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
-        "120[\%_ptr_UniformConstant_float] cannot be a type"));
+        "120[%_ptr_UniformConstant_float] cannot be a type"));
 }
 
 TEST_F(ValidateExtInst, VLoadNWrongStorageClass) {
@@ -4591,7 +4591,7 @@ TEST_F(ValidateExtInst, VLoadHalfPNotPointer) {
   CompileSuccessfully(GenerateKernelCode(ss.str()));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
-        "114[\%_ptr_UniformConstant_half] cannot be a type"));
+        "114[%_ptr_UniformConstant_half] cannot be a type"));
 }
 
 TEST_F(ValidateExtInst, VLoadHalfWrongStorageClass) {
@@ -4744,7 +4744,7 @@ TEST_F(ValidateExtInst, VStoreNPNotPointer) {
   CompileSuccessfully(GenerateKernelCode(ss.str()));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
-        "124[\%_ptr_Generic_float] cannot be a type"));
+        "124[%_ptr_Generic_float] cannot be a type"));
 }
 
 TEST_F(ValidateExtInst, VStoreNPNotGeneric) {
@@ -5058,7 +5058,7 @@ TEST_F(ValidateExtInst, OpenCLStdPrintfFormatNotPointer) {
   CompileSuccessfully(GenerateKernelCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
-        "134[\%_ptr_UniformConstant_uchar] cannot be a type"));
+        "134[%_ptr_UniformConstant_uchar] cannot be a type"));
 }
 
 TEST_F(ValidateExtInst, OpenCLStdPrintfFormatNotUniformConstStorageClass) {
@@ -5150,7 +5150,7 @@ TEST_F(ValidateExtInst, OpenCLStdPrefetchPtrNotPointer) {
   CompileSuccessfully(GenerateKernelCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
-        "99[\%_ptr_CrossWorkgroup_uint] cannot be a type"));
+        "99[%_ptr_CrossWorkgroup_uint] cannot be a type"));
 }
 
 TEST_F(ValidateExtInst, OpenCLStdPrefetchPtrNotCrossWorkgroup) {

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -784,7 +784,7 @@ class OpTypeArrayLengthTest
         spvValidate(ScopedContext().context, &cbinary, &diagnostic_);
     if (status != SPV_SUCCESS) {
       spvDiagnosticPrint(diagnostic_);
-      EXPECT_THAT(std::string(diagnostic_->error), 
+      EXPECT_THAT(std::string(diagnostic_->error),
                   testing::ContainsRegex(expected_err));
     }
     return status;

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -205,7 +205,7 @@ TEST_F(ValidateIdWithMessage, OpMemberNameTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpMemberName Type <id> '1[foo]' is not a struct type."));
+      HasSubstr("OpMemberName Type <id> '1[\%uint]' is not a struct type."));
 }
 TEST_F(ValidateIdWithMessage, OpMemberNameMemberBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -216,8 +216,8 @@ TEST_F(ValidateIdWithMessage, OpMemberNameMemberBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpMemberName Member <id> '1[foo]' index is larger than "
-                "Type <id> '1[foo]'s member count."));
+      HasSubstr("OpMemberName Member <id> '1[\%_struct_1]' index is larger "
+                "than Type <id> '1[\%_struct_1]'s member count."));
 }
 
 TEST_F(ValidateIdWithMessage, OpLineGood) {
@@ -239,7 +239,7 @@ TEST_F(ValidateIdWithMessage, OpLineFileBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpLine Target <id> '1' is not an OpString."));
+              HasSubstr("OpLine Target <id> '1[\%uint]' is not an OpString."));
 }
 
 TEST_F(ValidateIdWithMessage, OpDecorateGood) {
@@ -276,7 +276,7 @@ TEST_F(ValidateIdWithMessage, OpMemberDecorateBad) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpMemberDecorate Structure type <id> '1' is not a struct type."));
+          "OpMemberDecorate Structure type <id> '1[\%uint]' is not a struct type."));
 }
 TEST_F(ValidateIdWithMessage, OpMemberDecorateMemberBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -287,8 +287,8 @@ TEST_F(ValidateIdWithMessage, OpMemberDecorateMemberBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Index 3 provided in OpMemberDecorate for struct <id> "
-                        "1 is out of bounds. The structure has 2 members. "
-                        "Largest valid index is 1."));
+                        "1[\%_struct_1] is out of bounds. The structure has 2 "
+                        "members. Largest valid index is 1."));
 }
 
 TEST_F(ValidateIdWithMessage, OpGroupDecorateGood) {
@@ -329,8 +329,8 @@ TEST_F(ValidateIdWithMessage, OpGroupDecorateDecorationGroupBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpGroupDecorate Decoration group <id> '1' is not a "
-                        "decoration group."));
+              HasSubstr("OpGroupDecorate Decoration group <id> '1[%1]' is not "
+                        "a decoration group."));
 }
 TEST_F(ValidateIdWithMessage, OpGroupDecorateTargetBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -355,8 +355,8 @@ TEST_F(ValidateIdWithMessage, OpGroupMemberDecorateDecorationGroupBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpGroupMemberDecorate Decoration group <id> '1' is "
-                        "not a decoration group."));
+              HasSubstr("OpGroupMemberDecorate Decoration group <id> '1[%1]' "
+                        "is not a decoration group."));
 }
 TEST_F(ValidateIdWithMessage, OpGroupMemberDecorateIdNotStructBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -366,8 +366,8 @@ TEST_F(ValidateIdWithMessage, OpGroupMemberDecorateIdNotStructBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpGroupMemberDecorate Structure type <id> '2' is not "
-                        "a struct type."));
+              HasSubstr("OpGroupMemberDecorate Structure type <id> '2[\%uint]' "
+                        "is not a struct type."));
 }
 TEST_F(ValidateIdWithMessage, OpGroupMemberDecorateIndexOutOfBoundBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -381,8 +381,8 @@ TEST_F(ValidateIdWithMessage, OpGroupMemberDecorateIndexOutOfBoundBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Index 3 provided in OpGroupMemberDecorate for struct "
-                        "<id> 2 is out of bounds. The structure has 3 members. "
-                        "Largest valid index is 2."));
+                        "<id> 2[\%_struct_2] is out of bounds. The structure "
+                        "has 3 members. Largest valid index is 2."));
 }
 
 // TODO: OpExtInst
@@ -408,7 +408,8 @@ TEST_F(ValidateIdWithMessage, OpEntryPointFunctionBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpEntryPoint Entry Point <id> '1' is not a function."));
+      HasSubstr("OpEntryPoint Entry Point <id> '1[\%void]' is not a "
+                "function."));
 }
 TEST_F(ValidateIdWithMessage, OpEntryPointParameterCountBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -422,8 +423,8 @@ TEST_F(ValidateIdWithMessage, OpEntryPointParameterCountBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpEntryPoint Entry Point <id> '1's function parameter "
-                        "count is not zero"));
+              HasSubstr("OpEntryPoint Entry Point <id> '1[%1]'s function "
+                        "parameter count is not zero"));
 }
 TEST_F(ValidateIdWithMessage, OpEntryPointReturnTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -438,8 +439,8 @@ TEST_F(ValidateIdWithMessage, OpEntryPointReturnTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpEntryPoint Entry Point <id> '1's function return "
-                        "type is not void."));
+              HasSubstr("OpEntryPoint Entry Point <id> '1[%1]'s function "
+                        "return type is not void."));
 }
 
 TEST_F(ValidateIdWithMessage, OpEntryPointInterfaceIsNotVariableTypeBad) {
@@ -522,8 +523,8 @@ TEST_F(ValidateIdWithMessage, OpExecutionModeEntryPointMissing) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpExecutionMode Entry Point <id> '1' is not the Entry "
-                        "Point operand of an OpEntryPoint."));
+              HasSubstr("OpExecutionMode Entry Point <id> '1[%1]' is not the "
+                        "Entry Point operand of an OpEntryPoint."));
 }
 
 TEST_F(ValidateIdWithMessage, OpExecutionModeEntryPointBad) {
@@ -541,8 +542,8 @@ TEST_F(ValidateIdWithMessage, OpExecutionModeEntryPointBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpExecutionMode Entry Point <id> '2' is not the Entry "
-                        "Point operand of an OpEntryPoint."));
+              HasSubstr("OpExecutionMode Entry Point <id> '2[%2]' is not the "
+                        "Entry Point operand of an OpEntryPoint."));
 }
 
 TEST_F(ValidateIdWithMessage, OpTypeVectorFloat) {
@@ -586,7 +587,8 @@ TEST_F(ValidateIdWithMessage, OpTypeVectorComponentTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpTypeVector Component Type <id> '2' is not a scalar type."));
+      HasSubstr("OpTypeVector Component Type <id> "
+                "'2[\%_ptr_UniformConstant_float]' is not a scalar type."));
 }
 
 TEST_F(ValidateIdWithMessage, OpTypeVectorColumnCountLessThanTwoBad) {
@@ -742,7 +744,8 @@ TEST_F(ValidateIdWithMessage, OpTypeArrayElementTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpTypeArray Element Type <id> '2' is not a type."));
+              HasSubstr("OpTypeArray Element Type <id> '2[\%uint_1]' is not a "
+                        "type."));
 }
 
 // Signed or unsigned.
@@ -783,7 +786,7 @@ class OpTypeArrayLengthTest
         spvValidate(ScopedContext().context, &cbinary, &diagnostic_);
     if (status != SPV_SUCCESS) {
       spvDiagnosticPrint(diagnostic_);
-      EXPECT_THAT(std::string(diagnostic_->error), HasSubstr(expected_err));
+      EXPECT_THAT(std::string(diagnostic_->error), testing::ContainsRegex(expected_err));
     }
     return status;
   }
@@ -820,11 +823,13 @@ TEST_P(OpTypeArrayLengthTest, LengthZero) {
   EXPECT_EQ(
       SPV_ERROR_INVALID_ID,
       Val(CompileSuccessfully(MakeArrayLength("0", kSigned, width)),
-          "OpTypeArray Length <id> '2' default value must be at least 1."));
+          "OpTypeArray Length <id> '2\\[\%.*\\]' default value must be at "
+          "least 1."));
   EXPECT_EQ(
       SPV_ERROR_INVALID_ID,
       Val(CompileSuccessfully(MakeArrayLength("0", kUnsigned, width)),
-          "OpTypeArray Length <id> '2' default value must be at least 1."));
+          "OpTypeArray Length <id> '2\\[\%.*\\]' default value must be at "
+          "least 1."));
 }
 
 TEST_P(OpTypeArrayLengthTest, LengthNegative) {
@@ -832,20 +837,24 @@ TEST_P(OpTypeArrayLengthTest, LengthNegative) {
   EXPECT_EQ(
       SPV_ERROR_INVALID_ID,
       Val(CompileSuccessfully(MakeArrayLength("-1", kSigned, width)),
-          "OpTypeArray Length <id> '2' default value must be at least 1."));
+          "OpTypeArray Length <id> '2\\[\%.*\\]' default value must be at "
+          "least 1."));
   EXPECT_EQ(
       SPV_ERROR_INVALID_ID,
       Val(CompileSuccessfully(MakeArrayLength("-2", kSigned, width)),
-          "OpTypeArray Length <id> '2' default value must be at least 1."));
+          "OpTypeArray Length <id> '2\\[\%.*\\]' default value must be at "
+          "least 1."));
   EXPECT_EQ(
       SPV_ERROR_INVALID_ID,
       Val(CompileSuccessfully(MakeArrayLength("-123", kSigned, width)),
-          "OpTypeArray Length <id> '2' default value must be at least 1."));
+          "OpTypeArray Length <id> '2\\[\%.*\\]' default value must be at "
+          "least 1."));
   const std::string neg_max = "0x8" + std::string(width / 4 - 1, '0');
   EXPECT_EQ(
       SPV_ERROR_INVALID_ID,
       Val(CompileSuccessfully(MakeArrayLength(neg_max, kSigned, width)),
-          "OpTypeArray Length <id> '2' default value must be at least 1."));
+          "OpTypeArray Length <id> '2\\[\%.*\\]' default value must be at "
+          "least 1."));
 }
 
 // The only valid widths for integers are 8, 16, 32, and 64.
@@ -866,7 +875,7 @@ TEST_F(ValidateIdWithMessage, OpTypeArrayLengthNull) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpTypeArray Length <id> '2' default value must be at least 1."));
+          "OpTypeArray Length <id> '2[%2]' default value must be at least 1."));
 }
 
 TEST_F(ValidateIdWithMessage, OpTypeArrayLengthSpecConst) {
@@ -905,7 +914,8 @@ TEST_F(ValidateIdWithMessage, OpTypeRuntimeArrayBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpTypeRuntimeArray Element Type <id> '2' is not a type."));
+      HasSubstr("OpTypeRuntimeArray Element Type <id> '2[\%uint_0]' is not a "
+                "type."));
 }
 // TODO: Object of this type can only be created with OpVariable using the
 // Unifrom Storage Class
@@ -928,7 +938,8 @@ TEST_F(ValidateIdWithMessage, OpTypeStructMemberTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpTypeStruct Member Type <id> '3' is not a type."));
+              HasSubstr("OpTypeStruct Member Type <id> '3[\%double_0]' is not "
+                        "a type."));
 }
 
 TEST_F(ValidateIdWithMessage, OpTypePointerGood) {
@@ -946,7 +957,8 @@ TEST_F(ValidateIdWithMessage, OpTypePointerBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpTypePointer Type <id> '2' is not a type."));
+              HasSubstr("OpTypePointer Type <id> '2[\%uint_0]' is not a "
+                        "type."));
 }
 
 TEST_F(ValidateIdWithMessage, OpTypeFunctionGood) {
@@ -964,7 +976,8 @@ TEST_F(ValidateIdWithMessage, OpTypeFunctionReturnTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpTypeFunction Return Type <id> '2' is not a type."));
+              HasSubstr("OpTypeFunction Return Type <id> '2[\%uint_0]' is not "
+                        "a type."));
 }
 TEST_F(ValidateIdWithMessage, OpTypeFunctionParameterBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -976,7 +989,8 @@ TEST_F(ValidateIdWithMessage, OpTypeFunctionParameterBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpTypeFunction Parameter Type <id> '3' is not a type."));
+      HasSubstr("OpTypeFunction Parameter Type <id> '3[\%uint_0]' is not a "
+                "type."));
 }
 
 TEST_F(ValidateIdWithMessage, OpTypeFunctionParameterTypeVoidBad) {
@@ -987,8 +1001,8 @@ TEST_F(ValidateIdWithMessage, OpTypeFunctionParameterTypeVoidBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpTypeFunction Parameter Type <id> '1' cannot be "
-                        "OpTypeVoid."));
+              HasSubstr("OpTypeFunction Parameter Type <id> '1[\%void]' cannot "
+                        "be OpTypeVoid."));
 }
 
 TEST_F(ValidateIdWithMessage, OpTypePipeGood) {
@@ -1015,7 +1029,8 @@ TEST_F(ValidateIdWithMessage, OpConstantTrueBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpConstantTrue Result Type <id> '1' is not a boolean type."));
+      HasSubstr("OpConstantTrue Result Type <id> '1[\%void]' is not a boolean "
+                "type."));
 }
 
 TEST_F(ValidateIdWithMessage, OpConstantFalseGood) {
@@ -1033,7 +1048,8 @@ TEST_F(ValidateIdWithMessage, OpConstantFalseBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpConstantFalse Result Type <id> '1' is not a boolean type."));
+      HasSubstr("OpConstantFalse Result Type <id> '1[\%void]' is not a boolean "
+                "type."));
 }
 
 TEST_F(ValidateIdWithMessage, OpConstantGood) {
@@ -1084,7 +1100,8 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeVectorResultTypeBad) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpConstantComposite Result Type <id> '1' is not a composite type."));
+          "OpConstantComposite Result Type <id> '1[\%float]' is not a "
+          "composite type."));
 }
 TEST_F(ValidateIdWithMessage, OpConstantCompositeVectorConstituentTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -1098,8 +1115,9 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeVectorConstituentTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpConstantComposite Constituent <id> '5's type does not match "
-                "Result Type <id> '2's vector element type."));
+      HasSubstr("OpConstantComposite Constituent <id> '5[\%uint_42]'s type "
+                "does not match Result Type <id> '2[\%v4float]'s vector "
+                "element type."));
 }
 TEST_F(ValidateIdWithMessage,
        OpConstantCompositeVectorConstituentUndefTypeBad) {
@@ -1114,8 +1132,8 @@ TEST_F(ValidateIdWithMessage,
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpConstantComposite Constituent <id> '5's type does not match "
-                "Result Type <id> '2's vector element type."));
+      HasSubstr("OpConstantComposite Constituent <id> '5[%5]'s type does not "
+                "match Result Type <id> '2[\%v4float]'s vector element type."));
 }
 TEST_F(ValidateIdWithMessage, OpConstantCompositeMatrixGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -1163,9 +1181,9 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeMatrixConstituentTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpConstantComposite Constituent <id> '10' vector "
-                        "component count does not match Result Type <id> '4's "
-                        "vector component count."));
+              HasSubstr("OpConstantComposite Constituent <id> '10[%10]' vector "
+                        "component count does not match Result Type <id> "
+                        "'4[\%mat4v4float]'s vector component count."));
 }
 TEST_F(ValidateIdWithMessage,
        OpConstantCompositeMatrixConstituentUndefTypeBad) {
@@ -1184,9 +1202,9 @@ TEST_F(ValidateIdWithMessage,
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpConstantComposite Constituent <id> '10' vector "
-                        "component count does not match Result Type <id> '4's "
-                        "vector component count."));
+              HasSubstr("OpConstantComposite Constituent <id> '10[%10]' vector "
+                        "component count does not match Result Type <id> "
+                        "'4[\%mat4v4float]'s vector component count."));
 }
 TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -1215,7 +1233,8 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstConstituentTypeBad) {
 %4 = OpConstantComposite %3 %2 %2 %2 %1)";  // Uses a type as operand
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 1 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 1[\%uint] cannot be a "
+                                               "type"));
 }
 TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstConstituentBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -1228,7 +1247,7 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstConstituentBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpConstantComposite Constituent <id> '5' is not a "
+              HasSubstr("OpConstantComposite Constituent <id> '5[%5]' is not a "
                         "constant or undef."));
 }
 TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstituentTypeBad) {
@@ -1242,8 +1261,10 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstituentTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpConstantComposite Constituent <id> '5's type does "
-                        "not match Result Type <id> '3's array element type."));
+              HasSubstr("OpConstantComposite Constituent <id> "
+                        "'5[\%float_3_1400001]'s type does not match Result "
+                        "Type <id> '3[\%_arr_uint_uint_4]'s array element "
+                        "type."));
 }
 TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstituentUndefTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -1256,8 +1277,10 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstituentUndefTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpConstantComposite Constituent <id> '5's type does "
-                        "not match Result Type <id> '3's array element type."));
+              HasSubstr("OpConstantComposite Constituent <id> "
+                        "'5[%5]'s type does not match Result "
+                        "Type <id> '3[\%_arr_uint_uint_4]'s array element "
+                        "type."));
 }
 TEST_F(ValidateIdWithMessage, OpConstantCompositeStructGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -1292,8 +1315,9 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeStructMemberTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpConstantComposite Constituent <id> '5' type does "
-                        "not match the Result Type <id> '3's member type."));
+              HasSubstr("OpConstantComposite Constituent <id> "
+                        "'5[\%ulong_4300000000]' type does not match the "
+                        "Result Type <id> '3[\%_struct_3]'s member type."));
 }
 
 TEST_F(ValidateIdWithMessage, OpConstantCompositeStructMemberUndefTypeBad) {
@@ -1307,8 +1331,9 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeStructMemberUndefTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpConstantComposite Constituent <id> '5' type does "
-                        "not match the Result Type <id> '3's member type."));
+              HasSubstr("OpConstantComposite Constituent <id> '5[%5]' type "
+                        "does not match the Result Type <id> '3[\%_struct_3]'s "
+                        "member type."));
 }
 
 TEST_F(ValidateIdWithMessage, OpConstantSamplerGood) {
@@ -1328,7 +1353,8 @@ TEST_F(ValidateIdWithMessage, OpConstantSamplerResultTypeBad) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpConstantSampler Result Type <id> '1' is not a sampler type."));
+          "OpConstantSampler Result Type <id> '1[\%float]' is not a sampler "
+          "type."));
 }
 
 TEST_F(ValidateIdWithMessage, OpConstantNullGood) {
@@ -1376,7 +1402,8 @@ TEST_F(ValidateIdWithMessage, OpConstantNullBasicBad) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpConstantNull Result Type <id> '1' cannot have a null value."));
+          "OpConstantNull Result Type <id> '1[\%void]' cannot have a null "
+          "value."));
 }
 
 TEST_F(ValidateIdWithMessage, OpConstantNullArrayBad) {
@@ -1391,7 +1418,8 @@ TEST_F(ValidateIdWithMessage, OpConstantNullArrayBad) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpConstantNull Result Type <id> '4' cannot have a null value."));
+          "OpConstantNull Result Type <id> '4[\%_arr_2_uint_4]' cannot have a "
+          "null value."));
 }
 
 TEST_F(ValidateIdWithMessage, OpConstantNullStructBad) {
@@ -1404,7 +1432,7 @@ TEST_F(ValidateIdWithMessage, OpConstantNullStructBad) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpConstantNull Result Type <id> '2' cannot have a null value."));
+          "OpConstantNull Result Type <id> '2[\%_struct_2]' cannot have a null value."));
 }
 
 TEST_F(ValidateIdWithMessage, OpConstantNullRuntimeArrayBad) {
@@ -1417,7 +1445,8 @@ TEST_F(ValidateIdWithMessage, OpConstantNullRuntimeArrayBad) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpConstantNull Result Type <id> '2' cannot have a null value."));
+          "OpConstantNull Result Type <id> '2[\%_runtimearr_bool]' cannot have "
+          "a null value."));
 }
 
 TEST_F(ValidateIdWithMessage, OpSpecConstantTrueGood) {
@@ -1523,9 +1552,9 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeVectorConstituentTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '5's type "
-                        "does not match Result Type <id> '2's vector element "
-                        "type."));
+              HasSubstr("OpSpecConstantComposite Constituent <id> "
+                        "'5[\%uint_42]'s type does not match Result Type <id> "
+                        "'2[\%v4float]'s vector element type."));
 }
 
 // Invalid: Constituent is not a constant
@@ -1542,8 +1571,8 @@ TEST_F(ValidateIdWithMessage,
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '6' is not a "
-                        "constant or undef."));
+              HasSubstr("OpSpecConstantComposite Constituent <id> '6[%6]' is "
+                        "not a constant or undef."));
 }
 
 // Invalid: Vector contains a mix of Undef-int and Float.
@@ -1559,9 +1588,9 @@ TEST_F(ValidateIdWithMessage,
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '5's type "
-                        "does not match Result Type <id> '2's vector element "
-                        "type."));
+              HasSubstr("OpSpecConstantComposite Constituent <id> '5[%5]'s "
+                        "type does not match Result Type <id> '2[\%v4float]'s "
+                        "vector element type."));
 }
 
 // Invalid: Vector expects 3 components, but 4 specified.
@@ -1576,8 +1605,8 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeVectorNumComponentsBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpSpecConstantComposite Constituent <id> count does "
-                        "not match Result Type <id> '2's vector component "
-                        "count."));
+                        "not match Result Type <id> '2[\%v3float]'s vector "
+                        "component count."));
 }
 
 // Valid: 4x4 matrix of floats
@@ -1631,9 +1660,9 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeMatrixConstituentTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '10' vector "
-                        "component count does not match Result Type <id> '4's "
-                        "vector component count."));
+              HasSubstr("OpSpecConstantComposite Constituent <id> '10[%10]' "
+                        "vector component count does not match Result Type "
+                        "<id> '4[\%mat4v4float]'s vector component count."));
 }
 
 // Invalid: Matrix type expects 4 columns but only 3 specified.
@@ -1653,7 +1682,8 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeMatrixNumColsBad) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("OpSpecConstantComposite Constituent <id> count does "
-                "not match Result Type <id> '3's matrix column count."));
+                "not match Result Type <id> '3[\%mat4v4float]'s matrix column "
+                "count."));
 }
 
 // Invalid: Composite contains a non-const/undef component
@@ -1671,8 +1701,8 @@ TEST_F(ValidateIdWithMessage,
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '7' is not a "
-                        "constant composite or undef."));
+              HasSubstr("OpSpecConstantComposite Constituent <id> '7[%7]' is "
+                        "not a constant composite or undef."));
 }
 
 // Invalid: Composite contains a column that is *not* a vector (it's an array)
@@ -1691,9 +1721,9 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeMatrixColTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '8' type "
-                        "does not match Result Type <id> '7's matrix column "
-                        "type."));
+              HasSubstr("OpSpecConstantComposite Constituent <id> '8[%8]' type "
+                        "does not match Result Type <id> '7[\%mat4v4float]'s "
+                        "matrix column type."));
 }
 
 // Invalid: Matrix with an Undef column of the wrong size.
@@ -1714,9 +1744,9 @@ TEST_F(ValidateIdWithMessage,
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '10' vector "
-                        "component count does not match Result Type <id> '4's "
-                        "vector component count."));
+              HasSubstr("OpSpecConstantComposite Constituent <id> '10[%10]' "
+                        "vector component count does not match Result Type "
+                        "<id> '4[\%mat4v4float]'s vector component count."));
 }
 
 // Invalid: Matrix in which some columns are Int and some are Float.
@@ -1735,9 +1765,9 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeMatrixColumnTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '8' "
-                        "component type does not match Result Type <id> '5's "
-                        "matrix column component type."));
+              HasSubstr("OpSpecConstantComposite Constituent <id> '8[%8]' "
+                        "component type does not match Result Type <id> "
+                        "'5[\%mat2v2float]'s matrix column component type."));
 }
 
 // Valid: Array of integers
@@ -1765,7 +1795,8 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeArrayNumComponentsBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpSpecConstantComposite Constituent count does not "
-                        "match Result Type <id> '3's array length."));
+                        "match Result Type <id> '3[\%_arr_uint_uint_4]'s array "
+                        "length."));
 }
 
 // Valid: Array of Integers and Undef-int
@@ -1792,8 +1823,8 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeArrayConstConstituentBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '5' is not a "
-                        "constant or undef."));
+              HasSubstr("OpSpecConstantComposite Constituent <id> '5[%5]' is "
+                        "not a constant or undef."));
 }
 
 // Invalid: Array has a mix of Int and Float components.
@@ -1808,9 +1839,9 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeArrayConstituentTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '5's type "
-                        "does not match Result Type <id> '3's array element "
-                        "type."));
+              HasSubstr("OpSpecConstantComposite Constituent <id> '5[%5]'s "
+                        "type does not match Result Type <id> "
+                        "'3[\%_arr_uint_uint_4]'s array element type."));
 }
 
 // Invalid: Array has a mix of Int and Undef-float.
@@ -1826,9 +1857,9 @@ TEST_F(ValidateIdWithMessage,
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '5's type "
-                        "does not match Result Type <id> '3's array element "
-                        "type."));
+              HasSubstr("OpSpecConstantComposite Constituent <id> '5[%5]'s "
+                        "type does not match Result Type <id> "
+                        "'3[\%_arr_uint_2]'s array element type."));
 }
 
 // Valid: Struct of {Int32,Int32,Int64}.
@@ -1856,9 +1887,9 @@ TEST_F(ValidateIdWithMessage,
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '2' count "
-                        "does not match Result Type <id> '2's struct member "
-                        "count."));
+              HasSubstr("OpSpecConstantComposite Constituent <id> "
+                        "'2[\%_struct_2]' count does not match Result Type "
+                        "<id> '2[\%_struct_2]'s struct member count."));
 }
 
 // Valid: Struct uses Undef-int64.
@@ -1888,8 +1919,8 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeStructNonConstBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '7' is not a "
-                        "constant or undef."));
+              HasSubstr("OpSpecConstantComposite Constituent <id> '7[%7]' is "
+                        "not a constant or undef."));
 }
 
 // Invalid: Struct component type does not match expected specialization type.
@@ -1905,9 +1936,9 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeStructMemberTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '5' type "
-                        "does not match the Result Type <id> '3's member "
-                        "type."));
+              HasSubstr("OpSpecConstantComposite Constituent <id> '5[%5]' type "
+                        "does not match the Result Type <id> '3[\%_struct_3]'s "
+                        "member type."));
 }
 
 // Invalid: Undef-int64 used when Int32 was expected.
@@ -1922,9 +1953,9 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeStructMemberUndefTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '5' type "
-                        "does not match the Result Type <id> '3's member "
-                        "type."));
+              HasSubstr("OpSpecConstantComposite Constituent <id> '5[%5]' type "
+                        "does not match the Result Type <id> '3[\%_struct_3]'s "
+                        "member type."));
 }
 
 // TODO: OpSpecConstantOp
@@ -1966,7 +1997,8 @@ TEST_F(ValidateIdWithMessage, OpVariableResultTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpVariable Result Type <id> '1' is not a pointer type."));
+      HasSubstr("OpVariable Result Type <id> '1[\%uint]' is not a pointer "
+                "type."));
 }
 TEST_F(ValidateIdWithMessage, OpVariableInitializerIsTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -1975,7 +2007,8 @@ TEST_F(ValidateIdWithMessage, OpVariableInitializerIsTypeBad) {
 %3 = OpVariable %2 Input %2)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 2 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 2[\%_ptr_Input_uint] "
+                                               "cannot be a type"));
 }
 
 TEST_F(ValidateIdWithMessage, OpVariableInitializerIsFunctionVarBad) {
@@ -1995,8 +2028,8 @@ OpFunctionEnd
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpVariable Initializer <id> '8' is not a constant or "
-                        "module-scope variable"));
+              HasSubstr("OpVariable Initializer <id> '8[%8]' is not a constant "
+                        "or module-scope variable"));
 }
 
 TEST_F(ValidateIdWithMessage, OpVariableInitializerIsModuleVarGood) {
@@ -2389,8 +2422,9 @@ TEST_F(ValidateIdWithMessage, OpLoadResultTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpLoad Result Type <id> '3' does not match Pointer "
-                        "<id> '5's type."));
+              HasSubstr("OpLoad Result Type <id> "
+                        "'3[\%_ptr_UniformConstant_uint]' does not match "
+                        "Pointer <id> '5[%5]'s type."));
 }
 
 TEST_F(ValidateIdWithMessage, OpLoadPointerBad) {
@@ -2409,7 +2443,8 @@ TEST_F(ValidateIdWithMessage, OpLoadPointerBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   // Prove that SSA checks trigger for a bad Id value.
   // The next test case show the not-a-logical-pointer case.
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 8 has not been defined"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 8[%8] has not been "
+                                               "defined"));
 }
 
 // Disabled as bitcasting type to object is now not valid.
@@ -2471,7 +2506,8 @@ TEST_F(ValidateIdWithMessage, OpStorePointerBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpStore Pointer <id> '7' is not a logical pointer."));
+              HasSubstr("OpStore Pointer <id> '7[\%uint_0]' is not a logical "
+                        "pointer."));
 }
 
 // Disabled as bitcasting type to object is now not valid.
@@ -2551,7 +2587,7 @@ TEST_F(ValidateIdWithMessage, OpStoreObjectGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpStore Object <id> '9's type is void."));
+              HasSubstr("OpStore Object <id> '9[%9]'s type is void."));
 }
 TEST_F(ValidateIdWithMessage, OpStoreTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -2570,8 +2606,8 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpStore Pointer <id> '7's type does not match Object "
-                        "<id> '6's type."));
+              HasSubstr("OpStore Pointer <id> '7[%7]'s type does not match "
+                        "Object <id> '6[\%float_3_1400001]'s type."));
 }
 
 // The next series of test check test a relaxation of the rules for stores to
@@ -2603,8 +2639,8 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeBadStruct) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpStore Pointer <id> '8's type does not match Object "
-                        "<id> '11's type."));
+              HasSubstr("OpStore Pointer <id> '8[%8]'s type does not match "
+                        "Object <id> '11[%11]'s type."));
 }
 
 // Same code as the last test.  The difference is that we relax the rule.
@@ -2734,8 +2770,8 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeBadRelaxedStruct1) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpStore Pointer <id> '13's layout does not match Object "
-                "<id> '16's layout."));
+      HasSubstr("OpStore Pointer <id> '13[%13]'s layout does not match Object "
+                "<id> '16[%16]'s layout."));
 }
 
 // This test check that the even with the relaxed rules an error is identified
@@ -2774,8 +2810,8 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeBadRelaxedStruct2) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpStore Pointer <id> '13's layout does not match Object "
-                "<id> '16's layout."));
+      HasSubstr("OpStore Pointer <id> '13[%13]'s layout does not match Object "
+                "<id> '16[%16]'s layout."));
 }
 
 TEST_F(ValidateIdWithMessage, OpStoreTypeRelaxedLogicalPointerReturnPointer) {
@@ -2836,7 +2872,7 @@ TEST_F(ValidateIdWithMessage, OpStoreVoid) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpStore Object <id> '8's type is void."));
+              HasSubstr("OpStore Object <id> '8[%8]'s type is void."));
 }
 
 TEST_F(ValidateIdWithMessage, OpStoreLabel) {
@@ -2854,7 +2890,7 @@ TEST_F(ValidateIdWithMessage, OpStoreLabel) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpStore Object <id> '7' is not an object."));
+              HasSubstr("OpStore Object <id> '7[%7]' is not an object."));
 }
 
 // TODO: enable when this bug is fixed:
@@ -2951,7 +2987,7 @@ OpFunctionEnd
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Target operand <id> '6' is not a pointer."));
+              HasSubstr("Target operand <id> '6[%6]' is not a pointer."));
 }
 
 TEST_F(ValidateIdWithMessage, OpCopyMemoryNonPointerSource) {
@@ -2972,7 +3008,7 @@ OpFunctionEnd
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Source operand <id> '6' is not a pointer."));
+              HasSubstr("Source operand <id> '6[%6]' is not a pointer."));
 }
 
 TEST_F(ValidateIdWithMessage, OpCopyMemoryBad) {
@@ -2995,8 +3031,8 @@ TEST_F(ValidateIdWithMessage, OpCopyMemoryBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Target <id> '5's type does not match "
-                        "Source <id> '2's type."));
+              HasSubstr("Target <id> '5[%5]'s type does not match "
+                        "Source <id> '2[\%uint]'s type."));
 }
 
 TEST_F(ValidateIdWithMessage, OpCopyMemoryVoidTarget) {
@@ -3018,7 +3054,8 @@ OpFunctionEnd
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Target operand <id> '7' cannot be a void pointer."));
+              HasSubstr("Target operand <id> '7[%7]' cannot be a void "
+                        "pointer."));
 }
 
 TEST_F(ValidateIdWithMessage, OpCopyMemoryVoidSource) {
@@ -3040,7 +3077,8 @@ OpFunctionEnd
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Source operand <id> '7' cannot be a void pointer."));
+              HasSubstr("Source operand <id> '7[%7]' cannot be a void "
+                        "pointer."));
 }
 
 TEST_F(ValidateIdWithMessage, OpCopyMemorySizedGood) {
@@ -3078,7 +3116,7 @@ TEST_F(ValidateIdWithMessage, OpCopyMemorySizedTargetBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Target operand <id> '9' is not a pointer."));
+              HasSubstr("Target operand <id> '9[%9]' is not a pointer."));
 }
 TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSourceBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -3097,7 +3135,7 @@ TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSourceBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Source operand <id> '5' is not a pointer."));
+              HasSubstr("Source operand <id> '5[\%uint_4]' is not a pointer."));
 }
 TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -3118,7 +3156,7 @@ TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Size operand <id> '6' must be a scalar integer type."));
+      HasSubstr("Size operand <id> '6[%6]' must be a scalar integer type."));
 }
 TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -3141,7 +3179,8 @@ TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Size operand <id> '9' must be a scalar integer type."));
+      HasSubstr("Size operand <id> '9[\%float_1]' must be a scalar integer "
+                "type."));
 }
 
 TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeConstantNull) {
@@ -3165,7 +3204,8 @@ OpFunctionEnd
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Size operand <id> '3' cannot be a constant zero."));
+              HasSubstr("Size operand <id> '3[%3]' cannot be a constant "
+                        "zero."));
 }
 
 TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeConstantZero) {
@@ -3189,7 +3229,8 @@ OpFunctionEnd
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Size operand <id> '3' cannot be a constant zero."));
+              HasSubstr("Size operand <id> '3[\%uint_0]' cannot be a constant "
+                        "zero."));
 }
 
 TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeConstantZero64) {
@@ -3213,7 +3254,8 @@ OpFunctionEnd
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Size operand <id> '3' cannot be a constant zero."));
+              HasSubstr("Size operand <id> '3[\%ulong_0]' cannot be a constant "
+                        "zero."));
 }
 
 TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeConstantNegative) {
@@ -3238,7 +3280,8 @@ OpFunctionEnd
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Size operand <id> '3' cannot have the sign bit set to 1."));
+      HasSubstr("Size operand <id> '3[\%int_n1]' cannot have the sign bit set "
+                "to 1."));
 }
 
 TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeConstantNegative64) {
@@ -3263,7 +3306,8 @@ OpFunctionEnd
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Size operand <id> '3' cannot have the sign bit set to 1."));
+      HasSubstr("Size operand <id> '3[\%long_n1]' cannot have the sign bit set "
+                "to 1."));
 }
 
 TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeUnsignedNegative) {
@@ -3403,7 +3447,7 @@ OpFunctionEnd
   )";
 
   const std::string expected_err = "The Result Type of " + instr +
-                                   " <id> '36' must be "
+                                   " <id> '36[%36]' must be "
                                    "OpTypePointer. Found OpTypeFloat.";
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
@@ -3423,7 +3467,8 @@ OpFunctionEnd
   )";
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 1 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 1[\%void] cannot be a "
+                                               "type"));
 }
 
 // Invalid. The base type of an access chain instruction must be a pointer.
@@ -3440,7 +3485,8 @@ OpFunctionEnd
   )";
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 8 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
+    "8[\%_ptr_Private_float] cannot be a type"));
 }
 
 // Invalid: The storage class of Base and Result do not match.
@@ -3743,8 +3789,8 @@ OpFunctionEnd
   )";
   const std::string expected_err = "Index is out of bounds: " + instr +
                                    " can not find index 3 into the structure "
-                                   "<id> '25'. This structure has 3 members. "
-                                   "Largest valid index is 2.";
+                                   "<id> '25[\%_struct_25]'. This structure "
+                                   "has 3 members. Largest valid index is 2.";
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr(expected_err));
@@ -3890,8 +3936,9 @@ TEST_F(ValidateIdWithMessage, OpFunctionResultTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpFunction Result Type <id> '2' does not match the "
-                        "Function Type's return type <id> '1'."));
+              HasSubstr("OpFunction Result Type <id> '2[\%uint]' does not "
+                        "match the Function Type's return type <id> "
+                        "'1[\%void]'."));
 }
 TEST_F(ValidateIdWithMessage, OpReturnValueTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -3906,8 +3953,8 @@ TEST_F(ValidateIdWithMessage, OpReturnValueTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpReturnValue Value <id> '3's type does not match "
-                        "OpFunction's return type."));
+              HasSubstr("OpReturnValue Value <id> '3[\%float_0]'s type does "
+                        "not match OpFunction's return type."));
 }
 TEST_F(ValidateIdWithMessage, OpFunctionFunctionTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -3921,7 +3968,8 @@ OpFunctionEnd)";
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpFunction Function Type <id> '2' is not a function type."));
+      HasSubstr("OpFunction Function Type <id> '2[\%uint]' is not a function "
+                "type."));
 }
 
 TEST_F(ValidateIdWithMessage, OpFunctionUseBad) {
@@ -3937,7 +3985,7 @@ OpFunctionEnd
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Invalid use of function result id 3."));
+              HasSubstr("Invalid use of function result id 3[%3]."));
 }
 
 TEST_F(ValidateIdWithMessage, OpFunctionParameterGood) {
@@ -3981,8 +4029,8 @@ TEST_F(ValidateIdWithMessage, OpFunctionParameterResultTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpFunctionParameter Result Type <id> '1' does not match the "
-                "OpTypeFunction parameter type of the same index."));
+      HasSubstr("OpFunctionParameter Result Type <id> '1[\%void]' does not "
+                "match the OpTypeFunction parameter type of the same index."));
 }
 
 TEST_F(ValidateIdWithMessage, OpFunctionCallGood) {
@@ -4030,8 +4078,9 @@ TEST_F(ValidateIdWithMessage, OpFunctionCallResultTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpFunctionCall Result Type <id> '1's type does not "
-                        "match Function <id> '2's return type."));
+              HasSubstr("OpFunctionCall Result Type <id> '1[\%void]'s type "
+                        "does not match Function <id> '2[\%uint]'s return "
+                        "type."));
 }
 TEST_F(ValidateIdWithMessage, OpFunctionCallFunctionBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -4049,7 +4098,8 @@ TEST_F(ValidateIdWithMessage, OpFunctionCallFunctionBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpFunctionCall Function <id> '5' is not a function."));
+              HasSubstr("OpFunctionCall Function <id> '5[\%uint_42]' is not a "
+                        "function."));
 }
 TEST_F(ValidateIdWithMessage, OpFunctionCallArgumentTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -4077,8 +4127,9 @@ TEST_F(ValidateIdWithMessage, OpFunctionCallArgumentTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpFunctionCall Argument <id> '7's type does not match "
-                        "Function <id> '2's parameter type."));
+              HasSubstr("OpFunctionCall Argument <id> '7[\%float_3_1400001]'s "
+                        "type does not match Function <id> '2[\%uint]'s "
+                        "parameter type."));
 }
 
 // Valid: OpSampledImage result <id> is used in the same block by
@@ -4109,8 +4160,8 @@ OpFunctionEnd)";
       getDiagnosticString(),
       HasSubstr("All OpSampledImage instructions must be in the same block in "
                 "which their Result <id> are consumed. OpSampledImage Result "
-                "Type <id> '23' has a consumer in a different basic block. The "
-                "consumer instruction <id> is '25'."));
+                "Type <id> '23[%23]' has a consumer in a different basic "
+                "block. The consumer instruction <id> is '25[%25]'."));
 }
 
 // Invalid: OpSampledImage result <id> is used by OpSelect
@@ -4314,7 +4365,7 @@ TEST_F(ValidateIdWithMessage, OpVectorShuffleComponentCount) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("OpVectorShuffle component literals count does not match "
-                "Result Type <id> '2's vector component count."));
+                "Result Type <id> '2[\%v3uint]'s vector component count."));
 }
 
 TEST_F(ValidateIdWithMessage, OpVectorShuffleVector1Type) {
@@ -4591,7 +4642,8 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 3 is not a type id"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 3[\%true] is not a type "
+                                               "id"));
 }
 
 TEST_F(ValidateIdWithMessage, OpPhiSamePredecessor) {
@@ -4703,8 +4755,9 @@ OpFunctionEnd
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpPhi's result type <id> 2 does not match incoming "
-                        "value <id> 6 type <id> 5."));
+              HasSubstr("OpPhi's result type <id> 2[\%bool] does not match "
+                        "incoming value <id> 6[\%uint_0] type <id> "
+                        "5[\%uint]."));
 }
 
 TEST_F(ValidateIdWithMessage, OpPhiPredecessorNotABlock) {
@@ -4730,7 +4783,8 @@ OpFunctionEnd
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpPhi's incoming basic block <id> 3 is not an OpLabel."));
+      HasSubstr("OpPhi's incoming basic block <id> 3[\%true] is not an "
+                "OpLabel."));
 }
 
 TEST_F(ValidateIdWithMessage, OpPhiNotAPredecessor) {
@@ -4755,8 +4809,8 @@ OpFunctionEnd
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpPhi's incoming basic block <id> 9 is not a "
-                        "predecessor of <id> 8."));
+              HasSubstr("OpPhi's incoming basic block <id> 9[%9] is not a "
+                        "predecessor of <id> 8[%8]."));
 }
 
 TEST_F(ValidateIdWithMessage, OpBranchConditionalGood) {
@@ -4856,7 +4910,8 @@ OpBranchConditional %bool %target_t %target_f
 
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 3 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 3[\%bool] cannot be a "
+                                               "type"));
 }
 
 // TODO: OpSwitch
@@ -4918,7 +4973,8 @@ TEST_F(ValidateIdWithMessage, OpReturnValueIsType) {
      OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 1 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 1[\%void] cannot be a "
+                                               "type"));
 }
 
 TEST_F(ValidateIdWithMessage, OpReturnValueIsLabel) {
@@ -4934,7 +4990,8 @@ TEST_F(ValidateIdWithMessage, OpReturnValueIsLabel) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpReturnValue Value <id> '5' does not represent a value."));
+      HasSubstr("OpReturnValue Value <id> '5[%5]' does not represent a "
+                "value."));
 }
 
 TEST_F(ValidateIdWithMessage, OpReturnValueIsVoid) {
@@ -4951,7 +5008,8 @@ TEST_F(ValidateIdWithMessage, OpReturnValueIsVoid) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpReturnValue value's type <id> '1' is missing or void."));
+      HasSubstr("OpReturnValue value's type <id> '1[\%void]' is missing or "
+                "void."));
 }
 
 TEST_F(ValidateIdWithMessage, OpReturnValueIsVariableInPhysical) {
@@ -4987,8 +5045,9 @@ TEST_F(ValidateIdWithMessage, OpReturnValueIsVariableInLogical) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpReturnValue value's type <id> '3' is a pointer, "
-                        "which is invalid in the Logical addressing model."));
+              HasSubstr("OpReturnValue value's type <id> "
+                        "'3[\%_ptr_Function_uint]' is a pointer, which is "
+                        "invalid in the Logical addressing model."));
 }
 
 // With the VariablePointer Capability, the return value of a function is
@@ -5060,7 +5119,8 @@ TEST_F(ValidateIdWithMessage, UndefinedIdScope) {
 )";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 7 has not been defined"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 7[%7] has not been "
+                                               "defined"));
 }
 
 TEST_F(ValidateIdWithMessage, UndefinedIdMemSem) {
@@ -5077,7 +5137,8 @@ TEST_F(ValidateIdWithMessage, UndefinedIdMemSem) {
 )";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 7 has not been defined"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 7[%7] has not been "
+                                               "defined"));
 }
 
 TEST_F(ValidateIdWithMessage,
@@ -5212,7 +5273,8 @@ TEST_F(ValidateIdWithMessage, OpLoadBitcastNonPointerBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpLoad type for pointer <id> '11' is not a pointer type."));
+      HasSubstr("OpLoad type for pointer <id> '11[%11]' is not a pointer "
+                "type."));
 }
 TEST_F(ValidateIdWithMessage, OpStoreBitcastPointerGood) {
   std::string spirv = kOpenCLMemoryModel64 + R"(
@@ -5252,7 +5314,8 @@ TEST_F(ValidateIdWithMessage, OpStoreBitcastNonPointerBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpStore type for pointer <id> '11' is not a pointer type."));
+      HasSubstr("OpStore type for pointer <id> '11[%11]' is not a pointer "
+                "type."));
 }
 
 // Result <id> resulting from an instruction within a function may not be used
@@ -5279,7 +5342,8 @@ OpFunctionEnd
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "ID 7 defined in block 6 does not dominate its use in block 9"));
+          "ID 7[%7] defined in block 6[%6] does not dominate its use in block "
+          "9[%9]"));
 }
 
 TEST_F(ValidateIdWithMessage, SpecIdTargetNotSpecializationConstant) {
@@ -5297,8 +5361,9 @@ OpFunctionEnd
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpDecorate SpecId decoration target <id> '1' is not a "
-                        "scalar specialization constant."));
+              HasSubstr("OpDecorate SpecId decoration target <id> "
+                        "'1[\%uint_3]' is not a scalar specialization "
+                        "constant."));
 }
 
 TEST_F(ValidateIdWithMessage, SpecIdTargetOpSpecConstantOpBad) {
@@ -5318,8 +5383,8 @@ OpFunctionEnd
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpDecorate SpecId decoration target <id> '1' is not a "
-                        "scalar specialization constant."));
+              HasSubstr("OpDecorate SpecId decoration target <id> '1[%1]' is "
+                        "not a scalar specialization constant."));
 }
 
 TEST_F(ValidateIdWithMessage, SpecIdTargetOpSpecConstantCompositeBad) {
@@ -5338,8 +5403,8 @@ OpFunctionEnd
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpDecorate SpecId decoration target <id> '1' is not a "
-                        "scalar specialization constant."));
+              HasSubstr("OpDecorate SpecId decoration target <id> '1[%1]' is "
+                        "not a scalar specialization constant."));
 }
 
 TEST_F(ValidateIdWithMessage, SpecIdTargetGood) {
@@ -5415,7 +5480,7 @@ TEST_F(ValidateIdWithMessage, TypeFunctionBadUse) {
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Invalid use of function type result id 2."));
+              HasSubstr("Invalid use of function type result id 2[%2]."));
 }
 
 TEST_F(ValidateIdWithMessage, BadTypeId) {
@@ -5433,7 +5498,8 @@ TEST_F(ValidateIdWithMessage, BadTypeId) {
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 4 is not a type id"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 4[\%float_0] is not a type "
+                                               "id"));
 }
 
 TEST_F(ValidateIdWithMessage, VulkanMemoryModelLoadMakePointerVisibleGood) {
@@ -6094,8 +6160,8 @@ OpFunctionEnd
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("ID 7 defined in block 6 does not dominate its use in "
-                        "block 9\n  %9 = OpLabel"));
+              HasSubstr("ID 7[%7] defined in block 6[%6] does not dominate its "
+                        "use in block 9[%9]\n  %9 = OpLabel"));
 }
 
 TEST_F(ValidateIdWithMessage, IdDefInUnreachableBlock2) {
@@ -6120,8 +6186,8 @@ OpFunctionEnd
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("ID 8 defined in block 7 does not dominate its use in "
-                        "block 10\n  %10 = OpLabel"));
+              HasSubstr("ID 8[%8] defined in block 7[%7] does not dominate its "
+                        "use in block 10[%10]\n  %10 = OpLabel"));
 }
 
 TEST_F(ValidateIdWithMessage, IdDefInUnreachableBlock3) {
@@ -6146,8 +6212,8 @@ OpFunctionEnd
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("ID 8 defined in block 7 does not dominate its use in "
-                        "block 10\n  %10 = OpLabel"));
+              HasSubstr("ID 8[%8] defined in block 7[%7] does not dominate its "
+                        "use in block 10[%10]\n  %10 = OpLabel"));
 }
 
 TEST_F(ValidateIdWithMessage, IdDefInUnreachableBlock4) {
@@ -6213,8 +6279,8 @@ OpFunctionEnd
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("ID 9 defined in block 8 does not dominate its use in "
-                        "block 7\n  %7 = OpLabel"));
+              HasSubstr("ID 9[%9] defined in block 8[%8] does not dominate its "
+                        "use in block 7[%7]\n  %7 = OpLabel"));
 }
 
 TEST_F(ValidateIdWithMessage, ReachableDefUnreachableUse) {
@@ -6265,8 +6331,9 @@ TEST_F(ValidateIdWithMessage, UnreachableDefUsedInPhi) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("In OpPhi instruction 14, ID 13 definition does not dominate "
-                "its parent 7\n  %14 = OpPhi %float %11 %10 %13 %7"));
+      HasSubstr("In OpPhi instruction 14[%14], ID 13[%13] definition does not "
+                "dominate its parent 7[%7]\n  %14 = OpPhi %float %11 %10 %13 "
+                "%7"));
 }
 }  // namespace
 }  // namespace val

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -205,7 +205,7 @@ TEST_F(ValidateIdWithMessage, OpMemberNameTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpMemberName Type <id> '1[\%uint]' is not a struct type."));
+      HasSubstr("OpMemberName Type <id> '1[%uint]' is not a struct type."));
 }
 TEST_F(ValidateIdWithMessage, OpMemberNameMemberBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -216,8 +216,8 @@ TEST_F(ValidateIdWithMessage, OpMemberNameMemberBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpMemberName Member <id> '1[\%_struct_1]' index is larger "
-                "than Type <id> '1[\%_struct_1]'s member count."));
+      HasSubstr("OpMemberName Member <id> '1[%_struct_1]' index is larger "
+                "than Type <id> '1[%_struct_1]'s member count."));
 }
 
 TEST_F(ValidateIdWithMessage, OpLineGood) {
@@ -239,7 +239,7 @@ TEST_F(ValidateIdWithMessage, OpLineFileBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpLine Target <id> '1[\%uint]' is not an OpString."));
+              HasSubstr("OpLine Target <id> '1[%uint]' is not an OpString."));
 }
 
 TEST_F(ValidateIdWithMessage, OpDecorateGood) {
@@ -276,7 +276,7 @@ TEST_F(ValidateIdWithMessage, OpMemberDecorateBad) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpMemberDecorate Structure type <id> '1[\%uint]' is not a struct type."));
+          "OpMemberDecorate Structure type <id> '1[%uint]' is not a struct type."));
 }
 TEST_F(ValidateIdWithMessage, OpMemberDecorateMemberBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -287,7 +287,7 @@ TEST_F(ValidateIdWithMessage, OpMemberDecorateMemberBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Index 3 provided in OpMemberDecorate for struct <id> "
-                        "1[\%_struct_1] is out of bounds. The structure has 2 "
+                        "1[%_struct_1] is out of bounds. The structure has 2 "
                         "members. Largest valid index is 1."));
 }
 
@@ -366,7 +366,7 @@ TEST_F(ValidateIdWithMessage, OpGroupMemberDecorateIdNotStructBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpGroupMemberDecorate Structure type <id> '2[\%uint]' "
+              HasSubstr("OpGroupMemberDecorate Structure type <id> '2[%uint]' "
                         "is not a struct type."));
 }
 TEST_F(ValidateIdWithMessage, OpGroupMemberDecorateIndexOutOfBoundBad) {
@@ -381,7 +381,7 @@ TEST_F(ValidateIdWithMessage, OpGroupMemberDecorateIndexOutOfBoundBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Index 3 provided in OpGroupMemberDecorate for struct "
-                        "<id> 2[\%_struct_2] is out of bounds. The structure "
+                        "<id> 2[%_struct_2] is out of bounds. The structure "
                         "has 3 members. Largest valid index is 2."));
 }
 
@@ -408,7 +408,7 @@ TEST_F(ValidateIdWithMessage, OpEntryPointFunctionBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpEntryPoint Entry Point <id> '1[\%void]' is not a "
+      HasSubstr("OpEntryPoint Entry Point <id> '1[%void]' is not a "
                 "function."));
 }
 TEST_F(ValidateIdWithMessage, OpEntryPointParameterCountBad) {
@@ -588,7 +588,7 @@ TEST_F(ValidateIdWithMessage, OpTypeVectorComponentTypeBad) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("OpTypeVector Component Type <id> "
-                "'2[\%_ptr_UniformConstant_float]' is not a scalar type."));
+                "'2[%_ptr_UniformConstant_float]' is not a scalar type."));
 }
 
 TEST_F(ValidateIdWithMessage, OpTypeVectorColumnCountLessThanTwoBad) {
@@ -744,7 +744,7 @@ TEST_F(ValidateIdWithMessage, OpTypeArrayElementTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpTypeArray Element Type <id> '2[\%uint_1]' is not a "
+              HasSubstr("OpTypeArray Element Type <id> '2[%uint_1]' is not a "
                         "type."));
 }
 
@@ -823,12 +823,12 @@ TEST_P(OpTypeArrayLengthTest, LengthZero) {
   EXPECT_EQ(
       SPV_ERROR_INVALID_ID,
       Val(CompileSuccessfully(MakeArrayLength("0", kSigned, width)),
-          "OpTypeArray Length <id> '2\\[\%.*\\]' default value must be at "
+          "OpTypeArray Length <id> '2\\[%.*\\]' default value must be at "
           "least 1."));
   EXPECT_EQ(
       SPV_ERROR_INVALID_ID,
       Val(CompileSuccessfully(MakeArrayLength("0", kUnsigned, width)),
-          "OpTypeArray Length <id> '2\\[\%.*\\]' default value must be at "
+          "OpTypeArray Length <id> '2\\[%.*\\]' default value must be at "
           "least 1."));
 }
 
@@ -837,23 +837,23 @@ TEST_P(OpTypeArrayLengthTest, LengthNegative) {
   EXPECT_EQ(
       SPV_ERROR_INVALID_ID,
       Val(CompileSuccessfully(MakeArrayLength("-1", kSigned, width)),
-          "OpTypeArray Length <id> '2\\[\%.*\\]' default value must be at "
+          "OpTypeArray Length <id> '2\\[%.*\\]' default value must be at "
           "least 1."));
   EXPECT_EQ(
       SPV_ERROR_INVALID_ID,
       Val(CompileSuccessfully(MakeArrayLength("-2", kSigned, width)),
-          "OpTypeArray Length <id> '2\\[\%.*\\]' default value must be at "
+          "OpTypeArray Length <id> '2\\[%.*\\]' default value must be at "
           "least 1."));
   EXPECT_EQ(
       SPV_ERROR_INVALID_ID,
       Val(CompileSuccessfully(MakeArrayLength("-123", kSigned, width)),
-          "OpTypeArray Length <id> '2\\[\%.*\\]' default value must be at "
+          "OpTypeArray Length <id> '2\\[%.*\\]' default value must be at "
           "least 1."));
   const std::string neg_max = "0x8" + std::string(width / 4 - 1, '0');
   EXPECT_EQ(
       SPV_ERROR_INVALID_ID,
       Val(CompileSuccessfully(MakeArrayLength(neg_max, kSigned, width)),
-          "OpTypeArray Length <id> '2\\[\%.*\\]' default value must be at "
+          "OpTypeArray Length <id> '2\\[%.*\\]' default value must be at "
           "least 1."));
 }
 
@@ -914,7 +914,7 @@ TEST_F(ValidateIdWithMessage, OpTypeRuntimeArrayBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpTypeRuntimeArray Element Type <id> '2[\%uint_0]' is not a "
+      HasSubstr("OpTypeRuntimeArray Element Type <id> '2[%uint_0]' is not a "
                 "type."));
 }
 // TODO: Object of this type can only be created with OpVariable using the
@@ -938,7 +938,7 @@ TEST_F(ValidateIdWithMessage, OpTypeStructMemberTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpTypeStruct Member Type <id> '3[\%double_0]' is not "
+              HasSubstr("OpTypeStruct Member Type <id> '3[%double_0]' is not "
                         "a type."));
 }
 
@@ -957,7 +957,7 @@ TEST_F(ValidateIdWithMessage, OpTypePointerBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpTypePointer Type <id> '2[\%uint_0]' is not a "
+              HasSubstr("OpTypePointer Type <id> '2[%uint_0]' is not a "
                         "type."));
 }
 
@@ -976,7 +976,7 @@ TEST_F(ValidateIdWithMessage, OpTypeFunctionReturnTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpTypeFunction Return Type <id> '2[\%uint_0]' is not "
+              HasSubstr("OpTypeFunction Return Type <id> '2[%uint_0]' is not "
                         "a type."));
 }
 TEST_F(ValidateIdWithMessage, OpTypeFunctionParameterBad) {
@@ -989,7 +989,7 @@ TEST_F(ValidateIdWithMessage, OpTypeFunctionParameterBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpTypeFunction Parameter Type <id> '3[\%uint_0]' is not a "
+      HasSubstr("OpTypeFunction Parameter Type <id> '3[%uint_0]' is not a "
                 "type."));
 }
 
@@ -1001,7 +1001,7 @@ TEST_F(ValidateIdWithMessage, OpTypeFunctionParameterTypeVoidBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpTypeFunction Parameter Type <id> '1[\%void]' cannot "
+              HasSubstr("OpTypeFunction Parameter Type <id> '1[%void]' cannot "
                         "be OpTypeVoid."));
 }
 
@@ -1029,7 +1029,7 @@ TEST_F(ValidateIdWithMessage, OpConstantTrueBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpConstantTrue Result Type <id> '1[\%void]' is not a boolean "
+      HasSubstr("OpConstantTrue Result Type <id> '1[%void]' is not a boolean "
                 "type."));
 }
 
@@ -1048,7 +1048,7 @@ TEST_F(ValidateIdWithMessage, OpConstantFalseBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpConstantFalse Result Type <id> '1[\%void]' is not a boolean "
+      HasSubstr("OpConstantFalse Result Type <id> '1[%void]' is not a boolean "
                 "type."));
 }
 
@@ -1100,7 +1100,7 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeVectorResultTypeBad) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpConstantComposite Result Type <id> '1[\%float]' is not a "
+          "OpConstantComposite Result Type <id> '1[%float]' is not a "
           "composite type."));
 }
 TEST_F(ValidateIdWithMessage, OpConstantCompositeVectorConstituentTypeBad) {
@@ -1115,8 +1115,8 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeVectorConstituentTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpConstantComposite Constituent <id> '5[\%uint_42]'s type "
-                "does not match Result Type <id> '2[\%v4float]'s vector "
+      HasSubstr("OpConstantComposite Constituent <id> '5[%uint_42]'s type "
+                "does not match Result Type <id> '2[%v4float]'s vector "
                 "element type."));
 }
 TEST_F(ValidateIdWithMessage,
@@ -1133,7 +1133,7 @@ TEST_F(ValidateIdWithMessage,
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("OpConstantComposite Constituent <id> '5[%5]'s type does not "
-                "match Result Type <id> '2[\%v4float]'s vector element type."));
+                "match Result Type <id> '2[%v4float]'s vector element type."));
 }
 TEST_F(ValidateIdWithMessage, OpConstantCompositeMatrixGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -1183,7 +1183,7 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeMatrixConstituentTypeBad) {
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpConstantComposite Constituent <id> '10[%10]' vector "
                         "component count does not match Result Type <id> "
-                        "'4[\%mat4v4float]'s vector component count."));
+                        "'4[%mat4v4float]'s vector component count."));
 }
 TEST_F(ValidateIdWithMessage,
        OpConstantCompositeMatrixConstituentUndefTypeBad) {
@@ -1204,7 +1204,7 @@ TEST_F(ValidateIdWithMessage,
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpConstantComposite Constituent <id> '10[%10]' vector "
                         "component count does not match Result Type <id> "
-                        "'4[\%mat4v4float]'s vector component count."));
+                        "'4[%mat4v4float]'s vector component count."));
 }
 TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -1225,6 +1225,7 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayWithUndefGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
+
 TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstConstituentTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
@@ -1233,7 +1234,7 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstConstituentTypeBad) {
 %4 = OpConstantComposite %3 %2 %2 %2 %1)";  // Uses a type as operand
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 1[\%uint] cannot be a "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 1[%uint] cannot be a "
                                                "type"));
 }
 TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstConstituentBad) {
@@ -1262,8 +1263,8 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstituentTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpConstantComposite Constituent <id> "
-                        "'5[\%float_3_1400001]'s type does not match Result "
-                        "Type <id> '3[\%_arr_uint_uint_4]'s array element "
+                        "'5[%float_3_1400001]'s type does not match Result "
+                        "Type <id> '3[%_arr_uint_uint_4]'s array element "
                         "type."));
 }
 TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstituentUndefTypeBad) {
@@ -1279,7 +1280,7 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstituentUndefTypeBad) {
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpConstantComposite Constituent <id> "
                         "'5[%5]'s type does not match Result "
-                        "Type <id> '3[\%_arr_uint_uint_4]'s array element "
+                        "Type <id> '3[%_arr_uint_uint_4]'s array element "
                         "type."));
 }
 TEST_F(ValidateIdWithMessage, OpConstantCompositeStructGood) {
@@ -1316,8 +1317,8 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeStructMemberTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpConstantComposite Constituent <id> "
-                        "'5[\%ulong_4300000000]' type does not match the "
-                        "Result Type <id> '3[\%_struct_3]'s member type."));
+                        "'5[%ulong_4300000000]' type does not match the "
+                        "Result Type <id> '3[%_struct_3]'s member type."));
 }
 
 TEST_F(ValidateIdWithMessage, OpConstantCompositeStructMemberUndefTypeBad) {
@@ -1332,7 +1333,7 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeStructMemberUndefTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpConstantComposite Constituent <id> '5[%5]' type "
-                        "does not match the Result Type <id> '3[\%_struct_3]'s "
+                        "does not match the Result Type <id> '3[%_struct_3]'s "
                         "member type."));
 }
 
@@ -1353,7 +1354,7 @@ TEST_F(ValidateIdWithMessage, OpConstantSamplerResultTypeBad) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpConstantSampler Result Type <id> '1[\%float]' is not a sampler "
+          "OpConstantSampler Result Type <id> '1[%float]' is not a sampler "
           "type."));
 }
 
@@ -1402,7 +1403,7 @@ TEST_F(ValidateIdWithMessage, OpConstantNullBasicBad) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpConstantNull Result Type <id> '1[\%void]' cannot have a null "
+          "OpConstantNull Result Type <id> '1[%void]' cannot have a null "
           "value."));
 }
 
@@ -1418,7 +1419,7 @@ TEST_F(ValidateIdWithMessage, OpConstantNullArrayBad) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpConstantNull Result Type <id> '4[\%_arr_2_uint_4]' cannot have a "
+          "OpConstantNull Result Type <id> '4[%_arr_2_uint_4]' cannot have a "
           "null value."));
 }
 
@@ -1432,7 +1433,7 @@ TEST_F(ValidateIdWithMessage, OpConstantNullStructBad) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpConstantNull Result Type <id> '2[\%_struct_2]' cannot have a null value."));
+          "OpConstantNull Result Type <id> '2[%_struct_2]' cannot have a null value."));
 }
 
 TEST_F(ValidateIdWithMessage, OpConstantNullRuntimeArrayBad) {
@@ -1445,7 +1446,7 @@ TEST_F(ValidateIdWithMessage, OpConstantNullRuntimeArrayBad) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpConstantNull Result Type <id> '2[\%_runtimearr_bool]' cannot have "
+          "OpConstantNull Result Type <id> '2[%_runtimearr_bool]' cannot have "
           "a null value."));
 }
 
@@ -1553,8 +1554,8 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeVectorConstituentTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpSpecConstantComposite Constituent <id> "
-                        "'5[\%uint_42]'s type does not match Result Type <id> "
-                        "'2[\%v4float]'s vector element type."));
+                        "'5[%uint_42]'s type does not match Result Type <id> "
+                        "'2[%v4float]'s vector element type."));
 }
 
 // Invalid: Constituent is not a constant
@@ -1589,7 +1590,7 @@ TEST_F(ValidateIdWithMessage,
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpSpecConstantComposite Constituent <id> '5[%5]'s "
-                        "type does not match Result Type <id> '2[\%v4float]'s "
+                        "type does not match Result Type <id> '2[%v4float]'s "
                         "vector element type."));
 }
 
@@ -1605,7 +1606,7 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeVectorNumComponentsBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpSpecConstantComposite Constituent <id> count does "
-                        "not match Result Type <id> '2[\%v3float]'s vector "
+                        "not match Result Type <id> '2[%v3float]'s vector "
                         "component count."));
 }
 
@@ -1662,7 +1663,7 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeMatrixConstituentTypeBad) {
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpSpecConstantComposite Constituent <id> '10[%10]' "
                         "vector component count does not match Result Type "
-                        "<id> '4[\%mat4v4float]'s vector component count."));
+                        "<id> '4[%mat4v4float]'s vector component count."));
 }
 
 // Invalid: Matrix type expects 4 columns but only 3 specified.
@@ -1682,7 +1683,7 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeMatrixNumColsBad) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("OpSpecConstantComposite Constituent <id> count does "
-                "not match Result Type <id> '3[\%mat4v4float]'s matrix column "
+                "not match Result Type <id> '3[%mat4v4float]'s matrix column "
                 "count."));
 }
 
@@ -1722,7 +1723,7 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeMatrixColTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpSpecConstantComposite Constituent <id> '8[%8]' type "
-                        "does not match Result Type <id> '7[\%mat4v4float]'s "
+                        "does not match Result Type <id> '7[%mat4v4float]'s "
                         "matrix column type."));
 }
 
@@ -1746,7 +1747,7 @@ TEST_F(ValidateIdWithMessage,
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpSpecConstantComposite Constituent <id> '10[%10]' "
                         "vector component count does not match Result Type "
-                        "<id> '4[\%mat4v4float]'s vector component count."));
+                        "<id> '4[%mat4v4float]'s vector component count."));
 }
 
 // Invalid: Matrix in which some columns are Int and some are Float.
@@ -1767,7 +1768,7 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeMatrixColumnTypeBad) {
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpSpecConstantComposite Constituent <id> '8[%8]' "
                         "component type does not match Result Type <id> "
-                        "'5[\%mat2v2float]'s matrix column component type."));
+                        "'5[%mat2v2float]'s matrix column component type."));
 }
 
 // Valid: Array of integers
@@ -1795,7 +1796,7 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeArrayNumComponentsBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpSpecConstantComposite Constituent count does not "
-                        "match Result Type <id> '3[\%_arr_uint_uint_4]'s array "
+                        "match Result Type <id> '3[%_arr_uint_uint_4]'s array "
                         "length."));
 }
 
@@ -1841,7 +1842,7 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeArrayConstituentTypeBad) {
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpSpecConstantComposite Constituent <id> '5[%5]'s "
                         "type does not match Result Type <id> "
-                        "'3[\%_arr_uint_uint_4]'s array element type."));
+                        "'3[%_arr_uint_uint_4]'s array element type."));
 }
 
 // Invalid: Array has a mix of Int and Undef-float.
@@ -1859,7 +1860,7 @@ TEST_F(ValidateIdWithMessage,
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpSpecConstantComposite Constituent <id> '5[%5]'s "
                         "type does not match Result Type <id> "
-                        "'3[\%_arr_uint_2]'s array element type."));
+                        "'3[%_arr_uint_2]'s array element type."));
 }
 
 // Valid: Struct of {Int32,Int32,Int64}.
@@ -1888,8 +1889,8 @@ TEST_F(ValidateIdWithMessage,
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpSpecConstantComposite Constituent <id> "
-                        "'2[\%_struct_2]' count does not match Result Type "
-                        "<id> '2[\%_struct_2]'s struct member count."));
+                        "'2[%_struct_2]' count does not match Result Type "
+                        "<id> '2[%_struct_2]'s struct member count."));
 }
 
 // Valid: Struct uses Undef-int64.
@@ -1937,7 +1938,7 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeStructMemberTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpSpecConstantComposite Constituent <id> '5[%5]' type "
-                        "does not match the Result Type <id> '3[\%_struct_3]'s "
+                        "does not match the Result Type <id> '3[%_struct_3]'s "
                         "member type."));
 }
 
@@ -1954,7 +1955,7 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeStructMemberUndefTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpSpecConstantComposite Constituent <id> '5[%5]' type "
-                        "does not match the Result Type <id> '3[\%_struct_3]'s "
+                        "does not match the Result Type <id> '3[%_struct_3]'s "
                         "member type."));
 }
 
@@ -1997,7 +1998,7 @@ TEST_F(ValidateIdWithMessage, OpVariableResultTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpVariable Result Type <id> '1[\%uint]' is not a pointer "
+      HasSubstr("OpVariable Result Type <id> '1[%uint]' is not a pointer "
                 "type."));
 }
 TEST_F(ValidateIdWithMessage, OpVariableInitializerIsTypeBad) {
@@ -2007,7 +2008,7 @@ TEST_F(ValidateIdWithMessage, OpVariableInitializerIsTypeBad) {
 %3 = OpVariable %2 Input %2)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 2[\%_ptr_Input_uint] "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 2[%_ptr_Input_uint] "
                                                "cannot be a type"));
 }
 
@@ -2423,7 +2424,7 @@ TEST_F(ValidateIdWithMessage, OpLoadResultTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpLoad Result Type <id> "
-                        "'3[\%_ptr_UniformConstant_uint]' does not match "
+                        "'3[%_ptr_UniformConstant_uint]' does not match "
                         "Pointer <id> '5[%5]'s type."));
 }
 
@@ -2506,7 +2507,7 @@ TEST_F(ValidateIdWithMessage, OpStorePointerBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpStore Pointer <id> '7[\%uint_0]' is not a logical "
+              HasSubstr("OpStore Pointer <id> '7[%uint_0]' is not a logical "
                         "pointer."));
 }
 
@@ -2607,7 +2608,7 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpStore Pointer <id> '7[%7]'s type does not match "
-                        "Object <id> '6[\%float_3_1400001]'s type."));
+                        "Object <id> '6[%float_3_1400001]'s type."));
 }
 
 // The next series of test check test a relaxation of the rules for stores to
@@ -3032,7 +3033,7 @@ TEST_F(ValidateIdWithMessage, OpCopyMemoryBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Target <id> '5[%5]'s type does not match "
-                        "Source <id> '2[\%uint]'s type."));
+                        "Source <id> '2[%uint]'s type."));
 }
 
 TEST_F(ValidateIdWithMessage, OpCopyMemoryVoidTarget) {
@@ -3135,7 +3136,7 @@ TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSourceBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Source operand <id> '5[\%uint_4]' is not a pointer."));
+              HasSubstr("Source operand <id> '5[%uint_4]' is not a pointer."));
 }
 TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -3179,7 +3180,7 @@ TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Size operand <id> '9[\%float_1]' must be a scalar integer "
+      HasSubstr("Size operand <id> '9[%float_1]' must be a scalar integer "
                 "type."));
 }
 
@@ -3229,7 +3230,7 @@ OpFunctionEnd
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Size operand <id> '3[\%uint_0]' cannot be a constant "
+              HasSubstr("Size operand <id> '3[%uint_0]' cannot be a constant "
                         "zero."));
 }
 
@@ -3254,7 +3255,7 @@ OpFunctionEnd
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Size operand <id> '3[\%ulong_0]' cannot be a constant "
+              HasSubstr("Size operand <id> '3[%ulong_0]' cannot be a constant "
                         "zero."));
 }
 
@@ -3280,7 +3281,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Size operand <id> '3[\%int_n1]' cannot have the sign bit set "
+      HasSubstr("Size operand <id> '3[%int_n1]' cannot have the sign bit set "
                 "to 1."));
 }
 
@@ -3306,7 +3307,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Size operand <id> '3[\%long_n1]' cannot have the sign bit set "
+      HasSubstr("Size operand <id> '3[%long_n1]' cannot have the sign bit set "
                 "to 1."));
 }
 
@@ -3467,7 +3468,7 @@ OpFunctionEnd
   )";
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 1[\%void] cannot be a "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 1[%void] cannot be a "
                                                "type"));
 }
 
@@ -3486,7 +3487,7 @@ OpFunctionEnd
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
-    "8[\%_ptr_Private_float] cannot be a type"));
+    "8[%_ptr_Private_float] cannot be a type"));
 }
 
 // Invalid: The storage class of Base and Result do not match.
@@ -3789,7 +3790,7 @@ OpFunctionEnd
   )";
   const std::string expected_err = "Index is out of bounds: " + instr +
                                    " can not find index 3 into the structure "
-                                   "<id> '25[\%_struct_25]'. This structure "
+                                   "<id> '25[%_struct_25]'. This structure "
                                    "has 3 members. Largest valid index is 2.";
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
@@ -3936,9 +3937,9 @@ TEST_F(ValidateIdWithMessage, OpFunctionResultTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpFunction Result Type <id> '2[\%uint]' does not "
+              HasSubstr("OpFunction Result Type <id> '2[%uint]' does not "
                         "match the Function Type's return type <id> "
-                        "'1[\%void]'."));
+                        "'1[%void]'."));
 }
 TEST_F(ValidateIdWithMessage, OpReturnValueTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -3953,7 +3954,7 @@ TEST_F(ValidateIdWithMessage, OpReturnValueTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpReturnValue Value <id> '3[\%float_0]'s type does "
+              HasSubstr("OpReturnValue Value <id> '3[%float_0]'s type does "
                         "not match OpFunction's return type."));
 }
 TEST_F(ValidateIdWithMessage, OpFunctionFunctionTypeBad) {
@@ -3968,7 +3969,7 @@ OpFunctionEnd)";
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpFunction Function Type <id> '2[\%uint]' is not a function "
+      HasSubstr("OpFunction Function Type <id> '2[%uint]' is not a function "
                 "type."));
 }
 
@@ -4029,7 +4030,7 @@ TEST_F(ValidateIdWithMessage, OpFunctionParameterResultTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpFunctionParameter Result Type <id> '1[\%void]' does not "
+      HasSubstr("OpFunctionParameter Result Type <id> '1[%void]' does not "
                 "match the OpTypeFunction parameter type of the same index."));
 }
 
@@ -4078,8 +4079,8 @@ TEST_F(ValidateIdWithMessage, OpFunctionCallResultTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpFunctionCall Result Type <id> '1[\%void]'s type "
-                        "does not match Function <id> '2[\%uint]'s return "
+              HasSubstr("OpFunctionCall Result Type <id> '1[%void]'s type "
+                        "does not match Function <id> '2[%uint]'s return "
                         "type."));
 }
 TEST_F(ValidateIdWithMessage, OpFunctionCallFunctionBad) {
@@ -4098,7 +4099,7 @@ TEST_F(ValidateIdWithMessage, OpFunctionCallFunctionBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpFunctionCall Function <id> '5[\%uint_42]' is not a "
+              HasSubstr("OpFunctionCall Function <id> '5[%uint_42]' is not a "
                         "function."));
 }
 TEST_F(ValidateIdWithMessage, OpFunctionCallArgumentTypeBad) {
@@ -4127,8 +4128,8 @@ TEST_F(ValidateIdWithMessage, OpFunctionCallArgumentTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpFunctionCall Argument <id> '7[\%float_3_1400001]'s "
-                        "type does not match Function <id> '2[\%uint]'s "
+              HasSubstr("OpFunctionCall Argument <id> '7[%float_3_1400001]'s "
+                        "type does not match Function <id> '2[%uint]'s "
                         "parameter type."));
 }
 
@@ -4365,7 +4366,7 @@ TEST_F(ValidateIdWithMessage, OpVectorShuffleComponentCount) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("OpVectorShuffle component literals count does not match "
-                "Result Type <id> '2[\%v3uint]'s vector component count."));
+                "Result Type <id> '2[%v3uint]'s vector component count."));
 }
 
 TEST_F(ValidateIdWithMessage, OpVectorShuffleVector1Type) {
@@ -4642,7 +4643,7 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 3[\%true] is not a type "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 3[%true] is not a type "
                                                "id"));
 }
 
@@ -4755,9 +4756,9 @@ OpFunctionEnd
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpPhi's result type <id> 2[\%bool] does not match "
-                        "incoming value <id> 6[\%uint_0] type <id> "
-                        "5[\%uint]."));
+              HasSubstr("OpPhi's result type <id> 2[%bool] does not match "
+                        "incoming value <id> 6[%uint_0] type <id> "
+                        "5[%uint]."));
 }
 
 TEST_F(ValidateIdWithMessage, OpPhiPredecessorNotABlock) {
@@ -4783,7 +4784,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpPhi's incoming basic block <id> 3[\%true] is not an "
+      HasSubstr("OpPhi's incoming basic block <id> 3[%true] is not an "
                 "OpLabel."));
 }
 
@@ -4910,7 +4911,7 @@ OpBranchConditional %bool %target_t %target_f
 
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 3[\%bool] cannot be a "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 3[%bool] cannot be a "
                                                "type"));
 }
 
@@ -4973,7 +4974,7 @@ TEST_F(ValidateIdWithMessage, OpReturnValueIsType) {
      OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 1[\%void] cannot be a "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 1[%void] cannot be a "
                                                "type"));
 }
 
@@ -5008,7 +5009,7 @@ TEST_F(ValidateIdWithMessage, OpReturnValueIsVoid) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpReturnValue value's type <id> '1[\%void]' is missing or "
+      HasSubstr("OpReturnValue value's type <id> '1[%void]' is missing or "
                 "void."));
 }
 
@@ -5046,7 +5047,7 @@ TEST_F(ValidateIdWithMessage, OpReturnValueIsVariableInLogical) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpReturnValue value's type <id> "
-                        "'3[\%_ptr_Function_uint]' is a pointer, which is "
+                        "'3[%_ptr_Function_uint]' is a pointer, which is "
                         "invalid in the Logical addressing model."));
 }
 
@@ -5362,7 +5363,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpDecorate SpecId decoration target <id> "
-                        "'1[\%uint_3]' is not a scalar specialization "
+                        "'1[%uint_3]' is not a scalar specialization "
                         "constant."));
 }
 
@@ -5498,7 +5499,7 @@ TEST_F(ValidateIdWithMessage, BadTypeId) {
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 4[\%float_0] is not a type "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 4[%float_0] is not a type "
                                                "id"));
 }
 

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -273,10 +273,9 @@ TEST_F(ValidateIdWithMessage, OpMemberDecorateBad) {
 %1 = OpTypeInt 32 0)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr(
-          "OpMemberDecorate Structure type <id> '1[%uint]' is not a struct type."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpMemberDecorate Structure type <id> '1[%uint]' is "
+                        "not a struct type."));
 }
 TEST_F(ValidateIdWithMessage, OpMemberDecorateMemberBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -406,10 +405,9 @@ TEST_F(ValidateIdWithMessage, OpEntryPointFunctionBad) {
 %1 = OpTypeVoid)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpEntryPoint Entry Point <id> '1[%void]' is not a "
-                "function."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpEntryPoint Entry Point <id> '1[%void]' is not a "
+                        "function."));
 }
 TEST_F(ValidateIdWithMessage, OpEntryPointParameterCountBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -786,7 +784,8 @@ class OpTypeArrayLengthTest
         spvValidate(ScopedContext().context, &cbinary, &diagnostic_);
     if (status != SPV_SUCCESS) {
       spvDiagnosticPrint(diagnostic_);
-      EXPECT_THAT(std::string(diagnostic_->error), testing::ContainsRegex(expected_err));
+      EXPECT_THAT(std::string(diagnostic_->error), 
+                  testing::ContainsRegex(expected_err));
     }
     return status;
   }
@@ -820,41 +819,35 @@ TEST_P(OpTypeArrayLengthTest, LengthPositive) {
 
 TEST_P(OpTypeArrayLengthTest, LengthZero) {
   const int width = GetParam();
-  EXPECT_EQ(
-      SPV_ERROR_INVALID_ID,
-      Val(CompileSuccessfully(MakeArrayLength("0", kSigned, width)),
-          "OpTypeArray Length <id> '2\\[%.*\\]' default value must be at "
-          "least 1."));
-  EXPECT_EQ(
-      SPV_ERROR_INVALID_ID,
-      Val(CompileSuccessfully(MakeArrayLength("0", kUnsigned, width)),
-          "OpTypeArray Length <id> '2\\[%.*\\]' default value must be at "
-          "least 1."));
+  EXPECT_EQ(SPV_ERROR_INVALID_ID,
+            Val(CompileSuccessfully(MakeArrayLength("0", kSigned, width)),
+                "OpTypeArray Length <id> '2\\[%.*\\]' default value must be at "
+                "least 1."));
+  EXPECT_EQ(SPV_ERROR_INVALID_ID,
+            Val(CompileSuccessfully(MakeArrayLength("0", kUnsigned, width)),
+                "OpTypeArray Length <id> '2\\[%.*\\]' default value must be at "
+                "least 1."));
 }
 
 TEST_P(OpTypeArrayLengthTest, LengthNegative) {
   const int width = GetParam();
-  EXPECT_EQ(
-      SPV_ERROR_INVALID_ID,
-      Val(CompileSuccessfully(MakeArrayLength("-1", kSigned, width)),
-          "OpTypeArray Length <id> '2\\[%.*\\]' default value must be at "
-          "least 1."));
-  EXPECT_EQ(
-      SPV_ERROR_INVALID_ID,
-      Val(CompileSuccessfully(MakeArrayLength("-2", kSigned, width)),
-          "OpTypeArray Length <id> '2\\[%.*\\]' default value must be at "
-          "least 1."));
-  EXPECT_EQ(
-      SPV_ERROR_INVALID_ID,
-      Val(CompileSuccessfully(MakeArrayLength("-123", kSigned, width)),
-          "OpTypeArray Length <id> '2\\[%.*\\]' default value must be at "
-          "least 1."));
+  EXPECT_EQ(SPV_ERROR_INVALID_ID,
+            Val(CompileSuccessfully(MakeArrayLength("-1", kSigned, width)),
+                "OpTypeArray Length <id> '2\\[%.*\\]' default value must be at "
+                "least 1."));
+  EXPECT_EQ(SPV_ERROR_INVALID_ID,
+            Val(CompileSuccessfully(MakeArrayLength("-2", kSigned, width)),
+                "OpTypeArray Length <id> '2\\[%.*\\]' default value must be at "
+                "least 1."));
+  EXPECT_EQ(SPV_ERROR_INVALID_ID,
+            Val(CompileSuccessfully(MakeArrayLength("-123", kSigned, width)),
+                "OpTypeArray Length <id> '2\\[%.*\\]' default value must be at "
+                "least 1."));
   const std::string neg_max = "0x8" + std::string(width / 4 - 1, '0');
-  EXPECT_EQ(
-      SPV_ERROR_INVALID_ID,
-      Val(CompileSuccessfully(MakeArrayLength(neg_max, kSigned, width)),
-          "OpTypeArray Length <id> '2\\[%.*\\]' default value must be at "
-          "least 1."));
+  EXPECT_EQ(SPV_ERROR_INVALID_ID,
+            Val(CompileSuccessfully(MakeArrayLength(neg_max, kSigned, width)),
+                "OpTypeArray Length <id> '2\\[%.*\\]' default value must be at "
+                "least 1."));
 }
 
 // The only valid widths for integers are 8, 16, 32, and 64.
@@ -1099,9 +1092,8 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeVectorResultTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr(
-          "OpConstantComposite Result Type <id> '1[%float]' is not a "
-          "composite type."));
+      HasSubstr("OpConstantComposite Result Type <id> '1[%float]' is not a "
+                "composite type."));
 }
 TEST_F(ValidateIdWithMessage, OpConstantCompositeVectorConstituentTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -1402,9 +1394,8 @@ TEST_F(ValidateIdWithMessage, OpConstantNullBasicBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr(
-          "OpConstantNull Result Type <id> '1[%void]' cannot have a null "
-          "value."));
+      HasSubstr("OpConstantNull Result Type <id> '1[%void]' cannot have a null "
+                "value."));
 }
 
 TEST_F(ValidateIdWithMessage, OpConstantNullArrayBad) {
@@ -1430,10 +1421,9 @@ TEST_F(ValidateIdWithMessage, OpConstantNullStructBad) {
 %4 = OpConstantNull %3)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr(
-          "OpConstantNull Result Type <id> '2[%_struct_2]' cannot have a null value."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpConstantNull Result Type <id> '2[%_struct_2]' "
+                        "cannot have a null value."));
 }
 
 TEST_F(ValidateIdWithMessage, OpConstantNullRuntimeArrayBad) {
@@ -3486,8 +3476,8 @@ OpFunctionEnd
   )";
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand "
-    "8[%_ptr_Private_float] cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand 8[%_ptr_Private_float] cannot be a type"));
 }
 
 // Invalid: The storage class of Base and Result do not match.
@@ -4782,10 +4772,9 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpPhi's incoming basic block <id> 3[%true] is not an "
-                "OpLabel."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpPhi's incoming basic block <id> 3[%true] is not an "
+                        "OpLabel."));
 }
 
 TEST_F(ValidateIdWithMessage, OpPhiNotAPredecessor) {
@@ -4989,10 +4978,9 @@ TEST_F(ValidateIdWithMessage, OpReturnValueIsLabel) {
      OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpReturnValue Value <id> '5[%5]' does not represent a "
-                "value."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpReturnValue Value <id> '5[%5]' does not represent a "
+                        "value."));
 }
 
 TEST_F(ValidateIdWithMessage, OpReturnValueIsVoid) {

--- a/test/val/val_image_test.cpp
+++ b/test/val/val_image_test.cpp
@@ -672,7 +672,8 @@ TEST_F(ValidateImage, ImageTexelPointerImageNotResultTypePointer) {
 
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 136 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 136[%136] cannot be a "
+                                               "type"));
 }
 
 TEST_F(ValidateImage, ImageTexelPointerImageNotImage) {

--- a/test/val/val_limits_test.cpp
+++ b/test/val/val_limits_test.cpp
@@ -353,7 +353,7 @@ TEST_F(ValidateLimits, OpTypeFunctionBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpTypeFunction may not take more than 255 arguments. "
-                        "OpTypeFunction <id> '2' has 256 arguments."));
+                        "OpTypeFunction <id> '2[%2]' has 256 arguments."));
 }
 
 // Valid: OpTypeFunction with 100 arguments (Custom limit: 100)
@@ -389,7 +389,7 @@ TEST_F(ValidateLimits, CustomizedOpTypeFunctionBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpTypeFunction may not take more than 100 arguments. "
-                        "OpTypeFunction <id> '2' has 101 arguments."));
+                        "OpTypeFunction <id> '2[%2]' has 101 arguments."));
 }
 
 // Valid: module has 65,535 global variables.

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -442,9 +442,8 @@ OpFunctionEnd
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpVariable, <id> '5', has a disallowed initializer & storage class "
-          "combination.\n"
-          "From WebGPU execution environment spec:\n"
+          "OpVariable, <id> '5[%5]', has a disallowed initializer & storage "
+          "class combination.\nFrom WebGPU execution environment spec:\n"
           "Variable declarations that include initializers must have one of "
           "the following storage classes: Output, Private, or Function\n"
           "  %5 = OpVariable %_ptr_Uniform_float Uniform %float_1\n"));
@@ -535,9 +534,8 @@ OpFunctionEnd
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpVariable, <id> '5', has a disallowed initializer & storage class "
-          "combination.\n"
-          "From Vulkan spec, Appendix A:\n"
+          "OpVariable, <id> '5[%5]', has a disallowed initializer & storage "
+          "class combination.\nFrom Vulkan spec, Appendix A:\n"
           "Variable declarations that include initializers must have one of "
           "the following storage classes: Output, Private, or Function\n  "
           "%5 = OpVariable %_ptr_Input_float Input %float_1\n"));
@@ -620,8 +618,9 @@ TEST_F(ValidateMemory, ArrayLenResultNotIntType) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "The Result Type of OpArrayLength <id> '10' must be OpTypeInt with "
-          "width 32 and signedness 0.\n  %10 = OpArrayLength %float %9 0\n"));
+          "The Result Type of OpArrayLength <id> '10[%10]' must be OpTypeInt "
+          "with width 32 and signedness 0.\n  %10 = OpArrayLength %float %9 "
+          "0\n"));
 }
 
 TEST_F(ValidateMemory, ArrayLenResultNot32bits) {
@@ -652,8 +651,9 @@ TEST_F(ValidateMemory, ArrayLenResultNot32bits) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "The Result Type of OpArrayLength <id> '11' must be OpTypeInt with "
-          "width 32 and signedness 0.\n  %11 = OpArrayLength %ushort %10 0\n"));
+          "The Result Type of OpArrayLength <id> '11[%11]' must be OpTypeInt "
+          "with width 32 and signedness 0.\n  %11 = OpArrayLength %ushort %10 "
+          "0\n"));
 }
 
 TEST_F(ValidateMemory, ArrayLenResultSigned) {
@@ -683,8 +683,9 @@ TEST_F(ValidateMemory, ArrayLenResultSigned) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "The Result Type of OpArrayLength <id> '11' must be OpTypeInt with "
-          "width 32 and signedness 0.\n  %11 = OpArrayLength %int %10 0\n"));
+          "The Result Type of OpArrayLength <id> '11[%11]' must be OpTypeInt "
+          "with width 32 and signedness 0.\n  %11 = OpArrayLength %int %10 "
+          "0\n"));
 }
 
 TEST_F(ValidateMemory, ArrayLenInputNotStruct) {
@@ -712,8 +713,8 @@ TEST_F(ValidateMemory, ArrayLenInputNotStruct) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("The Struture's type in OpArrayLength <id> '11' must "
-                        "be a pointer to an OpTypeStruct."));
+              HasSubstr("The Struture's type in OpArrayLength <id> '11[%11]' "
+                        "must be a pointer to an OpTypeStruct."));
 }
 
 TEST_F(ValidateMemory, ArrayLenInputLastMemberNoRTA) {
@@ -742,8 +743,9 @@ TEST_F(ValidateMemory, ArrayLenInputLastMemberNoRTA) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("The Struture's last member in OpArrayLength <id> '11' must be "
-                "an OpTypeRuntimeArray.\n  %11 = OpArrayLength %uint %10 0\n"));
+      HasSubstr("The Struture's last member in OpArrayLength <id> '11[%11]' "
+                "must be an OpTypeRuntimeArray.\n  %11 = OpArrayLength %uint "
+                "%10 0\n"));
 }
 
 TEST_F(ValidateMemory, ArrayLenInputLastMemberNoRTA2) {
@@ -772,8 +774,9 @@ TEST_F(ValidateMemory, ArrayLenInputLastMemberNoRTA2) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("The Struture's last member in OpArrayLength <id> '11' must be "
-                "an OpTypeRuntimeArray.\n  %11 = OpArrayLength %uint %10 1\n"));
+      HasSubstr("The Struture's last member in OpArrayLength <id> '11[%11]' "
+                "must be an OpTypeRuntimeArray.\n  %11 = OpArrayLength %uint "
+                "%10 1\n"));
 }
 
 TEST_F(ValidateMemory, ArrayLenIndexNotLastMember) {
@@ -803,8 +806,8 @@ TEST_F(ValidateMemory, ArrayLenIndexNotLastMember) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "The array member in OpArrayLength <id> '11' must be an the last "
-          "member of the struct.\n  %11 = OpArrayLength %uint %10 0\n"));
+          "The array member in OpArrayLength <id> '11[%11]' must be an the "
+          "last member of the struct.\n  %11 = OpArrayLength %uint %10 0\n"));
 }
 
 TEST_F(ValidateMemory, ArrayLenIndexNotPointerToStruct) {
@@ -835,8 +838,8 @@ TEST_F(ValidateMemory, ArrayLenIndexNotPointerToStruct) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "The Struture's type in OpArrayLength <id> '12' must be a pointer to "
-          "an OpTypeStruct.\n  %12 = OpArrayLength %uint %11 0\n"));
+          "The Struture's type in OpArrayLength <id> '12[%12]' must be a "
+          "pointer to an OpTypeStruct.\n  %12 = OpArrayLength %uint %11 0\n"));
 }
 
 TEST_F(ValidateMemory, ArrayLenPointerIsAType) {
@@ -859,7 +862,8 @@ TEST_F(ValidateMemory, ArrayLenPointerIsAType) {
 
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 4 cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 4[\%float] cannot be a "
+                                               "type"));
 }
 
 TEST_F(ValidateMemory, PushConstantNotStructGood) {
@@ -905,8 +909,8 @@ TEST_F(ValidateMemory, VulkanPushConstantNotStructBad) {
   CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_1);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_1));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("PushConstant OpVariable <id> '6' has illegal type.\n"
-                        "From Vulkan spec, section 14.5.1:\n"
+              HasSubstr("PushConstant OpVariable <id> '6[%6]' has illegal "
+                        "type.\nFrom Vulkan spec, section 14.5.1:\n"
                         "Such variables must be typed as OpTypeStruct, "
                         "or an array of this type"));
 }

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -862,7 +862,7 @@ TEST_F(ValidateMemory, ArrayLenPointerIsAType) {
 
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 4[\%float] cannot be a "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 4[%float] cannot be a "
                                                "type"));
 }
 

--- a/test/val/val_ssa_test.cpp
+++ b/test/val/val_ssa_test.cpp
@@ -118,7 +118,7 @@ TEST_F(ValidateSSA, DominateUsageWithinBlockBad) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("ID .\\[bad\\] has not been defined\n"
+              MatchesRegex("ID .\\[\%bad\\] has not been defined\n"
                            "  %8 = OpIAdd %uint %uint_1 %bad\n"));
 }
 
@@ -141,7 +141,7 @@ TEST_F(ValidateSSA, DominateUsageSameInstructionBad) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("ID .\\[sum\\] has not been defined\n"
+              MatchesRegex("ID .\\[\%sum\\] has not been defined\n"
                            "  %sum = OpIAdd %uint %uint_1 %sum\n"));
 }
 
@@ -202,7 +202,8 @@ TEST_F(ValidateSSA, ForwardMemberNameMissingTargetBad) {
 )";
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("size"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("The following forward "
+            "referenced IDs have not been defined:\n2[%2]"));
 }
 
 TEST_F(ValidateSSA, ForwardDecorateGood) {
@@ -1124,8 +1125,8 @@ TEST_F(ValidateSSA, IdDoesNotDominateItsUseBad) {
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      MatchesRegex("ID .\\[eleven\\] defined in block .\\[true_block\\] does "
-                   "not dominate its use in block .\\[false_block\\]\n"
+      MatchesRegex("ID .\\[\%eleven\\] defined in block .\\[\%true_block\\] "
+                   "does not dominate its use in block .\\[\%false_block\\]\n"
                    "  %false_block = OpLabel\n"));
 }
 
@@ -1185,7 +1186,7 @@ TEST_F(ValidateSSA,
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("ID .\\[inew\\] has not been defined\n"
+              MatchesRegex("ID .\\[\%inew\\] has not been defined\n"
                            "  %19 = OpIAdd %uint %inew %uint_1\n"));
 }
 
@@ -1268,8 +1269,8 @@ TEST_F(ValidateSSA, PhiVariableDefNotDominatedByParentBlockBad) {
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      MatchesRegex("In OpPhi instruction .\\[phi\\], ID .\\[true_copy\\] "
-                   "definition does not dominate its parent .\\[if_false\\]\n"
+      MatchesRegex("In OpPhi instruction .\\[\%phi\\], ID .\\[\%true_copy\\] "
+                   "definition does not dominate its parent .\\[\%if_false\\]\n"
                    "  %phi = OpPhi %bool %true_copy %if_false %false_copy "
                    "%if_true\n"));
 }
@@ -1396,8 +1397,8 @@ TEST_F(ValidateSSA, UseFunctionParameterFromOtherFunctionBad) {
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      MatchesRegex("ID .\\[first\\] used in function .\\[func2\\] is used "
-                   "outside of it's defining function .\\[func\\]\n"
+      MatchesRegex("ID .\\[\%first\\] used in function .\\[\%func2\\] is used "
+                   "outside of it's defining function .\\[\%func\\]\n"
                    "  %func = OpFunction %void None %14\n"));
 }
 

--- a/test/val/val_ssa_test.cpp
+++ b/test/val/val_ssa_test.cpp
@@ -118,7 +118,7 @@ TEST_F(ValidateSSA, DominateUsageWithinBlockBad) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("ID .\\[\%bad\\] has not been defined\n"
+              MatchesRegex("ID .\\[%bad\\] has not been defined\n"
                            "  %8 = OpIAdd %uint %uint_1 %bad\n"));
 }
 
@@ -141,7 +141,7 @@ TEST_F(ValidateSSA, DominateUsageSameInstructionBad) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("ID .\\[\%sum\\] has not been defined\n"
+              MatchesRegex("ID .\\[%sum\\] has not been defined\n"
                            "  %sum = OpIAdd %uint %uint_1 %sum\n"));
 }
 
@@ -1125,8 +1125,8 @@ TEST_F(ValidateSSA, IdDoesNotDominateItsUseBad) {
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      MatchesRegex("ID .\\[\%eleven\\] defined in block .\\[\%true_block\\] "
-                   "does not dominate its use in block .\\[\%false_block\\]\n"
+      MatchesRegex("ID .\\[%eleven\\] defined in block .\\[%true_block\\] "
+                   "does not dominate its use in block .\\[%false_block\\]\n"
                    "  %false_block = OpLabel\n"));
 }
 
@@ -1186,7 +1186,7 @@ TEST_F(ValidateSSA,
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("ID .\\[\%inew\\] has not been defined\n"
+              MatchesRegex("ID .\\[%inew\\] has not been defined\n"
                            "  %19 = OpIAdd %uint %inew %uint_1\n"));
 }
 
@@ -1269,8 +1269,8 @@ TEST_F(ValidateSSA, PhiVariableDefNotDominatedByParentBlockBad) {
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      MatchesRegex("In OpPhi instruction .\\[\%phi\\], ID .\\[\%true_copy\\] "
-                   "definition does not dominate its parent .\\[\%if_false\\]\n"
+      MatchesRegex("In OpPhi instruction .\\[%phi\\], ID .\\[%true_copy\\] "
+                   "definition does not dominate its parent .\\[%if_false\\]\n"
                    "  %phi = OpPhi %bool %true_copy %if_false %false_copy "
                    "%if_true\n"));
 }
@@ -1397,8 +1397,8 @@ TEST_F(ValidateSSA, UseFunctionParameterFromOtherFunctionBad) {
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      MatchesRegex("ID .\\[\%first\\] used in function .\\[\%func2\\] is used "
-                   "outside of it's defining function .\\[\%func\\]\n"
+      MatchesRegex("ID .\\[%first\\] used in function .\\[%func2\\] is used "
+                   "outside of it's defining function .\\[%func\\]\n"
                    "  %func = OpFunction %void None %14\n"));
 }
 

--- a/test/val/val_ssa_test.cpp
+++ b/test/val/val_ssa_test.cpp
@@ -202,8 +202,9 @@ TEST_F(ValidateSSA, ForwardMemberNameMissingTargetBad) {
 )";
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("The following forward "
-            "referenced IDs have not been defined:\n2[%2]"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("The following forward referenced IDs have not been "
+                        "defined:\n2[%2]"));
 }
 
 TEST_F(ValidateSSA, ForwardDecorateGood) {


### PR DESCRIPTION
This CL changes the id/name output from the validator to always use a
consistent id[%name] style. This removes the need for getIdOrName. The
name lookup is changed to use the NameMapper so the output is consistent
with what the disassembler will produce.

Fixes #2137