### PR TITLE
Remove useless semi-colons

### DIFF
--- a/test/link/type_match_test.cpp
+++ b/test/link/type_match_test.cpp
@@ -84,44 +84,46 @@ using TypeMatch = spvtest::LinkerTest;
   MatchF(T##Of##A##Of##B, \
          MatchPart1(B, b) MatchPart2(A, a, b) MatchPart2(T, type, a))
 
+// clang-format off
 // Basic types
-Match1(Int);
-Match1(Float);
-Match1(Opaque);
-Match1(Sampler);
-Match1(Event);
-Match1(DeviceEvent);
-Match1(ReserveId);
-Match1(Queue);
-Match1(Pipe);
-Match1(PipeStorage);
-Match1(NamedBarrier);
+Match1(Int)
+Match1(Float)
+Match1(Opaque)
+Match1(Sampler)
+Match1(Event)
+Match1(DeviceEvent)
+Match1(ReserveId)
+Match1(Queue)
+Match1(Pipe)
+Match1(PipeStorage)
+Match1(NamedBarrier)
 
 // Simpler (restricted) compound types
-Match2(Vector, Float);
-Match3(Matrix, Vector, Float);
-Match2(Image, Float);
+Match2(Vector, Float)
+Match3(Matrix, Vector, Float)
+Match2(Image, Float)
 
 // Unrestricted compound types
 #define MatchCompounds1(A) \
-  Match2(RuntimeArray, A); \
-  Match2(Struct, A);       \
-  Match2(Pointer, A);      \
-  Match2(Function, A);     \
-  Match2(Array, A);
+  Match2(RuntimeArray, A)  \
+  Match2(Struct, A)        \
+  Match2(Pointer, A)       \
+  Match2(Function, A)      \
+  Match2(Array, A)
 #define MatchCompounds2(A, B) \
-  Match3(RuntimeArray, A, B); \
-  Match3(Struct, A, B);       \
-  Match3(Pointer, A, B);      \
-  Match3(Function, A, B);     \
-  Match3(Array, A, B);
+  Match3(RuntimeArray, A, B)  \
+  Match3(Struct, A, B)        \
+  Match3(Pointer, A, B)       \
+  Match3(Function, A, B)      \
+  Match3(Array, A, B)
 
-MatchCompounds1(Float);
-MatchCompounds2(Array, Float);
-MatchCompounds2(RuntimeArray, Float);
-MatchCompounds2(Struct, Float);
-MatchCompounds2(Pointer, Float);
-MatchCompounds2(Function, Float);
+MatchCompounds1(Float)
+MatchCompounds2(Array, Float)
+MatchCompounds2(RuntimeArray, Float)
+MatchCompounds2(Struct, Float)
+MatchCompounds2(Pointer, Float)
+MatchCompounds2(Function, Float)
+// clang-format on
 
 // ForwardPointer tests, which don't fit into the previous mold
 #define MatchFpF(N, CODE)                                             \
@@ -134,11 +136,13 @@ MatchCompounds2(Function, Float);
 #define MatchFp2(T, A) \
   MatchFpF(ForwardPointerOf##T, MatchPart1(A, a) MatchPart2(T, realtype, a))
 
-MatchFp1(Float);
-MatchFp2(Array, Float);
-MatchFp2(RuntimeArray, Float);
-MatchFp2(Struct, Float);
-MatchFp2(Function, Float);
+    // clang-format off
+MatchFp1(Float)
+MatchFp2(Array, Float)
+MatchFp2(RuntimeArray, Float)
+MatchFp2(Struct, Float)
+MatchFp2(Function, Float)
+// clang-format on
 
 }  // namespace
 }  // namespace spvtools

