### PR TITLE
Linker: Better type comparison for OpTypeArray and OpTypeForwardPointer

### DIFF
--- a/source/opt/remove_duplicates_pass.h
+++ b/source/opt/remove_duplicates_pass.h
@@ -36,12 +36,6 @@ class RemoveDuplicatesPass : public Pass {
   const char* name() const override { return "remove-duplicates"; }
   Status Process() override;
 
-  // TODO(pierremoreau): Move this function somewhere else (e.g. pass.h or
-  // within the type manager)
-  // Returns whether two types are equal, and have the same decorations.
-  static bool AreTypesEqual(const Instruction& inst1, const Instruction& inst2,
-                            IRContext* context);
-
  private:
   // Remove duplicate capabilities from the module
   //

--- a/source/opt/type_manager.h
+++ b/source/opt/type_manager.h
@@ -209,6 +209,8 @@ class TypeManager {
 
   IdToTypeMap id_to_incomplete_type_;  // Maps ids to their type representations
                                        // for incomplete types.
+
+  std::unordered_map<uint32_t, const Instruction*> id_to_constant_inst_;
 };
 
 }  // namespace analysis

--- a/source/opt/types.h
+++ b/source/opt/types.h
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "source/latest_version_spirv_header.h"
+#include "source/opt/instruction.h"
 #include "spirv-tools/libspirv.h"
 
 namespace spvtools {
@@ -356,12 +357,19 @@ class SampledImage : public Type {
 
 class Array : public Type {
  public:
-  Array(Type* element_type, uint32_t length_id);
+  Array(Type* element_type, uint32_t length_id, uint32_t spec_id);
+  Array(Type* element_type, uint32_t length_id, const Type* constant_type,
+        Operand::OperandData constant_words);
   Array(const Array&) = default;
 
   std::string str() const override;
   const Type* element_type() const { return element_type_; }
   uint32_t LengthId() const { return length_id_; }
+  uint32_t length_spec_id() const { return length_spec_id_; }
+  const Type* length_constant_type() const { return length_constant_type_; }
+  Operand::OperandData length_constant_words() const {
+    return length_constant_words_;
+  }
 
   Array* AsArray() override { return this; }
   const Array* AsArray() const override { return this; }
@@ -376,6 +384,9 @@ class Array : public Type {
 
   const Type* element_type_;
   uint32_t length_id_;
+  uint32_t length_spec_id_;
+  const Type* length_constant_type_;
+  Operand::OperandData length_constant_words_;
 };
 
 class RuntimeArray : public Type {

--- a/test/opt/type_manager_test.cpp
+++ b/test/opt/type_manager_test.cpp
@@ -117,10 +117,10 @@ std::vector<std::unique_ptr<Type>> GenerateAllTypes() {
   types.emplace_back(new SampledImage(image2));
 
   // Array
-  types.emplace_back(new Array(f32, 100));
-  types.emplace_back(new Array(f32, 42));
+  types.emplace_back(new Array(f32, 100, 1u));
+  types.emplace_back(new Array(f32, 42, 2u));
   auto* a42f32 = types.back().get();
-  types.emplace_back(new Array(u64, 24));
+  types.emplace_back(new Array(u64, 24, s32, {42}));
 
   // RuntimeArray
   types.emplace_back(new RuntimeArray(v3f32));

--- a/test/opt/types_test.cpp
+++ b/test/opt/types_test.cpp
@@ -72,7 +72,7 @@ TestMultipleInstancesOfTheSameType(Image, f64_t_.get(), SpvDimCube, 0, 0, 1, 1,
                                    SpvAccessQualifierWriteOnly);
 TestMultipleInstancesOfTheSameType(Sampler);
 TestMultipleInstancesOfTheSameType(SampledImage, image_t_.get());
-TestMultipleInstancesOfTheSameType(Array, u32_t_.get(), 10);
+TestMultipleInstancesOfTheSameType(Array, u32_t_.get(), 10, 3);
 TestMultipleInstancesOfTheSameType(RuntimeArray, u32_t_.get());
 TestMultipleInstancesOfTheSameType(Struct, std::vector<const Type*>{
                                                u32_t_.get(), f64_t_.get()});
@@ -151,10 +151,10 @@ std::vector<std::unique_ptr<Type>> GenerateAllTypes() {
   types.emplace_back(new SampledImage(image2));
 
   // Array
-  types.emplace_back(new Array(f32, 100));
-  types.emplace_back(new Array(f32, 42));
+  types.emplace_back(new Array(f32, 100, 1u));
+  types.emplace_back(new Array(f32, 42, 2u));
   auto* a42f32 = types.back().get();
-  types.emplace_back(new Array(u64, 24));
+  types.emplace_back(new Array(u64, 24, s32, {42}));
 
   // RuntimeArray
   types.emplace_back(new RuntimeArray(v3f32));


### PR DESCRIPTION
This is an attempt to fix #2442 by re-implementing type comparisons for `OpTypeArray`. This new comparison checks that the values of the constants are the same, or if those are specialised constants, that they refer to the same `SpecId`.