### PR TITLE
spirv-fuzz: Fix instruction function use

### DIFF
--- a/source/fuzz/fuzzer_pass_adjust_memory_operands_masks.cpp
+++ b/source/fuzz/fuzzer_pass_adjust_memory_operands_masks.cpp
@@ -75,7 +75,7 @@ void FuzzerPassAdjustMemoryOperandsMasks::Apply() {
                   *inst_it, mask_index);
           auto existing_mask =
               existing_mask_in_operand_index < inst_it->NumInOperands()
-                  ? inst_it->GetSingleWordOperand(
+                  ? inst_it->GetSingleWordInOperand(
                         existing_mask_in_operand_index)
                   : static_cast<uint32_t>(SpvMemoryAccessMaskNone);
 


### PR DESCRIPTION
This change replaces the instruction function `GetSingleWordOperand`
with `GetSingleWordInOperand`. Debugging spirv-fuzz, `GetSingleWordOperand`
was returning the result id of an OpLoad instruction with memory operands.