### PR TITLE
Validate nested constructs

### DIFF
--- a/source/opt/block_merge_util.cpp
+++ b/source/opt/block_merge_util.cpp
@@ -49,6 +49,18 @@ bool IsMerge(IRContext* context, BasicBlock* block) {
   return IsMerge(context, block->id());
 }
 
+// Returns true if |id| is the continue target of a merge instruction.
+bool IsContinue(IRContext* context, uint32_t id) {
+  return !context->get_def_use_mgr()->WhileEachUse(id, [](Instruction* user,
+                                                          uint32_t index) {
+    SpvOp op = user->opcode();
+    if (op == SpvOpLoopMerge && index == 1u) {
+      return false;
+    }
+    return true;
+  });
+}
+
 // Removes any OpPhi instructions in |block|, which should have exactly one
 // predecessor, replacing uses of OpPhi ids with the ids associated with the
 // predecessor.
@@ -83,6 +95,11 @@ bool CanMergeWithSuccessor(IRContext* context, BasicBlock* block) {
   bool succ_is_merge = IsMerge(context, lab_id);
   if (pred_is_merge && succ_is_merge) {
     // Cannot merge two merges together.
+    return false;
+  }
+
+  if (pred_is_merge && IsContinue(context, lab_id)) {
+    // Cannot merge a continue target with a merge block.
     return false;
   }
 

--- a/source/opt/block_merge_util.cpp
+++ b/source/opt/block_merge_util.cpp
@@ -51,14 +51,14 @@ bool IsMerge(IRContext* context, BasicBlock* block) {
 
 // Returns true if |id| is the continue target of a merge instruction.
 bool IsContinue(IRContext* context, uint32_t id) {
-  return !context->get_def_use_mgr()->WhileEachUse(id, [](Instruction* user,
-                                                          uint32_t index) {
-    SpvOp op = user->opcode();
-    if (op == SpvOpLoopMerge && index == 1u) {
-      return false;
-    }
-    return true;
-  });
+  return !context->get_def_use_mgr()->WhileEachUse(
+      id, [](Instruction* user, uint32_t index) {
+        SpvOp op = user->opcode();
+        if (op == SpvOpLoopMerge && index == 1u) {
+          return false;
+        }
+        return true;
+      });
 }
 
 // Removes any OpPhi instructions in |block|, which should have exactly one

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -284,12 +284,11 @@ bool InlinePass::GenInlineCode(
     if (rid != 0) callee_result_ids.insert(rid);
   });
 
-  // If the caller is in a single-block loop, and the callee has multiple
-  // blocks, then the normal inlining logic will place the OpLoopMerge in
-  // the last of several blocks in the loop.  Instead, it should be placed
-  // at the end of the first block.  First determine if the caller is in a
-  // single block loop.  We'll wait to move the OpLoopMerge until the end
-  // of the regular inlining logic, and only if necessary.
+  // If the caller is a loop header and the callee has multiple blocks, then the
+  // normal inlining logic will place the OpLoopMerge in the last of several
+  // blocks in the loop.  Instead, it should be placed at the end of the first
+  // block.  We'll wait to move the OpLoopMerge until the end of the regular
+  // inlining logic, and only if necessary.
   bool caller_is_loop_header = false;
   if (call_block_itr->GetLoopMergeInst()) {
     caller_is_loop_header = true;

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -27,7 +27,6 @@
 static const int kSpvFunctionCallFunctionId = 2;
 static const int kSpvFunctionCallArgumentId = 3;
 static const int kSpvReturnValueId = 0;
-static const int kSpvLoopMergeContinueTargetIdInIdx = 1;
 
 namespace spvtools {
 namespace opt {

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -291,14 +291,9 @@ bool InlinePass::GenInlineCode(
   // at the end of the first block.  First determine if the caller is in a
   // single block loop.  We'll wait to move the OpLoopMerge until the end
   // of the regular inlining logic, and only if necessary.
-  //bool caller_is_single_block_loop = false;
   bool caller_is_loop_header = false;
-  //if (auto* loop_merge = call_block_itr->GetLoopMergeInst()) {
   if (call_block_itr->GetLoopMergeInst()) {
     caller_is_loop_header = true;
-    //caller_is_single_block_loop =
-    //    call_block_itr->id() ==
-    //    loop_merge->GetSingleWordInOperand(kSpvLoopMergeContinueTargetIdInIdx);
   }
 
   bool callee_begins_with_structured_header =
@@ -612,10 +607,6 @@ bool InlinePass::GenInlineCode(
     --loop_merge_itr;
     assert(loop_merge_itr->opcode() == SpvOpLoopMerge);
     std::unique_ptr<Instruction> cp_inst(loop_merge_itr->Clone(context()));
-    //if (caller_is_single_block_loop) {
-    //  // Also, update its continue target to point to the last block.
-    //  cp_inst->SetInOperand(kSpvLoopMergeContinueTargetIdInIdx, {last->id()});
-    //}
     first->tail().InsertBefore(std::move(cp_inst));
 
     // Remove the loop merge from the last block.

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -291,13 +291,14 @@ bool InlinePass::GenInlineCode(
   // at the end of the first block.  First determine if the caller is in a
   // single block loop.  We'll wait to move the OpLoopMerge until the end
   // of the regular inlining logic, and only if necessary.
-  bool caller_is_single_block_loop = false;
+  //bool caller_is_single_block_loop = false;
   bool caller_is_loop_header = false;
-  if (auto* loop_merge = call_block_itr->GetLoopMergeInst()) {
+  //if (auto* loop_merge = call_block_itr->GetLoopMergeInst()) {
+  if (call_block_itr->GetLoopMergeInst()) {
     caller_is_loop_header = true;
-    caller_is_single_block_loop =
-        call_block_itr->id() ==
-        loop_merge->GetSingleWordInOperand(kSpvLoopMergeContinueTargetIdInIdx);
+    //caller_is_single_block_loop =
+    //    call_block_itr->id() ==
+    //    loop_merge->GetSingleWordInOperand(kSpvLoopMergeContinueTargetIdInIdx);
   }
 
   bool callee_begins_with_structured_header =
@@ -611,10 +612,10 @@ bool InlinePass::GenInlineCode(
     --loop_merge_itr;
     assert(loop_merge_itr->opcode() == SpvOpLoopMerge);
     std::unique_ptr<Instruction> cp_inst(loop_merge_itr->Clone(context()));
-    if (caller_is_single_block_loop) {
-      // Also, update its continue target to point to the last block.
-      cp_inst->SetInOperand(kSpvLoopMergeContinueTargetIdInIdx, {last->id()});
-    }
+    //if (caller_is_single_block_loop) {
+    //  // Also, update its continue target to point to the last block.
+    //  cp_inst->SetInOperand(kSpvLoopMergeContinueTargetIdInIdx, {last->id()});
+    //}
     first->tail().InsertBefore(std::move(cp_inst));
 
     // Remove the loop merge from the last block.

--- a/source/val/basic_block.h
+++ b/source/val/basic_block.h
@@ -15,8 +15,8 @@
 #ifndef SOURCE_VAL_BASIC_BLOCK_H_
 #define SOURCE_VAL_BASIC_BLOCK_H_
 
-#include <cstdint>
 #include <bitset>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <vector>
@@ -28,7 +28,7 @@ namespace val {
 
 enum BlockType : uint32_t {
   kBlockTypeUndefined,
-  kBlockTypeHeader,
+  kBlockTypeSelection,
   kBlockTypeLoop,
   kBlockTypeMerge,
   kBlockTypeBreak,

--- a/source/val/function.cpp
+++ b/source/val/function.cpp
@@ -14,9 +14,8 @@
 
 #include "source/val/function.h"
 
-#include <cassert>
-
 #include <algorithm>
+#include <cassert>
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
@@ -99,7 +98,7 @@ spv_result_t Function::RegisterLoopMerge(uint32_t merge_id,
 spv_result_t Function::RegisterSelectionMerge(uint32_t merge_id) {
   RegisterBlock(merge_id, false);
   BasicBlock& merge_block = blocks_.at(merge_id);
-  current_block_->set_type(kBlockTypeHeader);
+  current_block_->set_type(kBlockTypeSelection);
   merge_block.set_type(kBlockTypeMerge);
   merge_block_header_[&merge_block] = current_block_;
 
@@ -344,7 +343,7 @@ int Function::GetBlockDepth(BasicBlock* bb) {
     BasicBlock* header = merge_block_header_[bb];
     assert(header);
     block_depth_[bb] = GetBlockDepth(header);
-  } else if (bb_dom->is_type(kBlockTypeHeader) ||
+  } else if (bb_dom->is_type(kBlockTypeSelection) ||
              bb_dom->is_type(kBlockTypeLoop)) {
     // The dominator of the given block is a header block. So, the nesting
     // depth of this block is: 1 + nesting depth of the header.

--- a/source/val/validate_cfg.cpp
+++ b/source/val/validate_cfg.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "source/val/validate.h"
-
 #include <algorithm>
 #include <cassert>
 #include <functional>
@@ -34,6 +32,7 @@
 #include "source/val/basic_block.h"
 #include "source/val/construct.h"
 #include "source/val/function.h"
+#include "source/val/validate.h"
 #include "source/val/validation_state.h"
 
 namespace spvtools {
@@ -729,7 +728,7 @@ spv_result_t StructuredControlFlowChecks(
     }
 
     Construct::ConstructBlockSet construct_blocks = construct.blocks(function);
-    //auto PrintConstruct = [](const Construct& c) {
+    // auto PrintConstruct = [](const Construct& c) {
     //  switch (c.type()) {
     //    case ConstructType::kSelection:
     //      return "Selection";
@@ -741,8 +740,8 @@ spv_result_t StructuredControlFlowChecks(
     //      return "";
     //  }
     //};
-    //std::cout << PrintConstruct(construct) << " construct headed by " << header->id() << "\n";
-    //for (auto block : construct_blocks) {
+    // std::cout << PrintConstruct(construct) << " construct headed by " <<
+    // header->id() << "\n"; for (auto block : construct_blocks) {
     //  std::cout << " block: " << block->id() << "\n";
     //}
     for (auto block : construct_blocks) {
@@ -772,7 +771,8 @@ spv_result_t StructuredControlFlowChecks(
         }
       }
 
-      if (block->is_type(BlockType::kBlockTypeHeader)) {
+      if (block->is_type(BlockType::kBlockTypeSelection) ||
+          block->is_type(BlockType::kBlockTypeLoop)) {
         size_t index = (block->terminator() - &_.ordered_instructions()[0]) - 1;
         const auto& merge_inst = _.ordered_instructions()[index];
         if (merge_inst.opcode() == SpvOpSelectionMerge ||

--- a/source/val/validate_cfg.cpp
+++ b/source/val/validate_cfg.cpp
@@ -728,22 +728,6 @@ spv_result_t StructuredControlFlowChecks(
     }
 
     Construct::ConstructBlockSet construct_blocks = construct.blocks(function);
-    // auto PrintConstruct = [](const Construct& c) {
-    //  switch (c.type()) {
-    //    case ConstructType::kSelection:
-    //      return "Selection";
-    //    case ConstructType::kContinue:
-    //      return "Continue";
-    //    case ConstructType::kLoop:
-    //      return "Loop";
-    //    default:
-    //      return "";
-    //  }
-    //};
-    // std::cout << PrintConstruct(construct) << " construct headed by " <<
-    // header->id() << "\n"; for (auto block : construct_blocks) {
-    //  std::cout << " block: " << block->id() << "\n";
-    //}
     for (auto block : construct_blocks) {
       std::string construct_name, header_name, exit_name;
       std::tie(construct_name, header_name, exit_name) =

--- a/test/fuzz/transformation_copy_object_test.cpp
+++ b/test/fuzz/transformation_copy_object_test.cpp
@@ -291,7 +291,7 @@ TEST(TransformationCopyObjectTest, CheckIllegalCases) {
          %31 = OpLabel
          %42 = OpAccessChain %36 %18 %41
          %43 = OpLoad %11 %42
-               OpSelectionMerge %47 None
+               OpSelectionMerge %45 None
                OpSwitch %43 %46 0 %44 1 %45
          %46 = OpLabel
          %69 = OpIAdd %11 %96 %27

--- a/test/fuzz/transformation_replace_id_with_synonym_test.cpp
+++ b/test/fuzz/transformation_replace_id_with_synonym_test.cpp
@@ -159,18 +159,20 @@ const std::string kComplexShader = R"(
          %65 = OpAccessChain %13 %11 %64
          %66 = OpLoad %6 %65
          %67 = OpSGreaterThan %29 %84 %66
-               OpSelectionMerge %69 None
+               OpSelectionMerge %1000 None
                OpBranchConditional %67 %68 %72
          %68 = OpLabel
          %71 = OpIAdd %6 %84 %26
-               OpBranch %69
+               OpBranch %1000
          %72 = OpLabel
          %74 = OpIAdd %6 %84 %64
         %205 = OpCopyObject %6 %74
-               OpBranch %69
-         %69 = OpLabel
+               OpBranch %1000
+       %1000 = OpLabel
          %86 = OpPhi %6 %71 %68 %74 %72
         %301 = OpPhi %6 %71 %68 %15 %72
+               OpBranch %69
+         %69 = OpLabel
                OpBranch %20
          %22 = OpLabel
          %75 = OpAccessChain %46 %42 %50
@@ -421,18 +423,20 @@ TEST(TransformationReplaceIdWithSynonymTest, LegalTransformations) {
          %65 = OpAccessChain %13 %11 %64
          %66 = OpLoad %6 %65
          %67 = OpSGreaterThan %29 %84 %66
-               OpSelectionMerge %69 None
+               OpSelectionMerge %1000 None
                OpBranchConditional %67 %68 %72
          %68 = OpLabel
          %71 = OpIAdd %6 %84 %26
-               OpBranch %69
+               OpBranch %1000
          %72 = OpLabel
          %74 = OpIAdd %6 %84 %64
         %205 = OpCopyObject %6 %74
-               OpBranch %69
-         %69 = OpLabel
+               OpBranch %1000
+       %1000 = OpLabel
          %86 = OpPhi %6 %71 %68 %205 %72
         %301 = OpPhi %6 %71 %68 %15 %72
+               OpBranch %69
+         %69 = OpLabel
                OpBranch %20
          %22 = OpLabel
          %75 = OpAccessChain %46 %42 %50

--- a/test/opt/aggressive_dead_code_elim_test.cpp
+++ b/test/opt/aggressive_dead_code_elim_test.cpp
@@ -5932,7 +5932,6 @@ OpBranch %42
 %42 = OpLabel
 %43 = OpLoad %int %i
 %44 = OpSLessThan %bool %43 %int_1
-OpSelectionMerge %45 None
 OpBranchConditional %44 %46 %40
 %46 = OpLabel
 %47 = OpLoad %int %i

--- a/test/opt/block_merge_test.cpp
+++ b/test/opt/block_merge_test.cpp
@@ -447,9 +447,52 @@ OpBranch %header
 OpLoopMerge %merge %continue None
 OpBranch %inner_header
 %inner_header = OpLabel
-OpSelectionMerge %continue None
-OpBranchConditional %true %then %continue
+OpSelectionMerge %if_merge None
+OpBranchConditional %true %then %if_merge
 %then = OpLabel
+OpBranch %continue
+%if_merge = OpLabel
+OpBranch %continue
+%continue = OpLabel
+OpBranchConditional %false %merge %header
+%merge = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<BlockMergePass>(text, true);
+}
+
+TEST_F(BlockMergeTest, CannotMergeContinue) {
+  const std::string text = R"(
+; CHECK: OpBranch [[loop_header:%\w+]]
+; CHECK: [[loop_header]] = OpLabel
+; CHECK-NEXT: OpLoopMerge {{%\w+}} [[continue:%\w+]]
+; CHECK-NEXT: OpBranchConditional {{%\w+}} [[if_header:%\w+]]
+; CHECK: [[if_header]] = OpLabel
+; CHECK-NEXT: OpSelectionMerge
+; CHECK: [[continue]] = OpLabel
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %func "func"
+OpExecutionMode %func OriginUpperLeft
+%void = OpTypeVoid
+%bool = OpTypeBool
+%true = OpConstantTrue %bool
+%false = OpConstantFalse  %bool
+%functy = OpTypeFunction %void
+%func = OpFunction %void None %functy
+%entry = OpLabel
+OpBranch %header
+%header = OpLabel
+OpLoopMerge %merge %continue None
+OpBranchConditional %true %inner_header %merge
+%inner_header = OpLabel
+OpSelectionMerge %if_merge None
+OpBranchConditional %true %then %if_merge
+%then = OpLabel
+OpBranch %continue
+%if_merge = OpLabel
 OpBranch %continue
 %continue = OpLabel
 OpBranchConditional %false %merge %header

--- a/test/opt/dead_branch_elim_test.cpp
+++ b/test/opt/dead_branch_elim_test.cpp
@@ -2798,7 +2798,9 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<DeadBranchElimPass>(predefs + body, true);
+  // The selection merge in the loop naming the continue target as merge is
+  // invalid, but handled by this pass so validation is disabled.
+  SinglePassRunAndMatch<DeadBranchElimPass>(predefs + body, false);
 }
 
 TEST_F(DeadBranchElimTest, SelectionMergeWithNestedLoop) {
@@ -2942,7 +2944,9 @@ OpReturn
 OpFunctionEnd
 )";
 
-  SinglePassRunAndMatch<DeadBranchElimPass>(body, true);
+  // The selection merge in the loop naming the continue target as merge is
+  // invalid, but handled by this pass so validation is disabled.
+  SinglePassRunAndMatch<DeadBranchElimPass>(body, false);
 }
 
 TEST_F(DeadBranchElimTest, UnreachableMergeAndContinueSameBlock) {

--- a/test/opt/inline_test.cpp
+++ b/test/opt/inline_test.cpp
@@ -1819,7 +1819,7 @@ OpFunctionEnd
 %9 = OpLabel
 OpBranch %10
 %10 = OpLabel
-OpLoopMerge %12 %13 None
+OpLoopMerge %12 %10 None
 OpBranch %13
 %13 = OpLabel
 OpBranchConditional %true %10 %12
@@ -1980,7 +1980,7 @@ OpFunctionEnd
 OpBranch %13
 %13 = OpLabel
 %14 = OpCopyObject %bool %false
-OpLoopMerge %16 %19 None
+OpLoopMerge %16 %13 None
 OpBranch %17
 %17 = OpLabel
 %18 = OpCopyObject %bool %true
@@ -2145,7 +2145,7 @@ OpBranch %19
 %19 = OpLabel
 %20 = OpCopyObject %int %int_2
 %25 = OpCopyObject %int %int_0
-OpLoopMerge %23 %26 None
+OpLoopMerge %23 %19 None
 OpBranch %26
 %27 = OpLabel
 %28 = OpCopyObject %int %int_1

--- a/test/opt/local_ssa_elim_test.cpp
+++ b/test/opt/local_ssa_elim_test.cpp
@@ -193,7 +193,24 @@ OpDecorate %fo Location 0
 )";
 
   const std::string before =
-      R"(%main = OpFunction %void None %9
+      R"(
+; CHECK: = OpFunction
+; CHECK-NEXT: [[entry:%\w+]] = OpLabel
+; CHECK: [[outer_header:%\w+]] = OpLabel
+; CHECK-NEXT: [[outer_f:%\w+]] = OpPhi %float %float_0 [[entry]] [[inner_f:%\w+]] [[outer_be:%\w+]]
+; CHECK-NEXT: [[i:%\w+]] = OpPhi %int %int_0 [[entry]] [[i_next:%\w+]] [[outer_be]]
+; CHECK-NEXT: OpSLessThan {{%\w+}} [[i]]
+; CHECK: [[inner_pre_header:%\w+]] = OpLabel
+; CHECK: [[inner_header:%\w+]] = OpLabel
+; CHECK-NEXT: [[inner_f]] = OpPhi %float [[outer_f]] [[inner_pre_header]] [[f_next:%\w+]] [[inner_be:%\w+]]
+; CHECK-NEXT: [[j:%\w+]] = OpPhi %int %int_0 [[inner_pre_header]] [[j_next:%\w+]] [[inner_be]]
+; CHECK: [[inner_be]] = OpLabel
+; CHECK: [[f_next]] = OpFAdd %float [[inner_f]]
+; CHECK: [[j_next]] = OpIAdd %int [[j]] %int_1
+; CHECK: [[outer_be]] = OpLabel
+; CHECK: [[i_next]] = OpIAdd
+; CHECK: OpStore %fo [[outer_f]]
+%main = OpFunction %void None %9
 %24 = OpLabel
 %f = OpVariable %_ptr_Function_float Function
 %i = OpVariable %_ptr_Function_int Function
@@ -212,8 +229,8 @@ OpBranch %31
 %31 = OpLabel
 %32 = OpLoad %int %j
 %33 = OpSLessThan %bool %32 %int_4
-OpLoopMerge %29 %34 None
-OpBranchConditional %33 %34 %29
+OpLoopMerge %50 %34 None
+OpBranchConditional %33 %34 %50
 %34 = OpLabel
 %35 = OpLoad %float %f
 %36 = OpLoad %int %i
@@ -226,6 +243,8 @@ OpStore %f %40
 %42 = OpIAdd %int %41 %int_1
 OpStore %j %42
 OpBranch %31
+%50 = OpLabel
+OpBranch %29
 %29 = OpLabel
 %43 = OpLoad %int %i
 %44 = OpIAdd %int %43 %int_1
@@ -238,50 +257,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  const std::string after =
-      R"(%main = OpFunction %void None %9
-%24 = OpLabel
-%f = OpVariable %_ptr_Function_float Function
-%i = OpVariable %_ptr_Function_int Function
-%j = OpVariable %_ptr_Function_int Function
-OpStore %f %float_0
-OpStore %i %int_0
-OpBranch %25
-%25 = OpLabel
-%47 = OpPhi %float %float_0 %24 %50 %29
-%46 = OpPhi %int %int_0 %24 %44 %29
-%27 = OpSLessThan %bool %46 %int_4
-OpLoopMerge %28 %29 None
-OpBranchConditional %27 %30 %28
-%30 = OpLabel
-OpStore %j %int_0
-OpBranch %31
-%31 = OpLabel
-%50 = OpPhi %float %47 %30 %40 %34
-%48 = OpPhi %int %int_0 %30 %42 %34
-%33 = OpSLessThan %bool %48 %int_4
-OpLoopMerge %29 %34 None
-OpBranchConditional %33 %34 %29
-%34 = OpLabel
-%38 = OpAccessChain %_ptr_Input_float %BC %46 %48
-%39 = OpLoad %float %38
-%40 = OpFAdd %float %50 %39
-OpStore %f %40
-%42 = OpIAdd %int %48 %int_1
-OpStore %j %42
-OpBranch %31
-%29 = OpLabel
-%44 = OpIAdd %int %46 %int_1
-OpStore %i %44
-OpBranch %25
-%28 = OpLabel
-OpStore %fo %47
-OpReturn
-OpFunctionEnd
-)";
-
-  SinglePassRunAndCheck<SSARewritePass>(predefs + before, predefs + after, true,
-                                        true);
+  SinglePassRunAndMatch<SSARewritePass>(predefs + before, true);
 }
 
 TEST_F(LocalSSAElimTest, ForLoopWithContinue) {

--- a/test/opt/loop_optimizations/fusion_legal.cpp
+++ b/test/opt/loop_optimizations/fusion_legal.cpp
@@ -3177,7 +3177,7 @@ TEST_F(FusionLegalTest, OuterloopWithBreakContinueInInner) {
          %21 = OpLabel
          %29 = OpSMod %6 %96 %28
          %30 = OpIEqual %17 %29 %9
-               OpSelectionMerge %23 None
+               OpSelectionMerge %sel_merge None
                OpBranchConditional %30 %31 %48
          %31 = OpLabel
          %44 = OpAccessChain %7 %41 %91 %96
@@ -3187,8 +3187,10 @@ TEST_F(FusionLegalTest, OuterloopWithBreakContinueInInner) {
                OpStore %47 %46
                OpBranch %32
          %48 = OpLabel
-               OpBranch %23
+               OpBranch %sel_merge
          %32 = OpLabel
+               OpBranch %sel_merge
+  %sel_merge = OpLabel
                OpBranch %23
          %23 = OpLabel
          %52 = OpIAdd %6 %96 %51

--- a/test/opt/pass_merge_return_test.cpp
+++ b/test/opt/pass_merge_return_test.cpp
@@ -1390,7 +1390,6 @@ TEST_F(MergeReturnPassTest, SerialLoopsUpdateBlockMapping) {
                OpLoopMerge %36 %40 None
                OpBranch %35
          %35 = OpLabel
-               OpSelectionMerge %40 None
                OpBranchConditional %77 %39 %40
          %39 = OpLabel
                OpReturnValue %16
@@ -1402,7 +1401,6 @@ TEST_F(MergeReturnPassTest, SerialLoopsUpdateBlockMapping) {
                OpLoopMerge %45 %49 None
                OpBranch %44
          %44 = OpLabel
-               OpSelectionMerge %49 None
                OpBranchConditional %77 %48 %49
          %48 = OpLabel
                OpReturnValue %16
@@ -1415,7 +1413,6 @@ TEST_F(MergeReturnPassTest, SerialLoopsUpdateBlockMapping) {
                OpLoopMerge %64 %68 None
                OpBranch %63
          %63 = OpLabel
-               OpSelectionMerge %68 None
                OpBranchConditional %77 %67 %68
          %67 = OpLabel
                OpReturnValue %16
@@ -1813,12 +1810,14 @@ TEST_F(MergeReturnPassTest, PhiInSecondMerge) {
                OpLoopMerge %11 %12 None
                OpBranch %13
          %13 = OpLabel
-               OpLoopMerge %12 %14 None
-               OpBranchConditional %8 %15 %12
+               OpLoopMerge %18 %14 None
+               OpBranchConditional %8 %15 %18
          %15 = OpLabel
                OpReturn
          %14 = OpLabel
                OpBranch %13
+         %18 = OpLabel
+               OpBranch %12
          %12 = OpLabel
          %16 = OpUndef %float
                OpBranchConditional %8 %10 %11

--- a/test/reduce/reducer_test.cpp
+++ b/test/reduce/reducer_test.cpp
@@ -125,19 +125,21 @@ TEST(ReducerTest, ExprToConstantAndRemoveUnreferenced) {
          %29 = OpAccessChain %28 %27 %9
          %30 = OpLoad %24 %29
          %32 = OpFOrdGreaterThan %22 %30 %31
-               OpSelectionMerge %34 None
+               OpSelectionMerge %90 None
                OpBranchConditional %32 %33 %46
          %33 = OpLabel
          %40 = OpFAdd %24 %71 %30
          %45 = OpISub %6 %73 %21
-               OpBranch %34
+               OpBranch %90
          %46 = OpLabel
          %50 = OpFMul %24 %71 %30
          %54 = OpSDiv %6 %73 %21
-               OpBranch %34
-         %34 = OpLabel
+               OpBranch %90
+         %90 = OpLabel
          %77 = OpPhi %6 %45 %33 %54 %46
          %76 = OpPhi %24 %40 %33 %50 %46
+               OpBranch %34
+         %34 = OpLabel
          %57 = OpIAdd %6 %70 %56
                OpBranch %10
          %12 = OpLabel
@@ -193,11 +195,13 @@ TEST(ReducerTest, ExprToConstantAndRemoveUnreferenced) {
                OpLoopMerge %12 %34 None
                OpBranchConditional %100 %11 %12
          %11 = OpLabel
-               OpSelectionMerge %34 None
+               OpSelectionMerge %90 None
                OpBranchConditional %100 %33 %46
          %33 = OpLabel
-               OpBranch %34
+               OpBranch %90
          %46 = OpLabel
+               OpBranch %90
+         %90 = OpLabel
                OpBranch %34
          %34 = OpLabel
                OpBranch %10
@@ -345,7 +349,6 @@ const std::string kShaderWithLoopsDivAndMul = R"(
                OpLoopMerge %33 %38 None
                OpBranch %32
          %32 = OpLabel
-               OpSelectionMerge %38 None
                OpBranchConditional %30 %37 %38
          %37 = OpLabel
                OpSelectionMerge %42 None

--- a/test/reduce/validation_during_reduction_test.cpp
+++ b/test/reduce/validation_during_reduction_test.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "source/reduce/reducer.h"
-
 #include "source/reduce/reduction_opportunity.h"
 #include "source/reduce/remove_instruction_reduction_opportunity.h"
 #include "test/reduce/reduce_test_util.h"
@@ -23,8 +22,8 @@ namespace reduce {
 namespace {
 
 using opt::Function;
-using opt::IRContext;
 using opt::Instruction;
+using opt::IRContext;
 
 // A dumb reduction opportunity finder that finds opportunities to remove global
 // values regardless of whether they are referenced. This is very likely to make
@@ -181,19 +180,21 @@ TEST(ValidationDuringReductionTest, CheckInvalidPassMakesNoProgress) {
          %29 = OpAccessChain %28 %27 %9
          %30 = OpLoad %24 %29
          %32 = OpFOrdGreaterThan %22 %30 %31
-               OpSelectionMerge %34 None
+               OpSelectionMerge %90 None
                OpBranchConditional %32 %33 %46
          %33 = OpLabel
          %40 = OpFAdd %24 %71 %30
          %45 = OpISub %6 %73 %21
-               OpBranch %34
+               OpBranch %90
          %46 = OpLabel
          %50 = OpFMul %24 %71 %30
          %54 = OpSDiv %6 %73 %21
-               OpBranch %34
-         %34 = OpLabel
+               OpBranch %90
+         %90 = OpLabel
          %77 = OpPhi %6 %45 %33 %54 %46
          %76 = OpPhi %24 %40 %33 %50 %46
+               OpBranch %34
+         %34 = OpLabel
          %57 = OpIAdd %6 %70 %56
                OpBranch %10
          %12 = OpLabel
@@ -303,19 +304,21 @@ TEST(ValidationDuringReductionTest, CheckNotAlwaysInvalidCanMakeProgress) {
          %29 = OpAccessChain %28 %27 %9
          %30 = OpLoad %24 %29
          %32 = OpFOrdGreaterThan %22 %30 %31
-               OpSelectionMerge %34 None
+               OpSelectionMerge %90 None
                OpBranchConditional %32 %33 %46
          %33 = OpLabel
          %40 = OpFAdd %24 %71 %30
          %45 = OpISub %6 %73 %21
-               OpBranch %34
+               OpBranch %90
          %46 = OpLabel
          %50 = OpFMul %24 %71 %30
          %54 = OpSDiv %6 %73 %21
-               OpBranch %34
-         %34 = OpLabel
+               OpBranch %90
+         %90 = OpLabel
          %77 = OpPhi %6 %45 %33 %54 %46
          %76 = OpPhi %24 %40 %33 %50 %46
+               OpBranch %34
+         %34 = OpLabel
          %57 = OpIAdd %6 %70 %56
                OpBranch %10
          %12 = OpLabel
@@ -392,19 +395,21 @@ TEST(ValidationDuringReductionTest, CheckNotAlwaysInvalidCanMakeProgress) {
          %29 = OpAccessChain %28 %27 %9
          %30 = OpLoad %24 %29
          %32 = OpFOrdGreaterThan %22 %30 %31
-               OpSelectionMerge %34 None
+               OpSelectionMerge %90 None
                OpBranchConditional %32 %33 %46
          %33 = OpLabel
          %40 = OpFAdd %24 %71 %30
          %45 = OpISub %6 %73 %21
-               OpBranch %34
+               OpBranch %90
          %46 = OpLabel
          %50 = OpFMul %24 %71 %30
          %54 = OpSDiv %6 %73 %21
-               OpBranch %34
-         %34 = OpLabel
+               OpBranch %90
+         %90 = OpLabel
          %77 = OpPhi %6 %45 %33 %54 %46
          %76 = OpPhi %24 %40 %33 %50 %46
+               OpBranch %34
+         %34 = OpLabel
          %57 = OpIAdd %6 %70 %56
                OpBranch %10
          %12 = OpLabel

--- a/test/val/val_cfg_test.cpp
+++ b/test/val/val_cfg_test.cpp
@@ -2038,7 +2038,7 @@ TEST_P(ValidateCFG,
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions()) << getDiagnosticString();
 }
 
-TEST_P(ValidateCFG, ContinueTargetCanBeMergeBlockForNestedStructureGood) {
+TEST_P(ValidateCFG, ContinueTargetCanBeMergeBlockForNestedStructure) {
   // The continue construct cannot be the merge target of a nested selection
   // because the loop construct must contain "if_merge" because it contains
   // "if_head".


### PR DESCRIPTION
Validate the spec rule:
> when a construct contains another header block, it also contains that header’s corresponding merge block if that merge block is reachable in the CFG

Fixes #3031 

Identified problems in block merging and inlining. Block merging will no longer merge a continue target. Inlining a single block loop will not modify the continue target. Had to fix up many invalid tests.