### PR TITLE
spirv-fuzz: Rework id descriptors

### DIFF
--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -50,6 +50,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_split_blocks.h
         fuzzer_util.h
         id_use_descriptor.h
+        instruction_descriptor.h
         protobufs/spirvfuzz_protobufs.h
         pseudo_random_generator.h
         random_generator.h
@@ -99,6 +100,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_split_blocks.cpp
         fuzzer_util.cpp
         id_use_descriptor.cpp
+        instruction_descriptor.cpp
         pseudo_random_generator.cpp
         random_generator.cpp
         replayer.cpp

--- a/source/fuzz/force_render_red.cpp
+++ b/source/fuzz/force_render_red.cpp
@@ -15,6 +15,7 @@
 #include "source/fuzz/force_render_red.h"
 
 #include "source/fuzz/fact_manager.h"
+#include "source/fuzz/instruction_descriptor.h"
 #include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
 #include "source/fuzz/transformation_replace_constant_with_uniform.h"
 #include "source/fuzz/uniform_buffer_element_descriptor.h"
@@ -147,9 +148,10 @@ MakeConstantUniformReplacement(opt::IRContext* ir_context,
                                uint32_t greater_than_instruction,
                                uint32_t in_operand_index) {
   return MakeUnique<TransformationReplaceConstantWithUniform>(
-      transformation::MakeIdUseDescriptor(constant_id, SpvOpFOrdGreaterThan,
-                                          in_operand_index,
-                                          greater_than_instruction, 0),
+      MakeIdUseDescriptor(constant_id,
+                          MakeInstructionDescriptor(greater_than_instruction,
+                                                    SpvOpFOrdGreaterThan, 0),
+                          in_operand_index),
       fact_manager.GetUniformDescriptorsForConstant(ir_context, constant_id)[0],
       ir_context->TakeNextId(), ir_context->TakeNextId());
 }

