### PR TITLE
Use last version

### DIFF
--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -97,6 +97,7 @@ spv_result_t spvOpcodeTableNameLookup(spv_target_env env,
   // preferable but the table requires sorting on the Opcode name, but it's
   // static const initialized and matches the order of the spec.
   const size_t nameLength = strlen(name);
+  const auto version = spvVersionForTargetEnv(env);
   for (uint64_t opcodeIndex = 0; opcodeIndex < table->count; ++opcodeIndex) {
     const spv_opcode_desc_t& entry = table->entries[opcodeIndex];
     // We considers the current opcode as available as long as
@@ -107,7 +108,7 @@ spv_result_t spvOpcodeTableNameLookup(spv_target_env env,
     // Note that the second rule assumes the extension enabling this instruction
     // is indeed requested in the SPIR-V code; checking that should be
     // validator's work.
-    if ((spvVersionForTargetEnv(env) >= entry.minVersion ||
+    if (((version >= entry.minVersion && version <= entry.lastVersion) ||
          entry.numExtensions > 0u || entry.numCapabilities > 0u) &&
         nameLength == strlen(entry.name) &&
         !strncmp(name, entry.name, nameLength)) {
@@ -130,8 +131,8 @@ spv_result_t spvOpcodeTableValueLookup(spv_target_env env,
   const auto beg = table->entries;
   const auto end = table->entries + table->count;
 
-  spv_opcode_desc_t needle = {"",    opcode, 0, nullptr, 0,  {},
-                              false, false,  0, nullptr, ~0u};
+  spv_opcode_desc_t needle = {"",    opcode, 0, nullptr, 0,   {},
+                              false, false,  0, nullptr, ~0u, ~0u};
 
   auto comp = [](const spv_opcode_desc_t& lhs, const spv_opcode_desc_t& rhs) {
     return lhs.opcode < rhs.opcode;
@@ -142,6 +143,7 @@ spv_result_t spvOpcodeTableValueLookup(spv_target_env env,
   // which means they can have different minimal version requirements.
   // Assumes the underlying table is already sorted ascendingly according to
   // opcode value.
+  const auto version = spvVersionForTargetEnv(env);
   for (auto it = std::lower_bound(beg, end, needle, comp);
        it != end && it->opcode == opcode; ++it) {
     // We considers the current opcode as available as long as
@@ -152,7 +154,7 @@ spv_result_t spvOpcodeTableValueLookup(spv_target_env env,
     // Note that the second rule assumes the extension enabling this instruction
     // is indeed requested in the SPIR-V code; checking that should be
     // validator's work.
-    if (spvVersionForTargetEnv(env) >= it->minVersion ||
+    if ((version >= it->minVersion && version <= it->lastVersion) ||
         it->numExtensions > 0u || it->numCapabilities > 0u) {
       *pEntry = it;
       return SPV_SUCCESS;
@@ -182,8 +184,8 @@ void spvInstructionCopy(const uint32_t* words, const SpvOp opcode,
 const char* spvOpcodeString(const SpvOp opcode) {
   const auto beg = kOpcodeTableEntries;
   const auto end = kOpcodeTableEntries + ARRAY_SIZE(kOpcodeTableEntries);
-  spv_opcode_desc_t needle = {"",    opcode, 0, nullptr, 0,  {},
-                              false, false,  0, nullptr, ~0u};
+  spv_opcode_desc_t needle = {"",    opcode, 0, nullptr, 0,   {},
+                              false, false,  0, nullptr, ~0u, ~0u};
   auto comp = [](const spv_opcode_desc_t& lhs, const spv_opcode_desc_t& rhs) {
     return lhs.opcode < rhs.opcode;
   };

--- a/source/operand.cpp
+++ b/source/operand.cpp
@@ -16,6 +16,7 @@
 
 #include <assert.h>
 #include <string.h>
+
 #include <algorithm>
 
 #include "source/macro.h"
@@ -50,6 +51,7 @@ spv_result_t spvOperandTableNameLookup(spv_target_env env,
   if (!table) return SPV_ERROR_INVALID_TABLE;
   if (!name || !pEntry) return SPV_ERROR_INVALID_POINTER;
 
+  const auto version = spvVersionForTargetEnv(env);
   for (uint64_t typeIndex = 0; typeIndex < table->count; ++typeIndex) {
     const auto& group = table->types[typeIndex];
     if (type != group.type) continue;
@@ -64,7 +66,7 @@ spv_result_t spvOperandTableNameLookup(spv_target_env env,
       // Note that the second rule assumes the extension enabling this operand
       // is indeed requested in the SPIR-V code; checking that should be
       // validator's work.
-      if ((spvVersionForTargetEnv(env) >= entry.minVersion ||
+      if (((version >= entry.minVersion && version <= entry.lastVersion) ||
            entry.numExtensions > 0u || entry.numCapabilities > 0u) &&
           nameLength == strlen(entry.name) &&
           !strncmp(entry.name, name, nameLength)) {
@@ -85,7 +87,7 @@ spv_result_t spvOperandTableValueLookup(spv_target_env env,
   if (!table) return SPV_ERROR_INVALID_TABLE;
   if (!pEntry) return SPV_ERROR_INVALID_POINTER;
 
-  spv_operand_desc_t needle = {"", value, 0, nullptr, 0, nullptr, {}, ~0u};
+  spv_operand_desc_t needle = {"", value, 0, nullptr, 0, nullptr, {}, ~0u, ~0u};
 
   auto comp = [](const spv_operand_desc_t& lhs, const spv_operand_desc_t& rhs) {
     return lhs.value < rhs.value;
@@ -108,6 +110,7 @@ spv_result_t spvOperandTableValueLookup(spv_target_env env,
     // requirements.
     // Assumes the underlying table is already sorted ascendingly according to
     // opcode value.
+    const auto version = spvVersionForTargetEnv(env);
     for (auto it = std::lower_bound(beg, end, needle, comp);
          it != end && it->value == value; ++it) {
       // We consider the current operand as available as long as
@@ -119,7 +122,7 @@ spv_result_t spvOperandTableValueLookup(spv_target_env env,
       // Note that the second rule assumes the extension enabling this operand
       // is indeed requested in the SPIR-V code; checking that should be
       // validator's work.
-      if (spvVersionForTargetEnv(env) >= it->minVersion ||
+      if ((version >= it->minVersion && version <= it->lastVersion) ||
           it->numExtensions > 0u || it->numCapabilities > 0u) {
         *pEntry = it;
         return SPV_SUCCESS;

--- a/source/table.h
+++ b/source/table.h
@@ -15,9 +15,8 @@
 #ifndef SOURCE_TABLE_H_
 #define SOURCE_TABLE_H_
 
-#include "source/latest_version_spirv_header.h"
-
 #include "source/extensions.h"
+#include "source/latest_version_spirv_header.h"
 #include "spirv-tools/libspirv.hpp"
 
 typedef struct spv_opcode_desc_t {
@@ -42,6 +41,7 @@ typedef struct spv_opcode_desc_t {
   // extensions. ~0u means reserved for future use. ~0u and non-empty extension
   // lists means only available in extensions.
   const uint32_t minVersion;
+  const uint32_t lastVersion;
 } spv_opcode_desc_t;
 
 typedef struct spv_operand_desc_t {
@@ -60,6 +60,7 @@ typedef struct spv_operand_desc_t {
   // extensions. ~0u means reserved for future use. ~0u and non-empty extension
   // lists means only available in extensions.
   const uint32_t minVersion;
+  const uint32_t lastVersion;
 } spv_operand_desc_t;
 
 typedef struct spv_operand_desc_group_t {

--- a/source/val/validate_instruction.cpp
+++ b/source/val/validate_instruction.cpp
@@ -309,20 +309,19 @@ spv_result_t VersionCheck(ValidationState_t& _, const Instruction* inst) {
 
   const auto min_version = inst_desc->minVersion;
   const auto last_version = inst_desc->lastVersion;
+  const auto module_version = _.version();
+
+  if (last_version < module_version) {
+    return _.diag(SPV_ERROR_WRONG_VERSION, inst)
+           << spvOpcodeString(opcode) << " requires SPIR-V version "
+           << SPV_SPIRV_VERSION_MAJOR_PART(last_version) << "."
+           << SPV_SPIRV_VERSION_MINOR_PART(last_version) << " or earlier";
+  }
 
   if (inst_desc->numCapabilities > 0u) {
     // We already checked that the direct capability dependency has been
     // satisfied. We don't need to check any further.
     return SPV_SUCCESS;
-  }
-
-  const auto module_version = _.version();
-
-  if (last_version < module_version) {
-    return _.diag(SPV_ERROR_WRONG_VERSION, inst)
-           << spvOpcodeString(opcode) << " requires "
-           << spvTargetEnvDescription(static_cast<spv_target_env>(last_version))
-           << " at maximum.";
   }
 
   ExtensionSet exts(inst_desc->numExtensions, inst_desc->extensions);

--- a/test/val/val_atomics_test.cpp
+++ b/test/val/val_atomics_test.cpp
@@ -1975,6 +1975,29 @@ TEST_F(ValidateAtomics, WebGPUQueueFamilyMemoryScopeGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_WEBGPU_0));
 }
 
+TEST_F(ValidateAtomics, CompareExchangeWeakV13ValV14Good) {
+  const std::string body = R"(
+%val1 = OpAtomicCompareExchangeWeak %u32 %u32_var %device %relaxed %relaxed %u32_0 %u32_0
+)";
+
+  CompileSuccessfully(GenerateKernelCode(body), SPV_ENV_UNIVERSAL_1_3);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_4));
+}
+
+TEST_F(ValidateAtomics, CompareExchangeWeakV14Bad) {
+  const std::string body = R"(
+%val1 = OpAtomicCompareExchangeWeak %u32 %u32_var %device %relaxed %relaxed %u32_0 %u32_0
+)";
+
+  CompileSuccessfully(GenerateKernelCode(body), SPV_ENV_UNIVERSAL_1_4);
+  EXPECT_EQ(SPV_ERROR_WRONG_VERSION,
+            ValidateInstructions(SPV_ENV_UNIVERSAL_1_4));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(
+          "AtomicCompareExchangeWeak requires SPIR-V version 1.3 or earlier"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -6332,6 +6332,36 @@ TEST_F(ValidateDecorations, NonWritableVarFunctionV13TargetV14Bad) {
                         "buffer\n  %var_func"));
 }
 
+TEST_F(ValidateDecorations, BufferBlockV13ValV14Good) {
+  std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %1 BufferBlock
+%1 = OpTypeStruct
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_4));
+}
+
+TEST_F(ValidateDecorations, BufferBlockV14Bad) {
+  std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %1 BufferBlock
+%1 = OpTypeStruct
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_4);
+  EXPECT_EQ(SPV_ERROR_WRONG_VERSION,
+            ValidateInstructions(SPV_ENV_UNIVERSAL_1_4));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("2nd operand of Decorate: operand BufferBlock(3) "
+                        "requires SPIR-V version 1.3 or earlier"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools

--- a/utils/generate_grammar_tables.py
+++ b/utils/generate_grammar_tables.py
@@ -62,6 +62,14 @@ def convert_min_required_version(version):
     return 'SPV_SPIRV_VERSION_WORD({})'.format(version.replace('.', ','))
 
 
+def convert_max_required_version(version):
+    """Converts the maximum required SPIR-V version encoded in the
+    grammar to the symbol in SPIRV-Tools"""
+    if version is None:
+        return '0xffffffffu'
+    return 'SPV_SPIRV_VERSION_WORD({})'.format(version.replace('.', ','))
+
+
 def compose_capability_list(caps):
     """Returns a string containing a braced list of capabilities as enums.
 
@@ -206,7 +214,7 @@ class InstInitializer(object):
     """Instances holds a SPIR-V instruction suitable for printing as
     the initializer for spv_opcode_desc_t."""
 
-    def __init__(self, opname, caps, exts, operands, version):
+    def __init__(self, opname, caps, exts, operands, version, lastVersion):
         """Initialization.
 
         Arguments:
@@ -215,6 +223,7 @@ class InstInitializer(object):
           - exts: a sequence of names of extensions enabling this enumerant
           - operands: a sequence of (operand-kind, operand-quantifier) tuples
           - version: minimal SPIR-V version required for this opcode
+          - lastVersion: last version of SPIR-V that includes this opcode
         """
 
         assert opname.startswith('Op')
@@ -232,6 +241,7 @@ class InstInitializer(object):
         self.def_result_id = 'IdResult' in operands
 
         self.version = convert_min_required_version(version)
+        self.lastVersion = convert_max_required_version(lastVersion)
 
     def fix_syntax(self):
         """Fix an instruction's syntax, adjusting for differences between
@@ -251,7 +261,7 @@ class InstInitializer(object):
                     '{num_operands}', '{{{operands}}}',
                     '{def_result_id}', '{ref_type_id}',
                     '{num_exts}', '{exts}',
-                    '{min_version}}}']
+                    '{min_version}', '{max_version}}}']
         return ', '.join(template).format(
             opname=self.opname,
             num_caps=self.num_caps,
@@ -262,7 +272,8 @@ class InstInitializer(object):
             ref_type_id=(1 if self.ref_type_id else 0),
             num_exts=self.num_exts,
             exts=self.exts,
-            min_version=self.version)
+            min_version=self.version,
+            max_version=self.lastVersion)
 
 
 class ExtInstInitializer(object):
@@ -315,13 +326,14 @@ def generate_instruction(inst, is_ext_inst):
     operands = inst.get('operands', {})
     operands = [(o['kind'], o.get('quantifier', '')) for o in operands]
     min_version = inst.get('version', None)
+    max_version = inst.get('lastVersion', None)
 
     assert opname is not None
 
     if is_ext_inst:
         return str(ExtInstInitializer(opname, opcode, caps, operands))
     else:
-        return str(InstInitializer(opname, caps, exts, operands, min_version))
+        return str(InstInitializer(opname, caps, exts, operands, min_version, max_version))
 
 
 def generate_instruction_table(inst_table):
@@ -370,7 +382,7 @@ def generate_extended_instruction_table(inst_table, set_name):
 class EnumerantInitializer(object):
     """Prints an enumerant as the initializer for spv_operand_desc_t."""
 
-    def __init__(self, enumerant, value, caps, exts, parameters, version):
+    def __init__(self, enumerant, value, caps, exts, parameters, version, lastVersion):
         """Initialization.
 
         Arguments:
@@ -380,6 +392,7 @@ class EnumerantInitializer(object):
           - exts: a sequence of names of extensions enabling this enumerant
           - parameters: a sequence of (operand-kind, operand-quantifier) tuples
           - version: minimal SPIR-V version required for this opcode
+          - lastVersion: last SPIR-V version this opode appears
         """
         self.enumerant = enumerant
         self.value = value
@@ -389,11 +402,13 @@ class EnumerantInitializer(object):
         self.exts = get_extension_array_name(exts)
         self.parameters = [convert_operand_kind(p) for p in parameters]
         self.version = convert_min_required_version(version)
+        self.lastVersion = convert_max_required_version(lastVersion)
 
     def __str__(self):
         template = ['{{"{enumerant}"', '{value}', '{num_caps}',
                     '{caps}', '{num_exts}', '{exts}',
-                    '{{{parameters}}}', '{min_version}}}']
+                    '{{{parameters}}}', '{min_version}',
+                    '{max_version}}}']
         return ', '.join(template).format(
             enumerant=self.enumerant,
             value=self.value,
@@ -402,7 +417,8 @@ class EnumerantInitializer(object):
             num_exts=self.num_exts,
             exts=self.exts,
             parameters=', '.join(self.parameters),
-            min_version=self.version)
+            min_version=self.version,
+            max_version=self.lastVersion)
 
 
 def generate_enum_operand_kind_entry(entry, extension_map):
@@ -426,12 +442,13 @@ def generate_enum_operand_kind_entry(entry, extension_map):
     params = [p.get('kind') for p in params]
     params = zip(params, [''] * len(params))
     version = entry.get('version', None)
+    max_version = entry.get('lastVersion', None)
 
     assert enumerant is not None
     assert value is not None
 
     return str(EnumerantInitializer(
-        enumerant, value, caps, exts, params, version))
+        enumerant, value, caps, exts, params, version, max_version))
 
 
 def generate_enum_operand_kind(enum, synthetic_exts_list):


### PR DESCRIPTION
Grammar tables now include lastVersion entry. This is used to perform version checks. The assembler remains quite liberal about allowing things past their last version if there is an enabling capability, but validation fails.

Changes to NonWritable tests were for ease of extension.