### PR TITLE
Clear debug information for kill and replacement

### DIFF
--- a/source/opt/debug_info_manager.h
+++ b/source/opt/debug_info_manager.h
@@ -15,8 +15,8 @@
 #ifndef SOURCE_OPT_DEBUG_INFO_MANAGER_H_
 #define SOURCE_OPT_DEBUG_INFO_MANAGER_H_
 
-#include <list>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "source/opt/instruction.h"
 #include "source/opt/module.h"
@@ -138,12 +138,6 @@ class DebugInfoManager {
   // Erases |instr| from data structures of this class.
   void ClearDebugInfo(Instruction* instr);
 
-  // Runs the given function |f| on each DebugDeclare or DebugValue
-  // instruction whose variable or value is |var_or_value_id|.
-  void ForEachDebugDeclareOrValue(
-      uint32_t var_or_value_id,
-      const std::function<void(Instruction*)>& f) const;
-
  private:
   IRContext* context() { return context_; }
 
@@ -163,18 +157,18 @@ class DebugInfoManager {
   // in |inst| must not already be registered.
   void RegisterDbgFunction(Instruction* inst);
 
-  // Register the DebugDeclare or DebugValue instruction |dbg_inst| into
-  // |var_id_to_dbg_decl_| using |id| as a key.
-  void RegisterDbgDeclareOrValue(uint32_t var_or_value_id,
-                                 Instruction* dbg_inst);
+  // Register the DebugDeclare or DebugValue with Deref operation
+  // |dbg_declare| into |var_id_to_dbg_decl_| using OpVariable id
+  // |var_id| as a key.
+  void RegisterDbgDeclare(uint32_t var_id, Instruction* dbg_declare);
 
   // Returns a DebugExpression instruction without Operation operands.
   Instruction* GetEmptyDebugExpression();
 
-  // Returns true if |inst| is DebugValue who has Deref operation and
-  // its Value operand is a result id of OpVariable with Function
-  // storage class. Otherwise, returns 0.
-  bool IsDebugValueUsedForDeclare(Instruction* inst);
+  // Returns the id of Value operand if |inst| is DebugValue who has Deref
+  // operation and its Value operand is a result id of OpVariable with
+  // Function storage class. Otherwise, returns 0.
+  uint32_t GetVariableIdOfDebugValueUsedForDeclare(Instruction* inst);
 
   // Returns true if a scope |ancestor| is |scope| or an ancestor scope
   // of |scope|.
@@ -200,7 +194,8 @@ class DebugInfoManager {
 
   // Mapping from variable or value ids to DebugDeclare or DebugValue
   // instructions whose operand is the variable or value.
-  std::unordered_map<uint32_t, std::list<Instruction*>> var_id_to_dbg_decl_;
+  std::unordered_map<uint32_t, std::unordered_set<Instruction*>>
+      var_id_to_dbg_decl_;
 
   // DebugInfoNone instruction. We need only a single DebugInfoNone.
   // To reuse the existing one, we keep it using this member variable.

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -430,12 +430,6 @@ void IRContext::KillOperandFromDebugInstructions(Instruction* inst) {
       }
     }
   }
-  // Kill DebugValue or DebugDeclare whose operand is |id|.
-  std::vector<Instruction*> dbg_decl_or_value;
-  get_debug_info_mgr()->ForEachDebugDeclareOrValue(
-      id,
-      [&dbg_decl_or_value](Instruction* i) { dbg_decl_or_value.push_back(i); });
-  for (auto* i : dbg_decl_or_value) KillInst(i);
 }
 
 void IRContext::AddCombinatorsForCapability(uint32_t capability) {

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -355,6 +355,9 @@ void IRContext::ForgetUses(Instruction* inst) {
       get_decoration_mgr()->RemoveDecoration(inst);
     }
   }
+  if (AreAnalysesValid(kAnalysisDebugInfo)) {
+    get_debug_info_mgr()->ClearDebugInfo(inst);
+  }
   RemoveFromIdToName(inst);
 }
 
