### PR TITLE
spirv-fuzz: make equivalence classes deterministic

### DIFF
--- a/test/fuzz/equivalence_relation_test.cpp
+++ b/test/fuzz/equivalence_relation_test.cpp
@@ -118,6 +118,28 @@ TEST(EquivalenceRelationTest, BasicTest) {
   }
 }
 
+TEST(EquivalenceRelationTest, DeterministicEquivalenceClassOrder) {
+  EquivalenceRelation<uint32_t, UInt32Hash, UInt32Equals> relation1;
+  EquivalenceRelation<uint32_t, UInt32Hash, UInt32Equals> relation2;
+
+  for (uint32_t i = 0; i < 1000; ++i) {
+    if (i >= 10) {
+      relation1.MakeEquivalent(i, i - 10);
+      relation2.MakeEquivalent(i, i - 10);
+    }
+  }
+
+  // We constructed the equivalence relations in the same way, so we would like
+  // them to have identical representatives, and identically-ordered equivalence
+  // classes per representative.
+  ASSERT_THAT(ToUIntVector(relation1.GetEquivalenceClassRepresentatives()),
+              ToUIntVector(relation2.GetEquivalenceClassRepresentatives()));
+  for (auto representative : relation1.GetEquivalenceClassRepresentatives()) {
+    ASSERT_THAT(ToUIntVector(relation1.GetEquivalenceClass(*representative)),
+                ToUIntVector(relation2.GetEquivalenceClass(*representative)));
+  }
+}
+
 }  // namespace
 }  // namespace fuzz
 }  // namespace spvtools


### PR DESCRIPTION
An equivalence relation is computed by traversing the tree of values
rooted at the class's representative.  Children were represented by
unordered sets, meaning that the order of values in an equivalence
class could be nondeterministic.  This change makes things
deterministic by representing children using a vector.

The path compression optimization employed in the implementation of
the underlying union-find data structure has the potential to change
the order in which elements appear in an equivalence class by changing
the structure of the tree, so the guarantee of determinism is limited
to being a deterministic function of the manner in which the
equivalence relation is updated and inspected.
