### PR TITLE
Amd ext to khr

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -75,6 +75,7 @@ SPVTOOLS_SRC_FILES := \
 
 SPVTOOLS_OPT_SRC_FILES := \
 		source/opt/aggressive_dead_code_elim_pass.cpp \
+		sourc/opt/amd_ext_to_khr.cpp
 		source/opt/basic_block.cpp \
 		source/opt/block_merge_pass.cpp \
 		source/opt/block_merge_util.cpp \

--- a/Android.mk
+++ b/Android.mk
@@ -75,7 +75,7 @@ SPVTOOLS_SRC_FILES := \
 
 SPVTOOLS_OPT_SRC_FILES := \
 		source/opt/aggressive_dead_code_elim_pass.cpp \
-		sourc/opt/amd_ext_to_khr.cpp \
+		source/opt/amd_ext_to_khr.cpp \
 		source/opt/basic_block.cpp \
 		source/opt/block_merge_pass.cpp \
 		source/opt/block_merge_util.cpp \

--- a/Android.mk
+++ b/Android.mk
@@ -75,7 +75,7 @@ SPVTOOLS_SRC_FILES := \
 
 SPVTOOLS_OPT_SRC_FILES := \
 		source/opt/aggressive_dead_code_elim_pass.cpp \
-		sourc/opt/amd_ext_to_khr.cpp
+		sourc/opt/amd_ext_to_khr.cpp \
 		source/opt/basic_block.cpp \
 		source/opt/block_merge_pass.cpp \
 		source/opt/block_merge_util.cpp \

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -451,6 +451,8 @@ static_library("spvtools_opt") {
   sources = [
     "source/opt/aggressive_dead_code_elim_pass.cpp",
     "source/opt/aggressive_dead_code_elim_pass.h",
+    "source/opt/amd_ext_to_khr.cpp",
+    "source/opt/amd_ext_to_khr.h",
     "source/opt/basic_block.cpp",
     "source/opt/basic_block.h",
     "source/opt/block_merge_pass.cpp",

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -823,6 +823,11 @@ Optimizer::PassToken CreateDescriptorScalarReplacementPass();
 // function that has a single OpKill.  This allows more code to be inlined.
 Optimizer::PassToken CreateWrapOpKillPass();
 
+// Replaces the extensions VK_AMD_shader_ballot,VK_AMD_gcn_shader, and
+// VK_AMD_shader_trinary_minmax with equivalant code using core instructions and
+// capabilities.
+Optimizer::PassToken CreateAmdExtToKhrPass();
+
 }  // namespace spvtools
 
 #endif  // INCLUDE_SPIRV_TOOLS_OPTIMIZER_HPP_

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -824,7 +824,7 @@ Optimizer::PassToken CreateDescriptorScalarReplacementPass();
 Optimizer::PassToken CreateWrapOpKillPass();
 
 // Replaces the extensions VK_AMD_shader_ballot,VK_AMD_gcn_shader, and
-// VK_AMD_shader_trinary_minmax with equivalant code using core instructions and
+// VK_AMD_shader_trinary_minmax with equivalent code using core instructions and
 // capabilities.
 Optimizer::PassToken CreateAmdExtToKhrPass();
 

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -13,6 +13,7 @@
 # limitations under the License.
 set(SPIRV_TOOLS_OPT_SOURCES
   aggressive_dead_code_elim_pass.h
+  amd_ext_to_khr.h
   basic_block.h
   block_merge_pass.h
   block_merge_util.h
@@ -117,6 +118,7 @@ set(SPIRV_TOOLS_OPT_SOURCES
   wrap_opkill.h
 
   aggressive_dead_code_elim_pass.cpp
+  amd_ext_to_khr.cpp
   basic_block.cpp
   block_merge_pass.cpp
   block_merge_util.cpp

--- a/source/opt/amd_ext_to_khr.cpp
+++ b/source/opt/amd_ext_to_khr.cpp
@@ -299,6 +299,9 @@ Pass::Status AmdExtensionToKhrPass::Process() {
     changed = true;
   }
 
+  // The replacements that take place use instructions that are missing before
+  // SPIR-V 1.3. If we changed something, we will have to make sure the version
+  // is at least SPIR-V 1.3 to make sure those instruction can be used.
   if (changed) {
     uint32_t version = get_module()->version();
     if (version < 0x00010300 /*1.3*/) {

--- a/source/opt/amd_ext_to_khr.cpp
+++ b/source/opt/amd_ext_to_khr.cpp
@@ -1,0 +1,241 @@
+// Copyright (c) 2019 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/opt/amd_ext_to_khr.h"
+
+#include "ir_builder.h"
+#include "source/opt/ir_context.h"
+#include "spv-amd-shader-ballot.insts.inc"
+#include "type_manager.h"
+
+namespace spvtools {
+namespace opt {
+
+namespace {
+
+enum ExtOpcodes {
+  AmdShaderBallotSwizzleInvocationsAMD = 1,
+  AmdShaderBallotSwizzleInvocationsMaskedAMD = 2,
+  AmdShaderBallotWriteInvocationAMD = 3,
+  AmdShaderBallotMbcntAMD = 4
+};
+
+analysis::Type* GetUIntType(IRContext* ctx) {
+  analysis::Integer int_type(32, false);
+  return ctx->get_type_mgr()->GetRegisteredType(&int_type);
+}
+
+FoldingRule ReplaceOpCode(SpvOp new_opcode) {
+  return [new_opcode](IRContext* ctx, Instruction* inst,
+                      const std::vector<const analysis::Constant*>&) {
+    ctx->AddCapability(SpvCapabilityGroupNonUniformArithmetic);
+    inst->SetOpcode(new_opcode);
+    return true;
+  };
+}
+
+FoldingRule NotImplementedYet() {
+  return [](IRContext*, Instruction*,
+            const std::vector<const analysis::Constant*>&) {
+    assert(false && "Replacement not implemented yet.");
+    return false;
+  };
+}
+
+FoldingRule ReplaceWriteInvocation() {
+  return [](IRContext* ctx, Instruction* inst,
+            const std::vector<const analysis::Constant*>&) {
+    uint32_t var_id =
+        ctx->GetBuiltinInputVarId(SpvBuiltInSubgroupLocalInvocationId);
+    ctx->AddCapability(SpvCapabilitySubgroupBallotKHR);
+    ctx->AddExtension("SPV_KHR_shader_ballot");
+    assert(var_id != 0 && "Could not get SubgroupLocalInvocationId variable.");
+    Instruction* var_inst = ctx->get_def_use_mgr()->GetDef(var_id);
+    Instruction* var_ptr_type =
+        ctx->get_def_use_mgr()->GetDef(var_inst->type_id());
+
+    InstructionBuilder ir_builder(
+        ctx, inst,
+        IRContext::kAnalysisDefUse | IRContext::kAnalysisInstrToBlockMapping);
+    Instruction* t =
+        ir_builder.AddLoad(var_ptr_type->GetSingleWordInOperand(1), var_id);
+    analysis::Bool bool_type;
+    uint32_t bool_type_id = ctx->get_type_mgr()->GetTypeInstruction(&bool_type);
+    Instruction* cmp =
+        ir_builder.AddBinaryOp(bool_type_id, SpvOpIEqual, t->result_id(),
+                               inst->GetSingleWordInOperand(4));
+
+    // Build a select.
+    inst->SetOpcode(SpvOpSelect);
+    Instruction::OperandList new_operands;
+    new_operands.push_back({SPV_OPERAND_TYPE_ID, {cmp->result_id()}});
+    new_operands.push_back(inst->GetInOperand(3));
+    new_operands.push_back(inst->GetInOperand(2));
+
+    inst->SetInOperands(std::move(new_operands));
+    ctx->UpdateDefUse(inst);
+    return true;
+  };
+}
+
+FoldingRule ReplaceMbcnt() {
+  return [](IRContext* context, Instruction* inst,
+            const std::vector<const analysis::Constant*>&) {
+    analysis::TypeManager* type_mgr = context->get_type_mgr();
+    analysis::DefUseManager* def_use_mgr = context->get_def_use_mgr();
+
+    uint32_t var_id = context->GetBuiltinInputVarId(SpvBuiltInSubgroupLtMask);
+    assert(var_id != 0 && "Could not get SubgroupLtMask variable.");
+    context->AddCapability(SpvCapabilityGroupNonUniformBallot);
+    Instruction* var_inst = def_use_mgr->GetDef(var_id);
+    Instruction* var_ptr_type = def_use_mgr->GetDef(var_inst->type_id());
+    Instruction* var_type =
+        def_use_mgr->GetDef(var_ptr_type->GetSingleWordInOperand(1));
+    assert(var_type->opcode() == SpvOpTypeVector &&
+           "Variable is suppose to be a vector of 4 ints");
+
+    // Get the type for the shuffle.
+    analysis::Vector temp_type(GetUIntType(context), 2);
+    const analysis::Type* shuffle_type =
+        context->get_type_mgr()->GetRegisteredType(&temp_type);
+    uint32_t shuffle_type_id = type_mgr->GetTypeInstruction(shuffle_type);
+
+    uint32_t mask_id = inst->GetSingleWordInOperand(2);
+    Instruction* mask_inst = def_use_mgr->GetDef(mask_id);
+
+    // Testing with amd's shader compiler shows that a 64-bit mask is expected.
+    assert(type_mgr->GetType(mask_inst->type_id())->AsInteger() != nullptr);
+    assert(type_mgr->GetType(mask_inst->type_id())->AsInteger()->width() == 64);
+
+    InstructionBuilder ir_builder(
+        context, inst,
+        IRContext::kAnalysisDefUse | IRContext::kAnalysisInstrToBlockMapping);
+    Instruction* load = ir_builder.AddLoad(var_type->result_id(), var_id);
+    Instruction* shuffle = ir_builder.AddVectorShuffle(
+        shuffle_type_id, load->result_id(), load->result_id(), {0, 1});
+    Instruction* bitcast = ir_builder.AddUnaryOp(
+        mask_inst->type_id(), SpvOpBitcast, shuffle->result_id());
+    Instruction* t = ir_builder.AddBinaryOp(
+        mask_inst->type_id(), SpvOpBitwiseAnd, bitcast->result_id(), mask_id);
+
+    inst->SetOpcode(SpvOpBitCount);
+    inst->SetInOperands({{SPV_OPERAND_TYPE_ID, {t->result_id()}}});
+    context->UpdateDefUse(inst);
+    return true;
+  };
+}
+
+class AmdExtFoldingRules : public FoldingRules {
+ public:
+  explicit AmdExtFoldingRules(IRContext* ctx) : FoldingRules(ctx) {}
+
+ protected:
+  virtual void AddFoldingRules() override {
+    rules_[SpvOpGroupIAddNonUniformAMD].push_back(
+        ReplaceOpCode(SpvOpGroupNonUniformIAdd));
+    rules_[SpvOpGroupFAddNonUniformAMD].push_back(
+        ReplaceOpCode(SpvOpGroupNonUniformFAdd));
+    rules_[SpvOpGroupUMinNonUniformAMD].push_back(
+        ReplaceOpCode(SpvOpGroupNonUniformUMin));
+    rules_[SpvOpGroupSMinNonUniformAMD].push_back(
+        ReplaceOpCode(SpvOpGroupNonUniformSMin));
+    rules_[SpvOpGroupFMinNonUniformAMD].push_back(
+        ReplaceOpCode(SpvOpGroupNonUniformFMin));
+    rules_[SpvOpGroupUMaxNonUniformAMD].push_back(
+        ReplaceOpCode(SpvOpGroupNonUniformUMax));
+    rules_[SpvOpGroupSMaxNonUniformAMD].push_back(
+        ReplaceOpCode(SpvOpGroupNonUniformSMax));
+    rules_[SpvOpGroupFMaxNonUniformAMD].push_back(
+        ReplaceOpCode(SpvOpGroupNonUniformFMax));
+
+    uint32_t extension_id =
+        context()->module()->GetExtInstImportId("SPV_AMD_shader_ballot");
+
+    ext_rules_[{extension_id, AmdShaderBallotSwizzleInvocationsAMD}].push_back(
+        NotImplementedYet());
+    ext_rules_[{extension_id, AmdShaderBallotSwizzleInvocationsMaskedAMD}]
+        .push_back(NotImplementedYet());
+    ext_rules_[{extension_id, AmdShaderBallotWriteInvocationAMD}].push_back(
+        ReplaceWriteInvocation());
+    ext_rules_[{extension_id, AmdShaderBallotMbcntAMD}].push_back(
+        ReplaceMbcnt());
+  }
+};
+
+class AmdExtConstFoldingRules : public ConstantFoldingRules {
+ public:
+  AmdExtConstFoldingRules(IRContext* ctx) : ConstantFoldingRules(ctx) {}
+
+ protected:
+  virtual void AddFoldingRules() override {}
+};
+
+}  // namespace
+
+Pass::Status AmdExtensionToKhrPass::Process() {
+  bool changed = false;
+
+  // Traverse the body of the functions to replace instructions that require
+  // the extensions.
+  InstructionFolder folder(
+      context(),
+      std::unique_ptr<AmdExtFoldingRules>(new AmdExtFoldingRules(context())),
+      MakeUnique<AmdExtConstFoldingRules>(context()));
+  for (Function& func : *get_module()) {
+    func.ForEachInst([&changed, &folder](Instruction* inst) {
+      if (folder.FoldInstruction(inst)) {
+        changed = true;
+      }
+    });
+  }
+
+  // Now that instruction that require the extensions have been removed, we can
+  // remove the extension instructions.
+  std::vector<Instruction*> to_be_killed;
+  for (Instruction& inst : context()->module()->extensions()) {
+    if (inst.opcode() == SpvOpExtension) {
+      if (!strcmp("SPV_AMD_shader_ballot",
+                  reinterpret_cast<const char*>(
+                      &(inst.GetInOperand(0).words[0])))) {
+        to_be_killed.push_back(&inst);
+      }
+    }
+  }
+
+  for (Instruction& inst : context()->ext_inst_imports()) {
+    if (inst.opcode() == SpvOpExtInstImport) {
+      if (!strcmp("SPV_AMD_shader_ballot",
+                  reinterpret_cast<const char*>(
+                      &(inst.GetInOperand(0).words[0])))) {
+        to_be_killed.push_back(&inst);
+      }
+    }
+  }
+
+  for (Instruction* inst : to_be_killed) {
+    context()->KillInst(inst);
+    changed = true;
+  }
+
+  if (changed) {
+    uint32_t version = get_module()->version();
+    if (version < 0x00010300 /*1.3*/) {
+      get_module()->set_version(0x00010300);
+    }
+  }
+  return changed ? Status::SuccessWithChange : Status::SuccessWithoutChange;
+}
+
+}  // namespace opt
+}  // namespace spvtools

--- a/source/opt/amd_ext_to_khr.cpp
+++ b/source/opt/amd_ext_to_khr.cpp
@@ -98,8 +98,8 @@ FoldingRule NotImplementedYet() {
 // with
 //
 //     %id = OpLoad %uint %SubgroupLocalInvocationId
-//    %cmp = OpIEqual %bool %21 %invocation_index
-// %result = OpSelect %type %23 %write_value %input_value
+//    %cmp = OpIEqual %bool %id %invocation_index
+// %result = OpSelect %type %cmp %write_value %input_value
 //
 // Also adding the capabilities and builtins that are needed.
 FoldingRule ReplaceWriteInvocation() {
@@ -151,13 +151,13 @@ FoldingRule ReplaceWriteInvocation() {
 // AMD's shader compiler expects a 64-bit integer mask.
 //
 //     %var = OpLoad %v4uint %SubgroupLtMaskKHR
-// %shuffle = OpVectorShuffle %v2uint %24 %24 0 1
-//    %cast = OpBitcast %ulong %25
+// %shuffle = OpVectorShuffle %v2uint %var %var 0 1
+//    %cast = OpBitcast %ulong %shuffle
 //
 // Perform the mask and count the bits.
 //
-//     %and = OpBitwiseAnd %ulong %26 %mask
-//  %result = OpBitCount %uint %27
+//     %and = OpBitwiseAnd %ulong %cast %mask
+//  %result = OpBitCount %uint %and
 //
 // Also adding the capabilities and builtins that are needed.
 FoldingRule ReplaceMbcnt() {

--- a/source/opt/amd_ext_to_khr.cpp
+++ b/source/opt/amd_ext_to_khr.cpp
@@ -51,8 +51,9 @@ FoldingRule ReplaceGroupNonuniformOperationOpCode(SpvOp new_opcode) {
     case SpvOpGroupNonUniformFMax:
       break;
     default:
-      assert(false &&
-             "Should replacing with a group non uniform arithmetic operation.");
+      assert(
+          false &&
+          "Should be replacing with a group non uniform arithmetic operation.");
   }
 
   return [new_opcode](IRContext* ctx, Instruction* inst,
@@ -69,7 +70,7 @@ FoldingRule ReplaceGroupNonuniformOperationOpCode(SpvOp new_opcode) {
         break;
       default:
         assert(false &&
-               "Should replacing a group non uniform arithmetic operation.");
+               "Should be replacing a group non uniform arithmetic operation.");
     }
 
     ctx->AddCapability(SpvCapabilityGroupNonUniformArithmetic);

--- a/source/opt/amd_ext_to_khr.h
+++ b/source/opt/amd_ext_to_khr.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2019 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_OPT_AMD_EXT_TO_KHR_H_
+#define SOURCE_OPT_AMD_EXT_TO_KHR_H_
+
+#include "source/opt/ir_context.h"
+#include "source/opt/module.h"
+#include "source/opt/pass.h"
+
+namespace spvtools {
+namespace opt {
+
+// Replaces the extensions VK_AMD_shader_ballot,VK_AMD_gcn_shader, and
+// VK_AMD_shader_trinary_minmax with equivalant code using core instructions and
+// capabilities.
+class AmdExtensionToKhrPass : public Pass {
+ public:
+  const char* name() const override { return "amd-ext-to-khr"; }
+  Status Process() override;
+
+  IRContext::Analysis GetPreservedAnalyses() override {
+    return IRContext::kAnalysisInstrToBlockMapping |
+           IRContext::kAnalysisDecorations | IRContext::kAnalysisCombinators |
+           IRContext::kAnalysisCFG | IRContext::kAnalysisDominatorAnalysis |
+           IRContext::kAnalysisLoopAnalysis | IRContext::kAnalysisNameMap |
+           IRContext::kAnalysisScalarEvolution |
+           IRContext::kAnalysisRegisterPressure |
+           IRContext::kAnalysisValueNumberTable |
+           IRContext::kAnalysisStructuredCFG |
+           IRContext::kAnalysisBuiltinVarId |
+           IRContext::kAnalysisIdToFuncMapping | IRContext::kAnalysisTypes |
+           IRContext::kAnalysisDefUse | IRContext::kAnalysisConstants;
+  }
+};
+
+}  // namespace opt
+}  // namespace spvtools
+
+#endif  // SOURCE_OPT_AMD_EXT_TO_KHR_H_

--- a/source/opt/amd_ext_to_khr.h
+++ b/source/opt/amd_ext_to_khr.h
@@ -22,7 +22,7 @@
 namespace spvtools {
 namespace opt {
 
-// Replaces the extensions VK_AMD_shader_ballot,VK_AMD_gcn_shader, and
+// Replaces the extensions VK_AMD_shader_ballot, VK_AMD_gcn_shader, and
 // VK_AMD_shader_trinary_minmax with equivalant code using core instructions and
 // capabilities.
 class AmdExtensionToKhrPass : public Pass {

--- a/source/opt/instrument_pass.cpp
+++ b/source/opt/instrument_pass.cpp
@@ -451,15 +451,7 @@ analysis::Type* InstrumentPass::GetUintRuntimeArrayType(uint32_t width) {
 void InstrumentPass::AddStorageBufferExt() {
   if (storage_buffer_ext_defined_) return;
   if (!get_feature_mgr()->HasExtension(kSPV_KHR_storage_buffer_storage_class)) {
-    const std::string ext_name("SPV_KHR_storage_buffer_storage_class");
-    const auto num_chars = ext_name.size();
-    // Compute num words, accommodate the terminating null character.
-    const auto num_words = (num_chars + 1 + 3) / 4;
-    std::vector<uint32_t> ext_words(num_words, 0u);
-    std::memcpy(ext_words.data(), ext_name.data(), num_chars);
-    context()->AddExtension(std::unique_ptr<Instruction>(
-        new Instruction(context(), SpvOpExtension, 0u, 0u,
-                        {{SPV_OPERAND_TYPE_LITERAL_STRING, ext_words}})));
+    context()->AddExtension("SPV_KHR_storage_buffer_storage_class");
   }
   storage_buffer_ext_defined_ = true;
 }

--- a/source/opt/ir_builder.h
+++ b/source/opt/ir_builder.h
@@ -482,6 +482,26 @@ class InstructionBuilder {
     return AddInstruction(std::move(new_inst));
   }
 
+  Instruction* AddVectorShuffle(uint32_t result_type, uint32_t vec1,
+                                uint32_t vec2,
+                                const std::vector<uint32_t>& components) {
+    std::vector<Operand> operands;
+    operands.push_back({SPV_OPERAND_TYPE_ID, {vec1}});
+    operands.push_back({SPV_OPERAND_TYPE_ID, {vec2}});
+    for (uint32_t id : components) {
+      operands.push_back({SPV_OPERAND_TYPE_LITERAL_INTEGER, {id}});
+    }
+
+    uint32_t result_id = GetContext()->TakeNextId();
+    if (result_id == 0) {
+      return nullptr;
+    }
+
+    std::unique_ptr<Instruction> new_inst(new Instruction(
+        GetContext(), SpvOpVectorShuffle, result_type, result_id, operands));
+    return AddInstruction(std::move(new_inst));
+  }
+
   // Inserts the new instruction before the insertion point.
   Instruction* AddInstruction(std::unique_ptr<Instruction>&& insn) {
     Instruction* insn_ptr = &*insert_before_.InsertBefore(std::move(insn));

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -258,7 +258,6 @@ bool IRContext::IsConsistent() {
 #ifndef SPIRV_CHECK_CONTEXT
   return true;
 #endif
-
   if (AreAnalysesValid(kAnalysisDefUse)) {
     analysis::DefUseManager new_def_use(module());
     if (*get_def_use_mgr() != new_def_use) {
@@ -702,7 +701,8 @@ uint32_t IRContext::GetBuiltinInputVarId(uint32_t builtin) {
       case SpvBuiltInVertexIndex:
       case SpvBuiltInInstanceIndex:
       case SpvBuiltInPrimitiveId:
-      case SpvBuiltInInvocationId: {
+      case SpvBuiltInInvocationId:
+      case SpvBuiltInSubgroupLocalInvocationId: {
         analysis::Integer uint_ty(32, false);
         reg_type = type_mgr->GetRegisteredType(&uint_ty);
         break;
@@ -720,6 +720,13 @@ uint32_t IRContext::GetBuiltinInputVarId(uint32_t builtin) {
         analysis::Type* reg_float_ty = type_mgr->GetRegisteredType(&float_ty);
         analysis::Vector v3float_ty(reg_float_ty, 3);
         reg_type = type_mgr->GetRegisteredType(&v3float_ty);
+        break;
+      }
+      case SpvBuiltInSubgroupLtMask: {
+        analysis::Integer uint_ty(32, false);
+        analysis::Type* reg_uint_ty = type_mgr->GetRegisteredType(&uint_ty);
+        analysis::Vector v4uint_ty(reg_uint_ty, 4);
+        reg_type = type_mgr->GetRegisteredType(&v4uint_ty);
         break;
       }
       default: {

--- a/source/opt/ir_context.h
+++ b/source/opt/ir_context.h
@@ -190,9 +190,13 @@ class IRContext {
   // Clears all debug instructions (excluding OpLine & OpNoLine).
   inline void debug_clear();
 
+  // Add |capability| to the module, if it is not already enabled.
+  inline void AddCapability(SpvCapability capability);
+
   // Appends a capability instruction to this module.
   inline void AddCapability(std::unique_ptr<Instruction>&& c);
   // Appends an extension instruction to this module.
+  inline void AddExtension(const std::string& ext_name);
   inline void AddExtension(std::unique_ptr<Instruction>&& e);
   // Appends an extended instruction set instruction to this module.
   inline void AddExtInstImport(std::unique_ptr<Instruction>&& e);
@@ -925,13 +929,36 @@ IteratorRange<Module::const_inst_iterator> IRContext::debugs3() const {
 
 void IRContext::debug_clear() { module_->debug_clear(); }
 
+void IRContext::AddCapability(SpvCapability capability) {
+  if (!get_feature_mgr()->HasCapability(capability)) {
+    std::unique_ptr<Instruction> capability_inst(
+        new Instruction(this, SpvOpCapability, 0, 0,
+                        {{SPV_OPERAND_TYPE_CAPABILITY, {capability}}}));
+    AddCapability(std::move(capability_inst));
+  }
+}
+
 void IRContext::AddCapability(std::unique_ptr<Instruction>&& c) {
   AddCombinatorsForCapability(c->GetSingleWordInOperand(0));
   if (feature_mgr_ != nullptr) {
     feature_mgr_->AddCapability(
         static_cast<SpvCapability>(c->GetSingleWordInOperand(0)));
   }
+  if (AreAnalysesValid(kAnalysisDefUse)) {
+    get_def_use_mgr()->AnalyzeInstDefUse(c.get());
+  }
   module()->AddCapability(std::move(c));
+}
+
+void IRContext::AddExtension(const std::string& ext_name) {
+  const auto num_chars = ext_name.size();
+  // Compute num words, accommodate the terminating null character.
+  const auto num_words = (num_chars + 1 + 3) / 4;
+  std::vector<uint32_t> ext_words(num_words, 0u);
+  std::memcpy(ext_words.data(), ext_name.data(), num_chars);
+  AddExtension(std::unique_ptr<Instruction>(
+      new Instruction(this, SpvOpExtension, 0u, 0u,
+                      {{SPV_OPERAND_TYPE_LITERAL_STRING, ext_words}})));
 }
 
 void IRContext::AddExtension(std::unique_ptr<Instruction>&& e) {

--- a/source/opt/ir_context.h
+++ b/source/opt/ir_context.h
@@ -931,9 +931,9 @@ void IRContext::debug_clear() { module_->debug_clear(); }
 
 void IRContext::AddCapability(SpvCapability capability) {
   if (!get_feature_mgr()->HasCapability(capability)) {
-    std::unique_ptr<Instruction> capability_inst(
-        new Instruction(this, SpvOpCapability, 0, 0,
-                        {{SPV_OPERAND_TYPE_CAPABILITY, {capability}}}));
+    std::unique_ptr<Instruction> capability_inst(new Instruction(
+        this, SpvOpCapability, 0, 0,
+        {{SPV_OPERAND_TYPE_CAPABILITY, {static_cast<uint32_t>(capability)}}}));
     AddCapability(std::move(capability_inst));
   }
 }

--- a/source/opt/module.h
+++ b/source/opt/module.h
@@ -133,6 +133,8 @@ class Module {
 
   inline uint32_t version() const { return header_.version; }
 
+  inline void set_version(uint32_t v) { header_.version = v; }
+
   // Iterators for capabilities instructions contained in this module.
   inline inst_iterator capability_begin();
   inline inst_iterator capability_end();

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -492,6 +492,8 @@ bool Optimizer::RegisterPassFromFlag(const std::string& flag) {
     RegisterPass(CreateGraphicsRobustAccessPass());
   } else if (pass_name == "wrap-opkill") {
     RegisterPass(CreateWrapOpKillPass());
+  } else if (pass_name == "amd-ext-to-khr") {
+    RegisterPass(CreateAmdExtToKhrPass());
   } else {
     Errorf(consumer(), nullptr, {},
            "Unknown flag '--%s'. Use --help for a list of valid flags",
@@ -917,6 +919,11 @@ Optimizer::PassToken CreateDescriptorScalarReplacementPass() {
 
 Optimizer::PassToken CreateWrapOpKillPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(MakeUnique<opt::WrapOpKill>());
+}
+
+Optimizer::PassToken CreateAmdExtToKhrPass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::AmdExtensionToKhrPass>());
 }
 
 }  // namespace spvtools

--- a/source/opt/pass.h
+++ b/source/opt/pass.h
@@ -26,6 +26,7 @@
 #include "source/opt/ir_context.h"
 #include "source/opt/module.h"
 #include "spirv-tools/libspirv.hpp"
+#include "types.h"
 
 namespace spvtools {
 namespace opt {

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -18,6 +18,7 @@
 // A single header to include all passes.
 
 #include "source/opt/aggressive_dead_code_elim_pass.h"
+#include "source/opt/amd_ext_to_khr.h"
 #include "source/opt/block_merge_pass.h"
 #include "source/opt/ccp_pass.h"
 #include "source/opt/cfg_cleanup_pass.h"

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -17,6 +17,7 @@ add_subdirectory(loop_optimizations)
 
 add_spvtools_unittest(TARGET opt
   SRCS aggressive_dead_code_elim_test.cpp
+       amd_ext_to_khr.cpp
        assembly_builder_test.cpp
        block_merge_test.cpp
        ccp_test.cpp

--- a/test/opt/amd_ext_to_khr.cpp
+++ b/test/opt/amd_ext_to_khr.cpp
@@ -1,0 +1,240 @@
+// Copyright (c) 2019 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+
+#include "gmock/gmock.h"
+
+#include "test/opt/pass_fixture.h"
+#include "test/opt/pass_utils.h"
+
+namespace spvtools {
+namespace opt {
+namespace {
+
+using AmdExtToKhrTest = PassTest<::testing::Test>;
+
+using ::testing::HasSubstr;
+
+std::string GetTest(std::string op_code, std::string new_op_code) {
+  const std::string text = R"(
+; CHECK: OpCapability Shader
+; CHECK-NOT: OpExtension "SPV_AMD_shader_ballot"
+; CHECK: OpFunction
+; CHECK-NEXT: OpLabel
+; CHECK-NEXT: [[undef:%\w+]] = OpUndef %uint
+; CHECK-NEXT: )" + new_op_code +
+                           R"( %uint %uint_3 Reduce [[undef]]
+               OpCapability Shader
+               OpCapability Groups
+               OpExtension "SPV_AMD_shader_ballot"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %1 "func"
+               OpExecutionMode %1 OriginUpperLeft
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %uint_3 = OpConstant %uint 3
+          %1 = OpFunction %void None %3
+          %6 = OpLabel
+          %7 = OpUndef %uint
+          %8 = )" + op_code +
+                           R"( %uint %uint_3 Reduce %7
+               OpReturn
+               OpFunctionEnd
+
+)";
+  return text;
+}
+
+TEST_F(AmdExtToKhrTest, ReplaceGroupIAddNonUniformAMD) {
+  std::string text =
+      GetTest("OpGroupIAddNonUniformAMD", "OpGroupNonUniformIAdd");
+  SinglePassRunAndMatch<AmdExtensionToKhrPass>(text, true);
+}
+TEST_F(AmdExtToKhrTest, ReplaceGroupFAddNonUniformAMD) {
+  std::string text =
+      GetTest("OpGroupFAddNonUniformAMD", "OpGroupNonUniformFAdd");
+  SinglePassRunAndMatch<AmdExtensionToKhrPass>(text, true);
+}
+TEST_F(AmdExtToKhrTest, ReplaceGroupUMinNonUniformAMD) {
+  std::string text =
+      GetTest("OpGroupUMinNonUniformAMD", "OpGroupNonUniformUMin");
+  SinglePassRunAndMatch<AmdExtensionToKhrPass>(text, true);
+}
+TEST_F(AmdExtToKhrTest, ReplaceGroupSMinNonUniformAMD) {
+  std::string text =
+      GetTest("OpGroupSMinNonUniformAMD", "OpGroupNonUniformSMin");
+  SinglePassRunAndMatch<AmdExtensionToKhrPass>(text, true);
+}
+TEST_F(AmdExtToKhrTest, ReplaceGroupFMinNonUniformAMD) {
+  std::string text =
+      GetTest("OpGroupFMinNonUniformAMD", "OpGroupNonUniformFMin");
+  SinglePassRunAndMatch<AmdExtensionToKhrPass>(text, true);
+}
+TEST_F(AmdExtToKhrTest, ReplaceGroupUMaxNonUniformAMD) {
+  std::string text =
+      GetTest("OpGroupUMaxNonUniformAMD", "OpGroupNonUniformUMax");
+  SinglePassRunAndMatch<AmdExtensionToKhrPass>(text, true);
+}
+TEST_F(AmdExtToKhrTest, ReplaceGroupSMaxNonUniformAMD) {
+  std::string text =
+      GetTest("OpGroupSMaxNonUniformAMD", "OpGroupNonUniformSMax");
+  SinglePassRunAndMatch<AmdExtensionToKhrPass>(text, true);
+}
+TEST_F(AmdExtToKhrTest, ReplaceGroupFMaxNonUniformAMD) {
+  std::string text =
+      GetTest("OpGroupFMaxNonUniformAMD", "OpGroupNonUniformFMax");
+  SinglePassRunAndMatch<AmdExtensionToKhrPass>(text, true);
+}
+
+TEST_F(AmdExtToKhrTest, ReplaceMbcntAMD) {
+  const std::string text = R"(
+; CHECK: OpCapability Shader
+; CHECK-NOT: OpExtension "SPV_AMD_shader_ballot"
+; CHECK-NOT: OpExtInstImport "SPV_AMD_shader_ballot"
+; CHECK: OpDecorate [[var:%\w+]] BuiltIn SubgroupLtMask
+; CHECK: [[var]] = OpVariable %_ptr_Input_v4uint Input
+; CHECK: OpFunction
+; CHECK-NEXT: OpLabel
+; CHECK-NEXT: [[ld:%\w+]] = OpLoad %v4uint [[var]]
+; CHECK-NEXT: [[shuffle:%\w+]] = OpVectorShuffle %v2uint [[ld]] [[ld]] 0 1
+; CHECK-NEXT: [[bitcast:%\w+]] = OpBitcast %ulong [[shuffle]]
+; CHECK-NEXT: [[and:%\w+]] = OpBitwiseAnd %ulong [[bitcast]] %ulong_0
+; CHECK-NEXT: [[result:%\w+]] = OpBitCount %uint [[and]]
+               OpCapability Shader
+               OpCapability Int64
+               OpExtension "SPV_AMD_shader_ballot"
+          %1 = OpExtInstImport "SPV_AMD_shader_ballot"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "func"
+               OpExecutionMode %2 OriginUpperLeft
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+      %ulong = OpTypeInt 64 0
+    %ulong_0 = OpConstant %ulong 0
+          %2 = OpFunction %void None %4
+          %8 = OpLabel
+          %9 = OpExtInst %uint %1 MbcntAMD %ulong_0
+               OpReturn
+               OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<AmdExtensionToKhrPass>(text, true);
+}
+
+TEST_F(AmdExtToKhrTest, ReplaceWriteInvocationAMD) {
+  const std::string text = R"(
+; CHECK: OpCapability Shader
+; CHECK-NOT: OpExtension "SPV_AMD_shader_ballot"
+; CHECK-NOT: OpExtInstImport "SPV_AMD_shader_ballot"
+; CHECK: OpDecorate [[var:%\w+]] BuiltIn SubgroupLocalInvocationId
+; CHECK: [[var]] = OpVariable %_ptr_Input_uint Input
+; CHECK: OpFunction
+; CHECK-NEXT: OpLabel
+; CHECK-NEXT: [[input_val:%\w+]] = OpUndef %uint
+; CHECK-NEXT: [[write_val:%\w+]] = OpUndef %uint
+; CHECK-NEXT: [[ld:%\w+]] = OpLoad %uint [[var]]
+; CHECK-NEXT: [[cmp:%\w+]] = OpIEqual %bool [[ld]] %uint_3
+; CHECK-NEXT: [[result:%\w+]] = OpSelect %uint [[cmp]] [[write_val]] [[input_val]]
+               OpCapability Shader
+               OpExtension "SPV_AMD_shader_ballot"
+        %ext = OpExtInstImport "SPV_AMD_shader_ballot"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %1 "func"
+               OpExecutionMode %1 OriginUpperLeft
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %uint_3 = OpConstant %uint 3
+          %1 = OpFunction %void None %3
+          %6 = OpLabel
+          %7 = OpUndef %uint
+          %8 = OpUndef %uint
+          %9 = OpExtInst %uint %ext WriteInvocationAMD %7 %8 %uint_3
+               OpReturn
+               OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<AmdExtensionToKhrPass>(text, true);
+}
+
+TEST_F(AmdExtToKhrTest, SetVersion) {
+  const std::string text = R"(
+               OpCapability Shader
+               OpCapability Int64
+               OpExtension "SPV_AMD_shader_ballot"
+          %1 = OpExtInstImport "SPV_AMD_shader_ballot"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "func"
+               OpExecutionMode %2 OriginUpperLeft
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+      %ulong = OpTypeInt 64 0
+    %ulong_0 = OpConstant %ulong 0
+          %2 = OpFunction %void None %4
+          %8 = OpLabel
+          %9 = OpExtInst %uint %1 MbcntAMD %ulong_0
+               OpReturn
+               OpFunctionEnd
+)";
+
+  // Set the version to 1.1 and make sure it is upgraded to 1.3.
+  SetTargetEnv(SPV_ENV_UNIVERSAL_1_1);
+  SetDisassembleOptions(0);
+  auto result = SinglePassRunAndDisassemble<AmdExtensionToKhrPass>(
+      text, /* skip_nop = */ true, /* skip_validation = */ false);
+
+  EXPECT_EQ(Pass::Status::SuccessWithChange, std::get<1>(result));
+  const std::string& output = std::get<0>(result);
+  EXPECT_THAT(output, HasSubstr("Version: 1.3"));
+}
+
+TEST_F(AmdExtToKhrTest, SetVersion1) {
+  const std::string text = R"(
+               OpCapability Shader
+               OpCapability Int64
+               OpExtension "SPV_AMD_shader_ballot"
+          %1 = OpExtInstImport "SPV_AMD_shader_ballot"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "func"
+               OpExecutionMode %2 OriginUpperLeft
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+      %ulong = OpTypeInt 64 0
+    %ulong_0 = OpConstant %ulong 0
+          %2 = OpFunction %void None %4
+          %8 = OpLabel
+          %9 = OpExtInst %uint %1 MbcntAMD %ulong_0
+               OpReturn
+               OpFunctionEnd
+)";
+
+  // Set the version to 1.4 and make sure it is stays the same.
+  SetTargetEnv(SPV_ENV_UNIVERSAL_1_4);
+  SetDisassembleOptions(0);
+  auto result = SinglePassRunAndDisassemble<AmdExtensionToKhrPass>(
+      text, /* skip_nop = */ true, /* skip_validation = */ false);
+
+  EXPECT_EQ(Pass::Status::SuccessWithChange, std::get<1>(result));
+  const std::string& output = std::get<0>(result);
+  EXPECT_THAT(output, HasSubstr("Version: 1.4"));
+}
+
+}  // namespace
+}  // namespace opt
+}  // namespace spvtools

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -109,6 +109,11 @@ NOTE: The optimizer is a work in progress.
 Options (in lexicographical order):)",
       program, program);
   printf(R"(
+  --amd-ext-to-khr
+               Replaces the extensions VK_AMD_shader_ballot,VK_AMD_gcn_shader,
+               and VK_AMD_shader_trinary_minmax with equivalant code using core
+               instructions and capabilities.)");
+  printf(R"(
   --ccp
                Apply the conditional constant propagation transform.  This will
                propagate constant values throughout the program, and simplify

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -110,7 +110,7 @@ Options (in lexicographical order):)",
       program, program);
   printf(R"(
   --amd-ext-to-khr
-               Replaces the extensions VK_AMD_shader_ballot,VK_AMD_gcn_shader,
+               Replaces the extensions VK_AMD_shader_ballot, VK_AMD_gcn_shader,
                and VK_AMD_shader_trinary_minmax with equivalant code using core
                instructions and capabilities.)");
   printf(R"(


### PR DESCRIPTION
Add the first steps to removing the AMD extension VK_AMD_shader_ballot.
Splitting up to make the PRs smaller.

Adding utilities to add capabilities and change the version of the
module.

Replaces the instructions:

OpGroupIAddNonUniformAMD = 5000
OpGroupFAddNonUniformAMD = 5001
OpGroupFMinNonUniformAMD = 5002
OpGroupUMinNonUniformAMD = 5003
OpGroupSMinNonUniformAMD = 5004
OpGroupFMaxNonUniformAMD = 5005
OpGroupUMaxNonUniformAMD = 5006
OpGroupSMaxNonUniformAMD = 5007

and extentend instructions

WriteInvocationAMD = 3
MbcntAMD = 4

Part of #2814