### PR TITLE
spirv-fuzz: Fix in operand type assertion

### DIFF
--- a/source/fuzz/id_use_descriptor.cpp
+++ b/source/fuzz/id_use_descriptor.cpp
@@ -52,7 +52,7 @@ protobufs::IdUseDescriptor MakeIdUseDescriptorFromUse(
     opt::IRContext* context, opt::Instruction* inst,
     uint32_t in_operand_index) {
   const auto& in_operand = inst->GetInOperand(in_operand_index);
-  assert(in_operand.type == SPV_OPERAND_TYPE_ID);
+  assert(spvIsInIdType(in_operand.type));
   return MakeIdUseDescriptor(in_operand.words[0],
                              MakeInstructionDescriptor(context, inst),
                              in_operand_index);


### PR DESCRIPTION
`spvtools::fuzz::MakeIdUseDescriptorFromUse` asserts if the id use type is
`SPV_OPERAND_TYPE_ID`. The problem is that not all id types are covered by
this condition. The bug was found because the first operand of an `OpControlBarrier`
instruction has `SPV_OPERAND_TYPE_SCOPE_ID` as type. Therefore, to cover
all cases the `spvIsInIdType` function is used.

Fixes #3665.