### PR TITLE
Validate usage of 8- and 16-bit types with only storage capabilities

### DIFF
--- a/source/val/validate_composites.cpp
+++ b/source/val/validate_composites.cpp
@@ -158,6 +158,12 @@ spv_result_t ValidateVectorExtractDynamic(ValidationState_t& _,
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
            << "Expected Index to be int scalar";
   }
+
+  if (_.HasCapability(SpvCapabilityShader) &&
+      _.ContainsLimitedUseIntOrFloatType(inst->type_id())) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+           << "Cannot extract from a vector of 8- or 16-bit types";
+  }
   return SPV_SUCCESS;
 }
 
@@ -187,6 +193,12 @@ spv_result_t ValidateVectorInsertDyanmic(ValidationState_t& _,
   if (!_.IsIntScalarType(index_type)) {
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
            << "Expected Index to be int scalar";
+  }
+
+  if (_.HasCapability(SpvCapabilityShader) &&
+      _.ContainsLimitedUseIntOrFloatType(inst->type_id())) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+           << "Cannot insert into a vector of 8- or 16-bit types";
   }
   return SPV_SUCCESS;
 }
@@ -344,6 +356,12 @@ spv_result_t ValidateCompositeConstruct(ValidationState_t& _,
              << "Expected Result Type to be a composite type";
     }
   }
+
+  if (_.HasCapability(SpvCapabilityShader) &&
+      _.ContainsLimitedUseIntOrFloatType(inst->type_id())) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+           << "Cannot create a composite containing 8- or 16-bit types";
+  }
   return SPV_SUCCESS;
 }
 
@@ -361,6 +379,12 @@ spv_result_t ValidateCompositeExtract(ValidationState_t& _,
            << ") does not match the type that results from indexing into "
               "the composite (Op"
            << spvOpcodeString(_.GetIdOpcode(member_type)) << ").";
+  }
+
+  if (_.HasCapability(SpvCapabilityShader) &&
+      _.ContainsLimitedUseIntOrFloatType(inst->type_id())) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+           << "Cannot extract from a composite of 8- or 16-bit types";
   }
   return SPV_SUCCESS;
 }
@@ -390,6 +414,12 @@ spv_result_t ValidateCompositeInsert(ValidationState_t& _,
            << ") does not match the type that results from indexing into the "
               "Composite (Op"
            << spvOpcodeString(_.GetIdOpcode(member_type)) << ").";
+  }
+
+  if (_.HasCapability(SpvCapabilityShader) &&
+      _.ContainsLimitedUseIntOrFloatType(inst->type_id())) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+           << "Cannot insert into a composite of 8- or 16-bit types";
   }
   return SPV_SUCCESS;
 }
@@ -438,6 +468,12 @@ spv_result_t ValidateTranspose(ValidationState_t& _, const Instruction* inst) {
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
            << "Expected number of columns and the column size of Matrix "
            << "to be the reverse of those of Result Type";
+  }
+
+  if (_.HasCapability(SpvCapabilityShader) &&
+      _.ContainsLimitedUseIntOrFloatType(inst->type_id())) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+           << "Cannot transpose matrices of 16-bit floats";
   }
   return SPV_SUCCESS;
 }
@@ -510,6 +546,12 @@ spv_result_t ValidateVectorShuffle(ValidationState_t& _,
     }
   }
 
+  if (_.HasCapability(SpvCapabilityShader) &&
+      _.ContainsLimitedUseIntOrFloatType(inst->type_id())) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+           << "Cannot shuffle a vector of 8- or 16-bit types";
+  }
+
   return SPV_SUCCESS;
 }
 
@@ -526,6 +568,12 @@ spv_result_t ValidateCopyLogical(ValidationState_t& _,
   if (!_.LogicallyMatch(source_type, result_type, false)) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
            << "Result Type does not logically match the Operand type";
+  }
+
+  if (_.HasCapability(SpvCapabilityShader) &&
+      _.ContainsLimitedUseIntOrFloatType(inst->type_id())) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+           << "Cannot copy composites of 8- or 16-bit types";
   }
 
   return SPV_SUCCESS;

