### PR TITLE
spirv-fuzz: Always add new globals to entry point interfaces

### DIFF
--- a/source/fuzz/transformation_add_global_variable.cpp
+++ b/source/fuzz/transformation_add_global_variable.cpp
@@ -89,8 +89,8 @@ void TransformationAddGlobalVariable::Apply(
     // the module.  This means that the global is available for other
     // transformations to use.
     //
-    // A downside of this is that the global will be in
-    // the interface even if it ends up never being used.
+    // A downside of this is that the global will be in the interface even if it
+    // ends up never being used.
     //
     // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3111) revisit
     //  this if a more thorough approach to entry point interfaces is taken.

--- a/source/fuzz/transformation_add_global_variable.h
+++ b/source/fuzz/transformation_add_global_variable.h
@@ -48,6 +48,9 @@ class TransformationAddGlobalVariable : public Transformation {
   protobufs::Transformation ToMessage() const override;
 
  private:
+  static bool PrivateGlobalsMustBeDeclaredInEntryPointInterfaces(
+      opt::IRContext* context);
+
   protobufs::TransformationAddGlobalVariable message_;
 };
 


### PR DESCRIPTION
In the context of SPIR-V 1.4 or higher, global variables cannot be
used by an instruction unless they are listed in the interface of all
entry points that might invoke the instruction.  This change
conservatively adds new global variables to the interfaces of all
entry points (if the SPIR-V version is 1.4 or higher).

Issue #3111 notes that a more rigorous approach to entry point
interfaces could be taken in spirv-fuzz, which would allow being less
conservative here.