### PR TITLE
Fix OpLine bug of merge-blocks pass

### DIFF
--- a/source/opt/block_merge_util.cpp
+++ b/source/opt/block_merge_util.cpp
@@ -175,7 +175,9 @@ void MergeWithSuccessor(IRContext* context, Function* func,
       // the validation error that OpLine is placed between OpLoopMerge
       // and OpBranchConditional.
       auto terminator = bi->terminator();
-      merge_inst->dbg_line_insts() = terminator->dbg_line_insts();
+      auto& vec = terminator->dbg_line_insts();
+      auto& new_vec = merge_inst->dbg_line_insts();
+      new_vec.insert(new_vec.end(), vec.begin(), vec.end());
       terminator->clear_dbg_line_insts();
 
       // Move the merge instruction to just before the terminator.

--- a/source/opt/block_merge_util.cpp
+++ b/source/opt/block_merge_util.cpp
@@ -171,8 +171,15 @@ void MergeWithSuccessor(IRContext* context, Function* func,
       // flow declaration.
       context->KillInst(merge_inst);
     } else {
+      // Move OpLine/OpNoLine information to merge_inst. This solves
+      // the validation error that OpLine is placed between OpLoopMerge
+      // and OpBranchConditional.
+      auto terminator = bi->terminator();
+      merge_inst->dbg_line_insts() = terminator->dbg_line_insts();
+      terminator->clear_dbg_line_insts();
+
       // Move the merge instruction to just before the terminator.
-      merge_inst->InsertBefore(bi->terminator());
+      merge_inst->InsertBefore(terminator);
     }
   }
   context->ReplaceAllUsesWith(lab_id, bi->id());

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -172,6 +172,9 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
     return dbg_line_insts_;
   }
 
+  // Clear line-related debug instructions attached to this instruction.
+  void clear_dbg_line_insts() { dbg_line_insts_.clear(); }
+
   // Same semantics as in the base class except the list the InstructionList
   // containing |pos| will now assume ownership of |this|.
   // inline void MoveBefore(Instruction* pos);


### PR DESCRIPTION
As explained in #3118, spirv-opt merge-blocks pass causes a
spirv-val error when an OpBranch has an OpLine in front of it.

OpLoopMerge
OpBranch ; Will be killed by merge-blocks pass
OpLabel  ; Will be killed by merge-blocks pass
OpLine   ; will be placed between OpLoopMerge and OpBranch - error!
OpBranch

To fix this issue, this commit moves line info of OpBranch to
OpLoopMerge.

Fixes #3118