### PR TITLE
vscode: Add missing fields to schema.Opcode

### DIFF
--- a/utils/vscode/src/schema/schema.go
+++ b/utils/vscode/src/schema/schema.go
@@ -629,11 +629,15 @@ var (
 
 	OpNop = &Opcode {
 		Opname:   "OpNop",
+		Class:    "Miscellaneous",
+		Opcode:   0,
 		Operands: []Operand {
 		},
 	}
 	OpUndef = &Opcode {
 		Opname:   "OpUndef",
+		Class:    "Miscellaneous",
+		Opcode:   1,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -649,6 +653,8 @@ var (
 	}
 	OpSourceContinued = &Opcode {
 		Opname:   "OpSourceContinued",
+		Class:    "Debug",
+		Opcode:   2,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindLiteralString,
@@ -659,6 +665,8 @@ var (
 	}
 	OpSource = &Opcode {
 		Opname:   "OpSource",
+		Class:    "Debug",
+		Opcode:   3,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindSourceLanguage,
@@ -684,6 +692,8 @@ var (
 	}
 	OpSourceExtension = &Opcode {
 		Opname:   "OpSourceExtension",
+		Class:    "Debug",
+		Opcode:   4,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindLiteralString,
@@ -694,6 +704,8 @@ var (
 	}
 	OpName = &Opcode {
 		Opname:   "OpName",
+		Class:    "Debug",
+		Opcode:   5,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -709,6 +721,8 @@ var (
 	}
 	OpMemberName = &Opcode {
 		Opname:   "OpMemberName",
+		Class:    "Debug",
+		Opcode:   6,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -729,6 +743,8 @@ var (
 	}
 	OpString = &Opcode {
 		Opname:   "OpString",
+		Class:    "Debug",
+		Opcode:   7,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -744,6 +760,8 @@ var (
 	}
 	OpLine = &Opcode {
 		Opname:   "OpLine",
+		Class:    "Debug",
+		Opcode:   8,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -764,6 +782,8 @@ var (
 	}
 	OpExtension = &Opcode {
 		Opname:   "OpExtension",
+		Class:    "Extension",
+		Opcode:   10,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindLiteralString,
@@ -774,6 +794,8 @@ var (
 	}
 	OpExtInstImport = &Opcode {
 		Opname:   "OpExtInstImport",
+		Class:    "Extension",
+		Opcode:   11,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -789,6 +811,8 @@ var (
 	}
 	OpExtInst = &Opcode {
 		Opname:   "OpExtInst",
+		Class:    "Extension",
+		Opcode:   12,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -819,6 +843,8 @@ var (
 	}
 	OpMemoryModel = &Opcode {
 		Opname:   "OpMemoryModel",
+		Class:    "Mode-Setting",
+		Opcode:   14,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindAddressingModel,
@@ -834,6 +860,8 @@ var (
 	}
 	OpEntryPoint = &Opcode {
 		Opname:   "OpEntryPoint",
+		Class:    "Mode-Setting",
+		Opcode:   15,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindExecutionModel,
@@ -859,6 +887,8 @@ var (
 	}
 	OpExecutionMode = &Opcode {
 		Opname:   "OpExecutionMode",
+		Class:    "Mode-Setting",
+		Opcode:   16,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -874,6 +904,8 @@ var (
 	}
 	OpCapability = &Opcode {
 		Opname:   "OpCapability",
+		Class:    "Mode-Setting",
+		Opcode:   17,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindCapability,
@@ -884,6 +916,8 @@ var (
 	}
 	OpTypeVoid = &Opcode {
 		Opname:   "OpTypeVoid",
+		Class:    "Type-Declaration",
+		Opcode:   19,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -894,6 +928,8 @@ var (
 	}
 	OpTypeBool = &Opcode {
 		Opname:   "OpTypeBool",
+		Class:    "Type-Declaration",
+		Opcode:   20,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -904,6 +940,8 @@ var (
 	}
 	OpTypeInt = &Opcode {
 		Opname:   "OpTypeInt",
+		Class:    "Type-Declaration",
+		Opcode:   21,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -924,6 +962,8 @@ var (
 	}
 	OpTypeFloat = &Opcode {
 		Opname:   "OpTypeFloat",
+		Class:    "Type-Declaration",
+		Opcode:   22,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -939,6 +979,8 @@ var (
 	}
 	OpTypeVector = &Opcode {
 		Opname:   "OpTypeVector",
+		Class:    "Type-Declaration",
+		Opcode:   23,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -959,6 +1001,8 @@ var (
 	}
 	OpTypeMatrix = &Opcode {
 		Opname:   "OpTypeMatrix",
+		Class:    "Type-Declaration",
+		Opcode:   24,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -979,6 +1023,8 @@ var (
 	}
 	OpTypeImage = &Opcode {
 		Opname:   "OpTypeImage",
+		Class:    "Type-Declaration",
+		Opcode:   25,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -1029,6 +1075,8 @@ var (
 	}
 	OpTypeSampler = &Opcode {
 		Opname:   "OpTypeSampler",
+		Class:    "Type-Declaration",
+		Opcode:   26,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -1039,6 +1087,8 @@ var (
 	}
 	OpTypeSampledImage = &Opcode {
 		Opname:   "OpTypeSampledImage",
+		Class:    "Type-Declaration",
+		Opcode:   27,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -1054,6 +1104,8 @@ var (
 	}
 	OpTypeArray = &Opcode {
 		Opname:   "OpTypeArray",
+		Class:    "Type-Declaration",
+		Opcode:   28,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -1074,6 +1126,8 @@ var (
 	}
 	OpTypeRuntimeArray = &Opcode {
 		Opname:   "OpTypeRuntimeArray",
+		Class:    "Type-Declaration",
+		Opcode:   29,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -1089,6 +1143,8 @@ var (
 	}
 	OpTypeStruct = &Opcode {
 		Opname:   "OpTypeStruct",
+		Class:    "Type-Declaration",
+		Opcode:   30,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -1104,6 +1160,8 @@ var (
 	}
 	OpTypeOpaque = &Opcode {
 		Opname:   "OpTypeOpaque",
+		Class:    "Type-Declaration",
+		Opcode:   31,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -1119,6 +1177,8 @@ var (
 	}
 	OpTypePointer = &Opcode {
 		Opname:   "OpTypePointer",
+		Class:    "Type-Declaration",
+		Opcode:   32,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -1139,6 +1199,8 @@ var (
 	}
 	OpTypeFunction = &Opcode {
 		Opname:   "OpTypeFunction",
+		Class:    "Type-Declaration",
+		Opcode:   33,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -1159,6 +1221,8 @@ var (
 	}
 	OpTypeEvent = &Opcode {
 		Opname:   "OpTypeEvent",
+		Class:    "Type-Declaration",
+		Opcode:   34,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -1169,6 +1233,8 @@ var (
 	}
 	OpTypeDeviceEvent = &Opcode {
 		Opname:   "OpTypeDeviceEvent",
+		Class:    "Type-Declaration",
+		Opcode:   35,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -1179,6 +1245,8 @@ var (
 	}
 	OpTypeReserveId = &Opcode {
 		Opname:   "OpTypeReserveId",
+		Class:    "Type-Declaration",
+		Opcode:   36,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -1189,6 +1257,8 @@ var (
 	}
 	OpTypeQueue = &Opcode {
 		Opname:   "OpTypeQueue",
+		Class:    "Type-Declaration",
+		Opcode:   37,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -1199,6 +1269,8 @@ var (
 	}
 	OpTypePipe = &Opcode {
 		Opname:   "OpTypePipe",
+		Class:    "Type-Declaration",
+		Opcode:   38,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -1214,6 +1286,8 @@ var (
 	}
 	OpTypeForwardPointer = &Opcode {
 		Opname:   "OpTypeForwardPointer",
+		Class:    "Type-Declaration",
+		Opcode:   39,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -1229,6 +1303,8 @@ var (
 	}
 	OpConstantTrue = &Opcode {
 		Opname:   "OpConstantTrue",
+		Class:    "Constant-Creation",
+		Opcode:   41,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1244,6 +1320,8 @@ var (
 	}
 	OpConstantFalse = &Opcode {
 		Opname:   "OpConstantFalse",
+		Class:    "Constant-Creation",
+		Opcode:   42,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1259,6 +1337,8 @@ var (
 	}
 	OpConstant = &Opcode {
 		Opname:   "OpConstant",
+		Class:    "Constant-Creation",
+		Opcode:   43,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1279,6 +1359,8 @@ var (
 	}
 	OpConstantComposite = &Opcode {
 		Opname:   "OpConstantComposite",
+		Class:    "Constant-Creation",
+		Opcode:   44,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1299,6 +1381,8 @@ var (
 	}
 	OpConstantSampler = &Opcode {
 		Opname:   "OpConstantSampler",
+		Class:    "Constant-Creation",
+		Opcode:   45,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1329,6 +1413,8 @@ var (
 	}
 	OpConstantNull = &Opcode {
 		Opname:   "OpConstantNull",
+		Class:    "Constant-Creation",
+		Opcode:   46,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1344,6 +1430,8 @@ var (
 	}
 	OpSpecConstantTrue = &Opcode {
 		Opname:   "OpSpecConstantTrue",
+		Class:    "Constant-Creation",
+		Opcode:   48,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1359,6 +1447,8 @@ var (
 	}
 	OpSpecConstantFalse = &Opcode {
 		Opname:   "OpSpecConstantFalse",
+		Class:    "Constant-Creation",
+		Opcode:   49,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1374,6 +1464,8 @@ var (
 	}
 	OpSpecConstant = &Opcode {
 		Opname:   "OpSpecConstant",
+		Class:    "Constant-Creation",
+		Opcode:   50,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1394,6 +1486,8 @@ var (
 	}
 	OpSpecConstantComposite = &Opcode {
 		Opname:   "OpSpecConstantComposite",
+		Class:    "Constant-Creation",
+		Opcode:   51,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1414,6 +1508,8 @@ var (
 	}
 	OpSpecConstantOp = &Opcode {
 		Opname:   "OpSpecConstantOp",
+		Class:    "Constant-Creation",
+		Opcode:   52,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1434,6 +1530,8 @@ var (
 	}
 	OpFunction = &Opcode {
 		Opname:   "OpFunction",
+		Class:    "Function",
+		Opcode:   54,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1459,6 +1557,8 @@ var (
 	}
 	OpFunctionParameter = &Opcode {
 		Opname:   "OpFunctionParameter",
+		Class:    "Function",
+		Opcode:   55,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1474,11 +1574,15 @@ var (
 	}
 	OpFunctionEnd = &Opcode {
 		Opname:   "OpFunctionEnd",
+		Class:    "Function",
+		Opcode:   56,
 		Operands: []Operand {
 		},
 	}
 	OpFunctionCall = &Opcode {
 		Opname:   "OpFunctionCall",
+		Class:    "Function",
+		Opcode:   57,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1504,6 +1608,8 @@ var (
 	}
 	OpVariable = &Opcode {
 		Opname:   "OpVariable",
+		Class:    "Memory",
+		Opcode:   59,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1529,6 +1635,8 @@ var (
 	}
 	OpImageTexelPointer = &Opcode {
 		Opname:   "OpImageTexelPointer",
+		Class:    "Memory",
+		Opcode:   60,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1559,6 +1667,8 @@ var (
 	}
 	OpLoad = &Opcode {
 		Opname:   "OpLoad",
+		Class:    "Memory",
+		Opcode:   61,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1584,6 +1694,8 @@ var (
 	}
 	OpStore = &Opcode {
 		Opname:   "OpStore",
+		Class:    "Memory",
+		Opcode:   62,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -1604,6 +1716,8 @@ var (
 	}
 	OpCopyMemory = &Opcode {
 		Opname:   "OpCopyMemory",
+		Class:    "Memory",
+		Opcode:   63,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -1629,6 +1743,8 @@ var (
 	}
 	OpCopyMemorySized = &Opcode {
 		Opname:   "OpCopyMemorySized",
+		Class:    "Memory",
+		Opcode:   64,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -1659,6 +1775,8 @@ var (
 	}
 	OpAccessChain = &Opcode {
 		Opname:   "OpAccessChain",
+		Class:    "Memory",
+		Opcode:   65,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1684,6 +1802,8 @@ var (
 	}
 	OpInBoundsAccessChain = &Opcode {
 		Opname:   "OpInBoundsAccessChain",
+		Class:    "Memory",
+		Opcode:   66,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1709,6 +1829,8 @@ var (
 	}
 	OpPtrAccessChain = &Opcode {
 		Opname:   "OpPtrAccessChain",
+		Class:    "Memory",
+		Opcode:   67,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1739,6 +1861,8 @@ var (
 	}
 	OpArrayLength = &Opcode {
 		Opname:   "OpArrayLength",
+		Class:    "Memory",
+		Opcode:   68,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1764,6 +1888,8 @@ var (
 	}
 	OpGenericPtrMemSemantics = &Opcode {
 		Opname:   "OpGenericPtrMemSemantics",
+		Class:    "Memory",
+		Opcode:   69,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1784,6 +1910,8 @@ var (
 	}
 	OpInBoundsPtrAccessChain = &Opcode {
 		Opname:   "OpInBoundsPtrAccessChain",
+		Class:    "Memory",
+		Opcode:   70,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1814,6 +1942,8 @@ var (
 	}
 	OpDecorate = &Opcode {
 		Opname:   "OpDecorate",
+		Class:    "Annotation",
+		Opcode:   71,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -1829,6 +1959,8 @@ var (
 	}
 	OpMemberDecorate = &Opcode {
 		Opname:   "OpMemberDecorate",
+		Class:    "Annotation",
+		Opcode:   72,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -1849,6 +1981,8 @@ var (
 	}
 	OpDecorationGroup = &Opcode {
 		Opname:   "OpDecorationGroup",
+		Class:    "Annotation",
+		Opcode:   73,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -1859,6 +1993,8 @@ var (
 	}
 	OpGroupDecorate = &Opcode {
 		Opname:   "OpGroupDecorate",
+		Class:    "Annotation",
+		Opcode:   74,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -1874,6 +2010,8 @@ var (
 	}
 	OpGroupMemberDecorate = &Opcode {
 		Opname:   "OpGroupMemberDecorate",
+		Class:    "Annotation",
+		Opcode:   75,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -1889,6 +2027,8 @@ var (
 	}
 	OpVectorExtractDynamic = &Opcode {
 		Opname:   "OpVectorExtractDynamic",
+		Class:    "Composite",
+		Opcode:   77,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1914,6 +2054,8 @@ var (
 	}
 	OpVectorInsertDynamic = &Opcode {
 		Opname:   "OpVectorInsertDynamic",
+		Class:    "Composite",
+		Opcode:   78,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1944,6 +2086,8 @@ var (
 	}
 	OpVectorShuffle = &Opcode {
 		Opname:   "OpVectorShuffle",
+		Class:    "Composite",
+		Opcode:   79,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1974,6 +2118,8 @@ var (
 	}
 	OpCompositeConstruct = &Opcode {
 		Opname:   "OpCompositeConstruct",
+		Class:    "Composite",
+		Opcode:   80,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -1994,6 +2140,8 @@ var (
 	}
 	OpCompositeExtract = &Opcode {
 		Opname:   "OpCompositeExtract",
+		Class:    "Composite",
+		Opcode:   81,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2019,6 +2167,8 @@ var (
 	}
 	OpCompositeInsert = &Opcode {
 		Opname:   "OpCompositeInsert",
+		Class:    "Composite",
+		Opcode:   82,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2049,6 +2199,8 @@ var (
 	}
 	OpCopyObject = &Opcode {
 		Opname:   "OpCopyObject",
+		Class:    "Composite",
+		Opcode:   83,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2069,6 +2221,8 @@ var (
 	}
 	OpTranspose = &Opcode {
 		Opname:   "OpTranspose",
+		Class:    "Composite",
+		Opcode:   84,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2089,6 +2243,8 @@ var (
 	}
 	OpSampledImage = &Opcode {
 		Opname:   "OpSampledImage",
+		Class:    "Image",
+		Opcode:   86,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2114,6 +2270,8 @@ var (
 	}
 	OpImageSampleImplicitLod = &Opcode {
 		Opname:   "OpImageSampleImplicitLod",
+		Class:    "Image",
+		Opcode:   87,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2144,6 +2302,8 @@ var (
 	}
 	OpImageSampleExplicitLod = &Opcode {
 		Opname:   "OpImageSampleExplicitLod",
+		Class:    "Image",
+		Opcode:   88,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2174,6 +2334,8 @@ var (
 	}
 	OpImageSampleDrefImplicitLod = &Opcode {
 		Opname:   "OpImageSampleDrefImplicitLod",
+		Class:    "Image",
+		Opcode:   89,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2209,6 +2371,8 @@ var (
 	}
 	OpImageSampleDrefExplicitLod = &Opcode {
 		Opname:   "OpImageSampleDrefExplicitLod",
+		Class:    "Image",
+		Opcode:   90,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2244,6 +2408,8 @@ var (
 	}
 	OpImageSampleProjImplicitLod = &Opcode {
 		Opname:   "OpImageSampleProjImplicitLod",
+		Class:    "Image",
+		Opcode:   91,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2274,6 +2440,8 @@ var (
 	}
 	OpImageSampleProjExplicitLod = &Opcode {
 		Opname:   "OpImageSampleProjExplicitLod",
+		Class:    "Image",
+		Opcode:   92,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2304,6 +2472,8 @@ var (
 	}
 	OpImageSampleProjDrefImplicitLod = &Opcode {
 		Opname:   "OpImageSampleProjDrefImplicitLod",
+		Class:    "Image",
+		Opcode:   93,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2339,6 +2509,8 @@ var (
 	}
 	OpImageSampleProjDrefExplicitLod = &Opcode {
 		Opname:   "OpImageSampleProjDrefExplicitLod",
+		Class:    "Image",
+		Opcode:   94,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2374,6 +2546,8 @@ var (
 	}
 	OpImageFetch = &Opcode {
 		Opname:   "OpImageFetch",
+		Class:    "Image",
+		Opcode:   95,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2404,6 +2578,8 @@ var (
 	}
 	OpImageGather = &Opcode {
 		Opname:   "OpImageGather",
+		Class:    "Image",
+		Opcode:   96,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2439,6 +2615,8 @@ var (
 	}
 	OpImageDrefGather = &Opcode {
 		Opname:   "OpImageDrefGather",
+		Class:    "Image",
+		Opcode:   97,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2474,6 +2652,8 @@ var (
 	}
 	OpImageRead = &Opcode {
 		Opname:   "OpImageRead",
+		Class:    "Image",
+		Opcode:   98,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2504,6 +2684,8 @@ var (
 	}
 	OpImageWrite = &Opcode {
 		Opname:   "OpImageWrite",
+		Class:    "Image",
+		Opcode:   99,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -2529,6 +2711,8 @@ var (
 	}
 	OpImage = &Opcode {
 		Opname:   "OpImage",
+		Class:    "Image",
+		Opcode:   100,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2549,6 +2733,8 @@ var (
 	}
 	OpImageQueryFormat = &Opcode {
 		Opname:   "OpImageQueryFormat",
+		Class:    "Image",
+		Opcode:   101,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2569,6 +2755,8 @@ var (
 	}
 	OpImageQueryOrder = &Opcode {
 		Opname:   "OpImageQueryOrder",
+		Class:    "Image",
+		Opcode:   102,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2589,6 +2777,8 @@ var (
 	}
 	OpImageQuerySizeLod = &Opcode {
 		Opname:   "OpImageQuerySizeLod",
+		Class:    "Image",
+		Opcode:   103,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2614,6 +2804,8 @@ var (
 	}
 	OpImageQuerySize = &Opcode {
 		Opname:   "OpImageQuerySize",
+		Class:    "Image",
+		Opcode:   104,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2634,6 +2826,8 @@ var (
 	}
 	OpImageQueryLod = &Opcode {
 		Opname:   "OpImageQueryLod",
+		Class:    "Image",
+		Opcode:   105,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2659,6 +2853,8 @@ var (
 	}
 	OpImageQueryLevels = &Opcode {
 		Opname:   "OpImageQueryLevels",
+		Class:    "Image",
+		Opcode:   106,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2679,6 +2875,8 @@ var (
 	}
 	OpImageQuerySamples = &Opcode {
 		Opname:   "OpImageQuerySamples",
+		Class:    "Image",
+		Opcode:   107,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2699,6 +2897,8 @@ var (
 	}
 	OpConvertFToU = &Opcode {
 		Opname:   "OpConvertFToU",
+		Class:    "Conversion",
+		Opcode:   109,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2719,6 +2919,8 @@ var (
 	}
 	OpConvertFToS = &Opcode {
 		Opname:   "OpConvertFToS",
+		Class:    "Conversion",
+		Opcode:   110,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2739,6 +2941,8 @@ var (
 	}
 	OpConvertSToF = &Opcode {
 		Opname:   "OpConvertSToF",
+		Class:    "Conversion",
+		Opcode:   111,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2759,6 +2963,8 @@ var (
 	}
 	OpConvertUToF = &Opcode {
 		Opname:   "OpConvertUToF",
+		Class:    "Conversion",
+		Opcode:   112,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2779,6 +2985,8 @@ var (
 	}
 	OpUConvert = &Opcode {
 		Opname:   "OpUConvert",
+		Class:    "Conversion",
+		Opcode:   113,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2799,6 +3007,8 @@ var (
 	}
 	OpSConvert = &Opcode {
 		Opname:   "OpSConvert",
+		Class:    "Conversion",
+		Opcode:   114,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2819,6 +3029,8 @@ var (
 	}
 	OpFConvert = &Opcode {
 		Opname:   "OpFConvert",
+		Class:    "Conversion",
+		Opcode:   115,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2839,6 +3051,8 @@ var (
 	}
 	OpQuantizeToF16 = &Opcode {
 		Opname:   "OpQuantizeToF16",
+		Class:    "Conversion",
+		Opcode:   116,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2859,6 +3073,8 @@ var (
 	}
 	OpConvertPtrToU = &Opcode {
 		Opname:   "OpConvertPtrToU",
+		Class:    "Conversion",
+		Opcode:   117,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2879,6 +3095,8 @@ var (
 	}
 	OpSatConvertSToU = &Opcode {
 		Opname:   "OpSatConvertSToU",
+		Class:    "Conversion",
+		Opcode:   118,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2899,6 +3117,8 @@ var (
 	}
 	OpSatConvertUToS = &Opcode {
 		Opname:   "OpSatConvertUToS",
+		Class:    "Conversion",
+		Opcode:   119,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2919,6 +3139,8 @@ var (
 	}
 	OpConvertUToPtr = &Opcode {
 		Opname:   "OpConvertUToPtr",
+		Class:    "Conversion",
+		Opcode:   120,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2939,6 +3161,8 @@ var (
 	}
 	OpPtrCastToGeneric = &Opcode {
 		Opname:   "OpPtrCastToGeneric",
+		Class:    "Conversion",
+		Opcode:   121,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2959,6 +3183,8 @@ var (
 	}
 	OpGenericCastToPtr = &Opcode {
 		Opname:   "OpGenericCastToPtr",
+		Class:    "Conversion",
+		Opcode:   122,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -2979,6 +3205,8 @@ var (
 	}
 	OpGenericCastToPtrExplicit = &Opcode {
 		Opname:   "OpGenericCastToPtrExplicit",
+		Class:    "Conversion",
+		Opcode:   123,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3004,6 +3232,8 @@ var (
 	}
 	OpBitcast = &Opcode {
 		Opname:   "OpBitcast",
+		Class:    "Conversion",
+		Opcode:   124,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3024,6 +3254,8 @@ var (
 	}
 	OpSNegate = &Opcode {
 		Opname:   "OpSNegate",
+		Class:    "Arithmetic",
+		Opcode:   126,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3044,6 +3276,8 @@ var (
 	}
 	OpFNegate = &Opcode {
 		Opname:   "OpFNegate",
+		Class:    "Arithmetic",
+		Opcode:   127,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3064,6 +3298,8 @@ var (
 	}
 	OpIAdd = &Opcode {
 		Opname:   "OpIAdd",
+		Class:    "Arithmetic",
+		Opcode:   128,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3089,6 +3325,8 @@ var (
 	}
 	OpFAdd = &Opcode {
 		Opname:   "OpFAdd",
+		Class:    "Arithmetic",
+		Opcode:   129,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3114,6 +3352,8 @@ var (
 	}
 	OpISub = &Opcode {
 		Opname:   "OpISub",
+		Class:    "Arithmetic",
+		Opcode:   130,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3139,6 +3379,8 @@ var (
 	}
 	OpFSub = &Opcode {
 		Opname:   "OpFSub",
+		Class:    "Arithmetic",
+		Opcode:   131,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3164,6 +3406,8 @@ var (
 	}
 	OpIMul = &Opcode {
 		Opname:   "OpIMul",
+		Class:    "Arithmetic",
+		Opcode:   132,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3189,6 +3433,8 @@ var (
 	}
 	OpFMul = &Opcode {
 		Opname:   "OpFMul",
+		Class:    "Arithmetic",
+		Opcode:   133,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3214,6 +3460,8 @@ var (
 	}
 	OpUDiv = &Opcode {
 		Opname:   "OpUDiv",
+		Class:    "Arithmetic",
+		Opcode:   134,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3239,6 +3487,8 @@ var (
 	}
 	OpSDiv = &Opcode {
 		Opname:   "OpSDiv",
+		Class:    "Arithmetic",
+		Opcode:   135,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3264,6 +3514,8 @@ var (
 	}
 	OpFDiv = &Opcode {
 		Opname:   "OpFDiv",
+		Class:    "Arithmetic",
+		Opcode:   136,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3289,6 +3541,8 @@ var (
 	}
 	OpUMod = &Opcode {
 		Opname:   "OpUMod",
+		Class:    "Arithmetic",
+		Opcode:   137,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3314,6 +3568,8 @@ var (
 	}
 	OpSRem = &Opcode {
 		Opname:   "OpSRem",
+		Class:    "Arithmetic",
+		Opcode:   138,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3339,6 +3595,8 @@ var (
 	}
 	OpSMod = &Opcode {
 		Opname:   "OpSMod",
+		Class:    "Arithmetic",
+		Opcode:   139,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3364,6 +3622,8 @@ var (
 	}
 	OpFRem = &Opcode {
 		Opname:   "OpFRem",
+		Class:    "Arithmetic",
+		Opcode:   140,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3389,6 +3649,8 @@ var (
 	}
 	OpFMod = &Opcode {
 		Opname:   "OpFMod",
+		Class:    "Arithmetic",
+		Opcode:   141,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3414,6 +3676,8 @@ var (
 	}
 	OpVectorTimesScalar = &Opcode {
 		Opname:   "OpVectorTimesScalar",
+		Class:    "Arithmetic",
+		Opcode:   142,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3439,6 +3703,8 @@ var (
 	}
 	OpMatrixTimesScalar = &Opcode {
 		Opname:   "OpMatrixTimesScalar",
+		Class:    "Arithmetic",
+		Opcode:   143,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3464,6 +3730,8 @@ var (
 	}
 	OpVectorTimesMatrix = &Opcode {
 		Opname:   "OpVectorTimesMatrix",
+		Class:    "Arithmetic",
+		Opcode:   144,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3489,6 +3757,8 @@ var (
 	}
 	OpMatrixTimesVector = &Opcode {
 		Opname:   "OpMatrixTimesVector",
+		Class:    "Arithmetic",
+		Opcode:   145,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3514,6 +3784,8 @@ var (
 	}
 	OpMatrixTimesMatrix = &Opcode {
 		Opname:   "OpMatrixTimesMatrix",
+		Class:    "Arithmetic",
+		Opcode:   146,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3539,6 +3811,8 @@ var (
 	}
 	OpOuterProduct = &Opcode {
 		Opname:   "OpOuterProduct",
+		Class:    "Arithmetic",
+		Opcode:   147,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3564,6 +3838,8 @@ var (
 	}
 	OpDot = &Opcode {
 		Opname:   "OpDot",
+		Class:    "Arithmetic",
+		Opcode:   148,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3589,6 +3865,8 @@ var (
 	}
 	OpIAddCarry = &Opcode {
 		Opname:   "OpIAddCarry",
+		Class:    "Arithmetic",
+		Opcode:   149,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3614,6 +3892,8 @@ var (
 	}
 	OpISubBorrow = &Opcode {
 		Opname:   "OpISubBorrow",
+		Class:    "Arithmetic",
+		Opcode:   150,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3639,6 +3919,8 @@ var (
 	}
 	OpUMulExtended = &Opcode {
 		Opname:   "OpUMulExtended",
+		Class:    "Arithmetic",
+		Opcode:   151,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3664,6 +3946,8 @@ var (
 	}
 	OpSMulExtended = &Opcode {
 		Opname:   "OpSMulExtended",
+		Class:    "Arithmetic",
+		Opcode:   152,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3689,6 +3973,8 @@ var (
 	}
 	OpAny = &Opcode {
 		Opname:   "OpAny",
+		Class:    "Relational_and_Logical",
+		Opcode:   154,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3709,6 +3995,8 @@ var (
 	}
 	OpAll = &Opcode {
 		Opname:   "OpAll",
+		Class:    "Relational_and_Logical",
+		Opcode:   155,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3729,6 +4017,8 @@ var (
 	}
 	OpIsNan = &Opcode {
 		Opname:   "OpIsNan",
+		Class:    "Relational_and_Logical",
+		Opcode:   156,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3749,6 +4039,8 @@ var (
 	}
 	OpIsInf = &Opcode {
 		Opname:   "OpIsInf",
+		Class:    "Relational_and_Logical",
+		Opcode:   157,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3769,6 +4061,8 @@ var (
 	}
 	OpIsFinite = &Opcode {
 		Opname:   "OpIsFinite",
+		Class:    "Relational_and_Logical",
+		Opcode:   158,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3789,6 +4083,8 @@ var (
 	}
 	OpIsNormal = &Opcode {
 		Opname:   "OpIsNormal",
+		Class:    "Relational_and_Logical",
+		Opcode:   159,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3809,6 +4105,8 @@ var (
 	}
 	OpSignBitSet = &Opcode {
 		Opname:   "OpSignBitSet",
+		Class:    "Relational_and_Logical",
+		Opcode:   160,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3829,6 +4127,8 @@ var (
 	}
 	OpLessOrGreater = &Opcode {
 		Opname:   "OpLessOrGreater",
+		Class:    "Relational_and_Logical",
+		Opcode:   161,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3854,6 +4154,8 @@ var (
 	}
 	OpOrdered = &Opcode {
 		Opname:   "OpOrdered",
+		Class:    "Relational_and_Logical",
+		Opcode:   162,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3879,6 +4181,8 @@ var (
 	}
 	OpUnordered = &Opcode {
 		Opname:   "OpUnordered",
+		Class:    "Relational_and_Logical",
+		Opcode:   163,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3904,6 +4208,8 @@ var (
 	}
 	OpLogicalEqual = &Opcode {
 		Opname:   "OpLogicalEqual",
+		Class:    "Relational_and_Logical",
+		Opcode:   164,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3929,6 +4235,8 @@ var (
 	}
 	OpLogicalNotEqual = &Opcode {
 		Opname:   "OpLogicalNotEqual",
+		Class:    "Relational_and_Logical",
+		Opcode:   165,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3954,6 +4262,8 @@ var (
 	}
 	OpLogicalOr = &Opcode {
 		Opname:   "OpLogicalOr",
+		Class:    "Relational_and_Logical",
+		Opcode:   166,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -3979,6 +4289,8 @@ var (
 	}
 	OpLogicalAnd = &Opcode {
 		Opname:   "OpLogicalAnd",
+		Class:    "Relational_and_Logical",
+		Opcode:   167,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4004,6 +4316,8 @@ var (
 	}
 	OpLogicalNot = &Opcode {
 		Opname:   "OpLogicalNot",
+		Class:    "Relational_and_Logical",
+		Opcode:   168,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4024,6 +4338,8 @@ var (
 	}
 	OpSelect = &Opcode {
 		Opname:   "OpSelect",
+		Class:    "Relational_and_Logical",
+		Opcode:   169,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4054,6 +4370,8 @@ var (
 	}
 	OpIEqual = &Opcode {
 		Opname:   "OpIEqual",
+		Class:    "Relational_and_Logical",
+		Opcode:   170,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4079,6 +4397,8 @@ var (
 	}
 	OpINotEqual = &Opcode {
 		Opname:   "OpINotEqual",
+		Class:    "Relational_and_Logical",
+		Opcode:   171,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4104,6 +4424,8 @@ var (
 	}
 	OpUGreaterThan = &Opcode {
 		Opname:   "OpUGreaterThan",
+		Class:    "Relational_and_Logical",
+		Opcode:   172,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4129,6 +4451,8 @@ var (
 	}
 	OpSGreaterThan = &Opcode {
 		Opname:   "OpSGreaterThan",
+		Class:    "Relational_and_Logical",
+		Opcode:   173,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4154,6 +4478,8 @@ var (
 	}
 	OpUGreaterThanEqual = &Opcode {
 		Opname:   "OpUGreaterThanEqual",
+		Class:    "Relational_and_Logical",
+		Opcode:   174,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4179,6 +4505,8 @@ var (
 	}
 	OpSGreaterThanEqual = &Opcode {
 		Opname:   "OpSGreaterThanEqual",
+		Class:    "Relational_and_Logical",
+		Opcode:   175,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4204,6 +4532,8 @@ var (
 	}
 	OpULessThan = &Opcode {
 		Opname:   "OpULessThan",
+		Class:    "Relational_and_Logical",
+		Opcode:   176,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4229,6 +4559,8 @@ var (
 	}
 	OpSLessThan = &Opcode {
 		Opname:   "OpSLessThan",
+		Class:    "Relational_and_Logical",
+		Opcode:   177,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4254,6 +4586,8 @@ var (
 	}
 	OpULessThanEqual = &Opcode {
 		Opname:   "OpULessThanEqual",
+		Class:    "Relational_and_Logical",
+		Opcode:   178,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4279,6 +4613,8 @@ var (
 	}
 	OpSLessThanEqual = &Opcode {
 		Opname:   "OpSLessThanEqual",
+		Class:    "Relational_and_Logical",
+		Opcode:   179,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4304,6 +4640,8 @@ var (
 	}
 	OpFOrdEqual = &Opcode {
 		Opname:   "OpFOrdEqual",
+		Class:    "Relational_and_Logical",
+		Opcode:   180,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4329,6 +4667,8 @@ var (
 	}
 	OpFUnordEqual = &Opcode {
 		Opname:   "OpFUnordEqual",
+		Class:    "Relational_and_Logical",
+		Opcode:   181,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4354,6 +4694,8 @@ var (
 	}
 	OpFOrdNotEqual = &Opcode {
 		Opname:   "OpFOrdNotEqual",
+		Class:    "Relational_and_Logical",
+		Opcode:   182,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4379,6 +4721,8 @@ var (
 	}
 	OpFUnordNotEqual = &Opcode {
 		Opname:   "OpFUnordNotEqual",
+		Class:    "Relational_and_Logical",
+		Opcode:   183,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4404,6 +4748,8 @@ var (
 	}
 	OpFOrdLessThan = &Opcode {
 		Opname:   "OpFOrdLessThan",
+		Class:    "Relational_and_Logical",
+		Opcode:   184,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4429,6 +4775,8 @@ var (
 	}
 	OpFUnordLessThan = &Opcode {
 		Opname:   "OpFUnordLessThan",
+		Class:    "Relational_and_Logical",
+		Opcode:   185,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4454,6 +4802,8 @@ var (
 	}
 	OpFOrdGreaterThan = &Opcode {
 		Opname:   "OpFOrdGreaterThan",
+		Class:    "Relational_and_Logical",
+		Opcode:   186,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4479,6 +4829,8 @@ var (
 	}
 	OpFUnordGreaterThan = &Opcode {
 		Opname:   "OpFUnordGreaterThan",
+		Class:    "Relational_and_Logical",
+		Opcode:   187,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4504,6 +4856,8 @@ var (
 	}
 	OpFOrdLessThanEqual = &Opcode {
 		Opname:   "OpFOrdLessThanEqual",
+		Class:    "Relational_and_Logical",
+		Opcode:   188,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4529,6 +4883,8 @@ var (
 	}
 	OpFUnordLessThanEqual = &Opcode {
 		Opname:   "OpFUnordLessThanEqual",
+		Class:    "Relational_and_Logical",
+		Opcode:   189,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4554,6 +4910,8 @@ var (
 	}
 	OpFOrdGreaterThanEqual = &Opcode {
 		Opname:   "OpFOrdGreaterThanEqual",
+		Class:    "Relational_and_Logical",
+		Opcode:   190,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4579,6 +4937,8 @@ var (
 	}
 	OpFUnordGreaterThanEqual = &Opcode {
 		Opname:   "OpFUnordGreaterThanEqual",
+		Class:    "Relational_and_Logical",
+		Opcode:   191,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4604,6 +4964,8 @@ var (
 	}
 	OpShiftRightLogical = &Opcode {
 		Opname:   "OpShiftRightLogical",
+		Class:    "Bit",
+		Opcode:   194,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4629,6 +4991,8 @@ var (
 	}
 	OpShiftRightArithmetic = &Opcode {
 		Opname:   "OpShiftRightArithmetic",
+		Class:    "Bit",
+		Opcode:   195,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4654,6 +5018,8 @@ var (
 	}
 	OpShiftLeftLogical = &Opcode {
 		Opname:   "OpShiftLeftLogical",
+		Class:    "Bit",
+		Opcode:   196,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4679,6 +5045,8 @@ var (
 	}
 	OpBitwiseOr = &Opcode {
 		Opname:   "OpBitwiseOr",
+		Class:    "Bit",
+		Opcode:   197,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4704,6 +5072,8 @@ var (
 	}
 	OpBitwiseXor = &Opcode {
 		Opname:   "OpBitwiseXor",
+		Class:    "Bit",
+		Opcode:   198,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4729,6 +5099,8 @@ var (
 	}
 	OpBitwiseAnd = &Opcode {
 		Opname:   "OpBitwiseAnd",
+		Class:    "Bit",
+		Opcode:   199,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4754,6 +5126,8 @@ var (
 	}
 	OpNot = &Opcode {
 		Opname:   "OpNot",
+		Class:    "Bit",
+		Opcode:   200,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4774,6 +5148,8 @@ var (
 	}
 	OpBitFieldInsert = &Opcode {
 		Opname:   "OpBitFieldInsert",
+		Class:    "Bit",
+		Opcode:   201,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4809,6 +5185,8 @@ var (
 	}
 	OpBitFieldSExtract = &Opcode {
 		Opname:   "OpBitFieldSExtract",
+		Class:    "Bit",
+		Opcode:   202,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4839,6 +5217,8 @@ var (
 	}
 	OpBitFieldUExtract = &Opcode {
 		Opname:   "OpBitFieldUExtract",
+		Class:    "Bit",
+		Opcode:   203,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4869,6 +5249,8 @@ var (
 	}
 	OpBitReverse = &Opcode {
 		Opname:   "OpBitReverse",
+		Class:    "Bit",
+		Opcode:   204,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4889,6 +5271,8 @@ var (
 	}
 	OpBitCount = &Opcode {
 		Opname:   "OpBitCount",
+		Class:    "Bit",
+		Opcode:   205,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4909,6 +5293,8 @@ var (
 	}
 	OpDPdx = &Opcode {
 		Opname:   "OpDPdx",
+		Class:    "Derivative",
+		Opcode:   207,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4929,6 +5315,8 @@ var (
 	}
 	OpDPdy = &Opcode {
 		Opname:   "OpDPdy",
+		Class:    "Derivative",
+		Opcode:   208,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4949,6 +5337,8 @@ var (
 	}
 	OpFwidth = &Opcode {
 		Opname:   "OpFwidth",
+		Class:    "Derivative",
+		Opcode:   209,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4969,6 +5359,8 @@ var (
 	}
 	OpDPdxFine = &Opcode {
 		Opname:   "OpDPdxFine",
+		Class:    "Derivative",
+		Opcode:   210,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -4989,6 +5381,8 @@ var (
 	}
 	OpDPdyFine = &Opcode {
 		Opname:   "OpDPdyFine",
+		Class:    "Derivative",
+		Opcode:   211,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5009,6 +5403,8 @@ var (
 	}
 	OpFwidthFine = &Opcode {
 		Opname:   "OpFwidthFine",
+		Class:    "Derivative",
+		Opcode:   212,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5029,6 +5425,8 @@ var (
 	}
 	OpDPdxCoarse = &Opcode {
 		Opname:   "OpDPdxCoarse",
+		Class:    "Derivative",
+		Opcode:   213,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5049,6 +5447,8 @@ var (
 	}
 	OpDPdyCoarse = &Opcode {
 		Opname:   "OpDPdyCoarse",
+		Class:    "Derivative",
+		Opcode:   214,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5069,6 +5469,8 @@ var (
 	}
 	OpFwidthCoarse = &Opcode {
 		Opname:   "OpFwidthCoarse",
+		Class:    "Derivative",
+		Opcode:   215,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5089,16 +5491,22 @@ var (
 	}
 	OpEmitVertex = &Opcode {
 		Opname:   "OpEmitVertex",
+		Class:    "Primitive",
+		Opcode:   218,
 		Operands: []Operand {
 		},
 	}
 	OpEndPrimitive = &Opcode {
 		Opname:   "OpEndPrimitive",
+		Class:    "Primitive",
+		Opcode:   219,
 		Operands: []Operand {
 		},
 	}
 	OpEmitStreamVertex = &Opcode {
 		Opname:   "OpEmitStreamVertex",
+		Class:    "Primitive",
+		Opcode:   220,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -5109,6 +5517,8 @@ var (
 	}
 	OpEndStreamPrimitive = &Opcode {
 		Opname:   "OpEndStreamPrimitive",
+		Class:    "Primitive",
+		Opcode:   221,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -5119,6 +5529,8 @@ var (
 	}
 	OpControlBarrier = &Opcode {
 		Opname:   "OpControlBarrier",
+		Class:    "Barrier",
+		Opcode:   224,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdScope,
@@ -5139,6 +5551,8 @@ var (
 	}
 	OpMemoryBarrier = &Opcode {
 		Opname:   "OpMemoryBarrier",
+		Class:    "Barrier",
+		Opcode:   225,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdScope,
@@ -5154,6 +5568,8 @@ var (
 	}
 	OpAtomicLoad = &Opcode {
 		Opname:   "OpAtomicLoad",
+		Class:    "Atomic",
+		Opcode:   227,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5184,6 +5600,8 @@ var (
 	}
 	OpAtomicStore = &Opcode {
 		Opname:   "OpAtomicStore",
+		Class:    "Atomic",
+		Opcode:   228,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -5209,6 +5627,8 @@ var (
 	}
 	OpAtomicExchange = &Opcode {
 		Opname:   "OpAtomicExchange",
+		Class:    "Atomic",
+		Opcode:   229,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5244,6 +5664,8 @@ var (
 	}
 	OpAtomicCompareExchange = &Opcode {
 		Opname:   "OpAtomicCompareExchange",
+		Class:    "Atomic",
+		Opcode:   230,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5289,6 +5711,8 @@ var (
 	}
 	OpAtomicCompareExchangeWeak = &Opcode {
 		Opname:   "OpAtomicCompareExchangeWeak",
+		Class:    "Atomic",
+		Opcode:   231,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5334,6 +5758,8 @@ var (
 	}
 	OpAtomicIIncrement = &Opcode {
 		Opname:   "OpAtomicIIncrement",
+		Class:    "Atomic",
+		Opcode:   232,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5364,6 +5790,8 @@ var (
 	}
 	OpAtomicIDecrement = &Opcode {
 		Opname:   "OpAtomicIDecrement",
+		Class:    "Atomic",
+		Opcode:   233,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5394,6 +5822,8 @@ var (
 	}
 	OpAtomicIAdd = &Opcode {
 		Opname:   "OpAtomicIAdd",
+		Class:    "Atomic",
+		Opcode:   234,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5429,6 +5859,8 @@ var (
 	}
 	OpAtomicISub = &Opcode {
 		Opname:   "OpAtomicISub",
+		Class:    "Atomic",
+		Opcode:   235,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5464,6 +5896,8 @@ var (
 	}
 	OpAtomicSMin = &Opcode {
 		Opname:   "OpAtomicSMin",
+		Class:    "Atomic",
+		Opcode:   236,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5499,6 +5933,8 @@ var (
 	}
 	OpAtomicUMin = &Opcode {
 		Opname:   "OpAtomicUMin",
+		Class:    "Atomic",
+		Opcode:   237,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5534,6 +5970,8 @@ var (
 	}
 	OpAtomicSMax = &Opcode {
 		Opname:   "OpAtomicSMax",
+		Class:    "Atomic",
+		Opcode:   238,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5569,6 +6007,8 @@ var (
 	}
 	OpAtomicUMax = &Opcode {
 		Opname:   "OpAtomicUMax",
+		Class:    "Atomic",
+		Opcode:   239,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5604,6 +6044,8 @@ var (
 	}
 	OpAtomicAnd = &Opcode {
 		Opname:   "OpAtomicAnd",
+		Class:    "Atomic",
+		Opcode:   240,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5639,6 +6081,8 @@ var (
 	}
 	OpAtomicOr = &Opcode {
 		Opname:   "OpAtomicOr",
+		Class:    "Atomic",
+		Opcode:   241,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5674,6 +6118,8 @@ var (
 	}
 	OpAtomicXor = &Opcode {
 		Opname:   "OpAtomicXor",
+		Class:    "Atomic",
+		Opcode:   242,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5709,6 +6155,8 @@ var (
 	}
 	OpPhi = &Opcode {
 		Opname:   "OpPhi",
+		Class:    "Control-Flow",
+		Opcode:   245,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5729,6 +6177,8 @@ var (
 	}
 	OpLoopMerge = &Opcode {
 		Opname:   "OpLoopMerge",
+		Class:    "Control-Flow",
+		Opcode:   246,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -5749,6 +6199,8 @@ var (
 	}
 	OpSelectionMerge = &Opcode {
 		Opname:   "OpSelectionMerge",
+		Class:    "Control-Flow",
+		Opcode:   247,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -5764,6 +6216,8 @@ var (
 	}
 	OpLabel = &Opcode {
 		Opname:   "OpLabel",
+		Class:    "Control-Flow",
+		Opcode:   248,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -5774,6 +6228,8 @@ var (
 	}
 	OpBranch = &Opcode {
 		Opname:   "OpBranch",
+		Class:    "Control-Flow",
+		Opcode:   249,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -5784,6 +6240,8 @@ var (
 	}
 	OpBranchConditional = &Opcode {
 		Opname:   "OpBranchConditional",
+		Class:    "Control-Flow",
+		Opcode:   250,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -5809,6 +6267,8 @@ var (
 	}
 	OpSwitch = &Opcode {
 		Opname:   "OpSwitch",
+		Class:    "Control-Flow",
+		Opcode:   251,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -5829,16 +6289,22 @@ var (
 	}
 	OpKill = &Opcode {
 		Opname:   "OpKill",
+		Class:    "Control-Flow",
+		Opcode:   252,
 		Operands: []Operand {
 		},
 	}
 	OpReturn = &Opcode {
 		Opname:   "OpReturn",
+		Class:    "Control-Flow",
+		Opcode:   253,
 		Operands: []Operand {
 		},
 	}
 	OpReturnValue = &Opcode {
 		Opname:   "OpReturnValue",
+		Class:    "Control-Flow",
+		Opcode:   254,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -5849,11 +6315,15 @@ var (
 	}
 	OpUnreachable = &Opcode {
 		Opname:   "OpUnreachable",
+		Class:    "Control-Flow",
+		Opcode:   255,
 		Operands: []Operand {
 		},
 	}
 	OpLifetimeStart = &Opcode {
 		Opname:   "OpLifetimeStart",
+		Class:    "Control-Flow",
+		Opcode:   256,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -5869,6 +6339,8 @@ var (
 	}
 	OpLifetimeStop = &Opcode {
 		Opname:   "OpLifetimeStop",
+		Class:    "Control-Flow",
+		Opcode:   257,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -5884,6 +6356,8 @@ var (
 	}
 	OpGroupAsyncCopy = &Opcode {
 		Opname:   "OpGroupAsyncCopy",
+		Class:    "Group",
+		Opcode:   259,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5929,6 +6403,8 @@ var (
 	}
 	OpGroupWaitEvents = &Opcode {
 		Opname:   "OpGroupWaitEvents",
+		Class:    "Group",
+		Opcode:   260,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdScope,
@@ -5949,6 +6425,8 @@ var (
 	}
 	OpGroupAll = &Opcode {
 		Opname:   "OpGroupAll",
+		Class:    "Group",
+		Opcode:   261,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5974,6 +6452,8 @@ var (
 	}
 	OpGroupAny = &Opcode {
 		Opname:   "OpGroupAny",
+		Class:    "Group",
+		Opcode:   262,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -5999,6 +6479,8 @@ var (
 	}
 	OpGroupBroadcast = &Opcode {
 		Opname:   "OpGroupBroadcast",
+		Class:    "Group",
+		Opcode:   263,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6029,6 +6511,8 @@ var (
 	}
 	OpGroupIAdd = &Opcode {
 		Opname:   "OpGroupIAdd",
+		Class:    "Group",
+		Opcode:   264,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6059,6 +6543,8 @@ var (
 	}
 	OpGroupFAdd = &Opcode {
 		Opname:   "OpGroupFAdd",
+		Class:    "Group",
+		Opcode:   265,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6089,6 +6575,8 @@ var (
 	}
 	OpGroupFMin = &Opcode {
 		Opname:   "OpGroupFMin",
+		Class:    "Group",
+		Opcode:   266,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6119,6 +6607,8 @@ var (
 	}
 	OpGroupUMin = &Opcode {
 		Opname:   "OpGroupUMin",
+		Class:    "Group",
+		Opcode:   267,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6149,6 +6639,8 @@ var (
 	}
 	OpGroupSMin = &Opcode {
 		Opname:   "OpGroupSMin",
+		Class:    "Group",
+		Opcode:   268,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6179,6 +6671,8 @@ var (
 	}
 	OpGroupFMax = &Opcode {
 		Opname:   "OpGroupFMax",
+		Class:    "Group",
+		Opcode:   269,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6209,6 +6703,8 @@ var (
 	}
 	OpGroupUMax = &Opcode {
 		Opname:   "OpGroupUMax",
+		Class:    "Group",
+		Opcode:   270,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6239,6 +6735,8 @@ var (
 	}
 	OpGroupSMax = &Opcode {
 		Opname:   "OpGroupSMax",
+		Class:    "Group",
+		Opcode:   271,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6269,6 +6767,8 @@ var (
 	}
 	OpReadPipe = &Opcode {
 		Opname:   "OpReadPipe",
+		Class:    "Pipe",
+		Opcode:   274,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6304,6 +6804,8 @@ var (
 	}
 	OpWritePipe = &Opcode {
 		Opname:   "OpWritePipe",
+		Class:    "Pipe",
+		Opcode:   275,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6339,6 +6841,8 @@ var (
 	}
 	OpReservedReadPipe = &Opcode {
 		Opname:   "OpReservedReadPipe",
+		Class:    "Pipe",
+		Opcode:   276,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6384,6 +6888,8 @@ var (
 	}
 	OpReservedWritePipe = &Opcode {
 		Opname:   "OpReservedWritePipe",
+		Class:    "Pipe",
+		Opcode:   277,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6429,6 +6935,8 @@ var (
 	}
 	OpReserveReadPipePackets = &Opcode {
 		Opname:   "OpReserveReadPipePackets",
+		Class:    "Pipe",
+		Opcode:   278,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6464,6 +6972,8 @@ var (
 	}
 	OpReserveWritePipePackets = &Opcode {
 		Opname:   "OpReserveWritePipePackets",
+		Class:    "Pipe",
+		Opcode:   279,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6499,6 +7009,8 @@ var (
 	}
 	OpCommitReadPipe = &Opcode {
 		Opname:   "OpCommitReadPipe",
+		Class:    "Pipe",
+		Opcode:   280,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -6524,6 +7036,8 @@ var (
 	}
 	OpCommitWritePipe = &Opcode {
 		Opname:   "OpCommitWritePipe",
+		Class:    "Pipe",
+		Opcode:   281,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -6549,6 +7063,8 @@ var (
 	}
 	OpIsValidReserveId = &Opcode {
 		Opname:   "OpIsValidReserveId",
+		Class:    "Pipe",
+		Opcode:   282,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6569,6 +7085,8 @@ var (
 	}
 	OpGetNumPipePackets = &Opcode {
 		Opname:   "OpGetNumPipePackets",
+		Class:    "Pipe",
+		Opcode:   283,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6599,6 +7117,8 @@ var (
 	}
 	OpGetMaxPipePackets = &Opcode {
 		Opname:   "OpGetMaxPipePackets",
+		Class:    "Pipe",
+		Opcode:   284,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6629,6 +7149,8 @@ var (
 	}
 	OpGroupReserveReadPipePackets = &Opcode {
 		Opname:   "OpGroupReserveReadPipePackets",
+		Class:    "Pipe",
+		Opcode:   285,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6669,6 +7191,8 @@ var (
 	}
 	OpGroupReserveWritePipePackets = &Opcode {
 		Opname:   "OpGroupReserveWritePipePackets",
+		Class:    "Pipe",
+		Opcode:   286,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6709,6 +7233,8 @@ var (
 	}
 	OpGroupCommitReadPipe = &Opcode {
 		Opname:   "OpGroupCommitReadPipe",
+		Class:    "Pipe",
+		Opcode:   287,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdScope,
@@ -6739,6 +7265,8 @@ var (
 	}
 	OpGroupCommitWritePipe = &Opcode {
 		Opname:   "OpGroupCommitWritePipe",
+		Class:    "Pipe",
+		Opcode:   288,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdScope,
@@ -6769,6 +7297,8 @@ var (
 	}
 	OpEnqueueMarker = &Opcode {
 		Opname:   "OpEnqueueMarker",
+		Class:    "Device-Side_Enqueue",
+		Opcode:   291,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6804,6 +7334,8 @@ var (
 	}
 	OpEnqueueKernel = &Opcode {
 		Opname:   "OpEnqueueKernel",
+		Class:    "Device-Side_Enqueue",
+		Opcode:   292,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6874,6 +7406,8 @@ var (
 	}
 	OpGetKernelNDrangeSubGroupCount = &Opcode {
 		Opname:   "OpGetKernelNDrangeSubGroupCount",
+		Class:    "Device-Side_Enqueue",
+		Opcode:   293,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6914,6 +7448,8 @@ var (
 	}
 	OpGetKernelNDrangeMaxSubGroupSize = &Opcode {
 		Opname:   "OpGetKernelNDrangeMaxSubGroupSize",
+		Class:    "Device-Side_Enqueue",
+		Opcode:   294,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6954,6 +7490,8 @@ var (
 	}
 	OpGetKernelWorkGroupSize = &Opcode {
 		Opname:   "OpGetKernelWorkGroupSize",
+		Class:    "Device-Side_Enqueue",
+		Opcode:   295,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -6989,6 +7527,8 @@ var (
 	}
 	OpGetKernelPreferredWorkGroupSizeMultiple = &Opcode {
 		Opname:   "OpGetKernelPreferredWorkGroupSizeMultiple",
+		Class:    "Device-Side_Enqueue",
+		Opcode:   296,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7024,6 +7564,8 @@ var (
 	}
 	OpRetainEvent = &Opcode {
 		Opname:   "OpRetainEvent",
+		Class:    "Device-Side_Enqueue",
+		Opcode:   297,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -7034,6 +7576,8 @@ var (
 	}
 	OpReleaseEvent = &Opcode {
 		Opname:   "OpReleaseEvent",
+		Class:    "Device-Side_Enqueue",
+		Opcode:   298,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -7044,6 +7588,8 @@ var (
 	}
 	OpCreateUserEvent = &Opcode {
 		Opname:   "OpCreateUserEvent",
+		Class:    "Device-Side_Enqueue",
+		Opcode:   299,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7059,6 +7605,8 @@ var (
 	}
 	OpIsValidEvent = &Opcode {
 		Opname:   "OpIsValidEvent",
+		Class:    "Device-Side_Enqueue",
+		Opcode:   300,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7079,6 +7627,8 @@ var (
 	}
 	OpSetUserEventStatus = &Opcode {
 		Opname:   "OpSetUserEventStatus",
+		Class:    "Device-Side_Enqueue",
+		Opcode:   301,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -7094,6 +7644,8 @@ var (
 	}
 	OpCaptureEventProfilingInfo = &Opcode {
 		Opname:   "OpCaptureEventProfilingInfo",
+		Class:    "Device-Side_Enqueue",
+		Opcode:   302,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -7114,6 +7666,8 @@ var (
 	}
 	OpGetDefaultQueue = &Opcode {
 		Opname:   "OpGetDefaultQueue",
+		Class:    "Device-Side_Enqueue",
+		Opcode:   303,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7129,6 +7683,8 @@ var (
 	}
 	OpBuildNDRange = &Opcode {
 		Opname:   "OpBuildNDRange",
+		Class:    "Device-Side_Enqueue",
+		Opcode:   304,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7159,6 +7715,8 @@ var (
 	}
 	OpImageSparseSampleImplicitLod = &Opcode {
 		Opname:   "OpImageSparseSampleImplicitLod",
+		Class:    "Image",
+		Opcode:   305,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7189,6 +7747,8 @@ var (
 	}
 	OpImageSparseSampleExplicitLod = &Opcode {
 		Opname:   "OpImageSparseSampleExplicitLod",
+		Class:    "Image",
+		Opcode:   306,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7219,6 +7779,8 @@ var (
 	}
 	OpImageSparseSampleDrefImplicitLod = &Opcode {
 		Opname:   "OpImageSparseSampleDrefImplicitLod",
+		Class:    "Image",
+		Opcode:   307,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7254,6 +7816,8 @@ var (
 	}
 	OpImageSparseSampleDrefExplicitLod = &Opcode {
 		Opname:   "OpImageSparseSampleDrefExplicitLod",
+		Class:    "Image",
+		Opcode:   308,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7289,6 +7853,8 @@ var (
 	}
 	OpImageSparseSampleProjImplicitLod = &Opcode {
 		Opname:   "OpImageSparseSampleProjImplicitLod",
+		Class:    "Image",
+		Opcode:   309,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7319,6 +7885,8 @@ var (
 	}
 	OpImageSparseSampleProjExplicitLod = &Opcode {
 		Opname:   "OpImageSparseSampleProjExplicitLod",
+		Class:    "Image",
+		Opcode:   310,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7349,6 +7917,8 @@ var (
 	}
 	OpImageSparseSampleProjDrefImplicitLod = &Opcode {
 		Opname:   "OpImageSparseSampleProjDrefImplicitLod",
+		Class:    "Image",
+		Opcode:   311,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7384,6 +7954,8 @@ var (
 	}
 	OpImageSparseSampleProjDrefExplicitLod = &Opcode {
 		Opname:   "OpImageSparseSampleProjDrefExplicitLod",
+		Class:    "Image",
+		Opcode:   312,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7419,6 +7991,8 @@ var (
 	}
 	OpImageSparseFetch = &Opcode {
 		Opname:   "OpImageSparseFetch",
+		Class:    "Image",
+		Opcode:   313,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7449,6 +8023,8 @@ var (
 	}
 	OpImageSparseGather = &Opcode {
 		Opname:   "OpImageSparseGather",
+		Class:    "Image",
+		Opcode:   314,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7484,6 +8060,8 @@ var (
 	}
 	OpImageSparseDrefGather = &Opcode {
 		Opname:   "OpImageSparseDrefGather",
+		Class:    "Image",
+		Opcode:   315,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7519,6 +8097,8 @@ var (
 	}
 	OpImageSparseTexelsResident = &Opcode {
 		Opname:   "OpImageSparseTexelsResident",
+		Class:    "Image",
+		Opcode:   316,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7539,11 +8119,15 @@ var (
 	}
 	OpNoLine = &Opcode {
 		Opname:   "OpNoLine",
+		Class:    "Debug",
+		Opcode:   317,
 		Operands: []Operand {
 		},
 	}
 	OpAtomicFlagTestAndSet = &Opcode {
 		Opname:   "OpAtomicFlagTestAndSet",
+		Class:    "Atomic",
+		Opcode:   318,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7574,6 +8158,8 @@ var (
 	}
 	OpAtomicFlagClear = &Opcode {
 		Opname:   "OpAtomicFlagClear",
+		Class:    "Atomic",
+		Opcode:   319,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -7594,6 +8180,8 @@ var (
 	}
 	OpImageSparseRead = &Opcode {
 		Opname:   "OpImageSparseRead",
+		Class:    "Image",
+		Opcode:   320,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7624,6 +8212,8 @@ var (
 	}
 	OpSizeOf = &Opcode {
 		Opname:   "OpSizeOf",
+		Class:    "Miscellaneous",
+		Opcode:   321,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7644,6 +8234,8 @@ var (
 	}
 	OpTypePipeStorage = &Opcode {
 		Opname:   "OpTypePipeStorage",
+		Class:    "Type-Declaration",
+		Opcode:   322,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -7654,6 +8246,8 @@ var (
 	}
 	OpConstantPipeStorage = &Opcode {
 		Opname:   "OpConstantPipeStorage",
+		Class:    "Pipe",
+		Opcode:   323,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7684,6 +8278,8 @@ var (
 	}
 	OpCreatePipeFromPipeStorage = &Opcode {
 		Opname:   "OpCreatePipeFromPipeStorage",
+		Class:    "Pipe",
+		Opcode:   324,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7704,6 +8300,8 @@ var (
 	}
 	OpGetKernelLocalSizeForSubgroupCount = &Opcode {
 		Opname:   "OpGetKernelLocalSizeForSubgroupCount",
+		Class:    "Device-Side_Enqueue",
+		Opcode:   325,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7744,6 +8342,8 @@ var (
 	}
 	OpGetKernelMaxNumSubgroups = &Opcode {
 		Opname:   "OpGetKernelMaxNumSubgroups",
+		Class:    "Device-Side_Enqueue",
+		Opcode:   326,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7779,6 +8379,8 @@ var (
 	}
 	OpTypeNamedBarrier = &Opcode {
 		Opname:   "OpTypeNamedBarrier",
+		Class:    "Type-Declaration",
+		Opcode:   327,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -7789,6 +8391,8 @@ var (
 	}
 	OpNamedBarrierInitialize = &Opcode {
 		Opname:   "OpNamedBarrierInitialize",
+		Class:    "Barrier",
+		Opcode:   328,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7809,6 +8413,8 @@ var (
 	}
 	OpMemoryNamedBarrier = &Opcode {
 		Opname:   "OpMemoryNamedBarrier",
+		Class:    "Barrier",
+		Opcode:   329,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -7829,6 +8435,8 @@ var (
 	}
 	OpModuleProcessed = &Opcode {
 		Opname:   "OpModuleProcessed",
+		Class:    "Debug",
+		Opcode:   330,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindLiteralString,
@@ -7839,6 +8447,8 @@ var (
 	}
 	OpExecutionModeId = &Opcode {
 		Opname:   "OpExecutionModeId",
+		Class:    "Mode-Setting",
+		Opcode:   331,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -7854,6 +8464,8 @@ var (
 	}
 	OpDecorateId = &Opcode {
 		Opname:   "OpDecorateId",
+		Class:    "Annotation",
+		Opcode:   332,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -7869,6 +8481,8 @@ var (
 	}
 	OpGroupNonUniformElect = &Opcode {
 		Opname:   "OpGroupNonUniformElect",
+		Class:    "Non-Uniform",
+		Opcode:   333,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7889,6 +8503,8 @@ var (
 	}
 	OpGroupNonUniformAll = &Opcode {
 		Opname:   "OpGroupNonUniformAll",
+		Class:    "Non-Uniform",
+		Opcode:   334,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7914,6 +8530,8 @@ var (
 	}
 	OpGroupNonUniformAny = &Opcode {
 		Opname:   "OpGroupNonUniformAny",
+		Class:    "Non-Uniform",
+		Opcode:   335,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7939,6 +8557,8 @@ var (
 	}
 	OpGroupNonUniformAllEqual = &Opcode {
 		Opname:   "OpGroupNonUniformAllEqual",
+		Class:    "Non-Uniform",
+		Opcode:   336,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7964,6 +8584,8 @@ var (
 	}
 	OpGroupNonUniformBroadcast = &Opcode {
 		Opname:   "OpGroupNonUniformBroadcast",
+		Class:    "Non-Uniform",
+		Opcode:   337,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -7994,6 +8616,8 @@ var (
 	}
 	OpGroupNonUniformBroadcastFirst = &Opcode {
 		Opname:   "OpGroupNonUniformBroadcastFirst",
+		Class:    "Non-Uniform",
+		Opcode:   338,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8019,6 +8643,8 @@ var (
 	}
 	OpGroupNonUniformBallot = &Opcode {
 		Opname:   "OpGroupNonUniformBallot",
+		Class:    "Non-Uniform",
+		Opcode:   339,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8044,6 +8670,8 @@ var (
 	}
 	OpGroupNonUniformInverseBallot = &Opcode {
 		Opname:   "OpGroupNonUniformInverseBallot",
+		Class:    "Non-Uniform",
+		Opcode:   340,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8069,6 +8697,8 @@ var (
 	}
 	OpGroupNonUniformBallotBitExtract = &Opcode {
 		Opname:   "OpGroupNonUniformBallotBitExtract",
+		Class:    "Non-Uniform",
+		Opcode:   341,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8099,6 +8729,8 @@ var (
 	}
 	OpGroupNonUniformBallotBitCount = &Opcode {
 		Opname:   "OpGroupNonUniformBallotBitCount",
+		Class:    "Non-Uniform",
+		Opcode:   342,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8129,6 +8761,8 @@ var (
 	}
 	OpGroupNonUniformBallotFindLSB = &Opcode {
 		Opname:   "OpGroupNonUniformBallotFindLSB",
+		Class:    "Non-Uniform",
+		Opcode:   343,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8154,6 +8788,8 @@ var (
 	}
 	OpGroupNonUniformBallotFindMSB = &Opcode {
 		Opname:   "OpGroupNonUniformBallotFindMSB",
+		Class:    "Non-Uniform",
+		Opcode:   344,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8179,6 +8815,8 @@ var (
 	}
 	OpGroupNonUniformShuffle = &Opcode {
 		Opname:   "OpGroupNonUniformShuffle",
+		Class:    "Non-Uniform",
+		Opcode:   345,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8209,6 +8847,8 @@ var (
 	}
 	OpGroupNonUniformShuffleXor = &Opcode {
 		Opname:   "OpGroupNonUniformShuffleXor",
+		Class:    "Non-Uniform",
+		Opcode:   346,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8239,6 +8879,8 @@ var (
 	}
 	OpGroupNonUniformShuffleUp = &Opcode {
 		Opname:   "OpGroupNonUniformShuffleUp",
+		Class:    "Non-Uniform",
+		Opcode:   347,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8269,6 +8911,8 @@ var (
 	}
 	OpGroupNonUniformShuffleDown = &Opcode {
 		Opname:   "OpGroupNonUniformShuffleDown",
+		Class:    "Non-Uniform",
+		Opcode:   348,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8299,6 +8943,8 @@ var (
 	}
 	OpGroupNonUniformIAdd = &Opcode {
 		Opname:   "OpGroupNonUniformIAdd",
+		Class:    "Non-Uniform",
+		Opcode:   349,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8334,6 +8980,8 @@ var (
 	}
 	OpGroupNonUniformFAdd = &Opcode {
 		Opname:   "OpGroupNonUniformFAdd",
+		Class:    "Non-Uniform",
+		Opcode:   350,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8369,6 +9017,8 @@ var (
 	}
 	OpGroupNonUniformIMul = &Opcode {
 		Opname:   "OpGroupNonUniformIMul",
+		Class:    "Non-Uniform",
+		Opcode:   351,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8404,6 +9054,8 @@ var (
 	}
 	OpGroupNonUniformFMul = &Opcode {
 		Opname:   "OpGroupNonUniformFMul",
+		Class:    "Non-Uniform",
+		Opcode:   352,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8439,6 +9091,8 @@ var (
 	}
 	OpGroupNonUniformSMin = &Opcode {
 		Opname:   "OpGroupNonUniformSMin",
+		Class:    "Non-Uniform",
+		Opcode:   353,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8474,6 +9128,8 @@ var (
 	}
 	OpGroupNonUniformUMin = &Opcode {
 		Opname:   "OpGroupNonUniformUMin",
+		Class:    "Non-Uniform",
+		Opcode:   354,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8509,6 +9165,8 @@ var (
 	}
 	OpGroupNonUniformFMin = &Opcode {
 		Opname:   "OpGroupNonUniformFMin",
+		Class:    "Non-Uniform",
+		Opcode:   355,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8544,6 +9202,8 @@ var (
 	}
 	OpGroupNonUniformSMax = &Opcode {
 		Opname:   "OpGroupNonUniformSMax",
+		Class:    "Non-Uniform",
+		Opcode:   356,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8579,6 +9239,8 @@ var (
 	}
 	OpGroupNonUniformUMax = &Opcode {
 		Opname:   "OpGroupNonUniformUMax",
+		Class:    "Non-Uniform",
+		Opcode:   357,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8614,6 +9276,8 @@ var (
 	}
 	OpGroupNonUniformFMax = &Opcode {
 		Opname:   "OpGroupNonUniformFMax",
+		Class:    "Non-Uniform",
+		Opcode:   358,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8649,6 +9313,8 @@ var (
 	}
 	OpGroupNonUniformBitwiseAnd = &Opcode {
 		Opname:   "OpGroupNonUniformBitwiseAnd",
+		Class:    "Non-Uniform",
+		Opcode:   359,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8684,6 +9350,8 @@ var (
 	}
 	OpGroupNonUniformBitwiseOr = &Opcode {
 		Opname:   "OpGroupNonUniformBitwiseOr",
+		Class:    "Non-Uniform",
+		Opcode:   360,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8719,6 +9387,8 @@ var (
 	}
 	OpGroupNonUniformBitwiseXor = &Opcode {
 		Opname:   "OpGroupNonUniformBitwiseXor",
+		Class:    "Non-Uniform",
+		Opcode:   361,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8754,6 +9424,8 @@ var (
 	}
 	OpGroupNonUniformLogicalAnd = &Opcode {
 		Opname:   "OpGroupNonUniformLogicalAnd",
+		Class:    "Non-Uniform",
+		Opcode:   362,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8789,6 +9461,8 @@ var (
 	}
 	OpGroupNonUniformLogicalOr = &Opcode {
 		Opname:   "OpGroupNonUniformLogicalOr",
+		Class:    "Non-Uniform",
+		Opcode:   363,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8824,6 +9498,8 @@ var (
 	}
 	OpGroupNonUniformLogicalXor = &Opcode {
 		Opname:   "OpGroupNonUniformLogicalXor",
+		Class:    "Non-Uniform",
+		Opcode:   364,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8859,6 +9535,8 @@ var (
 	}
 	OpGroupNonUniformQuadBroadcast = &Opcode {
 		Opname:   "OpGroupNonUniformQuadBroadcast",
+		Class:    "Non-Uniform",
+		Opcode:   365,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8889,6 +9567,8 @@ var (
 	}
 	OpGroupNonUniformQuadSwap = &Opcode {
 		Opname:   "OpGroupNonUniformQuadSwap",
+		Class:    "Non-Uniform",
+		Opcode:   366,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8919,6 +9599,8 @@ var (
 	}
 	OpCopyLogical = &Opcode {
 		Opname:   "OpCopyLogical",
+		Class:    "Composite",
+		Opcode:   400,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8939,6 +9621,8 @@ var (
 	}
 	OpPtrEqual = &Opcode {
 		Opname:   "OpPtrEqual",
+		Class:    "Memory",
+		Opcode:   401,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8964,6 +9648,8 @@ var (
 	}
 	OpPtrNotEqual = &Opcode {
 		Opname:   "OpPtrNotEqual",
+		Class:    "Memory",
+		Opcode:   402,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -8989,6 +9675,8 @@ var (
 	}
 	OpPtrDiff = &Opcode {
 		Opname:   "OpPtrDiff",
+		Class:    "Memory",
+		Opcode:   403,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9014,6 +9702,8 @@ var (
 	}
 	OpSubgroupBallotKHR = &Opcode {
 		Opname:   "OpSubgroupBallotKHR",
+		Class:    "Group",
+		Opcode:   4421,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9034,6 +9724,8 @@ var (
 	}
 	OpSubgroupFirstInvocationKHR = &Opcode {
 		Opname:   "OpSubgroupFirstInvocationKHR",
+		Class:    "Group",
+		Opcode:   4422,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9054,6 +9746,8 @@ var (
 	}
 	OpSubgroupAllKHR = &Opcode {
 		Opname:   "OpSubgroupAllKHR",
+		Class:    "Group",
+		Opcode:   4428,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9074,6 +9768,8 @@ var (
 	}
 	OpSubgroupAnyKHR = &Opcode {
 		Opname:   "OpSubgroupAnyKHR",
+		Class:    "Group",
+		Opcode:   4429,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9094,6 +9790,8 @@ var (
 	}
 	OpSubgroupAllEqualKHR = &Opcode {
 		Opname:   "OpSubgroupAllEqualKHR",
+		Class:    "Group",
+		Opcode:   4430,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9114,6 +9812,8 @@ var (
 	}
 	OpSubgroupReadInvocationKHR = &Opcode {
 		Opname:   "OpSubgroupReadInvocationKHR",
+		Class:    "Group",
+		Opcode:   4432,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9139,6 +9839,8 @@ var (
 	}
 	OpGroupIAddNonUniformAMD = &Opcode {
 		Opname:   "OpGroupIAddNonUniformAMD",
+		Class:    "Group",
+		Opcode:   5000,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9169,6 +9871,8 @@ var (
 	}
 	OpGroupFAddNonUniformAMD = &Opcode {
 		Opname:   "OpGroupFAddNonUniformAMD",
+		Class:    "Group",
+		Opcode:   5001,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9199,6 +9903,8 @@ var (
 	}
 	OpGroupFMinNonUniformAMD = &Opcode {
 		Opname:   "OpGroupFMinNonUniformAMD",
+		Class:    "Group",
+		Opcode:   5002,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9229,6 +9935,8 @@ var (
 	}
 	OpGroupUMinNonUniformAMD = &Opcode {
 		Opname:   "OpGroupUMinNonUniformAMD",
+		Class:    "Group",
+		Opcode:   5003,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9259,6 +9967,8 @@ var (
 	}
 	OpGroupSMinNonUniformAMD = &Opcode {
 		Opname:   "OpGroupSMinNonUniformAMD",
+		Class:    "Group",
+		Opcode:   5004,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9289,6 +9999,8 @@ var (
 	}
 	OpGroupFMaxNonUniformAMD = &Opcode {
 		Opname:   "OpGroupFMaxNonUniformAMD",
+		Class:    "Group",
+		Opcode:   5005,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9319,6 +10031,8 @@ var (
 	}
 	OpGroupUMaxNonUniformAMD = &Opcode {
 		Opname:   "OpGroupUMaxNonUniformAMD",
+		Class:    "Group",
+		Opcode:   5006,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9349,6 +10063,8 @@ var (
 	}
 	OpGroupSMaxNonUniformAMD = &Opcode {
 		Opname:   "OpGroupSMaxNonUniformAMD",
+		Class:    "Group",
+		Opcode:   5007,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9379,6 +10095,8 @@ var (
 	}
 	OpFragmentMaskFetchAMD = &Opcode {
 		Opname:   "OpFragmentMaskFetchAMD",
+		Class:    "Reserved",
+		Opcode:   5011,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9404,6 +10122,8 @@ var (
 	}
 	OpFragmentFetchAMD = &Opcode {
 		Opname:   "OpFragmentFetchAMD",
+		Class:    "Reserved",
+		Opcode:   5012,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9434,6 +10154,8 @@ var (
 	}
 	OpReadClockKHR = &Opcode {
 		Opname:   "OpReadClockKHR",
+		Class:    "Reserved",
+		Opcode:   5056,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9454,6 +10176,8 @@ var (
 	}
 	OpImageSampleFootprintNV = &Opcode {
 		Opname:   "OpImageSampleFootprintNV",
+		Class:    "Image",
+		Opcode:   5283,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9494,6 +10218,8 @@ var (
 	}
 	OpGroupNonUniformPartitionNV = &Opcode {
 		Opname:   "OpGroupNonUniformPartitionNV",
+		Class:    "Non-Uniform",
+		Opcode:   5296,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9514,6 +10240,8 @@ var (
 	}
 	OpWritePackedPrimitiveIndices4x8NV = &Opcode {
 		Opname:   "OpWritePackedPrimitiveIndices4x8NV",
+		Class:    "Reserved",
+		Opcode:   5299,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -9529,6 +10257,8 @@ var (
 	}
 	OpReportIntersectionNV = &Opcode {
 		Opname:   "OpReportIntersectionNV",
+		Class:    "Reserved",
+		Opcode:   5334,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9554,16 +10284,22 @@ var (
 	}
 	OpIgnoreIntersectionNV = &Opcode {
 		Opname:   "OpIgnoreIntersectionNV",
+		Class:    "Reserved",
+		Opcode:   5335,
 		Operands: []Operand {
 		},
 	}
 	OpTerminateRayNV = &Opcode {
 		Opname:   "OpTerminateRayNV",
+		Class:    "Reserved",
+		Opcode:   5336,
 		Operands: []Operand {
 		},
 	}
 	OpTraceNV = &Opcode {
 		Opname:   "OpTraceNV",
+		Class:    "Reserved",
+		Opcode:   5337,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -9624,6 +10360,8 @@ var (
 	}
 	OpTypeAccelerationStructureNV = &Opcode {
 		Opname:   "OpTypeAccelerationStructureNV",
+		Class:    "Reserved",
+		Opcode:   5341,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -9634,6 +10372,8 @@ var (
 	}
 	OpExecuteCallableNV = &Opcode {
 		Opname:   "OpExecuteCallableNV",
+		Class:    "Reserved",
+		Opcode:   5344,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -9649,6 +10389,8 @@ var (
 	}
 	OpTypeCooperativeMatrixNV = &Opcode {
 		Opname:   "OpTypeCooperativeMatrixNV",
+		Class:    "Reserved",
+		Opcode:   5358,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -9679,6 +10421,8 @@ var (
 	}
 	OpCooperativeMatrixLoadNV = &Opcode {
 		Opname:   "OpCooperativeMatrixLoadNV",
+		Class:    "Reserved",
+		Opcode:   5359,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9714,6 +10458,8 @@ var (
 	}
 	OpCooperativeMatrixStoreNV = &Opcode {
 		Opname:   "OpCooperativeMatrixStoreNV",
+		Class:    "Reserved",
+		Opcode:   5360,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -9744,6 +10490,8 @@ var (
 	}
 	OpCooperativeMatrixMulAddNV = &Opcode {
 		Opname:   "OpCooperativeMatrixMulAddNV",
+		Class:    "Reserved",
+		Opcode:   5361,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9774,6 +10522,8 @@ var (
 	}
 	OpCooperativeMatrixLengthNV = &Opcode {
 		Opname:   "OpCooperativeMatrixLengthNV",
+		Class:    "Reserved",
+		Opcode:   5362,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9794,21 +10544,29 @@ var (
 	}
 	OpBeginInvocationInterlockEXT = &Opcode {
 		Opname:   "OpBeginInvocationInterlockEXT",
+		Class:    "Reserved",
+		Opcode:   5364,
 		Operands: []Operand {
 		},
 	}
 	OpEndInvocationInterlockEXT = &Opcode {
 		Opname:   "OpEndInvocationInterlockEXT",
+		Class:    "Reserved",
+		Opcode:   5365,
 		Operands: []Operand {
 		},
 	}
 	OpDemoteToHelperInvocationEXT = &Opcode {
 		Opname:   "OpDemoteToHelperInvocationEXT",
+		Class:    "Reserved",
+		Opcode:   5380,
 		Operands: []Operand {
 		},
 	}
 	OpIsHelperInvocationEXT = &Opcode {
 		Opname:   "OpIsHelperInvocationEXT",
+		Class:    "Reserved",
+		Opcode:   5381,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9824,6 +10582,8 @@ var (
 	}
 	OpSubgroupShuffleINTEL = &Opcode {
 		Opname:   "OpSubgroupShuffleINTEL",
+		Class:    "Group",
+		Opcode:   5571,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9849,6 +10609,8 @@ var (
 	}
 	OpSubgroupShuffleDownINTEL = &Opcode {
 		Opname:   "OpSubgroupShuffleDownINTEL",
+		Class:    "Group",
+		Opcode:   5572,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9879,6 +10641,8 @@ var (
 	}
 	OpSubgroupShuffleUpINTEL = &Opcode {
 		Opname:   "OpSubgroupShuffleUpINTEL",
+		Class:    "Group",
+		Opcode:   5573,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9909,6 +10673,8 @@ var (
 	}
 	OpSubgroupShuffleXorINTEL = &Opcode {
 		Opname:   "OpSubgroupShuffleXorINTEL",
+		Class:    "Group",
+		Opcode:   5574,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9934,6 +10700,8 @@ var (
 	}
 	OpSubgroupBlockReadINTEL = &Opcode {
 		Opname:   "OpSubgroupBlockReadINTEL",
+		Class:    "Group",
+		Opcode:   5575,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9954,6 +10722,8 @@ var (
 	}
 	OpSubgroupBlockWriteINTEL = &Opcode {
 		Opname:   "OpSubgroupBlockWriteINTEL",
+		Class:    "Group",
+		Opcode:   5576,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -9969,6 +10739,8 @@ var (
 	}
 	OpSubgroupImageBlockReadINTEL = &Opcode {
 		Opname:   "OpSubgroupImageBlockReadINTEL",
+		Class:    "Group",
+		Opcode:   5577,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -9994,6 +10766,8 @@ var (
 	}
 	OpSubgroupImageBlockWriteINTEL = &Opcode {
 		Opname:   "OpSubgroupImageBlockWriteINTEL",
+		Class:    "Group",
+		Opcode:   5578,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -10014,6 +10788,8 @@ var (
 	}
 	OpSubgroupImageMediaBlockReadINTEL = &Opcode {
 		Opname:   "OpSubgroupImageMediaBlockReadINTEL",
+		Class:    "Group",
+		Opcode:   5580,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10049,6 +10825,8 @@ var (
 	}
 	OpSubgroupImageMediaBlockWriteINTEL = &Opcode {
 		Opname:   "OpSubgroupImageMediaBlockWriteINTEL",
+		Class:    "Group",
+		Opcode:   5581,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -10079,6 +10857,8 @@ var (
 	}
 	OpUCountLeadingZerosINTEL = &Opcode {
 		Opname:   "OpUCountLeadingZerosINTEL",
+		Class:    "Reserved",
+		Opcode:   5585,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10099,6 +10879,8 @@ var (
 	}
 	OpUCountTrailingZerosINTEL = &Opcode {
 		Opname:   "OpUCountTrailingZerosINTEL",
+		Class:    "Reserved",
+		Opcode:   5586,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10119,6 +10901,8 @@ var (
 	}
 	OpAbsISubINTEL = &Opcode {
 		Opname:   "OpAbsISubINTEL",
+		Class:    "Reserved",
+		Opcode:   5587,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10144,6 +10928,8 @@ var (
 	}
 	OpAbsUSubINTEL = &Opcode {
 		Opname:   "OpAbsUSubINTEL",
+		Class:    "Reserved",
+		Opcode:   5588,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10169,6 +10955,8 @@ var (
 	}
 	OpIAddSatINTEL = &Opcode {
 		Opname:   "OpIAddSatINTEL",
+		Class:    "Reserved",
+		Opcode:   5589,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10194,6 +10982,8 @@ var (
 	}
 	OpUAddSatINTEL = &Opcode {
 		Opname:   "OpUAddSatINTEL",
+		Class:    "Reserved",
+		Opcode:   5590,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10219,6 +11009,8 @@ var (
 	}
 	OpIAverageINTEL = &Opcode {
 		Opname:   "OpIAverageINTEL",
+		Class:    "Reserved",
+		Opcode:   5591,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10244,6 +11036,8 @@ var (
 	}
 	OpUAverageINTEL = &Opcode {
 		Opname:   "OpUAverageINTEL",
+		Class:    "Reserved",
+		Opcode:   5592,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10269,6 +11063,8 @@ var (
 	}
 	OpIAverageRoundedINTEL = &Opcode {
 		Opname:   "OpIAverageRoundedINTEL",
+		Class:    "Reserved",
+		Opcode:   5593,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10294,6 +11090,8 @@ var (
 	}
 	OpUAverageRoundedINTEL = &Opcode {
 		Opname:   "OpUAverageRoundedINTEL",
+		Class:    "Reserved",
+		Opcode:   5594,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10319,6 +11117,8 @@ var (
 	}
 	OpISubSatINTEL = &Opcode {
 		Opname:   "OpISubSatINTEL",
+		Class:    "Reserved",
+		Opcode:   5595,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10344,6 +11144,8 @@ var (
 	}
 	OpUSubSatINTEL = &Opcode {
 		Opname:   "OpUSubSatINTEL",
+		Class:    "Reserved",
+		Opcode:   5596,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10369,6 +11171,8 @@ var (
 	}
 	OpIMul32x16INTEL = &Opcode {
 		Opname:   "OpIMul32x16INTEL",
+		Class:    "Reserved",
+		Opcode:   5597,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10394,6 +11198,8 @@ var (
 	}
 	OpUMul32x16INTEL = &Opcode {
 		Opname:   "OpUMul32x16INTEL",
+		Class:    "Reserved",
+		Opcode:   5598,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10419,6 +11225,8 @@ var (
 	}
 	OpDecorateString = &Opcode {
 		Opname:   "OpDecorateString",
+		Class:    "Annotation",
+		Opcode:   5632,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -10434,6 +11242,8 @@ var (
 	}
 	OpDecorateStringGOOGLE = &Opcode {
 		Opname:   "OpDecorateStringGOOGLE",
+		Class:    "Annotation",
+		Opcode:   5632,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -10449,6 +11259,8 @@ var (
 	}
 	OpMemberDecorateString = &Opcode {
 		Opname:   "OpMemberDecorateString",
+		Class:    "Annotation",
+		Opcode:   5633,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -10469,6 +11281,8 @@ var (
 	}
 	OpMemberDecorateStringGOOGLE = &Opcode {
 		Opname:   "OpMemberDecorateStringGOOGLE",
+		Class:    "Annotation",
+		Opcode:   5633,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdRef,
@@ -10489,6 +11303,8 @@ var (
 	}
 	OpVmeImageINTEL = &Opcode {
 		Opname:   "OpVmeImageINTEL",
+		Class:    "@exclude",
+		Opcode:   5699,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10514,6 +11330,8 @@ var (
 	}
 	OpTypeVmeImageINTEL = &Opcode {
 		Opname:   "OpTypeVmeImageINTEL",
+		Class:    "@exclude",
+		Opcode:   5700,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -10529,6 +11347,8 @@ var (
 	}
 	OpTypeAvcImePayloadINTEL = &Opcode {
 		Opname:   "OpTypeAvcImePayloadINTEL",
+		Class:    "@exclude",
+		Opcode:   5701,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -10539,6 +11359,8 @@ var (
 	}
 	OpTypeAvcRefPayloadINTEL = &Opcode {
 		Opname:   "OpTypeAvcRefPayloadINTEL",
+		Class:    "@exclude",
+		Opcode:   5702,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -10549,6 +11371,8 @@ var (
 	}
 	OpTypeAvcSicPayloadINTEL = &Opcode {
 		Opname:   "OpTypeAvcSicPayloadINTEL",
+		Class:    "@exclude",
+		Opcode:   5703,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -10559,6 +11383,8 @@ var (
 	}
 	OpTypeAvcMcePayloadINTEL = &Opcode {
 		Opname:   "OpTypeAvcMcePayloadINTEL",
+		Class:    "@exclude",
+		Opcode:   5704,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -10569,6 +11395,8 @@ var (
 	}
 	OpTypeAvcMceResultINTEL = &Opcode {
 		Opname:   "OpTypeAvcMceResultINTEL",
+		Class:    "@exclude",
+		Opcode:   5705,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -10579,6 +11407,8 @@ var (
 	}
 	OpTypeAvcImeResultINTEL = &Opcode {
 		Opname:   "OpTypeAvcImeResultINTEL",
+		Class:    "@exclude",
+		Opcode:   5706,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -10589,6 +11419,8 @@ var (
 	}
 	OpTypeAvcImeResultSingleReferenceStreamoutINTEL = &Opcode {
 		Opname:   "OpTypeAvcImeResultSingleReferenceStreamoutINTEL",
+		Class:    "@exclude",
+		Opcode:   5707,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -10599,6 +11431,8 @@ var (
 	}
 	OpTypeAvcImeResultDualReferenceStreamoutINTEL = &Opcode {
 		Opname:   "OpTypeAvcImeResultDualReferenceStreamoutINTEL",
+		Class:    "@exclude",
+		Opcode:   5708,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -10609,6 +11443,8 @@ var (
 	}
 	OpTypeAvcImeSingleReferenceStreaminINTEL = &Opcode {
 		Opname:   "OpTypeAvcImeSingleReferenceStreaminINTEL",
+		Class:    "@exclude",
+		Opcode:   5709,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -10619,6 +11455,8 @@ var (
 	}
 	OpTypeAvcImeDualReferenceStreaminINTEL = &Opcode {
 		Opname:   "OpTypeAvcImeDualReferenceStreaminINTEL",
+		Class:    "@exclude",
+		Opcode:   5710,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -10629,6 +11467,8 @@ var (
 	}
 	OpTypeAvcRefResultINTEL = &Opcode {
 		Opname:   "OpTypeAvcRefResultINTEL",
+		Class:    "@exclude",
+		Opcode:   5711,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -10639,6 +11479,8 @@ var (
 	}
 	OpTypeAvcSicResultINTEL = &Opcode {
 		Opname:   "OpTypeAvcSicResultINTEL",
+		Class:    "@exclude",
+		Opcode:   5712,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResult,
@@ -10649,6 +11491,8 @@ var (
 	}
 	OpSubgroupAvcMceGetDefaultInterBaseMultiReferencePenaltyINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceGetDefaultInterBaseMultiReferencePenaltyINTEL",
+		Class:    "@exclude",
+		Opcode:   5713,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10674,6 +11518,8 @@ var (
 	}
 	OpSubgroupAvcMceSetInterBaseMultiReferencePenaltyINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceSetInterBaseMultiReferencePenaltyINTEL",
+		Class:    "@exclude",
+		Opcode:   5714,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10699,6 +11545,8 @@ var (
 	}
 	OpSubgroupAvcMceGetDefaultInterShapePenaltyINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceGetDefaultInterShapePenaltyINTEL",
+		Class:    "@exclude",
+		Opcode:   5715,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10724,6 +11572,8 @@ var (
 	}
 	OpSubgroupAvcMceSetInterShapePenaltyINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceSetInterShapePenaltyINTEL",
+		Class:    "@exclude",
+		Opcode:   5716,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10749,6 +11599,8 @@ var (
 	}
 	OpSubgroupAvcMceGetDefaultInterDirectionPenaltyINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceGetDefaultInterDirectionPenaltyINTEL",
+		Class:    "@exclude",
+		Opcode:   5717,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10774,6 +11626,8 @@ var (
 	}
 	OpSubgroupAvcMceSetInterDirectionPenaltyINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceSetInterDirectionPenaltyINTEL",
+		Class:    "@exclude",
+		Opcode:   5718,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10799,6 +11653,8 @@ var (
 	}
 	OpSubgroupAvcMceGetDefaultIntraLumaShapePenaltyINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceGetDefaultIntraLumaShapePenaltyINTEL",
+		Class:    "@exclude",
+		Opcode:   5719,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10824,6 +11680,8 @@ var (
 	}
 	OpSubgroupAvcMceGetDefaultInterMotionVectorCostTableINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceGetDefaultInterMotionVectorCostTableINTEL",
+		Class:    "@exclude",
+		Opcode:   5720,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10849,6 +11707,8 @@ var (
 	}
 	OpSubgroupAvcMceGetDefaultHighPenaltyCostTableINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceGetDefaultHighPenaltyCostTableINTEL",
+		Class:    "@exclude",
+		Opcode:   5721,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10864,6 +11724,8 @@ var (
 	}
 	OpSubgroupAvcMceGetDefaultMediumPenaltyCostTableINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceGetDefaultMediumPenaltyCostTableINTEL",
+		Class:    "@exclude",
+		Opcode:   5722,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10879,6 +11741,8 @@ var (
 	}
 	OpSubgroupAvcMceGetDefaultLowPenaltyCostTableINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceGetDefaultLowPenaltyCostTableINTEL",
+		Class:    "@exclude",
+		Opcode:   5723,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10894,6 +11758,8 @@ var (
 	}
 	OpSubgroupAvcMceSetMotionVectorCostFunctionINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceSetMotionVectorCostFunctionINTEL",
+		Class:    "@exclude",
+		Opcode:   5724,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10929,6 +11795,8 @@ var (
 	}
 	OpSubgroupAvcMceGetDefaultIntraLumaModePenaltyINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceGetDefaultIntraLumaModePenaltyINTEL",
+		Class:    "@exclude",
+		Opcode:   5725,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10954,6 +11822,8 @@ var (
 	}
 	OpSubgroupAvcMceGetDefaultNonDcLumaIntraPenaltyINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceGetDefaultNonDcLumaIntraPenaltyINTEL",
+		Class:    "@exclude",
+		Opcode:   5726,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10969,6 +11839,8 @@ var (
 	}
 	OpSubgroupAvcMceGetDefaultIntraChromaModeBasePenaltyINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceGetDefaultIntraChromaModeBasePenaltyINTEL",
+		Class:    "@exclude",
+		Opcode:   5727,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -10984,6 +11856,8 @@ var (
 	}
 	OpSubgroupAvcMceSetAcOnlyHaarINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceSetAcOnlyHaarINTEL",
+		Class:    "@exclude",
+		Opcode:   5728,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11004,6 +11878,8 @@ var (
 	}
 	OpSubgroupAvcMceSetSourceInterlacedFieldPolarityINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceSetSourceInterlacedFieldPolarityINTEL",
+		Class:    "@exclude",
+		Opcode:   5729,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11029,6 +11905,8 @@ var (
 	}
 	OpSubgroupAvcMceSetSingleReferenceInterlacedFieldPolarityINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceSetSingleReferenceInterlacedFieldPolarityINTEL",
+		Class:    "@exclude",
+		Opcode:   5730,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11054,6 +11932,8 @@ var (
 	}
 	OpSubgroupAvcMceSetDualReferenceInterlacedFieldPolaritiesINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceSetDualReferenceInterlacedFieldPolaritiesINTEL",
+		Class:    "@exclude",
+		Opcode:   5731,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11084,6 +11964,8 @@ var (
 	}
 	OpSubgroupAvcMceConvertToImePayloadINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceConvertToImePayloadINTEL",
+		Class:    "@exclude",
+		Opcode:   5732,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11104,6 +11986,8 @@ var (
 	}
 	OpSubgroupAvcMceConvertToImeResultINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceConvertToImeResultINTEL",
+		Class:    "@exclude",
+		Opcode:   5733,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11124,6 +12008,8 @@ var (
 	}
 	OpSubgroupAvcMceConvertToRefPayloadINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceConvertToRefPayloadINTEL",
+		Class:    "@exclude",
+		Opcode:   5734,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11144,6 +12030,8 @@ var (
 	}
 	OpSubgroupAvcMceConvertToRefResultINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceConvertToRefResultINTEL",
+		Class:    "@exclude",
+		Opcode:   5735,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11164,6 +12052,8 @@ var (
 	}
 	OpSubgroupAvcMceConvertToSicPayloadINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceConvertToSicPayloadINTEL",
+		Class:    "@exclude",
+		Opcode:   5736,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11184,6 +12074,8 @@ var (
 	}
 	OpSubgroupAvcMceConvertToSicResultINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceConvertToSicResultINTEL",
+		Class:    "@exclude",
+		Opcode:   5737,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11204,6 +12096,8 @@ var (
 	}
 	OpSubgroupAvcMceGetMotionVectorsINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceGetMotionVectorsINTEL",
+		Class:    "@exclude",
+		Opcode:   5738,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11224,6 +12118,8 @@ var (
 	}
 	OpSubgroupAvcMceGetInterDistortionsINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceGetInterDistortionsINTEL",
+		Class:    "@exclude",
+		Opcode:   5739,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11244,6 +12140,8 @@ var (
 	}
 	OpSubgroupAvcMceGetBestInterDistortionsINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceGetBestInterDistortionsINTEL",
+		Class:    "@exclude",
+		Opcode:   5740,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11264,6 +12162,8 @@ var (
 	}
 	OpSubgroupAvcMceGetInterMajorShapeINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceGetInterMajorShapeINTEL",
+		Class:    "@exclude",
+		Opcode:   5741,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11284,6 +12184,8 @@ var (
 	}
 	OpSubgroupAvcMceGetInterMinorShapeINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceGetInterMinorShapeINTEL",
+		Class:    "@exclude",
+		Opcode:   5742,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11304,6 +12206,8 @@ var (
 	}
 	OpSubgroupAvcMceGetInterDirectionsINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceGetInterDirectionsINTEL",
+		Class:    "@exclude",
+		Opcode:   5743,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11324,6 +12228,8 @@ var (
 	}
 	OpSubgroupAvcMceGetInterMotionVectorCountINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceGetInterMotionVectorCountINTEL",
+		Class:    "@exclude",
+		Opcode:   5744,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11344,6 +12250,8 @@ var (
 	}
 	OpSubgroupAvcMceGetInterReferenceIdsINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceGetInterReferenceIdsINTEL",
+		Class:    "@exclude",
+		Opcode:   5745,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11364,6 +12272,8 @@ var (
 	}
 	OpSubgroupAvcMceGetInterReferenceInterlacedFieldPolaritiesINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcMceGetInterReferenceInterlacedFieldPolaritiesINTEL",
+		Class:    "@exclude",
+		Opcode:   5746,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11394,6 +12304,8 @@ var (
 	}
 	OpSubgroupAvcImeInitializeINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeInitializeINTEL",
+		Class:    "@exclude",
+		Opcode:   5747,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11424,6 +12336,8 @@ var (
 	}
 	OpSubgroupAvcImeSetSingleReferenceINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeSetSingleReferenceINTEL",
+		Class:    "@exclude",
+		Opcode:   5748,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11454,6 +12368,8 @@ var (
 	}
 	OpSubgroupAvcImeSetDualReferenceINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeSetDualReferenceINTEL",
+		Class:    "@exclude",
+		Opcode:   5749,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11489,6 +12405,8 @@ var (
 	}
 	OpSubgroupAvcImeRefWindowSizeINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeRefWindowSizeINTEL",
+		Class:    "@exclude",
+		Opcode:   5750,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11514,6 +12432,8 @@ var (
 	}
 	OpSubgroupAvcImeAdjustRefOffsetINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeAdjustRefOffsetINTEL",
+		Class:    "@exclude",
+		Opcode:   5751,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11549,6 +12469,8 @@ var (
 	}
 	OpSubgroupAvcImeConvertToMcePayloadINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeConvertToMcePayloadINTEL",
+		Class:    "@exclude",
+		Opcode:   5752,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11569,6 +12491,8 @@ var (
 	}
 	OpSubgroupAvcImeSetMaxMotionVectorCountINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeSetMaxMotionVectorCountINTEL",
+		Class:    "@exclude",
+		Opcode:   5753,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11594,6 +12518,8 @@ var (
 	}
 	OpSubgroupAvcImeSetUnidirectionalMixDisableINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeSetUnidirectionalMixDisableINTEL",
+		Class:    "@exclude",
+		Opcode:   5754,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11614,6 +12540,8 @@ var (
 	}
 	OpSubgroupAvcImeSetEarlySearchTerminationThresholdINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeSetEarlySearchTerminationThresholdINTEL",
+		Class:    "@exclude",
+		Opcode:   5755,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11639,6 +12567,8 @@ var (
 	}
 	OpSubgroupAvcImeSetWeightedSadINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeSetWeightedSadINTEL",
+		Class:    "@exclude",
+		Opcode:   5756,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11664,6 +12594,8 @@ var (
 	}
 	OpSubgroupAvcImeEvaluateWithSingleReferenceINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeEvaluateWithSingleReferenceINTEL",
+		Class:    "@exclude",
+		Opcode:   5757,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11694,6 +12626,8 @@ var (
 	}
 	OpSubgroupAvcImeEvaluateWithDualReferenceINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeEvaluateWithDualReferenceINTEL",
+		Class:    "@exclude",
+		Opcode:   5758,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11729,6 +12663,8 @@ var (
 	}
 	OpSubgroupAvcImeEvaluateWithSingleReferenceStreaminINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeEvaluateWithSingleReferenceStreaminINTEL",
+		Class:    "@exclude",
+		Opcode:   5759,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11764,6 +12700,8 @@ var (
 	}
 	OpSubgroupAvcImeEvaluateWithDualReferenceStreaminINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeEvaluateWithDualReferenceStreaminINTEL",
+		Class:    "@exclude",
+		Opcode:   5760,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11804,6 +12742,8 @@ var (
 	}
 	OpSubgroupAvcImeEvaluateWithSingleReferenceStreamoutINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeEvaluateWithSingleReferenceStreamoutINTEL",
+		Class:    "@exclude",
+		Opcode:   5761,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11834,6 +12774,8 @@ var (
 	}
 	OpSubgroupAvcImeEvaluateWithDualReferenceStreamoutINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeEvaluateWithDualReferenceStreamoutINTEL",
+		Class:    "@exclude",
+		Opcode:   5762,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11869,6 +12811,8 @@ var (
 	}
 	OpSubgroupAvcImeEvaluateWithSingleReferenceStreaminoutINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeEvaluateWithSingleReferenceStreaminoutINTEL",
+		Class:    "@exclude",
+		Opcode:   5763,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11904,6 +12848,8 @@ var (
 	}
 	OpSubgroupAvcImeEvaluateWithDualReferenceStreaminoutINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeEvaluateWithDualReferenceStreaminoutINTEL",
+		Class:    "@exclude",
+		Opcode:   5764,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11944,6 +12890,8 @@ var (
 	}
 	OpSubgroupAvcImeConvertToMceResultINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeConvertToMceResultINTEL",
+		Class:    "@exclude",
+		Opcode:   5765,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11964,6 +12912,8 @@ var (
 	}
 	OpSubgroupAvcImeGetSingleReferenceStreaminINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeGetSingleReferenceStreaminINTEL",
+		Class:    "@exclude",
+		Opcode:   5766,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -11984,6 +12934,8 @@ var (
 	}
 	OpSubgroupAvcImeGetDualReferenceStreaminINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeGetDualReferenceStreaminINTEL",
+		Class:    "@exclude",
+		Opcode:   5767,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12004,6 +12956,8 @@ var (
 	}
 	OpSubgroupAvcImeStripSingleReferenceStreamoutINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeStripSingleReferenceStreamoutINTEL",
+		Class:    "@exclude",
+		Opcode:   5768,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12024,6 +12978,8 @@ var (
 	}
 	OpSubgroupAvcImeStripDualReferenceStreamoutINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeStripDualReferenceStreamoutINTEL",
+		Class:    "@exclude",
+		Opcode:   5769,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12044,6 +13000,8 @@ var (
 	}
 	OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTEL",
+		Class:    "@exclude",
+		Opcode:   5770,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12069,6 +13027,8 @@ var (
 	}
 	OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeDistortionsINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeDistortionsINTEL",
+		Class:    "@exclude",
+		Opcode:   5771,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12094,6 +13054,8 @@ var (
 	}
 	OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeReferenceIdsINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeReferenceIdsINTEL",
+		Class:    "@exclude",
+		Opcode:   5772,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12119,6 +13081,8 @@ var (
 	}
 	OpSubgroupAvcImeGetStreamoutDualReferenceMajorShapeMotionVectorsINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeGetStreamoutDualReferenceMajorShapeMotionVectorsINTEL",
+		Class:    "@exclude",
+		Opcode:   5773,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12149,6 +13113,8 @@ var (
 	}
 	OpSubgroupAvcImeGetStreamoutDualReferenceMajorShapeDistortionsINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeGetStreamoutDualReferenceMajorShapeDistortionsINTEL",
+		Class:    "@exclude",
+		Opcode:   5774,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12179,6 +13145,8 @@ var (
 	}
 	OpSubgroupAvcImeGetStreamoutDualReferenceMajorShapeReferenceIdsINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeGetStreamoutDualReferenceMajorShapeReferenceIdsINTEL",
+		Class:    "@exclude",
+		Opcode:   5775,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12209,6 +13177,8 @@ var (
 	}
 	OpSubgroupAvcImeGetBorderReachedINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeGetBorderReachedINTEL",
+		Class:    "@exclude",
+		Opcode:   5776,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12234,6 +13204,8 @@ var (
 	}
 	OpSubgroupAvcImeGetTruncatedSearchIndicationINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeGetTruncatedSearchIndicationINTEL",
+		Class:    "@exclude",
+		Opcode:   5777,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12254,6 +13226,8 @@ var (
 	}
 	OpSubgroupAvcImeGetUnidirectionalEarlySearchTerminationINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeGetUnidirectionalEarlySearchTerminationINTEL",
+		Class:    "@exclude",
+		Opcode:   5778,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12274,6 +13248,8 @@ var (
 	}
 	OpSubgroupAvcImeGetWeightingPatternMinimumMotionVectorINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeGetWeightingPatternMinimumMotionVectorINTEL",
+		Class:    "@exclude",
+		Opcode:   5779,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12294,6 +13270,8 @@ var (
 	}
 	OpSubgroupAvcImeGetWeightingPatternMinimumDistortionINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcImeGetWeightingPatternMinimumDistortionINTEL",
+		Class:    "@exclude",
+		Opcode:   5780,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12314,6 +13292,8 @@ var (
 	}
 	OpSubgroupAvcFmeInitializeINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcFmeInitializeINTEL",
+		Class:    "@exclude",
+		Opcode:   5781,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12364,6 +13344,8 @@ var (
 	}
 	OpSubgroupAvcBmeInitializeINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcBmeInitializeINTEL",
+		Class:    "@exclude",
+		Opcode:   5782,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12419,6 +13401,8 @@ var (
 	}
 	OpSubgroupAvcRefConvertToMcePayloadINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcRefConvertToMcePayloadINTEL",
+		Class:    "@exclude",
+		Opcode:   5783,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12439,6 +13423,8 @@ var (
 	}
 	OpSubgroupAvcRefSetBidirectionalMixDisableINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcRefSetBidirectionalMixDisableINTEL",
+		Class:    "@exclude",
+		Opcode:   5784,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12459,6 +13445,8 @@ var (
 	}
 	OpSubgroupAvcRefSetBilinearFilterEnableINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcRefSetBilinearFilterEnableINTEL",
+		Class:    "@exclude",
+		Opcode:   5785,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12479,6 +13467,8 @@ var (
 	}
 	OpSubgroupAvcRefEvaluateWithSingleReferenceINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcRefEvaluateWithSingleReferenceINTEL",
+		Class:    "@exclude",
+		Opcode:   5786,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12509,6 +13499,8 @@ var (
 	}
 	OpSubgroupAvcRefEvaluateWithDualReferenceINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcRefEvaluateWithDualReferenceINTEL",
+		Class:    "@exclude",
+		Opcode:   5787,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12544,6 +13536,8 @@ var (
 	}
 	OpSubgroupAvcRefEvaluateWithMultiReferenceINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcRefEvaluateWithMultiReferenceINTEL",
+		Class:    "@exclude",
+		Opcode:   5788,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12574,6 +13568,8 @@ var (
 	}
 	OpSubgroupAvcRefEvaluateWithMultiReferenceInterlacedINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcRefEvaluateWithMultiReferenceInterlacedINTEL",
+		Class:    "@exclude",
+		Opcode:   5789,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12609,6 +13605,8 @@ var (
 	}
 	OpSubgroupAvcRefConvertToMceResultINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcRefConvertToMceResultINTEL",
+		Class:    "@exclude",
+		Opcode:   5790,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12629,6 +13627,8 @@ var (
 	}
 	OpSubgroupAvcSicInitializeINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicInitializeINTEL",
+		Class:    "@exclude",
+		Opcode:   5791,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12649,6 +13649,8 @@ var (
 	}
 	OpSubgroupAvcSicConfigureSkcINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicConfigureSkcINTEL",
+		Class:    "@exclude",
+		Opcode:   5792,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12694,6 +13696,8 @@ var (
 	}
 	OpSubgroupAvcSicConfigureIpeLumaINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicConfigureIpeLumaINTEL",
+		Class:    "@exclude",
+		Opcode:   5793,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12749,6 +13753,8 @@ var (
 	}
 	OpSubgroupAvcSicConfigureIpeLumaChromaINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicConfigureIpeLumaChromaINTEL",
+		Class:    "@exclude",
+		Opcode:   5794,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12819,6 +13825,8 @@ var (
 	}
 	OpSubgroupAvcSicGetMotionVectorMaskINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicGetMotionVectorMaskINTEL",
+		Class:    "@exclude",
+		Opcode:   5795,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12844,6 +13852,8 @@ var (
 	}
 	OpSubgroupAvcSicConvertToMcePayloadINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicConvertToMcePayloadINTEL",
+		Class:    "@exclude",
+		Opcode:   5796,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12864,6 +13874,8 @@ var (
 	}
 	OpSubgroupAvcSicSetIntraLumaShapePenaltyINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicSetIntraLumaShapePenaltyINTEL",
+		Class:    "@exclude",
+		Opcode:   5797,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12889,6 +13901,8 @@ var (
 	}
 	OpSubgroupAvcSicSetIntraLumaModeCostFunctionINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicSetIntraLumaModeCostFunctionINTEL",
+		Class:    "@exclude",
+		Opcode:   5798,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12924,6 +13938,8 @@ var (
 	}
 	OpSubgroupAvcSicSetIntraChromaModeCostFunctionINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicSetIntraChromaModeCostFunctionINTEL",
+		Class:    "@exclude",
+		Opcode:   5799,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12949,6 +13965,8 @@ var (
 	}
 	OpSubgroupAvcSicSetBilinearFilterEnableINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicSetBilinearFilterEnableINTEL",
+		Class:    "@exclude",
+		Opcode:   5800,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12969,6 +13987,8 @@ var (
 	}
 	OpSubgroupAvcSicSetSkcForwardTransformEnableINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicSetSkcForwardTransformEnableINTEL",
+		Class:    "@exclude",
+		Opcode:   5801,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -12994,6 +14014,8 @@ var (
 	}
 	OpSubgroupAvcSicSetBlockBasedRawSkipSadINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicSetBlockBasedRawSkipSadINTEL",
+		Class:    "@exclude",
+		Opcode:   5802,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -13019,6 +14041,8 @@ var (
 	}
 	OpSubgroupAvcSicEvaluateIpeINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicEvaluateIpeINTEL",
+		Class:    "@exclude",
+		Opcode:   5803,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -13044,6 +14068,8 @@ var (
 	}
 	OpSubgroupAvcSicEvaluateWithSingleReferenceINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicEvaluateWithSingleReferenceINTEL",
+		Class:    "@exclude",
+		Opcode:   5804,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -13074,6 +14100,8 @@ var (
 	}
 	OpSubgroupAvcSicEvaluateWithDualReferenceINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicEvaluateWithDualReferenceINTEL",
+		Class:    "@exclude",
+		Opcode:   5805,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -13109,6 +14137,8 @@ var (
 	}
 	OpSubgroupAvcSicEvaluateWithMultiReferenceINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicEvaluateWithMultiReferenceINTEL",
+		Class:    "@exclude",
+		Opcode:   5806,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -13139,6 +14169,8 @@ var (
 	}
 	OpSubgroupAvcSicEvaluateWithMultiReferenceInterlacedINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicEvaluateWithMultiReferenceInterlacedINTEL",
+		Class:    "@exclude",
+		Opcode:   5807,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -13174,6 +14206,8 @@ var (
 	}
 	OpSubgroupAvcSicConvertToMceResultINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicConvertToMceResultINTEL",
+		Class:    "@exclude",
+		Opcode:   5808,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -13194,6 +14228,8 @@ var (
 	}
 	OpSubgroupAvcSicGetIpeLumaShapeINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicGetIpeLumaShapeINTEL",
+		Class:    "@exclude",
+		Opcode:   5809,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -13214,6 +14250,8 @@ var (
 	}
 	OpSubgroupAvcSicGetBestIpeLumaDistortionINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicGetBestIpeLumaDistortionINTEL",
+		Class:    "@exclude",
+		Opcode:   5810,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -13234,6 +14272,8 @@ var (
 	}
 	OpSubgroupAvcSicGetBestIpeChromaDistortionINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicGetBestIpeChromaDistortionINTEL",
+		Class:    "@exclude",
+		Opcode:   5811,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -13254,6 +14294,8 @@ var (
 	}
 	OpSubgroupAvcSicGetPackedIpeLumaModesINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicGetPackedIpeLumaModesINTEL",
+		Class:    "@exclude",
+		Opcode:   5812,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -13274,6 +14316,8 @@ var (
 	}
 	OpSubgroupAvcSicGetIpeChromaModeINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicGetIpeChromaModeINTEL",
+		Class:    "@exclude",
+		Opcode:   5813,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -13294,6 +14338,8 @@ var (
 	}
 	OpSubgroupAvcSicGetPackedSkcLumaCountThresholdINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicGetPackedSkcLumaCountThresholdINTEL",
+		Class:    "@exclude",
+		Opcode:   5814,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -13314,6 +14360,8 @@ var (
 	}
 	OpSubgroupAvcSicGetPackedSkcLumaSumThresholdINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicGetPackedSkcLumaSumThresholdINTEL",
+		Class:    "@exclude",
+		Opcode:   5815,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,
@@ -13334,6 +14382,8 @@ var (
 	}
 	OpSubgroupAvcSicGetInterRawSadsINTEL = &Opcode {
 		Opname:   "OpSubgroupAvcSicGetInterRawSadsINTEL",
+		Class:    "@exclude",
+		Opcode:   5816,
 		Operands: []Operand {
 			Operand {
 				Kind:       OperandKindIdResultType,

--- a/utils/vscode/src/schema/schema.go.tmpl
+++ b/utils/vscode/src/schema/schema.go.tmpl
@@ -105,6 +105,8 @@ var (
 
 {{range $i := .Instructions}}	{{$i.Opname}} = &Opcode {
 		Opname:   "{{$i.Opname}}",
+		Class:    "{{$i.Class}}",
+		Opcode:   {{$i.Opcode}},
 		Operands: []Operand {•{{range $i := $i.Operands}}
 			Operand {
 				Kind:       OperandKind{{$i.Kind}},


### PR DESCRIPTION
These were declared in the `Opcode` struct type, but were never assigned.
They're not actually used by the language server, but I reused this go schema package for a local experiment and found they were missing.