### PR TITLE
Preserve debug info in scalar replacement pass

### DIFF
--- a/source/opt/constants.cpp
+++ b/source/opt/constants.cpp
@@ -396,6 +396,12 @@ uint32_t ConstantManager::GetFloatConst(float val) {
   return GetDefiningInstruction(c)->result_id();
 }
 
+uint32_t ConstantManager::GetSIntConst(int32_t val) {
+  Type* sint_type = context()->get_type_mgr()->GetSIntType();
+  const Constant* c = GetConstant(sint_type, {static_cast<uint32_t>(val)});
+  return GetDefiningInstruction(c)->result_id();
+}
+
 std::vector<const analysis::Constant*> Constant::GetVectorComponents(
     analysis::ConstantManager* const_mgr) const {
   std::vector<const analysis::Constant*> components;

--- a/source/opt/constants.h
+++ b/source/opt/constants.h
@@ -630,7 +630,7 @@ class ConstantManager {
   // Returns the id of a 32-bit floating point constant with value |val|.
   uint32_t GetFloatConst(float val);
 
-  // Returns the id of a 32-bit singed integer constant with value |val|.
+  // Returns the id of a 32-bit signed integer constant with value |val|.
   uint32_t GetSIntConst(int32_t val);
 
  private:

--- a/source/opt/constants.h
+++ b/source/opt/constants.h
@@ -630,6 +630,9 @@ class ConstantManager {
   // Returns the id of a 32-bit floating point constant with value |val|.
   uint32_t GetFloatConst(float val);
 
+  // Returns the id of a 32-bit singed integer constant with value |val|.
+  uint32_t GetSIntConst(int32_t val);
+
  private:
   // Creates a Constant instance with the given type and a vector of constant
   // defining words. Returns a unique pointer to the created Constant instance

--- a/source/opt/debug_info_manager.cpp
+++ b/source/opt/debug_info_manager.cpp
@@ -452,9 +452,11 @@ bool DebugInfoManager::IsDeclareVisibleToInstr(Instruction* dbg_declare,
 Instruction* DebugInfoManager::AddDebugValueWithIndex(
     uint32_t dbg_local_var_id, uint32_t value_id, uint32_t expr_id,
     uint32_t index_id, Instruction* insert_before) {
+  uint32_t result_id = context()->TakeNextId();
+  if (!result_id) return nullptr;
   std::unique_ptr<Instruction> new_dbg_value(new Instruction(
       context(), SpvOpExtInst, context()->get_type_mgr()->GetVoidTypeId(),
-      context()->TakeNextId(),
+      result_id,
       {
           {spv_operand_type_t::SPV_OPERAND_TYPE_ID,
            {context()
@@ -513,6 +515,7 @@ void DebugInfoManager::AddDebugValueIfVarDeclIsVisible(
         AddDebugValueWithIndex(dbg_decl_or_val->GetSingleWordOperand(
                                    kDebugValueOperandLocalVariableIndex),
                                value_id, 0, index_id, insert_before);
+    assert(added_dbg_value != nullptr);
     added_dbg_value->UpdateDebugInfoFrom(scope_and_line);
   }
 }

--- a/source/opt/debug_info_manager.cpp
+++ b/source/opt/debug_info_manager.cpp
@@ -485,9 +485,9 @@ Instruction* DebugInfoManager::AddDebugValueWithIndex(
   return added_dbg_value;
 }
 
-void DebugInfoManager::AddDebugValue(Instruction* scope_and_line,
-                                     uint32_t variable_id, uint32_t value_id,
-                                     Instruction* insert_pos) {
+void DebugInfoManager::AddDebugValueIfVarDeclIsVisible(
+    Instruction* scope_and_line, uint32_t variable_id, uint32_t value_id,
+    Instruction* insert_pos) {
   auto dbg_decl_itr = var_id_to_dbg_decl_.find(variable_id);
   if (dbg_decl_itr == var_id_to_dbg_decl_.end()) return;
 

--- a/source/opt/debug_info_manager.cpp
+++ b/source/opt/debug_info_manager.cpp
@@ -33,6 +33,7 @@ static const uint32_t kDebugDeclareOperandLocalVariableIndex = 4;
 static const uint32_t kDebugDeclareOperandVariableIndex = 5;
 static const uint32_t kDebugValueOperandLocalVariableIndex = 4;
 static const uint32_t kDebugValueOperandExpressionIndex = 6;
+static const uint32_t kDebugValueOperandIndexesIndex = 7;
 static const uint32_t kDebugOperationOperandOperationIndex = 4;
 static const uint32_t kOpVariableOperandStorageClassIndex = 2;
 static const uint32_t kDebugLocalVariableOperandParentIndex = 9;
@@ -448,11 +449,9 @@ bool DebugInfoManager::IsDeclareVisibleToInstr(Instruction* dbg_declare,
   return IsAncestorOfScope(instr_scope_id, decl_scope_id);
 }
 
-void DebugInfoManager::AddDebugValueWithIndex(uint32_t dbg_local_var_id,
-                                              uint32_t value_id,
-                                              uint32_t expr_id,
-                                              uint32_t index_id,
-                                              Instruction* insert_before) {
+Instruction* DebugInfoManager::AddDebugValueWithIndex(
+    uint32_t dbg_local_var_id, uint32_t value_id, uint32_t expr_id,
+    uint32_t index_id, Instruction* insert_before) {
   std::unique_ptr<Instruction> new_dbg_value(new Instruction(
       context(), SpvOpExtInst, context()->get_type_mgr()->GetVoidTypeId(),
       context()->TakeNextId(),
@@ -475,6 +474,7 @@ void DebugInfoManager::AddDebugValueWithIndex(uint32_t dbg_local_var_id,
 
   Instruction* added_dbg_value =
       insert_before->InsertBefore(std::move(new_dbg_value));
+  AnalyzeDebugInst(added_dbg_value);
   if (context()->AreAnalysesValid(IRContext::Analysis::kAnalysisDefUse))
     context()->get_def_use_mgr()->AnalyzeInstDefUse(added_dbg_value);
   if (context()->AreAnalysesValid(
@@ -482,6 +482,7 @@ void DebugInfoManager::AddDebugValueWithIndex(uint32_t dbg_local_var_id,
     auto insert_blk = context()->get_instr_block(insert_before);
     context()->set_instr_block(added_dbg_value, insert_blk);
   }
+  return added_dbg_value;
 }
 
 void DebugInfoManager::AddDebugValue(Instruction* scope_and_line,
@@ -494,36 +495,6 @@ void DebugInfoManager::AddDebugValue(Instruction* scope_and_line,
   for (auto* dbg_decl_or_val : dbg_decl_itr->second) {
     if (!IsDeclareVisibleToInstr(dbg_decl_or_val, instr_scope_id)) continue;
 
-    uint32_t result_id = context()->TakeNextId();
-    std::unique_ptr<Instruction> new_dbg_value(new Instruction(
-        context(), SpvOpExtInst, context()->get_type_mgr()->GetVoidTypeId(),
-        result_id,
-        {
-            {spv_operand_type_t::SPV_OPERAND_TYPE_ID,
-             {context()
-                  ->get_feature_mgr()
-                  ->GetExtInstImportId_OpenCL100DebugInfo()}},
-            {spv_operand_type_t::SPV_OPERAND_TYPE_EXTENSION_INSTRUCTION_NUMBER,
-             {static_cast<uint32_t>(OpenCLDebugInfo100DebugValue)}},
-            {spv_operand_type_t::SPV_OPERAND_TYPE_ID,
-             {dbg_decl_or_val->GetSingleWordOperand(
-                 kDebugValueOperandLocalVariableIndex)}},
-            {spv_operand_type_t::SPV_OPERAND_TYPE_ID, {value_id}},
-            {spv_operand_type_t::SPV_OPERAND_TYPE_ID,
-             {GetEmptyDebugExpression()->result_id()}},
-        }));
-
-    if (dbg_decl_or_val->NumOperands() >
-        kDebugValueOperandExpressionIndex + 1) {
-      assert(dbg_decl_or_val->GetOpenCL100DebugOpcode() ==
-             OpenCLDebugInfo100DebugValue);
-      for (uint32_t i = kDebugValueOperandExpressionIndex + 1;
-           i < dbg_decl_or_val->NumOperands(); ++i) {
-        new_dbg_value->AddOperand({spv_operand_type_t::SPV_OPERAND_TYPE_ID,
-                                   {dbg_decl_or_val->GetSingleWordOperand(i)}});
-      }
-    }
-
     // Avoid inserting the new DebugValue between OpPhi or OpVariable
     // instructions.
     Instruction* insert_before = insert_pos->NextNode();
@@ -532,17 +503,17 @@ void DebugInfoManager::AddDebugValue(Instruction* scope_and_line,
       insert_before = insert_before->NextNode();
     }
 
-    Instruction* added_dbg_value =
-        insert_before->InsertBefore(std::move(new_dbg_value));
-    added_dbg_value->UpdateDebugInfoFrom(scope_and_line);
-    AnalyzeDebugInst(added_dbg_value);
-    if (context()->AreAnalysesValid(IRContext::Analysis::kAnalysisDefUse))
-      context()->get_def_use_mgr()->AnalyzeInstDefUse(added_dbg_value);
-    if (context()->AreAnalysesValid(
-            IRContext::Analysis::kAnalysisInstrToBlockMapping)) {
-      auto insert_blk = context()->get_instr_block(insert_before);
-      context()->set_instr_block(added_dbg_value, insert_blk);
+    uint32_t index_id = 0;
+    if (dbg_decl_or_val->NumOperands() > kDebugValueOperandIndexesIndex) {
+      index_id =
+          dbg_decl_or_val->GetSingleWordOperand(kDebugValueOperandIndexesIndex);
     }
+
+    Instruction* added_dbg_value =
+        AddDebugValueWithIndex(dbg_decl_or_val->GetSingleWordOperand(
+                                   kDebugValueOperandLocalVariableIndex),
+                               value_id, 0, index_id, insert_before);
+    added_dbg_value->UpdateDebugInfoFrom(scope_and_line);
   }
 }
 

--- a/source/opt/debug_info_manager.cpp
+++ b/source/opt/debug_info_manager.cpp
@@ -498,7 +498,7 @@ void DebugInfoManager::AddDebugValue(Instruction* scope_and_line,
 
     Instruction* added_dbg_value =
         insert_before->InsertBefore(std::move(new_dbg_value));
-    added_dbg_value->UpdateDebugInfo(scope_and_line);
+    added_dbg_value->UpdateDebugInfoFrom(scope_and_line);
     AnalyzeDebugInst(added_dbg_value);
     if (context()->AreAnalysesValid(IRContext::Analysis::kAnalysisDefUse))
       context()->get_def_use_mgr()->AnalyzeInstDefUse(added_dbg_value);

--- a/source/opt/debug_info_manager.h
+++ b/source/opt/debug_info_manager.h
@@ -145,6 +145,12 @@ class DebugInfoManager {
   void AddDebugValue(Instruction* scope_and_line, uint32_t variable_id,
                      uint32_t value_id, Instruction* insert_pos);
 
+  // Generates a DebugValue instruction with |dbg_local_var_id|, |value_id|,
+  // |expr_id|, |index_id| operands and inserts it before |insert_before|.
+  void AddDebugValueWithIndex(uint32_t dbg_local_var_id, uint32_t value_id,
+                              uint32_t expr_id, uint32_t index_id,
+                              Instruction* insert_before);
+
   // Erases |instr| from data structures of this class.
   void ClearDebugInfo(Instruction* instr);
 
@@ -214,9 +220,6 @@ class DebugInfoManager {
   // instructions whose operand is the variable or value.
   std::unordered_map<uint32_t, std::unordered_set<Instruction*>>
       var_id_to_dbg_decl_;
-
-  // DebugOperation whose OpCode is OpenCLDebugInfo100Deref.
-  Instruction* deref_operation_;
 
   // DebugOperation whose OpCode is OpenCLDebugInfo100Deref.
   Instruction* deref_operation_;

--- a/source/opt/debug_info_manager.h
+++ b/source/opt/debug_info_manager.h
@@ -218,6 +218,9 @@ class DebugInfoManager {
   // DebugOperation whose OpCode is OpenCLDebugInfo100Deref.
   Instruction* deref_operation_;
 
+  // DebugOperation whose OpCode is OpenCLDebugInfo100Deref.
+  Instruction* deref_operation_;
+
   // DebugInfoNone instruction. We need only a single DebugInfoNone.
   // To reuse the existing one, we keep it using this member variable.
   Instruction* debug_info_none_inst_;

--- a/source/opt/debug_info_manager.h
+++ b/source/opt/debug_info_manager.h
@@ -142,8 +142,9 @@ class DebugInfoManager {
   // Generates a DebugValue instruction with value |value_id| for every local
   // variable that is in the scope of |scope_and_line| and whose memory is
   // |variable_id| and inserts it after the instruction |insert_pos|.
-  void AddDebugValue(Instruction* scope_and_line, uint32_t variable_id,
-                     uint32_t value_id, Instruction* insert_pos);
+  void AddDebugValueIfVarDeclIsVisible(Instruction* scope_and_line,
+                                       uint32_t variable_id, uint32_t value_id,
+                                       Instruction* insert_pos);
 
   // Generates a DebugValue instruction with |dbg_local_var_id|, |value_id|,
   // |expr_id|, |index_id| operands and inserts it before |insert_before|.

--- a/source/opt/debug_info_manager.h
+++ b/source/opt/debug_info_manager.h
@@ -147,9 +147,10 @@ class DebugInfoManager {
 
   // Generates a DebugValue instruction with |dbg_local_var_id|, |value_id|,
   // |expr_id|, |index_id| operands and inserts it before |insert_before|.
-  void AddDebugValueWithIndex(uint32_t dbg_local_var_id, uint32_t value_id,
-                              uint32_t expr_id, uint32_t index_id,
-                              Instruction* insert_before);
+  Instruction* AddDebugValueWithIndex(uint32_t dbg_local_var_id,
+                                      uint32_t value_id, uint32_t expr_id,
+                                      uint32_t index_id,
+                                      Instruction* insert_before);
 
   // Erases |instr| from data structures of this class.
   void ClearDebugInfo(Instruction* instr);

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -301,7 +301,7 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
     return dbg_scope_.GetInlinedAt();
   }
   // Updates OpLine and DebugScope based on the information of |from|.
-  inline void UpdateDebugInfo(const Instruction* from);
+  inline void UpdateDebugInfoFrom(const Instruction* from);
   // Remove the |index|-th operand
   void RemoveOperand(uint32_t index) {
     operands_.erase(operands_.begin() + index);
@@ -667,7 +667,7 @@ inline void Instruction::UpdateDebugInlinedAt(uint32_t new_inlined_at) {
   }
 }
 
-inline void Instruction::UpdateDebugInfo(const Instruction* from) {
+inline void Instruction::UpdateDebugInfoFrom(const Instruction* from) {
   if (from == nullptr) return;
   clear_dbg_line_insts();
   if (!from->dbg_line_insts().empty())

--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -147,7 +147,7 @@ bool LocalSingleStoreElimPass::ProcessVariable(Instruction* var_inst) {
         context()->get_type_mgr()->GetType(var_inst->type_id());
     const analysis::Type* store_type = var_type->AsPointer()->pointee_type();
     if (!(store_type->AsStruct() || store_type->AsArray())) {
-      context()->get_debug_info_mgr()->AddDebugValue(
+      context()->get_debug_info_mgr()->AddDebugValueIfVarDeclIsVisible(
           store_inst, var_id, store_inst->GetSingleWordInOperand(1),
           store_inst);
       context()->get_debug_info_mgr()->KillDebugDeclares(var_id);

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -173,10 +173,14 @@ bool ScalarReplacementPass::ReplaceWholeDebugDeclare(
   // Add DebugValue instruction with Indexes operand and Deref operation.
   int32_t idx = 0;
   for (const auto* var : replacements) {
-    context()->get_debug_info_mgr()->AddDebugValueWithIndex(
-        dbg_decl->GetSingleWordOperand(kDebugDeclareOperandLocalVariableIndex),
-        var->result_id(), deref_expr->result_id(),
-        context()->get_constant_mgr()->GetSIntConst(idx), dbg_decl);
+    Instruction* added_dbg_value =
+        context()->get_debug_info_mgr()->AddDebugValueWithIndex(
+            dbg_decl->GetSingleWordOperand(
+                kDebugDeclareOperandLocalVariableIndex),
+            var->result_id(), deref_expr->result_id(),
+            context()->get_constant_mgr()->GetSIntConst(idx), var->NextNode());
+    if (added_dbg_value == nullptr) return false;
+    added_dbg_value->UpdateDebugInfoFrom(dbg_decl);
     ++idx;
   }
   return true;

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -788,7 +788,7 @@ bool ScalarReplacementPass::CheckUses(const Instruction* inst,
                                           uint32_t index) {
     if (user->GetOpenCL100DebugOpcode() == OpenCLDebugInfo100DebugDeclare ||
         user->GetOpenCL100DebugOpcode() == OpenCLDebugInfo100DebugValue) {
-      // TODO: include num_partial_accesses if it uses Deref operation or
+      // TODO: include num_partial_accesses if it uses Fragment operation or
       // DebugValue has Indexes operand.
       stats->num_full_accesses++;
       return;

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -27,7 +27,6 @@
 
 static const uint32_t kDebugValueOperandValueIndex = 5;
 static const uint32_t kDebugValueOperandExpressionIndex = 6;
-static const uint32_t kDebugDeclareOperandVariableIndex = 5;
 static const uint32_t kDebugInstructionOpcodeIndex = 3;
 
 namespace spvtools {

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -26,7 +26,6 @@
 #include "source/util/make_unique.h"
 
 static const uint32_t kDebugDeclareOperandLocalVariableIndex = 4;
-static const uint32_t kDebugDeclareOperandVariableIndex = 5;
 static const uint32_t kDebugValueOperandValueIndex = 5;
 static const uint32_t kDebugValueOperandExpressionIndex = 6;
 

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -173,12 +173,15 @@ bool ScalarReplacementPass::ReplaceWholeDebugDeclare(
   // Add DebugValue instruction with Indexes operand and Deref operation.
   int32_t idx = 0;
   for (const auto* var : replacements) {
+    uint32_t dbg_local_variable =
+        dbg_decl->GetSingleWordOperand(kDebugDeclareOperandLocalVariableIndex);
+    uint32_t index_id = context()->get_constant_mgr()->GetSIntConst(idx);
+
     Instruction* added_dbg_value =
         context()->get_debug_info_mgr()->AddDebugValueWithIndex(
-            dbg_decl->GetSingleWordOperand(
-                kDebugDeclareOperandLocalVariableIndex),
-            var->result_id(), deref_expr->result_id(),
-            context()->get_constant_mgr()->GetSIntConst(idx), var->NextNode());
+            dbg_local_variable,
+            /*value_id=*/var->result_id(), /*expr_id=*/deref_expr->result_id(),
+            index_id, /*insert_before=*/var->NextNode());
     if (added_dbg_value == nullptr) return false;
     added_dbg_value->UpdateDebugInfoFrom(dbg_decl);
     ++idx;

--- a/source/opt/scalar_replacement_pass.h
+++ b/source/opt/scalar_replacement_pass.h
@@ -199,6 +199,21 @@ class ScalarReplacementPass : public Pass {
   bool ReplaceWholeStore(Instruction* store,
                          const std::vector<Instruction*>& replacements);
 
+  // Replaces the DebugDeclare to the entire composite.
+  //
+  // Generates a DebugValue with Deref operation for each element in the
+  // scalarized variable from the original DebugDeclare.  Returns true if
+  // successful.
+  bool ReplaceWholeDebugDeclare(Instruction* dbg_decl,
+                                const std::vector<Instruction*>& replacements);
+
+  // Replaces the DebugValue to the entire composite.
+  //
+  // Generates a DebugValue for each element in the scalarized variable from
+  // the original DebugValue.  Returns true if successful.
+  bool ReplaceWholeDebugValue(Instruction* dbg_value,
+                              const std::vector<Instruction*>& replacements);
+
   // Replaces an access chain to the composite variable with either a direct use
   // of the appropriate replacement variable or another access chain with the
   // replacement variable as the base and one fewer indexes. Returns true if

--- a/source/opt/ssa_rewrite_pass.cpp
+++ b/source/opt/ssa_rewrite_pass.cpp
@@ -307,8 +307,8 @@ void SSARewriter::ProcessStore(Instruction* inst, BasicBlock* bb) {
   }
   if (pass_->IsTargetVar(var_id)) {
     WriteVariable(var_id, bb, val_id);
-    pass_->context()->get_debug_info_mgr()->AddDebugValue(inst, var_id, val_id,
-                                                          inst);
+    pass_->context()->get_debug_info_mgr()->AddDebugValueIfVarDeclIsVisible(
+        inst, var_id, val_id, inst);
 
 #if SSA_REWRITE_DEBUGGING_LEVEL > 1
     std::cerr << "\tFound store '%" << var_id << " = %" << val_id << "': "
@@ -491,7 +491,7 @@ bool SSARewriter::ApplyReplacements() {
 
     // Add DebugValue for the new OpPhi instruction.
     insert_it->SetDebugScope(local_var->GetDebugScope());
-    pass_->context()->get_debug_info_mgr()->AddDebugValue(
+    pass_->context()->get_debug_info_mgr()->AddDebugValueIfVarDeclIsVisible(
         &*insert_it, phi_candidate->var_id(), phi_candidate->result_id(),
         &*insert_it);
 

--- a/source/opt/wrap_opkill.cpp
+++ b/source/opt/wrap_opkill.cpp
@@ -71,7 +71,7 @@ bool WrapOpKill::ReplaceWithFunctionCall(Instruction* inst) {
   if (call_inst == nullptr) {
     return false;
   }
-  call_inst->UpdateDebugInfo(inst);
+  call_inst->UpdateDebugInfoFrom(inst);
 
   Instruction* return_inst = nullptr;
   uint32_t return_type_id = GetOwningFunctionsReturnType(inst);

--- a/test/opt/ir_context_test.cpp
+++ b/test/opt/ir_context_test.cpp
@@ -1070,11 +1070,13 @@ OpFunctionEnd)";
 
   // No DebugValue should be added because result id '26' is not used for
   // DebugDeclare.
-  ctx->get_debug_info_mgr()->AddDebugValue(dbg_decl, 26, 22, dbg_decl);
+  ctx->get_debug_info_mgr()->AddDebugValueIfVarDeclIsVisible(dbg_decl, 26, 22,
+                                                             dbg_decl);
   EXPECT_EQ(dbg_decl->NextNode()->opcode(), SpvOpReturn);
 
   // DebugValue should be added because result id '20' is used for DebugDeclare.
-  ctx->get_debug_info_mgr()->AddDebugValue(dbg_decl, 20, 22, dbg_decl);
+  ctx->get_debug_info_mgr()->AddDebugValueIfVarDeclIsVisible(dbg_decl, 20, 22,
+                                                             dbg_decl);
   EXPECT_EQ(dbg_decl->NextNode()->GetOpenCL100DebugOpcode(),
             OpenCLDebugInfo100DebugValue);
 
@@ -1087,13 +1089,15 @@ OpFunctionEnd)";
 
   // No DebugValue should be added because result id '20' is not used for
   // DebugDeclare.
-  ctx->get_debug_info_mgr()->AddDebugValue(dbg_decl, 20, 7, dbg_decl);
+  ctx->get_debug_info_mgr()->AddDebugValueIfVarDeclIsVisible(dbg_decl, 20, 7,
+                                                             dbg_decl);
   Instruction* dbg_value = dbg_decl->NextNode();
   EXPECT_EQ(dbg_value->GetOpenCL100DebugOpcode(), OpenCLDebugInfo100DebugValue);
   EXPECT_EQ(dbg_value->GetSingleWordOperand(kDebugValueOperandValueIndex), 22);
 
   // DebugValue should be added because result id '26' is used for DebugDeclare.
-  ctx->get_debug_info_mgr()->AddDebugValue(dbg_decl, 26, 7, dbg_decl);
+  ctx->get_debug_info_mgr()->AddDebugValueIfVarDeclIsVisible(dbg_decl, 26, 7,
+                                                             dbg_decl);
   dbg_value = dbg_decl->NextNode();
   EXPECT_EQ(dbg_value->GetOpenCL100DebugOpcode(), OpenCLDebugInfo100DebugValue);
   EXPECT_EQ(dbg_value->GetSingleWordOperand(kDebugValueOperandValueIndex), 7);

--- a/test/opt/scalar_replacement_test.cpp
+++ b/test/opt/scalar_replacement_test.cpp
@@ -1899,6 +1899,186 @@ TEST_F(ScalarReplacementTest, RelaxedPrecisionMemberDecoration) {
   SinglePassRunAndMatch<ScalarReplacementPass>(text, true);
 }
 
+TEST_F(ScalarReplacementTest, DebugDeclare) {
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+%ext = OpExtInstImport "OpenCL.DebugInfo.100"
+OpMemoryModel Logical GLSL450
+%test = OpString "test"
+OpName %6 "simple_struct"
+%1 = OpTypeVoid
+%2 = OpTypeInt 32 0
+%uint_32 = OpConstant %2 32
+%3 = OpTypeStruct %2 %2 %2 %2
+%4 = OpTypePointer Function %3
+%5 = OpTypePointer Function %2
+%6 = OpTypeFunction %2
+%7 = OpConstantNull %3
+%8 = OpConstant %2 0
+%9 = OpConstant %2 1
+%10 = OpConstant %2 2
+%11 = OpConstant %2 3
+%null_expr = OpExtInst %1 %ext DebugExpression
+%src = OpExtInst %1 %ext DebugSource %test
+%cu = OpExtInst %1 %ext DebugCompilationUnit 1 4 %src HLSL
+%dbg_tf = OpExtInst %1 %ext DebugTypeBasic %test %uint_32 Float
+%main_ty = OpExtInst %1 %ext DebugTypeFunction FlagIsProtected|FlagIsPrivate %1
+%dbg_main = OpExtInst %1 %ext DebugFunction %test %main_ty %src 0 0 %cu %test FlagIsProtected|FlagIsPrivate 0 %12
+%dbg_foo = OpExtInst %1 %ext DebugLocalVariable %test %dbg_tf %src 0 0 %dbg_main FlagIsLocal
+%12 = OpFunction %2 None %6
+%13 = OpLabel
+%scope = OpExtInst %1 %ext DebugScope %dbg_main
+%14 = OpVariable %4 Function %7
+
+; CHECK: [[deref:%\w+]] = OpExtInst %void [[ext:%\w+]] DebugOperation Deref
+; CHECK: [[dbg_local_var:%\w+]] = OpExtInst %void [[ext]] DebugLocalVariable
+; CHECK: [[deref_expr:%\w+]] = OpExtInst %void [[ext]] DebugExpression [[deref]]
+; CHECK: [[repl3:%\w+]] = OpVariable %_ptr_Function_uint Function
+; CHECK: [[repl2:%\w+]] = OpVariable %_ptr_Function_uint Function
+; CHECK: [[repl1:%\w+]] = OpVariable %_ptr_Function_uint Function
+; CHECK: [[repl0:%\w+]] = OpVariable %_ptr_Function_uint Function
+; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl0]] [[deref_expr]] %int_0
+; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl1]] [[deref_expr]] %int_1
+; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl2]] [[deref_expr]] %int_2
+; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl3]] [[deref_expr]] %int_3
+; CHECK-NOT: DebugDeclare
+%decl = OpExtInst %1 %ext DebugDeclare %dbg_foo %14 %null_expr
+
+%15 = OpInBoundsAccessChain %5 %14 %8
+%16 = OpLoad %2 %15
+%17 = OpAccessChain %5 %14 %10
+%18 = OpLoad %2 %17
+%19 = OpIAdd %2 %16 %18
+OpReturnValue %19
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<ScalarReplacementPass>(text, true);
+}
+
+TEST_F(ScalarReplacementTest, DebugValue) {
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+%ext = OpExtInstImport "OpenCL.DebugInfo.100"
+OpMemoryModel Logical GLSL450
+%test = OpString "test"
+OpName %6 "simple_struct"
+%1 = OpTypeVoid
+%2 = OpTypeInt 32 0
+%uint_32 = OpConstant %2 32
+%3 = OpTypeStruct %2 %2 %2 %2
+%4 = OpTypePointer Function %3
+%5 = OpTypePointer Function %2
+%6 = OpTypeFunction %2
+%7 = OpConstantNull %3
+%8 = OpConstant %2 0
+%9 = OpConstant %2 1
+%10 = OpConstant %2 2
+%11 = OpConstant %2 3
+%deref = OpExtInst %1 %ext DebugOperation Deref
+%deref_expr = OpExtInst %1 %ext DebugExpression %deref
+%null_expr = OpExtInst %1 %ext DebugExpression
+%src = OpExtInst %1 %ext DebugSource %test
+%cu = OpExtInst %1 %ext DebugCompilationUnit 1 4 %src HLSL
+%dbg_tf = OpExtInst %1 %ext DebugTypeBasic %test %uint_32 Float
+%main_ty = OpExtInst %1 %ext DebugTypeFunction FlagIsProtected|FlagIsPrivate %1
+%dbg_main = OpExtInst %1 %ext DebugFunction %test %main_ty %src 0 0 %cu %test FlagIsProtected|FlagIsPrivate 0 %12
+%dbg_foo = OpExtInst %1 %ext DebugLocalVariable %test %dbg_tf %src 0 0 %dbg_main FlagIsLocal
+%12 = OpFunction %2 None %6
+%13 = OpLabel
+%scope = OpExtInst %1 %ext DebugScope %dbg_main
+%14 = OpVariable %4 Function %7
+
+; CHECK: [[deref:%\w+]] = OpExtInst %void [[ext:%\w+]] DebugOperation Deref
+; CHECK: [[deref_expr:%\w+]] = OpExtInst %void [[ext]] DebugExpression [[deref]]
+; CHECK: [[dbg_local_var:%\w+]] = OpExtInst %void [[ext]] DebugLocalVariable
+; CHECK: [[repl3:%\w+]] = OpVariable %_ptr_Function_uint Function
+; CHECK: [[repl2:%\w+]] = OpVariable %_ptr_Function_uint Function
+; CHECK: [[repl1:%\w+]] = OpVariable %_ptr_Function_uint Function
+; CHECK: [[repl0:%\w+]] = OpVariable %_ptr_Function_uint Function
+; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl0]] [[deref_expr]] %int_0
+; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl1]] [[deref_expr]] %int_1
+; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl2]] [[deref_expr]] %int_2
+; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl3]] [[deref_expr]] %int_3
+%value = OpExtInst %1 %ext DebugValue %dbg_foo %14 %deref_expr
+
+%15 = OpInBoundsAccessChain %5 %14 %8
+%16 = OpLoad %2 %15
+%17 = OpAccessChain %5 %14 %10
+%18 = OpLoad %2 %17
+%19 = OpIAdd %2 %16 %18
+OpReturnValue %19
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<ScalarReplacementPass>(text, true);
+}
+
+TEST_F(ScalarReplacementTest, DebugDeclareRecursive) {
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+%ext = OpExtInstImport "OpenCL.DebugInfo.100"
+OpMemoryModel Logical GLSL450
+%test = OpString "test"
+OpName %6 "simple_struct"
+%1 = OpTypeVoid
+%2 = OpTypeInt 32 0
+%uint_32 = OpConstant %2 32
+%float = OpTypeFloat 32
+%float_1 = OpConstant %float 1
+%member = OpTypeStruct %2 %float
+%3 = OpTypeStruct %2 %member %float
+%4 = OpTypePointer Function %3
+%5 = OpTypePointer Function %2
+%ptr_float_Function = OpTypePointer Function %float
+%6 = OpTypeFunction %2
+%cmember = OpConstantComposite %member %uint_32 %float_1
+%7 = OpConstantComposite %3 %uint_32 %cmember %float_1
+%8 = OpConstant %2 0
+%9 = OpConstant %2 1
+%10 = OpConstant %2 2
+%null_expr = OpExtInst %1 %ext DebugExpression
+%src = OpExtInst %1 %ext DebugSource %test
+%cu = OpExtInst %1 %ext DebugCompilationUnit 1 4 %src HLSL
+%dbg_tf = OpExtInst %1 %ext DebugTypeBasic %test %uint_32 Float
+%main_ty = OpExtInst %1 %ext DebugTypeFunction FlagIsProtected|FlagIsPrivate %1
+%dbg_main = OpExtInst %1 %ext DebugFunction %test %main_ty %src 0 0 %cu %test FlagIsProtected|FlagIsPrivate 0 %12
+%dbg_foo = OpExtInst %1 %ext DebugLocalVariable %test %dbg_tf %src 0 0 %dbg_main FlagIsLocal
+%12 = OpFunction %2 None %6
+%13 = OpLabel
+%scope = OpExtInst %1 %ext DebugScope %dbg_main
+%14 = OpVariable %4 Function %7
+
+; CHECK: [[deref:%\w+]] = OpExtInst %void [[ext:%\w+]] DebugOperation Deref
+; CHECK: [[dbg_local_var:%\w+]] = OpExtInst %void [[ext]] DebugLocalVariable
+; CHECK: [[deref_expr:%\w+]] = OpExtInst %void [[ext]] DebugExpression [[deref]]
+; CHECK: [[repl2:%\w+]] = OpVariable %_ptr_Function_float Function %float_1
+; CHECK: [[repl1:%\w+]] = OpVariable %_ptr_Function_uint Function %uint_32
+; CHECK: [[repl3:%\w+]] = OpVariable %_ptr_Function_float Function %float_1
+; CHECK: [[repl0:%\w+]] = OpVariable %_ptr_Function_uint Function %uint_32
+; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl0]] [[deref_expr]] %int_0
+; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl1]] [[deref_expr]] %int_1 %int_0
+; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl2]] [[deref_expr]] %int_1 %int_1
+; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl3]] [[deref_expr]] %int_2
+; CHECK-NOT: DebugDeclare
+%decl = OpExtInst %1 %ext DebugDeclare %dbg_foo %14 %null_expr
+
+%15 = OpInBoundsAccessChain %5 %14 %8
+%16 = OpLoad %2 %15
+%17 = OpAccessChain %ptr_float_Function %14 %10
+%18 = OpLoad %float %17
+%value = OpConvertFToU %2 %18
+%19 = OpIAdd %2 %16 %value
+OpReturnValue %19
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<ScalarReplacementPass>(text, true);
+}
+
 }  // namespace
 }  // namespace opt
 }  // namespace spvtools

--- a/test/opt/scalar_replacement_test.cpp
+++ b/test/opt/scalar_replacement_test.cpp
@@ -1935,13 +1935,13 @@ OpName %6 "simple_struct"
 ; CHECK: [[dbg_local_var:%\w+]] = OpExtInst %void [[ext]] DebugLocalVariable
 ; CHECK: [[deref_expr:%\w+]] = OpExtInst %void [[ext]] DebugExpression [[deref]]
 ; CHECK: [[repl3:%\w+]] = OpVariable %_ptr_Function_uint Function
+; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl3]] [[deref_expr]] %int_3
 ; CHECK: [[repl2:%\w+]] = OpVariable %_ptr_Function_uint Function
+; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl2]] [[deref_expr]] %int_2
 ; CHECK: [[repl1:%\w+]] = OpVariable %_ptr_Function_uint Function
+; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl1]] [[deref_expr]] %int_1
 ; CHECK: [[repl0:%\w+]] = OpVariable %_ptr_Function_uint Function
 ; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl0]] [[deref_expr]] %int_0
-; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl1]] [[deref_expr]] %int_1
-; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl2]] [[deref_expr]] %int_2
-; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl3]] [[deref_expr]] %int_3
 ; CHECK-NOT: DebugDeclare
 %decl = OpExtInst %1 %ext DebugDeclare %dbg_foo %14 %null_expr
 
