### PR TITLE
spirv-fuzz: improvements to representation of data synonym facts

### DIFF
--- a/source/fuzz/data_descriptor.cpp
+++ b/source/fuzz/data_descriptor.cpp
@@ -20,14 +20,12 @@ namespace spvtools {
 namespace fuzz {
 
 protobufs::DataDescriptor MakeDataDescriptor(uint32_t object,
-                                             std::vector<uint32_t>&& indices,
-                                             uint32_t num_contiguous_elements) {
+                                             std::vector<uint32_t>&& indices) {
   protobufs::DataDescriptor result;
   result.set_object(object);
   for (auto index : indices) {
     result.add_index(index);
   }
-  result.set_num_contiguous_elements(num_contiguous_elements);
   return result;
 }
 
@@ -48,6 +46,23 @@ bool DataDescriptorEquals::operator()(
          first->index().size() == second->index().size() &&
          std::equal(first->index().begin(), first->index().end(),
                     second->index().begin());
+}
+
+std::ostream& operator<<(std::ostream& out,
+                         const protobufs::DataDescriptor& data_descriptor) {
+  out << data_descriptor.object();
+  out << "[";
+  bool first = true;
+  for (auto index : data_descriptor.index()) {
+    if (first) {
+      first = false;
+    } else {
+      out << ", ";
+    }
+    out << index;
+  }
+  out << "]";
+  return out;
 }
 
 }  // namespace fuzz

--- a/source/fuzz/data_descriptor.h
+++ b/source/fuzz/data_descriptor.h
@@ -17,6 +17,7 @@
 
 #include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
 
+#include <ostream>
 #include <vector>
 
 namespace spvtools {
@@ -25,8 +26,7 @@ namespace fuzz {
 // Factory method to create a data descriptor message from an object id and a
 // list of indices.
 protobufs::DataDescriptor MakeDataDescriptor(uint32_t object,
-                                             std::vector<uint32_t>&& indices,
-                                             uint32_t num_contiguous_elements);
+                                             std::vector<uint32_t>&& indices);
 
 // Hash function for data descriptors.
 struct DataDescriptorHash {
@@ -38,6 +38,9 @@ struct DataDescriptorEquals {
   bool operator()(const protobufs::DataDescriptor* first,
                   const protobufs::DataDescriptor* second) const;
 };
+
+std::ostream& operator<<(std::ostream& out,
+                         const protobufs::DataDescriptor& data_descriptor);
 
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/fact_manager.h
+++ b/source/fuzz/fact_manager.h
@@ -126,12 +126,13 @@ class FactManager {
   // For each distinct kind of fact to be managed, we use a separate opaque
   // struct type.
 
-  class ConstantUniformFacts;  // Opaque class for management of
-                               // constant uniform facts.
+  struct ConstantUniformFacts;  // Opaque class for management of
+                                // constant uniform facts.
   std::unique_ptr<ConstantUniformFacts>
       uniform_constant_facts_;  // Unique pointer to internal data.
 
-  class DataSynonymFacts;  // Opaque class for management of data synonym facts.
+  struct DataSynonymFacts;  // Opaque class for management of data synonym
+                            // facts.
   std::unique_ptr<DataSynonymFacts>
       data_synonym_facts_;  // Unique pointer to internal data.
 };

--- a/source/fuzz/fact_manager.h
+++ b/source/fuzz/fact_manager.h
@@ -55,7 +55,8 @@ class FactManager {
 
   // Record the fact that |data1| and |data2| are synonymous.
   void AddFactDataSynonym(const protobufs::DataDescriptor& data1,
-                          const protobufs::DataDescriptor& data2);
+                          const protobufs::DataDescriptor& data2,
+                          opt::IRContext* context);
 
   // The fact manager is responsible for managing a few distinct categories of
   // facts. In principle there could be different fact managers for each kind
@@ -106,13 +107,17 @@ class FactManager {
 
   // Returns every id for which a fact of the form "this id is synonymous
   // with this piece of data" is known.
-  std::set<uint32_t> GetIdsForWhichSynonymsAreKnown() const;
+  std::vector<uint32_t> GetIdsForWhichSynonymsAreKnown() const;
 
-  // Requires that at least one synonym for |id| is known, and returns the
-  // equivalence class of all known synonyms.
-  std::unordered_set<const protobufs::DataDescriptor*, DataDescriptorHash,
-                     DataDescriptorEquals>
-  GetSynonymsForId(uint32_t id) const;
+  // Returns the equivalence class of all known synonyms of |id|, or an empty
+  // set if no synonyms are known.
+  std::vector<const protobufs::DataDescriptor*> GetSynonymsForId(
+      uint32_t id) const;
+
+  // Return true if and ony if |data_descriptor1| and |data_descriptor2| are
+  // known to be synonymous.
+  bool IsSynonymous(const protobufs::DataDescriptor& data_descriptor1,
+                    const protobufs::DataDescriptor& data_descriptor2) const;
 
   // End of id synonym facts
   //==============================
@@ -121,13 +126,12 @@ class FactManager {
   // For each distinct kind of fact to be managed, we use a separate opaque
   // struct type.
 
-  struct ConstantUniformFacts;  // Opaque struct for holding data about uniform
-                                // buffer elements.
+  class ConstantUniformFacts;  // Opaque class for management of
+                               // constant uniform facts.
   std::unique_ptr<ConstantUniformFacts>
       uniform_constant_facts_;  // Unique pointer to internal data.
 
-  struct DataSynonymFacts;  // Opaque struct for holding data about data
-                            // synonyms.
+  class DataSynonymFacts;  // Opaque class for management of data synonym facts.
   std::unique_ptr<DataSynonymFacts>
       data_synonym_facts_;  // Unique pointer to internal data.
 };

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -82,10 +82,6 @@ message DataDescriptor {
   // 0 or more indices, used to index into a composite object
   repeated uint32 index = 2;
 
-  // The number of contiguous elements.  This will typically be 1, but e.g. 2 or
-  // 3 can be used to describe the 'xy' or 'xyz' portion of a vec4.
-  uint32 num_contiguous_elements = 3;
-
 }
 
 message UniformBufferElementDescriptor {

--- a/source/fuzz/transformation_composite_extract.cpp
+++ b/source/fuzz/transformation_composite_extract.cpp
@@ -106,11 +106,11 @@ void TransformationCompositeExtract::Apply(
     indices.push_back(an_index);
   }
   protobufs::DataDescriptor data_descriptor_for_extracted_element =
-      MakeDataDescriptor(message_.composite_id(), std::move(indices), 1);
+      MakeDataDescriptor(message_.composite_id(), std::move(indices));
   protobufs::DataDescriptor data_descriptor_for_result_id =
-      MakeDataDescriptor(message_.fresh_id(), {}, 1);
+      MakeDataDescriptor(message_.fresh_id(), {});
   fact_manager->AddFactDataSynonym(data_descriptor_for_extracted_element,
-                                   data_descriptor_for_result_id);
+                                   data_descriptor_for_result_id, context);
 }
 
 protobufs::Transformation TransformationCompositeExtract::ToMessage() const {

--- a/source/fuzz/transformation_copy_object.cpp
+++ b/source/fuzz/transformation_copy_object.cpp
@@ -102,9 +102,9 @@ void TransformationCopyObject::Apply(opt::IRContext* context,
   fuzzerutil::UpdateModuleIdBound(context, message_.fresh_id());
   context->InvalidateAnalysesExceptFor(opt::IRContext::Analysis::kAnalysisNone);
 
-  fact_manager->AddFactDataSynonym(
-      MakeDataDescriptor(message_.object(), {}, 1),
-      MakeDataDescriptor(message_.fresh_id(), {}, 1));
+  fact_manager->AddFactDataSynonym(MakeDataDescriptor(message_.object(), {}),
+                                   MakeDataDescriptor(message_.fresh_id(), {}),
+                                   context);
 }
 
 protobufs::Transformation TransformationCopyObject::ToMessage() const {

--- a/source/fuzz/transformation_replace_id_with_synonym.cpp
+++ b/source/fuzz/transformation_replace_id_with_synonym.cpp
@@ -46,8 +46,9 @@ bool TransformationReplaceIdWithSynonym::IsApplicable(
   auto id_of_interest = message_.id_use_descriptor().id_of_interest();
 
   // Does the fact manager know about the synonym?
-  if (fact_manager.GetIdsForWhichSynonymsAreKnown().count(id_of_interest) ==
-      0) {
+  auto ids_with_known_synonyms = fact_manager.GetIdsForWhichSynonymsAreKnown();
+  if (std::find(ids_with_known_synonyms.begin(), ids_with_known_synonyms.end(),
+                id_of_interest) == ids_with_known_synonyms.end()) {
     return false;
   }
 

--- a/test/fuzz/equivalence_relation_test.cpp
+++ b/test/fuzz/equivalence_relation_test.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <external/googletest/googlemock/include/gmock/gmock-generated-matchers.h>
 #include <set>
 
 #include "gmock/gmock.h"

--- a/test/fuzz/equivalence_relation_test.cpp
+++ b/test/fuzz/equivalence_relation_test.cpp
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <external/googletest/googlemock/include/gmock/gmock-generated-matchers.h>
 #include <set>
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "source/fuzz/equivalence_relation.h"
 
@@ -33,12 +35,11 @@ struct UInt32Hash {
   }
 };
 
-std::set<uint32_t> ToUIntSet(
-    EquivalenceRelation<uint32_t, UInt32Hash, UInt32Equals>::ValueSet
-        pointers) {
-  std::set<uint32_t> result;
+std::vector<uint32_t> ToUIntVector(
+    const std::vector<const uint32_t*>& pointers) {
+  std::vector<uint32_t> result;
   for (auto pointer : pointers) {
-    result.insert(*pointer);
+    result.push_back(*pointer);
   }
   return result;
 }
@@ -59,38 +60,63 @@ TEST(EquivalenceRelationTest, BasicTest) {
 
   relation.MakeEquivalent(78, 80);
 
-  std::set<uint32_t> class1;
+  std::vector<uint32_t> class1;
   for (uint32_t element = 0; element < 98; element += 2) {
     ASSERT_TRUE(relation.IsEquivalent(0, element));
     ASSERT_TRUE(relation.IsEquivalent(element, element + 2));
-    class1.insert(element);
+    class1.push_back(element);
   }
-  class1.insert(98);
-  ASSERT_TRUE(class1 == ToUIntSet(relation.GetEquivalenceClass(0)));
-  ASSERT_TRUE(class1 == ToUIntSet(relation.GetEquivalenceClass(4)));
-  ASSERT_TRUE(class1 == ToUIntSet(relation.GetEquivalenceClass(40)));
+  class1.push_back(98);
 
-  std::set<uint32_t> class2;
+  ASSERT_THAT(ToUIntVector(relation.GetEquivalenceClass(0)),
+              testing::WhenSorted(class1));
+  ASSERT_THAT(ToUIntVector(relation.GetEquivalenceClass(4)),
+              testing::WhenSorted(class1));
+  ASSERT_THAT(ToUIntVector(relation.GetEquivalenceClass(40)),
+              testing::WhenSorted(class1));
+
+  std::vector<uint32_t> class2;
   for (uint32_t element = 1; element < 79; element += 2) {
     ASSERT_TRUE(relation.IsEquivalent(1, element));
     ASSERT_TRUE(relation.IsEquivalent(element, element + 2));
-    class2.insert(element);
+    class2.push_back(element);
   }
-  class2.insert(79);
-  ASSERT_TRUE(class2 == ToUIntSet(relation.GetEquivalenceClass(1)));
-  ASSERT_TRUE(class2 == ToUIntSet(relation.GetEquivalenceClass(11)));
-  ASSERT_TRUE(class2 == ToUIntSet(relation.GetEquivalenceClass(31)));
+  class2.push_back(79);
+  ASSERT_THAT(ToUIntVector(relation.GetEquivalenceClass(1)),
+              testing::WhenSorted(class2));
+  ASSERT_THAT(ToUIntVector(relation.GetEquivalenceClass(11)),
+              testing::WhenSorted(class2));
+  ASSERT_THAT(ToUIntVector(relation.GetEquivalenceClass(31)),
+              testing::WhenSorted(class2));
 
-  std::set<uint32_t> class3;
+  std::vector<uint32_t> class3;
   for (uint32_t element = 81; element < 99; element += 2) {
     ASSERT_TRUE(relation.IsEquivalent(81, element));
     ASSERT_TRUE(relation.IsEquivalent(element, element + 2));
-    class3.insert(element);
+    class3.push_back(element);
   }
-  class3.insert(99);
-  ASSERT_TRUE(class3 == ToUIntSet(relation.GetEquivalenceClass(81)));
-  ASSERT_TRUE(class3 == ToUIntSet(relation.GetEquivalenceClass(91)));
-  ASSERT_TRUE(class3 == ToUIntSet(relation.GetEquivalenceClass(99)));
+  class3.push_back(99);
+  ASSERT_THAT(ToUIntVector(relation.GetEquivalenceClass(81)),
+              testing::WhenSorted(class3));
+  ASSERT_THAT(ToUIntVector(relation.GetEquivalenceClass(91)),
+              testing::WhenSorted(class3));
+  ASSERT_THAT(ToUIntVector(relation.GetEquivalenceClass(99)),
+              testing::WhenSorted(class3));
+
+  bool first = true;
+  std::vector<const uint32_t*> previous_class;
+  for (auto representative : relation.GetEquivalenceClassRepresentatives()) {
+    std::vector<const uint32_t*> current_class =
+        relation.GetEquivalenceClass(*representative);
+    ASSERT_TRUE(std::find(current_class.begin(), current_class.end(),
+                          representative) != current_class.end());
+    if (!first) {
+      ASSERT_TRUE(std::find(previous_class.begin(), previous_class.end(),
+                            representative) == previous_class.end());
+    }
+    previous_class = current_class;
+    first = false;
+  }
 }
 
 }  // namespace

--- a/test/fuzz/transformation_composite_extract_test.cpp
+++ b/test/fuzz/transformation_composite_extract_test.cpp
@@ -20,13 +20,6 @@ namespace spvtools {
 namespace fuzz {
 namespace {
 
-bool IsSynonymous(const FactManager& fact_manager, uint32_t id,
-                  uint32_t composite_id, std::vector<uint32_t>&& indices) {
-  protobufs::DataDescriptor data_descriptor =
-      MakeDataDescriptor(composite_id, std::move(indices), 1);
-  return fact_manager.GetSynonymsForId(id).count(&data_descriptor) == 1;
-}
-
 TEST(TransformationCompositeExtractTest, BasicTest) {
   std::string shader = R"(
                OpCapability Shader
@@ -179,12 +172,18 @@ TEST(TransformationCompositeExtractTest, BasicTest) {
   transformation_6.Apply(context.get(), &fact_manager);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  ASSERT_TRUE(IsSynonymous(fact_manager, 201, 100, {2}));
-  ASSERT_TRUE(IsSynonymous(fact_manager, 202, 104, {0, 2}));
-  ASSERT_TRUE(IsSynonymous(fact_manager, 203, 104, {0}));
-  ASSERT_TRUE(IsSynonymous(fact_manager, 204, 101, {0}));
-  ASSERT_TRUE(IsSynonymous(fact_manager, 205, 102, {2}));
-  ASSERT_TRUE(IsSynonymous(fact_manager, 206, 103, {1}));
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(201, {}),
+                                        MakeDataDescriptor(100, {2})));
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(202, {}),
+                                        MakeDataDescriptor(104, {0, 2})));
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(203, {}),
+                                        MakeDataDescriptor(104, {0})));
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(204, {}),
+                                        MakeDataDescriptor(101, {0})));
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(205, {}),
+                                        MakeDataDescriptor(102, {2})));
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(206, {}),
+                                        MakeDataDescriptor(103, {1})));
 
   std::string after_transformation = R"(
                OpCapability Shader

