### PR TITLE
Fixed undefined reference to 'clock_gettime' by linking rt library

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -361,6 +361,14 @@ target_compile_definitions(${SPIRV_TOOLS}-shared
 )
 add_dependencies( ${SPIRV_TOOLS}-shared core_tables enum_string_mapping extinst_tables )
 
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+  find_library(LIBRT rt)
+  if(LIBRT)
+    target_link_libraries(${SPIRV_TOOLS} ${LIBRT})
+    target_link_libraries(${SPIRV_TOOLS}-shared ${LIBRT})
+  endif()
+endif()
+
 if(ENABLE_SPIRV_TOOLS_INSTALL)
   install(TARGETS ${SPIRV_TOOLS} ${SPIRV_TOOLS}-shared
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
On CentOS6.8 with a local build of g++ 6.4.0 (the default g++ version on CentOS6.8 is 4.4.7), the build fails with undefined reference to 'clock_gettime'.

Linking ${SPIRV_TOOLS} and ${SPIRV_TOOLS}-shared against the rt library fixed the issue.
