### PR TITLE
Avoid GCC8 warning in text_handler.cpp.

### DIFF
--- a/source/text_handler.cpp
+++ b/source/text_handler.cpp
@@ -313,7 +313,7 @@ spv_result_t AssemblyContext::binaryEncodeString(const char* value,
   pInst->words.back() = 0;
 
   char* dest = (char*)&pInst->words[oldWordCount];
-  strncpy(dest, value, length);
+  strncpy(dest, value, length + 1);
 
   return SPV_SUCCESS;
 }


### PR DESCRIPTION
In the function `AssemblyContext::binaryEncodeString`, we want to copy
a nul terminated string to an instruction.  When coping the string, we
did not copy the nul at the end of the source.  It was added by setting
the entire last word to 0, which is mandated by the spir-v spec.  This
is not a bug, but it does trigger a warning in GCC8 when doing a release
build.

To avoid the warning, we will copy the nul character at the end of the
string too.

Fixes #1541.