### PR TITLE
spirv-fuzz: Use validator to check break/continue dominance conditions

### DIFF
--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -14,6 +14,8 @@
 
 #include "source/fuzz/fuzzer_util.h"
 
+#include "source/opt/build_module.h"
+
 namespace spvtools {
 namespace fuzz {
 
@@ -180,108 +182,6 @@ opt::BasicBlock::iterator GetIteratorForInstruction(
   return block->end();
 }
 
-bool NewEdgeRespectsUseDefDominance(opt::IRContext* context,
-                                    opt::BasicBlock* bb_from,
-                                    opt::BasicBlock* bb_to) {
-  assert(bb_from->terminator()->opcode() == SpvOpBranch);
-
-  // If there is *already* an edge from |bb_from| to |bb_to|, then adding
-  // another edge is fine from a dominance point of view.
-  if (bb_from->terminator()->GetSingleWordInOperand(0) == bb_to->id()) {
-    return true;
-  }
-
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/2919): the
-  //  solution below to determining whether a new edge respects dominance
-  //  rules is incomplete.  Test
-  //  TransformationAddDeadContinueTest::DISABLED_Miscellaneous6 exposes the
-  //  problem.  In practice, this limitation does not bite too often, and the
-  //  worst it does is leads to SPIR-V that spirv-val rejects.
-
-  // Let us assume that the module being manipulated is valid according to the
-  // rules of the SPIR-V language.
-  //
-  // Suppose that some block Y is dominated by |bb_to| (which includes the case
-  // where Y = |bb_to|).
-  //
-  // Suppose that Y uses an id i that is defined in some other block X.
-  //
-  // Because the module is valid, X must dominate Y.  We are concerned about
-  // whether an edge from |bb_from| to |bb_to| could *stop* X from dominating
-  // Y.
-  //
-  // Because |bb_to| dominates Y, a new edge from |bb_from| to |bb_to| can
-  // only affect whether X dominates Y if X dominates |bb_to|.
-  //
-  // So let us assume that X does dominate |bb_to|, so that we have:
-  //
-  //   (X defines i) dominates |bb_to| dominates (Y uses i)
-  //
-  // The new edge from |bb_from| to |bb_to| will stop the definition of i in X
-  // from dominating the use of i in Y exactly when the new edge will stop X
-  // from dominating |bb_to|.
-  //
-  // Now, the block X that we are worried about cannot dominate |bb_from|,
-  // because in that case X would still dominate |bb_to| after we add an edge
-  // from |bb_from| to |bb_to|.
-  //
-  // Also, it cannot be that X = |bb_to|, because nothing can stop a block
-  // from dominating itself.
-  //
-  // So we are looking for a block X such that:
-  //
-  // - X strictly dominates |bb_to|
-  // - X does not dominate |bb_from|
-  // - X defines an id i
-  // - i is used in some block Y
-  // - |bb_to| dominates Y
-
-  // Walk the dominator tree backwards, starting from the immediate dominator
-  // of |bb_to|.  We can stop when we find a block that also dominates
-  // |bb_from|.
-  auto dominator_analysis = context->GetDominatorAnalysis(bb_from->GetParent());
-  for (auto dominator = dominator_analysis->ImmediateDominator(bb_to);
-       dominator != nullptr &&
-       !dominator_analysis->Dominates(dominator, bb_from);
-       dominator = dominator_analysis->ImmediateDominator(dominator)) {
-    // |dominator| is a candidate for block X in the above description.
-    // We now look through the instructions for a candidate instruction i.
-    for (auto& inst : *dominator) {
-      // Consider all the uses of this instruction.
-      if (!context->get_def_use_mgr()->WhileEachUse(
-              &inst,
-              [bb_to, context, dominator_analysis](
-                  opt::Instruction* user, uint32_t operand_index) -> bool {
-                // If this use is in an OpPhi, we need to check that dominance
-                // of the relevant *parent* block is not spoiled.  Otherwise we
-                // need to check that dominance of the block containing the use
-                // is not spoiled.
-                opt::BasicBlock* use_block_or_phi_parent =
-                    user->opcode() == SpvOpPhi
-                        ? context->cfg()->block(
-                              user->GetSingleWordOperand(operand_index + 1))
-                        : context->get_instr_block(user);
-
-                // There might not be any relevant block, e.g. if the use is in
-                // a decoration; in this case the new edge is unproblematic.
-                if (use_block_or_phi_parent == nullptr) {
-                  return true;
-                }
-
-                // With reference to the above discussion,
-                // |use_block_or_phi_parent| is a candidate for the block Y.
-                // If |bb_to| dominates this block, the new edge would be
-                // problematic.
-                return !dominator_analysis->Dominates(bb_to,
-                                                      use_block_or_phi_parent);
-              })) {
-        return false;
-      }
-    }
-  }
-  return true;
-}
-
 bool BlockIsReachableInItsFunction(opt::IRContext* context,
                                    opt::BasicBlock* bb) {
   auto enclosing_function = bb->GetParent();
@@ -397,6 +297,19 @@ uint32_t GetArraySize(const opt::Instruction& array_type_instruction,
     return 0;
   }
   return array_length_constant->GetU32();
+}
+
+bool IsValid(opt::IRContext* context) {
+  std::vector<uint32_t> binary;
+  context->module()->ToBinary(&binary, false);
+  return SpirvTools(context->grammar().target_env()).Validate(binary);
+}
+
+std::unique_ptr<opt::IRContext> CloneIRContext(opt::IRContext* context) {
+  std::vector<uint32_t> binary;
+  context->module()->ToBinary(&binary, false);
+  return BuildModule(context->grammar().target_env(), nullptr, binary.data(),
+                     binary.size());
 }
 
 }  // namespace fuzzerutil

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -69,14 +69,6 @@ bool BlockIsInLoopContinueConstruct(opt::IRContext* context, uint32_t block_id,
 opt::BasicBlock::iterator GetIteratorForInstruction(
     opt::BasicBlock* block, const opt::Instruction* inst);
 
-// The function determines whether adding an edge from |bb_from| to |bb_to| -
-// is legitimate with respect to the SPIR-V rule that a definition must
-// dominate all of its uses.  This is because adding such an edge can change
-// dominance in the control flow graph, potentially making the module invalid.
-bool NewEdgeRespectsUseDefDominance(opt::IRContext* context,
-                                    opt::BasicBlock* bb_from,
-                                    opt::BasicBlock* bb_to);
-
 // Returns true if and only if there is a path to |bb| from the entry block of
 // the function that contains |bb|.
 bool BlockIsReachableInItsFunction(opt::IRContext* context,
@@ -116,6 +108,13 @@ uint32_t GetNumberOfStructMembers(
 // 0 if there is not a static size.
 uint32_t GetArraySize(const opt::Instruction& array_type_instruction,
                       opt::IRContext* context);
+
+// Returns true if and only if |context| is valid, according to the validator.
+bool IsValid(opt::IRContext* context);
+
+// Returns a clone of |context|, by writing |context| to a binary and then
+// parsing it again.
+std::unique_ptr<opt::IRContext> CloneIRContext(opt::IRContext* context);
 
 }  // namespace fuzzerutil
 

--- a/source/fuzz/transformation_add_dead_break.h
+++ b/source/fuzz/transformation_add_dead_break.h
@@ -67,6 +67,14 @@ class TransformationAddDeadBreak : public Transformation {
   bool AddingBreakRespectsStructuredControlFlow(opt::IRContext* context,
                                                 opt::BasicBlock* bb_from) const;
 
+  // Used by 'Apply' to actually apply the transformation to the module of
+  // interest, and by 'IsApplicable' to do a dry-run of the transformation on a
+  // cloned module, in order to check that the transformation leads to a valid
+  // module.  This is only invoked by 'IsApplicable' after certain basic
+  // applicability checks have been made, ensuring that the invocation of this
+  // method is legal.
+  void ApplyImpl(opt::IRContext* context) const;
+
   protobufs::TransformationAddDeadBreak message_;
 };
 

--- a/source/fuzz/transformation_add_dead_continue.cpp
+++ b/source/fuzz/transformation_add_dead_continue.cpp
@@ -106,34 +106,30 @@ bool TransformationAddDeadContinue::IsApplicable(
     return false;
   }
 
-  // Check that adding the continue would not violate the property that a
-  // definition must dominate all of its uses.
-  if (!fuzzerutil::NewEdgeRespectsUseDefDominance(
-          context, bb_from, context->cfg()->block(continue_block))) {
+  // Check whether the data passed to extend OpPhi instructions is appropriate.
+  if (!fuzzerutil::PhiIdsOkForNewEdge(context, bb_from,
+                                      context->cfg()->block(continue_block),
+                                      message_.phi_id())) {
     return false;
   }
 
-  // The transformation is good if and only if the given phi ids are sufficient
-  // to extend relevant OpPhi instructions in the continue block.
-  return fuzzerutil::PhiIdsOkForNewEdge(context, bb_from,
-                                        context->cfg()->block(continue_block),
-                                        message_.phi_id());
+  // Adding the dead break is only valid if SPIR-V rules related to dominance
+  // hold.  Rather than checking these rules explicitly, we defer to the
+  // validator.  We make a clone of the module, apply the transformation to the
+  // clone, and check whether the transformed clone is valid.
+  //
+  // In principle some of the above checks could be removed, with more reliance
+  // being places on the validator.  This should be revisited if we are sure
+  // the validator is complete with respect to checking structured control flow
+  // rules.
+  auto cloned_context = fuzzerutil::CloneIRContext(context);
+  ApplyImpl(cloned_context.get());
+  return fuzzerutil::IsValid(cloned_context.get());
 }
 
 void TransformationAddDeadContinue::Apply(opt::IRContext* context,
                                           FactManager* /*unused*/) const {
-  auto bb_from = context->cfg()->block(message_.from_block());
-  auto continue_block =
-      bb_from->IsLoopHeader()
-          ? bb_from->ContinueBlockId()
-          : context->GetStructuredCFGAnalysis()->LoopContinueBlock(
-                message_.from_block());
-  assert(continue_block &&
-         "Precondition for this transformation requires that "
-         "message_.from_block must be in a loop.");
-  fuzzerutil::AddUnreachableEdgeAndUpdateOpPhis(
-      context, bb_from, context->cfg()->block(continue_block),
-      message_.continue_condition_value(), message_.phi_id());
+  ApplyImpl(context);
   // Invalidate all analyses
   context->InvalidateAnalysesExceptFor(opt::IRContext::Analysis::kAnalysisNone);
 }
@@ -142,6 +138,20 @@ protobufs::Transformation TransformationAddDeadContinue::ToMessage() const {
   protobufs::Transformation result;
   *result.mutable_add_dead_continue() = message_;
   return result;
+}
+
+void TransformationAddDeadContinue::ApplyImpl(
+    spvtools::opt::IRContext* context) const {
+  auto bb_from = context->cfg()->block(message_.from_block());
+  auto continue_block =
+      bb_from->IsLoopHeader()
+          ? bb_from->ContinueBlockId()
+          : context->GetStructuredCFGAnalysis()->LoopContinueBlock(
+                message_.from_block());
+  assert(continue_block && "message_.from_block must be in a loop.");
+  fuzzerutil::AddUnreachableEdgeAndUpdateOpPhis(
+      context, bb_from, context->cfg()->block(continue_block),
+      message_.continue_condition_value(), message_.phi_id());
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_dead_continue.h
+++ b/source/fuzz/transformation_add_dead_continue.h
@@ -64,6 +64,14 @@ class TransformationAddDeadContinue : public Transformation {
   protobufs::Transformation ToMessage() const override;
 
  private:
+  // Used by 'Apply' to actually apply the transformation to the module of
+  // interest, and by 'IsApplicable' to do a dry-run of the transformation on a
+  // cloned module, in order to check that the transformation leads to a valid
+  // module.  This is only invoked by 'IsApplicable' after certain basic
+  // applicability checks have been made, ensuring that the invocation of this
+  // method is legal.
+  void ApplyImpl(opt::IRContext* context) const;
+
   protobufs::TransformationAddDeadContinue message_;
 };
 

--- a/test/fuzz/transformation_add_dead_continue_test.cpp
+++ b/test/fuzz/transformation_add_dead_continue_test.cpp
@@ -1514,11 +1514,8 @@ TEST(TransformationAddDeadContinueTest, Miscellaneous5) {
   ASSERT_FALSE(bad_transformation.IsApplicable(context.get(), fact_manager));
 }
 
-TEST(TransformationAddDeadContinueTest, DISABLED_Miscellaneous6) {
-  // A miscellaneous test that exposing a known bug in spirv-fuzz.
-
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/2919): re-enable
-  //  this test as an when the known issue is fixed.
+TEST(TransformationAddDeadContinueTest, Miscellaneous6) {
+  // A miscellaneous test that exposed a bug in spirv-fuzz.
 
   std::string shader = R"(
                OpCapability Shader
@@ -1536,7 +1533,7 @@ TEST(TransformationAddDeadContinueTest, DISABLED_Miscellaneous6) {
                OpBranch %10
          %10 = OpLabel
                OpLoopMerge %13 %12 None
-               OpBranchConditional %9 %13 %11
+               OpBranch %11
          %11 = OpLabel
          %20 = OpCopyObject %6 %9
                OpBranch %12


### PR DESCRIPTION
The passes that add dead breaks and continues suffer from the
challenge that a new control flow graph edge can change dominance
information, leading to the potenital for definitions to no longer
dominate their uses.  The attempt at guarding against this was known
to be incomplete.  This change calls on the SPIR-V validator to do the
necessary checking: in deciding whether adding such an edge would be
legitimate, we clone the module, add the edge, and use the validator
to check whether the transformed clone is valid.

This strategy is heavy-weight, and should be used sparingly, but seems
like a good option when the validity of transformations is intricate,
to avoid reimplementing swathes of validation logic in the fuzzer.

Fixes #2919.