### PR TITLE
Remove merge assert in block calculation

### DIFF
--- a/source/val/construct.cpp
+++ b/source/val/construct.cpp
@@ -73,7 +73,6 @@ Construct::ConstructBlockSet Construct::blocks(Function* function) const {
   auto header = entry_block();
   auto merge = exit_block();
   assert(header);
-  assert(merge);
   int header_depth = function->GetBlockDepth(const_cast<BasicBlock*>(header));
   ConstructBlockSet construct_blocks;
   std::unordered_set<BasicBlock*> corresponding_headers;


### PR DESCRIPTION
Fixes #2488

* Validator doesn't identify back-edge of the loop, so the merge is
never set
* Construct::blocks() has safe uses of `merge` so the assert can be
removed
* Added a test