### PR TITLE
Fix operand access of composite in upgrade memory model

### DIFF
--- a/source/opt/upgrade_memory_model.cpp
+++ b/source/opt/upgrade_memory_model.cpp
@@ -429,7 +429,7 @@ std::pair<bool, bool> UpgradeMemoryModel::CheckType(
     } else {
       assert(spvOpcodeIsComposite(element_inst->opcode()));
       element_inst = context()->get_def_use_mgr()->GetDef(
-          element_inst->GetSingleWordInOperand(1u));
+          element_inst->GetSingleWordInOperand(0u));
     }
   }
 


### PR DESCRIPTION
Fixes #2992

* Accessing aggregate subtype used the wrong operand
  * Added a test