### PR TITLE
Delete nullptr in function bb list immediately

### DIFF
--- a/kokoro/scripts/linux/build.sh
+++ b/kokoro/scripts/linux/build.sh
@@ -46,7 +46,7 @@ fi
 ADDITIONAL_CMAKE_FLAGS=""
 if [ $CONFIG = "ASAN" ]
 then
-  ADDITIONAL_CMAKE_FLAGS="SPIRV_USE_SANITIZER=address"
+  ADDITIONAL_CMAKE_FLAGS="SPIRV_USE_SANITIZER=address,bounds,null"
   [ $COMPILER = "clang" ] || { echo "$CONFIG requires clang"; exit 1; }
 elif [ $CONFIG = "COVERAGE" ]
 then

--- a/source/opt/function.h
+++ b/source/opt/function.h
@@ -192,13 +192,13 @@ inline void Function::AddBasicBlocks(T src_begin, T src_end, iterator ip) {
 }
 
 inline void Function::MoveBasicBlockToAfter(uint32_t id, BasicBlock* ip) {
-  auto block_to_move = std::move(*FindBlock(id).Get());
+  std::unique_ptr<BasicBlock> block_to_move = std::move(*FindBlock(id).Get());
+  blocks_.erase(std::find(std::begin(blocks_), std::end(blocks_), nullptr));
 
   assert(block_to_move->GetParent() == ip->GetParent() &&
          "Both blocks have to be in the same function.");
 
   InsertBasicBlockAfter(std::move(block_to_move), ip);
-  blocks_.erase(std::find(std::begin(blocks_), std::end(blocks_), nullptr));
 }
 
 inline void Function::RemoveEmptyBlocks() {


### PR DESCRIPTION
When moving blocks around, we ended up with a nullptr for a basic block,
and it was left in the list for a little bit.  However, in that time, it
would end up being dereferenced while traversing the function.

To fix this, we delete it right away.  This was found in an asan build
that runs our current tests.  No new tests are needed, but I did add
extra check asan checks for our asan bot.