### PR TITLE
Remove single iteration loop

### DIFF
--- a/source/opt/debug_info_manager.cpp
+++ b/source/opt/debug_info_manager.cpp
@@ -380,9 +380,8 @@ void DebugInfoManager::KillDebugDeclares(uint32_t variable_id) {
     Instruction* kill_inst = nullptr;
     auto dbg_decl_itr = var_id_to_dbg_decl_.find(variable_id);
     if (dbg_decl_itr != var_id_to_dbg_decl_.end()) {
-      for (auto dbg_decl : dbg_decl_itr->second) {
-        kill_inst = dbg_decl;
-        break;
+      if (!dbg_decl_itr->second.empty()) {
+        kill_inst = *dbg_decl_itr->second.begin();
       }
     }
     if (kill_inst)


### PR DESCRIPTION
This loop is intentionally designed to only ever execute, which is non-obvious
on first glance. Changing the code to be clearer that the entire data structure
isn't being iterated.

This will also fix importing SPIRV-Tools into Chromium, since their style
checkers are failing the build due to this iterate once construct.