### PR TITLE
Change the way to include header

### DIFF
--- a/source/opt/desc_sroa.cpp
+++ b/source/opt/desc_sroa.cpp
@@ -14,7 +14,7 @@
 
 #include "source/opt/desc_sroa.h"
 
-#include <source/util/string_utils.h>
+#include "source/util/string_utils.h"
 
 namespace spvtools {
 namespace opt {


### PR DESCRIPTION
Including source/util/string_utils.h always uses
"source/util/string_utils.h" instead of
<source/util/string_utils.h>.