### PR TITLE
Handle DebugScope in compact-ids pass

### DIFF
--- a/source/opt/compact_ids_pass.cpp
+++ b/source/opt/compact_ids_pass.cpp
@@ -56,6 +56,17 @@ Pass::Status CompactIdsPass::Process() {
           }
           ++operand;
         }
+        if (inst->GetDebugScope().GetLexicalScope() != kNoDebugScope) {
+          auto it =
+              result_id_mapping.find(inst->GetDebugScope().GetLexicalScope());
+          if (it != result_id_mapping.end())
+            inst->UpdateLexicalScope(it->second);
+        }
+        if (inst->GetDebugInlinedAt() != kNoInlinedAt) {
+          auto it = result_id_mapping.find(inst->GetDebugInlinedAt());
+          if (it != result_id_mapping.end())
+            inst->UpdateDebugInlinedAt(it->second);
+        }
       },
       true);
 

--- a/source/opt/compact_ids_pass.cpp
+++ b/source/opt/compact_ids_pass.cpp
@@ -21,6 +21,22 @@
 
 namespace spvtools {
 namespace opt {
+namespace {
+
+uint32_t GetRemappedId(
+    std::unordered_map<uint32_t, uint32_t>* result_id_mapping, uint32_t id) {
+  auto it = result_id_mapping->find(id);
+  if (it == result_id_mapping->end()) {
+    const uint32_t new_id =
+        static_cast<uint32_t>(result_id_mapping->size()) + 1;
+    const auto insertion_result = result_id_mapping->emplace(id, new_id);
+    it = insertion_result.first;
+    assert(insertion_result.second);
+  }
+  return it->second;
+}
+
+}  // namespace
 
 Pass::Status CompactIdsPass::Process() {
   bool modified = false;
@@ -34,18 +50,10 @@ Pass::Status CompactIdsPass::Process() {
           if (spvIsIdType(type)) {
             assert(operand->words.size() == 1);
             uint32_t& id = operand->words[0];
-            auto it = result_id_mapping.find(id);
-            if (it == result_id_mapping.end()) {
-              const uint32_t new_id =
-                  static_cast<uint32_t>(result_id_mapping.size()) + 1;
-              const auto insertion_result =
-                  result_id_mapping.emplace(id, new_id);
-              it = insertion_result.first;
-              assert(insertion_result.second);
-            }
-            if (id != it->second) {
+            uint32_t new_id = GetRemappedId(&result_id_mapping, id);
+            if (id != new_id) {
               modified = true;
-              id = it->second;
+              id = new_id;
               // Update data cached in the instruction object.
               if (type == SPV_OPERAND_TYPE_RESULT_ID) {
                 inst->SetResultId(id);
@@ -56,16 +64,22 @@ Pass::Status CompactIdsPass::Process() {
           }
           ++operand;
         }
-        if (inst->GetDebugScope().GetLexicalScope() != kNoDebugScope) {
-          auto it =
-              result_id_mapping.find(inst->GetDebugScope().GetLexicalScope());
-          if (it != result_id_mapping.end())
-            inst->UpdateLexicalScope(it->second);
+
+        uint32_t scope_id = inst->GetDebugScope().GetLexicalScope();
+        if (scope_id != kNoDebugScope) {
+          uint32_t new_id = GetRemappedId(&result_id_mapping, scope_id);
+          if (scope_id != new_id) {
+            inst->UpdateLexicalScope(new_id);
+            modified = true;
+          }
         }
-        if (inst->GetDebugInlinedAt() != kNoInlinedAt) {
-          auto it = result_id_mapping.find(inst->GetDebugInlinedAt());
-          if (it != result_id_mapping.end())
-            inst->UpdateDebugInlinedAt(it->second);
+        uint32_t inlinedat_id = inst->GetDebugInlinedAt();
+        if (inlinedat_id != kNoInlinedAt) {
+          uint32_t new_id = GetRemappedId(&result_id_mapping, inlinedat_id);
+          if (inlinedat_id != new_id) {
+            inst->UpdateDebugInlinedAt(new_id);
+            modified = true;
+          }
         }
       },
       true);

--- a/source/opt/compact_ids_pass.cpp
+++ b/source/opt/compact_ids_pass.cpp
@@ -23,6 +23,8 @@ namespace spvtools {
 namespace opt {
 namespace {
 
+// Returns the remapped id of |id| from |result_id_mapping|. If the remapped
+// id does not exist, adds a new one to |result_id_mapping| and returns it.
 uint32_t GetRemappedId(
     std::unordered_map<uint32_t, uint32_t>* result_id_mapping, uint32_t id) {
   auto it = result_id_mapping->find(id);

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -305,6 +305,8 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   inline uint32_t GetDebugInlinedAt() const {
     return dbg_scope_.GetInlinedAt();
   }
+  // Updates lexical scope of DebugScope and OpLine.
+  inline void UpdateLexicalScope(uint32_t scope);
   // Updates OpLine and DebugScope based on the information of |from|.
   inline void UpdateDebugInfoFrom(const Instruction* from);
   // Remove the |index|-th operand
@@ -665,6 +667,13 @@ inline void Instruction::SetDebugScope(const DebugScope& scope) {
   dbg_scope_ = scope;
   for (auto& i : dbg_line_insts_) {
     i.dbg_scope_ = scope;
+  }
+}
+
+inline void Instruction::UpdateLexicalScope(uint32_t scope) {
+  dbg_scope_.SetLexicalScope(scope);
+  for (auto& i : dbg_line_insts_) {
+    i.dbg_scope_.SetLexicalScope(scope);
   }
 }
 


### PR DESCRIPTION
We have to update OpenCL.DebugInfo.100 DebugScope for instructions if we
change its lexical scope or DebugInlinedAt.