@@ -366,6 +369,9 @@ void IRContext::AnalyzeUses(Instruction* inst) {
     if (inst->IsDecoration()) {
       get_decoration_mgr()->AddDecoration(inst);
     }
+  }
+  if (AreAnalysesValid(kAnalysisDebugInfo)) {
+    get_debug_info_mgr()->AnalyzeDebugInst(inst);
   }
   if (id_to_name_ &&
       (inst->opcode() == SpvOpName || inst->opcode() == SpvOpMemberName)) {
@@ -424,10 +430,12 @@ void IRContext::KillOperandFromDebugInstructions(Instruction* inst) {
       }
     }
   }
-  // Notice that we do not need anythings to do for local variables.
-  // DebugLocalVariable does not have an OpVariable operand. Instead,
-  // DebugDeclare/DebugValue has an OpVariable operand for a local
-  // variable. The function inlining pass handles it properly.
+  // Kill DebugValue or DebugDeclare whose operand is |id|.
+  std::vector<Instruction*> dbg_decl_or_value;
+  get_debug_info_mgr()->ForEachDebugDeclareOrValue(
+      id,
+      [&dbg_decl_or_value](Instruction* i) { dbg_decl_or_value.push_back(i); });
+  for (auto* i : dbg_decl_or_value) KillInst(i);
 }
 
 void IRContext::AddCombinatorsForCapability(uint32_t capability) {

--- a/test/opt/ir_context_test.cpp
+++ b/test/opt/ir_context_test.cpp
@@ -870,7 +870,7 @@ TEST_F(IRContextTest, AsanErrorTest) {
       << bb->id();  // Make sure asan does not complain about use after free.
 }
 
-TEST_F(IRContextTest, DebugInstructionReplaceAllUses) {
+TEST_F(IRContextTest, DebugInstructionReplaceSingleUse) {
   const std::string text = R"(
 OpCapability Shader
 OpCapability Linkage
@@ -911,8 +911,10 @@ OpFunctionEnd)";
   std::unique_ptr<IRContext> ctx =
       BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
                   SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  ctx->BuildInvalidAnalyses(IRContext::kAnalysisDebugInfo);
   DummyPassPreservesAll pass(Pass::Status::SuccessWithChange);
   pass.Run(ctx.get());
+  EXPECT_TRUE(ctx->AreAnalysesValid(IRContext::kAnalysisDebugInfo));
 
   auto* dbg_value = ctx->get_def_use_mgr()->GetDef(24);
   EXPECT_TRUE(dbg_value->GetSingleWordOperand(kDebugValueOperandValueIndex) ==
@@ -929,6 +931,233 @@ OpFunctionEnd)";
   dbg_decl = ctx->get_def_use_mgr()->GetDef(25);
   EXPECT_TRUE(
       dbg_decl->GetSingleWordOperand(kDebugDeclareOperandVariableIndex) == 20);
+}
+
+TEST_F(IRContextTest, DebugInstructionReplaceAllUses) {
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+%1 = OpExtInstImport "OpenCL.DebugInfo.100"
+OpMemoryModel Logical GLSL450
+%2 = OpString "test"
+%3 = OpTypeVoid
+%4 = OpTypeFunction %3
+%5 = OpTypeFloat 32
+%6 = OpTypePointer Function %5
+%7 = OpConstant %5 0
+%8 = OpTypeInt 32 0
+%9 = OpConstant %8 32
+%10 = OpExtInst %3 %1 DebugExpression
+%11 = OpExtInst %3 %1 DebugSource %2
+%12 = OpExtInst %3 %1 DebugCompilationUnit 1 4 %11 HLSL
+%13 = OpExtInst %3 %1 DebugTypeFunction FlagIsProtected|FlagIsPrivate %3
+%14 = OpExtInst %3 %1 DebugFunction %2 %13 %11 0 0 %12 %2 FlagIsProtected|FlagIsPrivate 0 %17
+%15 = OpExtInst %3 %1 DebugTypeBasic %2 %9 Float
+%16 = OpExtInst %3 %1 DebugLocalVariable %2 %15 %11 0 0 %14 FlagIsLocal
+%27 = OpExtInst %3 %1 DebugLocalVariable %2 %15 %11 1 0 %14 FlagIsLocal
+%17 = OpFunction %3 None %4
+%18 = OpLabel
+%19 = OpExtInst %3 %1 DebugScope %14
+%20 = OpVariable %6 Function
+%26 = OpVariable %6 Function
+OpBranch %21
+%21 = OpLabel
+%22 = OpPhi %5 %7 %18
+OpBranch %23
+%23 = OpLabel
+OpLine %2 0 0
+OpStore %20 %7
+%24 = OpExtInst %3 %1 DebugValue %16 %22 %10
+%25 = OpExtInst %3 %1 DebugDeclare %16 %26 %10
+%28 = OpExtInst %3 %1 DebugValue %27 %22 %10
+%29 = OpExtInst %3 %1 DebugDeclare %27 %26 %10
+OpReturn
+OpFunctionEnd)";
+
+  std::unique_ptr<IRContext> ctx =
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  ctx->BuildInvalidAnalyses(IRContext::kAnalysisDebugInfo);
+  DummyPassPreservesAll pass(Pass::Status::SuccessWithChange);
+  pass.Run(ctx.get());
+  EXPECT_TRUE(ctx->AreAnalysesValid(IRContext::kAnalysisDebugInfo));
+
+  auto* dbg_value0 = ctx->get_def_use_mgr()->GetDef(24);
+  auto* dbg_value1 = ctx->get_def_use_mgr()->GetDef(28);
+  EXPECT_TRUE(dbg_value0->GetSingleWordOperand(kDebugValueOperandValueIndex) ==
+              22);
+  EXPECT_TRUE(dbg_value1->GetSingleWordOperand(kDebugValueOperandValueIndex) ==
+              22);
+  EXPECT_TRUE(ctx->ReplaceAllUsesWith(22, 7));
+  dbg_value0 = ctx->get_def_use_mgr()->GetDef(24);
+  dbg_value1 = ctx->get_def_use_mgr()->GetDef(28);
+  EXPECT_TRUE(dbg_value0->GetSingleWordOperand(kDebugValueOperandValueIndex) ==
+              7);
+  EXPECT_TRUE(dbg_value1->GetSingleWordOperand(kDebugValueOperandValueIndex) ==
+              7);
+
+  auto* dbg_decl0 = ctx->get_def_use_mgr()->GetDef(25);
+  auto* dbg_decl1 = ctx->get_def_use_mgr()->GetDef(29);
+  EXPECT_TRUE(
+      dbg_decl0->GetSingleWordOperand(kDebugDeclareOperandVariableIndex) == 26);
+  EXPECT_TRUE(
+      dbg_decl1->GetSingleWordOperand(kDebugDeclareOperandVariableIndex) == 26);
+  EXPECT_TRUE(ctx->ReplaceAllUsesWith(26, 20));
+  dbg_decl0 = ctx->get_def_use_mgr()->GetDef(25);
+  dbg_decl1 = ctx->get_def_use_mgr()->GetDef(29);
+  EXPECT_TRUE(
+      dbg_decl0->GetSingleWordOperand(kDebugDeclareOperandVariableIndex) == 20);
+  EXPECT_TRUE(
+      dbg_decl1->GetSingleWordOperand(kDebugDeclareOperandVariableIndex) == 20);
+}
+
+TEST_F(IRContextTest, KillDebugInstruction) {
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+%1 = OpExtInstImport "OpenCL.DebugInfo.100"
+OpMemoryModel Logical GLSL450
+%2 = OpString "test"
+%3 = OpTypeVoid
+%4 = OpTypeFunction %3
+%5 = OpTypeFloat 32
+%6 = OpTypePointer Function %5
+%7 = OpConstant %5 0
+%8 = OpTypeInt 32 0
+%9 = OpConstant %8 32
+%10 = OpExtInst %3 %1 DebugExpression
+%11 = OpExtInst %3 %1 DebugSource %2
+%12 = OpExtInst %3 %1 DebugCompilationUnit 1 4 %11 HLSL
+%13 = OpExtInst %3 %1 DebugTypeFunction FlagIsProtected|FlagIsPrivate %3
+%14 = OpExtInst %3 %1 DebugFunction %2 %13 %11 0 0 %12 %2 FlagIsProtected|FlagIsPrivate 0 %17
+%15 = OpExtInst %3 %1 DebugTypeBasic %2 %9 Float
+%16 = OpExtInst %3 %1 DebugLocalVariable %2 %15 %11 0 0 %14 FlagIsLocal
+%27 = OpExtInst %3 %1 DebugLocalVariable %2 %15 %11 1 0 %14 FlagIsLocal
+%17 = OpFunction %3 None %4
+%18 = OpLabel
+%19 = OpExtInst %3 %1 DebugScope %14
+%20 = OpVariable %6 Function
+%26 = OpVariable %6 Function
+OpBranch %21
+%21 = OpLabel
+%22 = OpPhi %5 %7 %18
+OpBranch %23
+%23 = OpLabel
+OpLine %2 0 0
+OpStore %20 %7
+%24 = OpExtInst %3 %1 DebugValue %16 %22 %10
+%25 = OpExtInst %3 %1 DebugDeclare %16 %26 %10
+%28 = OpExtInst %3 %1 DebugValue %27 %22 %10
+%29 = OpExtInst %3 %1 DebugDeclare %27 %26 %10
+OpReturn
+OpFunctionEnd)";
+
+  std::unique_ptr<IRContext> ctx =
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  ctx->BuildInvalidAnalyses(IRContext::kAnalysisDebugInfo);
+  DummyPassPreservesAll pass(Pass::Status::SuccessWithChange);
+  pass.Run(ctx.get());
+  EXPECT_TRUE(ctx->AreAnalysesValid(IRContext::kAnalysisDebugInfo));
+
+  auto* dbg_decl = ctx->get_def_use_mgr()->GetDef(25);
+  ctx->KillInst(dbg_decl);
+  EXPECT_TRUE(ctx->get_def_use_mgr()->GetDef(25) == nullptr);
+
+  auto* phi = ctx->get_def_use_mgr()->GetDef(22);
+  ctx->KillInst(phi);
+  EXPECT_TRUE(ctx->get_def_use_mgr()->GetDef(24) == nullptr);
+  EXPECT_TRUE(ctx->get_def_use_mgr()->GetDef(28) == nullptr);
+  EXPECT_EQ(ctx->get_def_use_mgr()->GetDef(29)->GetOpenCL100DebugOpcode(),
+            OpenCLDebugInfo100DebugDeclare);
+}
+
+TEST_F(IRContextTest, AddDebugValueAfterReplaceUse) {
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+%1 = OpExtInstImport "OpenCL.DebugInfo.100"
+OpMemoryModel Logical GLSL450
+%2 = OpString "test"
+%3 = OpTypeVoid
+%4 = OpTypeFunction %3
+%5 = OpTypeFloat 32
+%6 = OpTypePointer Function %5
+%7 = OpConstant %5 0
+%8 = OpTypeInt 32 0
+%9 = OpConstant %8 32
+%10 = OpExtInst %3 %1 DebugExpression
+%11 = OpExtInst %3 %1 DebugSource %2
+%12 = OpExtInst %3 %1 DebugCompilationUnit 1 4 %11 HLSL
+%13 = OpExtInst %3 %1 DebugTypeFunction FlagIsProtected|FlagIsPrivate %3
+%14 = OpExtInst %3 %1 DebugFunction %2 %13 %11 0 0 %12 %2 FlagIsProtected|FlagIsPrivate 0 %17
+%15 = OpExtInst %3 %1 DebugTypeBasic %2 %9 Float
+%16 = OpExtInst %3 %1 DebugLocalVariable %2 %15 %11 0 0 %14 FlagIsLocal
+%17 = OpFunction %3 None %4
+%18 = OpLabel
+%19 = OpExtInst %3 %1 DebugScope %14
+%20 = OpVariable %6 Function
+%26 = OpVariable %6 Function
+OpBranch %21
+%21 = OpLabel
+%27 = OpExtInst %3 %1 DebugScope %14
+%22 = OpPhi %5 %7 %18
+OpBranch %23
+%23 = OpLabel
+%28 = OpExtInst %3 %1 DebugScope %14
+OpLine %2 0 0
+OpStore %20 %7
+%24 = OpExtInst %3 %1 DebugValue %16 %22 %10
+%25 = OpExtInst %3 %1 DebugDeclare %16 %26 %10
+OpReturn
+OpFunctionEnd)";
+
+  std::unique_ptr<IRContext> ctx =
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  ctx->BuildInvalidAnalyses(IRContext::kAnalysisDebugInfo);
+  DummyPassPreservesAll pass(Pass::Status::SuccessWithChange);
+  pass.Run(ctx.get());
+  EXPECT_TRUE(ctx->AreAnalysesValid(IRContext::kAnalysisDebugInfo));
+
+  // Replace all uses of result it '26' with '20'
+  auto* dbg_decl = ctx->get_def_use_mgr()->GetDef(25);
+  EXPECT_EQ(dbg_decl->GetSingleWordOperand(kDebugDeclareOperandVariableIndex),
+            26);
+  EXPECT_TRUE(ctx->ReplaceAllUsesWith(26, 20));
+  dbg_decl = ctx->get_def_use_mgr()->GetDef(25);
+  EXPECT_EQ(dbg_decl->GetSingleWordOperand(kDebugDeclareOperandVariableIndex),
+            20);
+
+  // No DebugValue should be added because result id '26' is not used for
+  // DebugDeclare.
+  ctx->get_debug_info_mgr()->AddDebugValue(dbg_decl, 26, 22, dbg_decl);
+  EXPECT_EQ(dbg_decl->NextNode()->opcode(), SpvOpReturn);
+
+  // DebugValue should be added because result id '20' is used for DebugDeclare.
+  ctx->get_debug_info_mgr()->AddDebugValue(dbg_decl, 20, 22, dbg_decl);
+  EXPECT_EQ(dbg_decl->NextNode()->GetOpenCL100DebugOpcode(),
+            OpenCLDebugInfo100DebugValue);
+
+  // Replace all uses of result it '20' with '26'
+  EXPECT_EQ(dbg_decl->GetSingleWordOperand(kDebugDeclareOperandVariableIndex),
+            20);
+  EXPECT_TRUE(ctx->ReplaceAllUsesWith(20, 26));
+  EXPECT_EQ(dbg_decl->GetSingleWordOperand(kDebugDeclareOperandVariableIndex),
+            26);
+
+  // No DebugValue should be added because result id '20' is not used for
+  // DebugDeclare.
+  ctx->get_debug_info_mgr()->AddDebugValue(dbg_decl, 20, 7, dbg_decl);
+  Instruction* dbg_value = dbg_decl->NextNode();
+  EXPECT_EQ(dbg_value->GetOpenCL100DebugOpcode(), OpenCLDebugInfo100DebugValue);
+  EXPECT_EQ(dbg_value->GetSingleWordOperand(kDebugValueOperandValueIndex), 22);
+
+  // DebugValue should be added because result id '26' is used for DebugDeclare.
+  ctx->get_debug_info_mgr()->AddDebugValue(dbg_decl, 26, 7, dbg_decl);
+  dbg_value = dbg_decl->NextNode();
+  EXPECT_EQ(dbg_value->GetOpenCL100DebugOpcode(), OpenCLDebugInfo100DebugValue);
+  EXPECT_EQ(dbg_value->GetSingleWordOperand(kDebugValueOperandValueIndex), 7);
 }
 
 }  // namespace

