### PR TITLE
spirv-fuzz: Fix GetIdEquivalenceClasses

### DIFF
--- a/source/fuzz/fuzzer_pass_add_opphi_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_add_opphi_synonyms.cpp
@@ -167,6 +167,12 @@ FuzzerPassAddOpPhiSynonyms::GetIdEquivalenceClasses() {
       continue;
     }
 
+    // Exclude OpFunction and OpUndef instructions.
+    if (pair.second->opcode() == SpvOpFunction ||
+        pair.second->opcode() == SpvOpUndef) {
+      continue;
+    }
+
     // We need a new equivalence class for this id.
     std::set<uint32_t> new_equivalence_class;
 

--- a/source/fuzz/fuzzer_pass_add_opphi_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_add_opphi_synonyms.cpp
@@ -167,7 +167,10 @@ FuzzerPassAddOpPhiSynonyms::GetIdEquivalenceClasses() {
       continue;
     }
 
-    // Exclude OpFunction and OpUndef instructions.
+    // Exclude OpFunction and OpUndef instructions, because:
+    // - OpFunction does not yield a value;
+    // - OpUndef yields an undefined value at each use, so it should never be a
+    //   synonym of another id.
     if (pair.second->opcode() == SpvOpFunction ||
         pair.second->opcode() == SpvOpUndef) {
       continue;

--- a/test/fuzz/fuzzer_pass_add_opphi_synonyms_test.cpp
+++ b/test/fuzz/fuzzer_pass_add_opphi_synonyms_test.cpp
@@ -76,6 +76,7 @@ std::string shader = R"(
           %5 = OpTypeBool
           %6 = OpConstantTrue %5
           %7 = OpTypeInt 32 1
+         %31 = OpTypeFunction %7
           %8 = OpTypeInt 32 0
           %9 = OpConstant %7 1
          %10 = OpConstant %7 2
@@ -108,6 +109,10 @@ std::string shader = R"(
                OpBranch %28
          %28 = OpLabel
                OpReturn
+               OpFunctionEnd
+         %32 = OpFunction %7 None %31
+         %33 = OpLabel
+               OpReturnValue %9
                OpFunctionEnd
 )";
 


### PR DESCRIPTION
FuzzerPassAddOpPhiSynonyms::GetIdEquivalenceClasses considers every id
with type among Bool, Integer, Float, Vector, Matrix, Array, Struct,
Pointer (if VariablePointers is enabled) to find sets of potential
synonyms.

However, some instructions with these types cannot be used in an OpPhi:
- OpFunction cannot be used as a value
- OpUndef should not be used, because it yields an undefined value for
  each use

Fixes #3761 .