### PR TITLE
Handle volatile memory semantics in upgrade

### DIFF
--- a/source/opt/upgrade_memory_model.h
+++ b/source/opt/upgrade_memory_model.h
@@ -57,11 +57,18 @@ class UpgradeMemoryModel : public Pass {
   // capability and extension.
   void UpgradeMemoryModelInstruction();
 
-  // Upgrades memory, image and barrier instructions.
+  // Upgrades memory, image and atomic instructions.
   // Memory and image instructions convert coherent and volatile decorations
-  // into flags on the instruction. Barriers in tessellation shaders get the
-  // output storage semantic if appropriate.
+  // into flags on the instruction.
+  // Atomic memory semantics convert volatile decoration into flags on the
+  // instruction.
   void UpgradeInstructions();
+
+  // Upgrades memory and image operands for instructions that have them.
+  void UpgradeMemoryAndImages();
+
+  // Adds the volatile memory semantic if necessary.
+  void UpgradeAtomics();
 
   // Returns whether |id| is coherent and/or volatile.
   std::tuple<bool, bool, SpvScope> GetInstructionAttributes(uint32_t id);
@@ -94,6 +101,11 @@ class UpgradeMemoryModel : public Pass {
   void UpgradeFlags(Instruction* inst, uint32_t in_operand, bool is_coherent,
                     bool is_volatile, OperationType operation_type,
                     InstructionType inst_type);
+
+  // Modifies the semantics at |in_operand| of |inst| to include the volatile
+  // bit if |is_volatile| is true.
+  void UpgradeSemantics(Instruction* inst, uint32_t in_operand,
+                        bool is_volatile);
 
   // Returns the result id for a constant for |scope|.
   uint32_t GetScopeConstant(SpvScope scope);


### PR DESCRIPTION
* If an atomic is decorated with volatile add the volatile bit to its
memory semantics

Fixed some comments and refactored a method too.