@@ -2058,11 +2058,11 @@ OpName %6 "simple_struct"
 ; CHECK: [[repl2:%\w+]] = OpVariable %_ptr_Function_float Function %float_1
 ; CHECK: [[repl1:%\w+]] = OpVariable %_ptr_Function_uint Function %uint_32
 ; CHECK: [[repl3:%\w+]] = OpVariable %_ptr_Function_float Function %float_1
-; CHECK: [[repl0:%\w+]] = OpVariable %_ptr_Function_uint Function %uint_32
-; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl0]] [[deref_expr]] %int_0
+; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl3]] [[deref_expr]] %int_2
 ; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl1]] [[deref_expr]] %int_1 %int_0
 ; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl2]] [[deref_expr]] %int_1 %int_1
-; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl3]] [[deref_expr]] %int_2
+; CHECK: [[repl0:%\w+]] = OpVariable %_ptr_Function_uint Function %uint_32
+; CHECK: OpExtInst %void [[ext]] DebugValue [[dbg_local_var]] [[repl0]] [[deref_expr]] %int_0
 ; CHECK-NOT: DebugDeclare
 %decl = OpExtInst %1 %ext DebugDeclare %dbg_foo %14 %null_expr
 


### PR DESCRIPTION
Preserve OpenCL.DebugInfo.100 and line information in scalar
replacement pass.

