### PR TITLE
Handle CompositeInsert with no indices in VDCE

### DIFF
--- a/source/opt/vector_dce.cpp
+++ b/source/opt/vector_dce.cpp
@@ -113,30 +113,44 @@ void VectorDCE::MarkInsertUsesAsLive(
     std::vector<VectorDCE::WorkListItem>* work_list) {
   analysis::DefUseManager* def_use_mgr = context()->get_def_use_mgr();
 
-  uint32_t insert_position =
-      current_item.instruction->GetSingleWordInOperand(2);
+  if (current_item.instruction->NumInOperands() > 2) {
+    uint32_t insert_position =
+        current_item.instruction->GetSingleWordInOperand(2);
 
-  // Add the elements of the composite object that are used.
-  uint32_t operand_id =
-      current_item.instruction->GetSingleWordInOperand(kInsertCompositeIdInIdx);
-  Instruction* operand_inst = def_use_mgr->GetDef(operand_id);
+    // Add the elements of the composite object that are used.
+    uint32_t operand_id = current_item.instruction->GetSingleWordInOperand(
+        kInsertCompositeIdInIdx);
+    Instruction* operand_inst = def_use_mgr->GetDef(operand_id);
 
-  WorkListItem new_item;
-  new_item.instruction = operand_inst;
-  new_item.components = current_item.components;
-  new_item.components.Clear(insert_position);
+    WorkListItem new_item;
+    new_item.instruction = operand_inst;
+    new_item.components = current_item.components;
+    new_item.components.Clear(insert_position);
 
-  AddItemToWorkListIfNeeded(new_item, live_components, work_list);
+    AddItemToWorkListIfNeeded(new_item, live_components, work_list);
 
-  // Add the element being inserted if it is used.
-  if (current_item.components.Get(insert_position)) {
-    uint32_t obj_operand_id =
+    // Add the element being inserted if it is used.
+    if (current_item.components.Get(insert_position)) {
+      uint32_t obj_operand_id =
+          current_item.instruction->GetSingleWordInOperand(
+              kInsertObjectIdInIdx);
+      Instruction* obj_operand_inst = def_use_mgr->GetDef(obj_operand_id);
+      WorkListItem new_item_for_obj;
+      new_item_for_obj.instruction = obj_operand_inst;
+      new_item_for_obj.components.Set(0);
+      AddItemToWorkListIfNeeded(new_item_for_obj, live_components, work_list);
+    }
+  } else {
+    // If there are no indices, then this is a copy of the object being
+    // inserted.
+    uint32_t object_id =
         current_item.instruction->GetSingleWordInOperand(kInsertObjectIdInIdx);
-    Instruction* obj_operand_inst = def_use_mgr->GetDef(obj_operand_id);
-    WorkListItem new_item_for_obj;
-    new_item_for_obj.instruction = obj_operand_inst;
-    new_item_for_obj.components.Set(0);
-    AddItemToWorkListIfNeeded(new_item_for_obj, live_components, work_list);
+    Instruction* object_inst = def_use_mgr->GetDef(object_id);
+
+    WorkListItem new_item;
+    new_item.instruction = object_inst;
+    new_item.components = current_item.components;
+    AddItemToWorkListIfNeeded(new_item, live_components, work_list);
   }
 }
 
@@ -324,6 +338,17 @@ bool VectorDCE::RewriteInsertInstruction(
     Instruction* current_inst, const utils::BitVector& live_components) {
   // If the value being inserted is not live, then we can skip the insert.
   bool modified = false;
+
+  if (current_inst->NumInOperands() == 2) {
+    // If there are no indices, then this is the same as a copy.
+    modified = true;
+    context()->KillNamesAndDecorates(current_inst->result_id());
+    uint32_t object_id =
+        current_inst->GetSingleWordInOperand(kInsertObjectIdInIdx);
+    context()->ReplaceAllUsesWith(current_inst->result_id(), object_id);
+    return modified;
+  }
+
   uint32_t insert_index = current_inst->GetSingleWordInOperand(2);
   if (!live_components.Get(insert_index)) {
     modified = true;
@@ -331,6 +356,7 @@ bool VectorDCE::RewriteInsertInstruction(
     uint32_t composite_id =
         current_inst->GetSingleWordInOperand(kInsertCompositeIdInIdx);
     context()->ReplaceAllUsesWith(current_inst->result_id(), composite_id);
+    return modified;
   }
 
   // If the values already in the composite are not used, then replace it with

--- a/test/opt/vector_dce_test.cpp
+++ b/test/opt/vector_dce_test.cpp
@@ -574,7 +574,7 @@ OpFunctionEnd
 )";
 
   SinglePassRunAndCheck<VectorDCE>(before_predefs + before,
-                                            after_predefs + after, true, true);
+                                   after_predefs + after, true, true);
 }
 
 TEST_F(VectorDCETest, InsertObjectLive) {

--- a/test/opt/vector_dce_test.cpp
+++ b/test/opt/vector_dce_test.cpp
@@ -490,6 +490,7 @@ OpDecorate %OutColor Location 0
 %_ptr_Output_v4float = OpTypePointer Output %v4float
 %OutColor = OpVariable %_ptr_Output_v4float Output
 %27 = OpUndef %v4float
+%55 = OpUndef %v4float
 )";
 
   const std::string before =
