### PR TITLE
Fix Constants Analyses bug inserted by #2302

### DIFF
--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -89,6 +89,11 @@ void IRContext::InvalidateAnalysesExceptFor(
 }
 
 void IRContext::InvalidateAnalyses(IRContext::Analysis analyses_to_invalidate) {
+  // The ConstantManager contains Type pointers. If the TypeManager goes
+  // away, the ConstantManager has to go away.
+  if (analyses_to_invalidate & kAnalysisTypes) {
+    analyses_to_invalidate |= kAnalysisConstants;
+  }
   if (analyses_to_invalidate & kAnalysisDefUse) {
     def_use_mgr_.reset(nullptr);
   }
@@ -127,9 +132,6 @@ void IRContext::InvalidateAnalyses(IRContext::Analysis analyses_to_invalidate) {
     constant_mgr_.reset(nullptr);
   }
   if (analyses_to_invalidate & kAnalysisTypes) {
-    // The ConstantManager contains Type pointers. If the TypeManager goes
-    // away, the ConstantManager has to go away.
-    constant_mgr_.reset(nullptr);
     type_mgr_.reset(nullptr);
   }
 


### PR DESCRIPTION
Invalidate ConstantsManager when invalidating TypeManager since ConstantsManager contains pointers into TypeManager. But... also need to also remove Constants from the valid_analyses set when
invalidating, otherwise Constants is not reinitialized before used the next time.

Note that #2303 does not create a new bug. It just makes a partial (and thus ineffective) fix. It deletes an invalid ConstantsManager but then doesn't remove it from the valid_analyses set, so it doesn't get reinitialized before use, so following passes still get a bad ConstantsManager, although empty rather than invalid.