### PR TITLE
Fix and add more checks for logical and variable pointers

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -306,6 +306,7 @@ set(SPIRV_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_layout.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_literals.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_logicals.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_logical_pointers.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_memory.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_memory_semantics.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/val/validate_misc.cpp

--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -283,8 +283,27 @@ bool spvOpcodeReturnsLogicalVariablePointer(const SpvOp opcode) {
     case SpvOpCopyObject:
     case SpvOpSelect:
     case SpvOpPhi:
+    case SpvOpFunction:
     case SpvOpFunctionCall:
     case SpvOpPtrAccessChain:
+    case SpvOpInBoundsPtrAccessChain:
+    case SpvOpLoad:
+    case SpvOpConstantNull:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool spvOpcodeGeneratesVariablePointer(const SpvOp opcode) {
+  // SPIR-V spec section 2.2.2 Types, definition of "Variable Pointer".
+  switch (opcode) {
+    case SpvOpSelect:
+    case SpvOpPhi:
+    case SpvOpFunction:
+    case SpvOpFunctionCall:
+    case SpvOpPtrAccessChain:
+    case SpvOpInBoundsPtrAccessChain:
     case SpvOpLoad:
     case SpvOpConstantNull:
       return true;

--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -289,6 +289,7 @@ bool spvOpcodeReturnsLogicalVariablePointer(const SpvOp opcode) {
     case SpvOpInBoundsPtrAccessChain:
     case SpvOpLoad:
     case SpvOpConstantNull:
+    case SpvOpUndef:
       return true;
     default:
       return false;
@@ -306,6 +307,7 @@ bool spvOpcodeGeneratesVariablePointer(const SpvOp opcode) {
     case SpvOpInBoundsPtrAccessChain:
     case SpvOpLoad:
     case SpvOpConstantNull:
+    case SpvOpUndef:
       return true;
     default:
       return false;

--- a/source/opcode.h
+++ b/source/opcode.h
@@ -86,6 +86,11 @@ int32_t spvOpcodeReturnsLogicalPointer(const SpvOp opcode);
 // pointer when using the logical addressing model.
 bool spvOpcodeReturnsLogicalVariablePointer(const SpvOp opcode);
 
+// Returns whether the given opcode initially creates a variable pointer
+// if the result is a logical pointer (as opposed to merely propagating
+// when an operand is already a variable pointer).
+bool spvOpcodeGeneratesVariablePointer(const SpvOp opcode);
+
 // Determines if the given opcode generates a type. Returns zero if false,
 // non-zero otherwise.
 int32_t spvOpcodeGeneratesType(SpvOp opcode);

--- a/source/val/validate.cpp
+++ b/source/val/validate.cpp
@@ -413,6 +413,7 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
     if (auto error = NonUniformPass(*vstate, &instruction)) return error;
 
     if (auto error = LiteralsPass(*vstate, &instruction)) return error;
+    if (auto error = LogicalPointersPass(*vstate, &instruction)) return error;
   }
 
   // Validate the preconditions involving adjacent instructions. e.g. SpvOpPhi

--- a/source/val/validate.h
+++ b/source/val/validate.h
@@ -197,6 +197,9 @@ spv_result_t FunctionPass(ValidationState_t& _, const Instruction* inst);
 /// Validates correctness of miscellaneous instructions.
 spv_result_t MiscPass(ValidationState_t& _, const Instruction* inst);
 
+/// Validates correctness of instructions that generate logical pointers.
+spv_result_t LogicalPointersPass(ValidationState_t& _, const Instruction* inst);
+
 /// Validates execution limitations.
 ///
 /// Verifies execution models are allowed for all functionality they contain.

--- a/source/val/validate_cfg.cpp
+++ b/source/val/validate_cfg.cpp
@@ -48,19 +48,7 @@ spv_result_t ValidatePhi(ValidationState_t& _, const Instruction* inst) {
               "basic blocks.";
   }
 
-  const Instruction* type_inst = _.FindDef(inst->type_id());
-  assert(type_inst);
-
-  const SpvOp type_opcode = type_inst->opcode();
-  if (type_opcode == SpvOpTypePointer &&
-      _.addressing_model() == SpvAddressingModelLogical) {
-    if (!_.features().variable_pointers &&
-        !_.features().variable_pointers_storage_buffer) {
-      return _.diag(SPV_ERROR_INVALID_DATA, inst)
-             << "Using pointers with OpPhi requires capability "
-             << "VariablePointers or VariablePointersStorageBuffer";
-    }
-  }
+  assert(_.FindDef(inst->type_id()));
 
   // Create a uniqued vector of predecessor ids for comparison against
   // incoming values. OpBranchConditional %cond %label %label produces two

--- a/source/val/validate_logical_pointers.cpp
+++ b/source/val/validate_logical_pointers.cpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2019 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/opcode.h"
+#include "source/val/instruction.h"
+#include "source/val/validate.h"
+#include "source/val/validation_state.h"
+
+namespace spvtools {
+namespace val {
+
+spv_result_t LogicalPointersPass(ValidationState_t& _,
+                                 const Instruction* inst) {
+  if (_.options()->relax_logical_pointer) return SPV_SUCCESS;
+
+  // Success if the instruction does not produce a pointer.
+  if (!inst->type_id()) return SPV_SUCCESS;
+
+  auto result_type = _.FindDef(inst->type_id());
+  if (!result_type) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst) << "Missing result type";
+  }
+  if (result_type->opcode() != SpvOpTypePointer) return SPV_SUCCESS;
+
+  const auto storage_class = result_type->GetOperandAs<uint32_t>(1);
+
+  // Success if the instruction does not produce a logical pointer.
+  if (_.addressing_model() == SpvAddressingModelPhysicalStorageBuffer64) {
+    if (storage_class == SpvStorageClassPhysicalStorageBuffer)
+      return SPV_SUCCESS;
+  } else if (_.addressing_model() != SpvAddressingModelLogical) {
+    return SPV_SUCCESS;
+  }
+
+  if (!spvOpcodeReturnsLogicalVariablePointer(inst->opcode())) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+           << "Logical pointers must not be produced by this opcode";
+  }
+
+  if (spvOpcodeGeneratesVariablePointer(inst->opcode())) {
+    // Check capabilities and storage class.
+    if (!_.features().variable_pointers &&
+        !_.features().variable_pointers_storage_buffer) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "Generating variable pointers requires capability "
+             << "VariablePointers or VariablePointersStorageBuffer";
+    }
+
+    if (storage_class != SpvStorageClassWorkgroup &&
+        storage_class != SpvStorageClassStorageBuffer) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "Variable pointers must point to Workgroup or StorageBuffer "
+                "storage classes";
+    }
+
+    if (storage_class == SpvStorageClassWorkgroup &&
+        !_.features().variable_pointers) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "Variable pointers to Workgroup storage class require "
+                "capability VariablePointers";
+    }
+  }
+
+  return SPV_SUCCESS;
+}
+
+}  // namespace val
+}  // namespace spvtools

