### PR TITLE
Improve spirv-fuzz CMake code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,8 @@ if(SPIRV_BUILD_COMPRESSION)
           "Please remove SPIRV_BUILD_COMPRESSION from your build options.")
 endif(SPIRV_BUILD_COMPRESSION)
 
+option(SPIRV_BUILD_FUZZER "Build spirv-fuzz" OFF)
+
 option(SPIRV_WERROR "Enable error on warning" ON)
 if(("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR (("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang") AND (NOT CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")))
   set(COMPILER_IS_LIKE_GNU TRUE)

--- a/README.md
+++ b/README.md
@@ -349,10 +349,7 @@ option, like so:
 
 ```sh
 # In <spirv-dir> (the SPIRV-Tools repo root):
-git clone https://github.com/protocolbuffers/protobuf external/protobuf
-pushd external/protobuf
-git checkout v3.7.1
-popd
+git clone --depth=1 --branch v3.13.0 https://github.com/protocolbuffers/protobuf external/protobuf
 
 # In your build directory:
 cmake [-G <platform-generator>] <spirv-dir> -DSPIRV_BUILD_FUZZER=ON

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -152,27 +152,7 @@ if(SPIRV_BUILD_FUZZER)
       add_compile_options(-Wno-inconsistent-missing-override)
     endif()
 
-    set(
-        SPIRV_TOOLS_PROTOBUF_DEFINITIONS
-        -DGOOGLE_PROTOBUF_NO_RTTI=1
-        -DGOOGLE_PROTOBUF_USE_UNALIGNED=0)
-
-    # Compile protobufs with the above definitions.
-#    add_compile_definitions(${SPIRV_TOOLS_PROTOBUF_DEFINITIONS})
-    set_property(
-        DIRECTORY  "${SPIRV_TOOLS_PROTOBUF_DIR}"
-        APPEND PROPERTY COMPILE_DEFINITIONS
-        ${SPIRV_TOOLS_PROTOBUF_DEFINITIONS})
-
     add_subdirectory(${SPIRV_TOOLS_PROTOBUF_DIR} EXCLUDE_FROM_ALL)
-
-    # Also, add the definitions to the interface of libprotobuf.
-    target_compile_definitions(libprotobuf PUBLIC ${SPIRV_TOOLS_PROTOBUF_DEFINITIONS})
-
-
-    get_directory_property(SPIRV_TOOLS_TEMP_D COMPILE_DEFINITIONS)
-
-    message(FATAL_ERROR ${SPIRV_TOOLS_TEMP_D})
 
   endif()
 endif()

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -137,6 +137,23 @@ if (NOT ${SPIRV_SKIP_TESTS})
 endif()
 
 if(SPIRV_BUILD_FUZZER)
+
+  function(backup_compile_options)
+    get_property(
+        SPIRV_TOOLS_BACKUP_EXTERNAL_COMPILE_OPTIONS
+        DIRECTORY
+        PROPERTY COMPILE_OPTIONS
+        )
+  endfunction()
+
+  function(restore_compile_options)
+    set_property(
+        DIRECTORY
+        PROPERTY COMPILE_OPTIONS
+        ${SPIRV_TOOLS_BACKUP_EXTERNAL_COMPILE_OPTIONS}
+    )
+  endfunction()
+
   if(NOT TARGET protobuf::libprotobuf OR NOT TARGET protobuf::protoc)
 
     set(SPIRV_TOOLS_PROTOBUF_DIR ${CMAKE_CURRENT_SOURCE_DIR}/protobuf/cmake)
@@ -148,11 +165,15 @@ if(SPIRV_BUILD_FUZZER)
     set(protobuf_BUILD_TESTS OFF CACHE BOOL "Disable protobuf tests")
     set(protobuf_MSVC_STATIC_RUNTIME OFF CACHE BOOL "Do not build protobuf static runtime")
 
+    backup_compile_options()
+
     if (${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
-      add_compile_options(-Wno-inconsistent-missing-override)
+      add_compile_options(-Wno-inconsistent-missing-override -Wno-shadow)
     endif()
 
     add_subdirectory(${SPIRV_TOOLS_PROTOBUF_DIR} EXCLUDE_FROM_ALL)
+
+    restore_compile_options()
 
   endif()
 endif()

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -168,7 +168,7 @@ if(SPIRV_BUILD_FUZZER)
     backup_compile_options()
 
     if (${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
-      add_compile_options(-Wno-inconsistent-missing-override -Wno-shadow)
+      add_compile_options(-Wno-inconsistent-missing-override)
     endif()
 
     add_subdirectory(${SPIRV_TOOLS_PROTOBUF_DIR} EXCLUDE_FROM_ALL)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -74,11 +74,11 @@ if (NOT ${SPIRV_SKIP_TESTS})
           "Use shared (DLL) run-time lib even when Google Test is built as static lib."
           ON)
       endif()
-      # gtest requires special defines for building as a shared 
+      # gtest requires special defines for building as a shared
       # library, simply always build as static.
-      push_variable(BUILD_SHARED_LIBS 0) 
+      push_variable(BUILD_SHARED_LIBS 0)
       add_subdirectory(${GMOCK_DIR} EXCLUDE_FROM_ALL)
-      pop_variable(BUILD_SHARED_LIBS) 
+      pop_variable(BUILD_SHARED_LIBS)
     endif()
   endif()
   if (TARGET gmock)
@@ -137,16 +137,42 @@ if (NOT ${SPIRV_SKIP_TESTS})
 endif()
 
 if(SPIRV_BUILD_FUZZER)
-  set(PROTOBUF_DIR ${CMAKE_CURRENT_SOURCE_DIR}/protobuf/cmake)
-  set(protobuf_BUILD_TESTS OFF CACHE BOOL "Disable protobuf tests")
-  set(protobuf_MSVC_STATIC_RUNTIME OFF CACHE BOOL "Do not build protobuf static runtime")
-  if (IS_DIRECTORY ${PROTOBUF_DIR})
-    if (${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
-      add_definitions(-Wno-inconsistent-missing-override)
+  if(NOT TARGET protobuf::libprotobuf OR NOT TARGET protobuf::protoc)
+
+    set(SPIRV_TOOLS_PROTOBUF_DIR ${CMAKE_CURRENT_SOURCE_DIR}/protobuf/cmake)
+    if (NOT IS_DIRECTORY ${SPIRV_TOOLS_PROTOBUF_DIR})
+      message(
+          FATAL_ERROR
+          "protobuf not found - please checkout a copy under external/.")
     endif()
-    add_subdirectory(${PROTOBUF_DIR} EXCLUDE_FROM_ALL)
-  else()
-    message(FATAL_ERROR
-      "protobuf not found - please checkout a copy under external/.")
+    set(protobuf_BUILD_TESTS OFF CACHE BOOL "Disable protobuf tests")
+    set(protobuf_MSVC_STATIC_RUNTIME OFF CACHE BOOL "Do not build protobuf static runtime")
+
+    if (${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
+      add_compile_options(-Wno-inconsistent-missing-override)
+    endif()
+
+    set(
+        SPIRV_TOOLS_PROTOBUF_DEFINITIONS
+        -DGOOGLE_PROTOBUF_NO_RTTI=1
+        -DGOOGLE_PROTOBUF_USE_UNALIGNED=0)
+
+    # Compile protobufs with the above definitions.
+#    add_compile_definitions(${SPIRV_TOOLS_PROTOBUF_DEFINITIONS})
+    set_property(
+        DIRECTORY  "${SPIRV_TOOLS_PROTOBUF_DIR}"
+        APPEND PROPERTY COMPILE_DEFINITIONS
+        ${SPIRV_TOOLS_PROTOBUF_DEFINITIONS})
+
+    add_subdirectory(${SPIRV_TOOLS_PROTOBUF_DIR} EXCLUDE_FROM_ALL)
+
+    # Also, add the definitions to the interface of libprotobuf.
+    target_compile_definitions(libprotobuf PUBLIC ${SPIRV_TOOLS_PROTOBUF_DEFINITIONS})
+
+
+    get_directory_property(SPIRV_TOOLS_TEMP_D COMPILE_DEFINITIONS)
+
+    message(FATAL_ERROR ${SPIRV_TOOLS_TEMP_D})
+
   endif()
-endif(SPIRV_BUILD_FUZZER)
+endif()

--- a/kokoro/scripts/linux/build.sh
+++ b/kokoro/scripts/linux/build.sh
@@ -71,11 +71,7 @@ git clone --depth=1 https://github.com/KhronosGroup/SPIRV-Headers external/spirv
 git clone --depth=1 https://github.com/google/googletest          external/googletest
 git clone --depth=1 https://github.com/google/effcee              external/effcee
 git clone --depth=1 https://github.com/google/re2                 external/re2
-git clone --depth=1 https://github.com/protocolbuffers/protobuf   external/protobuf
-pushd external/protobuf
-git fetch --all --tags --prune
-git checkout v3.7.1
-popd
+git clone --depth=1 --branch v3.13.0 https://github.com/protocolbuffers/protobuf external/protobuf
 
 mkdir build && cd $SRC/build
 

--- a/kokoro/scripts/macos/build.sh
+++ b/kokoro/scripts/macos/build.sh
@@ -35,11 +35,7 @@ git clone --depth=1 https://github.com/KhronosGroup/SPIRV-Headers external/spirv
 git clone --depth=1 https://github.com/google/googletest          external/googletest
 git clone --depth=1 https://github.com/google/effcee              external/effcee
 git clone --depth=1 https://github.com/google/re2                 external/re2
-git clone --depth=1 https://github.com/protocolbuffers/protobuf   external/protobuf
-pushd external/protobuf
-git fetch --all --tags --prune
-git checkout v3.7.1
-popd
+git clone --depth=1 --branch v3.13.0 https://github.com/protocolbuffers/protobuf external/protobuf
 
 mkdir build && cd $SRC/build
 

--- a/kokoro/scripts/windows/build.bat
+++ b/kokoro/scripts/windows/build.bat
@@ -29,11 +29,7 @@ git clone --depth=1 https://github.com/KhronosGroup/SPIRV-Headers external/spirv
 git clone --depth=1 https://github.com/google/googletest          external/googletest
 git clone --depth=1 https://github.com/google/effcee              external/effcee
 git clone --depth=1 https://github.com/google/re2                 external/re2
-git clone --depth=1 https://github.com/protocolbuffers/protobuf   external/protobuf
-pushd external\protobuf
-git fetch --all --tags --prune
-git checkout v3.7.1
-popd
+git clone --depth=1 --branch v3.13.0 https://github.com/protocolbuffers/protobuf external/protobuf
 
 :: #########################################
 :: set up msvc build env

--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -324,7 +324,6 @@ if(SPIRV_BUILD_FUZZER)
   add_library(SPIRV-Tools-fuzz ${SPIRV_TOOLS_FUZZ_SOURCES})
 
   spvtools_default_compile_options(SPIRV-Tools-fuzz)
-  target_compile_definitions(SPIRV-Tools-fuzz PUBLIC -DGOOGLE_PROTOBUF_NO_RTTI -DGOOGLE_PROTOBUF_USE_UNALIGNED=0)
 
   # Compilation of the auto-generated protobuf source file will yield warnings,
   # which we have no control over and thus wish to ignore.

--- a/source/fuzz/protobufs/spirvfuzz_protobufs.h
+++ b/source/fuzz/protobufs/spirvfuzz_protobufs.h
@@ -24,6 +24,7 @@
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wshadow"
 #elif defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"


### PR DESCRIPTION
This change improves spirv-fuzz CMake code to be more compatible with other projects that might want to include spirv-fuzz as a sub-project.

* Add a CMake option for building spirv-fuzz. 
* We now check if protobuf targets are already available. 
* We no longer specify `-DGOOGLE_PROTOBUF_NO_RTTI -DGOOGLE_PROTOBUF_USE_UNALIGNED=0`; a newer version of protobuf does not require this. Note that we probably should have specified this for protobuf targets as well, but this is no longer needed. 
* Updated protobuf version in Kokoro scripts and README.md. 

