### PR TITLE
spirv-fuzz: Add DecisionMaker

### DIFF
--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -31,6 +31,7 @@ if(SPIRV_BUILD_FUZZER)
   set(SPIRV_TOOLS_FUZZ_SOURCES
         call_graph.h
         data_descriptor.h
+        decision_maker.h
         equivalence_relation.h
         fact_manager.h
         force_render_red.h
@@ -165,6 +166,7 @@ if(SPIRV_BUILD_FUZZER)
 
         call_graph.cpp
         data_descriptor.cpp
+        decision_maker.cpp
         fact_manager.cpp
         force_render_red.cpp
         fuzzer.cpp

--- a/source/fuzz/decision_maker.cpp
+++ b/source/fuzz/decision_maker.cpp
@@ -1,0 +1,98 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/decision_maker.h"
+
+#include <functional>
+
+namespace spvtools {
+namespace fuzz {
+
+DecisionMaker::DecisionMaker() = default;
+
+DecisionMaker DecisionMaker::CreateInstance(uint32_t seed) {
+  // We use a short variable name |r| for the result, as we use it a lot below.
+  DecisionMaker r;
+  r.engine_.seed(seed);
+
+  r.fuzzer_pass_add_access_chains_chance_of_adding_access_chain_ =
+      r.ChooseBetweenMinAndMax({5, 50});
+  r.fuzzer_pass_add_access_chains_chance_of_going_deeper_ =
+      r.ChooseBetweenMinAndMax({50, 95});
+
+  return r;
+}
+
+DecisionMaker::~DecisionMaker() = default;
+
+bool DecisionMaker::FuzzerPassAddAccessChainsShouldAddLoad() {
+  return ChoosePercentage(
+      fuzzer_pass_add_access_chains_chance_of_adding_access_chain_);
+}
+
+opt::Instruction*
+DecisionMaker::FuzzerPassAddAccessChainsChoosePointerInstruction(
+    const std::vector<opt::Instruction*>& pointer_instructions) {
+  return pointer_instructions[RandomIndex(pointer_instructions.size())];
+}
+
+bool DecisionMaker::FuzzerPassAddAccessChainsShouldGoDeeper() {
+  return ChoosePercentage(
+      fuzzer_pass_add_access_chains_chance_of_going_deeper_);
+}
+
+bool DecisionMaker::FuzzerPassAddAccessChainsChooseIndexForAccessChain(
+    uint32_t composite_size_bound) {
+  return RandomIndex(composite_size_bound);
+}
+
+bool DecisionMaker::FuzzerPassAddAccessChainsChooseIsSigned() {
+  return ChooseIsSigned();
+}
+
+// Protected member functions:
+
+bool DecisionMaker::ChooseIsSigned() { return ChooseEven(); }
+
+uint32_t DecisionMaker::ChooseBetweenMinAndMax(
+    const std::pair<uint32_t, uint32_t>& min_max) {
+  assert(min_max.first <= min_max.second);
+  return min_max.first + RandomUint32(min_max.second - min_max.first + 1);
+}
+
+bool DecisionMaker::ChoosePercentage(uint32_t percentage_chance) {
+  assert(percentage_chance <= 100);
+  // We use 101 because we want a result in the closed interval [0, 100], and
+  // RandomUint32 is not inclusive of its bound.
+  return RandomUint32(101) < percentage_chance;
+}
+
+uint32_t DecisionMaker::RandomIndex(size_t size) {
+  assert(size);
+  return RandomUint32(static_cast<uint32_t>(size));
+}
+
+bool DecisionMaker::ChooseEven() {
+  // We use 2 to get the closed interval [0, 1].
+  return RandomUint32(2) == 0;
+}
+
+uint32_t DecisionMaker::RandomUint32(uint32_t bound) {
+  assert(bound > 0 && "Bound must be positive");
+  return static_cast<uint32_t>(
+      std::uniform_int_distribution<>(0, bound - 1)(engine_));
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/decision_maker.h
+++ b/source/fuzz/decision_maker.h
@@ -1,0 +1,96 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_DECISION_MAKER_H_
+#define SOURCE_FUZZ_DECISION_MAKER_H_
+
+#include <random>
+
+#include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
+#include "source/opt/function.h"
+
+namespace spvtools {
+namespace fuzz {
+
+// Resolves all random decisions that need to be made by fuzzer passes.
+// The current interface of the class (when including private members) does not
+// hide/abstract the random number generator |engine_| nor the probability
+// fields such as
+// |fuzzer_pass_add_access_chains_chance_of_adding_access_chain_|, despite the
+// fact that these details might not always be needed (e.g. when testing or
+// when a different "decision strategy" is desired). Thus, this interface may
+// change in the future. However, the public member functions are assumed to be
+// fairly stable, so should be used by fuzzer passes and can be overridden for
+// testing purposes.
+//
+// Use |DecisionMaker::CreateInstance(seed)| to get an instance.
+//
+class DecisionMaker {
+ protected:
+  DecisionMaker();
+
+ public:
+  virtual ~DecisionMaker();
+
+  static DecisionMaker CreateInstance(uint32_t seed);
+
+ public:
+  //
+  // FuzzerPassAddAccessChains.
+  //
+
+  virtual bool FuzzerPassAddAccessChainsShouldAddLoad();
+
+  virtual opt::Instruction* FuzzerPassAddAccessChainsChoosePointerInstruction(
+      const std::vector<opt::Instruction*>& pointer_instructions);
+
+  virtual bool FuzzerPassAddAccessChainsShouldGoDeeper();
+
+  virtual bool FuzzerPassAddAccessChainsChooseIndexForAccessChain(
+      uint32_t composite_size_bound);
+
+  virtual bool FuzzerPassAddAccessChainsChooseIsSigned();
+
+  //
+  // End of fuzz pass member functions.
+  //
+
+ protected:
+  // Decides whether to use a signed number. We may want to bias this across all
+  // passes, so all fuzzer-pass specific functions above should call this by
+  // default.
+  virtual bool ChooseIsSigned();
+
+  virtual uint32_t ChooseBetweenMinAndMax(
+      const std::pair<uint32_t, uint32_t>& min_max);
+
+  virtual bool ChoosePercentage(uint32_t percentage_chance);
+
+  virtual uint32_t RandomIndex(size_t size);
+
+  virtual bool ChooseEven();
+
+  virtual uint32_t RandomUint32(uint32_t bound);
+
+  uint32_t fuzzer_pass_add_access_chains_chance_of_adding_access_chain_;
+  uint32_t fuzzer_pass_add_access_chains_chance_of_going_deeper_;
+
+ private:
+  std::mt19937 engine_;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_DECISION_MAKER_H_

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -186,6 +186,9 @@ Fuzzer::FuzzerResultStatus Fuzzer::Run(
   // Make a PRNG from the seed passed to the fuzzer on creation.
   PseudoRandomGenerator random_generator(impl_->seed);
 
+  // Create a decision maker (to eventually replace the RNG) from the seed.
+  DecisionMaker decisionMaker = DecisionMaker::CreateInstance(impl_->seed);
+
   // The fuzzer will introduce new ids into the module.  The module's id bound
   // gives the smallest id that can be used for this purpose.  We add an offset
   // to this so that there is a sizeable gap between the ids used in the
@@ -194,7 +197,8 @@ Fuzzer::FuzzerResultStatus Fuzzer::Run(
   // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/2541) consider the
   //  case where the maximum id bound is reached.
   auto minimum_fresh_id = ir_context->module()->id_bound() + kIdBoundGap;
-  FuzzerContext fuzzer_context(&random_generator, minimum_fresh_id);
+  FuzzerContext fuzzer_context(&random_generator, &decisionMaker,
+                               minimum_fresh_id);
 
   FactManager fact_manager;
   fact_manager.AddFacts(impl_->consumer, initial_facts, ir_context.get());

--- a/source/fuzz/fuzzer_context.cpp
+++ b/source/fuzz/fuzzer_context.cpp
@@ -63,8 +63,6 @@ const std::pair<uint32_t, uint32_t> kChanceOfChoosingWorkgroupStorageClass = {
 const std::pair<uint32_t, uint32_t> kChanceOfConstructingComposite = {20, 50};
 const std::pair<uint32_t, uint32_t> kChanceOfCopyingObject = {20, 50};
 const std::pair<uint32_t, uint32_t> kChanceOfDonatingAdditionalModule = {5, 50};
-const std::pair<uint32_t, uint32_t> kChanceOfGoingDeeperWhenMakingAccessChain =
-    {50, 95};
 const std::pair<uint32_t, uint32_t> kChanceOfInterchangingZeroLikeConstants = {
     10, 90};
 const std::pair<uint32_t, uint32_t>
@@ -125,8 +123,10 @@ const std::function<bool(uint32_t, RandomGenerator*)>
 }  // namespace
 
 FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
+                             DecisionMaker* decision_maker,
                              uint32_t min_fresh_id)
     : random_generator_(random_generator),
+      decision_maker_(decision_maker),
       next_fresh_id_(min_fresh_id),
       max_equivalence_class_size_for_data_synonym_fact_closure_(
           kDefaultMaxEquivalenceClassSizeForDataSynonymFactClosure),
@@ -140,8 +140,6 @@ FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
           kGetDefaultMaxNumberOfParametersReplacedWithStruct),
       go_deeper_in_constant_obfuscation_(
           kDefaultGoDeeperInConstantObfuscation) {
-  chance_of_adding_access_chain_ =
-      ChooseBetweenMinAndMax(kChanceOfAddingAccessChain);
   chance_of_adding_another_struct_field_ =
       ChooseBetweenMinAndMax(kChanceOfAddingAnotherStructField);
   chance_of_adding_array_or_struct_type_ =
@@ -198,8 +196,6 @@ FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
   chance_of_copying_object_ = ChooseBetweenMinAndMax(kChanceOfCopyingObject);
   chance_of_donating_additional_module_ =
       ChooseBetweenMinAndMax(kChanceOfDonatingAdditionalModule);
-  chance_of_going_deeper_when_making_access_chain_ =
-      ChooseBetweenMinAndMax(kChanceOfGoingDeeperWhenMakingAccessChain);
   chance_of_interchanging_signedness_of_integer_operands_ =
       ChooseBetweenMinAndMax(kChanceOfInterchangingSignednessOfIntegerOperands);
   chance_of_interchanging_zero_like_constants_ =
@@ -245,6 +241,8 @@ FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
 }
 
 FuzzerContext::~FuzzerContext() = default;
+
+DecisionMaker* FuzzerContext::GetDecisionMaker() { return decision_maker_; }
 
 uint32_t FuzzerContext::GetFreshId() { return next_fresh_id_++; }
 

--- a/source/fuzz/fuzzer_context.h
+++ b/source/fuzz/fuzzer_context.h
@@ -18,6 +18,7 @@
 #include <functional>
 #include <utility>
 
+#include "source/fuzz/decision_maker.h"
 #include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
 #include "source/fuzz/random_generator.h"
 #include "source/opt/function.h"
@@ -32,9 +33,13 @@ class FuzzerContext {
  public:
   // Constructs a fuzzer context with a given random generator and the minimum
   // value that can be used for fresh ids.
-  FuzzerContext(RandomGenerator* random_generator, uint32_t min_fresh_id);
+  FuzzerContext(RandomGenerator* random_generator,
+                DecisionMaker* decision_maker, uint32_t min_fresh_id);
 
   ~FuzzerContext();
+
+  // Returns the DecisionMaker for making random decisions.
+  DecisionMaker* GetDecisionMaker();
 
   // Returns a random boolean.
   bool ChooseEven();
@@ -106,9 +111,6 @@ class FuzzerContext {
 
   // Probabilities associated with applying various transformations.
   // Keep them in alphabetical order.
-  uint32_t GetChanceOfAddingAccessChain() {
-    return chance_of_adding_access_chain_;
-  }
   uint32_t GetChanceOfAddingAnotherStructField() {
     return chance_of_adding_another_struct_field_;
   }
@@ -182,9 +184,6 @@ class FuzzerContext {
   uint32_t GetChanceOfCopyingObject() { return chance_of_copying_object_; }
   uint32_t GetChanceOfDonatingAdditionalModule() {
     return chance_of_donating_additional_module_;
-  }
-  uint32_t GetChanceOfGoingDeeperWhenMakingAccessChain() {
-    return chance_of_going_deeper_when_making_access_chain_;
   }
   uint32_t GetChanceOfInterchangingSignednessOfIntegerOperands() {
     return chance_of_interchanging_signedness_of_integer_operands_;
@@ -322,12 +321,14 @@ class FuzzerContext {
  private:
   // The source of randomness.
   RandomGenerator* random_generator_;
+  // The decision maker. I.e. the new source of randomness.
+  DecisionMaker* decision_maker_;
   // The next fresh id to be issued.
   uint32_t next_fresh_id_;
 
   // Probabilities associated with applying various transformations.
   // Keep them in alphabetical order.
-  uint32_t chance_of_adding_access_chain_;
+
   uint32_t chance_of_adding_another_struct_field_;
   uint32_t chance_of_adding_array_or_struct_type_;
   uint32_t chance_of_adding_copy_memory_;
@@ -358,7 +359,7 @@ class FuzzerContext {
   uint32_t chance_of_constructing_composite_;
   uint32_t chance_of_copying_object_;
   uint32_t chance_of_donating_additional_module_;
-  uint32_t chance_of_going_deeper_when_making_access_chain_;
+
   uint32_t chance_of_interchanging_signedness_of_integer_operands_;
   uint32_t chance_of_interchanging_zero_like_constants_;
   uint32_t chance_of_inverting_comparison_operators_;

--- a/source/fuzz/fuzzer_pass.h
+++ b/source/fuzz/fuzzer_pass.h
@@ -18,6 +18,7 @@
 #include <functional>
 #include <vector>
 
+#include "source/fuzz/decision_maker.h"
 #include "source/fuzz/fuzzer_context.h"
 #include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
 #include "source/fuzz/transformation.h"
@@ -51,6 +52,10 @@ class FuzzerPass {
   }
 
   FuzzerContext* GetFuzzerContext() const { return fuzzer_context_; }
+
+  DecisionMaker* GetDecisionMaker() const {
+    return GetFuzzerContext()->GetDecisionMaker();
+  }
 
   protobufs::TransformationSequence* GetTransformations() const {
     return transformations_;

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -15,9 +15,11 @@
 if (${SPIRV_BUILD_FUZZER})
 
   set(SOURCES
+          decision_maker_mock.h
           fuzz_test_util.h
 
           data_synonym_transformation_test.cpp
+          decision_maker_mock.cpp
           equivalence_relation_test.cpp
           fact_manager_test.cpp
           fuzz_test_util.cpp

--- a/test/fuzz/decision_maker_mock.cpp
+++ b/test/fuzz/decision_maker_mock.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "test/fuzz/decision_maker_mock.h"
+
+namespace spvtools {
+namespace fuzz {
+
+uint32_t DecisionMakerMock::RandomUint32(uint32_t bound) {
+  assert(false &&
+         "Should not have reached a random decision in DecisionMakerMock");
+  return 0;
+}
+}  // namespace fuzz
+}  // namespace spvtools

--- a/test/fuzz/decision_maker_mock.h
+++ b/test/fuzz/decision_maker_mock.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TEST_FUZZ_DECISION_MAKER_MOCK_H_
+#define TEST_FUZZ_DECISION_MAKER_MOCK_H_
+
+#include "source/fuzz/decision_maker.h"
+
+namespace spvtools {
+namespace fuzz {
+
+// A version of DecisionMaker that should be used for testing. |RandomUint32|
+// has been overridden to assert false. Thus, all member functions that might
+// lead to the use of the random number generator must be overridden as part of
+// the test.
+//
+// For example, when testing FuzzerPassAddAccessChains, we must create a class
+// deriving from DecisionMakerMock that overrides:
+//  - |FuzzerPassAddAccessChainsShouldAddLoad|
+//  - |FuzzerPassAddAccessChainsChoosePointerInstruction|
+//  - etc.
+//
+// This ensures that all random choices in FuzzerPassAddAccessChains are
+// controlled.
+class DecisionMakerMock : public DecisionMaker {
+ protected:
+  virtual uint32_t RandomUint32(uint32_t bound);
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // TEST_FUZZ_DECISION_MAKER_MOCK_H_


### PR DESCRIPTION
Introduces a prototype of the DecisionMaker, a class that resolves all random decisions made by
 fuzzer passes. It can also be mocked to allow testing of fuzzer passes.

This is just a prototype and we probably don't want to merge this yet.

Fixes #2849.

