### PR TITLE
Handle nested breaks from switches.

### DIFF
--- a/source/opt/dead_branch_elim_pass.cpp
+++ b/source/opt/dead_branch_elim_pass.cpp
@@ -169,24 +169,43 @@ bool DeadBranchElimPass::MarkLiveBlocks(
 
     if (simplify) {
       modified = true;
-      // Replace with unconditional branch.
-      // Remove the merge instruction if it is a selection merge.
-      AddBranch(live_lab_id, block);
-      context()->KillInst(terminator);
+      // Replace branch with a simpler branch.
+      // Fix up the merge instruction if it is a selection merge.
       Instruction* mergeInst = block->GetMergeInst();
       if (mergeInst && mergeInst->opcode() == SpvOpSelectionMerge) {
-        Instruction* first_break = FindFirstExitFromSelectionMerge(
-            live_lab_id, mergeInst->GetSingleWordInOperand(0),
-            cfgAnalysis->LoopMergeBlock(live_lab_id),
-            cfgAnalysis->LoopContinueBlock(live_lab_id));
-        if (first_break == nullptr) {
-          context()->KillInst(mergeInst);
+        if (mergeInst->NextNode()->opcode() == SpvOpSwitch &&
+            SwitchHasNestedBreak(block->id())) {
+          // We have to keep the switch because it has a nest break, so we
+          // remove all cases except for the live one.
+          Instruction::OperandList new_operands;
+          new_operands.push_back(terminator->GetInOperand(0));
+          new_operands.push_back({SPV_OPERAND_TYPE_ID, {live_lab_id}});
+          terminator->SetInOperands(std::move(new_operands));
+          context()->UpdateDefUse(terminator);
         } else {
-          mergeInst->RemoveFromList();
-          first_break->InsertBefore(std::unique_ptr<Instruction>(mergeInst));
-          context()->set_instr_block(mergeInst,
-                                     context()->get_instr_block(first_break));
+          // Check if the merge instruction is still needed because of a non
+          // nested break from the construct.  More the merge instruction if it
+          // is still needed.
+          Instruction* first_break = FindFirstExitFromSelectionMerge(
+              live_lab_id, mergeInst->GetSingleWordInOperand(0),
+              cfgAnalysis->LoopMergeBlock(live_lab_id),
+              cfgAnalysis->LoopContinueBlock(live_lab_id),
+              cfgAnalysis->SwitchMergeBlock(live_lab_id));
+
+          AddBranch(live_lab_id, block);
+          context()->KillInst(terminator);
+          if (first_break == nullptr) {
+            context()->KillInst(mergeInst);
+          } else {
+            mergeInst->RemoveFromList();
+            first_break->InsertBefore(std::unique_ptr<Instruction>(mergeInst));
+            context()->set_instr_block(mergeInst,
+                                       context()->get_instr_block(first_break));
+          }
         }
+      } else {
+        AddBranch(live_lab_id, block);
+        context()->KillInst(terminator);
       }
       stack.push_back(GetParentBlock(live_lab_id));
     } else {
@@ -455,11 +474,12 @@ Pass::Status DeadBranchElimPass::Process() {
 
 Instruction* DeadBranchElimPass::FindFirstExitFromSelectionMerge(
     uint32_t start_block_id, uint32_t merge_block_id, uint32_t loop_merge_id,
-    uint32_t loop_continue_id) {
+    uint32_t loop_continue_id, uint32_t switch_merge_id) {
   // To find the "first" exit, we follow branches looking for a conditional
   // branch that is not in a nested construct and is not the header of a new
   // construct.  We follow the control flow from |start_block_id| to find the
   // first one.
+
   while (start_block_id != merge_block_id && start_block_id != loop_merge_id &&
          start_block_id != loop_continue_id) {
     BasicBlock* start_block = context()->get_instr_block(start_block_id);
@@ -483,6 +503,11 @@ Instruction* DeadBranchElimPass::FindFirstExitFromSelectionMerge(
               next_block_id = branch->GetSingleWordInOperand(3 - i);
               break;
             }
+            if (branch->GetSingleWordInOperand(i) == switch_merge_id &&
+                switch_merge_id != merge_block_id) {
+              next_block_id = branch->GetSingleWordInOperand(3 - i);
+              break;
+            }
           }
 
           if (next_block_id == 0) {
@@ -493,11 +518,15 @@ Instruction* DeadBranchElimPass::FindFirstExitFromSelectionMerge(
       case SpvOpSwitch:
         next_block_id = start_block->MergeBlockIdIfAny();
         if (next_block_id == 0) {
-          // A switch with no merge instructions can have at most 4 targets:
+          // A switch with no merge instructions can have at most 5 targets:
           //   a. |merge_block_id|
           //   b. |loop_merge_id|
           //   c. |loop_continue_id|
-          //   d. 1 block inside the current region.
+          //   d. |switch_merge_id|
+          //   e. 1 block inside the current region.
+          //
+          // Note that because this is a switch, |merge_block_id| must equal
+          // |switch_merge_id|.
           //
           // This leads to a number of cases of what to do.
           //
@@ -511,7 +540,6 @@ Instruction* DeadBranchElimPass::FindFirstExitFromSelectionMerge(
           //
           // 3.  Otherwise, this branch may break, but not to the current merge
           // block.  So we continue with the block that is inside the loop.
-
           bool found_break = false;
           for (uint32_t i = 1; i < branch->NumInOperands(); i += 2) {
             uint32_t target = branch->GetSingleWordInOperand(i);
@@ -583,6 +611,26 @@ void DeadBranchElimPass::AddBlocksWithBackEdge(
       blocks_with_back_edges->insert(bb);
     }
   }
+}
+
+bool DeadBranchElimPass::SwitchHasNestedBreak(uint32_t start_block_id) {
+  std::vector<BasicBlock*> block_in_construct;
+  BasicBlock* start_block = context()->get_instr_block(start_block_id);
+  uint32_t merge_block_id = start_block->MergeBlockIdIfAny();
+
+  StructuredCFGAnalysis* cfg_analysis = context()->GetStructuredCFGAnalysis();
+  return !get_def_use_mgr()->WhileEachUser(
+      merge_block_id, [this, cfg_analysis, start_block_id](Instruction* inst) {
+        if (!inst->IsBranch()) {
+          return true;
+        }
+
+        BasicBlock* bb = context()->get_instr_block(inst);
+        if (bb->id() == start_block_id) {
+          return true;
+        }
+        return (cfg_analysis->ContainingConstruct(inst) == start_block_id);
+      });
 }
 
 }  // namespace opt

--- a/source/opt/dead_branch_elim_pass.cpp
+++ b/source/opt/dead_branch_elim_pass.cpp
@@ -620,7 +620,8 @@ bool DeadBranchElimPass::SwitchHasNestedBreak(uint32_t switch_header_id) {
 
   StructuredCFGAnalysis* cfg_analysis = context()->GetStructuredCFGAnalysis();
   return !get_def_use_mgr()->WhileEachUser(
-      merge_block_id, [this, cfg_analysis, switch_header_id](Instruction* inst) {
+      merge_block_id,
+      [this, cfg_analysis, switch_header_id](Instruction* inst) {
         if (!inst->IsBranch()) {
           return true;
         }

--- a/source/opt/dead_branch_elim_pass.cpp
+++ b/source/opt/dead_branch_elim_pass.cpp
@@ -183,9 +183,9 @@ bool DeadBranchElimPass::MarkLiveBlocks(
           terminator->SetInOperands(std::move(new_operands));
           context()->UpdateDefUse(terminator);
         } else {
-          // Check if the merge instruction is still needed because of a non
-          // nested break from the construct.  More the merge instruction if it
-          // is still needed.
+          // Check if the merge instruction is still needed because of a
+          // non-nested break from the construct.  Move the merge instruction if
+          // it is still needed.
           Instruction* first_break = FindFirstExitFromSelectionMerge(
               live_lab_id, mergeInst->GetSingleWordInOperand(0),
               cfgAnalysis->LoopMergeBlock(live_lab_id),

--- a/source/opt/dead_branch_elim_pass.cpp
+++ b/source/opt/dead_branch_elim_pass.cpp
@@ -613,23 +613,23 @@ void DeadBranchElimPass::AddBlocksWithBackEdge(
   }
 }
 
-bool DeadBranchElimPass::SwitchHasNestedBreak(uint32_t start_block_id) {
+bool DeadBranchElimPass::SwitchHasNestedBreak(uint32_t switch_header_id) {
   std::vector<BasicBlock*> block_in_construct;
-  BasicBlock* start_block = context()->get_instr_block(start_block_id);
+  BasicBlock* start_block = context()->get_instr_block(switch_header_id);
   uint32_t merge_block_id = start_block->MergeBlockIdIfAny();
 
   StructuredCFGAnalysis* cfg_analysis = context()->GetStructuredCFGAnalysis();
   return !get_def_use_mgr()->WhileEachUser(
-      merge_block_id, [this, cfg_analysis, start_block_id](Instruction* inst) {
+      merge_block_id, [this, cfg_analysis, switch_header_id](Instruction* inst) {
         if (!inst->IsBranch()) {
           return true;
         }
 
         BasicBlock* bb = context()->get_instr_block(inst);
-        if (bb->id() == start_block_id) {
+        if (bb->id() == switch_header_id) {
           return true;
         }
-        return (cfg_analysis->ContainingConstruct(inst) == start_block_id);
+        return (cfg_analysis->ContainingConstruct(inst) == switch_header_id);
       });
 }
 

--- a/source/opt/dead_branch_elim_pass.h
+++ b/source/opt/dead_branch_elim_pass.h
@@ -148,7 +148,7 @@ class DeadBranchElimPass : public MemPass {
                                                uint32_t merge_block_id,
                                                uint32_t loop_merge_id,
                                                uint32_t loop_continue_id,
-                                               uint32_t i);
+                                               uint32_t switch_merge_id);
 
   // Adds to |blocks_with_back_edges| all of the blocks on the path from the
   // basic block |cont_id| to |header_id| and |merge_id|.  The intention is that
@@ -157,7 +157,10 @@ class DeadBranchElimPass : public MemPass {
   void AddBlocksWithBackEdge(
       uint32_t cont_id, uint32_t header_id, uint32_t merge_id,
       std::unordered_set<BasicBlock*>* blocks_with_back_edges);
-  bool SwitchHasNestedBreak(uint32_t start_block_id);
+
+  // Returns true if there is a brach to the merge node of the selection
+  // construct |switch_header_id| that is inside a nested selection construct.
+  bool SwitchHasNestedBreak(uint32_t switch_header_id);
 };
 
 }  // namespace opt

--- a/source/opt/dead_branch_elim_pass.h
+++ b/source/opt/dead_branch_elim_pass.h
@@ -147,7 +147,8 @@ class DeadBranchElimPass : public MemPass {
   Instruction* FindFirstExitFromSelectionMerge(uint32_t start_block_id,
                                                uint32_t merge_block_id,
                                                uint32_t loop_merge_id,
-                                               uint32_t loop_continue_id);
+                                               uint32_t loop_continue_id,
+                                               uint32_t i);
 
   // Adds to |blocks_with_back_edges| all of the blocks on the path from the
   // basic block |cont_id| to |header_id| and |merge_id|.  The intention is that
@@ -156,6 +157,7 @@ class DeadBranchElimPass : public MemPass {
   void AddBlocksWithBackEdge(
       uint32_t cont_id, uint32_t header_id, uint32_t merge_id,
       std::unordered_set<BasicBlock*>* blocks_with_back_edges);
+  bool SwitchHasNestedBreak(uint32_t start_block_id);
 };
 
 }  // namespace opt

--- a/source/opt/struct_cfg_analysis.h
+++ b/source/opt/struct_cfg_analysis.h
@@ -42,6 +42,11 @@ class StructuredCFGAnalysis {
     return it->second.containing_construct;
   }
 
+  // Returns the id of the header of the innermost merge construct
+  // that contains |inst|.  Returns |0| if |inst| is not contained in any
+  // merge construct.
+  uint32_t ContainingConstruct(Instruction* inst);
+
   // Returns the id of the merge block of the innermost merge construct
   // that contains |bb_id|.  Returns |0| if |bb_id| is not contained in any
   // merge construct.
@@ -68,6 +73,21 @@ class StructuredCFGAnalysis {
   // construct.
   uint32_t LoopContinueBlock(uint32_t bb_id);
 
+  // Returns the id of the header of the innermost switch construct
+  // that contains |bb_id| as long as there is no intervening loop.  Returns |0|
+  // if construct exists.
+  uint32_t ContainingSwitch(uint32_t bb_id) {
+    auto it = bb_to_construct_.find(bb_id);
+    if (it == bb_to_construct_.end()) {
+      return 0;
+    }
+    return it->second.containing_switch;
+  }
+  // Returns the id of the merge block of the innermost switch construct
+  // that contains |bb_id| as long as there is no intervening loop.  Return |0|
+  // if no such block exists.
+  uint32_t SwitchMergeBlock(uint32_t bb_id);
+
   bool IsContinueBlock(uint32_t bb_id);
   bool IsMergeBlock(uint32_t bb_id);
 
@@ -82,6 +102,7 @@ class StructuredCFGAnalysis {
   struct ConstructInfo {
     uint32_t containing_construct;
     uint32_t containing_loop;
+    uint32_t containing_switch;
   };
 
   // Populates |bb_to_construct_| with the innermost containing merge and loop

--- a/source/opt/struct_cfg_analysis.h
+++ b/source/opt/struct_cfg_analysis.h
@@ -75,7 +75,7 @@ class StructuredCFGAnalysis {
 
   // Returns the id of the header of the innermost switch construct
   // that contains |bb_id| as long as there is no intervening loop.  Returns |0|
-  // if construct exists.
+  // if no such construct exists.
   uint32_t ContainingSwitch(uint32_t bb_id) {
     auto it = bb_to_construct_.find(bb_id);
     if (it == bb_to_construct_.end()) {

--- a/test/opt/dead_branch_elim_test.cpp
+++ b/test/opt/dead_branch_elim_test.cpp
@@ -3034,7 +3034,7 @@ TEST_F(DeadBranchElimTest, FoldSwitchWithNestedBreak) {
   SinglePassRunAndMatch<DeadBranchElimPass>(spirv, true);
 }
 
-TEST_F(DeadBranchElimTest, FoldBrachWithBreakToSwitch) {
+TEST_F(DeadBranchElimTest, FoldBranchWithBreakToSwitch) {
   const std::string spirv = R"(
 ; CHECK: OpSelectionMerge [[sel_merge:%\w+]]
 ; CHECK-NEXT: OpSwitch {{%\w+}} {{%\w+}} 3 [[bb:%\w+]]

--- a/test/opt/dead_branch_elim_test.cpp
+++ b/test/opt/dead_branch_elim_test.cpp
@@ -2993,6 +2993,94 @@ OpFunctionEnd
   SinglePassRunAndMatch<DeadBranchElimPass>(spirv, true);
 }
 
+// Fold a switch with a nested break.  The only case should be the default.
+TEST_F(DeadBranchElimTest, FoldSwitchWithNestedBreak) {
+  const std::string spirv = R"(
+; CHECK: OpSwitch %int_3 [[case_bb:%\w+]]{{[[:space:]]}}
+; CHECK: [[case_bb]] = OpLabel
+; CHECK-NEXT: OpUndef
+; CHECK-NEXT: OpSelectionMerge
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %2 "main"
+               OpSource GLSL 450
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+      %int_3 = OpConstant %int 3
+      %int_1 = OpConstant %int 1
+       %bool = OpTypeBool
+          %2 = OpFunction %void None %4
+         %10 = OpLabel
+               OpSelectionMerge %11 None
+               OpSwitch %int_3 %12 3 %13
+         %12 = OpLabel
+               OpBranch %11
+         %13 = OpLabel
+         %14 = OpUndef %bool
+               OpSelectionMerge %15 None
+               OpBranchConditional %14 %16 %15
+         %16 = OpLabel
+               OpBranch %11
+         %15 = OpLabel
+               OpBranch %11
+         %11 = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<DeadBranchElimPass>(spirv, true);
+}
+
+TEST_F(DeadBranchElimTest, FoldBrachWithBreakToSwitch) {
+  const std::string spirv = R"(
+; CHECK: OpSelectionMerge [[sel_merge:%\w+]]
+; CHECK-NEXT: OpSwitch {{%\w+}} {{%\w+}} 3 [[bb:%\w+]]
+; CHECK: [[bb]] = OpLabel
+; CHECK-NEXT: OpBranch [[bb2:%\w+]]
+; CHECK: [[bb2]] = OpLabel
+; CHECK-NOT: OpSelectionMerge
+; CHECK: OpFunctionEnd
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %2 "main"
+               OpSource GLSL 450
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+      %int_3 = OpConstant %int 3
+      %int_1 = OpConstant %int 1
+       %bool = OpTypeBool
+       %true = OpConstantTrue %bool
+          %2 = OpFunction %void None %4
+         %10 = OpLabel
+  %undef_int = OpUndef %int
+               OpSelectionMerge %11 None
+               OpSwitch %undef_int %12 3 %13
+         %12 = OpLabel
+               OpBranch %11
+         %13 = OpLabel
+               OpSelectionMerge %15 None
+               OpBranchConditional %true %16 %15
+         %16 = OpLabel
+         %14 = OpUndef %bool
+               OpBranchConditional %14 %11 %17
+         %17 = OpLabel
+               OpBranch %15
+         %15 = OpLabel
+               OpBranch %11
+         %11 = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<DeadBranchElimPass>(spirv, true);
+}
+
 // TODO(greg-lunarg): Add tests to verify handling of these cases:
 //
 //    More complex control flow

--- a/test/opt/struct_cfg_analysis_test.cpp
+++ b/test/opt/struct_cfg_analysis_test.cpp
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "source/opt/struct_cfg_analysis.h"
+
 #include <string>
 
 #include "gmock/gmock.h"
-#include "source/opt/struct_cfg_analysis.h"
 #include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"
@@ -59,18 +60,24 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(1), 0);
   EXPECT_EQ(analysis.MergeBlock(1), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(1), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(1), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(1), 0);
 
   // BB2 is in the construct.
   EXPECT_EQ(analysis.ContainingConstruct(2), 1);
   EXPECT_EQ(analysis.ContainingLoop(2), 0);
   EXPECT_EQ(analysis.MergeBlock(2), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(2), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(2), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(2), 0);
 
   // The merge node is not in the construct.
   EXPECT_EQ(analysis.ContainingConstruct(3), 0);
   EXPECT_EQ(analysis.ContainingLoop(3), 0);
   EXPECT_EQ(analysis.MergeBlock(3), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(3), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(3), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(3), 0);
 }
 
 TEST_F(StructCFGAnalysisTest, BBInLoop) {
@@ -110,24 +117,32 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(1), 0);
   EXPECT_EQ(analysis.MergeBlock(1), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(1), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(1), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(1), 0);
 
   // BB2 is in the construct.
   EXPECT_EQ(analysis.ContainingConstruct(2), 1);
   EXPECT_EQ(analysis.ContainingLoop(2), 1);
   EXPECT_EQ(analysis.MergeBlock(2), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(2), 3);
+  EXPECT_EQ(analysis.ContainingSwitch(2), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(2), 0);
 
   // The merge node is not in the construct.
   EXPECT_EQ(analysis.ContainingConstruct(3), 0);
   EXPECT_EQ(analysis.ContainingLoop(3), 0);
   EXPECT_EQ(analysis.MergeBlock(3), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(3), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(3), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(3), 0);
 
   // The continue block is in the construct.
   EXPECT_EQ(analysis.ContainingConstruct(4), 1);
   EXPECT_EQ(analysis.ContainingLoop(4), 1);
   EXPECT_EQ(analysis.MergeBlock(4), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(4), 3);
+  EXPECT_EQ(analysis.ContainingSwitch(4), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(4), 0);
 }
 
 TEST_F(StructCFGAnalysisTest, SelectionInLoop) {
@@ -172,36 +187,48 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(1), 0);
   EXPECT_EQ(analysis.MergeBlock(1), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(1), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(1), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(1), 0);
 
   // Selection header is in the loop only.
   EXPECT_EQ(analysis.ContainingConstruct(2), 1);
   EXPECT_EQ(analysis.ContainingLoop(2), 1);
   EXPECT_EQ(analysis.MergeBlock(2), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(2), 3);
+  EXPECT_EQ(analysis.ContainingSwitch(2), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(2), 0);
 
   // The loop merge node is not in either construct.
   EXPECT_EQ(analysis.ContainingConstruct(3), 0);
   EXPECT_EQ(analysis.ContainingLoop(3), 0);
   EXPECT_EQ(analysis.MergeBlock(3), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(3), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(3), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(3), 0);
 
   // The continue block is in the loop only.
   EXPECT_EQ(analysis.ContainingConstruct(4), 1);
   EXPECT_EQ(analysis.ContainingLoop(4), 1);
   EXPECT_EQ(analysis.MergeBlock(4), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(4), 3);
+  EXPECT_EQ(analysis.ContainingSwitch(4), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(4), 0);
 
   // BB5 is in the selection fist and the loop.
   EXPECT_EQ(analysis.ContainingConstruct(5), 2);
   EXPECT_EQ(analysis.ContainingLoop(5), 1);
   EXPECT_EQ(analysis.MergeBlock(5), 6);
   EXPECT_EQ(analysis.LoopMergeBlock(5), 3);
+  EXPECT_EQ(analysis.ContainingSwitch(5), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(5), 0);
 
   // The selection merge is in the loop only.
   EXPECT_EQ(analysis.ContainingConstruct(6), 1);
   EXPECT_EQ(analysis.ContainingLoop(6), 1);
   EXPECT_EQ(analysis.MergeBlock(6), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(6), 3);
+  EXPECT_EQ(analysis.ContainingSwitch(6), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(6), 0);
 }
 
 TEST_F(StructCFGAnalysisTest, LoopInSelection) {
@@ -246,36 +273,48 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(1), 0);
   EXPECT_EQ(analysis.MergeBlock(1), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(1), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(1), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(1), 0);
 
   // Loop header is in the selection only.
   EXPECT_EQ(analysis.ContainingConstruct(2), 1);
   EXPECT_EQ(analysis.ContainingLoop(2), 0);
   EXPECT_EQ(analysis.MergeBlock(2), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(2), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(2), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(2), 0);
 
   // The selection merge node is not in either construct.
   EXPECT_EQ(analysis.ContainingConstruct(3), 0);
   EXPECT_EQ(analysis.ContainingLoop(3), 0);
   EXPECT_EQ(analysis.MergeBlock(3), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(3), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(3), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(3), 0);
 
   // The loop merge is in the selection only.
   EXPECT_EQ(analysis.ContainingConstruct(4), 1);
   EXPECT_EQ(analysis.ContainingLoop(4), 0);
   EXPECT_EQ(analysis.MergeBlock(4), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(4), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(4), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(4), 0);
 
   // The loop continue target is in the loop.
   EXPECT_EQ(analysis.ContainingConstruct(5), 2);
   EXPECT_EQ(analysis.ContainingLoop(5), 2);
   EXPECT_EQ(analysis.MergeBlock(5), 4);
   EXPECT_EQ(analysis.LoopMergeBlock(5), 4);
+  EXPECT_EQ(analysis.ContainingSwitch(5), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(5), 0);
 
   // BB6 is in the loop.
   EXPECT_EQ(analysis.ContainingConstruct(6), 2);
   EXPECT_EQ(analysis.ContainingLoop(6), 2);
   EXPECT_EQ(analysis.MergeBlock(6), 4);
   EXPECT_EQ(analysis.LoopMergeBlock(6), 4);
+  EXPECT_EQ(analysis.ContainingSwitch(6), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(6), 0);
 }
 
 TEST_F(StructCFGAnalysisTest, SelectionInSelection) {
@@ -318,30 +357,40 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(1), 0);
   EXPECT_EQ(analysis.MergeBlock(1), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(1), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(1), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(1), 0);
 
   // The inner header is in the outer selection.
   EXPECT_EQ(analysis.ContainingConstruct(2), 1);
   EXPECT_EQ(analysis.ContainingLoop(2), 0);
   EXPECT_EQ(analysis.MergeBlock(2), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(2), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(2), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(2), 0);
 
   // The outer merge node is not in either construct.
   EXPECT_EQ(analysis.ContainingConstruct(3), 0);
   EXPECT_EQ(analysis.ContainingLoop(3), 0);
   EXPECT_EQ(analysis.MergeBlock(3), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(3), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(3), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(3), 0);
 
   // The inner merge is in the outer selection.
   EXPECT_EQ(analysis.ContainingConstruct(4), 1);
   EXPECT_EQ(analysis.ContainingLoop(4), 0);
   EXPECT_EQ(analysis.MergeBlock(4), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(4), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(4), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(4), 0);
 
   // BB5 is in the inner selection.
   EXPECT_EQ(analysis.ContainingConstruct(5), 2);
   EXPECT_EQ(analysis.ContainingLoop(5), 0);
   EXPECT_EQ(analysis.MergeBlock(5), 4);
   EXPECT_EQ(analysis.LoopMergeBlock(5), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(5), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(5), 0);
 }
 
 TEST_F(StructCFGAnalysisTest, LoopInLoop) {
@@ -388,42 +437,56 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(1), 0);
   EXPECT_EQ(analysis.MergeBlock(1), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(1), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(1), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(1), 0);
 
   // The inner loop header is in the outer loop.
   EXPECT_EQ(analysis.ContainingConstruct(2), 1);
   EXPECT_EQ(analysis.ContainingLoop(2), 1);
   EXPECT_EQ(analysis.MergeBlock(2), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(2), 3);
+  EXPECT_EQ(analysis.ContainingSwitch(2), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(2), 0);
 
   // The outer merge node is not in either construct.
   EXPECT_EQ(analysis.ContainingConstruct(3), 0);
   EXPECT_EQ(analysis.ContainingLoop(3), 0);
   EXPECT_EQ(analysis.MergeBlock(3), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(3), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(3), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(3), 0);
 
   // The inner merge is in the outer loop.
   EXPECT_EQ(analysis.ContainingConstruct(4), 1);
   EXPECT_EQ(analysis.ContainingLoop(4), 1);
   EXPECT_EQ(analysis.MergeBlock(4), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(4), 3);
+  EXPECT_EQ(analysis.ContainingSwitch(4), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(4), 0);
 
   // The inner continue target is in the inner loop.
   EXPECT_EQ(analysis.ContainingConstruct(5), 2);
   EXPECT_EQ(analysis.ContainingLoop(5), 2);
   EXPECT_EQ(analysis.MergeBlock(5), 4);
   EXPECT_EQ(analysis.LoopMergeBlock(5), 4);
+  EXPECT_EQ(analysis.ContainingSwitch(5), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(5), 0);
 
   // BB6 is in the loop.
   EXPECT_EQ(analysis.ContainingConstruct(6), 2);
   EXPECT_EQ(analysis.ContainingLoop(6), 2);
   EXPECT_EQ(analysis.MergeBlock(6), 4);
   EXPECT_EQ(analysis.LoopMergeBlock(6), 4);
+  EXPECT_EQ(analysis.ContainingSwitch(6), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(6), 0);
 
   // The outer continue target is in the outer loop.
   EXPECT_EQ(analysis.ContainingConstruct(7), 1);
   EXPECT_EQ(analysis.ContainingLoop(7), 1);
   EXPECT_EQ(analysis.MergeBlock(7), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(7), 3);
+  EXPECT_EQ(analysis.ContainingSwitch(7), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(7), 0);
 }
 
 TEST_F(StructCFGAnalysisTest, KernelTest) {
@@ -458,6 +521,8 @@ OpFunctionEnd
     EXPECT_EQ(analysis.ContainingLoop(i), 0);
     EXPECT_EQ(analysis.MergeBlock(i), 0);
     EXPECT_EQ(analysis.LoopMergeBlock(i), 0);
+    EXPECT_EQ(analysis.ContainingSwitch(i), 0);
+    EXPECT_EQ(analysis.SwitchMergeBlock(i), 0);
   }
 }
 
@@ -479,6 +544,297 @@ OpFunctionEnd
 
   // #2451: This segfaulted on empty functions.
   StructuredCFGAnalysis analysis(context.get());
+}
+
+TEST_F(StructCFGAnalysisTest, BBInSwitch) {
+  const std::string text = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main"
+%void = OpTypeVoid
+%bool = OpTypeBool
+%bool_undef = OpUndef %bool
+%uint = OpTypeInt 32 0
+%uint_undef = OpUndef %uint
+%void_func = OpTypeFunction %void
+%main = OpFunction %void None %void_func
+%1 = OpLabel
+OpSelectionMerge %3 None
+OpSwitch %uint_undef %2 0 %3
+%2 = OpLabel
+OpBranch %3
+%3 = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  std::unique_ptr<IRContext> context =
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+
+  StructuredCFGAnalysis analysis(context.get());
+
+  // The header is not in the construct.
+  EXPECT_EQ(analysis.ContainingConstruct(1), 0);
+  EXPECT_EQ(analysis.ContainingLoop(1), 0);
+  EXPECT_EQ(analysis.MergeBlock(1), 0);
+  EXPECT_EQ(analysis.LoopMergeBlock(1), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(1), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(1), 0);
+
+  // BB2 is in the construct.
+  EXPECT_EQ(analysis.ContainingConstruct(2), 1);
+  EXPECT_EQ(analysis.ContainingLoop(2), 0);
+  EXPECT_EQ(analysis.MergeBlock(2), 3);
+  EXPECT_EQ(analysis.LoopMergeBlock(2), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(2), 1);
+  EXPECT_EQ(analysis.SwitchMergeBlock(2), 3);
+
+  // The merge node is not in the construct.
+  EXPECT_EQ(analysis.ContainingConstruct(3), 0);
+  EXPECT_EQ(analysis.ContainingLoop(3), 0);
+  EXPECT_EQ(analysis.MergeBlock(3), 0);
+  EXPECT_EQ(analysis.LoopMergeBlock(3), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(3), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(3), 0);
+}
+
+TEST_F(StructCFGAnalysisTest, LoopInSwitch) {
+  const std::string text = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main"
+%void = OpTypeVoid
+%bool = OpTypeBool
+%bool_undef = OpUndef %bool
+%uint = OpTypeInt 32 0
+%uint_undef = OpUndef %uint
+%void_func = OpTypeFunction %void
+%main = OpFunction %void None %void_func
+%entry_lab = OpLabel
+OpBranch %1
+%1 = OpLabel
+OpSelectionMerge %3 None
+OpSwitch %uint_undef %2 1 %3
+%2 = OpLabel
+OpLoopMerge %4 %5 None
+OpBranchConditional %undef_bool %4 %6
+%5 = OpLabel
+OpBranch %2
+%6 = OpLabel
+OpBranch %4
+%4 = OpLabel
+OpBranch %3
+%3 = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  std::unique_ptr<IRContext> context =
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+
+  StructuredCFGAnalysis analysis(context.get());
+
+  // The selection header is not in either construct.
+  EXPECT_EQ(analysis.ContainingConstruct(1), 0);
+  EXPECT_EQ(analysis.ContainingLoop(1), 0);
+  EXPECT_EQ(analysis.MergeBlock(1), 0);
+  EXPECT_EQ(analysis.LoopMergeBlock(1), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(1), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(1), 0);
+
+  // Loop header is in the selection only.
+  EXPECT_EQ(analysis.ContainingConstruct(2), 1);
+  EXPECT_EQ(analysis.ContainingLoop(2), 0);
+  EXPECT_EQ(analysis.MergeBlock(2), 3);
+  EXPECT_EQ(analysis.LoopMergeBlock(2), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(2), 1);
+  EXPECT_EQ(analysis.SwitchMergeBlock(2), 3);
+
+  // The selection merge node is not in either construct.
+  EXPECT_EQ(analysis.ContainingConstruct(3), 0);
+  EXPECT_EQ(analysis.ContainingLoop(3), 0);
+  EXPECT_EQ(analysis.MergeBlock(3), 0);
+  EXPECT_EQ(analysis.LoopMergeBlock(3), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(3), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(3), 0);
+
+  // The loop merge is in the selection only.
+  EXPECT_EQ(analysis.ContainingConstruct(4), 1);
+  EXPECT_EQ(analysis.ContainingLoop(4), 0);
+  EXPECT_EQ(analysis.MergeBlock(4), 3);
+  EXPECT_EQ(analysis.LoopMergeBlock(4), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(4), 1);
+  EXPECT_EQ(analysis.SwitchMergeBlock(4), 3);
+
+  // The loop continue target is in the loop.
+  EXPECT_EQ(analysis.ContainingConstruct(5), 2);
+  EXPECT_EQ(analysis.ContainingLoop(5), 2);
+  EXPECT_EQ(analysis.MergeBlock(5), 4);
+  EXPECT_EQ(analysis.LoopMergeBlock(5), 4);
+  EXPECT_EQ(analysis.ContainingSwitch(5), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(5), 0);
+
+  // BB6 is in the loop.
+  EXPECT_EQ(analysis.ContainingConstruct(6), 2);
+  EXPECT_EQ(analysis.ContainingLoop(6), 2);
+  EXPECT_EQ(analysis.MergeBlock(6), 4);
+  EXPECT_EQ(analysis.LoopMergeBlock(6), 4);
+  EXPECT_EQ(analysis.ContainingSwitch(6), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(6), 0);
+}
+
+TEST_F(StructCFGAnalysisTest, SelectionInSwitch) {
+  const std::string text = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main"
+%void = OpTypeVoid
+%bool = OpTypeBool
+%bool_undef = OpUndef %bool
+%uint = OpTypeInt 32 0
+%uint_undef = OpUndef %uint
+%void_func = OpTypeFunction %void
+%main = OpFunction %void None %void_func
+%entry_lab = OpLabel
+OpBranch %1
+%1 = OpLabel
+OpSelectionMerge %3 None
+OpSwitch %uint_undef %2 10 %3
+%2 = OpLabel
+OpSelectionMerge %4 None
+OpBranchConditional %undef_bool %4 %5
+%5 = OpLabel
+OpBranch %4
+%4 = OpLabel
+OpBranch %3
+%3 = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  std::unique_ptr<IRContext> context =
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+
+  StructuredCFGAnalysis analysis(context.get());
+
+  // The outer selection header is not in either construct.
+  EXPECT_EQ(analysis.ContainingConstruct(1), 0);
+  EXPECT_EQ(analysis.ContainingLoop(1), 0);
+  EXPECT_EQ(analysis.MergeBlock(1), 0);
+  EXPECT_EQ(analysis.LoopMergeBlock(1), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(1), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(1), 0);
+
+  // The inner header is in the outer selection.
+  EXPECT_EQ(analysis.ContainingConstruct(2), 1);
+  EXPECT_EQ(analysis.ContainingLoop(2), 0);
+  EXPECT_EQ(analysis.MergeBlock(2), 3);
+  EXPECT_EQ(analysis.LoopMergeBlock(2), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(2), 1);
+  EXPECT_EQ(analysis.SwitchMergeBlock(2), 3);
+
+  // The outer merge node is not in either construct.
+  EXPECT_EQ(analysis.ContainingConstruct(3), 0);
+  EXPECT_EQ(analysis.ContainingLoop(3), 0);
+  EXPECT_EQ(analysis.MergeBlock(3), 0);
+  EXPECT_EQ(analysis.LoopMergeBlock(3), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(3), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(3), 0);
+
+  // The inner merge is in the outer selection.
+  EXPECT_EQ(analysis.ContainingConstruct(4), 1);
+  EXPECT_EQ(analysis.ContainingLoop(4), 0);
+  EXPECT_EQ(analysis.MergeBlock(4), 3);
+  EXPECT_EQ(analysis.LoopMergeBlock(4), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(4), 1);
+  EXPECT_EQ(analysis.SwitchMergeBlock(4), 3);
+
+  // BB5 is in the inner selection.
+  EXPECT_EQ(analysis.ContainingConstruct(5), 2);
+  EXPECT_EQ(analysis.ContainingLoop(5), 0);
+  EXPECT_EQ(analysis.MergeBlock(5), 4);
+  EXPECT_EQ(analysis.LoopMergeBlock(5), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(5), 1);
+  EXPECT_EQ(analysis.SwitchMergeBlock(5), 3);
+}
+
+TEST_F(StructCFGAnalysisTest, SwitchInSelection) {
+  const std::string text = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main"
+%void = OpTypeVoid
+%bool = OpTypeBool
+%bool_undef = OpUndef %bool
+%uint = OpTypeInt 32 0
+%uint_undef = OpUndef %uint
+%void_func = OpTypeFunction %void
+%main = OpFunction %void None %void_func
+%entry_lab = OpLabel
+OpBranch %1
+%1 = OpLabel
+OpSelectionMerge %3 None
+OpBranchConditional %undef_bool %2 %3
+%2 = OpLabel
+OpSelectionMerge %4 None
+OpSwitch %uint_undef %4 7 %5
+%5 = OpLabel
+OpBranch %4
+%4 = OpLabel
+OpBranch %3
+%3 = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  std::unique_ptr<IRContext> context =
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+
+  StructuredCFGAnalysis analysis(context.get());
+
+  // The outer selection header is not in either construct.
+  EXPECT_EQ(analysis.ContainingConstruct(1), 0);
+  EXPECT_EQ(analysis.ContainingLoop(1), 0);
+  EXPECT_EQ(analysis.MergeBlock(1), 0);
+  EXPECT_EQ(analysis.LoopMergeBlock(1), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(1), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(1), 0);
+
+  // The inner header is in the outer selection.
+  EXPECT_EQ(analysis.ContainingConstruct(2), 1);
+  EXPECT_EQ(analysis.ContainingLoop(2), 0);
+  EXPECT_EQ(analysis.MergeBlock(2), 3);
+  EXPECT_EQ(analysis.LoopMergeBlock(2), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(2), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(2), 0);
+
+  // The outer merge node is not in either construct.
+  EXPECT_EQ(analysis.ContainingConstruct(3), 0);
+  EXPECT_EQ(analysis.ContainingLoop(3), 0);
+  EXPECT_EQ(analysis.MergeBlock(3), 0);
+  EXPECT_EQ(analysis.LoopMergeBlock(3), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(3), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(3), 0);
+
+  // The inner merge is in the outer selection.
+  EXPECT_EQ(analysis.ContainingConstruct(4), 1);
+  EXPECT_EQ(analysis.ContainingLoop(4), 0);
+  EXPECT_EQ(analysis.MergeBlock(4), 3);
+  EXPECT_EQ(analysis.LoopMergeBlock(4), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(4), 0);
+  EXPECT_EQ(analysis.SwitchMergeBlock(4), 0);
+
+  // BB5 is in the inner selection.
+  EXPECT_EQ(analysis.ContainingConstruct(5), 2);
+  EXPECT_EQ(analysis.ContainingLoop(5), 0);
+  EXPECT_EQ(analysis.MergeBlock(5), 4);
+  EXPECT_EQ(analysis.LoopMergeBlock(5), 0);
+  EXPECT_EQ(analysis.ContainingSwitch(5), 2);
+  EXPECT_EQ(analysis.SwitchMergeBlock(5), 4);
 }
 
 }  // namespace


### PR DESCRIPTION
There was a recent decision made to allow branches to the merge node of
a switch even if the switch is not the first enclosing construct.  They
can be generated by glslang from break statements in switches.

Dead branch elimination seems to be the only optimization that will
break because of this change, so I will update that optimizations.

The change made are:

- Track switches in structured cfg analysis.
- In Dead branch elimination:
  - Look for nested breaks that will require a switch instruction.
  - Rewrite, but don't delete, switchs that are required even if it
    could be replaced by an unconditional branch.
  - When looking for the first break, consider the merge of a switch
    as well.

See #2612.