### PR TITLE
Debug info preservation in dead branch elimination

### DIFF
--- a/test/opt/dead_branch_elim_test.cpp
+++ b/test/opt/dead_branch_elim_test.cpp
@@ -3304,6 +3304,101 @@ OpFunctionEnd
   SinglePassRunAndMatch<DeadBranchElimPass>(text, true);
 }
 
+TEST_F(DeadBranchElimTest, DebugInformation) {
+  const std::string text = R"(
+OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+%ext = OpExtInstImport "OpenCL.DebugInfo.100"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %gl_FragColor
+OpExecutionMode %main OriginUpperLeft
+OpSource GLSL 140
+%name = OpString "test"
+OpName %main "main"
+OpName %gl_FragColor "gl_FragColor"
+%void = OpTypeVoid
+%5 = OpTypeFunction %void
+%bool = OpTypeBool
+%true = OpConstantTrue %bool
+%float = OpTypeFloat 32
+%v4float = OpTypeVector %float 4
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+%float_0 = OpConstant %float 0
+
+; CHECK: [[value:%\w+]] = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
+%12 = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
+%float_1 = OpConstant %float 1
+%14 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%gl_FragColor = OpVariable %_ptr_Output_v4float Output
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%uint = OpTypeInt 32 0
+%uint_32 = OpConstant %uint 32
+
+%null_expr = OpExtInst %void %ext DebugExpression
+%src = OpExtInst %void %ext DebugSource %name
+%cu = OpExtInst %void %ext DebugCompilationUnit 1 4 %src HLSL
+%ty = OpExtInst %void %ext DebugTypeFunction FlagIsProtected|FlagIsPrivate %void
+%dbg_main = OpExtInst %void %ext DebugFunction %name %ty %src 0 0 %cu %name FlagIsProtected|FlagIsPrivate 0 %main
+
+; CHECK: [[bb1:%\w+]] = OpExtInst %void [[ext:%\w+]] DebugLexicalBlock [[src:%\w+]] 1 0 [[dbg_main:%\w+]]
+; CHECK: [[bb2:%\w+]] = OpExtInst %void [[ext]] DebugLexicalBlock [[src]] 2 0 [[dbg_main]]
+; CHECK: [[bb3:%\w+]] = OpExtInst %void [[ext]] DebugLexicalBlock [[src]] 3 0 [[dbg_main]]
+%bb1 = OpExtInst %void %ext DebugLexicalBlock %src 1 0 %dbg_main
+%bb2 = OpExtInst %void %ext DebugLexicalBlock %src 2 0 %dbg_main
+%bb3 = OpExtInst %void %ext DebugLexicalBlock %src 3 0 %dbg_main
+
+%dbg_f = OpExtInst %void %ext DebugTypeBasic %name %uint_32 Float
+; CHECK: [[dbg_foo:%\w+]] = OpExtInst %void [[ext]] DebugLocalVariable {{%\w+}} [[ty:%\w+]] [[src]] 0 0 [[dbg_main]]
+%dbg_foo = OpExtInst %void %ext DebugLocalVariable %name %dbg_f %src 0 0 %dbg_main FlagIsLocal
+; CHECK: [[dbg_bar:%\w+]] = OpExtInst %void [[ext]] DebugLocalVariable {{%\w+}} [[ty]] [[src]] 1 0 [[bb3]]
+%dbg_bar = OpExtInst %void %ext DebugLocalVariable %name %dbg_f %src 1 0 %bb3 FlagIsLocal
+
+%main = OpFunction %void None %5
+%17 = OpLabel
+; CHECK-NOT: DebugScope [[dbg_main]]
+; CHECK-NOT: OpLine {{%\w+}} 0 0
+%scope0 = OpExtInst %void %ext DebugScope %dbg_main
+OpLine %name 0 0
+OpSelectionMerge %18 None
+OpBranchConditional %true %19 %20
+%19 = OpLabel
+; CHECK: DebugScope [[bb1]]
+; CHECK: OpLine {{%\w+}} 1 0
+%scope1 = OpExtInst %void %ext DebugScope %bb1
+OpLine %name 1 0
+OpBranch %18
+%20 = OpLabel
+; CHECK-NOT: DebugScope [[bb2]]
+; CHECK-NOT: OpLine {{%\w+}} 2 0
+%scope2 = OpExtInst %void %ext DebugScope %bb2
+OpLine %name 2 0
+OpBranch %18
+%18 = OpLabel
+
+; CHECK: DebugScope [[bb3]]
+; CHECK-NOT: OpLine {{%\w+}} 3 0
+; CHECK: DebugValue [[dbg_foo]] [[value]]
+; CHECK: OpLine {{%\w+}} 4 0
+; CHECK: OpStore %gl_FragColor [[value]]
+; CHECK: DebugDeclare [[dbg_bar]] %gl_FragColor
+; CHECK: DebugValue [[dbg_bar]] [[value]]
+%scope3 = OpExtInst %void %ext DebugScope %bb3
+OpLine %name 3 0
+%21 = OpPhi %v4float %12 %19 %14 %20
+%decl0 = OpExtInst %void %ext DebugValue %dbg_foo %21 %null_expr
+OpLine %name 4 0
+OpStore %gl_FragColor %21
+%decl1 = OpExtInst %void %ext DebugDeclare %dbg_bar %gl_FragColor %null_expr
+%decl2 = OpExtInst %void %ext DebugValue %dbg_bar %21 %null_expr
+OpLine %name 5 0
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<DeadBranchElimPass>(text, true);
+}
+
 // TODO(greg-lunarg): Add tests to verify handling of these cases:
 //
 //    More complex control flow


### PR DESCRIPTION
The DeadBranchElimPass class already handles the OpenCL.DebugInfo.100
instructions correctly. This commit just adds a unit test to make sure
it preserves the information properly.