### PR TITLE
Validator: no Storage comparison for pointer param

### DIFF
--- a/source/val/validate_function.cpp
+++ b/source/val/validate_function.cpp
@@ -24,6 +24,17 @@ namespace spvtools {
 namespace val {
 namespace {
 
+// Returns true if |a| and |b| are instruction defining pointers that point to
+// the same type.
+bool ArePointersToSameType(val::Instruction* a, val::Instruction* b) {
+  if (a->opcode() != SpvOpTypePointer || b->opcode() != SpvOpTypePointer) {
+    return false;
+  }
+
+  uint32_t a_type = a->GetOperandAs<uint32_t>(2);
+  return a_type && (a_type == b->GetOperandAs<uint32_t>(2));
+}
+
 spv_result_t ValidateFunction(ValidationState_t& _, const Instruction* inst) {
   const auto function_type_id = inst->GetOperandAs<uint32_t>(3);
   const auto function_type = _.FindDef(function_type_id);
@@ -245,7 +256,10 @@ spv_result_t ValidateFunctionCall(ValidationState_t& _,
     const auto parameter_type_id =
         function_type->GetOperandAs<uint32_t>(param_index);
     const auto parameter_type = _.FindDef(parameter_type_id);
-    if (!parameter_type || argument_type->id() != parameter_type->id()) {
+    if (!parameter_type ||
+        (argument_type->id() != parameter_type->id() &&
+         !(_.options()->relax_logical_pointer &&
+           ArePointersToSameType(argument_type, parameter_type)))) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
              << "OpFunctionCall Argument <id> '" << _.getIdName(argument_id)
              << "'s type does not match Function <id> '"

--- a/test/val/val_storage_test.cpp
+++ b/test/val/val_storage_test.cpp
@@ -186,6 +186,65 @@ TEST_F(ValidateStorage, GenericVariableInsideFunction) {
               HasSubstr("OpVariable storage class cannot be Generic"));
 }
 
+TEST_F(ValidateStorage, RelaxedLogicalPointerFunctionParam) {
+  const auto str = R"(
+          OpCapability Shader
+          OpCapability Linkage
+          OpMemoryModel Logical GLSL450
+%intt   = OpTypeInt 32 1
+%voidt  = OpTypeVoid
+%ptrt   = OpTypePointer Function %intt
+%vfunct = OpTypeFunction %voidt
+%vifunct = OpTypeFunction %voidt %ptrt
+%wgroupptrt = OpTypePointer Workgroup %intt
+%wgroup = OpVariable %wgroupptrt Workgroup
+%main   = OpFunction %voidt None %vfunct
+%mainl  = OpLabel
+%ret    = OpFunctionCall %voidt %func %wgroup
+          OpReturn
+          OpFunctionEnd
+%func   = OpFunction %voidt None %vifunct
+%arg    = OpFunctionParameter %ptrt
+%funcl  = OpLabel
+          OpReturn
+          OpFunctionEnd
+)";
+  CompileSuccessfully(str);
+  getValidatorOptions()->relax_logical_pointer = true;
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateStorage, RelaxedLogicalPointerFunctionParamBad) {
+  const auto str = R"(
+          OpCapability Shader
+          OpCapability Linkage
+          OpMemoryModel Logical GLSL450
+%floatt = OpTypeFloat 32
+%intt   = OpTypeInt 32 1
+%voidt  = OpTypeVoid
+%ptrt   = OpTypePointer Function %intt
+%vfunct = OpTypeFunction %voidt
+%vifunct = OpTypeFunction %voidt %ptrt
+%wgroupptrt = OpTypePointer Workgroup %floatt
+%wgroup = OpVariable %wgroupptrt Workgroup
+%main   = OpFunction %voidt None %vfunct
+%mainl  = OpLabel
+%ret    = OpFunctionCall %voidt %func %wgroup
+          OpReturn
+          OpFunctionEnd
+%func   = OpFunction %voidt None %vifunct
+%arg    = OpFunctionParameter %ptrt
+%funcl  = OpLabel
+          OpReturn
+          OpFunctionEnd
+)";
+  CompileSuccessfully(str);
+  getValidatorOptions()->relax_logical_pointer = true;
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpFunctionCall Argument <id> '"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
DXC changed its policy and now, for variables with Workgroup Storage
Class, DXC passes it directly to functions instead of creating
temporal variables with Function Storage Class.
If relax-logical-pointer is enabled, Validator must consider
variables whose pointer types are the same except Storage Class
as variables with the same type.

Related to #2423