### PR TITLE
Add fuzzer pass that adds useful constructs to a module

### DIFF
--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -30,12 +30,18 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer.h
         fuzzer_context.h
         fuzzer_pass.h
+        fuzzer_pass_add_useful_constructs.h
         fuzzer_pass_permute_blocks.h
         fuzzer_pass_split_blocks.h
         fuzzer_util.h
         protobufs/spirvfuzz_protobufs.h
         pseudo_random_generator.h
         random_generator.h
+        transformation_add_constant_boolean.h
+        transformation_add_constant_scalar.h
+        transformation_add_type_boolean.h
+        transformation_add_type_float.h
+        transformation_add_type_int.h
         transformation_move_block_down.h
         transformation_split_block.h
         ${CMAKE_CURRENT_BINARY_DIR}/protobufs/spvtoolsfuzz.pb.h
@@ -44,11 +50,17 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer.cpp
         fuzzer_context.cpp
         fuzzer_pass.cpp
+        fuzzer_pass_add_useful_constructs.cpp
         fuzzer_pass_permute_blocks.cpp
         fuzzer_pass_split_blocks.cpp
         fuzzer_util.cpp
         pseudo_random_generator.cpp
         random_generator.cpp
+        transformation_add_constant_boolean.cpp
+        transformation_add_constant_scalar.cpp
+        transformation_add_type_boolean.cpp
+        transformation_add_type_float.cpp
+        transformation_add_type_int.cpp
         transformation_move_block_down.cpp
         transformation_split_block.cpp
         ${CMAKE_CURRENT_BINARY_DIR}/protobufs/spvtoolsfuzz.pb.cc

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -19,6 +19,7 @@
 
 #include "source/fuzz/fact_manager.h"
 #include "source/fuzz/fuzzer_context.h"
+#include "source/fuzz/fuzzer_pass_add_useful_constructs.h"
 #include "source/fuzz/fuzzer_pass_permute_blocks.h"
 #include "source/fuzz/fuzzer_pass_split_blocks.h"
 #include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
