### PR TITLE
spirv-fuzz: Relax type checking for int contants

### DIFF
--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -1193,7 +1193,7 @@ void AddStructType(opt::IRContext* ir_context, uint32_t result_id,
   UpdateModuleIdBound(ir_context, result_id);
 }
 
-bool TypesArEqualUpToSign(opt::IRContext* ir_context, uint32_t type1_id,
+bool TypesAreEqualUpToSign(opt::IRContext* ir_context, uint32_t type1_id,
                           uint32_t type2_id) {
   if (type1_id == type2_id) {
     return true;

--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -1194,7 +1194,7 @@ void AddStructType(opt::IRContext* ir_context, uint32_t result_id,
 }
 
 bool TypesAreEqualUpToSign(opt::IRContext* ir_context, uint32_t type1_id,
-                          uint32_t type2_id) {
+                           uint32_t type2_id) {
   if (type1_id == type2_id) {
     return true;
   }

--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -1193,6 +1193,38 @@ void AddStructType(opt::IRContext* ir_context, uint32_t result_id,
   UpdateModuleIdBound(ir_context, result_id);
 }
 
+bool TypesArEqualUpToSign(opt::IRContext* ir_context, uint32_t type1_id,
+                          uint32_t type2_id) {
+  if (type1_id == type2_id) {
+    return true;
+  }
+
+  auto type1 = ir_context->get_type_mgr()->GetType(type1_id);
+  auto type2 = ir_context->get_type_mgr()->GetType(type2_id);
+
+  // Integer scalar types must have the same width
+  if (type1->AsInteger() && type2->AsInteger()) {
+    return type1->AsInteger()->width() == type2->AsInteger()->width();
+  }
+
+  // Integer vector types must have the same number of components and their
+  // component types must be integers with the same width.
+  if (type1->AsVector() && type2->AsVector()) {
+    auto component_type1 = type1->AsVector()->element_type()->AsInteger();
+    auto component_type2 = type2->AsVector()->element_type()->AsInteger();
+
+    // Only check the component count and width if they are integer.
+    if (component_type1 && component_type2) {
+      return type1->AsVector()->element_count() ==
+                 type2->AsVector()->element_count() &&
+             component_type1->width() == component_type2->width();
+    }
+  }
+
+  // In all other cases, the types cannot be considered equal.
+  return false;
+}
+
 }  // namespace fuzzerutil
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -357,12 +357,12 @@ uint32_t MaybeGetStructType(opt::IRContext* ir_context,
 //   Every component of the composite constant is looked up by calling this
 //   function with the type id of that component.
 // Returns 0 if no such instruction is present in the module.
-// The returned id either participates in IdIsIrrelevant fact or not,
-// depending on the |is_irrelevant| parameter.
+// The returned id either participates in IdIsIrrelevant fact or not, depending
+// on the |is_irrelevant| parameter.
 uint32_t MaybeGetZeroConstant(
     opt::IRContext* ir_context,
     const TransformationContext& transformation_context,
-    uint32_t scalar_or_composite_type_id, bool is_irrelevant = false);
+    uint32_t scalar_or_composite_type_id, bool is_irrelevant);
 
 // Returns the result id of an OpConstant instruction. |scalar_type_id| must be
 // a result id of a scalar type (i.e. int, float or bool). Returns 0 if no such
@@ -447,8 +447,8 @@ inline uint32_t FloatToWord(float value) {
 // - |type1_id| and |type2_id| are the same id
 // - |type1_id| and |type2_id| refer to integer scalar or vector types, only
 //   differing by their signedness.
-bool TypesArEqualUpToSign(opt::IRContext* ir_context, uint32_t type1_id,
-                          uint32_t type2_id);
+bool TypesAreEqualUpToSign(opt::IRContext* ir_context, uint32_t type1_id,
+                           uint32_t type2_id);
 
 }  // namespace fuzzerutil
 

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -349,10 +349,9 @@ uint32_t MaybeGetStructType(opt::IRContext* ir_context,
                             const std::vector<uint32_t>& component_type_ids);
 
 // Recursive definition is the following:
-// - if |scalar_or_composite_type_id| is a result id of a scalar type -
-// returns
-//   a result id of the following constants (depending on the type): int ->
-//   0, float -> 0.0, bool -> false.
+// - if |scalar_or_composite_type_id| is a result id of a scalar type - returns
+//   a result id of the following constants (depending on the type): int -> 0,
+//   float -> 0.0, bool -> false.
 // - otherwise, returns a result id of an OpConstantComposite instruction.
 //   Every component of the composite constant is looked up by calling this
 //   function with the type id of that component.
@@ -372,7 +371,7 @@ uint32_t MaybeGetScalarConstant(
     opt::IRContext* ir_context,
     const TransformationContext& transformation_context,
     const std::vector<uint32_t>& words, uint32_t scalar_type_id,
-    bool is_irrelevant = false);
+    bool is_irrelevant);
 
 // Returns the result id of an OpConstantComposite instruction.
 // |composite_type_id| must be a result id of a composite type (i.e. vector,
@@ -383,7 +382,7 @@ uint32_t MaybeGetCompositeConstant(
     opt::IRContext* ir_context,
     const TransformationContext& transformation_context,
     const std::vector<uint32_t>& component_ids, uint32_t composite_type_id,
-    bool is_irrelevant = false);
+    bool is_irrelevant);
 
 // Returns the result id of an OpConstant instruction of integral type.
 // Returns 0 if no such instruction or type is present in the module.
@@ -393,7 +392,7 @@ uint32_t MaybeGetIntegerConstant(
     opt::IRContext* ir_context,
     const TransformationContext& transformation_context,
     const std::vector<uint32_t>& words, uint32_t width, bool is_signed,
-    bool is_irrelevant = false);
+    bool is_irrelevant);
 
 // Returns the result id of an OpConstant instruction of floating-point type.
 // Returns 0 if no such instruction or type is present in the module.
