### PR TITLE
spirv-fuzz: Create synonym via OpPhi and existing synonyms

### DIFF
--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -124,6 +124,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_add_local_variable.h
         transformation_add_loop_preheader.h
         transformation_add_no_contraction_decoration.h
+        transformation_add_opphi_synonym.h
         transformation_add_parameter.h
         transformation_add_relaxed_decoration.h
         transformation_add_spec_constant_op.h
@@ -274,6 +275,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_add_local_variable.cpp
         transformation_add_loop_preheader.cpp
         transformation_add_no_contraction_decoration.cpp
+        transformation_add_opphi_synonym.cpp
         transformation_add_parameter.cpp
         transformation_add_relaxed_decoration.cpp
         transformation_add_spec_constant_op.cpp

--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -59,6 +59,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_add_local_variables.h
         fuzzer_pass_add_loop_preheaders.h
         fuzzer_pass_add_no_contraction_decorations.h
+        fuzzer_pass_add_opphi_synonyms.h
         fuzzer_pass_add_parameters.h
         fuzzer_pass_add_relaxed_decorations.h
         fuzzer_pass_add_stores.h
@@ -211,6 +212,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_add_local_variables.cpp
         fuzzer_pass_add_loop_preheaders.cpp
         fuzzer_pass_add_no_contraction_decorations.cpp
+        fuzzer_pass_add_opphi_synonyms.cpp
         fuzzer_pass_add_parameters.cpp
         fuzzer_pass_add_relaxed_decorations.cpp
         fuzzer_pass_add_stores.cpp

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -35,6 +35,7 @@
 #include "source/fuzz/fuzzer_pass_add_local_variables.h"
 #include "source/fuzz/fuzzer_pass_add_loop_preheaders.h"
 #include "source/fuzz/fuzzer_pass_add_no_contraction_decorations.h"
+#include "source/fuzz/fuzzer_pass_add_opphi_synonyms.h"
 #include "source/fuzz/fuzzer_pass_add_parameters.h"
 #include "source/fuzz/fuzzer_pass_add_relaxed_decorations.h"
 #include "source/fuzz/fuzzer_pass_add_stores.h"
