### PR TITLE
Output disassembly line number for binary parse errors.

### DIFF
--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -123,8 +123,8 @@ class Parser {
   // returned object will be propagated to the current parse's diagnostic
   // object.
   spvtools::DiagnosticStream diagnostic(spv_result_t error) {
-    return spvtools::DiagnosticStream({0, 0, _.word_index}, consumer_, "",
-                                      error);
+    return spvtools::DiagnosticStream({0, 0, _.instruction_count}, consumer_,
+                                       "", error);
   }
 
   // Returns a diagnostic stream object with the default parse error code.
@@ -179,6 +179,7 @@ class Parser {
           num_words(num_words_arg),
           diagnostic(diagnostic_arg),
           word_index(0),
+          instruction_count(0),
           endian(),
           requires_endian_conversion(false) {
       // Temporary storage for parser state within a single instruction.
@@ -192,6 +193,7 @@ class Parser {
     size_t num_words;            // Number of words in the module.
     spv_diagnostic* diagnostic;  // Where diagnostics go.
     size_t word_index;           // The current position in words.
+    size_t instruction_count;    // The count of processed instructions
     spv_endianness_t endian;     // The endianness of the binary.
     // Is the SPIR-V binary in a different endiannes from the host native
     // endianness?
@@ -269,6 +271,8 @@ spv_result_t Parser::parseModule() {
 }
 
 spv_result_t Parser::parseInstruction() {
+  _.instruction_count++;
+
   // The zero values for all members except for opcode are the
   // correct initial values.
   spv_parsed_instruction_t inst = {};

--- a/test/binary_parse_test.cpp
+++ b/test/binary_parse_test.cpp
@@ -308,7 +308,7 @@ TEST_F(BinaryParseTest, SpecifyConsumerNullDiagnosticsForBadParse) {
         EXPECT_STREQ("input", source);
         EXPECT_EQ(0u, position.line);
         EXPECT_EQ(0u, position.column);
-        EXPECT_EQ(5u, position.index);
+        EXPECT_EQ(1u, position.index);
         EXPECT_STREQ("Invalid opcode: 65535", message);
       });
 

--- a/test/c_interface_test.cpp
+++ b/test/c_interface_test.cpp
@@ -150,7 +150,7 @@ TEST(CInterface, SpecifyConsumerNullDiagnosticForDisassembling) {
         EXPECT_STREQ("input", source);
         EXPECT_EQ(0u, position.line);
         EXPECT_EQ(0u, position.column);
-        EXPECT_EQ(5u, position.index);
+        EXPECT_EQ(1u, position.index);
         EXPECT_STREQ("Invalid opcode: 65535", message);
       });
 


### PR DESCRIPTION
This Cl changes the binary parser to keep track of the instruction count
being processed. The parser will then use that instruction number as the
error number, instead of the binary word.

This should make it easier to match the error up to what the
disassembler would output for the error.

Issue #2091