### PR TITLE
spirv-fuzz: do not replace boolean constant argument to OpPhi instruction

### DIFF
--- a/source/fuzz/transformation_replace_boolean_constant_with_constant_binary.cpp
+++ b/source/fuzz/transformation_replace_boolean_constant_with_constant_binary.cpp
@@ -178,7 +178,7 @@ bool TransformationReplaceBooleanConstantWithConstantBinary::IsApplicable(
       context->get_constant_mgr()->FindDeclaredConstant(message_.rhs_id());
   bool expected_result = (boolean_constant->opcode() == SpvOpConstantTrue);
 
-  const SpvOp binary_opcode = static_cast<SpvOp>(message_.opcode());
+  const auto binary_opcode = static_cast<SpvOp>(message_.opcode());
 
   // We consider the floating point, signed and unsigned integer cases
   // separately.  In each case the logic is very similar.
@@ -237,8 +237,17 @@ bool TransformationReplaceBooleanConstantWithConstantBinary::IsApplicable(
   }
 
   // The id use descriptor must identify some instruction
-  return transformation::FindInstruction(message_.id_use_descriptor(),
-                                         context) != nullptr;
+  auto instruction =
+      transformation::FindInstruction(message_.id_use_descriptor(), context);
+  if (instruction == nullptr) {
+    return false;
+  }
+
+  // The instruction must not be an OpPhi, as we cannot insert a binary
+  // operator instruction before an OpPhi.
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/2902): there is
+  //  scope for being less conservative.
+  return instruction->opcode() != SpvOpPhi;
 }
 
 void TransformationReplaceBooleanConstantWithConstantBinary::Apply(

--- a/source/fuzz/transformation_replace_boolean_constant_with_constant_binary.h
+++ b/source/fuzz/transformation_replace_boolean_constant_with_constant_binary.h
@@ -43,6 +43,12 @@ class TransformationReplaceBooleanConstantWithConstantBinary
   // - |message_.opcode| must be suitable for applying to |message.lhs_id| and
   //   |message_.rhs_id|, and the result must evaluate to the boolean constant
   //   c.
+  // - The boolean constant usage must not be an argument to OpPhi, because in
+  //   this case it is not legal to insert a binary operator instruction right
+  //   before the OpPhi.
+  //   TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/2902): consider
+  //    replacing a boolean in an OpPhi by adding a binary operator instruction
+  //    to the parent block for the OpPhi.
   bool IsApplicable(opt::IRContext* context,
                     const FactManager& fact_manager) const override;
 


### PR DESCRIPTION
Before this change, spirv-fuzz would replace a constant boolean
argument to an OpPhi with the result of a binary operation, inserting
the instruction to compute the binary operation right before the
OpPhi, leading to an invalid module.  This change conservatively
disallows replacing OpPhi arguments.  Issue #2902 notes that there is
scope for being less conservative.

Fixes #2897.