--- a/test/opt/local_ssa_elim_test.cpp
+++ b/test/opt/local_ssa_elim_test.cpp
@@ -2185,13 +2185,13 @@ TEST_F(LocalSSAElimTest, DebugValueForReferenceVariable) {
 ; CHECK: [[f_name:%\w+]] = OpString "f"
 ; CHECK: [[i_name:%\w+]] = OpString "i"
 ; CHECK: [[x_name:%\w+]] = OpString "x"
-; CHECK: [[dbg_f:%\w+]] = OpExtInst %void [[ext:%\d+]] DebugLocalVariable [[f_name]]
+; CHECK: OpExtInst %void [[ext:%\d+]] DebugLocalVariable [[f_name]]
 ; CHECK: [[dbg_i:%\w+]] = OpExtInst %void [[ext]] DebugLocalVariable [[i_name]]
-; CHECK: [[dbg_x:%\w+]] = OpExtInst %void [[ext]] DebugLocalVariable [[x_name]]
+; CHECK: OpExtInst %void [[ext]] DebugLocalVariable [[x_name]]
 
 ; CHECK:      OpStore %f %float_0
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_f]] %float_0
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_x]] %float_0
+; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue {{%\w+}} %float_0
+; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue {{%\w+}} %float_0
 ; CHECK-NEXT: OpStore %i %int_0
 ; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_i]] %int_0
 