--- a/source/val/validate_constants.cpp
+++ b/source/val/validate_constants.cpp
@@ -436,7 +436,7 @@ spv_result_t ConstantPass(ValidationState_t& _, const Instruction* inst) {
   if (spvOpcodeIsConstant(inst->opcode()) &&
       _.HasCapability(SpvCapabilityShader) &&
       !_.IsPointerType(inst->type_id()) &&
-      _.ContainsSmallIntOrFloatType(inst->type_id())) {
+      _.ContainsLimitedUseIntOrFloatType(inst->type_id())) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
            << "Cannot form constants of 8- or 16-bit types";
   }

--- a/source/val/validate_constants.cpp
+++ b/source/val/validate_constants.cpp
@@ -434,16 +434,11 @@ spv_result_t ConstantPass(ValidationState_t& _, const Instruction* inst) {
   // Generally disallow creating 8- or 16-bit constants unless the full
   // capabilities are present.
   if (spvOpcodeIsConstant(inst->opcode()) &&
-      _.HasCapability(SpvCapabilityShader)) {
-    if ((!_.HasCapability(SpvCapabilityInt16) &&
-         _.ContainsSizedIntOrFloatType(inst->type_id(), SpvOpTypeInt, 16)) ||
-        (!_.HasCapability(SpvCapabilityInt8) &&
-         _.ContainsSizedIntOrFloatType(inst->type_id(), SpvOpTypeInt, 8)) ||
-        (!_.HasCapability(SpvCapabilityFloat16) &&
-         _.ContainsSizedIntOrFloatType(inst->type_id(), SpvOpTypeFloat, 16))) {
-      return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "Cannot form constants of 8- or 16-bit types";
-    }
+      _.HasCapability(SpvCapabilityShader) &&
+      !_.IsPointerType(inst->type_id()) &&
+      _.ContainsSmallIntOrFloatType(inst->type_id())) {
+    return _.diag(SPV_ERROR_INVALID_ID, inst)
+           << "Cannot form constants of 8- or 16-bit types";
   }
 
   return SPV_SUCCESS;

--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -428,8 +428,7 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
     }
   }
 
