### PR TITLE
Validate that selections are structured

### DIFF
--- a/source/val/validate_cfg.cpp
+++ b/source/val/validate_cfg.cpp
@@ -606,6 +606,7 @@ spv_result_t ValidateStructuredSelections(
       seen.insert(merge->GetOperandAs<uint32_t>(0));
       seen.insert(merge->GetOperandAs<uint32_t>(1));
     } else {
+      // Only track the pointer if it is a merge instruction.
       merge = nullptr;
     }
 

--- a/source/val/validate_cfg.cpp
+++ b/source/val/validate_cfg.cpp
@@ -590,6 +590,9 @@ spv_result_t StructuredSwitchChecks(ValidationState_t& _, Function* function,
   return SPV_SUCCESS;
 }
 
+// Validates that all CFG divergences (i.e. conditional branch or switch) are
+// structured correctly. Either divergence is preceded by a merge instruction
+// or the divergence introduces at most one unseen label.
 spv_result_t ValidateStructuredSelections(
     ValidationState_t& _, const std::vector<const BasicBlock*>& postorder) {
   std::unordered_set<uint32_t> seen;

--- a/test/opt/if_conversion_test.cpp
+++ b/test/opt/if_conversion_test.cpp
@@ -375,14 +375,12 @@ OpEntryPoint Vertex %1 "func" %2
 OpSelectionMerge %12 None
 OpBranchConditional %true %13 %12
 %13 = OpLabel
-OpBranchConditional %true %14 %15
+OpBranchConditional %true %14 %12
 %14 = OpLabel
 OpBranch %12
-%15 = OpLabel
-OpBranch %12
 %12 = OpLabel
-%16 = OpPhi %uint %uint_0 %11 %uint_0 %14 %uint_1 %15
-OpStore %2 %16
+%15 = OpPhi %uint %uint_0 %11 %uint_0 %13 %uint_1 %14
+OpStore %2 %15
 OpReturn
 OpFunctionEnd
 )";

--- a/test/val/val_cfg_test.cpp
+++ b/test/val/val_cfg_test.cpp
@@ -3026,6 +3026,7 @@ OpMemoryModel Logical GLSL450
 %undef = OpUndef %bool
 %func = OpFunction %void None %void_fn
 %entry = OpLabel
+OpSelectionMerge %block None
 OpBranchConditional %undef %block %unreachable
 %block = OpLabel
 OpReturn
@@ -3049,6 +3050,7 @@ OpMemoryModel Logical GLSL450
 %undef = OpUndef %int
 %func = OpFunction %void None %void_fn
 %entry = OpLabel
+OpSelectionMerge %block1 None
 OpSwitch %undef %block1 0 %unreachable 1 %block2
 %block1 = OpLabel
 OpReturn


### PR DESCRIPTION
Validate that all selections are structured (i.e. are preceeded by a merge instruction) where necessary.

Checks that switches and conditional branches are preceeded by a merge instruction if two or more  unique targets have not yet been encountered in a reverse post order traversal. This intentional does not flag code like:
```
%b0 = OpLabel
OpSelectionMerge %b3 None
OpBranchConditional %c1 %b1 %b2
%b1 = OpLabel
OpBranchConditional %c2 %b2 %b3 ; not an error
%b2 = OpLabel
OpBranch %b3
%b3 = OpLabel
```

Updated a few offending unit tests. Tested against CTS.