### PR TITLE
Invalidate StructuredCFGAnalysis in KillInst

### DIFF
--- a/source/opt/dead_branch_elim_pass.cpp
+++ b/source/opt/dead_branch_elim_pass.cpp
@@ -93,8 +93,6 @@ BasicBlock* DeadBranchElimPass::GetParentBlock(uint32_t id) {
 
 bool DeadBranchElimPass::MarkLiveBlocks(
     Function* func, std::unordered_set<BasicBlock*>* live_blocks) {
-  StructuredCFGAnalysis* cfgAnalysis = context()->GetStructuredCFGAnalysis();
-
   std::unordered_set<BasicBlock*> blocks_with_backedge;
   std::vector<BasicBlock*> stack;
   stack.push_back(&*func->begin());
@@ -188,9 +186,12 @@ bool DeadBranchElimPass::MarkLiveBlocks(
           // it is still needed.
           Instruction* first_break = FindFirstExitFromSelectionMerge(
               live_lab_id, mergeInst->GetSingleWordInOperand(0),
-              cfgAnalysis->LoopMergeBlock(live_lab_id),
-              cfgAnalysis->LoopContinueBlock(live_lab_id),
-              cfgAnalysis->SwitchMergeBlock(live_lab_id));
+              context()->GetStructuredCFGAnalysis()->LoopMergeBlock(
+                  live_lab_id),
+              context()->GetStructuredCFGAnalysis()->LoopContinueBlock(
+                  live_lab_id),
+              context()->GetStructuredCFGAnalysis()->SwitchMergeBlock(
+                  live_lab_id));
 
           AddBranch(live_lab_id, block);
           context()->KillInst(terminator);

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -165,6 +165,13 @@ Instruction* IRContext::KillInst(Instruction* inst) {
     constant_mgr_->RemoveId(inst->result_id());
   }
 
+  if (AreAnalysesValid(kAnalysisStructuredCFG) &&
+      (inst->opcode() == SpvOpLoopMerge ||
+       inst->opcode() == SpvOpSelectionMerge ||
+       inst->opcode() == SpvOpSwitch)) {
+    InvalidateAnalyses(kAnalysisStructuredCFG);
+  }
+
   RemoveFromIdToName(inst);
 
   Instruction* next_instruction = nullptr;


### PR DESCRIPTION
Fixes issue in dead_branch_elim_pass.cpp where a stale
StructuredCFGAnalysis leads to dereferencing a null pointer.

Fixes #2667