### PR TITLE
 OpAtomicLoad, OpAtomicStore, OpAtomicExchange can operate on int or float value. Except for Vulkan environment that only operates on int value.

### DIFF
--- a/source/val/validate_atomics.cpp
+++ b/source/val/validate_atomics.cpp
@@ -55,8 +55,7 @@ spv_result_t AtomicsPass(ValidationState_t& _, const Instruction* inst) {
       if (_.HasCapability(SpvCapabilityKernel) &&
           (opcode == SpvOpAtomicLoad || opcode == SpvOpAtomicExchange ||
            opcode == SpvOpAtomicCompareExchange)) {
-        if (!(_.IsFloatScalarType(result_type) &&
-              !spvIsVulkanEnv(_.context()->target_env)) &&
+        if (!_.IsFloatScalarType(result_type) &&
             !_.IsIntScalarType(result_type)) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << spvOpcodeString(opcode)

--- a/source/val/validate_atomics.cpp
+++ b/source/val/validate_atomics.cpp
@@ -56,7 +56,7 @@ spv_result_t AtomicsPass(ValidationState_t& _, const Instruction* inst) {
           (opcode == SpvOpAtomicLoad || opcode == SpvOpAtomicExchange ||
            opcode == SpvOpAtomicCompareExchange)) {
         if (!(_.IsFloatScalarType(result_type) &&
-          !spvIsVulkanEnv(_.context()->target_env)) &&
+              !spvIsVulkanEnv(_.context()->target_env)) &&
             !_.IsIntScalarType(result_type)) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << spvOpcodeString(opcode)

--- a/source/val/validate_atomics.cpp
+++ b/source/val/validate_atomics.cpp
@@ -55,7 +55,8 @@ spv_result_t AtomicsPass(ValidationState_t& _, const Instruction* inst) {
       if (_.HasCapability(SpvCapabilityKernel) &&
           (opcode == SpvOpAtomicLoad || opcode == SpvOpAtomicExchange ||
            opcode == SpvOpAtomicCompareExchange)) {
-        if (!_.IsFloatScalarType(result_type) &&
+        if (!(_.IsFloatScalarType(result_type) &&
+          !spvIsVulkanEnv(_.context()->target_env)) &&
             !_.IsIntScalarType(result_type)) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << spvOpcodeString(opcode)

--- a/test/val/val_atomics_test.cpp
+++ b/test/val/val_atomics_test.cpp
@@ -245,7 +245,7 @@ TEST_F(ValidateAtomics, AtomicLoadFloatVulkan) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("expected Result Type to be int scalar type"));
+      HasSubstr("expected Result Type to be int scalar type));
 }
 
 TEST_F(ValidateAtomics, AtomicLoadVulkanSuccess) {

--- a/test/val/val_atomics_test.cpp
+++ b/test/val/val_atomics_test.cpp
@@ -225,6 +225,29 @@ TEST_F(ValidateAtomics, AtomicLoadKernelSuccess) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
+TEST_F(ValidateAtomics, AtomicLoadFloatNotVulkanSuccess) {
+  const std::string body = R"(
+%val1 = OpAtomicLoad %f32 %f32_var %device %relaxed
+%val2 = OpAtomicLoad %f32 %f32_var %workgroup %acquire
+)";
+
+  CompileSuccessfully(GenerateKernelCode(body));
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateAtomics, AtomicLoadFloatVulkan) {
+  const std::string body = R"(
+%val1 = OpAtomicLoad %f32 %f32_var %device %relaxed
+%val2 = OpAtomicLoad %f32 %f32_var %workgroup %acquire
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body), SPV_ENV_VULKAN_1_0);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("expected Result Type to be int scalar type"));
+}
+
 TEST_F(ValidateAtomics, AtomicLoadVulkanSuccess) {
   const std::string body = R"(
 %val1 = OpAtomicLoad %u32 %u32_var %device %relaxed

--- a/test/val/val_atomics_test.cpp
+++ b/test/val/val_atomics_test.cpp
@@ -243,9 +243,8 @@ TEST_F(ValidateAtomics, AtomicLoadFloatVulkan) {
 
   CompileSuccessfully(GenerateShaderCode(body), SPV_ENV_VULKAN_1_0);
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
-    EXPECT_THAT(
-    getDiagnosticString(),
-    HasSubstr("expected Result Type to be int scalar type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("expected Result Type to be int scalar type"));
 }
 
 TEST_F(ValidateAtomics, AtomicLoadInt64WithCapabilityVulkanSuccess) {


### PR DESCRIPTION
To fix: #2128 
Please review. 