### PR TITLE
spirv-opt: Add function to compute loop nesting depth of a block in StructuredCFGAnalysis

### DIFF
--- a/source/opt/struct_cfg_analysis.cpp
+++ b/source/opt/struct_cfg_analysis.cpp
@@ -150,6 +150,19 @@ uint32_t StructuredCFGAnalysis::LoopContinueBlock(uint32_t bb_id) {
   return merge_inst->GetSingleWordInOperand(kContinueNodeIndex);
 }
 
+uint32_t StructuredCFGAnalysis::LoopNestingDepth(uint32_t bb_id) {
+  uint32_t result = 0;
+
+  // Find the merge block of the current loop as long as the block is inside a
+  // loop, exiting a loop for each iteration.
+  for (uint32_t merge_block_id = LoopMergeBlock(bb_id); merge_block_id != 0;
+       merge_block_id = LoopMergeBlock(merge_block_id)) {
+    result++;
+  }
+
+  return result;
+}
+
 uint32_t StructuredCFGAnalysis::SwitchMergeBlock(uint32_t bb_id) {
   uint32_t header_id = ContainingSwitch(bb_id);
   if (header_id == 0) {

--- a/source/opt/struct_cfg_analysis.h
+++ b/source/opt/struct_cfg_analysis.h
@@ -74,6 +74,13 @@ class StructuredCFGAnalysis {
   // construct.
   uint32_t LoopContinueBlock(uint32_t bb_id);
 
+  // Returns the loop nesting depth of |bb_id| within its function, i.e. the
+  // number of loop constructs in which |bb_id| is contained. As per other
+  // functions in StructuredCFGAnalysis, a loop header is not regarded as being
+  // part of the loop that it heads, so that e.g. the nesting depth of an
+  // outer-most loop header is 0.
+  uint32_t LoopNestingDepth(uint32_t bb_id);
+
   // Returns the id of the header of the innermost switch construct
   // that contains |bb_id| as long as there is no intervening loop.  Returns |0|
   // if no such construct exists.

--- a/test/opt/struct_cfg_analysis_test.cpp
+++ b/test/opt/struct_cfg_analysis_test.cpp
@@ -61,6 +61,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(1), 0);
   EXPECT_EQ(analysis.MergeBlock(1), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(1), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(1), 0);
   EXPECT_EQ(analysis.ContainingSwitch(1), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(1), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(1));
@@ -73,6 +74,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(2), 0);
   EXPECT_EQ(analysis.MergeBlock(2), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(2), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(2), 0);
   EXPECT_EQ(analysis.ContainingSwitch(2), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(2), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(2));
@@ -85,6 +87,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(3), 0);
   EXPECT_EQ(analysis.MergeBlock(3), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(3), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(3), 0);
   EXPECT_EQ(analysis.ContainingSwitch(3), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(3), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(3));
@@ -130,6 +133,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(1), 0);
   EXPECT_EQ(analysis.MergeBlock(1), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(1), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(1), 0);
   EXPECT_EQ(analysis.ContainingSwitch(1), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(1), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(1));
@@ -142,6 +146,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(2), 1);
   EXPECT_EQ(analysis.MergeBlock(2), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(2), 3);
+  EXPECT_EQ(analysis.LoopNestingDepth(2), 1);
   EXPECT_EQ(analysis.ContainingSwitch(2), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(2), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(2));
@@ -154,6 +159,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(3), 0);
   EXPECT_EQ(analysis.MergeBlock(3), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(3), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(3), 0);
   EXPECT_EQ(analysis.ContainingSwitch(3), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(3), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(3));
@@ -166,6 +172,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(4), 1);
   EXPECT_EQ(analysis.MergeBlock(4), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(4), 3);
+  EXPECT_EQ(analysis.LoopNestingDepth(4), 1);
   EXPECT_EQ(analysis.ContainingSwitch(4), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(4), 0);
   EXPECT_TRUE(analysis.IsContinueBlock(4));
@@ -216,6 +223,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(1), 0);
   EXPECT_EQ(analysis.MergeBlock(1), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(1), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(1), 0);
   EXPECT_EQ(analysis.ContainingSwitch(1), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(1), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(1));
@@ -228,6 +236,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(2), 1);
   EXPECT_EQ(analysis.MergeBlock(2), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(2), 3);
+  EXPECT_EQ(analysis.LoopNestingDepth(2), 1);
   EXPECT_EQ(analysis.ContainingSwitch(2), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(2), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(2));
