### PR TITLE
Avoid use of 'sanity' and 'sanity check' in the code base

### DIFF
--- a/source/fuzz/transformation_set_loop_control.cpp
+++ b/source/fuzz/transformation_set_loop_control.cpp
@@ -42,8 +42,8 @@ bool TransformationSetLoopControl::IsApplicable(
     return false;
   }
 
-  // We sanity-check that the transformation does not try to set any meaningless
-  // bits of the loop control mask.
+  // We coherence-check that the transformation does not try to set any
+  // meaningless bits of the loop control mask.
   uint32_t all_loop_control_mask_bits_set =
       SpvLoopControlUnrollMask | SpvLoopControlDontUnrollMask |
       SpvLoopControlDependencyInfiniteMask |

--- a/source/fuzz/transformation_set_loop_control.cpp
+++ b/source/fuzz/transformation_set_loop_control.cpp
@@ -42,8 +42,8 @@ bool TransformationSetLoopControl::IsApplicable(
     return false;
   }
 
-  // We coherence-check that the transformation does not try to set any
-  // meaningless bits of the loop control mask.
+  // We assert that the transformation does not try to set any meaningless bits
+  // of the loop control mask.
   uint32_t all_loop_control_mask_bits_set =
       SpvLoopControlUnrollMask | SpvLoopControlDontUnrollMask |
       SpvLoopControlDependencyInfiniteMask |

