### PR TITLE
Preserve debug info in vector DCE pass

### DIFF
--- a/source/opt/vector_dce.cpp
+++ b/source/opt/vector_dce.cpp
@@ -53,8 +53,7 @@ void VectorDCE::FindLiveComponents(Function* function,
   // components are live because of arbitrary nesting of structs.
   function->ForEachInst(
       [&work_list, this, live_components](Instruction* current_inst) {
-        if (current_inst->GetOpenCL100DebugOpcode() !=
-            OpenCLDebugInfo100InstructionsMax) {
+        if (current_inst->IsOpenCL100DebugInstr()) {
           return;
         }
         if (!HasVectorOrScalarResult(current_inst) ||

--- a/source/opt/vector_dce.cpp
+++ b/source/opt/vector_dce.cpp
@@ -388,7 +388,7 @@ bool VectorDCE::RewriteInsertInstruction(
 void VectorDCE::MarkDebugValueUsesAsDead(
     Instruction* composite, std::vector<Instruction*>* dead_dbg_value) {
   context()->get_def_use_mgr()->ForEachUser(
-      composite, [this, &dead_dbg_value](Instruction* use) {
+      composite, [&dead_dbg_value](Instruction* use) {
         if (use->GetOpenCL100DebugOpcode() == OpenCLDebugInfo100DebugValue)
           dead_dbg_value->push_back(use);
       });

--- a/source/opt/vector_dce.cpp
+++ b/source/opt/vector_dce.cpp
@@ -300,7 +300,12 @@ bool VectorDCE::HasScalarResult(const Instruction* inst) const {
 bool VectorDCE::RewriteInstructions(
     Function* function, const VectorDCE::LiveComponentMap& live_components) {
   bool modified = false;
+
+  // Kill DebugValue in the middle of the instruction iteration will result
+  // in accessing a dangling pointer. We keep dead DebugValue instructions
+  // in |dead_dbg_value| to kill them once after the iteration.
   std::vector<Instruction*> dead_dbg_value;
+
   function->ForEachInst([&modified, this, live_components,
                          &dead_dbg_value](Instruction* current_inst) {
     if (!context()->IsCombinatorInstruction(current_inst)) {

--- a/source/opt/vector_dce.cpp
+++ b/source/opt/vector_dce.cpp
@@ -388,7 +388,7 @@ bool VectorDCE::RewriteInsertInstruction(
 void VectorDCE::MarkDebugValueUsesAsDead(
     Instruction* composite, std::vector<Instruction*>* dead_dbg_value) {
   context()->get_def_use_mgr()->ForEachUser(
-      composite, [this](Instruction* use) {
+      composite, [this, &dead_dbg_value](Instruction* use) {
         if (use->GetOpenCL100DebugOpcode() == OpenCLDebugInfo100DebugValue)
           dead_dbg_value->push_back(use);
       });

--- a/source/opt/vector_dce.h
+++ b/source/opt/vector_dce.h
@@ -73,6 +73,10 @@ class VectorDCE : public MemPass {
   bool RewriteInstructions(Function* function,
                            const LiveComponentMap& live_components);
 
+  // Makrs all DebugValue instructions that use |composite| for their values as
+  // dead instructions by putting them into |dead_dbg_value_|.
+  void MarkDebugValueUsesAsDead(Instruction* composite);
+
   // Rewrites the OpCompositeInsert instruction |current_inst| to avoid
   // unnecessary computes given that the only components of the result that are
   // live are |live_components|.
@@ -143,6 +147,9 @@ class VectorDCE : public MemPass {
   // A BitVector that can always be used to say that all components of a vector
   // are live.
   utils::BitVector all_components_live_;
+
+  // OpenCL.DebugInfo.100 DebugValue instructions to be killed.
+  std::vector<Instruction*> dead_dbg_value_;
 };
 
 }  // namespace opt

--- a/source/opt/vector_dce.h
+++ b/source/opt/vector_dce.h
@@ -74,8 +74,9 @@ class VectorDCE : public MemPass {
                            const LiveComponentMap& live_components);
 
   // Makrs all DebugValue instructions that use |composite| for their values as
-  // dead instructions by putting them into |dead_dbg_value_|.
-  void MarkDebugValueUsesAsDead(Instruction* composite);
+  // dead instructions by putting them into |dead_dbg_value|.
+  void MarkDebugValueUsesAsDead(Instruction* composite,
+                                std::vector<Instruction*>* dead_dbg_value);
 
   // Rewrites the OpCompositeInsert instruction |current_inst| to avoid
   // unnecessary computes given that the only components of the result that are
@@ -87,7 +88,8 @@ class VectorDCE : public MemPass {
   // If the composite input to |current_inst| is not live, then it is replaced
   // by and OpUndef in |current_inst|.
   bool RewriteInsertInstruction(Instruction* current_inst,
-                                const utils::BitVector& live_components);
+                                const utils::BitVector& live_components,
+                                std::vector<Instruction*>* dead_dbg_value);
 
   // Returns true if the result of |inst| is a vector or a scalar.
   bool HasVectorOrScalarResult(const Instruction* inst) const;
@@ -147,9 +149,6 @@ class VectorDCE : public MemPass {
   // A BitVector that can always be used to say that all components of a vector
   // are live.
   utils::BitVector all_components_live_;
-
-  // OpenCL.DebugInfo.100 DebugValue instructions to be killed.
-  std::vector<Instruction*> dead_dbg_value_;
 };
 
 }  // namespace opt


### PR DESCRIPTION
This commit lets the vector DCE pass preserve the OpenCL.DebugInfo.100
information properly. When the vector DCE pass determines the liveness
of instructions, the debug instructions must not affect the decision. In
addition, when it kills some instructions, it has to kill DebugValue
instructions that use the killed instructions. When it updates some
composite values to meaningful values (not undef), it has to remove
DebugValue because the value information becomes incorrect.