### PR TITLE
Check that derivatives operate on 32-bit values

### DIFF
--- a/source/val/validate_derivatives.cpp
+++ b/source/val/validate_derivatives.cpp
@@ -46,6 +46,10 @@ spv_result_t DerivativesPass(ValidationState_t& _, const Instruction* inst) {
                << "Expected Result Type to be float scalar or vector type: "
                << spvOpcodeString(opcode);
       }
+      if (!_.ContainsSizedIntOrFloatType(result_type, SpvOpTypeFloat, 32)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << "Result type component width must be 32 bits";
+      }
 
       const uint32_t p_type = _.GetOperandTypeId(inst, 2);
       if (p_type != result_type) {

--- a/test/val/val_derivatives_test.cpp
+++ b/test/val/val_derivatives_test.cpp
@@ -173,7 +173,7 @@ TEST_P(ValidateHalfDerivatives, ScalarFailure) {
               HasSubstr("Result type component width must be 32 bits"));
 }
 
-TEST_P(ValidateHalfDerivatives, VectorSuccess) {
+TEST_P(ValidateHalfDerivatives, VectorFailure) {
   const std::string op = GetParam();
   const std::string body = "%val = " + op + " %f16vec4 %f16vec4_0\n";
 

--- a/test/val/val_derivatives_test.cpp
+++ b/test/val/val_derivatives_test.cpp
@@ -185,15 +185,10 @@ TEST_P(ValidateHalfDerivatives, VectorSuccess) {
 }
 
 INSTANTIATE_TEST_SUITE_P(HalfDerivatives, ValidateHalfDerivatives,
-                         ::testing::Values("OpDPdx",
-                                           "OpDPdy",
-                                           "OpFwidth",
-                                           "OpDPdxFine",
-                                           "OpDPdyFine",
-                                           "OpFwidthFine",
-                                           "OpDPdxCoarse",
-                                           "OpDPdyCoarse",
-                                           "OpFwidthCoarse"));
+                         ::testing::Values("OpDPdx", "OpDPdy", "OpFwidth",
+                                           "OpDPdxFine", "OpDPdyFine",
+                                           "OpFwidthFine", "OpDPdxCoarse",
+                                           "OpDPdyCoarse", "OpFwidthCoarse"));
 
 }  // namespace
 }  // namespace val

--- a/test/val/val_derivatives_test.cpp
+++ b/test/val/val_derivatives_test.cpp
@@ -62,7 +62,17 @@ OpCapability DerivativeControl
 
 %f32vec4_ptr_input = OpTypePointer Input %f32vec4
 %f32vec4_var_input = OpVariable %f32vec4_ptr_input Input
+)";
 
+  if (capabilities_and_extensions.find("OpCapability Float16") !=
+      std::string::npos) {
+    ss << "%f16 = OpTypeFloat 16\n"
+       << "%f16vec4 = OpTypeVector %f16 4\n"
+       << "%f16_0 = OpConstantNull %f16\n"
+       << "%f16vec4_0 = OpConstantNull %f16vec4\n";
+  }
+
+  ss << R"(
 %main = OpFunction %void None %func
 %main_entry = OpLabel
 )";
@@ -149,6 +159,41 @@ TEST_F(ValidateDerivatives, OpDPdxWrongExecutionModel) {
               HasSubstr("Derivative instructions require Fragment or GLCompute "
                         "execution model: DPdx"));
 }
+
+using ValidateHalfDerivatives = spvtest::ValidateBase<std::string>;
+
+TEST_P(ValidateHalfDerivatives, ScalarFailure) {
+  const std::string op = GetParam();
+  const std::string body = "%val = " + op + " %f16 %f16_0\n";
+
+  CompileSuccessfully(
+      GenerateShaderCode(body, "OpCapability Float16\n").c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Result type component width must be 32 bits"));
+}
+
+TEST_P(ValidateHalfDerivatives, VectorSuccess) {
+  const std::string op = GetParam();
+  const std::string body = "%val = " + op + " %f16vec4 %f16vec4_0\n";
+
+  CompileSuccessfully(
+      GenerateShaderCode(body, "OpCapability Float16\n").c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Result type component width must be 32 bits"));
+}
+
+INSTANTIATE_TEST_SUITE_P(HalfDerivatives, ValidateHalfDerivatives,
+                         ::testing::Values("OpDPdx",
+                                           "OpDPdy",
+                                           "OpFwidth",
+                                           "OpDPdxFine",
+                                           "OpDPdyFine",
+                                           "OpFwidthFine",
+                                           "OpDPdxCoarse",
+                                           "OpDPdyCoarse",
+                                           "OpFwidthCoarse"));
 
 }  // namespace
 }  // namespace val


### PR DESCRIPTION
* Add a check that derivative functions only operate on scalar or vector
32-bit floating point values
* Added tests to disallow half derivatives