### PR TITLE
Relaxed bitcast with pointers

### DIFF
--- a/source/val/validate_conversion.cpp
+++ b/source/val/validate_conversion.cpp
@@ -18,6 +18,7 @@
 
 #include "source/diagnostic.h"
 #include "source/opcode.h"
+#include "source/spirv_constant.h"
 #include "source/val/instruction.h"
 #include "source/val/validation_state.h"
 
@@ -449,14 +450,8 @@ spv_result_t ConversionPass(ValidationState_t& _, const Instruction* inst) {
 
       const bool result_is_pointer = _.IsPointerType(result_type);
       const bool result_is_int_scalar = _.IsIntScalarType(result_type);
-      const bool result_is_int_vector = _.IsIntVectorType(result_type);
-      const bool result_has_int32 =
-          _.ContainsSizedIntOrFloatType(result_type, SpvOpTypeInt, 32);
       const bool input_is_pointer = _.IsPointerType(input_type);
       const bool input_is_int_scalar = _.IsIntScalarType(input_type);
-      const bool input_is_int_vector = _.IsIntVectorType(input_type);
-      const bool input_has_int32 =
-          _.ContainsSizedIntOrFloatType(input_type, SpvOpTypeInt, 32);
 
       if (!result_is_pointer && !result_is_int_scalar &&
           !_.IsIntVectorType(result_type) &&
@@ -473,19 +468,40 @@ spv_result_t ConversionPass(ValidationState_t& _, const Instruction* inst) {
                << "Expected input to be a pointer or int or float vector "
                << "or scalar: " << spvOpcodeString(opcode);
 
-      if (result_is_pointer && !input_is_pointer && !input_is_int_scalar &&
-          !(input_is_int_vector && input_has_int32))
-        return _.diag(SPV_ERROR_INVALID_DATA, inst)
-               << "Expected input to be a pointer, int scalar or 32-bit int "
-                  "vector if Result Type is pointer: "
-               << spvOpcodeString(opcode);
+      if (_.version() >= SPV_SPIRV_VERSION_WORD(1, 5) ||
+          _.HasExtension(kSPV_KHR_physical_storage_buffer)) {
+        const bool result_is_int_vector = _.IsIntVectorType(result_type);
+        const bool result_has_int32 =
+            _.ContainsSizedIntOrFloatType(result_type, SpvOpTypeInt, 32);
+        const bool input_is_int_vector = _.IsIntVectorType(input_type);
+        const bool input_has_int32 =
+            _.ContainsSizedIntOrFloatType(input_type, SpvOpTypeInt, 32);
+        if (result_is_pointer && !input_is_pointer && !input_is_int_scalar &&
+            !(input_is_int_vector && input_has_int32))
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << "Expected input to be a pointer, int scalar or 32-bit int "
+                    "vector if Result Type is pointer: "
+                 << spvOpcodeString(opcode);
 
-      if (input_is_pointer && !result_is_pointer && !result_is_int_scalar &&
-          !(result_is_int_vector && result_has_int32))
-        return _.diag(SPV_ERROR_INVALID_DATA, inst)
-               << "Pointer can only be converted to another pointer, int "
-                  "scalar or 32-bit int vector: "
-               << spvOpcodeString(opcode);
+        if (input_is_pointer && !result_is_pointer && !result_is_int_scalar &&
+            !(result_is_int_vector && result_has_int32))
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << "Pointer can only be converted to another pointer, int "
+                    "scalar or 32-bit int vector: "
+                 << spvOpcodeString(opcode);
+      } else {
+        if (result_is_pointer && !input_is_pointer && !input_is_int_scalar)
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << "Expected input to be a pointer or int scalar if Result "
+                    "Type is pointer: "
+                 << spvOpcodeString(opcode);
+
+        if (input_is_pointer && !result_is_pointer && !result_is_int_scalar)
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << "Pointer can only be converted to another pointer or int "
+                    "scalar: "
+                 << spvOpcodeString(opcode);
+      }
 
       if (!result_is_pointer && !input_is_pointer) {
         const uint32_t result_size =

--- a/test/val/val_conversion_test.cpp
+++ b/test/val/val_conversion_test.cpp
@@ -248,6 +248,8 @@ OpMemoryModel Physical32 OpenCL
 %f64vec4_0123 = OpConstantComposite %f64vec4 %f64_0 %f64_1 %f64_2 %f64_3
 %f64vec4_1234 = OpConstantComposite %f64vec4 %f64_1 %f64_2 %f64_3 %f64_4
 
+%u64vec2_01 = OpConstantComposite %u64vec2 %u64_0 %u64_1
+
 %true = OpConstantTrue %bool
 %false = OpConstantFalse %bool
 
@@ -1200,6 +1202,8 @@ TEST_F(ValidateConversion, BitcastSuccess) {
 %val7 = OpBitcast %f32vec2 %u64_1
 %val8 = OpBitcast %f64 %u32vec2_12
 %val9 = OpBitcast %f32vec4 %f64vec2_12
+%val10 = OpBitcast %u32ptr_func %u32vec2_01
+%val11 = OpBitcast %u32vec2 %ptr
 )";
 
   CompileSuccessfully(GenerateKernelCode(body).c_str());
@@ -1249,10 +1253,21 @@ TEST_F(ValidateConversion, BitcastPtrWrongInputType) {
 
   CompileSuccessfully(GenerateKernelCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Expected input to be a pointer or int scalar if Result Type "
-                "is pointer: Bitcast"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Expected input to be a pointer, int scalar or 32-bit "
+                        "int vector if Result Type is pointer: Bitcast"));
+}
+
+TEST_F(ValidateConversion, BitcastPtrWrongInputTypeIntVector) {
+  const std::string body = R"(
+%val = OpBitcast %u32ptr_func %u64vec2_01
+)";
+
+  CompileSuccessfully(GenerateKernelCode(body).c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Expected input to be a pointer, int scalar or 32-bit "
+                        "int vector if Result Type is pointer: Bitcast"));
 }
 
 TEST_F(ValidateConversion, BitcastPtrWrongResultType) {
@@ -1262,11 +1277,21 @@ TEST_F(ValidateConversion, BitcastPtrWrongResultType) {
 
   CompileSuccessfully(GenerateKernelCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr(
-          "Pointer can only be converted to another pointer or int scalar: "
-          "Bitcast"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Pointer can only be converted to another pointer, int "
+                        "scalar or 32-bit int vector: Bitcast"));
+}
+
+TEST_F(ValidateConversion, BitcastPtrWrongResultTypeIntVector) {
+  const std::string body = R"(
+%val = OpBitcast %u64vec2 %f32inp
+)";
+
+  CompileSuccessfully(GenerateKernelCode(body).c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Pointer can only be converted to another pointer, int "
+                        "scalar or 32-bit int vector: Bitcast"));
 }
 
 TEST_F(ValidateConversion, BitcastDifferentTotalBitWidth) {

--- a/test/val/val_conversion_test.cpp
+++ b/test/val/val_conversion_test.cpp
@@ -1202,11 +1202,52 @@ TEST_F(ValidateConversion, BitcastSuccess) {
 %val7 = OpBitcast %f32vec2 %u64_1
 %val8 = OpBitcast %f64 %u32vec2_12
 %val9 = OpBitcast %f32vec4 %f64vec2_12
+)";
+
+  CompileSuccessfully(GenerateKernelCode(body).c_str());
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateConversion, BitcastSuccessSPV1p5) {
+  const std::string body = R"(
+%ptr = OpVariable %f32ptr_func Function
+%val1 = OpBitcast %u32 %ptr
+%val2 = OpBitcast %u64 %ptr
+%val3 = OpBitcast %f32ptr_func %u32_1
+%val4 = OpBitcast %f32ptr_wg %u64_1
+%val5 = OpBitcast %f32 %u32_1
+%val6 = OpBitcast %f32vec2 %u32vec2_12
+%val7 = OpBitcast %f32vec2 %u64_1
+%val8 = OpBitcast %f64 %u32vec2_12
+%val9 = OpBitcast %f32vec4 %f64vec2_12
 %val10 = OpBitcast %u32ptr_func %u32vec2_01
 %val11 = OpBitcast %u32vec2 %ptr
 )";
 
