### PR TITLE
Close opened file handles.

### DIFF
--- a/tools/io.h
+++ b/tools/io.h
@@ -37,6 +37,7 @@ bool ReadFile(const char* filename, const char* mode, std::vector<T>* data) {
     if (ftell(fp) == -1L) {
       if (ferror(fp)) {
         fprintf(stderr, "error: error reading file '%s'\n", filename);
+        if (use_file) fclose(fp);
         return false;
       }
     } else {
@@ -45,6 +46,7 @@ bool ReadFile(const char* filename, const char* mode, std::vector<T>* data) {
             stderr,
             "error: file size should be a multiple of %zd; file '%s' corrupt\n",
             sizeof(T), filename);
+        if (use_file) fclose(fp);
         return false;
       }
     }
@@ -69,6 +71,7 @@ bool WriteFile(const char* filename, const char* mode, const T* data,
     size_t written = fwrite(data, sizeof(T), count, fp);
     if (count != written) {
       fprintf(stderr, "error: could not write to file '%s'\n", filename);
+      if (!use_stdout) fclose(fp);
       return false;
     }
     if (!use_stdout) fclose(fp);


### PR DESCRIPTION
The close for the file handles was missing in the error cases.

Fixes #2641