### PR TITLE
[spirv-opt] refactor inlining pass

### DIFF
--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -585,7 +585,7 @@ bool InlinePass::IsInlinableFunctionCall(const Instruction* inst) {
     // We rely on the merge-return pass to handle the early return case
     // in advance.
     std::string message =
-        "The function '%" + std::to_string(calleeFnId) +
+        "The function '" + id2function_[calleeFnId]->DefInst().PrettyPrint() +
         "' could not be inlined because the return instruction "
         "is not at the end of the function. This could be fixed by "
         "running merge-return before inlining.";

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -339,7 +339,7 @@ bool InlinePass::InlineInstructionInBB(
   // Copy callee instruction and remap all input Ids.
   std::unique_ptr<Instruction> cp_inst(inst->Clone(context()));
   bool succeeded =
-      cp_inst->WhileEachInId([&callee2caller, this](uint32_t* iid) {
+      cp_inst->WhileEachInId([&callee2caller](uint32_t* iid) {
         const auto mapItr = callee2caller->find(*iid);
         if (mapItr != callee2caller->end()) {
           *iid = mapItr->second;

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -257,6 +257,21 @@ bool InlinePass::GenInlineCode(
   auto fi = early_return_funcs_.find(calleeFn->result_id());
   const bool earlyReturn = fi != early_return_funcs_.end();
 
+  // If the caller is a loop header and the callee has multiple blocks, then the
+  // normal inlining logic will place the OpLoopMerge in the last of several
+  // blocks in the loop.  Instead, it should be placed at the end of the first
+  // block.  We'll wait to move the OpLoopMerge until the end of the regular
+  // inlining logic, and only if necessary.
+  bool caller_is_loop_header = false;
+  if (call_block_itr->GetLoopMergeInst()) {
+    caller_is_loop_header = true;
+  }
+
+  bool callee_begins_with_structured_header =
+      (*(calleeFn->begin())).GetMergeInst() != nullptr;
+
+  std::unique_ptr<BasicBlock> single_trip_loop_cont_blk;
+
   // Map parameters to actual arguments.
   MapParams(calleeFn, call_inst_itr, &callee2caller);
 
@@ -264,6 +279,108 @@ bool InlinePass::GenInlineCode(
   // them.
   if (!CloneAndMapLocals(calleeFn, new_vars, &callee2caller)) {
     return false;
+  }
+
+  // new_blk_ptr is a new basic block in the caller.  New instructions are
+  // written to it.  It is created when we encounter the OpLabel
+  // of the first callee block.  It is appended to new_blocks only when
+  // it is complete.
+  std::unique_ptr<BasicBlock> new_blk_ptr;
+  uint32_t returnLabelId = 0;
+  bool multiBlocks = false;
+  {
+    auto callee_block_itr = calleeFn->begin();
+
+    // First block needs to use label of original block
+    // but map callee label in case of phi reference.
+    uint32_t labelId = call_block_itr->id();
+    callee2caller[callee_block_itr->GetLabelInst()->result_id()] = labelId;
+    new_blk_ptr = MakeUnique<BasicBlock>(NewLabel(labelId));
+
+    // Copy contents of original caller block up to call instruction.
+    for (auto cii = call_block_itr->begin(); cii != call_inst_itr;
+         cii = call_block_itr->begin()) {
+      Instruction* inst = &*cii;
+      inst->RemoveFromList();
+      std::unique_ptr<Instruction> cp_inst(inst);
+      // Remember same-block ops for possible regeneration.
+      if (IsSameBlockOp(&*cp_inst)) {
+        auto* sb_inst_ptr = cp_inst.get();
+        preCallSB[cp_inst->result_id()] = sb_inst_ptr;
+      }
+      new_blk_ptr->AddInstruction(std::move(cp_inst));
+    }
+
+    if (caller_is_loop_header && callee_begins_with_structured_header) {
+      // We can't place both the caller's merge instruction and
+      // another merge instruction in the same block.  So split the
+      // calling block. Insert an unconditional branch to a new guard
+      // block.  Later, once we know the ID of the last block,  we
+      // will move the caller's OpLoopMerge from the last generated
+      // block into the first block. We also wait to avoid
+      // invalidating various iterators.
+      const auto guard_block_id = context()->TakeNextId();
+      if (guard_block_id == 0) {
+        return false;
+      }
+      AddBranch(guard_block_id, &new_blk_ptr);
+      new_blocks->push_back(std::move(new_blk_ptr));
+      // Start the next block.
+      new_blk_ptr = MakeUnique<BasicBlock>(NewLabel(guard_block_id));
+      // Reset the mapping of the callee's entry block to point to
+      // the guard block.  Do this so we can fix up phis later on to
+      // satisfy dominance.
+      callee2caller[callee_block_itr->GetLabelInst()->result_id()] =
+          guard_block_id;
+    }
+    // If callee has early return, insert a header block for
+    // single-trip loop that will encompass callee code.  Start
+    // postheader block.
+    //
+    // Note: Consider the following combination:
+    //  - the caller is a single block loop
+    //  - the callee does not begin with a structure header
+    //  - the callee has multiple returns.
+    // We still need to split the caller block and insert a guard
+    // block. But we only need to do it once. We haven't done it yet,
+    // but the single-trip loop header will serve the same purpose.
+    if (earlyReturn) {
+      uint32_t singleTripLoopHeaderId = context()->TakeNextId();
+      if (singleTripLoopHeaderId == 0) {
+        return false;
+      }
+      AddBranch(singleTripLoopHeaderId, &new_blk_ptr);
+      new_blocks->push_back(std::move(new_blk_ptr));
+      new_blk_ptr = MakeUnique<BasicBlock>(NewLabel(singleTripLoopHeaderId));
+      returnLabelId = context()->TakeNextId();
+      uint32_t singleTripLoopContinueId = context()->TakeNextId();
+      if (returnLabelId == 0 || singleTripLoopContinueId == 0) {
+        return false;
+      }
+      AddLoopMerge(returnLabelId, singleTripLoopContinueId, &new_blk_ptr);
+      uint32_t postHeaderId = context()->TakeNextId();
+      if (postHeaderId == 0) {
+        return false;
+      }
+      AddBranch(postHeaderId, &new_blk_ptr);
+      new_blocks->push_back(std::move(new_blk_ptr));
+      new_blk_ptr = MakeUnique<BasicBlock>(NewLabel(postHeaderId));
+      multiBlocks = true;
+      // Reset the mapping of the callee's entry block to point to
+      // the post-header block.  Do this so we can fix up phis later
+      // on to satisfy dominance.
+      callee2caller[callee_block_itr->GetLabelInst()->result_id()] =
+          postHeaderId;
+
+      single_trip_loop_cont_blk =
+          MakeUnique<BasicBlock>(NewLabel(singleTripLoopContinueId));
+      uint32_t false_id = GetFalseId();
+      if (false_id == 0) {
+        return false;
+      }
+      AddBranchCond(false_id, singleTripLoopHeaderId, returnLabelId,
+                    &single_trip_loop_cont_blk);
+    }
   }
 
   // Create return var if needed.
@@ -284,37 +401,15 @@ bool InlinePass::GenInlineCode(
     if (rid != 0) callee_result_ids.insert(rid);
   });
 
-  // If the caller is a loop header and the callee has multiple blocks, then the
-  // normal inlining logic will place the OpLoopMerge in the last of several
-  // blocks in the loop.  Instead, it should be placed at the end of the first
-  // block.  We'll wait to move the OpLoopMerge until the end of the regular
-  // inlining logic, and only if necessary.
-  bool caller_is_loop_header = false;
-  if (call_block_itr->GetLoopMergeInst()) {
-    caller_is_loop_header = true;
-  }
-
-  bool callee_begins_with_structured_header =
-      (*(calleeFn->begin())).GetMergeInst() != nullptr;
-
   // Clone and map callee code. Copy caller block code to beginning of
   // first block and end of last block.
   bool prevInstWasReturn = false;
-  uint32_t singleTripLoopHeaderId = 0;
-  uint32_t singleTripLoopContinueId = 0;
-  uint32_t returnLabelId = 0;
-  bool multiBlocks = false;
-  // new_blk_ptr is a new basic block in the caller.  New instructions are
-  // written to it.  It is created when we encounter the OpLabel
-  // of the first callee block.  It is appended to new_blocks only when
-  // it is complete.
-  std::unique_ptr<BasicBlock> new_blk_ptr;
   bool successful = calleeFn->WhileEachInst(
       [&new_blocks, &callee2caller, &call_block_itr, &call_inst_itr,
        &new_blk_ptr, &prevInstWasReturn, &returnLabelId, &returnVarId,
        caller_is_loop_header, callee_begins_with_structured_header,
        &calleeTypeId, &multiBlocks, &postCallSB, &preCallSB, earlyReturn,
-       &singleTripLoopHeaderId, &singleTripLoopContinueId, &callee_result_ids,
+       &callee_result_ids, &single_trip_loop_cont_blk, &calleeFn,
        this](const Instruction* cpi) {
         switch (cpi->opcode()) {
           case SpvOpFunction:
@@ -349,6 +444,11 @@ bool InlinePass::GenInlineCode(
             break;
           }
           case SpvOpLabel: {
+            // Skip the first block.
+            if (cpi->result_id() ==
+                calleeFn->begin()->GetLabelInst()->result_id())
+              return true;
+
             // If previous instruction was early return, insert branch
             // instruction to return block.
             if (prevInstWasReturn) {
@@ -363,7 +463,6 @@ bool InlinePass::GenInlineCode(
             }
             // Finish current block (if it exists) and get label for next block.
             uint32_t labelId;
-            bool firstBlock = false;
             if (new_blk_ptr != nullptr) {
               new_blocks->push_back(std::move(new_blk_ptr));
               // If result id is already mapped, use it, otherwise get a new
@@ -376,94 +475,10 @@ bool InlinePass::GenInlineCode(
               if (labelId == 0) {
                 return false;
               }
-            } else {
-              // First block needs to use label of original block
-              // but map callee label in case of phi reference.
-              labelId = call_block_itr->id();
-              callee2caller[cpi->result_id()] = labelId;
-              firstBlock = true;
             }
             // Create first/next block.
             new_blk_ptr = MakeUnique<BasicBlock>(NewLabel(labelId));
-            if (firstBlock) {
-              // Copy contents of original caller block up to call instruction.
-              for (auto cii = call_block_itr->begin(); cii != call_inst_itr;
-                   cii = call_block_itr->begin()) {
-                Instruction* inst = &*cii;
-                inst->RemoveFromList();
-                std::unique_ptr<Instruction> cp_inst(inst);
-                // Remember same-block ops for possible regeneration.
-                if (IsSameBlockOp(&*cp_inst)) {
-                  auto* sb_inst_ptr = cp_inst.get();
-                  preCallSB[cp_inst->result_id()] = sb_inst_ptr;
-                }
-                new_blk_ptr->AddInstruction(std::move(cp_inst));
-              }
-              if (caller_is_loop_header &&
-                  callee_begins_with_structured_header) {
-                // We can't place both the caller's merge instruction and
-                // another merge instruction in the same block.  So split the
-                // calling block. Insert an unconditional branch to a new guard
-                // block.  Later, once we know the ID of the last block,  we
-                // will move the caller's OpLoopMerge from the last generated
-                // block into the first block. We also wait to avoid
-                // invalidating various iterators.
-                const auto guard_block_id = context()->TakeNextId();
-                if (guard_block_id == 0) {
-                  return false;
-                }
-                AddBranch(guard_block_id, &new_blk_ptr);
-                new_blocks->push_back(std::move(new_blk_ptr));
-                // Start the next block.
-                new_blk_ptr = MakeUnique<BasicBlock>(NewLabel(guard_block_id));
-                // Reset the mapping of the callee's entry block to point to
-                // the guard block.  Do this so we can fix up phis later on to
-                // satisfy dominance.
-                callee2caller[cpi->result_id()] = guard_block_id;
-              }
-              // If callee has early return, insert a header block for
-              // single-trip loop that will encompass callee code.  Start
-              // postheader block.
-              //
-              // Note: Consider the following combination:
-              //  - the caller is a single block loop
-              //  - the callee does not begin with a structure header
-              //  - the callee has multiple returns.
-              // We still need to split the caller block and insert a guard
-              // block. But we only need to do it once. We haven't done it yet,
-              // but the single-trip loop header will serve the same purpose.
-              if (earlyReturn) {
-                singleTripLoopHeaderId = context()->TakeNextId();
-                if (singleTripLoopHeaderId == 0) {
-                  return false;
-                }
-                AddBranch(singleTripLoopHeaderId, &new_blk_ptr);
-                new_blocks->push_back(std::move(new_blk_ptr));
-                new_blk_ptr =
-                    MakeUnique<BasicBlock>(NewLabel(singleTripLoopHeaderId));
-                returnLabelId = context()->TakeNextId();
-                singleTripLoopContinueId = context()->TakeNextId();
-                if (returnLabelId == 0 || singleTripLoopContinueId == 0) {
-                  return false;
-                }
-                AddLoopMerge(returnLabelId, singleTripLoopContinueId,
-                             &new_blk_ptr);
-                uint32_t postHeaderId = context()->TakeNextId();
-                if (postHeaderId == 0) {
-                  return false;
-                }
-                AddBranch(postHeaderId, &new_blk_ptr);
-                new_blocks->push_back(std::move(new_blk_ptr));
-                new_blk_ptr = MakeUnique<BasicBlock>(NewLabel(postHeaderId));
-                multiBlocks = true;
-                // Reset the mapping of the callee's entry block to point to
-                // the post-header block.  Do this so we can fix up phis later
-                // on to satisfy dominance.
-                callee2caller[cpi->result_id()] = postHeaderId;
-              }
-            } else {
-              multiBlocks = true;
-            }
+            multiBlocks = true;
           } break;
           case SpvOpReturnValue: {
             // Store return value to return variable.
@@ -497,14 +512,7 @@ bool InlinePass::GenInlineCode(
                 // target block now, with a false branch back to the loop
                 // header.
                 new_blocks->push_back(std::move(new_blk_ptr));
-                new_blk_ptr =
-                    MakeUnique<BasicBlock>(NewLabel(singleTripLoopContinueId));
-                uint32_t false_id = GetFalseId();
-                if (false_id == 0) {
-                  return false;
-                }
-                AddBranchCond(false_id, singleTripLoopHeaderId, returnLabelId,
-                              &new_blk_ptr);
+                new_blk_ptr = std::move(single_trip_loop_cont_blk);
               }
               // Generate the return block.
               new_blocks->push_back(std::move(new_blk_ptr));

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -196,16 +196,6 @@ class InlinePass : public Pass {
       uint32_t* returnLabelId, std::unique_ptr<BasicBlock> new_blk_ptr,
       uint32_t entry_blk_label_id);
 
-  // Moves instructions of the caller function up to the call instruction.
-  std::unique_ptr<BasicBlock> InlineInstsBeforeEntryBlock(
-      std::vector<std::unique_ptr<BasicBlock>>* new_blocks,
-      std::unordered_map<uint32_t, uint32_t>* callee2caller,
-      std::unordered_map<uint32_t, Instruction*>* preCallSB,
-      std::unique_ptr<BasicBlock>* single_trip_loop_cont_blk,
-      uint32_t* returnLabelId, BasicBlock::iterator call_inst_itr,
-      UptrVectorIterator<BasicBlock> call_block_itr, bool caller_is_loop_header,
-      Function* calleeFn);
-
   // Add store instructions for initializers of variables.
   InstructionList::iterator AddStoresForVariableInitializers(
       std::unordered_map<uint32_t, uint32_t>* callee2caller,

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -196,23 +196,43 @@ class InlinePass : public Pass {
       uint32_t* returnLabelId, std::unique_ptr<BasicBlock> new_blk_ptr,
       uint32_t entry_blk_label_id);
 
-  // Add store instructions for initializers of variables
-  void AddStoresForVariableInitializers(
-      std::unordered_map<uint32_t, uint32_t>* callee2caller,
-      std::unique_ptr<BasicBlock>* new_blk_ptr,
-      UptrVectorIterator<BasicBlock> callee_block_itr);
-
-  // Inlines the entry block of the callee function and instructions of the
-  // caller function up to the call instruction.
-  std::unique_ptr<BasicBlock> InlineEntryBlock(
+  // Inlines instructions of the caller function up to the call instruction.
+  std::unique_ptr<BasicBlock> InlineInstsBeforeEntryBlock(
       std::vector<std::unique_ptr<BasicBlock>>* new_blocks,
-      std::vector<std::unique_ptr<Instruction>>* new_vars,
       std::unordered_map<uint32_t, uint32_t>* callee2caller,
       std::unordered_map<uint32_t, Instruction*>* preCallSB,
       std::unique_ptr<BasicBlock>* single_trip_loop_cont_blk,
       uint32_t* returnLabelId, BasicBlock::iterator call_inst_itr,
-      UptrVectorIterator<BasicBlock> call_block_itr,
-      bool caller_is_loop_header);
+      UptrVectorIterator<BasicBlock> call_block_itr, bool caller_is_loop_header,
+      Function* calleeFn);
+
+  // Add store instructions for initializers of variables.
+  InstructionList::iterator AddStoresForVariableInitializers(
+      std::unordered_map<uint32_t, uint32_t>* callee2caller,
+      std::unique_ptr<BasicBlock>* new_blk_ptr,
+      UptrVectorIterator<BasicBlock> callee_block_itr);
+
+  // Inlines a single instruction of the callee function.
+  bool InlineInstructionInBB(
+      std::unordered_map<uint32_t, uint32_t>* callee2caller,
+      BasicBlock* new_blk_ptr, const Instruction* inst,
+      const std::unordered_set<uint32_t>& callee_result_ids);
+
+  // Inlines a single termination instruction of the callee function.
+  bool InlineTerminationInstructionInBB(
+      std::unordered_map<uint32_t, uint32_t>* callee2caller,
+      std::unique_ptr<BasicBlock>* new_blk_ptr, uint32_t* returnLabelId,
+      bool* prevInstWasReturn, const Instruction* inst,
+      const std::unordered_set<uint32_t>& callee_result_ids,
+      uint32_t returnVarId);
+
+  // Inlines the entry block of the callee function.
+  bool InlineEntryBlock(std::unordered_map<uint32_t, uint32_t>* callee2caller,
+                        std::unique_ptr<BasicBlock>* new_blk_ptr,
+                        uint32_t* returnLabelId, bool* prevInstWasReturn,
+                        Function* calleeFn,
+                        const std::unordered_set<uint32_t>& callee_result_ids,
+                        uint32_t returnVarId);
 };
 
 }  // namespace opt

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -173,9 +173,9 @@ class InlinePass : public Pass {
   std::unordered_set<uint32_t> funcs_called_from_continue_;
 
  private:
-  // Copies instructions of the caller function up to the call instruction
+  // Moves instructions of the caller function up to the call instruction
   // to |new_blk_ptr|.
-  void CopyInstsBeforeEntryBlock(
+  void MoveInstsBeforeEntryBlock(
       std::unordered_map<uint32_t, Instruction*>* preCallSB,
       BasicBlock* new_blk_ptr, BasicBlock::iterator call_inst_itr,
       UptrVectorIterator<BasicBlock> call_block_itr);
@@ -240,9 +240,9 @@ class InlinePass : public Pass {
       const std::unordered_set<uint32_t>& callee_result_ids,
       uint32_t returnVarId);
 
-  // Copies instructions of the caller function after the call instruction
+  // Moves instructions of the caller function after the call instruction
   // to |new_blk_ptr|.
-  bool CopyCallerInstsAfterFunctionCall(
+  bool MoveCallerInstsAfterFunctionCall(
       std::unordered_map<uint32_t, Instruction*>* preCallSB,
       std::unordered_map<uint32_t, uint32_t>* postCallSB,
       std::unique_ptr<BasicBlock>* new_blk_ptr,

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -124,9 +124,9 @@ class InlinePass : public Pass {
   // Return true if |inst| is a function call that can be inlined.
   bool IsInlinableFunctionCall(const Instruction* inst);
 
-  // Return true if |func| does not have a return that is
-  // nested in a structured if, switch or loop.
-  bool HasNoReturnInStructuredConstruct(Function* func);
+  // Return true if |func| has a return in a basic block that is not a
+  // tail basic block.
+  bool HasReturnBeforeTailBlock(Function* func);
 
   // Return true if |func| has no return in a loop. The current analysis
   // requires structured control flow, so return false if control flow not

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -196,7 +196,7 @@ class InlinePass : public Pass {
       uint32_t* returnLabelId, std::unique_ptr<BasicBlock> new_blk_ptr,
       uint32_t entry_blk_label_id);
 
-  // Inlines instructions of the caller function up to the call instruction.
+  // Moves instructions of the caller function up to the call instruction.
   std::unique_ptr<BasicBlock> InlineInstsBeforeEntryBlock(
       std::vector<std::unique_ptr<BasicBlock>>* new_blocks,
       std::unordered_map<uint32_t, uint32_t>* callee2caller,
@@ -249,6 +249,14 @@ class InlinePass : public Pass {
       bool* prevInstWasReturn, bool* multiBlocks, Function* calleeFn,
       const std::unordered_set<uint32_t>& callee_result_ids,
       uint32_t returnVarId);
+
+  // Copies instructions of the caller function after the call instruction
+  // to |new_blk_ptr|.
+  bool CopyCallerInstsAfterFunctionCall(
+      std::unordered_map<uint32_t, Instruction*>* preCallSB,
+      std::unordered_map<uint32_t, uint32_t>* postCallSB,
+      std::unique_ptr<BasicBlock>* new_blk_ptr,
+      BasicBlock::iterator call_inst_itr, bool multiBlocks);
 };
 
 }  // namespace opt

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -171,6 +171,35 @@ class InlinePass : public Pass {
   // Set of functions that are originally called directly or indirectly from a
   // continue construct.
   std::unordered_set<uint32_t> funcs_called_from_continue_;
+
+ private:
+  void CopyInstsBeforeEntryBlock(
+      std::unordered_map<uint32_t, Instruction*>* preCallSB,
+      BasicBlock* new_blk_ptr, BasicBlock::iterator call_inst_itr,
+      UptrVectorIterator<BasicBlock> call_block_itr);
+
+  std::unique_ptr<BasicBlock> AddGuardBlock(
+      std::vector<std::unique_ptr<BasicBlock>>* new_blocks,
+      std::unordered_map<uint32_t, uint32_t>* callee2caller,
+      std::unique_ptr<BasicBlock> new_blk_ptr, uint32_t entry_blk_label_id);
+
+  std::unique_ptr<BasicBlock> InsertHeaderBlockForSingleTripLoop(
+      std::vector<std::unique_ptr<BasicBlock>>* new_blocks,
+      std::unordered_map<uint32_t, uint32_t>* callee2caller,
+      std::unique_ptr<BasicBlock>* single_trip_loop_cont_blk,
+      uint32_t* returnLabelId, std::unique_ptr<BasicBlock> new_blk_ptr,
+      uint32_t entry_blk_label_id);
+
+  std::unique_ptr<BasicBlock> InlineEntryBlock(
+      std::vector<std::unique_ptr<BasicBlock>>* new_blocks,
+      std::vector<std::unique_ptr<Instruction>>* new_vars,
+      std::unordered_map<uint32_t, uint32_t>* callee2caller,
+      std::unordered_map<uint32_t, Instruction*>* preCallSB,
+      std::unique_ptr<BasicBlock>* single_trip_loop_cont_blk,
+      uint32_t* returnLabelId, Function* calleeFn,
+      BasicBlock::iterator call_inst_itr,
+      UptrVectorIterator<BasicBlock> call_block_itr,
+      bool caller_is_loop_header);
 };
 
 }  // namespace opt

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -233,6 +233,22 @@ class InlinePass : public Pass {
                         Function* calleeFn,
                         const std::unordered_set<uint32_t>& callee_result_ids,
                         uint32_t returnVarId);
+
+  // Inlines a OpLabel instruction of the callee function.
+  uint32_t InlineLabel(
+      const Instruction* inst, std::unique_ptr<BasicBlock>* new_blk_ptr,
+      uint32_t* returnLabelId, bool* prevInstWasReturn,
+      const std::unordered_map<uint32_t, uint32_t>& callee2caller);
+
+  // Inlines basic blocks of the callee function other than the entry basic
+  // block.
+  std::unique_ptr<BasicBlock> InlineBasicBlocks(
+      std::vector<std::unique_ptr<BasicBlock>>* new_blocks,
+      std::unordered_map<uint32_t, uint32_t>* callee2caller,
+      std::unique_ptr<BasicBlock> new_blk_ptr, uint32_t* returnLabelId,
+      bool* prevInstWasReturn, bool* multiBlocks, Function* calleeFn,
+      const std::unordered_set<uint32_t>& callee_result_ids,
+      uint32_t returnVarId);
 };
 
 }  // namespace opt

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -185,35 +185,34 @@ class InlinePass : public Pass {
 
   // Add store instructions for initializers of variables.
   InstructionList::iterator AddStoresForVariableInitializers(
-      std::unordered_map<uint32_t, uint32_t>* callee2caller,
+      const std::unordered_map<uint32_t, uint32_t>& callee2caller,
       std::unique_ptr<BasicBlock>* new_blk_ptr,
       UptrVectorIterator<BasicBlock> callee_block_itr);
 
   // Inlines a single instruction of the callee function.
   bool InlineInstructionInBB(
-      std::unordered_map<uint32_t, uint32_t>* callee2caller,
+      const std::unordered_map<uint32_t, uint32_t>& callee2caller,
       BasicBlock* new_blk_ptr, const Instruction* inst);
 
-  // Inlines a single termination instruction of the callee function.
-  bool InlineTerminationInstructionInBB(
-      std::unordered_map<uint32_t, uint32_t>* callee2caller,
-      std::unique_ptr<BasicBlock>* new_blk_ptr, uint32_t returnLabelId,
+  // Inlines the return instruction of the callee function.
+  std::unique_ptr<BasicBlock> InlineReturn(
+      const std::unordered_map<uint32_t, uint32_t>& callee2caller,
+      std::vector<std::unique_ptr<BasicBlock>>* new_blocks,
+      std::unique_ptr<BasicBlock> new_blk_ptr, Function* calleeFn,
       const Instruction* inst, uint32_t returnVarId);
 
   // Inlines the entry block of the callee function.
-  bool InlineEntryBlock(std::unordered_map<uint32_t, uint32_t>* callee2caller,
-                        std::unique_ptr<BasicBlock>* new_blk_ptr,
-                        uint32_t returnLabelId,
-                        UptrVectorIterator<BasicBlock> callee_first_block,
-                        uint32_t returnVarId);
+  bool InlineEntryBlock(
+      const std::unordered_map<uint32_t, uint32_t>& callee2caller,
+      std::unique_ptr<BasicBlock>* new_blk_ptr,
+      UptrVectorIterator<BasicBlock> callee_first_block);
 
   // Inlines basic blocks of the callee function other than the entry basic
   // block.
   std::unique_ptr<BasicBlock> InlineBasicBlocks(
       std::vector<std::unique_ptr<BasicBlock>>* new_blocks,
-      std::unordered_map<uint32_t, uint32_t>* callee2caller,
-      std::unique_ptr<BasicBlock> new_blk_ptr, uint32_t returnLabelId,
-      Function* calleeFn, uint32_t returnVarId);
+      const std::unordered_map<uint32_t, uint32_t>& callee2caller,
+      std::unique_ptr<BasicBlock> new_blk_ptr, Function* calleeFn);
 
   // Moves instructions of the caller function after the call instruction
   // to |new_blk_ptr|.

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -124,10 +124,6 @@ class InlinePass : public Pass {
   // Return true if |inst| is a function call that can be inlined.
   bool IsInlinableFunctionCall(const Instruction* inst);
 
-  // Return true if |func| has a return in a basic block that is not a
-  // tail basic block.
-  bool HasReturnBeforeTailBlock(Function* func);
-
   // Return true if |func| has no return in a loop. The current analysis
   // requires structured control flow, so return false if control flow not
   // structured ie. module is not a shader.

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -187,15 +187,6 @@ class InlinePass : public Pass {
       std::unordered_map<uint32_t, uint32_t>* callee2caller,
       std::unique_ptr<BasicBlock> new_blk_ptr, uint32_t entry_blk_label_id);
 
-  // Inserts a header block and a post-header block into |new_blocks|
-  // for single-trip loop.
-  std::unique_ptr<BasicBlock> InsertHeaderBlockForSingleTripLoop(
-      std::vector<std::unique_ptr<BasicBlock>>* new_blocks,
-      std::unordered_map<uint32_t, uint32_t>* callee2caller,
-      std::unique_ptr<BasicBlock>* single_trip_loop_cont_blk,
-      uint32_t* returnLabelId, std::unique_ptr<BasicBlock> new_blk_ptr,
-      uint32_t entry_blk_label_id);
-
   // Add store instructions for initializers of variables.
   InstructionList::iterator AddStoresForVariableInitializers(
       std::unordered_map<uint32_t, uint32_t>* callee2caller,
@@ -210,29 +201,23 @@ class InlinePass : public Pass {
   // Inlines a single termination instruction of the callee function.
   bool InlineTerminationInstructionInBB(
       std::unordered_map<uint32_t, uint32_t>* callee2caller,
-      std::unique_ptr<BasicBlock>* new_blk_ptr, uint32_t* returnLabelId,
-      bool* prevInstWasReturn, const Instruction* inst, uint32_t returnVarId);
+      std::unique_ptr<BasicBlock>* new_blk_ptr, uint32_t returnLabelId,
+      const Instruction* inst, uint32_t returnVarId);
 
   // Inlines the entry block of the callee function.
   bool InlineEntryBlock(std::unordered_map<uint32_t, uint32_t>* callee2caller,
                         std::unique_ptr<BasicBlock>* new_blk_ptr,
-                        uint32_t* returnLabelId, bool* prevInstWasReturn,
+                        uint32_t returnLabelId,
                         UptrVectorIterator<BasicBlock> callee_first_block,
                         uint32_t returnVarId);
-
-  // Inlines a OpLabel instruction of the callee function.
-  uint32_t InlineLabel(
-      const Instruction* inst, std::unique_ptr<BasicBlock>* new_blk_ptr,
-      uint32_t* returnLabelId, bool* prevInstWasReturn,
-      const std::unordered_map<uint32_t, uint32_t>& callee2caller);
 
   // Inlines basic blocks of the callee function other than the entry basic
   // block.
   std::unique_ptr<BasicBlock> InlineBasicBlocks(
       std::vector<std::unique_ptr<BasicBlock>>* new_blocks,
       std::unordered_map<uint32_t, uint32_t>* callee2caller,
-      std::unique_ptr<BasicBlock> new_blk_ptr, uint32_t* returnLabelId,
-      bool* prevInstWasReturn, Function* calleeFn, uint32_t returnVarId);
+      std::unique_ptr<BasicBlock> new_blk_ptr, uint32_t returnLabelId,
+      Function* calleeFn, uint32_t returnVarId);
 
   // Moves instructions of the caller function after the call instruction
   // to |new_blk_ptr|.

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -196,6 +196,12 @@ class InlinePass : public Pass {
       uint32_t* returnLabelId, std::unique_ptr<BasicBlock> new_blk_ptr,
       uint32_t entry_blk_label_id);
 
+  // Add store instructions for initializers of variables
+  void AddStoresForVariableInitializers(
+      std::unordered_map<uint32_t, uint32_t>* callee2caller,
+      std::unique_ptr<BasicBlock>* new_blk_ptr,
+      UptrVectorIterator<BasicBlock> callee_block_itr);
+
   // Inlines the entry block of the callee function and instructions of the
   // caller function up to the call instruction.
   std::unique_ptr<BasicBlock> InlineEntryBlock(

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -257,6 +257,10 @@ class InlinePass : public Pass {
       std::unordered_map<uint32_t, uint32_t>* postCallSB,
       std::unique_ptr<BasicBlock>* new_blk_ptr,
       BasicBlock::iterator call_inst_itr, bool multiBlocks);
+
+  // Move the OpLoopMerge from the last block back to the first.
+  void MoveLoopMergeInstToFirstBlock(
+      std::vector<std::unique_ptr<BasicBlock>>* new_blocks);
 };
 
 }  // namespace opt

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -173,16 +173,22 @@ class InlinePass : public Pass {
   std::unordered_set<uint32_t> funcs_called_from_continue_;
 
  private:
+  // Copies instructions of the caller function up to the call instruction
+  // to |new_blk_ptr|.
   void CopyInstsBeforeEntryBlock(
       std::unordered_map<uint32_t, Instruction*>* preCallSB,
       BasicBlock* new_blk_ptr, BasicBlock::iterator call_inst_itr,
       UptrVectorIterator<BasicBlock> call_block_itr);
 
+  // Returns a new guard block after adding a branch to the end of
+  // |new_blocks|.
   std::unique_ptr<BasicBlock> AddGuardBlock(
       std::vector<std::unique_ptr<BasicBlock>>* new_blocks,
       std::unordered_map<uint32_t, uint32_t>* callee2caller,
       std::unique_ptr<BasicBlock> new_blk_ptr, uint32_t entry_blk_label_id);
 
+  // Inserts a header block and a post-header block into |new_blocks|
+  // for single-trip loop.
   std::unique_ptr<BasicBlock> InsertHeaderBlockForSingleTripLoop(
       std::vector<std::unique_ptr<BasicBlock>>* new_blocks,
       std::unordered_map<uint32_t, uint32_t>* callee2caller,
@@ -190,14 +196,15 @@ class InlinePass : public Pass {
       uint32_t* returnLabelId, std::unique_ptr<BasicBlock> new_blk_ptr,
       uint32_t entry_blk_label_id);
 
+  // Inlines the entry block of the callee function and instructions of the
+  // caller function up to the call instruction.
   std::unique_ptr<BasicBlock> InlineEntryBlock(
       std::vector<std::unique_ptr<BasicBlock>>* new_blocks,
       std::vector<std::unique_ptr<Instruction>>* new_vars,
       std::unordered_map<uint32_t, uint32_t>* callee2caller,
       std::unordered_map<uint32_t, Instruction*>* preCallSB,
       std::unique_ptr<BasicBlock>* single_trip_loop_cont_blk,
-      uint32_t* returnLabelId, Function* calleeFn,
-      BasicBlock::iterator call_inst_itr,
+      uint32_t* returnLabelId, BasicBlock::iterator call_inst_itr,
       UptrVectorIterator<BasicBlock> call_block_itr,
       bool caller_is_loop_header);
 };

--- a/source/opt/inline_pass.h
+++ b/source/opt/inline_pass.h
@@ -205,23 +205,19 @@ class InlinePass : public Pass {
   // Inlines a single instruction of the callee function.
   bool InlineInstructionInBB(
       std::unordered_map<uint32_t, uint32_t>* callee2caller,
-      BasicBlock* new_blk_ptr, const Instruction* inst,
-      const std::unordered_set<uint32_t>& callee_result_ids);
+      BasicBlock* new_blk_ptr, const Instruction* inst);
 
   // Inlines a single termination instruction of the callee function.
   bool InlineTerminationInstructionInBB(
       std::unordered_map<uint32_t, uint32_t>* callee2caller,
       std::unique_ptr<BasicBlock>* new_blk_ptr, uint32_t* returnLabelId,
-      bool* prevInstWasReturn, const Instruction* inst,
-      const std::unordered_set<uint32_t>& callee_result_ids,
-      uint32_t returnVarId);
+      bool* prevInstWasReturn, const Instruction* inst, uint32_t returnVarId);
 
   // Inlines the entry block of the callee function.
   bool InlineEntryBlock(std::unordered_map<uint32_t, uint32_t>* callee2caller,
                         std::unique_ptr<BasicBlock>* new_blk_ptr,
                         uint32_t* returnLabelId, bool* prevInstWasReturn,
-                        Function* calleeFn,
-                        const std::unordered_set<uint32_t>& callee_result_ids,
+                        UptrVectorIterator<BasicBlock> callee_first_block,
                         uint32_t returnVarId);
 
   // Inlines a OpLabel instruction of the callee function.
@@ -236,9 +232,7 @@ class InlinePass : public Pass {
       std::vector<std::unique_ptr<BasicBlock>>* new_blocks,
       std::unordered_map<uint32_t, uint32_t>* callee2caller,
       std::unique_ptr<BasicBlock> new_blk_ptr, uint32_t* returnLabelId,
-      bool* prevInstWasReturn, bool* multiBlocks, Function* calleeFn,
-      const std::unordered_set<uint32_t>& callee_result_ids,
-      uint32_t returnVarId);
+      bool* prevInstWasReturn, Function* calleeFn, uint32_t returnVarId);
 
   // Moves instructions of the caller function after the call instruction
   // to |new_blk_ptr|.

--- a/test/opt/inline_opaque_test.cpp
+++ b/test/opt/inline_opaque_test.cpp
@@ -102,12 +102,12 @@ OpStore %30 %29
 OpStore %32 %31
 %33 = OpLoad %S_t %s0
 OpStore %param %33
-%41 = OpAccessChain %_ptr_Function_18 %param %int_2
-%42 = OpLoad %18 %41
-%43 = OpAccessChain %_ptr_Function_v2float %param %int_0
-%44 = OpLoad %v2float %43
-%45 = OpImageSampleImplicitLod %v4float %42 %44
-OpStore %outColor %45
+%42 = OpAccessChain %_ptr_Function_18 %param %int_2
+%43 = OpLoad %18 %42
+%44 = OpAccessChain %_ptr_Function_v2float %param %int_0
+%45 = OpLoad %v2float %44
+%46 = OpImageSampleImplicitLod %v4float %43 %45
+OpStore %outColor %46
 OpReturn
 OpFunctionEnd
 )";
@@ -191,10 +191,10 @@ OpFunctionEnd
 %34 = OpVariable %_ptr_Function_20 Function
 %35 = OpVariable %_ptr_Function_20 Function
 %25 = OpVariable %_ptr_Function_20 Function
-%36 = OpLoad %20 %sampler16
-OpStore %34 %36
-%37 = OpLoad %20 %34
-OpStore %35 %37
+%37 = OpLoad %20 %sampler16
+OpStore %34 %37
+%38 = OpLoad %20 %34
+OpStore %35 %38
 %26 = OpLoad %20 %35
 OpStore %25 %26
 %27 = OpLoad %20 %25
@@ -301,12 +301,12 @@ OpStore %31 %30
 OpStore %33 %32
 %34 = OpLoad %S_t %s0
 OpStore %param %34
-%44 = OpAccessChain %_ptr_Function_19 %param %int_2
-%45 = OpLoad %19 %44
-%46 = OpAccessChain %_ptr_Function_v2float %param %int_0
-%47 = OpLoad %v2float %46
-%48 = OpImageSampleImplicitLod %v4float %45 %47
-OpStore %outColor %48
+%45 = OpAccessChain %_ptr_Function_19 %param %int_2
+%46 = OpLoad %19 %45
+%47 = OpAccessChain %_ptr_Function_v2float %param %int_0
+%48 = OpLoad %v2float %47
+%49 = OpImageSampleImplicitLod %v4float %46 %48
+OpStore %outColor %49
 OpReturn
 OpFunctionEnd
 )";

--- a/test/opt/inline_test.cpp
+++ b/test/opt/inline_test.cpp
@@ -1442,33 +1442,33 @@ OpFunctionEnd
       R"(%false = OpConstantFalse %bool
 %main = OpFunction %void None %10
 %22 = OpLabel
-%35 = OpVariable %_ptr_Function_float Function
+%40 = OpVariable %_ptr_Function_float Function
 %color = OpVariable %_ptr_Function_v4float Function
 %param = OpVariable %_ptr_Function_v4float Function
 %23 = OpLoad %v4float %BaseColor
 OpStore %param %23
-OpBranch %36
-%36 = OpLabel
-OpLoopMerge %37 %38 None
-OpBranch %39
-%39 = OpLabel
-%40 = OpAccessChain %_ptr_Function_float %param %uint_0
-%41 = OpLoad %float %40
-%42 = OpFOrdLessThan %bool %41 %float_0
-OpSelectionMerge %43 None
-OpBranchConditional %42 %44 %43
-%44 = OpLabel
-OpStore %35 %float_0
-OpBranch %37
-%43 = OpLabel
-%45 = OpAccessChain %_ptr_Function_float %param %uint_0
-%46 = OpLoad %float %45
-OpStore %35 %46
-OpBranch %37
+OpBranch %35
+%35 = OpLabel
+OpLoopMerge %36 %37 None
+OpBranch %38
 %38 = OpLabel
-OpBranchConditional %false %36 %37
+%41 = OpAccessChain %_ptr_Function_float %param %uint_0
+%42 = OpLoad %float %41
+%43 = OpFOrdLessThan %bool %42 %float_0
+OpSelectionMerge %44 None
+OpBranchConditional %43 %45 %44
+%45 = OpLabel
+OpStore %40 %float_0
+OpBranch %36
+%44 = OpLabel
+%46 = OpAccessChain %_ptr_Function_float %param %uint_0
+%47 = OpLoad %float %46
+OpStore %40 %47
+OpBranch %36
 %37 = OpLabel
-%24 = OpLoad %float %35
+OpBranchConditional %false %35 %36
+%36 = OpLabel
+%24 = OpLoad %float %40
 %25 = OpCompositeConstruct %v4float %24 %24 %24 %24
 OpStore %color %25
 %26 = OpLoad %v4float %color
@@ -2397,7 +2397,7 @@ OpFunctionEnd
   const std::string main_after =
       R"(%main = OpFunction %void None %7
 %23 = OpLabel
-%38 = OpVariable %_ptr_Function_float Function
+%42 = OpVariable %_ptr_Function_float Function
 %i = OpVariable %_ptr_Function_int Function
 OpStore %i %int_0
 OpBranch %24
@@ -2410,23 +2410,23 @@ OpBranch %27
 OpBranchConditional %29 %30 %25
 %30 = OpLabel
 OpStore %_GLF_color %21
-OpBranch %39
-%39 = OpLabel
-OpLoopMerge %40 %41 None
-OpBranch %42
-%42 = OpLabel
+OpBranch %37
+%37 = OpLabel
+OpLoopMerge %38 %39 None
+OpBranch %40
+%40 = OpLabel
 OpSelectionMerge %43 None
 OpBranchConditional %true %44 %43
 %44 = OpLabel
-OpStore %38 %float_1
-OpBranch %40
+OpStore %42 %float_1
+OpBranch %38
 %43 = OpLabel
-OpStore %38 %float_1
-OpBranch %40
-%41 = OpLabel
-OpBranchConditional %false %39 %40
-%40 = OpLabel
-%31 = OpLoad %float %38
+OpStore %42 %float_1
+OpBranch %38
+%39 = OpLabel
+OpBranchConditional %false %37 %38
+%38 = OpLabel
+%31 = OpLoad %float %42
 OpBranch %26
 %26 = OpLabel
 %32 = OpLoad %int %i

--- a/test/opt/inline_test.cpp
+++ b/test/opt/inline_test.cpp
@@ -115,12 +115,12 @@ TEST_F(InlineTest, Simple) {
       "%param = OpVariable %_ptr_Function_v4float Function",
          "%22 = OpLoad %v4float %BaseColor",
                "OpStore %param %22",
-         "%33 = OpAccessChain %_ptr_Function_float %param %uint_0",
-         "%34 = OpLoad %float %33",
-         "%35 = OpAccessChain %_ptr_Function_float %param %uint_1",
-         "%36 = OpLoad %float %35",
-         "%37 = OpFAdd %float %34 %36",
-               "OpStore %32 %37",
+         "%34 = OpAccessChain %_ptr_Function_float %param %uint_0",
+         "%35 = OpLoad %float %34",
+         "%36 = OpAccessChain %_ptr_Function_float %param %uint_1",
+         "%37 = OpLoad %float %36",
+         "%38 = OpFAdd %float %35 %37",
+               "OpStore %32 %38",
          "%23 = OpLoad %float %32",
          "%24 = OpCompositeConstruct %v4float %23 %23 %23 %23",
                "OpStore %color %24",
@@ -248,7 +248,7 @@ TEST_F(InlineTest, Nested) {
       // clang-format off
        "%main = OpFunction %void None %15",
          "%28 = OpLabel",
-         "%57 = OpVariable %_ptr_Function_float Function",
+         "%58 = OpVariable %_ptr_Function_float Function",
          "%46 = OpVariable %_ptr_Function_float Function",
          "%47 = OpVariable %_ptr_Function_float Function",
          "%48 = OpVariable %_ptr_Function_float Function",
@@ -256,21 +256,21 @@ TEST_F(InlineTest, Nested) {
     "%param_1 = OpVariable %_ptr_Function_v4float Function",
          "%29 = OpLoad %v4float %BaseColor",
                "OpStore %param_1 %29",
-         "%49 = OpAccessChain %_ptr_Function_float %param_1 %uint_0",
-         "%50 = OpLoad %float %49",
-         "%51 = OpAccessChain %_ptr_Function_float %param_1 %uint_1",
-         "%52 = OpLoad %float %51",
-         "%53 = OpFAdd %float %50 %52",
-               "OpStore %46 %53",
-         "%54 = OpAccessChain %_ptr_Function_float %param_1 %uint_2",
-         "%55 = OpLoad %float %54",
-               "OpStore %47 %55",
-         "%58 = OpLoad %float %46",
-         "%59 = OpLoad %float %47",
-         "%60 = OpFMul %float %58 %59",
-               "OpStore %57 %60",
-         "%56 = OpLoad %float %57",
-               "OpStore %48 %56",
+         "%50 = OpAccessChain %_ptr_Function_float %param_1 %uint_0",
+         "%51 = OpLoad %float %50",
+         "%52 = OpAccessChain %_ptr_Function_float %param_1 %uint_1",
+         "%53 = OpLoad %float %52",
+         "%54 = OpFAdd %float %51 %53",
+               "OpStore %46 %54",
+         "%55 = OpAccessChain %_ptr_Function_float %param_1 %uint_2",
+         "%56 = OpLoad %float %55",
+               "OpStore %47 %56",
+         "%60 = OpLoad %float %46",
+         "%61 = OpLoad %float %47",
+         "%62 = OpFMul %float %60 %61",
+               "OpStore %58 %62",
+         "%57 = OpLoad %float %58",
+               "OpStore %48 %57",
          "%30 = OpLoad %float %48",
          "%31 = OpCompositeConstruct %v4float %30 %30 %30 %30",
                "OpStore %color %31",
@@ -390,13 +390,13 @@ TEST_F(InlineTest, InOutParameter) {
                "OpStore %b %24",
          "%25 = OpLoad %v4float %b",
                "OpStore %param %25",
-         "%39 = OpAccessChain %_ptr_Function_float %param %uint_0",
-         "%40 = OpLoad %float %39",
-         "%41 = OpAccessChain %_ptr_Function_float %param %uint_1",
-         "%42 = OpLoad %float %41",
-         "%43 = OpFAdd %float %40 %42",
-         "%44 = OpAccessChain %_ptr_Function_float %param %uint_2",
-               "OpStore %44 %43",
+         "%40 = OpAccessChain %_ptr_Function_float %param %uint_0",
+         "%41 = OpLoad %float %40",
+         "%42 = OpAccessChain %_ptr_Function_float %param %uint_1",
+         "%43 = OpLoad %float %42",
+         "%44 = OpFAdd %float %41 %43",
+         "%45 = OpAccessChain %_ptr_Function_float %param %uint_2",
+               "OpStore %45 %44",
          "%27 = OpLoad %v4float %param",
                "OpStore %b %27",
          "%28 = OpAccessChain %_ptr_Function_float %b %uint_2",
@@ -521,21 +521,21 @@ TEST_F(InlineTest, BranchInCallee) {
       "%param = OpVariable %_ptr_Function_v4float Function",
          "%24 = OpLoad %v4float %BaseColor",
                "OpStore %param %24",
-         "%40 = OpAccessChain %_ptr_Function_float %param %uint_0",
-         "%41 = OpLoad %float %40",
-               "OpStore %38 %41",
-         "%42 = OpLoad %float %38",
-         "%43 = OpFOrdLessThan %bool %42 %float_0",
-               "OpSelectionMerge %44 None",
-               "OpBranchConditional %43 %45 %44",
+         "%41 = OpAccessChain %_ptr_Function_float %param %uint_0",
+         "%42 = OpLoad %float %41",
+               "OpStore %38 %42",
+         "%43 = OpLoad %float %38",
+         "%44 = OpFOrdLessThan %bool %43 %float_0",
+               "OpSelectionMerge %48 None",
+               "OpBranchConditional %44 %45 %48",
          "%45 = OpLabel",
          "%46 = OpLoad %float %38",
          "%47 = OpFNegate %float %46",
                "OpStore %38 %47",
-               "OpBranch %44",
-         "%44 = OpLabel",
-         "%48 = OpLoad %float %38",
-               "OpStore %39 %48",
+               "OpBranch %48",
+         "%48 = OpLabel",
+         "%49 = OpLoad %float %38",
+               "OpStore %39 %49",
          "%25 = OpLoad %float %39",
          "%26 = OpCompositeConstruct %v4float %25 %25 %25 %25",
                "OpStore %color %26",
@@ -675,8 +675,8 @@ TEST_F(InlineTest, PhiAfterCall) {
       // clang-format off
        "%main = OpFunction %void None %12",
          "%27 = OpLabel",
-         "%62 = OpVariable %_ptr_Function_float Function",
          "%63 = OpVariable %_ptr_Function_float Function",
+         "%64 = OpVariable %_ptr_Function_float Function",
          "%52 = OpVariable %_ptr_Function_float Function",
          "%53 = OpVariable %_ptr_Function_float Function",
       "%color = OpVariable %_ptr_Function_v4float Function",
@@ -687,20 +687,20 @@ TEST_F(InlineTest, PhiAfterCall) {
          "%29 = OpAccessChain %_ptr_Function_float %color %uint_0",
          "%30 = OpLoad %float %29",
                "OpStore %param %30",
-         "%54 = OpLoad %float %param",
-               "OpStore %52 %54",
-         "%55 = OpLoad %float %52",
-         "%56 = OpFOrdLessThan %bool %55 %float_0",
-               "OpSelectionMerge %57 None",
-               "OpBranchConditional %56 %58 %57",
+         "%55 = OpLoad %float %param",
+               "OpStore %52 %55",
+         "%56 = OpLoad %float %52",
+         "%57 = OpFOrdLessThan %bool %56 %float_0",
+               "OpSelectionMerge %61 None",
+               "OpBranchConditional %57 %58 %61",
          "%58 = OpLabel",
          "%59 = OpLoad %float %52",
          "%60 = OpFNegate %float %59",
                "OpStore %52 %60",
-               "OpBranch %57",
-         "%57 = OpLabel",
-         "%61 = OpLoad %float %52",
-               "OpStore %53 %61",
+               "OpBranch %61",
+         "%61 = OpLabel",
+         "%62 = OpLoad %float %52",
+               "OpStore %53 %62",
          "%31 = OpLoad %float %53",
          "%32 = OpFOrdGreaterThan %bool %31 %float_2",
                "OpSelectionMerge %33 None",
@@ -709,25 +709,25 @@ TEST_F(InlineTest, PhiAfterCall) {
          "%35 = OpAccessChain %_ptr_Function_float %color %uint_1",
          "%36 = OpLoad %float %35",
                "OpStore %param_0 %36",
-         "%64 = OpLoad %float %param_0",
-               "OpStore %62 %64",
-         "%65 = OpLoad %float %62",
-         "%66 = OpFOrdLessThan %bool %65 %float_0",
-               "OpSelectionMerge %67 None",
-               "OpBranchConditional %66 %68 %67",
-         "%68 = OpLabel",
-         "%69 = OpLoad %float %62",
-         "%70 = OpFNegate %float %69",
-               "OpStore %62 %70",
-               "OpBranch %67",
-         "%67 = OpLabel",
-         "%71 = OpLoad %float %62",
+         "%66 = OpLoad %float %param_0",
+               "OpStore %63 %66",
+         "%67 = OpLoad %float %63",
+         "%68 = OpFOrdLessThan %bool %67 %float_0",
+               "OpSelectionMerge %72 None",
+               "OpBranchConditional %68 %69 %72",
+         "%69 = OpLabel",
+         "%70 = OpLoad %float %63",
+         "%71 = OpFNegate %float %70",
                "OpStore %63 %71",
-         "%37 = OpLoad %float %63",
+               "OpBranch %72",
+         "%72 = OpLabel",
+         "%73 = OpLoad %float %63",
+               "OpStore %64 %73",
+         "%37 = OpLoad %float %64",
          "%38 = OpFOrdGreaterThan %bool %37 %float_2",
                "OpBranch %33",
          "%33 = OpLabel",
-         "%39 = OpPhi %bool %32 %57 %38 %67",
+         "%39 = OpPhi %bool %32 %61 %38 %72",
                "OpSelectionMerge %40 None",
                "OpBranchConditional %39 %41 %40",
          "%41 = OpLabel",
@@ -902,28 +902,28 @@ TEST_F(InlineTest, OpSampledImageOutOfBlock) {
                "OpStore %color1 %42",
          "%43 = OpLoad %v4float %BaseColor",
                "OpStore %param %43",
-         "%68 = OpAccessChain %_ptr_Function_float %param %uint_0",
-         "%69 = OpLoad %float %68",
-               "OpStore %66 %69",
-         "%70 = OpLoad %float %66",
-         "%71 = OpFOrdLessThan %bool %70 %float_0",
-               "OpSelectionMerge %72 None",
-               "OpBranchConditional %71 %73 %72",
+         "%69 = OpAccessChain %_ptr_Function_float %param %uint_0",
+         "%70 = OpLoad %float %69",
+               "OpStore %66 %70",
+         "%71 = OpLoad %float %66",
+         "%72 = OpFOrdLessThan %bool %71 %float_0",
+               "OpSelectionMerge %76 None",
+               "OpBranchConditional %72 %73 %76",
          "%73 = OpLabel",
          "%74 = OpLoad %float %66",
          "%75 = OpFNegate %float %74",
                "OpStore %66 %75",
-               "OpBranch %72",
-         "%72 = OpLabel",
-         "%76 = OpLoad %float %66",
-               "OpStore %67 %76",
+               "OpBranch %76",
+         "%76 = OpLabel",
+         "%77 = OpLoad %float %66",
+               "OpStore %67 %77",
          "%44 = OpLoad %float %67",
          "%45 = OpCompositeConstruct %v4float %44 %44 %44 %44",
                "OpStore %color2 %45",
          "%46 = OpLoad %25 %t2D",
          "%47 = OpLoad %27 %samp",
-         "%77 = OpSampledImage %29 %39 %40",
-         "%48 = OpImageSampleImplicitLod %v4float %77 %35",
+         "%78 = OpSampledImage %29 %39 %40",
+         "%48 = OpImageSampleImplicitLod %v4float %78 %35",
                "OpStore %color3 %48",
          "%49 = OpLoad %v4float %color1",
          "%50 = OpLoad %v4float %color2",
@@ -1108,27 +1108,27 @@ TEST_F(InlineTest, OpImageOutOfBlock) {
                "OpStore %color1 %43",
          "%46 = OpLoad %v4float %BaseColor",
                "OpStore %param %46",
-         "%70 = OpAccessChain %_ptr_Function_float %param %uint_0",
-         "%71 = OpLoad %float %70",
-               "OpStore %68 %71",
-         "%72 = OpLoad %float %68",
-         "%73 = OpFOrdLessThan %bool %72 %float_0",
-               "OpSelectionMerge %74 None",
-               "OpBranchConditional %73 %75 %74",
+         "%71 = OpAccessChain %_ptr_Function_float %param %uint_0",
+         "%72 = OpLoad %float %71",
+               "OpStore %68 %72",
+         "%73 = OpLoad %float %68",
+         "%74 = OpFOrdLessThan %bool %73 %float_0",
+               "OpSelectionMerge %78 None",
+               "OpBranchConditional %74 %75 %78",
          "%75 = OpLabel",
          "%76 = OpLoad %float %68",
          "%77 = OpFNegate %float %76",
                "OpStore %68 %77",
-               "OpBranch %74",
-         "%74 = OpLabel",
-         "%78 = OpLoad %float %68",
-               "OpStore %69 %78",
+               "OpBranch %78",
+         "%78 = OpLabel",
+         "%79 = OpLoad %float %68",
+               "OpStore %69 %79",
          "%47 = OpLoad %float %69",
          "%48 = OpCompositeConstruct %v4float %47 %47 %47 %47",
                "OpStore %color2 %48",
-         "%79 = OpSampledImage %30 %40 %41",
-         "%80 = OpImage %26 %79",
-         "%49 = OpSampledImage %30 %80 %45",
+         "%80 = OpSampledImage %30 %40 %41",
+         "%81 = OpImage %26 %80",
+         "%49 = OpSampledImage %30 %81 %45",
          "%50 = OpImageSampleImplicitLod %v4float %49 %36",
                "OpStore %color3 %50",
          "%51 = OpLoad %v4float %color1",
@@ -1314,28 +1314,28 @@ TEST_F(InlineTest, OpImageAndOpSampledImageOutOfBlock) {
                "OpStore %color1 %43",
          "%47 = OpLoad %v4float %BaseColor",
                "OpStore %param %47",
-         "%70 = OpAccessChain %_ptr_Function_float %param %uint_0",
-         "%71 = OpLoad %float %70",
-               "OpStore %68 %71",
-         "%72 = OpLoad %float %68",
-         "%73 = OpFOrdLessThan %bool %72 %float_0",
-               "OpSelectionMerge %74 None",
-               "OpBranchConditional %73 %75 %74",
+         "%71 = OpAccessChain %_ptr_Function_float %param %uint_0",
+         "%72 = OpLoad %float %71",
+               "OpStore %68 %72",
+         "%73 = OpLoad %float %68",
+         "%74 = OpFOrdLessThan %bool %73 %float_0",
+               "OpSelectionMerge %78 None",
+               "OpBranchConditional %74 %75 %78",
          "%75 = OpLabel",
          "%76 = OpLoad %float %68",
          "%77 = OpFNegate %float %76",
                "OpStore %68 %77",
-               "OpBranch %74",
-         "%74 = OpLabel",
-         "%78 = OpLoad %float %68",
-               "OpStore %69 %78",
+               "OpBranch %78",
+         "%78 = OpLabel",
+         "%79 = OpLoad %float %68",
+               "OpStore %69 %79",
          "%48 = OpLoad %float %69",
          "%49 = OpCompositeConstruct %v4float %48 %48 %48 %48",
                "OpStore %color2 %49",
-         "%79 = OpSampledImage %30 %40 %41",
-         "%80 = OpImage %26 %79",
-         "%81 = OpSampledImage %30 %80 %45",
-         "%50 = OpImageSampleImplicitLod %v4float %81 %36",
+         "%80 = OpSampledImage %30 %40 %41",
+         "%81 = OpImage %26 %80",
+         "%82 = OpSampledImage %30 %81 %45",
+         "%50 = OpImageSampleImplicitLod %v4float %82 %36",
                "OpStore %color3 %50",
          "%51 = OpLoad %v4float %color1",
          "%52 = OpLoad %v4float %color2",
@@ -1452,18 +1452,18 @@ OpBranch %35
 OpLoopMerge %36 %37 None
 OpBranch %38
 %38 = OpLabel
-%41 = OpAccessChain %_ptr_Function_float %param %uint_0
-%42 = OpLoad %float %41
-%43 = OpFOrdLessThan %bool %42 %float_0
-OpSelectionMerge %44 None
-OpBranchConditional %43 %45 %44
+%42 = OpAccessChain %_ptr_Function_float %param %uint_0
+%43 = OpLoad %float %42
+%44 = OpFOrdLessThan %bool %43 %float_0
+OpSelectionMerge %46 None
+OpBranchConditional %44 %45 %46
 %45 = OpLabel
 OpStore %40 %float_0
 OpBranch %36
-%44 = OpLabel
-%46 = OpAccessChain %_ptr_Function_float %param %uint_0
-%47 = OpLoad %float %46
-OpStore %40 %47
+%46 = OpLabel
+%47 = OpAccessChain %_ptr_Function_float %param %uint_0
+%48 = OpLoad %float %47
+OpStore %40 %48
 OpBranch %36
 %37 = OpLabel
 OpBranchConditional %false %35 %36
@@ -1536,13 +1536,13 @@ OpFunctionEnd
   const std::string after =
       R"(%main = OpFunction %void None %4
 %10 = OpLabel
-OpSelectionMerge %12 None
-OpBranchConditional %true %13 %12
-%12 = OpLabel
-OpBranch %14
+OpSelectionMerge %13 None
+OpBranchConditional %true %14 %13
 %13 = OpLabel
-OpBranch %12
+OpBranch %15
 %14 = OpLabel
+OpBranch %13
+%15 = OpLabel
 OpReturn
 OpFunctionEnd
 )";
@@ -1619,17 +1619,17 @@ OpFunctionEnd
 %19 = OpLabel
 %21 = OpVariable %_ptr_Function_int Function
 %x = OpVariable %_ptr_Function_int Function
-%22 = OpCopyObject %int %int_0
-OpSelectionMerge %23 None
-OpBranchConditional %true %24 %23
-%23 = OpLabel
-%26 = OpPhi %int %22 %19 %25 %24
-OpStore %21 %26
-OpBranch %27
+%23 = OpCopyObject %int %int_0
+OpSelectionMerge %24 None
+OpBranchConditional %true %26 %24
 %24 = OpLabel
-%25 = OpCopyObject %int %int_0
-OpBranch %23
-%27 = OpLabel
+%25 = OpPhi %int %23 %19 %27 %26
+OpStore %21 %25
+OpBranch %28
+%26 = OpLabel
+%27 = OpCopyObject %int %int_0
+OpBranch %24
+%28 = OpLabel
 %20 = OpLoad %int %21
 OpStore %x %20
 OpReturn
@@ -1820,8 +1820,8 @@ OpFunctionEnd
 OpBranch %10
 %10 = OpLabel
 OpLoopMerge %12 %10 None
-OpBranch %13
-%13 = OpLabel
+OpBranch %14
+%14 = OpLabel
 OpBranchConditional %true %10 %12
 %12 = OpLabel
 OpReturn
@@ -1890,11 +1890,11 @@ OpFunctionEnd
 OpBranch %18
 %18 = OpLabel
 %19 = OpCopyObject %int %int_3
-%25 = OpCopyObject %int %int_1
+%26 = OpCopyObject %int %int_1
 OpLoopMerge %22 %23 None
-OpBranch %26
-%26 = OpLabel
-%27 = OpCopyObject %int %int_2
+OpBranch %27
+%27 = OpLabel
+%28 = OpCopyObject %int %int_2
 %21 = OpCopyObject %int %int_4
 OpBranchConditional %true %23 %22
 %23 = OpLabel
@@ -1983,11 +1983,11 @@ OpBranch %13
 OpLoopMerge %16 %13 None
 OpBranch %17
 %17 = OpLabel
-%18 = OpCopyObject %bool %true
-OpSelectionMerge %19 None
-OpBranchConditional %true %19 %19
-%19 = OpLabel
-%20 = OpPhi %bool %18 %17
+%19 = OpCopyObject %bool %true
+OpSelectionMerge %20 None
+OpBranchConditional %true %20 %20
+%20 = OpLabel
+%21 = OpPhi %bool %19 %17
 OpBranchConditional %true %13 %16
 %16 = OpLabel
 OpReturn
@@ -2060,11 +2060,11 @@ OpBranch %18
 OpLoopMerge %22 %23 None
 OpBranch %25
 %25 = OpLabel
-%26 = OpCopyObject %int %int_1
-OpSelectionMerge %27 None
-OpBranchConditional %true %27 %27
-%27 = OpLabel
-%28 = OpCopyObject %int %int_2
+%27 = OpCopyObject %int %int_1
+OpSelectionMerge %28 None
+OpBranchConditional %true %28 %28
+%28 = OpLabel
+%29 = OpCopyObject %int %int_2
 %21 = OpCopyObject %int %int_4
 OpBranchConditional %true %23 %22
 %23 = OpLabel
@@ -2144,13 +2144,13 @@ OpFunctionEnd
 OpBranch %19
 %19 = OpLabel
 %20 = OpCopyObject %int %int_2
-%25 = OpCopyObject %int %int_0
+%26 = OpCopyObject %int %int_0
 OpLoopMerge %23 %19 None
-OpBranch %26
+OpBranch %29
 %27 = OpLabel
 %28 = OpCopyObject %int %int_1
-OpBranch %26
-%26 = OpLabel
+OpBranch %29
+%29 = OpLabel
 %22 = OpCopyObject %int %int_3
 OpBranchConditional %true %19 %23
 %23 = OpLabel
@@ -2219,16 +2219,16 @@ OpFunctionEnd
       R"(%1 = OpFunction %void None %9
 %20 = OpLabel
 %21 = OpCopyObject %int %int_3
-%24 = OpCopyObject %int %int_0
-OpBranch %25
-%25 = OpLabel
-%26 = OpPhi %int %24 %20
-%27 = OpCopyObject %int %int_1
-OpBranch %28
+%25 = OpCopyObject %int %int_0
+OpBranch %26
+%26 = OpLabel
+%27 = OpPhi %int %25 %20
+%28 = OpCopyObject %int %int_1
+OpBranch %31
 %29 = OpLabel
 %30 = OpCopyObject %int %int_2
-OpBranch %28
-%28 = OpLabel
+OpBranch %31
+%31 = OpLabel
 %23 = OpCopyObject %int %int_4
 OpReturn
 OpFunctionEnd
@@ -2415,12 +2415,12 @@ OpBranch %37
 OpLoopMerge %38 %39 None
 OpBranch %40
 %40 = OpLabel
-OpSelectionMerge %43 None
-OpBranchConditional %true %44 %43
+OpSelectionMerge %45 None
+OpBranchConditional %true %44 %45
 %44 = OpLabel
 OpStore %42 %float_1
 OpBranch %38
-%43 = OpLabel
+%45 = OpLabel
 OpStore %42 %float_1
 OpBranch %38
 %39 = OpLabel
@@ -2526,7 +2526,7 @@ OpFunctionEnd
 )";
 
   const std::string after =
-      R"(OpDecorate %37 RelaxedPrecision
+      R"(OpDecorate %38 RelaxedPrecision
 %void = OpTypeVoid
 %11 = OpTypeFunction %void
 %float = OpTypeFloat 32
@@ -2548,12 +2548,12 @@ OpFunctionEnd
 %param = OpVariable %_ptr_Function_v4float Function
 %23 = OpLoad %v4float %BaseColor
 OpStore %param %23
-%33 = OpAccessChain %_ptr_Function_float %param %uint_0
-%34 = OpLoad %float %33
-%35 = OpAccessChain %_ptr_Function_float %param %uint_1
-%36 = OpLoad %float %35
-%37 = OpFAdd %float %34 %36
-OpStore %32 %37
+%34 = OpAccessChain %_ptr_Function_float %param %uint_0
+%35 = OpLoad %float %34
+%36 = OpAccessChain %_ptr_Function_float %param %uint_1
+%37 = OpLoad %float %36
+%38 = OpFAdd %float %35 %37
+OpStore %32 %38
 %24 = OpLoad %float %32
 %25 = OpCompositeConstruct %v4float %24 %24 %24 %24
 OpStore %color %25
@@ -2672,12 +2672,12 @@ OpFunctionEnd
 %param = OpVariable %_ptr_Function_v4float Function
 %22 = OpLoad %v4float %BaseColor
 OpStore %param %22
-%33 = OpAccessChain %_ptr_Function_float %param %uint_0
-%34 = OpLoad %float %33
-%35 = OpAccessChain %_ptr_Function_float %param %uint_1
-%36 = OpLoad %float %35
-%37 = OpFAdd %float %34 %36
-OpStore %32 %37
+%34 = OpAccessChain %_ptr_Function_float %param %uint_0
+%35 = OpLoad %float %34
+%36 = OpAccessChain %_ptr_Function_float %param %uint_1
+%37 = OpLoad %float %36
+%38 = OpFAdd %float %35 %37
+OpStore %32 %38
 %23 = OpLoad %float %32
 %24 = OpCompositeConstruct %v4float %23 %23 %23 %23
 OpStore %color %24
@@ -3017,7 +3017,7 @@ OpName %kill_ "kill("
 %main = OpFunction %void None %3
 %5 = OpLabel
 OpKill
-%17 = OpLabel
+%18 = OpLabel
 OpReturn
 OpFunctionEnd
 %kill_ = OpFunction %void None %3


### PR DESCRIPTION
In the function inlining pass, a lamda function contains
lots of logic and it is too complicated. This commit breaks
it down into small functions to be more readable.