### PR TITLE
spirv-fuzz: Arbitrary variable facts

### DIFF
--- a/source/fuzz/fact_manager.cpp
+++ b/source/fuzz/fact_manager.cpp
@@ -859,11 +859,43 @@ bool FactManager::LivesafeFunctionFacts::FunctionIsLivesafe(
 // End of livesafe function facts
 //==============================
 
+//==============================
+// Arbitrarily-valued variable facts
+
+// The purpose of this class is to group the fields and data used to represent
+// facts about livesafe functions.
+class FactManager::ArbitrarilyValuedVaribleFacts {
+ public:
+  // See method in FactManager which delegates to this method.
+  void AddFact(const protobufs::FactValueOfVariableIsArbitrary& fact);
+
+  // See method in FactManager which delegates to this method.
+  bool VariableValueIsArbitrary(uint32_t variable_id) const;
+
+ private:
+  std::set<uint32_t> arbitrary_valued_varible_ids_;
+};
+
+void FactManager::ArbitrarilyValuedVaribleFacts::AddFact(
+    const protobufs::FactValueOfVariableIsArbitrary& fact) {
+  arbitrary_valued_varible_ids_.insert(fact.variable_id());
+}
+
+bool FactManager::ArbitrarilyValuedVaribleFacts::VariableValueIsArbitrary(
+    uint32_t variable_id) const {
+  return arbitrary_valued_varible_ids_.count(variable_id) != 0;
+}
+
+// End of arbitrarily-valued variable facts
+//==============================
+
 FactManager::FactManager()
     : uniform_constant_facts_(MakeUnique<ConstantUniformFacts>()),
       data_synonym_facts_(MakeUnique<DataSynonymFacts>()),
       dead_block_facts_(MakeUnique<DeadBlockFacts>()),
-      livesafe_function_facts_(MakeUnique<LivesafeFunctionFacts>()) {}
+      livesafe_function_facts_(MakeUnique<LivesafeFunctionFacts>()),
+      arbitrarily_valued_variable_facts_(
+          MakeUnique<ArbitrarilyValuedVaribleFacts>()) {}
 
 FactManager::~FactManager() = default;
 
@@ -983,6 +1015,17 @@ void FactManager::AddFactFunctionIsLivesafe(uint32_t function_id) {
   protobufs::FactFunctionIsLivesafe fact;
   fact.set_function_id(function_id);
   livesafe_function_facts_->AddFact(fact);
+}
+
+bool FactManager::VariableValueIsArbitrary(uint32_t variable_id) const {
+  return arbitrarily_valued_variable_facts_->VariableValueIsArbitrary(
+      variable_id);
+}
+
+void FactManager::AddFactValueOfVariableIsArbitrary(uint32_t variable_id) {
+  protobufs::FactValueOfVariableIsArbitrary fact;
+  fact.set_variable_id(variable_id);
+  arbitrarily_valued_variable_facts_->AddFact(fact);
 }
 
 }  // namespace fuzz

