### PR TITLE
Remove the static maps from CheckDecorationsCompatibility

### DIFF
--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -1017,14 +1017,14 @@ spv_result_t CheckDecorationsCompatibility(ValidationState_t& vstate) {
   // to the same id.
   static const SpvDecoration mutually_exclusive_per_id[][2] = {
       {SpvDecorationBlock, SpvDecorationBufferBlock}};
-  static const uint32_t num_mutually_exclusive_per_id_pairs =
+  static const auto num_mutually_exclusive_per_id_pairs =
       sizeof(mutually_exclusive_per_id) / (2 * sizeof(SpvDecoration));
 
   // An Array of pairs where the decorations in the pair cannot both be applied
   // to the same member.
   static const SpvDecoration mutually_exclusive_per_member[][2] = {
       {SpvDecorationRowMajor, SpvDecorationColMajor}};
-  static const uint32_t num_mutually_exclusive_per_mem_pairs =
+  static const auto num_mutually_exclusive_per_mem_pairs =
       sizeof(mutually_exclusive_per_member) / (2 * sizeof(SpvDecoration));
 
   std::set<PerIDKey> seen_per_id;


### PR DESCRIPTION
There are a few data structures in the function
`CheckDecorationsCompatibility` that are allocated using `new` and their
address is stored in a static pointer.  This code pattern causes the
MSVC memory leak checker to say there is a memory leak.  Some people
are interested in keeping that clean.

To work around it, I have replaced them with either a function or an
array of POD types.  The array can be kept as a static directly because
it has a trivial destructor, and we don't have to worry about it being
destroyed too early.

Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/2317.