### PR TITLE
Don't move debug or decorations when folding

### DIFF
--- a/source/opt/ir_context.h
+++ b/source/opt/ir_context.h
@@ -382,6 +382,15 @@ class IRContext {
   // |before| and |after| must be registered definitions in the DefUseManager.
   bool ReplaceAllUsesWith(uint32_t before, uint32_t after);
 
+  // Replace all uses of |before| id with |after| id if those uses
+  // (instruction, operand pair) return true for |predicate|. Returns true if
+  // any replacement happens. This method does not kill the definition of the
+  // |before| id. If |after| is the same as |before|, does nothing and return
+  // false.
+  bool ReplaceAllUsesWithPredicate(
+      uint32_t before, uint32_t after,
+      const std::function<bool(Instruction*, uint32_t)>& predicate);
+
   // Returns true if all of the analyses that are suppose to be valid are
   // actually valid.
   bool IsConsistent();


### PR DESCRIPTION
Fixes #2764

* Don't replace all uses when simplifying instructions, instead only
update non-debug, non-decoration uses
  * added a test

Decorations shouldn't be pulled into generators when simplifying instructions.