### PR TITLE
Don't unswitch the latch block.

### DIFF
--- a/source/opt/loop_unswitch_pass.cpp
+++ b/source/opt/loop_unswitch_pass.cpp
@@ -74,6 +74,10 @@ class LoopUnswitch {
 
     for (uint32_t bb_id : loop_->GetBlocks()) {
       BasicBlock* bb = cfg.block(bb_id);
+      if (loop_->GetLatchBlock() == bb) {
+        continue;
+      }
+
       if (bb->terminator()->IsBranch() &&
           bb->terminator()->opcode() != SpvOpBranch) {
         if (IsConditionLoopInvariant(bb->terminator())) {

--- a/test/opt/loop_optimizations/unswitch.cpp
+++ b/test/opt/loop_optimizations/unswitch.cpp
@@ -906,6 +906,40 @@ TEST_F(UnswitchTest, UnswitchNotUniform) {
   EXPECT_EQ(Pass::Status::SuccessWithoutChange, std::get<1>(result));
 }
 
+TEST_F(UnswitchTest, DontUnswitchLatch) {
+  // Check that the unswitch is not triggered for the latch branch.
+  const std::string text = R"(
+         OpCapability Shader
+    %1 = OpExtInstImport "GLSL.std.450"
+         OpMemoryModel Logical GLSL450
+         OpEntryPoint Fragment %4 "main"
+         OpExecutionMode %4 OriginUpperLeft
+         OpSource ESSL 310
+ %void = OpTypeVoid
+    %3 = OpTypeFunction %void
+ %bool = OpTypeBool
+%false = OpConstantFalse %bool
+    %4 = OpFunction %void None %3
+    %5 = OpLabel
+         OpBranch %6
+    %6 = OpLabel
+         OpLoopMerge %8 %9 None
+         OpBranch %7
+    %7 = OpLabel
+         OpBranch %9
+    %9 = OpLabel
+         OpBranchConditional %false %6 %8
+    %8 = OpLabel
+         OpReturn
+         OpFunctionEnd
+  )";
+
+  auto result =
+      SinglePassRunAndDisassemble<LoopUnswitchPass>(text, true, false);
+
+  EXPECT_EQ(Pass::Status::SuccessWithoutChange, std::get<1>(result));
+}
+
 }  // namespace
 }  // namespace opt
 }  // namespace spvtools


### PR DESCRIPTION
Loop unswitching is unswitching the conditional branch that creates the
back-edge. In the version of the loop, where the bachedge is not taken,
there is no back-edge. This is what causes the validator to complain.

The solution I will go with will be to now unswitch a condition with a
back-edge. At this time we do not now if loop unswitching is used. We do
not include it in the optimization sets provided, nor is it used in
glslang's set. When there are opportunities and no breaks from the loop,
the loop with either be a single iteration loop, or an infinite loop.
There is no performance advantage to performing loop unswitching in
either of those cases. If there is a break, maintaining structured
control flow will be tricky. Unless we see a clear advantage to handling
these case, I would go with the safer simpler solution.

Fixes #2201.