### PR TITLE
Fix #2609 - Handle out-of-bounds scalar replacements.

### DIFF
--- a/source/opt/scalar_replacement_pass.h
+++ b/source/opt/scalar_replacement_pass.h
@@ -117,9 +117,12 @@ class ScalarReplacementPass : public Pass {
   // for element of the composite type. Uses of |inst| are updated as
   // appropriate. If the replacement variables are themselves scalarizable, they
   // get added to |worklist| for further processing. If any replacement
-  // variable ends up with no uses it is erased. Returns false if the variable
-  // could not be replaced.
-  bool ReplaceVariable(Instruction* inst, std::queue<Instruction*>* worklist);
+  // variable ends up with no uses it is erased. Returns
+  //  - Status::SuccessWithoutChange if the variable could not be replaced.
+  //  - Status::SuccessWithChange if it made replacements.
+  //  - Status::Failure if it couldn't create replacement variables.
+  Pass::Status ReplaceVariable(Instruction* inst,
+                               std::queue<Instruction*>* worklist);
 
   // Returns the underlying storage type for |inst|.
   //

--- a/test/opt/scalar_replacement_test.cpp
+++ b/test/opt/scalar_replacement_test.cpp
@@ -1668,11 +1668,8 @@ TEST_F(ScalarReplacementTest, OutOfBoundOpAccessChain) {
                OpExecutionMode %main OriginUpperLeft
                OpSource ESSL 310
                OpName %main "main"
-               OpName %i "i"
                OpName %a "a"
                OpName %_GLF_color "_GLF_color"
-               OpDecorate %i RelaxedPrecision
-               OpDecorate %19 RelaxedPrecision
                OpDecorate %_GLF_color Location 0
        %void = OpTypeVoid
           %3 = OpTypeFunction %void
@@ -1689,11 +1686,8 @@ TEST_F(ScalarReplacementTest, OutOfBoundOpAccessChain) {
  %_GLF_color = OpVariable %_ptr_Output_float Output
        %main = OpFunction %void None %3
           %5 = OpLabel
-          %i = OpVariable %_ptr_Function_int Function
           %a = OpVariable %_ptr_Function__arr_float_uint_1 Function
-               OpStore %i %int_1
-         %19 = OpLoad %int %i
-         %21 = OpAccessChain %_ptr_Function_float %a %19
+         %21 = OpAccessChain %_ptr_Function_float %a %int_1
          %22 = OpLoad %float %21
                OpStore %_GLF_color %22
                OpReturn


### PR DESCRIPTION
When SROA tries to do a replacement for an OpAccessChain that is exactly
one element out of bounds, the code was trying to access its internal
array of replacements and segfaulting.

This protects the code from doing this, and it additionally fixes the
way SROA works by not returning failure when it refuses to do a
replacement.  Instead of failing the optimization pass, SROA will now
simply refuse to do the replacement and keep going.