--- a/source/fuzz/fact_manager.h
+++ b/source/fuzz/fact_manager.h
@@ -64,6 +64,10 @@ class FactManager {
   // Records the fact that |function_id| is livesafe.
   void AddFactFunctionIsLivesafe(uint32_t function_id);
 
+  // Records the fact that |variable_id| has an arbitrary value and can thus be
+  // stored to without affecting the module's behaviour.
+  void AddFactValueOfVariableIsArbitrary(uint32_t variable_id);
+
   // The fact manager is responsible for managing a few distinct categories of
   // facts. In principle there could be different fact managers for each kind
   // of fact, but in practice providing one 'go to' place for facts is
@@ -153,7 +157,16 @@ class FactManager {
   // to be livesafe.
   bool FunctionIsLivesafe(uint32_t function_id) const;
 
-  // End of dead block facts
+  // End of dead livesafe function facts
+  //==============================
+
+  //==============================
+  // Querying facts about arbitrarily-valued variables
+
+  // Returns true if and ony if |variable_id| is arbitrarily-valued.
+  bool VariableValueIsArbitrary(uint32_t variable_id) const;
+
+  // End of arbitrarily-valued variable facts
   //==============================
 
  private:
@@ -177,6 +190,11 @@ class FactManager {
                                 // function facts.
   std::unique_ptr<LivesafeFunctionFacts>
       livesafe_function_facts_;  // Unique pointer to internal data.
+
+  class ArbitrarilyValuedVaribleFacts;  // Opaque class for management of
+  // facts about variables whose values should be expected to be arbitrary.
+  std::unique_ptr<ArbitrarilyValuedVaribleFacts>
+      arbitrarily_valued_variable_facts_;  // Unique pointer to internal data.
 };
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_pass_donate_modules.cpp
+++ b/source/fuzz/fuzzer_pass_donate_modules.cpp
@@ -396,6 +396,11 @@ void FuzzerPassDonateModules::HandleTypesAndValues(
         // have storage class private.  As a result, we simply add a Private
         // storage class global variable, using remapped versions of the result
         // type and initializer ids for the global variable in the donor.
+        //
+        // We regard the added variable as having an arbitrary value.  This
+        // means that future passes can add stores to the variable in any
+        // way they wish, and pass them as pointer parameters to functions
+        // without worrying about whether their data might get modified.
         new_result_id = GetFuzzerContext()->GetFreshId();
         ApplyTransformation(TransformationAddGlobalVariable(
             new_result_id,
@@ -403,7 +408,8 @@ void FuzzerPassDonateModules::HandleTypesAndValues(
             type_or_value.NumInOperands() == 1
                 ? 0
                 : original_id_to_donated_id->at(
-                      type_or_value.GetSingleWordInOperand(1))));
+                      type_or_value.GetSingleWordInOperand(1)),
+            true));
       } break;
       case SpvOpUndef: {
         // It is fine to have multiple Undef instructions of the same type, so

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -168,6 +168,7 @@ message Fact {
     FactDataSynonym data_synonym_fact = 2;
     FactBlockIsDead block_is_dead_fact = 3;
     FactFunctionIsLivesafe function_is_livesafe_fact = 4;
+    FactValueOfVariableIsArbitrary value_of_variable_is_arbitrary = 5;
   }
 }
 
@@ -220,6 +221,19 @@ message FactFunctionIsLivesafe {
   // functions.
 
   uint32 function_id = 1;
+}
+
+message FactValueOfVariableIsArbitrary {
+
+  // Records the fact that the value stored in the variable or function
+  // parameter with the given id can be arbitrary: the module's observable
+  // behaviour does not depend on it.  This means that arbitrary stores can be
+  // made to the variable, and that nothing can be guaranteed about values
+  // loaded from the variable.
+
+  // The result id of an OpVariable instruction, or an OpFunctionParameter
+  // instruction with pointer type
+  uint32 variable_id = 1;
 }
 
 message AccessChainClampingInfo {
@@ -492,6 +506,13 @@ message TransformationAddGlobalVariable {
 
   // Optional initializer; 0 if there is no initializer
   uint32 initializer_id = 3;
+
+  // True if and only if the value of the variable should be regarded, in
+  // general, as totally unknown and subject to change (even if, due to an
+  // initializer, the original value is known).  This is the case for variables
+  // added when a module is donated, for example, and means that stores to such
+  // variables can be performed in an arbitrary fashion.
+  bool value_is_arbitrary = 4;
 
 }
 

--- a/source/fuzz/transformation_add_global_variable.h
+++ b/source/fuzz/transformation_add_global_variable.h
@@ -29,7 +29,8 @@ class TransformationAddGlobalVariable : public Transformation {
       const protobufs::TransformationAddGlobalVariable& message);
 
   TransformationAddGlobalVariable(uint32_t fresh_id, uint32_t type_id,
-                                  uint32_t initializer_id);
+                                  uint32_t initializer_id,
+                                  bool value_is_arbitrary);
 
   // - |message_.fresh_id| must be fresh
   // - |message_.type_id| must be the id of a pointer type with Private storage

