### PR TITLE
Fix use of 'is' operator for comparison

### DIFF
--- a/utils/check_symbol_exports.py
+++ b/utils/check_symbol_exports.py
@@ -81,7 +81,7 @@ def main():
         print('{}: error: {} does not exist'.format(PROG, args.library))
         sys.exit(1)
 
-    if os.name is 'posix':
+    if os.name == 'posix':
         status = check_library(args.library)
         sys.exit(status)
     else:


### PR DESCRIPTION
The 'is' operator is not meant to be used for comparisons. It currently working is an implementation detail of CPython.
CPython 3.8 has added a SyntaxWarning for this.