### PR TITLE
Fix some clang-tidy issues in graphics_robust_access_pass

### DIFF
--- a/source/opt/graphics_robust_access_pass.cpp
+++ b/source/opt/graphics_robust_access_pass.cpp
@@ -160,7 +160,6 @@
 namespace spvtools {
 namespace opt {
 
-using opt::BasicBlock;
 using opt::Instruction;
 using opt::Operand;
 using spvtools::MakeUnique;

--- a/source/opt/graphics_robust_access_pass.h
+++ b/source/opt/graphics_robust_access_pass.h
@@ -81,8 +81,8 @@ class GraphicsRobustAccessPass : public Pass {
   // sign extension or zero extension.  The new instruction is inserted
   // immediately before |before_inst|, and is analyzed for definitions and uses.
   // Returns the newly inserted instruction.  Assumes the |value| is an integer
-  // scalar of a narrower type than |bitwidth| bits.
-  Instruction* WidenInteger(bool sign_extend, uint32_t bitwidth,
+  // scalar of a narrower type than |bit_width| bits.
+  Instruction* WidenInteger(bool sign_extend, uint32_t bit_width,
                             Instruction* value, Instruction* before_inst);
 
   // Returns a new instruction that invokes the UClamp GLSL.std.450 extended
@@ -109,7 +109,8 @@ class GraphicsRobustAccessPass : public Pass {
   // the module is modified.  Returns a status code to indicate success
   // or failure.  If assumptions are not met, returns an error status code
   // and emits a diagnostic.
-  spv_result_t ClampCoordinateForImageTexelPointer(opt::Instruction* itp);
+  spv_result_t ClampCoordinateForImageTexelPointer(
+      opt::Instruction* image_texel_pointer);
 
   // Gets the instruction that defines the given id.
   opt::Instruction* GetDef(uint32_t id) {

--- a/test/opt/graphics_robust_access_test.cpp
+++ b/test/opt/graphics_robust_access_test.cpp
@@ -199,11 +199,11 @@ std::string ACCheck(const std::string& access_chain_inst,
                     const std::string& original,
                     const std::string& transformed) {
   return "\n ; CHECK: %ac = " + access_chain_inst + " %ptr_ty %var" +
-         (transformed.size() ? " " : "") + transformed +
+         (transformed.empty() ? "" : " ") + transformed +
          "\n ; CHECK-NOT: " + access_chain_inst +
          "\n ; CHECK-NEXT: OpReturn"
          "\n %ac = " +
-         access_chain_inst + " %ptr_ty %var " + (original.size() ? " " : "") +
+         access_chain_inst + " %ptr_ty %var " + (original.empty() ? "" : " ") +
          original + "\n";
 }
 
@@ -211,11 +211,11 @@ std::string ACCheckFail(const std::string& access_chain_inst,
                         const std::string& original,
                         const std::string& transformed) {
   return "\n ; CHECK: %ac = " + access_chain_inst + " %ptr_ty %var" +
-         (transformed.size() ? " " : "") + transformed +
+         (transformed.empty() ? "" : " ") + transformed +
          "\n ; CHECK-NOT: " + access_chain_inst +
          "\n ; CHECK-NOT: OpReturn"
          "\n %ac = " +
-         access_chain_inst + " %ptr_ty %var " + (original.size() ? " " : "") +
+         access_chain_inst + " %ptr_ty %var " + (original.empty() ? "" : " ") +
          original + "\n";
 }
 


### PR DESCRIPTION
One remains: the fact that the image-texel-pointer modification
is mostly dead code. But that's intentional for now.