### PR TITLE
Validator: Support VK_KHR_shader_float_controls

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -522,6 +522,41 @@ SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetScalarBlockLayout(
 SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetSkipBlockLayout(
     spv_validator_options options, bool val);
 
+// Enables the SeparateDenormSettings feature, allowing separate
+// denorm settings for different bit widths.
+SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetSeparateDenormSettings(
+    spv_validator_options options, bool val);
+
+// Enables the SeparateRoundingModeSettings feature, allowing separate
+// rounding mode settings for different bit widths.
+SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetSeparateRoundingModeSettings(
+    spv_validator_options options, bool val);
+
+// Enables the SignedZeroIfNanPreserve feature for the bit widths
+// specified in the bitmask (combinations of 16, 32 and 64)
+SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetSignedZeroInfNanPreserve(
+    spv_validator_options options, uint32_t bitmask);
+
+// Enables the ShaderDenormPreserve feature for the bit widths
+// specified in the bitmask (combinations of 16, 32 and 64)
+SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetDenormPreserve(
+    spv_validator_options options, uint32_t bitmask);
+
+// Enables the ShaderDenormFlushToZero feature for the bit widths
+// specified in the bitmask (combinations of 16, 32 and 64)
+SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetDenormFlushToZero(
+    spv_validator_options options, uint32_t bitmask);
+
+// Enables the ShaderRoundingModeRTE feature for the bit widths
+// specified in the bitmask (combinations of 16, 32 and 64)
+SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetRoundingModeRTE(
+    spv_validator_options options, uint32_t bitmask);
+
+// Enables the ShaderRoundingModeRTZ feature for the bit widths
+// specified in the bitmask (combinations of 16, 32 and 64)
+SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetRoundingModeRTZ(
+    spv_validator_options options, uint32_t bitmask);
+
 // Creates an optimizer options object with default options. Returns a valid
 // options object. The object remains valid until it is passed into
 // |spvOptimizerOptionsDestroy|.

--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -110,6 +110,48 @@ class ValidatorOptions {
     spvValidatorOptionsSetRelaxLogicalPointer(options_, val);
   }
 
+  // Enables the SeparateDenormSettings feature, allowing separate
+  // denorm settings for different bit widths
+  void SetSeparateDenormSettings(bool val) {
+    spvValidatorOptionsSetSeparateDenormSettings(options_, val);
+  }
+
+  // Enables the SeparateRoundingModeSettings feature, allowing separate
+  // rounding mode settings for different bit widths
+  void SetSeparateRoundingModeSettings(bool val) {
+    spvValidatorOptionsSetSeparateRoundingModeSettings(options_, val);
+  }
+
+  // Enables the SignedZeroIfNanPreserve feature for the bit widths
+  // specified in the bitmask (combinations of 16, 32 and 64)
+  void SetSignedZeroInfNanPreserve(uint32_t bitmask) {
+    spvValidatorOptionsSetSignedZeroInfNanPreserve(options_, bitmask);
+  }
+
+  // Enables the ShaderDenormPreserve feature for the bit widths
+  // specified in the bitmask (combinations of 16, 32 and 64)
+  void SetDenormPreserve(uint32_t bitmask) {
+    spvValidatorOptionsSetDenormPreserve(options_, bitmask);
+  }
+
+  // Enables the ShaderDenormFlushToZero feature for the bit widths
+  // specified in the bitmask (combinations of 16, 32 and 64)
+  void SetDenormFlushToZero(uint32_t bitmask) {
+    spvValidatorOptionsSetDenormFlushToZero(options_, bitmask);
+  }
+
+  // Enables the ShaderRoundingModeRTE feature for the bit widths
+  // specified in the bitmask (combinations of 16, 32 and 64)
+  void SetRoundingModeRTE(uint32_t bitmask) {
+    spvValidatorOptionsSetRoundingModeRTE(options_, bitmask);
+  }
+
+  // Enables the ShaderRoundingModeRTZ feature for the bit widths
+  // specified in the bitmask (combinations of 16, 32 and 64)
+  void SetRoundingModeRTZ(uint32_t bitmask) {
+    spvValidatorOptionsSetRoundingModeRTZ(options_, bitmask);
+  }
+
  private:
   spv_validator_options options_;
 };

