### PR TITLE
Fix webgpu header file name in BUILD.gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -515,7 +515,7 @@ static_library("spvtools_opt") {
     "source/opt/function.cpp",
     "source/opt/function.h",
     "source/opt/generate_webgpu_initializers_pass.cpp",
-    "source/opt/generate_webgpu_initializers_pass.hpp",
+    "source/opt/generate_webgpu_initializers_pass.h",
     "source/opt/if_conversion.cpp",
     "source/opt/if_conversion.h",
     "source/opt/inline_exhaustive_pass.cpp",


### PR DESCRIPTION
A .h file was specified as .hpp file, causing `gn gen path/ --check` to
fail.