### PR TITLE
spirv-fuzz: Fuzzer pass to add equation instructions

### DIFF
--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -42,6 +42,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_add_dead_blocks.h
         fuzzer_pass_add_dead_breaks.h
         fuzzer_pass_add_dead_continues.h
+        fuzzer_pass_add_equation_instructions.h
         fuzzer_pass_add_function_calls.h
         fuzzer_pass_add_global_variables.h
         fuzzer_pass_add_loads.h
@@ -96,6 +97,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_composite_construct.h
         transformation_composite_extract.h
         transformation_copy_object.h
+        transformation_equation_instruction.h
         transformation_function_call.h
         transformation_load.h
         transformation_merge_blocks.h
@@ -126,6 +128,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_add_dead_blocks.cpp
         fuzzer_pass_add_dead_breaks.cpp
         fuzzer_pass_add_dead_continues.cpp
+        fuzzer_pass_add_equation_instructions.cpp
         fuzzer_pass_add_function_calls.cpp
         fuzzer_pass_add_global_variables.cpp
         fuzzer_pass_add_loads.cpp
@@ -179,6 +182,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_composite_construct.cpp
         transformation_composite_extract.cpp
         transformation_copy_object.cpp
+        transformation_equation_instruction.cpp
         transformation_function_call.cpp
         transformation_load.cpp
         transformation_merge_blocks.cpp

--- a/source/fuzz/equivalence_relation.h
+++ b/source/fuzz/equivalence_relation.h
@@ -205,7 +205,7 @@ class EquivalenceRelation {
       parent_[current] = result;
       children_[result].push_back(current);
       auto child_iterator =
-              std::find(children_[next].begin(), children_[next].end(), current);
+          std::find(children_[next].begin(), children_[next].end(), current);
       assert(child_iterator != children_[next].end() &&
              "'next' is the parent of 'current', so 'current' should be a "
              "child of 'next'");
@@ -216,7 +216,6 @@ class EquivalenceRelation {
   }
 
  private:
-
   // Maps every value to a parent.  The representative of an equivalence class
   // is its own parent.  A value's representative can be found by walking its
   // chain of ancestors.

--- a/source/fuzz/equivalence_relation.h
+++ b/source/fuzz/equivalence_relation.h
@@ -102,7 +102,9 @@ class EquivalenceRelation {
     }
   }
 
-  // TODO comment
+  // Requires that |value| is not known to the equivalence relation. Registers
+  // it in its own equivalence class and returns a pointer to the equivalence
+  // class representative.
   const T* Register(T& value) {
     assert(!Exists(value));
 

--- a/source/fuzz/fact_manager.cpp
+++ b/source/fuzz/fact_manager.cpp
@@ -426,8 +426,8 @@ class FactManager::DataSynonymAndIdEquationFacts {
   // into sub-components of the data descriptors, if they are composites, to
   // record that their components are pairwise-synonymous.
   void AddDataSynonymFactRecursive(const protobufs::DataDescriptor& dd1,
-          const protobufs::DataDescriptor& dd2,
-                        opt::IRContext* context);
+                                   const protobufs::DataDescriptor& dd2,
+                                   opt::IRContext* context);
 
   // Inspects all known facts and adds corollary facts; e.g. if we know that
   // a.x == b.x and a.y == b.y, where a and b have vec2 type, we can record
@@ -554,7 +554,7 @@ void FactManager::DataSynonymAndIdEquationFacts::AddIdEquationFactRecursive(
                 // Equation form: "a = (d - c) + c"
                 // We can thus infer "a = d"
                 AddDataSynonymFactRecursive(lhs_dd, *equation.operands[0],
-                        context);
+                                            context);
               }
               if (equation.operands[0] == rhs_dds[1]) {
                 // Equation form: "a = (c - e) + c"
@@ -661,8 +661,7 @@ void FactManager::DataSynonymAndIdEquationFacts::AddIdEquationFactRecursive(
           if (equation.opcode == opcode) {
             // Equation form: "a = !!b" or "a = -(-b)"
             // We can thus infer "a = b"
-            AddDataSynonymFactRecursive(lhs_dd, *equation.operands[0],
-                                        context);
+            AddDataSynonymFactRecursive(lhs_dd, *equation.operands[0], context);
           }
         }
       }