--- a/source/fuzz/transformation_outline_function.h
+++ b/source/fuzz/transformation_outline_function.h
@@ -158,10 +158,14 @@ class TransformationOutlineFunction : public Transformation {
   // A new struct type to represent the function return type, and a new function
   // type for the function, will be added to the module (unless suitable types
   // are already present).
+  //
+  // Facts about the function containing the outlined region that are relevant
+  // to the new function are propagated via |fact_manager|.
   std::unique_ptr<opt::Function> PrepareFunctionPrototype(
-      opt::IRContext* context, const std::vector<uint32_t>& region_input_ids,
+      const std::vector<uint32_t>& region_input_ids,
       const std::vector<uint32_t>& region_output_ids,
-      const std::map<uint32_t, uint32_t>& input_id_to_fresh_id_map) const;
+      const std::map<uint32_t, uint32_t>& input_id_to_fresh_id_map,
+      opt::IRContext* context, FactManager* fact_manager) const;
 
   // Creates the body of the outlined function by cloning blocks from the
   // original region, given by |region_blocks|, adapting the cloned version

--- a/test/fuzz/transformation_add_global_variable_test.cpp
+++ b/test/fuzz/transformation_add_global_variable_test.cpp
@@ -60,71 +60,78 @@ TEST(TransformationAddGlobalVariableTest, BasicTest) {
   FactManager fact_manager;
 
   // Id already in use
-  ASSERT_FALSE(TransformationAddGlobalVariable(4, 10, 0).IsApplicable(
-      context.get(), fact_manager));
+  ASSERT_FALSE(TransformationAddGlobalVariable(4, 10, 0, true)
+                   .IsApplicable(context.get(), fact_manager));
   // %1 is not a type
-  ASSERT_FALSE(TransformationAddGlobalVariable(100, 1, 0).IsApplicable(
-      context.get(), fact_manager));
+  ASSERT_FALSE(TransformationAddGlobalVariable(100, 1, 0, false)
+                   .IsApplicable(context.get(), fact_manager));
 
   // %7 is not a pointer type
-  ASSERT_FALSE(TransformationAddGlobalVariable(100, 7, 0).IsApplicable(
-      context.get(), fact_manager));
+  ASSERT_FALSE(TransformationAddGlobalVariable(100, 7, 0, true)
+                   .IsApplicable(context.get(), fact_manager));
 
   // %9 does not have Private storage class
-  ASSERT_FALSE(TransformationAddGlobalVariable(100, 9, 0).IsApplicable(
-      context.get(), fact_manager));
+  ASSERT_FALSE(TransformationAddGlobalVariable(100, 9, 0, false)
+                   .IsApplicable(context.get(), fact_manager));
 
   // %15 does not have Private storage class
-  ASSERT_FALSE(TransformationAddGlobalVariable(100, 15, 0)
+  ASSERT_FALSE(TransformationAddGlobalVariable(100, 15, 0, true)
                    .IsApplicable(context.get(), fact_manager));
 
   // %10 is a pointer to float, while %16 is an int constant
-  ASSERT_FALSE(TransformationAddGlobalVariable(100, 10, 16)
+  ASSERT_FALSE(TransformationAddGlobalVariable(100, 10, 16, false)
                    .IsApplicable(context.get(), fact_manager));
 
   // %10 is a Private pointer to float, while %15 is a variable with type
   // Uniform float pointer
-  ASSERT_FALSE(TransformationAddGlobalVariable(100, 10, 15)
+  ASSERT_FALSE(TransformationAddGlobalVariable(100, 10, 15, true)
                    .IsApplicable(context.get(), fact_manager));
 
   // %12 is a Private pointer to int, while %10 is a variable with type
   // Private float pointer
-  ASSERT_FALSE(TransformationAddGlobalVariable(100, 12, 10)
+  ASSERT_FALSE(TransformationAddGlobalVariable(100, 12, 10, false)
                    .IsApplicable(context.get(), fact_manager));
 
   // %10 is pointer-to-float, and %14 has type pointer-to-float; that's not OK
   // since the initializer's type should be the *pointee* type.
-  ASSERT_FALSE(TransformationAddGlobalVariable(104, 10, 14)
+  ASSERT_FALSE(TransformationAddGlobalVariable(104, 10, 14, true)
                    .IsApplicable(context.get(), fact_manager));
 
   // This would work in principle, but logical addressing does not allow
   // a pointer to a pointer.
-  ASSERT_FALSE(TransformationAddGlobalVariable(104, 17, 14)
+  ASSERT_FALSE(TransformationAddGlobalVariable(104, 17, 14, false)
                    .IsApplicable(context.get(), fact_manager));
 
   TransformationAddGlobalVariable transformations[] = {
       // %100 = OpVariable %12 Private
-      TransformationAddGlobalVariable(100, 12, 0),
+      TransformationAddGlobalVariable(100, 12, 0, true),
 
       // %101 = OpVariable %10 Private
-      TransformationAddGlobalVariable(101, 10, 0),
+      TransformationAddGlobalVariable(101, 10, 0, false),
 
       // %102 = OpVariable %13 Private
-      TransformationAddGlobalVariable(102, 13, 0),
+      TransformationAddGlobalVariable(102, 13, 0, true),
 
       // %103 = OpVariable %12 Private %16
-      TransformationAddGlobalVariable(103, 12, 16),
+      TransformationAddGlobalVariable(103, 12, 16, false),
 
       // %104 = OpVariable %19 Private %21
-      TransformationAddGlobalVariable(104, 19, 21),
+      TransformationAddGlobalVariable(104, 19, 21, true),
 
       // %105 = OpVariable %19 Private %22
-      TransformationAddGlobalVariable(105, 19, 22)};
+      TransformationAddGlobalVariable(105, 19, 22, false)};
 
   for (auto& transformation : transformations) {
     ASSERT_TRUE(transformation.IsApplicable(context.get(), fact_manager));
     transformation.Apply(context.get(), &fact_manager);
   }
+  ASSERT_TRUE(fact_manager.VariableValueIsArbitrary(100));
+  ASSERT_TRUE(fact_manager.VariableValueIsArbitrary(102));
+  ASSERT_TRUE(fact_manager.VariableValueIsArbitrary(104));
+  ASSERT_FALSE(fact_manager.VariableValueIsArbitrary(101));
+  ASSERT_FALSE(fact_manager.VariableValueIsArbitrary(103));
+  ASSERT_FALSE(fact_manager.VariableValueIsArbitrary(105));
+
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -215,18 +222,21 @@ TEST(TransformationAddGlobalVariableTest, TestEntryPointInterfaceEnlargement) {
 
   TransformationAddGlobalVariable transformations[] = {
       // %100 = OpVariable %12 Private
-      TransformationAddGlobalVariable(100, 12, 0),
+      TransformationAddGlobalVariable(100, 12, 0, true),
 
       // %101 = OpVariable %12 Private %16
-      TransformationAddGlobalVariable(101, 12, 16),
+      TransformationAddGlobalVariable(101, 12, 16, false),
 
       // %102 = OpVariable %19 Private %21
-      TransformationAddGlobalVariable(102, 19, 21)};
+      TransformationAddGlobalVariable(102, 19, 21, true)};
 
   for (auto& transformation : transformations) {
     ASSERT_TRUE(transformation.IsApplicable(context.get(), fact_manager));
     transformation.Apply(context.get(), &fact_manager);
   }
+  ASSERT_TRUE(fact_manager.VariableValueIsArbitrary(100));
+  ASSERT_TRUE(fact_manager.VariableValueIsArbitrary(102));
+  ASSERT_FALSE(fact_manager.VariableValueIsArbitrary(101));
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(


### PR DESCRIPTION
This change adds a new kind of fact to the fact manager, which records
when a variable (or pointer parameter) refers to an arbitrary value,
so that anything can be stored to it, without affecting the observable
behaviour of the module, and nothing can be guaranteed about values
loaded from it.  Donated modules are the current source of such
variables, and other transformations, such as outlining, have been
adapted to propagate these facts appropriately.