@@ -2200,8 +2200,8 @@ TEST_F(LocalSSAElimTest, DebugValueForReferenceVariable) {
 ; CHECK:      [[loop_head:%\w+]] = OpLabel
 ; CHECK:      [[phi0:%\w+]] = OpPhi %float %float_0
 ; CHECK:      [[phi1:%\w+]] = OpPhi %int %int_0
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_f]] [[phi0]]
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_x]] [[phi0]]
+; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue {{%\w+}} [[phi0]]
+; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue {{%\w+}} [[phi0]]
 ; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_i]] [[phi1]]
 ; CHECK:      OpLoopMerge [[loop_merge:%\w+]] [[loop_cont:%\w+]] None
 ; CHECK-NEXT: OpBranch [[loop_body:%\w+]]
@@ -2211,8 +2211,8 @@ TEST_F(LocalSSAElimTest, DebugValueForReferenceVariable) {
 
 ; CHECK:      [[bb]] = OpLabel
 ; CHECK:      OpStore %f [[f_val:%\w+]]
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_f]] [[f_val]]
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_x]] [[f_val]]
+; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue {{%\w+}} [[f_val]]
+; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue {{%\w+}} [[f_val]]
 ; CHECK-NEXT: OpBranch [[loop_cont]]
 
 ; CHECK:      [[loop_cont]] = OpLabel
