### PR TITLE
Allow DebugTypeTemplate for Type operand

### DIFF
--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -179,7 +179,7 @@ spv_result_t ValidateOperandDebugType(
           return true;
         }
         return OpenCLDebugInfo100DebugTypeBasic <= dbg_inst &&
-               dbg_inst <= OpenCLDebugInfo100DebugTypePtrToMember;
+               dbg_inst <= OpenCLDebugInfo100DebugTypeTemplate;
       };
   if (DoesDebugInfoOperandMatchExpectation(_, expectation, inst, word_index))
     return SPV_SUCCESS;


### PR DESCRIPTION
Some OpenCL.DebugInfo.100 instructions such as DebugGlobalVariable
and DebugLocalVariable have the Type operand. This commit allows them to
use DebugTypeTemplate for the Type operand.