@@ -97,6 +98,12 @@ Fuzzer::FuzzerResultStatus Fuzzer::Run(
   if (!fact_manager.AddFacts(initial_facts, ir_context.get())) {
     return Fuzzer::FuzzerResultStatus::kInitialFactsInvalid;
   }
+
+  // Add some essential ingredients to the module if they are not already
+  // present, such as boolean constants.
+  FuzzerPassAddUsefulConstructs(ir_context.get(), &fact_manager,
+                                &fuzzer_context, transformation_sequence_out)
+          .Apply();
 
   // Apply some semantics-preserving passes.
   FuzzerPassSplitBlocks(ir_context.get(), &fact_manager, &fuzzer_context,

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -103,7 +103,7 @@ Fuzzer::FuzzerResultStatus Fuzzer::Run(
   // present, such as boolean constants.
   FuzzerPassAddUsefulConstructs(ir_context.get(), &fact_manager,
                                 &fuzzer_context, transformation_sequence_out)
-          .Apply();
+      .Apply();
 
   // Apply some semantics-preserving passes.
   FuzzerPassSplitBlocks(ir_context.get(), &fact_manager, &fuzzer_context,

--- a/source/fuzz/fuzzer_pass_add_useful_constructs.cpp
+++ b/source/fuzz/fuzzer_pass_add_useful_constructs.cpp
@@ -1,0 +1,182 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/fuzzer_pass_add_useful_constructs.h"
+
+#include "source/fuzz/transformation_add_constant_boolean.h"
+#include "source/fuzz/transformation_add_constant_scalar.h"
+#include "source/fuzz/transformation_add_type_boolean.h"
+#include "source/fuzz/transformation_add_type_float.h"
+#include "source/fuzz/transformation_add_type_int.h"
+
+namespace spvtools {
+namespace fuzz {
+
+using opt::IRContext;
+
+FuzzerPassAddUsefulConstructs::FuzzerPassAddUsefulConstructs(
+    opt::IRContext* ir_context, FactManager* fact_manager,
+    FuzzerContext* fuzzer_context,
+    protobufs::TransformationSequence* transformations)
+    : FuzzerPass(ir_context, fact_manager, fuzzer_context, transformations){};
+
+FuzzerPassAddUsefulConstructs::~FuzzerPassAddUsefulConstructs() = default;
+
+void FuzzerPassAddUsefulConstructs::MaybeAddIntConstant(
+    uint32_t width, bool is_signed, std::vector<uint32_t> data) const {
+  opt::analysis::Integer temp_int_type(width, is_signed);
+  assert(GetIRContext()->get_type_mgr()->GetId(&temp_int_type) &&
+         "int type should already be registered.");
+  auto registered_int_type = GetIRContext()
+                                 ->get_type_mgr()
+                                 ->GetRegisteredType(&temp_int_type)
+                                 ->AsInteger();
+  auto int_type_id = GetIRContext()->get_type_mgr()->GetId(registered_int_type);
+  assert(int_type_id &&
+         "The relevant int type should have been added to the module already.");
+  opt::analysis::IntConstant int_constant(registered_int_type, data);
+  if (!GetIRContext()->get_constant_mgr()->FindConstant(&int_constant)) {
+    protobufs::TransformationAddConstantScalar add_constant_int =
+        transformation::MakeTransformationAddConstantScalar(
+            GetFuzzerContext()->GetFreshId(), int_type_id, data);
+    assert(transformation::IsApplicable(add_constant_int, GetIRContext(),
+                                        *GetFactManager()) &&
+           "Should be applicable by construction.");
+    transformation::Apply(add_constant_int, GetIRContext(), GetFactManager());
+    *GetTransformations()->add_transformation()->mutable_add_constant_scalar() =
+        add_constant_int;
+  }
+}
+
+void FuzzerPassAddUsefulConstructs::MaybeAddFloatConstant(
+    uint32_t width, std::vector<uint32_t> data) const {
+  opt::analysis::Float temp_float_type(width);
+  assert(GetIRContext()->get_type_mgr()->GetId(&temp_float_type) &&
+         "float type should already be registered.");
+  auto registered_float_type = GetIRContext()
+                                   ->get_type_mgr()
+                                   ->GetRegisteredType(&temp_float_type)
+                                   ->AsFloat();
+  auto float_type_id =
+      GetIRContext()->get_type_mgr()->GetId(registered_float_type);
+  assert(
+      float_type_id &&
+      "The relevant float type should have been added to the module already.");
+  opt::analysis::FloatConstant float_constant(registered_float_type, data);
+  if (!GetIRContext()->get_constant_mgr()->FindConstant(&float_constant)) {
+    protobufs::TransformationAddConstantScalar add_constant_int =
+        transformation::MakeTransformationAddConstantScalar(
+            GetFuzzerContext()->GetFreshId(), float_type_id, data);
+    assert(transformation::IsApplicable(add_constant_int, GetIRContext(),
+                                        *GetFactManager()) &&
+           "Should be applicable by construction.");
+    transformation::Apply(add_constant_int, GetIRContext(), GetFactManager());
+    *GetTransformations()->add_transformation()->mutable_add_constant_scalar() =
+        add_constant_int;
+  }
+}
+
+void FuzzerPassAddUsefulConstructs::Apply() {
+  {
+    // Add boolean type if not present.
+    opt::analysis::Bool temp_bool_type;
+    if (!GetIRContext()->get_type_mgr()->GetId(&temp_bool_type)) {
+      protobufs::TransformationAddTypeBoolean add_type_boolean =
+          transformation::MakeTransformationAddTypeBoolean(
+              GetFuzzerContext()->GetFreshId());
+      assert(transformation::IsApplicable(add_type_boolean, GetIRContext(),
+                                          *GetFactManager()) &&
+             "Should be applicable by construction.");
+      transformation::Apply(add_type_boolean, GetIRContext(), GetFactManager());
+      *GetTransformations()->add_transformation()->mutable_add_type_boolean() =
+          add_type_boolean;
+    }
+  }
+
+  {
+    // Add signed and unsigned 32-bit integer types if not present.
+    for (auto is_signed : {true, false}) {
+      opt::analysis::Integer temp_int_type(32, is_signed);
+      if (!GetIRContext()->get_type_mgr()->GetId(&temp_int_type)) {
+        protobufs::TransformationAddTypeInt add_type_int =
+            transformation::MakeTransformationAddTypeInt(
+                GetFuzzerContext()->GetFreshId(), 32, is_signed);
+        assert(transformation::IsApplicable(add_type_int, GetIRContext(),
+                                            *GetFactManager()) &&
+               "Should be applicable by construction.");
+        transformation::Apply(add_type_int, GetIRContext(), GetFactManager());
+        *GetTransformations()->add_transformation()->mutable_add_type_int() =
+            add_type_int;
+      }
+    }
+  }
+
+  {
+    // Add 32-bit float type if not present.
+    opt::analysis::Float temp_float_type(32);
+    if (!GetIRContext()->get_type_mgr()->GetId(&temp_float_type)) {
+      protobufs::TransformationAddTypeFloat add_type_float =
+          transformation::MakeTransformationAddTypeFloat(
+              GetFuzzerContext()->GetFreshId(), 32);
+      assert(transformation::IsApplicable(add_type_float, GetIRContext(),
+                                          *GetFactManager()) &&
+             "Should be applicable by construction.");
+      transformation::Apply(add_type_float, GetIRContext(), GetFactManager());
+      *GetTransformations()->add_transformation()->mutable_add_type_float() =
+          add_type_float;
+    }
+  }
+
+  // Add boolean constants true and false if not present.
+  opt::analysis::Bool temp_bool_type;
+  auto bool_type = GetIRContext()
+                       ->get_type_mgr()
+                       ->GetRegisteredType(&temp_bool_type)
+                       ->AsBool();
+  for (auto boolean_value : {true, false}) {
+    // Add OpConstantTrue/False if not already there.
+    opt::analysis::BoolConstant bool_constant(bool_type, boolean_value);
+    if (!GetIRContext()->get_constant_mgr()->FindConstant(&bool_constant)) {
+      protobufs::TransformationAddConstantBoolean add_constant_boolean =
+          transformation::MakeTransformationAddConstantBoolean(
+              GetFuzzerContext()->GetFreshId(), boolean_value);
+      assert(transformation::IsApplicable(add_constant_boolean, GetIRContext(),
+                                          *GetFactManager()) &&
+             "Should be applicable by construction.");
+      transformation::Apply(add_constant_boolean, GetIRContext(),
+                            GetFactManager());
+      *GetTransformations()
+           ->add_transformation()
+           ->mutable_add_constant_boolean() = add_constant_boolean;
+    }
+  }
+
+  // Add signed and unsigned 32-bit integer constants 0 and 1 if not present.
+  for (auto is_signed : {true, false}) {
+    for (auto value : {0u, 1u}) {
+      MaybeAddIntConstant(32, is_signed, {value});
+    }
+  }
+
+  // Add 32-bit float constants 0.0 and 1.0 if not present.
+  uint32_t uint_data[2];
+  float float_data[2] = {0.0, 1.0};
+  memcpy(uint_data, float_data, sizeof(float_data));
+  for (unsigned int& datum : uint_data) {
+    MaybeAddFloatConstant(32, {datum});
+  }
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/fuzzer_pass_add_useful_constructs.cpp
+++ b/source/fuzz/fuzzer_pass_add_useful_constructs.cpp
@@ -75,15 +75,15 @@ void FuzzerPassAddUsefulConstructs::MaybeAddFloatConstant(
       "The relevant float type should have been added to the module already.");
   opt::analysis::FloatConstant float_constant(registered_float_type, data);
   if (!GetIRContext()->get_constant_mgr()->FindConstant(&float_constant)) {
-    protobufs::TransformationAddConstantScalar add_constant_int =
+    protobufs::TransformationAddConstantScalar add_constant_float =
         transformation::MakeTransformationAddConstantScalar(
             GetFuzzerContext()->GetFreshId(), float_type_id, data);
-    assert(transformation::IsApplicable(add_constant_int, GetIRContext(),
+    assert(transformation::IsApplicable(add_constant_float, GetIRContext(),
                                         *GetFactManager()) &&
            "Should be applicable by construction.");
-    transformation::Apply(add_constant_int, GetIRContext(), GetFactManager());
+    transformation::Apply(add_constant_float, GetIRContext(), GetFactManager());
     *GetTransformations()->add_transformation()->mutable_add_constant_scalar() =
-        add_constant_int;
+        add_constant_float;
   }
 }
 

--- a/source/fuzz/fuzzer_pass_add_useful_constructs.h
+++ b/source/fuzz/fuzzer_pass_add_useful_constructs.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_FUZZER_PASS_ADD_USEFUL_CONSTRUCTS_
+#define SOURCE_FUZZ_FUZZER_PASS_ADD_USEFUL_CONSTRUCTS_
+
+#include "source/fuzz/fuzzer_pass.h"
+
+namespace spvtools {
+namespace fuzz {
+
+// An initial pass for adding useful ingredients to the module, such as boolean
+// constants, if they are not present.
+class FuzzerPassAddUsefulConstructs : public FuzzerPass {
+ public:
+  FuzzerPassAddUsefulConstructs(
+      opt::IRContext* ir_context, FactManager* fact_manager,
+      FuzzerContext* fuzzer_context,
+      protobufs::TransformationSequence* transformations);
+
+  ~FuzzerPassAddUsefulConstructs() override;
+
+  void Apply() override;
+
+ private:
+  void MaybeAddIntConstant(uint32_t width, bool is_signed,
+                           std::vector<uint32_t> data) const;
+
+  void MaybeAddFloatConstant(uint32_t width, std::vector<uint32_t> data) const;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // #define SOURCE_FUZZ_FUZZER_PASS_ADD_USEFUL_CONSTRUCTS_

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -35,16 +35,20 @@ message TransformationSequence {
 
 message Transformation {
   oneof transformation {
-    TransformationAddConstantBoolean add_constant_boolean = 1;
-    TransformationAddConstantScalar add_constant_scalar = 2;
-    TransformationAddTypeBoolean add_type_boolean = 3;
-    TransformationAddTypeFloat add_type_float = 4;
-    TransformationAddTypeInt add_type_int = 5;
-    TransformationMoveBlockDown move_block_down = 6;
-    TransformationSplitBlock split_block = 7;
+    // Order the transformation options by numeric id (rather than
+    // alphabetically).
+    TransformationMoveBlockDown move_block_down = 1;
+    TransformationSplitBlock split_block = 2;
+    TransformationAddConstantBoolean add_constant_boolean = 3;
+    TransformationAddConstantScalar add_constant_scalar = 4;
+    TransformationAddTypeBoolean add_type_boolean = 5;
+    TransformationAddTypeFloat add_type_float = 6;
+    TransformationAddTypeInt add_type_int = 7;
+    // Add additional option using the next available number.
   }
-  // Currently there are no transformations.
 }
+
+// Keep transformation message types in alphabetical order:
 
 message TransformationAddConstantBoolean {
 

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -35,18 +35,86 @@ message TransformationSequence {
 
 message Transformation {
   oneof transformation {
-    TransformationMoveBlockDown move_block_down = 1;
-    TransformationSplitBlock split_block = 2;
+    TransformationAddConstantBoolean add_constant_boolean = 1;
+    TransformationAddConstantScalar add_constant_scalar = 2;
+    TransformationAddTypeBoolean add_type_boolean = 3;
+    TransformationAddTypeFloat add_type_float = 4;
+    TransformationAddTypeInt add_type_int = 5;
+    TransformationMoveBlockDown move_block_down = 6;
+    TransformationSplitBlock split_block = 7;
   }
   // Currently there are no transformations.
 }
 
+message TransformationAddConstantBoolean {
+
+  // Supports adding the constants true and false to a module, which may be
+  // necessary in order to enable other transformations if they are not present.
+
+  uint32 fresh_id = 1;
+  bool is_true = 2;
+
+}
+
+message TransformationAddConstantScalar {
+
+  // Adds a constant of the given scalar type
+
+  // Id for the constant
+  uint32 fresh_id = 1;
+
+  // Id for the scalar type of the constant
+  uint32 type_id = 2;
+
+  // Value of the constant
+  repeated uint32 word = 3;
+
+}
+
+message TransformationAddTypeBoolean {
+
+  // Adds OpTypeBool to the module
+
+  // Id to be used for the type
+  uint32 fresh_id = 1;
+
+}
+
+message TransformationAddTypeFloat {
+
+  // Adds OpTypeFloat to the module with the given width
+
+  // Id to be used for the type
+  uint32 fresh_id = 1;
+
+  // Floating-point width
+  uint32 width = 2;
+
+}
+
+message TransformationAddTypeInt {
+
+  // Adds OpTypeInt to the module with the given width and signedness
+
+  // Id to be used for the type
+  uint32 fresh_id = 1;
+
+  // Integer width
+  uint32 width = 2;
+
+  // True if and only if this is a signed type
+  bool is_signed = 3;
+
+}
+
 message TransformationMoveBlockDown {
+
   // A transformation that moves a basic block to be one position lower in
   // program order.
 
   // The id of the block to move down.
   uint32 block_id = 1;
+
 }
 
 message TransformationSplitBlock {

--- a/source/fuzz/transformation_add_constant_boolean.cpp
+++ b/source/fuzz/transformation_add_constant_boolean.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_add_constant_boolean.h"
+
+#include "source/fuzz/fuzzer_util.h"
+#include "source/opt/types.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace transformation {
+
+using opt::IRContext;
+
+bool IsApplicable(const protobufs::TransformationAddConstantBoolean& message,
+                  IRContext* context, const FactManager& /*unused*/) {
+  opt::analysis::Bool bool_type;
+  if (!context->get_type_mgr()->GetId(&bool_type)) {
+    // No OpTypeBool is present.
+    return false;
+  }
+  return fuzzerutil::IsFreshId(context, message.fresh_id());
+}
+
+void Apply(const protobufs::TransformationAddConstantBoolean& message,
+           IRContext* context, FactManager* /*unused*/) {
+  opt::analysis::Bool bool_type;
+  // Add the boolean constant to the module, ensuring the module's id bound is
+  // high enough.
+  fuzzerutil::UpdateModuleIdBound(context, message.fresh_id());
+  context->module()->AddGlobalValue(
+      message.is_true() ? SpvOpConstantTrue : SpvOpConstantFalse,
+      message.fresh_id(), context->get_type_mgr()->GetId(&bool_type));
+  // We have added an instruction to the module, so need to be careful about the
+  // validity of existing analyses.
+  context->InvalidateAnalysesExceptFor(IRContext::Analysis::kAnalysisNone);
+}
+
+protobufs::TransformationAddConstantBoolean
+MakeTransformationAddConstantBoolean(uint32_t fresh_id, bool is_true) {
+  protobufs::TransformationAddConstantBoolean result;
+  result.set_fresh_id(fresh_id);
+  result.set_is_true(is_true);
+  return result;
+}
+
+}  // namespace transformation
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/transformation_add_constant_boolean.h
+++ b/source/fuzz/transformation_add_constant_boolean.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_TRANSFORMATION_ADD_BOOLEAN_CONSTANT_H_
+#define SOURCE_FUZZ_TRANSFORMATION_ADD_BOOLEAN_CONSTANT_H_
+
+#include "source/fuzz/fact_manager.h"
+#include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
+#include "source/opt/ir_context.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace transformation {
+
+// - |fresh_id| must not be used by the module.
+// - The module must already contain OpTypeBool.
+bool IsApplicable(const protobufs::TransformationAddConstantBoolean& message,
+                  opt::IRContext* context, const FactManager& fact_manager);
+
+// - Adds OpConstantTrue (OpConstantFalse) to the module with id |fresh_id|
+// if |is_true| holds (does not hold).
+void Apply(const protobufs::TransformationAddConstantBoolean& message,
+           opt::IRContext* context, FactManager* fact_manager);
+
+// Helper factory to create a transformation message.
+protobufs::TransformationAddConstantBoolean
+MakeTransformationAddConstantBoolean(uint32_t fresh_id, bool is_true);
+
+}  // namespace transformation
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_TRANSFORMATION_ADD_BOOLEAN_CONSTANT_H_

--- a/source/fuzz/transformation_add_constant_scalar.cpp
+++ b/source/fuzz/transformation_add_constant_scalar.cpp
@@ -1,0 +1,83 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_add_constant_scalar.h"
+
+#include "source/fuzz/fuzzer_util.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace transformation {
+
+using opt::IRContext;
+
+bool IsApplicable(const protobufs::TransformationAddConstantScalar& message,
+                  IRContext* context,
+                  const spvtools::fuzz::FactManager& /*unused*/) {
+  // The id needs to be fresh.
+  if (!fuzzerutil::IsFreshId(context, message.fresh_id())) {
+    return false;
+  }
+  // The type id for the scalar must exist and be a type.
+  auto type = context->get_type_mgr()->GetType(message.type_id());
+  if (!type) {
+    return false;
+  }
+  uint32_t width;
+  if (type->AsFloat()) {
+    width = type->AsFloat()->width();
+  } else if (type->AsInteger()) {
+    width = type->AsInteger()->width();
+  } else {
+    return false;
+  }
+  // The number of words is the integer floor of the width.
+  auto words = (width + 32 - 1) / 32;
+
+  // The number of words provided by the transformation needs to match the
+  // width of the type.
+  return static_cast<uint32_t>(message.word().size()) == words;
+}
+
+void Apply(const protobufs::TransformationAddConstantScalar& message,
+           IRContext* context, spvtools::fuzz::FactManager* /*unused*/) {
+  opt::Instruction::OperandList operand_list;
+  for (auto word : message.word()) {
+    operand_list.push_back({SPV_OPERAND_TYPE_LITERAL_INTEGER, {word}});
+  }
+  context->module()->AddGlobalValue(
+      MakeUnique<opt::Instruction>(context, SpvOpConstant, message.type_id(),
+                                   message.fresh_id(), operand_list));
+
+  fuzzerutil::UpdateModuleIdBound(context, message.fresh_id());
+
+  // We have added an instruction to the module, so need to be careful about the
+  // validity of existing analyses.
+  context->InvalidateAnalysesExceptFor(IRContext::Analysis::kAnalysisNone);
+}
+
+protobufs::TransformationAddConstantScalar MakeTransformationAddConstantScalar(
+    uint32_t fresh_id, uint32_t type_id, std::vector<uint32_t> words) {
+  protobufs::TransformationAddConstantScalar result;
+  result.set_fresh_id(fresh_id);
+  result.set_type_id(type_id);
+  for (auto word : words) {
+    result.add_word(word);
+  }
+  return result;
+}
+
+}  // namespace transformation
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/transformation_add_constant_scalar.h
+++ b/source/fuzz/transformation_add_constant_scalar.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_TRANSFORMATION_ADD_CONSTANT_SCALAR_H_
+#define SOURCE_FUZZ_TRANSFORMATION_ADD_CONSTANT_SCALAR_H_
+
+#include <vector>
+
+#include "source/fuzz/fact_manager.h"
+#include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
+#include "source/opt/ir_context.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace transformation {
+
+// - |message.fresh_id| must not be used by the module
+// - |message.type_id| must be the id of a floating-point or integer type
+// - The size of |message.word| must be compatible with the width of this type
+bool IsApplicable(const protobufs::TransformationAddConstantScalar& message,
+                  opt::IRContext* context, const FactManager& fact_manager);
+
+// Adds a new OpConstant instruction with the given type and words.
+void Apply(const protobufs::TransformationAddConstantScalar& message,
+           opt::IRContext* context, FactManager* fact_manager);
+
+// Helper factory to create a transformation message.
+protobufs::TransformationAddConstantScalar MakeTransformationAddConstantScalar(
+    uint32_t fresh_id, uint32_t type_id, std::vector<uint32_t> words);
+
+}  // namespace transformation
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_TRANSFORMATION_ADD_CONSTANT_SCALAR_H_

--- a/source/fuzz/transformation_add_type_boolean.cpp
+++ b/source/fuzz/transformation_add_type_boolean.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_add_type_boolean.h"
+
+#include "source/fuzz/fuzzer_util.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace transformation {
+
+using opt::IRContext;
+
+bool IsApplicable(const protobufs::TransformationAddTypeBoolean& message,
+                  IRContext* context,
+                  const spvtools::fuzz::FactManager& /*unused*/) {
+  // The id must be fresh.
+  if (!fuzzerutil::IsFreshId(context, message.fresh_id())) {
+    return false;
+  }
+
+  // Applicable if there is no bool type already declared in the module.
+  opt::analysis::Bool bool_type;
+  return context->get_type_mgr()->GetId(&bool_type) == 0;
+}
+
+void Apply(const protobufs::TransformationAddTypeBoolean& message,
+           IRContext* context, spvtools::fuzz::FactManager* /*unused*/) {
+  opt::Instruction::OperandList empty_operands;
+  context->module()->AddType(MakeUnique<opt::Instruction>(
+      context, SpvOpTypeBool, 0, message.fresh_id(), empty_operands));
+  fuzzerutil::UpdateModuleIdBound(context, message.fresh_id());
+  // We have added an instruction to the module, so need to be careful about the
+  // validity of existing analyses.
+  context->InvalidateAnalysesExceptFor(IRContext::Analysis::kAnalysisNone);
+}
+
+protobufs::TransformationAddTypeBoolean MakeTransformationAddTypeBoolean(
+    uint32_t fresh_id) {
+  protobufs::TransformationAddTypeBoolean result;
+  result.set_fresh_id(fresh_id);
+  return result;
+}
+
+}  // namespace transformation
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/transformation_add_type_boolean.h
+++ b/source/fuzz/transformation_add_type_boolean.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_TRANSFORMATION_ADD_TYPE_BOOLEAN_H_
+#define SOURCE_FUZZ_TRANSFORMATION_ADD_TYPE_BOOLEAN_H_
+
+#include "source/fuzz/fact_manager.h"
+#include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
+#include "source/opt/ir_context.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace transformation {
+
+// - |message.fresh_id| must not be used by the module.
+// - The module must not yet declare OpTypeBoolean
+bool IsApplicable(const protobufs::TransformationAddTypeBoolean& message,
+                  opt::IRContext* context, const FactManager& fact_manager);
+
+// Adds OpTypeBoolean with |message.fresh_id| as result id.
+void Apply(const protobufs::TransformationAddTypeBoolean& message,
+           opt::IRContext* context, FactManager* fact_manager);
+
+// Helper factory to create a transformation message.
+protobufs::TransformationAddTypeBoolean MakeTransformationAddTypeBoolean(
+    uint32_t fresh_id);
+
+}  // namespace transformation
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_TRANSFORMATION_ADD_TYPE_BOOLEAN_H_

--- a/source/fuzz/transformation_add_type_float.cpp
+++ b/source/fuzz/transformation_add_type_float.cpp
@@ -1,0 +1,61 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_add_type_float.h"
+
+#include "source/fuzz/fuzzer_util.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace transformation {
+
+using opt::IRContext;
+
+bool IsApplicable(const protobufs::TransformationAddTypeFloat& message,
+                  IRContext* context,
+                  const spvtools::fuzz::FactManager& /*unused*/) {
+  // The id must be fresh.
+  if (!fuzzerutil::IsFreshId(context, message.fresh_id())) {
+    return false;
+  }
+
+  // Applicable if there is no float type with this width already declared in
+  // the module.
+  opt::analysis::Float float_type(message.width());
+  return context->get_type_mgr()->GetId(&float_type) == 0;
+}
+
+void Apply(const protobufs::TransformationAddTypeFloat& message,
+           IRContext* context, spvtools::fuzz::FactManager* /*unused*/) {
+  opt::Instruction::OperandList width = {
+      {SPV_OPERAND_TYPE_LITERAL_INTEGER, {message.width()}}};
+  context->module()->AddType(MakeUnique<opt::Instruction>(
+      context, SpvOpTypeFloat, 0, message.fresh_id(), width));
+  fuzzerutil::UpdateModuleIdBound(context, message.fresh_id());
+  // We have added an instruction to the module, so need to be careful about the
+  // validity of existing analyses.
+  context->InvalidateAnalysesExceptFor(IRContext::Analysis::kAnalysisNone);
+}
+
+protobufs::TransformationAddTypeFloat MakeTransformationAddTypeFloat(
+    uint32_t fresh_id, uint32_t width) {
+  protobufs::TransformationAddTypeFloat result;
+  result.set_fresh_id(fresh_id);
+  result.set_width(width);
+  return result;
+}
+
+}  // namespace transformation
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/transformation_add_type_float.h
+++ b/source/fuzz/transformation_add_type_float.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_TRANSFORMATION_ADD_TYPE_FLOAT_H_
+#define SOURCE_FUZZ_TRANSFORMATION_ADD_TYPE_FLOAT_H_
+
+#include "source/fuzz/fact_manager.h"
+#include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
+#include "source/opt/ir_context.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace transformation {
+
+// - |message.fresh_id| must not be used by the module
+// - The module must not contain an OpTypeFloat instruction with width
+//   |message.width|
+bool IsApplicable(const protobufs::TransformationAddTypeFloat& message,
+                  opt::IRContext* context, const FactManager& fact_manager);
+
+// Adds an OpTypeFloat instruction to the module with the given width
+void Apply(const protobufs::TransformationAddTypeFloat& message,
+           opt::IRContext* context, FactManager* fact_manager);
+
+// Helper factory to create a transformation message.
+protobufs::TransformationAddTypeFloat MakeTransformationAddTypeFloat(
+    uint32_t fresh_id, uint32_t width);
+
+}  // namespace transformation
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_TRANSFORMATION_ADD_TYPE_FLOAT_H_

--- a/source/fuzz/transformation_add_type_int.cpp
+++ b/source/fuzz/transformation_add_type_int.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_add_type_int.h"
+
+#include "source/fuzz/fuzzer_util.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace transformation {
+
+using opt::IRContext;
+
+bool IsApplicable(const protobufs::TransformationAddTypeInt& message,
+                  IRContext* context,
+                  const spvtools::fuzz::FactManager& /*unused*/) {
+  // The id must be fresh.
+  if (!fuzzerutil::IsFreshId(context, message.fresh_id())) {
+    return false;
+  }
+
+  // Applicable if there is no int type with this width and signedness already
+  // declared in the module.
+  opt::analysis::Integer int_type(message.width(), message.is_signed());
+  return context->get_type_mgr()->GetId(&int_type) == 0;
+}
+
+void Apply(const protobufs::TransformationAddTypeInt& message,
+           IRContext* context, spvtools::fuzz::FactManager* /*unused*/) {
+  opt::Instruction::OperandList in_operands = {
+      {SPV_OPERAND_TYPE_LITERAL_INTEGER, {message.width()}},
+      {SPV_OPERAND_TYPE_LITERAL_INTEGER, {message.is_signed() ? 1u : 0u}}};
+  context->module()->AddType(MakeUnique<opt::Instruction>(
+      context, SpvOpTypeInt, 0, message.fresh_id(), in_operands));
+  fuzzerutil::UpdateModuleIdBound(context, message.fresh_id());
+  // We have added an instruction to the module, so need to be careful about the
+  // validity of existing analyses.
+  context->InvalidateAnalysesExceptFor(IRContext::Analysis::kAnalysisNone);
+}
+
+protobufs::TransformationAddTypeInt MakeTransformationAddTypeInt(
+    uint32_t fresh_id, uint32_t width, bool is_signed) {
+  protobufs::TransformationAddTypeInt result;
+  result.set_fresh_id(fresh_id);
+  result.set_width(width);
+  result.set_is_signed(is_signed);
+  return result;
+}
+
+}  // namespace transformation
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/transformation_add_type_int.h
+++ b/source/fuzz/transformation_add_type_int.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_TRANSFORMATION_ADD_TYPE_INT_H_
+#define SOURCE_FUZZ_TRANSFORMATION_ADD_TYPE_INT_H_
+
+#include "source/fuzz/fact_manager.h"
+#include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
+#include "source/opt/ir_context.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace transformation {
+
+// - |message.fresh_id| must not be used by the module
+// - The module must not contain an OpTypeInt instruction with width
+//   |message.width| and signedness |message.is_signed|
+bool IsApplicable(const protobufs::TransformationAddTypeInt& message,
+                  opt::IRContext* context, const FactManager& fact_manager);
+
+// Adds an OpTypeInt instruction to the module with the given width and
+// signedness.
+void Apply(const protobufs::TransformationAddTypeInt& message,
+           opt::IRContext* context, FactManager* fact_manager);
+
+// Helper factory to create a transformation message.
+protobufs::TransformationAddTypeInt MakeTransformationAddTypeInt(
+    uint32_t fresh_id, uint32_t width, bool is_signed);
+
+}  // namespace transformation
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_TRANSFORMATION_ADD_TYPE_INT_H_

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -18,6 +18,11 @@ if (${SPIRV_BUILD_FUZZER})
           fuzz_test_util.h
 
           fuzz_test_util.cpp
+          transformation_add_constant_boolean_test.cpp
+          transformation_add_constant_scalar_test.cpp
+          transformation_add_type_boolean_test.cpp
+          transformation_add_type_float_test.cpp
+          transformation_add_type_int_test.cpp
           transformation_move_block_down_test.cpp
           transformation_split_block_test.cpp)
 

--- a/test/fuzz/transformation_add_constant_boolean_test.cpp
+++ b/test/fuzz/transformation_add_constant_boolean_test.cpp
@@ -1,0 +1,155 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_add_constant_boolean.h"
+#include "test/fuzz/fuzz_test_util.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace {
+
+TEST(TransformationAddConstantBooleanTest, NeitherPresentInitiallyAddBoth) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %6 = OpTypeBool
+          %3 = OpTypeFunction %2
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+
+  // True and false can both be added as neither is present.
+  ASSERT_TRUE(transformation::IsApplicable(
+      transformation::MakeTransformationAddConstantBoolean(7, true),
+      context.get(), fact_manager));
+  ASSERT_TRUE(transformation::IsApplicable(
+      transformation::MakeTransformationAddConstantBoolean(7, false),
+      context.get(), fact_manager));
+
+  // Id 5 is already taken.
+  ASSERT_FALSE(transformation::IsApplicable(
+      transformation::MakeTransformationAddConstantBoolean(5, true),
+      context.get(), fact_manager));
+
+  auto add_true = transformation::MakeTransformationAddConstantBoolean(7, true);
+  auto add_false =
+      transformation::MakeTransformationAddConstantBoolean(8, false);
+
+  ASSERT_TRUE(
+      transformation::IsApplicable(add_true, context.get(), fact_manager));
+  transformation::Apply(add_true, context.get(), &fact_manager);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  // Having added true, we cannot add it again with the same id.
+  ASSERT_FALSE(
+      transformation::IsApplicable(add_true, context.get(), fact_manager));
+  // But we can add it with a different id.
+  auto add_true_again =
+      transformation::MakeTransformationAddConstantBoolean(100, true);
+  ASSERT_TRUE(transformation::IsApplicable(add_true_again, context.get(),
+                                           fact_manager));
+  transformation::Apply(add_true_again, context.get(), &fact_manager);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  ASSERT_TRUE(
+      transformation::IsApplicable(add_false, context.get(), fact_manager));
+  transformation::Apply(add_false, context.get(), &fact_manager);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  // Having added false, we cannot add it again with the same id.
+  ASSERT_FALSE(
+      transformation::IsApplicable(add_false, context.get(), fact_manager));
+  // But we can add it with a different id.
+  auto add_false_again =
+      transformation::MakeTransformationAddConstantBoolean(101, false);
+  ASSERT_TRUE(transformation::IsApplicable(add_false_again, context.get(),
+                                           fact_manager));
+  transformation::Apply(add_false_again, context.get(), &fact_manager);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  std::string after_transformation = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %6 = OpTypeBool
+          %3 = OpTypeFunction %2
+          %7 = OpConstantTrue %6
+        %100 = OpConstantTrue %6
+          %8 = OpConstantFalse %6
+        %101 = OpConstantFalse %6
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  ASSERT_TRUE(IsEqual(env, after_transformation, context.get()));
+}
+
+TEST(TransformationAddConstantBooleanTest, NoOpTypeBoolPresent) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+
+  // Neither true nor false can be added as OpTypeBool is not present.
+  ASSERT_FALSE(transformation::IsApplicable(
+      transformation::MakeTransformationAddConstantBoolean(6, true),
+      context.get(), fact_manager));
+  ASSERT_FALSE(transformation::IsApplicable(
+      transformation::MakeTransformationAddConstantBoolean(6, false),
+      context.get(), fact_manager));
+}
+
+}  // namespace
+}  // namespace fuzz
+}  // namespace spvtools

