### PR TITLE
Fix gn check

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -660,6 +660,7 @@ static_library("spvtools_opt") {
 
   deps = [
     ":spvtools",
+    ":spvtools_vendor_tables_spv-amd-shader-ballot",
   ]
   public_deps = [
     ":spvtools_headers",


### PR DESCRIPTION
spriv-opt was missing a dependency on the AMD ballot extension that was
needed because it uses a header in the AMD ext to KHR ext pass.