### PR TITLE
spirv-fuzz: Add TransformationSplitLoop

### DIFF
--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -111,6 +111,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_replace_parameter_with_global.h
         fuzzer_pass_replace_params_with_struct.h
         fuzzer_pass_split_blocks.h
+        fuzzer_pass_split_loops.h
         fuzzer_pass_swap_commutable_operands.h
         fuzzer_pass_swap_conditional_branch_operands.h
         fuzzer_pass_toggle_access_chain_instruction.h
@@ -206,6 +207,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_set_memory_operands_mask.h
         transformation_set_selection_control.h
         transformation_split_block.h
+        transformation_split_loop.h
         transformation_store.h
         transformation_swap_commutable_operands.h
         transformation_swap_conditional_branch_operands.h
@@ -287,6 +289,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_replace_parameter_with_global.cpp
         fuzzer_pass_replace_params_with_struct.cpp
         fuzzer_pass_split_blocks.cpp
+        fuzzer_pass_split_loops.cpp
         fuzzer_pass_swap_commutable_operands.cpp
         fuzzer_pass_swap_conditional_branch_operands.cpp
         fuzzer_pass_toggle_access_chain_instruction.cpp
@@ -380,6 +383,7 @@ if(SPIRV_BUILD_FUZZER)
         transformation_set_memory_operands_mask.cpp
         transformation_set_selection_control.cpp
         transformation_split_block.cpp
+        transformation_split_loop.cpp
         transformation_store.cpp
         transformation_swap_commutable_operands.cpp
         transformation_swap_conditional_branch_operands.cpp

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -80,6 +80,7 @@
 #include "source/fuzz/fuzzer_pass_replace_parameter_with_global.h"
 #include "source/fuzz/fuzzer_pass_replace_params_with_struct.h"
 #include "source/fuzz/fuzzer_pass_split_blocks.h"
+#include "source/fuzz/fuzzer_pass_split_loops.h"
 #include "source/fuzz/fuzzer_pass_swap_commutable_operands.h"
 #include "source/fuzz/fuzzer_pass_swap_conditional_branch_operands.h"
 #include "source/fuzz/fuzzer_pass_toggle_access_chain_instruction.h"
