### PR TITLE
Add support for different default branches in roll-deps

### DIFF
--- a/utils/roll_deps.sh
+++ b/utils/roll_deps.sh
@@ -13,19 +13,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Attempts to roll all entries in DEPS to origin/master and creates a
-# commit.
+# Attempts to roll all entries in DEPS to tip-of-tree and create a commit.
 #
 # Depends on roll-dep from depot_path being in PATH.
+
+effcee_dir="third_party/effcee/"
+effcee_trunk="origin/main"
+googletest_dir="third_party/googletest/"
+googletest_trunk="origin/master"
+re2_dir="third_party/re2/"
+re2_trunk="origin/master"
+spirv_headers_dir="third_party/spirv-headers/"
+spirv_headers_trunk="origin/master"
 
 # This script assumes it's parent directory is the repo root.
 repo_path=$(dirname "$0")/..
 
-effcee_dir="external/effcee/"
-googletest_dir="external/googletest/"
-re2_dir="external/re2/"
-spirv_headers_dir="external/spirv-headers/"
-
 cd "$repo_path"
 
-roll-dep "$@" "${effcee_dir}" "${googletest_dir}" "${re2_dir}" "${spirv_headers_dir}"
+if [[ $(git diff --stat) != '' ]]; then
+    echo "Working tree is dirty, commit changes before attempting to roll DEPS"
+    exit 1
+fi
+
+old_head=$(git rev-parse HEAD)
+
+roll-dep --ignore-dirty-tree --roll-to="${effcee_trunk}" "${effcee_dir}"
+roll-dep --ignore-dirty-tree --roll-to="${googletest_trunk}" "${googletest_dir}"
+roll-dep --ignore-dirty-tree --roll-to="${re2_trunk}" "${re2_dir}"
+roll-dep --ignore-dirty-tree --roll-to="${spirv_headers_trunk}" "${spirv_headers_dir}"
+
+git rebase --interactive "${old_head}"


### PR DESCRIPTION
This in anticipation of some repos changing their default branch name. This is based off to the change I made in https://github.com/google/shaderc/pull/1086