--- a/test/fuzz/transformation_add_constant_scalar_test.cpp
+++ b/test/fuzz/transformation_add_constant_scalar_test.cpp
@@ -1,0 +1,209 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_add_constant_scalar.h"
+#include "test/fuzz/fuzz_test_util.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace {
+
+TEST(TransformationAddConstantScalarTest, BasicTest) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %8 "x"
+               OpName %12 "y"
+               OpName %16 "z"
+               OpDecorate %8 RelaxedPrecision
+               OpDecorate %12 RelaxedPrecision
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Function %6
+          %9 = OpConstant %6 1
+         %10 = OpTypeInt 32 0
+         %11 = OpTypePointer Function %10
+         %13 = OpConstant %10 2
+         %14 = OpTypeFloat 32
+         %15 = OpTypePointer Function %14
+         %17 = OpConstant %14 3
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+          %8 = OpVariable %7 Function
+         %12 = OpVariable %11 Function
+         %16 = OpVariable %15 Function
+               OpStore %8 %9
+               OpStore %12 %13
+               OpStore %16 %17
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+
+  const float float_values[2] = {3.0, 30.0};
+  uint32_t uint_for_float[2];
+  memcpy(uint_for_float, float_values, sizeof(float_values));
+
+  auto add_signed_int_1 =
+      transformation::MakeTransformationAddConstantScalar(100, 6, {1});
+  auto add_signed_int_10 =
+      transformation::MakeTransformationAddConstantScalar(101, 6, {10});
+  auto add_unsigned_int_2 =
+      transformation::MakeTransformationAddConstantScalar(102, 10, {2});
+  auto add_unsigned_int_20 =
+      transformation::MakeTransformationAddConstantScalar(103, 10, {20});
+  auto add_float_3 = transformation::MakeTransformationAddConstantScalar(
+      104, 14, {uint_for_float[0]});
+  auto add_float_30 = transformation::MakeTransformationAddConstantScalar(
+      105, 14, {uint_for_float[1]});
+  auto bad_add_float_30_id_already_used =
+      transformation::MakeTransformationAddConstantScalar(104, 14,
+                                                          {uint_for_float[1]});
+  auto bad_id_already_used =
+      transformation::MakeTransformationAddConstantScalar(1, 6, {1});
+  auto bad_no_data =
+      transformation::MakeTransformationAddConstantScalar(100, 6, {});
+  auto bad_too_much_data =
+      transformation::MakeTransformationAddConstantScalar(100, 6, {1, 2});
+  auto bad_type_id_does_not_exist =
+      transformation::MakeTransformationAddConstantScalar(108, 2020,
+                                                          {uint_for_float[0]});
+  auto bad_type_id_is_not_a_type =
+      transformation::MakeTransformationAddConstantScalar(109, 9, {0});
+  auto bad_type_id_is_void =
+      transformation::MakeTransformationAddConstantScalar(110, 2, {0});
+  auto bad_type_id_is_pointer =
+      transformation::MakeTransformationAddConstantScalar(111, 11, {0});
+
+  // Id is already in use.
+  ASSERT_FALSE(transformation::IsApplicable(bad_id_already_used, context.get(),
+                                            fact_manager));
+
+  // At least one word of data must be provided.
+  ASSERT_FALSE(
+      transformation::IsApplicable(bad_no_data, context.get(), fact_manager));
+
+  // Cannot give two data words for a 32-bit type.
+  ASSERT_FALSE(transformation::IsApplicable(bad_too_much_data, context.get(),
+                                            fact_manager));
+
+  // Type id does not exist
+  ASSERT_FALSE(transformation::IsApplicable(bad_type_id_does_not_exist,
+                                            context.get(), fact_manager));
+
+  // Type id is not a type
+  ASSERT_FALSE(transformation::IsApplicable(bad_type_id_is_not_a_type,
+                                            context.get(), fact_manager));
+
+  // Type id is void
+  ASSERT_FALSE(transformation::IsApplicable(bad_type_id_is_void, context.get(),
+                                            fact_manager));
+
+  // Type id is pointer
+  ASSERT_FALSE(transformation::IsApplicable(bad_type_id_is_pointer,
+                                            context.get(), fact_manager));
+
+  ASSERT_TRUE(transformation::IsApplicable(add_signed_int_1, context.get(),
+                                           fact_manager));
+  transformation::Apply(add_signed_int_1, context.get(), &fact_manager);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  ASSERT_TRUE(transformation::IsApplicable(add_signed_int_10, context.get(),
+                                           fact_manager));
+  transformation::Apply(add_signed_int_10, context.get(), &fact_manager);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  ASSERT_TRUE(transformation::IsApplicable(add_unsigned_int_2, context.get(),
+                                           fact_manager));
+  transformation::Apply(add_unsigned_int_2, context.get(), &fact_manager);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  ASSERT_TRUE(transformation::IsApplicable(add_unsigned_int_20, context.get(),
+                                           fact_manager));
+  transformation::Apply(add_unsigned_int_20, context.get(), &fact_manager);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  ASSERT_TRUE(
+      transformation::IsApplicable(add_float_3, context.get(), fact_manager));
+  transformation::Apply(add_float_3, context.get(), &fact_manager);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  ASSERT_TRUE(
+      transformation::IsApplicable(add_float_30, context.get(), fact_manager));
+  transformation::Apply(add_float_30, context.get(), &fact_manager);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  ASSERT_FALSE(transformation::IsApplicable(bad_add_float_30_id_already_used,
+                                            context.get(), fact_manager));
+
+  std::string after_transformation = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %8 "x"
+               OpName %12 "y"
+               OpName %16 "z"
+               OpDecorate %8 RelaxedPrecision
+               OpDecorate %12 RelaxedPrecision
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Function %6
+          %9 = OpConstant %6 1
+         %10 = OpTypeInt 32 0
+         %11 = OpTypePointer Function %10
+         %13 = OpConstant %10 2
+         %14 = OpTypeFloat 32
+         %15 = OpTypePointer Function %14
+         %17 = OpConstant %14 3
+        %100 = OpConstant %6 1
+        %101 = OpConstant %6 10
+        %102 = OpConstant %10 2
+        %103 = OpConstant %10 20
+        %104 = OpConstant %14 3
+        %105 = OpConstant %14 30
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+          %8 = OpVariable %7 Function
+         %12 = OpVariable %11 Function
+         %16 = OpVariable %15 Function
+               OpStore %8 %9
+               OpStore %12 %13
+               OpStore %16 %17
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  ASSERT_TRUE(IsEqual(env, after_transformation, context.get()));
+}
+
+}  // namespace
+}  // namespace fuzz
+}  // namespace spvtools

