### PR TITLE
spirv-fuzz: Extend TransformationRecordSynonymousConstants to allow composite constants

### DIFF
--- a/source/fuzz/transformation_record_synonymous_constants.cpp
+++ b/source/fuzz/transformation_record_synonymous_constants.cpp
@@ -58,28 +58,23 @@ bool AreEquivalentConstants(opt::IRContext* ir_context, uint32_t constant_id1,
     return scalar1->words() == constant2->AsScalarConstant()->words();
   }
 
-  // If the constants are composite, they are equivalent iff their components
-  // match
-  if (constant1->AsCompositeConstant()) {
-    // Since the types match, we already know that the number of components is
-    // the same. We check that the input operands of the definitions are all
-    // constants and that they are pairwise equivalent.
-    for (uint32_t i = 0; i < def_1->NumInOperands(); i++) {
-      if (!AreEquivalentConstants(ir_context, def_1->GetSingleWordInOperand(i),
-                                  def_2->GetSingleWordInOperand(i))) {
-        return false;
-      }
-    }
+  // The only remaining possibility is that the constants are composite
+  assert(constant1->AsCompositeConstant() &&
+         "Equivalence of constants can only be checked with scalar, composite "
+         "or null constants.");
 
-    // If we get here, all the components are equivalent
-    return true;
+  // Since the types match, we already know that the number of components is
+  // the same. We check that the input operands of the definitions are all
+  // constants and that they are pairwise equivalent.
+  for (uint32_t i = 0; i < def_1->NumInOperands(); i++) {
+    if (!AreEquivalentConstants(ir_context, def_1->GetSingleWordInOperand(i),
+                                def_2->GetSingleWordInOperand(i))) {
+      return false;
+    }
   }
 
-  // If we get here, the type is not sensible to check for equivalence
-  assert(false &&
-         "Equivalency of constants can only be checked with scalar, composite "
-         "or null constants.");
-  return false;
+  // If we get here, all the components are equivalent
+  return true;
 }
 }  // namespace
 

