### PR TITLE
spirv-fuzz: Move IRContext parameter into constructor

### DIFF
--- a/source/fuzz/data_descriptor.h
+++ b/source/fuzz/data_descriptor.h
@@ -15,10 +15,10 @@
 #ifndef SOURCE_FUZZ_DATA_DESCRIPTOR_H_
 #define SOURCE_FUZZ_DATA_DESCRIPTOR_H_
 
-#include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
-
 #include <ostream>
 #include <vector>
+
+#include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
 
 namespace spvtools {
 namespace fuzz {

--- a/source/fuzz/fact_manager/constant_uniform_facts.h
+++ b/source/fuzz/fact_manager/constant_uniform_facts.h
@@ -28,22 +28,21 @@ namespace fact_manager {
 // facts about uniform constants.
 class ConstantUniformFacts {
  public:
+  explicit ConstantUniformFacts(opt::IRContext* ir_context);
+
   // See method in FactManager which delegates to this method.
-  bool AddFact(const protobufs::FactConstantUniform& fact,
-               opt::IRContext* context);
+  bool AddFact(const protobufs::FactConstantUniform& fact);
 
   // See method in FactManager which delegates to this method.
   std::vector<uint32_t> GetConstantsAvailableFromUniformsForType(
-      opt::IRContext* ir_context, uint32_t type_id) const;
+      uint32_t type_id) const;
 
   // See method in FactManager which delegates to this method.
   std::vector<protobufs::UniformBufferElementDescriptor>
-  GetUniformDescriptorsForConstant(opt::IRContext* ir_context,
-                                   uint32_t constant_id) const;
+  GetUniformDescriptorsForConstant(uint32_t constant_id) const;
 
   // See method in FactManager which delegates to this method.
   uint32_t GetConstantFromUniformDescriptor(
-      opt::IRContext* context,
       const protobufs::UniformBufferElementDescriptor& uniform_descriptor)
       const;
 
@@ -69,10 +68,9 @@ class ConstantUniformFacts {
   // Yields the id of a constant of type |type_id| whose data matches the
   // constant data in |constant_uniform_fact|, or 0 if no such constant is
   // declared.
-  static uint32_t GetConstantId(
-      opt::IRContext* context,
+  uint32_t GetConstantId(
       const protobufs::FactConstantUniform& constant_uniform_fact,
-      uint32_t type_id);
+      uint32_t type_id) const;
 
   // Checks that the width of a floating-point constant is supported, and that
   // the constant is finite.
@@ -81,6 +79,8 @@ class ConstantUniformFacts {
 
   std::vector<std::pair<protobufs::FactConstantUniform, uint32_t>>
       facts_and_type_ids_;
+
+  opt::IRContext* ir_context_;
 };
 
 }  // namespace fact_manager

--- a/source/fuzz/fact_manager/data_synonym_and_id_equation_facts.cpp
+++ b/source/fuzz/fact_manager/data_synonym_and_id_equation_facts.cpp
@@ -51,34 +51,36 @@ bool DataSynonymAndIdEquationFacts::OperationEquals::operator()(
   return true;
 }
 
+DataSynonymAndIdEquationFacts::DataSynonymAndIdEquationFacts(
+    opt::IRContext* ir_context)
+    : ir_context_(ir_context) {}
+
 void DataSynonymAndIdEquationFacts::AddFact(
     const protobufs::FactDataSynonym& fact,
     const DeadBlockFacts& dead_block_facts,
-    const IrrelevantValueFacts& irrelevant_value_facts,
-    opt::IRContext* context) {
+    const IrrelevantValueFacts& irrelevant_value_facts) {
   (void)dead_block_facts;        // Keep release compilers happy.
   (void)irrelevant_value_facts;  // Keep release compilers happy.
   assert(!irrelevant_value_facts.IdIsIrrelevant(fact.data1().object(),
-                                                dead_block_facts, context) &&
+                                                dead_block_facts) &&
          !irrelevant_value_facts.IdIsIrrelevant(fact.data2().object(),
-                                                dead_block_facts, context) &&
+                                                dead_block_facts) &&
          "Irrelevant ids cannot be synonymous with other ids.");
 
   // Add the fact, including all facts relating sub-components of the data
   // descriptors that are involved.
-  AddDataSynonymFactRecursive(fact.data1(), fact.data2(), context);
+  AddDataSynonymFactRecursive(fact.data1(), fact.data2());
 }
 
 void DataSynonymAndIdEquationFacts::AddFact(
     const protobufs::FactIdEquation& fact,
     const DeadBlockFacts& dead_block_facts,
-    const IrrelevantValueFacts& irrelevant_value_facts,
-    opt::IRContext* context) {
+    const IrrelevantValueFacts& irrelevant_value_facts) {
   (void)dead_block_facts;        // Keep release compilers happy.
   (void)irrelevant_value_facts;  // Keep release compilers happy.
-  assert(!irrelevant_value_facts.IdIsIrrelevant(fact.lhs_id(), dead_block_facts,
-                                                context) &&
-         "Irrelevant ids are not allowed.");
+  assert(
+      !irrelevant_value_facts.IdIsIrrelevant(fact.lhs_id(), dead_block_facts) &&
+      "Irrelevant ids are not allowed.");
 
   protobufs::DataDescriptor lhs_dd = MakeDataDescriptor(fact.lhs_id(), {});
 
@@ -89,8 +91,7 @@ void DataSynonymAndIdEquationFacts::AddFact(
   // equation.
   std::vector<const protobufs::DataDescriptor*> rhs_dds;
   for (auto rhs_id : fact.rhs_id()) {
-    assert(!irrelevant_value_facts.IdIsIrrelevant(rhs_id, dead_block_facts,
-                                                  context) &&
+    assert(!irrelevant_value_facts.IdIsIrrelevant(rhs_id, dead_block_facts) &&
            "Irrelevant ids are not allowed.");
 
     // Register a data descriptor based on this id in the equivalence relation
@@ -99,8 +100,7 @@ void DataSynonymAndIdEquationFacts::AddFact(
   }
 
   // Now add the fact.
-  AddEquationFactRecursive(lhs_dd, static_cast<SpvOp>(fact.opcode()), rhs_dds,
-                           context);
+  AddEquationFactRecursive(lhs_dd, static_cast<SpvOp>(fact.opcode()), rhs_dds);
 }
 
 DataSynonymAndIdEquationFacts::OperationSet
@@ -115,8 +115,7 @@ DataSynonymAndIdEquationFacts::GetEquations(
 
 void DataSynonymAndIdEquationFacts::AddEquationFactRecursive(
     const protobufs::DataDescriptor& lhs_dd, SpvOp opcode,
-    const std::vector<const protobufs::DataDescriptor*>& rhs_dds,
-    opt::IRContext* context) {
+    const std::vector<const protobufs::DataDescriptor*>& rhs_dds) {
   assert(synonymous_.Exists(lhs_dd) &&
          "The LHS must be known to the equivalence relation.");
   for (auto rhs_dd : rhs_dds) {
@@ -153,14 +152,13 @@ void DataSynonymAndIdEquationFacts::AddEquationFactRecursive(
   switch (opcode) {
     case SpvOpConvertSToF:
     case SpvOpConvertUToF:
-      ComputeConversionDataSynonymFacts(*rhs_dds[0], context);
+      ComputeConversionDataSynonymFacts(*rhs_dds[0]);
       break;
     case SpvOpBitcast: {
-      assert(DataDescriptorsAreWellFormedAndComparable(context, lhs_dd,
-                                                       *rhs_dds[0]) &&
+      assert(DataDescriptorsAreWellFormedAndComparable(lhs_dd, *rhs_dds[0]) &&
              "Operands of OpBitcast equation fact must have compatible types");
       if (!synonymous_.IsEquivalent(lhs_dd, *rhs_dds[0])) {
-        AddDataSynonymFactRecursive(lhs_dd, *rhs_dds[0], context);
+        AddDataSynonymFactRecursive(lhs_dd, *rhs_dds[0]);
       }
     } break;
     case SpvOpIAdd: {
@@ -171,13 +169,13 @@ void DataSynonymAndIdEquationFacts::AddEquationFactRecursive(
           if (synonymous_.IsEquivalent(*equation.operands[1], *rhs_dds[1])) {
             // Equation form: "a = (d - c) + c"
             // We can thus infer "a = d"
-            AddDataSynonymFactRecursive(lhs_dd, *equation.operands[0], context);
+            AddDataSynonymFactRecursive(lhs_dd, *equation.operands[0]);
           }
           if (synonymous_.IsEquivalent(*equation.operands[0], *rhs_dds[1])) {
             // Equation form: "a = (c - e) + c"
             // We can thus infer "a = -e"
             AddEquationFactRecursive(lhs_dd, SpvOpSNegate,
-                                     {equation.operands[1]}, context);
+                                     {equation.operands[1]});
           }
         }
       }
@@ -187,7 +185,7 @@ void DataSynonymAndIdEquationFacts::AddEquationFactRecursive(
           if (synonymous_.IsEquivalent(*equation.operands[1], *rhs_dds[0])) {
             // Equation form: "a = b + (d - b)"
             // We can thus infer "a = d"
-            AddDataSynonymFactRecursive(lhs_dd, *equation.operands[0], context);
+            AddDataSynonymFactRecursive(lhs_dd, *equation.operands[0]);
           }
         }
       }
@@ -201,12 +199,12 @@ void DataSynonymAndIdEquationFacts::AddEquationFactRecursive(
           if (synonymous_.IsEquivalent(*equation.operands[0], *rhs_dds[1])) {
             // Equation form: "a = (c + e) - c"
             // We can thus infer "a = e"
-            AddDataSynonymFactRecursive(lhs_dd, *equation.operands[1], context);
+            AddDataSynonymFactRecursive(lhs_dd, *equation.operands[1]);
           }
           if (synonymous_.IsEquivalent(*equation.operands[1], *rhs_dds[1])) {
             // Equation form: "a = (d + c) - c"
             // We can thus infer "a = d"
-            AddDataSynonymFactRecursive(lhs_dd, *equation.operands[0], context);
+            AddDataSynonymFactRecursive(lhs_dd, *equation.operands[0]);
           }
         }
 
@@ -216,7 +214,7 @@ void DataSynonymAndIdEquationFacts::AddEquationFactRecursive(
             // Equation form: "a = (c - e) - c"
             // We can thus infer "a = -e"
             AddEquationFactRecursive(lhs_dd, SpvOpSNegate,
-                                     {equation.operands[1]}, context);
+                                     {equation.operands[1]});
           }
         }
       }
@@ -228,13 +226,13 @@ void DataSynonymAndIdEquationFacts::AddEquationFactRecursive(
             // Equation form: "a = b - (b + e)"
             // We can thus infer "a = -e"
             AddEquationFactRecursive(lhs_dd, SpvOpSNegate,
-                                     {equation.operands[1]}, context);
+                                     {equation.operands[1]});
           }
           if (synonymous_.IsEquivalent(*equation.operands[1], *rhs_dds[0])) {
             // Equation form: "a = b - (d + b)"
             // We can thus infer "a = -d"
             AddEquationFactRecursive(lhs_dd, SpvOpSNegate,
-                                     {equation.operands[0]}, context);
+                                     {equation.operands[0]});
           }
         }
         if (equation.opcode == SpvOpISub) {
@@ -242,7 +240,7 @@ void DataSynonymAndIdEquationFacts::AddEquationFactRecursive(
           if (synonymous_.IsEquivalent(*equation.operands[0], *rhs_dds[0])) {
             // Equation form: "a = b - (b - e)"
             // We can thus infer "a = e"
-            AddDataSynonymFactRecursive(lhs_dd, *equation.operands[1], context);
+            AddDataSynonymFactRecursive(lhs_dd, *equation.operands[1]);
           }
         }
       }
@@ -255,7 +253,7 @@ void DataSynonymAndIdEquationFacts::AddEquationFactRecursive(
         if (equation.opcode == opcode) {
           // Equation form: "a = !!b" or "a = -(-b)"
           // We can thus infer "a = b"
-          AddDataSynonymFactRecursive(lhs_dd, *equation.operands[0], context);
+          AddDataSynonymFactRecursive(lhs_dd, *equation.operands[0]);
         }
       }
       break;
@@ -266,9 +264,9 @@ void DataSynonymAndIdEquationFacts::AddEquationFactRecursive(
 }
 
 void DataSynonymAndIdEquationFacts::AddDataSynonymFactRecursive(
-    const protobufs::DataDescriptor& dd1, const protobufs::DataDescriptor& dd2,
-    opt::IRContext* context) {
-  assert(DataDescriptorsAreWellFormedAndComparable(context, dd1, dd2));
+    const protobufs::DataDescriptor& dd1,
+    const protobufs::DataDescriptor& dd2) {
+  assert(DataDescriptorsAreWellFormedAndComparable(dd1, dd2));
 
   // Record that the data descriptors provided in the fact are equivalent.
   MakeEquivalent(dd1, dd2);
@@ -279,19 +277,20 @@ void DataSynonymAndIdEquationFacts::AddDataSynonymFactRecursive(
 
   // |dd1| and |dd2| belong to the same equivalence class so it doesn't matter
   // which one we use here.
-  ComputeConversionDataSynonymFacts(dd1, context);
+  ComputeConversionDataSynonymFacts(dd1);
 
-  ComputeCompositeDataSynonymFacts(dd1, dd2, context);
+  ComputeCompositeDataSynonymFacts(dd1, dd2);
 }
 
 void DataSynonymAndIdEquationFacts::ComputeConversionDataSynonymFacts(
-    const protobufs::DataDescriptor& dd, opt::IRContext* context) {
+    const protobufs::DataDescriptor& dd) {
   assert(synonymous_.Exists(dd) &&
          "|dd| should've been registered in the equivalence relation");
 
   const auto* type =
-      context->get_type_mgr()->GetType(fuzzerutil::WalkCompositeTypeIndices(
-          context, fuzzerutil::GetTypeId(context, dd.object()), dd.index()));
+      ir_context_->get_type_mgr()->GetType(fuzzerutil::WalkCompositeTypeIndices(
+          ir_context_, fuzzerutil::GetTypeId(ir_context_, dd.object()),
+          dd.index()));
   assert(type && "Data descriptor has invalid type");
 
   if ((type->AsVector() && type->AsVector()->element_type()->AsInteger()) ||
@@ -306,8 +305,9 @@ void DataSynonymAndIdEquationFacts::ComputeConversionDataSynonymFacts(
       auto equivalence_class = synonymous_.GetEquivalenceClass(*fact.first);
       auto dd_it = std::find_if(
           equivalence_class.begin(), equivalence_class.end(),
-          [context](const protobufs::DataDescriptor* a) {
-            return context->get_def_use_mgr()->GetDef(a->object()) != nullptr;
+          [this](const protobufs::DataDescriptor* a) {
+            return ir_context_->get_def_use_mgr()->GetDef(a->object()) !=
+                   nullptr;
           });
       if (dd_it == equivalence_class.end()) {
         // Skip |equivalence_class| if it has no valid ids.
@@ -335,7 +335,7 @@ void DataSynonymAndIdEquationFacts::ComputeConversionDataSynonymFacts(
           if (!synonymous_.IsEquivalent(*synonym_a, *synonym_b)) {
             // |synonym_a| and |synonym_b| have compatible types - they are
             // synonymous.
-            AddDataSynonymFactRecursive(*synonym_a, *synonym_b, context);
+            AddDataSynonymFactRecursive(*synonym_a, *synonym_b);
           }
         }
       }
@@ -344,18 +344,19 @@ void DataSynonymAndIdEquationFacts::ComputeConversionDataSynonymFacts(
 }
 
 void DataSynonymAndIdEquationFacts::ComputeCompositeDataSynonymFacts(
-    const protobufs::DataDescriptor& dd1, const protobufs::DataDescriptor& dd2,
-    opt::IRContext* context) {
+    const protobufs::DataDescriptor& dd1,
+    const protobufs::DataDescriptor& dd2) {
   // Check whether this is a synonym about composite objects. If it is,
   // we can recursively add synonym facts about their associated sub-components.
 
   // Get the type of the object referred to by the first data descriptor in the
   // synonym fact.
   uint32_t type_id = fuzzerutil::WalkCompositeTypeIndices(
-      context, context->get_def_use_mgr()->GetDef(dd1.object())->type_id(),
+      ir_context_,
+      ir_context_->get_def_use_mgr()->GetDef(dd1.object())->type_id(),
       dd1.index());
-  auto type = context->get_type_mgr()->GetType(type_id);
-  auto type_instruction = context->get_def_use_mgr()->GetDef(type_id);
+  auto type = ir_context_->get_type_mgr()->GetType(type_id);
+  auto type_instruction = ir_context_->get_def_use_mgr()->GetDef(type_id);
   assert(type != nullptr &&
          "Invalid data synonym fact: one side has an unknown type.");
 
@@ -364,7 +365,7 @@ void DataSynonymAndIdEquationFacts::ComputeCompositeDataSynonymFacts(
   uint32_t num_composite_elements;
   if (type->AsArray()) {
     num_composite_elements =
-        fuzzerutil::GetArraySize(*type_instruction, context);
+        fuzzerutil::GetArraySize(*type_instruction, ir_context_);
   } else if (type->AsMatrix()) {
     num_composite_elements = type->AsMatrix()->element_count();
   } else if (type->AsStruct()) {
@@ -400,8 +401,7 @@ void DataSynonymAndIdEquationFacts::ComputeCompositeDataSynonymFacts(
     extended_indices2.push_back(i);
     AddDataSynonymFactRecursive(
         MakeDataDescriptor(dd1.object(), std::move(extended_indices1)),
-        MakeDataDescriptor(dd2.object(), std::move(extended_indices2)),
-        context);
+        MakeDataDescriptor(dd2.object(), std::move(extended_indices2)));
 
     if (i < kCompositeElementBound - 1 || i == num_composite_elements - 1) {
       // We have not reached the bound yet, or have already skipped ahead to the
@@ -416,7 +416,7 @@ void DataSynonymAndIdEquationFacts::ComputeCompositeDataSynonymFacts(
 }
 
 void DataSynonymAndIdEquationFacts::ComputeClosureOfFacts(
-    opt::IRContext* context, uint32_t maximum_equivalence_class_size) {
+    uint32_t maximum_equivalence_class_size) {
   // Suppose that obj_1[a_1, ..., a_m] and obj_2[b_1, ..., b_n] are distinct
   // data descriptors that describe objects of the same composite type, and that
   // the composite type is comprised of k components.
@@ -579,18 +579,18 @@ void DataSynonymAndIdEquationFacts::ComputeClosureOfFacts(
 
           // Get the type of obj_1
           auto dd1_root_type_id =
-              context->get_def_use_mgr()->GetDef(dd1->object())->type_id();
+              ir_context_->get_def_use_mgr()->GetDef(dd1->object())->type_id();
           // Use this type, together with a_1, ..., a_m, to get the type of
           // obj_1[a_1, ..., a_m].
           auto dd1_prefix_type = fuzzerutil::WalkCompositeTypeIndices(
-              context, dd1_root_type_id, dd1_prefix.index());
+              ir_context_, dd1_root_type_id, dd1_prefix.index());
 
           // Similarly, get the type of obj_2 and use it to get the type of
           // obj_2[b_1, ..., b_n].
           auto dd2_root_type_id =
-              context->get_def_use_mgr()->GetDef(dd2->object())->type_id();
+              ir_context_->get_def_use_mgr()->GetDef(dd2->object())->type_id();
           auto dd2_prefix_type = fuzzerutil::WalkCompositeTypeIndices(
-              context, dd2_root_type_id, dd2_prefix.index());
+              ir_context_, dd2_root_type_id, dd2_prefix.index());
 
           // If the types of dd1_prefix and dd2_prefix are not the same, they
           // cannot be synonymous.
@@ -614,12 +614,12 @@ void DataSynonymAndIdEquationFacts::ComputeClosureOfFacts(
           // or vector.
           uint32_t num_components_in_composite;
           auto composite_type =
-              context->get_type_mgr()->GetType(dd1_prefix_type);
+              ir_context_->get_type_mgr()->GetType(dd1_prefix_type);
           auto composite_type_instruction =
-              context->get_def_use_mgr()->GetDef(dd1_prefix_type);
+              ir_context_->get_def_use_mgr()->GetDef(dd1_prefix_type);
           if (composite_type->AsArray()) {
-            num_components_in_composite =
-                fuzzerutil::GetArraySize(*composite_type_instruction, context);
+            num_components_in_composite = fuzzerutil::GetArraySize(
+                *composite_type_instruction, ir_context_);
             if (num_components_in_composite == 0) {
               // This indicates that the array has an unknown size, in which
               // case we cannot be sure we have matched all of its elements with
@@ -683,8 +683,8 @@ void DataSynonymAndIdEquationFacts::ComputeClosureOfFacts(
             // have deduced that |dd1_prefix| and |dd2_prefix| are synonymous
             // by observing that all their sub-components are already
             // synonymous.
-            assert(DataDescriptorsAreWellFormedAndComparable(
-                context, dd1_prefix, dd2_prefix));
+            assert(DataDescriptorsAreWellFormedAndComparable(dd1_prefix,
+                                                             dd2_prefix));
             MakeEquivalent(dd1_prefix, dd2_prefix);
             // Now that we know this pair of data descriptors are synonymous,
             // there is no point recording how close they are to being
@@ -778,24 +778,26 @@ DataSynonymAndIdEquationFacts::RegisterDataDescriptor(
 }
 
 bool DataSynonymAndIdEquationFacts::DataDescriptorsAreWellFormedAndComparable(
-    opt::IRContext* context, const protobufs::DataDescriptor& dd1,
-    const protobufs::DataDescriptor& dd2) {
-  assert(context->get_def_use_mgr()->GetDef(dd1.object()) &&
-         context->get_def_use_mgr()->GetDef(dd2.object()) &&
+    const protobufs::DataDescriptor& dd1,
+    const protobufs::DataDescriptor& dd2) const {
+  assert(ir_context_->get_def_use_mgr()->GetDef(dd1.object()) &&
+         ir_context_->get_def_use_mgr()->GetDef(dd2.object()) &&
          "Both descriptors must exist in the module");
 
   auto end_type_id_1 = fuzzerutil::WalkCompositeTypeIndices(
-      context, fuzzerutil::GetTypeId(context, dd1.object()), dd1.index());
+      ir_context_, fuzzerutil::GetTypeId(ir_context_, dd1.object()),
+      dd1.index());
   auto end_type_id_2 = fuzzerutil::WalkCompositeTypeIndices(
-      context, fuzzerutil::GetTypeId(context, dd2.object()), dd2.index());
+      ir_context_, fuzzerutil::GetTypeId(ir_context_, dd2.object()),
+      dd2.index());
   // The end types of the data descriptors must exist.
   if (end_type_id_1 == 0 || end_type_id_2 == 0) {
     return false;
   }
   // Neither end type is allowed to be void.
-  if (context->get_def_use_mgr()->GetDef(end_type_id_1)->opcode() ==
+  if (ir_context_->get_def_use_mgr()->GetDef(end_type_id_1)->opcode() ==
           SpvOpTypeVoid ||
-      context->get_def_use_mgr()->GetDef(end_type_id_2)->opcode() ==
+      ir_context_->get_def_use_mgr()->GetDef(end_type_id_2)->opcode() ==
           SpvOpTypeVoid) {
     return false;
   }
@@ -807,8 +809,8 @@ bool DataSynonymAndIdEquationFacts::DataDescriptorsAreWellFormedAndComparable(
   // vectors that differ only in signedness.
 
   // Get both types.
-  const auto* type_a = context->get_type_mgr()->GetType(end_type_id_1);
-  const auto* type_b = context->get_type_mgr()->GetType(end_type_id_2);
+  const auto* type_a = ir_context_->get_type_mgr()->GetType(end_type_id_1);
+  const auto* type_b = ir_context_->get_type_mgr()->GetType(end_type_id_2);
   assert(type_a && type_b && "Data descriptors have invalid type(s)");
 
   // If both types are numerical or vectors of numerical components, then they

--- a/source/fuzz/fact_manager/data_synonym_and_id_equation_facts.h
+++ b/source/fuzz/fact_manager/data_synonym_and_id_equation_facts.h
@@ -36,21 +36,21 @@ class IrrelevantValueFacts;
 // facts about data synonyms and id equations.
 class DataSynonymAndIdEquationFacts {
  public:
+  explicit DataSynonymAndIdEquationFacts(opt::IRContext* ir_context);
+
   // See method in FactManager which delegates to this method.
   // |dead_block_facts| and |irrelevant_value_facts| are passed for consistency
   // checks.
   void AddFact(const protobufs::FactDataSynonym& fact,
                const DeadBlockFacts& dead_block_facts,
-               const IrrelevantValueFacts& irrelevant_value_facts,
-               opt::IRContext* context);
+               const IrrelevantValueFacts& irrelevant_value_facts);
 
   // See method in FactManager which delegates to this method.
   // |dead_block_facts| and |irrelevant_value_facts| are passed for consistency
   // checks.
   void AddFact(const protobufs::FactIdEquation& fact,
                const DeadBlockFacts& dead_block_facts,
-               const IrrelevantValueFacts& irrelevant_value_facts,
-               opt::IRContext* context);
+               const IrrelevantValueFacts& irrelevant_value_facts);
 
   // See method in FactManager which delegates to this method.
   std::vector<const protobufs::DataDescriptor*> GetSynonymsForId(
@@ -68,8 +68,7 @@ class DataSynonymAndIdEquationFacts {
                     const protobufs::DataDescriptor& data_descriptor2) const;
 
   // See method in FactManager which delegates to this method.
-  void ComputeClosureOfFacts(opt::IRContext* context,
-                             uint32_t maximum_equivalence_class_size);
+  void ComputeClosureOfFacts(uint32_t maximum_equivalence_class_size);
 
  private:
   // This helper struct represents the right hand side of an equation as an
@@ -96,20 +95,17 @@ class DataSynonymAndIdEquationFacts {
   // into sub-components of the data descriptors, if they are composites, to
   // record that their components are pairwise-synonymous.
   void AddDataSynonymFactRecursive(const protobufs::DataDescriptor& dd1,
-                                   const protobufs::DataDescriptor& dd2,
-                                   opt::IRContext* context);
+                                   const protobufs::DataDescriptor& dd2);
 
   // Computes various corollary facts from the data descriptor |dd| if members
   // of its equivalence class participate in equation facts with OpConvert*
   // opcodes. The descriptor should be registered in the equivalence relation.
-  void ComputeConversionDataSynonymFacts(const protobufs::DataDescriptor& dd,
-                                         opt::IRContext* context);
+  void ComputeConversionDataSynonymFacts(const protobufs::DataDescriptor& dd);
 
   // Recurses into sub-components of the data descriptors, if they are
   // composites, to record that their components are pairwise-synonymous.
   void ComputeCompositeDataSynonymFacts(const protobufs::DataDescriptor& dd1,
-                                        const protobufs::DataDescriptor& dd2,
-                                        opt::IRContext* context);
+                                        const protobufs::DataDescriptor& dd2);
 
   // Records the fact that |dd1| and |dd2| are equivalent, and merges the sets
   // of equations that are known about them.
@@ -126,9 +122,9 @@ class DataSynonymAndIdEquationFacts {
   // - they are the same
   // - they both are numerical or vectors of numerical components with the same
   //   number of components and the same bit count per component
-  static bool DataDescriptorsAreWellFormedAndComparable(
-      opt::IRContext* context, const protobufs::DataDescriptor& dd1,
-      const protobufs::DataDescriptor& dd2);
+  bool DataDescriptorsAreWellFormedAndComparable(
+      const protobufs::DataDescriptor& dd1,
+      const protobufs::DataDescriptor& dd2) const;
 
   OperationSet GetEquations(const protobufs::DataDescriptor* lhs) const;
 
@@ -140,8 +136,7 @@ class DataSynonymAndIdEquationFacts {
   // from this and other known facts.
   void AddEquationFactRecursive(
       const protobufs::DataDescriptor& lhs_dd, SpvOp opcode,
-      const std::vector<const protobufs::DataDescriptor*>& rhs_dds,
-      opt::IRContext* context);
+      const std::vector<const protobufs::DataDescriptor*>& rhs_dds);
 
   // The data descriptors that are known to be synonymous with one another are
   // captured by this equivalence relation.
@@ -166,6 +161,9 @@ class DataSynonymAndIdEquationFacts {
   // in that relation.
   std::unordered_map<const protobufs::DataDescriptor*, OperationSet>
       id_equations_;
+
+  // Pointer to the SPIR-V module we store facts about.
+  opt::IRContext* ir_context_;
 };
 
 }  // namespace fact_manager

--- a/source/fuzz/fact_manager/fact_manager.h
+++ b/source/fuzz/fact_manager/fact_manager.h
@@ -42,21 +42,22 @@ namespace fuzz {
 // the module.
 class FactManager {
  public:
+  explicit FactManager(opt::IRContext* ir_context);
+
   // Adds all the facts from |facts|, checking them for validity with respect to
   // |context|.  Warnings about invalid facts are communicated via
   // |message_consumer|; such facts are otherwise ignored.
   void AddFacts(const MessageConsumer& message_consumer,
-                const protobufs::FactSequence& facts, opt::IRContext* context);
+                const protobufs::FactSequence& facts);
 
   // Checks the fact for validity with respect to |context|.  Returns false,
   // with no side effects, if the fact is invalid.  Otherwise adds |fact| to the
   // fact manager.
-  bool AddFact(const protobufs::Fact& fact, opt::IRContext* context);
+  bool AddFact(const protobufs::Fact& fact);
 
   // Record the fact that |data1| and |data2| are synonymous.
   void AddFactDataSynonym(const protobufs::DataDescriptor& data1,
-                          const protobufs::DataDescriptor& data2,
-                          opt::IRContext* context);
+                          const protobufs::DataDescriptor& data2);
 
   // Records the fact that |block_id| is dead.
   void AddFactBlockIsDead(uint32_t block_id);
@@ -67,21 +68,19 @@ class FactManager {
   // Records the fact that the value of the pointee associated with |pointer_id|
   // is irrelevant: it does not affect the observable behaviour of the module.
   // |pointer_id| must exist in the module and actually be a pointer.
-  void AddFactValueOfPointeeIsIrrelevant(uint32_t pointer_id,
-                                         opt::IRContext* context);
+  void AddFactValueOfPointeeIsIrrelevant(uint32_t pointer_id);
 
   // Records a fact that the |result_id| is irrelevant (i.e. it doesn't affect
   // the semantics of the module).
   // |result_id| must exist in the module and actually be a pointer.
-  void AddFactIdIsIrrelevant(uint32_t result_id, opt::IRContext* context);
+  void AddFactIdIsIrrelevant(uint32_t result_id);
 
   // Records the fact that |lhs_id| is defined by the equation:
   //
   //   |lhs_id| = |opcode| |rhs_id[0]| ... |rhs_id[N-1]|
   //
   void AddFactIdEquation(uint32_t lhs_id, SpvOp opcode,
-                         const std::vector<uint32_t>& rhs_id,
-                         opt::IRContext* context);
+                         const std::vector<uint32_t>& rhs_id);
 
   // Inspects all known facts and adds corollary facts; e.g. if we know that
   // a.x == b.x and a.y == b.y, where a and b have vec2 type, we can record
@@ -95,8 +94,7 @@ class FactManager {
   // The parameter |maximum_equivalence_class_size| specifies the size beyond
   // which equivalence classes should not be mined for new facts, to avoid
   // excessively-long closure computations.
-  void ComputeClosureOfFacts(opt::IRContext* ir_context,
-                             uint32_t maximum_equivalence_class_size);
+  void ComputeClosureOfFacts(uint32_t maximum_equivalence_class_size);
 
   // The fact manager is responsible for managing a few distinct categories of
   // facts. In principle there could be different fact managers for each kind
@@ -116,20 +114,18 @@ class FactManager {
   // "constant == uniform element" fact is known.  If multiple identically-
   // valued constants are relevant, only one will appear in the sequence.
   std::vector<uint32_t> GetConstantsAvailableFromUniformsForType(
-      opt::IRContext* ir_context, uint32_t type_id) const;
+      uint32_t type_id) const;
 
   // Provides details of all uniform elements that are known to be equal to the
   // constant associated with |constant_id| in |ir_context|.
   std::vector<protobufs::UniformBufferElementDescriptor>
-  GetUniformDescriptorsForConstant(opt::IRContext* ir_context,
-                                   uint32_t constant_id) const;
+  GetUniformDescriptorsForConstant(uint32_t constant_id) const;
 
   // Returns the id of a constant whose value is known to match that of
   // |uniform_descriptor|, and whose type matches the type of the uniform
   // element.  If multiple such constant is exist, the one that is returned
   // is arbitrary.  Returns 0 if no such constant id exists.
   uint32_t GetConstantFromUniformDescriptor(
-      opt::IRContext* context,
       const protobufs::UniformBufferElementDescriptor& uniform_descriptor)
       const;
 
@@ -196,11 +192,11 @@ class FactManager {
 
   // Returns true if there exists a fact that the |result_id| is irrelevant or
   // if |result_id| is declared in a block that has been declared dead.
-  bool IdIsIrrelevant(uint32_t result_id, opt::IRContext* context) const;
+  bool IdIsIrrelevant(uint32_t result_id) const;
 
   // Returns a set of all the ids which have been declared irrelevant, or which
   // have been declared inside a dead block.
-  std::unordered_set<uint32_t> GetIrrelevantIds(opt::IRContext* context) const;
+  std::unordered_set<uint32_t> GetIrrelevantIds() const;
 
   // End of irrelevant value facts
   //==============================

--- a/source/fuzz/fact_manager/irrelevant_value_facts.h
+++ b/source/fuzz/fact_manager/irrelevant_value_facts.h
@@ -33,21 +33,21 @@ class DeadBlockFacts;
 // facts about various irrelevant values in the module.
 class IrrelevantValueFacts {
  public:
+  explicit IrrelevantValueFacts(opt::IRContext* ir_context);
+
   // See method in FactManager which delegates to this method.
   // |data_synonym_and_id_equation_facts| and |context| are passed for
   // consistency checks.
   void AddFact(
       const protobufs::FactPointeeValueIsIrrelevant& fact,
-      const DataSynonymAndIdEquationFacts& data_synonym_and_id_equation_facts,
-      opt::IRContext* context);
+      const DataSynonymAndIdEquationFacts& data_synonym_and_id_equation_facts);
 
   // See method in FactManager which delegates to this method.
   // |data_synonym_and_id_equation_facts| and |context| are passed for
   // consistency checks.
   void AddFact(
       const protobufs::FactIdIsIrrelevant& fact,
-      const DataSynonymAndIdEquationFacts& data_synonym_and_id_equation_facts,
-      opt::IRContext* context);
+      const DataSynonymAndIdEquationFacts& data_synonym_and_id_equation_facts);
 
   // See method in FactManager which delegates to this method.
   bool PointeeValueIsIrrelevant(uint32_t pointer_id) const;
@@ -56,18 +56,18 @@ class IrrelevantValueFacts {
   // |dead_block_facts| and |context| are passed to check whether |result_id| is
   // declared inside a dead block, in which case it is irrelevant.
   bool IdIsIrrelevant(uint32_t result_id,
-                      const DeadBlockFacts& dead_block_facts,
-                      opt::IRContext* context) const;
+                      const DeadBlockFacts& dead_block_facts) const;
 
   // See method in FactManager which delegates to this method.
   // |dead_block_facts| and |context| are passed to also add all the ids
   // declared in dead blocks to the set of irrelevant ids.
   std::unordered_set<uint32_t> GetIrrelevantIds(
-      const DeadBlockFacts& dead_block_facts, opt::IRContext* context) const;
+      const DeadBlockFacts& dead_block_facts) const;
 
  private:
   std::unordered_set<uint32_t> pointers_to_irrelevant_pointees_ids_;
   std::unordered_set<uint32_t> irrelevant_ids_;
+  opt::IRContext* ir_context_;
 };
 
 }  // namespace fact_manager

--- a/source/fuzz/force_render_red.cpp
+++ b/source/fuzz/force_render_red.cpp
@@ -150,7 +150,7 @@ MakeConstantUniformReplacement(opt::IRContext* ir_context,
                           MakeInstructionDescriptor(greater_than_instruction,
                                                     SpvOpFOrdGreaterThan, 0),
                           in_operand_index),
-      fact_manager.GetUniformDescriptorsForConstant(ir_context, constant_id)[0],
+      fact_manager.GetUniformDescriptorsForConstant(constant_id)[0],
       ir_context->TakeNextId(), ir_context->TakeNextId());
 }
 
@@ -182,9 +182,9 @@ bool ForceRenderRed(
   assert(ir_context);
 
   // Set up a fact manager with any given initial facts.
-  FactManager fact_manager;
+  FactManager fact_manager(ir_context.get());
   for (auto& fact : initial_facts.fact()) {
-    fact_manager.AddFact(fact, ir_context.get());
+    fact_manager.AddFact(fact);
   }
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -273,8 +273,7 @@ bool ForceRenderRed(
       // We have at least one float uniform; let's see whether we have at least
       // two.
       auto available_constants =
-          fact_manager.GetConstantsAvailableFromUniformsForType(
-              ir_context.get(), float_type_id);
+          fact_manager.GetConstantsAvailableFromUniformsForType(float_type_id);
       if (available_constants.size() > 1) {
         // Grab the float constants associated with the first two known float
         // uniforms.

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -211,8 +211,8 @@ Fuzzer::FuzzerResult Fuzzer::Run() {
   fuzzer_context_ =
       MakeUnique<FuzzerContext>(random_generator_.get(), minimum_fresh_id);
 
-  FactManager fact_manager;
-  fact_manager.AddFacts(consumer_, initial_facts_, ir_context_.get());
+  FactManager fact_manager(ir_context_.get());
+  fact_manager.AddFacts(consumer_, initial_facts_);
   transformation_context_ =
       MakeUnique<TransformationContext>(&fact_manager, validator_options_);
 

--- a/source/fuzz/fuzzer_pass_add_dead_breaks.cpp
+++ b/source/fuzz/fuzzer_pass_add_dead_breaks.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/fuzzer_pass_add_dead_breaks.h"
+
 #include "source/fuzz/fuzzer_util.h"
 #include "source/fuzz/transformation_add_dead_break.h"
 #include "source/opt/ir_context.h"

--- a/source/fuzz/fuzzer_pass_add_dead_continues.cpp
+++ b/source/fuzz/fuzzer_pass_add_dead_continues.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/fuzzer_pass_add_dead_continues.h"
+
 #include "source/fuzz/fuzzer_util.h"
 #include "source/fuzz/transformation_add_dead_continue.h"
 #include "source/opt/ir_context.h"

--- a/source/fuzz/fuzzer_pass_add_equation_instructions.cpp
+++ b/source/fuzz/fuzzer_pass_add_equation_instructions.cpp
@@ -77,14 +77,13 @@ void FuzzerPassAddEquationInstructions::Apply() {
         std::vector<opt::Instruction*> available_instructions =
             FindAvailableInstructions(
                 function, block, inst_it,
-                [this](opt::IRContext* ir_context,
+                [this](opt::IRContext* /*unused*/,
                        opt::Instruction* instruction) -> bool {
                   return instruction->result_id() && instruction->type_id() &&
                          instruction->opcode() != SpvOpUndef &&
                          !GetTransformationContext()
                               ->GetFactManager()
-                              ->IdIsIrrelevant(instruction->result_id(),
-                                               ir_context);
+                              ->IdIsIrrelevant(instruction->result_id());
                 });
 
         // Try the opcodes for which we know how to make ids at random until

--- a/source/fuzz/fuzzer_pass_add_opphi_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_add_opphi_synonyms.cpp
@@ -157,7 +157,7 @@ FuzzerPassAddOpPhiSynonyms::GetIdEquivalenceClasses() {
 
     // Exclude irrelevant ids.
     if (GetTransformationContext()->GetFactManager()->IdIsIrrelevant(
-            pair.first, GetIRContext())) {
+            pair.first)) {
       continue;
     }
 
@@ -195,7 +195,7 @@ FuzzerPassAddOpPhiSynonyms::GetIdEquivalenceClasses() {
 
       // The synonym must not be irrelevant.
       if (GetTransformationContext()->GetFactManager()->IdIsIrrelevant(
-              synonym->object(), GetIRContext())) {
+              synonym->object())) {
         continue;
       }
 

--- a/source/fuzz/fuzzer_pass_add_vector_shuffle_instructions.cpp
+++ b/source/fuzz/fuzzer_pass_add_vector_shuffle_instructions.cpp
@@ -75,8 +75,7 @@ void FuzzerPassAddVectorShuffleInstructions::Apply() {
 
                   if (!GetTransformationContext()
                            ->GetFactManager()
-                           ->IdIsIrrelevant(instruction->result_id(),
-                                            GetIRContext()) &&
+                           ->IdIsIrrelevant(instruction->result_id()) &&
                       !fuzzerutil::CanMakeSynonymOf(ir_context,
                                                     *GetTransformationContext(),
                                                     instruction)) {

--- a/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
@@ -148,7 +148,7 @@ void FuzzerPassApplyIdSynonyms::Apply() {
           }
 
           assert(!GetTransformationContext()->GetFactManager()->IdIsIrrelevant(
-                     synonym_to_try->object(), GetIRContext()) &&
+                     synonym_to_try->object()) &&
                  "Irrelevant ids can't participate in DataSynonym facts");
           ApplyTransformation(TransformationCompositeExtract(
               MakeInstructionDescriptor(GetIRContext(),

--- a/source/fuzz/fuzzer_pass_construct_composites.cpp
+++ b/source/fuzz/fuzzer_pass_construct_composites.cpp
@@ -77,7 +77,7 @@ void FuzzerPassConstructComposites::Apply() {
               // to produce a synonym out of the id.
               return GetTransformationContext()
                          ->GetFactManager()
-                         ->IdIsIrrelevant(inst->result_id(), GetIRContext()) ||
+                         ->IdIsIrrelevant(inst->result_id()) ||
                      fuzzerutil::CanMakeSynonymOf(
                          ir_context, *GetTransformationContext(), inst);
             });

--- a/source/fuzz/fuzzer_pass_construct_composites.h
+++ b/source/fuzz/fuzzer_pass_construct_composites.h
@@ -15,10 +15,10 @@
 #ifndef SOURCE_FUZZ_FUZZER_PASS_CONSTRUCT_COMPOSITES_H_
 #define SOURCE_FUZZ_FUZZER_PASS_CONSTRUCT_COMPOSITES_H_
 
-#include "source/fuzz/fuzzer_pass.h"
-
 #include <map>
 #include <vector>
+
+#include "source/fuzz/fuzzer_pass.h"
 
 namespace spvtools {
 namespace fuzz {

--- a/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.cpp
+++ b/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/fuzzer_pass_duplicate_regions_with_selections.h"
+
 #include "source/fuzz/fuzzer_util.h"
 #include "source/fuzz/transformation_duplicate_region_with_selection.h"
 

--- a/source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.cpp
+++ b/source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.cpp
@@ -48,7 +48,7 @@ void FuzzerPassInterchangeSignednessOfIntegerOperands::Apply() {
     // constant with opposite signedness, and this can only be done if they are
     // not irrelevant.
     if (GetTransformationContext()->GetFactManager()->IdIsIrrelevant(
-            constant_id, GetIRContext())) {
+            constant_id)) {
       continue;
     }
 
@@ -60,7 +60,7 @@ void FuzzerPassInterchangeSignednessOfIntegerOperands::Apply() {
     }
 
     assert(!GetTransformationContext()->GetFactManager()->IdIsIrrelevant(
-               toggled_id, GetIRContext()) &&
+               toggled_id) &&
            "FindOrCreateToggledConstant can't produce an irrelevant id");
 
     // Record synonymous constants

--- a/source/fuzz/fuzzer_pass_interchange_zero_like_constants.cpp
+++ b/source/fuzz/fuzzer_pass_interchange_zero_like_constants.cpp
@@ -73,7 +73,7 @@ void FuzzerPassInterchangeZeroLikeConstants::Apply() {
   for (auto constant : GetIRContext()->GetConstants()) {
     uint32_t constant_id = constant->result_id();
     if (GetTransformationContext()->GetFactManager()->IdIsIrrelevant(
-            constant_id, GetIRContext())) {
+            constant_id)) {
       continue;
     }
 
@@ -84,7 +84,7 @@ void FuzzerPassInterchangeZeroLikeConstants::Apply() {
     }
 
     assert(!GetTransformationContext()->GetFactManager()->IdIsIrrelevant(
-               toggled_id, GetIRContext()) &&
+               toggled_id) &&
            "FindOrCreateToggledConstant can't produce an irrelevant id");
 
     // Record synonymous constants

--- a/source/fuzz/fuzzer_pass_obfuscate_constants.cpp
+++ b/source/fuzz/fuzzer_pass_obfuscate_constants.cpp
@@ -347,8 +347,7 @@ void FuzzerPassObfuscateConstants::ObfuscateScalarConstant(
   auto uniform_descriptors =
       GetTransformationContext()
           ->GetFactManager()
-          ->GetUniformDescriptorsForConstant(GetIRContext(),
-                                             constant_use.id_of_interest());
+          ->GetUniformDescriptorsForConstant(constant_use.id_of_interest());
   if (uniform_descriptors.empty()) {
     // No relevant uniforms, so do not obfuscate.
     return;

--- a/source/fuzz/fuzzer_pass_permute_function_parameters.cpp
+++ b/source/fuzz/fuzzer_pass_permute_function_parameters.cpp
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "source/fuzz/fuzzer_pass_permute_function_parameters.h"
+
 #include <numeric>
 #include <vector>
 
 #include "source/fuzz/fuzzer_context.h"
-#include "source/fuzz/fuzzer_pass_permute_function_parameters.h"
 #include "source/fuzz/fuzzer_util.h"
 #include "source/fuzz/instruction_descriptor.h"
 #include "source/fuzz/transformation_permute_function_parameters.h"

--- a/source/fuzz/fuzzer_pass_permute_phi_operands.cpp
+++ b/source/fuzz/fuzzer_pass_permute_phi_operands.cpp
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "source/fuzz/fuzzer_pass_permute_phi_operands.h"
+
 #include <numeric>
 #include <vector>
 
 #include "source/fuzz/fuzzer_context.h"
-#include "source/fuzz/fuzzer_pass_permute_phi_operands.h"
 #include "source/fuzz/fuzzer_util.h"
 #include "source/fuzz/instruction_descriptor.h"
 #include "source/fuzz/transformation_permute_phi_operands.h"

--- a/source/fuzz/fuzzer_pass_push_ids_through_variables.cpp
+++ b/source/fuzz/fuzzer_pass_push_ids_through_variables.cpp
@@ -96,8 +96,7 @@ void FuzzerPassPushIdsThroughVariables::Apply() {
                   // able to produce a synonym out of the id.
                   if (!GetTransformationContext()
                            ->GetFactManager()
-                           ->IdIsIrrelevant(instruction->result_id(),
-                                            GetIRContext()) &&
+                           ->IdIsIrrelevant(instruction->result_id()) &&
                       !fuzzerutil::CanMakeSynonymOf(ir_context,
                                                     *GetTransformationContext(),
                                                     instruction)) {

--- a/source/fuzz/fuzzer_pass_replace_irrelevant_ids.cpp
+++ b/source/fuzz/fuzzer_pass_replace_irrelevant_ids.cpp
@@ -46,8 +46,8 @@ void FuzzerPassReplaceIrrelevantIds::Apply() {
 
   // Find all the irrelevant ids that still exist in the module and all the
   // types for which irrelevant ids exist.
-  for (auto id : GetTransformationContext()->GetFactManager()->GetIrrelevantIds(
-           GetIRContext())) {
+  for (auto id :
+       GetTransformationContext()->GetFactManager()->GetIrrelevantIds()) {
     // Check that the id still exists in the module.
     auto declaration = GetIRContext()->get_def_use_mgr()->GetDef(id);
     if (!declaration) {

--- a/source/fuzz/fuzzer_pass_replace_opphi_ids_from_dead_predecessors.cpp
+++ b/source/fuzz/fuzzer_pass_replace_opphi_ids_from_dead_predecessors.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/fuzzer_pass_replace_opphi_ids_from_dead_predecessors.h"
+
 #include "source/fuzz/transformation_replace_opphi_id_from_dead_predecessor.h"
 
 namespace spvtools {
@@ -80,7 +81,6 @@ void FuzzerPassReplaceOpPhiIdsFromDeadPredecessors::Apply() {
                 &function, &block, block.end(),
                 [type_id, current_id](opt::IRContext* /* unused */,
                                       opt::Instruction* candidate) -> bool {
-
                   // Only consider instructions with a result id different from
                   // the currently-used one, and with the right type.
                   return candidate->HasResultId() &&

--- a/source/fuzz/fuzzer_pass_swap_conditional_branch_operands.cpp
+++ b/source/fuzz/fuzzer_pass_swap_conditional_branch_operands.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/fuzzer_pass_swap_conditional_branch_operands.h"
+
 #include "source/fuzz/fuzzer_context.h"
 #include "source/fuzz/fuzzer_util.h"
 #include "source/fuzz/instruction_descriptor.h"

--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -33,7 +33,7 @@ uint32_t MaybeGetOpConstant(opt::IRContext* ir_context,
     if (inst.opcode() == SpvOpConstant && inst.type_id() == type_id &&
         inst.GetInOperand(0).words == words &&
         transformation_context.GetFactManager()->IdIsIrrelevant(
-            inst.result_id(), ir_context) == is_irrelevant) {
+            inst.result_id()) == is_irrelevant) {
       return inst.result_id();
     }
   }
@@ -261,8 +261,8 @@ bool CanMakeSynonymOf(opt::IRContext* ir_context,
     // We can only make a synonym of an instruction that generates an id.
     return false;
   }
-  if (transformation_context.GetFactManager()->IdIsIrrelevant(inst->result_id(),
-                                                              ir_context)) {
+  if (transformation_context.GetFactManager()->IdIsIrrelevant(
+          inst->result_id())) {
     // An irrelevant id can't be a synonym of anything.
     return false;
   }
@@ -1149,7 +1149,7 @@ uint32_t MaybeGetCompositeConstant(
     if (inst.opcode() == SpvOpConstantComposite &&
         inst.type_id() == composite_type_id &&
         transformation_context.GetFactManager()->IdIsIrrelevant(
-            inst.result_id(), ir_context) == is_irrelevant &&
+            inst.result_id()) == is_irrelevant &&
         inst.NumInOperands() == component_ids.size()) {
       bool is_match = true;
 
@@ -1229,7 +1229,7 @@ uint32_t MaybeGetBoolConstant(
       if (inst.opcode() == (value ? SpvOpConstantTrue : SpvOpConstantFalse) &&
           inst.type_id() == type_id &&
           transformation_context.GetFactManager()->IdIsIrrelevant(
-              inst.result_id(), ir_context) == is_irrelevant) {
+              inst.result_id()) == is_irrelevant) {
         return inst.result_id();
       }
     }

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -428,7 +428,7 @@ message Transformation {
     TransformationAddTypeInt add_type_int = 7;
     TransformationAddDeadBreak add_dead_break = 8;
     TransformationReplaceBooleanConstantWithConstantBinary
-      replace_boolean_constant_with_constant_binary = 9;
+        replace_boolean_constant_with_constant_binary = 9;
     TransformationAddTypePointer add_type_pointer = 10;
     TransformationReplaceConstantWithUniform replace_constant_with_uniform = 11;
     TransformationAddDeadContinue add_dead_continue = 12;
@@ -1678,19 +1678,19 @@ message TransformationRecordSynonymousConstants {
 
 message TransformationReplaceAddSubMulWithCarryingExtended {
 
-   // Replaces OpIAdd with OpIAddCarry, OpISub with OpISubBorrow, OpIMul
-   // with OpUMulExtended or OpSMulExtended (depending on the signedness
-   // of the operands) and stores the result into a |struct_fresh_id|.
-   // In the original instruction the result type id and the type ids of
-   // the operands must be the same. Then the transformation extracts
-   // the first element of the result into the original |result_id|.
-   // This value is the same as the result of the original instruction.
+  // Replaces OpIAdd with OpIAddCarry, OpISub with OpISubBorrow, OpIMul
+  // with OpUMulExtended or OpSMulExtended (depending on the signedness
+  // of the operands) and stores the result into a |struct_fresh_id|.
+  // In the original instruction the result type id and the type ids of
+  // the operands must be the same. Then the transformation extracts
+  // the first element of the result into the original |result_id|.
+  // This value is the same as the result of the original instruction.
 
-   // The fresh id of the intermediate result.
-   uint32 struct_fresh_id = 1;
+  // The fresh id of the intermediate result.
+  uint32 struct_fresh_id = 1;
 
-   // The result id of the original instruction.
-   uint32 result_id = 2;
+  // The result id of the original instruction.
+  uint32 result_id = 2;
 
 }
 
@@ -1754,16 +1754,16 @@ message TransformationReplaceConstantWithUniform {
 
 message TransformationReplaceCopyMemoryWithLoadStore {
 
-   // A transformation that replaces instructions OpCopyMemory with loading
-   // the source variable to an intermediate value and storing this value into the
-   // target variable of the original OpCopyMemory instruction.
+  // A transformation that replaces instructions OpCopyMemory with loading
+  // the source variable to an intermediate value and storing this value into the
+  // target variable of the original OpCopyMemory instruction.
 
-   // The intermediate value.
-   uint32 fresh_id = 1;
+  // The intermediate value.
+  uint32 fresh_id = 1;
 
-   // The instruction descriptor to OpCopyMemory. It is necessary, because
-   // OpCopyMemory doesn't have a result id.
-   InstructionDescriptor copy_memory_instruction_descriptor = 2;
+  // The instruction descriptor to OpCopyMemory. It is necessary, because
+  // OpCopyMemory doesn't have a result id.
+  InstructionDescriptor copy_memory_instruction_descriptor = 2;
 }
 
 message TransformationReplaceCopyObjectWithStoreLoad {

--- a/source/fuzz/replayer.cpp
+++ b/source/fuzz/replayer.cpp
@@ -90,8 +90,8 @@ Replayer::ReplayerResult Replayer::Run() {
     last_valid_binary = binary_in_;
   }
 
-  FactManager fact_manager;
-  fact_manager.AddFacts(consumer_, initial_facts_, ir_context.get());
+  FactManager fact_manager(ir_context.get());
+  fact_manager.AddFacts(consumer_, initial_facts_);
   std::unique_ptr<TransformationContext> transformation_context =
       first_overflow_id_ == 0
           ? MakeUnique<TransformationContext>(&fact_manager, validator_options_)

--- a/source/fuzz/transformation_access_chain.cpp
+++ b/source/fuzz/transformation_access_chain.cpp
@@ -339,7 +339,7 @@ void TransformationAccessChain::Apply(
   if (transformation_context->GetFactManager()->PointeeValueIsIrrelevant(
           message_.pointer_id())) {
     transformation_context->GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-        message_.fresh_id(), ir_context);
+        message_.fresh_id());
   }
 }
 

--- a/source/fuzz/transformation_add_bit_instruction_synonym.cpp
+++ b/source/fuzz/transformation_add_bit_instruction_synonym.cpp
@@ -221,7 +221,7 @@ void TransformationAddBitInstructionSynonym::AddBitwiseSynonym(
   // |bit_instruction|.
   transformation_context->GetFactManager()->AddFactDataSynonym(
       MakeDataDescriptor(bit_insert.result_id(), {}),
-      MakeDataDescriptor(bit_instruction->result_id(), {}), ir_context);
+      MakeDataDescriptor(bit_instruction->result_id(), {}));
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_constant_boolean.cpp
+++ b/source/fuzz/transformation_add_constant_boolean.cpp
@@ -53,7 +53,7 @@ void TransformationAddConstantBoolean::Apply(
 
   if (message_.is_irrelevant()) {
     transformation_context->GetFactManager()->AddFactIdIsIrrelevant(
-        message_.fresh_id(), ir_context);
+        message_.fresh_id());
   }
 }
 

--- a/source/fuzz/transformation_add_constant_composite.cpp
+++ b/source/fuzz/transformation_add_constant_composite.cpp
@@ -122,7 +122,7 @@ void TransformationAddConstantComposite::Apply(
 
   if (message_.is_irrelevant()) {
     transformation_context->GetFactManager()->AddFactIdIsIrrelevant(
-        message_.fresh_id(), ir_context);
+        message_.fresh_id());
   }
 }
 

--- a/source/fuzz/transformation_add_constant_scalar.cpp
+++ b/source/fuzz/transformation_add_constant_scalar.cpp
@@ -80,7 +80,7 @@ void TransformationAddConstantScalar::Apply(
 
   if (message_.is_irrelevant()) {
     transformation_context->GetFactManager()->AddFactIdIsIrrelevant(
-        message_.fresh_id(), ir_context);
+        message_.fresh_id());
   }
 }
 

--- a/source/fuzz/transformation_add_copy_memory.cpp
+++ b/source/fuzz/transformation_add_copy_memory.cpp
@@ -143,7 +143,7 @@ void TransformationAddCopyMemory::Apply(
   // about the destination pointer, and record this fact so that the destination
   // pointer can be used freely by other fuzzer passes.
   transformation_context->GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      message_.fresh_id(), ir_context);
+      message_.fresh_id());
 }
 
 protobufs::Transformation TransformationAddCopyMemory::ToMessage() const {

--- a/source/fuzz/transformation_add_function.cpp
+++ b/source/fuzz/transformation_add_function.cpp
@@ -203,14 +203,12 @@ void TransformationAddFunction::Apply(
                 ->GetDef(instruction.result_type_id())
                 ->opcode() == SpvOpTypePointer) {
           transformation_context->GetFactManager()
-              ->AddFactValueOfPointeeIsIrrelevant(instruction.result_id(),
-                                                  ir_context);
+              ->AddFactValueOfPointeeIsIrrelevant(instruction.result_id());
         }
         break;
       case SpvOpVariable:
         transformation_context->GetFactManager()
-            ->AddFactValueOfPointeeIsIrrelevant(instruction.result_id(),
-                                                ir_context);
+            ->AddFactValueOfPointeeIsIrrelevant(instruction.result_id());
         break;
       default:
         break;

--- a/source/fuzz/transformation_add_global_variable.cpp
+++ b/source/fuzz/transformation_add_global_variable.cpp
@@ -105,7 +105,7 @@ void TransformationAddGlobalVariable::Apply(
 
   if (message_.value_is_irrelevant()) {
     transformation_context->GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-        message_.fresh_id(), ir_context);
+        message_.fresh_id());
   }
 }
 

--- a/source/fuzz/transformation_add_local_variable.cpp
+++ b/source/fuzz/transformation_add_local_variable.cpp
@@ -78,7 +78,7 @@ void TransformationAddLocalVariable::Apply(
 
   if (message_.value_is_irrelevant()) {
     transformation_context->GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-        message_.fresh_id(), ir_context);
+        message_.fresh_id());
   }
 }
 

--- a/source/fuzz/transformation_add_loop_preheader.cpp
+++ b/source/fuzz/transformation_add_loop_preheader.cpp
@@ -104,7 +104,6 @@ void TransformationAddLoopPreheader::Apply(
       loop_header->id(),
       [this, &ir_context, &dominator_analysis, &loop_header,
        &back_edge_block_id](opt::Instruction* use_inst, uint32_t use_index) {
-
         if (dominator_analysis->Dominates(loop_header->GetLabelInst(),
                                           use_inst)) {
           // If |use_inst| is a branch instruction dominated by the header, the
@@ -144,7 +143,6 @@ void TransformationAddLoopPreheader::Apply(
   loop_header->ForEachPhiInst([this, &ir_context, &preheader,
                                &back_edge_block_id,
                                &phi_ids_used](opt::Instruction* phi_inst) {
-
     // The loop header must have at least 2 incoming edges (the back edge, and
     // at least one from outside the loop).
     assert(phi_inst->NumInOperands() >= 4);

--- a/source/fuzz/transformation_add_loop_to_create_int_constant_synonym.cpp
+++ b/source/fuzz/transformation_add_loop_to_create_int_constant_synonym.cpp
@@ -413,7 +413,7 @@ void TransformationAddLoopToCreateIntConstantSynonym::Apply(
   // Record that |message_.syn_id| is synonymous with |message_.constant_id|.
   transformation_context->GetFactManager()->AddFactDataSynonym(
       MakeDataDescriptor(message_.syn_id(), {}),
-      MakeDataDescriptor(message_.constant_id(), {}), ir_context);
+      MakeDataDescriptor(message_.constant_id(), {}));
 }
 
 protobufs::Transformation

--- a/source/fuzz/transformation_add_opphi_synonym.cpp
+++ b/source/fuzz/transformation_add_opphi_synonym.cpp
@@ -155,7 +155,7 @@ void TransformationAddOpPhiSynonym::Apply(
   // that it is a synonym of the first one.
   transformation_context->GetFactManager()->AddFactDataSynonym(
       MakeDataDescriptor(message_.fresh_id(), {}),
-      MakeDataDescriptor(first_id, {}), ir_context);
+      MakeDataDescriptor(first_id, {}));
 }
 
 protobufs::Transformation TransformationAddOpPhiSynonym::ToMessage() const {

--- a/source/fuzz/transformation_add_parameter.cpp
+++ b/source/fuzz/transformation_add_parameter.cpp
@@ -161,10 +161,10 @@ void TransformationAddParameter::Apply(
   // of a pointer type we mark it with PointeeValueIsIrrelevant.
   if (new_parameter_kind != opt::analysis::Type::kPointer) {
     transformation_context->GetFactManager()->AddFactIdIsIrrelevant(
-        message_.parameter_fresh_id(), ir_context);
+        message_.parameter_fresh_id());
   } else {
     transformation_context->GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-        message_.parameter_fresh_id(), ir_context);
+        message_.parameter_fresh_id());
   }
 }
 

--- a/source/fuzz/transformation_add_spec_constant_op.cpp
+++ b/source/fuzz/transformation_add_spec_constant_op.cpp
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "source/fuzz/transformation_add_spec_constant_op.h"
+
 #include <utility>
 
 #include "source/fuzz/fuzzer_util.h"
-#include "source/fuzz/transformation_add_spec_constant_op.h"
 
 namespace spvtools {
 namespace fuzz {

--- a/source/fuzz/transformation_add_synonym.cpp
+++ b/source/fuzz/transformation_add_synonym.cpp
@@ -109,13 +109,13 @@ void TransformationAddSynonym::Apply(
           message_.result_id()) &&
       new_synonym_type->AsPointer()) {
     transformation_context->GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-        message_.synonym_fresh_id(), ir_context);
+        message_.synonym_fresh_id());
   }
 
   // Mark two ids as synonymous.
   transformation_context->GetFactManager()->AddFactDataSynonym(
       MakeDataDescriptor(message_.result_id(), {}),
-      MakeDataDescriptor(message_.synonym_fresh_id(), {}), ir_context);
+      MakeDataDescriptor(message_.synonym_fresh_id(), {}));
 }
 
 protobufs::Transformation TransformationAddSynonym::ToMessage() const {

--- a/source/fuzz/transformation_composite_construct.cpp
+++ b/source/fuzz/transformation_composite_construct.cpp
@@ -96,8 +96,7 @@ bool TransformationCompositeConstruct::IsApplicable(
 
     // We should be able to create a synonym of |component| if it's not
     // irrelevant.
-    if (!transformation_context.GetFactManager()->IdIsIrrelevant(component,
-                                                                 ir_context) &&
+    if (!transformation_context.GetFactManager()->IdIsIrrelevant(component) &&
         !fuzzerutil::CanMakeSynonymOf(ir_context, transformation_context,
                                       inst)) {
       return false;
@@ -160,10 +159,10 @@ void TransformationCompositeConstruct::Apply(
            subvector_index < component_type->AsVector()->element_count();
            subvector_index++) {
         if (!transformation_context->GetFactManager()->IdIsIrrelevant(
-                component, ir_context)) {
+                component)) {
           transformation_context->GetFactManager()->AddFactDataSynonym(
               MakeDataDescriptor(component, {subvector_index}),
-              MakeDataDescriptor(message_.fresh_id(), {index}), ir_context);
+              MakeDataDescriptor(message_.fresh_id(), {index}));
         }
         index++;
       }
@@ -171,10 +170,10 @@ void TransformationCompositeConstruct::Apply(
       // The other cases are simple: the component is made directly synonymous
       // with the element of the composite being constructed.
       if (!transformation_context->GetFactManager()->IdIsIrrelevant(
-              component, ir_context)) {
+              component)) {
         transformation_context->GetFactManager()->AddFactDataSynonym(
             MakeDataDescriptor(component, {}),
-            MakeDataDescriptor(message_.fresh_id(), {index}), ir_context);
+            MakeDataDescriptor(message_.fresh_id(), {index}));
       }
       index++;
     }

--- a/source/fuzz/transformation_composite_extract.cpp
+++ b/source/fuzz/transformation_composite_extract.cpp
@@ -56,7 +56,7 @@ bool TransformationCompositeExtract::IsApplicable(
     return false;
   }
   if (!transformation_context.GetFactManager()->IdIsIrrelevant(
-          message_.composite_id(), ir_context) &&
+          message_.composite_id()) &&
       !fuzzerutil::CanMakeSynonymOf(ir_context, transformation_context,
                                     composite_instruction)) {
     // |composite_id| will participate in DataSynonym facts. Thus, it can't be
@@ -115,7 +115,7 @@ void TransformationCompositeExtract::Apply(
   // Add the fact that the id storing the extracted element is synonymous with
   // the index into the structure.
   if (!transformation_context->GetFactManager()->IdIsIrrelevant(
-          message_.composite_id(), ir_context)) {
+          message_.composite_id())) {
     std::vector<uint32_t> indices;
     for (auto an_index : message_.index()) {
       indices.push_back(an_index);
@@ -125,8 +125,7 @@ void TransformationCompositeExtract::Apply(
     protobufs::DataDescriptor data_descriptor_for_result_id =
         MakeDataDescriptor(message_.fresh_id(), {});
     transformation_context->GetFactManager()->AddFactDataSynonym(
-        data_descriptor_for_extracted_element, data_descriptor_for_result_id,
-        ir_context);
+        data_descriptor_for_extracted_element, data_descriptor_for_result_id);
   }
 }
 

--- a/source/fuzz/transformation_composite_insert.cpp
+++ b/source/fuzz/transformation_composite_insert.cpp
@@ -143,7 +143,7 @@ void TransformationCompositeInsert::Apply(
 
   // If |composite_id| is irrelevant then don't add any synonyms.
   if (transformation_context->GetFactManager()->IdIsIrrelevant(
-          message_.composite_id(), ir_context)) {
+          message_.composite_id())) {
     return;
   }
   uint32_t current_node_type_id = composite_type_id;
@@ -174,8 +174,7 @@ void TransformationCompositeInsert::Apply(
           MakeDataDescriptor(message_.fresh_id(),
                              std::vector<uint32_t>(current_index)),
           MakeDataDescriptor(message_.composite_id(),
-                             std::vector<uint32_t>(current_index)),
-          ir_context);
+                             std::vector<uint32_t>(current_index)));
       current_index.pop_back();
     }
     // Store the prefix of the |index|.
@@ -184,11 +183,10 @@ void TransformationCompositeInsert::Apply(
   // The element which has been changed is synonymous to the found object
   // itself. Add this fact only if |object_id| is not irrelevant.
   if (!transformation_context->GetFactManager()->IdIsIrrelevant(
-          message_.object_id(), ir_context)) {
+          message_.object_id())) {
     transformation_context->GetFactManager()->AddFactDataSynonym(
         MakeDataDescriptor(message_.object_id(), {}),
-        MakeDataDescriptor(message_.fresh_id(), std::vector<uint32_t>(index)),
-        ir_context);
+        MakeDataDescriptor(message_.fresh_id(), std::vector<uint32_t>(index)));
   }
 }
 

--- a/source/fuzz/transformation_compute_data_synonym_fact_closure.cpp
+++ b/source/fuzz/transformation_compute_data_synonym_fact_closure.cpp
@@ -35,10 +35,10 @@ bool TransformationComputeDataSynonymFactClosure::IsApplicable(
 }
 
 void TransformationComputeDataSynonymFactClosure::Apply(
-    opt::IRContext* ir_context,
+    opt::IRContext* /*unused*/,
     TransformationContext* transformation_context) const {
   transformation_context->GetFactManager()->ComputeClosureOfFacts(
-      ir_context, message_.maximum_equivalence_class_size());
+      message_.maximum_equivalence_class_size());
 }
 
 protobufs::Transformation

--- a/source/fuzz/transformation_equation_instruction.cpp
+++ b/source/fuzz/transformation_equation_instruction.cpp
@@ -60,8 +60,7 @@ bool TransformationEquationInstruction::IsApplicable(
     if (inst->opcode() == SpvOpUndef) {
       return false;
     }
-    if (transformation_context.GetFactManager()->IdIsIrrelevant(id,
-                                                                ir_context)) {
+    if (transformation_context.GetFactManager()->IdIsIrrelevant(id)) {
       return false;
     }
     if (!fuzzerutil::IdIsAvailableBeforeInstruction(ir_context, insert_before,
@@ -94,8 +93,7 @@ void TransformationEquationInstruction::Apply(
   ir_context->InvalidateAnalysesExceptFor(opt::IRContext::kAnalysisNone);
 
   transformation_context->GetFactManager()->AddFactIdEquation(
-      message_.fresh_id(), static_cast<SpvOp>(message_.opcode()), rhs_id,
-      ir_context);
+      message_.fresh_id(), static_cast<SpvOp>(message_.opcode()), rhs_id);
 }
 
 protobufs::Transformation TransformationEquationInstruction::ToMessage() const {

--- a/source/fuzz/transformation_flatten_conditional_branch.cpp
+++ b/source/fuzz/transformation_flatten_conditional_branch.cpp
@@ -358,7 +358,7 @@ void TransformationFlattenConditionalBranch::Apply(
   }
   for (auto irrelevant_id : irrelevant_ids) {
     transformation_context->GetFactManager()->AddFactIdIsIrrelevant(
-        irrelevant_id, ir_context);
+        irrelevant_id);
   }
 }
 

--- a/source/fuzz/transformation_outline_function.cpp
+++ b/source/fuzz/transformation_outline_function.cpp
@@ -451,7 +451,6 @@ std::vector<uint32_t> TransformationOutlineFunction::GetRegionInputIds(
           inst,
           [ir_context, &inst, region_exit_block, &region_set, &result](
               opt::Instruction* use, uint32_t /*unused*/) -> bool {
-
             // Find the block in which this id use occurs, recording the id as
             // an input id if the block is outside the region, with some
             // exceptions detailed below.
@@ -500,7 +499,6 @@ std::vector<uint32_t> TransformationOutlineFunction::GetRegionOutputIds(
           &inst,
           [&region_set, ir_context, &inst, region_exit_block, &result](
               opt::Instruction* use, uint32_t /*unused*/) -> bool {
-
             // Find the block in which this id use occurs, recording the id as
             // an output id if the block is outside the region, with some
             // exceptions detailed below.
@@ -651,8 +649,7 @@ TransformationOutlineFunction::PrepareFunctionPrototype(
     if (transformation_context->GetFactManager()->PointeeValueIsIrrelevant(
             id)) {
       transformation_context->GetFactManager()
-          ->AddFactValueOfPointeeIsIrrelevant(input_id_to_fresh_id_map.at(id),
-                                              ir_context);
+          ->AddFactValueOfPointeeIsIrrelevant(input_id_to_fresh_id_map.at(id));
     }
   }
 

--- a/source/fuzz/transformation_permute_phi_operands.cpp
+++ b/source/fuzz/transformation_permute_phi_operands.cpp
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "source/fuzz/transformation_permute_phi_operands.h"
+
 #include <vector>
 
 #include "source/fuzz/fuzzer_util.h"
-#include "source/fuzz/transformation_permute_phi_operands.h"
 
 namespace spvtools {
 namespace fuzz {

--- a/source/fuzz/transformation_push_id_through_variable.cpp
+++ b/source/fuzz/transformation_push_id_through_variable.cpp
@@ -76,7 +76,7 @@ bool TransformationPushIdThroughVariable::IsApplicable(
 
   // We should be able to create a synonym of |value_id| if it's not irrelevant.
   if (!transformation_context.GetFactManager()->IdIsIrrelevant(
-          message_.value_id(), ir_context) &&
+          message_.value_id()) &&
       !fuzzerutil::CanMakeSynonymOf(ir_context, transformation_context,
                                     value_instruction)) {
     return false;
@@ -154,12 +154,12 @@ void TransformationPushIdThroughVariable::Apply(
   ir_context->InvalidateAnalysesExceptFor(opt::IRContext::kAnalysisNone);
 
   if (!transformation_context->GetFactManager()->IdIsIrrelevant(
-          message_.value_id(), ir_context)) {
+          message_.value_id())) {
     // Adds the fact that |message_.value_synonym_id|
     // and |message_.value_id| are synonymous.
     transformation_context->GetFactManager()->AddFactDataSynonym(
         MakeDataDescriptor(message_.value_synonym_id(), {}),
-        MakeDataDescriptor(message_.value_id(), {}), ir_context);
+        MakeDataDescriptor(message_.value_id(), {}));
   }
 }
 

--- a/source/fuzz/transformation_record_synonymous_constants.cpp
+++ b/source/fuzz/transformation_record_synonymous_constants.cpp
@@ -41,9 +41,9 @@ bool TransformationRecordSynonymousConstants::IsApplicable(
   }
 
   if (transformation_context.GetFactManager()->IdIsIrrelevant(
-          message_.constant1_id(), ir_context) ||
+          message_.constant1_id()) ||
       transformation_context.GetFactManager()->IdIsIrrelevant(
-          message_.constant2_id(), ir_context)) {
+          message_.constant2_id())) {
     return false;
   }
 
@@ -52,12 +52,12 @@ bool TransformationRecordSynonymousConstants::IsApplicable(
 }
 
 void TransformationRecordSynonymousConstants::Apply(
-    opt::IRContext* ir_context,
+    opt::IRContext* /*unused*/,
     TransformationContext* transformation_context) const {
   // Add the fact to the fact manager
   transformation_context->GetFactManager()->AddFactDataSynonym(
       MakeDataDescriptor(message_.constant1_id(), {}),
-      MakeDataDescriptor(message_.constant2_id(), {}), ir_context);
+      MakeDataDescriptor(message_.constant2_id(), {}));
 }
 
 protobufs::Transformation TransformationRecordSynonymousConstants::ToMessage()

--- a/source/fuzz/transformation_replace_constant_with_uniform.cpp
+++ b/source/fuzz/transformation_replace_constant_with_uniform.cpp
@@ -157,7 +157,7 @@ bool TransformationReplaceConstantWithUniform::IsApplicable(
   // by the uniform buffer element descriptor will hold a scalar value.
   auto constant_id_associated_with_uniform =
       transformation_context.GetFactManager()->GetConstantFromUniformDescriptor(
-          ir_context, message_.uniform_descriptor());
+          message_.uniform_descriptor());
   if (!constant_id_associated_with_uniform) {
     return false;
   }

--- a/source/fuzz/transformation_replace_copy_object_with_store_load.cpp
+++ b/source/fuzz/transformation_replace_copy_object_with_store_load.cpp
@@ -133,7 +133,7 @@ void TransformationReplaceCopyObjectWithStoreLoad::Apply(
   // and src_operand (id used by OpCopyObject) are synonymous.
   transformation_context->GetFactManager()->AddFactDataSynonym(
       MakeDataDescriptor(message_.copy_object_result_id(), {}),
-      MakeDataDescriptor(src_operand, {}), ir_context);
+      MakeDataDescriptor(src_operand, {}));
 }
 
 protobufs::Transformation

--- a/source/fuzz/transformation_replace_irrelevant_id.cpp
+++ b/source/fuzz/transformation_replace_irrelevant_id.cpp
@@ -37,8 +37,8 @@ bool TransformationReplaceIrrelevantId::IsApplicable(
   auto id_of_interest = message_.id_use_descriptor().id_of_interest();
 
   // The id must be irrelevant.
-  if (!transformation_context.GetFactManager()->IdIsIrrelevant(id_of_interest,
-                                                               ir_context)) {
+  if (!transformation_context.GetFactManager()->IdIsIrrelevant(
+          id_of_interest)) {
     return false;
   }
 

--- a/source/fuzz/transformation_replace_parameter_with_global.cpp
+++ b/source/fuzz/transformation_replace_parameter_with_global.cpp
@@ -184,9 +184,9 @@ void TransformationReplaceParameterWithGlobal::Apply(
   // Mark the pointee of the global variable storing the parameter's value as
   // irrelevant if replaced parameter is irrelevant.
   if (transformation_context->GetFactManager()->IdIsIrrelevant(
-          message_.parameter_id(), ir_context)) {
+          message_.parameter_id())) {
     transformation_context->GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-        message_.global_variable_fresh_id(), ir_context);
+        message_.global_variable_fresh_id());
   }
 }
 

--- a/source/fuzz/transformation_swap_commutable_operands.cpp
+++ b/source/fuzz/transformation_swap_commutable_operands.cpp
@@ -31,8 +31,7 @@ TransformationSwapCommutableOperands::TransformationSwapCommutableOperands(
 }
 
 bool TransformationSwapCommutableOperands::IsApplicable(
-    opt::IRContext* ir_context, const TransformationContext& /*unused*/
-    ) const {
+    opt::IRContext* ir_context, const TransformationContext& /*unused*/) const {
   auto instruction =
       FindInstruction(message_.instruction_descriptor(), ir_context);
   if (instruction == nullptr) return false;
@@ -46,8 +45,7 @@ bool TransformationSwapCommutableOperands::IsApplicable(
 }
 
 void TransformationSwapCommutableOperands::Apply(
-    opt::IRContext* ir_context, TransformationContext* /*unused*/
-    ) const {
+    opt::IRContext* ir_context, TransformationContext* /*unused*/) const {
   auto instruction =
       FindInstruction(message_.instruction_descriptor(), ir_context);
   // By design, the instructions defined to be commutative have exactly two

--- a/source/fuzz/transformation_swap_conditional_branch_operands.cpp
+++ b/source/fuzz/transformation_swap_conditional_branch_operands.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_swap_conditional_branch_operands.h"
+
 #include "source/fuzz/fuzzer_util.h"
 #include "source/fuzz/instruction_descriptor.h"
 

--- a/source/fuzz/transformation_toggle_access_chain_instruction.cpp
+++ b/source/fuzz/transformation_toggle_access_chain_instruction.cpp
@@ -33,8 +33,7 @@ TransformationToggleAccessChainInstruction::
 }
 
 bool TransformationToggleAccessChainInstruction::IsApplicable(
-    opt::IRContext* ir_context, const TransformationContext& /*unused*/
-    ) const {
+    opt::IRContext* ir_context, const TransformationContext& /*unused*/) const {
   auto instruction =
       FindInstruction(message_.instruction_descriptor(), ir_context);
   if (instruction == nullptr) {
@@ -56,8 +55,7 @@ bool TransformationToggleAccessChainInstruction::IsApplicable(
 }
 
 void TransformationToggleAccessChainInstruction::Apply(
-    opt::IRContext* ir_context, TransformationContext* /*unused*/
-    ) const {
+    opt::IRContext* ir_context, TransformationContext* /*unused*/) const {
   auto instruction =
       FindInstruction(message_.instruction_descriptor(), ir_context);
   SpvOp opcode = instruction->opcode();

--- a/source/fuzz/transformation_vector_shuffle.cpp
+++ b/source/fuzz/transformation_vector_shuffle.cpp
@@ -59,7 +59,7 @@ bool TransformationVectorShuffle::IsApplicable(
   }
   // We should be able to create a synonym of |vector1| if it's not irrelevant.
   if (!transformation_context.GetFactManager()->IdIsIrrelevant(
-          message_.vector1(), ir_context) &&
+          message_.vector1()) &&
       !fuzzerutil::CanMakeSynonymOf(ir_context, transformation_context,
                                     vector1_instruction)) {
     return false;
@@ -72,7 +72,7 @@ bool TransformationVectorShuffle::IsApplicable(
   }
   // We should be able to create a synonym of |vector2| if it's not irrelevant.
   if (!transformation_context.GetFactManager()->IdIsIrrelevant(
-          message_.vector2(), ir_context) &&
+          message_.vector2()) &&
       !fuzzerutil::CanMakeSynonymOf(ir_context, transformation_context,
                                     vector2_instruction)) {
     return false;
@@ -156,7 +156,7 @@ void TransformationVectorShuffle::Apply(
   // If the new instruction is irrelevant (because it is in a dead block), it
   // cannot participate in any DataSynonym fact.
   if (transformation_context->GetFactManager()->IdIsIrrelevant(
-          message_.fresh_id(), ir_context)) {
+          message_.fresh_id())) {
     return;
   }
 
@@ -185,7 +185,7 @@ void TransformationVectorShuffle::Apply(
         GetVectorType(ir_context, message_.vector1())->element_count()) {
       // Irrelevant id cannot participate in DataSynonym facts.
       if (transformation_context->GetFactManager()->IdIsIrrelevant(
-              message_.vector1(), ir_context)) {
+              message_.vector1())) {
         continue;
       }
 
@@ -194,7 +194,7 @@ void TransformationVectorShuffle::Apply(
     } else {
       // Irrelevant id cannot participate in DataSynonym facts.
       if (transformation_context->GetFactManager()->IdIsIrrelevant(
-              message_.vector2(), ir_context)) {
+              message_.vector2())) {
         continue;
       }
 
@@ -212,8 +212,7 @@ void TransformationVectorShuffle::Apply(
     // Add a fact relating this input vector component with the associated
     // result component.
     transformation_context->GetFactManager()->AddFactDataSynonym(
-        descriptor_for_result_component, descriptor_for_source_component,
-        ir_context);
+        descriptor_for_result_component, descriptor_for_source_component);
   }
 }
 

--- a/test/fuzz/comparator_deep_blocks_first_test.cpp
+++ b/test/fuzz/comparator_deep_blocks_first_test.cpp
@@ -75,7 +75,7 @@ TEST(ComparatorDeepBlocksFirstTest, Compare) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -109,7 +109,7 @@ TEST(ComparatorDeepBlocksFirstTest, Sort) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/data_synonym_transformation_test.cpp
+++ b/test/fuzz/data_synonym_transformation_test.cpp
@@ -28,9 +28,9 @@ namespace {
 // number of transformations that relate to data synonyms.
 
 protobufs::Fact MakeSynonymFact(uint32_t first_id,
-                                std::vector<uint32_t>&& first_indices,
+                                std::vector<uint32_t> first_indices,
                                 uint32_t second_id,
-                                std::vector<uint32_t>&& second_indices) {
+                                std::vector<uint32_t> second_indices) {
   protobufs::FactDataSynonym data_synonym_fact;
   *data_synonym_fact.mutable_data1() =
       MakeDataDescriptor(first_id, std::move(first_indices));
@@ -122,25 +122,25 @@ TEST(DataSynonymTransformationTest, ArrayCompositeSynonyms) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(12, {}, 100, {0}), context.get());
+      MakeSynonymFact(12, {}, 100, {0}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(13, {}, 100, {1}), context.get());
+      MakeSynonymFact(13, {}, 100, {1}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(22, {}, 100, {2}), context.get());
+      MakeSynonymFact(22, {}, 100, {2}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(28, {}, 101, {0}), context.get());
+      MakeSynonymFact(28, {}, 101, {0}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(23, {}, 101, {1}), context.get());
+      MakeSynonymFact(23, {}, 101, {1}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(32, {}, 101, {2}), context.get());
+      MakeSynonymFact(32, {}, 101, {2}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(23, {}, 101, {3}), context.get());
+      MakeSynonymFact(23, {}, 101, {3}));
 
   // Replace %12 with %100[0] in '%25 = OpAccessChain %24 %20 %12'
   auto instruction_descriptor_1 =
@@ -410,17 +410,17 @@ TEST(DataSynonymTransformationTest, MatrixCompositeSynonyms) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(23, {}, 100, {0}), context.get());
+      MakeSynonymFact(23, {}, 100, {0}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(25, {}, 100, {1}), context.get());
+      MakeSynonymFact(25, {}, 100, {1}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(50, {}, 100, {2}), context.get());
+      MakeSynonymFact(50, {}, 100, {2}));
 
   // Replace %23 with %100[0] in '%26 = OpFAdd %7 %23 %25'
   auto instruction_descriptor_1 = MakeInstructionDescriptor(26, SpvOpFAdd, 0);
@@ -580,25 +580,25 @@ TEST(DataSynonymTransformationTest, StructCompositeSynonyms) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(16, {}, 100, {0}), context.get());
+      MakeSynonymFact(16, {}, 100, {0}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(45, {}, 100, {1}), context.get());
+      MakeSynonymFact(45, {}, 100, {1}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(27, {}, 101, {0}), context.get());
+      MakeSynonymFact(27, {}, 101, {0}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(36, {}, 101, {1}), context.get());
+      MakeSynonymFact(36, {}, 101, {1}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(27, {}, 101, {2}), context.get());
+      MakeSynonymFact(27, {}, 101, {2}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(22, {}, 102, {0}), context.get());
+      MakeSynonymFact(22, {}, 102, {0}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(15, {}, 102, {1}), context.get());
+      MakeSynonymFact(15, {}, 102, {1}));
 
   // Replace %45 with %100[1] in '%46 = OpCompositeConstruct %32 %35 %45'
   auto instruction_descriptor_1 =
@@ -870,51 +870,51 @@ TEST(DataSynonymTransformationTest, VectorCompositeSynonyms) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(20, {0}, 100, {0}), context.get());
+      MakeSynonymFact(20, {0}, 100, {0}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(20, {1}, 100, {1}), context.get());
+      MakeSynonymFact(20, {1}, 100, {1}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(20, {2}, 100, {2}), context.get());
+      MakeSynonymFact(20, {2}, 100, {2}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(54, {}, 100, {3}), context.get());
+      MakeSynonymFact(54, {}, 100, {3}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(15, {0}, 101, {0}), context.get());
+      MakeSynonymFact(15, {0}, 101, {0}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(15, {1}, 101, {1}), context.get());
+      MakeSynonymFact(15, {1}, 101, {1}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(19, {0}, 101, {2}), context.get());
+      MakeSynonymFact(19, {0}, 101, {2}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(19, {1}, 101, {3}), context.get());
+      MakeSynonymFact(19, {1}, 101, {3}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(27, {}, 102, {0}), context.get());
+      MakeSynonymFact(27, {}, 102, {0}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(15, {0}, 102, {1}), context.get());
+      MakeSynonymFact(15, {0}, 102, {1}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(15, {1}, 102, {2}), context.get());
+      MakeSynonymFact(15, {1}, 102, {2}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(33, {}, 103, {0}), context.get());
+      MakeSynonymFact(33, {}, 103, {0}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(47, {0}, 103, {1}), context.get());
+      MakeSynonymFact(47, {0}, 103, {1}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(47, {1}, 103, {2}), context.get());
+      MakeSynonymFact(47, {1}, 103, {2}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(47, {2}, 103, {3}), context.get());
+      MakeSynonymFact(47, {2}, 103, {3}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(42, {}, 104, {0}), context.get());
+      MakeSynonymFact(42, {}, 104, {0}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(45, {}, 104, {1}), context.get());
+      MakeSynonymFact(45, {}, 104, {1}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(38, {0}, 105, {0}), context.get());
+      MakeSynonymFact(38, {0}, 105, {0}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(38, {1}, 105, {1}), context.get());
+      MakeSynonymFact(38, {1}, 105, {1}));
   transformation_context.GetFactManager()->AddFact(
-      MakeSynonymFact(46, {}, 105, {2}), context.get());
+      MakeSynonymFact(46, {}, 105, {2}));
 
   // Replace %20 with %100[0:2] in '%80 = OpCopyObject %16 %20'
   auto instruction_descriptor_1 =
@@ -923,7 +923,7 @@ TEST(DataSynonymTransformationTest, VectorCompositeSynonyms) {
                                                100, 100, {0, 1, 2});
   ASSERT_TRUE(shuffle_1.IsApplicable(context.get(), transformation_context));
   shuffle_1.Apply(context.get(), &transformation_context);
-  fact_manager.ComputeClosureOfFacts(context.get(), 100);
+  fact_manager.ComputeClosureOfFacts(100);
 
   auto replacement_1 = TransformationReplaceIdWithSynonym(
       MakeIdUseDescriptor(20, instruction_descriptor_1, 0), 200);
@@ -953,7 +953,7 @@ TEST(DataSynonymTransformationTest, VectorCompositeSynonyms) {
                                                101, 101, {0, 1});
   ASSERT_TRUE(shuffle_3.IsApplicable(context.get(), transformation_context));
   shuffle_3.Apply(context.get(), &transformation_context);
-  fact_manager.ComputeClosureOfFacts(context.get(), 100);
+  fact_manager.ComputeClosureOfFacts(100);
 
   auto replacement_3 = TransformationReplaceIdWithSynonym(
       MakeIdUseDescriptor(15, instruction_descriptor_3, 1), 202);
@@ -969,7 +969,7 @@ TEST(DataSynonymTransformationTest, VectorCompositeSynonyms) {
                                                101, 101, {2, 3});
   ASSERT_TRUE(shuffle_4.IsApplicable(context.get(), transformation_context));
   shuffle_4.Apply(context.get(), &transformation_context);
-  fact_manager.ComputeClosureOfFacts(context.get(), 100);
+  fact_manager.ComputeClosureOfFacts(100);
 
   auto replacement_4 = TransformationReplaceIdWithSynonym(
       MakeIdUseDescriptor(19, instruction_descriptor_4, 0), 203);
@@ -1001,7 +1001,7 @@ TEST(DataSynonymTransformationTest, VectorCompositeSynonyms) {
                                                102, 102, {1, 2});
   ASSERT_TRUE(shuffle_6.IsApplicable(context.get(), transformation_context));
   shuffle_6.Apply(context.get(), &transformation_context);
-  fact_manager.ComputeClosureOfFacts(context.get(), 100);
+  fact_manager.ComputeClosureOfFacts(100);
 
   auto replacement_6 = TransformationReplaceIdWithSynonym(
       MakeIdUseDescriptor(15, instruction_descriptor_6, 0), 205);
@@ -1031,7 +1031,7 @@ TEST(DataSynonymTransformationTest, VectorCompositeSynonyms) {
                                                103, 103, {1, 2, 3});
   ASSERT_TRUE(shuffle_8.IsApplicable(context.get(), transformation_context));
   shuffle_8.Apply(context.get(), &transformation_context);
-  fact_manager.ComputeClosureOfFacts(context.get(), 100);
+  fact_manager.ComputeClosureOfFacts(100);
 
   auto replacement_8 = TransformationReplaceIdWithSynonym(
       MakeIdUseDescriptor(47, instruction_descriptor_8, 0), 207);
@@ -1074,7 +1074,7 @@ TEST(DataSynonymTransformationTest, VectorCompositeSynonyms) {
                                                 105, 105, {0, 1});
   ASSERT_TRUE(shuffle_11.IsApplicable(context.get(), transformation_context));
   shuffle_11.Apply(context.get(), &transformation_context);
-  fact_manager.ComputeClosureOfFacts(context.get(), 100);
+  fact_manager.ComputeClosureOfFacts(100);
 
   auto replacement_11 = TransformationReplaceIdWithSynonym(
       MakeIdUseDescriptor(38, instruction_descriptor_11, 1), 210);

--- a/test/fuzz/fact_manager_test.cpp
+++ b/test/fuzz/fact_manager_test.cpp
@@ -35,8 +35,7 @@ using opt::analysis::Integer;
 using opt::analysis::Type;
 
 bool AddFactHelper(
-    FactManager* fact_manager, opt::IRContext* context,
-    std::vector<uint32_t>&& words,
+    FactManager* fact_manager, const std::vector<uint32_t>& words,
     const protobufs::UniformBufferElementDescriptor& descriptor) {
   protobufs::FactConstantUniform constant_uniform_fact;
   for (auto word : words) {
@@ -46,7 +45,7 @@ bool AddFactHelper(
       descriptor;
   protobufs::Fact fact;
   *fact.mutable_constant_uniform_fact() = constant_uniform_fact;
-  return fact_manager->AddFact(fact, context);
+  return fact_manager->AddFact(fact);
 }
 
 TEST(FactManagerTest, ConstantsAvailableViaUniforms) {
@@ -256,7 +255,7 @@ TEST(FactManagerTest, ConstantsAvailableViaUniforms) {
     std::memcpy(&buffer_double_20, &temp, sizeof(temp));
   }
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
 
   uint32_t type_int32_id = 11;
   uint32_t type_int64_id = 13;
@@ -266,103 +265,100 @@ TEST(FactManagerTest, ConstantsAvailableViaUniforms) {
   uint32_t type_double_id = 16;
 
   // Initially there should be no facts about uniforms.
-  ASSERT_TRUE(fact_manager
-                  .GetConstantsAvailableFromUniformsForType(context.get(),
-                                                            type_uint32_id)
-                  .empty());
+  ASSERT_TRUE(
+      fact_manager.GetConstantsAvailableFromUniformsForType(type_uint32_id)
+          .empty());
 
   // In the comments that follow we write v[...][...] to refer to uniform
   // variable v indexed with some given indices, when in practice v is
   // identified via a (descriptor set, binding) pair.
 
   // 100[2][3] == int(1)
-  ASSERT_TRUE(AddFactHelper(&fact_manager, context.get(), {1},
+  ASSERT_TRUE(AddFactHelper(&fact_manager, {1},
                             MakeUniformBufferElementDescriptor(0, 0, {2, 3})));
 
   // 200[1][2][3] == int(1)
-  ASSERT_TRUE(
-      AddFactHelper(&fact_manager, context.get(), {1},
-                    MakeUniformBufferElementDescriptor(0, 1, {1, 2, 3})));
+  ASSERT_TRUE(AddFactHelper(
+      &fact_manager, {1}, MakeUniformBufferElementDescriptor(0, 1, {1, 2, 3})));
 
   // 300[1][0][2][3] == int(1)
   ASSERT_TRUE(
-      AddFactHelper(&fact_manager, context.get(), {1},
+      AddFactHelper(&fact_manager, {1},
                     MakeUniformBufferElementDescriptor(0, 2, {1, 0, 2, 3})));
 
   // 400[2][3] = int32_min
-  ASSERT_TRUE(AddFactHelper(&fact_manager, context.get(), {buffer_int32_min[0]},
+  ASSERT_TRUE(AddFactHelper(&fact_manager, {buffer_int32_min[0]},
                             MakeUniformBufferElementDescriptor(0, 3, {2, 3})));
 
   // 500[1][2][3] = int32_min
   ASSERT_TRUE(
-      AddFactHelper(&fact_manager, context.get(), {buffer_int32_min[0]},
+      AddFactHelper(&fact_manager, {buffer_int32_min[0]},
                     MakeUniformBufferElementDescriptor(0, 4, {1, 2, 3})));
 
   // 600[1][2][3] = int64_max
-  ASSERT_TRUE(AddFactHelper(
-      &fact_manager, context.get(), {buffer_int64_max[0], buffer_int64_max[1]},
-      MakeUniformBufferElementDescriptor(0, 5, {1, 2, 3})));
+  ASSERT_TRUE(
+      AddFactHelper(&fact_manager, {buffer_int64_max[0], buffer_int64_max[1]},
+                    MakeUniformBufferElementDescriptor(0, 5, {1, 2, 3})));
 
   // 700[1][1] = int64_max
-  ASSERT_TRUE(AddFactHelper(&fact_manager, context.get(),
+  ASSERT_TRUE(AddFactHelper(&fact_manager,
                             {buffer_int64_max[0], buffer_int64_max[1]},
                             MakeUniformBufferElementDescriptor(0, 6, {1, 1})));
 
   // 800[2][3] = uint(1)
-  ASSERT_TRUE(AddFactHelper(&fact_manager, context.get(), {1},
+  ASSERT_TRUE(AddFactHelper(&fact_manager, {1},
                             MakeUniformBufferElementDescriptor(1, 0, {2, 3})));
 
   // 900[1][2][3] = uint(1)
-  ASSERT_TRUE(
-      AddFactHelper(&fact_manager, context.get(), {1},
-                    MakeUniformBufferElementDescriptor(1, 1, {1, 2, 3})));
+  ASSERT_TRUE(AddFactHelper(
+      &fact_manager, {1}, MakeUniformBufferElementDescriptor(1, 1, {1, 2, 3})));
 
   // 1000[1][0][2][3] = uint(1)
   ASSERT_TRUE(
-      AddFactHelper(&fact_manager, context.get(), {1},
+      AddFactHelper(&fact_manager, {1},
                     MakeUniformBufferElementDescriptor(1, 2, {1, 0, 2, 3})));
 
   // 1100[0] = uint64(1)
-  ASSERT_TRUE(AddFactHelper(&fact_manager, context.get(),
+  ASSERT_TRUE(AddFactHelper(&fact_manager,
                             {buffer_uint64_1[0], buffer_uint64_1[1]},
                             MakeUniformBufferElementDescriptor(1, 3, {0})));
 
   // 1200[0][0] = uint64_max
-  ASSERT_TRUE(AddFactHelper(&fact_manager, context.get(),
+  ASSERT_TRUE(AddFactHelper(&fact_manager,
                             {buffer_uint64_max[0], buffer_uint64_max[1]},
                             MakeUniformBufferElementDescriptor(1, 4, {0, 0})));
 
   // 1300[1][0] = uint64_max
-  ASSERT_TRUE(AddFactHelper(&fact_manager, context.get(),
+  ASSERT_TRUE(AddFactHelper(&fact_manager,
                             {buffer_uint64_max[0], buffer_uint64_max[1]},
                             MakeUniformBufferElementDescriptor(1, 5, {1, 0})));
 
   // 1400[6] = float(10.0)
-  ASSERT_TRUE(AddFactHelper(&fact_manager, context.get(), {buffer_float_10[0]},
+  ASSERT_TRUE(AddFactHelper(&fact_manager, {buffer_float_10[0]},
                             MakeUniformBufferElementDescriptor(1, 6, {6})));
 
   // 1500[7] = float(10.0)
-  ASSERT_TRUE(AddFactHelper(&fact_manager, context.get(), {buffer_float_10[0]},
+  ASSERT_TRUE(AddFactHelper(&fact_manager, {buffer_float_10[0]},
                             MakeUniformBufferElementDescriptor(2, 0, {7})));
 
   // 1600[9][9] = float(10.0)
-  ASSERT_TRUE(AddFactHelper(&fact_manager, context.get(), {buffer_float_10[0]},
+  ASSERT_TRUE(AddFactHelper(&fact_manager, {buffer_float_10[0]},
                             MakeUniformBufferElementDescriptor(2, 1, {9, 9})));
 
   // 1700[9][9][1] = double(10.0)
-  ASSERT_TRUE(AddFactHelper(
-      &fact_manager, context.get(), {buffer_double_10[0], buffer_double_10[1]},
-      MakeUniformBufferElementDescriptor(2, 2, {9, 9, 1})));
+  ASSERT_TRUE(
+      AddFactHelper(&fact_manager, {buffer_double_10[0], buffer_double_10[1]},
+                    MakeUniformBufferElementDescriptor(2, 2, {9, 9, 1})));
 
   // 1800[9][9][2] = double(10.0)
-  ASSERT_TRUE(AddFactHelper(
-      &fact_manager, context.get(), {buffer_double_10[0], buffer_double_10[1]},
-      MakeUniformBufferElementDescriptor(2, 3, {9, 9, 2})));
+  ASSERT_TRUE(
+      AddFactHelper(&fact_manager, {buffer_double_10[0], buffer_double_10[1]},
+                    MakeUniformBufferElementDescriptor(2, 3, {9, 9, 2})));
 
   // 1900[0][0][0][0][0] = double(20.0)
-  ASSERT_TRUE(AddFactHelper(
-      &fact_manager, context.get(), {buffer_double_20[0], buffer_double_20[1]},
-      MakeUniformBufferElementDescriptor(2, 4, {0, 0, 0, 0, 0})));
+  ASSERT_TRUE(
+      AddFactHelper(&fact_manager, {buffer_double_20[0], buffer_double_20[1]},
+                    MakeUniformBufferElementDescriptor(2, 4, {0, 0, 0, 0, 0})));
 
   opt::Instruction::OperandList operands = {
       {SPV_OPERAND_TYPE_LITERAL_INTEGER, {1}}};
@@ -406,59 +402,52 @@ TEST(FactManagerTest, ConstantsAvailableViaUniforms) {
   context->InvalidateAnalysesExceptFor(opt::IRContext::Analysis::kAnalysisNone);
 
   // Constants 1 and int32_min are available.
-  ASSERT_EQ(2, fact_manager
-                   .GetConstantsAvailableFromUniformsForType(context.get(),
-                                                             type_int32_id)
-                   .size());
+  ASSERT_EQ(2,
+            fact_manager.GetConstantsAvailableFromUniformsForType(type_int32_id)
+                .size());
   // Constant int64_max is available.
-  ASSERT_EQ(1, fact_manager
-                   .GetConstantsAvailableFromUniformsForType(context.get(),
-                                                             type_int64_id)
-                   .size());
+  ASSERT_EQ(1,
+            fact_manager.GetConstantsAvailableFromUniformsForType(type_int64_id)
+                .size());
   // Constant 1u is available.
-  ASSERT_EQ(1, fact_manager
-                   .GetConstantsAvailableFromUniformsForType(context.get(),
-                                                             type_uint32_id)
-                   .size());
+  ASSERT_EQ(
+      1, fact_manager.GetConstantsAvailableFromUniformsForType(type_uint32_id)
+             .size());
   // Constants 1u and uint64_max are available.
-  ASSERT_EQ(2, fact_manager
-                   .GetConstantsAvailableFromUniformsForType(context.get(),
-                                                             type_uint64_id)
-                   .size());
+  ASSERT_EQ(
+      2, fact_manager.GetConstantsAvailableFromUniformsForType(type_uint64_id)
+             .size());
   // Constant 10.0 is available.
-  ASSERT_EQ(1, fact_manager
-                   .GetConstantsAvailableFromUniformsForType(context.get(),
-                                                             type_float_id)
-                   .size());
+  ASSERT_EQ(1,
+            fact_manager.GetConstantsAvailableFromUniformsForType(type_float_id)
+                .size());
   // Constants 10.0 and 20.0 are available.
-  ASSERT_EQ(2, fact_manager
-                   .GetConstantsAvailableFromUniformsForType(context.get(),
-                                                             type_double_id)
-                   .size());
+  ASSERT_EQ(
+      2, fact_manager.GetConstantsAvailableFromUniformsForType(type_double_id)
+             .size());
 
   ASSERT_EQ(std::numeric_limits<int64_t>::max(),
             context->get_constant_mgr()
                 ->FindDeclaredConstant(
                     fact_manager.GetConstantsAvailableFromUniformsForType(
-                        context.get(), type_int64_id)[0])
+                        type_int64_id)[0])
                 ->AsIntConstant()
                 ->GetS64());
   ASSERT_EQ(1, context->get_constant_mgr()
                    ->FindDeclaredConstant(
                        fact_manager.GetConstantsAvailableFromUniformsForType(
-                           context.get(), type_uint32_id)[0])
+                           type_uint32_id)[0])
                    ->AsIntConstant()
                    ->GetU32());
   ASSERT_EQ(10.0f,
             context->get_constant_mgr()
                 ->FindDeclaredConstant(
                     fact_manager.GetConstantsAvailableFromUniformsForType(
-                        context.get(), type_float_id)[0])
+                        type_float_id)[0])
                 ->AsFloatConstant()
                 ->GetFloat());
   const std::vector<uint32_t>& double_constant_ids =
-      fact_manager.GetConstantsAvailableFromUniformsForType(context.get(),
-                                                            type_double_id);
+      fact_manager.GetConstantsAvailableFromUniformsForType(type_double_id);
   ASSERT_EQ(10.0, context->get_constant_mgr()
                       ->FindDeclaredConstant(double_constant_ids[0])
                       ->AsFloatConstant()
@@ -469,8 +458,8 @@ TEST(FactManagerTest, ConstantsAvailableViaUniforms) {
                       ->GetDouble());
 
   const std::vector<protobufs::UniformBufferElementDescriptor>
-      descriptors_for_double_10 = fact_manager.GetUniformDescriptorsForConstant(
-          context.get(), double_constant_ids[0]);
+      descriptors_for_double_10 =
+          fact_manager.GetUniformDescriptorsForConstant(double_constant_ids[0]);
   ASSERT_EQ(2, descriptors_for_double_10.size());
   {
     auto temp = MakeUniformBufferElementDescriptor(2, 2, {9, 9, 1});
@@ -483,8 +472,8 @@ TEST(FactManagerTest, ConstantsAvailableViaUniforms) {
         &temp, &descriptors_for_double_10[1]));
   }
   const std::vector<protobufs::UniformBufferElementDescriptor>
-      descriptors_for_double_20 = fact_manager.GetUniformDescriptorsForConstant(
-          context.get(), double_constant_ids[1]);
+      descriptors_for_double_20 =
+          fact_manager.GetUniformDescriptorsForConstant(double_constant_ids[1]);
   ASSERT_EQ(1, descriptors_for_double_20.size());
   {
     auto temp = MakeUniformBufferElementDescriptor(2, 4, {0, 0, 0, 0, 0});
@@ -493,11 +482,11 @@ TEST(FactManagerTest, ConstantsAvailableViaUniforms) {
   }
 
   auto constant_1_id = fact_manager.GetConstantFromUniformDescriptor(
-      context.get(), MakeUniformBufferElementDescriptor(2, 3, {9, 9, 2}));
+      MakeUniformBufferElementDescriptor(2, 3, {9, 9, 2}));
   ASSERT_TRUE(constant_1_id);
 
   auto constant_2_id = fact_manager.GetConstantFromUniformDescriptor(
-      context.get(), MakeUniformBufferElementDescriptor(2, 4, {0, 0, 0, 0, 0}));
+      MakeUniformBufferElementDescriptor(2, 4, {0, 0, 0, 0, 0}));
   ASSERT_TRUE(constant_2_id);
 
   ASSERT_EQ(double_constant_ids[0], constant_1_id);
@@ -546,29 +535,28 @@ TEST(FactManagerTest, TwoConstantsWithSameValue) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
 
   auto uniform_buffer_element_descriptor =
       MakeUniformBufferElementDescriptor(0, 0, {0});
 
   // (0, 0, [0]) = int(1)
-  ASSERT_TRUE(AddFactHelper(&fact_manager, context.get(), {1},
-                            uniform_buffer_element_descriptor));
-  auto constants =
-      fact_manager.GetConstantsAvailableFromUniformsForType(context.get(), 6);
+  ASSERT_TRUE(
+      AddFactHelper(&fact_manager, {1}, uniform_buffer_element_descriptor));
+  auto constants = fact_manager.GetConstantsAvailableFromUniformsForType(6);
   ASSERT_EQ(1, constants.size());
   ASSERT_TRUE(constants[0] == 9 || constants[0] == 20);
 
   auto constant = fact_manager.GetConstantFromUniformDescriptor(
-      context.get(), uniform_buffer_element_descriptor);
+      uniform_buffer_element_descriptor);
   ASSERT_TRUE(constant == 9 || constant == 20);
 
   // Because the constants with ids 9 and 20 are equal, we should get the same
   // single uniform buffer element descriptor when we look up the descriptors
   // for either one of them.
   for (auto constant_id : {9u, 20u}) {
-    auto descriptors = fact_manager.GetUniformDescriptorsForConstant(
-        context.get(), constant_id);
+    auto descriptors =
+        fact_manager.GetUniformDescriptorsForConstant(constant_id);
     ASSERT_EQ(1, descriptors.size());
     ASSERT_TRUE(UniformBufferElementDescriptorEquals()(
         &uniform_buffer_element_descriptor, &descriptors[0]));
@@ -612,7 +600,7 @@ TEST(FactManagerTest, NonFiniteFactsAreNotValid) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   auto uniform_buffer_element_descriptor_f =
       MakeUniformBufferElementDescriptor(0, 0, {0});
 
@@ -624,12 +612,12 @@ TEST(FactManagerTest, NonFiniteFactsAreNotValid) {
     float positive_infinity_float = std::numeric_limits<float>::infinity();
     uint32_t words[1];
     memcpy(words, &positive_infinity_float, sizeof(float));
-    ASSERT_FALSE(AddFactHelper(&fact_manager, context.get(), {words[0]},
+    ASSERT_FALSE(AddFactHelper(&fact_manager, {words[0]},
                                uniform_buffer_element_descriptor_f));
     // f == -inf
     float negative_infinity_float = std::numeric_limits<float>::infinity();
     memcpy(words, &negative_infinity_float, sizeof(float));
-    ASSERT_FALSE(AddFactHelper(&fact_manager, context.get(), {words[0]},
+    ASSERT_FALSE(AddFactHelper(&fact_manager, {words[0]},
                                uniform_buffer_element_descriptor_f));
   }
 
@@ -638,7 +626,7 @@ TEST(FactManagerTest, NonFiniteFactsAreNotValid) {
     float quiet_nan_float = std::numeric_limits<float>::quiet_NaN();
     uint32_t words[1];
     memcpy(words, &quiet_nan_float, sizeof(float));
-    ASSERT_FALSE(AddFactHelper(&fact_manager, context.get(), {words[0]},
+    ASSERT_FALSE(AddFactHelper(&fact_manager, {words[0]},
                                uniform_buffer_element_descriptor_f));
   }
 
@@ -647,14 +635,12 @@ TEST(FactManagerTest, NonFiniteFactsAreNotValid) {
     double positive_infinity_double = std::numeric_limits<double>::infinity();
     uint32_t words[2];
     memcpy(words, &positive_infinity_double, sizeof(double));
-    ASSERT_FALSE(AddFactHelper(&fact_manager, context.get(),
-                               {words[0], words[1]},
+    ASSERT_FALSE(AddFactHelper(&fact_manager, {words[0], words[1]},
                                uniform_buffer_element_descriptor_d));
     // d == -inf
     double negative_infinity_double = -std::numeric_limits<double>::infinity();
     memcpy(words, &negative_infinity_double, sizeof(double));
-    ASSERT_FALSE(AddFactHelper(&fact_manager, context.get(),
-                               {words[0], words[1]},
+    ASSERT_FALSE(AddFactHelper(&fact_manager, {words[0], words[1]},
                                uniform_buffer_element_descriptor_d));
   }
 
@@ -663,8 +649,7 @@ TEST(FactManagerTest, NonFiniteFactsAreNotValid) {
     double quiet_nan_double = std::numeric_limits<double>::quiet_NaN();
     uint32_t words[2];
     memcpy(words, &quiet_nan_double, sizeof(double));
-    ASSERT_FALSE(AddFactHelper(&fact_manager, context.get(),
-                               {words[0], words[1]},
+    ASSERT_FALSE(AddFactHelper(&fact_manager, {words[0], words[1]},
                                uniform_buffer_element_descriptor_d));
   }
 }
@@ -730,14 +715,14 @@ TEST(FactManagerTest, AmbiguousFact) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   auto uniform_buffer_element_descriptor =
       MakeUniformBufferElementDescriptor(0, 0, {0});
 
   // The fact cannot be added because it is ambiguous: there are two uniforms
   // with descriptor set 0 and binding 0.
-  ASSERT_FALSE(AddFactHelper(&fact_manager, context.get(), {1},
-                             uniform_buffer_element_descriptor));
+  ASSERT_FALSE(
+      AddFactHelper(&fact_manager, {1}, uniform_buffer_element_descriptor));
 }
 
 TEST(FactManagerTest, RecursiveAdditionOfFacts) {
@@ -767,10 +752,10 @@ TEST(FactManagerTest, RecursiveAdditionOfFacts) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
 
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(10, {}),
-                                  MakeDataDescriptor(11, {2}), context.get());
+                                  MakeDataDescriptor(11, {2}));
 
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(10, {}),
                                         MakeDataDescriptor(11, {2})));
@@ -829,43 +814,43 @@ TEST(FactManagerTest, CorollaryConversionFacts) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
 
   // Add equation facts
-  fact_manager.AddFactIdEquation(24, SpvOpConvertSToF, {15}, context.get());
-  fact_manager.AddFactIdEquation(25, SpvOpConvertSToF, {16}, context.get());
-  fact_manager.AddFactIdEquation(26, SpvOpConvertUToF, {17}, context.get());
-  fact_manager.AddFactIdEquation(27, SpvOpConvertSToF, {18}, context.get());
-  fact_manager.AddFactIdEquation(28, SpvOpConvertUToF, {19}, context.get());
-  fact_manager.AddFactIdEquation(29, SpvOpConvertUToF, {20}, context.get());
-  fact_manager.AddFactIdEquation(30, SpvOpConvertSToF, {21}, context.get());
-  fact_manager.AddFactIdEquation(31, SpvOpConvertUToF, {22}, context.get());
-  fact_manager.AddFactIdEquation(32, SpvOpConvertUToF, {23}, context.get());
+  fact_manager.AddFactIdEquation(24, SpvOpConvertSToF, {15});
+  fact_manager.AddFactIdEquation(25, SpvOpConvertSToF, {16});
+  fact_manager.AddFactIdEquation(26, SpvOpConvertUToF, {17});
+  fact_manager.AddFactIdEquation(27, SpvOpConvertSToF, {18});
+  fact_manager.AddFactIdEquation(28, SpvOpConvertUToF, {19});
+  fact_manager.AddFactIdEquation(29, SpvOpConvertUToF, {20});
+  fact_manager.AddFactIdEquation(30, SpvOpConvertSToF, {21});
+  fact_manager.AddFactIdEquation(31, SpvOpConvertUToF, {22});
+  fact_manager.AddFactIdEquation(32, SpvOpConvertUToF, {23});
 
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(15, {}),
-                                  MakeDataDescriptor(16, {}), context.get());
+                                  MakeDataDescriptor(16, {}));
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(24, {}),
                                         MakeDataDescriptor(25, {})));
 
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(17, {}),
-                                  MakeDataDescriptor(18, {}), context.get());
+                                  MakeDataDescriptor(18, {}));
   ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(26, {}),
                                          MakeDataDescriptor(27, {})));
 
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(19, {}),
-                                  MakeDataDescriptor(20, {}), context.get());
+                                  MakeDataDescriptor(20, {}));
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(28, {}),
                                         MakeDataDescriptor(29, {})));
 
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(21, {}),
-                                  MakeDataDescriptor(22, {}), context.get());
+                                  MakeDataDescriptor(22, {}));
   ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(30, {}),
                                          MakeDataDescriptor(31, {})));
 
   ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(32, {}),
                                          MakeDataDescriptor(28, {})));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(23, {}),
-                                  MakeDataDescriptor(19, {}), context.get());
+                                  MakeDataDescriptor(19, {}));
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(32, {}),
                                         MakeDataDescriptor(28, {})));
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(32, {}),
@@ -902,12 +887,12 @@ TEST(FactManagerTest, HandlesCorollariesWithInvalidIds) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
 
   // Add required facts.
-  fact_manager.AddFactIdEquation(14, SpvOpConvertSToF, {9}, context.get());
+  fact_manager.AddFactIdEquation(14, SpvOpConvertSToF, {9});
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(14, {}),
-                                  MakeDataDescriptor(17, {}), context.get());
+                                  MakeDataDescriptor(17, {}));
 
   // Apply TransformationMergeBlocks which will remove %17 from the module.
   spvtools::ValidatorOptions validator_options;
@@ -922,7 +907,7 @@ TEST(FactManagerTest, HandlesCorollariesWithInvalidIds) {
   ASSERT_EQ(context->get_def_use_mgr()->GetDef(17), nullptr);
 
   // Add another equation.
-  fact_manager.AddFactIdEquation(15, SpvOpConvertSToF, {9}, context.get());
+  fact_manager.AddFactIdEquation(15, SpvOpConvertSToF, {9});
 
   // Check that two ids are synonymous even though one of them doesn't exist in
   // the module (%17).
@@ -936,7 +921,7 @@ TEST(FactManagerTest, HandlesCorollariesWithInvalidIds) {
   ASSERT_TRUE(context->KillDef(14));
   ASSERT_TRUE(context->KillDef(15));
 
-  fact_manager.AddFactIdEquation(18, SpvOpConvertSToF, {9}, context.get());
+  fact_manager.AddFactIdEquation(18, SpvOpConvertSToF, {9});
 
   // We don't create synonyms if at least one of the equivalence classes has no
   // valid members.
@@ -971,14 +956,14 @@ TEST(FactManagerTest, LogicalNotEquationFacts) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
 
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(15, {}),
-                                  MakeDataDescriptor(7, {}), context.get());
+                                  MakeDataDescriptor(7, {}));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(16, {}),
-                                  MakeDataDescriptor(14, {}), context.get());
-  fact_manager.AddFactIdEquation(14, SpvOpLogicalNot, {7}, context.get());
-  fact_manager.AddFactIdEquation(17, SpvOpLogicalNot, {16}, context.get());
+                                  MakeDataDescriptor(14, {}));
+  fact_manager.AddFactIdEquation(14, SpvOpLogicalNot, {7});
+  fact_manager.AddFactIdEquation(17, SpvOpLogicalNot, {16});
 
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(15, {}),
                                         MakeDataDescriptor(7, {})));
@@ -1015,10 +1000,10 @@ TEST(FactManagerTest, SignedNegateEquationFacts) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
 
-  fact_manager.AddFactIdEquation(14, SpvOpSNegate, {7}, context.get());
-  fact_manager.AddFactIdEquation(15, SpvOpSNegate, {14}, context.get());
+  fact_manager.AddFactIdEquation(14, SpvOpSNegate, {7});
+  fact_manager.AddFactIdEquation(15, SpvOpSNegate, {14});
 
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(7, {}),
                                         MakeDataDescriptor(15, {})));
@@ -1057,21 +1042,21 @@ TEST(FactManagerTest, AddSubNegateFacts1) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
 
-  fact_manager.AddFactIdEquation(14, SpvOpIAdd, {15, 16}, context.get());
+  fact_manager.AddFactIdEquation(14, SpvOpIAdd, {15, 16});
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(17, {}),
-                                  MakeDataDescriptor(15, {}), context.get());
+                                  MakeDataDescriptor(15, {}));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(18, {}),
-                                  MakeDataDescriptor(16, {}), context.get());
-  fact_manager.AddFactIdEquation(19, SpvOpISub, {14, 18}, context.get());
-  fact_manager.AddFactIdEquation(20, SpvOpISub, {14, 17}, context.get());
+                                  MakeDataDescriptor(16, {}));
+  fact_manager.AddFactIdEquation(19, SpvOpISub, {14, 18});
+  fact_manager.AddFactIdEquation(20, SpvOpISub, {14, 17});
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(21, {}),
-                                  MakeDataDescriptor(14, {}), context.get());
-  fact_manager.AddFactIdEquation(22, SpvOpISub, {16, 21}, context.get());
+                                  MakeDataDescriptor(14, {}));
+  fact_manager.AddFactIdEquation(22, SpvOpISub, {16, 21});
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(23, {}),
-                                  MakeDataDescriptor(22, {}), context.get());
-  fact_manager.AddFactIdEquation(24, SpvOpSNegate, {23}, context.get());
+                                  MakeDataDescriptor(22, {}));
+  fact_manager.AddFactIdEquation(24, SpvOpSNegate, {23});
 
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(19, {}),
                                         MakeDataDescriptor(15, {})));
@@ -1113,33 +1098,33 @@ TEST(FactManagerTest, AddSubNegateFacts2) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
 
-  fact_manager.AddFactIdEquation(14, SpvOpISub, {15, 16}, context.get());
-  fact_manager.AddFactIdEquation(17, SpvOpIAdd, {14, 16}, context.get());
+  fact_manager.AddFactIdEquation(14, SpvOpISub, {15, 16});
+  fact_manager.AddFactIdEquation(17, SpvOpIAdd, {14, 16});
 
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(17, {}),
                                         MakeDataDescriptor(15, {})));
 
-  fact_manager.AddFactIdEquation(18, SpvOpIAdd, {16, 14}, context.get());
+  fact_manager.AddFactIdEquation(18, SpvOpIAdd, {16, 14});
 
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(18, {}),
                                         MakeDataDescriptor(15, {})));
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(17, {}),
                                         MakeDataDescriptor(18, {})));
 
