### PR TITLE
spirv-fuzz: Use an irrelevant id for the unused components

### DIFF
--- a/source/fuzz/fuzzer_pass_add_image_sample_unused_components.cpp
+++ b/source/fuzz/fuzzer_pass_add_image_sample_unused_components.cpp
@@ -184,7 +184,7 @@ void FuzzerPassAddImageSampleUnusedComponents::Apply() {
          // FindOrCreateZeroConstant
          // %20 = OpConstant %4 0
          // %21 = OpConstantComposite %5 %20 %20
-         FindOrCreateZeroConstant(zero_constant_type_id, false)},
+         FindOrCreateZeroConstant(zero_constant_type_id, true)},
         MakeInstructionDescriptor(GetIRContext(), instruction),
         coordinate_with_unused_components_id));
 


### PR DESCRIPTION
Fixes #3808.