### PR TITLE
spirv-fuzz: Support identical predecessors in TransformationPropagateInstructionUp

### DIFF
--- a/source/fuzz/fuzzer_pass_propagate_instructions_up.cpp
+++ b/source/fuzz/fuzzer_pass_propagate_instructions_up.cpp
@@ -44,7 +44,13 @@ void FuzzerPassPropagateInstructionsUp::Apply() {
               GetIRContext(), block.id())) {
         std::map<uint32_t, uint32_t> fresh_ids;
         for (auto id : GetIRContext()->cfg()->preds(block.id())) {
-          fresh_ids[id] = GetFuzzerContext()->GetFreshId();
+          auto& fresh_id = fresh_ids[id];
+
+          if (!fresh_id) {
+            // Create a fresh id if it hasn't been created yet. |fresh_id| will
+            // be default-initialized to 0 in this case.
+            fresh_id = GetFuzzerContext()->GetFreshId();
+          }
         }
 
         ApplyTransformation(


### PR DESCRIPTION
A basic block may have multiple identical predecessors as follows:
```
%1 = OpLabel
OpSelectionMerge %2 None
OpBranchConditional %true %2 %2
%2 = OpLabel
...
```
This case wasn't supported before.