### PR TITLE
spirv-fuzz: add dead blocks

### DIFF
--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -36,6 +36,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer.h
         fuzzer_context.h
         fuzzer_pass.h
+        fuzzer_pass_add_dead_blocks.h
         fuzzer_pass_add_dead_breaks.h
         fuzzer_pass_add_dead_continues.h
         fuzzer_pass_add_no_contraction_decorations.h
@@ -66,6 +67,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_add_constant_boolean.h
         transformation_add_constant_composite.h
         transformation_add_constant_scalar.h
+        transformation_add_dead_block.h
         transformation_add_dead_break.h
         transformation_add_dead_continue.h
         transformation_add_function.h
@@ -105,6 +107,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer.cpp
         fuzzer_context.cpp
         fuzzer_pass.cpp
+        fuzzer_pass_add_dead_blocks.cpp
         fuzzer_pass_add_dead_breaks.cpp
         fuzzer_pass_add_dead_continues.cpp
         fuzzer_pass_add_no_contraction_decorations.cpp
@@ -134,6 +137,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_add_constant_boolean.cpp
         transformation_add_constant_composite.cpp
         transformation_add_constant_scalar.cpp
+        transformation_add_dead_block.cpp
         transformation_add_dead_break.cpp
         transformation_add_dead_continue.cpp
         transformation_add_function.cpp