-  CompileSuccessfully(GenerateKernelCode(body).c_str());
+  CompileSuccessfully(GenerateKernelCode(body).c_str(), SPV_ENV_UNIVERSAL_1_5);
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
+}
+
+TEST_F(ValidateConversion, BitcastSuccessPhysicalStorageBufferKHR) {
+  const std::string body = R"(
+%ptr = OpVariable %f32ptr_func Function
+%val1 = OpBitcast %u32 %ptr
+%val2 = OpBitcast %u64 %ptr
+%val3 = OpBitcast %f32ptr_func %u32_1
+%val4 = OpBitcast %f32ptr_wg %u64_1
+%val5 = OpBitcast %f32 %u32_1
+%val6 = OpBitcast %f32vec2 %u32vec2_12
+%val7 = OpBitcast %f32vec2 %u64_1
+%val8 = OpBitcast %f64 %u32vec2_12
+%val9 = OpBitcast %f32vec4 %f64vec2_12
+%val10 = OpBitcast %u32ptr_func %u32vec2_01
+%val11 = OpBitcast %u32vec2 %ptr
+)";
+
+  CompileSuccessfully(
+      GenerateKernelCode(body,
+                         "\nOpExtension \"SPV_KHR_physical_storage_buffer\"")
+          .c_str());
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1254,16 +1295,61 @@ TEST_F(ValidateConversion, BitcastPtrWrongInputType) {
   CompileSuccessfully(GenerateKernelCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Expected input to be a pointer or int scalar if "
+                        "Result Type is pointer: Bitcast"));
+}
+
+TEST_F(ValidateConversion, BitcastPtrWrongInputTypeSPV1p5) {
+  const std::string body = R"(
+%val = OpBitcast %u32ptr_func %f32_1
+)";
+
+  CompileSuccessfully(GenerateKernelCode(body).c_str(), SPV_ENV_UNIVERSAL_1_5);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA,
+            ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
+  EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Expected input to be a pointer, int scalar or 32-bit "
                         "int vector if Result Type is pointer: Bitcast"));
 }
 
