### PR TITLE
Add RemoveOpNameInstruction reduction pass

### DIFF
--- a/source/reduce/CMakeLists.txt
+++ b/source/reduce/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SPIRV_TOOLS_REDUCE_SOURCES
         reduction_opportunity.h
         reduction_pass.h
         remove_instruction_reduction_opportunity.h
+        remove_opname_instruction_reduction_pass.h
         remove_unreferenced_instruction_reduction_pass.h
         structured_loop_to_selection_reduction_opportunity.h
         structured_loop_to_selection_reduction_pass.h
@@ -31,6 +32,7 @@ set(SPIRV_TOOLS_REDUCE_SOURCES
         reduction_pass.cpp
         remove_instruction_reduction_opportunity.cpp
         remove_unreferenced_instruction_reduction_pass.cpp
+        remove_opname_instruction_reduction_pass.cpp
         structured_loop_to_selection_reduction_opportunity.cpp
         structured_loop_to_selection_reduction_pass.cpp
         )

--- a/source/reduce/remove_opname_instruction_reduction_pass.cpp
+++ b/source/reduce/remove_opname_instruction_reduction_pass.cpp
@@ -28,7 +28,7 @@ RemoveOpNameInstructionReductionPass::GetAvailableOpportunities(
   std::vector<std::unique_ptr<ReductionOpportunity>> result;
 
   for (auto& inst : context->module()->debugs2()) {
-    if (inst.opcode() == SpvOpName) {
+    if (inst.opcode() == SpvOpName || inst.opcode() == SpvOpMemberName) {
       result.push_back(MakeUnique<RemoveInstructionReductionOpportunity>(&inst));
     }
   }

--- a/source/reduce/remove_opname_instruction_reduction_pass.cpp
+++ b/source/reduce/remove_opname_instruction_reduction_pass.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "remove_opname_instruction_reduction_pass.h"
+#include "remove_instruction_reduction_opportunity.h"
+#include "source/opcode.h"
+#include "source/opt/instruction.h"
+
+namespace spvtools {
+namespace reduce {
+
+using namespace opt;
+
+std::vector<std::unique_ptr<ReductionOpportunity>>
+RemoveOpNameInstructionReductionPass::GetAvailableOpportunities(
+    opt::IRContext* context) const {
+  std::vector<std::unique_ptr<ReductionOpportunity>> result;
+
+  for (auto& inst : context->module()->debugs2()) {
+    if (inst.opcode() == SpvOpName) {
+      result.push_back(MakeUnique<RemoveInstructionReductionOpportunity>(&inst));
+    }
+  }
+  return result;
+}
+
+std::string RemoveOpNameInstructionReductionPass::GetName() const {
+  return "RemoveOpNameInstructionReductionPass";
+}
+
+}  // namespace reduce
+}  // namespace spvtools

--- a/source/reduce/remove_opname_instruction_reduction_pass.cpp
+++ b/source/reduce/remove_opname_instruction_reduction_pass.cpp
@@ -29,7 +29,8 @@ RemoveOpNameInstructionReductionPass::GetAvailableOpportunities(
 
   for (auto& inst : context->module()->debugs2()) {
     if (inst.opcode() == SpvOpName || inst.opcode() == SpvOpMemberName) {
-      result.push_back(MakeUnique<RemoveInstructionReductionOpportunity>(&inst));
+      result.push_back(
+          MakeUnique<RemoveInstructionReductionOpportunity>(&inst));
     }
   }
   return result;

--- a/source/reduce/remove_opname_instruction_reduction_pass.h
+++ b/source/reduce/remove_opname_instruction_reduction_pass.h
@@ -27,8 +27,7 @@ class RemoveOpNameInstructionReductionPass : public ReductionPass {
  public:
   // Creates the reduction pass in the context of the given target environment
   // |target_env|
-  explicit RemoveOpNameInstructionReductionPass(
-      const spv_target_env target_env)
+  explicit RemoveOpNameInstructionReductionPass(const spv_target_env target_env)
       : ReductionPass(target_env) {}
 
   ~RemoveOpNameInstructionReductionPass() override = default;

--- a/source/reduce/remove_opname_instruction_reduction_pass.h
+++ b/source/reduce/remove_opname_instruction_reduction_pass.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_REDUCE_REMOVE_OPNAME_INSTRUCTION_REDUCTION_PASS_H_
+#define SOURCE_REDUCE_REMOVE_OPNAME_INSTRUCTION_REDUCTION_PASS_H_
+
+#include "reduction_pass.h"
+
+namespace spvtools {
+namespace reduce {
+
+// A reduction pass for removing OpName instructions.  As well as making the
+// module smaller, removing an OpName instruction may create opportunities to
+// remove the instruction that create the id to which the OpName applies.
+class RemoveOpNameInstructionReductionPass : public ReductionPass {
+ public:
+  // Creates the reduction pass in the context of the given target environment
+  // |target_env|
+  explicit RemoveOpNameInstructionReductionPass(
+      const spv_target_env target_env)
+      : ReductionPass(target_env) {}
+
+  ~RemoveOpNameInstructionReductionPass() override = default;
+
+  // The name of this pass.
+  std::string GetName() const final;
+
+ protected:
+  // Finds all opportunities for removing opName instructions in the
+  // given module.
+  std::vector<std::unique_ptr<ReductionOpportunity>> GetAvailableOpportunities(
+      opt::IRContext* context) const final;
+
+ private:
+};
+
+}  // namespace reduce
+}  // namespace spvtools
+
+#endif  // SOURCE_REDUCE_REMOVE_OpName_INSTRUCTION_REDUCTION_PASS_H_

--- a/test/reduce/CMakeLists.txt
+++ b/test/reduce/CMakeLists.txt
@@ -18,6 +18,7 @@ add_spvtools_unittest(TARGET reduce
         reduce_test_util.cpp
         reduce_test_util.h
         reducer_test.cpp
+        remove_opname_instruction_reduction_pass_test.cpp
         remove_unreferenced_instruction_reduction_pass_test.cpp
         structured_loop_to_selection_reduction_pass_test.cpp
         LIBS SPIRV-Tools-reduce

--- a/test/reduce/remove_opname_instruction_reduction_pass_test.cpp
+++ b/test/reduce/remove_opname_instruction_reduction_pass_test.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "reduce_test_util.h"
+
+#include "source/opt/build_module.h"
+#include "source/reduce/reduction_opportunity.h"
+#include "source/reduce/remove_opname_instruction_reduction_pass.h"
+
+namespace spvtools {
+namespace reduce {
+namespace {
+
+TEST(RemoveOpnameInstructionReductionPassTest, RemoveSingleOpName) {
+  const std::string prologue = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+  )";
+
+  const std::string epilogue = R"(
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const std::string original = prologue + R"(
+               OpName %4 "main"
+  )" + epilogue;
+
+  const std::string expected = prologue + epilogue;
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context =
+      BuildModule(env, consumer, original, kReduceAssembleOption);
+  const auto pass =
+      TestSubclass<RemoveOpNameInstructionReductionPass>(env);
+  const auto ops = pass.WrapGetAvailableOpportunities(context.get());
+  ASSERT_EQ(1, ops.size());
+  ASSERT_TRUE(ops[0]->PreconditionHolds());
+  ops[0]->TryToApply();
+
+  CheckEqual(env, expected, context.get());
+}
+
+}  // namespace
+}  // namespace reduce
+}  // namespace spvtools

--- a/test/reduce/remove_opname_instruction_reduction_pass_test.cpp
+++ b/test/reduce/remove_opname_instruction_reduction_pass_test.cpp
@@ -87,6 +87,70 @@ TEST(RemoveOpnameInstructionReductionPassTest, RemoveSingleOpName) {
   CheckEqual(env, expected, context.get());
 }
 
+TEST(RemoveOpnameInstructionReductionPassTest, TryApplyRemovesAllOpName) {
+  const std::string prologue = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+  )";
+
+  const std::string epilogue = R"(
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeFloat 32
+          %7 = OpTypePointer Function %6
+          %9 = OpConstant %6 1
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+          %8 = OpVariable %7 Function
+         %10 = OpVariable %7 Function
+         %11 = OpVariable %7 Function
+         %12 = OpVariable %7 Function
+               OpStore %8 %9
+               OpStore %10 %9
+               OpStore %11 %9
+               OpStore %12 %9
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const std::string original = prologue + R"(
+               OpName %4 "main"
+               OpName %8 "a"
+               OpName %10 "b"
+               OpName %11 "c"
+               OpName %12 "d"
+  )" + epilogue;
+
+  const std::string expected = prologue + epilogue;
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+
+  std::vector<uint32_t> binary;
+  SpirvTools t(env);
+  ASSERT_TRUE(t.Assemble(original, &binary, kReduceAssembleOption));
+
+  const auto consumer = nullptr;
+  const auto context =
+      BuildModule(env, consumer, original, kReduceAssembleOption);
+  auto pass = TestSubclass<RemoveOpNameInstructionReductionPass>(env);
+
+  {
+    // Check the right number of opportunities is detected
+    const auto ops = pass.WrapGetAvailableOpportunities(context.get());
+    ASSERT_EQ(5, ops.size());
+  }
+
+  {
+    // The reduction should remove all OpName
+    auto reduced_binary = pass.TryApplyReduction(binary);
+    CheckEqual(env, expected, reduced_binary);
+  }
+}
+
 }  // namespace
 }  // namespace reduce
 }  // namespace spvtools

