### PR TITLE
Avoid pessimizing std::move

### DIFF
--- a/test/opt/pass_fixture.h
+++ b/test/opt/pass_fixture.h
@@ -60,8 +60,7 @@ class PassTest : public TestT {
   // from pass Process() function.
   std::tuple<std::vector<uint32_t>, Pass::Status> OptimizeToBinary(
       Pass* pass, const std::string& original, bool skip_nop) {
-    context_ =
-        std::move(BuildModule(env_, consumer_, original, assemble_options_));
+    context_ = BuildModule(env_, consumer_, original, assemble_options_);
     EXPECT_NE(nullptr, context()) << "Assembling failed for shader:\n"
                                   << original << std::endl;
     if (!context()) {
@@ -197,8 +196,7 @@ class PassTest : public TestT {
   // messages.
   template <typename PassT, typename... Args>
   void SinglePassRunAndFail(const std::string& original, Args&&... args) {
-    context_ =
-        std::move(BuildModule(env_, consumer_, original, assemble_options_));
+    context_ = BuildModule(env_, consumer_, original, assemble_options_);
     EXPECT_NE(nullptr, context()) << "Assembling failed for shader:\n"
                                   << original << std::endl;
     std::ostringstream errs;
@@ -235,8 +233,7 @@ class PassTest : public TestT {
   void RunAndCheck(const std::string& original, const std::string& expected) {
     assert(manager_->NumPasses());
 
-    context_ =
-        std::move(BuildModule(env_, nullptr, original, assemble_options_));
+    context_ = BuildModule(env_, nullptr, original, assemble_options_);
     ASSERT_NE(nullptr, context());
 
     context()->set_preserve_bindings(OptimizerOptions()->preserve_bindings_);


### PR DESCRIPTION
Should fix a warning