--- a/source/spirv_validator_options.cpp
+++ b/source/spirv_validator_options.cpp
@@ -104,3 +104,38 @@ void spvValidatorOptionsSetSkipBlockLayout(spv_validator_options options,
                                            bool val) {
   options->skip_block_layout = val;
 }
+
+void spvValidatorOptionsSetSeparateDenormSettings(spv_validator_options options,
+                                                  bool val) {
+  options->separate_denorm_settings = val;
+}
+
+void spvValidatorOptionsSetSeparateRoundingModeSettings(
+    spv_validator_options options, bool val) {
+  options->separate_rounding_mode_settings = val;
+}
+
+void spvValidatorOptionsSetSignedZeroInfNanPreserve(
+    spv_validator_options options, uint32_t bitmask) {
+  options->signed_zero_inf_nan_preserve = bitmask;
+}
+
+void spvValidatorOptionsSetDenormPreserve(spv_validator_options options,
+                                          uint32_t bitmask) {
+  options->denorm_preserve = bitmask;
+}
+
+void spvValidatorOptionsSetDenormFlushToZero(spv_validator_options options,
+                                             uint32_t bitmask) {
+  options->denorm_flush_to_zero = bitmask;
+}
+
+void spvValidatorOptionsSetRoundingModeRTE(spv_validator_options options,
+                                           uint32_t bitmask) {
+  options->rounding_mode_rte = bitmask;
+}
+
+void spvValidatorOptionsSetRoundingModeRTZ(spv_validator_options options,
+                                           uint32_t bitmask) {
+  options->rounding_mode_rtz = bitmask;
+}

--- a/source/spirv_validator_options.h
+++ b/source/spirv_validator_options.h
@@ -44,7 +44,14 @@ struct spv_validator_options_t {
         relax_logical_pointer(false),
         relax_block_layout(false),
         scalar_block_layout(false),
-        skip_block_layout(false) {}
+        skip_block_layout(false),
+        separate_denorm_settings(false),
+        separate_rounding_mode_settings(false),
+        signed_zero_inf_nan_preserve(0),
+        denorm_preserve(0),
+        denorm_flush_to_zero(0),
+        rounding_mode_rte(0),
+        rounding_mode_rtz(0) {}
 
   validator_universal_limits_t universal_limits_;
   bool relax_struct_store;
@@ -52,6 +59,16 @@ struct spv_validator_options_t {
   bool relax_block_layout;
   bool scalar_block_layout;
   bool skip_block_layout;
+
+  bool separate_denorm_settings;
+  bool separate_rounding_mode_settings;
+  // Float controls features, with the corresponding bit widths
+  // expressed as bitmasks (combinations of 16, 32 and 64)
+  uint32_t signed_zero_inf_nan_preserve;
+  uint32_t denorm_preserve;
+  uint32_t denorm_flush_to_zero;
+  uint32_t rounding_mode_rte;
+  uint32_t rounding_mode_rtz;
 };
 
 #endif  // SOURCE_SPIRV_VALIDATOR_OPTIONS_H_

--- a/source/val/validate_mode_setting.cpp
+++ b/source/val/validate_mode_setting.cpp
@@ -394,6 +394,101 @@ spv_result_t ValidateExecutionMode(ValidationState_t& _,
                     "execution model.";
         }
       }
