### PR TITLE
Fix SSA-rewrite to remove DebugDeclare for variables without loads

### DIFF
--- a/source/opt/ssa_rewrite_pass.cpp
+++ b/source/opt/ssa_rewrite_pass.cpp
@@ -624,11 +624,9 @@ Pass::Status SSARewritePass::Process() {
   for (auto& fn : *get_module()) {
     status =
         CombineStatus(status, SSARewriter(this).RewriteFunctionIntoSSA(&fn));
-    if (status == Status::SuccessWithChange) {
-      // Kill DebugDeclares for target variables.
-      for (auto var_id : seen_target_vars_) {
-        context()->get_debug_info_mgr()->KillDebugDeclares(var_id);
-      }
+    // Kill DebugDeclares for target variables.
+    for (auto var_id : seen_target_vars_) {
+      context()->get_debug_info_mgr()->KillDebugDeclares(var_id);
     }
     if (status == Status::Failure) {
       break;


### PR DESCRIPTION
Previously, the removal of DebugDeclares was predicated on the module "changing". In this case, "changing" actually meant loads being removed. This omitted the case where a variable had all its loads removed by a previous pass but still needed its DebugDeclare to be replaced with DebugValues by SSA-rewrite. The test case included in this PR gives further details.

This commit now has SSA-rewrite do  the DebugDeclare removal unconditionally. It appears that the purpose of the previous condition was just one of optimization, so it seems that its removal will not cause a functional problem. It is imagined that few functions will not require SSA-Rewrite, so few functions will suffer compile-time degradation from this change, and for those that do, the degradation will likely be nearly insignificant.