### PR TITLE
spirv-fuzz: Add replay range option

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -676,6 +676,12 @@ SPIRV_TOOLS_EXPORT void spvFuzzerOptionsEnableReplayValidation(
 SPIRV_TOOLS_EXPORT void spvFuzzerOptionsSetRandomSeed(
     spv_fuzzer_options options, uint32_t seed);
 
+// Sets the range of transformations that should be applied during replay: 0
+// means all transformations, +N means the first N transformations, -N means all
+// except the final N transformations.
+SPIRV_TOOLS_EXPORT void spvFuzzerOptionsSetReplayRange(
+    spv_fuzzer_options options, int32_t replay_range);
+
 // Sets the maximum number of steps that the shrinker should take before giving
 // up.
 SPIRV_TOOLS_EXPORT void spvFuzzerOptionsSetShrinkerStepLimit(

--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -227,6 +227,11 @@ class FuzzerOptions {
     spvFuzzerOptionsSetRandomSeed(options_, seed);
   }
 
+  // See spvFuzzerOptionsSetReplayRange.
+  void set_replay_range(int32_t replay_range) {
+    spvFuzzerOptionsSetReplayRange(options_, replay_range);
+  }
+
   // See spvFuzzerOptionsSetShrinkerStepLimit.
   void set_shrinker_step_limit(uint32_t shrinker_step_limit) {
     spvFuzzerOptionsSetShrinkerStepLimit(options_, shrinker_step_limit);

--- a/source/fuzz/protobufs/spirvfuzz_protobufs.h
+++ b/source/fuzz/protobufs/spirvfuzz_protobufs.h
@@ -39,6 +39,7 @@
 // where warnings are ignored.
 
 #include "google/protobuf/util/json_util.h"
+#include "google/protobuf/util/message_differencer.h"
 #include "source/fuzz/protobufs/spvtoolsfuzz.pb.h"
 
 #if defined(__clang__)

--- a/source/fuzz/replayer.h
+++ b/source/fuzz/replayer.h
@@ -34,6 +34,7 @@ class Replayer {
     kFailedToCreateSpirvToolsInterface,
     kInitialBinaryInvalid,
     kReplayValidationFailure,
+    kTooManyTransformationsRequested,
   };
 
   // Constructs a replayer from the given target environment.
@@ -52,16 +53,17 @@ class Replayer {
   // invoked once for each message communicated from the library.
   void SetMessageConsumer(MessageConsumer consumer);
 
-  // Transforms |binary_in| to |binary_out| by attempting to apply the
-  // transformations from |transformation_sequence_in|.  Initial facts about the
-  // input binary and the context in which it will execute are provided via
-  // |initial_facts|.  The transformations that were successfully applied are
-  // returned via |transformation_sequence_out|.
+  // Transforms |binary_in| to |binary_out| by attempting to apply the first
+  // |num_transformations_to_apply| transformations from
+  // |transformation_sequence_in|.  Initial facts about the input binary and the
+  // context in which it will execute are provided via |initial_facts|.  The
+  // transformations that were successfully applied are returned via
+  // |transformation_sequence_out|.
   ReplayerResultStatus Run(
       const std::vector<uint32_t>& binary_in,
       const protobufs::FactSequence& initial_facts,
       const protobufs::TransformationSequence& transformation_sequence_in,
-      std::vector<uint32_t>* binary_out,
+      uint32_t num_transformations_to_apply, std::vector<uint32_t>* binary_out,
       protobufs::TransformationSequence* transformation_sequence_out) const;
 
  private:

--- a/source/fuzz/shrinker.cpp
+++ b/source/fuzz/shrinker.cpp
@@ -124,6 +124,7 @@ Shrinker::ShrinkerResultStatus Shrinker::Run(
   if (Replayer(impl_->target_env, impl_->validate_during_replay,
                impl_->validator_options)
           .Run(binary_in, initial_facts, transformation_sequence_in,
+               transformation_sequence_in.transformation_size(),
                &current_best_binary, &current_best_transformations) !=
       Replayer::ReplayerResultStatus::kComplete) {
     return ShrinkerResultStatus::kReplayFailed;
@@ -196,6 +197,7 @@ Shrinker::ShrinkerResultStatus Shrinker::Run(
       if (Replayer(impl_->target_env, impl_->validate_during_replay,
                    impl_->validator_options)
               .Run(binary_in, initial_facts, transformations_with_chunk_removed,
+                   transformations_with_chunk_removed.transformation_size(),
                    &next_binary, &next_transformation_sequence) !=
           Replayer::ReplayerResultStatus::kComplete) {
         // Replay should not fail; if it does, we need to abort shrinking.

--- a/source/spirv_fuzzer_options.cpp
+++ b/source/spirv_fuzzer_options.cpp
@@ -22,6 +22,7 @@ const uint32_t kDefaultStepLimit = 250;
 spv_fuzzer_options_t::spv_fuzzer_options_t()
     : has_random_seed(false),
       random_seed(0),
+      replay_range(0),
       replay_validation_enabled(false),
       shrinker_step_limit(kDefaultStepLimit),
       fuzzer_pass_validation_enabled(false) {}
@@ -43,6 +44,11 @@ SPIRV_TOOLS_EXPORT void spvFuzzerOptionsSetRandomSeed(
     spv_fuzzer_options options, uint32_t seed) {
   options->has_random_seed = true;
   options->random_seed = seed;
+}
+
+SPIRV_TOOLS_EXPORT void spvFuzzerOptionsSetReplayRange(
+    spv_fuzzer_options options, int32_t replay_range) {
+  options->replay_range = replay_range;
 }
 
 SPIRV_TOOLS_EXPORT void spvFuzzerOptionsSetShrinkerStepLimit(

--- a/source/spirv_fuzzer_options.h
+++ b/source/spirv_fuzzer_options.h
@@ -29,6 +29,9 @@ struct spv_fuzzer_options_t {
   bool has_random_seed;
   uint32_t random_seed;
 
+  // See spvFuzzerOptionsSetReplayRange.
+  int32_t replay_range;
+
   // See spvFuzzerOptionsEnableReplayValidation.
   bool replay_validation_enabled;
 

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -24,6 +24,7 @@ if (${SPIRV_BUILD_FUZZER})
           fuzzer_pass_construct_composites_test.cpp
           fuzzer_pass_donate_modules_test.cpp
           instruction_descriptor_test.cpp
+          replayer_test.cpp
           transformation_access_chain_test.cpp
           transformation_add_constant_boolean_test.cpp
           transformation_add_constant_composite_test.cpp

--- a/test/fuzz/fuzzer_replayer_test.cpp
+++ b/test/fuzz/fuzzer_replayer_test.cpp
@@ -1659,6 +1659,8 @@ void RunFuzzerAndReplayer(const std::string& shader,
     replayer.SetMessageConsumer(kConsoleMessageConsumer);
     auto replayer_result_status = replayer.Run(
         binary_in, initial_facts, fuzzer_transformation_sequence_out,
+        static_cast<uint32_t>(
+            fuzzer_transformation_sequence_out.transformation_size()),
         &replayer_binary_out, &replayer_transformation_sequence_out);
     ASSERT_EQ(Replayer::ReplayerResultStatus::kComplete,
               replayer_result_status);

--- a/test/fuzz/replayer_test.cpp
+++ b/test/fuzz/replayer_test.cpp
@@ -1,0 +1,301 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/replayer.h"
+
+#include "source/fuzz/instruction_descriptor.h"
+#include "source/fuzz/transformation_split_block.h"
+#include "test/fuzz/fuzz_test_util.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace {
+
+TEST(ReplayerTest, PartialReplay) {
+  const std::string kTestShader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %8 "g"
+               OpName %11 "x"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Private %6
+          %8 = OpVariable %7 Private
+          %9 = OpConstant %6 10
+         %10 = OpTypePointer Function %6
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %11 = OpVariable %10 Function
+               OpStore %8 %9
+         %12 = OpLoad %6 %8
+               OpStore %11 %12
+         %13 = OpLoad %6 %8
+               OpStore %11 %13
+         %14 = OpLoad %6 %8
+               OpStore %11 %14
+         %15 = OpLoad %6 %8
+               OpStore %11 %15
+         %16 = OpLoad %6 %8
+               OpStore %11 %16
+         %17 = OpLoad %6 %8
+               OpStore %11 %17
+         %18 = OpLoad %6 %8
+               OpStore %11 %18
+         %19 = OpLoad %6 %8
+               OpStore %11 %19
+         %20 = OpLoad %6 %8
+               OpStore %11 %20
+         %21 = OpLoad %6 %8
+               OpStore %11 %21
+         %22 = OpLoad %6 %8
+               OpStore %11 %22
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  spvtools::ValidatorOptions validator_options;
+
+  std::vector<uint32_t> binary_in;
+  SpirvTools t(env);
+  t.SetMessageConsumer(kSilentConsumer);
+  ASSERT_TRUE(t.Assemble(kTestShader, &binary_in, kFuzzAssembleOption));
+  ASSERT_TRUE(t.Validate(binary_in));
+
+  protobufs::TransformationSequence transformations;
+  for (uint32_t id = 12; id <= 22; id++) {
+    *transformations.add_transformation() =
+        TransformationSplitBlock(MakeInstructionDescriptor(id, SpvOpLoad, 0),
+                                 id + 100)
+            .ToMessage();
+  }
+
+  {
+    // Full replay
+    protobufs::TransformationSequence transformations_out;
+    protobufs::FactSequence empty_facts;
+    std::vector<uint32_t> binary_out;
+    Replayer replayer(env, true, validator_options);
+    replayer.SetMessageConsumer(kSilentConsumer);
+    auto replayer_result_status =
+        replayer.Run(binary_in, empty_facts, transformations, 11, &binary_out,
+                     &transformations_out);
+    // Replay should succeed.
+    ASSERT_EQ(Replayer::ReplayerResultStatus::kComplete,
+              replayer_result_status);
+    // All transformations should be applied.
+    ASSERT_TRUE(google::protobuf::util::MessageDifferencer::Equals(
+        transformations, transformations_out));
+
+    const std::string kFullySplitShader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %8 "g"
+               OpName %11 "x"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Private %6
+          %8 = OpVariable %7 Private
+          %9 = OpConstant %6 10
+         %10 = OpTypePointer Function %6
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %11 = OpVariable %10 Function
+               OpStore %8 %9
+               OpBranch %112
+        %112 = OpLabel
+         %12 = OpLoad %6 %8
+               OpStore %11 %12
+               OpBranch %113
+        %113 = OpLabel
+         %13 = OpLoad %6 %8
+               OpStore %11 %13
+               OpBranch %114
+        %114 = OpLabel
+         %14 = OpLoad %6 %8
+               OpStore %11 %14
+               OpBranch %115
+        %115 = OpLabel
+         %15 = OpLoad %6 %8
+               OpStore %11 %15
+               OpBranch %116
+        %116 = OpLabel
+         %16 = OpLoad %6 %8
+               OpStore %11 %16
+               OpBranch %117
+        %117 = OpLabel
+         %17 = OpLoad %6 %8
+               OpStore %11 %17
+               OpBranch %118
+        %118 = OpLabel
+         %18 = OpLoad %6 %8
+               OpStore %11 %18
+               OpBranch %119
+        %119 = OpLabel
+         %19 = OpLoad %6 %8
+               OpStore %11 %19
+               OpBranch %120
+        %120 = OpLabel
+         %20 = OpLoad %6 %8
+               OpStore %11 %20
+               OpBranch %121
+        %121 = OpLabel
+         %21 = OpLoad %6 %8
+               OpStore %11 %21
+               OpBranch %122
+        %122 = OpLabel
+         %22 = OpLoad %6 %8
+               OpStore %11 %22
+               OpReturn
+               OpFunctionEnd
+    )";
+    ASSERT_TRUE(IsEqual(env, kFullySplitShader, binary_out));
+  }
+
+  {
+    // Half replay
+    protobufs::TransformationSequence transformations_out;
+    protobufs::FactSequence empty_facts;
+    std::vector<uint32_t> binary_out;
+    Replayer replayer(env, true, validator_options);
+    replayer.SetMessageConsumer(kSilentConsumer);
+    auto replayer_result_status =
+        replayer.Run(binary_in, empty_facts, transformations, 5, &binary_out,
+                     &transformations_out);
+    // Replay should succeed.
+    ASSERT_EQ(Replayer::ReplayerResultStatus::kComplete,
+              replayer_result_status);
+    // The first 5 transformations should be applied
+    ASSERT_EQ(5, transformations_out.transformation_size());
+    for (uint32_t i = 0; i < 5; i++) {
+      ASSERT_TRUE(google::protobuf::util::MessageDifferencer::Equals(
+          transformations.transformation(i),
+          transformations_out.transformation(i)));
+    }
+
+    const std::string kHalfSplitShader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %8 "g"
+               OpName %11 "x"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Private %6
+          %8 = OpVariable %7 Private
+          %9 = OpConstant %6 10
+         %10 = OpTypePointer Function %6
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %11 = OpVariable %10 Function
+               OpStore %8 %9
+               OpBranch %112
+        %112 = OpLabel
+         %12 = OpLoad %6 %8
+               OpStore %11 %12
+               OpBranch %113
+        %113 = OpLabel
+         %13 = OpLoad %6 %8
+               OpStore %11 %13
+               OpBranch %114
+        %114 = OpLabel
+         %14 = OpLoad %6 %8
+               OpStore %11 %14
+               OpBranch %115
+        %115 = OpLabel
+         %15 = OpLoad %6 %8
+               OpStore %11 %15
+               OpBranch %116
+        %116 = OpLabel
+         %16 = OpLoad %6 %8
+               OpStore %11 %16
+         %17 = OpLoad %6 %8
+               OpStore %11 %17
+         %18 = OpLoad %6 %8
+               OpStore %11 %18
+         %19 = OpLoad %6 %8
+               OpStore %11 %19
+         %20 = OpLoad %6 %8
+               OpStore %11 %20
+         %21 = OpLoad %6 %8
+               OpStore %11 %21
+         %22 = OpLoad %6 %8
+               OpStore %11 %22
+               OpReturn
+               OpFunctionEnd
+    )";
+    ASSERT_TRUE(IsEqual(env, kHalfSplitShader, binary_out));
+  }
+
+  {
+    // Empty replay
+    protobufs::TransformationSequence transformations_out;
+    protobufs::FactSequence empty_facts;
+    std::vector<uint32_t> binary_out;
+    Replayer replayer(env, true, validator_options);
+    replayer.SetMessageConsumer(kSilentConsumer);
+    auto replayer_result_status =
+        replayer.Run(binary_in, empty_facts, transformations, 0, &binary_out,
+                     &transformations_out);
+    // Replay should succeed.
+    ASSERT_EQ(Replayer::ReplayerResultStatus::kComplete,
+              replayer_result_status);
+    // No transformations should be applied
+    ASSERT_EQ(0, transformations_out.transformation_size());
+    ASSERT_TRUE(IsEqual(env, kTestShader, binary_out));
+  }
+
+  {
+    // Invalid replay: too many transformations
+    protobufs::TransformationSequence transformations_out;
+    protobufs::FactSequence empty_facts;
+    std::vector<uint32_t> binary_out;
+    // The number of transformations requested to be applied exceeds the number
+    // of transformations
+    Replayer replayer(env, true, validator_options);
+    replayer.SetMessageConsumer(kSilentConsumer);
+    auto replayer_result_status =
+        replayer.Run(binary_in, empty_facts, transformations, 12, &binary_out,
+                     &transformations_out);
+
+    // Replay should not succeed.
+    ASSERT_EQ(Replayer::ReplayerResultStatus::kTooManyTransformationsRequested,
+              replayer_result_status);
+    // No transformations should be applied
+    ASSERT_EQ(0, transformations_out.transformation_size());
+    // The output binary should be empty
+    ASSERT_TRUE(binary_out.empty());
+  }
+}
+
+}  // namespace
+}  // namespace fuzz
+}  // namespace spvtools


### PR DESCRIPTION
This change adds a --replay-range argument to spirv-fuzz that
facilitates applying only a prefix of transformations.