### PR TITLE
Repair test for unused storage buffer with descriptor

### DIFF
--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -3023,6 +3023,8 @@ TEST_F(ValidateDecorations,
             OpMemoryModel Logical GLSL450
             OpEntryPoint Fragment %1 "main"
             OpExecutionMode %1 OriginUpperLeft
+            OpDecorate %struct Block
+            OpMemberDecorate %struct 0 Offset 0
 
     %void = OpTypeVoid
   %voidfn = OpTypeFunction %void


### PR DESCRIPTION
Fixes two things:
- struct needed layout decorations.  It never had them
- use Block decoration, rather than BufferBlock that was removed in
  #2380