### PR TITLE
Reject folding comparisons with unfoldable types.

### DIFF
--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -630,16 +630,12 @@ bool Instruction::IsFoldableByFoldScalar() const {
   // Even if the type of the instruction is foldable, its operands may not be
   // foldable (e.g., comparisons of 64bit types).  Check that all operand types
   // are foldable before accepting the instruction.
-  bool all_operands_are_foldable = true;
-  ForEachInOperand(
-      [&all_operands_are_foldable, &folder, this](const uint32_t* op_id) {
-        Instruction* def_inst = context()->get_def_use_mgr()->GetDef(*op_id);
-        Instruction* def_inst_type =
-            context()->get_def_use_mgr()->GetDef(def_inst->type_id());
-        all_operands_are_foldable &= folder.IsFoldableType(def_inst_type);
-      });
-
-  return all_operands_are_foldable;
+  return WhileEachInOperand([&folder, this](const uint32_t* op_id) {
+    Instruction* def_inst = context()->get_def_use_mgr()->GetDef(*op_id);
+    Instruction* def_inst_type =
+        context()->get_def_use_mgr()->GetDef(def_inst->type_id());
+    return folder.IsFoldableType(def_inst_type);
+  });
 }
 
 bool Instruction::IsFloatingPointFoldingAllowed() const {

--- a/test/opt/ccp_test.cpp
+++ b/test/opt/ccp_test.cpp
@@ -925,43 +925,6 @@ TEST_F(CCPTest, FoldWithDecoration) {
   SinglePassRunAndMatch<CCPPass>(text, true);
 }
 
-// Reduced from https://github.com/KhronosGroup/SPIRV-Tools/issues/3343.
-// Comparisons using 64-bit types should not be foldable even if their operands
-// are constant.
-TEST_F(CCPTest, Reject64BitComparisons) {
-  const std::string text = R"(
-               OpCapability Addresses
-               OpCapability Kernel
-               OpCapability Int64
-          %1 = OpExtInstImport "OpenCL.std"
-               OpMemoryModel Physical64 OpenCL
-               OpEntryPoint Kernel %main "main"
-       %bool = OpTypeBool
-       %void = OpTypeVoid
-      %ulong = OpTypeInt 64 0
-    %ulong_0 = OpConstant %ulong 0
-    %ulong_1 = OpConstant %ulong 1
-  %main_type = OpTypeFunction %void
-       %main = OpFunction %void None %main_type
-      %entry = OpLabel
-        %cmp = OpULessThan %bool %ulong_1 %ulong_0
-
-; Constant propagation should be refusing to fold 1L < 0L to false
-; (the constant folder does not handle 64-bit types yet).
-;
-; CHECK-NOT: OpBranchConditional %false {{%\d+}} {{%\d+}}
-               OpBranchConditional %cmp %then %endif
-
-       %then = OpLabel
-               OpBranch %endif
-      %endif = OpLabel
-               OpReturn
-               OpFunctionEnd
-)";
-
-  SinglePassRunAndMatch<CCPPass>(text, true);
-}
-
 }  // namespace
 }  // namespace opt
 }  // namespace spvtools

--- a/test/opt/fold_test.cpp
+++ b/test/opt/fold_test.cpp
@@ -3297,7 +3297,16 @@ INSTANTIATE_TEST_SUITE_P(IntegerArithmeticTestCases, GeneralInstructionFoldingTe
             "%2 = OpIMul %int %3 %int_1\n" +
             "OpReturn\n" +
             "OpFunctionEnd",
-        2, 3)
+        2, 3),
+    // Test case 20: Don't fold comparisons of 64-bit types
+    // (https://github.com/KhronosGroup/SPIRV-Tools/issues/3343).
+    InstructionFoldingCase<uint32_t>(
+        Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpSLessThan %bool %long_0 %long_2\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+        2, 0)
 ));
 
 INSTANTIATE_TEST_SUITE_P(CompositeExtractFoldingTest, GeneralInstructionFoldingTest,

--- a/test/opt/fold_test.cpp
+++ b/test/opt/fold_test.cpp
@@ -3298,7 +3298,7 @@ INSTANTIATE_TEST_SUITE_P(IntegerArithmeticTestCases, GeneralInstructionFoldingTe
             "OpReturn\n" +
             "OpFunctionEnd",
         2, 3),
-    // Test case 20: Don't fold comparisons of 64-bit types
+    // Test case 42: Don't fold comparisons of 64-bit types
     // (https://github.com/KhronosGroup/SPIRV-Tools/issues/3343).
     InstructionFoldingCase<uint32_t>(
         Header() + "%main = OpFunction %void None %void_func\n" +


### PR DESCRIPTION
When CCP is evaluating an instruction, it was trying to fold a
comparison with 64 bit integers.  This was causing a fold failure later
since the folder still cannot deal with 64 bit integers.

Fixes #3343.