### PR TITLE
spirv-val: Extend variable pointer return cases

### DIFF
--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -289,6 +289,7 @@ bool spvOpcodeReturnsLogicalVariablePointer(const SpvOp opcode) {
     case SpvOpPtrAccessChain:
     case SpvOpLoad:
     case SpvOpConstantNull:
+    case SpvOpCompositeExtract:
       return true;
     default:
       return false;


### PR DESCRIPTION
Fixes #3410.