-  fact_manager.AddFactIdEquation(19, SpvOpISub, {14, 15}, context.get());
-  fact_manager.AddFactIdEquation(20, SpvOpSNegate, {19}, context.get());
+  fact_manager.AddFactIdEquation(19, SpvOpISub, {14, 15});
+  fact_manager.AddFactIdEquation(20, SpvOpSNegate, {19});
 
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(20, {}),
                                         MakeDataDescriptor(16, {})));
 
-  fact_manager.AddFactIdEquation(21, SpvOpISub, {14, 19}, context.get());
+  fact_manager.AddFactIdEquation(21, SpvOpISub, {14, 19});
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(21, {}),
                                         MakeDataDescriptor(15, {})));
 
-  fact_manager.AddFactIdEquation(22, SpvOpISub, {14, 18}, context.get());
-  fact_manager.AddFactIdEquation(23, SpvOpSNegate, {22}, context.get());
+  fact_manager.AddFactIdEquation(22, SpvOpISub, {14, 18});
+  fact_manager.AddFactIdEquation(23, SpvOpSNegate, {22});
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(23, {}),
                                         MakeDataDescriptor(16, {})));
 }
@@ -1189,42 +1174,42 @@ TEST(FactManagerTest, ConversionEquations) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
 
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(16, {}),
-                                  MakeDataDescriptor(17, {}), context.get());
+                                  MakeDataDescriptor(17, {}));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(18, {}),
-                                  MakeDataDescriptor(19, {}), context.get());
+                                  MakeDataDescriptor(19, {}));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(20, {}),
-                                  MakeDataDescriptor(21, {}), context.get());
+                                  MakeDataDescriptor(21, {}));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(22, {}),
-                                  MakeDataDescriptor(23, {}), context.get());
+                                  MakeDataDescriptor(23, {}));
 