@@ -402,8 +401,7 @@ uint32_t MaybeGetIntegerConstant(
 uint32_t MaybeGetFloatConstant(
     opt::IRContext* ir_context,
     const TransformationContext& transformation_context,
-    const std::vector<uint32_t>& words, uint32_t width,
-    bool is_irrelevant = false);
+    const std::vector<uint32_t>& words, uint32_t width, bool is_irrelevant);
 
 // Returns the id of a boolean constant with value |value| if it exists in the
 // module, or 0 otherwise. The returned id either participates in IdIsIrrelevant
@@ -411,7 +409,7 @@ uint32_t MaybeGetFloatConstant(
 uint32_t MaybeGetBoolConstant(
     opt::IRContext* context,
     const TransformationContext& transformation_context, bool value,
-    bool is_irrelevant = false);
+    bool is_irrelevant);
 
 // Creates a new OpTypeInt instruction in the module. Updates module's id bound
 // to accommodate for |result_id|.

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -349,15 +349,16 @@ uint32_t MaybeGetStructType(opt::IRContext* ir_context,
                             const std::vector<uint32_t>& component_type_ids);
 
 // Recursive definition is the following:
-// - if |scalar_or_composite_type_id| is a result id of a scalar type - returns
-//   a result id of the following constants (depending on the type): int -> 0,
-//   float -> 0.0, bool -> false.
+// - if |scalar_or_composite_type_id| is a result id of a scalar type -
+// returns
+//   a result id of the following constants (depending on the type): int ->
+//   0, float -> 0.0, bool -> false.
 // - otherwise, returns a result id of an OpConstantComposite instruction.
 //   Every component of the composite constant is looked up by calling this
 //   function with the type id of that component.
 // Returns 0 if no such instruction is present in the module.
