### PR TITLE
Fix Fuchsia build.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -288,7 +288,10 @@ config("spvtools_internal_config") {
   configs = [ ":spvtools_public_config" ]
 
   if (is_clang) {
-    cflags = [ "-Wno-implicit-fallthrough" ]
+    cflags = [
+      "-Wno-implicit-fallthrough",
+      "-Wno-newline-eof",
+    ]
   }
 }
 


### PR DESCRIPTION
Most auto-generated files included by the SPIRV-Tools sources
do not have a proper newline at the end of file, creating a
hundred of compiler warnings, and even some build failures
when BUILD.gn is used for the Fuchsia build.

This fixes the issue by disabling the warning entirely.