### PR TITLE
Fix googletest inclusion

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -47,7 +47,7 @@ if (NOT ${SPIRV_SKIP_TESTS})
   if (TARGET gmock)
     message(STATUS "Google Mock already configured")
   else()
-    set(GMOCK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/googletest/googlemock)
+    set(GMOCK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/googletest)
     if(EXISTS ${GMOCK_DIR})
       if(MSVC)
         # Our tests use ::testing::Combine.  Work around a compiler


### PR DESCRIPTION
The googletest root CMakeLists.txt now sets a GOOGLETEST_VERSION variable, which is needed by the subprojects. We previously included only a subproject, which now fails. Use add_subdirectory(external/googletest EXCLUDE_FROM_ALL) to add the root CMakeLists.txt file, which by default builds GMock and GTest, as required. We already use EXCLUDE_FROM_ALL, which should shield us from e.g. building their tests, installing their targets, etc. If this causes issues, we can change the googletest CMakeLists.txt file to only mess with compiler settings, add tests, etc. if it is the root project being built.