+      break;
+    case SpvExecutionModeSignedZeroInfNanPreserve: {
+      const auto bit_width = inst->GetOperandAs<uint32_t>(2);
+      if ((_.options()->signed_zero_inf_nan_preserve & bit_width) == 0) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << "The corresponding float controls feature must be enabled "
+                  "for bit width "
+               << bit_width << ".";
+      }
+      break;
+    }
+    case SpvExecutionModeDenormPreserve: {
+      const auto bit_width = inst->GetOperandAs<uint32_t>(2);
+      if ((_.options()->denorm_preserve & bit_width) == 0) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << "The corresponding float controls feature must be enabled "
+                  "for bit width "
+               << bit_width << ".";
+      }
+
+      auto found = _.first_denorm_execution_mode().find(bit_width);
+      if (found == _.first_denorm_execution_mode().end()) {
+        _.first_denorm_execution_mode()[bit_width] = mode;
+      } else if (found->second != mode &&
+                 !_.options()->separate_denorm_settings) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << "Separate denorm execution modes for different bit widths "
+                  "are not allowed unless the corresponding feature is "
+                  "enabled.";
+      }
+      break;
+    }
+    case SpvExecutionModeDenormFlushToZero: {
+      const auto bit_width = inst->GetOperandAs<uint32_t>(2);
+      if ((_.options()->denorm_flush_to_zero & bit_width) == 0) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << "The corresponding float controls feature must be enabled "
+                  "for bit width "
+               << bit_width << ".";
+      }
+
+      auto found = _.first_denorm_execution_mode().find(bit_width);
+      if (found == _.first_denorm_execution_mode().end()) {
+        _.first_denorm_execution_mode()[bit_width] = mode;
+      } else if (found->second != mode &&
+                 !_.options()->separate_denorm_settings) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << "Separate denorm execution modes for different bit widths "
+                  "are not allowed unless the corresponding feature is "
+                  "enabled.";
+      }
+      break;
+    }
+    case SpvExecutionModeRoundingModeRTE: {
+      const auto bit_width = inst->GetOperandAs<uint32_t>(2);
+      if ((_.options()->rounding_mode_rte & bit_width) == 0) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << "The corresponding float controls feature must be enabled "
+                  "for bit width "
+               << bit_width << ".";
+      }
+
+      auto found = _.first_rounding_execution_mode().find(bit_width);
+      if (found == _.first_rounding_execution_mode().end()) {
+        _.first_rounding_execution_mode()[bit_width] = mode;
+      } else if (found->second != mode &&
+                 !_.options()->separate_rounding_mode_settings) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << "Separate rounding execution modes for different bit widths "
+                  "are not allowed unless the corresponding feature is "
+                  "enabled.";
+      }
+      break;
+    }
+    case SpvExecutionModeRoundingModeRTZ: {
+      const auto bit_width = inst->GetOperandAs<uint32_t>(2);
+      if ((_.options()->rounding_mode_rtz & bit_width) == 0) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << "The corresponding float controls feature must be enabled "
+                  "for bit width "
+               << bit_width << ".";
+      }
+
+      auto found = _.first_rounding_execution_mode().find(bit_width);
+      if (found == _.first_rounding_execution_mode().end()) {
+        _.first_rounding_execution_mode()[bit_width] = mode;
+      } else if (found->second != mode &&
+                 !_.options()->separate_rounding_mode_settings) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << "Separate rounding execution modes for different bit widths "
+                  "are not allowed unless the corresponding feature is "
+                  "enabled.";
+      }
+      break;
+    }
     default:
       break;
   }

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -263,6 +263,22 @@ class ValidationState_t {
     return &it->second;
   }
 
+  /// Mapping between bit widths (16, 32 and 64) and the corresponding denorm
+  /// execution mode which is first encountered. Used to check if
+  /// separateDenormSettings is respected.
+  std::unordered_map<uint32_t, SpvExecutionMode>&
+  first_denorm_execution_mode() {
+    return first_denorm_execution_mode_;
+  }
+
+  /// Mapping between bit widths (16, 32 and 64) and the corresponding rounding
+  /// execution mode which is first encountered. Used to check if
+  /// separateRoundingModeSettings is respected.
+  std::unordered_map<uint32_t, SpvExecutionMode>&
+  first_rounding_execution_mode() {
+    return first_rounding_execution_mode_;
+  }
+
   /// Traverses call tree and computes function_to_entry_points_.
   /// Note: called after fully parsing the binary.
   void ComputeFunctionToEntryPointMapping();
