### PR TITLE
Remove names and decorations of imported symbols

### DIFF
--- a/source/link/linker.cpp
+++ b/source/link/linker.cpp
@@ -137,8 +137,6 @@ spv_result_t CheckImportExportCompatibility(const MessageConsumer& consumer,
 // TODO(pierremoreau): Linkage attributes applied by a group decoration are
 //                     currently not handled. (You could have a group being
 //                     applied to a single ID.)
-// TODO(pierremoreau): Run a pass for removing dead instructions, for example
-//                     OpName for prototypes of imported funcions.
 spv_result_t RemoveLinkageSpecificInstructions(
     const MessageConsumer& consumer, const LinkerOptions& options,
     const LinkageTable& linkings_to_do, DecorationManager* decoration_manager,
@@ -531,24 +529,6 @@ spv_result_t RemoveLinkageSpecificInstructions(
   // TODO(pierremoreau): Remove FuncParamAttr decorations of imported
   // functions' return type.
 
-  // Remove FuncParamAttr decorations of imported functions' parameters.
-  // From the SPIR-V specification, Sec. 2.13:
-  //   When resolving imported functions, the Function Control and all Function
-  //   Parameter Attributes are taken from the function definition, and not
-  //   from the function declaration.
-  for (const auto& linking_entry : linkings_to_do) {
-    for (const auto parameter_id :
-         linking_entry.imported_symbol.parameter_ids) {
-      decoration_manager->RemoveDecorationsFrom(
-          parameter_id, [](const Instruction& inst) {
-            return (inst.opcode() == SpvOpDecorate ||
-                    inst.opcode() == SpvOpMemberDecorate) &&
-                   inst.GetSingleWordInOperand(1u) ==
-                       SpvDecorationFuncParamAttr;
-          });
-    }
-  }
-
   // Remove prototypes of imported functions
   for (const auto& linking_entry : linkings_to_do) {
     for (auto func_iter = linked_context->module()->begin();
@@ -746,24 +726,34 @@ spv_result_t Link(const Context& context, const uint32_t* const* binaries,
   opt::Pass::Status pass_res = manager.Run(&linked_context);
   if (pass_res == opt::Pass::Status::Failure) return SPV_ERROR_INVALID_DATA;
 
-  // Phase 7: Rematch import variables/functions to export variables/functions
-  for (const auto& linking_entry : linkings_to_do)
+  // Phase 7: Remove all names and decorations of import variables/functions
+  for (const auto& linking_entry : linkings_to_do) {
+    linked_context.KillNamesAndDecorates(linking_entry.imported_symbol.id);
+    for (const auto parameter_id :
+         linking_entry.imported_symbol.parameter_ids) {
+      linked_context.KillNamesAndDecorates(parameter_id);
+    }
+  }
+
+  // Phase 8: Rematch import variables/functions to export variables/functions
+  for (const auto& linking_entry : linkings_to_do) {
     linked_context.ReplaceAllUsesWith(linking_entry.imported_symbol.id,
                                       linking_entry.exported_symbol.id);
+  }
 
-  // Phase 8: Remove linkage specific instructions, such as import/export
+  // Phase 9: Remove linkage specific instructions, such as import/export
   // attributes, linkage capability, etc. if applicable
   res = RemoveLinkageSpecificInstructions(consumer, options, linkings_to_do,
                                           linked_context.get_decoration_mgr(),
                                           &linked_context);
   if (res != SPV_SUCCESS) return res;
 
-  // Phase 9: Compact the IDs used in the module
+  // Phase 10: Compact the IDs used in the module
   manager.AddPass<opt::CompactIdsPass>();
   pass_res = manager.Run(&linked_context);
   if (pass_res == opt::Pass::Status::Failure) return SPV_ERROR_INVALID_DATA;
 
-  // Phase 10: Output the module
+  // Phase 11: Output the module
   linked_context.module()->ToBinary(linked_binary, true);
 
   return SPV_SUCCESS;


### PR DESCRIPTION
There seems to be no reason to keep the original variable/function/parameter decorations around for import symbols, as the corresponding exports should either match them or should override them. At least that's my understanding, but if there are any exceptions to that please let me know.

Also, with this change the generated module won't have stale decoration and name instructions referring to ids which no longer exist after linking.