### PR TITLE
Add undef for inlined void function

### DIFF
--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -619,6 +619,14 @@ bool InlinePass::GenInlineCode(
     assert(resId != 0);
     AddLoad(calleeTypeId, resId, returnVarId, &new_blk_ptr,
             call_inst_itr->dbg_line_inst(), call_inst_itr->GetDebugScope());
+  } else {
+    // Even though it is very unlikely, it is possible that the result id of
+    // the void-function call is used, so we need to generate an instruction
+    // with that result id.
+    std::unique_ptr<Instruction> undef_inst(
+        new Instruction(context(), SpvOpUndef, call_inst_itr->type_id(),
+                        call_inst_itr->result_id(), {}));
+    new_blk_ptr->AddInstruction(std::move(undef_inst));
   }
 
   // Move instructions of original caller block after call instruction.

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -626,7 +626,7 @@ bool InlinePass::GenInlineCode(
     std::unique_ptr<Instruction> undef_inst(
         new Instruction(context(), SpvOpUndef, call_inst_itr->type_id(),
                         call_inst_itr->result_id(), {}));
-    new_blk_ptr->AddInstruction(std::move(undef_inst));
+    context()->AddGlobalValue(std::move(undef_inst));
   }
 
   // Move instructions of original caller block after call instruction.

--- a/test/opt/inline_opaque_test.cpp
+++ b/test/opt/inline_opaque_test.cpp
@@ -90,7 +90,8 @@ OpFunctionEnd
 )";
 
   const std::string after =
-      R"(%main = OpFunction %void None %12
+      R"(%34 = OpUndef %void
+%main = OpFunction %void None %12
 %28 = OpLabel
 %s0 = OpVariable %_ptr_Function_S_t Function
 %param = OpVariable %_ptr_Function_S_t Function
@@ -108,7 +109,6 @@ OpStore %param %33
 %45 = OpLoad %v2float %44
 %46 = OpImageSampleImplicitLod %v4float %43 %45
 OpStore %outColor %46
-%34 = OpUndef %void
 OpReturn
 OpFunctionEnd
 )";
@@ -290,7 +290,8 @@ OpFunctionEnd
 )";
 
   const std::string after =
-      R"(%main2 = OpFunction %void None %13
+      R"(%35 = OpUndef %void
+%main2 = OpFunction %void None %13
 %29 = OpLabel
 %s0 = OpVariable %_ptr_Function_S_t Function
 %param = OpVariable %_ptr_Function_S_t Function
@@ -308,7 +309,6 @@ OpStore %param %34
 %48 = OpLoad %v2float %47
 %49 = OpImageSampleImplicitLod %v4float %46 %48
 OpStore %outColor %49
-%35 = OpUndef %void
 OpReturn
 OpFunctionEnd
 )";

--- a/test/opt/inline_opaque_test.cpp
+++ b/test/opt/inline_opaque_test.cpp
@@ -108,6 +108,7 @@ OpStore %param %33
 %45 = OpLoad %v2float %44
 %46 = OpImageSampleImplicitLod %v4float %43 %45
 OpStore %outColor %46
+%34 = OpUndef %void
 OpReturn
 OpFunctionEnd
 )";
@@ -307,6 +308,7 @@ OpStore %param %34
 %48 = OpLoad %v2float %47
 %49 = OpImageSampleImplicitLod %v4float %46 %48
 OpStore %outColor %49
+%35 = OpUndef %void
 OpReturn
 OpFunctionEnd
 )";

--- a/test/opt/inline_test.cpp
+++ b/test/opt/inline_test.cpp
@@ -1545,9 +1545,9 @@ OpFunctionEnd
 
   const std::string undef = "%11 = OpUndef %void\n";
 
-  SinglePassRunAndCheck<InlineExhaustivePass>(predefs + nonEntryFuncs + before,
-                                              predefs + undef + nonEntryFuncs + after,
-                                              false, true);
+  SinglePassRunAndCheck<InlineExhaustivePass>(
+      predefs + nonEntryFuncs + before, predefs + undef + nonEntryFuncs + after,
+      false, true);
 }
 
 TEST_F(InlineTest, MultiBlockLoopHeaderCallsMultiBlockCallee) {
@@ -1623,9 +1623,9 @@ OpFunctionEnd
 )";
 
   const std::string undef = "%20 = OpUndef %void\n";
