### PR TITLE
Validate location assignments

### DIFF
--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -1540,6 +1540,21 @@ spv_result_t CheckBlockDecoration(ValidationState_t& vstate,
   return SPV_SUCCESS;
 }
 
+spv_result_t CheckLocationDecoration(ValidationState_t& vstate,
+                                     const Instruction& inst,
+                                     const Decoration& decoration) {
+  if (inst.opcode() == SpvOpVariable) return SPV_SUCCESS;
+
+  if (decoration.struct_member_index() != Decoration::kInvalidMember &&
+      inst.opcode() == SpvOpTypeStruct) {
+    return SPV_SUCCESS;
+  }
+
+  return vstate.diag(SPV_ERROR_INVALID_ID, &inst)
+         << "Location decoration can only be applied to a variable or member "
+            "of a structure type";
+}
+
 #define PASS_OR_BAIL_AT_LINE(X, LINE)           \
   {                                             \
     spv_result_t e##LINE = (X);                 \
@@ -1589,6 +1604,9 @@ spv_result_t CheckDecorationsFromDecoration(ValidationState_t& vstate) {
         case SpvDecorationBlock:
         case SpvDecorationBufferBlock:
           PASS_OR_BAIL(CheckBlockDecoration(vstate, *inst, decoration));
+          break;
+        case SpvDecorationLocation:
+          PASS_OR_BAIL(CheckLocationDecoration(vstate, *inst, decoration));
           break;
         default:
           break;

--- a/source/val/validate_interfaces.cpp
+++ b/source/val/validate_interfaces.cpp
@@ -191,6 +191,7 @@ spv_result_t GetLocationsForVariable(ValidationState_t& _,
                                      const Instruction* variable,
                                      std::vector<bool>* locations,
                                      std::vector<bool>* output_index1_locations) {
+  const bool is_fragment = entry_point->GetOperandAs<SpvExecutionModel>(0);
   const bool is_output =
       variable->GetOperandAs<SpvStorageClass>(2) == SpvStorageClassOutput;
   auto ptr_type_id = variable->GetOperandAs<uint32_t>(0);
@@ -226,6 +227,10 @@ spv_result_t GetLocationsForVariable(ValidationState_t& _,
       has_component = true;
       component = dec.params()[0];
     } else if (dec.dec_type() == SpvDecorationIndex) {
+      if (!is_output || !is_fragment) {
+        return _.diag(SPV_ERROR_INVALID_DATA, variable)
+          << "Index can only be applied to Fragment output variables";
+      }
       if (has_index && dec.params()[0] != index) {
         return _.diag(SPV_ERROR_INVALID_DATA, variable)
                << "Variable has conflicting index decorations";

--- a/source/val/validate_interfaces.cpp
+++ b/source/val/validate_interfaces.cpp
@@ -102,6 +102,191 @@ spv_result_t check_interface_variable(ValidationState_t& _,
   return SPV_SUCCESS;
 }
 
+// This function assumes a base location has been determined already. As such
+// any location decoration is invalid.
+// TODO: if this code turns out to be slow, there is an opportunity to cache
+// the for a given type id.
+spv_result_t NumConsumedLocations(ValidationState_t& _, const Instruction* type,
+                                  uint32_t* num_locations) {
+  *num_locations = 0;
+  switch (type->opcode()) {
+    case SpvOpTypeInt:
+    case SpvOpTypeFloat:
+      *num_locations = 1;
+      break;
+    case SpvOpTypeVector:
+      if ((_.ContainsSizedIntOrFloatType(type->id(), SpvOpTypeInt, 64) ||
+           _.ContainsSizedIntOrFloatType(type->id(), SpvOpTypeFloat, 64)) &&
+          (type->GetOperandAs<uint32_t>(2) > 2)) {
+        *num_locations = 2;
+      } else {
+        *num_locations = 1;
+      }
+      break;
+    case SpvOpTypeMatrix:
+      NumConsumedLocations(_, _.FindDef(type->GetOperandAs<uint32_t>(1)),
+                           num_locations);
+      *num_locations *= type->GetOperandAs<uint32_t>(2);
+      break;
+    case SpvOpTypeArray: {
+      NumConsumedLocations(_, _.FindDef(type->GetOperandAs<uint32_t>(1)),
+                           num_locations);
+      bool is_int = false;
+      bool is_const = false;
+      uint32_t value = 0;
+      std::tie(is_int, is_const, value) =
+          _.EvalInt32IfConst(type->GetOperandAs<uint32_t>(2));
+      if (is_int && is_const) *num_locations *= value;
+      break;
+    }
+    case SpvOpTypeStruct: {
+      if (_.HasDecoration(type->id(), SpvDecorationLocation)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, type)
+               << "Members cannot be assigned a location";
+      }
+      for (uint32_t i = 1; i < type->operands().size(); ++i) {
+        uint32_t member_locations = 0;
+        if (auto error = NumConsumedLocations(
+                _, _.FindDef(type->GetOperandAs<uint32_t>(i)),
+                &member_locations)) {
+          return error;
+        }
+        *num_locations += member_locations;
+      }
+      break;
+    }
+    default:
+      break;
+  }
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t GetLocationsForVariable(ValidationState_t& _,
+                                     const Instruction* entry_point,
+                                     const Instruction* variable,
+                                     std::unordered_set<uint32_t>* locations) {
+  auto ptr_type_id = variable->GetOperandAs<uint32_t>(0);
+  auto ptr_type = _.FindDef(ptr_type_id);
+  auto type_id = ptr_type->GetOperandAs<uint32_t>(2);
+  auto type = _.FindDef(type_id);
+  // Unpack optional arrayness.
+  if (type->opcode() == SpvOpTypeArray ||
+      type->opcode() == SpvOpTypeRuntimeArray) {
+    type_id = type->GetOperandAs<uint32_t>(1);
+    type = _.FindDef(type_id);
+  }
+  bool has_location = false;
+  uint32_t location = 0;
+  bool is_block = _.HasDecoration(type_id, SpvDecorationBlock);
+  for (auto& dec : _.id_decorations(variable->id())) {
+    if (dec.dec_type() == SpvDecorationLocation) {
+      if (has_location && dec.params()[0] != location) {
+        return _.diag(SPV_ERROR_INVALID_DATA, variable)
+               << "Variable has conflicting location decorations";
+      }
+      has_location = true;
+      location = dec.params()[0];
+    } else if (dec.dec_type() == SpvDecorationBuiltIn) {
+      // Don't check built-ins.
+      return SPV_SUCCESS;
+    }
+  }
+
+  if (type->opcode() == SpvOpTypeStruct) {
+    // Don't check built-ins.
+    if (_.HasDecoration(type_id, SpvDecorationBuiltIn))
+      return SPV_SUCCESS;
+  }
+
+  // Only block-decorated structs don't need a location on the variable.
+  if (!has_location && !is_block) {
+    return _.diag(SPV_ERROR_INVALID_DATA, variable)
+           << "Variable must be decorated with a location";
+  }
+
+  const std::string storage_class =
+      (variable->GetOperandAs<SpvStorageClass>(2) == SpvStorageClassInput)
+          ? "input"
+          : "output";
+  if (has_location) {
+    uint32_t num_locations = 0;
+    if (auto error = NumConsumedLocations(_, type, &num_locations))
+      return error;
+
+    for (uint32_t i = location; i < location + num_locations; ++i) {
+      if (!locations->insert(i).second) {
+        return _.diag(SPV_ERROR_INVALID_DATA, entry_point)
+               << "Entry-point has conflicting " << storage_class
+               << " location assignment at location " << i;
+      }
+    }
+  } else {
+    // For Block-decorated structs with no location assigned to the variable,
+    // each member of the block must be assigned a location.
+    std::unordered_map<uint32_t, uint32_t> member_locations;
+    for (auto& dec : _.id_decorations(type_id)) {
+      if (dec.dec_type() == SpvDecorationLocation) {
+        auto where = member_locations.find(dec.struct_member_index());
+        if (where == member_locations.end()) {
+          member_locations[dec.struct_member_index()] = dec.params()[0];
+        } else if (where->second != dec.params()[0]) {
+          return _.diag(SPV_ERROR_INVALID_DATA, type)
+                 << "Member index " << dec.struct_member_index()
+                 << " has conflicting location assignments";
+        }
+      }
+    }
+
+    for (uint32_t i = 1; i < type->operands().size(); ++i) {
+      auto where = member_locations.find(i - 1);
+      if (where == member_locations.end()) {
+        return _.diag(SPV_ERROR_INVALID_DATA, type)
+               << "Member index " << i - 1
+               << " is missing a location assignment";
+      }
+      location = where->second;
+      auto member = _.FindDef(type->GetOperandAs<uint32_t>(i));
+      uint32_t num_locations = 0;
+      if (auto error = NumConsumedLocations(_, member, &num_locations))
+        return error;
+
+      for (uint32_t l = location; l < location + num_locations; ++l) {
+        if (!locations->insert(l).second) {
+          return _.diag(SPV_ERROR_INVALID_DATA, entry_point)
+                 << "Entry-point has conflicting " << storage_class
+                 << " location assignment at location " << l;
+        }
+      }
+    }
+  }
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t ValidateLocations(ValidationState_t& _, const Instruction* entry_point) {
+  std::unordered_set<uint32_t> input_locations;
+  std::unordered_set<uint32_t> output_locations;
+  for (uint32_t i = 3; i < entry_point->operands().size(); ++i) {
+    auto interface_id = entry_point->GetOperandAs<uint32_t>(i);
+    auto interface_var = _.FindDef(interface_id);
+    auto storage_class = interface_var->GetOperandAs<SpvStorageClass>(2);
+    if (storage_class != SpvStorageClassInput &&
+        storage_class != SpvStorageClassOutput) {
+      continue;
+    }
+
+    auto locations = (storage_class == SpvStorageClassInput)
+                         ? &input_locations
+                         : &output_locations;
+    if (auto error =
+            GetLocationsForVariable(_, entry_point, interface_var, locations))
+      return error;
+  }
+
+  return SPV_SUCCESS;
+}
+
 }  // namespace
 
 spv_result_t ValidateInterfaces(ValidationState_t& _) {
@@ -110,6 +295,14 @@ spv_result_t ValidateInterfaces(ValidationState_t& _) {
     if (is_interface_variable(&inst, is_spv_1_4)) {
       if (auto error = check_interface_variable(_, &inst)) {
         return error;
+      }
+    }
+  }
+
+  if (spvIsVulkanEnv(_.context()->target_env)) {
+    for (auto& inst : _.ordered_instructions()) {
+      if (inst.opcode() == SpvOpEntryPoint) {
+        if (auto error = ValidateLocations(_, &inst)) return error;
       }
     }
   }

--- a/source/val/validate_interfaces.cpp
+++ b/source/val/validate_interfaces.cpp
@@ -476,8 +476,7 @@ spv_result_t ValidateInterfaces(ValidationState_t& _) {
           return error;
         }
       }
-      if (inst.opcode() == SpvOpTypeVoid)
-        break;
+      if (inst.opcode() == SpvOpTypeVoid) break;
     }
   }
 

--- a/test/val/val_builtins_test.cpp
+++ b/test/val/val_builtins_test.cpp
@@ -2532,7 +2532,9 @@ TEST_F(ValidateBuiltIns, GeometryPositionInOutSuccess) {
   CodeGenerator generator = CodeGenerator::GetDefaultShaderCodeGenerator();
 
   generator.before_types_ = R"(
+OpDecorate %input_type Block
 OpMemberDecorate %input_type 0 BuiltIn Position
+OpDecorate %output_type Block
 OpMemberDecorate %output_type 0 BuiltIn Position
 )";
 
@@ -2543,8 +2545,7 @@ OpMemberDecorate %output_type 0 BuiltIn Position
 %input = OpVariable %input_ptr Input
 %input_f32vec4_ptr = OpTypePointer Input %f32vec4
 %output_type = OpTypeStruct %f32vec4
-%arrayed_output_type = OpTypeArray %output_type %u32_3
-%output_ptr = OpTypePointer Output %arrayed_output_type
+%output_ptr = OpTypePointer Output %output_type
 %output = OpVariable %output_ptr Output
 %output_f32vec4_ptr = OpTypePointer Output %f32vec4
 )";
@@ -2555,7 +2556,7 @@ OpMemberDecorate %output_type 0 BuiltIn Position
   entry_point.interfaces = "%input %output";
   entry_point.body = R"(
 %input_pos = OpAccessChain %input_f32vec4_ptr %input %u32_0 %u32_0
-%output_pos = OpAccessChain %output_f32vec4_ptr %output %u32_0 %u32_0
+%output_pos = OpAccessChain %output_f32vec4_ptr %output %u32_0
 %pos = OpLoad %f32vec4 %input_pos
 OpStore %output_pos %pos
 )";

--- a/test/val/val_builtins_test.cpp
+++ b/test/val/val_builtins_test.cpp
@@ -3062,6 +3062,8 @@ TEST_F(ValidateBuiltIns, GetUnderlyingTypeNoAssert) {
                       OpEntryPoint Fragment %4 "PSMa" %12 %17
                       OpExecutionMode %4 OriginUpperLeft
                       OpDecorate %gl_PointCoord BuiltIn PointCoord
+                      OpDecorate %12 Location 0
+                      OpDecorate %17 Location 0
               %void = OpTypeVoid
                  %3 = OpTypeFunction %void
              %float = OpTypeFloat 32

--- a/test/val/val_capability_test.cpp
+++ b/test/val/val_capability_test.cpp
@@ -1367,8 +1367,9 @@ std::make_pair(std::string(kOpenCLMemoryModel) +
           std::vector<std::string>{"GeometryStreams"}),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt Location 0\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpMemberDecorate %struct 0 Location 0\n"
+          "%intt = OpTypeInt 32 0\n"
+          "%struct = OpTypeStruct %intt\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -7097,6 +7097,68 @@ TEST_F(ValidateDecorations, FunctionsWithOpGroupDecorate) {
   EXPECT_EQ(SPV_SUCCESS, ValidateAndRetrieveValidationState());
 }
 
+TEST_F(ValidateDecorations, LocationVariableGood) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %in_var Location 0
+%float = OpTypeFloat 32
+%ptr_input_float = OpTypePointer Input %float
+%in_var = OpVariable %ptr_input_float Input
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateDecorations, LocationStructMemberGood) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpMemberDecorate %struct 0 Location 0
+%float = OpTypeFloat 32
+%struct = OpTypeStruct %float
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateDecorations, LocationStructBad) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %struct Location 0
+%float = OpTypeFloat 32
+%struct = OpTypeStruct %float
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Location decoration can only be applied to a variable "
+                        "or member of a structure type"));
+}
+
+TEST_F(ValidateDecorations, LocationFloatBad) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %float Location 0
+%float = OpTypeFloat 32
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Location decoration can only be applied to a variable "
+                        "or member of a structure type"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools

