### PR TITLE
Add fuzzer pass to copy objects

### DIFF
--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -34,6 +34,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_add_dead_breaks.h
         fuzzer_pass_add_dead_continues.h
         fuzzer_pass_add_useful_constructs.h
+        fuzzer_pass_copy_objects.h
         fuzzer_pass_obfuscate_constants.h
         fuzzer_pass_permute_blocks.h
         fuzzer_pass_split_blocks.h
@@ -69,6 +70,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_add_dead_breaks.cpp
         fuzzer_pass_add_dead_continues.cpp
         fuzzer_pass_add_useful_constructs.cpp
+        fuzzer_pass_copy_objects.cpp
         fuzzer_pass_obfuscate_constants.cpp
         fuzzer_pass_permute_blocks.cpp
         fuzzer_pass_split_blocks.cpp

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -22,6 +22,7 @@
 #include "source/fuzz/fuzzer_pass_add_dead_breaks.h"
 #include "source/fuzz/fuzzer_pass_add_dead_continues.h"
 #include "source/fuzz/fuzzer_pass_add_useful_constructs.h"
+#include "source/fuzz/fuzzer_pass_copy_objects.h"
 #include "source/fuzz/fuzzer_pass_obfuscate_constants.h"
 #include "source/fuzz/fuzzer_pass_permute_blocks.h"
 #include "source/fuzz/fuzzer_pass_split_blocks.h"
