### PR TITLE
Rework management of probabilities in spirv-fuzz

### DIFF
--- a/source/fuzz/fuzzer_context.cpp
+++ b/source/fuzz/fuzzer_context.cpp
@@ -58,8 +58,11 @@ FuzzerContext::~FuzzerContext() = default;
 
 uint32_t FuzzerContext::GetFreshId() { return next_fresh_id_++; }
 
-RandomGenerator* FuzzerContext::GetRandomGenerator() {
-  return random_generator_;
+bool FuzzerContext::ChooseEven() { return random_generator_->RandomBool(); }
+
+bool FuzzerContext::ChoosePercentage(uint32_t percentage_chance) {
+  assert(percentage_chance <= 100);
+  return random_generator_->RandomPercentage() < percentage_chance;
 }
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_context.h
+++ b/source/fuzz/fuzzer_context.h
@@ -83,7 +83,6 @@ class FuzzerContext {
   // Keep them in alphabetical order.
   uint32_t chance_of_adding_dead_break_;
   uint32_t chance_of_adding_dead_continue_;
-  uint32_t chance_of_copying_object_;
   uint32_t chance_of_moving_block_down_;
   uint32_t chance_of_obfuscating_constant_;
   uint32_t chance_of_splitting_block_;

--- a/source/fuzz/fuzzer_context.h
+++ b/source/fuzz/fuzzer_context.h
@@ -34,8 +34,22 @@ class FuzzerContext {
 
   ~FuzzerContext();
 
-  // Provides the random generator used to control fuzzing.
-  RandomGenerator* GetRandomGenerator();
+  // Returns a random boolean.
+  bool ChooseEven();
+
+  // Returns true if and only if a randomly-chosen integer in the range [0, 100]
+  // is less than |percentage_chance|.
+  bool ChoosePercentage(uint32_t percentage_chance);
+
+  // Returns a random index into |sequence|, which is expected to have a 'size'
+  // method, and which must be non-empty.  Typically 'HasSizeMethod' will be an
+  // std::vector.
+  template <typename HasSizeMethod>
+  uint32_t RandomIndex(HasSizeMethod sequence) {
+    assert(sequence.size() > 0);
+    return random_generator_->RandomUint32(
+        static_cast<uint32_t>(sequence.size()));
+  }
 
   // Yields an id that is guaranteed not to be used in the module being fuzzed,
   // or to have been issued before.
@@ -53,11 +67,10 @@ class FuzzerContext {
   }
   uint32_t GetChanceOfSplittingBlock() { return chance_of_splitting_block_; }
 
-  // Probability distributions to control how deeply to recurse.
+  // Functions to control how deeply to recurse.
   // Keep them in alphabetical order.
-  const std::function<bool(uint32_t, RandomGenerator*)>&
-  GoDeeperInConstantObfuscation() {
-    return go_deeper_in_constant_obfuscation_;
+  bool GoDeeperInConstantObfuscation(uint32_t depth) {
+    return go_deeper_in_constant_obfuscation_(depth, random_generator_);
   }
 
  private:
@@ -70,6 +83,7 @@ class FuzzerContext {
   // Keep them in alphabetical order.
   uint32_t chance_of_adding_dead_break_;
   uint32_t chance_of_adding_dead_continue_;
+  uint32_t chance_of_copying_object_;
   uint32_t chance_of_moving_block_down_;
   uint32_t chance_of_obfuscating_constant_;
   uint32_t chance_of_splitting_block_;

--- a/source/fuzz/fuzzer_pass_add_dead_breaks.cpp
+++ b/source/fuzz/fuzzer_pass_add_dead_breaks.cpp
@@ -51,8 +51,7 @@ void FuzzerPassAddDeadBreaks::Apply() {
         //  merge blocks.  This will lead to interesting opportunities being
         //  missed.
         auto candidate_transformation = TransformationAddDeadBreak(
-            block.id(), merge_block_id,
-            GetFuzzerContext()->GetRandomGenerator()->RandomBool(), {});
+            block.id(), merge_block_id, GetFuzzerContext()->ChooseEven(), {});
         if (candidate_transformation.IsApplicable(GetIRContext(),
                                                   *GetFactManager())) {
           // Only consider a transformation as a candidate if it is applicable.
@@ -77,16 +76,15 @@ void FuzzerPassAddDeadBreaks::Apply() {
   while (!candidate_transformations.empty()) {
     // Choose a random index into the sequence of remaining candidate
     // transformations.
-    auto index = GetFuzzerContext()->GetRandomGenerator()->RandomUint32(
-        static_cast<uint32_t>(candidate_transformations.size()));
+    auto index = GetFuzzerContext()->RandomIndex(candidate_transformations);
     // Remove the transformation at the chosen index from the sequence.
     auto transformation = std::move(candidate_transformations[index]);
     candidate_transformations.erase(candidate_transformations.begin() + index);
     // Probabilistically decide whether to try to apply it vs. ignore it, in the
     // case that it is applicable.
     if (transformation.IsApplicable(GetIRContext(), *GetFactManager()) &&
-        GetFuzzerContext()->GetRandomGenerator()->RandomPercentage() >
-            GetFuzzerContext()->GetChanceOfAddingDeadBreak()) {
+        GetFuzzerContext()->ChoosePercentage(
+            GetFuzzerContext()->GetChanceOfAddingDeadBreak())) {
       transformation.Apply(GetIRContext(), GetFactManager());
       *GetTransformations()->add_transformation() = transformation.ToMessage();
     }

--- a/source/fuzz/fuzzer_pass_add_dead_continues.cpp
+++ b/source/fuzz/fuzzer_pass_add_dead_continues.cpp
@@ -40,14 +40,13 @@ void FuzzerPassAddDeadContinues::Apply() {
       //  merge blocks.  This will lead to interesting opportunities being
       //  missed.
       auto candidate_transformation = TransformationAddDeadContinue(
-          block.id(), GetFuzzerContext()->GetRandomGenerator()->RandomBool(),
-          {});
+          block.id(), GetFuzzerContext()->ChooseEven(), {});
       // Probabilistically decide whether to apply the transformation in the
       // case that it is applicable.
       if (candidate_transformation.IsApplicable(GetIRContext(),
                                                 *GetFactManager()) &&
-          GetFuzzerContext()->GetRandomGenerator()->RandomPercentage() >
-              GetFuzzerContext()->GetChanceOfAddingDeadContinue()) {
+          GetFuzzerContext()->ChoosePercentage(
+              GetFuzzerContext()->GetChanceOfAddingDeadContinue())) {
         candidate_transformation.Apply(GetIRContext(), GetFactManager());
         *GetTransformations()->add_transformation() =
             candidate_transformation.ToMessage();

--- a/source/fuzz/fuzzer_pass_permute_blocks.cpp
+++ b/source/fuzz/fuzzer_pass_permute_blocks.cpp
@@ -57,8 +57,8 @@ void FuzzerPassPermuteBlocks::Apply() {
     // would provide more freedom for A to move.
     for (auto id = block_ids.rbegin(); id != block_ids.rend(); ++id) {
       // Randomly decide whether to ignore the block id.
-      if (GetFuzzerContext()->GetRandomGenerator()->RandomPercentage() >
-          GetFuzzerContext()->GetChanceOfMovingBlockDown()) {
+      if (!GetFuzzerContext()->ChoosePercentage(
+              GetFuzzerContext()->GetChanceOfMovingBlockDown())) {
         continue;
       }
       // Keep pushing the block down, until pushing down fails.

--- a/source/fuzz/fuzzer_pass_split_blocks.cpp
+++ b/source/fuzz/fuzzer_pass_split_blocks.cpp
@@ -44,8 +44,9 @@ void FuzzerPassSplitBlocks::Apply() {
   // Now go through all the block pointers that were gathered.
   for (auto& block : blocks) {
     // Probabilistically decide whether to try to split this block.
-    if (GetFuzzerContext()->GetRandomGenerator()->RandomPercentage() >
-        GetFuzzerContext()->GetChanceOfSplittingBlock()) {
+    if (!GetFuzzerContext()->ChoosePercentage(
+            GetFuzzerContext()->GetChanceOfSplittingBlock())) {
+      // We are not going to try to split this block.
       continue;
     }
     // We are going to try to split this block.  We now need to choose where
@@ -77,9 +78,8 @@ void FuzzerPassSplitBlocks::Apply() {
     }
     // Having identified all the places we might be able to split the block,
     // we choose one of them.
-    auto base_offset = base_offset_pairs
-        [GetFuzzerContext()->GetRandomGenerator()->RandomUint32(
-            static_cast<uint32_t>(base_offset_pairs.size()))];
+    auto base_offset =
+        base_offset_pairs[GetFuzzerContext()->RandomIndex(base_offset_pairs)];
     auto transformation =
         TransformationSplitBlock(base_offset.first, base_offset.second,
                                  GetFuzzerContext()->GetFreshId());


### PR DESCRIPTION
Before this change there was quite a lot of duplication in the code
being used to choose random percentages, and some of it was incorrect
so that a percentage chance of (100-N)% instead of N% was being used.
Also there was a lot of duplicate code to choose a random index into a
vector.  This change eliminates that duplication (fixing up the
percentage problem), and gets rid of direct access to the random
number generator being used for fuzzing, so that all randomization
requests must go through the FuzzerContext class, discouraging future
ad-hoc uses of the random number generator.