### PR TITLE
Fix spirv-headers link in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ version.  An API call reports the software version as a C-style string.
 
 * Support for SPIR-V 1.0, 1.1, 1.2, and 1.3
   * Based on SPIR-V syntax described by JSON grammar files in the
-    [SPIRV-Headers](spirv-headers) repository.
+    [SPIRV-Headers](https://github.com/KhronosGroup/SPIRV-Headers) repository.
 * Support for extended instruction sets:
   * GLSL std450 version 1.0 Rev 3
   * OpenCL version 1.0 Rev 2


### PR DESCRIPTION
Fixes #2515.