@@ -240,6 +249,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(3), 0);
   EXPECT_EQ(analysis.MergeBlock(3), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(3), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(3), 0);
   EXPECT_EQ(analysis.ContainingSwitch(3), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(3), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(3));
@@ -252,6 +262,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(4), 1);
   EXPECT_EQ(analysis.MergeBlock(4), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(4), 3);
+  EXPECT_EQ(analysis.LoopNestingDepth(4), 1);
   EXPECT_EQ(analysis.ContainingSwitch(4), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(4), 0);
   EXPECT_TRUE(analysis.IsContinueBlock(4));
@@ -264,6 +275,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(5), 1);
   EXPECT_EQ(analysis.MergeBlock(5), 6);
   EXPECT_EQ(analysis.LoopMergeBlock(5), 3);
+  EXPECT_EQ(analysis.LoopNestingDepth(5), 1);
   EXPECT_EQ(analysis.ContainingSwitch(5), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(5), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(5));
@@ -276,6 +288,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(6), 1);
   EXPECT_EQ(analysis.MergeBlock(6), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(6), 3);
+  EXPECT_EQ(analysis.LoopNestingDepth(6), 1);
   EXPECT_EQ(analysis.ContainingSwitch(6), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(6), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(6));
@@ -326,6 +339,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(1), 0);
   EXPECT_EQ(analysis.MergeBlock(1), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(1), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(1), 0);
   EXPECT_EQ(analysis.ContainingSwitch(1), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(1), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(1));
@@ -338,6 +352,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(2), 0);
   EXPECT_EQ(analysis.MergeBlock(2), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(2), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(2), 0);
   EXPECT_EQ(analysis.ContainingSwitch(2), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(2), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(2));
@@ -350,6 +365,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(3), 0);
   EXPECT_EQ(analysis.MergeBlock(3), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(3), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(3), 0);
   EXPECT_EQ(analysis.ContainingSwitch(3), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(3), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(3));
@@ -362,6 +378,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(4), 0);
   EXPECT_EQ(analysis.MergeBlock(4), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(4), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(4), 0);
   EXPECT_EQ(analysis.ContainingSwitch(4), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(4), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(4));
@@ -374,6 +391,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(5), 2);
   EXPECT_EQ(analysis.MergeBlock(5), 4);
   EXPECT_EQ(analysis.LoopMergeBlock(5), 4);
+  EXPECT_EQ(analysis.LoopNestingDepth(5), 1);
   EXPECT_EQ(analysis.ContainingSwitch(5), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(5), 0);
   EXPECT_TRUE(analysis.IsContinueBlock(5));
@@ -386,6 +404,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(6), 2);
   EXPECT_EQ(analysis.MergeBlock(6), 4);
   EXPECT_EQ(analysis.LoopMergeBlock(6), 4);
+  EXPECT_EQ(analysis.LoopNestingDepth(6), 1);
   EXPECT_EQ(analysis.ContainingSwitch(6), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(6), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(6));
@@ -434,6 +453,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(1), 0);
   EXPECT_EQ(analysis.MergeBlock(1), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(1), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(1), 0);
   EXPECT_EQ(analysis.ContainingSwitch(1), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(1), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(1));
@@ -446,6 +466,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(2), 0);
   EXPECT_EQ(analysis.MergeBlock(2), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(2), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(2), 0);
   EXPECT_EQ(analysis.ContainingSwitch(2), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(2), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(2));
@@ -458,6 +479,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(3), 0);
   EXPECT_EQ(analysis.MergeBlock(3), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(3), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(3), 0);
   EXPECT_EQ(analysis.ContainingSwitch(3), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(3), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(3));
@@ -470,6 +492,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(4), 0);
   EXPECT_EQ(analysis.MergeBlock(4), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(4), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(4), 0);
   EXPECT_EQ(analysis.ContainingSwitch(4), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(4), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(4));
@@ -482,6 +505,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(5), 0);
   EXPECT_EQ(analysis.MergeBlock(5), 4);
   EXPECT_EQ(analysis.LoopMergeBlock(5), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(5), 0);
   EXPECT_EQ(analysis.ContainingSwitch(5), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(5), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(5));
@@ -534,6 +558,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(1), 0);
   EXPECT_EQ(analysis.MergeBlock(1), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(1), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(1), 0);
   EXPECT_EQ(analysis.ContainingSwitch(1), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(1), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(1));
