### PR TITLE
Avoid uninit warning in GCC

### DIFF
--- a/source/fuzz/id_use_descriptor.cpp
+++ b/source/fuzz/id_use_descriptor.cpp
@@ -51,7 +51,7 @@ protobufs::IdUseDescriptor MakeIdUseDescriptor(
 protobufs::IdUseDescriptor MakeIdUseDescriptorFromUse(
     opt::IRContext* context, opt::Instruction* inst,
     uint32_t in_operand_index) {
-  auto in_operand = inst->GetInOperand(in_operand_index);
+  const auto& in_operand = inst->GetInOperand(in_operand_index);
   assert(in_operand.type == SPV_OPERAND_TYPE_ID);
   return MakeIdUseDescriptor(in_operand.words[0],
                              MakeInstructionDescriptor(context, inst),


### PR DESCRIPTION
Fixes

spirv-tools/source/fuzz/id_use_descriptor.cpp:58:46: error: ‘*((void*)& in_operand +32)’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
                              in_operand_index);
                                              ^
