### PR TITLE
Updated desc_sroa to support flattening structures

### DIFF
--- a/source/opt/desc_sroa.cpp
+++ b/source/opt/desc_sroa.cpp
@@ -56,8 +56,20 @@ bool DescriptorScalarReplacement::IsCandidate(Instruction* var) {
   uint32_t var_type_id = ptr_type_inst->GetSingleWordInOperand(1);
   Instruction* var_type_inst =
       context()->get_def_use_mgr()->GetDef(var_type_id);
-  if (var_type_inst->opcode() != SpvOpTypeArray) {
+  if (var_type_inst->opcode() != SpvOpTypeArray &&
+      var_type_inst->opcode() != SpvOpTypeStruct) {
     return false;
+  }
+
+  // All structures with descriptor assignments must be replaced by variables,
+  // one for each of their members - with the exception of a structure that
+  // contains only a runtime array.
+  if (var_type_inst->opcode() == SpvOpTypeStruct) {
+    if (var_type_inst->NumInOperands() == 1) {
+      Instruction* member_type_inst = context()->get_def_use_mgr()->GetDef(
+          var_type_inst->GetSingleWordInOperand(0));
+      if (member_type_inst->opcode() == SpvOpTypeRuntimeArray) return false;
+    }
   }
 
   bool has_desc_set_decoration = false;
@@ -177,21 +189,36 @@ uint32_t DescriptorScalarReplacement::GetReplacementVariable(Instruction* var,
     uint32_t ptr_type_id = var->type_id();
     Instruction* ptr_type_inst = get_def_use_mgr()->GetDef(ptr_type_id);
     assert(ptr_type_inst->opcode() == SpvOpTypePointer &&
-           "Variable should be a pointer to an array.");
-    uint32_t arr_type_id = ptr_type_inst->GetSingleWordInOperand(1);
-    Instruction* arr_type_inst = get_def_use_mgr()->GetDef(arr_type_id);
-    assert(arr_type_inst->opcode() == SpvOpTypeArray &&
-           "Variable should be a pointer to an array.");
+           "Variable should be a pointer to an array or structure.");
+    uint32_t pointee_type_id = ptr_type_inst->GetSingleWordInOperand(1);
+    Instruction* pointee_type_inst = get_def_use_mgr()->GetDef(pointee_type_id);
+    const bool is_array = pointee_type_inst->opcode() == SpvOpTypeArray;
+    const bool is_struct = pointee_type_inst->opcode() == SpvOpTypeStruct;
+    assert((is_array || is_struct) &&
+           "Variable should be a pointer to an array or structure.");
 
-    uint32_t array_len_id = arr_type_inst->GetSingleWordInOperand(1);
-    const analysis::Constant* array_len_const =
-        context()->get_constant_mgr()->FindDeclaredConstant(array_len_id);
-    assert(array_len_const != nullptr && "Array length must be a constant.");
-    uint32_t array_len = array_len_const->GetU32();
+    // For arrays, each array element should be replaced with a new replacement
+    // variable
+    if (is_array) {
+      uint32_t array_len_id = pointee_type_inst->GetSingleWordInOperand(1);
+      const analysis::Constant* array_len_const =
+          context()->get_constant_mgr()->FindDeclaredConstant(array_len_id);
+      assert(array_len_const != nullptr && "Array length must be a constant.");
+      uint32_t array_len = array_len_const->GetU32();
 
-    replacement_vars = replacement_variables_
-                           .insert({var, std::vector<uint32_t>(array_len, 0)})
-                           .first;
+      replacement_vars = replacement_variables_
+                             .insert({var, std::vector<uint32_t>(array_len, 0)})
+                             .first;
+    }
+    // For structures, each member should be replaced with a new replacement
+    // variable
+    if (is_struct) {
+      const uint32_t num_members = pointee_type_inst->NumInOperands();
+      replacement_vars =
+          replacement_variables_
+              .insert({var, std::vector<uint32_t>(num_members, 0)})
+              .first;
+    }
   }
 
   if (replacement_vars->second[idx] == 0) {
@@ -212,12 +239,17 @@ uint32_t DescriptorScalarReplacement::CreateReplacementVariable(
   uint32_t ptr_type_id = var->type_id();
   Instruction* ptr_type_inst = get_def_use_mgr()->GetDef(ptr_type_id);
   assert(ptr_type_inst->opcode() == SpvOpTypePointer &&
-         "Variable should be a pointer to an array.");
-  uint32_t arr_type_id = ptr_type_inst->GetSingleWordInOperand(1);
-  Instruction* arr_type_inst = get_def_use_mgr()->GetDef(arr_type_id);
-  assert(arr_type_inst->opcode() == SpvOpTypeArray &&
-         "Variable should be a pointer to an array.");
-  uint32_t element_type_id = arr_type_inst->GetSingleWordInOperand(0);
+         "Variable should be a pointer to an array or structure.");
+  uint32_t pointee_type_id = ptr_type_inst->GetSingleWordInOperand(1);
+  Instruction* pointee_type_inst = get_def_use_mgr()->GetDef(pointee_type_id);
+  const bool is_array = pointee_type_inst->opcode() == SpvOpTypeArray;
+  const bool is_struct = pointee_type_inst->opcode() == SpvOpTypeStruct;
+  assert((is_array || is_struct) &&
+         "Variable should be a pointer to an array or structure.");
+
+  uint32_t element_type_id =
+      is_array ? pointee_type_inst->GetSingleWordInOperand(0)
+               : pointee_type_inst->GetSingleWordInOperand(idx);
 
   uint32_t ptr_element_type_id = context()->get_type_mgr()->FindPointerToType(
       element_type_id, storage_class);
@@ -242,19 +274,32 @@ uint32_t DescriptorScalarReplacement::CreateReplacementVariable(
 
     uint32_t decoration = new_decoration->GetSingleWordInOperand(1u);
     if (decoration == SpvDecorationBinding) {
-      uint32_t new_binding = new_decoration->GetSingleWordInOperand(2) + idx;
+      uint32_t new_binding = new_decoration->GetSingleWordInOperand(2) +
+                             idx * GetNumBindingsUsedByType(ptr_element_type_id);
       new_decoration->SetInOperand(2, {new_binding});
     }
     context()->AddAnnotationInst(std::move(new_decoration));
   }
 
   // Create a new OpName for the replacement variable.
+  std::vector<std::unique_ptr<Instruction>> names_to_add;
   for (auto p : context()->GetNames(var->result_id())) {
     Instruction* name_inst = p.second;
     std::string name_str = utils::MakeString(name_inst->GetOperand(1).words);
-    name_str += "[";
-    name_str += utils::ToString(idx);
-    name_str += "]";
+    if (is_array) {
+      name_str += "[" + utils::ToString(idx) + "]";
+    }
+    if (is_struct) {
+      Instruction* member_name_inst =
+          context()->GetMemberName(pointee_type_inst->result_id(), idx);
+      name_str += ".";
+      if (member_name_inst)
+        name_str += utils::MakeString(member_name_inst->GetOperand(2).words);
+      else
+        // In case the member does not have a name assigned to it, use the
+        // member index.
+        name_str += utils::ToString(idx);
+    }
 
     std::unique_ptr<Instruction> new_name(new Instruction(
         context(), SpvOpName, 0, 0,
@@ -262,11 +307,51 @@ uint32_t DescriptorScalarReplacement::CreateReplacementVariable(
             {SPV_OPERAND_TYPE_ID, {id}},
             {SPV_OPERAND_TYPE_LITERAL_STRING, utils::MakeVector(name_str)}}));
     Instruction* new_name_inst = new_name.get();
-    context()->AddDebug2Inst(std::move(new_name));
     get_def_use_mgr()->AnalyzeInstDefUse(new_name_inst);
+    names_to_add.push_back(std::move(new_name));
   }
 
+  // We shouldn't add the new names when we are iterating over name ranges
+  // above. We can add all the new names now.
+  for (auto& new_name : names_to_add)
+    context()->AddDebug2Inst(std::move(new_name));
+
   return id;
+}
+
+uint32_t DescriptorScalarReplacement::GetNumBindingsUsedByType(uint32_t type_id) {
+  Instruction* type_inst = get_def_use_mgr()->GetDef(type_id);
+
+  // If it's a pointer, look at the underlying type.
+  if(type_inst->opcode() == SpvOpTypePointer) {
+    type_id = type_inst->GetSingleWordInOperand(1);
+    type_inst = get_def_use_mgr()->GetDef(type_id);
+  }
+
+  // Arrays consume N*M binding numbers where N is the array length, and M is
+  // the number of bindings used by each array element.
+  if(type_inst->opcode() == SpvOpTypeArray) {
+    uint32_t element_type_id = type_inst->GetSingleWordInOperand(0);
+    uint32_t length_id = type_inst->GetSingleWordInOperand(1);
+    const analysis::Constant* length_const =
+        context()->get_constant_mgr()->FindDeclaredConstant(length_id);
+    // OpTypeArray's length must always be a constant
+    assert(length_const != nullptr);
+    uint32_t num_elems = length_const->GetU32();
+    return num_elems * GetNumBindingsUsedByType(element_type_id);
+  }
+
+  // Structures consume M binding numbers where M is the sum of binding numbers
+  // used by their members.
+  if(type_inst->opcode() == SpvOpTypeStruct) {
+    uint32_t sum = 0;
+    for (uint32_t i = 0; i < type_inst->NumInOperands(); i++)
+      sum += GetNumBindingsUsedByType(type_inst->GetSingleWordInOperand(i));
+    return sum;
+  }
+
+  // All other types are considered to take up 1 binding number.
+  return 1;
 }
 
 }  // namespace opt

