### PR TITLE
Handle decorations better in some optimizations

### DIFF
--- a/source/opt/decoration_manager.h
+++ b/source/opt/decoration_manager.h
@@ -74,6 +74,12 @@ class DecorationManager {
   // instructions that apply the same decorations but to different IDs, still
   // count as being the same.
   bool HaveTheSameDecorations(uint32_t id1, uint32_t id2) const;
+
+  // Returns whether two IDs have the same decorations. Two SpvOpGroupDecorate
+  // instructions that apply the same decorations but to different IDs, still
+  // count as being the same.
+  bool HaveSubsetOfDecorations(uint32_t id1, uint32_t id2) const;
+
   // Returns whether the two decorations instructions are the same and are
   // applying the same decorations; unless |ignore_target| is false, the targets
   // to which they are applied to does not matter, except for the member part.

--- a/source/opt/value_number_table.cpp
+++ b/source/opt/value_number_table.cpp
@@ -78,8 +78,12 @@ uint32_t ValueNumberTable::AssignValueNumber(Instruction* inst) {
     return value;
   }
 
+  analysis::DecorationManager* dec_mgr = context()->get_decoration_mgr();
+
   // When we copy an object, the value numbers should be the same.
-  if (inst->opcode() == SpvOpCopyObject) {
+  if (inst->opcode() == SpvOpCopyObject &&
+      dec_mgr->HaveTheSameDecorations(inst->result_id(),
+                                      inst->GetSingleWordInOperand(0))) {
     value = GetValueNumber(inst->GetSingleWordInOperand(0));
     if (value != 0) {
       id_to_value_[inst->result_id()] = value;
@@ -89,7 +93,9 @@ uint32_t ValueNumberTable::AssignValueNumber(Instruction* inst) {
 
   // Phi nodes are a type of copy.  If all of the inputs have the same value
   // number, then we can assign the result of the phi the same value number.
-  if (inst->opcode() == SpvOpPhi) {
+  if (inst->opcode() == SpvOpPhi &&
+      dec_mgr->HaveTheSameDecorations(inst->result_id(),
+                                      inst->GetSingleWordInOperand(0))) {
     value = GetValueNumber(inst->GetSingleWordInOperand(0));
     if (value != 0) {
       for (uint32_t op = 2; op < inst->NumInOperands(); op += 2) {

--- a/test/opt/decoration_manager_test.cpp
+++ b/test/opt/decoration_manager_test.cpp
@@ -1277,6 +1277,232 @@ OpDecorateStringGOOGLE %2 HlslSemanticGOOGLE "hello"
   EXPECT_FALSE(decoManager->HaveTheSameDecorations(1u, 2u));
 }
 
+TEST_F(DecorationManagerTest, SubSetTestOpDecorate1) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %1 Restrict
+OpDecorate %2 Constant
+OpDecorate %2 Restrict
+OpDecorate %1 Constant
+%u32    = OpTypeInt 32 0
+%1      = OpVariable %u32 Uniform
+%2      = OpVariable %u32 Uniform
+)";
+  DecorationManager* decoManager = GetDecorationManager(spirv);
+  EXPECT_THAT(GetErrorMessage(), "");
+  EXPECT_TRUE(decoManager->HaveSubsetOfDecorations(1u, 2u));
+}
+
+TEST_F(DecorationManagerTest, SubSetTestOpDecorate2) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %1 Restrict
+OpDecorate %2 Constant
+OpDecorate %2 Restrict
+%u32    = OpTypeInt 32 0
+%1      = OpVariable %u32 Uniform
+%2      = OpVariable %u32 Uniform
+)";
+  DecorationManager* decoManager = GetDecorationManager(spirv);
+  EXPECT_THAT(GetErrorMessage(), "");
+  EXPECT_TRUE(decoManager->HaveSubsetOfDecorations(1u, 2u));
+}
+
+TEST_F(DecorationManagerTest, SubSetTestOpDecorate3) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %1 Constant
+OpDecorate %2 Constant
+OpDecorate %2 Restrict
+%u32    = OpTypeInt 32 0
+%1      = OpVariable %u32 Uniform
+%2      = OpVariable %u32 Uniform
+)";
+  DecorationManager* decoManager = GetDecorationManager(spirv);
+  EXPECT_THAT(GetErrorMessage(), "");
+  EXPECT_TRUE(decoManager->HaveSubsetOfDecorations(1u, 2u));
+}
+
+TEST_F(DecorationManagerTest, SubSetTestOpDecorate4) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %1 Restrict
+OpDecorate %2 Constant
+OpDecorate %2 Restrict
+OpDecorate %1 Constant
+%u32    = OpTypeInt 32 0
+%1      = OpVariable %u32 Uniform
+%2      = OpVariable %u32 Uniform
+)";
+  DecorationManager* decoManager = GetDecorationManager(spirv);
+  EXPECT_THAT(GetErrorMessage(), "");
+  EXPECT_TRUE(decoManager->HaveSubsetOfDecorations(2u, 1u));
+}
+
+TEST_F(DecorationManagerTest, SubSetTestOpDecorate5) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %1 Restrict
+OpDecorate %2 Constant
+OpDecorate %2 Restrict
+%u32    = OpTypeInt 32 0
+%1      = OpVariable %u32 Uniform
+%2      = OpVariable %u32 Uniform
+)";
+  DecorationManager* decoManager = GetDecorationManager(spirv);
+  EXPECT_THAT(GetErrorMessage(), "");
+  EXPECT_FALSE(decoManager->HaveSubsetOfDecorations(2u, 1u));
+}
+
+TEST_F(DecorationManagerTest, SubSetTestOpDecorate6) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %1 Constant
+OpDecorate %2 Constant
+OpDecorate %2 Restrict
+%u32    = OpTypeInt 32 0
+%1      = OpVariable %u32 Uniform
+%2      = OpVariable %u32 Uniform
+)";
+  DecorationManager* decoManager = GetDecorationManager(spirv);
+  EXPECT_THAT(GetErrorMessage(), "");
+  EXPECT_FALSE(decoManager->HaveSubsetOfDecorations(2u, 1u));
+}
+
+TEST_F(DecorationManagerTest, SubSetTestOpDecorate7) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %1 Constant
+OpDecorate %2 Constant
+OpDecorate %2 Restrict
+OpDecorate %1 Invariant
+%u32    = OpTypeInt 32 0
+%1      = OpVariable %u32 Uniform
+%2      = OpVariable %u32 Uniform
+)";
+  DecorationManager* decoManager = GetDecorationManager(spirv);
+  EXPECT_THAT(GetErrorMessage(), "");
+  EXPECT_FALSE(decoManager->HaveSubsetOfDecorations(2u, 1u));
+  EXPECT_FALSE(decoManager->HaveSubsetOfDecorations(1u, 2u));
+}
+
+TEST_F(DecorationManagerTest, SubSetTestOpMemberDecorate1) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpMemberDecorate %1 0 Offset 0
+OpMemberDecorate %1 0 Offset 4
+OpMemberDecorate %2 0 Offset 0
+OpMemberDecorate %2 0 Offset 4
+%u32    = OpTypeInt 32 0
+%1      = OpTypeStruct %u32 %u32 %u32
+%2      = OpTypeStruct %u32 %u32 %u32
+)";
+  DecorationManager* decoManager = GetDecorationManager(spirv);
+  EXPECT_THAT(GetErrorMessage(), "");
+  EXPECT_TRUE(decoManager->HaveSubsetOfDecorations(1u, 2u));
+  EXPECT_TRUE(decoManager->HaveSubsetOfDecorations(2u, 1u));
+}
+
+TEST_F(DecorationManagerTest, SubSetTestOpMemberDecorate2) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpMemberDecorate %1 0 Offset 0
+OpMemberDecorate %2 0 Offset 0
+OpMemberDecorate %2 0 Offset 4
+%u32    = OpTypeInt 32 0
+%1      = OpTypeStruct %u32 %u32 %u32
+%2      = OpTypeStruct %u32 %u32 %u32
+)";
+  DecorationManager* decoManager = GetDecorationManager(spirv);
+  EXPECT_THAT(GetErrorMessage(), "");
+  EXPECT_TRUE(decoManager->HaveSubsetOfDecorations(1u, 2u));
+  EXPECT_FALSE(decoManager->HaveSubsetOfDecorations(2u, 1u));
+}
+
+TEST_F(DecorationManagerTest, SubSetTestOpDecorateId1) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorateId %1 AlignmentId %2
+%u32    = OpTypeInt 32 0
+%1      = OpVariable %u32 Uniform
+%3      = OpVariable %u32 Uniform
+%2      = OpSpecConstant %u32 0
+)";
+  DecorationManager* decoManager = GetDecorationManager(spirv);
+  EXPECT_THAT(GetErrorMessage(), "");
+  EXPECT_FALSE(decoManager->HaveSubsetOfDecorations(1u, 3u));
+  EXPECT_TRUE(decoManager->HaveSubsetOfDecorations(3u, 1u));
+}
+
+TEST_F(DecorationManagerTest, SubSetTestOpDecorateId2) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorateId %1 AlignmentId %2
+OpDecorateId %3 AlignmentId %4
+%u32    = OpTypeInt 32 0
+%1      = OpVariable %u32 Uniform
+%3      = OpVariable %u32 Uniform
+%2      = OpSpecConstant %u32 0
+%4      = OpSpecConstant %u32 1
+)";
+  DecorationManager* decoManager = GetDecorationManager(spirv);
+  EXPECT_THAT(GetErrorMessage(), "");
+  EXPECT_FALSE(decoManager->HaveSubsetOfDecorations(1u, 3u));
+  EXPECT_FALSE(decoManager->HaveSubsetOfDecorations(3u, 1u));
+}
+
+TEST_F(DecorationManagerTest, SubSetTestOpDecorateString1) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpExtension "SPV_GOOGLE_hlsl_functionality1"
+OpExtension "SPV_GOOGLE_decorate_string"
+OpMemoryModel Logical GLSL450
+OpDecorateString %1 HlslSemanticGOOGLE "hello"
+OpDecorateString %2 HlslSemanticGOOGLE "world"
+)";
+  DecorationManager* decoManager = GetDecorationManager(spirv);
+  EXPECT_THAT(GetErrorMessage(), "");
+  EXPECT_FALSE(decoManager->HaveSubsetOfDecorations(1u, 2u));
+  EXPECT_FALSE(decoManager->HaveSubsetOfDecorations(2u, 1u));
+}
+
+TEST_F(DecorationManagerTest, SubSetTestOpDecorateString2) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpExtension "SPV_GOOGLE_hlsl_functionality1"
+OpExtension "SPV_GOOGLE_decorate_string"
+OpMemoryModel Logical GLSL450
+OpDecorateString %1 HlslSemanticGOOGLE "hello"
+)";
+  DecorationManager* decoManager = GetDecorationManager(spirv);
+  EXPECT_THAT(GetErrorMessage(), "");
+  EXPECT_FALSE(decoManager->HaveSubsetOfDecorations(1u, 2u));
+  EXPECT_TRUE(decoManager->HaveSubsetOfDecorations(2u, 1u));
+}
 }  // namespace
 }  // namespace analysis
 }  // namespace opt


### PR DESCRIPTION
There are a couple spots where we are not looking at decorations when we should.

1. Value numbering is suppose to assign a different value number to ids if they have different decorations.  However that is not being done for OpCopyObject and OpPhi.

1. Instruction simplification is propagating OpCopyObject instruction without checking for decorations.  It should only do that if no decorations are being lost.

Add a new function to the decoration manager to check if the decorations of one id are a subset of the decorations of another.

Fixes #2715.