### PR TITLE
Allow arrayed storage images for NonWritable decoration

### DIFF
--- a/source/val/validate_type.cpp
+++ b/source/val/validate_type.cpp
@@ -262,17 +262,22 @@ spv_result_t ValidateTypeStruct(ValidationState_t& _, const Instruction* inst) {
 
 spv_result_t ValidateTypePointer(ValidationState_t& _,
                                  const Instruction* inst) {
-  const auto type_id = inst->GetOperandAs<uint32_t>(2);
-  const auto type = _.FindDef(type_id);
+  auto type_id = inst->GetOperandAs<uint32_t>(2);
+  auto type = _.FindDef(type_id);
   if (!type || !spvOpcodeGeneratesType(type->opcode())) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
            << "OpTypePointer Type <id> '" << _.getIdName(type_id)
            << "' is not a type.";
   }
   // See if this points to a storage image.
-  if (type->opcode() == SpvOpTypeImage) {
-    const auto storage_class = inst->GetOperandAs<uint32_t>(1);
-    if (storage_class == SpvStorageClassUniformConstant) {
+  const auto storage_class = inst->GetOperandAs<SpvStorageClass>(1);
+  if (storage_class == SpvStorageClassUniformConstant) {
+    // Unpack an optional level of arraying.
+    if (type->opcode() == SpvOpTypeArray) {
+      type_id = type->GetOperandAs<uint32_t>(1);
+      type = _.FindDef(type_id);
+    }
+    if (type->opcode() == SpvOpTypeImage) {
       const auto sampled = type->GetOperandAs<uint32_t>(6);
       // 2 indicates this image is known to be be used without a sampler, i.e.
       // a storage image.

--- a/source/val/validate_type.cpp
+++ b/source/val/validate_type.cpp
@@ -273,7 +273,8 @@ spv_result_t ValidateTypePointer(ValidationState_t& _,
   const auto storage_class = inst->GetOperandAs<SpvStorageClass>(1);
   if (storage_class == SpvStorageClassUniformConstant) {
     // Unpack an optional level of arraying.
-    if (type->opcode() == SpvOpTypeArray) {
+    if (type->opcode() == SpvOpTypeArray ||
+        type->opcode() == SpvOpTypeRuntimeArray) {
       type_id = type->GetOperandAs<uint32_t>(1);
       type = _.FindDef(type_id);
     }

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -5517,6 +5517,8 @@ std::string ShaderWithNonWritableTarget(const std::string& target,
 
   return std::string(R"(
             OpCapability Shader
+            OpCapability RuntimeDescriptorArrayEXT
+            OpExtension "SPV_EXT_descriptor_indexing"
             OpExtension "SPV_KHR_storage_buffer_storage_class"
             OpMemoryModel Logical GLSL450
             OpEntryPoint Vertex %main "main"
@@ -5558,6 +5560,7 @@ std::string ShaderWithNonWritableTarget(const std::string& target,
  ; sampled image
  %imsam = OpTypeImage %float 2D 0 0 0 1 R32f
 %array_imstor = OpTypeArray %imstor %int_2
+%rta_imstor = OpTypeRuntimeArray %imstor
 
 %_ptr_Uniform_stb        = OpTypePointer Uniform %struct_b
 %_ptr_Uniform_stbb       = OpTypePointer Uniform %struct_bb
@@ -5569,6 +5572,7 @@ std::string ShaderWithNonWritableTarget(const std::string& target,
 %_ptr_imstor             = OpTypePointer UniformConstant %imstor
 %_ptr_imsam              = OpTypePointer UniformConstant %imsam
 %_ptr_array_imstor       = OpTypePointer UniformConstant %array_imstor
+%_ptr_rta_imstor         = OpTypePointer UniformConstant %rta_imstor
 
 %extra_fn = OpTypeFunction %void %float %_ptr_Private %_ptr_imstor
 
@@ -5581,6 +5585,7 @@ std::string ShaderWithNonWritableTarget(const std::string& target,
 %var_imstor = OpVariable %_ptr_imstor UniformConstant
 %var_imsam = OpVariable %_ptr_imsam UniformConstant
 %var_array_imstor = OpVariable %_ptr_array_imstor UniformConstant
+%var_rta_imstor = OpVariable %_ptr_rta_imstor UniformConstant
 
   %helper = OpFunction %void None %extra_fn
  %param_f = OpFunctionParameter %float
@@ -5761,6 +5766,13 @@ TEST_F(ValidateDecorations, NonWritableVarFunctionBad) {
 
 TEST_F(ValidateDecorations, NonWritableArrayGood) {
   std::string spirv = ShaderWithNonWritableTarget("%var_array_imstor");
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateDecorations, NonWritableRuntimeArrayGood) {
+  std::string spirv = ShaderWithNonWritableTarget("%var_rta_imstor");
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -5546,6 +5546,8 @@ std::string ShaderWithNonWritableTarget(const std::string& target,
    %void_fn = OpTypeFunction %void
      %float = OpTypeFloat 32
    %float_0 = OpConstant %float 0
+   %int     = OpTypeInt 32 0
+   %int_2   = OpConstant %int 2
   %struct_b = OpTypeStruct %float
  %struct_bb = OpTypeStruct %float
  %rtarr = OpTypeRuntimeArray %float
@@ -5555,6 +5557,7 @@ std::string ShaderWithNonWritableTarget(const std::string& target,
  %imstor = OpTypeImage %float 2D 0 0 0 2 R32f
  ; sampled image
  %imsam = OpTypeImage %float 2D 0 0 0 1 R32f
+%array_imstor = OpTypeArray %imstor %int_2
 
 %_ptr_Uniform_stb        = OpTypePointer Uniform %struct_b
 %_ptr_Uniform_stbb       = OpTypePointer Uniform %struct_bb
@@ -5565,6 +5568,7 @@ std::string ShaderWithNonWritableTarget(const std::string& target,
 %_ptr_Function           = OpTypePointer Function %float
 %_ptr_imstor             = OpTypePointer UniformConstant %imstor
 %_ptr_imsam              = OpTypePointer UniformConstant %imsam
+%_ptr_array_imstor       = OpTypePointer UniformConstant %array_imstor
 
 %extra_fn = OpTypeFunction %void %float %_ptr_Private %_ptr_imstor
 
@@ -5576,6 +5580,7 @@ std::string ShaderWithNonWritableTarget(const std::string& target,
 %var_priv = OpVariable %_ptr_Private Private
 %var_imstor = OpVariable %_ptr_imstor UniformConstant
 %var_imsam = OpVariable %_ptr_imsam UniformConstant
+%var_array_imstor = OpVariable %_ptr_array_imstor UniformConstant
 
   %helper = OpFunction %void None %extra_fn
  %param_f = OpFunctionParameter %float
@@ -5752,6 +5757,13 @@ TEST_F(ValidateDecorations, NonWritableVarFunctionBad) {
               HasSubstr("Target of NonWritable decoration is invalid: must "
                         "point to a storage image, uniform block, or storage "
                         "buffer\n  %var_func"));
+}
+
+TEST_F(ValidateDecorations, NonWritableArrayGood) {
+  std::string spirv = ShaderWithNonWritableTarget("%var_array_imstor");
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
 TEST_P(ValidateWebGPUCombineDecorationResult, Decorate) {


### PR DESCRIPTION
Fixes #2354

* Storage image pointer registration allows optional level of arraying
* Added a test

FYI @alegal-arm