### PR TITLE
spirv-fuzz: Transformation to convert OpSelect to conditional branch

### DIFF
--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -255,11 +255,8 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_replace_irrelevant_ids.cpp
         fuzzer_pass_replace_linear_algebra_instructions.cpp
         fuzzer_pass_replace_loads_stores_with_copy_memories.cpp
-<<<<<<< HEAD
         fuzzer_pass_replace_opphi_ids_from_dead_predecessors.cpp
-=======
         fuzzer_pass_replace_opselects_with_conditional_branches.cpp
->>>>>>> a626d96c (Rename transformation)
         fuzzer_pass_replace_parameter_with_global.cpp
         fuzzer_pass_replace_params_with_struct.cpp
         fuzzer_pass_split_blocks.cpp

--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -174,6 +174,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_replace_linear_algebra_instruction.h
         transformation_replace_load_store_with_copy_memory.h
         transformation_replace_opphi_id_from_dead_predecessor.h
+        transformation_replace_opselect_with_conditional_branch.h
         transformation_replace_parameter_with_global.h
         transformation_replace_params_with_struct.h
         transformation_set_function_control.h
@@ -306,6 +307,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_composite_insert.cpp
         transformation_compute_data_synonym_fact_closure.cpp
         transformation_context.cpp
+        transformation_replace_opselect_with_conditional_branch.cpp
         transformation_equation_instruction.cpp
         transformation_function_call.cpp
         transformation_inline_function.cpp

--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -95,6 +95,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_replace_linear_algebra_instructions.h
         fuzzer_pass_replace_loads_stores_with_copy_memories.h
         fuzzer_pass_replace_opphi_ids_from_dead_predecessors.h
+        fuzzer_pass_replace_opselects_with_conditional_branches.h
         fuzzer_pass_replace_parameter_with_global.h
         fuzzer_pass_replace_params_with_struct.h
         fuzzer_pass_split_blocks.h
@@ -254,7 +255,11 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_replace_irrelevant_ids.cpp
         fuzzer_pass_replace_linear_algebra_instructions.cpp
         fuzzer_pass_replace_loads_stores_with_copy_memories.cpp
+<<<<<<< HEAD
         fuzzer_pass_replace_opphi_ids_from_dead_predecessors.cpp
