### PR TITLE
Allow NonWritable to target struct members.

### DIFF
--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -1269,17 +1269,6 @@ spv_result_t CheckNonWritableDecoration(ValidationState_t& vstate,
              << "Target of NonWritable decoration is invalid: must point to a "
                 "storage image, uniform block, or storage buffer";
     }
-  } else {
-    // The target is a struct member.  The annotations pass already checks that
-    // it is a structure.  So now fall through to ensure that the structure is
-    // used as a UBO or SSBO.
-    const auto type_id = inst.id();
-    if (!vstate.IsStructForUniformBlock(type_id) &&
-        !vstate.IsStructForStorageBuffer(type_id)) {
-      return vstate.diag(SPV_ERROR_INVALID_ID, &inst)
-             << "Target of NonWritable member decoration is invalid: must be "
-                "the struct type of a uniform block or storage buffer";
-    }
   }
 
   return SPV_SUCCESS;

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -5743,7 +5743,7 @@ std::string ShaderWithNonWritableTarget(const std::string& target,
             OpName %var_imsam "var_imsam"
             OpName %var_priv "var_priv"
             OpName %var_func "var_func"
-            OpName %struct_bad "struct_bad"
+            OpName %simple_struct "simple_struct"
 
             OpDecorate %struct_b Block
             OpDecorate %struct_bb BufferBlock
@@ -5766,7 +5766,7 @@ std::string ShaderWithNonWritableTarget(const std::string& target,
  %struct_bb = OpTypeStruct %float
  %rtarr = OpTypeRuntimeArray %float
 %struct_b_rtarr = OpTypeStruct %rtarr
-%struct_bad = OpTypeStruct %float
+%simple_struct = OpTypeStruct %float
  ; storage image
  %imstor = OpTypeImage %float 2D 0 0 0 2 R32f
  ; sampled image
@@ -5932,15 +5932,11 @@ TEST_F(ValidateDecorations, NonWritableMemberOfSsboInStorageBufferGood) {
   EXPECT_THAT(getDiagnosticString(), Eq(""));
 }
 
-TEST_F(ValidateDecorations, NonWritableMemberOfNonBlockStructBad) {
-  std::string spirv = ShaderWithNonWritableTarget("%struct_bad", true);
+TEST_F(ValidateDecorations, NonWritableMemberOfStructGood) {
+  std::string spirv = ShaderWithNonWritableTarget("%simple_struct", true);
 
   CompileSuccessfully(spirv);
-  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Target of NonWritable member decoration is invalid: must be "
-                "the struct type of a uniform block or storage buffer"));
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
 TEST_F(ValidateDecorations, NonWritableVarWorkgroupBad) {


### PR DESCRIPTION
It should be allowed for the `NonWritable` decoration to be applied to
structure type members.