### PR TITLE
Fix CMake issue related to spirv-fuzz

### DIFF
--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 if(SPIRV_BUILD_FUZZER)
+
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/protobufs)
+
   set(PROTOBUF_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/protobufs/spvtoolsfuzz.proto)
 
   add_custom_command(


### PR DESCRIPTION
spirv-fuzz generates protobuf sources in a 'protobuf' directory.  When
building with Unix Makefiles, compilation would fail due to to this
directory not existing.  This change causes the directory to be
created when the build is prepared.