### PR TITLE
Keep NOPs when comparing with original binary

### DIFF
--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -565,8 +565,11 @@ bool Optimizer::Run(const uint32_t* original_binary,
 
 #ifndef NDEBUG
   if (status == opt::Pass::Status::SuccessWithoutChange) {
-    auto changed = optimized_binary->size() != original_binary_size ||
-                   memcmp(optimized_binary->data(), original_binary,
+    std::vector<uint32_t> optimized_binary_with_nop;
+    context->module()->ToBinary(&optimized_binary_with_nop,
+                                /* skip_nop = */ false);
+    auto changed = optimized_binary_with_nop.size() != original_binary_size ||
+                   memcmp(optimized_binary_with_nop.data(), original_binary,
                           original_binary_size) != 0;
     assert(!changed &&
            "Binary unexpectedly changed despite optimizer saying there was no "


### PR DESCRIPTION
We have a check that ensures that the optimizer did not change the
binary when it says that it did not.  However, when the binary is
converted back to a binary, we made a decision to remove OpNop
instructions.  This means that any spv file that contains a NOP
originally will fail this check.

To get around this, we convert the module to a second binary that keeps
the OpNop instructions.  That binary is compared against the original.

Fixes https://crbug.com/1010191