### PR TITLE
Refactor reducer options

### DIFF
--- a/source/spirv_reducer_options.cpp
+++ b/source/spirv_reducer_options.cpp
@@ -18,7 +18,7 @@
 #include "source/spirv_reducer_options.h"
 
 namespace {
-// The default maximum number of steps for the reducer to run before giving up.
+// The default maximum number of steps the reducer will take before giving up.
 const uint32_t kDefaultStepLimit = 250;
 }  // namespace
 

--- a/source/spirv_reducer_options.cpp
+++ b/source/spirv_reducer_options.cpp
@@ -17,6 +17,14 @@
 
 #include "source/spirv_reducer_options.h"
 
+namespace {
+// The default maximum number of steps for the reducer to run before giving up.
+const uint32_t kDefaultStepLimit = 250;
+}  // namespace
+
+spv_reducer_options_t::spv_reducer_options_t()
+    : step_limit(kDefaultStepLimit), fail_on_validation_error(false) {}
+
 SPIRV_TOOLS_EXPORT spv_reducer_options spvReducerOptionsCreate() {
   return new spv_reducer_options_t();
 }

--- a/source/spirv_reducer_options.h
+++ b/source/spirv_reducer_options.h
@@ -20,14 +20,10 @@
 #include <string>
 #include <utility>
 
-// The default maximum number of steps for the reducer to run before giving up.
-const uint32_t kDefaultStepLimit = 250;
-
 // Manages command line options passed to the SPIR-V Reducer. New struct
 // members may be added for any new option.
 struct spv_reducer_options_t {
-  spv_reducer_options_t()
-      : step_limit(kDefaultStepLimit), fail_on_validation_error(false) {}
+  spv_reducer_options_t();
 
   // See spvReducerOptionsSetStepLimit.
   uint32_t step_limit;


### PR DESCRIPTION
Avoids polluting the global namespace with a constant, and moves constructor to .cpp file as is done for spirv-reduce's options.