### PR TITLE
Fix BUILD.gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -305,7 +305,6 @@ source_set("spvtools_headers") {
 
 static_library("spvtools") {
   deps = [
-    ":spvtools_core_enums_unified1",
     ":spvtools_core_tables_unified1",
     ":spvtools_generators_inc",
     ":spvtools_glsl_tables_glsl1-0",
@@ -376,6 +375,7 @@ static_library("spvtools") {
   ]
 
   public_deps = [
+    ":spvtools_core_enums_unified1",
     ":spvtools_headers",
   ]
 


### PR DESCRIPTION
extensions_enum.inc is included from source/table.h.
So spvtools_core_enums_unified1 target generating the header should be in public_deps of
spvtools target.

See reference for more detail of rule.
https://gn.googlesource.com/gn/+/master/docs/reference.md#var_public_deps

This is for crbug.com/931596