@@ -2343,7 +2343,7 @@ TEST_F(LocalSSAElimTest, DebugValueForReferenceVariableInBB) {
 ; CHECK: [[dbg_bb_child:%\w+]] = OpExtInst %void [[ext]] DebugLexicalBlock
 ; CHECK: [[dbg_f:%\w+]] = OpExtInst %void [[ext]] DebugLocalVariable [[f_name]]
 ; CHECK: [[dbg_i:%\w+]] = OpExtInst %void [[ext]] DebugLocalVariable [[i_name]]
-; CHECK: [[dbg_x:%\w+]] = OpExtInst %void [[ext]] DebugLocalVariable [[x_name]]
+; CHECK: OpExtInst %void [[ext]] DebugLocalVariable [[x_name]]
 
 ; CHECK:      OpExtInst %void [[ext]] DebugScope [[dbg_main]]
 ; CHECK:      OpStore %f %float_0
@@ -2368,15 +2368,15 @@ TEST_F(LocalSSAElimTest, DebugValueForReferenceVariableInBB) {
 ; CHECK:      [[bb]] = OpLabel
 ; CHECK:      OpExtInst %void [[ext]] DebugScope [[dbg_bb]]
 ; CHECK:      OpStore %f [[f_val:%\w+]]
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_f]] [[f_val]]
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_x]] [[f_val]]
+; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue {{%\w+}} [[f_val]]
+; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue {{%\w+}} [[f_val]]
 ; CHECK-NEXT: OpBranch [[bb_child:%\w+]]
 
 ; CHECK:      [[bb_child]] = OpLabel
 ; CHECK:      OpExtInst %void [[ext]] DebugScope [[dbg_bb_child]]
 ; CHECK:      OpStore %f [[new_f_val:%\w+]]
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_f]] [[new_f_val]]
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_x]] [[new_f_val]]
+; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue {{%\w+}} [[new_f_val]]
+; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue {{%\w+}} [[new_f_val]]
 ; CHECK-NEXT: OpBranch [[loop_cont]]
 
 ; CHECK:      [[loop_cont]] = OpLabel