@@ -287,6 +288,7 @@ Fuzzer::FuzzerResult Fuzzer::Run() {
         &pass_instances);
     MaybeAddRepeatedPass<FuzzerPassReplaceParamsWithStruct>(&pass_instances);
     MaybeAddRepeatedPass<FuzzerPassSplitBlocks>(&pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassSplitLoops>(&pass_instances);
     MaybeAddRepeatedPass<FuzzerPassSwapBranchConditionalOperands>(
         &pass_instances);
     // There is a theoretical possibility that no pass instances were created

--- a/source/fuzz/fuzzer_context.cpp
+++ b/source/fuzz/fuzzer_context.cpp
@@ -130,6 +130,7 @@ const std::pair<uint32_t, uint32_t> kChanceOfReplacingParametersWithGlobals = {
 const std::pair<uint32_t, uint32_t> kChanceOfReplacingParametersWithStruct = {
     20, 40};
 const std::pair<uint32_t, uint32_t> kChanceOfSplittingBlock = {40, 95};
+const std::pair<uint32_t, uint32_t> kChanceOfSplittingLoop = {20, 70};
 const std::pair<uint32_t, uint32_t> kChanceOfSwappingConditionalBranchOperands =
     {10, 70};
 const std::pair<uint32_t, uint32_t> kChanceOfTogglingAccessChainInstruction = {
@@ -316,6 +317,7 @@ FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
   chance_of_replacing_parameters_with_struct_ =
       ChooseBetweenMinAndMax(kChanceOfReplacingParametersWithStruct);
   chance_of_splitting_block_ = ChooseBetweenMinAndMax(kChanceOfSplittingBlock);
+  chance_of_splitting_loop_ = ChooseBetweenMinAndMax(kChanceOfSplittingLoop);
   chance_of_swapping_conditional_branch_operands_ =
       ChooseBetweenMinAndMax(kChanceOfSwappingConditionalBranchOperands);
   chance_of_toggling_access_chain_instruction_ =

--- a/source/fuzz/fuzzer_context.cpp
+++ b/source/fuzz/fuzzer_context.cpp
@@ -130,7 +130,7 @@ const std::pair<uint32_t, uint32_t> kChanceOfReplacingParametersWithGlobals = {
 const std::pair<uint32_t, uint32_t> kChanceOfReplacingParametersWithStruct = {
     20, 40};
 const std::pair<uint32_t, uint32_t> kChanceOfSplittingBlock = {40, 95};
-const std::pair<uint32_t, uint32_t> kChanceOfSplittingLoop = {20, 70};
+const std::pair<uint32_t, uint32_t> kChanceOfSplittingLoop = {2, 5};
 const std::pair<uint32_t, uint32_t> kChanceOfSwappingConditionalBranchOperands =
     {10, 70};
 const std::pair<uint32_t, uint32_t> kChanceOfTogglingAccessChainInstruction = {
@@ -139,6 +139,7 @@ const std::pair<uint32_t, uint32_t> kChanceOfTogglingAccessChainInstruction = {
 // Default limits for various quantities that are chosen during fuzzing.
 // Keep them in alphabetical order.
 const uint32_t kDefaultMaxEquivalenceClassSizeForDataSynonymFactClosure = 1000;
+const uint32_t kDefaultMaxLimitOfLoopIterationsWhenSplittingLoop = 20;
 const uint32_t kDefaultMaxLoopControlPartialCount = 100;
 const uint32_t kDefaultMaxLoopControlPeelCount = 100;
 const uint32_t kDefaultMaxLoopLimit = 20;
@@ -147,6 +148,7 @@ const uint32_t kDefaultMaxNewArraySizeLimit = 100;
 //  think whether there is a better limit on the maximum number of parameters.
 const uint32_t kDefaultMaxNumberOfFunctionParameters = 128;
 const uint32_t kDefaultMaxNumberOfNewParameters = 15;
+const uint32_t kDefaultMinLimitOfLoopIterationsWhenSplittingLoop = 2;
 const uint32_t kGetDefaultMaxNumberOfParametersReplacedWithStruct = 5;
 
 // Default functions for controlling how deep to go during recursive
@@ -167,6 +169,8 @@ FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
       next_fresh_id_(min_fresh_id),
       max_equivalence_class_size_for_data_synonym_fact_closure_(
           kDefaultMaxEquivalenceClassSizeForDataSynonymFactClosure),
+      max_limit_of_loop_iterations_when_splitting_loop_(
+          kDefaultMaxLimitOfLoopIterationsWhenSplittingLoop),
       max_loop_control_partial_count_(kDefaultMaxLoopControlPartialCount),
       max_loop_control_peel_count_(kDefaultMaxLoopControlPeelCount),
       max_loop_limit_(kDefaultMaxLoopLimit),
@@ -175,6 +179,8 @@ FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
       max_number_of_new_parameters_(kDefaultMaxNumberOfNewParameters),
       max_number_of_parameters_replaced_with_struct_(
           kGetDefaultMaxNumberOfParametersReplacedWithStruct),
+      min_limit_of_loop_iterations_when_splitting_loop_(
+          kDefaultMinLimitOfLoopIterationsWhenSplittingLoop),
       go_deeper_in_constant_obfuscation_(
           kDefaultGoDeeperInConstantObfuscation) {
   chance_of_accepting_repeated_pass_recommendation_ =

--- a/source/fuzz/fuzzer_context.h
+++ b/source/fuzz/fuzzer_context.h
@@ -352,6 +352,11 @@ class FuzzerContext {
   int64_t GetRandomValueForStepConstantInLoop() {
     return random_generator_->RandomUint64(UINT64_MAX);
   }
+  uint32_t GetRandomLimitOfIterationsWhenSplittingLoop() {
+    return ChooseBetweenMinAndMax(
+        {min_limit_of_loop_iterations_when_splitting_loop_,
+         max_limit_of_loop_iterations_when_splitting_loop_});
+  }
   uint32_t GetRandomLoopControlPartialCount() {
     return random_generator_->RandomUint32(max_loop_control_partial_count_);
   }
@@ -479,6 +484,7 @@ class FuzzerContext {
   // chosen during fuzzing.
   // Keep them in alphabetical order.
   uint32_t max_equivalence_class_size_for_data_synonym_fact_closure_;
+  uint32_t max_limit_of_loop_iterations_when_splitting_loop_;
   uint32_t max_loop_control_partial_count_;
   uint32_t max_loop_control_peel_count_;
   uint32_t max_loop_limit_;
@@ -486,6 +492,7 @@ class FuzzerContext {
   uint32_t max_number_of_function_parameters_;
   uint32_t max_number_of_new_parameters_;
   uint32_t max_number_of_parameters_replaced_with_struct_;
+  uint32_t min_limit_of_loop_iterations_when_splitting_loop_;
 
   // Functions to determine with what probability to go deeper when generating
   // or mutating constructs recursively.

--- a/source/fuzz/fuzzer_context.h
+++ b/source/fuzz/fuzzer_context.h
@@ -301,6 +301,7 @@ class FuzzerContext {
     return chance_of_replacing_parameters_with_struct_;
   }
   uint32_t GetChanceOfSplittingBlock() { return chance_of_splitting_block_; }
+  uint32_t GetChanceOfSplittingLoop() { return chance_of_splitting_loop_; }
   uint32_t GetChanceOfSwappingConditionalBranchOperands() {
     return chance_of_swapping_conditional_branch_operands_;
   }
@@ -470,6 +471,7 @@ class FuzzerContext {
   uint32_t chance_of_replacing_parameters_with_globals_;
   uint32_t chance_of_replacing_parameters_with_struct_;
   uint32_t chance_of_splitting_block_;
+  uint32_t chance_of_splitting_loop_;
   uint32_t chance_of_swapping_conditional_branch_operands_;
   uint32_t chance_of_toggling_access_chain_instruction_;
 

--- a/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
@@ -49,6 +49,12 @@ void FuzzerPassApplyIdSynonyms::Apply() {
     // when considering a given use, we might apply a transformation that will
     // invalidate the def-use manager.
     std::vector<std::pair<opt::Instruction*, uint32_t>> uses;
+
+    if (GetIRContext()->get_def_use_mgr()->GetDef(id_with_known_synonyms) ==
+        nullptr) {
+      continue;
+    }
+
     GetIRContext()->get_def_use_mgr()->ForEachUse(
         id_with_known_synonyms,
         [&uses](opt::Instruction* use_inst, uint32_t use_index) -> void {
@@ -89,6 +95,10 @@ void FuzzerPassApplyIdSynonyms::Apply() {
             MakeDataDescriptor(id_with_known_synonyms, {});
         if (DataDescriptorEquals()(data_descriptor, &descriptor_for_this_id)) {
           // Exclude the fact that the id is synonymous with itself.
+          continue;
+        }
+        if (GetIRContext()->get_def_use_mgr()->GetDef(
+                data_descriptor->object()) == nullptr) {
           continue;
         }
 

--- a/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
@@ -112,6 +112,10 @@ void FuzzerPassApplyIdSynonyms::Apply() {
         auto synonym_to_try =
             GetFuzzerContext()->RemoveAtRandomIndex(&synonyms_to_try);
 
+        if (GetIRContext()->get_def_use_mgr()->GetDef(
+                synonym_to_try->object()) == nullptr) {
+          continue;
+        }
         // If the synonym's |index_size| is zero, the synonym represents an id.
         // Otherwise it represents some element of a composite structure, in
         // which case we need to be able to add an extract instruction to get

--- a/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
@@ -112,14 +112,15 @@ void FuzzerPassApplyIdSynonyms::Apply() {
         auto synonym_to_try =
             GetFuzzerContext()->RemoveAtRandomIndex(&synonyms_to_try);
 
-        if (GetIRContext()->get_def_use_mgr()->GetDef(
-                synonym_to_try->object()) == nullptr) {
-          continue;
-        }
-        // If the synonym's |index_size| is zero, the synonym represents an id.
-        // Otherwise it represents some element of a composite structure, in
-        // which case we need to be able to add an extract instruction to get
-        // that element out.
+        assert(GetIRContext()->get_def_use_mgr()->GetDef(
+                   synonym_to_try->object()) != nullptr &&
+               "At this point all elements in synonyms_to_try must exist in "
+               "the module.");
+
+        // If the synonym's |index_size| is zero, the synonym represents an
+        // id. Otherwise it represents some element of a composite
+        // structure, in which case we need to be able to add an extract
+        // instruction to get that element out.
         if (synonym_to_try->index_size() > 0 &&
             !fuzzerutil::CanInsertOpcodeBeforeInstruction(SpvOpCompositeExtract,
                                                           use_inst) &&

--- a/source/fuzz/fuzzer_pass_split_loops.cpp
+++ b/source/fuzz/fuzzer_pass_split_loops.cpp
@@ -62,7 +62,7 @@ void FuzzerPassSplitLoops::Apply() {
             }
           }
         }
-        // Create the required constants and variables.
+        // Create the required constants, variables and pointer types.
         FindOrCreateIntegerConstant({0}, 32, false, false);
         FindOrCreateIntegerConstant({1}, 32, false, false);
         FindOrCreateBoolConstant(true, false);
@@ -70,25 +70,19 @@ void FuzzerPassSplitLoops::Apply() {
         uint32_t constant_limit_id = FindOrCreateIntegerConstant(
             {GetFuzzerContext()->GetRandomLimitOfIterationsWhenSplittingLoop()},
             32, false, false);
-
-        uint32_t local_unsigned_int_type = FindOrCreatePointerType(
-            FindOrCreateIntegerType(32, false), SpvStorageClassFunction);
-        uint32_t variable_counter_id = FindOrCreateLocalVariable(
-            local_unsigned_int_type, function.result_id(), false);
-
-        uint32_t local_bool_type = FindOrCreatePointerType(
-            FindOrCreateBoolType(), SpvStorageClassFunction);
-        uint32_t variable_run_second_id = FindOrCreateLocalVariable(
-            local_bool_type, function.result_id(), false);
+        FindOrCreatePointerType(FindOrCreateIntegerType(32, false),
+                                SpvStorageClassFunction);
+        FindOrCreatePointerType(FindOrCreateBoolType(),
+                                SpvStorageClassFunction);
 
         // Apply the transformation.
         TransformationSplitLoop transformation = TransformationSplitLoop(
-            block->id(), variable_counter_id, variable_run_second_id,
-            constant_limit_id, GetFuzzerContext()->GetFreshId(),
+            block->id(), GetFuzzerContext()->GetFreshId(),
+            GetFuzzerContext()->GetFreshId(), constant_limit_id,
             GetFuzzerContext()->GetFreshId(), GetFuzzerContext()->GetFreshId(),
             GetFuzzerContext()->GetFreshId(), GetFuzzerContext()->GetFreshId(),
             GetFuzzerContext()->GetFreshId(), GetFuzzerContext()->GetFreshId(),
-            std::move(logical_not_fresh_ids),
+            GetFuzzerContext()->GetFreshId(), std::move(logical_not_fresh_ids),
             std::move(original_label_to_duplicate_label),
             std::move(original_id_to_duplicate_id));
         MaybeApplyTransformation(transformation);

--- a/source/fuzz/fuzzer_pass_split_loops.cpp
+++ b/source/fuzz/fuzzer_pass_split_loops.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/fuzzer_pass_split_loops.h"
+#include "source/fuzz/transformation_split_loop.h"
+
+namespace spvtools {
+namespace fuzz {
+
+FuzzerPassSplitLoops::FuzzerPassSplitLoops(
+    opt::IRContext* ir_context, TransformationContext* transformation_context,
+    FuzzerContext* fuzzer_context,
+    protobufs::TransformationSequence* transformations)
+    : FuzzerPass(ir_context, transformation_context, fuzzer_context,
+                 transformations) {}
+
+FuzzerPassSplitLoops::~FuzzerPassSplitLoops() = default;
+
+void FuzzerPassSplitLoops::Apply() {
+  if (!GetFuzzerContext()->ChoosePercentage(
+          GetFuzzerContext()->GetChanceOfSplittingLoop())) {
+  }
+}  // namespace fuzz
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/fuzzer_pass_split_loops.cpp
+++ b/source/fuzz/fuzzer_pass_split_loops.cpp
@@ -50,6 +50,7 @@ void FuzzerPassSplitLoops::Apply() {
             GetIRContext(), block, merge_block);
         std::map<uint32_t, uint32_t> original_label_to_duplicate_label;
         std::map<uint32_t, uint32_t> original_id_to_duplicate_id;
+        std::vector<uint32_t> logical_not_fresh_ids;
         for (auto& loop_block : loop_blocks) {
           original_label_to_duplicate_label[loop_block->id()] =
               GetFuzzerContext()->GetFreshId();
@@ -83,6 +84,7 @@ void FuzzerPassSplitLoops::Apply() {
             GetFuzzerContext()->GetFreshId(), GetFuzzerContext()->GetFreshId(),
             GetFuzzerContext()->GetFreshId(), GetFuzzerContext()->GetFreshId(),
             GetFuzzerContext()->GetFreshId(), GetFuzzerContext()->GetFreshId(),
+            std::move(logical_not_fresh_ids),
             std::move(original_label_to_duplicate_label),
             std::move(original_id_to_duplicate_id));
         MaybeApplyTransformation(transformation);

--- a/source/fuzz/fuzzer_pass_split_loops.h
+++ b/source/fuzz/fuzzer_pass_split_loops.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SPIRV_TOOLS_FUZZER_PASS_SPLIT_LOOPS_H
-#define SPIRV_TOOLS_FUZZER_PASS_SPLIT_LOOPS_H
+#ifndef SOURCE_FUZZ_FUZZER_PASS_SPLIT_LOOPS_H_
+#define SOURCE_FUZZ_FUZZER_PASS_SPLIT_LOOPS_H_
 
 #include "source/fuzz/fuzzer_pass.h"
 
@@ -35,4 +35,4 @@ class FuzzerPassSplitLoops : public FuzzerPass {
 }  // namespace fuzz
 }  // namespace spvtools
 
-#endif  // SPIRV_TOOLS_FUZZER_PASS_SPLIT_LOOPS_H
+#endif  // SOURCE_FUZZ_FUZZER_PASS_SPLIT_LOOPS_H_

--- a/source/fuzz/fuzzer_pass_split_loops.h
+++ b/source/fuzz/fuzzer_pass_split_loops.h
@@ -20,6 +20,9 @@
 namespace spvtools {
 namespace fuzz {
 
+// A fuzzer pass that iterates over the whole module. For each function it finds
+// loop headers. For each loop it randomly decides whether to apply the
+// corresponding transformation SplitLoops.
 class FuzzerPassSplitLoops : public FuzzerPass {
  public:
   FuzzerPassSplitLoops(opt::IRContext* ir_context,

--- a/source/fuzz/fuzzer_pass_split_loops.h
+++ b/source/fuzz/fuzzer_pass_split_loops.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SPIRV_TOOLS_FUZZER_PASS_SPLIT_LOOPS_H
+#define SPIRV_TOOLS_FUZZER_PASS_SPLIT_LOOPS_H
+
+#include "source/fuzz/fuzzer_pass.h"
+
+namespace spvtools {
+namespace fuzz {
+
+class FuzzerPassSplitLoops : public FuzzerPass {
+ public:
+  FuzzerPassSplitLoops(opt::IRContext* ir_context,
+                       TransformationContext* transformation_context,
+                       FuzzerContext* fuzzer_context,
+                       protobufs::TransformationSequence* transformations);
+
+  ~FuzzerPassSplitLoops() override;
+
+  void Apply() override;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SPIRV_TOOLS_FUZZER_PASS_SPLIT_LOOPS_H

--- a/source/fuzz/pass_management/repeated_pass_instances.h
+++ b/source/fuzz/pass_management/repeated_pass_instances.h
@@ -66,6 +66,7 @@
 #include "source/fuzz/fuzzer_pass_replace_parameter_with_global.h"
 #include "source/fuzz/fuzzer_pass_replace_params_with_struct.h"
 #include "source/fuzz/fuzzer_pass_split_blocks.h"
+#include "source/fuzz/fuzzer_pass_split_loops.h"
 #include "source/fuzz/fuzzer_pass_swap_conditional_branch_operands.h"
 
 namespace spvtools {
@@ -155,6 +156,7 @@ class RepeatedPassInstances {
   REPEATED_PASS_INSTANCE(ReplaceLinearAlgebraInstructions);
   REPEATED_PASS_INSTANCE(ReplaceParamsWithStruct);
   REPEATED_PASS_INSTANCE(SplitBlocks);
+  REPEATED_PASS_INSTANCE(SplitLoops);
   REPEATED_PASS_INSTANCE(SwapBranchConditionalOperands);
 #undef REPEATED_PASS_INSTANCE
 

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -498,6 +498,7 @@ message Transformation {
     TransformationFlattenConditionalBranch flatten_conditional_branch = 76;
     TransformationAddBitInstructionSynonym add_bit_instruction_synonym = 77;
     TransformationAddLoopToCreateIntConstantSynonym add_loop_to_create_int_constant_synonym = 78;
+    TransformationSplitLoop split_loop = 79;
     // Add additional option using the next available number.
   }
 }
@@ -2000,6 +2001,60 @@ message TransformationSplitBlock {
   uint32 fresh_id = 2;
 
 }
+
+message TransformationSplitLoop {
+    // A transformation that replaces a loop with two loops, which in total
+    // iterate over the same loop body with the same condition of iteration.
+    // The first loop is executed up to a constant number of times. If more
+    // iterations are required, they are performed in the second loop.
+
+    // Fresh id for a variable, which stores the number of iterations.
+    uint32 variable_counter_fresh_id = 1;
+
+    // Fresh id for a variable, which indicates whether there was a break
+    // from the loop body
+    uint32 variable_exited_fresh_id = 2;
+
+    // Fresh id for an OpLoad instruction from |counter|
+    uint32 load_counter_fresh_id = 3;
+
+    // Fresh id for an OpLoad instruction from |exited|
+    uint32 load_exited_fresh_id = 4;
+
+    // Id for a limit of the number of iterations in the first loop.
+    uint32 iteration_limit_id = 5;
+
+    // Fresh id for a condition on |counter| in the continue block of the
+    // first loop.
+    uint32 condition_counter_fresh_id = 6;
+
+    // Fresh id for OpLogicalNot instruction before the conditional after
+    // the first loop.
+    uint32 logical_not_fresh_id = 7;
+
+    // Fresh id for a then branch of the conditional after the first loop.
+    uint32 then_branch_fresh_id = 8;
+
+    // Fresh id for an else branch of the conditional after the first loop.
+    uint32 else_branch_fresh_id = 9;
+
+    // Block id of the entry block of the original loop
+    uint32 entry_block_id = 10;
+
+    // Block id of the exit block of the original loop
+    uint32 exit_block_id = 11;
+
+    // Map that maps from a result id in the original loop to the
+    // corresponding result id in the duplicated loop (the second loop).
+    repeated UInt32Pair original_id_to_duplicate_id = 12;
+
+    // Map that maps from a label in the original region to the corresponding
+    // label in the duplicated region
+    repeated UInt32Pair original_label_to_duplicate_label = 13;
+
+}
+
+
 
 message TransformationStore {
 

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -2032,20 +2032,23 @@ message TransformationSplitLoop {
     // Fresh id for a new entry block of the body of the first loop.
     uint32 new_body_entry_block_fresh_id = 8;
 
+    // Fresh id for a conditional block after the first loop merge block.
+    uint32 conditional_block_fresh_id = 9;
+
     // Id for an OpLoad instruction with |run_second|.
-    uint32 load_run_second_fresh_id = 9;
+    uint32 load_run_second_fresh_id = 10;
 
     // Id for a final selection merge block (after the first and the
     // second loop).
-    uint32 selection_merge_block_fresh_id = 10;
+    uint32 selection_merge_block_fresh_id = 11;
 
     // Map that maps from a label in the first loop to the corresponding
     // label in the second loop.
-    repeated UInt32Pair original_label_to_duplicate_label = 11;
+    repeated UInt32Pair original_label_to_duplicate_label = 12;
 
     // Map that maps from a result id in the first loop to the corresponding
     // result id in the second loop.
-    repeated UInt32Pair original_id_to_duplicate_id = 12;
+    repeated UInt32Pair original_id_to_duplicate_id = 13;
 }
 
 

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -2012,11 +2012,11 @@ message TransformationSplitLoop {
     // Block id of the header of the original loop.
     uint32 loop_header_id = 1;
 
-    // Id for a variable which stores the number of iterations.
-    uint32 variable_counter_id = 2;
+    // Fresh id for a variable which stores the number of iterations.
+    uint32 variable_counter_fresh_id = 2;
 
-    // Id for a variable which indicates if the second loop should be executed.
-    uint32 variable_run_second_id = 3;
+    // Fresh id for a variable which indicates if the second loop should be executed.
+    uint32 variable_run_second_fresh_id = 3;
 
     // Id for a limit of the number of iterations in the first loop.
     uint32 constant_limit_id = 4;

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -2008,49 +2008,57 @@ message TransformationSplitLoop {
     // The first loop is executed up to a constant number of times. If more
     // iterations are required, they are performed in the second loop.
 
-    // Fresh id for a variable, which stores the number of iterations.
-    uint32 variable_counter_fresh_id = 1;
+    // Block id of the header of the original loop.
+    uint32 loop_header_id = 1;
 
-    // Fresh id for a variable, which indicates whether there was a break
-    // from the loop body
-    uint32 variable_exited_fresh_id = 2;
+    // Id for a variable which stores the number of iterations.
+    uint32 variable_counter_id = 2;
 
-    // Fresh id for an OpLoad instruction from |counter|
-    uint32 load_counter_fresh_id = 3;
+    // Id for a variable which indicates if the second loop should be executed.
+    uint32 variable_run_second_id = 3;
 
-    // Fresh id for an OpLoad instruction from |exited|
-    uint32 load_exited_fresh_id = 4;
+    // Id for an integer constant 1 used by incrementation of |counter|.
+    uint32 constant_one_id = 4;
+
+    // Id for an integer constant 0 used by initialization of |counter|.
+    uint32 constant_zero_id = 5;
 
     // Id for a limit of the number of iterations in the first loop.
-    uint32 iteration_limit_id = 5;
+    uint32 constant_limit_id = 6;
 
-    // Fresh id for a condition on |counter| in the continue block of the
-    // first loop.
-    uint32 condition_counter_fresh_id = 6;
+    // Fresh id for an OpLoad instruction with |counter|.
+    uint32 load_counter_fresh_id = 7;
 
-    // Fresh id for OpLogicalNot instruction before the conditional after
-    // the first loop.
-    uint32 logical_not_fresh_id = 7;
+    // Fresh id for incrementation of the counter.
+    uint32 increment_counter_fresh_id = 8;
 
-    // Fresh id for a then branch of the conditional after the first loop.
-    uint32 then_branch_fresh_id = 8;
+    // Fresh id for a boolean condition on the value |counter|.
+    uint32 condition_counter_fresh_id = 9;
 
-    // Fresh id for an else branch of the conditional after the first loop.
-    uint32 else_branch_fresh_id = 9;
+    // Fresh id for a new predecessor of the merge block of the first
+    // loop.
+    uint32 pred_merge_block_fresh_id = 10;
 
-    // Block id of the entry block of the original loop
-    uint32 entry_block_id = 10;
+    // Id for constant "true" for the variable |run_second|.
+    uint32 constant_true_id = 11;
 
-    // Block id of the exit block of the original loop
-    uint32 exit_block_id = 11;
+    // Id for constant "false" for the variable |run_second|.
+    uint32 constant_false_id = 12;
 
-    // Map that maps from a result id in the original loop to the
-    // corresponding result id in the duplicated loop (the second loop).
-    repeated UInt32Pair original_id_to_duplicate_id = 12;
+    // Id for an OpLoad instruction with |run_second|.
+    uint32 load_run_second_fresh_id = 13;
 
-    // Map that maps from a label in the original region to the corresponding
-    // label in the duplicated region
-    repeated UInt32Pair original_label_to_duplicate_label = 13;
+    // Id for a final selection merge block (after the first and the
+    // second loop).
+    uint32 selection_merge_block_fresh_id = 14;
+
+    // Map that maps from a label in the first loop to the corresponding
+    // label in the second loop.
+    repeated UInt32Pair original_label_to_duplicate_label = 15;
+
+    // Map that maps from a result id in the first loop to the corresponding
+    // result id in the second loop.
+    repeated UInt32Pair original_id_to_duplicate_id = 16;
 
 }
 

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -2004,56 +2004,60 @@ message TransformationSplitBlock {
 
 message TransformationSplitLoop {
 
-    // A transformation that replaces a loop with two loops, which in total
-    // iterate over the same loop body with the same condition of iteration.
-    // The first loop is executed up to a constant number of times. If more
-    // iterations are required, they are performed in the second loop.
+  // A transformation that replaces a loop with two loops, which in total
+  // iterate over the same loop body with the same condition of iteration.
+  // The first loop is executed up to a constant number of times. If more
+  // iterations are required, they are performed in the second loop.
 
-    // Block id of the header of the original loop.
-    uint32 loop_header_id = 1;
+  // Block id of the header of the original loop.
+  uint32 loop_header_id = 1;
 
-    // Fresh id for a variable which stores the number of iterations.
-    uint32 variable_counter_fresh_id = 2;
+  // Fresh id for a variable which stores the number of iterations.
+  uint32 variable_counter_fresh_id = 2;
 
-    // Fresh id for a variable which indicates if the second loop should be executed.
-    uint32 variable_run_second_fresh_id = 3;
+  // Fresh id for a variable which indicates if the second loop should be executed.
+  uint32 variable_run_second_fresh_id = 3;
 
-    // Id for a limit of the number of iterations in the first loop.
-    uint32 constant_limit_id = 4;
+  // Id for a limit of the number of iterations in the first loop.
+  uint32 constant_limit_id = 4;
 
-    // Fresh id for an OpLoad instruction with |counter|.
-    uint32 load_counter_fresh_id = 5;
+  // Fresh id for an OpLoad instruction with |variable_counter_fresh_id|.
+  uint32 load_counter_fresh_id = 5;
 
-    // Fresh id for incrementation of |counter|.
-    uint32 increment_counter_fresh_id = 6;
+  // Fresh id for incrementation of |variable_counter_fresh_id|.
+  uint32 increment_counter_fresh_id = 6;
 
-    // Fresh id for a boolean condition on the value of |counter|.
-    uint32 condition_counter_fresh_id = 7;
+  // Fresh id for a boolean condition on the value of
+  // |variable_counter_fresh_id|.
+  uint32 condition_counter_fresh_id = 7;
 
-    // Fresh id for a new entry block of the body of the first loop.
-    uint32 new_body_entry_block_fresh_id = 8;
+  // Fresh id for a new entry block of the body of the first loop.
+  uint32 new_body_entry_block_fresh_id = 8;
 
-    // Fresh id for a conditional block after the first loop merge block.
-    uint32 conditional_block_fresh_id = 9;
+  // Fresh id for a conditional block after the first loop merge block.
+  uint32 conditional_block_fresh_id = 9;
 
-    // Fresh id for an OpLoad instruction with |run_second|.
-    uint32 load_run_second_fresh_id = 10;
+  // Fresh id for an OpLoad instruction with
+  // |variable_run_second_fresh_id|.
+  uint32 load_run_second_fresh_id = 10;
 
-    // Fresh id for a final selection merge block (after the first and the
-    // second loop).
-    uint32 selection_merge_block_fresh_id = 11;
+  // Fresh id for a final selection merge block (after the first and the
+  // second loop).
+  uint32 selection_merge_block_fresh_id = 11;
 
-    // Fresh id for OpLogicalNot instructions for each case when it there is
-    // a terminator: OpBranchConditional %c %merge %other
-    repeated uint32 logical_not_fresh_ids = 12;
+  // Fresh id for OpLogicalNot instructions for each case when there is
+  // a terminator: OpBranchConditional %c %merge %other
+  // These OpLogicalNot instructions are used to change the value of
+  // |variable_run_second_id| which would normally be equal to %c.
+  repeated uint32 logical_not_fresh_ids = 12;
 
-    // Map that maps from a label in the first loop to the corresponding
-    // label in the second loop.
-    repeated UInt32Pair original_label_to_duplicate_label = 13;
+  // Map that maps from a label in the first loop to the corresponding
+  // label in the second loop.
+  repeated UInt32Pair original_label_to_duplicate_label = 13;
 
-    // Map that maps from a result id in the first loop to the corresponding
-    // result id in the second loop.
-    repeated UInt32Pair original_id_to_duplicate_id = 14;
+  // Map that maps from a result id in the first loop to the corresponding
+  // result id in the second loop.
+  repeated UInt32Pair original_id_to_duplicate_id = 14;
 }
 
 

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -2017,49 +2017,35 @@ message TransformationSplitLoop {
     // Id for a variable which indicates if the second loop should be executed.
     uint32 variable_run_second_id = 3;
 
-    // Id for an integer constant 1 used by incrementation of |counter|.
-    uint32 constant_one_id = 4;
-
-    // Id for an integer constant 0 used by initialization of |counter|.
-    uint32 constant_zero_id = 5;
-
     // Id for a limit of the number of iterations in the first loop.
-    uint32 constant_limit_id = 6;
+    uint32 constant_limit_id = 4;
 
     // Fresh id for an OpLoad instruction with |counter|.
-    uint32 load_counter_fresh_id = 7;
+    uint32 load_counter_fresh_id = 5;
 
     // Fresh id for incrementation of the counter.
-    uint32 increment_counter_fresh_id = 8;
+    uint32 increment_counter_fresh_id = 6;
 
     // Fresh id for a boolean condition on the value |counter|.
-    uint32 condition_counter_fresh_id = 9;
+    uint32 condition_counter_fresh_id = 7;
 
-    // Fresh id for a new predecessor of the merge block of the first
-    // loop.
-    uint32 pred_merge_block_fresh_id = 10;
-
-    // Id for constant "true" for the variable |run_second|.
-    uint32 constant_true_id = 11;
-
-    // Id for constant "false" for the variable |run_second|.
-    uint32 constant_false_id = 12;
+    // Fresh id for a new entry block of the body of the first loop.
+    uint32 new_body_entry_block_fresh_id = 8;
 
     // Id for an OpLoad instruction with |run_second|.
-    uint32 load_run_second_fresh_id = 13;
+    uint32 load_run_second_fresh_id = 9;
 
     // Id for a final selection merge block (after the first and the
     // second loop).
-    uint32 selection_merge_block_fresh_id = 14;
+    uint32 selection_merge_block_fresh_id = 10;
 
     // Map that maps from a label in the first loop to the corresponding
     // label in the second loop.
-    repeated UInt32Pair original_label_to_duplicate_label = 15;
+    repeated UInt32Pair original_label_to_duplicate_label = 11;
 
     // Map that maps from a result id in the first loop to the corresponding
     // result id in the second loop.
-    repeated UInt32Pair original_id_to_duplicate_id = 16;
-
+    repeated UInt32Pair original_id_to_duplicate_id = 12;
 }
 
 

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -2023,10 +2023,10 @@ message TransformationSplitLoop {
     // Fresh id for an OpLoad instruction with |counter|.
     uint32 load_counter_fresh_id = 5;
 
-    // Fresh id for incrementation of the counter.
+    // Fresh id for incrementation of |counter|.
     uint32 increment_counter_fresh_id = 6;
 
-    // Fresh id for a boolean condition on the value |counter|.
+    // Fresh id for a boolean condition on the value of |counter|.
     uint32 condition_counter_fresh_id = 7;
 
     // Fresh id for a new entry block of the body of the first loop.

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -2035,20 +2035,24 @@ message TransformationSplitLoop {
     // Fresh id for a conditional block after the first loop merge block.
     uint32 conditional_block_fresh_id = 9;
 
-    // Id for an OpLoad instruction with |run_second|.
+    // Fresh id for an OpLoad instruction with |run_second|.
     uint32 load_run_second_fresh_id = 10;
 
-    // Id for a final selection merge block (after the first and the
+    // Fresh id for a final selection merge block (after the first and the
     // second loop).
     uint32 selection_merge_block_fresh_id = 11;
 
+    // Fresh id for OpLogicalNot instructions for each case when it there is
+    // a terminator: OpBranchConditional %c %merge %other
+    repeated uint32 logical_not_fresh_ids = 12;
+
     // Map that maps from a label in the first loop to the corresponding
     // label in the second loop.
-    repeated UInt32Pair original_label_to_duplicate_label = 12;
+    repeated UInt32Pair original_label_to_duplicate_label = 13;
 
     // Map that maps from a result id in the first loop to the corresponding
     // result id in the second loop.
-    repeated UInt32Pair original_id_to_duplicate_id = 13;
+    repeated UInt32Pair original_id_to_duplicate_id = 14;
 }
 
 

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -2003,6 +2003,7 @@ message TransformationSplitBlock {
 }
 
 message TransformationSplitLoop {
+
     // A transformation that replaces a loop with two loops, which in total
     // iterate over the same loop body with the same condition of iteration.
     // The first loop is executed up to a constant number of times. If more

--- a/source/fuzz/transformation.cpp
+++ b/source/fuzz/transformation.cpp
@@ -90,6 +90,7 @@
 #include "source/fuzz/transformation_set_memory_operands_mask.h"
 #include "source/fuzz/transformation_set_selection_control.h"
 #include "source/fuzz/transformation_split_block.h"
+#include "source/fuzz/transformation_split_loop.h"
 #include "source/fuzz/transformation_store.h"
 #include "source/fuzz/transformation_swap_commutable_operands.h"
 #include "source/fuzz/transformation_swap_conditional_branch_operands.h"
@@ -327,6 +328,8 @@ std::unique_ptr<Transformation> Transformation::FromMessage(
           message.set_selection_control());
     case protobufs::Transformation::TransformationCase::kSplitBlock:
       return MakeUnique<TransformationSplitBlock>(message.split_block());
+    case protobufs::Transformation::TransformationCase::kSplitLoop:
+      return MakeUnique<TransformationSplitLoop>(message.split_loop());
     case protobufs::Transformation::TransformationCase::kStore:
       return MakeUnique<TransformationStore>(message.store());
     case protobufs::Transformation::TransformationCase::kSwapCommutableOperands:

--- a/source/fuzz/transformation_duplicate_region_with_selection.cpp
+++ b/source/fuzz/transformation_duplicate_region_with_selection.cpp
@@ -321,21 +321,21 @@ void TransformationDuplicateRegionWithSelection::Apply(
   // We know that |entry_block| has only one predecessor, since the region is
   // single-entry, single-exit and its constructs and their merge blocks must be
   // either wholly within or wholly outside of the region.
-
-  for (auto entry_block_pred : entry_block_preds) {
-    uint32_t entry_block_pred_id =
-        ir_context->get_instr_block(entry_block_pred)->id();
-    // Update all the OpPhi instructions in the |entry_block|. Change every
-    // occurrence of |entry_block_pred_id| to the id of |new_entry|, because we
-    // will insert |new_entry| before |entry_block|.
-    for (auto& instr : *entry_block) {
-      if (instr.opcode() == SpvOpPhi) {
-        instr.ForEachId([this, entry_block_pred_id](uint32_t* id) {
-          if (*id == entry_block_pred_id) {
-            *id = message_.new_entry_fresh_id();
-          }
-        });
-      }
+  assert(entry_block_preds.size() == 1 &&
+         "The entry of the region to be duplicated can have only one "
+         "predecessor.");
+  uint32_t entry_block_pred_id =
+      ir_context->get_instr_block(entry_block_preds[0])->id();
+  // Update all the OpPhi instructions in the |entry_block|. Change every
+  // occurrence of |entry_block_pred_id| to the id of |new_entry|, because we
+  // will insert |new_entry| before |entry_block|.
+  for (auto& instr : *entry_block) {
+    if (instr.opcode() == SpvOpPhi) {
+      instr.ForEachId([this, entry_block_pred_id](uint32_t* id) {
+        if (*id == entry_block_pred_id) {
+          *id = message_.new_entry_fresh_id();
+        }
+      });
     }
   }
 

--- a/source/fuzz/transformation_duplicate_region_with_selection.cpp
+++ b/source/fuzz/transformation_duplicate_region_with_selection.cpp
@@ -321,21 +321,21 @@ void TransformationDuplicateRegionWithSelection::Apply(
   // We know that |entry_block| has only one predecessor, since the region is
   // single-entry, single-exit and its constructs and their merge blocks must be
   // either wholly within or wholly outside of the region.
-  assert(entry_block_preds.size() == 1 &&
-         "The entry of the region to be duplicated can have only one "
-         "predecessor.");
-  uint32_t entry_block_pred_id =
-      ir_context->get_instr_block(entry_block_preds[0])->id();
-  // Update all the OpPhi instructions in the |entry_block|. Change every
-  // occurrence of |entry_block_pred_id| to the id of |new_entry|, because we
-  // will insert |new_entry| before |entry_block|.
-  for (auto& instr : *entry_block) {
-    if (instr.opcode() == SpvOpPhi) {
-      instr.ForEachId([this, entry_block_pred_id](uint32_t* id) {
-        if (*id == entry_block_pred_id) {
-          *id = message_.new_entry_fresh_id();
-        }
-      });
+
+  for (auto entry_block_pred : entry_block_preds) {
+    uint32_t entry_block_pred_id =
+        ir_context->get_instr_block(entry_block_pred)->id();
+    // Update all the OpPhi instructions in the |entry_block|. Change every
+    // occurrence of |entry_block_pred_id| to the id of |new_entry|, because we
+    // will insert |new_entry| before |entry_block|.
+    for (auto& instr : *entry_block) {
+      if (instr.opcode() == SpvOpPhi) {
+        instr.ForEachId([this, entry_block_pred_id](uint32_t* id) {
+          if (*id == entry_block_pred_id) {
+            *id = message_.new_entry_fresh_id();
+          }
+        });
+      }
     }
   }
 

--- a/source/fuzz/transformation_duplicate_region_with_selection.cpp
+++ b/source/fuzz/transformation_duplicate_region_with_selection.cpp
@@ -177,6 +177,16 @@ bool TransformationDuplicateRegionWithSelection::IsApplicable(
     }
   }
 
+  auto entry_block_preds = ir_context->cfg()->preds(entry_block->id());
+  std::sort(entry_block_preds.begin(), entry_block_preds.end());
+  entry_block_preds.erase(
+      unique(entry_block_preds.begin(), entry_block_preds.end()),
+      entry_block_preds.end());
+  // We consider entry blocks with only one predecessor.
+  if (entry_block_preds.size() > 1) {
+    return false;
+  }
+
   // Get the maps from the protobuf.
   // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3786):
   //     Consider additionally providing overflow ids to make this

--- a/source/fuzz/transformation_duplicate_region_with_selection.cpp
+++ b/source/fuzz/transformation_duplicate_region_with_selection.cpp
@@ -177,16 +177,6 @@ bool TransformationDuplicateRegionWithSelection::IsApplicable(
     }
   }
 
-  auto entry_block_preds = ir_context->cfg()->preds(entry_block->id());
-  std::sort(entry_block_preds.begin(), entry_block_preds.end());
-  entry_block_preds.erase(
-      unique(entry_block_preds.begin(), entry_block_preds.end()),
-      entry_block_preds.end());
-  // We consider entry blocks with only one predecessor.
-  if (entry_block_preds.size() > 1) {
-    return false;
-  }
-
   // Get the maps from the protobuf.
   // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3786):
   //     Consider additionally providing overflow ids to make this

--- a/source/fuzz/transformation_split_loop.cpp
+++ b/source/fuzz/transformation_split_loop.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_split_loop.h"
+
+#include "source/fuzz/fuzzer_util.h"
+
+namespace spvtools {
+namespace fuzz {
+
+/*
+ * uint32_t variable_counter_fresh_id, uint32_t variable_exited_fresh_id,
+      uint32_t load_counter_fresh_id, uint32_t load_exited_fresh_id,
+      uint32_t iteration_limit_id, uint32_t condition_counter_fresh_id,
+      uint32_t logical_not_fresh_id, uint32_t then_branch_fresh_id,
+      uint32_t else_branch_fresh_id, uint32_t entry_block_id,
+      uint32_t exit_block_id,
+      std::map<uint32_t, uint32_t> original_id_to_duplicate_id,
+      std::map<uint32_t, uint32_t> original_label_to_duplicate_label
+ */
+
+TransformationSplitLoop::TransformationSplitLoop(
+    const spvtools::fuzz::protobufs::TransformationSplitLoop& message)
+    : message_(message) {}
+
+TransformationSplitLoop::TransformationSplitLoop(
+    uint32_t variable_counter_fresh_id, uint32_t variable_exited_fresh_id,
+    uint32_t load_counter_fresh_id, uint32_t load_exited_fresh_id,
+    uint32_t iteration_limit_id, uint32_t condition_counter_fresh_id,
+    uint32_t logical_not_fresh_id, uint32_t then_branch_fresh_id,
+    uint32_t else_branch_fresh_id, uint32_t entry_block_id,
+    uint32_t exit_block_id,
+    std::map<uint32_t, uint32_t> original_id_to_duplicate_id,
+    std::map<uint32_t, uint32_t> original_label_to_duplicate_label) {
+  message_.set_variable_counter_fresh_id(variable_counter_fresh_id);
+  message_.set_variable_exited_fresh_id(variable_exited_fresh_id);
+  message_.set_load_counter_fresh_id(load_counter_fresh_id);
+  message_.set_load_exited_fresh_id(load_exited_fresh_id);
+  message_.set_iteration_limit_id(iteration_limit_id);
+  message_.set_condition_counter_fresh_id(condition_counter_fresh_id);
+  message_.set_logical_not_fresh_id(logical_not_fresh_id);
+  message_.set_then_branch_fresh_id(then_branch_fresh_id);
+  message_.set_else_branch_fresh_id(else_branch_fresh_id);
+  message_.set_entry_block_id(entry_block_id);
+  message_.set_exit_block_id(exit_block_id);
+  *message_.mutable_original_id_to_duplicate_id() =
+      fuzzerutil::MapToRepeatedUInt32Pair(original_id_to_duplicate_id);
+  *message_.mutable_original_label_to_duplicate_label() =
+      fuzzerutil::MapToRepeatedUInt32Pair(original_label_to_duplicate_label);
+}
+
+bool TransformationSplitLoop::IsApplicable(
+    opt::IRContext* /*unused*/, const TransformationContext& /*unused*/) const {
+  return false;
+}
+
+void TransformationSplitLoop::Apply(opt::IRContext* /*unused*/,
+                                    TransformationContext* /*unused*/) const {}
+
+protobufs::Transformation TransformationSplitLoop::ToMessage() const {
+  protobufs::Transformation result;
+  *result.mutable_split_loop() = message_;
+  return result;
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/transformation_split_loop.cpp
+++ b/source/fuzz/transformation_split_loop.cpp
@@ -114,19 +114,15 @@ void TransformationSplitLoop::Apply(
   auto const_true_id = fuzzerutil::MaybeGetBoolConstant(
       ir_context, *transformation_context, true, false);
 
-  fuzzerutil::UpdateModuleIdBound(ir_context, message_.load_counter_fresh_id());
-  fuzzerutil::UpdateModuleIdBound(ir_context,
-                                  message_.increment_counter_fresh_id());
-  fuzzerutil::UpdateModuleIdBound(ir_context,
-                                  message_.condition_counter_fresh_id());
-  fuzzerutil::UpdateModuleIdBound(ir_context,
-                                  message_.new_body_entry_block_fresh_id());
-  fuzzerutil::UpdateModuleIdBound(ir_context,
-                                  message_.conditional_block_fresh_id());
-  fuzzerutil::UpdateModuleIdBound(ir_context,
-                                  message_.load_run_second_fresh_id());
-  fuzzerutil::UpdateModuleIdBound(ir_context,
-                                  message_.selection_merge_block_fresh_id());
+  for (uint32_t id :
+       {message_.load_counter_fresh_id(), message_.increment_counter_fresh_id(),
+        message_.condition_counter_fresh_id(),
+        message_.new_body_entry_block_fresh_id(),
+        message_.conditional_block_fresh_id(),
+        message_.load_run_second_fresh_id(),
+        message_.selection_merge_block_fresh_id()}) {
+    fuzzerutil::UpdateModuleIdBound(ir_context, id);
+  }
 
   auto loop_header_block = ir_context->cfg()->block(message_.loop_header_id());
   auto merge_block =

--- a/source/fuzz/transformation_split_loop.cpp
+++ b/source/fuzz/transformation_split_loop.cpp
@@ -19,58 +19,363 @@
 namespace spvtools {
 namespace fuzz {
 
-/*
- * uint32_t variable_counter_fresh_id, uint32_t variable_exited_fresh_id,
-      uint32_t load_counter_fresh_id, uint32_t load_exited_fresh_id,
-      uint32_t iteration_limit_id, uint32_t condition_counter_fresh_id,
-      uint32_t logical_not_fresh_id, uint32_t then_branch_fresh_id,
-      uint32_t else_branch_fresh_id, uint32_t entry_block_id,
-      uint32_t exit_block_id,
-      std::map<uint32_t, uint32_t> original_id_to_duplicate_id,
-      std::map<uint32_t, uint32_t> original_label_to_duplicate_label
- */
-
 TransformationSplitLoop::TransformationSplitLoop(
     const spvtools::fuzz::protobufs::TransformationSplitLoop& message)
     : message_(message) {}
 
 TransformationSplitLoop::TransformationSplitLoop(
-    uint32_t variable_counter_fresh_id, uint32_t variable_exited_fresh_id,
-    uint32_t load_counter_fresh_id, uint32_t load_exited_fresh_id,
-    uint32_t iteration_limit_id, uint32_t condition_counter_fresh_id,
-    uint32_t logical_not_fresh_id, uint32_t then_branch_fresh_id,
-    uint32_t else_branch_fresh_id, uint32_t entry_block_id,
-    uint32_t exit_block_id,
-    std::map<uint32_t, uint32_t> original_id_to_duplicate_id,
-    std::map<uint32_t, uint32_t> original_label_to_duplicate_label) {
-  message_.set_variable_counter_fresh_id(variable_counter_fresh_id);
-  message_.set_variable_exited_fresh_id(variable_exited_fresh_id);
+    uint32_t loop_header_id, uint32_t variable_counter_id,
+    uint32_t variable_run_second_id, uint32_t constant_one_id,
+    uint32_t constant_zero_id, uint32_t constant_limit_id,
+    uint32_t load_counter_fresh_id, uint32_t increment_counter_fresh_id,
+    uint32_t condition_counter_fresh_id, uint32_t pred_merge_block_fresh_id,
+    uint32_t constant_true_id, uint32_t constant_false_id,
+    uint32_t load_run_second_fresh_id, uint32_t selection_merge_block_fresh_id,
+    std::map<uint32_t, uint32_t> original_label_to_duplicate_label,
+    std::map<uint32_t, uint32_t> original_id_to_duplicate_id) {
+  message_.set_loop_header_id(loop_header_id);
+  message_.set_variable_counter_id(variable_counter_id);
+  message_.set_variable_run_second_id(variable_run_second_id);
+  message_.set_constant_one_id(constant_one_id);
+  message_.set_constant_zero_id(constant_zero_id);
+  message_.set_constant_limit_id(constant_limit_id);
   message_.set_load_counter_fresh_id(load_counter_fresh_id);
-  message_.set_load_exited_fresh_id(load_exited_fresh_id);
-  message_.set_iteration_limit_id(iteration_limit_id);
+  message_.set_increment_counter_fresh_id(increment_counter_fresh_id);
   message_.set_condition_counter_fresh_id(condition_counter_fresh_id);
-  message_.set_logical_not_fresh_id(logical_not_fresh_id);
-  message_.set_then_branch_fresh_id(then_branch_fresh_id);
-  message_.set_else_branch_fresh_id(else_branch_fresh_id);
-  message_.set_entry_block_id(entry_block_id);
-  message_.set_exit_block_id(exit_block_id);
-  *message_.mutable_original_id_to_duplicate_id() =
-      fuzzerutil::MapToRepeatedUInt32Pair(original_id_to_duplicate_id);
+  message_.set_pred_merge_block_fresh_id(pred_merge_block_fresh_id);
+  message_.set_constant_true_id(constant_true_id);
+  message_.set_constant_false_id(constant_false_id);
+  message_.set_load_run_second_fresh_id(load_run_second_fresh_id);
+  message_.set_selection_merge_block_fresh_id(selection_merge_block_fresh_id);
   *message_.mutable_original_label_to_duplicate_label() =
       fuzzerutil::MapToRepeatedUInt32Pair(original_label_to_duplicate_label);
+  *message_.mutable_original_id_to_duplicate_id() =
+      fuzzerutil::MapToRepeatedUInt32Pair(original_id_to_duplicate_id);
 }
 
 bool TransformationSplitLoop::IsApplicable(
-    opt::IRContext* /*unused*/, const TransformationContext& /*unused*/) const {
-  return false;
+    opt::IRContext* ir_context, const TransformationContext& /*unused*/) const {
+  std::set<uint32_t> ids_used_by_this_transformation;
+
+  if (!CheckIdIsFreshAndNotUsedByThisTransformation(
+          message_.load_counter_fresh_id(), ir_context,
+          &ids_used_by_this_transformation)) {
+    return false;
+  }
+  if (!CheckIdIsFreshAndNotUsedByThisTransformation(
+          message_.increment_counter_fresh_id(), ir_context,
+          &ids_used_by_this_transformation)) {
+    return false;
+  }
+  if (!CheckIdIsFreshAndNotUsedByThisTransformation(
+          message_.pred_merge_block_fresh_id(), ir_context,
+          &ids_used_by_this_transformation)) {
+    return false;
+  }
+
+  auto entry_block = ir_context->cfg()->block(message_.loop_header_id());
+  if (!entry_block->IsLoopHeader()) {
+    return false;
+  }
+  return true;
 }
 
-void TransformationSplitLoop::Apply(opt::IRContext* /*unused*/,
-                                    TransformationContext* /*unused*/) const {}
+void TransformationSplitLoop::Apply(opt::IRContext* ir_context,
+                                    TransformationContext* /*unused*/) const {
+  fuzzerutil::UpdateModuleIdBound(ir_context, message_.load_counter_fresh_id());
+  fuzzerutil::UpdateModuleIdBound(ir_context,
+                                  message_.increment_counter_fresh_id());
+  fuzzerutil::UpdateModuleIdBound(ir_context,
+                                  message_.condition_counter_fresh_id());
+  fuzzerutil::UpdateModuleIdBound(ir_context,
+                                  message_.pred_merge_block_fresh_id());
+  fuzzerutil::UpdateModuleIdBound(ir_context, message_.load_counter_fresh_id());
+  fuzzerutil::UpdateModuleIdBound(ir_context,
+                                  message_.selection_merge_block_fresh_id());
+  fuzzerutil::UpdateModuleIdBound(ir_context,
+                                  message_.load_run_second_fresh_id());
+
+  std::unique_ptr<opt::BasicBlock> pred_merge_block =
+      MakeUnique<opt::BasicBlock>(MakeUnique<opt::Instruction>(
+          ir_context, SpvOpLabel, 0, message_.pred_merge_block_fresh_id(),
+          opt::Instruction::OperandList()));
+
+  auto loop_header_block = ir_context->cfg()->block(message_.loop_header_id());
+  auto merge_block =
+      ir_context->cfg()->block(loop_header_block->MergeBlockId());
+  auto enclosing_function = loop_header_block->GetParent();
+  pred_merge_block->SetParent(enclosing_function);
+
+  // .......................................................
+  // 1. Duplicate the loop
+  // .......................................................
+
+  std::map<uint32_t, uint32_t> original_label_to_duplicate_label =
+      fuzzerutil::RepeatedUInt32PairToMap(
+          message_.original_label_to_duplicate_label());
+
+  std::map<uint32_t, uint32_t> original_id_to_duplicate_id =
+      fuzzerutil::RepeatedUInt32PairToMap(
+          message_.original_id_to_duplicate_id());
+
+  std::unique_ptr<opt::BasicBlock> selection_merge_block =
+      MakeUnique<opt::BasicBlock>(MakeUnique<opt::Instruction>(
+          ir_context, SpvOpLabel, 0, message_.selection_merge_block_fresh_id(),
+          opt::Instruction::OperandList()));
+  selection_merge_block->SetParent(enclosing_function);
+
+  auto exited_type_id = fuzzerutil::GetPointeeTypeIdFromPointerType(
+      ir_context, ir_context->get_def_use_mgr()
+                      ->GetDef(message_.variable_run_second_id())
+                      ->type_id());
+
+  std::vector<opt::BasicBlock*> blocks;
+  for (auto block_it = enclosing_function->begin();
+       block_it != enclosing_function->end(); block_it++) {
+    blocks.push_back(&*block_it);
+  }
+  std::set<opt::BasicBlock*> loop_blocks =
+      GetRegionBlocks(ir_context, loop_header_block, merge_block);
+
+  std::vector<opt::Instruction*> instructions_to_move;
+  opt::BasicBlock* previous_block = nullptr;
+
+  for (auto& block : blocks) {
+    if (loop_blocks.count(block) == 0) {
+      continue;
+    }
+    fuzzerutil::UpdateModuleIdBound(
+        ir_context, original_label_to_duplicate_label[block->id()]);
+
+    std::unique_ptr<opt::BasicBlock> duplicated_block =
+        MakeUnique<opt::BasicBlock>(MakeUnique<opt::Instruction>(
+            ir_context, SpvOpLabel, 0,
+            original_label_to_duplicate_label[block->id()],
+            opt::Instruction::OperandList()));
+
+    std::vector<opt::Instruction*> instructions_to_move_block;
+    for (auto& instr : *block) {
+      if (block == merge_block && (instr.opcode() == SpvOpReturn ||
+                                   instr.opcode() == SpvOpReturnValue ||
+                                   instr.opcode() == SpvOpBranch)) {
+        instructions_to_move.push_back(&instr);
+        continue;
+      }
+      if (instr.result_id()) {
+        fuzzerutil::UpdateModuleIdBound(
+            ir_context, original_id_to_duplicate_id[instr.result_id()]);
+      }
+      auto cloned_instr = instr.Clone(ir_context);
+      duplicated_block->AddInstruction(
+          std::unique_ptr<opt::Instruction>(cloned_instr));
+      cloned_instr->ForEachId(
+          [original_id_to_duplicate_id,
+           original_label_to_duplicate_label](uint32_t* op) {
+            if (original_id_to_duplicate_id.count(*op) != 0) {
+              *op = original_id_to_duplicate_id.at(*op);
+            }
+            if (original_label_to_duplicate_label.count(*op) != 0) {
+              *op = original_label_to_duplicate_label.at(*op);
+            }
+          });
+    }
+
+    // Duplicate the instruction.
+    // auto cloned_instr = instr.Clone(ir_context);
+    // duplicated_block->AddInstruction(
+    //    std::unique_ptr<opt::Instruction>(cloned_instr));
+
+    // If an id from the original region was used in this instruction,
+    // replace it with the value from |original_id_to_duplicate_id|.
+    // If a label from the original region was used in this instruction,
+    // replace it with the value from |original_label_to_duplicate_label|.
+
+    // If the block is the first duplicated block, insert it before the exit
+    // block of the original region. Otherwise, insert it after the preceding
+    // one.
+    duplicated_block->SetParent(enclosing_function);
+    auto duplicated_block_ptr = duplicated_block.get();
+    if (previous_block) {
+      enclosing_function->InsertBasicBlockAfter(std::move(duplicated_block),
+                                                previous_block);
+    } else {
+      enclosing_function->InsertBasicBlockAfter(std::move(duplicated_block),
+                                                merge_block);
+    }
+    previous_block = duplicated_block_ptr;
+  }
+
+  merge_block->terminator()->InsertBefore(
+      MakeUnique<opt::Instruction>(opt::Instruction(
+          ir_context, SpvOpLoad, exited_type_id,
+          message_.load_run_second_fresh_id(),
+          opt::Instruction::OperandList(
+              {{SPV_OPERAND_TYPE_ID, {message_.variable_run_second_id()}}}))));
+
+  merge_block->terminator()->InsertBefore(MakeUnique<opt::Instruction>(
+      opt::Instruction(ir_context, SpvOpSelectionMerge, 0, 0,
+                       {{SPV_OPERAND_TYPE_ID, {selection_merge_block->id()}},
+                        {SPV_OPERAND_TYPE_SELECTION_CONTROL, {0}}})));
+
+  merge_block->terminator()->InsertBefore(
+      MakeUnique<opt::Instruction>(opt::Instruction(
+          ir_context, SpvOpBranchConditional, 0, 0,
+          {{SPV_OPERAND_TYPE_ID, {message_.load_run_second_fresh_id()}},
+           {SPV_OPERAND_TYPE_ID,
+            {original_label_to_duplicate_label[loop_header_block->id()]}},
+           {SPV_OPERAND_TYPE_ID, {selection_merge_block->id()}}})));
+  // After execution of the loop, this variable stores a pointer to the last
+  // duplicated block.
+  auto duplicated_merge_block = previous_block;
+
+  for (auto instr : instructions_to_move) {
+    auto cloned_instr = instr->Clone(ir_context);
+    selection_merge_block->AddInstruction(
+        std::unique_ptr<opt::Instruction>(cloned_instr));
+    ir_context->KillInst(instr);
+  }
+
+  duplicated_merge_block->AddInstruction(MakeUnique<opt::Instruction>(
+      opt::Instruction(ir_context, SpvOpBranch, 0, 0,
+                       opt::Instruction::OperandList(
+                           {{SPV_OPERAND_TYPE_ID,
+                             {message_.selection_merge_block_fresh_id()}}}))));
+
+  // .......................................................
+  // 2. Insert some specific instructions in the first loop.
+  // .......................................................
+
+  enclosing_function->begin()->terminator()->InsertBefore(
+      MakeUnique<opt::Instruction>(opt::Instruction(
+          ir_context, SpvOpStore, 0, 0,
+          opt::Instruction::OperandList(
+              {{SPV_OPERAND_TYPE_ID, {message_.variable_counter_id()}},
+               {SPV_OPERAND_TYPE_ID, {message_.constant_zero_id()}}}))));
+
+  enclosing_function->begin()->terminator()->InsertBefore(
+      MakeUnique<opt::Instruction>(opt::Instruction(
+          ir_context, SpvOpStore, 0, 0,
+          opt::Instruction::OperandList(
+              {{SPV_OPERAND_TYPE_ID, {message_.variable_run_second_id()}},
+               {SPV_OPERAND_TYPE_ID, {message_.constant_true_id()}}}))));
+
+  pred_merge_block->AddInstruction(
+      MakeUnique<opt::Instruction>(opt::Instruction(
+          ir_context, SpvOpStore, 0, 0,
+          opt::Instruction::OperandList(
+              {{SPV_OPERAND_TYPE_ID, {message_.variable_run_second_id()}},
+               {SPV_OPERAND_TYPE_ID, {message_.constant_false_id()}}}))));
+
+  pred_merge_block->AddInstruction(MakeUnique<opt::Instruction>(
+      opt::Instruction(ir_context, SpvOpBranch, 0, 0,
+                       opt::Instruction::OperandList(
+                           {{SPV_OPERAND_TYPE_ID, {merge_block->id()}}}))));
+
+  auto condition_block = ir_context->cfg()->block(
+      loop_header_block->terminator()->GetSingleWordOperand(0));
+  // Replace all uses of merge label with the |pred_merge_block| label, except
+  // for the block directly after the loop header.
+  ir_context->get_def_use_mgr()->ForEachUse(
+      merge_block->id(),
+      [ir_context, this, loop_blocks, &loop_header_block, condition_block](
+          opt::Instruction* user, uint32_t operand_index) {
+        auto user_block = ir_context->get_instr_block(user);
+        // We don't change the merge block of the function.
+        if (user->opcode() == SpvOpLoopMerge) {
+          return;
+        }
+        // If the condition of the loop is false, we don't set |exited| to true,
+        // so we progress directly to the merge block.
+        if (user->opcode() == SpvOpBranchConditional &&
+            user_block == condition_block) {
+          return;
+        }
+        if ((loop_blocks.find(user_block) == loop_blocks.end())) {
+          return;
+        }
+        user->SetOperand(operand_index, {message_.pred_merge_block_fresh_id()});
+      });
+
+  auto counter_type_id = fuzzerutil::GetPointeeTypeIdFromPointerType(
+      ir_context, ir_context->get_def_use_mgr()
+                      ->GetDef(message_.variable_counter_id())
+                      ->type_id());
+
+  loop_header_block->terminator()->PreviousNode()->InsertBefore(
+      MakeUnique<opt::Instruction>(opt::Instruction(
+          ir_context, SpvOpLoad, counter_type_id,
+          message_.load_counter_fresh_id(),
+          opt::Instruction::OperandList(
+              {{SPV_OPERAND_TYPE_ID, {message_.variable_counter_id()}}}))));
+
+  loop_header_block->terminator()->PreviousNode()->InsertBefore(
+      MakeUnique<opt::Instruction>(opt::Instruction(
+          ir_context, SpvOpIAdd, counter_type_id,
+          message_.increment_counter_fresh_id(),
+          opt::Instruction::OperandList(
+              {{SPV_OPERAND_TYPE_ID, {message_.load_counter_fresh_id()}},
+               {SPV_OPERAND_TYPE_ID, {message_.constant_one_id()}}}))));
+
+  loop_header_block->terminator()->PreviousNode()->InsertBefore(
+      MakeUnique<opt::Instruction>(opt::Instruction(
+          ir_context, SpvOpStore, 0, 0,
+          opt::Instruction::OperandList(
+              {{SPV_OPERAND_TYPE_ID, {message_.variable_counter_id()}},
+               {SPV_OPERAND_TYPE_ID,
+                {message_.increment_counter_fresh_id()}}}))));
+
+  auto bool_type_id = fuzzerutil::MaybeGetBoolType(ir_context);
+  assert(bool_type_id && "The bool type must be present.");
+  loop_header_block->terminator()->PreviousNode()->InsertBefore(
+      MakeUnique<opt::Instruction>(opt::Instruction(
+          ir_context, SpvOpSLessThan, bool_type_id,
+          message_.condition_counter_fresh_id(),
+          {{SPV_OPERAND_TYPE_ID, {message_.increment_counter_fresh_id()}},
+           {SPV_OPERAND_TYPE_ID, {message_.constant_limit_id()}}})));
+
+  loop_header_block->terminator()->InsertBefore(
+      MakeUnique<opt::Instruction>(opt::Instruction(
+          ir_context, SpvOpBranchConditional, 0, 0,
+          {{SPV_OPERAND_TYPE_ID, {message_.condition_counter_fresh_id()}},
+           {SPV_OPERAND_TYPE_ID, {condition_block->id()}},
+           {SPV_OPERAND_TYPE_ID, {merge_block->id()}}})));
+
+  // Remove the OpBranch instruction.
+  ir_context->KillInst(loop_header_block->terminator());
+
+  enclosing_function->InsertBasicBlockBefore(std::move(pred_merge_block),
+                                             merge_block);
+  enclosing_function->InsertBasicBlockAfter(std::move(selection_merge_block),
+                                            duplicated_merge_block);
+
+  ir_context->InvalidateAnalysesExceptFor(opt::IRContext::kAnalysisNone);
+}  // namespace fuzz
 
 protobufs::Transformation TransformationSplitLoop::ToMessage() const {
   protobufs::Transformation result;
   *result.mutable_split_loop() = message_;
+  return result;
+}
+
+std::set<opt::BasicBlock*> TransformationSplitLoop::GetRegionBlocks(
+    opt::IRContext* ir_context, opt::BasicBlock* entry_block,
+    opt::BasicBlock* exit_block) {
+  auto enclosing_function = entry_block->GetParent();
+  auto dominator_analysis =
+      ir_context->GetDominatorAnalysis(enclosing_function);
+  auto postdominator_analysis =
+      ir_context->GetPostDominatorAnalysis(enclosing_function);
+
+  // A block belongs to a region between the entry block and the exit block if
+  // and only if it is dominated by the entry block and post-dominated by the
+  // exit block.
+  std::set<opt::BasicBlock*> result;
+  for (auto& block : *enclosing_function) {
+    if (dominator_analysis->Dominates(entry_block, &block) &&
+        postdominator_analysis->Dominates(exit_block, &block)) {
+      result.insert(&block);
+    }
+  }
   return result;
 }
 

--- a/source/fuzz/transformation_split_loop.cpp
+++ b/source/fuzz/transformation_split_loop.cpp
@@ -130,6 +130,9 @@ bool TransformationSplitLoop::IsApplicable(
 
   // The header of the loop cannot be the first block.
   auto enclosing_function = loop_header_block->GetParent();
+  // Avoid unused variable warning in release mode.
+  (void)enclosing_function;
+
   assert(&*enclosing_function->begin() != loop_header_block &&
          "A loop header cannot be an entry block of a function.");
 

--- a/source/fuzz/transformation_split_loop.cpp
+++ b/source/fuzz/transformation_split_loop.cpp
@@ -30,6 +30,7 @@ TransformationSplitLoop::TransformationSplitLoop(
     uint32_t condition_counter_fresh_id, uint32_t new_body_entry_block_fresh_id,
     uint32_t conditional_block_fresh_id, uint32_t load_run_second_fresh_id,
     uint32_t selection_merge_block_fresh_id,
+    const std::vector<uint32_t>& logical_not_fresh_ids,
     const std::map<uint32_t, uint32_t>& original_label_to_duplicate_label,
     const std::map<uint32_t, uint32_t>& original_id_to_duplicate_id) {
   message_.set_loop_header_id(loop_header_id);
@@ -43,6 +44,9 @@ TransformationSplitLoop::TransformationSplitLoop(
   message_.set_conditional_block_fresh_id(conditional_block_fresh_id);
   message_.set_load_run_second_fresh_id(load_run_second_fresh_id);
   message_.set_selection_merge_block_fresh_id(selection_merge_block_fresh_id);
+  for (auto logical_not_fresh_id : logical_not_fresh_ids) {
+    message_.add_logical_not_fresh_ids(logical_not_fresh_id);
+  }
   *message_.mutable_original_label_to_duplicate_label() =
       fuzzerutil::MapToRepeatedUInt32Pair(original_label_to_duplicate_label);
   *message_.mutable_original_id_to_duplicate_id() =
@@ -141,6 +145,9 @@ void TransformationSplitLoop::Apply(
       fuzzerutil::RepeatedUInt32PairToMap(
           message_.original_id_to_duplicate_id());
 
+  std::vector<uint32_t> logical_not_fresh_ids =
+      fuzzerutil::RepeatedFieldToVector(message_.logical_not_fresh_ids());
+
   std::unique_ptr<opt::BasicBlock> selection_merge_block =
       MakeUnique<opt::BasicBlock>(MakeUnique<opt::Instruction>(
           ir_context, SpvOpLabel, 0, message_.selection_merge_block_fresh_id(),
@@ -155,27 +162,6 @@ void TransformationSplitLoop::Apply(
       MakeUnique<opt::BasicBlock>(MakeUnique<opt::Instruction>(
           ir_context, SpvOpLabel, 0, message_.conditional_block_fresh_id(),
           opt::Instruction::OperandList{}));
-
-  // In the terminator of |loop_header| take first branch which is not a merge
-  // block and set it to |new_body_entry|
-  auto loop_header_terminator = loop_header_block->terminator();
-  uint32_t next_not_merge_id;
-  uint32_t next_not_merge_pos;
-  if (loop_header_terminator->opcode() == SpvOpBranch) {
-    next_not_merge_id = loop_header_terminator->GetSingleWordInOperand(0);
-    next_not_merge_pos = 0;
-  } else  // SpvOpBranchConditional
-  {
-    uint32_t first_id = loop_header_terminator->GetSingleWordInOperand(1);
-    uint32_t second_id = loop_header_terminator->GetSingleWordInOperand(2);
-    if (first_id != merge_block->id()) {
-      next_not_merge_id = first_id;
-      next_not_merge_pos = 1;
-    } else {
-      next_not_merge_id = second_id;
-      next_not_merge_pos = 2;
-    }
-  }
 
   // We know that the execution of the transformed region will end in
   // |selection_merge_block|. Hence, we need to change all occurrences of the
@@ -209,7 +195,7 @@ void TransformationSplitLoop::Apply(
 
   std::vector<opt::Instruction*> instructions_to_move;
   opt::BasicBlock* previous_block = nullptr;
-
+  opt::BasicBlock* duplicated_merge_block = nullptr;
   for (auto& block : blocks) {
     if (loop_blocks.count(block) == 0) {
       continue;
@@ -286,10 +272,12 @@ void TransformationSplitLoop::Apply(
                                                 merge_block);
     }
     previous_block = duplicated_block_ptr;
+    // After execution of the loop, this variable stores a pointer to the last
+    // duplicated block.
+    if (block == merge_block) {
+      duplicated_merge_block = duplicated_block_ptr;
+    }
   }
-  // After execution of the loop, this variable stores a pointer to the last
-  // duplicated block.
-  auto duplicated_merge_block = previous_block;
 
   for (auto instr : instructions_to_move) {
     auto cloned_instr = instr->Clone(ir_context);
@@ -398,27 +386,88 @@ void TransformationSplitLoop::Apply(
 
   auto merge_block_instr = merge_block->GetLabelInst();
   ir_context->get_def_use_mgr()->ForEachUse(
-      merge_block_instr, [this, const_false_id, ir_context, loop_blocks](
-                             opt::Instruction* user, uint32_t) {
+      merge_block_instr,
+      [this, const_false_id, ir_context, loop_blocks, &logical_not_fresh_ids,
+       bool_type_id](opt::Instruction* user, uint32_t operand) {
         auto user_block = ir_context->get_instr_block(user);
-        if (loop_blocks.find(user_block) != loop_blocks.end() &&
-            user->opcode() == SpvOpBranch) {
-          user_block->AddInstruction(
-              MakeUnique<opt::Instruction>(opt::Instruction(
-                  ir_context, SpvOpStore, 0, 0,
-                  opt::Instruction::OperandList(
-                      {{SPV_OPERAND_TYPE_ID,
-                        {message_.variable_run_second_id()}},
-                       {SPV_OPERAND_TYPE_ID, {const_false_id}}}))));
-          auto cloned_instr = user->Clone(ir_context);
-          user_block->AddInstruction(
-              std::unique_ptr<opt::Instruction>(cloned_instr));
-          ir_context->KillInst(user);
+        if (loop_blocks.find(user_block) == loop_blocks.end()) {
+          return;
+        }
+        // If we branch unconditionally to the merge block, set |run_second| to
+        // false.
+        if (user->opcode() == SpvOpBranch) {
+          user->InsertBefore(MakeUnique<opt::Instruction>(opt::Instruction(
+              ir_context, SpvOpStore, 0, 0,
+              opt::Instruction::OperandList(
+                  {{SPV_OPERAND_TYPE_ID, {message_.variable_run_second_id()}},
+                   {SPV_OPERAND_TYPE_ID, {const_false_id}}}))));
+        } else if (user->opcode() == SpvOpBranchConditional) {
+          // If we have an instruction of form: OpBranchConditional %cond %other
+          // %merge then set |run_second| to the value of the boolean condition
+          // %cond
+          auto instr_to_insert_before = user;
+          if (user_block->IsLoopHeader()) {
+            instr_to_insert_before = user->PreviousNode();
+          }
+          if (operand == 2) {
+            instr_to_insert_before->InsertBefore(MakeUnique<opt::Instruction>(
+                opt::Instruction(ir_context, SpvOpStore, 0, 0,
+                                 opt::Instruction::OperandList(
+                                     {{SPV_OPERAND_TYPE_ID,
+                                       {message_.variable_run_second_id()}},
+                                      {SPV_OPERAND_TYPE_ID,
+                                       {user->GetSingleWordInOperand(0)}}}))));
+          } else if (operand == 1) {
+            // If we have an instruction of form: OpBranchConditional %cond
+            // %merge %other then set |run_second| to the negation of the value
+            // of the boolean condition %cond.
+            auto result_id = logical_not_fresh_ids.back();
+            logical_not_fresh_ids.pop_back();
+            instr_to_insert_before->InsertBefore(
+                MakeUnique<opt::Instruction>(opt::Instruction(
+                    ir_context, SpvOpLogicalNot, bool_type_id, result_id,
+                    opt::Instruction::OperandList(
+                        {{SPV_OPERAND_TYPE_ID,
+                          {user->GetSingleWordInOperand(0)}}}))));
+            instr_to_insert_before->InsertBefore(MakeUnique<opt::Instruction>(
+                opt::Instruction(ir_context, SpvOpStore, 0, 0,
+                                 opt::Instruction::OperandList(
+                                     {{SPV_OPERAND_TYPE_ID,
+                                       {message_.variable_run_second_id()}},
+                                      {SPV_OPERAND_TYPE_ID, {result_id}}}))));
+          }
         }
       });
 
+  // In the terminator of |loop_header| take first branch which is not a merge
+  // block and set it to |new_body_entry|
+  auto loop_header_terminator = loop_header_block->terminator();
+  uint32_t next_not_merge_id;
+  uint32_t next_not_merge_pos;
+  if (loop_header_terminator->opcode() == SpvOpBranch) {
+    next_not_merge_id = loop_header_terminator->GetSingleWordInOperand(0);
+    next_not_merge_pos = 0;
+  } else  // SpvOpBranchConditional
+  {
+    uint32_t first_id = loop_header_terminator->GetSingleWordInOperand(1);
+    uint32_t second_id = loop_header_terminator->GetSingleWordInOperand(2);
+    if (first_id != merge_block->id()) {
+      next_not_merge_id = first_id;
+      next_not_merge_pos = 1;
+    } else {
+      next_not_merge_id = second_id;
+      next_not_merge_pos = 2;
+    }
+  }
+
   loop_header_terminator->SetInOperand(next_not_merge_pos,
                                        {new_body_entry_block->id()});
+
+  loop_header_block->GetLoopMergeInst()->ForEachInOperand([this](uint32_t* id) {
+    if (*id == message_.loop_header_id()) {
+      *id = message_.new_body_entry_block_fresh_id();
+    }
+  });
 
   // Insert conditional branch at the end of |new_body_entry|. If the number of
   // iterations is smaller than the limit, go to |next_not_merge_id|. Otherwise,

--- a/source/fuzz/transformation_split_loop.cpp
+++ b/source/fuzz/transformation_split_loop.cpp
@@ -28,7 +28,8 @@ TransformationSplitLoop::TransformationSplitLoop(
     uint32_t variable_run_second_id, uint32_t constant_limit_id,
     uint32_t load_counter_fresh_id, uint32_t increment_counter_fresh_id,
     uint32_t condition_counter_fresh_id, uint32_t new_body_entry_block_fresh_id,
-    uint32_t load_run_second_fresh_id, uint32_t selection_merge_block_fresh_id,
+    uint32_t conditional_block_fresh_id, uint32_t load_run_second_fresh_id,
+    uint32_t selection_merge_block_fresh_id,
     const std::map<uint32_t, uint32_t>& original_label_to_duplicate_label,
     const std::map<uint32_t, uint32_t>& original_id_to_duplicate_id) {
   message_.set_loop_header_id(loop_header_id);
@@ -39,6 +40,7 @@ TransformationSplitLoop::TransformationSplitLoop(
   message_.set_increment_counter_fresh_id(increment_counter_fresh_id);
   message_.set_condition_counter_fresh_id(condition_counter_fresh_id);
   message_.set_new_body_entry_block_fresh_id(new_body_entry_block_fresh_id);
+  message_.set_conditional_block_fresh_id(conditional_block_fresh_id);
   message_.set_load_run_second_fresh_id(load_run_second_fresh_id);
   message_.set_selection_merge_block_fresh_id(selection_merge_block_fresh_id);
   *message_.mutable_original_label_to_duplicate_label() =
@@ -67,11 +69,37 @@ bool TransformationSplitLoop::IsApplicable(
     return false;
   }
 
-  auto entry_block = ir_context->cfg()->block(message_.loop_header_id());
-  if (!entry_block->IsLoopHeader()) {
+  auto loop_header_block = ir_context->cfg()->block(message_.loop_header_id());
+  if (!loop_header_block->IsLoopHeader()) {
     return false;
   }
-  return true;
+
+  auto continue_id = loop_header_block->ContinueBlockId();
+  auto entry_block_pred_ids = ir_context->cfg()->preds(loop_header_block->id());
+  std::sort(entry_block_pred_ids.begin(), entry_block_pred_ids.end());
+
+  entry_block_pred_ids.erase(
+      unique(entry_block_pred_ids.begin(), entry_block_pred_ids.end()),
+      entry_block_pred_ids.end());
+
+  entry_block_pred_ids.erase(
+      std::remove(entry_block_pred_ids.begin(), entry_block_pred_ids.end(),
+                  continue_id),
+      entry_block_pred_ids.end());
+  if (entry_block_pred_ids.size() > 1) {
+    return false;
+  }
+
+  auto merge_block =
+      ir_context->cfg()->block(loop_header_block->MergeBlockId());
+  switch (merge_block->terminator()->opcode()) {
+    case SpvOpBranch:
+    case SpvOpReturn:
+    case SpvOpReturnValue:
+      return true;
+    default:
+      return false;
+  }
 }
 
 void TransformationSplitLoop::Apply(
@@ -93,11 +121,12 @@ void TransformationSplitLoop::Apply(
                                   message_.condition_counter_fresh_id());
   fuzzerutil::UpdateModuleIdBound(ir_context,
                                   message_.new_body_entry_block_fresh_id());
-  fuzzerutil::UpdateModuleIdBound(ir_context, message_.load_counter_fresh_id());
   fuzzerutil::UpdateModuleIdBound(ir_context,
-                                  message_.selection_merge_block_fresh_id());
+                                  message_.conditional_block_fresh_id());
   fuzzerutil::UpdateModuleIdBound(ir_context,
                                   message_.load_run_second_fresh_id());
+  fuzzerutil::UpdateModuleIdBound(ir_context,
+                                  message_.selection_merge_block_fresh_id());
 
   auto loop_header_block = ir_context->cfg()->block(message_.loop_header_id());
   auto merge_block =
@@ -119,7 +148,56 @@ void TransformationSplitLoop::Apply(
   std::unique_ptr<opt::BasicBlock> selection_merge_block =
       MakeUnique<opt::BasicBlock>(MakeUnique<opt::Instruction>(
           ir_context, SpvOpLabel, 0, message_.selection_merge_block_fresh_id(),
-          opt::Instruction::OperandList()));
+          opt::Instruction::OperandList{}));
+
+  std::unique_ptr<opt::BasicBlock> new_body_entry_block =
+      MakeUnique<opt::BasicBlock>(MakeUnique<opt::Instruction>(
+          ir_context, SpvOpLabel, 0, message_.new_body_entry_block_fresh_id(),
+          opt::Instruction::OperandList{}));
+
+  std::unique_ptr<opt::BasicBlock> conditional_block =
+      MakeUnique<opt::BasicBlock>(MakeUnique<opt::Instruction>(
+          ir_context, SpvOpLabel, 0, message_.conditional_block_fresh_id(),
+          opt::Instruction::OperandList{}));
+
+  // In the terminator of |loop_header| take first branch which is not a merge
+  // block and set it to |new_body_entry|
+  auto loop_header_terminator = loop_header_block->terminator();
+  uint32_t next_not_merge_id;
+  uint32_t next_not_merge_pos;
+  if (loop_header_terminator->opcode() == SpvOpBranch) {
+    next_not_merge_id = loop_header_terminator->GetSingleWordInOperand(0);
+    next_not_merge_pos = 0;
+  } else  // SpvOpBranchConditional
+  {
+    uint32_t first_id = loop_header_terminator->GetSingleWordInOperand(1);
+    uint32_t second_id = loop_header_terminator->GetSingleWordInOperand(2);
+    if (first_id != merge_block->id()) {
+      next_not_merge_id = first_id;
+      next_not_merge_pos = 1;
+    } else {
+      next_not_merge_id = second_id;
+      next_not_merge_pos = 2;
+    }
+  }
+
+  // We know that the execution of the transformed region will end in
+  // |selection_merge_block|. Hence, we need to change all occurrences of the
+  // label id of the |merge_block| to the label id of the
+  // |selection_merge_block|.
+  merge_block->ForEachSuccessorLabel(
+      [this, &merge_block, ir_context](uint32_t label_id) {
+        auto block = ir_context->cfg()->block(label_id);
+        for (auto& instr : *block) {
+          if (instr.opcode() == SpvOpPhi) {
+            instr.ForEachId([this, &merge_block](uint32_t* id) {
+              if (*id == merge_block->id()) {
+                *id = message_.selection_merge_block_fresh_id();
+              }
+            });
+          }
+        }
+      });
 
   auto exited_type_id = fuzzerutil::GetPointeeTypeIdFromPointerType(
       ir_context, ir_context->get_def_use_mgr()
@@ -127,9 +205,8 @@ void TransformationSplitLoop::Apply(
                       ->type_id());
 
   std::vector<opt::BasicBlock*> blocks;
-  for (auto block_it = enclosing_function->begin();
-       block_it != enclosing_function->end(); block_it++) {
-    blocks.push_back(&*block_it);
+  for (auto& block : *enclosing_function) {
+    blocks.push_back(&block);
   }
   std::set<opt::BasicBlock*> loop_blocks =
       GetRegionBlocks(ir_context, loop_header_block, merge_block);
@@ -175,6 +252,20 @@ void TransformationSplitLoop::Apply(
               *op = original_label_to_duplicate_label.at(*op);
             }
           });
+      // Resolve OpPhi instruction in the first duplicated block. If there was a
+      // branch from outside of the loop, change the id to the id of
+      // |conditional_block|.
+      if (!previous_block && cloned_instr->opcode() == SpvOpPhi) {
+        for (uint32_t i = 1; i < cloned_instr->NumInOperands(); i += 2) {
+          auto duplicated_continue_id =
+              original_label_to_duplicate_label[loop_header_block
+                                                    ->ContinueBlockId()];
+          if (cloned_instr->GetSingleWordInOperand(i) !=
+              duplicated_continue_id) {
+            cloned_instr->SetInOperand(i, {conditional_block->id()});
+          }
+        }
+      }
     }
 
     // Duplicate the instruction.
@@ -190,7 +281,6 @@ void TransformationSplitLoop::Apply(
     // If the block is the first duplicated block, insert it before the exit
     // block of the original region. Otherwise, insert it after the preceding
     // one.
-    duplicated_block->SetParent(enclosing_function);
     auto duplicated_block_ptr = duplicated_block.get();
     if (previous_block) {
       enclosing_function->InsertBasicBlockAfter(std::move(duplicated_block),
@@ -201,26 +291,6 @@ void TransformationSplitLoop::Apply(
     }
     previous_block = duplicated_block_ptr;
   }
-
-  merge_block->terminator()->InsertBefore(
-      MakeUnique<opt::Instruction>(opt::Instruction(
-          ir_context, SpvOpLoad, exited_type_id,
-          message_.load_run_second_fresh_id(),
-          opt::Instruction::OperandList(
-              {{SPV_OPERAND_TYPE_ID, {message_.variable_run_second_id()}}}))));
-
-  merge_block->terminator()->InsertBefore(MakeUnique<opt::Instruction>(
-      opt::Instruction(ir_context, SpvOpSelectionMerge, 0, 0,
-                       {{SPV_OPERAND_TYPE_ID, {selection_merge_block->id()}},
-                        {SPV_OPERAND_TYPE_SELECTION_CONTROL, {0}}})));
-
-  merge_block->terminator()->InsertBefore(
-      MakeUnique<opt::Instruction>(opt::Instruction(
-          ir_context, SpvOpBranchConditional, 0, 0,
-          {{SPV_OPERAND_TYPE_ID, {message_.load_run_second_fresh_id()}},
-           {SPV_OPERAND_TYPE_ID,
-            {original_label_to_duplicate_label[loop_header_block->id()]}},
-           {SPV_OPERAND_TYPE_ID, {selection_merge_block->id()}}})));
   // After execution of the loop, this variable stores a pointer to the last
   // duplicated block.
   auto duplicated_merge_block = previous_block;
@@ -232,6 +302,31 @@ void TransformationSplitLoop::Apply(
     ir_context->KillInst(instr);
   }
 
+  merge_block->AddInstruction(MakeUnique<opt::Instruction>(opt::Instruction(
+      ir_context, SpvOpBranch, 0, 0,
+      opt::Instruction::OperandList(
+          {{SPV_OPERAND_TYPE_ID, {message_.conditional_block_fresh_id()}}}))));
+
+  conditional_block->AddInstruction(
+      MakeUnique<opt::Instruction>(opt::Instruction(
+          ir_context, SpvOpLoad, exited_type_id,
+          message_.load_run_second_fresh_id(),
+          opt::Instruction::OperandList(
+              {{SPV_OPERAND_TYPE_ID, {message_.variable_run_second_id()}}}))));
+
+  conditional_block->AddInstruction(MakeUnique<opt::Instruction>(
+      opt::Instruction(ir_context, SpvOpSelectionMerge, 0, 0,
+                       {{SPV_OPERAND_TYPE_ID, {selection_merge_block->id()}},
+                        {SPV_OPERAND_TYPE_SELECTION_CONTROL, {0}}})));
+
+  conditional_block->AddInstruction(
+      MakeUnique<opt::Instruction>(opt::Instruction(
+          ir_context, SpvOpBranchConditional, 0, 0,
+          {{SPV_OPERAND_TYPE_ID, {message_.load_run_second_fresh_id()}},
+           {SPV_OPERAND_TYPE_ID,
+            {original_label_to_duplicate_label[loop_header_block->id()]}},
+           {SPV_OPERAND_TYPE_ID, {selection_merge_block->id()}}})));
+
   duplicated_merge_block->AddInstruction(MakeUnique<opt::Instruction>(
       opt::Instruction(ir_context, SpvOpBranch, 0, 0,
                        opt::Instruction::OperandList(
@@ -242,29 +337,33 @@ void TransformationSplitLoop::Apply(
   // 2. Insert some specific instructions in the first loop.
   // .......................................................
 
-  enclosing_function->begin()->terminator()->InsertBefore(
+  auto block_terminator = enclosing_function->entry()->terminator();
+
+  enclosing_function->entry()->AddInstruction(
       MakeUnique<opt::Instruction>(opt::Instruction(
           ir_context, SpvOpStore, 0, 0,
           opt::Instruction::OperandList(
               {{SPV_OPERAND_TYPE_ID, {message_.variable_counter_id()}},
                {SPV_OPERAND_TYPE_ID, {const_zero_id}}}))));
 
-  enclosing_function->begin()->terminator()->InsertBefore(
+  enclosing_function->entry()->AddInstruction(
       MakeUnique<opt::Instruction>(opt::Instruction(
           ir_context, SpvOpStore, 0, 0,
           opt::Instruction::OperandList(
               {{SPV_OPERAND_TYPE_ID, {message_.variable_run_second_id()}},
                {SPV_OPERAND_TYPE_ID, {const_true_id}}}))));
 
+  {
+    auto cloned_instr = block_terminator->Clone(ir_context);
+    enclosing_function->entry()->AddInstruction(
+        std::unique_ptr<opt::Instruction>(cloned_instr));
+    ir_context->KillInst(block_terminator);
+  }
+
   auto counter_type_id = fuzzerutil::GetPointeeTypeIdFromPointerType(
       ir_context, ir_context->get_def_use_mgr()
                       ->GetDef(message_.variable_counter_id())
                       ->type_id());
-
-  std::unique_ptr<opt::BasicBlock> new_body_entry_block =
-      MakeUnique<opt::BasicBlock>(MakeUnique<opt::Instruction>(
-          ir_context, SpvOpLabel, 0, message_.new_body_entry_block_fresh_id(),
-          opt::Instruction::OperandList()));
 
   new_body_entry_block->AddInstruction(
       MakeUnique<opt::Instruction>(opt::Instruction(
@@ -291,9 +390,10 @@ void TransformationSplitLoop::Apply(
 
   auto bool_type_id = fuzzerutil::MaybeGetBoolType(ir_context);
   assert(bool_type_id && "The bool type must be present.");
+
   new_body_entry_block->AddInstruction(
       MakeUnique<opt::Instruction>(opt::Instruction(
-          ir_context, SpvOpSLessThan, bool_type_id,
+          ir_context, SpvOpULessThan, bool_type_id,
           message_.condition_counter_fresh_id(),
           {{SPV_OPERAND_TYPE_ID, {message_.increment_counter_fresh_id()}},
            {SPV_OPERAND_TYPE_ID, {message_.constant_limit_id()}}})));
@@ -307,34 +407,20 @@ void TransformationSplitLoop::Apply(
         auto user_block = ir_context->get_instr_block(user);
         if (loop_blocks.find(user_block) != loop_blocks.end() &&
             user->opcode() == SpvOpBranch) {
-          user->InsertBefore(MakeUnique<opt::Instruction>(opt::Instruction(
-              ir_context, SpvOpStore, 0, 0,
-              opt::Instruction::OperandList(
-                  {{SPV_OPERAND_TYPE_ID, {message_.variable_run_second_id()}},
-                   {SPV_OPERAND_TYPE_ID, {const_false_id}}}))));
+          user_block->AddInstruction(
+              MakeUnique<opt::Instruction>(opt::Instruction(
+                  ir_context, SpvOpStore, 0, 0,
+                  opt::Instruction::OperandList(
+                      {{SPV_OPERAND_TYPE_ID,
+                        {message_.variable_run_second_id()}},
+                       {SPV_OPERAND_TYPE_ID, {const_false_id}}}))));
+          auto cloned_instr = user->Clone(ir_context);
+          user_block->AddInstruction(
+              std::unique_ptr<opt::Instruction>(cloned_instr));
+          ir_context->KillInst(user);
         }
       });
 
-  // In the terminator of |loop_header| take first branch which is not a merge
-  // block and set it to |new_body_entry|
-  auto loop_header_terminator = loop_header_block->terminator();
-  uint32_t next_not_merge_id;
-  uint32_t next_not_merge_pos;
-  if (loop_header_terminator->opcode() == SpvOpBranch) {
-    next_not_merge_id = loop_header_terminator->GetSingleWordInOperand(0);
-    next_not_merge_pos = 0;
-  } else  // SpvOpBranchConditional
-  {
-    uint32_t first_id = loop_header_terminator->GetSingleWordInOperand(1);
-    uint32_t second_id = loop_header_terminator->GetSingleWordInOperand(2);
-    if (first_id != merge_block->id()) {
-      next_not_merge_id = first_id;
-      next_not_merge_pos = 1;
-    } else {
-      next_not_merge_id = second_id;
-      next_not_merge_pos = 2;
-    }
-  }
   loop_header_terminator->SetInOperand(next_not_merge_pos,
                                        {new_body_entry_block->id()});
 
@@ -349,13 +435,31 @@ void TransformationSplitLoop::Apply(
            {SPV_OPERAND_TYPE_ID, {next_not_merge_id}},
            {SPV_OPERAND_TYPE_ID, {merge_block->id()}}})));
 
+  // auto new_body_entry_block_instr = new_body_entry_block->GetLabelInst();
+
   enclosing_function->InsertBasicBlockAfter(std::move(new_body_entry_block),
                                             loop_header_block);
   enclosing_function->InsertBasicBlockAfter(std::move(selection_merge_block),
                                             duplicated_merge_block);
+  enclosing_function->InsertBasicBlockAfter(std::move(conditional_block),
+                                            merge_block);
+
+  {
+    auto block = ir_context->cfg()->block(next_not_merge_id);
+    for (auto& instr : *block) {
+      if (instr.opcode() == SpvOpPhi) {
+        for (uint32_t i = 1; i < instr.NumInOperands(); i += 2) {
+          if (instr.GetSingleWordInOperand(i) == message_.loop_header_id()) {
+            instr.SetInOperand(i, {message_.new_body_entry_block_fresh_id()});
+          }
+        }
+      }
+    }
+  }
 
   ir_context->InvalidateAnalysesExceptFor(opt::IRContext::kAnalysisNone);
-}
+
+}  // namespace fuzz
 
 protobufs::Transformation TransformationSplitLoop::ToMessage() const {
   protobufs::Transformation result;

--- a/source/fuzz/transformation_split_loop.h
+++ b/source/fuzz/transformation_split_loop.h
@@ -40,15 +40,37 @@ class TransformationSplitLoop : public Transformation {
       const std::map<uint32_t, uint32_t>& original_label_to_duplicate_label,
       const std::map<uint32_t, uint32_t>& original_id_to_duplicate_id);
 
+  // - |loop_header_id| must refer to an existing loop header.
+  // - |variable_counter_id| must refer to a variable of type integer.
+  // - |variable_run_second_id| must refer to a variable of type bool.
+  // - |constant_limit_id| must correspond to an integer constant (the limit of
+  //   iterations in the first loop).
+  // - |load_counter_fresh_id|, |increment_counter_fresh_id|,
+  //   |condition_counter_fresh_id|, |new_body_entry_block_fresh_id|,
+  //   |conditional_block_fresh_id|, |load_run_second_fresh_id|,
+  //   |selection_merge_block_fresh_id| must be distinct, fresh ids.
+  // - |logical_not_fresh_ids| must contain at least as many distinct fresh ids
+  //   as there are terminators of form "OpBranchConditional %cond %merge
+  //   %other" in the loop.
+  // - |original_label_to_duplicate_label| must contain at least a key for every
+  //   block in the original loop.
+  // - |original_id_to_duplicate_id| must contain at least a key for every
+  //   result id in the original loop.
   bool IsApplicable(
       opt::IRContext* ir_context,
       const TransformationContext& transformation_context) const override;
 
+  // A transformation that replaces a loop with two loops, which in total
+  // iterate over the same loop body with the same condition of iteration.
+  // The first loop is executed up to a constant number of times. If more
+  // iterations are required, they are performed in the second loop.
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
   protobufs::Transformation ToMessage() const override;
 
+  // Returns the set of blocks dominated by |entry_block| and post-dominated
+  // by |exit_block|.
   static std::set<opt::BasicBlock*> GetRegionBlocks(
       opt::IRContext* ir_context, opt::BasicBlock* entry_block,
       opt::BasicBlock* exit_block);

--- a/source/fuzz/transformation_split_loop.h
+++ b/source/fuzz/transformation_split_loop.h
@@ -29,8 +29,8 @@ class TransformationSplitLoop : public Transformation {
       const protobufs::TransformationSplitLoop& message);
 
   explicit TransformationSplitLoop(
-      uint32_t loop_header_id, uint32_t variable_counter_id,
-      uint32_t variable_run_second_id, uint32_t constant_limit_id,
+      uint32_t loop_header_id, uint32_t variable_counter_fresh_id,
+      uint32_t variable_run_second_fresh_id, uint32_t constant_limit_id,
       uint32_t load_counter_fresh_id, uint32_t increment_counter_fresh_id,
       uint32_t condition_counter_fresh_id,
       uint32_t new_body_entry_block_fresh_id,
@@ -41,11 +41,10 @@ class TransformationSplitLoop : public Transformation {
       const std::map<uint32_t, uint32_t>& original_id_to_duplicate_id);
 
   // - |loop_header_id| must refer to an existing loop header.
-  // - |variable_counter_id| must refer to a variable of type integer.
-  // - |variable_run_second_id| must refer to a variable of type bool.
   // - |constant_limit_id| must correspond to an integer constant (the limit of
   //   iterations in the first loop).
-  // - |load_counter_fresh_id|, |increment_counter_fresh_id|,
+  // - |variable_counter_fresh_id|, |variable_run_second_fresh_id|,
+  //   |load_counter_fresh_id|, |increment_counter_fresh_id|,
   //   |condition_counter_fresh_id|, |new_body_entry_block_fresh_id|,
   //   |conditional_block_fresh_id|, |load_run_second_fresh_id|,
   //   |selection_merge_block_fresh_id| must be distinct, fresh ids.

--- a/source/fuzz/transformation_split_loop.h
+++ b/source/fuzz/transformation_split_loop.h
@@ -29,14 +29,16 @@ class TransformationSplitLoop : public Transformation {
       const protobufs::TransformationSplitLoop& message);
 
   explicit TransformationSplitLoop(
-      uint32_t variable_counter_fresh_id, uint32_t variable_exited_fresh_id,
-      uint32_t load_counter_fresh_id, uint32_t load_exited_fresh_id,
-      uint32_t iteration_limit_id, uint32_t condition_counter_fresh_id,
-      uint32_t logical_not_fresh_id, uint32_t then_branch_fresh_id,
-      uint32_t else_branch_fresh_id, uint32_t entry_block_id,
-      uint32_t exit_block_id,
-      std::map<uint32_t, uint32_t> original_id_to_duplicate_id,
-      std::map<uint32_t, uint32_t> original_label_to_duplicate_label);
+      uint32_t loop_header_id, uint32_t variable_counter_id,
+      uint32_t variable_run_second_id, uint32_t constant_one_id,
+      uint32_t constant_zero_id, uint32_t constant_limit_id,
+      uint32_t load_counter_fresh_id, uint32_t increment_counter_fresh_id,
+      uint32_t condition_counter_fresh_id, uint32_t pred_merge_block_fresh_id,
+      uint32_t constant_true_id, uint32_t constant_false_id,
+      uint32_t load_run_second_fresh_id,
+      uint32_t selection_merge_block_fresh_id,
+      std::map<uint32_t, uint32_t> original_label_to_duplicate_label,
+      std::map<uint32_t, uint32_t> original_id_to_duplicate_id);
 
   bool IsApplicable(
       opt::IRContext* ir_context,
@@ -46,6 +48,10 @@ class TransformationSplitLoop : public Transformation {
              TransformationContext* transformation_context) const override;
 
   protobufs::Transformation ToMessage() const override;
+
+  static std::set<opt::BasicBlock*> GetRegionBlocks(
+      opt::IRContext* ir_context, opt::BasicBlock* entry_block,
+      opt::BasicBlock* exit_block);
 
  private:
   protobufs::TransformationSplitLoop message_;

--- a/source/fuzz/transformation_split_loop.h
+++ b/source/fuzz/transformation_split_loop.h
@@ -33,7 +33,8 @@ class TransformationSplitLoop : public Transformation {
       uint32_t variable_run_second_id, uint32_t constant_limit_id,
       uint32_t load_counter_fresh_id, uint32_t increment_counter_fresh_id,
       uint32_t condition_counter_fresh_id,
-      uint32_t new_body_entry_block_fresh_id, uint32_t load_run_second_fresh_id,
+      uint32_t new_body_entry_block_fresh_id,
+      uint32_t conditional_block_fresh_id, uint32_t load_run_second_fresh_id,
       uint32_t selection_merge_block_fresh_id,
       const std::map<uint32_t, uint32_t>& original_label_to_duplicate_label,
       const std::map<uint32_t, uint32_t>& original_id_to_duplicate_id);

--- a/source/fuzz/transformation_split_loop.h
+++ b/source/fuzz/transformation_split_loop.h
@@ -36,6 +36,7 @@ class TransformationSplitLoop : public Transformation {
       uint32_t new_body_entry_block_fresh_id,
       uint32_t conditional_block_fresh_id, uint32_t load_run_second_fresh_id,
       uint32_t selection_merge_block_fresh_id,
+      const std::vector<uint32_t>& logical_not_fresh_ids,
       const std::map<uint32_t, uint32_t>& original_label_to_duplicate_label,
       const std::map<uint32_t, uint32_t>& original_id_to_duplicate_id);
 

--- a/source/fuzz/transformation_split_loop.h
+++ b/source/fuzz/transformation_split_loop.h
@@ -48,6 +48,10 @@ class TransformationSplitLoop : public Transformation {
   //   |condition_counter_fresh_id|, |new_body_entry_block_fresh_id|,
   //   |conditional_block_fresh_id|, |load_run_second_fresh_id|,
   //   |selection_merge_block_fresh_id| must be distinct, fresh ids.
+  // - |variable_counter_fresh_id| is used to create a local variable pointing
+  //   to unsigned integer type.
+  // - |variable_run_second_id| is used to create a local variable pointing to
+  //   bool type.
   // - |logical_not_fresh_ids| must contain at least as many distinct fresh ids
   //   as there are terminators of form "OpBranchConditional %cond %merge
   //   %other" in the loop.

--- a/source/fuzz/transformation_split_loop.h
+++ b/source/fuzz/transformation_split_loop.h
@@ -30,15 +30,13 @@ class TransformationSplitLoop : public Transformation {
 
   explicit TransformationSplitLoop(
       uint32_t loop_header_id, uint32_t variable_counter_id,
-      uint32_t variable_run_second_id, uint32_t constant_one_id,
-      uint32_t constant_zero_id, uint32_t constant_limit_id,
+      uint32_t variable_run_second_id, uint32_t constant_limit_id,
       uint32_t load_counter_fresh_id, uint32_t increment_counter_fresh_id,
-      uint32_t condition_counter_fresh_id, uint32_t pred_merge_block_fresh_id,
-      uint32_t constant_true_id, uint32_t constant_false_id,
-      uint32_t load_run_second_fresh_id,
+      uint32_t condition_counter_fresh_id,
+      uint32_t new_body_entry_block_fresh_id, uint32_t load_run_second_fresh_id,
       uint32_t selection_merge_block_fresh_id,
-      std::map<uint32_t, uint32_t> original_label_to_duplicate_label,
-      std::map<uint32_t, uint32_t> original_id_to_duplicate_id);
+      const std::map<uint32_t, uint32_t>& original_label_to_duplicate_label,
+      const std::map<uint32_t, uint32_t>& original_id_to_duplicate_id);
 
   bool IsApplicable(
       opt::IRContext* ir_context,

--- a/source/fuzz/transformation_split_loop.h
+++ b/source/fuzz/transformation_split_loop.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SPIRV_TOOLS_TRANSFORMATION_SPLIT_LOOP_H
+#define SPIRV_TOOLS_TRANSFORMATION_SPLIT_LOOP_H
+
+#include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
+#include "source/fuzz/transformation.h"
+#include "source/fuzz/transformation_context.h"
+#include "source/opt/ir_context.h"
+
+namespace spvtools {
+namespace fuzz {
+
+class TransformationSplitLoop : public Transformation {
+ public:
+  explicit TransformationSplitLoop(
+      const protobufs::TransformationSplitLoop& message);
+
+  explicit TransformationSplitLoop(
+      uint32_t variable_counter_fresh_id, uint32_t variable_exited_fresh_id,
+      uint32_t load_counter_fresh_id, uint32_t load_exited_fresh_id,
+      uint32_t iteration_limit_id, uint32_t condition_counter_fresh_id,
+      uint32_t logical_not_fresh_id, uint32_t then_branch_fresh_id,
+      uint32_t else_branch_fresh_id, uint32_t entry_block_id,
+      uint32_t exit_block_id,
+      std::map<uint32_t, uint32_t> original_id_to_duplicate_id,
+      std::map<uint32_t, uint32_t> original_label_to_duplicate_label);
+
+  bool IsApplicable(
+      opt::IRContext* ir_context,
+      const TransformationContext& transformation_context) const override;
+
+  void Apply(opt::IRContext* ir_context,
+             TransformationContext* transformation_context) const override;
+
+  protobufs::Transformation ToMessage() const override;
+
+ private:
+  protobufs::TransformationSplitLoop message_;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SPIRV_TOOLS_TRANSFORMATION_ADD_RELAXED_DECORATION_H

--- a/source/fuzz/transformation_split_loop.h
+++ b/source/fuzz/transformation_split_loop.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SPIRV_TOOLS_TRANSFORMATION_SPLIT_LOOP_H
-#define SPIRV_TOOLS_TRANSFORMATION_SPLIT_LOOP_H
+#ifndef SOURCE_FUZZ_TRANSFORMATION_SPLIT_LOOP_H_
+#define SOURCE_FUZZ_TRANSFORMATION_SPLIT_LOOP_H_
 
 #include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
 #include "source/fuzz/transformation.h"
@@ -58,4 +58,4 @@ class TransformationSplitLoop : public Transformation {
 }  // namespace fuzz
 }  // namespace spvtools
 
-#endif  // SPIRV_TOOLS_TRANSFORMATION_ADD_RELAXED_DECORATION_H
+#endif  // SOURCE_FUZZ_TRANSFORMATION_SPLIT_LOOP_H_

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -101,6 +101,7 @@ if (${SPIRV_BUILD_FUZZER})
           transformation_set_memory_operands_mask_test.cpp
           transformation_set_selection_control_test.cpp
           transformation_split_block_test.cpp
+          transformation_split_loop_test.cpp
           transformation_store_test.cpp
           transformation_swap_commutable_operands_test.cpp
           transformation_swap_conditional_branch_operands_test.cpp

--- a/test/fuzz/transformation_split_loop_test.cpp
+++ b/test/fuzz/transformation_split_loop_test.cpp
@@ -89,10 +89,9 @@ TEST(TransformationSplitLoopTest, BasicScenarios) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
   spvtools::ValidatorOptions validator_options;
-  TransformationContext transformation_context(&fact_manager,
-                                               validator_options);
+  TransformationContext transformation_context(
+      MakeUnique<FactManager>(context.get()), validator_options);
 
   auto transformation = TransformationSplitLoop(11, 50, 54, 24, 101, 102, 103,
                                                 104, 105, 106, 107, {{}},
@@ -215,10 +214,9 @@ TEST(TransformationSplitLoopTest, TestShaderFirstLoop) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
   spvtools::ValidatorOptions validator_options;
-  TransformationContext transformation_context(&fact_manager,
-                                               validator_options);
+  TransformationContext transformation_context(
+      MakeUnique<FactManager>(context.get()), validator_options);
 
   auto transformation = TransformationSplitLoop(12, 100, 102, 9, 201, 202, 203,
                                                 204, 205, 206, 207, {{}},
@@ -348,10 +346,9 @@ TEST(TransformationSplitLoopTest, TestShaderSecondLoop) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
   spvtools::ValidatorOptions validator_options;
-  TransformationContext transformation_context(&fact_manager,
-                                               validator_options);
+  TransformationContext transformation_context(
+      MakeUnique<FactManager>(context.get()), validator_options);
 
   auto transformation = TransformationSplitLoop(
       42, 100, 102, 9, 201, 202, 203, 204, 205, 206, 207, {{}},
@@ -417,10 +414,10 @@ TEST(TransformationSplitLoopTest, HeaderIsContinueTargetTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
   spvtools::ValidatorOptions validator_options;
-  TransformationContext transformation_context(&fact_manager,
-                                               validator_options);
+  TransformationContext transformation_context(
+      MakeUnique<FactManager>(context.get()), validator_options);
+
   auto transformation =
       TransformationSplitLoop(11, 53, 54, 55, 101, 102, 103, 104, 105, 106, 107,
                               {}, {{11, 201}, {13, 202}}, {{}});
@@ -486,10 +483,10 @@ TEST(TransformationSplitLoopTest, BranchConditionalContinueTargetTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
   spvtools::ValidatorOptions validator_options;
-  TransformationContext transformation_context(&fact_manager,
-                                               validator_options);
+  TransformationContext transformation_context(
+      MakeUnique<FactManager>(context.get()), validator_options);
+
   auto transformation =
       TransformationSplitLoop(11, 53, 54, 55, 101, 102, 103, 104, 105, 106, 107,
                               {108}, {{11, 201}, {12, 202}, {13, 203}}, {{}});
@@ -555,10 +552,9 @@ TEST(TransformationSplitLoopTest, NotApplicableScenarios) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
   spvtools::ValidatorOptions validator_options;
-  TransformationContext transformation_context(&fact_manager,
-                                               validator_options);
+  TransformationContext transformation_context(
+      MakeUnique<FactManager>(context.get()), validator_options);
 
   // Bad: |load_counter_fresh_id| is not fresh.
   auto transformation_bad_1 = TransformationSplitLoop(
@@ -754,10 +750,10 @@ TEST(TransformationSplitLoopTest, ResolvingOpPhiMergeBlock) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
   spvtools::ValidatorOptions validator_options;
-  TransformationContext transformation_context(&fact_manager,
-                                               validator_options);
+  TransformationContext transformation_context(
+      MakeUnique<FactManager>(context.get()), validator_options);
+
   auto transformation_good_1 = TransformationSplitLoop(
       8, 53, 54, 55, 101, 102, 103, 104, 105, 106, 107, {{}},
       {{8, 201}, {11, 202}, {10, 203}}, {{70, 301}});
@@ -889,10 +885,10 @@ TEST(TransformationSplitLoopTest, ResolvingOpPhiHeaderBlock) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
   spvtools::ValidatorOptions validator_options;
-  TransformationContext transformation_context(&fact_manager,
-                                               validator_options);
+  TransformationContext transformation_context(
+      MakeUnique<FactManager>(context.get()), validator_options);
+
   auto transformation_good_1 = TransformationSplitLoop(
       8, 53, 54, 55, 101, 102, 103, 104, 105, 106, 107, {{}},
       {{8, 201}, {11, 202}, {10, 203}}, {{72, 301}});
@@ -1027,10 +1023,9 @@ TEST(TransformationSplitLoopTest, ResolvingOpPhiBodyBlock) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
   spvtools::ValidatorOptions validator_options;
-  TransformationContext transformation_context(&fact_manager,
-                                               validator_options);
+  TransformationContext transformation_context(
+      MakeUnique<FactManager>(context.get()), validator_options);
 
   auto transformation_good_1 = TransformationSplitLoop(
       8, 53, 54, 55, 101, 102, 103, 104, 105, 106, 107, {{}},
@@ -1166,10 +1161,10 @@ TEST(TransformationSplitLoopTest, OpPhiInMergeBlockNotApplicable) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
   spvtools::ValidatorOptions validator_options;
-  TransformationContext transformation_context(&fact_manager,
-                                               validator_options);
+  TransformationContext transformation_context(
+      MakeUnique<FactManager>(context.get()), validator_options);
+
   auto transformation_bad = TransformationSplitLoop(
       8, 53, 54, 55, 101, 102, 103, 104, 105, 106, 107, {{}},
       {{8, 201}, {11, 202}, {10, 203}}, {{70, 301}, {71, 302}});
@@ -1230,10 +1225,10 @@ TEST(TransformationSplitLoopTest, LogicalNotFreshIdsNotApplicable) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
   spvtools::ValidatorOptions validator_options;
-  TransformationContext transformation_context(&fact_manager,
-                                               validator_options);
+  TransformationContext transformation_context(
+      MakeUnique<FactManager>(context.get()), validator_options);
+
   // Bad: Insufficient number of fresh ids as |logical_not_fresh_ids|.
   auto transformation_bad_1 =
       TransformationSplitLoop(8, 53, 54, 55, 101, 102, 103, 104, 105, 106, 107,

--- a/test/fuzz/transformation_split_loop_test.cpp
+++ b/test/fuzz/transformation_split_loop_test.cpp
@@ -766,9 +766,8 @@ TEST(TransformationSplitLoopTest, ResolvingOpPhiMergeBlock) {
                                                  transformation_context));
   transformation_good_1.Apply(context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
-
   std::string expected_shader = R"(
-               OpCapability Shader
+                 OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %4 "main"
@@ -800,15 +799,14 @@ TEST(TransformationSplitLoopTest, ResolvingOpPhiMergeBlock) {
                OpStore %54 %14
                OpBranch %8
           %8 = OpLabel
-               OpStore %54 %14
-               OpLoopMerge %10 %11 None
-               OpBranchConditional %14 %104 %10
-        %104 = OpLabel
         %101 = OpLoad %50 %53
         %102 = OpIAdd %50 %101 %57
                OpStore %53 %102
         %103 = OpULessThan %13 %102 %55
-               OpBranchConditional %103 %11 %10
+               OpLoopMerge %10 %11 None
+               OpBranchConditional %103 %104 %10
+        %104 = OpLabel
+               OpBranchConditional %14 %11 %10
          %11 = OpLabel
                OpBranch %8
          %10 = OpLabel
@@ -832,7 +830,7 @@ TEST(TransformationSplitLoopTest, ResolvingOpPhiMergeBlock) {
          %71 = OpPhi %13 %70 %107
                OpReturn
                OpFunctionEnd
-      )";
+        )";
   ASSERT_TRUE(IsEqual(env, expected_shader, context.get()));
 }
 
@@ -905,7 +903,7 @@ TEST(TransformationSplitLoopTest, ResolvingOpPhiHeaderBlock) {
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string expected_shader = R"(
-               OpCapability Shader
+                 OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %4 "main"
@@ -941,15 +939,14 @@ TEST(TransformationSplitLoopTest, ResolvingOpPhiHeaderBlock) {
                OpBranch %8
           %8 = OpLabel
          %72 = OpPhi %13 %71 %70 %71 %11
-               OpStore %54 %14
-               OpLoopMerge %10 %11 None
-               OpBranchConditional %14 %104 %10
-        %104 = OpLabel
         %101 = OpLoad %50 %53
         %102 = OpIAdd %50 %101 %57
                OpStore %53 %102
         %103 = OpULessThan %13 %102 %55
-               OpBranchConditional %103 %11 %10
+               OpLoopMerge %10 %11 None
+               OpBranchConditional %103 %104 %10
+        %104 = OpLabel
+               OpBranchConditional %14 %11 %10
          %11 = OpLabel
                OpBranch %8
          %10 = OpLabel
@@ -971,7 +968,7 @@ TEST(TransformationSplitLoopTest, ResolvingOpPhiHeaderBlock) {
          %20 = OpLabel
                OpReturn
                OpFunctionEnd
-      )";
+        )";
   ASSERT_TRUE(IsEqual(env, expected_shader, context.get()));
 }
 
@@ -1043,7 +1040,6 @@ TEST(TransformationSplitLoopTest, ResolvingOpPhiBodyBlock) {
                                                  transformation_context));
   transformation_good_1.Apply(context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
-
   std::string expected_shader = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
@@ -1077,16 +1073,15 @@ TEST(TransformationSplitLoopTest, ResolvingOpPhiBodyBlock) {
                OpStore %54 %14
                OpBranch %8
           %8 = OpLabel
-         %70 = OpCopyObject %13 %14
-               OpStore %54 %14
-               OpLoopMerge %10 %11 None
-               OpBranchConditional %14 %104 %10
-        %104 = OpLabel
         %101 = OpLoad %50 %53
         %102 = OpIAdd %50 %101 %57
                OpStore %53 %102
         %103 = OpULessThan %13 %102 %55
-               OpBranchConditional %103 %30 %10
+               OpLoopMerge %10 %11 None
+               OpBranchConditional %103 %104 %10
+        %104 = OpLabel
+         %70 = OpCopyObject %13 %14
+               OpBranchConditional %14 %30 %10
          %30 = OpLabel
          %71 = OpPhi %13 %70 %104
                OpBranch %11
@@ -1114,7 +1109,7 @@ TEST(TransformationSplitLoopTest, ResolvingOpPhiBodyBlock) {
          %20 = OpLabel
                OpReturn
                OpFunctionEnd
-      )";
+        )";
   ASSERT_TRUE(IsEqual(env, expected_shader, context.get()));
 }
 

--- a/test/fuzz/transformation_split_loop_test.cpp
+++ b/test/fuzz/transformation_split_loop_test.cpp
@@ -34,20 +34,22 @@ TEST(TransformationSplitLoopTest, BasicScenarios) {
           %2 = OpTypeVoid
           %3 = OpTypeFunction %2
           %6 = OpTypeInt 32 1
+         %60 = OpTypeInt 32 0
           %7 = OpTypePointer Function %6
-          %9 = OpConstant %6 0
-         %17 = OpConstant %6 10
+         %61 = OpTypePointer Function %60
+          %9 = OpConstant %60 0
+         %17 = OpConstant %60 10
          %18 = OpTypeBool
          %55 = OpConstantTrue %18
          %56 = OpConstantFalse %18
          %53 = OpTypePointer Function %18
-         %24 = OpConstant %6 3
-         %30 = OpConstant %6 1
+         %24 = OpConstant %60 3
+         %30 = OpConstant %60 1
           %4 = OpFunction %2 None %3
           %5 = OpLabel
-          %8 = OpVariable %7 Function
-         %10 = OpVariable %7 Function
-         %50 = OpVariable %7 Function
+          %8 = OpVariable %61 Function
+         %10 = OpVariable %61 Function
+         %50 = OpVariable %61 Function
          %54 = OpVariable %53 Function
                OpStore %8 %9
                OpStore %10 %9
@@ -56,15 +58,15 @@ TEST(TransformationSplitLoopTest, BasicScenarios) {
                OpLoopMerge %13 %14 None
                OpBranch %15
          %15 = OpLabel
-         %16 = OpLoad %6 %10
+         %16 = OpLoad %60 %10
          %19 = OpSLessThan %18 %16 %17
                OpBranchConditional %19 %12 %13
          %12 = OpLabel
-         %20 = OpLoad %6 %10
-         %21 = OpLoad %6 %8
-         %22 = OpIAdd %6 %21 %20
+         %20 = OpLoad %60 %10
+         %21 = OpLoad %60 %8
+         %22 = OpIAdd %60 %21 %20
                OpStore %8 %22
-         %23 = OpLoad %6 %10
+         %23 = OpLoad %60 %10
          %25 = OpIEqual %18 %23 %24
                OpSelectionMerge %27 None
                OpBranchConditional %25 %26 %27
@@ -73,8 +75,8 @@ TEST(TransformationSplitLoopTest, BasicScenarios) {
          %27 = OpLabel
                OpBranch %14
          %14 = OpLabel
-         %29 = OpLoad %6 %10
-         %31 = OpIAdd %6 %29 %30
+         %29 = OpLoad %60 %10
+         %31 = OpIAdd %60 %29 %30
                OpStore %10 %31
                OpBranch %11
          %13 = OpLabel
@@ -92,37 +94,288 @@ TEST(TransformationSplitLoopTest, BasicScenarios) {
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  auto transformation = TransformationSplitLoop(11, 50, 54, 30, 9, 24, 101, 102,
-                                                103, 104, 55, 56, 105, 106,
-                                                {{11, 201},
-                                                 {15, 202},
-                                                 {12, 203},
-                                                 {13, 204},
-                                                 {26, 205},
-                                                 {27, 206},
-                                                 {14, 207}},
-                                                {{16, 301},
-                                                 {19, 302},
-                                                 {20, 303},
-                                                 {21, 304},
-                                                 {22, 305},
-                                                 {23, 306},
-                                                 {25, 307},
-                                                 {29, 308},
-                                                 {31, 309}});
+  auto transformation =
+      TransformationSplitLoop(11, 50, 54, 24, 101, 102, 103, 104, 105, 106,
+                              {{11, 201},
+                               {15, 202},
+                               {12, 203},
+                               {13, 204},
+                               {26, 205},
+                               {27, 206},
+                               {14, 207}},
+                              {{16, 301},
+                               {19, 302},
+                               {20, 303},
+                               {21, 304},
+                               {22, 305},
+                               {23, 306},
+                               {25, 307},
+                               {29, 308},
+                               {31, 309}});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
   transformation.Apply(context.get(), &transformation_context);
 
-  std::vector<uint32_t> actual_binary;
+  ASSERT_TRUE(IsValid(env, context.get()));
+}
+
+TEST(TransformationSplitLoopTest, TestShaderFirstLoop) {
+  // This is a simple transformation and this test handles the main cases.
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 320
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+        %110 = OpTypeInt 32 0
+        %111 = OpConstant %110 0
+        %112 = OpConstant %110 1
+        %113 = OpTypePointer Function %110
+          %7 = OpTypePointer Function %6
+          %9 = OpConstant %6 20
+         %11 = OpConstant %6 0
+         %18 = OpConstant %6 100
+         %19 = OpTypeBool
+        %103 = OpConstantTrue %19
+        %104 = OpConstantFalse %19
+        %101 = OpTypePointer Function %19
+         %30 = OpConstant %6 300
+         %39 = OpConstant %6 1
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+          %8 = OpVariable %7 Function
+         %10 = OpVariable %7 Function
+         %41 = OpVariable %7 Function
+        %100 = OpVariable %113 Function
+        %102 = OpVariable %101 Function
+               OpStore %8 %9
+               OpStore %10 %11
+               OpBranch %12
+         %12 = OpLabel
+               OpLoopMerge %14 %15 None
+               OpBranch %16
+         %16 = OpLabel
+         %17 = OpLoad %6 %10
+         %20 = OpSLessThan %19 %17 %18
+               OpBranchConditional %20 %13 %14
+         %13 = OpLabel
+         %21 = OpLoad %6 %10
+         %22 = OpLoad %6 %8
+         %23 = OpSGreaterThan %19 %21 %22
+               OpSelectionMerge %25 None
+               OpBranchConditional %23 %24 %25
+         %24 = OpLabel
+               OpBranch %14
+         %25 = OpLabel
+         %27 = OpLoad %6 %8
+         %28 = OpLoad %6 %10
+         %29 = OpIAdd %6 %27 %28
+         %31 = OpSGreaterThan %19 %29 %30
+               OpSelectionMerge %33 None
+               OpBranchConditional %31 %32 %33
+         %32 = OpLabel
+               OpBranch %14
+         %33 = OpLabel
+         %35 = OpLoad %6 %10
+         %36 = OpLoad %6 %8
+         %37 = OpIAdd %6 %36 %35
+               OpStore %8 %37
+               OpBranch %15
+         %15 = OpLabel
+         %38 = OpLoad %6 %10
+         %40 = OpIAdd %6 %38 %39
+               OpStore %10 %40
+               OpBranch %12
+         %14 = OpLabel
+               OpStore %41 %11
+               OpBranch %42
+         %42 = OpLabel
+         %47 = OpLoad %6 %41
+         %48 = OpSLessThan %19 %47 %18
+               OpLoopMerge %44 %45 None
+               OpBranchConditional %48 %43 %44
+         %43 = OpLabel
+               OpBranch %45
+         %45 = OpLabel
+         %49 = OpLoad %6 %41
+         %50 = OpIAdd %6 %49 %39
+               OpStore %41 %50
+               OpBranch %42
+         %44 = OpLabel
+               OpReturn
+               OpFunctionEnd
+      )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  // First loop.
+
+  auto transformation =
+      TransformationSplitLoop(12, 100, 102, 9, 201, 202, 203, 204, 205, 206,
+                              {{12, 301},
+                               {16, 302},
+                               {13, 303},
+                               {24, 304},
+                               {25, 305},
+                               {32, 306},
+                               {33, 307},
+                               {15, 308},
+                               {14, 309}},
+                              {{17, 401},
+                               {20, 402},
+                               {21, 403},
+                               {22, 404},
+                               {23, 405},
+                               {27, 406},
+                               {28, 407},
+                               {29, 408},
+                               {31, 409},
+                               {35, 410},
+                               {36, 411},
+                               {37, 412},
+                               {38, 413},
+                               {40, 414}});
+  ASSERT_TRUE(
+      transformation.IsApplicable(context.get(), transformation_context));
+  transformation.Apply(context.get(), &transformation_context);
+
+  ASSERT_TRUE(IsValid(env, context.get()));
+}
+
+TEST(TransformationSplitLoopTest, TestShaderSecondLoop) {
+  // This is a simple transformation and this test handles the main cases.
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 320
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+        %110 = OpTypeInt 32 0
+        %111 = OpConstant %110 0
+        %112 = OpConstant %110 1
+        %113 = OpTypePointer Function %110
+          %7 = OpTypePointer Function %6
+          %9 = OpConstant %6 20
+         %11 = OpConstant %6 0
+         %18 = OpConstant %6 100
+         %19 = OpTypeBool
+        %103 = OpConstantTrue %19
+        %104 = OpConstantFalse %19
+        %101 = OpTypePointer Function %19
+         %30 = OpConstant %6 300
+         %39 = OpConstant %6 1
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+          %8 = OpVariable %7 Function
+         %10 = OpVariable %7 Function
+         %41 = OpVariable %7 Function
+        %100 = OpVariable %113 Function
+        %102 = OpVariable %101 Function
+               OpStore %8 %9
+               OpStore %10 %11
+               OpBranch %12
+         %12 = OpLabel
+               OpLoopMerge %14 %15 None
+               OpBranch %16
+         %16 = OpLabel
+         %17 = OpLoad %6 %10
+         %20 = OpSLessThan %19 %17 %18
+               OpBranchConditional %20 %13 %14
+         %13 = OpLabel
+         %21 = OpLoad %6 %10
+         %22 = OpLoad %6 %8
+         %23 = OpSGreaterThan %19 %21 %22
+               OpSelectionMerge %25 None
+               OpBranchConditional %23 %24 %25
+         %24 = OpLabel
+               OpBranch %14
+         %25 = OpLabel
+         %27 = OpLoad %6 %8
+         %28 = OpLoad %6 %10
+         %29 = OpIAdd %6 %27 %28
+         %31 = OpSGreaterThan %19 %29 %30
+               OpSelectionMerge %33 None
+               OpBranchConditional %31 %32 %33
+         %32 = OpLabel
+               OpBranch %14
+         %33 = OpLabel
+         %35 = OpLoad %6 %10
+         %36 = OpLoad %6 %8
+         %37 = OpIAdd %6 %36 %35
+               OpStore %8 %37
+               OpBranch %15
+         %15 = OpLabel
+         %38 = OpLoad %6 %10
+         %40 = OpIAdd %6 %38 %39
+               OpStore %10 %40
+               OpBranch %12
+         %14 = OpLabel
+               OpStore %41 %11
+               OpBranch %42
+         %42 = OpLabel
+         %47 = OpLoad %6 %41
+         %48 = OpSLessThan %19 %47 %18
+               OpLoopMerge %44 %45 None
+               OpBranchConditional %48 %43 %44
+         %43 = OpLabel
+               OpBranch %45
+         %45 = OpLabel
+         %49 = OpLoad %6 %41
+         %50 = OpIAdd %6 %49 %39
+               OpStore %41 %50
+               OpBranch %42
+         %44 = OpLabel
+               OpReturn
+               OpFunctionEnd
+      )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  // Second loop.
+
+  auto transformation =
+      TransformationSplitLoop(42, 100, 102, 9, 201, 202, 203, 204, 205, 206,
+                              {{42, 301}, {43, 302}, {44, 303}, {45, 304}},
+                              {{47, 401}, {48, 402}, {49, 403}, {50, 404}});
+  ASSERT_TRUE(
+      transformation.IsApplicable(context.get(), transformation_context));
+
+  transformation.Apply(context.get(), &transformation_context);
+
+  /*std::vector<uint32_t> actual_binary;
   context.get()->module()->ToBinary(&actual_binary, false);
   SpirvTools t(env);
   std::string actual_disassembled;
   t.Disassemble(actual_binary, &actual_disassembled, kFuzzDisassembleOption);
-  std::cout << actual_disassembled << std::endl;
+  std::cout << actual_disassembled << std::endl;*/
 
   ASSERT_TRUE(IsValid(env, context.get()));
 }
+
 }  // namespace
 }  // namespace fuzz
 }  // namespace spvtools

--- a/test/fuzz/transformation_split_loop_test.cpp
+++ b/test/fuzz/transformation_split_loop_test.cpp
@@ -98,24 +98,24 @@ TEST(TransformationSplitLoopTest, BasicScenarios) {
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  auto transformation =
-      TransformationSplitLoop(11, 50, 54, 24, 101, 102, 103, 104, 105, 106, 107,
-                              {{11, 201},
-                               {15, 202},
-                               {12, 203},
-                               {13, 204},
-                               {26, 205},
-                               {27, 206},
-                               {14, 207}},
-                              {{16, 301},
-                               {19, 302},
-                               {20, 303},
-                               {21, 304},
-                               {22, 305},
-                               {23, 306},
-                               {25, 307},
-                               {29, 308},
-                               {31, 309}});
+  auto transformation = TransformationSplitLoop(11, 50, 54, 24, 101, 102, 103,
+                                                104, 105, 106, 107, {{}},
+                                                {{11, 201},
+                                                 {15, 202},
+                                                 {12, 203},
+                                                 {13, 204},
+                                                 {26, 205},
+                                                 {27, 206},
+                                                 {14, 207}},
+                                                {{16, 301},
+                                                 {19, 302},
+                                                 {20, 303},
+                                                 {21, 304},
+                                                 {22, 305},
+                                                 {23, 306},
+                                                 {25, 307},
+                                                 {29, 308},
+                                                 {31, 309}});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
   transformation.Apply(context.get(), &transformation_context);
@@ -227,7 +227,7 @@ TEST(TransformationSplitLoopTest, TestShaderFirstLoop) {
   // First loop.
 
   auto transformation = TransformationSplitLoop(12, 100, 102, 9, 201, 202, 203,
-                                                204, 205, 206, 207,
+                                                204, 205, 206, 207, {{}},
                                                 {{12, 301},
                                                  {16, 302},
                                                  {13, 303},
@@ -361,10 +361,10 @@ TEST(TransformationSplitLoopTest, TestShaderSecondLoop) {
 
   // Second loop.
 
-  auto transformation =
-      TransformationSplitLoop(42, 100, 102, 9, 201, 202, 203, 204, 205, 206,
-                              207, {{42, 301}, {43, 302}, {44, 303}, {45, 304}},
-                              {{47, 401}, {48, 402}, {49, 403}, {50, 404}});
+  auto transformation = TransformationSplitLoop(
+      42, 100, 102, 9, 201, 202, 203, 204, 205, 206, 207, {{}},
+      {{42, 301}, {43, 302}, {44, 303}, {45, 304}},
+      {{47, 401}, {48, 402}, {49, 403}, {50, 404}});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
 
@@ -462,6 +462,7 @@ TEST(TransformationSplitLoopTest, FuzzerPassBasicTest) {
 
   ASSERT_TRUE(IsValid(env, context.get()));
 }
+
 TEST(TransformationSplitLoopTest, DesignDocTest) {
   // This is a simple transformation and this test handles the main cases.
   std::string shader = R"(
@@ -548,24 +549,174 @@ TEST(TransformationSplitLoopTest, DesignDocTest) {
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
+  auto transformation = TransformationSplitLoop(11, 53, 54, 55, 101, 102, 103,
+                                                104, 105, 106, 107, {{}},
+                                                {{11, 201},
+                                                 {15, 202},
+                                                 {12, 203},
+                                                 {13, 204},
+                                                 {26, 205},
+                                                 {27, 206},
+                                                 {14, 207}},
+                                                {{16, 301},
+                                                 {19, 302},
+                                                 {20, 303},
+                                                 {21, 304},
+                                                 {22, 305},
+                                                 {23, 306},
+                                                 {25, 307},
+                                                 {29, 308},
+                                                 {31, 309}});
+  ASSERT_TRUE(
+      transformation.IsApplicable(context.get(), transformation_context));
+  transformation.Apply(context.get(), &transformation_context);
+
+  /*std::vector<uint32_t> actual_binary;
+  context.get()->module()->ToBinary(&actual_binary, false);
+  SpirvTools t(env);
+  std::string actual_disassembled;
+  t.Disassemble(actual_binary, &actual_disassembled, kFuzzDisassembleOption);
+  std::cout << actual_disassembled << std::endl;*/
+
+  ASSERT_TRUE(IsValid(env, context.get()));
+}
+
+TEST(TransformationSplitLoopTest, HeaderIsContinueTargetTest) {
+  // This test handles a case where the header of the loop is also the continue
+  // target of the loop
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %8 "s"
+               OpName %10 "i"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+         %50 = OpTypeInt 32 0
+         %51 = OpTypePointer Function %50
+          %7 = OpTypePointer Function %6
+          %9 = OpConstant %6 0
+         %17 = OpConstant %6 10
+         %55 = OpConstant %50 4
+         %56 = OpConstant %50 0
+         %57 = OpConstant %50 1
+         %18 = OpTypeBool
+         %58 = OpConstantTrue %18
+         %59 = OpConstantFalse %18
+         %52 = OpTypePointer Function %18
+         %24 = OpConstant %6 5
+         %30 = OpConstant %6 1
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+          %8 = OpVariable %7 Function
+         %10 = OpVariable %7 Function
+         %53 = OpVariable %51 Function
+         %54 = OpVariable %52 Function
+               OpStore %8 %9
+               OpStore %10 %9
+               OpBranch %11
+         %11 = OpLabel
+               OpLoopMerge %13 %11 None
+               OpBranchConditional %59 %11 %13
+         %13 = OpLabel
+               OpReturn
+               OpFunctionEnd
+      )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
   auto transformation =
       TransformationSplitLoop(11, 53, 54, 55, 101, 102, 103, 104, 105, 106, 107,
-                              {{11, 201},
-                               {15, 202},
-                               {12, 203},
-                               {13, 204},
-                               {26, 205},
-                               {27, 206},
-                               {14, 207}},
-                              {{16, 301},
-                               {19, 302},
-                               {20, 303},
-                               {21, 304},
-                               {22, 305},
-                               {23, 306},
-                               {25, 307},
-                               {29, 308},
-                               {31, 309}});
+                              {}, {{11, 201}, {13, 202}}, {{}});
+
+  ASSERT_TRUE(
+      transformation.IsApplicable(context.get(), transformation_context));
+  transformation.Apply(context.get(), &transformation_context);
+
+  /*std::vector<uint32_t> actual_binary;
+  context.get()->module()->ToBinary(&actual_binary, false);
+  SpirvTools t(env);
+  std::string actual_disassembled;
+  t.Disassemble(actual_binary, &actual_disassembled, kFuzzDisassembleOption);
+  std::cout << actual_disassembled << std::endl;*/
+
+  ASSERT_TRUE(IsValid(env, context.get()));
+}
+
+TEST(TransformationSplitLoopTest, BranchConditionalContinueTargetTest) {
+  // This test handles a case where there is a OpBranchConditional instruction
+  // in the continue target.
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %8 "s"
+               OpName %10 "i"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+         %50 = OpTypeInt 32 0
+         %51 = OpTypePointer Function %50
+          %7 = OpTypePointer Function %6
+          %9 = OpConstant %6 0
+         %17 = OpConstant %6 10
+         %55 = OpConstant %50 4
+         %56 = OpConstant %50 0
+         %57 = OpConstant %50 1
+         %18 = OpTypeBool
+         %58 = OpConstantTrue %18
+         %59 = OpConstantFalse %18
+         %52 = OpTypePointer Function %18
+         %24 = OpConstant %6 5
+         %30 = OpConstant %6 1
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+          %8 = OpVariable %7 Function
+         %10 = OpVariable %7 Function
+         %53 = OpVariable %51 Function
+         %54 = OpVariable %52 Function
+               OpStore %8 %9
+               OpStore %10 %9
+               OpBranch %11
+         %11 = OpLabel
+               OpLoopMerge %13 %12 None
+               OpBranch %12
+         %12 = OpLabel
+               OpBranchConditional %58 %13 %11
+         %13 = OpLabel
+               OpReturn
+               OpFunctionEnd
+      )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+  auto transformation =
+      TransformationSplitLoop(11, 53, 54, 55, 101, 102, 103, 104, 105, 106, 107,
+                              {108}, {{11, 201}, {12, 202}, {13, 203}}, {{}});
+
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
   transformation.Apply(context.get(), &transformation_context);

--- a/test/fuzz/transformation_split_loop_test.cpp
+++ b/test/fuzz/transformation_split_loop_test.cpp
@@ -1,0 +1,144 @@
+// Copyright (c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_split_loop.h"
+#include "test/fuzz/fuzz_test_util.h"
+
+namespace spvtools {
+namespace fuzz {
+namespace {
+/*
+TEST(TransformationSplitLoopTest, BasicScenarios) {
+  // This is a simple transformation and this test handles the main cases.
+  std::string shader = R"(
+                 OpCapability Shader
+            %1 = OpExtInstImport "GLSL.std.450"
+                 OpMemoryModel Logical GLSL450
+                 OpEntryPoint Fragment %4 "main"
+                 OpExecutionMode %4 OriginUpperLeft
+                 OpSource ESSL 310
+                 OpName %4 "main"
+                 OpName %8 "a"
+                 OpName %10 "b"
+                 OpName %14 "c"
+            %2 = OpTypeVoid
+            %3 = OpTypeFunction %2
+            %6 = OpTypeInt 32 1
+            %7 = OpTypePointer Function %6
+            %9 = OpConstant %6 4
+           %11 = OpConstant %6 6
+           %12 = OpTypeBool
+           %13 = OpTypePointer Function %12
+           %15 = OpConstantTrue %12
+            %4 = OpFunction %2 None %3
+            %5 = OpLabel
+            %8 = OpVariable %7 Function
+           %10 = OpVariable %7 Function
+           %14 = OpVariable %13 Function
+                 OpStore %8 %9
+                 OpStore %10 %11
+                 OpStore %14 %15
+                 OpSelectionMerge %19 None
+                 OpBranchConditional %15 %19 %100
+          %100 = OpLabel
+           %25 = OpISub %6 %9 %11
+           %28 = OpLogicalNot %12 %15
+                 OpBranch %19
+           %19 = OpLabel
+           %27 = OpISub %6 %9 %11
+                 OpReturn
+                 OpFunctionEnd
+      )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  FactManager fact_manager;
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(&fact_manager,
+                                               validator_options);
+
+  fact_manager.AddFactBlockIsDead(100);
+
+  // Invalid: 200 is not an id.
+  ASSERT_FALSE(TransformationAddRelaxedDecoration(200).IsApplicable(
+      context.get(), transformation_context));
+  // Invalid: 1 is not in a block.
+  ASSERT_FALSE(TransformationAddRelaxedDecoration(1).IsApplicable(
+      context.get(), transformation_context));
+  // Invalid: 27 is not in a dead block.
+  ASSERT_FALSE(TransformationAddRelaxedDecoration(27).IsApplicable(
+      context.get(), transformation_context));
+  // Invalid: 28 is in a dead block, but returns bool (not numeric).
+  ASSERT_FALSE(TransformationAddRelaxedDecoration(28).IsApplicable(
+      context.get(), transformation_context));
+  // It is valid to add RelaxedPrecision to 25 (and it's fine to
+  // have a duplicate).
+  for (uint32_t result_id : {25u, 25u}) {
+  TransformationAddRelaxedDecoration transformation(result_id);
+  ASSERT_TRUE(
+      transformation.IsApplicable(context.get(), transformation_context));
+  transformation.Apply(context.get(), &transformation_context);
+  ASSERT_TRUE(IsValid(env, context.get()));
+  }
+
+  std::string after_transformation = R"(
+                 OpCapability Shader
+            %1 = OpExtInstImport "GLSL.std.450"
+                 OpMemoryModel Logical GLSL450
+                 OpEntryPoint Fragment %4 "main"
+                 OpExecutionMode %4 OriginUpperLeft
+                 OpSource ESSL 310
+                 OpName %4 "main"
+                 OpName %8 "a"
+                 OpName %10 "b"
+                 OpName %14 "c"
+                 OpDecorate %25 RelaxedPrecision
+                 OpDecorate %25 RelaxedPrecision
+            %2 = OpTypeVoid
+            %3 = OpTypeFunction %2
+            %6 = OpTypeInt 32 1
+            %7 = OpTypePointer Function %6
+            %9 = OpConstant %6 4
+           %11 = OpConstant %6 6
+           %12 = OpTypeBool
+           %13 = OpTypePointer Function %12
+           %15 = OpConstantTrue %12
+            %4 = OpFunction %2 None %3
+            %5 = OpLabel
+            %8 = OpVariable %7 Function
+           %10 = OpVariable %7 Function
+           %14 = OpVariable %13 Function
+                 OpStore %8 %9
+                 OpStore %10 %11
+                 OpStore %14 %15
+                 OpSelectionMerge %19 None
+                 OpBranchConditional %15 %19 %100
+          %100 = OpLabel
+           %25 = OpISub %6 %9 %11
+           %28 = OpLogicalNot %12 %15
+                 OpBranch %19
+           %19 = OpLabel
+           %27 = OpISub %6 %9 %11
+                 OpReturn
+                 OpFunctionEnd
+    )";
+  ASSERT_TRUE(IsEqual(env, after_transformation, context.get()));
+  }
+  */
+}  // namespace
+}  // namespace fuzz
+}  // namespace spvtools

--- a/test/fuzz/transformation_split_loop_test.cpp
+++ b/test/fuzz/transformation_split_loop_test.cpp
@@ -18,47 +18,68 @@
 namespace spvtools {
 namespace fuzz {
 namespace {
-/*
+
 TEST(TransformationSplitLoopTest, BasicScenarios) {
   // This is a simple transformation and this test handles the main cases.
   std::string shader = R"(
-                 OpCapability Shader
-            %1 = OpExtInstImport "GLSL.std.450"
-                 OpMemoryModel Logical GLSL450
-                 OpEntryPoint Fragment %4 "main"
-                 OpExecutionMode %4 OriginUpperLeft
-                 OpSource ESSL 310
-                 OpName %4 "main"
-                 OpName %8 "a"
-                 OpName %10 "b"
-                 OpName %14 "c"
-            %2 = OpTypeVoid
-            %3 = OpTypeFunction %2
-            %6 = OpTypeInt 32 1
-            %7 = OpTypePointer Function %6
-            %9 = OpConstant %6 4
-           %11 = OpConstant %6 6
-           %12 = OpTypeBool
-           %13 = OpTypePointer Function %12
-           %15 = OpConstantTrue %12
-            %4 = OpFunction %2 None %3
-            %5 = OpLabel
-            %8 = OpVariable %7 Function
-           %10 = OpVariable %7 Function
-           %14 = OpVariable %13 Function
-                 OpStore %8 %9
-                 OpStore %10 %11
-                 OpStore %14 %15
-                 OpSelectionMerge %19 None
-                 OpBranchConditional %15 %19 %100
-          %100 = OpLabel
-           %25 = OpISub %6 %9 %11
-           %28 = OpLogicalNot %12 %15
-                 OpBranch %19
-           %19 = OpLabel
-           %27 = OpISub %6 %9 %11
-                 OpReturn
-                 OpFunctionEnd
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %8 "s"
+               OpName %10 "i"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Function %6
+          %9 = OpConstant %6 0
+         %17 = OpConstant %6 10
+         %18 = OpTypeBool
+         %55 = OpConstantTrue %18
+         %56 = OpConstantFalse %18
+         %53 = OpTypePointer Function %18
+         %24 = OpConstant %6 3
+         %30 = OpConstant %6 1
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+          %8 = OpVariable %7 Function
+         %10 = OpVariable %7 Function
+         %50 = OpVariable %7 Function
+         %54 = OpVariable %53 Function
+               OpStore %8 %9
+               OpStore %10 %9
+               OpBranch %11
+         %11 = OpLabel
+               OpLoopMerge %13 %14 None
+               OpBranch %15
+         %15 = OpLabel
+         %16 = OpLoad %6 %10
+         %19 = OpSLessThan %18 %16 %17
+               OpBranchConditional %19 %12 %13
+         %12 = OpLabel
+         %20 = OpLoad %6 %10
+         %21 = OpLoad %6 %8
+         %22 = OpIAdd %6 %21 %20
+               OpStore %8 %22
+         %23 = OpLoad %6 %10
+         %25 = OpIEqual %18 %23 %24
+               OpSelectionMerge %27 None
+               OpBranchConditional %25 %26 %27
+         %26 = OpLabel
+               OpBranch %13
+         %27 = OpLabel
+               OpBranch %14
+         %14 = OpLabel
+         %29 = OpLoad %6 %10
+         %31 = OpIAdd %6 %29 %30
+               OpStore %10 %31
+               OpBranch %11
+         %13 = OpLabel
+               OpReturn
+               OpFunctionEnd
       )";
 
   const auto env = SPV_ENV_UNIVERSAL_1_4;
@@ -71,74 +92,37 @@ TEST(TransformationSplitLoopTest, BasicScenarios) {
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  fact_manager.AddFactBlockIsDead(100);
-
-  // Invalid: 200 is not an id.
-  ASSERT_FALSE(TransformationAddRelaxedDecoration(200).IsApplicable(
-      context.get(), transformation_context));
-  // Invalid: 1 is not in a block.
-  ASSERT_FALSE(TransformationAddRelaxedDecoration(1).IsApplicable(
-      context.get(), transformation_context));
-  // Invalid: 27 is not in a dead block.
-  ASSERT_FALSE(TransformationAddRelaxedDecoration(27).IsApplicable(
-      context.get(), transformation_context));
-  // Invalid: 28 is in a dead block, but returns bool (not numeric).
-  ASSERT_FALSE(TransformationAddRelaxedDecoration(28).IsApplicable(
-      context.get(), transformation_context));
-  // It is valid to add RelaxedPrecision to 25 (and it's fine to
-  // have a duplicate).
-  for (uint32_t result_id : {25u, 25u}) {
-  TransformationAddRelaxedDecoration transformation(result_id);
+  auto transformation = TransformationSplitLoop(11, 50, 54, 30, 9, 24, 101, 102,
+                                                103, 104, 55, 56, 105, 106,
+                                                {{11, 201},
+                                                 {15, 202},
+                                                 {12, 203},
+                                                 {13, 204},
+                                                 {26, 205},
+                                                 {27, 206},
+                                                 {14, 207}},
+                                                {{16, 301},
+                                                 {19, 302},
+                                                 {20, 303},
+                                                 {21, 304},
+                                                 {22, 305},
+                                                 {23, 306},
+                                                 {25, 307},
+                                                 {29, 308},
+                                                 {31, 309}});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
   transformation.Apply(context.get(), &transformation_context);
-  ASSERT_TRUE(IsValid(env, context.get()));
-  }
 
-  std::string after_transformation = R"(
-                 OpCapability Shader
-            %1 = OpExtInstImport "GLSL.std.450"
-                 OpMemoryModel Logical GLSL450
-                 OpEntryPoint Fragment %4 "main"
-                 OpExecutionMode %4 OriginUpperLeft
-                 OpSource ESSL 310
-                 OpName %4 "main"
-                 OpName %8 "a"
-                 OpName %10 "b"
-                 OpName %14 "c"
-                 OpDecorate %25 RelaxedPrecision
-                 OpDecorate %25 RelaxedPrecision
-            %2 = OpTypeVoid
-            %3 = OpTypeFunction %2
-            %6 = OpTypeInt 32 1
-            %7 = OpTypePointer Function %6
-            %9 = OpConstant %6 4
-           %11 = OpConstant %6 6
-           %12 = OpTypeBool
-           %13 = OpTypePointer Function %12
-           %15 = OpConstantTrue %12
-            %4 = OpFunction %2 None %3
-            %5 = OpLabel
-            %8 = OpVariable %7 Function
-           %10 = OpVariable %7 Function
-           %14 = OpVariable %13 Function
-                 OpStore %8 %9
-                 OpStore %10 %11
-                 OpStore %14 %15
-                 OpSelectionMerge %19 None
-                 OpBranchConditional %15 %19 %100
-          %100 = OpLabel
-           %25 = OpISub %6 %9 %11
-           %28 = OpLogicalNot %12 %15
-                 OpBranch %19
-           %19 = OpLabel
-           %27 = OpISub %6 %9 %11
-                 OpReturn
-                 OpFunctionEnd
-    )";
-  ASSERT_TRUE(IsEqual(env, after_transformation, context.get()));
-  }
-  */
+  std::vector<uint32_t> actual_binary;
+  context.get()->module()->ToBinary(&actual_binary, false);
+  SpirvTools t(env);
+  std::string actual_disassembled;
+  t.Disassemble(actual_binary, &actual_disassembled, kFuzzDisassembleOption);
+  std::cout << actual_disassembled << std::endl;
+
+  ASSERT_TRUE(IsValid(env, context.get()));
+}
 }  // namespace
 }  // namespace fuzz
 }  // namespace spvtools

--- a/test/fuzz/transformation_split_loop_test.cpp
+++ b/test/fuzz/transformation_split_loop_test.cpp
@@ -19,7 +19,7 @@ namespace spvtools {
 namespace fuzz {
 namespace {
 
-TEST(TransformationSplitLoopTest, BasicScenarios) {
+TEST(TransformationSplitLoopTest, BasicScenario) {
   // In this test scenario we have a simple loop.
   std::string shader = R"(
                OpCapability Shader
@@ -93,7 +93,7 @@ TEST(TransformationSplitLoopTest, BasicScenarios) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(context.get()), validator_options);
 
-  auto transformation = TransformationSplitLoop(11, 50, 54, 24, 101, 102, 103,
+  auto transformation = TransformationSplitLoop(11, 120, 121, 24, 101, 102, 103,
                                                 104, 105, 106, 107, {{}},
                                                 {{11, 201},
                                                  {15, 202},
@@ -218,7 +218,7 @@ TEST(TransformationSplitLoopTest, TestShaderFirstLoop) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(context.get()), validator_options);
 
-  auto transformation = TransformationSplitLoop(12, 100, 102, 9, 201, 202, 203,
+  auto transformation = TransformationSplitLoop(12, 120, 121, 9, 201, 202, 203,
                                                 204, 205, 206, 207, {{}},
                                                 {{12, 301},
                                                  {16, 302},
@@ -351,7 +351,7 @@ TEST(TransformationSplitLoopTest, TestShaderSecondLoop) {
       MakeUnique<FactManager>(context.get()), validator_options);
 
   auto transformation = TransformationSplitLoop(
-      42, 100, 102, 9, 201, 202, 203, 204, 205, 206, 207, {{}},
+      42, 120, 121, 9, 201, 202, 203, 204, 205, 206, 207, {{}},
       {{42, 301}, {43, 302}, {44, 303}, {45, 304}},
       {{47, 401}, {48, 402}, {49, 403}, {50, 404}});
   ASSERT_TRUE(
@@ -419,8 +419,8 @@ TEST(TransformationSplitLoopTest, HeaderIsContinueTargetTest) {
       MakeUnique<FactManager>(context.get()), validator_options);
 
   auto transformation =
-      TransformationSplitLoop(11, 53, 54, 55, 101, 102, 103, 104, 105, 106, 107,
-                              {}, {{11, 201}, {13, 202}}, {{}});
+      TransformationSplitLoop(11, 120, 121, 55, 101, 102, 103, 104, 105, 106,
+                              107, {}, {{11, 201}, {13, 202}}, {{}});
 
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
@@ -487,9 +487,9 @@ TEST(TransformationSplitLoopTest, BranchConditionalContinueTargetTest) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(context.get()), validator_options);
 
-  auto transformation =
-      TransformationSplitLoop(11, 53, 54, 55, 101, 102, 103, 104, 105, 106, 107,
-                              {108}, {{11, 201}, {12, 202}, {13, 203}}, {{}});
+  auto transformation = TransformationSplitLoop(
+      11, 120, 121, 55, 101, 102, 103, 104, 105, 106, 107, {108},
+      {{11, 201}, {12, 202}, {13, 203}}, {{}});
 
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
@@ -558,142 +558,101 @@ TEST(TransformationSplitLoopTest, NotApplicableScenarios) {
 
   // Bad: |load_counter_fresh_id| is not fresh.
   auto transformation_bad_1 = TransformationSplitLoop(
-      11, 53, 54, 55, 55, 102, 103, 104, 105, 106, 107, {108},
+      11, 120, 121, 55, 55, 102, 103, 104, 105, 106, 107, {108},
       {{11, 201}, {13, 202}, {14, 203}}, {{70, 301}});
   ASSERT_FALSE(
       transformation_bad_1.IsApplicable(context.get(), transformation_context));
 
   // Bad: |increment_counter_fresh_id| is not fresh.
   auto transformation_bad_2 = TransformationSplitLoop(
-      11, 53, 54, 55, 101, 55, 103, 104, 105, 106, 107, {108},
+      11, 120, 121, 55, 101, 55, 103, 104, 105, 106, 107, {108},
       {{11, 201}, {13, 202}, {14, 203}}, {{70, 301}});
   ASSERT_FALSE(
       transformation_bad_2.IsApplicable(context.get(), transformation_context));
 
   // Bad: |condition_counter_fresh_id| is not fresh.
   auto transformation_bad_3 = TransformationSplitLoop(
-      11, 53, 54, 55, 101, 102, 55, 104, 105, 106, 107, {108},
+      11, 120, 121, 55, 101, 102, 55, 104, 105, 106, 107, {108},
       {{11, 201}, {13, 202}, {14, 203}}, {{70, 301}});
   ASSERT_FALSE(
       transformation_bad_3.IsApplicable(context.get(), transformation_context));
 
   // Bad: |new_body_entry_block_fresh_id| is not fresh.
   auto transformation_bad_4 = TransformationSplitLoop(
-      11, 53, 54, 55, 101, 102, 103, 55, 105, 106, 107, {108},
+      11, 120, 121, 55, 101, 102, 103, 55, 105, 106, 107, {108},
       {{11, 201}, {13, 202}, {14, 203}}, {{70, 301}});
   ASSERT_FALSE(
       transformation_bad_4.IsApplicable(context.get(), transformation_context));
 
   // Bad: |conditional_block_fresh_id| is not fresh.
   auto transformation_bad_5 = TransformationSplitLoop(
-      11, 53, 54, 55, 101, 102, 103, 104, 55, 106, 107, {108},
+      11, 120, 121, 55, 101, 102, 103, 104, 55, 106, 107, {108},
       {{11, 201}, {13, 202}, {14, 203}}, {{70, 301}});
   ASSERT_FALSE(
       transformation_bad_5.IsApplicable(context.get(), transformation_context));
 
   // Bad: |load_run_second_id| is not fresh.
   auto transformation_bad_6 = TransformationSplitLoop(
-      11, 53, 54, 55, 101, 102, 103, 104, 105, 55, 107, {108},
+      11, 120, 121, 55, 101, 102, 103, 104, 105, 55, 107, {108},
       {{11, 201}, {13, 202}, {14, 203}}, {{70, 301}});
   ASSERT_FALSE(
       transformation_bad_6.IsApplicable(context.get(), transformation_context));
 
   // Bad: |selection_merge_fresh_block_fresh_id| is not fresh.
   auto transformation_bad_7 = TransformationSplitLoop(
-      11, 53, 54, 55, 101, 102, 103, 104, 105, 106, 55, {108},
+      11, 120, 121, 55, 101, 102, 103, 104, 105, 106, 55, {108},
       {{11, 201}, {13, 202}, {14, 203}}, {{70, 301}});
   ASSERT_FALSE(
       transformation_bad_7.IsApplicable(context.get(), transformation_context));
 
-  // Bad: |variable_counter_id| does not refer to an existing instruction.
+  // Bad: |constant_limit_id| does not refer to an existing instruction.
   auto transformation_bad_8 = TransformationSplitLoop(
-      11, 90, 54, 55, 101, 102, 103, 104, 105, 106, 107, {108},
+      11, 120, 121, 90, 101, 102, 103, 104, 105, 106, 107, {108},
       {{11, 201}, {13, 202}, {14, 203}}, {{70, 301}});
   ASSERT_FALSE(
       transformation_bad_8.IsApplicable(context.get(), transformation_context));
 
-  // Bad: |variable_counter_id| does not refer to an OpVariable.
+  // Bad: |constant_limit_id| does not refer to an integer value.
   auto transformation_bad_9 = TransformationSplitLoop(
-      11, 55, 54, 55, 101, 102, 103, 104, 105, 106, 107, {108},
+      11, 120, 121, 58, 101, 102, 103, 104, 105, 106, 107, {108},
       {{11, 201}, {13, 202}, {14, 203}}, {{70, 301}});
   ASSERT_FALSE(
       transformation_bad_9.IsApplicable(context.get(), transformation_context));
-
-  // Bad: |variable_counter_id| does not refer to an integer variable.
+  // Bad: |loop_header_id| does not refer to a loop header.
   auto transformation_bad_10 = TransformationSplitLoop(
-      11, 54, 54, 55, 101, 102, 103, 104, 105, 106, 107, {108},
+      14, 120, 121, 55, 101, 102, 103, 104, 105, 106, 107, {108},
       {{11, 201}, {13, 202}, {14, 203}}, {{70, 301}});
   ASSERT_FALSE(transformation_bad_10.IsApplicable(context.get(),
                                                   transformation_context));
-
-  // Bad: |variable_run_second| does not refer to an existing instruction.
-  auto transformation_bad_11 = TransformationSplitLoop(
-      11, 53, 90, 55, 101, 102, 103, 104, 105, 106, 107, {108},
-      {{11, 201}, {13, 202}, {14, 203}}, {{70, 301}});
-  ASSERT_FALSE(transformation_bad_11.IsApplicable(context.get(),
-                                                  transformation_context));
-  // Bad: |variable_run_second| does not refer to an OpVariable
-  auto transformation_bad_12 = TransformationSplitLoop(
-      11, 53, 55, 55, 101, 102, 103, 104, 105, 106, 107, {108},
-      {{11, 201}, {13, 202}, {14, 203}}, {{70, 301}});
-  ASSERT_FALSE(transformation_bad_12.IsApplicable(context.get(),
-                                                  transformation_context));
-
-  // Bad: |variable_run_second| does not refer to a boolean variable
-  auto transformation_bad_13 = TransformationSplitLoop(
-      11, 53, 53, 55, 101, 102, 103, 104, 105, 106, 107, {108},
-      {{11, 201}, {13, 202}, {14, 203}}, {{70, 301}});
-  ASSERT_FALSE(transformation_bad_13.IsApplicable(context.get(),
-                                                  transformation_context));
-
-  // Bad: |constant_limit_id| does not refer to an existing instruction.
-  auto transformation_bad_14 = TransformationSplitLoop(
-      11, 53, 54, 90, 101, 102, 103, 104, 105, 106, 107, {108},
-      {{11, 201}, {13, 202}, {14, 203}}, {{70, 301}});
-  ASSERT_FALSE(transformation_bad_14.IsApplicable(context.get(),
-                                                  transformation_context));
-
-  // Bad: |constant_limit_id| does not refer to an integer value.
-  auto transformation_bad_15 = TransformationSplitLoop(
-      11, 53, 54, 58, 101, 102, 103, 104, 105, 106, 107, {108},
-      {{11, 201}, {13, 202}, {14, 203}}, {{70, 301}});
-  ASSERT_FALSE(transformation_bad_15.IsApplicable(context.get(),
-                                                  transformation_context));
-  // Bad: |loop_header_id| does not refer to a loop header.
-  auto transformation_bad_16 = TransformationSplitLoop(
-      14, 53, 54, 55, 101, 102, 103, 104, 105, 106, 107, {108},
-      {{11, 201}, {13, 202}, {14, 203}}, {{70, 301}});
-  ASSERT_FALSE(transformation_bad_16.IsApplicable(context.get(),
-                                                  transformation_context));
   // Bad: There is no entry for block with id 13 in
   // |original_label_to_duplicate_label|.
-  auto transformation_bad_17 =
-      TransformationSplitLoop(11, 53, 54, 55, 101, 102, 103, 104, 105, 106, 107,
-                              {108}, {{11, 201}, {14, 203}}, {{70, 301}});
-  ASSERT_FALSE(transformation_bad_17.IsApplicable(context.get(),
+  auto transformation_bad_11 =
+      TransformationSplitLoop(11, 120, 121, 55, 101, 102, 103, 104, 105, 106,
+                              107, {108}, {{11, 201}, {14, 203}}, {{70, 301}});
+  ASSERT_FALSE(transformation_bad_11.IsApplicable(context.get(),
                                                   transformation_context));
 
   // Bad: Value of id 13 in |original_label_to_duplicate_label| is not a fresh
   // id.
-  auto transformation_bad_18 = TransformationSplitLoop(
-      11, 53, 54, 55, 101, 102, 103, 104, 105, 106, 107, {108},
+  auto transformation_bad_12 = TransformationSplitLoop(
+      11, 120, 121, 55, 101, 102, 103, 104, 105, 106, 107, {108},
       {{11, 201}, {13, 55}, {14, 203}}, {{70, 301}});
-  ASSERT_FALSE(transformation_bad_18.IsApplicable(context.get(),
+  ASSERT_FALSE(transformation_bad_12.IsApplicable(context.get(),
                                                   transformation_context));
 
   // Bad: There is no entry for instruction with id 70 in
   // |original_id_to_duplicate_id|.
-  auto transformation_bad_19 =
-      TransformationSplitLoop(11, 53, 54, 55, 101, 102, 103, 104, 105, 106, 107,
-                              {108}, {{11, 201}, {13, 202}, {14, 203}}, {{}});
-  ASSERT_FALSE(transformation_bad_19.IsApplicable(context.get(),
+  auto transformation_bad_13 = TransformationSplitLoop(
+      11, 120, 121, 55, 101, 102, 103, 104, 105, 106, 107, {108},
+      {{11, 201}, {13, 202}, {14, 203}}, {{}});
+  ASSERT_FALSE(transformation_bad_13.IsApplicable(context.get(),
                                                   transformation_context));
 
   // Bad: Value of id 70 in |original_id_to_duplicate_id| is not a fresh id.
-  auto transformation_bad_20 = TransformationSplitLoop(
-      11, 53, 54, 55, 101, 102, 103, 104, 105, 106, 107, {108},
+  auto transformation_bad_14 = TransformationSplitLoop(
+      11, 120, 121, 55, 101, 102, 103, 104, 105, 106, 107, {108},
       {{11, 201}, {13, 202}, {14, 203}}, {{70, 55}});
-  ASSERT_FALSE(transformation_bad_20.IsApplicable(context.get(),
+  ASSERT_FALSE(transformation_bad_14.IsApplicable(context.get(),
                                                   transformation_context));
 }
 
@@ -755,15 +714,16 @@ TEST(TransformationSplitLoopTest, ResolvingOpPhiMergeBlock) {
       MakeUnique<FactManager>(context.get()), validator_options);
 
   auto transformation_good_1 = TransformationSplitLoop(
-      8, 53, 54, 55, 101, 102, 103, 104, 105, 106, 107, {{}},
+      8, 120, 121, 55, 101, 102, 103, 104, 105, 106, 107, {{}},
       {{8, 201}, {11, 202}, {10, 203}}, {{70, 301}});
 
   ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
                                                  transformation_context));
   transformation_good_1.Apply(context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
+
   std::string expected_shader = R"(
-                 OpCapability Shader
+               OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %4 "main"
@@ -789,15 +749,15 @@ TEST(TransformationSplitLoopTest, ResolvingOpPhiMergeBlock) {
                OpFunctionEnd
           %6 = OpFunction %2 None %3
           %7 = OpLabel
+        %120 = OpVariable %51 Function %56
+        %121 = OpVariable %52 Function %14
          %53 = OpVariable %51 Function
          %54 = OpVariable %52 Function
-               OpStore %53 %56
-               OpStore %54 %14
                OpBranch %8
           %8 = OpLabel
-        %101 = OpLoad %50 %53
+        %101 = OpLoad %50 %120
         %102 = OpIAdd %50 %101 %57
-               OpStore %53 %102
+               OpStore %120 %102
         %103 = OpULessThan %13 %102 %55
                OpLoopMerge %10 %11 None
                OpBranchConditional %103 %104 %10
@@ -809,7 +769,7 @@ TEST(TransformationSplitLoopTest, ResolvingOpPhiMergeBlock) {
          %70 = OpCopyObject %13 %14
                OpBranch %105
         %105 = OpLabel
-        %106 = OpLoad %13 %54
+        %106 = OpLoad %13 %121
                OpSelectionMerge %107 None
                OpBranchConditional %106 %201 %107
         %201 = OpLabel
@@ -890,7 +850,7 @@ TEST(TransformationSplitLoopTest, ResolvingOpPhiHeaderBlock) {
       MakeUnique<FactManager>(context.get()), validator_options);
 
   auto transformation_good_1 = TransformationSplitLoop(
-      8, 53, 54, 55, 101, 102, 103, 104, 105, 106, 107, {{}},
+      8, 120, 121, 55, 101, 102, 103, 104, 105, 106, 107, {{}},
       {{8, 201}, {11, 202}, {10, 203}}, {{72, 301}});
 
   ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
@@ -899,7 +859,7 @@ TEST(TransformationSplitLoopTest, ResolvingOpPhiHeaderBlock) {
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string expected_shader = R"(
-                 OpCapability Shader
+               OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %4 "main"
@@ -925,19 +885,19 @@ TEST(TransformationSplitLoopTest, ResolvingOpPhiHeaderBlock) {
                OpFunctionEnd
           %6 = OpFunction %2 None %3
           %7 = OpLabel
+        %120 = OpVariable %51 Function %56
+        %121 = OpVariable %52 Function %14
          %53 = OpVariable %51 Function
          %54 = OpVariable %52 Function
-               OpStore %53 %56
-               OpStore %54 %14
                OpBranch %70
          %70 = OpLabel
          %71 = OpCopyObject %13 %14
                OpBranch %8
           %8 = OpLabel
          %72 = OpPhi %13 %71 %70 %71 %11
-        %101 = OpLoad %50 %53
+        %101 = OpLoad %50 %120
         %102 = OpIAdd %50 %101 %57
-               OpStore %53 %102
+               OpStore %120 %102
         %103 = OpULessThan %13 %102 %55
                OpLoopMerge %10 %11 None
                OpBranchConditional %103 %104 %10
@@ -948,7 +908,7 @@ TEST(TransformationSplitLoopTest, ResolvingOpPhiHeaderBlock) {
          %10 = OpLabel
                OpBranch %105
         %105 = OpLabel
-        %106 = OpLoad %13 %54
+        %106 = OpLoad %13 %121
                OpSelectionMerge %107 None
                OpBranchConditional %106 %201 %107
         %201 = OpLabel
@@ -1028,12 +988,13 @@ TEST(TransformationSplitLoopTest, ResolvingOpPhiBodyBlock) {
       MakeUnique<FactManager>(context.get()), validator_options);
 
   auto transformation_good_1 = TransformationSplitLoop(
-      8, 53, 54, 55, 101, 102, 103, 104, 105, 106, 107, {{}},
+      8, 120, 121, 55, 101, 102, 103, 104, 105, 106, 107, {{}},
       {{8, 201}, {11, 202}, {10, 203}, {30, 204}}, {{70, 301}, {71, 302}});
 
   ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
                                                  transformation_context));
   transformation_good_1.Apply(context.get(), &transformation_context);
+
   ASSERT_TRUE(IsValid(env, context.get()));
   std::string expected_shader = R"(
                OpCapability Shader
@@ -1062,15 +1023,15 @@ TEST(TransformationSplitLoopTest, ResolvingOpPhiBodyBlock) {
                OpFunctionEnd
           %6 = OpFunction %2 None %3
           %7 = OpLabel
+        %120 = OpVariable %51 Function %56
+        %121 = OpVariable %52 Function %14
          %53 = OpVariable %51 Function
          %54 = OpVariable %52 Function
-               OpStore %53 %56
-               OpStore %54 %14
                OpBranch %8
           %8 = OpLabel
-        %101 = OpLoad %50 %53
+        %101 = OpLoad %50 %120
         %102 = OpIAdd %50 %101 %57
-               OpStore %53 %102
+               OpStore %120 %102
         %103 = OpULessThan %13 %102 %55
                OpLoopMerge %10 %11 None
                OpBranchConditional %103 %104 %10
@@ -1085,7 +1046,7 @@ TEST(TransformationSplitLoopTest, ResolvingOpPhiBodyBlock) {
          %10 = OpLabel
                OpBranch %105
         %105 = OpLabel
-        %106 = OpLoad %13 %54
+        %106 = OpLoad %13 %121
                OpSelectionMerge %107 None
                OpBranchConditional %106 %201 %107
         %201 = OpLabel
@@ -1166,7 +1127,7 @@ TEST(TransformationSplitLoopTest, OpPhiInMergeBlockNotApplicable) {
       MakeUnique<FactManager>(context.get()), validator_options);
 
   auto transformation_bad = TransformationSplitLoop(
-      8, 53, 54, 55, 101, 102, 103, 104, 105, 106, 107, {{}},
+      8, 120, 121, 55, 101, 102, 103, 104, 105, 106, 107, {{}},
       {{8, 201}, {11, 202}, {10, 203}}, {{70, 301}, {71, 302}});
 
   ASSERT_FALSE(
@@ -1231,18 +1192,236 @@ TEST(TransformationSplitLoopTest, LogicalNotFreshIdsNotApplicable) {
 
   // Bad: Insufficient number of fresh ids as |logical_not_fresh_ids|.
   auto transformation_bad_1 =
-      TransformationSplitLoop(8, 53, 54, 55, 101, 102, 103, 104, 105, 106, 107,
-                              {}, {{8, 201}, {11, 202}, {10, 203}}, {{}});
+      TransformationSplitLoop(8, 120, 121, 55, 101, 102, 103, 104, 105, 106,
+                              107, {}, {{8, 201}, {11, 202}, {10, 203}}, {{}});
 
   ASSERT_FALSE(
       transformation_bad_1.IsApplicable(context.get(), transformation_context));
 
   // Bad: The id in |logical_not_fresh_ids| is not fresh.
-  auto transformation_bad_2 =
-      TransformationSplitLoop(8, 53, 54, 55, 101, 102, 103, 104, 105, 106, 107,
-                              {55}, {{8, 201}, {11, 202}, {10, 203}}, {{}});
+  auto transformation_bad_2 = TransformationSplitLoop(
+      8, 120, 121, 55, 101, 102, 103, 104, 105, 106, 107, {55},
+      {{8, 201}, {11, 202}, {10, 203}}, {{}});
   ASSERT_FALSE(
       transformation_bad_2.IsApplicable(context.get(), transformation_context));
+}
+
+TEST(TransformationSplitLoopTest, NestedLoopSplitOuter) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 320
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypePointer Function %6
+          %9 = OpConstant %6 0
+         %17 = OpConstant %6 10
+        %900 = OpTypeInt 32 0
+        %901 = OpConstant %900 0
+        %902 = OpConstant %900 1
+        %903 = OpConstant %900 3
+        %904 = OpTypePointer Function %900
+         %18 = OpTypeBool
+        %905 = OpConstantTrue %18
+        %906 = OpConstantFalse %18
+        %100 = OpTypePointer Function %18
+        %101 = OpConstant %6 5
+         %29 = OpConstant %6 1
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+          %8 = OpVariable %7 Function
+         %10 = OpVariable %7 Function
+         %20 = OpVariable %7 Function
+               OpStore %8 %9
+               OpStore %10 %9
+               OpBranch %11
+         %11 = OpLabel
+               OpLoopMerge %13 %14 None
+               OpBranch %15
+         %15 = OpLabel
+         %16 = OpLoad %6 %10
+         %19 = OpSLessThan %18 %16 %17
+               OpBranchConditional %19 %12 %13
+         %12 = OpLabel
+               OpStore %20 %9
+               OpBranch %21
+         %21 = OpLabel
+               OpLoopMerge %23 %24 None
+               OpBranch %25
+         %25 = OpLabel
+         %26 = OpLoad %6 %20
+         %27 = OpSLessThan %18 %26 %17
+               OpBranchConditional %27 %22 %23
+         %22 = OpLabel
+         %28 = OpLoad %6 %8
+         %30 = OpIAdd %6 %28 %29
+               OpStore %8 %30
+               OpBranch %24
+         %24 = OpLabel
+         %31 = OpLoad %6 %20
+         %32 = OpIAdd %6 %31 %29
+               OpStore %20 %32
+               OpBranch %21
+         %23 = OpLabel
+               OpBranch %14
+         %14 = OpLabel
+         %33 = OpLoad %6 %10
+         %34 = OpIAdd %6 %33 %29
+               OpStore %10 %34
+               OpBranch %11
+         %13 = OpLabel
+               OpReturn
+               OpFunctionEnd
+      )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(
+      MakeUnique<FactManager>(context.get()), validator_options);
+
+  auto transformation =
+      TransformationSplitLoop(/*loop_header_id*/ 11,
+                              /*variable_counter_id*/ 1000,
+                              /*variable_run_second_id*/ 1001,
+                              /*constant_limit_id*/ 903,
+                              /*load_counter_fresh_id*/ 1002,
+                              /*increment_counter_fresh_id*/ 1003,
+                              /*condition_counter_fresh_id*/ 1004,
+                              /*new_body_entry_block_fresh_id*/ 1005,
+                              /*conditional_block_fresh_id*/ 1006,
+                              /*load_run_second_fresh_id*/ 1007,
+                              /*selection_merge_block_fresh_id*/ 1008,
+                              /*logical_not_fresh_ids*/ {},
+                              /*original_label_to_duplicate_label*/
+                              {{11, 2000},
+                               {15, 2001},
+                               {12, 2002},
+                               {21, 2003},
+                               {25, 2004},
+                               {22, 2005},
+                               {24, 2006},
+                               {23, 2007},
+                               {14, 2008},
+                               {13, 2009}},
+                              /*original_id_to_duplicate_id*/
+                              {{16, 3000},
+                               {19, 3001},
+                               {26, 3002},
+                               {27, 3003},
+                               {28, 3004},
+                               {30, 3005},
+                               {31, 3006},
+                               {32, 3007},
+                               {33, 3008},
+                               {34, 3009}});
+
+  ASSERT_TRUE(
+      transformation.IsApplicable(context.get(), transformation_context));
+  transformation.Apply(context.get(), &transformation_context);
+  ASSERT_TRUE(IsValid(env, context.get()));
+}
+TEST(TransformationSplitLoopTest, ConstantsNotPresentNotApplicable) {
+  // In this test scenario we don't provide the required constant
+  // OpConstantFalse. Therefore, the transformation is not applicable.
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %8 "s"
+               OpName %10 "i"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+         %60 = OpTypeInt 32 0
+          %7 = OpTypePointer Function %6
+         %61 = OpTypePointer Function %60
+          %9 = OpConstant %60 0
+         %17 = OpConstant %60 10
+         %18 = OpTypeBool
+         %55 = OpConstantTrue %18
+         %53 = OpTypePointer Function %18
+         %24 = OpConstant %60 3
+         %30 = OpConstant %60 1
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+          %8 = OpVariable %61 Function
+         %10 = OpVariable %61 Function
+         %50 = OpVariable %61 Function
+         %54 = OpVariable %53 Function
+               OpStore %8 %9
+               OpStore %10 %9
+               OpBranch %11
+         %11 = OpLabel
+               OpLoopMerge %13 %14 None
+               OpBranch %15
+         %15 = OpLabel
+         %16 = OpLoad %60 %10
+         %19 = OpSLessThan %18 %16 %17
+               OpBranchConditional %19 %12 %13
+         %12 = OpLabel
+         %20 = OpLoad %60 %10
+         %21 = OpLoad %60 %8
+         %22 = OpIAdd %60 %21 %20
+               OpStore %8 %22
+         %23 = OpLoad %60 %10
+         %25 = OpIEqual %18 %23 %24
+               OpSelectionMerge %27 None
+               OpBranchConditional %25 %26 %27
+         %26 = OpLabel
+               OpBranch %13
+         %27 = OpLabel
+               OpBranch %14
+         %14 = OpLabel
+         %29 = OpLoad %60 %10
+         %31 = OpIAdd %60 %29 %30
+               OpStore %10 %31
+               OpBranch %11
+         %13 = OpLabel
+               OpReturn
+               OpFunctionEnd
+      )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_4;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
+
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(
+      MakeUnique<FactManager>(context.get()), validator_options);
+
+  auto transformation = TransformationSplitLoop(11, 120, 121, 24, 101, 102, 103,
+                                                104, 105, 106, 107, {{}},
+                                                {{11, 201},
+                                                 {15, 202},
+                                                 {12, 203},
+                                                 {13, 204},
+                                                 {26, 205},
+                                                 {27, 206},
+                                                 {14, 207}},
+                                                {{16, 301},
+                                                 {19, 302},
+                                                 {20, 303},
+                                                 {21, 304},
+                                                 {22, 305},
+                                                 {23, 306},
+                                                 {25, 307},
+                                                 {29, 308},
+                                                 {31, 309}});
+  ASSERT_FALSE(
+      transformation.IsApplicable(context.get(), transformation_context));
 }
 
 }  // namespace


### PR DESCRIPTION
Adds a transformation that replaces a loop with two loops, which in
total iterate over the same loop body with the same condition of
iteration. The first loop is executed up to a constant number of times.
If more iterations are required, they are performed in the second loop.

Fixes #3777 