### PR TITLE
Fix leaks in tests

### DIFF
--- a/test/binary_parse_test.cpp
+++ b/test/binary_parse_test.cpp
@@ -197,6 +197,8 @@ ParsedInstruction MakeParsedInt32TypeInstruction(uint32_t result_id) {
 
 class BinaryParseTest : public spvtest::TextToBinaryTestBase<::testing::Test> {
  protected:
+  ~BinaryParseTest() { spvDiagnosticDestroy(diagnostic_); }
+
   void Parse(const SpirvVector& words, spv_result_t expected_result,
              bool flip_words = false) {
     SpirvVector flipped_words(words);

--- a/test/ext_inst.glsl_test.cpp
+++ b/test/ext_inst.glsl_test.cpp
@@ -61,7 +61,7 @@ OpFunctionEnd
 ; Generator: Khronos SPIR-V Tools Assembler; 0
 ; Bound: 9
 ; Schema: 0)";
-  spv_binary binary;
+  spv_binary binary = nullptr;
   spv_diagnostic diagnostic;
   spv_result_t error = spvTextToBinary(context, spirv.c_str(), spirv.size(),
                                        &binary, &diagnostic);
@@ -102,6 +102,7 @@ OpFunctionEnd
   }
   EXPECT_EQ(spirv_header + spirv, output_text->str);
   spvTextDestroy(output_text);
+  spvBinaryDestroy(binary);
   spvContextDestroy(context);
 }
 

--- a/test/test_fixture.h
+++ b/test/test_fixture.h
@@ -61,6 +61,8 @@ class TextToBinaryTestBase : public T {
   // compilation success. Returns the compiled code.
   SpirvVector CompileSuccessfully(const std::string& txt,
                                   spv_target_env env = SPV_ENV_UNIVERSAL_1_0) {
+    DestroyBinary();
+    DestroyDiagnostic();
     spv_result_t status =
         spvTextToBinary(ScopedContext(env).context, txt.c_str(), txt.size(),
                         &binary, &diagnostic);
@@ -79,6 +81,8 @@ class TextToBinaryTestBase : public T {
   // Returns the error message(s).
   std::string CompileFailure(const std::string& txt,
                              spv_target_env env = SPV_ENV_UNIVERSAL_1_0) {
+    DestroyBinary();
+    DestroyDiagnostic();
     EXPECT_NE(SPV_SUCCESS,
               spvTextToBinary(ScopedContext(env).context, txt.c_str(),
                               txt.size(), &binary, &diagnostic))
@@ -94,6 +98,7 @@ class TextToBinaryTestBase : public T {
       uint32_t disassemble_options = SPV_BINARY_TO_TEXT_OPTION_NONE,
       spv_target_env env = SPV_ENV_UNIVERSAL_1_0) {
     DestroyBinary();
+    DestroyDiagnostic();
     ScopedContext context(env);
     disassemble_options |= SPV_BINARY_TO_TEXT_OPTION_NO_HEADER;
     spv_result_t error = spvTextToBinary(context.context, txt.c_str(),
@@ -126,6 +131,8 @@ class TextToBinaryTestBase : public T {
   // Returns the error message.
   std::string EncodeSuccessfullyDecodeFailed(
       const std::string& txt, const SpirvVector& words_to_append) {
+    DestroyBinary();
+    DestroyDiagnostic();
     SpirvVector code =
         spvtest::Concatenate({CompileSuccessfully(txt), words_to_append});
 
@@ -167,6 +174,12 @@ class TextToBinaryTestBase : public T {
   void DestroyBinary() {
     spvBinaryDestroy(binary);
     binary = nullptr;
+  }
+
+  // Destroys the diagnostic, if it exists.
+  void DestroyDiagnostic() {
+    spvDiagnosticDestroy(diagnostic);
+    diagnostic = nullptr;
   }
 
   spv_diagnostic diagnostic;

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -780,6 +780,8 @@ class OpTypeArrayLengthTest
   // Runs spvValidate() on v, printing any errors via spvDiagnosticPrint().
   spv_result_t Val(const SpirvVector& v, const std::string& expected_err = "") {
     spv_const_binary_t cbinary{v.data(), v.size()};
+    spvDiagnosticDestroy(diagnostic_);
+    diagnostic_ = nullptr;
     const auto status =
         spvValidate(ScopedContext().context, &cbinary, &diagnostic_);
     if (status != SPV_SUCCESS) {


### PR DESCRIPTION
Fixes all but 1 leak in test_spirv_unit_tests

Generally, a test fixture in a method that can generatea a binary
should release any previously cached binary.  Similarly for diagnostics.