@@ -675,10 +674,8 @@ void FactManager::DataSynonymAndIdEquationFacts::AddIdEquationFactRecursive(
 
 void FactManager::DataSynonymAndIdEquationFacts::AddDataSynonymFactRecursive(
     const protobufs::DataDescriptor& dd1, const protobufs::DataDescriptor& dd2,
-    opt::IRContext*
-    context) {
-  assert(DataDescriptorsAreWellFormedAndComparable(context, dd1,
-                                                   dd2));
+    opt::IRContext* context) {
+  assert(DataDescriptorsAreWellFormedAndComparable(context, dd1, dd2));
 
   // Record that the data descriptors provided in the fact are equivalent.
   synonymous_.MakeEquivalent(dd1, dd2);
@@ -694,8 +691,7 @@ void FactManager::DataSynonymAndIdEquationFacts::AddDataSynonymFactRecursive(
   // Get the type of the object referred to by the first data descriptor in the
   // synonym fact.
   uint32_t type_id = fuzzerutil::WalkCompositeTypeIndices(
-      context,
-      context->get_def_use_mgr()->GetDef(dd1.object())->type_id(),
+      context, context->get_def_use_mgr()->GetDef(dd1.object())->type_id(),
       dd1.index());
   auto type = context->get_type_mgr()->GetType(type_id);
   auto type_instruction = context->get_def_use_mgr()->GetDef(type_id);
@@ -731,10 +727,10 @@ void FactManager::DataSynonymAndIdEquationFacts::AddDataSynonymFactRecursive(
     std::vector<uint32_t> extended_indices2 =
         fuzzerutil::RepeatedFieldToVector(dd2.index());
     extended_indices2.push_back(i);
-    AddDataSynonymFactRecursive(MakeDataDescriptor(dd1.object(), std::move(extended_indices1)),
-                                MakeDataDescriptor(dd2.object(), std::move
-                                (extended_indices2)),
-                                context);
+    AddDataSynonymFactRecursive(
+        MakeDataDescriptor(dd1.object(), std::move(extended_indices1)),
+        MakeDataDescriptor(dd2.object(), std::move(extended_indices2)),
+        context);
   }
 }
 

--- a/source/fuzz/fact_manager.cpp
+++ b/source/fuzz/fact_manager.cpp
@@ -554,7 +554,9 @@ void FactManager::DataSynonymAndIdEquationFacts::AddEquationFactRecursive(
   if (id_equations_.count(&lhs_dd) == 0) {
     // We have not seen an equation with this LHS before, so associate the LHS
     // with an initially empty set.
-    id_equations_.insert({&lhs_dd, {}});
+    id_equations_.insert(
+        {&lhs_dd,
+         std::unordered_set<Operation, OperationHash, OperationEquals>()});
   }
 
   {

--- a/source/fuzz/fact_manager.cpp
+++ b/source/fuzz/fact_manager.cpp
@@ -481,7 +481,7 @@ class FactManager::DataSynonymAndIdEquationFacts {
   // whether a new fact has been added since the last time such a computation
   // was performed.
   //
-  // It is mutable so facilitate having const methods, that provide answers to
+  // It is mutable to facilitate having const methods, that provide answers to
   // questions about data synonym facts, triggering closure computation on
   // demand.
   mutable bool closure_computation_required_ = false;
@@ -554,9 +554,7 @@ void FactManager::DataSynonymAndIdEquationFacts::AddEquationFactRecursive(
   if (id_equations_.count(&lhs_dd) == 0) {
     // We have not seen an equation with this LHS before, so associate the LHS
     // with an initially empty set.
-    id_equations_.insert(
-        {&lhs_dd,
-         std::unordered_set<Operation, OperationHash, OperationEquals>()});
+    id_equations_.insert({&lhs_dd, {}});
   }
 
   {

--- a/source/fuzz/fact_manager.h
+++ b/source/fuzz/fact_manager.h
@@ -68,7 +68,10 @@ class FactManager {
   // is irrelevant: it does not affect the observable behaviour of the module.
   void AddFactValueOfPointeeIsIrrelevant(uint32_t pointer_id);
 
-  // TODO comment
+  // Records the fact that |lhs_id| is defined by the equation:
+  //
+  //   |lhs_id| = |opcode| |rhs_id[0]| ... |rhs_id[N-1]|
+  //
   void AddFactIdEquation(uint32_t lhs_id, SpvOp opcode,
                          const std::vector<uint32_t>& rhs_id,
                          opt::IRContext* context);

--- a/source/fuzz/fact_manager.h
+++ b/source/fuzz/fact_manager.h
@@ -68,6 +68,10 @@ class FactManager {
   // is irrelevant: it does not affect the observable behaviour of the module.
   void AddFactValueOfPointeeIsIrrelevant(uint32_t pointer_id);
 
+  // TODO comment
+  void AddFactIdEquation(uint32_t lhs_id, SpvOp opcode, const
+  std::vector<uint32_t>& rhs_id, opt::IRContext* context);
+
   // The fact manager is responsible for managing a few distinct categories of
   // facts. In principle there could be different fact managers for each kind
   // of fact, but in practice providing one 'go to' place for facts is
@@ -179,9 +183,9 @@ class FactManager {
   std::unique_ptr<ConstantUniformFacts>
       uniform_constant_facts_;  // Unique pointer to internal data.
 
-  class DataSynonymFacts;  // Opaque class for management of data synonym facts.
-  std::unique_ptr<DataSynonymFacts>
-      data_synonym_facts_;  // Unique pointer to internal data.
+  class DataSynonymAndIdEquationFacts;  // Opaque class for management of data synonym and id equation facts.
+  std::unique_ptr<DataSynonymAndIdEquationFacts>
+      data_synonym_and_id_equation_facts_;  // Unique pointer to internal data.
 
   class DeadBlockFacts;  // Opaque class for management of dead block facts.
   std::unique_ptr<DeadBlockFacts>

--- a/source/fuzz/fact_manager.h
+++ b/source/fuzz/fact_manager.h
@@ -69,8 +69,9 @@ class FactManager {
   void AddFactValueOfPointeeIsIrrelevant(uint32_t pointer_id);
 
   // TODO comment
-  void AddFactIdEquation(uint32_t lhs_id, SpvOp opcode, const
-  std::vector<uint32_t>& rhs_id, opt::IRContext* context);
+  void AddFactIdEquation(uint32_t lhs_id, SpvOp opcode,
+                         const std::vector<uint32_t>& rhs_id,
+                         opt::IRContext* context);
 
   // The fact manager is responsible for managing a few distinct categories of
   // facts. In principle there could be different fact managers for each kind
@@ -183,7 +184,8 @@ class FactManager {
   std::unique_ptr<ConstantUniformFacts>
       uniform_constant_facts_;  // Unique pointer to internal data.
 
-  class DataSynonymAndIdEquationFacts;  // Opaque class for management of data synonym and id equation facts.
+  class DataSynonymAndIdEquationFacts;  // Opaque class for management of data
+                                        // synonym and id equation facts.
   std::unique_ptr<DataSynonymAndIdEquationFacts>
       data_synonym_and_id_equation_facts_;  // Unique pointer to internal data.
 

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -26,6 +26,7 @@
 #include "source/fuzz/fuzzer_pass_add_dead_blocks.h"
 #include "source/fuzz/fuzzer_pass_add_dead_breaks.h"
 #include "source/fuzz/fuzzer_pass_add_dead_continues.h"
+#include "source/fuzz/fuzzer_pass_add_equation_instructions.h"
 #include "source/fuzz/fuzzer_pass_add_function_calls.h"
 #include "source/fuzz/fuzzer_pass_add_global_variables.h"
 #include "source/fuzz/fuzzer_pass_add_loads.h"
@@ -200,6 +201,9 @@ Fuzzer::FuzzerResultStatus Fuzzer::Run(
     MaybeAddPass<FuzzerPassAddDeadContinues>(&passes, ir_context.get(),
                                              &fact_manager, &fuzzer_context,
                                              transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddEquationInstructions>(
+        &passes, ir_context.get(), &fact_manager, &fuzzer_context,
+        transformation_sequence_out);
     MaybeAddPass<FuzzerPassAddFunctionCalls>(&passes, ir_context.get(),
                                              &fact_manager, &fuzzer_context,
                                              transformation_sequence_out);

--- a/source/fuzz/fuzzer_context.cpp
+++ b/source/fuzz/fuzzer_context.cpp
@@ -30,6 +30,8 @@ const std::pair<uint32_t, uint32_t> kChanceOfAddingArrayOrStructType = {20, 90};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingDeadBlock = {20, 90};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingDeadBreak = {5, 80};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingDeadContinue = {5, 80};
+const std::pair<uint32_t, uint32_t> kChanceOfAddingEquationInstruction = {5,
+                                                                          90};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingGlobalVariable = {20, 90};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingLoad = {5, 50};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingLocalVariable = {20, 90};
@@ -102,6 +104,8 @@ FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
       ChooseBetweenMinAndMax(kChanceOfAddingDeadBreak);
   chance_of_adding_dead_continue_ =
       ChooseBetweenMinAndMax(kChanceOfAddingDeadContinue);
+  chance_of_adding_equation_instruction_ =
+      ChooseBetweenMinAndMax(kChanceOfAddingEquationInstruction);
   chance_of_adding_global_variable_ =
       ChooseBetweenMinAndMax(kChanceOfAddingGlobalVariable);
   chance_of_adding_load_ = ChooseBetweenMinAndMax(kChanceOfAddingLoad);

--- a/source/fuzz/fuzzer_context.h
+++ b/source/fuzz/fuzzer_context.h
@@ -82,6 +82,9 @@ class FuzzerContext {
   uint32_t GetChanceOfAddingDeadContinue() {
     return chance_of_adding_dead_continue_;
   }
+  uint32_t GetChanceOfAddingEquationInstruction() {
+    return chance_of_adding_equation_instruction_;
+  }
   uint32_t GetChanceOfAddingGlobalVariable() {
     return chance_of_adding_global_variable_;
   }
@@ -177,6 +180,7 @@ class FuzzerContext {
   uint32_t chance_of_adding_dead_block_;
   uint32_t chance_of_adding_dead_break_;
   uint32_t chance_of_adding_dead_continue_;
+  uint32_t chance_of_adding_equation_instruction_;
   uint32_t chance_of_adding_global_variable_;
   uint32_t chance_of_adding_load_;
   uint32_t chance_of_adding_local_variable_;

--- a/source/fuzz/fuzzer_pass_add_equation_instructions.cpp
+++ b/source/fuzz/fuzzer_pass_add_equation_instructions.cpp
@@ -23,7 +23,8 @@ FuzzerPassAddEquationInstructions::FuzzerPassAddEquationInstructions(
     protobufs::TransformationSequence* transformations)
     : FuzzerPass(ir_context, fact_manager, fuzzer_context, transformations) {}
 
-FuzzerPassAddEquationInstructions::~FuzzerPassAddEquationInstructions() = default;
+FuzzerPassAddEquationInstructions::~FuzzerPassAddEquationInstructions() =
+    default;
 
 void FuzzerPassAddEquationInstructions::Apply() {
   assert(false && "Implement");

--- a/source/fuzz/fuzzer_pass_add_equation_instructions.cpp
+++ b/source/fuzz/fuzzer_pass_add_equation_instructions.cpp
@@ -14,6 +14,11 @@
 
 #include "source/fuzz/fuzzer_pass_add_equation_instructions.h"
 
+#include <vector>
+
+#include "source/fuzz/fuzzer_util.h"
+#include "source/fuzz/transformation_equation_instruction.h"
+
 namespace spvtools {
 namespace fuzz {
 
@@ -27,7 +32,147 @@ FuzzerPassAddEquationInstructions::~FuzzerPassAddEquationInstructions() =
     default;
 
 void FuzzerPassAddEquationInstructions::Apply() {
-  assert(false && "Implement");
+  MaybeAddTransformationBeforeEachInstruction(
+      [this](opt::Function* function, opt::BasicBlock* block,
+             opt::BasicBlock::iterator inst_it,
+             const protobufs::InstructionDescriptor& instruction_descriptor) {
+        if (!GetFuzzerContext()->ChoosePercentage(
+                GetFuzzerContext()->GetChanceOfAddingEquationInstruction())) {
+          return;
+        }
+
+        // Check that it is OK to add an equation instruction before the given
+        // instruction in principle - e.g. check that this does not lead to
+        // inserting before an OpVariable or OpPhi instruction.  We use OpIAdd
+        // as an example opcode for this check, to be representative of *some*
+        // opcode that defines an equation, even though we may choose a
+        // different opcode below.
+        if (!fuzzerutil::CanInsertOpcodeBeforeInstruction(SpvOpIAdd, inst_it)) {
+          return;
+        }
+
+        // Get all available instructions with result ids and types that are not
+        // OpUndef.
+        std::vector<opt::Instruction*> available_instructions =
+            FindAvailableInstructions(
+                function, block, inst_it,
+                [](opt::IRContext*, opt::Instruction* instruction) -> bool {
+                  return instruction->result_id() && instruction->type_id() &&
+                         instruction->opcode() != SpvOpUndef;
+                });
+
+        // Try the opcodes for which we know how to make ids at random until
+        // something works.
+        std::vector<SpvOp> candidate_opcodes = {SpvOpIAdd, SpvOpISub,
+                                                SpvOpLogicalNot, SpvOpSNegate};
+        do {
+          auto opcode =
+              GetFuzzerContext()->RemoveAtRandomIndex(&candidate_opcodes);
+          switch (opcode) {
+            case SpvOpIAdd:
+            case SpvOpISub: {
+              auto integer_instructions =
+                  GetIntegerInstructions(available_instructions);
+              if (!integer_instructions.empty()) {
+                auto lhs = integer_instructions.at(
+                    GetFuzzerContext()->RandomIndex(integer_instructions));
+                auto lhs_type =
+                    GetIRContext()->get_type_mgr()->GetType(lhs->type_id());
+                auto candidate_rhs_instructions = RestrictToWidth(
+                    integer_instructions,
+                    lhs_type->AsVector() ? lhs_type->AsVector()->element_count()
+                                         : 1);
+                auto rhs = candidate_rhs_instructions.at(
+                    GetFuzzerContext()->RandomIndex(
+                        candidate_rhs_instructions));
+                ApplyTransformation(TransformationEquationInstruction(
+                    GetFuzzerContext()->GetFreshId(), opcode,
+                    {lhs->result_id(), rhs->result_id()},
+                    instruction_descriptor));
+                return;
+              }
+              break;
+            }
+            case SpvOpLogicalNot: {
+              auto boolean_instructions =
+                  GetBooleanInstructions(available_instructions);
+              if (!boolean_instructions.empty()) {
+                ApplyTransformation(TransformationEquationInstruction(
+                    GetFuzzerContext()->GetFreshId(), opcode,
+                    {boolean_instructions
+                         .at(GetFuzzerContext()->RandomIndex(
+                             boolean_instructions))
+                         ->result_id()},
+                    instruction_descriptor));
+                return;
+              }
+              break;
+            }
+            case SpvOpSNegate: {
+              auto integer_instructions =
+                  GetIntegerInstructions(available_instructions);
+              if (!integer_instructions.empty()) {
+                ApplyTransformation(TransformationEquationInstruction(
+                    GetFuzzerContext()->GetFreshId(), opcode,
+                    {integer_instructions
+                         .at(GetFuzzerContext()->RandomIndex(
+                             integer_instructions))
+                         ->result_id()},
+                    instruction_descriptor));
+                return;
+              }
+              break;
+            }
+            default:
+              assert(false && "Unexpected opcode.");
+              break;
+          }
+        } while (!candidate_opcodes.empty());
+        // Reaching here means that we did not manage to apply any
+        // transformation at this point of the module.
+      });
+}
+
+std::vector<opt::Instruction*>
+FuzzerPassAddEquationInstructions::GetIntegerInstructions(
+    const std::vector<opt::Instruction*>& instructions) const {
+  std::vector<opt::Instruction*> result;
+  for (auto& inst : instructions) {
+    auto type = GetIRContext()->get_type_mgr()->GetType(inst->type_id());
+    if (type->AsInteger() ||
+        (type->AsVector() && type->AsVector()->element_type()->AsInteger())) {
+      result.push_back(inst);
+    }
+  }
+  return result;
+}
+
+std::vector<opt::Instruction*>
+FuzzerPassAddEquationInstructions::GetBooleanInstructions(
+    const std::vector<opt::Instruction*>& instructions) const {
+  std::vector<opt::Instruction*> result;
+  for (auto& inst : instructions) {
+    auto type = GetIRContext()->get_type_mgr()->GetType(inst->type_id());
+    if (type->AsBool() ||
+        (type->AsVector() && type->AsVector()->element_type()->AsBool())) {
+      result.push_back(inst);
+    }
+  }
+  return result;
+}
+
+std::vector<opt::Instruction*>
+FuzzerPassAddEquationInstructions::RestrictToWidth(
+    const std::vector<opt::Instruction*>& instructions, uint32_t width) const {
+  std::vector<opt::Instruction*> result;
+  for (auto& inst : instructions) {
+    auto type = GetIRContext()->get_type_mgr()->GetType(inst->type_id());
+    if ((width == 1 && !type->AsVector()) ||
+        (width > 1 && type->AsVector()->element_count() == width)) {
+      result.push_back(inst);
+    }
+  }
+  return result;
 }
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_pass_add_equation_instructions.cpp
+++ b/source/fuzz/fuzzer_pass_add_equation_instructions.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/fuzzer_pass_add_equation_instructions.h"
+
+namespace spvtools {
+namespace fuzz {
+
+FuzzerPassAddEquationInstructions::FuzzerPassAddEquationInstructions(
+    opt::IRContext* ir_context, FactManager* fact_manager,
+    FuzzerContext* fuzzer_context,
+    protobufs::TransformationSequence* transformations)
+    : FuzzerPass(ir_context, fact_manager, fuzzer_context, transformations) {}
+
+FuzzerPassAddEquationInstructions::~FuzzerPassAddEquationInstructions() = default;
+
+void FuzzerPassAddEquationInstructions::Apply() {
+  assert(false && "Implement");
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/fuzzer_pass_add_equation_instructions.h
+++ b/source/fuzz/fuzzer_pass_add_equation_instructions.h
@@ -23,9 +23,10 @@ namespace fuzz {
 // TODO comment
 class FuzzerPassAddEquationInstructions : public FuzzerPass {
  public:
-  FuzzerPassAddEquationInstructions(opt::IRContext* ir_context, FactManager* fact_manager,
-                        FuzzerContext* fuzzer_context,
-                        protobufs::TransformationSequence* transformations);
+  FuzzerPassAddEquationInstructions(
+      opt::IRContext* ir_context, FactManager* fact_manager,
+      FuzzerContext* fuzzer_context,
+      protobufs::TransformationSequence* transformations);
 
   ~FuzzerPassAddEquationInstructions();
 

--- a/source/fuzz/fuzzer_pass_add_equation_instructions.h
+++ b/source/fuzz/fuzzer_pass_add_equation_instructions.h
@@ -22,7 +22,8 @@
 namespace spvtools {
 namespace fuzz {
 
-// TODO comment
+// Fuzzer pass that sprinkles instructions through the module that define
+// equations using various arithmetic and logical operators.
 class FuzzerPassAddEquationInstructions : public FuzzerPass {
  public:
   FuzzerPassAddEquationInstructions(
@@ -45,11 +46,19 @@ class FuzzerPassAddEquationInstructions : public FuzzerPass {
   std::vector<opt::Instruction*> GetBooleanInstructions(
       const std::vector<opt::Instruction*>& instructions) const;
 
-  // Assuming that |instructions| are scalars or vectors of some type, returns
+  // Requires that |instructions| are scalars or vectors of some type.  Returns
   // only those instructions whose width is |width|. If |width| is 1 this means
   // the scalars.
-  std::vector<opt::Instruction*> RestrictToWidth(
-      const std::vector<opt::Instruction*>& instructions, uint32_t width) const;
+  std::vector<opt::Instruction*> RestrictToVectorWidth(
+      const std::vector<opt::Instruction*>& instructions,
+      uint32_t vector_width) const;
+
+  // Requires that |instructions| are integer scalars or vectors.  Returns only
+  // those instructions for which the bit-width of the underlying integer type
+  // is |bit_width|.
+  std::vector<opt::Instruction*> RestrictToElementBitWidth(
+      const std::vector<opt::Instruction*>& instructions,
+      uint32_t bit_width) const;
 };
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_pass_add_equation_instructions.h
+++ b/source/fuzz/fuzzer_pass_add_equation_instructions.h
@@ -15,6 +15,8 @@
 #ifndef SOURCE_FUZZ_FUZZER_PASS_ADD_EQUATION_INSTRUCTIONS_H_
 #define SOURCE_FUZZ_FUZZER_PASS_ADD_EQUATION_INSTRUCTIONS_H_
 
+#include <vector>
+
 #include "source/fuzz/fuzzer_pass.h"
 
 namespace spvtools {
@@ -31,6 +33,23 @@ class FuzzerPassAddEquationInstructions : public FuzzerPass {
   ~FuzzerPassAddEquationInstructions();
 
   void Apply() override;
+
+ private:
+  // Yields those instructions in |instructions| that have integer scalar or
+  // vector result type.
+  std::vector<opt::Instruction*> GetIntegerInstructions(
+      const std::vector<opt::Instruction*>& instructions) const;
+
+  // Yields those instructions in |instructions| that have boolean scalar or
+  // vector result type.
+  std::vector<opt::Instruction*> GetBooleanInstructions(
+      const std::vector<opt::Instruction*>& instructions) const;
+
+  // Assuming that |instructions| are scalars or vectors of some type, returns
+  // only those instructions whose width is |width|. If |width| is 1 this means
+  // the scalars.
+  std::vector<opt::Instruction*> RestrictToWidth(
+      const std::vector<opt::Instruction*>& instructions, uint32_t width) const;
 };
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_pass_add_equation_instructions.h
+++ b/source/fuzz/fuzzer_pass_add_equation_instructions.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_FUZZER_PASS_ADD_EQUATION_INSTRUCTIONS_H_
+#define SOURCE_FUZZ_FUZZER_PASS_ADD_EQUATION_INSTRUCTIONS_H_
+
+#include "source/fuzz/fuzzer_pass.h"
+
+namespace spvtools {
+namespace fuzz {
+
+// TODO comment
+class FuzzerPassAddEquationInstructions : public FuzzerPass {
+ public:
+  FuzzerPassAddEquationInstructions(opt::IRContext* ir_context, FactManager* fact_manager,
+                        FuzzerContext* fuzzer_context,
+                        protobufs::TransformationSequence* transformations);
+
+  ~FuzzerPassAddEquationInstructions();
+
+  void Apply() override;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_FUZZER_PASS_ADD_EQUATION_INSTRUCTIONS_H_

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -355,6 +355,7 @@ message Transformation {
     TransformationStore store = 37;
     TransformationFunctionCall function_call = 38;
     TransformationAccessChain access_chain = 39;
+    TransformationEquationInstruction equation_instruction = 40;
     // Add additional option using the next available number.
   }
 }
@@ -762,6 +763,28 @@ message TransformationCopyObject {
 
   // A fresh id for the copied object
   uint32 fresh_id = 3;
+
+}
+
+message TransformationEquationInstruction {
+
+  // A transformation that adds an instruction to the module that defines an
+  // equation between its result id and input operand ids, such that the
+  // equation is guaranteed to hold at any program point where all ids involved
+  // are available (i.e. at any program point dominated by the instruction).
+
+  // The result id of the new instruction
+  uint32 fresh_id = 1;
+
+  // The instruction's opcode
+  uint32 opcode = 2;
+
+  // The input operands to the instruction
+  repeated uint32 in_operand_id = 3;
+
+  // A descriptor for an instruction in a block before which the new
+  // instruction should be inserted
+  InstructionDescriptor instruction_to_insert_before = 4;
 
 }
 

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -168,8 +168,8 @@ message Fact {
     FactDataSynonym data_synonym_fact = 2;
     FactBlockIsDead block_is_dead_fact = 3;
     FactFunctionIsLivesafe function_is_livesafe_fact = 4;
-    FactPointeeValueIsIrrelevant pointee_value_is_irrelevant = 5;
-    FactIdEquation id_equation = 6;
+    FactPointeeValueIsIrrelevant pointee_value_is_irrelevant_fact = 5;
+    FactIdEquation id_equation_fact = 6;
   }
 }
 

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -226,12 +226,25 @@ message FactFunctionIsLivesafe {
 
 message FactIdEquation {
 
-  // TODO write it
+  // Records the fact that the equation:
+  //
+  // lhs_id = opcode rhs_id[0] rhs_id[1] ... rhs_id[N-1]
+  //
+  // holds; e.g. that the equation:
+  //
+  // %12 = OpIAdd %13 %14
+  //
+  // holds in the case where lhs_id is 12, rhs_id is [13, 14], and the opcode is
+  // OpIAdd.
 
+  // The left-hand-side of the equation.
   uint32 lhs_id = 1;
 
+  // A SPIR-V opcode, from a restricted set of instructions for which equation
+  // facts make sense.
   uint32 opcode = 2;
 
+  // The operands to the right-hand-side of the equation.
   repeated uint32 rhs_id = 3;
 
 }

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -169,10 +169,20 @@ message Fact {
     FactBlockIsDead block_is_dead_fact = 3;
     FactFunctionIsLivesafe function_is_livesafe_fact = 4;
     FactPointeeValueIsIrrelevant pointee_value_is_irrelevant = 5;
+    FactIdEquation id_equation = 6;
   }
 }
 
 // Keep fact message types in alphabetical order:
+
+message FactBlockIsDead {
+
+  // Records the fact that a block is guaranteed to be dynamically unreachable.
+  // This is useful because it informs the fuzzer that rather arbitrary changes
+  // can be made to this block.
+
+  uint32 block_id = 1;
+}
 
 message FactConstantUniform {
 
@@ -203,15 +213,6 @@ message FactDataSynonym {
 
 }
 
-message FactBlockIsDead {
-
-  // Records the fact that a block is guaranteed to be dynamically unreachable.
-  // This is useful because it informs the fuzzer that rather arbitrary changes
-  // can be made to this block.
-
-  uint32 block_id = 1;
-}
-
 message FactFunctionIsLivesafe {
 
   // Records the fact that a function is guaranteed to be "livesafe", meaning
@@ -221,6 +222,18 @@ message FactFunctionIsLivesafe {
   // functions.
 
   uint32 function_id = 1;
+}
+
+message FactIdEquation {
+
+  // TODO write it
+
+  uint32 lhs_id = 1;
+
+  uint32 opcode = 2;
+
+  repeated uint32 rhs_id = 3;
+
 }
 
 message FactPointeeValueIsIrrelevant {

--- a/source/fuzz/transformation.cpp
+++ b/source/fuzz/transformation.cpp
@@ -41,6 +41,7 @@
 #include "source/fuzz/transformation_composite_construct.h"
 #include "source/fuzz/transformation_composite_extract.h"
 #include "source/fuzz/transformation_copy_object.h"
+#include "source/fuzz/transformation_equation_instruction.h"
 #include "source/fuzz/transformation_function_call.h"
 #include "source/fuzz/transformation_load.h"
 #include "source/fuzz/transformation_merge_blocks.h"
@@ -128,6 +129,9 @@ std::unique_ptr<Transformation> Transformation::FromMessage(
           message.composite_extract());
     case protobufs::Transformation::TransformationCase::kCopyObject:
       return MakeUnique<TransformationCopyObject>(message.copy_object());
+    case protobufs::Transformation::TransformationCase::kEquationInstruction:
+      return MakeUnique<TransformationEquationInstruction>(
+          message.equation_instruction());
     case protobufs::Transformation::TransformationCase::kFunctionCall:
       return MakeUnique<TransformationFunctionCall>(message.function_call());
     case protobufs::Transformation::TransformationCase::kLoad:

--- a/source/fuzz/transformation_equation_instruction.cpp
+++ b/source/fuzz/transformation_equation_instruction.cpp
@@ -177,7 +177,7 @@ uint32_t TransformationEquationInstruction::MaybeGetResultType(
     }
 
     default:
-      // We do not know what to do with an equation that uses this opcode.
+      assert(false && "Inappropriate opcode for equation instruction.");
       return 0;
   }
 }

--- a/source/fuzz/transformation_equation_instruction.cpp
+++ b/source/fuzz/transformation_equation_instruction.cpp
@@ -24,17 +24,16 @@ TransformationEquationInstruction::TransformationEquationInstruction(
     const spvtools::fuzz::protobufs::TransformationEquationInstruction& message)
     : message_(message) {}
 
-TransformationEquationInstruction::TransformationEquationInstruction(uint32_t
-fresh_id, SpvOp opcode, const
-std::vector<uint32_t>& in_operand_id, const
-protobufs::InstructionDescriptor& instruction_to_insert_before) {
+TransformationEquationInstruction::TransformationEquationInstruction(
+    uint32_t fresh_id, SpvOp opcode, const std::vector<uint32_t>& in_operand_id,
+    const protobufs::InstructionDescriptor& instruction_to_insert_before) {
   message_.set_fresh_id(fresh_id);
   message_.set_opcode(opcode);
   for (auto id : in_operand_id) {
     message_.add_in_operand_id(id);
   }
   *message_.mutable_instruction_to_insert_before() =
-          instruction_to_insert_before;
+      instruction_to_insert_before;
 }
 
 bool TransformationEquationInstruction::IsApplicable(
@@ -45,8 +44,8 @@ bool TransformationEquationInstruction::IsApplicable(
     return false;
   }
   // The instruction to insert before must exist.
-  auto insert_before = FindInstruction(message_.instruction_to_insert_before(),
-          context);
+  auto insert_before =
+      FindInstruction(message_.instruction_to_insert_before(), context);
   if (!insert_before) {
     return false;
   }
@@ -61,13 +60,12 @@ bool TransformationEquationInstruction::IsApplicable(
       return false;
     }
     if (!fuzzerutil::IdIsAvailableBeforeInstruction(context, insert_before,
-            id)) {
+                                                    id)) {
       return false;
     }
   }
 
   return MaybeGetResultType(context) != 0;
-
 }
 
 void TransformationEquationInstruction::Apply(
@@ -77,22 +75,20 @@ void TransformationEquationInstruction::Apply(
   opt::Instruction::OperandList in_operands;
   std::vector<uint32_t> rhs_id;
   for (auto id : message_.in_operand_id()) {
-    in_operands.push_back({ SPV_OPERAND_TYPE_ID, { id }});
+    in_operands.push_back({SPV_OPERAND_TYPE_ID, {id}});
     rhs_id.push_back(id);
   }
 
-  FindInstruction(message_.instruction_to_insert_before(), context)->InsertBefore(
-          MakeUnique<opt::Instruction>(context, static_cast<SpvOp>(message_
-          .opcode()), MaybeGetResultType(context), message_.fresh_id(),
-                  in_operands));
+  FindInstruction(message_.instruction_to_insert_before(), context)
+      ->InsertBefore(MakeUnique<opt::Instruction>(
+          context, static_cast<SpvOp>(message_.opcode()),
+          MaybeGetResultType(context), message_.fresh_id(), in_operands));
 
   context->InvalidateAnalysesExceptFor(opt::IRContext::kAnalysisNone);
 
   fact_manager->AddFactIdEquation(message_.fresh_id(),
-          static_cast<SpvOp>(message_.opcode()),
-          rhs_id, context);
-
-
+                                  static_cast<SpvOp>(message_.opcode()), rhs_id,
+                                  context);
 }
 
 protobufs::Transformation TransformationEquationInstruction::ToMessage() const {
@@ -101,34 +97,85 @@ protobufs::Transformation TransformationEquationInstruction::ToMessage() const {
   return result;
 }
 
-uint32_t TransformationEquationInstruction::MaybeGetResultType
-(opt::IRContext* context) const {
+uint32_t TransformationEquationInstruction::MaybeGetResultType(
+    opt::IRContext* context) const {
   switch (static_cast<SpvOp>(message_.opcode())) {
     case SpvOpIAdd:
-    case SpvOpISub:
-      assert(false);
-      return 0;
+    case SpvOpISub: {
+      if (message_.in_operand_id().size() != 2) {
+        return 0;
+      }
+      uint32_t first_operand_width = 0;
+      uint32_t first_operand_type_id = 0;
+      for (uint32_t index = 0; index < 2; index++) {
+        auto operand_inst =
+            context->get_def_use_mgr()->GetDef(message_.in_operand_id(index));
+        if (!operand_inst || !operand_inst->type_id()) {
+          return 0;
+        }
+        auto operand_type =
+            context->get_type_mgr()->GetType(operand_inst->type_id());
+        if (!(operand_type->AsInteger() ||
+              (operand_type->AsVector() &&
+               operand_type->AsVector()->element_type()->AsInteger()))) {
+          return 0;
+        }
+        uint32_t operand_width =
+            operand_type->AsInteger()
+                ? 1
+                : operand_type->AsVector()->element_count();
+        if (index == 0) {
+          first_operand_width = operand_width;
+          first_operand_type_id = operand_inst->type_id();
+        } else {
+          assert(first_operand_width != 0 &&
+                 "The first operand should have been processed.");
+          if (operand_width != first_operand_width) {
+            return 0;
+          }
+        }
+      }
+      assert(first_operand_type_id != 0 &&
+             "A type must have been found for the first operand.");
+      return first_operand_type_id;
+    }
     case SpvOpLogicalNot: {
       if (message_.in_operand_id().size() != 1) {
         return 0;
       }
-      auto operand_inst = context->get_def_use_mgr()->GetDef(message_
-                                                                     .in_operand_id(
-                                                                             0));
+      auto operand_inst =
+          context->get_def_use_mgr()->GetDef(message_.in_operand_id(0));
       if (!operand_inst || !operand_inst->type_id()) {
         return 0;
       }
-      auto operand_type = context->get_type_mgr()->GetType(
-              operand_inst->type_id());
-      if (!(operand_type->AsBool() || (operand_type->AsVector() &&
-                                       operand_type->AsVector()->element_type()->AsBool()))) {
+      auto operand_type =
+          context->get_type_mgr()->GetType(operand_inst->type_id());
+      if (!(operand_type->AsBool() ||
+            (operand_type->AsVector() &&
+             operand_type->AsVector()->element_type()->AsBool()))) {
         return 0;
       }
       return operand_inst->type_id();
     }
-    case SpvOpSNegate:
-      assert(false);
-      return 0;
+    case SpvOpSNegate: {
+      if (message_.in_operand_id().size() != 1) {
+        return 0;
+      }
+      auto operand_inst =
+          context->get_def_use_mgr()->GetDef(message_.in_operand_id(0));
+      if (!operand_inst || !operand_inst->type_id()) {
+        return 0;
+      }
+      auto operand_type =
+          context->get_type_mgr()->GetType(operand_inst->type_id());
+      if (!(operand_type->AsInteger() ||
+            (operand_type->AsVector() &&
+             operand_type->AsVector()->element_type()->AsInteger()))) {
+        return 0;
+      }
+      return operand_inst->type_id();
+    }
+
     default:
       // We do not know what to do with an equation that uses this opcode.
       return 0;

--- a/source/fuzz/transformation_equation_instruction.cpp
+++ b/source/fuzz/transformation_equation_instruction.cpp
@@ -1,0 +1,139 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_equation_instruction.h"
+
+#include "source/fuzz/fuzzer_util.h"
+#include "source/fuzz/instruction_descriptor.h"
+
+namespace spvtools {
+namespace fuzz {
+
+TransformationEquationInstruction::TransformationEquationInstruction(
+    const spvtools::fuzz::protobufs::TransformationEquationInstruction& message)
+    : message_(message) {}
+
+TransformationEquationInstruction::TransformationEquationInstruction(uint32_t
+fresh_id, SpvOp opcode, const
+std::vector<uint32_t>& in_operand_id, const
+protobufs::InstructionDescriptor& instruction_to_insert_before) {
+  message_.set_fresh_id(fresh_id);
+  message_.set_opcode(opcode);
+  for (auto id : in_operand_id) {
+    message_.add_in_operand_id(id);
+  }
+  *message_.mutable_instruction_to_insert_before() =
+          instruction_to_insert_before;
+}
+
+bool TransformationEquationInstruction::IsApplicable(
+    opt::IRContext* context,
+    const spvtools::fuzz::FactManager& /*unused*/) const {
+  // The result id must be fresh.
+  if (!fuzzerutil::IsFreshId(context, message_.fresh_id())) {
+    return false;
+  }
+  // The instruction to insert before must exist.
+  auto insert_before = FindInstruction(message_.instruction_to_insert_before(),
+          context);
+  if (!insert_before) {
+    return false;
+  }
+  // The input ids must all exist, not be OpUndef, and be available before this
+  // instruction.
+  for (auto id : message_.in_operand_id()) {
+    auto inst = context->get_def_use_mgr()->GetDef(id);
+    if (!inst) {
+      return false;
+    }
+    if (inst->opcode() == SpvOpUndef) {
+      return false;
+    }
+    if (!fuzzerutil::IdIsAvailableBeforeInstruction(context, insert_before,
+            id)) {
+      return false;
+    }
+  }
+
+  return MaybeGetResultType(context) != 0;
+
+}
+
+void TransformationEquationInstruction::Apply(
+    opt::IRContext* context, spvtools::fuzz::FactManager* fact_manager) const {
+  fuzzerutil::UpdateModuleIdBound(context, message_.fresh_id());
+
+  opt::Instruction::OperandList in_operands;
+  std::vector<uint32_t> rhs_id;
+  for (auto id : message_.in_operand_id()) {
+    in_operands.push_back({ SPV_OPERAND_TYPE_ID, { id }});
+    rhs_id.push_back(id);
+  }
+
+  FindInstruction(message_.instruction_to_insert_before(), context)->InsertBefore(
+          MakeUnique<opt::Instruction>(context, static_cast<SpvOp>(message_
+          .opcode()), MaybeGetResultType(context), message_.fresh_id(),
+                  in_operands));
+
+  context->InvalidateAnalysesExceptFor(opt::IRContext::kAnalysisNone);
+
+  fact_manager->AddFactIdEquation(message_.fresh_id(),
+          static_cast<SpvOp>(message_.opcode()),
+          rhs_id, context);
+
+
+}
+
+protobufs::Transformation TransformationEquationInstruction::ToMessage() const {
+  protobufs::Transformation result;
+  *result.mutable_equation_instruction() = message_;
+  return result;
+}
+
+uint32_t TransformationEquationInstruction::MaybeGetResultType
+(opt::IRContext* context) const {
+  switch (static_cast<SpvOp>(message_.opcode())) {
+    case SpvOpIAdd:
+    case SpvOpISub:
+      assert(false);
+      return 0;
+    case SpvOpLogicalNot: {
+      if (message_.in_operand_id().size() != 1) {
+        return 0;
+      }
+      auto operand_inst = context->get_def_use_mgr()->GetDef(message_
+                                                                     .in_operand_id(
+                                                                             0));
+      if (!operand_inst || !operand_inst->type_id()) {
+        return 0;
+      }
+      auto operand_type = context->get_type_mgr()->GetType(
+              operand_inst->type_id());
+      if (!(operand_type->AsBool() || (operand_type->AsVector() &&
+                                       operand_type->AsVector()->element_type()->AsBool()))) {
+        return 0;
+      }
+      return operand_inst->type_id();
+    }
+    case SpvOpSNegate:
+      assert(false);
+      return 0;
+    default:
+      // We do not know what to do with an equation that uses this opcode.
+      return 0;
+  }
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/transformation_equation_instruction.h
+++ b/source/fuzz/transformation_equation_instruction.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_TRANSFORMATION_EQUATION_INSTRUCTION_H_
+#define SOURCE_FUZZ_TRANSFORMATION_EQUATION_INSTRUCTION_H_
+
+#include <vector>
+
+#include "source/fuzz/fact_manager.h"
+#include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
+#include "source/fuzz/transformation.h"
+#include "source/opt/ir_context.h"
+
+namespace spvtools {
+namespace fuzz {
+
+class TransformationEquationInstruction : public Transformation {
+ public:
+  explicit TransformationEquationInstruction(
+      const protobufs::TransformationEquationInstruction& message);
+
+  TransformationEquationInstruction(uint32_t fresh_id, SpvOp opcode, const
+  std::vector<uint32_t>& in_operand_id, const
+  protobufs::InstructionDescriptor& instruction_to_insert_before);
+
+  // TODO comment
+  bool IsApplicable(opt::IRContext* context,
+                    const FactManager& fact_manager) const override;
+
+  // TODO comment
+  void Apply(opt::IRContext* context, FactManager* fact_manager) const override;
+
+  protobufs::Transformation ToMessage() const override;
+
+ private:
+
+  // TODO comment
+  uint32_t MaybeGetResultType(opt::IRContext* context) const;
+
+  protobufs::TransformationEquationInstruction message_;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_TRANSFORMATION_EQUATION_INSTRUCTION_H_

--- a/source/fuzz/transformation_equation_instruction.h
+++ b/source/fuzz/transformation_equation_instruction.h
@@ -30,9 +30,10 @@ class TransformationEquationInstruction : public Transformation {
   explicit TransformationEquationInstruction(
       const protobufs::TransformationEquationInstruction& message);
 
-  TransformationEquationInstruction(uint32_t fresh_id, SpvOp opcode, const
-  std::vector<uint32_t>& in_operand_id, const
-  protobufs::InstructionDescriptor& instruction_to_insert_before);
+  TransformationEquationInstruction(
+      uint32_t fresh_id, SpvOp opcode,
+      const std::vector<uint32_t>& in_operand_id,
+      const protobufs::InstructionDescriptor& instruction_to_insert_before);
 
   // TODO comment
   bool IsApplicable(opt::IRContext* context,
@@ -44,7 +45,6 @@ class TransformationEquationInstruction : public Transformation {
   protobufs::Transformation ToMessage() const override;
 
  private:
-
   // TODO comment
   uint32_t MaybeGetResultType(opt::IRContext* context) const;
 

--- a/source/fuzz/transformation_equation_instruction.h
+++ b/source/fuzz/transformation_equation_instruction.h
@@ -35,17 +35,36 @@ class TransformationEquationInstruction : public Transformation {
       const std::vector<uint32_t>& in_operand_id,
       const protobufs::InstructionDescriptor& instruction_to_insert_before);
 
-  // TODO comment
+  // - |message_.fresh_id| must be fresh.
+  // - |message_.instruction_to_insert_before| must identify an instruction
+  //   before which an equation instruction can legitimately be inserted.
+  // - Each id in |message_.in_operand_id| must exist, not be an OpUndef, and
+  //   be available before |message_.instruction_to_insert_before|.
+  // - |message_.opcode| must be an opcode for which we know how to handle
+  //   equations, the types of the ids in |message_.in_operand_id| must be
+  //   suitable for use with this opcode, and the module must contain an
+  //   appropriate result type id.
   bool IsApplicable(opt::IRContext* context,
                     const FactManager& fact_manager) const override;
 
-  // TODO comment
+  // Adds an instruction to the module, right before
+  // |message_.instruction_to_insert_before|, of the form:
+  //
+  // |message_.fresh_id| = |message_.opcode| %type |message_.in_operand_ids|
+  //
+  // where %type is a type id that already exists in the module and that is
+  // compatible with the opcode and input operands.
+  //
+  // The fact manager is also updated to inform it of this equation fact.
   void Apply(opt::IRContext* context, FactManager* fact_manager) const override;
 
   protobufs::Transformation ToMessage() const override;
 
  private:
-  // TODO comment
+  // A helper that, in one fell swoop, checks that |message_.opcode| and the ids
+  // in |message_.in_operand_id| are compatible, and that the module contains
+  // an appropriate result type id.  If all is well, the result type id is
+  // returned.  Otherwise, 0 is returned.
   uint32_t MaybeGetResultType(opt::IRContext* context) const;
 
   protobufs::TransformationEquationInstruction message_;

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -48,6 +48,7 @@ if (${SPIRV_BUILD_FUZZER})
           transformation_composite_construct_test.cpp
           transformation_composite_extract_test.cpp
           transformation_copy_object_test.cpp
+          transformation_equation_instruction_test.cpp
           transformation_function_call_test.cpp
           transformation_load_test.cpp
           transformation_merge_blocks_test.cpp

--- a/test/fuzz/fact_manager_test.cpp
+++ b/test/fuzz/fact_manager_test.cpp
@@ -1173,6 +1173,224 @@ TEST(FactManagerTest, RecursiveAdditionOfFacts) {
                                         context.get()));
 }
 
+TEST(FactManagerTest, LogicalNotEquationFacts) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %12 "main"
+               OpExecutionMode %12 OriginUpperLeft
+               OpSource ESSL 310
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeBool
+          %7 = OpConstantTrue %6
+         %12 = OpFunction %2 None %3
+         %13 = OpLabel
+         %14 = OpLogicalNot %6 %7
+         %15 = OpCopyObject %6 %7
+         %16 = OpCopyObject %6 %14
+         %17 = OpLogicalNot %6 %16
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+
+  fact_manager.AddFactDataSynonym(MakeDataDescriptor(15, {}),
+                                  MakeDataDescriptor(7, {}), context.get());
+  fact_manager.AddFactDataSynonym(MakeDataDescriptor(16, {}),
+                                  MakeDataDescriptor(14, {}), context.get());
+  fact_manager.AddFactIdEquation(14, SpvOpLogicalNot, {7}, context.get());
+  fact_manager.AddFactIdEquation(17, SpvOpLogicalNot, {16}, context.get());
+
+  ASSERT_TRUE(fact_manager.IsSynonymous(
+          MakeDataDescriptor(15, {}), MakeDataDescriptor(7, {}), context
+          .get()));
+  ASSERT_TRUE(fact_manager.IsSynonymous(
+          MakeDataDescriptor(17, {}), MakeDataDescriptor(7, {}), context
+                  .get()));
+  ASSERT_TRUE(fact_manager.IsSynonymous(
+          MakeDataDescriptor(15, {}), MakeDataDescriptor(17, {}), context
+                  .get()));
+  ASSERT_TRUE(fact_manager.IsSynonymous(
+          MakeDataDescriptor(16, {}), MakeDataDescriptor(14, {}), context
+                  .get()));
+}
+
+TEST(FactManagerTest, SignedNegateEquationFacts) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %12 "main"
+               OpExecutionMode %12 OriginUpperLeft
+               OpSource ESSL 310
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpConstant %6 24
+         %12 = OpFunction %2 None %3
+         %13 = OpLabel
+         %14 = OpSNegate %6 %7
+         %15 = OpSNegate %6 %14
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+
+  fact_manager.AddFactIdEquation(14, SpvOpSNegate, {7}, context.get());
+  fact_manager.AddFactIdEquation(15, SpvOpSNegate, {14}, context.get());
+
+  ASSERT_TRUE(fact_manager.IsSynonymous(
+          MakeDataDescriptor(7, {}), MakeDataDescriptor(15, {}), context
+                  .get()));
+}
+
+TEST(FactManagerTest, AddSubNegateFacts1) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %12 "main"
+               OpExecutionMode %12 OriginUpperLeft
+               OpSource ESSL 310
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+         %15 = OpConstant %6 24
+         %16 = OpConstant %6 37
+         %12 = OpFunction %2 None %3
+         %13 = OpLabel
+         %14 = OpIAdd %6 %15 %16
+         %17 = OpCopyObject %6 %15
+         %18 = OpCopyObject %6 %16
+         %19 = OpISub %6 %14 %18 ; ==> synonymous(%19, %15)
+         %20 = OpISub %6 %14 %17 ; ==> synonymous(%20, %16)
+         %21 = OpCopyObject %6 %14
+         %22 = OpISub %6 %16 %21
+         %23 = OpCopyObject %6 %22
+         %24 = OpSNegate %6 %23 ; ==> synonymous(%24, %15)
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+
+  fact_manager.AddFactIdEquation(14, SpvOpIAdd, {15, 16}, context.get());
+  fact_manager.AddFactDataSynonym(MakeDataDescriptor(17, {}), MakeDataDescriptor
+  (15, {}), context.get());
+  fact_manager.AddFactDataSynonym(MakeDataDescriptor(18, {}),
+          MakeDataDescriptor
+          (16, {}), context.get());
+  fact_manager.AddFactIdEquation(19, SpvOpISub, {14, 18}, context.get());
+  fact_manager.AddFactIdEquation(20, SpvOpISub, {14, 17}, context.get());
+  fact_manager.AddFactDataSynonym(MakeDataDescriptor(21, {}),
+                                  MakeDataDescriptor
+                                          (14, {}), context.get());
+  fact_manager.AddFactIdEquation(22, SpvOpISub, {16, 21}, context.get());
+  fact_manager.AddFactDataSynonym(MakeDataDescriptor(23, {}),
+                                  MakeDataDescriptor
+                                          (22, {}), context.get());
+  fact_manager.AddFactIdEquation(24, SpvOpSNegate, {23}, context.get());
+
+  ASSERT_TRUE(fact_manager.IsSynonymous(
+          MakeDataDescriptor(19, {}), MakeDataDescriptor(15, {}), context
+                  .get()));
+  ASSERT_TRUE(fact_manager.IsSynonymous(
+          MakeDataDescriptor(20, {}), MakeDataDescriptor(16, {}), context
+                  .get()));
+  ASSERT_TRUE(fact_manager.IsSynonymous(
+          MakeDataDescriptor(24, {}), MakeDataDescriptor(15, {}), context
+                  .get()));
+}
+
+TEST(FactManagerTest, AddSubNegateFacts2) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %12 "main"
+               OpExecutionMode %12 OriginUpperLeft
+               OpSource ESSL 310
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+         %15 = OpConstant %6 24
+         %16 = OpConstant %6 37
+         %12 = OpFunction %2 None %3
+         %13 = OpLabel
+         %14 = OpISub %6 %15 %16
+         %17 = OpIAdd %6 %14 %16 ; ==> synonymous(%17, %15)
+         %18 = OpIAdd %6 %16 %14 ; ==> synonymous(%17, %18, %15)
+         %19 = OpISub %6 %14 %15
+         %20 = OpSNegate %6 %19 ; ==> synonymous(%20, %16)
+         %21 = OpISub %6 %14 %19 ; ==> synonymous(%21, %15)
+         %22 = OpISub %6 %14 %18
+         %23 = OpSNegate %6 %22 ; ==> synonymous(%23, %16)
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+
+  fact_manager.AddFactIdEquation(14, SpvOpISub, {15, 16}, context.get());
+  fact_manager.AddFactIdEquation(17, SpvOpIAdd, {14, 16}, context.get());
+
+  ASSERT_TRUE(fact_manager.IsSynonymous(
+          MakeDataDescriptor(17, {}), MakeDataDescriptor(15, {}), context
+                  .get()));
+
+  fact_manager.AddFactIdEquation(18, SpvOpIAdd, {16, 14}, context.get());
+
+  ASSERT_TRUE(fact_manager.IsSynonymous(
+          MakeDataDescriptor(18, {}), MakeDataDescriptor(15, {}), context
+                  .get()));
+  ASSERT_TRUE(fact_manager.IsSynonymous(
+          MakeDataDescriptor(17, {}), MakeDataDescriptor(18, {}), context
+                  .get()));
+
+  fact_manager.AddFactIdEquation(19, SpvOpISub, {14, 15}, context.get());
+  fact_manager.AddFactIdEquation(20, SpvOpSNegate, {19}, context.get());
+
+  ASSERT_TRUE(fact_manager.IsSynonymous(
+          MakeDataDescriptor(20, {}), MakeDataDescriptor(16, {}), context
+                  .get()));
+
+  fact_manager.AddFactIdEquation(21, SpvOpISub, {14, 19}, context.get());
+  ASSERT_TRUE(fact_manager.IsSynonymous(
+          MakeDataDescriptor(21, {}), MakeDataDescriptor(15, {}), context
+                  .get()));
+
+  fact_manager.AddFactIdEquation(22, SpvOpISub, {14, 18}, context.get());
+  fact_manager.AddFactIdEquation(23, SpvOpSNegate, {22}, context.get());
+  ASSERT_TRUE(fact_manager.IsSynonymous(
+          MakeDataDescriptor(23, {}), MakeDataDescriptor(16, {}), context
+                  .get()));
+
+}
+
 }  // namespace
 }  // namespace fuzz
 }  // namespace spvtools

--- a/test/fuzz/fact_manager_test.cpp
+++ b/test/fuzz/fact_manager_test.cpp
@@ -1210,17 +1210,13 @@ TEST(FactManagerTest, LogicalNotEquationFacts) {
   fact_manager.AddFactIdEquation(17, SpvOpLogicalNot, {16}, context.get());
 
   ASSERT_TRUE(fact_manager.IsSynonymous(
-          MakeDataDescriptor(15, {}), MakeDataDescriptor(7, {}), context
-          .get()));
+      MakeDataDescriptor(15, {}), MakeDataDescriptor(7, {}), context.get()));
   ASSERT_TRUE(fact_manager.IsSynonymous(
-          MakeDataDescriptor(17, {}), MakeDataDescriptor(7, {}), context
-                  .get()));
+      MakeDataDescriptor(17, {}), MakeDataDescriptor(7, {}), context.get()));
   ASSERT_TRUE(fact_manager.IsSynonymous(
-          MakeDataDescriptor(15, {}), MakeDataDescriptor(17, {}), context
-                  .get()));
+      MakeDataDescriptor(15, {}), MakeDataDescriptor(17, {}), context.get()));
   ASSERT_TRUE(fact_manager.IsSynonymous(
-          MakeDataDescriptor(16, {}), MakeDataDescriptor(14, {}), context
-                  .get()));
+      MakeDataDescriptor(16, {}), MakeDataDescriptor(14, {}), context.get()));
 }
 
 TEST(FactManagerTest, SignedNegateEquationFacts) {
@@ -1254,8 +1250,7 @@ TEST(FactManagerTest, SignedNegateEquationFacts) {
   fact_manager.AddFactIdEquation(15, SpvOpSNegate, {14}, context.get());
 
   ASSERT_TRUE(fact_manager.IsSynonymous(
-          MakeDataDescriptor(7, {}), MakeDataDescriptor(15, {}), context
-                  .get()));
+      MakeDataDescriptor(7, {}), MakeDataDescriptor(15, {}), context.get()));
 }
 
 TEST(FactManagerTest, AddSubNegateFacts1) {
@@ -1294,31 +1289,25 @@ TEST(FactManagerTest, AddSubNegateFacts1) {
   FactManager fact_manager;
 
   fact_manager.AddFactIdEquation(14, SpvOpIAdd, {15, 16}, context.get());
-  fact_manager.AddFactDataSynonym(MakeDataDescriptor(17, {}), MakeDataDescriptor
-  (15, {}), context.get());
+  fact_manager.AddFactDataSynonym(MakeDataDescriptor(17, {}),
+                                  MakeDataDescriptor(15, {}), context.get());
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(18, {}),
-          MakeDataDescriptor
-          (16, {}), context.get());
+                                  MakeDataDescriptor(16, {}), context.get());
   fact_manager.AddFactIdEquation(19, SpvOpISub, {14, 18}, context.get());
   fact_manager.AddFactIdEquation(20, SpvOpISub, {14, 17}, context.get());
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(21, {}),
-                                  MakeDataDescriptor
-                                          (14, {}), context.get());
+                                  MakeDataDescriptor(14, {}), context.get());
   fact_manager.AddFactIdEquation(22, SpvOpISub, {16, 21}, context.get());
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(23, {}),
-                                  MakeDataDescriptor
-                                          (22, {}), context.get());
+                                  MakeDataDescriptor(22, {}), context.get());
   fact_manager.AddFactIdEquation(24, SpvOpSNegate, {23}, context.get());
 
   ASSERT_TRUE(fact_manager.IsSynonymous(
-          MakeDataDescriptor(19, {}), MakeDataDescriptor(15, {}), context
-                  .get()));
+      MakeDataDescriptor(19, {}), MakeDataDescriptor(15, {}), context.get()));
   ASSERT_TRUE(fact_manager.IsSynonymous(
-          MakeDataDescriptor(20, {}), MakeDataDescriptor(16, {}), context
-                  .get()));
+      MakeDataDescriptor(20, {}), MakeDataDescriptor(16, {}), context.get()));
   ASSERT_TRUE(fact_manager.IsSynonymous(
-          MakeDataDescriptor(24, {}), MakeDataDescriptor(15, {}), context
-                  .get()));
+      MakeDataDescriptor(24, {}), MakeDataDescriptor(15, {}), context.get()));
 }
 
 TEST(FactManagerTest, AddSubNegateFacts2) {
@@ -1359,35 +1348,29 @@ TEST(FactManagerTest, AddSubNegateFacts2) {
   fact_manager.AddFactIdEquation(17, SpvOpIAdd, {14, 16}, context.get());
 
   ASSERT_TRUE(fact_manager.IsSynonymous(
-          MakeDataDescriptor(17, {}), MakeDataDescriptor(15, {}), context
-                  .get()));
+      MakeDataDescriptor(17, {}), MakeDataDescriptor(15, {}), context.get()));
 
   fact_manager.AddFactIdEquation(18, SpvOpIAdd, {16, 14}, context.get());
 
   ASSERT_TRUE(fact_manager.IsSynonymous(
-          MakeDataDescriptor(18, {}), MakeDataDescriptor(15, {}), context
-                  .get()));
+      MakeDataDescriptor(18, {}), MakeDataDescriptor(15, {}), context.get()));
   ASSERT_TRUE(fact_manager.IsSynonymous(
-          MakeDataDescriptor(17, {}), MakeDataDescriptor(18, {}), context
-                  .get()));
+      MakeDataDescriptor(17, {}), MakeDataDescriptor(18, {}), context.get()));
 
   fact_manager.AddFactIdEquation(19, SpvOpISub, {14, 15}, context.get());
   fact_manager.AddFactIdEquation(20, SpvOpSNegate, {19}, context.get());
 
   ASSERT_TRUE(fact_manager.IsSynonymous(
-          MakeDataDescriptor(20, {}), MakeDataDescriptor(16, {}), context
-                  .get()));
+      MakeDataDescriptor(20, {}), MakeDataDescriptor(16, {}), context.get()));
 
   fact_manager.AddFactIdEquation(21, SpvOpISub, {14, 19}, context.get());
   ASSERT_TRUE(fact_manager.IsSynonymous(
-          MakeDataDescriptor(21, {}), MakeDataDescriptor(15, {}), context
-                  .get()));
+      MakeDataDescriptor(21, {}), MakeDataDescriptor(15, {}), context.get()));
 
   fact_manager.AddFactIdEquation(22, SpvOpISub, {14, 18}, context.get());
   fact_manager.AddFactIdEquation(23, SpvOpSNegate, {22}, context.get());
   ASSERT_TRUE(fact_manager.IsSynonymous(
-          MakeDataDescriptor(23, {}), MakeDataDescriptor(16, {}), context
-                  .get()));
+      MakeDataDescriptor(23, {}), MakeDataDescriptor(16, {}), context.get()));
 }
 
 }  // namespace

--- a/test/fuzz/fact_manager_test.cpp
+++ b/test/fuzz/fact_manager_test.cpp
@@ -1388,7 +1388,6 @@ TEST(FactManagerTest, AddSubNegateFacts2) {
   ASSERT_TRUE(fact_manager.IsSynonymous(
           MakeDataDescriptor(23, {}), MakeDataDescriptor(16, {}), context
                   .get()));
-
 }
 
 }  // namespace

--- a/test/fuzz/transformation_equation_instruction_test.cpp
+++ b/test/fuzz/transformation_equation_instruction_test.cpp
@@ -109,6 +109,7 @@ TEST(TransformationEquationInstructionTest, SignedNegate) {
           %3 = OpTypeFunction %2
           %6 = OpTypeInt 32 1
           %7 = OpConstant %6 24
+         %20 = OpUndef %6
          %12 = OpFunction %2 None %3
          %13 = OpLabel
          %30 = OpCopyObject %6 %7

--- a/test/fuzz/transformation_equation_instruction_test.cpp
+++ b/test/fuzz/transformation_equation_instruction_test.cpp
@@ -32,6 +32,8 @@ TEST(TransformationEquationInstructionTest, SignedNegate) {
           %3 = OpTypeFunction %2
           %6 = OpTypeInt 32 1
           %7 = OpConstant %6 24
+         %40 = OpTypeBool
+         %41 = OpConstantTrue %40
          %20 = OpUndef %6
          %12 = OpFunction %2 None %3
          %13 = OpLabel
@@ -83,6 +85,26 @@ TEST(TransformationEquationInstructionTest, SignedNegate) {
                (context
                        .get(), fact_manager));
 
+  // Bad: too many arguments to OpSNegate.
+  ASSERT_FALSE(TransformationEquationInstruction(
+                       14, SpvOpSNegate, {7, 7}, return_instruction).IsApplicable(context
+                       .get(), fact_manager));
+
+  // Bad: 40 is a type id.
+  ASSERT_FALSE(TransformationEquationInstruction(
+                       14, SpvOpSNegate, {40}, return_instruction).IsApplicable(context
+                       .get(), fact_manager));
+
+  // Bad: wrong type of argument to OpSNegate.
+  ASSERT_FALSE(TransformationEquationInstruction(
+                       14, SpvOpSNegate, {41}, return_instruction).IsApplicable(context
+                       .get(), fact_manager));
+
+  // Bad: OpLoad is not a suitable opcode for an equation.
+  ASSERT_FALSE(TransformationEquationInstruction(
+                       14, SpvOpLoad, {41}, return_instruction).IsApplicable(context
+                       .get(), fact_manager));
+
   auto transformation1 = TransformationEquationInstruction(
           14, SpvOpSNegate, {7}, return_instruction);
   ASSERT_TRUE(transformation1.IsApplicable(context.get(), fact_manager));
@@ -109,6 +131,8 @@ TEST(TransformationEquationInstructionTest, SignedNegate) {
           %3 = OpTypeFunction %2
           %6 = OpTypeInt 32 1
           %7 = OpConstant %6 24
+         %40 = OpTypeBool
+         %41 = OpConstantTrue %40
          %20 = OpUndef %6
          %12 = OpFunction %2 None %3
          %13 = OpLabel
@@ -134,6 +158,8 @@ TEST(TransformationEquationInstructionTest, LogicalNot) {
           %3 = OpTypeFunction %2
           %6 = OpTypeBool
           %7 = OpConstantTrue %6
+         %20 = OpTypeInt 32 0
+         %21 = OpConstant %20 5
          %12 = OpFunction %2 None %3
          %13 = OpLabel
                OpReturn
@@ -149,6 +175,21 @@ TEST(TransformationEquationInstructionTest, LogicalNot) {
 
   protobufs::InstructionDescriptor return_instruction =
       MakeInstructionDescriptor(13, SpvOpReturn, 0);
+
+  // Bad: too few arguments to OpLogicalNot.
+  ASSERT_FALSE(TransformationEquationInstruction(
+                       14, SpvOpLogicalNot, {}, return_instruction).IsApplicable(context
+                       .get(), fact_manager));
+
+  // Bad: 6 is a type id.
+  ASSERT_FALSE(TransformationEquationInstruction(
+                       14, SpvOpLogicalNot, {6}, return_instruction).IsApplicable(context
+                       .get(), fact_manager));
+
+  // Bad: wrong type of argument to OpLogicalNot.
+  ASSERT_FALSE(TransformationEquationInstruction(
+                       14, SpvOpLogicalNot, {21}, return_instruction).IsApplicable(context
+                       .get(), fact_manager));
 
   auto transformation1 = TransformationEquationInstruction(
       14, SpvOpLogicalNot, {7}, return_instruction);
@@ -176,6 +217,8 @@ TEST(TransformationEquationInstructionTest, LogicalNot) {
           %3 = OpTypeFunction %2
           %6 = OpTypeBool
           %7 = OpConstantTrue %6
+         %20 = OpTypeInt 32 0
+         %21 = OpConstant %20 5
          %12 = OpFunction %2 None %3
          %13 = OpLabel
          %14 = OpLogicalNot %6 %7
@@ -198,8 +241,12 @@ TEST(TransformationEquationInstructionTest, AddSubNegate1) {
           %2 = OpTypeVoid
           %3 = OpTypeFunction %2
           %6 = OpTypeInt 32 1
+         %20 = OpTypeVector %6 3
          %15 = OpConstant %6 24
          %16 = OpConstant %6 37
+         %21 = OpConstantComposite %20 %15 %16 %15
+         %23 = OpTypeBool
+         %22 = OpConstantTrue %23
          %12 = OpFunction %2 None %3
          %13 = OpLabel
                OpReturn
@@ -215,6 +262,27 @@ TEST(TransformationEquationInstructionTest, AddSubNegate1) {
 
   protobufs::InstructionDescriptor return_instruction =
       MakeInstructionDescriptor(13, SpvOpReturn, 0);
+
+  // Bad: too many arguments to OpIAdd.
+  ASSERT_FALSE(TransformationEquationInstruction(
+                       14, SpvOpIAdd, {15, 16, 16}, return_instruction).IsApplicable(context
+                       .get(), fact_manager));
+  // Bad: boolean argument to OpIAdd.
+  ASSERT_FALSE(TransformationEquationInstruction(
+                       14, SpvOpIAdd, {15, 22}, return_instruction).IsApplicable(context
+                       .get(), fact_manager));
+  // Bad: type as argument to OpIAdd.
+  ASSERT_FALSE(TransformationEquationInstruction(
+                       14, SpvOpIAdd, {23, 16}, return_instruction).IsApplicable(context
+                       .get(), fact_manager));
+  // Bad: arguments of mismatched widths
+  ASSERT_FALSE(TransformationEquationInstruction(
+                       14, SpvOpIAdd, {15, 21}, return_instruction).IsApplicable(context
+                       .get(), fact_manager));
+  // Bad: arguments of mismatched widths
+  ASSERT_FALSE(TransformationEquationInstruction(
+                       14, SpvOpIAdd, {21, 15}, return_instruction).IsApplicable(context
+                       .get(), fact_manager));
 
   auto transformation1 = TransformationEquationInstruction(
       14, SpvOpIAdd, {15, 16}, return_instruction);
@@ -262,8 +330,12 @@ TEST(TransformationEquationInstructionTest, AddSubNegate1) {
           %2 = OpTypeVoid
           %3 = OpTypeFunction %2
           %6 = OpTypeInt 32 1
+         %20 = OpTypeVector %6 3
          %15 = OpConstant %6 24
          %16 = OpConstant %6 37
+         %21 = OpConstantComposite %20 %15 %16 %15
+         %23 = OpTypeBool
+         %22 = OpConstantTrue %23
          %12 = OpFunction %2 None %3
          %13 = OpLabel
          %14 = OpIAdd %6 %15 %16

--- a/test/fuzz/transformation_equation_instruction_test.cpp
+++ b/test/fuzz/transformation_equation_instruction_test.cpp
@@ -235,12 +235,12 @@ TEST(TransformationEquationInstructionTest, AddSubNegate1) {
           %2 = OpTypeVoid
           %3 = OpTypeFunction %2
           %6 = OpTypeInt 32 1
-         %20 = OpTypeVector %6 3
+         %30 = OpTypeVector %6 3
          %15 = OpConstant %6 24
          %16 = OpConstant %6 37
-         %21 = OpConstantComposite %20 %15 %16 %15
-         %23 = OpTypeBool
-         %22 = OpConstantTrue %23
+         %31 = OpConstantComposite %30 %15 %16 %15
+         %33 = OpTypeBool
+         %32 = OpConstantTrue %33
          %12 = OpFunction %2 None %3
          %13 = OpLabel
                OpReturn
@@ -262,19 +262,19 @@ TEST(TransformationEquationInstructionTest, AddSubNegate1) {
                                                  return_instruction)
                    .IsApplicable(context.get(), fact_manager));
   // Bad: boolean argument to OpIAdd.
-  ASSERT_FALSE(TransformationEquationInstruction(14, SpvOpIAdd, {15, 22},
+  ASSERT_FALSE(TransformationEquationInstruction(14, SpvOpIAdd, {15, 32},
                                                  return_instruction)
                    .IsApplicable(context.get(), fact_manager));
   // Bad: type as argument to OpIAdd.
-  ASSERT_FALSE(TransformationEquationInstruction(14, SpvOpIAdd, {23, 16},
+  ASSERT_FALSE(TransformationEquationInstruction(14, SpvOpIAdd, {33, 16},
                                                  return_instruction)
                    .IsApplicable(context.get(), fact_manager));
   // Bad: arguments of mismatched widths
-  ASSERT_FALSE(TransformationEquationInstruction(14, SpvOpIAdd, {15, 21},
+  ASSERT_FALSE(TransformationEquationInstruction(14, SpvOpIAdd, {15, 31},
                                                  return_instruction)
                    .IsApplicable(context.get(), fact_manager));
   // Bad: arguments of mismatched widths
-  ASSERT_FALSE(TransformationEquationInstruction(14, SpvOpIAdd, {21, 15},
+  ASSERT_FALSE(TransformationEquationInstruction(14, SpvOpIAdd, {31, 15},
                                                  return_instruction)
                    .IsApplicable(context.get(), fact_manager));
 
@@ -324,12 +324,12 @@ TEST(TransformationEquationInstructionTest, AddSubNegate1) {
           %2 = OpTypeVoid
           %3 = OpTypeFunction %2
           %6 = OpTypeInt 32 1
-         %20 = OpTypeVector %6 3
+         %30 = OpTypeVector %6 3
          %15 = OpConstant %6 24
          %16 = OpConstant %6 37
-         %21 = OpConstantComposite %20 %15 %16 %15
-         %23 = OpTypeBool
-         %22 = OpConstantTrue %23
+         %31 = OpConstantComposite %30 %15 %16 %15
+         %33 = OpTypeBool
+         %32 = OpConstantTrue %33
          %12 = OpFunction %2 None %3
          %13 = OpLabel
          %14 = OpIAdd %6 %15 %16

--- a/test/fuzz/transformation_equation_instruction_test.cpp
+++ b/test/fuzz/transformation_equation_instruction_test.cpp
@@ -50,75 +50,69 @@ TEST(TransformationEquationInstructionTest, SignedNegate) {
   FactManager fact_manager;
 
   protobufs::InstructionDescriptor return_instruction =
-          MakeInstructionDescriptor(13, SpvOpReturn, 0);
+      MakeInstructionDescriptor(13, SpvOpReturn, 0);
 
   // Bad: id already in use.
-  ASSERT_FALSE(TransformationEquationInstruction(
-                       7, SpvOpSNegate, {7}, return_instruction).IsApplicable(context
-                       .get(), fact_manager));
+  ASSERT_FALSE(TransformationEquationInstruction(7, SpvOpSNegate, {7},
+                                                 return_instruction)
+                   .IsApplicable(context.get(), fact_manager));
 
   // Bad: identified instruction does not exist.
-  ASSERT_FALSE(TransformationEquationInstruction(
-                       14, SpvOpSNegate, {7}, MakeInstructionDescriptor(13,
-                                                                        SpvOpLoad, 0)).IsApplicable
-               (context
-                       .get(), fact_manager));
+  ASSERT_FALSE(
+      TransformationEquationInstruction(
+          14, SpvOpSNegate, {7}, MakeInstructionDescriptor(13, SpvOpLoad, 0))
+          .IsApplicable(context.get(), fact_manager));
 
   // Bad: id 100 does not exist
-  ASSERT_FALSE(TransformationEquationInstruction(
-                       14, SpvOpSNegate, {100}, return_instruction).IsApplicable
-               (context
-                       .get(), fact_manager));
+  ASSERT_FALSE(TransformationEquationInstruction(14, SpvOpSNegate, {100},
+                                                 return_instruction)
+                   .IsApplicable(context.get(), fact_manager));
 
   // Bad: id 20 is an OpUndef
-  ASSERT_FALSE(TransformationEquationInstruction(
-                       14, SpvOpSNegate, {20}, return_instruction).IsApplicable
-               (context
-                       .get(), fact_manager));
+  ASSERT_FALSE(TransformationEquationInstruction(14, SpvOpSNegate, {20},
+                                                 return_instruction)
+                   .IsApplicable(context.get(), fact_manager));
 
   // Bad: id 30 is not available right before its definition
   ASSERT_FALSE(TransformationEquationInstruction(
-                       14, SpvOpSNegate, {30}, MakeInstructionDescriptor(30,
-                                                                         SpvOpCopyObject, 0)
-               )
-                       .IsApplicable
-               (context
-                       .get(), fact_manager));
+                   14, SpvOpSNegate, {30},
+                   MakeInstructionDescriptor(30, SpvOpCopyObject, 0))
+                   .IsApplicable(context.get(), fact_manager));
 
   // Bad: too many arguments to OpSNegate.
-  ASSERT_FALSE(TransformationEquationInstruction(
-                       14, SpvOpSNegate, {7, 7}, return_instruction).IsApplicable(context
-                       .get(), fact_manager));
+  ASSERT_FALSE(TransformationEquationInstruction(14, SpvOpSNegate, {7, 7},
+                                                 return_instruction)
+                   .IsApplicable(context.get(), fact_manager));
 
   // Bad: 40 is a type id.
-  ASSERT_FALSE(TransformationEquationInstruction(
-                       14, SpvOpSNegate, {40}, return_instruction).IsApplicable(context
-                       .get(), fact_manager));
+  ASSERT_FALSE(TransformationEquationInstruction(14, SpvOpSNegate, {40},
+                                                 return_instruction)
+                   .IsApplicable(context.get(), fact_manager));
 
   // Bad: wrong type of argument to OpSNegate.
-  ASSERT_FALSE(TransformationEquationInstruction(
-                       14, SpvOpSNegate, {41}, return_instruction).IsApplicable(context
-                       .get(), fact_manager));
+  ASSERT_FALSE(TransformationEquationInstruction(14, SpvOpSNegate, {41},
+                                                 return_instruction)
+                   .IsApplicable(context.get(), fact_manager));
 
   // Bad: OpLoad is not a suitable opcode for an equation.
-  ASSERT_FALSE(TransformationEquationInstruction(
-                       14, SpvOpLoad, {41}, return_instruction).IsApplicable(context
-                       .get(), fact_manager));
+  ASSERT_FALSE(
+      TransformationEquationInstruction(14, SpvOpLoad, {41}, return_instruction)
+          .IsApplicable(context.get(), fact_manager));
 
   auto transformation1 = TransformationEquationInstruction(
-          14, SpvOpSNegate, {7}, return_instruction);
+      14, SpvOpSNegate, {7}, return_instruction);
   ASSERT_TRUE(transformation1.IsApplicable(context.get(), fact_manager));
   transformation1.Apply(context.get(), &fact_manager);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation2 = TransformationEquationInstruction(
-          15, SpvOpSNegate, {14}, return_instruction);
+      15, SpvOpSNegate, {14}, return_instruction);
   ASSERT_TRUE(transformation2.IsApplicable(context.get(), fact_manager));
   transformation2.Apply(context.get(), &fact_manager);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(fact_manager.IsSynonymous(
-          MakeDataDescriptor(15, {}), MakeDataDescriptor(7, {}), context.get()));
+      MakeDataDescriptor(15, {}), MakeDataDescriptor(7, {}), context.get()));
 
   std::string after_transformation = R"(
                OpCapability Shader
@@ -177,19 +171,19 @@ TEST(TransformationEquationInstructionTest, LogicalNot) {
       MakeInstructionDescriptor(13, SpvOpReturn, 0);
 
   // Bad: too few arguments to OpLogicalNot.
-  ASSERT_FALSE(TransformationEquationInstruction(
-                       14, SpvOpLogicalNot, {}, return_instruction).IsApplicable(context
-                       .get(), fact_manager));
+  ASSERT_FALSE(TransformationEquationInstruction(14, SpvOpLogicalNot, {},
+                                                 return_instruction)
+                   .IsApplicable(context.get(), fact_manager));
 
   // Bad: 6 is a type id.
-  ASSERT_FALSE(TransformationEquationInstruction(
-                       14, SpvOpLogicalNot, {6}, return_instruction).IsApplicable(context
-                       .get(), fact_manager));
+  ASSERT_FALSE(TransformationEquationInstruction(14, SpvOpLogicalNot, {6},
+                                                 return_instruction)
+                   .IsApplicable(context.get(), fact_manager));
 
   // Bad: wrong type of argument to OpLogicalNot.
-  ASSERT_FALSE(TransformationEquationInstruction(
-                       14, SpvOpLogicalNot, {21}, return_instruction).IsApplicable(context
-                       .get(), fact_manager));
+  ASSERT_FALSE(TransformationEquationInstruction(14, SpvOpLogicalNot, {21},
+                                                 return_instruction)
+                   .IsApplicable(context.get(), fact_manager));
 
   auto transformation1 = TransformationEquationInstruction(
       14, SpvOpLogicalNot, {7}, return_instruction);
@@ -264,25 +258,25 @@ TEST(TransformationEquationInstructionTest, AddSubNegate1) {
       MakeInstructionDescriptor(13, SpvOpReturn, 0);
 
   // Bad: too many arguments to OpIAdd.
-  ASSERT_FALSE(TransformationEquationInstruction(
-                       14, SpvOpIAdd, {15, 16, 16}, return_instruction).IsApplicable(context
-                       .get(), fact_manager));
+  ASSERT_FALSE(TransformationEquationInstruction(14, SpvOpIAdd, {15, 16, 16},
+                                                 return_instruction)
+                   .IsApplicable(context.get(), fact_manager));
   // Bad: boolean argument to OpIAdd.
-  ASSERT_FALSE(TransformationEquationInstruction(
-                       14, SpvOpIAdd, {15, 22}, return_instruction).IsApplicable(context
-                       .get(), fact_manager));
+  ASSERT_FALSE(TransformationEquationInstruction(14, SpvOpIAdd, {15, 22},
+                                                 return_instruction)
+                   .IsApplicable(context.get(), fact_manager));
   // Bad: type as argument to OpIAdd.
-  ASSERT_FALSE(TransformationEquationInstruction(
-                       14, SpvOpIAdd, {23, 16}, return_instruction).IsApplicable(context
-                       .get(), fact_manager));
+  ASSERT_FALSE(TransformationEquationInstruction(14, SpvOpIAdd, {23, 16},
+                                                 return_instruction)
+                   .IsApplicable(context.get(), fact_manager));
   // Bad: arguments of mismatched widths
-  ASSERT_FALSE(TransformationEquationInstruction(
-                       14, SpvOpIAdd, {15, 21}, return_instruction).IsApplicable(context
-                       .get(), fact_manager));
+  ASSERT_FALSE(TransformationEquationInstruction(14, SpvOpIAdd, {15, 21},
+                                                 return_instruction)
+                   .IsApplicable(context.get(), fact_manager));
   // Bad: arguments of mismatched widths
-  ASSERT_FALSE(TransformationEquationInstruction(
-                       14, SpvOpIAdd, {21, 15}, return_instruction).IsApplicable(context
-                       .get(), fact_manager));
+  ASSERT_FALSE(TransformationEquationInstruction(14, SpvOpIAdd, {21, 15},
+                                                 return_instruction)
+                   .IsApplicable(context.get(), fact_manager));
 
   auto transformation1 = TransformationEquationInstruction(
       14, SpvOpIAdd, {15, 16}, return_instruction);
@@ -386,65 +380,58 @@ TEST(TransformationEquationInstructionTest, AddSubNegate2) {
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation2 = TransformationEquationInstruction(
-          17, SpvOpIAdd, {14, 16}, return_instruction);
+      17, SpvOpIAdd, {14, 16}, return_instruction);
   ASSERT_TRUE(transformation2.IsApplicable(context.get(), fact_manager));
   transformation2.Apply(context.get(), &fact_manager);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(fact_manager.IsSynonymous(
-          MakeDataDescriptor(17, {}), MakeDataDescriptor(15, {}), context.get
-                  ()));
+      MakeDataDescriptor(17, {}), MakeDataDescriptor(15, {}), context.get()));
 
   auto transformation3 = TransformationEquationInstruction(
-          18, SpvOpIAdd, {16, 14}, return_instruction);
+      18, SpvOpIAdd, {16, 14}, return_instruction);
   ASSERT_TRUE(transformation3.IsApplicable(context.get(), fact_manager));
   transformation3.Apply(context.get(), &fact_manager);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(fact_manager.IsSynonymous(
-          MakeDataDescriptor(17, {}), MakeDataDescriptor(18, {}), context.get
-                  ()));
+      MakeDataDescriptor(17, {}), MakeDataDescriptor(18, {}), context.get()));
   ASSERT_TRUE(fact_manager.IsSynonymous(
-          MakeDataDescriptor(18, {}), MakeDataDescriptor(15, {}), context.get
-                  ()));
+      MakeDataDescriptor(18, {}), MakeDataDescriptor(15, {}), context.get()));
 
   auto transformation4 = TransformationEquationInstruction(
-          19, SpvOpISub, {14, 15}, return_instruction);
+      19, SpvOpISub, {14, 15}, return_instruction);
   ASSERT_TRUE(transformation4.IsApplicable(context.get(), fact_manager));
   transformation4.Apply(context.get(), &fact_manager);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation5 = TransformationEquationInstruction(
-          20, SpvOpSNegate, {19}, return_instruction);
+      20, SpvOpSNegate, {19}, return_instruction);
   ASSERT_TRUE(transformation5.IsApplicable(context.get(), fact_manager));
   transformation5.Apply(context.get(), &fact_manager);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(fact_manager.IsSynonymous(
-          MakeDataDescriptor(20, {}), MakeDataDescriptor(16, {}), context.get
-                  ()));
+      MakeDataDescriptor(20, {}), MakeDataDescriptor(16, {}), context.get()));
 
   auto transformation6 = TransformationEquationInstruction(
-          21, SpvOpISub, {14, 19}, return_instruction);
+      21, SpvOpISub, {14, 19}, return_instruction);
   ASSERT_TRUE(transformation6.IsApplicable(context.get(), fact_manager));
   transformation6.Apply(context.get(), &fact_manager);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(fact_manager.IsSynonymous(
-          MakeDataDescriptor(21, {}), MakeDataDescriptor(15, {}), context.get
-          ()));
+      MakeDataDescriptor(21, {}), MakeDataDescriptor(15, {}), context.get()));
 
   auto transformation7 = TransformationEquationInstruction(
-          22, SpvOpISub, {14, 18}, return_instruction);
+      22, SpvOpISub, {14, 18}, return_instruction);
   ASSERT_TRUE(transformation7.IsApplicable(context.get(), fact_manager));
   transformation7.Apply(context.get(), &fact_manager);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation8 = TransformationEquationInstruction(
-          23, SpvOpSNegate, {22}, return_instruction);
+      23, SpvOpSNegate, {22}, return_instruction);
   ASSERT_TRUE(transformation8.IsApplicable(context.get(), fact_manager));
   transformation8.Apply(context.get(), &fact_manager);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(fact_manager.IsSynonymous(
-          MakeDataDescriptor(23, {}), MakeDataDescriptor(16, {}), context.get
-          ()));
-
+      MakeDataDescriptor(23, {}), MakeDataDescriptor(16, {}), context.get()));
 
   std::string after_transformation = R"(
                OpCapability Shader

--- a/test/fuzz/transformation_equation_instruction_test.cpp
+++ b/test/fuzz/transformation_equation_instruction_test.cpp
@@ -94,11 +94,6 @@ TEST(TransformationEquationInstructionTest, SignedNegate) {
                                                  return_instruction)
                    .IsApplicable(context.get(), fact_manager));
 
-  // Bad: OpLoad is not a suitable opcode for an equation.
-  ASSERT_FALSE(
-      TransformationEquationInstruction(14, SpvOpLoad, {41}, return_instruction)
-          .IsApplicable(context.get(), fact_manager));
-
   auto transformation1 = TransformationEquationInstruction(
       14, SpvOpSNegate, {7}, return_instruction);
   ASSERT_TRUE(transformation1.IsApplicable(context.get(), fact_manager));


### PR DESCRIPTION
This introduces a new fuzzer pass to add instructions to the module
that define equations, and support in the fact manager for recording
equation facts and deducing synonym facts from equation facts.

Initially the only equations that are supported involve OpIAdd,
OpISub, OpSNegate and OpLogicalNot, but there is scope for adding
support for equations over various other operators.