-  auto storage_class =
-      inst->GetOperandAs<SpvStorageClass>(storage_class_index);
+  auto storage_class = inst->GetOperandAs<SpvStorageClass>(storage_class_index);
   if (storage_class != SpvStorageClassWorkgroup &&
       storage_class != SpvStorageClassCrossWorkgroup &&
       storage_class != SpvStorageClassPrivate &&
@@ -719,7 +718,8 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
       auto underlying_type = value_type;
       while (underlying_type->opcode() == SpvOpTypePointer) {
         storage_class = underlying_type->GetOperandAs<SpvStorageClass>(1u);
-        underlying_type = _.FindDef(underlying_type->GetOperandAs<uint32_t>(2u));
+        underlying_type =
+            _.FindDef(underlying_type->GetOperandAs<uint32_t>(2u));
       }
       bool storage_class_ok = true;
       std::string sc_name = _.grammar().lookupOperandName(
@@ -773,7 +773,8 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
       auto underlying_type = value_type;
       while (underlying_type->opcode() == SpvOpTypePointer) {
         storage_class = underlying_type->GetOperandAs<SpvStorageClass>(1u);
-        underlying_type = _.FindDef(underlying_type->GetOperandAs<uint32_t>(2u));
+        underlying_type =
+            _.FindDef(underlying_type->GetOperandAs<uint32_t>(2u));
       }
       bool storage_class_ok = true;
       std::string sc_name = _.grammar().lookupOperandName(
@@ -862,7 +863,7 @@ spv_result_t ValidateLoad(ValidationState_t& _, const Instruction* inst) {
   if (auto error = CheckMemoryAccess(_, inst, 3)) return error;
 
   if (_.HasCapability(SpvCapabilityShader) &&
-      _.ContainsSmallIntOrFloatType(inst->type_id()) &&
+      _.ContainsLimitedUseIntOrFloatType(inst->type_id()) &&
       result_type->opcode() != SpvOpTypePointer) {
     if (result_type->opcode() != SpvOpTypeInt &&
         result_type->opcode() != SpvOpTypeFloat &&
@@ -981,7 +982,7 @@ spv_result_t ValidateStore(ValidationState_t& _, const Instruction* inst) {
   if (auto error = CheckMemoryAccess(_, inst, 2)) return error;
 
   if (_.HasCapability(SpvCapabilityShader) &&
-      _.ContainsSmallIntOrFloatType(inst->type_id()) &&
+      _.ContainsLimitedUseIntOrFloatType(inst->type_id()) &&
       object_type->opcode() != SpvOpTypePointer) {
     if (object_type->opcode() != SpvOpTypeInt &&
         object_type->opcode() != SpvOpTypeFloat &&

--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -734,12 +734,14 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
         case SpvStorageClassUniform:
           if (!_.HasCapability(
                   SpvCapabilityUniformAndStorageBuffer16BitAccess)) {
-            if (value_type->opcode() == SpvOpTypeArray ||
-                value_type->opcode() == SpvOpTypeRuntimeArray) {
-              value_type = _.FindDef(value_type->GetOperandAs<uint32_t>(1u));
+            if (underlying_type->opcode() == SpvOpTypeArray ||
+                underlying_type->opcode() == SpvOpTypeRuntimeArray) {
+              underlying_type =
+                  _.FindDef(underlying_type->GetOperandAs<uint32_t>(1u));
             }
             if (!_.HasCapability(SpvCapabilityStorageBuffer16BitAccess) ||
-                !_.HasDecoration(value_type->id(), SpvDecorationBufferBlock)) {
+                !_.HasDecoration(underlying_type->id(),
+                                 SpvDecorationBufferBlock)) {
               storage_class_ok = false;
             }
           }
@@ -789,12 +791,14 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
         case SpvStorageClassUniform:
           if (!_.HasCapability(
                   SpvCapabilityUniformAndStorageBuffer8BitAccess)) {
-            if (value_type->opcode() == SpvOpTypeArray ||
-                value_type->opcode() == SpvOpTypeRuntimeArray) {
-              value_type = _.FindDef(value_type->GetOperandAs<uint32_t>(1u));
+            if (underlying_type->opcode() == SpvOpTypeArray ||
+                underlying_type->opcode() == SpvOpTypeRuntimeArray) {
+              underlying_type =
+                  _.FindDef(underlying_type->GetOperandAs<uint32_t>(1u));
             }
             if (!_.HasCapability(SpvCapabilityStorageBuffer8BitAccess) ||
-                !_.HasDecoration(value_type->id(), SpvDecorationBufferBlock)) {
+                !_.HasDecoration(underlying_type->id(),
+                                 SpvDecorationBufferBlock)) {
               storage_class_ok = false;
             }
           }

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -1226,5 +1226,42 @@ const Instruction* ValidationState_t::TracePointer(
   return base_ptr;
 }
 
+bool ValidationState_t::ContainsSizedIntOrFloatType(uint32_t id, SpvOp type,
+                                                    uint32_t width) const {
+  if (type != SpvOpTypeInt || type != SpvOpTypeFloat) return false;
+
+  const auto inst = FindDef(id);
+  if (!inst) return false;
+
+  if (inst->opcode() == type) {
+    return inst->GetOperandAs<uint32_t>(1u) == width;
+  }
+
+  switch (inst->opcode()) {
+    case SpvOpTypeArray:
+    case SpvOpTypeRuntimeArray:
+    case SpvOpTypeVector:
+    case SpvOpTypeMatrix:
+    case SpvOpTypeImage:
+    case SpvOpTypeSampledImage:
+      return ContainsSizedIntOrFloatType(inst->GetOperandAs<uint32_t>(1u), type,
+                                         width);
+    case SpvOpTypePointer:
+      return ContainsSizedIntOrFloatType(inst->GetOperandAs<uint32_t>(2u), type,
+                                         width);
+    case SpvOpTypeFunction:
+    case SpvOpTypeStruct: {
+      for (uint32_t i = 1; i < inst->operands().size(); ++i) {
+        if (ContainsSizedIntOrFloatType(inst->GetOperandAs<uint32_t>(i), type,
+                                        width))
+          return true;
+      }
+      return false;
+    }
+    default:
+      return false;
+  }
+}
+
 }  // namespace val
 }  // namespace spvtools

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -1263,5 +1263,17 @@ bool ValidationState_t::ContainsSizedIntOrFloatType(uint32_t id, SpvOp type,
   }
 }
 
+bool ValidationState_t::ContainsSmallIntOrFloatType(uint32_t id) const {
+  if ((!HasCapability(SpvCapabilityInt16) &&
+       ContainsSizedIntOrFloatType(id, SpvOpTypeInt, 16)) ||
+      (!HasCapability(SpvCapabilityInt8) &&
+       ContainsSizedIntOrFloatType(id, SpvOpTypeInt, 8)) ||
+      (!HasCapability(SpvCapabilityFloat16) &&
+       ContainsSizedIntOrFloatType(id, SpvOpTypeFloat, 16))) {
+    return true;
+  }
+  return false;
+}
+
 }  // namespace val
 }  // namespace spvtools

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -1228,7 +1228,7 @@ const Instruction* ValidationState_t::TracePointer(
 
 bool ValidationState_t::ContainsSizedIntOrFloatType(uint32_t id, SpvOp type,
                                                     uint32_t width) const {
-  if (type != SpvOpTypeInt || type != SpvOpTypeFloat) return false;
+  if (type != SpvOpTypeInt && type != SpvOpTypeFloat) return false;
 
   const auto inst = FindDef(id);
   if (!inst) return false;

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -1244,6 +1244,7 @@ bool ValidationState_t::ContainsSizedIntOrFloatType(uint32_t id, SpvOp type,
     case SpvOpTypeMatrix:
     case SpvOpTypeImage:
     case SpvOpTypeSampledImage:
+    case SpvOpTypeCooperativeMatrixNV:
       return ContainsSizedIntOrFloatType(inst->GetOperandAs<uint32_t>(1u), type,
                                          width);
     case SpvOpTypePointer:

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -1247,6 +1247,7 @@ bool ValidationState_t::ContainsSizedIntOrFloatType(uint32_t id, SpvOp type,
       return ContainsSizedIntOrFloatType(inst->GetOperandAs<uint32_t>(1u), type,
                                          width);
     case SpvOpTypePointer:
+      if (IsForwardPointer(id)) return false;
       return ContainsSizedIntOrFloatType(inst->GetOperandAs<uint32_t>(2u), type,
                                          width);
     case SpvOpTypeFunction:

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -1263,7 +1263,7 @@ bool ValidationState_t::ContainsSizedIntOrFloatType(uint32_t id, SpvOp type,
   }
 }
 
-bool ValidationState_t::ContainsSmallIntOrFloatType(uint32_t id) const {
+bool ValidationState_t::ContainsLimitedUseIntOrFloatType(uint32_t id) const {
   if ((!HasCapability(SpvCapabilityInt16) &&
        ContainsSizedIntOrFloatType(id, SpvOpTypeInt, 16)) ||
       (!HasCapability(SpvCapabilityInt8) &&

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -573,6 +573,8 @@ class ValidationState_t {
   // of |width| bits.
   bool ContainsSizedIntOrFloatType(uint32_t id, SpvOp type,
                                    uint32_t width) const;
+  // Returns true if |id| contains a 8- or 16-bit int or 16-bit float.
+  bool ContainsSmallIntOrFloatType(uint32_t id) const;
 
   // Gets value from OpConstant and OpSpecConstant as uint64.
   // Returns false on failure (no instruction, wrong instruction, not int).

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -569,6 +569,11 @@ class ValidationState_t {
   bool IsIntCooperativeMatrixType(uint32_t id) const;
   bool IsUnsignedIntCooperativeMatrixType(uint32_t id) const;
 
+  // Returns true if |id| contains |type| (or integer or floating point type)
+  // of |width| bits.
+  bool ContainsSizedIntOrFloatType(uint32_t id, SpvOp type,
+                                   uint32_t width) const;
+
   // Gets value from OpConstant and OpSpecConstant as uint64.
   // Returns false on failure (no instruction, wrong instruction, not int).
   bool GetConstantValUint64(uint32_t id, uint64_t* val) const;

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -569,12 +569,12 @@ class ValidationState_t {
   bool IsIntCooperativeMatrixType(uint32_t id) const;
   bool IsUnsignedIntCooperativeMatrixType(uint32_t id) const;
 
-  // Returns true if |id| contains |type| (or integer or floating point type)
-  // of |width| bits.
+  // Returns true if |id| is a type id that contains |type| (or integer or
+  // floating point type) of |width| bits.
   bool ContainsSizedIntOrFloatType(uint32_t id, SpvOp type,
                                    uint32_t width) const;
-  // Returns true if |id| contains a 8- or 16-bit int or 16-bit float that is
-  // not generally enabled for use.
+  // Returns true if |id| is a type id that contains a 8- or 16-bit int or
+  // 16-bit float that is not generally enabled for use.
   bool ContainsLimitedUseIntOrFloatType(uint32_t id) const;
 
   // Gets value from OpConstant and OpSpecConstant as uint64.

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -573,8 +573,9 @@ class ValidationState_t {
   // of |width| bits.
   bool ContainsSizedIntOrFloatType(uint32_t id, SpvOp type,
                                    uint32_t width) const;
-  // Returns true if |id| contains a 8- or 16-bit int or 16-bit float.
-  bool ContainsSmallIntOrFloatType(uint32_t id) const;
+  // Returns true if |id| contains a 8- or 16-bit int or 16-bit float that is
+  // not generally enabled for use.
+  bool ContainsLimitedUseIntOrFloatType(uint32_t id) const;
 
   // Gets value from OpConstant and OpSpecConstant as uint64.
   // Returns false on failure (no instruction, wrong instruction, not int).

--- a/test/val/val_constants_test.cpp
+++ b/test/val/val_constants_test.cpp
@@ -22,14 +22,17 @@
 
 #include "gmock/gmock.h"
 #include "test/unit_spirv.h"
+#include "test/val/val_code_generator.h"
 #include "test/val/val_fixtures.h"
 
 namespace spvtools {
 namespace val {
 namespace {
 
+using ::testing::Combine;
 using ::testing::Eq;
 using ::testing::HasSubstr;
+using ::testing::Values;
 using ::testing::ValuesIn;
 
 using ValidateConstant = spvtest::ValidateBase<bool>;
@@ -366,6 +369,61 @@ OpMemoryModel Logical GLSL450
           "Prior to SPIR-V 1.4, specialization constant operation UConvert "
           "requires Kernel capability or extension SPV_AMD_gpu_shader_int16"));
 }
+
+using SmallStorageConstants = spvtest::ValidateBase<std::string>;
+
+CodeGenerator GetSmallStorageCodeGenerator() {
+  CodeGenerator generator;
+  generator.capabilities_ = R"(
+OpCapability Shader
+OpCapability Linkage
+OpCapability UniformAndStorageBuffer16BitAccess
+OpCapability StoragePushConstant16
+OpCapability StorageInputOutput16
+OpCapability UniformAndStorageBuffer8BitAccess
+OpCapability StoragePushConstant8
+)";
+  generator.extensions_ = R"(
+OpExtension "SPV_KHR_16bit_storage"
+OpExtension "SPV_KHR_8bit_storage"
+)";
+  generator.memory_model_ = "OpMemoryModel Logical GLSL450\n";
+  generator.types_ = R"(
+%short = OpTypeInt 16 0
+%short2 = OpTypeVector %short 2
+%char = OpTypeInt 8 0
+%char2 = OpTypeVector %char 2
+%half = OpTypeFloat 16
+%half2 = OpTypeVector %half 2
+%int = OpTypeInt 32 0
+%int_0 = OpConstant %int 0
+%float = OpTypeFloat 32
+%float_0 = OpConstant %float 0
+)";
+  return generator;
+}
+
+TEST_P(SmallStorageConstants, SmallConstant) {
+  std::string constant = GetParam();
+  CodeGenerator generator = GetSmallStorageCodeGenerator();
+  generator.after_types_ += constant + "\n";
+  CompileSuccessfully(generator.Build(), SPV_ENV_UNIVERSAL_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Cannot form constants of 8- or 16-bit types"));
+}
+
+// Constant composites would be caught through scalar constants.
+INSTANTIATE_TEST_SUITE_P(
+    SmallConstants, SmallStorageConstants,
+    Values("%c = OpConstant %char 0", "%c = OpConstantNull %char2",
+           "%c = OpConstant %short 0", "%c = OpConstantNull %short",
+           "%c = OpConstant %half 0", "%c = OpConstantNull %half",
+           "%c = OpSpecConstant %char 0", "%c = OpSpecConstant %short 0",
+           "%c = OpSpecConstant %half 0",
+           "%c = OpSpecConstantOp %char SConvert %int_0",
+           "%c = OpSpecConstantOp %short SConvert %int_0",
+           "%c = OpSpecConstantOp %half FConvert %float_0"));
 
 }  // namespace
 }  // namespace val

--- a/test/val/val_constants_test.cpp
+++ b/test/val/val_constants_test.cpp
@@ -425,6 +425,23 @@ INSTANTIATE_TEST_SUITE_P(
            "%c = OpSpecConstantOp %short SConvert %int_0",
            "%c = OpSpecConstantOp %half FConvert %float_0"));
 
+TEST_F(ValidateConstant, NullPointerTo16BitStorageOk) {
+  std::string spirv = R"(
+OpCapability Shader
+OpCapability VariablePointersStorageBuffer
+OpCapability UniformAndStorageBuffer16BitAccess
+OpCapability Linkage
+OpExtension "SPV_KHR_16bit_storage"
+OpMemoryModel Logical GLSL450
+%half = OpTypeFloat 16
+%ptr_ssbo_half = OpTypePointer StorageBuffer %half
+%null_ptr = OpConstantNull %ptr_ssbo_half
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -717,8 +717,7 @@ OpTypeForwardPointer %_ptr_Generic_struct_A Generic
 }
 
 TEST_F(ValidateData, ext_16bit_storage_caps_allow_free_fp_rounding_mode) {
-  for (const char* cap : {"StorageUniform16", "StorageUniformBufferBlock16",
-                          "StoragePushConstant16", "StorageInputOutput16"}) {
+  for (const char* cap : {"StorageUniform16", "StorageUniformBufferBlock16"}) {
     for (const char* mode : {"RTE", "RTZ", "RTP", "RTN"}) {
       std::string str = std::string(R"(
         OpCapability Shader

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -4554,41 +4554,6 @@ OpFunctionEnd
                 "pointer to a 16-bit floating-point scalar or vector object."));
 }
 
-TEST_F(ValidateDecorations, FPRoundingModeBadStorageClass) {
-  std::string spirv = R"(
-OpCapability Shader
-OpCapability Linkage
-OpCapability StorageBuffer16BitAccess
-OpExtension "SPV_KHR_storage_buffer_storage_class"
-OpExtension "SPV_KHR_variable_pointers"
-OpExtension "SPV_KHR_16bit_storage"
-OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %main "main"
-OpDecorate %_ FPRoundingMode RTE
-%half = OpTypeFloat 16
-%float = OpTypeFloat 32
-%float_1_25 = OpConstant %float 1.25
-%half_ptr = OpTypePointer Private %half
-%half_ptr_var = OpVariable %half_ptr Private
-%void = OpTypeVoid
-%func = OpTypeFunction %void
-%main = OpFunction %void None %func
-%main_entry = OpLabel
-%_ = OpFConvert %half %float_1_25
-OpStore %half_ptr_var %_
-OpReturn
-OpFunctionEnd
-  )";
-
-  CompileSuccessfully(spirv);
-  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("FPRoundingMode decoration can be applied only to the "
-                        "Object operand of an OpStore in the StorageBuffer, "
-                        "PhysicalStorageBufferEXT, Uniform, "
-                        "PushConstant, Input, or Output Storage Classes."));
-}
-
 TEST_F(ValidateDecorations, FPRoundingModeMultipleOpStoreGood) {
   std::string spirv = R"(
 OpCapability Shader

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -4155,8 +4155,9 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Cannot copy memory of objects containing 8- or 16-bit types"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Cannot copy memory of objects containing 8- or 16-bit types"));
 }
 
 TEST_F(ValidateMemory, SmallStorageCopyMemoryShort) {
@@ -4186,8 +4187,9 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Cannot copy memory of objects containing 8- or 16-bit types"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Cannot copy memory of objects containing 8- or 16-bit types"));
 }
 
 TEST_F(ValidateMemory, SmallStorageCopyMemoryHalf) {
@@ -4217,8 +4219,9 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Cannot copy memory of objects containing 8- or 16-bit types"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Cannot copy memory of objects containing 8- or 16-bit types"));
 }
 
 TEST_F(ValidateMemory, SmallStorageVariableArrayBufferBlockShort) {

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -4128,6 +4128,99 @@ INSTANTIATE_TEST_SUITE_P(LoadStoreFloat16, ValidateSizedLoadStore,
                                  Values("scalar", "vector", "matrix",
                                         "struct")));
 
+TEST_F(ValidateMemory, SmallStorageCopyMemoryChar) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpCapability UniformAndStorageBuffer8BitAccess
+OpExtension "SPV_KHR_8bit_storage"
+OpMemoryModel Logical GLSL450
+OpDecorate %block Block
+OpMemberDecorate %block 0 Offset 0
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%int_0 = OpConstant %int 0
+%char = OpTypeInt 8 0
+%block = OpTypeStruct %char
+%ptr_ssbo_block = OpTypePointer StorageBuffer %block
+%in = OpVariable %ptr_ssbo_block StorageBuffer
+%out = OpVariable %ptr_ssbo_block StorageBuffer
+%void_fn = OpTypeFunction %void
+%func = OpFunction %void None %void_fn
+%entry = OpLabel
+OpCopyMemory %out %in
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Cannot copy memory of objects containing 8- or 16-bit types"));
+}
+
+TEST_F(ValidateMemory, SmallStorageCopyMemoryShort) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpCapability UniformAndStorageBuffer16BitAccess
+OpExtension "SPV_KHR_16bit_storage"
+OpMemoryModel Logical GLSL450
+OpDecorate %block Block
+OpMemberDecorate %block 0 Offset 0
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%int_0 = OpConstant %int 0
+%short = OpTypeInt 16 0
+%block = OpTypeStruct %short
+%ptr_ssbo_block = OpTypePointer StorageBuffer %block
+%in = OpVariable %ptr_ssbo_block StorageBuffer
+%out = OpVariable %ptr_ssbo_block StorageBuffer
+%void_fn = OpTypeFunction %void
+%func = OpFunction %void None %void_fn
+%entry = OpLabel
+OpCopyMemory %out %in
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Cannot copy memory of objects containing 8- or 16-bit types"));
+}
+
+TEST_F(ValidateMemory, SmallStorageCopyMemoryHalf) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpCapability UniformAndStorageBuffer16BitAccess
+OpExtension "SPV_KHR_16bit_storage"
+OpMemoryModel Logical GLSL450
+OpDecorate %block Block
+OpMemberDecorate %block 0 Offset 0
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%int_0 = OpConstant %int 0
+%half = OpTypeFloat 16
+%block = OpTypeStruct %half
+%ptr_ssbo_block = OpTypePointer StorageBuffer %block
+%in = OpVariable %ptr_ssbo_block StorageBuffer
+%out = OpVariable %ptr_ssbo_block StorageBuffer
+%void_fn = OpTypeFunction %void
+%func = OpFunction %void None %void_fn
+%entry = OpLabel
+OpCopyMemory %out %in
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Cannot copy memory of objects containing 8- or 16-bit types"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -4221,6 +4221,75 @@ OpFunctionEnd
               HasSubstr("Cannot copy memory of objects containing 8- or 16-bit types"));
 }
 
+TEST_F(ValidateMemory, SmallStorageVariableArrayBufferBlockShort) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpCapability StorageBuffer16BitAccess
+OpExtension "SPV_KHR_16bit_storage"
+OpMemoryModel Logical GLSL450
+OpDecorate %block BufferBlock
+OpMemberDecorate %block 0 Offset 0
+%void = OpTypeVoid
+%short = OpTypeInt 16 0
+%int = OpTypeInt 32 0
+%int_4 = OpConstant %int 4
+%block = OpTypeStruct %short
+%block_array = OpTypeArray %block %int_4
+%ptr_block_array = OpTypePointer Uniform %block_array
+%var = OpVariable %ptr_block_array Uniform
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
+}
+
+TEST_F(ValidateMemory, SmallStorageVariableArrayBufferBlockChar) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpCapability StorageBuffer8BitAccess
+OpExtension "SPV_KHR_8bit_storage"
+OpMemoryModel Logical GLSL450
+OpDecorate %block BufferBlock
+OpMemberDecorate %block 0 Offset 0
+%void = OpTypeVoid
+%char = OpTypeInt 8 0
+%int = OpTypeInt 32 0
+%int_4 = OpConstant %int 4
+%block = OpTypeStruct %char
+%block_array = OpTypeArray %block %int_4
+%ptr_block_array = OpTypePointer Uniform %block_array
+%var = OpVariable %ptr_block_array Uniform
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
+}
+
+TEST_F(ValidateMemory, SmallStorageVariableArrayBufferBlockHalf) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpCapability StorageBuffer16BitAccess
+OpExtension "SPV_KHR_16bit_storage"
+OpMemoryModel Logical GLSL450
+OpDecorate %block BufferBlock
+OpMemberDecorate %block 0 Offset 0
+%void = OpTypeVoid
+%half = OpTypeFloat 16
+%int = OpTypeInt 32 0
+%int_4 = OpConstant %int 4
+%block = OpTypeStruct %half
+%block_array = OpTypeArray %block %int_4
+%ptr_block_array = OpTypePointer Uniform %block_array
+%var = OpVariable %ptr_block_array Uniform
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
Fixes #2669 

* Validates use cases for 8- and 16-bit types when only storage capabilities are present
  * OpVariable - specific capability check for storage class
  * OpLoad - only scalar vector and matrix (and pointers)
  * OpStore - only scalar vector and matrix (and pointers)
  * Conversions - width-only conversions
  * Constants - only pointer null
  * Composites - none
* Unified some conversions tests to cover more cases
* Some new helper functions in ValidationState_t to identify the right types and use cases