--- a/test/opt/local_ssa_elim_test.cpp
+++ b/test/opt/local_ssa_elim_test.cpp
@@ -2185,14 +2185,14 @@ TEST_F(LocalSSAElimTest, DebugValueForReferenceVariable) {
 ; CHECK: [[f_name:%\w+]] = OpString "f"
 ; CHECK: [[i_name:%\w+]] = OpString "i"
 ; CHECK: [[x_name:%\w+]] = OpString "x"
-; CHECK: OpExtInst %void [[ext:%\d+]] DebugLocalVariable [[f_name]]
+; CHECK: [[dbg_f:%\w+]] = OpExtInst %void [[ext:%\d+]] DebugLocalVariable [[f_name]]
 ; CHECK: [[dbg_i:%\w+]] = OpExtInst %void [[ext]] DebugLocalVariable [[i_name]]
-; CHECK: OpExtInst %void [[ext]] DebugLocalVariable [[x_name]]
+; CHECK: [[dbg_x:%\w+]] = OpExtInst %void [[ext]] DebugLocalVariable [[x_name]]
 
 ; CHECK:      OpStore %f %float_0
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue {{%\w+}} %float_0
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue {{%\w+}} %float_0
-; CHECK-NEXT: OpStore %i %int_0
+; CHECK-DAG:  OpExtInst %void [[ext]] DebugValue [[dbg_f]] %float_0
+; CHECK-DAG:  OpExtInst %void [[ext]] DebugValue [[dbg_x]] %float_0
+; CHECK:      OpStore %i %int_0
 ; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_i]] %int_0
 
 ; CHECK-NOT:  DebugDeclare
