### PR TITLE
Don't change type of input and output var in dead member elim

### DIFF
--- a/source/opt/eliminate_dead_members_pass.h
+++ b/source/opt/eliminate_dead_members_pass.h
@@ -137,6 +137,7 @@ class EliminateDeadMembersPass : public MemPass {
   // type that are used, and must be kept.
   std::unordered_map<uint32_t, std::set<uint32_t>> used_members_;
   void MarkStructOperandsAsFullyUsed(const Instruction* inst);
+  void MarkPointeeTypeAsFullUsed(uint32_t ptr_type_id);
 };
 
 }  // namespace opt


### PR DESCRIPTION
The types of input and output variables must match for the pipeline.  We
cannot see the uses in all of the shader, so dead member
elimination cannot safely change the type of input and output variables.