### PR TITLE
Assert false in IsApplicable method of TransformationAccessChain

### DIFF
--- a/source/fuzz/transformation_access_chain.cpp
+++ b/source/fuzz/transformation_access_chain.cpp
@@ -74,10 +74,7 @@ bool TransformationAccessChain::IsApplicable(
   switch (pointer->opcode()) {
     case SpvOpConstantNull:
     case SpvOpUndef:
-      // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3185): When
-      //  fuzzing for real we would like an 'assert(false)' here.  But we also
-      //  want to be able to write negative unit tests.
-      return false;
+      assert(false && "Null or undefined pointer");
     default:
       break;
   }

--- a/source/fuzz/transformation_access_chain.cpp
+++ b/source/fuzz/transformation_access_chain.cpp
@@ -74,7 +74,10 @@ bool TransformationAccessChain::IsApplicable(
   switch (pointer->opcode()) {
     case SpvOpConstantNull:
     case SpvOpUndef:
-      assert(false && "Null or undefined pointer");
+      assert(
+          false &&
+          "Access chains should not be created from null/undefined pointers");
+      return false;
     default:
       break;
   }

--- a/test/fuzz/transformation_access_chain_test.cpp
+++ b/test/fuzz/transformation_access_chain_test.cpp
@@ -184,14 +184,16 @@ TEST(TransformationAccessChainTest, BasicTest) {
                    .IsApplicable(context.get(), transformation_context));
 
   // Bad: pointer is null
-  ASSERT_FALSE(TransformationAccessChain(
+  ASSERT_DEATH(TransformationAccessChain(
                    100, 45, {80}, MakeInstructionDescriptor(24, SpvOpLoad, 0))
-                   .IsApplicable(context.get(), transformation_context));
+                   .IsApplicable(context.get(), transformation_context),
+               "Null or undefined pointer");
 
   // Bad: pointer is undef
-  ASSERT_FALSE(TransformationAccessChain(
+  ASSERT_DEATH(TransformationAccessChain(
                    100, 46, {80}, MakeInstructionDescriptor(24, SpvOpLoad, 0))
-                   .IsApplicable(context.get(), transformation_context));
+                   .IsApplicable(context.get(), transformation_context),
+               "Null or undefined pointer");
 
   // Bad: pointer to result type does not exist
   ASSERT_FALSE(TransformationAccessChain(

--- a/test/fuzz/transformation_access_chain_test.cpp
+++ b/test/fuzz/transformation_access_chain_test.cpp
@@ -183,17 +183,23 @@ TEST(TransformationAccessChainTest, BasicTest) {
                    100, 43, {80}, MakeInstructionDescriptor(24, SpvOpLoad, 100))
                    .IsApplicable(context.get(), transformation_context));
 
+#ifndef NDEBUG
   // Bad: pointer is null
-  ASSERT_DEATH(TransformationAccessChain(
-                   100, 45, {80}, MakeInstructionDescriptor(24, SpvOpLoad, 0))
-                   .IsApplicable(context.get(), transformation_context),
-               "Null or undefined pointer");
+  ASSERT_DEATH(
+      TransformationAccessChain(100, 45, {80},
+                                MakeInstructionDescriptor(24, SpvOpLoad, 0))
+          .IsApplicable(context.get(), transformation_context),
+      "Access chains should not be created from null/undefined pointers");
+#endif
 
+#ifndef NDEBUG
   // Bad: pointer is undef
-  ASSERT_DEATH(TransformationAccessChain(
-                   100, 46, {80}, MakeInstructionDescriptor(24, SpvOpLoad, 0))
-                   .IsApplicable(context.get(), transformation_context),
-               "Null or undefined pointer");
+  ASSERT_DEATH(
+      TransformationAccessChain(100, 46, {80},
+                                MakeInstructionDescriptor(24, SpvOpLoad, 0))
+          .IsApplicable(context.get(), transformation_context),
+      "Access chains should not be created from null/undefined pointers");
+#endif
 
   // Bad: pointer to result type does not exist
   ASSERT_FALSE(TransformationAccessChain(


### PR DESCRIPTION
… if it is invalid (with null or undefined pointer).

In this case, assert false instead of returning false so that the fuzzer fails.

(See issue #3185 )