### PR TITLE
Add missing files to BUILD.gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -729,6 +729,8 @@ static_library("spvtools_reduce") {
     "source/reduce/remove_instruction_reduction_opportunity.h",
     "source/reduce/remove_opname_instruction_reduction_opportunity_finder.cpp",
     "source/reduce/remove_opname_instruction_reduction_opportunity_finder.h",
+    "source/reduce/remove_relaxed_precision_decoration_opportunity_finder.cpp",
+    "source/reduce/remove_relaxed_precision_decoration_opportunity_finder.h",
     "source/reduce/remove_selection_reduction_opportunity.cpp",
     "source/reduce/remove_selection_reduction_opportunity.h",
     "source/reduce/remove_selection_reduction_opportunity_finder.cpp",


### PR DESCRIPTION
New files missing from BUILD.gn caused build failures in Chromium and
ANGLE:
remove_relaxed_precision_decoration_opportunity_finder.cpp
remove_relaxed_precision_decoration_opportunity_finder.h