### PR TITLE
Generalize IsReadOnlyVariable() to apply to pointers

### DIFF
--- a/source/opt/code_sink.cpp
+++ b/source/opt/code_sink.cpp
@@ -177,7 +177,7 @@ bool CodeSinkingPass::ReferencesMutableMemory(Instruction* inst) {
     return true;
   }
 
-  if (base_ptr->IsReadOnlyVariable()) {
+  if (base_ptr->IsReadOnlyPointer()) {
     return false;
   }
 

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -415,7 +415,7 @@ bool Instruction::IsVulkanUniformBuffer() const {
 }
 
 bool Instruction::IsReadOnlyPointerShaders() const {
-  if (!type_id()) {
+  if (type_id() == 0) {
     return false;
   }
 
@@ -454,7 +454,7 @@ bool Instruction::IsReadOnlyPointerShaders() const {
 }
 
 bool Instruction::IsReadOnlyPointerKernel() const {
-  if (!type_id()) {
+  if (type_id() == 0) {
     return false;
   }
 

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -29,7 +29,7 @@ namespace {
 // Indices used to get particular operands out of instructions using InOperand.
 const uint32_t kTypeImageDimIndex = 1;
 const uint32_t kLoadBaseIndex = 0;
-const uint32_t kVariableStorageClassIndex = 0;
+const uint32_t kPointerTypeStorageClassIndex = 0;
 const uint32_t kTypeImageSampledIndex = 5;
 
 // Constants for OpenCL.DebugInfo.100 extension instructions.
@@ -187,7 +187,7 @@ bool Instruction::IsReadOnlyLoad() const {
     }
 
     if (address_def->opcode() == SpvOpVariable) {
-      if (address_def->IsReadOnlyVariable()) {
+      if (address_def->IsReadOnlyPointer()) {
         return true;
       }
     }
@@ -232,11 +232,11 @@ Instruction* Instruction::GetBaseAddress() const {
   return base_inst;
 }
 
-bool Instruction::IsReadOnlyVariable() const {
+bool Instruction::IsReadOnlyPointer() const {
   if (context()->get_feature_mgr()->HasCapability(SpvCapabilityShader))
-    return IsReadOnlyVariableShaders();
+    return IsReadOnlyPointerShaders();
   else
-    return IsReadOnlyVariableKernel();
+    return IsReadOnlyPointerKernel();
 }
 
 bool Instruction::IsVulkanStorageImage() const {
@@ -244,7 +244,8 @@ bool Instruction::IsVulkanStorageImage() const {
     return false;
   }
 
-  uint32_t storage_class = GetSingleWordInOperand(kVariableStorageClassIndex);
+  uint32_t storage_class =
+      GetSingleWordInOperand(kPointerTypeStorageClassIndex);
   if (storage_class != SpvStorageClassUniformConstant) {
     return false;
   }
@@ -278,7 +279,8 @@ bool Instruction::IsVulkanSampledImage() const {
     return false;
   }
 
-  uint32_t storage_class = GetSingleWordInOperand(kVariableStorageClassIndex);
+  uint32_t storage_class =
+      GetSingleWordInOperand(kPointerTypeStorageClassIndex);
   if (storage_class != SpvStorageClassUniformConstant) {
     return false;
   }
@@ -312,7 +314,8 @@ bool Instruction::IsVulkanStorageTexelBuffer() const {
     return false;
   }
 
-  uint32_t storage_class = GetSingleWordInOperand(kVariableStorageClassIndex);
+  uint32_t storage_class =
+      GetSingleWordInOperand(kPointerTypeStorageClassIndex);
   if (storage_class != SpvStorageClassUniformConstant) {
     return false;
   }
@@ -361,7 +364,8 @@ bool Instruction::IsVulkanStorageBuffer() const {
     return false;
   }
 
-  uint32_t storage_class = GetSingleWordInOperand(kVariableStorageClassIndex);
+  uint32_t storage_class =
+      GetSingleWordInOperand(kPointerTypeStorageClassIndex);
   if (storage_class == SpvStorageClassUniform) {
     bool is_buffer_block = false;
     context()->get_decoration_mgr()->ForEachDecoration(
@@ -383,7 +387,8 @@ bool Instruction::IsVulkanUniformBuffer() const {
     return false;
   }
 
-  uint32_t storage_class = GetSingleWordInOperand(kVariableStorageClassIndex);
+  uint32_t storage_class =
+      GetSingleWordInOperand(kPointerTypeStorageClassIndex);
   if (storage_class != SpvStorageClassUniform) {
     return false;
   }
@@ -409,9 +414,18 @@ bool Instruction::IsVulkanUniformBuffer() const {
   return is_block;
 }
 
-bool Instruction::IsReadOnlyVariableShaders() const {
-  uint32_t storage_class = GetSingleWordInOperand(kVariableStorageClassIndex);
+bool Instruction::IsReadOnlyPointerShaders() const {
+  if (!type_id()) {
+    return false;
+  }
+
   Instruction* type_def = context()->get_def_use_mgr()->GetDef(type_id());
+  if (type_def->opcode() != SpvOpTypePointer) {
+    return false;
+  }
+
+  uint32_t storage_class =
+      type_def->GetSingleWordInOperand(kPointerTypeStorageClassIndex);
 
   switch (storage_class) {
     case SpvStorageClassUniformConstant:
@@ -439,8 +453,19 @@ bool Instruction::IsReadOnlyVariableShaders() const {
   return is_nonwritable;
 }
 
-bool Instruction::IsReadOnlyVariableKernel() const {
-  uint32_t storage_class = GetSingleWordInOperand(kVariableStorageClassIndex);
+bool Instruction::IsReadOnlyPointerKernel() const {
+  if (!type_id()) {
+    return false;
+  }
+
+  Instruction* type_def = context()->get_def_use_mgr()->GetDef(type_id());
+  if (type_def->opcode() != SpvOpTypePointer) {
+    return false;
+  }
+
+  uint32_t storage_class =
+      type_def->GetSingleWordInOperand(kPointerTypeStorageClassIndex);
+
   return storage_class == SpvStorageClassUniformConstant;
 }
 

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -396,8 +396,8 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   // Memory-to-memory instructions are not considered loads.
   inline bool IsLoad() const;
 
-  // Returns true if the instruction declares a variable that is read-only.
-  bool IsReadOnlyVariable() const;
+  // Returns true if the instruction generates a read-only pointer.
+  bool IsReadOnlyPointer() const;
 
   // The following functions check for the various descriptor types defined in
   // the Vulkan specification section 13.1.
@@ -526,11 +526,11 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
     return 0;
   }
 
-  // Returns true if the instruction declares a variable that is read-only.  The
-  // first version assumes the module is a shader module.  The second assumes a
+  // Returns true if the instruction generates a read-only pointer.  The first
+  // version assumes the module is a shader module.  The second assumes a
   // kernel.
-  bool IsReadOnlyVariableShaders() const;
-  bool IsReadOnlyVariableKernel() const;
+  bool IsReadOnlyPointerShaders() const;
+  bool IsReadOnlyPointerKernel() const;
 
   // Returns true if the result of |inst| can be used as the base image for an
   // instruction that samples a image, reads an image, or writes to an image.

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -396,7 +396,13 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   // Memory-to-memory instructions are not considered loads.
   inline bool IsLoad() const;
 
-  // Returns true if the instruction generates a read-only pointer.
+  // Returns true if the instruction generates a pointer that is definitely
+  // read-only.  This is determined by analysing the pointer type's storage
+  // class and decorations that target the pointer's id.  It does not analyse
+  // other instructions that the pointer may be derived from.  Thus if 'true' is
+  // returned, the pointer is definitely read-only, while if 'false' is returned
+  // it is possible that the pointer may actually be read-only if it is derived
+  // from another pointer that is decorated as read-only.
   bool IsReadOnlyPointer() const;
 
   // The following functions check for the various descriptor types defined in
@@ -526,7 +532,8 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
     return 0;
   }
 
-  // Returns true if the instruction generates a read-only pointer.  The first
+  // Returns true if the instruction generates a read-only pointer, with the
+  // same caveats documented in the comment for IsReadOnlyPointer.  The first
   // version assumes the module is a shader module.  The second assumes a
   // kernel.
   bool IsReadOnlyPointerShaders() const;

--- a/test/opt/instruction_test.cpp
+++ b/test/opt/instruction_test.cpp
@@ -353,7 +353,7 @@ TEST_F(DescriptorTypeTest, StorageImage) {
   EXPECT_FALSE(type->IsVulkanUniformBuffer());
 
   Instruction* variable = context->get_def_use_mgr()->GetDef(3);
-  EXPECT_FALSE(variable->IsReadOnlyVariable());
+  EXPECT_FALSE(variable->IsReadOnlyPointer());
 }
 
 TEST_F(DescriptorTypeTest, SampledImage) {
@@ -389,7 +389,7 @@ TEST_F(DescriptorTypeTest, SampledImage) {
   EXPECT_FALSE(type->IsVulkanUniformBuffer());
 
   Instruction* variable = context->get_def_use_mgr()->GetDef(3);
-  EXPECT_TRUE(variable->IsReadOnlyVariable());
+  EXPECT_TRUE(variable->IsReadOnlyPointer());
 }
 
 TEST_F(DescriptorTypeTest, StorageTexelBuffer) {
@@ -425,7 +425,7 @@ TEST_F(DescriptorTypeTest, StorageTexelBuffer) {
   EXPECT_FALSE(type->IsVulkanUniformBuffer());
 
   Instruction* variable = context->get_def_use_mgr()->GetDef(3);
-  EXPECT_FALSE(variable->IsReadOnlyVariable());
+  EXPECT_FALSE(variable->IsReadOnlyPointer());
 }
 
 TEST_F(DescriptorTypeTest, StorageBuffer) {
@@ -464,7 +464,7 @@ TEST_F(DescriptorTypeTest, StorageBuffer) {
   EXPECT_FALSE(type->IsVulkanUniformBuffer());
 
   Instruction* variable = context->get_def_use_mgr()->GetDef(3);
-  EXPECT_FALSE(variable->IsReadOnlyVariable());
+  EXPECT_FALSE(variable->IsReadOnlyPointer());
 }
 
 TEST_F(DescriptorTypeTest, UniformBuffer) {
@@ -503,7 +503,7 @@ TEST_F(DescriptorTypeTest, UniformBuffer) {
   EXPECT_TRUE(type->IsVulkanUniformBuffer());
 
   Instruction* variable = context->get_def_use_mgr()->GetDef(3);
-  EXPECT_TRUE(variable->IsReadOnlyVariable());
+  EXPECT_TRUE(variable->IsReadOnlyPointer());
 }
 
 TEST_F(DescriptorTypeTest, NonWritableIsReadOnly) {
@@ -536,7 +536,7 @@ TEST_F(DescriptorTypeTest, NonWritableIsReadOnly) {
   std::unique_ptr<IRContext> context =
       BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text);
   Instruction* variable = context->get_def_use_mgr()->GetDef(3);
-  EXPECT_TRUE(variable->IsReadOnlyVariable());
+  EXPECT_TRUE(variable->IsReadOnlyPointer());
 }
 
 TEST_F(OpaqueTypeTest, BaseOpaqueTypesShader) {

--- a/test/opt/instruction_test.cpp
+++ b/test/opt/instruction_test.cpp
@@ -569,7 +569,7 @@ TEST_F(DescriptorTypeTest, NonWritableIsReadOnly) {
 TEST_F(DescriptorTypeTest, AccessChainIntoReadOnlyStructIsReadOnly) {
   const std::string text = R"(
                OpCapability Shader
-          %1 = OpExt  InstImport "GLSL.std.450"
+          %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %2 "main"
                OpExecutionMode %2 OriginUpperLeft

--- a/test/opt/instruction_test.cpp
+++ b/test/opt/instruction_test.cpp
@@ -560,8 +560,8 @@ TEST_F(DescriptorTypeTest, NonWritableIsReadOnly) {
   EXPECT_TRUE(variable->IsReadOnlyPointer());
 
   // This demonstrates that the check for whether a pointer is read-only is not
-  // precise: copying a NonWritable-decorated variable can lead to a pointer
-  // that the check does not regard as read-only.
+  // precise: copying a NonWritable-decorated variable can yield a pointer that
+  // the check does not regard as read-only.
   Instruction* object_copy = context->get_def_use_mgr()->GetDef(12);
   EXPECT_FALSE(object_copy->IsReadOnlyPointer());
 }

--- a/test/opt/instruction_test.cpp
+++ b/test/opt/instruction_test.cpp
@@ -559,14 +559,17 @@ TEST_F(DescriptorTypeTest, NonWritableIsReadOnly) {
   Instruction* variable = context->get_def_use_mgr()->GetDef(3);
   EXPECT_TRUE(variable->IsReadOnlyPointer());
 
+  // This demonstrates that the check for whether a pointer is read-only is not
+  // precise: copying a NonWritable-decorated variable can lead to a pointer
+  // that the check does not regard as read-only.
   Instruction* object_copy = context->get_def_use_mgr()->GetDef(12);
-  EXPECT_TRUE(object_copy->IsReadOnlyPointer());
+  EXPECT_FALSE(object_copy->IsReadOnlyPointer());
 }
 
 TEST_F(DescriptorTypeTest, AccessChainIntoReadOnlyStructIsReadOnly) {
   const std::string text = R"(
                OpCapability Shader
-          %1 = OpExtInstImport "GLSL.std.450"
+          %1 = OpExt  InstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %2 "main"
                OpExecutionMode %2 OriginUpperLeft


### PR DESCRIPTION
Generalizes the IsReadOnlyVariable() method, and related methods, so
that they can be used to ask whether pointer result ids are read-only.

Fixes #3324.