### PR TITLE
Fix add-dead-break and add-dead-continue passes to respect dominance

### DIFF
--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -77,9 +77,7 @@ opt::BasicBlock::iterator GetIteratorForBaseInstructionAndOffset(
 // Block |bb_from| is assumed to be in a structured control flow construct, and
 // block |bb_to| is assumed to be either the merge bock for that construct (in
 // the case of a loop, conditional or switch) or the continue target for that
-// construct (in the case of a loop only). Furthermore, |construct_merge_block|
-// is the merge block of the construct (so that |construct_merge_block| will
-// often be equal to |bb_to|.
+// construct (in the case of a loop only).
 //
 // The function determines whether adding an edge from |bb_from| to |bb_to| -
 // i.e. a break or continue for the construct
@@ -87,8 +85,7 @@ opt::BasicBlock::iterator GetIteratorForBaseInstructionAndOffset(
 // dominate all of its uses.  This is because adding such an edge can change
 // dominance in the control flow graph, potentially making the module invalid.
 bool NewEdgeLeavingConstructBodyRespectsUseDefDominance(
-    opt::IRContext* context, opt::BasicBlock* bb_from, opt::BasicBlock* bb_to,
-    opt::BasicBlock* construct_merge_block);
+    opt::IRContext* context, opt::BasicBlock* bb_from, opt::BasicBlock* bb_to);
 
 }  // namespace fuzzerutil
 

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -74,6 +74,22 @@ bool BlockIsInLoopContinueConstruct(opt::IRContext* context, uint32_t block_id,
 opt::BasicBlock::iterator GetIteratorForBaseInstructionAndOffset(
     opt::BasicBlock* block, const opt::Instruction* base_inst, uint32_t offset);
 
+// Block |bb_from| is assumed to be in a structured control flow construct, and
+// block |bb_to| is assumed to be either the merge bock for that construct (in
+// the case of a loop, conditional or switch) or the continue target for that
+// construct (in the case of a loop only). Furthermore, |construct_merge_block|
+// is the merge block of the construct (so that |construct_merge_block| will
+// often be equal to |bb_to|.
+//
+// The function determines whether adding an edge from |bb_from| to |bb_to| -
+// i.e. a break or continue for the construct
+// - is legitimate with respect to the SPIR-V rule that a definition must
+// dominate all of its uses.  This is because adding such an edge can change
+// dominance in the control flow graph, potentially making the module invalid.
+bool NewEdgeLeavingConstructBodyRespectsUseDefDominance(
+    opt::IRContext* context, opt::BasicBlock* bb_from, opt::BasicBlock* bb_to,
+    opt::BasicBlock* construct_merge_block);
+
 }  // namespace fuzzerutil
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_dead_break.cpp
+++ b/source/fuzz/transformation_add_dead_break.cpp
@@ -162,9 +162,16 @@ bool TransformationAddDeadBreak::IsApplicable(
     return false;
   }
 
-  // Finally, check that adding the break would respect the rules of structured
+  // Check that adding the break would respect the rules of structured
   // control flow.
