### PR TITLE
Ensure timestamp does not vary with timezone.

### DIFF
--- a/utils/update_build_version.py
+++ b/utils/update_build_version.py
@@ -119,7 +119,7 @@ def describe(directory):
             # clock time with enviornment variable SOURCE_DATE_EPOCH
             # containing a (presumably) fixed timestamp.
             timestamp = int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
-            formatted = datetime.date.fromtimestamp(timestamp).isoformat()
+            formatted = datetime.datetime.utcfromtimestamp(timestamp).isoformat()
             return 'unknown hash, {}'.format(formatted)
 
 


### PR DESCRIPTION
Thanks for implementing `SOURCE_DATE_EPOCH`. However, I think that the timestamp you then generate using `isoformat` varies with the build user's timezone. This should make it use UTC instead.