### PR TITLE
Roll external/spirv-headers/ af64a9e82..dc77030ac (4 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -6,7 +6,7 @@ vars = {
   'effcee_revision': 'cd25ec17e9382f99a895b9ef53ff3c277464d07d',
   'googletest_revision': 'f2fb48c3b3d79a75a88a99fba6576b25d42ec528',
   're2_revision': '5bd613749fd530b576b890283bfb6bc6ea6246cb',
-  'spirv_headers_revision': 'af64a9e826bf5bb5fcd2434dd71be1e41e922563',
+  'spirv_headers_revision': 'dc77030acc9c6fe7ca21fff54c5a9d7b532d7da6',
 }
 
 deps = {


### PR DESCRIPTION
$ git log af64a9e82..dc77030ac --date=short --no-merges --format='%ad %ae %s'
2020-01-20 dneto Fix the license to match LICENSE
2020-01-20 syoussefi Add BUILD.gn
2019-11-20 Tobias.Hector Off-by-one errors
2019-11-20 Tobias.Hector Reserve a new block of 64 opcodes

Created with:
  roll-dep external/spirv-headers