### PR TITLE
spirv-fuzz: Ensure that donated variables are always initialized

### DIFF
--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -471,6 +471,36 @@ bool InstructionIsFunctionParameter(opt::Instruction* instruction,
   return found_parameter;
 }
 
+uint32_t GetTypeId(opt::IRContext* context, uint32_t result_id) {
+  return context->get_def_use_mgr()->GetDef(result_id)->type_id();
+}
+
+uint32_t GetPointeeTypeIdFromPointerType(opt::Instruction* pointer_type_inst) {
+  assert(pointer_type_inst && pointer_type_inst->opcode() == SpvOpTypePointer &&
+         "Precondition: |pointer_type_inst| must be OpTypePointer.");
+  return pointer_type_inst->GetSingleWordInOperand(1);
+}
+
+uint32_t GetPointeeTypeIdFromPointerType(opt::IRContext* context,
+                                         uint32_t pointer_type_id) {
+  return GetPointeeTypeIdFromPointerType(
+      context->get_def_use_mgr()->GetDef(pointer_type_id));
+}
+
+SpvStorageClass GetStorageClassFromPointerType(
+    opt::Instruction* pointer_type_inst) {
+  assert(pointer_type_inst && pointer_type_inst->opcode() == SpvOpTypePointer &&
+         "Precondition: |pointer_type_inst| must be OpTypePointer.");
+  return static_cast<SpvStorageClass>(
+      pointer_type_inst->GetSingleWordInOperand(0));
+}
+
+SpvStorageClass GetStorageClassFromPointerType(opt::IRContext* context,
+                                               uint32_t pointer_type_id) {
+  return GetStorageClassFromPointerType(
+      context->get_def_use_mgr()->GetDef(pointer_type_id));
+}
+
 }  // namespace fuzzerutil
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -158,6 +158,29 @@ bool IdIsAvailableBeforeInstruction(opt::IRContext* context,
 bool InstructionIsFunctionParameter(opt::Instruction* instruction,
                                     opt::Function* function);
 
+// Returns the type id of the instruction defined by |result_id|, or 0 if there
+// is no such result id.
+uint32_t GetTypeId(opt::IRContext* context, uint32_t result_id);
+
+// Given |pointer_type_inst|, which must be an OpTypePointer instruction,
+// returns the id of the associated pointee type.
+uint32_t GetPointeeTypeIdFromPointerType(opt::Instruction* pointer_type_inst);
+
+// Given |pointer_type_id|, which must be the id of a pointer type, returns the
+// id of the associated pointee type.
+uint32_t GetPointeeTypeIdFromPointerType(opt::IRContext* context,
+                                         uint32_t pointer_type_id);
+
+// Given |pointer_type_inst|, which must be an OpTypePointer instruction,
+// returns the associated storage class.
+SpvStorageClass GetStorageClassFromPointerType(
+    opt::Instruction* pointer_type_inst);
+
+// Given |pointer_type_id|, which must be the id of a pointer type, returns the
+// associated storage class.
+SpvStorageClass GetStorageClassFromPointerType(opt::IRContext* context,
+                                               uint32_t pointer_type_id);
+
 }  // namespace fuzzerutil
 
 }  // namespace fuzz

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -505,7 +505,7 @@ message TransformationAddGlobalVariable {
   // The type of the global variable
   uint32 type_id = 2;
 
-  // Optional initializer; 0 if there is no initializer
+  // Initial value of the variable
   uint32 initializer_id = 3;
 
   // True if and only if the behaviour of the module should not depend on the

--- a/source/fuzz/transformation_add_global_variable.cpp
+++ b/source/fuzz/transformation_add_global_variable.cpp
@@ -53,21 +53,19 @@ bool TransformationAddGlobalVariable::IsApplicable(
   if (pointer_type->storage_class() != SpvStorageClassPrivate) {
     return false;
   }
-  if (message_.initializer_id()) {
-    // The initializer id must be the id of a constant.  Check this with the
-    // constant manager.
-    auto constant_id = context->get_constant_mgr()->GetConstantsFromIds(
-        {message_.initializer_id()});
-    if (constant_id.empty()) {
-      return false;
-    }
-    assert(constant_id.size() == 1 &&
-           "We asked for the constant associated with a single id; we should "
-           "get a single constant.");
-    // The type of the constant must match the pointee type of the pointer.
-    if (pointer_type->pointee_type() != constant_id[0]->type()) {
-      return false;
-    }
+  // The initializer id must be the id of a constant.  Check this with the
+  // constant manager.
+  auto constant_id = context->get_constant_mgr()->GetConstantsFromIds(
+      {message_.initializer_id()});
+  if (constant_id.empty()) {
+    return false;
+  }
+  assert(constant_id.size() == 1 &&
+         "We asked for the constant associated with a single id; we should "
+         "get a single constant.");
+  // The type of the constant must match the pointee type of the pointer.
+  if (pointer_type->pointee_type() != constant_id[0]->type()) {
+    return false;
   }
   return true;
 }

--- a/source/fuzz/transformation_load.cpp
+++ b/source/fuzz/transformation_load.cpp
@@ -82,11 +82,8 @@ bool TransformationLoad::IsApplicable(
 
 void TransformationLoad::Apply(opt::IRContext* context,
                                spvtools::fuzz::FactManager* /*unused*/) const {
-  uint32_t result_type = context->get_def_use_mgr()
-                             ->GetDef(context->get_def_use_mgr()
-                                          ->GetDef(message_.pointer_id())
-                                          ->type_id())
-                             ->GetSingleWordInOperand(1);
+  uint32_t result_type = fuzzerutil::GetPointeeTypeIdFromPointerType(
+      context, fuzzerutil::GetTypeId(context, message_.pointer_id()));
   fuzzerutil::UpdateModuleIdBound(context, message_.fresh_id());
   FindInstruction(message_.instruction_to_insert_before(), context)
       ->InsertBefore(MakeUnique<opt::Instruction>(

--- a/test/fuzz/fuzzer_pass_donate_modules_test.cpp
+++ b/test/fuzz/fuzzer_pass_donate_modules_test.cpp
@@ -314,14 +314,17 @@ TEST(FuzzerPassDonateModulesTest, DonationWithUniforms) {
         %100 = OpTypePointer Function %6
         %101 = OpTypeStruct %6
         %102 = OpTypePointer Private %101
-        %103 = OpVariable %102 Private
-        %104 = OpConstant %12 0
-        %105 = OpTypePointer Private %6
-        %106 = OpTypePointer Function %12
-        %107 = OpTypeStruct %12
-        %108 = OpTypePointer Private %107
-        %109 = OpVariable %108 Private
-        %110 = OpTypePointer Private %12
+        %104 = OpConstant %6 0
+        %105 = OpConstantComposite %101 %104
+        %103 = OpVariable %102 Private %105
+        %106 = OpConstant %12 0
+        %107 = OpTypePointer Private %6
+        %108 = OpTypePointer Function %12
+        %109 = OpTypeStruct %12
+        %110 = OpTypePointer Private %109
+        %112 = OpConstantComposite %109 %13
+        %111 = OpVariable %110 Private %112
+        %113 = OpTypePointer Private %12
           %4 = OpFunction %2 None %3
           %5 = OpLabel
           %8 = OpVariable %7 Function
@@ -334,16 +337,16 @@ TEST(FuzzerPassDonateModulesTest, DonationWithUniforms) {
                OpStore %18 %24
                OpReturn
                OpFunctionEnd
-        %111 = OpFunction %2 None %3
-        %112 = OpLabel
-        %113 = OpVariable %100 Function
-        %114 = OpVariable %106 Function
-        %115 = OpAccessChain %105 %103 %104
-        %116 = OpLoad %6 %115
-               OpStore %113 %116
-        %117 = OpAccessChain %110 %109 %104
-        %118 = OpLoad %12 %117
-               OpStore %114 %118
+        %114 = OpFunction %2 None %3
+        %115 = OpLabel
+        %116 = OpVariable %100 Function %104
+        %117 = OpVariable %108 Function %13
+        %118 = OpAccessChain %107 %103 %106
+        %119 = OpLoad %6 %118
+               OpStore %116 %119
+        %120 = OpAccessChain %113 %111 %106
+        %121 = OpLoad %12 %120
+               OpStore %117 %121
                OpReturn
                OpFunctionEnd
   )";
@@ -420,19 +423,21 @@ TEST(FuzzerPassDonateModulesTest, DonationWithInputAndOutputVariables) {
          %10 = OpTypePointer Input %7
          %11 = OpVariable %10 Input
         %100 = OpTypePointer Private %7
-        %101 = OpVariable %100 Private
-        %102 = OpTypePointer Private %7
-        %103 = OpVariable %102 Private
+        %102 = OpConstant %6 0
+        %103 = OpConstantComposite %7 %102 %102 %102 %102
+        %101 = OpVariable %100 Private %103
+        %104 = OpTypePointer Private %7
+        %105 = OpVariable %104 Private %103
           %4 = OpFunction %2 None %3
           %5 = OpLabel
          %12 = OpLoad %7 %11
                OpStore %9 %12
                OpReturn
                OpFunctionEnd
-        %104 = OpFunction %2 None %3
-        %105 = OpLabel
-        %106 = OpLoad %7 %103
-               OpStore %101 %106
+        %106 = OpFunction %2 None %3
+        %107 = OpLabel
+        %108 = OpLoad %7 %105
+               OpStore %101 %108
                OpReturn
                OpFunctionEnd
   )";

--- a/test/fuzz/transformation_add_global_variable_test.cpp
+++ b/test/fuzz/transformation_add_global_variable_test.cpp
@@ -30,8 +30,10 @@ TEST(TransformationAddGlobalVariableTest, BasicTest) {
           %2 = OpTypeVoid
           %3 = OpTypeFunction %2
           %6 = OpTypeFloat 32
+         %40 = OpConstant %6 0
           %7 = OpTypeInt 32 1
           %8 = OpTypeVector %6 2
+         %41 = OpConstantComposite %8 %40 %40
           %9 = OpTypePointer Function %6
          %10 = OpTypePointer Private %6
          %20 = OpTypePointer Uniform %6
@@ -104,13 +106,13 @@ TEST(TransformationAddGlobalVariableTest, BasicTest) {
 
   TransformationAddGlobalVariable transformations[] = {
       // %100 = OpVariable %12 Private
-      TransformationAddGlobalVariable(100, 12, 0, true),
+      TransformationAddGlobalVariable(100, 12, 16, true),
 
       // %101 = OpVariable %10 Private
-      TransformationAddGlobalVariable(101, 10, 0, false),
+      TransformationAddGlobalVariable(101, 10, 40, false),
 
       // %102 = OpVariable %13 Private
-      TransformationAddGlobalVariable(102, 13, 0, true),
+      TransformationAddGlobalVariable(102, 13, 41, true),
 
       // %103 = OpVariable %12 Private %16
       TransformationAddGlobalVariable(103, 12, 16, false),
@@ -144,8 +146,10 @@ TEST(TransformationAddGlobalVariableTest, BasicTest) {
           %2 = OpTypeVoid
           %3 = OpTypeFunction %2
           %6 = OpTypeFloat 32
+         %40 = OpConstant %6 0
           %7 = OpTypeInt 32 1
           %8 = OpTypeVector %6 2
+         %41 = OpConstantComposite %8 %40 %40
           %9 = OpTypePointer Function %6
          %10 = OpTypePointer Private %6
          %20 = OpTypePointer Uniform %6
@@ -160,9 +164,9 @@ TEST(TransformationAddGlobalVariableTest, BasicTest) {
          %19 = OpTypePointer Private %18
          %21 = OpConstantTrue %18
          %22 = OpConstantFalse %18
-        %100 = OpVariable %12 Private
-        %101 = OpVariable %10 Private
-        %102 = OpVariable %13 Private
+        %100 = OpVariable %12 Private %16
+        %101 = OpVariable %10 Private %40
+        %102 = OpVariable %13 Private %41
         %103 = OpVariable %12 Private %16
         %104 = OpVariable %19 Private %21
         %105 = OpVariable %19 Private %22
@@ -222,7 +226,7 @@ TEST(TransformationAddGlobalVariableTest, TestEntryPointInterfaceEnlargement) {
 
   TransformationAddGlobalVariable transformations[] = {
       // %100 = OpVariable %12 Private
-      TransformationAddGlobalVariable(100, 12, 0, true),
+      TransformationAddGlobalVariable(100, 12, 16, true),
 
       // %101 = OpVariable %12 Private %16
       TransformationAddGlobalVariable(101, 12, 16, false),
@@ -265,7 +269,7 @@ TEST(TransformationAddGlobalVariableTest, TestEntryPointInterfaceEnlargement) {
          %18 = OpTypeBool
          %19 = OpTypePointer Private %18
          %21 = OpConstantTrue %18
-        %100 = OpVariable %12 Private
+        %100 = OpVariable %12 Private %16
         %101 = OpVariable %12 Private %16
         %102 = OpVariable %19 Private %21
           %4 = OpFunction %2 None %3


### PR DESCRIPTION
This change ensures that global and local variables donated from other
modules are always initialized at their declaration in the module
being transformed.  This is to help limit issues related to undefined
behaviour that might arise due to accessing uninitialized memory.

The change also introduces some helper functions in fuzzer_util to
make it easier to find the pointee types of pointer types.