### PR TITLE
Improve reducer algorithm and other changes

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -557,14 +557,17 @@ SPIRV_TOOLS_EXPORT spv_reducer_options spvReducerOptionsCreate();
 // Destroys the given reducer options object.
 SPIRV_TOOLS_EXPORT void spvReducerOptionsDestroy(spv_reducer_options options);
 
-// Records the maximum number of reduction steps that should run before the
-// reducer gives up.
+// Sets the maximum number of reduction steps that should run before the reducer
+// gives up.
 SPIRV_TOOLS_EXPORT void spvReducerOptionsSetStepLimit(
     spv_reducer_options options, uint32_t step_limit);
 
-// Sets seed for random number generation.
-SPIRV_TOOLS_EXPORT void spvReducerOptionsSetSeed(spv_reducer_options options,
-                                                 uint32_t seed);
+// Sets the fail-on-validation-error option; if true, the reducer will return
+// kStateInvalid if a reduction step yields a state that fails SPIR-V
+// validation. Otherwise, an invalid state is treated as uninteresting and the
+// reduction backtracks and continues.
+SPIRV_TOOLS_EXPORT void spvReducerOptionsSetFailOnValidationError(
+    spv_reducer_options options, bool fail_on_validation_error);
 
 // Encodes the given SPIR-V assembly text to its binary representation. The
 // length parameter specifies the number of bytes for text. Encoded binary will

