### PR TITLE
Change the order branches are simplified in dead branch elim

### DIFF
--- a/source/opt/dead_branch_elim_pass.h
+++ b/source/opt/dead_branch_elim_pass.h
@@ -161,6 +161,12 @@ class DeadBranchElimPass : public MemPass {
   // Returns true if there is a brach to the merge node of the selection
   // construct |switch_header_id| that is inside a nested selection construct.
   bool SwitchHasNestedBreak(uint32_t switch_header_id);
+
+  // Replaces the terminator of |block| with a branch to |live_lab_id|.  The
+  // merge instruction is deleted or moved as needed to maintain structured
+  // control flow.  Assumes that the StructuredCFGAnalysis is valid for the
+  // constructs containing |block|.
+  void SimplifyBranch(BasicBlock* block, uint32_t live_lab_id);
 };
 
 }  // namespace opt


### PR DESCRIPTION
Dead branch elimination needs to know about the constructs that a block is contained it when determining what to do with its merge instruction.  We currently fold branches in block as we see them, which is parent constructs before their children.  This causes the struct cfg analysis to crash because it tries to get the parent construct for a block after the parent has been folded.

This can be fixed by folding the branch of the children before the parents.

Fixes #2667.