### PR TITLE
Rolling 4 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -3,10 +3,10 @@ use_relative_paths = True
 vars = {
   'github': 'https://github.com',
 
-  'effcee_revision': '5af957bbfc7da4e9f7aa8cac11379fa36dd79b84',
-  'googletest_revision': '011959aafddcd30611003de96cfd8d7a7685c700',
-  're2_revision': 'aecba11114cf1fac5497aeb844b6966106de3eb6',
-  'spirv_headers_revision': 'ac638f1815425403e946d0ab78bac71d2bdbf3be',
+  'effcee_revision': '2ec8f8738118cc483b67c04a759fee53496c5659',
+  'googletest_revision': 'a781fe29bcf73003559a3583167fe3d647518464',
+  're2_revision': 'ca11026a032ce2a3de4b3c389ee53d2bdc8794d6',
+  'spirv_headers_revision': '979924c8bc839e4cb1b69d03d48398551f369ce7',
 }
 
 deps = {


### PR DESCRIPTION
Roll external/effcee/ 5af957bbf..2ec8f8738 (3 commits)

https://github.com/google/effcee/compare/5af957bbfc7d...2ec8f8738118

$ git log 5af957bbf..2ec8f8738 --date=short --no-merges --format='%ad %ae %s'
2020-06-16 dneto Start v2020.0-dev
2020-06-16 dneto Finalize v2019.1
2020-06-15 dneto Update CHANGES

Created with:
  roll-dep external/effcee

Roll external/googletest/ 011959aaf..a781fe29b (54 commits)

https://github.com/google/googletest/compare/011959aafddc...a781fe29bcf7

$ git log 011959aaf..a781fe29b --date=short --no-merges --format='%ad %ae %s'
2020-07-13 ofats Googletest export
2020-07-11 ashikpaul17 Fixed some minor typos
2020-07-09 absl-team Googletest export
2020-07-07 ofats Googletest export
2020-07-07 absl-team Googletest export
2020-07-07 absl-team Googletest export
2020-07-01 absl-team Googletest export
2020-04-11 olivier.ldff use target_compile_features to use c++11 if cmake > 3.8
2020-06-26 absl-team Googletest export
2020-06-25 absl-team Googletest export
2020-06-24 absl-team Googletest export
2020-06-24 absl-team Googletest export
2020-06-19 amatanhead Make EXPECT_THROW and EXPECT_NO_THROW macros more informative
2020-06-19 mayur.shingote Updated googletest issue tracker url.
2020-06-17 absl-team Googletest export
2020-06-15 absl-team Googletest export
2020-06-12 dmauro Googletest export
2020-06-10 absl-team Googletest export
2020-06-08 absl-team Googletest export
2020-06-08 absl-team Googletest export
2020-06-05 dmauro Googletest export
2020-06-10 rharrison Fix build issue for MinGW
2020-06-04 dmauro Googletest export
2020-06-03 absl-team Googletest export
2020-06-02 absl-team Googletest export
2020-06-01 absl-team Googletest export
2020-05-30 eli fix compilation on OpenBSD 6.7
2020-03-07 krystian.kuzniarek make UniversalPrinter<std::any> support RTTI
2020-03-07 krystian.kuzniarek specialize UniversalPrinter<> for std::any (without support for RTTI)
2020-03-07 krystian.kuzniarek specialize UniversalPrinter<> for std::optional
2020-03-07 krystian.kuzniarek specialize UniversalPrinter<> for std::variant
2020-05-28 dmauro Googletest export
2020-05-28 dmauro Googletest export
2020-05-27 absl-team Googletest export
2020-05-27 dmauro Googletest export
2020-05-19 absl-team Googletest export
2020-05-18 absl-team Googletest export
2020-05-18 durandal Googletest export
2020-05-18 absl-team Googletest export
2020-05-14 absl-team Googletest export
2020-05-25 invalid_ms_user Use count function instead of handwritten loop
2020-05-10 mate.pek README.dm: Renamed related open source project name: Catch2 and Google Test Explorer -> C++ TestMate
2020-03-26 mvoorsluys Fix test with stack.
2020-03-26 mvoorsluys Fixed xml unit-tests and added extra tests
2020-03-26 mvoorsluys Fix multiple \n characters in xml file when using GTEST_SKIP.
2020-03-26 mvoorsluys Only write ">\n" once when there is failure and skipped tests.
2020-03-26 mvoorsluys Output skipped information in the xml file.
2020-03-21 ngompa13 Set the version for the libraries
2020-02-21 nini16041988-gitbucket Add missing call for gtest_list_output_unittest_ unitTest. Add unitTest for fixed TEST_P line number. Use CodeLocation TestInfo struct.
2020-02-18 nini16041988-gitbucket Fix: shadow member
2020-02-18 nini16041988-gitbucket Add correct line number to TEST_P test cases for gtest_output.
2020-02-06 59134746+aribibek fix a link to documentation
2020-01-17 hgsilverman Fix always false condition and clean function body
2020-01-22 mjvk Fixes extensions missing for QNX

Created with:
  roll-dep external/googletest

Roll external/re2/ aecba1111..ca11026a0 (12 commits)

https://github.com/google/re2/compare/aecba11114cf...ca11026a032c

$ git log aecba1111..ca11026a0 --date=short --no-merges --format='%ad %ae %s'
2020-07-14 junyer Make Regexp::Simplify() return a null pointer when stopped early.
2020-07-05 junyer Bump SONAME, which missing ')' versus unexpected ')' needed.
2020-07-03 courbet Make the compiler inline the hot RE2::DFA loop.
2020-06-25 Shikugawa change bazel cpu symbol from wasm to wasm32
2020-06-18 junyer Write tests for the move semantics.
2020-06-18 junyer Improve RE2::Set and FilteredRE2 move semantics.
2020-06-16 junyer Distinguish between missing ')' and unexpected ')'.
2020-06-16 junyer Make RE2::Set and FilteredRE2 movable.
2020-06-15 junyer Herp derp. It's actually constant-time append.
2020-06-14 junyer Implement linear-time append for patch lists.
2020-06-08 junyer Don't pass `-pthread` when building for WebAssembly.
2020-06-06 junyer Add a clarifying comment about case folding.

Created with:
  roll-dep external/re2

Roll external/spirv-headers/ ac638f181..979924c8b (10 commits)

https://github.com/KhronosGroup/SPIRV-Headers/compare/ac638f181542...979924c8bc83

$ git log ac638f181..979924c8b --date=short --no-merges --format='%ad %ae %s'
2020-07-21 alanbaker Support SPV_KHR_terminate_invocation (#163)
2020-07-19 vkushwaha Add changes for SPV_EXT_shader_atomic_float
2020-06-26 dj2 Register the Tint compiler
2020-06-01 dneto spir-v.xml: Use plain ASCII quotes in comment
2020-05-29 cepheus Rebuild headers against the previous grammar commit.
2020-05-29 dmitry.sidorov Apply suggestions
2020-04-05 dmitry.sidorov Add Intel specific definitions from KhronosGroup/SPIRV-LLVM-Translator
2020-05-29 cepheus Header build from previous grammar update.
2020-05-25 michael.kinsner Propose bit allocation mechanism for the FP Fast Math Mode bitfield, following from the mechanism previously added for the loop control bitfield.
2020-04-05 dmitry.sidorov Add SPV_INTEL_function_pointers preview extension

Created with:
  roll-dep external/spirv-headers

Fixes #3574