### PR TITLE
Add pass to legalize OpVectorShuffle for WebGPU

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -119,6 +119,7 @@ SPVTOOLS_OPT_SRC_FILES := \
 		source/opt/instrument_pass.cpp \
 		source/opt/ir_context.cpp \
 		source/opt/ir_loader.cpp \
+                source/opt/legalize_vector_shuffle_pass.cpp \
 		source/opt/licm_pass.cpp \
 		source/opt/local_access_chain_convert_pass.cpp \
 		source/opt/local_redundancy_elimination.cpp \

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -540,6 +540,8 @@ static_library("spvtools_opt") {
     "source/opt/ir_loader.cpp",
     "source/opt/ir_loader.h",
     "source/opt/iterator.h",
+    "source/opt/legalize_vector_shuffle_pass.cpp",
+    "source/opt/legalize_vector_shuffle_pass.h",
     "source/opt/licm_pass.cpp",
     "source/opt/licm_pass.h",
     "source/opt/local_access_chain_convert_pass.cpp",

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -763,6 +763,11 @@ Optimizer::PassToken CreateGenerateWebGPUInitializersPass();
 // match up correctly.  This pass will fix the errors that it can.
 Optimizer::PassToken CreateFixStorageClassPass();
 
+// Create a pass to legalize OpVectorShuffle operands going into WebGPU. WebGPU
+// forbids using 0xFFFFFFFF, which indicates an undefined result, so this pass
+// converts those literals to 0.
+Optimizer::PassToken CreateLegalizeVectorShufflePass();
+
 }  // namespace spvtools
 
 #endif  // INCLUDE_SPIRV_TOOLS_OPTIMIZER_HPP_

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -157,6 +157,7 @@ set(SPIRV_TOOLS_OPT_SOURCES
   instrument_pass.cpp
   ir_context.cpp
   ir_loader.cpp
+  legalize_vector_shuffle_pass.cpp
   licm_pass.cpp
   local_access_chain_convert_pass.cpp
   local_redundancy_elimination.cpp

--- a/source/opt/legalize_vector_shuffle_pass.cpp
+++ b/source/opt/legalize_vector_shuffle_pass.cpp
@@ -21,7 +21,7 @@ namespace opt {
 
 Pass::Status LegalizeVectorShufflePass::Process() {
   bool changed = false;
-  context()->module()->ForEachInst([this, &changed](Instruction* inst) {
+  context()->module()->ForEachInst([&changed](Instruction* inst) {
     if (inst->opcode() != SpvOpVectorShuffle) return;
 
     bool inner_changed = false;
@@ -32,9 +32,6 @@ Pass::Status LegalizeVectorShufflePass::Process() {
       inner_changed = true;
       inst->SetInOperand(idx, {0});
     }
-
-    if (!inner_changed) return;
-    context()->UpdateDefUse(inst);
   });
 
   return changed ? Status::SuccessWithChange : Status::SuccessWithoutChange;

--- a/source/opt/legalize_vector_shuffle_pass.cpp
+++ b/source/opt/legalize_vector_shuffle_pass.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/opt/legalize_vector_shuffle_pass.h"
+
+#include "source/opt/ir_context.h"
+
+namespace spvtools {
+namespace opt {
+
+Pass::Status LegalizeVectorShufflePass::Process() {
+  bool changed = false;
+  context()->module()->ForEachInst([this, &changed](Instruction* inst) {
+    if (inst->opcode() != SpvOpVectorShuffle) return;
+
+    bool inner_changed = false;
+    for (uint32_t idx = 2; idx < inst->NumInOperands(); ++idx) {
+      auto literal = inst->GetSingleWordInOperand(idx);
+      if (literal != 0xFFFFFFFF) continue;
+      changed = true;
+      inner_changed = true;
+      inst->SetInOperand(idx, {0});
+    }
+
+    if (!inner_changed) return;
+    context()->UpdateDefUse(inst);
+  });
+
+  return changed ? Status::SuccessWithChange : Status::SuccessWithoutChange;
+}
+
+}  // namespace opt
+}  // namespace spvtools

--- a/source/opt/legalize_vector_shuffle_pass.cpp
+++ b/source/opt/legalize_vector_shuffle_pass.cpp
@@ -24,12 +24,10 @@ Pass::Status LegalizeVectorShufflePass::Process() {
   context()->module()->ForEachInst([&changed](Instruction* inst) {
     if (inst->opcode() != SpvOpVectorShuffle) return;
 
-    bool inner_changed = false;
     for (uint32_t idx = 2; idx < inst->NumInOperands(); ++idx) {
       auto literal = inst->GetSingleWordInOperand(idx);
       if (literal != 0xFFFFFFFF) continue;
       changed = true;
-      inner_changed = true;
       inst->SetInOperand(idx, {0});
     }
   });

--- a/source/opt/legalize_vector_shuffle_pass.h
+++ b/source/opt/legalize_vector_shuffle_pass.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_OPT_LEGALIZE_VECTOR_SHUFFLE_PASS_H_
+#define SOURCE_OPT_LEGALIZE_VECTOR_SHUFFLE_PASS_H_
+
+#include "source/opt/ir_context.h"
+#include "source/opt/module.h"
+#include "source/opt/pass.h"
+
+namespace spvtools {
+namespace opt {
+
+// Converts any usages of 0xFFFFFFFF for the literals in OpVectorShuffle to a
+// literal 0. This is needed because using OxFFFFFFFF is forbidden by the WebGPU
+// spec. 0xFFFFFFFF in the main spec indicates that the result for this
+// component has not source, thus is undefined. Since this is undefined
+// behaviour we are free to use that value 0.
+class LegalizeVectorShufflePass : public Pass {
+ public:
+  const char* name() const override { return "legalize-vector-shuffle"; }
+  Status Process() override;
+
+  IRContext::Analysis GetPreservedAnalyses() override {
+    return IRContext::kAnalysisInstrToBlockMapping |
+           IRContext::kAnalysisDecorations | IRContext::kAnalysisCombinators |
+           IRContext::kAnalysisCFG | IRContext::kAnalysisDominatorAnalysis |
+           IRContext::kAnalysisLoopAnalysis | IRContext::kAnalysisNameMap |
+           IRContext::kAnalysisScalarEvolution |
+           IRContext::kAnalysisRegisterPressure |
+           IRContext::kAnalysisValueNumberTable |
+           IRContext::kAnalysisStructuredCFG |
+           IRContext::kAnalysisBuiltinVarId |
+           IRContext::kAnalysisIdToFuncMapping | IRContext::kAnalysisTypes |
+           IRContext::kAnalysisDefUse | IRContext::kAnalysisConstants;
+  }
+};
+
+}  // namespace opt
+}  // namespace spvtools
+
+#endif  // SOURCE_OPT_LEGALIZE_VECTOR_SHUFFLE_PASS_H_

--- a/source/opt/legalize_vector_shuffle_pass.h
+++ b/source/opt/legalize_vector_shuffle_pass.h
@@ -25,8 +25,8 @@ namespace opt {
 // Converts any usages of 0xFFFFFFFF for the literals in OpVectorShuffle to a
 // literal 0. This is needed because using OxFFFFFFFF is forbidden by the WebGPU
 // spec. 0xFFFFFFFF in the main spec indicates that the result for this
-// component has not source, thus is undefined. Since this is undefined
-// behaviour we are free to use that value 0.
+// component has no source, thus is undefined. Since this is undefined
+// behaviour we are free to use 0.
 class LegalizeVectorShufflePass : public Pass {
  public:
   const char* name() const override { return "legalize-vector-shuffle"; }

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -224,6 +224,7 @@ Optimizer& Optimizer::RegisterVulkanToWebGPUPasses() {
   return RegisterPass(CreateStripDebugInfoPass())
       .RegisterPass(CreateStripAtomicCounterMemoryPass())
       .RegisterPass(CreateGenerateWebGPUInitializersPass())
+      .RegisterPass(CreateLegalizeVectorShufflePass())
       .RegisterPass(CreateEliminateDeadConstantPass())
       .RegisterPass(CreateFlattenDecorationPass())
       .RegisterPass(CreateAggressiveDCEPass())
@@ -466,6 +467,8 @@ bool Optimizer::RegisterPassFromFlag(const std::string& flag) {
     RegisterLegalizationPasses();
   } else if (pass_name == "generate-webgpu-initializers") {
     RegisterPass(CreateGenerateWebGPUInitializersPass());
+  } else if (pass_name == "legalize-vector-shuffle") {
+    RegisterPass(CreateLegalizeVectorShufflePass());
   } else {
     Errorf(consumer(), nullptr, {},
            "Unknown flag '--%s'. Use --help for a list of valid flags",
@@ -854,6 +857,11 @@ Optimizer::PassToken CreateGenerateWebGPUInitializersPass() {
 Optimizer::PassToken CreateFixStorageClassPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::FixStorageClass>());
+}
+
+Optimizer::PassToken CreateLegalizeVectorShufflePass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::LegalizeVectorShufflePass>());
 }
 
 }  // namespace spvtools

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -41,6 +41,7 @@
 #include "source/opt/inline_exhaustive_pass.h"
 #include "source/opt/inline_opaque_pass.h"
 #include "source/opt/inst_bindless_check_pass.h"
+#include "source/opt/legalize_vector_shuffle_pass.h"
 #include "source/opt/licm_pass.h"
 #include "source/opt/local_access_chain_convert_pass.h"
 #include "source/opt/local_redundancy_elimination.h"

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -54,6 +54,7 @@ add_spvtools_unittest(TARGET opt
        ir_context_test.cpp
        ir_loader_test.cpp
        iterator_test.cpp
+       legalize_vector_shuffle_test.cpp
        line_debug_info_test.cpp
        local_access_chain_convert_test.cpp
        local_redundancy_elimination_test.cpp

--- a/test/opt/legalize_vector_shuffle_test.cpp
+++ b/test/opt/legalize_vector_shuffle_test.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+
+#include "test/opt/pass_fixture.h"
+#include "test/opt/pass_utils.h"
+
+namespace spvtools {
+namespace opt {
+namespace {
+
+using LegalizeVectorShuffleTest = PassTest<::testing::Test>;
+
+void operator+=(std::vector<const char*>& lhs, const char* rhs) {
+  lhs.push_back(rhs);
+}
+
+void operator+=(std::vector<const char*>& lhs,
+                const std::vector<const char*> rhs) {
+  for (auto elem : rhs) lhs.push_back(elem);
+}
+
+std::vector<const char*> header = {
+    "OpCapability Shader",
+    "OpCapability VulkanMemoryModelKHR",
+    "OpExtension \"SPV_KHR_vulkan_memory_model\"",
+    "OpMemoryModel Logical VulkanKHR",
+    "OpEntryPoint Vertex %1 \"shader\"",
+    "%uint = OpTypeInt 32 0",
+    "%v3uint = OpTypeVector %uint 3"};
+
+std::string GetTestString(const char* shuffle) {
+  std::vector<const char*> result = header;
+  result += {"%_ptr_Function_v3uint = OpTypePointer Function %v3uint",
+             "%void = OpTypeVoid",
+             "%6 = OpTypeFunction %void",
+             "%1 = OpFunction %void None %6",
+             "%7 = OpLabel",
+             "%8 = OpVariable %_ptr_Function_v3uint Function",
+             "%9 = OpLoad %v3uint %8",
+             "%10 = OpLoad %v3uint %8"};
+  result += shuffle;
+  result += {"OpReturn", "OpFunctionEnd"};
+  return JoinAllInsts(result);
+}
+
+TEST_F(LegalizeVectorShuffleTest, Changed) {
+  std::string input =
+      GetTestString("%11 = OpVectorShuffle %v3uint %9 %10 2 1 0xFFFFFFFF");
+  std::string expected =
+      GetTestString("%11 = OpVectorShuffle %v3uint %9 %10 2 1 0");
+
+  SinglePassRunAndCheck<LegalizeVectorShufflePass>(input, expected,
+                                                   /* skip_nop = */ false);
+}
+
+TEST_F(LegalizeVectorShuffleTest, FunctionUnchanged) {
+  std::string input =
+      GetTestString("%11 = OpVectorShuffle %v3uint %9 %10 2 1 0");
+  std::string expected =
+      GetTestString("%11 = OpVectorShuffle %v3uint %9 %10 2 1 0");
+
+  SinglePassRunAndCheck<LegalizeVectorShufflePass>(input, expected,
+                                                   /* skip_nop = */ false);
+}
+
+}  // namespace
+}  // namespace opt
+}  // namespace spvtools


### PR DESCRIPTION
In WebGPU, the component operand 0xFFFFFFFF is forbidden, but in
Vulkan it is used to indicate a value is undefined. When converting to
WebGPU, 0xFFFFFFFF needs to converted to a legal value, though the
specific one does not matter, since it was used to indicate an
undefined entry in the original code. Choosing to use 0, since the
operands are required to be on [0, N-1], so 0 is guaranteed to always
be valid.

Fixes #2349