### PR TITLE
spirv-fuzz: Pass to replace int operands with ints of opposite signedness

### DIFF
--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -65,6 +65,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_copy_objects.h
         fuzzer_pass_donate_modules.h
         fuzzer_pass_invert_comparison_operators.h
+        fuzzer_pass_interchange_integer_operands.h
         fuzzer_pass_interchange_zero_like_constants.h
         fuzzer_pass_merge_blocks.h
         fuzzer_pass_obfuscate_constants.h
@@ -194,6 +195,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_copy_objects.cpp
         fuzzer_pass_donate_modules.cpp
         fuzzer_pass_invert_comparison_operators.cpp
+        fuzzer_pass_interchange_integer_operands.cpp
         fuzzer_pass_interchange_zero_like_constants.cpp
         fuzzer_pass_merge_blocks.cpp
         fuzzer_pass_obfuscate_constants.cpp

--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -65,7 +65,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_copy_objects.h
         fuzzer_pass_donate_modules.h
         fuzzer_pass_invert_comparison_operators.h
-        fuzzer_pass_interchange_integer_operands.h
+        fuzzer_pass_interchange_signedness_of_integer_operands.h
         fuzzer_pass_interchange_zero_like_constants.h
         fuzzer_pass_merge_blocks.h
         fuzzer_pass_obfuscate_constants.h
@@ -195,7 +195,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_copy_objects.cpp
         fuzzer_pass_donate_modules.cpp
         fuzzer_pass_invert_comparison_operators.cpp
-        fuzzer_pass_interchange_integer_operands.cpp
+        fuzzer_pass_interchange_signedness_of_integer_operands.cpp
         fuzzer_pass_interchange_zero_like_constants.cpp
         fuzzer_pass_merge_blocks.cpp
         fuzzer_pass_obfuscate_constants.cpp

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -46,6 +46,7 @@
 #include "source/fuzz/fuzzer_pass_construct_composites.h"
 #include "source/fuzz/fuzzer_pass_copy_objects.h"
 #include "source/fuzz/fuzzer_pass_donate_modules.h"
+#include "source/fuzz/fuzzer_pass_interchange_integer_operands.h"
 #include "source/fuzz/fuzzer_pass_interchange_zero_like_constants.h"
 #include "source/fuzz/fuzzer_pass_invert_comparison_operators.h"
 #include "source/fuzz/fuzzer_pass_merge_blocks.h"
