### PR TITLE
spirv-fuzz: Improve debugging facilities

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -627,6 +627,11 @@ SPIRV_TOOLS_EXPORT void spvFuzzerOptionsSetRandomSeed(
 SPIRV_TOOLS_EXPORT void spvFuzzerOptionsSetShrinkerStepLimit(
     spv_fuzzer_options options, uint32_t shrinker_step_limit);
 
+// Enables running the validator after every pass is applied during a fuzzing
+// run.
+SPIRV_TOOLS_EXPORT void spvFuzzerOptionsEnableFuzzerPassValidation(
+    spv_fuzzer_options options);
+
 // Encodes the given SPIR-V assembly text to its binary representation. The
 // length parameter specifies the number of bytes for text. Encoded binary will
 // be stored into *binary. Any error will be written into *diagnostic if

--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -229,6 +229,11 @@ class FuzzerOptions {
     spvFuzzerOptionsSetShrinkerStepLimit(options_, shrinker_step_limit);
   }
 
+  // See spvFuzzerOptionsEnableFuzzerPassValidation.
+  void enable_fuzzer_pass_validation() {
+    spvFuzzerOptionsEnableFuzzerPassValidation(options_);
+  }
+
  private:
   spv_fuzzer_options options_;
 };

--- a/source/fuzz/fuzzer.h
+++ b/source/fuzz/fuzzer.h
@@ -32,11 +32,16 @@ class Fuzzer {
   enum class FuzzerResultStatus {
     kComplete,
     kFailedToCreateSpirvToolsInterface,
+    kFuzzerPassLedToInvalidModule,
     kInitialBinaryInvalid,
   };
 
-  // Constructs a fuzzer from the given target environment.
-  explicit Fuzzer(spv_target_env env);
+  // Constructs a fuzzer from the given target environment |env|.  |seed| is a
+  // seed for pseudo-random number generation.
+  // |validate_after_each_fuzzer_pass| controls whether the validator will be
+  // invoked after every fuzzer pass is applied.
+  explicit Fuzzer(spv_target_env env, uint32_t seed,
+                  bool validate_after_each_fuzzer_pass);
 
   // Disables copy/move constructor/assignment operations.
   Fuzzer(const Fuzzer&) = delete;
@@ -51,14 +56,13 @@ class Fuzzer {
   void SetMessageConsumer(MessageConsumer consumer);
 
   // Transforms |binary_in| to |binary_out| by running a number of randomized
-  // fuzzer passes, controlled via |options|.  Initial facts about the input
-  // binary and the context in which it will execute are provided via
-  // |initial_facts|.  The transformation sequence that was applied is returned
-  // via |transformation_sequence_out|.
+  // fuzzer passes.  Initial facts about the input binary and the context in
+  // which it will execute are provided via |initial_facts|.  The transformation
+  // sequence that was applied is returned via |transformation_sequence_out|.
   FuzzerResultStatus Run(
       const std::vector<uint32_t>& binary_in,
       const protobufs::FactSequence& initial_facts,
-      spv_const_fuzzer_options options, std::vector<uint32_t>* binary_out,
+      std::vector<uint32_t>* binary_out,
       protobufs::TransformationSequence* transformation_sequence_out) const;
 
  private:

--- a/source/spirv_fuzzer_options.cpp
+++ b/source/spirv_fuzzer_options.cpp
@@ -23,7 +23,8 @@ spv_fuzzer_options_t::spv_fuzzer_options_t()
     : has_random_seed(false),
       random_seed(0),
       replay_validation_enabled(false),
-      shrinker_step_limit(kDefaultStepLimit) {}
+      shrinker_step_limit(kDefaultStepLimit),
+      fuzzer_pass_validation_enabled(false) {}
 
 SPIRV_TOOLS_EXPORT spv_fuzzer_options spvFuzzerOptionsCreate() {
   return new spv_fuzzer_options_t();
@@ -47,4 +48,9 @@ SPIRV_TOOLS_EXPORT void spvFuzzerOptionsSetRandomSeed(
 SPIRV_TOOLS_EXPORT void spvFuzzerOptionsSetShrinkerStepLimit(
     spv_fuzzer_options options, uint32_t shrinker_step_limit) {
   options->shrinker_step_limit = shrinker_step_limit;
+}
+
+SPIRV_TOOLS_EXPORT void spvFuzzerOptionsEnableFuzzerPassValidation(
+    spv_fuzzer_options options) {
+  options->fuzzer_pass_validation_enabled = true;
 }

--- a/source/spirv_fuzzer_options.h
+++ b/source/spirv_fuzzer_options.h
@@ -34,6 +34,9 @@ struct spv_fuzzer_options_t {
 
   // See spvFuzzerOptionsSetShrinkerStepLimit.
   uint32_t shrinker_step_limit;
+
+  // See spvFuzzerOptionsValidateAfterEveryPass.
+  bool fuzzer_pass_validation_enabled;
 };
 
 #endif  // SOURCE_SPIRV_FUZZER_OPTIONS_H_

--- a/test/fuzz/fuzz_test_util.cpp
+++ b/test/fuzz/fuzz_test_util.cpp
@@ -14,6 +14,7 @@
 
 #include "test/fuzz/fuzz_test_util.h"
 
+#include <fstream>
 #include <iostream>
 
 #include "tools/io.h"
@@ -102,6 +103,21 @@ void DumpShader(const std::vector<uint32_t>& binary, const char* filename) {
       WriteFile(filename, "wb", &binary[0], binary.size());
   if (!write_file_succeeded) {
     std::cerr << "Failed to dump shader" << std::endl;
+  }
+}
+
+void DumpTransformationsJson(
+    const protobufs::TransformationSequence& transformations,
+    const char* filename) {
+  std::string json_string;
+  auto json_options = google::protobuf::util::JsonOptions();
+  json_options.add_whitespace = true;
+  auto json_generation_status = google::protobuf::util::MessageToJsonString(
+      transformations, &json_string, json_options);
+  if (json_generation_status == google::protobuf::util::Status::OK) {
+    std::ofstream transformations_json_file(filename);
+    transformations_json_file << json_string;
+    transformations_json_file.close();
   }
 }
 

--- a/test/fuzz/fuzz_test_util.h
+++ b/test/fuzz/fuzz_test_util.h
@@ -19,6 +19,7 @@
 
 #include <vector>
 
+#include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
 #include "source/opt/build_module.h"
 #include "source/opt/ir_context.h"
 #include "spirv-tools/libspirv.h"
@@ -99,6 +100,12 @@ void DumpShader(opt::IRContext* context, const char* filename);
 
 // Dumps |binary| to file |filename|. Useful for interactive debugging.
 void DumpShader(const std::vector<uint32_t>& binary, const char* filename);
+
+// Dumps |transformations| to file |filename| in JSON format. Useful for
+// interactive debugging.
+void DumpTransformationsJson(
+    const protobufs::TransformationSequence& transformations,
+    const char* filename);
 
 }  // namespace fuzz
 }  // namespace spvtools

--- a/test/fuzz/fuzzer_replayer_test.cpp
+++ b/test/fuzz/fuzzer_replayer_test.cpp
@@ -62,13 +62,11 @@ void RunFuzzerAndReplayer(const std::string& shader,
   for (uint32_t seed = initial_seed; seed < initial_seed + num_runs; seed++) {
     std::vector<uint32_t> fuzzer_binary_out;
     protobufs::TransformationSequence fuzzer_transformation_sequence_out;
-    spvtools::FuzzerOptions fuzzer_options;
-    spvFuzzerOptionsSetRandomSeed(fuzzer_options, seed);
 
-    Fuzzer fuzzer(env);
+    Fuzzer fuzzer(env, seed, true);
     fuzzer.SetMessageConsumer(kSilentConsumer);
     auto fuzzer_result_status =
-        fuzzer.Run(binary_in, initial_facts, fuzzer_options, &fuzzer_binary_out,
+        fuzzer.Run(binary_in, initial_facts, &fuzzer_binary_out,
                    &fuzzer_transformation_sequence_out);
     ASSERT_EQ(Fuzzer::FuzzerResultStatus::kComplete, fuzzer_result_status);
     ASSERT_TRUE(t.Validate(fuzzer_binary_out));

--- a/test/fuzz/fuzzer_shrinker_test.cpp
+++ b/test/fuzz/fuzzer_shrinker_test.cpp
@@ -165,12 +165,10 @@ void RunFuzzerAndShrinker(const std::string& shader,
   // Run the fuzzer and check that it successfully yields a valid binary.
   std::vector<uint32_t> fuzzer_binary_out;
   protobufs::TransformationSequence fuzzer_transformation_sequence_out;
-  spvtools::FuzzerOptions fuzzer_options;
-  spvFuzzerOptionsSetRandomSeed(fuzzer_options, seed);
-  Fuzzer fuzzer(env);
+  Fuzzer fuzzer(env, seed, true);
   fuzzer.SetMessageConsumer(kSilentConsumer);
   auto fuzzer_result_status =
-      fuzzer.Run(binary_in, initial_facts, fuzzer_options, &fuzzer_binary_out,
+      fuzzer.Run(binary_in, initial_facts, &fuzzer_binary_out,
                  &fuzzer_transformation_sequence_out);
   ASSERT_EQ(Fuzzer::FuzzerResultStatus::kComplete, fuzzer_result_status);
   ASSERT_TRUE(t.Validate(fuzzer_binary_out));


### PR DESCRIPTION
Adds an option to run the validator on the SPIR-V binary after each
fuzzer pass has been applied, to help identify when the fuzzer has
made the module invalid.  Also adds a helper method to allow dumping
of the sequence of transformations that have been applied to a JSON
file.