--- a/test/reduce/remove_opname_instruction_reduction_pass_test.cpp
+++ b/test/reduce/remove_opname_instruction_reduction_pass_test.cpp
@@ -38,8 +38,6 @@ TEST(RemoveOpnameInstructionReductionPassTest, NothingToRemove) {
                OpFunctionEnd
   )";
 
-  const std::string expected = original;
-
   const auto env = SPV_ENV_UNIVERSAL_1_3;
   const auto consumer = nullptr;
   const auto context =
@@ -48,10 +46,7 @@ TEST(RemoveOpnameInstructionReductionPassTest, NothingToRemove) {
       TestSubclass<RemoveOpNameInstructionReductionPass>(env);
   const auto ops = pass.WrapGetAvailableOpportunities(context.get());
   ASSERT_EQ(0, ops.size());
-
-  CheckEqual(env, expected, context.get());
 }
-
 
 TEST(RemoveOpnameInstructionReductionPassTest, RemoveSingleOpName) {
   const std::string prologue = R"(

--- a/test/reduce/remove_opname_instruction_reduction_pass_test.cpp
+++ b/test/reduce/remove_opname_instruction_reduction_pass_test.cpp
@@ -22,6 +22,37 @@ namespace spvtools {
 namespace reduce {
 namespace {
 
+TEST(RemoveOpnameInstructionReductionPassTest, NothingToRemove) {
+  const std::string original = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const std::string expected = original;
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context =
+      BuildModule(env, consumer, original, kReduceAssembleOption);
+  const auto pass =
+      TestSubclass<RemoveOpNameInstructionReductionPass>(env);
+  const auto ops = pass.WrapGetAvailableOpportunities(context.get());
+  ASSERT_EQ(0, ops.size());
+
+  CheckEqual(env, expected, context.get());
+}
+
+
 TEST(RemoveOpnameInstructionReductionPassTest, RemoveSingleOpName) {
   const std::string prologue = R"(
                OpCapability Shader

--- a/test/reduce/remove_opname_instruction_reduction_pass_test.cpp
+++ b/test/reduce/remove_opname_instruction_reduction_pass_test.cpp
@@ -17,6 +17,7 @@
 #include "source/opt/build_module.h"
 #include "source/reduce/reduction_opportunity.h"
 #include "source/reduce/remove_opname_instruction_reduction_pass.h"
+#include <source/reduce/remove_unreferenced_instruction_reduction_pass.h>
 
 namespace spvtools {
 namespace reduce {
@@ -128,27 +129,79 @@ TEST(RemoveOpnameInstructionReductionPassTest, TryApplyRemovesAllOpName) {
   const std::string expected = prologue + epilogue;
 
   const auto env = SPV_ENV_UNIVERSAL_1_3;
-
-  std::vector<uint32_t> binary;
-  SpirvTools t(env);
-  ASSERT_TRUE(t.Assemble(original, &binary, kReduceAssembleOption));
-
-  const auto consumer = nullptr;
-  const auto context =
-      BuildModule(env, consumer, original, kReduceAssembleOption);
   auto pass = TestSubclass<RemoveOpNameInstructionReductionPass>(env);
 
   {
     // Check the right number of opportunities is detected
+    const auto consumer = nullptr;
+    const auto context =
+        BuildModule(env, consumer, original, kReduceAssembleOption);
     const auto ops = pass.WrapGetAvailableOpportunities(context.get());
     ASSERT_EQ(5, ops.size());
   }
 
   {
     // The reduction should remove all OpName
+    std::vector<uint32_t> binary;
+    SpirvTools t(env);
+    ASSERT_TRUE(t.Assemble(original, &binary, kReduceAssembleOption));
     auto reduced_binary = pass.TryApplyReduction(binary);
     CheckEqual(env, expected, reduced_binary);
   }
+}
+
+TEST(RemoveOpnameInstructionReductionPassTest, EnableRemoveUnreferencedInstruction) {
+  const std::string source = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %8 "a"
+               OpName %11 "this-name-counts-as-usage-for-load-instruction"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeFloat 32
+          %7 = OpTypePointer Function %6
+          %9 = OpConstant %6 1
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+          %8 = OpVariable %7 Function
+         %11 = OpLoad %6 %8 ;; this OpLoad has no "use" outside of its OpName
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto consumer = nullptr;
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  std::vector<uint32_t> binary;
+  SpirvTools t(env);
+  ASSERT_TRUE(t.Assemble(source, &binary, kReduceAssembleOption));
+
+  const auto unreferenced_inst_pass =
+      TestSubclass<RemoveUnreferencedInstructionReductionPass>(env);
+  auto opname_inst_pass =
+      TestSubclass<RemoveOpNameInstructionReductionPass>(env);
+
+  // Save unreferenced inst opportunities before applying OpName reduction
+  const auto context_before =
+      BuildModule(env, consumer, source, kReduceAssembleOption);
+  const auto unreferenced_inst_ops_before =
+      unreferenced_inst_pass.WrapGetAvailableOpportunities(context_before.get());
+
+  // Apply OpName reduction
+  auto reduced_binary = opname_inst_pass.TryApplyReduction(binary);
+
+  // Check that a new unreferenced inst opportunity has appeared
+  const auto context_after =
+      BuildModule(env, consumer, reduced_binary.data(), reduced_binary.size());
+  const auto unreferenced_inst_ops_after =
+      unreferenced_inst_pass.WrapGetAvailableOpportunities(context_after.get());
+  ASSERT_EQ(
+      unreferenced_inst_ops_after.size(),
+      unreferenced_inst_ops_before.size() + 1);
 }
 
 }  // namespace

--- a/tools/reduce/reduce.cpp
+++ b/tools/reduce/reduce.cpp
@@ -16,6 +16,7 @@
 #include <cerrno>
 #include <cstring>
 #include <functional>
+#include <source/reduce/remove_opname_instruction_reduction_pass.h>
 
 #include "source/opt/build_module.h"
 #include "source/opt/ir_context.h"
@@ -204,6 +205,8 @@ int main(int argc, const char** argv) {
         return ExecuteCommand(command);
       });
 
+  reducer.AddReductionPass(
+      spvtools::MakeUnique<RemoveOpNameInstructionReductionPass>(target_env));
   reducer.AddReductionPass(
       spvtools::MakeUnique<OperandToConstReductionPass>(target_env));
   reducer.AddReductionPass(

--- a/tools/reduce/reduce.cpp
+++ b/tools/reduce/reduce.cpp
@@ -212,6 +212,8 @@ int main(int argc, const char** argv) {
   reducer.AddReductionPass(
       spvtools::MakeUnique<OperandToDominatingIdReductionPass>(target_env));
   reducer.AddReductionPass(
+      spvtools::MakeUnique<RemoveOpNameInstructionReductionPass>(target_env));
+  reducer.AddReductionPass(
       spvtools::MakeUnique<RemoveUnreferencedInstructionReductionPass>(
           target_env));
   reducer.AddReductionPass(

--- a/tools/reduce/reduce.cpp
+++ b/tools/reduce/reduce.cpp
@@ -16,7 +16,6 @@
 #include <cerrno>
 #include <cstring>
 #include <functional>
-#include <source/reduce/remove_opname_instruction_reduction_pass.h>
 
 #include "source/opt/build_module.h"
 #include "source/opt/ir_context.h"
@@ -24,6 +23,7 @@
 #include "source/reduce/operand_to_const_reduction_pass.h"
 #include "source/reduce/operand_to_dominating_id_reduction_pass.h"
 #include "source/reduce/reducer.h"
+#include "source/reduce/remove_opname_instruction_reduction_pass.h"
 #include "source/reduce/remove_unreferenced_instruction_reduction_pass.h"
 #include "source/reduce/structured_loop_to_selection_reduction_pass.h"
 #include "source/spirv_reducer_options.h"
@@ -211,8 +211,6 @@ int main(int argc, const char** argv) {
       spvtools::MakeUnique<OperandToConstReductionPass>(target_env));
   reducer.AddReductionPass(
       spvtools::MakeUnique<OperandToDominatingIdReductionPass>(target_env));
-  reducer.AddReductionPass(
-      spvtools::MakeUnique<RemoveOpNameInstructionReductionPass>(target_env));
   reducer.AddReductionPass(
       spvtools::MakeUnique<RemoveUnreferencedInstructionReductionPass>(
           target_env));


### PR DESCRIPTION
Add a spirv-reduce pass which removes OpName and OpMemberName instructions.

This is useful to enable other reduction passes, e.g. RemoveUnreferencedInstruction may not be able to remove an instruction creating an id whose only usage is an OpName for this id.