-// The returned id either participates in IdIsIrrelevant fact or not, depending
-// on the |is_irrelevant| parameter.
+// The returned id either participates in IdIsIrrelevant fact or not,
+// depending on the |is_irrelevant| parameter.
 uint32_t MaybeGetZeroConstant(
     opt::IRContext* ir_context,
     const TransformationContext& transformation_context,
@@ -440,6 +441,13 @@ inline uint32_t FloatToWord(float value) {
   memcpy(&result, &value, sizeof(uint32_t));
   return result;
 }
+
+// Returns true if any of the following is true:
+// - |type1_id| and |type2_id| are the same id
+// - |type1_id| and |type2_id| refer to integer scalar or vector types, only
+//   differing by their signedness.
+bool TypesArEqualUpToSign(opt::IRContext* ir_context, uint32_t type1_id,
+                          uint32_t type2_id);
 
 }  // namespace fuzzerutil
 

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -362,7 +362,7 @@ uint32_t MaybeGetStructType(opt::IRContext* ir_context,
 uint32_t MaybeGetZeroConstant(
     opt::IRContext* ir_context,
     const TransformationContext& transformation_context,
-    uint32_t scalar_or_composite_type_id, bool is_irrelevant);
+    uint32_t scalar_or_composite_type_id, bool is_irrelevant = false);
 
 // Returns the result id of an OpConstant instruction. |scalar_type_id| must be
 // a result id of a scalar type (i.e. int, float or bool). Returns 0 if no such
@@ -372,7 +372,7 @@ uint32_t MaybeGetScalarConstant(
     opt::IRContext* ir_context,
     const TransformationContext& transformation_context,
     const std::vector<uint32_t>& words, uint32_t scalar_type_id,
-    bool is_irrelevant);
+    bool is_irrelevant = false);
 
 // Returns the result id of an OpConstantComposite instruction.
 // |composite_type_id| must be a result id of a composite type (i.e. vector,
@@ -383,7 +383,7 @@ uint32_t MaybeGetCompositeConstant(
     opt::IRContext* ir_context,
     const TransformationContext& transformation_context,
     const std::vector<uint32_t>& component_ids, uint32_t composite_type_id,
-    bool is_irrelevant);
+    bool is_irrelevant = false);
 
 // Returns the result id of an OpConstant instruction of integral type.
 // Returns 0 if no such instruction or type is present in the module.
@@ -393,7 +393,7 @@ uint32_t MaybeGetIntegerConstant(
     opt::IRContext* ir_context,
     const TransformationContext& transformation_context,
     const std::vector<uint32_t>& words, uint32_t width, bool is_signed,
-    bool is_irrelevant);
+    bool is_irrelevant = false);
 
 // Returns the result id of an OpConstant instruction of floating-point type.
 // Returns 0 if no such instruction or type is present in the module.
@@ -402,7 +402,8 @@ uint32_t MaybeGetIntegerConstant(
 uint32_t MaybeGetFloatConstant(
     opt::IRContext* ir_context,
     const TransformationContext& transformation_context,
-    const std::vector<uint32_t>& words, uint32_t width, bool is_irrelevant);
+    const std::vector<uint32_t>& words, uint32_t width,
+    bool is_irrelevant = false);
 
 // Returns the id of a boolean constant with value |value| if it exists in the
 // module, or 0 otherwise. The returned id either participates in IdIsIrrelevant
@@ -410,7 +411,7 @@ uint32_t MaybeGetFloatConstant(
 uint32_t MaybeGetBoolConstant(
     opt::IRContext* context,
     const TransformationContext& transformation_context, bool value,
-    bool is_irrelevant);
+    bool is_irrelevant = false);
 
 // Creates a new OpTypeInt instruction in the module. Updates module's id bound
 // to accommodate for |result_id|.

