### PR TITLE
Allow arrays of out per-primitive builtins for mesh shaders

### DIFF
--- a/test/val/val_code_generator.cpp
+++ b/test/val/val_code_generator.cpp
@@ -46,6 +46,8 @@ std::string GetDefaultShaderTypes() {
 %bool = OpTypeBool
 %f32 = OpTypeFloat 32
 %f64 = OpTypeFloat 64
+%i32 = OpTypeInt 32 1
+%i64 = OpTypeInt 64 1
 %u32 = OpTypeInt 32 0
 %u64 = OpTypeInt 64 0
 %f32vec2 = OpTypeVector %f32 2


### PR DESCRIPTION
- Allow arrays of out per-primitive builtins for mesh shaders - PrimitiveID, Layer, ViewportIndex.
- We already allow arrays of per-vertex builtins such as Position, PointSize, etc. (see use of similar function ValidateOptionalArrayedF32 for reference).