### PR TITLE
Combine extinst-name and extinst-output-base into one arg.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -235,9 +235,8 @@ $(1)/$(2).h : \
         $(LOCAL_PATH)/utils/generate_language_headers.py \
         $(3)
 		@$(HOST_PYTHON) $(LOCAL_PATH)/utils/generate_language_headers.py \
-		    --extinst-name=$(2) \
 		    --extinst-grammar=$(3) \
-		    --extinst-output-base=$(1)/$(2)
+		    --extinst-output-path=$(1)/$(2).h
 		@echo "[$(TARGET_ARCH_ABI)] Generate language specific header for $(2): headers <= grammar"
 $(foreach F,$(SPVTOOLS_SRC_FILES) $(SPVTOOLS_OPT_SRC_FILES),$(LOCAL_PATH)/$F ) \
 	: $(1)/$(2).h

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -184,21 +184,19 @@ template("spvtools_language_header") {
     script = "utils/generate_language_headers.py"
 
     name = invoker.name
-    extinst_output_base = "${target_gen_dir}/${name}"
+    extinst_output_path = "${target_gen_dir}/${name}.h"
 
     args = [
-      "--extinst-name",
-      "${name}",
       "--extinst-grammar",
       rebase_path(invoker.grammar_file, root_build_dir),
-      "--extinst-output-base",
-      rebase_path(extinst_output_base, root_build_dir),
+      "--extinst-output-path",
+      rebase_path(extinst_output_path, root_build_dir),
     ]
     inputs = [
       invoker.grammar_file,
     ]
     outputs = [
-      "${extinst_output_base}.h",
+      "${extinst_output_path}",
     ]
   }
 }

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -167,16 +167,16 @@ def generate_vendor_tables(extension, operand_kind_prefix = ""):
 def generate_extinst_lang_headers(name, grammar = None):
     if not grammar:
         fail("Must specify grammar", "grammar")
-    fmtargs = [name]
+    outs = [name + ".h"],
+    fmtargs = outs
     native.genrule(
         name = "gen_extinst_lang_headers_" + name,
         srcs = [grammar],
-        outs = [name + ".h"],
+        outs = outs,
         cmd = (
             "$(location :generate_language_headers) " +
-            "--extinst-name={0} " +
             "--extinst-grammar=$< " +
-            "--extinst-output-base=$(@D)/{0}"
+            "--extinst-output-path=$(location {0})"
         ).format(*fmtargs),
         tools = [":generate_language_headers"],
         visibility = ["//visibility:private"],

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -167,7 +167,7 @@ def generate_vendor_tables(extension, operand_kind_prefix = ""):
 def generate_extinst_lang_headers(name, grammar = None):
     if not grammar:
         fail("Must specify grammar", "grammar")
-    outs = [name + ".h"],
+    outs = [name + ".h"]
     fmtargs = outs
     native.genrule(
         name = "gen_extinst_lang_headers_" + name,

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -126,13 +126,11 @@ macro(spvtools_vendor_tables VENDOR_TABLE SHORT_NAME OPERAND_KIND_PREFIX)
 endmacro(spvtools_vendor_tables)
 
 macro(spvtools_extinst_lang_headers NAME GRAMMAR_FILE)
-  set(OUTBASE ${spirv-tools_BINARY_DIR}/${NAME})
-  set(OUT_H ${OUTBASE}.h)
+  set(OUT_H ${spirv-tools_BINARY_DIR}/${NAME}.h)
   add_custom_command(OUTPUT ${OUT_H}
     COMMAND ${PYTHON_EXECUTABLE} ${LANG_HEADER_PROCESSING_SCRIPT}
-      --extinst-name=${NAME}
       --extinst-grammar=${GRAMMAR_FILE}
-      --extinst-output-base=${OUTBASE}
+      --extinst-output-path=${OUT_H}
     DEPENDS ${LANG_HEADER_PROCESSING_SCRIPT} ${GRAMMAR_FILE}
     COMMENT "Generate language specific header for ${NAME}.")
   add_custom_target(spirv-tools-header-${NAME} DEPENDS ${OUT_H})

--- a/utils/generate_language_headers.py
+++ b/utils/generate_language_headers.py
@@ -159,27 +159,25 @@ def main():
     import argparse
     parser = argparse.ArgumentParser(description='Generate language headers from a JSON grammar')
 
-    parser.add_argument('--extinst-name',
-                        type=str, required=True,
-                        help='The name to use in tokens')
     parser.add_argument('--extinst-grammar', metavar='<path>',
                         type=str, required=True,
                         help='input JSON grammar file for extended instruction set')
-    parser.add_argument('--extinst-output-base', metavar='<path>',
+    parser.add_argument('--extinst-output-path', metavar='<path>',
                         type=str, required=True,
-                        help='Basename of the language-specific output file.')
+                        help='Path of the language-specific output file.')
     args = parser.parse_args()
 
     with open(args.extinst_grammar) as json_file:
         grammar_json = json.loads(json_file.read())
-        grammar = ExtInstGrammar(name = args.extinst_name,
+        grammar_name = os.path.splitext(os.path.basename(args.extinst_output_path))[0]
+        grammar = ExtInstGrammar(name = grammar_name,
                                  copyright = grammar_json['copyright'],
                                  instructions = grammar_json['instructions'],
                                  operand_kinds = grammar_json['operand_kinds'],
                                  version = grammar_json['version'],
                                  revision = grammar_json['revision'])
-        make_path_to_file(args.extinst_output_base)
-        with open(args.extinst_output_base + '.h', 'w') as f:
+        make_path_to_file(args.extinst_output_path)
+        with open(args.extinst_output_path, 'w') as f:
             f.write(CGenerator().generate(grammar))
 
 


### PR DESCRIPTION
Some build systems such as Android blueprints require that the inputs
and outputs of generator scripts are all provided as arguments.  These
two arguments to generate_language_headers.py are combined to form the
output path in the script.  This change simply lets the user provide the
whole output path as an argument.

I wasn't able to test to bazel build files locally.