### PR TITLE
Warn when input facts are invalid.

### DIFF
--- a/source/fuzz/fact_manager.h
+++ b/source/fuzz/fact_manager.h
@@ -41,11 +41,14 @@ class FactManager {
   ~FactManager();
 
   // Adds all the facts from |facts|, checking them for validity with respect to
-  // |context|. Returns true if and only if all facts are valid.
-  bool AddFacts(const protobufs::FactSequence& facts, opt::IRContext* context);
+  // |context|.  Warnings about invalid facts are communicated via
+  // |message_consumer|; such facts are otherwise ignored.
+  void AddFacts(const MessageConsumer& message_consumer,
+                const protobufs::FactSequence& facts, opt::IRContext* context);
 
-  // Adds |fact| to the fact manager, checking it for validity with respect to
-  // |context|. Returns true if and only if the fact is valid.
+  // Checks the fact for validity with respect to |context|.  Returns false,
+  // with no side effects, if the fact is invalid.  Otherwise adds |fact| to the
+  // fact manager.
   bool AddFact(const protobufs::Fact& fact, opt::IRContext* context);
 
   // The fact manager will ultimately be responsible for managing a few distinct

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -97,9 +97,7 @@ Fuzzer::FuzzerResultStatus Fuzzer::Run(
   FuzzerContext fuzzer_context(&random_generator, minimum_fresh_id);
 
   FactManager fact_manager;
-  if (!fact_manager.AddFacts(initial_facts, ir_context.get())) {
-    return Fuzzer::FuzzerResultStatus::kInitialFactsInvalid;
-  }
+  fact_manager.AddFacts(impl_->consumer, initial_facts, ir_context.get());
 
   // Add some essential ingredients to the module if they are not already
   // present, such as boolean constants.

--- a/source/fuzz/fuzzer.h
+++ b/source/fuzz/fuzzer.h
@@ -33,7 +33,6 @@ class Fuzzer {
     kComplete,
     kFailedToCreateSpirvToolsInterface,
     kInitialBinaryInvalid,
-    kInitialFactsInvalid,
   };
 
   // Constructs a fuzzer from the given target environment.

--- a/source/fuzz/replayer.cpp
+++ b/source/fuzz/replayer.cpp
@@ -81,9 +81,7 @@ Replayer::ReplayerResultStatus Replayer::Run(
   assert(ir_context);
 
   FactManager fact_manager;
-  if (!fact_manager.AddFacts(initial_facts, ir_context.get())) {
-    return Replayer::ReplayerResultStatus::kInitialFactsInvalid;
-  }
+  fact_manager.AddFacts(impl_->consumer, initial_facts, ir_context.get());
 
   // Consider the transformation proto messages in turn.
   for (auto& message : transformation_sequence_in.transformation()) {

--- a/source/fuzz/replayer.h
+++ b/source/fuzz/replayer.h
@@ -33,7 +33,6 @@ class Replayer {
     kComplete,
     kFailedToCreateSpirvToolsInterface,
     kInitialBinaryInvalid,
-    kInitialFactsInvalid,
   };
 
   // Constructs a replayer from the given target environment.

--- a/tools/fuzz/fuzz.cpp
+++ b/tools/fuzz/fuzz.cpp
@@ -257,7 +257,7 @@ int main(int argc, const char** argv) {
   const std::string dot_spv(".spv");
   std::string in_facts_file =
       in_binary_file.substr(0, in_binary_file.length() - dot_spv.length()) +
-      ".json";
+      ".facts";
   std::ifstream facts_input(in_facts_file);
   if (facts_input) {
     std::string facts_json_string((std::istreambuf_iterator<char>(facts_input)),


### PR DESCRIPTION
Fixes #2621.

Instead of aborting when an invalid input fact is provided, the tool
now warns about the invalid fact and then ignores it.  This is
convenient for example if facts are specified about uniforms with
descriptor sets and bindings that happen to not be present in the
input binary.