### PR TITLE
spirv-fuzz: Overflow ids

### DIFF
--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -30,6 +30,7 @@ if(SPIRV_BUILD_FUZZER)
 
   set(SPIRV_TOOLS_FUZZ_SOURCES
         call_graph.h
+        counter_overflow_id_source.h
         data_descriptor.h
         equivalence_relation.h
         fact_manager/constant_uniform_facts.h
@@ -100,6 +101,7 @@ if(SPIRV_BUILD_FUZZER)
         id_use_descriptor.h
         instruction_descriptor.h
         instruction_message.h
+        overflow_id_source.h
         protobufs/spirvfuzz_protobufs.h
         pseudo_random_generator.h
         random_generator.h
@@ -180,6 +182,7 @@ if(SPIRV_BUILD_FUZZER)
         ${CMAKE_CURRENT_BINARY_DIR}/protobufs/spvtoolsfuzz.pb.h
 
         call_graph.cpp
+        counter_overflow_id_source.cpp
         data_descriptor.cpp
         fact_manager/constant_uniform_facts.cpp
         fact_manager/data_synonym_and_id_equation_facts.cpp
@@ -249,6 +252,7 @@ if(SPIRV_BUILD_FUZZER)
         id_use_descriptor.cpp
         instruction_descriptor.cpp
         instruction_message.cpp
+        overflow_id_source.cpp
         pseudo_random_generator.cpp
         random_generator.cpp
         replayer.cpp

--- a/source/fuzz/counter_overflow_id_source.cpp
+++ b/source/fuzz/counter_overflow_id_source.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/counter_overflow_id_source.h"
+
+namespace spvtools {
+namespace fuzz {
+
+CounterOverflowIdSource::CounterOverflowIdSource(uint32_t first_available_id)
+    : next_available_id_(first_available_id) {}
+
+bool CounterOverflowIdSource::HasOverflowIds() const { return true; }
+
+uint32_t CounterOverflowIdSource::GetNextOverflowId() {
+  return next_available_id_++;
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/counter_overflow_id_source.h
+++ b/source/fuzz/counter_overflow_id_source.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_COUNTER_OVERFLOW_ID_SOURCE_H_
+#define SOURCE_FUZZ_COUNTER_OVERFLOW_ID_SOURCE_H_
+
+#include "source/fuzz/overflow_id_source.h"
+
+namespace spvtools {
+namespace fuzz {
+
+// A source of overflow ids that uses a counter to provide successive ids from
+// a given starting value.
+class CounterOverflowIdSource : public OverflowIdSource {
+ public:
+  // |first_available_id| is the starting value for the counter.
+  explicit CounterOverflowIdSource(uint32_t first_available_id);
+
+  // Always returns true.
+  bool HasOverflowIds() const override;
+
+  // Returns the current counter value and increments the counter.
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/2541) We should
+  //  account for the case where the maximum allowed id is reached.
+  uint32_t GetNextOverflowId() override;
+
+ private:
+  uint32_t next_available_id_;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_OVERFLOW_ID_SOURCE_COUNTER_H_

--- a/source/fuzz/overflow_id_source.cpp
+++ b/source/fuzz/overflow_id_source.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/overflow_id_source.h"
+
+namespace spvtools {
+namespace fuzz {
+
+OverflowIdSource::~OverflowIdSource() = default;
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/overflow_id_source.h
+++ b/source/fuzz/overflow_id_source.h
@@ -1,0 +1,106 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_OVERFLOW_ID_SOURCE_H_
+#define SOURCE_FUZZ_OVERFLOW_ID_SOURCE_H_
+
+#include <cstdint>
+
+namespace spvtools {
+namespace fuzz {
+
+// An implementation of this interface can be used to provide fresh ids on
+// demand when applying a transformation.
+//
+// During fuzzing this should never be required: a fuzzer pass should determine
+// all the fresh ids it requires to apply a transformation.
+//
+// However, during shrinking we can have the situation where, after removing
+// an early transformation, a later transformation needs more ids.
+//
+// As an example, suppose a SPIR-V function originally has this form:
+//
+// main() {
+//   stmt1;
+//   stmt2;
+//   stmt3;
+//   stmt4;
+// }
+//
+// Now suppose two *outlining* transformations are applied.  The first
+// transformation, T1, outlines "stmt1; stmt2;" into a function foo, giving us:
+//
+// foo() {
+//   stmt1;
+//   stmt2;
+// }
+//
+// main() {
+//   foo();
+//   stmt3;
+//   stmt4;
+// }
+//
+// The second transformation, T2, outlines "foo(); stmt3;" from main into a
+// function bar, giving us:
+//
+// foo() {
+//   stmt1;
+//   stmt2;
+// }
+//
+// bar() {
+//   foo();
+//   stmt3;
+// }
+//
+// main() {
+//   bar();
+//   stmt4;
+// }
+//
+// Suppose that T2 used a set of fresh ids, FRESH, in order to perform its
+// outlining.
+//
+// Now suppose that during shrinking we remove T1, but still want to apply T2.
+// The fresh ids used by T2 - FRESH - are sufficient to outline "foo(); stmt3;".
+// However, because we did not apply T1, "foo();" does not exist and instead the
+// task of T2 is to outline "stmt1; stmt2; stmt3;".  The set FRESH contains
+// *some* of the fresh ids required to do this (those for "stmt3;"), but not all
+// of them (those for "stmt1; stmt2;" are missing).
+//
+// A source of overflow ids can be used to allow the shrinker to proceed
+// nevertheless.
+//
+// It is desirable to use overflow ids only when needed.  In our worked example,
+// T2 should still use the ids from FRESH when handling "stmt3;", because later
+// transformations might refer to those ids and will become inapplicable if
+// overflow ids are used instead.
+class OverflowIdSource {
+ public:
+  virtual ~OverflowIdSource();
+
+  // Returns true if and only if this source is capable of providing overflow
+  // ids.
+  virtual bool HasOverflowIds() const = 0;
+
+  // Precondition: HasOverflowIds() must hold.  Returns the next available
+  // overflow id.
+  virtual uint32_t GetNextOverflowId() = 0;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_OVERFLOW_ID_SOURCE_H_

--- a/source/fuzz/replayer.cpp
+++ b/source/fuzz/replayer.cpp
@@ -14,8 +14,10 @@
 
 #include "source/fuzz/replayer.h"
 
+#include <memory>
 #include <utility>
 
+#include "source/fuzz/counter_overflow_id_source.h"
 #include "source/fuzz/fact_manager/fact_manager.h"
 #include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
 #include "source/fuzz/transformation.h"
@@ -54,7 +56,8 @@ Replayer::ReplayerResultStatus Replayer::Run(
     const std::vector<uint32_t>& binary_in,
     const protobufs::FactSequence& initial_facts,
     const protobufs::TransformationSequence& transformation_sequence_in,
-    uint32_t num_transformations_to_apply, std::vector<uint32_t>* binary_out,
+    uint32_t num_transformations_to_apply, uint32_t first_overflow_id,
+    std::vector<uint32_t>* binary_out,
     protobufs::TransformationSequence* transformation_sequence_out) const {
   // Check compatibility between the library version being linked with and the
   // header files being used.
@@ -97,8 +100,13 @@ Replayer::ReplayerResultStatus Replayer::Run(
 
   FactManager fact_manager;
   fact_manager.AddFacts(impl_->consumer, initial_facts, ir_context.get());
-  TransformationContext transformation_context(&fact_manager,
-                                               impl_->validator_options);
+  std::unique_ptr<TransformationContext> transformation_context =
+      first_overflow_id == 0
+          ? MakeUnique<TransformationContext>(&fact_manager,
+                                              impl_->validator_options)
+          : MakeUnique<TransformationContext>(
+                &fact_manager, impl_->validator_options,
+                MakeUnique<CounterOverflowIdSource>(first_overflow_id));
 
   // Consider the transformation proto messages in turn.
   uint32_t counter = 0;
@@ -112,10 +120,10 @@ Replayer::ReplayerResultStatus Replayer::Run(
 
     // Check whether the transformation can be applied.
     if (transformation->IsApplicable(ir_context.get(),
-                                     transformation_context)) {
+                                     *transformation_context)) {
       // The transformation is applicable, so apply it, and copy it to the
       // sequence of transformations that were applied.
-      transformation->Apply(ir_context.get(), &transformation_context);
+      transformation->Apply(ir_context.get(), transformation_context.get());
       *transformation_sequence_out->add_transformation() = message;
 
       if (impl_->validate_during_replay) {

--- a/source/fuzz/replayer.h
+++ b/source/fuzz/replayer.h
@@ -55,15 +55,24 @@ class Replayer {
 
   // Transforms |binary_in| to |binary_out| by attempting to apply the first
   // |num_transformations_to_apply| transformations from
-  // |transformation_sequence_in|.  Initial facts about the input binary and the
-  // context in which it will execute are provided via |initial_facts|.  The
-  // transformations that were successfully applied are returned via
+  // |transformation_sequence_in|.
+  //
+  // Initial facts about the input binary and the context in which it will
+  // execute are provided via |initial_facts|.
+  //
+  // |first_overflow_id| should be set to 0 if overflow ids are not available
+  // during replay.  Otherwise |first_overflow_id| must be larger than any id
+  // referred to in |binary_in| or |transformation_sequence_in|, and overflow
+  // ids will be available during replay starting from this value.
+  //
+  // The transformations that were successfully applied are returned via
   // |transformation_sequence_out|.
   ReplayerResultStatus Run(
       const std::vector<uint32_t>& binary_in,
       const protobufs::FactSequence& initial_facts,
       const protobufs::TransformationSequence& transformation_sequence_in,
-      uint32_t num_transformations_to_apply, std::vector<uint32_t>* binary_out,
+      uint32_t num_transformations_to_apply, uint32_t first_overflow_id,
+      std::vector<uint32_t>* binary_out,
       protobufs::TransformationSequence* transformation_sequence_out) const;
 
  private:

--- a/source/fuzz/shrinker.cpp
+++ b/source/fuzz/shrinker.cpp
@@ -18,6 +18,8 @@
 
 #include "source/fuzz/pseudo_random_generator.h"
 #include "source/fuzz/replayer.h"
+#include "source/opt/build_module.h"
+#include "source/opt/ir_context.h"
 #include "source/spirv_fuzzer_options.h"
 #include "source/util/make_unique.h"
 
@@ -67,6 +69,10 @@ struct Shrinker::Impl {
         validate_during_replay(validate),
         validator_options(options) {}
 
+  // Returns the id bound for the given SPIR-V binary, which is assumed to be
+  // valid.
+  uint32_t GetIdBound(const std::vector<uint32_t>& binary);
+
   const spv_target_env target_env;          // Target environment.
   MessageConsumer consumer;                 // Message consumer.
   const uint32_t step_limit;                // Step limit for reductions.
@@ -75,6 +81,14 @@ struct Shrinker::Impl {
                                             // transformations.
   spv_validator_options validator_options;  // Options to control validation.
 };
+
+uint32_t Shrinker::Impl::GetIdBound(const std::vector<uint32_t>& binary) {
+  // Build the module from the input binary.
+  std::unique_ptr<opt::IRContext> ir_context =
+      BuildModule(target_env, consumer, binary.data(), binary.size());
+  assert(ir_context && "Error building module.");
+  return ir_context->module()->id_bound();
+}
 
 Shrinker::Shrinker(spv_target_env env, uint32_t step_limit,
                    bool validate_during_replay,
@@ -99,7 +113,7 @@ Shrinker::ShrinkerResultStatus Shrinker::Run(
   // header files being used.
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
-  spvtools::SpirvTools tools(impl_->target_env);
+  SpirvTools tools(impl_->target_env);
   if (!tools.IsValid()) {
     impl_->consumer(SPV_MSG_ERROR, nullptr, {},
                     "Failed to create SPIRV-Tools interface; stopping.");
@@ -127,7 +141,8 @@ Shrinker::ShrinkerResultStatus Shrinker::Run(
   if (replayer.Run(binary_in, initial_facts, transformation_sequence_in,
                    static_cast<uint32_t>(
                        transformation_sequence_in.transformation_size()),
-                   &current_best_binary, &current_best_transformations) !=
+                   /* No overflow ids */ 0, &current_best_binary,
+                   &current_best_transformations) !=
       Replayer::ReplayerResultStatus::kComplete) {
     return ShrinkerResultStatus::kReplayFailed;
   }
@@ -139,6 +154,10 @@ Shrinker::ShrinkerResultStatus Shrinker::Run(
                     "Initial binary is not interesting; stopping.");
     return ShrinkerResultStatus::kInitialBinaryNotInteresting;
   }
+
+  // The largest id used by the module before any shrinking has been applied
+  // serves as the first id that can be used for overflow purposes.
+  const uint32_t first_overflow_id = impl_->GetIdBound(current_best_binary);
 
   uint32_t attempt = 0;  // Keeps track of the number of shrink attempts that
                          // have been tried, whether successful or not.
@@ -201,7 +220,7 @@ Shrinker::ShrinkerResultStatus Shrinker::Run(
               binary_in, initial_facts, transformations_with_chunk_removed,
               static_cast<uint32_t>(
                   transformations_with_chunk_removed.transformation_size()),
-              &next_binary, &next_transformation_sequence) !=
+              first_overflow_id, &next_binary, &next_transformation_sequence) !=
           Replayer::ReplayerResultStatus::kComplete) {
         // Replay should not fail; if it does, we need to abort shrinking.
         return ShrinkerResultStatus::kReplayFailed;

--- a/source/fuzz/shrinker.cpp
+++ b/source/fuzz/shrinker.cpp
@@ -158,6 +158,8 @@ Shrinker::ShrinkerResultStatus Shrinker::Run(
   // The largest id used by the module before any shrinking has been applied
   // serves as the first id that can be used for overflow purposes.
   const uint32_t first_overflow_id = impl_->GetIdBound(current_best_binary);
+  assert(first_overflow_id >= impl_->GetIdBound(binary_in) &&
+         "Applying transformations should only increase a module's id bound.");
 
   uint32_t attempt = 0;  // Keeps track of the number of shrink attempts that
                          // have been tried, whether successful or not.

--- a/source/fuzz/transformation_context.h
+++ b/source/fuzz/transformation_context.h
@@ -15,7 +15,10 @@
 #ifndef SOURCE_FUZZ_TRANSFORMATION_CONTEXT_H_
 #define SOURCE_FUZZ_TRANSFORMATION_CONTEXT_H_
 
+#include <memory>
+
 #include "source/fuzz/fact_manager/fact_manager.h"
+#include "source/fuzz/overflow_id_source.h"
 #include "spirv-tools/libspirv.hpp"
 
 namespace spvtools {
@@ -26,15 +29,28 @@ namespace fuzz {
 class TransformationContext {
  public:
   // Constructs a transformation context with a given fact manager and validator
-  // options.
+  // options.  Overflow ids are not available from a transformation context
+  // constructed in this way.
   TransformationContext(FactManager* fact_manager,
                         spv_validator_options validator_options);
+
+  // Constructs a transformation context with a given fact manager, validator
+  // options and overflow id source.
+  TransformationContext(FactManager* fact_manager,
+                        spv_validator_options validator_options,
+                        std::unique_ptr<OverflowIdSource> overflow_id_source);
 
   ~TransformationContext();
 
   FactManager* GetFactManager() { return fact_manager_; }
 
   const FactManager* GetFactManager() const { return fact_manager_; }
+
+  OverflowIdSource* GetOverflowIdSource() { return overflow_id_source_.get(); }
+
+  const OverflowIdSource* GetOverflowIdSource() const {
+    return overflow_id_source_.get();
+  }
 
   spv_validator_options GetValidatorOptions() const {
     return validator_options_;
@@ -48,6 +64,8 @@ class TransformationContext {
   // Options to control validation when deciding whether transformations can be
   // applied.
   spv_validator_options validator_options_;
+
+  std::unique_ptr<OverflowIdSource> overflow_id_source_;
 };
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_outline_function.cpp
+++ b/source/fuzz/transformation_outline_function.cpp
@@ -48,7 +48,8 @@ TransformationOutlineFunction::TransformationOutlineFunction(
 }
 
 bool TransformationOutlineFunction::IsApplicable(
-    opt::IRContext* ir_context, const TransformationContext& /*unused*/) const {
+    opt::IRContext* ir_context,
+    const TransformationContext& transformation_context) const {
   std::set<uint32_t> ids_used_by_this_transformation;
 
   // The various new ids used by the transformation must be fresh and distinct.
@@ -234,8 +235,9 @@ bool TransformationOutlineFunction::IsApplicable(
       fuzzerutil::RepeatedUInt32PairToMap(message_.input_id_to_fresh_id());
   for (auto id : GetRegionInputIds(ir_context, region_set, exit_block)) {
     // There needs to be a corresponding fresh id to be used as a function
-    // parameter.
-    if (input_id_to_fresh_id_map.count(id) == 0) {
+    // parameter, or overflow ids need to be available.
+    if (input_id_to_fresh_id_map.count(id) == 0 &&
+        !transformation_context.GetOverflowIdSource()->HasOverflowIds()) {
       return false;
     }
     // Furthermore, if the input id has pointer type it must be an OpVariable
@@ -263,8 +265,10 @@ bool TransformationOutlineFunction::IsApplicable(
   for (auto id : GetRegionOutputIds(ir_context, region_set, exit_block)) {
     if (
         // ... there needs to be a corresponding fresh id that can hold the
-        // value for this id computed in the outlined function, and ...
-        output_id_to_fresh_id_map.count(id) == 0
+        // value for this id computed in the outlined function (or overflow ids
+        // must be available), and ...
+        (output_id_to_fresh_id_map.count(id) == 0 &&
+         !transformation_context.GetOverflowIdSource()->HasOverflowIds())
         // ... the output id must not have pointer type (to avoid creating a
         // struct with pointer members to pass data out of the outlined
         // function)
@@ -305,6 +309,23 @@ void TransformationOutlineFunction::Apply(
       fuzzerutil::RepeatedUInt32PairToMap(message_.input_id_to_fresh_id());
   auto output_id_to_fresh_id_map =
       fuzzerutil::RepeatedUInt32PairToMap(message_.output_id_to_fresh_id());
+
+  // Use overflow ids to augment these maps at any locations where fresh ids are
+  // required but not provided.
+  for (uint32_t id : region_input_ids) {
+    if (input_id_to_fresh_id_map.count(id) == 0) {
+      input_id_to_fresh_id_map.insert(
+          {id,
+           transformation_context->GetOverflowIdSource()->GetNextOverflowId()});
+    }
+  }
+  for (uint32_t id : region_output_ids) {
+    if (output_id_to_fresh_id_map.count(id) == 0) {
+      output_id_to_fresh_id_map.insert(
+          {id,
+           transformation_context->GetOverflowIdSource()->GetNextOverflowId()});
+    }
+  }
 
   UpdateModuleIdBoundForFreshIds(ir_context, input_id_to_fresh_id_map,
                                  output_id_to_fresh_id_map);
@@ -609,18 +630,23 @@ TransformationOutlineFunction::PrepareFunctionPrototype(
                 {function_type_id}}})));
 
   // Add one parameter to the function for each input id, using the fresh ids
-  // provided in |input_id_to_fresh_id_map|.
+  // provided in |input_id_to_fresh_id_map|, or overflow ids if needed.
   for (auto id : region_input_ids) {
+    uint32_t fresh_id = input_id_to_fresh_id_map.count(id)
+                            ? input_id_to_fresh_id_map.at(id)
+                            : transformation_context->GetOverflowIdSource()
+                                  ->GetNextOverflowId();
+
     outlined_function->AddParameter(MakeUnique<opt::Instruction>(
         ir_context, SpvOpFunctionParameter,
-        ir_context->get_def_use_mgr()->GetDef(id)->type_id(),
-        input_id_to_fresh_id_map.at(id), opt::Instruction::OperandList()));
+        ir_context->get_def_use_mgr()->GetDef(id)->type_id(), fresh_id,
+        opt::Instruction::OperandList()));
     // If the input id is an irrelevant-valued variable, the same should be true
     // of the corresponding parameter.
     if (transformation_context->GetFactManager()->PointeeValueIsIrrelevant(
             id)) {
       transformation_context->GetFactManager()
-          ->AddFactValueOfPointeeIsIrrelevant(input_id_to_fresh_id_map.at(id));
+          ->AddFactValueOfPointeeIsIrrelevant(fresh_id);
     }
   }
 

--- a/source/fuzz/transformation_outline_function.cpp
+++ b/source/fuzz/transformation_outline_function.cpp
@@ -632,21 +632,16 @@ TransformationOutlineFunction::PrepareFunctionPrototype(
   // Add one parameter to the function for each input id, using the fresh ids
   // provided in |input_id_to_fresh_id_map|, or overflow ids if needed.
   for (auto id : region_input_ids) {
-    uint32_t fresh_id = input_id_to_fresh_id_map.count(id)
-                            ? input_id_to_fresh_id_map.at(id)
-                            : transformation_context->GetOverflowIdSource()
-                                  ->GetNextOverflowId();
-
     outlined_function->AddParameter(MakeUnique<opt::Instruction>(
         ir_context, SpvOpFunctionParameter,
-        ir_context->get_def_use_mgr()->GetDef(id)->type_id(), fresh_id,
-        opt::Instruction::OperandList()));
+        ir_context->get_def_use_mgr()->GetDef(id)->type_id(),
+        input_id_to_fresh_id_map.at(id), opt::Instruction::OperandList()));
     // If the input id is an irrelevant-valued variable, the same should be true
     // of the corresponding parameter.
     if (transformation_context->GetFactManager()->PointeeValueIsIrrelevant(
             id)) {
       transformation_context->GetFactManager()
-          ->AddFactValueOfPointeeIsIrrelevant(fresh_id);
+          ->AddFactValueOfPointeeIsIrrelevant(input_id_to_fresh_id_map.at(id));
     }
   }
 

--- a/test/fuzz/fuzzer_replayer_test.cpp
+++ b/test/fuzz/fuzzer_replayer_test.cpp
@@ -1661,7 +1661,7 @@ void RunFuzzerAndReplayer(const std::string& shader,
         binary_in, initial_facts, fuzzer_transformation_sequence_out,
         static_cast<uint32_t>(
             fuzzer_transformation_sequence_out.transformation_size()),
-        &replayer_binary_out, &replayer_transformation_sequence_out);
+        0, &replayer_binary_out, &replayer_transformation_sequence_out);
     ASSERT_EQ(Replayer::ReplayerResultStatus::kComplete,
               replayer_result_status);
 

--- a/test/fuzz/replayer_test.cpp
+++ b/test/fuzz/replayer_test.cpp
@@ -95,8 +95,8 @@ TEST(ReplayerTest, PartialReplay) {
     Replayer replayer(env, true, validator_options);
     replayer.SetMessageConsumer(kSilentConsumer);
     auto replayer_result_status =
-        replayer.Run(binary_in, empty_facts, transformations, 11, &binary_out,
-                     &transformations_out);
+        replayer.Run(binary_in, empty_facts, transformations, 11, 0,
+                     &binary_out, &transformations_out);
     // Replay should succeed.
     ASSERT_EQ(Replayer::ReplayerResultStatus::kComplete,
               replayer_result_status);
@@ -183,7 +183,7 @@ TEST(ReplayerTest, PartialReplay) {
     Replayer replayer(env, true, validator_options);
     replayer.SetMessageConsumer(kSilentConsumer);
     auto replayer_result_status =
-        replayer.Run(binary_in, empty_facts, transformations, 5, &binary_out,
+        replayer.Run(binary_in, empty_facts, transformations, 5, 0, &binary_out,
                      &transformations_out);
     // Replay should succeed.
     ASSERT_EQ(Replayer::ReplayerResultStatus::kComplete,
@@ -263,7 +263,7 @@ TEST(ReplayerTest, PartialReplay) {
     Replayer replayer(env, true, validator_options);
     replayer.SetMessageConsumer(kSilentConsumer);
     auto replayer_result_status =
-        replayer.Run(binary_in, empty_facts, transformations, 0, &binary_out,
+        replayer.Run(binary_in, empty_facts, transformations, 0, 0, &binary_out,
                      &transformations_out);
     // Replay should succeed.
     ASSERT_EQ(Replayer::ReplayerResultStatus::kComplete,
@@ -283,8 +283,8 @@ TEST(ReplayerTest, PartialReplay) {
     Replayer replayer(env, true, validator_options);
     replayer.SetMessageConsumer(kSilentConsumer);
     auto replayer_result_status =
-        replayer.Run(binary_in, empty_facts, transformations, 12, &binary_out,
-                     &transformations_out);
+        replayer.Run(binary_in, empty_facts, transformations, 12, 0,
+                     &binary_out, &transformations_out);
 
     // Replay should not succeed.
     ASSERT_EQ(Replayer::ReplayerResultStatus::kTooManyTransformationsRequested,

--- a/tools/fuzz/fuzz.cpp
+++ b/tools/fuzz/fuzz.cpp
@@ -428,7 +428,7 @@ bool Replay(const spv_target_env& target_env,
 
   auto replay_result_status = replayer.Run(
       binary_in, initial_facts, transformation_sequence,
-      num_transformations_to_apply, binary_out, transformations_applied);
+      num_transformations_to_apply, 0, binary_out, transformations_applied);
   return !(replay_result_status !=
            spvtools::fuzz::Replayer::ReplayerResultStatus::kComplete);
 }


### PR DESCRIPTION
This change adds the notion of "overflow ids", which can be used
during shrinking to facilitate applying transformations that would
otherwise have become inapplicable due to earlier transformations
being removed.