### PR TITLE
spirv-fuzz: Add fuzzer passes to add loads/stores

### DIFF
--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -41,8 +41,10 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_add_dead_breaks.h
         fuzzer_pass_add_dead_continues.h
         fuzzer_pass_add_global_variables.h
+        fuzzer_pass_add_loads.h
         fuzzer_pass_add_local_variables.h
         fuzzer_pass_add_no_contraction_decorations.h
+        fuzzer_pass_add_stores.h
         fuzzer_pass_add_useful_constructs.h
         fuzzer_pass_adjust_function_controls.h
         fuzzer_pass_adjust_loop_controls.h
@@ -90,6 +92,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_composite_construct.h
         transformation_composite_extract.h
         transformation_copy_object.h
+        transformation_load.h
         transformation_merge_blocks.h
         transformation_move_block_down.h
         transformation_outline_function.h
@@ -101,6 +104,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_set_memory_operands_mask.h
         transformation_set_selection_control.h
         transformation_split_block.h
+        transformation_store.h
         transformation_vector_shuffle.h
         uniform_buffer_element_descriptor.h
         ${CMAKE_CURRENT_BINARY_DIR}/protobufs/spvtoolsfuzz.pb.h
@@ -116,8 +120,10 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_add_dead_breaks.cpp
         fuzzer_pass_add_dead_continues.cpp
         fuzzer_pass_add_global_variables.cpp
+        fuzzer_pass_add_loads.cpp
         fuzzer_pass_add_local_variables.cpp
         fuzzer_pass_add_no_contraction_decorations.cpp
+        fuzzer_pass_add_stores.cpp
         fuzzer_pass_add_useful_constructs.cpp
         fuzzer_pass_adjust_function_controls.cpp
         fuzzer_pass_adjust_loop_controls.cpp
@@ -164,6 +170,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_composite_construct.cpp
         transformation_composite_extract.cpp
         transformation_copy_object.cpp
+        transformation_load.cpp
         transformation_merge_blocks.cpp
         transformation_move_block_down.cpp
         transformation_outline_function.cpp
@@ -175,6 +182,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_set_memory_operands_mask.cpp
         transformation_set_selection_control.cpp
         transformation_split_block.cpp
+        transformation_store.cpp
         transformation_vector_shuffle.cpp
         uniform_buffer_element_descriptor.cpp
         ${CMAKE_CURRENT_BINARY_DIR}/protobufs/spvtoolsfuzz.pb.cc