-  fact_manager.AddFactIdEquation(25, SpvOpConvertUToF, {16}, context.get());
-  fact_manager.AddFactIdEquation(26, SpvOpConvertUToF, {17}, context.get());
+  fact_manager.AddFactIdEquation(25, SpvOpConvertUToF, {16});
+  fact_manager.AddFactIdEquation(26, SpvOpConvertUToF, {17});
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(25, {}),
                                         MakeDataDescriptor(26, {})));
 
-  fact_manager.AddFactIdEquation(27, SpvOpConvertSToF, {20}, context.get());
-  fact_manager.AddFactIdEquation(28, SpvOpConvertUToF, {21}, context.get());
+  fact_manager.AddFactIdEquation(27, SpvOpConvertSToF, {20});
+  fact_manager.AddFactIdEquation(28, SpvOpConvertUToF, {21});
   ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(27, {}),
                                          MakeDataDescriptor(28, {})));
 
-  fact_manager.AddFactIdEquation(29, SpvOpConvertSToF, {18}, context.get());
-  fact_manager.AddFactIdEquation(30, SpvOpConvertUToF, {19}, context.get());
+  fact_manager.AddFactIdEquation(29, SpvOpConvertSToF, {18});
+  fact_manager.AddFactIdEquation(30, SpvOpConvertUToF, {19});
   ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(29, {}),
                                          MakeDataDescriptor(30, {})));
 