@@ -536,25 +537,31 @@ OpFunctionEnd
       R"(%main = OpFunction %void None %10
 %28 = OpLabel
 %29 = OpLoad %v4float %In0
+%30 = OpLoad %float %In1
+%31 = OpLoad %float %In2
+%32 = OpFAdd %float %30 %31
+%33 = OpCompositeInsert %v4float %32 %29 1
 %34 = OpAccessChain %_ptr_Uniform_uint %_ %int_0
 %35 = OpLoad %uint %34
 %36 = OpINotEqual %bool %35 %uint_0
 OpSelectionMerge %37 None
 OpBranchConditional %36 %38 %37
 %38 = OpLabel
-%39 = OpCompositeInsert %v4float %float_1 %29 0
+%39 = OpCompositeInsert %v4float %float_1 %55 0
 OpBranch %37
 %37 = OpLabel
 %40 = OpPhi %v4float %29 %28 %39 %38
 %41 = OpCompositeExtract %float %40 0
-%42 = OpCompositeInsert %v4float %41 %27 0
+%42 = OpCompositeInsert %v4float %41 %55 0
+%43 = OpCompositeExtract %float %40 1
+%44 = OpCompositeInsert %v4float %43 %42 1
 %45 = OpAccessChain %_ptr_Uniform_uint %_ %int_1
 %46 = OpLoad %uint %45
 %47 = OpINotEqual %bool %46 %uint_0
 OpSelectionMerge %48 None
 OpBranchConditional %47 %49 %48
 %49 = OpLabel
-%50 = OpCompositeInsert %v4float %float_0 %42 0
+%50 = OpCompositeInsert %v4float %float_0 %55 0
 OpBranch %48
 %48 = OpLabel
 %51 = OpPhi %v4float %42 %37 %50 %49
@@ -566,7 +573,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<DeadInsertElimPass>(before_predefs + before,
+  SinglePassRunAndCheck<VectorDCE>(before_predefs + before,
                                             after_predefs + after, true, true);
 }
 
@@ -608,7 +615,7 @@ OpFunctionEnd
 )";
 
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
-  SinglePassRunAndCheck<DeadInsertElimPass>(before, before, true, true);
+  SinglePassRunAndCheck<VectorDCE>(before, before, true, true);
 }
 
 TEST_F(VectorDCETest, DeadInsertInCycle) {
@@ -1148,7 +1155,39 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndCheck<DeadInsertElimPass>(text, text, true, true);
+  SinglePassRunAndCheck<VectorDCE>(text, text, true, true);
+}
+
+TEST_F(VectorDCETest, InsertWithNoIndices) {
+  const std::string text = R"(
+; CHECK: OpEntryPoint Fragment {{%\w+}} "PSMain" [[in1:%\w+]] [[in2:%\w+]] [[out:%\w+]]
+; CHECK: OpFunction
+; CHECK: [[ld:%\w+]] = OpLoad %v4float [[in2]]
+; CHECK: OpStore [[out]] [[ld]]
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %1 "PSMain" %2 %14 %3
+               OpExecutionMode %1 OriginUpperLeft
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+          %2 = OpVariable %_ptr_Input_v4float Input
+          %14 = OpVariable %_ptr_Input_v4float Input
+          %3 = OpVariable %_ptr_Output_v4float Output
+          %1 = OpFunction %void None %5
+         %10 = OpLabel
+         %13 = OpLoad %v4float %14
+         %11 = OpLoad %v4float %2
+         %12 = OpCompositeInsert %v4float %13 %11
+               OpStore %3 %12
+               OpReturn
+               OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<VectorDCE>(text, true);
 }
 
 }  // namespace


### PR DESCRIPTION
In the spec, there it nothing that forces an OpCompositeInsert to have
an index, but VDCE assumes there is at least 1 in a couple places.

This commit updates VDCE to handle these cases.