--- a/test/val/val_interfaces_test.cpp
+++ b/test/val/val_interfaces_test.cpp
@@ -607,9 +607,10 @@ OpFunctionEnd
 
   CompileSuccessfully(text, SPV_ENV_VULKAN_1_0);
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Entry-point has conflicting output location assignment "
-                        "at location 1"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Entry-point has conflicting output location assignment "
+                "at location 1"));
 }
 
 TEST_F(ValidateInterfacesTest,
@@ -1127,7 +1128,8 @@ OpFunctionEnd
               HasSubstr("Variable has conflicting component decorations"));
 }
 
-TEST_F(ValidateInterfacesTest, VulkanLocationsConflictingComponentStructMember) {
+TEST_F(ValidateInterfacesTest,
+       VulkanLocationsConflictingComponentStructMember) {
   const std::string text = R"(
 OpCapability Shader
 OpMemoryModel Logical GLSL450
@@ -1181,12 +1183,14 @@ OpFunctionEnd
 
   CompileSuccessfully(text, SPV_ENV_VULKAN_1_0);
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Entry-point has conflicting output location assignment "
-                        "at location 1"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Entry-point has conflicting output location assignment "
+                "at location 1"));
 }
 
-TEST_F(ValidateInterfacesTest, VulkanLocationsVariableNoConflictDifferentIndex) {
+TEST_F(ValidateInterfacesTest,
+       VulkanLocationsVariableNoConflictDifferentIndex) {
   const std::string text = R"(
 OpCapability Shader
 OpMemoryModel Logical GLSL450

--- a/test/val/val_interfaces_test.cpp
+++ b/test/val/val_interfaces_test.cpp
@@ -1271,6 +1271,91 @@ OpFunctionEnd
       HasSubstr("Index can only be applied to Fragment output variables"));
 }
 
