### PR TITLE
spirv-fuzz: adds TransformationReplaceCopyMemoryWithLoadStore

### DIFF
--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -136,6 +136,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_record_synonymous_constants.h
         transformation_replace_boolean_constant_with_constant_binary.h
         transformation_replace_constant_with_uniform.h
+        transformation_replace_copy_memory_with_load_store.h
         transformation_replace_id_with_synonym.h
         transformation_replace_linear_algebra_instruction.h
         transformation_replace_parameter_with_global.h
@@ -258,6 +259,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_record_synonymous_constants.cpp
         transformation_replace_boolean_constant_with_constant_binary.cpp
         transformation_replace_constant_with_uniform.cpp
+        transformation_replace_copy_memory_with_load_store.cpp
         transformation_replace_id_with_synonym.cpp
         transformation_replace_linear_algebra_instruction.cpp
         transformation_replace_parameter_with_global.cpp

--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -73,6 +73,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_permute_function_parameters.h
         fuzzer_pass_permute_phi_operands.h
         fuzzer_pass_push_ids_through_variables.h
+        fuzzer_pass_replace_copy_memories_with_loads_stores.h
         fuzzer_pass_replace_linear_algebra_instructions.h
         fuzzer_pass_replace_parameter_with_global.h
         fuzzer_pass_replace_params_with_struct.h
@@ -197,6 +198,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_permute_function_parameters.cpp
         fuzzer_pass_permute_phi_operands.cpp
         fuzzer_pass_push_ids_through_variables.cpp
+        fuzzer_pass_replace_copy_memories_with_loads_stores.cpp
         fuzzer_pass_replace_linear_algebra_instructions.cpp
         fuzzer_pass_replace_parameter_with_global.cpp
         fuzzer_pass_replace_params_with_struct.cpp

--- a/source/fuzz/fuzzer_context.cpp
+++ b/source/fuzz/fuzzer_context.cpp
@@ -77,6 +77,8 @@ const std::pair<uint32_t, uint32_t> kChanceOfOutliningFunction = {10, 90};
 const std::pair<uint32_t, uint32_t> kChanceOfPermutingParameters = {30, 90};
 const std::pair<uint32_t, uint32_t> kChanceOfPermutingPhiOperands = {30, 90};
 const std::pair<uint32_t, uint32_t> kChanceOfPushingIdThroughVariable = {5, 50};
+const std::pair<uint32_t, uint32_t> kChanceOfReplacingCopyMemoryWithLoadStore =
+    {20, 90};
 const std::pair<uint32_t, uint32_t> kChanceOfReplacingIdWithSynonym = {10, 90};
 const std::pair<uint32_t, uint32_t>
     kChanceOfReplacingLinearAlgebraInstructions = {10, 90};
@@ -210,6 +212,8 @@ FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
       ChooseBetweenMinAndMax(kChanceOfPermutingPhiOperands);
   chance_of_pushing_id_through_variable_ =
       ChooseBetweenMinAndMax(kChanceOfPushingIdThroughVariable);
+  chance_of_replacing_copy_memory_with_load_store_ =
+      ChooseBetweenMinAndMax(kChanceOfReplacingCopyMemoryWithLoadStore);
   chance_of_replacing_id_with_synonym_ =
       ChooseBetweenMinAndMax(kChanceOfReplacingIdWithSynonym);
   chance_of_replacing_linear_algebra_instructions_ =

