### PR TITLE
Non memory object as parameters.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,7 @@ if(NOT COMMAND find_host_program)
   endmacro()
 endif()
 
-find_host_package(PythonInterp)
+find_host_package(PythonInterp 2.7 REQUIRED)
 
 # Check for symbol exports on Linux.
 # At the moment, this check will fail on the OSX build machines for the Android NDK.

--- a/source/val/validate_function.cpp
+++ b/source/val/validate_function.cpp
@@ -253,7 +253,8 @@ spv_result_t ValidateFunctionCall(ValidationState_t& _,
     }
 
     if (_.addressing_model() == SpvAddressingModelLogical) {
-      if (parameter_type->opcode() == SpvOpTypePointer) {
+      if (parameter_type->opcode() == SpvOpTypePointer &&
+          !_.options()->relax_logical_pointer) {
         SpvStorageClass sc = parameter_type->GetOperandAs<SpvStorageClass>(1u);
         // Validate which storage classes can be pointer operands.
         switch (sc) {


### PR DESCRIPTION
In relaxed addressing mode, we want to accept non memory objects
because this is a very natural translation of hlsl.  It should be fixed
by legalization by inlining the calls.

A sample hlsl code that generates this code pattern is:

```
struct S {
  float fn_1() { return 0.0; }
};

struct T {
  S s;
};

float main() : A {
  T t;
  t.s.fn_1();
  return 0.0;
}
➜  dxc cat t.hlsl
struct S {
  float fn_1() { return 0.0; }
};

struct T {
  S s;
};

float main() : A {
  T t;
  t.s.fn_1();
  return 0.0;
}
```