### PR TITLE
Preserve OpenCL.DebugInfo.100 through private-to-local pass

### DIFF
--- a/source/opt/debug_info_manager.h
+++ b/source/opt/debug_info_manager.h
@@ -153,6 +153,11 @@ class DebugInfoManager {
   // Function storage class. Otherwise, returns 0.
   uint32_t GetVariableIdOfDebugValueUsedForDeclare(Instruction* inst);
 
+  // Converts DebugGlobalVariable |dbg_global_var| to a DebugLocalVariable and
+  // creates a DebugDeclare mapping the new DebugLocalVariable to |local_var|.
+  void ConvertDebugGlobalToLocalVariable(Instruction* dbg_global_var,
+                                         Instruction* local_var);
+
  private:
   IRContext* context() { return context_; }
 

--- a/source/opt/private_to_local_pass.cpp
+++ b/source/opt/private_to_local_pass.cpp
@@ -157,6 +157,12 @@ uint32_t PrivateToLocalPass::GetNewType(uint32_t old_type_id) {
 bool PrivateToLocalPass::IsValidUse(const Instruction* inst) const {
   // The cases in this switch have to match the cases in |UpdateUse|.
   // If we don't know how to update it, it is not valid.
+  if (inst->GetOpenCL100DebugOpcode() ==
+          OpenCLDebugInfo100DebugGlobalVariable ||
+      inst->GetOpenCL100DebugOpcode() == OpenCLDebugInfo100DebugDeclare ||
+      inst->GetOpenCL100DebugOpcode() == OpenCLDebugInfo100DebugValue) {
+    return true;
+  }
   switch (inst->opcode()) {
     case SpvOpLoad:
     case SpvOpStore:
@@ -179,6 +185,13 @@ bool PrivateToLocalPass::UpdateUse(Instruction* inst) {
   // The cases in this switch have to match the cases in |IsValidUse|.  If we
   // don't think it is valid, the optimization will not view the variable as a
   // candidate, and therefore the use will not be updated.
+  if (inst->GetOpenCL100DebugOpcode() ==
+          OpenCLDebugInfo100DebugGlobalVariable ||
+      inst->GetOpenCL100DebugOpcode() == OpenCLDebugInfo100DebugDeclare ||
+      inst->GetOpenCL100DebugOpcode() == OpenCLDebugInfo100DebugValue) {
+    // TODO: Do we have to allow DebugDeclare and DebugValue?
+    return true;
+  }
   switch (inst->opcode()) {
     case SpvOpLoad:
     case SpvOpStore:

--- a/source/opt/private_to_local_pass.cpp
+++ b/source/opt/private_to_local_pass.cpp
@@ -138,7 +138,7 @@ bool PrivateToLocalPass::MoveVariable(Instruction* variable,
   function->begin()->begin()->InsertBefore(move(var));
 
   // Update uses where the type may have changed.
-  return UpdateUses(variable->result_id());
+  return UpdateUses(variable);
 }
 
 uint32_t PrivateToLocalPass::GetNewType(uint32_t old_type_id) {
@@ -158,9 +158,7 @@ bool PrivateToLocalPass::IsValidUse(const Instruction* inst) const {
   // The cases in this switch have to match the cases in |UpdateUse|.
   // If we don't know how to update it, it is not valid.
   if (inst->GetOpenCL100DebugOpcode() ==
-          OpenCLDebugInfo100DebugGlobalVariable ||
-      inst->GetOpenCL100DebugOpcode() == OpenCLDebugInfo100DebugDeclare ||
-      inst->GetOpenCL100DebugOpcode() == OpenCLDebugInfo100DebugValue) {
+      OpenCLDebugInfo100DebugGlobalVariable) {
     return true;
   }
   switch (inst->opcode()) {
@@ -181,15 +179,14 @@ bool PrivateToLocalPass::IsValidUse(const Instruction* inst) const {
   }
 }
 
-bool PrivateToLocalPass::UpdateUse(Instruction* inst) {
+bool PrivateToLocalPass::UpdateUse(Instruction* inst, Instruction* user) {
   // The cases in this switch have to match the cases in |IsValidUse|.  If we
   // don't think it is valid, the optimization will not view the variable as a
   // candidate, and therefore the use will not be updated.
   if (inst->GetOpenCL100DebugOpcode() ==
-          OpenCLDebugInfo100DebugGlobalVariable ||
-      inst->GetOpenCL100DebugOpcode() == OpenCLDebugInfo100DebugDeclare ||
-      inst->GetOpenCL100DebugOpcode() == OpenCLDebugInfo100DebugValue) {
-    // TODO: Do we have to allow DebugDeclare and DebugValue?
+      OpenCLDebugInfo100DebugGlobalVariable) {
+    context()->get_debug_info_mgr()->ConvertDebugGlobalToLocalVariable(inst,
+                                                                       user);
     return true;
   }
   switch (inst->opcode()) {
@@ -209,7 +206,7 @@ bool PrivateToLocalPass::UpdateUse(Instruction* inst) {
       context()->AnalyzeUses(inst);
 
       // Update uses where the type may have changed.
-      if (!UpdateUses(inst->result_id())) {
+      if (!UpdateUses(inst)) {
         return false;
       }
     } break;
@@ -224,13 +221,14 @@ bool PrivateToLocalPass::UpdateUse(Instruction* inst) {
   return true;
 }
 
-bool PrivateToLocalPass::UpdateUses(uint32_t id) {
+bool PrivateToLocalPass::UpdateUses(Instruction* inst) {
+  uint32_t id = inst->result_id();
   std::vector<Instruction*> uses;
   context()->get_def_use_mgr()->ForEachUser(
       id, [&uses](Instruction* use) { uses.push_back(use); });
 
   for (Instruction* use : uses) {
-    if (!UpdateUse(use)) {
+    if (!UpdateUse(use, inst)) {
       return false;
     }
   }

--- a/source/opt/private_to_local_pass.h
+++ b/source/opt/private_to_local_pass.h
@@ -63,8 +63,8 @@ class PrivateToLocalPass : public Pass {
 
   // Updates |inst|, and any instruction dependent on |inst|, to reflect the
   // change of the base pointer now pointing to the function storage class.
-  bool UpdateUse(Instruction* inst);
-  bool UpdateUses(uint32_t id);
+  bool UpdateUse(Instruction* inst, Instruction* user);
+  bool UpdateUses(Instruction* inst);
 };
 
 }  // namespace opt

--- a/test/opt/private_to_local_test.cpp
+++ b/test/opt/private_to_local_test.cpp
@@ -452,6 +452,48 @@ TEST_F(PrivateToLocalTest, IdBoundOverflow1) {
   EXPECT_EQ(Pass::Status::Failure, std::get<1>(result));
 }
 
+TEST_F(PrivateToLocalTest, DebugPrivateToLocal) {
+  // Debug instructions must not have any impact on changing the private
+  // variable to a local.
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+         %10 = OpExtInstImport "OpenCL.DebugInfo.100"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+         %11 = OpString "test"
+               OpSource GLSL 430
+         %13 = OpTypeInt 32 0
+         %14 = OpConstant %13 32
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+; CHECK: [[float:%[a-zA-Z_\d]+]] = OpTypeFloat 32
+          %5 = OpTypeFloat 32
+; CHECK: [[newtype:%[a-zA-Z_\d]+]] = OpTypePointer Function [[float]]
+          %6 = OpTypePointer Private %5
+; CHECK-NOT: OpVariable [[.+]] Private
+          %8 = OpVariable %6 Private
+
+         %12 = OpExtInst %3 %10 DebugTypeBasic %11 %14 Float
+         %15 = OpExtInst %3 %10 DebugSource %11
+         %16 = OpExtInst %3 %10 DebugCompilationUnit 1 4 %15 GLSL
+; CHECK: DebugGlobalVariable {{%\d+}} {{%\d+}} {{%\d+}} 0 0 {{%\d+}} {{%\d+}} [[newvar:%[a-zA-Z_\d]+]]
+         %17 = OpExtInst %3 %10 DebugGlobalVariable %11 %12 %15 0 0 %16 %11 %8 FlagIsDefinition
+
+; CHECK: OpFunction
+          %2 = OpFunction %3 None %4
+; CHECK: OpLabel
+          %7 = OpLabel
+; CHECK-NEXT: [[newvar]] = OpVariable [[newtype]] Function
+; CHECK: OpLoad [[float]] [[newvar]]
+          %9 = OpLoad %5 %8
+               OpReturn
+               OpFunctionEnd
+  )";
+  SinglePassRunAndMatch<PrivateToLocalPass>(text, false);
+}
+
 }  // namespace
 }  // namespace opt
 }  // namespace spvtools

--- a/test/opt/private_to_local_test.cpp
+++ b/test/opt/private_to_local_test.cpp
@@ -478,20 +478,22 @@ TEST_F(PrivateToLocalTest, DebugPrivateToLocal) {
          %12 = OpExtInst %3 %10 DebugTypeBasic %11 %14 Float
          %15 = OpExtInst %3 %10 DebugSource %11
          %16 = OpExtInst %3 %10 DebugCompilationUnit 1 4 %15 GLSL
-; CHECK: DebugGlobalVariable {{%\d+}} {{%\d+}} {{%\d+}} 0 0 {{%\d+}} {{%\d+}} [[newvar:%[a-zA-Z_\d]+]]
+; CHECK-NOT: DebugGlobalVariable
+; CHECK: [[dbg_newvar:%[a-zA-Z_\d]+]] = OpExtInst {{%\w+}} {{%\w+}} DebugLocalVariable
          %17 = OpExtInst %3 %10 DebugGlobalVariable %11 %12 %15 0 0 %16 %11 %8 FlagIsDefinition
 
 ; CHECK: OpFunction
           %2 = OpFunction %3 None %4
 ; CHECK: OpLabel
           %7 = OpLabel
-; CHECK-NEXT: [[newvar]] = OpVariable [[newtype]] Function
+; CHECK-NEXT: [[newvar:%[a-zA-Z_\d]+]] = OpVariable [[newtype]] Function
+; CHECK-NEXT: DebugDeclare [[dbg_newvar]] [[newvar]]
 ; CHECK: OpLoad [[float]] [[newvar]]
           %9 = OpLoad %5 %8
                OpReturn
                OpFunctionEnd
   )";
-  SinglePassRunAndMatch<PrivateToLocalPass>(text, false);
+  SinglePassRunAndMatch<PrivateToLocalPass>(text, true);
 }
 
 }  // namespace


### PR DESCRIPTION
1. A debug instruction must not have any impact on the private-to-local
optimization.
2. DebugGlobalVariable for the OpVariable optimized by private-to-local
must be converted to a DebugLocalVariable because we want to run
the ssa-rewrite to propagate DebugValue properly, which correctly
delivers the updates of local variables to the debugger.