### PR TITLE
StripReflectInfoPass: removing SpvDecorationUserTypeGOOGLE (fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/3779)

### DIFF
--- a/source/opt/strip_reflect_info_pass.cpp
+++ b/source/opt/strip_reflect_info_pass.cpp
@@ -32,7 +32,8 @@ Pass::Status StripReflectInfoPass::Process() {
   for (auto& inst : context()->module()->annotations()) {
     switch (inst.opcode()) {
       case SpvOpDecorateStringGOOGLE:
-        if (inst.GetSingleWordInOperand(1) == SpvDecorationHlslSemanticGOOGLE) {
+        if (inst.GetSingleWordInOperand(1) == SpvDecorationHlslSemanticGOOGLE ||
+            inst.GetSingleWordInOperand(1) == SpvDecorationUserTypeGOOGLE) {
           to_remove.push_back(&inst);
         } else {
           other_uses_for_decorate_string = true;
@@ -40,7 +41,8 @@ Pass::Status StripReflectInfoPass::Process() {
         break;
 
       case SpvOpMemberDecorateStringGOOGLE:
-        if (inst.GetSingleWordInOperand(2) == SpvDecorationHlslSemanticGOOGLE) {
+        if (inst.GetSingleWordInOperand(2) == SpvDecorationHlslSemanticGOOGLE ||
+            inst.GetSingleWordInOperand(2) == SpvDecorationUserTypeGOOGLE) {
           to_remove.push_back(&inst);
         } else {
           other_uses_for_decorate_string = true;
@@ -63,6 +65,8 @@ Pass::Status StripReflectInfoPass::Process() {
     const char* ext_name =
         reinterpret_cast<const char*>(&inst.GetInOperand(0).words[0]);
     if (0 == std::strcmp(ext_name, "SPV_GOOGLE_hlsl_functionality1")) {
+      to_remove.push_back(&inst);
+    } else if (0 == std::strcmp(ext_name, "SPV_GOOGLE_user_type")) {
       to_remove.push_back(&inst);
     } else if (!other_uses_for_decorate_string &&
                0 == std::strcmp(ext_name, "SPV_GOOGLE_decorate_string")) {


### PR DESCRIPTION
This fix removes SpvDecorationUserTypeGOOGLE operands when stripping reflection info. See https://github.com/KhronosGroup/SPIRV-Tools/issues/3779