### PR TITLE
Add SPIRV-Opt pass to isolate OpFunctionCall instructions

### DIFF
--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -246,6 +246,12 @@ Optimizer::PassToken CreateEliminateDeadFunctionsPass();
 // This will not affect the data layout of the remaining members.
 Optimizer::PassToken CreateEliminateDeadMembersPass();
 
+// Creates an isolate-function-calls pass.
+// An isolate-function-calls pass will split blocks containing function calls
+// on both sides of the call operation. This allows inliner performance to be
+// less sensitive to the size of the surrounding code.
+Optimizer::PassToken CreateIsolateFunctionCallsPass();
+
 // Creates a set-spec-constant-default-value pass from a mapping from spec-ids
 // to the default values in the form of string.
 // A set-spec-constant-default-value pass sets the default values for the

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -60,6 +60,7 @@ set(SPIRV_TOOLS_OPT_SOURCES
   ir_builder.h
   ir_context.h
   ir_loader.h
+  isolate_function_calls_pass.h
   licm_pass.h
   local_access_chain_convert_pass.h
   local_redundancy_elimination.h
@@ -160,6 +161,7 @@ set(SPIRV_TOOLS_OPT_SOURCES
   instrument_pass.cpp
   ir_context.cpp
   ir_loader.cpp
+  isolate_function_calls_pass.cpp
   legalize_vector_shuffle_pass.cpp
   licm_pass.cpp
   local_access_chain_convert_pass.cpp

--- a/source/opt/isolate_function_calls_pass.cpp
+++ b/source/opt/isolate_function_calls_pass.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/opt/isolate_function_calls_pass.h"
+
+#include <vector>
+#include <cstdio>
+
+#include "source/opt/ir_context.h"
+#include "source/opt/iterator.h"
+
+namespace spvtools {
+namespace opt {
+
+bool IsolateFunctionCallsPass::IsolateCalls(Function* func) {
+  bool modified = false;
+  for (auto bi = func->begin(); bi != func->end(); bi++) {
+    for (auto ii = bi->begin(); ii != bi->end(); ++ii) {
+      if (ii->opcode() != SpvOp::SpvOpFunctionCall) continue;
+
+      modified = true;
+
+      // Grab the block index in the function
+      auto blockIndex = bi - func->begin();
+
+      uint32_t postCallBlockId = context()->TakeNextId();
+      uint32_t callBlockId = context()->TakeNextId();
+      auto nextInst = ii; ++nextInst;
+
+      BasicBlock *block = &*bi;
+      /*BasicBlock *postCallBlock = */ block->SplitBasicBlock(context(), postCallBlockId, nextInst);
+      BasicBlock *callBlock = block->SplitBasicBlock(context(), callBlockId, ii);
+
+      // Add branch from call block to post-call block
+      std::unique_ptr<Instruction> postCallBranch(
+              new Instruction(context(), SpvOpBranch, 0, 0,
+                  {{spv_operand_type_t::SPV_OPERAND_TYPE_ID, {postCallBlockId}}}));
+      callBlock->AddInstruction(std::move(postCallBranch));
+
+      // Add branch from pre-call block to call block
+      std::unique_ptr<Instruction> callBranch(
+              new Instruction(context(), SpvOpBranch, 0, 0,
+                  {{spv_operand_type_t::SPV_OPERAND_TYPE_ID, {callBlockId}}}));
+      block->AddInstruction(std::move(callBranch));
+
+      // Insertion may have invalidated bi, reconstruct it.
+      bi = func->begin() + blockIndex;
+      bi++; // skip over the call block
+      break;
+    }
+  }
+  return modified;
+}
+
+Pass::Status IsolateFunctionCallsPass::Process() {
+  // Process all entry point functions.
+  bool anyModified = false;
+  ProcessFunction pfn = [&anyModified, this](Function* fp) { anyModified |= IsolateCalls(fp); return false; };
+  context()->ProcessEntryPointCallTree(pfn);
+  return anyModified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
+}
+
+IsolateFunctionCallsPass::IsolateFunctionCallsPass() = default;
+
+}  // namespace opt
+}  // namespace spvtools

--- a/source/opt/isolate_function_calls_pass.h
+++ b/source/opt/isolate_function_calls_pass.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_OPT_ISOLATE_FUNCTION_CALLS_PASS_H_
+#define SOURCE_OPT_ISOLATE_FUNCTION_CALLS_PASS_H_
+
+#include <algorithm>
+#include <map>
+#include <queue>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+#include "source/opt/basic_block.h"
+#include "source/opt/def_use_manager.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/module.h"
+#include "source/opt/pass.h"
+
+namespace spvtools {
+namespace opt {
+
+// See optimizer.hpp for documentation.
+class IsolateFunctionCallsPass : public Pass {
+ public:
+  IsolateFunctionCallsPass();
+  const char* name() const override { return "isolate-function-calls"; }
+  Status Process() override;
+
+  IRContext::Analysis GetPreservedAnalyses() override {
+    return IRContext::kAnalysisInstrToBlockMapping |
+           IRContext::kAnalysisDecorations | IRContext::kAnalysisCombinators |
+           IRContext::kAnalysisNameMap | IRContext::kAnalysisConstants |
+           IRContext::kAnalysisTypes;
+  }
+
+ private:
+  bool IsolateCalls(Function *func);
+};
+
+}  // namespace opt
+}  // namespace spvtools
+
+#endif  // SOURCE_OPT_ISOLATE_FUNCTION_CALLS_PASS_H_

--- a/source/opt/iterator.h
+++ b/source/opt/iterator.h
@@ -72,6 +72,7 @@ class UptrVectorIterator
 
   inline ptrdiff_t operator-(const UptrVectorIterator& that) const;
   inline bool operator<(const UptrVectorIterator& that) const;
+  inline UptrVectorIterator operator+(ptrdiff_t offset) const { return UptrVectorIterator(container_, iterator_ + offset); }
 
   // Inserts the given |value| to the position pointed to by this iterator
   // and returns an iterator to the newly iserted |value|.

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -646,6 +646,11 @@ Optimizer::PassToken CreateStrengthReductionPass() {
       MakeUnique<opt::StrengthReductionPass>());
 }
 
+Optimizer::PassToken CreateIsolateFunctionCallsPass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::IsolateFunctionCallsPass>());
+}
+
 Optimizer::PassToken CreateBlockMergePass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::BlockMergePass>());

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -42,6 +42,7 @@
 #include "source/opt/inline_exhaustive_pass.h"
 #include "source/opt/inline_opaque_pass.h"
 #include "source/opt/inst_bindless_check_pass.h"
+#include "source/opt/isolate_function_calls_pass.h"
 #include "source/opt/legalize_vector_shuffle_pass.h"
 #include "source/opt/licm_pass.h"
 #include "source/opt/local_access_chain_convert_pass.h"


### PR DESCRIPTION
When a callee is large and contains many function calls, the inliner spends
a significant amount of time repeatedly walking the instructions looking
for inlining opportunities. This accounts for approx 10% of my profile
in dEQP-VK.ubo.random.all_shared_buffer.48 [which has 2 shaders, each of
which contains about 2K inlining opportunities] run on Swiftshader.

By splitting the callee block on either side of the call instruction, we
ensure that there is no large body of non-call instructions to repeatedly consider.
The resulting branches can be cleaned up by a later block merging pass.

Change-Id: Ib8c1420ac452aa591496f6bfedf8cc2ba7bc7416