### PR TITLE
Fix test_val_limits MSVC build

### DIFF
--- a/test/val/CMakeLists.txt
+++ b/test/val/CMakeLists.txt
@@ -48,6 +48,7 @@ add_spvtools_unittest(TARGET val_limits
   SRCS val_limits_test.cpp
        ${VAL_TEST_COMMON_SRCS}
   LIBS ${SPIRV_TOOLS}
+  PCH_FILE pch_test_val
 )
 
 add_spvtools_unittest(TARGET val_ijklmnop


### PR DESCRIPTION
Now that there are source files in VAL_TEST_COMMON_SRCS, MSVC expects the same PCH settings for all uses of such a source file. So enable PCH for test_val_limits.