-  SinglePassRunAndCheck<InlineExhaustivePass>(predefs + nonEntryFuncs + before,
-                                              predefs + undef + nonEntryFuncs + after,
-                                              false, true);
+  SinglePassRunAndCheck<InlineExhaustivePass>(
+      predefs + nonEntryFuncs + before, predefs + undef + nonEntryFuncs + after,
+      false, true);
 }
 
 TEST_F(InlineTest, SingleBlockLoopCallsMultiBlockCalleeHavingSelectionMerge) {
@@ -1712,9 +1712,9 @@ OpReturn
 OpFunctionEnd
 )";
   const std::string undef = "%15 = OpUndef %void\n";
-  SinglePassRunAndCheck<InlineExhaustivePass>(predefs + nonEntryFuncs + before,
-                                              predefs + undef + nonEntryFuncs + after,
-                                              false, true);
+  SinglePassRunAndCheck<InlineExhaustivePass>(
+      predefs + nonEntryFuncs + before, predefs + undef + nonEntryFuncs + after,
+      false, true);
 }
 
 TEST_F(InlineTest,
@@ -1794,9 +1794,9 @@ OpFunctionEnd
 )";
 
   const std::string undef = "%20 = OpUndef %void\n";
-  SinglePassRunAndCheck<InlineExhaustivePass>(predefs + nonEntryFuncs + before,
-                                              predefs + undef + nonEntryFuncs + after,
-                                              false, true);
+  SinglePassRunAndCheck<InlineExhaustivePass>(
+      predefs + nonEntryFuncs + before, predefs + undef + nonEntryFuncs + after,
+      false, true);
 }
 
 TEST_F(InlineTest, NonInlinableCalleeWithSingleReturn) {

--- a/test/opt/inline_test.cpp
+++ b/test/opt/inline_test.cpp
@@ -381,6 +381,7 @@ TEST_F(InlineTest, InOutParameter) {
 
   const std::vector<const char*> after = {
       // clang-format off
+         "%26 = OpUndef %void",
        "%main = OpFunction %void None %11",
          "%23 = OpLabel",
           "%b = OpVariable %_ptr_Function_v4float Function",
@@ -397,7 +398,6 @@ TEST_F(InlineTest, InOutParameter) {
          "%44 = OpFAdd %float %41 %43",
          "%45 = OpAccessChain %_ptr_Function_float %param %uint_2",
                "OpStore %45 %44",
-         "%26 = OpUndef %void",
          "%27 = OpLoad %v4float %param",
                "OpStore %b %27",
          "%28 = OpAccessChain %_ptr_Function_float %b %uint_2",
@@ -1504,11 +1504,11 @@ OpSource OpenCL_C 120
 %bool = OpTypeBool
 %true = OpConstantTrue %bool
 %void = OpTypeVoid
+%5 = OpTypeFunction %void
 )";
 
   const std::string nonEntryFuncs =
-      R"(%5 = OpTypeFunction %void
-%6 = OpFunction %void None %5
+      R"(%6 = OpFunction %void None %5
 %7 = OpLabel
 OpBranch %8
 %8 = OpLabel
@@ -1537,15 +1537,16 @@ OpBranch %10
 OpLoopMerge %12 %10 None
 OpBranch %14
 %14 = OpLabel
-%11 = OpUndef %void
 OpBranchConditional %true %10 %12
 %12 = OpLabel
 OpReturn
 OpFunctionEnd
 )";
 
+  const std::string undef = "%11 = OpUndef %void\n";
+
   SinglePassRunAndCheck<InlineExhaustivePass>(predefs + nonEntryFuncs + before,
-                                              predefs + nonEntryFuncs + after,
+                                              predefs + undef + nonEntryFuncs + after,
                                               false, true);
 }
 
@@ -1611,7 +1612,6 @@ OpLoopMerge %22 %23 None
 OpBranch %27
 %27 = OpLabel
 %28 = OpCopyObject %int %int_2
-%20 = OpUndef %void
 %21 = OpCopyObject %int %int_4
 OpBranchConditional %true %23 %22
 %23 = OpLabel
@@ -1622,8 +1622,9 @@ OpReturn
 OpFunctionEnd
 )";
 
