### PR TITLE
spirv-fuzz: Ignore specialization constants

### DIFF
--- a/source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.cpp
+++ b/source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.cpp
@@ -91,8 +91,8 @@ void FuzzerPassInterchangeSignednessOfIntegerOperands::Apply() {
 
 uint32_t FuzzerPassInterchangeSignednessOfIntegerOperands::
     FindOrCreateToggledIntegerConstant(uint32_t id) {
-  // |id| must represent a non-specialization constant because the constant
-  // manager does not declare specialization constants.
+  // |id| must not be a specialization constant because we do not know the value
+  // of specialization constants.
   if (opt::IsSpecConstantInst(
           GetIRContext()->get_def_use_mgr()->GetDef(id)->opcode())) {
     return 0;

--- a/source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.cpp
+++ b/source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.cpp
@@ -91,6 +91,12 @@ void FuzzerPassInterchangeSignednessOfIntegerOperands::Apply() {
 
 uint32_t FuzzerPassInterchangeSignednessOfIntegerOperands::
     FindOrCreateToggledIntegerConstant(uint32_t id) {
+  // |id| must represent a non-specialization constant because the constant
+  // manager does not declare specialization constants.
+  if (!GetIRContext()->get_def_use_mgr()->GetDef(id)->IsConstant()) {
+    return 0;
+  }
+
   auto constant = GetIRContext()->get_constant_mgr()->FindDeclaredConstant(id);
 
   // This pass only toggles integer constants.

--- a/source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.cpp
+++ b/source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.cpp
@@ -93,7 +93,8 @@ uint32_t FuzzerPassInterchangeSignednessOfIntegerOperands::
     FindOrCreateToggledIntegerConstant(uint32_t id) {
   // |id| must represent a non-specialization constant because the constant
   // manager does not declare specialization constants.
-  if (!GetIRContext()->get_def_use_mgr()->GetDef(id)->IsConstant()) {
+  if (IsSpecConstantInst(
+          GetIRContext()->get_def_use_mgr()->GetDef(id)->opcode())) {
     return 0;
   }
 

--- a/source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.cpp
+++ b/source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.cpp
@@ -93,7 +93,7 @@ uint32_t FuzzerPassInterchangeSignednessOfIntegerOperands::
     FindOrCreateToggledIntegerConstant(uint32_t id) {
   // |id| must represent a non-specialization constant because the constant
   // manager does not declare specialization constants.
-  if (IsSpecConstantInst(
+  if (opt::IsSpecConstantInst(
           GetIRContext()->get_def_use_mgr()->GetDef(id)->opcode())) {
     return 0;
   }

--- a/source/fuzz/fuzzer_pass_interchange_zero_like_constants.cpp
+++ b/source/fuzz/fuzzer_pass_interchange_zero_like_constants.cpp
@@ -36,7 +36,7 @@ uint32_t FuzzerPassInterchangeZeroLikeConstants::FindOrCreateToggledConstant(
     opt::Instruction* declaration) {
   // |declaration| must be a non-specialization constant because the constant
   // manager does not declare specialization constants.
-  if (!declaration->IsConstant()) {
+  if (IsSpecConstantInst(declaration->opcode())) {
     return 0;
   }
 

--- a/source/fuzz/fuzzer_pass_interchange_zero_like_constants.cpp
+++ b/source/fuzz/fuzzer_pass_interchange_zero_like_constants.cpp
@@ -36,7 +36,7 @@ uint32_t FuzzerPassInterchangeZeroLikeConstants::FindOrCreateToggledConstant(
     opt::Instruction* declaration) {
   // |declaration| must be a non-specialization constant because the constant
   // manager does not declare specialization constants.
-  if (IsSpecConstantInst(declaration->opcode())) {
+  if (opt::IsSpecConstantInst(declaration->opcode())) {
     return 0;
   }
 

--- a/source/fuzz/fuzzer_pass_interchange_zero_like_constants.cpp
+++ b/source/fuzz/fuzzer_pass_interchange_zero_like_constants.cpp
@@ -34,8 +34,8 @@ FuzzerPassInterchangeZeroLikeConstants::
 
 uint32_t FuzzerPassInterchangeZeroLikeConstants::FindOrCreateToggledConstant(
     opt::Instruction* declaration) {
-  // |declaration| must be a non-specialization constant because the constant
-  // manager does not declare specialization constants.
+  // |declaration| must not be a specialization constant because we do not know
+  // the value of specialization constants.
   if (opt::IsSpecConstantInst(declaration->opcode())) {
     return 0;
   }

--- a/source/fuzz/fuzzer_pass_interchange_zero_like_constants.cpp
+++ b/source/fuzz/fuzzer_pass_interchange_zero_like_constants.cpp
@@ -34,6 +34,12 @@ FuzzerPassInterchangeZeroLikeConstants::
 
 uint32_t FuzzerPassInterchangeZeroLikeConstants::FindOrCreateToggledConstant(
     opt::Instruction* declaration) {
+  // |declaration| must be a non-specialization constant because the constant
+  // manager does not declare specialization constants.
+  if (!declaration->IsConstant()) {
+    return 0;
+  }
+
   auto constant = GetIRContext()->get_constant_mgr()->FindDeclaredConstant(
       declaration->result_id());
 

--- a/source/opt/constants.cpp
+++ b/source/opt/constants.cpp
@@ -305,17 +305,14 @@ const Constant* ConstantManager::GetConstantFromInst(const Instruction* inst) {
     // OpConstant{True|False} have the value embedded in the opcode. So they
     // are not handled by the for-loop above. Here we add the value explicitly.
     case SpvOp::SpvOpConstantTrue:
-    case SpvOp::SpvOpSpecConstantTrue:
       literal_words_or_ids.push_back(true);
       break;
     case SpvOp::SpvOpConstantFalse:
-    case SpvOp::SpvOpSpecConstantFalse:
       literal_words_or_ids.push_back(false);
       break;
+    case SpvOp::SpvOpConstantNull:
     case SpvOp::SpvOpConstant:
     case SpvOp::SpvOpConstantComposite:
-    case SpvOp::SpvOpConstantNull:
-    case SpvOp::SpvOpSpecConstant:
     case SpvOp::SpvOpSpecConstantComposite:
       break;
     default:

--- a/source/opt/constants.cpp
+++ b/source/opt/constants.cpp
@@ -305,14 +305,17 @@ const Constant* ConstantManager::GetConstantFromInst(const Instruction* inst) {
     // OpConstant{True|False} have the value embedded in the opcode. So they
     // are not handled by the for-loop above. Here we add the value explicitly.
     case SpvOp::SpvOpConstantTrue:
+    case SpvOp::SpvOpSpecConstantTrue:
       literal_words_or_ids.push_back(true);
       break;
     case SpvOp::SpvOpConstantFalse:
+    case SpvOp::SpvOpSpecConstantFalse:
       literal_words_or_ids.push_back(false);
       break;
-    case SpvOp::SpvOpConstantNull:
     case SpvOp::SpvOpConstant:
     case SpvOp::SpvOpConstantComposite:
+    case SpvOp::SpvOpConstantNull:
+    case SpvOp::SpvOpSpecConstant:
     case SpvOp::SpvOpSpecConstantComposite:
       break;
     default:


### PR DESCRIPTION
`FuzzerPassInterchangeSignednessOfIntegerOperands` and `FuzzerPassInterchangeZeroLikeConstants` both included specialization constants when trying to find integer constants with known values. However, this is incorrect behavior because we do not know the value of specialization constants. Furthermore, ConstantManager does not support them, and this led to crashes where we assumed we could look up specialization constants via the ConstantManager.

This change fixes both passes to ignore specialization constants.

Fixes #3663.
