### PR TITLE
Enable /MP4 flag only for MSVC

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -415,6 +415,8 @@ if(ENABLE_SPIRV_TOOLS_INSTALL)
 endif(ENABLE_SPIRV_TOOLS_INSTALL)
 
 if(MSVC)
-  # Enable parallel builds across four cores for this lib
-  add_definitions(/MP4)
+  if(NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+    # Enable parallel builds across four cores for this lib
+    add_definitions(/MP4)
+  endif()
 endif()

--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -293,8 +293,10 @@ if(SPIRV_BUILD_FUZZER)
         )
 
   if(MSVC)
-    # Enable parallel builds across four cores for this lib
-    add_definitions(/MP4)
+    if(NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+      # Enable parallel builds across four cores for this lib
+      add_definitions(/MP4)
+    endif()
   endif()
 
   spvtools_pch(SPIRV_TOOLS_FUZZ_SOURCES pch_source_fuzz)

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -227,8 +227,10 @@ set(SPIRV_TOOLS_OPT_SOURCES
 )
 
 if(MSVC)
-  # Enable parallel builds across four cores for this lib
-  add_definitions(/MP4)
+  if(NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+    # Enable parallel builds across four cores for this lib
+    add_definitions(/MP4)
+  endif()
 endif()
 
 spvtools_pch(SPIRV_TOOLS_OPT_SOURCES pch_source_opt)

--- a/source/reduce/CMakeLists.txt
+++ b/source/reduce/CMakeLists.txt
@@ -71,8 +71,10 @@ set(SPIRV_TOOLS_REDUCE_SOURCES
 )
 
 if(MSVC)
-  # Enable parallel builds across four cores for this lib
-  add_definitions(/MP4)
+  if(NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+    # Enable parallel builds across four cores for this lib
+    add_definitions(/MP4)
+  endif()
 endif()
 
 spvtools_pch(SPIRV_TOOLS_REDUCE_SOURCES pch_source_reduce)


### PR DESCRIPTION
This PR makes SPIRV-Tools compilable with clang-cl.

`/MP` flag is not yet supported on clang-cl as of clang/LLVM 10.0:

https://reviews.llvm.org/D52193

