### PR TITLE
Fix memory leak in unrolling.

### DIFF
--- a/source/opt/loop_descriptor.cpp
+++ b/source/opt/loop_descriptor.cpp
@@ -937,22 +937,23 @@ void LoopDescriptor::PostModificationCleanup() {
 
   for (Loop* loop : loops_to_remove_) {
     loops_.erase(std::find(loops_.begin(), loops_.end(), loop));
+    delete loop;
   }
 
   for (auto& pair : loops_to_add_) {
     Loop* parent = pair.first;
-    Loop* loop = pair.second;
+    std::unique_ptr<Loop> loop = std::move(pair.second);
 
     if (parent) {
       loop->SetParent(nullptr);
-      parent->AddNestedLoop(loop);
+      parent->AddNestedLoop(loop.get());
 
       for (uint32_t block_id : loop->GetBlocks()) {
         parent->AddBasicBlock(block_id);
       }
     }
 
-    loops_.emplace_back(loop);
+    loops_.emplace_back(loop.release());
   }
 
   loops_to_add_.clear();

--- a/source/opt/loop_descriptor.h
+++ b/source/opt/loop_descriptor.h
@@ -499,8 +499,8 @@ class LoopDescriptor {
 
   // Mark the loop |loop_to_add| as needing to be added when the user calls
   // PostModificationCleanup. |parent| may be null.
-  inline void AddLoop(Loop* loop_to_add, Loop* parent) {
-    loops_to_add_.emplace_back(std::make_pair(parent, loop_to_add));
+  inline void AddLoop(std::unique_ptr<Loop>&& loop_to_add, Loop* parent) {
+    loops_to_add_.emplace_back(std::make_pair(parent, std::move(loop_to_add)));
   }
 
   // Checks all loops in |this| and will create pre-headers for all loops
@@ -537,7 +537,9 @@ class LoopDescriptor {
   // TODO(dneto): This should be a vector of unique_ptr.  But VisualStudio 2013
   // is unable to compile it.
   using LoopContainerType = std::vector<Loop*>;
-  using LoopsToAddContainerType = std::vector<std::pair<Loop*, Loop*>>;
+
+  using LoopsToAddContainerType =
+      std::vector<std::pair<Loop*, std::unique_ptr<Loop>>>;
 
   // Creates loop descriptors for the function |f|.
   void PopulateList(IRContext* context, const Function* f);

--- a/test/opt/pass_manager_test.cpp
+++ b/test/opt/pass_manager_test.cpp
@@ -107,8 +107,7 @@ class DuplicateInstPass : public Pass {
  public:
   const char* name() const override { return "DuplicateInst"; }
   Status Process() override {
-    auto inst =
-        MakeUnique<Instruction>(*(--context()->debug1_end())->Clone(context()));
+    auto inst = MakeUnique<Instruction>(*(--context()->debug1_end()));
     context()->AddDebug1Inst(std::move(inst));
     return Status::SuccessWithChange;
   }
@@ -121,21 +120,21 @@ TEST_F(PassManagerTest, Run) {
 
   AddPass<AppendOpNopPass>();
   AddPass<AppendOpNopPass>();
-  RunAndCheck(text.c_str(), (text + "OpNop\nOpNop\n").c_str());
+  RunAndCheck(text, text + "OpNop\nOpNop\n");
 
   RenewPassManger();
   AddPass<AppendOpNopPass>();
   AddPass<DuplicateInstPass>();
-  RunAndCheck(text.c_str(), (text + "OpNop\nOpNop\n").c_str());
+  RunAndCheck(text, text + "OpNop\nOpNop\n");
 
   RenewPassManger();
   AddPass<DuplicateInstPass>();
   AddPass<AppendOpNopPass>();
-  RunAndCheck(text.c_str(), (text + "OpSource ESSL 310\nOpNop\n").c_str());
+  RunAndCheck(text, text + "OpSource ESSL 310\nOpNop\n");
 
   RenewPassManger();
   AddPass<AppendMultipleOpNopPass>(3);
-  RunAndCheck(text.c_str(), (text + "OpNop\nOpNop\nOpNop\n").c_str());
+  RunAndCheck(text, text + "OpNop\nOpNop\nOpNop\n");
 }
 
 // A pass that appends an OpTypeVoid instruction that uses a given id.

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -478,8 +478,11 @@ OptStatus ParseOconfigFlag(const char* prog_name, const char* opt_flag,
     new_argv[i] = flags[i].c_str();
   }
 
-  return ParseFlags(static_cast<int>(flags.size()), new_argv, optimizer,
-                    in_file, out_file, validator_options, optimizer_options);
+  auto ret_val =
+      ParseFlags(static_cast<int>(flags.size()), new_argv, optimizer, in_file,
+                 out_file, validator_options, optimizer_options);
+  delete[] new_argv;
+  return ret_val;
 }
 
 // Canonicalize the flag in |argv[argi]| of the form '--pass arg' into
@@ -659,7 +662,6 @@ int main(int argc, const char** argv) {
   const char* out_file = nullptr;
 
   spv_target_env target_env = kDefaultEnvironment;
-
 
   spvtools::Optimizer optimizer(target_env);
   optimizer.SetMessageConsumer(spvtools::utils::CLIMessageConsumer);


### PR DESCRIPTION
During unrolling a new loop is created, but its ownership is not clear
as it gets passed through the code.  Changed something to unique_ptr to
make that clearer.

Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/2299.
Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/2296
Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/2297