### PR TITLE
Remove semicolon

### DIFF
--- a/source/fuzz/fact_manager.cpp
+++ b/source/fuzz/fact_manager.cpp
@@ -896,7 +896,7 @@ bool FactManager::IsSynonymous(
     opt::IRContext* context) const {
   return data_synonym_facts_->IsSynonymous(data_descriptor1, data_descriptor2,
                                            context);
-};
+}
 
 }  // namespace fuzz
 }  // namespace spvtools


### PR DESCRIPTION
This breaks builds on some Mac systems. Not sure why the bots miss it. 