### PR TITLE
Fix clang-tidy warning about definition/declaration mismatch.

### DIFF
--- a/source/opt/pass.cpp
+++ b/source/opt/pass.cpp
@@ -58,9 +58,9 @@ uint32_t Pass::GenerateCopy(Instruction* object_to_copy, uint32_t new_type_id,
   analysis::TypeManager* type_mgr = context()->get_type_mgr();
   analysis::ConstantManager* const_mgr = context()->get_constant_mgr();
 
-  uint32_t original_type_id = object_inst->type_id();
+  uint32_t original_type_id = object_to_copy->type_id();
   if (original_type_id == new_type_id) {
-    return object_inst->result_id();
+    return object_to_copy->result_id();
   }
 
   InstructionBuilder ir_builder(
@@ -86,7 +86,7 @@ uint32_t Pass::GenerateCopy(Instruction* object_to_copy, uint32_t new_type_id,
     uint32_t array_length = length_const->AsIntConstant()->GetU32();
     for (uint32_t i = 0; i < array_length; i++) {
       Instruction* extract = ir_builder.AddCompositeExtract(
-          original_element_type_id, object_inst->result_id(), {i});
+          original_element_type_id, object_to_copy->result_id(), {i});
       element_ids.push_back(
           GenerateCopy(extract, new_element_type_id, insertion_position));
     }
@@ -104,7 +104,7 @@ uint32_t Pass::GenerateCopy(Instruction* object_to_copy, uint32_t new_type_id,
     std::vector<uint32_t> element_ids;
     for (uint32_t i = 0; i < original_types.size(); i++) {
       Instruction* extract = ir_builder.AddCompositeExtract(
-          type_mgr->GetId(original_types[i]), object_inst->result_id(), {i});
+          type_mgr->GetId(original_types[i]), object_to_copy->result_id(), {i});
       element_ids.push_back(GenerateCopy(extract, type_mgr->GetId(new_types[i]),
                                          insertion_position));
     }

--- a/source/opt/pass.cpp
+++ b/source/opt/pass.cpp
@@ -53,7 +53,7 @@ uint32_t Pass::GetPointeeTypeId(const Instruction* ptrInst) const {
   return ptrTypeInst->GetSingleWordInOperand(kTypePointerTypeIdInIdx);
 }
 
-uint32_t Pass::GenerateCopy(Instruction* object_inst, uint32_t new_type_id,
+uint32_t Pass::GenerateCopy(Instruction* object_to_copy, uint32_t new_type_id,
                             Instruction* insertion_position) {
   analysis::TypeManager* type_mgr = context()->get_type_mgr();
   analysis::ConstantManager* const_mgr = context()->get_constant_mgr();


### PR DESCRIPTION
Found internally with clang-tidy.