### PR TITLE
Roll external/spirv-headers/ 8b911bd2b..de99d4d83 (8 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -11,7 +11,7 @@ vars = {
   'googletest_revision': '98a0d007d7092b72eea0e501bb9ad17908a1a036',
   'testing_revision': '340252637e2e7c72c0901dcbeeacfff419e19b59',
   're2_revision': '6cf8ccd82dbaab2668e9b13596c68183c9ecd13f',
-  'spirv_headers_revision': '8b911bd2ba37677037b38c9bd286c7c05701bcda',
+  'spirv_headers_revision': 'de99d4d834aeb51dd9f099baa285bd44fd04bb3d',
 }
 
 deps = {


### PR DESCRIPTION
https://github.com/KhronosGroup/SPIRV-Headers/compare/8b911bd2ba37...de99d4d834ae

$ git log 8b911bd2b..de99d4d83 --date=short --no-merges --format='%ad %ae %s'
2019-06-12 dneto Add Volatile to Memory Semantics, for SPV_KHR_vulkan_memory_model
2019-06-10 ehsannas Add grammar and symbols for UserTypeGOOGLE extension to unified1.
2019-06-07 cepheus Add missing "version" : "None" to a bunch of reserved enumerants.
2019-06-07 cepheus Add more detail about reserving tokens to the README.
2019-06-07 cepheus Restore numerical order in enumerants.
2019-05-18 mchiasson Update CMakeLists.txt
2019-05-16 mchiasson updated as per code review
2019-05-11 mchiasson cmake development configuration package Fixes #104

Created with:
  roll-dep external/spirv-headers

Fixes #2680