### PR TITLE
spirv-fuzz: Transformation to add loop preheader

### DIFF
--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -107,6 +107,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_add_global_variable.h
         transformation_add_image_sample_unused_components.h
         transformation_add_local_variable.h
+        transformation_add_loop_preheader.h
         transformation_add_no_contraction_decoration.h
         transformation_add_parameter.h
         transformation_add_relaxed_decoration.h
@@ -235,6 +236,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_add_global_variable.cpp
         transformation_add_image_sample_unused_components.cpp
         transformation_add_local_variable.cpp
+        transformation_add_loop_preheader.cpp
         transformation_add_no_contraction_decoration.cpp
         transformation_add_parameter.cpp
         transformation_add_relaxed_decoration.cpp

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -719,14 +719,14 @@ message TransformationAddLoopPreheader {
   // This allows turning instructions of the form:
   //
   //   %loop_header_block = OpLabel
-  //                 %id1 = OpPhi %type %pred1_id %val1 %pred2_id %val2 %backedge_block_id %val3
+  //                 %id1 = OpPhi %type %val1 %pred1_id %val2 %pred2_id %val3 %backedge_block_id
   //
   // into:
   //            %fresh_id = OpLabel
-  //             %phi_id1 = OpPhi %type %pred1_id %val1 %pred2_id %val2
+  //             %phi_id1 = OpPhi %type %val1 %pred1_id %val2 %pred2_id
   //                        OpBranch %header_id
   //   %loop_header_block = OpLabel
-  //                 %id1 = OpPhi %type %fresh_id %phi_id1 %backedge_block_id %val3
+  //                 %id1 = OpPhi %type %phi_id1 %fresh_id %val3 %backedge_block_id
   repeated uint32 phi_id = 3;
 
 }

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -407,6 +407,7 @@ message Transformation {
     TransformationReplaceCopyObjectWithStoreLoad replace_copy_object_with_store_load = 60;
     TransformationReplaceCopyMemoryWithLoadStore replace_copy_memory_with_load_store = 61;
     TransformationReplaceLoadStoreWithCopyMemory replace_load_store_with_copy_memory = 62;
+    TransformationAddLoopPreheader add_loop_preheader = 63;
     // Add additional option using the next available number.
   }
 }
