### PR TITLE
spirv-fuzz: Remove unused functions

### DIFF
--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -1013,45 +1013,6 @@ void AddStructType(opt::IRContext* ir_context, uint32_t result_id,
   UpdateModuleIdBound(ir_context, result_id);
 }
 
-uint32_t FindOrCreateIntegerType(opt::IRContext* ir_context, uint32_t result_id,
-                                 uint32_t width, bool is_signed) {
-  if (auto existing_id = MaybeGetIntegerType(ir_context, width, is_signed)) {
-    return existing_id;
-  }
-  AddIntegerType(ir_context, result_id, width, is_signed);
-  return result_id;
-}
-
-uint32_t FindOrCreateFloatType(opt::IRContext* ir_context, uint32_t result_id,
-                               uint32_t width) {
-  if (auto existing_id = MaybeGetFloatType(ir_context, width)) {
-    return existing_id;
-  }
-  AddFloatType(ir_context, result_id, width);
-  return result_id;
-}
-
-uint32_t FindOrCreateVectorType(opt::IRContext* ir_context, uint32_t result_id,
-                                uint32_t component_type_id,
-                                uint32_t element_count) {
-  if (auto existing_id =
-          MaybeGetVectorType(ir_context, component_type_id, element_count)) {
-    return existing_id;
-  }
-  AddVectorType(ir_context, result_id, component_type_id, element_count);
-  return result_id;
-}
-
-uint32_t FindOrCreateStructType(
-    opt::IRContext* ir_context, uint32_t result_id,
-    const std::vector<uint32_t>& component_type_ids) {
-  if (auto existing_id = MaybeGetStructType(ir_context, component_type_ids)) {
-    return existing_id;
-  }
-  AddStructType(ir_context, result_id, component_type_ids);
-  return result_id;
-}
-
 }  // namespace fuzzerutil
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -369,39 +369,6 @@ void AddVectorType(opt::IRContext* ir_context, uint32_t result_id,
 void AddStructType(opt::IRContext* ir_context, uint32_t result_id,
                    const std::vector<uint32_t>& component_type_ids);
 
-// Returns a result id of an OpTypeInt instruction in the module. Creates a new
-// instruction with |result_id|, if no required OpTypeInt is present in the
-// module, and returns |result_id|. Updates module's id bound to accommodate for
-// |result_id|.
-uint32_t FindOrCreateIntegerType(opt::IRContext* ir_context, uint32_t result_id,
-                                 uint32_t width, bool is_signed);
-
-// Returns a result id of an OpTypeFloat instruction in the module. Creates a
-// new instruction with |result_id|, if no required OpTypeFloat is present in
-// the module, and returns |result_id|. Updates module's id bound
-// to accommodate for |result_id|.
-uint32_t FindOrCreateFloatType(opt::IRContext* ir_context, uint32_t result_id,
-                               uint32_t width);
-
-// Returns a result id of an OpTypeVector instruction in the module. Creates a
-// new instruction with |result_id|, if no required OpTypeVector is present in
-// the module, and returns |result_id|. |component_type_id| must be a valid
-// result id of an OpTypeInt, OpTypeFloat or OpTypeBool instruction in the
-// module. |element_count| must be in the range [2, 4]. Updates module's id
-// bound to accommodate for |result_id|.
-uint32_t FindOrCreateVectorType(opt::IRContext* ir_context, uint32_t result_id,
-                                uint32_t component_type_id,
-                                uint32_t element_count);
-
-// Returns a result id of an OpTypeStruct instruction in the module. Creates a
-// new instruction with |result_id|, if no required OpTypeStruct is present in
-// the module, and returns |result_id|. Updates module's id bound
-// to accommodate for |result_id|. |component_type_ids| may not contain a result
-// id of an OpTypeFunction.
-uint32_t FindOrCreateStructType(
-    opt::IRContext* ir_context, uint32_t result_id,
-    const std::vector<uint32_t>& component_type_ids);
-
 }  // namespace fuzzerutil
 
 }  // namespace fuzz


### PR DESCRIPTION
Removes unused functions from `fuzzerutil`.