### PR TITLE
spirv-fuzz: Generalise transformation access chain

### DIFF
--- a/source/fuzz/fuzzer_pass.h
+++ b/source/fuzz/fuzzer_pass.h
@@ -179,7 +179,7 @@ class FuzzerPass {
   // on the |is_irrelevant| parameter.
   uint32_t FindOrCreateIntegerConstant(const std::vector<uint32_t>& words,
                                        uint32_t width, bool is_signed,
-                                       bool is_irrelevant);
+                                       bool is_irrelevant = false);
 
   // Returns the id of an OpConstant instruction, with a floating-point
   // type of width specified by |width|, with |words| as its value.  If either

--- a/source/fuzz/fuzzer_pass.h
+++ b/source/fuzz/fuzzer_pass.h
@@ -175,11 +175,10 @@ class FuzzerPass {
   // with |words| as its value.  If either the required integer type or the
   // constant do not exist, transformations are applied to add them.
   // The returned id either participates in IdIsIrrelevant fact or not,
-  // depending
-  // on the |is_irrelevant| parameter.
+  // depending on the |is_irrelevant| parameter.
   uint32_t FindOrCreateIntegerConstant(const std::vector<uint32_t>& words,
                                        uint32_t width, bool is_signed,
-                                       bool is_irrelevant = false);
+                                       bool is_irrelevant);
 
   // Returns the id of an OpConstant instruction, with a floating-point
   // type of width specified by |width|, with |words| as its value.  If either

--- a/source/fuzz/fuzzer_pass_add_access_chains.cpp
+++ b/source/fuzz/fuzzer_pass_add_access_chains.cpp
@@ -140,9 +140,6 @@ void FuzzerPassAddAccessChains::Apply() {
           uint32_t index_value =
               GetFuzzerContext()->GetRandomIndexForAccessChain(bound);
 
-          index_ids.push_back(FindOrCreateIntegerConstant(
-              {index_value}, 32, GetFuzzerContext()->ChooseEven(), false));
-
           switch (subobject_type->opcode()) {
             case SpvOpTypeArray:
             case SpvOpTypeMatrix:

--- a/source/fuzz/fuzzer_pass_add_access_chains.cpp
+++ b/source/fuzz/fuzzer_pass_add_access_chains.cpp
@@ -154,20 +154,20 @@ void FuzzerPassAddAccessChains::Apply() {
               //   the maximum value for an index
               // - a new pair of fresh ids for the clamping instructions
               FindOrCreateBoolType();
-              FindOrCreateIntegerConstant({bound - 1}, 32, is_signed);
+              FindOrCreateIntegerConstant({bound - 1}, 32, is_signed, false);
               std::pair<uint32_t, uint32_t> fresh_pair_of_ids = {
                   GetFuzzerContext()->GetFreshId(),
                   GetFuzzerContext()->GetFreshId()};
               fresh_ids_for_clamping.emplace_back(fresh_pair_of_ids);
 
-              index_ids.push_back(
-                  FindOrCreateIntegerConstant({index_value}, 32, is_signed));
+              index_ids.push_back(FindOrCreateIntegerConstant(
+                  {index_value}, 32, is_signed, false));
               subobject_type_id = subobject_type->GetSingleWordInOperand(0);
 
             } break;
             case SpvOpTypeStruct:
               index_ids.push_back(FindOrCreateIntegerConstant(
-                  {index_value}, 32, GetFuzzerContext()->ChooseEven()));
+                  {index_value}, 32, GetFuzzerContext()->ChooseEven(), false));
               subobject_type_id =
                   subobject_type->GetSingleWordInOperand(index_value);
               break;

--- a/source/fuzz/fuzzer_pass_add_access_chains.cpp
+++ b/source/fuzz/fuzzer_pass_add_access_chains.cpp
@@ -92,6 +92,11 @@ void FuzzerPassAddAccessChains::Apply() {
             relevant_pointer_instructions[GetFuzzerContext()->RandomIndex(
                 relevant_pointer_instructions)];
         std::vector<uint32_t> index_ids;
+
+        // Each index accessing a non-struct composite will be clamped, thus
+        // needing a pair of fresh ids
+        std::vector<std::pair<uint32_t, uint32_t>> fresh_ids_for_clamping;
+
         auto pointer_type = GetIRContext()->get_def_use_mgr()->GetDef(
             chosen_pointer->type_id());
         uint32_t subobject_type_id = pointer_type->GetSingleWordInOperand(1);
@@ -132,20 +137,24 @@ void FuzzerPassAddAccessChains::Apply() {
             break;
           }
 
-          // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3179) We
-          //  could allow non-constant indices when looking up non-structs,
-          //  using clamping to ensure they are in-bounds.
           uint32_t index_value =
               GetFuzzerContext()->GetRandomIndexForAccessChain(bound);
+
           index_ids.push_back(FindOrCreateIntegerConstant(
               {index_value}, 32, GetFuzzerContext()->ChooseEven(), false));
+
           switch (subobject_type->opcode()) {
             case SpvOpTypeArray:
             case SpvOpTypeMatrix:
             case SpvOpTypeVector:
+              // The index will be clamped
+              index_ids.push_back(FindOrCreateIntegerConstantReadyForClamping(
+                  index_value, bound, &fresh_ids_for_clamping));
               subobject_type_id = subobject_type->GetSingleWordInOperand(0);
               break;
             case SpvOpTypeStruct:
+              index_ids.push_back(FindOrCreateIntegerConstant(
+                  {index_value}, 32, GetFuzzerContext()->ChooseEven()));
               subobject_type_id =
                   subobject_type->GetSingleWordInOperand(index_value);
               break;
@@ -162,8 +171,24 @@ void FuzzerPassAddAccessChains::Apply() {
         // Apply the transformation to add an access chain.
         ApplyTransformation(TransformationAccessChain(
             GetFuzzerContext()->GetFreshId(), chosen_pointer->result_id(),
-            index_ids, instruction_descriptor));
+            index_ids, instruction_descriptor, fresh_ids_for_clamping));
       });