@@ -333,6 +334,9 @@ Fuzzer::FuzzerResultStatus Fuzzer::Run(
       &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
       transformation_sequence_out);
   MaybeAddPass<FuzzerPassAddNoContractionDecorations>(
+      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
+      transformation_sequence_out);
+  MaybeAddPass<FuzzerPassInterchangeIntegerOperands>(
       &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
       transformation_sequence_out);
   MaybeAddPass<FuzzerPassInterchangeZeroLikeConstants>(

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -46,7 +46,7 @@
 #include "source/fuzz/fuzzer_pass_construct_composites.h"
 #include "source/fuzz/fuzzer_pass_copy_objects.h"
 #include "source/fuzz/fuzzer_pass_donate_modules.h"
-#include "source/fuzz/fuzzer_pass_interchange_integer_operands.h"
+#include "source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.h"
 #include "source/fuzz/fuzzer_pass_interchange_zero_like_constants.h"
 #include "source/fuzz/fuzzer_pass_invert_comparison_operators.h"
 #include "source/fuzz/fuzzer_pass_merge_blocks.h"
@@ -336,7 +336,7 @@ Fuzzer::FuzzerResultStatus Fuzzer::Run(
   MaybeAddPass<FuzzerPassAddNoContractionDecorations>(
       &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
       transformation_sequence_out);
-  MaybeAddPass<FuzzerPassInterchangeIntegerOperands>(
+  MaybeAddPass<FuzzerPassInterchangeSignednessOfIntegerOperands>(
       &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
       transformation_sequence_out);
   MaybeAddPass<FuzzerPassInterchangeZeroLikeConstants>(

--- a/source/fuzz/fuzzer_context.cpp
+++ b/source/fuzz/fuzzer_context.cpp
@@ -67,8 +67,8 @@ const std::pair<uint32_t, uint32_t> kChanceOfGoingDeeperWhenMakingAccessChain =
     {50, 95};
 const std::pair<uint32_t, uint32_t> kChanceOfInterchangingZeroLikeConstants = {
     10, 90};
-const std::pair<uint32_t, uint32_t> kChanceOfInterchangingIntegerOperands = {
-    10, 90};
+const std::pair<uint32_t, uint32_t>
+    kChanceOfInterchangingSignednessOfIntegerOperands = {10, 90};
 const std::pair<uint32_t, uint32_t> kChanceOfInvertingComparisonOperators = {
     20, 50};
 const std::pair<uint32_t, uint32_t> kChanceOfMakingDonorLivesafe = {40, 60};
@@ -199,8 +199,8 @@ FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
       ChooseBetweenMinAndMax(kChanceOfDonatingAdditionalModule);
   chance_of_going_deeper_when_making_access_chain_ =
       ChooseBetweenMinAndMax(kChanceOfGoingDeeperWhenMakingAccessChain);
-  chance_of_interchanging_integer_operands_ =
-      ChooseBetweenMinAndMax(kChanceOfInterchangingIntegerOperands);
+  chance_of_interchanging_signedness_of_integer_operands_ =
+      ChooseBetweenMinAndMax(kChanceOfInterchangingSignednessOfIntegerOperands);
   chance_of_interchanging_zero_like_constants_ =
       ChooseBetweenMinAndMax(kChanceOfInterchangingZeroLikeConstants);
   chance_of_inverting_comparison_operators_ =

--- a/source/fuzz/fuzzer_context.cpp
+++ b/source/fuzz/fuzzer_context.cpp
@@ -67,6 +67,8 @@ const std::pair<uint32_t, uint32_t> kChanceOfGoingDeeperWhenMakingAccessChain =
     {50, 95};
 const std::pair<uint32_t, uint32_t> kChanceOfInterchangingZeroLikeConstants = {
     10, 90};
+const std::pair<uint32_t, uint32_t> kChanceOfInterchangingIntegerOperands = {
+    10, 90};
 const std::pair<uint32_t, uint32_t> kChanceOfInvertingComparisonOperators = {
     20, 50};
 const std::pair<uint32_t, uint32_t> kChanceOfMakingDonorLivesafe = {40, 60};
@@ -197,6 +199,8 @@ FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
       ChooseBetweenMinAndMax(kChanceOfDonatingAdditionalModule);
   chance_of_going_deeper_when_making_access_chain_ =
       ChooseBetweenMinAndMax(kChanceOfGoingDeeperWhenMakingAccessChain);
+  chance_of_interchanging_integer_operands_ =
+      ChooseBetweenMinAndMax(kChanceOfInterchangingIntegerOperands);
   chance_of_interchanging_zero_like_constants_ =
       ChooseBetweenMinAndMax(kChanceOfInterchangingZeroLikeConstants);
   chance_of_inverting_comparison_operators_ =

--- a/source/fuzz/fuzzer_context.h
+++ b/source/fuzz/fuzzer_context.h
@@ -186,6 +186,9 @@ class FuzzerContext {
   uint32_t GetChanceOfGoingDeeperWhenMakingAccessChain() {
     return chance_of_going_deeper_when_making_access_chain_;
   }
+  uint32_t GetChanceOfInterchangingIntegerOperands() {
+    return chance_of_interchanging_integer_operands_;
+  }
   uint32_t GetChanceOfInterchangingZeroLikeConstants() {
     return chance_of_interchanging_zero_like_constants_;
   }
@@ -353,6 +356,7 @@ class FuzzerContext {
   uint32_t chance_of_copying_object_;
   uint32_t chance_of_donating_additional_module_;
   uint32_t chance_of_going_deeper_when_making_access_chain_;
+  uint32_t chance_of_interchanging_integer_operands_;
   uint32_t chance_of_interchanging_zero_like_constants_;
   uint32_t chance_of_inverting_comparison_operators_;
   uint32_t chance_of_making_donor_livesafe_;

--- a/source/fuzz/fuzzer_context.h
+++ b/source/fuzz/fuzzer_context.h
@@ -186,8 +186,8 @@ class FuzzerContext {
   uint32_t GetChanceOfGoingDeeperWhenMakingAccessChain() {
     return chance_of_going_deeper_when_making_access_chain_;
   }
-  uint32_t GetChanceOfInterchangingIntegerOperands() {
-    return chance_of_interchanging_integer_operands_;
+  uint32_t GetChanceOfInterchangingSignednessOfIntegerOperands() {
+    return chance_of_interchanging_signedness_of_integer_operands_;
   }
   uint32_t GetChanceOfInterchangingZeroLikeConstants() {
     return chance_of_interchanging_zero_like_constants_;
@@ -356,7 +356,7 @@ class FuzzerContext {
   uint32_t chance_of_copying_object_;
   uint32_t chance_of_donating_additional_module_;
   uint32_t chance_of_going_deeper_when_making_access_chain_;
-  uint32_t chance_of_interchanging_integer_operands_;
+  uint32_t chance_of_interchanging_signedness_of_integer_operands_;
   uint32_t chance_of_interchanging_zero_like_constants_;
   uint32_t chance_of_inverting_comparison_operators_;
   uint32_t chance_of_making_donor_livesafe_;

--- a/source/fuzz/fuzzer_pass.h
+++ b/source/fuzz/fuzzer_pass.h
@@ -273,7 +273,7 @@ class FuzzerPass {
   uint32_t FindOrCreateZeroConstant(uint32_t scalar_or_composite_type_id,
                                     bool is_irrelevant);
 
-  // Adds a pair {id_use_descriptor, |replacement_id|} to the vector
+  // Adds a pair (id_use_descriptor, |replacement_id|) to the vector
   // |uses_to_replace|, where id_use_descriptor is the id use descriptor
   // representing the usage of an id in the |use_inst| instruction, at operand
   // index |use_index|, only if the instruction is in a basic block.

--- a/source/fuzz/fuzzer_pass.h
+++ b/source/fuzz/fuzzer_pass.h
@@ -273,6 +273,16 @@ class FuzzerPass {
   uint32_t FindOrCreateZeroConstant(uint32_t scalar_or_composite_type_id,
                                     bool is_irrelevant);
 
+  // Adds a pair {id_use_descriptor, |replacement_id|} to the vector
+  // |uses_to_replace|, where id_use_descriptor is the id use descriptor
+  // representing the usage of an id in the |use_inst| instruction, at operand
+  // index |use_index|, only if the instruction is in a basic block.
+  // If the instruction is not in a basic block, it does nothing.
+  void MaybeAddUseToReplace(
+      opt::Instruction* use_inst, uint32_t use_index, uint32_t replacement_id,
+      std::vector<std::pair<protobufs::IdUseDescriptor, uint32_t>>*
+      uses_to_replace);
+
  private:
   opt::IRContext* ir_context_;
   TransformationContext* transformation_context_;

--- a/source/fuzz/fuzzer_pass.h
+++ b/source/fuzz/fuzzer_pass.h
@@ -281,7 +281,7 @@ class FuzzerPass {
   void MaybeAddUseToReplace(
       opt::Instruction* use_inst, uint32_t use_index, uint32_t replacement_id,
       std::vector<std::pair<protobufs::IdUseDescriptor, uint32_t>>*
-      uses_to_replace);
+          uses_to_replace);
 
  private:
   opt::IRContext* ir_context_;

--- a/source/fuzz/fuzzer_pass_interchange_integer_operands.cpp
+++ b/source/fuzz/fuzzer_pass_interchange_integer_operands.cpp
@@ -69,7 +69,7 @@ void FuzzerPassInterchangeIntegerOperands::Apply() {
                                              uint32_t use_index) -> void {
           if (GetFuzzerContext()->ChoosePercentage(
                   GetFuzzerContext()
-                      ->GetChanceOfInterchangingZeroLikeConstants())) {
+                      ->GetChanceOfInterchangingIntegerOperands())) {
             MaybeAddUseToReplace(use_inst, use_index, toggled_id,
                                  &uses_to_replace);
           }

--- a/source/fuzz/fuzzer_pass_interchange_integer_operands.cpp
+++ b/source/fuzz/fuzzer_pass_interchange_integer_operands.cpp
@@ -117,10 +117,9 @@ FuzzerPassInterchangeIntegerOperands::FindOrCreateToggledIntegerConstant(
 
   // Find or create the toggled components.
   for (auto component : constant->AsVectorConstant()->GetComponents()) {
-    toggled_components.push_back(
-        FindOrCreateToggledIntegerConstant(FindOrCreateIntegerConstant(
-            component->AsIntConstant()->words(), component_type->width(),
-            !component_type->IsSigned(), false)));
+    toggled_components.push_back(FindOrCreateIntegerConstant(
+        component->AsIntConstant()->words(), component_type->width(),
+        !component_type->IsSigned(), false));
   }
 
   // Find or create the required toggled vector type.

--- a/source/fuzz/fuzzer_pass_interchange_integer_operands.h
+++ b/source/fuzz/fuzzer_pass_interchange_integer_operands.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_FUZZER_PASS_INTERCHANGE_INTEGER_OPERANDS_
+#define SOURCE_FUZZ_FUZZER_PASS_INTERCHANGE_INTEGER_OPERANDS_
+
+#include "source/fuzz/fuzzer_pass.h"
+
+namespace spvtools {
+namespace fuzz {
+
+// A pass that:
+// - Finds all the integer constant (scalars or vectors) definitions in the
+//   module and adds the definitions of the integer with the same data words but
+//   opposite signedness. If the synonym is already in the module, it does not
+//   add a new one.
+// - For each use of an integer constant where its signedness does not matter,
+//   decides whether to change it to the
+//   id of the toggled constant.
+class FuzzerPassInterchangeIntegerOperands : public FuzzerPass {
+ public:
+  FuzzerPassInterchangeIntegerOperands(
+      opt::IRContext* ir_context, TransformationContext* transformation_context,
+      FuzzerContext* fuzzer_context,
+      protobufs::TransformationSequence* transformations);
+
+  ~FuzzerPassInterchangeIntegerOperands() override;
+
+  void Apply() override;
+
+ private:
+  // Given the id of an integer constant (scalar or vector), it finds or creates
+  // the corresponding toggled constant (the integer with the same data words
+  // but opposite signedness). Returns the id of the toggled instruction if the
+  // constant is an integer scalar or vector, 0 otherwise.
+  uint32_t FindOrCreateToggledIntegerConstant(uint32_t id);
+};
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_FUZZER_PASS_INTERCHANGE_INTEGER_OPERANDS_

--- a/source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.h
+++ b/source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SOURCE_FUZZ_FUZZER_PASS_INTERCHANGE_INTEGER_OPERANDS_
-#define SOURCE_FUZZ_FUZZER_PASS_INTERCHANGE_INTEGER_OPERANDS_
+#ifndef SOURCE_FUZZ_FUZZER_PASS_INTERCHANGE_SIGNEDNESS_OF_INTEGER_OPERANDS_
+#define SOURCE_FUZZ_FUZZER_PASS_INTERCHANGE_SIGNEDNESS_OF_INTEGER_OPERANDS_
 
 #include "source/fuzz/fuzzer_pass.h"
 
@@ -21,21 +21,20 @@ namespace spvtools {
 namespace fuzz {
 
 // A pass that:
-// - Finds all the integer constant (scalars or vectors) definitions in the
+// - Finds all the integer constant (scalar and vector) definitions in the
 //   module and adds the definitions of the integer with the same data words but
 //   opposite signedness. If the synonym is already in the module, it does not
 //   add a new one.
 // - For each use of an integer constant where its signedness does not matter,
-//   decides whether to change it to the
-//   id of the toggled constant.
-class FuzzerPassInterchangeIntegerOperands : public FuzzerPass {
+// decides whether to change it to the id of the toggled constant.
+class FuzzerPassInterchangeSignednessOfIntegerOperands : public FuzzerPass {
  public:
-  FuzzerPassInterchangeIntegerOperands(
+  FuzzerPassInterchangeSignednessOfIntegerOperands(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassInterchangeIntegerOperands() override;
+  ~FuzzerPassInterchangeSignednessOfIntegerOperands() override;
 
   void Apply() override;
 
@@ -49,4 +48,4 @@ class FuzzerPassInterchangeIntegerOperands : public FuzzerPass {
 }  // namespace fuzz
 }  // namespace spvtools
 
-#endif  // SOURCE_FUZZ_FUZZER_PASS_INTERCHANGE_INTEGER_OPERANDS_
+#endif  // SOURCE_FUZZ_FUZZER_PASS_INTERCHANGE_SIGNEDNESS_OF_INTEGER_OPERANDS_

--- a/source/fuzz/fuzzer_pass_interchange_zero_like_constants.h
+++ b/source/fuzz/fuzzer_pass_interchange_zero_like_constants.h
@@ -46,16 +46,6 @@ class FuzzerPassInterchangeZeroLikeConstants : public FuzzerPass {
   // Returns the id of the toggled instruction if the constant is zero-like,
   // 0 otherwise.
   uint32_t FindOrCreateToggledConstant(opt::Instruction* declaration);
-
-  // Given an id use (described by an instruction and an index) and an id with
-  // which the original one should be replaced, adds a pair (with the elements
-  // being the corresponding id use descriptor and the replacement id) to
-  // |uses_to_replace| if the use is in an instruction block, otherwise does
-  // nothing.
-  void MaybeAddUseToReplace(
-      opt::Instruction* use_inst, uint32_t use_index, uint32_t replacement_id,
-      std::vector<std::pair<protobufs::IdUseDescriptor, uint32_t>>*
-          uses_to_replace);
 };
 
 }  // namespace fuzz


### PR DESCRIPTION
This PR introduces FuzzerPassInterchangeIntegerOperands, which:
- finds all integer vectors or constants
- finds or creates the corresponding constants with opposite
  signedness
- records such constants as synonyms of the first ones
- replaces the usages of the original constants with the new ones
  if allowed
  
Fixes #2677 . 