@@ -107,6 +108,9 @@ Fuzzer::FuzzerResultStatus Fuzzer::Run(
       .Apply();
 
   // Apply some semantics-preserving passes.
+  FuzzerPassCopyObjects(ir_context.get(), &fact_manager, &fuzzer_context,
+                        transformation_sequence_out)
+      .Apply();
   FuzzerPassSplitBlocks(ir_context.get(), &fact_manager, &fuzzer_context,
                         transformation_sequence_out)
       .Apply();

--- a/source/fuzz/fuzzer_context.cpp
+++ b/source/fuzz/fuzzer_context.cpp
@@ -26,6 +26,7 @@ namespace {
 
 const uint32_t kDefaultChanceOfAddingDeadBreak = 20;
 const uint32_t kDefaultChanceOfAddingDeadContinue = 20;
+const uint32_t kDefaultChanceOfCopyingObject = 20;
 const uint32_t kDefaultChanceOfMovingBlockDown = 25;
 const uint32_t kDefaultChanceOfObfuscatingConstant = 20;
 const uint32_t kDefaultChanceOfSplittingBlock = 20;
@@ -48,6 +49,7 @@ FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
       next_fresh_id_(min_fresh_id),
       chance_of_adding_dead_break_(kDefaultChanceOfAddingDeadBreak),
       chance_of_adding_dead_continue_(kDefaultChanceOfAddingDeadContinue),
+      chance_of_copying_object_(kDefaultChanceOfCopyingObject),
       chance_of_moving_block_down_(kDefaultChanceOfMovingBlockDown),
       chance_of_obfuscating_constant_(kDefaultChanceOfObfuscatingConstant),
       chance_of_splitting_block_(kDefaultChanceOfSplittingBlock),

--- a/source/fuzz/fuzzer_context.h
+++ b/source/fuzz/fuzzer_context.h
@@ -61,6 +61,7 @@ class FuzzerContext {
   uint32_t GetChanceOfAddingDeadContinue() {
     return chance_of_adding_dead_continue_;
   }
+  uint32_t GetChanceOfCopyingObject() { return chance_of_copying_object_; }
   uint32_t GetChanceOfMovingBlockDown() { return chance_of_moving_block_down_; }
   uint32_t GetChanceOfObfuscatingConstant() {
     return chance_of_obfuscating_constant_;
@@ -83,6 +84,7 @@ class FuzzerContext {
   // Keep them in alphabetical order.
   uint32_t chance_of_adding_dead_break_;
   uint32_t chance_of_adding_dead_continue_;
+  uint32_t chance_of_copying_object_;
   uint32_t chance_of_moving_block_down_;
   uint32_t chance_of_obfuscating_constant_;
   uint32_t chance_of_splitting_block_;

--- a/source/fuzz/fuzzer_pass_copy_objects.cpp
+++ b/source/fuzz/fuzzer_pass_copy_objects.cpp
@@ -1,0 +1,132 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/fuzzer_pass_copy_objects.h"
+
+#include "source/fuzz/transformation_copy_object.h"
+
+namespace spvtools {
+namespace fuzz {
+
+FuzzerPassCopyObjects::FuzzerPassCopyObjects(
+    opt::IRContext* ir_context, FactManager* fact_manager,
+    FuzzerContext* fuzzer_context,
+    protobufs::TransformationSequence* transformations)
+    : FuzzerPass(ir_context, fact_manager, fuzzer_context, transformations) {}
+
+FuzzerPassCopyObjects::~FuzzerPassCopyObjects() = default;
+
+void FuzzerPassCopyObjects::Apply() {
+
+  // Consider every block in every function.
+  for (auto &function : *GetIRContext()->module()) {
+    for (auto &block : function) {
+      // We now consider every instruction in the block, randomly deciding whether to add an object copy before the
+      // instruction.
+
+      // TODO: got here - write comment.
+      // In order to insert object copy instructions, we need to identify where in the block we...
+
+
+      // The initial base instruction is the block label.
+      uint32_t base = block.id();
+      uint32_t offset = 0;
+      // Consider every instruction in the block.  The label is excluded: it is
+      // only necessary to consider it as a base in case the first instruction
+      // in the block does not have a result id.
+      for (auto inst_it = block.begin(); inst_it != block.end(); ++inst_it) {
+        if (inst_it->HasResultId()) {
+          // In the case that the instruction has a result id, we use the
+          // instruction as its own base, with zero offset.
+          base = inst_it->result_id();
+          offset = 0;
+        } else {
+          // The instruction does not have a result id, so we need to identify
+          // it via the latest instruction that did have a result id (base), and
+          // an incremented offset.
+          offset++;
+        }
+
+        if (!TransformationCopyObject::CanInsertCopyBefore(inst_it)) {
+          continue;
+        }
+
+        // Randomly decide whether to try inserting an object copy here.
+        if(!GetFuzzerContext()->ChoosePercentage(GetFuzzerContext()->GetChanceOfCopyingObject())) {
+          continue;
+        }
+
+        // Populate list of potential instructions that can be copied.
+        // TODO(afd) The following is (relatively) simple, but may end up being prohibitively
+        //  inefficient, as it walks the whole dominator tree for every copy that is added.
+
+        std::vector<opt::Instruction*> copyable_instructions;
+
+        // Consider all global declarations
+        for (auto& global : GetIRContext()->module()->types_values()) {
+          if (TransformationCopyObject::IsCopyable(GetIRContext(), &global)) {
+            copyable_instructions.push_back(&global);
+          }
+        }
+
+        // Consider all previous instructions in this block
+        for (auto prev_inst_it = block.begin(); prev_inst_it != inst_it; ++prev_inst_it) {
+          if (TransformationCopyObject::IsCopyable(GetIRContext(), &*prev_inst_it)) {
+            copyable_instructions.push_back(&*prev_inst_it);
+          }
+        }
+
+        // Walk the dominator tree to consider all instructions from dominating blocks
+        auto dominator_analysis = GetIRContext()->GetDominatorAnalysis(&function);
+        for (auto next_dominator = dominator_analysis->ImmediateDominator(&block);
+             next_dominator != nullptr;
+             next_dominator = dominator_analysis->ImmediateDominator(next_dominator)) {
+          for (auto& dominating_inst : *next_dominator) {
+            if (TransformationCopyObject::IsCopyable(GetIRContext(), &dominating_inst)) {
+              copyable_instructions.push_back(&dominating_inst);
+            }
+          }
+        }
+
+        // At this point, |copyable_instructions| contains all the instructions we might
+        // think of copying.
+
+        if (!copyable_instructions.empty()) {
+          uint32_t index = GetFuzzerContext()->RandomIndex(copyable_instructions);
+          TransformationCopyObject transformation(
+                  copyable_instructions[index]->result_id(),
+                  base, offset, GetFuzzerContext()->GetFreshId());
+          assert(transformation.IsApplicable(GetIRContext(), *GetFactManager()) && "This transformation should be applicable by construction.");
+          transformation.Apply(GetIRContext(), GetFactManager());
+          *GetTransformations()->add_transformation() = transformation.ToMessage();
+
+          if (!inst_it->HasResultId()) {
+            // We have inserted a new instruction before the current instruction, and we are tracking the current
+            // id-less instruction via an offset (offset) from a previous instruction (base) that has an id.
+            // We increment |offset| to reflect the newly-inserted instruction.
+            //
+            // This is slightly preferable to the alternative of setting |base| to be the result id of the new
+            // instruction, since on replay we might end up eliminating this copy but keeping a subsequent copy.
+            offset++;
+          }
+
+        }
+      }
+    }
+  }
+
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/fuzzer_pass_copy_objects.h
+++ b/source/fuzz/fuzzer_pass_copy_objects.h
@@ -30,7 +30,6 @@ class FuzzerPassCopyObjects : public FuzzerPass {
   ~FuzzerPassCopyObjects();
 
   void Apply() override;
-
 };
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_pass_copy_objects.h
+++ b/source/fuzz/fuzzer_pass_copy_objects.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_FUZZER_PASS_COPY_OBJECTS_H_
+#define SOURCE_FUZZ_FUZZER_PASS_COPY_OBJECTS_H_
+
+#include "source/fuzz/fuzzer_pass.h"
+
+namespace spvtools {
+namespace fuzz {
+
+// A fuzzer pass for adding adding copies of objects to the module.
+class FuzzerPassCopyObjects : public FuzzerPass {
+ public:
+  FuzzerPassCopyObjects(opt::IRContext* ir_context, FactManager* fact_manager,
+                        FuzzerContext* fuzzer_context,
+                        protobufs::TransformationSequence* transformations);
+
+  ~FuzzerPassCopyObjects();
+
+  void Apply() override;
+
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_FUZZER_PASS_COPY_OBJECTS_H_

--- a/source/fuzz/transformation.cpp
+++ b/source/fuzz/transformation.cpp
@@ -25,6 +25,7 @@
 #include "transformation_add_type_float.h"
 #include "transformation_add_type_int.h"
 #include "transformation_add_type_pointer.h"
+#include "transformation_copy_object.h"
 #include "transformation_move_block_down.h"
 #include "transformation_replace_boolean_constant_with_constant_binary.h"
 #include "transformation_replace_constant_with_uniform.h"
@@ -59,6 +60,8 @@ std::unique_ptr<Transformation> Transformation::FromMessage(
     case protobufs::Transformation::TransformationCase::kAddTypePointer:
       return MakeUnique<TransformationAddTypePointer>(
           message.add_type_pointer());
+    case protobufs::Transformation::TransformationCase::kCopyObject:
+      return MakeUnique<TransformationCopyObject>(message.copy_object());
     case protobufs::Transformation::TransformationCase::kMoveBlockDown:
       return MakeUnique<TransformationMoveBlockDown>(message.move_block_down());
     case protobufs::Transformation::TransformationCase::
@@ -71,13 +74,12 @@ std::unique_ptr<Transformation> Transformation::FromMessage(
           message.replace_constant_with_uniform());
     case protobufs::Transformation::TransformationCase::kSplitBlock:
       return MakeUnique<TransformationSplitBlock>(message.split_block());
-    default:
-      assert(message.transformation_case() ==
-                 protobufs::Transformation::TRANSFORMATION_NOT_SET &&
-             "Unhandled transformation type.");
+    case protobufs::Transformation::TRANSFORMATION_NOT_SET:
       assert(false && "An unset transformation was encountered.");
       return nullptr;
   }
+  assert(false && "Should be unreachable as all cases must be handled above.");
+  return nullptr;
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_copy_object.h
+++ b/source/fuzz/transformation_copy_object.h
@@ -28,8 +28,8 @@ class TransformationCopyObject : public Transformation {
   explicit TransformationCopyObject(
       const protobufs::TransformationCopyObject& message);
 
-  TransformationCopyObject(uint32_t fresh_id, uint32_t object,
-                           uint32_t insert_after_id, uint32_t offset);
+  TransformationCopyObject(uint32_t object, uint32_t base_instruction_id,
+                           uint32_t offset, uint32_t fresh_id);
 
   // - |message_.fresh_id| must not be used by the module.
   // - |message_.object| must be a result id that is a legitimate operand for
@@ -57,6 +57,14 @@ class TransformationCopyObject : public Transformation {
   void Apply(opt::IRContext* context, FactManager* fact_manager) const override;
 
   protobufs::Transformation ToMessage() const override;
+
+  // Determines whether it is OK to make a copy of |inst|.
+  static bool IsCopyable(opt::IRContext* ir_context, opt::Instruction* inst);
+
+  // Determines whether it is OK to insert a copy instruction before the given
+  // instruction.
+  static bool CanInsertCopyBefore(
+      const opt::BasicBlock::iterator& instruction_in_block);
 
  private:
   protobufs::TransformationCopyObject message_;


### PR DESCRIPTION
A new fuzzer pass that randomly introduces OpCopyObject instructions
that make copies of ids, and uses the fact manager to record the fact
that an id %id is synonymous with an id generated by an OpCopyObject
applied to %id.  (A future pass will exploit such synonym facts.)
