### PR TITLE
If SPIRV-Headers is in our tree, include it as subproject

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -25,7 +25,17 @@ else()
 endif()
 
 if (IS_DIRECTORY ${SPIRV_HEADER_DIR})
+  # TODO(dneto): We should not be modifying the parent scope.
   set(SPIRV_HEADER_INCLUDE_DIR ${SPIRV_HEADER_DIR}/include PARENT_SCOPE)
+
+  # Add SPIRV-Headers as a sub-project if it isn't already defined.
+  # Do this so enclosing projects can use SPIRV-Headers_SOURCE_DIR to find
+  # headers to include.
+  if (NOT DEFINED SPIRV-Headers_SOURCE_DIR)
+    set(SPIRV_HEADERS_SKIP_INSTALL ON)
+    set(SPIRV_HEADERS_SKIP_EXAMPLES ON)
+    add_subdirectory(${SPIRV_HEADER_DIR})
+  endif()
 else()
   message(FATAL_ERROR
     "SPIRV-Headers was not found - please checkout a copy under external/.")


### PR DESCRIPTION
This allows enclosing projects to use SPIRV-Headers_SOURCE_DIR
to set up in header includes.