### PR TITLE
VK_KHR_uniform_buffer_standard_layout validation

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -504,6 +504,11 @@ SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetRelaxLogicalPointer(
 SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetRelaxBlockLayout(
     spv_validator_options options, bool val);
 
+// Records whether the validator should use standard block layout rules for
+// uniform blocks.
+SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetUniformBufferStandardLayout(
+    spv_validator_options options, bool val);
+
 // Records whether the validator should use "scalar" block layout rules.
 // Scalar layout rules are more permissive than relaxed block layout.
 //

--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -88,6 +88,12 @@ class ValidatorOptions {
     spvValidatorOptionsSetRelaxBlockLayout(options_, val);
   }
 
+  // Enables VK_KHR_uniform_buffer_standard_layout when validating standard
+  // uniform layout.  If true, disables scalar block layout rules.
+  void SetUniformBufferStandardLayout(bool val) {
+    spvValidatorOptionsSetUniformBufferStandardLayout(options_, val);
+  }
+
   // Enables VK_EXT_scalar_block_layout when validating standard
   // uniform/storage buffer/push-constant layout.  If true, disables
   // relaxed block layout rules.

--- a/source/spirv_validator_options.cpp
+++ b/source/spirv_validator_options.cpp
@@ -95,6 +95,11 @@ void spvValidatorOptionsSetRelaxBlockLayout(spv_validator_options options,
   options->relax_block_layout = val;
 }
 
+void spvValidatorOptionsSetUniformBufferStandardLayout(spv_validator_options options,
+                                            bool val) {
+  options->uniform_buffer_standard_layout = val;
+}
+
 void spvValidatorOptionsSetScalarBlockLayout(spv_validator_options options,
                                              bool val) {
   options->scalar_block_layout = val;

--- a/source/spirv_validator_options.cpp
+++ b/source/spirv_validator_options.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "source/spirv_validator_options.h"
+
 #include <cassert>
 #include <cstring>
-
-#include "source/spirv_validator_options.h"
 
 bool spvParseUniversalLimitsOptions(const char* s, spv_validator_limit* type) {
   auto match = [s](const char* b) {
@@ -95,8 +95,8 @@ void spvValidatorOptionsSetRelaxBlockLayout(spv_validator_options options,
   options->relax_block_layout = val;
 }
 
-void spvValidatorOptionsSetUniformBufferStandardLayout(spv_validator_options options,
-                                            bool val) {
+void spvValidatorOptionsSetUniformBufferStandardLayout(
+    spv_validator_options options, bool val) {
   options->uniform_buffer_standard_layout = val;
 }
 

--- a/source/spirv_validator_options.h
+++ b/source/spirv_validator_options.h
@@ -43,6 +43,7 @@ struct spv_validator_options_t {
         relax_struct_store(false),
         relax_logical_pointer(false),
         relax_block_layout(false),
+        uniform_buffer_standard_layout(false),
         scalar_block_layout(false),
         skip_block_layout(false) {}
 
@@ -50,6 +51,7 @@ struct spv_validator_options_t {
   bool relax_struct_store;
   bool relax_logical_pointer;
   bool relax_block_layout;
+  bool uniform_buffer_standard_layout;
   bool scalar_block_layout;
   bool skip_block_layout;
 };

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -384,6 +384,10 @@ spv_result_t checkLayout(uint32_t struct_id, const char* storage_class_str,
                          ValidationState_t& vstate) {
   if (vstate.options()->skip_block_layout) return SPV_SUCCESS;
 
+  // blockRules are the same as bufferBlock rules if the uniform buffer
+  // standard layout extension is being used.
+  if (vstate.options()->uniform_buffer_standard_layout) blockRules = false;
+
   // Relaxed layout and scalar layout can both be in effect at the same time.
   // For example, relaxed layout is implied by Vulkan 1.1.  But scalar layout
   // is more permissive than relaxed layout.

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -2254,7 +2254,8 @@ TEST_F(ValidateDecorations, BlockArrayBaseAlignmentWithVulkan1_1StillBad) {
           "member 1 at offset 8 is not aligned to 16"));
 }
 
-TEST_F(ValidateDecorations, BlockArrayBaseAlignmentWithBlockStandardLayoutGood) {
+TEST_F(ValidateDecorations,
+       BlockArrayBaseAlignmentWithBlockStandardLayoutGood) {
   // Same as previous test, but with VK_KHR_uniform_buffer_standard_layout
   std::string spirv = R"(
                OpCapability Shader
@@ -2284,7 +2285,8 @@ TEST_F(ValidateDecorations, BlockArrayBaseAlignmentWithBlockStandardLayoutGood) 
   )";
 
   CompileSuccessfully(spirv);
-  spvValidatorOptionsSetUniformBufferStandardLayout(getValidatorOptions(), true);
+  spvValidatorOptionsSetUniformBufferStandardLayout(getValidatorOptions(),
+                                                    true);
   EXPECT_EQ(SPV_SUCCESS,
             ValidateAndRetrieveValidationState(SPV_ENV_VULKAN_1_0));
   EXPECT_THAT(getDiagnosticString(), Eq(""));

--- a/tools/val/val.cpp
+++ b/tools/val/val.cpp
@@ -51,6 +51,8 @@ Options:
   --relax-block-layout             Enable VK_KHR_relaxed_block_layout when checking standard
                                    uniform, storage buffer, and push constant layouts.
                                    This is the default when targeting Vulkan 1.1 or later.
+  --uniform-buffer-standard-layout Enable VK_KHR_uniform_buffer_standard_layout when checking standard
+                                   uniform buffer layouts.
   --scalar-block-layout            Enable VK_EXT_scalar_block_layout when checking standard
                                    uniform, storage buffer, and push constant layouts.  Scalar layout
                                    rules are more permissive than relaxed block layout so in effect
@@ -140,6 +142,8 @@ int main(int argc, char** argv) {
         options.SetRelaxLogicalPointer(true);
       } else if (0 == strcmp(cur_arg, "--relax-block-layout")) {
         options.SetRelaxBlockLayout(true);
+      } else if (0 == strcmp(cur_arg, "--uniform-buffer-standard-layout")) {
+        options.SetUniformBufferStandardLayout(true);
       } else if (0 == strcmp(cur_arg, "--scalar-block-layout")) {
         options.SetScalarBlockLayout(true);
       } else if (0 == strcmp(cur_arg, "--skip-block-layout")) {


### PR DESCRIPTION
Add a command-line option to enable validating SPIR-V for
implementations that support VK_KHR_uniform_buffer_standard_layout.