### PR TITLE
Permit Simple and GLSL450 memory model in WEBGPU_0

### DIFF
--- a/source/val/validate_mode_setting.cpp
+++ b/source/val/validate_mode_setting.cpp
@@ -501,10 +501,6 @@ spv_result_t ValidateMemoryModel(ValidationState_t& _,
       return _.diag(SPV_ERROR_INVALID_DATA, inst)
              << "Addressing model must be Logical for WebGPU environment.";
     }
-    if (_.memory_model() != SpvMemoryModelVulkanKHR) {
-      return _.diag(SPV_ERROR_INVALID_DATA, inst)
-             << "Memory model must be VulkanKHR for WebGPU environment.";
-    }
   }
 
   if (spvIsOpenCLEnv(_.context()->target_env)) {

--- a/test/val/val_webgpu_test.cpp
+++ b/test/val/val_webgpu_test.cpp
@@ -239,19 +239,70 @@ TEST_F(ValidateWebGPU, LogicalAddressingVulkanKHRMemoryGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_WEBGPU_0));
 }
 
-TEST_F(ValidateWebGPU, NonVulkanKHRMemoryModelBad) {
+TEST_F(ValidateWebGPU, LogicalAddressingGLSL450MemoryGood) {
   std::string spirv = R"(
-     OpCapability Shader
-     OpMemoryModel Logical GLSL450
+          OpCapability Shader
+          OpMemoryModel Logical GLSL450
+          OpEntryPoint Vertex %func "shader"
+%void   = OpTypeVoid
+%void_f = OpTypeFunction %void
+%func   = OpFunction %void None %void_f
+%label  = OpLabel
+          OpReturn
+          OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_WEBGPU_0));
+}
+
+TEST_F(ValidateWebGPU, LogicalAddressingSimpleMemoryGood) {
+  std::string spirv = R"(
+          OpCapability Shader
+          OpMemoryModel Logical Simple
+          OpEntryPoint Vertex %func "shader"
+%void   = OpTypeVoid
+%void_f = OpTypeFunction %void
+%func   = OpFunction %void None %void_f
+%label  = OpLabel
+          OpReturn
+          OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_WEBGPU_0));
+}
+
+TEST_F(ValidateWebGPU, KernelIsBad) {
+  std::string spirv = R"(
+     OpCapability Kernel
+     OpMemoryModel Logical Simple
      OpNoLine
 )";
 
   CompileSuccessfully(spirv);
 
-  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_WEBGPU_0));
+  EXPECT_EQ(SPV_ERROR_INVALID_CAPABILITY,
+            ValidateInstructions(SPV_ENV_WEBGPU_0));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Memory model must be VulkanKHR for WebGPU "
-                        "environment.\n  OpMemoryModel Logical GLSL450\n"));
+              HasSubstr("Capability Kernel is not allowed by WebGPU "
+                        "specification (or requires extension)"));
+}
+
+TEST_F(ValidateWebGPU, OpenCLMemoryModelBad) {
+  std::string spirv = R"(
+     OpCapability Shader
+     OpMemoryModel Logical OpenCL
+     OpNoLine
+)";
+
+  CompileSuccessfully(spirv);
+
+  EXPECT_EQ(SPV_ERROR_INVALID_CAPABILITY,
+            ValidateInstructions(SPV_ENV_WEBGPU_0));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand 2 of MemoryModel requires one of these "
+                        "capabilities: Kernel"));
 }
 
 TEST_F(ValidateWebGPU, AllowListedExtendedInstructionsImportGood) {


### PR DESCRIPTION
Now that WebGPU ingests WGSL instead of SPIR-V,
there is no need to be so strict about the memory model.

Allow any memory model that is already allowed by Vulkan 1.0,
either directly or via an existing.