### PR TITLE
spirv-opt: Implement opt::Function::HasEarlyReturn function

### DIFF
--- a/source/opt/function.cpp
+++ b/source/opt/function.cpp
@@ -227,6 +227,18 @@ BasicBlock* Function::InsertBasicBlockBefore(
   return nullptr;
 }
 
+bool Function::HasEarlyReturn() const {
+  auto post_dominator_analysis =
+      blocks_.front()->GetLabel()->context()->GetPostDominatorAnalysis(this);
+  for (auto& block : blocks_) {
+    if (spvOpcodeIsReturn(block->tail()->opcode()) &&
+        !post_dominator_analysis->Dominates(block.get(), entry().get())) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool Function::IsRecursive() const {
   IRContext* ctx = blocks_.front()->GetLabel()->context();
   IRContext::ProcessFunction mark_visited = [this](Function* fp) {

--- a/source/opt/function.h
+++ b/source/opt/function.h
@@ -158,7 +158,10 @@ class Function {
   BasicBlock* InsertBasicBlockBefore(std::unique_ptr<BasicBlock>&& new_block,
                                      BasicBlock* position);
 
-  // Return true if the function calls itself either directly or indirectly.
+  // Returns true if the function has a return block other than the exit block.
+  bool HasEarlyReturn() const;
+
+  // Returns true if the function calls itself either directly or indirectly.
   bool IsRecursive() const;
 
   // Pretty-prints all the basic blocks in this function into a std::string.


### PR DESCRIPTION
This PR implements the `opt::Function::HasEarlyReturn` function that checks
if the given `opt::Function` object has a return block other than the exit block.