### PR TITLE
Rolling 4 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -3,10 +3,10 @@ use_relative_paths = True
 vars = {
   'github': 'https://github.com',
 
-  'effcee_revision': 'cd25ec17e9382f99a895b9ef53ff3c277464d07d',
-  'googletest_revision': 'f2fb48c3b3d79a75a88a99fba6576b25d42ec528',
-  're2_revision': '5bd613749fd530b576b890283bfb6bc6ea6246cb',
-  'spirv_headers_revision': 'f8bf11a0253a32375c32cad92c841237b96696c0',
+  'effcee_revision': '5af957bbfc7da4e9f7aa8cac11379fa36dd79b84',
+  'googletest_revision': '011959aafddcd30611003de96cfd8d7a7685c700',
+  're2_revision': 'aecba11114cf1fac5497aeb844b6966106de3eb6',
+  'spirv_headers_revision': 'ac638f1815425403e946d0ab78bac71d2bdbf3be',
 }
 
 deps = {


### PR DESCRIPTION
Roll external/effcee/ cd25ec17e..5af957bbf (3 commits)

https://github.com/google/effcee/compare/cd25ec17e938...5af957bbfc7d

$ git log cd25ec17e..5af957bbf --date=short --no-merges --format='%ad %ae %s'
2019-12-20 raj.khem Respect CMAKE_INSTALL_LIBDIR in installed CMake files
2019-10-30 dneto Travis-CI: macOS: Run brew update first
2019-10-30 dneto Add namespace to make_unique to avoid potential collisions

Roll external/googletest/ f2fb48c3b..011959aaf (233 commits)

https://github.com/google/googletest/compare/f2fb48c3b3d7...011959aafddc

$ git log f2fb48c3b..011959aaf --date=short --no-merges --format='%ad %ae %s'
2020-05-13 absl-team Googletest export
2020-05-13 absl-team Googletest export
2020-05-11 absl-team Googletest export
2020-05-08 martin Remove an explicit include of debugapi.h
2020-05-08 martin Revert "Googletest export"
2020-05-07 absl-team Googletest export
2020-05-04 absl-team Googletest export
2020-04-30 absl-team Googletest export
2020-04-28 absl-team Googletest export
2020-04-27 absl-team Googletest export
2020-04-24 absl-team Googletest export
2020-04-23 absl-team Googletest export
2020-04-20 absl-team Googletest export
2020-04-20 absl-team Googletest export
2020-04-17 absl-team Googletest export
2020-05-01 56075233+keshavgbpecdelhi Removed a typo in README.md
2020-03-28 arthur.j.odwyer Add -Wdeprecated to the build configuration.
2020-04-16 arthur.j.odwyer Fix a -Wdeprecated warning.
2020-04-16 arthur.j.odwyer Fix a -Wdeprecated warning.
2020-04-16 arthur.j.odwyer Fix a -Wdeprecated warning.
2020-04-16 arthur.j.odwyer Remove all uses of GTEST_DISALLOW_{MOVE_,}ASSIGN_.
2020-04-19 igor.n.nazarenko Enable protobuf printing for open-source proto messages.
2020-04-16 arthur.j.odwyer VariadicMatcher needs a non-defaulted move constructor for compile-time performance.
2020-04-10 absl-team Googletest export
2020-04-12 jbohl fix signed/unsigned comparison issue (on OpenBSD)
2020-04-09 malcolm.parsons Remove redundant .c_str()
2020-04-06 mail gtest-unittest-api_test - fix warning in clang build
2020-04-01 absl-team Googletest export
2020-04-05 jijyunneng Remove duplicate codes existed in get-nprocessors.sh
2020-03-30 absl-team Googletest export
2020-03-29 verdoialaurent Fix --gtest_print_time coloring
2020-03-28 arthur.j.odwyer Replace the last instance of `throw()` with `noexcept`. NFC.
2020-03-28 arthur.j.odwyer Fix a typo in .travis.yml
2020-03-23 absl-team Googletest export
2020-03-24 krystian.kuzniarek remove chapters on Autotools, Meson and plain Makefiles
2020-03-24 krystian.kuzniarek remove dead code in googletest-output-test
2020-03-24 pkryger Swap settimer and sigaction calls to avoid SIGPROF
2020-03-21 ngompa13 Ensure that gtest/gmock pkgconfig requirements specify version
2020-03-20 absl-team Googletest export
2020-03-18 calum.robinson Add GTEST_BRIEF option
2019-07-11 adam.f.badura Add support for std::function in MockFunction (#2277)
2019-12-26 adam.f.badura Add tests for MockFunction deduction (#2277)
2020-03-17 absl-team Googletest export
2020-03-16 dmauro Googletest export
2020-03-13 absl-team Googletest export
2020-03-06 absl-team Googletest export
2020-03-03 absl-team Googletest export
2020-03-03 absl-team Googletest export
2020-03-11 romain.geissler Make sure IsATTY does not clobber errno.
2020-02-27 absl-team Googletest export
(...)
2019-10-16 absl-team Googletest export
2019-10-11 joshdcannon Avoid recursive macros
2019-10-09 robert Add more override keywords
2019-10-07 chrisjohnsonmail Update to distinguish prelease purpose of this fork.
2019-10-11 joshdcannon Removing extraneous parenthesis
2019-10-11 joshdcannon Evaluate and cat NARG in different macros
2019-08-29 chrisjohnsonmail Add ESP8266 configs to PlatformIO build
2019-08-28 chrisjohnsonmail feat: Add support for ESP8266 platform
2019-10-11 joshdcannon Removing extraneous test
2019-10-11 joshdcannon Replace compile-test with preprocessor test
2019-10-11 joshdcannon Fix preprocessor tests
2019-10-11 joshdcannon Add a compile test
2019-10-11 joshdcannon Workaround MSVC VA_ARGS weirdness
2019-10-11 misterg Googletest export
2019-10-10 absl-team Googletest export
2019-10-10 absl-team Googletest export
2019-10-11 krystian.kuzniarek clean-up broken paths for PlatformIO
2019-10-10 chrisjohnsonmail chore:  update version
2019-10-10 joshdcannon Made noexcept condition more exciting
2019-10-09 absl-team Googletest export
2019-10-09 zeb Mention Cornichon as a related open source project
2019-10-07 joshdcannon Use declval in noexcept expression
2019-10-07 joshdcannon Switch to free function to avoid GCC bug
2019-10-07 joshdcannon Avoid comma operator
2019-10-07 joshdcannon Fix spacing
2019-10-07 joshdcannon Use the verbatim noexcept spec in MOCKED_METHOD
2019-10-07 joshdcannon Use FormatFileLocation for streaming file and line
2019-10-05 soap Add documentation for pkg-config in cross-compilation settings
2019-10-05 soap Revert "Use pcfiledir for prefix in pkgconfig file"
2019-10-03 misterg Googletest export
2019-10-03 absl-team Googletest export
2019-10-02 absl-team Googletest export
2019-09-29 misterg Googletest export
2019-10-01 ant35rookie Fix typo in documents
2019-09-29 misterg Googletest export
2019-09-27 misterg Googletest export
2019-09-25 absl-team Googletest export
2019-09-25 absl-team Googletest export
2019-09-24 absl-team Googletest export
2019-09-19 absl-team Googletest export
2019-09-27 gennadiycivil Bump llvm version to 4 so brew can work again
2019-08-16 pbarker Add many missing override keywords
2019-09-05 krystian.kuzniarek remove GTEST_ARRAY_SIZE_
2019-08-22 krystian.kuzniarek mention the existing support for wide strings in string matchers
2019-09-16 krystian.kuzniarek square away the stuff that hasn't been merged in a manual review
2019-09-07 krystian.kuzniarek square away the stuff that hasn't been merged in a manual review
2019-08-22 krystian.kuzniarek change usings
2019-09-10 krystian.kuzniarek change includes in gtest-port.h
2019-09-10 krystian.kuzniarek remove GTEST_HAS_STD_STRING
2019-09-10 krystian.kuzniarek remove a dead function

Roll external/re2/ 5bd613749..aecba1111 (88 commits)

https://github.com/google/re2/compare/5bd613749fd5...aecba11114cf

$ git log 5bd613749..aecba1111 --date=short --no-merges --format='%ad %ae %s'
2020-05-27 junyer Refuse to rewrite when MaxSubmatch() is too large.
2020-05-22 junyer Use CMAKE_CXX_STANDARD now that we can.
2020-05-22 junyer Make "front and back" prefix accel work with MSVC.
2020-05-22 junyer Rename to Regexp::RequiredPrefixForAccel().
2020-05-22 junyer Add a basic test for prefix accel.
2020-05-20 junyer Implement "front and back" prefix accel.
2020-05-19 junyer Generalise from "first byte" to "prefix accel".
2020-05-19 junyer have_first_byte now implies run_forward.
2020-05-19 junyer Tidy up the code around the memchr(3) calls.
2020-05-17 junyer Remove a pointer chase from Regexp::Walker<>.
2020-05-17 junyer Tidy up the code for NFA threads a bit more.
2020-05-17 junyer Argh. I overlooked the constructor and destructor.
2020-05-17 junyer Undo use of PODArray<> for NFA threads.
2020-05-17 junyer Use PODArray<> in a few more places.
2020-05-16 junyer Separate build/install for libre2.a and libre2.so.
2020-05-16 junyer Refine a preprocessor check for MSVC.
2020-05-15 junyer Compute first byte for forward Progs only.
2020-05-11 junyer Don't dereference params->start unconditionally.
2020-05-11 junyer Compute first_byte using the Regexp, not the Prog.
2020-05-11 junyer Implement Regexp::RequiredPrefixUnanchored().
2020-05-11 junyer Refactor Regexp::RequiredPrefix().
2020-05-10 junyer Lower the memory budget in TestCompile.InsufficientMemory.
2020-05-05 junyer Remove first_byte from StartInfo and simplify accordingly.
2020-05-02 junyer `^' is a caret, not a carat.
2020-04-23 junyer Compute first_byte_ eagerly.
2020-04-23 junyer Remove unused flags_ member from Prog class.
2020-04-23 junyer Replace some uses of "LL" and "ULL" suffixes.
2020-04-21 junyer Explain the need for double backslashes.
2020-04-20 junyer Remove memrchr() and the logic that calls it.
2020-04-19 junyer Use 64-bit integers for the BitState bitmap.
2020-04-09 junyer Remove deprecated APIs. Bump SONAME accordingly.
2020-04-06 junyer Go back to using __builtin_ctzll(). Sigh.
2020-04-05 junyer Return the fanout histogram in a vector, not a map.
2020-04-05 junyer Optimise fanout bucketing.
2020-04-05 junyer Add Clang 10 to the Travis CI matrix.
2020-03-27 junyer Aiieee. Add a missing underscore.
2020-03-27 junyer Include the pattern length in "DFA out of memory" errors.
2020-03-15 junyer Update Unicode data to 13.0.0.
2020-03-12 junyer SRWLOCK requires Windows Vista or Windows Server 2008 at minimum.
2020-03-04 donatas.saulys Using slim RW lock on windows
2020-03-02 junyer Set SONAME to 6.
2020-03-01 junyer Bump SONAME to reflect the ABI break.
2020-02-28 junyer Add macOS and Xcode jobs to the Travis CI matrix.
2020-02-26 junyer Don't break the RE2 object when compiling the reverse Prog fails.
2020-02-26 junyer Revert "Refuse to rewrite when MaxSubmatch() is too large."
2020-02-25 junyer Fall back to NFA execution when compiling the reverse Prog failed.
2020-02-25 junyer Refuse to rewrite when MaxSubmatch() is too large.
2020-02-20 junyer Tweak the comment on RE2::QuoteMeta().
2020-02-17 junyer Move DeBruijnString() alongside StringGenerator.
2020-02-14 junyer Fix the check for Apple platforms. Mea culpa.
2020-02-14 junyer Provide hooks::context iff thread_local is supported.
2020-02-14 junyer Update doc/syntax.html.
2020-02-13 junyer MSVC also doesn't like casting lambdas with `+'. Sigh.
2020-02-13 junyer Only the latest MSVC allows designated initalisers.
2020-02-13 junyer Provide instrumentation points called "hooks".
2020-02-11 junyer Tidy up some GCC-only guards.
2020-02-04 junyer Tidy up the SWIG guard around LazyRE2.
2020-02-03 junyer Tweak some of the comments about FilteredRE2.
2020-01-31 junyer Avoid using the forward DFA in "ANCHOR_END" cases.
2020-01-29 junyer Make the fuzzer use FuzzedDataProvider.
2020-01-12 junyer Tidy up a test.
2020-01-07 junyer Prevent ShortVisit() from crashing fuzzers.
2020-01-05 junyer Fix a comment.
2019-12-29 junyer Make DFA use hints.
2019-12-13 junyer std::is_pod<> was deprecated in C++20.
2019-12-09 junyer Simplify the bytecode for the 80-10FFFF rune range.
2019-11-25 junyer Fix nullptr-with-nonzero-offset bugs found by UBSan.
2019-11-25 junyer Check if empty() instead of comparing size() with 0.
2019-11-10 junyer Fix a latent bug in Regexp::Walker<T>::Reset().
2019-10-29 junyer Tweak some printed debugging for style.
2019-10-29 junyer Address the MSVC warnings that crept in recently.
2019-10-29 junyer Simplify parse_double_float() in util/pcre.cc.
2019-10-13 junyer Fix the regexp_benchmark build with GNU make.
2019-10-11 junyer Oops, wrap a couple of lines.
2019-10-11 junyer Read flags using the GetFlag() style.
2019-10-11 junyer Make flags use the DEFINE_FLAG() style.
2019-10-11 junyer Remove a condition from exhaustive1_test.cc that is no longer needed.
2019-10-11 junyer Move util/flags.h into the testing target.
2019-10-11 junyer Don't declare testing::TempDir() in dump.cc itself.
2019-10-11 junyer Split out the fake testing::MallocCounter into its own file.
2019-10-11 junyer Remove the fake test_tmpdir flag in favour of testing::TempDir().
2019-10-10 junyer Remove the comment on NumCPUs().
2019-10-10 junyer Call .range(0) explicitly rather than just .range().
2019-10-10 junyer Move NumCPUs() into regexp_benchmark.cc.
2019-10-10 junyer Migrate to the new benchmark API.
2019-10-10 junyer Implement the new benchmark API as a layer over the old benchmark API.
2019-10-09 junyer Tidy up the ersatz benchmark library.
2019-10-07 junyer Move pod_array.h and sparse_{array,set}.h from util/ to re2/.

Roll external/spirv-headers/ f8bf11a02..ac638f181 (7 commits)

https://github.com/KhronosGroup/SPIRV-Headers/compare/f8bf11a0253a...ac638f181542

$ git log f8bf11a02..ac638f181 --date=short --no-merges --format='%ad %ae %s'
2020-05-20 dneto Update example to use unified1 headers
2020-04-24 cepheus Update headers to SPIR-V 1.5 Revision 3
2020-04-24 cepheus Add a bunch of missing "version" : "None" for ray tracing.
2020-04-24 cepheus Rebuild the headers with the fixed grammar file.
2020-04-24 cepheus Add missing "version" : "None" for ShaderCallKHR
2020-04-24 cepheus Grammar: The ray-tracing updates were not done in numerical ordering.
2020-04-13 cepheus Discuss generator magic number reservations.

Created with:
  roll-dep external/effcee external/googletest external/re2 external/spirv-headers