### PR TITLE
spirv-fuzz: Split blocks starting with OpPhi before trying to outline

### DIFF
--- a/source/fuzz/fuzzer_pass_outline_functions.cpp
+++ b/source/fuzz/fuzzer_pass_outline_functions.cpp
@@ -52,22 +52,19 @@ void FuzzerPassOutlineFunctions::Apply() {
     // If the entry block starts with OpPhi, try to split it.
     if (entry_block->begin()->opcode() == SpvOpPhi) {
       // Find the first non-OpPhi instruction.
-      opt::Instruction* non_phi_inst = nullptr;
-      for (auto phi_inst : *entry_block) {
-        if (phi_inst.NextNode()->opcode() != SpvOpPhi) {
-          non_phi_inst = phi_inst.NextNode();
+      opt::Instruction* non_phi_inst;
+      for (auto instruction : *entry_block) {
+        if (instruction.opcode() != SpvOpPhi) {
+          non_phi_inst = &instruction;
           break;
         }
       }
 
-      // Sanity check.
-      assert(non_phi_inst && non_phi_inst->opcode() != SpvOpPhi &&
-             non_phi_inst->PreviousNode()->opcode() == SpvOpPhi);
-
       // If the split was not applicable, the transformation will not work.
       uint32_t new_block_id = GetFuzzerContext()->GetFreshId();
       if (!MaybeApplyTransformation(TransformationSplitBlock(
-              MakeInstructionDescriptor(GetIRContext(), non_phi_inst),
+              MakeInstructionDescriptor(non_phi_inst->result_id(),
+                                        non_phi_inst->opcode(), 0),
               new_block_id))) {
         return;
       }

--- a/source/fuzz/fuzzer_pass_outline_functions.cpp
+++ b/source/fuzz/fuzzer_pass_outline_functions.cpp
@@ -17,7 +17,9 @@
 #include <vector>
 
 #include "source/fuzz/fuzzer_util.h"
+#include "source/fuzz/instruction_descriptor.h"
 #include "source/fuzz/transformation_outline_function.h"
+#include "source/fuzz/transformation_split_block.h"
 
 namespace spvtools {
 namespace fuzz {
@@ -46,6 +48,34 @@ void FuzzerPassOutlineFunctions::Apply() {
       blocks.push_back(&block);
     }
     auto entry_block = blocks[GetFuzzerContext()->RandomIndex(blocks)];
+
+    // If the entry block starts with OpPhi, try to split it.
+    if (entry_block->begin()->opcode() == SpvOpPhi) {
+      // Find the first non-OpPhi instruction.
+      opt::Instruction* non_phi_inst = nullptr;
+      for (auto phi_inst : *entry_block) {
+        if (phi_inst.NextNode()->opcode() != SpvOpPhi) {
+          non_phi_inst = phi_inst.NextNode();
+          break;
+        }
+      }
+
+      // Sanity check.
+      assert(non_phi_inst && non_phi_inst->opcode() != SpvOpPhi &&
+             non_phi_inst->PreviousNode()->opcode() == SpvOpPhi);
+
+      // If the split was not applicable, the transformation will not work.
+      uint32_t new_block_id = GetFuzzerContext()->GetFreshId();
+      if (!MaybeApplyTransformation(TransformationSplitBlock(
+              MakeInstructionDescriptor(GetIRContext(), non_phi_inst),
+              new_block_id))) {
+        return;
+      }
+
+      // The new entry block is the newly-created block.
+      entry_block = &*function->FindBlock(new_block_id);
+    }
+
     auto dominator_analysis = GetIRContext()->GetDominatorAnalysis(function);
     auto postdominator_analysis =
         GetIRContext()->GetPostDominatorAnalysis(function);


### PR DESCRIPTION
This PR modifies FuzzerPassOutlineFunctions so that it tries to split
a block starting with OpPhi instructions, so that it is more likely
that the selected blocks can be outlined using
TransformationOutlineFunction.

Fixes #3094 .