### PR TITLE
spirv-fuzz: Check integer and float width capabilities

### DIFF
--- a/source/fuzz/transformation_add_type_float.cpp
+++ b/source/fuzz/transformation_add_type_float.cpp
@@ -38,12 +38,11 @@ bool TransformationAddTypeFloat::IsApplicable(
 
   // If the float type width is 16 or 64, then the corresponding Float16 or
   // Float64 capability must be present.
-  if (message_.width() == 16) {
-    assert(ir_context->get_feature_mgr()->HasCapability(SpvCapabilityFloat16) &&
-           "Missing Float16 capability.");
-  } else if (message_.width() == 64) {
-    assert(ir_context->get_feature_mgr()->HasCapability(SpvCapabilityFloat64) &&
-           "Missing Float64 capability.");
+  if ((message_.width() == 16 &&
+       !ir_context->get_feature_mgr()->HasCapability(SpvCapabilityFloat16)) ||
+      (message_.width() == 64 &&
+       !ir_context->get_feature_mgr()->HasCapability(SpvCapabilityFloat64))) {
+    return false;
   }
 
   // Applicable if there is no float type with this width already declared in

--- a/source/fuzz/transformation_add_type_float.cpp
+++ b/source/fuzz/transformation_add_type_float.cpp
@@ -43,11 +43,14 @@ bool TransformationAddTypeFloat::IsApplicable(
 
 void TransformationAddTypeFloat::Apply(
     opt::IRContext* ir_context, TransformationContext* /*unused*/) const {
-  // If the float type width is 16 or 64, then the corresponding Float16 and
-  // Float64 capabilities must be added.
-  if (message_.width() == 16) {
+  // If the float type width is 16 or 64 and the corresponding Float16 or
+  // Float64 capability is not present, then add it.
+  if (message_.width() == 16 &&
+      !ir_context->get_feature_mgr()->HasCapability(SpvCapabilityFloat16)) {
     ir_context->AddCapability(SpvCapabilityFloat16);
-  } else if (message_.width() == 64) {
+  } else if (message_.width() == 64 &&
+             !ir_context->get_feature_mgr()->HasCapability(
+                 SpvCapabilityFloat64)) {
     ir_context->AddCapability(SpvCapabilityFloat64);
   }
 

--- a/source/fuzz/transformation_add_type_float.cpp
+++ b/source/fuzz/transformation_add_type_float.cpp
@@ -43,6 +43,14 @@ bool TransformationAddTypeFloat::IsApplicable(
 
 void TransformationAddTypeFloat::Apply(
     opt::IRContext* ir_context, TransformationContext* /*unused*/) const {
+  // If the float type width is 16 or 64, then the corresponding Float16 and
+  // Float64 capabilities must be added.
+  if (message_.width() == 16) {
+    ir_context->AddCapability(SpvCapabilityFloat16);
+  } else if (message_.width() == 64) {
+    ir_context->AddCapability(SpvCapabilityFloat64);
+  }
+
   fuzzerutil::AddFloatType(ir_context, message_.fresh_id(), message_.width());
   // We have added an instruction to the module, so need to be careful about the
   // validity of existing analyses.

--- a/source/fuzz/transformation_add_type_float.cpp
+++ b/source/fuzz/transformation_add_type_float.cpp
@@ -36,13 +36,26 @@ bool TransformationAddTypeFloat::IsApplicable(
     return false;
   }
 
-  // If the float type width is 16 or 64, then the corresponding Float16 or
-  // Float64 capability must be present.
-  if ((message_.width() == 16 &&
-       !ir_context->get_feature_mgr()->HasCapability(SpvCapabilityFloat16)) ||
-      (message_.width() == 64 &&
-       !ir_context->get_feature_mgr()->HasCapability(SpvCapabilityFloat64))) {
-    return false;
+  // Checks float type width capabilities.
+  switch (message_.width()) {
+    case 16:
+      // The Float16 capability must be present.
+      if (!ir_context->get_feature_mgr()->HasCapability(SpvCapabilityFloat16)) {
+        return false;
+      }
+      break;
+    case 32:
+      // No capabilities needed.
+      break;
+    case 64:
+      // The Float64 capability must be present.
+      if (!ir_context->get_feature_mgr()->HasCapability(SpvCapabilityFloat64)) {
+        return false;
+      }
+      break;
+    default:
+      assert(false && "Unexpected float type width");
+      return false;
   }
 
   // Applicable if there is no float type with this width already declared in

--- a/source/fuzz/transformation_add_type_int.cpp
+++ b/source/fuzz/transformation_add_type_int.cpp
@@ -38,6 +38,17 @@ bool TransformationAddTypeInt::IsApplicable(
     return false;
   }
 
+  // If the integer type width is 8, 16 or 64, then the corresponding Int8,
+  // Int16 or Int64 capability must be present.
+  if ((message_.width() == 8 &&
+       !ir_context->get_feature_mgr()->HasCapability(SpvCapabilityInt8)) ||
+      (message_.width() == 16 &&
+       !ir_context->get_feature_mgr()->HasCapability(SpvCapabilityInt16)) ||
+      (message_.width() == 64 &&
+       !ir_context->get_feature_mgr()->HasCapability(SpvCapabilityInt64))) {
+    return false;
+  }
+
   // Applicable if there is no int type with this width and signedness already
   // declared in the module.
   return fuzzerutil::MaybeGetIntegerType(ir_context, message_.width(),

--- a/source/fuzz/transformation_add_type_int.cpp
+++ b/source/fuzz/transformation_add_type_int.cpp
@@ -38,15 +38,32 @@ bool TransformationAddTypeInt::IsApplicable(
     return false;
   }
 
-  // If the integer type width is 8, 16 or 64, then the corresponding Int8,
-  // Int16 or Int64 capability must be present.
-  if ((message_.width() == 8 &&
-       !ir_context->get_feature_mgr()->HasCapability(SpvCapabilityInt8)) ||
-      (message_.width() == 16 &&
-       !ir_context->get_feature_mgr()->HasCapability(SpvCapabilityInt16)) ||
-      (message_.width() == 64 &&
-       !ir_context->get_feature_mgr()->HasCapability(SpvCapabilityInt64))) {
-    return false;
+  // Checks integer type width capabilities.
+  switch (message_.width()) {
+    case 8:
+      // The Int8 capability must be present.
+      if (!ir_context->get_feature_mgr()->HasCapability(SpvCapabilityInt8)) {
+        return false;
+      }
+      break;
+    case 16:
+      // The Int16 capability must be present.
+      if (!ir_context->get_feature_mgr()->HasCapability(SpvCapabilityInt16)) {
+        return false;
+      }
+      break;
+    case 32:
+      // No capabilities needed.
+      break;
+    case 64:
+      // The Int64 capability must be present.
+      if (!ir_context->get_feature_mgr()->HasCapability(SpvCapabilityInt64)) {
+        return false;
+      }
+      break;
+    default:
+      assert(false && "Unexpected integer type width");
+      return false;
   }
 
   // Applicable if there is no int type with this width and signedness already

--- a/test/fuzz/transformation_add_type_float_test.cpp
+++ b/test/fuzz/transformation_add_type_float_test.cpp
@@ -19,26 +19,30 @@ namespace spvtools {
 namespace fuzz {
 namespace {
 
-TEST(TransformationAddTypeFloatTest, BasicTest) {
-  std::string shader = R"(
-               OpCapability Shader
-          %1 = OpExtInstImport "GLSL.std.450"
-               OpMemoryModel Logical GLSL450
-               OpEntryPoint Fragment %4 "main"
-               OpExecutionMode %4 OriginUpperLeft
-               OpSource ESSL 310
-               OpName %4 "main"
-          %2 = OpTypeVoid
-          %3 = OpTypeFunction %2
-          %4 = OpFunction %2 None %3
-          %5 = OpLabel
-               OpReturn
-               OpFunctionEnd
+TEST(TransformationAddTypeFloatTest, IsApplicable) {
+  std::string reference_shader = R"(
+         OpCapability Shader
+         OpCapability Float16
+    %1 = OpExtInstImport "GLSL.std.450"
+         OpMemoryModel Logical GLSL450
+         OpEntryPoint Vertex %5 "main"
+
+; Types
+    %2 = OpTypeFloat 16
+    %3 = OpTypeVoid
+    %4 = OpTypeFunction %3
+
+; main function
+    %5 = OpFunction %3 None %4
+    %6 = OpLabel
+         OpReturn
+         OpFunctionEnd
   )";
 
   const auto env = SPV_ENV_UNIVERSAL_1_3;
   const auto consumer = nullptr;
-  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  const auto context =
+      BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   FactManager fact_manager;
@@ -46,37 +50,94 @@ TEST(TransformationAddTypeFloatTest, BasicTest) {
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  // Not applicable because id 1 is already in use.
-  ASSERT_FALSE(TransformationAddTypeFloat(1, 32).IsApplicable(
-      context.get(), transformation_context));
+  // Tests non-fresh id.
+  auto transformation = TransformationAddTypeFloat(1, 32);
+  ASSERT_FALSE(
+      transformation.IsApplicable(context.get(), transformation_context));
 
-  auto add_type_float_32 = TransformationAddTypeFloat(100, 32);
+  // Tests missing Float64 capability.
+  transformation = TransformationAddTypeFloat(7, 64);
+  ASSERT_FALSE(
+      transformation.IsApplicable(context.get(), transformation_context));
+
+  // Tests existing 16-bit float type.
+  transformation = TransformationAddTypeFloat(7, 16);
+  ASSERT_FALSE(
+      transformation.IsApplicable(context.get(), transformation_context));
+
+  // Tests adding 32-bit float type.
+  transformation = TransformationAddTypeFloat(7, 32);
   ASSERT_TRUE(
-      add_type_float_32.IsApplicable(context.get(), transformation_context));
-  add_type_float_32.Apply(context.get(), &transformation_context);
+      transformation.IsApplicable(context.get(), transformation_context));
+}
+
+TEST(TransformationAddTypeFloatTest, Apply) {
+  std::string reference_shader = R"(
+         OpCapability Shader
+         OpCapability Float16
+         OpCapability Float64
+    %1 = OpExtInstImport "GLSL.std.450"
+         OpMemoryModel Logical GLSL450
+         OpEntryPoint Vertex %4 "main"
+
+; Types
+    %2 = OpTypeVoid
+    %3 = OpTypeFunction %2
+
+; main function
+    %4 = OpFunction %2 None %3
+    %5 = OpLabel
+         OpReturn
+         OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context =
+      BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  // Not applicable as we already have this type now.
-  ASSERT_FALSE(TransformationAddTypeFloat(101, 32).IsApplicable(
-      context.get(), transformation_context));
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
 
-  std::string after_transformation = R"(
-               OpCapability Shader
-          %1 = OpExtInstImport "GLSL.std.450"
-               OpMemoryModel Logical GLSL450
-               OpEntryPoint Fragment %4 "main"
-               OpExecutionMode %4 OriginUpperLeft
-               OpSource ESSL 310
-               OpName %4 "main"
-          %2 = OpTypeVoid
-          %3 = OpTypeFunction %2
-        %100 = OpTypeFloat 32
-          %4 = OpFunction %2 None %3
-          %5 = OpLabel
-               OpReturn
-               OpFunctionEnd
+  // Adds 16-bit float type.
+  auto transformation = TransformationAddTypeFloat(6, 16);
+  transformation.Apply(context.get(), &transformation_context);
+
+  // Adds 32-bit float type.
+  transformation = TransformationAddTypeFloat(7, 32);
+  transformation.Apply(context.get(), &transformation_context);
+
+  // Adds 64-bit float type.
+  transformation = TransformationAddTypeFloat(8, 64);
+  transformation.Apply(context.get(), &transformation_context);
+
+  std::string variant_shader = R"(
+         OpCapability Shader
+         OpCapability Float16
+         OpCapability Float64
+    %1 = OpExtInstImport "GLSL.std.450"
+         OpMemoryModel Logical GLSL450
+         OpEntryPoint Vertex %4 "main"
+
+; Types
+    %2 = OpTypeVoid
+    %3 = OpTypeFunction %2
+    %6 = OpTypeFloat 16
+    %7 = OpTypeFloat 32
+    %8 = OpTypeFloat 64
+
+; main function
+    %4 = OpFunction %2 None %3
+    %5 = OpLabel
+         OpReturn
+         OpFunctionEnd
   )";
-  ASSERT_TRUE(IsEqual(env, after_transformation, context.get()));
+
+  ASSERT_TRUE(IsValid(env, context.get()));
+  ASSERT_TRUE(IsEqual(env, variant_shader, context.get()));
 }
 
 }  // namespace

--- a/test/fuzz/transformation_add_type_int_test.cpp
+++ b/test/fuzz/transformation_add_type_int_test.cpp
@@ -19,26 +19,30 @@ namespace spvtools {
 namespace fuzz {
 namespace {
 
-TEST(TransformationAddTypeIntTest, BasicTest) {
-  std::string shader = R"(
-               OpCapability Shader
-          %1 = OpExtInstImport "GLSL.std.450"
-               OpMemoryModel Logical GLSL450
-               OpEntryPoint Fragment %4 "main"
-               OpExecutionMode %4 OriginUpperLeft
-               OpSource ESSL 310
-               OpName %4 "main"
-          %2 = OpTypeVoid
-          %3 = OpTypeFunction %2
-          %4 = OpFunction %2 None %3
-          %5 = OpLabel
-               OpReturn
-               OpFunctionEnd
+TEST(TransformationAddTypeIntTest, IsApplicable) {
+  std::string reference_shader = R"(
+         OpCapability Shader
+         OpCapability Int8
+    %1 = OpExtInstImport "GLSL.std.450"
+         OpMemoryModel Logical GLSL450
+         OpEntryPoint Vertex %5 "main"
+
+; Types
+    %2 = OpTypeInt 8 1
+    %3 = OpTypeVoid
+    %4 = OpTypeFunction %3
+
+; main function
+    %5 = OpFunction %3 None %4
+    %6 = OpLabel
+         OpReturn
+         OpFunctionEnd
   )";
 
   const auto env = SPV_ENV_UNIVERSAL_1_3;
   const auto consumer = nullptr;
-  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  const auto context =
+      BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   FactManager fact_manager;
@@ -46,50 +50,136 @@ TEST(TransformationAddTypeIntTest, BasicTest) {
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  // Not applicable because id 1 is already in use.
-  ASSERT_FALSE(TransformationAddTypeInt(1, 32, false)
-                   .IsApplicable(context.get(), transformation_context));
+  // Tests non-fresh id.
+  auto transformation = TransformationAddTypeInt(1, 32, false);
+  ASSERT_FALSE(
+      transformation.IsApplicable(context.get(), transformation_context));
 
-  auto add_type_signed_int_32 = TransformationAddTypeInt(100, 32, true);
-  auto add_type_unsigned_int_32 = TransformationAddTypeInt(101, 32, false);
-  auto add_type_signed_int_32_again = TransformationAddTypeInt(102, 32, true);
-  auto add_type_unsigned_int_32_again =
-      TransformationAddTypeInt(103, 32, false);
+  // Tests missing Int16 capability.
+  transformation = TransformationAddTypeInt(7, 16, false);
+  ASSERT_FALSE(
+      transformation.IsApplicable(context.get(), transformation_context));
 
-  ASSERT_TRUE(add_type_signed_int_32.IsApplicable(context.get(),
-                                                  transformation_context));
-  add_type_signed_int_32.Apply(context.get(), &transformation_context);
-  ASSERT_TRUE(IsValid(env, context.get()));
+  // Tests missing Int64 capability.
+  transformation = TransformationAddTypeInt(7, 64, false);
+  ASSERT_FALSE(
+      transformation.IsApplicable(context.get(), transformation_context));
 
-  ASSERT_TRUE(add_type_unsigned_int_32.IsApplicable(context.get(),
-                                                    transformation_context));
-  add_type_unsigned_int_32.Apply(context.get(), &transformation_context);
-  ASSERT_TRUE(IsValid(env, context.get()));
+  // Tests existing signed 8-bit integer type.
+  transformation = TransformationAddTypeInt(7, 8, true);
+  ASSERT_FALSE(
+      transformation.IsApplicable(context.get(), transformation_context));
 
-  // Not applicable as we already have these types now.
-  ASSERT_FALSE(add_type_signed_int_32_again.IsApplicable(
-      context.get(), transformation_context));
-  ASSERT_FALSE(add_type_unsigned_int_32_again.IsApplicable(
-      context.get(), transformation_context));
+  // Tests adding unsigned 8-bit integer type.
+  transformation = TransformationAddTypeInt(7, 8, false);
+  ASSERT_TRUE(
+      transformation.IsApplicable(context.get(), transformation_context));
 
-  std::string after_transformation = R"(
-               OpCapability Shader
-          %1 = OpExtInstImport "GLSL.std.450"
-               OpMemoryModel Logical GLSL450
-               OpEntryPoint Fragment %4 "main"
-               OpExecutionMode %4 OriginUpperLeft
-               OpSource ESSL 310
-               OpName %4 "main"
-          %2 = OpTypeVoid
-          %3 = OpTypeFunction %2
-        %100 = OpTypeInt 32 1
-        %101 = OpTypeInt 32 0
-          %4 = OpFunction %2 None %3
-          %5 = OpLabel
-               OpReturn
-               OpFunctionEnd
+  // Tests adding unsigned 32-bit integer type.
+  transformation = TransformationAddTypeInt(7, 32, false);
+  ASSERT_TRUE(
+      transformation.IsApplicable(context.get(), transformation_context));
+
+  // Tests adding signed 32-bit integer type.
+  transformation = TransformationAddTypeInt(7, 32, true);
+  ASSERT_TRUE(
+      transformation.IsApplicable(context.get(), transformation_context));
+}
+
+TEST(TransformationAddTypeIntTest, Apply) {
+  std::string reference_shader = R"(
+         OpCapability Shader
+         OpCapability Int8
+         OpCapability Int16
+         OpCapability Int64
+    %1 = OpExtInstImport "GLSL.std.450"
+         OpMemoryModel Logical GLSL450
+         OpEntryPoint Vertex %4 "main"
+
+; Types
+    %2 = OpTypeVoid
+    %3 = OpTypeFunction %2
+
+; main function
+    %4 = OpFunction %2 None %3
+    %5 = OpLabel
+         OpReturn
+         OpFunctionEnd
   )";
-  ASSERT_TRUE(IsEqual(env, after_transformation, context.get()));
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+  const auto context =
+      BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  // Adds signed 8-bit integer type.
+  auto transformation = TransformationAddTypeInt(6, 8, true);
+  transformation.Apply(context.get(), &transformation_context);
+
+  // Adds signed 16-bit integer type.
+  transformation = TransformationAddTypeInt(7, 16, true);
+  transformation.Apply(context.get(), &transformation_context);
+
+  // Adds signed 32-bit integer type.
+  transformation = TransformationAddTypeInt(8, 32, true);
+  transformation.Apply(context.get(), &transformation_context);
+
+  // Adds signed 64-bit integer type.
+  transformation = TransformationAddTypeInt(9, 64, true);
+  transformation.Apply(context.get(), &transformation_context);
+
+  // Adds unsigned 8-bit integer type.
+  transformation = TransformationAddTypeInt(10, 8, false);
+  transformation.Apply(context.get(), &transformation_context);
+
+  // Adds unsigned 16-bit integer type.
+  transformation = TransformationAddTypeInt(11, 16, false);
+  transformation.Apply(context.get(), &transformation_context);
+
+  // Adds unsigned 32-bit integer type.
+  transformation = TransformationAddTypeInt(12, 32, false);
+  transformation.Apply(context.get(), &transformation_context);
+
+  // Adds unsigned 64-bit integer type.
+  transformation = TransformationAddTypeInt(13, 64, false);
+  transformation.Apply(context.get(), &transformation_context);
+
+  std::string variant_shader = R"(
+         OpCapability Shader
+         OpCapability Int8
+         OpCapability Int16
+         OpCapability Int64
+    %1 = OpExtInstImport "GLSL.std.450"
+         OpMemoryModel Logical GLSL450
+         OpEntryPoint Vertex %4 "main"
+
+; Types
+    %2 = OpTypeVoid
+    %3 = OpTypeFunction %2
+    %6 = OpTypeInt 8 1
+    %7 = OpTypeInt 16 1
+    %8 = OpTypeInt 32 1
+    %9 = OpTypeInt 64 1
+   %10 = OpTypeInt 8 0
+   %11 = OpTypeInt 16 0
+   %12 = OpTypeInt 32 0
+   %13 = OpTypeInt 64 0
+
+; main function
+    %4 = OpFunction %2 None %3
+    %5 = OpLabel
+         OpReturn
+         OpFunctionEnd
+  )";
+
+  ASSERT_TRUE(IsValid(env, context.get()));
+  ASSERT_TRUE(IsEqual(env, variant_shader, context.get()));
 }
 
 }  // namespace


### PR DESCRIPTION
`TransformationAddTypeFloat` and `TransformationAddTypeInt` did not check whether the required capabilities were present when adding 16-bit, 64-bit, and 8-bit types.

This change adds these checks in the `IsApplicable` method of each transformation.

Fixes #3669.