--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -151,16 +151,20 @@ class ReducerOptions {
   ~ReducerOptions() { spvReducerOptionsDestroy(options_); }
 
   // Allow implicit conversion to the underlying object.
-  operator spv_reducer_options() const { return options_; }
+  operator spv_reducer_options() const {  // NOLINT(google-explicit-constructor)
+    return options_;
+  }
 
-  // Records the maximum number of reduction steps that should
-  // run before the reducer gives up.
+  // See spvReducerOptionsSetStepLimit.
   void set_step_limit(uint32_t step_limit) {
     spvReducerOptionsSetStepLimit(options_, step_limit);
   }
 
-  // Sets a seed to be used for random number generation.
-  void set_seed(uint32_t seed) { spvReducerOptionsSetSeed(options_, seed); }
+  // See spvReducerOptionsSetFailOnValidationError.
+  void set_fail_on_validation_error(bool fail_on_validation_error) {
+    spvReducerOptionsSetFailOnValidationError(options_,
+                                              fail_on_validation_error);
+  }
 
  private:
   spv_reducer_options options_;

--- a/source/reduce/reducer.cpp
+++ b/source/reduce/reducer.cpp
@@ -15,10 +15,17 @@
 #include <cassert>
 #include <sstream>
 
+#include "source/reduce/merge_blocks_reduction_opportunity_finder.h"
+#include "source/reduce/operand_to_const_reduction_opportunity_finder.h"
+#include "source/reduce/operand_to_dominating_id_reduction_opportunity_finder.h"
+#include "source/reduce/operand_to_undef_reduction_opportunity_finder.h"
+#include "source/reduce/remove_function_reduction_opportunity_finder.h"
+#include "source/reduce/remove_opname_instruction_reduction_opportunity_finder.h"
+#include "source/reduce/remove_unreferenced_instruction_reduction_opportunity_finder.h"
+#include "source/reduce/structured_loop_to_selection_reduction_opportunity_finder.h"
 #include "source/spirv_reducer_options.h"
 
 #include "reducer.h"
-#include "reduction_pass.h"
 
 namespace spvtools {
 namespace reduce {
@@ -105,13 +112,15 @@ Reducer::ReductionResultStatus Reducer::Run(
       do {
         auto maybe_result = pass->TryApplyReduction(current_binary);
         if (maybe_result.empty()) {
-          // This pass did not have any impact, so move on to the next pass.
+          // For this round, the pass has no more opportunities (chunks) to
+          // apply, so move on to the next pass.
           impl_->consumer(
               SPV_MSG_INFO, nullptr, {},
               ("Pass " + pass->GetName() + " did not make a reduction step.")
                   .c_str());
           break;
         }
+        bool interesting = false;
         std::stringstream stringstream;
         reductions_applied++;
         stringstream << "Pass " << pass->GetName() << " made reduction step "
@@ -125,6 +134,9 @@ Reducer::ReductionResultStatus Reducer::Run(
           // invalid binary from being regarded as interesting.
           impl_->consumer(SPV_MSG_INFO, nullptr, {},
                           "Reduction step produced an invalid binary.");
+          if (options->fail_on_validation_error) {
+            return Reducer::ReductionResultStatus::kStateInvalid;
+          }
         } else if (impl_->interestingness_function(maybe_result,
                                                    reductions_applied)) {
           // Success!  The binary produced by this reduction step is
@@ -133,8 +145,11 @@ Reducer::ReductionResultStatus Reducer::Run(
           impl_->consumer(SPV_MSG_INFO, nullptr, {},
                           "Reduction step succeeded.");
           current_binary = std::move(maybe_result);
+          interesting = true;
           another_round_worthwhile = true;
         }
+        // We must call this before the next call to TryApplyReduction.
+        pass->NotifyInteresting(interesting);
         // Bail out if the reduction step limit has been reached.
       } while (!impl_->ReachedStepLimit(reductions_applied, options));
     }
@@ -151,6 +166,25 @@ Reducer::ReductionResultStatus Reducer::Run(
   }
   impl_->consumer(SPV_MSG_INFO, nullptr, {}, "No more to reduce; stopping.");
   return Reducer::ReductionResultStatus::kComplete;
+}
+
+void Reducer::AddDefaultReductionPasses() {
+  AddReductionPass(spvtools::MakeUnique<
+                   RemoveOpNameInstructionReductionOpportunityFinder>());
+  AddReductionPass(
+      spvtools::MakeUnique<OperandToUndefReductionOpportunityFinder>());
+  AddReductionPass(
+      spvtools::MakeUnique<OperandToConstReductionOpportunityFinder>());
+  AddReductionPass(
+      spvtools::MakeUnique<OperandToDominatingIdReductionOpportunityFinder>());
+  AddReductionPass(spvtools::MakeUnique<
+                   RemoveUnreferencedInstructionReductionOpportunityFinder>());
+  AddReductionPass(spvtools::MakeUnique<
+                   StructuredLoopToSelectionReductionOpportunityFinder>());
+  AddReductionPass(
+      spvtools::MakeUnique<MergeBlocksReductionOpportunityFinder>());
+  AddReductionPass(
+      spvtools::MakeUnique<RemoveFunctionReductionOpportunityFinder>());
 }
 
 void Reducer::AddReductionPass(

--- a/source/reduce/reducer.h
+++ b/source/reduce/reducer.h
@@ -34,7 +34,11 @@ class Reducer {
     kInitialStateNotInteresting,
     kReachedStepLimit,
     kComplete,
-    kInitialStateInvalid
+    kInitialStateInvalid,
+
+    // Returned when the fail-on-validation-error option is set and a
+    // reduction step yields a state that fails validation.
+    kStateInvalid,
   };
 
   // The type for a function that will take a binary and return true if and
@@ -75,6 +79,9 @@ class Reducer {
   // turned out to be interesting.
   void SetInterestingnessFunction(
       InterestingnessFunction interestingness_function);
+
+  // Adds all default reduction passes.
+  void AddDefaultReductionPasses();
 
   // Adds a reduction pass based on the given finder to the sequence of passes
   // that will be iterated over.

--- a/source/reduce/reduction_pass.h
+++ b/source/reduce/reduction_pass.h
@@ -33,16 +33,27 @@ namespace reduce {
 class ReductionPass {
  public:
   // Constructs a reduction pass with a given target environment, |target_env|,
-  // and a given finder of reduction opportunities, |finder|.  Initially the
-  // pass is uninitialized.
+  // and a given finder of reduction opportunities, |finder|.
   explicit ReductionPass(const spv_target_env target_env,
                          std::unique_ptr<ReductionOpportunityFinder> finder)
       : target_env_(target_env),
         finder_(std::move(finder)),
-        is_initialized_(false) {}
+        index_(0),
+        granularity_(UINT32_MAX) {}
 
-  // Applies the reduction pass to the given binary.
+  // Applies the reduction pass to the given binary by applying a "chunk" of
+  // reduction opportunities. Returns the new binary if a chunk was applied; in
+  // this case, before the next call the caller must invoke
+  // NotifyInteresting(...) to indicate whether the new binary is interesting.
+  // Returns an empty vector if there are no more chunks left to apply; in this
+  // case, the index will be reset and the granularity lowered for the next
+  // round.
   std::vector<uint32_t> TryApplyReduction(const std::vector<uint32_t>& binary);
+
+  // Notifies the reduction pass whether the binary returned from
+  // TryApplyReduction is interesting, so that the next call to
+  // TryApplyReduction will avoid applying the same chunk of opportunities.
+  void NotifyInteresting(bool interesting);
 
   // Sets a consumer to which relevant messages will be directed.
   void SetMessageConsumer(MessageConsumer consumer);
@@ -59,7 +70,6 @@ class ReductionPass {
   const spv_target_env target_env_;
   const std::unique_ptr<ReductionOpportunityFinder> finder_;
   MessageConsumer consumer_;
-  bool is_initialized_;
   uint32_t index_;
   uint32_t granularity_;
 };

--- a/source/reduce/reduction_pass.h
+++ b/source/reduce/reduction_pass.h
@@ -15,7 +15,7 @@
 #ifndef SOURCE_REDUCE_REDUCTION_PASS_H_
 #define SOURCE_REDUCE_REDUCTION_PASS_H_
 
-#include <cstdint>
+#include <limits>
 
 #include "source/opt/ir_context.h"
 #include "source/reduce/reduction_opportunity_finder.h"
@@ -40,7 +40,7 @@ class ReductionPass {
       : target_env_(target_env),
         finder_(std::move(finder)),
         index_(0),
-        granularity_(UINT32_MAX) {}
+        granularity_(std::numeric_limits<uint32_t>::max()) {}
 
   // Applies the reduction pass to the given binary by applying a "chunk" of
   // reduction opportunities. Returns the new binary if a chunk was applied; in

--- a/source/reduce/reduction_pass.h
+++ b/source/reduce/reduction_pass.h
@@ -15,10 +15,11 @@
 #ifndef SOURCE_REDUCE_REDUCTION_PASS_H_
 #define SOURCE_REDUCE_REDUCTION_PASS_H_
 
-#include "spirv-tools/libspirv.hpp"
+#include <cstdint>
 
-#include "reduction_opportunity_finder.h"
 #include "source/opt/ir_context.h"
+#include "source/reduce/reduction_opportunity_finder.h"
+#include "spirv-tools/libspirv.hpp"
 
 namespace spvtools {
 namespace reduce {

--- a/source/spirv_reducer_options.cpp
+++ b/source/spirv_reducer_options.cpp
@@ -29,3 +29,8 @@ SPIRV_TOOLS_EXPORT void spvReducerOptionsSetStepLimit(
     spv_reducer_options options, uint32_t step_limit) {
   options->step_limit = step_limit;
 }
+
+SPIRV_TOOLS_EXPORT void spvReducerOptionsSetFailOnValidationError(
+    spv_reducer_options options, bool fail_on_validation_error) {
+  options->fail_on_validation_error = fail_on_validation_error;
+}

--- a/source/spirv_reducer_options.h
+++ b/source/spirv_reducer_options.h
@@ -26,10 +26,14 @@ const uint32_t kDefaultStepLimit = 250;
 // Manages command line options passed to the SPIR-V Reducer. New struct
 // members may be added for any new option.
 struct spv_reducer_options_t {
-  spv_reducer_options_t() : step_limit(kDefaultStepLimit) {}
+  spv_reducer_options_t()
+      : step_limit(kDefaultStepLimit), fail_on_validation_error(false) {}
 
-  // The number of steps the reducer will run for before giving up.
+  // See spvReducerOptionsSetStepLimit.
   uint32_t step_limit;
+
+  // See spvReducerOptionsSetFailOnValidationError.
+  bool fail_on_validation_error;
 };
 
 #endif  // SOURCE_SPIRV_REDUCER_OPTIONS_H_

--- a/test/reduce/reduce_test_util.cpp
+++ b/test/reduce/reduce_test_util.cpp
@@ -14,6 +14,8 @@
 
 #include "reduce_test_util.h"
 
+#include <iostream>
+
 namespace spvtools {
 namespace reduce {
 
@@ -67,6 +69,29 @@ std::string ToString(spv_target_env env, const opt::IRContext* ir) {
 void NopDiagnostic(spv_message_level_t /*level*/, const char* /*source*/,
                    const spv_position_t& /*position*/,
                    const char* /*message*/) {}
+
+
+void CLIMessageConsumer(spv_message_level_t level, const char*,
+                        const spv_position_t& position, const char* message) {
+  switch (level) {
+    case SPV_MSG_FATAL:
+    case SPV_MSG_INTERNAL_ERROR:
+    case SPV_MSG_ERROR:
+      std::cerr << "error: line " << position.index << ": " << message
+                << std::endl;
+      break;
+    case SPV_MSG_WARNING:
+      std::cout << "warning: line " << position.index << ": " << message
+                << std::endl;
+      break;
+    case SPV_MSG_INFO:
+      std::cout << "info: line " << position.index << ": " << message
+                << std::endl;
+      break;
+    default:
+      break;
+  }
+}
 
 }  // namespace reduce
 }  // namespace spvtools

--- a/test/reduce/reduce_test_util.cpp
+++ b/test/reduce/reduce_test_util.cpp
@@ -70,7 +70,6 @@ void NopDiagnostic(spv_message_level_t /*level*/, const char* /*source*/,
                    const spv_position_t& /*position*/,
                    const char* /*message*/) {}
 
-
 void CLIMessageConsumer(spv_message_level_t level, const char*,
                         const spv_position_t& position, const char* message) {
   switch (level) {

--- a/test/reduce/reduce_test_util.h
+++ b/test/reduce/reduce_test_util.h
@@ -59,6 +59,11 @@ const uint32_t kReduceDisassembleOption =
 void NopDiagnostic(spv_message_level_t /*level*/, const char* /*source*/,
                    const spv_position_t& /*position*/, const char* /*message*/);
 
+// Prints reducer messages (for debugging).
+void CLIMessageConsumer(spv_message_level_t level, const char*,
+                        const spv_position_t& position, const char* message);
+
+
 }  // namespace reduce
 }  // namespace spvtools
 

--- a/test/reduce/reduce_test_util.h
+++ b/test/reduce/reduce_test_util.h
@@ -63,7 +63,6 @@ void NopDiagnostic(spv_message_level_t /*level*/, const char* /*source*/,
 void CLIMessageConsumer(spv_message_level_t level, const char*,
                         const spv_position_t& position, const char* message);
 
-
 }  // namespace reduce
 }  // namespace spvtools
 

--- a/test/reduce/reducer_test.cpp
+++ b/test/reduce/reducer_test.cpp
@@ -229,6 +229,7 @@ TEST(ReducerTest, ExprToConstantAndRemoveUnreferenced) {
   std::vector<uint32_t> binary_out;
   spvtools::ReducerOptions reducer_options;
   reducer_options.set_step_limit(500);
+  reducer_options.set_fail_on_validation_error(true);
   spvtools::ValidatorOptions validator_options;
 
   Reducer::ReductionResultStatus status = reducer.Run(
@@ -304,6 +305,7 @@ TEST(ReducerTest, RemoveOpnameAndRemoveUnreferenced) {
   std::vector<uint32_t> binary_out;
   spvtools::ReducerOptions reducer_options;
   reducer_options.set_step_limit(500);
+  reducer_options.set_fail_on_validation_error(true);
   spvtools::ValidatorOptions validator_options;
 
   Reducer::ReductionResultStatus status = reducer.Run(


### PR DESCRIPTION
Fix #2475. Fix #2476. 

* Improve reducer algorithm: shrink granularity, remove an early return, no lazy initialization, notify pass if binary is interesting, add comments.
* Add fail-on-validation-error option to fail a reduction if an invalid state is reached; useful for tests.
* Set fail-on-validation-error in tests.
* Improve some documentation comments.
* Add Reducer::AddDefaultReductionPasses so tests (and other library consumers) can add the default reduction passes.
* Add CLIMessageConsumer in test_reduce so we can see messages for tricky tests.
* Remove test RemoveUnreferencedInstructionReductionPassTest_ApplyReduction because it was indirectly testing the reduction algorithm, not the RemoveUnreferencedInstruction pass.
* Tweak tests where needed.