--- a/source/fuzz/fact_manager.cpp
+++ b/source/fuzz/fact_manager.cpp
@@ -860,30 +860,30 @@ bool FactManager::LivesafeFunctionFacts::FunctionIsLivesafe(
 //==============================
 
 //==============================
-// Arbitrarily-valued variable facts
+// Irrelevant pointee value facts
 
 // The purpose of this class is to group the fields and data used to represent
-// facts about livesafe functions.
-class FactManager::ArbitrarilyValuedVaribleFacts {
+// facts about pointers whose pointee values are irrelevant.
+class FactManager::IrrelevantPointeeValueFacts {
  public:
   // See method in FactManager which delegates to this method.
-  void AddFact(const protobufs::FactValueOfVariableIsArbitrary& fact);
+  void AddFact(const protobufs::FactPointeeValueIsIrrelevant& fact);
 
   // See method in FactManager which delegates to this method.
-  bool VariableValueIsArbitrary(uint32_t variable_id) const;
+  bool PointeeValueIsIrrelevant(uint32_t pointer_id) const;
 
  private:
-  std::set<uint32_t> arbitrary_valued_varible_ids_;
+  std::set<uint32_t> pointers_to_irrelevant_pointees_ids_;
 };
 
-void FactManager::ArbitrarilyValuedVaribleFacts::AddFact(
-    const protobufs::FactValueOfVariableIsArbitrary& fact) {
-  arbitrary_valued_varible_ids_.insert(fact.variable_id());
+void FactManager::IrrelevantPointeeValueFacts::AddFact(
+    const protobufs::FactPointeeValueIsIrrelevant& fact) {
+  pointers_to_irrelevant_pointees_ids_.insert(fact.pointer_id());
 }
 
-bool FactManager::ArbitrarilyValuedVaribleFacts::VariableValueIsArbitrary(
-    uint32_t variable_id) const {
-  return arbitrary_valued_varible_ids_.count(variable_id) != 0;
+bool FactManager::IrrelevantPointeeValueFacts::PointeeValueIsIrrelevant(
+    uint32_t pointer_id) const {
+  return pointers_to_irrelevant_pointees_ids_.count(pointer_id) != 0;
 }
 
 // End of arbitrarily-valued variable facts
@@ -894,8 +894,8 @@ FactManager::FactManager()
       data_synonym_facts_(MakeUnique<DataSynonymFacts>()),
       dead_block_facts_(MakeUnique<DeadBlockFacts>()),
       livesafe_function_facts_(MakeUnique<LivesafeFunctionFacts>()),
-      arbitrarily_valued_variable_facts_(
-          MakeUnique<ArbitrarilyValuedVaribleFacts>()) {}
+      irrelevant_pointee_value_facts_(
+          MakeUnique<IrrelevantPointeeValueFacts>()) {}
 
 FactManager::~FactManager() = default;
 
@@ -1017,15 +1017,14 @@ void FactManager::AddFactFunctionIsLivesafe(uint32_t function_id) {
   livesafe_function_facts_->AddFact(fact);
 }
 
-bool FactManager::VariableValueIsArbitrary(uint32_t variable_id) const {
-  return arbitrarily_valued_variable_facts_->VariableValueIsArbitrary(
-      variable_id);
+bool FactManager::PointeeValueIsIrrelevant(uint32_t pointer_id) const {
+  return irrelevant_pointee_value_facts_->PointeeValueIsIrrelevant(pointer_id);
 }
 
-void FactManager::AddFactValueOfVariableIsArbitrary(uint32_t variable_id) {
-  protobufs::FactValueOfVariableIsArbitrary fact;
-  fact.set_variable_id(variable_id);
-  arbitrarily_valued_variable_facts_->AddFact(fact);
+void FactManager::AddFactValueOfPointeeIsIrrelevant(uint32_t pointer_id) {
+  protobufs::FactPointeeValueIsIrrelevant fact;
+  fact.set_pointer_id(pointer_id);
+  irrelevant_pointee_value_facts_->AddFact(fact);
 }
 
 }  // namespace fuzz

--- a/source/fuzz/fact_manager.h
+++ b/source/fuzz/fact_manager.h
@@ -64,9 +64,9 @@ class FactManager {
   // Records the fact that |function_id| is livesafe.
   void AddFactFunctionIsLivesafe(uint32_t function_id);
 
-  // Records the fact that |variable_id| has an arbitrary value and can thus be
-  // stored to without affecting the module's behaviour.
-  void AddFactValueOfVariableIsArbitrary(uint32_t variable_id);
+  // Records the fact that the value of the pointee associated with |pointer_id|
+  // is irrelevant: it does not affect the observable behaviour of the module.
+  void AddFactValueOfPointeeIsIrrelevant(uint32_t pointer_id);
 
   // The fact manager is responsible for managing a few distinct categories of
   // facts. In principle there could be different fact managers for each kind
@@ -161,12 +161,13 @@ class FactManager {
   //==============================
 
   //==============================
-  // Querying facts about arbitrarily-valued variables
+  // Querying facts about pointers with irrelevant pointee values
 
-  // Returns true if and ony if |variable_id| is arbitrarily-valued.
-  bool VariableValueIsArbitrary(uint32_t variable_id) const;
+  // Returns true if and ony if the value of the pointee associated with
+  // |pointer_id| is irrelevant.
+  bool PointeeValueIsIrrelevant(uint32_t pointer_id) const;
 
-  // End of arbitrarily-valued variable facts
+  // End of irrelevant pointee value facts
   //==============================
 
  private:
@@ -191,10 +192,10 @@ class FactManager {
   std::unique_ptr<LivesafeFunctionFacts>
       livesafe_function_facts_;  // Unique pointer to internal data.
 
-  class ArbitrarilyValuedVaribleFacts;  // Opaque class for management of
-  // facts about variables whose values should be expected to be arbitrary.
-  std::unique_ptr<ArbitrarilyValuedVaribleFacts>
-      arbitrarily_valued_variable_facts_;  // Unique pointer to internal data.
+  class IrrelevantPointeeValueFacts;  // Opaque class for management of
+  // facts about pointers whose pointee values do not matter.
+  std::unique_ptr<IrrelevantPointeeValueFacts>
+      irrelevant_pointee_value_facts_;  // Unique pointer to internal data.
 };
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -26,8 +26,10 @@
 #include "source/fuzz/fuzzer_pass_add_dead_breaks.h"
 #include "source/fuzz/fuzzer_pass_add_dead_continues.h"
 #include "source/fuzz/fuzzer_pass_add_global_variables.h"
+#include "source/fuzz/fuzzer_pass_add_loads.h"
 #include "source/fuzz/fuzzer_pass_add_local_variables.h"
 #include "source/fuzz/fuzzer_pass_add_no_contraction_decorations.h"
+#include "source/fuzz/fuzzer_pass_add_stores.h"
 #include "source/fuzz/fuzzer_pass_add_useful_constructs.h"
 #include "source/fuzz/fuzzer_pass_adjust_function_controls.h"
 #include "source/fuzz/fuzzer_pass_adjust_loop_controls.h"
@@ -196,9 +198,15 @@ Fuzzer::FuzzerResultStatus Fuzzer::Run(
     MaybeAddPass<FuzzerPassAddGlobalVariables>(&passes, ir_context.get(),
                                                &fact_manager, &fuzzer_context,
                                                transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddLoads>(&passes, ir_context.get(), &fact_manager,
+                                     &fuzzer_context,
+                                     transformation_sequence_out);
     MaybeAddPass<FuzzerPassAddLocalVariables>(&passes, ir_context.get(),
                                               &fact_manager, &fuzzer_context,
                                               transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddStores>(&passes, ir_context.get(), &fact_manager,
+                                      &fuzzer_context,
+                                      transformation_sequence_out);
     MaybeAddPass<FuzzerPassApplyIdSynonyms>(&passes, ir_context.get(),
                                             &fact_manager, &fuzzer_context,
                                             transformation_sequence_out);

--- a/source/fuzz/fuzzer_context.cpp
+++ b/source/fuzz/fuzzer_context.cpp
@@ -30,10 +30,12 @@ const std::pair<uint32_t, uint32_t> kChanceOfAddingDeadBlock = {20, 90};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingDeadBreak = {5, 80};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingDeadContinue = {5, 80};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingGlobalVariable = {20, 90};
+const std::pair<uint32_t, uint32_t> kChanceOfAddingLoad = {5, 50};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingLocalVariable = {20, 90};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingMatrixType = {20, 70};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingNoContractionDecoration = {
     5, 70};
+const std::pair<uint32_t, uint32_t> kChanceOfAddingStore = {5, 50};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingVectorType = {20, 70};
 const std::pair<uint32_t, uint32_t> kChanceOfAdjustingFunctionControl = {20,
                                                                          70};
@@ -92,12 +94,14 @@ FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
       ChooseBetweenMinAndMax(kChanceOfAddingDeadContinue);
   chance_of_adding_global_variable_ =
       ChooseBetweenMinAndMax(kChanceOfAddingGlobalVariable);
+  chance_of_adding_load_ = ChooseBetweenMinAndMax(kChanceOfAddingLoad);
   chance_of_adding_local_variable_ =
       ChooseBetweenMinAndMax(kChanceOfAddingLocalVariable);
   chance_of_adding_matrix_type_ =
       ChooseBetweenMinAndMax(kChanceOfAddingMatrixType);
   chance_of_adding_no_contraction_decoration_ =
       ChooseBetweenMinAndMax(kChanceOfAddingNoContractionDecoration);
+  chance_of_adding_store_ = ChooseBetweenMinAndMax(kChanceOfAddingStore);
   chance_of_adding_vector_type_ =
       ChooseBetweenMinAndMax(kChanceOfAddingVectorType);
   chance_of_adjusting_function_control_ =

--- a/source/fuzz/fuzzer_context.h
+++ b/source/fuzz/fuzzer_context.h
@@ -72,6 +72,7 @@ class FuzzerContext {
   uint32_t GetChanceOfAddingGlobalVariable() {
     return chance_of_adding_global_variable_;
   }
+  uint32_t GetChanceOfAddingLoad() { return chance_of_adding_load_; }
   uint32_t GetChanceOfAddingLocalVariable() {
     return chance_of_adding_local_variable_;
   }
@@ -81,6 +82,7 @@ class FuzzerContext {
   uint32_t GetChanceOfAddingNoContractionDecoration() {
     return chance_of_adding_no_contraction_decoration_;
   }
+  uint32_t GetChanceOfAddingStore() { return chance_of_adding_store_; }
   uint32_t GetChanceOfAddingVectorType() {
     return chance_of_adding_vector_type_;
   }
@@ -155,9 +157,11 @@ class FuzzerContext {
   uint32_t chance_of_adding_dead_break_;
   uint32_t chance_of_adding_dead_continue_;
   uint32_t chance_of_adding_global_variable_;
+  uint32_t chance_of_adding_load_;
   uint32_t chance_of_adding_local_variable_;
   uint32_t chance_of_adding_matrix_type_;
   uint32_t chance_of_adding_no_contraction_decoration_;
+  uint32_t chance_of_adding_store_;
   uint32_t chance_of_adding_vector_type_;
   uint32_t chance_of_adjusting_function_control_;
   uint32_t chance_of_adjusting_loop_control_;

--- a/source/fuzz/fuzzer_pass_add_loads.cpp
+++ b/source/fuzz/fuzzer_pass_add_loads.cpp
@@ -1,0 +1,85 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/fuzzer_pass_add_loads.h"
+
+#include "source/fuzz/fuzzer_util.h"
+#include "source/fuzz/transformation_load.h"
+
+namespace spvtools {
+namespace fuzz {
+
+FuzzerPassAddLoads::FuzzerPassAddLoads(
+    opt::IRContext* ir_context, FactManager* fact_manager,
+    FuzzerContext* fuzzer_context,
+    protobufs::TransformationSequence* transformations)
+    : FuzzerPass(ir_context, fact_manager, fuzzer_context, transformations) {}
+
+FuzzerPassAddLoads::~FuzzerPassAddLoads() = default;
+
+void FuzzerPassAddLoads::Apply() {
+  MaybeAddTransformationBeforeEachInstruction(
+      [this](const opt::Function& function, opt::BasicBlock* block,
+             opt::BasicBlock::iterator inst_it,
+             const protobufs::InstructionDescriptor& instruction_descriptor)
+          -> void {
+        assert(inst_it->opcode() ==
+                   instruction_descriptor.target_instruction_opcode() &&
+               "The opcode of the instruction we might insert before must be "
+               "the same as the opcode in the descriptor for the instruction");
+
+        // Check whether it is legitimate to insert a load before this
+        // instruction.
+        if (!fuzzerutil::CanInsertOpcodeBeforeInstruction(SpvOpLoad, inst_it)) {
+          return;
+        }
+
+        // Randomly decide whether to try inserting an object copy here.
+        if (!GetFuzzerContext()->ChoosePercentage(
+                GetFuzzerContext()->GetChanceOfAddingLoad())) {
+          return;
+        }
+
+        std::vector<opt::Instruction*> relevant_instructions =
+            FindAvailableInstructions(
+                function, block, inst_it,
+                [](opt::IRContext* context,
+                   opt::Instruction* instruction) -> bool {
+                  if (!instruction->result_id() || !instruction->type_id()) {
+                    return false;
+                  }
+                  return context->get_def_use_mgr()
+                             ->GetDef(instruction->type_id())
+                             ->opcode() == SpvOpTypePointer;
+                });
+
+        // At this point, |relevant_instructions| contains all the pointers
+        // we might think of loading from.
+        if (relevant_instructions.empty()) {
+          return;
+        }
+
+        // Choose a pointer at random, and create and apply a loading
+        // transformation based on it.
+        ApplyTransformation(TransformationLoad(
+            GetFuzzerContext()->GetFreshId(),
+            relevant_instructions[GetFuzzerContext()->RandomIndex(
+                                      relevant_instructions)]
+                ->result_id(),
+            instruction_descriptor));
+      });
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/fuzzer_pass_add_loads.h
+++ b/source/fuzz/fuzzer_pass_add_loads.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_FUZZER_PASS_ADD_LOADS_H_
+#define SOURCE_FUZZ_FUZZER_PASS_ADD_LOADS_H_
+
+#include "source/fuzz/fuzzer_pass.h"
+
+namespace spvtools {
+namespace fuzz {
+
+// Fuzzer pass that adds stores, at random, from pointers in the module.
+class FuzzerPassAddLoads : public FuzzerPass {
+ public:
+  FuzzerPassAddLoads(opt::IRContext* ir_context, FactManager* fact_manager,
+                     FuzzerContext* fuzzer_context,
+                     protobufs::TransformationSequence* transformations);
+
+  ~FuzzerPassAddLoads();
+
+  void Apply() override;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_FUZZER_PASS_ADD_LOADS_H_

--- a/source/fuzz/fuzzer_pass_add_local_variables.h
+++ b/source/fuzz/fuzzer_pass_add_local_variables.h
@@ -17,9 +17,6 @@
 
 #include "source/fuzz/fuzzer_pass.h"
 
-#include <utility>
-#include <vector>
-
 namespace spvtools {
 namespace fuzz {
 

--- a/source/fuzz/fuzzer_pass_add_stores.cpp
+++ b/source/fuzz/fuzzer_pass_add_stores.cpp
@@ -1,0 +1,115 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/fuzzer_pass_add_stores.h"
+
+#include "source/fuzz/fuzzer_util.h"
+#include "source/fuzz/transformation_store.h"
+
+namespace spvtools {
+namespace fuzz {
+
+FuzzerPassAddStores::FuzzerPassAddStores(
+    opt::IRContext* ir_context, FactManager* fact_manager,
+    FuzzerContext* fuzzer_context,
+    protobufs::TransformationSequence* transformations)
+    : FuzzerPass(ir_context, fact_manager, fuzzer_context, transformations) {}
+
+FuzzerPassAddStores::~FuzzerPassAddStores() = default;
+
+void FuzzerPassAddStores::Apply() {
+  MaybeAddTransformationBeforeEachInstruction(
+      [this](const opt::Function& function, opt::BasicBlock* block,
+             opt::BasicBlock::iterator inst_it,
+             const protobufs::InstructionDescriptor& instruction_descriptor)
+          -> void {
+        assert(inst_it->opcode() ==
+                   instruction_descriptor.target_instruction_opcode() &&
+               "The opcode of the instruction we might insert before must be "
+               "the same as the opcode in the descriptor for the instruction");
+
+        // Check whether it is legitimate to insert a store before this
+        // instruction.
+        if (!fuzzerutil::CanInsertOpcodeBeforeInstruction(SpvOpStore,
+                                                          inst_it)) {
+          return;
+        }
+
+        // Randomly decide whether to try inserting an object copy here.
+        if (!GetFuzzerContext()->ChoosePercentage(
+                GetFuzzerContext()->GetChanceOfAddingStore())) {
+          return;
+        }
+
+        std::vector<opt::Instruction*> relevant_pointers =
+            FindAvailableInstructions(
+                function, block, inst_it,
+                [this, block](opt::IRContext* context,
+                              opt::Instruction* instruction) -> bool {
+                  if (!instruction->result_id() || !instruction->type_id()) {
+                    return false;
+                  }
+                  auto type_inst = context->get_def_use_mgr()->GetDef(
+                      instruction->type_id());
+                  if (type_inst->opcode() != SpvOpTypePointer) {
+                    return false;
+                  }
+                  if (type_inst->GetSingleWordInOperand(0) ==
+                      SpvStorageClassInput) {
+                    return false;
+                  }
+                  return GetFactManager()->BlockIsDead(block->id()) ||
+                         GetFactManager()->PointeeValueIsIrrelevant(
+                             instruction->result_id());
+                });
+
+        // At this point, |relevant_pointers| contains all the pointers we might
+        // think of storing to.
+        if (relevant_pointers.empty()) {
+          return;
+        }
+
+        auto pointer = relevant_pointers[GetFuzzerContext()->RandomIndex(
+            relevant_pointers)];
+
+        std::vector<opt::Instruction*> relevant_values =
+            FindAvailableInstructions(
+                function, block, inst_it,
+                [pointer](opt::IRContext* context,
+                          opt::Instruction* instruction) -> bool {
+                  if (!instruction->result_id() || !instruction->type_id()) {
+                    return false;
+                  }
+                  return instruction->type_id() ==
+                         context->get_def_use_mgr()
+                             ->GetDef(pointer->type_id())
+                             ->GetSingleWordInOperand(1);
+                });
+
+        if (relevant_values.empty()) {
+          return;
+        }
+
+        // Choose a value at random, and create and apply a storing
+        // transformation based on it and the pointer.
+        ApplyTransformation(TransformationStore(
+            pointer->result_id(),
+            relevant_values[GetFuzzerContext()->RandomIndex(relevant_values)]
+                ->result_id(),
+            instruction_descriptor));
+      });
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/fuzzer_pass_add_stores.h
+++ b/source/fuzz/fuzzer_pass_add_stores.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020  Google LLC
+// Copyright (c) 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/fuzz/fuzzer_pass_add_stores.h
+++ b/source/fuzz/fuzzer_pass_add_stores.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2020  Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_FUZZER_PASS_ADD_STORES_H_
+#define SOURCE_FUZZ_FUZZER_PASS_ADD_STORES_H_
+
+#include "source/fuzz/fuzzer_pass.h"
+
+namespace spvtools {
+namespace fuzz {
+
+// Fuzzer pass that adds stores, at random, through pointers in the module,
+// either (a) from dead blocks, or (b) through pointers whose pointee values
+// are known not to affect the module's overall behaviour.
+class FuzzerPassAddStores : public FuzzerPass {
+ public:
+  FuzzerPassAddStores(opt::IRContext* ir_context, FactManager* fact_manager,
+                      FuzzerContext* fuzzer_context,
+                      protobufs::TransformationSequence* transformations);
+
+  ~FuzzerPassAddStores();
+
+  void Apply() override;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_FUZZER_PASS_ADD_STORES_H_

--- a/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
@@ -97,9 +97,9 @@ void FuzzerPassApplyIdSynonyms::Apply() {
           continue;
         }
 
-        if (!fuzzerutil::IdsIsAvailableAtUse(GetIRContext(), use_inst,
-                                             use_in_operand_index,
-                                             synonym_to_try->object())) {
+        if (!fuzzerutil::IdIsAvailableAtUse(GetIRContext(), use_inst,
+                                            use_in_operand_index,
+                                            synonym_to_try->object())) {
           continue;
         }
 

--- a/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
@@ -97,9 +97,9 @@ void FuzzerPassApplyIdSynonyms::Apply() {
           continue;
         }
 
-        if (!TransformationReplaceIdWithSynonym::IdsIsAvailableAtUse(
-                GetIRContext(), use_inst, use_in_operand_index,
-                synonym_to_try->object())) {
+        if (!fuzzerutil::IdsIsAvailableAtUse(GetIRContext(), use_inst,
+                                             use_in_operand_index,
+                                             synonym_to_try->object())) {
           continue;
         }
 

--- a/source/fuzz/fuzzer_pass_copy_objects.cpp
+++ b/source/fuzz/fuzzer_pass_copy_objects.cpp
@@ -64,15 +64,11 @@ void FuzzerPassCopyObjects::Apply() {
 
         // Choose a copyable instruction at random, and create and apply an
         // object copying transformation based on it.
-        uint32_t index = GetFuzzerContext()->RandomIndex(relevant_instructions);
-        TransformationCopyObject transformation(
-            relevant_instructions[index]->result_id(), instruction_descriptor,
-            GetFuzzerContext()->GetFreshId());
-        assert(transformation.IsApplicable(GetIRContext(), *GetFactManager()) &&
-               "This transformation should be applicable by construction.");
-        transformation.Apply(GetIRContext(), GetFactManager());
-        *GetTransformations()->add_transformation() =
-            transformation.ToMessage();
+        ApplyTransformation(TransformationCopyObject(
+            relevant_instructions[GetFuzzerContext()->RandomIndex(
+                                      relevant_instructions)]
+                ->result_id(),
+            instruction_descriptor, GetFuzzerContext()->GetFreshId()));
       });
 }
 

--- a/source/fuzz/fuzzer_pass_donate_modules.cpp
+++ b/source/fuzz/fuzzer_pass_donate_modules.cpp
@@ -397,7 +397,7 @@ void FuzzerPassDonateModules::HandleTypesAndValues(
         // storage class global variable, using remapped versions of the result
         // type and initializer ids for the global variable in the donor.
         //
-        // We regard the added variable as having an arbitrary value.  This
+        // We regard the added variable as having an irrelevant value.  This
         // means that future passes can add stores to the variable in any
         // way they wish, and pass them as pointer parameters to functions
         // without worrying about whether their data might get modified.

--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -400,9 +400,9 @@ opt::Function* FindFunction(opt::IRContext* ir_context, uint32_t function_id) {
   return nullptr;
 }
 
-bool IdsIsAvailableAtUse(opt::IRContext* context,
-                         opt::Instruction* use_instruction,
-                         uint32_t use_input_operand_index, uint32_t id) {
+bool IdIsAvailableAtUse(opt::IRContext* context,
+                        opt::Instruction* use_instruction,
+                        uint32_t use_input_operand_index, uint32_t id) {
   auto defining_instruction = context->get_def_use_mgr()->GetDef(id);
   auto enclosing_function =
       context->get_instr_block(use_instruction)->GetParent();
@@ -433,9 +433,9 @@ bool IdsIsAvailableAtUse(opt::IRContext* context,
   return dominator_analysis->Dominates(defining_instruction, use_instruction);
 }
 
-bool IdsIsAvailableBeforeInstruction(opt::IRContext* context,
-                                     opt::Instruction* instruction,
-                                     uint32_t id) {
+bool IdIsAvailableBeforeInstruction(opt::IRContext* context,
+                                    opt::Instruction* instruction,
+                                    uint32_t id) {
   auto defining_instruction = context->get_def_use_mgr()->GetDef(id);
   auto enclosing_function = context->get_instr_block(instruction)->GetParent();
   // If the id a function parameter, it needs to be associated with the

--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -400,6 +400,39 @@ opt::Function* FindFunction(opt::IRContext* ir_context, uint32_t function_id) {
   return nullptr;
 }
 
+bool IdsIsAvailableAtUse(opt::IRContext* context,
+                         opt::Instruction* use_instruction,
+                         uint32_t use_input_operand_index, uint32_t id) {
+  auto defining_instruction = context->get_def_use_mgr()->GetDef(id);
+  auto enclosing_function =
+      context->get_instr_block(use_instruction)->GetParent();
+  // If the id a function parameter, it needs to be associated with the
+  // function containing the use.
+  if (defining_instruction->opcode() == SpvOpFunctionParameter) {
+    return InstructionIsFunctionParameter(defining_instruction,
+                                          enclosing_function);
+  }
+  if (!context->get_instr_block(id)) {
+    // The id must be at global scope.
+    return true;
+  }
+  if (defining_instruction == use_instruction) {
+    // It is not OK for a definition to use itself.
+    return false;
+  }
+  auto dominator_analysis = context->GetDominatorAnalysis(enclosing_function);
+  if (use_instruction->opcode() == SpvOpPhi) {
+    // In the case where the use is an operand to OpPhi, it is actually the
+    // *parent* block associated with the operand that must be dominated by
+    // the synonym.
+    auto parent_block =
+        use_instruction->GetSingleWordInOperand(use_input_operand_index + 1);
+    return dominator_analysis->Dominates(
+        context->get_instr_block(defining_instruction)->id(), parent_block);
+  }
+  return dominator_analysis->Dominates(defining_instruction, use_instruction);
+}
+
 bool IdsIsAvailableBeforeInstruction(opt::IRContext* context,
                                      opt::Instruction* instruction,
                                      uint32_t id) {

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -141,6 +141,17 @@ uint32_t FindFunctionType(opt::IRContext* ir_context,
 // function exists.
 opt::Function* FindFunction(opt::IRContext* ir_context, uint32_t function_id);
 
+// Checks whether |id| is available (according to dominance rules) at the
+// program point directly before |instruction|.
+bool IdsIsAvailableBeforeInstruction(opt::IRContext* context,
+                                     opt::Instruction* instruction,
+                                     uint32_t id);
+
+// Returns true if and only if |instruction| is an OpFunctionParameter
+// associated with |function|.
+bool InstructionIsFunctionParameter(opt::Instruction* instruction,
+                                    opt::Function* function);
+
 }  // namespace fuzzerutil
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -144,15 +144,14 @@ opt::Function* FindFunction(opt::IRContext* ir_context, uint32_t function_id);
 // Checks whether |id| is available (according to dominance rules) at the use
 // point defined by input operand |use_input_operand_index| of
 // |use_instruction|.
-bool IdsIsAvailableAtUse(opt::IRContext* context,
-                         opt::Instruction* use_instruction,
-                         uint32_t use_input_operand_index, uint32_t id);
+bool IdIsAvailableAtUse(opt::IRContext* context,
+                        opt::Instruction* use_instruction,
+                        uint32_t use_input_operand_index, uint32_t id);
 
 // Checks whether |id| is available (according to dominance rules) at the
 // program point directly before |instruction|.
-bool IdsIsAvailableBeforeInstruction(opt::IRContext* context,
-                                     opt::Instruction* instruction,
-                                     uint32_t id);
+bool IdIsAvailableBeforeInstruction(opt::IRContext* context,
+                                    opt::Instruction* instruction, uint32_t id);
 
 // Returns true if and only if |instruction| is an OpFunctionParameter
 // associated with |function|.

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -141,6 +141,13 @@ uint32_t FindFunctionType(opt::IRContext* ir_context,
 // function exists.
 opt::Function* FindFunction(opt::IRContext* ir_context, uint32_t function_id);
 
+// Checks whether |id| is available (according to dominance rules) at the use
+// point defined by input operand |use_input_operand_index| of
+// |use_instruction|.
+bool IdsIsAvailableAtUse(opt::IRContext* context,
+                         opt::Instruction* use_instruction,
+                         uint32_t use_input_operand_index, uint32_t id);
+
 // Checks whether |id| is available (according to dominance rules) at the
 // program point directly before |instruction|.
 bool IdsIsAvailableBeforeInstruction(opt::IRContext* context,

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -168,7 +168,7 @@ message Fact {
     FactDataSynonym data_synonym_fact = 2;
     FactBlockIsDead block_is_dead_fact = 3;
     FactFunctionIsLivesafe function_is_livesafe_fact = 4;
-    FactValueOfVariableIsArbitrary value_of_variable_is_arbitrary = 5;
+    FactPointeeValueIsIrrelevant pointee_value_does_not_matter = 5;
   }
 }
 
@@ -223,17 +223,15 @@ message FactFunctionIsLivesafe {
   uint32 function_id = 1;
 }
 
-message FactValueOfVariableIsArbitrary {
+message FactPointeeValueIsIrrelevant {
 
-  // Records the fact that the value stored in the variable or function
-  // parameter with the given id can be arbitrary: the module's observable
-  // behaviour does not depend on it.  This means that arbitrary stores can be
-  // made to the variable, and that nothing can be guaranteed about values
-  // loaded from the variable.
+  // Records the fact that value of the data pointed to by a pointer id does
+  // not influence the observable behaviour of the module.  This means that
+  // arbitrary stores can be made through the pointer, and that nothing can be
+  // guaranteed about the values that are loaded via the pointer.
 
-  // The result id of an OpVariable instruction, or an OpFunctionParameter
-  // instruction with pointer type
-  uint32 variable_id = 1;
+  // A result id of pointer type
+  uint32 pointer_id = 1;
 }
 
 message AccessChainClampingInfo {
@@ -340,6 +338,8 @@ message Transformation {
     TransformationAddFunction add_function = 33;
     TransformationAddDeadBlock add_dead_block = 34;
     TransformationAddLocalVariable add_local_variable = 35;
+    TransformationLoad load = 36;
+    TransformationStore store = 37;
     // Add additional option using the next available number.
   }
 }
@@ -511,7 +511,7 @@ message TransformationAddGlobalVariable {
   // True if and only if the behaviour of the module should not depend on the
   // value of the variable, in which case stores to the variable can be
   // performed in an arbitrary fashion.
-  bool value_is_arbitrary = 4;
+  bool value_is_irrelevant = 4;
 
 }
 
@@ -536,7 +536,7 @@ message TransformationAddLocalVariable {
   // True if and only if the behaviour of the module should not depend on the
   // value of the variable, in which case stores to the variable can be
   // performed in an arbitrary fashion.
-  bool value_is_arbitrary = 5;
+  bool value_is_irrelevant = 5;
 
 }
 
@@ -728,6 +728,22 @@ message TransformationCopyObject {
 
   // A fresh id for the copied object
   uint32 fresh_id = 3;
+
+}
+
+message TransformationLoad {
+
+  // Transformation that adds an OpLoad instruction from a pointer into an id.
+
+  // The result of the load instruction
+  uint32 fresh_id = 1;
+
+  // The pointer to be loaded from
+  uint32 pointer_id = 2;
+
+  // A descriptor for an instruction in a block before which the new OpLoad
+  // instruction should be inserted
+  InstructionDescriptor instruction_to_insert_before = 3;
 
 }
 
@@ -940,6 +956,22 @@ message TransformationSplitBlock {
   // earlier transformations, it may inhibit later transformations from
   // applying.
   uint32 fresh_id = 2;
+
+}
+
+message TransformationStore {
+
+  // Transformation that adds an OpStore instruction of an id to a pointer.
+
+  // The pointer to be stored to
+  uint32 pointer_id = 1;
+
+  // The value to be stored
+  uint32 value_id = 2;
+
+  // A descriptor for an instruction in a block before which the new OpStore
+  // instruction should be inserted
+  InstructionDescriptor instruction_to_insert_before = 3;
 
 }
 

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -168,7 +168,7 @@ message Fact {
     FactDataSynonym data_synonym_fact = 2;
     FactBlockIsDead block_is_dead_fact = 3;
     FactFunctionIsLivesafe function_is_livesafe_fact = 4;
-    FactPointeeValueIsIrrelevant pointee_value_does_not_matter = 5;
+    FactPointeeValueIsIrrelevant pointee_value_is_irrelevant = 5;
   }
 }
 

--- a/source/fuzz/transformation.cpp
+++ b/source/fuzz/transformation.cpp
@@ -40,6 +40,7 @@
 #include "source/fuzz/transformation_composite_construct.h"
 #include "source/fuzz/transformation_composite_extract.h"
 #include "source/fuzz/transformation_copy_object.h"
+#include "source/fuzz/transformation_load.h"
 #include "source/fuzz/transformation_merge_blocks.h"
 #include "source/fuzz/transformation_move_block_down.h"
 #include "source/fuzz/transformation_outline_function.h"
@@ -51,6 +52,7 @@
 #include "source/fuzz/transformation_set_memory_operands_mask.h"
 #include "source/fuzz/transformation_set_selection_control.h"
 #include "source/fuzz/transformation_split_block.h"
+#include "source/fuzz/transformation_store.h"
 #include "source/fuzz/transformation_vector_shuffle.h"
 #include "source/util/make_unique.h"
 
@@ -122,6 +124,8 @@ std::unique_ptr<Transformation> Transformation::FromMessage(
           message.composite_extract());
     case protobufs::Transformation::TransformationCase::kCopyObject:
       return MakeUnique<TransformationCopyObject>(message.copy_object());
+    case protobufs::Transformation::TransformationCase::kLoad:
+      return MakeUnique<TransformationLoad>(message.load());
     case protobufs::Transformation::TransformationCase::kMergeBlocks:
       return MakeUnique<TransformationMergeBlocks>(message.merge_blocks());
     case protobufs::Transformation::TransformationCase::kMoveBlockDown:
@@ -154,6 +158,8 @@ std::unique_ptr<Transformation> Transformation::FromMessage(
           message.set_selection_control());
     case protobufs::Transformation::TransformationCase::kSplitBlock:
       return MakeUnique<TransformationSplitBlock>(message.split_block());
+    case protobufs::Transformation::TransformationCase::kStore:
+      return MakeUnique<TransformationStore>(message.store());
     case protobufs::Transformation::TransformationCase::kVectorShuffle:
       return MakeUnique<TransformationVectorShuffle>(message.vector_shuffle());
     case protobufs::Transformation::TRANSFORMATION_NOT_SET:

--- a/source/fuzz/transformation_add_function.cpp
+++ b/source/fuzz/transformation_add_function.cpp
@@ -155,7 +155,7 @@ void TransformationAddFunction::Apply(
                     // that |success| is not used).
 
   // Record the fact that all pointer parameters and variables declared in the
-  // function should be regarded as having arbitrary values.  This allows other
+  // function should be regarded as having irrelevant values.  This allows other
   // passes to store arbitrarily to such variables, and to pass them freely as
   // parameters to other functions knowing that it is OK if they get
   // over-written.
@@ -165,12 +165,12 @@ void TransformationAddFunction::Apply(
         if (context->get_def_use_mgr()
                 ->GetDef(instruction.result_type_id())
                 ->opcode() == SpvOpTypePointer) {
-          fact_manager->AddFactValueOfVariableIsArbitrary(
+          fact_manager->AddFactValueOfPointeeIsIrrelevant(
               instruction.result_id());
         }
         break;
       case SpvOpVariable:
-        fact_manager->AddFactValueOfVariableIsArbitrary(
+        fact_manager->AddFactValueOfPointeeIsIrrelevant(
             instruction.result_id());
         break;
       default:

--- a/source/fuzz/transformation_add_global_variable.cpp
+++ b/source/fuzz/transformation_add_global_variable.cpp
@@ -25,11 +25,11 @@ TransformationAddGlobalVariable::TransformationAddGlobalVariable(
 
 TransformationAddGlobalVariable::TransformationAddGlobalVariable(
     uint32_t fresh_id, uint32_t type_id, uint32_t initializer_id,
-    bool value_is_arbitrary) {
+    bool value_is_irrelevant) {
   message_.set_fresh_id(fresh_id);
   message_.set_type_id(type_id);
   message_.set_initializer_id(initializer_id);
-  message_.set_value_is_arbitrary(value_is_arbitrary);
+  message_.set_value_is_irrelevant(value_is_irrelevant);
 }
 
 bool TransformationAddGlobalVariable::IsApplicable(
@@ -101,8 +101,8 @@ void TransformationAddGlobalVariable::Apply(
     }
   }
 
-  if (message_.value_is_arbitrary()) {
-    fact_manager->AddFactValueOfVariableIsArbitrary(message_.fresh_id());
+  if (message_.value_is_irrelevant()) {
+    fact_manager->AddFactValueOfPointeeIsIrrelevant(message_.fresh_id());
   }
 
   // We have added an instruction to the module, so need to be careful about the

--- a/source/fuzz/transformation_add_global_variable.h
+++ b/source/fuzz/transformation_add_global_variable.h
@@ -30,7 +30,7 @@ class TransformationAddGlobalVariable : public Transformation {
 
   TransformationAddGlobalVariable(uint32_t fresh_id, uint32_t type_id,
                                   uint32_t initializer_id,
-                                  bool value_is_arbitrary);
+                                  bool value_is_irrelevant);
 
   // - |message_.fresh_id| must be fresh
   // - |message_.type_id| must be the id of a pointer type with Private storage
@@ -44,6 +44,9 @@ class TransformationAddGlobalVariable : public Transformation {
   // |message_.type_id| and either no initializer or |message_.initializer_id|
   // as an initializer, depending on whether |message_.initializer_id| is 0.
   // The global variable has result id |message_.fresh_id|.
+  //
+  // If |message_.value_is_irrelevant| holds, adds a corresponding fact to
+  // |fact_manager|.
   void Apply(opt::IRContext* context, FactManager* fact_manager) const override;
 
   protobufs::Transformation ToMessage() const override;

--- a/source/fuzz/transformation_add_local_variable.cpp
+++ b/source/fuzz/transformation_add_local_variable.cpp
@@ -25,12 +25,12 @@ TransformationAddLocalVariable::TransformationAddLocalVariable(
 
 TransformationAddLocalVariable::TransformationAddLocalVariable(
     uint32_t fresh_id, uint32_t type_id, uint32_t function_id,
-    uint32_t initializer_id, bool value_is_arbitrary) {
+    uint32_t initializer_id, bool value_is_irrelevant) {
   message_.set_fresh_id(fresh_id);
   message_.set_type_id(type_id);
   message_.set_function_id(function_id);
   message_.set_initializer_id(initializer_id);
-  message_.set_value_is_arbitrary(value_is_arbitrary);
+  message_.set_value_is_irrelevant(value_is_irrelevant);
 }
 
 bool TransformationAddLocalVariable::IsApplicable(
@@ -82,8 +82,8 @@ void TransformationAddLocalVariable::Apply(
 
                     SpvStorageClassFunction}},
                {SPV_OPERAND_TYPE_ID, {message_.initializer_id()}}})));
-  if (message_.value_is_arbitrary()) {
-    fact_manager->AddFactValueOfVariableIsArbitrary(message_.fresh_id());
+  if (message_.value_is_irrelevant()) {
+    fact_manager->AddFactValueOfPointeeIsIrrelevant(message_.fresh_id());
   }
   context->InvalidateAnalysesExceptFor(opt::IRContext::kAnalysisNone);
 }

--- a/source/fuzz/transformation_add_local_variable.h
+++ b/source/fuzz/transformation_add_local_variable.h
@@ -30,7 +30,7 @@ class TransformationAddLocalVariable : public Transformation {
 
   TransformationAddLocalVariable(uint32_t fresh_id, uint32_t type_id,
                                  uint32_t function_id, uint32_t initializer_id,
-                                 bool value_is_arbitrary);
+                                 bool value_is_irrelevant);
 
   // - |message_.fresh_id| must not be used by the module
   // - |message_.type_id| must be the id of a pointer type with Function
@@ -44,7 +44,7 @@ class TransformationAddLocalVariable : public Transformation {
   // Adds an instruction to the start of |message_.function_id|, of the form:
   //   |message_.fresh_id| = OpVariable |message_.type_id| Function
   //                         |message_.initializer_id|
-  // If |message_.value_is_arbitrary| holds, adds a corresponding fact to
+  // If |message_.value_is_irrelevant| holds, adds a corresponding fact to
   // |fact_manager|.
   void Apply(opt::IRContext* context, FactManager* fact_manager) const override;
 

--- a/source/fuzz/transformation_composite_construct.cpp
+++ b/source/fuzz/transformation_composite_construct.cpp
@@ -84,27 +84,8 @@ bool TransformationCompositeConstruct::IsApplicable(
   // Now check whether every component being used to initialize the composite is
   // available at the desired program point.
   for (auto& component : message_.component()) {
-    auto component_inst = context->get_def_use_mgr()->GetDef(component);
-    if (!context->get_instr_block(component)) {
-      // The component does not have a block; that means it is in global scope,
-      // which is OK. (Whether the component actually corresponds to an
-      // instruction is checked above when determining whether types are
-      // suitable.)
-      continue;
-    }
-    // Check whether the component is available.
-    if (insert_before->HasResultId() &&
-        insert_before->result_id() == component) {
-      // This constitutes trying to use an id right before it is defined.  The
-      // special case is needed due to an instruction always dominating itself.
-      return false;
-    }
-    if (!context
-             ->GetDominatorAnalysis(
-                 context->get_instr_block(&*insert_before)->GetParent())
-             ->Dominates(component_inst, &*insert_before)) {
-      // The instruction defining the component must dominate the instruction we
-      // wish to insert the composite before.
+    if (!fuzzerutil::IdsIsAvailableBeforeInstruction(context, insert_before,
+                                                     component)) {
       return false;
     }
   }

--- a/source/fuzz/transformation_composite_construct.cpp
+++ b/source/fuzz/transformation_composite_construct.cpp
@@ -84,8 +84,8 @@ bool TransformationCompositeConstruct::IsApplicable(
   // Now check whether every component being used to initialize the composite is
   // available at the desired program point.
   for (auto& component : message_.component()) {
-    if (!fuzzerutil::IdsIsAvailableBeforeInstruction(context, insert_before,
-                                                     component)) {
+    if (!fuzzerutil::IdIsAvailableBeforeInstruction(context, insert_before,
+                                                    component)) {
       return false;
     }
   }

--- a/source/fuzz/transformation_copy_object.cpp
+++ b/source/fuzz/transformation_copy_object.cpp
@@ -64,20 +64,10 @@ bool TransformationCopyObject::IsApplicable(
     return false;
   }
 
-  // |message_object| must be available at the point where we want to add the
-  // copy. It is available if it is at global scope (in which case it has no
-  // block), or if it dominates the point of insertion but is different from the
-  // point of insertion.
-  //
-  // The reason why the object needs to be different from the insertion point is
-  // that the copy will be added *before* this point, and we do not want to
-  // insert it before the object's defining instruction.
-  return !context->get_instr_block(object_inst) ||
-         (object_inst != &*insert_before &&
-          context
-              ->GetDominatorAnalysis(
-                  context->get_instr_block(insert_before)->GetParent())
-              ->Dominates(object_inst, &*insert_before));
+  // |message_object| must be available directly before the point where we want
+  // to add the copy.
+  return fuzzerutil::IdsIsAvailableBeforeInstruction(context, insert_before,
+                                                     message_.object());
 }
 
 void TransformationCopyObject::Apply(opt::IRContext* context,

--- a/source/fuzz/transformation_copy_object.cpp
+++ b/source/fuzz/transformation_copy_object.cpp
@@ -66,8 +66,8 @@ bool TransformationCopyObject::IsApplicable(
 
   // |message_object| must be available directly before the point where we want
   // to add the copy.
-  return fuzzerutil::IdsIsAvailableBeforeInstruction(context, insert_before,
-                                                     message_.object());
+  return fuzzerutil::IdIsAvailableBeforeInstruction(context, insert_before,
+                                                    message_.object());
 }
 
 void TransformationCopyObject::Apply(opt::IRContext* context,

--- a/source/fuzz/transformation_copy_object.cpp
+++ b/source/fuzz/transformation_copy_object.cpp
@@ -105,6 +105,10 @@ void TransformationCopyObject::Apply(opt::IRContext* context,
   fact_manager->AddFactDataSynonym(MakeDataDescriptor(message_.object(), {}),
                                    MakeDataDescriptor(message_.fresh_id(), {}),
                                    context);
+
+  if (fact_manager->PointeeValueIsIrrelevant(message_.object())) {
+    fact_manager->AddFactValueOfPointeeIsIrrelevant(message_.fresh_id());
+  }
 }
 
 protobufs::Transformation TransformationCopyObject::ToMessage() const {

--- a/source/fuzz/transformation_copy_object.h
+++ b/source/fuzz/transformation_copy_object.h
@@ -57,7 +57,10 @@ class TransformationCopyObject : public Transformation {
   //   is added directly before the instruction at |message_.insert_after_id| +
   //   |message_|.offset, where %ty is the type of |message_.object|.
   // - The fact that |message_.fresh_id| and |message_.object| are synonyms
-  //   is added to the fact manager.
+  //   is added to |fact_manager|.
+  // - If |message_.object| is a pointer whose pointee value is known to be
+  //   irrelevant, the analogous fact is added to |fact_manager| about
+  //   |message_.fresh_id|.
   void Apply(opt::IRContext* context, FactManager* fact_manager) const override;
 
   protobufs::Transformation ToMessage() const override;

--- a/source/fuzz/transformation_load.cpp
+++ b/source/fuzz/transformation_load.cpp
@@ -76,8 +76,8 @@ bool TransformationLoad::IsApplicable(
   }
 
   // The pointer needs to be available at the insertion point.
-  return fuzzerutil::IdsIsAvailableBeforeInstruction(context, insert_before,
-                                                     message_.pointer_id());
+  return fuzzerutil::IdIsAvailableBeforeInstruction(context, insert_before,
+                                                    message_.pointer_id());
 }
 
 void TransformationLoad::Apply(opt::IRContext* context,

--- a/source/fuzz/transformation_load.cpp
+++ b/source/fuzz/transformation_load.cpp
@@ -1,0 +1,93 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_load.h"
+
+#include "source/fuzz/fuzzer_util.h"
+#include "source/fuzz/instruction_descriptor.h"
+
+namespace spvtools {
+namespace fuzz {
+
+TransformationLoad::TransformationLoad(
+    const spvtools::fuzz::protobufs::TransformationLoad& message)
+    : message_(message) {}
+
+TransformationLoad::TransformationLoad(
+    uint32_t fresh_id, uint32_t pointer_id,
+    const protobufs::InstructionDescriptor& instruction_to_insert_before) {
+  message_.set_fresh_id(fresh_id);
+  message_.set_pointer_id(pointer_id);
+  *message_.mutable_instruction_to_insert_before() =
+      instruction_to_insert_before;
+}
+
+bool TransformationLoad::IsApplicable(
+    opt::IRContext* context,
+    const spvtools::fuzz::FactManager& /*unused*/) const {
+  if (!fuzzerutil::IsFreshId(context, message_.fresh_id())) {
+    return false;
+  }
+  auto pointer = context->get_def_use_mgr()->GetDef(message_.pointer_id());
+  if (!pointer || !pointer->type_id()) {
+    return false;
+  }
+  auto pointer_type = context->get_def_use_mgr()->GetDef(pointer->type_id());
+  assert(pointer_type && "Type id must be defined.");
+  if (pointer_type->opcode() != SpvOpTypePointer) {
+    return false;
+  }
+  switch (pointer->opcode()) {
+    case SpvOpConstantNull:
+    case SpvOpUndef:
+      // Do not load from a null or undefined pointer.
+      return false;
+    default:
+      break;
+  }
+
+  auto insert_before =
+      FindInstruction(message_.instruction_to_insert_before(), context);
+  if (!fuzzerutil::CanInsertOpcodeBeforeInstruction(SpvOpLoad, insert_before)) {
+    return false;
+  }
+
+  return fuzzerutil::IdsIsAvailableBeforeInstruction(context, insert_before,
+                                                     message_.pointer_id());
+}
+
+void TransformationLoad::Apply(opt::IRContext* context,
+                               spvtools::fuzz::FactManager* /*unused*/) const {
+  uint32_t result_type = context->get_def_use_mgr()
+                             ->GetDef(context->get_def_use_mgr()
+                                          ->GetDef(message_.pointer_id())
+                                          ->type_id())
+                             ->GetSingleWordInOperand(1);
+  fuzzerutil::UpdateModuleIdBound(context, message_.fresh_id());
+  FindInstruction(message_.instruction_to_insert_before(), context)
+      ->InsertBefore(MakeUnique<opt::Instruction>(
+          context, SpvOpLoad, result_type, message_.fresh_id(),
+          opt::Instruction::OperandList(
+              {{SPV_OPERAND_TYPE_ID, {message_.pointer_id()}}})));
+  context->InvalidateAnalysesExceptFor(opt::IRContext::kAnalysisNone);
+}
+
+protobufs::Transformation TransformationLoad::ToMessage() const {
+  protobufs::Transformation result;
+  *result.mutable_load() = message_;
+  return result;
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/transformation_load.h
+++ b/source/fuzz/transformation_load.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_TRANSFORMATION_LOAD_H_
+#define SOURCE_FUZZ_TRANSFORMATION_LOAD_H_
+
+#include "source/fuzz/fact_manager.h"
+#include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
+#include "source/fuzz/transformation.h"
+#include "source/opt/ir_context.h"
+
+namespace spvtools {
+namespace fuzz {
+
+class TransformationLoad : public Transformation {
+ public:
+  explicit TransformationLoad(const protobufs::TransformationLoad& message);
+
+  TransformationLoad(
+      uint32_t fresh_id, uint32_t pointer_id,
+      const protobufs::InstructionDescriptor& instruction_to_insert_before);
+
+  // TODO comment
+  bool IsApplicable(opt::IRContext* context,
+                    const FactManager& fact_manager) const override;
+
+  // TODO comment
+  void Apply(opt::IRContext* context, FactManager* fact_manager) const override;
+
+  protobufs::Transformation ToMessage() const override;
+
+ private:
+  protobufs::TransformationLoad message_;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_TRANSFORMATION_LOAD_H_

--- a/source/fuzz/transformation_load.h
+++ b/source/fuzz/transformation_load.h
@@ -31,11 +31,20 @@ class TransformationLoad : public Transformation {
       uint32_t fresh_id, uint32_t pointer_id,
       const protobufs::InstructionDescriptor& instruction_to_insert_before);
 
-  // TODO comment
+  // - |message_.fresh_id| must be fresh
+  // - |message_.pointer_id| must be the id of a pointer
+  // - The pointer must not be OpConstantNull or OpUndef
+  // - |message_.instruction_to_insert_before| must identify an instruction
+  //   before which it is valid to insert an OpLoad, and where
+  //   |message_.pointer_id| is available (according to dominance rules)
   bool IsApplicable(opt::IRContext* context,
                     const FactManager& fact_manager) const override;
 
-  // TODO comment
+  // Adds an instruction of the form:
+  //   |message_.fresh_id| = OpLoad %type |message_.pointer_id|
+  // before the instruction identified by
+  // |message_.instruction_to_insert_before|, where %type is the pointer's
+  // pointee type.
   void Apply(opt::IRContext* context, FactManager* fact_manager) const override;
 
   protobufs::Transformation ToMessage() const override;

--- a/source/fuzz/transformation_outline_function.cpp
+++ b/source/fuzz/transformation_outline_function.cpp
@@ -617,10 +617,10 @@ TransformationOutlineFunction::PrepareFunctionPrototype(
         context, SpvOpFunctionParameter,
         context->get_def_use_mgr()->GetDef(id)->type_id(),
         input_id_to_fresh_id_map.at(id), opt::Instruction::OperandList()));
-    // If the input id is an arbitrary-valued variable, the same should be true
+    // If the input id is an irrelevant-valued variable, the same should be true
     // of the corresponding parameter.
-    if (fact_manager->VariableValueIsArbitrary(id)) {
-      fact_manager->AddFactValueOfVariableIsArbitrary(
+    if (fact_manager->PointeeValueIsIrrelevant(id)) {
+      fact_manager->AddFactValueOfPointeeIsIrrelevant(
           input_id_to_fresh_id_map.at(id));
     }
   }

--- a/source/fuzz/transformation_replace_id_with_synonym.cpp
+++ b/source/fuzz/transformation_replace_id_with_synonym.cpp
@@ -65,7 +65,7 @@ bool TransformationReplaceIdWithSynonym::IsApplicable(
 
   // The transformation is applicable if the synonymous id is available at the
   // use point.
-  return fuzzerutil::IdsIsAvailableAtUse(
+  return fuzzerutil::IdIsAvailableAtUse(
       context, use_instruction, message_.id_use_descriptor().in_operand_index(),
       message_.synonymous_id());
 }

--- a/source/fuzz/transformation_replace_id_with_synonym.cpp
+++ b/source/fuzz/transformation_replace_id_with_synonym.cpp
@@ -65,9 +65,9 @@ bool TransformationReplaceIdWithSynonym::IsApplicable(
 
   // The transformation is applicable if the synonymous id is available at the
   // use point.
-  return IdsIsAvailableAtUse(context, use_instruction,
-                             message_.id_use_descriptor().in_operand_index(),
-                             message_.synonymous_id());
+  return fuzzerutil::IdsIsAvailableAtUse(
+      context, use_instruction, message_.id_use_descriptor().in_operand_index(),
+      message_.synonymous_id());
 }
 
 void TransformationReplaceIdWithSynonym::Apply(
@@ -86,30 +86,6 @@ protobufs::Transformation TransformationReplaceIdWithSynonym::ToMessage()
   protobufs::Transformation result;
   *result.mutable_replace_id_with_synonym() = message_;
   return result;
-}
-
-bool TransformationReplaceIdWithSynonym::IdsIsAvailableAtUse(
-    opt::IRContext* context, opt::Instruction* use_instruction,
-    uint32_t use_input_operand_index, uint32_t id) {
-  if (!context->get_instr_block(id)) {
-    return true;
-  }
-  auto defining_instruction = context->get_def_use_mgr()->GetDef(id);
-  if (defining_instruction == use_instruction) {
-    return false;
-  }
-  auto dominator_analysis = context->GetDominatorAnalysis(
-      context->get_instr_block(use_instruction)->GetParent());
-  if (use_instruction->opcode() == SpvOpPhi) {
-    // In the case where the use is an operand to OpPhi, it is actually the
-    // *parent* block associated with the operand that must be dominated by
-    // the synonym.
-    auto parent_block =
-        use_instruction->GetSingleWordInOperand(use_input_operand_index + 1);
-    return dominator_analysis->Dominates(
-        context->get_instr_block(defining_instruction)->id(), parent_block);
-  }
-  return dominator_analysis->Dominates(defining_instruction, use_instruction);
 }
 
 bool TransformationReplaceIdWithSynonym::UseCanBeReplacedWithSynonym(

--- a/source/fuzz/transformation_replace_id_with_synonym.h
+++ b/source/fuzz/transformation_replace_id_with_synonym.h
@@ -51,14 +51,6 @@ class TransformationReplaceIdWithSynonym : public Transformation {
 
   protobufs::Transformation ToMessage() const override;
 
-  // Checks whether the |id| is available (according to dominance rules) at the
-  // use point defined by input operand |use_input_operand_index| of
-  // |use_instruction|.
-  static bool IdsIsAvailableAtUse(opt::IRContext* context,
-                                  opt::Instruction* use_instruction,
-                                  uint32_t use_input_operand_index,
-                                  uint32_t id);
-
   // Checks whether various conditions hold related to the acceptability of
   // replacing the id use at |use_in_operand_index| of |use_instruction| with
   // a synonym.  In particular, this checks that:

--- a/source/fuzz/transformation_store.cpp
+++ b/source/fuzz/transformation_store.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_store.h"
+
+#include "source/fuzz/fuzzer_util.h"
+#include "source/fuzz/instruction_descriptor.h"
+
+namespace spvtools {
+namespace fuzz {
+
+TransformationStore::TransformationStore(
+    const spvtools::fuzz::protobufs::TransformationStore& message)
+    : message_(message) {}
+
+TransformationStore::TransformationStore(
+    uint32_t pointer_id, uint32_t value_id,
+    const protobufs::InstructionDescriptor& instruction_to_insert_before) {
+  message_.set_pointer_id(pointer_id);
+  message_.set_value_id(value_id);
+  *message_.mutable_instruction_to_insert_before() =
+      instruction_to_insert_before;
+}
+
+bool TransformationStore::IsApplicable(
+    opt::IRContext* context,
+    const spvtools::fuzz::FactManager& fact_manager) const {
+  auto pointer = context->get_def_use_mgr()->GetDef(message_.pointer_id());
+  if (!pointer || !pointer->type_id()) {
+    return false;
+  }
+  auto pointer_type = context->get_def_use_mgr()->GetDef(pointer->type_id());
+  assert(pointer_type && "Type id must be defined.");
+  if (pointer_type->opcode() != SpvOpTypePointer) {
+    return false;
+  }
+  switch (pointer->opcode()) {
+    case SpvOpConstantNull:
+    case SpvOpUndef:
+      // Do not store to a null or undefined pointer.
+      return false;
+    default:
+      break;
+  }
+
+  auto insert_before =
+      FindInstruction(message_.instruction_to_insert_before(), context);
+  if (!fuzzerutil::CanInsertOpcodeBeforeInstruction(SpvOpStore,
+                                                    insert_before)) {
+    return false;
+  }
+
+  if (!fact_manager.BlockIsDead(
+          context->get_instr_block(insert_before)->id()) &&
+      !fact_manager.PointeeValueIsIrrelevant(message_.pointer_id())) {
+    return false;
+  }
+
+  if (pointer_type->GetSingleWordInOperand(1) !=
+      context->get_def_use_mgr()->GetDef(message_.value_id())->type_id()) {
+    return false;
+  }
+
+  if (pointer_type->GetSingleWordInOperand(0) == SpvStorageClassInput) {
+    return false;
+  }
+
+  return fuzzerutil::IdsIsAvailableBeforeInstruction(context, insert_before,
+                                                     message_.pointer_id()) &&
+         fuzzerutil::IdsIsAvailableBeforeInstruction(context, insert_before,
+                                                     message_.value_id());
+}
+
+void TransformationStore::Apply(opt::IRContext* context,
+                                spvtools::fuzz::FactManager* /*unused*/) const {
+  FindInstruction(message_.instruction_to_insert_before(), context)
+      ->InsertBefore(MakeUnique<opt::Instruction>(
+          context, SpvOpStore, 0, 0,
+          opt::Instruction::OperandList(
+              {{SPV_OPERAND_TYPE_ID, {message_.pointer_id()}},
+               {SPV_OPERAND_TYPE_ID, {message_.value_id()}}})));
+  context->InvalidateAnalysesExceptFor(opt::IRContext::kAnalysisNone);
+}
+
+protobufs::Transformation TransformationStore::ToMessage() const {
+  protobufs::Transformation result;
+  *result.mutable_store() = message_;
+  return result;
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/transformation_store.cpp
+++ b/source/fuzz/transformation_store.cpp
@@ -97,14 +97,14 @@ bool TransformationStore::IsApplicable(
   }
 
   // The pointer needs to be available at the insertion point.
-  if (!fuzzerutil::IdsIsAvailableBeforeInstruction(context, insert_before,
-                                                   message_.pointer_id())) {
+  if (!fuzzerutil::IdIsAvailableBeforeInstruction(context, insert_before,
+                                                  message_.pointer_id())) {
     return false;
   }
 
   // The value needs to be available at the insertion point.
-  return fuzzerutil::IdsIsAvailableBeforeInstruction(context, insert_before,
-                                                     message_.value_id());
+  return fuzzerutil::IdIsAvailableBeforeInstruction(context, insert_before,
+                                                    message_.value_id());
 }
 
 void TransformationStore::Apply(opt::IRContext* context,

--- a/source/fuzz/transformation_store.h
+++ b/source/fuzz/transformation_store.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_TRANSFORMATION_STORE_H_
+#define SOURCE_FUZZ_TRANSFORMATION_STORE_H_
+
+#include "source/fuzz/fact_manager.h"
+#include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
+#include "source/fuzz/transformation.h"
+#include "source/opt/ir_context.h"
+
+namespace spvtools {
+namespace fuzz {
+
+class TransformationStore : public Transformation {
+ public:
+  explicit TransformationStore(const protobufs::TransformationStore& message);
+
+  TransformationStore(
+      uint32_t pointer_id, uint32_t value_id,
+      const protobufs::InstructionDescriptor& instruction_to_insert_before);
+
+  // TODO comment
+  bool IsApplicable(opt::IRContext* context,
+                    const FactManager& fact_manager) const override;
+
+  // TODO comment
+  void Apply(opt::IRContext* context, FactManager* fact_manager) const override;
+
+  protobufs::Transformation ToMessage() const override;
+
+ private:
+  protobufs::TransformationStore message_;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_TRANSFORMATION_STORE_H_

--- a/source/fuzz/transformation_store.h
+++ b/source/fuzz/transformation_store.h
@@ -31,11 +31,24 @@ class TransformationStore : public Transformation {
       uint32_t pointer_id, uint32_t value_id,
       const protobufs::InstructionDescriptor& instruction_to_insert_before);
 
-  // TODO comment
+  // - |message_.pointer_id| must be the id of a pointer
+  // - The pointer type must not have read-only storage class
+  // - The pointer must not be OpConstantNull or OpUndef
+  // - |message_.value_id| must be an instruction result id that has the same
+  //   type as the pointee type of |message_.pointer_id|
+  // - |message_.instruction_to_insert_before| must identify an instruction
+  //   before which it is valid to insert an OpStore, and where both
+  //   |message_.pointer_id| and |message_.value_id| are available (according
+  //   to dominance rules)
+  // - Either the insertion point must be in a dead block, or it must be known
+  //   that the pointee value of |message_.pointer_id| is irrelevant
   bool IsApplicable(opt::IRContext* context,
                     const FactManager& fact_manager) const override;
 
-  // TODO comment
+  // Adds an instruction of the form:
+  //   OpStore |pointer_id| |value_id|
+  // before the instruction identified by
+  // |message_.instruction_to_insert_before|.
   void Apply(opt::IRContext* context, FactManager* fact_manager) const override;
 
   protobufs::Transformation ToMessage() const override;

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -47,6 +47,7 @@ if (${SPIRV_BUILD_FUZZER})
           transformation_composite_construct_test.cpp
           transformation_composite_extract_test.cpp
           transformation_copy_object_test.cpp
+          transformation_load_test.cpp
           transformation_merge_blocks_test.cpp
           transformation_move_block_down_test.cpp
           transformation_outline_function_test.cpp
@@ -58,6 +59,7 @@ if (${SPIRV_BUILD_FUZZER})
           transformation_set_memory_operands_mask_test.cpp
           transformation_set_selection_control_test.cpp
           transformation_split_block_test.cpp
+          transformation_store_test.cpp
           transformation_vector_shuffle_test.cpp
           uniform_buffer_element_descriptor_test.cpp)
 

--- a/test/fuzz/transformation_add_global_variable_test.cpp
+++ b/test/fuzz/transformation_add_global_variable_test.cpp
@@ -125,12 +125,12 @@ TEST(TransformationAddGlobalVariableTest, BasicTest) {
     ASSERT_TRUE(transformation.IsApplicable(context.get(), fact_manager));
     transformation.Apply(context.get(), &fact_manager);
   }
-  ASSERT_TRUE(fact_manager.VariableValueIsArbitrary(100));
-  ASSERT_TRUE(fact_manager.VariableValueIsArbitrary(102));
-  ASSERT_TRUE(fact_manager.VariableValueIsArbitrary(104));
-  ASSERT_FALSE(fact_manager.VariableValueIsArbitrary(101));
-  ASSERT_FALSE(fact_manager.VariableValueIsArbitrary(103));
-  ASSERT_FALSE(fact_manager.VariableValueIsArbitrary(105));
+  ASSERT_TRUE(fact_manager.PointeeValueIsIrrelevant(100));
+  ASSERT_TRUE(fact_manager.PointeeValueIsIrrelevant(102));
+  ASSERT_TRUE(fact_manager.PointeeValueIsIrrelevant(104));
+  ASSERT_FALSE(fact_manager.PointeeValueIsIrrelevant(101));
+  ASSERT_FALSE(fact_manager.PointeeValueIsIrrelevant(103));
+  ASSERT_FALSE(fact_manager.PointeeValueIsIrrelevant(105));
 
   ASSERT_TRUE(IsValid(env, context.get()));
 
@@ -234,9 +234,9 @@ TEST(TransformationAddGlobalVariableTest, TestEntryPointInterfaceEnlargement) {
     ASSERT_TRUE(transformation.IsApplicable(context.get(), fact_manager));
     transformation.Apply(context.get(), &fact_manager);
   }
-  ASSERT_TRUE(fact_manager.VariableValueIsArbitrary(100));
-  ASSERT_TRUE(fact_manager.VariableValueIsArbitrary(102));
-  ASSERT_FALSE(fact_manager.VariableValueIsArbitrary(101));
+  ASSERT_TRUE(fact_manager.PointeeValueIsIrrelevant(100));
+  ASSERT_TRUE(fact_manager.PointeeValueIsIrrelevant(102));
+  ASSERT_FALSE(fact_manager.PointeeValueIsIrrelevant(101));
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(

--- a/test/fuzz/transformation_add_local_variable_test.cpp
+++ b/test/fuzz/transformation_add_local_variable_test.cpp
@@ -133,12 +133,12 @@ TEST(TransformationAddLocalVariableTest, BasicTest) {
     transformation.Apply(context.get(), &fact_manager);
   }
 
-  ASSERT_FALSE(fact_manager.VariableValueIsArbitrary(100));
-  ASSERT_TRUE(fact_manager.VariableValueIsArbitrary(101));
-  ASSERT_FALSE(fact_manager.VariableValueIsArbitrary(102));
-  ASSERT_TRUE(fact_manager.VariableValueIsArbitrary(103));
-  ASSERT_FALSE(fact_manager.VariableValueIsArbitrary(104));
-  ASSERT_TRUE(fact_manager.VariableValueIsArbitrary(105));
+  ASSERT_FALSE(fact_manager.PointeeValueIsIrrelevant(100));
+  ASSERT_TRUE(fact_manager.PointeeValueIsIrrelevant(101));
+  ASSERT_FALSE(fact_manager.PointeeValueIsIrrelevant(102));
+  ASSERT_TRUE(fact_manager.PointeeValueIsIrrelevant(103));
+  ASSERT_FALSE(fact_manager.PointeeValueIsIrrelevant(104));
+  ASSERT_TRUE(fact_manager.PointeeValueIsIrrelevant(105));
 
   std::string after_transformation = R"(
                OpCapability Shader

--- a/test/fuzz/transformation_load_test.cpp
+++ b/test/fuzz/transformation_load_test.cpp
@@ -86,11 +86,11 @@ TEST(TransformationLoadTest, BasicTest) {
 
   FactManager fact_manager;
 
-  fact_manager.PointeeValueIsIrrelevant(27);
-  fact_manager.PointeeValueIsIrrelevant(11);
-  fact_manager.PointeeValueIsIrrelevant(46);
-  fact_manager.PointeeValueIsIrrelevant(16);
-  fact_manager.PointeeValueIsIrrelevant(52);
+  fact_manager.AddFactValueOfPointeeIsIrrelevant(27);
+  fact_manager.AddFactValueOfPointeeIsIrrelevant(11);
+  fact_manager.AddFactValueOfPointeeIsIrrelevant(46);
+  fact_manager.AddFactValueOfPointeeIsIrrelevant(16);
+  fact_manager.AddFactValueOfPointeeIsIrrelevant(52);
 
   fact_manager.AddFactBlockIsDead(36);
 
@@ -170,6 +170,11 @@ TEST(TransformationLoadTest, BasicTest) {
   ASSERT_FALSE(
       TransformationLoad(100, 40, MakeInstructionDescriptor(37, SpvOpReturn, 0))
           .IsApplicable(context.get(), fact_manager));
+
+  // Bad: The described instruction does not exist
+  ASSERT_FALSE(TransformationLoad(
+                   100, 33, MakeInstructionDescriptor(1000, SpvOpReturn, 0))
+                   .IsApplicable(context.get(), fact_manager));
 
   {
     TransformationLoad transformation(

--- a/test/fuzz/transformation_load_test.cpp
+++ b/test/fuzz/transformation_load_test.cpp
@@ -1,0 +1,272 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_load.h"
+#include "source/fuzz/instruction_descriptor.h"
+#include "test/fuzz/fuzz_test_util.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace {
+
+TEST(TransformationLoadTest, BasicTest) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypeFloat 32
+          %8 = OpTypeStruct %6 %7
+          %9 = OpTypePointer Function %8
+         %10 = OpTypeFunction %6 %9
+         %14 = OpConstant %6 0
+         %15 = OpTypePointer Function %6
+         %51 = OpTypePointer Private %6
+         %21 = OpConstant %6 2
+         %23 = OpConstant %6 1
+         %24 = OpConstant %7 1
+         %25 = OpTypePointer Function %7
+         %50 = OpTypePointer Private %7
+         %34 = OpTypeBool
+         %35 = OpConstantFalse %34
+         %60 = OpConstantNull %50
+         %61 = OpUndef %51
+         %52 = OpVariable %50 Private
+         %53 = OpVariable %51 Private
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %20 = OpVariable %9 Function
+         %27 = OpVariable %9 Function ; irrelevant
+         %22 = OpAccessChain %15 %20 %14
+         %44 = OpCopyObject %9 %20
+         %26 = OpAccessChain %25 %20 %23
+         %29 = OpFunctionCall %6 %12 %27
+         %30 = OpAccessChain %15 %20 %14
+         %45 = OpCopyObject %15 %30
+         %33 = OpAccessChain %15 %20 %14
+               OpSelectionMerge %37 None
+               OpBranchConditional %35 %36 %37
+         %36 = OpLabel
+         %38 = OpAccessChain %15 %20 %14
+         %40 = OpAccessChain %15 %20 %14
+         %43 = OpAccessChain %15 %20 %14
+               OpBranch %37
+         %37 = OpLabel
+               OpReturn
+               OpFunctionEnd
+         %12 = OpFunction %6 None %10
+         %11 = OpFunctionParameter %9 ; irrelevant
+         %13 = OpLabel
+         %46 = OpCopyObject %9 %11 ; irrelevant
+         %16 = OpAccessChain %15 %11 %14 ; irrelevant
+               OpReturnValue %21
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+
+  fact_manager.PointeeValueIsIrrelevant(27);
+  fact_manager.PointeeValueIsIrrelevant(11);
+  fact_manager.PointeeValueIsIrrelevant(46);
+  fact_manager.PointeeValueIsIrrelevant(16);
+  fact_manager.PointeeValueIsIrrelevant(52);
+
+  fact_manager.AddFactBlockIsDead(36);
+
+  // Variables with pointee types:
+  //  52 - ptr_to(7)
+  //  53 - ptr_to(6)
+  //  20 - ptr_to(8)
+  //  27 - ptr_to(8) - irrelevant
+
+  // Access chains with pointee type:
+  //  22 - ptr_to(6)
+  //  26 - ptr_to(6)
+  //  30 - ptr_to(6)
+  //  33 - ptr_to(6)
+  //  38 - ptr_to(6)
+  //  40 - ptr_to(6)
+  //  43 - ptr_to(6)
+  //  16 - ptr_to(6) - irrelevant
+
+  // Copied object with pointee type:
+  //  44 - ptr_to(8)
+  //  45 - ptr_to(6)
+  //  46 - ptr_to(8) - irrelevant
+
+  // Function parameters with pointee type:
+  //  11 - ptr_to(8) - irrelevant
+
+  // Pointers that cannot be used:
+  //  60 - null
+  //  61 - undefined
+
+  // Bad: id is not fresh
+  ASSERT_FALSE(TransformationLoad(
+                   33, 33, MakeInstructionDescriptor(38, SpvOpAccessChain, 0))
+                   .IsApplicable(context.get(), fact_manager));
+  // Bad: attempt to load from 11 from outside its function
+  ASSERT_FALSE(TransformationLoad(
+                   100, 11, MakeInstructionDescriptor(38, SpvOpAccessChain, 0))
+                   .IsApplicable(context.get(), fact_manager));
+
+  // Bad: pointer is not available
+  ASSERT_FALSE(TransformationLoad(
+                   100, 33, MakeInstructionDescriptor(45, SpvOpCopyObject, 0))
+                   .IsApplicable(context.get(), fact_manager));
+
+  // Bad: attempt to insert before OpVariable
+  ASSERT_FALSE(TransformationLoad(
+                   100, 27, MakeInstructionDescriptor(27, SpvOpVariable, 0))
+                   .IsApplicable(context.get(), fact_manager));
+
+  // Bad: pointer id does not exist
+  ASSERT_FALSE(
+      TransformationLoad(100, 1000,
+                         MakeInstructionDescriptor(38, SpvOpAccessChain, 0))
+          .IsApplicable(context.get(), fact_manager));
+
+  // Bad: pointer id exists but does not have a type
+  ASSERT_FALSE(TransformationLoad(
+                   100, 5, MakeInstructionDescriptor(38, SpvOpAccessChain, 0))
+                   .IsApplicable(context.get(), fact_manager));
+
+  // Bad: pointer id exists and has a type, but is not a pointer
+  ASSERT_FALSE(TransformationLoad(
+                   100, 24, MakeInstructionDescriptor(38, SpvOpAccessChain, 0))
+                   .IsApplicable(context.get(), fact_manager));
+
+  // Bad: attempt to load from null pointer
+  ASSERT_FALSE(TransformationLoad(
+                   100, 60, MakeInstructionDescriptor(38, SpvOpAccessChain, 0))
+                   .IsApplicable(context.get(), fact_manager));
+
+  // Bad: attempt to load from undefined pointer
+  ASSERT_FALSE(TransformationLoad(
+                   100, 61, MakeInstructionDescriptor(38, SpvOpAccessChain, 0))
+                   .IsApplicable(context.get(), fact_manager));
+  // Bad: %40 is not available at the program point
+  ASSERT_FALSE(
+      TransformationLoad(100, 40, MakeInstructionDescriptor(37, SpvOpReturn, 0))
+          .IsApplicable(context.get(), fact_manager));
+
+  {
+    TransformationLoad transformation(
+        100, 33, MakeInstructionDescriptor(38, SpvOpAccessChain, 0));
+    ASSERT_TRUE(transformation.IsApplicable(context.get(), fact_manager));
+    transformation.Apply(context.get(), &fact_manager);
+    ASSERT_TRUE(IsValid(env, context.get()));
+  }
+
+  {
+    TransformationLoad transformation(
+        101, 46, MakeInstructionDescriptor(16, SpvOpReturnValue, 0));
+    ASSERT_TRUE(transformation.IsApplicable(context.get(), fact_manager));
+    transformation.Apply(context.get(), &fact_manager);
+    ASSERT_TRUE(IsValid(env, context.get()));
+  }
+
+  {
+    TransformationLoad transformation(
+        102, 16, MakeInstructionDescriptor(16, SpvOpReturnValue, 0));
+    ASSERT_TRUE(transformation.IsApplicable(context.get(), fact_manager));
+    transformation.Apply(context.get(), &fact_manager);
+    ASSERT_TRUE(IsValid(env, context.get()));
+  }
+
+  {
+    TransformationLoad transformation(
+        103, 40, MakeInstructionDescriptor(43, SpvOpAccessChain, 0));
+    ASSERT_TRUE(transformation.IsApplicable(context.get(), fact_manager));
+    transformation.Apply(context.get(), &fact_manager);
+    ASSERT_TRUE(IsValid(env, context.get()));
+  }
+
+  std::string after_transformation = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypeFloat 32
+          %8 = OpTypeStruct %6 %7
+          %9 = OpTypePointer Function %8
+         %10 = OpTypeFunction %6 %9
+         %14 = OpConstant %6 0
+         %15 = OpTypePointer Function %6
+         %51 = OpTypePointer Private %6
+         %21 = OpConstant %6 2
+         %23 = OpConstant %6 1
+         %24 = OpConstant %7 1
+         %25 = OpTypePointer Function %7
+         %50 = OpTypePointer Private %7
+         %34 = OpTypeBool
+         %35 = OpConstantFalse %34
+         %60 = OpConstantNull %50
+         %61 = OpUndef %51
+         %52 = OpVariable %50 Private
+         %53 = OpVariable %51 Private
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %20 = OpVariable %9 Function
+         %27 = OpVariable %9 Function ; irrelevant
+         %22 = OpAccessChain %15 %20 %14
+         %44 = OpCopyObject %9 %20
+         %26 = OpAccessChain %25 %20 %23
+         %29 = OpFunctionCall %6 %12 %27
+         %30 = OpAccessChain %15 %20 %14
+         %45 = OpCopyObject %15 %30
+         %33 = OpAccessChain %15 %20 %14
+               OpSelectionMerge %37 None
+               OpBranchConditional %35 %36 %37
+         %36 = OpLabel
+        %100 = OpLoad %6 %33
+         %38 = OpAccessChain %15 %20 %14
+         %40 = OpAccessChain %15 %20 %14
+        %103 = OpLoad %6 %40
+         %43 = OpAccessChain %15 %20 %14
+               OpBranch %37
+         %37 = OpLabel
+               OpReturn
+               OpFunctionEnd
+         %12 = OpFunction %6 None %10
+         %11 = OpFunctionParameter %9 ; irrelevant
+         %13 = OpLabel
+         %46 = OpCopyObject %9 %11 ; irrelevant
+         %16 = OpAccessChain %15 %11 %14 ; irrelevant
+        %101 = OpLoad %8 %46
+        %102 = OpLoad %6 %16
+               OpReturnValue %21
+               OpFunctionEnd
+  )";
+  ASSERT_TRUE(IsEqual(env, after_transformation, context.get()));
+}
+
+}  // namespace
+}  // namespace fuzz
+}  // namespace spvtools

--- a/test/fuzz/transformation_outline_function_test.cpp
+++ b/test/fuzz/transformation_outline_function_test.cpp
@@ -1827,11 +1827,11 @@ TEST(TransformationOutlineFunctionTest,
 }
 
 TEST(TransformationOutlineFunctionTest, OutlineLivesafe) {
-  // In the following, %30 is a livesafe function, with arbitrary parameter
-  // %200 and arbitrary local variable %201.  Variable %100 is a loop limiter,
-  // which is not arbitrary.  The test checks that the outlined function is
+  // In the following, %30 is a livesafe function, with irrelevant parameter
+  // %200 and irrelevant local variable %201.  Variable %100 is a loop limiter,
+  // which is not irrelevant.  The test checks that the outlined function is
   // livesafe, and that the parameters corresponding to %200 and %201 have the
-  // arbitrary fact associated with them.
+  // irrelevant fact associated with them.
   std::string shader = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
@@ -1914,8 +1914,8 @@ TEST(TransformationOutlineFunctionTest, OutlineLivesafe) {
 
   FactManager fact_manager;
   fact_manager.AddFactFunctionIsLivesafe(30);
-  fact_manager.AddFactValueOfVariableIsArbitrary(200);
-  fact_manager.AddFactValueOfVariableIsArbitrary(201);
+  fact_manager.AddFactValueOfPointeeIsIrrelevant(200);
+  fact_manager.AddFactValueOfPointeeIsIrrelevant(201);
 
   TransformationOutlineFunction transformation(
       /*entry_block*/ 198,
@@ -1937,16 +1937,16 @@ TEST(TransformationOutlineFunctionTest, OutlineLivesafe) {
   ASSERT_TRUE(fact_manager.FunctionIsLivesafe(30));
   // The outlined function should be livesafe.
   ASSERT_TRUE(fact_manager.FunctionIsLivesafe(402));
-  // The variable and parameter that were originally arbitrary should still be.
-  ASSERT_TRUE(fact_manager.VariableValueIsArbitrary(200));
-  ASSERT_TRUE(fact_manager.VariableValueIsArbitrary(201));
-  // The loop limiter should still be non-arbitrary.
-  ASSERT_FALSE(fact_manager.VariableValueIsArbitrary(100));
-  // The parameters for the original arbitrary variables should be arbitrary.
-  ASSERT_TRUE(fact_manager.VariableValueIsArbitrary(408));
-  ASSERT_TRUE(fact_manager.VariableValueIsArbitrary(409));
-  // The parameter for the loop limiter should not be arbitrary.
-  ASSERT_FALSE(fact_manager.VariableValueIsArbitrary(407));
+  // The variable and parameter that were originally irrelevant should still be.
+  ASSERT_TRUE(fact_manager.PointeeValueIsIrrelevant(200));
+  ASSERT_TRUE(fact_manager.PointeeValueIsIrrelevant(201));
+  // The loop limiter should still be non-irrelevant.
+  ASSERT_FALSE(fact_manager.PointeeValueIsIrrelevant(100));
+  // The parameters for the original irrelevant variables should be irrelevant.
+  ASSERT_TRUE(fact_manager.PointeeValueIsIrrelevant(408));
+  ASSERT_TRUE(fact_manager.PointeeValueIsIrrelevant(409));
+  // The parameter for the loop limiter should not be irrelevant.
+  ASSERT_FALSE(fact_manager.PointeeValueIsIrrelevant(407));
 
   std::string after_transformation = R"(
                OpCapability Shader
@@ -2237,9 +2237,9 @@ TEST(TransformationOutlineFunctionTest, OutlineWithDeadBlocks2) {
 }
 
 TEST(TransformationOutlineFunctionTest,
-     OutlineWithArbitraryVariablesAndParameters) {
-  // This checks that if the outlined region uses a mixture of arbitrary and
-  // non-arbitrary variables and parameters, these properties are preserved
+     OutlineWithIrrelevantVariablesAndParameters) {
+  // This checks that if the outlined region uses a mixture of irrelevant and
+  // non-irrelevant variables and parameters, these properties are preserved
   // during outlining.
   std::string shader = R"(
                OpCapability Shader
@@ -2287,8 +2287,8 @@ TEST(TransformationOutlineFunctionTest,
   ASSERT_TRUE(IsValid(env, context.get()));
 
   FactManager fact_manager;
-  fact_manager.AddFactValueOfVariableIsArbitrary(9);
-  fact_manager.AddFactValueOfVariableIsArbitrary(14);
+  fact_manager.AddFactValueOfPointeeIsIrrelevant(9);
+  fact_manager.AddFactValueOfPointeeIsIrrelevant(14);
 
   TransformationOutlineFunction transformation(
       /*entry_block*/ 50,
@@ -2305,10 +2305,10 @@ TEST(TransformationOutlineFunctionTest,
   ASSERT_TRUE(transformation.IsApplicable(context.get(), fact_manager));
   transformation.Apply(context.get(), &fact_manager);
   ASSERT_TRUE(IsValid(env, context.get()));
-  // The variables that were originally abitrary, plus input parameters
-  // corresponding to them, should be arbitrary.  The rest should not be.
+  // The variables that were originally irrelevant, plus input parameters
+  // corresponding to them, should be irrelevant.  The rest should not be.
   for (uint32_t variable_id : {9u, 14u, 206u, 208u}) {
-    ASSERT_TRUE(fact_manager.VariableValueIsArbitrary(variable_id));
+    ASSERT_TRUE(fact_manager.PointeeValueIsIrrelevant(variable_id));
   }
   for (uint32_t variable_id : {10u, 20u, 207u, 209u}) {
     ASSERT_FALSE(fact_manager.BlockIsDead(variable_id));

--- a/test/fuzz/transformation_store_test.cpp
+++ b/test/fuzz/transformation_store_test.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_store.h"
+#include "test/fuzz/fuzz_test_util.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace {
+
+TEST(TransformationStoreTest, BasicTest) {
+  std::string shader = R"(
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+
+  // TODO - add test content
+
+  std::string after_transformation = R"(
+  )";
+  ASSERT_TRUE(IsEqual(env, after_transformation, context.get()));
+  FAIL();  // Remove once test is implemented
+}
+
+}  // namespace
+}  // namespace fuzz
+}  // namespace spvtools

--- a/test/fuzz/transformation_store_test.cpp
+++ b/test/fuzz/transformation_store_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_store.h"
+#include "source/fuzz/instruction_descriptor.h"
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -21,6 +22,70 @@ namespace {
 
 TEST(TransformationStoreTest, BasicTest) {
   std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main" %92 %52 %53
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpDecorate %92 BuiltIn FragCoord
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypeFloat 32
+          %8 = OpTypeStruct %6 %7
+          %9 = OpTypePointer Function %8
+         %10 = OpTypeFunction %6 %9
+         %14 = OpConstant %6 0
+         %15 = OpTypePointer Function %6
+         %51 = OpTypePointer Private %6
+         %21 = OpConstant %6 2
+         %23 = OpConstant %6 1
+         %24 = OpConstant %7 1
+         %25 = OpTypePointer Function %7
+         %50 = OpTypePointer Private %7
+         %34 = OpTypeBool
+         %35 = OpConstantFalse %34
+         %60 = OpConstantNull %50
+         %61 = OpUndef %51
+         %52 = OpVariable %50 Private
+         %53 = OpVariable %51 Private
+         %80 = OpConstantComposite %8 %21 %24
+         %90 = OpTypeVector %7 4
+         %91 = OpTypePointer Input %90
+         %92 = OpVariable %91 Input
+         %93 = OpConstantComposite %90 %24 %24 %24 %24
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %20 = OpVariable %9 Function
+         %27 = OpVariable %9 Function ; irrelevant
+         %22 = OpAccessChain %15 %20 %14
+         %44 = OpCopyObject %9 %20
+         %26 = OpAccessChain %25 %20 %23
+         %29 = OpFunctionCall %6 %12 %27
+         %30 = OpAccessChain %15 %20 %14
+         %45 = OpCopyObject %15 %30
+         %81 = OpCopyObject %9 %27 ; irrelevant
+         %33 = OpAccessChain %15 %20 %14
+               OpSelectionMerge %37 None
+               OpBranchConditional %35 %36 %37
+         %36 = OpLabel
+         %38 = OpAccessChain %15 %20 %14
+         %40 = OpAccessChain %15 %20 %14
+         %43 = OpAccessChain %15 %20 %14
+         %82 = OpCopyObject %9 %27 ; irrelevant
+               OpBranch %37
+         %37 = OpLabel
+               OpReturn
+               OpFunctionEnd
+         %12 = OpFunction %6 None %10
+         %11 = OpFunctionParameter %9 ; irrelevant
+         %13 = OpLabel
+         %46 = OpCopyObject %9 %11 ; irrelevant
+         %16 = OpAccessChain %15 %11 %14 ; irrelevant
+         %95 = OpCopyObject %8 %80
+               OpReturnValue %21
+               OpFunctionEnd
   )";
 
   const auto env = SPV_ENV_UNIVERSAL_1_4;
@@ -30,12 +95,245 @@ TEST(TransformationStoreTest, BasicTest) {
 
   FactManager fact_manager;
 
-  // TODO - add test content
+  fact_manager.AddFactValueOfPointeeIsIrrelevant(27);
+  fact_manager.AddFactValueOfPointeeIsIrrelevant(11);
+  fact_manager.AddFactValueOfPointeeIsIrrelevant(46);
+  fact_manager.AddFactValueOfPointeeIsIrrelevant(16);
+  fact_manager.AddFactValueOfPointeeIsIrrelevant(52);
+  fact_manager.AddFactValueOfPointeeIsIrrelevant(81);
+  fact_manager.AddFactValueOfPointeeIsIrrelevant(82);
+
+  fact_manager.AddFactBlockIsDead(36);
+
+  // Variables with pointee types:
+  //  52 - ptr_to(7)
+  //  53 - ptr_to(6)
+  //  20 - ptr_to(8)
+  //  27 - ptr_to(8) - irrelevant
+  //  92 - ptr_to(90) - read only
+
+  // Access chains with pointee type:
+  //  22 - ptr_to(6)
+  //  26 - ptr_to(6)
+  //  30 - ptr_to(6)
+  //  33 - ptr_to(6)
+  //  38 - ptr_to(6)
+  //  40 - ptr_to(6)
+  //  43 - ptr_to(6)
+  //  16 - ptr_to(6) - irrelevant
+
+  // Copied object with pointee type:
+  //  44 - ptr_to(8)
+  //  45 - ptr_to(6)
+  //  46 - ptr_to(8) - irrelevant
+  //  81 - ptr_to(8) - irrelevant
+  //  82 - ptr_to(8) - irrelevant
+
+  // Function parameters with pointee type:
+  //  11 - ptr_to(8) - irrelevant
+
+  // Pointers that cannot be used:
+  //  60 - null
+  //  61 - undefined
+
+  // Bad: attempt to store to 11 from outside its function
+  ASSERT_FALSE(TransformationStore(
+                   11, 80, MakeInstructionDescriptor(38, SpvOpAccessChain, 0))
+                   .IsApplicable(context.get(), fact_manager));
+
+  // Bad: pointer is not available
+  ASSERT_FALSE(TransformationStore(
+                   81, 80, MakeInstructionDescriptor(45, SpvOpCopyObject, 0))
+                   .IsApplicable(context.get(), fact_manager));
+
+  // Bad: attempt to insert before OpVariable
+  ASSERT_FALSE(TransformationStore(
+                   52, 24, MakeInstructionDescriptor(27, SpvOpVariable, 0))
+                   .IsApplicable(context.get(), fact_manager));
+
+  // Bad: pointer id does not exist
+  ASSERT_FALSE(TransformationStore(
+                   1000, 24, MakeInstructionDescriptor(38, SpvOpAccessChain, 0))
+                   .IsApplicable(context.get(), fact_manager));
+
+  // Bad: pointer id exists but does not have a type
+  ASSERT_FALSE(TransformationStore(
+                   5, 24, MakeInstructionDescriptor(38, SpvOpAccessChain, 0))
+                   .IsApplicable(context.get(), fact_manager));
+
+  // Bad: pointer id exists and has a type, but is not a pointer
+  ASSERT_FALSE(TransformationStore(
+                   24, 24, MakeInstructionDescriptor(38, SpvOpAccessChain, 0))
+                   .IsApplicable(context.get(), fact_manager));
+
+  // Bad: attempt to store to a null pointer
+  ASSERT_FALSE(TransformationStore(
+                   60, 24, MakeInstructionDescriptor(38, SpvOpAccessChain, 0))
+                   .IsApplicable(context.get(), fact_manager));
+
+  // Bad: attempt to store to an undefined pointer
+  ASSERT_FALSE(TransformationStore(
+                   61, 21, MakeInstructionDescriptor(38, SpvOpAccessChain, 0))
+                   .IsApplicable(context.get(), fact_manager));
+
+  // Bad: %82 is not available at the program point
+  ASSERT_FALSE(
+      TransformationStore(82, 80, MakeInstructionDescriptor(37, SpvOpReturn, 0))
+          .IsApplicable(context.get(), fact_manager));
+
+  // Bad: value id does not exist
+  ASSERT_FALSE(TransformationStore(
+                   27, 1000, MakeInstructionDescriptor(38, SpvOpAccessChain, 0))
+                   .IsApplicable(context.get(), fact_manager));
+
+  // Bad: value id exists but does not have a type
+  ASSERT_FALSE(TransformationStore(
+                   27, 15, MakeInstructionDescriptor(38, SpvOpAccessChain, 0))
+                   .IsApplicable(context.get(), fact_manager));
+
+  // Bad: value id exists but has the wrong type
+  ASSERT_FALSE(TransformationStore(
+                   27, 14, MakeInstructionDescriptor(38, SpvOpAccessChain, 0))
+                   .IsApplicable(context.get(), fact_manager));
+
+  // Bad: attempt to store to read-only variable
+  ASSERT_FALSE(TransformationStore(
+                   92, 93, MakeInstructionDescriptor(40, SpvOpAccessChain, 0))
+                   .IsApplicable(context.get(), fact_manager));
+
+  // Bad: value is not available
+  ASSERT_FALSE(TransformationStore(
+                   27, 95, MakeInstructionDescriptor(40, SpvOpAccessChain, 0))
+                   .IsApplicable(context.get(), fact_manager));
+
+  // Bad: variable being stored to does not have an irrelevant pointee value,
+  // and the store is not in a dead block.
+  ASSERT_FALSE(TransformationStore(
+                   20, 95, MakeInstructionDescriptor(45, SpvOpCopyObject, 0))
+                   .IsApplicable(context.get(), fact_manager));
+
+  // The described instruction does not exist.
+  ASSERT_FALSE(TransformationStore(
+                   27, 80, MakeInstructionDescriptor(1000, SpvOpAccessChain, 0))
+                   .IsApplicable(context.get(), fact_manager));
+
+  {
+    // Store to irrelevant variable from dead block.
+    TransformationStore transformation(
+        27, 80, MakeInstructionDescriptor(38, SpvOpAccessChain, 0));
+    ASSERT_TRUE(transformation.IsApplicable(context.get(), fact_manager));
+    transformation.Apply(context.get(), &fact_manager);
+    ASSERT_TRUE(IsValid(env, context.get()));
+  }
+
+  {
+    // Store to irrelevant variable from live block.
+    TransformationStore transformation(
+        11, 95, MakeInstructionDescriptor(95, SpvOpReturnValue, 0));
+    ASSERT_TRUE(transformation.IsApplicable(context.get(), fact_manager));
+    transformation.Apply(context.get(), &fact_manager);
+    ASSERT_TRUE(IsValid(env, context.get()));
+  }
+
+  {
+    // Store to irrelevant variable from live block.
+    TransformationStore transformation(
+        46, 80, MakeInstructionDescriptor(95, SpvOpReturnValue, 0));
+    ASSERT_TRUE(transformation.IsApplicable(context.get(), fact_manager));
+    transformation.Apply(context.get(), &fact_manager);
+    ASSERT_TRUE(IsValid(env, context.get()));
+  }
+
+  {
+    // Store to irrelevant variable from live block.
+    TransformationStore transformation(
+        16, 21, MakeInstructionDescriptor(95, SpvOpReturnValue, 0));
+    ASSERT_TRUE(transformation.IsApplicable(context.get(), fact_manager));
+    transformation.Apply(context.get(), &fact_manager);
+    ASSERT_TRUE(IsValid(env, context.get()));
+  }
+
+  {
+    // Store to non-irrelevant variable from dead block.
+    TransformationStore transformation(
+        53, 21, MakeInstructionDescriptor(38, SpvOpAccessChain, 0));
+    ASSERT_TRUE(transformation.IsApplicable(context.get(), fact_manager));
+    transformation.Apply(context.get(), &fact_manager);
+    ASSERT_TRUE(IsValid(env, context.get()));
+  }
 
   std::string after_transformation = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main" %92 %52 %53
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpDecorate %92 BuiltIn FragCoord
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypeFloat 32
+          %8 = OpTypeStruct %6 %7
+          %9 = OpTypePointer Function %8
+         %10 = OpTypeFunction %6 %9
+         %14 = OpConstant %6 0
+         %15 = OpTypePointer Function %6
+         %51 = OpTypePointer Private %6
+         %21 = OpConstant %6 2
+         %23 = OpConstant %6 1
+         %24 = OpConstant %7 1
+         %25 = OpTypePointer Function %7
+         %50 = OpTypePointer Private %7
+         %34 = OpTypeBool
+         %35 = OpConstantFalse %34
+         %60 = OpConstantNull %50
+         %61 = OpUndef %51
+         %52 = OpVariable %50 Private
+         %53 = OpVariable %51 Private
+         %80 = OpConstantComposite %8 %21 %24
+         %90 = OpTypeVector %7 4
+         %91 = OpTypePointer Input %90
+         %92 = OpVariable %91 Input
+         %93 = OpConstantComposite %90 %24 %24 %24 %24
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %20 = OpVariable %9 Function
+         %27 = OpVariable %9 Function ; irrelevant
+         %22 = OpAccessChain %15 %20 %14
+         %44 = OpCopyObject %9 %20
+         %26 = OpAccessChain %25 %20 %23
+         %29 = OpFunctionCall %6 %12 %27
+         %30 = OpAccessChain %15 %20 %14
+         %45 = OpCopyObject %15 %30
+         %81 = OpCopyObject %9 %27 ; irrelevant
+         %33 = OpAccessChain %15 %20 %14
+               OpSelectionMerge %37 None
+               OpBranchConditional %35 %36 %37
+         %36 = OpLabel
+               OpStore %27 %80
+               OpStore %53 %21
+         %38 = OpAccessChain %15 %20 %14
+         %40 = OpAccessChain %15 %20 %14
+         %43 = OpAccessChain %15 %20 %14
+         %82 = OpCopyObject %9 %27 ; irrelevant
+               OpBranch %37
+         %37 = OpLabel
+               OpReturn
+               OpFunctionEnd
+         %12 = OpFunction %6 None %10
+         %11 = OpFunctionParameter %9 ; irrelevant
+         %13 = OpLabel
+         %46 = OpCopyObject %9 %11 ; irrelevant
+         %16 = OpAccessChain %15 %11 %14 ; irrelevant
+         %95 = OpCopyObject %8 %80
+               OpStore %11 %95
+               OpStore %46 %80
+               OpStore %16 %21
+               OpReturnValue %21
+               OpFunctionEnd
   )";
   ASSERT_TRUE(IsEqual(env, after_transformation, context.get()));
-  FAIL();  // Remove once test is implemented
 }
 
 }  // namespace


### PR DESCRIPTION
This change adds fuzzer passes that sprinkle loads and stores into a
module at random, with stores restricted to occur in either dead
blocks, or to use pointers for which it is known that the pointee
value does not influence the module's overall behaviour.

The change also generalises the VariableValueIsArbitrary fact to
PointeeValueIsIrrelevant, to allow stores through access chains or
object copies of variables whose values are known to be irrelevant.

The change includes some other minor refactorings.