### PR TITLE
Avoid using a global static map.

### DIFF
--- a/source/spirv_target_env.cpp
+++ b/source/spirv_target_env.cpp
@@ -104,39 +104,42 @@ uint32_t spvVersionForTargetEnv(spv_target_env env) {
   return SPV_SPIRV_VERSION_WORD(0, 0);
 }
 
-static const std::map<std::string, spv_target_env> spvTargetEnvNameMap = {
-    {"vulkan1.1spv1.4", SPV_ENV_VULKAN_1_1_SPIRV_1_4},
-    {"vulkan1.0", SPV_ENV_VULKAN_1_0},
-    {"vulkan1.1", SPV_ENV_VULKAN_1_1},
-    {"spv1.0", SPV_ENV_UNIVERSAL_1_0},
-    {"spv1.1", SPV_ENV_UNIVERSAL_1_1},
-    {"spv1.2", SPV_ENV_UNIVERSAL_1_2},
-    {"spv1.3", SPV_ENV_UNIVERSAL_1_3},
-    {"spv1.4", SPV_ENV_UNIVERSAL_1_4},
-    {"opencl1.2embedded", SPV_ENV_OPENCL_EMBEDDED_1_2},
-    {"opencl1.2", SPV_ENV_OPENCL_1_2},
-    {"opencl2.0embedded", SPV_ENV_OPENCL_EMBEDDED_2_0},
-    {"opencl2.0", SPV_ENV_OPENCL_2_0},
-    {"opencl2.1embedded", SPV_ENV_OPENCL_EMBEDDED_2_1},
-    {"opencl2.1", SPV_ENV_OPENCL_2_1},
-    {"opencl2.2embedded", SPV_ENV_OPENCL_EMBEDDED_2_2},
-    {"opencl2.2", SPV_ENV_OPENCL_2_2},
-    {"opengl4.0", SPV_ENV_OPENGL_4_0},
-    {"opengl4.1", SPV_ENV_OPENGL_4_1},
-    {"opengl4.2", SPV_ENV_OPENGL_4_2},
-    {"opengl4.3", SPV_ENV_OPENGL_4_3},
-    {"opengl4.5", SPV_ENV_OPENGL_4_5},
-    {"webgpu0", SPV_ENV_WEBGPU_0},
-};
+const std::map<std::string, spv_target_env> getSpvTargetEnvNameMap() {
+  static std::map<std::string, spv_target_env> result = {
+      {"vulkan1.1spv1.4", SPV_ENV_VULKAN_1_1_SPIRV_1_4},
+      {"vulkan1.0", SPV_ENV_VULKAN_1_0},
+      {"vulkan1.1", SPV_ENV_VULKAN_1_1},
+      {"spv1.0", SPV_ENV_UNIVERSAL_1_0},
+      {"spv1.1", SPV_ENV_UNIVERSAL_1_1},
+      {"spv1.2", SPV_ENV_UNIVERSAL_1_2},
+      {"spv1.3", SPV_ENV_UNIVERSAL_1_3},
+      {"spv1.4", SPV_ENV_UNIVERSAL_1_4},
+      {"opencl1.2embedded", SPV_ENV_OPENCL_EMBEDDED_1_2},
+      {"opencl1.2", SPV_ENV_OPENCL_1_2},
+      {"opencl2.0embedded", SPV_ENV_OPENCL_EMBEDDED_2_0},
+      {"opencl2.0", SPV_ENV_OPENCL_2_0},
+      {"opencl2.1embedded", SPV_ENV_OPENCL_EMBEDDED_2_1},
+      {"opencl2.1", SPV_ENV_OPENCL_2_1},
+      {"opencl2.2embedded", SPV_ENV_OPENCL_EMBEDDED_2_2},
+      {"opencl2.2", SPV_ENV_OPENCL_2_2},
+      {"opengl4.0", SPV_ENV_OPENGL_4_0},
+      {"opengl4.1", SPV_ENV_OPENGL_4_1},
+      {"opengl4.2", SPV_ENV_OPENGL_4_2},
+      {"opengl4.3", SPV_ENV_OPENGL_4_3},
+      {"opengl4.5", SPV_ENV_OPENGL_4_5},
+      {"webgpu0", SPV_ENV_WEBGPU_0},
+  };
+  return result;
+}
 
 bool spvParseTargetEnv(const char* s, spv_target_env* env) {
   std::string envstr;
   if (s != nullptr) {
     envstr = s;
   }
-  if (spvTargetEnvNameMap.count(envstr) != 0) {
+  if (getSpvTargetEnvNameMap().count(envstr) != 0) {
     if (env) {
-      *env = spvTargetEnvNameMap.at(envstr);
+      *env = getSpvTargetEnvNameMap().at(envstr);
     }
     return true;
   }
@@ -282,7 +285,7 @@ std::string spvTargetEnvList(const int pad, const int wrap) {
   std::string line;
   std::string sep = "";
 
-  for (auto& env_name : spvTargetEnvNameMap) {
+  for (auto& env_name : getSpvTargetEnvNameMap()) {
     std::string word = sep + env_name.first;
     if (line.length() + word.length() > max_line_len) {
       // Adding one word wouldn't fit, commit the line in progress and


### PR DESCRIPTION
It is better to use a "getter" function I believe according to the C++
coding guide.

The existence of the global static caused a weird startup issue in DXC (which includes SPIRV-Tools as
an external project).