### PR TITLE
spirv-fuzz: add class to represent equivalence relation

### DIFF
--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -30,6 +30,7 @@ if(SPIRV_BUILD_FUZZER)
 
   set(SPIRV_TOOLS_FUZZ_SOURCES
         data_descriptor.h
+        equivalence_relation.h
         fact_manager.h
         force_render_red.h
         fuzzer.h

--- a/source/fuzz/equivalence_relation.h
+++ b/source/fuzz/equivalence_relation.h
@@ -27,7 +27,7 @@ namespace fuzz {
 
 // A class for representing an equivalence relation on objects of type |T|,
 // which should be a value type.  The type |T| is required to have a copy
-// constructor, and the |PointerHashT| and |PointerEqualsT| must be functors
+// constructor, and |PointerHashT| and |PointerEqualsT| must be functors
 // providing hashing and equality testing functionality for pointers to objects
 // of type |T|.
 //

--- a/source/fuzz/equivalence_relation.h
+++ b/source/fuzz/equivalence_relation.h
@@ -1,0 +1,181 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_EQUIVALENCE_RELATION_H_
+#define SOURCE_FUZZ_EQUIVALENCE_RELATION_H_
+
+#include <map>
+#include <memory>
+#include <set>
+#include <unordered_set>
+#include <vector>
+
+#include "source/util/make_unique.h"
+
+namespace spvtools {
+namespace fuzz {
+
+// A class for representing an equivalence relation on objects of type |T|,
+// which should be a value type.  The type |T| is required to have a copy
+// constructor, and the |PointerHashT| and |PointerEqualsT| must be functors
+// providing hashing and equality testing functionality for pointers to objects
+// of type |T|.
+template <typename T, typename PointerHashT, typename PointerEqualsT>
+class EquivalenceRelation {
+ public:
+  using ValueSet = std::unordered_set<const T*, PointerHashT, PointerEqualsT>;
+
+  // Merges the equivalence classes associated with |value1| and |value2|.
+  // If any of these values was not previously in the equivalence relation, it
+  // is added to the pool of values known to be in the relation.
+  void MakeEquivalent(const T& value1, const T& value2) {
+    // Register each value if necessary.
+    for (auto value : {value1, value2}) {
+      if (!Exists(value)) {
+        // Register the value in the equivalence relation.  This relies on
+        // T having a copy constructor.
+        auto unique_pointer_to_value = MakeUnique<T>(value);
+        auto pointer_to_value = unique_pointer_to_value.get();
+        owned_values_.push_back(std::move(unique_pointer_to_value));
+        value_set_.insert(pointer_to_value);
+
+        // Initially say that the value is its own parent and that it has no
+        // children.
+        parent_[pointer_to_value] = pointer_to_value;
+        children_[pointer_to_value] = std::set<const T*>();
+      }
+    }
+
+    // Look up canonical pointers to each of the values in the value pool.
+    const T* value1_ptr = *value_set_.find(&value1);
+    const T* value2_ptr = *value_set_.find(&value2);
+
+    // If the values turn out to be identical, they are already in the same
+    // equivalence class so there is nothing to do.
+    if (value1_ptr == value2_ptr) {
+      return;
+    }
+
+    // Find the representative for each value's equivalence class, and if they
+    // are not already in the same class, make one the parent of the other.
+    const T* representative1 = Find(value1_ptr);
+    const T* representative2 = Find(value2_ptr);
+    if (representative1 != representative2) {
+      parent_[representative1] = representative2;
+      children_[representative2].insert(representative1);
+    }
+  }
+
+  // Returns pointers to all values in the equivalence class of |value|, which
+  // must already be part of the equivalence relation.
+  ValueSet GetEquivalenceClass(const T& value) const {
+    assert(Exists(value));
+
+    ValueSet result;
+
+    // Traverse the tree of values rooted at the representative of the
+    // equivalence class to which |value| belongs, and collect up all the values
+    // that are encountered.  This constitutes the whole equivalence class.
+    std::vector<const T*> stack;
+    stack.push_back(Find(*value_set_.find(&value)));
+    while (!stack.empty()) {
+      const T* item = stack.back();
+      result.insert(item);
+      stack.pop_back();
+      for (auto child : children_[item]) {
+        stack.push_back(child);
+      }
+    }
+    return result;
+  }
+
+  // Returns true if and only if |value1| and |value2| are in the same
+  // equivalence class.  Both values must already be known to the equivalence
+  // relation.
+  bool IsEquivalent(const T& value1, const T& value2) const {
+    return Find(&value1) == Find(&value2);
+  }
+
+  // Returns the set of all values known to be part of the equivalence relation.
+  ValueSet GetAllKnownValues() const {
+    ValueSet result;
+    for (auto& value : owned_values_) {
+      result.insert(value.get());
+    }
+    return result;
+  }
+
+ private:
+  // Returns true if and only if |value| is known to be part of the equivalence
+  // relation.
+  bool Exists(const T& value) const {
+    return value_set_.find(&value) != value_set_.end();
+  }
+
+  // Returns the representative of the equivalence class of |value|, which must
+  // already be known to the equivalence relation.  This is the 'Find' operation
+  // in a classic union-find data structure.
+  const T* Find(const T* value) const {
+    assert(Exists(*value));
+
+    // Compute the result by chasing parents until we find a value that is its
+    // own parent.
+    const T* result = value;
+    while (parent_[result] != result) {
+      result = parent_[result];
+    }
+
+    // At this point, |result| is the representative of the equivalence class.
+    // Now perform the 'path compression' optimization by doing another pass up
+    // the parent chain, setting the parent of each node to be the
+    // representative, and rewriting children correspondingly.
+    const T* current = value;
+    while (parent_[current] != result) {
+      const T* next = parent_[current];
+      parent_[current] = result;
+      children_[result].insert(current);
+      children_[next].erase(current);
+      current = next;
+    }
+    return result;
+  }
+
+  // Maps every value to a parent.  The representative of an equivalence class
+  // is its own parent.  A value's representative can be found by walking its
+  // chain of ancestors.
+  //
+  // Mutable because the intuitively const method, 'Find', performs path
+  // compression.
+  mutable std::map<const T*, const T*> parent_;
+
+  // Stores the children of each value.  This allows the equivalence class of
+  // a value to be calculated by traversing all descendents of the class's
+  // representative.
+  //
+  // Mutable because the intuitively const method, 'Find', performs path
+  // compression.
+  mutable std::map<const T*, std::set<const T*>> children_;
+
+  // The values known to the equivalence relation are alloacated in
+  // |owned_values_|, and |value_pool_| provides (via |PointerHashT| and
+  // |PointerEqualsT|) a means for mapping a value of interest to a pointer
+  // into an equivalent value in |owned_values_|.
+  ValueSet value_set_;
+  std::vector<std::unique_ptr<T>> owned_values_;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_EQUIVALENCE_RELATION_H_

--- a/source/fuzz/equivalence_relation.h
+++ b/source/fuzz/equivalence_relation.h
@@ -15,9 +15,8 @@
 #ifndef SOURCE_FUZZ_EQUIVALENCE_RELATION_H_
 #define SOURCE_FUZZ_EQUIVALENCE_RELATION_H_
 
-#include <map>
 #include <memory>
-#include <set>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -88,7 +87,7 @@ class EquivalenceRelation {
         // Initially say that the value is its own parent and that it has no
         // children.
         parent_[pointer_to_value] = pointer_to_value;
-        children_[pointer_to_value] = std::set<const T*>();
+        children_[pointer_to_value] = std::unordered_set<const T*>();
       }
     }
 
@@ -192,7 +191,7 @@ class EquivalenceRelation {
   //
   // Mutable because the intuitively const method, 'Find', performs path
   // compression.
-  mutable std::map<const T*, const T*> parent_;
+  mutable std::unordered_map<const T*, const T*> parent_;
 
   // Stores the children of each value.  This allows the equivalence class of
   // a value to be calculated by traversing all descendents of the class's
@@ -200,7 +199,7 @@ class EquivalenceRelation {
   //
   // Mutable because the intuitively const method, 'Find', performs path
   // compression.
-  mutable std::map<const T*, std::set<const T*>> children_;
+  mutable std::unordered_map<const T*, std::unordered_set<const T*>> children_;
 
   // The values known to the equivalence relation are alloacated in
   // |owned_values_|, and |value_pool_| provides (via |PointerHashT| and

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -17,6 +17,7 @@ if (${SPIRV_BUILD_FUZZER})
   set(SOURCES
           fuzz_test_util.h
 
+          equivalence_relation_test.cpp
           fact_manager_test.cpp
           fuzz_test_util.cpp
           fuzzer_pass_add_useful_constructs_test.cpp

--- a/test/fuzz/equivalence_relation_test.cpp
+++ b/test/fuzz/equivalence_relation_test.cpp
@@ -33,7 +33,7 @@ struct UInt32Hash {
   }
 };
 
-std::set<uint32_t> ChasePointers(
+std::set<uint32_t> ToUIntSet(
     EquivalenceRelation<uint32_t, UInt32Hash, UInt32Equals>::ValueSet
         pointers) {
   std::set<uint32_t> result;
@@ -66,9 +66,9 @@ TEST(EquivalenceRelationTest, BasicTest) {
     class1.insert(element);
   }
   class1.insert(98);
-  ASSERT_TRUE(class1 == ChasePointers(relation.GetEquivalenceClass(0)));
-  ASSERT_TRUE(class1 == ChasePointers(relation.GetEquivalenceClass(4)));
-  ASSERT_TRUE(class1 == ChasePointers(relation.GetEquivalenceClass(40)));
+  ASSERT_TRUE(class1 == ToUIntSet(relation.GetEquivalenceClass(0)));
+  ASSERT_TRUE(class1 == ToUIntSet(relation.GetEquivalenceClass(4)));
+  ASSERT_TRUE(class1 == ToUIntSet(relation.GetEquivalenceClass(40)));
 
   std::set<uint32_t> class2;
   for (uint32_t element = 1; element < 79; element += 2) {
@@ -77,9 +77,9 @@ TEST(EquivalenceRelationTest, BasicTest) {
     class2.insert(element);
   }
   class2.insert(79);
-  ASSERT_TRUE(class2 == ChasePointers(relation.GetEquivalenceClass(1)));
-  ASSERT_TRUE(class2 == ChasePointers(relation.GetEquivalenceClass(11)));
-  ASSERT_TRUE(class2 == ChasePointers(relation.GetEquivalenceClass(31)));
+  ASSERT_TRUE(class2 == ToUIntSet(relation.GetEquivalenceClass(1)));
+  ASSERT_TRUE(class2 == ToUIntSet(relation.GetEquivalenceClass(11)));
+  ASSERT_TRUE(class2 == ToUIntSet(relation.GetEquivalenceClass(31)));
 
   std::set<uint32_t> class3;
   for (uint32_t element = 81; element < 99; element += 2) {
@@ -88,9 +88,9 @@ TEST(EquivalenceRelationTest, BasicTest) {
     class3.insert(element);
   }
   class3.insert(99);
-  ASSERT_TRUE(class3 == ChasePointers(relation.GetEquivalenceClass(81)));
-  ASSERT_TRUE(class3 == ChasePointers(relation.GetEquivalenceClass(91)));
-  ASSERT_TRUE(class3 == ChasePointers(relation.GetEquivalenceClass(99)));
+  ASSERT_TRUE(class3 == ToUIntSet(relation.GetEquivalenceClass(81)));
+  ASSERT_TRUE(class3 == ToUIntSet(relation.GetEquivalenceClass(91)));
+  ASSERT_TRUE(class3 == ToUIntSet(relation.GetEquivalenceClass(99)));
 }
 
 }  // namespace

--- a/test/fuzz/equivalence_relation_test.cpp
+++ b/test/fuzz/equivalence_relation_test.cpp
@@ -1,0 +1,98 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <set>
+
+#include "gtest/gtest.h"
+#include "source/fuzz/equivalence_relation.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace {
+
+struct UInt32Equals {
+  bool operator()(const uint32_t* first, const uint32_t* second) const {
+    return *first == *second;
+  }
+};
+
+struct UInt32Hash {
+  size_t operator()(const uint32_t* element) const {
+    return static_cast<size_t>(*element);
+  }
+};
+
+std::set<uint32_t> ChasePointers(
+    EquivalenceRelation<uint32_t, UInt32Hash, UInt32Equals>::ValueSet
+        pointers) {
+  std::set<uint32_t> result;
+  for (auto pointer : pointers) {
+    result.insert(*pointer);
+  }
+  return result;
+}
+
+TEST(EquivalenceRelationTest, BasicTest) {
+  EquivalenceRelation<uint32_t, UInt32Hash, UInt32Equals> relation;
+  ASSERT_TRUE(relation.GetAllKnownValues().empty());
+
+  for (uint32_t element = 2; element < 80; element += 2) {
+    relation.MakeEquivalent(0, element);
+    relation.MakeEquivalent(element - 1, element + 1);
+  }
+
+  for (uint32_t element = 82; element < 100; element += 2) {
+    relation.MakeEquivalent(80, element);
+    relation.MakeEquivalent(element - 1, element + 1);
+  }
+
+  relation.MakeEquivalent(78, 80);
+
+  std::set<uint32_t> class1;
+  for (uint32_t element = 0; element < 98; element += 2) {
+    ASSERT_TRUE(relation.IsEquivalent(0, element));
+    ASSERT_TRUE(relation.IsEquivalent(element, element + 2));
+    class1.insert(element);
+  }
+  class1.insert(98);
+  ASSERT_TRUE(class1 == ChasePointers(relation.GetEquivalenceClass(0)));
+  ASSERT_TRUE(class1 == ChasePointers(relation.GetEquivalenceClass(4)));
+  ASSERT_TRUE(class1 == ChasePointers(relation.GetEquivalenceClass(40)));
+
+  std::set<uint32_t> class2;
+  for (uint32_t element = 1; element < 79; element += 2) {
+    ASSERT_TRUE(relation.IsEquivalent(1, element));
+    ASSERT_TRUE(relation.IsEquivalent(element, element + 2));
+    class2.insert(element);
+  }
+  class2.insert(79);
+  ASSERT_TRUE(class2 == ChasePointers(relation.GetEquivalenceClass(1)));
+  ASSERT_TRUE(class2 == ChasePointers(relation.GetEquivalenceClass(11)));
+  ASSERT_TRUE(class2 == ChasePointers(relation.GetEquivalenceClass(31)));
+
+  std::set<uint32_t> class3;
+  for (uint32_t element = 81; element < 99; element += 2) {
+    ASSERT_TRUE(relation.IsEquivalent(81, element));
+    ASSERT_TRUE(relation.IsEquivalent(element, element + 2));
+    class3.insert(element);
+  }
+  class3.insert(99);
+  ASSERT_TRUE(class3 == ChasePointers(relation.GetEquivalenceClass(81)));
+  ASSERT_TRUE(class3 == ChasePointers(relation.GetEquivalenceClass(91)));
+  ASSERT_TRUE(class3 == ChasePointers(relation.GetEquivalenceClass(99)));
+}
+
+}  // namespace
+}  // namespace fuzz
+}  // namespace spvtools


### PR DESCRIPTION
Adds a templated class for representing an equivalence relation on a
value data type.  This will be used by spirv-fuzz for representing
sets of distinct pieces of data in a shader that are known to have
equal values.