@@ -2200,9 +2200,9 @@ TEST_F(LocalSSAElimTest, DebugValueForReferenceVariable) {
 ; CHECK:      [[loop_head:%\w+]] = OpLabel
 ; CHECK:      [[phi0:%\w+]] = OpPhi %float %float_0
 ; CHECK:      [[phi1:%\w+]] = OpPhi %int %int_0
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue {{%\w+}} [[phi0]]
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue {{%\w+}} [[phi0]]
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_i]] [[phi1]]
+; CHECK-DAG:  OpExtInst %void [[ext]] DebugValue [[dbg_f]] [[phi0]]
+; CHECK-DAG:  OpExtInst %void [[ext]] DebugValue [[dbg_x]] [[phi0]]
+; CHECK:      OpExtInst %void [[ext]] DebugValue [[dbg_i]] [[phi1]]
 ; CHECK:      OpLoopMerge [[loop_merge:%\w+]] [[loop_cont:%\w+]] None
 ; CHECK-NEXT: OpBranch [[loop_body:%\w+]]
 
@@ -2211,9 +2211,9 @@ TEST_F(LocalSSAElimTest, DebugValueForReferenceVariable) {
 
 ; CHECK:      [[bb]] = OpLabel
 ; CHECK:      OpStore %f [[f_val:%\w+]]
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue {{%\w+}} [[f_val]]
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue {{%\w+}} [[f_val]]
-; CHECK-NEXT: OpBranch [[loop_cont]]
+; CHECK-DAG:  OpExtInst %void [[ext]] DebugValue [[dbg_f]] [[f_val]]
+; CHECK-DAG:  OpExtInst %void [[ext]] DebugValue [[dbg_x]] [[f_val]]
+; CHECK:      OpBranch [[loop_cont]]
 
 ; CHECK:      [[loop_cont]] = OpLabel
 ; CHECK:      OpStore %i [[i_val:%\w+]]
@@ -2343,7 +2343,7 @@ TEST_F(LocalSSAElimTest, DebugValueForReferenceVariableInBB) {
 ; CHECK: [[dbg_bb_child:%\w+]] = OpExtInst %void [[ext]] DebugLexicalBlock
 ; CHECK: [[dbg_f:%\w+]] = OpExtInst %void [[ext]] DebugLocalVariable [[f_name]]
 ; CHECK: [[dbg_i:%\w+]] = OpExtInst %void [[ext]] DebugLocalVariable [[i_name]]
-; CHECK: OpExtInst %void [[ext]] DebugLocalVariable [[x_name]]
+; CHECK: [[dbg_x:%\w+]] = OpExtInst %void [[ext]] DebugLocalVariable [[x_name]]
 
 ; CHECK:      OpExtInst %void [[ext]] DebugScope [[dbg_main]]
 ; CHECK:      OpStore %f %float_0
@@ -2368,16 +2368,16 @@ TEST_F(LocalSSAElimTest, DebugValueForReferenceVariableInBB) {
 ; CHECK:      [[bb]] = OpLabel
 ; CHECK:      OpExtInst %void [[ext]] DebugScope [[dbg_bb]]
 ; CHECK:      OpStore %f [[f_val:%\w+]]
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue {{%\w+}} [[f_val]]
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue {{%\w+}} [[f_val]]
-; CHECK-NEXT: OpBranch [[bb_child:%\w+]]
+; CHECK-DAG:  OpExtInst %void [[ext]] DebugValue [[dbg_f]] [[f_val]]
+; CHECK-DAG:  OpExtInst %void [[ext]] DebugValue [[dbg_x]] [[f_val]]
+; CHECK:      OpBranch [[bb_child:%\w+]]
 
 ; CHECK:      [[bb_child]] = OpLabel
 ; CHECK:      OpExtInst %void [[ext]] DebugScope [[dbg_bb_child]]
 ; CHECK:      OpStore %f [[new_f_val:%\w+]]
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue {{%\w+}} [[new_f_val]]
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue {{%\w+}} [[new_f_val]]
-; CHECK-NEXT: OpBranch [[loop_cont]]
+; CHECK-DAG:  OpExtInst %void [[ext]] DebugValue [[dbg_f]] [[new_f_val]]
+; CHECK-DAG:  OpExtInst %void [[ext]] DebugValue [[dbg_x]] [[new_f_val]]
+; CHECK:      OpBranch [[loop_cont]]
 
 ; CHECK:      [[loop_cont]] = OpLabel
 ; CHECK:      OpStore %i [[i_val:%\w+]]

--- a/test/opt/local_ssa_elim_test.cpp
+++ b/test/opt/local_ssa_elim_test.cpp
@@ -2190,8 +2190,8 @@ TEST_F(LocalSSAElimTest, DebugValueForReferenceVariable) {
 ; CHECK: [[dbg_x:%\w+]] = OpExtInst %void [[ext]] DebugLocalVariable [[x_name]]
 
 ; CHECK:      OpStore %f %float_0
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_x]] %float_0
 ; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_f]] %float_0
+; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_x]] %float_0
 ; CHECK-NEXT: OpStore %i %int_0
 ; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_i]] %int_0
 
@@ -2200,8 +2200,8 @@ TEST_F(LocalSSAElimTest, DebugValueForReferenceVariable) {
 ; CHECK:      [[loop_head:%\w+]] = OpLabel
 ; CHECK:      [[phi0:%\w+]] = OpPhi %float %float_0
 ; CHECK:      [[phi1:%\w+]] = OpPhi %int %int_0
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_x]] [[phi0]]
 ; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_f]] [[phi0]]
+; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_x]] [[phi0]]
 ; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_i]] [[phi1]]
 ; CHECK:      OpLoopMerge [[loop_merge:%\w+]] [[loop_cont:%\w+]] None
 ; CHECK-NEXT: OpBranch [[loop_body:%\w+]]
@@ -2211,8 +2211,8 @@ TEST_F(LocalSSAElimTest, DebugValueForReferenceVariable) {
 
 ; CHECK:      [[bb]] = OpLabel
 ; CHECK:      OpStore %f [[f_val:%\w+]]
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_x]] [[f_val]]
 ; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_f]] [[f_val]]
+; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_x]] [[f_val]]
 ; CHECK-NEXT: OpBranch [[loop_cont]]
 
 ; CHECK:      [[loop_cont]] = OpLabel
@@ -2368,15 +2368,15 @@ TEST_F(LocalSSAElimTest, DebugValueForReferenceVariableInBB) {
 ; CHECK:      [[bb]] = OpLabel
 ; CHECK:      OpExtInst %void [[ext]] DebugScope [[dbg_bb]]
 ; CHECK:      OpStore %f [[f_val:%\w+]]
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_x]] [[f_val]]
 ; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_f]] [[f_val]]
+; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_x]] [[f_val]]
 ; CHECK-NEXT: OpBranch [[bb_child:%\w+]]
 
 ; CHECK:      [[bb_child]] = OpLabel
 ; CHECK:      OpExtInst %void [[ext]] DebugScope [[dbg_bb_child]]
 ; CHECK:      OpStore %f [[new_f_val:%\w+]]
-; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_x]] [[new_f_val]]
 ; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_f]] [[new_f_val]]
+; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_x]] [[new_f_val]]
 ; CHECK-NEXT: OpBranch [[loop_cont]]
 
 ; CHECK:      [[loop_cont]] = OpLabel


### PR DESCRIPTION
For many spirv-opt passes such as simplify-instructions pass, we have to
correctly clear the OpenCL.DebugInfo.100 debug information for
KillInst() and ReplaceAllUses(). If we keep some debug information that
disappeared because of KillInst() and ReplaceAllUses(), adding new
DebugValue instructions will generate incorrect information. This CL
update DebugInfoManager and IRContext to correctly clear debug
information.