### PR TITLE
Add replayer tool for spirv-fuzz.

### DIFF
--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -39,6 +39,7 @@ if(SPIRV_BUILD_FUZZER)
         protobufs/spirvfuzz_protobufs.h
         pseudo_random_generator.h
         random_generator.h
+        replayer.h
         transformation_add_constant_boolean.h
         transformation_add_constant_scalar.h
         transformation_add_dead_break.h
@@ -63,6 +64,7 @@ if(SPIRV_BUILD_FUZZER)
         id_use_descriptor.cpp
         pseudo_random_generator.cpp
         random_generator.cpp
+        replayer.cpp
         transformation_add_constant_boolean.cpp
         transformation_add_constant_scalar.cpp
         transformation_add_dead_break.cpp

--- a/source/fuzz/replayer.cpp
+++ b/source/fuzz/replayer.cpp
@@ -140,8 +140,6 @@ struct Replayer::Impl {
 
 Replayer::Replayer(spv_target_env env) : impl_(MakeUnique<Impl>(env)) {}
 
-Replayer::~Replayer() = default;
-
 void Replayer::SetMessageConsumer(MessageConsumer c) {
   impl_->consumer = std::move(c);
 }

--- a/source/fuzz/replayer.cpp
+++ b/source/fuzz/replayer.cpp
@@ -1,0 +1,200 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/replayer.h"
+
+#include <utility>
+
+#include "source/fuzz/fact_manager.h"
+#include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
+#include "source/fuzz/transformation_add_constant_boolean.h"
+#include "source/fuzz/transformation_add_constant_scalar.h"
+#include "source/fuzz/transformation_add_dead_break.h"
+#include "source/fuzz/transformation_add_type_boolean.h"
+#include "source/fuzz/transformation_add_type_float.h"
+#include "source/fuzz/transformation_add_type_int.h"
+#include "source/fuzz/transformation_move_block_down.h"
+#include "source/fuzz/transformation_replace_boolean_constant_with_constant_binary.h"
+#include "source/fuzz/transformation_split_block.h"
+#include "source/opt/build_module.h"
+#include "source/util/make_unique.h"
+
+namespace spvtools {
+namespace fuzz {
+
+namespace {
+
+// Returns true if and only if the precondition for |transformation| holds, with
+// respect to the given |context| and |fact_manager|.
+bool IsApplicable(const protobufs::Transformation& transformation,
+                  opt::IRContext* context, const FactManager& fact_manager) {
+  switch (transformation.transformation_case()) {
+    case protobufs::Transformation::TransformationCase::kAddConstantBoolean:
+      return transformation::IsApplicable(transformation.add_constant_boolean(),
+                                          context, fact_manager);
+    case protobufs::Transformation::TransformationCase::kAddConstantScalar:
+      return transformation::IsApplicable(transformation.add_constant_scalar(),
+                                          context, fact_manager);
+    case protobufs::Transformation::TransformationCase::kAddDeadBreak:
+      return transformation::IsApplicable(transformation.add_dead_break(),
+                                          context, fact_manager);
+    case protobufs::Transformation::TransformationCase::kAddTypeBoolean:
+      return transformation::IsApplicable(transformation.add_type_boolean(),
+                                          context, fact_manager);
+    case protobufs::Transformation::TransformationCase::kAddTypeFloat:
+      return transformation::IsApplicable(transformation.add_type_float(),
+                                          context, fact_manager);
+    case protobufs::Transformation::TransformationCase::kAddTypeInt:
+      return transformation::IsApplicable(transformation.add_type_int(),
+                                          context, fact_manager);
+    case protobufs::Transformation::TransformationCase::kMoveBlockDown:
+      return transformation::IsApplicable(transformation.move_block_down(),
+                                          context, fact_manager);
+    case protobufs::Transformation::TransformationCase::
+        kReplaceBooleanConstantWithConstantBinary:
+      return transformation::IsApplicable(
+          transformation.replace_boolean_constant_with_constant_binary(),
+          context, fact_manager);
+    case protobufs::Transformation::TransformationCase::kSplitBlock:
+      return transformation::IsApplicable(transformation.split_block(), context,
+                                          fact_manager);
+    default:
+      assert(transformation.transformation_case() ==
+                 protobufs::Transformation::TRANSFORMATION_NOT_SET &&
+             "Unhandled transformation type.");
+      assert(false && "An unset transformation was encountered.");
+      return false;
+  }
+}
+
+// Requires that IsApplicable holds.  Applies |transformation| to the given
+// |context| and |fact_manager|.
+void Apply(const protobufs::Transformation& transformation,
+           opt::IRContext* context, FactManager* fact_manager) {
+  switch (transformation.transformation_case()) {
+    case protobufs::Transformation::TransformationCase::kAddConstantBoolean:
+      transformation::Apply(transformation.add_constant_boolean(), context,
+                            fact_manager);
+      break;
+    case protobufs::Transformation::TransformationCase::kAddConstantScalar:
+      transformation::Apply(transformation.add_constant_scalar(), context,
+                            fact_manager);
+      break;
+    case protobufs::Transformation::TransformationCase::kAddDeadBreak:
+      transformation::Apply(transformation.add_dead_break(), context,
+                            fact_manager);
+      break;
+    case protobufs::Transformation::TransformationCase::kAddTypeBoolean:
+      transformation::Apply(transformation.add_type_boolean(), context,
+                            fact_manager);
+      break;
+    case protobufs::Transformation::TransformationCase::kAddTypeFloat:
+      transformation::Apply(transformation.add_type_float(), context,
+                            fact_manager);
+      break;
+    case protobufs::Transformation::TransformationCase::kAddTypeInt:
+      transformation::Apply(transformation.add_type_int(), context,
+                            fact_manager);
+      break;
+    case protobufs::Transformation::TransformationCase::kMoveBlockDown:
+      transformation::Apply(transformation.move_block_down(), context,
+                            fact_manager);
+      break;
+    case protobufs::Transformation::TransformationCase::
+        kReplaceBooleanConstantWithConstantBinary:
+      transformation::Apply(
+          transformation.replace_boolean_constant_with_constant_binary(),
+          context, fact_manager);
+      break;
+    case protobufs::Transformation::TransformationCase::kSplitBlock:
+      transformation::Apply(transformation.split_block(), context,
+                            fact_manager);
+      break;
+    default:
+      assert(transformation.transformation_case() ==
+                 protobufs::Transformation::TRANSFORMATION_NOT_SET &&
+             "Unhandled transformation type.");
+      assert(false && "An unset transformation was encountered.");
+  }
+}
+
+}  // namespace
+
+struct Replayer::Impl {
+  explicit Impl(spv_target_env env) : target_env(env) {}
+
+  const spv_target_env target_env;  // Target environment.
+  MessageConsumer consumer;         // Message consumer.
+};
+
+Replayer::Replayer(spv_target_env env) : impl_(MakeUnique<Impl>(env)) {}
+
+Replayer::~Replayer() = default;
+
+void Replayer::SetMessageConsumer(MessageConsumer c) {
+  impl_->consumer = std::move(c);
+}
+
+Replayer::ReplayerResultStatus Replayer::Run(
+    const std::vector<uint32_t>& binary_in,
+    const protobufs::FactSequence& initial_facts,
+    const protobufs::TransformationSequence& transformation_sequence_in,
+    std::vector<uint32_t>* binary_out,
+    protobufs::TransformationSequence* transformation_sequence_out) const {
+  // Check compatibility between the library version being linked with and the
+  // header files being used.
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  spvtools::SpirvTools tools(impl_->target_env);
+  if (!tools.IsValid()) {
+    impl_->consumer(SPV_MSG_ERROR, nullptr, {},
+                    "Failed to create SPIRV-Tools interface; stopping.");
+    return Replayer::ReplayerResultStatus::kFailedToCreateSpirvToolsInterface;
+  }
+
+  // Initial binary should be valid.
+  if (!tools.Validate(&binary_in[0], binary_in.size())) {
+    impl_->consumer(SPV_MSG_INFO, nullptr, {},
+                    "Initial binary is invalid; stopping.");
+    return Replayer::ReplayerResultStatus::kInitialBinaryInvalid;
+  }
+
+  // Build the module from the input binary.
+  std::unique_ptr<opt::IRContext> ir_context = BuildModule(
+      impl_->target_env, impl_->consumer, binary_in.data(), binary_in.size());
+  assert(ir_context);
+
+  FactManager fact_manager;
+  if (!fact_manager.AddFacts(initial_facts, ir_context.get())) {
+    return Replayer::ReplayerResultStatus::kInitialFactsInvalid;
+  }
+
+  // Consider the transformation proto messages in turn.
+  for (auto& transformation : transformation_sequence_in.transformation()) {
+    // Check whether the transformation can be applied.
+    if (IsApplicable(transformation, ir_context.get(), fact_manager)) {
+      // The transformation is applicable, so apply it, and copy it to the
+      // sequence of transformations that were applied.
+      Apply(transformation, ir_context.get(), &fact_manager);
+      *transformation_sequence_out->add_transformation() = transformation;
+    }
+  }
+
+  // Write out the module as a binary.
+  ir_context->module()->ToBinary(binary_out, false);
+  return Replayer::ReplayerResultStatus::kComplete;
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/replayer.cpp
+++ b/source/fuzz/replayer.cpp
@@ -140,6 +140,8 @@ struct Replayer::Impl {
 
 Replayer::Replayer(spv_target_env env) : impl_(MakeUnique<Impl>(env)) {}
 
+Replayer::~Replayer() = default;
+
 void Replayer::SetMessageConsumer(MessageConsumer c) {
   impl_->consumer = std::move(c);
 }

--- a/source/fuzz/replayer.h
+++ b/source/fuzz/replayer.h
@@ -45,8 +45,6 @@ class Replayer {
   Replayer& operator=(const Replayer&) = delete;
   Replayer& operator=(Replayer&&) = delete;
 
-  ~Replayer();
-
   // Sets the message consumer to the given |consumer|. The |consumer| will be
   // invoked once for each message communicated from the library.
   void SetMessageConsumer(MessageConsumer consumer);

--- a/source/fuzz/replayer.h
+++ b/source/fuzz/replayer.h
@@ -1,0 +1,75 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_REPLAYER_H_
+#define SOURCE_FUZZ_REPLAYER_H_
+
+#include <memory>
+#include <vector>
+
+#include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
+#include "source/opt/ir_context.h"
+#include "spirv-tools/libspirv.hpp"
+
+namespace spvtools {
+namespace fuzz {
+
+// Transforms a SPIR-V module into a semantically equivalent SPIR-V module by
+// applying a series of pre-defined transformations.
+class Replayer {
+ public:
+  // Possible statuses that can result from running the replayer.
+  enum ReplayerResultStatus {
+    kComplete,
+    kFailedToCreateSpirvToolsInterface,
+    kInitialBinaryInvalid,
+    kInitialFactsInvalid,
+  };
+
+  // Constructs a replayer from the given target environment.
+  explicit Replayer(spv_target_env env);
+
+  // Disables copy/move constructor/assignment operations.
+  Replayer(const Replayer&) = delete;
+  Replayer(Replayer&&) = delete;
+  Replayer& operator=(const Replayer&) = delete;
+  Replayer& operator=(Replayer&&) = delete;
+
+  ~Replayer();
+
+  // Sets the message consumer to the given |consumer|. The |consumer| will be
+  // invoked once for each message communicated from the library.
+  void SetMessageConsumer(MessageConsumer consumer);
+
+  // Transforms |binary_in| to |binary_out| by attempting to apply the
+  // transformations from |transformation_sequence_in|.  Initial facts about the
+  // input binary and the context in which it will execute are provided via
+  // |initial_facts|.  The transformations that were successfully applied are
+  // returned via |transformation_sequence_out|.
+  ReplayerResultStatus Run(
+      const std::vector<uint32_t>& binary_in,
+      const protobufs::FactSequence& initial_facts,
+      const protobufs::TransformationSequence& transformation_sequence_in,
+      std::vector<uint32_t>* binary_out,
+      protobufs::TransformationSequence* transformation_sequence_out) const;
+
+ private:
+  struct Impl;                  // Opaque struct for holding internal data.
+  std::unique_ptr<Impl> impl_;  // Unique pointer to internal data.
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_REPLAYER_H_

--- a/source/fuzz/replayer.h
+++ b/source/fuzz/replayer.h
@@ -45,6 +45,8 @@ class Replayer {
   Replayer& operator=(const Replayer&) = delete;
   Replayer& operator=(Replayer&&) = delete;
 
+  ~Replayer();
+
   // Sets the message consumer to the given |consumer|. The |consumer| will be
   // invoked once for each message communicated from the library.
   void SetMessageConsumer(MessageConsumer consumer);

--- a/source/fuzz/replayer.h
+++ b/source/fuzz/replayer.h
@@ -19,7 +19,6 @@
 #include <vector>
 
 #include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
-#include "source/opt/ir_context.h"
 #include "spirv-tools/libspirv.hpp"
 
 namespace spvtools {

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -17,7 +17,7 @@ if (${SPIRV_BUILD_FUZZER})
   set(SOURCES
           fuzz_test_util.h
 
-          fuzzer_test.cpp
+          fuzzer_replayer_test.cpp
           fact_manager_test.cpp
           fuzz_test_util.cpp
           transformation_add_constant_boolean_test.cpp

--- a/tools/fuzz/fuzz.cpp
+++ b/tools/fuzz/fuzz.cpp
@@ -21,6 +21,7 @@
 
 #include "source/fuzz/fuzzer.h"
 #include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
+#include "source/fuzz/replayer.h"
 #include "source/opt/build_module.h"
 #include "source/opt/ir_context.h"
 #include "source/opt/log.h"
@@ -32,7 +33,7 @@
 namespace {
 
 // Status and actions to perform after parsing command-line arguments.
-enum class FuzzActions { CONTINUE, STOP };
+enum class FuzzActions { CONTINUE, REPLAY, STOP };
 
 struct FuzzStatus {
   FuzzActions action;
@@ -60,6 +61,9 @@ Options (in lexicographical order):
 
   -h, --help
                Print this help.
+  --replay
+               File from which to read a sequence of transformations to replay
+               (instead of fuzzing)
   --seed
                Unsigned 32-bit integer seed to control random number
                generation.
@@ -90,6 +94,7 @@ bool EndsWithSpv(const std::string& filename) {
 
 FuzzStatus ParseFlags(int argc, const char** argv, std::string* in_binary_file,
                       std::string* out_binary_file,
+                      std::string* replay_transformations_file,
                       spvtools::FuzzerOptions* fuzzer_options) {
   uint32_t positional_arg_index = 0;
 
@@ -110,6 +115,9 @@ FuzzStatus ParseFlags(int argc, const char** argv, std::string* in_binary_file,
           PrintUsage(argv[0]);
           return {FuzzActions::STOP, 1};
         }
+      } else if (0 == strncmp(cur_arg, "--replay=", sizeof("--replay=") - 1)) {
+        const auto split_flag = spvtools::utils::SplitFlagArgs(cur_arg);
+        *replay_transformations_file = std::string(split_flag.second);
       } else if (0 == strncmp(cur_arg, "--seed=", sizeof("--seed=") - 1)) {
         const auto split_flag = spvtools::utils::SplitFlagArgs(cur_arg);
         char* end = nullptr;
@@ -158,6 +166,12 @@ FuzzStatus ParseFlags(int argc, const char** argv, std::string* in_binary_file,
     return {FuzzActions::STOP, 1};
   }
 
+  if (!replay_transformations_file->empty()) {
+    // A replay transformations file was given, thus the tool is being invoked
+    // in replay mode.
+    return {FuzzActions::REPLAY, 0};
+  }
+
   return {FuzzActions::CONTINUE, 0};
 }
 
@@ -168,12 +182,13 @@ const auto kDefaultEnvironment = SPV_ENV_UNIVERSAL_1_3;
 int main(int argc, const char** argv) {
   std::string in_binary_file;
   std::string out_binary_file;
+  std::string replay_transformations_file;
 
   spv_target_env target_env = kDefaultEnvironment;
   spvtools::FuzzerOptions fuzzer_options;
 
   FuzzStatus status = ParseFlags(argc, argv, &in_binary_file, &out_binary_file,
-                                 &fuzzer_options);
+                                 &replay_transformations_file, &fuzzer_options);
 
   if (status.action == FuzzActions::STOP) {
     return status.code;
@@ -205,15 +220,40 @@ int main(int argc, const char** argv) {
   std::vector<uint32_t> binary_out;
   spvtools::fuzz::protobufs::TransformationSequence transformations_applied;
 
-  spvtools::fuzz::Fuzzer fuzzer(target_env);
-  fuzzer.SetMessageConsumer(spvtools::utils::CLIMessageConsumer);
-  auto fuzz_result_status =
-      fuzzer.Run(binary_in, initial_facts, &binary_out,
-                 &transformations_applied, fuzzer_options);
-  if (fuzz_result_status !=
-      spvtools::fuzz::Fuzzer::FuzzerResultStatus::kComplete) {
-    spvtools::Error(FuzzDiagnostic, nullptr, {}, "Error running fuzzer");
-    return 1;
+  if (status.action == FuzzActions::REPLAY) {
+    std::ifstream existing_transformations_file;
+    existing_transformations_file.open(replay_transformations_file,
+                                       std::ios::in | std::ios::binary);
+    spvtools::fuzz::protobufs::TransformationSequence
+        existing_transformation_sequence;
+    auto parse_success = existing_transformation_sequence.ParseFromIstream(
+        &existing_transformations_file);
+    existing_transformations_file.close();
+    if (!parse_success) {
+      spvtools::Error(FuzzDiagnostic, nullptr, {},
+                      "Error reading transformations for replay");
+      return 1;
+    }
+    spvtools::fuzz::Replayer replayer(target_env);
+    replayer.SetMessageConsumer(spvtools::utils::CLIMessageConsumer);
+    auto replay_result_status =
+        replayer.Run(binary_in, initial_facts, existing_transformation_sequence,
+                     &binary_out, &transformations_applied);
+    if (replay_result_status !=
+        spvtools::fuzz::Replayer::ReplayerResultStatus::kComplete) {
+      return 1;
+    }
+  } else {
+    spvtools::fuzz::Fuzzer fuzzer(target_env);
+    fuzzer.SetMessageConsumer(spvtools::utils::CLIMessageConsumer);
+    auto fuzz_result_status =
+        fuzzer.Run(binary_in, initial_facts, &binary_out,
+                   &transformations_applied, fuzzer_options);
+    if (fuzz_result_status !=
+        spvtools::fuzz::Fuzzer::FuzzerResultStatus::kComplete) {
+      spvtools::Error(FuzzDiagnostic, nullptr, {}, "Error running fuzzer");
+      return 1;
+    }
   }
 
   if (!WriteFile<uint32_t>(out_binary_file.c_str(), "wb", binary_out.data(),


### PR DESCRIPTION
The replayer takes an existing sequence of transformations and applies them to a module.  Replaying a sequence of transformations that were obtained via fuzzing should lead to an identical module to the module that was fuzzed.  Tests have been added to check for this.