-  fact_manager.AddFactIdEquation(31, SpvOpConvertSToF, {22}, context.get());
-  fact_manager.AddFactIdEquation(32, SpvOpConvertSToF, {23}, context.get());
+  fact_manager.AddFactIdEquation(31, SpvOpConvertSToF, {22});
+  fact_manager.AddFactIdEquation(32, SpvOpConvertSToF, {23});
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(31, {}),
                                         MakeDataDescriptor(32, {})));
 
-  fact_manager.AddFactIdEquation(33, SpvOpConvertUToF, {17}, context.get());
+  fact_manager.AddFactIdEquation(33, SpvOpConvertUToF, {17});
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(33, {}),
                                         MakeDataDescriptor(26, {})));
 
-  fact_manager.AddFactIdEquation(34, SpvOpConvertSToF, {23}, context.get());
+  fact_manager.AddFactIdEquation(34, SpvOpConvertSToF, {23});
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(32, {}),
                                         MakeDataDescriptor(34, {})));
 }
@@ -1274,12 +1259,11 @@ TEST(FactManagerTest, BitcastEquationFacts) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
 
   uint32_t lhs_id = 30;
   for (uint32_t rhs_id : {6, 6, 7, 7, 19, 19, 20, 20, 21, 21, 22, 22}) {
-    fact_manager.AddFactIdEquation(lhs_id, SpvOpBitcast, {rhs_id},
-                                   context.get());
+    fact_manager.AddFactIdEquation(lhs_id, SpvOpBitcast, {rhs_id});
     ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(lhs_id, {}),
                                           MakeDataDescriptor(rhs_id, {})));
     ++lhs_id;
