### PR TITLE
Validate that OpUnreacahble is not statically reachable

### DIFF
--- a/source/val/validate_cfg.cpp
+++ b/source/val/validate_cfg.cpp
@@ -725,6 +725,36 @@ spv_result_t PerformWebGPUCfgChecks(ValidationState_t& _, Function* function) {
   return SPV_SUCCESS;
 }
 
+// Checks that there are no OpUnreachable instructions reachable from the entry
+// block of |function|.
+spv_result_t ValidateUnreachableBlocks(ValidationState_t& _,
+                                       Function& function) {
+  auto* entry_block = function.first_block();
+  std::vector<BasicBlock*> stack;
+  std::unordered_set<BasicBlock*> seen;
+  if (entry_block) stack.push_back(entry_block);
+
+  while (!stack.empty()) {
+    auto* block = stack.back();
+    stack.pop_back();
+
+    if (!seen.insert(block).second) continue;
+
+    auto* terminator = block->terminator();
+    if (terminator->opcode() == SpvOpUnreachable) {
+      return _.diag(SPV_ERROR_INVALID_CFG, block->label())
+             << "Statically reachable blocks cannot be terminated by "
+                "OpUnreachable";
+    }
+
+    for (auto* succ : *block->successors()) {
+      stack.push_back(succ);
+    }
+  }
+
+  return SPV_SUCCESS;
+}
+
 spv_result_t PerformCfgChecks(ValidationState_t& _) {
   for (auto& function : _.functions()) {
     // Check all referenced blocks are defined within a function
@@ -826,6 +856,8 @@ spv_result_t PerformCfgChecks(ValidationState_t& _) {
         }
       }
     }
+
+    if (auto error = ValidateUnreachableBlocks(_, function)) return error;
 
     /// Structured control flow checks are only required for shader capabilities
     if (_.HasCapability(SpvCapabilityShader)) {

--- a/test/opt/block_merge_test.cpp
+++ b/test/opt/block_merge_test.cpp
@@ -590,7 +590,7 @@ OpUnreachable
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<BlockMergePass>(text, true);
+  SinglePassRunAndMatch<BlockMergePass>(text, false);
 }
 
 TEST_F(BlockMergeTest, DontMergeReturn) {

--- a/test/opt/inline_test.cpp
+++ b/test/opt/inline_test.cpp
@@ -2421,7 +2421,8 @@ OpBranchConditional %true %44 %43
 OpStore %38 %float_1
 OpBranch %40
 %43 = OpLabel
-OpUnreachable
+OpStore %38 %float_1
+OpBranch %40
 %41 = OpLabel
 OpBranchConditional %false %39 %40
 %40 = OpLabel
@@ -2446,7 +2447,7 @@ OpBranchConditional %true %36 %35
 %36 = OpLabel
 OpReturnValue %float_1
 %35 = OpLabel
-OpUnreachable
+OpReturnValue %float_1
 OpFunctionEnd
 )";
 
@@ -3058,6 +3059,7 @@ OpDecorate %2 DescriptorSet 439418829
 %4 = OpTypeFunction %void
 %float = OpTypeFloat 32
 %_struct_6 = OpTypeStruct %float %float
+%15 = OpConstantNull %_struct_6
 %7 = OpTypeFunction %_struct_6
 %1 = OpFunction %void Pure|Const %4
 %8 = OpLabel
@@ -3067,10 +3069,11 @@ OpFunctionEnd
 %9 = OpFunction %_struct_6 None %7
 %10 = OpLabel
 %11 = OpFunctionCall %_struct_6 %9
-OpUnreachable
+OpReturnValue %15
 OpFunctionEnd
 )";
 
+  SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SinglePassRunAndCheck<InlineExhaustivePass>(test, test, false, true);
 }
 
@@ -3086,6 +3089,7 @@ OpDecorate %2 DescriptorSet 439418829
 %4 = OpTypeFunction %void
 %float = OpTypeFloat 32
 %_struct_6 = OpTypeStruct %float %float
+%15 = OpConstantNull %_struct_6
 %7 = OpTypeFunction %_struct_6
 %1 = OpFunction %void Pure|Const %4
 %8 = OpLabel
@@ -3095,15 +3099,16 @@ OpFunctionEnd
 %9 = OpFunction %_struct_6 None %7
 %10 = OpLabel
 %11 = OpFunctionCall %_struct_6 %12