--- a/source/fuzz/fact_manager.cpp
+++ b/source/fuzz/fact_manager.cpp
@@ -803,34 +803,36 @@ bool FactManager::DataSynonymFacts::IsSynonymous(
 //==============================
 // Dead id facts
 
-// TODO comment.
-class FactManager::DeadIdFacts {
+// The purpose of this class is to group the fields and data used to represent
+// facts about data blocks.
+class FactManager::DeadBlockFacts {
  public:
   // See method in FactManager which delegates to this method.
-  void AddFact(const protobufs::FactIdIsDead& fact);
+  void AddFact(const protobufs::FactBlockIsDead& fact);
 
   // See method in FactManager which delegates to this method.
-  bool IdIsDead(uint32_t id) const;
+  bool BlockIsDead(uint32_t block_id) const;
 
  private:
-  std::set<uint32_t> dead_ids_;
+  std::set<uint32_t> dead_block_ids_;
 };
 
-void FactManager::DeadIdFacts::AddFact(const protobufs::FactIdIsDead& fact) {
-  dead_ids_.insert(fact.id());
+void FactManager::DeadBlockFacts::AddFact(
+    const protobufs::FactBlockIsDead& fact) {
+  dead_block_ids_.insert(fact.block_id());
 }
 
-bool FactManager::DeadIdFacts::IdIsDead(uint32_t id) const {
-  return dead_ids_.count(id) != 0;
+bool FactManager::DeadBlockFacts::BlockIsDead(uint32_t block_id) const {
+  return dead_block_ids_.count(block_id) != 0;
 }
 
-// End of dead id facts
+// End of dead block facts
 //==============================
 
 FactManager::FactManager()
     : uniform_constant_facts_(MakeUnique<ConstantUniformFacts>()),
       data_synonym_facts_(MakeUnique<DataSynonymFacts>()),
-      dead_id_facts_(MakeUnique<DeadIdFacts>()) {}
+      dead_block_facts_(MakeUnique<DeadBlockFacts>()) {}
 
 FactManager::~FactManager() = default;
 
@@ -855,8 +857,8 @@ bool FactManager::AddFact(const fuzz::protobufs::Fact& fact,
     case protobufs::Fact::kDataSynonymFact:
       data_synonym_facts_->AddFact(fact.data_synonym_fact(), context);
       return true;
-    case protobufs::Fact::kIdIsDeadFact:
-      dead_id_facts_->AddFact(fact.id_is_dead_fact());
+    case protobufs::Fact::kBlockIsDeadFact:
+      dead_block_facts_->AddFact(fact.block_is_dead_fact());
       return true;
     default:
       assert(false && "Unknown fact type.");
@@ -929,14 +931,14 @@ bool FactManager::IsSynonymous(
                                            context);
 }
 
-bool FactManager::IdIsDead(uint32_t id) const {
-  return dead_id_facts_->IdIsDead(id);
+bool FactManager::BlockIsDead(uint32_t block_id) const {
+  return dead_block_facts_->BlockIsDead(block_id);
 }
 
-void FactManager::AddFactIdIsDead(uint32_t id) {
-  protobufs::FactIdIsDead fact;
-  fact.set_id(id);
-  dead_id_facts_->AddFact(fact);
+void FactManager::AddFactBlockIsDead(uint32_t block_id) {
+  protobufs::FactBlockIsDead fact;
+  fact.set_block_id(block_id);
+  dead_block_facts_->AddFact(fact);
 }
 
 }  // namespace fuzz

--- a/source/fuzz/fact_manager.h
+++ b/source/fuzz/fact_manager.h
@@ -58,6 +58,9 @@ class FactManager {
                           const protobufs::DataDescriptor& data2,
                           opt::IRContext* context);
 
+  // Records the fact that |id| is dead.
+  void AddFactIdIsDead(uint32_t id);
+
   // The fact manager is responsible for managing a few distinct categories of
   // facts. In principle there could be different fact managers for each kind
   // of fact, but in practice providing one 'go to' place for facts is
@@ -130,6 +133,14 @@ class FactManager {
   // End of id synonym facts
   //==============================
 
+  //==============================
+  // Querying facts about dead ids
+
+  bool IdIsDead(uint32_t id) const;
+
+  // End of dead id facts
+  //==============================
+
  private:
   // For each distinct kind of fact to be managed, we use a separate opaque
   // class type.
@@ -142,6 +153,10 @@ class FactManager {
   class DataSynonymFacts;  // Opaque class for management of data synonym facts.
   std::unique_ptr<DataSynonymFacts>
       data_synonym_facts_;  // Unique pointer to internal data.
+
+  class DeadIdFacts;  // Opaque class for management of dead id facts.
+  std::unique_ptr<DeadIdFacts>
+      dead_id_facts_;  // Unique pointer to internal data.
 };
 
 }  // namespace fuzz

--- a/source/fuzz/fact_manager.h
+++ b/source/fuzz/fact_manager.h
@@ -58,8 +58,8 @@ class FactManager {
                           const protobufs::DataDescriptor& data2,
                           opt::IRContext* context);
 
-  // Records the fact that |id| is dead.
-  void AddFactIdIsDead(uint32_t id);
+  // Records the fact that |block_id| is dead.
+  void AddFactBlockIsDead(uint32_t block_id);
 
   // The fact manager is responsible for managing a few distinct categories of
   // facts. In principle there could be different fact managers for each kind
@@ -134,11 +134,13 @@ class FactManager {
   //==============================
 
   //==============================
-  // Querying facts about dead ids
+  // Querying facts about dead blocks
 
-  bool IdIsDead(uint32_t id) const;
+  // Returns true if and ony if |block_id| is the id of a block known to be
+  // dynamically unreachable.
+  bool BlockIsDead(uint32_t block_id) const;
 
-  // End of dead id facts
+  // End of dead block facts
   //==============================
 
  private:
@@ -154,9 +156,9 @@ class FactManager {
   std::unique_ptr<DataSynonymFacts>
       data_synonym_facts_;  // Unique pointer to internal data.
 
-  class DeadIdFacts;  // Opaque class for management of dead id facts.
-  std::unique_ptr<DeadIdFacts>
-      dead_id_facts_;  // Unique pointer to internal data.
+  class DeadBlockFacts;  // Opaque class for management of dead block facts.
+  std::unique_ptr<DeadBlockFacts>
+      dead_block_facts_;  // Unique pointer to internal data.
 };
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -21,6 +21,7 @@
 #include "fuzzer_pass_adjust_memory_operands_masks.h"
 #include "source/fuzz/fact_manager.h"
 #include "source/fuzz/fuzzer_context.h"
+#include "source/fuzz/fuzzer_pass_add_dead_blocks.h"
 #include "source/fuzz/fuzzer_pass_add_dead_breaks.h"
 #include "source/fuzz/fuzzer_pass_add_dead_continues.h"
 #include "source/fuzz/fuzzer_pass_add_no_contraction_decorations.h"
@@ -177,6 +178,9 @@ Fuzzer::FuzzerResultStatus Fuzzer::Run(
   // Apply some semantics-preserving passes.
   std::vector<std::unique_ptr<FuzzerPass>> passes;
   while (passes.empty()) {
+    MaybeAddPass<FuzzerPassAddDeadBlocks>(&passes, ir_context.get(),
+                                          &fact_manager, &fuzzer_context,
+                                          transformation_sequence_out);
     MaybeAddPass<FuzzerPassAddDeadBreaks>(&passes, ir_context.get(),
                                           &fact_manager, &fuzzer_context,
                                           transformation_sequence_out);

--- a/source/fuzz/fuzzer_context.cpp
+++ b/source/fuzz/fuzzer_context.cpp
@@ -23,6 +23,7 @@ namespace {
 // Default <minimum, maximum> pairs of probabilities for applying various
 // transformations. All values are percentages. Keep them in alphabetical order.
 
+const std::pair<uint32_t, uint32_t> kChanceOfAddingDeadBlock = {20, 90};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingDeadBreak = {5, 80};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingDeadContinue = {5, 80};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingNoContractionDecoration = {
@@ -67,6 +68,8 @@ FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
       next_fresh_id_(min_fresh_id),
       go_deeper_in_constant_obfuscation_(
           kDefaultGoDeeperInConstantObfuscation) {
+  chance_of_adding_dead_block_ =
+      ChooseBetweenMinAndMax(kChanceOfAddingDeadBlock);
   chance_of_adding_dead_break_ =
       ChooseBetweenMinAndMax(kChanceOfAddingDeadBreak);
   chance_of_adding_dead_continue_ =

--- a/source/fuzz/fuzzer_context.h
+++ b/source/fuzz/fuzzer_context.h
@@ -58,6 +58,7 @@ class FuzzerContext {
 
   // Probabilities associated with applying various transformations.
   // Keep them in alphabetical order.
+  uint32_t GetChanceOfAddingDeadBlock() { return chance_of_adding_dead_block_; }
   uint32_t GetChanceOfAddingDeadBreak() { return chance_of_adding_dead_break_; }
   uint32_t GetChanceOfAddingDeadContinue() {
     return chance_of_adding_dead_continue_;
@@ -117,6 +118,7 @@ class FuzzerContext {
 
   // Probabilities associated with applying various transformations.
   // Keep them in alphabetical order.
+  uint32_t chance_of_adding_dead_block_;
   uint32_t chance_of_adding_dead_break_;
   uint32_t chance_of_adding_dead_continue_;
   uint32_t chance_of_adding_no_contraction_decoration_;

--- a/source/fuzz/fuzzer_pass_add_dead_blocks.cpp
+++ b/source/fuzz/fuzzer_pass_add_dead_blocks.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/fuzzer_pass_add_dead_blocks.h"
+
+namespace spvtools {
+namespace fuzz {
+
+FuzzerPassAddDeadBlocks::FuzzerPassAddDeadBlocks(
+    opt::IRContext* ir_context, FactManager* fact_manager,
+    FuzzerContext* fuzzer_context,
+    protobufs::TransformationSequence* transformations)
+    : FuzzerPass(ir_context, fact_manager, fuzzer_context, transformations) {}
+
+FuzzerPassAddDeadBlocks::~FuzzerPassAddDeadBlocks() = default;
+
+void FuzzerPassAddDeadBlocks::Apply() {
+  assert(false && "Implement");
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/fuzzer_pass_add_dead_blocks.cpp
+++ b/source/fuzz/fuzzer_pass_add_dead_blocks.cpp
@@ -14,6 +14,9 @@
 
 #include "source/fuzz/fuzzer_pass_add_dead_blocks.h"
 
+#include "source/fuzz/fuzzer_util.h"
+#include "source/fuzz/transformation_add_dead_block.h"
+
 namespace spvtools {
 namespace fuzz {
 
@@ -26,7 +29,40 @@ FuzzerPassAddDeadBlocks::FuzzerPassAddDeadBlocks(
 FuzzerPassAddDeadBlocks::~FuzzerPassAddDeadBlocks() = default;
 
 void FuzzerPassAddDeadBlocks::Apply() {
-  assert(false && "Implement");
+  std::vector<opt::BasicBlock*> candidate_blocks;
+  for (auto& function : *GetIRContext()->module()) {
+    for (auto& block : function) {
+      if (!GetFuzzerContext()->ChoosePercentage(
+              GetFuzzerContext()->GetChanceOfAddingDeadBlock())) {
+        continue;
+      }
+      if (block.IsLoopHeader()) {
+        continue;
+      }
+      if (block.terminator()->opcode() != SpvOpBranch) {
+        continue;
+      }
+      if (fuzzerutil::IsMergeOrContinue(
+              GetIRContext(), block.terminator()->GetSingleWordInOperand(0))) {
+        continue;
+      }
+      // TODO think about OpPhi here
+      candidate_blocks.push_back(&block);
+    }
+  }
+  while (!candidate_blocks.empty()) {
+    uint32_t index = GetFuzzerContext()->RandomIndex(candidate_blocks);
+    auto block = candidate_blocks.at(index);
+    candidate_blocks.erase(candidate_blocks.begin() + index);
+    // TODO: address OpPhi situation
+    TransformationAddDeadBlock transformation(
+        GetFuzzerContext()->GetFreshId(), block->id(),
+        GetFuzzerContext()->ChooseEven(), {});
+    if (transformation.IsApplicable(GetIRContext(), *GetFactManager())) {
+      transformation.Apply(GetIRContext(), GetFactManager());
+      *GetTransformations()->add_transformation() = transformation.ToMessage();
+    }
+  }
 }
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_pass_add_dead_blocks.cpp
+++ b/source/fuzz/fuzzer_pass_add_dead_blocks.cpp
@@ -46,11 +46,9 @@ void FuzzerPassAddDeadBlocks::Apply() {
       //
       // It means that fresh ids for transformations that turn out not to be
       // applicable end up being unused.
-      candidate_transformations.emplace_back(TransformationAddDeadBlock
-      (GetFuzzerContext()->GetFreshId(),
-                                                block.id(),
-                                                GetFuzzerContext()
-                                                ->ChooseEven()));
+      candidate_transformations.emplace_back(TransformationAddDeadBlock(
+          GetFuzzerContext()->GetFreshId(), block.id(),
+          GetFuzzerContext()->ChooseEven()));
     }
   }
   // Apply all those transformations that are in fact applicable.

--- a/source/fuzz/fuzzer_pass_add_dead_blocks.cpp
+++ b/source/fuzz/fuzzer_pass_add_dead_blocks.cpp
@@ -46,7 +46,6 @@ void FuzzerPassAddDeadBlocks::Apply() {
               GetIRContext(), block.terminator()->GetSingleWordInOperand(0))) {
         continue;
       }
-      // TODO think about OpPhi here
       candidate_blocks.push_back(&block);
     }
   }
@@ -54,10 +53,9 @@ void FuzzerPassAddDeadBlocks::Apply() {
     uint32_t index = GetFuzzerContext()->RandomIndex(candidate_blocks);
     auto block = candidate_blocks.at(index);
     candidate_blocks.erase(candidate_blocks.begin() + index);
-    // TODO: address OpPhi situation
-    TransformationAddDeadBlock transformation(
-        GetFuzzerContext()->GetFreshId(), block->id(),
-        GetFuzzerContext()->ChooseEven(), {});
+    TransformationAddDeadBlock transformation(GetFuzzerContext()->GetFreshId(),
+                                              block->id(),
+                                              GetFuzzerContext()->ChooseEven());
     if (transformation.IsApplicable(GetIRContext(), *GetFactManager())) {
       transformation.Apply(GetIRContext(), GetFactManager());
       *GetTransformations()->add_transformation() = transformation.ToMessage();

--- a/source/fuzz/fuzzer_pass_add_dead_blocks.h
+++ b/source/fuzz/fuzzer_pass_add_dead_blocks.h
@@ -24,8 +24,8 @@ namespace fuzz {
 class FuzzerPassAddDeadBlocks : public FuzzerPass {
  public:
   FuzzerPassAddDeadBlocks(opt::IRContext* ir_context, FactManager* fact_manager,
-                        FuzzerContext* fuzzer_context,
-                        protobufs::TransformationSequence* transformations);
+                          FuzzerContext* fuzzer_context,
+                          protobufs::TransformationSequence* transformations);
 
   ~FuzzerPassAddDeadBlocks();
 

--- a/source/fuzz/fuzzer_pass_add_dead_blocks.h
+++ b/source/fuzz/fuzzer_pass_add_dead_blocks.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_FUZZER_PASS_ADD_DEAD_BLOCKS_H_
+#define SOURCE_FUZZ_FUZZER_PASS_ADD_DEAD_BLOCKS_H_
+
+#include "source/fuzz/fuzzer_pass.h"
+
+namespace spvtools {
+namespace fuzz {
+
+// TODO comment
+class FuzzerPassAddDeadBlocks : public FuzzerPass {
+ public:
+  FuzzerPassAddDeadBlocks(opt::IRContext* ir_context, FactManager* fact_manager,
+                        FuzzerContext* fuzzer_context,
+                        protobufs::TransformationSequence* transformations);
+
+  ~FuzzerPassAddDeadBlocks();
+
+  void Apply() override;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_FUZZER_PASS_ADD_DEAD_BLOCKS_H_

--- a/source/fuzz/fuzzer_pass_add_dead_blocks.h
+++ b/source/fuzz/fuzzer_pass_add_dead_blocks.h
@@ -20,7 +20,8 @@
 namespace spvtools {
 namespace fuzz {
 
-// TODO comment
+// Fuzzer pass to add dynamically unreachable blocks to the module.  Future
+// passes can then manipulate such blocks.
 class FuzzerPassAddDeadBlocks : public FuzzerPass {
  public:
   FuzzerPassAddDeadBlocks(opt::IRContext* ir_context, FactManager* fact_manager,

--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -112,14 +112,14 @@ bool PhiIdsOkForNewEdge(
 uint32_t MaybeGetBoolConstantId(opt::IRContext* context, bool value) {
   opt::analysis::Bool bool_type;
   auto registered_bool_type =
-          context->get_type_mgr()->GetRegisteredType(&bool_type);
+      context->get_type_mgr()->GetRegisteredType(&bool_type);
   if (!registered_bool_type) {
     return 0;
   }
   opt::analysis::BoolConstant bool_constant(registered_bool_type->AsBool(),
-          value);
+                                            value);
   return context->get_constant_mgr()->FindDeclaredConstant(
-          &bool_constant, context->get_type_mgr()->GetId(&bool_type));
+      &bool_constant, context->get_type_mgr()->GetId(&bool_type));
 }
 
 void AddUnreachableEdgeAndUpdateOpPhis(
@@ -133,7 +133,9 @@ void AddUnreachableEdgeAndUpdateOpPhis(
 
   // Get the id of the boolean constant to be used as the condition.
   uint32_t bool_id = MaybeGetBoolConstantId(context, condition_value);
-  assert(bool_id && "Precondition that condition value must be available is not satisfied");
+  assert(
+      bool_id &&
+      "Precondition that condition value must be available is not satisfied");
 
   const bool from_to_edge_already_exists = bb_from->IsSuccessor(bb_to);
   auto successor = bb_from->terminator()->GetSingleWordInOperand(0);
@@ -330,19 +332,18 @@ bool IsNonFunctionTypeId(opt::IRContext* ir_context, uint32_t id) {
 bool IsMergeOrContinue(opt::IRContext* ir_context, uint32_t block_id) {
   bool result = false;
   ir_context->get_def_use_mgr()->WhileEachUse(
-          block_id,
-          [&result](
-                  const opt::Instruction* use_instruction,
-                  uint32_t /*unused*/) -> bool {
-              switch (use_instruction->opcode()) {
-                case SpvOpLoopMerge:
-                case SpvOpSelectionMerge:
-                  result = true;
-                  return false;
-                default:
-                  return true;
-              }
-          });
+      block_id,
+      [&result](const opt::Instruction* use_instruction,
+                uint32_t /*unused*/) -> bool {
+        switch (use_instruction->opcode()) {
+          case SpvOpLoopMerge:
+          case SpvOpSelectionMerge:
+            result = true;
+            return false;
+          default:
+            return true;
+        }
+      });
   return result;
 }
 

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -52,8 +52,13 @@ bool PhiIdsOkForNewEdge(
     opt::IRContext* context, opt::BasicBlock* bb_from, opt::BasicBlock* bb_to,
     const google::protobuf::RepeatedField<google::protobuf::uint32>& phi_ids);
 
-// Requires that PhiIdsOkForNewEdge(context, bb_from, bb_to, phi_ids) holds,
-// and that bb_from ends with "OpBranch %some_block".  Turns OpBranch into
+// Returns the id of a boolean constant with value |value| if it exists in the
+// module, or 0 otherwise.
+uint32_t MaybeGetBoolConstantId(opt::IRContext* context, bool value);
+
+// Requires that a boolean constant with value |condition_value| is available,
+// that PhiIdsOkForNewEdge(context, bb_from, bb_to, phi_ids) holds, and that
+// bb_from ends with "OpBranch %some_block".  Turns OpBranch into
 // "OpBranchConditional |condition_value| ...", such that control will branch
 // to %some_block, with |bb_to| being the unreachable alternative.  Updates
 // OpPhi instructions in |bb_to| using |phi_ids| so that the new edge is valid.
@@ -122,6 +127,9 @@ std::unique_ptr<opt::IRContext> CloneIRContext(opt::IRContext* context);
 // Returns true if and only if |id| is the id of a type that is not a function
 // type.
 bool IsNonFunctionTypeId(opt::IRContext* ir_context, uint32_t id);
+
+// Returns true if and only if |block_id| is a merge block or continue target
+bool IsMergeOrContinue(opt::IRContext* ir_context, uint32_t block_id);
 
 }  // namespace fuzzerutil
 

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -166,6 +166,7 @@ message Fact {
     // Order the fact options by numeric id (rather than alphabetically).
     FactConstantUniform constant_uniform_fact = 1;
     FactDataSynonym data_synonym_fact = 2;
+    FactIdIsDead id_is_dead_fact = 3;
   }
 }
 
@@ -198,6 +199,16 @@ message FactDataSynonym {
 
   DataDescriptor data2 = 2;
 
+}
+
+message FactIdIsDead {
+
+  // Records the fact that a block label instruction, or an instruction inside
+  // a block, is guaranteed to be dynamically unreachable.  This is useful
+  // because it informs the fuzzer that rather arbitrary changes can be made
+  // in relation to this instruction.
+
+  uint32 id = 1;
 }
 
 message TransformationSequence {

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -242,6 +242,7 @@ message Transformation {
     TransformationAddGlobalVariable add_global_variable = 31;
     TransformationAddGlobalUndef add_global_undef = 32;
     TransformationAddFunction add_function = 33;
+    TransformationAddDeadBlock add_dead_block = 34;
     // Add additional option using the next available number.
   }
 }
@@ -275,7 +276,7 @@ message TransformationAddConstantComposite {
 
 message TransformationAddConstantScalar {
 
-  // Adds a constant of the given scalar type
+  // Adds a constant of the given scalar type.
 
   // Id for the constant
   uint32 fresh_id = 1;
@@ -285,6 +286,29 @@ message TransformationAddConstantScalar {
 
   // Value of the constant
   repeated uint32 word = 3;
+
+}
+
+message TransformationAddDeadBlock {
+
+  // Adds a new block to the module that is statically reachable from an
+  // existing block, but dynamically unreachable.
+
+  // Fresh id for the dead block
+  uint32 fresh_id = 1;
+
+  // Id of an existing block terminated with OpBranch, such that this OpBranch
+  // can be replaced with an OpBranchConditional to its exiting successor or
+  // the dead block
+  uint32 existing_block = 2;
+
+  // Determines whether the condition associated with the OpBranchConditional
+  // is true or false
+  bool condition_value = 3;
+
+  // A sequence of ids suitable for extending OpPhi instructions at the
+  // successor of |existing_block| as a result of adding a new edge
+  repeated uint32 phi_id = 4;
 
 }
 

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -166,7 +166,7 @@ message Fact {
     // Order the fact options by numeric id (rather than alphabetically).
     FactConstantUniform constant_uniform_fact = 1;
     FactDataSynonym data_synonym_fact = 2;
-    FactIdIsDead id_is_dead_fact = 3;
+    FactBlockIsDead block_is_dead_fact = 3;
   }
 }
 
@@ -201,14 +201,13 @@ message FactDataSynonym {
 
 }
 
-message FactIdIsDead {
+message FactBlockIsDead {
 
-  // Records the fact that a block label instruction, or an instruction inside
-  // a block, is guaranteed to be dynamically unreachable.  This is useful
-  // because it informs the fuzzer that rather arbitrary changes can be made
-  // in relation to this instruction.
+  // Records the fact that a block is guaranteed to be dynamically unreachable.
+  // This is useful because it informs the fuzzer that rather arbitrary changes
+  // can be made to this block.
 
-  uint32 id = 1;
+  uint32 block_id = 1;
 }
 
 message TransformationSequence {
@@ -316,10 +315,6 @@ message TransformationAddDeadBlock {
   // Determines whether the condition associated with the OpBranchConditional
   // is true or false
   bool condition_value = 3;
-
-  // A sequence of ids suitable for extending OpPhi instructions at the
-  // successor of |existing_block| as a result of adding a new edge
-  repeated uint32 phi_id = 4;
 
 }
 

--- a/source/fuzz/transformation.cpp
+++ b/source/fuzz/transformation.cpp
@@ -19,6 +19,7 @@
 #include "source/fuzz/transformation_add_constant_boolean.h"
 #include "source/fuzz/transformation_add_constant_composite.h"
 #include "source/fuzz/transformation_add_constant_scalar.h"
+#include "source/fuzz/transformation_add_dead_block.h"
 #include "source/fuzz/transformation_add_dead_break.h"
 #include "source/fuzz/transformation_add_dead_continue.h"
 #include "source/fuzz/transformation_add_function.h"
@@ -68,6 +69,9 @@ std::unique_ptr<Transformation> Transformation::FromMessage(
     case protobufs::Transformation::TransformationCase::kAddConstantScalar:
       return MakeUnique<TransformationAddConstantScalar>(
           message.add_constant_scalar());
+    case protobufs::Transformation::TransformationCase::kAddDeadBlock:
+      return MakeUnique<TransformationAddDeadBlock>(
+          message.add_dead_block());
     case protobufs::Transformation::TransformationCase::kAddDeadBreak:
       return MakeUnique<TransformationAddDeadBreak>(message.add_dead_break());
     case protobufs::Transformation::TransformationCase::kAddDeadContinue:

--- a/source/fuzz/transformation.cpp
+++ b/source/fuzz/transformation.cpp
@@ -70,8 +70,7 @@ std::unique_ptr<Transformation> Transformation::FromMessage(
       return MakeUnique<TransformationAddConstantScalar>(
           message.add_constant_scalar());
     case protobufs::Transformation::TransformationCase::kAddDeadBlock:
-      return MakeUnique<TransformationAddDeadBlock>(
-          message.add_dead_block());
+      return MakeUnique<TransformationAddDeadBlock>(message.add_dead_block());
     case protobufs::Transformation::TransformationCase::kAddDeadBreak:
       return MakeUnique<TransformationAddDeadBreak>(message.add_dead_break());
     case protobufs::Transformation::TransformationCase::kAddDeadContinue:

--- a/source/fuzz/transformation_add_dead_block.cpp
+++ b/source/fuzz/transformation_add_dead_block.cpp
@@ -1,0 +1,107 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_add_dead_block.h"
+
+#include "source/fuzz/fuzzer_util.h"
+
+namespace spvtools {
+namespace fuzz {
+
+TransformationAddDeadBlock::TransformationAddDeadBlock(
+    const spvtools::fuzz::protobufs::TransformationAddDeadBlock& message)
+    : message_(message) {}
+
+TransformationAddDeadBlock::TransformationAddDeadBlock(
+        uint32_t fresh_id, uint32_t existing_block,
+bool condition_value,
+        std::vector<uint32_t> phi_id) {
+  message_.set_fresh_id(fresh_id);
+  message_.set_existing_block(existing_block);
+  message_.set_condition_value(condition_value);
+  for (auto id : phi_id) {
+    message_.add_phi_id(id);
+  }
+}
+
+bool TransformationAddDeadBlock::IsApplicable(
+    opt::IRContext* context,
+    const spvtools::fuzz::FactManager& /*unused*/) const {
+  // The new block's id must be fresh.
+  if (!fuzzerutil::IsFreshId(context, message_.fresh_id())) {
+    return false;
+  }
+
+  // First, we check that a constant with the same value as
+  // |message_.condition_value| is present.
+  if (!fuzzerutil::MaybeGetBoolConstantId(context, message_.condition_value())) {
+    // The required constant is not present, so the transformation cannot be
+    // applied.
+    return false;
+  }
+
+  // The existing block must indeed exist.
+  auto existing_block = fuzzerutil::MaybeFindBlock(context, message_.existing_block());
+  if (!existing_block) {
+    return false;
+  }
+
+  // It must not head a loop.
+  if (existing_block->IsLoopHeader()) {
+    return false;
+  }
+
+  // It must end with OpBranch.
+  if (existing_block->terminator()->opcode() != SpvOpBranch) {
+    return false;
+  }
+
+  // Its successor must not be a merge block nor continue target.
+  if (fuzzerutil::IsMergeOrContinue(context, existing_block->terminator()->GetSingleWordInOperand(0))) {
+    return false;
+  }
+  return true;
+}
+
+void TransformationAddDeadBlock::Apply(
+    opt::IRContext* context, spvtools::fuzz::FactManager* /*unused*/) const {
+  // TODO comment
+  fuzzerutil::UpdateModuleIdBound(context, message_.fresh_id());
+  auto existing_block = context->cfg()->block(message_.existing_block());
+  auto successor_block_id = existing_block->terminator()->GetSingleWordInOperand(0);
+  auto bool_id = fuzzerutil::MaybeGetBoolConstantId(context, message_.condition_value());
+
+  auto enclosing_function = existing_block->GetParent();
+  std::unique_ptr<opt::BasicBlock> new_block =
+          MakeUnique<opt::BasicBlock>(MakeUnique<opt::Instruction>(
+                  context, SpvOpLabel, 0, message_.fresh_id(), opt::Instruction::OperandList()));
+  new_block->SetParent(enclosing_function);
+  new_block->AddInstruction(MakeUnique<opt::Instruction>(context, SpvOpBranch, 0, 0, opt::Instruction::OperandList({{SPV_OPERAND_TYPE_ID, {successor_block_id}}})));
+  existing_block->terminator()->SetOpcode(SpvOpBranchConditional);
+  existing_block->terminator()->SetInOperands(
+          {{SPV_OPERAND_TYPE_ID, {bool_id}},
+           {SPV_OPERAND_TYPE_ID, {message_.condition_value() ? successor_block_id : message_.fresh_id()}},
+           {SPV_OPERAND_TYPE_ID, {message_.condition_value() ? message_.fresh_id() : successor_block_id}}});
+  enclosing_function->InsertBasicBlockAfter(std::move(new_block), existing_block);
+  context->InvalidateAnalysesExceptFor(opt::IRContext::kAnalysisNone);
+}
+
+protobufs::Transformation TransformationAddDeadBlock::ToMessage() const {
+  protobufs::Transformation result;
+  *result.mutable_add_dead_block() = message_;
+  return result;
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/transformation_add_dead_block.cpp
+++ b/source/fuzz/transformation_add_dead_block.cpp
@@ -140,11 +140,8 @@ void TransformationAddDeadBlock::Apply(
   context->cfg()
       ->block(successor_block_id)
       ->ForEachPhiInst([this](opt::Instruction* phi_inst) {
-        // There should be a single existing predecessor, hence two input
-        // operands.
-        assert(phi_inst->NumInOperands() == 2);
-        // Copy the operand that provides the phi value for the single existing
-        // predecessor.
+        // Copy the operand that provides the phi value for the first of any
+        // existing predecessors.
         opt::Operand copy_of_existing_operand = phi_inst->GetInOperand(0);
         // Use this as the value associated with the new predecessor.
         phi_inst->AddOperand(std::move(copy_of_existing_operand));

--- a/source/fuzz/transformation_add_dead_block.cpp
+++ b/source/fuzz/transformation_add_dead_block.cpp
@@ -72,6 +72,12 @@ bool TransformationAddDeadBlock::IsApplicable(
     return false;
   }
 
+  // The successor must not be a loop header (i.e., |message_.existing_block|
+  // must not be a back-edge block.
+  if (context->cfg()->block(successor_block_id)->IsLoopHeader()) {
+    return false;
+  }
+
   return true;
 }
 

--- a/source/fuzz/transformation_add_dead_block.h
+++ b/source/fuzz/transformation_add_dead_block.h
@@ -28,8 +28,7 @@ class TransformationAddDeadBlock : public Transformation {
   explicit TransformationAddDeadBlock(
       const protobufs::TransformationAddDeadBlock& message);
 
-  TransformationAddDeadBlock(uint32_t fresh_id,
-                             uint32_t existing_block,
+  TransformationAddDeadBlock(uint32_t fresh_id, uint32_t existing_block,
                              bool condition_value,
                              std::vector<uint32_t> phi_id);
 

--- a/source/fuzz/transformation_add_dead_block.h
+++ b/source/fuzz/transformation_add_dead_block.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_TRANSFORMATION_ADD_DEAD_BLOCK_H_
+#define SOURCE_FUZZ_TRANSFORMATION_ADD_DEAD_BLOCK_H_
+
+#include "source/fuzz/fact_manager.h"
+#include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
+#include "source/fuzz/transformation.h"
+#include "source/opt/ir_context.h"
+
+namespace spvtools {
+namespace fuzz {
+
+class TransformationAddDeadBlock : public Transformation {
+ public:
+  explicit TransformationAddDeadBlock(
+      const protobufs::TransformationAddDeadBlock& message);
+
+  TransformationAddDeadBlock(uint32_t fresh_id,
+                             uint32_t existing_block,
+                             bool condition_value,
+                             std::vector<uint32_t> phi_id);
+
+  // TODO comment
+  bool IsApplicable(opt::IRContext* context,
+                    const FactManager& fact_manager) const override;
+
+  // TODO comment
+  void Apply(opt::IRContext* context, FactManager* fact_manager) const override;
+
+  protobufs::Transformation ToMessage() const override;
+
+ private:
+  protobufs::TransformationAddDeadBlock message_;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_TRANSFORMATION_ADD_DEAD_BLOCK_H_

--- a/source/fuzz/transformation_add_dead_block.h
+++ b/source/fuzz/transformation_add_dead_block.h
@@ -29,14 +29,23 @@ class TransformationAddDeadBlock : public Transformation {
       const protobufs::TransformationAddDeadBlock& message);
 
   TransformationAddDeadBlock(uint32_t fresh_id, uint32_t existing_block,
-                             bool condition_value,
-                             std::vector<uint32_t> phi_id);
+                             bool condition_value);
 
-  // TODO comment
+  // - |message_.fresh_id| must be a fresh id
+  // - A constant with the same value as |message_.condition_value| must be
+  //   available
+  // - |message_.existing_block| must be a block that is not a loop header,
+  //   and that ends with OpBranch to a block that is not a merge block nor
+  //   continue target - this is because the successor will become the merge
+  //   block of a selection construct headed at |message_.existing_block|
   bool IsApplicable(opt::IRContext* context,
                     const FactManager& fact_manager) const override;
 
-  // TODO comment
+  // Changes the OpBranch from |message_.existing_block| to its successor 's'
+  // to an OpBranchConditional to either 's' or a new block,
+  // |message_.fresh_id|, which itself unconditionally branches to 's'.  The
+  // conditional branch uses |message.condition_value| as its condition, and is
+  // arranged so that control will pass to 's' at runtime.
   void Apply(opt::IRContext* context, FactManager* fact_manager) const override;
 
   protobufs::Transformation ToMessage() const override;

--- a/source/fuzz/transformation_add_dead_block.h
+++ b/source/fuzz/transformation_add_dead_block.h
@@ -38,6 +38,9 @@ class TransformationAddDeadBlock : public Transformation {
   //   and that ends with OpBranch to a block that is not a merge block nor
   //   continue target - this is because the successor will become the merge
   //   block of a selection construct headed at |message_.existing_block|
+  // - |message_.existing_block| must not be a back-edge block, since in this
+  //   case the newly-added block would lead to another back-edge to the
+  //   associated loop header
   bool IsApplicable(opt::IRContext* context,
                     const FactManager& fact_manager) const override;
 

--- a/source/fuzz/transformation_add_dead_break.cpp
+++ b/source/fuzz/transformation_add_dead_break.cpp
@@ -111,15 +111,7 @@ bool TransformationAddDeadBreak::IsApplicable(
     opt::IRContext* context, const FactManager& /*unused*/) const {
   // First, we check that a constant with the same value as
   // |message_.break_condition_value| is present.
-  opt::analysis::Bool bool_type;
-  auto registered_bool_type =
-      context->get_type_mgr()->GetRegisteredType(&bool_type);
-  if (!registered_bool_type) {
-    return false;
-  }
-  opt::analysis::BoolConstant bool_constant(registered_bool_type->AsBool(),
-                                            message_.break_condition_value());
-  if (!context->get_constant_mgr()->FindConstant(&bool_constant)) {
+  if (!fuzzerutil::MaybeGetBoolConstantId(context, message_.break_condition_value())) {
     // The required constant is not present, so the transformation cannot be
     // applied.
     return false;

--- a/source/fuzz/transformation_add_dead_break.cpp
+++ b/source/fuzz/transformation_add_dead_break.cpp
@@ -111,7 +111,8 @@ bool TransformationAddDeadBreak::IsApplicable(
     opt::IRContext* context, const FactManager& /*unused*/) const {
   // First, we check that a constant with the same value as
   // |message_.break_condition_value| is present.
-  if (!fuzzerutil::MaybeGetBoolConstantId(context, message_.break_condition_value())) {
+  if (!fuzzerutil::MaybeGetBoolConstantId(context,
+                                          message_.break_condition_value())) {
     // The required constant is not present, so the transformation cannot be
     // applied.
     return false;

--- a/source/fuzz/transformation_add_dead_continue.cpp
+++ b/source/fuzz/transformation_add_dead_continue.cpp
@@ -37,7 +37,8 @@ bool TransformationAddDeadContinue::IsApplicable(
     opt::IRContext* context, const FactManager& /*unused*/) const {
   // First, we check that a constant with the same value as
   // |message_.continue_condition_value| is present.
-  if (!fuzzerutil::MaybeGetBoolConstantId(context, message_.continue_condition_value())) {
+  if (!fuzzerutil::MaybeGetBoolConstantId(
+          context, message_.continue_condition_value())) {
     // The required constant is not present, so the transformation cannot be
     // applied.
     return false;

--- a/source/fuzz/transformation_add_dead_continue.cpp
+++ b/source/fuzz/transformation_add_dead_continue.cpp
@@ -37,15 +37,7 @@ bool TransformationAddDeadContinue::IsApplicable(
     opt::IRContext* context, const FactManager& /*unused*/) const {
   // First, we check that a constant with the same value as
   // |message_.continue_condition_value| is present.
-  opt::analysis::Bool bool_type;
-  auto registered_bool_type =
-      context->get_type_mgr()->GetRegisteredType(&bool_type);
-  if (!registered_bool_type) {
-    return false;
-  }
-  opt::analysis::BoolConstant bool_constant(
-      registered_bool_type->AsBool(), message_.continue_condition_value());
-  if (!context->get_constant_mgr()->FindConstant(&bool_constant)) {
+  if (!fuzzerutil::MaybeGetBoolConstantId(context, message_.continue_condition_value())) {
     // The required constant is not present, so the transformation cannot be
     // applied.
     return false;

--- a/source/fuzz/transformation_outline_function.cpp
+++ b/source/fuzz/transformation_outline_function.cpp
@@ -151,22 +151,7 @@ bool TransformationOutlineFunction::IsApplicable(
 
   // For simplicity, we do not allow the exit block to be a merge block or
   // continue target.
-  bool exit_block_is_merge_or_continue = false;
-  context->get_def_use_mgr()->WhileEachUse(
-      exit_block->id(),
-      [&exit_block_is_merge_or_continue](
-          const opt::Instruction* use_instruction,
-          uint32_t /*unused*/) -> bool {
-        switch (use_instruction->opcode()) {
-          case SpvOpLoopMerge:
-          case SpvOpSelectionMerge:
-            exit_block_is_merge_or_continue = true;
-            return false;
-          default:
-            return true;
-        }
-      });
-  if (exit_block_is_merge_or_continue) {
+  if (fuzzerutil::IsMergeOrContinue(context, exit_block->id())) {
     return false;
   }
 

--- a/source/fuzz/transformation_outline_function.cpp
+++ b/source/fuzz/transformation_outline_function.cpp
@@ -277,7 +277,7 @@ bool TransformationOutlineFunction::IsApplicable(
 }
 
 void TransformationOutlineFunction::Apply(
-    opt::IRContext* context, spvtools::fuzz::FactManager* /*unused*/) const {
+    opt::IRContext* context, spvtools::fuzz::FactManager* fact_manager) const {
   // The entry block for the region before outlining.
   auto original_region_entry_block =
       context->cfg()->block(message_.entry_block());
@@ -342,10 +342,10 @@ void TransformationOutlineFunction::Apply(
 
   // Fill out the body of the outlined function according to the region that is
   // being outlined.
-  PopulateOutlinedFunction(context, *original_region_entry_block,
+  PopulateOutlinedFunction(*original_region_entry_block,
                            *original_region_exit_block, region_blocks,
                            region_output_ids, output_id_to_fresh_id_map,
-                           outlined_function.get());
+                           context, outlined_function.get(), fact_manager);
 
   // Collapse the region that has been outlined into a function down to a single
   // block that calls said function.
@@ -704,12 +704,13 @@ void TransformationOutlineFunction::RemapInputAndOutputIdsInRegion(
 }
 
 void TransformationOutlineFunction::PopulateOutlinedFunction(
-    opt::IRContext* context, const opt::BasicBlock& original_region_entry_block,
+    const opt::BasicBlock& original_region_entry_block,
     const opt::BasicBlock& original_region_exit_block,
     const std::set<opt::BasicBlock*>& region_blocks,
     const std::vector<uint32_t>& region_output_ids,
     const std::map<uint32_t, uint32_t>& output_id_to_fresh_id_map,
-    opt::Function* outlined_function) const {
+    opt::IRContext* context, opt::Function* outlined_function,
+    FactManager* fact_manager) const {
   // When we create the exit block for the outlined region, we use this pointer
   // to track of it so that we can manipulate it later.
   opt::BasicBlock* outlined_region_exit_block = nullptr;
@@ -722,6 +723,13 @@ void TransformationOutlineFunction::PopulateOutlinedFunction(
           context, SpvOpLabel, 0, message_.new_function_region_entry_block(),
           opt::Instruction::OperandList()));
   outlined_region_entry_block->SetParent(outlined_function);
+
+  // If the original region's entry block was dead, the outlined region's entry
+  // block is also dead.
+  if (fact_manager->BlockIsDead(original_region_entry_block.id())) {
+    fact_manager->AddFactBlockIsDead(outlined_region_entry_block->id());
+  }
+
   if (&original_region_entry_block == &original_region_exit_block) {
     outlined_region_exit_block = outlined_region_entry_block.get();
   }

--- a/source/fuzz/transformation_outline_function.h
+++ b/source/fuzz/transformation_outline_function.h
@@ -178,14 +178,18 @@ class TransformationOutlineFunction : public Transformation {
   // and patching up branches to |original_region_entry_block| to refer to its
   // clone.  Parameters |region_output_ids| and |output_id_to_fresh_id_map| are
   // used to determine what the function should return.
+  //
+  // The |fact_manager| argument allow facts about blocks being outlined, e.g.
+  // whether they are dead blocks, to be asserted about blocks that get created
+  // during outlining.
   void PopulateOutlinedFunction(
-      opt::IRContext* context,
       const opt::BasicBlock& original_region_entry_block,
       const opt::BasicBlock& original_region_exit_block,
       const std::set<opt::BasicBlock*>& region_blocks,
       const std::vector<uint32_t>& region_output_ids,
       const std::map<uint32_t, uint32_t>& output_id_to_fresh_id_map,
-      opt::Function* outlined_function) const;
+      opt::IRContext* context, opt::Function* outlined_function,
+      FactManager* fact_manager) const;
 
   // Shrinks the outlined region, given by |region_blocks|, down to the single
   // block |original_region_entry_block|.  This block is itself shrunk to just

--- a/source/fuzz/transformation_split_block.cpp
+++ b/source/fuzz/transformation_split_block.cpp
@@ -80,7 +80,7 @@ bool TransformationSplitBlock::IsApplicable(
 }
 
 void TransformationSplitBlock::Apply(opt::IRContext* context,
-                                     FactManager* /*unused*/) const {
+                                     FactManager* fact_manager) const {
   opt::Instruction* instruction_to_split_before =
       FindInstruction(message_.instruction_to_split_before(), context);
   opt::BasicBlock* block_to_split =
@@ -114,6 +114,13 @@ void TransformationSplitBlock::Apply(opt::IRContext* context,
            "one predecessor.");
     phi_inst->SetInOperand(1, {block_to_split->id()});
   });
+
+  // If the block being split was dead, the new block arising from the split is
+  // also dead.
+  if (fact_manager->IdIsDead(block_to_split->id())) {
+    fact_manager->AddFactIdIsDead(message_.fresh_id());
+  }
+
   // Invalidate all analyses
   context->InvalidateAnalysesExceptFor(opt::IRContext::Analysis::kAnalysisNone);
 }

--- a/source/fuzz/transformation_split_block.cpp
+++ b/source/fuzz/transformation_split_block.cpp
@@ -117,8 +117,8 @@ void TransformationSplitBlock::Apply(opt::IRContext* context,
 
   // If the block being split was dead, the new block arising from the split is
   // also dead.
-  if (fact_manager->IdIsDead(block_to_split->id())) {
-    fact_manager->AddFactIdIsDead(message_.fresh_id());
+  if (fact_manager->BlockIsDead(block_to_split->id())) {
+    fact_manager->AddFactBlockIsDead(message_.fresh_id());
   }
 
   // Invalidate all analyses

--- a/source/fuzz/transformation_split_block.h
+++ b/source/fuzz/transformation_split_block.h
@@ -48,6 +48,7 @@ class TransformationSplitBlock : public Transformation {
   // - All instructions of 'blk' from 'inst' onwards are moved into the new
   //   block.
   // - 'blk' is made to jump unconditionally to the new block.
+  // - If 'blk' was dead, the new block is also dead.
   void Apply(opt::IRContext* context, FactManager* fact_manager) const override;
 
   protobufs::Transformation ToMessage() const override;

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -27,6 +27,7 @@ if (${SPIRV_BUILD_FUZZER})
           transformation_add_constant_boolean_test.cpp
           transformation_add_constant_composite_test.cpp
           transformation_add_constant_scalar_test.cpp
+          transformation_add_dead_block_test.cpp
           transformation_add_dead_break_test.cpp
           transformation_add_dead_continue_test.cpp
           transformation_add_function_test.cpp

--- a/test/fuzz/fuzz_test_util.cpp
+++ b/test/fuzz/fuzz_test_util.cpp
@@ -76,6 +76,7 @@ bool IsValid(spv_target_env env, const opt::IRContext* ir) {
   std::vector<uint32_t> binary;
   ir->module()->ToBinary(&binary, false);
   SpirvTools t(env);
+  t.SetMessageConsumer(kConsoleMessageConsumer);
   return t.Validate(binary);
 }
 

--- a/test/fuzz/transformation_add_dead_block_test.cpp
+++ b/test/fuzz/transformation_add_dead_block_test.cpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_add_dead_block.h"
+#include "test/fuzz/fuzz_test_util.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace {
+
+TEST(TransformationAddDeadBlockTest, BasicTest) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeBool
+          %7 = OpConstantTrue %6
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpBranch %8
+          %8 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+
+  // Id 4 is already in use
+  ASSERT_FALSE(TransformationAddDeadBlock(4, 5, true, {}).IsApplicable(context.get(), fact_manager));
+
+  // Id 7 is not a block
+  ASSERT_FALSE(TransformationAddDeadBlock(100, 7, true, {}).IsApplicable(context.get(), fact_manager));
+
+  TransformationAddDeadBlock transformation(100, 5, true, {});
+  ASSERT_TRUE(transformation.IsApplicable(context.get(), fact_manager));
+  transformation.Apply(context.get(), &fact_manager);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  std::string after_transformation = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeBool
+          %7 = OpConstantTrue %6
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpSelectionMerge %8
+               OpBranchConditional %7 %8 %100
+        %100 = OpLabel
+               OpBranch %8
+          %8 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+  ASSERT_TRUE(IsEqual(env, after_transformation, context.get()));
+}
+
+// Target block must not be merge or continue
+
+// Source block must not be loop head
+
+// Target block can start with OpPhi; need to give suitable ids in that case
+
+}  // namespace
+}  // namespace fuzz
+}  // namespace spvtools

--- a/test/fuzz/transformation_add_dead_block_test.cpp
+++ b/test/fuzz/transformation_add_dead_block_test.cpp
@@ -48,15 +48,19 @@ TEST(TransformationAddDeadBlockTest, BasicTest) {
   FactManager fact_manager;
 
   // Id 4 is already in use
-  ASSERT_FALSE(TransformationAddDeadBlock(4, 5, true, {}).IsApplicable(context.get(), fact_manager));
+  ASSERT_FALSE(TransformationAddDeadBlock(4, 5, true, {})
+                   .IsApplicable(context.get(), fact_manager));
 
   // Id 7 is not a block
-  ASSERT_FALSE(TransformationAddDeadBlock(100, 7, true, {}).IsApplicable(context.get(), fact_manager));
+  ASSERT_FALSE(TransformationAddDeadBlock(100, 7, true, {})
+                   .IsApplicable(context.get(), fact_manager));
 
   TransformationAddDeadBlock transformation(100, 5, true, {});
   ASSERT_TRUE(transformation.IsApplicable(context.get(), fact_manager));
   transformation.Apply(context.get(), &fact_manager);
   ASSERT_TRUE(IsValid(env, context.get()));
+
+  ASSERT_TRUE(fact_manager.IdIsDead(100));
 
   std::string after_transformation = R"(
                OpCapability Shader
@@ -72,7 +76,7 @@ TEST(TransformationAddDeadBlockTest, BasicTest) {
           %7 = OpConstantTrue %6
           %4 = OpFunction %2 None %3
           %5 = OpLabel
-               OpSelectionMerge %8
+               OpSelectionMerge %8 None
                OpBranchConditional %7 %8 %100
         %100 = OpLabel
                OpBranch %8
@@ -83,11 +87,12 @@ TEST(TransformationAddDeadBlockTest, BasicTest) {
   ASSERT_TRUE(IsEqual(env, after_transformation, context.get()));
 }
 
-// Target block must not be merge or continue
+// TODO Target block must not be merge or continue
 
-// Source block must not be loop head
+// TODO Source block must not be loop head
 
-// Target block can start with OpPhi; need to give suitable ids in that case
+// TODO Target block can start with OpPhi; need to give suitable ids in that
+//  case
 
 }  // namespace
 }  // namespace fuzz

--- a/test/fuzz/transformation_add_dead_block_test.cpp
+++ b/test/fuzz/transformation_add_dead_block_test.cpp
@@ -312,8 +312,8 @@ TEST(TransformationAddDeadBlockTest, BackEdge) {
 
   // 9 is a back edge block, so it would not be OK to add a dead block here,
   // as then both 9 and the dead block would branch to the loop header, 8.
-  ASSERT_FALSE(TransformationAddDeadBlock(100, 9, true).IsApplicable(context
-  .get(), fact_manager));
+  ASSERT_FALSE(TransformationAddDeadBlock(100, 9, true)
+                   .IsApplicable(context.get(), fact_manager));
 }
 
 }  // namespace

--- a/test/fuzz/transformation_split_block_test.cpp
+++ b/test/fuzz/transformation_split_block_test.cpp
@@ -774,6 +774,77 @@ TEST(TransformationSplitBlockTest, SplitOpPhiWithSinglePredecessor) {
   ASSERT_TRUE(IsEqual(env, after_split, context.get()));
 }
 
+TEST(TransformationSplitBlockTest, DeadBlockShouldSplitToTwoDeadBlocks) {
+  // This checks that if a block B is marked as dead, it should split into a
+  // pair of dead blocks.
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeBool
+          %7 = OpConstantFalse %6
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpSelectionMerge %9 None
+               OpBranchConditional %7 %8 %9
+          %8 = OpLabel
+               OpBranch %9
+          %9 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+
+  FactManager fact_manager;
+
+  // Record the fact that block 8 is dead.
+  fact_manager.AddFactIdIsDead(8);
+
+  auto split = TransformationSplitBlock(
+      MakeInstructionDescriptor(8, SpvOpBranch, 0), 100);
+  ASSERT_TRUE(split.IsApplicable(context.get(), fact_manager));
+  split.Apply(context.get(), &fact_manager);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  ASSERT_TRUE(fact_manager.IdIsDead(8));
+  ASSERT_TRUE(fact_manager.IdIsDead(100));
+
+  std::string after_split = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeBool
+          %7 = OpConstantFalse %6
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpSelectionMerge %9 None
+               OpBranchConditional %7 %8 %9
+          %8 = OpLabel
+               OpBranch %100
+        %100 = OpLabel
+               OpBranch %9
+          %9 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+  ASSERT_TRUE(IsEqual(env, after_split, context.get()));
+}
+
 }  // namespace
 }  // namespace fuzz
 }  // namespace spvtools

--- a/test/fuzz/transformation_split_block_test.cpp
+++ b/test/fuzz/transformation_split_block_test.cpp
@@ -807,7 +807,7 @@ TEST(TransformationSplitBlockTest, DeadBlockShouldSplitToTwoDeadBlocks) {
   FactManager fact_manager;
 
   // Record the fact that block 8 is dead.
-  fact_manager.AddFactIdIsDead(8);
+  fact_manager.AddFactBlockIsDead(8);
 
   auto split = TransformationSplitBlock(
       MakeInstructionDescriptor(8, SpvOpBranch, 0), 100);
@@ -815,8 +815,8 @@ TEST(TransformationSplitBlockTest, DeadBlockShouldSplitToTwoDeadBlocks) {
   split.Apply(context.get(), &fact_manager);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  ASSERT_TRUE(fact_manager.IdIsDead(8));
-  ASSERT_TRUE(fact_manager.IdIsDead(100));
+  ASSERT_TRUE(fact_manager.BlockIsDead(8));
+  ASSERT_TRUE(fact_manager.BlockIsDead(100));
 
   std::string after_split = R"(
                OpCapability Shader


### PR DESCRIPTION
This adds a new kind of fact to the fact manager that knows whether a
block is dead - i.e. guaranteed to be statically unreachable - and a
new transformation for adding a selection construct to a CFG that
conditionally branches to a fresh, dead block, such that the branch
will never be dynamically taken.  Transformations that may create new
blocks ('split block' and 'outline function') are updated to propagate
dead block facts to newly-created blocks where appropriate.  A fuzzer
pass randomly adds dead blocks to the module.

Future transformations will be able to exploit the fact that such
blocks are known to be dead.
