### PR TITLE
Debug info preservation in copy-prop-array pass

### DIFF
--- a/source/opt/copy_prop_arrays.cpp
+++ b/source/opt/copy_prop_arrays.cpp
@@ -29,6 +29,12 @@ const uint32_t kCompositeExtractObjectInOperand = 0;
 const uint32_t kTypePointerStorageClassInIdx = 0;
 const uint32_t kTypePointerPointeeInIdx = 1;
 
+bool IsOpenCL100DebugInstructionReferencingOpVariable(Instruction* di) {
+  auto dbg_opcode = di->GetOpenCL100DebugOpcode();
+  return dbg_opcode == OpenCLDebugInfo100DebugDeclare ||
+         dbg_opcode == OpenCLDebugInfo100DebugValue;
+}
+
 }  // namespace
 
 Pass::Status CopyPropagateArrays::Process() {
@@ -188,6 +194,8 @@ bool CopyPropagateArrays::HasValidReferencesOnly(Instruction* ptr_inst,
           return ptr_inst->opcode() == SpvOpVariable &&
                  store_inst->GetSingleWordInOperand(kStorePointerInOperand) ==
                      ptr_inst->result_id();
+        } else if (IsOpenCL100DebugInstructionReferencingOpVariable(use)) {
+          return true;
         }
         // Some other instruction.  Be conservative.
         return false;
@@ -492,6 +500,8 @@ bool CopyPropagateArrays::CanUpdateUses(Instruction* original_ptr_inst,
                                                        const_mgr,
                                                        type](Instruction* use,
                                                              uint32_t) {
+    if (IsOpenCL100DebugInstructionReferencingOpVariable(use)) return true;
+
     switch (use->opcode()) {
       case SpvOpLoad: {
         analysis::Pointer* pointer_type = type->AsPointer();
@@ -565,6 +575,7 @@ bool CopyPropagateArrays::CanUpdateUses(Instruction* original_ptr_inst,
     }
   });
 }
+
 void CopyPropagateArrays::UpdateUses(Instruction* original_ptr_inst,
                                      Instruction* new_ptr_inst) {
   analysis::TypeManager* type_mgr = context()->get_type_mgr();
@@ -580,6 +591,39 @@ void CopyPropagateArrays::UpdateUses(Instruction* original_ptr_inst,
   for (auto pair : uses) {
     Instruction* use = pair.first;
     uint32_t index = pair.second;
+
+    if (use->GetOpenCL100DebugOpcode() != OpenCLDebugInfo100InstructionsMax) {
+      switch (use->GetOpenCL100DebugOpcode()) {
+        case OpenCLDebugInfo100DebugDeclare: {
+          context()->ForgetUses(use);
+          use->SetOperand(
+              index - 2, {static_cast<uint32_t>(OpenCLDebugInfo100DebugValue)});
+          use->SetOperand(index, {new_ptr_inst->result_id()});
+
+          // Insert a Deref Operation to the DebugExpress.
+          Instruction* dbg_expr =
+              def_use_mgr->GetDef(use->GetSingleWordOperand(index + 1));
+          auto* deref_expr_instr =
+              get_debug_info_mgr()->CloneDebugExpressionAndPushDerefOperation(
+                  dbg_expr);
+          use->SetOperand(index + 1, {deref_expr_instr->result_id()});
+
+          context()->AnalyzeUses(deref_expr_instr);
+          context()->AnalyzeUses(use);
+          break;
+        }
+        case OpenCLDebugInfo100DebugValue:
+          context()->ForgetUses(use);
+          use->SetOperand(index, {new_ptr_inst->result_id()});
+          context()->AnalyzeUses(use);
+          break;
+        default:
+          assert(false && "Don't know how to rewrite instruction");
+          break;
+      }
+      continue;
+    }
+
     switch (use->opcode()) {
       case SpvOpLoad: {
         // Replace the actual use.

--- a/source/opt/copy_prop_arrays.cpp
+++ b/source/opt/copy_prop_arrays.cpp
@@ -609,7 +609,8 @@ void CopyPropagateArrays::UpdateUses(Instruction* original_ptr_inst,
 
             // Change DebugDeclare to DebugValue.
             use->SetOperand(
-                index - 2, {static_cast<uint32_t>(OpenCLDebugInfo100DebugValue)});
+                index - 2,
+                {static_cast<uint32_t>(OpenCLDebugInfo100DebugValue)});
             use->SetOperand(index, {new_ptr_inst->result_id()});
 
             // Add Deref operation.

--- a/source/opt/debug_info_manager.cpp
+++ b/source/opt/debug_info_manager.cpp
@@ -614,9 +614,10 @@ void DebugInfoManager::ClearDebugInfo(Instruction* instr) {
          dbg_instr_itr != context()->module()->ext_inst_debuginfo_end();
          ++dbg_instr_itr) {
       if (instr != &*dbg_instr_itr &&
-          dbg_instr_itr->GetOpenCL100DebugOpcode() == OpenCLDebugInfo100DebugOperation &&
-          dbg_instr_itr->GetSingleWordOperand(kDebugOperationOperandOpCodeIndex) ==
-              OpenCLDebugInfo100Deref) {
+          dbg_instr_itr->GetOpenCL100DebugOpcode() ==
+              OpenCLDebugInfo100DebugOperation &&
+          dbg_instr_itr->GetSingleWordOperand(
+              kDebugOperationOperandOpCodeIndex) == OpenCLDebugInfo100Deref) {
         deref_operation_ = &*dbg_instr_itr;
         break;
       }

--- a/source/opt/debug_info_manager.cpp
+++ b/source/opt/debug_info_manager.cpp
@@ -608,6 +608,21 @@ void DebugInfoManager::ClearDebugInfo(Instruction* instr) {
     }
   }
 
+  if (deref_operation_ == instr) {
+    deref_operation_ = nullptr;
+    for (auto dbg_instr_itr = context()->module()->ext_inst_debuginfo_begin();
+         dbg_instr_itr != context()->module()->ext_inst_debuginfo_end();
+         ++dbg_instr_itr) {
+      if (instr != &*dbg_instr_itr &&
+          dbg_instr_itr->GetOpenCL100DebugOpcode() == OpenCLDebugInfo100DebugOperation &&
+          dbg_instr_itr->GetSingleWordOperand(kDebugOperationOperandOpCodeIndex) ==
+              OpenCLDebugInfo100Deref) {
+        deref_operation_ = &*dbg_instr_itr;
+        break;
+      }
+    }
+  }
+
   if (debug_info_none_inst_ == instr) {
     debug_info_none_inst_ = nullptr;
     for (auto dbg_instr_itr = context()->module()->ext_inst_debuginfo_begin();
@@ -617,6 +632,7 @@ void DebugInfoManager::ClearDebugInfo(Instruction* instr) {
           dbg_instr_itr->GetOpenCL100DebugOpcode() ==
               OpenCLDebugInfo100DebugInfoNone) {
         debug_info_none_inst_ = &*dbg_instr_itr;
+        break;
       }
     }
   }
@@ -628,6 +644,7 @@ void DebugInfoManager::ClearDebugInfo(Instruction* instr) {
          ++dbg_instr_itr) {
       if (instr != &*dbg_instr_itr && IsEmptyDebugExpression(&*dbg_instr_itr)) {
         empty_debug_expr_inst_ = &*dbg_instr_itr;
+        break;
       }
     }
   }

--- a/source/opt/debug_info_manager.cpp
+++ b/source/opt/debug_info_manager.cpp
@@ -274,8 +274,7 @@ Instruction* DebugInfoManager::GetDebugOperationWithDeref() {
   return deref_operation_;
 }
 
-Instruction* DebugInfoManager::CloneDebugExpressionAndPushDerefOperation(
-    Instruction* dbg_expr) {
+Instruction* DebugInfoManager::DerefDebugExpression(Instruction* dbg_expr) {
   assert(dbg_expr->GetOpenCL100DebugOpcode() ==
          OpenCLDebugInfo100DebugExpression);
   std::unique_ptr<Instruction> deref_expr(dbg_expr->Clone(context()));

--- a/source/opt/debug_info_manager.h
+++ b/source/opt/debug_info_manager.h
@@ -97,7 +97,7 @@ class DebugInfoManager {
 
   // Clones DebugExpress instruction |dbg_expr| and add Deref Operation
   // in the front of the Operation list of |dbg_expr|.
-  Instruction* CloneDebugExpressionAndPushDerefOperation(Instruction* dbg_expr);
+  Instruction* DerefDebugExpression(Instruction* dbg_expr);
 
   // Returns a DebugInfoNone instruction.
   Instruction* GetDebugInfoNone();

--- a/source/opt/debug_info_manager.h
+++ b/source/opt/debug_info_manager.h
@@ -95,6 +95,10 @@ class DebugInfoManager {
   uint32_t CreateDebugInlinedAt(const Instruction* line,
                                 const DebugScope& scope);
 
+  // Clones DebugExpress instruction |dbg_expr| and add Deref Operation
+  // in the front of the Operation list of |dbg_expr|.
+  Instruction* CloneDebugExpressionAndPushDerefOperation(Instruction* dbg_expr);
+
   // Returns a DebugInfoNone instruction.
   Instruction* GetDebugInfoNone();
 
@@ -149,6 +153,9 @@ class DebugInfoManager {
   // does not exists.
   Instruction* GetDbgInst(uint32_t id);
 
+  // Returns a DebugOperation instruction with OpCode Deref.
+  Instruction* GetDebugOperationWithDeref();
+
   // Registers the debug instruction |inst| into |id_to_dbg_inst_| using id of
   // |inst| as a key.
   void RegisterDbgInst(Instruction* inst);
@@ -196,6 +203,9 @@ class DebugInfoManager {
   // instructions whose operand is the variable or value.
   std::unordered_map<uint32_t, std::unordered_set<Instruction*>>
       var_id_to_dbg_decl_;
+
+  // DebugOperation whose OpCode is OpenCLDebugInfo100Deref.
+  Instruction* deref_operation_;
 
   // DebugInfoNone instruction. We need only a single DebugInfoNone.
   // To reuse the existing one, we keep it using this member variable.

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -306,6 +306,10 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   void RemoveOperand(uint32_t index) {
     operands_.erase(operands_.begin() + index);
   }
+  // Insert an operand before the |index|-th operand
+  void InsertOperand(uint32_t index, Operand&& operand) {
+    operands_.insert(operands_.begin() + index, operand);
+  }
 
   // The following methods are similar to the above, but are for in operands.
   uint32_t NumInOperands() const {

--- a/source/opt/pass.h
+++ b/source/opt/pass.h
@@ -71,10 +71,6 @@ class Pass {
     return context()->get_def_use_mgr();
   }
 
-  analysis::DebugInfoManager* get_debug_info_mgr() const {
-    return context()->get_debug_info_mgr();
-  }
-
   analysis::DecorationManager* get_decoration_mgr() const {
     return context()->get_decoration_mgr();
   }

--- a/source/opt/ssa_rewrite_pass.cpp
+++ b/source/opt/ssa_rewrite_pass.cpp
@@ -307,7 +307,8 @@ void SSARewriter::ProcessStore(Instruction* inst, BasicBlock* bb) {
   }
   if (pass_->IsTargetVar(var_id)) {
     WriteVariable(var_id, bb, val_id);
-    pass_->get_debug_info_mgr()->AddDebugValue(inst, var_id, val_id, inst);
+    pass_->context()->get_debug_info_mgr()->AddDebugValue(inst, var_id, val_id,
+                                                          inst);
 
 #if SSA_REWRITE_DEBUGGING_LEVEL > 1
     std::cerr << "\tFound store '%" << var_id << " = %" << val_id << "': "
@@ -490,7 +491,7 @@ bool SSARewriter::ApplyReplacements() {
 
     // Add DebugValue for the new OpPhi instruction.
     insert_it->SetDebugScope(local_var->GetDebugScope());
-    pass_->get_debug_info_mgr()->AddDebugValue(
+    pass_->context()->get_debug_info_mgr()->AddDebugValue(
         &*insert_it, phi_candidate->var_id(), phi_candidate->result_id(),
         &*insert_it);
 


### PR DESCRIPTION
When the pass replaces the local variable `OpVariable` ids to their
corresponding pointers, we have to update operands of DebugValue or
DebugDeclare instructions that are the local variable ids.

Fixes #3429