### PR TITLE
Fix compiler error on macOS with XCode12

### DIFF
--- a/source/cfa.h
+++ b/source/cfa.h
@@ -127,7 +127,7 @@ class CFA {
 template <class BB>
 bool CFA<BB>::FindInWorkList(const std::vector<block_info>& work_list,
                              uint32_t id) {
-  for (const auto& b : work_list) {
+  for (auto& b : work_list) {
     if (b.block->id() == id) return true;
   }
   return false;


### PR DESCRIPTION
Fixed a minor language building snafu with Apple's XCode12 and updated compiler tools. XCode12 is needed for the new MoltenVK (which brings in this library) libraries.