### PR TITLE
CMake: install cmake files in libdir/cmake if not compiled with msvc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,7 +210,7 @@ else()
 endif()
 
 if(ENABLE_SPIRV_TOOLS_INSTALL)
-  if(WIN32)
+  if(MSVC)
     macro(spvtools_config_package_dir TARGET PATH)
       set(${PATH} ${TARGET}/cmake)
     endmacro()


### PR DESCRIPTION
when compiled with GCC or Clang in Windows the cmake files are installed
in individual folder. But with this change cmake files are placed in lib
folder which follows the GNUInstallDirs rules.