### PR TITLE
spirv-fuzz: do not allow a dead break to target an unreachable block

### DIFF
--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -300,6 +300,13 @@ bool NewEdgeRespectsUseDefDominance(opt::IRContext* context,
   return true;
 }
 
+bool BlockIsReachableInItsFunction(opt::IRContext* context,
+                                   opt::BasicBlock* bb) {
+  auto enclosing_function = bb->GetParent();
+  return context->GetDominatorAnalysis(enclosing_function)
+      ->Dominates(enclosing_function->entry().get(), bb);
+}
+
 }  // namespace fuzzerutil
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -82,6 +82,11 @@ bool NewEdgeRespectsUseDefDominance(opt::IRContext* context,
                                     opt::BasicBlock* bb_from,
                                     opt::BasicBlock* bb_to);
 
+// Returns true if and only if there is a path to |bb| from the entry block of
+// the function that contains |bb|.
+bool BlockIsReachableInItsFunction(opt::IRContext* context,
+                                   opt::BasicBlock* bb);
+
 }  // namespace fuzzerutil
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_dead_break.cpp
+++ b/source/fuzz/transformation_add_dead_break.cpp
@@ -138,6 +138,13 @@ bool TransformationAddDeadBreak::IsApplicable(
     return false;
   }
 
+  if (!fuzzerutil::BlockIsReachableInItsFunction(context, bb_to)) {
+    // If the target of the break is unreachable, we conservatively do not
+    // allow adding a dead break, to avoid the compilations that arise due to
+    // the lack of sensible dominance information for unreachable blocks.
+    return false;
+  }
+
   // Check that |message_.from_block| ends with an unconditional branch.
   if (bb_from->terminator()->opcode() != SpvOpBranch) {
     // The block associated with the id does not end with an unconditional

--- a/source/fuzz/transformation_add_dead_continue.cpp
+++ b/source/fuzz/transformation_add_dead_continue.cpp
@@ -85,10 +85,9 @@ bool TransformationAddDeadContinue::IsApplicable(
 
   auto continue_block = context->cfg()->block(loop_header)->ContinueBlockId();
 
-  if (!context->GetDominatorAnalysis(bb_from->GetParent())
-           ->Dominates(loop_header, continue_block)) {
-    // If the loop's continue block is not dominated by the loop header, the
-    // continue block is unreachable. In that case, we conservatively do not
+  if (!fuzzerutil::BlockIsReachableInItsFunction(
+          context, context->cfg()->block(continue_block))) {
+    // If the loop's continue block is unreachable, we conservatively do not
     // allow adding a dead continue, to avoid the compilations that arise due to
     // the lack of sensible dominance information for unreachable blocks.
     return false;


### PR DESCRIPTION
Because dominance information becomes a bit unreliable when blocks are
unreachable, this change makes it so that the 'dead break'
transformation will not introduce a break to an unreachable block.

Fixes #2907.