-TEST_F(ValidateConversion, BitcastPtrWrongInputTypeIntVector) {
+TEST_F(ValidateConversion, BitcastPtrWrongInputTypePhysicalStorageBufferKHR) {
+  const std::string body = R"(
+%val = OpBitcast %u32ptr_func %f32_1
+)";
+
+  CompileSuccessfully(
+      GenerateKernelCode(body,
+                         "\nOpExtension \"SPV_KHR_physical_storage_buffer\"")
+          .c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Expected input to be a pointer, int scalar or 32-bit "
+                        "int vector if Result Type is pointer: Bitcast"));
+}
+
+TEST_F(ValidateConversion, BitcastPtrWrongInputTypeIntVectorSPV1p5) {
   const std::string body = R"(
 %val = OpBitcast %u32ptr_func %u64vec2_01
 )";
 
-  CompileSuccessfully(GenerateKernelCode(body).c_str());
+  CompileSuccessfully(GenerateKernelCode(body).c_str(), SPV_ENV_UNIVERSAL_1_5);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA,
+            ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Expected input to be a pointer, int scalar or 32-bit "
+                        "int vector if Result Type is pointer: Bitcast"));
+}
+
+TEST_F(ValidateConversion,
+       BitcastPtrWrongInputTypeIntVectorPhysicalStorageBufferKHR) {
+  const std::string body = R"(
+%val = OpBitcast %u32ptr_func %u64vec2_01
+)";
+
+  CompileSuccessfully(
+      GenerateKernelCode(body,
+                         "\nOpExtension \"SPV_KHR_physical_storage_buffer\"")
+          .c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Expected input to be a pointer, int scalar or 32-bit "
@@ -1278,16 +1364,61 @@ TEST_F(ValidateConversion, BitcastPtrWrongResultType) {
   CompileSuccessfully(GenerateKernelCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Pointer can only be converted to another pointer or "
+                        "int scalar: Bitcast"));
+}
+
+TEST_F(ValidateConversion, BitcastPtrWrongResultTypeSPV1p5) {
+  const std::string body = R"(
+%val = OpBitcast %f32 %f32inp
+)";
+
+  CompileSuccessfully(GenerateKernelCode(body).c_str(), SPV_ENV_UNIVERSAL_1_5);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA,
+            ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
+  EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Pointer can only be converted to another pointer, int "
                         "scalar or 32-bit int vector: Bitcast"));
 }
 
-TEST_F(ValidateConversion, BitcastPtrWrongResultTypeIntVector) {
+TEST_F(ValidateConversion, BitcastPtrWrongResultTypePhysicalStorageBufferKHR) {
+  const std::string body = R"(
+%val = OpBitcast %f32 %f32inp
+)";
+
+  CompileSuccessfully(
+      GenerateKernelCode(body,
+                         "\nOpExtension \"SPV_KHR_physical_storage_buffer\"")
+          .c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Pointer can only be converted to another pointer, int "
+                        "scalar or 32-bit int vector: Bitcast"));
+}
+
+TEST_F(ValidateConversion, BitcastPtrWrongResultTypeIntVectorSPV1p5) {
   const std::string body = R"(
 %val = OpBitcast %u64vec2 %f32inp
 )";
 
-  CompileSuccessfully(GenerateKernelCode(body).c_str());
+  CompileSuccessfully(GenerateKernelCode(body).c_str(), SPV_ENV_UNIVERSAL_1_5);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA,
+            ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Pointer can only be converted to another pointer, int "
+                        "scalar or 32-bit int vector: Bitcast"));
+}
+
+TEST_F(ValidateConversion,
+       BitcastPtrWrongResultTypeIntVectorPhysicalStorageBufferKHR) {
+  const std::string body = R"(
+%val = OpBitcast %u64vec2 %f32inp
+)";
+
+  CompileSuccessfully(
+      GenerateKernelCode(body,
+                         "\nOpExtension \"SPV_KHR_physical_storage_buffer\"")
+          .c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Pointer can only be converted to another pointer, int "


### PR DESCRIPTION
In SPIR-V 1.5 or in the presence of SPV_KHR_physical_storage_buffer allow bitcast between pointers and 32-bit integer vectors.

New tests