@@ -254,6 +255,9 @@ Fuzzer::FuzzerResultStatus Fuzzer::Run(
         &passes, ir_context.get(), &transformation_context, &fuzzer_context,
         transformation_sequence_out);
     MaybeAddPass<FuzzerPassAddLoopPreheaders>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddOpPhiSynonyms>(
         &passes, ir_context.get(), &transformation_context, &fuzzer_context,
         transformation_sequence_out);
     MaybeAddPass<FuzzerPassAddParameters>(

--- a/source/fuzz/fuzzer_context.cpp
+++ b/source/fuzz/fuzzer_context.cpp
@@ -43,6 +43,7 @@ const std::pair<uint32_t, uint32_t> kChanceOfAddingLoopPreheader = {20, 90};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingMatrixType = {20, 70};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingNoContractionDecoration = {
     5, 70};
+const std::pair<uint32_t, uint32_t> kChanceOfAddingOpPhiSynonym = {5, 70};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingParameters = {5, 70};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingRelaxedDecoration = {20, 90};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingStore = {5, 50};
@@ -182,6 +183,8 @@ FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
       ChooseBetweenMinAndMax(kChanceOfAddingMatrixType);
   chance_of_adding_no_contraction_decoration_ =
       ChooseBetweenMinAndMax(kChanceOfAddingNoContractionDecoration);
+  chance_of_adding_opphi_synonym_ =
+      ChooseBetweenMinAndMax(kChanceOfAddingOpPhiSynonym);
   chance_of_adding_parameters =
       ChooseBetweenMinAndMax(kChanceOfAddingParameters);
   chance_of_adding_relaxed_decoration_ =

--- a/source/fuzz/fuzzer_context.h
+++ b/source/fuzz/fuzzer_context.h
@@ -148,6 +148,9 @@ class FuzzerContext {
   uint32_t GetChanceOfAddingNoContractionDecoration() {
     return chance_of_adding_no_contraction_decoration_;
   }
+  uint32_t GetChanceOfAddingOpPhiSynonym() {
+    return chance_of_adding_opphi_synonym_;
+  }
   uint32_t GetChanceOfAddingParameters() { return chance_of_adding_parameters; }
   uint32_t GetChanceOfAddingRelaxedDecoration() {
     return chance_of_adding_relaxed_decoration_;
@@ -367,6 +370,7 @@ class FuzzerContext {
   uint32_t chance_of_adding_loop_preheader_;
   uint32_t chance_of_adding_matrix_type_;
   uint32_t chance_of_adding_no_contraction_decoration_;
+  uint32_t chance_of_adding_opphi_synonym_;
   uint32_t chance_of_adding_parameters;
   uint32_t chance_of_adding_relaxed_decoration_;
   uint32_t chance_of_adding_store_;

--- a/source/fuzz/fuzzer_pass_add_opphi_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_add_opphi_synonyms.cpp
@@ -1,0 +1,101 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/fuzzer_pass_add_opphi_synonyms.h"
+
+#include "source/fuzz/transformation_add_opphi_synonym.h"
+
+namespace spvtools {
+namespace fuzz {
+
+FuzzerPassAddOpPhiSynonyms::FuzzerPassAddOpPhiSynonyms(
+    opt::IRContext* ir_context, TransformationContext* transformation_context,
+    FuzzerContext* fuzzer_context,
+    protobufs::TransformationSequence* transformations)
+    : FuzzerPass(ir_context, transformation_context, fuzzer_context,
+                 transformations) {}
+
+FuzzerPassAddOpPhiSynonyms::~FuzzerPassAddOpPhiSynonyms() = default;
+
+void FuzzerPassAddOpPhiSynonyms::Apply() {}
+
+std::vector<std::set<uint32_t>>
+FuzzerPassAddOpPhiSynonyms::GetIdEquivalenceClasses() {
+  std::vector<std::set<uint32_t>> id_equivalence_classes;
+
+  // Keep track of all the ids that have already be assigned to a class.
+  std::set<uint32_t> already_in_a_class;
+
+  for (const auto& pair : GetIRContext()->get_def_use_mgr()->id_to_defs()) {
+    // Exclude ids that have already been assigned to a class.
+    if (already_in_a_class.count(pair.first)) {
+      continue;
+    }
+
+    // Exclude irrelevant ids.
+    if (GetTransformationContext()->GetFactManager()->IdIsIrrelevant(
+            pair.first)) {
+      continue;
+    }
+
+    // Exclude ids having a type that is not allowed by the transformation.
+    if (!TransformationAddOpPhiSynonym::CheckTypeIsAllowed(
+            GetIRContext(), pair.second->type_id())) {
+      continue;
+    }
+
+    // We need a new equivalence class for this id.
+    std::set<uint32_t> new_equivalence_class;
+
+    // Add this id to the class.
+    new_equivalence_class.emplace(pair.first);
+    already_in_a_class.emplace(pair.first);
+
+    // Add all the synonyms with the same type to this class.
+    for (auto synonym :
+         GetTransformationContext()->GetFactManager()->GetSynonymsForId(
+             pair.first)) {
+      // The synonym must not be an indexed access into a composite.
+      if (synonym->index_size() > 0) {
+        continue;
+      }
+
+      // The synonym must not be irrelevant.
+      if (GetTransformationContext()->GetFactManager()->IdIsIrrelevant(
+              synonym->object())) {
+        continue;
+      }
+
+      auto synonym_def =
+          GetIRContext()->get_def_use_mgr()->GetDef(synonym->object());
+      // The synonym must exist and have the same type as the id we are
+      // considering.
+      if (!synonym_def || synonym_def->type_id() != pair.second->type_id()) {
+        continue;
+      }
+
+      // We can add this synonym to the new equivalence class.
+      new_equivalence_class.emplace(synonym->object());
+      already_in_a_class.emplace(synonym->object());
+    }
+
+    // Add the new equivalence class to the list of equivalence classes.
+    id_equivalence_classes.emplace_back(std::move(new_equivalence_class));
+  }
+
+  return id_equivalence_classes;
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/fuzzer_pass_add_opphi_synonyms.h
+++ b/source/fuzz/fuzzer_pass_add_opphi_synonyms.h
@@ -39,12 +39,13 @@ class FuzzerPassAddOpPhiSynonyms : public FuzzerPass {
   // declared synonymous and they have the same type.
   std::vector<std::set<uint32_t>> GetIdEquivalenceClasses();
 
-  // Returns true iff |set| contains at least |distinct_ids_required| ids so
-  // that all of these ids are available at the end of at least one predecessor
-  // of the block with label |block_id|.
+  // Returns true iff |equivalence_class| contains at least
+  // |distinct_ids_required| ids so that all of these ids are available at the
+  // end of at least one predecessor of the block with label |block_id|.
   // Assumes that the block has at least one predecessor.
-  bool SetIsSuitableForBlock(const std::set<uint32_t>& set, uint32_t block_id,
-                             uint32_t distinct_ids_required);
+  bool EquivalenceClassIsSuitableForBlock(
+      const std::set<uint32_t>& equivalence_class, uint32_t block_id,
+      uint32_t distinct_ids_required);
 
   // Returns a vector with the ids that are available to use at the end of the
   // block with id |pred_id|, selected among the given |ids|. Assumes that
@@ -53,14 +54,16 @@ class FuzzerPassAddOpPhiSynonyms : public FuzzerPass {
                                        uint32_t pred_id);
 
  private:
-  // Randomly chooses one of the sets in |candidates|, so that it satisfies all
-  // of the following conditions:
+  // Randomly chooses one of the equivalence classes in |candidates|, so that it
+  // satisfies all of the following conditions:
   // - For each of the predecessors of the |block_id| block, there is at least
-  //   one id in the chosen set that is available at the end of it.
+  //   one id in the chosen equivalence class that is available at the end of
+  //   it.
   // - There are at least |distinct_ids_required| ids available at the end of
   //   some predecessor.
-  // Returns nullptr if no set in |candidates| satisfies the requirements.
-  std::set<uint32_t>* MaybeFindSuitableSetRandomly(
+  // Returns nullptr if no equivalence class in |candidates| satisfies the
+  // requirements.
+  std::set<uint32_t>* MaybeFindSuitableEquivalenceClassRandomly(
       const std::vector<std::set<uint32_t>*>& candidates, uint32_t block_id,
       uint32_t distinct_ids_required);
 };

--- a/source/fuzz/fuzzer_pass_add_opphi_synonyms.h
+++ b/source/fuzz/fuzzer_pass_add_opphi_synonyms.h
@@ -19,6 +19,10 @@
 
 namespace spvtools {
 namespace fuzz {
+
+// A fuzzer pass to add OpPhi instructions which can take the values of ids that
+// have been marked as synonymous. This instruction will itself be marked as
+// synonymous with the others.
 class FuzzerPassAddOpPhiSynonyms : public FuzzerPass {
  public:
   FuzzerPassAddOpPhiSynonyms(

--- a/source/fuzz/fuzzer_pass_add_opphi_synonyms.h
+++ b/source/fuzz/fuzzer_pass_add_opphi_synonyms.h
@@ -34,6 +34,31 @@ class FuzzerPassAddOpPhiSynonyms : public FuzzerPass {
   // in the module, where two ids are considered equivalent iff they have been
   // declared synonymous and they have the same type.
   std::vector<std::set<uint32_t>> GetIdEquivalenceClasses();
+
+  // Returns true iff |set| contains at least |distinct_ids_required| ids so
+  // that all of these ids are available at the end of at least one predecessor
+  // of the block with label |block_id|.
+  // Assumes that the block has at least one predecessor.
+  bool SetIsSuitableForBlock(const std::set<uint32_t>& set, uint32_t block_id,
+                             uint32_t distinct_ids_required);
+
+  // Returns a vector with the ids that are available to use at the end of the
+  // block with id |pred_id|, selected among the given |ids|. Assumes that
+  // |pred_id| is the label of a block and all ids in |ids| exist in the module.
+  std::vector<uint32_t> GetSuitableIds(const std::set<uint32_t>& ids,
+                                       uint32_t pred_id);
+
+ private:
+  // Randomly chooses one of the sets in |candidates|, so that it satisfies all
+  // of the following conditions:
+  // - For each of the predecessors of the |block_id| block, there is at least
+  //   one id in the chosen set that is available at the end of it.
+  // - There are at least |distinct_ids_required| ids available at the end of
+  //   some predecessor.
+  // Returns nullptr if no set in |candidates| satisfies the requirements.
+  std::set<uint32_t>* MaybeFindSuitableSetRandomly(
+      const std::vector<std::set<uint32_t>*>& candidates, uint32_t block_id,
+      uint32_t distinct_ids_required);
 };
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/fuzzer_pass_add_opphi_synonyms.h
+++ b/source/fuzz/fuzzer_pass_add_opphi_synonyms.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_FUZZER_PASS_ADD_OPPHI_SYNONYMS_
+#define SOURCE_FUZZ_FUZZER_PASS_ADD_OPPHI_SYNONYMS_
+
+#include "source/fuzz/fuzzer_pass.h"
+
+namespace spvtools {
+namespace fuzz {
+class FuzzerPassAddOpPhiSynonyms : public FuzzerPass {
+ public:
+  FuzzerPassAddOpPhiSynonyms(
+      opt::IRContext* ir_context, TransformationContext* transformation_context,
+      FuzzerContext* fuzzer_context,
+      protobufs::TransformationSequence* transformations);
+
+  ~FuzzerPassAddOpPhiSynonyms() override;
+
+  void Apply() override;
+
+  // Computes the equivalence classes for the non-pointer and non-irrelevant ids
+  // in the module, where two ids are considered equivalent iff they have been
+  // declared synonymous and they have the same type.
+  std::vector<std::set<uint32_t>> GetIdEquivalenceClasses();
+};
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_FUZZER_PASS_ADD_OPPHI_SYNONYMS_

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -414,6 +414,7 @@ message Transformation {
     TransformationPropagateInstructionUp propagate_instruction_up = 67;
     TransformationCompositeInsert composite_insert = 68;
     TransformationInlineFunction inline_function = 69;
+    TransformationAddOpPhiSynonym add_opphi_synonym = 70;
     // Add additional option using the next available number.
   }
 }
@@ -744,6 +745,24 @@ message TransformationAddNoContractionDecoration {
   // Result id to be decorated
   uint32 result_id = 1;
 
+}
+
+message TransformationAddOpPhiSynonym {
+
+  // Adds an OpPhi instruction at the start of a block with n predecessors (pred_1, pred_2, ..., pred_n)
+  // and n related ids (id_1, id_2, ..., id_n) which are pairwise synonymous.
+  // The instruction will be of the form:
+  //       %fresh_id = OpPhi %type %id_1 %pred_1 %id_2 %pred_2 ... %id_n %pred_n
+  // and fresh_id will be recorded as being synonymous with all the other ids.
+
+  // Label id of the block
+  uint32 block_id = 1;
+
+  // Pairs (pred_i, id_i)
+  repeated UInt32Pair pred_to_id = 2;
+
+  // Fresh id for the new instruction
+  uint32 fresh_id = 3;
 }
 
 message TransformationAddParameter {

--- a/source/fuzz/transformation.cpp
+++ b/source/fuzz/transformation.cpp
@@ -33,6 +33,7 @@
 #include "source/fuzz/transformation_add_local_variable.h"
 #include "source/fuzz/transformation_add_loop_preheader.h"
 #include "source/fuzz/transformation_add_no_contraction_decoration.h"
+#include "source/fuzz/transformation_add_opphi_synonym.h"
 #include "source/fuzz/transformation_add_parameter.h"
 #include "source/fuzz/transformation_add_relaxed_decoration.h"
 #include "source/fuzz/transformation_add_spec_constant_op.h"
@@ -141,6 +142,9 @@ std::unique_ptr<Transformation> Transformation::FromMessage(
         kAddNoContractionDecoration:
       return MakeUnique<TransformationAddNoContractionDecoration>(
           message.add_no_contraction_decoration());
+    case protobufs::Transformation::TransformationCase::kAddOpphiSynonym:
+      return MakeUnique<TransformationAddOpPhiSynonym>(
+          message.add_opphi_synonym());
     case protobufs::Transformation::TransformationCase::kAddParameter:
       return MakeUnique<TransformationAddParameter>(message.add_parameter());
     case protobufs::Transformation::TransformationCase::kAddRelaxedDecoration:

--- a/source/fuzz/transformation_add_opphi_synonym.cpp
+++ b/source/fuzz/transformation_add_opphi_synonym.cpp
@@ -175,17 +175,10 @@ bool TransformationAddOpPhiSynonym::CheckTypeIsAllowed(
   }
 
   // We allow the following types: Bool, Integer, Float, Vector, Matrix, Array,
-  // RuntimeArray, Struct.
-  if (type->AsBool() || type->AsInteger() || type->AsFloat() ||
-      type->AsVector() || type->AsMatrix() || type->AsArray() ||
-      type->AsStruct()) {
-    return true;
-  }
-
-  // If the VariablePointers capability is enabled, we can also allow pointers.
-  return ir_context->get_feature_mgr()->HasCapability(
-             SpvCapabilityVariablePointers) &&
-         type->AsPointer();
+  // Struct.
+  return type->AsBool() || type->AsInteger() || type->AsFloat() ||
+         type->AsVector() || type->AsMatrix() || type->AsArray() ||
+         type->AsStruct();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_opphi_synonym.cpp
+++ b/source/fuzz/transformation_add_opphi_synonym.cpp
@@ -81,8 +81,8 @@ bool TransformationAddOpPhiSynonym::IsApplicable(
   uint32_t first_id = preds_to_ids.begin()->second;
   uint32_t type_id = ir_context->get_def_use_mgr()->GetDef(first_id)->type_id();
 
-  // Check that the id is not a pointer.
-  if (ir_context->get_type_mgr()->GetType(type_id)->AsPointer()) {
+  // Check that the type of the id is allowed.
+  if (!CheckTypeIsAllowed(ir_context, type_id)) {
     return false;
   }
 
@@ -161,6 +161,18 @@ protobufs::Transformation TransformationAddOpPhiSynonym::ToMessage() const {
   protobufs::Transformation result;
   *result.mutable_add_opphi_synonym() = message_;
   return result;
+}
+
+bool TransformationAddOpPhiSynonym::CheckTypeIsAllowed(
+    opt::IRContext* ir_context, uint32_t type_id) {
+  auto type = ir_context->get_type_mgr()->GetType(type_id);
+  if (!type) {
+    return false;
+  }
+
+  return type->AsBool() || type->AsInteger() || type->AsFloat() ||
+         type->AsVector() || type->AsMatrix() || type->AsArray() ||
+         type->AsRuntimeArray() || type->AsStruct();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_opphi_synonym.cpp
+++ b/source/fuzz/transformation_add_opphi_synonym.cpp
@@ -88,8 +88,9 @@ bool TransformationAddOpPhiSynonym::IsApplicable(
 
   for (auto& pair : preds_to_ids) {
     // Check that the id is synonymous with the others by checking that it is
-    // synonymous with the first one.
-    if (!transformation_context.GetFactManager()->IsSynonymous(
+    // synonymous with the first one (or it is the same id).
+    if (pair.second != first_id &&
+        !transformation_context.GetFactManager()->IsSynonymous(
             MakeDataDescriptor(pair.second, {}),
             MakeDataDescriptor(first_id, {}))) {
       return false;
@@ -170,9 +171,18 @@ bool TransformationAddOpPhiSynonym::CheckTypeIsAllowed(
     return false;
   }
 
-  return type->AsBool() || type->AsInteger() || type->AsFloat() ||
-         type->AsVector() || type->AsMatrix() || type->AsArray() ||
-         type->AsRuntimeArray() || type->AsStruct();
+  // We allow the following types: Bool, Integer, Float, Vector, Matrix, Array,
+  // RuntimeArray, Struct.
+  if (type->AsBool() || type->AsInteger() || type->AsFloat() ||
+      type->AsVector() || type->AsMatrix() || type->AsArray() ||
+      type->AsRuntimeArray() || type->AsStruct()) {
+    return true;
+  }
+
+  // If the VariablePointers capability is enabled, we can also allow pointers.
+  return ir_context->get_feature_mgr()->HasCapability(
+             SpvCapabilityVariablePointers) &&
+         type->AsPointer();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_opphi_synonym.cpp
+++ b/source/fuzz/transformation_add_opphi_synonym.cpp
@@ -80,6 +80,12 @@ bool TransformationAddOpPhiSynonym::IsApplicable(
   // are available to use at the end of the corresponding predecessor block.
   uint32_t first_id = preds_to_ids.begin()->second;
   uint32_t type_id = ir_context->get_def_use_mgr()->GetDef(first_id)->type_id();
+
+  // Check that the id is not a pointer.
+  if (ir_context->get_type_mgr()->GetType(type_id)->AsPointer()) {
+    return false;
+  }
+
   for (auto& pair : preds_to_ids) {
     // Check that the id is synonymous with the others by checking that it is
     // synonymous with the first one.

--- a/source/fuzz/transformation_add_opphi_synonym.cpp
+++ b/source/fuzz/transformation_add_opphi_synonym.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_add_opphi_synonym.h"
+
+#include "source/fuzz/fuzzer_util.h"
+
+namespace spvtools {
+namespace fuzz {
+TransformationAddOpPhiSynonym::TransformationAddOpPhiSynonym(
+    const protobufs::TransformationAddOpPhiSynonym& message)
+    : message_(message) {}
+
+TransformationAddOpPhiSynonym::TransformationAddOpPhiSynonym(
+    uint32_t block_id, std::map<uint32_t, uint32_t>& preds_to_ids,
+    uint32_t fresh_id) {
+  message_.set_block_id(block_id);
+  *message_.mutable_pred_to_id() =
+      fuzzerutil::MapToRepeatedUInt32Pair(preds_to_ids);
+  message_.set_fresh_id(fresh_id);
+}
+
+bool TransformationAddOpPhiSynonym::IsApplicable(
+    opt::IRContext* /* ir_context */,
+    const TransformationContext& /* transformation_context */) const {
+  return false;
+}
+
+void TransformationAddOpPhiSynonym::Apply(
+    opt::IRContext* /* ir_context */,
+    TransformationContext* /* transformation_context */) const {}
+
+protobufs::Transformation TransformationAddOpPhiSynonym::ToMessage() const {
+  protobufs::Transformation result;
+  *result.mutable_add_opphi_synonym() = message_;
+  return result;
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/transformation_add_opphi_synonym.h
+++ b/source/fuzz/transformation_add_opphi_synonym.h
@@ -25,7 +25,7 @@ class TransformationAddOpPhiSynonym : public Transformation {
       const protobufs::TransformationAddOpPhiSynonym& message);
 
   TransformationAddOpPhiSynonym(uint32_t block_id,
-                                std::map<uint32_t, uint32_t>& preds_to_ids,
+                                std::map<uint32_t, uint32_t>&& preds_to_ids,
                                 uint32_t fresh_id);
 
   // - |message_.block_id| is the label of a block with at least one

--- a/source/fuzz/transformation_add_opphi_synonym.h
+++ b/source/fuzz/transformation_add_opphi_synonym.h
@@ -34,6 +34,9 @@ class TransformationAddOpPhiSynonym : public Transformation {
   //   the block to an id that is available at the end of the predecessor.
   // - All the ids corresponding to a predecessor in |message_.pred_to_id|:
   //    - have been recorded as synonymous and all have the same type.
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3726): if a
+  // predecessor is a dead block, any id of the right type could be used, even
+  // if it is not synonym with the others.
   //    - have one of the following types: Bool, Integer, Float, Vector, Matrix,
   //      Array, Struct. The Pointer type is allowed if the VariablePointers
   //      capability is enabled.

--- a/source/fuzz/transformation_add_opphi_synonym.h
+++ b/source/fuzz/transformation_add_opphi_synonym.h
@@ -38,9 +38,9 @@ class TransformationAddOpPhiSynonym : public Transformation {
   //       predecessor is a dead block, any id of the right type could be used,
   //       even if it is not synonym with the others.
   //    - have one of the following types: Bool, Integer, Float, Vector, Matrix,
-  //      Array, Struct.
-  //      TODO: Consider enabling pointers, if the VariablePointers capability
-  //      is enabled and the other requirements are met.
+  //      Array, Struct. Pointer types are also allowed if the VariablePointers
+  //      capability is enabled and the storage class is Workgroup or
+  //      StorageBuffer.
   // - |message_.fresh_id| is a fresh id.
   bool IsApplicable(
       opt::IRContext* ir_context,
@@ -57,6 +57,8 @@ class TransformationAddOpPhiSynonym : public Transformation {
 
   // Returns true if |type_id| is the id of a type in the module, which is one
   // of the following: Bool, Integer, Float, Vector, Matrix, Array, Struct.
+  // Pointer types are also allowed if the VariablePointers capability is
+  // enabled and the storage class is Workgroup or StorageBuffer.
   static bool CheckTypeIsAllowed(opt::IRContext* ir_context, uint32_t type_id);
 
   protobufs::Transformation ToMessage() const override;

--- a/source/fuzz/transformation_add_opphi_synonym.h
+++ b/source/fuzz/transformation_add_opphi_synonym.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_TRANSFORMATION_ADD_OPPHI_SYNONYM_H_
+#define SOURCE_FUZZ_TRANSFORMATION_ADD_OPPHI_SYNONYM_H_
+
+#include "source/fuzz/transformation.h"
+
+namespace spvtools {
+namespace fuzz {
+class TransformationAddOpPhiSynonym : public Transformation {
+ public:
+  explicit TransformationAddOpPhiSynonym(
+      const protobufs::TransformationAddOpPhiSynonym& message);
+
+  TransformationAddOpPhiSynonym(uint32_t block_id,
+                                std::map<uint32_t, uint32_t>& preds_to_ids,
+                                uint32_t fresh_id);
+
+  bool IsApplicable(
+      opt::IRContext* ir_context,
+      const TransformationContext& transformation_context) const override;
+
+  void Apply(opt::IRContext* ir_context,
+             TransformationContext* transformation_context) const override;
+
+  protobufs::Transformation ToMessage() const override;
+
+ private:
+  protobufs::TransformationAddOpPhiSynonym message_;
+};
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_TRANSFORMATION_ADD_OPPHI_SYNONYM_H_

--- a/source/fuzz/transformation_add_opphi_synonym.h
+++ b/source/fuzz/transformation_add_opphi_synonym.h
@@ -34,7 +34,8 @@ class TransformationAddOpPhiSynonym : public Transformation {
   //   the block to an id that is available at the end of the predecessor.
   // - All the ids in |message_.pred_to_id| have been recorded as synonymous and
   //   all have the same type.
-  // - The ids in |message_.pred_to_id| do not refer to pointers.
+  // - The ids in |message_.pred_to_id| have one of the following types: Bool,
+  //   Integer, Float, Vector, Matrix, Array, RuntimeArray, Struct.
   // - |message_.fresh_id| is a fresh id.
   bool IsApplicable(
       opt::IRContext* ir_context,
@@ -48,6 +49,11 @@ class TransformationAddOpPhiSynonym : public Transformation {
   // This instruction is then marked as synonymous with the ids.
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
+
+  // Returns true if |type_id| is the id of a type in the module, which is one
+  // of the following: Bool, Integer, Float, Vector, Matrix, Array,
+  // RuntimeArray, Struct.
+  static bool CheckTypeIsAllowed(opt::IRContext* ir_context, uint32_t type_id);
 
   protobufs::Transformation ToMessage() const override;
 

--- a/source/fuzz/transformation_add_opphi_synonym.h
+++ b/source/fuzz/transformation_add_opphi_synonym.h
@@ -34,6 +34,7 @@ class TransformationAddOpPhiSynonym : public Transformation {
   //   the block to an id that is available at the end of the predecessor.
   // - All the ids in |message_.pred_to_id| have been recorded as synonymous and
   //   all have the same type.
+  // - The ids in |message_.pred_to_id| do not refer to pointers.
   // - |message_.fresh_id| is a fresh id.
   bool IsApplicable(
       opt::IRContext* ir_context,

--- a/source/fuzz/transformation_add_opphi_synonym.h
+++ b/source/fuzz/transformation_add_opphi_synonym.h
@@ -28,10 +28,23 @@ class TransformationAddOpPhiSynonym : public Transformation {
                                 std::map<uint32_t, uint32_t>& preds_to_ids,
                                 uint32_t fresh_id);
 
+  // - |message_.block_id| is the label of a block with at least one
+  //   predecessor.
+  // - |message_.pred_to_id| contains a mapping from each of the predecessors of
+  //   the block to an id that is available at the end of the predecessor.
+  // - All the ids in |message_.pred_to_id| have been recorded as synonymous and
+  //   all have the same type.
+  // - |message_.fresh_id| is a fresh id.
   bool IsApplicable(
       opt::IRContext* ir_context,
       const TransformationContext& transformation_context) const override;
 
+  // Given a block with n predecessors, with n >= 1, and n corresponding
+  // synonymous ids of the same type, each available to use at the end of the
+  // corresponding predecessor, adds an OpPhi instruction at the beginning of
+  // the block of the form:
+  //   %fresh_id = OpPhi %type %id_1 %pred_1 %id_2 %pred_2 ... %id_n %pred_n
+  // This instruction is then marked as synonymous with the ids.
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 

--- a/source/fuzz/transformation_add_opphi_synonym.h
+++ b/source/fuzz/transformation_add_opphi_synonym.h
@@ -34,12 +34,13 @@ class TransformationAddOpPhiSynonym : public Transformation {
   //   the block to an id that is available at the end of the predecessor.
   // - All the ids corresponding to a predecessor in |message_.pred_to_id|:
   //    - have been recorded as synonymous and all have the same type.
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3726): if a
-  // predecessor is a dead block, any id of the right type could be used, even
-  // if it is not synonym with the others.
+  //      TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3726): if a
+  //       predecessor is a dead block, any id of the right type could be used,
+  //       even if it is not synonym with the others.
   //    - have one of the following types: Bool, Integer, Float, Vector, Matrix,
-  //      Array, Struct. The Pointer type is allowed if the VariablePointers
-  //      capability is enabled.
+  //      Array, Struct.
+  //      TODO: Consider enabling pointers, if the VariablePointers capability
+  //      is enabled and the other requirements are met.
   // - |message_.fresh_id| is a fresh id.
   bool IsApplicable(
       opt::IRContext* ir_context,
@@ -55,8 +56,7 @@ class TransformationAddOpPhiSynonym : public Transformation {
              TransformationContext* transformation_context) const override;
 
   // Returns true if |type_id| is the id of a type in the module, which is one
-  // of the following: Bool, Integer, Float, Vector, Matrix, Array, Struct, or
-  // if the type is Pointer and the VariablePointers capability is enabled.
+  // of the following: Bool, Integer, Float, Vector, Matrix, Array, Struct.
   static bool CheckTypeIsAllowed(opt::IRContext* ir_context, uint32_t type_id);
 
   protobufs::Transformation ToMessage() const override;

--- a/source/fuzz/transformation_add_opphi_synonym.h
+++ b/source/fuzz/transformation_add_opphi_synonym.h
@@ -24,9 +24,9 @@ class TransformationAddOpPhiSynonym : public Transformation {
   explicit TransformationAddOpPhiSynonym(
       const protobufs::TransformationAddOpPhiSynonym& message);
 
-  TransformationAddOpPhiSynonym(uint32_t block_id,
-                                std::map<uint32_t, uint32_t>&& preds_to_ids,
-                                uint32_t fresh_id);
+  TransformationAddOpPhiSynonym(
+      uint32_t block_id, const std::map<uint32_t, uint32_t>& preds_to_ids,
+      uint32_t fresh_id);
 
   // - |message_.block_id| is the label of a block with at least one
   //   predecessor.

--- a/source/fuzz/transformation_add_opphi_synonym.h
+++ b/source/fuzz/transformation_add_opphi_synonym.h
@@ -32,10 +32,11 @@ class TransformationAddOpPhiSynonym : public Transformation {
   //   predecessor.
   // - |message_.pred_to_id| contains a mapping from each of the predecessors of
   //   the block to an id that is available at the end of the predecessor.
-  // - All the ids in |message_.pred_to_id| have been recorded as synonymous and
-  //   all have the same type.
-  // - The ids in |message_.pred_to_id| have one of the following types: Bool,
-  //   Integer, Float, Vector, Matrix, Array, RuntimeArray, Struct.
+  // - All the ids corresponding to a predecessor in |message_.pred_to_id|:
+  //    - have been recorded as synonymous and all have the same type.
+  //    - have one of the following types: Bool, Integer, Float, Vector, Matrix,
+  //      Array, Struct. The Pointer type is allowed if the VariablePointers
+  //      capability is enabled.
   // - |message_.fresh_id| is a fresh id.
   bool IsApplicable(
       opt::IRContext* ir_context,
@@ -51,8 +52,8 @@ class TransformationAddOpPhiSynonym : public Transformation {
              TransformationContext* transformation_context) const override;
 
   // Returns true if |type_id| is the id of a type in the module, which is one
-  // of the following: Bool, Integer, Float, Vector, Matrix, Array,
-  // RuntimeArray, Struct.
+  // of the following: Bool, Integer, Float, Vector, Matrix, Array, Struct, or
+  // if the type is Pointer and the VariablePointers capability is enabled.
   static bool CheckTypeIsAllowed(opt::IRContext* ir_context, uint32_t type_id);
 
   protobufs::Transformation ToMessage() const override;

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -42,6 +42,7 @@ if (${SPIRV_BUILD_FUZZER})
           transformation_add_local_variable_test.cpp
           transformation_add_loop_preheader_test.cpp
           transformation_add_no_contraction_decoration_test.cpp
+          transformation_add_opphi_synonym_test.cpp
           transformation_add_parameter_test.cpp
           transformation_add_relaxed_decoration_test.cpp
           transformation_add_synonym_test.cpp

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -21,6 +21,7 @@ if (${SPIRV_BUILD_FUZZER})
           equivalence_relation_test.cpp
           fact_manager_test.cpp
           fuzz_test_util.cpp
+          fuzzer_pass_add_opphi_synonyms_test.cpp
           fuzzer_pass_construct_composites_test.cpp
           fuzzer_pass_donate_modules_test.cpp
           fuzzer_pass_outline_functions_test.cpp

--- a/test/fuzz/fuzzer_pass_add_opphi_synonyms_test.cpp
+++ b/test/fuzz/fuzzer_pass_add_opphi_synonyms_test.cpp
@@ -140,18 +140,21 @@ TEST(FuzzerPassAddOpPhiSynonymsTest, HelperFunctions) {
 
   // The set {24, 26, 30} is not suitable for 18 (none if the ids is available
   // for predecessor 20).
-  ASSERT_FALSE(fuzzer_pass.SetIsSuitableForBlock({24, 26, 30}, 18, 1));
+  ASSERT_FALSE(
+      fuzzer_pass.EquivalenceClassIsSuitableForBlock({24, 26, 30}, 18, 1));
 
   // The set {6} is not suitable for 18 if we require at least 2 distinct
   // available ids.
-  ASSERT_FALSE(fuzzer_pass.SetIsSuitableForBlock({6}, 18, 2));
+  ASSERT_FALSE(fuzzer_pass.EquivalenceClassIsSuitableForBlock({6}, 18, 2));
 
   // Only id 26 from the set {24, 26, 30} is available to use for the
   // transformation at block 29, so the set is not suitable if we want at least
   // 2 available ids.
-  ASSERT_FALSE(fuzzer_pass.SetIsSuitableForBlock({24, 26, 30}, 29, 2));
+  ASSERT_FALSE(
+      fuzzer_pass.EquivalenceClassIsSuitableForBlock({24, 26, 30}, 29, 2));
 
-  ASSERT_TRUE(fuzzer_pass.SetIsSuitableForBlock({24, 26, 30}, 29, 1));
+  ASSERT_TRUE(
+      fuzzer_pass.EquivalenceClassIsSuitableForBlock({24, 26, 30}, 29, 1));
 
   // %21 is not available at the end of block 20.
   ASSERT_TRUE(ListsHaveTheSameElements<uint32_t>(

--- a/test/fuzz/fuzzer_pass_add_opphi_synonyms_test.cpp
+++ b/test/fuzz/fuzzer_pass_add_opphi_synonyms_test.cpp
@@ -1,0 +1,127 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/fuzzer_pass_add_opphi_synonyms.h"
+#include "source/fuzz/pseudo_random_generator.h"
+#include "test/fuzz/fuzz_test_util.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace {
+
+protobufs::Fact MakeSynonymFact(uint32_t first, uint32_t second) {
+  protobufs::FactDataSynonym data_synonym_fact;
+  *data_synonym_fact.mutable_data1() = MakeDataDescriptor(first, {});
+  *data_synonym_fact.mutable_data2() = MakeDataDescriptor(second, {});
+  protobufs::Fact result;
+  *result.mutable_data_synonym_fact() = data_synonym_fact;
+  return result;
+}
+
+// Adds synonym facts to the fact manager.
+void SetUpIdSynonyms(FactManager* fact_manager, opt::IRContext* context) {
+  fact_manager->AddFact(MakeSynonymFact(11, 9), context);
+  fact_manager->AddFact(MakeSynonymFact(13, 9), context);
+  fact_manager->AddFact(MakeSynonymFact(14, 9), context);
+  fact_manager->AddFact(MakeSynonymFact(19, 9), context);
+  fact_manager->AddFact(MakeSynonymFact(20, 9), context);
+  fact_manager->AddFact(MakeSynonymFact(10, 21), context);
+}
+
+bool EquivalenceClassesMatch(const std::vector<std::set<uint32_t>>& classes1,
+                             const std::vector<std::set<uint32_t>>& classes2) {
+  std::set<std::set<uint32_t>> set1;
+  for (auto equivalence_class : classes1) {
+    set1.emplace(equivalence_class);
+  }
+
+  std::set<std::set<uint32_t>> set2;
+  for (auto equivalence_class : classes2) {
+    set2.emplace(equivalence_class);
+  }
+
+  return set1 == set2;
+}
+
+TEST(FuzzerPassAddOpPhiSynonymsTest, GetEquivalenceClasses) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %2 "main"
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeBool
+          %6 = OpConstantTrue %5
+          %7 = OpTypeInt 32 1
+          %8 = OpTypeInt 32 0
+         %22 = OpTypePointer Function %7
+          %9 = OpConstant %7 1
+         %10 = OpConstant %7 2
+         %11 = OpConstant %8 1
+          %2 = OpFunction %3 None %4
+         %12 = OpLabel
+         %23 = OpVariable %22 Function
+         %13 = OpCopyObject %7 %9
+         %14 = OpCopyObject %8 %11
+               OpBranch %15
+         %15 = OpLabel
+               OpSelectionMerge %16 None
+               OpBranchConditional %6 %17 %18
+         %17 = OpLabel
+         %19 = OpCopyObject %7 %13
+         %20 = OpCopyObject %8 %14
+         %21 = OpCopyObject %7 %10
+               OpBranch %16
+         %18 = OpLabel
+         %24 = OpCopyObject %22 %23
+         %25 = OpCopyObject %7 %10
+               OpBranch %16
+         %16 = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  const auto env = SPV_ENV_UNIVERSAL_1_5;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  PseudoRandomGenerator prng(0);
+  FuzzerContext fuzzer_context(&prng, 100);
+  protobufs::TransformationSequence transformation_sequence;
+
+  FuzzerPassAddOpPhiSynonyms fuzzer_pass(context.get(), &transformation_context,
+                                         &fuzzer_context,
+                                         &transformation_sequence);
+
+  SetUpIdSynonyms(&fact_manager, context.get());
+  fact_manager.AddFact(MakeSynonymFact(23, 24), context.get());
+
+  std::vector<std::set<uint32_t>> expected_equivalence_classes = {
+      {9, 13, 19}, {11, 14, 20}, {10, 21}, {6}, {25}};
+
+  ASSERT_TRUE(EquivalenceClassesMatch(fuzzer_pass.GetIdEquivalenceClasses(),
+                                      expected_equivalence_classes));
+}
+}  // namespace
+}  // namespace fuzz
+}  // namespace spvtools

--- a/test/fuzz/transformation_add_opphi_synonym_test.cpp
+++ b/test/fuzz/transformation_add_opphi_synonym_test.cpp
@@ -1,0 +1,298 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_add_opphi_synonym.h"
+
+#include "test/fuzz/fuzz_test_util.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace {
+
+protobufs::Fact MakeSynonymFact(uint32_t first, uint32_t second) {
+  protobufs::FactDataSynonym data_synonym_fact;
+  *data_synonym_fact.mutable_data1() = MakeDataDescriptor(first, {});
+  *data_synonym_fact.mutable_data2() = MakeDataDescriptor(second, {});
+  protobufs::Fact result;
+  *result.mutable_data_synonym_fact() = data_synonym_fact;
+  return result;
+}
+
+// Adds synonym facts to the fact manager.
+void SetUpIdSynonyms(FactManager* fact_manager, opt::IRContext* context) {
+  fact_manager->AddFact(MakeSynonymFact(11, 9), context);
+  fact_manager->AddFact(MakeSynonymFact(13, 9), context);
+  fact_manager->AddFact(MakeSynonymFact(14, 9), context);
+  fact_manager->AddFact(MakeSynonymFact(19, 9), context);
+  fact_manager->AddFact(MakeSynonymFact(20, 9), context);
+  fact_manager->AddFact(MakeSynonymFact(10, 21), context);
+}
+
+TEST(TransformationAddOpPhiSynonymTest, Inapplicable) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %2 "main"
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeBool
+          %6 = OpConstantTrue %5
+          %7 = OpTypeInt 32 1
+          %8 = OpTypeInt 32 0
+          %9 = OpConstant %7 1
+         %10 = OpConstant %7 2
+         %11 = OpConstant %8 1
+          %2 = OpFunction %3 None %4
+         %12 = OpLabel
+         %13 = OpCopyObject %7 %9
+         %14 = OpCopyObject %8 %11
+               OpBranch %15
+         %15 = OpLabel
+               OpSelectionMerge %16 None
+               OpBranchConditional %6 %17 %18
+         %17 = OpLabel
+         %19 = OpCopyObject %7 %13
+         %20 = OpCopyObject %8 %14
+         %21 = OpCopyObject %7 %10
+               OpBranch %16
+         %18 = OpLabel
+               OpBranch %16
+         %16 = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_5;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  SetUpIdSynonyms(&fact_manager, context.get());
+
+  // %13 is not a block label.
+  ASSERT_FALSE(TransformationAddOpPhiSynonym(13, {}, 100)
+                   .IsApplicable(context.get(), transformation_context));
+
+  // Block %12 does not have a predecessor.
+  ASSERT_FALSE(TransformationAddOpPhiSynonym(12, {}, 100)
+                   .IsApplicable(context.get(), transformation_context));
+
+  // Not all predecessors of %16 (%17 and %18) are considered in the map.
+  ASSERT_FALSE(TransformationAddOpPhiSynonym(16, {{17, 19}}, 100)
+                   .IsApplicable(context.get(), transformation_context));
+
+  // %30 does not exist in the module.
+  ASSERT_FALSE(TransformationAddOpPhiSynonym(16, {{30, 19}}, 100)
+                   .IsApplicable(context.get(), transformation_context));
+
+  // %20 is not a block label.
+  ASSERT_FALSE(TransformationAddOpPhiSynonym(16, {{20, 19}}, 100)
+                   .IsApplicable(context.get(), transformation_context));
+
+  // %15 is not the id of one of the predecessors of the block.
+  ASSERT_FALSE(TransformationAddOpPhiSynonym(16, {{15, 19}}, 100)
+                   .IsApplicable(context.get(), transformation_context));
+
+  // %30 does not exist in the module.
+  ASSERT_FALSE(TransformationAddOpPhiSynonym(16, {{17, 30}, {18, 13}}, 100)
+                   .IsApplicable(context.get(), transformation_context));
+
+  // %19 and %10 are not synonymous.
+  ASSERT_FALSE(TransformationAddOpPhiSynonym(16, {{17, 19}, {18, 10}}, 100)
+                   .IsApplicable(context.get(), transformation_context));
+
+  // %19 and %14 do not have the same type.
+  ASSERT_FALSE(TransformationAddOpPhiSynonym(16, {{17, 19}, {18, 14}}, 100)
+                   .IsApplicable(context.get(), transformation_context));
+
+  // %19 is not available at the end of %18.
+  ASSERT_FALSE(TransformationAddOpPhiSynonym(16, {{17, 9}, {18, 19}}, 100)
+                   .IsApplicable(context.get(), transformation_context));
+
+  // %21 is not a fresh id.
+  ASSERT_FALSE(TransformationAddOpPhiSynonym(16, {{17, 9}, {18, 9}}, 21)
+                   .IsApplicable(context.get(), transformation_context));
+}
+
+TEST(TransformationAddOpPhiSynonymTest, Apply) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %2 "main"
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeBool
+          %6 = OpConstantTrue %5
+          %7 = OpTypeInt 32 1
+          %8 = OpTypeInt 32 0
+          %9 = OpConstant %7 1
+         %10 = OpConstant %7 2
+         %11 = OpConstant %8 1
+          %2 = OpFunction %3 None %4
+         %12 = OpLabel
+         %13 = OpCopyObject %7 %9
+         %14 = OpCopyObject %8 %11
+               OpBranch %15
+         %15 = OpLabel
+               OpSelectionMerge %16 None
+               OpBranchConditional %6 %17 %18
+         %17 = OpLabel
+         %19 = OpCopyObject %7 %13
+         %20 = OpCopyObject %8 %14
+         %21 = OpCopyObject %7 %10
+               OpBranch %16
+         %18 = OpLabel
+               OpBranch %16
+         %16 = OpLabel
+               OpBranch %22
+         %22 = OpLabel
+               OpLoopMerge %23 %24 None
+               OpBranchConditional %6 %25 %23
+         %25 = OpLabel
+               OpSelectionMerge %26 None
+               OpBranchConditional %6 %27 %26
+         %27 = OpLabel
+         %28 = OpCopyObject %7 %13
+               OpBranch %23
+         %26 = OpLabel
+               OpSelectionMerge %29 None
+               OpBranchConditional %6 %29 %24
+         %29 = OpLabel
+         %30 = OpCopyObject %7 %13
+               OpBranch %23
+         %24 = OpLabel
+               OpBranch %22
+         %23 = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_5;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  SetUpIdSynonyms(&fact_manager, context.get());
+
+  // Add some further synonym facts.
+  fact_manager.AddFact(MakeSynonymFact(28, 9), context.get());
+  fact_manager.AddFact(MakeSynonymFact(30, 9), context.get());
+
+  auto transformation1 = TransformationAddOpPhiSynonym(17, {{15, 13}}, 100);
+  ASSERT_TRUE(
+      transformation1.IsApplicable(context.get(), transformation_context));
+  transformation1.Apply(context.get(), &transformation_context);
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(100, {}),
+                                        MakeDataDescriptor(9, {})));
+
+  auto transformation2 =
+      TransformationAddOpPhiSynonym(16, {{17, 19}, {18, 13}}, 101);
+  ASSERT_TRUE(
+      transformation2.IsApplicable(context.get(), transformation_context));
+  transformation2.Apply(context.get(), &transformation_context);
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(101, {}),
+                                        MakeDataDescriptor(9, {})));
+
+  auto transformation3 =
+      TransformationAddOpPhiSynonym(23, {{22, 13}, {27, 28}, {29, 30}}, 102);
+  ASSERT_TRUE(
+      transformation3.IsApplicable(context.get(), transformation_context));
+  transformation3.Apply(context.get(), &transformation_context);
+  ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(102, {}),
+                                        MakeDataDescriptor(9, {})));
+
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  std::string after_transformations = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %2 "main"
+          %3 = OpTypeVoid
+          %4 = OpTypeFunction %3
+          %5 = OpTypeBool
+          %6 = OpConstantTrue %5
+          %7 = OpTypeInt 32 1
+          %8 = OpTypeInt 32 0
+          %9 = OpConstant %7 1
+         %10 = OpConstant %7 2
+         %11 = OpConstant %8 1
+          %2 = OpFunction %3 None %4
+         %12 = OpLabel
+         %13 = OpCopyObject %7 %9
+         %14 = OpCopyObject %8 %11
+               OpBranch %15
+         %15 = OpLabel
+               OpSelectionMerge %16 None
+               OpBranchConditional %6 %17 %18
+         %17 = OpLabel
+        %100 = OpPhi %7 %13 %15
+         %19 = OpCopyObject %7 %13
+         %20 = OpCopyObject %8 %14
+         %21 = OpCopyObject %7 %10
+               OpBranch %16
+         %18 = OpLabel
+               OpBranch %16
+         %16 = OpLabel
+        %101 = OpPhi %7 %19 %17 %13 %18
+               OpBranch %22
+         %22 = OpLabel
+               OpLoopMerge %23 %24 None
+               OpBranchConditional %6 %25 %23
+         %25 = OpLabel
+               OpSelectionMerge %26 None
+               OpBranchConditional %6 %27 %26
+         %27 = OpLabel
+         %28 = OpCopyObject %7 %13
+               OpBranch %23
+         %26 = OpLabel
+               OpSelectionMerge %29 None
+               OpBranchConditional %6 %29 %24
+         %29 = OpLabel
+         %30 = OpCopyObject %7 %13
+               OpBranch %23
+         %24 = OpLabel
+               OpBranch %22
+         %23 = OpLabel
+        %102 = OpPhi %7 %13 %22 %28 %27 %30 %29
+               OpReturn
+               OpFunctionEnd
+)";
+
+  ASSERT_TRUE(IsEqual(env, after_transformations, context.get()));
+}
+}  // namespace
+}  // namespace fuzz
+}  // namespace spvtools

--- a/test/fuzz/transformation_add_opphi_synonym_test.cpp
+++ b/test/fuzz/transformation_add_opphi_synonym_test.cpp
@@ -54,11 +54,13 @@ TEST(TransformationAddOpPhiSynonymTest, Inapplicable) {
           %6 = OpConstantTrue %5
           %7 = OpTypeInt 32 1
           %8 = OpTypeInt 32 0
+         %22 = OpTypePointer Function %7
           %9 = OpConstant %7 1
          %10 = OpConstant %7 2
          %11 = OpConstant %8 1
           %2 = OpFunction %3 None %4
          %12 = OpLabel
+         %23 = OpVariable %22 Function
          %13 = OpCopyObject %7 %9
          %14 = OpCopyObject %8 %11
                OpBranch %15
@@ -71,6 +73,7 @@ TEST(TransformationAddOpPhiSynonymTest, Inapplicable) {
          %21 = OpCopyObject %7 %10
                OpBranch %16
          %18 = OpLabel
+         %24 = OpCopyObject %22 %23
                OpBranch %16
          %16 = OpLabel
                OpReturn
@@ -88,6 +91,7 @@ TEST(TransformationAddOpPhiSynonymTest, Inapplicable) {
                                                validator_options);
 
   SetUpIdSynonyms(&fact_manager, context.get());
+  fact_manager.AddFact(MakeSynonymFact(23, 24), context.get());
 
   // %13 is not a block label.
   ASSERT_FALSE(TransformationAddOpPhiSynonym(13, {{}}, 100)
@@ -131,6 +135,10 @@ TEST(TransformationAddOpPhiSynonymTest, Inapplicable) {
 
   // %21 is not a fresh id.
   ASSERT_FALSE(TransformationAddOpPhiSynonym(16, {{{17, 9}, {18, 9}}}, 21)
+                   .IsApplicable(context.get(), transformation_context));
+
+  // %23 and %24 have pointer id.
+  ASSERT_FALSE(TransformationAddOpPhiSynonym(16, {{{17, 23}, {18, 24}}}, 100)
                    .IsApplicable(context.get(), transformation_context));
 }
 


### PR DESCRIPTION
A transformation that adds new OpPhi instructions to blocks with >=1
predecessors, so that its value depends on previously-defined ids of
the right type, which are all synonymous. This instruction is also
recorded as synonymous to the others.

The related fuzzer pass still needs to be implemented.

Fixes #3592 .