+}
+
+uint32_t FuzzerPassAddAccessChains::FindOrCreateIntegerConstantReadyForClamping(
+    uint32_t value, uint32_t bound,
+    std::vector<std::pair<uint32_t, uint32_t>>* fresh_ids_for_clamping) {
+  // Choose the signedness of the constant
+  bool is_signed = GetFuzzerContext()->ChooseEven();
+
+  // Make the constant ready for clamping
+  FindOrCreateBoolType();
+  FindOrCreateIntegerConstant({bound - 1}, 32, is_signed);
+  std::pair<uint32_t, uint32_t> fresh_pair_of_ids = {
+      GetFuzzerContext()->GetFreshId(), GetFuzzerContext()->GetFreshId()};
+  fresh_ids_for_clamping->emplace_back(fresh_pair_of_ids);
+
+  return FindOrCreateIntegerConstant({value}, 32, is_signed);
 }
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_pass_add_access_chains.h
+++ b/source/fuzz/fuzzer_pass_add_access_chains.h
@@ -33,21 +33,6 @@ class FuzzerPassAddAccessChains : public FuzzerPass {
   ~FuzzerPassAddAccessChains();
 
   void Apply() override;
-
- private:
-  // Returns the id of a 32-bit integer constant of value |value|, which is
-  // randomly chosen to be signed or unsigned. If such constant already exists
-  // in the module, it is found, otherwise a new one is created.
-  // Adds instructions to the module so that clamping can be correctly
-  // performed. In particular, it makes sure (by adding them if not present)
-  // that the module has:
-  // - An OpTypeBool instruction
-  // - An OpConstant of the same type as the one whose id is returned, and value
-  //   |bound| - 1
-  // Adds a pair of fresh ids to |fresh_ids_for_clamping|.
-  uint32_t FindOrCreateIntegerConstantReadyForClamping(
-      uint32_t value, uint32_t bound,
-      std::vector<std::pair<uint32_t, uint32_t>>* fresh_ids_for_clamping);
 };
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_pass_add_access_chains.h
+++ b/source/fuzz/fuzzer_pass_add_access_chains.h
@@ -33,6 +33,21 @@ class FuzzerPassAddAccessChains : public FuzzerPass {
   ~FuzzerPassAddAccessChains();
 
   void Apply() override;
+
+ private:
+  // Returns the id of a 32-bit integer constant of value |value|, which is
+  // randomly chosen to be signed or unsigned. If such constant already exists
+  // in the module, it is found, otherwise a new one is created.
+  // Adds instructions to the module so that clamping can be correctly
+  // performed. In particular, it makes sure (by adding them if not present)
+  // that the module has:
+  // - An OpTypeBool instruction
+  // - An OpConstant of the same type as the one whose id is returned, and value
+  //   |bound| - 1
+  // Adds a pair of fresh ids to |fresh_ids_for_clamping|.
+  uint32_t FindOrCreateIntegerConstantReadyForClamping(
+      uint32_t value, uint32_t bound,
+      std::vector<std::pair<uint32_t, uint32_t>>* fresh_ids_for_clamping);
 };
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_pass_donate_modules.cpp
+++ b/source/fuzz/fuzzer_pass_donate_modules.cpp
@@ -1100,11 +1100,11 @@ void FuzzerPassDonateModules::AddLivesafeFunction(
                      "A runtime array type in the donor should have been "
                      "replaced by a fixed-sized array in the recipient.");
               // The size of this fixed-size array is a suitable bound.
-              bound = TransformationAddFunction::GetBoundForCompositeIndex(
-                  GetIRContext(), *fixed_size_array_type);
+              bound = fuzzerutil::GetBoundForCompositeIndex(
+                  *fixed_size_array_type, GetIRContext());
             } else {
-              bound = TransformationAddFunction::GetBoundForCompositeIndex(
-                  donor_ir_context, *should_be_composite_type);
+              bound = fuzzerutil::GetBoundForCompositeIndex(
+                  *should_be_composite_type, donor_ir_context);
             }
             const uint32_t index_id = inst.GetSingleWordInOperand(index);
             auto index_inst =

