### PR TITLE
Fix -Wrange-loop-analysis warning

### DIFF
--- a/source/cfa.h
+++ b/source/cfa.h
@@ -127,7 +127,7 @@ class CFA {
 template <class BB>
 bool CFA<BB>::FindInWorkList(const std::vector<block_info>& work_list,
                              uint32_t id) {
-  for (const auto b : work_list) {
+  for (const auto& b : work_list) {
     if (b.block->id() == id) return true;
   }
   return false;


### PR DESCRIPTION
Clang 10 has `-Wrange-loop-analysis` included in `-Wall` (since removed in https://reviews.llvm.org/D73434). If `-Werror` is also specified, this will cause compilation to fail.