### PR TITLE
spirv-fuzz: Set message consumer in replayer when shrinking

### DIFF
--- a/test/fuzz/fuzzer_shrinker_test.cpp
+++ b/test/fuzz/fuzzer_shrinker_test.cpp
@@ -1111,6 +1111,18 @@ TEST(FuzzerShrinkerTest, Miscellaneous3) {
     *temp.mutable_constant_uniform_fact() = resolution_y_eq_100;
     *facts.mutable_fact()->Add() = temp;
   }
+  // Also add an invalid fact, which should be ignored.
+  {
+    protobufs::FactConstantUniform bad_fact;
+    // The descriptor set, binding and indices used here deliberately make no
+    // sense.
+    *bad_fact.mutable_uniform_buffer_element_descriptor() =
+        MakeUniformBufferElementDescriptor(22, 33, {44, 55});
+    *bad_fact.mutable_constant_word()->Add() = 100;
+    protobufs::Fact temp;
+    *temp.mutable_constant_uniform_fact() = bad_fact;
+    *facts.mutable_fact()->Add() = temp;
+  }
 
   // Do 2 fuzzer runs, starting from an initial seed of 194 (seed value chosen
   // arbitrarily).


### PR DESCRIPTION
Fixes an issue with the shrinker, where the message consumer set for
the shrinker was not being passed on to the replay object that the
shrinker creates.  This meant that messages generated during replay
would cause an exception to be thrown.