--- a/test/fuzz/transformation_add_type_boolean_test.cpp
+++ b/test/fuzz/transformation_add_type_boolean_test.cpp
@@ -1,0 +1,83 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_add_type_boolean.h"
+#include "test/fuzz/fuzz_test_util.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace {
+
+TEST(TransformationAddTypeBooleanTest, BasicTest) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+
+  // Not applicable because id 1 is already in use.
+  ASSERT_FALSE(transformation::IsApplicable(
+      transformation::MakeTransformationAddTypeBoolean(1), context.get(),
+      fact_manager));
+
+  auto add_type_bool = transformation::MakeTransformationAddTypeBoolean(100);
+  ASSERT_TRUE(
+      transformation::IsApplicable(add_type_bool, context.get(), fact_manager));
+  transformation::Apply(add_type_bool, context.get(), &fact_manager);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  // Not applicable as we already have this type now.
+  ASSERT_FALSE(transformation::IsApplicable(
+      transformation::MakeTransformationAddTypeBoolean(101), context.get(),
+      fact_manager));
+
+  std::string after_transformation = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+        %100 = OpTypeBool
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+  ASSERT_TRUE(IsEqual(env, after_transformation, context.get()));
+}
+
+}  // namespace
+}  // namespace fuzz
+}  // namespace spvtools

