### PR TITLE
spirv-fuzz: Compute corollary facts from OpBitcast

### DIFF
--- a/source/fuzz/fact_manager.cpp
+++ b/source/fuzz/fact_manager.cpp
@@ -540,21 +540,25 @@ class FactManager::DataSynonymAndIdEquationFacts {
       id_equations_;
 
   // Represents a map from a strongly connected component (SCC) in the graph to
-  // the set of vertices of that component. The SCC is represented by one of its
-  // vertices (i.e. |scc_to_node_[K].contains(K) == true| for some |K|).
-  // Each data descriptor is a representative of some equivalence class.
-  // Check out the documentation for the ComputeBitcastDataSynonymFacts method
-  // to learn more about why we use a graph and SCCs here.
+  // the set of vertices of that component. The graph is used to compute
+  // corollary facts from the OpBitcast equation facts (see implementation
+  // comments in the ComputeBitcastDataSynonymFacts method to learn why we need
+  // a graph here). The SCC is represented by one of its vertices (i.e.
+  // |scc_to_node_[K].contains(K) == true| for some |K|). Each data descriptor
+  // is a representative of some equivalence class.
   std::unordered_map<const protobufs::DataDescriptor*,
                      std::unordered_set<const protobufs::DataDescriptor*>>
       scc_to_node_;
 
   // Represents a map from a vertex in the graph to its strongly connected
-  // component (SCC). The SCC is represented by one of its
-  // vertices (i.e. |node_to_scc_[K]| might be equal to |K| for some |K|).
-  // Each data descriptor is a representative of some equivalence class.
-  // Check out the documentation for the ComputeBitcastDataSynonymFacts method
-  // to learn more about why we use a graph and SCCs here.
+  // component (SCC). The graph is used to compute corollary facts from the
+  // OpBitcast equation facts (see implementation comments in the
+  // ComputeBitcastDataSynonymFacts method to learn why we need a graph here).
+  // The SCC is represented by one of its vertices (i.e. |node_to_scc_[K]| might
+  // be equal to |K| for some |K|). Each data descriptor is a representative of
+  // some equivalence class. Check out the documentation for the
+  // ComputeBitcastDataSynonymFacts method to learn more about why we use a
+  // graph and SCCs here.
   std::unordered_map<const protobufs::DataDescriptor*,
                      const protobufs::DataDescriptor*>
       node_to_scc_;

--- a/source/fuzz/fact_manager.cpp
+++ b/source/fuzz/fact_manager.cpp
@@ -538,9 +538,7 @@ void FactManager::DataSynonymAndIdEquationFacts::AddFact(
   protobufs::DataDescriptor lhs_dd = MakeDataDescriptor(fact.lhs_id(), {});
 
   // Register the LHS in the equivalence relation if needed.
-  if (!synonymous_.Exists(lhs_dd)) {
-    RegisterDataDescriptor(lhs_dd);
-  }
+  RegisterDataDescriptor(lhs_dd);
 
   // Get equivalence class representatives for all ids used on the RHS of the
   // equation.
@@ -1151,11 +1149,8 @@ void FactManager::DataSynonymAndIdEquationFacts::MakeEquivalent(
     const protobufs::DataDescriptor& dd2) {
   // Register the data descriptors if they are not already known to the
   // equivalence relation.
-  for (const auto& dd : {dd1, dd2}) {
-    if (!synonymous_.Exists(dd)) {
-      RegisterDataDescriptor(dd);
-    }
-  }
+  RegisterDataDescriptor(dd1);
+  RegisterDataDescriptor(dd2);
 
   if (synonymous_.IsEquivalent(dd1, dd2)) {
     // The data descriptors are already known to be equivalent, so there is

--- a/source/fuzz/fact_manager.cpp
+++ b/source/fuzz/fact_manager.cpp
@@ -463,6 +463,13 @@ class FactManager::DataSynonymAndIdEquationFacts {
   void ComputeConversionDataSynonymFacts(const protobufs::DataDescriptor& dd,
                                          opt::IRContext* context);
 
+  // Computes various corollary facts that can be derived from the strongly
+  // connected component |scc|. Take a look at the implementation comments to
+  // learn more about how these facts a computed and why we need a graph
+  // abstraction for that.
+  void ComputeBitcastDataSynonymFacts(const protobufs::DataDescriptor* scc,
+                                      opt::IRContext* context);
+
   // Recurses into sub-components of the data descriptors, if they are
   // composites, to record that their components are pairwise-synonymous.
   void ComputeCompositeDataSynonymFacts(const protobufs::DataDescriptor& dd1,
@@ -473,6 +480,18 @@ class FactManager::DataSynonymAndIdEquationFacts {
   // of equations that are known about them.
   void MakeEquivalent(const protobufs::DataDescriptor& dd1,
                       const protobufs::DataDescriptor& dd2);
+
+  // Merges two connected components, represented by |scc_a| and |scc_b| and
+  // returns a descriptor for the resulting SCC. Both |scc_a| and |scc_b| must
+  // be valid SCCs (i.e. |scc_to_node_.find(scc_[a|b]) != scc_to_node_.end()|).
+  const protobufs::DataDescriptor* MergeConnectedComponents(
+      const protobufs::DataDescriptor* scc_a,
+      const protobufs::DataDescriptor* scc_b);
+
+  // Registers a data descriptor in the equivalence relation and returns its
+  // representative. Additionally, adjusts SCCs to account for a new vertex.
+  const protobufs::DataDescriptor* RegisterDataDescriptor(
+      const protobufs::DataDescriptor& dd);
 
   // Returns true if and only if |dd1| and |dd2| are valid data descriptors
   // whose associated data have compatible types. Two types are compatible if:
@@ -519,6 +538,26 @@ class FactManager::DataSynonymAndIdEquationFacts {
   // in that relation.
   std::unordered_map<const protobufs::DataDescriptor*, OperationSet>
       id_equations_;
+
+  // Represents a map from a strongly connected component (SCC) in the graph to
+  // the set of vertices of that component. The SCC is represented by one of its
+  // vertices (i.e. |scc_to_node_[K].contains(K) == true| for some |K|).
+  // Each data descriptor is a representative of some equivalence class.
+  // Check out the documentation for the ComputeBitcastDataSynonymFacts method
+  // to learn more about why we use a graph and SCCs here.
+  std::unordered_map<const protobufs::DataDescriptor*,
+                     std::unordered_set<const protobufs::DataDescriptor*>>
+      scc_to_node_;
+
+  // Represents a map from a vertex in the graph to its strongly connected
+  // component (SCC). The SCC is represented by one of its
+  // vertices (i.e. |node_to_scc_[K]| might be equal to |K| for some |K|).
+  // Each data descriptor is a representative of some equivalence class.
+  // Check out the documentation for the ComputeBitcastDataSynonymFacts method
+  // to learn more about why we use a graph and SCCs here.
+  std::unordered_map<const protobufs::DataDescriptor*,
+                     const protobufs::DataDescriptor*>
+      node_to_scc_;
 };
 
 void FactManager::DataSynonymAndIdEquationFacts::AddFact(
@@ -534,7 +573,7 @@ void FactManager::DataSynonymAndIdEquationFacts::AddFact(
 
   // Register the LHS in the equivalence relation if needed.
   if (!synonymous_.Exists(lhs_dd)) {
-    synonymous_.Register(lhs_dd);
+    RegisterDataDescriptor(lhs_dd);
   }
 
   // Get equivalence class representatives for all ids used on the RHS of the
@@ -543,11 +582,8 @@ void FactManager::DataSynonymAndIdEquationFacts::AddFact(
   for (auto rhs_id : fact.rhs_id()) {
     // Register a data descriptor based on this id in the equivalence relation
     // if needed, and then record the equivalence class representative.
-    protobufs::DataDescriptor rhs_dd = MakeDataDescriptor(rhs_id, {});
-    if (!synonymous_.Exists(rhs_dd)) {
-      synonymous_.Register(rhs_dd);
-    }
-    rhs_dd_ptrs.push_back(synonymous_.Find(&rhs_dd));
+    rhs_dd_ptrs.push_back(
+        RegisterDataDescriptor(MakeDataDescriptor(rhs_id, {})));
   }
 
   // Now add the fact.
@@ -606,6 +642,15 @@ void FactManager::DataSynonymAndIdEquationFacts::AddEquationFactRecursive(
     case SpvOpConvertSToF:
     case SpvOpConvertUToF:
       ComputeConversionDataSynonymFacts(*rhs_dds[0], context);
+      break;
+    case SpvOpBitcast:
+      // The equation, that we have just added, might have merged two connected
+      // components, so we need to recompute corollary facts.
+      ComputeBitcastDataSynonymFacts(
+          MergeConnectedComponents(
+              node_to_scc_.at(lhs_dd_representative),
+              node_to_scc_.at(synonymous_.Find(rhs_dds[0]))),
+          context);
       break;
     case SpvOpIAdd: {
       // Equation form: "a = b + c"
@@ -716,9 +761,24 @@ void FactManager::DataSynonymAndIdEquationFacts::AddDataSynonymFactRecursive(
 
   // Record that the data descriptors provided in the fact are equivalent.
   MakeEquivalent(dd1, dd2);
+  assert(synonymous_.Find(&dd1) == synonymous_.Find(&dd2) &&
+         "|dd1| and |dd2| must have a single representative");
+  assert(node_to_scc_.find(synonymous_.Find(&dd1)) != node_to_scc_.end() &&
+         "|dd1| and |dd2| must belong to the same connected component");
 
   // Compute various corollary facts.
+
+  // |dd1| and |dd2| might have belonged to different connected components.
+  // We have merged those components once we have marked |dd1| and |dd2| as
+  // synonymous, so we need to recompute corollary facts for the resulting
+  // component.
+  ComputeBitcastDataSynonymFacts(node_to_scc_.at(synonymous_.Find(&dd1)),
+                                 context);
+
+  // |dd1| and |dd2| belong to the same equivalence class so it doesn't matter
+  // which one we use here.
   ComputeConversionDataSynonymFacts(dd1, context);
+
   ComputeCompositeDataSynonymFacts(dd1, dd2, context);
 }
 
@@ -775,11 +835,68 @@ void FactManager::DataSynonymAndIdEquationFacts::
   }
 }
 
+void FactManager::DataSynonymAndIdEquationFacts::ComputeBitcastDataSynonymFacts(
+    const protobufs::DataDescriptor* scc, opt::IRContext* context) {
+  assert(scc_to_node_.find(scc) != scc_to_node_.end() &&
+         "Connected component is invalid");
+
+  // Consider a graph where each vertex is an equivalence class and each edge
+  // is an equation fact with OpBitcast opcode. Concretely, each edge has a form
+  // |%a = OpBitcast %b| where |a| and |b| belong to some equivalence classes
+  // (i.e. vertices). These edges are undirected. From now on, an edge
+  // |%a = OpBitcast %b| will be denoted as |a -- b| where |a| and |b| are the
+  // equivalence classes (i.e. vertices).
+  //
+  // Consider two edges |a -- b|, |a -- c|. This graph can be a result of any of
+  // four cases (since edges are undirected):
+  // 1. |%a = OpBitcast %b| and |%a = OpBitcast %c|
+  // 2. |%a = OpBitcast %b| and |%c = OpBitcast %a|
+  // 3. |%b = OpBitcast %a| and |%a = OpBitcast %c|
+  // 4. |%b = OpBitcast %a| and |%c = OpBitcast %a|
+  // where |a|s on both equations represent synonymous (not necessarily
+  // identical) ids. In all four cases, |b| and |c| are synonymous if they have
+  // compatible types (we allow two instructions to be synonymous even if they
+  // have different types - e.g. signed and unsigned integers. See
+  // DataDescriptorsAreWellFormedAndComparable method for more details).
+  //
+  // We can generalize this example as follows. Consider a graph that consists
+  // of strongly connected components. Each component consists of vertices and
+  // edges as described above. If there exists a path |a -- ... -- b| in some
+  // component s.t. |a| and |b| have compatible types (as determined by the
+  // DataDescriptorsAreWellFormedAndComparable method), then |a| and |b| are
+  // equivalent (remember that |a| and |b| are equivalence classes and when we
+  // say 'they are equivalent' we mean that all their members are synonymous).
+  // This proposition holds since each edge is an OpBitcast instruction and
+  // this instruction does not change the bit pattern of its operands, it only
+  // changes the type of the pattern. Thus, to ensure that we have computed all
+  // corollary facts, we need to make sure that all pairs of vertices in every
+  // SCC have incompatible types.
+
+  // We create a copy of the std::unordered_set since a recursive call to the
+  // AddDataSynonymFactRecursive method might invalidate set's iterators.
+  auto nodes = scc_to_node_.at(scc);
+
+  // Time complexity of this procedure (assuming AddDataSynonymFactRecursive
+  // only merges vertices in constant time and calls this method) is O(n^4) in
+  // the worst case scenario (|n| is a number of vertices in the |scc|).
+  for (const auto* node_a : nodes) {
+    for (const auto* node_b : nodes) {
+      // We have to skip the iteration if |node_a| and |node_b| are already
+      // synonymous since we would end up with an infinite recursion otherwise.
+      if (node_a != node_b && !synonymous_.IsEquivalent(*node_a, *node_b) &&
+          DataDescriptorsAreWellFormedAndComparable(context, *node_a,
+                                                    *node_b)) {
+        AddDataSynonymFactRecursive(*node_a, *node_b, context);
+      }
+    }
+  }
+}
+
 void FactManager::DataSynonymAndIdEquationFacts::
     ComputeCompositeDataSynonymFacts(const protobufs::DataDescriptor& dd1,
                                      const protobufs::DataDescriptor& dd2,
                                      opt::IRContext* context) {
-  // Check whether this is a synonym about composite objects.  If it is,
+  // Check whether this is a synonym about composite objects. If it is,
   // we can recursively add synonym facts about their associated sub-components.
 
   // Get the type of the object referred to by the first data descriptor in the
@@ -1137,7 +1254,7 @@ void FactManager::DataSynonymAndIdEquationFacts::MakeEquivalent(
   // equivalence relation.
   for (const auto& dd : {dd1, dd2}) {
     if (!synonymous_.Exists(dd)) {
-      synonymous_.Register(dd);
+      RegisterDataDescriptor(dd);
     }
   }
 
@@ -1204,6 +1321,64 @@ void FactManager::DataSynonymAndIdEquationFacts::MakeEquivalent(
   }
   // Delete the no longer-relevant equations about |no_longer_representative|.
   id_equations_.erase(no_longer_representative);
+
+  // We also adjust strongly connected components to account for the merged
+  // vertices.
+  const auto* scc_a = node_to_scc_.at(no_longer_representative);
+  const auto* scc_b = node_to_scc_.at(still_representative);
+
+  scc_to_node_.at(scc_a).erase(no_longer_representative);
+  node_to_scc_.erase(no_longer_representative);
+
+  MergeConnectedComponents(scc_a, scc_b);
+}
+
+const protobufs::DataDescriptor*
+FactManager::DataSynonymAndIdEquationFacts::MergeConnectedComponents(
+    const protobufs::DataDescriptor* scc_a,
+    const protobufs::DataDescriptor* scc_b) {
+  assert(scc_to_node_.find(scc_a) != scc_to_node_.end() &&
+         scc_to_node_.find(scc_b) != scc_to_node_.end() &&
+         "Connected components are invalid");
+
+  if (scc_a == scc_b) {
+    return scc_a;
+  }
+
+  const auto* less_scc = scc_a;
+  const auto* more_scc = scc_b;
+
+  auto* less_nodes = &scc_to_node_.at(less_scc);
+  auto* more_nodes = &scc_to_node_.at(more_scc);
+
+  if (less_nodes->size() > more_nodes->size()) {
+    std::swap(less_nodes, more_nodes);
+    std::swap(less_scc, more_scc);
+  }
+
+  more_nodes->insert(less_nodes->begin(), less_nodes->end());
+  for (const auto* node : *less_nodes) {
+    node_to_scc_.at(node) = more_scc;
+  }
+
+  scc_to_node_.erase(less_scc);
+  return more_scc;
+}
+
+const protobufs::DataDescriptor*
+FactManager::DataSynonymAndIdEquationFacts::RegisterDataDescriptor(
+    const protobufs::DataDescriptor& dd) {
+  if (!synonymous_.Exists(dd)) {
+    const auto* representative = synonymous_.Register(dd);
+    assert(node_to_scc_.find(representative) == node_to_scc_.end() &&
+           scc_to_node_.find(representative) == scc_to_node_.end() &&
+           "The node should not belong to any connected component");
+    node_to_scc_[representative] = representative;
+    scc_to_node_[representative].insert(representative);
+    return representative;
+  }
+
+  return synonymous_.Find(&dd);
 }
 
 bool FactManager::DataSynonymAndIdEquationFacts::

--- a/test/fuzz/fact_manager_test.cpp
+++ b/test/fuzz/fact_manager_test.cpp
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "source/fuzz/fact_manager.h"
+
 #include <limits>
 
-#include "source/fuzz/fact_manager.h"
 #include "source/fuzz/uniform_buffer_element_descriptor.h"
 #include "test/fuzz/fuzz_test_util.h"
 
@@ -780,6 +781,212 @@ TEST(FactManagerTest, RecursiveAdditionOfFacts) {
                                         MakeDataDescriptor(11, {2, 2})));
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(10, {3}),
                                         MakeDataDescriptor(11, {2, 3})));
+}
+
+TEST(FactManagerTest, CorollaryBitcastFacts) {
+  std::string shader = R"(
+               OpCapability Shader
+               ; we use these capabilities to increase the variety of types
+               OpCapability Int64
+               OpCapability Float64
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %12 "main"
+               OpExecutionMode %12 OriginUpperLeft
+               OpSource ESSL 310
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %4 = OpTypeInt 32 1
+          %5 = OpTypeInt 32 0
+          %6 = OpTypeInt 64 1
+          %7 = OpTypeInt 64 0
+          %8 = OpTypeFloat 32
+          %9 = OpTypeFloat 64
+         %10 = OpTypeVector %4 4
+         %11 = OpTypeVector %5 4
+         %14 = OpTypeVector %6 2
+         %15 = OpTypeVector %7 2
+         %16 = OpTypeVector %8 4
+         %17 = OpTypeVector %9 2
+         ; groups of synonyms are indented
+         ; int32
+         %18 = OpConstant %4 23
+         %19 = OpConstant %4 23
+         %20 = OpConstant %5 23
+         ; float32
+         %30 = OpConstant %8 23
+         %31 = OpConstant %8 23
+         %32 = OpConstant %8 23
+         ; ivec32
+         %42 = OpConstantComposite %10 %18 %18 %18 %18
+         %43 = OpConstantComposite %10 %19 %19 %19 %19
+         %44 = OpConstantComposite %11 %20 %20 %20 %20
+         ; vec32
+         ; also synonymous to %92
+         %54 = OpConstantComposite %16 %30 %30 %30 %30
+         %55 = OpConstantComposite %16 %31 %31 %31 %31
+         %56 = OpConstantComposite %16 %32 %32 %32 %32
+         %12 = OpFunction %2 None %3
+         %13 = OpLabel
+         ; Connected component #1
+         ; ivec32 -- ivec64
+         %83 = OpBitcast %14 %42 ; synonymous to %84 and %86
+         %84 = OpBitcast %15 %43
+         %85 = OpBitcast %10 %84 ; synonymous to %42
+         %86 = OpBitcast %14 %44
+         ; ivec64 -- vec64
+         %80 = OpBitcast %17 %83 ; synonymous to %81 and %82
+         %81 = OpBitcast %17 %84
+         %82 = OpBitcast %17 %86
+         %87 = OpBitcast %15 %82 ; synonymous to %83
+         ; vec64 -- vec32
+         %88 = OpBitcast %16 %80 ; synonymous to %89 and %90
+         %89 = OpBitcast %16 %81
+         %90 = OpBitcast %16 %82
+         %91 = OpBitcast %17 %89 ; synonymous to %80
+         ; Connected component #2
+         ; vec32 -- ivec32
+         %92 = OpBitcast %11 %88 ; synonymous to %93 and %94
+         %93 = OpBitcast %10 %89
+         %94 = OpBitcast %11 %90
+         %95 = OpBitcast %16 %93 ; synonymous to %88
+        %106 = OpBitcast %11 %93 ; signedness cast - self-loop in the graph
+         ; ivec32 -- vec32
+         %96 = OpBitcast %16 %92 ; synonymous to %97, %98 and %54
+         %97 = OpBitcast %16 %93
+         %98 = OpBitcast %16 %94
+         ; ivec32 -- vec64
+         %99 = OpBitcast %17 %92 ; synonymous to %100 and %101
+        %100 = OpBitcast %17 %93
+        %101 = OpBitcast %17 %94
+         ; vec32 -- vec64
+        %102 = OpBitcast %17 %54 ; synonymous to %99 and %103 and %104
+        %103 = OpBitcast %17 %55
+        %104 = OpBitcast %17 %56
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+
+  fact_manager.AddFactDataSynonym(MakeDataDescriptor(18, {}),
+                                  MakeDataDescriptor(19, {}), context.get());
+  fact_manager.AddFactDataSynonym(MakeDataDescriptor(18, {}),
+                                  MakeDataDescriptor(20, {}), context.get());
+
+  fact_manager.AddFactDataSynonym(MakeDataDescriptor(30, {}),
+                                  MakeDataDescriptor(31, {}), context.get());
+  fact_manager.AddFactDataSynonym(MakeDataDescriptor(30, {}),
+                                  MakeDataDescriptor(32, {}), context.get());
+
+  fact_manager.AddFactDataSynonym(MakeDataDescriptor(42, {}),
+                                  MakeDataDescriptor(43, {}), context.get());
+  fact_manager.AddFactDataSynonym(MakeDataDescriptor(42, {}),
+                                  MakeDataDescriptor(44, {}), context.get());
+
+  fact_manager.AddFactDataSynonym(MakeDataDescriptor(54, {}),
+                                  MakeDataDescriptor(55, {}), context.get());
+  fact_manager.AddFactDataSynonym(MakeDataDescriptor(54, {}),
+                                  MakeDataDescriptor(56, {}), context.get());
+
+  ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(83, {}),
+                                         MakeDataDescriptor(84, {})));
+  fact_manager.AddFactIdEquation(83, SpvOpBitcast, {42}, context.get());
+  fact_manager.AddFactIdEquation(84, SpvOpBitcast, {43}, context.get());
+  fact_manager.AddFactIdEquation(86, SpvOpBitcast, {44}, context.get());
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(83, {}),
+                                        MakeDataDescriptor(84, {})));
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(83, {}),
+                                        MakeDataDescriptor(86, {})));
+
+  ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(85, {}),
+                                         MakeDataDescriptor(42, {})));
+  fact_manager.AddFactIdEquation(85, SpvOpBitcast, {84}, context.get());
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(85, {}),
+                                        MakeDataDescriptor(42, {})));
+
+  fact_manager.AddFactIdEquation(88, SpvOpBitcast, {80}, context.get());
+  fact_manager.AddFactIdEquation(89, SpvOpBitcast, {81}, context.get());
+  fact_manager.AddFactIdEquation(90, SpvOpBitcast, {82}, context.get());
+  fact_manager.AddFactIdEquation(91, SpvOpBitcast, {89}, context.get());
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(91, {}),
+                                        MakeDataDescriptor(81, {})));
+  ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(91, {}),
+                                         MakeDataDescriptor(80, {})));
+
+  fact_manager.AddFactIdEquation(80, SpvOpBitcast, {83}, context.get());
+  fact_manager.AddFactIdEquation(81, SpvOpBitcast, {84}, context.get());
+  fact_manager.AddFactIdEquation(82, SpvOpBitcast, {86}, context.get());
+  fact_manager.AddFactIdEquation(87, SpvOpBitcast, {82}, context.get());
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(80, {}),
+                                        MakeDataDescriptor(81, {})));
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(80, {}),
+                                        MakeDataDescriptor(82, {})));
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(91, {}),
+                                        MakeDataDescriptor(80, {})));
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(88, {}),
+                                        MakeDataDescriptor(89, {})));
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(88, {}),
+                                        MakeDataDescriptor(90, {})));
+
+  ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(92, {}),
+                                         MakeDataDescriptor(93, {})));
+  ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(92, {}),
+                                         MakeDataDescriptor(94, {})));
+  ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(93, {}),
+                                         MakeDataDescriptor(94, {})));
+  fact_manager.AddFactDataSynonym(MakeDataDescriptor(99, {}),
+                                  MakeDataDescriptor(100, {}), context.get());
+  fact_manager.AddFactDataSynonym(MakeDataDescriptor(99, {}),
+                                  MakeDataDescriptor(101, {}), context.get());
+  fact_manager.AddFactIdEquation(96, SpvOpBitcast, {92}, context.get());
+  fact_manager.AddFactIdEquation(97, SpvOpBitcast, {93}, context.get());
+  fact_manager.AddFactIdEquation(98, SpvOpBitcast, {94}, context.get());
+  ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(96, {}),
+                                         MakeDataDescriptor(97, {})));
+  ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(96, {}),
+                                         MakeDataDescriptor(98, {})));
+  fact_manager.AddFactIdEquation(99, SpvOpBitcast, {92}, context.get());
+  fact_manager.AddFactIdEquation(100, SpvOpBitcast, {93}, context.get());
+  fact_manager.AddFactIdEquation(101, SpvOpBitcast, {94}, context.get());
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(96, {}),
+                                        MakeDataDescriptor(97, {})));
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(96, {}),
+                                        MakeDataDescriptor(98, {})));
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(92, {}),
+                                        MakeDataDescriptor(93, {})));
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(92, {}),
+                                        MakeDataDescriptor(94, {})));
+
+  fact_manager.AddFactIdEquation(102, SpvOpBitcast, {54}, context.get());
+  fact_manager.AddFactIdEquation(103, SpvOpBitcast, {55}, context.get());
+  fact_manager.AddFactIdEquation(104, SpvOpBitcast, {56}, context.get());
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(102, {}),
+                                        MakeDataDescriptor(103, {})));
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(102, {}),
+                                        MakeDataDescriptor(104, {})));
+  ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(102, {}),
+                                         MakeDataDescriptor(99, {})));
+  fact_manager.AddFactDataSynonym(MakeDataDescriptor(54, {}),
+                                  MakeDataDescriptor(96, {}), context.get());
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(102, {}),
+                                        MakeDataDescriptor(99, {})));
+
+  fact_manager.AddFactIdEquation(106, SpvOpBitcast, {93}, context.get());
+  ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(96, {}),
+                                         MakeDataDescriptor(88, {})));
+  fact_manager.AddFactIdEquation(92, SpvOpBitcast, {88}, context.get());
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(96, {}),
+                                        MakeDataDescriptor(88, {})));
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(100, {}),
+                                        MakeDataDescriptor(80, {})));
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(92, {}),
+                                        MakeDataDescriptor(42, {})));
 }
 
 TEST(FactManagerTest, CorollaryConversionFacts) {

--- a/test/fuzz/fact_manager_test.cpp
+++ b/test/fuzz/fact_manager_test.cpp
@@ -783,66 +783,6 @@ TEST(FactManagerTest, RecursiveAdditionOfFacts) {
                                         MakeDataDescriptor(11, {2, 3})));
 }
 
