### PR TITLE
Handle OpConstantNull in copy-prop-arrays.

### DIFF
--- a/source/opt/copy_prop_arrays.cpp
+++ b/source/opt/copy_prop_arrays.cpp
@@ -306,8 +306,7 @@ CopyPropagateArrays::BuildMemoryObjectFromCompositeConstruct(
   analysis::ConstantManager* const_mgr = context()->get_constant_mgr();
   const analysis::Constant* last_access =
       const_mgr->FindDeclaredConstant(memory_object->AccessChain().back());
-  if (!last_access ||
-      (!last_access->AsIntConstant() && !last_access->AsNullConstant())) {
+  if (!last_access || !last_access->type()->AsInteger()) {
     return nullptr;
   }
 
@@ -340,7 +339,7 @@ CopyPropagateArrays::BuildMemoryObjectFromCompositeConstruct(
 
     last_access =
         const_mgr->FindDeclaredConstant(member_object->AccessChain().back());
-    if (!last_access || !last_access->AsIntConstant()) {
+    if (!last_access || !last_access->type()->AsInteger()) {
       return nullptr;
     }
 
@@ -368,8 +367,7 @@ CopyPropagateArrays::BuildMemoryObjectFromInsert(Instruction* insert_inst) {
   } else if (const analysis::Array* array_type = result_type->AsArray()) {
     const analysis::Constant* length_const =
         const_mgr->FindDeclaredConstant(array_type->LengthId());
-    assert(length_const->AsIntConstant());
-    number_of_elements = length_const->AsIntConstant()->GetU32();
+    number_of_elements = length_const->GetU32();
   } else if (const analysis::Vector* vector_type = result_type->AsVector()) {
     number_of_elements = vector_type->element_count();
   } else if (const analysis::Matrix* matrix_type = result_type->AsMatrix()) {
@@ -401,7 +399,7 @@ CopyPropagateArrays::BuildMemoryObjectFromInsert(Instruction* insert_inst) {
 
   const analysis::Constant* last_access =
       const_mgr->FindDeclaredConstant(memory_object->AccessChain().back());
-  if (!last_access || !last_access->AsIntConstant()) {
+  if (!last_access || !last_access->type()->AsInteger()) {
     return nullptr;
   }
 
@@ -449,7 +447,7 @@ CopyPropagateArrays::BuildMemoryObjectFromInsert(Instruction* insert_inst) {
     const analysis::Constant* current_last_access =
         const_mgr->FindDeclaredConstant(
             current_memory_object->AccessChain().back());
-    if (!current_last_access || !current_last_access->AsIntConstant()) {
+    if (!current_last_access || !current_last_access->type()->AsInteger()) {
       return nullptr;
     }
 
@@ -513,7 +511,7 @@ bool CopyPropagateArrays::CanUpdateUses(Instruction* original_ptr_inst,
           const analysis::Constant* index_const =
               const_mgr->FindDeclaredConstant(use->GetSingleWordInOperand(i));
           if (index_const) {
-            access_chain.push_back(index_const->AsIntConstant()->GetU32());
+            access_chain.push_back(index_const->GetU32());
           } else {
             // Variable index means the type is a type where every element
             // is the same type.  Use element 0 to get the type.
@@ -613,7 +611,7 @@ void CopyPropagateArrays::UpdateUses(Instruction* original_ptr_inst,
           const analysis::Constant* index_const =
               const_mgr->FindDeclaredConstant(use->GetSingleWordInOperand(i));
           if (index_const) {
-            access_chain.push_back(index_const->AsIntConstant()->GetU32());
+            access_chain.push_back(index_const->GetU32());
           } else {
             // Variable index means the type is an type where every element
             // is the same type.  Use element 0 to get the type.
@@ -749,8 +747,8 @@ uint32_t CopyPropagateArrays::MemoryObject::GetNumberOfMembers() {
     const analysis::Constant* length_const =
         context->get_constant_mgr()->FindDeclaredConstant(
             array_type->LengthId());
-    assert(length_const->AsIntConstant());
-    return length_const->AsIntConstant()->GetU32();
+    assert(length_const->type()->AsInteger());
+    return length_const->GetU32();
   } else if (const analysis::Vector* vector_type = type->AsVector()) {
     return vector_type->element_count();
   } else if (const analysis::Matrix* matrix_type = type->AsMatrix()) {
@@ -776,8 +774,7 @@ std::vector<uint32_t> CopyPropagateArrays::MemoryObject::GetAccessIds() const {
     if (!element_index_const) {
       access_indices.push_back(0);
     } else {
-      assert(element_index_const->AsIntConstant());
-      access_indices.push_back(element_index_const->AsIntConstant()->GetU32());
+      access_indices.push_back(element_index_const->GetU32());
     }
   }
   return access_indices;

--- a/test/opt/copy_prop_array_test.cpp
+++ b/test/opt/copy_prop_array_test.cpp
@@ -1571,6 +1571,57 @@ OpFunctionEnd
   SinglePassRunAndCheck<CopyPropagateArrays>(before, after, true, true);
 }
 
+TEST_F(CopyPropArrayPassTest, IndexIsNullConstnat) {
+  const std::string text = R"(
+; CHECK: [[var:%\w+]] = OpVariable {{%\w+}} Uniform
+; CHECK: [[null:%\w+]] = OpConstantNull %uint
+; CHECK: [[ac1:%\w+]] = OpAccessChain %_ptr_Uniform__arr_uint_uint_1 [[var]] %uint_0 %uint_0
+; CHECK: OpAccessChain %_ptr_Uniform_uint [[ac1]] [[null]]
+; CHECK-NEXT: OpReturn
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 600
+               OpDecorate %myCBuffer DescriptorSet 0
+               OpDecorate %myCBuffer Binding 0
+               OpDecorate %_arr_v4float_uint_1 ArrayStride 16
+               OpMemberDecorate %MyConstantBuffer 0 Offset 0
+               OpMemberDecorate %type_myCBuffer 0 Offset 0
+               OpDecorate %type_myCBuffer Block
+       %uint = OpTypeInt 32 0
+      %int_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+%_arr_v4float_uint_1 = OpTypeArray %uint %uint_1
+%MyConstantBuffer = OpTypeStruct %_arr_v4float_uint_1
+%type_myCBuffer = OpTypeStruct %MyConstantBuffer
+%_ptr_Uniform_type_myCBuffer = OpTypePointer Uniform %type_myCBuffer
+%_arr_v4float_uint_1_0 = OpTypeArray %uint %uint_1
+       %void = OpTypeVoid
+         %19 = OpTypeFunction %void
+%_ptr_Function_v4float = OpTypePointer Function %uint
+%_ptr_Uniform_MyConstantBuffer = OpTypePointer Uniform %MyConstantBuffer
+  %myCBuffer = OpVariable %_ptr_Uniform_type_myCBuffer Uniform
+%_ptr_Function__arr_v4float_uint_1_0 = OpTypePointer Function %_arr_v4float_uint_1_0
+         %23 = OpConstantNull %uint
+       %main = OpFunction %void None %19
+         %24 = OpLabel
+         %25 = OpVariable %_ptr_Function__arr_v4float_uint_1_0 Function
+         %26 = OpAccessChain %_ptr_Uniform_MyConstantBuffer %myCBuffer %int_0
+         %27 = OpLoad %MyConstantBuffer %26
+         %28 = OpCompositeExtract %_arr_v4float_uint_1 %27 0
+         %29 = OpCompositeExtract %uint %28 0
+         %30 = OpCompositeConstruct %_arr_v4float_uint_1_0 %29
+               OpStore %25 %30
+         %31 = OpAccessChain %_ptr_Function_v4float %25 %23
+               OpReturn
+               OpFunctionEnd
+)";
+
+  SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  SinglePassRunAndMatch<CopyPropagateArrays>(text, true);
+}
+
 }  // namespace
 }  // namespace opt
 }  // namespace spvtools


### PR DESCRIPTION
Many of the places in copy propagate arrays assumes that integer constant will be defined by an OpConstant instruction.  That is not always true.  We fix these spots by allowing for an OpConstantNull.

Fixes #2869.