--- a/test/fuzz/transformation_copy_object_test.cpp
+++ b/test/fuzz/transformation_copy_object_test.cpp
@@ -60,14 +60,16 @@ TEST(TransformationCopyObjectTest, CopyBooleanConstants) {
     ASSERT_TRUE(copy_true.IsApplicable(context.get(), fact_manager));
     copy_true.Apply(context.get(), &fact_manager);
 
-    std::set<uint32_t> ids_for_which_synonyms_are_known =
+    auto ids_for_which_synonyms_are_known =
         fact_manager.GetIdsForWhichSynonymsAreKnown();
     ASSERT_EQ(2, ids_for_which_synonyms_are_known.size());
-    ASSERT_TRUE(ids_for_which_synonyms_are_known.find(7) !=
-                ids_for_which_synonyms_are_known.end());
+    ASSERT_TRUE(std::find(ids_for_which_synonyms_are_known.begin(),
+                          ids_for_which_synonyms_are_known.end(),
+                          7) != ids_for_which_synonyms_are_known.end());
     ASSERT_EQ(2, fact_manager.GetSynonymsForId(7).size());
-    protobufs::DataDescriptor descriptor_100 = MakeDataDescriptor(100, {}, 1);
-    ASSERT_TRUE(fact_manager.GetSynonymsForId(7).count(&descriptor_100) > 0);
+    protobufs::DataDescriptor descriptor_100 = MakeDataDescriptor(100, {});
+    ASSERT_TRUE(
+        fact_manager.IsSynonymous(MakeDataDescriptor(7, {}), descriptor_100));
   }
 
   {
@@ -75,14 +77,16 @@ TEST(TransformationCopyObjectTest, CopyBooleanConstants) {
         8, MakeInstructionDescriptor(100, SpvOpReturn, 0), 101);
     ASSERT_TRUE(copy_false.IsApplicable(context.get(), fact_manager));
     copy_false.Apply(context.get(), &fact_manager);
-    std::set<uint32_t> ids_for_which_synonyms_are_known =
+    auto ids_for_which_synonyms_are_known =
         fact_manager.GetIdsForWhichSynonymsAreKnown();
     ASSERT_EQ(4, ids_for_which_synonyms_are_known.size());
-    ASSERT_TRUE(ids_for_which_synonyms_are_known.find(8) !=
-                ids_for_which_synonyms_are_known.end());
+    ASSERT_TRUE(std::find(ids_for_which_synonyms_are_known.begin(),
+                          ids_for_which_synonyms_are_known.end(),
+                          8) != ids_for_which_synonyms_are_known.end());
     ASSERT_EQ(2, fact_manager.GetSynonymsForId(8).size());
-    protobufs::DataDescriptor descriptor_101 = MakeDataDescriptor(101, {}, 1);
-    ASSERT_TRUE(fact_manager.GetSynonymsForId(8).count(&descriptor_101) > 0);
+    protobufs::DataDescriptor descriptor_101 = MakeDataDescriptor(101, {});
+    ASSERT_TRUE(
+        fact_manager.IsSynonymous(MakeDataDescriptor(8, {}), descriptor_101));
   }
 
   {
@@ -90,14 +94,16 @@ TEST(TransformationCopyObjectTest, CopyBooleanConstants) {
         101, MakeInstructionDescriptor(5, SpvOpReturn, 0), 102);
     ASSERT_TRUE(copy_false_again.IsApplicable(context.get(), fact_manager));
     copy_false_again.Apply(context.get(), &fact_manager);
-    std::set<uint32_t> ids_for_which_synonyms_are_known =
+    auto ids_for_which_synonyms_are_known =
         fact_manager.GetIdsForWhichSynonymsAreKnown();
     ASSERT_EQ(5, ids_for_which_synonyms_are_known.size());
-    ASSERT_TRUE(ids_for_which_synonyms_are_known.find(101) !=
-                ids_for_which_synonyms_are_known.end());
+    ASSERT_TRUE(std::find(ids_for_which_synonyms_are_known.begin(),
+                          ids_for_which_synonyms_are_known.end(),
+                          101) != ids_for_which_synonyms_are_known.end());
     ASSERT_EQ(3, fact_manager.GetSynonymsForId(101).size());
-    protobufs::DataDescriptor descriptor_102 = MakeDataDescriptor(102, {}, 1);
-    ASSERT_TRUE(fact_manager.GetSynonymsForId(101).count(&descriptor_102) > 0);
+    protobufs::DataDescriptor descriptor_102 = MakeDataDescriptor(102, {});
+    ASSERT_TRUE(
+        fact_manager.IsSynonymous(MakeDataDescriptor(101, {}), descriptor_102));
   }
 
   {
@@ -105,14 +111,16 @@ TEST(TransformationCopyObjectTest, CopyBooleanConstants) {
         7, MakeInstructionDescriptor(102, SpvOpReturn, 0), 103);
     ASSERT_TRUE(copy_true_again.IsApplicable(context.get(), fact_manager));
     copy_true_again.Apply(context.get(), &fact_manager);
-    std::set<uint32_t> ids_for_which_synonyms_are_known =
+    auto ids_for_which_synonyms_are_known =
         fact_manager.GetIdsForWhichSynonymsAreKnown();
     ASSERT_EQ(6, ids_for_which_synonyms_are_known.size());
-    ASSERT_TRUE(ids_for_which_synonyms_are_known.find(7) !=
-                ids_for_which_synonyms_are_known.end());
+    ASSERT_TRUE(std::find(ids_for_which_synonyms_are_known.begin(),
+                          ids_for_which_synonyms_are_known.end(),
+                          7) != ids_for_which_synonyms_are_known.end());
     ASSERT_EQ(3, fact_manager.GetSynonymsForId(7).size());
-    protobufs::DataDescriptor descriptor_103 = MakeDataDescriptor(103, {}, 1);
-    ASSERT_TRUE(fact_manager.GetSynonymsForId(7).count(&descriptor_103) > 0);
+    protobufs::DataDescriptor descriptor_103 = MakeDataDescriptor(103, {});
+    ASSERT_TRUE(
+        fact_manager.IsSynonymous(MakeDataDescriptor(7, {}), descriptor_103));
   }
 
   std::string after_transformation = R"(


### PR DESCRIPTION
This change fixes a bug in EquivalenceRelation, changes the interface
of EquivalenceRelation to avoid exposing (potentially
nondeterministic) unordered sets, and changes the interface of
FactManager to allow querying data synonyms directly.  These interface
changes have required a lot of corresponding changes to client code
and tests.