+TEST_F(ValidateInterfacesTest, VulkanLocationsArrayWithComponent) {
+  const std::string text = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %4 "main" %11 %18 %28 %36 %40
+OpExecutionMode %4 OriginUpperLeft
+OpDecorate %11 Location 0
+OpDecorate %18 Component 0
+OpDecorate %18 Location 0
+OpDecorate %28 Component 1
+OpDecorate %28 Location 0
+OpDecorate %36 Location 1
+OpDecorate %40 Component 0
+OpDecorate %40 Location 1
+%void = OpTypeVoid
+%3 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%11 = OpVariable %_ptr_Input_v4float Input
+%_ptr_Output_float = OpTypePointer Output %float
+%18 = OpVariable %_ptr_Output_float Output
+%uint = OpTypeInt 32 0
+%v3float = OpTypeVector %float 3
+%uint_2 = OpConstant %uint 2
+%_arr_v3float_uint_2 = OpTypeArray %v3float %uint_2
+%_ptr_Output__arr_v3float_uint_2 = OpTypePointer Output %_arr_v3float_uint_2
+%28 = OpVariable %_ptr_Output__arr_v3float_uint_2 Output
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+%36 = OpVariable %_ptr_Input_v4float Input
+%40 = OpVariable %_ptr_Output_float Output
+%4 = OpFunction %void None %3
+%5 = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_0);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+}
+
+TEST_F(ValidateInterfacesTest, VulkanLocationsArrayWithComponentBad) {
+  const std::string text = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %4 "main" %11 %18 %28 %36 %40
+OpExecutionMode %4 OriginUpperLeft
+OpDecorate %11 Location 0
+OpDecorate %18 Component 0
+OpDecorate %18 Location 0
+OpDecorate %28 Component 1
+OpDecorate %28 Location 0
+OpDecorate %36 Location 1
+OpDecorate %40 Component 1
+OpDecorate %40 Location 1
+%void = OpTypeVoid
+%3 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%11 = OpVariable %_ptr_Input_v4float Input
+%_ptr_Output_float = OpTypePointer Output %float
+%18 = OpVariable %_ptr_Output_float Output
+%uint = OpTypeInt 32 0
+%v3float = OpTypeVector %float 3
+%uint_2 = OpConstant %uint 2
+%_arr_v3float_uint_2 = OpTypeArray %v3float %uint_2
+%_ptr_Output__arr_v3float_uint_2 = OpTypePointer Output %_arr_v3float_uint_2
+%28 = OpVariable %_ptr_Output__arr_v3float_uint_2 Output
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+%36 = OpVariable %_ptr_Input_v4float Input
+%40 = OpVariable %_ptr_Output_float Output
+%4 = OpFunction %void None %3
+%5 = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_0);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Entry-point has conflicting output location "
+                        "assignment at location 1, component 1"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
Validate that location, component and index decorations do not cause an overlap in any interface.

Checks:
* location can only be applied to variables or structure members
* variable that require a location have one
* index can only be on fragment outputs
* no conflicting location, component, index assignments
  * utility functions calculate the consumed locations and components

Tests include common corners such as a scalar being packed after 3-component 64-bit vector. 

Tested against CTS.