### PR TITLE
Only allow previously declared forward refs in structs

### DIFF
--- a/source/val/validate_id.cpp
+++ b/source/val/validate_id.cpp
@@ -191,7 +191,14 @@ spv_result_t IdPass(ValidationState_t& _, Instruction* inst) {
             ret = SPV_SUCCESS;
           }
         } else if (can_have_forward_declared_ids(i)) {
-          ret = _.ForwardDeclareId(operand_word);
+          if (inst->opcode() == SpvOpTypeStruct &&
+              !_.IsForwardPointer(operand_word)) {
+            ret = _.diag(SPV_ERROR_INVALID_ID, inst)
+                  << "Operand " << _.getIdName(operand_word)
+                  << " requires a previous definition";
+          } else {
+            ret = _.ForwardDeclareId(operand_word);
+          }
         } else {
           ret = _.diag(SPV_ERROR_INVALID_ID, inst)
                 << "ID " << _.getIdName(operand_word)

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -658,9 +658,8 @@ TEST_F(ValidateData, missing_forward_pointer_decl) {
 )";
   CompileSuccessfully(str.c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("The following forward referenced IDs have not been defined:"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand 3[%3] requires a previous definition"));
 }
 
 TEST_F(ValidateData, missing_forward_pointer_decl_self_reference) {
@@ -670,8 +669,9 @@ TEST_F(ValidateData, missing_forward_pointer_decl_self_reference) {
 )";
   CompileSuccessfully(str.c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Structure members may not be self references"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Operand 2[%_struct_2] requires a previous definition"));
 }
 
 TEST_F(ValidateData, forward_pointer_missing_definition) {

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -5178,9 +5178,8 @@ TEST_F(ValidateIdWithMessage, UndefinedTypeId) {
 )";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("The following forward referenced IDs have not been defined"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand 2[%2] requires a previous definition"));
 }
 
 TEST_F(ValidateIdWithMessage, UndefinedIdScope) {
@@ -6465,6 +6464,26 @@ TEST_F(ValidateIdWithMessage, OpTypeForwardPointerWrongStorageClass) {
                 "pointer definition.\n  OpTypeForwardPointer "
                 "%_ptr_Function_int CrossWorkgroup"));
 }
+
+TEST_F(ValidateIdWithMessage, MissingForwardPointer) {
+  const std::string spirv = R"(
+               OpCapability Linkage
+               OpCapability Shader
+               OpMemoryModel Logical Simple
+      %float = OpTypeFloat 32
+  %_struct_9 = OpTypeStruct %float %_ptr_Uniform__struct_9
+%_ptr_Uniform__struct_9 = OpTypePointer Uniform %_struct_9
+       %1278 = OpVariable %_ptr_Uniform__struct_9 Uniform
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(
+          "Operand 3[%_ptr_Uniform__struct_2] requires a previous definition"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
Fixes https://crbug.com/1008130

* Restore a missing check that the only valid forward references in
structs are previously declared forward pointers