### PR TITLE
Add validation rules for OpenCL.DebugInfo.100 extension

### DIFF
--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -2184,7 +2184,7 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
       case OpenCLDebugInfo100DebugOperation:
         // The binary parser validates the opcode for DebugInfoNone,
         // DebugNoScope, DebugOperation, and the literal values don't need
-        // furhter checks.
+        // further checks.
         break;
       case OpenCLDebugInfo100DebugCompilationUnit: {
         CHECK_DEBUG_OPERAND("Source", OpenCLDebugInfo100DebugSource, 7);

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 
+#include "OpenCLDebugInfo100.h"
 #include "source/diagnostic.h"
 #include "source/enum_string_mapping.h"
 #include "source/extensions.h"

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -2227,6 +2227,13 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
           auto validate_count = ValidateOperandForDebugInfo(
               _, "Component Count", SpvOpConstant, inst, i, ext_inst_name);
           if (validate_count != SPV_SUCCESS) return validate_count;
+          auto* component_count = _.FindDef(inst->word(i));
+          if (!_.IsIntScalarType(component_count->type_id()) ||
+              !component_count->word(3)) {
+            return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                   << ext_inst_name() << ": Component Count must be positive "
+                   << "integer";
+          }
         }
         break;
       }
@@ -2283,6 +2290,12 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
         auto validate_size = ValidateOperandForDebugInfo(
             _, "Size", SpvOpConstant, inst, 11, ext_inst_name);
         if (validate_size != SPV_SUCCESS) return validate_size;
