### PR TITLE
Roll external/spirv-headers/ 30ef660ce..a17e17e36 (1 commit)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -6,7 +6,7 @@ vars = {
   'effcee_revision': 'cd25ec17e9382f99a895b9ef53ff3c277464d07d',
   'googletest_revision': 'f2fb48c3b3d79a75a88a99fba6576b25d42ec528',
   're2_revision': '5bd613749fd530b576b890283bfb6bc6ea6246cb',
-  'spirv_headers_revision': '30ef660ce2e666f7ae925598b8a267f4da6d33aa',
+  'spirv_headers_revision': 'a17e17e36da44d2cd1740132ecd7a8cb078f1d15',
 }
 
 deps = {


### PR DESCRIPTION
https://github.com/KhronosGroup/SPIRV-Headers/compare/30ef660ce2e6...a17e17e36da4

$ git log 30ef660ce..a17e17e36 --date=short --no-merges --format='%ad %ae %s'
2020-03-13 jmadill Add missing header to BUILD.gn.

Created with:
  roll-dep external/spirv-headers

@johnkslang @zoddicus PTAL