### PR TITLE
Add required tools.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,7 @@ if(NOT COMMAND find_host_program)
   endmacro()
 endif()
 
-find_host_package(PythonInterp 2.7 REQUIRED)
+find_host_package(PythonInterp 2 EXACT REQUIRED)
 
 # Check for symbol exports on Linux.
 # At the moment, this check will fail on the OSX build machines for the Android NDK.

--- a/README.md
+++ b/README.md
@@ -269,6 +269,30 @@ cmake [-G <platform-generator>] <spirv-dir>
 Once the build files have been generated, build using your preferred
 development environment.
 
+### Tools you'll need
+
+For building and testing SPIRV-Tools, the following tools should be
+installed regardless of your OS:
+
+- [CMake](http://www.cmake.org/): for generating compilation targets.  Version
+  2.8.12 or later.
+- [Python 2](http://www.python.org/): for utility scripts and running the test suite.
+
+SPIRV-Tools is regularly tests with the the following compilers:
+
+On Linux
+- GCC version 4.8.5
+- Clang version 3.8
+
+On MacOS
+- AppleClang 10.0
+
+On Windows
+- Visual Studio 2015
+- Visual Studio 2017
+
+Other compilers or later versions may work, but they are not tested.
+
 ### CMake options
 
 The following CMake options are supported:


### PR DESCRIPTION
We added a section to the readme to mention the tools that are needed to
build and test spirv-tools.  For the compiler, the compilers used by the
bots are mentioned.

The CMakeFile is changed to search specifically for python2, since we
have python scripts that cannot be run using python3.