### PR TITLE
Remove extra ';' after member function definition.

### DIFF
--- a/source/opt/graphics_robust_access_pass.h
+++ b/source/opt/graphics_robust_access_pass.h
@@ -41,7 +41,7 @@ class GraphicsRobustAccessPass : public Pass {
            IRContext::kAnalysisInstrToBlockMapping |
            IRContext::kAnalysisConstants | IRContext::kAnalysisTypes |
            IRContext::kAnalysisIdToFuncMapping;
-  };
+  }
 
  private:
   // Records failure for the current module, and returns a stream


### PR DESCRIPTION
This fixes a clang compiler warning about extra semicolons that blocks ANGLE's integration.