### PR TITLE
spirv-fuzz: Add TransformationDuplicateRegionWithSelection

### DIFF
--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -73,6 +73,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_construct_composites.h
         fuzzer_pass_copy_objects.h
         fuzzer_pass_donate_modules.h
+        fuzzer_pass_duplicate_regions_with_selections.h
         fuzzer_pass_inline_functions.h
         fuzzer_pass_invert_comparison_operators.h
         fuzzer_pass_interchange_signedness_of_integer_operands.h
@@ -149,6 +150,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_composite_insert.h
         transformation_compute_data_synonym_fact_closure.h
         transformation_context.h
+        transformation_duplicate_region_with_selection.h
         transformation_equation_instruction.h
         transformation_function_call.h
         transformation_inline_function.h
@@ -234,6 +236,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_construct_composites.cpp
         fuzzer_pass_copy_objects.cpp
         fuzzer_pass_donate_modules.cpp
+        fuzzer_pass_duplicate_regions_with_selections.cpp
         fuzzer_pass_inline_functions.cpp
         fuzzer_pass_invert_comparison_operators.cpp
         fuzzer_pass_interchange_signedness_of_integer_operands.cpp
@@ -309,7 +312,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_composite_insert.cpp
         transformation_compute_data_synonym_fact_closure.cpp
         transformation_context.cpp
-        transformation_replace_opselect_with_conditional_branch.cpp
+        transformation_duplicate_region_with_selection.cpp
         transformation_equation_instruction.cpp
         transformation_function_call.cpp
         transformation_inline_function.cpp
@@ -336,6 +339,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_replace_linear_algebra_instruction.cpp
         transformation_replace_load_store_with_copy_memory.cpp
         transformation_replace_opphi_id_from_dead_predecessor.cpp
+        transformation_replace_opselect_with_conditional_branch.cpp
         transformation_replace_parameter_with_global.cpp
         transformation_replace_params_with_struct.cpp
         transformation_set_function_control.cpp

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -49,8 +49,12 @@
 #include "source/fuzz/fuzzer_pass_construct_composites.h"
 #include "source/fuzz/fuzzer_pass_copy_objects.h"
 #include "source/fuzz/fuzzer_pass_donate_modules.h"
+<<<<<<< HEAD
 #include "source/fuzz/fuzzer_pass_inline_functions.h"
-#include "source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.h"
+=======
+#include "source/fuzz/fuzzer_pass_duplicate_regions_with_selections.h"
+>>>>>>> d2362271 (Initial structure.)
+    #include "source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.h"
 #include "source/fuzz/fuzzer_pass_interchange_zero_like_constants.h"
 #include "source/fuzz/fuzzer_pass_invert_comparison_operators.h"
 #include "source/fuzz/fuzzer_pass_make_vector_operations_dynamic.h"
@@ -85,328 +89,331 @@
 #include "source/spirv_fuzzer_options.h"
 #include "source/util/make_unique.h"
 