--- a/test/fuzz/transformation_add_type_float_test.cpp
+++ b/test/fuzz/transformation_add_type_float_test.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_add_type_float.h"
+#include "test/fuzz/fuzz_test_util.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace {
+
+TEST(TransformationAddTypeFloatTest, BasicTest) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+
+  // Not applicable because id 1 is already in use.
+  ASSERT_FALSE(transformation::IsApplicable(
+      transformation::MakeTransformationAddTypeFloat(1, 32), context.get(),
+      fact_manager));
+
+  auto add_type_float_32 =
+      transformation::MakeTransformationAddTypeFloat(100, 32);
+  ASSERT_TRUE(transformation::IsApplicable(add_type_float_32, context.get(),
+                                           fact_manager));
+  transformation::Apply(add_type_float_32, context.get(), &fact_manager);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  // Not applicable as we already have this type now.
+  ASSERT_FALSE(transformation::IsApplicable(
+      transformation::MakeTransformationAddTypeFloat(101, 32), context.get(),
+      fact_manager));
+
+  std::string after_transformation = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+        %100 = OpTypeFloat 32
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+  ASSERT_TRUE(IsEqual(env, after_transformation, context.get()));
+}
+
+}  // namespace
+}  // namespace fuzz
+}  // namespace spvtools

