### PR TITLE
Fix invalid OpPhi generated by merge-return.

### DIFF
--- a/source/opt/merge_return_pass.cpp
+++ b/source/opt/merge_return_pass.cpp
@@ -204,7 +204,11 @@ void MergeReturnPass::BranchToBlock(BasicBlock* block, uint32_t target) {
     RecordReturned(block);
     RecordReturnValue(block);
   }
+
   BasicBlock* target_block = context()->get_instr_block(target);
+  if (target_block->GetLoopMergeInst()) {
+    cfg()->SplitLoopHeader(target_block);
+  }
   UpdatePhiNodes(block, target_block);
 
   Instruction* return_inst = block->terminator();
@@ -368,6 +372,9 @@ void MergeReturnPass::BreakFromConstruct(
   // code, not the new header.
   if (block->GetLoopMergeInst()) {
     cfg()->SplitLoopHeader(block);
+  }
+  if (merge_block->GetLoopMergeInst()) {
+    cfg()->SplitLoopHeader(merge_block);
   }
 
   // Leave the phi instructions behind.

--- a/source/opt/merge_return_pass.cpp
+++ b/source/opt/merge_return_pass.cpp
@@ -239,15 +239,16 @@ void MergeReturnPass::CreatePhiNodesForInst(BasicBlock* merge_block,
   if (inst.result_id() != 0) {
     std::vector<Instruction*> users_to_update;
     context()->get_def_use_mgr()->ForEachUser(
-        &inst, [&users_to_update, &dom_tree, &inst, inst_bb, this](Instruction* user) {
+        &inst,
+        [&users_to_update, &dom_tree, &inst, inst_bb, this](Instruction* user) {
           BasicBlock* user_bb = nullptr;
           if (user->opcode() != SpvOpPhi) {
             user_bb = context()->get_instr_block(user);
           } else {
             // For OpPhi, the use should be considered to be in the predecessor.
-            for(uint32_t i = 0; i < user->NumInOperands(); i+=2) {
+            for (uint32_t i = 0; i < user->NumInOperands(); i += 2) {
               if (user->GetSingleWordInOperand(i) == inst.result_id()) {
-                uint32_t user_bb_id = user->GetSingleWordInOperand(i+1);
+                uint32_t user_bb_id = user->GetSingleWordInOperand(i + 1);
                 user_bb = context()->get_instr_block(user_bb_id);
                 break;
               }


### PR DESCRIPTION
When we create a new phi node for a value say %10, we have to replace
all of the uses of %10 that are no longer dominated by the def of %10
by the result id of the new phi.  However, if the use is in a phi node,
it is possible that the bb contains the use is not dominated by either.
In this case, needs to be handled differently.