--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -1137,7 +1137,8 @@ uint32_t MaybeGetIntegerConstantFromValueAndType(opt::IRContext* ir_context,
                       ->GetType(int_type_inst->result_id())
                       ->AsInteger();
 
-  assert(int_type && "The given type id must correspond to an integer type.");
+  assert(int_type && int_type->width() == 32 &&
+         "The given type id must correspond to an 32-bit integer type.");
 
   opt::analysis::IntConstant constant(int_type, {value});
 

--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -373,6 +373,28 @@ uint32_t GetArraySize(const opt::Instruction& array_type_instruction,
   return array_length_constant->GetU32();
 }
 
+uint32_t GetBoundForCompositeIndex(const opt::Instruction& composite_type_inst,
+                                   opt::IRContext* ir_context) {
+  switch (composite_type_inst.opcode()) {
+    case SpvOpTypeArray:
+      return fuzzerutil::GetArraySize(composite_type_inst, ir_context);
+    case SpvOpTypeMatrix:
+    case SpvOpTypeVector:
+      return composite_type_inst.GetSingleWordInOperand(1);
+    case SpvOpTypeStruct: {
+      return fuzzerutil::GetNumberOfStructMembers(composite_type_inst);
+    }
+    case SpvOpTypeRuntimeArray:
+      assert(false &&
+             "GetBoundForCompositeIndex should not be invoked with an "
+             "OpTypeRuntimeArray, which does not have a static bound.");
+      return 0;
+    default:
+      assert(false && "Unknown composite type.");
+      return 0;
+  }
+}
+
 bool IsValid(opt::IRContext* context, spv_validator_options validator_options) {
   std::vector<uint32_t> binary;
   context->module()->ToBinary(&binary, false);
@@ -1102,6 +1124,31 @@ uint32_t MaybeGetIntegerConstant(
   }
 
   return 0;
+}
+
+uint32_t MaybeGetIntegerConstantFromValueAndType(opt::IRContext* ir_context,
+                                                 uint32_t value,
+                                                 uint32_t int_type_id) {
+  auto int_type_inst = ir_context->get_def_use_mgr()->GetDef(int_type_id);
+
+  assert(int_type_inst && "The given type id must exist.");
+
+  auto int_type = ir_context->get_type_mgr()
+                      ->GetType(int_type_inst->result_id())
+                      ->AsInteger();
+
+  assert(int_type && "The given type id must correspond to an integer type.");
+
+  opt::analysis::IntConstant constant(int_type, {value});
+
+  // Check that the constant exists in the module.
+  if (!ir_context->get_constant_mgr()->FindConstant(&constant)) {
+    return 0;
+  }
+
+  return ir_context->get_constant_mgr()
+      ->GetDefiningInstruction(&constant)
+      ->result_id();
 }
 
 uint32_t MaybeGetFloatConstant(

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -401,10 +401,10 @@ uint32_t MaybeGetIntegerConstant(
     const std::vector<uint32_t>& words, uint32_t width, bool is_signed,
     bool is_irrelevant);
 
-// Returns the id of an integer constant in the module with type |int_type_id|
-// and value |value|, or 0 if no such constant exists in the module.
-// |int_type_id| must exist in the module and it must correspond to an integer
-// type.
+// Returns the id of a 32-bit integer constant in the module with type
+// |int_type_id| and value |value|, or 0 if no such constant exists in the
+// module. |int_type_id| must exist in the module and it must correspond to a
+// 32-bit integer type.
 uint32_t MaybeGetIntegerConstantFromValueAndType(opt::IRContext* ir_context,
                                                  uint32_t value,
                                                  uint32_t int_type_id);

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -141,6 +141,13 @@ uint32_t GetNumberOfStructMembers(
 uint32_t GetArraySize(const opt::Instruction& array_type_instruction,
                       opt::IRContext* context);
 
+// Returns the bound for indexing into a composite of type
+// |composite_type_inst|, i.e. the number of fields of a struct, the size of an
+// array, the number of components of a vector, or the number of columns of a
+// matrix. |composite_type_inst| must be the type of a composite.
+uint32_t GetBoundForCompositeIndex(const opt::Instruction& composite_type_inst,
+                                   opt::IRContext* ir_context);
+
 // Returns true if and only if |context| is valid, according to the validator
 // instantiated with |validator_options|.
 bool IsValid(opt::IRContext* context, spv_validator_options validator_options);
@@ -393,6 +400,14 @@ uint32_t MaybeGetIntegerConstant(
     const TransformationContext& transformation_context,
     const std::vector<uint32_t>& words, uint32_t width, bool is_signed,
     bool is_irrelevant);
+
+// Returns the id of an integer constant in the module with type |int_type_id|
+// and value |value|, or 0 if no such constant exists in the module.
+// |int_type_id| must exist in the module and it must correspond to an integer
+// type.
+uint32_t MaybeGetIntegerConstantFromValueAndType(opt::IRContext* ir_context,
+                                                 uint32_t value,
+                                                 uint32_t int_type_id);
 
 // Returns the result id of an OpConstant instruction of floating-point type.
 // Returns 0 if no such instruction or type is present in the module.

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -429,6 +429,9 @@ message TransformationAccessChain {
   // OpAccessChain instruction should be inserted
   InstructionDescriptor instruction_to_insert_before = 4;
 
+  // Additional fresh ids, required to clamp index variables
+  repeated uint32 fresh_id_for_clamping = 5;
+
 }
 
 message TransformationAddConstantBoolean {

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -430,7 +430,7 @@ message TransformationAccessChain {
   InstructionDescriptor instruction_to_insert_before = 4;
 
   // Additional fresh ids, required to clamp index variables
-  repeated uint32 fresh_id_for_clamping = 5;
+  repeated UInt32Pair fresh_ids_for_clamping = 5;
 
 }
 

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -423,7 +423,6 @@ message TransformationAccessChain {
   // %t1 = OpULessThanEqual %bool %index %bound_minus_one
   // %t2 = OpSelect %int_type %t1 %index %bound_minus_one
 
-
   // Result id for the access chain
   uint32 fresh_id = 1;
 

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -416,6 +416,14 @@ message TransformationAccessChain {
 
   // Adds an access chain instruction based on a given pointer and indices.
 
+  // When accessing a struct, the corresponding indices must be 32-bit integer constants.
+  // For any other composite, the indices can be any 32-bit integer, and the transformation
+  // adds two instructions for each such index to clamp it to the bound, as follows:
+  //
+  // %t1 = OpULessThanEqual %bool %index %bound_minus_one
+  // %t2 = OpSelect %int_type %t1 %index %bound_minus_one
+
+
   // Result id for the access chain
   uint32 fresh_id = 1;
 
@@ -429,7 +437,8 @@ message TransformationAccessChain {
   // OpAccessChain instruction should be inserted
   InstructionDescriptor instruction_to_insert_before = 4;
 
-  // Additional fresh ids, required to clamp index variables
+  // Additional fresh ids, required to clamp index variables. A pair is needed
+  // for each access to a non-struct composite.
   repeated UInt32Pair fresh_ids_for_clamping = 5;
 
 }

--- a/source/fuzz/transformation_access_chain.cpp
+++ b/source/fuzz/transformation_access_chain.cpp
@@ -138,21 +138,18 @@ bool TransformationAccessChain::IsApplicable(
       // Get two new ids to use and update the amount used.
       protobufs::UInt32Pair pair =
           message_.fresh_ids_for_clamping()[id_pairs_used++];
-      std::pair<uint32_t, uint32_t> fresh_ids;
-      fresh_ids.first = pair.first();
-      fresh_ids.second = pair.second();
 
       // Check that the ids are actually fresh and not already used by this
       // transformation.
       if (!CheckIdIsFreshAndNotUsedByThisTransformation(
-              fresh_ids.first, ir_context, &fresh_ids_used) ||
+              pair.first(), ir_context, &fresh_ids_used) ||
           !CheckIdIsFreshAndNotUsedByThisTransformation(
-              fresh_ids.second, ir_context, &fresh_ids_used)) {
+              pair.second(), ir_context, &fresh_ids_used)) {
         return false;
       }
 
       if (!CreateAndGetClampedIndexId(ir_context, index_id, subobject_type_id,
-                                      false, fresh_ids)
+                                      false, {pair.first(), pair.second()})
                .first) {
         return false;
       }

--- a/source/fuzz/transformation_access_chain.cpp
+++ b/source/fuzz/transformation_access_chain.cpp
@@ -192,6 +192,12 @@ bool TransformationAccessChain::IsApplicable(
       fresh_ids.first = pair.first();
       fresh_ids.second = pair.second();
 
+      // Check that the ids are actually fresh
+      if (!fuzzerutil::IsFreshId(ir_context, fresh_ids.first) ||
+          !fuzzerutil::IsFreshId(ir_context, fresh_ids.second)) {
+        return false;
+      }
+
       if (!GetIndexValueOrId(ir_context, index_id, subobject_type_id, false,
                              fresh_ids)
                .first) {

--- a/source/fuzz/transformation_access_chain.cpp
+++ b/source/fuzz/transformation_access_chain.cpp
@@ -294,8 +294,9 @@ std::tuple<bool, uint32_t, uint32_t>
 TransformationAccessChain::GetIndexValueAndId(
     opt::IRContext* ir_context, uint32_t index_id, uint32_t object_type_id,
     bool add_clamping_instructions, std::vector<uint32_t> fresh_ids) const {
+  auto object_type_def = ir_context->get_def_use_mgr()->GetDef(object_type_id);
   // The object being indexed must be a composite
-  if (!spvOpcodeIsComposite(static_cast<SpvOp>(object_type_id))) {
+  if (!spvOpcodeIsComposite(object_type_def->opcode())) {
     return {false, 0, 0};
   }
 
@@ -332,12 +333,14 @@ TransformationAccessChain::GetIndexValueAndId(
       // Constant with value bound-1 not found
       return {false, 0, 0};
     }
+
+    return {true, bound - 1, bound_minus_one_id};
   }
 
   // The index is not a constant
 
   // Structs can only be accessed via constants
-  if (object_type_id == SpvOpTypeStruct) {
+  if (object_type_def->opcode() == SpvOpTypeStruct) {
     return {false, 0, 0};
   }
 

--- a/source/fuzz/transformation_access_chain.cpp
+++ b/source/fuzz/transformation_access_chain.cpp
@@ -325,7 +325,12 @@ TransformationAccessChain::GetIndexValueAndId(
       return {true, value, index_id};
     }
 
-    // The constant is out of bound. We need to use a constant with value
+    // Indices for structs must be in-bound constants
+    if (object_type_def->opcode() == SpvOpTypeStruct) {
+      return {false, 0, 0};
+    }
+
+    // The constant is out of bounds. We need to use a constant with value
     // bound-1
     uint32_t bound_minus_one_id =
         FindIntConstant(ir_context, bound - 1, index_instruction->type_id());

--- a/source/fuzz/transformation_access_chain.h
+++ b/source/fuzz/transformation_access_chain.h
@@ -34,8 +34,8 @@ class TransformationAccessChain : public Transformation {
       uint32_t fresh_id, uint32_t pointer_id,
       const std::vector<uint32_t>& index_id,
       const protobufs::InstructionDescriptor& instruction_to_insert_before,
-      const std::vector<uint32_t>& fresh_id_for_clamping =
-          std::vector<uint32_t>());
+      const std::vector<std::pair<uint32_t, uint32_t>>& fresh_ids_for_clamping =
+          {});
 
   // - |message_.fresh_id| must be fresh
   // - |message_.instruction_to_insert_before| must identify an instruction

--- a/source/fuzz/transformation_access_chain.h
+++ b/source/fuzz/transformation_access_chain.h
@@ -79,24 +79,24 @@ class TransformationAccessChain : public Transformation {
   protobufs::Transformation ToMessage() const override;
 
  private:
-  // Returns {false, 0, 0} if:
+  // Returns {false, 0} if:
   // - |index_id| does not correspond to a 32-bit integer
   // - the object being indexed is not a composite type
-  // - the object type is a struct and the index is not a constant
-  // - the object being indexed is not a composite type
+  // - the object type is a struct and the index is not a constant or
+  //   the index is out of bounds
   // - it is not possible to clamp the index variable to the bound
-  // Returns {true, value, new_id} otherwise, where:
-  // - value is the value of the index if it is a constant, 0 otherwise
-  // - new_id is the id at which the index for addressing the composite can
-  //   be found: it will be the same as |index_id| if the index is a constant,
-  //   otherwise it is the index of the newly-defined clamped index variable
+  // Otherwise, returns:
+  // - {true, value} if the object being indexed is a struct (and the index
+  //   is thus a constant), where value is the value of the constant
+  // - {true, clamped_id} if the object being indexed is not a struct, where
+  //   clamped_id is the id at which to find the clamped index id
   // This method only modifies the module if add_clamping_instructions is true.
-  // |fresh_ids| contains the fresh ids needed for clamping, but it can be
-  // if clamping is not needed.
-  std::tuple<bool, uint32_t, uint32_t> GetIndexValueAndId(
+  // |fresh_ids| contains the fresh ids needed for clamping, and it is ignored
+  // if clamping is not needed (i.e. the object is a struct).
+  std::pair<bool, uint32_t> GetIndexValueOrId(
       opt::IRContext* ir_context, uint32_t index_id, uint32_t object_type_id,
-      bool add_clamping_instructions,
-      std::vector<uint32_t> fresh_ids = std::vector<uint32_t>()) const;
+      bool add_clamping_instructions = false,
+      std::pair<uint32_t, uint32_t> fresh_ids = {0, 0}) const;
 
   // Try to clamp the integer variable defined by |int_inst| so that the
   // result is smaller than the given bound. The |fresh_ids| are used to

--- a/source/fuzz/transformation_access_chain.h
+++ b/source/fuzz/transformation_access_chain.h
@@ -47,6 +47,15 @@ class TransformationAccessChain : public Transformation {
   // - |message_.index_id| must be a sequence of ids of 32-bit integer constants
   //   such that it is possible to walk the pointee type of
   //   |message_.pointer_id| using these indices, remaining in-bounds.
+  // - The indices can be non-constant if the pointee type of
+  //   |message_.pointer_id| is not a struct. In this case, enough fresh ids
+  //   must be given in |message_.fresh_id_for_clamping| to perform clamping
+  //   (2 ids for each non-constant index are required). This requires the
+  //   bool type and a constant of value (bound - 1) to be declared in the
+  //   module.
+  // - The index can be an out-of-bound constant if the pointee type of
+  //   |message_.pointer_id| is not a struct and a constant with the same type
+  //   id and value (bound-1) can be found in the module.
   // - If type t is the final type reached by walking these indices, the module
   //   must include an instruction "OpTypePointer SC %t" where SC is the storage
   //   class associated with |message_.pointer_id|
@@ -60,6 +69,9 @@ class TransformationAccessChain : public Transformation {
   // type reached by walking the pointee type of |message_.pointer_id| using
   // the indices in |message_.index_id|, and with the same storage class as
   // |message_.pointer_id|.
+  //
+  // If some of the indices do not correspond to constants, instructions to
+  // clamp them are added just before the OpAccessChain instruction.
   //
   // If the fact manager in |transformation_context| reports that
   // |message_.pointer_id| has an irrelevant pointee value, then the fact that

--- a/source/fuzz/transformation_access_chain.h
+++ b/source/fuzz/transformation_access_chain.h
@@ -48,13 +48,10 @@ class TransformationAccessChain : public Transformation {
   //   |message_.pointer_id| using these indices.
   // - All indices used to access a struct must be OpConstant.
   // - The indices used to index non-struct composites will be clamped to be
-  //   in bound. Enough pairs of fresh ids must be given in
-  //   |message_.fresh_id_for_clamping| to perform clamping (one pair for
+  //   in bound. Enough fresh ids must be given in
+  //   |message_.fresh_id_for_clamping| to perform clamping (2 for
   //   each index accessing a non-struct). This requires the bool type and
   //   a constant of value (bound - 1) to be declared in the module.
-  // - The index can be an out-of-bound constant if the pointee type of
-  //   |message_.pointer_id| is not a struct and a constant with the same type
-  //   id and value (bound-1) can be found in the module.
   // - If type t is the final type reached by walking these indices, the module
   //   must include an instruction "OpTypePointer SC %t" where SC is the storage
   //   class associated with |message_.pointer_id|

--- a/source/fuzz/transformation_access_chain.h
+++ b/source/fuzz/transformation_access_chain.h
@@ -95,20 +95,6 @@ class TransformationAccessChain : public Transformation {
   static bool ValidIndexToComposite(opt::IRContext* ir_context,
                                     uint32_t index_id, uint32_t object_type_id);
 
-  // Tries to clamp the integer defined by |int_inst| so that the result is
-  // smaller than the given bound. The |fresh_ids| are used for the new
-  // instructions necessary to perform such operations.
-  // If |add_clamping_instructions| is true, these new instructions are inserted
-  // just before |message_.instruction_to_insert_before|.
-  // If |add_clamping_instructions| is false, the module is not changed (so no
-  // instructions are added).
-  // Returns false if a constant with value |bound|-1 is not found in the
-  // module or if the bool type is not found in the module, true otherwise.
-  bool TryToClampInteger(opt::IRContext* ir_context,
-                         const opt::Instruction& int_inst, uint32_t bound,
-                         std::pair<uint32_t, uint32_t> fresh_ids,
-                         bool add_clamping_instructions) const;
-
   protobufs::TransformationAccessChain message_;
 };
 

--- a/source/fuzz/transformation_access_chain.h
+++ b/source/fuzz/transformation_access_chain.h
@@ -34,25 +34,24 @@ class TransformationAccessChain : public Transformation {
       uint32_t fresh_id, uint32_t pointer_id,
       const std::vector<uint32_t>& index_id,
       const protobufs::InstructionDescriptor& instruction_to_insert_before,
-      const std::vector<uint32_t>& fresh_id_for_clamping = std::vector<uint32_t>()
-      );
+      const std::vector<uint32_t>& fresh_id_for_clamping =
+          std::vector<uint32_t>());
 
-  // TODO: Update
   // - |message_.fresh_id| must be fresh
   // - |message_.instruction_to_insert_before| must identify an instruction
   //   before which it is legitimate to insert an OpAccessChain instruction
   // - |message_.pointer_id| must be a result id with pointer type that is
   //   available (according to dominance rules) at the insertion point.
   // - The pointer must not be OpConstantNull or OpUndef
-  // - |message_.index_id| must be a sequence of ids of 32-bit integer constants
+  // - |message_.index_id| must be a sequence of ids of 32-bit integers
   //   such that it is possible to walk the pointee type of
-  //   |message_.pointer_id| using these indices, remaining in-bounds.
-  // - The indices can be non-constant if the pointee type of
-  //   |message_.pointer_id| is not a struct. In this case, enough fresh ids
-  //   must be given in |message_.fresh_id_for_clamping| to perform clamping
-  //   (2 ids for each non-constant index are required). This requires the
-  //   bool type and a constant of value (bound - 1) to be declared in the
-  //   module.
+  //   |message_.pointer_id| using these indices.
+  // - All indices used to access a struct must be OpConstant.
+  // - The indices used to index non-struct composites will be clamped to be
+  //   in bound. Enough pairs of fresh ids must be given in
+  //   |message_.fresh_id_for_clamping| to perform clamping (one pair for
+  //   each index accessing a non-struct). This requires the bool type and
+  //   a constant of value (bound - 1) to be declared in the module.
   // - The index can be an out-of-bound constant if the pointee type of
   //   |message_.pointer_id| is not a struct and a constant with the same type
   //   id and value (bound-1) can be found in the module.
@@ -70,8 +69,8 @@ class TransformationAccessChain : public Transformation {
   // the indices in |message_.index_id|, and with the same storage class as
   // |message_.pointer_id|.
   //
-  // If some of the indices do not correspond to constants, instructions to
-  // clamp them are added just before the OpAccessChain instruction.
+  // For each of the indices traversing non-struct composites, two clamping
+  // instructions are added using ids in |message_.fresh_id_for_clamping|
   //
   // If the fact manager in |transformation_context| reports that
   // |message_.pointer_id| has an irrelevant pointee value, then the fact that

--- a/source/fuzz/transformation_access_chain.h
+++ b/source/fuzz/transformation_access_chain.h
@@ -89,25 +89,6 @@ class TransformationAccessChain : public Transformation {
                                           uint32_t index_id,
                                           uint32_t object_type_id) const;
 
-  // Returns {false, 0} in each of the following cases:
-  // - |index_id| does not correspond to a 32-bit integer
-  // - the object being indexed is not a composite
-  // - the object being indexed is a struct
-  // - it is not possible to clamp the index to the bound
-  // Otherwise, returns {true, clamped_id}, where clamped_id is the id at which
-  // to find the clamped index id.
-  // Clamping an index to the bound requires:
-  // - a valid pair of fresh ids for the clamping instructions
-  // - The presence of OpTypeBool in the module
-  // - The presence of an integer OpConstant of the same type as the index,
-  //   with the value being the bound - 1.
-  // This method only modifies the module if add_clamping_instructions is true.
-  // |fresh_ids| contains the pair of fresh ids needed for clamping.
-  std::pair<bool, uint32_t> CreateAndGetClampedIndexId(
-      opt::IRContext* ir_context, uint32_t index_id, uint32_t object_type_id,
-      bool add_clamping_instructions,
-      std::pair<uint32_t, uint32_t> fresh_ids) const;
-
   // Returns true if |index_id| corresponds, in the given context, to a 32-bit
   // integer which can be used to index an object of the type specified by
   // |object_type_id|. Returns false otherwise.

--- a/source/fuzz/transformation_add_function.cpp
+++ b/source/fuzz/transformation_add_function.cpp
@@ -794,8 +794,8 @@ bool TransformationAddFunction::TryToClampAccessChainIndices(
 
     // Get the bound for the composite being indexed into; e.g. the number of
     // columns of matrix or the size of an array.
-    uint32_t bound =
-        GetBoundForCompositeIndex(ir_context, *should_be_composite_type);
+    uint32_t bound = fuzzerutil::GetBoundForCompositeIndex(
+        *should_be_composite_type, ir_context);
 
     // Get the instruction associated with the index and figure out its integer
     // type.
@@ -871,28 +871,6 @@ bool TransformationAddFunction::TryToClampAccessChainIndices(
         FollowCompositeIndex(ir_context, *should_be_composite_type, index_id);
   }
   return true;
-}
-
-uint32_t TransformationAddFunction::GetBoundForCompositeIndex(
-    opt::IRContext* ir_context, const opt::Instruction& composite_type_inst) {
-  switch (composite_type_inst.opcode()) {
-    case SpvOpTypeArray:
-      return fuzzerutil::GetArraySize(composite_type_inst, ir_context);
-    case SpvOpTypeMatrix:
-    case SpvOpTypeVector:
-      return composite_type_inst.GetSingleWordInOperand(1);
-    case SpvOpTypeStruct: {
-      return fuzzerutil::GetNumberOfStructMembers(composite_type_inst);
-    }
-    case SpvOpTypeRuntimeArray:
-      assert(false &&
-             "GetBoundForCompositeIndex should not be invoked with an "
-             "OpTypeRuntimeArray, which does not have a static bound.");
-      return 0;
-    default:
-      assert(false && "Unknown composite type.");
-      return 0;
-  }
 }
 
 opt::Instruction* TransformationAddFunction::FollowCompositeIndex(

--- a/source/fuzz/transformation_add_function.h
+++ b/source/fuzz/transformation_add_function.h
@@ -58,13 +58,6 @@ class TransformationAddFunction : public Transformation {
 
   protobufs::Transformation ToMessage() const override;
 
-  // Helper method that returns the bound for indexing into a composite of type
-  // |composite_type_inst|, i.e. the number of fields of a struct, the size of
-  // an array, the number of components of a vector, or the number of columns of
-  // a matrix.
-  static uint32_t GetBoundForCompositeIndex(
-      opt::IRContext* ir_context, const opt::Instruction& composite_type_inst);
-
   // Helper method that, given composite type |composite_type_inst|, returns the
   // type of the sub-object at index |index_id|, which is required to be in-
   // bounds.

--- a/test/fuzz/transformation_access_chain_test.cpp
+++ b/test/fuzz/transformation_access_chain_test.cpp
@@ -162,10 +162,11 @@ TEST(TransformationAccessChainTest, BasicTest) {
           .IsApplicable(context.get(), transformation_context));
 
   // Bad: index id is out of bounds
-  ASSERT_FALSE(
-      TransformationAccessChain(100, 43, {80, 83},
-                                MakeInstructionDescriptor(24, SpvOpLoad, 0))
-          .IsApplicable(context.get(), transformation_context));
+  // TODO: Should this be allowed now?
+  //  ASSERT_FALSE(
+  //      TransformationAccessChain(100, 43, {80, 83},
+  //                                MakeInstructionDescriptor(24, SpvOpLoad, 0))
+  //          .IsApplicable(context.get(), transformation_context));
 
   // Bad: attempt to insert before variable
   ASSERT_FALSE(TransformationAccessChain(

--- a/test/fuzz/transformation_access_chain_test.cpp
+++ b/test/fuzz/transformation_access_chain_test.cpp
@@ -460,8 +460,8 @@ TEST(TransformationAccessChainTest, ClampingVariables) {
                OpExecutionMode %2 OriginUpperLeft
                OpSource ESSL 310
           %4 = OpTypeVoid
-          %5 = OpTypeFunction %4
-          %6 = OpTypeBool
+          %5 = OpTypeBool
+          %6 = OpTypeFunction %4
           %7 = OpTypeInt 32 1
           %8 = OpTypeVector %7 4
           %9 = OpTypePointer Function %8
@@ -469,24 +469,42 @@ TEST(TransformationAccessChainTest, ClampingVariables) {
          %11 = OpConstant %7 1
          %12 = OpConstant %7 3
          %13 = OpConstant %7 2
-         %14 = OpConstant %7 10
-         %15 = OpConstantComposite %8 %10 %11 %12 %13
-         %16 = OpTypePointer Function %7
-         %17 = OpTypeInt 32 0
-         %18 = OpConstant %17 1
-         %19 = OpTypeFloat 32
-         %20 = OpTypeVector %19 4
-         %21 = OpTypePointer Output %20
-          %3 = OpVariable %21 Output
-          %2 = OpFunction %4 None %5
-         %22 = OpLabel
-         %23 = OpVariable %9 Function
-         %24 = OpVariable %16 Function
-         %25 = OpVariable %16 Function
-               OpStore %23 %15
-               OpStore %24 %10
-         %26 = OpLoad %7 %24
-         %27 = OpAccessChain %16 %23 %26
+         %14 = OpConstantComposite %8 %10 %11 %12 %13
+         %15 = OpTypePointer Function %7
+         %16 = OpTypeInt 32 0
+         %17 = OpConstant %16 1
+         %18 = OpConstant %16 3
+         %19 = OpTypeStruct %8
+         %20 = OpTypePointer Function %19
+         %21 = OpConstant %16 9
+         %22 = OpConstant %16 10
+         %23 = OpTypeArray %19 %22
+         %24 = OpTypePointer Function %23
+         %25 = OpTypeFloat 32
+         %26 = OpTypeVector %25 4
+         %27 = OpTypePointer Output %26
+          %3 = OpVariable %27 Output
+          %2 = OpFunction %4 None %6
+         %28 = OpLabel
+         %29 = OpVariable %9 Function
+         %30 = OpVariable %15 Function
+         %31 = OpVariable %15 Function
+         %32 = OpVariable %20 Function
+         %33 = OpVariable %15 Function
+         %34 = OpVariable %24 Function
+               OpStore %29 %14
+               OpStore %30 %10
+         %36 = OpLoad %7 %30
+         %38 = OpLoad %8 %29
+         %39 = OpCompositeConstruct %19 %38
+         %40 = OpLoad %7 %30
+         %41 = OpAccessChain %15 %32 %10 %40
+         %42 = OpLoad %8 %29
+         %43 = OpCompositeConstruct %19 %42
+         %44 = OpAccessChain %20 %34 %11
+         %45 = OpLoad %7 %30
+         %46 = OpLoad %7 %33
+         %47 = OpAccessChain %15 %34 %45 %10 %46
                OpReturn
                OpFunctionEnd
   )";
@@ -502,10 +520,19 @@ TEST(TransformationAccessChainTest, ClampingVariables) {
                                                validator_options);
 
   {
-    // The out of bounds constant index is clamped to be in-bound
     TransformationAccessChain transformation(
-        100, 23, {14}, MakeInstructionDescriptor(26, SpvOpReturn, 0),
+        100, 29, {17}, MakeInstructionDescriptor(36, SpvOpLoad, 0),
         {{200, 201}});
+    ASSERT_TRUE(
+        transformation.IsApplicable(context.get(), transformation_context));
+    transformation.Apply(context.get(), &transformation_context);
+    ASSERT_TRUE(IsValid(env, context.get()));
+  }
+
+  {
+    TransformationAccessChain transformation(
+        101, 29, {36}, MakeInstructionDescriptor(38, SpvOpLoad, 0),
+        {{202, 203}});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
     transformation.Apply(context.get(), &transformation_context);
@@ -520,8 +547,8 @@ TEST(TransformationAccessChainTest, ClampingVariables) {
                OpExecutionMode %2 OriginUpperLeft
                OpSource ESSL 310
           %4 = OpTypeVoid
-          %5 = OpTypeFunction %4
-          %6 = OpTypeBool
+          %5 = OpTypeBool
+          %6 = OpTypeFunction %4
           %7 = OpTypeInt 32 1
           %8 = OpTypeVector %7 4
           %9 = OpTypePointer Function %8
@@ -529,27 +556,48 @@ TEST(TransformationAccessChainTest, ClampingVariables) {
          %11 = OpConstant %7 1
          %12 = OpConstant %7 3
          %13 = OpConstant %7 2
-         %14 = OpConstant %7 10
-         %15 = OpConstantComposite %8 %10 %11 %12 %13
-         %16 = OpTypePointer Function %7
-         %17 = OpTypeInt 32 0
-         %18 = OpConstant %17 1
-         %19 = OpTypeFloat 32
-         %20 = OpTypeVector %19 4
-         %21 = OpTypePointer Output %20
-          %3 = OpVariable %21 Output
-          %2 = OpFunction %4 None %5
-         %22 = OpLabel
-         %23 = OpVariable %9 Function
-         %24 = OpVariable %16 Function
-         %25 = OpVariable %16 Function
-               OpStore %23 %15
-               OpStore %24 %10
-         %26 = OpLoad %7 %24
-         %27 = OpAccessChain %16 %23 %26
-        %200 = OpULessThanEqual %6 %14 %12
-        %201 = OpSelect %7 %200 %14 %12
-        %100 = OpAccessChain %16 %23 %201
+         %14 = OpConstantComposite %8 %10 %11 %12 %13
+         %15 = OpTypePointer Function %7
+         %16 = OpTypeInt 32 0
+         %17 = OpConstant %16 1
+         %18 = OpConstant %16 3
+         %19 = OpTypeStruct %8
+         %20 = OpTypePointer Function %19
+         %21 = OpConstant %16 9
+         %22 = OpConstant %16 10
+         %23 = OpTypeArray %19 %22
+         %24 = OpTypePointer Function %23
+         %25 = OpTypeFloat 32
+         %26 = OpTypeVector %25 4
+         %27 = OpTypePointer Output %26
+          %3 = OpVariable %27 Output
+          %2 = OpFunction %4 None %6
+         %28 = OpLabel
+         %29 = OpVariable %9 Function
+         %30 = OpVariable %15 Function
+         %31 = OpVariable %15 Function
+         %32 = OpVariable %20 Function
+         %33 = OpVariable %15 Function
+         %34 = OpVariable %24 Function
+               OpStore %29 %14
+               OpStore %30 %10
+        %200 = OpULessThanEqual %5 %17 %18
+        %201 = OpSelect %16 %200 %17 %18
+        %100 = OpAccessChain %15 %29 %201
+         %36 = OpLoad %7 %30
+        %202 = OpULessThanEqual %5 %36 %12
+        %203 = OpSelect %7 %202 %36 %12
+        %101 = OpAccessChain %15 %29 %203
+         %38 = OpLoad %8 %29
+         %39 = OpCompositeConstruct %19 %38
+         %40 = OpLoad %7 %30
+         %41 = OpAccessChain %15 %32 %10 %40
+         %42 = OpLoad %8 %29
+         %43 = OpCompositeConstruct %19 %42
+         %44 = OpAccessChain %20 %34 %11
+         %45 = OpLoad %7 %30
+         %46 = OpLoad %7 %33
+         %47 = OpAccessChain %15 %34 %45 %10 %46
                OpReturn
                OpFunctionEnd
   )";

--- a/test/fuzz/transformation_access_chain_test.cpp
+++ b/test/fuzz/transformation_access_chain_test.cpp
@@ -456,25 +456,99 @@ TEST(TransformationAccessChainTest, IsomorphicStructs) {
   }
 
   std::string after_transformation = R"(
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 8
+; Bound: 49
+; Schema: 0
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
-               OpEntryPoint Fragment %4 "main" %11 %12
+               OpEntryPoint Fragment %4 "main" %48
                OpExecutionMode %4 OriginUpperLeft
                OpSource ESSL 310
+               OpName %4 "main"
+               OpName %9 "x"
+               OpName %16 "index"
+               OpName %17 "a"
+               OpName %25 "A"
+               OpMemberName %25 0 "x"
+               OpName %27 "str"
+               OpName %33 "index2"
+               OpName %37 "vars"
+               OpName %48 "color"
+               OpDecorate %9 RelaxedPrecision
+               OpDecorate %16 RelaxedPrecision
+               OpDecorate %17 RelaxedPrecision
+               OpDecorate %21 RelaxedPrecision
+               OpDecorate %22 RelaxedPrecision
+               OpDecorate %24 RelaxedPrecision
+               OpMemberDecorate %25 0 RelaxedPrecision
+               OpDecorate %28 RelaxedPrecision
+               OpDecorate %30 RelaxedPrecision
+               OpDecorate %32 RelaxedPrecision
+               OpDecorate %33 RelaxedPrecision
+               OpDecorate %38 RelaxedPrecision
+               OpDecorate %41 RelaxedPrecision
+               OpDecorate %42 RelaxedPrecision
+               OpDecorate %44 RelaxedPrecision
+               OpDecorate %48 Location 0
           %2 = OpTypeVoid
           %3 = OpTypeFunction %2
-          %6 = OpTypeFloat 32
-          %7 = OpTypeStruct %6
-          %8 = OpTypePointer Private %7
-          %9 = OpTypeStruct %6
-         %10 = OpTypePointer Private %9
-         %11 = OpVariable %8 Private
-         %12 = OpVariable %10 Private
+          %6 = OpTypeInt 32 1
+          %7 = OpTypeVector %6 4
+          %8 = OpTypePointer Function %7
+         %10 = OpConstant %6 0
+         %11 = OpConstant %6 1
+         %12 = OpConstant %6 3
+         %13 = OpConstant %6 2
+         %14 = OpConstantComposite %7 %10 %11 %12 %13
+         %15 = OpTypePointer Function %6
+         %18 = OpTypeInt 32 0
+         %19 = OpConstant %18 1
+         %25 = OpTypeStruct %7
+         %26 = OpTypePointer Function %25
+         %34 = OpConstant %18 10
+         %35 = OpTypeArray %25 %34
+         %36 = OpTypePointer Function %35
+         %45 = OpTypeFloat 32
+         %46 = OpTypeVector %45 4
+         %47 = OpTypePointer Output %46
+         %48 = OpVariable %47 Output
           %4 = OpFunction %2 None %3
           %5 = OpLabel
-        %100 = OpAccessChain %8 %11
-        %101 = OpAccessChain %10 %12
+          %9 = OpVariable %8 Function
+         %16 = OpVariable %15 Function
+         %17 = OpVariable %15 Function
+         %27 = OpVariable %26 Function
+         %33 = OpVariable %15 Function
+         %37 = OpVariable %36 Function
+               OpStore %9 %14
+               OpStore %16 %10
+         %20 = OpAccessChain %15 %9 %19
+         %21 = OpLoad %6 %20
+               OpStore %17 %21
+         %22 = OpLoad %6 %16
+         %23 = OpAccessChain %15 %9 %22
+         %24 = OpLoad %6 %23
+               OpStore %17 %24
+         %28 = OpLoad %7 %9
+         %29 = OpCompositeConstruct %25 %28
+               OpStore %27 %29
+         %30 = OpLoad %6 %16
+         %31 = OpAccessChain %15 %27 %10 %30
+         %32 = OpLoad %6 %31
+               OpStore %17 %32
+               OpStore %33 %11
+         %38 = OpLoad %7 %9
+         %39 = OpCompositeConstruct %25 %38
+         %40 = OpAccessChain %26 %37 %11
+               OpStore %40 %39
+         %41 = OpLoad %6 %16
+         %42 = OpLoad %6 %33
+         %43 = OpAccessChain %15 %37 %41 %10 %42
+         %44 = OpLoad %6 %43
+               OpStore %17 %44
                OpReturn
                OpFunctionEnd
   )";
@@ -486,36 +560,37 @@ TEST(TransformationAccessChainTest, ClampingVariables) {
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
-               OpEntryPoint Fragment %2 "main" %4
+               OpEntryPoint Fragment %2 "main" %3
                OpExecutionMode %2 OriginUpperLeft
                OpSource ESSL 310
-          %9 = OpTypeVoid
-          %3 = OpTypeFunction %9
-         %10 = OpTypeInt 32 1
-         %11 = OpTypeVector %10 4
-         %12 = OpTypePointer Function %11
-         %13 = OpConstant %10 0
-         %15 = OpConstant %10 1
-         %16 = OpConstant %10 3
-         %17 = OpConstant %10 2
-         %18 = OpConstant %10 10
-         %14 = OpConstantComposite %11 %13 %15 %16 %17
-         %19 = OpTypePointer Function %10
-         %21 = OpTypeInt 32 0
-         %24 = OpConstant %21 1
-         %25 = OpTypeFloat 32
-         %26 = OpTypeVector %25 4
-         %27 = OpTypePointer Output %26
-          %4 = OpVariable %27 Output
-          %2 = OpFunction %9 None %3
-          %5 = OpLabel
-          %6 = OpVariable %12 Function
-          %7 = OpVariable %19 Function
-          %8 = OpVariable %19 Function
-               OpStore %6 %14
-               OpStore %7 %13
-         %22 = OpLoad %10 %7
-         %23 = OpAccessChain %19 %6 %22
+          %4 = OpTypeVoid
+          %5 = OpTypeFunction %4
+          %6 = OpTypeBool
+          %7 = OpTypeInt 32 1
+          %8 = OpTypeVector %7 4
+          %9 = OpTypePointer Function %8
+         %10 = OpConstant %7 0
+         %11 = OpConstant %7 1
+         %12 = OpConstant %7 3
+         %13 = OpConstant %7 2
+         %14 = OpConstant %7 10
+         %15 = OpConstantComposite %8 %10 %11 %12 %13
+         %16 = OpTypePointer Function %7
+         %17 = OpTypeInt 32 0
+         %18 = OpConstant %17 1
+         %19 = OpTypeFloat 32
+         %20 = OpTypeVector %19 4
+         %21 = OpTypePointer Output %20
+          %3 = OpVariable %21 Output
+          %2 = OpFunction %4 None %5
+         %22 = OpLabel
+         %23 = OpVariable %9 Function
+         %24 = OpVariable %16 Function
+         %25 = OpVariable %16 Function
+               OpStore %23 %15
+               OpStore %24 %10
+         %26 = OpLoad %7 %24
+         %27 = OpAccessChain %16 %23 %26
                OpReturn
                OpFunctionEnd
   )";
@@ -531,10 +606,10 @@ TEST(TransformationAccessChainTest, ClampingVariables) {
                                                validator_options);
 
   {
-    // Out of bounds constant index is clamped to be in-bound
-    // (the corresponding constant must be in the module)
+    // The out of bounds constant index is clamped to be in-bound
     TransformationAccessChain transformation(
-        100, 6, {18}, MakeInstructionDescriptor(22, SpvOpReturn, 0));
+        100, 23, {14}, MakeInstructionDescriptor(26, SpvOpReturn, 0),
+        {200, 201});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
     transformation.Apply(context.get(), &transformation_context);
@@ -545,37 +620,40 @@ TEST(TransformationAccessChainTest, ClampingVariables) {
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
-               OpEntryPoint Fragment %2 "main" %4
+               OpEntryPoint Fragment %2 "main" %3
                OpExecutionMode %2 OriginUpperLeft
                OpSource ESSL 310
-          %9 = OpTypeVoid
-          %3 = OpTypeFunction %9
-         %10 = OpTypeInt 32 1
-         %11 = OpTypeVector %10 4
-         %12 = OpTypePointer Function %11
-         %13 = OpConstant %10 0
-         %15 = OpConstant %10 1
-         %16 = OpConstant %10 3
-         %17 = OpConstant %10 2
-         %18 = OpConstant %10 10
-         %14 = OpConstantComposite %11 %13 %15 %16 %17
-         %19 = OpTypePointer Function %10
-         %21 = OpTypeInt 32 0
-         %24 = OpConstant %21 1
-         %25 = OpTypeFloat 32
-         %26 = OpTypeVector %25 4
-         %27 = OpTypePointer Output %26
-          %4 = OpVariable %27 Output
-          %2 = OpFunction %9 None %3
-          %5 = OpLabel
-          %6 = OpVariable %12 Function
-          %7 = OpVariable %19 Function
-          %8 = OpVariable %19 Function
-               OpStore %6 %14
-               OpStore %7 %13
-         %22 = OpLoad %10 %7
-         %23 = OpAccessChain %19 %6 %22
-        %100 = OpAccessChain %19 %6 %16
+          %4 = OpTypeVoid
+          %5 = OpTypeFunction %4
+          %6 = OpTypeBool
+          %7 = OpTypeInt 32 1
+          %8 = OpTypeVector %7 4
+          %9 = OpTypePointer Function %8
+         %10 = OpConstant %7 0
+         %11 = OpConstant %7 1
+         %12 = OpConstant %7 3
+         %13 = OpConstant %7 2
+         %14 = OpConstant %7 10
+         %15 = OpConstantComposite %8 %10 %11 %12 %13
+         %16 = OpTypePointer Function %7
+         %17 = OpTypeInt 32 0
+         %18 = OpConstant %17 1
+         %19 = OpTypeFloat 32
+         %20 = OpTypeVector %19 4
+         %21 = OpTypePointer Output %20
+          %3 = OpVariable %21 Output
+          %2 = OpFunction %4 None %5
+         %22 = OpLabel
+         %23 = OpVariable %9 Function
+         %24 = OpVariable %16 Function
+         %25 = OpVariable %16 Function
+               OpStore %23 %15
+               OpStore %24 %10
+         %26 = OpLoad %7 %24
+         %27 = OpAccessChain %16 %23 %26
+        %200 = OpULessThanEqual %6 %14 %12
+        %201 = OpSelect %7 %200 %14 %12
+        %100 = OpAccessChain %16 %23 %201
                OpReturn
                OpFunctionEnd
   )";


### PR DESCRIPTION
This PR generalises TransformationAddAccessChain so that dynamic
indices for non-struct composites (with clamping to ensure that
accesses are in-bound) are allowed.

The transformation will add instructions to clamp any index to
a non-struct composite, regardless of whether it is a constant
or not.

Fixes #3179 