### PR TITLE
Reset pointers before iterating in fuzzer to avoid double free

### DIFF
--- a/test/fuzzers/spvtools_dis_fuzzer.cpp
+++ b/test/fuzzers/spvtools_dis_fuzzer.cpp
@@ -55,8 +55,15 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
        options++) {
     spvBinaryToText(context, input.data(), input.size(), options, &text,
                     &diagnostic);
-    if (diagnostic) spvDiagnosticDestroy(diagnostic);
-    if (text) spvTextDestroy(text);
+    if (diagnostic) {
+        spvDiagnosticDestroy(diagnostic);
+        diagnostic = nullptr;
+    }
+
+    if (text) {
+        spvTextDestroy(text);
+        text = nullptr;
+    }
   }
 
   spvContextDestroy(context);

--- a/test/fuzzers/spvtools_dis_fuzzer.cpp
+++ b/test/fuzzers/spvtools_dis_fuzzer.cpp
@@ -56,13 +56,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     spvBinaryToText(context, input.data(), input.size(), options, &text,
                     &diagnostic);
     if (diagnostic) {
-        spvDiagnosticDestroy(diagnostic);
-        diagnostic = nullptr;
+      spvDiagnosticDestroy(diagnostic);
+      diagnostic = nullptr;
     }
 
     if (text) {
-        spvTextDestroy(text);
-        text = nullptr;
+      spvTextDestroy(text);
+      text = nullptr;
     }
   }
 


### PR DESCRIPTION
Fixes #3002