### PR TITLE
spirv-fuzz: Add GetParameters

### DIFF
--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -675,6 +675,18 @@ bool IsPermutationOfRange(const std::vector<uint32_t>& arr, uint32_t lo,
          *min_max.second == hi;
 }
 
+std::vector<opt::Instruction*> GetParameters(opt::IRContext* ir_context,
+                                             uint32_t function_id) {
+  auto* function = FindFunction(ir_context, function_id);
+  assert(function && "|function_id| is invalid");
+
+  std::vector<opt::Instruction*> result;
+  function->ForEachParam(
+      [&result](opt::Instruction* inst) { result.push_back(inst); });
+
+  return result;
+}
+
 }  // namespace fuzzerutil
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -261,7 +261,7 @@ bool HasDuplicates(const std::vector<uint32_t>& arr);
 bool IsPermutationOfRange(const std::vector<uint32_t>& arr, uint32_t lo,
                           uint32_t hi);
 
-// Returns OpFunctionParameter instruction corresponding to the function
+// Returns OpFunctionParameter instructions corresponding to the function
 // with result id |function_id|.
 std::vector<opt::Instruction*> GetParameters(opt::IRContext* ir_context,
                                              uint32_t function_id);

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -261,6 +261,11 @@ bool HasDuplicates(const std::vector<uint32_t>& arr);
 bool IsPermutationOfRange(const std::vector<uint32_t>& arr, uint32_t lo,
                           uint32_t hi);
 
+// Returns OpFunctionParameter instruction corresponding to the function
+// with result id |function_id|.
+std::vector<opt::Instruction*> GetParameters(opt::IRContext* ir_context,
+                                             uint32_t function_id);
+
 }  // namespace fuzzerutil
 
 }  // namespace fuzz


### PR DESCRIPTION
Adds a `GetParameters` function to `fuzzerutil`.