--- a/source/fuzz/transformation_record_synonymous_constants.cpp
+++ b/source/fuzz/transformation_record_synonymous_constants.cpp
@@ -84,8 +84,8 @@ bool TransformationRecordSynonymousConstants::AreEquivalentConstants(
   assert(constant1 && constant2 && "The ids must refer to constants.");
 
   // The types must be compatible.
-  if (!fuzzerutil::TypesArEqualUpToSign(ir_context, def_1->type_id(),
-                                        def_2->type_id())) {
+  if (!fuzzerutil::TypesAreEqualUpToSign(ir_context, def_1->type_id(),
+                                         def_2->type_id())) {
     return false;
   }
 

--- a/source/fuzz/transformation_record_synonymous_constants.cpp
+++ b/source/fuzz/transformation_record_synonymous_constants.cpp
@@ -15,6 +15,8 @@
 
 #include "transformation_record_synonymous_constants.h"
 
+#include "source/fuzz/fuzzer_util.h"
+
 namespace spvtools {
 namespace fuzz {
 
@@ -82,19 +84,8 @@ bool TransformationRecordSynonymousConstants::AreEquivalentConstants(
   assert(constant1 && constant2 && "The ids must refer to constants.");
 
   // The types must be compatible.
-  if (constant1->type()->AsInteger() && constant2->type()->AsInteger()) {
-    // Two integer scalars cannot be equivalent if their width is not the same.
-    if (constant1->type()->AsInteger()->width() !=
-        constant2->type()->AsInteger()->width()) {
-      return false;
-    }
-  } else if (constant1->type()->AsVector() && constant2->type()->AsVector() &&
-             constant1->type()->AsVector()->element_type()->AsInteger() &&
-             constant2->type()->AsVector()->element_type()->AsInteger()) {
-    // Two integer vectors are equivalent even if their type ids don't match,
-    // as long as their components are pairwise equivalent.
-  } else if (def_1->type_id() != def_2->type_id()) {
-    // For everything else, the type ids must match.
+  if (!fuzzerutil::TypesArEqualUpToSign(ir_context, def_1->type_id(),
+                                        def_2->type_id())) {
     return false;
   }
 

--- a/source/fuzz/transformation_record_synonymous_constants.h
+++ b/source/fuzz/transformation_record_synonymous_constants.h
@@ -32,16 +32,17 @@ class TransformationRecordSynonymousConstants : public Transformation {
   // - |message_.constant_id| and |message_.synonym_id| are distinct ids
   //   of constants
   // - |message_.constant_id| and |message_.synonym_id| refer to constants
-  //   that are equal or equivalent.
-  //   TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3536): Signed and
-  //   unsigned integers are currently considered non-equivalent
-  //   Two integers with the same width and value are equal, even if one is
-  //   signed and the other is not.
-  //   Constants are equivalent:
-  //   - if both of them represent zero-like values of the same type
-  //   - if they are composite constants with the same type and their
-  //     components are pairwise equivalent.
-  // - |constant1_id| and |constant2_id| may not be irrelevant.
+  //   that are equivalent.
+  // Constants are equivalent if at least one of the following holds:
+  // - they are equal (i.e. they have the same type ids and equal values)
+  // - both of them represent zero-like values of compatible types
+  // - they are composite constants with compatible types and their
+  //   components are pairwise equivalent
+  // Two types are compatible if at least one of the following holds:
+  // - they have the same id
+  // - they are integer scalar types with the same width
+  // - they are integer vectors and their components have the same width
+  //   (this is always the case if the components are equivalent)
   bool IsApplicable(
       opt::IRContext* ir_context,
       const TransformationContext& transformation_context) const override;

--- a/source/fuzz/transformation_replace_id_with_synonym.cpp
+++ b/source/fuzz/transformation_replace_id_with_synonym.cpp
@@ -67,8 +67,8 @@ bool TransformationReplaceIdWithSynonym::IsApplicable(
   // constants with different signedness, their use can only be swapped if the
   // instruction is agnostic to the signedness of the operand.
   if (type_id_of_interest != type_id_synonym &&
-      fuzzerutil::TypesArEqualUpToSign(ir_context, type_id_of_interest,
-                                       type_id_synonym) &&
+      fuzzerutil::TypesAreEqualUpToSign(ir_context, type_id_of_interest,
+                                        type_id_synonym) &&
       !IsAgnosticToSignednessOfOperand(
           use_instruction->opcode(),
           message_.id_use_descriptor().in_operand_index())) {

--- a/source/fuzz/transformation_replace_id_with_synonym.h
+++ b/source/fuzz/transformation_replace_id_with_synonym.h
@@ -64,6 +64,13 @@ class TransformationReplaceIdWithSynonym : public Transformation {
                                           opt::Instruction* use_instruction,
                                           uint32_t use_in_operand_index);
 
+  // Returns true if the instruction with opcode |opcode| does not change its
+  // behaviour depending on the signedness of the operand at
+  // |use_in_operand_index|.
+  // Assumes that the operand must be the id of an integer scalar or vector.
+  static bool IsAgnosticToSignednessOfOperand(SpvOp opcode,
+                                              uint32_t use_in_operand_index);
+
  private:
   protobufs::TransformationReplaceIdWithSynonym message_;
 };

--- a/test/fuzz/transformation_record_synonymous_constants_test.cpp
+++ b/test/fuzz/transformation_record_synonymous_constants_test.cpp
@@ -98,7 +98,7 @@ TEST(TransformationRecordSynonymousConstantsTest, IntConstants) {
 #endif
 
 #ifndef NDEBUG
-  // Swapping the ids gives the same result
+  // %3 is not a constant declaration
   ASSERT_DEATH(TransformationRecordSynonymousConstants(9, 3).IsApplicable(
                    context.get(), transformation_context),
                "The ids must refer to constants.");

--- a/test/fuzz/transformation_record_synonymous_constants_test.cpp
+++ b/test/fuzz/transformation_record_synonymous_constants_test.cpp
@@ -684,6 +684,104 @@ TEST(TransformationRecordSynonymousConstantsTest, ArrayCompositeConstants) {
       context.get(), transformation_context));
 }
 
+TEST(TransformationRecordSynonymousConstantsTest, IntVectors) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main" %3
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource ESSL 310
+               OpDecorate %3 Location 0
+          %4 = OpTypeVoid
+          %5 = OpTypeFunction %4
+          %6 = OpTypeInt 32 1
+          %7 = OpTypeInt 32 0
+          %8 = OpTypeVector %6 4
+          %9 = OpTypeVector %7 4
+         %10 = OpTypePointer Function %8
+         %11 = OpTypePointer Function %8
+         %12 = OpConstant %6 0
+         %13 = OpConstant %7 0
+         %14 = OpConstant %6 1
+         %25 = OpConstant %7 1
+         %15 = OpConstantComposite %8 %12 %12 %12 %12
+         %16 = OpConstantComposite %9 %13 %13 %13 %13
+         %17 = OpConstantComposite %8 %14 %12 %12 %14
+         %18 = OpConstantComposite %9 %25 %13 %13 %25
+         %19 = OpConstantNull %8
+         %20 = OpConstantNull %9
+         %21 = OpTypeFloat 32
+         %22 = OpTypeVector %21 4
+         %23 = OpTypePointer Output %22
+          %3 = OpVariable %23 Output
+          %2 = OpFunction %4 None %5
+         %24 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  // %15 and %17 are not equivalent (having non-equivalent components)
+  ASSERT_FALSE(TransformationRecordSynonymousConstants(15, 17).IsApplicable(
+      context.get(), transformation_context));
+
+  // %17 and %19 are not equivalent (%19 is null, %17 is non-zero)
+  ASSERT_FALSE(TransformationRecordSynonymousConstants(17, 19).IsApplicable(
+      context.get(), transformation_context));
+
+  // %17 and %20 are not equivalent (%19 is null, %20 is non-zero)
+  ASSERT_FALSE(TransformationRecordSynonymousConstants(17, 20).IsApplicable(
+      context.get(), transformation_context));
+
+  // %15 and %16 are equivalent (having pairwise equivalent components)
+  ASSERT_TRUE(TransformationRecordSynonymousConstants(15, 16).IsApplicable(
+      context.get(), transformation_context));
+
+  ApplyTransformationAndCheckFactManager(15, 16, context.get(),
+                                         &transformation_context);
+
+  // %17 and %18 are equivalent (having pairwise equivalent components)
+  ASSERT_TRUE(TransformationRecordSynonymousConstants(17, 18).IsApplicable(
+      context.get(), transformation_context));
+
+  ApplyTransformationAndCheckFactManager(17, 18, context.get(),
+                                         &transformation_context);
+
+  // %19 and %20 are equivalent (both null vectors with compatible types)
+  ASSERT_TRUE(TransformationRecordSynonymousConstants(19, 20).IsApplicable(
+      context.get(), transformation_context));
+
+  ApplyTransformationAndCheckFactManager(19, 20, context.get(),
+                                         &transformation_context);
+
+  // %15 and %19 are equivalent (they have compatible types, %15 is zero-like
+  // and %19 is null)
+  ASSERT_TRUE(TransformationRecordSynonymousConstants(15, 19).IsApplicable(
+      context.get(), transformation_context));
+
+  ApplyTransformationAndCheckFactManager(15, 19, context.get(),
+                                         &transformation_context);
+
+  // %15 and %20 are equivalent (they have compatible types, %15 is zero-like
+  // and %20 is null)
+  ASSERT_TRUE(TransformationRecordSynonymousConstants(15, 20).IsApplicable(
+      context.get(), transformation_context));
+
+  ApplyTransformationAndCheckFactManager(15, 20, context.get(),
+                                         &transformation_context);
+}
+
 TEST(TransformationRecordSynonymousConstantsTest, FirstIrrelevantConstant) {
   std::string shader = R"(
                OpCapability Shader

--- a/test/fuzz/transformation_record_synonymous_constants_test.cpp
+++ b/test/fuzz/transformation_record_synonymous_constants_test.cpp
@@ -90,13 +90,19 @@ TEST(TransformationRecordSynonymousConstantsTest, IntConstants) {
                                                validator_options);
   ASSERT_TRUE(IsValid(env, context.get()));
 
+#ifndef NDEBUG
   // %3 is not a constant declaration
-  ASSERT_FALSE(TransformationRecordSynonymousConstants(3, 9).IsApplicable(
-      context.get(), transformation_context));
+  ASSERT_DEATH(TransformationRecordSynonymousConstants(3, 9).IsApplicable(
+                   context.get(), transformation_context),
+               "The ids must refer to constants.");
+#endif
 
+#ifndef NDEBUG
   // Swapping the ids gives the same result
-  ASSERT_FALSE(TransformationRecordSynonymousConstants(9, 3).IsApplicable(
-      context.get(), transformation_context));
+  ASSERT_DEATH(TransformationRecordSynonymousConstants(9, 3).IsApplicable(
+                   context.get(), transformation_context),
+               "The ids must refer to constants.");
+#endif
 
   // The two constants must be different
   ASSERT_FALSE(TransformationRecordSynonymousConstants(9, 9).IsApplicable(
@@ -129,14 +135,12 @@ TEST(TransformationRecordSynonymousConstantsTest, IntConstants) {
   ApplyTransformationAndCheckFactManager(13, 22, context.get(),
                                          &transformation_context);
 
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3536):
-  // Relax type check for integers. Uncomment this code once the issue is fixed.
-  // // %13 and %20 are equal even if %13 is signed and %20 is unsigned
-  //  ASSERT_TRUE(TransformationRecordSynonymousConstants(13, 20).IsApplicable(
-  //      context.get(), transformation_context));
-  //
-  //  ApplyTransformationAndCheckFactManager(13, 20, context.get(),
-  //                                         &transformation_context);
+  // %13 and %20 are equal even if %13 is signed and %20 is unsigned
+  ASSERT_TRUE(TransformationRecordSynonymousConstants(13, 20).IsApplicable(
+      context.get(), transformation_context));
+
+  ApplyTransformationAndCheckFactManager(13, 20, context.get(),
+                                         &transformation_context);
 
   // %9 and %11 are equivalent (OpConstant with value 0 and OpConstantNull)
   ASSERT_TRUE(TransformationRecordSynonymousConstants(9, 11).IsApplicable(


### PR DESCRIPTION
Right now, TransformationRecordSynonymousConstants requires the type
ids of two candidate constants to be exactly the same.
This PR adds an exception for integer constants, which can be
considered equivalent even if their signedness is different.
This applies to both integers and vector constants.

The IsApplicable method of ReplaceIdWithSynonym is also updated so
that, in the case of two integer constants which don't have the same
type, they can only be swapped in particular instructions (those
that don't take the signedness into consideration).

Fixes #3536  .