@@ -700,6 +701,32 @@ message TransformationAddLocalVariable {
   // performed in an arbitrary fashion.
   bool value_is_irrelevant = 5;
 
+}
+
+message TransformationAddLoopPreheader {
+
+  // A transformation that adds a loop preheader block before the given loop header.
+
+  // The id of the loop header block
+  uint32 header_id = 1;
+
+  // A fresh id for the preheader block
+  uint32 fresh_id = 2;
+
+  // Fresh ids for splitting the OpPhi instructions in the header.
+  // A new OpPhi instruction in the preheader is needed for each OpPhi instruction in the header.
+  // This allows turning instructions of the form:
+  //
+  //   %header_id = OpLabel
+  //         %id1 = OpPhi %type %pred1_id %val1 %pred2_id %val2 %backedge_block_id %val3
+  //
+  // into:
+  //    %fresh_id = OpLabel
+  //     %phi_id1 = OpPhi %type %pred1_id %val1 %pred2_id %val2
+  //                OpBranch %header_id
+  //   %header_id = OpLabel
+  //         %id1 = OpPhi %type %fresh_id %phi_id1 %backedge_block_id %val3
+  repeated uint32 phi_id = 3;
 }
 
 message TransformationAddNoContractionDecoration {

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -708,7 +708,7 @@ message TransformationAddLoopPreheader {
   // A transformation that adds a loop preheader block before the given loop header.
 
   // The id of the loop header block
-  uint32 header_id = 1;
+  uint32 loop_header_block = 1;
 
   // A fresh id for the preheader block
   uint32 fresh_id = 2;
@@ -717,16 +717,17 @@ message TransformationAddLoopPreheader {
   // A new OpPhi instruction in the preheader is needed for each OpPhi instruction in the header.
   // This allows turning instructions of the form:
   //
-  //   %header_id = OpLabel
-  //         %id1 = OpPhi %type %pred1_id %val1 %pred2_id %val2 %backedge_block_id %val3
+  //   %loop_header_block = OpLabel
+  //                 %id1 = OpPhi %type %pred1_id %val1 %pred2_id %val2 %backedge_block_id %val3
   //
   // into:
-  //    %fresh_id = OpLabel
-  //     %phi_id1 = OpPhi %type %pred1_id %val1 %pred2_id %val2
-  //                OpBranch %header_id
-  //   %header_id = OpLabel
-  //         %id1 = OpPhi %type %fresh_id %phi_id1 %backedge_block_id %val3
+  //            %fresh_id = OpLabel
+  //             %phi_id1 = OpPhi %type %pred1_id %val1 %pred2_id %val2
+  //                        OpBranch %header_id
+  //   %loop_header_block = OpLabel
+  //                 %id1 = OpPhi %type %fresh_id %phi_id1 %backedge_block_id %val3
   repeated uint32 phi_id = 3;
+
 }
 
 message TransformationAddNoContractionDecoration {

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -714,7 +714,8 @@ message TransformationAddLoopPreheader {
   uint32 fresh_id = 2;
 
   // Fresh ids for splitting the OpPhi instructions in the header.
-  // A new OpPhi instruction in the preheader is needed for each OpPhi instruction in the header.
+  // A new OpPhi instruction in the preheader is needed for each OpPhi instruction in the header,
+  // if the header has more than one predecessor outside of the loop.
   // This allows turning instructions of the form:
   //
   //   %loop_header_block = OpLabel

--- a/source/fuzz/transformation.cpp
+++ b/source/fuzz/transformation.cpp
@@ -31,6 +31,7 @@
 #include "source/fuzz/transformation_add_global_variable.h"
 #include "source/fuzz/transformation_add_image_sample_unused_components.h"
 #include "source/fuzz/transformation_add_local_variable.h"
+#include "source/fuzz/transformation_add_loop_preheader.h"
 #include "source/fuzz/transformation_add_no_contraction_decoration.h"
 #include "source/fuzz/transformation_add_parameter.h"
 #include "source/fuzz/transformation_add_relaxed_decoration.h"
@@ -127,6 +128,9 @@ std::unique_ptr<Transformation> Transformation::FromMessage(
     case protobufs::Transformation::TransformationCase::kAddLocalVariable:
       return MakeUnique<TransformationAddLocalVariable>(
           message.add_local_variable());
+    case protobufs::Transformation::TransformationCase::kAddLoopPreheader:
+      return MakeUnique<TransformationAddLoopPreheader>(
+          message.add_loop_preheader());
     case protobufs::Transformation::TransformationCase::
         kAddNoContractionDecoration:
       return MakeUnique<TransformationAddNoContractionDecoration>(

--- a/source/fuzz/transformation_add_loop_preheader.cpp
+++ b/source/fuzz/transformation_add_loop_preheader.cpp
@@ -35,7 +35,7 @@ TransformationAddLoopPreheader::TransformationAddLoopPreheader(
 
 bool TransformationAddLoopPreheader::IsApplicable(
     opt::IRContext* ir_context,
-    const TransformationContext& transformation_context) const {
+    const TransformationContext& /* unused */) const {
   // |message_.loop_header_block()| must be the id of a loop header block.
   opt::BasicBlock* loop_header_block =
       fuzzerutil::MaybeFindBlock(ir_context, message_.loop_header_block());
@@ -52,7 +52,7 @@ bool TransformationAddLoopPreheader::IsApplicable(
 
   // If the block only has one predecessor outside of the loop (and thus 2 in
   // total), then no additional fresh ids are necessary.
-  if (ir_context->cfg()->preds(message_.fresh_id()).size() == 2) {
+  if (ir_context->cfg()->preds(message_.loop_header_block()).size() == 2) {
     return true;
   }
 

--- a/source/fuzz/transformation_add_loop_preheader.cpp
+++ b/source/fuzz/transformation_add_loop_preheader.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transformation_add_loop_preheader.h"
+
+namespace spvtools {
+namespace fuzz {
+TransformationAddLoopPreheader::TransformationAddLoopPreheader(
+    const protobufs::TransformationAddLoopPreheader& message)
+    : message_(message) {}
+
+TransformationAddLoopPreheader::TransformationAddLoopPreheader(
+    uint32_t loop_header_block, uint32_t fresh_id,
+    std::vector<uint32_t> phi_id) {
+  message_.set_loop_header_block(loop_header_block);
+  message_.set_fresh_id(fresh_id);
+  for (auto id : phi_id) {
+    message_.add_phi_id(id);
+  }
+}
+
+bool TransformationAddLoopPreheader::IsApplicable(
+    opt::IRContext* /* ir_context */,
+    const TransformationContext& /* transformation_context */) const {
+  return false;
+}
+void TransformationAddLoopPreheader::Apply(
+    opt::IRContext* /* ir_context */,
+    TransformationContext* /* transformation_context */) const {}
+
+protobufs::Transformation TransformationAddLoopPreheader::ToMessage() const {
+  protobufs::Transformation result;
+  *result.mutable_add_loop_preheader() = message_;
+  return result;
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/transformation_add_loop_preheader.cpp
+++ b/source/fuzz/transformation_add_loop_preheader.cpp
@@ -14,6 +14,9 @@
 
 #include "transformation_add_loop_preheader.h"
 
+#include "source/fuzz/fuzzer_util.h"
+#include "source/opt/instruction.h"
+
 namespace spvtools {
 namespace fuzz {
 TransformationAddLoopPreheader::TransformationAddLoopPreheader(
@@ -31,10 +34,49 @@ TransformationAddLoopPreheader::TransformationAddLoopPreheader(
 }
 
 bool TransformationAddLoopPreheader::IsApplicable(
-    opt::IRContext* /* ir_context */,
-    const TransformationContext& /* transformation_context */) const {
-  return false;
+    opt::IRContext* ir_context,
+    const TransformationContext& transformation_context) const {
+  // |message_.loop_header_block()| must be the id of a loop header block.
+  opt::BasicBlock* loop_header_block =
+      fuzzerutil::MaybeFindBlock(ir_context, message_.loop_header_block());
+  if (!loop_header_block || !loop_header_block->IsLoopHeader()) {
+    return false;
+  }
+
+  // The id for the preheader must actually be fresh.
+  std::set<uint32_t> used_ids;
+  if (!CheckIdIsFreshAndNotUsedByThisTransformation(message_.fresh_id(),
+                                                    ir_context, &used_ids)) {
+    return false;
+  }
+
+  // If the block only has one predecessor outside of the loop (and thus 2 in
+  // total), then no additional fresh ids are necessary.
+  if (ir_context->cfg()->preds(message_.fresh_id()).size() == 2) {
+    return true;
+  }
+
+  // Count the number of OpPhi instructions.
+  int32_t num_phi_insts = 0;
+  loop_header_block->ForEachPhiInst(
+      [&num_phi_insts](opt::Instruction* /* unused */) { num_phi_insts++; });
+
+  // There must be enough fresh ids for the OpPhi instructions.
+  if (num_phi_insts > message_.phi_id_size()) {
+    return false;
+  }
+
+  // Check that the needed ids are fresh and distinct.
+  for (int32_t i = 0; i < num_phi_insts; i++) {
+    if (!CheckIdIsFreshAndNotUsedByThisTransformation(message_.phi_id(i),
+                                                      ir_context, &used_ids)) {
+      return false;
+    }
+  }
+
+  return true;
 }
+
 void TransformationAddLoopPreheader::Apply(
     opt::IRContext* /* ir_context */,
     TransformationContext* /* transformation_context */) const {}

--- a/source/fuzz/transformation_add_loop_preheader.h
+++ b/source/fuzz/transformation_add_loop_preheader.h
@@ -28,12 +28,20 @@ class TransformationAddLoopPreheader : public Transformation {
   TransformationAddLoopPreheader(uint32_t loop_header_block, uint32_t fresh_id,
                                  std::vector<uint32_t> phi_id);
 
-  // TODO: Comment
+  // - |message_.loop_header_block| must be the id of a loop header block in
+  //   the given module.
+  // - |message_.fresh_id| must be an available id.
+  // - |message_.phi_ids| must be a list of available ids.
+  //   It can be empty if the loop header only has one predecessor outside of
+  //   the loop. Otherwise, it must contain at least as many ids as OpPhi
+  //   instructions in the loop header block.
   bool IsApplicable(
       opt::IRContext* ir_context,
       const TransformationContext& transformation_context) const override;
 
-  // TODO: Comment
+  // Adds a preheader block as the unique out-of-loop predecessor of the given
+  // loop header block. All of the existing out-of-loop predecessors of the
+  // header are changed so that they branch to the preheader instead.
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 

--- a/source/fuzz/transformation_add_loop_preheader.h
+++ b/source/fuzz/transformation_add_loop_preheader.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_TRANSFORMATION_ADD_LOOP_PREHEADER_H
+#define SOURCE_FUZZ_TRANSFORMATION_ADD_LOOP_PREHEADER_H
+
+#include "source/fuzz/transformation.h"
+
+namespace spvtools {
+namespace fuzz {
+
+class TransformationAddLoopPreheader : public Transformation {
+ public:
+  explicit TransformationAddLoopPreheader(
+      const protobufs::TransformationAddLoopPreheader& message);
+
+  TransformationAddLoopPreheader(uint32_t loop_header_block, uint32_t fresh_id,
+                                 std::vector<uint32_t> phi_id);
+
+  // TODO: Comment
+  bool IsApplicable(
+      opt::IRContext* ir_context,
+      const TransformationContext& transformation_context) const override;
+
+  // TODO: Comment
+  void Apply(opt::IRContext* ir_context,
+             TransformationContext* transformation_context) const override;
+
+  protobufs::Transformation ToMessage() const override;
+
+ private:
+  protobufs::TransformationAddLoopPreheader message_;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_TRANSFORMATION_ADD_LOOP_PREHEADER_H

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -39,6 +39,7 @@ if (${SPIRV_BUILD_FUZZER})
           transformation_add_global_variable_test.cpp
           transformation_add_image_sample_unused_components_test.cpp
           transformation_add_local_variable_test.cpp
+          transformation_add_loop_preheader_test.cpp
           transformation_add_no_contraction_decoration_test.cpp
           transformation_add_parameter_test.cpp
           transformation_add_relaxed_decoration_test.cpp

--- a/test/fuzz/transformation_add_loop_preheader_test.cpp
+++ b/test/fuzz/transformation_add_loop_preheader_test.cpp
@@ -51,6 +51,13 @@ TEST(TransformationAddLoopPreheaderTest, SimpleTest) {
                OpBranch %13
          %13 = OpLabel
                OpBranchConditional %7 %14 %12
+         %15 = OpLabel
+               OpLoopMerge %17 %16 None
+               OpBranch %16
+         %16 = OpLabel
+               OpBranchConditional %7 %15 %17
+         %17 = OpLabel
+               OpBranch %14
          %14 = OpLabel
                OpReturn
                OpFunctionEnd
@@ -73,6 +80,11 @@ TEST(TransformationAddLoopPreheaderTest, SimpleTest) {
 
   // The id %12 is not fresh
   ASSERT_FALSE(TransformationAddLoopPreheader(10, 12, {})
+                   .IsApplicable(context.get(), transformation_context));
+
+  // Loop header %15 is not reachable (the only predecessor is the back-edge
+  // block)
+  ASSERT_FALSE(TransformationAddLoopPreheader(15, 100, {})
                    .IsApplicable(context.get(), transformation_context));
 
   auto transformation1 = TransformationAddLoopPreheader(10, 20, {});
@@ -121,6 +133,13 @@ TEST(TransformationAddLoopPreheaderTest, SimpleTest) {
                OpBranch %13
          %13 = OpLabel
                OpBranchConditional %7 %14 %12
+         %15 = OpLabel
+               OpLoopMerge %17 %16 None
+               OpBranch %16
+         %16 = OpLabel
+               OpBranchConditional %7 %15 %17
+         %17 = OpLabel
+               OpBranch %14
          %14 = OpLabel
                OpReturn
                OpFunctionEnd

--- a/test/fuzz/transformation_add_loop_preheader_test.cpp
+++ b/test/fuzz/transformation_add_loop_preheader_test.cpp
@@ -1,0 +1,169 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_add_loop_preheader.h"
+
+#include "test/fuzz/fuzz_test_util.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace {
+
+TEST(TransformationAddLoopPreheaderTest, SimpleTest) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeBool
+          %7 = OpConstantFalse %6
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpBranch %8
+          %8 = OpLabel
+               OpLoopMerge %10 %9 None
+               OpBranch %9
+          %9 = OpLabel
+               OpBranchConditional %7 %8 %10
+         %10 = OpLabel
+               OpSelectionMerge %13 None
+               OpBranchConditional %7 %11 %12
+         %11 = OpLabel
+               OpBranch %13
+         %12 = OpLabel
+               OpBranch %13
+         %13 = OpLabel
+               OpLoopMerge %15 %14 None
+               OpBranch %14
+         %14 = OpLabel
+               OpBranchConditional %7 %13 %15
+         %15 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_5;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  // %9 is not a loop header
+  ASSERT_FALSE(TransformationAddLoopPreheader(9, 13, {}).IsApplicable(
+      context.get(), transformation_context));
+
+  // The id %10 is not fresh
+  ASSERT_FALSE(TransformationAddLoopPreheader(8, 10, {}).IsApplicable(
+      context.get(), transformation_context));
+
+  ASSERT_TRUE(TransformationAddLoopPreheader(8, 20, {}).IsApplicable(
+      context.get(), transformation_context));
+
+  ASSERT_TRUE(TransformationAddLoopPreheader(13, 21, {})
+                  .IsApplicable(context.get(), transformation_context));
+}
+
+TEST(TransformationAddLoopPreheaderTest, OpPhi) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeBool
+          %7 = OpConstantFalse %6
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %20 = OpCopyObject %6 %7
+               OpBranch %8
+          %8 = OpLabel
+         %31 = OpPhi %6 %20 %5 %21 %9
+               OpLoopMerge %10 %9 None
+               OpBranch %9
+          %9 = OpLabel
+         %21 = OpCopyObject %6 %7
+               OpBranchConditional %7 %8 %10
+         %10 = OpLabel
+               OpSelectionMerge %13 None
+               OpBranchConditional %7 %11 %12
+         %11 = OpLabel
+         %22 = OpCopyObject %6 %7
+               OpBranch %13
+         %12 = OpLabel
+         %23 = OpCopyObject %6 %7
+               OpBranch %13
+         %13 = OpLabel
+         %32 = OpPhi %6 %22 %11 %23 %12 %24 %14
+         %33 = OpPhi %6 %7 %11 %7 %12 %24 %14
+               OpLoopMerge %15 %14 None
+               OpBranch %14
+         %14 = OpLabel
+         %24 = OpCopyObject %6 %7
+               OpBranchConditional %7 %13 %15
+         %15 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_5;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  ASSERT_TRUE(TransformationAddLoopPreheader(8, 40, {}).IsApplicable(
+      context.get(), transformation_context));
+
+  // Not enough ids for the OpPhi instructions are given
+  ASSERT_FALSE(TransformationAddLoopPreheader(13, 41, {})
+                   .IsApplicable(context.get(), transformation_context));
+
+  // Not enough ids for the OpPhi instructions are given
+  ASSERT_FALSE(TransformationAddLoopPreheader(13, 41, {42})
+                   .IsApplicable(context.get(), transformation_context));
+
+  // One of the ids is not fresh
+  ASSERT_FALSE(TransformationAddLoopPreheader(13, 41, {31, 42})
+                   .IsApplicable(context.get(), transformation_context));
+
+  // One of the ids is repeated
+  ASSERT_FALSE(TransformationAddLoopPreheader(13, 41, {41, 42})
+                   .IsApplicable(context.get(), transformation_context));
+
+  ASSERT_TRUE(TransformationAddLoopPreheader(13, 41, {42, 43})
+                  .IsApplicable(context.get(), transformation_context));
+}
+
+}  // namespace
+}  // namespace fuzz
+}  // namespace spvtools


### PR DESCRIPTION
This PR introduces TransformationAddLoopPreheader, which, given
a loop header and enough fresh ids, adds a loop preheader, updating
all the references so that this new block is the only out-of-loop
predecessor of the header, which branches unconditionally to the
header.

See the discussion in #3095 .