### PR TITLE
Make spvParseTargetEnv public

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -445,6 +445,10 @@ typedef enum {
 // Returns a string describing the given SPIR-V target environment.
 SPIRV_TOOLS_EXPORT const char* spvTargetEnvDescription(spv_target_env env);
 
+// Parses s into *env and returns true if successful.  If unparsable, returns
+// false and sets *env to SPV_ENV_UNIVERSAL_1_0.
+SPIRV_TOOLS_EXPORT bool spvParseTargetEnv(const char* s, spv_target_env* env);
+
 // Creates a context object.  Returns null if env is invalid.
 SPIRV_TOOLS_EXPORT spv_context spvContextCreate(spv_target_env env);
 

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -57,8 +57,8 @@ Optimizer::PassToken::~PassToken() {}
 struct Optimizer::Impl {
   explicit Impl(spv_target_env env) : target_env(env), pass_manager() {}
 
-  spv_target_env target_env;        // Target environment.
-  opt::PassManager pass_manager;    // Internal implementation pass manager.
+  spv_target_env target_env;      // Target environment.
+  opt::PassManager pass_manager;  // Internal implementation pass manager.
 };
 
 Optimizer::Optimizer(spv_target_env env) : impl_(new Impl(env)) {}

--- a/source/spirv_target_env.h
+++ b/source/spirv_target_env.h
@@ -19,10 +19,6 @@
 
 #include "spirv-tools/libspirv.h"
 
-// Parses s into *env and returns true if successful.  If unparsable, returns
-// false and sets *env to SPV_ENV_UNIVERSAL_1_0.
-bool spvParseTargetEnv(const char* s, spv_target_env* env);
-
 // Returns true if |env| is a VULKAN environment, false otherwise.
 bool spvIsVulkanEnv(spv_target_env env);
 


### PR DESCRIPTION
This CL moves the method to parse the SPIRV environment into the public headers. This will allow other applications to re-use the same parsing logic.