### PR TITLE
Add data structures for DebugScope, DebugNoScope, DebugDeclare, DebugValue

### DIFF
--- a/source/opt/function.h
+++ b/source/opt/function.h
@@ -56,6 +56,8 @@ class Function {
 
   // Appends a parameter to this function.
   inline void AddParameter(std::unique_ptr<Instruction> p);
+  // Appends a debug instruction in function header to this function.
+  inline void AddDebugInstructionInHeader(std::unique_ptr<Instruction> p);
   // Appends a basic block to this function.
   inline void AddBasicBlock(std::unique_ptr<BasicBlock> b);
   // Appends a basic block to this function at the position |ip|.
@@ -151,6 +153,8 @@ class Function {
   std::unique_ptr<Instruction> def_inst_;
   // All parameters to this function.
   std::vector<std::unique_ptr<Instruction>> params_;
+  // All debug instructions in this function's header.
+  InstructionList debug_insts_in_header_;
   // All basic blocks inside this function in specification order
   std::vector<std::unique_ptr<BasicBlock>> blocks_;
   // The OpFunctionEnd instruction.
@@ -165,6 +169,11 @@ inline Function::Function(std::unique_ptr<Instruction> def_inst)
 
 inline void Function::AddParameter(std::unique_ptr<Instruction> p) {
   params_.emplace_back(std::move(p));
+}
+
+inline void Function::AddDebugInstructionInHeader(
+    std::unique_ptr<Instruction> p) {
+  debug_insts_in_header_.push_back(std::move(p));
 }
 
 inline void Function::AddBasicBlock(std::unique_ptr<BasicBlock> b) {

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -116,7 +116,11 @@ Instruction::Instruction(Instruction&& that)
       unique_id_(that.unique_id_),
       operands_(std::move(that.operands_)),
       dbg_line_insts_(std::move(that.dbg_line_insts_)),
-      dbg_scope_(that.dbg_scope_) {}
+      dbg_scope_(that.dbg_scope_) {
+  for (auto& i : dbg_line_insts_) {
+    i.dbg_scope_ = that.dbg_scope_;
+  }
+}
 
 Instruction& Instruction::operator=(Instruction&& that) {
   opcode_ = that.opcode_;
@@ -126,6 +130,9 @@ Instruction& Instruction::operator=(Instruction&& that) {
   operands_ = std::move(that.operands_);
   dbg_line_insts_ = std::move(that.dbg_line_insts_);
   dbg_scope_ = that.dbg_scope_;
+  for (auto& i : dbg_line_insts_) {
+    i.dbg_scope_ = that.dbg_scope_;
+  }
   return *this;
 }
 
@@ -138,6 +145,9 @@ Instruction* Instruction::Clone(IRContext* c) const {
   clone->operands_ = operands_;
   clone->dbg_line_insts_ = dbg_line_insts_;
   clone->dbg_scope_ = dbg_scope_;
+  for (auto& i : clone->dbg_line_insts_) {
+    i.dbg_scope_ = dbg_scope_;
+  }
   return clone;
 }
 

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -16,6 +16,7 @@
 
 #include <initializer_list>
 
+#include "OpenCLDebugInfo100.h"
 #include "source/disassemble.h"
 #include "source/opt/fold.h"
 #include "source/opt/ir_context.h"

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -39,7 +39,7 @@ Instruction::Instruction(IRContext* c)
       has_type_id_(false),
       has_result_id_(false),
       unique_id_(c->TakeNextUniqueId()),
-      dbg_scope_(0, 0) {}
+      dbg_scope_(kNoDebugScope, kNoInlinedAt) {}
 
 Instruction::Instruction(IRContext* c, SpvOp op)
     : utils::IntrusiveNodeBase<Instruction>(),
@@ -48,7 +48,7 @@ Instruction::Instruction(IRContext* c, SpvOp op)
       has_type_id_(false),
       has_result_id_(false),
       unique_id_(c->TakeNextUniqueId()),
-      dbg_scope_(0, 0) {}
+      dbg_scope_(kNoDebugScope, kNoInlinedAt) {}
 
 Instruction::Instruction(IRContext* c, const spv_parsed_instruction_t& inst,
                          std::vector<Instruction>&& dbg_line)
@@ -58,7 +58,7 @@ Instruction::Instruction(IRContext* c, const spv_parsed_instruction_t& inst,
       has_result_id_(inst.result_id != 0),
       unique_id_(c->TakeNextUniqueId()),
       dbg_line_insts_(std::move(dbg_line)),
-      dbg_scope_(0, 0) {
+      dbg_scope_(kNoDebugScope, kNoInlinedAt) {
   assert((!IsDebugLineInst(opcode_) || dbg_line.empty()) &&
          "Op(No)Line attaching to Op(No)Line found");
   for (uint32_t i = 0; i < inst.num_operands; ++i) {
@@ -96,7 +96,7 @@ Instruction::Instruction(IRContext* c, SpvOp op, uint32_t ty_id,
       has_result_id_(res_id != 0),
       unique_id_(c->TakeNextUniqueId()),
       operands_(),
-      dbg_scope_(0, 0) {
+      dbg_scope_(kNoDebugScope, kNoInlinedAt) {
   if (has_type_id_) {
     operands_.emplace_back(spv_operand_type_t::SPV_OPERAND_TYPE_TYPE_ID,
                            std::initializer_list<uint32_t>{ty_id});

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -102,8 +102,8 @@ inline bool operator!=(const Operand& o1, const Operand& o2) {
 // TODO: Let validator check that the result id is not used anywhere.
 class DebugScope {
  public:
-  DebugScope(uint32_t id0, uint32_t id1)
-      : lexical_scope_(id0), inlined_at_(id1) {}
+  DebugScope(uint32_t lexical_scope, uint32_t inlined_at)
+      : lexical_scope_(lexical_scope), inlined_at_(inlined_at) {}
 
   inline bool operator!=(const DebugScope& d) const {
     return lexical_scope_ != d.lexical_scope_ || inlined_at_ != d.inlined_at_;

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -241,7 +241,7 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   inline void SetResultId(uint32_t res_id);
   inline bool HasResultId() const { return has_result_id_; }
   // Sets DebugScope.
-  inline void SetDebugScope(const DebugScope& scope) { dbg_scope_ = scope; }
+  inline void SetDebugScope(const DebugScope& scope);
   inline const DebugScope& GetDebugScope() const { return dbg_scope_; }
   // Remove the |index|-th operand
   void RemoveOperand(uint32_t index) {
@@ -569,6 +569,13 @@ inline void Instruction::SetResultId(uint32_t res_id) {
 
   auto ridx = has_type_id_ ? 1 : 0;
   operands_[ridx].words = {res_id};
+}
+
+inline void Instruction::SetDebugScope(const DebugScope& scope) {
+  dbg_scope_ = scope;
+  for (auto& i : dbg_line_insts_) {
+    i.dbg_scope_ = scope;
+  }
 }
 
 inline void Instruction::SetResultType(uint32_t ty_id) {

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -32,6 +32,9 @@
 #include "source/opt/reflect.h"
 #include "spirv-tools/libspirv.h"
 
+const uint32_t kNoDebugScope = 0;
+const uint32_t kNoInlinedAt = 0;
+
 namespace spvtools {
 namespace opt {
 
@@ -92,13 +95,11 @@ inline bool operator!=(const Operand& o1, const Operand& o2) {
 }
 
 // This structure is used to represent a DebugScope instruction from
-// the OpenCL.100.DebugInfo extened instruction set. Since this
-// structure is added to Instruction class as a member variable, we
-// want to reduce the size of structure. Hence, we keep only its Scope
-// and InlinedAt operands but not its result id. Note that losing its
-// result id will result in a different binary even when there is no
-// optimization. We skip the sanity check in Optimizer::Run(..) when
-// the module contains a DebugScope instruction.
+// the OpenCL.100.DebugInfo extened instruction set. Note that we can
+// ignore the result id of DebugScope instruction because it is not
+// used for anything. We do not keep it to reduce the size of
+// structure.
+// TODO: Let validator check that the result id is not used anywhere.
 class DebugScope {
  public:
   DebugScope(uint32_t id0, uint32_t id1)
@@ -123,11 +124,11 @@ class DebugScope {
 
  private:
   // The result id of the lexical scope in which this debug scope is
-  // contained. The value is |0| if there is no scope.
+  // contained. The value is kNoDebugScope if there is no scope.
   uint32_t lexical_scope_;
 
   // The result id of DebugInlinedAt if instruction in this debug scope
-  // is inlined. The value is |0| if it is not inlined.
+  // is inlined. The value is kNoInlinedAt if it is not inlined.
   uint32_t inlined_at_;
 };
 
@@ -152,7 +153,7 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
         has_type_id_(false),
         has_result_id_(false),
         unique_id_(0),
-        dbg_scope_(0, 0) {}
+        dbg_scope_(kNoDebugScope, kNoInlinedAt) {}
 
   // Creates a default OpNop instruction.
   Instruction(IRContext*);

--- a/source/opt/ir_loader.cpp
+++ b/source/opt/ir_loader.cpp
@@ -194,24 +194,13 @@ bool IrLoader::AddInstruction(const spv_parsed_instruction_t* inst) {
           switch (ext_inst_key) {
             case OpenCLDebugInfo100DebugDeclare: {
               const uint32_t local_var_id = inst->words[kLocalVariableIdIndex];
-              module_->AddDebugDeclare(local_var_id, std::move(spv_inst));
+              module_->AddDebugLocalVariableInfo(local_var_id,
+                                                 std::move(spv_inst));
               break;
             }
             case OpenCLDebugInfo100DebugValue: {
-              if (block_ == nullptr) {  // Inside function but outside blocks
-                // It is weird that we use DebugValue outside a block.
-                // In this case, an operand of DebugValue must be an
-                // OpFunctionParameter.
-                // TODO: We do not allow this case for the simplicity but
-                //       we need a discussion. If we allow it, will we put
-                //       it in function::params_?
-                Errorf(consumer_, src, loc,
-                       "DebugValue outside a basic block is not allowed.",
-                       opcode);
-                return false;
-              } else {
-                block_->AddInstruction(std::move(spv_inst));
-              }
+              const uint32_t value_id = inst->words[kLocalVariableIdIndex];
+              module_->AddDebugLocalVariableInfo(value_id, std::move(spv_inst));
               break;
             }
             default: {
@@ -229,24 +218,13 @@ bool IrLoader::AddInstruction(const spv_parsed_instruction_t* inst) {
           switch (ext_inst_key) {
             case DebugInfoDebugDeclare: {
               const uint32_t local_var_id = inst->words[6];
-              module_->AddDebugDeclare(local_var_id, std::move(spv_inst));
+              module_->AddDebugLocalVariableInfo(local_var_id,
+                                                 std::move(spv_inst));
               break;
             }
             case DebugInfoDebugValue: {
-              if (block_ == nullptr) {  // Inside function but outside blocks
-                // It is weird that we use DebugValue outside a block.
-                // In this case, an operand of DebugValue must be an
-                // OpFunctionParameter.
-                // TODO: We do not allow this case for the simplicity but
-                //       we need a discussion. If we allow it, will we put
-                //       it in function::params_?
-                Errorf(consumer_, src, loc,
-                       "DebugValue outside a basic block is not allowed.",
-                       opcode);
-                return false;
-              } else {
-                block_->AddInstruction(std::move(spv_inst));
-              }
+              const uint32_t value_id = inst->words[kLocalVariableIdIndex];
+              module_->AddDebugLocalVariableInfo(value_id, std::move(spv_inst));
               break;
             }
             default: {

--- a/source/opt/ir_loader.cpp
+++ b/source/opt/ir_loader.cpp
@@ -23,6 +23,11 @@
 #include "source/opt/reflect.h"
 #include "source/util/make_unique.h"
 
+static const uint32_t kExtensionInstructionIndex = 4;
+static const uint32_t kLocalVariableIdIndex = 6;
+static const uint32_t kLexicalScopeIndex = 5;
+static const uint32_t kInlinedAtIndex = 6;
+
 namespace spvtools {
 namespace opt {
 
@@ -30,14 +35,58 @@ IrLoader::IrLoader(const MessageConsumer& consumer, Module* m)
     : consumer_(consumer),
       module_(m),
       source_("<instruction>"),
-      inst_index_(0) {}
+      inst_index_(0),
+      last_dbg_scope_(0, 0) {}
 
 bool IrLoader::AddInstruction(const spv_parsed_instruction_t* inst) {
   ++inst_index_;
   const auto opcode = static_cast<SpvOp>(inst->opcode);
   if (IsDebugLineInst(opcode)) {
-    dbg_line_info_.push_back(Instruction(module()->context(), *inst));
+    dbg_line_info_.push_back(
+        Instruction(module()->context(), *inst, last_dbg_scope_));
     return true;
+  }
+
+  // If it is a DebugScope or DebugNoScope of debug extension, we do not
+  // create a new instruction, but simply keep the information in
+  // struct DebugScope.
+  if (opcode == SpvOpExtInst && spvExtInstIsDebugInfo(inst->ext_inst_type)) {
+    const uint32_t ext_inst_index = inst->words[kExtensionInstructionIndex];
+    if (inst->ext_inst_type == SPV_EXT_INST_TYPE_OPENCL_DEBUGINFO_100) {
+      const OpenCLDebugInfo100Instructions ext_inst_key =
+          OpenCLDebugInfo100Instructions(ext_inst_index);
+      if (ext_inst_key == OpenCLDebugInfo100DebugScope) {
+        uint32_t inlined_at = 0;
+        if (inst->num_words > kInlinedAtIndex)
+          inlined_at = inst->words[kInlinedAtIndex];
+        last_dbg_scope_ =
+            DebugScope(inst->words[kLexicalScopeIndex], inlined_at);
+        module()->SetContainDebugScope();
+        return true;
+      }
+      if (ext_inst_key == OpenCLDebugInfo100DebugNoScope) {
+        last_dbg_scope_ = DebugScope(0, 0);
+        module()->SetContainDebugScope();
+        return true;
+      }
+    } else {
+      const DebugInfoInstructions ext_inst_key =
+          DebugInfoInstructions(ext_inst_index);
+      if (ext_inst_key == DebugInfoDebugScope) {
+        uint32_t inlined_at = 0;
+        if (inst->num_words > kInlinedAtIndex)
+          inlined_at = inst->words[kInlinedAtIndex];
+        last_dbg_scope_ =
+            DebugScope(inst->words[kLexicalScopeIndex], inlined_at);
+        module()->SetContainDebugScope();
+        return true;
+      }
+      if (ext_inst_key == DebugInfoDebugNoScope) {
+        last_dbg_scope_ = DebugScope(0, 0);
+        module()->SetContainDebugScope();
+        return true;
+      }
+    }
   }
 
   std::unique_ptr<Instruction> spv_inst(
@@ -90,6 +139,7 @@ bool IrLoader::AddInstruction(const spv_parsed_instruction_t* inst) {
     block_->AddInstruction(std::move(spv_inst));
     function_->AddBasicBlock(std::move(block_));
     block_ = nullptr;
+    last_dbg_scope_ = DebugScope(0, 0);
   } else {
     if (function_ == nullptr) {  // Outside function definition
       SPIRV_ASSERT(consumer_, block_ == nullptr);
@@ -131,6 +181,10 @@ bool IrLoader::AddInstruction(const spv_parsed_instruction_t* inst) {
         return false;
       }
     } else {
+      if (opcode == SpvOpLoopMerge || opcode == SpvOpSelectionMerge)
+        last_dbg_scope_ = DebugScope(0, 0);
+      if (last_dbg_scope_.lexical_scope)
+        spv_inst->SetDebugScope(last_dbg_scope_);
       if (block_ == nullptr) {  // Inside function but outside blocks
         if (opcode != SpvOpFunctionParameter) {
           Errorf(consumer_, src, loc,
@@ -141,39 +195,6 @@ bool IrLoader::AddInstruction(const spv_parsed_instruction_t* inst) {
         }
         function_->AddParameter(std::move(spv_inst));
       } else {
-        if (opcode == SpvOpExtInst &&
-            spvExtInstIsDebugInfo(inst->ext_inst_type)) {
-          const uint32_t ext_inst_index = inst->words[4];
-          if (inst->ext_inst_type == SPV_EXT_INST_TYPE_OPENCL_DEBUGINFO_100) {
-            const OpenCLDebugInfo100Instructions ext_inst_key =
-                OpenCLDebugInfo100Instructions(ext_inst_index);
-            if (ext_inst_key != OpenCLDebugInfo100DebugScope &&
-                ext_inst_key != OpenCLDebugInfo100DebugNoScope &&
-                ext_inst_key != OpenCLDebugInfo100DebugDeclare &&
-                ext_inst_key != OpenCLDebugInfo100DebugValue) {
-              Errorf(consumer_, src, loc,
-                     "Debug info extension instruction other than DebugScope, "
-                     "DebugNoScope, DebugDeclare, and DebugValue found inside "
-                     "function",
-                     opcode);
-              return false;
-            }
-          } else {
-            const DebugInfoInstructions ext_inst_key =
-                DebugInfoInstructions(ext_inst_index);
-            if (ext_inst_key != DebugInfoDebugScope &&
-                ext_inst_key != DebugInfoDebugNoScope &&
-                ext_inst_key != DebugInfoDebugDeclare &&
-                ext_inst_key != DebugInfoDebugValue) {
-              Errorf(consumer_, src, loc,
-                     "Debug info extension instruction other than DebugScope, "
-                     "DebugNoScope, DebugDeclare, and DebugValue found inside "
-                     "function",
-                     opcode);
-              return false;
-            }
-          }
-        }
         block_->AddInstruction(std::move(spv_inst));
       }
     }

--- a/source/opt/ir_loader.cpp
+++ b/source/opt/ir_loader.cpp
@@ -23,7 +23,7 @@
 #include "source/opt/reflect.h"
 #include "source/util/make_unique.h"
 
-static const uint32_t kExtensionInstructionIndex = 4;
+static const uint32_t kExtInstSetIndex = 4;
 static const uint32_t kLocalVariableIdIndex = 6;
 static const uint32_t kLexicalScopeIndex = 5;
 static const uint32_t kInlinedAtIndex = 6;
@@ -51,7 +51,7 @@ bool IrLoader::AddInstruction(const spv_parsed_instruction_t* inst) {
   // create a new instruction, but simply keep the information in
   // struct DebugScope.
   if (opcode == SpvOpExtInst && spvExtInstIsDebugInfo(inst->ext_inst_type)) {
-    const uint32_t ext_inst_index = inst->words[kExtensionInstructionIndex];
+    const uint32_t ext_inst_index = inst->words[kExtInstSetIndex];
     if (inst->ext_inst_type == SPV_EXT_INST_TYPE_OPENCL_DEBUGINFO_100) {
       const OpenCLDebugInfo100Instructions ext_inst_key =
           OpenCLDebugInfo100Instructions(ext_inst_index);
@@ -61,12 +61,12 @@ bool IrLoader::AddInstruction(const spv_parsed_instruction_t* inst) {
           inlined_at = inst->words[kInlinedAtIndex];
         last_dbg_scope_ =
             DebugScope(inst->words[kLexicalScopeIndex], inlined_at);
-        module()->SetContainDebugScope();
+        module()->SetContainsDebugScope();
         return true;
       }
       if (ext_inst_key == OpenCLDebugInfo100DebugNoScope) {
         last_dbg_scope_ = DebugScope(0, 0);
-        module()->SetContainDebugScope();
+        module()->SetContainsDebugScope();
         return true;
       }
     } else {
@@ -78,12 +78,12 @@ bool IrLoader::AddInstruction(const spv_parsed_instruction_t* inst) {
           inlined_at = inst->words[kInlinedAtIndex];
         last_dbg_scope_ =
             DebugScope(inst->words[kLexicalScopeIndex], inlined_at);
-        module()->SetContainDebugScope();
+        module()->SetContainsDebugScope();
         return true;
       }
       if (ext_inst_key == DebugInfoDebugNoScope) {
         last_dbg_scope_ = DebugScope(0, 0);
-        module()->SetContainDebugScope();
+        module()->SetContainsDebugScope();
         return true;
       }
     }
@@ -183,11 +183,11 @@ bool IrLoader::AddInstruction(const spv_parsed_instruction_t* inst) {
     } else {
       if (opcode == SpvOpLoopMerge || opcode == SpvOpSelectionMerge)
         last_dbg_scope_ = DebugScope(0, 0);
-      if (last_dbg_scope_.lexical_scope)
+      if (last_dbg_scope_.GetLexicalScope())
         spv_inst->SetDebugScope(last_dbg_scope_);
       if (opcode == SpvOpExtInst &&
           spvExtInstIsDebugInfo(inst->ext_inst_type)) {
-        const uint32_t ext_inst_index = inst->words[kExtensionInstructionIndex];
+        const uint32_t ext_inst_index = inst->words[kExtInstSetIndex];
         if (inst->ext_inst_type == SPV_EXT_INST_TYPE_OPENCL_DEBUGINFO_100) {
           const OpenCLDebugInfo100Instructions ext_inst_key =
               OpenCLDebugInfo100Instructions(ext_inst_index);

--- a/source/opt/ir_loader.h
+++ b/source/opt/ir_loader.h
@@ -78,6 +78,12 @@ class IrLoader {
   std::unique_ptr<BasicBlock> block_;
   // Line related debug instructions accumulated thus far.
   std::vector<Instruction> dbg_line_info_;
+
+  // The last DebugScope information. If |last_dbg_scope_.lexical_scope|
+  // is not zero, AddInstruction() lets Instruction::dbg_scope_ be the
+  // same with |last_dbg_scope_|. Otherwise, AddInstruction() lets
+  // Instruction::dbg_scope_ have DebugScope(0, 0) which means DebugNoScope.
+  DebugScope last_dbg_scope_;
 };
 
 }  // namespace opt

--- a/source/opt/ir_loader.h
+++ b/source/opt/ir_loader.h
@@ -79,10 +79,7 @@ class IrLoader {
   // Line related debug instructions accumulated thus far.
   std::vector<Instruction> dbg_line_info_;
 
-  // The last DebugScope information. If |last_dbg_scope_.lexical_scope|
-  // is not zero, AddInstruction() lets Instruction::dbg_scope_ be the
-  // same with |last_dbg_scope_|. Otherwise, AddInstruction() lets
-  // Instruction::dbg_scope_ have DebugScope(0, 0) which means DebugNoScope.
+  // The last DebugScope information that IrLoader::AddInstruction() handled.
   DebugScope last_dbg_scope_;
 };
 

--- a/source/opt/module.cpp
+++ b/source/opt/module.cpp
@@ -137,10 +137,54 @@ void Module::ToBinary(std::vector<uint32_t>* binary, bool skip_nop) const {
   binary->push_back(header_.bound);
   binary->push_back(header_.reserved);
 
-  auto write_inst = [binary, skip_nop](const Instruction* i) {
-    if (!(skip_nop && i->IsNop())) i->ToBinaryWithoutAttachedDebugInsts(binary);
-  };
-  ForEachInst(write_inst, true);
+  if (ext_inst_debuginfo_.empty()) {
+    auto write_inst = [binary, skip_nop](const Instruction* i) {
+      if (!(skip_nop && i->IsNop()))
+        i->ToBinaryWithoutAttachedDebugInsts(binary);
+    };
+    ForEachInst(write_inst, true);
+  } else {
+    DebugScope last_scope(0, 0);
+    auto write_inst = [binary, skip_nop, &last_scope,
+                       this](const Instruction* i) {
+      if (!(skip_nop && i->IsNop())) {
+        const auto& scope = i->GetDebugScope();
+        if (scope != last_scope) {
+          // Create a new DebugScope instruction
+          std::unique_ptr<Instruction> dscope(
+              ext_inst_debuginfo_.begin()->Clone(context()));
+          std::vector<Operand> operands(dscope->begin(), dscope->begin() + 4);
+          operands[1] = Operand(
+              SPV_OPERAND_TYPE_RESULT_ID,
+              utils::SmallVector<uint32_t, 2>({context()->TakeNextId()}));
+          if (scope.lexical_scope) {
+            operands[3] = Operand(SPV_OPERAND_TYPE_LITERAL_INTEGER,
+                                  utils::SmallVector<uint32_t, 2>({23}));
+            operands.emplace_back(
+                SPV_OPERAND_TYPE_RESULT_ID,
+                utils::SmallVector<uint32_t, 2>({scope.lexical_scope}));
+            if (scope.inlined_at) {
+              operands.emplace_back(
+                  SPV_OPERAND_TYPE_RESULT_ID,
+                  utils::SmallVector<uint32_t, 2>({scope.inlined_at}));
+            }
+          } else {
+            operands[3] = Operand(SPV_OPERAND_TYPE_LITERAL_INTEGER,
+                                  utils::SmallVector<uint32_t, 2>({24}));
+          }
+          dscope->ReplaceOperands(operands);
+          dscope->ToBinaryWithoutAttachedDebugInsts(binary);
+        }
+        last_scope = scope;
+
+        i->ToBinaryWithoutAttachedDebugInsts(binary);
+        auto it = local_var_to_dbg_decl_.find(i->result_id());
+        if (it != local_var_to_dbg_decl_.end())
+          it->second->ToBinaryWithoutAttachedDebugInsts(binary);
+      }
+    };
+    ForEachInst(write_inst, true);
+  }
 }
 
 uint32_t Module::ComputeIdBound() const {

--- a/source/opt/module.cpp
+++ b/source/opt/module.cpp
@@ -152,9 +152,6 @@ void Module::ToBinary(std::vector<uint32_t>* binary, bool skip_nop) const {
       }
 
       i->ToBinaryWithoutAttachedDebugInsts(binary);
-      auto it = debug_declare_.find(i->result_id());
-      if (it != debug_declare_.end())
-        it->second->ToBinaryWithoutAttachedDebugInsts(binary);
     }
   };
   ForEachInst(write_inst, true);

--- a/source/opt/module.cpp
+++ b/source/opt/module.cpp
@@ -151,8 +151,8 @@ void Module::ToBinary(std::vector<uint32_t>* binary, bool skip_nop) const {
       }
 
       i->ToBinaryWithoutAttachedDebugInsts(binary);
-      auto it = local_var_info_.find(i->result_id());
-      if (it != local_var_info_.end())
+      auto it = debug_declare_.find(i->result_id());
+      if (it != debug_declare_.end())
         it->second->ToBinaryWithoutAttachedDebugInsts(binary);
     }
   };

--- a/source/opt/module.cpp
+++ b/source/opt/module.cpp
@@ -137,6 +137,7 @@ void Module::ToBinary(std::vector<uint32_t>* binary, bool skip_nop) const {
   binary->push_back(header_.bound);
   binary->push_back(header_.reserved);
 
+  size_t bound_idx = binary->size() - 2;
   DebugScope last_scope(0, 0);
   auto write_inst = [binary, skip_nop, &last_scope,
                      this](const Instruction* i) {
@@ -157,6 +158,9 @@ void Module::ToBinary(std::vector<uint32_t>* binary, bool skip_nop) const {
     }
   };
   ForEachInst(write_inst, true);
+
+  // We create new instructions for DebugScope. The bound must be updated.
+  binary->data()[bound_idx] = header_.bound;
 }
 
 uint32_t Module::ComputeIdBound() const {

--- a/source/opt/module.cpp
+++ b/source/opt/module.cpp
@@ -138,7 +138,7 @@ void Module::ToBinary(std::vector<uint32_t>* binary, bool skip_nop) const {
   binary->push_back(header_.reserved);
 
   size_t bound_idx = binary->size() - 2;
-  DebugScope last_scope(0, 0);
+  DebugScope last_scope(kNoDebugScope, kNoInlinedAt);
   auto write_inst = [binary, skip_nop, &last_scope,
                      this](const Instruction* i) {
     if (!(skip_nop && i->IsNop())) {

--- a/source/opt/module.cpp
+++ b/source/opt/module.cpp
@@ -178,8 +178,8 @@ void Module::ToBinary(std::vector<uint32_t>* binary, bool skip_nop) const {
         last_scope = scope;
 
         i->ToBinaryWithoutAttachedDebugInsts(binary);
-        auto it = local_var_to_dbg_decl_.find(i->result_id());
-        if (it != local_var_to_dbg_decl_.end())
+        auto it = local_var_info_.find(i->result_id());
+        if (it != local_var_info_.end())
           it->second->ToBinaryWithoutAttachedDebugInsts(binary);
       }
     };

--- a/source/opt/module.h
+++ b/source/opt/module.h
@@ -312,7 +312,7 @@ class Module {
 
   // A map between a result id of a local variable or a value of a local
   // variable and its corresponding DebugDeclare or DebugValue.
-  std::unordered_map<uint32_t, std::unique_ptr<Instruction>> local_var_info_;
+  std::unordered_map<uint32_t, std::unique_ptr<Instruction>> debug_declare_;
 };
 
 // Pretty-prints |module| to |str|. Returns |str|.
@@ -376,7 +376,7 @@ inline void Module::AddFunction(std::unique_ptr<Function> f) {
 
 inline void Module::AddDebugLocalVariableInfo(uint32_t id,
                                               std::unique_ptr<Instruction> di) {
-  local_var_info_[id] = std::move(di);
+  debug_declare_[id] = std::move(di);
 }
 
 inline void Module::SetContainsDebugScope() { contains_debug_scope_ = true; }

--- a/source/opt/module.h
+++ b/source/opt/module.h
@@ -48,7 +48,7 @@ class Module {
   using const_inst_iterator = InstructionList::const_iterator;
 
   // Creates an empty module with zero'd header.
-  Module() : header_({}) {}
+  Module() : header_({}), contains_debug_scope_(false) {}
 
   // Sets the header to the given |header|.
   void SetHeader(const ModuleHeader& header) { header_ = header; }
@@ -117,6 +117,10 @@ class Module {
 
   // Appends a function to this module.
   inline void AddFunction(std::unique_ptr<Function> f);
+
+  // Sets |contains_debug_scope_| as true.
+  inline void SetContainDebugScope();
+  inline bool ContainDebugScope() { return contains_debug_scope_; }
 
   // Returns a vector of pointers to type-declaration instructions in this
   // module.
@@ -295,6 +299,9 @@ class Module {
   // If the module ends with Op*Line instruction, they will not be attached to
   // any instruction.  We record them here, so they will not be lost.
   std::vector<Instruction> trailing_dbg_line_info_;
+
+  // This module contains DebugScope or DebugNoScope.
+  bool contains_debug_scope_;
 };
 
 // Pretty-prints |module| to |str|. Returns |str|.
@@ -355,6 +362,8 @@ inline void Module::AddGlobalValue(std::unique_ptr<Instruction> v) {
 inline void Module::AddFunction(std::unique_ptr<Function> f) {
   functions_.emplace_back(std::move(f));
 }
+
+inline void Module::SetContainDebugScope() { contains_debug_scope_ = true; }
 
 inline Module::inst_iterator Module::capability_begin() {
   return capabilities_.begin();

--- a/source/opt/module.h
+++ b/source/opt/module.h
@@ -126,8 +126,8 @@ class Module {
                                         std::unique_ptr<Instruction> di);
 
   // Sets |contains_debug_scope_| as true.
-  inline void SetContainDebugScope();
-  inline bool ContainDebugScope() { return contains_debug_scope_; }
+  inline void SetContainsDebugScope();
+  inline bool ContainsDebugScope() { return contains_debug_scope_; }
 
   // Returns a vector of pointers to type-declaration instructions in this
   // module.
@@ -379,7 +379,7 @@ inline void Module::AddDebugLocalVariableInfo(uint32_t id,
   local_var_info_[id] = std::move(di);
 }
 
-inline void Module::SetContainDebugScope() { contains_debug_scope_ = true; }
+inline void Module::SetContainsDebugScope() { contains_debug_scope_ = true; }
 
 inline Module::inst_iterator Module::capability_begin() {
   return capabilities_.begin();

--- a/source/opt/module.h
+++ b/source/opt/module.h
@@ -119,10 +119,11 @@ class Module {
   // Appends a function to this module.
   inline void AddFunction(std::unique_ptr<Function> f);
 
-  // Adds a mapping between a result id of local variable OpVariable and
-  // a Instruction object for a DebugDeclare whose operand is the local
-  // variable.
-  inline void AddDebugDeclare(uint32_t id, std::unique_ptr<Instruction> di);
+  // Adds a mapping between a result id of local variable OpVariable or
+  // a value of a local variable and a Instruction object for a
+  // DebugDeclare or a DebugValue whose operand is the local variable.
+  inline void AddDebugLocalVariableInfo(uint32_t id,
+                                        std::unique_ptr<Instruction> di);
 
   // Sets |contains_debug_scope_| as true.
   inline void SetContainDebugScope();
@@ -309,10 +310,9 @@ class Module {
   // This module contains DebugScope or DebugNoScope.
   bool contains_debug_scope_;
 
-  // A map between a result id of a local variable and its corresponding
-  // DebugDeclare.
-  std::unordered_map<uint32_t, std::unique_ptr<Instruction>>
-      local_var_to_dbg_decl_;
+  // A map between a result id of a local variable or a value of a local
+  // variable and its corresponding DebugDeclare or DebugValue.
+  std::unordered_map<uint32_t, std::unique_ptr<Instruction>> local_var_info_;
 };
 
 // Pretty-prints |module| to |str|. Returns |str|.
@@ -374,9 +374,9 @@ inline void Module::AddFunction(std::unique_ptr<Function> f) {
   functions_.emplace_back(std::move(f));
 }
 
-inline void Module::AddDebugDeclare(uint32_t id,
-                                    std::unique_ptr<Instruction> di) {
-  local_var_to_dbg_decl_[id] = std::move(di);
+inline void Module::AddDebugLocalVariableInfo(uint32_t id,
+                                              std::unique_ptr<Instruction> di) {
+  local_var_info_[id] = std::move(di);
 }
 
 inline void Module::SetContainDebugScope() { contains_debug_scope_ = true; }

--- a/source/opt/module.h
+++ b/source/opt/module.h
@@ -17,6 +17,7 @@
 
 #include <functional>
 #include <memory>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -117,6 +118,11 @@ class Module {
 
   // Appends a function to this module.
   inline void AddFunction(std::unique_ptr<Function> f);
+
+  // Adds a mapping between a result id of local variable OpVariable and
+  // a Instruction object for a DebugDeclare whose operand is the local
+  // variable.
+  inline void AddDebugDeclare(uint32_t id, std::unique_ptr<Instruction> di);
 
   // Sets |contains_debug_scope_| as true.
   inline void SetContainDebugScope();
@@ -302,6 +308,11 @@ class Module {
 
   // This module contains DebugScope or DebugNoScope.
   bool contains_debug_scope_;
+
+  // A map between a result id of a local variable and its corresponding
+  // DebugDeclare.
+  std::unordered_map<uint32_t, std::unique_ptr<Instruction>>
+      local_var_to_dbg_decl_;
 };
 
 // Pretty-prints |module| to |str|. Returns |str|.
@@ -361,6 +372,11 @@ inline void Module::AddGlobalValue(std::unique_ptr<Instruction> v) {
 
 inline void Module::AddFunction(std::unique_ptr<Function> f) {
   functions_.emplace_back(std::move(f));
+}
+
+inline void Module::AddDebugDeclare(uint32_t id,
+                                    std::unique_ptr<Instruction> di) {
+  local_var_to_dbg_decl_[id] = std::move(di);
 }
 
 inline void Module::SetContainDebugScope() { contains_debug_scope_ = true; }

--- a/source/opt/module.h
+++ b/source/opt/module.h
@@ -119,12 +119,6 @@ class Module {
   // Appends a function to this module.
   inline void AddFunction(std::unique_ptr<Function> f);
 
-  // Adds a mapping between a result id of local variable OpVariable or
-  // a value of a local variable and a Instruction object for a
-  // DebugDeclare or a DebugValue whose operand is the local variable.
-  inline void AddDebugLocalVariableInfo(uint32_t id,
-                                        std::unique_ptr<Instruction> di);
-
   // Sets |contains_debug_scope_| as true.
   inline void SetContainsDebugScope();
   inline bool ContainsDebugScope() { return contains_debug_scope_; }
@@ -309,10 +303,6 @@ class Module {
 
   // This module contains DebugScope or DebugNoScope.
   bool contains_debug_scope_;
-
-  // A map between a result id of a local variable or a value of a local
-  // variable and its corresponding DebugDeclare or DebugValue.
-  std::unordered_map<uint32_t, std::unique_ptr<Instruction>> debug_declare_;
 };
 
 // Pretty-prints |module| to |str|. Returns |str|.
@@ -372,11 +362,6 @@ inline void Module::AddGlobalValue(std::unique_ptr<Instruction> v) {
 
 inline void Module::AddFunction(std::unique_ptr<Function> f) {
   functions_.emplace_back(std::move(f));
-}
-
-inline void Module::AddDebugLocalVariableInfo(uint32_t id,
-                                              std::unique_ptr<Instruction> di) {
-  debug_declare_[id] = std::move(di);
 }
 
 inline void Module::SetContainsDebugScope() { contains_debug_scope_ = true; }

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -569,6 +569,10 @@ bool Optimizer::Run(const uint32_t* original_binary,
   }
 
 #ifndef NDEBUG
+  // We do not keep the result id of DebugScope in struct DebugScope.
+  // Instead, we assign random ids for them, which results in sanity
+  // check failures. We want to skip the sanity check when the module
+  // contains DebugScope instructions.
   if (status == opt::Pass::Status::SuccessWithoutChange &&
       !context->module()->ContainsDebugScope()) {
     std::vector<uint32_t> optimized_binary_with_nop;

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -569,7 +569,8 @@ bool Optimizer::Run(const uint32_t* original_binary,
   }
 
 #ifndef NDEBUG
-  if (status == opt::Pass::Status::SuccessWithoutChange) {
+  if (status == opt::Pass::Status::SuccessWithoutChange &&
+      !context->module()->ContainDebugScope()) {
     std::vector<uint32_t> optimized_binary_with_nop;
     context->module()->ToBinary(&optimized_binary_with_nop,
                                 /* skip_nop = */ false);

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -570,7 +570,7 @@ bool Optimizer::Run(const uint32_t* original_binary,
 
 #ifndef NDEBUG
   if (status == opt::Pass::Status::SuccessWithoutChange &&
-      !context->module()->ContainDebugScope()) {
+      !context->module()->ContainsDebugScope()) {
     std::vector<uint32_t> optimized_binary_with_nop;
     context->module()->ToBinary(&optimized_binary_with_nop,
                                 /* skip_nop = */ false);

--- a/test/opt/ir_loader_test.cpp
+++ b/test/opt/ir_loader_test.cpp
@@ -234,34 +234,33 @@ OpLine %7 3 18
 %44 = OpExtInst %void %1 DebugLocalVariable %16 %40 %34 6 16 %43 FlagIsLocal 0
 %45 = OpExtInst %void %1 DebugLocalVariable %17 %40 %34 7 16 %43 FlagIsLocal 1
 %46 = OpExtInst %void %1 DebugLocalVariable %18 %36 %34 8 3 %43 FlagIsLocal
-%47 = OpExtInst %void %1 DebugDeclare %44 %pos %42
-%48 = OpExtInst %void %1 DebugDeclare %45 %color %42
 OpLine %7 6 1
 %main = OpFunction %void None %31
-%49 = OpLabel
-%50 = OpExtInst %void %1 DebugScope %43
+%47 = OpLabel
+%60 = OpExtInst %void %1 DebugScope %43
 OpLine %7 8 13
 %vout = OpVariable %_ptr_Function_VS_OUTPUT Function
-%51 = OpExtInst %void %1 DebugDeclare %46 %vout %42
+%49 = OpExtInst %void %1 DebugDeclare %46 %vout %42
 OpLine %7 9 14
-%52 = OpLoad %v4float %pos
+%50 = OpLoad %v4float %pos
 OpLine %7 9 3
-%53 = OpAccessChain %_ptr_Function_v4float %vout %int_0
-%54 = OpExtInst %void %1 DebugValue %46 %53 %42 %int_0
-OpStore %53 %52
+%51 = OpAccessChain %_ptr_Function_v4float %vout %int_0
+%52 = OpExtInst %void %1 DebugValue %46 %51 %42 %int_0
+OpStore %51 %50
 OpLine %7 10 16
-%55 = OpLoad %v4float %color
+%53 = OpLoad %v4float %color
 OpLine %7 10 3
-%56 = OpAccessChain %_ptr_Function_v4float %vout %int_1
-%57 = OpExtInst %void %1 DebugValue %46 %56 %42 %int_1
-OpStore %56 %55
+%54 = OpAccessChain %_ptr_Function_v4float %vout %int_1
+%55 = OpExtInst %void %1 DebugValue %46 %54 %42 %int_1
+OpStore %54 %53
 OpLine %7 11 10
-%58 = OpLoad %VS_OUTPUT %vout
+%56 = OpLoad %VS_OUTPUT %vout
 OpLine %7 11 3
-%59 = OpCompositeExtract %v4float %58 0
-OpStore %gl_Position %59
-%60 = OpCompositeExtract %v4float %58 1
-OpStore %out_var_COLOR %60
+%57 = OpCompositeExtract %v4float %56 0
+OpStore %gl_Position %57
+%58 = OpCompositeExtract %v4float %56 1
+OpStore %out_var_COLOR %58
+%61 = OpExtInst %void %1 DebugNoScope
 OpReturn
 OpFunctionEnd
 )");
@@ -377,7 +376,7 @@ OpLine %5 12 37
 OpLine %5 12 1
 %main = OpFunction %void None %36
 %bb_entry = OpLabel
-%52 = OpExtInst %void %1 DebugScope %47
+%70 = OpExtInst %void %1 DebugScope %47
 OpLine %5 13 16
 %param_var_arg1 = OpVariable %_ptr_Function_float Function
 %53 = OpLoad %float %pos
@@ -386,6 +385,7 @@ OpLine %5 13 10
 %54 = OpFunctionCall %v4float %func1 %param_var_arg1
 OpLine %5 13 3
 OpStore %gl_Position %54
+%71 = OpExtInst %void %1 DebugNoScope
 OpReturn
 OpFunctionEnd
 OpLine %5 5 1
@@ -393,41 +393,45 @@ OpLine %5 5 1
 OpLine %5 5 20
 %arg1 = OpFunctionParameter %_ptr_Function_float
 %bb_entry_0 = OpLabel
-%55 = OpExtInst %void %1 DebugScope %48
+%72 = OpExtInst %void %1 DebugScope %48
 OpLine %5 9 16
 %param_var_arg2 = OpVariable %_ptr_Function_float Function
 OpLine %5 6 7
-%56 = OpLoad %float %arg1
+%57 = OpLoad %float %arg1
 OpLine %5 6 12
-%57 = OpFOrdGreaterThan %bool %56 %float_1
+%58 = OpFOrdGreaterThan %bool %57 %float_1
 OpLine %5 6 17
+%73 = OpExtInst %void %1 DebugNoScope
 OpSelectionMerge %if_merge None
-OpBranchConditional %57 %if_true %if_merge
+OpBranchConditional %58 %if_true %if_merge
 %if_true = OpLabel
-%58 = OpExtInst %void %1 DebugScope %50
+%74 = OpExtInst %void %1 DebugScope %50
 OpLine %5 7 5
+%75 = OpExtInst %void %1 DebugNoScope
 OpReturnValue %32
 %if_merge = OpLabel
-%59 = OpExtInst %void %1 DebugScope %51
+%76 = OpExtInst %void %1 DebugScope %51
 OpLine %5 9 16
-%60 = OpLoad %float %arg1
-OpStore %param_var_arg2 %60
+%63 = OpLoad %float %arg1
+OpStore %param_var_arg2 %63
 OpLine %5 9 10
-%61 = OpFunctionCall %v4float %func2 %param_var_arg2
+%64 = OpFunctionCall %v4float %func2 %param_var_arg2
 OpLine %5 9 3
-OpReturnValue %61
+%77 = OpExtInst %void %1 DebugNoScope
+OpReturnValue %64
 OpFunctionEnd
 OpLine %5 1 1
 %func2 = OpFunction %v4float None %38
 OpLine %5 1 20
 %arg2 = OpFunctionParameter %_ptr_Function_float
 %bb_entry_1 = OpLabel
-%62 = OpExtInst %void %1 DebugScope %49
+%78 = OpExtInst %void %1 DebugScope %49
 OpLine %5 2 17
-%63 = OpLoad %float %arg2
-%64 = OpCompositeConstruct %v4float %63 %float_0 %float_0 %float_0
+%67 = OpLoad %float %arg2
+%68 = OpCompositeConstruct %v4float %67 %float_0 %float_0 %float_0
 OpLine %5 2 3
-OpReturnValue %64
+%79 = OpExtInst %void %1 DebugNoScope
+OpReturnValue %68
 OpFunctionEnd
 )");
 }
@@ -547,28 +551,31 @@ OpLine %5 12 37
 OpLine %5 12 1
 %main = OpFunction %void None %28
 %bb_entry = OpLabel
-%51 = OpExtInst %void %1 DebugScope %44 %49
+%62 = OpExtInst %void %1 DebugScope %44 %49
 OpLine %5 6 7
 %52 = OpLoad %float %pos
 OpLine %5 6 12
 %53 = OpFOrdGreaterThan %bool %52 %float_1
 OpLine %5 6 17
+%63 = OpExtInst %void %1 DebugNoScope
 OpSelectionMerge %if_merge None
 OpBranchConditional %53 %if_true %if_merge
 %if_true = OpLabel
-%54 = OpExtInst %void %1 DebugScope %46 %49
+%64 = OpExtInst %void %1 DebugScope %46 %49
 OpLine %5 7 5
 OpStore %gl_Position %24
+%65 = OpExtInst %void %1 DebugNoScope
 OpReturn
 %if_merge = OpLabel
-%55 = OpExtInst %void %1 DebugScope %45 %50
+%66 = OpExtInst %void %1 DebugScope %45 %50
 OpLine %5 2 17
-%56 = OpLoad %float %pos
+%58 = OpLoad %float %pos
 OpLine %5 2 10
-%57 = OpCompositeConstruct %v4float %56 %float_0 %float_0 %float_0
-%58 = OpExtInst %void %1 DebugScope %43
+%59 = OpCompositeConstruct %v4float %58 %float_0 %float_0 %float_0
+%67 = OpExtInst %void %1 DebugScope %43
 OpLine %5 13 3
-OpStore %gl_Position %57
+OpStore %gl_Position %59
+%68 = OpExtInst %void %1 DebugNoScope
 OpReturn
 OpFunctionEnd
 )");
@@ -683,8 +690,8 @@ OpLine %5 12 37
 %51 = OpExtInst %void %1 DebugLexicalBlock %40 9 3 %48
 OpLine %5 12 1
 %main = OpFunction %void None %36
-%52 = OpExtInst %void %1 DebugScope %47
 %bb_entry = OpLabel
+%70 = OpExtInst %void %1 DebugScope %47
 OpLine %5 13 16
 %param_var_arg1 = OpVariable %_ptr_Function_float Function
 %53 = OpLoad %float %pos
@@ -693,6 +700,7 @@ OpLine %5 13 10
 %54 = OpFunctionCall %v4float %func1 %param_var_arg1
 OpLine %5 13 3
 OpStore %gl_Position %54
+%71 = OpExtInst %void %1 DebugNoScope
 OpReturn
 OpFunctionEnd
 OpLine %5 5 1
@@ -700,48 +708,244 @@ OpLine %5 5 1
 OpLine %5 5 20
 %arg1 = OpFunctionParameter %_ptr_Function_float
 %bb_entry_0 = OpLabel
-%55 = OpExtInst %void %1 DebugScope %48
+%72 = OpExtInst %void %1 DebugScope %48
 OpLine %5 9 16
 %param_var_arg2 = OpVariable %_ptr_Function_float Function
 OpLine %5 6 7
-%56 = OpLoad %float %arg1
+%57 = OpLoad %float %arg1
 OpLine %5 6 12
-%57 = OpFOrdGreaterThan %bool %56 %float_1
+%58 = OpFOrdGreaterThan %bool %57 %float_1
 OpLine %5 6 17
+%73 = OpExtInst %void %1 DebugNoScope
 OpSelectionMerge %if_merge None
-OpBranchConditional %57 %if_true %if_merge
+OpBranchConditional %58 %if_true %if_merge
 %if_true = OpLabel
-%58 = OpExtInst %void %1 DebugScope %50
+%74 = OpExtInst %void %1 DebugScope %50
 OpLine %5 7 5
+%75 = OpExtInst %void %1 DebugNoScope
 OpReturnValue %32
 %if_merge = OpLabel
-%59 = OpExtInst %void %1 DebugScope %51
+%76 = OpExtInst %void %1 DebugScope %51
 OpLine %5 9 16
-%60 = OpLoad %float %arg1
-OpStore %param_var_arg2 %60
+%63 = OpLoad %float %arg1
+OpStore %param_var_arg2 %63
 OpLine %5 9 10
-%61 = OpFunctionCall %v4float %func2 %param_var_arg2
+%64 = OpFunctionCall %v4float %func2 %param_var_arg2
 OpLine %5 9 3
-OpReturnValue %61
+%77 = OpExtInst %void %1 DebugNoScope
+OpReturnValue %64
 OpFunctionEnd
 OpLine %5 1 1
 %func2 = OpFunction %v4float None %38
 OpLine %5 1 20
 %arg2 = OpFunctionParameter %_ptr_Function_float
 %bb_entry_1 = OpLabel
-%62 = OpExtInst %void %1 DebugScope %49
+%78 = OpExtInst %void %1 DebugScope %49
 OpLine %5 2 17
-%63 = OpLoad %float %arg2
-%64 = OpCompositeConstruct %v4float %63 %float_0 %float_0 %float_0
+%67 = OpLoad %float %arg2
+%68 = OpCompositeConstruct %v4float %67 %float_0 %float_0 %float_0
 OpLine %5 2 3
-OpReturnValue %64
+%79 = OpExtInst %void %1 DebugNoScope
+OpReturnValue %68
 OpFunctionEnd
 )";
 
   SpirvTools t(SPV_ENV_UNIVERSAL_1_1);
   std::unique_ptr<IRContext> context =
       BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text);
-  ASSERT_EQ(nullptr, context);
+  ASSERT_NE(nullptr, context);
+
+  std::vector<uint32_t> binary;
+  context->module()->ToBinary(&binary, /* skip_nop = */ false);
+
+  std::string disassembled_text;
+  EXPECT_TRUE(t.Disassemble(binary, &disassembled_text));
+  EXPECT_EQ(text, disassembled_text);
+}
+
+TEST(IrBuilder, DebugInfoInstInFunctionOutOfBlock2) {
+  // /* HLSL */
+  //
+  // struct VS_OUTPUT {
+  //   float4 pos : SV_POSITION;
+  //   float4 color : COLOR;
+  // };
+  //
+  // VS_OUTPUT main(float4 pos : POSITION,
+  //                float4 color : COLOR) {
+  //   VS_OUTPUT vout;
+  //   vout.pos = pos;
+  //   vout.color = color;
+  //   return vout;
+  // }
+  const std::string text = R"(OpCapability Shader
+%1 = OpExtInstImport "OpenCL.DebugInfo.100"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Vertex %main "main" %in_var_POSITION %in_var_COLOR %gl_Position %out_var_COLOR
+%7 = OpString "vs.hlsl"
+OpSource HLSL 600 %7 "#line 1 \"vs.hlsl\"
+struct VS_OUTPUT {
+  float4 pos : SV_POSITION;
+  float4 color : COLOR;
+};
+
+VS_OUTPUT main(float4 pos : POSITION,
+               float4 color : COLOR) {
+  VS_OUTPUT vout;
+  vout.pos = pos;
+  vout.color = color;
+  return vout;
+}
+"
+%8 = OpString "#line 1 \"vs.hlsl\"
+struct VS_OUTPUT {
+  float4 pos : SV_POSITION;
+  float4 color : COLOR;
+};
+
+VS_OUTPUT main(float4 pos : POSITION,
+               float4 color : COLOR) {
+  VS_OUTPUT vout;
+  vout.pos = pos;
+  vout.color = color;
+  return vout;
+}
+"
+%9 = OpString "VS_OUTPUT"
+%10 = OpString "float"
+%11 = OpString "src.main"
+%12 = OpString "pos"
+%13 = OpString "color"
+%14 = OpString "vout"
+OpName %in_var_POSITION "in.var.POSITION"
+OpName %in_var_COLOR "in.var.COLOR"
+OpName %out_var_COLOR "out.var.COLOR"
+OpName %main "main"
+OpName %param_var_pos "param.var.pos"
+OpName %param_var_color "param.var.color"
+OpName %VS_OUTPUT "VS_OUTPUT"
+OpMemberName %VS_OUTPUT 0 "pos"
+OpMemberName %VS_OUTPUT 1 "color"
+OpName %src_main "src.main"
+OpName %pos "pos"
+OpName %color "color"
+OpName %bb_entry "bb.entry"
+OpName %vout "vout"
+OpDecorate %gl_Position BuiltIn Position
+OpDecorate %in_var_POSITION Location 0
+OpDecorate %in_var_COLOR Location 1
+OpDecorate %out_var_COLOR Location 0
+%int = OpTypeInt 32 1
+%int_0 = OpConstant %int 0
+%int_1 = OpConstant %int 1
+%uint = OpTypeInt 32 0
+%uint_32 = OpConstant %uint 32
+%float = OpTypeFloat 32
+%v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%void = OpTypeVoid
+%uint_256 = OpConstant %uint 256
+%uint_0 = OpConstant %uint 0
+%uint_128 = OpConstant %uint 128
+%36 = OpTypeFunction %void
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+%VS_OUTPUT = OpTypeStruct %v4float %v4float
+%38 = OpTypeFunction %VS_OUTPUT %_ptr_Function_v4float %_ptr_Function_v4float
+%_ptr_Function_VS_OUTPUT = OpTypePointer Function %VS_OUTPUT
+OpLine %7 6 29
+%in_var_POSITION = OpVariable %_ptr_Input_v4float Input
+OpLine %7 7 31
+%in_var_COLOR = OpVariable %_ptr_Input_v4float Input
+OpLine %7 2 16
+%gl_Position = OpVariable %_ptr_Output_v4float Output
+OpLine %7 3 18
+%out_var_COLOR = OpVariable %_ptr_Output_v4float Output
+%40 = OpExtInst %void %1 DebugExpression
+%41 = OpExtInst %void %1 DebugSource %7 %8
+%42 = OpExtInst %void %1 DebugCompilationUnit 1 4 %41 HLSL
+%43 = OpExtInst %void %1 DebugTypeComposite %9 Structure %41 1 1 %42 %9 %uint_256 FlagIsProtected|FlagIsPrivate %44 %45
+%46 = OpExtInst %void %1 DebugTypeBasic %10 %uint_32 Float
+%47 = OpExtInst %void %1 DebugTypeVector %46 4
+%48 = OpExtInst %void %1 DebugTypeFunction FlagIsProtected|FlagIsPrivate %43 %47 %47
+%49 = OpExtInst %void %1 DebugFunction %11 %48 %41 6 1 %42 %11 FlagIsProtected|FlagIsPrivate 7 %src_main
+%50 = OpExtInst %void %1 DebugLocalVariable %12 %47 %41 6 23 %49 FlagIsLocal 0
+%51 = OpExtInst %void %1 DebugLocalVariable %13 %47 %41 7 23 %49 FlagIsLocal 1
+%52 = OpExtInst %void %1 DebugLexicalBlock %41 7 38 %49
+%53 = OpExtInst %void %1 DebugLocalVariable %14 %43 %41 8 13 %52 FlagIsLocal
+%44 = OpExtInst %void %1 DebugTypeMember %12 %47 %41 2 3 %43 %uint_0 %uint_128 FlagIsProtected|FlagIsPrivate
+%45 = OpExtInst %void %1 DebugTypeMember %13 %47 %41 3 3 %43 %uint_128 %uint_128 FlagIsProtected|FlagIsPrivate
+OpLine %7 6 1
+%main = OpFunction %void None %36
+%54 = OpLabel
+%74 = OpExtInst %void %1 DebugScope %42
+OpLine %7 6 23
+%param_var_pos = OpVariable %_ptr_Function_v4float Function
+OpLine %7 7 23
+%param_var_color = OpVariable %_ptr_Function_v4float Function
+OpLine %7 6 23
+%56 = OpLoad %v4float %in_var_POSITION
+OpStore %param_var_pos %56
+OpLine %7 7 23
+%57 = OpLoad %v4float %in_var_COLOR
+OpStore %param_var_color %57
+OpLine %7 6 1
+%58 = OpFunctionCall %VS_OUTPUT %src_main %param_var_pos %param_var_color
+OpLine %7 6 11
+%59 = OpCompositeExtract %v4float %58 0
+OpLine %7 2 16
+OpStore %gl_Position %59
+OpLine %7 6 11
+%60 = OpCompositeExtract %v4float %58 1
+OpLine %7 3 18
+OpStore %out_var_COLOR %60
+%75 = OpExtInst %void %1 DebugNoScope
+OpReturn
+OpFunctionEnd
+OpLine %7 6 1
+%src_main = OpFunction %VS_OUTPUT None %38
+%76 = OpExtInst %void %1 DebugScope %49
+OpLine %7 6 23
+%pos = OpFunctionParameter %_ptr_Function_v4float
+%63 = OpExtInst %void %1 DebugDeclare %50 %pos %40
+OpLine %7 7 23
+%color = OpFunctionParameter %_ptr_Function_v4float
+%64 = OpExtInst %void %1 DebugDeclare %51 %color %40
+%77 = OpExtInst %void %1 DebugNoScope
+%bb_entry = OpLabel
+%78 = OpExtInst %void %1 DebugScope %52
+OpLine %7 8 13
+%vout = OpVariable %_ptr_Function_VS_OUTPUT Function
+%67 = OpExtInst %void %1 DebugDeclare %53 %vout %40
+OpLine %7 9 14
+%68 = OpLoad %v4float %pos
+OpLine %7 9 3
+%69 = OpAccessChain %_ptr_Function_v4float %vout %int_0
+OpStore %69 %68
+OpLine %7 10 16
+%70 = OpLoad %v4float %color
+OpLine %7 10 3
+%71 = OpAccessChain %_ptr_Function_v4float %vout %int_1
+OpStore %71 %70
+OpLine %7 11 10
+%72 = OpLoad %VS_OUTPUT %vout
+OpLine %7 11 3
+%79 = OpExtInst %void %1 DebugNoScope
+OpReturnValue %72
+OpFunctionEnd
+)";
+
+  SpirvTools t(SPV_ENV_UNIVERSAL_1_1);
+  std::unique_ptr<IRContext> context =
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text);
+  ASSERT_NE(nullptr, context);
+
+  std::vector<uint32_t> binary;
+  context->module()->ToBinary(&binary, /* skip_nop = */ false);
+
+  std::string disassembled_text;
+  EXPECT_TRUE(t.Disassemble(binary, &disassembled_text));
+  EXPECT_EQ(text, disassembled_text);
 }
 
 TEST(IrBuilder, LocalGlobalVariables) {

--- a/test/opt/ir_loader_test.cpp
+++ b/test/opt/ir_loader_test.cpp
@@ -907,9 +907,9 @@ OpLine %7 6 1
 %76 = OpExtInst %void %1 DebugScope %49
 OpLine %7 6 23
 %pos = OpFunctionParameter %_ptr_Function_v4float
-%63 = OpExtInst %void %1 DebugDeclare %50 %pos %40
 OpLine %7 7 23
 %color = OpFunctionParameter %_ptr_Function_v4float
+%63 = OpExtInst %void %1 DebugDeclare %50 %pos %40
 %64 = OpExtInst %void %1 DebugDeclare %51 %color %40
 %77 = OpExtInst %void %1 DebugNoScope
 %bb_entry = OpLabel


### PR DESCRIPTION
This commit adds data structures for rich debug info and lets ir_loader
and module correctly load/dump IR instructions.
- For debug instructions other than `DebugScope`, `DebugNoScope`,
`DebugDeclare`, `DebugValue`, we already added
`InstructionList ext_inst_debuginfo_` in `Module` class.
- For `DebugScope`/`DebugNoScope`, this commit adds
`struct DebugScope` in `Instruction` class.
  - When ir_loader processes `DebugScope`/`DebugNoScope`, we update
`last_dbg_scope_` of ir_loader to update the last `DebugScope`
information. When ir_loader processes a terminator instruction or merge
instruction, it sets `last_dbg_scope_` as `DebugNoScope` because it is the
end of the scope. When module dumps IR, if the next `DebugScope` is new
scope information, it generates a `DebugScope` instruction. If the next
`DebugScope` denotes the end of a scope, it generates a `DebugNoScope`
instruction.
- For `DebugDeclare`, this commit adds
`std::map<uint32_t, std::unique_ptr<Instruction>> local_var_to_dbg_decl_`
that is a map between each result id of local variable and its
corresponding `DebugDeclare`. When we remove a local variable, we can
remove `DebugDeclare` and add a new `DebugValue` in `InstructionList`
of basic block like a normal instruction.