+  const std::string undef = "%20 = OpUndef %void\n";
   SinglePassRunAndCheck<InlineExhaustivePass>(predefs + nonEntryFuncs + before,
-                                              predefs + nonEntryFuncs + after,
+                                              predefs + undef + nonEntryFuncs + after,
                                               false, true);
 }
 
@@ -1705,15 +1706,14 @@ OpSelectionMerge %20 None
 OpBranchConditional %true %20 %20
 %20 = OpLabel
 %21 = OpPhi %bool %19 %17
-%15 = OpUndef %void
 OpBranchConditional %true %13 %16
 %16 = OpLabel
 OpReturn
 OpFunctionEnd
 )";
-
+  const std::string undef = "%15 = OpUndef %void\n";
   SinglePassRunAndCheck<InlineExhaustivePass>(predefs + nonEntryFuncs + before,
-                                              predefs + nonEntryFuncs + after,
+                                              predefs + undef + nonEntryFuncs + after,
                                               false, true);
 }
 
@@ -1783,7 +1783,6 @@ OpSelectionMerge %28 None
 OpBranchConditional %true %28 %28
 %28 = OpLabel
 %29 = OpCopyObject %int %int_2
-%20 = OpUndef %void
 %21 = OpCopyObject %int %int_4
 OpBranchConditional %true %23 %22
 %23 = OpLabel
@@ -1794,8 +1793,9 @@ OpReturn
 OpFunctionEnd
 )";
 
+  const std::string undef = "%20 = OpUndef %void\n";
   SinglePassRunAndCheck<InlineExhaustivePass>(predefs + nonEntryFuncs + before,
-                                              predefs + nonEntryFuncs + after,
+                                              predefs + undef + nonEntryFuncs + after,
                                               false, true);
 }
 
@@ -2169,13 +2169,13 @@ OpName %foo "foo"
 OpName %foo_entry "foo_entry"
 %void = OpTypeVoid
 %void_fn = OpTypeFunction %void
+%3 = OpUndef %void
 %foo = OpFunction %void None %void_fn
 %foo_entry = OpLabel
 OpReturn
 OpFunctionEnd
 %main = OpFunction %void None %void_fn
 %main_entry = OpLabel
-%3 = OpUndef %void
 OpReturn
 OpFunctionEnd
 )";
@@ -2443,11 +2443,11 @@ OpName %kill_ "kill("
 %3 = OpTypeFunction %void
 %bool = OpTypeBool
 %true = OpConstantTrue %bool
+%16 = OpUndef %void
 %main = OpFunction %void None %3
 %5 = OpLabel
 OpKill
 %18 = OpLabel
-%16 = OpUndef %void
 OpReturn
 OpFunctionEnd
 %kill_ = OpFunction %void None %3
@@ -2541,11 +2541,11 @@ OpName %kill_ "kill("
 %3 = OpTypeFunction %void
 %bool = OpTypeBool
 %true = OpConstantTrue %bool
+%16 = OpUndef %void
 %main = OpFunction %void None %3
 %5 = OpLabel
 OpTerminateInvocation
 %18 = OpLabel
-%16 = OpUndef %void
 OpReturn
 OpFunctionEnd
 %kill_ = OpFunction %void None %3
@@ -2769,6 +2769,7 @@ OpFunctionEnd
 %uint_0 = OpConstant %uint 0
 %false = OpConstantFalse %bool
 %_ptr_Function_bool = OpTypePointer Function %bool
+%11 = OpUndef %void
 %foo_ = OpFunction %void None %4
 %7 = OpLabel
 %18 = OpVariable %_ptr_Function_bool Function %false
@@ -2811,7 +2812,6 @@ OpBranch %24
 %23 = OpLabel
 OpBranch %22
 %24 = OpLabel
-%11 = OpUndef %void
 OpReturn
 OpFunctionEnd
 )";
@@ -3860,8 +3860,8 @@ OpFunctionEnd
 
 TEST_F(InlineTest, UsingVoidFunctionResult) {
   const std::string text = R"(
-; CHECK: OpFunction
 ; CHECK: [[undef:%\w+]] = OpUndef %void
+; CHECK: OpFunction
 ; CHECK: OpCopyObject %void [[undef]]
 ; CHECK: OpFunctionEnd
                OpCapability Shader


### PR DESCRIPTION
It is possible that the result of a void function call is used.  In case
it is used, we need something that still defines its id after inlining.
We add an undef for that purpose.

Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/3704