--- a/source/fuzz/fuzzer_context.h
+++ b/source/fuzz/fuzzer_context.h
@@ -212,6 +212,9 @@ class FuzzerContext {
   uint32_t GetChanceOfPushingIdThroughVariable() {
     return chance_of_pushing_id_through_variable_;
   }
+  uint32_t GetChanceOfReplacingCopyMemoryWithLoadStore() {
+    return chance_of_replacing_copy_memory_with_load_store_;
+  }
   uint32_t GetChanceOfReplacingIdWithSynonym() {
     return chance_of_replacing_id_with_synonym_;
   }
@@ -354,6 +357,7 @@ class FuzzerContext {
   uint32_t chance_of_permuting_parameters_;
   uint32_t chance_of_permuting_phi_operands_;
   uint32_t chance_of_pushing_id_through_variable_;
+  uint32_t chance_of_replacing_copy_memory_with_load_store_;
   uint32_t chance_of_replacing_id_with_synonym_;
   uint32_t chance_of_replacing_linear_algebra_instructions_;
   uint32_t chance_of_replacing_parameters_with_globals_;

--- a/source/fuzz/fuzzer_pass_replace_copy_memories_with_loads_stores.cpp
+++ b/source/fuzz/fuzzer_pass_replace_copy_memories_with_loads_stores.cpp
@@ -41,7 +41,7 @@ void FuzzerPassReplaceCopyMemoriesWithLoadsStores::Apply() {
                 ->GetChanceOfReplacingCopyMemoryWithLoadStore())) {
       return;
     }
-    // The instruction must be OpCopyObject.
+    // The instruction must be OpCopyMemory.
     if (instruction->opcode() != SpvOpCopyMemory) {
       return;
     }
@@ -56,6 +56,7 @@ void FuzzerPassReplaceCopyMemoriesWithLoadsStores::Apply() {
 
     auto instruction_descriptor =
         MakeInstructionDescriptor(GetIRContext(), instruction);
+
     // Apply the transformation replacing OpCopyMemory with OpLoad and OpStore.
     ApplyTransformation(TransformationReplaceCopyMemoryWithLoadStore(
         GetFuzzerContext()->GetFreshId(), instruction_descriptor));

--- a/source/fuzz/fuzzer_pass_replace_copy_memories_with_loads_stores.cpp
+++ b/source/fuzz/fuzzer_pass_replace_copy_memories_with_loads_stores.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/fuzzer_pass_replace_copy_memories_with_loads_stores.h"
+
+#include "source/fuzz/fuzzer_util.h"
+#include "source/fuzz/instruction_descriptor.h"
+#include "source/fuzz/transformation_replace_copy_memory_with_load_store.h"
+
+namespace spvtools {
+namespace fuzz {
+
+FuzzerPassReplaceCopyMemoriesWithLoadsStores::
+    FuzzerPassReplaceCopyMemoriesWithLoadsStores(
+        opt::IRContext* ir_context,
+        TransformationContext* transformation_context,
+        FuzzerContext* fuzzer_context,
+        protobufs::TransformationSequence* transformations)
+    : FuzzerPass(ir_context, transformation_context, fuzzer_context,
+                 transformations) {}
+
+FuzzerPassReplaceCopyMemoriesWithLoadsStores::
+    ~FuzzerPassReplaceCopyMemoriesWithLoadsStores() = default;
+
+void FuzzerPassReplaceCopyMemoriesWithLoadsStores::Apply() {
+  GetIRContext()->module()->ForEachInst([this](opt::Instruction* instruction) {
+    // Randomly decide whether to replace the OpCopyMemory.
+    if (!GetFuzzerContext()->ChoosePercentage(
+            GetFuzzerContext()
+                ->GetChanceOfReplacingCopyMemoryWithLoadStore())) {
+      return;
+    }
+    // The instruction must be OpCopyObject.
+    if (instruction->opcode() != SpvOpCopyMemory) {
+      return;
+    }
+
+    // It must be valid to insert OpStore and OpLoad instructions
+    // before the instruction OpCopyMemory.
+    if (!fuzzerutil::CanInsertOpcodeBeforeInstruction(SpvOpStore,
+                                                      instruction) ||
+        !fuzzerutil::CanInsertOpcodeBeforeInstruction(SpvOpLoad, instruction)) {
+      return;
+    }
+
+    auto instruction_descriptor =
+        MakeInstructionDescriptor(GetIRContext(), instruction);
+    // Apply the transformation replacing OpCopyMemory with OpLoad and OpStore.
+    ApplyTransformation(TransformationReplaceCopyMemoryWithLoadStore(
+        GetFuzzerContext()->GetFreshId(), instruction_descriptor));
+  });
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/fuzzer_pass_replace_copy_memories_with_loads_stores.h
+++ b/source/fuzz/fuzzer_pass_replace_copy_memories_with_loads_stores.h
@@ -20,9 +20,9 @@
 namespace spvtools {
 namespace fuzz {
 
-// Replaces instructions OpCopyObject with storing into a new variable
-// and immediately loading this variable to |result_id| of the
-// original OpCopyObject instruction.
+// Replaces instructions OpCopyMemory with loading the source variable to
+// an intermediate value and storing this value into the target variable of
+// the original OpCopyMemory instruction.
 class FuzzerPassReplaceCopyMemoriesWithLoadsStores : public FuzzerPass {
  public:
   FuzzerPassReplaceCopyMemoriesWithLoadsStores(

--- a/source/fuzz/fuzzer_pass_replace_copy_memories_with_loads_stores.h
+++ b/source/fuzz/fuzzer_pass_replace_copy_memories_with_loads_stores.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SPIRV_TOOLS_FUZZER_PASS_REPLACE_COPY_MEMORIES_WITH_LOADS_STORES_H
+#define SPIRV_TOOLS_FUZZER_PASS_REPLACE_COPY_MEMORIES_WITH_LOADS_STORES_H
+
+#include "source/fuzz/fuzzer_pass.h"
+
+namespace spvtools {
+namespace fuzz {
+
+// Replaces instructions OpCopyObject with storing into a new variable
+// and immediately loading this variable to |result_id| of the
+// original OpCopyObject instruction.
+class FuzzerPassReplaceCopyMemoriesWithLoadsStores : public FuzzerPass {
+ public:
+  FuzzerPassReplaceCopyMemoriesWithLoadsStores(
+      opt::IRContext* ir_context, TransformationContext* transformation_context,
+      FuzzerContext* fuzzer_context,
+      protobufs::TransformationSequence* transformations);
+
+  ~FuzzerPassReplaceCopyMemoriesWithLoadsStores() override;
+
+  void Apply() override;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SPIRV_TOOLS_FUZZER_PASS_REPLACE_COPY_MEMORIES_WITH_LOADS_STORES_H

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -404,6 +404,7 @@ message Transformation {
     TransformationAddSynonym add_synonym = 57;
     TransformationAddRelaxedDecoration add_relaxed_decoration = 58;
     TransformationReplaceParamsWithStruct replace_params_with_struct = 59;
+    TransformationReplaceCopyMemoryWithLoadStore replace_copy_memory_with_load_store= 60;
     // Add additional option using the next available number.
   }
 }
@@ -1214,6 +1215,19 @@ message TransformationRecordSynonymousConstants {
   // The id of the synonym
   uint32 constant2_id = 2;
 
+}
+
+message TransformationReplaceCopyMemoryWithLoadStore {
+
+   // A transformation that replaces an OpCopyMemory instruction
+   // with loading to source_value and immediately storing it to the
+   // target of original OpCopyMemory instruction.
+
+   // The intermediate value
+   uint32 source_value = 1;
+
+   // The instruction descriptor
+   InstructionDescriptor instruction_descriptor = 2;
 }
 
 message TransformationReplaceParameterWithGlobal {

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -1219,9 +1219,9 @@ message TransformationRecordSynonymousConstants {
 
 message TransformationReplaceCopyMemoryWithLoadStore {
 
-   // A transformation that replaces an OpCopyMemory instruction
-   // with loading to source_value and immediately storing it to the
-   // target of original OpCopyMemory instruction.
+   // A transformation that replaces instructions OpCopyMemory with loading
+   // the source variable to an intermediate value and storing this value into the
+   // target variable of the original OpCopyMemory instruction.
 
    // The intermediate value
    uint32 source_value = 1;

--- a/source/fuzz/transformation.cpp
+++ b/source/fuzz/transformation.cpp
@@ -62,6 +62,7 @@
 #include "source/fuzz/transformation_record_synonymous_constants.h"
 #include "source/fuzz/transformation_replace_boolean_constant_with_constant_binary.h"
 #include "source/fuzz/transformation_replace_constant_with_uniform.h"
+#include "source/fuzz/transformation_replace_copy_memory_with_load_store.h"
 #include "source/fuzz/transformation_replace_id_with_synonym.h"
 #include "source/fuzz/transformation_replace_linear_algebra_instruction.h"
 #include "source/fuzz/transformation_replace_parameter_with_global.h"
@@ -216,6 +217,10 @@ std::unique_ptr<Transformation> Transformation::FromMessage(
         kReplaceConstantWithUniform:
       return MakeUnique<TransformationReplaceConstantWithUniform>(
           message.replace_constant_with_uniform());
+    case protobufs::Transformation::TransformationCase::
+        kReplaceCopyMemoryWithLoadStore:
+      return MakeUnique<TransformationReplaceCopyMemoryWithLoadStore>(
+          message.replace_copy_memory_with_load_store());
     case protobufs::Transformation::TransformationCase::kReplaceIdWithSynonym:
       return MakeUnique<TransformationReplaceIdWithSynonym>(
           message.replace_id_with_synonym());

--- a/source/fuzz/transformation_replace_copy_memory_with_load_store.cpp
+++ b/source/fuzz/transformation_replace_copy_memory_with_load_store.cpp
@@ -43,8 +43,8 @@ bool TransformationReplaceCopyMemoryWithLoadStore::IsApplicable(
   // OpCopyMemory.
   auto copy_memory_instruction =
       FindInstruction(message_.instruction_descriptor(), ir_context);
-  if ((!copy_memory_instruction) ||
-      (copy_memory_instruction->opcode() != SpvOpCopyMemory)) {
+  if (!copy_memory_instruction ||
+      copy_memory_instruction->opcode() != SpvOpCopyMemory) {
     return false;
   }
   // It must be valid to insert the OpStore and OpLoad instruction before it.
@@ -62,10 +62,12 @@ void TransformationReplaceCopyMemoryWithLoadStore::Apply(
       copy_memory_instruction->GetSingleWordInOperand(0));
   auto source = ir_context->get_def_use_mgr()->GetDef(
       copy_memory_instruction->GetSingleWordInOperand(1));
-  std::cout << fuzzerutil::GetTypeId(ir_context, target->result_id())
-            << std::endl;
-  assert(target->type_id() == SpvOpTypePointer &&
-         source->type_id() == SpvOpTypePointer &&
+  auto target_type_opcode =
+      ir_context->get_def_use_mgr()->GetDef(target->type_id())->opcode();
+  auto source_type_opcode =
+      ir_context->get_def_use_mgr()->GetDef(source->type_id())->opcode();
+  assert(target_type_opcode == SpvOpTypePointer &&
+         source_type_opcode == SpvOpTypePointer &&
          "Operands must be of type OpTypePointer");
   uint32_t target_pointee_type = fuzzerutil::GetPointeeTypeIdFromPointerType(
       ir_context, target->type_id());

--- a/source/fuzz/transformation_replace_copy_memory_with_load_store.cpp
+++ b/source/fuzz/transformation_replace_copy_memory_with_load_store.cpp
@@ -40,7 +40,7 @@ bool TransformationReplaceCopyMemoryWithLoadStore::IsApplicable(
   if (!fuzzerutil::IsFreshId(ir_context, message_.source_value())) {
     return false;
   }
-  // The instruction to insert before must be defined and of opcode
+  // The instruction to be replaced must be defined and of opcode
   // OpCopyMemory.
   auto copy_memory_instruction =
       FindInstruction(message_.instruction_descriptor(), ir_context);
@@ -64,7 +64,7 @@ void TransformationReplaceCopyMemoryWithLoadStore::Apply(
          copy_memory_instruction->opcode() == SpvOpCopyMemory &&
          "The required OpCopyMemory instruction must be defined.");
 
-  // Get ids used as a source and target of |copy_memory_instruction|.
+  // Get types of ids used as a source and target of |copy_memory_instruction|.
   auto target = ir_context->get_def_use_mgr()->GetDef(
       copy_memory_instruction->GetSingleWordInOperand(0));
   auto source = ir_context->get_def_use_mgr()->GetDef(

--- a/source/fuzz/transformation_replace_copy_memory_with_load_store.cpp
+++ b/source/fuzz/transformation_replace_copy_memory_with_load_store.cpp
@@ -1,0 +1,124 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_replace_copy_memory_with_load_store.h"
+
+#include "source/fuzz/fuzzer_util.h"
+#include "source/fuzz/instruction_descriptor.h"
+
+namespace spvtools {
+namespace fuzz {
+
+TransformationReplaceCopyMemoryWithLoadStore::
+    TransformationReplaceCopyMemoryWithLoadStore(
+        const spvtools::fuzz::protobufs::
+            TransformationReplaceCopyMemoryWithLoadStore& message)
+    : message_(message) {}
+
+TransformationReplaceCopyMemoryWithLoadStore::
+    TransformationReplaceCopyMemoryWithLoadStore(
+        uint32_t source_value,
+        const protobufs::InstructionDescriptor& instruction_descriptor) {
+  message_.set_source_value(source_value);
+  *message_.mutable_instruction_descriptor() = instruction_descriptor;
+}
+
+bool TransformationReplaceCopyMemoryWithLoadStore::IsApplicable(
+    opt::IRContext* ir_context, const TransformationContext& /*unused*/) const {
+  // |message_.source_value| must be fresh.
+  if (!fuzzerutil::IsFreshId(ir_context, message_.source_value())) return false;
+
+  // The instruction to insert before must be defined and of opcode
+  // OpCopyMemory.
+  auto copy_memory_instruction =
+      FindInstruction(message_.instruction_descriptor(), ir_context);
+  if ((!copy_memory_instruction) ||
+      (copy_memory_instruction->opcode() != SpvOpCopyMemory)) {
+    return false;
+  }
+  // It must be valid to insert the OpStore and OpLoad instruction before it.
+  return (fuzzerutil::CanInsertOpcodeBeforeInstruction(
+              SpvOpStore, copy_memory_instruction) &&
+          fuzzerutil::CanInsertOpcodeBeforeInstruction(
+              SpvOpLoad, copy_memory_instruction));
+}
+
+void TransformationReplaceCopyMemoryWithLoadStore::Apply(
+    opt::IRContext* ir_context, TransformationContext*) const {
+  auto copy_memory_instruction =
+      FindInstruction(message_.instruction_descriptor(), ir_context);
+  auto operand_target = copy_memory_instruction->GetSingleWordOperand(0);
+  auto operand_source = copy_memory_instruction->GetSingleWordOperand(1);
+  std::cout << operand_target << std::endl;
+  std::cout << operand_source << std::endl;
+}
+/*
+auto value_instruction =
+    ir_context->get_def_use_mgr()->GetDef(message_.value_id());
+
+// A pointer type instruction pointing to the value type must be defined.
+auto pointer_type_id = fuzzerutil::MaybeGetPointerType(
+    ir_context, value_instruction->type_id(),
+    static_cast<SpvStorageClass>(message_.variable_storage_class()));
+assert(pointer_type_id && "The required pointer type must be available.");
+
+// Adds whether a global or local variable.
+if (message_.variable_storage_class() == SpvStorageClassPrivate) {
+  fuzzerutil::AddGlobalVariable(ir_context, message_.variable_id(),
+                                pointer_type_id, SpvStorageClassPrivate,
+                                message_.initializer_id());
+} else {
+  auto function_id = ir_context
+                         ->get_instr_block(FindInstruction(
+                             message_.instruction_descriptor(), ir_context))
+                         ->GetParent()
+                         ->result_id();
+  fuzzerutil::AddLocalVariable(ir_context, message_.variable_id(),
+                               pointer_type_id, function_id,
+                               message_.initializer_id());
+}
+
+// First, insert the OpLoad instruction before |instruction_descriptor| and
+// then insert the OpStore instruction before the OpLoad instruction.
+fuzzerutil::UpdateModuleIdBound(ir_context, message_.value_synonym_id());
+FindInstruction(message_.instruction_descriptor(), ir_context)
+    ->InsertBefore(MakeUnique<opt::Instruction>(
+        ir_context, SpvOpLoad, value_instruction->type_id(),
+        message_.value_synonym_id(),
+        opt::Instruction::OperandList(
+            {{SPV_OPERAND_TYPE_ID, {message_.variable_id()}}})))
+    ->InsertBefore(MakeUnique<opt::Instruction>(
+        ir_context, SpvOpStore, 0, 0,
+        opt::Instruction::OperandList(
+            {{SPV_OPERAND_TYPE_ID, {message_.variable_id()}},
+             {SPV_OPERAND_TYPE_ID, {message_.value_id()}}})));
+
+ir_context->InvalidateAnalysesExceptFor(opt::IRContext::kAnalysisNone);
+
+// Adds the fact that |message_.value_synonym_id|
+// and |message_.value_id| are synonymous.
+transformation_context->GetFactManager()->AddFactDataSynonym(
+    MakeDataDescriptor(message_.value_synonym_id(), {}),
+    MakeDataDescriptor(message_.value_id(), {}), ir_context);
+    */
+
+protobufs::Transformation
+TransformationReplaceCopyMemoryWithLoadStore::ToMessage() const {
+  protobufs::Transformation result;
+  *result.mutable_replace_copy_memory_with_load_store() = message_;
+  return result;
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/transformation_replace_copy_memory_with_load_store.h
+++ b/source/fuzz/transformation_replace_copy_memory_with_load_store.h
@@ -32,14 +32,16 @@ class TransformationReplaceCopyMemoryWithLoadStore : public Transformation {
       uint32_t source_value,
       const protobufs::InstructionDescriptor& instruction_descriptor);
 
-  // - |source_value| must be fresh
-  // - |instruction_descriptor| must refer to an OpCopyMemory instruction.
+  // - |message_.source_value| must be a fresh id.
+  // - |message_.instruction_descriptor| must refer to an OpCopyMemory
+  //   instruction.
   bool IsApplicable(
       opt::IRContext* ir_context,
       const TransformationContext& transformation_context) const override;
 
-  // Replaces an OpCopyMemory instruction with loading to source_value and
-  // immediately storing it to the target of original OpCopyMemory instruction.
+  // Replaces instruction OpCopyMemory with loading the source variable to an
+  // intermediate value and storing this value into the target variable of the
+  // original OpCopyMemory instruction.
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 

--- a/source/fuzz/transformation_replace_copy_memory_with_load_store.h
+++ b/source/fuzz/transformation_replace_copy_memory_with_load_store.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SPIRV_TOOLS_TRANSFORMATION_REPLACE_COPY_MEMORY_WITH_LOAD_STORE_H
+#define SPIRV_TOOLS_TRANSFORMATION_REPLACE_COPY_MEMORY_WITH_LOAD_STORE_H
+
+#include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
+#include "source/fuzz/transformation.h"
+#include "source/fuzz/transformation_context.h"
+#include "source/opt/ir_context.h"
+
+namespace spvtools {
+namespace fuzz {
+
+class TransformationReplaceCopyMemoryWithLoadStore : public Transformation {
+ public:
+  explicit TransformationReplaceCopyMemoryWithLoadStore(
+      const protobufs::TransformationReplaceCopyMemoryWithLoadStore& message);
+
+  TransformationReplaceCopyMemoryWithLoadStore(
+      uint32_t source_value,
+      const protobufs::InstructionDescriptor& instruction_descriptor);
+
+  // - |source_value| must be fresh
+  // - |instruction_descriptor| must refer to an OpCopyMemory instruction.
+  bool IsApplicable(
+      opt::IRContext* ir_context,
+      const TransformationContext& transformation_context) const override;
+
+  // Replaces an OpCopyMemory instruction with loading to source_value and
+  // immediately storing it to the target of original OpCopyMemory instruction.
+  void Apply(opt::IRContext* ir_context,
+             TransformationContext* transformation_context) const override;
+
+  protobufs::Transformation ToMessage() const override;
+
+ private:
+  protobufs::TransformationReplaceCopyMemoryWithLoadStore message_;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SPIRV_TOOLS_TRANSFORMATION_REPLACE_COPY_MEMORY_WITH_LOAD_STORE_H

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -69,6 +69,7 @@ if (${SPIRV_BUILD_FUZZER})
           transformation_replace_parameter_with_global_test.cpp
           transformation_replace_boolean_constant_with_constant_binary_test.cpp
           transformation_replace_constant_with_uniform_test.cpp
+          transformation_replace_copy_memory_with_load_store_test.cpp
           transformation_replace_id_with_synonym_test.cpp
           transformation_replace_linear_algebra_instruction_test.cpp
           transformation_replace_params_with_struct_test.cpp

--- a/test/fuzz/transformation_replace_copy_memory_with_load_store_test.cpp
+++ b/test/fuzz/transformation_replace_copy_memory_with_load_store_test.cpp
@@ -66,6 +66,12 @@ TEST(TransformationReplaceCopyMemoryWithLoadStoreTest, BasicScenarios) {
       transformation.IsApplicable(context.get(), transformation_context));
   transformation.Apply(context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
+  std::vector<uint32_t> actual_binary;
+  context.get()->module()->ToBinary(&actual_binary, false);
+  SpirvTools t(env);
+  std::string actual_disassembled;
+  t.Disassemble(actual_binary, &actual_disassembled, kFuzzDisassembleOption);
+  std::cout << actual_disassembled;
 }
 
 }  // namespace

--- a/test/fuzz/transformation_replace_copy_memory_with_load_store_test.cpp
+++ b/test/fuzz/transformation_replace_copy_memory_with_load_store_test.cpp
@@ -1,0 +1,105 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_replace_copy_memory_with_load_store.h"
+#include "test/fuzz/fuzz_test_util.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace {
+TEST(TransformationReplaceCopyMemoryWithLoadStoreTest, BasicScenarios) {
+  // This is a simple transformation and this test handles the main cases.
+
+  std::string shader = R"(
+               
+    )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  fact_manager.AddFactBlockIsDead(100);
+
+  // Invalid: 200 is not an id.
+  ASSERT_FALSE(TransformationAddRelaxedDecoration(200).IsApplicable(
+      context.get(), transformation_context));
+  // Invalid: 27 is not in a dead block.
+  ASSERT_FALSE(TransformationAddRelaxedDecoration(27).IsApplicable(
+      context.get(), transformation_context));
+  // Invalid: 28 is in a dead block, but returns bool (not numeric).
+  ASSERT_FALSE(TransformationAddRelaxedDecoration(28).IsApplicable(
+      context.get(), transformation_context));
+  // It is valid to add RelaxedPrecision to 25 (and it's fine to
+  // have a duplicate).
+  for (uint32_t result_id : {25u, 25u}) {
+    TransformationAddRelaxedDecoration transformation(result_id);
+    ASSERT_TRUE(
+        transformation.IsApplicable(context.get(), transformation_context));
+    transformation.Apply(context.get(), &transformation_context);
+    ASSERT_TRUE(IsValid(env, context.get()));
+  }
+
+  std::string after_transformation = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %8 "a"
+               OpName %10 "b"
+               OpName %14 "c"
+               OpDecorate %25 RelaxedPrecision
+               OpDecorate %25 RelaxedPrecision
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Function %6
+          %9 = OpConstant %6 4
+         %11 = OpConstant %6 6
+         %12 = OpTypeBool
+         %13 = OpTypePointer Function %12
+         %15 = OpConstantTrue %12
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+          %8 = OpVariable %7 Function
+         %10 = OpVariable %7 Function
+         %14 = OpVariable %13 Function
+               OpStore %8 %9
+               OpStore %10 %11
+               OpStore %14 %15
+               OpSelectionMerge %19 None
+               OpBranchConditional %15 %19 %100
+        %100 = OpLabel
+         %25 = OpISub %6 %9 %11
+         %28 = OpLogicalNot %12 %15
+               OpBranch %19
+         %19 = OpLabel
+         %27 = OpISub %6 %9 %11
+               OpReturn
+               OpFunctionEnd
+  )";
+  ASSERT_TRUE(IsEqual(env, after_transformation, context.get()));
+}
+
+}  // namespace
+}  // namespace fuzz
+}  // namespace spvtools

--- a/test/fuzz/transformation_replace_copy_memory_with_load_store_test.cpp
+++ b/test/fuzz/transformation_replace_copy_memory_with_load_store_test.cpp
@@ -19,6 +19,7 @@
 namespace spvtools {
 namespace fuzz {
 namespace {
+
 TEST(TransformationReplaceCopyMemoryWithLoadStoreTest, BasicScenarios) {
   // This is a simple transformation and this test handles the main cases.
 
@@ -77,13 +78,13 @@ TEST(TransformationReplaceCopyMemoryWithLoadStoreTest, BasicScenarios) {
   auto instruction_descriptor_valid_2 =
       MakeInstructionDescriptor(5, SpvOpCopyMemory, 0);
 
-  // Invalid: |source_id| is not fresh
+  // Invalid: |source_id| is not a fresh id.
   auto transformation_invalid_1 = TransformationReplaceCopyMemoryWithLoadStore(
       15, instruction_descriptor_valid_1);
   ASSERT_FALSE(transformation_invalid_1.IsApplicable(context.get(),
                                                      transformation_context));
 
-  // Invalid: |instruction_descriptor_invalid| refers to an instruction OpStore
+  // Invalid: |instruction_descriptor_invalid| refers to an instruction OpStore.
   auto transformation_invalid_2 = TransformationReplaceCopyMemoryWithLoadStore(
       20, instruction_descriptor_invalid_1);
   ASSERT_FALSE(transformation_invalid_2.IsApplicable(context.get(),


### PR DESCRIPTION
Adds a transformation that replaces instruction OpCopyMemory with
loading the source variable to an intermediate value and storing this
value into the target variable of the original OpCopyMemory instruction.

Fixes #3352