### PR TITLE
Added TransformationAddRelaxedDecoration

### DIFF
--- a/include/spirv-tools/instrument.hpp
+++ b/include/spirv-tools/instrument.hpp
@@ -110,6 +110,16 @@ static const int kInstRayTracingOutLaunchIdX = kInstCommonOutCnt;
 static const int kInstRayTracingOutLaunchIdY = kInstCommonOutCnt + 1;
 static const int kInstRayTracingOutLaunchIdZ = kInstCommonOutCnt + 2;
 
+// Mesh Shader Output Record Offsets
+static const int kInstMeshOutGlobalInvocationIdX = kInstCommonOutCnt;
+static const int kInstMeshOutGlobalInvocationIdY = kInstCommonOutCnt + 1;
+static const int kInstMeshOutGlobalInvocationIdZ = kInstCommonOutCnt + 2;
+
+// Task Shader Output Record Offsets
+static const int kInstTaskOutGlobalInvocationIdX = kInstCommonOutCnt;
+static const int kInstTaskOutGlobalInvocationIdY = kInstCommonOutCnt + 1;
+static const int kInstTaskOutGlobalInvocationIdZ = kInstCommonOutCnt + 2;
+
 // Size of Common and Stage-specific Members
 static const int kInstStageOutCnt = kInstCommonOutCnt + 3;
 