--- a/test/fuzz/transformation_add_type_int_test.cpp
+++ b/test/fuzz/transformation_add_type_int_test.cpp
@@ -1,0 +1,98 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_add_type_int.h"
+#include "test/fuzz/fuzz_test_util.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace {
+
+TEST(TransformationAddTypeIntTest, BasicTest) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+
+  // Not applicable because id 1 is already in use.
+  ASSERT_FALSE(transformation::IsApplicable(
+      transformation::MakeTransformationAddTypeInt(1, 32, false), context.get(),
+      fact_manager));
+
+  auto add_type_signed_int_32 =
+      transformation::MakeTransformationAddTypeInt(100, 32, true);
+  auto add_type_unsigned_int_32 =
+      transformation::MakeTransformationAddTypeInt(101, 32, false);
+  auto add_type_signed_int_32_again =
+      transformation::MakeTransformationAddTypeInt(102, 32, true);
+  auto add_type_unsigned_int_32_again =
+      transformation::MakeTransformationAddTypeInt(103, 32, false);
+
+  ASSERT_TRUE(transformation::IsApplicable(add_type_signed_int_32,
+                                           context.get(), fact_manager));
+  transformation::Apply(add_type_signed_int_32, context.get(), &fact_manager);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  ASSERT_TRUE(transformation::IsApplicable(add_type_unsigned_int_32,
+                                           context.get(), fact_manager));
+  transformation::Apply(add_type_unsigned_int_32, context.get(), &fact_manager);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  // Not applicable as we already have these types now.
+  ASSERT_FALSE(transformation::IsApplicable(add_type_signed_int_32_again,
+                                            context.get(), fact_manager));
+  ASSERT_FALSE(transformation::IsApplicable(add_type_unsigned_int_32_again,
+                                            context.get(), fact_manager));
+
+  std::string after_transformation = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+        %100 = OpTypeInt 32 1
+        %101 = OpTypeInt 32 0
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+  ASSERT_TRUE(IsEqual(env, after_transformation, context.get()));
+}
+
+}  // namespace
+}  // namespace fuzz
+}  // namespace spvtools


### PR DESCRIPTION
This new pass adds some basic ingredients to a module on which future passes are likely to depend, such as boolean constants and some specfic integer and floating-point values.  This is not a fuzzer pass in the true sense in that it does not employ randomization, but it makes sense to define it as a fuzzer pass since it is the first of a number of transformations passes that the fuzzer will run on a module.