@@ -546,6 +571,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(2), 1);
   EXPECT_EQ(analysis.MergeBlock(2), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(2), 3);
+  EXPECT_EQ(analysis.LoopNestingDepth(2), 1);
   EXPECT_EQ(analysis.ContainingSwitch(2), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(2), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(2));
@@ -558,6 +584,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(3), 0);
   EXPECT_EQ(analysis.MergeBlock(3), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(3), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(3), 0);
   EXPECT_EQ(analysis.ContainingSwitch(3), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(3), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(3));
@@ -570,6 +597,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(4), 1);
   EXPECT_EQ(analysis.MergeBlock(4), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(4), 3);
+  EXPECT_EQ(analysis.LoopNestingDepth(4), 1);
   EXPECT_EQ(analysis.ContainingSwitch(4), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(4), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(4));
@@ -582,6 +610,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(5), 2);
   EXPECT_EQ(analysis.MergeBlock(5), 4);
   EXPECT_EQ(analysis.LoopMergeBlock(5), 4);
+  EXPECT_EQ(analysis.LoopNestingDepth(5), 2);
   EXPECT_EQ(analysis.ContainingSwitch(5), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(5), 0);
   EXPECT_TRUE(analysis.IsContinueBlock(5));
@@ -594,6 +623,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(6), 2);
   EXPECT_EQ(analysis.MergeBlock(6), 4);
   EXPECT_EQ(analysis.LoopMergeBlock(6), 4);
+  EXPECT_EQ(analysis.LoopNestingDepth(6), 2);
   EXPECT_EQ(analysis.ContainingSwitch(6), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(6), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(6));
@@ -606,6 +636,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(7), 1);
   EXPECT_EQ(analysis.MergeBlock(7), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(7), 3);
+  EXPECT_EQ(analysis.LoopNestingDepth(7), 1);
   EXPECT_EQ(analysis.ContainingSwitch(7), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(7), 0);
   EXPECT_TRUE(analysis.IsContinueBlock(7));
@@ -646,6 +677,7 @@ OpFunctionEnd
     EXPECT_EQ(analysis.ContainingLoop(i), 0);
     EXPECT_EQ(analysis.MergeBlock(i), 0);
     EXPECT_EQ(analysis.LoopMergeBlock(i), 0);
+    EXPECT_EQ(analysis.LoopNestingDepth(i), 0);
     EXPECT_EQ(analysis.ContainingSwitch(i), 0);
     EXPECT_EQ(analysis.SwitchMergeBlock(i), 0);
     EXPECT_FALSE(analysis.IsContinueBlock(i));
@@ -708,6 +740,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(1), 0);
   EXPECT_EQ(analysis.MergeBlock(1), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(1), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(1), 0);
   EXPECT_EQ(analysis.ContainingSwitch(1), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(1), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(1));
@@ -720,6 +753,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(2), 0);
   EXPECT_EQ(analysis.MergeBlock(2), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(2), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(2), 0);
   EXPECT_EQ(analysis.ContainingSwitch(2), 1);
   EXPECT_EQ(analysis.SwitchMergeBlock(2), 3);
   EXPECT_FALSE(analysis.IsContinueBlock(2));
@@ -732,6 +766,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(3), 0);
   EXPECT_EQ(analysis.MergeBlock(3), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(3), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(3), 0);
   EXPECT_EQ(analysis.ContainingSwitch(3), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(3), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(3));
@@ -782,6 +817,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(1), 0);
   EXPECT_EQ(analysis.MergeBlock(1), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(1), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(1), 0);
   EXPECT_EQ(analysis.ContainingSwitch(1), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(1), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(1));
@@ -794,6 +830,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(2), 0);
   EXPECT_EQ(analysis.MergeBlock(2), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(2), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(2), 0);
   EXPECT_EQ(analysis.ContainingSwitch(2), 1);
   EXPECT_EQ(analysis.SwitchMergeBlock(2), 3);
   EXPECT_FALSE(analysis.IsContinueBlock(2));
@@ -806,6 +843,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(3), 0);
   EXPECT_EQ(analysis.MergeBlock(3), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(3), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(3), 0);
   EXPECT_EQ(analysis.ContainingSwitch(3), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(3), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(3));
