### PR TITLE
spirv-fuzz: do not replace a pointer argument to a function call with a synonym

### DIFF
--- a/source/fuzz/transformation_replace_id_with_synonym.h
+++ b/source/fuzz/transformation_replace_id_with_synonym.h
@@ -41,6 +41,8 @@ class TransformationReplaceIdWithSynonym : public Transformation {
   //   dominated by their definitions.
   // - The id must not be an index into an access chain whose base object has
   //   struct type, as such indices must be constants.
+  // - The id must not be a pointer argument to a function call (because the
+  //   synonym might not be a memory object declaration).
   // - |fresh_id_for_temporary| must be 0.
   // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/2855): the
   //  motivation for the temporary is to support the case where an id is


### PR DESCRIPTION
Before this change, spirv-fuzz would replace a pointer argument to a
function call with a synonym, which is problematic when the synonym is
not a memory object declaration, since function call arguments are
required to be memory object declarations.  This change adds a check
to ensure that such a replacement is not made.

Fixes #2896.
