### PR TITLE
BUILD.gn: Add deps and move files for `gn check`

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -670,6 +670,7 @@ static_library("spvtools_link") {
   ]
   deps = [
     ":spvtools",
+    ":spvtools_opt",
     ":spvtools_val",
   ]
   public_deps = [
@@ -736,6 +737,8 @@ static_library("spvtools_reduce") {
     "source/reduce/structured_loop_to_selection_reduction_opportunity.h",
     "source/reduce/structured_loop_to_selection_reduction_opportunity_finder.cpp",
     "source/reduce/structured_loop_to_selection_reduction_opportunity_finder.h",
+    "source/spirv_reducer_options.cpp",
+    "source/spirv_reducer_options.h",
   ]
   deps = [
     ":spvtools",
@@ -865,6 +868,7 @@ source_set("spvtools_software_version") {
   ]
   deps = [
     ":spvtools_build_version",
+    ":spvtools_headers",
   ]
   configs += [ ":spvtools_internal_config" ]
 }
@@ -949,12 +953,11 @@ if (!is_ios) {
   # iOS does not allow std::system calls which spirv-reduce requires
   executable("spirv-reduce") {
     sources = [
-      "source/spirv_reducer_options.cpp",
-      "source/spirv_reducer_options.h",
       "tools/reduce/reduce.cpp",
     ]
     deps = [
       ":spvtools",
+      ":spvtools_opt",
       ":spvtools_reduce",
       ":spvtools_software_version",
       ":spvtools_util_cli_consumer",


### PR DESCRIPTION
This makes SPIRV-Tools produce no GN check errors when used in Dawn and
ANGLE

PTAL @zoddicus !