### PR TITLE
spirv-fuzz: Do not replace the Sample argument in OpImageTexelPointer

### DIFF
--- a/source/fuzz/transformation_replace_id_with_synonym.cpp
+++ b/source/fuzz/transformation_replace_id_with_synonym.cpp
@@ -170,6 +170,15 @@ bool TransformationReplaceIdWithSynonym::UseCanBeReplacedWithSynonym(
       return false;
     }
   }
+
+  if (use_instruction->opcode() == SpvOpImageTexelPointer &&
+      use_in_operand_index == 2) {
+    // The OpImageTexelPointer instruction has a Sample parameter that in some
+    // situations must be an id for the value 0.  To guard against disrupting
+    // that requirement, we do not replace this argument to that instruction.
+    return false;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
The Sample argument of OpImageTexelPointer is sometimes required to be
a zero constant.  It thus cannot be replaced with a synonym in
general.  This change avoids replacing this argument with a synonym.