### PR TITLE
Add gl_BaseInstance to the name mapper.

### DIFF
--- a/source/name_mapper.cpp
+++ b/source/name_mapper.cpp
@@ -153,6 +153,7 @@ void FriendlyNameMapper::SaveBuiltInName(uint32_t target_id,
     CASE(SubgroupLocalInvocationId)
     GLCASE(VertexIndex)
     GLCASE(InstanceIndex)
+    GLCASE(BaseInstance)
     CASE(SubgroupEqMaskKHR)
     CASE(SubgroupGeMaskKHR)
     CASE(SubgroupGtMaskKHR)

--- a/test/name_mapper_test.cpp
+++ b/test/name_mapper_test.cpp
@@ -270,6 +270,7 @@ INSTANTIATE_TEST_SUITE_P(
         BuiltInCase("SubgroupLocalInvocationId"),
         BuiltInGLCase("VertexIndex"),
         BuiltInGLCase("InstanceIndex"),
+        BuiltInGLCase("BaseInstance"),
         BuiltInCase("SubgroupEqMaskKHR"),
         BuiltInCase("SubgroupGeMaskKHR"),
         BuiltInCase("SubgroupGtMaskKHR"),


### PR DESCRIPTION
GLSL: https://www.khronos.org/opengl/wiki/Built-in_Variable_(GLSL)
SPIR-V: `BaseInstance` [Builtin](https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#_a_id_builtin_a_builtin) decoration