### PR TITLE
Properly mark IR changed if instruction folder creates more than one constant

### DIFF
--- a/source/opt/ccp_pass.cpp
+++ b/source/opt/ccp_pass.cpp
@@ -150,7 +150,7 @@ SSAPropagator::PropStatus CCPPass::VisitAssignment(Instruction* instr) {
     // that CCP has modified the IR, independently of whether the constant is
     // actually propagated. See
     // https://github.com/KhronosGroup/SPIRV-Tools/issues/3636 for details.
-    if (folded_inst->result_id() == next_id) created_new_constant_ = true;
+    if (folded_inst->result_id() >= next_id) created_new_constant_ = true;
 
     return SSAPropagator::kInteresting;
   }


### PR DESCRIPTION
In #3636, I missed that the instruction folder may create more than a
single constant per call.  Since CCP was only checking whether one
constant had been created after folding, it was wrongly thinking that
the IR had not changed.

Fixes #3738.