1. Set the debug scope and line information for the new replacement
   instructions.
2. Replace DebugDeclare and DebugValue if their OpVariable or value
   operands are replaced by scalars.
  - If the initial aggregate has DebugValue, we clone a DebugValue
    for each scalar and add one more index for the scalar to 'Indexes'
    operand of the cloned DebugValue as we add an index to 'Indexes'
    operand of OpAccessChain.
  - If the initial aggregate has DebugDeclare, we create a DebugValue
    with Deref operation for each scalar and add an index for the scalar
    to 'Indexes' operand.
  - For example,
```
   struct S { int a; int b;}
   S foo; // before scalar replacement

   int foo_a; // after scalar replacement
   int foo_b;

   DebugDeclare %dbg_foo %foo %null_expr // before

   DebugValue %dbg_foo %foo_a %Deref_expr 0 // after
   DebugValue %dbg_foo %foo_b %Deref_expr 1 // means Value(foo.members[1]) == Deref(%foo_b)
```
Note that the DebugValue instructions for the SROA'd structure
elements are linked to the original debug info for `S foo` via the
`%dbg_foo`. Each DebugValue has Deref and 'Indexes' i.e., 0
for `%foo_a` and 1 for `%foo_b` in the above example.
`DebugValue %dbg_foo %foo_a %Deref_expr 0` means that
`Deref(%foo_a)` is the value of `0`th member of `%dbg_foo`.