@@ -1321,39 +1305,39 @@ TEST(FactManagerTest, EquationAndEquivalenceFacts) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
 
-  fact_manager.AddFactIdEquation(14, SpvOpISub, {15, 16}, context.get());
+  fact_manager.AddFactIdEquation(14, SpvOpISub, {15, 16});
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(114, {}),
-                                  MakeDataDescriptor(14, {}), context.get());
-  fact_manager.AddFactIdEquation(17, SpvOpIAdd, {114, 16}, context.get());
+                                  MakeDataDescriptor(14, {}));
+  fact_manager.AddFactIdEquation(17, SpvOpIAdd, {114, 16});
 
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(17, {}),
                                         MakeDataDescriptor(15, {})));
 
-  fact_manager.AddFactIdEquation(18, SpvOpIAdd, {16, 114}, context.get());
+  fact_manager.AddFactIdEquation(18, SpvOpIAdd, {16, 114});
 
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(18, {}),
                                         MakeDataDescriptor(15, {})));
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(17, {}),
                                         MakeDataDescriptor(18, {})));
 
-  fact_manager.AddFactIdEquation(19, SpvOpISub, {14, 15}, context.get());
+  fact_manager.AddFactIdEquation(19, SpvOpISub, {14, 15});
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(119, {}),
-                                  MakeDataDescriptor(19, {}), context.get());
-  fact_manager.AddFactIdEquation(20, SpvOpSNegate, {119}, context.get());
+                                  MakeDataDescriptor(19, {}));
+  fact_manager.AddFactIdEquation(20, SpvOpSNegate, {119});
 
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(20, {}),
                                         MakeDataDescriptor(16, {})));
 
-  fact_manager.AddFactIdEquation(21, SpvOpISub, {14, 19}, context.get());
+  fact_manager.AddFactIdEquation(21, SpvOpISub, {14, 19});
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(21, {}),
                                         MakeDataDescriptor(15, {})));
 
-  fact_manager.AddFactIdEquation(22, SpvOpISub, {14, 18}, context.get());
+  fact_manager.AddFactIdEquation(22, SpvOpISub, {14, 18});
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(22, {}),
-                                  MakeDataDescriptor(220, {}), context.get());
-  fact_manager.AddFactIdEquation(23, SpvOpSNegate, {220}, context.get());
+                                  MakeDataDescriptor(220, {}));
+  fact_manager.AddFactIdEquation(23, SpvOpSNegate, {220});
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(23, {}),
                                         MakeDataDescriptor(16, {})));
 }
@@ -1394,10 +1378,10 @@ TEST(FactManagerTest, CheckingFactsDoesNotAddConstants) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
 
   // 8[0] == int(1)
