### PR TITLE
Shrinker for spirv-fuzz

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -607,6 +607,11 @@ SPIRV_TOOLS_EXPORT void spvFuzzerOptionsDestroy(spv_fuzzer_options options);
 SPIRV_TOOLS_EXPORT void spvFuzzerOptionsSetRandomSeed(
     spv_fuzzer_options options, uint32_t seed);
 
+// Sets the maximum number of steps that the shrinker should take before giving
+// up.
+SPIRV_TOOLS_EXPORT void spvFuzzerOptionsSetShrinkerStepLimit(
+    spv_fuzzer_options options, uint32_t shrinker_step_limit);
+
 // Encodes the given SPIR-V assembly text to its binary representation. The
 // length parameter specifies the number of bytes for text. Encoded binary will
 // be stored into *binary. Any error will be written into *diagnostic if

--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -207,6 +207,11 @@ class FuzzerOptions {
     spvFuzzerOptionsSetRandomSeed(options_, seed);
   }
 
+  // See spvFuzzerOptionsSetShrinkerStepLimit.
+  void set_shrinker_step_limit(uint32_t shrinker_step_limit) {
+    spvFuzzerOptionsSetShrinkerStepLimit(options_, shrinker_step_limit);
+  }
+
  private:
   spv_fuzzer_options options_;
 };

--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -41,6 +41,7 @@ if(SPIRV_BUILD_FUZZER)
         pseudo_random_generator.h
         random_generator.h
         replayer.h
+        shrinker.h
         transformation.h
         transformation_add_constant_boolean.h
         transformation_add_constant_scalar.h
@@ -70,6 +71,7 @@ if(SPIRV_BUILD_FUZZER)
         pseudo_random_generator.cpp
         random_generator.cpp
         replayer.cpp
