### PR TITLE
Convert sampled consumers to being Instructions instead of IDs

### DIFF
--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -800,10 +800,9 @@ spv_result_t ValidateSampledImage(ValidationState_t& _,
   // to OpPhi instructions or OpSelect instructions, or any instructions other
   // than the image lookup and query instructions specified to take an operand
   // whose type is OpTypeSampledImage.
-  std::vector<uint32_t> consumers = _.getSampledImageConsumers(inst->id());
+  std::vector<Instruction*> consumers = _.getSampledImageConsumers(inst->id());
   if (!consumers.empty()) {
-    for (auto consumer_id : consumers) {
-      const auto consumer_instr = _.FindDef(consumer_id);
+    for (auto consumer_instr : consumers) {
       const auto consumer_opcode = consumer_instr->opcode();
       if (consumer_instr->block() != inst->block()) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
@@ -814,7 +813,7 @@ spv_result_t ValidateSampledImage(ValidationState_t& _,
                << _.getIdName(inst->id())
                << "' has a consumer in a different basic "
                   "block. The consumer instruction <id> is '"
-               << _.getIdName(consumer_id) << "'.";
+               << _.getIdName(consumer_instr->id()) << "'.";
       }
       // TODO: The following check is incomplete. We should also check that the
       // Sampled Image is not used by instructions that should not take
@@ -828,8 +827,8 @@ spv_result_t ValidateSampledImage(ValidationState_t& _,
                   "operands of Op"
                << spvOpcodeString(static_cast<SpvOp>(consumer_opcode)) << "."
                << " Found result <id> '" << _.getIdName(inst->id())
-               << "' as an operand of <id> '" << _.getIdName(consumer_id)
-               << "'.";
+               << "' as an operand of <id> '"
+               << _.getIdName(consumer_instr->id()) << "'.";
       }
     }
   }

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -540,15 +540,15 @@ void ValidationState_t::RegisterInstruction(Instruction* inst) {
       const uint32_t operand_word = inst->word(operand.offset);
       Instruction* operand_inst = FindDef(operand_word);
       if (operand_inst && SpvOpSampledImage == operand_inst->opcode()) {
-        RegisterSampledImageConsumer(operand_word, inst->id());
+        RegisterSampledImageConsumer(operand_word, inst);
       }
     }
   }
 }
 
-std::vector<uint32_t> ValidationState_t::getSampledImageConsumers(
+std::vector<Instruction*> ValidationState_t::getSampledImageConsumers(
     uint32_t sampled_image_id) const {
-  std::vector<uint32_t> result;
+  std::vector<Instruction*> result;
   auto iter = sampled_image_consumers_.find(sampled_image_id);
   if (iter != sampled_image_consumers_.end()) {
     result = iter->second;
@@ -557,8 +557,8 @@ std::vector<uint32_t> ValidationState_t::getSampledImageConsumers(
 }
 
 void ValidationState_t::RegisterSampledImageConsumer(uint32_t sampled_image_id,
-                                                     uint32_t consumer_id) {
-  sampled_image_consumers_[sampled_image_id].push_back(consumer_id);
+                                                     Instruction* consumer) {
+  sampled_image_consumers_[sampled_image_id].push_back(consumer);
 }
 
 uint32_t ValidationState_t::getIdBound() const { return id_bound_; }

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -432,13 +432,13 @@ class ValidationState_t {
     return all_definitions_;
   }
 
-  /// Returns a vector containing the Ids of instructions that consume the given
+  /// Returns a vector containing the instructions that consume the given
   /// SampledImage id.
-  std::vector<uint32_t> getSampledImageConsumers(uint32_t id) const;
+  std::vector<Instruction*> getSampledImageConsumers(uint32_t id) const;
 
   /// Records cons_id as a consumer of sampled_image_id.
   void RegisterSampledImageConsumer(uint32_t sampled_image_id,
-                                    uint32_t cons_id);
+                                    Instruction* consumer);
 
   /// Returns the set of Global Variables.
   std::unordered_set<uint32_t>& global_vars() { return global_vars_; }
@@ -684,7 +684,8 @@ class ValidationState_t {
 
   /// Stores a vector of instructions that use the result of a given
   /// OpSampledImage instruction.
-  std::unordered_map<uint32_t, std::vector<uint32_t>> sampled_image_consumers_;
+  std::unordered_map<uint32_t, std::vector<Instruction*>>
+      sampled_image_consumers_;
 
   /// A map of operand IDs and their names defined by the OpName instruction
   std::unordered_map<uint32_t, std::string> operand_names_;

--- a/test/val/val_image_test.cpp
+++ b/test/val/val_image_test.cpp
@@ -4452,7 +4452,7 @@ OpExtension "SPV_KHR_vulkan_memory_model"
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
 }
 
-// This used to cause a seg fault on OpReturnValue, verifying it doesn't
+// This example used to cause a seg fault on OpReturnValue, verifying it doesn't
 // anymore.
 TEST_F(ValidateImage, Issue2463NoSegFault) {
   const std::string spirv = R"(

--- a/test/val/val_image_test.cpp
+++ b/test/val/val_image_test.cpp
@@ -4452,6 +4452,38 @@ OpExtension "SPV_KHR_vulkan_memory_model"
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
 }
 
+// This used to cause a seg fault on OpReturnValue, verifying it doesn't
+// anymore.
+TEST_F(ValidateImage, Issue2463NoSegFault) {
+  const std::string spirv = R"(
+               OpCapability Linkage
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+       %void = OpTypeVoid
+          %6 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+          %8 = OpTypeImage %float 3D 0 0 0 1 Unknown
+%_ptr_UniformConstant_8 = OpTypePointer UniformConstant %8
+         %10 = OpTypeSampler
+%_ptr_UniformConstant_10 = OpTypePointer UniformConstant %10
+         %12 = OpTypeSampledImage %8
+         %13 = OpTypeFunction %12 %_ptr_UniformConstant_8 %_ptr_UniformConstant_10
+         %23 = OpFunction %12 None %13
+         %24 = OpFunctionParameter %_ptr_UniformConstant_8
+         %25 = OpFunctionParameter %_ptr_UniformConstant_10
+         %26 = OpLabel
+         %27 = OpLoad %8 %24
+         %28 = OpLoad %10 %25
+         %29 = OpSampledImage %12 %27 %28
+               OpReturnValue %29
+               OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv);
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
Changing the stored value for a sampled image consumer to be the
instruction instead of result ID, since not all instructions have
result IDs. Using result IDs led to a potential crash when using
OpReturnValue, which doesn't have a result ID. OpReturnValue is not a
legal consumer, but the validator needs to look at the instruction to
determine this, thus storing the pointer to the instruction, instead
of trying to fetch the pointer using the instruction.

Issue #1528 covers fixing the check.

Fixes #2463