### PR TITLE
GN: Make SPIRV-Tools target use public_deps.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -766,7 +766,7 @@ static_library("spvtools_reduce") {
 }
 
 group("SPIRV-Tools") {
-  deps = [
+  public_deps = [
     ":spvtools",
     ":spvtools_link",
     ":spvtools_opt",


### PR DESCRIPTION
Should prevent invalid header usage warnings in dependent targets.

See http://anglebug.com/3876 for context.

@dj2 PTAL