### PR TITLE
Roll 2 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -4,9 +4,9 @@ vars = {
   'github': 'https://github.com',
 
   'effcee_revision': '2ec8f8738118cc483b67c04a759fee53496c5659',
-  'googletest_revision': 'a781fe29bcf73003559a3583167fe3d647518464',
+  'googletest_revision': '3af06fe1664d30f98de1e78c53a7087e842a2547',
   're2_revision': 'ca11026a032ce2a3de4b3c389ee53d2bdc8794d6',
-  'spirv_headers_revision': '5538bf4386f19e42072bf8c2dfc3acf8d0196f3b',
+  'spirv_headers_revision': '3fdabd0da2932c276b25b9b4a988ba134eba1aa6',
 }
 
 deps = {


### PR DESCRIPTION
Roll external/googletest/ a781fe29b..3af06fe16 (12 commits)

https://github.com/google/googletest/compare/a781fe29bcf7...3af06fe1664d

$ git log a781fe29b..3af06fe16 --date=short --no-merges --format='%ad %ae %s'
2020-08-05 absl-team Googletest export
2020-08-03 absl-team Googletest export
2020-08-03 absl-team Googletest export
2020-08-05 zumix.cpp fix endif comment
2020-08-02 zumix.cpp fix tests
2020-07-29 franciscogthiesen Removing tiny-dnn from "Who is using.."
2020-07-28 absl-team Googletest export
2020-07-29 zumix.cpp fix GTEST_REMOVE_LEGACY_TEST_CASEAPI_ typo
2020-07-28 absl-team Googletest export
2020-07-26 ofats Googletest export
2020-07-19 jasjuang fix clang tidy modernize-use-equals-default warnings
2020-07-02 siliconearth Fix test failing when simple regex is used

Created with:
  roll-dep external/googletest

Roll external/spirv-headers/ 5538bf438..3fdabd0da (1 commit)

https://github.com/KhronosGroup/SPIRV-Headers/compare/5538bf4386f1...3fdabd0da293

$ git log 5538bf438..3fdabd0da --date=short --no-merges --format='%ad %ae %s'
2020-08-03 44190824+mmerecki Reserve SPIR-V token range for upcoming Intel extensions. (#165)

Created with:
  roll-dep external/spirv-headers