### PR TITLE
WIP: Add member initializations to fix GCC10 warning

### DIFF
--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -80,8 +80,10 @@ struct Operand {
 
   Operand(spv_operand_type_t t, const OperandData& w) : type(t), words(w) {}
 
-  spv_operand_type_t type;  // Type of this logical operand.
-  OperandData words;        // Binary segments of this logical operand.
+  // Type of this logical operand.
+  spv_operand_type_t type = SPV_OPERAND_TYPE_NONE;
+  // Binary segments of this logical operand.
+  OperandData words = {};
 
   // Returns a string operand as a C-style string.
   const char* AsCString() const {


### PR DESCRIPTION
See #3526

I don't have MinGW GCC 10.0 handy so I can't verify this actually fixes the problem.  It's just a guess.