@@ -818,6 +856,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(4), 0);
   EXPECT_EQ(analysis.MergeBlock(4), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(4), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(4), 0);
   EXPECT_EQ(analysis.ContainingSwitch(4), 1);
   EXPECT_EQ(analysis.SwitchMergeBlock(4), 3);
   EXPECT_FALSE(analysis.IsContinueBlock(4));
@@ -830,6 +869,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(5), 2);
   EXPECT_EQ(analysis.MergeBlock(5), 4);
   EXPECT_EQ(analysis.LoopMergeBlock(5), 4);
+  EXPECT_EQ(analysis.LoopNestingDepth(5), 1);
   EXPECT_EQ(analysis.ContainingSwitch(5), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(5), 0);
   EXPECT_TRUE(analysis.IsContinueBlock(5));
@@ -842,6 +882,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(6), 2);
   EXPECT_EQ(analysis.MergeBlock(6), 4);
   EXPECT_EQ(analysis.LoopMergeBlock(6), 4);
+  EXPECT_EQ(analysis.LoopNestingDepth(6), 1);
   EXPECT_EQ(analysis.ContainingSwitch(6), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(6), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(6));
@@ -890,6 +931,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(1), 0);
   EXPECT_EQ(analysis.MergeBlock(1), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(1), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(1), 0);
   EXPECT_EQ(analysis.ContainingSwitch(1), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(1), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(1));
@@ -902,6 +944,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(2), 0);
   EXPECT_EQ(analysis.MergeBlock(2), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(2), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(2), 0);
   EXPECT_EQ(analysis.ContainingSwitch(2), 1);
   EXPECT_EQ(analysis.SwitchMergeBlock(2), 3);
   EXPECT_FALSE(analysis.IsContinueBlock(2));
@@ -914,6 +957,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(3), 0);
   EXPECT_EQ(analysis.MergeBlock(3), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(3), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(3), 0);
   EXPECT_EQ(analysis.ContainingSwitch(3), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(3), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(3));
@@ -926,6 +970,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(4), 0);
   EXPECT_EQ(analysis.MergeBlock(4), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(4), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(4), 0);
   EXPECT_EQ(analysis.ContainingSwitch(4), 1);
   EXPECT_EQ(analysis.SwitchMergeBlock(4), 3);
   EXPECT_FALSE(analysis.IsContinueBlock(4));
@@ -938,6 +983,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(5), 0);
   EXPECT_EQ(analysis.MergeBlock(5), 4);
   EXPECT_EQ(analysis.LoopMergeBlock(5), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(5), 0);
   EXPECT_EQ(analysis.ContainingSwitch(5), 1);
   EXPECT_EQ(analysis.SwitchMergeBlock(5), 3);
   EXPECT_FALSE(analysis.IsContinueBlock(5));
@@ -986,6 +1032,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(1), 0);
   EXPECT_EQ(analysis.MergeBlock(1), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(1), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(1), 0);
   EXPECT_EQ(analysis.ContainingSwitch(1), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(1), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(1));
@@ -998,6 +1045,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(2), 0);
   EXPECT_EQ(analysis.MergeBlock(2), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(2), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(2), 0);
   EXPECT_EQ(analysis.ContainingSwitch(2), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(2), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(2));
@@ -1010,6 +1058,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(3), 0);
   EXPECT_EQ(analysis.MergeBlock(3), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(3), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(3), 0);
   EXPECT_EQ(analysis.ContainingSwitch(3), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(3), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(3));
@@ -1022,6 +1071,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(4), 0);
   EXPECT_EQ(analysis.MergeBlock(4), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(4), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(4), 0);
   EXPECT_EQ(analysis.ContainingSwitch(4), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(4), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(4));
@@ -1034,6 +1084,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(5), 0);
   EXPECT_EQ(analysis.MergeBlock(5), 4);
   EXPECT_EQ(analysis.LoopMergeBlock(5), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(5), 0);
   EXPECT_EQ(analysis.ContainingSwitch(5), 2);
   EXPECT_EQ(analysis.SwitchMergeBlock(5), 4);
   EXPECT_FALSE(analysis.IsContinueBlock(5));
@@ -1084,6 +1135,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(1), 0);
   EXPECT_EQ(analysis.MergeBlock(1), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(1), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(1), 0);
   EXPECT_EQ(analysis.ContainingSwitch(1), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(1), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(1));
@@ -1096,6 +1148,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(2), 1);
   EXPECT_EQ(analysis.MergeBlock(2), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(2), 3);
