### PR TITLE
spirv-fuzz: Relax type constraints in DataSynonym facts

### DIFF
--- a/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
@@ -60,7 +60,7 @@ void FuzzerPassApplyIdSynonyms::Apply() {
           }
         });
 
-    for (auto& use : uses) {
+    for (const auto& use : uses) {
       auto use_inst = use.first;
       auto use_index = use.second;
       auto block_containing_use = GetIRContext()->get_instr_block(use_inst);
@@ -82,7 +82,7 @@ void FuzzerPassApplyIdSynonyms::Apply() {
       }
 
       std::vector<const protobufs::DataDescriptor*> synonyms_to_try;
-      for (auto& data_descriptor :
+      for (const auto* data_descriptor :
            GetTransformationContext()->GetFactManager()->GetSynonymsForId(
                id_with_known_synonyms)) {
         protobufs::DataDescriptor descriptor_for_this_id =
@@ -91,7 +91,12 @@ void FuzzerPassApplyIdSynonyms::Apply() {
           // Exclude the fact that the id is synonymous with itself.
           continue;
         }
-        synonyms_to_try.push_back(data_descriptor);
+
+        if (DescriptorsHaveCompatibleTypes(
+                use_inst->opcode(), use_in_operand_index,
+                descriptor_for_this_id, *data_descriptor)) {
+          synonyms_to_try.push_back(data_descriptor);
+        }
       }
       while (!synonyms_to_try.empty()) {
         auto synonym_to_try =
@@ -160,6 +165,27 @@ void FuzzerPassApplyIdSynonyms::Apply() {
       }
     }
   }
+}
+
+bool FuzzerPassApplyIdSynonyms::DescriptorsHaveCompatibleTypes(
+    SpvOp opcode, uint32_t use_in_operand_index,
+    const protobufs::DataDescriptor& dd1,
+    const protobufs::DataDescriptor& dd2) {
+  auto base_object_type_id_1 =
+      fuzzerutil::GetTypeId(GetIRContext(), dd1.object());
+  auto base_object_type_id_2 =
+      fuzzerutil::GetTypeId(GetIRContext(), dd2.object());
+  assert(base_object_type_id_1 && base_object_type_id_2 &&
+         "Data descriptors are invalid");
+
+  auto type_id_1 = fuzzerutil::WalkCompositeTypeIndices(
+      GetIRContext(), base_object_type_id_1, dd1.index());
+  auto type_id_2 = fuzzerutil::WalkCompositeTypeIndices(
+      GetIRContext(), base_object_type_id_2, dd2.index());
+  assert(type_id_1 && type_id_2 && "Data descriptors have invalid types");
+
+  return TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      GetIRContext(), opcode, use_in_operand_index, type_id_1, type_id_2);
 }
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
@@ -92,7 +92,7 @@ void FuzzerPassApplyIdSynonyms::Apply() {
           continue;
         }
 
-        if (DescriptorsHaveCompatibleTypes(
+        if (DataDescriptorsHaveCompatibleTypes(
                 use_inst->opcode(), use_in_operand_index,
                 descriptor_for_this_id, *data_descriptor)) {
           synonyms_to_try.push_back(data_descriptor);
@@ -167,7 +167,7 @@ void FuzzerPassApplyIdSynonyms::Apply() {
   }
 }
 
-bool FuzzerPassApplyIdSynonyms::DescriptorsHaveCompatibleTypes(
+bool FuzzerPassApplyIdSynonyms::DataDescriptorsHaveCompatibleTypes(
     SpvOp opcode, uint32_t use_in_operand_index,
     const protobufs::DataDescriptor& dd1,
     const protobufs::DataDescriptor& dd2) {

--- a/source/fuzz/fuzzer_pass_apply_id_synonyms.h
+++ b/source/fuzz/fuzzer_pass_apply_id_synonyms.h
@@ -16,7 +16,6 @@
 #define SOURCE_FUZZ_FUZZER_PASS_APPLY_ID_SYNONYMS_
 
 #include "source/fuzz/fuzzer_pass.h"
-
 #include "source/opt/ir_context.h"
 
 namespace spvtools {
@@ -34,6 +33,16 @@ class FuzzerPassApplyIdSynonyms : public FuzzerPass {
   ~FuzzerPassApplyIdSynonyms() override;
 
   void Apply() override;
+
+ private:
+  // Returns true if uses of |dd1| can be replaced with |dd2| and vice-versa
+  // with respect to the type. Concretely, returns true if |dd1| and |dd2| have
+  // the same type or both |dd1| and |dd2| are either a numerical or a vector
+  // type of integral components with possibly different signedness.
+  bool DescriptorsHaveCompatibleTypes(SpvOp opcode,
+                                      uint32_t use_in_operand_index,
+                                      const protobufs::DataDescriptor& dd1,
+                                      const protobufs::DataDescriptor& dd2);
 };
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_pass_apply_id_synonyms.h
+++ b/source/fuzz/fuzzer_pass_apply_id_synonyms.h
@@ -39,10 +39,10 @@ class FuzzerPassApplyIdSynonyms : public FuzzerPass {
   // with respect to the type. Concretely, returns true if |dd1| and |dd2| have
   // the same type or both |dd1| and |dd2| are either a numerical or a vector
   // type of integral components with possibly different signedness.
-  bool DescriptorsHaveCompatibleTypes(SpvOp opcode,
-                                      uint32_t use_in_operand_index,
-                                      const protobufs::DataDescriptor& dd1,
-                                      const protobufs::DataDescriptor& dd2);
+  bool DataDescriptorsHaveCompatibleTypes(SpvOp opcode,
+                                          uint32_t use_in_operand_index,
+                                          const protobufs::DataDescriptor& dd1,
+                                          const protobufs::DataDescriptor& dd2);
 };
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_replace_id_with_synonym.h
+++ b/source/fuzz/transformation_replace_id_with_synonym.h
@@ -64,6 +64,15 @@ class TransformationReplaceIdWithSynonym : public Transformation {
                                           opt::Instruction* use_instruction,
                                           uint32_t use_in_operand_index);
 
+  // Returns true if |type_id_1| and |type_id_2| represent compatible types
+  // given the context of the instruction with |opcode| (i.e. we can replace
+  // an operand of |opcode| of the first type with an id of the second type
+  // and vice-versa).
+  static bool TypesAreCompatible(opt::IRContext* ir_context, SpvOp opcode,
+                                 uint32_t use_in_operand_index,
+                                 uint32_t type_id_1, uint32_t type_id_2);
+
+ private:
   // Returns true if the instruction with opcode |opcode| does not change its
   // behaviour depending on the signedness of the operand at
   // |use_in_operand_index|.
@@ -71,7 +80,6 @@ class TransformationReplaceIdWithSynonym : public Transformation {
   static bool IsAgnosticToSignednessOfOperand(SpvOp opcode,
                                               uint32_t use_in_operand_index);
 
- private:
   protobufs::TransformationReplaceIdWithSynonym message_;
 };
 


### PR DESCRIPTION
Fixes #3595.