-  ASSERT_TRUE(AddFactHelper(&fact_manager, context.get(), {1},
+  ASSERT_TRUE(AddFactHelper(&fact_manager, {1},
                             MakeUniformBufferElementDescriptor(0, 0, {0})));
 
   // Although 8[0] has the value 1, we do not have the constant 1 in the module.
@@ -1408,7 +1392,7 @@ TEST(FactManagerTest, CheckingFactsDoesNotAddConstants) {
   opt::analysis::IntConstant constant_one(int_type, {1});
   ASSERT_FALSE(context->get_constant_mgr()->FindConstant(&constant_one));
   auto available_constants =
-      fact_manager.GetConstantsAvailableFromUniformsForType(context.get(), 6);
+      fact_manager.GetConstantsAvailableFromUniformsForType(6);
   ASSERT_EQ(0, available_constants.size());
   ASSERT_TRUE(IsEqual(env, shader, context.get()));
   ASSERT_FALSE(context->get_constant_mgr()->FindConstant(&constant_one));
@@ -1438,15 +1422,15 @@ TEST(FactManagerTest, IdIsIrrelevant) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
 
-  ASSERT_FALSE(fact_manager.IdIsIrrelevant(12, context.get()));
-  ASSERT_FALSE(fact_manager.IdIsIrrelevant(13, context.get()));
+  ASSERT_FALSE(fact_manager.IdIsIrrelevant(12));
+  ASSERT_FALSE(fact_manager.IdIsIrrelevant(13));
 
-  fact_manager.AddFactIdIsIrrelevant(12, context.get());
+  fact_manager.AddFactIdIsIrrelevant(12);
 
-  ASSERT_TRUE(fact_manager.IdIsIrrelevant(12, context.get()));
-  ASSERT_FALSE(fact_manager.IdIsIrrelevant(13, context.get()));
+  ASSERT_TRUE(fact_manager.IdIsIrrelevant(12));
+  ASSERT_FALSE(fact_manager.IdIsIrrelevant(13));
 }
 
 TEST(FactManagerTest, GetIrrelevantIds) {
@@ -1474,19 +1458,18 @@ TEST(FactManagerTest, GetIrrelevantIds) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
 
-  ASSERT_EQ(fact_manager.GetIrrelevantIds(context.get()),
-            std::unordered_set<uint32_t>({}));
+  ASSERT_EQ(fact_manager.GetIrrelevantIds(), std::unordered_set<uint32_t>({}));
 
-  fact_manager.AddFactIdIsIrrelevant(12, context.get());
+  fact_manager.AddFactIdIsIrrelevant(12);
 
-  ASSERT_EQ(fact_manager.GetIrrelevantIds(context.get()),
+  ASSERT_EQ(fact_manager.GetIrrelevantIds(),
             std::unordered_set<uint32_t>({12}));
 
-  fact_manager.AddFactIdIsIrrelevant(13, context.get());
+  fact_manager.AddFactIdIsIrrelevant(13);
 
-  ASSERT_EQ(fact_manager.GetIrrelevantIds(context.get()),
+  ASSERT_EQ(fact_manager.GetIrrelevantIds(),
             std::unordered_set<uint32_t>({12, 13}));
 }
 
@@ -1522,7 +1505,7 @@ TEST(FactManagerTest, BlockIsDead) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
 
   ASSERT_FALSE(fact_manager.BlockIsDead(9));
   ASSERT_FALSE(fact_manager.BlockIsDead(11));
@@ -1578,32 +1561,31 @@ TEST(FactManagerTest, IdsFromDeadBlocksAreIrrelevant) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
 
   ASSERT_FALSE(fact_manager.BlockIsDead(14));
   ASSERT_FALSE(fact_manager.BlockIsDead(19));
 
   // Initially no id is irrelevant.
-  ASSERT_FALSE(fact_manager.IdIsIrrelevant(16, context.get()));
-  ASSERT_FALSE(fact_manager.IdIsIrrelevant(17, context.get()));
-  ASSERT_EQ(fact_manager.GetIrrelevantIds(context.get()),
-            std::unordered_set<uint32_t>({}));
+  ASSERT_FALSE(fact_manager.IdIsIrrelevant(16));
+  ASSERT_FALSE(fact_manager.IdIsIrrelevant(17));
+  ASSERT_EQ(fact_manager.GetIrrelevantIds(), std::unordered_set<uint32_t>({}));
 
   fact_manager.AddFactBlockIsDead(14);
 
   // %16 and %17 should now be considered irrelevant.
-  ASSERT_TRUE(fact_manager.IdIsIrrelevant(16, context.get()));
-  ASSERT_TRUE(fact_manager.IdIsIrrelevant(17, context.get()));
-  ASSERT_EQ(fact_manager.GetIrrelevantIds(context.get()),
+  ASSERT_TRUE(fact_manager.IdIsIrrelevant(16));
+  ASSERT_TRUE(fact_manager.IdIsIrrelevant(17));
+  ASSERT_EQ(fact_manager.GetIrrelevantIds(),
             std::unordered_set<uint32_t>({16, 17}));
 
   // Similarly for %21.
-  ASSERT_FALSE(fact_manager.IdIsIrrelevant(21, context.get()));
+  ASSERT_FALSE(fact_manager.IdIsIrrelevant(21));
 
   fact_manager.AddFactBlockIsDead(19);
 
-  ASSERT_TRUE(fact_manager.IdIsIrrelevant(21, context.get()));
-  ASSERT_EQ(fact_manager.GetIrrelevantIds(context.get()),
+  ASSERT_TRUE(fact_manager.IdIsIrrelevant(21));
+  ASSERT_EQ(fact_manager.GetIrrelevantIds(),
             std::unordered_set<uint32_t>({16, 17, 21}));
 }
 }  // namespace

--- a/test/fuzz/fuzz_test_util.h
+++ b/test/fuzz/fuzz_test_util.h
@@ -15,10 +15,9 @@
 #ifndef TEST_FUZZ_FUZZ_TEST_UTIL_H_
 #define TEST_FUZZ_FUZZ_TEST_UTIL_H_
 
-#include "gtest/gtest.h"
-
 #include <vector>
 
+#include "gtest/gtest.h"
 #include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
 #include "source/opt/build_module.h"
 #include "source/opt/ir_context.h"

--- a/test/fuzz/fuzzer_pass_add_opphi_synonyms_test.cpp
+++ b/test/fuzz/fuzzer_pass_add_opphi_synonyms_test.cpp
@@ -30,23 +30,23 @@ protobufs::Fact MakeSynonymFact(uint32_t first, uint32_t second) {
 }
 
 // Adds synonym facts to the fact manager.
-void SetUpIdSynonyms(FactManager* fact_manager, opt::IRContext* context) {
+void SetUpIdSynonyms(FactManager* fact_manager) {
   // Synonyms {9, 11, 15, 16, 21, 22}
-  fact_manager->AddFact(MakeSynonymFact(11, 9), context);
-  fact_manager->AddFact(MakeSynonymFact(15, 9), context);
-  fact_manager->AddFact(MakeSynonymFact(16, 9), context);
-  fact_manager->AddFact(MakeSynonymFact(21, 9), context);
-  fact_manager->AddFact(MakeSynonymFact(22, 9), context);
+  fact_manager->AddFact(MakeSynonymFact(11, 9));
+  fact_manager->AddFact(MakeSynonymFact(15, 9));
+  fact_manager->AddFact(MakeSynonymFact(16, 9));
+  fact_manager->AddFact(MakeSynonymFact(21, 9));
+  fact_manager->AddFact(MakeSynonymFact(22, 9));
 
   // Synonyms {10, 23}
-  fact_manager->AddFact(MakeSynonymFact(10, 23), context);
+  fact_manager->AddFact(MakeSynonymFact(10, 23));
 
   // Synonyms {14, 27}
-  fact_manager->AddFact(MakeSynonymFact(14, 27), context);
+  fact_manager->AddFact(MakeSynonymFact(14, 27));
 
   // Synonyms {24, 26, 30}
-  fact_manager->AddFact(MakeSynonymFact(26, 24), context);
-  fact_manager->AddFact(MakeSynonymFact(30, 24), context);
+  fact_manager->AddFact(MakeSynonymFact(26, 24));
+  fact_manager->AddFact(MakeSynonymFact(30, 24));
 }
 
 // Returns true if the given lists have the same elements, regardless of their
@@ -122,7 +122,7 @@ TEST(FuzzerPassAddOpPhiSynonymsTest, HelperFunctions) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -135,7 +135,7 @@ TEST(FuzzerPassAddOpPhiSynonymsTest, HelperFunctions) {
                                          &fuzzer_context,
                                          &transformation_sequence);
 
-  SetUpIdSynonyms(&fact_manager, context.get());
+  SetUpIdSynonyms(&fact_manager);
 
   std::vector<std::set<uint32_t>> expected_equivalence_classes = {
       {9, 15, 21}, {11, 16, 22}, {10, 23}, {6}, {24, 26, 30}};

--- a/test/fuzz/fuzzer_pass_construct_composites_test.cpp
+++ b/test/fuzz/fuzzer_pass_construct_composites_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/fuzzer_pass_construct_composites.h"
+
 #include "source/fuzz/pseudo_random_generator.h"
 #include "test/fuzz/fuzz_test_util.h"
 
@@ -81,7 +82,7 @@ TEST(FuzzerPassConstructCompositesTest, IsomorphicStructs) {
         BuildModule(env, consumer, shader, kFuzzAssembleOption);
     ASSERT_TRUE(IsValid(env, context.get()));
 
-    FactManager fact_manager;
+    FactManager fact_manager(context.get());
     spvtools::ValidatorOptions validator_options;
     TransformationContext transformation_context(&fact_manager,
                                                  validator_options);
@@ -163,7 +164,7 @@ TEST(FuzzerPassConstructCompositesTest, IsomorphicArrays) {
         BuildModule(env, consumer, shader, kFuzzAssembleOption);
     ASSERT_TRUE(IsValid(env, context.get()));
 
-    FactManager fact_manager;
+    FactManager fact_manager(context.get());
     spvtools::ValidatorOptions validator_options;
     TransformationContext transformation_context(&fact_manager,
                                                  validator_options);

--- a/test/fuzz/fuzzer_pass_donate_modules_test.cpp
+++ b/test/fuzz/fuzzer_pass_donate_modules_test.cpp
@@ -196,7 +196,7 @@ TEST(FuzzerPassDonateModulesTest, BasicDonation) {
       BuildModule(env, consumer, donor_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, donor_context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(recipient_context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -274,7 +274,7 @@ TEST(FuzzerPassDonateModulesTest, DonationWithUniforms) {
       env, consumer, recipient_and_donor_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, donor_context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(recipient_context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -402,7 +402,7 @@ TEST(FuzzerPassDonateModulesTest, DonationWithInputAndOutputVariables) {
       env, consumer, recipient_and_donor_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, donor_context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(recipient_context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -494,7 +494,7 @@ TEST(FuzzerPassDonateModulesTest, DonateFunctionTypeWithDifferentPointers) {
       env, consumer, recipient_and_donor_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, donor_context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(recipient_context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -561,7 +561,7 @@ TEST(FuzzerPassDonateModulesTest, DonateOpConstantNull) {
       BuildModule(env, consumer, donor_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, donor_context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(recipient_context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -686,7 +686,7 @@ TEST(FuzzerPassDonateModulesTest, DonateCodeThatUsesImages) {
       BuildModule(env, consumer, donor_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, donor_context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(recipient_context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -779,7 +779,7 @@ TEST(FuzzerPassDonateModulesTest, DonateCodeThatUsesSampler) {
       BuildModule(env, consumer, donor_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, donor_context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(recipient_context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -908,7 +908,7 @@ TEST(FuzzerPassDonateModulesTest, DonateCodeThatUsesImageStructField) {
       BuildModule(env, consumer, donor_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, donor_context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(recipient_context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1041,7 +1041,7 @@ TEST(FuzzerPassDonateModulesTest, DonateCodeThatUsesImageFunctionParameter) {
       BuildModule(env, consumer, donor_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, donor_context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(recipient_context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1120,7 +1120,7 @@ TEST(FuzzerPassDonateModulesTest, DonateShaderWithImageStorageClass) {
       BuildModule(env, consumer, donor_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, donor_context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(recipient_context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1204,7 +1204,7 @@ TEST(FuzzerPassDonateModulesTest, DonateComputeShaderWithRuntimeArray) {
       BuildModule(env, consumer, donor_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, donor_context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(recipient_context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1305,7 +1305,7 @@ TEST(FuzzerPassDonateModulesTest, DonateComputeShaderWithRuntimeArrayLivesafe) {
       BuildModule(env, consumer, donor_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, donor_context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(recipient_context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1374,7 +1374,7 @@ TEST(FuzzerPassDonateModulesTest, DonateComputeShaderWithWorkgroupVariables) {
       BuildModule(env, consumer, donor_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, donor_context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(recipient_context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1481,7 +1481,7 @@ TEST(FuzzerPassDonateModulesTest, DonateComputeShaderWithAtomics) {
       BuildModule(env, consumer, donor_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, donor_context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(recipient_context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1662,7 +1662,7 @@ TEST(FuzzerPassDonateModulesTest, Miscellaneous1) {
       BuildModule(env, consumer, donor_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, donor_context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(recipient_context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1731,7 +1731,7 @@ TEST(FuzzerPassDonateModulesTest, OpSpecConstantInstructions) {
       BuildModule(env, consumer, donor_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, donor_context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(recipient_context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1885,7 +1885,7 @@ TEST(FuzzerPassDonateModulesTest, DonationSupportsOpTypeRuntimeArray) {
       BuildModule(env, consumer, donor_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, donor_context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(recipient_context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1955,7 +1955,7 @@ TEST(FuzzerPassDonateModulesTest, HandlesCapabilities) {
       BuildModule(env, consumer, donor_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, donor_context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(recipient_context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -2185,7 +2185,7 @@ TEST(FuzzerPassDonateModulesTest, HandlesOpPhisInMergeBlock) {
       BuildModule(env, consumer, donor_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, donor_context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(recipient_context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/fuzzer_pass_outline_functions_test.cpp
+++ b/test/fuzz/fuzzer_pass_outline_functions_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/fuzzer_pass_outline_functions.h"
+
 #include "source/fuzz/pseudo_random_generator.h"
 #include "test/fuzz/fuzz_test_util.h"
 
@@ -118,7 +119,7 @@ TEST(FuzzerPassOutlineFunctionsTest, EntryIsAlreadySuitable) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -163,7 +164,7 @@ TEST(FuzzerPassOutlineFunctionsTest, EntryHasOpVariable) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -289,7 +290,7 @@ TEST(FuzzerPassOutlineFunctionsTest, EntryBlockIsHeader) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -458,7 +459,7 @@ TEST(FuzzerPassOutlineFunctionsTest, ExitBlock) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/fuzzer_pass_test.cpp
+++ b/test/fuzz/fuzzer_pass_test.cpp
@@ -76,7 +76,7 @@ TEST(FuzzerPassTest, ForEachInstructionWithInstructionDescriptor) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/instruction_descriptor_test.cpp
+++ b/test/fuzz/instruction_descriptor_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/instruction_descriptor.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {

--- a/test/fuzz/transformation_access_chain_test.cpp
+++ b/test/fuzz/transformation_access_chain_test.cpp
@@ -117,13 +117,13 @@ TEST(TransformationAccessChainTest, BasicTest) {
 
   // Indices 0-5 are in ids 80-85
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      54, context.get());
+      54);
 
   // Bad: id is not fresh
   ASSERT_FALSE(TransformationAccessChain(
@@ -403,7 +403,7 @@ TEST(TransformationAccessChainTest, IsomorphicStructs) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -511,7 +511,7 @@ TEST(TransformationAccessChainTest, ClampingVariables) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_bit_instruction_synonym_test.cpp
+++ b/test/fuzz/transformation_add_bit_instruction_synonym_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_add_bit_instruction_synonym.h"
+
 #include "source/fuzz/instruction_descriptor.h"
 #include "test/fuzz/fuzz_test_util.h"
 
@@ -80,7 +81,7 @@ TEST(TransformationAddBitInstructionSynonymTest, IsApplicable) {
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -221,7 +222,7 @@ TEST(TransformationAddBitInstructionSynonymTest, AddBitwiseSynonym) {
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_constant_boolean_test.cpp
+++ b/test/fuzz/transformation_add_constant_boolean_test.cpp
@@ -43,7 +43,7 @@ TEST(TransformationAddConstantBooleanTest, NeitherPresentInitiallyAddBoth) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -107,10 +107,10 @@ TEST(TransformationAddConstantBooleanTest, NeitherPresentInitiallyAddBoth) {
   irrelevant_false.Apply(context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  ASSERT_FALSE(fact_manager.IdIsIrrelevant(100, context.get()));
-  ASSERT_FALSE(fact_manager.IdIsIrrelevant(101, context.get()));
-  ASSERT_TRUE(fact_manager.IdIsIrrelevant(102, context.get()));
-  ASSERT_TRUE(fact_manager.IdIsIrrelevant(103, context.get()));
+  ASSERT_FALSE(fact_manager.IdIsIrrelevant(100));
+  ASSERT_FALSE(fact_manager.IdIsIrrelevant(101));
+  ASSERT_TRUE(fact_manager.IdIsIrrelevant(102));
+  ASSERT_TRUE(fact_manager.IdIsIrrelevant(103));
 
   std::string after_transformation = R"(
                OpCapability Shader
@@ -160,7 +160,7 @@ TEST(TransformationAddConstantBooleanTest, NoOpTypeBoolPresent) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_constant_composite_test.cpp
+++ b/test/fuzz/transformation_add_constant_composite_test.cpp
@@ -64,7 +64,7 @@ TEST(TransformationAddConstantCompositeTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -135,11 +135,11 @@ TEST(TransformationAddConstantCompositeTest, BasicTest) {
   ASSERT_TRUE(IsValid(env, context.get()));
 
   for (uint32_t id = 100; id <= 106; ++id) {
-    ASSERT_FALSE(fact_manager.IdIsIrrelevant(id, context.get()));
+    ASSERT_FALSE(fact_manager.IdIsIrrelevant(id));
   }
 
   for (uint32_t id = 107; id <= 113; ++id) {
-    ASSERT_TRUE(fact_manager.IdIsIrrelevant(id, context.get()));
+    ASSERT_TRUE(fact_manager.IdIsIrrelevant(id));
   }
 
   std::string after_transformation = R"(

--- a/test/fuzz/transformation_add_constant_null_test.cpp
+++ b/test/fuzz/transformation_add_constant_null_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_add_constant_null.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -49,7 +50,7 @@ TEST(TransformationAddConstantNullTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_constant_scalar_test.cpp
+++ b/test/fuzz/transformation_add_constant_scalar_test.cpp
@@ -70,7 +70,7 @@ TEST(TransformationAddConstantScalarTest, IsApplicable) {
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -166,7 +166,7 @@ TEST(TransformationAddConstantScalarTest, Apply) {
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -272,11 +272,11 @@ TEST(TransformationAddConstantScalarTest, Apply) {
   ASSERT_TRUE(IsValid(env, context.get()));
 
   for (uint32_t result_id = 19; result_id <= 24; ++result_id) {
-    ASSERT_FALSE(fact_manager.IdIsIrrelevant(result_id, context.get()));
+    ASSERT_FALSE(fact_manager.IdIsIrrelevant(result_id));
   }
 
   for (uint32_t result_id = 25; result_id <= 30; ++result_id) {
-    ASSERT_TRUE(fact_manager.IdIsIrrelevant(result_id, context.get()));
+    ASSERT_TRUE(fact_manager.IdIsIrrelevant(result_id));
   }
 
   std::string variant_shader = R"(

--- a/test/fuzz/transformation_add_copy_memory_test.cpp
+++ b/test/fuzz/transformation_add_copy_memory_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_add_copy_memory.h"
+
 #include "source/fuzz/instruction_descriptor.h"
 #include "test/fuzz/fuzz_test_util.h"
 
@@ -139,7 +140,7 @@ TEST(TransformationAddCopyMemoryTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_dead_block_test.cpp
+++ b/test/fuzz/transformation_add_dead_block_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_add_dead_block.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -61,7 +62,7 @@ TEST(TransformationAddDeadBlockTest, BasicTest) {
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -171,7 +172,7 @@ TEST(TransformationAddDeadBlockTest, TargetBlockMustNotBeSelectionMerge) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -219,7 +220,7 @@ TEST(TransformationAddDeadBlockTest, TargetBlockMustNotBeLoopMergeOrContinue) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -265,7 +266,7 @@ TEST(TransformationAddDeadBlockTest, SourceBlockMustNotBeLoopHead) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -305,7 +306,7 @@ TEST(TransformationAddDeadBlockTest, OpPhiInTarget) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -378,7 +379,7 @@ TEST(TransformationAddDeadBlockTest, BackEdge) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_dead_break_test.cpp
+++ b/test/fuzz/transformation_add_dead_break_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_add_dead_break.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -98,7 +99,7 @@ TEST(TransformationAddDeadBreakTest, BreaksOutOfSimpleIf) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -340,7 +341,7 @@ TEST(TransformationAddDeadBreakTest, BreakOutOfNestedIfs) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -703,7 +704,7 @@ TEST(TransformationAddDeadBreakTest, BreakOutOfNestedSwitches) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1125,7 +1126,7 @@ TEST(TransformationAddDeadBreakTest, BreakOutOfLoopNest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1462,7 +1463,7 @@ TEST(TransformationAddDeadBreakTest, NoBreakFromContinueConstruct) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1525,7 +1526,7 @@ TEST(TransformationAddDeadBreakTest, BreakFromBackEdgeBlock) {
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1659,7 +1660,7 @@ TEST(TransformationAddDeadBreakTest, SelectionInContinueConstruct) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1877,7 +1878,7 @@ TEST(TransformationAddDeadBreakTest, LoopInContinueConstruct) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -2098,7 +2099,7 @@ TEST(TransformationAddDeadBreakTest, PhiInstructions) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -2289,7 +2290,7 @@ TEST(TransformationAddDeadBreakTest, RespectDominanceRules1) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -2346,7 +2347,7 @@ TEST(TransformationAddDeadBreakTest, RespectDominanceRules2) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -2397,7 +2398,7 @@ TEST(TransformationAddDeadBreakTest, RespectDominanceRules3) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -2489,7 +2490,7 @@ TEST(TransformationAddDeadBreakTest, RespectDominanceRules4) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -2575,7 +2576,7 @@ TEST(TransformationAddDeadBreakTest, RespectDominanceRules5) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -2636,7 +2637,7 @@ TEST(TransformationAddDeadBreakTest, RespectDominanceRules6) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -2699,7 +2700,7 @@ TEST(TransformationAddDeadBreakTest, RespectDominanceRules7) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -2749,7 +2750,7 @@ TEST(TransformationAddDeadBreakTest, RespectDominanceRules8) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -2799,7 +2800,7 @@ TEST(TransformationAddDeadBreakTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_dead_continue_test.cpp
+++ b/test/fuzz/transformation_add_dead_continue_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_add_dead_continue.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -96,7 +97,7 @@ TEST(TransformationAddDeadContinueTest, SimpleExample) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -370,7 +371,7 @@ TEST(TransformationAddDeadContinueTest, LoopNest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -610,7 +611,7 @@ TEST(TransformationAddDeadConditionalTest, LoopInContinueConstruct) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -821,7 +822,7 @@ TEST(TransformationAddDeadContinueTest, PhiInstructions) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -996,7 +997,7 @@ TEST(TransformationAddDeadContinueTest, RespectDominanceRules1) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1112,7 +1113,7 @@ TEST(TransformationAddDeadContinueTest, RespectDominanceRules2) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1164,7 +1165,7 @@ TEST(TransformationAddDeadContinueTest, RespectDominanceRules3) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1307,7 +1308,7 @@ TEST(TransformationAddDeadContinueTest, Miscellaneous1) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1377,7 +1378,7 @@ TEST(TransformationAddDeadContinueTest, Miscellaneous2) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1439,7 +1440,7 @@ TEST(TransformationAddDeadContinueTest, Miscellaneous3) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1503,7 +1504,7 @@ TEST(TransformationAddDeadContinueTest, Miscellaneous4) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1559,7 +1560,7 @@ TEST(TransformationAddDeadContinueTest, Miscellaneous5) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1608,7 +1609,7 @@ TEST(TransformationAddDeadContinueTest, Miscellaneous6) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_function_test.cpp
+++ b/test/fuzz/transformation_add_function_test.cpp
@@ -144,7 +144,7 @@ TEST(TransformationAddFunctionTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -493,7 +493,7 @@ TEST(TransformationAddFunctionTest, InapplicableTransformations) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -631,17 +631,17 @@ TEST(TransformationAddFunctionTest, LoopLimiters) {
   instructions.push_back(MakeInstructionMessage(SpvOpReturn, 0, 0, {}));
   instructions.push_back(MakeInstructionMessage(SpvOpFunctionEnd, 0, 0, {}));
 
-  FactManager fact_manager1;
-  FactManager fact_manager2;
+  const auto context1 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  const auto context2 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context1.get()));
+
+  FactManager fact_manager1(context1.get());
+  FactManager fact_manager2(context2.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context1(&fact_manager1,
                                                 validator_options);
   TransformationContext transformation_context2(&fact_manager2,
                                                 validator_options);
-
-  const auto context1 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
-  const auto context2 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
-  ASSERT_TRUE(IsValid(env, context1.get()));
 
   TransformationAddFunction add_dead_function(instructions);
   ASSERT_TRUE(
@@ -853,17 +853,17 @@ TEST(TransformationAddFunctionTest, KillAndUnreachableInVoidFunction) {
   instructions.push_back(MakeInstructionMessage(SpvOpKill, 0, 0, {}));
   instructions.push_back(MakeInstructionMessage(SpvOpFunctionEnd, 0, 0, {}));
 
-  FactManager fact_manager1;
-  FactManager fact_manager2;
+  const auto context1 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  const auto context2 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context1.get()));
+
+  FactManager fact_manager1(context1.get());
+  FactManager fact_manager2(context2.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context1(&fact_manager1,
                                                 validator_options);
   TransformationContext transformation_context2(&fact_manager2,
                                                 validator_options);
-
-  const auto context1 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
-  const auto context2 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
-  ASSERT_TRUE(IsValid(env, context1.get()));
 
   TransformationAddFunction add_dead_function(instructions);
   ASSERT_TRUE(
@@ -1008,17 +1008,17 @@ TEST(TransformationAddFunctionTest, KillAndUnreachableInNonVoidFunction) {
   instructions.push_back(MakeInstructionMessage(SpvOpKill, 0, 0, {}));
   instructions.push_back(MakeInstructionMessage(SpvOpFunctionEnd, 0, 0, {}));
 
-  FactManager fact_manager1;
-  FactManager fact_manager2;
+  const auto context1 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  const auto context2 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context1.get()));
+
+  FactManager fact_manager1(context1.get());
+  FactManager fact_manager2(context2.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context1(&fact_manager1,
                                                 validator_options);
   TransformationContext transformation_context2(&fact_manager2,
                                                 validator_options);
-
-  const auto context1 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
-  const auto context2 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
-  ASSERT_TRUE(IsValid(env, context1.get()));
 
   TransformationAddFunction add_dead_function(instructions);
   ASSERT_TRUE(
@@ -1295,17 +1295,17 @@ TEST(TransformationAddFunctionTest, ClampedAccessChains) {
   instructions.push_back(MakeInstructionMessage(SpvOpReturn, 0, 0, {}));
   instructions.push_back(MakeInstructionMessage(SpvOpFunctionEnd, 0, 0, {}));
 
-  FactManager fact_manager1;
-  FactManager fact_manager2;
+  const auto context1 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  const auto context2 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context1.get()));
+
+  FactManager fact_manager1(context1.get());
+  FactManager fact_manager2(context2.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context1(&fact_manager1,
                                                 validator_options);
   TransformationContext transformation_context2(&fact_manager2,
                                                 validator_options);
-
-  const auto context1 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
-  const auto context2 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
-  ASSERT_TRUE(IsValid(env, context1.get()));
 
   TransformationAddFunction add_dead_function(instructions);
   ASSERT_TRUE(
@@ -1622,8 +1622,12 @@ TEST(TransformationAddFunctionTest, LivesafeCanCallLivesafe) {
   instructions.push_back(MakeInstructionMessage(SpvOpReturn, 0, 0, {}));
   instructions.push_back(MakeInstructionMessage(SpvOpFunctionEnd, 0, 0, {}));
 
-  FactManager fact_manager1;
-  FactManager fact_manager2;
+  const auto context1 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  const auto context2 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context1.get()));
+
+  FactManager fact_manager1(context1.get());
+  FactManager fact_manager2(context2.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context1(&fact_manager1,
                                                 validator_options);
@@ -1632,10 +1636,6 @@ TEST(TransformationAddFunctionTest, LivesafeCanCallLivesafe) {
 
   // Mark function 6 as livesafe.
   transformation_context2.GetFactManager()->AddFactFunctionIsLivesafe(6);
-
-  const auto context1 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
-  const auto context2 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
-  ASSERT_TRUE(IsValid(env, context1.get()));
 
   TransformationAddFunction add_dead_function(instructions);
   ASSERT_TRUE(
@@ -1722,17 +1722,17 @@ TEST(TransformationAddFunctionTest, LivesafeOnlyCallsLivesafe) {
   instructions.push_back(MakeInstructionMessage(SpvOpReturn, 0, 0, {}));
   instructions.push_back(MakeInstructionMessage(SpvOpFunctionEnd, 0, 0, {}));
 
-  FactManager fact_manager1;
-  FactManager fact_manager2;
+  const auto context1 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  const auto context2 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context1.get()));
+
+  FactManager fact_manager1(context1.get());
+  FactManager fact_manager2(context2.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context1(&fact_manager1,
                                                 validator_options);
   TransformationContext transformation_context2(&fact_manager2,
                                                 validator_options);
-
-  const auto context1 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
-  const auto context2 = BuildModule(env, consumer, shader, kFuzzAssembleOption);
-  ASSERT_TRUE(IsValid(env, context1.get()));
 
   TransformationAddFunction add_dead_function(instructions);
   ASSERT_TRUE(
@@ -1853,14 +1853,13 @@ TEST(TransformationAddFunctionTest,
   )";
   const auto env = SPV_ENV_UNIVERSAL_1_4;
   const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
-
-  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
-  ASSERT_TRUE(IsValid(env, context.get()));
 
   // Make a sequence of instruction messages corresponding to function %6 in
   // |donor|.
@@ -2011,14 +2010,13 @@ TEST(TransformationAddFunctionTest,
   )";
   const auto env = SPV_ENV_UNIVERSAL_1_4;
   const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
-
-  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
-  ASSERT_TRUE(IsValid(env, context.get()));
 
   // Make a sequence of instruction messages corresponding to function %6 in
   // |donor|.
@@ -2167,14 +2165,13 @@ TEST(TransformationAddFunctionTest, LoopLimitersHeaderIsBackEdgeBlock) {
   )";
   const auto env = SPV_ENV_UNIVERSAL_1_4;
   const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
-
-  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
-  ASSERT_TRUE(IsValid(env, context.get()));
 
   // Make a sequence of instruction messages corresponding to function %6 in
   // |donor|.
@@ -2315,14 +2312,13 @@ TEST(TransformationAddFunctionTest, InfiniteLoop) {
   )";
   const auto env = SPV_ENV_UNIVERSAL_1_4;
   const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
-
-  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
-  ASSERT_TRUE(IsValid(env, context.get()));
 
   // Make a sequence of instruction messages corresponding to function %6 in
   // |donor|.
@@ -2430,14 +2426,13 @@ TEST(TransformationAddFunctionTest, UnreachableContinueConstruct) {
 
   const auto env = SPV_ENV_UNIVERSAL_1_4;
   const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
-
-  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
-  ASSERT_TRUE(IsValid(env, context.get()));
 
   // Make a sequence of instruction messages corresponding to function %6 in
   // |donor|.
@@ -2596,14 +2591,13 @@ TEST(TransformationAddFunctionTest, LoopLimitersAndOpPhi1) {
 
   const auto env = SPV_ENV_UNIVERSAL_1_4;
   const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
-
-  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
-  ASSERT_TRUE(IsValid(env, context.get()));
 
   // Make a sequence of instruction messages corresponding to function %8 in
   // |donor|.
@@ -2789,14 +2783,13 @@ TEST(TransformationAddFunctionTest, LoopLimitersAndOpPhi2) {
 
   const auto env = SPV_ENV_UNIVERSAL_1_4;
   const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
-
-  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
-  ASSERT_TRUE(IsValid(env, context.get()));
 
   // Make a sequence of instruction messages corresponding to function %8 in
   // |donor|.
@@ -2940,14 +2933,13 @@ TEST(TransformationAddFunctionTest, StaticallyOutOfBoundsArrayAccess) {
   )";
   const auto env = SPV_ENV_UNIVERSAL_1_4;
   const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
-
-  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
-  ASSERT_TRUE(IsValid(env, context.get()));
 
   // Make a sequence of instruction messages corresponding to function %6 in
   // |donor|.

--- a/test/fuzz/transformation_add_global_undef_test.cpp
+++ b/test/fuzz/transformation_add_global_undef_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_add_global_undef.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -46,7 +47,7 @@ TEST(TransformationAddGlobalUndefTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_global_variable_test.cpp
+++ b/test/fuzz/transformation_add_global_variable_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_add_global_variable.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -59,7 +60,7 @@ TEST(TransformationAddGlobalVariableTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -248,7 +249,7 @@ TEST(TransformationAddGlobalVariableTest, TestEntryPointInterfaceEnlargement) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -345,7 +346,7 @@ TEST(TransformationAddGlobalVariableTest, TestAddingWorkgroupGlobals) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_image_sample_unused_components_test.cpp
+++ b/test/fuzz/transformation_add_image_sample_unused_components_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_add_image_sample_unused_components.h"
+
 #include "source/fuzz/instruction_descriptor.h"
 #include "test/fuzz/fuzz_test_util.h"
 
@@ -65,7 +66,7 @@ TEST(TransformationAddImageSampleUnusedComponentsTest, IsApplicable) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -193,7 +194,7 @@ TEST(TransformationAddImageSampleUnusedComponentsTest, Apply) {
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_local_variable_test.cpp
+++ b/test/fuzz/transformation_add_local_variable_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_add_local_variable.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -78,7 +79,7 @@ TEST(TransformationAddLocalVariableTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_loop_preheader_test.cpp
+++ b/test/fuzz/transformation_add_loop_preheader_test.cpp
@@ -67,7 +67,7 @@ TEST(TransformationAddLoopPreheaderTest, SimpleTest) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -198,7 +198,7 @@ TEST(TransformationAddLoopPreheaderTest, OpPhi) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_loop_to_create_int_constant_synonym_test.cpp
+++ b/test/fuzz/transformation_add_loop_to_create_int_constant_synonym_test.cpp
@@ -76,7 +76,7 @@ TEST(TransformationAddLoopToCreateIntConstantSynonymTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -187,7 +187,7 @@ TEST(TransformationAddLoopToCreateIntConstantSynonymTest,
         BuildModule(env, consumer, shader, kFuzzAssembleOption);
     ASSERT_TRUE(IsValid(env, context.get()));
 
-    FactManager fact_manager;
+    FactManager fact_manager(context.get());
     spvtools::ValidatorOptions validator_options;
     TransformationContext transformation_context(&fact_manager,
                                                  validator_options);
@@ -228,7 +228,7 @@ TEST(TransformationAddLoopToCreateIntConstantSynonymTest,
         BuildModule(env, consumer, shader, kFuzzAssembleOption);
     ASSERT_TRUE(IsValid(env, context.get()));
 
-    FactManager fact_manager;
+    FactManager fact_manager(context.get());
     spvtools::ValidatorOptions validator_options;
     TransformationContext transformation_context(&fact_manager,
                                                  validator_options);
@@ -269,7 +269,7 @@ TEST(TransformationAddLoopToCreateIntConstantSynonymTest,
         BuildModule(env, consumer, shader, kFuzzAssembleOption);
     ASSERT_TRUE(IsValid(env, context.get()));
 
-    FactManager fact_manager;
+    FactManager fact_manager(context.get());
     spvtools::ValidatorOptions validator_options;
     TransformationContext transformation_context(&fact_manager,
                                                  validator_options);
@@ -337,7 +337,7 @@ TEST(TransformationAddLoopToCreateIntConstantSynonymTest, Simple) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -561,7 +561,7 @@ TEST(TransformationAddLoopToCreateIntConstantSynonymTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -752,7 +752,7 @@ TEST(TransformationAddLoopToCreateIntConstantSynonymTest, 64BitConstants) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -871,7 +871,7 @@ TEST(TransformationAddLoopToCreateIntConstantSynonymTest, Underflow) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_no_contraction_decoration_test.cpp
+++ b/test/fuzz/transformation_add_no_contraction_decoration_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_add_no_contraction_decoration.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -93,7 +94,7 @@ TEST(TransformationAddNoContractionDecorationTest, BasicScenarios) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_opphi_synonym_test.cpp
+++ b/test/fuzz/transformation_add_opphi_synonym_test.cpp
@@ -30,13 +30,13 @@ protobufs::Fact MakeSynonymFact(uint32_t first, uint32_t second) {
 }
 
 // Adds synonym facts to the fact manager.
-void SetUpIdSynonyms(FactManager* fact_manager, opt::IRContext* context) {
-  fact_manager->AddFact(MakeSynonymFact(11, 9), context);
-  fact_manager->AddFact(MakeSynonymFact(13, 9), context);
-  fact_manager->AddFact(MakeSynonymFact(14, 9), context);
-  fact_manager->AddFact(MakeSynonymFact(19, 9), context);
-  fact_manager->AddFact(MakeSynonymFact(20, 9), context);
-  fact_manager->AddFact(MakeSynonymFact(10, 21), context);
+void SetUpIdSynonyms(FactManager* fact_manager) {
+  fact_manager->AddFact(MakeSynonymFact(11, 9));
+  fact_manager->AddFact(MakeSynonymFact(13, 9));
+  fact_manager->AddFact(MakeSynonymFact(14, 9));
+  fact_manager->AddFact(MakeSynonymFact(19, 9));
+  fact_manager->AddFact(MakeSynonymFact(20, 9));
+  fact_manager->AddFact(MakeSynonymFact(10, 21));
 }
 
 TEST(TransformationAddOpPhiSynonymTest, Inapplicable) {
@@ -85,13 +85,13 @@ TEST(TransformationAddOpPhiSynonymTest, Inapplicable) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  SetUpIdSynonyms(&fact_manager, context.get());
-  fact_manager.AddFact(MakeSynonymFact(23, 24), context.get());
+  SetUpIdSynonyms(&fact_manager);
+  fact_manager.AddFact(MakeSynonymFact(23, 24));
 
   // %13 is not a block label.
   ASSERT_FALSE(TransformationAddOpPhiSynonym(13, {{}}, 100)
@@ -207,16 +207,16 @@ TEST(TransformationAddOpPhiSynonymTest, Apply) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  SetUpIdSynonyms(&fact_manager, context.get());
+  SetUpIdSynonyms(&fact_manager);
 
   // Add some further synonym facts.
-  fact_manager.AddFact(MakeSynonymFact(28, 9), context.get());
-  fact_manager.AddFact(MakeSynonymFact(30, 9), context.get());
+  fact_manager.AddFact(MakeSynonymFact(28, 9));
+  fact_manager.AddFact(MakeSynonymFact(30, 9));
 
   auto transformation1 = TransformationAddOpPhiSynonym(17, {{{15, 13}}}, 100);
   ASSERT_TRUE(
@@ -352,14 +352,14 @@ TEST(TransformationAddOpPhiSynonymTest, VariablePointers) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
   // Declare synonyms
-  fact_manager.AddFact(MakeSynonymFact(3, 15), context.get());
-  fact_manager.AddFact(MakeSynonymFact(12, 16), context.get());
+  fact_manager.AddFact(MakeSynonymFact(3, 15));
+  fact_manager.AddFact(MakeSynonymFact(12, 16));
 
   // Remove the VariablePointers capability.
   context.get()->get_feature_mgr()->RemoveCapability(

--- a/test/fuzz/transformation_add_parameter_test.cpp
+++ b/test/fuzz/transformation_add_parameter_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_add_parameter.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -101,7 +102,7 @@ TEST(TransformationAddParameterTest, NonPointerBasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -136,28 +137,28 @@ TEST(TransformationAddParameterTest, NonPointerBasicTest) {
     ASSERT_TRUE(correct.IsApplicable(context.get(), transformation_context));
     correct.Apply(context.get(), &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
-    ASSERT_TRUE(fact_manager.IdIsIrrelevant(60, context.get()));
+    ASSERT_TRUE(fact_manager.IdIsIrrelevant(60));
   }
   {
     TransformationAddParameter correct(17, 62, 7, {{}}, 63);
     ASSERT_TRUE(correct.IsApplicable(context.get(), transformation_context));
     correct.Apply(context.get(), &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
-    ASSERT_TRUE(fact_manager.IdIsIrrelevant(62, context.get()));
+    ASSERT_TRUE(fact_manager.IdIsIrrelevant(62));
   }
   {
     TransformationAddParameter correct(29, 64, 31, {{}}, 65);
     ASSERT_TRUE(correct.IsApplicable(context.get(), transformation_context));
     correct.Apply(context.get(), &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
-    ASSERT_TRUE(fact_manager.IdIsIrrelevant(64, context.get()));
+    ASSERT_TRUE(fact_manager.IdIsIrrelevant(64));
   }
   {
     TransformationAddParameter correct(34, 66, 7, {{}}, 67);
     ASSERT_TRUE(correct.IsApplicable(context.get(), transformation_context));
     correct.Apply(context.get(), &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
-    ASSERT_TRUE(fact_manager.IdIsIrrelevant(66, context.get()));
+    ASSERT_TRUE(fact_manager.IdIsIrrelevant(66));
   }
 
   std::string expected_shader = R"(
@@ -321,7 +322,7 @@ TEST(TransformationAddParameterTest, NonPointerNotApplicableTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -448,7 +449,7 @@ TEST(TransformationAddParameterTest, PointerFunctionTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -667,7 +668,7 @@ TEST(TransformationAddParameterTest, PointerPrivateWorkgroupTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -880,7 +881,7 @@ TEST(TransformationAddParameterTest, PointerMoreEntriesInMapTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1036,7 +1037,7 @@ TEST(TransformationAddParameterTest, PointeeValueIsIrrelevantTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_relaxed_decoration_test.cpp
+++ b/test/fuzz/transformation_add_relaxed_decoration_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_add_relaxed_decoration.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -66,7 +67,7 @@ TEST(TransformationAddRelaxedDecorationTest, BasicScenarios) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_synonym_test.cpp
+++ b/test/fuzz/transformation_add_synonym_test.cpp
@@ -70,12 +70,12 @@ TEST(TransformationAddSynonymTest, NotApplicable) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  fact_manager.AddFactIdIsIrrelevant(24, context.get());
+  fact_manager.AddFactIdIsIrrelevant(24);
 
   auto insert_before = MakeInstructionDescriptor(22, SpvOpReturn, 0);
 
@@ -208,7 +208,7 @@ TEST(TransformationAddSynonymTest, AddZeroSubZeroMulOne) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -345,7 +345,7 @@ TEST(TransformationAddSynonymTest, LogicalAndLogicalOr) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -439,7 +439,7 @@ TEST(TransformationAddSynonymTest, LogicalAndConstantIsNotPresent) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -479,7 +479,7 @@ TEST(TransformationAddSynonymTest, LogicalOrConstantIsNotPresent) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -539,7 +539,7 @@ TEST(TransformationAddSynonymTest, CopyObject) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -636,7 +636,7 @@ TEST(TransformationAddSynonymTest, CopyBooleanConstants) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -944,7 +944,7 @@ TEST(TransformationAddSynonymTest, CheckIllegalCases) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1139,7 +1139,7 @@ TEST(TransformationAddSynonymTest, MiscellaneousCopies) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1249,7 +1249,7 @@ TEST(TransformationAddSynonymTest, DoNotCopyNullOrUndefPointers) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1295,13 +1295,12 @@ TEST(TransformationAddSynonymTest, PropagateIrrelevantPointeeFact) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      8, context.get());
+  transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(8);
 
   TransformationAddSynonym transformation1(
       8, protobufs::TransformationAddSynonym::COPY_OBJECT, 100,
@@ -1381,7 +1380,7 @@ TEST(TransformationAddSynonym, DoNotCopyOpSampledImage) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1421,7 +1420,7 @@ TEST(TransformationAddSynonym, DoNotCopyVoidRunctionResult) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_type_array_test.cpp
+++ b/test/fuzz/transformation_add_type_array_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_add_type_array.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -53,7 +54,7 @@ TEST(TransformationAddTypeArrayTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_type_boolean_test.cpp
+++ b/test/fuzz/transformation_add_type_boolean_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_add_type_boolean.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -41,7 +42,7 @@ TEST(TransformationAddTypeBooleanTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_type_float_test.cpp
+++ b/test/fuzz/transformation_add_type_float_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_add_type_float.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -45,7 +46,7 @@ TEST(TransformationAddTypeFloatTest, IsApplicable) {
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -97,7 +98,7 @@ TEST(TransformationAddTypeFloatTest, Apply) {
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_type_function_test.cpp
+++ b/test/fuzz/transformation_add_type_function_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_add_type_function.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -58,7 +59,7 @@ TEST(TransformationAddTypeFunctionTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_type_int_test.cpp
+++ b/test/fuzz/transformation_add_type_int_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_add_type_int.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -45,7 +46,7 @@ TEST(TransformationAddTypeIntTest, IsApplicable) {
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -113,7 +114,7 @@ TEST(TransformationAddTypeIntTest, Apply) {
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_type_matrix_test.cpp
+++ b/test/fuzz/transformation_add_type_matrix_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_add_type_matrix.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -46,7 +47,7 @@ TEST(TransformationAddTypeMatrixTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_type_pointer_test.cpp
+++ b/test/fuzz/transformation_add_type_pointer_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_add_type_pointer.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -96,7 +97,7 @@ TEST(TransformationAddTypePointerTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_type_struct_test.cpp
+++ b/test/fuzz/transformation_add_type_struct_test.cpp
@@ -47,7 +47,7 @@ TEST(TransformationAddTypeStructTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -139,7 +139,7 @@ TEST(TransformationAddTypeStructTest, HandlesBuiltInMembers) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_add_type_vector_test.cpp
+++ b/test/fuzz/transformation_add_type_vector_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_add_type_vector.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -44,7 +45,7 @@ TEST(TransformationAddTypeVectorTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_adjust_branch_weights_test.cpp
+++ b/test/fuzz/transformation_adjust_branch_weights_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_adjust_branch_weights.h"
+
 #include "source/fuzz/instruction_descriptor.h"
 #include "test/fuzz/fuzz_test_util.h"
 
@@ -100,7 +101,7 @@ TEST(TransformationAdjustBranchWeightsTest, IsApplicableTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -250,7 +251,7 @@ TEST(TransformationAdjustBranchWeightsTest, ApplyTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_composite_construct_test.cpp
+++ b/test/fuzz/transformation_composite_construct_test.cpp
@@ -129,7 +129,7 @@ TEST(TransformationCompositeConstructTest, ConstructArrays) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -395,7 +395,7 @@ TEST(TransformationCompositeConstructTest, ConstructMatrices) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -608,7 +608,7 @@ TEST(TransformationCompositeConstructTest, ConstructStructs) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -932,7 +932,7 @@ TEST(TransformationCompositeConstructTest, ConstructVectors) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1426,7 +1426,7 @@ TEST(TransformationCompositeConstructTest, AddSynonymsForRelevantIds) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1510,12 +1510,12 @@ TEST(TransformationCompositeConstructTest, DontAddSynonymsForIrrelevantIds) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  fact_manager.AddFactIdIsIrrelevant(25, context.get());
+  fact_manager.AddFactIdIsIrrelevant(25);
 
   TransformationCompositeConstruct transformation(
       32, {25, 28, 31}, MakeInstructionDescriptor(31, SpvOpReturn, 0), 200);

--- a/test/fuzz/transformation_composite_extract_test.cpp
+++ b/test/fuzz/transformation_composite_extract_test.cpp
@@ -96,7 +96,7 @@ TEST(TransformationCompositeExtractTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -351,7 +351,7 @@ TEST(TransformationCompositeExtractTest, IllegalInsertionPoints) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -475,7 +475,7 @@ TEST(TransformationCompositeExtractTest, AddSynonymsForRelevantIds) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -564,12 +564,12 @@ TEST(TransformationCompositeExtractTest, DontAddSynonymsForIrrelevantIds) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  fact_manager.AddFactIdIsIrrelevant(100, context.get());
+  fact_manager.AddFactIdIsIrrelevant(100);
   TransformationCompositeExtract transformation(
       MakeInstructionDescriptor(36, SpvOpConvertFToS, 0), 201, 100, {2});
   ASSERT_TRUE(

--- a/test/fuzz/transformation_composite_insert_test.cpp
+++ b/test/fuzz/transformation_composite_insert_test.cpp
@@ -95,7 +95,7 @@ TEST(TransformationCompositeInsertTest, NotApplicableScenarios) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -216,7 +216,7 @@ TEST(TransformationCompositeInsertTest, EmptyCompositeScenarios) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -359,13 +359,13 @@ TEST(TransformationCompositeInsertTest, IrrelevantCompositeNoSynonyms) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
   // Add fact that the composite is irrelevant.
-  fact_manager.AddFactIdIsIrrelevant(30, context.get());
+  fact_manager.AddFactIdIsIrrelevant(30);
 
   auto transformation_good_1 = TransformationCompositeInsert(
       MakeInstructionDescriptor(30, SpvOpStore, 0), 50, 30, 11, {1, 0, 0});
@@ -464,13 +464,13 @@ TEST(TransformationCompositeInsertTest, IrrelevantObjectSomeSynonyms) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
   // Add fact that the object is irrelevant.
-  fact_manager.AddFactIdIsIrrelevant(11, context.get());
+  fact_manager.AddFactIdIsIrrelevant(11);
 
   auto transformation_good_1 = TransformationCompositeInsert(
       MakeInstructionDescriptor(30, SpvOpStore, 0), 50, 30, 11, {1, 0, 0});
@@ -571,7 +571,7 @@ TEST(TransformationCompositeInsertTest, ApplicableCreatedSynonyms) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -774,7 +774,7 @@ TEST(TransformationCompositeInsertTest, IdNotAvailableScenarios) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_compute_data_synonym_fact_closure_test.cpp
+++ b/test/fuzz/transformation_compute_data_synonym_fact_closure_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_compute_data_synonym_fact_closure.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -122,7 +123,7 @@ TEST(TransformationComputeDataSynonymFactClosureTest, DataSynonymFacts) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -140,7 +141,7 @@ TEST(TransformationComputeDataSynonymFactClosureTest, DataSynonymFacts) {
                                          MakeDataDescriptor(101, {1})));
 
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(24, {}),
-                                  MakeDataDescriptor(101, {}), context.get());
+                                  MakeDataDescriptor(101, {}));
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(24, {}),
                                         MakeDataDescriptor(101, {})));
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(24, {0}),
@@ -157,7 +158,7 @@ TEST(TransformationComputeDataSynonymFactClosureTest, DataSynonymFacts) {
   ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(27, {1}),
                                          MakeDataDescriptor(102, {1})));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(27, {0}),
-                                  MakeDataDescriptor(102, {0}), context.get());
+                                  MakeDataDescriptor(102, {0}));
   ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(27, {}),
                                          MakeDataDescriptor(102, {})));
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(27, {0}),
@@ -165,7 +166,7 @@ TEST(TransformationComputeDataSynonymFactClosureTest, DataSynonymFacts) {
   ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(27, {1}),
                                          MakeDataDescriptor(102, {1})));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(27, {1}),
-                                  MakeDataDescriptor(102, {1}), context.get());
+                                  MakeDataDescriptor(102, {1}));
 
   TransformationComputeDataSynonymFactClosure(100).Apply(
       context.get(), &transformation_context);
@@ -200,15 +201,15 @@ TEST(TransformationComputeDataSynonymFactClosureTest, DataSynonymFacts) {
   ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(34, {3}),
                                          MakeDataDescriptor(105, {3})));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(30, {}),
-                                  MakeDataDescriptor(103, {}), context.get());
+                                  MakeDataDescriptor(103, {}));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(33, {}),
-                                  MakeDataDescriptor(104, {}), context.get());
+                                  MakeDataDescriptor(104, {}));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(34, {0}),
-                                  MakeDataDescriptor(105, {0}), context.get());
+                                  MakeDataDescriptor(105, {0}));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(34, {1}),
-                                  MakeDataDescriptor(105, {1}), context.get());
+                                  MakeDataDescriptor(105, {1}));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(34, {2}),
-                                  MakeDataDescriptor(105, {2}), context.get());
+                                  MakeDataDescriptor(105, {2}));
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(30, {}),
                                         MakeDataDescriptor(103, {})));
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(30, {0}),
@@ -233,7 +234,7 @@ TEST(TransformationComputeDataSynonymFactClosureTest, DataSynonymFacts) {
                                          MakeDataDescriptor(105, {3})));
 
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(34, {3}),
-                                  MakeDataDescriptor(105, {3}), context.get());
+                                  MakeDataDescriptor(105, {3}));
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(33, {0}),
                                         MakeDataDescriptor(104, {0})));
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(34, {3}),
@@ -242,15 +243,15 @@ TEST(TransformationComputeDataSynonymFactClosureTest, DataSynonymFacts) {
   ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(21, {}),
                                          MakeDataDescriptor(100, {})));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(21, {0}),
-                                  MakeDataDescriptor(100, {0}), context.get());
+                                  MakeDataDescriptor(100, {0}));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(21, {1}),
-                                  MakeDataDescriptor(100, {1}), context.get());
+                                  MakeDataDescriptor(100, {1}));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(21, {2}),
-                                  MakeDataDescriptor(100, {2}), context.get());
+                                  MakeDataDescriptor(100, {2}));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(21, {3}),
-                                  MakeDataDescriptor(100, {3}), context.get());
+                                  MakeDataDescriptor(100, {3}));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(21, {4}),
-                                  MakeDataDescriptor(100, {4}), context.get());
+                                  MakeDataDescriptor(100, {4}));
 
   TransformationComputeDataSynonymFactClosure(100).Apply(
       context.get(), &transformation_context);
@@ -263,7 +264,7 @@ TEST(TransformationComputeDataSynonymFactClosureTest, DataSynonymFacts) {
   ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(35, {}),
                                          MakeDataDescriptor(39, {0})));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(39, {0}),
-                                  MakeDataDescriptor(35, {}), context.get());
+                                  MakeDataDescriptor(35, {}));
   ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(39, {0}),
                                          MakeDataDescriptor(107, {0})));
   ASSERT_TRUE(fact_manager.IsSynonymous(MakeDataDescriptor(35, {}),
@@ -280,13 +281,13 @@ TEST(TransformationComputeDataSynonymFactClosureTest, DataSynonymFacts) {
   ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(38, {}),
                                          MakeDataDescriptor(106, {})));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(38, {0}),
-                                  MakeDataDescriptor(36, {}), context.get());
+                                  MakeDataDescriptor(36, {}));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(106, {0}),
-                                  MakeDataDescriptor(36, {}), context.get());
+                                  MakeDataDescriptor(36, {}));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(38, {1}),
-                                  MakeDataDescriptor(37, {}), context.get());
+                                  MakeDataDescriptor(37, {}));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(106, {1}),
-                                  MakeDataDescriptor(37, {}), context.get());
+                                  MakeDataDescriptor(37, {}));
 
   TransformationComputeDataSynonymFactClosure(100).Apply(
       context.get(), &transformation_context);
@@ -305,13 +306,13 @@ TEST(TransformationComputeDataSynonymFactClosureTest, DataSynonymFacts) {
   ASSERT_FALSE(fact_manager.IsSynonymous(MakeDataDescriptor(40, {}),
                                          MakeDataDescriptor(108, {})));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(107, {0}),
-                                  MakeDataDescriptor(35, {}), context.get());
+                                  MakeDataDescriptor(35, {}));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(40, {0}),
-                                  MakeDataDescriptor(108, {0}), context.get());
+                                  MakeDataDescriptor(108, {0}));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(40, {1}),
-                                  MakeDataDescriptor(108, {1}), context.get());
+                                  MakeDataDescriptor(108, {1}));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(40, {2}),
-                                  MakeDataDescriptor(108, {2}), context.get());
+                                  MakeDataDescriptor(108, {2}));
 
   TransformationComputeDataSynonymFactClosure(100).Apply(
       context.get(), &transformation_context);

--- a/test/fuzz/transformation_duplicate_region_with_selection_test.cpp
+++ b/test/fuzz/transformation_duplicate_region_with_selection_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_duplicate_region_with_selection.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -77,7 +78,7 @@ TEST(TransformationDuplicateRegionWithSelectionTest, BasicUseTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -209,7 +210,7 @@ TEST(TransformationDuplicateRegionWithSelectionTest, BasicExitBlockTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -348,7 +349,7 @@ TEST(TransformationDuplicateRegionWithSelectionTest, NotApplicableCFGTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -446,7 +447,7 @@ TEST(TransformationDuplicateRegionWithSelectionTest, NotApplicableIdTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -617,7 +618,7 @@ TEST(TransformationDuplicateRegionWithSelectionTest, NotApplicableCFGTest2) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -700,7 +701,7 @@ TEST(TransformationDuplicateRegionWithSelectionTest, NotApplicableCFGTest3) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -785,7 +786,7 @@ TEST(TransformationDuplicateRegionWithSelectionTest, MultipleBlocksLoopTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -974,7 +975,7 @@ TEST(TransformationDuplicateRegionWithSelectionTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1129,7 +1130,7 @@ TEST(TransformationDuplicateRegionWithSelectionTest, NotApplicableEarlyReturn) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1208,7 +1209,7 @@ TEST(TransformationDuplicateRegionWithSelectionTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1345,7 +1346,7 @@ TEST(TransformationDuplicateRegionWithSelectionTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1407,7 +1408,7 @@ TEST(TransformationDuplicateRegionWithSelectionTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1527,7 +1528,7 @@ TEST(TransformationDuplicateRegionWithSelectionTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1666,7 +1667,7 @@ TEST(TransformationDuplicateRegionWithSelectionTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_equation_instruction_test.cpp
+++ b/test/fuzz/transformation_equation_instruction_test.cpp
@@ -48,7 +48,7 @@ TEST(TransformationEquationInstructionTest, SignedNegate) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -166,7 +166,7 @@ TEST(TransformationEquationInstructionTest, LogicalNot) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -258,7 +258,7 @@ TEST(TransformationEquationInstructionTest, AddSubNegate1) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -382,7 +382,7 @@ TEST(TransformationEquationInstructionTest, AddSubNegate2) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -524,7 +524,7 @@ TEST(TransformationEquationInstructionTest, Bitcast) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -649,7 +649,7 @@ TEST(TransformationEquationInstructionTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -698,7 +698,7 @@ TEST(TransformationEquationInstructionTest, BitcastResultTypeIntDoesNotExist1) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -743,7 +743,7 @@ TEST(TransformationEquationInstructionTest, BitcastResultTypeIntDoesNotExist2) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -818,7 +818,7 @@ TEST(TransformationEquationInstructionTest, BitcastResultTypeIntDoesNotExist3) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -892,7 +892,7 @@ TEST(TransformationEquationInstructionTest, BitcastResultTypeIntDoesNotExist4) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -963,7 +963,7 @@ TEST(TransformationEquationInstructionTest, BitcastResultTypeIntDoesNotExist5) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1036,7 +1036,7 @@ TEST(TransformationEquationInstructionTest, BitcastResultTypeIntDoesNotExist6) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1115,7 +1115,7 @@ TEST(TransformationEquationInstructionTest, BitcastResultTypeIntDoesNotExist7) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1189,7 +1189,7 @@ TEST(TransformationEquationInstructionTest, Miscellaneous1) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1259,7 +1259,7 @@ TEST(TransformationEquationInstructionTest, Miscellaneous2) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1343,7 +1343,7 @@ TEST(TransformationEquationInstructionTest, ConversionInstructions) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1511,7 +1511,7 @@ TEST(TransformationEquationInstructionTest, FloatResultTypeDoesNotExist) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1564,7 +1564,7 @@ TEST(TransformationEquationInstructionTest, HandlesIrrelevantIds) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1578,10 +1578,10 @@ TEST(TransformationEquationInstructionTest, HandlesIrrelevantIds) {
       transformation.IsApplicable(context.get(), transformation_context));
 
   // Handles irrelevant ids.
-  fact_manager.AddFactIdIsIrrelevant(16, context.get());
+  fact_manager.AddFactIdIsIrrelevant(16);
   ASSERT_FALSE(
       transformation.IsApplicable(context.get(), transformation_context));
-  fact_manager.AddFactIdIsIrrelevant(15, context.get());
+  fact_manager.AddFactIdIsIrrelevant(15);
   ASSERT_FALSE(
       transformation.IsApplicable(context.get(), transformation_context));
 }

--- a/test/fuzz/transformation_flatten_conditional_branch_test.cpp
+++ b/test/fuzz/transformation_flatten_conditional_branch_test.cpp
@@ -132,7 +132,7 @@ TEST(TransformationFlattenConditionalBranchTest, Inapplicable) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -240,7 +240,7 @@ TEST(TransformationFlattenConditionalBranchTest, Simple) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -412,7 +412,7 @@ TEST(TransformationFlattenConditionalBranchTest, LoadStoreFunctionCall) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -490,8 +490,7 @@ TEST(TransformationFlattenConditionalBranchTest, LoadStoreFunctionCall) {
   transformation1.Apply(context.get(), &transformation_context);
 
   // Check that the placeholder id was marked as irrelevant.
-  ASSERT_TRUE(transformation_context.GetFactManager()->IdIsIrrelevant(
-      103, context.get()));
+  ASSERT_TRUE(transformation_context.GetFactManager()->IdIsIrrelevant(103));
 
   // Make a new transformation context with a source of overflow ids.
   TransformationContext new_transformation_context(
@@ -686,7 +685,7 @@ TEST(TransformationFlattenConditionalBranchTest, EdgeCases) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_function_call_test.cpp
+++ b/test/fuzz/transformation_function_call_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_function_call.h"
+
 #include "source/fuzz/instruction_descriptor.h"
 #include "test/fuzz/fuzz_test_util.h"
 
@@ -133,7 +134,7 @@ TEST(TransformationFunctionCallTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -147,23 +148,23 @@ TEST(TransformationFunctionCallTest, BasicTest) {
   transformation_context.GetFactManager()->AddFactFunctionIsLivesafe(21);
   transformation_context.GetFactManager()->AddFactFunctionIsLivesafe(200);
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      71, context.get());
+      71);
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      72, context.get());
+      72);
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      19, context.get());
+      19);
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      20, context.get());
+      20);
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      23, context.get());
+      23);
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      44, context.get());
+      44);
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      46, context.get());
+      46);
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      51, context.get());
+      51);
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      52, context.get());
+      52);
 
   // Livesafe functions with argument types: 21(7, 13), 200(7, 13)
   // Non-livesafe functions with argument types: 4(), 10(7), 17(7, 13), 24(7)
@@ -446,7 +447,7 @@ TEST(TransformationFunctionCallTest, DoNotInvokeEntryPoint) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_inline_function_test.cpp
+++ b/test/fuzz/transformation_inline_function_test.cpp
@@ -141,7 +141,7 @@ TEST(TransformationInlineFunctionTest, IsApplicable) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -273,7 +273,7 @@ TEST(TransformationInlineFunctionTest, Apply) {
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -513,7 +513,7 @@ TEST(TransformationInlineFunctionTest, ApplyToMultipleFunctions) {
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -784,7 +784,7 @@ TEST(TransformationInlineFunctionTest, HandlesOpPhisInTheSecondBlock) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_invert_comparison_operator_test.cpp
+++ b/test/fuzz/transformation_invert_comparison_operator_test.cpp
@@ -59,7 +59,7 @@ TEST(TransformationInvertComparisonOperatorTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_load_test.cpp
+++ b/test/fuzz/transformation_load_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_load.h"
+
 #include "source/fuzz/instruction_descriptor.h"
 #include "test/fuzz/fuzz_test_util.h"
 
@@ -84,21 +85,21 @@ TEST(TransformationLoadTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      27, context.get());
+      27);
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      11, context.get());
+      11);
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      46, context.get());
+      46);
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      16, context.get());
+      16);
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      52, context.get());
+      52);
 
   transformation_context.GetFactManager()->AddFactBlockIsDead(36);
 

--- a/test/fuzz/transformation_make_vector_operation_dynamic_test.cpp
+++ b/test/fuzz/transformation_make_vector_operation_dynamic_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_make_vector_operation_dynamic.h"
+
 #include "source/fuzz/instruction_descriptor.h"
 #include "test/fuzz/fuzz_test_util.h"
 
@@ -92,7 +93,7 @@ TEST(TransformationMakeVectorOperationDynamicTest, IsApplicable) {
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -205,7 +206,7 @@ TEST(TransformationMakeVectorOperationDynamicTest, Apply) {
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_merge_blocks_test.cpp
+++ b/test/fuzz/transformation_merge_blocks_test.cpp
@@ -44,7 +44,7 @@ TEST(TransformationMergeBlocksTest, BlockDoesNotExist) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -86,7 +86,7 @@ TEST(TransformationMergeBlocksTest, DoNotMergeFirstBlockHasMultipleSuccessors) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -127,7 +127,7 @@ TEST(TransformationMergeBlocksTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -169,7 +169,7 @@ TEST(TransformationMergeBlocksTest, MergeWhenSecondBlockIsSelectionMerge) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -243,7 +243,7 @@ TEST(TransformationMergeBlocksTest, MergeWhenSecondBlockIsLoopMerge) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -322,7 +322,7 @@ TEST(TransformationMergeBlocksTest, MergeWhenSecondBlockIsLoopContinue) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -397,7 +397,7 @@ TEST(TransformationMergeBlocksTest, MergeWhenSecondBlockStartsWithOpPhi) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -478,7 +478,7 @@ TEST(TransformationMergeBlocksTest, BasicMerge) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -570,7 +570,7 @@ TEST(TransformationMergeBlocksTest, MergeWhenSecondBlockIsSelectionHeader) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -661,7 +661,7 @@ TEST(TransformationMergeBlocksTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_move_block_down_test.cpp
+++ b/test/fuzz/transformation_move_block_down_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_move_block_down.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -52,7 +53,7 @@ TEST(TransformationMoveBlockDownTest, NoMovePossible1) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -93,7 +94,7 @@ TEST(TransformationMoveBlockDownTest, NoMovePossible2) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -136,7 +137,7 @@ TEST(TransformationMoveBlockDownTest, NoMovePossible3) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -183,7 +184,7 @@ TEST(TransformationMoveBlockDownTest, NoMovePossible4) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -292,7 +293,7 @@ TEST(TransformationMoveBlockDownTest, ManyMovesPossible) {
   const auto context =
       BuildModule(env, consumer, before_transformation, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -709,7 +710,7 @@ TEST(TransformationMoveBlockDownTest, DoNotMoveUnreachable) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_move_instruction_down_test.cpp
+++ b/test/fuzz/transformation_move_instruction_down_test.cpp
@@ -66,7 +66,7 @@ TEST(TransformationMoveInstructionDownTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -209,7 +209,7 @@ TEST(TransformationMoveInstructionDownTest, HandlesUnsupportedInstructions) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -314,7 +314,7 @@ TEST(TransformationMoveInstructionDownTest, HandlesBarrierInstructions) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -395,7 +395,7 @@ TEST(TransformationMoveInstructionDownTest, HandlesSimpleInstructions) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -602,12 +602,12 @@ TEST(TransformationMoveInstructionDownTest, HandlesMemoryInstructions) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  fact_manager.AddFactValueOfPointeeIsIrrelevant(22, context.get());
+  fact_manager.AddFactValueOfPointeeIsIrrelevant(22);
 
   // Invalid swaps.
 

--- a/test/fuzz/transformation_mutate_pointer_test.cpp
+++ b/test/fuzz/transformation_mutate_pointer_test.cpp
@@ -79,13 +79,13 @@ TEST(TransformationMutatePointerTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  fact_manager.AddFactIdIsIrrelevant(35, context.get());
-  fact_manager.AddFactIdIsIrrelevant(39, context.get());
+  fact_manager.AddFactIdIsIrrelevant(35);
+  fact_manager.AddFactIdIsIrrelevant(39);
 
   const auto insert_before = MakeInstructionDescriptor(26, SpvOpReturn, 0);
 
@@ -140,7 +140,7 @@ TEST(TransformationMutatePointerTest, BasicTest) {
                    26, 70, MakeInstructionDescriptor(26, SpvOpAccessChain, 0))
                    .IsApplicable(context.get(), transformation_context));
 
-  fact_manager.AddFactIdIsIrrelevant(40, context.get());
+  fact_manager.AddFactIdIsIrrelevant(40);
 
   uint32_t fresh_id = 70;
   uint32_t pointer_ids[] = {
@@ -269,12 +269,12 @@ TEST(TransformationMutatePointerTest, HandlesUnreachableBlocks) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  fact_manager.AddFactIdIsIrrelevant(7, context.get());
+  fact_manager.AddFactIdIsIrrelevant(7);
 
   ASSERT_FALSE(
       context->GetDominatorAnalysis(context->GetFunction(4))->IsReachable(10));

--- a/test/fuzz/transformation_outline_function_test.cpp
+++ b/test/fuzz/transformation_outline_function_test.cpp
@@ -45,7 +45,7 @@ TEST(TransformationOutlineFunctionTest, TrivialOutline) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -110,7 +110,7 @@ TEST(TransformationOutlineFunctionTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -167,7 +167,7 @@ TEST(TransformationOutlineFunctionTest, OutlineInterestingControlFlowNoState) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -256,7 +256,7 @@ TEST(TransformationOutlineFunctionTest, OutlineCodeThatGeneratesUnusedIds) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -334,7 +334,7 @@ TEST(TransformationOutlineFunctionTest, OutlineCodeThatGeneratesSingleUsedId) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -433,7 +433,7 @@ TEST(TransformationOutlineFunctionTest, OutlineDiamondThatGeneratesSeveralIds) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -533,7 +533,7 @@ TEST(TransformationOutlineFunctionTest, OutlineCodeThatUsesASingleId) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -611,7 +611,7 @@ TEST(TransformationOutlineFunctionTest, OutlineCodeThatUsesAVariable) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -699,7 +699,7 @@ TEST(TransformationOutlineFunctionTest, OutlineCodeThatUsesAParameter) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -789,7 +789,7 @@ TEST(TransformationOutlineFunctionTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -839,7 +839,7 @@ TEST(TransformationOutlineFunctionTest, DoNotOutlineIfRegionInvolvesReturn) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -890,7 +890,7 @@ TEST(TransformationOutlineFunctionTest, DoNotOutlineIfRegionInvolvesKill) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -942,7 +942,7 @@ TEST(TransformationOutlineFunctionTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -986,7 +986,7 @@ TEST(TransformationOutlineFunctionTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1030,7 +1030,7 @@ TEST(TransformationOutlineFunctionTest, DoNotOutlineIfLoopHeadIsOutsideRegion) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1073,7 +1073,7 @@ TEST(TransformationOutlineFunctionTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1118,7 +1118,7 @@ TEST(TransformationOutlineFunctionTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1163,7 +1163,7 @@ TEST(TransformationOutlineFunctionTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1205,7 +1205,7 @@ TEST(TransformationOutlineFunctionTest, OutlineRegionEndingWithReturnVoid) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1296,7 +1296,7 @@ TEST(TransformationOutlineFunctionTest, OutlineRegionEndingWithReturnValue) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1391,7 +1391,7 @@ TEST(TransformationOutlineFunctionTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1481,7 +1481,7 @@ TEST(TransformationOutlineFunctionTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1567,7 +1567,7 @@ TEST(TransformationOutlineFunctionTest, DoNotOutlineRegionThatStartsWithOpPhi) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1624,7 +1624,7 @@ TEST(TransformationOutlineFunctionTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1681,7 +1681,7 @@ TEST(TransformationOutlineFunctionTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1741,7 +1741,7 @@ TEST(TransformationOutlineFunctionTest, DoNotOutlineRegionThatUsesAccessChain) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1803,7 +1803,7 @@ TEST(TransformationOutlineFunctionTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1870,7 +1870,7 @@ TEST(TransformationOutlineFunctionTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -2026,16 +2026,16 @@ TEST(TransformationOutlineFunctionTest, OutlineLivesafe) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
   transformation_context.GetFactManager()->AddFactFunctionIsLivesafe(30);
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      200, context.get());
+      200);
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      201, context.get());
+      201);
 
   TransformationOutlineFunction transformation(
       /*entry_block*/ 198,
@@ -2255,7 +2255,7 @@ TEST(TransformationOutlineFunctionTest, OutlineWithDeadBlocks1) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -2339,7 +2339,7 @@ TEST(TransformationOutlineFunctionTest, OutlineWithDeadBlocks2) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -2424,15 +2424,14 @@ TEST(TransformationOutlineFunctionTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
+  transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(9);
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      9, context.get());
-  transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      14, context.get());
+      14);
 
   TransformationOutlineFunction transformation(
       /*entry_block*/ 50,
@@ -2501,7 +2500,7 @@ TEST(TransformationOutlineFunctionTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -2559,7 +2558,7 @@ TEST(TransformationOutlineFunctionTest, ExitBlockHeadsLoop) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -2742,7 +2741,7 @@ TEST(TransformationOutlineFunctionTest, Miscellaneous1) {
         BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
     ASSERT_TRUE(IsValid(env, context.get()));
 
-    FactManager fact_manager;
+    FactManager fact_manager(context.get());
     TransformationContext transformation_context(&fact_manager,
                                                  validator_options);
 
@@ -2884,7 +2883,7 @@ TEST(TransformationOutlineFunctionTest, Miscellaneous1) {
     const auto context =
         BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
     ASSERT_TRUE(IsValid(env, context.get()));
-    FactManager fact_manager;
+    FactManager fact_manager(context.get());
     TransformationContext new_transformation_context(
         &fact_manager, validator_options,
         MakeUnique<CounterOverflowIdSource>(2000));
@@ -3046,7 +3045,7 @@ TEST(TransformationOutlineFunctionTest, Miscellaneous2) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -3105,7 +3104,7 @@ TEST(TransformationOutlineFunctionTest, Miscellaneous3) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -3198,7 +3197,7 @@ TEST(TransformationOutlineFunctionTest, Miscellaneous4) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_permute_function_parameters_test.cpp
+++ b/test/fuzz/transformation_permute_function_parameters_test.cpp
@@ -253,7 +253,7 @@ TEST(TransformationPermuteFunctionParametersTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_permute_phi_operands_test.cpp
+++ b/test/fuzz/transformation_permute_phi_operands_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_permute_phi_operands.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -67,7 +68,7 @@ TEST(TransformationPermutePhiOperandsTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_propagate_instruction_up_test.cpp
+++ b/test/fuzz/transformation_propagate_instruction_up_test.cpp
@@ -73,7 +73,7 @@ TEST(TransformationPropagateInstructionUpTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -357,7 +357,7 @@ TEST(TransformationPropagateInstructionUpTest, BlockDominatesPredecessor1) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -476,7 +476,7 @@ TEST(TransformationPropagateInstructionUpTest, BlockDominatesPredecessor2) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -591,7 +591,7 @@ TEST(TransformationPropagateInstructionUpTest, BlockDominatesPredecessor3) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -686,7 +686,7 @@ TEST(TransformationPropagateInstructionUpTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -767,7 +767,7 @@ TEST(TransformationPropagateInstructionUpTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -848,7 +848,7 @@ TEST(TransformationPropagateInstructionUpTest, MultipleIdenticalPredecessors) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_push_id_through_variable_test.cpp
+++ b/test/fuzz/transformation_push_id_through_variable_test.cpp
@@ -96,7 +96,7 @@ TEST(TransformationPushIdThroughVariableTest, IsApplicable) {
   const auto context =
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -327,7 +327,7 @@ TEST(TransformationPushIdThroughVariableTest, Apply) {
   const auto context =
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -573,7 +573,7 @@ TEST(TransformationPushIdThroughVariableTest, AddSynonymsForRelevantIds) {
   const auto context =
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -674,7 +674,7 @@ TEST(TransformationPushIdThroughVariableTest, DontAddSynonymsForIrrelevantIds) {
   const auto context =
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -682,7 +682,7 @@ TEST(TransformationPushIdThroughVariableTest, DontAddSynonymsForIrrelevantIds) {
   // Tests the reference shader validity.
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  fact_manager.AddFactIdIsIrrelevant(21, context.get());
+  fact_manager.AddFactIdIsIrrelevant(21);
 
   uint32_t value_id = 21;
   uint32_t value_synonym_id = 62;

--- a/test/fuzz/transformation_record_synonymous_constants_test.cpp
+++ b/test/fuzz/transformation_record_synonymous_constants_test.cpp
@@ -84,7 +84,7 @@ TEST(TransformationRecordSynonymousConstantsTest, IntConstants) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -201,7 +201,7 @@ TEST(TransformationRecordSynonymousConstantsTest, BoolConstants) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -293,7 +293,7 @@ TEST(TransformationRecordSynonymousConstantsTest, FloatConstants) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -399,7 +399,7 @@ TEST(TransformationRecordSynonymousConstantsTest,
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -536,7 +536,7 @@ TEST(TransformationRecordSynonymousConstantsTest, StructCompositeConstants) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -634,7 +634,7 @@ TEST(TransformationRecordSynonymousConstantsTest, ArrayCompositeConstants) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -725,7 +725,7 @@ TEST(TransformationRecordSynonymousConstantsTest, IntVectors) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -806,7 +806,7 @@ TEST(TransformationRecordSynonymousConstantsTest, FirstIrrelevantConstant) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -814,7 +814,7 @@ TEST(TransformationRecordSynonymousConstantsTest, FirstIrrelevantConstant) {
   ASSERT_TRUE(TransformationRecordSynonymousConstants(7, 8).IsApplicable(
       context.get(), transformation_context));
 
-  fact_manager.AddFactIdIsIrrelevant(7, context.get());
+  fact_manager.AddFactIdIsIrrelevant(7);
   ASSERT_FALSE(TransformationRecordSynonymousConstants(7, 8).IsApplicable(
       context.get(), transformation_context));
 }
@@ -843,7 +843,7 @@ TEST(TransformationRecordSynonymousConstantsTest, SecondIrrelevantConstant) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -851,7 +851,7 @@ TEST(TransformationRecordSynonymousConstantsTest, SecondIrrelevantConstant) {
   ASSERT_TRUE(TransformationRecordSynonymousConstants(7, 8).IsApplicable(
       context.get(), transformation_context));
 
-  fact_manager.AddFactIdIsIrrelevant(8, context.get());
+  fact_manager.AddFactIdIsIrrelevant(8);
   ASSERT_FALSE(TransformationRecordSynonymousConstants(7, 8).IsApplicable(
       context.get(), transformation_context));
 }
@@ -879,7 +879,7 @@ TEST(TransformationRecordSynonymousConstantsTest, InvalidIds) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_replace_add_sub_mul_with_carrying_extended_test.cpp
+++ b/test/fuzz/transformation_replace_add_sub_mul_with_carrying_extended_test.cpp
@@ -15,7 +15,6 @@
 #include "source/fuzz/transformation_replace_add_sub_mul_with_carrying_extended.h"
 
 #include "source/fuzz/fuzzer_util.h"
-
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -60,7 +59,7 @@ TEST(TransformationReplaceAddSubMulWithCarryingExtendedTest,
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -148,7 +147,7 @@ TEST(TransformationReplaceAddSubMulWithCarryingExtendedTest,
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -245,7 +244,7 @@ TEST(TransformationReplaceAddSubMulWithCarryingExtendedTest,
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -408,7 +407,7 @@ TEST(TransformationReplaceAddSubMulWithCarryingExtendedTest,
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_replace_boolean_constant_with_constant_binary_test.cpp
+++ b/test/fuzz/transformation_replace_boolean_constant_with_constant_binary_test.cpp
@@ -162,7 +162,7 @@ TEST(TransformationReplaceBooleanConstantWithConstantBinaryTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -537,7 +537,7 @@ TEST(TransformationReplaceBooleanConstantWithConstantBinaryTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -653,7 +653,7 @@ TEST(TransformationReplaceBooleanConstantWithConstantBinaryTest, OpPhi) {
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -732,7 +732,7 @@ TEST(TransformationReplaceBooleanConstantWithConstantBinaryTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_replace_constant_with_uniform_test.cpp
+++ b/test/fuzz/transformation_replace_constant_with_uniform_test.cpp
@@ -23,8 +23,7 @@ namespace fuzz {
 namespace {
 
 bool AddFactHelper(
-    TransformationContext* transformation_context, opt::IRContext* context,
-    uint32_t word,
+    TransformationContext* transformation_context, uint32_t word,
     const protobufs::UniformBufferElementDescriptor& descriptor) {
   protobufs::FactConstantUniform constant_uniform_fact;
   constant_uniform_fact.add_constant_word(word);
@@ -32,7 +31,7 @@ bool AddFactHelper(
       descriptor;
   protobufs::Fact fact;
   *fact.mutable_constant_uniform_fact() = constant_uniform_fact;
-  return transformation_context->GetFactManager()->AddFact(fact, context);
+  return transformation_context->GetFactManager()->AddFact(fact);
 }
 
 TEST(TransformationReplaceConstantWithUniformTest, BasicReplacements) {
@@ -105,7 +104,7 @@ TEST(TransformationReplaceConstantWithUniformTest, BasicReplacements) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -117,12 +116,9 @@ TEST(TransformationReplaceConstantWithUniformTest, BasicReplacements) {
   protobufs::UniformBufferElementDescriptor blockname_c =
       MakeUniformBufferElementDescriptor(0, 0, {2});
 
-  ASSERT_TRUE(
-      AddFactHelper(&transformation_context, context.get(), 1, blockname_a));
-  ASSERT_TRUE(
-      AddFactHelper(&transformation_context, context.get(), 2, blockname_b));
-  ASSERT_TRUE(
-      AddFactHelper(&transformation_context, context.get(), 3, blockname_c));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, 1, blockname_a));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, 2, blockname_b));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, 3, blockname_c));
 
   // The constant ids are 9, 11 and 14, for 1, 2 and 3 respectively.
   protobufs::IdUseDescriptor use_of_9_in_store =
@@ -471,7 +467,7 @@ TEST(TransformationReplaceConstantWithUniformTest, NestedStruct) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -485,14 +481,10 @@ TEST(TransformationReplaceConstantWithUniformTest, NestedStruct) {
   protobufs::UniformBufferElementDescriptor blockname_4 =
       MakeUniformBufferElementDescriptor(0, 0, {1, 0, 1, 0});
 
-  ASSERT_TRUE(
-      AddFactHelper(&transformation_context, context.get(), 1, blockname_1));
-  ASSERT_TRUE(
-      AddFactHelper(&transformation_context, context.get(), 2, blockname_2));
-  ASSERT_TRUE(
-      AddFactHelper(&transformation_context, context.get(), 3, blockname_3));
-  ASSERT_TRUE(
-      AddFactHelper(&transformation_context, context.get(), 4, blockname_4));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, 1, blockname_1));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, 2, blockname_2));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, 3, blockname_3));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, 4, blockname_4));
 
   // The constant ids are 13, 15, 17 and 20, for 1, 2, 3 and 4 respectively.
   protobufs::IdUseDescriptor use_of_13_in_store =
@@ -716,7 +708,7 @@ TEST(TransformationReplaceConstantWithUniformTest, NoUniformIntPointerPresent) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -724,8 +716,7 @@ TEST(TransformationReplaceConstantWithUniformTest, NoUniformIntPointerPresent) {
   protobufs::UniformBufferElementDescriptor blockname_0 =
       MakeUniformBufferElementDescriptor(0, 0, {0});
 
-  ASSERT_TRUE(
-      AddFactHelper(&transformation_context, context.get(), 0, blockname_0));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, 0, blockname_0));
 
   // The constant id is 9 for 0.
   protobufs::IdUseDescriptor use_of_9_in_store =
@@ -794,7 +785,7 @@ TEST(TransformationReplaceConstantWithUniformTest, NoConstantPresentForIndex) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -804,8 +795,7 @@ TEST(TransformationReplaceConstantWithUniformTest, NoConstantPresentForIndex) {
   protobufs::UniformBufferElementDescriptor blockname_9 =
       MakeUniformBufferElementDescriptor(0, 0, {1});
 
-  ASSERT_TRUE(
-      AddFactHelper(&transformation_context, context.get(), 9, blockname_9));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, 9, blockname_9));
 
   // The constant id is 9 for 9.
   protobufs::IdUseDescriptor use_of_9_in_store =
@@ -871,7 +861,7 @@ TEST(TransformationReplaceConstantWithUniformTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -882,8 +872,8 @@ TEST(TransformationReplaceConstantWithUniformTest,
   uint32_t float_data[1];
   float temp = 3.0;
   memcpy(&float_data[0], &temp, sizeof(float));
-  ASSERT_TRUE(AddFactHelper(&transformation_context, context.get(),
-                            float_data[0], blockname_3));
+  ASSERT_TRUE(
+      AddFactHelper(&transformation_context, float_data[0], blockname_3));
 
   // The constant id is 9 for 3.0.
   protobufs::IdUseDescriptor use_of_9_in_store =
@@ -961,7 +951,7 @@ TEST(TransformationReplaceConstantWithUniformTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -971,10 +961,8 @@ TEST(TransformationReplaceConstantWithUniformTest,
   protobufs::UniformBufferElementDescriptor blockname_10 =
       MakeUniformBufferElementDescriptor(0, 0, {1});
 
-  ASSERT_TRUE(
-      AddFactHelper(&transformation_context, context.get(), 9, blockname_9));
-  ASSERT_TRUE(
-      AddFactHelper(&transformation_context, context.get(), 10, blockname_10));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, 9, blockname_9));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, 10, blockname_10));
 
   // The constant ids for 9 and 10 are 9 and 11 respectively
   protobufs::IdUseDescriptor use_of_9_in_store =
@@ -1180,7 +1168,7 @@ TEST(TransformationReplaceConstantWithUniformTest, ComplexReplacements) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1231,43 +1219,35 @@ TEST(TransformationReplaceConstantWithUniformTest, ComplexReplacements) {
   protobufs::UniformBufferElementDescriptor uniform_h_y =
       MakeUniformBufferElementDescriptor(0, 0, {2, 1});
 
-  ASSERT_TRUE(AddFactHelper(&transformation_context, context.get(),
-                            float_array_data[0], uniform_f_a_0));
-  ASSERT_TRUE(AddFactHelper(&transformation_context, context.get(),
-                            float_array_data[1], uniform_f_a_1));
-  ASSERT_TRUE(AddFactHelper(&transformation_context, context.get(),
-                            float_array_data[2], uniform_f_a_2));
-  ASSERT_TRUE(AddFactHelper(&transformation_context, context.get(),
-                            float_array_data[3], uniform_f_a_3));
-  ASSERT_TRUE(AddFactHelper(&transformation_context, context.get(),
-                            float_array_data[4], uniform_f_a_4));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, float_array_data[0],
+                            uniform_f_a_0));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, float_array_data[1],
+                            uniform_f_a_1));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, float_array_data[2],
+                            uniform_f_a_2));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, float_array_data[3],
+                            uniform_f_a_3));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, float_array_data[4],
+                            uniform_f_a_4));
 
-  ASSERT_TRUE(
-      AddFactHelper(&transformation_context, context.get(), 1, uniform_f_b_x));
-  ASSERT_TRUE(
-      AddFactHelper(&transformation_context, context.get(), 2, uniform_f_b_y));
-  ASSERT_TRUE(
-      AddFactHelper(&transformation_context, context.get(), 3, uniform_f_b_z));
-  ASSERT_TRUE(
-      AddFactHelper(&transformation_context, context.get(), 4, uniform_f_b_w));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, 1, uniform_f_b_x));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, 2, uniform_f_b_y));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, 3, uniform_f_b_z));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, 4, uniform_f_b_w));
 
-  ASSERT_TRUE(AddFactHelper(&transformation_context, context.get(),
-                            float_vector_data[0], uniform_f_c_x));
-  ASSERT_TRUE(AddFactHelper(&transformation_context, context.get(),
-                            float_vector_data[1], uniform_f_c_y));
-  ASSERT_TRUE(AddFactHelper(&transformation_context, context.get(),
-                            float_vector_data[2], uniform_f_c_z));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, float_vector_data[0],
+                            uniform_f_c_x));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, float_vector_data[1],
+                            uniform_f_c_y));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, float_vector_data[2],
+                            uniform_f_c_z));
 
-  ASSERT_TRUE(
-      AddFactHelper(&transformation_context, context.get(), 42, uniform_f_d));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, 42, uniform_f_d));
 
-  ASSERT_TRUE(
-      AddFactHelper(&transformation_context, context.get(), 22, uniform_g));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, 22, uniform_g));
 
-  ASSERT_TRUE(
-      AddFactHelper(&transformation_context, context.get(), 100, uniform_h_x));
-  ASSERT_TRUE(
-      AddFactHelper(&transformation_context, context.get(), 200, uniform_h_y));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, 100, uniform_h_x));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, 200, uniform_h_y));
 
   std::vector<TransformationReplaceConstantWithUniform> transformations;
 
@@ -1531,7 +1511,7 @@ TEST(TransformationReplaceConstantWithUniformTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1539,8 +1519,7 @@ TEST(TransformationReplaceConstantWithUniformTest,
   protobufs::UniformBufferElementDescriptor blockname_a =
       MakeUniformBufferElementDescriptor(0, 0, {0});
 
-  ASSERT_TRUE(
-      AddFactHelper(&transformation_context, context.get(), 0, blockname_a));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, 0, blockname_a));
 
   ASSERT_FALSE(TransformationReplaceConstantWithUniform(
                    MakeIdUseDescriptor(
@@ -1592,15 +1571,14 @@ TEST(TransformationReplaceConstantWithUniformTest, ReplaceOpPhiOperand) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
   auto int_descriptor = MakeUniformBufferElementDescriptor(0, 0, {0});
 
-  ASSERT_TRUE(
-      AddFactHelper(&transformation_context, context.get(), 2, int_descriptor));
+  ASSERT_TRUE(AddFactHelper(&transformation_context, 2, int_descriptor));
 
   {
     TransformationReplaceConstantWithUniform transformation(

--- a/test/fuzz/transformation_replace_copy_memory_with_load_store_test.cpp
+++ b/test/fuzz/transformation_replace_copy_memory_with_load_store_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_replace_copy_memory_with_load_store.h"
+
 #include "source/fuzz/instruction_descriptor.h"
 #include "test/fuzz/fuzz_test_util.h"
 
@@ -65,7 +66,7 @@ TEST(TransformationReplaceCopyMemoryWithLoadStoreTest, BasicScenarios) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_replace_copy_object_with_store_load_test.cpp
+++ b/test/fuzz/transformation_replace_copy_object_with_store_load_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_replace_copy_object_with_store_load.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -77,7 +78,7 @@ TEST(TransformationReplaceCopyObjectWithStoreLoad, BasicScenarios) {
   const auto context =
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_replace_id_with_synonym_test.cpp
+++ b/test/fuzz/transformation_replace_id_with_synonym_test.cpp
@@ -199,18 +199,18 @@ protobufs::Fact MakeSynonymFact(uint32_t first, uint32_t second) {
 }
 
 // Equips the fact manager with synonym facts for the above shader.
-void SetUpIdSynonyms(FactManager* fact_manager, opt::IRContext* context) {
-  fact_manager->AddFact(MakeSynonymFact(15, 200), context);
-  fact_manager->AddFact(MakeSynonymFact(15, 201), context);
-  fact_manager->AddFact(MakeSynonymFact(15, 202), context);
-  fact_manager->AddFact(MakeSynonymFact(55, 203), context);
-  fact_manager->AddFact(MakeSynonymFact(54, 204), context);
-  fact_manager->AddFact(MakeSynonymFact(74, 205), context);
-  fact_manager->AddFact(MakeSynonymFact(78, 206), context);
-  fact_manager->AddFact(MakeSynonymFact(84, 207), context);
-  fact_manager->AddFact(MakeSynonymFact(33, 208), context);
-  fact_manager->AddFact(MakeSynonymFact(12, 209), context);
-  fact_manager->AddFact(MakeSynonymFact(19, 210), context);
+void SetUpIdSynonyms(FactManager* fact_manager) {
+  fact_manager->AddFact(MakeSynonymFact(15, 200));
+  fact_manager->AddFact(MakeSynonymFact(15, 201));
+  fact_manager->AddFact(MakeSynonymFact(15, 202));
+  fact_manager->AddFact(MakeSynonymFact(55, 203));
+  fact_manager->AddFact(MakeSynonymFact(54, 204));
+  fact_manager->AddFact(MakeSynonymFact(74, 205));
+  fact_manager->AddFact(MakeSynonymFact(78, 206));
+  fact_manager->AddFact(MakeSynonymFact(84, 207));
+  fact_manager->AddFact(MakeSynonymFact(33, 208));
+  fact_manager->AddFact(MakeSynonymFact(12, 209));
+  fact_manager->AddFact(MakeSynonymFact(19, 210));
 }
 
 TEST(TransformationReplaceIdWithSynonymTest, IllegalTransformations) {
@@ -220,12 +220,12 @@ TEST(TransformationReplaceIdWithSynonymTest, IllegalTransformations) {
       BuildModule(env, consumer, kComplexShader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  SetUpIdSynonyms(transformation_context.GetFactManager(), context.get());
+  SetUpIdSynonyms(transformation_context.GetFactManager());
 
   // %202 cannot replace %15 as in-operand 0 of %300, since %202 does not
   // dominate %300.
@@ -295,12 +295,12 @@ TEST(TransformationReplaceIdWithSynonymTest, LegalTransformations) {
       BuildModule(env, consumer, kComplexShader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  SetUpIdSynonyms(transformation_context.GetFactManager(), context.get());
+  SetUpIdSynonyms(transformation_context.GetFactManager());
 
   auto global_constant_synonym = TransformationReplaceIdWithSynonym(
       MakeIdUseDescriptor(19, MakeInstructionDescriptor(47, SpvOpStore, 0), 1),
@@ -518,15 +518,13 @@ TEST(TransformationReplaceIdWithSynonymTest, SynonymsOfVariables) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(10, 100),
-                                                   context.get());
-  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(8, 101),
-                                                   context.get());
+  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(10, 100));
+  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(8, 101));
 
   // Replace %10 with %100 in:
   // %11 = OpLoad %6 %10
@@ -652,13 +650,12 @@ TEST(TransformationReplaceIdWithSynonymTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(14, 100),
-                                                   context.get());
+  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(14, 100));
 
   // Replace %14 with %100 in:
   // %16 = OpFunctionCall %2 %10 %14
@@ -818,39 +815,26 @@ TEST(TransformationReplaceIdWithSynonymTest, SynonymsOfAccessChainIndices) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
   // Add synonym facts corresponding to the OpCopyObject operations that have
   // been applied to all constants in the module.
-  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(16, 100),
-                                                   context.get());
-  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(21, 101),
-                                                   context.get());
-  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(17, 102),
-                                                   context.get());
-  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(57, 103),
-                                                   context.get());
-  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(18, 104),
-                                                   context.get());
-  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(40, 105),
-                                                   context.get());
-  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(32, 106),
-                                                   context.get());
-  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(43, 107),
-                                                   context.get());
-  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(55, 108),
-                                                   context.get());
-  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(8, 109),
-                                                   context.get());
-  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(47, 110),
-                                                   context.get());
-  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(28, 111),
-                                                   context.get());
-  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(45, 112),
-                                                   context.get());
+  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(16, 100));
+  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(21, 101));
+  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(17, 102));
+  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(57, 103));
+  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(18, 104));
+  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(40, 105));
+  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(32, 106));
+  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(43, 107));
+  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(55, 108));
+  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(8, 109));
+  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(47, 110));
+  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(28, 111));
+  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(45, 112));
 
   // Replacements of the form %16 -> %100
 
@@ -1319,17 +1303,15 @@ TEST(TransformationReplaceIdWithSynonymTest, RuntimeArrayTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
   // Add synonym fact relating %50 and %12.
-  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(50, 12),
-                                                   context.get());
+  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(50, 12));
   // Add synonym fact relating %51 and %14.
-  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(51, 14),
-                                                   context.get());
+  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(51, 14));
 
   // Not legal because the index being replaced is a struct index.
   ASSERT_FALSE(
@@ -1432,14 +1414,13 @@ TEST(TransformationReplaceIdWithSynonymTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
   // Add synonym fact relating %100 and %9.
-  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(100, 9),
-                                                   context.get());
+  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(100, 9));
 
   // Not legal the Sample argument of OpImageTexelPointer needs to be a zero
   // constant.
@@ -1494,15 +1475,14 @@ TEST(TransformationReplaceIdWithSynonymTest, EquivalentIntegerConstants) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
   // Add synonym fact relating %10 and %13 (equivalent integer constant with
   // different signedness).
-  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(10, 13),
-                                                   context.get());
+  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(10, 13));
 
   // Legal because OpSNegate always considers the integer as signed
   auto replacement1 = TransformationReplaceIdWithSynonym(
@@ -1639,15 +1619,14 @@ TEST(TransformationReplaceIdWithSynonymTest, EquivalentIntegerVectorConstants) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
   // Add synonym fact relating %10 and %13 (equivalent integer vectors with
   // different signedness).
-  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(14, 15),
-                                                   context.get());
+  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(14, 15));
 
   // Legal because OpIAdd does not consider the signedness of the operands
   auto replacement1 = TransformationReplaceIdWithSynonym(
@@ -1666,8 +1645,7 @@ TEST(TransformationReplaceIdWithSynonymTest, EquivalentIntegerVectorConstants) {
 
   // Add synonym fact relating %12 and %13 (equivalent integer constants with
   // different signedness).
-  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(12, 13),
-                                                   context.get());
+  transformation_context.GetFactManager()->AddFact(MakeSynonymFact(12, 13));
 
   // Legal because the indices of OpAccessChain are always treated as signed
   auto replacement2 = TransformationReplaceIdWithSynonym(
@@ -1745,7 +1723,7 @@ TEST(TransformationReplaceIdWithSynonymTest, IncompatibleTypes) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1757,9 +1735,9 @@ TEST(TransformationReplaceIdWithSynonymTest, IncompatibleTypes) {
   ASSERT_TRUE(op_f_add);
 
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(12, {}),
-                                  MakeDataDescriptor(13, {}), context.get());
+                                  MakeDataDescriptor(13, {}));
   fact_manager.AddFactDataSynonym(MakeDataDescriptor(12, {}),
-                                  MakeDataDescriptor(10, {}), context.get());
+                                  MakeDataDescriptor(10, {}));
 
   // Synonym differs only in signedness for OpIAdd.
   ASSERT_TRUE(TransformationReplaceIdWithSynonym(

--- a/test/fuzz/transformation_replace_irrelevant_id_test.cpp
+++ b/test/fuzz/transformation_replace_irrelevant_id_test.cpp
@@ -61,12 +61,11 @@ const std::string shader = R"(
                OpFunctionEnd
 )";
 
-void SetUpIrrelevantIdFacts(FactManager* fact_manager,
-                            opt::IRContext* context) {
-  fact_manager->AddFactIdIsIrrelevant(17, context);
-  fact_manager->AddFactIdIsIrrelevant(23, context);
-  fact_manager->AddFactIdIsIrrelevant(24, context);
-  fact_manager->AddFactIdIsIrrelevant(25, context);
+void SetUpIrrelevantIdFacts(FactManager* fact_manager) {
+  fact_manager->AddFactIdIsIrrelevant(17);
+  fact_manager->AddFactIdIsIrrelevant(23);
+  fact_manager->AddFactIdIsIrrelevant(24);
+  fact_manager->AddFactIdIsIrrelevant(25);
 }
 
 TEST(TransformationReplaceIrrelevantIdTest, Inapplicable) {
@@ -75,13 +74,12 @@ TEST(TransformationReplaceIrrelevantIdTest, Inapplicable) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  SetUpIrrelevantIdFacts(transformation_context.GetFactManager(),
-                         context.get());
+  SetUpIrrelevantIdFacts(transformation_context.GetFactManager());
 
   auto instruction_21_descriptor =
       MakeInstructionDescriptor(21, SpvOpAccessChain, 0);
@@ -129,13 +127,12 @@ TEST(TransformationReplaceIrrelevantIdTest, Apply) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  SetUpIrrelevantIdFacts(transformation_context.GetFactManager(),
-                         context.get());
+  SetUpIrrelevantIdFacts(transformation_context.GetFactManager());
 
   auto instruction_24_descriptor = MakeInstructionDescriptor(24, SpvOpIAdd, 0);
 

--- a/test/fuzz/transformation_replace_linear_algebra_instruction_test.cpp
+++ b/test/fuzz/transformation_replace_linear_algebra_instruction_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_replace_linear_algebra_instruction.h"
+
 #include "source/fuzz/instruction_descriptor.h"
 #include "test/fuzz/fuzz_test_util.h"
 
@@ -69,7 +70,7 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest, IsApplicable) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -244,7 +245,7 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest, ReplaceOpTranspose) {
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -502,7 +503,7 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest,
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -674,7 +675,7 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest,
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -962,7 +963,7 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest,
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1297,7 +1298,7 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest,
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -1684,7 +1685,7 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest,
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -2158,7 +2159,7 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest, ReplaceOpOuterProduct) {
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -2396,7 +2397,7 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest, ReplaceOpDot) {
       BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_replace_load_store_with_copy_memory_test.cpp
+++ b/test/fuzz/transformation_replace_load_store_with_copy_memory_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_replace_load_store_with_copy_memory.h"
+
 #include "source/fuzz/instruction_descriptor.h"
 #include "test/fuzz/fuzz_test_util.h"
 
@@ -108,7 +109,7 @@ TEST(TransformationReplaceLoadStoreWithCopyMemoryTest, BasicScenarios) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_replace_opphi_id_from_dead_predecessor_test.cpp
+++ b/test/fuzz/transformation_replace_opphi_id_from_dead_predecessor_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_replace_opphi_id_from_dead_predecessor.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -74,7 +75,7 @@ TEST(TransformationReplaceOpPhiIdFromDeadPredecessorTest, Inapplicable) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -116,7 +117,7 @@ TEST(TransformationReplaceOpPhiIdFromDeadPredecessorTest, Apply) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_replace_opselect_with_conditional_branch_test.cpp
+++ b/test/fuzz/transformation_replace_opselect_with_conditional_branch_test.cpp
@@ -14,10 +14,9 @@
 
 #include "source/fuzz/transformation_replace_opselect_with_conditional_branch.h"
 
-#include "test/fuzz/fuzz_test_util.h"
-
 #include "source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.h"
 #include "source/fuzz/pseudo_random_generator.h"
+#include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
 namespace fuzz {
@@ -87,7 +86,7 @@ TEST(TransformationReplaceOpSelectWithConditionalBranchTest, Inapplicable) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -191,7 +190,7 @@ TEST(TransformationReplaceOpSelectWithConditionalBranchTest, Simple) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_replace_parameter_with_global_test.cpp
+++ b/test/fuzz/transformation_replace_parameter_with_global_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_replace_parameter_with_global.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -115,7 +116,7 @@ TEST(TransformationReplaceParameterWithGlobalTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -325,12 +326,12 @@ TEST(TransformationReplaceParameterWithGlobalTest,
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  fact_manager.AddFactIdIsIrrelevant(10, context.get());
+  fact_manager.AddFactIdIsIrrelevant(10);
 
   {
     TransformationReplaceParameterWithGlobal transformation(20, 10, 21);

--- a/test/fuzz/transformation_replace_params_with_struct_test.cpp
+++ b/test/fuzz/transformation_replace_params_with_struct_test.cpp
@@ -124,7 +124,7 @@ TEST(TransformationReplaceParamsWithStructTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -373,7 +373,7 @@ TEST(TransformationReplaceParamsWithStructTest, ParametersRemainValid) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_set_function_control_test.cpp
+++ b/test/fuzz/transformation_set_function_control_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_set_function_control.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -117,7 +118,7 @@ TEST(TransformationSetFunctionControlTest, VariousScenarios) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_set_memory_operands_mask_test.cpp
+++ b/test/fuzz/transformation_set_memory_operands_mask_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_set_memory_operands_mask.h"
+
 #include "source/fuzz/instruction_descriptor.h"
 #include "test/fuzz/fuzz_test_util.h"
 
@@ -92,7 +93,7 @@ TEST(TransformationSetMemoryOperandsMaskTest, PreSpirv14) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -337,7 +338,7 @@ TEST(TransformationSetMemoryOperandsMaskTest, Spirv14) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_set_selection_control_test.cpp
+++ b/test/fuzz/transformation_set_selection_control_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_set_selection_control.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {
@@ -102,7 +103,7 @@ TEST(TransformationSetSelectionControlTest, VariousScenarios) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_split_block_test.cpp
+++ b/test/fuzz/transformation_split_block_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_split_block.h"
+
 #include "source/fuzz/instruction_descriptor.h"
 #include "test/fuzz/fuzz_test_util.h"
 
@@ -88,7 +89,7 @@ TEST(TransformationSplitBlockTest, NotApplicable) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -201,7 +202,7 @@ TEST(TransformationSplitBlockTest, SplitBlockSeveralTimes) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -417,7 +418,7 @@ TEST(TransformationSplitBlockTest, SplitBlockBeforeSelectBranch) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -549,7 +550,7 @@ TEST(TransformationSplitBlockTest, SplitBlockBeforeSwitchBranch) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -685,7 +686,7 @@ TEST(TransformationSplitBlockTest, NoSplitDuringOpPhis) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -740,7 +741,7 @@ TEST(TransformationSplitBlockTest, SplitOpPhiWithSinglePredecessor) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -822,7 +823,7 @@ TEST(TransformationSplitBlockTest, DeadBlockShouldSplitToTwoDeadBlocks) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -912,7 +913,7 @@ TEST(TransformationSplitBlockTest, DoNotSplitUseOfOpSampledImage) {
   const auto consumer = nullptr;
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_store_test.cpp
+++ b/test/fuzz/transformation_store_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_store.h"
+
 #include "source/fuzz/instruction_descriptor.h"
 #include "test/fuzz/fuzz_test_util.h"
 
@@ -93,25 +94,25 @@ TEST(TransformationStoreTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      27, context.get());
+      27);
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      11, context.get());
+      11);
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      46, context.get());
+      46);
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      16, context.get());
+      16);
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      52, context.get());
+      52);
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      81, context.get());
+      81);
   transformation_context.GetFactManager()->AddFactValueOfPointeeIsIrrelevant(
-      82, context.get());
+      82);
 
   transformation_context.GetFactManager()->AddFactBlockIsDead(36);
 
@@ -397,7 +398,7 @@ TEST(TransformationStoreTest, DoNotAllowStoresToReadOnlyMemory) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_swap_commutable_operands_test.cpp
+++ b/test/fuzz/transformation_swap_commutable_operands_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_swap_commutable_operands.h"
+
 #include "source/fuzz/instruction_descriptor.h"
 #include "test/fuzz/fuzz_test_util.h"
 
@@ -111,7 +112,7 @@ TEST(TransformationSwapCommutableOperandsTest, IsApplicableTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -338,7 +339,7 @@ TEST(TransformationSwapCommutableOperandsTest, ApplyTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_swap_conditional_branch_operands_test.cpp
+++ b/test/fuzz/transformation_swap_conditional_branch_operands_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_swap_conditional_branch_operands.h"
+
 #include "source/fuzz/instruction_descriptor.h"
 #include "test/fuzz/fuzz_test_util.h"
 
@@ -68,7 +69,7 @@ TEST(TransformationSwapConditionalBranchOperandsTest, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_toggle_access_chain_instruction_test.cpp
+++ b/test/fuzz/transformation_toggle_access_chain_instruction_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/transformation_toggle_access_chain_instruction.h"
+
 #include "source/fuzz/instruction_descriptor.h"
 #include "test/fuzz/fuzz_test_util.h"
 
@@ -111,7 +112,7 @@ TEST(TransformationToggleAccessChainInstructionTest, IsApplicableTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -307,7 +308,7 @@ TEST(TransformationToggleAccessChainInstructionTest, ApplyTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);

--- a/test/fuzz/transformation_vector_shuffle_test.cpp
+++ b/test/fuzz/transformation_vector_shuffle_test.cpp
@@ -86,89 +86,89 @@ TEST(TransformationVectorShuffle, BasicTest) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(10, {}), MakeDataDescriptor(12, {0}), context.get());
+      MakeDataDescriptor(10, {}), MakeDataDescriptor(12, {0}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(11, {}), MakeDataDescriptor(12, {1}), context.get());
+      MakeDataDescriptor(11, {}), MakeDataDescriptor(12, {1}));
 
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(10, {}), MakeDataDescriptor(16, {0}), context.get());
+      MakeDataDescriptor(10, {}), MakeDataDescriptor(16, {0}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(11, {}), MakeDataDescriptor(16, {1}), context.get());
+      MakeDataDescriptor(11, {}), MakeDataDescriptor(16, {1}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(10, {}), MakeDataDescriptor(16, {2}), context.get());
+      MakeDataDescriptor(10, {}), MakeDataDescriptor(16, {2}));
 
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(10, {}), MakeDataDescriptor(20, {0}), context.get());
+      MakeDataDescriptor(10, {}), MakeDataDescriptor(20, {0}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(11, {}), MakeDataDescriptor(20, {1}), context.get());
+      MakeDataDescriptor(11, {}), MakeDataDescriptor(20, {1}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(10, {}), MakeDataDescriptor(20, {2}), context.get());
+      MakeDataDescriptor(10, {}), MakeDataDescriptor(20, {2}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(11, {}), MakeDataDescriptor(20, {3}), context.get());
+      MakeDataDescriptor(11, {}), MakeDataDescriptor(20, {3}));
 
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(25, {}), MakeDataDescriptor(27, {0}), context.get());
+      MakeDataDescriptor(25, {}), MakeDataDescriptor(27, {0}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(26, {}), MakeDataDescriptor(27, {1}), context.get());
+      MakeDataDescriptor(26, {}), MakeDataDescriptor(27, {1}));
 
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(25, {}), MakeDataDescriptor(31, {0}), context.get());
+      MakeDataDescriptor(25, {}), MakeDataDescriptor(31, {0}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(26, {}), MakeDataDescriptor(31, {1}), context.get());
+      MakeDataDescriptor(26, {}), MakeDataDescriptor(31, {1}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(25, {}), MakeDataDescriptor(31, {2}), context.get());
+      MakeDataDescriptor(25, {}), MakeDataDescriptor(31, {2}));
 
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(25, {}), MakeDataDescriptor(35, {0}), context.get());
+      MakeDataDescriptor(25, {}), MakeDataDescriptor(35, {0}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(26, {}), MakeDataDescriptor(35, {1}), context.get());
+      MakeDataDescriptor(26, {}), MakeDataDescriptor(35, {1}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(25, {}), MakeDataDescriptor(35, {2}), context.get());
+      MakeDataDescriptor(25, {}), MakeDataDescriptor(35, {2}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(26, {}), MakeDataDescriptor(35, {3}), context.get());
+      MakeDataDescriptor(26, {}), MakeDataDescriptor(35, {3}));
 
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(40, {}), MakeDataDescriptor(42, {0}), context.get());
+      MakeDataDescriptor(40, {}), MakeDataDescriptor(42, {0}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(41, {}), MakeDataDescriptor(42, {1}), context.get());
+      MakeDataDescriptor(41, {}), MakeDataDescriptor(42, {1}));
 
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(40, {}), MakeDataDescriptor(46, {0}), context.get());
+      MakeDataDescriptor(40, {}), MakeDataDescriptor(46, {0}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(41, {}), MakeDataDescriptor(46, {1}), context.get());
+      MakeDataDescriptor(41, {}), MakeDataDescriptor(46, {1}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(40, {}), MakeDataDescriptor(46, {2}), context.get());
+      MakeDataDescriptor(40, {}), MakeDataDescriptor(46, {2}));
 
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(40, {}), MakeDataDescriptor(50, {0}), context.get());
+      MakeDataDescriptor(40, {}), MakeDataDescriptor(50, {0}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(41, {}), MakeDataDescriptor(50, {1}), context.get());
+      MakeDataDescriptor(41, {}), MakeDataDescriptor(50, {1}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(40, {}), MakeDataDescriptor(50, {2}), context.get());
+      MakeDataDescriptor(40, {}), MakeDataDescriptor(50, {2}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(41, {}), MakeDataDescriptor(50, {3}), context.get());
+      MakeDataDescriptor(41, {}), MakeDataDescriptor(50, {3}));
 
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(55, {}), MakeDataDescriptor(61, {0}), context.get());
+      MakeDataDescriptor(55, {}), MakeDataDescriptor(61, {0}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(56, {}), MakeDataDescriptor(61, {1}), context.get());
+      MakeDataDescriptor(56, {}), MakeDataDescriptor(61, {1}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(55, {}), MakeDataDescriptor(61, {2}), context.get());
+      MakeDataDescriptor(55, {}), MakeDataDescriptor(61, {2}));
 
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(55, {}), MakeDataDescriptor(65, {0}), context.get());
+      MakeDataDescriptor(55, {}), MakeDataDescriptor(65, {0}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(56, {}), MakeDataDescriptor(65, {1}), context.get());
+      MakeDataDescriptor(56, {}), MakeDataDescriptor(65, {1}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(55, {}), MakeDataDescriptor(65, {2}), context.get());
+      MakeDataDescriptor(55, {}), MakeDataDescriptor(65, {2}));
   transformation_context.GetFactManager()->AddFactDataSynonym(
-      MakeDataDescriptor(56, {}), MakeDataDescriptor(65, {3}), context.get());
+      MakeDataDescriptor(56, {}), MakeDataDescriptor(65, {3}));
 
   // %103 does not dominate the return instruction.
   ASSERT_FALSE(TransformationVectorShuffle(
@@ -489,7 +489,7 @@ TEST(TransformationVectorShuffleTest, IllegalInsertionPoints) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -606,7 +606,7 @@ TEST(TransformationVectorShuffle, HandlesIrrelevantIds1) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
@@ -688,12 +688,12 @@ TEST(TransformationVectorShuffle, HandlesIrrelevantIds2) {
   const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
   ASSERT_TRUE(IsValid(env, context.get()));
 
-  FactManager fact_manager;
+  FactManager fact_manager(context.get());
   spvtools::ValidatorOptions validator_options;
   TransformationContext transformation_context(&fact_manager,
                                                validator_options);
 
-  fact_manager.AddFactIdIsIrrelevant(112, context.get());
+  fact_manager.AddFactIdIsIrrelevant(112);
   TransformationVectorShuffle transformation(
       MakeInstructionDescriptor(100, SpvOpReturn, 0), 200, 12, 112, {2, 0});
   ASSERT_TRUE(

--- a/test/fuzz/uniform_buffer_element_descriptor_test.cpp
+++ b/test/fuzz/uniform_buffer_element_descriptor_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "source/fuzz/uniform_buffer_element_descriptor.h"
+
 #include "test/fuzz/fuzz_test_util.h"
 
 namespace spvtools {


### PR DESCRIPTION
This PR converts `IRContext` parameter in fact managers into a class field. Part of #3698.