--- a/source/fuzz/transformation_record_synonymous_constants.cpp
+++ b/source/fuzz/transformation_record_synonymous_constants.cpp
@@ -19,8 +19,61 @@ namespace spvtools {
 namespace fuzz {
 
 namespace {
-bool IsScalarZeroConstant(const opt::analysis::Constant* constant) {
-  return constant->AsScalarConstant() && constant->IsZero();
+
+// Returns true if the two given constants are equivalent
+// (the description of IsApplicable specifies the conditions they must satisfy
+// to be considered equivalent)
+bool AreEquivalentConstants(opt::IRContext* ir_context,
+                            const opt::analysis::Constant& constant1,
+                            const opt::analysis::Constant& constant2) {
+  // Check that the type ids are the same
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3536): Somehow
+  // relax this for integers (so that unsigned integer and signed integer are
+  // considered the same type)
+  uint32_t type_id1 = ir_context->get_type_mgr()->GetId(constant1.type());
+  uint32_t type_id2 = ir_context->get_type_mgr()->GetId(constant2.type());
+  if (type_id1 != type_id2) {
+    return false;
+  }
+
+  // If either constant is null, the other is equivalent iff it is zero-like
+  if (constant1.AsNullConstant()) {
+    return constant2.IsZero();
+  }
+
+  if (constant2.AsNullConstant()) {
+    return constant1.IsZero();
+  }
+
+  // If the constants are scalar, they are equal iff their words are the same
+  if (auto scalar1 = constant1.AsScalarConstant()) {
+    return scalar1->words() == constant2.AsScalarConstant()->words();
+  }
+
+  // If the constants are composite, they are equivalent iff their components
+  // match
+  if (constant1.AsCompositeConstant()) {
+    auto components1 = constant1.AsCompositeConstant()->GetComponents();
+    auto components2 = constant2.AsCompositeConstant()->GetComponents();
+
+    // Since the types match, we already know that the number of components is
+    // the same, so we just need to check equivalence for each one
+    for (size_t i = 0; i < components1.size(); i++) {
+      if (!AreEquivalentConstants(ir_context, *components1[i],
+                                  *components2[i])) {
+        return false;
+      }
+    }
+
+    // If we get here, all the components are equivalent
+    return true;
+  }
+
+  // If we get here, the type is not sensible to check for equivalence
+  assert(false &&
+         "Equivalency of constants can only be checked with scalar, composite "
+         "or null constants.");
+  return false;
 }
 }  // namespace
 
@@ -54,30 +107,7 @@ bool TransformationRecordSynonymousConstants::IsApplicable(
     return false;
   }
 
-  // If the constants are equal, then they are equivalent
-  if (constant1 == constant2) {
-    return true;
-  }
-
-  // If the constants are two integers (signed or unsigned), they are equal
-  // if they have the same width and the same data words.
-  if (constant1->AsIntConstant() && constant2->AsIntConstant() &&
-      constant1->type()->AsInteger()->width() ==
-          constant2->type()->AsInteger()->width() &&
-      constant1->AsIntConstant()->words() ==
-          constant2->AsIntConstant()->words()) {
-    return true;
-  }
-
-  // The types must be the same
-  if (!constant1->type()->IsSame(constant2->type())) {
-    return false;
-  }
-
-  // The constants are equivalent if one is null and the other is a static
-  // constant with value 0.
-  return (constant1->AsNullConstant() && IsScalarZeroConstant(constant2)) ||
-         (IsScalarZeroConstant(constant1) && constant2->AsNullConstant());
+  return AreEquivalentConstants(ir_context, *constant1, *constant2);
 }
 
 void TransformationRecordSynonymousConstants::Apply(

--- a/source/fuzz/transformation_record_synonymous_constants.h
+++ b/source/fuzz/transformation_record_synonymous_constants.h
@@ -33,11 +33,14 @@ class TransformationRecordSynonymousConstants : public Transformation {
   //   of constants
   // - |message_.constant_id| and |message_.synonym_id| refer to constants
   //   that are equal or equivalent.
-  //   Two integers with the same width and value are equal, even if one is
-  //   signed and the other is not.
-  //   Constants are equivalent if both of them represent zero-like scalar
-  //   values of the same type (for example OpConstant of type int and value
-  //   0 and OpConstantNull of type int).
+  //   TODO: Fix this (Signed and unsigned integers are currently considered
+  //   non-equivalent)
+  //   Two integers with the same width and value are equal,
+  //   even if one is signed and the other is not. Constants are equivalent if
+  //   both of them represent zero-like values of the same type (for example
+  //   OpConstant of type int and value 0 and OpConstantNull of type int).
+  //   Composite constants are equivalent if they have the same type and their
+  //   components are pairwise equivalent.
   bool IsApplicable(
       opt::IRContext* ir_context,
       const TransformationContext& transformation_context) const override;

--- a/source/fuzz/transformation_record_synonymous_constants.h
+++ b/source/fuzz/transformation_record_synonymous_constants.h
@@ -33,14 +33,14 @@ class TransformationRecordSynonymousConstants : public Transformation {
   //   of constants
   // - |message_.constant_id| and |message_.synonym_id| refer to constants
   //   that are equal or equivalent.
-  //   TODO: Fix this (Signed and unsigned integers are currently considered
-  //   non-equivalent)
-  //   Two integers with the same width and value are equal,
-  //   even if one is signed and the other is not. Constants are equivalent if
-  //   both of them represent zero-like values of the same type (for example
-  //   OpConstant of type int and value 0 and OpConstantNull of type int).
-  //   Composite constants are equivalent if they have the same type and their
-  //   components are pairwise equivalent.
+  //   TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3536): Signed and
+  //   unsigned integers are currently considered non-equivalent
+  //   Two integers with the same width and value are equal, even if one is
+  //   signed and the other is not.
+  //   Constants are equivalent:
+  //   - if both of them represent zero-like values of the same type
+  //   - if they are composite constants with the same type and their
+  //     components are pairwise equivalent.
   bool IsApplicable(
       opt::IRContext* ir_context,
       const TransformationContext& transformation_context) const override;

--- a/source/fuzz/transformation_record_synonymous_constants.h
+++ b/source/fuzz/transformation_record_synonymous_constants.h
@@ -54,6 +54,13 @@ class TransformationRecordSynonymousConstants : public Transformation {
 
  private:
   protobufs::TransformationRecordSynonymousConstants message_;
+
+  // Returns true if the two given constants are equivalent
+  // (the description of IsApplicable specifies the conditions they must satisfy
+  // to be considered equivalent)
+  static bool AreEquivalentConstants(opt::IRContext* ir_context,
+                                     uint32_t constant_id1,
+                                     uint32_t constant_id2);
 };
 
 }  // namespace fuzz

--- a/test/fuzz/transformation_record_synonymous_constants_test.cpp
+++ b/test/fuzz/transformation_record_synonymous_constants_test.cpp
@@ -129,9 +129,9 @@ TEST(TransformationRecordSynonymousConstantsTest, IntConstants) {
   ApplyTransformationAndCheckFactManager(13, 22, context.get(),
                                          &transformation_context);
 
-  // TODO (https://github.com/KhronosGroup/SPIRV-Tools/issues/3536):
-  // Relax type check for integers.
-  // %13 and %20 are equal even if %13 is signed and %20 is unsigned
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3536):
+  // Relax type check for integers. Uncomment this code once the issue is fixed.
+  // // %13 and %20 are equal even if %13 is signed and %20 is unsigned
   //  ASSERT_TRUE(TransformationRecordSynonymousConstants(13, 20).IsApplicable(
   //      context.get(), transformation_context));
   //
@@ -515,6 +515,121 @@ TEST(TransformationRecordSynonymousConstantsTest, StructCompositeConstants) {
 
   // %25 and %39 are not equivalent (they have different types)
   ASSERT_FALSE(TransformationRecordSynonymousConstants(25, 39).IsApplicable(
+      context.get(), transformation_context));
+}
+
+TEST(TransformationRecordSynonymousConstantsTest, ArrayCompositeConstants) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main" %24
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %8 "a"
+               OpName %12 "d"
+               OpName %16 "e"
+               OpName %24 "color"
+               OpDecorate %12 RelaxedPrecision
+               OpDecorate %18 RelaxedPrecision
+               OpDecorate %24 Location 0
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeFloat 32
+          %7 = OpTypePointer Function %6
+          %9 = OpConstant %6 0
+         %38 = OpConstant %6 1
+         %10 = OpTypeInt 32 1
+         %11 = OpTypePointer Function %10
+         %13 = OpConstant %10 0
+         %27 = OpConstant %10 4
+         %14 = OpTypeBool
+         %15 = OpTypePointer Function %14
+         %17 = OpConstantFalse %14
+         %22 = OpTypeVector %6 4
+         %28 = OpTypeArray %6 %27
+         %29 = OpTypeArray %28 %27
+         %23 = OpTypePointer Output %22
+         %24 = OpVariable %23 Output
+         %25 = OpConstantComposite %22 %9 %9 %9 %9
+         %31 = OpConstantComposite %28 %9 %9 %9 %9
+         %32 = OpConstantComposite %28 %38 %9 %9 %9
+         %33 = OpConstantNull %28
+         %34 = OpConstantComposite %29 %31 %33 %31 %33
+         %35 = OpConstantComposite %29 %33 %31 %33 %31
+         %36 = OpConstantNull %29
+         %37 = OpConstantComposite %29 %32 %33 %31 %33
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+          %8 = OpVariable %7 Function
+         %12 = OpVariable %11 Function
+         %16 = OpVariable %15 Function
+               OpStore %8 %9
+               OpStore %12 %13
+               OpStore %16 %17
+         %18 = OpLoad %10 %12
+         %19 = OpIEqual %14 %18 %13
+               OpSelectionMerge %21 None
+               OpBranchConditional %19 %20 %26
+         %20 = OpLabel
+               OpStore %24 %25
+               OpBranch %21
+         %26 = OpLabel
+               OpStore %24 %25
+               OpBranch %21
+         %21 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  // %25 and %31 are not equivalent (they have different types)
+  ASSERT_FALSE(TransformationRecordSynonymousConstants(25, 31).IsApplicable(
+      context.get(), transformation_context));
+
+  // %31 and %32 are not equivalent (their components are not pairwise
+  // equivalent)
+  ASSERT_FALSE(TransformationRecordSynonymousConstants(31, 32).IsApplicable(
+      context.get(), transformation_context));
+
+  // %31 and %33 are equivalent (%31 has zero-valued components, 32 is null)
+  ASSERT_TRUE(TransformationRecordSynonymousConstants(31, 33).IsApplicable(
+      context.get(), transformation_context));
+
+  ApplyTransformationAndCheckFactManager(31, 33, context.get(),
+                                         &transformation_context);
+
+  // %34 and %35 are equivalent (same type, equivalent components)
+  ASSERT_TRUE(TransformationRecordSynonymousConstants(34, 35).IsApplicable(
+      context.get(), transformation_context));
+
+  ApplyTransformationAndCheckFactManager(34, 35, context.get(),
+                                         &transformation_context);
+
+  // %35 and %36 are equivalent (%36 is null, %35 has zero-valued components)
+  ASSERT_TRUE(TransformationRecordSynonymousConstants(35, 36).IsApplicable(
+      context.get(), transformation_context));
+
+  ApplyTransformationAndCheckFactManager(35, 36, context.get(),
+                                         &transformation_context);
+
+  // %34 and %37 are not equivalent (they have non-equivalent components)
+  ASSERT_FALSE(TransformationRecordSynonymousConstants(34, 37).IsApplicable(
+      context.get(), transformation_context));
+
+  // %36 and %37 are not equivalent (36 is null, 37 does not have all-zero
+  // components)
+  ASSERT_FALSE(TransformationRecordSynonymousConstants(36, 37).IsApplicable(
       context.get(), transformation_context));
 }
 

--- a/test/fuzz/transformation_record_synonymous_constants_test.cpp
+++ b/test/fuzz/transformation_record_synonymous_constants_test.cpp
@@ -353,17 +353,21 @@ TEST(TransformationRecordSynonymousConstantsTest,
          %15 = OpTypePointer Function %14
          %17 = OpConstantFalse %14
          %22 = OpTypeVector %6 4
+         %37 = OpTypeVector %6 3
          %32 = OpTypeMatrix %22 2
+         %39 = OpTypeMatrix %22 3
          %23 = OpTypePointer Output %22
          %24 = OpVariable %23 Output
          %25 = OpConstantComposite %22 %9 %9 %9 %9
          %27 = OpConstantNull %22
          %29 = OpConstantComposite %22 %9 %28 %28 %9
          %31 = OpConstantComposite %22 %30 %9 %9 %9
+         %38 = OpConstantComposite %37 %9 %9 %9
          %33 = OpConstantComposite %32 %25 %29
          %34 = OpConstantComposite %32 %27 %25
          %35 = OpConstantNull %32
          %36 = OpConstantComposite %32 %31 %25
+         %40 = OpConstantComposite %39 %25 %25 %25
           %4 = OpFunction %2 None %3
           %5 = OpLabel
           %8 = OpVariable %7 Function
@@ -426,12 +430,20 @@ TEST(TransformationRecordSynonymousConstantsTest,
   ASSERT_FALSE(TransformationRecordSynonymousConstants(27, 31).IsApplicable(
       context.get(), transformation_context));
 
+  // %25 and %38 are not equivalent (they have different sizes)
+  ASSERT_FALSE(TransformationRecordSynonymousConstants(25, 38).IsApplicable(
+      context.get(), transformation_context));
+
   // %35 and %36 are not equivalent (35 is null, 36 has non-zero components)
   ASSERT_FALSE(TransformationRecordSynonymousConstants(35, 36).IsApplicable(
       context.get(), transformation_context));
 
   // %33 and %36 are not equivalent (not all components are equivalent)
   ASSERT_FALSE(TransformationRecordSynonymousConstants(33, 36).IsApplicable(
+      context.get(), transformation_context));
+
+  // %33 and %40 are not equivalent (they have different sizes)
+  ASSERT_FALSE(TransformationRecordSynonymousConstants(33, 40).IsApplicable(
       context.get(), transformation_context));
 
   // %33 and %34 are equivalent (same type, equivalent components)
@@ -572,16 +584,19 @@ TEST(TransformationRecordSynonymousConstantsTest, ArrayCompositeConstants) {
          %11 = OpTypePointer Function %10
          %13 = OpConstant %10 0
          %27 = OpConstant %10 4
+         %39 = OpConstant %10 2
          %14 = OpTypeBool
          %15 = OpTypePointer Function %14
          %17 = OpConstantFalse %14
          %22 = OpTypeVector %6 4
          %28 = OpTypeArray %6 %27
          %29 = OpTypeArray %28 %27
+         %40 = OpTypeArray %6 %39
          %23 = OpTypePointer Output %22
          %24 = OpVariable %23 Output
          %25 = OpConstantComposite %22 %9 %9 %9 %9
          %31 = OpConstantComposite %28 %9 %9 %9 %9
+         %41 = OpConstantComposite %40 %9 %9
          %32 = OpConstantComposite %28 %38 %9 %9 %9
          %33 = OpConstantNull %28
          %34 = OpConstantComposite %29 %31 %33 %31 %33
@@ -623,6 +638,10 @@ TEST(TransformationRecordSynonymousConstantsTest, ArrayCompositeConstants) {
 
   // %25 and %31 are not equivalent (they have different types)
   ASSERT_FALSE(TransformationRecordSynonymousConstants(25, 31).IsApplicable(
+      context.get(), transformation_context));
+
+  // %25 and %41 are not equivalent (they have different sizes)
+  ASSERT_FALSE(TransformationRecordSynonymousConstants(25, 41).IsApplicable(
       context.get(), transformation_context));
 
   // %31 and %32 are not equivalent (their components are not pairwise


### PR DESCRIPTION
Implemented AreEquivalentConstants method to check equivalency of constants, changing IsApplicable method of TransformationRecordSynonymousConstants to allow recording equivalence of composite constants; added some tests to check this.

Tests with arrays and matrices still need to be added.

Related issue: #3533 