### PR TITLE
spirv-fuzz: Improve support for compute shaders in donation

### DIFF
--- a/source/fuzz/fuzzer_pass_add_global_variables.cpp
+++ b/source/fuzz/fuzzer_pass_add_global_variables.cpp
@@ -66,9 +66,11 @@ void FuzzerPassAddGlobalVariables::Apply() {
           available_pointers_to_basic_type[GetFuzzerContext()->RandomIndex(
               available_pointers_to_basic_type)];
     }
+    // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3274):  We could
+    //  add new variables with Workgroup storage class in compute shaders.
     ApplyTransformation(TransformationAddGlobalVariable(
         GetFuzzerContext()->GetFreshId(), pointer_type_id,
-        FindOrCreateZeroConstant(basic_type), true));
+        SpvStorageClassPrivate, FindOrCreateZeroConstant(basic_type), true));
   }
 }
 

--- a/source/fuzz/fuzzer_pass_donate_modules.cpp
+++ b/source/fuzz/fuzzer_pass_donate_modules.cpp
@@ -282,11 +282,6 @@ void FuzzerPassDonateModules::HandleTypesAndValues(
         // we go ahead and add a remapped version of the type declared by the
         // donor.
         uint32_t component_type_id = type_or_value.GetSingleWordInOperand(0);
-        if (!original_id_to_donated_id->count(component_type_id)) {
-          // We did not donate the component type of this array type, so we
-          // cannot donate the array type.
-          continue;
-        }
         new_result_id = GetFuzzerContext()->GetFreshId();
         ApplyTransformation(TransformationAddTypeArray(
             new_result_id, original_id_to_donated_id->at(component_type_id),
@@ -304,11 +299,6 @@ void FuzzerPassDonateModules::HandleTypesAndValues(
         // is rewritten to yield the fixed length that is used for the array.
 
         uint32_t component_type_id = type_or_value.GetSingleWordInOperand(0);
-        if (!original_id_to_donated_id->count(component_type_id)) {
-          // We did not donate the component type of this runtime array type, so
-          // we cannot donate it as a fixed-size array.
-          continue;
-        }
         new_result_id = GetFuzzerContext()->GetFreshId();
         ApplyTransformation(TransformationAddTypeArray(
             new_result_id, original_id_to_donated_id->at(component_type_id),
@@ -320,11 +310,6 @@ void FuzzerPassDonateModules::HandleTypesAndValues(
         std::vector<uint32_t> member_type_ids;
         for (uint32_t i = 0; i < type_or_value.NumInOperands(); i++) {
           auto component_type_id = type_or_value.GetSingleWordInOperand(i);
-          if (!original_id_to_donated_id->count(component_type_id)) {
-            // We did not donate every member type for this struct type, so we
-            // cannot donate the struct type.
-            continue;
-          }
           member_type_ids.push_back(
               original_id_to_donated_id->at(component_type_id));
         }
@@ -335,11 +320,6 @@ void FuzzerPassDonateModules::HandleTypesAndValues(
       case SpvOpTypePointer: {
         // Similar to SpvOpTypeArray.
         uint32_t pointee_type_id = type_or_value.GetSingleWordInOperand(1);
-        if (!original_id_to_donated_id->count(pointee_type_id)) {
-          // We did not donate the pointee type for this pointer type, so we
-          // cannot donate the pointer type.
-          continue;
-        }
         new_result_id = GetFuzzerContext()->GetFreshId();
         ApplyTransformation(TransformationAddTypePointer(
             new_result_id,
@@ -371,11 +351,6 @@ void FuzzerPassDonateModules::HandleTypesAndValues(
         for (uint32_t i = 0; i < type_or_value.NumInOperands(); i++) {
           uint32_t return_or_parameter_type =
               type_or_value.GetSingleWordInOperand(i);
-          if (!original_id_to_donated_id->count(return_or_parameter_type)) {
-            // We did not donate every return/parameter type for this function
-            // type, so we cannot donate the function type.
-            continue;
-          }
           return_and_parameter_types.push_back(
               original_id_to_donated_id->at(return_or_parameter_type));
         }
@@ -446,12 +421,6 @@ void FuzzerPassDonateModules::HandleTypesAndValues(
             constituent_ids));
       } break;
       case SpvOpConstantNull: {
-        if (!original_id_to_donated_id->count(type_or_value.type_id())) {
-          // We did not donate the type associated with this null constant, so
-          // we cannot donate the null constant.
-          continue;
-        }
-
         // It is fine to have multiple OpConstantNull instructions of the same
         // type, so we just add this to the recipient module.
         new_result_id = GetFuzzerContext()->GetFreshId();
@@ -460,12 +429,6 @@ void FuzzerPassDonateModules::HandleTypesAndValues(
             original_id_to_donated_id->at(type_or_value.type_id())));
       } break;
       case SpvOpVariable: {
-        if (!original_id_to_donated_id->count(type_or_value.type_id())) {
-          // We did not donate the pointer type associated with this variable,
-          // so we cannot donate the variable.
-          continue;
-        }
-
         // This is a global variable that could have one of various storage
         // classes.  However, we change all global variable pointer storage
         // classes (such as Uniform, Input and Output) to private when donating
@@ -517,12 +480,6 @@ void FuzzerPassDonateModules::HandleTypesAndValues(
             true));
       } break;
       case SpvOpUndef: {
-        if (!original_id_to_donated_id->count(type_or_value.type_id())) {
-          // We did not donate the type associated with this undef, so we cannot
-          // donate the undef.
-          continue;
-        }
-
         // It is fine to have multiple Undef instructions of the same type, so
         // we just add this to the recipient module.
         new_result_id = GetFuzzerContext()->GetFreshId();

--- a/source/fuzz/fuzzer_pass_donate_modules.cpp
+++ b/source/fuzz/fuzzer_pass_donate_modules.cpp
@@ -518,7 +518,7 @@ void FuzzerPassDonateModules::HandleTypesAndValues(
       } break;
       case SpvOpUndef: {
         if (!original_id_to_donated_id->count(type_or_value.type_id())) {
-          // We did not denote the type associated wit this undef, so we cannot
+          // We did not donate the type associated with this undef, so we cannot
           // donate the undef.
           continue;
         }
@@ -618,9 +618,10 @@ void FuzzerPassDonateModules::HandleFunctions(
           assert(fixed_size_array_type_instruction->opcode() ==
                      SpvOpTypeArray &&
                  "The donated array type must be fixed-size.");
+          auto array_size_id =
+              fixed_size_array_type_instruction->GetSingleWordInOperand(1);
           original_id_to_donated_id->insert(
-              {instruction->result_id(),
-               fixed_size_array_type_instruction->GetSingleWordInOperand(1)});
+              {instruction->result_id(), array_size_id});
         } else if (instruction->type_id()) {
           // If the ignored instruction has a basic result type then we
           // associate its result id with a constant of that type, so that

--- a/source/fuzz/fuzzer_pass_donate_modules.h
+++ b/source/fuzz/fuzzer_pass_donate_modules.h
@@ -77,6 +77,12 @@ class FuzzerPassDonateModules : public FuzzerPass {
                        std::map<uint32_t, uint32_t>* original_id_to_donated_id,
                        bool make_livesafe);
 
+  // During donation we will have to ignore some instructions, e.g. because they
+  // use opcodes that we cannot support or because they reference the ids of
+  // instructions that have not been donated.  This function encapsulates the
+  // logic for deciding which instructions should be ignored.
+  bool IgnoreInstruction(const opt::Instruction* instruction);
+
   // Returns the ids of all functions in |context| in a topological order in
   // relation to the call graph of |context|, which is assumed to be recursion-
   // free.

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -560,8 +560,9 @@ message TransformationAddGlobalUndef {
 
 message TransformationAddGlobalVariable {
 
-  // Adds a global variable of the given type to the module, with Private
-  // storage class and optionally with an initializer.
+  // Adds a global variable of the given type to the module, with Private or
+  // Workgroup storage class, and optionally (for the Private case) with an
+  // initializer.
 
   // Fresh id for the global variable
   uint32 fresh_id = 1;
@@ -569,13 +570,15 @@ message TransformationAddGlobalVariable {
   // The type of the global variable
   uint32 type_id = 2;
 
+  uint32 storage_class = 3;
+
   // Initial value of the variable
-  uint32 initializer_id = 3;
+  uint32 initializer_id = 4;
 
   // True if and only if the behaviour of the module should not depend on the
   // value of the variable, in which case stores to the variable can be
   // performed in an arbitrary fashion.
-  bool value_is_irrelevant = 4;
+  bool value_is_irrelevant = 5;
 
 }
 

--- a/source/fuzz/transformation_add_function.cpp
+++ b/source/fuzz/transformation_add_function.cpp
@@ -897,6 +897,11 @@ uint32_t TransformationAddFunction::GetBoundForCompositeIndex(
     case SpvOpTypeStruct: {
       return fuzzerutil::GetNumberOfStructMembers(composite_type_inst);
     }
+    case SpvOpTypeRuntimeArray:
+      assert(false &&
+             "GetBoundForCompositeIndex should not be invoked with an "
+             "OpTypeRuntimeArray, which does not have a static bound.");
+      return 0;
     default:
       assert(false && "Unknown composite type.");
       return 0;
@@ -909,6 +914,7 @@ opt::Instruction* TransformationAddFunction::FollowCompositeIndex(
   uint32_t sub_object_type_id;
   switch (composite_type_inst.opcode()) {
     case SpvOpTypeArray:
+    case SpvOpTypeRuntimeArray:
       sub_object_type_id = composite_type_inst.GetSingleWordInOperand(0);
       break;
     case SpvOpTypeMatrix:

--- a/source/fuzz/transformation_add_global_variable.cpp
+++ b/source/fuzz/transformation_add_global_variable.cpp
@@ -47,6 +47,7 @@ bool TransformationAddGlobalVariable::IsApplicable(
     case SpvStorageClassWorkgroup:
       break;
     default:
+      assert(false && "Unsupported storage class.");
       return false;
   }
   // The type id must correspond to a type.
@@ -66,6 +67,9 @@ bool TransformationAddGlobalVariable::IsApplicable(
   if (message_.initializer_id()) {
     // An initializer is not allowed if the storage class is Workgroup.
     if (storage_class == SpvStorageClassWorkgroup) {
+      assert(false &&
+             "By construction this transformation should not have an "
+             "initializer when Workgroup storage class is used.");
       return false;
     }
     // The initializer id must be the id of a constant.  Check this with the

--- a/source/fuzz/transformation_add_global_variable.cpp
+++ b/source/fuzz/transformation_add_global_variable.cpp
@@ -24,10 +24,11 @@ TransformationAddGlobalVariable::TransformationAddGlobalVariable(
     : message_(message) {}
 
 TransformationAddGlobalVariable::TransformationAddGlobalVariable(
-    uint32_t fresh_id, uint32_t type_id, uint32_t initializer_id,
-    bool value_is_irrelevant) {
+    uint32_t fresh_id, uint32_t type_id, SpvStorageClass storage_class,
+    uint32_t initializer_id, bool value_is_irrelevant) {
   message_.set_fresh_id(fresh_id);
   message_.set_type_id(type_id);
+  message_.set_storage_class(storage_class);
   message_.set_initializer_id(initializer_id);
   message_.set_value_is_irrelevant(value_is_irrelevant);
 }
@@ -37,6 +38,16 @@ bool TransformationAddGlobalVariable::IsApplicable(
   // The result id must be fresh.
   if (!fuzzerutil::IsFreshId(ir_context, message_.fresh_id())) {
     return false;
+  }
+
+  // The storage class must be Private or Workgroup.
+  auto storage_class = static_cast<SpvStorageClass>(message_.storage_class());
+  switch (storage_class) {
+    case SpvStorageClassPrivate:
+    case SpvStorageClassWorkgroup:
+      break;
+    default:
+      return false;
   }
   // The type id must correspond to a type.
   auto type = ir_context->get_type_mgr()->GetType(message_.type_id());
@@ -48,23 +59,29 @@ bool TransformationAddGlobalVariable::IsApplicable(
   if (!pointer_type) {
     return false;
   }
-  // ... with Private storage class.
-  if (pointer_type->storage_class() != SpvStorageClassPrivate) {
+  // ... with the right storage class.
+  if (pointer_type->storage_class() != storage_class) {
     return false;
   }
-  // The initializer id must be the id of a constant.  Check this with the
-  // constant manager.
-  auto constant_id = ir_context->get_constant_mgr()->GetConstantsFromIds(
-      {message_.initializer_id()});
-  if (constant_id.empty()) {
-    return false;
-  }
-  assert(constant_id.size() == 1 &&
-         "We asked for the constant associated with a single id; we should "
-         "get a single constant.");
-  // The type of the constant must match the pointee type of the pointer.
-  if (pointer_type->pointee_type() != constant_id[0]->type()) {
-    return false;
+  if (message_.initializer_id()) {
+    // An initializer is not allowed if the storage class is Workgroup.
+    if (storage_class == SpvStorageClassWorkgroup) {
+      return false;
+    }
+    // The initializer id must be the id of a constant.  Check this with the
+    // constant manager.
+    auto constant_id = ir_context->get_constant_mgr()->GetConstantsFromIds(
+        {message_.initializer_id()});
+    if (constant_id.empty()) {
+      return false;
+    }
+    assert(constant_id.size() == 1 &&
+           "We asked for the constant associated with a single id; we should "
+           "get a single constant.");
+    // The type of the constant must match the pointee type of the pointer.
+    if (pointer_type->pointee_type() != constant_id[0]->type()) {
+      return false;
+    }
   }
   return true;
 }
@@ -74,7 +91,7 @@ void TransformationAddGlobalVariable::Apply(
     TransformationContext* transformation_context) const {
   opt::Instruction::OperandList input_operands;
   input_operands.push_back(
-      {SPV_OPERAND_TYPE_STORAGE_CLASS, {SpvStorageClassPrivate}});
+      {SPV_OPERAND_TYPE_STORAGE_CLASS, {message_.storage_class()}});
   if (message_.initializer_id()) {
     input_operands.push_back(
         {SPV_OPERAND_TYPE_ID, {message_.initializer_id()}});
@@ -84,7 +101,7 @@ void TransformationAddGlobalVariable::Apply(
       input_operands));
   fuzzerutil::UpdateModuleIdBound(ir_context, message_.fresh_id());
 
-  if (PrivateGlobalsMustBeDeclaredInEntryPointInterfaces(ir_context)) {
+  if (GlobalVariablesMustBeDeclaredInEntryPointInterfaces(ir_context)) {
     // Conservatively add this global to the interface of every entry point in
     // the module.  This means that the global is available for other
     // transformations to use.
@@ -117,7 +134,7 @@ protobufs::Transformation TransformationAddGlobalVariable::ToMessage() const {
 }
 
 bool TransformationAddGlobalVariable::
-    PrivateGlobalsMustBeDeclaredInEntryPointInterfaces(
+    GlobalVariablesMustBeDeclaredInEntryPointInterfaces(
         opt::IRContext* ir_context) {
   // TODO(afd): We capture the universal environments for which this requirement
   //  holds.  The check should be refined on demand for other target

--- a/source/fuzz/transformation_add_global_variable.h
+++ b/source/fuzz/transformation_add_global_variable.h
@@ -29,22 +29,26 @@ class TransformationAddGlobalVariable : public Transformation {
       const protobufs::TransformationAddGlobalVariable& message);
 
   TransformationAddGlobalVariable(uint32_t fresh_id, uint32_t type_id,
+                                  SpvStorageClass storage_class,
                                   uint32_t initializer_id,
                                   bool value_is_irrelevant);
 
   // - |message_.fresh_id| must be fresh
-  // - |message_.type_id| must be the id of a pointer type with Private storage
-  //   class
-  // - |message_.initializer_id| must either be 0 or the id of a constant whose
+  // - |message_.type_id| must be the id of a pointer type with the same storage
+  //   class as |message_.storage_class|
+  // - |message_.storage_class| must be Private or Workgroup
+  // - |message_.initializer_id| must be 0 if |message_.storage_class| is
+  //   Workgroup, and otherwise may either be 0 or the id of a constant whose
   //   type is the pointee type of |message_.type_id|
   bool IsApplicable(
       opt::IRContext* ir_context,
       const TransformationContext& transformation_context) const override;
 
-  // Adds a global variable with Private storage class to the module, with type
-  // |message_.type_id| and either no initializer or |message_.initializer_id|
-  // as an initializer, depending on whether |message_.initializer_id| is 0.
-  // The global variable has result id |message_.fresh_id|.
+  // Adds a global variable with storage class |message_.storage_class| to the
+  // module, with type |message_.type_id| and either no initializer or
+  // |message_.initializer_id| as an initializer, depending on whether
+  // |message_.initializer_id| is 0.  The global variable has result id
+  // |message_.fresh_id|.
   //
   // If |message_.value_is_irrelevant| holds, adds a corresponding fact to the
   // fact manager in |transformation_context|.
@@ -54,7 +58,10 @@ class TransformationAddGlobalVariable : public Transformation {
   protobufs::Transformation ToMessage() const override;
 
  private:
-  static bool PrivateGlobalsMustBeDeclaredInEntryPointInterfaces(
+  // Returns true if and only if the SPIR-V version being used requires that
+  // global variables accessed in the static call graph of an entry point need
+  // to be listed in that entry point's interface.
+  static bool GlobalVariablesMustBeDeclaredInEntryPointInterfaces(
       opt::IRContext* ir_context);
 
   protobufs::TransformationAddGlobalVariable message_;

--- a/test/fuzz/transformation_add_global_variable_test.cpp
+++ b/test/fuzz/transformation_add_global_variable_test.cpp
@@ -350,9 +350,11 @@ TEST(TransformationAddGlobalVariableTest, TestAddingWorkgroupGlobals) {
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  ASSERT_FALSE(
+  ASSERT_DEATH(
       TransformationAddGlobalVariable(8, 7, SpvStorageClassWorkgroup, 50, true)
-          .IsApplicable(context.get(), transformation_context));
+          .IsApplicable(context.get(), transformation_context),
+      "By construction this transformation should not have an.*initializer "
+      "when Workgroup storage class is used");
 
   TransformationAddGlobalVariable transformations[] = {
       // %8 = OpVariable %7 Workgroup

--- a/test/fuzz/transformation_add_global_variable_test.cpp
+++ b/test/fuzz/transformation_add_global_variable_test.cpp
@@ -350,12 +350,6 @@ TEST(TransformationAddGlobalVariableTest, TestAddingWorkgroupGlobals) {
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  ASSERT_DEATH(
-      TransformationAddGlobalVariable(8, 7, SpvStorageClassWorkgroup, 50, true)
-          .IsApplicable(context.get(), transformation_context),
-      "By construction this transformation should not have an.*initializer "
-      "when Workgroup storage class is used");
-
   TransformationAddGlobalVariable transformations[] = {
       // %8 = OpVariable %7 Workgroup
       TransformationAddGlobalVariable(8, 7, SpvStorageClassWorkgroup, 0, true),

--- a/test/fuzz/transformation_add_global_variable_test.cpp
+++ b/test/fuzz/transformation_add_global_variable_test.cpp
@@ -350,6 +350,14 @@ TEST(TransformationAddGlobalVariableTest, TestAddingWorkgroupGlobals) {
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
+#ifndef NDEBUG
+  ASSERT_DEATH(
+      TransformationAddGlobalVariable(8, 7, SpvStorageClassWorkgroup, 50, true)
+          .IsApplicable(context.get(), transformation_context),
+      "By construction this transformation should not have an.*initializer "
+      "when Workgroup storage class is used");
+#endif
+
   TransformationAddGlobalVariable transformations[] = {
       // %8 = OpVariable %7 Workgroup
       TransformationAddGlobalVariable(8, 7, SpvStorageClassWorkgroup, 0, true),

--- a/test/fuzz/transformation_add_global_variable_test.cpp
+++ b/test/fuzz/transformation_add_global_variable_test.cpp
@@ -65,66 +65,82 @@ TEST(TransformationAddGlobalVariableTest, BasicTest) {
                                                validator_options);
 
   // Id already in use
-  ASSERT_FALSE(TransformationAddGlobalVariable(4, 10, 0, true)
-                   .IsApplicable(context.get(), transformation_context));
+  ASSERT_FALSE(
+      TransformationAddGlobalVariable(4, 10, SpvStorageClassPrivate, 0, true)
+          .IsApplicable(context.get(), transformation_context));
   // %1 is not a type
-  ASSERT_FALSE(TransformationAddGlobalVariable(100, 1, 0, false)
-                   .IsApplicable(context.get(), transformation_context));
+  ASSERT_FALSE(
+      TransformationAddGlobalVariable(100, 1, SpvStorageClassPrivate, 0, false)
+          .IsApplicable(context.get(), transformation_context));
 
   // %7 is not a pointer type
-  ASSERT_FALSE(TransformationAddGlobalVariable(100, 7, 0, true)
-                   .IsApplicable(context.get(), transformation_context));
+  ASSERT_FALSE(
+      TransformationAddGlobalVariable(100, 7, SpvStorageClassPrivate, 0, true)
+          .IsApplicable(context.get(), transformation_context));
 
   // %9 does not have Private storage class
-  ASSERT_FALSE(TransformationAddGlobalVariable(100, 9, 0, false)
-                   .IsApplicable(context.get(), transformation_context));
+  ASSERT_FALSE(
+      TransformationAddGlobalVariable(100, 9, SpvStorageClassPrivate, 0, false)
+          .IsApplicable(context.get(), transformation_context));
 
   // %15 does not have Private storage class
-  ASSERT_FALSE(TransformationAddGlobalVariable(100, 15, 0, true)
-                   .IsApplicable(context.get(), transformation_context));
+  ASSERT_FALSE(
+      TransformationAddGlobalVariable(100, 15, SpvStorageClassPrivate, 0, true)
+          .IsApplicable(context.get(), transformation_context));
 
   // %10 is a pointer to float, while %16 is an int constant
-  ASSERT_FALSE(TransformationAddGlobalVariable(100, 10, 16, false)
+  ASSERT_FALSE(TransformationAddGlobalVariable(100, 10, SpvStorageClassPrivate,
+                                               16, false)
                    .IsApplicable(context.get(), transformation_context));
 
   // %10 is a Private pointer to float, while %15 is a variable with type
   // Uniform float pointer
-  ASSERT_FALSE(TransformationAddGlobalVariable(100, 10, 15, true)
-                   .IsApplicable(context.get(), transformation_context));
+  ASSERT_FALSE(
+      TransformationAddGlobalVariable(100, 10, SpvStorageClassPrivate, 15, true)
+          .IsApplicable(context.get(), transformation_context));
 
   // %12 is a Private pointer to int, while %10 is a variable with type
   // Private float pointer
-  ASSERT_FALSE(TransformationAddGlobalVariable(100, 12, 10, false)
+  ASSERT_FALSE(TransformationAddGlobalVariable(100, 12, SpvStorageClassPrivate,
+                                               10, false)
                    .IsApplicable(context.get(), transformation_context));
 
   // %10 is pointer-to-float, and %14 has type pointer-to-float; that's not OK
   // since the initializer's type should be the *pointee* type.
-  ASSERT_FALSE(TransformationAddGlobalVariable(104, 10, 14, true)
-                   .IsApplicable(context.get(), transformation_context));
+  ASSERT_FALSE(
+      TransformationAddGlobalVariable(104, 10, SpvStorageClassPrivate, 14, true)
+          .IsApplicable(context.get(), transformation_context));
 
   // This would work in principle, but logical addressing does not allow
   // a pointer to a pointer.
-  ASSERT_FALSE(TransformationAddGlobalVariable(104, 17, 14, false)
+  ASSERT_FALSE(TransformationAddGlobalVariable(104, 17, SpvStorageClassPrivate,
+                                               14, false)
                    .IsApplicable(context.get(), transformation_context));
 
   TransformationAddGlobalVariable transformations[] = {
       // %100 = OpVariable %12 Private
-      TransformationAddGlobalVariable(100, 12, 16, true),
+      TransformationAddGlobalVariable(100, 12, SpvStorageClassPrivate, 16,
+                                      true),
 
       // %101 = OpVariable %10 Private
-      TransformationAddGlobalVariable(101, 10, 40, false),
+      TransformationAddGlobalVariable(101, 10, SpvStorageClassPrivate, 40,
+                                      false),
 
       // %102 = OpVariable %13 Private
-      TransformationAddGlobalVariable(102, 13, 41, true),
+      TransformationAddGlobalVariable(102, 13, SpvStorageClassPrivate, 41,
+                                      true),
 
       // %103 = OpVariable %12 Private %16
-      TransformationAddGlobalVariable(103, 12, 16, false),
+      TransformationAddGlobalVariable(103, 12, SpvStorageClassPrivate, 16,
+                                      false),
 
       // %104 = OpVariable %19 Private %21
-      TransformationAddGlobalVariable(104, 19, 21, true),
+      TransformationAddGlobalVariable(104, 19, SpvStorageClassPrivate, 21,
+                                      true),
 
       // %105 = OpVariable %19 Private %22
-      TransformationAddGlobalVariable(105, 19, 22, false)};
+      TransformationAddGlobalVariable(105, 19, SpvStorageClassPrivate, 22,
+                                      false)};
 
   for (auto& transformation : transformations) {
     ASSERT_TRUE(
@@ -239,13 +255,16 @@ TEST(TransformationAddGlobalVariableTest, TestEntryPointInterfaceEnlargement) {
 
   TransformationAddGlobalVariable transformations[] = {
       // %100 = OpVariable %12 Private
-      TransformationAddGlobalVariable(100, 12, 16, true),
+      TransformationAddGlobalVariable(100, 12, SpvStorageClassPrivate, 16,
+                                      true),
 
       // %101 = OpVariable %12 Private %16
-      TransformationAddGlobalVariable(101, 12, 16, false),
+      TransformationAddGlobalVariable(101, 12, SpvStorageClassPrivate, 16,
+                                      false),
 
       // %102 = OpVariable %19 Private %21
-      TransformationAddGlobalVariable(102, 19, 21, true)};
+      TransformationAddGlobalVariable(102, 19, SpvStorageClassPrivate, 21,
+                                      true)};
 
   for (auto& transformation : transformations) {
     ASSERT_TRUE(
@@ -295,6 +314,81 @@ TEST(TransformationAddGlobalVariableTest, TestEntryPointInterfaceEnlargement) {
                OpFunctionEnd
           %5 = OpFunction %2 None %3
          %31 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+  ASSERT_TRUE(IsEqual(env, after_transformation, context.get()));
+}
+
+TEST(TransformationAddGlobalVariableTest, TestAddingWorkgroupGlobals) {
+  // This checks that workgroup globals can be added to a compute shader.
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %4 "main"
+               OpExecutionMode %4 LocalSize 1 1 1
+               OpSource ESSL 310
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Workgroup %6
+         %50 = OpConstant %6 2
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  ASSERT_FALSE(
+      TransformationAddGlobalVariable(8, 7, SpvStorageClassWorkgroup, 50, true)
+          .IsApplicable(context.get(), transformation_context));
+
+  TransformationAddGlobalVariable transformations[] = {
+      // %8 = OpVariable %7 Workgroup
+      TransformationAddGlobalVariable(8, 7, SpvStorageClassWorkgroup, 0, true),
+
+      // %10 = OpVariable %7 Workgroup
+      TransformationAddGlobalVariable(10, 7, SpvStorageClassWorkgroup, 0,
+                                      false)};
+
+  for (auto& transformation : transformations) {
+    ASSERT_TRUE(
+        transformation.IsApplicable(context.get(), transformation_context));
+    transformation.Apply(context.get(), &transformation_context);
+  }
+  ASSERT_TRUE(
+      transformation_context.GetFactManager()->PointeeValueIsIrrelevant(8));
+  ASSERT_FALSE(
+      transformation_context.GetFactManager()->PointeeValueIsIrrelevant(10));
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  std::string after_transformation = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %4 "main" %8 %10
+               OpExecutionMode %4 LocalSize 1 1 1
+               OpSource ESSL 310
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Workgroup %6
+         %50 = OpConstant %6 2
+          %8 = OpVariable %7 Workgroup
+         %10 = OpVariable %7 Workgroup
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
                OpReturn
                OpFunctionEnd
   )";


### PR DESCRIPTION
(1) Runtime arrays are turned into fixed-size arrays, by turning
    OpTypeRuntimeArray into OpTypeArray and uses of OpArrayLength into
    uses of the constant used for the length of the fixed-size array.

(2) Atomic instructions are not donated, and uses of their results are
    replaced with uses of constants of the result type.