### PR TITLE
Set wrapped kill basic block's parent

### DIFF
--- a/source/opt/wrap_opkill.cpp
+++ b/source/opt/wrap_opkill.cpp
@@ -147,6 +147,7 @@ uint32_t WrapOpKill::GetOpKillFuncId() {
   bb->AddInstruction(std::move(kill_inst));
 
   // Add the bb to the function
+  bb->SetParent(opkill_function_.get());
   opkill_function_->AddBasicBlock(std::move(bb));
 
   // Add the function to the module.


### PR DESCRIPTION
Fixes #3268

* Set the parent of the basic block for the wrapper function
* Add a test