### PR TITLE
spirv-fuzz: Remove CanFindOrCreateZeroConstant

### DIFF
--- a/source/fuzz/fuzzer_pass.cpp
+++ b/source/fuzz/fuzzer_pass.cpp
@@ -529,26 +529,6 @@ uint32_t FuzzerPass::FindOrCreateZeroConstant(
   }
 }
 
-bool FuzzerPass::CanFindOrCreateZeroConstant(const opt::analysis::Type& type) {
-  switch (type.kind()) {
-    case opt::analysis::Type::kBool:
-    case opt::analysis::Type::kInteger:
-    case opt::analysis::Type::kFloat:
-    case opt::analysis::Type::kArray:
-    case opt::analysis::Type::kMatrix:
-    case opt::analysis::Type::kVector:
-      return true;
-    case opt::analysis::Type::kStruct:
-      return std::all_of(type.AsStruct()->element_types().begin(),
-                         type.AsStruct()->element_types().end(),
-                         [this](const opt::analysis::Type* element_type) {
-                           return CanFindOrCreateZeroConstant(*element_type);
-                         });
-    default:
-      return false;
-  }
-}
-
 void FuzzerPass::MaybeAddUseToReplace(
     opt::Instruction* use_inst, uint32_t use_index, uint32_t replacement_id,
     std::vector<std::pair<protobufs::IdUseDescriptor, uint32_t>>*

--- a/source/fuzz/fuzzer_pass.h
+++ b/source/fuzz/fuzzer_pass.h
@@ -273,9 +273,6 @@ class FuzzerPass {
   uint32_t FindOrCreateZeroConstant(uint32_t scalar_or_composite_type_id,
                                     bool is_irrelevant);
 
-  // Checks if FindOrCreateZeroConstant can be called on this type.
-  bool CanFindOrCreateZeroConstant(const opt::analysis::Type& type);
-
   // Adds a pair (id_use_descriptor, |replacement_id|) to the vector
   // |uses_to_replace|, where id_use_descriptor is the id use descriptor
   // representing the usage of an id in the |use_inst| instruction, at operand

--- a/source/fuzz/fuzzer_pass_flatten_conditional_branches.cpp
+++ b/source/fuzz/fuzzer_pass_flatten_conditional_branches.cpp
@@ -99,7 +99,7 @@ void FuzzerPassFlattenConditionalBranches::Apply() {
         // The id will be a zero constant if the type allows it, and an OpUndef
         // otherwise. We want to avoid using OpUndef, if possible, to avoid
         // undefined behaviour in the module as much as possible.
-        if (CanFindOrCreateZeroConstant(
+        if (fuzzerutil::CanCreateConstant(
                 *GetIRContext()->get_type_mgr()->GetType(
                     instruction->type_id()))) {
           wrapper_info.set_value_to_copy_id(


### PR DESCRIPTION
Replace `FuzzerPass::CanFindOrCreateZeroConstant` with `fuzzerutil::CanCreateConstant`.