### PR TITLE
Validate physical storage buffer restrictions

### DIFF
--- a/source/val/validate_constants.cpp
+++ b/source/val/validate_constants.cpp
@@ -304,7 +304,6 @@ bool IsTypeNullable(const std::vector<uint32_t>& instruction,
     case SpvOpTypeBool:
     case SpvOpTypeInt:
     case SpvOpTypeFloat:
-    case SpvOpTypePointer:
     case SpvOpTypeEvent:
     case SpvOpTypeDeviceEvent:
     case SpvOpTypeReserveId:
@@ -325,6 +324,11 @@ bool IsTypeNullable(const std::vector<uint32_t>& instruction,
       }
       return true;
     }
+    case SpvOpTypePointer:
+      if (instruction[2] == SpvStorageClassPhysicalStorageBuffer) {
+        return false;
+      }
+      return true;
     default:
       return false;
   }

--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -1590,8 +1590,8 @@ spv_result_t ValidatePtrComparison(ValidationState_t& _,
            << "Operand type must be a pointer";
   }
 
+  SpvStorageClass sc = op1_type->GetOperandAs<SpvStorageClass>(1u);
   if (_.addressing_model() == SpvAddressingModelLogical) {
-    SpvStorageClass sc = op1_type->GetOperandAs<SpvStorageClass>(1u);
     if (sc != SpvStorageClassWorkgroup && sc != SpvStorageClassStorageBuffer) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
              << "Invalid pointer storage class";
@@ -1602,6 +1602,9 @@ spv_result_t ValidatePtrComparison(ValidationState_t& _,
              << "Workgroup storage class pointer requires VariablePointers "
                 "capability to be specified";
     }
+  } else if (sc == SpvStorageClassPhysicalStorageBuffer) {
+    return _.diag(SPV_ERROR_INVALID_ID, inst)
+           << "Cannot use a pointer in the PhysicalStorageBuffer storage class";
   }
 
   return SPV_SUCCESS;

--- a/test/opt/inst_buff_addr_check_test.cpp
+++ b/test/opt/inst_buff_addr_check_test.cpp
@@ -608,10 +608,12 @@ OpReturn
 OpFunctionEnd
 )";
 
+  // Issue #2929: cannot use OpConstantNull of a physical storage buffer
+  // pointer.
   SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   SinglePassRunAndCheck<InstBuffAddrCheckPass>(
       defs_before + func_before, defs_after + func_after + new_funcs, true,
-      true, 7u, 23u, 2u);
+      false, 7u, 23u, 2u);
 }
 
 }  // namespace

--- a/test/val/val_constants_test.cpp
+++ b/test/val/val_constants_test.cpp
@@ -458,6 +458,26 @@ OpMemoryModel Logical GLSL450
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
+TEST_F(ValidateConstant, NullPhysicalStorageBuffer) {
+  std::string spirv = R"(
+OpCapability Shader
+OpCapability PhysicalStorageBufferAddresses
+OpCapability Linkage
+OpExtension "SPV_KHR_physical_storage_buffer"
+OpMemoryModel PhysicalStorageBuffer64 GLSL450
+OpName %ptr "ptr"
+%int = OpTypeInt 32 0
+%ptr = OpTypePointer PhysicalStorageBuffer %int
+%null = OpConstantNull %ptr
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpConstantNull Result Type <id> '1[%ptr]' cannot have "
+                        "a null value"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
* Physical storage buffer cannot be used with OpConstantNull,
OpPtrEqual, OpPtrNotEqual or OpPtrDiff
  * new tests
  * see also #2929