### PR TITLE
Connect OpenCL.DebugInfo.100 with "SPIRV.debug"

### DIFF
--- a/source/ext_inst.cpp
+++ b/source/ext_inst.cpp
@@ -127,6 +127,9 @@ spv_ext_inst_type_t spvExtInstImportTypeGet(const char* name) {
   if (!strcmp("OpenCL.DebugInfo.100", name)) {
     return SPV_EXT_INST_TYPE_OPENCL_DEBUGINFO_100;
   }
+  if (!strcmp("SPIRV.debug", name)) {
+    return SPV_EXT_INST_TYPE_OPENCL_DEBUGINFO_100;
+  }
   if (!strncmp("NonSemantic.ClspvReflection.", name, 28)) {
     return SPV_EXT_INST_TYPE_NONSEMANTIC_CLSPVREFLECTION;
   }


### PR DESCRIPTION
The SPIRV-LLVM-Translator by default uses "SPIRV.debug" instead of "OpenCL.DebugInfo.100". This commit allows to tolerate this behavior.

Resolves issue #3107
https://github.com/KhronosGroup/SPIRV-LLVM-Translator