### PR TITLE
Remove code sinking for -O.

### DIFF
--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -182,8 +182,7 @@ Optimizer& Optimizer::RegisterPerformancePasses() {
       .RegisterPass(CreateRedundancyEliminationPass())
       .RegisterPass(CreateDeadBranchElimPass())
       .RegisterPass(CreateBlockMergePass())
-      .RegisterPass(CreateSimplificationPass())
-      .RegisterPass(CreateCodeSinkingPass());
+      .RegisterPass(CreateSimplificationPass());
   // Currently exposing driver bugs resulting in crashes (#946)
   // .RegisterPass(CreateCommonUniformElimPass())
 }


### PR DESCRIPTION
Community feedback says it is not generaly benificial, so we will remove
it from the standard optimization set.