### PR TITLE
Kill the id-to-func map after wrap-opkill

### DIFF
--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -273,6 +273,14 @@ bool IRContext::IsConsistent() {
     }
   }
 
+  if (AreAnalysesValid(kAnalysisIdToFuncMapping)) {
+    for (auto& fn : *module_) {
+      if (id_to_func_[fn.result_id()] != &fn) {
+        return false;
+      }
+    }
+  }
+
   if (AreAnalysesValid(kAnalysisInstrToBlockMapping)) {
     for (auto& func : *module()) {
       for (auto& block : func) {
@@ -818,6 +826,7 @@ bool IRContext::ProcessCallTreeFromRoots(ProcessFunction& pfn,
     roots->pop();
     if (done.insert(fi).second) {
       Function* fn = GetFunction(fi);
+      assert(fn && "Trying to process a function that does not exist.");
       modified = pfn(fn) || modified;
       AddCalls(fn, roots);
     }

--- a/source/opt/wrap_opkill.h
+++ b/source/opt/wrap_opkill.h
@@ -34,8 +34,7 @@ class WrapOpKill : public Pass {
            IRContext::kAnalysisInstrToBlockMapping |
            IRContext::kAnalysisDecorations | IRContext::kAnalysisCombinators |
            IRContext::kAnalysisNameMap | IRContext::kAnalysisBuiltinVarId |
-           IRContext::kAnalysisIdToFuncMapping | IRContext::kAnalysisConstants |
-           IRContext::kAnalysisTypes;
+           IRContext::kAnalysisConstants | IRContext::kAnalysisTypes;
   }
 
  private:


### PR DESCRIPTION
Wrap-opkill will create a new function, invalidating the id-to-func map.
The preserved analyses for the pass have been updated to reflect that.

Also adding consistency check for the id-to-func map.  With this new
check, old tests identify this problem.  No new tests are needed.

Fixes #3038