### PR TITLE
utils/vscode: Change assembly file ext to .spvasm

### DIFF
--- a/utils/vscode/package.json
+++ b/utils/vscode/package.json
@@ -18,7 +18,7 @@
                 "id": "spirv",
                 "configuration": "spirv.configuration.json",
                 "extensions": [
-                    "spirv"
+                    "spvasm"
                 ]
             }
         ],


### PR DESCRIPTION
Instead of `.spirv`.
`.spvasm` is the official extension for these textual assembly files.