### PR TITLE
Element type is const for analysis::Vector,Matrix,RuntimeArray

### DIFF
--- a/source/opt/types.cpp
+++ b/source/opt/types.cpp
@@ -274,7 +274,7 @@ void Float::GetExtraHashWords(std::vector<uint32_t>* words,
   words->push_back(width_);
 }
 
-Vector::Vector(Type* type, uint32_t count)
+Vector::Vector(const Type* type, uint32_t count)
     : Type(kVector), element_type_(type), count_(count) {
   assert(type->AsBool() || type->AsInteger() || type->AsFloat());
 }
@@ -299,7 +299,7 @@ void Vector::GetExtraHashWords(std::vector<uint32_t>* words,
   words->push_back(count_);
 }
 
-Matrix::Matrix(Type* type, uint32_t count)
+Matrix::Matrix(const Type* type, uint32_t count)
     : Type(kMatrix), element_type_(type), count_(count) {
   assert(type->AsVector());
 }
@@ -426,7 +426,7 @@ void Array::GetExtraHashWords(std::vector<uint32_t>* words,
 
 void Array::ReplaceElementType(const Type* type) { element_type_ = type; }
 
-RuntimeArray::RuntimeArray(Type* type)
+RuntimeArray::RuntimeArray(const Type* type)
     : Type(kRuntimeArray), element_type_(type) {
   assert(!type->AsVoid());
 }

--- a/source/opt/types.h
+++ b/source/opt/types.h
@@ -258,7 +258,7 @@ class Float : public Type {
 
 class Vector : public Type {
  public:
-  Vector(Type* element_type, uint32_t count);
+  Vector(const Type* element_type, uint32_t count);
   Vector(const Vector&) = default;
 
   std::string str() const override;
@@ -280,7 +280,7 @@ class Vector : public Type {
 
 class Matrix : public Type {
  public:
-  Matrix(Type* element_type, uint32_t count);
+  Matrix(const Type* element_type, uint32_t count);
   Matrix(const Matrix&) = default;
 
   std::string str() const override;
@@ -407,7 +407,7 @@ class Array : public Type {
 
 class RuntimeArray : public Type {
  public:
-  RuntimeArray(Type* element_type);
+  RuntimeArray(const Type* element_type);
   RuntimeArray(const RuntimeArray&) = default;
 
   std::string str() const override;


### PR DESCRIPTION
This makes it symmetric with the result type of ...->element_type which
returns a const Type.

So now we can write code like this:

   analysis::Vector v = ...
   analysis::Vector(v->element_type(), 2);