### PR TITLE
tools/lesspipe: Allow generic shell

### DIFF
--- a/tools/lesspipe/spirv-lesspipe.sh
+++ b/tools/lesspipe/spirv-lesspipe.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # Copyright (c) 2016 The Khronos Group Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/lesspipe/spirv-lesspipe.sh
+++ b/tools/lesspipe/spirv-lesspipe.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Copyright (c) 2016 The Khronos Group Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Its better to allow generic shell for compatible with other distro