+  EXPECT_EQ(analysis.LoopNestingDepth(2), 1);
   EXPECT_EQ(analysis.ContainingSwitch(2), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(2), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(2));
@@ -1108,6 +1161,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(3), 0);
   EXPECT_EQ(analysis.MergeBlock(3), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(3), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(3), 0);
   EXPECT_EQ(analysis.ContainingSwitch(3), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(3), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(3));
@@ -1120,6 +1174,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(4), 1);
   EXPECT_EQ(analysis.MergeBlock(4), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(4), 3);
+  EXPECT_EQ(analysis.LoopNestingDepth(4), 1);
   EXPECT_EQ(analysis.ContainingSwitch(4), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(4), 0);
   EXPECT_TRUE(analysis.IsContinueBlock(4));
@@ -1132,6 +1187,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(5), 1);
   EXPECT_EQ(analysis.MergeBlock(5), 6);
   EXPECT_EQ(analysis.LoopMergeBlock(5), 3);
+  EXPECT_EQ(analysis.LoopNestingDepth(5), 1);
   EXPECT_EQ(analysis.ContainingSwitch(5), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(5), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(5));
@@ -1144,6 +1200,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(6), 1);
   EXPECT_EQ(analysis.MergeBlock(6), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(6), 3);
+  EXPECT_EQ(analysis.LoopNestingDepth(6), 1);
   EXPECT_EQ(analysis.ContainingSwitch(6), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(6), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(6));
@@ -1196,6 +1253,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(1), 0);
   EXPECT_EQ(analysis.MergeBlock(1), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(1), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(1), 0);
   EXPECT_EQ(analysis.ContainingSwitch(1), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(1), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(1));
@@ -1208,6 +1266,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(2), 1);
   EXPECT_EQ(analysis.MergeBlock(2), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(2), 3);
+  EXPECT_EQ(analysis.LoopNestingDepth(2), 1);
   EXPECT_EQ(analysis.ContainingSwitch(2), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(2), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(2));
@@ -1220,6 +1279,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(3), 0);
   EXPECT_EQ(analysis.MergeBlock(3), 0);
   EXPECT_EQ(analysis.LoopMergeBlock(3), 0);
+  EXPECT_EQ(analysis.LoopNestingDepth(3), 0);
   EXPECT_EQ(analysis.ContainingSwitch(3), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(3), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(3));
@@ -1232,6 +1292,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(4), 1);
   EXPECT_EQ(analysis.MergeBlock(4), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(4), 3);
+  EXPECT_EQ(analysis.LoopNestingDepth(4), 1);
   EXPECT_EQ(analysis.ContainingSwitch(4), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(4), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(4));
@@ -1244,6 +1305,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(5), 7);
   EXPECT_EQ(analysis.MergeBlock(5), 4);
   EXPECT_EQ(analysis.LoopMergeBlock(5), 4);
+  EXPECT_EQ(analysis.LoopNestingDepth(5), 2);
   EXPECT_EQ(analysis.ContainingSwitch(5), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(5), 0);
   EXPECT_TRUE(analysis.IsContinueBlock(5));
@@ -1256,6 +1318,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(6), 7);
   EXPECT_EQ(analysis.MergeBlock(6), 4);
   EXPECT_EQ(analysis.LoopMergeBlock(6), 4);
+  EXPECT_EQ(analysis.LoopNestingDepth(6), 2);
   EXPECT_EQ(analysis.ContainingSwitch(6), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(6), 0);
   EXPECT_FALSE(analysis.IsContinueBlock(6));
@@ -1268,6 +1331,7 @@ OpFunctionEnd
   EXPECT_EQ(analysis.ContainingLoop(7), 1);
   EXPECT_EQ(analysis.MergeBlock(7), 3);
   EXPECT_EQ(analysis.LoopMergeBlock(7), 3);
+  EXPECT_EQ(analysis.LoopNestingDepth(7), 1);
   EXPECT_EQ(analysis.ContainingSwitch(7), 0);
   EXPECT_EQ(analysis.SwitchMergeBlock(7), 0);
   EXPECT_TRUE(analysis.IsContinueBlock(7));


### PR DESCRIPTION
This PR adds the LoopNestingDepth function to StructuredCFGAnalysis.
This function, given a block id, returns the loop nesting depth of
such block within its function (the number of loop constructs
containing it).