### PR TITLE
spirv-fuzz: refactor to use RemoveAtRandomIndex

### DIFF
--- a/source/fuzz/fuzzer_pass_merge_blocks.cpp
+++ b/source/fuzz/fuzzer_pass_merge_blocks.cpp
@@ -53,9 +53,8 @@ void FuzzerPassMergeBlocks::Apply() {
   }
 
   while (!potential_transformations.empty()) {
-    uint32_t index = GetFuzzerContext()->RandomIndex(potential_transformations);
-    auto transformation = potential_transformations.at(index);
-    potential_transformations.erase(potential_transformations.begin() + index);
+    auto transformation =
+        GetFuzzerContext()->RemoveAtRandomIndex(&potential_transformations);
     MaybeApplyTransformation(transformation);
   }
 }


### PR DESCRIPTION
This PR makes the code in fuzzer_pass_merge_blocks.cpp simpler by
using the RemoveAtRandomIndex function from FuzzerContext

See related comment in #3540 