@@ -676,6 +692,16 @@ class ValidationState_t {
   /// Mapping entry point -> execution modes.
   std::unordered_map<uint32_t, std::set<SpvExecutionMode>>
       entry_point_to_execution_modes_;
+
+  /// Mapping between bit widths (16, 32 and 64) and the corresponding denorm
+  /// execution mode which is first encountered. Used to check if
+  /// separateDenormSettings is respected.
+  std::unordered_map<uint32_t, SpvExecutionMode> first_denorm_execution_mode_;
+
+  /// Mapping between bit widths (16, 32 and 64) and the corresponding rounding
+  /// execution mode which is first encountered. Used to check if
+  /// separateRoundingModeSettings is respected.
+  std::unordered_map<uint32_t, SpvExecutionMode> first_rounding_execution_mode_;
 
   /// Mapping function -> array of entry points inside this
   /// module which can (indirectly) call the function.

--- a/tools/val/val.cpp
+++ b/tools/val/val.cpp
@@ -60,6 +60,18 @@ Options:
   --relax-struct-store             Allow store from one struct type to a
                                    different type with compatible layout and
                                    members.
+  --separate-denorm-settings       Allow separate denorm settings for different bit widths.
+  --separate-rounding-settings     Allow separate rounding mode settings for different bit widths.
+  --signed-zero-if-nan-preserve    {16|32|64 and their bitwise combinations}
+                                   Enable the SignedZeroIfNanPreserve feature for the specified bit widths
+  --denorm-preserve                {16|32|64 and their bitwise combinations}
+                                   Enable the ShaderDenormPreserve feature for the specified bit widths
+  --denorm-flush-to-zero           {16|32|64 and their bitwise combinations}
+                                   Enable the ShaderDenormFlushToZero feature for the specified bit widths
+  --rounding-mode-rte              {16|32|64 and their bitwise combinations}
+                                   Enable the ShaderRoundingModeRTE feature for the specified bit widths
+  --rounding-mode-rtz              {16|32|64 and their bitwise combinations}
+                                   Enable the ShaderRoundingModeRTZ feature for the specified bit widths
   --version                        Display validator version information.
   --target-env                     {vulkan1.0|vulkan1.1|opencl2.2|spv1.0|spv1.1|spv1.2|spv1.3|webgpu0}
                                    Use Vulkan 1.0, Vulkan 1.1, OpenCL 2.2, SPIR-V 1.0,
@@ -140,6 +152,55 @@ int main(int argc, char** argv) {
         options.SetSkipBlockLayout(true);
       } else if (0 == strcmp(cur_arg, "--relax-struct-store")) {
         options.SetRelaxStructStore(true);
+      } else if (0 == strcmp(cur_arg, "--separate-denorm-settings")) {
+        options.SetSeparateDenormSettings(true);
+      } else if (0 == strcmp(cur_arg, "--separate-rounding-settings")) {
+        options.SetSeparateRoundingModeSettings(true);
+      } else if (0 == strcmp(cur_arg, "--signed-zero-if-nan-preserve")) {
+        uint32_t bitmask = 0;
+        if (sscanf(argv[++argi], "%u", &bitmask)) {
+          options.SetSignedZeroInfNanPreserve(bitmask);
+        } else {
+          fprintf(stderr, "error: missing argument to %s\n", cur_arg);
+          continue_processing = false;
+          return_code = 1;
+        }
+      } else if (0 == strcmp(cur_arg, "--denorm-preserve")) {
+        uint32_t bitmask = 0;
+        if (sscanf(argv[++argi], "%u", &bitmask)) {
+          options.SetDenormPreserve(bitmask);
+        } else {
+          fprintf(stderr, "error: missing argument to %s\n", cur_arg);
+          continue_processing = false;
+          return_code = 1;
+        }
+      } else if (0 == strcmp(cur_arg, "--denorm-flush-to-zero")) {
+        uint32_t bitmask = 0;
+        if (sscanf(argv[++argi], "%u", &bitmask)) {
+          options.SetDenormFlushToZero(bitmask);
+        } else {
+          fprintf(stderr, "error: missing argument to %s\n", cur_arg);
+          continue_processing = false;
+          return_code = 1;
+        }
+      } else if (0 == strcmp(cur_arg, "--rounding-mode-rte")) {
+        uint32_t bitmask = 0;
+        if (sscanf(argv[++argi], "%u", &bitmask)) {
+          options.SetRoundingModeRTE(bitmask);
+        } else {
+          fprintf(stderr, "error: missing argument to %s\n", cur_arg);
+          continue_processing = false;
+          return_code = 1;
+        }
+      } else if (0 == strcmp(cur_arg, "--rounding-mode-rtz")) {
+        uint32_t bitmask = 0;
+        if (sscanf(argv[++argi], "%u", &bitmask)) {
+          options.SetRoundingModeRTZ(bitmask);
+        } else {
+          fprintf(stderr, "error: missing argument to %s\n", cur_arg);
+          continue_processing = false;
+          return_code = 1;
+        }
       } else if (0 == cur_arg[1]) {
         // Setting a filename of "-" to indicate stdin.
         if (!inFile) {


### PR DESCRIPTION
Adds validator options to specify enabled float controls features.

By default, none of the features are considered to be active, so
validation will fail if any float controls are used.

For validator options that match directly to float control features,
the value is a bitwise OR of supported bit widths, e.g. (16 | 32).
The options for separate denorm and rounding modes are simple booleans.