### PR TITLE
Perform merge return with single return in loop.

### DIFF
--- a/source/opt/merge_return_pass.cpp
+++ b/source/opt/merge_return_pass.cpp
@@ -36,7 +36,13 @@ Pass::Status MergeReturnPass::Process() {
   ProcessFunction pfn = [&failed, is_shader, this](Function* function) {
     std::vector<BasicBlock*> return_blocks = CollectReturnBlocks(function);
     if (return_blocks.size() <= 1) {
-      return false;
+      if (!is_shader || return_blocks.size() == 0) {
+        return false;
+      }
+      if (context()->GetStructuredCFGAnalysis()->ContainingConstruct(
+              return_blocks[0]->id()) == 0) {
+        return false;
+      }
     }
 
     function_ = function;


### PR DESCRIPTION
Inlining does not inline functions that have a single return that is in a loop.  This is because the return cannot be replaced by a branch outside of the loop easily.  Merge return knows how to rewrite the function so the return is replaced by a branch.

Fixes #2038.