### PR TITLE
Don't register duplicate decoration in validator.

### DIFF
--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -380,7 +380,11 @@ class ValidationState_t {
 
   /// Registers the decoration for the given <id>
   void RegisterDecorationForId(uint32_t id, const Decoration& dec) {
-    id_decorations_[id].push_back(dec);
+    auto& dec_list = id_decorations_[id];
+    auto lb = std::find(dec_list.begin(), dec_list.end(), dec);
+    if (lb == dec_list.end()) {
+      dec_list.push_back(dec);
+    }
   }
 
   /// Registers the list of decorations for the given <id>


### PR DESCRIPTION
As far as I know, it is legal to have multiple decoration adding the
same decoration to the same id.  The validator registers all of these
decoration as if they were distinct decorations.  This can cause poor
memory usage and performance in some cases.

This fix is to make sure that duplicates are not registers.

I keep the type of the decoration list as an std::vector because I
expect it to be small enough in most cases that the linear search will
still be faster that using some type of map.

No tests are added because we do not have a mechanism to test memory
usage in our unit tests.

Fixes #2837.  The total memory usage drop to 14,236KB.