### PR TITLE
spirv-fuzz: Improvements to random number generation

### DIFF
--- a/source/fuzz/pseudo_random_generator.cpp
+++ b/source/fuzz/pseudo_random_generator.cpp
@@ -25,8 +25,12 @@ PseudoRandomGenerator::~PseudoRandomGenerator() = default;
 
 uint32_t PseudoRandomGenerator::RandomUint32(uint32_t bound) {
   assert(bound > 0 && "Bound must be positive");
-  return static_cast<uint32_t>(
-      std::uniform_int_distribution<>(0, bound - 1)(mt_));
+  return std::uniform_int_distribution<uint32_t>(0, bound - 1)(mt_);
+}
+
+uint64_t PseudoRandomGenerator::RandomUint64(uint64_t bound) {
+  assert(bound > 0 && "Bound must be positive");
+  return std::uniform_int_distribution<uint64_t>(0, bound - 1)(mt_);
 }
 
 bool PseudoRandomGenerator::RandomBool() {

--- a/source/fuzz/pseudo_random_generator.h
+++ b/source/fuzz/pseudo_random_generator.h
@@ -31,6 +31,8 @@ class PseudoRandomGenerator : public RandomGenerator {
 
   uint32_t RandomUint32(uint32_t bound) override;
 
+  uint64_t RandomUint64(uint64_t bound) override;
+
   uint32_t RandomPercentage() override;
 
   bool RandomBool() override;

--- a/source/fuzz/random_generator.h
+++ b/source/fuzz/random_generator.h
@@ -29,6 +29,9 @@ class RandomGenerator {
   // Returns a value in the half-open interval [0, bound).
   virtual uint32_t RandomUint32(uint32_t bound) = 0;
 
+  // Returns a value in the half-open interval [0, bound).
+  virtual uint64_t RandomUint64(uint64_t bound) = 0;
+
   // Returns a value in the closed interval [0, 100].
   virtual uint32_t RandomPercentage() = 0;
 


### PR DESCRIPTION
This PR extends the RandomGenerator interface and fixes the
PseudoRandomGenerator class. It:
- Fixes a problem that made the RandomUint32 of PseudoRandomGenerator
  segfault.
- Adds the RandomUint64 function to RandomGenerator and
  PseudoRandomGenerator.

Fixes #3805 .