### PR TITLE
Add -fextra-semi to Clang builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,6 +235,21 @@ endmacro(spvtools_pch)
 
 add_subdirectory(external)
 
+# Warning about extra semi-colons.
+#
+# This is not supported on all compilers/versions. so enabling only
+# for clang, since that works for all versions that our bots run.
+#
+# This is intentionally done after adding the external subdirectory,
+# so we don't enforce this flag on our dependencies, some of which do
+# not pass it.
+#
+# If the minimum version of CMake supported is updated to 3.0 or
+# later, then check_cxx_compiler_flag could be used instead.
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    add_compile_options("-Wextra-semi")
+endif()
+
 add_subdirectory(source)
 add_subdirectory(tools)
 


### PR DESCRIPTION
This will catch instances on the bots where PRs introduce unneeded
semi-colons, which are going to cause downstream users problems.

Fixes #2781