-TEST(FactManagerTest, CorollaryBitcastFacts) {
-  std::string shader = R"(
-               OpCapability Shader
-          %1 = OpExtInstImport "GLSL.std.450"
-               OpMemoryModel Logical GLSL450
-               OpEntryPoint Fragment %12 "main"
-               OpExecutionMode %12 OriginUpperLeft
-               OpSource ESSL 310
-          %2 = OpTypeVoid
-          %3 = OpTypeFunction %2
-          %4 = OpTypeInt 32 1
-          %5 = OpTypeInt 32 0
-          %8 = OpTypeFloat 32
-          %6 = OpConstant %4 23
-          %7 = OpConstant %5 23
-         %12 = OpFunction %2 None %3
-         %13 = OpLabel
-         %14 = OpBitcast %8 %6
-         %15 = OpBitcast %8 %7
-         %16 = OpBitcast %4 %15
-         %17 = OpBitcast %8 %16
-         %18 = OpBitcast %5 %14
-               OpReturn
-               OpFunctionEnd
-  )";
-
-  const auto env = SPV_ENV_UNIVERSAL_1_3;
-  const auto consumer = nullptr;
-  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
-  ASSERT_TRUE(IsValid(env, context.get()));
-
-  FactManager fact_manager;
-
-  fact_manager.AddFactIdEquation(14, SpvOpBitcast, {6}, context.get());
-  fact_manager.AddFactIdEquation(15, SpvOpBitcast, {7}, context.get());
-  ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(6, {}),
-                                         MakeDataDescriptor(7, {})));
-  ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(14, {}),
-                                         MakeDataDescriptor(15, {})));
-  fact_manager.AddFactDataSynonym(MakeDataDescriptor(14, {}),
-                                  MakeDataDescriptor(15, {}), context.get());
-  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(6, {}),
-                                        MakeDataDescriptor(7, {})));
-
-  fact_manager.AddFactIdEquation(17, SpvOpBitcast, {16}, context.get());
-  fact_manager.AddFactIdEquation(18, SpvOpBitcast, {14}, context.get());
-  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(18, {}),
-                                        MakeDataDescriptor(6, {})));
-  ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(17, {}),
-                                         MakeDataDescriptor(14, {})));
-  ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(18, {}),
-                                         MakeDataDescriptor(16, {})));
-  fact_manager.AddFactDataSynonym(MakeDataDescriptor(17, {}),
-                                  MakeDataDescriptor(14, {}), context.get());
-  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(18, {}),
-                                        MakeDataDescriptor(16, {})));
-  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(16, {}),
-                                        MakeDataDescriptor(6, {})));
-}
-
 TEST(FactManagerTest, CorollaryConversionFacts) {
   std::string shader = R"(
                OpCapability Shader
@@ -1214,6 +1154,63 @@ TEST(FactManagerTest, ConversionEquations) {
   fact_manager.AddFactIdEquation(34, SpvOpConvertSToF, {23}, context.get());
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(32, {}),
                                         MakeDataDescriptor(34, {})));
