### PR TITLE
spirv-fuzz: Fix assertion failure related to transformation applicability

### DIFF
--- a/source/fuzz/fuzzer_pass_push_ids_through_variables.cpp
+++ b/source/fuzz/fuzzer_pass_push_ids_through_variables.cpp
@@ -80,12 +80,21 @@ void FuzzerPassPushIdsThroughVariables::Apply() {
         std::vector<opt::Instruction*> value_instructions =
             FindAvailableInstructions(
                 function, block, instruction_iterator,
-                [basic_type_id](opt::IRContext* /*unused*/,
-                                opt::Instruction* instruction) -> bool {
+                [basic_type_id, instruction_descriptor](
+                    opt::IRContext* ir_context,
+                    opt::Instruction* instruction) -> bool {
                   if (!instruction->result_id() || !instruction->type_id()) {
                     return false;
                   }
-                  return instruction->type_id() == basic_type_id;
+
+                  if (instruction->type_id() != basic_type_id) {
+                    return false;
+                  }
+
+                  return fuzzerutil::IdIsAvailableBeforeInstruction(
+                      ir_context,
+                      FindInstruction(instruction_descriptor, ir_context),
+                      instruction->result_id());
                 });
 
         if (value_instructions.empty()) {


### PR DESCRIPTION
This change fixes an assertion failure related to the push
id through variable transformation. In the fuzzer pass class
it was missing the `IdIsAvailableBeforeInstruction` condition
that is checked in the `IsApplicable` function.