### PR TITLE
AggressiveDCE: Retain all bindings

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -570,11 +570,18 @@ void AggressiveDCEPass::InitializeModuleScopeLiveInstructions() {
       AddToWorklist(&entry);
     }
   }
-  // Keep workgroup size.
+  
   for (auto& anno : get_module()->annotations()) {
     if (anno.opcode() == SpvOpDecorate) {
+      // Keep workgroup size.
       if (anno.GetSingleWordInOperand(1u) == SpvDecorationBuiltIn &&
           anno.GetSingleWordInOperand(2u) == SpvBuiltInWorkgroupSize) {
+        AddToWorklist(&anno);
+      }
+      
+      // Keep all bindings.
+      if ((anno.GetSingleWordInOperand(1u) == SpvDecorationDescriptorSet) ||
+          (anno.GetSingleWordInOperand(1u) == SpvDecorationBinding)) {
         AddToWorklist(&anno);
       }
     }


### PR DESCRIPTION
Some background: my shader render pipeline uses SPIRV-Cross to convert SPIR-V into Metal shaders. For resource binding, argument buffers are used, mapping directly to Vulkan descriptor sets. Crucially, these argument buffers are shared across pipeline stages; each argument buffer may contain resources relevant to both the vertex and fragment stage.

As a result of this, I need all bindings to be visible to all shader stages, even if the binding may be unused in that stage: the argument buffer definition must be complete. To achieve this, the AggressiveDCE pass must not strip instructions with binding decorations. (Additional changes are also needed for SPIRV-Cross to support this; see https://github.com/troughton/SPIRV-Cross/commit/c3daef79b89caf3a85a7e7d7d5775dfb86babad6)

Note that simply not running the pass isn't an option; my source shaders are in HLSL so need to undergo legalisation.

I don't expect this to be merged as-is (since that would obviously be undesirable for code-size in a number of shaders), but I welcome suggestions for how retaining bindings should be added as an option – should it be added an option to AggressiveDCE, or should a separate pass be used? How should the option be exposed in the driver?