### PR TITLE
Loosen binding and descriptor check

### DIFF
--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -798,7 +798,9 @@ spv_result_t CheckDecorationsOfBuffers(ValidationState_t& vstate) {
       // UniformConstant which cannot be a struct.
       if (spvIsVulkanEnv(vstate.context()->target_env)) {
         if (uniform_constant) {
-          if (!hasDecoration(var_id, SpvDecorationDescriptorSet, vstate)) {
+          auto entry_points = vstate.EntryPointReferences(var_id);
+          if (!entry_points.empty() &&
+              !hasDecoration(var_id, SpvDecorationDescriptorSet, vstate)) {
             return vstate.diag(SPV_ERROR_INVALID_ID, vstate.FindDef(var_id))
                    << "UniformConstant id '" << var_id
                    << "' is missing DescriptorSet decoration.\n"
@@ -806,7 +808,8 @@ spv_result_t CheckDecorationsOfBuffers(ValidationState_t& vstate) {
                    << "These variables must have DescriptorSet and Binding "
                       "decorations specified";
           }
-          if (!hasDecoration(var_id, SpvDecorationBinding, vstate)) {
+          if (!entry_points.empty() &&
+              !hasDecoration(var_id, SpvDecorationBinding, vstate)) {
             return vstate.diag(SPV_ERROR_INVALID_ID, vstate.FindDef(var_id))
                    << "UniformConstant id '" << var_id
                    << "' is missing Binding decoration.\n"
@@ -843,7 +846,9 @@ spv_result_t CheckDecorationsOfBuffers(ValidationState_t& vstate) {
           // Vulkan 14.5.2: Check DescriptorSet and Binding decoration for
           // Uniform and StorageBuffer variables.
           if (uniform || storage_buffer) {
-            if (!hasDecoration(var_id, SpvDecorationDescriptorSet, vstate)) {
+            auto entry_points = vstate.EntryPointReferences(var_id);
+            if (!entry_points.empty() &&
+                !hasDecoration(var_id, SpvDecorationDescriptorSet, vstate)) {
               return vstate.diag(SPV_ERROR_INVALID_ID, vstate.FindDef(var_id))
                      << sc_str << " id '" << var_id
                      << "' is missing DescriptorSet decoration.\n"
@@ -851,7 +856,8 @@ spv_result_t CheckDecorationsOfBuffers(ValidationState_t& vstate) {
                      << "These variables must have DescriptorSet and Binding "
                         "decorations specified";
             }
-            if (!hasDecoration(var_id, SpvDecorationBinding, vstate)) {
+            if (!entry_points.empty() &&
+                !hasDecoration(var_id, SpvDecorationBinding, vstate)) {
               return vstate.diag(SPV_ERROR_INVALID_ID, vstate.FindDef(var_id))
                      << sc_str << " id '" << var_id
                      << "' is missing Binding decoration.\n"

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -930,9 +930,9 @@ const std::vector<uint32_t>& ValidationState_t::FunctionEntryPoints(
 }
 
 std::set<uint32_t> ValidationState_t::EntryPointReferences(uint32_t id) const {
-  std::set<uint32_t> entry_points;
+  std::set<uint32_t> referenced_entry_points;
   const auto inst = FindDef(id);
-  if (!inst) return entry_points;
+  if (!inst) return referenced_entry_points;
 
   std::vector<const Instruction*> stack;
   stack.push_back(inst);
@@ -943,8 +943,8 @@ std::set<uint32_t> ValidationState_t::EntryPointReferences(uint32_t id) const {
     if (const auto func = current_inst->function()) {
       // Instruction lives in a function, we can stop searching.
       const auto function_entry_points = FunctionEntryPoints(func->id());
-      entry_points.insert(function_entry_points.begin(),
-                          function_entry_points.end());
+      referenced_entry_points.insert(function_entry_points.begin(),
+                                     function_entry_points.end());
     } else {
       // Instruction is in the global scope, keep searching its uses.
       for (auto pair : current_inst->uses()) {
@@ -954,7 +954,7 @@ std::set<uint32_t> ValidationState_t::EntryPointReferences(uint32_t id) const {
     }
   }
 
-  return entry_points;
+  return referenced_entry_points;
 }
 
 std::string ValidationState_t::Disassemble(const Instruction& inst) const {

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -264,6 +264,11 @@ class ValidationState_t {
   /// Returns all the entry points that can call |func|.
   const std::vector<uint32_t>& FunctionEntryPoints(uint32_t func) const;
 
+  /// Returns all the entry points that statically use |id|.
+  ///
+  /// Note: requires ComputeFunctionToEntryPointMapping to have been called.
+  std::set<uint32_t> EntryPointReferences(uint32_t id) const;
+
   /// Inserts an <id> to the set of functions that are target of OpFunctionCall.
   void AddFunctionCallTarget(const uint32_t id) {
     function_call_targets_.insert(id);


### PR DESCRIPTION
* Only check for binding and descriptor set on variables that are
statically used by an entry point
 * updated tests and added a couple new ones
 * new method for collecting entry points that statically reference an
 id

The new validation state method will be useful for #2151