### PR TITLE
Fix merge return in the face of breaks

### DIFF
--- a/source/opt/merge_return_pass.cpp
+++ b/source/opt/merge_return_pass.cpp
@@ -408,8 +408,14 @@ bool MergeReturnPass::BreakFromConstruct(
   // Forget about the edges leaving block.  They will be removed.
   cfg()->RemoveSuccessorEdges(block);
 
-  BasicBlock* old_body = block->SplitBasicBlock(context(), TakeNextId(), iter);
+  auto old_body_id = TakeNextId();
+  BasicBlock* old_body = block->SplitBasicBlock(context(), old_body_id, iter);
   predicated->insert(old_body);
+  // If a return block is being split, mark the new body block also as a return
+  // block.
+  if (return_blocks_.count(block->id())) {
+    return_blocks_.insert(old_body_id);
+  }
 
   // If |block| was a continue target for a loop |old_body| is now the correct
   // continue target.

--- a/source/opt/merge_return_pass.cpp
+++ b/source/opt/merge_return_pass.cpp
@@ -677,9 +677,9 @@ void MergeReturnPass::AddNewPhiNodes(BasicBlock* bb, BasicBlock* pred,
 void MergeReturnPass::MarkForNewPhiNodes(BasicBlock* block,
                                          BasicBlock* single_original_pred) {
   auto iter = new_merge_nodes_.find(block);
-  assert(iter == new_merge_nodes_.end() ||
-         iter->second == single_original_pred &&
-             "Inconsistent dominator information");
+  assert((iter == new_merge_nodes_.end() ||
+          iter->second == single_original_pred) &&
+         "Inconsistent dominator information");
   if (iter == new_merge_nodes_.end()) {
     new_merge_nodes_[block] = single_original_pred;
   }

--- a/source/opt/merge_return_pass.cpp
+++ b/source/opt/merge_return_pass.cpp
@@ -676,13 +676,7 @@ void MergeReturnPass::AddNewPhiNodes(BasicBlock* bb, BasicBlock* pred,
 
 void MergeReturnPass::MarkForNewPhiNodes(BasicBlock* block,
                                          BasicBlock* single_original_pred) {
-  auto iter = new_merge_nodes_.find(block);
-  assert((iter == new_merge_nodes_.end() ||
-          iter->second == single_original_pred) &&
-         "Inconsistent dominator information");
-  if (iter == new_merge_nodes_.end()) {
-    new_merge_nodes_[block] = single_original_pred;
-  }
+  new_merge_nodes_[block] = single_original_pred;
 }
 
 void MergeReturnPass::InsertAfterElement(BasicBlock* element,

--- a/source/opt/merge_return_pass.h
+++ b/source/opt/merge_return_pass.h
@@ -240,12 +240,11 @@ class MergeReturnPass : public MemPass {
   // return block at the end of the pass.
   void CreateReturnBlock();
 
-  // Creates a Phi node in |merge_block| for the result of |inst| coming from
-  // |predecessor|.  Any uses of the result of |inst| that are no longer
+  // Creates a Phi node in |merge_block| for the result of |inst|.
+  // Any uses of the result of |inst| that are no longer
   // dominated by |inst|, are replaced with the result of the new |OpPhi|
   // instruction.
-  void CreatePhiNodesForInst(BasicBlock* merge_block, uint32_t predecessor,
-                             Instruction& inst);
+  void CreatePhiNodesForInst(BasicBlock* merge_block, Instruction& inst);
 
   // Traverse the nodes in |new_merge_nodes_|, and adds the OpPhi instructions
   // that are needed to make the code correct.  It is assumed that at this point
@@ -331,6 +330,11 @@ class MergeReturnPass : public MemPass {
   // values that will need a phi on the new edges.
   std::unordered_map<BasicBlock*, BasicBlock*> new_merge_nodes_;
   bool HasNontrivialUnreachableBlocks(Function* function);
+
+  // Contains all return blocks that are merged. This is set is populated while
+  // processing structured blocks and used to properly construct OpPhi
+  // instructions.
+  std::unordered_set<uint32_t> return_blocks_;
 };
 
 }  // namespace opt


### PR DESCRIPTION
Fixes #2453

* Enable addition of OpPhi instructions when the loop has multiple
predecessors of the merge due to a break
 * This can result in some values no longer dominating their uses
* Track return blocks in structured flow to produce OpPhis that have
multiple undef and non-undef arguments
* New tests to catch the bug