### PR TITLE
Handle instructions not in blocks in code sinking.

### DIFF
--- a/source/opt/code_sink.cpp
+++ b/source/opt/code_sink.cpp
@@ -80,7 +80,10 @@ BasicBlock* CodeSinkingPass::FindNewBasicBlockFor(Instruction* inst) {
   get_def_use_mgr()->ForEachUse(
       inst, [&bbs_with_uses, this](Instruction* use, uint32_t idx) {
         if (use->opcode() != SpvOpPhi) {
-          bbs_with_uses.insert(context()->get_instr_block(use)->id());
+          BasicBlock* use_bb = context()->get_instr_block(use);
+          if (use_bb) {
+            bbs_with_uses.insert(use_bb->id());
+          }
         } else {
           bbs_with_uses.insert(use->GetSingleWordOperand(idx + 1));
         }

--- a/test/opt/code_sink_test.cpp
+++ b/test/opt/code_sink_test.cpp
@@ -528,6 +528,30 @@ TEST_F(CodeSinkTest, MoveWithAtomicWithoutSync) {
   EXPECT_EQ(Pass::Status::SuccessWithChange, std::get<1>(result));
 }
 
+TEST_F(CodeSinkTest, DecorationOnLoad) {
+  const std::string text = R"(
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %1 "main" %2
+               OpDecorate %3 RelaxedPrecision
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+%_ptr_Input_float = OpTypePointer Input %float
+          %2 = OpVariable %_ptr_Input_float Input
+          %1 = OpFunction %void None %5
+          %8 = OpLabel
+          %3 = OpLoad %float %2
+               OpReturn
+               OpFunctionEnd
+)";
+
+  // We just want to make sure the code does not crash.
+  auto result = SinglePassRunAndDisassemble<CodeSinkingPass>(
+      text, /* skip_nop = */ true, /* do_validation = */ true);
+  EXPECT_EQ(Pass::Status::SuccessWithoutChange, std::get<1>(result));
+}
+
 }  // namespace
 }  // namespace opt
 }  // namespace spvtools


### PR DESCRIPTION
When looking at the uses of the result of an instruction, code sinking
assumes that all uses are in a basic block.  However, this is not true
if there is a decoration or name for the result of that insturction.
This commit checks for this.

Fixes https://crbug.com/923243.