### PR TITLE
spirv-fuzz: Handle invalid ids in fact manager

### DIFF
--- a/source/fuzz/fact_manager/data_synonym_and_id_equation_facts.cpp
+++ b/source/fuzz/fact_manager/data_synonym_and_id_equation_facts.cpp
@@ -274,14 +274,9 @@ void DataSynonymAndIdEquationFacts::ComputeConversionDataSynonymFacts(
   assert(synonymous_.Exists(dd) &&
          "|dd| should've been registered in the equivalence relation");
 
-  const auto* representative = synonymous_.Find(&dd);
-  assert(representative &&
-         "Representative can't be null for a registered descriptor");
-
   const auto* type =
       context->get_type_mgr()->GetType(fuzzerutil::WalkCompositeTypeIndices(
-          context, fuzzerutil::GetTypeId(context, representative->object()),
-          representative->index()));
+          context, fuzzerutil::GetTypeId(context, dd.object()), dd.index()));
   assert(type && "Data descriptor has invalid type");
 
   if ((type->AsVector() && type->AsVector()->element_type()->AsInteger()) ||
@@ -293,8 +288,13 @@ void DataSynonymAndIdEquationFacts::ComputeConversionDataSynonymFacts(
     std::vector<const protobufs::DataDescriptor*> convert_u_to_f_lhs;
 
     for (const auto& fact : id_equations_) {
+      if (!context->get_def_use_mgr()->GetDef(fact.first->object())) {
+        // Skip non-existent instructions.
+        continue;
+      }
+
       for (const auto& equation : fact.second) {
-        if (synonymous_.IsEquivalent(*equation.operands[0], *representative)) {
+        if (synonymous_.IsEquivalent(*equation.operands[0], dd)) {
           if (equation.opcode == SpvOpConvertSToF) {
             convert_s_to_f_lhs.push_back(fact.first);
           } else if (equation.opcode == SpvOpConvertUToF) {
@@ -304,13 +304,14 @@ void DataSynonymAndIdEquationFacts::ComputeConversionDataSynonymFacts(
       }
     }
 
-    for (const auto& synonyms :
-         {std::move(convert_s_to_f_lhs), std::move(convert_u_to_f_lhs)}) {
-      for (const auto* synonym_a : synonyms) {
-        for (const auto* synonym_b : synonyms) {
-          if (!synonymous_.IsEquivalent(*synonym_a, *synonym_b) &&
-              DataDescriptorsAreWellFormedAndComparable(context, *synonym_a,
-                                                        *synonym_b)) {
+    // We use pointers in the initializer list here since otherwise we would
+    // copy memory from these vectors.
+    for (const auto* synonyms : {&convert_s_to_f_lhs, &convert_u_to_f_lhs}) {
+      for (const auto* synonym_a : *synonyms) {
+        for (const auto* synonym_b : *synonyms) {
+          // DataDescriptorsAreWellFormedAndComparable will be called in the
+          // AddDataSynonymFactRecursive method.
+          if (!synonymous_.IsEquivalent(*synonym_a, *synonym_b)) {
             // |synonym_a| and |synonym_b| have compatible types - they are
             // synonymous.
             AddDataSynonymFactRecursive(*synonym_a, *synonym_b, context);
@@ -758,12 +759,14 @@ DataSynonymAndIdEquationFacts::RegisterDataDescriptor(
 bool DataSynonymAndIdEquationFacts::DataDescriptorsAreWellFormedAndComparable(
     opt::IRContext* context, const protobufs::DataDescriptor& dd1,
     const protobufs::DataDescriptor& dd2) {
+  assert(context->get_def_use_mgr()->GetDef(dd1.object()) &&
+         context->get_def_use_mgr()->GetDef(dd2.object()) &&
+         "Both descriptors must exist in the module");
+
   auto end_type_id_1 = fuzzerutil::WalkCompositeTypeIndices(
-      context, context->get_def_use_mgr()->GetDef(dd1.object())->type_id(),
-      dd1.index());
+      context, fuzzerutil::GetTypeId(context, dd1.object()), dd1.index());
   auto end_type_id_2 = fuzzerutil::WalkCompositeTypeIndices(
-      context, context->get_def_use_mgr()->GetDef(dd2.object())->type_id(),
-      dd2.index());
+      context, fuzzerutil::GetTypeId(context, dd2.object()), dd2.index());
   // The end types of the data descriptors must exist.
   if (end_type_id_1 == 0 || end_type_id_2 == 0) {
     return false;

--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -572,7 +572,9 @@ bool InstructionIsFunctionParameter(opt::Instruction* instruction,
 }
 
 uint32_t GetTypeId(opt::IRContext* context, uint32_t result_id) {
-  return context->get_def_use_mgr()->GetDef(result_id)->type_id();
+  const auto* inst = context->get_def_use_mgr()->GetDef(result_id);
+  assert(inst && "|result_id| is invalid");
+  return inst->type_id();
 }
 
 uint32_t GetPointeeTypeIdFromPointerType(opt::Instruction* pointer_type_inst) {


### PR DESCRIPTION
Fixes #3741.

This PR fixes two bugs:
1. Segfault in https://github.com/KhronosGroup/SPIRV-Tools/blob/4c239bd81bf79337e4a0cfe1c9da9caf1b25108a/source/fuzz/fuzzer_util.cpp#L574-L576 when `result_id` doesn't exist in the module. The bug is triggered in https://github.com/KhronosGroup/SPIRV-Tools/blob/4c239bd81bf79337e4a0cfe1c9da9caf1b25108a/source/fuzz/fact_manager/data_synonym_and_id_equation_facts.cpp#L290 when `representative->object()` doesn't exist in the module. This can happen in certain cases if we apply `TransformationMergeBlocks` first.
2. Segfault in either https://github.com/KhronosGroup/SPIRV-Tools/blob/4c239bd81bf79337e4a0cfe1c9da9caf1b25108a/source/fuzz/fact_manager/data_synonym_and_id_equation_facts.cpp#L769 or https://github.com/KhronosGroup/SPIRV-Tools/blob/4c239bd81bf79337e4a0cfe1c9da9caf1b25108a/source/fuzz/fact_manager/data_synonym_and_id_equation_facts.cpp#L772 happens if either `dd1.object()` or `dd2.object()` doesn't exist in the module. This can happen when `AddDataSynonymFactRecursive` is called recursively from `ComputeConversionDataSynonymFacts`. This bug is described in #3741.