### PR TITLE
Fix DebugNoScope to not output InlinedAt operand.

### DIFF
--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -921,8 +921,10 @@ void DebugScope::ToBinary(uint32_t type_id, uint32_t result_id,
       static_cast<uint32_t>(dbg_opcode),
   };
   binary->insert(binary->end(), operands.begin(), operands.end());
-  if (GetLexicalScope() != kNoDebugScope) binary->push_back(GetLexicalScope());
-  if (GetInlinedAt() != kNoInlinedAt) binary->push_back(GetInlinedAt());
+  if (GetLexicalScope() != kNoDebugScope) {
+    binary->push_back(GetLexicalScope());
+    if (GetInlinedAt() != kNoInlinedAt) binary->push_back(GetInlinedAt());
+  }
 }
 
 }  // namespace opt


### PR DESCRIPTION
This problem was seen as part of https://github.com/KhronosGroup/SPIRV-Tools/issues/3743 although it does not fix this issue, so the issue will stay open.

Essentially, the logic for outputting DebugNoScope was printing an InlinedAt operand when "available", which is not valid. This prevents this from happening.

The extra operand at the end of DebugNoScope created the appearance of an instruction with zero words which confused validation.
