### PR TITLE
Handle extract with no indexes

### DIFF
--- a/source/opt/folding_rules.cpp
+++ b/source/opt/folding_rules.cpp
@@ -1274,6 +1274,12 @@ FoldingRule CompositeConstructFeedingExtract() {
            "Wrong opcode.  Should be OpCompositeExtract.");
     analysis::DefUseManager* def_use_mgr = context->get_def_use_mgr();
     analysis::TypeManager* type_mgr = context->get_type_mgr();
+
+    // If there are no index operands, then this rule cannot do anything.
+    if (inst->NumInOperands() <= 1) {
+      return false;
+    }
+
     uint32_t cid = inst->GetSingleWordInOperand(kExtractCompositeIdInIdx);
     Instruction* cinst = def_use_mgr->GetDef(cid);
 
@@ -1399,6 +1405,20 @@ FoldingRule CompositeExtractFeedingConstruct() {
     inst->SetInOperands({{SPV_OPERAND_TYPE_ID, {original_id}}});
     return true;
   };
+}
+
+// Folds an OpCompositeExtact instruction with no indexes into an OpCopyObject.
+bool ExtractWithNoIndexes(IRContext*, Instruction* inst,
+                          const std::vector<const analysis::Constant*>&) {
+  assert(inst->opcode() == SpvOpCompositeExtract &&
+         "Wrong opcode.  Should be OpCompositeExtract.");
+
+  if (inst->NumInOperands() > 1) {
+    return false;
+  }
+
+  inst->SetOpcode(SpvOpCopyObject);
+  return true;
 }
 
 FoldingRule InsertFeedingExtract() {
@@ -2207,6 +2227,7 @@ void FoldingRules::AddFoldingRules() {
   // Take that into consideration.
   rules_[SpvOpCompositeConstruct].push_back(CompositeExtractFeedingConstruct());
 
+  rules_[SpvOpCompositeExtract].push_back(ExtractWithNoIndexes);
   rules_[SpvOpCompositeExtract].push_back(InsertFeedingExtract());
   rules_[SpvOpCompositeExtract].push_back(CompositeConstructFeedingExtract());
   rules_[SpvOpCompositeExtract].push_back(VectorShuffleFeedingExtract());

--- a/source/opt/folding_rules.cpp
+++ b/source/opt/folding_rules.cpp
@@ -1407,7 +1407,7 @@ FoldingRule CompositeExtractFeedingConstruct() {
   };
 }
 
-// Folds an OpCompositeExtact instruction with no indexes into an OpCopyObject.
+// Folds an OpCompositeExtract instruction with no indexes into an OpCopyObject.
 bool ExtractWithNoIndexes(IRContext*, Instruction* inst,
                           const std::vector<const analysis::Constant*>&) {
   assert(inst->opcode() == SpvOpCompositeExtract &&

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -820,7 +820,8 @@ ScalarReplacementPass::GetUsedComponents(Instruction* inst) {
         // Look for extract from the load.
         std::vector<uint32_t> t;
         if (def_use_mgr->WhileEachUser(use, [&t](Instruction* use2) {
-              if (use2->opcode() != SpvOpCompositeExtract) {
+              if (use2->opcode() != SpvOpCompositeExtract ||
+                  use2->NumInOperands() <= 1) {
                 return false;
               }
               t.push_back(use2->GetSingleWordInOperand(1));

--- a/test/opt/fold_test.cpp
+++ b/test/opt/fold_test.cpp
@@ -3333,7 +3333,16 @@ INSTANTIATE_TEST_SUITE_P(CompositeExtractFoldingTest, GeneralInstructionFoldingT
             "%3 = OpCompositeExtract %float %2 4\n" +
             "OpReturn\n" +
             "OpFunctionEnd",
-        3, 0)
+        3, 0),
+    // Test case 14: Fold OpCompositeExtract with no indexes.
+    InstructionFoldingCase<uint32_t>(
+        Header() + "%main = OpFunction %void None %void_func\n" +
+            "%main_lab = OpLabel\n" +
+            "%2 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1\n" +
+            "%3 = OpCompositeExtract %v4float %2\n" +
+            "OpReturn\n" +
+            "OpFunctionEnd",
+        3, 2)
 ));
 
 INSTANTIATE_TEST_SUITE_P(CompositeConstructFoldingTest, GeneralInstructionFoldingTest,

--- a/test/opt/scalar_replacement_test.cpp
+++ b/test/opt/scalar_replacement_test.cpp
@@ -1899,6 +1899,37 @@ TEST_F(ScalarReplacementTest, RelaxedPrecisionMemberDecoration) {
   SinglePassRunAndMatch<ScalarReplacementPass>(text, true);
 }
 
+TEST_F(ScalarReplacementTest, ExtractWithNoIndex) {
+  const std::string text = R"(
+; CHECK: [[var1:%\w+]] = OpVariable %_ptr_Function_float Function
+; CHECK: [[var2:%\w+]] = OpVariable %_ptr_Function_float Function
+; CHECK: [[ld1:%\w+]] = OpLoad %float [[var1]]
+; CHECK: [[ld2:%\w+]] = OpLoad %float [[var2]]
+; CHECK: [[constr:%\w+]] = OpCompositeConstruct {{%\w+}} [[ld2]] [[ld1]]
+; CHECK: OpCompositeExtract {{%\w+}} [[constr]]
+OpCapability Shader
+OpExtension ""
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %1 "main"
+OpExecutionMode %1 OriginUpperLeft
+%void = OpTypeVoid
+%3 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%_struct_5 = OpTypeStruct %float %float
+%_ptr_Private__struct_5 = OpTypePointer Private %_struct_5
+%_ptr_Function__struct_5 = OpTypePointer Function %_struct_5
+%1 = OpFunction %void Inline %3
+%8 = OpLabel
+%9 = OpVariable %_ptr_Function__struct_5 Function
+%10 = OpLoad %_struct_5 %9
+%11 = OpCompositeExtract %_struct_5 %10
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<ScalarReplacementPass>(text, true);
+}
+
 }  // namespace
 }  // namespace opt
 }  // namespace spvtools


### PR DESCRIPTION
It is possible that OpCompositeExtract instructions will not have any
indexes.  This is not handled well by scalar replacement and instruction
folding.

Fixes https://crbug.com/1006435