### PR TITLE
Android.mk: Add dependency from optimizer file to amd-shader-ballot-insts.inc

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -250,6 +250,8 @@ $(LOCAL_PATH)/source/ext_inst.cpp: \
 	$(1)/spv-amd-shader-ballot.insts.inc \
 	$(1)/spv-amd-shader-explicit-vertex-parameter.insts.inc \
 	$(1)/spv-amd-shader-trinary-minmax.insts.inc
+$(LOCAL_PATH)/source/opt/amd_ext_to_khr.cpp: \
+	$(1)/spv-amd-shader-ballot.insts.inc
 endef
 $(eval $(call gen_spvtools_grammar_tables,$(SPVTOOLS_OUT_PATH)))
 


### PR DESCRIPTION
This is required to fix the NDK build.