### PR TITLE
CCP should mark IR changed if it created new constants.

### DIFF
--- a/source/opt/ccp_pass.cpp
+++ b/source/opt/ccp_pass.cpp
@@ -135,6 +135,7 @@ SSAPropagator::PropStatus CCPPass::VisitAssignment(Instruction* instr) {
     }
     return it->second;
   };
+  uint32_t next_id = context()->module()->IdBound();
   Instruction* folded_inst =
       context()->get_instruction_folder().FoldInstructionToConstant(instr,
                                                                     map_func);
@@ -143,6 +144,14 @@ SSAPropagator::PropStatus CCPPass::VisitAssignment(Instruction* instr) {
     // instructions.  When folding we can only generate new constants.
     assert(folded_inst->IsConstant() && "CCP is only interested in constant.");
     values_[instr->result_id()] = folded_inst->result_id();
+
+    // If the folded instruction has just been created, its result ID will be
+    // larger than the previous ID bound. When this happens, we need to indicate
+    // that CCP has modified the IR, independently of whether the constant is
+    // actually propagated. See
+    // https://github.com/KhronosGroup/SPIRV-Tools/issues/3636 for details.
+    if (folded_inst->result_id() == next_id) created_new_constant_ = true;
+
     return SSAPropagator::kInteresting;
   }
 
@@ -266,16 +275,22 @@ SSAPropagator::PropStatus CCPPass::VisitInstruction(Instruction* instr,
 }
 
 bool CCPPass::ReplaceValues() {
-  bool retval = false;
+  // Even if we make no changes to the function's IR, propagation may have
+  // created new constants.  Even if those constants cannot be replaced in
+  // the IR, the constant definition itself is a change.  To reflect this,
+  // we initialize the IR changed indicator with the value of the
+  // created_new_constant_ indicator.  For an example, see the bug reported
+  // in https://github.com/KhronosGroup/SPIRV-Tools/issues/3636.
+  bool changed_ir = created_new_constant_;
   for (const auto& it : values_) {
     uint32_t id = it.first;
     uint32_t cst_id = it.second;
     if (!IsVaryingValue(cst_id) && id != cst_id) {
       context()->KillNamesAndDecorates(id);
-      retval |= context()->ReplaceAllUsesWith(id, cst_id);
+      changed_ir |= context()->ReplaceAllUsesWith(id, cst_id);
     }
   }
-  return retval;
+  return changed_ir;
 }
 
 bool CCPPass::PropagateConstants(Function* fp) {
@@ -313,6 +328,8 @@ void CCPPass::Initialize() {
       values_[inst.result_id()] = kVaryingSSAId;
     }
   }
