### PR TITLE
Add some val options to reduce

### DIFF
--- a/source/reduce/reducer.cpp
+++ b/source/reduce/reducer.cpp
@@ -69,7 +69,7 @@ Reducer::ReductionResultStatus Reducer::Run(
                       validator_options)) {
     impl_->consumer(SPV_MSG_INFO, nullptr, {},
                     "Initial binary is invalid; stopping.");
-    return Reducer::ReductionResultStatus::kInitialStateNotInteresting;
+    return Reducer::ReductionResultStatus::kInitialStateInvalid;
   }
 
   // Initial state should be interesting.

--- a/source/reduce/reducer.cpp
+++ b/source/reduce/reducer.cpp
@@ -52,14 +52,25 @@ void Reducer::SetInterestingnessFunction(
 }
 
 Reducer::ReductionResultStatus Reducer::Run(
-    std::vector<uint32_t>&& binary_in, std::vector<uint32_t>* binary_out,
+    const std::vector<uint32_t>& binary_in, std::vector<uint32_t>* binary_out,
     spv_const_reducer_options options,
     spv_validator_options validator_options) const {
   std::vector<uint32_t> current_binary = binary_in;
 
+  spvtools::SpirvTools tools(impl_->target_env);
+  assert(tools.IsValid() && "Failed to create SPIRV-Tools interface");
+
   // Keeps track of how many reduction attempts have been tried.  Reduction
   // bails out if this reaches a given limit.
   uint32_t reductions_applied = 0;
+
+  // Initial state should be valid.
+  if (!tools.Validate(&current_binary[0], current_binary.size(),
+                      validator_options)) {
+    impl_->consumer(SPV_MSG_INFO, nullptr, {},
+                    "Initial binary is invalid; stopping.");
+    return Reducer::ReductionResultStatus::kInitialStateNotInteresting;
+  }
 
   // Initial state should be interesting.
   if (!impl_->interestingness_function(current_binary, reductions_applied)) {
@@ -107,9 +118,8 @@ Reducer::ReductionResultStatus Reducer::Run(
                      << reductions_applied << ".";
         impl_->consumer(SPV_MSG_INFO, nullptr, {},
                         (stringstream.str().c_str()));
-        if (!spvtools::SpirvTools(impl_->target_env)
-                 .Validate(&maybe_result[0], maybe_result.size(),
-                           validator_options)) {
+        if (!tools.Validate(&maybe_result[0], maybe_result.size(),
+                            validator_options)) {
           // The reduction step went wrong and an invalid binary was produced.
           // By design, this shouldn't happen; this is a safeguard to stop an
           // invalid binary from being regarded as interesting.

--- a/source/reduce/reducer.cpp
+++ b/source/reduce/reducer.cpp
@@ -53,7 +53,8 @@ void Reducer::SetInterestingnessFunction(
 
 Reducer::ReductionResultStatus Reducer::Run(
     std::vector<uint32_t>&& binary_in, std::vector<uint32_t>* binary_out,
-    spv_const_reducer_options options) const {
+    spv_const_reducer_options options,
+    spv_validator_options validator_options) const {
   std::vector<uint32_t> current_binary = binary_in;
 
   // Keeps track of how many reduction attempts have been tried.  Reduction
@@ -106,7 +107,9 @@ Reducer::ReductionResultStatus Reducer::Run(
                      << reductions_applied << ".";
         impl_->consumer(SPV_MSG_INFO, nullptr, {},
                         (stringstream.str().c_str()));
-        if (!spvtools::SpirvTools(impl_->target_env).Validate(maybe_result)) {
+        if (!spvtools::SpirvTools(impl_->target_env)
+                 .Validate(&maybe_result[0], maybe_result.size(),
+                           validator_options)) {
           // The reduction step went wrong and an invalid binary was produced.
           // By design, this shouldn't happen; this is a safeguard to stop an
           // invalid binary from being regarded as interesting.

--- a/source/reduce/reducer.cpp
+++ b/source/reduce/reducer.cpp
@@ -52,10 +52,10 @@ void Reducer::SetInterestingnessFunction(
 }
 
 Reducer::ReductionResultStatus Reducer::Run(
-    const std::vector<uint32_t>& binary_in, std::vector<uint32_t>* binary_out,
+    std::vector<uint32_t>&& binary_in, std::vector<uint32_t>* binary_out,
     spv_const_reducer_options options,
     spv_validator_options validator_options) const {
-  std::vector<uint32_t> current_binary = binary_in;
+  std::vector<uint32_t> current_binary(std::move(binary_in));
 
   spvtools::SpirvTools tools(impl_->target_env);
   assert(tools.IsValid() && "Failed to create SPIRV-Tools interface");

--- a/source/reduce/reducer.h
+++ b/source/reduce/reducer.h
@@ -82,7 +82,7 @@ class Reducer {
   // Reduces the given SPIR-V module |binary_out|.
   // The reduced binary ends up in |binary_out|.
   // A status is returned.
-  ReductionResultStatus Run(const std::vector<uint32_t>& binary_in,
+  ReductionResultStatus Run(std::vector<uint32_t>&& binary_in,
                             std::vector<uint32_t>* binary_out,
                             spv_const_reducer_options options,
                             spv_validator_options validator_options) const;

--- a/source/reduce/reducer.h
+++ b/source/reduce/reducer.h
@@ -82,7 +82,7 @@ class Reducer {
   // Reduces the given SPIR-V module |binary_out|.
   // The reduced binary ends up in |binary_out|.
   // A status is returned.
-  ReductionResultStatus Run(std::vector<uint32_t>&& binary_in,
+  ReductionResultStatus Run(const std::vector<uint32_t>& binary_in,
                             std::vector<uint32_t>* binary_out,
                             spv_const_reducer_options options,
                             spv_validator_options validator_options) const;

--- a/source/reduce/reducer.h
+++ b/source/reduce/reducer.h
@@ -33,7 +33,8 @@ class Reducer {
   enum ReductionResultStatus {
     kInitialStateNotInteresting,
     kReachedStepLimit,
-    kComplete
+    kComplete,
+    kInitialStateInvalid
   };
 
   // The type for a function that will take a binary and return true if and

--- a/source/reduce/reducer.h
+++ b/source/reduce/reducer.h
@@ -84,7 +84,8 @@ class Reducer {
   // A status is returned.
   ReductionResultStatus Run(std::vector<uint32_t>&& binary_in,
                             std::vector<uint32_t>* binary_out,
-                            spv_const_reducer_options options) const;
+                            spv_const_reducer_options options,
+                            spv_validator_options validator_options) const;
 
  private:
   struct Impl;                  // Opaque struct for holding internal data.

--- a/test/reduce/reducer_test.cpp
+++ b/test/reduce/reducer_test.cpp
@@ -231,8 +231,7 @@ TEST(ReducerTest, ExprToConstantAndRemoveUnreferenced) {
   reducer_options.set_step_limit(500);
   spvtools::ValidatorOptions validator_options;
 
-  reducer.Run(std::move(binary_in), &binary_out, reducer_options,
-              validator_options);
+  reducer.Run(binary_in, &binary_out, reducer_options, validator_options);
 
   CheckEqual(env, expected, binary_out);
 }
@@ -257,7 +256,7 @@ TEST(ReducerTest, RemoveOpnameAndRemoveUnreferenced) {
          %10 = OpLabel
           %3 = OpVariable %8 Function
           %4 = OpLoad %7 %3
-               OpStore %3 %7
+               OpStore %3 %9
                OpReturn
                OpFunctionEnd
   )";
@@ -282,7 +281,7 @@ TEST(ReducerTest, RemoveOpnameAndRemoveUnreferenced) {
 
   spv_target_env env = SPV_ENV_UNIVERSAL_1_3;
   Reducer reducer(env);
-  // Make ping-pong interesting very quickly, as there are not much
+  // Make ping-pong interesting very quickly, as there are not many
   // opportunities.
   PingPongInteresting ping_pong_interesting(1);
   reducer.SetMessageConsumer(NopDiagnostic);
@@ -304,8 +303,10 @@ TEST(ReducerTest, RemoveOpnameAndRemoveUnreferenced) {
   reducer_options.set_step_limit(500);
   spvtools::ValidatorOptions validator_options;
 
-  reducer.Run(std::move(binary_in), &binary_out, reducer_options,
-              validator_options);
+  Reducer::ReductionResultStatus status =
+      reducer.Run(binary_in, &binary_out, reducer_options, validator_options);
+
+  ASSERT_EQ(status, Reducer::ReductionResultStatus::kComplete);
 
   CheckEqual(env, expected, binary_out);
 }

--- a/test/reduce/reducer_test.cpp
+++ b/test/reduce/reducer_test.cpp
@@ -229,8 +229,10 @@ TEST(ReducerTest, ExprToConstantAndRemoveUnreferenced) {
   std::vector<uint32_t> binary_out;
   spvtools::ReducerOptions reducer_options;
   reducer_options.set_step_limit(500);
+  spvtools::ValidatorOptions validator_options;
 
-  reducer.Run(std::move(binary_in), &binary_out, reducer_options);
+  reducer.Run(std::move(binary_in), &binary_out, reducer_options,
+              validator_options);
 
   CheckEqual(env, expected, binary_out);
 }
@@ -300,8 +302,10 @@ TEST(ReducerTest, RemoveOpnameAndRemoveUnreferenced) {
   std::vector<uint32_t> binary_out;
   spvtools::ReducerOptions reducer_options;
   reducer_options.set_step_limit(500);
+  spvtools::ValidatorOptions validator_options;
 
-  reducer.Run(std::move(binary_in), &binary_out, reducer_options);
+  reducer.Run(std::move(binary_in), &binary_out, reducer_options,
+              validator_options);
 
   CheckEqual(env, expected, binary_out);
 }

--- a/test/reduce/reducer_test.cpp
+++ b/test/reduce/reducer_test.cpp
@@ -231,7 +231,10 @@ TEST(ReducerTest, ExprToConstantAndRemoveUnreferenced) {
   reducer_options.set_step_limit(500);
   spvtools::ValidatorOptions validator_options;
 
-  reducer.Run(binary_in, &binary_out, reducer_options, validator_options);
+  Reducer::ReductionResultStatus status = reducer.Run(
+      std::move(binary_in), &binary_out, reducer_options, validator_options);
+
+  ASSERT_EQ(status, Reducer::ReductionResultStatus::kComplete);
 
   CheckEqual(env, expected, binary_out);
 }
@@ -303,8 +306,8 @@ TEST(ReducerTest, RemoveOpnameAndRemoveUnreferenced) {
   reducer_options.set_step_limit(500);
   spvtools::ValidatorOptions validator_options;
 
-  Reducer::ReductionResultStatus status =
-      reducer.Run(binary_in, &binary_out, reducer_options, validator_options);
+  Reducer::ReductionResultStatus status = reducer.Run(
+      std::move(binary_in), &binary_out, reducer_options, validator_options);
 
   ASSERT_EQ(status, Reducer::ReductionResultStatus::kComplete);
 

--- a/test/reduce/validation_during_reduction_test.cpp
+++ b/test/reduce/validation_during_reduction_test.cpp
@@ -530,8 +530,7 @@ TEST(ValidationDuringReductionTest, CheckValidationOptions) {
         reducer.Run(std::vector<uint32_t>(binary_in), &binary_out,
                     reducer_options, validator_options);
 
-    ASSERT_EQ(status,
-              Reducer::ReductionResultStatus::kInitialStateInvalid);
+    ASSERT_EQ(status, Reducer::ReductionResultStatus::kInitialStateInvalid);
   }
 
   // Try again with validator option.

--- a/test/reduce/validation_during_reduction_test.cpp
+++ b/test/reduce/validation_during_reduction_test.cpp
@@ -221,7 +221,10 @@ TEST(ValidationDuringReductionTest, CheckInvalidPassMakesNoProgress) {
   reducer_options.set_step_limit(500);
   spvtools::ValidatorOptions validator_options;
 
-  reducer.Run(binary_in, &binary_out, reducer_options, validator_options);
+  Reducer::ReductionResultStatus status = reducer.Run(
+      std::move(binary_in), &binary_out, reducer_options, validator_options);
+
+  ASSERT_EQ(status, Reducer::ReductionResultStatus::kComplete);
 
   // The reducer should have no impact.
   CheckEqual(env, original, binary_out);
@@ -427,8 +430,11 @@ TEST(ValidationDuringReductionTest, CheckNotAlwaysInvalidCanMakeProgress) {
   reducer_options.set_step_limit(500);
   spvtools::ValidatorOptions validator_options;
 
-  reducer.Run(std::move(binary_in), &binary_out, reducer_options,
-              validator_options);
+  Reducer::ReductionResultStatus status = reducer.Run(
+      std::move(binary_in), &binary_out, reducer_options, validator_options);
+
+  ASSERT_EQ(status, Reducer::ReductionResultStatus::kComplete);
+
   CheckEqual(env, expected, binary_out);
 }
 
@@ -521,7 +527,8 @@ TEST(ValidationDuringReductionTest, CheckValidationOptions) {
     setupReducerForCheckValidationOptions(&reducer);
 
     Reducer::ReductionResultStatus status =
-        reducer.Run(binary_in, &binary_out, reducer_options, validator_options);
+        reducer.Run(std::vector<uint32_t>(binary_in), &binary_out,
+                    reducer_options, validator_options);
 
     ASSERT_EQ(status,
               Reducer::ReductionResultStatus::kInitialStateNotInteresting);
@@ -537,7 +544,8 @@ TEST(ValidationDuringReductionTest, CheckValidationOptions) {
     setupReducerForCheckValidationOptions(&reducer);
 
     Reducer::ReductionResultStatus status =
-        reducer.Run(binary_in, &binary_out, reducer_options, validator_options);
+        reducer.Run(std::vector<uint32_t>(binary_in), &binary_out,
+                    reducer_options, validator_options);
 
     ASSERT_EQ(status, Reducer::ReductionResultStatus::kReachedStepLimit);
   }
@@ -553,7 +561,8 @@ TEST(ValidationDuringReductionTest, CheckValidationOptions) {
     setupReducerForCheckValidationOptions(&reducer);
 
     Reducer::ReductionResultStatus status =
-        reducer.Run(binary_in, &binary_out, reducer_options, validator_options);
+        reducer.Run(std::vector<uint32_t>(binary_in), &binary_out,
+                    reducer_options, validator_options);
 
     ASSERT_EQ(status, Reducer::ReductionResultStatus::kComplete);
   }

--- a/test/reduce/validation_during_reduction_test.cpp
+++ b/test/reduce/validation_during_reduction_test.cpp
@@ -531,7 +531,7 @@ TEST(ValidationDuringReductionTest, CheckValidationOptions) {
                     reducer_options, validator_options);
 
     ASSERT_EQ(status,
-              Reducer::ReductionResultStatus::kInitialStateNotInteresting);
+              Reducer::ReductionResultStatus::kInitialStateInvalid);
   }
 
   // Try again with validator option.

--- a/test/reduce/validation_during_reduction_test.cpp
+++ b/test/reduce/validation_during_reduction_test.cpp
@@ -160,8 +160,10 @@ TEST(ValidationDuringReductionTest, CheckInvalidPassMakesNoProgress) {
   std::vector<uint32_t> binary_out;
   spvtools::ReducerOptions reducer_options;
   reducer_options.set_step_limit(500);
+  spvtools::ValidatorOptions validator_options;
 
-  reducer.Run(std::move(binary_in), &binary_out, reducer_options);
+  reducer.Run(std::move(binary_in), &binary_out, reducer_options,
+              validator_options);
 
   // The reducer should have no impact.
   CheckEqual(env, original, binary_out);
@@ -365,8 +367,10 @@ TEST(ValidationDuringReductionTest, CheckNotAlwaysInvalidCanMakeProgress) {
   std::vector<uint32_t> binary_out;
   spvtools::ReducerOptions reducer_options;
   reducer_options.set_step_limit(500);
+  spvtools::ValidatorOptions validator_options;
 
-  reducer.Run(std::move(binary_in), &binary_out, reducer_options);
+  reducer.Run(std::move(binary_in), &binary_out, reducer_options,
+              validator_options);
   CheckEqual(env, expected, binary_out);
 }
 

--- a/tools/reduce/reduce.cpp
+++ b/tools/reduce/reduce.cpp
@@ -286,8 +286,8 @@ int main(int argc, const char** argv) {
   }
 
   std::vector<uint32_t> binary_out;
-  const auto reduction_status =
-      reducer.Run(binary_in, &binary_out, reducer_options, validator_options);
+  const auto reduction_status = reducer.Run(std::move(binary_in), &binary_out,
+                                            reducer_options, validator_options);
 
   if (reduction_status ==
           Reducer::ReductionResultStatus::kInitialStateNotInteresting ||

--- a/tools/reduce/reduce.cpp
+++ b/tools/reduce/reduce.cpp
@@ -286,8 +286,8 @@ int main(int argc, const char** argv) {
   }
 
   std::vector<uint32_t> binary_out;
-  const auto reduction_status = reducer.Run(std::move(binary_in), &binary_out,
-                                            reducer_options, validator_options);
+  const auto reduction_status =
+      reducer.Run(binary_in, &binary_out, reducer_options, validator_options);
 
   if (reduction_status ==
           Reducer::ReductionResultStatus::kInitialStateNotInteresting ||

--- a/tools/reduce/reduce.cpp
+++ b/tools/reduce/reduce.cpp
@@ -172,9 +172,6 @@ ReduceStatus ParseFlags(int argc, const char** argv, const char** in_file,
       assert(!*interestingness_test);
       *interestingness_test = cur_arg;
       positional_arg_index++;
-
-      // TODO: Refactor. Repeated C++ code for parsing these options. Also
-      // consider removing repeated help text.
     } else if (0 == strcmp(cur_arg, "--relax-logical-pointer")) {
       validator_options->SetRelaxLogicalPointer(true);
     } else if (0 == strcmp(cur_arg, "--relax-block-layout")) {

--- a/tools/reduce/reduce.cpp
+++ b/tools/reduce/reduce.cpp
@@ -111,21 +111,12 @@ Options (in lexicographical order):
   --version
                Display reducer version information.
 
-Supported validator options:
-  --relax-logical-pointer          Allow allocating an object of a pointer type and returning
-                                   a pointer value from a function in logical addressing mode
-  --relax-block-layout             Enable VK_KHR_relaxed_block_layout when checking standard
-                                   uniform, storage buffer, and push constant layouts.
-                                   This is the default when targeting Vulkan 1.1 or later.
-  --scalar-block-layout            Enable VK_EXT_scalar_block_layout when checking standard
-                                   uniform, storage buffer, and push constant layouts.  Scalar layout
-                                   rules are more permissive than relaxed block layout so in effect
-                                   this will override the --relax-block-layout option.
-  --skip-block-layout              Skip checking standard uniform/storage buffer layout.
-                                   Overrides any --relax-block-layout or --scalar-block-layout option.
-  --relax-struct-store             Allow store from one struct type to a
-                                   different type with compatible layout and
-                                   members.
+Supported validator options are as follows. See `spirv-val --help` for details.
+  --relax-logical-pointer
+  --relax-block-layout
+  --scalar-block-layout
+  --skip-block-layout
+  --relax-struct-store
 )",
       program, program);
 }


### PR DESCRIPTION
Fix #2396 

* Change Reducer::Run to *not* immediately copy the input binary.
* Check that initial shader is valid.
* Fix RemoveOpnameAndRemoveUnreferenced test; turns out the original shader is invalid, but we never notice because we don't check this and the reduced shader is valid; fix original shader. Assert reduction status is kComplete.
* Always check return value from `Reducer::Run`.
