### PR TITLE
Add SpirvTools::IsValid().

### DIFF
--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -235,6 +235,9 @@ class SpirvTools {
   bool Validate(const uint32_t* binary, size_t binary_size,
                 spv_validator_options options) const;
 
+  // Was this object successfully constructed.
+  bool IsValid() const;
+
  private:
   struct Impl;  // Opaque struct for holding the data fields used by this class.
   std::unique_ptr<Impl> impl_;  // Unique pointer to implementation data.

--- a/source/libspirv.cpp
+++ b/source/libspirv.cpp
@@ -128,8 +128,6 @@ bool SpirvTools::Validate(const uint32_t* binary, const size_t binary_size,
   return valid;
 }
 
-bool SpirvTools::IsValid() const {
-  return impl_->context != nullptr;
-}
+bool SpirvTools::IsValid() const { return impl_->context != nullptr; }
 
 }  // namespace spvtools

--- a/source/libspirv.cpp
+++ b/source/libspirv.cpp
@@ -128,4 +128,8 @@ bool SpirvTools::Validate(const uint32_t* binary, const size_t binary_size,
   return valid;
 }
 
+bool SpirvTools::IsValid() const {
+  return impl_->context != nullptr;
+}
+
 }  // namespace spvtools


### PR DESCRIPTION
Add a method to determine if a SpirvTools object was successfully
constructed and can be used.  It might not be depending on the parameter
to the constructor.
This is something a fuzzer wants to know before trying to use an
SpirvTools object constructed with a fuzzed parameter.