+
+  created_new_constant_ = false;
 }
 
 Pass::Status CCPPass::Process() {

--- a/source/opt/ccp_pass.cpp
+++ b/source/opt/ccp_pass.cpp
@@ -145,8 +145,8 @@ SSAPropagator::PropStatus CCPPass::VisitAssignment(Instruction* instr) {
     assert(folded_inst->IsConstant() && "CCP is only interested in constant.");
     values_[instr->result_id()] = folded_inst->result_id();
 
-    // If the folded instruction has just been created, its result ID will be
-    // larger than the previous ID bound. When this happens, we need to indicate
+    // If the folded instruction has just been created, its result ID will
+    // match the previous ID bound. When this happens, we need to indicate
     // that CCP has modified the IR, independently of whether the constant is
     // actually propagated. See
     // https://github.com/KhronosGroup/SPIRV-Tools/issues/3636 for details.

--- a/source/opt/ccp_pass.h
+++ b/source/opt/ccp_pass.h
@@ -105,6 +105,9 @@ class CCPPass : public MemPass {
 
   // Propagator engine used.
   std::unique_ptr<SSAPropagator> propagator_;
+
+  // True if the pass created new constant instructions during propagation.
+  bool created_new_constant_;
 };
 
 }  // namespace opt

--- a/test/opt/ccp_test.cpp
+++ b/test/opt/ccp_test.cpp
@@ -598,6 +598,11 @@ OpExecutionMode %func OriginUpperLeft
 %int_ptr_Input = OpTypePointer Input %int
 %in = OpVariable %int_ptr_Input Input
 %undef = OpUndef %int
+
+; Although no constants are propagated in this function, the propagator
+; generates a new %true value while visiting conditional statements.
+; CHECK: %true = OpConstantTrue %bool
+
 %functy = OpTypeFunction %void
 %func = OpFunction %void None %functy
 %1 = OpLabel
@@ -639,8 +644,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  auto res = SinglePassRunToBinary<CCPPass>(text, true);
-  EXPECT_EQ(std::get<1>(res), Pass::Status::SuccessWithoutChange);
+  auto result = SinglePassRunAndMatch<CCPPass>(text, true);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
 }
 
 TEST_F(CCPTest, UndefInPhi) {
@@ -1054,6 +1059,50 @@ TEST_F(CCPTest, DebugFoldMultipleForSingleConstant) {
 )";
 
   SinglePassRunAndMatch<CCPPass>(text, true);
+}
+
+// Test from https://github.com/KhronosGroup/SPIRV-Tools/issues/3636
+TEST_F(CCPTest, CCPNoChangeFailure) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 320
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpConstant %6 2
+         %13 = OpConstant %6 4
+         %21 = OpConstant %6 1
+         %10 = OpTypeBool
+         %17 = OpTypePointer Function %6
+
+; CCP is generating two new constants during propagation that end up being
+; dead because they cannot be replaced anywhere in the IR.  CCP was wrongly
+; considering the IR to be unmodified because of this.
+; CHECK: %true = OpConstantTrue %bool
+; CHECK: %int_3 = OpConstant %int 3
+
+          %4 = OpFunction %2 None %3
+         %11 = OpLabel
+               OpBranch %5
+          %5 = OpLabel
+         %23 = OpPhi %6 %7 %11 %20 %15
+          %9 = OpSLessThan %10 %23 %13
+               OpLoopMerge %8 %15 None
+               OpBranchConditional %9 %15 %8
+         %15 = OpLabel
+         %20 = OpIAdd %6 %23 %21
+               OpBranch %5
+          %8 = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+
+  auto result = SinglePassRunAndMatch<CCPPass>(text, true);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
 }
 
 }  // namespace

--- a/test/opt/pass_fixture.h
+++ b/test/opt/pass_fixture.h
@@ -176,9 +176,11 @@ class PassTest : public TestT {
   // result, using checks parsed from |original|.  Always skips OpNop.
   // This does *not* involve pass manager.  Callers are suggested to use
   // SCOPED_TRACE() for better messages.
+  // Returns a tuple of disassembly string and the boolean value from the pass
+  // Process() function.
   template <typename PassT, typename... Args>
-  void SinglePassRunAndMatch(const std::string& original, bool do_validation,
-                             Args&&... args) {
+  std::tuple<std::string, Pass::Status> SinglePassRunAndMatch(
+      const std::string& original, bool do_validation, Args&&... args) {
     const bool skip_nop = true;
     auto pass_result = SinglePassRunAndDisassemble<PassT>(
         original, skip_nop, do_validation, std::forward<Args>(args)...);
@@ -187,6 +189,7 @@ class PassTest : public TestT {
     EXPECT_EQ(effcee::Result::Status::Ok, match_result.status())
         << match_result.message() << "\nChecking result:\n"
         << disassembly;
+    return pass_result;
   }
 
   // Runs a single pass of class |PassT| on the binary assembled from the


### PR DESCRIPTION
This fixes #3636.

When CCP is simulating statements, it will sometimes successfully fold
an instruction, which laters switches to varying.  The initial fold of
the instruction may generate a new constant K.

The problem we were running into is when K never gets propagated to the
IR.  Its definition will still exist, so CCP should mark the IR modified
in this case.

In fixing this bug, I noticed that an existing test was suffering from
the same bug.  The change also makes PassTest::SinglePassRunAndMatch()
return the result from the pass, so that we can check that the pass
marks the IR modified in this case.