### PR TITLE
Disable checking that AtomicStorage capability is present

### DIFF
--- a/source/val/validate_memory_semantics.cpp
+++ b/source/val/validate_memory_semantics.cpp
@@ -119,15 +119,15 @@ spv_result_t ValidateMemorySemantics(ValidationState_t& _,
            << ": Memory Semantics UniformMemory requires capability Shader";
   }
 
-// Disabling this check until
-// https://github.com/KhronosGroup/glslang/issues/1618 is resolved.
-//   if (value & SpvMemorySemanticsAtomicCounterMemoryMask &&
-//      !_.HasCapability(SpvCapabilityAtomicStorage)) {
-//    return _.diag(SPV_ERROR_INVALID_DATA, inst)
-//           << spvOpcodeString(opcode)
-//           << ": Memory Semantics AtomicCounterMemory requires capability "
-//              "AtomicStorage";
-//  }
+  // Disabling this check until
+  // https://github.com/KhronosGroup/glslang/issues/1618 is resolved.
+  //   if (value & SpvMemorySemanticsAtomicCounterMemoryMask &&
+  //      !_.HasCapability(SpvCapabilityAtomicStorage)) {
+  //    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+  //           << spvOpcodeString(opcode)
+  //           << ": Memory Semantics AtomicCounterMemory requires capability "
+  //              "AtomicStorage";
+  //  }
 
   if (value & (SpvMemorySemanticsMakeAvailableKHRMask |
                SpvMemorySemanticsMakeVisibleKHRMask)) {

--- a/source/val/validate_memory_semantics.cpp
+++ b/source/val/validate_memory_semantics.cpp
@@ -119,13 +119,15 @@ spv_result_t ValidateMemorySemantics(ValidationState_t& _,
            << ": Memory Semantics UniformMemory requires capability Shader";
   }
 
-  if (value & SpvMemorySemanticsAtomicCounterMemoryMask &&
-      !_.HasCapability(SpvCapabilityAtomicStorage)) {
-    return _.diag(SPV_ERROR_INVALID_DATA, inst)
-           << spvOpcodeString(opcode)
-           << ": Memory Semantics AtomicCounterMemory requires capability "
-              "AtomicStorage";
-  }
+// Disabling this check until
+// https://github.com/KhronosGroup/glslang/issues/1618 is resolved.
+//   if (value & SpvMemorySemanticsAtomicCounterMemoryMask &&
+//      !_.HasCapability(SpvCapabilityAtomicStorage)) {
+//    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+//           << spvOpcodeString(opcode)
+//           << ": Memory Semantics AtomicCounterMemory requires capability "
+//              "AtomicStorage";
+//  }
 
   if (value & (SpvMemorySemanticsMakeAvailableKHRMask |
                SpvMemorySemanticsMakeVisibleKHRMask)) {

--- a/test/val/val_atomics_test.cpp
+++ b/test/val/val_atomics_test.cpp
@@ -1160,10 +1160,11 @@ OpAtomicStore %u32_var %device %relaxed %u32_1
 
 // Disabling this test until
 // https://github.com/KhronosGroup/glslang/issues/1618 is resolved.
-//TEST_F(ValidateAtomics, AtomicCounterMemorySemanticsNoCapability) {
+// TEST_F(ValidateAtomics, AtomicCounterMemorySemanticsNoCapability) {
 //  const std::string body = R"(
-//OpAtomicStore %u32_var %device %relaxed %u32_1
-//%val1 = OpAtomicIIncrement %u32 %u32_var %device %acquire_release_atomic_counter_workgroup
+// OpAtomicStore %u32_var %device %relaxed %u32_1
+//%val1 = OpAtomicIIncrement %u32 %u32_var %device
+//%acquire_release_atomic_counter_workgroup
 //)";
 //
 //  CompileSuccessfully(GenerateKernelCode(body));
@@ -1171,7 +1172,8 @@ OpAtomicStore %u32_var %device %relaxed %u32_1
 //  EXPECT_THAT(
 //      getDiagnosticString(),
 //      HasSubstr("AtomicIIncrement: Memory Semantics AtomicCounterMemory "
-//                "requires capability AtomicStorage\n  %40 = OpAtomicIIncrement "
+//                "requires capability AtomicStorage\n  %40 = OpAtomicIIncrement
+//                "
 //                "%uint %30 %uint_1_0 %uint_1288\n"));
 //}
 

--- a/test/val/val_atomics_test.cpp
+++ b/test/val/val_atomics_test.cpp
@@ -1158,20 +1158,22 @@ OpAtomicStore %u32_var %device %relaxed %u32_1
                         "requires capability Shader"));
 }
 
-TEST_F(ValidateAtomics, AtomicCounterMemorySemanticsNoCapability) {
-  const std::string body = R"(
-OpAtomicStore %u32_var %device %relaxed %u32_1
-%val1 = OpAtomicIIncrement %u32 %u32_var %device %acquire_release_atomic_counter_workgroup
-)";
-
-  CompileSuccessfully(GenerateKernelCode(body));
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("AtomicIIncrement: Memory Semantics AtomicCounterMemory "
-                "requires capability AtomicStorage\n  %40 = OpAtomicIIncrement "
-                "%uint %30 %uint_1_0 %uint_1288\n"));
-}
+// Disabling this test until
+// https://github.com/KhronosGroup/glslang/issues/1618 is resolved.
+//TEST_F(ValidateAtomics, AtomicCounterMemorySemanticsNoCapability) {
+//  const std::string body = R"(
+//OpAtomicStore %u32_var %device %relaxed %u32_1
+//%val1 = OpAtomicIIncrement %u32 %u32_var %device %acquire_release_atomic_counter_workgroup
+//)";
+//
+//  CompileSuccessfully(GenerateKernelCode(body));
+//  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+//  EXPECT_THAT(
+//      getDiagnosticString(),
+//      HasSubstr("AtomicIIncrement: Memory Semantics AtomicCounterMemory "
+//                "requires capability AtomicStorage\n  %40 = OpAtomicIIncrement "
+//                "%uint %30 %uint_1_0 %uint_1288\n"));
+//}
 
 TEST_F(ValidateAtomics, AtomicCounterMemorySemanticsWithCapability) {
   const std::string body = R"(


### PR DESCRIPTION
There is inconsistencies between the different specs about whether or
not this capability is required/allowed, so tooling like glslang
currently ignores it. Once this is resolved the check and test can be
re-enabled.