### PR TITLE
spirv-opt: Behave a bit better in the face of unknown instructions

### DIFF
--- a/source/opt/ir_loader.cpp
+++ b/source/opt/ir_loader.cpp
@@ -116,8 +116,10 @@ bool IrLoader::AddInstruction(const spv_parsed_instruction_t* inst) {
                  opcode == SpvOpUndef) {
         module_->AddGlobalValue(std::move(spv_inst));
       } else {
-        SPIRV_UNIMPLEMENTED(consumer_,
-                            "unhandled inst type outside function definition");
+        Errorf(consumer_, src, loc,
+               "Unhandled inst type (opcode: %d) found outside function definition.",
+               opcode);
+        return false;
       }
     } else {
       if (block_ == nullptr) {  // Inside function but outside blocks

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -510,10 +510,20 @@ bool Optimizer::Run(const uint32_t* original_binary,
   impl_->pass_manager.SetValidatorOptions(&opt_options->val_options_);
   impl_->pass_manager.SetTargetEnv(impl_->target_env);
   auto status = impl_->pass_manager.Run(context.get());
-  if (status == opt::Pass::Status::SuccessWithChange ||
-      (status == opt::Pass::Status::SuccessWithoutChange &&
-       (optimized_binary->data() != original_binary ||
-        optimized_binary->size() != original_binary_size))) {
+
+  bool binary_changed = false;
+  if (status == opt::Pass::Status::SuccessWithChange) {
+    binary_changed = true;
+  } else if (status == opt::Pass::Status::SuccessWithoutChange) {
+    if (optimized_binary->size() != original_binary_size ||
+        (memcmp(optimized_binary->data(), original_binary, original_binary_size) != 0)) {
+      binary_changed = true;
+      Logf(consumer(), SPV_MSG_WARNING, nullptr, {},
+           "Binary unexpectedly changed despite optimizer saying there was no change");
+    }
+  }
+
+  if (binary_changed) {
     optimized_binary->clear();
     context->module()->ToBinary(optimized_binary, /* skip_nop = */ true);
   }


### PR DESCRIPTION
Currently, if spirv-opt encounters an unknown instruction, it will drop it on the floor. This behavior can lead to crashes since the output might very well be invalid SPIR-V (see #2190 for an example). This turns the silent invalid output into an error -- still not a perfect outcome but a bit nicer than a hard-to-debug crash.

In addition, this *also* might have been caught by the optimize pass returning SuccessWithoutChange, but the high-level optimizer checks the output binary and silently fixes things up if the pass returned incorrectly. This is indicative of a bug in a pass, so I added an additional warning line to help debug this as well.