-OpUnreachable
+OpReturnValue %15
 OpFunctionEnd
 %12 = OpFunction %_struct_6 None %7
 %13 = OpLabel
 %14 = OpFunctionCall %_struct_6 %9
-OpUnreachable
+OpReturnValue %15
 OpFunctionEnd
 )";
 
+  SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SinglePassRunAndCheck<InlineExhaustivePass>(test, test, false, true);
 }
 

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -6203,20 +6203,22 @@ TEST_F(ValidateIdWithMessage, IdDefInUnreachableBlock1) {
 %4 = OpTypeFunction %3
 %5 = OpFunction %1 None %2
 %6 = OpLabel
-%7 = OpFunctionCall %3 %8
+OpReturn
+%7 = OpLabel
+%8 = OpFunctionCall %3 %9
 OpUnreachable
 OpFunctionEnd
-%8 = OpFunction %3 None %4
-%9 = OpLabel
-OpReturnValue %7
+%9 = OpFunction %3 None %4
+%10 = OpLabel
+OpReturnValue %8
 OpFunctionEnd
 )";
 
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("ID 7[%7] defined in block 6[%6] does not dominate its "
-                        "use in block 9[%9]\n  %9 = OpLabel"));
+              HasSubstr("ID 8[%8] defined in block 7[%7] does not dominate its "
+                        "use in block 10[%10]\n  %10 = OpLabel"));
 }
 
 TEST_F(ValidateIdWithMessage, IdDefInUnreachableBlock2) {

--- a/test/val/val_validation_state_test.cpp
+++ b/test/val/val_validation_state_test.cpp
@@ -56,15 +56,16 @@ OpExecutionMode %1 OriginUpperLeft
 %4 = OpTypeFunction %void
 %float = OpTypeFloat 32
 %_struct_6 = OpTypeStruct %float %float
+%null = OpConstantNull %_struct_6
 %7 = OpTypeFunction %_struct_6
 %12 = OpFunction %_struct_6 None %7
 %13 = OpLabel
-OpUnreachable
+OpReturnValue %null
 OpFunctionEnd
 %9 = OpFunction %_struct_6 None %7
 %10 = OpLabel
 %11 = OpFunctionCall %_struct_6 %12
-OpUnreachable
+OpReturnValue %null
 OpFunctionEnd
 %1 = OpFunction %void Pure|Const %4
 %8 = OpLabel
@@ -89,7 +90,7 @@ OpFunctionEnd
 %1 = OpFunction %void Pure|Const %4
 %8 = OpLabel
 %2 = OpFunctionCall %_struct_6 %9
-OpUnreachable
+OpReturn
 OpFunctionEnd
 )";
 
@@ -100,16 +101,17 @@ OpExecutionMode %1 OriginUpperLeft
 %4 = OpTypeFunction %void
 %float = OpTypeFloat 32
 %_struct_6 = OpTypeStruct %float %float
+%null = OpConstantNull %_struct_6
 %7 = OpTypeFunction %_struct_6
 %9 = OpFunction %_struct_6 None %7
 %10 = OpLabel
 %11 = OpFunctionCall %_struct_6 %12
-OpUnreachable
+OpReturnValue %null
 OpFunctionEnd
 %12 = OpFunction %_struct_6 None %7
 %13 = OpLabel
 %14 = OpFunctionCall %_struct_6 %9
-OpUnreachable
+OpReturnValue %null
 OpFunctionEnd
 %1 = OpFunction %void Pure|Const %4
 %8 = OpLabel
@@ -303,7 +305,7 @@ TEST_F(ValidationStateTest, CheckWebGPUIndirectlyRecursiveBodyBad) {
             ValidateAndRetrieveValidationState(SPV_ENV_WEBGPU_0));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("For WebGPU, functions need to be defined before being "
-                        "called.\n  %9 = OpFunctionCall %_struct_5 %10\n"));
+                        "called.\n  %10 = OpFunctionCall %_struct_5 %11\n"));
 }
 
 TEST_F(ValidationStateTest,


### PR DESCRIPTION
* Adds a validator check that ensures no block reachable from the entry
block is terminated by OpUnreachable
* Updated tests
* Added new tests

This came about from #2456. Adds a better error than what the validator caught for that case.