### PR TITLE
Let ADCE pass check DebugScope

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -533,6 +533,17 @@ bool AggressiveDCEPass::AggressiveDCE(Function* func) {
       AddToWorklist(dec);
     }
 
+    // Add DebugScope and DebugInlinedAt for |liveInst| to the work list.
+    if (liveInst->GetDebugScope().GetLexicalScope() != kNoDebugScope) {
+      auto* scope = get_def_use_mgr()->GetDef(
+          liveInst->GetDebugScope().GetLexicalScope());
+      AddToWorklist(scope);
+    }
+    if (liveInst->GetDebugInlinedAt() != kNoInlinedAt) {
+      auto* inlined_at =
+          get_def_use_mgr()->GetDef(liveInst->GetDebugInlinedAt());
+      AddToWorklist(inlined_at);
+    }
     worklist_.pop();
   }
 

--- a/source/opt/aggressive_dead_code_elim_pass.h
+++ b/source/opt/aggressive_dead_code_elim_pass.h
@@ -81,15 +81,6 @@ class AggressiveDCEPass : public MemPass {
     if (!live_insts_.Set(inst->unique_id())) {
       worklist_.push(inst);
     }
-    if (inst->GetDebugScope().GetLexicalScope() != kNoDebugScope) {
-      auto* scope =
-          get_def_use_mgr()->GetDef(inst->GetDebugScope().GetLexicalScope());
-      AddToWorklist(scope);
-    }
-    if (inst->GetDebugInlinedAt() != kNoInlinedAt) {
-      auto* inlined_at = get_def_use_mgr()->GetDef(inst->GetDebugInlinedAt());
-      AddToWorklist(inlined_at);
-    }
   }
 
   // Add all store instruction which use |ptrId|, directly or indirectly,

--- a/source/opt/aggressive_dead_code_elim_pass.h
+++ b/source/opt/aggressive_dead_code_elim_pass.h
@@ -81,6 +81,15 @@ class AggressiveDCEPass : public MemPass {
     if (!live_insts_.Set(inst->unique_id())) {
       worklist_.push(inst);
     }
+    if (inst->GetDebugScope().GetLexicalScope() != kNoDebugScope) {
+      auto* scope =
+          get_def_use_mgr()->GetDef(inst->GetDebugScope().GetLexicalScope());
+      AddToWorklist(scope);
+    }
+    if (inst->GetDebugInlinedAt() != kNoInlinedAt) {
+      auto* inlined_at = get_def_use_mgr()->GetDef(inst->GetDebugInlinedAt());
+      AddToWorklist(inlined_at);
+    }
   }
 
   // Add all store instruction which use |ptrId|, directly or indirectly,


### PR DESCRIPTION
In the existing code, ADCE pass does not check DebugScope of an
instruction when it checks the users of each instruction, which results
in removing OpenCL.Debug.100 instructions that are only used by
DebugScope. This commit lets ADCE pass add DebugScope of an instruction
to the live instruction set when the instruction is added to the live
instruction set.