-namespace spvtools {
-namespace fuzz {
+    namespace spvtools {
+  namespace fuzz {
 
-namespace {
-const uint32_t kIdBoundGap = 100;
+  namespace {
+  const uint32_t kIdBoundGap = 100;
 
-const uint32_t kTransformationLimit = 500;
+  const uint32_t kTransformationLimit = 500;
 
-const uint32_t kChanceOfApplyingAnotherPass = 85;
+  const uint32_t kChanceOfApplyingAnotherPass = 85;
 
-// A convenience method to add a fuzzer pass to |passes| with probability 0.5.
-// All fuzzer passes take |ir_context|, |transformation_context|,
-// |fuzzer_context| and |transformation_sequence_out| as parameters.  Extra
-// arguments can be provided via |extra_args|.
-template <typename T, typename... Args>
-void MaybeAddPass(
-    std::vector<std::unique_ptr<FuzzerPass>>* passes,
-    opt::IRContext* ir_context, TransformationContext* transformation_context,
-    FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformation_sequence_out,
-    Args&&... extra_args) {
-  if (fuzzer_context->ChooseEven()) {
-    passes->push_back(MakeUnique<T>(ir_context, transformation_context,
-                                    fuzzer_context, transformation_sequence_out,
-                                    std::forward<Args>(extra_args)...));
-  }
-}
-
-}  // namespace
-
-Fuzzer::Fuzzer(spv_target_env target_env, uint32_t seed,
-               bool validate_after_each_fuzzer_pass,
-               spv_validator_options validator_options)
-    : target_env_(target_env),
-      seed_(seed),
-      validate_after_each_fuzzer_pass_(validate_after_each_fuzzer_pass),
-      validator_options_(validator_options) {}
-
-Fuzzer::~Fuzzer() = default;
-
-void Fuzzer::SetMessageConsumer(MessageConsumer consumer) {
-  consumer_ = std::move(consumer);
-}
-
-bool Fuzzer::ApplyPassAndCheckValidity(
-    FuzzerPass* pass, const opt::IRContext& ir_context,
-    const spvtools::SpirvTools& tools) const {
-  pass->Apply();
-  if (validate_after_each_fuzzer_pass_) {
-    std::vector<uint32_t> binary_to_validate;
-    ir_context.module()->ToBinary(&binary_to_validate, false);
-    if (!tools.Validate(&binary_to_validate[0], binary_to_validate.size(),
-                        validator_options_)) {
-      consumer_(SPV_MSG_INFO, nullptr, {},
-                "Binary became invalid during fuzzing (set a breakpoint to "
-                "inspect); stopping.");
-      return false;
-    }
-  }
-  return true;
-}
-
-Fuzzer::FuzzerResultStatus Fuzzer::Run(
-    const std::vector<uint32_t>& binary_in,
-    const protobufs::FactSequence& initial_facts,
-    const std::vector<fuzzerutil::ModuleSupplier>& donor_suppliers,
-    std::vector<uint32_t>* binary_out,
-    protobufs::TransformationSequence* transformation_sequence_out) const {
-  // Check compatibility between the library version being linked with and the
-  // header files being used.
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
-
-  spvtools::SpirvTools tools(target_env_);
-  tools.SetMessageConsumer(consumer_);
-  if (!tools.IsValid()) {
-    consumer_(SPV_MSG_ERROR, nullptr, {},
-              "Failed to create SPIRV-Tools interface; stopping.");
-    return Fuzzer::FuzzerResultStatus::kFailedToCreateSpirvToolsInterface;
-  }
-
-  // Initial binary should be valid.
-  if (!tools.Validate(&binary_in[0], binary_in.size(), validator_options_)) {
-    consumer_(SPV_MSG_ERROR, nullptr, {},
-              "Initial binary is invalid; stopping.");
-    return Fuzzer::FuzzerResultStatus::kInitialBinaryInvalid;
-  }
-
-  // Build the module from the input binary.
-  std::unique_ptr<opt::IRContext> ir_context =
-      BuildModule(target_env_, consumer_, binary_in.data(), binary_in.size());
-  assert(ir_context);
-
-  // Make a PRNG from the seed passed to the fuzzer on creation.
-  PseudoRandomGenerator random_generator(seed_);
-
-  // The fuzzer will introduce new ids into the module.  The module's id bound
-  // gives the smallest id that can be used for this purpose.  We add an offset
-  // to this so that there is a sizeable gap between the ids used in the
-  // original module and the ids used for fuzzing, as a readability aid.
-  //
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/2541) consider the
-  //  case where the maximum id bound is reached.
-  auto minimum_fresh_id = ir_context->module()->id_bound() + kIdBoundGap;
-  FuzzerContext fuzzer_context(&random_generator, minimum_fresh_id);
-
-  FactManager fact_manager;
-  fact_manager.AddFacts(consumer_, initial_facts, ir_context.get());
-  TransformationContext transformation_context(&fact_manager,
-                                               validator_options_);
-
-  // Apply some semantics-preserving passes.
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3764): Enable
-  //  certain passes to run with a higher priority than the others.
-  std::vector<std::unique_ptr<FuzzerPass>> passes;
-  while (passes.empty()) {
-    MaybeAddPass<FuzzerPassAddAccessChains>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAddCompositeInserts>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAddCompositeTypes>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAddCopyMemory>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAddDeadBlocks>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAddDeadBreaks>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAddDeadContinues>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAddEquationInstructions>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAddFunctionCalls>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAddGlobalVariables>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAddImageSampleUnusedComponents>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAddLoads>(&passes, ir_context.get(),
-                                     &transformation_context, &fuzzer_context,
-                                     transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAddLocalVariables>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAddLoopPreheaders>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAddOpPhiSynonyms>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAddParameters>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAddRelaxedDecorations>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAddStores>(&passes, ir_context.get(),
-                                      &transformation_context, &fuzzer_context,
-                                      transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAddSynonyms>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAddVectorShuffleInstructions>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassApplyIdSynonyms>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassConstructComposites>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassCopyObjects>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassDonateModules>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out, donor_suppliers);
-    MaybeAddPass<FuzzerPassInlineFunctions>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassInvertComparisonOperators>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassMakeVectorOperationsDynamic>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassMergeBlocks>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassMutatePointers>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassObfuscateConstants>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassOutlineFunctions>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassPermuteBlocks>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassPermuteFunctionParameters>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassPermuteInstructions>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassPropagateInstructionsUp>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassPushIdsThroughVariables>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassReplaceAddsSubsMulsWithCarryingExtended>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassReplaceCopyMemoriesWithLoadsStores>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassReplaceCopyObjectsWithStoresLoads>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassReplaceLoadsStoresWithCopyMemories>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassReplaceParameterWithGlobal>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassReplaceLinearAlgebraInstructions>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassReplaceOpSelectsWithConditionalBranches>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassReplaceParamsWithStruct>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassSplitBlocks>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassSwapBranchConditionalOperands>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-  }
-
-  bool is_first = true;
-  while (static_cast<uint32_t>(
-             transformation_sequence_out->transformation_size()) <
-             kTransformationLimit &&
-         (is_first ||
-          fuzzer_context.ChoosePercentage(kChanceOfApplyingAnotherPass))) {
-    is_first = false;
-    if (!ApplyPassAndCheckValidity(
-            passes[fuzzer_context.RandomIndex(passes)].get(), *ir_context,
-            tools)) {
-      return Fuzzer::FuzzerResultStatus::kFuzzerPassLedToInvalidModule;
+  // A convenience method to add a fuzzer pass to |passes| with probability 0.5.
+  // All fuzzer passes take |ir_context|, |transformation_context|,
+  // |fuzzer_context| and |transformation_sequence_out| as parameters.  Extra
+  // arguments can be provided via |extra_args|.
+  template <typename T, typename... Args>
+  void MaybeAddPass(
+      std::vector<std::unique_ptr<FuzzerPass>>* passes,
+      opt::IRContext* ir_context, TransformationContext* transformation_context,
+      FuzzerContext* fuzzer_context,
+      protobufs::TransformationSequence* transformation_sequence_out,
+      Args&&... extra_args) {
+    if (fuzzer_context->ChooseEven()) {
+      passes->push_back(MakeUnique<T>(
+          ir_context, transformation_context, fuzzer_context,
+          transformation_sequence_out, std::forward<Args>(extra_args)...));
     }
   }
 
-  // Now apply some passes that it does not make sense to apply repeatedly,
-  // as they do not unlock other passes.
-  std::vector<std::unique_ptr<FuzzerPass>> final_passes;
-  MaybeAddPass<FuzzerPassAdjustBranchWeights>(
-      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
-      transformation_sequence_out);
-  MaybeAddPass<FuzzerPassAdjustFunctionControls>(
-      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
-      transformation_sequence_out);
-  MaybeAddPass<FuzzerPassAdjustLoopControls>(
-      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
-      transformation_sequence_out);
-  MaybeAddPass<FuzzerPassAdjustMemoryOperandsMasks>(
-      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
-      transformation_sequence_out);
-  MaybeAddPass<FuzzerPassAdjustSelectionControls>(
-      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
-      transformation_sequence_out);
-  MaybeAddPass<FuzzerPassAddNoContractionDecorations>(
-      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
-      transformation_sequence_out);
-  MaybeAddPass<FuzzerPassInterchangeSignednessOfIntegerOperands>(
-      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
-      transformation_sequence_out);
-  MaybeAddPass<FuzzerPassInterchangeZeroLikeConstants>(
-      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
-      transformation_sequence_out);
-  MaybeAddPass<FuzzerPassPermutePhiOperands>(
-      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
-      transformation_sequence_out);
-  MaybeAddPass<FuzzerPassReplaceOpPhiIdsFromDeadPredecessors>(
-      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
-      transformation_sequence_out);
-  MaybeAddPass<FuzzerPassReplaceIrrelevantIds>(
-      &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-      transformation_sequence_out);
-  MaybeAddPass<FuzzerPassSwapCommutableOperands>(
-      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
-      transformation_sequence_out);
-  MaybeAddPass<FuzzerPassToggleAccessChainInstruction>(
-      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
-      transformation_sequence_out);
-  for (auto& pass : final_passes) {
-    if (!ApplyPassAndCheckValidity(pass.get(), *ir_context, tools)) {
-      return Fuzzer::FuzzerResultStatus::kFuzzerPassLedToInvalidModule;
-    }
+  }  // namespace
+
+  Fuzzer::Fuzzer(spv_target_env target_env, uint32_t seed,
+                 bool validate_after_each_fuzzer_pass,
+                 spv_validator_options validator_options)
+      : target_env_(target_env),
+        seed_(seed),
+        validate_after_each_fuzzer_pass_(validate_after_each_fuzzer_pass),
+        validator_options_(validator_options) {}
+
+  Fuzzer::~Fuzzer() = default;
+
+  void Fuzzer::SetMessageConsumer(MessageConsumer consumer) {
+    consumer_ = std::move(consumer);
   }
 
-  // Encode the module as a binary.
-  ir_context->module()->ToBinary(binary_out, false);
+  bool Fuzzer::ApplyPassAndCheckValidity(
+      FuzzerPass* pass, const opt::IRContext& ir_context,
+      const spvtools::SpirvTools& tools) const {
+    pass->Apply();
+    if (validate_after_each_fuzzer_pass_) {
+      std::vector<uint32_t> binary_to_validate;
+      ir_context.module()->ToBinary(&binary_to_validate, false);
+      if (!tools.Validate(&binary_to_validate[0], binary_to_validate.size(),
+                          validator_options_)) {
+        consumer_(SPV_MSG_INFO, nullptr, {},
+                  "Binary became invalid during fuzzing (set a breakpoint to "
+                  "inspect); stopping.");
+        return false;
+      }
+    }
+    return true;
+  }
 
-  return Fuzzer::FuzzerResultStatus::kComplete;
-}
+  Fuzzer::FuzzerResultStatus Fuzzer::Run(
+      const std::vector<uint32_t>& binary_in,
+      const protobufs::FactSequence& initial_facts,
+      const std::vector<fuzzerutil::ModuleSupplier>& donor_suppliers,
+      std::vector<uint32_t>* binary_out,
+      protobufs::TransformationSequence* transformation_sequence_out) const {
+    // Check compatibility between the library version being linked with and the
+    // header files being used.
+    GOOGLE_PROTOBUF_VERIFY_VERSION;
 
-}  // namespace fuzz
+    spvtools::SpirvTools tools(target_env_);
+    tools.SetMessageConsumer(consumer_);
+    if (!tools.IsValid()) {
+      consumer_(SPV_MSG_ERROR, nullptr, {},
+                "Failed to create SPIRV-Tools interface; stopping.");
+      return Fuzzer::FuzzerResultStatus::kFailedToCreateSpirvToolsInterface;
+    }
+
+    // Initial binary should be valid.
+    if (!tools.Validate(&binary_in[0], binary_in.size(), validator_options_)) {
+      consumer_(SPV_MSG_ERROR, nullptr, {},
+                "Initial binary is invalid; stopping.");
+      return Fuzzer::FuzzerResultStatus::kInitialBinaryInvalid;
+    }
+
+    // Build the module from the input binary.
+    std::unique_ptr<opt::IRContext> ir_context =
+        BuildModule(target_env_, consumer_, binary_in.data(), binary_in.size());
+    assert(ir_context);
+
+    // Make a PRNG from the seed passed to the fuzzer on creation.
+    PseudoRandomGenerator random_generator(seed_);
+
+    // The fuzzer will introduce new ids into the module.  The module's id bound
+    // gives the smallest id that can be used for this purpose.  We add an
+    // offset to this so that there is a sizeable gap between the ids used in
+    // the original module and the ids used for fuzzing, as a readability aid.
+    //
+    // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/2541) consider
+    // the
+    //  case where the maximum id bound is reached.
+    auto minimum_fresh_id = ir_context->module()->id_bound() + kIdBoundGap;
+    FuzzerContext fuzzer_context(&random_generator, minimum_fresh_id);
+
+    FactManager fact_manager;
+    fact_manager.AddFacts(consumer_, initial_facts, ir_context.get());
+    TransformationContext transformation_context(&fact_manager,
+                                                 validator_options_);
+
+    // Apply some semantics-preserving passes.
+    // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3764): Enable
+    //  certain passes to run with a higher priority than the others.
+    std::vector<std::unique_ptr<FuzzerPass>> passes;
+    while (passes.empty()) {
+      MaybeAddPass<FuzzerPassAddAccessChains>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassAddCompositeInserts>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassAddCompositeTypes>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassAddCopyMemory>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassAddDeadBlocks>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassAddDeadBreaks>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassAddDeadContinues>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassAddEquationInstructions>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassAddFunctionCalls>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassAddGlobalVariables>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassAddImageSampleUnusedComponents>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassAddLoads>(&passes, ir_context.get(),
+                                       &transformation_context, &fuzzer_context,
+                                       transformation_sequence_out);
+      MaybeAddPass<FuzzerPassAddLocalVariables>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassAddLoopPreheaders>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassAddOpPhiSynonyms>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassAddParameters>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassAddRelaxedDecorations>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassAddStores>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassAddSynonyms>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassAddVectorShuffleInstructions>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassApplyIdSynonyms>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassConstructComposites>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassCopyObjects>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassDonateModules>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out, donor_suppliers);
+      /*MaybeAddPass<FuzzerPassDuplicateRegionsWithSelections>(
+            &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+            transformation_sequence_out, donor_suppliers);*/
+      MaybeAddPass<FuzzerPassInlineFunctions>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassInvertComparisonOperators>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassMakeVectorOperationsDynamic>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassMergeBlocks>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassMutatePointers>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassObfuscateConstants>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassOutlineFunctions>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassPermuteBlocks>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassPermuteFunctionParameters>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassPermuteInstructions>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassPropagateInstructionsUp>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassPushIdsThroughVariables>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassReplaceAddsSubsMulsWithCarryingExtended>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassReplaceCopyMemoriesWithLoadsStores>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassReplaceCopyObjectsWithStoresLoads>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassReplaceLoadsStoresWithCopyMemories>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassReplaceParameterWithGlobal>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassReplaceLinearAlgebraInstructions>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassReplaceOpSelectsWithConditionalBranches>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassReplaceParamsWithStruct>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassSplitBlocks>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+      MaybeAddPass<FuzzerPassSwapBranchConditionalOperands>(
+          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+          transformation_sequence_out);
+    }
+    bool is_first = true;
+    while (static_cast<uint32_t>(
+               transformation_sequence_out->transformation_size()) <
+               kTransformationLimit &&
+           (is_first ||
+            fuzzer_context.ChoosePercentage(kChanceOfApplyingAnotherPass))) {
+      is_first = false;
+      if (!ApplyPassAndCheckValidity(
+              passes[fuzzer_context.RandomIndex(passes)].get(), *ir_context,
+              tools)) {
+        return Fuzzer::FuzzerResultStatus::kFuzzerPassLedToInvalidModule;
+      }
+    }
+
+    // Now apply some passes that it does not make sense to apply repeatedly,
+    // as they do not unlock other passes.
+    std::vector<std::unique_ptr<FuzzerPass>> final_passes;
+    MaybeAddPass<FuzzerPassAdjustBranchWeights>(
+        &final_passes, ir_context.get(), &transformation_context,
+        &fuzzer_context, transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAdjustFunctionControls>(
+        &final_passes, ir_context.get(), &transformation_context,
+        &fuzzer_context, transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAdjustLoopControls>(
+        &final_passes, ir_context.get(), &transformation_context,
+        &fuzzer_context, transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAdjustMemoryOperandsMasks>(
+        &final_passes, ir_context.get(), &transformation_context,
+        &fuzzer_context, transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAdjustSelectionControls>(
+        &final_passes, ir_context.get(), &transformation_context,
+        &fuzzer_context, transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddNoContractionDecorations>(
+        &final_passes, ir_context.get(), &transformation_context,
+        &fuzzer_context, transformation_sequence_out);
+    MaybeAddPass<FuzzerPassInterchangeSignednessOfIntegerOperands>(
+        &final_passes, ir_context.get(), &transformation_context,
+        &fuzzer_context, transformation_sequence_out);
+    MaybeAddPass<FuzzerPassInterchangeZeroLikeConstants>(
+        &final_passes, ir_context.get(), &transformation_context,
+        &fuzzer_context, transformation_sequence_out);
+    MaybeAddPass<FuzzerPassPermutePhiOperands>(
+        &final_passes, ir_context.get(), &transformation_context,
+        &fuzzer_context, transformation_sequence_out);
+    MaybeAddPass<FuzzerPassReplaceOpPhiIdsFromDeadPredecessors>(
+        &final_passes, ir_context.get(), &transformation_context,
+        &fuzzer_context, transformation_sequence_out);
+    MaybeAddPass<FuzzerPassReplaceIrrelevantIds>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassSwapCommutableOperands>(
+        &final_passes, ir_context.get(), &transformation_context,
+        &fuzzer_context, transformation_sequence_out);
+    MaybeAddPass<FuzzerPassToggleAccessChainInstruction>(
+        &final_passes, ir_context.get(), &transformation_context,
+        &fuzzer_context, transformation_sequence_out);
+    for (auto& pass : final_passes) {
+      if (!ApplyPassAndCheckValidity(pass.get(), *ir_context, tools)) {
+        return Fuzzer::FuzzerResultStatus::kFuzzerPassLedToInvalidModule;
+      }
+    }
+
+    // Encode the module as a binary.
+    ir_context->module()->ToBinary(binary_out, false);
+
+    return Fuzzer::FuzzerResultStatus::kComplete;
+  }
+
+  }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -49,12 +49,9 @@
 #include "source/fuzz/fuzzer_pass_construct_composites.h"
 #include "source/fuzz/fuzzer_pass_copy_objects.h"
 #include "source/fuzz/fuzzer_pass_donate_modules.h"
-<<<<<<< HEAD
-#include "source/fuzz/fuzzer_pass_inline_functions.h"
-=======
 #include "source/fuzz/fuzzer_pass_duplicate_regions_with_selections.h"
->>>>>>> d2362271 (Initial structure.)
-    #include "source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.h"
+#include "source/fuzz/fuzzer_pass_inline_functions.h"
+#include "source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.h"
 #include "source/fuzz/fuzzer_pass_interchange_zero_like_constants.h"
 #include "source/fuzz/fuzzer_pass_invert_comparison_operators.h"
 #include "source/fuzz/fuzzer_pass_make_vector_operations_dynamic.h"
@@ -89,276 +86,275 @@
 #include "source/spirv_fuzzer_options.h"
 #include "source/util/make_unique.h"
 
-    namespace spvtools {
-  namespace fuzz {
+namespace spvtools {
+namespace fuzz {
 
-  namespace {
-  const uint32_t kIdBoundGap = 100;
+namespace {
+const uint32_t kIdBoundGap = 100;
 
-  const uint32_t kTransformationLimit = 500;
+const uint32_t kTransformationLimit = 500;
 
-  const uint32_t kChanceOfApplyingAnotherPass = 85;
+const uint32_t kChanceOfApplyingAnotherPass = 85;
 
-  // A convenience method to add a fuzzer pass to |passes| with probability 0.5.
-  // All fuzzer passes take |ir_context|, |transformation_context|,
-  // |fuzzer_context| and |transformation_sequence_out| as parameters.  Extra
-  // arguments can be provided via |extra_args|.
-  template <typename T, typename... Args>
-  void MaybeAddPass(
-      std::vector<std::unique_ptr<FuzzerPass>>* passes,
-      opt::IRContext* ir_context, TransformationContext* transformation_context,
-      FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformation_sequence_out,
-      Args&&... extra_args) {
-    if (fuzzer_context->ChooseEven()) {
-      passes->push_back(MakeUnique<T>(
-          ir_context, transformation_context, fuzzer_context,
-          transformation_sequence_out, std::forward<Args>(extra_args)...));
+// A convenience method to add a fuzzer pass to |passes| with probability 0.5.
+// All fuzzer passes take |ir_context|, |transformation_context|,
+// |fuzzer_context| and |transformation_sequence_out| as parameters.  Extra
+// arguments can be provided via |extra_args|.
+template <typename T, typename... Args>
+void MaybeAddPass(
+    std::vector<std::unique_ptr<FuzzerPass>>* passes,
+    opt::IRContext* ir_context, TransformationContext* transformation_context,
+    FuzzerContext* fuzzer_context,
+    protobufs::TransformationSequence* transformation_sequence_out,
+    Args&&... extra_args) {
+  if (fuzzer_context->ChooseEven()) {
+    passes->push_back(MakeUnique<T>(ir_context, transformation_context,
+                                    fuzzer_context, transformation_sequence_out,
+                                    std::forward<Args>(extra_args)...));
+  }
+}
+
+}  // namespace
+
+Fuzzer::Fuzzer(spv_target_env target_env, uint32_t seed,
+               bool validate_after_each_fuzzer_pass,
+               spv_validator_options validator_options)
+    : target_env_(target_env),
+      seed_(seed),
+      validate_after_each_fuzzer_pass_(validate_after_each_fuzzer_pass),
+      validator_options_(validator_options) {}
+
+Fuzzer::~Fuzzer() = default;
+
+void Fuzzer::SetMessageConsumer(MessageConsumer consumer) {
+  consumer_ = std::move(consumer);
+}
+
+bool Fuzzer::ApplyPassAndCheckValidity(
+    FuzzerPass* pass, const opt::IRContext& ir_context,
+    const spvtools::SpirvTools& tools) const {
+  pass->Apply();
+  if (validate_after_each_fuzzer_pass_) {
+    std::vector<uint32_t> binary_to_validate;
+    ir_context.module()->ToBinary(&binary_to_validate, false);
+    if (!tools.Validate(&binary_to_validate[0], binary_to_validate.size(),
+                        validator_options_)) {
+      consumer_(SPV_MSG_INFO, nullptr, {},
+                "Binary became invalid during fuzzing (set a breakpoint to "
+                "inspect); stopping.");
+      return false;
     }
   }
+  return true;
+}
 
-  }  // namespace
+Fuzzer::FuzzerResultStatus Fuzzer::Run(
+    const std::vector<uint32_t>& binary_in,
+    const protobufs::FactSequence& initial_facts,
+    const std::vector<fuzzerutil::ModuleSupplier>& donor_suppliers,
+    std::vector<uint32_t>* binary_out,
+    protobufs::TransformationSequence* transformation_sequence_out) const {
+  // Check compatibility between the library version being linked with and the
+  // header files being used.
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
 
-  Fuzzer::Fuzzer(spv_target_env target_env, uint32_t seed,
-                 bool validate_after_each_fuzzer_pass,
-                 spv_validator_options validator_options)
-      : target_env_(target_env),
-        seed_(seed),
-        validate_after_each_fuzzer_pass_(validate_after_each_fuzzer_pass),
-        validator_options_(validator_options) {}
-
-  Fuzzer::~Fuzzer() = default;
-
-  void Fuzzer::SetMessageConsumer(MessageConsumer consumer) {
-    consumer_ = std::move(consumer);
+  spvtools::SpirvTools tools(target_env_);
+  tools.SetMessageConsumer(consumer_);
+  if (!tools.IsValid()) {
+    consumer_(SPV_MSG_ERROR, nullptr, {},
+              "Failed to create SPIRV-Tools interface; stopping.");
+    return Fuzzer::FuzzerResultStatus::kFailedToCreateSpirvToolsInterface;
   }
 
-  bool Fuzzer::ApplyPassAndCheckValidity(
-      FuzzerPass* pass, const opt::IRContext& ir_context,
-      const spvtools::SpirvTools& tools) const {
-    pass->Apply();
-    if (validate_after_each_fuzzer_pass_) {
-      std::vector<uint32_t> binary_to_validate;
-      ir_context.module()->ToBinary(&binary_to_validate, false);
-      if (!tools.Validate(&binary_to_validate[0], binary_to_validate.size(),
-                          validator_options_)) {
-        consumer_(SPV_MSG_INFO, nullptr, {},
-                  "Binary became invalid during fuzzing (set a breakpoint to "
-                  "inspect); stopping.");
-        return false;
-      }
-    }
-    return true;
+  // Initial binary should be valid.
+  if (!tools.Validate(&binary_in[0], binary_in.size(), validator_options_)) {
+    consumer_(SPV_MSG_ERROR, nullptr, {},
+              "Initial binary is invalid; stopping.");
+    return Fuzzer::FuzzerResultStatus::kInitialBinaryInvalid;
   }
 
-  Fuzzer::FuzzerResultStatus Fuzzer::Run(
-      const std::vector<uint32_t>& binary_in,
-      const protobufs::FactSequence& initial_facts,
-      const std::vector<fuzzerutil::ModuleSupplier>& donor_suppliers,
-      std::vector<uint32_t>* binary_out,
-      protobufs::TransformationSequence* transformation_sequence_out) const {
-    // Check compatibility between the library version being linked with and the
-    // header files being used.
-    GOOGLE_PROTOBUF_VERIFY_VERSION;
+  // Build the module from the input binary.
+  std::unique_ptr<opt::IRContext> ir_context =
+      BuildModule(target_env_, consumer_, binary_in.data(), binary_in.size());
+  assert(ir_context);
 
-    spvtools::SpirvTools tools(target_env_);
-    tools.SetMessageConsumer(consumer_);
-    if (!tools.IsValid()) {
-      consumer_(SPV_MSG_ERROR, nullptr, {},
-                "Failed to create SPIRV-Tools interface; stopping.");
-      return Fuzzer::FuzzerResultStatus::kFailedToCreateSpirvToolsInterface;
-    }
+  // Make a PRNG from the seed passed to the fuzzer on creation.
+  PseudoRandomGenerator random_generator(seed_);
 
-    // Initial binary should be valid.
-    if (!tools.Validate(&binary_in[0], binary_in.size(), validator_options_)) {
-      consumer_(SPV_MSG_ERROR, nullptr, {},
-                "Initial binary is invalid; stopping.");
-      return Fuzzer::FuzzerResultStatus::kInitialBinaryInvalid;
-    }
+  // The fuzzer will introduce new ids into the module.  The module's id bound
+  // gives the smallest id that can be used for this purpose.  We add an
+  // offset to this so that there is a sizeable gap between the ids used in
+  // the original module and the ids used for fuzzing, as a readability aid.
+  //
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/2541) consider
+  // the
+  //  case where the maximum id bound is reached.
+  auto minimum_fresh_id = ir_context->module()->id_bound() + kIdBoundGap;
+  FuzzerContext fuzzer_context(&random_generator, minimum_fresh_id);
 
-    // Build the module from the input binary.
-    std::unique_ptr<opt::IRContext> ir_context =
-        BuildModule(target_env_, consumer_, binary_in.data(), binary_in.size());
-    assert(ir_context);
+  FactManager fact_manager;
+  fact_manager.AddFacts(consumer_, initial_facts, ir_context.get());
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options_);
 
-    // Make a PRNG from the seed passed to the fuzzer on creation.
-    PseudoRandomGenerator random_generator(seed_);
-
-    // The fuzzer will introduce new ids into the module.  The module's id bound
-    // gives the smallest id that can be used for this purpose.  We add an
-    // offset to this so that there is a sizeable gap between the ids used in
-    // the original module and the ids used for fuzzing, as a readability aid.
-    //
-    // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/2541) consider
-    // the
-    //  case where the maximum id bound is reached.
-    auto minimum_fresh_id = ir_context->module()->id_bound() + kIdBoundGap;
-    FuzzerContext fuzzer_context(&random_generator, minimum_fresh_id);
-
-    FactManager fact_manager;
-    fact_manager.AddFacts(consumer_, initial_facts, ir_context.get());
-    TransformationContext transformation_context(&fact_manager,
-                                                 validator_options_);
-
-    // Apply some semantics-preserving passes.
-    // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3764): Enable
-    //  certain passes to run with a higher priority than the others.
-    std::vector<std::unique_ptr<FuzzerPass>> passes;
-    while (passes.empty()) {
-      MaybeAddPass<FuzzerPassAddAccessChains>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassAddCompositeInserts>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassAddCompositeTypes>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassAddCopyMemory>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassAddDeadBlocks>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassAddDeadBreaks>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassAddDeadContinues>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassAddEquationInstructions>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassAddFunctionCalls>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassAddGlobalVariables>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassAddImageSampleUnusedComponents>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassAddLoads>(&passes, ir_context.get(),
-                                       &transformation_context, &fuzzer_context,
-                                       transformation_sequence_out);
-      MaybeAddPass<FuzzerPassAddLocalVariables>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassAddLoopPreheaders>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassAddOpPhiSynonyms>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassAddParameters>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassAddRelaxedDecorations>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassAddStores>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassAddSynonyms>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassAddVectorShuffleInstructions>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassApplyIdSynonyms>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassConstructComposites>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassCopyObjects>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassDonateModules>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out, donor_suppliers);
-      /*MaybeAddPass<FuzzerPassDuplicateRegionsWithSelections>(
-            &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-            transformation_sequence_out, donor_suppliers);*/
-      MaybeAddPass<FuzzerPassInlineFunctions>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassInvertComparisonOperators>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassMakeVectorOperationsDynamic>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassMergeBlocks>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassMutatePointers>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassObfuscateConstants>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassOutlineFunctions>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassPermuteBlocks>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassPermuteFunctionParameters>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassPermuteInstructions>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassPropagateInstructionsUp>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassPushIdsThroughVariables>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassReplaceAddsSubsMulsWithCarryingExtended>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassReplaceCopyMemoriesWithLoadsStores>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassReplaceCopyObjectsWithStoresLoads>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassReplaceLoadsStoresWithCopyMemories>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassReplaceParameterWithGlobal>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassReplaceLinearAlgebraInstructions>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassReplaceOpSelectsWithConditionalBranches>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassReplaceParamsWithStruct>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassSplitBlocks>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-      MaybeAddPass<FuzzerPassSwapBranchConditionalOperands>(
-          &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-          transformation_sequence_out);
-    }
-    bool is_first = true;
-    while (static_cast<uint32_t>(
-               transformation_sequence_out->transformation_size()) <
-               kTransformationLimit &&
-           (is_first ||
-            fuzzer_context.ChoosePercentage(kChanceOfApplyingAnotherPass))) {
-      is_first = false;
-      if (!ApplyPassAndCheckValidity(
-              passes[fuzzer_context.RandomIndex(passes)].get(), *ir_context,
-              tools)) {
-        return Fuzzer::FuzzerResultStatus::kFuzzerPassLedToInvalidModule;
-      }
+  // Apply some semantics-preserving passes.
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3764): Enable
+  //  certain passes to run with a higher priority than the others.
+  std::vector<std::unique_ptr<FuzzerPass>> passes;
+  while (passes.empty()) {
+    MaybeAddPass<FuzzerPassAddAccessChains>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddCompositeInserts>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddCompositeTypes>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddCopyMemory>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddDeadBlocks>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddDeadBreaks>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddDeadContinues>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddEquationInstructions>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddFunctionCalls>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddGlobalVariables>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddImageSampleUnusedComponents>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddLoads>(&passes, ir_context.get(),
+                                     &transformation_context, &fuzzer_context,
+                                     transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddLocalVariables>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddLoopPreheaders>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddOpPhiSynonyms>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddParameters>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddRelaxedDecorations>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddStores>(&passes, ir_context.get(),
+                                      &transformation_context, &fuzzer_context,
+                                      transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddSynonyms>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassAddVectorShuffleInstructions>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassApplyIdSynonyms>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassConstructComposites>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassCopyObjects>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassDonateModules>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out, donor_suppliers);
+    MaybeAddPass<FuzzerPassDuplicateRegionsWithSelections>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassInlineFunctions>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassInvertComparisonOperators>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassMakeVectorOperationsDynamic>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassMergeBlocks>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassMutatePointers>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassObfuscateConstants>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassOutlineFunctions>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassPermuteBlocks>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassPermuteFunctionParameters>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassPermuteInstructions>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassPropagateInstructionsUp>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassPushIdsThroughVariables>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassReplaceAddsSubsMulsWithCarryingExtended>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassReplaceCopyMemoriesWithLoadsStores>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassReplaceCopyObjectsWithStoresLoads>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassReplaceLoadsStoresWithCopyMemories>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassReplaceParameterWithGlobal>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassReplaceLinearAlgebraInstructions>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassReplaceOpSelectsWithConditionalBranches>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassReplaceParamsWithStruct>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassSplitBlocks>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+    MaybeAddPass<FuzzerPassSwapBranchConditionalOperands>(
+        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+        transformation_sequence_out);
+  }
+  bool is_first = true;
+  while (static_cast<uint32_t>(
+             transformation_sequence_out->transformation_size()) <
+             kTransformationLimit &&
+         (is_first ||
+          fuzzer_context.ChoosePercentage(kChanceOfApplyingAnotherPass))) {
+    is_first = false;
+    if (!ApplyPassAndCheckValidity(
+            passes[fuzzer_context.RandomIndex(passes)].get(), *ir_context,
+            tools)) {
+      return Fuzzer::FuzzerResultStatus::kFuzzerPassLedToInvalidModule;
     }
 
     // Now apply some passes that it does not make sense to apply repeatedly,
@@ -415,5 +411,5 @@
     return Fuzzer::FuzzerResultStatus::kComplete;
   }
 
-  }  // namespace fuzz
-}  // namespace spvtools
+}  // namespace fuzz
+}  // namespace fuzz

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -182,12 +182,11 @@ Fuzzer::FuzzerResultStatus Fuzzer::Run(
   PseudoRandomGenerator random_generator(seed_);
 
   // The fuzzer will introduce new ids into the module.  The module's id bound
-  // gives the smallest id that can be used for this purpose.  We add an
-  // offset to this so that there is a sizeable gap between the ids used in
-  // the original module and the ids used for fuzzing, as a readability aid.
+  // gives the smallest id that can be used for this purpose.  We add an offset
+  // to this so that there is a sizeable gap between the ids used in the
+  // original module and the ids used for fuzzing, as a readability aid.
   //
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/2541) consider
-  // the
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/2541) consider the
   //  case where the maximum id bound is reached.
   auto minimum_fresh_id = ir_context->module()->id_bound() + kIdBoundGap;
   FuzzerContext fuzzer_context(&random_generator, minimum_fresh_id);
@@ -344,6 +343,7 @@ Fuzzer::FuzzerResultStatus Fuzzer::Run(
         &passes, ir_context.get(), &transformation_context, &fuzzer_context,
         transformation_sequence_out);
   }
+
   bool is_first = true;
   while (static_cast<uint32_t>(
              transformation_sequence_out->transformation_size()) <

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -356,60 +356,61 @@ Fuzzer::FuzzerResultStatus Fuzzer::Run(
             tools)) {
       return Fuzzer::FuzzerResultStatus::kFuzzerPassLedToInvalidModule;
     }
-
-    // Now apply some passes that it does not make sense to apply repeatedly,
-    // as they do not unlock other passes.
-    std::vector<std::unique_ptr<FuzzerPass>> final_passes;
-    MaybeAddPass<FuzzerPassAdjustBranchWeights>(
-        &final_passes, ir_context.get(), &transformation_context,
-        &fuzzer_context, transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAdjustFunctionControls>(
-        &final_passes, ir_context.get(), &transformation_context,
-        &fuzzer_context, transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAdjustLoopControls>(
-        &final_passes, ir_context.get(), &transformation_context,
-        &fuzzer_context, transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAdjustMemoryOperandsMasks>(
-        &final_passes, ir_context.get(), &transformation_context,
-        &fuzzer_context, transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAdjustSelectionControls>(
-        &final_passes, ir_context.get(), &transformation_context,
-        &fuzzer_context, transformation_sequence_out);
-    MaybeAddPass<FuzzerPassAddNoContractionDecorations>(
-        &final_passes, ir_context.get(), &transformation_context,
-        &fuzzer_context, transformation_sequence_out);
-    MaybeAddPass<FuzzerPassInterchangeSignednessOfIntegerOperands>(
-        &final_passes, ir_context.get(), &transformation_context,
-        &fuzzer_context, transformation_sequence_out);
-    MaybeAddPass<FuzzerPassInterchangeZeroLikeConstants>(
-        &final_passes, ir_context.get(), &transformation_context,
-        &fuzzer_context, transformation_sequence_out);
-    MaybeAddPass<FuzzerPassPermutePhiOperands>(
-        &final_passes, ir_context.get(), &transformation_context,
-        &fuzzer_context, transformation_sequence_out);
-    MaybeAddPass<FuzzerPassReplaceOpPhiIdsFromDeadPredecessors>(
-        &final_passes, ir_context.get(), &transformation_context,
-        &fuzzer_context, transformation_sequence_out);
-    MaybeAddPass<FuzzerPassReplaceIrrelevantIds>(
-        &passes, ir_context.get(), &transformation_context, &fuzzer_context,
-        transformation_sequence_out);
-    MaybeAddPass<FuzzerPassSwapCommutableOperands>(
-        &final_passes, ir_context.get(), &transformation_context,
-        &fuzzer_context, transformation_sequence_out);
-    MaybeAddPass<FuzzerPassToggleAccessChainInstruction>(
-        &final_passes, ir_context.get(), &transformation_context,
-        &fuzzer_context, transformation_sequence_out);
-    for (auto& pass : final_passes) {
-      if (!ApplyPassAndCheckValidity(pass.get(), *ir_context, tools)) {
-        return Fuzzer::FuzzerResultStatus::kFuzzerPassLedToInvalidModule;
-      }
-    }
-
-    // Encode the module as a binary.
-    ir_context->module()->ToBinary(binary_out, false);
-
-    return Fuzzer::FuzzerResultStatus::kComplete;
   }
 
+  // Now apply some passes that it does not make sense to apply repeatedly,
+  // as they do not unlock other passes.
+  std::vector<std::unique_ptr<FuzzerPass>> final_passes;
+  MaybeAddPass<FuzzerPassAdjustBranchWeights>(
+      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
+      transformation_sequence_out);
+  MaybeAddPass<FuzzerPassAdjustFunctionControls>(
+      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
+      transformation_sequence_out);
+  MaybeAddPass<FuzzerPassAdjustLoopControls>(
+      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
+      transformation_sequence_out);
+  MaybeAddPass<FuzzerPassAdjustMemoryOperandsMasks>(
+      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
+      transformation_sequence_out);
+  MaybeAddPass<FuzzerPassAdjustSelectionControls>(
+      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
+      transformation_sequence_out);
+  MaybeAddPass<FuzzerPassAddNoContractionDecorations>(
+      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
+      transformation_sequence_out);
+  MaybeAddPass<FuzzerPassInterchangeSignednessOfIntegerOperands>(
+      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
+      transformation_sequence_out);
+  MaybeAddPass<FuzzerPassInterchangeZeroLikeConstants>(
+      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
+      transformation_sequence_out);
+  MaybeAddPass<FuzzerPassPermutePhiOperands>(
+      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
+      transformation_sequence_out);
+  MaybeAddPass<FuzzerPassReplaceOpPhiIdsFromDeadPredecessors>(
+      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
+      transformation_sequence_out);
+  MaybeAddPass<FuzzerPassReplaceIrrelevantIds>(
+      &passes, ir_context.get(), &transformation_context, &fuzzer_context,
+      transformation_sequence_out);
+  MaybeAddPass<FuzzerPassSwapCommutableOperands>(
+      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
+      transformation_sequence_out);
+  MaybeAddPass<FuzzerPassToggleAccessChainInstruction>(
+      &final_passes, ir_context.get(), &transformation_context, &fuzzer_context,
+      transformation_sequence_out);
+  for (auto& pass : final_passes) {
+    if (!ApplyPassAndCheckValidity(pass.get(), *ir_context, tools)) {
+      return Fuzzer::FuzzerResultStatus::kFuzzerPassLedToInvalidModule;
+    }
+  }
+
+  // Encode the module as a binary.
+  ir_context->module()->ToBinary(binary_out, false);
+
+  return Fuzzer::FuzzerResultStatus::kComplete;
+}
+
 }  // namespace fuzz
-}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/fuzzer_context.cpp
+++ b/source/fuzz/fuzzer_context.cpp
@@ -70,6 +70,8 @@ const std::pair<uint32_t, uint32_t> kChanceOfChoosingWorkgroupStorageClass = {
 const std::pair<uint32_t, uint32_t> kChanceOfConstructingComposite = {20, 50};
 const std::pair<uint32_t, uint32_t> kChanceOfCopyingObject = {20, 50};
 const std::pair<uint32_t, uint32_t> kChanceOfDonatingAdditionalModule = {5, 50};
+const std::pair<uint32_t, uint32_t> kChanceOfDuplicatingRegionWithSelection = {
+    20, 50};
 const std::pair<uint32_t, uint32_t> kChanceOfGoingDeeperToInsertInComposite = {
     30, 70};
 const std::pair<uint32_t, uint32_t> kChanceOfGoingDeeperWhenMakingAccessChain =
@@ -230,6 +232,8 @@ FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
   chance_of_copying_object_ = ChooseBetweenMinAndMax(kChanceOfCopyingObject);
   chance_of_donating_additional_module_ =
       ChooseBetweenMinAndMax(kChanceOfDonatingAdditionalModule);
+  chance_of_duplicating_region_with_selection_ =
+      ChooseBetweenMinAndMax(kChanceOfDuplicatingRegionWithSelection);
   chance_of_going_deeper_to_insert_in_composite_ =
       ChooseBetweenMinAndMax(kChanceOfGoingDeeperToInsertInComposite);
   chance_of_going_deeper_when_making_access_chain_ =

--- a/source/fuzz/fuzzer_context.h
+++ b/source/fuzz/fuzzer_context.h
@@ -198,6 +198,9 @@ class FuzzerContext {
   uint32_t GetChanceOfDonatingAdditionalModule() {
     return chance_of_donating_additional_module_;
   }
+  uint32_t GetChanceOfDuplicatingRegionWithSelection() {
+    return chance_of_duplicating_region_with_selection_;
+  }
   uint32_t GetChanceOfGoingDeeperToInsertInComposite() {
     return chance_of_going_deeper_to_insert_in_composite_;
   }
@@ -406,6 +409,7 @@ class FuzzerContext {
   uint32_t chance_of_constructing_composite_;
   uint32_t chance_of_copying_object_;
   uint32_t chance_of_donating_additional_module_;
+  uint32_t chance_of_duplicating_region_with_selection_;
   uint32_t chance_of_going_deeper_to_insert_in_composite_;
   uint32_t chance_of_going_deeper_when_making_access_chain_;
   uint32_t chance_of_inlining_function_;

--- a/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.cpp
+++ b/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/fuzzer_pass_duplicate_regions_with_selections.h"
+
+#include "source/fuzz/transformation_duplicate_region_with_selection.h"
+
+namespace spvtools {
+namespace fuzz {
+
+FuzzerPassDuplicateRegionsWithSelections::
+    FuzzerPassDuplicateRegionsWithSelections(
+        opt::IRContext* ir_context,
+        TransformationContext* transformation_context,
+        FuzzerContext* fuzzer_context,
+        protobufs::TransformationSequence* transformations)
+    : FuzzerPass(ir_context, transformation_context, fuzzer_context,
+                 transformations) {}
+
+FuzzerPassDuplicateRegionsWithSelections::
+    ~FuzzerPassDuplicateRegionsWithSelections() = default;
+
+void FuzzerPassDuplicateRegionsWithSelections::Apply() {
+  for (auto& function : *GetIRContext()->module()) {
+    for (auto& block : function) {
+      for (auto& instruction : block) {
+        (void)instruction;
+        if (GetFuzzerContext()->ChoosePercentage(
+                GetFuzzerContext()
+                    ->GetChanceOfDuplicatingRegionWithSelection())) {
+          continue;
+        }
+      }
+    }
+  }
+}
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.cpp
+++ b/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/fuzzer_pass_duplicate_regions_with_selections.h"
-
+#include "source/fuzz/fuzzer_util.h"
 #include "source/fuzz/transformation_duplicate_region_with_selection.h"
 
 namespace spvtools {
@@ -32,17 +32,84 @@ FuzzerPassDuplicateRegionsWithSelections::
     ~FuzzerPassDuplicateRegionsWithSelections() = default;
 
 void FuzzerPassDuplicateRegionsWithSelections::Apply() {
+  std::vector<opt::Function*> original_functions;
   for (auto& function : *GetIRContext()->module()) {
-    for (auto& block : function) {
-      for (auto& instruction : block) {
-        (void)instruction;
-        if (GetFuzzerContext()->ChoosePercentage(
-                GetFuzzerContext()
-                    ->GetChanceOfDuplicatingRegionWithSelection())) {
-          continue;
+    original_functions.push_back(&function);
+  }
+  for (auto& function : original_functions) {
+    if (!GetFuzzerContext()->ChoosePercentage(
+            GetFuzzerContext()->GetChanceOfDuplicatingRegionWithSelection())) {
+      continue;
+    }
+    std::vector<opt::BasicBlock*> start_blocks;
+    for (auto& block : *function) {
+      // We don't consider the first block to be the starting block.
+      if (&block == &*function->begin()) {
+        continue;
+      }
+      start_blocks.push_back(&block);
+    }
+    if (start_blocks.empty()) {
+      continue;
+    }
+    auto entry_block =
+        start_blocks[GetFuzzerContext()->RandomIndex(start_blocks)];
+    auto dominator_analysis = GetIRContext()->GetDominatorAnalysis(function);
+    auto postdominator_analysis =
+        GetIRContext()->GetPostDominatorAnalysis(function);
+    std::vector<opt::BasicBlock*> candidate_exit_blocks;
+    for (auto postdominates_entry_block = entry_block;
+         postdominates_entry_block != nullptr;
+         postdominates_entry_block = postdominator_analysis->ImmediateDominator(
+             postdominates_entry_block)) {
+      // Consider the block if it is dominated by the entry block, ignore it if
+      // it is a continue target.
+      if (dominator_analysis->Dominates(entry_block,
+                                        postdominates_entry_block) &&
+          !postdominates_entry_block->GetLoopMergeInst()) {
+        candidate_exit_blocks.push_back(postdominates_entry_block);
+      }
+    }
+    if (candidate_exit_blocks.empty()) {
+      continue;
+    }
+    auto exit_block = candidate_exit_blocks[GetFuzzerContext()->RandomIndex(
+        candidate_exit_blocks)];
+
+    auto region_blocks =
+        TransformationDuplicateRegionWithSelection::GetRegionBlocks(
+            GetIRContext(), entry_block, exit_block);
+    std::map<uint32_t, uint32_t> original_label_to_duplicate_label;
+    std::map<uint32_t, uint32_t> original_id_to_duplicate_id;
+    std::map<uint32_t, uint32_t> original_id_to_phi_id;
+    for (auto& block : region_blocks) {
+      original_label_to_duplicate_label[block->id()] =
+          GetFuzzerContext()->GetFreshId();
+      for (auto& instr : *block) {
+        if (instr.result_id()) {
+          original_id_to_duplicate_id[instr.result_id()] =
+              GetFuzzerContext()->GetFreshId();
+          if ((&instr == &*exit_block->tail() ||
+               fuzzerutil::IdIsAvailableBeforeInstruction(
+                   GetIRContext(), &*exit_block->tail(), instr.result_id()))) {
+            original_id_to_phi_id[instr.result_id()] =
+                GetFuzzerContext()->GetFreshId();
+          }
         }
       }
     }
+    // Make sure the transformation has access to a bool constant to be used
+    // while creating conditional construct.
+    auto condition_value = GetFuzzerContext()->ChooseEven();
+    auto condition_id = FindOrCreateBoolConstant(condition_value, false);
+    TransformationDuplicateRegionWithSelection transformation =
+        TransformationDuplicateRegionWithSelection(
+            GetFuzzerContext()->GetFreshId(), condition_id,
+            GetFuzzerContext()->GetFreshId(), entry_block->id(),
+            exit_block->id(), std::move(original_label_to_duplicate_label),
+            std::move(original_id_to_duplicate_id),
+            std::move(original_id_to_phi_id));
+    MaybeApplyTransformation(transformation);
   }
 }
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.cpp
+++ b/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.cpp
@@ -45,7 +45,7 @@ void FuzzerPassDuplicateRegionsWithSelections::Apply() {
     }
     std::vector<opt::BasicBlock*> start_blocks;
     for (auto& block : *function) {
-      // We currently don't consider the first block to be the starting block.
+      // Currently, we don't consider the first block to be the starting block.
       if (&block == &*function->begin()) {
         continue;
       }
@@ -85,8 +85,8 @@ void FuzzerPassDuplicateRegionsWithSelections::Apply() {
         TransformationDuplicateRegionWithSelection::GetRegionBlocks(
             GetIRContext(), entry_block, exit_block);
 
-    // Construct |original_label_to_duplicate_label| by iterating over all block
-    // in the region. Construct |original_id_to_duplicate_id| and
+    // Construct |original_label_to_duplicate_label| by iterating over all
+    // blocks in the region. Construct |original_id_to_duplicate_id| and
     // |original_id_to_phi_id| by iterating over all instructions in each block.
     std::map<uint32_t, uint32_t> original_label_to_duplicate_label;
     std::map<uint32_t, uint32_t> original_id_to_duplicate_id;
@@ -107,12 +107,13 @@ void FuzzerPassDuplicateRegionsWithSelections::Apply() {
         }
       }
     }
-    // Randomly decide between value "true" or "false"
+    // Randomly decide between value "true" or "false" for a bool constant.
     auto condition_value = GetFuzzerContext()->ChooseEven();
 
     // Make sure the transformation has access to a bool constant to be used
     // while creating conditional construct.
     auto condition_id = FindOrCreateBoolConstant(condition_value, true);
+
     TransformationDuplicateRegionWithSelection transformation =
         TransformationDuplicateRegionWithSelection(
             GetFuzzerContext()->GetFreshId(), condition_id,

--- a/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.cpp
+++ b/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.cpp
@@ -36,14 +36,16 @@ void FuzzerPassDuplicateRegionsWithSelections::Apply() {
   for (auto& function : *GetIRContext()->module()) {
     original_functions.push_back(&function);
   }
+  // Iterate over all of the functions in the module.
   for (auto& function : original_functions) {
+    // Randomly decide whether to apply the transformation.
     if (!GetFuzzerContext()->ChoosePercentage(
             GetFuzzerContext()->GetChanceOfDuplicatingRegionWithSelection())) {
       continue;
     }
     std::vector<opt::BasicBlock*> start_blocks;
     for (auto& block : *function) {
-      // We don't consider the first block to be the starting block.
+      // We currently don't consider the first block to be the starting block.
       if (&block == &*function->begin()) {
         continue;
       }
@@ -101,7 +103,7 @@ void FuzzerPassDuplicateRegionsWithSelections::Apply() {
     // Make sure the transformation has access to a bool constant to be used
     // while creating conditional construct.
     auto condition_value = GetFuzzerContext()->ChooseEven();
-    auto condition_id = FindOrCreateBoolConstant(condition_value, false);
+    auto condition_id = FindOrCreateBoolConstant(condition_value, true);
     TransformationDuplicateRegionWithSelection transformation =
         TransformationDuplicateRegionWithSelection(
             GetFuzzerContext()->GetFreshId(), condition_id,

--- a/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.h
+++ b/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SOURCE_FUZZ_FUZZER_PASS_DUPLICATE_REGIONS_WITH_SELECTIONS_H
-#define SOURCE_FUZZ_FUZZER_PASS_DUPLICATE_REGIONS_WITH_SELECTIONS_H
+#ifndef SOURCE_FUZZ_FUZZER_PASS_DUPLICATE_REGIONS_WITH_SELECTIONS_H_
+#define SOURCE_FUZZ_FUZZER_PASS_DUPLICATE_REGIONS_WITH_SELECTIONS_H_
 
 #include "source/fuzz/fuzzer_pass.h"
 
@@ -39,4 +39,4 @@ class FuzzerPassDuplicateRegionsWithSelections : public FuzzerPass {
 }  // namespace fuzz
 }  // namespace spvtools
 
-#endif  // SOURCE_FUZZ_FUZZER_PASS_DUPLICATE_REGIONS_WITH_SELECTIONS_H
+#endif  // SOURCE_FUZZ_FUZZER_PASS_DUPLICATE_REGIONS_WITH_SELECTIONS_H_

--- a/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.h
+++ b/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.h
@@ -12,14 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SPIRV_TOOLS_FUZZER_PASS_DUPLICATE_REGIONS_WITH_SELECTIONS_H
-#define SPIRV_TOOLS_FUZZER_PASS_DUPLICATE_REGIONS_WITH_SELECTIONS_H
+#ifndef SOURCE_FUZZ_FUZZER_PASS_DUPLICATE_REGIONS_WITH_SELECTIONS_H
+#define SOURCE_FUZZ_FUZZER_PASS_DUPLICATE_REGIONS_WITH_SELECTIONS_H
 
 #include "source/fuzz/fuzzer_pass.h"
 
 namespace spvtools {
 namespace fuzz {
 
+// A fuzzer pass that iterates over the whole module. For each function it
+// finds a single-entry, single-exit region with its constructs and their merge
+// blocks either completely within or completely outside the region. It
+// duplicates this region using the corresponding transformation.
 class FuzzerPassDuplicateRegionsWithSelections : public FuzzerPass {
  public:
   FuzzerPassDuplicateRegionsWithSelections(
@@ -35,4 +39,4 @@ class FuzzerPassDuplicateRegionsWithSelections : public FuzzerPass {
 }  // namespace fuzz
 }  // namespace spvtools
 
-#endif  // SPIRV_TOOLS_FUZZER_PASS_DUPLICATE_REGIONS_WITH_SELECTIONS_H
+#endif  // SOURCE_FUZZ_FUZZER_PASS_DUPLICATE_REGIONS_WITH_SELECTIONS_H

--- a/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.h
+++ b/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SPIRV_TOOLS_FUZZER_PASS_DUPLICATE_REGIONS_WITH_SELECTIONS_H
+#define SPIRV_TOOLS_FUZZER_PASS_DUPLICATE_REGIONS_WITH_SELECTIONS_H
+
+#include "source/fuzz/fuzzer_pass.h"
+
+namespace spvtools {
+namespace fuzz {
+
+class FuzzerPassDuplicateRegionsWithSelections : public FuzzerPass {
+ public:
+  FuzzerPassDuplicateRegionsWithSelections(
+      opt::IRContext* ir_context, TransformationContext* transformation_context,
+      FuzzerContext* fuzzer_context,
+      protobufs::TransformationSequence* transformations);
+
+  ~FuzzerPassDuplicateRegionsWithSelections() override;
+
+  void Apply() override;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SPIRV_TOOLS_FUZZER_PASS_DUPLICATE_REGIONS_WITH_SELECTIONS_H

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -1093,35 +1093,29 @@ message TransformationDuplicateRegionWithSelection {
   // Fresh id for a label of the new entry block
   uint32 new_entry_fresh_id = 1;
 
-  // Fresh id for a boolean expression.
-  uint32 condition_fresh_id = 2;
+  // Id for a boolean expression.
+  uint32 condition_id = 2;
 
   // Fresh id for a label of the merge block of the conditional.
   uint32 merge_label_fresh_id = 3;
 
-  // Fresh id for a label of the "then" branch of the conditional.
-  uint32 then_label_fresh_id = 4;
-
-  // Fresh id for a label of the "else" branch of the conditional.
-  uint32 else_label_fresh_id = 5;
-
   // Block id of the entry block of the original region.
-  uint32 entry_block_id = 6;
+  uint32 entry_block_id = 4;
 
   // Block id of the exit block of the original region.
-  uint32 exit_block_id = 7;
+  uint32 exit_block_id = 5;
 
   // Map that maps from a label in the original region to the corresponding label
   // in the duplicated region.
-  repeated UInt32Pair original_label_to_duplicate_label = 8;
+  repeated UInt32Pair original_label_to_duplicate_label = 6;
 
   // Map that maps from a result id in the original region to the corresponding
   // result id in the duplicated region.
-  repeated UInt32Pair original_id_to_duplicate_id = 9;
+  repeated UInt32Pair original_id_to_duplicate_id = 7;
 
   // Map that maps from a result id in the original region to the result id of the
   // corresponding OpPhi instruction.
-  repeated UInt32Pair original_id_to_phi_id = 10;
+  repeated UInt32Pair original_id_to_phi_id = 8;
 }
 
 message TransformationEquationInstruction {

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -1085,12 +1085,12 @@ message TransformationComputeDataSynonymFactClosure {
 
 message TransformationDuplicateRegionWithSelection {
 
-  // A transformation that inserts a conditional statement on a boolean expression
+  // A transformation that inserts a conditional statement with a boolean expression
   // of arbitrary value and duplicates a given single-entry, single-exit region, so
-  // that it is present in every conditional branch and will be executed regardless
+  // that it is present in each conditional branch and will be executed regardless
   // of which branch will be taken.
 
-  // Fresh id for a label of the new entry block
+  // Fresh id for a label of the new entry block.
   uint32 new_entry_fresh_id = 1;
 
   // Id for a boolean expression.

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -1090,35 +1090,38 @@ message TransformationDuplicateRegionWithSelection {
   // that it is present in every conditional branch and will be executed regardless
   // of which branch will be taken.
 
+  // Fresh id for a label of the new entry block
+  uint32 new_entry_fresh_id = 1;
+
   // Fresh id for a boolean expression.
-  uint32 condition_fresh_id = 1;
+  uint32 condition_fresh_id = 2;
 
   // Fresh id for a label of the merge block of the conditional.
-  uint32 merge_label_fresh_id = 2;
+  uint32 merge_label_fresh_id = 3;
 
   // Fresh id for a label of the "then" branch of the conditional.
-  uint32 then_label_fresh_id = 3;
+  uint32 then_label_fresh_id = 4;
 
   // Fresh id for a label of the "else" branch of the conditional.
-  uint32 else_label_fresh_id = 4;
+  uint32 else_label_fresh_id = 5;
 
   // Block id of the entry block of the original region.
-  uint32 entry_block_id = 5;
+  uint32 entry_block_id = 6;
 
   // Block id of the exit block of the original region.
-  uint32 exit_block_id = 6;
+  uint32 exit_block_id = 7;
 
   // Map that maps from a label in the original region to the corresponding label
   // in the duplicated region.
-  repeated UInt32Pair original_label_to_duplicate_label = 7;
+  repeated UInt32Pair original_label_to_duplicate_label = 8;
 
   // Map that maps from a result id in the original region to the corresponding
   // result id in the duplicated region.
-  repeated UInt32Pair original_id_to_duplicate_id = 8;
+  repeated UInt32Pair original_id_to_duplicate_id = 9;
 
   // Map that maps from a result id in the original region to the result id of the
   // corresponding OpPhi instruction.
-  repeated UInt32Pair original_id_to_phi_id = 9;
+  repeated UInt32Pair original_id_to_phi_id = 10;
 }
 
 message TransformationEquationInstruction {

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -419,6 +419,7 @@ message Transformation {
     TransformationReplaceIrrelevantId replace_irrelevant_id = 72;
     TransformationReplaceOpPhiIdFromDeadPredecessor replace_opphi_id_from_dead_predecessor = 73;
     TransformationReplaceOpSelectWithConditionalBranch replace_opselect_with_conditional_branch = 74;
+    TransformationDuplicateRegionWithSelection duplicate_region_with_selection = 75;
     // Add additional option using the next available number.
   }
 }
@@ -1080,6 +1081,44 @@ message TransformationComputeDataSynonymFactClosure {
   // larger than this size will be skipped.
   uint32 maximum_equivalence_class_size = 1;
 
+}
+
+message TransformationDuplicateRegionWithSelection {
+
+  // A transformation that inserts a conditional statement on a boolean expression
+  // of arbitrary value and duplicates a given single-entry, single-exit region, so
+  // that it is present in every conditional branch and will be executed regardless
+  // of which branch will be taken.
+
+  // Fresh id for a boolean expression.
+  uint32 condition_fresh_id = 1;
+
+  // Fresh id for a label of the merge block of the conditional.
+  uint32 merge_label_fresh_id = 2;
+
+  // Fresh id for a label of the "then" branch of the conditional.
+  uint32 then_label_fresh_id = 3;
+
+  // Fresh id for a label of the "else" branch of the conditional.
+  uint32 else_label_fresh_id = 4;
+
+  // Block id of the entry block of the original region.
+  uint32 entry_block_id = 5;
+
+  // Block id of the exit block of the original region.
+  uint32 exit_block_id = 6;
+
+  // Map that maps from a label in the original region to the corresponding label
+  // in the duplicated region.
+  repeated UInt32Pair original_label_to_duplicate_label = 7;
+
+  // Map that maps from a result id in the original region to the corresponding
+  // result id in the duplicated region.
+  repeated UInt32Pair original_id_to_duplicate_id = 8;
+
+  // Map that maps from a result id in the original region to the result id of the
+  // corresponding OpPhi instruction.
+  repeated UInt32Pair original_id_to_phi_id = 9;
 }
 
 message TransformationEquationInstruction {

--- a/source/fuzz/transformation.cpp
+++ b/source/fuzz/transformation.cpp
@@ -52,6 +52,7 @@
 #include "source/fuzz/transformation_composite_extract.h"
 #include "source/fuzz/transformation_composite_insert.h"
 #include "source/fuzz/transformation_compute_data_synonym_fact_closure.h"
+#include "source/fuzz/transformation_duplicate_region_with_selection.h"
 #include "source/fuzz/transformation_equation_instruction.h"
 #include "source/fuzz/transformation_function_call.h"
 #include "source/fuzz/transformation_inline_function.h"
@@ -196,6 +197,10 @@ std::unique_ptr<Transformation> Transformation::FromMessage(
         kComputeDataSynonymFactClosure:
       return MakeUnique<TransformationComputeDataSynonymFactClosure>(
           message.compute_data_synonym_fact_closure());
+    case protobufs::Transformation::TransformationCase::
+        kDuplicateRegionWithSelection:
+      return MakeUnique<TransformationDuplicateRegionWithSelection>(
+          message.duplicate_region_with_selection());
     case protobufs::Transformation::TransformationCase::kEquationInstruction:
       return MakeUnique<TransformationEquationInstruction>(
           message.equation_instruction());

--- a/source/fuzz/transformation_duplicate_region_with_selection.cpp
+++ b/source/fuzz/transformation_duplicate_region_with_selection.cpp
@@ -388,16 +388,16 @@ void TransformationDuplicateRegionWithSelection::Apply(
       // replace it with the value from |original_id_to_duplicate_id|.
       // If a label from the original region was used in this instruction,
       // replace it with the value from |original_label_to_duplicate_label|.
-      cloned_instr->ForEachId([original_id_to_duplicate_id,
-                               original_label_to_duplicate_label,
-                               ir_context](uint32_t* op) {
-        if (original_id_to_duplicate_id.count(*op) != 0) {
-          *op = original_id_to_duplicate_id.at(*op);
-        }
-        if (original_label_to_duplicate_label.count(*op) != 0) {
-          *op = original_label_to_duplicate_label.at(*op);
-        }
-      });
+      cloned_instr->ForEachId(
+          [original_id_to_duplicate_id,
+           original_label_to_duplicate_label](uint32_t* op) {
+            if (original_id_to_duplicate_id.count(*op) != 0) {
+              *op = original_id_to_duplicate_id.at(*op);
+            }
+            if (original_label_to_duplicate_label.count(*op) != 0) {
+              *op = original_label_to_duplicate_label.at(*op);
+            }
+          });
     }
 
     // If the block is the first duplicated block, insert it before the exit

--- a/source/fuzz/transformation_duplicate_region_with_selection.cpp
+++ b/source/fuzz/transformation_duplicate_region_with_selection.cpp
@@ -19,21 +19,6 @@
 namespace spvtools {
 namespace fuzz {
 
-/*
- * TransformationAddParameter::TransformationAddParameter(
-    uint32_t function_id, uint32_t parameter_fresh_id,
-    uint32_t parameter_type_id, std::map<uint32_t, uint32_t> call_parameter_ids,
-    uint32_t function_type_fresh_id) {
-  message_.set_function_id(function_id);
-  message_.set_parameter_fresh_id(parameter_fresh_id);
-  message_.set_parameter_type_id(parameter_type_id);
-  *message_.mutable_call_parameter_ids() =
-      fuzzerutil::MapToRepeatedUInt32Pair(call_parameter_ids);
-  message_.set_function_type_fresh_id(function_type_fresh_id);
-}
-
- */
-
 TransformationDuplicateRegionWithSelection::
     TransformationDuplicateRegionWithSelection(
         const spvtools::fuzz::protobufs::
@@ -42,12 +27,14 @@ TransformationDuplicateRegionWithSelection::
 
 TransformationDuplicateRegionWithSelection::
     TransformationDuplicateRegionWithSelection(
-        uint32_t condition_fresh_id, uint32_t merge_label_fresh_id,
-        uint32_t then_label_fresh_id, uint32_t else_label_fresh_id,
-        uint32_t entry_block_id, uint32_t exit_block_id,
+        uint32_t new_entry_fresh_id, uint32_t condition_fresh_id,
+        uint32_t merge_label_fresh_id, uint32_t then_label_fresh_id,
+        uint32_t else_label_fresh_id, uint32_t entry_block_id,
+        uint32_t exit_block_id,
         std::map<uint32_t, uint32_t> original_label_to_duplicate_label,
         std::map<uint32_t, uint32_t> original_id_to_duplicate_id,
         std::map<uint32_t, uint32_t> original_id_to_phi_id) {
+  message_.set_new_entry_fresh_id(new_entry_fresh_id);
   message_.set_condition_fresh_id(condition_fresh_id);
   message_.set_merge_label_fresh_id(merge_label_fresh_id);
   message_.set_then_label_fresh_id(then_label_fresh_id);
@@ -63,13 +50,395 @@ TransformationDuplicateRegionWithSelection::
 }
 
 bool TransformationDuplicateRegionWithSelection::IsApplicable(
-    opt::IRContext* /*ir_context*/,
+    opt::IRContext* ir_context,
     const TransformationContext& /*transformation_context*/) const {
-  return false;
+  std::set<uint32_t> ids_used_by_this_transformation;
+
+  // The various new ids used by the transformation must be fresh and distinct.
+  if (!CheckIdIsFreshAndNotUsedByThisTransformation(
+          message_.merge_label_fresh_id(), ir_context,
+          &ids_used_by_this_transformation)) {
+    return false;
+  }
+  if (!CheckIdIsFreshAndNotUsedByThisTransformation(
+          message_.then_label_fresh_id(), ir_context,
+          &ids_used_by_this_transformation)) {
+    return false;
+  }
+  if (!CheckIdIsFreshAndNotUsedByThisTransformation(
+          message_.else_label_fresh_id(), ir_context,
+          &ids_used_by_this_transformation)) {
+    return false;
+  }
+
+  // The entry and exit block ids must refer to blocks.
+  for (auto block_id : {message_.entry_block_id(), message_.exit_block_id()}) {
+    auto block_label = ir_context->get_def_use_mgr()->GetDef(block_id);
+    if (!block_label || block_label->opcode() != SpvOpLabel) {
+      return false;
+    }
+  }
+  auto entry_block = ir_context->cfg()->block(message_.entry_block_id());
+  auto exit_block = ir_context->cfg()->block(message_.exit_block_id());
+
+  // The block must be in the same function.
+  if (entry_block->GetParent() != exit_block->GetParent()) {
+    return false;
+  }
+
+  // The entry block must dominate the exit block.
+  auto dominator_analysis =
+      ir_context->GetDominatorAnalysis(entry_block->GetParent());
+  if (!dominator_analysis->Dominates(entry_block, exit_block)) {
+    return false;
+  }
+
+  // The exit block must post-dominate the entry block.
+  auto postdominator_analysis =
+      ir_context->GetPostDominatorAnalysis(entry_block->GetParent());
+  if (!postdominator_analysis->Dominates(exit_block, entry_block)) {
+    return false;
+  }
+
+  auto enclosing_function = entry_block->GetParent();
+
+  std::set<opt::BasicBlock*> region_set;
+  for (auto& block : *enclosing_function) {
+    if (dominator_analysis->Dominates(entry_block, &block) &&
+        postdominator_analysis->Dominates(exit_block, &block)) {
+      region_set.insert(&block);
+    }
+  }
+  // Check whether |region_set| really is a single-entry single-exit region, and
+  // also check whether structured control flow constructs and their merge
+  // and continue constructs are either wholly in or wholly out of the region -
+  // e.g. avoid the situation where the region contains the head of a loop but
+  // not the loop's continue construct.
+  //
+  // This is achieved by going through every block in the function that contains
+  // the region.
+  for (auto& block : *entry_block->GetParent()) {
+    if (&block == exit_block) {
+      // It is OK (and typically expected) for the exit block of the region to
+      // have successors outside the region.
+      //
+      // It is not OK for the exit block to head a loop construct.
+      if (block.GetLoopMergeInst()) {
+        return false;
+      }
+      continue;
+    }
+
+    if (region_set.count(&block) != 0) {
+      // The block is in the region and is not the region's exit block.  Let's
+      // see whether all of the block's successors are in the region.  If they
+      // are not, the region is not single-entry single-exit.
+      bool all_successors_in_region = true;
+      block.WhileEachSuccessorLabel([&all_successors_in_region, ir_context,
+                                     &region_set](uint32_t successor) -> bool {
+        if (region_set.count(ir_context->cfg()->block(successor)) == 0) {
+          all_successors_in_region = false;
+          return false;
+        }
+        return true;
+      });
+      if (!all_successors_in_region) {
+        return false;
+      }
+    }
+
+    if (auto merge = block.GetMergeInst()) {
+      // The block is a loop or selection header -- the header and its
+      // associated merge block had better both be in the region or both be
+      // outside the region.
+      auto merge_block =
+          ir_context->cfg()->block(merge->GetSingleWordOperand(0));
+      if (region_set.count(&block) != region_set.count(merge_block)) {
+        return false;
+      }
+    }
+
+    if (auto loop_merge = block.GetLoopMergeInst()) {
+      // Similar to the above, but for the continue target of a loop.
+      auto continue_target =
+          ir_context->cfg()->block(loop_merge->GetSingleWordOperand(1));
+      if (continue_target != exit_block &&
+          region_set.count(&block) != region_set.count(continue_target)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+std::set<opt::BasicBlock*>
+TransformationDuplicateRegionWithSelection::GetRegionBlocks(
+    opt::IRContext* ir_context, opt::BasicBlock* entry_block,
+    opt::BasicBlock* exit_block) {
+  auto enclosing_function = entry_block->GetParent();
+  auto dominator_analysis =
+      ir_context->GetDominatorAnalysis(enclosing_function);
+  auto postdominator_analysis =
+      ir_context->GetPostDominatorAnalysis(enclosing_function);
+
+  std::set<opt::BasicBlock*> result;
+  for (auto& block : *enclosing_function) {
+    if (dominator_analysis->Dominates(entry_block, &block) &&
+        postdominator_analysis->Dominates(exit_block, &block)) {
+      result.insert(&block);
+    }
+  }
+  return result;
 }
 
 void TransformationDuplicateRegionWithSelection::Apply(
-    opt::IRContext* /*ir_context*/, TransformationContext* /*unused*/) const {}
+    opt::IRContext* ir_context, TransformationContext* /*unused*/) const {
+  fuzzerutil::UpdateModuleIdBound(ir_context, message_.new_entry_fresh_id());
+  fuzzerutil::UpdateModuleIdBound(ir_context, message_.merge_label_fresh_id());
+  fuzzerutil::UpdateModuleIdBound(ir_context, message_.then_label_fresh_id());
+  fuzzerutil::UpdateModuleIdBound(ir_context, message_.else_label_fresh_id());
+
+  // Insert new entry block containing the main conditional instruction.
+  std::unique_ptr<opt::BasicBlock> new_entry_block =
+      MakeUnique<opt::BasicBlock>(MakeUnique<opt::Instruction>(
+          ir_context, SpvOpLabel, 0, message_.new_entry_fresh_id(),
+          opt::Instruction::OperandList()));
+
+  // Get the blocks contained in the region.
+  auto entry_block = ir_context->cfg()->block(message_.entry_block_id());
+  auto exit_block = ir_context->cfg()->block(message_.exit_block_id());
+  auto enclosing_function = entry_block->GetParent();
+
+  new_entry_block->SetParent(enclosing_function);
+
+  std::set<opt::BasicBlock*> region_blocks =
+      GetRegionBlocks(ir_context, entry_block, exit_block);
+
+  // Construct merge block.
+  std::unique_ptr<opt::BasicBlock> merge_block =
+      MakeUnique<opt::BasicBlock>(MakeUnique<opt::Instruction>(
+          ir_context, SpvOpLabel, 0, message_.merge_label_fresh_id(),
+          opt::Instruction::OperandList()));
+
+  merge_block->SetParent(enclosing_function);
+
+  auto entry_block_instr =
+      ir_context->get_def_use_mgr()->GetDef(message_.entry_block_id());
+  auto entry_block_label_id = entry_block_instr->result_id();
+
+  std::map<uint32_t, uint32_t> original_label_to_duplicate_label =
+      fuzzerutil::RepeatedUInt32PairToMap(
+          message_.original_label_to_duplicate_label());
+
+  std::map<uint32_t, uint32_t> original_id_to_duplicate_id =
+      fuzzerutil::RepeatedUInt32PairToMap(
+          message_.original_id_to_duplicate_id());
+
+  std::map<uint32_t, uint32_t> original_id_to_phi_id =
+      fuzzerutil::RepeatedUInt32PairToMap(message_.original_id_to_phi_id());
+
+  // Duplicate blocks of the original region
+  opt::BasicBlock* previous_block = nullptr;
+  for (auto block : region_blocks) {
+    auto label =
+        ir_context->get_def_use_mgr()->GetDef(block->id())->result_id();
+    std::unique_ptr<opt::BasicBlock> duplicated_block =
+        MakeUnique<opt::BasicBlock>(MakeUnique<opt::Instruction>(
+            ir_context, SpvOpLabel, 0, original_label_to_duplicate_label[label],
+            opt::Instruction::OperandList()));
+
+    for (auto instr : *block) {
+      auto cloned_instr = instr.Clone(ir_context);
+      if (instr.opcode() == SpvOpReturn || instr.opcode() == SpvOpReturnValue) {
+        continue;
+      }
+      if (block == exit_block && instr.opcode() == SpvOpBranch) {
+        continue;
+      }
+      duplicated_block->AddInstruction(
+          std::unique_ptr<opt::Instruction>(cloned_instr));
+      // If the id from the original id was used in this instruction, replace it
+      // with the duplicate id from the map |original_id_to_duplicate_id|.
+      cloned_instr->ForEachId([original_id_to_duplicate_id](uint32_t* op) {
+        if (original_id_to_duplicate_id.find(*op) !=
+            original_id_to_duplicate_id.end()) {
+          *op = original_id_to_duplicate_id.at(*op);
+        }
+      });
+    }
+
+    duplicated_block->SetParent(enclosing_function);
+    auto duplicated_block_ptr = duplicated_block.get();
+    if (previous_block) {
+      enclosing_function->InsertBasicBlockAfter(std::move(duplicated_block),
+                                                previous_block);
+    } else {
+      enclosing_function->InsertBasicBlockAfter(std::move(duplicated_block),
+                                                exit_block);
+    }
+    previous_block = duplicated_block_ptr;
+  }
+
+  std::vector<opt::Instruction*> instructions_to_be_remapped;
+  // Add OpPhi instructions to the merge block.
+  for (auto& block : region_blocks) {
+    for (auto& instr : *block) {
+      if (instr.result_id() != 0 /* &&
+          fuzzerutil::IdIsAvailableBeforeInstruction(
+              ir_context, &merge_branch_instr, instr.result_id())*/) {
+        instructions_to_be_remapped.push_back(&instr);
+        merge_block->AddInstruction(MakeUnique<opt::Instruction>(
+            ir_context, SpvOpPhi, instr.type_id(),
+            original_id_to_phi_id[instr.result_id()],
+            opt::Instruction::OperandList({
+                {SPV_OPERAND_TYPE_ID, {instr.result_id()}},
+                {SPV_OPERAND_TYPE_ID, {entry_block_label_id}},
+                {SPV_OPERAND_TYPE_ID,
+                 {original_id_to_duplicate_id[instr.result_id()]}},
+                {SPV_OPERAND_TYPE_ID,
+                 {original_label_to_duplicate_label[entry_block_label_id]}},
+            })));
+        fuzzerutil::UpdateModuleIdBound(
+            ir_context, original_id_to_phi_id[instr.result_id()]);
+
+        ir_context->get_def_use_mgr()->ForEachUse(
+            &instr,
+            [this, ir_context, &instr, region_blocks, original_id_to_phi_id,
+             &merge_block](opt::Instruction* user, uint32_t operand_index) {
+              auto user_block = ir_context->get_instr_block(user);
+              if ((region_blocks.find(user_block) != region_blocks.end()) ||
+                  user_block == merge_block.get()) {
+                return;
+              }
+              user->SetOperand(operand_index,
+                               {original_id_to_phi_id.at(instr.result_id())});
+            });
+      }
+    }
+  }
+  // Construct a conditional instruction in the |new_entry_block|. If the
+  // condition is true, the execution proceeds in the entry_block of the
+  // original region. If the condition is false, the execution proceeds in the
+  // first block of the duplicated region.
+
+  new_entry_block->AddInstruction(MakeUnique<opt::Instruction>(
+      ir_context, SpvOpSelectionMerge, 0, 0,
+      opt::Instruction::OperandList(
+          {{SPV_OPERAND_TYPE_ID, {message_.merge_label_fresh_id()}},
+           {SPV_OPERAND_TYPE_SELECTION_CONTROL, {0}}})));
+
+  new_entry_block->AddInstruction(MakeUnique<opt::Instruction>(
+      ir_context, SpvOpBranchConditional, 0, 0,
+      opt::Instruction::OperandList(
+          {{SPV_OPERAND_TYPE_ID, {message_.condition_fresh_id()}},
+           //{SPV_OPERAND_TYPE_ID, {enclosing_function->result_id()}},
+           {SPV_OPERAND_TYPE_ID, {entry_block_label_id}},
+           //{SPV_OPERAND_TYPE_ID,
+           // {original_label_to_duplicate_label[entry_block_label_id]}},
+           {SPV_OPERAND_TYPE_ID,
+            {original_label_to_duplicate_label[entry_block_label_id]}}})));
+
+  enclosing_function->InsertBasicBlockBefore(std::move(new_entry_block),
+                                             entry_block);
+
+  // If any of the blocks in the region contained an OpReturn or OpReturnValue
+  // instruction, move it to the merge block, since it will be the new exit
+  // block of the function.
+  for (auto block : region_blocks) {
+    block->ForEachInst([this, ir_context, &merge_block,
+                        &new_entry_block](opt::Instruction* instr) {
+      if (instr->opcode() == SpvOpReturn ||
+          instr->opcode() == SpvOpReturnValue) {
+        auto cloned_instr = instr->Clone(ir_context);
+        merge_block->AddInstruction(
+            std::unique_ptr<opt::Instruction>(cloned_instr));
+        ir_context->KillInst(instr);
+      }
+    });
+  }
+  exit_block->ForEachInst([this, ir_context, &merge_block,
+                           &new_entry_block](opt::Instruction* instr) {
+    if (instr->opcode() == SpvOpBranch) {
+      auto cloned_instr = instr->Clone(ir_context);
+      merge_block->AddInstruction(
+          std::unique_ptr<opt::Instruction>(cloned_instr));
+      ir_context->KillInst(instr);
+    }
+  });
+
+  // Add OpBranch instruction to the merge in the end of |exit_block|.
+  opt::Instruction merge_branch_instr = opt::Instruction(
+      ir_context, SpvOpBranch, 0, 0,
+      opt::Instruction::OperandList(
+          {{SPV_OPERAND_TYPE_ID, {message_.merge_label_fresh_id()}}}));
+
+  exit_block->AddInstruction(MakeUnique<opt::Instruction>(merge_branch_instr));
+  previous_block->AddInstruction(
+      MakeUnique<opt::Instruction>(merge_branch_instr));
+  /*
+  ir_context->InvalidateAnalysesExceptFor(opt::IRContext::kAnalysisNone);
+  auto i = ir_context->get_def_use_mgr()->GetDef(13);
+  (void)i;
+*/
+
+  enclosing_function->InsertBasicBlockAfter(std::move(merge_block),
+                                            previous_block);
+
+  // Insert the new entry block before the first block of the duplicated region.
+
+  // Execution needs to start in the new block instead of the entry block of the
+  // original region. Change all the uses of |entry_block_instr| to |new_entry|
+  ir_context->get_def_use_mgr()->ForEachUse(
+      entry_block_instr,
+      [this, ir_context](opt::Instruction* user, uint32_t operand_index) {
+        switch (user->opcode()) {
+          case SpvOpSwitch:
+          case SpvOpBranch:
+          case SpvOpBranchConditional:
+          case SpvOpLoopMerge:
+          case SpvOpSelectionMerge: {
+            user->SetOperand(operand_index, {message_.new_entry_fresh_id()});
+          } break;
+          case SpvOpName:
+            break;
+          default:
+            assert(false &&
+                   "The label id cannot be used by instructions other than "
+                   "OpSwitch, OpBranch, OpBranchConditional, OpLoopMerge, "
+                   "OpSelectionMerge");
+        }
+      });
+
+  ir_context->InvalidateAnalysesExceptFor(opt::IRContext::kAnalysisNone);
+  auto i = ir_context->get_def_use_mgr()->GetDef(13);
+  (void)i;
+
+}  // namespace fuzz
+
+/*
+for (auto block : region_blocks) {
+  block->ForEachInst(
+      [this, ir_context, &new_entry_block](opt::Instruction* instr) {
+        if (instr->opcode() == SpvOpVariable) {
+          auto cloned_instr = instr->Clone(ir_context);
+          new_entry_block->AddInstruction(
+              std::unique_ptr<opt::Instruction>(cloned_instr));
+          ir_context->KillInst(instr);
+          ir_context->get_def_use_mgr()->AnalyzeInstDefUse(cloned_instr);
+        }
+      });
+}*/
+/*
+ *   for (auto instr : *exit_block) {
+    if (instr.opcode() == SpvOpBranch) {
+      auto cloned_instr = instr.Clone(ir_context);
+      merge_block->AddInstruction(
+          std::unique_ptr<opt::Instruction>(cloned_instr));
+      ir_context->KillInst(&instr);
+      break;
+    }
+  }
+ */
 
 protobufs::Transformation
 TransformationDuplicateRegionWithSelection::ToMessage() const {

--- a/source/fuzz/transformation_duplicate_region_with_selection.cpp
+++ b/source/fuzz/transformation_duplicate_region_with_selection.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_duplicate_region_with_selection.h"
+
+#include "source/fuzz/fuzzer_util.h"
+
+namespace spvtools {
+namespace fuzz {
+
+/*
+ * TransformationAddParameter::TransformationAddParameter(
+    uint32_t function_id, uint32_t parameter_fresh_id,
+    uint32_t parameter_type_id, std::map<uint32_t, uint32_t> call_parameter_ids,
+    uint32_t function_type_fresh_id) {
+  message_.set_function_id(function_id);
+  message_.set_parameter_fresh_id(parameter_fresh_id);
+  message_.set_parameter_type_id(parameter_type_id);
+  *message_.mutable_call_parameter_ids() =
+      fuzzerutil::MapToRepeatedUInt32Pair(call_parameter_ids);
+  message_.set_function_type_fresh_id(function_type_fresh_id);
+}
+
+ */
+
+TransformationDuplicateRegionWithSelection::
+    TransformationDuplicateRegionWithSelection(
+        const spvtools::fuzz::protobufs::
+            TransformationDuplicateRegionWithSelection& message)
+    : message_(message) {}
+
+TransformationDuplicateRegionWithSelection::
+    TransformationDuplicateRegionWithSelection(
+        uint32_t condition_fresh_id, uint32_t merge_label_fresh_id,
+        uint32_t then_label_fresh_id, uint32_t else_label_fresh_id,
+        uint32_t entry_block_id, uint32_t exit_block_id,
+        std::map<uint32_t, uint32_t> original_label_to_duplicate_label,
+        std::map<uint32_t, uint32_t> original_id_to_duplicate_id,
+        std::map<uint32_t, uint32_t> original_id_to_phi_id) {
+  message_.set_condition_fresh_id(condition_fresh_id);
+  message_.set_merge_label_fresh_id(merge_label_fresh_id);
+  message_.set_then_label_fresh_id(then_label_fresh_id);
+  message_.set_else_label_fresh_id(else_label_fresh_id);
+  message_.set_entry_block_id(entry_block_id);
+  message_.set_exit_block_id(exit_block_id);
+  *message_.mutable_original_label_to_duplicate_label() =
+      fuzzerutil::MapToRepeatedUInt32Pair(original_label_to_duplicate_label);
+  *message_.mutable_original_id_to_duplicate_id() =
+      fuzzerutil::MapToRepeatedUInt32Pair(original_id_to_duplicate_id);
+  *message_.mutable_original_id_to_phi_id() =
+      fuzzerutil::MapToRepeatedUInt32Pair(original_id_to_phi_id);
+}
+
+bool TransformationDuplicateRegionWithSelection::IsApplicable(
+    opt::IRContext* /*ir_context*/,
+    const TransformationContext& /*transformation_context*/) const {
+  return false;
+}
+
+void TransformationDuplicateRegionWithSelection::Apply(
+    opt::IRContext* /*ir_context*/, TransformationContext* /*unused*/) const {}
+
+protobufs::Transformation
+TransformationDuplicateRegionWithSelection::ToMessage() const {
+  protobufs::Transformation result;
+  *result.mutable_duplicate_region_with_selection() = message_;
+  return result;
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/transformation_duplicate_region_with_selection.h
+++ b/source/fuzz/transformation_duplicate_region_with_selection.h
@@ -29,9 +29,10 @@ class TransformationDuplicateRegionWithSelection : public Transformation {
       const protobufs::TransformationDuplicateRegionWithSelection& message);
 
   explicit TransformationDuplicateRegionWithSelection(
-      uint32_t condition_fresh_id, uint32_t merge_label_fresh_id,
-      uint32_t then_label_fresh_id, uint32_t else_label_fresh_id,
-      uint32_t entry_block_id, uint32_t exit_block_id,
+      uint32_t new_entry_fresh_id, uint32_t condition_fresh_id,
+      uint32_t merge_label_fresh_id, uint32_t then_label_fresh_id,
+      uint32_t else_label_fresh_id, uint32_t entry_block_id,
+      uint32_t exit_block_id,
       std::map<uint32_t, uint32_t> original_label_to_duplicate_label,
       std::map<uint32_t, uint32_t> original_id_to_duplicate_id,
       std::map<uint32_t, uint32_t> original_id_to_phi_id);
@@ -56,6 +57,12 @@ class TransformationDuplicateRegionWithSelection : public Transformation {
   // will be executed regardless of which branch will be taken.
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
+
+  // Returns the set of blocks dominated by |entry_block| and post-dominated
+  // by |exit_block|.
+  static std::set<opt::BasicBlock*> GetRegionBlocks(
+      opt::IRContext* ir_context, opt::BasicBlock* entry_block,
+      opt::BasicBlock* exit_block);
 
   protobufs::Transformation ToMessage() const override;
 

--- a/source/fuzz/transformation_duplicate_region_with_selection.h
+++ b/source/fuzz/transformation_duplicate_region_with_selection.h
@@ -32,9 +32,9 @@ class TransformationDuplicateRegionWithSelection : public Transformation {
       uint32_t new_entry_fresh_id, uint32_t condition_id,
       uint32_t merge_label_fresh_id, uint32_t entry_block_id,
       uint32_t exit_block_id,
-      std::map<uint32_t, uint32_t> original_label_to_duplicate_label,
-      std::map<uint32_t, uint32_t> original_id_to_duplicate_id,
-      std::map<uint32_t, uint32_t> original_id_to_phi_id);
+      const std::map<uint32_t, uint32_t>& original_label_to_duplicate_label,
+      const std::map<uint32_t, uint32_t>& original_id_to_duplicate_id,
+      const std::map<uint32_t, uint32_t>& original_id_to_phi_id);
 
   // - |new_entry_fresh_id|, |merge_label_fresh_id| must be fresh and distinct.
   // - |condition_id| must refer to a valid instruction of boolean type.

--- a/source/fuzz/transformation_duplicate_region_with_selection.h
+++ b/source/fuzz/transformation_duplicate_region_with_selection.h
@@ -29,9 +29,8 @@ class TransformationDuplicateRegionWithSelection : public Transformation {
       const protobufs::TransformationDuplicateRegionWithSelection& message);
 
   explicit TransformationDuplicateRegionWithSelection(
-      uint32_t new_entry_fresh_id, uint32_t condition_fresh_id,
-      uint32_t merge_label_fresh_id, uint32_t then_label_fresh_id,
-      uint32_t else_label_fresh_id, uint32_t entry_block_id,
+      uint32_t new_entry_fresh_id, uint32_t condition_id,
+      uint32_t merge_label_fresh_id, uint32_t entry_block_id,
       uint32_t exit_block_id,
       std::map<uint32_t, uint32_t> original_label_to_duplicate_label,
       std::map<uint32_t, uint32_t> original_id_to_duplicate_id,

--- a/source/fuzz/transformation_duplicate_region_with_selection.h
+++ b/source/fuzz/transformation_duplicate_region_with_selection.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SPIRV_TOOLS_TRANSFORMATION_DUPLICATE_REGION_WITH_SELECTION_H
+#define SPIRV_TOOLS_TRANSFORMATION_DUPLICATE_REGION_WITH_SELECTION_H
+
+#include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
+#include "source/fuzz/transformation.h"
+#include "source/fuzz/transformation_context.h"
+#include "source/opt/ir_context.h"
+
+namespace spvtools {
+namespace fuzz {
+
+class TransformationDuplicateRegionWithSelection : public Transformation {
+ public:
+  explicit TransformationDuplicateRegionWithSelection(
+      const protobufs::TransformationDuplicateRegionWithSelection& message);
+
+  explicit TransformationDuplicateRegionWithSelection(
+      uint32_t condition_fresh_id, uint32_t merge_label_fresh_id,
+      uint32_t then_label_fresh_id, uint32_t else_label_fresh_id,
+      uint32_t entry_block_id, uint32_t exit_block_id,
+      std::map<uint32_t, uint32_t> original_label_to_duplicate_label,
+      std::map<uint32_t, uint32_t> original_id_to_duplicate_id,
+      std::map<uint32_t, uint32_t> original_id_to_phi_id);
+
+  // - |condition_fresh_id|, |merge_label_fresh_id|, |then_label_fresh_id|,
+  //   |else_label_fresh_id| must be fresh.
+  // - |entry_block_id| and |exit_block_id| must refer to a single-entry,
+  //   single-exit region.
+  // - |original_label_to_duplicate_label| must at least contain a key for every
+  //   block in the original region.
+  // - |original_id_to_duplicate_id| must at least contain a key for every
+  //   result id available at the end of the original region.
+  // - |original_id_to_phi_id| must at least contain a key for every result id
+  //   available at the end of the original region.
+  bool IsApplicable(
+      opt::IRContext* ir_context,
+      const TransformationContext& transformation_context) const override;
+
+  // A transformation that inserts a conditional statement on a boolean
+  // expression of arbitrary value and duplicates a given single-entry,
+  // single-exit region, so that it is present in every conditional branch and
+  // will be executed regardless of which branch will be taken.
+  void Apply(opt::IRContext* ir_context,
+             TransformationContext* transformation_context) const override;
+
+  protobufs::Transformation ToMessage() const override;
+
+ private:
+  protobufs::TransformationDuplicateRegionWithSelection message_;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SPIRV_TOOLS_TRANSFORMATION_DUPLICATE_REGION_WITH_SELECTION_H

--- a/source/fuzz/transformation_duplicate_region_with_selection.h
+++ b/source/fuzz/transformation_duplicate_region_with_selection.h
@@ -39,7 +39,9 @@ class TransformationDuplicateRegionWithSelection : public Transformation {
   // - |new_entry_fresh_id|, |merge_label_fresh_id| must be fresh and distinct.
   // - |condition_id| must refer to a valid instruction of boolean type.
   // - |entry_block_id| and |exit_block_id| must refer to valid blocks and they
-  //   must form a single-entry, single-exit region.
+  //   must form a single-entry, single-exit region. Its constructs and their
+  //   merge blocks must be either wholly within or wholly outside of the
+  //   region.
   // - |original_label_to_duplicate_label| must contain at least a key for every
   //   block in the original region.
   // - |original_id_to_duplicate_id| must contain at least a key for every

--- a/source/fuzz/transformation_duplicate_region_with_selection.h
+++ b/source/fuzz/transformation_duplicate_region_with_selection.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SPIRV_TOOLS_TRANSFORMATION_DUPLICATE_REGION_WITH_SELECTION_H
-#define SPIRV_TOOLS_TRANSFORMATION_DUPLICATE_REGION_WITH_SELECTION_H
+#ifndef SOURCE_FUZZ_TRANSFORMATION_DUPLICATE_REGION_WITH_SELECTION_H
+#define SOURCE_FUZZ_TRANSFORMATION_DUPLICATE_REGION_WITH_SELECTION_H
 
 #include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
 #include "source/fuzz/transformation.h"
@@ -75,4 +75,4 @@ class TransformationDuplicateRegionWithSelection : public Transformation {
 }  // namespace fuzz
 }  // namespace spvtools
 
-#endif  // SPIRV_TOOLS_TRANSFORMATION_DUPLICATE_REGION_WITH_SELECTION_H
+#endif  // SOURCE_FUZZ_TRANSFORMATION_DUPLICATE_REGION_WITH_SELECTION_H

--- a/source/fuzz/transformation_duplicate_region_with_selection.h
+++ b/source/fuzz/transformation_duplicate_region_with_selection.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SOURCE_FUZZ_TRANSFORMATION_DUPLICATE_REGION_WITH_SELECTION_H
-#define SOURCE_FUZZ_TRANSFORMATION_DUPLICATE_REGION_WITH_SELECTION_H
+#ifndef SOURCE_FUZZ_TRANSFORMATION_DUPLICATE_REGION_WITH_SELECTION_H_
+#define SOURCE_FUZZ_TRANSFORMATION_DUPLICATE_REGION_WITH_SELECTION_H_
 
 #include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
 #include "source/fuzz/transformation.h"
@@ -75,4 +75,4 @@ class TransformationDuplicateRegionWithSelection : public Transformation {
 }  // namespace fuzz
 }  // namespace spvtools
 
-#endif  // SOURCE_FUZZ_TRANSFORMATION_DUPLICATE_REGION_WITH_SELECTION_H
+#endif  // SOURCE_FUZZ_TRANSFORMATION_DUPLICATE_REGION_WITH_SELECTION_H_

--- a/source/fuzz/transformation_duplicate_region_with_selection.h
+++ b/source/fuzz/transformation_duplicate_region_with_selection.h
@@ -36,23 +36,24 @@ class TransformationDuplicateRegionWithSelection : public Transformation {
       std::map<uint32_t, uint32_t> original_id_to_duplicate_id,
       std::map<uint32_t, uint32_t> original_id_to_phi_id);
 
-  // - |condition_fresh_id|, |merge_label_fresh_id|, |then_label_fresh_id|,
-  //   |else_label_fresh_id| must be fresh.
-  // - |entry_block_id| and |exit_block_id| must refer to a single-entry,
-  //   single-exit region.
-  // - |original_label_to_duplicate_label| must at least contain a key for every
+  // - |new_entry_fresh_id|, |merge_label_fresh_id| must be fresh and distinct.
+  // - |condition_id| must refer to a valid instruction of boolean type.
+  // - |entry_block_id| and |exit_block_id| must refer to valid blocks and they
+  //   must form a single-entry, single-exit region.
+  // - |original_label_to_duplicate_label| must contain at least a key for every
   //   block in the original region.
-  // - |original_id_to_duplicate_id| must at least contain a key for every
-  //   result id available at the end of the original region.
-  // - |original_id_to_phi_id| must at least contain a key for every result id
+  // - |original_id_to_duplicate_id| must contain at least a key for every
+  //   result id in the original region.
+  // - |original_id_to_phi_id| must contain at least a key for every result id
   //   available at the end of the original region.
+  // - In each of these three maps, each value must be a distinct, fresh id.
   bool IsApplicable(
       opt::IRContext* ir_context,
       const TransformationContext& transformation_context) const override;
 
-  // A transformation that inserts a conditional statement on a boolean
+  // A transformation that inserts a conditional statement with a boolean
   // expression of arbitrary value and duplicates a given single-entry,
-  // single-exit region, so that it is present in every conditional branch and
+  // single-exit region, so that it is present in each conditional branch and
   // will be executed regardless of which branch will be taken.
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -62,6 +62,7 @@ if (${SPIRV_BUILD_FUZZER})
           transformation_composite_extract_test.cpp
           transformation_composite_insert_test.cpp
           transformation_compute_data_synonym_fact_closure_test.cpp
+          transformation_duplicate_region_with_selection_test.cpp
           transformation_equation_instruction_test.cpp
           transformation_function_call_test.cpp
           transformation_inline_function_test.cpp

--- a/test/fuzz/transformation_duplicate_region_with_selection_test.cpp
+++ b/test/fuzz/transformation_duplicate_region_with_selection_test.cpp
@@ -1181,13 +1181,13 @@ TEST(TransformationDuplicateRegionWithSelectionTest,
                OpStore %42 %216
                OpBranch %501
         %501 = OpLabel
-        %301 = OpPhi %8 %18 %15 %201 %110
-        %302 = OpPhi %20 %21 %15 %202 %110
         %312 = OpPhi %8 %39 %15 %212 %110
         %313 = OpPhi %8 %40 %15 %213 %110
         %314 = OpPhi %8 %41 %15 %214 %110
         %315 = OpPhi %8 %43 %15 %215 %110
         %316 = OpPhi %8 %45 %15 %216 %110
+        %301 = OpPhi %8 %18 %15 %201 %110
+        %302 = OpPhi %20 %21 %15 %202 %110
 
                OpReturn
                OpFunctionEnd
@@ -1248,7 +1248,7 @@ TEST(FuzzerPassTest, BasicTest) {
   FuzzerContext fuzzer_context(prng.get(), 100);
   protobufs::TransformationSequence transformation_sequence;
 
-  for (uint32_t i = 0; i < 40; i++) {
+  for (uint32_t i = 0; i < 100; i++) {
     FuzzerPassDuplicateRegionsWithSelections fuzzer_pass(
         context.get(), &transformation_context, &fuzzer_context,
         &transformation_sequence);

--- a/test/fuzz/transformation_duplicate_region_with_selection_test.cpp
+++ b/test/fuzz/transformation_duplicate_region_with_selection_test.cpp
@@ -15,9 +15,14 @@
 #include "source/fuzz/transformation_duplicate_region_with_selection.h"
 #include "test/fuzz/fuzz_test_util.h"
 
+/*to be removed*/
+#include "source/fuzz/fuzzer_pass_duplicate_regions_with_selections.h"
+#include "source/fuzz/pseudo_random_generator.h"
+
 namespace spvtools {
 namespace fuzz {
 namespace {
+
 TEST(TransformationDuplicateRegionWithSelectionTest, BasicUseTest) {
   // This test handles a case where the ids from the original region are used in
   // subsequent block.
@@ -282,6 +287,983 @@ TEST(TransformationDuplicateRegionWithSelectionTest, BasicExitBlockTest) {
 
   )";
   ASSERT_TRUE(IsEqual(env, expected_shader, context.get()));
+}
+
+TEST(TransformationDuplicateRegionWithSelectionTest, NotApplicableCFGTest) {
+  // This test handles few cases where the transformation is not applicable
+  // because of the control flow graph or layout of the blocks.
+
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %10 "fun(i1;"
+               OpName %9 "a"
+               OpName %18 "b"
+               OpName %25 "c"
+               OpName %27 "param"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Function %6
+          %8 = OpTypeFunction %2 %7
+         %13 = OpConstant %6 2
+         %14 = OpTypeBool
+         %24 = OpTypePointer Function %14
+         %26 = OpConstantTrue %14
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %25 = OpVariable %24 Function
+         %27 = OpVariable %7 Function
+               OpStore %25 %26
+               OpStore %27 %13
+         %28 = OpFunctionCall %2 %10 %27
+               OpReturn
+               OpFunctionEnd
+         %10 = OpFunction %2 None %8
+          %9 = OpFunctionParameter %7
+         %11 = OpLabel
+         %18 = OpVariable %7 Function
+         %12 = OpLoad %6 %9
+         %15 = OpSLessThan %14 %12 %13
+               OpSelectionMerge %17 None
+               OpBranchConditional %15 %16 %21
+         %16 = OpLabel
+         %19 = OpLoad %6 %9
+         %20 = OpIAdd %6 %19 %13
+               OpStore %18 %20
+               OpBranch %17
+         %21 = OpLabel
+         %22 = OpLoad %6 %9
+         %23 = OpISub %6 %22 %13
+               OpStore %18 %23
+               OpBranch %17
+         %17 = OpLabel
+               OpReturn
+               OpFunctionEnd
+    )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  // Bad: |entry_block_id| refers to the entry block of the function (this
+  // transformation currently avoids such cases).
+  TransformationDuplicateRegionWithSelection transformation_bad_1 =
+      TransformationDuplicateRegionWithSelection(
+          500, 26, 501, 11, 11, {{11, 100}}, {{18, 201}, {12, 202}, {15, 203}},
+          {{18, 301}, {12, 302}, {15, 303}});
+  ASSERT_FALSE(
+      transformation_bad_1.IsApplicable(context.get(), transformation_context));
+
+  // Bad: The block with id 16 does not dominate the block with id 21.
+  TransformationDuplicateRegionWithSelection transformation_bad_2 =
+      TransformationDuplicateRegionWithSelection(
+          500, 26, 501, 16, 21, {{16, 100}, {21, 101}},
+          {{19, 201}, {20, 202}, {22, 203}, {23, 204}},
+          {{19, 301}, {20, 302}, {22, 303}, {23, 304}});
+  ASSERT_FALSE(
+      transformation_bad_2.IsApplicable(context.get(), transformation_context));
+
+  // Bad: The block with id 21 does not post-dominate the block with id 11.
+  TransformationDuplicateRegionWithSelection transformation_bad_3 =
+      TransformationDuplicateRegionWithSelection(
+          500, 26, 501, 11, 21, {{11, 100}, {21, 101}},
+          {{18, 201}, {12, 202}, {15, 203}, {22, 204}, {23, 205}},
+          {{18, 301}, {12, 302}, {15, 303}, {22, 304}, {23, 305}});
+  ASSERT_FALSE(
+      transformation_bad_3.IsApplicable(context.get(), transformation_context));
+
+  // Bad: The block with id 5 is contained in a different function than the
+  // block with id 11.
+  TransformationDuplicateRegionWithSelection transformation_bad_4 =
+      TransformationDuplicateRegionWithSelection(
+          500, 26, 501, 5, 11, {{5, 100}, {11, 101}},
+          {{25, 201}, {27, 202}, {28, 203}, {18, 204}, {12, 205}, {15, 206}},
+          {{25, 301}, {27, 302}, {28, 303}, {18, 304}, {12, 305}, {15, 306}});
+  ASSERT_FALSE(
+      transformation_bad_4.IsApplicable(context.get(), transformation_context));
+}
+
+TEST(TransformationDuplicateRegionWithSelectionTest, NotApplicableIdTest) {
+  // This test handles a case where the supplied ids are either not fresh, not
+  // distinct, not valid in their context or do not refer to the existing
+  // instructions.
+
+  std::string shader = R"(
+               OpCapability Shader
+               OpCapability VariablePointers
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %10 "fun(i1;"
+               OpName %9 "a"
+               OpName %12 "b"
+               OpName %18 "c"
+               OpName %20 "param"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Function %6
+          %8 = OpTypeFunction %2 %7
+         %14 = OpConstant %6 2
+         %16 = OpTypeBool
+         %17 = OpTypePointer Function %16
+         %19 = OpConstantTrue %16
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %18 = OpVariable %17 Function
+         %20 = OpVariable %7 Function
+               OpStore %18 %19
+               OpStore %20 %14
+         %21 = OpFunctionCall %2 %10 %20
+               OpReturn
+               OpFunctionEnd
+         %10 = OpFunction %2 None %8
+          %9 = OpFunctionParameter %7
+         %11 = OpLabel
+         %12 = OpVariable %7 Function
+               OpBranch %800
+        %800 = OpLabel
+         %13 = OpLoad %6 %9
+         %15 = OpIAdd %6 %13 %14
+               OpStore %12 %15
+               OpReturn
+               OpFunctionEnd
+    )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  // Bad: A value in the |original_label_to_duplicate_label| is not a fresh id.
+  TransformationDuplicateRegionWithSelection transformation_bad_1 =
+      TransformationDuplicateRegionWithSelection(
+          500, 19, 501, 800, 800, {{800, 21}}, {{13, 201}, {15, 202}},
+          {{13, 301}, {15, 302}});
+
+  ASSERT_FALSE(
+      transformation_bad_1.IsApplicable(context.get(), transformation_context));
+
+  // Bad: Values in the |original_id_to_duplicate_id| are not distinct.
+  TransformationDuplicateRegionWithSelection transformation_bad_2 =
+      TransformationDuplicateRegionWithSelection(
+          500, 19, 501, 800, 800, {{800, 100}}, {{13, 201}, {15, 201}},
+          {{13, 301}, {15, 302}});
+  ASSERT_FALSE(
+      transformation_bad_2.IsApplicable(context.get(), transformation_context));
+
+  // Bad: Values in the |original_id_to_phi_id| are not fresh and are not
+  // distinct with previous values.
+  TransformationDuplicateRegionWithSelection transformation_bad_3 =
+      TransformationDuplicateRegionWithSelection(
+          500, 19, 501, 800, 800, {{800, 100}}, {{13, 201}, {15, 202}},
+          {{13, 18}, {15, 202}});
+  ASSERT_FALSE(
+      transformation_bad_3.IsApplicable(context.get(), transformation_context));
+
+  // Bad: |entry_block_id| does not refer to an existing instruction.
+  TransformationDuplicateRegionWithSelection transformation_bad_4 =
+      TransformationDuplicateRegionWithSelection(
+          500, 19, 501, 802, 800, {{800, 100}}, {{13, 201}, {15, 202}},
+          {{13, 301}, {15, 302}});
+  ASSERT_FALSE(
+      transformation_bad_4.IsApplicable(context.get(), transformation_context));
+
+  // Bad: |exit_block_id| does not refer to a block.
+  TransformationDuplicateRegionWithSelection transformation_bad_5 =
+      TransformationDuplicateRegionWithSelection(
+          500, 19, 501, 800, 9, {{800, 100}}, {{13, 201}, {15, 202}},
+          {{13, 301}, {15, 302}});
+  ASSERT_FALSE(
+      transformation_bad_5.IsApplicable(context.get(), transformation_context));
+
+  // Bad: |new_entry_fresh_id| is not fresh.
+  TransformationDuplicateRegionWithSelection transformation_bad_6 =
+      TransformationDuplicateRegionWithSelection(
+          20, 19, 501, 800, 800, {{800, 100}}, {{13, 201}, {15, 202}},
+          {{13, 301}, {15, 302}});
+  ASSERT_FALSE(
+      transformation_bad_6.IsApplicable(context.get(), transformation_context));
+
+  // Bad: |merge_label_fresh_id| is not fresh.
+  TransformationDuplicateRegionWithSelection transformation_bad_7 =
+      TransformationDuplicateRegionWithSelection(
+          500, 19, 20, 800, 800, {{800, 100}}, {{13, 201}, {15, 202}},
+          {{13, 301}, {15, 302}});
+  ASSERT_FALSE(
+      transformation_bad_7.IsApplicable(context.get(), transformation_context));
+
+  // Bad: Instruction with id 15 is from the original region and is available
+  // at the end of the region but it is not present in the
+  // |original_id_to_phi_id|.
+  TransformationDuplicateRegionWithSelection transformation_bad_8 =
+      TransformationDuplicateRegionWithSelection(
+          500, 19, 501, 800, 800, {{800, 100}}, {{13, 201}, {15, 202}},
+          {{13, 301}});
+  ASSERT_FALSE(
+      transformation_bad_8.IsApplicable(context.get(), transformation_context));
+
+  // Bad: Instruction with id 15 is from the original region but it is
+  // not present in the |original_id_to_duplicate_id|.
+  TransformationDuplicateRegionWithSelection transformation_bad_9 =
+      TransformationDuplicateRegionWithSelection(500, 19, 501, 800, 800,
+                                                 {{800, 100}}, {{13, 201}},
+                                                 {{13, 301}, {15, 302}});
+  ASSERT_FALSE(
+      transformation_bad_9.IsApplicable(context.get(), transformation_context));
+}
+
+TEST(TransformationDuplicateRegionWithSelectionTest, NotApplicableCFGTest2) {
+  // This test handles few cases where the transformation is not applicable
+  // because of the control flow graph or the layout of the blocks.
+
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %6 "fun("
+               OpName %10 "s"
+               OpName %12 "i"
+               OpName %29 "b"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %8 = OpTypeInt 32 1
+          %9 = OpTypePointer Function %8
+         %11 = OpConstant %8 0
+         %19 = OpConstant %8 10
+         %20 = OpTypeBool
+         %26 = OpConstant %8 1
+         %28 = OpTypePointer Function %20
+         %30 = OpConstantTrue %20
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %29 = OpVariable %28 Function
+               OpStore %29 %30
+         %31 = OpFunctionCall %2 %6
+               OpReturn
+               OpFunctionEnd
+          %6 = OpFunction %2 None %3
+          %7 = OpLabel
+         %10 = OpVariable %9 Function
+         %12 = OpVariable %9 Function
+               OpStore %10 %11
+               OpStore %12 %11
+               OpBranch %13
+         %13 = OpLabel
+               OpLoopMerge %15 %16 None
+               OpBranch %17
+         %17 = OpLabel
+         %18 = OpLoad %8 %12
+         %21 = OpSLessThan %20 %18 %19
+               OpBranchConditional %21 %14 %15
+         %14 = OpLabel
+         %22 = OpLoad %8 %10
+         %23 = OpLoad %8 %12
+         %24 = OpIAdd %8 %22 %23
+               OpStore %10 %24
+               OpBranch %16
+         %16 = OpLabel
+               OpBranch %50
+         %50 = OpLabel
+         %25 = OpLoad %8 %12
+         %27 = OpIAdd %8 %25 %26
+               OpStore %12 %27
+               OpBranch %13
+         %15 = OpLabel
+               OpReturn
+               OpFunctionEnd
+    )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+  // Bad: The exit block cannot be a header of a loop, because the region won't
+  // be a single-entry, single-exit region.
+  TransformationDuplicateRegionWithSelection transformation_bad_1 =
+      TransformationDuplicateRegionWithSelection(500, 30, 501, 13, 13,
+                                                 {{13, 100}}, {{}}, {{}});
+  ASSERT_FALSE(
+      transformation_bad_1.IsApplicable(context.get(), transformation_context));
+
+  // Bad: The block with id 13, the loop header, is in the region. The block
+  // with id 15, the loop merge block, is not in the region.
+  TransformationDuplicateRegionWithSelection transformation_bad_2 =
+      TransformationDuplicateRegionWithSelection(
+          500, 30, 501, 13, 17, {{13, 100}, {17, 101}}, {{18, 201}, {21, 202}},
+          {{18, 301}, {21, 302}});
+  ASSERT_FALSE(
+      transformation_bad_2.IsApplicable(context.get(), transformation_context));
+
+  // Bad: The block with id 13, the loop header, is not in the region. The block
+  // with id 16, the loop continue target, is in the region.
+  TransformationDuplicateRegionWithSelection transformation_bad_3 =
+      TransformationDuplicateRegionWithSelection(
+          500, 30, 501, 16, 50, {{16, 100}, {50, 101}}, {{25, 201}, {27, 202}},
+          {{25, 301}, {27, 302}});
+  ASSERT_FALSE(
+      transformation_bad_3.IsApplicable(context.get(), transformation_context));
+}
+
+TEST(TransformationDuplicateRegionWithSelectionTest, NotApplicableCFGTest3) {
+  // This test handles a case where for the block which is not the exit block,
+  // not all successors are in the region.
+
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %6 "fun("
+               OpName %14 "a"
+               OpName %19 "b"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %8 = OpTypeBool
+          %9 = OpConstantTrue %8
+         %12 = OpTypeInt 32 1
+         %13 = OpTypePointer Function %12
+         %15 = OpConstant %12 2
+         %17 = OpConstant %12 3
+         %18 = OpTypePointer Function %8
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %19 = OpVariable %18 Function
+               OpStore %19 %9
+         %20 = OpFunctionCall %2 %6
+               OpReturn
+               OpFunctionEnd
+          %6 = OpFunction %2 None %3
+          %7 = OpLabel
+         %14 = OpVariable %13 Function
+               OpSelectionMerge %11 None
+               OpBranchConditional %9 %10 %16
+         %10 = OpLabel
+               OpStore %14 %15
+               OpBranch %11
+         %16 = OpLabel
+               OpStore %14 %17
+               OpBranch %11
+         %11 = OpLabel
+               OpReturn
+               OpFunctionEnd
+    )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+  // Bad: The block with id 7, which is not an exit block, has two successors:
+  // the block with id 10 and the block with id 16. The block with id 16 is not
+  // in the region.
+  TransformationDuplicateRegionWithSelection transformation_bad_1 =
+      TransformationDuplicateRegionWithSelection(
+          500, 30, 501, 7, 10, {{13, 100}}, {{14, 201}}, {{14, 301}});
+  ASSERT_FALSE(
+      transformation_bad_1.IsApplicable(context.get(), transformation_context));
+}
+TEST(TransformationDuplicateRegionWithSelectionTest, MultipleBlocksLoopTest) {
+  // This test handles a case where the region consists of multiple blocks
+  // (they form a loop). The transformation is applicable and the region is
+  // duplicated.
+
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %6 "fun("
+               OpName %10 "s"
+               OpName %12 "i"
+               OpName %29 "b"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %8 = OpTypeInt 32 1
+          %9 = OpTypePointer Function %8
+         %11 = OpConstant %8 0
+         %19 = OpConstant %8 10
+         %20 = OpTypeBool
+         %26 = OpConstant %8 1
+         %28 = OpTypePointer Function %20
+         %30 = OpConstantTrue %20
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %29 = OpVariable %28 Function
+               OpStore %29 %30
+         %31 = OpFunctionCall %2 %6
+               OpReturn
+               OpFunctionEnd
+          %6 = OpFunction %2 None %3
+          %7 = OpLabel
+         %10 = OpVariable %9 Function
+         %12 = OpVariable %9 Function
+               OpStore %10 %11
+               OpStore %12 %11
+               OpBranch %50
+         %50 = OpLabel
+               OpBranch %13
+         %13 = OpLabel
+               OpLoopMerge %15 %16 None
+               OpBranch %17
+         %17 = OpLabel
+         %18 = OpLoad %8 %12
+         %21 = OpSLessThan %20 %18 %19
+               OpBranchConditional %21 %14 %15
+         %14 = OpLabel
+         %22 = OpLoad %8 %10
+         %23 = OpLoad %8 %12
+         %24 = OpIAdd %8 %22 %23
+               OpStore %10 %24
+               OpBranch %16
+         %16 = OpLabel
+         %25 = OpLoad %8 %12
+         %27 = OpIAdd %8 %25 %26
+               OpStore %12 %27
+               OpBranch %13
+         %15 = OpLabel
+               OpReturn
+               OpFunctionEnd
+    )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  TransformationDuplicateRegionWithSelection transformation_good_1 =
+      TransformationDuplicateRegionWithSelection(
+          500, 30, 501, 50, 15,
+          {{50, 100}, {13, 101}, {14, 102}, {15, 103}, {16, 104}, {17, 105}},
+          {{22, 201},
+           {23, 202},
+           {24, 203},
+           {25, 204},
+           {27, 205},
+           {18, 206},
+           {21, 207}},
+          {{22, 301},
+           {23, 302},
+           {24, 303},
+           {25, 304},
+           {27, 305},
+           {18, 306},
+           {21, 307}});
+  ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
+                                                 transformation_context));
+  transformation_good_1.Apply(context.get(), &transformation_context);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  std::string expected_shader = R"(
+                 OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %6 "fun("
+               OpName %10 "s"
+               OpName %12 "i"
+               OpName %29 "b"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %8 = OpTypeInt 32 1
+          %9 = OpTypePointer Function %8
+         %11 = OpConstant %8 0
+         %19 = OpConstant %8 10
+         %20 = OpTypeBool
+         %26 = OpConstant %8 1
+         %28 = OpTypePointer Function %20
+         %30 = OpConstantTrue %20
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %29 = OpVariable %28 Function
+               OpStore %29 %30
+         %31 = OpFunctionCall %2 %6
+               OpReturn
+               OpFunctionEnd
+          %6 = OpFunction %2 None %3
+          %7 = OpLabel
+         %10 = OpVariable %9 Function
+         %12 = OpVariable %9 Function
+               OpStore %10 %11
+               OpStore %12 %11
+               OpBranch %500
+        %500 = OpLabel
+               OpSelectionMerge %501 None
+               OpBranchConditional %30 %50 %100
+         %50 = OpLabel
+               OpBranch %13
+         %13 = OpLabel
+               OpLoopMerge %15 %16 None
+               OpBranch %17
+         %17 = OpLabel
+         %18 = OpLoad %8 %12
+         %21 = OpSLessThan %20 %18 %19
+               OpBranchConditional %21 %14 %15
+         %14 = OpLabel
+         %22 = OpLoad %8 %10
+         %23 = OpLoad %8 %12
+         %24 = OpIAdd %8 %22 %23
+               OpStore %10 %24
+               OpBranch %16
+         %16 = OpLabel
+         %25 = OpLoad %8 %12
+         %27 = OpIAdd %8 %25 %26
+               OpStore %12 %27
+               OpBranch %13
+         %15 = OpLabel
+               OpBranch %501
+        %100 = OpLabel
+               OpBranch %101
+        %101 = OpLabel
+               OpLoopMerge %103 %104 None
+               OpBranch %105
+        %105 = OpLabel
+        %206 = OpLoad %8 %12
+        %207 = OpSLessThan %20 %206 %19
+               OpBranchConditional %207 %102 %103
+        %102 = OpLabel
+        %201 = OpLoad %8 %10
+        %202 = OpLoad %8 %12
+        %203 = OpIAdd %8 %201 %202
+               OpStore %10 %203
+               OpBranch %104
+        %104 = OpLabel
+        %204 = OpLoad %8 %12
+        %205 = OpIAdd %8 %204 %26
+               OpStore %12 %205
+               OpBranch %101
+        %103 = OpLabel
+               OpBranch %501
+        %501 = OpLabel
+        %306 = OpPhi %8 %18 %15 %206 %103
+        %307 = OpPhi %20 %21 %15 %207 %103
+               OpReturn
+               OpFunctionEnd
+    )";
+  ASSERT_TRUE(IsEqual(env, expected_shader, context.get()));
+}
+
+TEST(TransformationDuplicateRegionWithSelectionTest,
+     MultipleBlocksNestedLoopTest) {
+  // This test handles a case where the region consists of multiple blocks
+  // (they form a nested loop). The transformation is applicable and the region
+  // is duplicated.
+
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %6 "fun("
+               OpName %10 "s"
+               OpName %12 "i"
+               OpName %22 "j"
+               OpName %38 "r"
+               OpName %42 "t"
+               OpName %47 "b"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %8 = OpTypeInt 32 1
+          %9 = OpTypePointer Function %8
+         %11 = OpConstant %8 0
+         %19 = OpConstant %8 10
+         %20 = OpTypeBool
+         %34 = OpConstant %8 1
+         %44 = OpConstant %8 2
+         %46 = OpTypePointer Function %20
+         %48 = OpConstantTrue %20
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %47 = OpVariable %46 Function
+               OpStore %47 %48
+         %49 = OpFunctionCall %2 %6
+               OpReturn
+               OpFunctionEnd
+          %6 = OpFunction %2 None %3
+          %7 = OpLabel
+         %10 = OpVariable %9 Function
+         %12 = OpVariable %9 Function
+         %22 = OpVariable %9 Function
+         %38 = OpVariable %9 Function
+         %42 = OpVariable %9 Function
+               OpStore %10 %11
+               OpStore %12 %11
+               OpBranch %13
+         %13 = OpLabel
+               OpLoopMerge %15 %16 None
+               OpBranch %17
+         %17 = OpLabel
+         %18 = OpLoad %8 %12
+         %21 = OpSLessThan %20 %18 %19
+               OpBranchConditional %21 %14 %15
+         %14 = OpLabel
+               OpStore %22 %11
+               OpBranch %23
+         %23 = OpLabel
+               OpLoopMerge %25 %26 None
+               OpBranch %27
+         %27 = OpLabel
+         %28 = OpLoad %8 %22
+         %29 = OpSLessThan %20 %28 %19
+               OpBranchConditional %29 %24 %25
+         %24 = OpLabel
+         %30 = OpLoad %8 %10
+         %31 = OpLoad %8 %12
+         %32 = OpIAdd %8 %30 %31
+               OpStore %10 %32
+               OpBranch %26
+         %26 = OpLabel
+         %33 = OpLoad %8 %22
+         %35 = OpIAdd %8 %33 %34
+               OpStore %22 %35
+               OpBranch %23
+         %25 = OpLabel
+               OpBranch %16
+         %16 = OpLabel
+         %36 = OpLoad %8 %12
+         %37 = OpIAdd %8 %36 %34
+               OpStore %12 %37
+               OpBranch %13
+         %15 = OpLabel
+         %39 = OpLoad %8 %10
+         %40 = OpLoad %8 %10
+         %41 = OpIMul %8 %39 %40
+               OpStore %38 %41
+         %43 = OpLoad %8 %10
+         %45 = OpIAdd %8 %43 %44
+               OpStore %42 %45
+               OpReturn
+               OpFunctionEnd
+    )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  TransformationDuplicateRegionWithSelection transformation_good_1 =
+      TransformationDuplicateRegionWithSelection(500, 48, 501, 13, 15,
+                                                 {{13, 100},
+                                                  {13, 101},
+                                                  {17, 102},
+                                                  {14, 103},
+                                                  {23, 104},
+                                                  {27, 105},
+                                                  {24, 106},
+                                                  {26, 107},
+                                                  {25, 108},
+                                                  {16, 109},
+                                                  {15, 110}},
+                                                 {{18, 201},
+                                                  {21, 202},
+                                                  {28, 203},
+                                                  {29, 204},
+                                                  {30, 205},
+                                                  {31, 206},
+                                                  {32, 207},
+                                                  {33, 208},
+                                                  {35, 209},
+                                                  {36, 210},
+                                                  {37, 211},
+                                                  {39, 212},
+                                                  {40, 213},
+                                                  {41, 214},
+                                                  {43, 215},
+                                                  {45, 216}},
+                                                 {{18, 301},
+                                                  {21, 302},
+                                                  {28, 303},
+                                                  {29, 304},
+                                                  {30, 305},
+                                                  {31, 306},
+                                                  {32, 307},
+                                                  {33, 308},
+                                                  {35, 309},
+                                                  {36, 310},
+                                                  {37, 311},
+                                                  {39, 312},
+                                                  {40, 313},
+                                                  {41, 314},
+                                                  {43, 315},
+                                                  {45, 316}});
+  ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
+                                                 transformation_context));
+  transformation_good_1.Apply(context.get(), &transformation_context);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  std::string expected_shader = R"(
+                 OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %6 "fun("
+               OpName %10 "s"
+               OpName %12 "i"
+               OpName %22 "j"
+               OpName %38 "r"
+               OpName %42 "t"
+               OpName %47 "b"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %8 = OpTypeInt 32 1
+          %9 = OpTypePointer Function %8
+         %11 = OpConstant %8 0
+         %19 = OpConstant %8 10
+         %20 = OpTypeBool
+         %34 = OpConstant %8 1
+         %44 = OpConstant %8 2
+         %46 = OpTypePointer Function %20
+         %48 = OpConstantTrue %20
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %47 = OpVariable %46 Function
+               OpStore %47 %48
+         %49 = OpFunctionCall %2 %6
+               OpReturn
+               OpFunctionEnd
+          %6 = OpFunction %2 None %3
+          %7 = OpLabel
+         %10 = OpVariable %9 Function
+         %12 = OpVariable %9 Function
+         %22 = OpVariable %9 Function
+         %38 = OpVariable %9 Function
+         %42 = OpVariable %9 Function
+               OpStore %10 %11
+               OpStore %12 %11
+               OpBranch %500
+        %500 = OpLabel
+               OpSelectionMerge %501 None
+               OpBranchConditional %48 %13 %100
+         %13 = OpLabel
+               OpLoopMerge %15 %16 None
+               OpBranch %17
+         %17 = OpLabel
+         %18 = OpLoad %8 %12
+         %21 = OpSLessThan %20 %18 %19
+               OpBranchConditional %21 %14 %15
+         %14 = OpLabel
+               OpStore %22 %11
+               OpBranch %23
+         %23 = OpLabel
+               OpLoopMerge %25 %26 None
+               OpBranch %27
+         %27 = OpLabel
+         %28 = OpLoad %8 %22
+         %29 = OpSLessThan %20 %28 %19
+               OpBranchConditional %29 %24 %25
+         %24 = OpLabel
+         %30 = OpLoad %8 %10
+         %31 = OpLoad %8 %12
+         %32 = OpIAdd %8 %30 %31
+               OpStore %10 %32
+               OpBranch %26
+         %26 = OpLabel
+         %33 = OpLoad %8 %22
+         %35 = OpIAdd %8 %33 %34
+               OpStore %22 %35
+               OpBranch %23
+         %25 = OpLabel
+               OpBranch %16
+         %16 = OpLabel
+         %36 = OpLoad %8 %12
+         %37 = OpIAdd %8 %36 %34
+               OpStore %12 %37
+               OpBranch %13
+         %15 = OpLabel
+         %39 = OpLoad %8 %10
+         %40 = OpLoad %8 %10
+         %41 = OpIMul %8 %39 %40
+               OpStore %38 %41
+         %43 = OpLoad %8 %10
+         %45 = OpIAdd %8 %43 %44
+               OpStore %42 %45
+               OpBranch %501
+        %100 = OpLabel
+               OpLoopMerge %110 %109 None
+               OpBranch %102
+        %102 = OpLabel
+        %201 = OpLoad %8 %12
+        %202 = OpSLessThan %20 %201 %19
+               OpBranchConditional %202 %103 %110
+        %103 = OpLabel
+               OpStore %22 %11
+               OpBranch %104
+        %104 = OpLabel
+               OpLoopMerge %108 %107 None
+               OpBranch %105
+        %105 = OpLabel
+        %203 = OpLoad %8 %22
+        %204 = OpSLessThan %20 %203 %19
+               OpBranchConditional %204 %106 %108
+        %106 = OpLabel
+        %205 = OpLoad %8 %10
+        %206 = OpLoad %8 %12
+        %207 = OpIAdd %8 %205 %206
+               OpStore %10 %207
+               OpBranch %107
+        %107 = OpLabel
+        %208 = OpLoad %8 %22
+        %209 = OpIAdd %8 %208 %34
+               OpStore %22 %209
+               OpBranch %104
+        %108 = OpLabel
+               OpBranch %109
+        %109 = OpLabel
+        %210 = OpLoad %8 %12
+        %211 = OpIAdd %8 %210 %34
+               OpStore %12 %211
+               OpBranch %100
+        %110 = OpLabel
+        %212 = OpLoad %8 %10
+        %213 = OpLoad %8 %10
+        %214 = OpIMul %8 %212 %213
+               OpStore %38 %214
+        %215 = OpLoad %8 %10
+        %216 = OpIAdd %8 %215 %44
+               OpStore %42 %216
+               OpBranch %501
+        %501 = OpLabel
+        %301 = OpPhi %8 %18 %15 %201 %110
+        %302 = OpPhi %20 %21 %15 %202 %110
+        %312 = OpPhi %8 %39 %15 %212 %110
+        %313 = OpPhi %8 %40 %15 %213 %110
+        %314 = OpPhi %8 %41 %15 %214 %110
+        %315 = OpPhi %8 %43 %15 %215 %110
+        %316 = OpPhi %8 %45 %15 %216 %110
+
+               OpReturn
+               OpFunctionEnd
+        )";
+  ASSERT_TRUE(IsEqual(env, expected_shader, context.get()));
+}
+
+TEST(FuzzerPassTest, BasicTest) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %6 "fun("
+               OpName %10 "s"
+               OpName %12 "r"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %8 = OpTypeInt 32 1
+          %9 = OpTypePointer Function %8
+         %11 = OpConstant %8 0
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %16 = OpFunctionCall %2 %6
+               OpReturn
+               OpFunctionEnd
+          %6 = OpFunction %2 None %3
+          %7 = OpLabel
+         %10 = OpVariable %9 Function
+         %12 = OpVariable %9 Function
+               OpBranch %30
+         %30 = OpLabel
+               OpStore %10 %11
+         %13 = OpLoad %8 %10
+         %14 = OpLoad %8 %10
+         %15 = OpIAdd %8 %13 %14
+               OpStore %12 %15
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_3;
+  const auto consumer = nullptr;
+
+  auto prng = MakeUnique<PseudoRandomGenerator>(0);
+
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  FuzzerContext fuzzer_context(prng.get(), 100);
+  protobufs::TransformationSequence transformation_sequence;
+
+  for (uint32_t i = 0; i < 40; i++) {
+    FuzzerPassDuplicateRegionsWithSelections fuzzer_pass(
+        context.get(), &transformation_context, &fuzzer_context,
+        &transformation_sequence);
+
+    fuzzer_pass.Apply();
+  }
+  // We just check that the result is valid.
+
+  std::vector<uint32_t> actual_binary;
+  context.get()->module()->ToBinary(&actual_binary, false);
+  SpirvTools t(env);
+  std::string actual_disassembled;
+  t.Disassemble(actual_binary, &actual_disassembled, kFuzzDisassembleOption);
+  std::cout << actual_disassembled << std::endl;
+  ASSERT_TRUE(IsValid(env, context.get()));
 }
 
 }  // namespace

--- a/test/fuzz/transformation_duplicate_region_with_selection_test.cpp
+++ b/test/fuzz/transformation_duplicate_region_with_selection_test.cpp
@@ -1147,7 +1147,8 @@ TEST(TransformationDuplicateRegionWithSelectionTest, NotApplicableEarlyReturn) {
       transformation_bad_1.IsApplicable(context.get(), transformation_context));
 }
 
-TEST(TransformationDuplicateRegionWithSelectionTest, ResolvingOpPhiEntryBlock) {
+TEST(TransformationDuplicateRegionWithSelectionTest,
+     ResolvingOpPhiEntryBlockOnePredecessor) {
   // This test handles a case where the entry block has an OpPhi instruction
   // referring to its predecessor. After transformation, this instruction needs
   // to be updated.
@@ -1223,7 +1224,7 @@ TEST(TransformationDuplicateRegionWithSelectionTest, ResolvingOpPhiEntryBlock) {
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string expected_shader = R"(
-                OpCapability Shader
+               OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %4 "main"
@@ -1267,16 +1268,14 @@ TEST(TransformationDuplicateRegionWithSelectionTest, ResolvingOpPhiEntryBlock) {
                OpStore %14 %17
                OpBranch %500
         %500 = OpLabel
+         %51 = OpPhi %6 %17 %11
                OpSelectionMerge %501 None
                OpBranchConditional %21 %50 %100
          %50 = OpLabel
-         %51 = OpPhi %6 %17 %500
                OpBranch %501
         %100 = OpLabel
-        %201 = OpPhi %6 %17 %500
                OpBranch %501
         %501 = OpLabel
-        %301 = OpPhi %6 %51 %50 %201 %100
                OpReturn
                OpFunctionEnd
     )";

--- a/test/fuzz/transformation_duplicate_region_with_selection_test.cpp
+++ b/test/fuzz/transformation_duplicate_region_with_selection_test.cpp
@@ -18,9 +18,9 @@
 namespace spvtools {
 namespace fuzz {
 namespace {
-TEST(TransformationDuplicateRegionWithSelectionTest, EntryBlockTest) {
-  // This test handles a case where the region consists of an entry block of an
-  // function.
+TEST(TransformationDuplicateRegionWithSelectionTest, BasicUseTest) {
+  // This test handles a case where the ids from the original region are used in
+  // subsequent block.
 
   std::string shader = R"(
                OpCapability Shader
@@ -52,7 +52,6 @@ TEST(TransformationDuplicateRegionWithSelectionTest, EntryBlockTest) {
                OpStore %18 %19
                OpStore %20 %14
          %21 = OpFunctionCall %2 %10 %20
-
                OpReturn
                OpFunctionEnd
          %10 = OpFunction %2 None %8
@@ -67,6 +66,7 @@ TEST(TransformationDuplicateRegionWithSelectionTest, EntryBlockTest) {
                OpBranch %900
          %900 = OpLabel
          %901 = OpIAdd %6 %15 %13
+         %902 = OpISub %6 %13 %15
                OpReturn
                OpFunctionEnd
     )";
@@ -83,20 +83,205 @@ TEST(TransformationDuplicateRegionWithSelectionTest, EntryBlockTest) {
 
   TransformationDuplicateRegionWithSelection transformation_good_1 =
       TransformationDuplicateRegionWithSelection(
-          500, 19, 501, 502, 503, 800, 800, {{800, 100}},
-          {{13, 201}, {15, 202}}, {{13, 301}, {15, 302}});
+          500, 19, 501, 800, 800, {{800, 100}}, {{13, 201}, {15, 202}},
+          {{13, 301}, {15, 302}});
 
   ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
                                                  transformation_context));
   transformation_good_1.Apply(context.get(), &transformation_context);
-  std::vector<uint32_t> actual_binary;
-  context.get()->module()->ToBinary(&actual_binary, false);
-  SpirvTools t(env);
-  std::string actual_disassembled;
-  t.Disassemble(actual_binary, &actual_disassembled, kFuzzDisassembleOption);
-  std::cout << actual_disassembled;
 
   ASSERT_TRUE(IsValid(env, context.get()));
+  std::string expected_shader = R"(
+               OpCapability Shader
+               OpCapability VariablePointers
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %10 "fun(i1;"
+               OpName %9 "a"
+               OpName %12 "b"
+               OpName %18 "c"
+               OpName %20 "param"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Function %6
+          %8 = OpTypeFunction %2 %7
+         %14 = OpConstant %6 2
+         %16 = OpTypeBool
+         %17 = OpTypePointer Function %16
+         %19 = OpConstantTrue %16
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %18 = OpVariable %17 Function
+         %20 = OpVariable %7 Function
+               OpStore %18 %19
+               OpStore %20 %14
+         %21 = OpFunctionCall %2 %10 %20
+               OpReturn
+               OpFunctionEnd
+         %10 = OpFunction %2 None %8
+          %9 = OpFunctionParameter %7
+         %11 = OpLabel
+         %12 = OpVariable %7 Function
+               OpBranch %500
+        %500 = OpLabel
+               OpSelectionMerge %501 None
+               OpBranchConditional %19 %800 %100
+        %800 = OpLabel
+         %13 = OpLoad %6 %9
+         %15 = OpIAdd %6 %13 %14
+               OpStore %12 %15
+               OpBranch %501
+        %100 = OpLabel
+        %201 = OpLoad %6 %9
+        %202 = OpIAdd %6 %201 %14
+               OpStore %12 %202
+               OpBranch %501
+        %501 = OpLabel
+        %301 = OpPhi %6 %13 %800 %201 %100
+        %302 = OpPhi %6 %15 %800 %202 %100
+               OpBranch %900
+        %900 = OpLabel
+        %901 = OpIAdd %6 %302 %301
+        %902 = OpISub %6 %301 %302
+               OpReturn
+               OpFunctionEnd
+  )";
+  ASSERT_TRUE(IsEqual(env, expected_shader, context.get()));
+}
+
+TEST(TransformationDuplicateRegionWithSelectionTest, BasicExitBlockTest) {
+  // This test handles a case where the exit block of the region is the exit
+  // block of the containing function.
+
+  std::string shader = R"(
+               OpCapability Shader
+               OpCapability VariablePointers
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %10 "fun(i1;"
+               OpName %9 "a"
+               OpName %12 "b"
+               OpName %18 "c"
+               OpName %20 "param"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Function %6
+          %8 = OpTypeFunction %2 %7
+         %14 = OpConstant %6 2
+         %16 = OpTypeBool
+         %17 = OpTypePointer Function %16
+         %19 = OpConstantTrue %16
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %18 = OpVariable %17 Function
+         %20 = OpVariable %7 Function
+               OpStore %18 %19
+               OpStore %20 %14
+         %21 = OpFunctionCall %2 %10 %20
+               OpReturn
+               OpFunctionEnd
+         %10 = OpFunction %2 None %8
+          %9 = OpFunctionParameter %7
+         %11 = OpLabel
+         %12 = OpVariable %7 Function
+               OpBranch %800
+        %800 = OpLabel
+         %13 = OpLoad %6 %9
+         %15 = OpIAdd %6 %13 %14
+               OpStore %12 %15
+               OpReturn
+               OpFunctionEnd
+    )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  TransformationDuplicateRegionWithSelection transformation_good_1 =
+      TransformationDuplicateRegionWithSelection(
+          500, 19, 501, 800, 800, {{800, 100}}, {{13, 201}, {15, 202}},
+          {{13, 301}, {15, 302}});
+
+  ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
+                                                 transformation_context));
+  transformation_good_1.Apply(context.get(), &transformation_context);
+
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  std::string expected_shader = R"(
+   OpCapability Shader
+               OpCapability VariablePointers
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %10 "fun(i1;"
+               OpName %9 "a"
+               OpName %12 "b"
+               OpName %18 "c"
+               OpName %20 "param"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Function %6
+          %8 = OpTypeFunction %2 %7
+         %14 = OpConstant %6 2
+         %16 = OpTypeBool
+         %17 = OpTypePointer Function %16
+         %19 = OpConstantTrue %16
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %18 = OpVariable %17 Function
+         %20 = OpVariable %7 Function
+               OpStore %18 %19
+               OpStore %20 %14
+         %21 = OpFunctionCall %2 %10 %20
+               OpReturn
+               OpFunctionEnd
+         %10 = OpFunction %2 None %8
+          %9 = OpFunctionParameter %7
+         %11 = OpLabel
+         %12 = OpVariable %7 Function
+               OpBranch %500
+        %500 = OpLabel
+               OpSelectionMerge %501 None
+               OpBranchConditional %19 %800 %100
+        %800 = OpLabel
+         %13 = OpLoad %6 %9
+         %15 = OpIAdd %6 %13 %14
+               OpStore %12 %15
+               OpBranch %501
+        %100 = OpLabel
+        %201 = OpLoad %6 %9
+        %202 = OpIAdd %6 %201 %14
+               OpStore %12 %202
+               OpBranch %501
+        %501 = OpLabel
+        %301 = OpPhi %6 %13 %800 %201 %100
+        %302 = OpPhi %6 %15 %800 %202 %100
+               OpReturn
+               OpFunctionEnd
+
+  )";
+  ASSERT_TRUE(IsEqual(env, expected_shader, context.get()));
 }
 
 }  // namespace

--- a/test/fuzz/transformation_duplicate_region_with_selection_test.cpp
+++ b/test/fuzz/transformation_duplicate_region_with_selection_test.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_duplicate_region_with_selection.h"
+#include "test/fuzz/fuzz_test_util.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace {
+TEST(TransformationDuplicateRegionWithSelectionTest, BasicScenarios) {
+  // This is a simple transformation and this test handles the main cases.
+
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %8 "a"
+               OpName %10 "b"
+               OpName %14 "c"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Function %6
+          %9 = OpConstant %6 4
+         %11 = OpConstant %6 6
+         %12 = OpTypeBool
+         %13 = OpTypePointer Function %12
+         %15 = OpConstantTrue %12
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+          %8 = OpVariable %7 Function
+         %10 = OpVariable %7 Function
+         %14 = OpVariable %13 Function
+               OpStore %8 %9
+               OpStore %10 %11
+               OpStore %14 %15
+               OpSelectionMerge %19 None
+               OpBranchConditional %15 %19 %100
+        %100 = OpLabel
+         %25 = OpISub %6 %9 %11
+         %28 = OpLogicalNot %12 %15
+               OpBranch %19
+         %19 = OpLabel
+         %27 = OpISub %6 %9 %11
+               OpReturn
+               OpFunctionEnd
+    )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+}
+
+}  // namespace
+}  // namespace fuzz
+}  // namespace spvtools


### PR DESCRIPTION
Adds a transformation that inserts a conditional statement with a
boolean expression of arbitrary value and duplicates a given
single-entry, single-exit region, so that it is present in each
conditional branch and will be executed regardless of which branch will
be taken.

Fixes #3614 