--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -676,6 +676,12 @@ SPIRV_TOOLS_EXPORT void spvFuzzerOptionsEnableReplayValidation(
 SPIRV_TOOLS_EXPORT void spvFuzzerOptionsSetRandomSeed(
     spv_fuzzer_options options, uint32_t seed);
 
+// Sets the range of transformations that should be applied during replay: 0
+// means all transformations, +N means the first N transformations, -N means all
+// except the final N transformations.
+SPIRV_TOOLS_EXPORT void spvFuzzerOptionsSetReplayRange(
+    spv_fuzzer_options options, int32_t replay_range);
+
 // Sets the maximum number of steps that the shrinker should take before giving
 // up.
 SPIRV_TOOLS_EXPORT void spvFuzzerOptionsSetShrinkerStepLimit(

--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -227,6 +227,11 @@ class FuzzerOptions {
     spvFuzzerOptionsSetRandomSeed(options_, seed);
   }
 
+  // See spvFuzzerOptionsSetReplayRange.
+  void set_replay_range(int32_t replay_range) {
+    spvFuzzerOptionsSetReplayRange(options_, replay_range);
+  }
+
   // See spvFuzzerOptionsSetShrinkerStepLimit.
   void set_shrinker_step_limit(uint32_t shrinker_step_limit) {
     spvFuzzerOptionsSetShrinkerStepLimit(options_, shrinker_step_limit);

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -345,7 +345,7 @@ set_source_files_properties(
 
 spvtools_pch(SPIRV_SOURCES pch_source)
 
-add_library(${SPIRV_TOOLS} ${SPIRV_SOURCES} ../test/fuzz/transformation_add_relaxed_decoration_test.cpp)
+add_library(${SPIRV_TOOLS} ${SPIRV_SOURCES})
 spvtools_default_compile_options(${SPIRV_TOOLS})
 target_include_directories(${SPIRV_TOOLS}
   PUBLIC

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -345,7 +345,7 @@ set_source_files_properties(
 
 spvtools_pch(SPIRV_SOURCES pch_source)
 
-add_library(${SPIRV_TOOLS} ${SPIRV_SOURCES})
+add_library(${SPIRV_TOOLS} ${SPIRV_SOURCES} ../test/fuzz/transformation_add_relaxed_decoration_test.cpp)
 spvtools_default_compile_options(${SPIRV_TOOLS})
 target_include_directories(${SPIRV_TOOLS}
   PUBLIC

--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -103,7 +103,8 @@ if(SPIRV_BUILD_FUZZER)
         transformation_add_local_variable.h
         transformation_add_no_contraction_decoration.h
         transformation_add_parameter.h
-          transformation_add_spec_constant_op.h
+        transformation_add_relaxed_decoration.h
+        transformation_add_spec_constant_op.h
         transformation_add_synonym.h
         transformation_add_type_array.h
         transformation_add_type_boolean.h
@@ -221,7 +222,8 @@ if(SPIRV_BUILD_FUZZER)
         transformation_add_local_variable.cpp
         transformation_add_no_contraction_decoration.cpp
         transformation_add_parameter.cpp
-          transformation_add_spec_constant_op.cpp
+        transformation_add_relaxed_decoration.cpp
+        transformation_add_spec_constant_op.cpp
         transformation_add_synonym.cpp
         transformation_add_type_array.cpp
         transformation_add_type_boolean.cpp
@@ -266,7 +268,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_vector_shuffle.cpp
         uniform_buffer_element_descriptor.cpp
         ${CMAKE_CURRENT_BINARY_DIR}/protobufs/spvtoolsfuzz.pb.cc
-          transformation_add_relaxed_decoration.cpp transformation_add_relaxed_decoration.h)
+        )
 
   if(MSVC)
     # Enable parallel builds across four cores for this lib

--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -103,7 +103,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_add_local_variable.h
         transformation_add_no_contraction_decoration.h
         transformation_add_parameter.h
-        transformation_add_spec_constant_op.h
+          transformation_add_spec_constant_op.h
         transformation_add_synonym.h
         transformation_add_type_array.h
         transformation_add_type_boolean.h
@@ -221,7 +221,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_add_local_variable.cpp
         transformation_add_no_contraction_decoration.cpp
         transformation_add_parameter.cpp
-        transformation_add_spec_constant_op.cpp
+          transformation_add_spec_constant_op.cpp
         transformation_add_synonym.cpp
         transformation_add_type_array.cpp
         transformation_add_type_boolean.cpp
@@ -266,7 +266,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_vector_shuffle.cpp
         uniform_buffer_element_descriptor.cpp
         ${CMAKE_CURRENT_BINARY_DIR}/protobufs/spvtoolsfuzz.pb.cc
-        )
+          transformation_add_relaxed_decoration.cpp transformation_add_relaxed_decoration.h)
 
   if(MSVC)
     # Enable parallel builds across four cores for this lib

--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -52,6 +52,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_add_local_variables.h
         fuzzer_pass_add_no_contraction_decorations.h
         fuzzer_pass_add_parameters.h
+        fuzzer_pass_add_relaxed_decorations.h
         fuzzer_pass_add_stores.h
         fuzzer_pass_add_vector_shuffle_instructions.h
         fuzzer_pass_adjust_branch_weights.h
@@ -172,6 +173,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_add_local_variables.cpp
         fuzzer_pass_add_no_contraction_decorations.cpp
         fuzzer_pass_add_parameters.cpp
+        fuzzer_pass_add_relaxed_decorations.cpp
         fuzzer_pass_add_stores.cpp
         fuzzer_pass_add_vector_shuffle_instructions.cpp
         fuzzer_pass_adjust_branch_weights.cpp

--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -65,6 +65,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_copy_objects.h
         fuzzer_pass_donate_modules.h
         fuzzer_pass_invert_comparison_operators.h
+        fuzzer_pass_interchange_zero_like_constants.h
         fuzzer_pass_merge_blocks.h
         fuzzer_pass_obfuscate_constants.h
         fuzzer_pass_outline_functions.h
@@ -186,6 +187,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_copy_objects.cpp
         fuzzer_pass_donate_modules.cpp
         fuzzer_pass_invert_comparison_operators.cpp
+        fuzzer_pass_interchange_zero_like_constants.cpp
         fuzzer_pass_merge_blocks.cpp
         fuzzer_pass_obfuscate_constants.cpp
         fuzzer_pass_outline_functions.cpp

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -18,7 +18,6 @@
 #include <memory>
 #include <sstream>
 
-#include "fuzzer_pass_adjust_memory_operands_masks.h"
 #include "source/fuzz/fact_manager.h"
 #include "source/fuzz/fuzzer_context.h"
 #include "source/fuzz/fuzzer_pass_add_access_chains.h"
@@ -41,11 +40,13 @@
 #include "source/fuzz/fuzzer_pass_adjust_branch_weights.h"
 #include "source/fuzz/fuzzer_pass_adjust_function_controls.h"
 #include "source/fuzz/fuzzer_pass_adjust_loop_controls.h"
+#include "source/fuzz/fuzzer_pass_adjust_memory_operands_masks.h"
 #include "source/fuzz/fuzzer_pass_adjust_selection_controls.h"
 #include "source/fuzz/fuzzer_pass_apply_id_synonyms.h"
 #include "source/fuzz/fuzzer_pass_construct_composites.h"
 #include "source/fuzz/fuzzer_pass_copy_objects.h"
 #include "source/fuzz/fuzzer_pass_donate_modules.h"
+#include "source/fuzz/fuzzer_pass_interchange_zero_like_constants.h"
 #include "source/fuzz/fuzzer_pass_invert_comparison_operators.h"
 #include "source/fuzz/fuzzer_pass_merge_blocks.h"
 #include "source/fuzz/fuzzer_pass_obfuscate_constants.h"
@@ -328,6 +329,9 @@ Fuzzer::FuzzerResultStatus Fuzzer::Run(
       &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
       transformation_sequence_out);
   MaybeAddPass<FuzzerPassAddNoContractionDecorations>(
+      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
+      transformation_sequence_out);
+  MaybeAddPass<FuzzerPassInterchangeZeroLikeConstants>(
       &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
       transformation_sequence_out);
   MaybeAddPass<FuzzerPassPermutePhiOperands>(

--- a/source/fuzz/fuzzer_context.cpp
+++ b/source/fuzz/fuzzer_context.cpp
@@ -65,6 +65,8 @@ const std::pair<uint32_t, uint32_t> kChanceOfCopyingObject = {20, 50};
 const std::pair<uint32_t, uint32_t> kChanceOfDonatingAdditionalModule = {5, 50};
 const std::pair<uint32_t, uint32_t> kChanceOfGoingDeeperWhenMakingAccessChain =
     {50, 95};
+const std::pair<uint32_t, uint32_t> kChanceOfInterchangingZeroLikeConstants = {
+    10, 90};
 const std::pair<uint32_t, uint32_t> kChanceOfInvertingComparisonOperators = {
     20, 50};
 const std::pair<uint32_t, uint32_t> kChanceOfMakingDonorLivesafe = {40, 60};
@@ -184,6 +186,8 @@ FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
       ChooseBetweenMinAndMax(kChanceOfDonatingAdditionalModule);
   chance_of_going_deeper_when_making_access_chain_ =
       ChooseBetweenMinAndMax(kChanceOfGoingDeeperWhenMakingAccessChain);
+  chance_of_interchanging_zero_like_constants_ =
+      ChooseBetweenMinAndMax(kChanceOfInterchangingZeroLikeConstants);
   chance_of_inverting_comparison_operators_ =
       ChooseBetweenMinAndMax(kChanceOfInvertingComparisonOperators);
   chance_of_making_donor_livesafe_ =

--- a/source/fuzz/fuzzer_context.cpp
+++ b/source/fuzz/fuzzer_context.cpp
@@ -42,6 +42,7 @@ const std::pair<uint32_t, uint32_t> kChanceOfAddingMatrixType = {20, 70};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingNoContractionDecoration = {
     5, 70};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingParameters = {5, 70};
+const std::pair<uint32_t, uint32_t> kChanceOfAddingRelaxedDecoration = {20, 90};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingStore = {5, 50};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingSynonyms = {20, 50};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingVectorType = {20, 70};
@@ -152,6 +153,8 @@ FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
       ChooseBetweenMinAndMax(kChanceOfAddingNoContractionDecoration);
   chance_of_adding_parameters =
       ChooseBetweenMinAndMax(kChanceOfAddingParameters);
+  chance_of_adding_relaxed_decoration_ =
+      ChooseBetweenMinAndMax(kChanceOfAddingRelaxedDecoration);
   chance_of_adding_store_ = ChooseBetweenMinAndMax(kChanceOfAddingStore);
   chance_of_adding_vector_shuffle_ =
       ChooseBetweenMinAndMax(kChanceOfAddingVectorShuffle);

--- a/source/fuzz/fuzzer_context.h
+++ b/source/fuzz/fuzzer_context.h
@@ -143,6 +143,9 @@ class FuzzerContext {
     return chance_of_adding_no_contraction_decoration_;
   }
   uint32_t GetChanceOfAddingParameters() { return chance_of_adding_parameters; }
+  uint32_t GetChanceOfAddingRelaxedDecoration() {
+    return chance_of_adding_relaxed_decoration_;
+  }
   uint32_t GetChanceOfAddingStore() { return chance_of_adding_store_; }
   uint32_t GetChanceOfAddingSynonyms() { return chance_of_adding_synonyms_; }
   uint32_t GetChanceOfAddingVectorShuffle() {
@@ -309,6 +312,7 @@ class FuzzerContext {
   uint32_t chance_of_adding_matrix_type_;
   uint32_t chance_of_adding_no_contraction_decoration_;
   uint32_t chance_of_adding_parameters;
+  uint32_t chance_of_adding_relaxed_decoration_;
   uint32_t chance_of_adding_store_;
   uint32_t chance_of_adding_synonyms_;
   uint32_t chance_of_adding_vector_shuffle_;

--- a/source/fuzz/fuzzer_context.h
+++ b/source/fuzz/fuzzer_context.h
@@ -186,6 +186,9 @@ class FuzzerContext {
   uint32_t GetChanceOfGoingDeeperWhenMakingAccessChain() {
     return chance_of_going_deeper_when_making_access_chain_;
   }
+  uint32_t GetChanceOfInterchangingZeroLikeConstants() {
+    return chance_of_interchanging_zero_like_constants_;
+  }
   uint32_t GetChanceOfInvertingComparisonOperators() {
     return chance_of_inverting_comparison_operators_;
   }
@@ -329,6 +332,7 @@ class FuzzerContext {
   uint32_t chance_of_copying_object_;
   uint32_t chance_of_donating_additional_module_;
   uint32_t chance_of_going_deeper_when_making_access_chain_;
+  uint32_t chance_of_interchanging_zero_like_constants_;
   uint32_t chance_of_inverting_comparison_operators_;
   uint32_t chance_of_making_donor_livesafe_;
   uint32_t chance_of_merging_blocks_;

--- a/source/fuzz/fuzzer_pass.cpp
+++ b/source/fuzz/fuzzer_pass.cpp
@@ -20,6 +20,7 @@
 #include "source/fuzz/instruction_descriptor.h"
 #include "source/fuzz/transformation_add_constant_boolean.h"
 #include "source/fuzz/transformation_add_constant_composite.h"
+#include "source/fuzz/transformation_add_constant_null.h"
 #include "source/fuzz/transformation_add_constant_scalar.h"
 #include "source/fuzz/transformation_add_global_undef.h"
 #include "source/fuzz/transformation_add_type_boolean.h"
@@ -370,6 +371,27 @@ uint32_t FuzzerPass::FindOrCreateGlobalUndef(uint32_t type_id) {
   }
   auto result = GetFuzzerContext()->GetFreshId();
   ApplyTransformation(TransformationAddGlobalUndef(result, type_id));
+  return result;
+}
+
+uint32_t FuzzerPass::FindOrCreateNullConstant(uint32_t type_id) {
+  // Find existing declaration
+  opt::analysis::NullConstant null_constant(
+      GetIRContext()->get_type_mgr()->GetType(type_id));
+  auto existing_constant =
+      GetIRContext()->get_constant_mgr()->FindConstant(&null_constant);
+
+  // Return if found
+  if (existing_constant) {
+    return GetIRContext()
+        ->get_constant_mgr()
+        ->GetDefiningInstruction(existing_constant)
+        ->result_id();
+  }
+
+  // Create new if not found
+  auto result = GetFuzzerContext()->GetFreshId();
+  ApplyTransformation(TransformationAddConstantNull(result, type_id));
   return result;
 }
 

--- a/source/fuzz/fuzzer_pass.h
+++ b/source/fuzz/fuzzer_pass.h
@@ -192,6 +192,12 @@ class FuzzerPass {
   // If no such instruction exists, a transformation is applied to add it.
   uint32_t FindOrCreateGlobalUndef(uint32_t type_id);
 
+  // Returns the id of an OpNullConstant instruction of type |type_id|. If
+  // that instruction doesn't exist, it is added through a transformation.
+  // |type_id| must be a valid result id of an OpType* instruction that exists
+  // in the module.
+  uint32_t FindOrCreateNullConstant(uint32_t type_id);
+
   // Define a *basic type* to be an integer, boolean or floating-point type,
   // or a matrix, vector, struct or fixed-size array built from basic types.  In
   // particular, a basic type cannot contain an opaque type (such as an image),

--- a/source/fuzz/fuzzer_pass_add_relaxed_decorations.cpp
+++ b/source/fuzz/fuzzer_pass_add_relaxed_decorations.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/fuzzer_pass_add_relaxed_decorations.h"
+
+#include "source/fuzz/transformation_add_relaxed_decoration.h"
+
+namespace spvtools {
+namespace fuzz {
+
+FuzzerPassAddRelaxedDecorations::FuzzerPassAddRelaxedDecorations(
+    opt::IRContext* ir_context, TransformationContext* transformation_context,
+    FuzzerContext* fuzzer_context,
+    protobufs::TransformationSequence* transformations)
+    : FuzzerPass(ir_context, transformation_context, fuzzer_context,
+                 transformations) {}
+
+FuzzerPassAddRelaxedDecorations::
+~FuzzerPassAddRelaxedDecorations() = default;
+
+void FuzzerPassAddRelaxedDecorations::Apply() {
+  // Consider every instruction in every block in every function.
+  for (auto& function : *GetIRContext()->module()) {
+    for (auto& block : function) {
+      for (auto& inst : block) {
+        // Restrict attention to numeric instructions (returning 32-bit floats
+        // or ints according to SPIR-V documentation).
+        if (TransformationAddRelaxedDecoration::IsNumeric(
+            inst.opcode())) {
+          // Randomly choose whether to apply the RelaxedPrecision decoration to
+          // this arithmetic instruction.
+          if (GetFuzzerContext()->ChoosePercentage(
+              GetFuzzerContext()
+                  ->GetChanceOfAddingRelaxedDecoration())) {
+            TransformationAddRelaxedDecoration transformation(
+                inst.result_id());
+            ApplyTransformation(transformation);
+          }
+        }
+      }
+    }
+  }
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/fuzzer_pass_add_relaxed_decorations.cpp
+++ b/source/fuzz/fuzzer_pass_add_relaxed_decorations.cpp
@@ -33,15 +33,15 @@ void FuzzerPassAddRelaxedDecorations::Apply() {
   for (auto& function : *GetIRContext()->module()) {
     for (auto& block : function) {
       for (auto& inst : block) {
-        // Restrict attention to numeric instructions (returning 32-bit floats
-        // or ints according to SPIR-V documentation) in dead blocks.
-        TransformationAddRelaxedDecoration transformation(inst.result_id());
-        if (transformation.IsApplicable(GetIRContext(),
-                                        *GetTransformationContext())) {
-          // Randomly choose whether to apply the RelaxedPrecision decoration to
-          // this numeric instruction.
-          if (GetFuzzerContext()->ChoosePercentage(
-                  GetFuzzerContext()->GetChanceOfAddingRelaxedDecoration())) {
+        // Randomly choose whether to apply the RelaxedPrecision decoration
+        // to this numeric instruction.
+        if (GetFuzzerContext()->ChoosePercentage(
+                GetFuzzerContext()->GetChanceOfAddingRelaxedDecoration())) {
+          TransformationAddRelaxedDecoration transformation(inst.result_id());
+          // Restrict attention to numeric instructions (returning 32-bit
+          // floats or ints according to SPIR-V documentation) in dead blocks.
+          if (transformation.IsApplicable(GetIRContext(),
+                                          *GetTransformationContext())) {
             transformation.Apply(GetIRContext(), GetTransformationContext());
             *GetTransformations()->add_transformation() =
                 transformation.ToMessage();

--- a/source/fuzz/fuzzer_pass_add_relaxed_decorations.h
+++ b/source/fuzz/fuzzer_pass_add_relaxed_decorations.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SPIRV_TOOLS_FUZZER_PASS_ADD_RELAXED_DECORATIONS_H
+#define SPIRV_TOOLS_FUZZER_PASS_ADD_RELAXED_DECORATIONS_H
+
+#include "source/fuzz/fuzzer_pass.h"
+
+namespace spvtools {
+namespace fuzz {
+
+// A pass that applies the Relaxed decoration to numeric instructions.
+class FuzzerPassAddRelaxedDecorations : public FuzzerPass {
+ public:
+  FuzzerPassAddRelaxedDecorations(
+      opt::IRContext* ir_context, TransformationContext* transformation_context,
+      FuzzerContext* fuzzer_context,
+      protobufs::TransformationSequence* transformations);
+
+  ~FuzzerPassAddRelaxedDecorations() override;
+
+  void Apply() override;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SPIRV_TOOLS_FUZZER_PASS_ADD_RELAXED_DECORATIONS_H

--- a/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
@@ -73,10 +73,9 @@ void FuzzerPassApplyIdSynonyms::Apply() {
         continue;
       }
       // |use_index| is the absolute index of the operand.  We require
-      // the index of the operand restricted to input operands only, so
-      // we subtract the number of non-input operands from |use_index|.
+      // the index of the operand restricted to input operands only.
       uint32_t use_in_operand_index =
-          use_index - use_inst->NumOperands() + use_inst->NumInOperands();
+          fuzzerutil::InOperandIndexFromOperandIndex(*use_inst, use_index);
       if (!TransformationReplaceIdWithSynonym::UseCanBeReplacedWithSynonym(
               GetIRContext(), use_inst, use_in_operand_index)) {
         continue;

--- a/source/fuzz/fuzzer_pass_interchange_zero_like_constants.cpp
+++ b/source/fuzz/fuzzer_pass_interchange_zero_like_constants.cpp
@@ -1,0 +1,124 @@
+// Copyright (c) 2020 Stefano Milizia
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/fuzzer_pass_interchange_zero_like_constants.h"
+#include "source/fuzz/fuzzer_util.h"
+#include "source/fuzz/id_use_descriptor.h"
+#include "source/fuzz/transformation_record_synonymous_constants.h"
+#include "source/fuzz/transformation_replace_id_with_synonym.h"
+
+namespace spvtools {
+namespace fuzz {
+FuzzerPassInterchangeZeroLikeConstants::FuzzerPassInterchangeZeroLikeConstants(
+    opt::IRContext* ir_context, TransformationContext* transformation_context,
+    FuzzerContext* fuzzer_context,
+    protobufs::TransformationSequence* transformations)
+    : FuzzerPass(ir_context, transformation_context, fuzzer_context,
+                 transformations) {}
+
+FuzzerPassInterchangeZeroLikeConstants::
+    ~FuzzerPassInterchangeZeroLikeConstants() = default;
+
+uint32_t FuzzerPassInterchangeZeroLikeConstants::FindOrCreateToggledConstant(
+    opt::Instruction* declaration) {
+  auto constant = GetIRContext()->get_constant_mgr()->FindDeclaredConstant(
+      declaration->result_id());
+
+  // This pass only toggles zero-like constants
+  if (!constant->IsZero()) {
+    return 0;
+  }
+
+  if (constant->AsScalarConstant()) {
+    return FindOrCreateNullConstant(declaration->type_id());
+  } else if (constant->AsNullConstant()) {
+    // Add declaration of equivalent scalar constant
+    auto kind = constant->type()->kind();
+    if (kind == opt::analysis::Type::kBool ||
+        kind == opt::analysis::Type::kInteger ||
+        kind == opt::analysis::Type::kFloat) {
+      return FindOrCreateZeroConstant(declaration->type_id());
+    }
+  }
+
+  return 0;
+}
+
+void FuzzerPassInterchangeZeroLikeConstants::MaybeAddUseToReplace(
+    opt::Instruction* use_inst, uint32_t use_index, uint32_t replacement_id,
+    std::vector<std::pair<protobufs::IdUseDescriptor, uint32_t>>*
+        uses_to_replace) {
+  // Only consider this use if it is in a block
+  if (!GetIRContext()->get_instr_block(use_inst)) {
+    return;
+  }
+
+  // Get the index of the operand restricted to input operands.
+  uint32_t in_operand_index =
+      fuzzerutil::InOperandIndexFromOperandIndex(*use_inst, use_index);
+  auto id_use_descriptor =
+      MakeIdUseDescriptorFromUse(GetIRContext(), use_inst, in_operand_index);
+  uses_to_replace->emplace_back(
+      std::make_pair(id_use_descriptor, replacement_id));
+}
+
+void FuzzerPassInterchangeZeroLikeConstants::Apply() {
+  // Make vector keeping track of all the uses we want to replace.
+  // This is a vector of pairs, where the first element is an id use descriptor
+  // identifying the use of a constant id and the second is the id that should
+  // be used to replace it.
+  std::vector<std::pair<protobufs::IdUseDescriptor, uint32_t>> uses_to_replace;
+
+  for (auto constant : GetIRContext()->GetConstants()) {
+    uint32_t constant_id = constant->result_id();
+    uint32_t toggled_id = FindOrCreateToggledConstant(constant);
+
+    if (!toggled_id) {
+      // Not a zero-like constant
+      continue;
+    }
+
+    // Record synonymous constants
+    ApplyTransformation(
+        TransformationRecordSynonymousConstants(constant_id, toggled_id));
+
+    // Find all the uses of the constant and, for each, probabilistically
+    // decide whether to replace it.
+    GetIRContext()->get_def_use_mgr()->ForEachUse(
+        constant_id,
+        [this, toggled_id, &uses_to_replace](opt::Instruction* use_inst,
+                                             uint32_t use_index) -> void {
+          if (GetFuzzerContext()->ChoosePercentage(
+                  GetFuzzerContext()
+                      ->GetChanceOfInterchangingZeroLikeConstants())) {
+            MaybeAddUseToReplace(use_inst, use_index, toggled_id,
+                                 &uses_to_replace);
+          }
+        });
+  }
+
+  // Replace the ids
+  for (auto use_to_replace : uses_to_replace) {
+    auto transformation = TransformationReplaceIdWithSynonym(
+        use_to_replace.first, use_to_replace.second);
+    if (transformation.IsApplicable(GetIRContext(),
+                                    *GetTransformationContext())) {
+      transformation.Apply(GetIRContext(), GetTransformationContext());
+      *GetTransformations()->add_transformation() = transformation.ToMessage();
+    }
+  }
+}
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/fuzzer_pass_interchange_zero_like_constants.h
+++ b/source/fuzz/fuzzer_pass_interchange_zero_like_constants.h
@@ -1,0 +1,63 @@
+// Copyright (c) 2020 Stefano Milizia
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_FUZZER_PASS_INTERCHANGE_ZERO_LIKE_CONSTANTS_
+#define SOURCE_FUZZ_FUZZER_PASS_INTERCHANGE_ZERO_LIKE_CONSTANTS_
+
+#include "source/fuzz/fuzzer_pass.h"
+
+namespace spvtools {
+namespace fuzz {
+
+// A pass that:
+// - Finds all the zero-like constant definitions in the module and adds the
+//   definitions of the corresponding synonym, recording the fact that they
+//   are synonymous. If the synonym is already in the module, it does not
+//   add a new one.
+// - For each use of a zero-like constant, decides whether to change it to the
+//   id of the toggled constant.
+class FuzzerPassInterchangeZeroLikeConstants : public FuzzerPass {
+ public:
+  FuzzerPassInterchangeZeroLikeConstants(
+      opt::IRContext* ir_context, TransformationContext* transformation_context,
+      FuzzerContext* fuzzer_context,
+      protobufs::TransformationSequence* transformations);
+
+  ~FuzzerPassInterchangeZeroLikeConstants() override;
+
+  void Apply() override;
+
+ private:
+  // Given the declaration of a zero-like constant, it finds or creates the
+  // corresponding toggled constant (a scalar constant of value 0 becomes a
+  // null constant of the same type and vice versa).
+  // Returns the id of the toggled instruction if the constant is zero-like,
+  // 0 otherwise.
+  uint32_t FindOrCreateToggledConstant(opt::Instruction* declaration);
+
+  // Given an id use (described by an instruction and an index) and an id with
+  // which the original one should be replaced, adds a pair (with the elements
+  // being the corresponding id use descriptor and the replacement id) to
+  // |uses_to_replace| if the use is in an instruction block, otherwise does
+  // nothing.
+  void MaybeAddUseToReplace(
+      opt::Instruction* use_inst, uint32_t use_index, uint32_t replacement_id,
+      std::vector<std::pair<protobufs::IdUseDescriptor, uint32_t>>*
+          uses_to_replace);
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+#endif  // SOURCE_FUZZ_FUZZER_PASS_INTERCHANGE_ZERO_LIKE_CONSTANTS_

--- a/source/fuzz/fuzzer_pass_obfuscate_constants.cpp
+++ b/source/fuzz/fuzzer_pass_obfuscate_constants.cpp
@@ -477,28 +477,18 @@ void FuzzerPassObfuscateConstants::Apply() {
           skipped_opcode_count.clear();
         }
 
-        switch (inst.opcode()) {
-          case SpvOpPhi:
-            // The instruction must not be an OpPhi, as we cannot insert
-            // instructions before an OpPhi.
-            // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/2902):
-            //  there is scope for being less conservative.
-            break;
-          case SpvOpVariable:
-            // The instruction must not be an OpVariable, the only id that an
-            // OpVariable uses is an initializer id, which has to remain
-            // constant.
-            break;
-          default:
-            // Consider each operand of the instruction, and add a constant id
-            // use for the operand if relevant.
-            for (uint32_t in_operand_index = 0;
-                 in_operand_index < inst.NumInOperands(); in_operand_index++) {
-              MaybeAddConstantIdUse(inst, in_operand_index,
-                                    base_instruction_result_id,
-                                    skipped_opcode_count, &constant_uses);
-            }
-            break;
+        // The instruction must not be an OpVariable, the only id that an
+        // OpVariable uses is an initializer id, which has to remain
+        // constant.
+        if (inst.opcode() != SpvOpVariable) {
+          // Consider each operand of the instruction, and add a constant id
+          // use for the operand if relevant.
+          for (uint32_t in_operand_index = 0;
+               in_operand_index < inst.NumInOperands(); in_operand_index++) {
+            MaybeAddConstantIdUse(inst, in_operand_index,
+                                  base_instruction_result_id,
+                                  skipped_opcode_count, &constant_uses);
+          }
         }
 
         if (!inst.HasResultId()) {

--- a/source/fuzz/fuzzer_pass_replace_linear_algebra_instructions.cpp
+++ b/source/fuzz/fuzzer_pass_replace_linear_algebra_instructions.cpp
@@ -45,6 +45,7 @@ void FuzzerPassReplaceLinearAlgebraInstructions::Apply() {
         instruction->opcode() != SpvOpMatrixTimesScalar &&
         instruction->opcode() != SpvOpVectorTimesMatrix &&
         instruction->opcode() != SpvOpMatrixTimesVector &&
+        instruction->opcode() != SpvOpMatrixTimesMatrix &&
         instruction->opcode() != SpvOpDot) {
       return;
     }

--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -552,6 +552,12 @@ uint32_t MaybeGetPointerType(opt::IRContext* context, uint32_t pointee_type_id,
   return 0;
 }
 
+uint32_t InOperandIndexFromOperandIndex(const opt::Instruction& inst,
+                                        uint32_t absolute_index) {
+  // Subtract the number of non-input operands from the index
+  return absolute_index - inst.NumOperands() + inst.NumInOperands();
+}
+
 bool IsNullConstantSupported(const opt::analysis::Type& type) {
   return type.AsBool() || type.AsInteger() || type.AsFloat() ||
          type.AsMatrix() || type.AsVector() || type.AsArray() ||

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -64,6 +64,12 @@ void AddUnreachableEdgeAndUpdateOpPhis(
     bool condition_value,
     const google::protobuf::RepeatedField<google::protobuf::uint32>& phi_ids);
 
+// Returns true if and only if |loop_header_id| is a loop header and
+// |block_id| is a reachable block branching to and dominated by
+// |loop_header_id|.
+bool BlockIsBackEdge(opt::IRContext* context, uint32_t block_id,
+                     uint32_t loop_header_id);
+
 // Returns true if and only if |maybe_loop_header_id| is a loop header and
 // |block_id| is in the continue construct of the associated loop.
 bool BlockIsInLoopContinueConstruct(opt::IRContext* context, uint32_t block_id,

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -213,6 +213,11 @@ SpvStorageClass GetStorageClassFromPointerType(opt::IRContext* context,
 uint32_t MaybeGetPointerType(opt::IRContext* context, uint32_t pointee_type_id,
                              SpvStorageClass storage_class);
 
+// Given an instruction |inst| and an operand absolute index |absolute_index|,
+// returns the index of the operand restricted to the input operands.
+uint32_t InOperandIndexFromOperandIndex(const opt::Instruction& inst,
+                                        uint32_t absolute_index);
+
 // Returns true if and only if |type| is one of the types for which it is legal
 // to have an OpConstantNull value.
 bool IsNullConstantSupported(const opt::analysis::Type& type);

--- a/source/fuzz/protobufs/spirvfuzz_protobufs.h
+++ b/source/fuzz/protobufs/spirvfuzz_protobufs.h
@@ -39,6 +39,7 @@
 // where warnings are ignored.
 
 #include "google/protobuf/util/json_util.h"
+#include "google/protobuf/util/message_differencer.h"
 #include "source/fuzz/protobufs/spvtoolsfuzz.pb.h"
 
 #if defined(__clang__)

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -387,6 +387,7 @@ message Transformation {
     TransformationReplaceParameterWithGlobal replace_parameter_with_global = 56;
     TransformationRecordSynonymousConstants record_synonymous_constants = 57;
     TransformationAddSynonym add_synonym = 58;
+    TransformationAddRelaxedDecoration add_relaxed_decoration = 59;
     // Add additional option using the next available number.
   }
 }
@@ -685,6 +686,15 @@ message TransformationAddParameter {
   // if a required function type already exists or if we can change
   // the old function type.
   uint32 function_type_fresh_id = 4;
+
+}
+
+message TransformationAddRelaxedDecoration {
+
+  // Applies OpDecorate RelaxedPrecision to the given result id
+
+  // Result id to be decorated
+  uint32 result_id = 1;
 
 }
 

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -1289,13 +1289,13 @@ message TransformationReplaceLinearAlgebraInstruction {
   //   OpMatrixTimesScalar
   //   OpVectorTimesMatrix
   //   OpMatrixTimesVector
+  //   OpMatrixTimesMatrix
   //   OpDot
   // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3354):
   // Right now we only support certain operations. When this issue is addressed
   // the supporting comments can be removed.
   // To be supported in the future:
   //   OpTranspose
-  //   OpMatrixTimesMatrix
   //   OpOuterProduct
   InstructionDescriptor instruction_descriptor = 2;
 

--- a/source/fuzz/replayer.h
+++ b/source/fuzz/replayer.h
@@ -34,6 +34,7 @@ class Replayer {
     kFailedToCreateSpirvToolsInterface,
     kInitialBinaryInvalid,
     kReplayValidationFailure,
+    kTooManyTransformationsRequested,
   };
 
   // Constructs a replayer from the given target environment.
@@ -52,16 +53,17 @@ class Replayer {
   // invoked once for each message communicated from the library.
   void SetMessageConsumer(MessageConsumer consumer);
 
-  // Transforms |binary_in| to |binary_out| by attempting to apply the
-  // transformations from |transformation_sequence_in|.  Initial facts about the
-  // input binary and the context in which it will execute are provided via
-  // |initial_facts|.  The transformations that were successfully applied are
-  // returned via |transformation_sequence_out|.
+  // Transforms |binary_in| to |binary_out| by attempting to apply the first
+  // |num_transformations_to_apply| transformations from
+  // |transformation_sequence_in|.  Initial facts about the input binary and the
+  // context in which it will execute are provided via |initial_facts|.  The
+  // transformations that were successfully applied are returned via
+  // |transformation_sequence_out|.
   ReplayerResultStatus Run(
       const std::vector<uint32_t>& binary_in,
       const protobufs::FactSequence& initial_facts,
       const protobufs::TransformationSequence& transformation_sequence_in,
-      std::vector<uint32_t>* binary_out,
+      uint32_t num_transformations_to_apply, std::vector<uint32_t>* binary_out,
       protobufs::TransformationSequence* transformation_sequence_out) const;
 
  private:

--- a/source/fuzz/shrinker.cpp
+++ b/source/fuzz/shrinker.cpp
@@ -124,6 +124,7 @@ Shrinker::ShrinkerResultStatus Shrinker::Run(
   if (Replayer(impl_->target_env, impl_->validate_during_replay,
                impl_->validator_options)
           .Run(binary_in, initial_facts, transformation_sequence_in,
+               transformation_sequence_in.transformation_size(),
                &current_best_binary, &current_best_transformations) !=
       Replayer::ReplayerResultStatus::kComplete) {
     return ShrinkerResultStatus::kReplayFailed;
@@ -196,6 +197,7 @@ Shrinker::ShrinkerResultStatus Shrinker::Run(
       if (Replayer(impl_->target_env, impl_->validate_during_replay,
                    impl_->validator_options)
               .Run(binary_in, initial_facts, transformations_with_chunk_removed,
+                   transformations_with_chunk_removed.transformation_size(),
                    &next_binary, &next_transformation_sequence) !=
           Replayer::ReplayerResultStatus::kComplete) {
         // Replay should not fail; if it does, we need to abort shrinking.

--- a/source/fuzz/transformation.cpp
+++ b/source/fuzz/transformation.cpp
@@ -33,6 +33,7 @@
 #include "source/fuzz/transformation_add_local_variable.h"
 #include "source/fuzz/transformation_add_no_contraction_decoration.h"
 #include "source/fuzz/transformation_add_parameter.h"
+#include "source/fuzz/transformation_add_relaxed_decoration.h"
 #include "source/fuzz/transformation_add_spec_constant_op.h"
 #include "source/fuzz/transformation_add_synonym.h"
 #include "source/fuzz/transformation_add_type_array.h"
@@ -129,6 +130,10 @@ std::unique_ptr<Transformation> Transformation::FromMessage(
           message.add_no_contraction_decoration());
     case protobufs::Transformation::TransformationCase::kAddParameter:
       return MakeUnique<TransformationAddParameter>(message.add_parameter());
+    case protobufs::Transformation::TransformationCase::
+      kAddRelaxedDecoration:
+      return MakeUnique<TransformationAddRelaxedDecoration>(
+          message.add_relaxed_decoration());
     case protobufs::Transformation::TransformationCase::kAddSpecConstantOp:
       return MakeUnique<TransformationAddSpecConstantOp>(
           message.add_spec_constant_op());

--- a/source/fuzz/transformation_add_dead_break.cpp
+++ b/source/fuzz/transformation_add_dead_break.cpp
@@ -85,12 +85,10 @@ bool TransformationAddDeadBreak::AddingBreakRespectsStructuredControlFlow(
     // loop as part of the loop, but it is not legal to jump from a loop's
     // continue construct to the loop's merge (except from the back-edge block),
     // so we need to check for this case.
-    //
-    // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/2577): We do not
-    //  currently allow a dead break from a back edge block, but we could and
-    //  ultimately should.
     return !fuzzerutil::BlockIsInLoopContinueConstruct(
-        ir_context, message_.from_block(), containing_construct);
+               ir_context, message_.from_block(), containing_construct) ||
+           fuzzerutil::BlockIsBackEdge(ir_context, message_.from_block(),
+                                       containing_construct);
   }
 
   // Case (3) holds if and only if |to_block| is the merge block for this
@@ -102,7 +100,9 @@ bool TransformationAddDeadBreak::AddingBreakRespectsStructuredControlFlow(
       message_.to_block() ==
           ir_context->cfg()->block(containing_loop_header)->MergeBlockId()) {
     return !fuzzerutil::BlockIsInLoopContinueConstruct(
-        ir_context, message_.from_block(), containing_loop_header);
+               ir_context, message_.from_block(), containing_loop_header) ||
+           fuzzerutil::BlockIsBackEdge(ir_context, message_.from_block(),
+                                       containing_loop_header);
   }
   return false;
 }

--- a/source/fuzz/transformation_add_no_contraction_decoration.cpp
+++ b/source/fuzz/transformation_add_no_contraction_decoration.cpp
@@ -37,11 +37,6 @@ bool TransformationAddNoContractionDecoration::IsApplicable(
   if (!instr) {
     return false;
   }
-  opt::BasicBlock* cur_block = ir_context->get_instr_block(instr);
-  // The instruction must have a block.
-  if (cur_block == nullptr) {
-    return false;
-  }
   // The instruction must be arithmetic.
   return IsArithmetic(instr->opcode());
 }

--- a/source/fuzz/transformation_add_no_contraction_decoration.cpp
+++ b/source/fuzz/transformation_add_no_contraction_decoration.cpp
@@ -37,6 +37,11 @@ bool TransformationAddNoContractionDecoration::IsApplicable(
   if (!instr) {
     return false;
   }
+  opt::BasicBlock* cur_block = ir_context->get_instr_block(instr);
+  // The instruction must have a block.
+  if (cur_block == nullptr) {
+    return false;
+  }
   // The instruction must be arithmetic.
   return IsArithmetic(instr->opcode());
 }

--- a/source/fuzz/transformation_add_relaxed_decoration.cpp
+++ b/source/fuzz/transformation_add_relaxed_decoration.cpp
@@ -38,7 +38,11 @@ bool TransformationAddRelaxedDecoration::IsApplicable(
     return false;
   }
   opt::BasicBlock* cur_block = ir_context->get_instr_block(instr);
-  // current block must be a dead block
+  // The instruction must have a block.
+  if (cur_block == nullptr) {
+    return false;
+  }
+  // |cur_block| must be a dead block.
   if (!(transformation_context.GetFactManager()->BlockIsDead(
           cur_block->id()))) {
     return false;

--- a/source/fuzz/transformation_add_relaxed_decoration.cpp
+++ b/source/fuzz/transformation_add_relaxed_decoration.cpp
@@ -19,29 +19,28 @@
 namespace spvtools {
 namespace fuzz {
 
-TransformationAddRelaxedDecoration::
-TransformationAddRelaxedDecoration(
-    const spvtools::fuzz::protobufs::
-    TransformationAddRelaxedDecoration& message)
+TransformationAddRelaxedDecoration::TransformationAddRelaxedDecoration(
+    const spvtools::fuzz::protobufs::TransformationAddRelaxedDecoration&
+        message)
     : message_(message) {}
 
-TransformationAddRelaxedDecoration::
-TransformationAddRelaxedDecoration(uint32_t result_id) {
+TransformationAddRelaxedDecoration::TransformationAddRelaxedDecoration(
+    uint32_t result_id) {
   message_.set_result_id(result_id);
 }
 
 bool TransformationAddRelaxedDecoration::IsApplicable(
-    opt::IRContext* ir_context, const TransformationContext& transformation_context) const {
+    opt::IRContext* ir_context,
+    const TransformationContext& transformation_context) const {
   // |message_.result_id| must be the id of an instruction.
   auto instr = ir_context->get_def_use_mgr()->GetDef(message_.result_id());
   if (!instr) {
     return false;
   }
-  opt::BasicBlock* cur_block =
-      ir_context->get_instr_block(instr);
+  opt::BasicBlock* cur_block = ir_context->get_instr_block(instr);
   // current block must be a dead block
   if (!(transformation_context.GetFactManager()->BlockIsDead(
-      cur_block->id()))) {
+          cur_block->id()))) {
     return false;
   }
   // The instruction must be numeric.
@@ -51,12 +50,12 @@ bool TransformationAddRelaxedDecoration::IsApplicable(
 void TransformationAddRelaxedDecoration::Apply(
     opt::IRContext* ir_context, TransformationContext* /*unused*/) const {
   // Add a RelaxedPrecision decoration targeting |message_.result_id|.
-  ir_context->get_decoration_mgr()->AddDecoration(message_.result_id(),
-                                                  SpvDecorationRelaxedPrecision);
+  ir_context->get_decoration_mgr()->AddDecoration(
+      message_.result_id(), SpvDecorationRelaxedPrecision);
 }
 
 protobufs::Transformation TransformationAddRelaxedDecoration::ToMessage()
-const {
+    const {
   protobufs::Transformation result;
   *result.mutable_add_relaxed_decoration() = message_;
   return result;

--- a/source/fuzz/transformation_add_relaxed_decoration.cpp
+++ b/source/fuzz/transformation_add_relaxed_decoration.cpp
@@ -1,0 +1,143 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_add_relaxed_decoration.h"
+
+#include "source/fuzz/fuzzer_util.h"
+
+namespace spvtools {
+namespace fuzz {
+
+TransformationAddRelaxedDecoration::
+TransformationAddRelaxedDecoration(
+    const spvtools::fuzz::protobufs::
+    TransformationAddRelaxedDecoration& message)
+    : message_(message) {}
+
+TransformationAddRelaxedDecoration::
+TransformationAddRelaxedDecoration(uint32_t result_id) {
+  message_.set_result_id(result_id);
+}
+
+bool TransformationAddRelaxedDecoration::IsApplicable(
+    opt::IRContext* ir_context, const TransformationContext& transformation_context) const {
+  // |message_.result_id| must be the id of an instruction.
+  auto instr = ir_context->get_def_use_mgr()->GetDef(message_.result_id());
+  if (!instr) {
+    return false;
+  }
+  opt::BasicBlock* cur_block =
+      ir_context->get_instr_block(instr);
+  // current block must be a dead block
+  if (!(transformation_context.GetFactManager()->BlockIsDead(
+      cur_block->id()))) {
+    return false;
+  }
+  // The instruction must be numeric.
+  return IsNumeric(instr->opcode());
+}
+
+void TransformationAddRelaxedDecoration::Apply(
+    opt::IRContext* ir_context, TransformationContext* /*unused*/) const {
+  // Add a RelaxedPrecision decoration targeting |message_.result_id|.
+  ir_context->get_decoration_mgr()->AddDecoration(message_.result_id(),
+                                                  SpvDecorationRelaxedPrecision);
+}
+
+protobufs::Transformation TransformationAddRelaxedDecoration::ToMessage()
+const {
+  protobufs::Transformation result;
+  *result.mutable_add_relaxed_decoration() = message_;
+  return result;
+}
+
+bool TransformationAddRelaxedDecoration::IsNumeric(uint32_t opcode) {
+  switch (opcode) {
+    case SpvOpConvertFToU:
+    case SpvOpConvertFToS:
+    case SpvOpConvertSToF:
+    case SpvOpConvertUToF:
+    case SpvOpUConvert:
+    case SpvOpSConvert:
+    case SpvOpFConvert:
+    case SpvOpConvertPtrToU:
+    case SpvOpSatConvertSToU:
+    case SpvOpSatConvertUToS:
+    case SpvOpVectorExtractDynamic:
+    case SpvOpVectorInsertDynamic:
+    case SpvOpVectorShuffle:
+    case SpvOpTranspose:
+    case SpvOpSNegate:
+    case SpvOpFNegate:
+    case SpvOpIAdd:
+    case SpvOpFAdd:
+    case SpvOpISub:
+    case SpvOpFSub:
+    case SpvOpIMul:
+    case SpvOpFMul:
+    case SpvOpUDiv:
+    case SpvOpSDiv:
+    case SpvOpFDiv:
+    case SpvOpUMod:
+    case SpvOpSRem:
+    case SpvOpSMod:
+    case SpvOpFRem:
+    case SpvOpFMod:
+    case SpvOpVectorTimesScalar:
+    case SpvOpMatrixTimesScalar:
+    case SpvOpVectorTimesMatrix:
+    case SpvOpMatrixTimesVector:
+    case SpvOpMatrixTimesMatrix:
+    case SpvOpOuterProduct:
+    case SpvOpDot:
+    case SpvOpIAddCarry:
+    case SpvOpISubBorrow:
+    case SpvOpUMulExtended:
+    case SpvOpSMulExtended:
+    case SpvOpShiftRightLogical:
+    case SpvOpShiftRightArithmetic:
+    case SpvOpShiftLeftLogical:
+    case SpvOpBitwiseOr:
+    case SpvOpBitwiseXor:
+    case SpvOpBitwiseAnd:
+    case SpvOpNot:
+    case SpvOpBitFieldInsert:
+    case SpvOpBitFieldSExtract:
+    case SpvOpBitFieldUExtract:
+    case SpvOpBitReverse:
+    case SpvOpBitCount:
+    case SpvOpAtomicLoad:
+    case SpvOpAtomicStore:
+    case SpvOpAtomicExchange:
+    case SpvOpAtomicCompareExchange:
+    case SpvOpAtomicCompareExchangeWeak:
+    case SpvOpAtomicIIncrement:
+    case SpvOpAtomicIDecrement:
+    case SpvOpAtomicIAdd:
+    case SpvOpAtomicISub:
+    case SpvOpAtomicSMin:
+    case SpvOpAtomicUMin:
+    case SpvOpAtomicSMax:
+    case SpvOpAtomicUMax:
+    case SpvOpAtomicAnd:
+    case SpvOpAtomicOr:
+    case SpvOpAtomicXor:
+      return true;
+    default:
+      return false;
+  }
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/transformation_add_relaxed_decoration.h
+++ b/source/fuzz/transformation_add_relaxed_decoration.h
@@ -31,10 +31,11 @@ class TransformationAddRelaxedDecoration : public Transformation {
   explicit TransformationAddRelaxedDecoration(uint32_t fresh_id);
 
   // - |message_.result_id| must be the result id of an instruction, which is
-  //   located in a dead block and Relaxed decoration can be applied
+  //   located in a dead block and Relaxed decoration can be applied.
   // - It does not matter whether this instruction is already annotated with the
   //   Relaxed decoration.
   bool IsApplicable(
+
       opt::IRContext* ir_context,
       const TransformationContext& transformation_context) const override;
 
@@ -57,6 +58,5 @@ class TransformationAddRelaxedDecoration : public Transformation {
 
 }  // namespace fuzz
 }  // namespace spvtools
-
 
 #endif  // SPIRV_TOOLS_TRANSFORMATION_ADD_RELAXED_DECORATION_H

--- a/source/fuzz/transformation_add_relaxed_decoration.h
+++ b/source/fuzz/transformation_add_relaxed_decoration.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SPIRV_TOOLS_TRANSFORMATION_ADD_RELAXED_DECORATION_H
+#define SPIRV_TOOLS_TRANSFORMATION_ADD_RELAXED_DECORATION_H
+
+#include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
+#include "source/fuzz/transformation.h"
+#include "source/fuzz/transformation_context.h"
+#include "source/opt/ir_context.h"
+
+namespace spvtools {
+namespace fuzz {
+
+class TransformationAddRelaxedDecoration : public Transformation {
+ public:
+  explicit TransformationAddRelaxedDecoration(
+      const protobufs::TransformationAddRelaxedDecoration& message);
+
+  explicit TransformationAddRelaxedDecoration(uint32_t fresh_id);
+
+  // - |message_.result_id| must be the result id of an instruction, which is
+  //   located in a dead block and Relaxed decoration can be applied
+  // - It does not matter whether this instruction is already annotated with the
+  //   Relaxed decoration.
+  bool IsApplicable(
+      opt::IRContext* ir_context,
+      const TransformationContext& transformation_context) const override;
+
+  // Adds a decoration of the form:
+  //   'OpDecoration |message_.result_id| RelaxedPrecision'
+  // to the module.
+  void Apply(opt::IRContext* ir_context,
+             TransformationContext* transformation_context) const override;
+
+  protobufs::Transformation ToMessage() const override;
+
+  // Returns true if and only if |opcode| is the opcode of an instruction
+  // that operates on 32-bit integers and 32-bit floats
+  // as defined by the SPIR-V specification.
+  static bool IsNumeric(uint32_t opcode);
+
+ private:
+  protobufs::TransformationAddRelaxedDecoration message_;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+
+#endif  // SPIRV_TOOLS_TRANSFORMATION_ADD_RELAXED_DECORATION_H

--- a/source/fuzz/transformation_replace_linear_algebra_instruction.h
+++ b/source/fuzz/transformation_replace_linear_algebra_instruction.h
@@ -68,6 +68,10 @@ class TransformationReplaceLinearAlgebraInstruction : public Transformation {
   void ReplaceOpMatrixTimesVector(opt::IRContext* ir_context,
                                   opt::Instruction* instruction) const;
 
+  // Replaces an OpMatrixTimesMatrix instruction.
+  void ReplaceOpMatrixTimesMatrix(opt::IRContext* ir_context,
+                                  opt::Instruction* instruction) const;
+
   // Replaces an OpDot instruction.
   void ReplaceOpDot(opt::IRContext* ir_context,
                     opt::Instruction* instruction) const;

--- a/source/opt/dominator_analysis.cpp
+++ b/source/opt/dominator_analysis.cpp
@@ -55,12 +55,25 @@ bool DominatorAnalysisBase::Dominates(Instruction* a, Instruction* b) const {
     return tree_.Dominates(bb_a, bb_b);
   }
 
-  Instruction* current_inst = a;
-  while ((current_inst = current_inst->NextNode())) {
-    if (current_inst == b) {
+  const Instruction* current = a;
+  const Instruction* other = b;
+
+  if (tree_.IsPostDominator()) {
+    std::swap(current, other);
+  }
+
+  // We handle OpLabel instructions explicitly since they are not stored in the
+  // instruction list.
+  if (current->opcode() == SpvOpLabel) {
+    return true;
+  }
+
+  while ((current = current->NextNode())) {
+    if (current == other) {
       return true;
     }
   }
+
   return false;
 }
 

--- a/source/opt/instrument_pass.cpp
+++ b/source/opt/instrument_pass.cpp
@@ -174,7 +174,9 @@ void InstrumentPass::GenStageStreamWriteCode(uint32_t stage_idx,
           context()->GetBuiltinInputVarId(SpvBuiltInInstanceIndex),
           kInstVertOutInstanceIndex, base_offset_id, builder);
     } break;
-    case SpvExecutionModelGLCompute: {
+    case SpvExecutionModelGLCompute:
+    case SpvExecutionModelTaskNV:
+    case SpvExecutionModelMeshNV: {
       // Load and store GlobalInvocationId.
       uint32_t load_id = GenVarLoad(
           context()->GetBuiltinInputVarId(SpvBuiltInGlobalInvocationId),
@@ -914,6 +916,7 @@ bool InstrumentPass::InstProcessEntryPointCallTree(InstProcessFunction& pfn) {
       stage != SpvExecutionModelGLCompute &&
       stage != SpvExecutionModelTessellationControl &&
       stage != SpvExecutionModelTessellationEvaluation &&
+      stage != SpvExecutionModelTaskNV && stage != SpvExecutionModelMeshNV &&
       stage != SpvExecutionModelRayGenerationNV &&
       stage != SpvExecutionModelIntersectionNV &&
       stage != SpvExecutionModelAnyHitNV &&

--- a/source/spirv_fuzzer_options.cpp
+++ b/source/spirv_fuzzer_options.cpp
@@ -22,6 +22,7 @@ const uint32_t kDefaultStepLimit = 250;
 spv_fuzzer_options_t::spv_fuzzer_options_t()
     : has_random_seed(false),
       random_seed(0),
+      replay_range(0),
       replay_validation_enabled(false),
       shrinker_step_limit(kDefaultStepLimit),
       fuzzer_pass_validation_enabled(false) {}
@@ -43,6 +44,11 @@ SPIRV_TOOLS_EXPORT void spvFuzzerOptionsSetRandomSeed(
     spv_fuzzer_options options, uint32_t seed) {
   options->has_random_seed = true;
   options->random_seed = seed;
+}
+
+SPIRV_TOOLS_EXPORT void spvFuzzerOptionsSetReplayRange(
+    spv_fuzzer_options options, int32_t replay_range) {
+  options->replay_range = replay_range;
 }
 
 SPIRV_TOOLS_EXPORT void spvFuzzerOptionsSetShrinkerStepLimit(

--- a/source/spirv_fuzzer_options.h
+++ b/source/spirv_fuzzer_options.h
@@ -29,6 +29,9 @@ struct spv_fuzzer_options_t {
   bool has_random_seed;
   uint32_t random_seed;
 
+  // See spvFuzzerOptionsSetReplayRange.
+  int32_t replay_range;
+
   // See spvFuzzerOptionsEnableReplayValidation.
   bool replay_validation_enabled;
 

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -24,6 +24,7 @@ if (${SPIRV_BUILD_FUZZER})
           fuzzer_pass_construct_composites_test.cpp
           fuzzer_pass_donate_modules_test.cpp
           instruction_descriptor_test.cpp
+          replayer_test.cpp
           transformation_access_chain_test.cpp
           transformation_add_constant_boolean_test.cpp
           transformation_add_constant_composite_test.cpp

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -40,6 +40,7 @@ if (${SPIRV_BUILD_FUZZER})
           transformation_add_local_variable_test.cpp
           transformation_add_no_contraction_decoration_test.cpp
           transformation_add_parameter_test.cpp
+          transformation_add_relaxed_decoration_test.cpp
           transformation_add_synonym_test.cpp
           transformation_add_type_array_test.cpp
           transformation_add_type_boolean_test.cpp

--- a/test/fuzz/fuzzer_replayer_test.cpp
+++ b/test/fuzz/fuzzer_replayer_test.cpp
@@ -1659,6 +1659,8 @@ void RunFuzzerAndReplayer(const std::string& shader,
     replayer.SetMessageConsumer(kConsoleMessageConsumer);
     auto replayer_result_status = replayer.Run(
         binary_in, initial_facts, fuzzer_transformation_sequence_out,
+        static_cast<uint32_t>(
+            fuzzer_transformation_sequence_out.transformation_size()),
         &replayer_binary_out, &replayer_transformation_sequence_out);
     ASSERT_EQ(Replayer::ReplayerResultStatus::kComplete,
               replayer_result_status);

--- a/test/fuzz/replayer_test.cpp
+++ b/test/fuzz/replayer_test.cpp
@@ -1,0 +1,301 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/replayer.h"
+
+#include "source/fuzz/instruction_descriptor.h"
+#include "source/fuzz/transformation_split_block.h"
+#include "test/fuzz/fuzz_test_util.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace {
+
+TEST(ReplayerTest, PartialReplay) {
+  const std::string kTestShader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %8 "g"
+               OpName %11 "x"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Private %6
+          %8 = OpVariable %7 Private
+          %9 = OpConstant %6 10
+         %10 = OpTypePointer Function %6
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %11 = OpVariable %10 Function
+               OpStore %8 %9
+         %12 = OpLoad %6 %8
+               OpStore %11 %12
+         %13 = OpLoad %6 %8
+               OpStore %11 %13
+         %14 = OpLoad %6 %8
+               OpStore %11 %14
+         %15 = OpLoad %6 %8
+               OpStore %11 %15
+         %16 = OpLoad %6 %8
+               OpStore %11 %16
+         %17 = OpLoad %6 %8
+               OpStore %11 %17
+         %18 = OpLoad %6 %8
+               OpStore %11 %18
+         %19 = OpLoad %6 %8
+               OpStore %11 %19
+         %20 = OpLoad %6 %8
+               OpStore %11 %20
+         %21 = OpLoad %6 %8
+               OpStore %11 %21
+         %22 = OpLoad %6 %8
+               OpStore %11 %22
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  spvtools::ValidatorOptions validator_options;
+
+  std::vector<uint32_t> binary_in;
+  SpirvTools t(env);
+  t.SetMessageConsumer(kSilentConsumer);
+  ASSERT_TRUE(t.Assemble(kTestShader, &binary_in, kFuzzAssembleOption));
+  ASSERT_TRUE(t.Validate(binary_in));
+
+  protobufs::TransformationSequence transformations;
+  for (uint32_t id = 12; id <= 22; id++) {
+    *transformations.add_transformation() =
+        TransformationSplitBlock(MakeInstructionDescriptor(id, SpvOpLoad, 0),
+                                 id + 100)
+            .ToMessage();
+  }
+
+  {
+    // Full replay
+    protobufs::TransformationSequence transformations_out;
+    protobufs::FactSequence empty_facts;
+    std::vector<uint32_t> binary_out;
+    Replayer replayer(env, true, validator_options);
+    replayer.SetMessageConsumer(kSilentConsumer);
+    auto replayer_result_status =
+        replayer.Run(binary_in, empty_facts, transformations, 11, &binary_out,
+                     &transformations_out);
+    // Replay should succeed.
+    ASSERT_EQ(Replayer::ReplayerResultStatus::kComplete,
+              replayer_result_status);
+    // All transformations should be applied.
+    ASSERT_TRUE(google::protobuf::util::MessageDifferencer::Equals(
+        transformations, transformations_out));
+
+    const std::string kFullySplitShader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %8 "g"
+               OpName %11 "x"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Private %6
+          %8 = OpVariable %7 Private
+          %9 = OpConstant %6 10
+         %10 = OpTypePointer Function %6
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %11 = OpVariable %10 Function
+               OpStore %8 %9
+               OpBranch %112
+        %112 = OpLabel
+         %12 = OpLoad %6 %8
+               OpStore %11 %12
+               OpBranch %113
+        %113 = OpLabel
+         %13 = OpLoad %6 %8
+               OpStore %11 %13
+               OpBranch %114
+        %114 = OpLabel
+         %14 = OpLoad %6 %8
+               OpStore %11 %14
+               OpBranch %115
+        %115 = OpLabel
+         %15 = OpLoad %6 %8
+               OpStore %11 %15
+               OpBranch %116
+        %116 = OpLabel
+         %16 = OpLoad %6 %8
+               OpStore %11 %16
+               OpBranch %117
+        %117 = OpLabel
+         %17 = OpLoad %6 %8
+               OpStore %11 %17
+               OpBranch %118
+        %118 = OpLabel
+         %18 = OpLoad %6 %8
+               OpStore %11 %18
+               OpBranch %119
+        %119 = OpLabel
+         %19 = OpLoad %6 %8
+               OpStore %11 %19
+               OpBranch %120
+        %120 = OpLabel
+         %20 = OpLoad %6 %8
+               OpStore %11 %20
+               OpBranch %121
+        %121 = OpLabel
+         %21 = OpLoad %6 %8
+               OpStore %11 %21
+               OpBranch %122
+        %122 = OpLabel
+         %22 = OpLoad %6 %8
+               OpStore %11 %22
+               OpReturn
+               OpFunctionEnd
+    )";
+    ASSERT_TRUE(IsEqual(env, kFullySplitShader, binary_out));
+  }
+
+  {
+    // Half replay
+    protobufs::TransformationSequence transformations_out;
+    protobufs::FactSequence empty_facts;
+    std::vector<uint32_t> binary_out;
+    Replayer replayer(env, true, validator_options);
+    replayer.SetMessageConsumer(kSilentConsumer);
+    auto replayer_result_status =
+        replayer.Run(binary_in, empty_facts, transformations, 5, &binary_out,
+                     &transformations_out);
+    // Replay should succeed.
+    ASSERT_EQ(Replayer::ReplayerResultStatus::kComplete,
+              replayer_result_status);
+    // The first 5 transformations should be applied
+    ASSERT_EQ(5, transformations_out.transformation_size());
+    for (uint32_t i = 0; i < 5; i++) {
+      ASSERT_TRUE(google::protobuf::util::MessageDifferencer::Equals(
+          transformations.transformation(i),
+          transformations_out.transformation(i)));
+    }
+
+    const std::string kHalfSplitShader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %8 "g"
+               OpName %11 "x"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Private %6
+          %8 = OpVariable %7 Private
+          %9 = OpConstant %6 10
+         %10 = OpTypePointer Function %6
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %11 = OpVariable %10 Function
+               OpStore %8 %9
+               OpBranch %112
+        %112 = OpLabel
+         %12 = OpLoad %6 %8
+               OpStore %11 %12
+               OpBranch %113
+        %113 = OpLabel
+         %13 = OpLoad %6 %8
+               OpStore %11 %13
+               OpBranch %114
+        %114 = OpLabel
+         %14 = OpLoad %6 %8
+               OpStore %11 %14
+               OpBranch %115
+        %115 = OpLabel
+         %15 = OpLoad %6 %8
+               OpStore %11 %15
+               OpBranch %116
+        %116 = OpLabel
+         %16 = OpLoad %6 %8
+               OpStore %11 %16
+         %17 = OpLoad %6 %8
+               OpStore %11 %17
+         %18 = OpLoad %6 %8
+               OpStore %11 %18
+         %19 = OpLoad %6 %8
+               OpStore %11 %19
+         %20 = OpLoad %6 %8
+               OpStore %11 %20
+         %21 = OpLoad %6 %8
+               OpStore %11 %21
+         %22 = OpLoad %6 %8
+               OpStore %11 %22
+               OpReturn
+               OpFunctionEnd
+    )";
+    ASSERT_TRUE(IsEqual(env, kHalfSplitShader, binary_out));
+  }
+
+  {
+    // Empty replay
+    protobufs::TransformationSequence transformations_out;
+    protobufs::FactSequence empty_facts;
+    std::vector<uint32_t> binary_out;
+    Replayer replayer(env, true, validator_options);
+    replayer.SetMessageConsumer(kSilentConsumer);
+    auto replayer_result_status =
+        replayer.Run(binary_in, empty_facts, transformations, 0, &binary_out,
+                     &transformations_out);
+    // Replay should succeed.
+    ASSERT_EQ(Replayer::ReplayerResultStatus::kComplete,
+              replayer_result_status);
+    // No transformations should be applied
+    ASSERT_EQ(0, transformations_out.transformation_size());
+    ASSERT_TRUE(IsEqual(env, kTestShader, binary_out));
+  }
+
+  {
+    // Invalid replay: too many transformations
+    protobufs::TransformationSequence transformations_out;
+    protobufs::FactSequence empty_facts;
+    std::vector<uint32_t> binary_out;
+    // The number of transformations requested to be applied exceeds the number
+    // of transformations
+    Replayer replayer(env, true, validator_options);
+    replayer.SetMessageConsumer(kSilentConsumer);
+    auto replayer_result_status =
+        replayer.Run(binary_in, empty_facts, transformations, 12, &binary_out,
+                     &transformations_out);
+
+    // Replay should not succeed.
+    ASSERT_EQ(Replayer::ReplayerResultStatus::kTooManyTransformationsRequested,
+              replayer_result_status);
+    // No transformations should be applied
+    ASSERT_EQ(0, transformations_out.transformation_size());
+    // The output binary should be empty
+    ASSERT_TRUE(binary_out.empty());
+  }
+}
+
+}  // namespace
+}  // namespace fuzz
+}  // namespace spvtools

--- a/test/fuzz/transformation_add_dead_break_test.cpp
+++ b/test/fuzz/transformation_add_dead_break_test.cpp
@@ -1196,15 +1196,15 @@ TEST(TransformationAddDeadBreakTest, BreakOutOfLoopNest) {
       TransformationAddDeadBreak(header_for_j, merge_do_while, true, {})
           .IsApplicable(context.get(), transformation_context));
 
-  // Not OK to break loop from its continue construct
+  // Not OK to break loop from its continue construct, except from the back-edge
+  // block.
   ASSERT_FALSE(
       TransformationAddDeadBreak(continue_do_while, merge_do_while, true, {})
           .IsApplicable(context.get(), transformation_context));
-  ASSERT_FALSE(
-      TransformationAddDeadBreak(continue_for_j, merge_for_j, false, {})
-          .IsApplicable(context.get(), transformation_context));
-  ASSERT_FALSE(TransformationAddDeadBreak(continue_for_i, merge_for_i, true, {})
-                   .IsApplicable(context.get(), transformation_context));
+  ASSERT_TRUE(TransformationAddDeadBreak(continue_for_j, merge_for_j, false, {})
+                  .IsApplicable(context.get(), transformation_context));
+  ASSERT_TRUE(TransformationAddDeadBreak(continue_for_i, merge_for_i, true, {})
+                  .IsApplicable(context.get(), transformation_context));
 
   // Not OK to break out of multiple non-loop constructs if not breaking to a
   // loop merge
@@ -1468,11 +1468,117 @@ TEST(TransformationAddDeadBreakTest, NoBreakFromContinueConstruct) {
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  // Not OK to break loop from its continue construct
+  // Not OK to break loop from its continue construct, except from the back-edge
+  // block.
   ASSERT_FALSE(TransformationAddDeadBreak(13, 12, true, {})
                    .IsApplicable(context.get(), transformation_context));
-  ASSERT_FALSE(TransformationAddDeadBreak(23, 12, true, {})
-                   .IsApplicable(context.get(), transformation_context));
+  ASSERT_TRUE(TransformationAddDeadBreak(23, 12, true, {})
+                  .IsApplicable(context.get(), transformation_context));
+}
+
+TEST(TransformationAddDeadBreakTest, BreakFromBackEdgeBlock) {
+  std::string reference_shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %10 "main"
+
+; Types
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %4 = OpTypeInt 32 0
+          %5 = OpTypeBool
+          %6 = OpTypePointer Function %4
+
+; Constants
+          %7 = OpConstant %4 0
+          %8 = OpConstant %4 1
+          %9 = OpConstantTrue %5
+
+; main function
+         %10 = OpFunction %2 None %3
+         %11 = OpLabel
+         %12 = OpVariable %6 Function
+               OpStore %12 %7
+               OpBranch %13
+         %13 = OpLabel
+               OpLoopMerge %21 %18 None ; structured loop
+               OpBranch %14
+         %14 = OpLabel
+         %15 = OpLoad %4 %12
+         %16 = OpULessThan %5 %15 %8 ; i < 1 ?
+               OpBranchConditional %16 %17 %21 ; body or break
+         %17 = OpLabel ; body
+               OpBranch %18
+         %18 = OpLabel ; continue target does not strictly dominates the back-edge block
+         %19 = OpLoad %4 %12
+         %20 = OpIAdd %4 %19 %8 ; ++i
+               OpStore %12 %20
+               OpBranch %13
+         %21 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_5;
+  const auto consumer = nullptr;
+  const auto context =
+      BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  auto transformation = TransformationAddDeadBreak(18, 21, true, {});
+  transformation.Apply(context.get(), &transformation_context);
+
+  std::string variant_shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %10 "main"
+
+; Types
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %4 = OpTypeInt 32 0
+          %5 = OpTypeBool
+          %6 = OpTypePointer Function %4
+
+; Constants
+          %7 = OpConstant %4 0
+          %8 = OpConstant %4 1
+          %9 = OpConstantTrue %5
+
+; main function
+         %10 = OpFunction %2 None %3
+         %11 = OpLabel
+         %12 = OpVariable %6 Function
+               OpStore %12 %7
+               OpBranch %13
+         %13 = OpLabel
+               OpLoopMerge %21 %18 None ; structured loop
+               OpBranch %14
+         %14 = OpLabel
+         %15 = OpLoad %4 %12
+         %16 = OpULessThan %5 %15 %8 ; i < 1 ?
+               OpBranchConditional %16 %17 %21 ; body or break
+         %17 = OpLabel ; body
+               OpBranch %18
+         %18 = OpLabel ; continue target does not strictly dominates the back-edge block
+         %19 = OpLoad %4 %12
+         %20 = OpIAdd %4 %19 %8 ; ++i
+               OpStore %12 %20
+               OpBranchConditional %9 %13 %21
+         %21 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  ASSERT_TRUE(IsValid(env, context.get()));
+  ASSERT_TRUE(IsEqual(env, variant_shader, context.get()));
 }
 
 TEST(TransformationAddDeadBreakTest, SelectionInContinueConstruct) {

--- a/test/fuzz/transformation_add_relaxed_decoration_test.cpp
+++ b/test/fuzz/transformation_add_relaxed_decoration_test.cpp
@@ -11,3 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include "source/fuzz/transformation_add_relaxed_decoration.h"
+#include "test/fuzz/fuzz_test_util.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace {}
+}  // namespace fuzz
+}  // namespace spvtools

--- a/test/fuzz/transformation_add_relaxed_decoration_test.cpp
+++ b/test/fuzz/transformation_add_relaxed_decoration_test.cpp
@@ -13,10 +13,149 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_add_relaxed_decoration.h"
+#include "source/fuzz/instruction_descriptor.h"
+#include "source/fuzz/transformation_add_dead_block.h"
+#include "source/fuzz/transformation_equation_instruction.h"
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
 namespace fuzz {
-namespace {}
+namespace {
+TEST(TransformationAddRelaxedDecorationTest, BasicScenarios) {
+  // This is a simple transformation and this test handles the main cases.
+
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %8 "a"
+               OpName %10 "b"
+               OpName %14 "c"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Function %6
+          %9 = OpConstant %6 4
+         %11 = OpConstant %6 6
+         %12 = OpTypeBool
+         %13 = OpTypePointer Function %12
+         %15 = OpConstantTrue %12
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+          %8 = OpVariable %7 Function
+         %10 = OpVariable %7 Function
+         %14 = OpVariable %13 Function
+               OpStore %8 %9
+               OpStore %10 %11
+               OpStore %14 %15
+               OpBranch %19
+         %19 = OpLabel
+         %27 = OpISub %6 %9 %11
+               OpReturn
+               OpFunctionEnd
+    )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  TransformationAddDeadBlock transformation1(100, 5, true);
+  ASSERT_TRUE(
+      transformation1.IsApplicable(context.get(), transformation_context));
+  transformation1.Apply(context.get(), &transformation_context);
+
+  protobufs::InstructionDescriptor return_instruction =
+      MakeInstructionDescriptor(100, SpvOpBranch, 0);
+
+  // SpvOpISub is numeric and is in the dead block, so transformation should be
+  // applicable.
+  auto transformation2 = TransformationEquationInstruction(
+      25, SpvOpISub, {9, 11}, return_instruction);
+  ASSERT_TRUE(
+      transformation2.IsApplicable(context.get(), transformation_context));
+  transformation2.Apply(context.get(), &transformation_context);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  auto transformation3 = TransformationEquationInstruction(
+      28, SpvOpLogicalNot, {15}, return_instruction);
+  ASSERT_TRUE(
+      transformation3.IsApplicable(context.get(), transformation_context));
+  transformation3.Apply(context.get(), &transformation_context);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  // Invalid: 200 is not an id.
+  ASSERT_FALSE(TransformationAddRelaxedDecoration(200).IsApplicable(
+      context.get(), transformation_context));
+  // Invalid: 27 is not in a dead block.
+  ASSERT_FALSE(TransformationAddRelaxedDecoration(27).IsApplicable(
+      context.get(), transformation_context));
+  // Invalid: 28 is in a dead block, but returns bool (not numeric).
+  ASSERT_FALSE(TransformationAddRelaxedDecoration(28).IsApplicable(
+      context.get(), transformation_context));
+  // It is valid to add RelaxedPrecision to 25 (and it's fine to
+  // have a duplicate).
+  for (uint32_t result_id : {25u, 25u}) {
+    TransformationAddRelaxedDecoration transformation4(result_id);
+    ASSERT_TRUE(
+        transformation4.IsApplicable(context.get(), transformation_context));
+    transformation4.Apply(context.get(), &transformation_context);
+    ASSERT_TRUE(IsValid(env, context.get()));
+  }
+
+  std::string after_transformation = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %8 "a"
+               OpName %10 "b"
+               OpName %14 "c"
+               OpDecorate %25 RelaxedPrecision
+               OpDecorate %25 RelaxedPrecision
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Function %6
+          %9 = OpConstant %6 4
+         %11 = OpConstant %6 6
+         %12 = OpTypeBool
+         %13 = OpTypePointer Function %12
+         %15 = OpConstantTrue %12
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+          %8 = OpVariable %7 Function
+         %10 = OpVariable %7 Function
+         %14 = OpVariable %13 Function
+               OpStore %8 %9
+               OpStore %10 %11
+               OpStore %14 %15
+               OpSelectionMerge %19 None
+               OpBranchConditional %15 %19 %100
+        %100 = OpLabel
+         %25 = OpISub %6 %9 %11
+         %28 = OpLogicalNot %12 %15
+               OpBranch %19
+         %19 = OpLabel
+         %27 = OpISub %6 %9 %11
+               OpReturn
+               OpFunctionEnd
+  )";
+  ASSERT_TRUE(IsEqual(env, after_transformation, context.get()));
+}
+
+}  // namespace
 }  // namespace fuzz
 }  // namespace spvtools

--- a/test/fuzz/transformation_add_relaxed_decoration_test.cpp
+++ b/test/fuzz/transformation_add_relaxed_decoration_test.cpp
@@ -1,0 +1,13 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/test/fuzz/transformation_push_id_through_variable_test.cpp
+++ b/test/fuzz/transformation_push_id_through_variable_test.cpp
@@ -291,6 +291,7 @@ TEST(TransformationPushIdThroughVariableTest, Apply) {
           %5 = OpLabel
          %20 = OpVariable %9 Function
          %27 = OpVariable %9 Function
+               OpStore %53 %21
          %22 = OpAccessChain %15 %20 %14
          %44 = OpCopyObject %9 %20
          %26 = OpAccessChain %25 %20 %23
@@ -386,11 +387,22 @@ TEST(TransformationPushIdThroughVariableTest, Apply) {
       initializer_id, instruction_descriptor);
   transformation.Apply(context.get(), &transformation_context);
 
+  value_id = 23;
+  value_synonym_id = 110;
+  variable_id = 111;
+  initializer_id = 21;
+  variable_storage_class = SpvStorageClassPrivate;
+  instruction_descriptor = MakeInstructionDescriptor(27, SpvOpStore, 0);
+  transformation = TransformationPushIdThroughVariable(
+      value_id, value_synonym_id, variable_id, variable_storage_class,
+      initializer_id, instruction_descriptor);
+  transformation.Apply(context.get(), &transformation_context);
+
   std::string variant_shader = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
-               OpEntryPoint Fragment %4 "main" %92 %52 %53 %109
+               OpEntryPoint Fragment %4 "main" %92 %52 %53 %109 %111
                OpExecutionMode %4 OriginUpperLeft
                OpSource ESSL 310
                OpDecorate %92 BuiltIn FragCoord
@@ -421,12 +433,16 @@ TEST(TransformationPushIdThroughVariableTest, Apply) {
          %92 = OpVariable %91 Input
          %93 = OpConstantComposite %90 %24 %24 %24 %24
         %109 = OpVariable %51 Private %21
+        %111 = OpVariable %51 Private %21
           %4 = OpFunction %2 None %3
           %5 = OpLabel
         %103 = OpVariable %15 Function %21
         %101 = OpVariable %9 Function %80
          %20 = OpVariable %9 Function
          %27 = OpVariable %9 Function
+               OpStore %111 %23
+        %110 = OpLoad %6 %111
+               OpStore %53 %21
          %22 = OpAccessChain %15 %20 %14
          %44 = OpCopyObject %9 %20
          %26 = OpAccessChain %25 %20 %23

--- a/test/fuzz/transformation_replace_linear_algebra_instruction_test.cpp
+++ b/test/fuzz/transformation_replace_linear_algebra_instruction_test.cpp
@@ -1192,6 +1192,549 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest,
   ASSERT_TRUE(IsEqual(env, variant_shader, context.get()));
 }
 
+TEST(TransformationReplaceLinearAlgebraInstructionTest,
+     ReplaceOpMatrixTimesMatrix) {
+  std::string reference_shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %54 "main"
+               OpExecutionMode %54 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %54 "main"
+
+; Types
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %4 = OpTypeFloat 32
+          %5 = OpTypeVector %4 2
+          %6 = OpTypeVector %4 3
+          %7 = OpTypeVector %4 4
+          %8 = OpTypeMatrix %5 2
+          %9 = OpTypeMatrix %5 3
+         %10 = OpTypeMatrix %5 4
+         %11 = OpTypeMatrix %6 2
+         %12 = OpTypeMatrix %6 3
+         %13 = OpTypeMatrix %6 4
+         %14 = OpTypeMatrix %7 2
+         %15 = OpTypeMatrix %7 3
+         %16 = OpTypeMatrix %7 4
+
+; Constant scalars
+         %17 = OpConstant %4 1
+         %18 = OpConstant %4 2
+         %19 = OpConstant %4 3
+         %20 = OpConstant %4 4
+         %21 = OpConstant %4 5
+         %22 = OpConstant %4 6
+         %23 = OpConstant %4 7
+         %24 = OpConstant %4 8
+         %25 = OpConstant %4 9
+         %26 = OpConstant %4 10
+         %27 = OpConstant %4 11
+         %28 = OpConstant %4 12
+         %29 = OpConstant %4 13
+         %30 = OpConstant %4 14
+         %31 = OpConstant %4 15
+         %32 = OpConstant %4 16
+
+; Constant vectors
+         %33 = OpConstantComposite %5 %17 %18
+         %34 = OpConstantComposite %5 %19 %20
+         %35 = OpConstantComposite %5 %21 %22
+         %36 = OpConstantComposite %5 %23 %24
+         %37 = OpConstantComposite %6 %17 %18 %19
+         %38 = OpConstantComposite %6 %20 %21 %22
+         %39 = OpConstantComposite %6 %23 %24 %25
+         %40 = OpConstantComposite %6 %26 %27 %28
+         %41 = OpConstantComposite %7 %17 %18 %19 %20
+         %42 = OpConstantComposite %7 %21 %22 %23 %24
+         %43 = OpConstantComposite %7 %25 %26 %27 %28
+         %44 = OpConstantComposite %7 %29 %30 %31 %32
+
+; Constant matrices
+         %45 = OpConstantComposite %8 %33 %34
+         %46 = OpConstantComposite %9 %33 %34 %35
+         %47 = OpConstantComposite %10 %33 %34 %35 %36
+         %48 = OpConstantComposite %11 %37 %38
+         %49 = OpConstantComposite %12 %37 %38 %39
+         %50 = OpConstantComposite %13 %37 %38 %39 %40
+         %51 = OpConstantComposite %14 %41 %42
+         %52 = OpConstantComposite %15 %41 %42 %43
+         %53 = OpConstantComposite %16 %41 %42 %43 %44
+
+; main function
+         %54 = OpFunction %2 None %3
+         %55 = OpLabel
+
+; Multiplying 2x2 matrix by 2x2 matrix
+         %56 = OpMatrixTimesMatrix %8 %45 %45
+
+; Multiplying 2x2 matrix by 2x3 matrix
+         %57 = OpMatrixTimesMatrix %9 %45 %46
+
+; Multiplying 2x2 matrix by 2x4 matrix
+         %58 = OpMatrixTimesMatrix %10 %45 %47
+
+; Multiplying 2x3 matrix by 3x2 matrix
+         %59 = OpMatrixTimesMatrix %8 %46 %48
+
+; Multiplying 2x3 matrix by 3x3 matrix
+         %60 = OpMatrixTimesMatrix %9 %46 %49
+
+; Multiplying 2x3 matrix by 3x4 matrix
+         %61 = OpMatrixTimesMatrix %10 %46 %50
+
+; Multiplying 2x4 matrix by 4x2 matrix
+         %62 = OpMatrixTimesMatrix %8 %47 %51
+
+; Multiplying 2x4 matrix by 4x3 matrix
+         %63 = OpMatrixTimesMatrix %9 %47 %52
+
+; Multiplying 2x4 matrix by 4x4 matrix
+         %64 = OpMatrixTimesMatrix %10 %47 %53
+
+; Multiplying 3x2 matrix by 2x2 matrix
+         %65 = OpMatrixTimesMatrix %11 %48 %45
+
+; Multiplying 3x2 matrix by 2x3 matrix
+         %66 = OpMatrixTimesMatrix %12 %48 %46
+
+; Multiplying 3x2 matrix by 2x4 matrix
+         %67 = OpMatrixTimesMatrix %13 %48 %47
+
+; Multiplying 3x3 matrix by 3x2 matrix
+         %68 = OpMatrixTimesMatrix %11 %49 %48
+
+; Multiplying 3x3 matrix by 3x3 matrix
+         %69 = OpMatrixTimesMatrix %12 %49 %49
+
+; Multiplying 3x3 matrix by 3x4 matrix
+         %70 = OpMatrixTimesMatrix %13 %49 %50
+
+; Multiplying 3x4 matrix by 4x2 matrix
+         %71 = OpMatrixTimesMatrix %11 %50 %51
+
+; Multiplying 3x4 matrix by 4x3 matrix
+         %72 = OpMatrixTimesMatrix %12 %50 %52
+
+; Multiplying 3x4 matrix by 4x4 matrix
+         %73 = OpMatrixTimesMatrix %13 %50 %53
+
+; Multiplying 4x2 matrix by 2x2 matrix
+         %74 = OpMatrixTimesMatrix %14 %51 %45
+
+; Multiplying 4x2 matrix by 2x3 matrix
+         %75 = OpMatrixTimesMatrix %15 %51 %46
+
+; Multiplying 4x2 matrix by 2x4 matrix
+         %76 = OpMatrixTimesMatrix %16 %51 %47
+
+; Multiplying 4x3 matrix by 3x2 matrix
+         %77 = OpMatrixTimesMatrix %14 %52 %48
+
+; Multiplying 4x3 matrix by 3x3 matrix
+         %78 = OpMatrixTimesMatrix %15 %52 %49
+
+; Multiplying 4x3 matrix by 3x4 matrix
+         %79 = OpMatrixTimesMatrix %16 %52 %50
+
+; Multiplying 4x4 matrix by 4x2 matrix
+         %80 = OpMatrixTimesMatrix %14 %53 %51
+
+; Multiplying 4x4 matrix by 4x3 matrix
+         %81 = OpMatrixTimesMatrix %15 %53 %52
+
+; Multiplying 4x4 matrix by 4x4 matrix
+         %82 = OpMatrixTimesMatrix %16 %53 %53
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_5;
+  const auto consumer = nullptr;
+  const auto context =
+      BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  auto instruction_descriptor =
+      MakeInstructionDescriptor(56, SpvOpMatrixTimesMatrix, 0);
+  auto transformation = TransformationReplaceLinearAlgebraInstruction(
+      {83,  84,  85,  86,  87,  88,  89,  90,  91,  92,  93,  94,  95,  96,
+       97,  98,  99,  100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110,
+       111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122},
+      instruction_descriptor);
+  transformation.Apply(context.get(), &transformation_context);
+
+  instruction_descriptor =
+      MakeInstructionDescriptor(57, SpvOpMatrixTimesMatrix, 0);
+  transformation = TransformationReplaceLinearAlgebraInstruction(
+      {123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134,
+       135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146,
+       147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158,
+       159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170,
+       171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182},
+      instruction_descriptor);
+  transformation.Apply(context.get(), &transformation_context);
+
+  instruction_descriptor =
+      MakeInstructionDescriptor(58, SpvOpMatrixTimesMatrix, 0);
+  transformation = TransformationReplaceLinearAlgebraInstruction(
+      {183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196,
+       197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210,
+       211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224,
+       225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238,
+       239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252,
+       253, 254, 255, 256, 257, 258, 259, 260, 261, 262},
+      instruction_descriptor);
+  transformation.Apply(context.get(), &transformation_context);
+
+  std::string variant_shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %54 "main"
+               OpExecutionMode %54 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %54 "main"
+
+; Types
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %4 = OpTypeFloat 32
+          %5 = OpTypeVector %4 2
+          %6 = OpTypeVector %4 3
+          %7 = OpTypeVector %4 4
+          %8 = OpTypeMatrix %5 2
+          %9 = OpTypeMatrix %5 3
+         %10 = OpTypeMatrix %5 4
+         %11 = OpTypeMatrix %6 2
+         %12 = OpTypeMatrix %6 3
+         %13 = OpTypeMatrix %6 4
+         %14 = OpTypeMatrix %7 2
+         %15 = OpTypeMatrix %7 3
+         %16 = OpTypeMatrix %7 4
+
+; Constant scalars
+         %17 = OpConstant %4 1
+         %18 = OpConstant %4 2
+         %19 = OpConstant %4 3
+         %20 = OpConstant %4 4
+         %21 = OpConstant %4 5
+         %22 = OpConstant %4 6
+         %23 = OpConstant %4 7
+         %24 = OpConstant %4 8
+         %25 = OpConstant %4 9
+         %26 = OpConstant %4 10
+         %27 = OpConstant %4 11
+         %28 = OpConstant %4 12
+         %29 = OpConstant %4 13
+         %30 = OpConstant %4 14
+         %31 = OpConstant %4 15
+         %32 = OpConstant %4 16
+
+; Constant vectors
+         %33 = OpConstantComposite %5 %17 %18
+         %34 = OpConstantComposite %5 %19 %20
+         %35 = OpConstantComposite %5 %21 %22
+         %36 = OpConstantComposite %5 %23 %24
+         %37 = OpConstantComposite %6 %17 %18 %19
+         %38 = OpConstantComposite %6 %20 %21 %22
+         %39 = OpConstantComposite %6 %23 %24 %25
+         %40 = OpConstantComposite %6 %26 %27 %28
+         %41 = OpConstantComposite %7 %17 %18 %19 %20
+         %42 = OpConstantComposite %7 %21 %22 %23 %24
+         %43 = OpConstantComposite %7 %25 %26 %27 %28
+         %44 = OpConstantComposite %7 %29 %30 %31 %32
+
+; Constant matrices
+         %45 = OpConstantComposite %8 %33 %34
+         %46 = OpConstantComposite %9 %33 %34 %35
+         %47 = OpConstantComposite %10 %33 %34 %35 %36
+         %48 = OpConstantComposite %11 %37 %38
+         %49 = OpConstantComposite %12 %37 %38 %39
+         %50 = OpConstantComposite %13 %37 %38 %39 %40
+         %51 = OpConstantComposite %14 %41 %42
+         %52 = OpConstantComposite %15 %41 %42 %43
+         %53 = OpConstantComposite %16 %41 %42 %43 %44
+
+; main function
+         %54 = OpFunction %2 None %3
+         %55 = OpLabel
+
+; Multiplying 2x2 matrix by 2x2 matrix
+         %83 = OpCompositeExtract %5 %45 0 ; matrix 2 column 0
+         %84 = OpCompositeExtract %5 %45 0 ; matrix 1 column 0
+         %85 = OpCompositeExtract %4 %84 0 ; matrix 1 row 0 column 0
+         %86 = OpCompositeExtract %4 %83 0 ; matrix 2 row 0 column 0
+         %87 = OpFMul %4 %85 %86
+         %88 = OpCompositeExtract %5 %45 1 ; matrix 1 column 1
+         %89 = OpCompositeExtract %4 %88 0 ; matrix 1 row 0 column 1
+         %90 = OpCompositeExtract %4 %83 1 ; matrix 2 row 1 column 0
+         %91 = OpFMul %4 %89 %90
+         %92 = OpFAdd %4 %87 %91
+         %93 = OpCompositeExtract %5 %45 0 ; matrix 1 column 0
+         %94 = OpCompositeExtract %4 %93 1 ; matrix 1 row 1 column 0
+         %95 = OpCompositeExtract %4 %83 0 ; matrix 2 row 0 column 0
+         %96 = OpFMul %4 %94 %95
+         %97 = OpCompositeExtract %5 %45 1 ; matrix 1 column 1
+         %98 = OpCompositeExtract %4 %97 1 ; matrix 1 row 1 column 1
+         %99 = OpCompositeExtract %4 %83 1 ; matrix 2 row 1 column 0
+        %100 = OpFMul %4 %98 %99
+        %101 = OpFAdd %4 %96 %100
+        %102 = OpCompositeConstruct %5 %92 %101 ; resulting matrix column 0
+        %103 = OpCompositeExtract %5 %45 1 ; matrix 2 column 1
+        %104 = OpCompositeExtract %5 %45 0 ; matrix 1 column 0
+        %105 = OpCompositeExtract %4 %104 0 ; matrix 1 row 0 column 0
+        %106 = OpCompositeExtract %4 %103 0 ; matrix 2 row 0 column 1
+        %107 = OpFMul %4 %105 %106
+        %108 = OpCompositeExtract %5 %45 1 ; matrix 1 column 1
+        %109 = OpCompositeExtract %4 %108 0 ; matrix 1 row 0 column 1
+        %110 = OpCompositeExtract %4 %103 1 ; matrix 2 row 1 column 1
+        %111 = OpFMul %4 %109 %110
+        %112 = OpFAdd %4 %107 %111
+        %113 = OpCompositeExtract %5 %45 0 ; matrix 1 column 0
+        %114 = OpCompositeExtract %4 %113 1 ; matrix 1 row 1 column 0
+        %115 = OpCompositeExtract %4 %103 0 ; matrix 2 row 0 column 1
+        %116 = OpFMul %4 %114 %115
+        %117 = OpCompositeExtract %5 %45 1 ; matrix 1 column 1
+        %118 = OpCompositeExtract %4 %117 1 ; matrix 1 row 1 column 1
+        %119 = OpCompositeExtract %4 %103 1 ; matrix 2 row 1 column 1
+        %120 = OpFMul %4 %118 %119
+        %121 = OpFAdd %4 %116 %120
+        %122 = OpCompositeConstruct %5 %112 %121 ; resulting matrix column 1
+         %56 = OpCompositeConstruct %8 %102 %122 ; resulting matrix
+
+; Multiplying 2x2 matrix by 2x3 matrix
+        %123 = OpCompositeExtract %5 %46 0 ; matrix 2 column 0
+        %124 = OpCompositeExtract %5 %45 0 ; matrix 1 column 0
+        %125 = OpCompositeExtract %4 %124 0 ; matrix 1 row 0 column 0
+        %126 = OpCompositeExtract %4 %123 0 ; matrix 2 row 0 column 0
+        %127 = OpFMul %4 %125 %126
+        %128 = OpCompositeExtract %5 %45 1 ; matrix 1 column 1
+        %129 = OpCompositeExtract %4 %128 0 ; matrix 1 row 0 column 1
+        %130 = OpCompositeExtract %4 %123 1 ; matrix 2 row 1 column 0
+        %131 = OpFMul %4 %129 %130
+        %132 = OpFAdd %4 %127 %131
+        %133 = OpCompositeExtract %5 %45 0 ; matrix 1 column 0
+        %134 = OpCompositeExtract %4 %133 1 ; matrix 1 row 1 column 0
+        %135 = OpCompositeExtract %4 %123 0 ; matrix 2 row 0 column 0
+        %136 = OpFMul %4 %134 %135
+        %137 = OpCompositeExtract %5 %45 1 ; matrix 1 column 1
+        %138 = OpCompositeExtract %4 %137 1 ; matrix 1 row 1 column 1
+        %139 = OpCompositeExtract %4 %123 1 ; matrix 2 row 1 column 0
+        %140 = OpFMul %4 %138 %139
+        %141 = OpFAdd %4 %136 %140
+        %142 = OpCompositeConstruct %5 %132 %141 ; resulting matrix column 0
+        %143 = OpCompositeExtract %5 %46 1 ; matrix 2 column 1
+        %144 = OpCompositeExtract %5 %45 0 ; matrix 1 column 0
+        %145 = OpCompositeExtract %4 %144 0 ; matrix 1 row 0 column 0
+        %146 = OpCompositeExtract %4 %143 0 ; matrix 2 row 0 column 1
+        %147 = OpFMul %4 %145 %146
+        %148 = OpCompositeExtract %5 %45 1 ; matrix 1 column 1
+        %149 = OpCompositeExtract %4 %148 0 ; matrix 1 row 0 column 1
+        %150 = OpCompositeExtract %4 %143 1 ; matrix 2 row 1 column 1
+        %151 = OpFMul %4 %149 %150
+        %152 = OpFAdd %4 %147 %151
+        %153 = OpCompositeExtract %5 %45 0 ; matrix 1 column 0
+        %154 = OpCompositeExtract %4 %153 1 ; matrix 1 row 1 column 0
+        %155 = OpCompositeExtract %4 %143 0 ; matrix 2 row 0 column 1
+        %156 = OpFMul %4 %154 %155
+        %157 = OpCompositeExtract %5 %45 1 ; matrix 1 column 1
+        %158 = OpCompositeExtract %4 %157 1 ; matrix 1 row 1 column 1
+        %159 = OpCompositeExtract %4 %143 1 ; matrix 2 row 1 column 1
+        %160 = OpFMul %4 %158 %159
+        %161 = OpFAdd %4 %156 %160
+        %162 = OpCompositeConstruct %5 %152 %161 ; resulting matrix column 1
+        %163 = OpCompositeExtract %5 %46 2 ; matrix 2 column 2
+        %164 = OpCompositeExtract %5 %45 0 ; matrix 1 column 0
+        %165 = OpCompositeExtract %4 %164 0 ; matrix 1 row 0 column 0
+        %166 = OpCompositeExtract %4 %163 0 ; matrix 2 row 0 column 2
+        %167 = OpFMul %4 %165 %166
+        %168 = OpCompositeExtract %5 %45 1 ; matrix 1 column 1
+        %169 = OpCompositeExtract %4 %168 0 ; matrix 1 row 0 column 1
+        %170 = OpCompositeExtract %4 %163 1 ; matrix 2 row 1 column 2
+        %171 = OpFMul %4 %169 %170
+        %172 = OpFAdd %4 %167 %171
+        %173 = OpCompositeExtract %5 %45 0 ; matrix 1 column 0
+        %174 = OpCompositeExtract %4 %173 1 ; matrix 1 row 1 column 0
+        %175 = OpCompositeExtract %4 %163 0 ; matrix 2 row 0 column 2
+        %176 = OpFMul %4 %174 %175
+        %177 = OpCompositeExtract %5 %45 1 ; matrix 1 column 1
+        %178 = OpCompositeExtract %4 %177 1 ; matrix 1 row 1 column 1
+        %179 = OpCompositeExtract %4 %163 1 ; matrix 2 row 1 column 2
+        %180 = OpFMul %4 %178 %179
+        %181 = OpFAdd %4 %176 %180
+        %182 = OpCompositeConstruct %5 %172 %181 ; resulting matrix column 2
+         %57 = OpCompositeConstruct %9 %142 %162 %182
+
+; Multiplying 2x2 matrix by 2x4 matrix
+        %183 = OpCompositeExtract %5 %47 0 ; matrix 2 column 0
+        %184 = OpCompositeExtract %5 %45 0 ; matrix 1 column 0
+        %185 = OpCompositeExtract %4 %184 0 ; matrix 1 row 0 column 0
+        %186 = OpCompositeExtract %4 %183 0 ; matrix 2 row 0 column 0
+        %187 = OpFMul %4 %185 %186
+        %188 = OpCompositeExtract %5 %45 1 ; matrix 1 column 1
+        %189 = OpCompositeExtract %4 %188 0 ; matrix 1 row 0 column 1
+        %190 = OpCompositeExtract %4 %183 1 ; matrix 2 row 1 column 0
+        %191 = OpFMul %4 %189 %190
+        %192 = OpFAdd %4 %187 %191
+        %193 = OpCompositeExtract %5 %45 0 ; matrix 1 column 0
+        %194 = OpCompositeExtract %4 %193 1 ; matrix 1 row 1 column 0
+        %195 = OpCompositeExtract %4 %183 0 ; matrix 2 row 0 column 0
+        %196 = OpFMul %4 %194 %195
+        %197 = OpCompositeExtract %5 %45 1 ; matrix 1 column 1
+        %198 = OpCompositeExtract %4 %197 1 ; matrix 1 row 1 column 1
+        %199 = OpCompositeExtract %4 %183 1 ; matrix 2 row 1 column 0
+        %200 = OpFMul %4 %198 %199
+        %201 = OpFAdd %4 %196 %200
+        %202 = OpCompositeConstruct %5 %192 %201 ; resulting matrix column 0
+        %203 = OpCompositeExtract %5 %47 1 ; matrix 2 column 1
+        %204 = OpCompositeExtract %5 %45 0 ; matrix 1 column 0
+        %205 = OpCompositeExtract %4 %204 0 ; matrix 1 row 0 column 0
+        %206 = OpCompositeExtract %4 %203 0 ; matrix 2 row 0 column 1
+        %207 = OpFMul %4 %205 %206
+        %208 = OpCompositeExtract %5 %45 1 ; matrix 1 column 1
+        %209 = OpCompositeExtract %4 %208 0 ; matrix 1 row 0 column 1
+        %210 = OpCompositeExtract %4 %203 1 ; matrix 2 row 1 column 1
+        %211 = OpFMul %4 %209 %210
+        %212 = OpFAdd %4 %207 %211
+        %213 = OpCompositeExtract %5 %45 0 ; matrix 1 column 0
+        %214 = OpCompositeExtract %4 %213 1 ; matrix 1 row 1 column 0
+        %215 = OpCompositeExtract %4 %203 0 ; matrix 2 row 0 column 1
+        %216 = OpFMul %4 %214 %215
+        %217 = OpCompositeExtract %5 %45 1 ; matrix 1 column 1
+        %218 = OpCompositeExtract %4 %217 1 ; matrix 1 row 1 column 1
+        %219 = OpCompositeExtract %4 %203 1 ; matrix 2 row 1 column 1
+        %220 = OpFMul %4 %218 %219
+        %221 = OpFAdd %4 %216 %220
+        %222 = OpCompositeConstruct %5 %212 %221 ; resulting matrix column 1
+        %223 = OpCompositeExtract %5 %47 2 ; matrix 2 column 2
+        %224 = OpCompositeExtract %5 %45 0 ; matrix 1 column 0
+        %225 = OpCompositeExtract %4 %224 0 ; matrix 1 row 0 column 0
+        %226 = OpCompositeExtract %4 %223 0 ; matrix 2 row 0 column 2
+        %227 = OpFMul %4 %225 %226
+        %228 = OpCompositeExtract %5 %45 1 ; matrix 1 column 1
+        %229 = OpCompositeExtract %4 %228 0 ; matrix 1 row 0 column 1
+        %230 = OpCompositeExtract %4 %223 1 ; matrix 2 row 1 column 2
+        %231 = OpFMul %4 %229 %230
+        %232 = OpFAdd %4 %227 %231
+        %233 = OpCompositeExtract %5 %45 0 ; matrix 1 column 0
+        %234 = OpCompositeExtract %4 %233 1 ; matrix 1 row 1 column 0
+        %235 = OpCompositeExtract %4 %223 0 ; matrix 2 row 0 column 2
+        %236 = OpFMul %4 %234 %235
+        %237 = OpCompositeExtract %5 %45 1 ; matrix 1 column 1
+        %238 = OpCompositeExtract %4 %237 1 ; matrix 1 row 1 column 1
+        %239 = OpCompositeExtract %4 %223 1 ; matrix 2 row 1 column 2
+        %240 = OpFMul %4 %238 %239
+        %241 = OpFAdd %4 %236 %240
+        %242 = OpCompositeConstruct %5 %232 %241 ; resulting matrix column 2
+        %243 = OpCompositeExtract %5 %47 3 ; matrix 2 column 3
+        %244 = OpCompositeExtract %5 %45 0 ; matrix 1 column 0
+        %245 = OpCompositeExtract %4 %244 0 ; matrix 1 row 0 column 0
+        %246 = OpCompositeExtract %4 %243 0 ; matrix 2 row 0 column 3
+        %247 = OpFMul %4 %245 %246
+        %248 = OpCompositeExtract %5 %45 1 ; matrix 1 column 1
+        %249 = OpCompositeExtract %4 %248 0 ; matrix 1 row 0 column 1
+        %250 = OpCompositeExtract %4 %243 1 ; matrix 2 row 1 column 3
+        %251 = OpFMul %4 %249 %250
+        %252 = OpFAdd %4 %247 %251
+        %253 = OpCompositeExtract %5 %45 0 ; matrix 1 column 0
+        %254 = OpCompositeExtract %4 %253 1 ; matrix 1 row 1 column 0
+        %255 = OpCompositeExtract %4 %243 0 ; matrix 2 row 0 column 3
+        %256 = OpFMul %4 %254 %255
+        %257 = OpCompositeExtract %5 %45 1 ; matrix 1 column 1
+        %258 = OpCompositeExtract %4 %257 1 ; matrix 1 row 1 column 1
+        %259 = OpCompositeExtract %4 %243 1 ; matrix 2 row 1 column 3
+        %260 = OpFMul %4 %258 %259
+        %261 = OpFAdd %4 %256 %260
+        %262 = OpCompositeConstruct %5 %252 %261 ; resulting matrix column 3
+         %58 = OpCompositeConstruct %10 %202 %222 %242 %262
+
+; Multiplying 2x3 matrix by 3x2 matrix
+         %59 = OpMatrixTimesMatrix %8 %46 %48
+
+; Multiplying 2x3 matrix by 3x3 matrix
+         %60 = OpMatrixTimesMatrix %9 %46 %49
+
+; Multiplying 2x3 matrix by 3x4 matrix
+         %61 = OpMatrixTimesMatrix %10 %46 %50
+
+; Multiplying 2x4 matrix by 4x2 matrix
+         %62 = OpMatrixTimesMatrix %8 %47 %51
+
+; Multiplying 2x4 matrix by 4x3 matrix
+         %63 = OpMatrixTimesMatrix %9 %47 %52
+
+; Multiplying 2x4 matrix by 4x4 matrix
+         %64 = OpMatrixTimesMatrix %10 %47 %53
+
+; Multiplying 3x2 matrix by 2x2 matrix
+         %65 = OpMatrixTimesMatrix %11 %48 %45
+
+; Multiplying 3x2 matrix by 2x3 matrix
+         %66 = OpMatrixTimesMatrix %12 %48 %46
+
+; Multiplying 3x2 matrix by 2x4 matrix
+         %67 = OpMatrixTimesMatrix %13 %48 %47
+
+; Multiplying 3x3 matrix by 3x2 matrix
+         %68 = OpMatrixTimesMatrix %11 %49 %48
+
+; Multiplying 3x3 matrix by 3x3 matrix
+         %69 = OpMatrixTimesMatrix %12 %49 %49
+
+; Multiplying 3x3 matrix by 3x4 matrix
+         %70 = OpMatrixTimesMatrix %13 %49 %50
+
+; Multiplying 3x4 matrix by 4x2 matrix
+         %71 = OpMatrixTimesMatrix %11 %50 %51
+
+; Multiplying 3x4 matrix by 4x3 matrix
+         %72 = OpMatrixTimesMatrix %12 %50 %52
+
+; Multiplying 3x4 matrix by 4x4 matrix
+         %73 = OpMatrixTimesMatrix %13 %50 %53
+
+; Multiplying 4x2 matrix by 2x2 matrix
+         %74 = OpMatrixTimesMatrix %14 %51 %45
+
+; Multiplying 4x2 matrix by 2x3 matrix
+         %75 = OpMatrixTimesMatrix %15 %51 %46
+
+; Multiplying 4x2 matrix by 2x4 matrix
+         %76 = OpMatrixTimesMatrix %16 %51 %47
+
+; Multiplying 4x3 matrix by 3x2 matrix
+         %77 = OpMatrixTimesMatrix %14 %52 %48
+
+; Multiplying 4x3 matrix by 3x3 matrix
+         %78 = OpMatrixTimesMatrix %15 %52 %49
+
+; Multiplying 4x3 matrix by 3x4 matrix
+         %79 = OpMatrixTimesMatrix %16 %52 %50
+
+; Multiplying 4x4 matrix by 4x2 matrix
+         %80 = OpMatrixTimesMatrix %14 %53 %51
+
+; Multiplying 4x4 matrix by 4x3 matrix
+         %81 = OpMatrixTimesMatrix %15 %53 %52
+
+; Multiplying 4x4 matrix by 4x4 matrix
+         %82 = OpMatrixTimesMatrix %16 %53 %53
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  ASSERT_TRUE(IsValid(env, context.get()));
+  ASSERT_TRUE(IsEqual(env, variant_shader, context.get()));
+}
+
 TEST(TransformationReplaceLinearAlgebraInstructionTest, ReplaceOpDot) {
   std::string reference_shader = R"(
                OpCapability Shader

--- a/test/opt/debug_info_manager_test.cpp
+++ b/test/opt/debug_info_manager_test.cpp
@@ -431,6 +431,74 @@ void main(float in_var_color : COLOR) {
   EXPECT_EQ(inst, before_100);
 }
 
+TEST(DebugInfoManager, KillDebugDeclares) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "OpenCL.DebugInfo.100"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %in_var_COLOR
+               OpExecutionMode %main OriginUpperLeft
+          %5 = OpString "ps.hlsl"
+         %14 = OpString "#line 1 \"ps.hlsl\"
+void main(float in_var_color : COLOR) {
+  float color = in_var_color;
+}
+"
+         %17 = OpString "float"
+         %21 = OpString "main"
+         %24 = OpString "color"
+               OpName %in_var_COLOR "in.var.COLOR"
+               OpName %main "main"
+               OpDecorate %in_var_COLOR Location 0
+       %uint = OpTypeInt 32 0
+    %uint_32 = OpConstant %uint 32
+      %float = OpTypeFloat 32
+%_ptr_Input_float = OpTypePointer Input %float
+       %void = OpTypeVoid
+         %27 = OpTypeFunction %void
+%_ptr_Function_float = OpTypePointer Function %float
+%in_var_COLOR = OpVariable %_ptr_Input_float Input
+         %13 = OpExtInst %void %1 DebugExpression
+         %15 = OpExtInst %void %1 DebugSource %5 %14
+         %16 = OpExtInst %void %1 DebugCompilationUnit 1 4 %15 HLSL
+         %18 = OpExtInst %void %1 DebugTypeBasic %17 %uint_32 Float
+         %20 = OpExtInst %void %1 DebugTypeFunction FlagIsProtected|FlagIsPrivate %18 %18
+         %22 = OpExtInst %void %1 DebugFunction %21 %20 %15 1 1 %16 %21 FlagIsProtected|FlagIsPrivate 1 %main
+         %12 = OpExtInst %void %1 DebugInfoNone
+         %25 = OpExtInst %void %1 DebugLocalVariable %24 %18 %15 1 20 %22 FlagIsLocal 0
+       %main = OpFunction %void None %27
+         %28 = OpLabel
+        %100 = OpVariable %_ptr_Function_float Function
+         %31 = OpLoad %float %in_var_COLOR
+               OpStore %100 %31
+         %36 = OpExtInst %void %1 DebugDeclare %25 %100 %13
+         %37 = OpExtInst %void %1 DebugDeclare %25 %100 %13
+         %38 = OpExtInst %void %1 DebugDeclare %25 %100 %13
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  std::unique_ptr<IRContext> context =
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  auto* dbg_info_mgr = context->get_debug_info_mgr();
+  auto* def_use_mgr = context->get_def_use_mgr();
+
+  EXPECT_TRUE(dbg_info_mgr->IsDebugDeclared(100));
+  EXPECT_EQ(def_use_mgr->GetDef(36)->GetOpenCL100DebugOpcode(),
+            OpenCLDebugInfo100DebugDeclare);
+  EXPECT_EQ(def_use_mgr->GetDef(37)->GetOpenCL100DebugOpcode(),
+            OpenCLDebugInfo100DebugDeclare);
+  EXPECT_EQ(def_use_mgr->GetDef(38)->GetOpenCL100DebugOpcode(),
+            OpenCLDebugInfo100DebugDeclare);
+
+  dbg_info_mgr->KillDebugDeclares(100);
+  EXPECT_EQ(def_use_mgr->GetDef(36), nullptr);
+  EXPECT_EQ(def_use_mgr->GetDef(37), nullptr);
+  EXPECT_EQ(def_use_mgr->GetDef(38), nullptr);
+  EXPECT_FALSE(dbg_info_mgr->IsDebugDeclared(100));
+}
+
 }  // namespace
 }  // namespace analysis
 }  // namespace opt


### PR DESCRIPTION
Added this transformation for now without related fuzzer pass. This transformation is very closesly related to TransformationAddNoContractionDecoration, so I reused some of its code. Operations which are applicable are taken from SPIR-V documentation. These are all operations that return 32-bit integers or floats.