+        auto* size = _.FindDef(inst->word(11));
+        if (!_.IsIntScalarType(size->type_id()) || !size->word(3)) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << ext_inst_name() << ": expected operand Size is a "
+                 << "positive integer";
+        }
         for (uint32_t word_index = 13; word_index < num_words;
              word_index += 2) {
           auto validate_value = ValidateOperandForDebugInfo(

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -81,6 +81,9 @@ bool DoesDebugInfoOperandMatchExpectation(
   return true;
 }
 
+// Check that the operand of a debug info instruction |inst| at |word_index|
+// is a result id of an debug info instruction whose debug instruction type
+// is |expected_debug_inst|.
 spv_result_t ValidateDebugInfoOperand(
     ValidationState_t& _, const std::string& debug_inst_name,
     OpenCLDebugInfo100Instructions expected_debug_inst, const Instruction* inst,
@@ -108,6 +111,8 @@ spv_result_t ValidateDebugInfoOperand(
          << desc->name;
 }
 
+// Check that the operand of a debug info instruction |inst| at |word_index|
+// is a result id of an debug info instruction with DebugTypeBasic.
 spv_result_t ValidateOperandBaseType(
     ValidationState_t& _, const Instruction* inst, uint32_t word_index,
     const std::function<std::string()>& ext_inst_name) {
@@ -116,6 +121,10 @@ spv_result_t ValidateOperandBaseType(
                                   word_index, ext_inst_name);
 }
 
+// Check that the operand of a debug info instruction |inst| at |word_index|
+// is a result id of a debug lexical scope instruction which is one of
+// DebugCompilationUnit, DebugFunction, DebugLexicalBlock, or
+// DebugTypeComposite.
 spv_result_t ValidateOperandLexicalScope(
     ValidationState_t& _, const std::string& debug_inst_name,
     const Instruction* inst, uint32_t word_index,
@@ -136,6 +145,9 @@ spv_result_t ValidateOperandLexicalScope(
          << " must be a result id of a lexical scope";
 }
 
+// Check that the operand of a debug info instruction |inst| at |word_index|
+// is a result id of a debug type instruction (See DebugTypeXXX in
+// "4.3. Type instructions" section of OpenCL.DebugInfo.100 spec.
 spv_result_t ValidateOperandDebugType(
     ValidationState_t& _, const std::string& debug_inst_name,
     const Instruction* inst, uint32_t word_index,

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -2155,9 +2155,11 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
         auto validate_file = ValidateOperandForDebugInfo(
             _, "File", SpvOpString, inst, 5, ext_inst_name);
         if (validate_file != SPV_SUCCESS) return validate_file;
-        auto validate_text = ValidateOperandForDebugInfo(
-            _, "Text", SpvOpString, inst, 6, ext_inst_name);
-        if (validate_text != SPV_SUCCESS) return validate_text;
+        if (num_operands == 6) {
+          auto validate_text = ValidateOperandForDebugInfo(
+              _, "Text", SpvOpString, inst, 6, ext_inst_name);
+          if (validate_text != SPV_SUCCESS) return validate_text;
+        }
         break;
       }
       case OpenCLDebugInfo100DebugTypeBasic: {

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -2223,7 +2223,7 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
       }
       case OpenCLDebugInfo100DebugTypeArray: {
         auto validate_base_type =
-            ValidateOperandBaseType(_, inst, 5, ext_inst_name);
+            ValidateOperandDebugType(_, "Base Type", inst, 5, ext_inst_name);
         if (validate_base_type != SPV_SUCCESS) return validate_base_type;
         for (uint32_t i = 6; i < num_words; ++i) {
           CHECK_OPERAND("Component Count", SpvOpConstant, i);

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -2367,7 +2367,19 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
             ValidateOperandLexicalScope(_, "Parent", inst, 10, ext_inst_name);
         if (validate_parent != SPV_SUCCESS) return validate_parent;
         CHECK_OPERAND("Linkage Name", SpvOpString, 11);
-        CHECK_OPERAND("Function", SpvOpFunction, 14);
+        // TODO: The current OpenCL.100.DebugInfo spec says "Function
+        // is an OpFunction which is described by this instruction.".
+        // However, the function definition can be opted-out e.g.,
+        // inlining. We assume that Function operand can be a
+        // DebugInfoNone, but we must discuss it and update the spec.
+        if (!DoesDebugInfoOperandMatchExpectation(
+                _,
+                [](OpenCLDebugInfo100Instructions dbg_inst) {
+                  return dbg_inst == OpenCLDebugInfo100DebugInfoNone;
+                },
+                inst, 14)) {
+          CHECK_OPERAND("Function", SpvOpFunction, 14);
+        }
         if (num_words == 16) {
           CHECK_DEBUG_OPERAND("Declaration",
                               OpenCLDebugInfo100DebugFunctionDeclaration, 15);

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -2355,7 +2355,6 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
         if (validate_size != SPV_SUCCESS) return validate_size;
         break;
       }
-
       case OpenCLDebugInfo100DebugFunction: {
         auto validate_name = ValidateOperandForDebugInfo(
             _, "Name", SpvOpString, inst, 5, ext_inst_name);
@@ -2381,6 +2380,24 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
               inst, 15, ext_inst_name);
           if (validate_decl != SPV_SUCCESS) return validate_decl;
         }
+        break;
+      }
+      case OpenCLDebugInfo100DebugFunctionDeclaration: {
+        auto validate_name = ValidateOperandForDebugInfo(
+            _, "Name", SpvOpString, inst, 5, ext_inst_name);
+        if (validate_name != SPV_SUCCESS) return validate_name;
+        auto validate_type =
+            ValidateOperandDebugType(_, "Type", inst, 6, ext_inst_name);
+        if (validate_type != SPV_SUCCESS) return validate_type;
+        auto validate_src = ValidateDebugInfoOperand(
+            _, "Source", OpenCLDebugInfo100DebugSource, inst, 7, ext_inst_name);
+        if (validate_src != SPV_SUCCESS) return validate_src;
+        auto validate_parent =
+            ValidateOperandLexicalScope(_, "Parent", inst, 10, ext_inst_name);
+        if (validate_parent != SPV_SUCCESS) return validate_parent;
+        auto validate_linkage_name = ValidateOperandForDebugInfo(
+            _, "Linkage Name", SpvOpString, inst, 11, ext_inst_name);
+        if (validate_linkage_name != SPV_SUCCESS) return validate_linkage_name;
         break;
       }
       case OpenCLDebugInfo100DebugLexicalBlock: {
@@ -2459,7 +2476,6 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
       case OpenCLDebugInfo100DebugTypeTemplateTemplateParameter:
       case OpenCLDebugInfo100DebugTypeTemplateParameterPack:
       case OpenCLDebugInfo100DebugGlobalVariable:
-      case OpenCLDebugInfo100DebugFunctionDeclaration:
       case OpenCLDebugInfo100DebugLexicalBlockDiscriminator:
       case OpenCLDebugInfo100DebugInlinedAt:
       case OpenCLDebugInfo100DebugInlinedVariable:

--- a/source/val/validate_id.cpp
+++ b/source/val/validate_id.cpp
@@ -171,8 +171,8 @@ spv_result_t IdPass(ValidationState_t& _, Instruction* inst) {
           const auto opcode = inst->opcode();
           if (spvOpcodeGeneratesType(def->opcode()) &&
               !spvOpcodeGeneratesType(opcode) && !spvOpcodeIsDebug(opcode) &&
-              !inst->IsNonSemantic() && !spvOpcodeIsDecoration(opcode) &&
-              opcode != SpvOpFunction &&
+              !inst->IsDebugInfo() && !inst->IsNonSemantic() &&
+              !spvOpcodeIsDecoration(opcode) && opcode != SpvOpFunction &&
               opcode != SpvOpCooperativeMatrixLengthNV &&
               !(opcode == SpvOpSpecConstantOp &&
                 inst->word(3) == SpvOpCooperativeMatrixLengthNV)) {
@@ -180,8 +180,8 @@ spv_result_t IdPass(ValidationState_t& _, Instruction* inst) {
                    << "Operand " << _.getIdName(operand_word)
                    << " cannot be a type";
           } else if (def->type_id() == 0 && !spvOpcodeGeneratesType(opcode) &&
-                     !spvOpcodeIsDebug(opcode) && !inst->IsNonSemantic() &&
-                     !spvOpcodeIsDecoration(opcode) &&
+                     !spvOpcodeIsDebug(opcode) && !inst->IsDebugInfo() &&
+                     !inst->IsNonSemantic() && !spvOpcodeIsDecoration(opcode) &&
                      !spvOpcodeIsBranch(opcode) && opcode != SpvOpPhi &&
                      opcode != SpvOpExtInst && opcode != SpvOpExtInstImport &&
                      opcode != SpvOpSelectionMerge &&

--- a/test/val/val_ext_inst_test.cpp
+++ b/test/val/val_ext_inst_test.cpp
@@ -1313,8 +1313,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeArrayFailBaseType) {
       src, size_const, dbg_inst_header, "", extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("expected operand Base Type must be a result id of "
-                        "DebugTypeBasic"));
+              HasSubstr("expected operand Base Type is not a valid debug "
+                        "type"));
 }
 
 TEST_F(ValidateOpenCL100DebugInfo, DebugTypeArrayFailComponentCount) {

--- a/test/val/val_ext_inst_test.cpp
+++ b/test/val/val_ext_inst_test.cpp
@@ -1404,6 +1404,66 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeVectorFail) {
                         "DebugTypeBasic"));
 }
 
+TEST_F(ValidateOpenCL100DebugInfo, DebugTypeVectorFailComponentZero) {
+  const std::string src = R"(
+%src = OpString "simple.hlsl"
+%code = OpString "main() {}"
+%float_name = OpString "float"
+)";
+
+  const std::string size_const = R"(
+%int_32 = OpConstant %u32 32
+)";
+
+  const std::string dbg_inst_header = R"(
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %int_32 Float
+%vfloat_info = OpExtInst %void %DbgExt DebugTypeVector %dbg_src 0
+)";
+
+  const std::string extension = R"(
+%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
+)";
+
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("expected operand Base Type must be a result id of "
+                        "DebugTypeBasic"));
+}
+
+TEST_F(ValidateOpenCL100DebugInfo, DebugTypeVectorFailComponentFive) {
+  const std::string src = R"(
+%src = OpString "simple.hlsl"
+%code = OpString "main() {}"
+%float_name = OpString "float"
+)";
+
+  const std::string size_const = R"(
+%int_32 = OpConstant %u32 32
+)";
+
+  const std::string dbg_inst_header = R"(
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %int_32 Float
+%vfloat_info = OpExtInst %void %DbgExt DebugTypeVector %dbg_src 5
+)";
+
+  const std::string extension = R"(
+%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
+)";
+
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("expected operand Base Type must be a result id of "
+                        "DebugTypeBasic"));
+}
+
 TEST_F(ValidateOpenCL100DebugInfo, DebugTypedef) {
   const std::string src = R"(
 %src = OpString "simple.hlsl"

--- a/test/val/val_ext_inst_test.cpp
+++ b/test/val/val_ext_inst_test.cpp
@@ -2280,6 +2280,69 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugDeclare) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
+TEST_F(ValidateOpenCL100DebugInfo, DebugDeclareParam) {
+  CompileSuccessfully(R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "OpenCL.DebugInfo.100"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main" %in_var_COLOR
+          %4 = OpString "test.hlsl"
+               OpSource HLSL 620 %4 "#line 1 \"test.hlsl\"
+void main(float foo:COLOR) {}
+"
+         %11 = OpString "#line 1 \"test.hlsl\"
+void main(float foo:COLOR) {}
+"
+         %14 = OpString "float"
+         %17 = OpString "src.main"
+         %20 = OpString "foo"
+               OpName %in_var_COLOR "in.var.COLOR"
+               OpName %main "main"
+               OpName %param_var_foo "param.var.foo"
+               OpName %src_main "src.main"
+               OpName %foo "foo"
+               OpName %bb_entry "bb.entry"
+               OpDecorate %in_var_COLOR Location 0
+       %uint = OpTypeInt 32 0
+    %uint_32 = OpConstant %uint 32
+      %float = OpTypeFloat 32
+%_ptr_Input_float = OpTypePointer Input %float
+       %void = OpTypeVoid
+         %23 = OpTypeFunction %void
+%_ptr_Function_float = OpTypePointer Function %float
+         %29 = OpTypeFunction %void %_ptr_Function_float
+               OpLine %4 1 21
+%in_var_COLOR = OpVariable %_ptr_Input_float Input
+         %10 = OpExtInst %void %1 DebugExpression
+         %12 = OpExtInst %void %1 DebugSource %4 %11
+         %13 = OpExtInst %void %1 DebugCompilationUnit 1 4 %12 HLSL
+         %15 = OpExtInst %void %1 DebugTypeBasic %14 %uint_32 Float
+         %16 = OpExtInst %void %1 DebugTypeFunction FlagIsProtected|FlagIsPrivate %void %15
+         %18 = OpExtInst %void %1 DebugFunction %17 %16 %12 1 1 %13 %17 FlagIsProtected|FlagIsPrivate 1 %src_main
+         %21 = OpExtInst %void %1 DebugLocalVariable %20 %15 %12 1 17 %18 FlagIsLocal 0
+         %22 = OpExtInst %void %1 DebugLexicalBlock %12 1 28 %18
+               OpLine %4 1 1
+       %main = OpFunction %void None %23
+         %24 = OpLabel
+               OpLine %4 1 17
+%param_var_foo = OpVariable %_ptr_Function_float Function
+         %27 = OpLoad %float %in_var_COLOR
+               OpLine %4 1 1
+         %28 = OpFunctionCall %void %src_main %param_var_foo
+               OpReturn
+               OpFunctionEnd
+   %src_main = OpFunction %void None %29
+               OpLine %4 1 17
+        %foo = OpFunctionParameter %_ptr_Function_float
+         %31 = OpExtInst %void %1 DebugDeclare %21 %foo %10
+   %bb_entry = OpLabel
+               OpLine %4 1 29
+               OpReturn
+               OpFunctionEnd
+)");
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
 TEST_P(ValidateOpenCL100DebugInfoDebugDeclare, Fail) {
   const std::string src = R"(
 %src = OpString "simple.hlsl"

--- a/test/val/val_ext_inst_test.cpp
+++ b/test/val/val_ext_inst_test.cpp
@@ -1046,6 +1046,24 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugSourceFailSource) {
                         "OpString"));
 }
 
+TEST_F(ValidateOpenCL100DebugInfo, DebugSourceNoText) {
+  const std::string src = R"(
+%src = OpString "simple.hlsl"
+)";
+
+  const std::string dbg_inst = R"(
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src
+)";
+
+  const std::string extension = R"(
+%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
+)";
+
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst, "",
+                                                     extension, "Vertex"));
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
 TEST_F(ValidateOpenCL100DebugInfo, DebugTypeBasicFailName) {
   const std::string src = R"(
 %src = OpString "simple.hlsl"


### PR DESCRIPTION
Add validation rules for DebugCompilationUnit, DebugSource,
DebugTypeBasic, DebugTypeVector, DebugTypeArray, DebugTypedef,
DebugTypeFunction, DebugTypeEnum, DebugTypeComposite,
DebugTypeMember, DebugTypeInheritance, DebugFunction,
DebugFunctionDeclaration, DebugLexicalBlock, DebugScope,
DebugLocalVariable, DebugDeclare, DebugExpression.