### PR TITLE
Broader check for ids that require a type

### DIFF
--- a/source/val/validate_id.cpp
+++ b/source/val/validate_id.cpp
@@ -171,6 +171,16 @@ spv_result_t IdPass(ValidationState_t& _, Instruction* inst) {
             return _.diag(SPV_ERROR_INVALID_ID, inst)
                    << "Operand " << _.getIdName(operand_word)
                    << " cannot be a type";
+          } else if (def->type_id() == 0 && !spvOpcodeGeneratesType(opcode) &&
+                     !spvOpcodeIsDebug(opcode) &&
+                     !spvOpcodeIsDecoration(opcode) &&
+                     !spvOpcodeIsBranch(opcode) && opcode != SpvOpPhi &&
+                     opcode != SpvOpExtInst && opcode != SpvOpExtInstImport &&
+                     opcode != SpvOpSelectionMerge &&
+                     opcode != SpvOpLoopMerge && opcode != SpvOpFunction) {
+            return _.diag(SPV_ERROR_INVALID_ID, inst)
+                   << "Operand " << _.getIdName(operand_word)
+                   << " requires a type";
           } else {
             ret = SPV_SUCCESS;
           }

--- a/test/val/val_composites_test.cpp
+++ b/test/val/val_composites_test.cpp
@@ -1480,7 +1480,7 @@ OpMemoryModel Logical GLSL450
 %v4float_0 = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
 %func = OpFunction %void None %void_fn
 %1 = OpLabel
-%ex = OpVectorExtractDynamic %float %v4float_0 %1
+%ex = OpVectorExtractDynamic %float %v4float_0 %v4float_0
 OpReturn
 OpFunctionEnd
 )";

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -2904,7 +2904,7 @@ TEST_F(ValidateIdWithMessage, OpStoreLabel) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpStore Object <id> '7[%7]' is not an object."));
+              HasSubstr("Operand 7[%7] requires a type"));
 }
 
 // TODO: enable when this bug is fixed:
@@ -3124,13 +3124,13 @@ TEST_F(ValidateIdWithMessage, OpCopyMemorySizedTargetBad) {
 %7 = OpTypeFunction %1
 %8 = OpFunction %1 None %7
 %9 = OpLabel
-     OpCopyMemorySized %9 %6 %5 None
+     OpCopyMemorySized %5 %5 %5 None
      OpReturn
      OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Target operand <id> '9[%9]' is not a pointer."));
+              HasSubstr("Target operand <id> '5[%uint_4]' is not a pointer."));
 }
 TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSourceBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -5002,8 +5002,7 @@ TEST_F(ValidateIdWithMessage, OpReturnValueIsLabel) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpReturnValue Value <id> '5[%5]' does not represent a "
-                        "value."));
+              HasSubstr("Operand 5[%5] requires a type"));
 }
 
 TEST_F(ValidateIdWithMessage, OpReturnValueIsVoid) {

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -1513,6 +1513,29 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
 }
 
+TEST_F(ValidateMemory, ArrayLengthStructIsLabel) {
+  const std::string spirv = R"(
+OpCapability Tessellation
+OpMemoryModel Logical GLSL450
+%void = OpTypeVoid
+%3 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%v4float = OpTypeVector %float 4
+%uint = OpTypeInt 32 0
+%4 = OpFunction %void None %3
+%20 = OpLabel
+%24 = OpArrayLength %uint %20 0
+%25 = OpLoad %v4float %24
+OpReturnValue %25
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand 7[%7] requires a type"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -1517,6 +1517,7 @@ TEST_F(ValidateMemory, ArrayLengthStructIsLabel) {
   const std::string spirv = R"(
 OpCapability Tessellation
 OpMemoryModel Logical GLSL450
+OpName %20 "incorrect"
 %void = OpTypeVoid
 %3 = OpTypeFunction %void
 %float = OpTypeFloat 32
@@ -1533,7 +1534,7 @@ OpFunctionEnd
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand 7[%7] requires a type"));
+              HasSubstr("Operand 1[%incorrect] requires a type"));
 }
 
 }  // namespace


### PR DESCRIPTION
Fixes https://crbug.com/911700

* Adds a broader check for when id operands require a type
* updated a few tests
* added a test to catch the original issue

I'm not certain whether this check is too complicated in this location, but it does catch a large class of errors at a single location.