--- a/source/val/validate_logicals.cpp
+++ b/source/val/validate_logicals.cpp
@@ -161,21 +161,12 @@ spv_result_t LogicalsPass(ValidationState_t& _, const Instruction* inst) {
 
         const SpvOp type_opcode = type_inst->opcode();
         switch (type_opcode) {
-          case SpvOpTypePointer: {
-            if (_.addressing_model() == SpvAddressingModelLogical &&
-                !_.features().variable_pointers &&
-                !_.features().variable_pointers_storage_buffer)
-              return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                     << "Using pointers with OpSelect requires capability "
-                     << "VariablePointers or VariablePointersStorageBuffer";
-            break;
-          }
-
           case SpvOpTypeVector: {
             dimension = type_inst->word(3);
             break;
           }
 
+          case SpvOpTypePointer:
           case SpvOpTypeBool:
           case SpvOpTypeInt:
           case SpvOpTypeFloat: {

--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -1356,14 +1356,6 @@ spv_result_t ValidateAccessChain(ValidationState_t& _,
 
 spv_result_t ValidatePtrAccessChain(ValidationState_t& _,
                                     const Instruction* inst) {
-  if (_.addressing_model() == SpvAddressingModelLogical) {
-    if (!_.features().variable_pointers &&
-        !_.features().variable_pointers_storage_buffer) {
-      return _.diag(SPV_ERROR_INVALID_DATA, inst)
-             << "Generating variable pointers requires capability "
-             << "VariablePointers or VariablePointersStorageBuffer";
-    }
-  }
   return ValidateAccessChain(_, inst);
 }
 

--- a/test/opt/ccp_test.cpp
+++ b/test/opt/ccp_test.cpp
@@ -893,6 +893,7 @@ OpReturn
 OpFunctionEnd
 )";
 
+  ValidatorOptions()->relax_logical_pointer = true;
   SinglePassRunAndMatch<CCPPass>(text, true);
 }
 

--- a/test/opt/eliminate_dead_member_test.cpp
+++ b/test/opt/eliminate_dead_member_test.cpp
@@ -898,9 +898,9 @@ TEST_F(EliminateDeadMemberTest, RemoveMemberPtrAccessChain) {
 ; CHECK: OpMemberDecorate %type__Globals 0 Offset 0
 ; CHECK: OpMemberDecorate %type__Globals 1 Offset 16
 ; CHECK: %type__Globals = OpTypeStruct %float %float
-; CHECK: [[ac:%\w+]] = OpAccessChain %_ptr_Uniform_type__Globals %_Globals %uint_0
-; CHECK: OpPtrAccessChain %_ptr_Uniform_float [[ac]] %uint_1 %uint_0
-; CHECK: OpPtrAccessChain %_ptr_Uniform_float [[ac]] %uint_0 %uint_1
+; CHECK: [[ac:%\w+]] = OpAccessChain %_ptr_StorageBuffer_type__Globals %_Globals %uint_0
+; CHECK: OpPtrAccessChain %_ptr_StorageBuffer_float [[ac]] %uint_1 %uint_0
+; CHECK: OpPtrAccessChain %_ptr_StorageBuffer_float [[ac]] %uint_0 %uint_1
                OpCapability Shader
                OpCapability VariablePointersStorageBuffer
                OpMemoryModel Logical GLSL450
@@ -926,17 +926,17 @@ TEST_F(EliminateDeadMemberTest, RemoveMemberPtrAccessChain) {
       %float = OpTypeFloat 32
 %type__Globals = OpTypeStruct %float %float %float
 %_arr_type__Globals_uint_3 = OpTypeArray %type__Globals %uint_3
-%_ptr_Uniform_type__Globals = OpTypePointer Uniform %type__Globals
-%_ptr_Uniform__arr_type__Globals_uint_3 = OpTypePointer Uniform %_arr_type__Globals_uint_3
+%_ptr_StorageBuffer_type__Globals = OpTypePointer StorageBuffer %type__Globals
+%_ptr_StorageBuffer__arr_type__Globals_uint_3 = OpTypePointer StorageBuffer %_arr_type__Globals_uint_3
        %void = OpTypeVoid
          %14 = OpTypeFunction %void
-%_ptr_Uniform_float = OpTypePointer Uniform %float
-   %_Globals = OpVariable %_ptr_Uniform__arr_type__Globals_uint_3 Uniform
+%_ptr_StorageBuffer_float = OpTypePointer StorageBuffer %float
+   %_Globals = OpVariable %_ptr_StorageBuffer__arr_type__Globals_uint_3 StorageBuffer
        %main = OpFunction %void None %14
          %16 = OpLabel
-         %17 = OpAccessChain %_ptr_Uniform_type__Globals %_Globals %uint_0
-         %18 = OpPtrAccessChain %_ptr_Uniform_float %17 %uint_1 %uint_0
-         %19 = OpPtrAccessChain %_ptr_Uniform_float %17 %uint_0 %uint_2
+         %17 = OpAccessChain %_ptr_StorageBuffer_type__Globals %_Globals %uint_0
+         %18 = OpPtrAccessChain %_ptr_StorageBuffer_float %17 %uint_1 %uint_0
+         %19 = OpPtrAccessChain %_ptr_StorageBuffer_float %17 %uint_0 %uint_2
                OpReturn
                OpFunctionEnd
 )";
@@ -957,11 +957,12 @@ TEST_F(EliminateDeadMemberTest, RemoveMemberInBoundsPtrAccessChain) {
 ; CHECK: OpMemberDecorate %type__Globals 0 Offset 0
 ; CHECK: OpMemberDecorate %type__Globals 1 Offset 16
 ; CHECK: %type__Globals = OpTypeStruct %float %float
-; CHECK: [[ac:%\w+]] = OpAccessChain %_ptr_Uniform_type__Globals %_Globals %uint_0
-; CHECK: OpInBoundsPtrAccessChain %_ptr_Uniform_float [[ac]] %uint_1 %uint_0
-; CHECK: OpInBoundsPtrAccessChain %_ptr_Uniform_float [[ac]] %uint_0 %uint_1
+; CHECK: [[ac:%\w+]] = OpAccessChain %_ptr_StorageBuffer_type__Globals %_Globals %uint_0
+; CHECK: OpInBoundsPtrAccessChain %_ptr_StorageBuffer_float [[ac]] %uint_1 %uint_0
+; CHECK: OpInBoundsPtrAccessChain %_ptr_StorageBuffer_float [[ac]] %uint_0 %uint_1
                OpCapability Shader
                OpCapability Addresses
+               OpCapability VariablePointers
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main"
                OpSource HLSL 600
@@ -985,17 +986,17 @@ TEST_F(EliminateDeadMemberTest, RemoveMemberInBoundsPtrAccessChain) {
       %float = OpTypeFloat 32
 %type__Globals = OpTypeStruct %float %float %float
 %_arr_type__Globals_uint_3 = OpTypeArray %type__Globals %uint_3
-%_ptr_Uniform_type__Globals = OpTypePointer Uniform %type__Globals
-%_ptr_Uniform__arr_type__Globals_uint_3 = OpTypePointer Uniform %_arr_type__Globals_uint_3
+%_ptr_StorageBuffer_type__Globals = OpTypePointer StorageBuffer %type__Globals
+%_ptr_StorageBuffer_arr_type__Globals_uint_3 = OpTypePointer StorageBuffer %_arr_type__Globals_uint_3
        %void = OpTypeVoid
          %14 = OpTypeFunction %void
-%_ptr_Uniform_float = OpTypePointer Uniform %float
-   %_Globals = OpVariable %_ptr_Uniform__arr_type__Globals_uint_3 Uniform
+%_ptr_StorageBuffer_float = OpTypePointer StorageBuffer %float
+   %_Globals = OpVariable %_ptr_StorageBuffer_arr_type__Globals_uint_3 StorageBuffer
        %main = OpFunction %void None %14
          %16 = OpLabel
-         %17 = OpAccessChain %_ptr_Uniform_type__Globals %_Globals %uint_0
-         %18 = OpInBoundsPtrAccessChain %_ptr_Uniform_float %17 %uint_1 %uint_0
-         %19 = OpInBoundsPtrAccessChain %_ptr_Uniform_float %17 %uint_0 %uint_2
+         %17 = OpAccessChain %_ptr_StorageBuffer_type__Globals %_Globals %uint_0
+         %18 = OpInBoundsPtrAccessChain %_ptr_StorageBuffer_float %17 %uint_1 %uint_0
+         %19 = OpInBoundsPtrAccessChain %_ptr_StorageBuffer_float %17 %uint_0 %uint_2
                OpReturn
                OpFunctionEnd
 )";

--- a/test/val/val_ext_inst_test.cpp
+++ b/test/val/val_ext_inst_test.cpp
@@ -6828,10 +6828,11 @@ TEST_F(ValidateExtInst, VStoreNAddressingModelLogical) {
   ss << "%val1 = OpExtInst %void %extinst vstoren %f32vec2_01 %u32_1 %ptr_g\n";
 
   CompileSuccessfully(GenerateKernelCode(ss.str(), "", "Logical"));
+  // The first validation error is from the OpPtrCastToGeneric
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpenCL.std vstoren can only be used with physical "
-                        "addressing models"));
+              HasSubstr("Logical pointers must not be produced by this "
+                        "opcode"));
 }
 
 TEST_F(ValidateExtInst, VStoreNOffsetNotSizeT) {

--- a/utils/check_copyright.py
+++ b/utils/check_copyright.py
@@ -31,7 +31,8 @@ AUTHORS = ['The Khronos Group Inc.',
            'Google Inc.',
            'Google LLC',
            'Pierre Moreau',
-           'Samsung Inc']
+           'Samsung Inc',
+           'Advanced Micro Devices, Inc.']
 CURRENT_YEAR='2020'
 
 YEARS = '(2014-2016|2015-2016|2016|2016-2017|2017|2017-2019|2018|2019|2020)'


### PR DESCRIPTION
Factor out the check of some generic validation rules about generating
logical and variable pointers to ensure that:

1. Variable pointers rules are checked also in the PhysicalStorageBuffer64
   addressing model.

2. The storage class of variable pointers is checked as per the spec.

3. Only the explicitly white-listed instructions can generate logical
   pointers.

This change assumes that OpInBoundsPtrAccessChain should be treated
the same as OpPtrAccessChain for the purpose of these validation
rules.

Fixes issue #2108.
See also: https://github.com/KhronosGroup/SPIRV-Tools/milestone/7
See also: Khronos SPIR-V issues #526 and #528