### PR TITLE
spirv-opt: Add spvOpcodeIsAccessChain

### DIFF
--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -719,3 +719,14 @@ std::vector<uint32_t> spvOpcodeMemorySemanticsOperandIndices(SpvOp opcode) {
       return {};
   }
 }
+
+bool spvOpcodeIsAccessChain(SpvOp opcode) {
+  switch (opcode) {
+    case SpvOpAccessChain:
+    case SpvOpInBoundsAccessChain:
+    case SpvOpPtrAccessChain:
+      return true;
+    default:
+      return false;
+  }
+}

--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -725,6 +725,7 @@ bool spvOpcodeIsAccessChain(SpvOp opcode) {
     case SpvOpAccessChain:
     case SpvOpInBoundsAccessChain:
     case SpvOpPtrAccessChain:
+    case SpvOpInBoundsPtrAccessChain:
       return true;
     default:
       return false;

--- a/source/opcode.h
+++ b/source/opcode.h
@@ -144,4 +144,7 @@ bool spvOpcodeIsImageSample(SpvOp opcode);
 // operands for |opcode|.
 std::vector<uint32_t> spvOpcodeMemorySemanticsOperandIndices(SpvOp opcode);
 
+// Returns true for opcodes that represents access chain instructions.
+bool spvOpcodeIsAccessChain(SpvOp opcode);
+
 #endif  // SOURCE_OPCODE_H_


### PR DESCRIPTION
This PR implements the `spvOpcodeIsAccessChain` function
that checks if the given opcode represents an access chain
instruction.