--- a/test/opt/types_test.cpp
+++ b/test/opt/types_test.cpp
@@ -65,17 +65,18 @@ class SameTypeTest : public ::testing::Test {
 #define TestMultipleInstancesOfTheSameType(ty, ...) \
   TestMultipleInstancesOfTheSameTypeQualified(ty, Simple, __VA_ARGS__)
 
-TestMultipleInstancesOfTheSameType(Void);
-TestMultipleInstancesOfTheSameType(Bool);
-TestMultipleInstancesOfTheSameType(Integer, 32, true);
-TestMultipleInstancesOfTheSameType(Float, 64);
-TestMultipleInstancesOfTheSameType(Vector, u32_t_.get(), 3);
-TestMultipleInstancesOfTheSameType(Matrix, v3u32_t_.get(), 4);
+// clang-format off
+TestMultipleInstancesOfTheSameType(Void)
+TestMultipleInstancesOfTheSameType(Bool)
+TestMultipleInstancesOfTheSameType(Integer, 32, true)
+TestMultipleInstancesOfTheSameType(Float, 64)
+TestMultipleInstancesOfTheSameType(Vector, u32_t_.get(), 3)
+TestMultipleInstancesOfTheSameType(Matrix, v3u32_t_.get(), 4)
 TestMultipleInstancesOfTheSameType(Image, f64_t_.get(), SpvDimCube, 0, 0, 1, 1,
                                    SpvImageFormatRgb10A2,
-                                   SpvAccessQualifierWriteOnly);
-TestMultipleInstancesOfTheSameType(Sampler);
-TestMultipleInstancesOfTheSameType(SampledImage, image_t_.get());
+                                   SpvAccessQualifierWriteOnly)
+TestMultipleInstancesOfTheSameType(Sampler)
+TestMultipleInstancesOfTheSameType(SampledImage, image_t_.get())
 // There are three classes of arrays, based on the kinds of length information
 // they have.
 // 1. Array length is a constant or spec constant without spec ID, with literals
@@ -85,34 +86,35 @@ TestMultipleInstancesOfTheSameTypeQualified(Array, LenConstant, u32_t_.get(),
                                                               {
                                                                   0,
                                                                   9999,
-                                                              }});
+                                                              }})
 // 2. Array length is a spec constant with a given spec id.
 TestMultipleInstancesOfTheSameTypeQualified(Array, LenSpecId, u32_t_.get(),
-                                            Array::LengthInfo{42, {1, 99}});
+                                            Array::LengthInfo{42, {1, 99}})
 // 3. Array length is an OpSpecConstantOp expression
 TestMultipleInstancesOfTheSameTypeQualified(Array, LenDefiningId, u32_t_.get(),
-                                            Array::LengthInfo{42, {2, 42}});
+                                            Array::LengthInfo{42, {2, 42}})
 
-TestMultipleInstancesOfTheSameType(RuntimeArray, u32_t_.get());
+TestMultipleInstancesOfTheSameType(RuntimeArray, u32_t_.get())
 TestMultipleInstancesOfTheSameType(Struct, std::vector<const Type*>{
-                                               u32_t_.get(), f64_t_.get()});
-TestMultipleInstancesOfTheSameType(Opaque, "testing rocks");
-TestMultipleInstancesOfTheSameType(Pointer, u32_t_.get(), SpvStorageClassInput);
+                                               u32_t_.get(), f64_t_.get()})
+TestMultipleInstancesOfTheSameType(Opaque, "testing rocks")
+TestMultipleInstancesOfTheSameType(Pointer, u32_t_.get(), SpvStorageClassInput)
 TestMultipleInstancesOfTheSameType(Function, u32_t_.get(),
-                                   {f64_t_.get(), f64_t_.get()});
-TestMultipleInstancesOfTheSameType(Event);
-TestMultipleInstancesOfTheSameType(DeviceEvent);
-TestMultipleInstancesOfTheSameType(ReserveId);
-TestMultipleInstancesOfTheSameType(Queue);
-TestMultipleInstancesOfTheSameType(Pipe, SpvAccessQualifierReadWrite);
-TestMultipleInstancesOfTheSameType(ForwardPointer, 10, SpvStorageClassUniform);
-TestMultipleInstancesOfTheSameType(PipeStorage);
-TestMultipleInstancesOfTheSameType(NamedBarrier);
-TestMultipleInstancesOfTheSameType(AccelerationStructureNV);
+                                   {f64_t_.get(), f64_t_.get()})
+TestMultipleInstancesOfTheSameType(Event)
+TestMultipleInstancesOfTheSameType(DeviceEvent)
+TestMultipleInstancesOfTheSameType(ReserveId)
+TestMultipleInstancesOfTheSameType(Queue)
+TestMultipleInstancesOfTheSameType(Pipe, SpvAccessQualifierReadWrite)
+TestMultipleInstancesOfTheSameType(ForwardPointer, 10, SpvStorageClassUniform)
+TestMultipleInstancesOfTheSameType(PipeStorage)
+TestMultipleInstancesOfTheSameType(NamedBarrier)
+TestMultipleInstancesOfTheSameType(AccelerationStructureNV)
 #undef TestMultipleInstanceOfTheSameType
 #undef TestMultipleInstanceOfTheSameTypeQual
 
 std::vector<std::unique_ptr<Type>> GenerateAllTypes() {
+  // clang-format on
   // Types in this test case are only equal to themselves, nothing else.
   std::vector<std::unique_ptr<Type>> types;
 


### PR DESCRIPTION
Later versions of clang seem to pick up more useless semi-colons.  I've removed them.