### PR TITLE
Fix use of Logf to avoid format security warning

### DIFF
--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -526,10 +526,12 @@ bool Optimizer::Run(const uint32_t* original_binary,
     binary_changed = true;
   } else if (status == opt::Pass::Status::SuccessWithoutChange) {
     if (optimized_binary->size() != original_binary_size ||
-        (memcmp(optimized_binary->data(), original_binary, original_binary_size) != 0)) {
+        (memcmp(optimized_binary->data(), original_binary,
+                original_binary_size) != 0)) {
       binary_changed = true;
-      Logf(consumer(), SPV_MSG_WARNING, nullptr, {},
-           "Binary unexpectedly changed despite optimizer saying there was no change");
+      Log(consumer(), SPV_MSG_WARNING, nullptr, {},
+          "Binary unexpectedly changed despite optimizer saying there was no "
+          "change");
     }
   }
 


### PR DESCRIPTION
When -Wformat-security is enabled, we are getting an error.  I do not
claim to fully understand when the warning is triggered or not, but this
one can be avoided by calling "Log" instead of "Logf" because the
formating string is not needed.