### PR TITLE
Add PCH_FILE for upgrade_memory_model target

### DIFF
--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -92,4 +92,5 @@ add_spvtools_unittest(TARGET opt
 add_spvtools_unittest(TARGET upgrade_memory_model
   SRCS upgrade_memory_model_test.cpp pass_utils.cpp
   LIBS SPIRV-Tools-opt
+  PCH_FILE pch_test_opt
 )


### PR DESCRIPTION
MSVC doesn't like building pass_utils.cpp twice in the same folder with different PCH settings.