### PR TITLE
Add SPV_KHR_shader_clock validation

### DIFF
--- a/source/val/validate_misc.cpp
+++ b/source/val/validate_misc.cpp
@@ -18,6 +18,7 @@
 #include "source/opcode.h"
 #include "source/spirv_target_env.h"
 #include "source/val/instruction.h"
+#include "source/val/validate_scopes.h"
 #include "source/val/validation_state.h"
 
 namespace spvtools {
@@ -34,6 +35,30 @@ spv_result_t ValidateUndef(ValidationState_t& _, const Instruction* inst) {
 
   if (spvIsWebGPUEnv(_.context()->target_env)) {
     return _.diag(SPV_ERROR_INVALID_BINARY, inst) << "OpUndef is disallowed";
+  }
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t ValidateShaderClock(ValidationState_t& _,
+                                 const Instruction* inst) {
+  const uint32_t execution_scope = inst->word(3);
+  if (auto error = ValidateExecutionScope(_, inst, execution_scope)) {
+    return error;
+  }
+
+  // Result Type must be a 64 - bit unsigned integer type or
+  // a vector of two - components of 32 -
+  // bit unsigned integer type
+  const uint32_t result_type = inst->type_id();
+  if (!(_.IsUnsignedIntScalarType(result_type) &&
+        _.GetBitWidth(result_type) == 64) &&
+      !(_.IsUnsignedIntVectorType(result_type) &&
+        _.GetDimension(result_type) == 2 && _.GetBitWidth(result_type) == 32)) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst) << "Expected Value to be a "
+                                                   "vector of two components"
+                                                   " of unsigned integer"
+                                                   " or 64bit unsigned integer";
   }
 
   return SPV_SUCCESS;
@@ -114,6 +139,11 @@ spv_result_t MiscPass(ValidationState_t& _, const Instruction* inst) {
                << spvOpcodeString(inst->opcode());
       break;
     }
+    case SpvOpReadClockKHR:
+      if (auto error = ValidateShaderClock(_, inst)) {
+        return error;
+      }
+      break;
     default:
       break;
   }

--- a/test/val/val_misc_test.cpp
+++ b/test/val/val_misc_test.cpp
@@ -83,6 +83,87 @@ OpMemoryModel Logical GLSL450
       getDiagnosticString(),
       HasSubstr("Cannot create undefined values with 8- or 16-bit types"));
 }
+
+const std::string ShaderClockSpriv = R"(
+OpCapability Shader
+OpCapability Int64
+OpCapability ShaderClockKHR
+OpExtension "SPV_KHR_shader_clock"
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main"
+OpExecutionMode %main OriginUpperLeft
+OpSource GLSL 450
+OpSourceExtension "GL_ARB_gpu_shader_int64"
+OpSourceExtension "GL_ARB_shader_clock"
+OpSourceExtension "GL_EXT_shader_realtime_clock"
+OpName %main "main"
+OpName %time1 "time1"
+%void = OpTypeVoid
+)";
+
+TEST_F(ValidateMisc, ShaderClockInt64) {
+  const std::string spirv = ShaderClockSpriv + R"(
+%3 = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%_ptr_Function_uint = OpTypePointer Function %uint
+%uint_3 = OpConstant %uint 3
+%uint_1 = OpConstant %uint 1
+%main = OpFunction %void None %3
+%5 = OpLabel
+%time1 = OpVariable %_ptr_Function_uint Function
+%11 = OpReadClockKHR %uint %uint_3
+OpStore %time1 %11
+OpReturn
+OpFunctionEnd)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("or 64bit unsigned integer"));
+}
+
+TEST_F(ValidateMisc, ShaderClockVec2) {
+  const std::string spirv = ShaderClockSpriv + R"(
+%3 = OpTypeFunction %void
+%ulong = OpTypeInt 64 0
+%_ptr_Function_ulong = OpTypePointer Function %ulong
+%uint = OpTypeInt 32 0
+%uint_3 = OpConstant %uint 3
+%v2uint = OpTypeVector %ulong 2
+%_ptr_Function_v2uint = OpTypePointer Function %v2uint
+%main = OpFunction %void None %3
+%5 = OpLabel
+%time1 = OpVariable %_ptr_Function_v2uint Function
+%15 = OpReadClockKHR %v2uint %uint_3
+OpStore %time1 %15
+OpReturn
+OpFunctionEnd)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("vector of two components"));
+}
+
+TEST_F(ValidateMisc, ShaderClockExecutionScope) {
+  const std::string spirv = ShaderClockSpriv + R"(
+%3 = OpTypeFunction %void
+%ulong = OpTypeInt 64 0
+%uint = OpTypeInt 32 0
+%_ptr_Function_ulong = OpTypePointer Function %ulong
+%uint_3 = OpConstant %uint 10
+%uint_1 = OpConstant %uint 1
+%main = OpFunction %void None %3
+%5 = OpLabel
+%time1 = OpVariable %_ptr_Function_ulong Function
+%11 = OpReadClockKHR %ulong %uint_3
+OpStore %time1 %11
+OpReturn
+OpFunctionEnd)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Invalid scope value"));
+}
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
Add checks for SPV_KHR_shader_clock

1) Check that the Result Type must be a 64-bit unsigned integer type or a vector of two-components of 32-bit unsigned integer.

2) Check for a valid execution scope.