+        shrinker.cpp
         transformation.cpp
         transformation_add_constant_boolean.cpp
         transformation_add_constant_scalar.cpp

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -55,14 +55,15 @@ void Fuzzer::SetMessageConsumer(MessageConsumer c) {
 Fuzzer::FuzzerResultStatus Fuzzer::Run(
     const std::vector<uint32_t>& binary_in,
     const protobufs::FactSequence& initial_facts,
+    spv_const_fuzzer_options options,
     std::vector<uint32_t>* binary_out,
-    protobufs::TransformationSequence* transformation_sequence_out,
-    spv_const_fuzzer_options options) const {
+    protobufs::TransformationSequence* transformation_sequence_out) const {
   // Check compatibility between the library version being linked with and the
   // header files being used.
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
   spvtools::SpirvTools tools(impl_->target_env);
+  tools.SetMessageConsumer(impl_->consumer);
   if (!tools.IsValid()) {
     impl_->consumer(SPV_MSG_ERROR, nullptr, {},
                     "Failed to create SPIRV-Tools interface; stopping.");

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -55,8 +55,7 @@ void Fuzzer::SetMessageConsumer(MessageConsumer c) {
 Fuzzer::FuzzerResultStatus Fuzzer::Run(
     const std::vector<uint32_t>& binary_in,
     const protobufs::FactSequence& initial_facts,
-    spv_const_fuzzer_options options,
-    std::vector<uint32_t>* binary_out,
+    spv_const_fuzzer_options options, std::vector<uint32_t>* binary_out,
     protobufs::TransformationSequence* transformation_sequence_out) const {
   // Check compatibility between the library version being linked with and the
   // header files being used.

--- a/source/fuzz/fuzzer.h
+++ b/source/fuzz/fuzzer.h
@@ -58,8 +58,7 @@ class Fuzzer {
   FuzzerResultStatus Run(
       const std::vector<uint32_t>& binary_in,
       const protobufs::FactSequence& initial_facts,
-      spv_const_fuzzer_options options,
-      std::vector<uint32_t>* binary_out,
+      spv_const_fuzzer_options options, std::vector<uint32_t>* binary_out,
       protobufs::TransformationSequence* transformation_sequence_out) const;
 
  private:

--- a/source/fuzz/shrinker.cpp
+++ b/source/fuzz/shrinker.cpp
@@ -14,6 +14,8 @@
 
 #include "source/fuzz/shrinker.h"
 
+#include <sstream>
+
 #include "source/fuzz/pseudo_random_generator.h"
 #include "source/fuzz/replayer.h"
 #include "source/spirv_fuzzer_options.h"
@@ -22,14 +24,53 @@
 namespace spvtools {
 namespace fuzz {
 
+namespace {
+
+// A helper to get the size of a protobuf transformation sequence in a less
+// verbose manner.
+uint32_t NumRemainingTransformations(
+    const protobufs::TransformationSequence& transformation_sequence) {
+  return static_cast<uint32_t>(transformation_sequence.transformation_size());
+}
+
+// A helper to return a transformation sequence identical to |transformations|,
+// except that a chunk of size |granularity| starting from
+// (|transformations.size| - |index + 1| x |granularity|) is removed.
+protobufs::TransformationSequence RemoveChunk(
+    const protobufs::TransformationSequence& transformations, uint32_t index,
+    uint32_t granularity) {
+  uint32_t lower = static_cast<uint32_t>(std::max(
+      0, static_cast<int>(NumRemainingTransformations(transformations)) -
+             static_cast<int>((index + 1) * granularity)));
+  uint32_t upper =
+      NumRemainingTransformations(transformations) - index * granularity;
+  assert(lower < upper);
+  assert(upper <= NumRemainingTransformations(transformations));
+  protobufs::TransformationSequence result;
+  for (uint32_t j = 0; j < NumRemainingTransformations(transformations); j++) {
+    if (j >= lower && j < upper) {
+      continue;
+    }
+    protobufs::Transformation transformation =
+        transformations.transformation()[j];
+    *result.mutable_transformation()->Add() = transformation;
+  }
+  return result;
+}
+
+}  // namespace
+
 struct Shrinker::Impl {
-  explicit Impl(spv_target_env env) : target_env(env) {}
+  explicit Impl(spv_target_env env, uint32_t limit)
+      : target_env(env), step_limit(limit) {}
 
   const spv_target_env target_env;  // Target environment.
   MessageConsumer consumer;         // Message consumer.
+  const uint32_t step_limit;        // Step limit for reductions.
 };
 
-Shrinker::Shrinker(spv_target_env env) : impl_(MakeUnique<Impl>(env)) {}
+Shrinker::Shrinker(spv_target_env env, uint32_t step_limit)
+    : impl_(MakeUnique<Impl>(env, step_limit)) {}
 
 Shrinker::~Shrinker() = default;
 
@@ -42,7 +83,7 @@ Shrinker::ShrinkerResultStatus Shrinker::Run(
     const protobufs::FactSequence& initial_facts,
     const protobufs::TransformationSequence& transformation_sequence_in,
     const Shrinker::InterestingnessFunction& interestingness_function,
-    spv_const_fuzzer_options options, std::vector<uint32_t>* binary_out,
+    std::vector<uint32_t>* binary_out,
     protobufs::TransformationSequence* transformation_sequence_out) const {
   // Check compatibility between the library version being linked with and the
   // header files being used.
@@ -62,65 +103,119 @@ Shrinker::ShrinkerResultStatus Shrinker::Run(
     return Shrinker::ShrinkerResultStatus::kInitialBinaryInvalid;
   }
 
-  // Make a PRNG, either from a given seed or from a random device.
-  PseudoRandomGenerator random_generator(
-      options->has_random_seed ? options->random_seed
-                               : static_cast<uint32_t>(std::random_device()()));
-
-  Replayer replayer(impl_->target_env);
-
   std::vector<uint32_t> current_best_binary;
   protobufs::TransformationSequence current_best_transformations;
-  std::vector<uint32_t> next_binary;
-  protobufs::TransformationSequence next_transformation_sequence;
 
-  auto replayer_result =
-      replayer.Run(binary_in, initial_facts, transformation_sequence_in,
-                   &current_best_binary, &current_best_transformations);
-  if (replayer_result != Replayer::ReplayerResultStatus::kComplete) {
+  // Run a replay of the initial transformation sequence to (a) check that it
+  // succeeds, (b) get the binary that results from running these
+  // transformations, and (c) get the subsequence of the initial transformations
+  // that actually apply (in principle this could be a strict subsequence).
+  if (Replayer(impl_->target_env)
+          .Run(binary_in, initial_facts, transformation_sequence_in,
+               &current_best_binary, &current_best_transformations) !=
+      Replayer::ReplayerResultStatus::kComplete) {
     return ShrinkerResultStatus::kReplayFailed;
   }
 
+  // Check that the binary produced by applying the initial transformations is
+  // indeed interesting.
   if (!interestingness_function(current_best_binary, 0)) {
+    impl_->consumer(SPV_MSG_INFO, nullptr, {},
+                    "Initial binary is not interesting; stopping.");
     return ShrinkerResultStatus::kInitialBinaryNotInteresting;
   }
 
-  for (uint32_t i = 1;
-       i < 100 && !current_best_transformations.transformation().empty(); i++) {
-    std::cout << "Attempt " << i << std::endl;
-    auto skipit = random_generator.RandomUint32(static_cast<uint32_t>(
-        current_best_transformations.transformation().size()));
-    protobufs::TransformationSequence candidate_sequence;
-    candidate_sequence.clear_transformation();
-    std::cout << "Remaining: "
-              << current_best_transformations.transformation().size()
-              << std::endl;
-    for (uint32_t j = 0;
-         j < static_cast<uint32_t>(
-                 current_best_transformations.transformation().size());
-         j++) {
-      if (j == skipit) {
-        continue;
+  uint32_t attempt = 0;  // Keeps track of the number of shrink attempts that
+                         // have been tried, whether successful or not.
+
+  uint32_t granularity =
+      std::max(1u, NumRemainingTransformations(current_best_transformations) /
+                       2);  // The number of contiguous transformations that the
+                            // shrinker will try to remove in one go; starts
+                            // high and decreases during the shrinking process.
+
+  // Keep shrinking until we:
+  // - reach the step limit,
+  // - run out of transformations to remove, or
+  // - cannot make the granularity of shrinking any finer.
+  while (attempt < impl_->step_limit &&
+         !current_best_transformations.transformation().empty() &&
+         granularity > 0) {
+    bool progress_this_round =
+        false;  // Used to decide whether to make the granularity with which we
+                // remove transformations finer.  If we managed to remove at
+                // least one chunk of transformations at a particular
+                // granularity, we set this flag so that we do not yet decrease
+                // granularity.
+
+    // We go through the transformations in reverse, in chunks of size
+    // |granularity|. This is encoded here via an index, |index|, recording how
+    // many chunks of size |granularity| have been tried. The loop exits early
+    // if we reach the shrinking step limit.
+    for (uint32_t index = 0;
+         attempt < impl_->step_limit &&
+         index * granularity <
+             NumRemainingTransformations(current_best_transformations);) {
+      // Remove a chunk of transformations according to the current index and
+      // granularity.
+      auto transformations_with_chunk_removed =
+          RemoveChunk(current_best_transformations, index, granularity);
+
+      // Replay the smaller sequence of transformations to get a next binary and
+      // transformation sequence. Note that the transformations arising from
+      // replay might be even smaller than the transformations with the chunk
+      // removed, because removing those transformaitons might make further
+      // transformations inapplicable.
+      std::vector<uint32_t> next_binary;
+      protobufs::TransformationSequence next_transformation_sequence;
+      if (Replayer(impl_->target_env)
+              .Run(binary_in, initial_facts, transformations_with_chunk_removed,
+                   &next_binary, &next_transformation_sequence) !=
+          Replayer::ReplayerResultStatus::kComplete) {
+        // Replay should not fail; if it does, we need to abort shrinking.
+        return ShrinkerResultStatus::kReplayFailed;
       }
-      protobufs::Transformation transformation =
-          current_best_transformations.transformation()[j];
-      *candidate_sequence.mutable_transformation()->Add() = transformation;
+
+      if (interestingness_function(next_binary, attempt)) {
+        // If the binary arising from the smaller transformation sequence is
+        // interesting, this becomes our current best binary and transformation
+        // sequence.
+        current_best_binary = next_binary;
+        current_best_transformations = next_transformation_sequence;
+        progress_this_round = true;
+      } else {
+        // Otherwise, increase index so that we try another chunk.  Note that we
+        // only increase index when the binary was not interesting because
+        // otherwise removal of the chunk means that the current index refers to
+        // a fresh chunk to be considered.
+        index++;
+      }
+      // Either way, this was a shrink attempt, so increment our count of shrink
+      // attempts.
+      attempt++;
     }
-    next_transformation_sequence.clear_transformation();
-    next_binary.clear();
-    replayer_result = replayer.Run(binary_in, initial_facts, candidate_sequence,
-                                   &next_binary, &next_transformation_sequence);
-    if (replayer_result != Replayer::ReplayerResultStatus::kComplete) {
-      return ShrinkerResultStatus::kReplayFailed;
-    }
-    if (interestingness_function(next_binary, i)) {
-      std::cout << "Interesting!" << std::endl;
-      current_best_binary = next_binary;
-      current_best_transformations.CopyFrom(next_transformation_sequence);
+    if (!progress_this_round) {
+      // If we didn't manage to remove any chunks at this granularity, try a
+      // smaller granularity.
+      granularity = granularity / 2;
     }
   }
+
+  // The output from the shrinker is the best binary we saw, and the
+  // transformations that led to it.
   *binary_out = current_best_binary;
   *transformation_sequence_out = current_best_transformations;
+
+  // Indicate whether shrinking completed or was truncated due to reaching the
+  // step limit.
+  assert(attempt <= impl_->step_limit);
+  if (attempt == impl_->step_limit) {
+    std::stringstream strstream;
+    strstream << "Shrinking did not complete; step limit " << impl_->step_limit
+              << " was reached.";
+    impl_->consumer(SPV_MSG_WARNING, nullptr, {}, strstream.str().c_str());
+    return Shrinker::ShrinkerResultStatus::kStepLimitReached;
+  }
   return Shrinker::ShrinkerResultStatus::kComplete;
 }
 

--- a/source/fuzz/shrinker.cpp
+++ b/source/fuzz/shrinker.cpp
@@ -1,0 +1,119 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/shrinker.h"
+
+#include "source/fuzz/pseudo_random_generator.h"
+#include "source/fuzz/replayer.h"
+#include "source/spirv_fuzzer_options.h"
+#include "source/util/make_unique.h"
+
+namespace spvtools {
+namespace fuzz {
+
+struct Shrinker::Impl {
+  explicit Impl(spv_target_env env) : target_env(env) {}
+
+  const spv_target_env target_env;  // Target environment.
+  MessageConsumer consumer;         // Message consumer.
+};
+
+Shrinker::Shrinker(spv_target_env env) : impl_(MakeUnique<Impl>(env)) {}
+
+Shrinker::~Shrinker() = default;
+
+void Shrinker::SetMessageConsumer(MessageConsumer c) {
+  impl_->consumer = std::move(c);
+}
+
+Shrinker::ShrinkerResultStatus Shrinker::Run(
+        const std::vector<uint32_t>& binary_in,
+        const protobufs::FactSequence& initial_facts,
+        const protobufs::TransformationSequence& transformation_sequence_in,
+        const Shrinker::InterestingnessFunction& interestingness_function,
+        spv_const_fuzzer_options options,
+        std::vector<uint32_t>* binary_out,
+        protobufs::TransformationSequence* transformation_sequence_out) const {
+  // Check compatibility between the library version being linked with and the
+  // header files being used.
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  spvtools::SpirvTools tools(impl_->target_env);
+  if (!tools.IsValid()) {
+    impl_->consumer(SPV_MSG_ERROR, nullptr, {},
+                    "Failed to create SPIRV-Tools interface; stopping.");
+    return Shrinker::ShrinkerResultStatus::kFailedToCreateSpirvToolsInterface;
+  }
+
+  // Initial binary should be valid.
+  if (!tools.Validate(&binary_in[0], binary_in.size())) {
+    impl_->consumer(SPV_MSG_INFO, nullptr, {},
+                    "Initial binary is invalid; stopping.");
+    return Shrinker::ShrinkerResultStatus::kInitialBinaryInvalid;
+  }
+
+  // Make a PRNG, either from a given seed or from a random device.
+  PseudoRandomGenerator random_generator(
+          options->has_random_seed ? options->random_seed
+                                   : static_cast<uint32_t>(std::random_device()()));
+
+  Replayer replayer(impl_->target_env);
+
+  std::vector<uint32_t> current_best_binary;
+  protobufs::TransformationSequence current_best_transformations;
+  std::vector<uint32_t> next_binary;
+  protobufs::TransformationSequence next_transformation_sequence;
+
+  auto replayer_result = replayer.Run(binary_in, initial_facts, transformation_sequence_in,
+          &current_best_binary, &current_best_transformations);
+  if (replayer_result != Replayer::ReplayerResultStatus::kComplete) {
+    return ShrinkerResultStatus::kReplayFailed;
+  }
+
+  if (!interestingness_function(current_best_binary, 0)) {
+    return ShrinkerResultStatus::kInitialBinaryNotInteresting;
+  }
+
+  for (uint32_t i = 1; i < 100 && !current_best_transformations.transformation().empty(); i++) {
+    std::cout << "Attempt " << i << std::endl;
+    auto skipit = random_generator.RandomUint32(static_cast<uint32_t>(current_best_transformations.transformation().size()));
+    protobufs::TransformationSequence candidate_sequence;
+    candidate_sequence.clear_transformation();
+    std::cout << "Remaining: " << current_best_transformations.transformation().size() << std::endl;
+    for (uint32_t j = 0; j < static_cast<uint32_t>(current_best_transformations.transformation().size()); j++) {
+      if (j == skipit) {
+        continue;
+      }
+      protobufs::Transformation transformation = current_best_transformations.transformation()[j];
+      *candidate_sequence.mutable_transformation()->Add() = transformation;
+    }
+    next_transformation_sequence.clear_transformation();
+    next_binary.clear();
+    replayer_result = replayer.Run(binary_in, initial_facts, candidate_sequence, &next_binary, &next_transformation_sequence);
+    if (replayer_result != Replayer::ReplayerResultStatus::kComplete) {
+      return ShrinkerResultStatus::kReplayFailed;
+    }
+    if (interestingness_function(next_binary, i)) {
+      std::cout << "Interesting!" << std::endl;
+      current_best_binary = next_binary;
+      current_best_transformations.CopyFrom(next_transformation_sequence);
+    }
+  }
+  *binary_out = current_best_binary;
+  *transformation_sequence_out = current_best_transformations;
+  return Shrinker::ShrinkerResultStatus::kComplete;
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/shrinker.h
+++ b/source/fuzz/shrinker.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SOURCE_FUZZ_FUZZER_H_
-#define SOURCE_FUZZ_FUZZER_H_
+#ifndef SOURCE_FUZZ_SHRINKER_H_
+#define SOURCE_FUZZ_SHRINKER_H_
 
 #include <memory>
 #include <vector>
@@ -24,40 +24,50 @@
 namespace spvtools {
 namespace fuzz {
 
-// Transforms a SPIR-V module into a semantically equivalent SPIR-V module by
-// running a number of randomized fuzzer passes.
-class Fuzzer {
+// TODO
+class Shrinker {
  public:
-  // Possible statuses that can result from running the fuzzer.
-  enum class FuzzerResultStatus {
+  // Possible statuses that can result from running the shrinker.
+  // TODO: maybe add step limit reached.
+  enum ShrinkerResultStatus {
     kComplete,
     kFailedToCreateSpirvToolsInterface,
     kInitialBinaryInvalid,
+    kInitialBinaryNotInteresting,
+    kReplayFailed,
   };
 
-  // Constructs a fuzzer from the given target environment.
-  explicit Fuzzer(spv_target_env env);
+  // The type for a function that will take a binary and return true if and
+  // only if the binary is deemed interesting. (The function also takes an
+  // integer argument that will be incremented each time the function is
+  // called; this is for debugging purposes).
+  //
+  // The notion of "interesting" depends on what properties of the binary or
+  // tools that process the binary we are trying to maintain during shrinking.
+  using InterestingnessFunction =
+  std::function<bool(const std::vector<uint32_t>&, uint32_t)>;
+
+  // Constructs a shrinker from the given target environment.
+  explicit Shrinker(spv_target_env env);
 
   // Disables copy/move constructor/assignment operations.
-  Fuzzer(const Fuzzer&) = delete;
-  Fuzzer(Fuzzer&&) = delete;
-  Fuzzer& operator=(const Fuzzer&) = delete;
-  Fuzzer& operator=(Fuzzer&&) = delete;
+  Shrinker(const Shrinker&) = delete;
+  Shrinker(Shrinker&&) = delete;
+  Shrinker& operator=(const Shrinker&) = delete;
+  Shrinker& operator=(Shrinker&&) = delete;
 
-  ~Fuzzer();
+  ~Shrinker();
 
   // Sets the message consumer to the given |consumer|. The |consumer| will be
   // invoked once for each message communicated from the library.
   void SetMessageConsumer(MessageConsumer consumer);
 
-  // Transforms |binary_in| to |binary_out| by running a number of randomized
-  // fuzzer passes, controlled via |options|.  Initial facts about the input
-  // binary and the context in which it will execute are provided via
-  // |initial_facts|.  The transformation sequence that was applied is returned
-  // via |transformation_sequence_out|.
-  FuzzerResultStatus Run(
+  // TODO
+  ShrinkerResultStatus Run(
       const std::vector<uint32_t>& binary_in,
       const protobufs::FactSequence& initial_facts,
+      const protobufs::TransformationSequence& transformation_sequence_in,
+      const InterestingnessFunction& interestingness_function,
       spv_const_fuzzer_options options,
       std::vector<uint32_t>* binary_out,
       protobufs::TransformationSequence* transformation_sequence_out) const;
@@ -70,4 +80,4 @@ class Fuzzer {
 }  // namespace fuzz
 }  // namespace spvtools
 
-#endif  // SOURCE_FUZZ_FUZZER_H_
+#endif  // SOURCE_FUZZ_SHRINKER_H_

--- a/source/fuzz/shrinker.h
+++ b/source/fuzz/shrinker.h
@@ -45,7 +45,7 @@ class Shrinker {
   // The notion of "interesting" depends on what properties of the binary or
   // tools that process the binary we are trying to maintain during shrinking.
   using InterestingnessFunction =
-  std::function<bool(const std::vector<uint32_t>&, uint32_t)>;
+      std::function<bool(const std::vector<uint32_t>&, uint32_t)>;
 
   // Constructs a shrinker from the given target environment.
   explicit Shrinker(spv_target_env env);
@@ -68,8 +68,7 @@ class Shrinker {
       const protobufs::FactSequence& initial_facts,
       const protobufs::TransformationSequence& transformation_sequence_in,
       const InterestingnessFunction& interestingness_function,
-      spv_const_fuzzer_options options,
-      std::vector<uint32_t>* binary_out,
+      spv_const_fuzzer_options options, std::vector<uint32_t>* binary_out,
       protobufs::TransformationSequence* transformation_sequence_out) const;
 
  private:

--- a/source/spirv_fuzzer_options.cpp
+++ b/source/spirv_fuzzer_options.cpp
@@ -14,7 +14,15 @@
 
 #include "source/spirv_fuzzer_options.h"
 
-spv_fuzzer_options_t::spv_fuzzer_options_t() = default;
+namespace {
+// The default maximum number of steps for the reducer to run before giving up.
+const uint32_t kDefaultStepLimit = 250;
+}  // namespace
+
+spv_fuzzer_options_t::spv_fuzzer_options_t()
+    : has_random_seed(false),
+      random_seed(0),
+      shrinker_step_limit(kDefaultStepLimit) {}
 
 SPIRV_TOOLS_EXPORT spv_fuzzer_options spvFuzzerOptionsCreate() {
   return new spv_fuzzer_options_t();
@@ -28,4 +36,9 @@ SPIRV_TOOLS_EXPORT void spvFuzzerOptionsSetRandomSeed(
     spv_fuzzer_options options, uint32_t seed) {
   options->has_random_seed = true;
   options->random_seed = seed;
+}
+
+SPIRV_TOOLS_EXPORT void spvFuzzerOptionsSetShrinkerStepLimit(
+    spv_fuzzer_options options, uint32_t shrinker_step_limit) {
+  options->shrinker_step_limit = shrinker_step_limit;
 }

--- a/source/spirv_fuzzer_options.h
+++ b/source/spirv_fuzzer_options.h
@@ -26,8 +26,11 @@ struct spv_fuzzer_options_t {
   spv_fuzzer_options_t();
 
   // See spvFuzzerOptionsSetRandomSeed.
-  bool has_random_seed = false;
-  uint32_t random_seed = 0;
+  bool has_random_seed;
+  uint32_t random_seed;
+
+  // See spvFuzzerOptionsSetShrinkerStepLimit.
+  uint32_t shrinker_step_limit;
 };
 
 #endif  // SOURCE_SPIRV_FUZZER_OPTIONS_H_

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -18,6 +18,7 @@ if (${SPIRV_BUILD_FUZZER})
           fuzz_test_util.h
 
           fuzzer_replayer_test.cpp
+          fuzzer_shrinker_test.cpp
           fact_manager_test.cpp
           fuzz_test_util.cpp
           fuzzer_pass_add_useful_constructs_test.cpp

--- a/test/fuzz/fuzz_test_util.h
+++ b/test/fuzz/fuzz_test_util.h
@@ -59,6 +59,11 @@ const uint32_t kFuzzAssembleOption =
 const uint32_t kFuzzDisassembleOption =
     SPV_BINARY_TO_TEXT_OPTION_NO_HEADER | SPV_BINARY_TO_TEXT_OPTION_INDENT;
 
+// A silent message consumer.
+const spvtools::MessageConsumer kSilentConsumer =
+    [](spv_message_level_t, const char*, const spv_position_t&,
+       const char*) -> void {};
+
 }  // namespace fuzz
 }  // namespace spvtools
 

--- a/test/fuzz/fuzzer_replayer_test.cpp
+++ b/test/fuzz/fuzzer_replayer_test.cpp
@@ -43,9 +43,9 @@ void RunFuzzerAndReplayer(const std::string& shader,
     spvFuzzerOptionsSetRandomSeed(fuzzer_options, seed);
 
     Fuzzer fuzzer(env);
-    auto fuzzer_result_status =
-        fuzzer.Run(binary_in, initial_facts, fuzzer_options, `&fuzzer_binary_out,
-                   &fuzzer_transformation_sequence_out);
+    auto fuzzer_result_status = fuzzer.Run(binary_in, initial_facts,
+                                           fuzzer_options, `& fuzzer_binary_out,
+                                           &fuzzer_transformation_sequence_out);
     ASSERT_EQ(Fuzzer::FuzzerResultStatus::kComplete, fuzzer_result_status);
     ASSERT_TRUE(t.Validate(fuzzer_binary_out));
 

--- a/test/fuzz/fuzzer_replayer_test.cpp
+++ b/test/fuzz/fuzzer_replayer_test.cpp
@@ -44,8 +44,8 @@ void RunFuzzerAndReplayer(const std::string& shader,
 
     Fuzzer fuzzer(env);
     auto fuzzer_result_status =
-        fuzzer.Run(binary_in, initial_facts, &fuzzer_binary_out,
-                   &fuzzer_transformation_sequence_out, fuzzer_options);
+        fuzzer.Run(binary_in, initial_facts, fuzzer_options, `&fuzzer_binary_out,
+                   &fuzzer_transformation_sequence_out);
     ASSERT_EQ(Fuzzer::FuzzerResultStatus::kComplete, fuzzer_result_status);
     ASSERT_TRUE(t.Validate(fuzzer_binary_out));
 

--- a/test/fuzz/fuzzer_shrinker_test.cpp
+++ b/test/fuzz/fuzzer_shrinker_test.cpp
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <functional>
+#include <vector>
+
 #include "source/fuzz/fuzzer.h"
-#include "source/fuzz/replayer.h"
+#include "source/fuzz/pseudo_random_generator.h"
+#include "source/fuzz/shrinker.h"
 #include "source/fuzz/uniform_buffer_element_descriptor.h"
 #include "test/fuzz/fuzz_test_util.h"
 
@@ -21,12 +25,143 @@ namespace spvtools {
 namespace fuzz {
 namespace {
 
-// Assembles the given |shader| text, and then runs the fuzzer |num_runs|
-// times, using successive seeds starting from |initial_seed|.  Checks that
-// the binary produced after each fuzzer run is valid, and that replaying
-// the transformations that were applied during fuzzing leads to an
-// identical binary.
-void RunFuzzerAndReplayer(const std::string& shader,
+// Abstract class exposing an interestingness function as a virtual method.
+class InterestingnessTest {
+ public:
+  virtual ~InterestingnessTest() = default;
+
+  // Abstract method that subclasses should implement for specific notions of
+  // interestingness. Its signature matches Shrinker::InterestingnessFunction.
+  // Argument |binary| is the SPIR-V binary to be checked; |counter| is used for
+  // debugging purposes.
+  virtual bool Interesting(const std::vector<uint32_t>& binary,
+                           uint32_t counter) = 0;
+
+  // Yields the Interesting instance method wrapped in a function object.
+  Shrinker::InterestingnessFunction AsFunction() {
+    return std::bind(&InterestingnessTest::Interesting, this,
+                     std::placeholders::_1, std::placeholders::_2);
+  }
+};
+
+// A test that says all binaries are interesting.
+class AlwaysInteresting : public InterestingnessTest {
+ public:
+  bool Interesting(const std::vector<uint32_t>&, uint32_t) override {
+    return true;
+  }
+};
+
+// A test that says a binary is interesting first time round, and uninteresting
+// thereafter.
+class OnlyInterestingFirstTime : public InterestingnessTest {
+ public:
+  explicit OnlyInterestingFirstTime() : first_time_(true) {}
+
+  bool Interesting(const std::vector<uint32_t>&, uint32_t) override {
+    if (first_time_) {
+      first_time_ = false;
+      return true;
+    }
+    return false;
+  }
+
+ private:
+  bool first_time_;
+};
+
+// A test that says a binary is interesting first time round, after which
+// interestingness ping pongs between false and true.
+class PingPong : public InterestingnessTest {
+ public:
+  explicit PingPong() : interesting_(false) {}
+
+  bool Interesting(const std::vector<uint32_t>&, uint32_t) override {
+    interesting_ = !interesting_;
+    return interesting_;
+  }
+
+ private:
+  bool interesting_;
+};
+
+// A test that says a binary is interesting first time round, then randomly
+// decides whether the binary is interesting a certain number of times, then
+// says the binary is always interesting thereafter. This allows the logic of
+// the shrinker to be tested in a randomized way, but such that shrinking should
+// eventually eliminate all transformations (as long as the number of initial
+// transformations is non-trivial).
+class RandomThenAlwaysInteresting : public InterestingnessTest {
+ public:
+  explicit RandomThenAlwaysInteresting(uint32_t limit, uint32_t seed)
+      : limit_(limit), number_of_times_asked_(0), random_generator_(seed) {}
+
+  bool Interesting(const std::vector<uint32_t>&, uint32_t) override {
+    bool result;
+    if (number_of_times_asked_ == 0) {
+      result = true;
+    } else if (number_of_times_asked_ < limit_) {
+      result = random_generator_.RandomBool();
+    } else {
+      result = true;
+    }
+    number_of_times_asked_++;
+    return result;
+  }
+
+ private:
+  const uint32_t limit_;
+  uint32_t number_of_times_asked_;
+  PseudoRandomGenerator random_generator_;
+};
+
+// |binary_in| and |initial_facts| are a SPIR-V binary and sequence of facts to
+// which |transformation_sequence_in| can be applied.  Shrinking of
+// |transformation_sequence_in| gets performed with respect to
+// |interestingness_function|.  If |expected_binary_out| is non-empty, it must
+// match the binary obtained by applying the final shrunk set of
+// transformations, in which case the number of such transforations should equal
+// |expected_transformations_out_size|.
+void RunAndCheckShrinker(
+    const spv_target_env& target_env, const std::vector<uint32_t>& binary_in,
+    const protobufs::FactSequence& initial_facts,
+    const protobufs::TransformationSequence& transformation_sequence_in,
+    const Shrinker::InterestingnessFunction& interestingness_function,
+    const std::vector<uint32_t>& expected_binary_out,
+    uint32_t expected_transformations_out_size) {
+  // We want tests to complete in reasonable time, so don't go on too long.
+  const uint32_t kStepLimit = 50;
+
+  // Run the shrinker.
+  Shrinker shrinker(target_env, kStepLimit);
+  shrinker.SetMessageConsumer(kSilentConsumer);
+
+  std::vector<uint32_t> binary_out;
+  protobufs::TransformationSequence transformations_out;
+  Shrinker::ShrinkerResultStatus shrinker_result_status =
+      shrinker.Run(binary_in, initial_facts, transformation_sequence_in,
+                   interestingness_function, &binary_out, &transformations_out);
+  ASSERT_TRUE(Shrinker::ShrinkerResultStatus::kComplete ==
+                  shrinker_result_status ||
+              Shrinker::ShrinkerResultStatus::kStepLimitReached ==
+                  shrinker_result_status);
+
+  // If a non-empty expected binary was provided, check that it matches the
+  // result of shrinking and that the expected number of transformations remain.
+  if (!expected_binary_out.empty()) {
+    ASSERT_EQ(expected_binary_out, binary_out);
+    ASSERT_EQ(
+        expected_transformations_out_size,
+        static_cast<uint32_t>(transformations_out.transformation().size()));
+  }
+}
+
+// Assembles the given |shader| text, and then does the following |num_runs|
+// times, with successive seeds starting from |initial_seed|:
+// - Runs the fuzzer with the seed to yield a set of transformations
+// - Shrinks the transformation with various interestingness functions,
+//   asserting some properties about the result each time
+void RunFuzzerAndShrinker(const std::string& shader,
                           const protobufs::FactSequence& initial_facts,
                           uint32_t initial_seed, uint32_t num_runs) {
   const auto env = SPV_ENV_UNIVERSAL_1_3;
@@ -37,11 +172,11 @@ void RunFuzzerAndReplayer(const std::string& shader,
   ASSERT_TRUE(t.Validate(binary_in));
 
   for (uint32_t seed = initial_seed; seed < initial_seed + num_runs; seed++) {
+    // Run the fuzzer and check that it successfully yields a valid binary.
     std::vector<uint32_t> fuzzer_binary_out;
     protobufs::TransformationSequence fuzzer_transformation_sequence_out;
     spvtools::FuzzerOptions fuzzer_options;
     spvFuzzerOptionsSetRandomSeed(fuzzer_options, seed);
-
     Fuzzer fuzzer(env);
     fuzzer.SetMessageConsumer(kSilentConsumer);
     auto fuzzer_result_status =
@@ -50,33 +185,36 @@ void RunFuzzerAndReplayer(const std::string& shader,
     ASSERT_EQ(Fuzzer::FuzzerResultStatus::kComplete, fuzzer_result_status);
     ASSERT_TRUE(t.Validate(fuzzer_binary_out));
 
-    std::vector<uint32_t> replayer_binary_out;
-    protobufs::TransformationSequence replayer_transformation_sequence_out;
+    // With the AlwaysInteresting test, we should quickly shrink to the original
+    // binary with no transformations remaining.
+    RunAndCheckShrinker(env, binary_in, initial_facts,
+                        fuzzer_transformation_sequence_out,
+                        AlwaysInteresting().AsFunction(), binary_in, 0);
 
-    Replayer replayer(env);
-    replayer.SetMessageConsumer(kSilentConsumer);
-    auto replayer_result_status = replayer.Run(
-        binary_in, initial_facts, fuzzer_transformation_sequence_out,
-        &replayer_binary_out, &replayer_transformation_sequence_out);
-    ASSERT_EQ(Replayer::ReplayerResultStatus::kComplete,
-              replayer_result_status);
+    // With the OnlyInterestingFirstTime test, no shrinking should be achieved.
+    RunAndCheckShrinker(
+        env, binary_in, initial_facts, fuzzer_transformation_sequence_out,
+        OnlyInterestingFirstTime().AsFunction(), fuzzer_binary_out,
+        static_cast<uint32_t>(
+            fuzzer_transformation_sequence_out.transformation_size()));
 
-    // After replaying the transformations applied by the fuzzer, exactly those
-    // transformations should have been applied, and the binary resulting from
-    // replay should be identical to that which resulted from fuzzing.
-    std::string fuzzer_transformations_string;
-    std::string replayer_transformations_string;
-    fuzzer_transformation_sequence_out.SerializeToString(
-        &fuzzer_transformations_string);
-    replayer_transformation_sequence_out.SerializeToString(
-        &replayer_transformations_string);
-    ASSERT_EQ(fuzzer_transformations_string, replayer_transformations_string);
-    ASSERT_EQ(fuzzer_binary_out, replayer_binary_out);
+    // The PingPong test is unpredictable; passing an empty expected binary
+    // means that we don't check anything beyond that shrinking completes
+    // successfully.
+    RunAndCheckShrinker(env, binary_in, initial_facts,
+                        fuzzer_transformation_sequence_out,
+                        PingPong().AsFunction(), {}, 0);
+
+    // With the RandomThenAlwaysInteresting test, we should eventually shrink to
+    // the original binary with no transformations remaining.
+    RunAndCheckShrinker(
+        env, binary_in, initial_facts, fuzzer_transformation_sequence_out,
+        RandomThenAlwaysInteresting(20, seed).AsFunction(), binary_in, 0);
   }
 }
 
-TEST(FuzzerReplayerTest, Miscellaneous1) {
-  // The SPIR-V came from this GLSL:
+TEST(FuzzerShrinkerTest, Miscellaneous1) {
+  // The following SPIR-V came from this GLSL:
   //
   // #version 310 es
   //
@@ -104,7 +242,7 @@ TEST(FuzzerReplayerTest, Miscellaneous1) {
   //   }
   // }
 
-  std::string shader = R"(
+  const std::string shader = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -237,16 +375,17 @@ TEST(FuzzerReplayerTest, Miscellaneous1) {
          %16 = OpLabel
                OpReturn
                OpFunctionEnd
+
   )";
 
-  // Do 10 fuzzer runs, starting from an initial seed of 0 (seed value chosen
-  // arbitrarily).
-  RunFuzzerAndReplayer(shader, protobufs::FactSequence(), 0, 10);
+  // Do 2 fuzz-and-shrink runs, starting from an initial seed of 2 (seed value
+  // chosen arbitrarily).
+  RunFuzzerAndShrinker(shader, protobufs::FactSequence(), 2, 2);
 }
 
-TEST(FuzzerReplayerTest, Miscellaneous2) {
-  // The SPIR-V came from this GLSL, which was then optimized using spirv-opt
-  // with the -O argument:
+TEST(FuzzerShrinkerTest, Miscellaneous2) {
+  // The following SPIR-V came from this GLSL, which was then optimized using
+  // spirv-opt with the -O argument:
   //
   // #version 310 es
   //
@@ -298,7 +437,7 @@ TEST(FuzzerReplayerTest, Miscellaneous2) {
   //   }
   // }
 
-  std::string shader = R"(
+  const std::string shader = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -484,14 +623,14 @@ TEST(FuzzerReplayerTest, Miscellaneous2) {
                OpFunctionEnd
   )";
 
-  // Do 10 fuzzer runs, starting from an initial seed of 10 (seed value chosen
+  // Do 2 fuzzer runs, starting from an initial seed of 19 (seed value chosen
   // arbitrarily).
-  RunFuzzerAndReplayer(shader, protobufs::FactSequence(), 10, 10);
+  RunFuzzerAndShrinker(shader, protobufs::FactSequence(), 19, 2);
 }
 
-TEST(FuzzerReplayerTest, Miscellaneous3) {
-  // The SPIR-V came from this GLSL, which was then optimized using spirv-opt
-  // with the -O argument:
+TEST(FuzzerShrinkerTest, Miscellaneous3) {
+  // The following SPIR-V came from this GLSL, which was then optimized using
+  // spirv-opt with the -O argument:
   //
   // #version 310 es
   //
@@ -598,7 +737,7 @@ TEST(FuzzerReplayerTest, Miscellaneous3) {
   //            }
   // }
 
-  std::string shader = R"(
+  const std::string shader = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -969,9 +1108,9 @@ TEST(FuzzerReplayerTest, Miscellaneous3) {
     *facts.mutable_fact()->Add() = temp;
   }
 
-  // Do 10 fuzzer runs, starting from an initial seed of 94 (seed value chosen
+  // Do 2 fuzzer runs, starting from an initial seed of 194 (seed value chosen
   // arbitrarily).
-  RunFuzzerAndReplayer(shader, facts, 94, 10);
+  RunFuzzerAndShrinker(shader, facts, 194, 2);
 }
 
 }  // namespace

--- a/test/fuzz/fuzzer_shrinker_test.cpp
+++ b/test/fuzz/fuzzer_shrinker_test.cpp
@@ -209,7 +209,7 @@ void RunFuzzerAndShrinker(const std::string& shader,
     // the original binary with no transformations remaining.
     RunAndCheckShrinker(
         env, binary_in, initial_facts, fuzzer_transformation_sequence_out,
-        RandomThenAlwaysInteresting(20, seed).AsFunction(), binary_in, 0);
+        RandomThenAlwaysInteresting(5, seed).AsFunction(), binary_in, 0);
   }
 }
 

--- a/test/fuzz/fuzzer_shrinker_test.cpp
+++ b/test/fuzz/fuzzer_shrinker_test.cpp
@@ -138,6 +138,15 @@ void RunAndCheckShrinker(
   Shrinker::ShrinkerResultStatus shrinker_result_status =
       shrinker.Run(binary_in, initial_facts, transformation_sequence_in,
                    interestingness_function, &binary_out, &transformations_out);
+  ASSERT_FALSE(shrinker_result_status ==
+               Shrinker::ShrinkerResultStatus::kInitialBinaryInvalid);
+  ASSERT_FALSE(
+      shrinker_result_status ==
+      Shrinker::ShrinkerResultStatus::kFailedToCreateSpirvToolsInterface);
+  ASSERT_FALSE(shrinker_result_status ==
+               Shrinker::ShrinkerResultStatus::kInitialBinaryNotInteresting);
+  ASSERT_FALSE(shrinker_result_status ==
+               Shrinker::ShrinkerResultStatus::kReplayFailed);
   ASSERT_TRUE(Shrinker::ShrinkerResultStatus::kComplete ==
                   shrinker_result_status ||
               Shrinker::ShrinkerResultStatus::kStepLimitReached ==
@@ -204,9 +213,9 @@ void RunFuzzerAndShrinker(const std::string& shader,
 
     // With the EventuallyAlwaysInteresting test, we should eventually shrink to
     // the original binary with no transformations remaining.
-    RunAndCheckShrinker(
-        env, binary_in, initial_facts, fuzzer_transformation_sequence_out,
-        EventuallyAlwaysInteresting(12, 3).AsFunction(), {}, 0);
+    RunAndCheckShrinker(env, binary_in, initial_facts,
+                        fuzzer_transformation_sequence_out,
+                        EventuallyAlwaysInteresting(12, 3).AsFunction(), {}, 0);
   }
 }
 
@@ -622,7 +631,7 @@ TEST(FuzzerShrinkerTest, Miscellaneous2) {
 
   // Do 2 fuzzer runs, starting from an initial seed of 19 (seed value chosen
   // arbitrarily).
-  RunFuzzerAndShrinker(shader, protobufs::FactSequence(), 19, 2);
+  RunFuzzerAndShrinker(shader, protobufs::FactSequence(), 19, 5);
 }
 
 TEST(FuzzerShrinkerTest, Miscellaneous3) {
@@ -1107,7 +1116,7 @@ TEST(FuzzerShrinkerTest, Miscellaneous3) {
 
   // Do 2 fuzzer runs, starting from an initial seed of 194 (seed value chosen
   // arbitrarily).
-  RunFuzzerAndShrinker(shader, facts, 194, 2);
+  RunFuzzerAndShrinker(shader, facts, 194, 5);
 }
 
 }  // namespace

--- a/test/fuzz/fuzzer_shrinker_test.cpp
+++ b/test/fuzz/fuzzer_shrinker_test.cpp
@@ -206,7 +206,7 @@ void RunFuzzerAndShrinker(const std::string& shader,
     // the original binary with no transformations remaining.
     RunAndCheckShrinker(
         env, binary_in, initial_facts, fuzzer_transformation_sequence_out,
-        EventuallyAlwaysInteresting(12, 3).AsFunction(), binary_in, 0);
+        EventuallyAlwaysInteresting(12, 3).AsFunction(), {}, 0);
   }
 }
 


### PR DESCRIPTION
Adds to spirv-fuzz the option to shrink a sequence of transformations that lead to an interesting binary to be generated, to find a smaller sub-sequence of transformations that still lead to an interesting (but hopefully simpler) binary being generated.  The notion of what counts as "interesting" comes from a user-provided script, the "interestingness function", similar to the way the spirv-reduce tool works.  The shrinking process will give up after a maximum number of steps, which can be configured on the command line.

Tests for the combination of fuzzing and shrinking are included, using a variety of interestingness functions.