--- a/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
@@ -85,8 +85,8 @@ void FuzzerPassApplyIdSynonyms::Apply() {
                     : GetFuzzerContext()->GetFreshId();
 
             TransformationReplaceIdWithSynonym replace_id_transformation(
-                transformation::MakeIdUseDescriptorFromUse(
-                    GetIRContext(), use_inst, use_in_operand_index),
+                MakeIdUseDescriptorFromUse(GetIRContext(), use_inst,
+                                           use_in_operand_index),
                 *synonym_to_try, fresh_id_for_temporary);
 
             // The transformation should be applicable by construction.

--- a/source/fuzz/id_use_descriptor.h
+++ b/source/fuzz/id_use_descriptor.h
@@ -12,28 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SOURCE_FUZZ_ID_USE_LOCATOR_H_
-#define SOURCE_FUZZ_ID_USE_LOCATOR_H_
+#ifndef SOURCE_FUZZ_ID_USE_DESCRIPTOR_H_
+#define SOURCE_FUZZ_ID_USE_DESCRIPTOR_H_
 
 #include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
 #include "source/opt/ir_context.h"
 
 namespace spvtools {
 namespace fuzz {
-namespace transformation {
 
-// Looks for an instruction in |context| such that the id use represented by
-// |descriptor| is one of the operands to said instruction.  Returns |nullptr|
-// if no such instruction can be found.
-opt::Instruction* FindInstruction(const protobufs::IdUseDescriptor& descriptor,
-                                  opt::IRContext* context);
+// Looks for an instruction in |context| that contains a use
+// identified by |id_use_descriptor|.
+// Returns |nullptr| if no such instruction can be found.
+opt::Instruction* FindInstructionContainingUse(
+    const protobufs::IdUseDescriptor& id_use_descriptor,
+    opt::IRContext* context);
 
 // Creates an IdUseDescriptor protobuf message from the given components.
 // See the protobuf definition for details of what these components mean.
 protobufs::IdUseDescriptor MakeIdUseDescriptor(
-    uint32_t id_of_interest, SpvOp target_instruction_opcode,
-    uint32_t in_operand_index, uint32_t base_instruction_result_id,
-    uint32_t num_opcodes_to_ignore);
+    uint32_t id_of_interest,
+    const protobufs::InstructionDescriptor& enclosing_instruction,
+    uint32_t in_operand_index);
 
 // Given an id use, represented by the instruction |inst| that uses the id, and
 // the input operand index |in_operand_index| associated with the usage, returns
@@ -41,8 +41,7 @@ protobufs::IdUseDescriptor MakeIdUseDescriptor(
 protobufs::IdUseDescriptor MakeIdUseDescriptorFromUse(
     opt::IRContext* context, opt::Instruction* inst, uint32_t in_operand_index);
 
-}  // namespace transformation
 }  // namespace fuzz
 }  // namespace spvtools
 
-#endif  // SOURCE_FUZZ_ID_USE_LOCATOR_H_
+#endif  // SOURCE_FUZZ_ID_USE_DESCRIPTOR_H_

--- a/source/fuzz/instruction_descriptor.cpp
+++ b/source/fuzz/instruction_descriptor.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/instruction_descriptor.h"
+
+namespace spvtools {
+namespace fuzz {
+
+opt::Instruction* FindInstruction(
+    const protobufs::InstructionDescriptor& instruction_descriptor,
+    spvtools::opt::IRContext* context) {
+  for (auto& function : *context->module()) {
+    for (auto& block : function) {
+      bool found_base =
+          block.id() == instruction_descriptor.base_instruction_result_id();
+      uint32_t num_ignored = 0;
+      for (auto& instruction : block) {
+        if (instruction.HasResultId() &&
+            instruction.result_id() ==
+                instruction_descriptor.base_instruction_result_id()) {
+          assert(!found_base &&
+                 "It should not be possible to find the base instruction "
+                 "multiple times.");
+          found_base = true;
+          assert(num_ignored == 0 &&
+                 "The skipped instruction count should only be incremented "
+                 "after the instruction base has been found.");
+        }
+        if (found_base &&
+            instruction.opcode() ==
+                instruction_descriptor.target_instruction_opcode()) {
+          if (num_ignored == instruction_descriptor.num_opcodes_to_ignore()) {
+            return &instruction;
+          }
+          num_ignored++;
+        }
+      }
+      if (found_base) {
+        // We found the base instruction, but did not find the target
+        // instruction in the same block.
+        return nullptr;
+      }
+    }
+  }
+  return nullptr;
+}
+
+protobufs::InstructionDescriptor MakeInstructionDescriptor(
+    uint32_t base_instruction_result_id, SpvOp target_instruction_opcode,
+    uint32_t num_opcodes_to_ignore) {
+  protobufs::InstructionDescriptor result;
+  result.set_base_instruction_result_id(base_instruction_result_id);
+  result.set_target_instruction_opcode(target_instruction_opcode);
+  result.set_num_opcodes_to_ignore(num_opcodes_to_ignore);
+  return result;
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/instruction_descriptor.h
+++ b/source/fuzz/instruction_descriptor.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_INSTRUCTION_DESCRIPTOR_H_
+#define SOURCE_FUZZ_INSTRUCTION_DESCRIPTOR_H_
+
+#include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
+#include "source/opt/ir_context.h"
+
+namespace spvtools {
+namespace fuzz {
+
+// Looks for an instruction in |context| corresponding to |descriptor|.
+// Returns |nullptr| if no such instruction can be found.
+opt::Instruction* FindInstruction(
+    const protobufs::InstructionDescriptor& instruction_descriptor,
+    opt::IRContext* context);
+
+// Creates an InstructionDescriptor protobuf message from the given
+// components.  See the protobuf definition for details of what these
+// components mean.
+protobufs::InstructionDescriptor MakeInstructionDescriptor(
+    uint32_t base_instruction_result_id, SpvOp target_instruction_opcode,
+    uint32_t num_opcodes_to_ignore);
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_INSTRUCTION_DESCRIPTOR_H_

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -21,6 +21,24 @@ syntax = "proto3";
 
 package spvtools.fuzz.protobufs;
 
+message InstructionDescriptor {
+
+  // Describes an instruction in some block of a function with respect to a
+  // base instruction.
+
+  // The id of an instruction after which the instruction being described is
+  // believed to be located.  It might be the using instruction itself.
+  uint32 base_instruction_result_id = 1;
+
+  // The opcode for the instruction being described.
+  uint32 target_instruction_opcode = 2;
+
+  // The number of matching opcodes to skip over when searching from the base
+  // instruction to the instruction being described.
+  uint32 num_opcodes_to_ignore = 3;
+
+}
+
 message IdUseDescriptor {
 
   // Describes a use of an id as an input operand to an instruction in some
@@ -28,10 +46,12 @@ message IdUseDescriptor {
 
   // Example:
   //   - id_of_interest = 42
-  //   - target_instruction_opcode = OpStore
+  //   - enclosing_instruction = (
+  //         base_instruction_result_id = 50,
+  //         target_instruction_opcode = OpStore
+  //         num_opcodes_to_ignore = 7
+  //     )
   //   - in_operand_index = 1
-  //   - base_instruction_result_id = 50
-  //   - num_opcodes_to_ignore = 7
   // represents a use of id 42 as input operand 1 to an OpStore instruction,
   // such that the OpStore instruction can be found in the same basic block as
   // the instruction with result id 50, and in particular is the 8th OpStore
@@ -41,19 +61,10 @@ message IdUseDescriptor {
   // An id that we would like to be able to find a use of.
   uint32 id_of_interest = 1;
 
-  // The opcode for the instruction that uses the id.
-  uint32 target_instruction_opcode = 2;
-
   // The input operand index at which the use is expected.
+  InstructionDescriptor enclosing_instruction = 2;
+
   uint32 in_operand_index = 3;
-
-  // The id of an instruction after which the instruction that contains the use
-  // is believed to occur; it might be the using instruction itself.
-  uint32 base_instruction_result_id = 4;
-
-  // The number of matching opcodes to skip over when searching for the using
-  // instruction from the base instruction.
-  uint32 num_opcodes_to_ignore = 5;
 
 }
 

--- a/source/fuzz/transformation_replace_boolean_constant_with_constant_binary.cpp
+++ b/source/fuzz/transformation_replace_boolean_constant_with_constant_binary.cpp
@@ -238,7 +238,7 @@ bool TransformationReplaceBooleanConstantWithConstantBinary::IsApplicable(
 
   // The id use descriptor must identify some instruction
   auto instruction =
-      transformation::FindInstruction(message_.id_use_descriptor(), context);
+      FindInstructionContainingUse(message_.id_use_descriptor(), context);
   if (instruction == nullptr) {
     return false;
   }
@@ -268,7 +268,7 @@ TransformationReplaceBooleanConstantWithConstantBinary::ApplyWithResult(
       message_.fresh_id_for_binary_operation(), operands);
   opt::Instruction* result = binary_instruction.get();
   auto instruction_containing_constant_use =
-      transformation::FindInstruction(message_.id_use_descriptor(), context);
+      FindInstructionContainingUse(message_.id_use_descriptor(), context);
 
   // We want to insert the new instruction before the instruction that contains
   // the use of the boolean, but we need to go backwards one more instruction if

--- a/source/fuzz/transformation_replace_constant_with_uniform.cpp
+++ b/source/fuzz/transformation_replace_constant_with_uniform.cpp
@@ -149,7 +149,7 @@ bool TransformationReplaceConstantWithUniform::IsApplicable(
   // The id use descriptor must identify some instruction with respect to the
   // module.
   auto instruction_using_constant =
-      transformation::FindInstruction(message_.id_use_descriptor(), context);
+      FindInstructionContainingUse(message_.id_use_descriptor(), context);
   if (!instruction_using_constant) {
     return false;
   }
@@ -188,7 +188,7 @@ void TransformationReplaceConstantWithUniform::Apply(
     spvtools::fuzz::FactManager* /*unused*/) const {
   // Get the instruction that contains the id use we wish to replace.
   auto instruction_containing_constant_use =
-      transformation::FindInstruction(message_.id_use_descriptor(), context);
+      FindInstructionContainingUse(message_.id_use_descriptor(), context);
   assert(instruction_containing_constant_use &&
          "Precondition requires that the id use can be found.");
   assert(instruction_containing_constant_use->GetSingleWordInOperand(

--- a/source/fuzz/transformation_replace_id_with_synonym.cpp
+++ b/source/fuzz/transformation_replace_id_with_synonym.cpp
@@ -62,7 +62,7 @@ bool TransformationReplaceIdWithSynonym::IsApplicable(
 
   // Does the id use descriptor in the transformation identify an instruction?
   auto use_instruction =
-      transformation::FindInstruction(message_.id_use_descriptor(), context);
+      FindInstructionContainingUse(message_.id_use_descriptor(), context);
   if (!use_instruction) {
     return false;
   }
@@ -101,7 +101,7 @@ void TransformationReplaceIdWithSynonym::Apply(
     spvtools::opt::IRContext* context,
     spvtools::fuzz::FactManager* /*unused*/) const {
   auto instruction_to_change =
-      transformation::FindInstruction(message_.id_use_descriptor(), context);
+      FindInstructionContainingUse(message_.id_use_descriptor(), context);
 
   // Ultimately we are going to replace the id use identified in the
   // transformation with |replacement_id|, which will either be the synonym's

--- a/test/fuzz/transformation_replace_boolean_constant_with_constant_binary_test.cpp
+++ b/test/fuzz/transformation_replace_boolean_constant_with_constant_binary_test.cpp
@@ -16,6 +16,7 @@
 
 #include "source/fuzz/fuzzer_util.h"
 #include "source/fuzz/id_use_descriptor.h"
+#include "source/fuzz/instruction_descriptor.h"
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -164,12 +165,14 @@ TEST(TransformationReplaceBooleanConstantWithConstantBinaryTest,
   FactManager fact_manager;
 
   std::vector<protobufs::IdUseDescriptor> uses_of_true = {
-      transformation::MakeIdUseDescriptor(41, SpvOpStore, 1, 44, 12),
-      transformation::MakeIdUseDescriptor(41, SpvOpLogicalOr, 0, 46, 0)};
+      MakeIdUseDescriptor(41, MakeInstructionDescriptor(44, SpvOpStore, 12), 1),
+      MakeIdUseDescriptor(41, MakeInstructionDescriptor(46, SpvOpLogicalOr, 0),
+                          0)};
 
   std::vector<protobufs::IdUseDescriptor> uses_of_false = {
-      transformation::MakeIdUseDescriptor(43, SpvOpStore, 1, 44, 13),
-      transformation::MakeIdUseDescriptor(43, SpvOpLogicalAnd, 1, 48, 0)};
+      MakeIdUseDescriptor(43, MakeInstructionDescriptor(44, SpvOpStore, 13), 1),
+      MakeIdUseDescriptor(43, MakeInstructionDescriptor(48, SpvOpLogicalAnd, 0),
+                          1)};
 
   const uint32_t fresh_id = 100;
 
@@ -529,10 +532,10 @@ TEST(TransformationReplaceBooleanConstantWithConstantBinaryTest,
 
   FactManager fact_manager;
 
-  auto use_of_true_in_if =
-      transformation::MakeIdUseDescriptor(13, SpvOpBranchConditional, 0, 10, 0);
-  auto use_of_false_in_while =
-      transformation::MakeIdUseDescriptor(21, SpvOpBranchConditional, 0, 16, 0);
+  auto use_of_true_in_if = MakeIdUseDescriptor(
+      13, MakeInstructionDescriptor(10, SpvOpBranchConditional, 0), 0);
+  auto use_of_false_in_while = MakeIdUseDescriptor(
+      21, MakeInstructionDescriptor(16, SpvOpBranchConditional, 0), 0);
 
   auto replacement_1 = TransformationReplaceBooleanConstantWithConstantBinary(
       use_of_true_in_if, 9, 11, SpvOpSLessThan, 100);
@@ -641,8 +644,8 @@ TEST(TransformationReplaceBooleanConstantWithConstantBinaryTest, OpPhi) {
   FactManager fact_manager;
 
   auto replacement = TransformationReplaceBooleanConstantWithConstantBinary(
-      transformation::MakeIdUseDescriptor(9, SpvOpPhi, 0, 23, 0), 13, 15,
-      SpvOpSLessThan, 100);
+      MakeIdUseDescriptor(9, MakeInstructionDescriptor(23, SpvOpPhi, 0), 0), 13,
+      15, SpvOpSLessThan, 100);
 
   ASSERT_FALSE(replacement.IsApplicable(context.get(), fact_manager));
 }

--- a/test/fuzz/transformation_replace_constant_with_uniform_test.cpp
+++ b/test/fuzz/transformation_replace_constant_with_uniform_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_replace_constant_with_uniform.h"
+#include "source/fuzz/instruction_descriptor.h"
 #include "source/fuzz/uniform_buffer_element_descriptor.h"
 #include "test/fuzz/fuzz_test_util.h"
 
@@ -116,11 +117,11 @@ TEST(TransformationReplaceConstantWithUniformTest, BasicReplacements) {
 
   // The constant ids are 9, 11 and 14, for 1, 2 and 3 respectively.
   protobufs::IdUseDescriptor use_of_9_in_store =
-      transformation::MakeIdUseDescriptor(9, SpvOpStore, 1, 8, 0);
+      MakeIdUseDescriptor(9, MakeInstructionDescriptor(8, SpvOpStore, 0), 1);
   protobufs::IdUseDescriptor use_of_11_in_add =
-      transformation::MakeIdUseDescriptor(11, SpvOpIAdd, 1, 12, 0);
+      MakeIdUseDescriptor(11, MakeInstructionDescriptor(12, SpvOpIAdd, 0), 1);
   protobufs::IdUseDescriptor use_of_14_in_add =
-      transformation::MakeIdUseDescriptor(14, SpvOpIAdd, 0, 15, 0);
+      MakeIdUseDescriptor(14, MakeInstructionDescriptor(15, SpvOpIAdd, 0), 0);
 
   // These transformations work: they match the facts.
   auto transformation_use_of_9_in_store =
@@ -167,7 +168,7 @@ TEST(TransformationReplaceConstantWithUniformTest, BasicReplacements) {
   // The following transformation does not apply because the id descriptor is
   // not sensible.
   protobufs::IdUseDescriptor nonsense_id_use_descriptor =
-      transformation::MakeIdUseDescriptor(9, SpvOpIAdd, 0, 15, 0);
+      MakeIdUseDescriptor(9, MakeInstructionDescriptor(15, SpvOpIAdd, 0), 0);
   ASSERT_FALSE(TransformationReplaceConstantWithUniform(
                    nonsense_id_use_descriptor, blockname_a, 101, 102)
                    .IsApplicable(context.get(), fact_manager));
@@ -477,13 +478,13 @@ TEST(TransformationReplaceConstantWithUniformTest, NestedStruct) {
 
   // The constant ids are 13, 15, 17 and 20, for 1, 2, 3 and 4 respectively.
   protobufs::IdUseDescriptor use_of_13_in_store =
-      transformation::MakeIdUseDescriptor(13, SpvOpStore, 1, 21, 0);
+      MakeIdUseDescriptor(13, MakeInstructionDescriptor(21, SpvOpStore, 0), 1);
   protobufs::IdUseDescriptor use_of_15_in_add =
-      transformation::MakeIdUseDescriptor(15, SpvOpIAdd, 1, 16, 0);
+      MakeIdUseDescriptor(15, MakeInstructionDescriptor(16, SpvOpIAdd, 0), 1);
   protobufs::IdUseDescriptor use_of_17_in_add =
-      transformation::MakeIdUseDescriptor(17, SpvOpIAdd, 0, 19, 0);
+      MakeIdUseDescriptor(17, MakeInstructionDescriptor(19, SpvOpIAdd, 0), 0);
   protobufs::IdUseDescriptor use_of_20_in_store =
-      transformation::MakeIdUseDescriptor(20, SpvOpStore, 1, 19, 1);
+      MakeIdUseDescriptor(20, MakeInstructionDescriptor(19, SpvOpStore, 1), 1);
 
   // These transformations work: they match the facts.
   auto transformation_use_of_13_in_store =
@@ -703,7 +704,7 @@ TEST(TransformationReplaceConstantWithUniformTest, NoUniformIntPointerPresent) {
 
   // The constant id is 9 for 0.
   protobufs::IdUseDescriptor use_of_9_in_store =
-      transformation::MakeIdUseDescriptor(9, SpvOpStore, 1, 8, 0);
+      MakeIdUseDescriptor(9, MakeInstructionDescriptor(8, SpvOpStore, 0), 1);
 
   // This transformation is not available because no uniform pointer to integer
   // type is present:
@@ -778,7 +779,7 @@ TEST(TransformationReplaceConstantWithUniformTest, NoConstantPresentForIndex) {
 
   // The constant id is 9 for 9.
   protobufs::IdUseDescriptor use_of_9_in_store =
-      transformation::MakeIdUseDescriptor(9, SpvOpStore, 1, 8, 0);
+      MakeIdUseDescriptor(9, MakeInstructionDescriptor(8, SpvOpStore, 0), 1);
 
   // This transformation is not available because no constant is present for the
   // index 1 required to index into the uniform buffer:
@@ -852,7 +853,7 @@ TEST(TransformationReplaceConstantWithUniformTest,
 
   // The constant id is 9 for 3.0.
   protobufs::IdUseDescriptor use_of_9_in_store =
-      transformation::MakeIdUseDescriptor(9, SpvOpStore, 1, 8, 0);
+      MakeIdUseDescriptor(9, MakeInstructionDescriptor(8, SpvOpStore, 0), 1);
 
   // This transformation is not available because no integer type is present to
   // allow a constant index to be expressed:
@@ -937,9 +938,9 @@ TEST(TransformationReplaceConstantWithUniformTest,
 
   // The constant ids for 9 and 10 are 9 and 11 respectively
   protobufs::IdUseDescriptor use_of_9_in_store =
-      transformation::MakeIdUseDescriptor(9, SpvOpStore, 1, 10, 0);
+      MakeIdUseDescriptor(9, MakeInstructionDescriptor(10, SpvOpStore, 0), 1);
   protobufs::IdUseDescriptor use_of_11_in_store =
-      transformation::MakeIdUseDescriptor(11, SpvOpStore, 1, 10, 1);
+      MakeIdUseDescriptor(11, MakeInstructionDescriptor(10, SpvOpStore, 1), 1);
 
   // These are right:
   ASSERT_TRUE(TransformationReplaceConstantWithUniform(use_of_9_in_store,
@@ -1220,58 +1221,58 @@ TEST(TransformationReplaceConstantWithUniformTest, ComplexReplacements) {
   std::vector<TransformationReplaceConstantWithUniform> transformations;
 
   transformations.emplace_back(TransformationReplaceConstantWithUniform(
-      transformation::MakeIdUseDescriptor(18, SpvOpStore, 1, 20, 0),
+      MakeIdUseDescriptor(18, MakeInstructionDescriptor(20, SpvOpStore, 0), 1),
       uniform_f_a_4, 200, 201));
   transformations.emplace_back(TransformationReplaceConstantWithUniform(
-      transformation::MakeIdUseDescriptor(22, SpvOpStore, 1, 23, 0),
+      MakeIdUseDescriptor(22, MakeInstructionDescriptor(23, SpvOpStore, 0), 1),
       uniform_f_a_3, 202, 203));
   transformations.emplace_back(TransformationReplaceConstantWithUniform(
-      transformation::MakeIdUseDescriptor(25, SpvOpStore, 1, 26, 0),
+      MakeIdUseDescriptor(25, MakeInstructionDescriptor(26, SpvOpStore, 0), 1),
       uniform_f_a_2, 204, 205));
   transformations.emplace_back(TransformationReplaceConstantWithUniform(
-      transformation::MakeIdUseDescriptor(28, SpvOpStore, 1, 29, 0),
+      MakeIdUseDescriptor(28, MakeInstructionDescriptor(29, SpvOpStore, 0), 1),
       uniform_f_a_1, 206, 207));
   transformations.emplace_back(TransformationReplaceConstantWithUniform(
-      transformation::MakeIdUseDescriptor(31, SpvOpStore, 1, 32, 0),
+      MakeIdUseDescriptor(31, MakeInstructionDescriptor(32, SpvOpStore, 0), 1),
       uniform_f_a_0, 208, 209));
 
   transformations.emplace_back(TransformationReplaceConstantWithUniform(
-      transformation::MakeIdUseDescriptor(30, SpvOpStore, 1, 35, 0),
+      MakeIdUseDescriptor(30, MakeInstructionDescriptor(35, SpvOpStore, 0), 1),
       uniform_f_b_w, 210, 211));
   transformations.emplace_back(TransformationReplaceConstantWithUniform(
-      transformation::MakeIdUseDescriptor(27, SpvOpStore, 1, 37, 0),
+      MakeIdUseDescriptor(27, MakeInstructionDescriptor(37, SpvOpStore, 0), 1),
       uniform_f_b_z, 212, 213));
   transformations.emplace_back(TransformationReplaceConstantWithUniform(
-      transformation::MakeIdUseDescriptor(24, SpvOpStore, 1, 39, 0),
+      MakeIdUseDescriptor(24, MakeInstructionDescriptor(39, SpvOpStore, 0), 1),
       uniform_f_b_y, 214, 215));
   transformations.emplace_back(TransformationReplaceConstantWithUniform(
-      transformation::MakeIdUseDescriptor(21, SpvOpStore, 1, 41, 0),
+      MakeIdUseDescriptor(21, MakeInstructionDescriptor(41, SpvOpStore, 0), 1),
       uniform_f_b_x, 216, 217));
 
   transformations.emplace_back(TransformationReplaceConstantWithUniform(
-      transformation::MakeIdUseDescriptor(44, SpvOpStore, 1, 45, 0),
+      MakeIdUseDescriptor(44, MakeInstructionDescriptor(45, SpvOpStore, 0), 1),
       uniform_f_c_z, 220, 221));
   transformations.emplace_back(TransformationReplaceConstantWithUniform(
-      transformation::MakeIdUseDescriptor(46, SpvOpStore, 1, 47, 0),
+      MakeIdUseDescriptor(46, MakeInstructionDescriptor(47, SpvOpStore, 0), 1),
       uniform_f_c_y, 222, 223));
   transformations.emplace_back(TransformationReplaceConstantWithUniform(
-      transformation::MakeIdUseDescriptor(48, SpvOpStore, 1, 49, 0),
+      MakeIdUseDescriptor(48, MakeInstructionDescriptor(49, SpvOpStore, 0), 1),
       uniform_f_c_x, 224, 225));
 
   transformations.emplace_back(TransformationReplaceConstantWithUniform(
-      transformation::MakeIdUseDescriptor(50, SpvOpStore, 1, 52, 0),
+      MakeIdUseDescriptor(50, MakeInstructionDescriptor(52, SpvOpStore, 0), 1),
       uniform_f_d, 226, 227));
 
   transformations.emplace_back(TransformationReplaceConstantWithUniform(
-      transformation::MakeIdUseDescriptor(53, SpvOpStore, 1, 54, 0),
+      MakeIdUseDescriptor(53, MakeInstructionDescriptor(54, SpvOpStore, 0), 1),
       uniform_h_x, 228, 229));
   transformations.emplace_back(TransformationReplaceConstantWithUniform(
-      transformation::MakeIdUseDescriptor(55, SpvOpStore, 1, 56, 0),
+      MakeIdUseDescriptor(55, MakeInstructionDescriptor(56, SpvOpStore, 0), 1),
       uniform_h_y, 230, 231));
 
   transformations.emplace_back(TransformationReplaceConstantWithUniform(
-      transformation::MakeIdUseDescriptor(42, SpvOpStore, 1, 43, 0), uniform_g,
-      218, 219));
+      MakeIdUseDescriptor(42, MakeInstructionDescriptor(43, SpvOpStore, 0), 1),
+      uniform_g, 218, 219));
 
   for (auto& transformation : transformations) {
     ASSERT_TRUE(transformation.IsApplicable(context.get(), fact_manager));


### PR DESCRIPTION
A refactoring that separates the identification of an instruction from
the identification of a use in an instruction, to enable the former to
be used independently of the latter.