### PR TITLE
AggressiveDCEPass: Set modified to true when appending to to_kill_

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -664,6 +664,9 @@ Pass::Status AggressiveDCEPass::ProcessImpl() {
   // been marked, it is safe to remove dead global values.
   modified |= ProcessGlobalValues();
 
+  // Sanity check.
+  assert(to_kill_.size() == 0 || modified);
+
   // Kill all dead instructions.
   for (auto inst : to_kill_) {
     context()->KillInst(inst);
@@ -846,6 +849,7 @@ bool AggressiveDCEPass::ProcessGlobalValues() {
         if (!IsDead(ptr_ty_inst)) continue;
       }
       to_kill_.push_back(&val);
+      modified = true;
     }
   }
 


### PR DESCRIPTION
Also add an assertion that these `modified` is true if to_kill_ has a non-zero size to catch this sort of issue in the pass.

Fixes: #2824