-  return AddingBreakRespectsStructuredControlFlow(context, bb_from);
+  if (!AddingBreakRespectsStructuredControlFlow(context, bb_from)) {
+    return false;
+  }
+
+  // Check that adding the break would not violate the property that a
+  // definition must dominate all of its uses.
+  return fuzzerutil::NewEdgeLeavingConstructBodyRespectsUseDefDominance(
+      context, bb_from, bb_to, bb_to);
 }
 
 void TransformationAddDeadBreak::Apply(opt::IRContext* context,

--- a/source/fuzz/transformation_add_dead_break.cpp
+++ b/source/fuzz/transformation_add_dead_break.cpp
@@ -171,7 +171,7 @@ bool TransformationAddDeadBreak::IsApplicable(
   // Check that adding the break would not violate the property that a
   // definition must dominate all of its uses.
   return fuzzerutil::NewEdgeLeavingConstructBodyRespectsUseDefDominance(
-      context, bb_from, bb_to, bb_to);
+      context, bb_from, bb_to);
 }
 
 void TransformationAddDeadBreak::Apply(opt::IRContext* context,

--- a/source/fuzz/transformation_add_dead_break.h
+++ b/source/fuzz/transformation_add_dead_break.h
@@ -48,6 +48,8 @@ class TransformationAddDeadBreak : public Transformation {
   //   the condition, and the ids in |message_.phi_ids| used to extend
   //   any OpPhi instructions at b as a result of the edge from a, must
   //   maintain validity of the module.
+  //   In particular, the new branch must not lead to violations of the rule
+  //   that a use must be dominated by its definition.
   bool IsApplicable(opt::IRContext* context,
                     const FactManager& fact_manager) const override;
 

--- a/source/fuzz/transformation_add_dead_continue.cpp
+++ b/source/fuzz/transformation_add_dead_continue.cpp
@@ -101,9 +101,7 @@ bool TransformationAddDeadContinue::IsApplicable(
   // Check that adding the continue would not violate the property that a
   // definition must dominate all of its uses.
   if (!fuzzerutil::NewEdgeLeavingConstructBodyRespectsUseDefDominance(
-          context, bb_from, context->cfg()->block(continue_block),
-          context->cfg()->block(
-              context->cfg()->block(loop_header)->MergeBlockId()))) {
+          context, bb_from, context->cfg()->block(continue_block))) {
     return false;
   }
 

--- a/source/fuzz/transformation_add_dead_continue.cpp
+++ b/source/fuzz/transformation_add_dead_continue.cpp
@@ -98,6 +98,15 @@ bool TransformationAddDeadContinue::IsApplicable(
     return false;
   }
 
+  // Check that adding the continue would not violate the property that a
+  // definition must dominate all of its uses.
+  if (!fuzzerutil::NewEdgeLeavingConstructBodyRespectsUseDefDominance(
+          context, bb_from, context->cfg()->block(continue_block),
+          context->cfg()->block(
+              context->cfg()->block(loop_header)->MergeBlockId()))) {
+    return false;
+  }
+
   // The transformation is good if and only if the given phi ids are sufficient
   // to extend relevant OpPhi instructions in the continue block.
   return fuzzerutil::PhiIdsOkForNewEdge(context, bb_from,

--- a/source/fuzz/transformation_add_dead_continue.h
+++ b/source/fuzz/transformation_add_dead_continue.h
@@ -47,6 +47,9 @@ class TransformationAddDeadContinue : public Transformation {
   //   as the condition, and the ids in |message_.phi_ids| used to extend any
   //   OpPhi instructions at b as a result of the edge from a, must maintain
   //   validity of the module.
+  //   In particular, adding an edge from somewhere in the loop to the continue
+  //   target must not prevent uses of ids in the continue target from being
+  //   dominated by the definitions of those ids.
   bool IsApplicable(opt::IRContext* context,
                     const FactManager& fact_manager) const override;
 

--- a/test/fuzz/transformation_add_dead_break_test.cpp
+++ b/test/fuzz/transformation_add_dead_break_test.cpp
@@ -2080,6 +2080,380 @@ TEST(TransformationAddDeadBreakTest, PhiInstructions) {
   ASSERT_TRUE(IsEqual(env, after_transformation, context.get()));
 }
 
+TEST(TransformationAddDeadBreakTest, RespectDominanceRules1) {
+  // Right after the loop, an OpCopyObject defined by the loop is used.  Adding
+  // a dead break would prevent that use from being dominated by its definition,
+  // so is not allowed.
+
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+         %10 = OpTypeBool
+         %11 = OpConstantFalse %10
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpBranch %100
+        %100 = OpLabel
+               OpLoopMerge %101 %102 None
+               OpBranch %103
+        %103 = OpLabel
+        %200 = OpCopyObject %10 %11
+               OpBranch %104
+        %104 = OpLabel
+               OpBranch %102
+        %102 = OpLabel
+               OpBranchConditional %11 %100 %101
+        %101 = OpLabel
+        %201 = OpCopyObject %10 %200
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+
+  auto bad_transformation = TransformationAddDeadBreak(100, 101, false, {});
+  ASSERT_FALSE(bad_transformation.IsApplicable(context.get(), fact_manager));
+}
+
+TEST(TransformationAddDeadBreakTest, RespectDominanceRules2) {
+  // This example captures the following idiom:
+  //
+  //   if {
+  // L1:
+  //   }
+  //   definition;
+  // L2:
+  //   use;
+  //
+  // Adding a dead jump from L1 to L2 would lead to 'definition' no longer
+  // dominating 'use', and so is not allowed.
+
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+         %10 = OpTypeBool
+         %11 = OpConstantFalse %10
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpBranch %100
+        %100 = OpLabel
+               OpSelectionMerge %101 None
+               OpBranchConditional %11 %102 %103
+        %102 = OpLabel
+               OpBranch %103
+        %103 = OpLabel
+        %200 = OpCopyObject %10 %11
+               OpBranch %101
+        %101 = OpLabel
+        %201 = OpCopyObject %10 %200
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+
+  auto bad_transformation = TransformationAddDeadBreak(102, 101, false, {});
+  ASSERT_FALSE(bad_transformation.IsApplicable(context.get(), fact_manager));
+}
+
+TEST(TransformationAddDeadBreakTest, RespectDominanceRules3) {
+  // Right after the loop, an OpCopyObject defined by the loop is used in an
+  // OpPhi. Adding a dead break is OK in this case, due to the use being in an
+  // OpPhi.
+
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+         %10 = OpTypeBool
+         %11 = OpConstantFalse %10
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpBranch %100
+        %100 = OpLabel
+               OpLoopMerge %101 %102 None
+               OpBranch %103
+        %103 = OpLabel
+        %200 = OpCopyObject %10 %11
+               OpBranch %104
+        %104 = OpLabel
+               OpBranch %102
+        %102 = OpLabel
+               OpBranchConditional %11 %100 %101
+        %101 = OpLabel
+        %201 = OpPhi %10 %200 %102
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+
+  auto good_transformation = TransformationAddDeadBreak(100, 101, false, {11});
+  ASSERT_TRUE(good_transformation.IsApplicable(context.get(), fact_manager));
+
+  good_transformation.Apply(context.get(), &fact_manager);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  std::string after_transformation = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+         %10 = OpTypeBool
+         %11 = OpConstantFalse %10
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpBranch %100
+        %100 = OpLabel
+               OpLoopMerge %101 %102 None
+               OpBranchConditional %11 %101 %103
+        %103 = OpLabel
+        %200 = OpCopyObject %10 %11
+               OpBranch %104
+        %104 = OpLabel
+               OpBranch %102
+        %102 = OpLabel
+               OpBranchConditional %11 %100 %101
+        %101 = OpLabel
+        %201 = OpPhi %10 %200 %102 %11 %100
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  ASSERT_TRUE(IsEqual(env, after_transformation, context.get()));
+}
+
+TEST(TransformationAddDeadBreakTest, RespectDominanceRules4) {
+  // This example captures the following idiom:
+  //
+  //   if {
+  // L1:
+  //   }
+  //   definition;
+  // L2:
+  //   use in OpPhi;
+  //
+  // Adding a dead jump from L1 to L2 is OK, due to 'use' being in an OpPhi.
+
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+         %10 = OpTypeBool
+         %11 = OpConstantFalse %10
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpBranch %100
+        %100 = OpLabel
+               OpSelectionMerge %101 None
+               OpBranchConditional %11 %102 %103
+        %102 = OpLabel
+               OpBranch %103
+        %103 = OpLabel
+        %200 = OpCopyObject %10 %11
+               OpBranch %101
+        %101 = OpLabel
+        %201 = OpPhi %10 %200 %103
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+
+  auto good_transformation = TransformationAddDeadBreak(102, 101, false, {11});
+  ASSERT_TRUE(good_transformation.IsApplicable(context.get(), fact_manager));
+
+  good_transformation.Apply(context.get(), &fact_manager);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  std::string after_transformation = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+         %10 = OpTypeBool
+         %11 = OpConstantFalse %10
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpBranch %100
+        %100 = OpLabel
+               OpSelectionMerge %101 None
+               OpBranchConditional %11 %102 %103
+        %102 = OpLabel
+               OpBranchConditional %11 %101 %103
+        %103 = OpLabel
+        %200 = OpCopyObject %10 %11
+               OpBranch %101
+        %101 = OpLabel
+        %201 = OpPhi %10 %200 %103 %11 %102
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  ASSERT_TRUE(IsEqual(env, after_transformation, context.get()));
+}
+
+TEST(TransformationAddDeadBreakTest, RespectDominanceRules5) {
+  // After, but not right after, the loop, an OpCopyObject defined by the loop
+  // is used in an OpPhi. Adding a dead break is not OK in this case.
+
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+         %10 = OpTypeBool
+         %11 = OpConstantFalse %10
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpBranch %100
+        %100 = OpLabel
+               OpLoopMerge %101 %102 None
+               OpBranch %103
+        %103 = OpLabel
+        %200 = OpCopyObject %10 %11
+               OpBranch %104
+        %104 = OpLabel
+               OpBranch %102
+        %102 = OpLabel
+               OpBranchConditional %11 %100 %101
+        %101 = OpLabel
+               OpBranch %105
+        %105 = OpLabel
+        %201 = OpPhi %10 %200 %101
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+
+  auto bad_transformation = TransformationAddDeadBreak(100, 101, false, {});
+  ASSERT_FALSE(bad_transformation.IsApplicable(context.get(), fact_manager));
+}
+
+TEST(TransformationAddDeadBreakTest, RespectDominanceRules6) {
+  // This example captures the following idiom:
+  //
+  //   if {
+  // L1:
+  //   }
+  //   definition;
+  // L2:
+  //   goto L3;
+  // L3:
+  //   use in OpPhi;
+  //
+  // Adding a dead jump from L1 to L2 not OK, due to the use in an OpPhi being
+  // in L3.
+
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+         %10 = OpTypeBool
+         %11 = OpConstantFalse %10
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpBranch %100
+        %100 = OpLabel
+               OpSelectionMerge %101 None
+               OpBranchConditional %11 %102 %103
+        %102 = OpLabel
+               OpBranch %103
+        %103 = OpLabel
+        %200 = OpCopyObject %10 %11
+               OpBranch %101
+        %101 = OpLabel
+               OpBranch %150
+        %150 = OpLabel
+        %201 = OpPhi %10 %200 %101
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+
+  auto bad_transformation = TransformationAddDeadBreak(102, 101, false, {});
+  ASSERT_FALSE(bad_transformation.IsApplicable(context.get(), fact_manager));
+}
+
 }  // namespace
 }  // namespace fuzz
 }  // namespace spvtools


### PR DESCRIPTION
The implementation of these passes had overlooked the fact that adding
a new edge to a control flow graph can change dominance information.
Adding a dead break/continue risks causing uses to no longer be
dominated by their definitions.  This change introduces various tests
to expose such scenarios, and augments the preconditions for these
transformations with checks to guard against the situation.