+=======
+        fuzzer_pass_replace_opselects_with_conditional_branches.cpp
+>>>>>>> a626d96c (Rename transformation)
         fuzzer_pass_replace_parameter_with_global.cpp
         fuzzer_pass_replace_params_with_struct.cpp
         fuzzer_pass_split_blocks.cpp

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -326,7 +326,7 @@ Fuzzer::FuzzerResultStatus Fuzzer::Run(
     MaybeAddPass<FuzzerPassReplaceLinearAlgebraInstructions>(
         &passes, ir_context.get(), &transformation_context, &fuzzer_context,
         transformation_sequence_out);
-    MaybeAddPass<FuzzerPassReplaceOpselectsWithConditionalBranches>(
+    MaybeAddPass<FuzzerPassReplaceOpSelectsWithConditionalBranches>(
         &passes, ir_context.get(), &transformation_context, &fuzzer_context,
         transformation_sequence_out);
     MaybeAddPass<FuzzerPassReplaceParamsWithStruct>(

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -71,6 +71,7 @@
 #include "source/fuzz/fuzzer_pass_replace_linear_algebra_instructions.h"
 #include "source/fuzz/fuzzer_pass_replace_loads_stores_with_copy_memories.h"
 #include "source/fuzz/fuzzer_pass_replace_opphi_ids_from_dead_predecessors.h"
+#include "source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.h"
 #include "source/fuzz/fuzzer_pass_replace_parameter_with_global.h"
 #include "source/fuzz/fuzzer_pass_replace_params_with_struct.h"
 #include "source/fuzz/fuzzer_pass_split_blocks.h"
@@ -323,6 +324,9 @@ Fuzzer::FuzzerResultStatus Fuzzer::Run(
         &passes, ir_context.get(), &transformation_context, &fuzzer_context,
         transformation_sequence_out);
     MaybeAddPass<FuzzerPassReplaceLinearAlgebraInstructions>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassReplaceOpselectsWithConditionalBranches>(
         &passes, ir_context.get(), &transformation_context, &fuzzer_context,
         transformation_sequence_out);
     MaybeAddPass<FuzzerPassReplaceParamsWithStruct>(

--- a/source/fuzz/fuzzer_context.cpp
+++ b/source/fuzz/fuzzer_context.cpp
@@ -27,6 +27,8 @@ const std::pair<uint32_t, uint32_t> kChanceOfAddingAccessChain = {5, 50};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingAnotherStructField = {20,
                                                                          90};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingArrayOrStructType = {20, 90};
+const std::pair<uint32_t, uint32_t>
+    kChanceOfAddingBothBranchesWhenReplacingOpSelect = {40, 60};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingCompositeInsert = {20, 50};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingCopyMemory = {20, 50};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingDeadBlock = {20, 90};
@@ -48,6 +50,8 @@ const std::pair<uint32_t, uint32_t> kChanceOfAddingParameters = {5, 70};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingRelaxedDecoration = {20, 90};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingStore = {5, 50};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingSynonyms = {20, 50};
+const std::pair<uint32_t, uint32_t>
+    kChanceOfAddingTrueBranchWhenReplacingOpSelect = {40, 60};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingVectorType = {20, 70};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingVectorShuffle = {20, 70};
 const std::pair<uint32_t, uint32_t> kChanceOfAdjustingBranchWeights = {20, 90};
@@ -106,7 +110,7 @@ const std::pair<uint32_t, uint32_t> kChanceOfReplacingLoadStoreWithCopyMemory =
 const std::pair<uint32_t, uint32_t>
     kChanceOfReplacingOpPhiIdFromDeadPredecessor = {20, 90};
 const std::pair<uint32_t, uint32_t>
-    kChanceOfReplacingOpselectWithConditionalBranch = {20, 90};
+    kChanceOfReplacingOpSelectWithConditionalBranch = {20, 90};
 const std::pair<uint32_t, uint32_t> kChanceOfReplacingParametersWithGlobals = {
     30, 70};
 const std::pair<uint32_t, uint32_t> kChanceOfReplacingParametersWithStruct = {
@@ -164,6 +168,8 @@ FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
       ChooseBetweenMinAndMax(kChanceOfAddingAnotherStructField);
   chance_of_adding_array_or_struct_type_ =
       ChooseBetweenMinAndMax(kChanceOfAddingArrayOrStructType);
+  chance_of_adding_both_branches_when_replacing_opselect_ =
+      ChooseBetweenMinAndMax(kChanceOfAddingBothBranchesWhenReplacingOpSelect);
   chance_of_adding_composite_insert_ =
       ChooseBetweenMinAndMax(kChanceOfAddingCompositeInsert);
   chance_of_adding_copy_memory_ =
@@ -196,6 +202,8 @@ FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
   chance_of_adding_relaxed_decoration_ =
       ChooseBetweenMinAndMax(kChanceOfAddingRelaxedDecoration);
   chance_of_adding_store_ = ChooseBetweenMinAndMax(kChanceOfAddingStore);
+  chance_of_adding_true_branch_when_replacing_opselect_ =
+      ChooseBetweenMinAndMax(kChanceOfAddingTrueBranchWhenReplacingOpSelect);
   chance_of_adding_vector_shuffle_ =
       ChooseBetweenMinAndMax(kChanceOfAddingVectorShuffle);
   chance_of_adding_vector_type_ =
@@ -274,7 +282,7 @@ FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
   chance_of_replacing_opphi_id_from_dead_predecessor_ =
       ChooseBetweenMinAndMax(kChanceOfReplacingOpPhiIdFromDeadPredecessor);
   chance_of_replacing_opselect_with_conditional_branch_ =
-      ChooseBetweenMinAndMax(kChanceOfReplacingOpselectWithConditionalBranch);
+      ChooseBetweenMinAndMax(kChanceOfReplacingOpSelectWithConditionalBranch);
   chance_of_replacing_parameters_with_globals_ =
       ChooseBetweenMinAndMax(kChanceOfReplacingParametersWithGlobals);
   chance_of_replacing_parameters_with_struct_ =

--- a/source/fuzz/fuzzer_context.cpp
+++ b/source/fuzz/fuzzer_context.cpp
@@ -105,6 +105,8 @@ const std::pair<uint32_t, uint32_t> kChanceOfReplacingLoadStoreWithCopyMemory =
     {20, 90};
 const std::pair<uint32_t, uint32_t>
     kChanceOfReplacingOpPhiIdFromDeadPredecessor = {20, 90};
+const std::pair<uint32_t, uint32_t>
+    kChanceOfReplacingOpselectWithConditionalBranch = {20, 90};
 const std::pair<uint32_t, uint32_t> kChanceOfReplacingParametersWithGlobals = {
     30, 70};
 const std::pair<uint32_t, uint32_t> kChanceOfReplacingParametersWithStruct = {
@@ -271,6 +273,8 @@ FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
       ChooseBetweenMinAndMax(kChanceOfReplacingLoadStoreWithCopyMemory);
   chance_of_replacing_opphi_id_from_dead_predecessor_ =
       ChooseBetweenMinAndMax(kChanceOfReplacingOpPhiIdFromDeadPredecessor);
+  chance_of_replacing_opselect_with_conditional_branch_ =
+      ChooseBetweenMinAndMax(kChanceOfReplacingOpselectWithConditionalBranch);
   chance_of_replacing_parameters_with_globals_ =
       ChooseBetweenMinAndMax(kChanceOfReplacingParametersWithGlobals);
   chance_of_replacing_parameters_with_struct_ =

--- a/source/fuzz/fuzzer_context.h
+++ b/source/fuzz/fuzzer_context.h
@@ -264,6 +264,9 @@ class FuzzerContext {
   uint32_t GetChanceOfReplacingOpPhiIdFromDeadPredecessor() {
     return chance_of_replacing_opphi_id_from_dead_predecessor_;
   }
+  uint32_t GetChanceOfReplacingOpselectWithConditionalBranch() {
+    return chance_of_replacing_opselect_with_conditional_branch_;
+  }
   uint32_t GetChanceOfReplacingParametersWithGlobals() {
     return chance_of_replacing_parameters_with_globals_;
   }
@@ -421,6 +424,7 @@ class FuzzerContext {
   uint32_t chance_of_replacing_linear_algebra_instructions_;
   uint32_t chance_of_replacing_load_store_with_copy_memory_;
   uint32_t chance_of_replacing_opphi_id_from_dead_predecessor_;
+  uint32_t chance_of_replacing_opselect_with_conditional_branch_;
   uint32_t chance_of_replacing_parameters_with_globals_;
   uint32_t chance_of_replacing_parameters_with_struct_;
   uint32_t chance_of_splitting_block_;

--- a/source/fuzz/fuzzer_context.h
+++ b/source/fuzz/fuzzer_context.h
@@ -115,6 +115,9 @@ class FuzzerContext {
   uint32_t GetChanceOfAddingArrayOrStructType() {
     return chance_of_adding_array_or_struct_type_;
   }
+  uint32_t GetChanceOfAddingBothBranchesWhenReplacingOpSelect() {
+    return chance_of_adding_both_branches_when_replacing_opselect_;
+  }
   uint32_t GetChanceOfAddingCompositeInsert() {
     return chance_of_adding_composite_insert_;
   }
@@ -157,6 +160,9 @@ class FuzzerContext {
   }
   uint32_t GetChanceOfAddingStore() { return chance_of_adding_store_; }
   uint32_t GetChanceOfAddingSynonyms() { return chance_of_adding_synonyms_; }
+  uint32_t GetChanceOfAddingTrueBranchWhenReplacingOpSelect() {
+    return chance_of_adding_true_branch_when_replacing_opselect_;
+  }
   uint32_t GetChanceOfAddingVectorShuffle() {
     return chance_of_adding_vector_shuffle_;
   }
@@ -367,6 +373,7 @@ class FuzzerContext {
   uint32_t chance_of_adding_access_chain_;
   uint32_t chance_of_adding_another_struct_field_;
   uint32_t chance_of_adding_array_or_struct_type_;
+  uint32_t chance_of_adding_both_branches_when_replacing_opselect_;
   uint32_t chance_of_adding_composite_insert_;
   uint32_t chance_of_adding_copy_memory_;
   uint32_t chance_of_adding_dead_block_;
@@ -385,6 +392,7 @@ class FuzzerContext {
   uint32_t chance_of_adding_relaxed_decoration_;
   uint32_t chance_of_adding_store_;
   uint32_t chance_of_adding_synonyms_;
+  uint32_t chance_of_adding_true_branch_when_replacing_opselect_;
   uint32_t chance_of_adding_vector_shuffle_;
   uint32_t chance_of_adding_vector_type_;
   uint32_t chance_of_adjusting_branch_weights_;

--- a/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.cpp
+++ b/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.cpp
@@ -15,7 +15,9 @@
 #include "source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.h"
 
 #include "source/fuzz/fuzzer_util.h"
+#include "source/fuzz/instruction_descriptor.h"
 #include "source/fuzz/transformation_replace_opselect_with_conditional_branch.h"
+#include "source/fuzz/transformation_split_block.h"
 
 namespace spvtools {
 namespace fuzz {
@@ -42,8 +44,11 @@ void FuzzerPassReplaceOpSelectsWithConditionalBranches::Apply() {
   for (auto& function : *GetIRContext()->module()) {
     for (auto& block : function) {
       // We cannot split loop headers, so we don't need to consider instructions
-      // in loop headers.
-      if (block.IsLoopHeader()) {
+      // in loop headers that are also merge blocks (since they would need to be
+      // split).
+      if (block.IsLoopHeader() &&
+          GetIRContext()->GetStructuredCFGAnalysis()->IsMergeBlock(
+              block.id())) {
         continue;
       }
 
@@ -58,6 +63,14 @@ void FuzzerPassReplaceOpSelectsWithConditionalBranches::Apply() {
                 GetFuzzerContext()
                     ->GetChanceOfReplacingOpselectWithConditionalBranch())) {
           continue;
+        }
+
+        // If the block is a loop header and we need to split it, the
+        // transformation cannot be applied because loop headers cannot be
+        // split. We can break out of this loop because the transformation can
+        // only be applied to at most the first instruction in a loop header.
+        if (block.IsLoopHeader() && InstructionNeedsSplitBefore(&instruction)) {
+          break;
         }
 
         // If the instruction separates an OpSampledImage from its use, the
@@ -75,12 +88,74 @@ void FuzzerPassReplaceOpSelectsWithConditionalBranches::Apply() {
     }
   }
 
-  // Apply the transformations.
+  // Apply the transformations, splitting the blocks containing the
+  // instructions, if necessary.
   for (uint32_t instruction_id : replaceable_opselect_instruction_ids) {
+    auto instruction =
+        GetIRContext()->get_def_use_mgr()->GetDef(instruction_id);
+
+    // If the instruction requires the block containing it to be split before
+    // it, split the block.
+    if (InstructionNeedsSplitBefore(instruction)) {
+      ApplyTransformation(TransformationSplitBlock(
+          MakeInstructionDescriptor(GetIRContext(), instruction),
+          GetFuzzerContext()->GetFreshId()));
+    }
+
+    // Decide whether to have two branches or just one.
+    bool two_branches = GetFuzzerContext()->ChoosePercentage(
+        GetFuzzerContext()
+            ->GetChanceOfAddingBothBranchesWhenReplacingOpSelect());
+
+    // If there will be only one branch, decide whether it will be the true
+    // branch or the false branch.
+    bool true_branch_id_zero =
+        !two_branches &&
+        GetFuzzerContext()->ChoosePercentage(
+            GetFuzzerContext()
+                ->GetChanceOfAddingTrueBranchWhenReplacingOpSelect());
+    bool false_branch_id_zero = !two_branches && !true_branch_id_zero;
+
+    uint32_t true_branch_id =
+        true_branch_id_zero ? 0 : GetFuzzerContext()->GetFreshId();
+    uint32_t false_branch_id =
+        false_branch_id_zero ? 0 : GetFuzzerContext()->GetFreshId();
+
     ApplyTransformation(TransformationReplaceOpSelectWithConditionalBranch(
-        instruction_id, GetFuzzerContext()->GetFreshId(),
-        GetFuzzerContext()->GetFreshId()));
+        instruction_id, true_branch_id, false_branch_id));
   }
+}
+
+bool FuzzerPassReplaceOpSelectsWithConditionalBranches::
+    InstructionNeedsSplitBefore(opt::Instruction* instruction) {
+  assert(instruction && instruction->opcode() == SpvOpSelect &&
+         "The instruction must be OpSelect.");
+
+  auto block = GetIRContext()->get_instr_block(instruction);
+  assert(block && "The instruction must be contained in a block.");
+
+  // We need to split the block if the instruction is not the first in its
+  // block.
+  if (instruction->unique_id() != block->begin()->unique_id()) {
+    return true;
+  }
+
+  // We need to split the block if it is a merge block.
+  if (GetIRContext()->GetStructuredCFGAnalysis()->IsMergeBlock(block->id())) {
+    return true;
+  }
+
+  // We need to split the block if it has more than one predecessor.
+  if (GetIRContext()->cfg()->preds(block->id()).size() != 1) {
+    return true;
+  }
+
+  // We need to split the block if its predecessor is a header or it does not
+  // branch unconditionally to the block.
+  auto predecessor = GetIRContext()->get_instr_block(
+      GetIRContext()->cfg()->preds(block->id())[0]);
+  return predecessor->MergeBlockIdIfAny() ||
+         predecessor->terminator()->opcode() != SpvOpBranch;
 }
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.cpp
+++ b/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.cpp
@@ -12,4 +12,76 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "fuzzer_pass_replace_opselects_with_conditional_branches.h"
+#include "source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.h"
+
+#include "source/fuzz/fuzzer_util.h"
+#include "source/fuzz/transformation_replace_opselect_with_conditional_branch.h"
+
+namespace spvtools {
+namespace fuzz {
+
+FuzzerPassReplaceOpselectsWithConditionalBranches::
+    FuzzerPassReplaceOpselectsWithConditionalBranches(
+        opt::IRContext* ir_context,
+        TransformationContext* transformation_context,
+        FuzzerContext* fuzzer_context,
+        protobufs::TransformationSequence* transformations)
+    : FuzzerPass(ir_context, transformation_context, fuzzer_context,
+                 transformations) {}
+
+FuzzerPassReplaceOpselectsWithConditionalBranches::
+    ~FuzzerPassReplaceOpselectsWithConditionalBranches() = default;
+
+void FuzzerPassReplaceOpselectsWithConditionalBranches::Apply() {
+  // Keep track of the instructions that we want to replace. We need to collect
+  // them in a vector, since it's not safe to modify the module while iterating
+  // over it.
+  std::vector<uint32_t> replaceable_opselect_instruction_ids;
+
+  // Loop over all the instructions in the module.
+  for (auto& function : *GetIRContext()->module()) {
+    for (auto& block : function) {
+      // We cannot split loop headers, so we don't need to consider instructions
+      // in loop headers.
+      if (block.IsLoopHeader()) {
+        continue;
+      }
+
+      for (auto& instruction : block) {
+        // We only care about OpSelect instructions.
+        if (instruction.opcode() != SpvOpSelect) {
+          continue;
+        }
+
+        // Randomly choose whether to consider this instruction for replacement.
+        if (!GetFuzzerContext()->ChoosePercentage(
+                GetFuzzerContext()
+                    ->GetChanceOfReplacingOpselectWithConditionalBranch())) {
+          continue;
+        }
+
+        // If the instruction separates an OpSampledImage from its use, the
+        // block cannot be split around it and the instruction cannot be
+        // replaced.
+        if (fuzzerutil::
+                SplitBeforeInstructionSeparatesOpSampledImageDefinitionFromUse(
+                    &block, &instruction)) {
+          continue;
+        }
+
+        // We can apply the transformation to this instruction.
+        replaceable_opselect_instruction_ids.push_back(instruction.result_id());
+      }
+    }
+  }
+
+  // Apply the transformations.
+  for (uint32_t instruction_id : replaceable_opselect_instruction_ids) {
+    ApplyTransformation(TransformationReplaceOpselectWithConditionalBranch(
+        instruction_id,
+        {GetFuzzerContext()->GetFreshId(), GetFuzzerContext()->GetFreshId()}));
+  }
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.cpp
+++ b/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.cpp
@@ -78,8 +78,8 @@ void FuzzerPassReplaceOpSelectsWithConditionalBranches::Apply() {
   // Apply the transformations.
   for (uint32_t instruction_id : replaceable_opselect_instruction_ids) {
     ApplyTransformation(TransformationReplaceOpSelectWithConditionalBranch(
-        instruction_id,
-        {GetFuzzerContext()->GetFreshId(), GetFuzzerContext()->GetFreshId()}));
+        instruction_id, GetFuzzerContext()->GetFreshId(),
+        GetFuzzerContext()->GetFreshId()));
   }
 }
 

--- a/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.cpp
+++ b/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "fuzzer_pass_replace_opselects_with_conditional_branches.h"

--- a/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.cpp
+++ b/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.cpp
@@ -20,8 +20,8 @@
 namespace spvtools {
 namespace fuzz {
 
-FuzzerPassReplaceOpselectsWithConditionalBranches::
-    FuzzerPassReplaceOpselectsWithConditionalBranches(
+FuzzerPassReplaceOpSelectsWithConditionalBranches::
+    FuzzerPassReplaceOpSelectsWithConditionalBranches(
         opt::IRContext* ir_context,
         TransformationContext* transformation_context,
         FuzzerContext* fuzzer_context,
@@ -29,10 +29,10 @@ FuzzerPassReplaceOpselectsWithConditionalBranches::
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassReplaceOpselectsWithConditionalBranches::
-    ~FuzzerPassReplaceOpselectsWithConditionalBranches() = default;
+FuzzerPassReplaceOpSelectsWithConditionalBranches::
+    ~FuzzerPassReplaceOpSelectsWithConditionalBranches() = default;
 
-void FuzzerPassReplaceOpselectsWithConditionalBranches::Apply() {
+void FuzzerPassReplaceOpSelectsWithConditionalBranches::Apply() {
   // Keep track of the instructions that we want to replace. We need to collect
   // them in a vector, since it's not safe to modify the module while iterating
   // over it.
@@ -77,7 +77,7 @@ void FuzzerPassReplaceOpselectsWithConditionalBranches::Apply() {
 
   // Apply the transformations.
   for (uint32_t instruction_id : replaceable_opselect_instruction_ids) {
-    ApplyTransformation(TransformationReplaceOpselectWithConditionalBranch(
+    ApplyTransformation(TransformationReplaceOpSelectWithConditionalBranch(
         instruction_id,
         {GetFuzzerContext()->GetFreshId(), GetFuzzerContext()->GetFreshId()}));
   }

--- a/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.cpp
+++ b/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.cpp
@@ -77,7 +77,7 @@ void FuzzerPassReplaceOpSelectsWithConditionalBranches::Apply() {
         // block cannot be split around it and the instruction cannot be
         // replaced.
         if (fuzzerutil::
-                SplitBeforeInstructionSeparatesOpSampledImageDefinitionFromUse(
+                SplittingBeforeInstructionSeparatesOpSampledImageDefinitionFromUse(
                     &block, &instruction)) {
           continue;
         }

--- a/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.h
+++ b/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.h
@@ -20,14 +20,14 @@
 namespace spvtools {
 namespace fuzz {
 
-class FuzzerPassReplaceOpselectsWithConditionalBranches : public FuzzerPass {
+class FuzzerPassReplaceOpSelectsWithConditionalBranches : public FuzzerPass {
  public:
-  FuzzerPassReplaceOpselectsWithConditionalBranches(
+  FuzzerPassReplaceOpSelectsWithConditionalBranches(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassReplaceOpselectsWithConditionalBranches() override;
+  ~FuzzerPassReplaceOpSelectsWithConditionalBranches() override;
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.h
+++ b/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.h
@@ -32,6 +32,19 @@ class FuzzerPassReplaceOpSelectsWithConditionalBranches : public FuzzerPass {
   ~FuzzerPassReplaceOpSelectsWithConditionalBranches() override;
 
   void Apply() override;
+
+ private:
+  // Returns true if any of the following holds:
+  // - the instruction is not the first in its block
+  // - the block containing it is a merge block
+  // - the block does not have a unique predecessor
+  // - the predecessor of the block is the header of a construct
+  // - the predecessor does not branch unconditionally to the block
+  // If this function returns true, the block must be split before the
+  // instruction for TransformationReplaceOpSelectWithConditionalBranch to be
+  // applicable.
+  // Assumes that the instruction is OpSelect.
+  bool InstructionNeedsSplitBefore(opt::Instruction* instruction);
 };
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.h
+++ b/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.h
@@ -20,6 +20,8 @@
 namespace spvtools {
 namespace fuzz {
 
+// A fuzzer pass to replace OpSelect instructions (where the condition is a
+// scalar boolean) with conditional branches and OpPhi instructions.
 class FuzzerPassReplaceOpSelectsWithConditionalBranches : public FuzzerPass {
  public:
   FuzzerPassReplaceOpSelectsWithConditionalBranches(
@@ -31,6 +33,8 @@ class FuzzerPassReplaceOpSelectsWithConditionalBranches : public FuzzerPass {
 
   void Apply() override;
 };
+
 }  // namespace fuzz
 }  // namespace spvtools
+
 #endif  // SOURCE_FUZZ_FUZZER_PASS_REPLACE_OPSELECTS_WITH_CONDITIONAL_BRANCHES_

--- a/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.h
+++ b/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_FUZZER_PASS_REPLACE_OPSELECTS_WITH_CONDITIONAL_BRANCHES_
+#define SOURCE_FUZZ_FUZZER_PASS_REPLACE_OPSELECTS_WITH_CONDITIONAL_BRANCHES_
+
+#include "source/fuzz/fuzzer_pass.h"
+
+namespace spvtools {
+namespace fuzz {
+
+class FuzzerPassReplaceOpselectsWithConditionalBranches : public FuzzerPass {
+ public:
+  FuzzerPassReplaceOpselectsWithConditionalBranches(
+      opt::IRContext* ir_context, TransformationContext* transformation_context,
+      FuzzerContext* fuzzer_context,
+      protobufs::TransformationSequence* transformations);
+
+  ~FuzzerPassReplaceOpselectsWithConditionalBranches() override;
+
+  void Apply() override;
+};
+}  // namespace fuzz
+}  // namespace spvtools
+#endif  // SOURCE_FUZZ_FUZZER_PASS_REPLACE_OPSELECTS_WITH_CONDITIONAL_BRANCHES_

--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -1509,6 +1509,39 @@ bool MembersHaveBuiltInDecoration(opt::IRContext* ir_context,
   return builtin_count != 0;
 }
 
+bool SplitBeforeInstructionSeparatesOpSampledImageDefinitionFromUse(
+    opt::BasicBlock* block_to_split, opt::Instruction* split_before) {
+  std::set<uint32_t> sampled_image_result_ids;
+  bool before_split = true;
+
+  // Check all the instructions in the block to split.
+  for (auto& instruction : *block_to_split) {
+    if (&instruction == &*split_before) {
+      before_split = false;
+    }
+    if (before_split) {
+      // If the instruction comes before the split and its opcode is
+      // OpSampledImage, record its result id.
+      if (instruction.opcode() == SpvOpSampledImage) {
+        sampled_image_result_ids.insert(instruction.result_id());
+      }
+    } else {
+      // If the instruction comes after the split, check if ids
+      // corresponding to OpSampledImage instructions defined before the split
+      // are used, and return true if they are.
+      if (!instruction.WhileEachInId(
+              [&sampled_image_result_ids](uint32_t* id) -> bool {
+                return !sampled_image_result_ids.count(*id);
+              })) {
+        return true;
+      }
+    }
+  }
+
+  // No usage that would be separated from the definition has been found.
+  return false;
+}
+
 }  // namespace fuzzerutil
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -1486,7 +1486,7 @@ bool MembersHaveBuiltInDecoration(opt::IRContext* ir_context,
   return builtin_count != 0;
 }
 
-bool SplitBeforeInstructionSeparatesOpSampledImageDefinitionFromUse(
+bool SplittingBeforeInstructionSeparatesOpSampledImageDefinitionFromUse(
     opt::BasicBlock* block_to_split, opt::Instruction* split_before) {
   std::set<uint32_t> sampled_image_result_ids;
   bool before_split = true;

--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -419,6 +419,29 @@ bool IsNonFunctionTypeId(opt::IRContext* ir_context, uint32_t id) {
   return type && !type->AsFunction();
 }
 
+bool IsMergeBlock(opt::IRContext* ir_context, uint32_t block_id) {
+  bool result = false;
+  ir_context->get_def_use_mgr()->WhileEachUse(
+      block_id,
+      [&result](const opt::Instruction* use_instruction,
+                uint32_t index) -> bool {
+        switch (use_instruction->opcode()) {
+          case SpvOpLoopMerge:
+            if (index == 0) {
+              result = true;
+              return false;
+            }
+            return true;
+          case SpvOpSelectionMerge:
+            result = true;
+            return false;
+          default:
+            return true;
+        }
+      });
+  return result;
+}
+
 bool IsMergeOrContinue(opt::IRContext* ir_context, uint32_t block_id) {
   bool result = false;
   ir_context->get_def_use_mgr()->WhileEachUse(

--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -419,29 +419,6 @@ bool IsNonFunctionTypeId(opt::IRContext* ir_context, uint32_t id) {
   return type && !type->AsFunction();
 }
 
-bool IsMergeBlock(opt::IRContext* ir_context, uint32_t block_id) {
-  bool result = false;
-  ir_context->get_def_use_mgr()->WhileEachUse(
-      block_id,
-      [&result](const opt::Instruction* use_instruction,
-                uint32_t index) -> bool {
-        switch (use_instruction->opcode()) {
-          case SpvOpLoopMerge:
-            if (index == 0) {
-              result = true;
-              return false;
-            }
-            return true;
-          case SpvOpSelectionMerge:
-            result = true;
-            return false;
-          default:
-            return true;
-        }
-      });
-  return result;
-}
-
 bool IsMergeOrContinue(opt::IRContext* ir_context, uint32_t block_id) {
   bool result = false;
   ir_context->get_def_use_mgr()->WhileEachUse(

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -161,6 +161,9 @@ std::unique_ptr<opt::IRContext> CloneIRContext(opt::IRContext* context);
 // type.
 bool IsNonFunctionTypeId(opt::IRContext* ir_context, uint32_t id);
 
+// Returns true if and only if |block_id| is a merge block
+bool IsMergeOrContinue(opt::IRContext* ir_context, uint32_t block_id);
+
 // Returns true if and only if |block_id| is a merge block or continue target
 bool IsMergeOrContinue(opt::IRContext* ir_context, uint32_t block_id);
 

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -161,9 +161,6 @@ std::unique_ptr<opt::IRContext> CloneIRContext(opt::IRContext* context);
 // type.
 bool IsNonFunctionTypeId(opt::IRContext* ir_context, uint32_t id);
 
-// Returns true if and only if |block_id| is a merge block
-bool IsMergeBlock(opt::IRContext* ir_context, uint32_t block_id);
-
 // Returns true if and only if |block_id| is a merge block or continue target
 bool IsMergeOrContinue(opt::IRContext* ir_context, uint32_t block_id);
 

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -162,7 +162,7 @@ std::unique_ptr<opt::IRContext> CloneIRContext(opt::IRContext* context);
 bool IsNonFunctionTypeId(opt::IRContext* ir_context, uint32_t id);
 
 // Returns true if and only if |block_id| is a merge block
-bool IsMergeOrContinue(opt::IRContext* ir_context, uint32_t block_id);
+bool IsMergeBlock(opt::IRContext* ir_context, uint32_t block_id);
 
 // Returns true if and only if |block_id| is a merge block or continue target
 bool IsMergeOrContinue(opt::IRContext* ir_context, uint32_t block_id);
@@ -526,6 +526,11 @@ bool IdUseCanBeReplaced(opt::IRContext* ir_context,
 // BuiltIn decoration.
 bool MembersHaveBuiltInDecoration(opt::IRContext* ir_context,
                                   uint32_t struct_type_id);
+
+// Returns true iff splitting block |block_to_split| just before the instruction
+// |split_before| would separate an OpSampledImage instruction from its usage.
+bool SplitBeforeInstructionSeparatesOpSampledImageDefinitionFromUse(
+    opt::BasicBlock* block_to_split, opt::Instruction* split_before);
 
 }  // namespace fuzzerutil
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -526,7 +526,7 @@ bool MembersHaveBuiltInDecoration(opt::IRContext* ir_context,
 
 // Returns true iff splitting block |block_to_split| just before the instruction
 // |split_before| would separate an OpSampledImage instruction from its usage.
-bool SplitBeforeInstructionSeparatesOpSampledImageDefinitionFromUse(
+bool SplittingBeforeInstructionSeparatesOpSampledImageDefinitionFromUse(
     opt::BasicBlock* block_to_split, opt::Instruction* split_before);
 
 }  // namespace fuzzerutil

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -1567,15 +1567,16 @@ message TransformationReplaceOpPhiIdFromDeadPredecessor {
 
 message TransformationReplaceOpSelectWithConditionalBranch {
 
-  // A transformation that takes an OpSelect instruction and replaces
-  // it with a conditional branch and an OpPhi instruction.
+  // A transformation that takes an OpSelect instruction with a
+  // scalar boolean condition and replaces it with a conditional
+  // branch and an OpPhi instruction.
 
   // The result id of the OpSelect instruction
   uint32 select_id = 1;
 
   // Fresh ids for the new blocks
-  UInt32Pair new_block_ids = 2;
-
+  uint32 true_block_fresh_id = 2;
+  uint32 merge_block_fresh_id = 3;
 }
 
 message TransformationReplaceParamsWithStruct {

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -1574,7 +1574,7 @@ message TransformationReplaceOpSelectWithConditionalBranch {
   uint32 select_id = 1;
 
   // Fresh ids for the new blocks
-  repeated uint32 new_block_id = 2;
+  UInt32Pair new_block_ids = 2;
 
 }
 

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -1570,13 +1570,32 @@ message TransformationReplaceOpSelectWithConditionalBranch {
   // A transformation that takes an OpSelect instruction with a
   // scalar boolean condition and replaces it with a conditional
   // branch and an OpPhi instruction.
+  // The OpSelect instruction must be the first instruction in its
+  // block, which must have a unique predecessor. The block will
+  // become the merge block of a new construct, while its predecessor
+  // will become the header.
+  // Given the original OpSelect instruction:
+  //   %id = OpSelect %type %cond %then %else
+  // The branching instruction of the header will be:
+  //         OpBranchConditional %cond %true_block_id %false_block_id
+  // and the OpSelect instruction will be turned into:
+  //   %id = OpPhi %type %then %true_block_id %else %false_block_id
+  // At most one of |true_block_id| and |false_block_id| can be zero. In
+  // that case, there will be no such block and all references to it
+  // will be replaced by %merge_block (where %merge_block is the
+  // block containing the OpSelect instruction).
 
-  // The result id of the OpSelect instruction
+  // The result id of the OpSelect instruction.
   uint32 select_id = 1;
 
-  // Fresh ids for the new blocks
-  uint32 true_block_fresh_id = 2;
-  uint32 merge_block_fresh_id = 3;
+  // A fresh id for the new block that the predecessor of the block
+  // containing |select_id| will branch to if the condition holds.
+  uint32 true_block_id = 2;
+
+  // A fresh id for the new block that the predecessor of the block
+  // containing |select_id| will branch to if the condition does not
+  // hold.
+  uint32 false_block_id = 3;
 }
 
 message TransformationReplaceParamsWithStruct {

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -418,6 +418,7 @@ message Transformation {
     TransformationMutatePointer mutate_pointer = 71;
     TransformationReplaceIrrelevantId replace_irrelevant_id = 72;
     TransformationReplaceOpPhiIdFromDeadPredecessor replace_opphi_id_from_dead_predecessor = 73;
+    TransformationReplaceOpSelectWithConditionalBranch replace_opselect_with_conditional_branch = 74;
     // Add additional option using the next available number.
   }
 }
@@ -1561,6 +1562,19 @@ message TransformationReplaceOpPhiIdFromDeadPredecessor {
   // The id that, after the transformation, will be associated with
   // the given predecessor.
   uint32 replacement_id = 3;
+
+}
+
+message TransformationReplaceOpSelectWithConditionalBranch {
+
+  // A transformation that takes an OpSelect instruction and replaces
+  // it with a conditional branch and an OpPhi instruction.
+
+  // The result id of the OpSelect instruction
+  uint32 select_id = 1;
+
+  // Fresh ids for the new blocks
+  repeated uint32 new_block_id = 2;
 
 }
 

--- a/source/fuzz/transformation.cpp
+++ b/source/fuzz/transformation.cpp
@@ -78,6 +78,7 @@
 #include "source/fuzz/transformation_replace_linear_algebra_instruction.h"
 #include "source/fuzz/transformation_replace_load_store_with_copy_memory.h"
 #include "source/fuzz/transformation_replace_opphi_id_from_dead_predecessor.h"
+#include "source/fuzz/transformation_replace_opselect_with_conditional_branch.h"
 #include "source/fuzz/transformation_replace_parameter_with_global.h"
 #include "source/fuzz/transformation_replace_params_with_struct.h"
 #include "source/fuzz/transformation_set_function_control.h"
@@ -276,6 +277,10 @@ std::unique_ptr<Transformation> Transformation::FromMessage(
         kReplaceLoadStoreWithCopyMemory:
       return MakeUnique<TransformationReplaceLoadStoreWithCopyMemory>(
           message.replace_load_store_with_copy_memory());
+    case protobufs::Transformation::TransformationCase::
+        kReplaceOpselectWithConditionalBranch:
+      return MakeUnique<TransformationReplaceOpSelectWithConditionalBranch>(
+          message.replace_opselect_with_conditional_branch());
     case protobufs::Transformation::TransformationCase::
         kReplaceParameterWithGlobal:
       return MakeUnique<TransformationReplaceParameterWithGlobal>(

--- a/source/fuzz/transformation.cpp
+++ b/source/fuzz/transformation.cpp
@@ -279,7 +279,7 @@ std::unique_ptr<Transformation> Transformation::FromMessage(
           message.replace_load_store_with_copy_memory());
     case protobufs::Transformation::TransformationCase::
         kReplaceOpselectWithConditionalBranch:
-      return MakeUnique<TransformationReplaceOpSelectWithConditionalBranch>(
+      return MakeUnique<TransformationReplaceOpselectWithConditionalBranch>(
           message.replace_opselect_with_conditional_branch());
     case protobufs::Transformation::TransformationCase::
         kReplaceParameterWithGlobal:

--- a/source/fuzz/transformation.cpp
+++ b/source/fuzz/transformation.cpp
@@ -279,7 +279,7 @@ std::unique_ptr<Transformation> Transformation::FromMessage(
           message.replace_load_store_with_copy_memory());
     case protobufs::Transformation::TransformationCase::
         kReplaceOpselectWithConditionalBranch:
-      return MakeUnique<TransformationReplaceOpselectWithConditionalBranch>(
+      return MakeUnique<TransformationReplaceOpSelectWithConditionalBranch>(
           message.replace_opselect_with_conditional_branch());
     case protobufs::Transformation::TransformationCase::
         kReplaceParameterWithGlobal:

--- a/source/fuzz/transformation_replace_opselect_with_conditional_branch.cpp
+++ b/source/fuzz/transformation_replace_opselect_with_conditional_branch.cpp
@@ -54,7 +54,16 @@ bool TransformationReplaceOpSelectWithConditionalBranch::IsApplicable(
 
   // In all cases, at least 2 fresh ids are needed.
   if (message_.new_block_id_size() < 2) {
-    return true;
+    return false;
+  }
+
+  // Check that the new block ids are fresh and distinct.
+  std::set<uint32_t> used_ids;
+  for (uint32_t id : message_.new_block_id()) {
+    if (!CheckIdIsFreshAndNotUsedByThisTransformation(id, ir_context,
+                                                      &used_ids)) {
+      return false;
+    }
   }
 
   // The block must be split around the OpSelect instruction. This means that

--- a/source/fuzz/transformation_replace_opselect_with_conditional_branch.cpp
+++ b/source/fuzz/transformation_replace_opselect_with_conditional_branch.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_replace_opselect_with_conditional_branch.h"
+
+namespace spvtools {
+namespace fuzz {
+TransformationReplaceOpSelectWithConditionalBranch::
+    TransformationReplaceOpSelectWithConditionalBranch(
+        const spvtools::fuzz::protobufs::
+            TransformationReplaceOpSelectWithConditionalBranch& message)
+    : message_(message) {}
+
+TransformationReplaceOpSelectWithConditionalBranch::
+    TransformationReplaceOpSelectWithConditionalBranch(
+        uint32_t select_id, std::vector<uint32_t> new_block_ids) {
+  message_.set_select_id(select_id);
+  for (auto id : new_block_ids) {
+    message_.add_new_block_id(id);
+  }
+}
+bool TransformationReplaceOpSelectWithConditionalBranch::IsApplicable(
+    opt::IRContext* ir_context,
+    const TransformationContext& /* transformation_context */) const {
+  return false;
+}
+
+void TransformationReplaceOpSelectWithConditionalBranch::Apply(
+    opt::IRContext* /* ir_context */,
+    TransformationContext* /* transformation_context */) const {}
+
+protobufs::Transformation
+TransformationReplaceOpSelectWithConditionalBranch::ToMessage() const {
+  protobufs::Transformation result;
+  *result.mutable_replace_opselect_with_conditional_branch() = message_;
+  return result;
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/transformation_replace_opselect_with_conditional_branch.cpp
+++ b/source/fuzz/transformation_replace_opselect_with_conditional_branch.cpp
@@ -18,14 +18,14 @@
 
 namespace spvtools {
 namespace fuzz {
-TransformationReplaceOpSelectWithConditionalBranch::
-    TransformationReplaceOpSelectWithConditionalBranch(
+TransformationReplaceOpselectWithConditionalBranch::
+    TransformationReplaceOpselectWithConditionalBranch(
         const spvtools::fuzz::protobufs::
-            TransformationReplaceOpSelectWithConditionalBranch& message)
+            TransformationReplaceOpselectWithConditionalBranch& message)
     : message_(message) {}
 
-TransformationReplaceOpSelectWithConditionalBranch::
-    TransformationReplaceOpSelectWithConditionalBranch(
+TransformationReplaceOpselectWithConditionalBranch::
+    TransformationReplaceOpselectWithConditionalBranch(
         uint32_t select_id, std::pair<uint32_t, uint32_t> new_block_ids) {
   message_.set_select_id(select_id);
   protobufs::UInt32Pair pair;
@@ -34,7 +34,7 @@ TransformationReplaceOpSelectWithConditionalBranch::
   *message_.mutable_new_block_ids() = pair;
 }
 
-bool TransformationReplaceOpSelectWithConditionalBranch::IsApplicable(
+bool TransformationReplaceOpselectWithConditionalBranch::IsApplicable(
     opt::IRContext* ir_context,
     const TransformationContext& /* unused */) const {
   auto instruction =
@@ -71,7 +71,7 @@ bool TransformationReplaceOpSelectWithConditionalBranch::IsApplicable(
           block, instruction);
 }
 
-void TransformationReplaceOpSelectWithConditionalBranch::Apply(
+void TransformationReplaceOpselectWithConditionalBranch::Apply(
     opt::IRContext* ir_context, TransformationContext* /* unused */) const {
   auto instruction =
       ir_context->get_def_use_mgr()->GetDef(message_.select_id());
@@ -136,7 +136,7 @@ void TransformationReplaceOpSelectWithConditionalBranch::Apply(
 }
 
 protobufs::Transformation
-TransformationReplaceOpSelectWithConditionalBranch::ToMessage() const {
+TransformationReplaceOpselectWithConditionalBranch::ToMessage() const {
   protobufs::Transformation result;
   *result.mutable_replace_opselect_with_conditional_branch() = message_;
   return result;

--- a/source/fuzz/transformation_replace_opselect_with_conditional_branch.cpp
+++ b/source/fuzz/transformation_replace_opselect_with_conditional_branch.cpp
@@ -58,12 +58,11 @@ bool TransformationReplaceOpSelectWithConditionalBranch::IsApplicable(
   // Check that the condition is a scalar boolean.
   auto condition = ir_context->get_def_use_mgr()->GetDef(
       instruction->GetSingleWordInOperand(0));
-  if (!condition) {
-    return false;
-  }
+  assert(condition && "The condition should always exist in a valid module.");
+
   auto condition_type =
       ir_context->get_type_mgr()->GetType(condition->type_id());
-  if (!condition_type || !condition_type->AsBool()) {
+  if (!condition_type->AsBool()) {
     return false;
   }
 
@@ -152,6 +151,10 @@ void TransformationReplaceOpSelectWithConditionalBranch::Apply(
   // instruction block otherwise.
   uint32_t else_block =
       message_.false_block_id() ? message_.false_block_id() : block->id();
+
+  assert(if_block != else_block &&
+         "|if_block| and |else_block| should always be different, if the "
+         "transformation is applicable.");
 
   // Add a conditional branching instruction to the predecessor, branching to
   // |if_block| if the condition is true and to |if_false| otherwise.

--- a/source/fuzz/transformation_replace_opselect_with_conditional_branch.cpp
+++ b/source/fuzz/transformation_replace_opselect_with_conditional_branch.cpp
@@ -18,14 +18,14 @@
 
 namespace spvtools {
 namespace fuzz {
-TransformationReplaceOpselectWithConditionalBranch::
-    TransformationReplaceOpselectWithConditionalBranch(
+TransformationReplaceOpSelectWithConditionalBranch::
+    TransformationReplaceOpSelectWithConditionalBranch(
         const spvtools::fuzz::protobufs::
-            TransformationReplaceOpselectWithConditionalBranch& message)
+            TransformationReplaceOpSelectWithConditionalBranch& message)
     : message_(message) {}
 
-TransformationReplaceOpselectWithConditionalBranch::
-    TransformationReplaceOpselectWithConditionalBranch(
+TransformationReplaceOpSelectWithConditionalBranch::
+    TransformationReplaceOpSelectWithConditionalBranch(
         uint32_t select_id, std::pair<uint32_t, uint32_t> new_block_ids) {
   message_.set_select_id(select_id);
   protobufs::UInt32Pair pair;
@@ -34,7 +34,7 @@ TransformationReplaceOpselectWithConditionalBranch::
   *message_.mutable_new_block_ids() = pair;
 }
 
-bool TransformationReplaceOpselectWithConditionalBranch::IsApplicable(
+bool TransformationReplaceOpSelectWithConditionalBranch::IsApplicable(
     opt::IRContext* ir_context,
     const TransformationContext& /* unused */) const {
   auto instruction =
@@ -71,7 +71,7 @@ bool TransformationReplaceOpselectWithConditionalBranch::IsApplicable(
           block, instruction);
 }
 
-void TransformationReplaceOpselectWithConditionalBranch::Apply(
+void TransformationReplaceOpSelectWithConditionalBranch::Apply(
     opt::IRContext* ir_context, TransformationContext* /* unused */) const {
   auto instruction =
       ir_context->get_def_use_mgr()->GetDef(message_.select_id());
@@ -136,7 +136,7 @@ void TransformationReplaceOpselectWithConditionalBranch::Apply(
 }
 
 protobufs::Transformation
-TransformationReplaceOpselectWithConditionalBranch::ToMessage() const {
+TransformationReplaceOpSelectWithConditionalBranch::ToMessage() const {
   protobufs::Transformation result;
   *result.mutable_replace_opselect_with_conditional_branch() = message_;
   return result;

--- a/source/fuzz/transformation_replace_opselect_with_conditional_branch.cpp
+++ b/source/fuzz/transformation_replace_opselect_with_conditional_branch.cpp
@@ -57,6 +57,12 @@ bool TransformationReplaceOpSelectWithConditionalBranch::IsApplicable(
     }
   }
 
+  // The block cannot be a loop header, since splitting it would make back edges
+  // invalid.
+  if (block->IsLoopHeader()) {
+    return false;
+  }
+
   // The block must be split around the OpSelect instruction. This means that
   // there cannot be an OpSampledImage instruction before OpSelect that is used
   // after it, because they are required to be in the same basic block.

--- a/source/fuzz/transformation_replace_opselect_with_conditional_branch.h
+++ b/source/fuzz/transformation_replace_opselect_with_conditional_branch.h
@@ -20,14 +20,14 @@
 namespace spvtools {
 namespace fuzz {
 
-class TransformationReplaceOpselectWithConditionalBranch
+class TransformationReplaceOpSelectWithConditionalBranch
     : public Transformation {
  public:
-  explicit TransformationReplaceOpselectWithConditionalBranch(
-      const protobufs::TransformationReplaceOpselectWithConditionalBranch&
+  explicit TransformationReplaceOpSelectWithConditionalBranch(
+      const protobufs::TransformationReplaceOpSelectWithConditionalBranch&
           message);
 
-  TransformationReplaceOpselectWithConditionalBranch(
+  TransformationReplaceOpSelectWithConditionalBranch(
       uint32_t select_id, std::pair<uint32_t, uint32_t> new_block_ids);
 
   // - |message_.select_id| is the result id of an OpSelect instruction.
@@ -46,7 +46,7 @@ class TransformationReplaceOpselectWithConditionalBranch
   protobufs::Transformation ToMessage() const override;
 
  private:
-  protobufs::TransformationReplaceOpselectWithConditionalBranch message_;
+  protobufs::TransformationReplaceOpSelectWithConditionalBranch message_;
 };
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_replace_opselect_with_conditional_branch.h
+++ b/source/fuzz/transformation_replace_opselect_with_conditional_branch.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_TRANSFORMATION_REPLACE_OPSELECT_WITH_CONDITIONAL_BRANCH_H
+#define SOURCE_FUZZ_TRANSFORMATION_REPLACE_OPSELECT_WITH_CONDITIONAL_BRANCH_H
+
+#include "source/fuzz/transformation.h"
+
+namespace spvtools {
+namespace fuzz {
+
+class TransformationReplaceOpSelectWithConditionalBranch
+    : public Transformation {
+ public:
+  explicit TransformationReplaceOpSelectWithConditionalBranch(
+      const protobufs::TransformationReplaceOpSelectWithConditionalBranch&
+          message);
+
+  TransformationReplaceOpSelectWithConditionalBranch(
+      uint32_t select_id, std::vector<uint32_t> new_block_ids);
+
+  // - |message_.select_id| is the result id of an OpSelect instruction.
+  // - The block containing the instruction can be split at the position
+  //   corresponding to the instruction.
+  // - |message_.new_block_id| contains at least 2 fresh ids if the block
+  // containing the instruction is not a merge block, at least 3 otherwise.
+  bool IsApplicable(
+      opt::IRContext* ir_context,
+      const TransformationContext& transformation_context) const override;
+
+  void Apply(opt::IRContext* ir_context,
+             TransformationContext* transformation_context) const override;
+
+  protobufs::Transformation ToMessage() const override;
+
+ private:
+  protobufs::TransformationReplaceOpSelectWithConditionalBranch message_;
+};
+}  // namespace fuzz
+}  // namespace spvtools
+#endif  // SOURCE_FUZZ_TRANSFORMATION_REPLACE_OPSELECT_WITH_CONDITIONAL_BRANCH_H

--- a/source/fuzz/transformation_replace_opselect_with_conditional_branch.h
+++ b/source/fuzz/transformation_replace_opselect_with_conditional_branch.h
@@ -28,9 +28,11 @@ class TransformationReplaceOpSelectWithConditionalBranch
           message);
 
   TransformationReplaceOpSelectWithConditionalBranch(
-      uint32_t select_id, std::pair<uint32_t, uint32_t> new_block_ids);
+      uint32_t select_id, uint32_t true_block_fresh_id,
+      uint32_t merge_block_fresh_id);
 
   // - |message_.select_id| is the result id of an OpSelect instruction.
+  // - The condition of the OpSelect must be a scalar boolean.
   // - The block containing the instruction can be split at the position
   //   corresponding to the instruction.
   // - The pair |message_.new_block_ids| contains 2 fresh and distinct ids
@@ -48,6 +50,8 @@ class TransformationReplaceOpSelectWithConditionalBranch
  private:
   protobufs::TransformationReplaceOpSelectWithConditionalBranch message_;
 };
+
 }  // namespace fuzz
 }  // namespace spvtools
+
 #endif  // SOURCE_FUZZ_TRANSFORMATION_REPLACE_OPSELECT_WITH_CONDITIONAL_BRANCH_H

--- a/source/fuzz/transformation_replace_opselect_with_conditional_branch.h
+++ b/source/fuzz/transformation_replace_opselect_with_conditional_branch.h
@@ -28,18 +28,18 @@ class TransformationReplaceOpSelectWithConditionalBranch
           message);
 
   TransformationReplaceOpSelectWithConditionalBranch(
-      uint32_t select_id, std::vector<uint32_t> new_block_ids);
+      uint32_t select_id, std::pair<uint32_t, uint32_t> new_block_ids);
 
   // - |message_.select_id| is the result id of an OpSelect instruction.
   // - The block containing the instruction can be split at the position
   //   corresponding to the instruction.
-  // - |message_.new_block_id| contains at least 2 fresh and distinct ids if the
-  //   block containing the instruction is not a merge block, at least 3
-  //   otherwise.
+  // - The pair |message_.new_block_ids| contains 2 fresh and distinct ids
   bool IsApplicable(
       opt::IRContext* ir_context,
       const TransformationContext& transformation_context) const override;
 
+  // Replaces the OpSelect instruction with id |message_.select_id| with a
+  // conditional branch and an OpPhi instruction.
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 

--- a/source/fuzz/transformation_replace_opselect_with_conditional_branch.h
+++ b/source/fuzz/transformation_replace_opselect_with_conditional_branch.h
@@ -34,7 +34,7 @@ class TransformationReplaceOpSelectWithConditionalBranch
   // - The block containing the instruction can be split at the position
   //   corresponding to the instruction.
   // - |message_.new_block_id| contains at least 2 fresh ids if the block
-  // containing the instruction is not a merge block, at least 3 otherwise.
+  //   containing the instruction is not a merge block, at least 3 otherwise.
   bool IsApplicable(
       opt::IRContext* ir_context,
       const TransformationContext& transformation_context) const override;

--- a/source/fuzz/transformation_replace_opselect_with_conditional_branch.h
+++ b/source/fuzz/transformation_replace_opselect_with_conditional_branch.h
@@ -27,15 +27,19 @@ class TransformationReplaceOpSelectWithConditionalBranch
       const protobufs::TransformationReplaceOpSelectWithConditionalBranch&
           message);
 
-  TransformationReplaceOpSelectWithConditionalBranch(
-      uint32_t select_id, uint32_t true_block_fresh_id,
-      uint32_t merge_block_fresh_id);
+  TransformationReplaceOpSelectWithConditionalBranch(uint32_t select_id,
+                                                     uint32_t true_block_id,
+                                                     uint32_t false_block_id);
 
   // - |message_.select_id| is the result id of an OpSelect instruction.
   // - The condition of the OpSelect must be a scalar boolean.
-  // - The block containing the instruction can be split at the position
-  //   corresponding to the instruction.
-  // - The pair |message_.new_block_ids| contains 2 fresh and distinct ids
+  // - The OpSelect instruction is the first instruction in its block.
+  // - The block containing the instruction is not a merge block, and it has a
+  //   single predecessor, which is not a header and whose last instruction is
+  //   OpBranch.
+  // - Each of |message_.true_block_id| and |message_.false_block_id| is either
+  //   0 or a valid fresh id, and at most one of them is 0. They must be
+  //   distinct.
   bool IsApplicable(
       opt::IRContext* ir_context,
       const TransformationContext& transformation_context) const override;

--- a/source/fuzz/transformation_replace_opselect_with_conditional_branch.h
+++ b/source/fuzz/transformation_replace_opselect_with_conditional_branch.h
@@ -33,8 +33,9 @@ class TransformationReplaceOpSelectWithConditionalBranch
   // - |message_.select_id| is the result id of an OpSelect instruction.
   // - The block containing the instruction can be split at the position
   //   corresponding to the instruction.
-  // - |message_.new_block_id| contains at least 2 fresh ids if the block
-  //   containing the instruction is not a merge block, at least 3 otherwise.
+  // - |message_.new_block_id| contains at least 2 fresh and distinct ids if the
+  //   block containing the instruction is not a merge block, at least 3
+  //   otherwise.
   bool IsApplicable(
       opt::IRContext* ir_context,
       const TransformationContext& transformation_context) const override;

--- a/source/fuzz/transformation_replace_opselect_with_conditional_branch.h
+++ b/source/fuzz/transformation_replace_opselect_with_conditional_branch.h
@@ -20,14 +20,14 @@
 namespace spvtools {
 namespace fuzz {
 
-class TransformationReplaceOpSelectWithConditionalBranch
+class TransformationReplaceOpselectWithConditionalBranch
     : public Transformation {
  public:
-  explicit TransformationReplaceOpSelectWithConditionalBranch(
-      const protobufs::TransformationReplaceOpSelectWithConditionalBranch&
+  explicit TransformationReplaceOpselectWithConditionalBranch(
+      const protobufs::TransformationReplaceOpselectWithConditionalBranch&
           message);
 
-  TransformationReplaceOpSelectWithConditionalBranch(
+  TransformationReplaceOpselectWithConditionalBranch(
       uint32_t select_id, std::pair<uint32_t, uint32_t> new_block_ids);
 
   // - |message_.select_id| is the result id of an OpSelect instruction.
@@ -46,7 +46,7 @@ class TransformationReplaceOpSelectWithConditionalBranch
   protobufs::Transformation ToMessage() const override;
 
  private:
-  protobufs::TransformationReplaceOpSelectWithConditionalBranch message_;
+  protobufs::TransformationReplaceOpselectWithConditionalBranch message_;
 };
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_split_block.cpp
+++ b/source/fuzz/transformation_split_block.cpp
@@ -83,27 +83,9 @@ bool TransformationSplitBlock::IsApplicable(
 
   // Splitting the block must not separate the definition of an OpSampledImage
   // from its use: the SPIR-V data rules require them to be in the same block.
-  std::set<uint32_t> sampled_image_result_ids;
-  bool before_split = true;
-  for (auto& instruction : *block_to_split) {
-    if (&instruction == &*split_before) {
-      before_split = false;
-    }
-    if (before_split) {
-      if (instruction.opcode() == SpvOpSampledImage) {
-        sampled_image_result_ids.insert(instruction.result_id());
-      }
-    } else {
-      if (!instruction.WhileEachInId(
-              [&sampled_image_result_ids](uint32_t* id) -> bool {
-                return !sampled_image_result_ids.count(*id);
-              })) {
-        return false;
-      }
-    }
-  }
-
-  return true;
+  return !fuzzerutil::
+      SplitBeforeInstructionSeparatesOpSampledImageDefinitionFromUse(
+          block_to_split, instruction_to_split_before);
 }
 
 void TransformationSplitBlock::Apply(

--- a/source/fuzz/transformation_split_block.cpp
+++ b/source/fuzz/transformation_split_block.cpp
@@ -84,7 +84,7 @@ bool TransformationSplitBlock::IsApplicable(
   // Splitting the block must not separate the definition of an OpSampledImage
   // from its use: the SPIR-V data rules require them to be in the same block.
   return !fuzzerutil::
-      SplitBeforeInstructionSeparatesOpSampledImageDefinitionFromUse(
+      SplittingBeforeInstructionSeparatesOpSampledImageDefinitionFromUse(
           block_to_split, instruction_to_split_before);
 }
 

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -87,6 +87,7 @@ if (${SPIRV_BUILD_FUZZER})
           transformation_replace_linear_algebra_instruction_test.cpp
           transformation_replace_load_store_with_copy_memory_test.cpp
           transformation_replace_opphi_id_from_dead_predecessor_test.cpp
+          transformation_replace_opselect_with_conditional_branch_test.cpp
           transformation_replace_parameter_with_global_test.cpp
           transformation_replace_params_with_struct_test.cpp
           transformation_set_function_control_test.cpp

--- a/test/fuzz/fuzzer_pass_construct_composites_test.cpp
+++ b/test/fuzz/fuzzer_pass_construct_composites_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/fuzzer_pass_construct_composites.h"
+#include "source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.h"
 #include "source/fuzz/pseudo_random_generator.h"
 #include "test/fuzz/fuzz_test_util.h"
 

--- a/test/fuzz/fuzzer_pass_construct_composites_test.cpp
+++ b/test/fuzz/fuzzer_pass_construct_composites_test.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "source/fuzz/fuzzer_pass_construct_composites.h"
-#include "source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.h"
 #include "source/fuzz/pseudo_random_generator.h"
 #include "test/fuzz/fuzz_test_util.h"
 

--- a/test/fuzz/transformation_replace_opselect_with_conditional_branch_test.cpp
+++ b/test/fuzz/transformation_replace_opselect_with_conditional_branch_test.cpp
@@ -58,6 +58,12 @@ TEST(TransformationReplaceOpSelectWithConditionalBranchTest, Inapplicable) {
          %27 = OpSampledImage %12 %22 %23
          %28 = OpSelect %5 %9 %6 %24
          %29 = OpImageSampleImplicitLod %7 %27 %18
+               OpBranch %30
+         %30 = OpLabel
+         %31 = OpSelect %5 %9 %6 %24
+               OpLoopMerge %32 %30 None
+               OpBranchConditional %9 %30 %32
+         %32 = OpLabel
                OpReturn
                OpFunctionEnd
 )";
@@ -80,6 +86,11 @@ TEST(TransformationReplaceOpSelectWithConditionalBranchTest, Inapplicable) {
   // separate an OpSampledImage instruction from its use.
   ASSERT_FALSE(
       TransformationReplaceOpSelectWithConditionalBranch(28, {100, 101})
+          .IsApplicable(context.get(), transformation_context));
+
+  // The block containing %31 cannot be split because it is a loop header.
+  ASSERT_FALSE(
+      TransformationReplaceOpSelectWithConditionalBranch(31, {100, 101})
           .IsApplicable(context.get(), transformation_context));
 }
 

--- a/test/fuzz/transformation_replace_opselect_with_conditional_branch_test.cpp
+++ b/test/fuzz/transformation_replace_opselect_with_conditional_branch_test.cpp
@@ -1,0 +1,205 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_replace_opselect_with_conditional_branch.h"
+
+#include "test/fuzz/fuzz_test_util.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace {
+
+TEST(TransformationReplaceOpSelectWithConditionalBranchTest, Inapplicable) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %2 "main"
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeInt 32 1
+          %6 = OpConstant %5 1
+          %7 = OpTypeVector %5 4
+          %8 = OpTypeBool
+          %9 = OpConstantTrue %8
+         %10 = OpTypeSampler
+         %11 = OpTypeImage %3 2D 2 0 0 1 Unknown
+         %12 = OpTypeSampledImage %11
+         %13 = OpTypePointer Function %11
+         %14 = OpTypePointer Function %10
+         %15 = OpTypeFloat 32
+         %16 = OpTypeVector %15 2
+         %17 = OpConstant %15 1
+         %18 = OpConstantComposite %16 %17 %17
+          %2 = OpFunction %3 None %4
+         %19 = OpLabel
+         %20 = OpVariable %13 Function
+         %21 = OpVariable %14 Function
+         %22 = OpLoad %11 %20
+         %23 = OpLoad %10 %21
+         %24 = OpCopyObject %5 %6
+         %25 = OpSelect %5 %9 %24 %6
+               OpBranch %26
+         %26 = OpLabel
+         %27 = OpSampledImage %12 %22 %23
+         %28 = OpSelect %5 %9 %6 %24
+         %29 = OpImageSampleImplicitLod %7 %27 %18
+               OpReturn
+               OpFunctionEnd
+)";
+  const auto env = SPV_ENV_UNIVERSAL_1_5;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  // %24 is not an OpSelect instruction.
+  ASSERT_FALSE(
+      TransformationReplaceOpSelectWithConditionalBranch(24, {100, 101})
+          .IsApplicable(context.get(), transformation_context));
+
+  // The block containing %28 cannot be split before %28 because this would
+  // separate an OpSampledImage instruction from its use.
+  ASSERT_FALSE(
+      TransformationReplaceOpSelectWithConditionalBranch(28, {100, 101})
+          .IsApplicable(context.get(), transformation_context));
+}
+
+TEST(TransformationReplaceOpSelectWithConditionalBranchTest, Simple) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %2 "main"
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeBool
+          %6 = OpConstantTrue %5
+          %7 = OpTypeInt 32 1
+          %8 = OpConstant %7 1
+          %2 = OpFunction %3 None %4
+          %9 = OpLabel
+         %10 = OpCopyObject %7 %8
+         %11 = OpSelect %7 %6 %10 %8
+         %12 = OpCopyObject %7 %10
+               OpReturn
+               OpFunctionEnd
+)";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_5;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  // 2 fresh ids are required.
+  ASSERT_FALSE(TransformationReplaceOpSelectWithConditionalBranch(11, {100})
+                   .IsApplicable(context.get(), transformation_context));
+
+  // One of the ids are not fresh.
+  ASSERT_FALSE(TransformationReplaceOpSelectWithConditionalBranch(11, {100, 11})
+                   .IsApplicable(context.get(), transformation_context));
+
+  // The ids are repeated.
+  ASSERT_FALSE(
+      TransformationReplaceOpSelectWithConditionalBranch(11, {100, 100})
+          .IsApplicable(context.get(), transformation_context));
+
+  ASSERT_TRUE(TransformationReplaceOpSelectWithConditionalBranch(11, {100, 101})
+                  .IsApplicable(context.get(), transformation_context));
+}
+
+TEST(TransformationReplaceOpSelectWithConditionalBranchTest, InsideMergeBlock) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %2 "main"
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeBool
+          %6 = OpConstantTrue %5
+          %7 = OpTypeInt 32 1
+          %8 = OpConstant %7 1
+          %2 = OpFunction %3 None %4
+          %9 = OpLabel
+               OpBranch %10
+         %10 = OpLabel
+               OpLoopMerge %11 %10 None
+               OpBranchConditional %6 %10 %11
+         %11 = OpLabel
+         %12 = OpSelect %7 %6 %8 %8
+               OpBranch %13
+         %13 = OpLabel
+               OpSelectionMerge %14 None
+               OpBranchConditional %6 %15 %14
+         %15 = OpLabel
+               OpBranch %14
+         %14 = OpLabel
+         %16 = OpSelect %7 %6 %8 %8
+               OpReturn
+               OpFunctionEnd
+)";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_5;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  // 3 fresh ids are required because %12 is in a merge block.
+  ASSERT_FALSE(
+      TransformationReplaceOpSelectWithConditionalBranch(12, {100, 101})
+          .IsApplicable(context.get(), transformation_context));
+
+  // 3 fresh ids are required because %16 is in a merge block.
+  ASSERT_FALSE(
+      TransformationReplaceOpSelectWithConditionalBranch(16, {100, 101})
+          .IsApplicable(context.get(), transformation_context));
+
+  auto transformation1 =
+      TransformationReplaceOpSelectWithConditionalBranch(12, {100, 101, 102});
+  ASSERT_TRUE(
+      transformation1.IsApplicable(context.get(), transformation_context));
+
+  auto transformation2 =
+      TransformationReplaceOpSelectWithConditionalBranch(16, {103, 104, 105});
+  ASSERT_TRUE(
+      transformation2.IsApplicable(context.get(), transformation_context));
+}
+
+}  // namespace
+}  // namespace fuzz
+}  // namespace spvtools

--- a/test/fuzz/transformation_replace_opselect_with_conditional_branch_test.cpp
+++ b/test/fuzz/transformation_replace_opselect_with_conditional_branch_test.cpp
@@ -125,10 +125,13 @@ TEST(TransformationReplaceOpSelectWithConditionalBranchTest, Inapplicable) {
   ASSERT_FALSE(TransformationReplaceOpSelectWithConditionalBranch(35, 100, 101)
                    .IsApplicable(context.get(), transformation_context));
 
+#ifndef NDEBUG
   // |true_block_id| and |false_block_id| are both 0.
-  ASSERT_FALSE(
+  ASSERT_DEATH(
       TransformationReplaceOpSelectWithConditionalBranch(37, 0, 0).IsApplicable(
-          context.get(), transformation_context));
+          context.get(), transformation_context),
+      "At least one of the ids must be non-zero.");
+#endif
 
   // The fresh ids are not distinct.
   ASSERT_FALSE(TransformationReplaceOpSelectWithConditionalBranch(37, 100, 100)

--- a/test/fuzz/transformation_replace_opselect_with_conditional_branch_test.cpp
+++ b/test/fuzz/transformation_replace_opselect_with_conditional_branch_test.cpp
@@ -79,18 +79,18 @@ TEST(TransformationReplaceOpSelectWithConditionalBranchTest, Inapplicable) {
 
   // %24 is not an OpSelect instruction.
   ASSERT_FALSE(
-      TransformationReplaceOpSelectWithConditionalBranch(24, {100, 101})
+      TransformationReplaceOpselectWithConditionalBranch(24, {100, 101})
           .IsApplicable(context.get(), transformation_context));
 
   // The block containing %28 cannot be split before %28 because this would
   // separate an OpSampledImage instruction from its use.
   ASSERT_FALSE(
-      TransformationReplaceOpSelectWithConditionalBranch(28, {100, 101})
+      TransformationReplaceOpselectWithConditionalBranch(28, {100, 101})
           .IsApplicable(context.get(), transformation_context));
 
   // The block containing %31 cannot be split because it is a loop header.
   ASSERT_FALSE(
-      TransformationReplaceOpSelectWithConditionalBranch(31, {100, 101})
+      TransformationReplaceOpselectWithConditionalBranch(31, {100, 101})
           .IsApplicable(context.get(), transformation_context));
 }
 
@@ -129,16 +129,16 @@ TEST(TransformationReplaceOpSelectWithConditionalBranchTest, Simple) {
                                                validator_options);
 
   // One of the ids are not fresh.
-  ASSERT_FALSE(TransformationReplaceOpSelectWithConditionalBranch(11, {100, 11})
+  ASSERT_FALSE(TransformationReplaceOpselectWithConditionalBranch(11, {100, 11})
                    .IsApplicable(context.get(), transformation_context));
 
   // The ids are repeated.
   ASSERT_FALSE(
-      TransformationReplaceOpSelectWithConditionalBranch(11, {100, 100})
+      TransformationReplaceOpselectWithConditionalBranch(11, {100, 100})
           .IsApplicable(context.get(), transformation_context));
 
   auto transformation =
-      TransformationReplaceOpSelectWithConditionalBranch(11, {100, 101});
+      TransformationReplaceOpselectWithConditionalBranch(11, {100, 101});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
   transformation.Apply(context.get(), &transformation_context);


### PR DESCRIPTION
This transformation takes an OpSelect instruction and replaces it with
a conditional branch, selecting the correct value using an OpPhi
instruction.

Fixes part of the issue #3544 .