--- a/source/opt/desc_sroa.cpp
+++ b/source/opt/desc_sroa.cpp
@@ -274,8 +274,9 @@ uint32_t DescriptorScalarReplacement::CreateReplacementVariable(
 
     uint32_t decoration = new_decoration->GetSingleWordInOperand(1u);
     if (decoration == SpvDecorationBinding) {
-      uint32_t new_binding = new_decoration->GetSingleWordInOperand(2) +
-                             idx * GetNumBindingsUsedByType(ptr_element_type_id);
+      uint32_t new_binding =
+          new_decoration->GetSingleWordInOperand(2) +
+          idx * GetNumBindingsUsedByType(ptr_element_type_id);
       new_decoration->SetInOperand(2, {new_binding});
     }
     context()->AddAnnotationInst(std::move(new_decoration));
@@ -319,18 +320,19 @@ uint32_t DescriptorScalarReplacement::CreateReplacementVariable(
   return id;
 }
 
-uint32_t DescriptorScalarReplacement::GetNumBindingsUsedByType(uint32_t type_id) {
+uint32_t DescriptorScalarReplacement::GetNumBindingsUsedByType(
+    uint32_t type_id) {
   Instruction* type_inst = get_def_use_mgr()->GetDef(type_id);
 
   // If it's a pointer, look at the underlying type.
-  if(type_inst->opcode() == SpvOpTypePointer) {
+  if (type_inst->opcode() == SpvOpTypePointer) {
     type_id = type_inst->GetSingleWordInOperand(1);
     type_inst = get_def_use_mgr()->GetDef(type_id);
   }
 
   // Arrays consume N*M binding numbers where N is the array length, and M is
   // the number of bindings used by each array element.
-  if(type_inst->opcode() == SpvOpTypeArray) {
+  if (type_inst->opcode() == SpvOpTypeArray) {
     uint32_t element_type_id = type_inst->GetSingleWordInOperand(0);
     uint32_t length_id = type_inst->GetSingleWordInOperand(1);
     const analysis::Constant* length_const =
@@ -343,7 +345,7 @@ uint32_t DescriptorScalarReplacement::GetNumBindingsUsedByType(uint32_t type_id)
 
   // Structures consume M binding numbers where M is the sum of binding numbers
   // used by their members.
-  if(type_inst->opcode() == SpvOpTypeStruct) {
+  if (type_inst->opcode() == SpvOpTypeStruct) {
     uint32_t sum = 0;
     for (uint32_t i = 0; i < type_inst->NumInOperands(); i++)
       sum += GetNumBindingsUsedByType(type_inst->GetSingleWordInOperand(i));

--- a/source/opt/desc_sroa.h
+++ b/source/opt/desc_sroa.h
@@ -70,6 +70,15 @@ class DescriptorScalarReplacement : public Pass {
   // element of |var|.
   uint32_t CreateReplacementVariable(Instruction* var, uint32_t idx);
 
+  // Returns the number of bindings used by the given |type_id|.
+  // All types are considered to use 1 binding slot, except:
+  // 1- A pointer type consumes as many binding numbers as its pointee.
+  // 2- An array of size N consumes N*M binding numbers, where M is the number
+  // of bindings used by each array element.
+  // 3- A structure consumes M binding numbers where M is the sum of binding
+  // numbers used by its members.
+  uint32_t GetNumBindingsUsedByType(uint32_t type_id);
+
   // A map from an OpVariable instruction to the set of variables that will be
   // used to replace it. The entry |replacement_variables_[var][i]| is the id of
   // a variable that will be used in the place of the the ith element of the

--- a/source/opt/desc_sroa.h
+++ b/source/opt/desc_sroa.h
@@ -75,8 +75,8 @@ class DescriptorScalarReplacement : public Pass {
   // 1- A pointer type consumes as many binding numbers as its pointee.
   // 2- An array of size N consumes N*M binding numbers, where M is the number
   // of bindings used by each array element.
-  // 3- A structure consumes M binding numbers where M is the sum of binding
-  // numbers used by its members.
+  // 3- The number of bindings consumed by a structure is the sum of the
+  // bindings used by its members.
   uint32_t GetNumBindingsUsedByType(uint32_t type_id);
 
   // A map from an OpVariable instruction to the set of variables that will be

--- a/source/opt/ir_context.h
+++ b/source/opt/ir_context.h
@@ -357,6 +357,13 @@ class IRContext {
   inline IteratorRange<std::multimap<uint32_t, Instruction*>::iterator>
   GetNames(uint32_t id);
 
+  // Returns an OpMemberName instruction that targets |struct_type_id| at
+  // index |index|. Returns nullptr if such instruction does not exist.
+  // While the SPIR-V spec does not prohibit having multiple OpMemberName
+  // instructions for the same structure member, it is hard to imagine a member
+  // having more than one name. This method returns the first one it finds.
+  inline Instruction* GetMemberName(uint32_t struct_type_id, uint32_t index);
+
   // Sets the message consumer to the given |consumer|. |consumer| which will be
   // invoked every time there is a message to be communicated to the outside.
   void SetMessageConsumer(MessageConsumer c) { consumer_ = std::move(c); }
@@ -1061,7 +1068,9 @@ void IRContext::AddDebug1Inst(std::unique_ptr<Instruction>&& d) {
 void IRContext::AddDebug2Inst(std::unique_ptr<Instruction>&& d) {
   if (AreAnalysesValid(kAnalysisNameMap)) {
     if (d->opcode() == SpvOpName || d->opcode() == SpvOpMemberName) {
-      id_to_name_->insert({d->result_id(), d.get()});
+      // OpName and OpMemberName do not have result-ids. The target of the
+      // instruction is at InOperand index 0.
+      id_to_name_->insert({d->GetSingleWordInOperand(0), d.get()});
     }
   }
   module()->AddDebug2Inst(std::move(d));
@@ -1133,6 +1142,21 @@ IRContext::GetNames(uint32_t id) {
   }
   auto result = id_to_name_->equal_range(id);
   return make_range(std::move(result.first), std::move(result.second));
+}
+
+Instruction* IRContext::GetMemberName(uint32_t struct_type_id, uint32_t index) {
+  if (!AreAnalysesValid(kAnalysisNameMap)) {
+    BuildIdToNameMap();
+  }
+  auto result = id_to_name_->equal_range(struct_type_id);
+  for (auto i = result.first; i != result.second; ++i) {
+    auto* name_instr = i->second;
+    if (name_instr->opcode() == SpvOpMemberName &&
+        name_instr->GetSingleWordInOperand(1) == index) {
+      return name_instr;
+    }
+  }
+  return nullptr;
 }
 
 }  // namespace opt

--- a/source/opt/ir_context.h
+++ b/source/opt/ir_context.h
@@ -358,7 +358,7 @@ class IRContext {
   GetNames(uint32_t id);
 
   // Returns an OpMemberName instruction that targets |struct_type_id| at
-  // index |index|. Returns nullptr if such instruction does not exist.
+  // index |index|. Returns nullptr if no such instruction exists.
   // While the SPIR-V spec does not prohibit having multiple OpMemberName
   // instructions for the same structure member, it is hard to imagine a member
   // having more than one name. This method returns the first one it finds.


### PR DESCRIPTION
This doesn't cover cases where we have the following pattern:
```
         %31 = OpAccessChain %_ptr_UniformConstant_S %globalS %int_0 %int_0
         %32 = OpLoad %S %31
         %33 = OpCompositeExtract %_arr_type_2d_image_uint_2 %32 0
         %34 = OpCompositeExtract %type_2d_image %33 0
         %35 = OpCompositeExtract %type_2d_image %33 1
         %36 = OpCompositeExtract %_arr_T_uint_2 %32 1
         %37 = OpCompositeExtract %T %36 0
         %38 = OpCompositeExtract %_arr_type_sampler_uint_3 %37 0
         %39 = OpCompositeExtract %type_sampler %38 1
         %40 = OpCompositeExtract %T %36 1
         %41 = OpCompositeExtract %_arr_type_sampler_uint_3 %40 0
         %42 = OpCompositeExtract %type_sampler %41 2
         %43 = OpSampledImage %type_sampled_image %34 %39
         %44 = OpImageSampleImplicitLod %v4float %43 %14 None
```

This pattern could be seen if a global structure of resources is passed to a function.