### PR TITLE
WIP: validator: ImageWrite texel type clarified

### DIFF
--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -1526,22 +1526,14 @@ spv_result_t ValidateImageWrite(ValidationState_t& _, const Instruction* inst) {
            << " components, but given only " << actual_coord_size;
   }
 
-  // TODO(atgoo@github.com) The spec doesn't explicitely say what the type
-  // of texel should be.
   const uint32_t texel_type = _.GetOperandTypeId(inst, 2);
+  // Must be numeric scalar or vector.
+  // Khronos SPIR WG internal issue #573 clarified this.
   if (!_.IsIntScalarOrVectorType(texel_type) &&
       !_.IsFloatScalarOrVectorType(texel_type)) {
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
            << "Expected Texel to be int or float vector or scalar";
   }
-
-#if 0
-  // TODO: See above.
-  if (_.GetDimension(texel_type) != 4) {
-    return _.diag(SPV_ERROR_INVALID_DATA, inst)
-        << "Expected Texel to have 4 components";
-  }
-#endif
 
   if (_.GetIdOpcode(info.sampled_type) != SpvOpTypeVoid) {
     const uint32_t texel_component_type = _.GetComponentType(texel_type);


### PR DESCRIPTION
The validator already implemented the rule clarified
by Khronos SPIR WG issue 573:

- For ImageWrite, the texel type must be numeric scalar or numeric
  vector.
- When the image sampled type is non-void, then the texel scalar
  type or component type must match the image sampled type.

Fixes #3418