+}
+
+TEST(FactManagerTest, BitcastEquationFacts) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %12 "main"
+               OpExecutionMode %12 OriginUpperLeft
+               OpSource ESSL 310
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %4 = OpTypeInt 32 1
+          %5 = OpTypeInt 32 0
+          %8 = OpTypeFloat 32
+          %9 = OpTypeVector %4 2
+         %10 = OpTypeVector %5 2
+         %11 = OpTypeVector %8 2
+          %6 = OpConstant %4 23
+          %7 = OpConstant %5 23
+         %19 = OpConstant %8 23
+         %20 = OpConstantComposite %9 %6 %6
+         %21 = OpConstantComposite %10 %7 %7
+         %22 = OpConstantComposite %11 %19 %19
+         %12 = OpFunction %2 None %3
+         %13 = OpLabel
+         %30 = OpBitcast %8 %6
+         %31 = OpBitcast %5 %6
+         %32 = OpBitcast %8 %7
+         %33 = OpBitcast %4 %7
+         %34 = OpBitcast %4 %19
+         %35 = OpBitcast %5 %19
+         %36 = OpBitcast %10 %20
+         %37 = OpBitcast %11 %20
+         %38 = OpBitcast %9 %21
+         %39 = OpBitcast %11 %21
+         %40 = OpBitcast %9 %22
+         %41 = OpBitcast %10 %22
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+
+  uint32_t lhs_id = 30;
+  for (uint32_t rhs_id : {6, 6, 7, 7, 19, 19, 20, 20, 21, 21, 22, 22}) {
+    fact_manager.AddFactIdEquation(lhs_id, SpvOpBitcast, {rhs_id},
+                                   context.get());
+    ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(lhs_id, {}),
+                                          MakeDataDescriptor(rhs_id, {})));
+    ++lhs_id;
+  }
 }
 
 TEST(FactManagerTest, EquationAndEquivalenceFacts) {


### PR DESCRIPTION
Splits #3523 in two parts. This part implements functionality to compute corollary facts from `OpBitcast` equation facts.