### PR TITLE
spirv-fuzz: Do not allow adding stores to read-only pointers

### DIFF
--- a/source/fuzz/fuzzer_pass_add_stores.cpp
+++ b/source/fuzz/fuzzer_pass_add_stores.cpp
@@ -68,9 +68,10 @@ void FuzzerPassAddStores::Apply() {
                     // Not a pointer.
                     return false;
                   }
-                  if (type_inst->GetSingleWordInOperand(0) ==
-                      SpvStorageClassInput) {
-                    // Read-only: cannot store to it.
+                  if (TransformationStore::StorageClassIsReadOnly(
+                          static_cast<SpvStorageClass>(
+                              type_inst->GetSingleWordInOperand(0)))) {
+                    // Read only: cannot store to it.
                     return false;
                   }
                   switch (instruction->result_id()) {

--- a/source/fuzz/fuzzer_pass_add_stores.cpp
+++ b/source/fuzz/fuzzer_pass_add_stores.cpp
@@ -68,9 +68,7 @@ void FuzzerPassAddStores::Apply() {
                     // Not a pointer.
                     return false;
                   }
-                  if (TransformationStore::StorageClassIsReadOnly(
-                          static_cast<SpvStorageClass>(
-                              type_inst->GetSingleWordInOperand(0)))) {
+                  if (instruction->IsReadOnlyPointer()) {
                     // Read only: cannot store to it.
                     return false;
                   }

--- a/source/fuzz/transformation_store.cpp
+++ b/source/fuzz/transformation_store.cpp
@@ -50,7 +50,8 @@ bool TransformationStore::IsApplicable(
   }
 
   // The pointer must not be read only.
-  if (pointer_type->GetSingleWordInOperand(0) == SpvStorageClassInput) {
+  if (TransformationStore::StorageClassIsReadOnly(static_cast<SpvStorageClass>(
+          pointer_type->GetSingleWordInOperand(0)))) {
     return false;
   }
 
@@ -123,6 +124,19 @@ protobufs::Transformation TransformationStore::ToMessage() const {
   protobufs::Transformation result;
   *result.mutable_store() = message_;
   return result;
+}
+
+bool TransformationStore::StorageClassIsReadOnly(
+    SpvStorageClass storage_class) {
+  switch (storage_class) {
+    case SpvStorageClassInput:
+    case SpvStorageClassPushConstant:
+    case SpvStorageClassUniformConstant:
+      // Read-only: cannot store to it.
+      return true;
+    default:
+      return false;
+  }
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_store.cpp
+++ b/source/fuzz/transformation_store.cpp
@@ -50,8 +50,7 @@ bool TransformationStore::IsApplicable(
   }
 
   // The pointer must not be read only.
-  if (TransformationStore::StorageClassIsReadOnly(static_cast<SpvStorageClass>(
-          pointer_type->GetSingleWordInOperand(0)))) {
+  if (pointer->IsReadOnlyPointer()) {
     return false;
   }
 
@@ -124,19 +123,6 @@ protobufs::Transformation TransformationStore::ToMessage() const {
   protobufs::Transformation result;
   *result.mutable_store() = message_;
   return result;
-}
-
-bool TransformationStore::StorageClassIsReadOnly(
-    SpvStorageClass storage_class) {
-  switch (storage_class) {
-    case SpvStorageClassInput:
-    case SpvStorageClassPushConstant:
-    case SpvStorageClassUniformConstant:
-      // Read-only: cannot store to it.
-      return true;
-    default:
-      return false;
-  }
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_store.h
+++ b/source/fuzz/transformation_store.h
@@ -55,6 +55,9 @@ class TransformationStore : public Transformation {
 
   protobufs::Transformation ToMessage() const override;
 
+  // Helper method to determine whether the given storage class is read-only.
+  static bool StorageClassIsReadOnly(SpvStorageClass storage_class);
+
  private:
   protobufs::TransformationStore message_;
 };

--- a/source/fuzz/transformation_store.h
+++ b/source/fuzz/transformation_store.h
@@ -55,9 +55,6 @@ class TransformationStore : public Transformation {
 
   protobufs::Transformation ToMessage() const override;
 
-  // Helper method to determine whether the given storage class is read-only.
-  static bool StorageClassIsReadOnly(SpvStorageClass storage_class);
-
  private:
   protobufs::TransformationStore message_;
 };


### PR DESCRIPTION
Adds checks for PushConstant and UniformConstant storage classes (in
addition to the existing check for Input storage class).