--- a/source/fuzz/transformation_split_block.cpp
+++ b/source/fuzz/transformation_split_block.cpp
@@ -135,7 +135,7 @@ void TransformationSplitBlock::Apply(
   // predecessor operand so that the block they used to be inside is now the
   // predecessor.
   new_bb->ForEachPhiInst([block_to_split](opt::Instruction* phi_inst) {
-    // The following assertion is a sanity check.  It is guaranteed to hold
+    // The following assertion is a coherence check.  It is guaranteed to hold
     // if IsApplicable holds.
     assert(phi_inst->NumInOperands() == 2 &&
            "We can only split a block before an OpPhi if block has exactly "

--- a/source/fuzz/transformation_split_block.cpp
+++ b/source/fuzz/transformation_split_block.cpp
@@ -135,11 +135,10 @@ void TransformationSplitBlock::Apply(
   // predecessor operand so that the block they used to be inside is now the
   // predecessor.
   new_bb->ForEachPhiInst([block_to_split](opt::Instruction* phi_inst) {
-    // The following assertion is a coherence check.  It is guaranteed to hold
-    // if IsApplicable holds.
-    assert(phi_inst->NumInOperands() == 2 &&
-           "We can only split a block before an OpPhi if block has exactly "
-           "one predecessor.");
+    assert(
+        phi_inst->NumInOperands() == 2 &&
+        "Precondition: a block can only be split before an OpPhi if the block"
+        "has exactly one predecessor.");
     phi_inst->SetInOperand(1, {block_to_split->id()});
   });
 

--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -696,7 +696,7 @@ Pass::Status AggressiveDCEPass::ProcessImpl() {
   // been marked, it is safe to remove dead global values.
   modified |= ProcessGlobalValues();
 
-  // Sanity check.
+  // Coherence check.
   assert(to_kill_.size() == 0 || modified);
 
   // Kill all dead instructions.

--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -696,8 +696,8 @@ Pass::Status AggressiveDCEPass::ProcessImpl() {
   // been marked, it is safe to remove dead global values.
   modified |= ProcessGlobalValues();
 
-  // Coherence check.
-  assert(to_kill_.size() == 0 || modified);
+  assert((to_kill_.empty() || modified) &&
+         "A dead instruction was identified, but no change recorded.");
 
   // Kill all dead instructions.
   for (auto inst : to_kill_) {

--- a/source/opt/loop_peeling.cpp
+++ b/source/opt/loop_peeling.cpp
@@ -1063,7 +1063,7 @@ LoopPeelingPass::LoopPeelingInfo::HandleInequality(CmpOperator cmp_op,
   }
 
   uint32_t cast_iteration = 0;
-  // sanity check: can we fit |iteration| in a uint32_t ?
+  // coherence check: can we fit |iteration| in a uint32_t ?
   if (static_cast<uint64_t>(iteration) < std::numeric_limits<uint32_t>::max()) {
     cast_iteration = static_cast<uint32_t>(iteration);
   }

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -579,8 +579,8 @@ bool Optimizer::Run(const uint32_t* original_binary,
 
 #ifndef NDEBUG
   // We do not keep the result id of DebugScope in struct DebugScope.
-  // Instead, we assign random ids for them, which results in sanity
-  // check failures. We want to skip the sanity check when the module
+  // Instead, we assign random ids for them, which results in coherence
+  // check failures. We want to skip the coherence check when the module
   // contains DebugScope instructions.
   if (status == opt::Pass::Status::SuccessWithoutChange &&
       !context->module()->ContainsDebugScope()) {

--- a/source/reduce/operand_to_dominating_id_reduction_opportunity_finder.cpp
+++ b/source/reduce/operand_to_dominating_id_reduction_opportunity_finder.cpp
@@ -91,7 +91,8 @@ void OperandToDominatingIdReductionOpportunityFinder::
             // constant.  It is thus not relevant to this pass.
             continue;
           }
-          // Sanity check that we don't get here if the argument is a constant.
+          // Coherence check: we should not get here if the argument is a
+          // constant.
           assert(!context->get_constant_mgr()->GetConstantFromInst(def));
           if (def->type_id() != candidate_dominator->type_id()) {
             // The types need to match.

--- a/test/binary_parse_test.cpp
+++ b/test/binary_parse_test.cpp
@@ -92,7 +92,7 @@ std::ostream& operator<<(std::ostream& os, const ParsedInstruction& inst) {
   return os;
 }
 
-// Sanity check for the equality operator on ParsedInstruction.
+// Coherence check for the equality operator on ParsedInstruction.
 TEST(ParsedInstruction, ZeroInitializedAreEqual) {
   spv_parsed_instruction_t pi = {};
   ParsedInstruction a(pi);

--- a/test/fuzz/transformation_add_dead_break_test.cpp
+++ b/test/fuzz/transformation_add_dead_break_test.cpp
@@ -21,7 +21,7 @@ namespace {
 
 TEST(TransformationAddDeadBreakTest, BreaksOutOfSimpleIf) {
   // For a simple if-then-else, checks that some dead break scenarios are
-  // possible, and sanity-checks that some illegal scenarios are indeed not
+  // possible, and coherence-checks that some illegal scenarios are indeed not
   // allowed.
 
   // The SPIR-V for this test is adapted from the following GLSL, by separating

--- a/test/fuzz/transformation_add_dead_continue_test.cpp
+++ b/test/fuzz/transformation_add_dead_continue_test.cpp
@@ -21,8 +21,8 @@ namespace {
 
 TEST(TransformationAddDeadContinueTest, SimpleExample) {
   // For a simple loop, checks that some dead continue scenarios are possible,
-  // sanity-checks that some illegal scenarios are indeed not allowed, and then
-  // applies a transformation.
+  // coherence-checks that some illegal scenarios are indeed not allowed, and
+  // then applies a transformation.
 
   // The SPIR-V for this test is adapted from the following GLSL, by separating
   // some assignments into their own basic blocks, and adding constants for true

--- a/test/opcode_table_get_test.cpp
+++ b/test/opcode_table_get_test.cpp
@@ -21,7 +21,7 @@ namespace {
 using GetTargetOpcodeTableGetTest = ::testing::TestWithParam<spv_target_env>;
 using ::testing::ValuesIn;
 
-TEST_P(GetTargetOpcodeTableGetTest, SanityCheck) {
+TEST_P(GetTargetOpcodeTableGetTest, CoherenceCheck) {
   spv_opcode_table table;
   ASSERT_EQ(SPV_SUCCESS, spvOpcodeTableGet(&table, GetParam()));
   ASSERT_NE(0u, table->count);

--- a/test/opt/graphics_robust_access_test.cpp
+++ b/test/opt/graphics_robust_access_test.cpp
@@ -1323,7 +1323,7 @@ TEST_F(GraphicsRobustAccessTest,
   // Split the address calculation across two access chains.  Force
   // the transform to walk up the access chains to find the base variable.
   // This time, put the different access chains in different basic blocks.
-  // This sanity checks that we keep the instruction-to-block mapping
+  // This coherence-checks that we keep the instruction-to-block mapping
   // consistent.
   for (auto* ac : AccessChains()) {
     std::ostringstream shaders;

--- a/utils/vscode/src/parser/parser.go
+++ b/utils/vscode/src/parser/parser.go
@@ -356,7 +356,7 @@ func lex(source string) ([]*Token, []Diagnostic, error) {
 
 	lastPos := Position{}
 	for l.e == nil {
-		// Sanity check the parser is making progress
+		// Coherence-check that the parser is making progress
 		if l.pos == lastPos {
 			log.Panicf("Parsing stuck at %v", l.pos)
 		}


### PR DESCRIPTION
In line with:

  https://source.android.com/setup/contribute/respectful-code

this change uses the terms 'coherence' and 'coherence check' where
'sanity' and 'sanity check' were previously used.