### PR TITLE
Try to fix go linter: exported constant comment

### DIFF
--- a/utils/vscode/src/grammar/grammar.go
+++ b/utils/vscode/src/grammar/grammar.go
@@ -70,10 +70,12 @@ type Parameter struct {
 type Quantifier string
 
 const (
-	// The quantified term may appear exactly once.
-	Once       Quantifier = ""
-	// The quantified term may appear zero or one time; an optional term.
+	// Once indicates the quantified term may appear exactly once.
+	Once Quantifier = ""
+	// ZeroOrOnce indicates the quantified term may appear zero or one
+	// time; an optional term.
 	ZeroOrOnce Quantifier = "?"
-	// The quantified term may appear any number of times.
+	// ZeroOrMany indicates the quantified term may appear any number of
+	// times.
 	ZeroOrMany Quantifier = "*"
 )


### PR DESCRIPTION
The linter wants the comment on an exported constant to
begin with the name of the constant.