### PR TITLE
Request for comment: extracting useful functionality from block merger to be reused by reducer

### DIFF
--- a/source/opt/block_merge_pass.cpp
+++ b/source/opt/block_merge_pass.cpp
@@ -24,104 +24,118 @@
 namespace spvtools {
 namespace opt {
 
+bool BlockMergePass::canMergeWithSuccessor(IRContext* context, BasicBlock *block) {
+  // Find block with single successor which has no other predecessors.
+  auto ii = block->end();
+  --ii;
+  Instruction* br = &*ii;
+  if (br->opcode() != SpvOpBranch) {
+    return false;
+  }
+
+  const uint32_t lab_id = br->GetSingleWordInOperand(0);
+  if (context->cfg()->preds(lab_id).size() != 1) {
+    return false;
+  }
+
+  bool pred_is_merge = IsMerge(context, block);
+  bool succ_is_merge = IsMerge(context, lab_id);
+  if (pred_is_merge && succ_is_merge) {
+    // Cannot merge two merges together.
+    return false;
+  }
+
+  Instruction* merge_inst = block->GetMergeInst();
+  const bool pred_is_header = IsHeader(block);
+  if (pred_is_header && lab_id != merge_inst->GetSingleWordInOperand(0u)) {
+    bool succ_is_header = IsHeader(context, lab_id);
+    if (pred_is_header && succ_is_header) {
+      // Cannot merge two headers together when the successor is not the merge
+      // block of the predecessor.
+      return false;
+    }
+
+    // If this is a header block and the successor is not its merge, we must
+    // be careful about which blocks we are willing to merge together.
+    // OpLoopMerge must be followed by a conditional or unconditional branch.
+    // The merge must be a loop merge because a selection merge cannot be
+    // followed by an unconditional branch.
+    BasicBlock* succ_block = context->get_instr_block(lab_id);
+    SpvOp succ_term_op = succ_block->terminator()->opcode();
+    assert(merge_inst->opcode() == SpvOpLoopMerge);
+    if (succ_term_op != SpvOpBranch &&
+        succ_term_op != SpvOpBranchConditional) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void BlockMergePass::mergeWithSuccessor(IRContext* context, Function* func, Function::iterator bi) {
+  auto ii = bi->end();
+  --ii;
+  Instruction *br = &*ii;
+  const uint32_t lab_id = br->GetSingleWordInOperand(0);
+  Instruction *merge_inst = bi->GetMergeInst();
+  bool pred_is_header = IsHeader(&*bi);
+
+  // Merge blocks.
+  context->KillInst(br);
+  auto sbi = bi;
+  for (; sbi != func->end(); ++sbi)
+    if (sbi->id() == lab_id) break;
+  // If bi is sbi's only predecessor, it dominates sbi and thus
+  // sbi must follow bi in func's ordering.
+  assert(sbi != func->end());
+
+  // Update the inst-to-block mapping for the instructions in sbi.
+  for (auto &inst : *sbi) {
+    context->set_instr_block(&inst, &*bi);
+  }
+
+  // Now actually move the instructions.
+  bi->AddInstructions(&*sbi);
+
+  if (merge_inst) {
+    if (pred_is_header && lab_id == merge_inst->GetSingleWordInOperand(0u)) {
+      // Merging the header and merge blocks, so remove the structured control
+      // flow declaration.
+      context->KillInst(merge_inst);
+    } else {
+      // Move the merge instruction to just before the terminator.
+      merge_inst->InsertBefore(bi->terminator());
+    }
+  }
+  context->ReplaceAllUsesWith(lab_id, bi->id());
+  context->KillInst(sbi->GetLabelInst());
+  (void) sbi.Erase();
+}
+
 bool BlockMergePass::MergeBlocks(Function* func) {
   bool modified = false;
   for (auto bi = func->begin(); bi != func->end();) {
-    // Find block with single successor which has no other predecessors.
-    auto ii = bi->end();
-    --ii;
-    Instruction* br = &*ii;
-    if (br->opcode() != SpvOpBranch) {
+
+    if (canMergeWithSuccessor(context(), &*bi)) {
+      mergeWithSuccessor(context(), func, bi);
+      // Reprocess block.
+      modified = true;
+    } else {
       ++bi;
-      continue;
     }
-
-    const uint32_t lab_id = br->GetSingleWordInOperand(0);
-    if (cfg()->preds(lab_id).size() != 1) {
-      ++bi;
-      continue;
-    }
-
-    bool pred_is_merge = IsMerge(&*bi);
-    bool succ_is_merge = IsMerge(lab_id);
-    if (pred_is_merge && succ_is_merge) {
-      // Cannot merge two merges together.
-      ++bi;
-      continue;
-    }
-
-    Instruction* merge_inst = bi->GetMergeInst();
-    bool pred_is_header = IsHeader(&*bi);
-    if (pred_is_header && lab_id != merge_inst->GetSingleWordInOperand(0u)) {
-      bool succ_is_header = IsHeader(lab_id);
-      if (pred_is_header && succ_is_header) {
-        // Cannot merge two headers together when the successor is not the merge
-        // block of the predecessor.
-        ++bi;
-        continue;
-      }
-
-      // If this is a header block and the successor is not its merge, we must
-      // be careful about which blocks we are willing to merge together.
-      // OpLoopMerge must be followed by a conditional or unconditional branch.
-      // The merge must be a loop merge because a selection merge cannot be
-      // followed by an unconditional branch.
-      BasicBlock* succ_block = context()->get_instr_block(lab_id);
-      SpvOp succ_term_op = succ_block->terminator()->opcode();
-      assert(merge_inst->opcode() == SpvOpLoopMerge);
-      if (succ_term_op != SpvOpBranch &&
-          succ_term_op != SpvOpBranchConditional) {
-        ++bi;
-        continue;
-      }
-    }
-
-    // Merge blocks.
-    context()->KillInst(br);
-    auto sbi = bi;
-    for (; sbi != func->end(); ++sbi)
-      if (sbi->id() == lab_id) break;
-    // If bi is sbi's only predecessor, it dominates sbi and thus
-    // sbi must follow bi in func's ordering.
-    assert(sbi != func->end());
-
-    // Update the inst-to-block mapping for the instructions in sbi.
-    for (auto& inst : *sbi) {
-      context()->set_instr_block(&inst, &*bi);
-    }
-
-    // Now actually move the instructions.
-    bi->AddInstructions(&*sbi);
-
-    if (merge_inst) {
-      if (pred_is_header && lab_id == merge_inst->GetSingleWordInOperand(0u)) {
-        // Merging the header and merge blocks, so remove the structured control
-        // flow declaration.
-        context()->KillInst(merge_inst);
-      } else {
-        // Move the merge instruction to just before the terminator.
-        merge_inst->InsertBefore(bi->terminator());
-      }
-    }
-    context()->ReplaceAllUsesWith(lab_id, bi->id());
-    context()->KillInst(sbi->GetLabelInst());
-    (void)sbi.Erase();
-    // Reprocess block.
-    modified = true;
   }
   return modified;
+}
+
+bool BlockMergePass::IsHeader(IRContext* context, uint32_t id) {
+  return IsHeader(context->get_instr_block(context->get_def_use_mgr()->GetDef(id)));
 }
 
 bool BlockMergePass::IsHeader(BasicBlock* block) {
   return block->GetMergeInst() != nullptr;
 }
 
-bool BlockMergePass::IsHeader(uint32_t id) {
-  return IsHeader(context()->get_instr_block(get_def_use_mgr()->GetDef(id)));
-}
-
-bool BlockMergePass::IsMerge(uint32_t id) {
-  return !get_def_use_mgr()->WhileEachUse(id, [](Instruction* user,
+bool BlockMergePass::IsMerge(IRContext* context, uint32_t id) {
+  return !context->get_def_use_mgr()->WhileEachUse(id, [](Instruction* user,
                                                  uint32_t index) {
     SpvOp op = user->opcode();
     if ((op == SpvOpLoopMerge || op == SpvOpSelectionMerge) && index == 0u) {
@@ -131,7 +145,7 @@ bool BlockMergePass::IsMerge(uint32_t id) {
   });
 }
 
-bool BlockMergePass::IsMerge(BasicBlock* block) { return IsMerge(block->id()); }
+bool BlockMergePass::IsMerge(IRContext* context, BasicBlock* block) { return IsMerge(context, block->id()); }
 
 Pass::Status BlockMergePass::Process() {
   // Process all entry point functions.

--- a/source/opt/block_merge_pass.h
+++ b/source/opt/block_merge_pass.h
@@ -48,6 +48,10 @@ class BlockMergePass : public Pass {
            IRContext::kAnalysisTypes;
   }
 
+  static bool canMergeWithSuccessor(IRContext* context, BasicBlock *block);
+
+  static void mergeWithSuccessor(IRContext* context, Function* func, Function::iterator bi);
+
  private:
 
   // Search |func| for blocks which have a single Branch to a block
@@ -55,13 +59,14 @@ class BlockMergePass : public Pass {
   bool MergeBlocks(Function* func);
 
   // Returns true if |block| (or |id|) contains a merge instruction.
-  bool IsHeader(BasicBlock* block);
-  bool IsHeader(uint32_t id);
+  static bool IsHeader(BasicBlock* block);
+  static bool IsHeader(IRContext* context, uint32_t id);
 
   // Returns true if |block| (or |id|) is the merge target of a merge
   // instruction.
-  bool IsMerge(BasicBlock* block);
-  bool IsMerge(uint32_t id);
+  static bool IsMerge(IRContext* context, BasicBlock* block);
+  static bool IsMerge(IRContext* context, uint32_t id);
+
 };
 
 }  // namespace opt


### PR DESCRIPTION
I'm opening this PR to start a discussion on how best to expose bits of functionality provided by the optimizer for use in the reducer.

The reducer should be able to try merging blocks.  It doesn't want to merge *all* blocks, as doing so might make the property of interest go away, so we'd like to be able to try mergeable pairs.

Here I have extracted the two key bits of functionality - checking whether a block can be merged with its successor, and actually merging a block with its successor - and made them public static methods of the block merger.  The reducer could then invoke them directly.  The price for this is that the block merger has to call these static methods and pass in its IRContext.

What do folks think of this approach in general (as there will be many other cases where the reducer could re-use analyses provided by the optimizer)?  It certainly seems better than redundantly reimplementing the same functionality in the reducer, but makes the reducer appear to depend on particular optimization pass classes, when really it just depends on helper functions associated with those passes.