### PR TITLE
spirv-fuzz: Report fresh ids in transformations

### DIFF
--- a/source/fuzz/counter_overflow_id_source.cpp
+++ b/source/fuzz/counter_overflow_id_source.cpp
@@ -18,12 +18,18 @@ namespace spvtools {
 namespace fuzz {
 
 CounterOverflowIdSource::CounterOverflowIdSource(uint32_t first_available_id)
-    : next_available_id_(first_available_id) {}
+    : next_available_id_(first_available_id), issued_ids_() {}
 
 bool CounterOverflowIdSource::HasOverflowIds() const { return true; }
 
 uint32_t CounterOverflowIdSource::GetNextOverflowId() {
+  issued_ids_.insert(next_available_id_);
   return next_available_id_++;
+}
+
+const std::unordered_set<uint32_t>&
+CounterOverflowIdSource::GetIssuedOverflowIds() const {
+  return issued_ids_;
 }
 
 }  // namespace fuzz

--- a/source/fuzz/counter_overflow_id_source.h
+++ b/source/fuzz/counter_overflow_id_source.h
@@ -35,8 +35,12 @@ class CounterOverflowIdSource : public OverflowIdSource {
   //  account for the case where the maximum allowed id is reached.
   uint32_t GetNextOverflowId() override;
 
+  const std::unordered_set<uint32_t>& GetIssuedOverflowIds() const override;
+
  private:
   uint32_t next_available_id_;
+
+  std::unordered_set<uint32_t> issued_ids_;
 };
 
 }  // namespace fuzz

--- a/source/fuzz/overflow_id_source.h
+++ b/source/fuzz/overflow_id_source.h
@@ -16,6 +16,7 @@
 #define SOURCE_FUZZ_OVERFLOW_ID_SOURCE_H_
 
 #include <cstdint>
+#include <unordered_set>
 
 namespace spvtools {
 namespace fuzz {
@@ -98,6 +99,10 @@ class OverflowIdSource {
   // Precondition: HasOverflowIds() must hold.  Returns the next available
   // overflow id.
   virtual uint32_t GetNextOverflowId() = 0;
+
+  // Returns the set of overflow ids from this source that have been previously
+  // issued via calls to GetNextOverflowId().
+  virtual const std::unordered_set<uint32_t>& GetIssuedOverflowIds() const = 0;
 };
 
 }  // namespace fuzz

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -738,11 +738,12 @@ message TransformationAddFunction {
   // Id of an existing global value with the same return type as the function
   // that can be used to replace OpKill and OpReachable instructions with
   // ReturnValue instructions.  Ignored if the function has void return type.
+  // Only relevant if |is_livesafe| holds.
   uint32 kill_unreachable_return_value_id = 6;
 
   // A mapping (represented as a sequence) from every access chain result id in
   // the function to the ids required to clamp its indices to ensure they are in
-  // bounds.
+  // bounds; only relevant if |is_livesafe| holds.
   repeated AccessChainClampingInfo access_chain_clamping_info = 7;
 
 }

--- a/source/fuzz/replayer.h
+++ b/source/fuzz/replayer.h
@@ -50,8 +50,7 @@ class Replayer {
            const std::vector<uint32_t>& binary_in,
            const protobufs::FactSequence& initial_facts,
            const protobufs::TransformationSequence& transformation_sequence_in,
-           uint32_t num_transformations_to_apply, uint32_t first_overflow_id,
-           bool validate_during_replay,
+           uint32_t num_transformations_to_apply, bool validate_during_replay,
            spv_validator_options validator_options);
 
   // Disables copy/move constructor/assignment operations.
@@ -66,11 +65,6 @@ class Replayer {
   // from |transformation_sequence_in_| to |binary_in_|.  Initial facts about
   // the input binary and the context in which it will execute are provided via
   // |initial_facts_|.
-  //
-  // |first_overflow_id_| should be set to 0 if overflow ids are not available
-  // during replay.  Otherwise |first_overflow_id_| must be larger than any id
-  // referred to in |binary_in_| or |transformation_sequence_in_|, and overflow
-  // ids will be available during replay starting from this value.
   //
   // On success, returns a successful result status together with the
   // transformations that were applied, the IR for the transformed module, and
@@ -97,10 +91,6 @@ class Replayer {
 
   // The number of transformations that should be replayed.
   const uint32_t num_transformations_to_apply_;
-
-  // Zero if overflow ids are not available, otherwise hold the value of the
-  // smallest id that may be used for overflow purposes.
-  const uint32_t first_overflow_id_;
 
   // Controls whether the validator should be run after every replay step.
   const bool validate_during_replay_;

--- a/source/fuzz/shrinker.cpp
+++ b/source/fuzz/shrinker.cpp
@@ -109,8 +109,7 @@ Shrinker::ShrinkerResult Shrinker::Run() {
                transformation_sequence_in_,
                static_cast<uint32_t>(
                    transformation_sequence_in_.transformation_size()),
-               /* No overflow ids */ 0, validate_during_replay_,
-               validator_options_)
+               validate_during_replay_, validator_options_)
           .Run();
   if (initial_replay_result.status !=
       Replayer::ReplayerResultStatus::kComplete) {
@@ -134,12 +133,6 @@ Shrinker::ShrinkerResult Shrinker::Run() {
     return {ShrinkerResultStatus::kInitialBinaryNotInteresting,
             std::vector<uint32_t>(), protobufs::TransformationSequence()};
   }
-
-  // The largest id used by the module before any shrinking has been applied
-  // serves as the first id that can be used for overflow purposes.
-  const uint32_t first_overflow_id = GetIdBound(current_best_binary);
-  assert(first_overflow_id >= GetIdBound(binary_in_) &&
-         "Applying transformations should only increase a module's id bound.");
 
   uint32_t attempt = 0;  // Keeps track of the number of shrink attempts that
                          // have been tried, whether successful or not.
@@ -202,7 +195,7 @@ Shrinker::ShrinkerResult Shrinker::Run() {
               transformations_with_chunk_removed,
               static_cast<uint32_t>(
                   transformations_with_chunk_removed.transformation_size()),
-              first_overflow_id, validate_during_replay_, validator_options_)
+              validate_during_replay_, validator_options_)
               .Run();
       if (replay_result.status != Replayer::ReplayerResultStatus::kComplete) {
         // Replay should not fail; if it does, we need to abort shrinking.

--- a/source/fuzz/transformation.h
+++ b/source/fuzz/transformation.h
@@ -16,6 +16,7 @@
 #define SOURCE_FUZZ_TRANSFORMATION_H_
 
 #include <memory>
+#include <unordered_set>
 
 #include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
 #include "source/fuzz/transformation_context.h"
@@ -58,6 +59,13 @@ namespace fuzz {
 
 class Transformation {
  public:
+  virtual ~Transformation();
+
+  // Factory method to obtain a transformation object from the protobuf
+  // representation of a transformation given by |message|.
+  static std::unique_ptr<Transformation> FromMessage(
+      const protobufs::Transformation& message);
+
   // A precondition that determines whether the transformation can be cleanly
   // applied in a semantics-preserving manner to the SPIR-V module given by
   // |ir_context|, in the presence of facts and other contextual information
@@ -77,15 +85,12 @@ class Transformation {
   virtual void Apply(opt::IRContext* ir_context,
                      TransformationContext* transformation_context) const = 0;
 
+  // Returns the set of fresh ids that appear in the transformation's protobuf
+  // message.
+  virtual std::unordered_set<uint32_t> GetFreshIds() const = 0;
+
   // Turns the transformation into a protobuf message for serialization.
   virtual protobufs::Transformation ToMessage() const = 0;
-
-  virtual ~Transformation();
-
-  // Factory method to obtain a transformation object from the protobuf
-  // representation of a transformation given by |message|.
-  static std::unique_ptr<Transformation> FromMessage(
-      const protobufs::Transformation& message);
 
   // Helper that returns true if and only if (a) |id| is a fresh id for the
   // module, and (b) |id| is not in |ids_used_by_this_transformation|, a set of

--- a/source/fuzz/transformation_access_chain.cpp
+++ b/source/fuzz/transformation_access_chain.cpp
@@ -408,9 +408,12 @@ bool TransformationAccessChain::ValidIndexToComposite(
 }
 
 std::unordered_set<uint32_t> TransformationAccessChain::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  std::unordered_set<uint32_t> result = {message_.fresh_id()};
+  for (auto& fresh_ids_for_clamping : message_.fresh_ids_for_clamping()) {
+    result.insert(fresh_ids_for_clamping.first());
+    result.insert(fresh_ids_for_clamping.second());
+  }
+  return result;
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_access_chain.cpp
+++ b/source/fuzz/transformation_access_chain.cpp
@@ -407,5 +407,11 @@ bool TransformationAccessChain::ValidIndexToComposite(
   return true;
 }
 
+std::unordered_set<uint32_t> TransformationAccessChain::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_access_chain.h
+++ b/source/fuzz/transformation_access_chain.h
@@ -76,6 +76,8 @@ class TransformationAccessChain : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_bit_instruction_synonym.cpp
+++ b/source/fuzz/transformation_add_bit_instruction_synonym.cpp
@@ -232,9 +232,11 @@ void TransformationAddBitInstructionSynonym::AddOpBitwiseOrOpNotSynonym(
 
 std::unordered_set<uint32_t>
 TransformationAddBitInstructionSynonym::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  std::unordered_set<uint32_t> result;
+  for (auto id : message_.fresh_ids()) {
+    result.insert(id);
+  }
+  return result;
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_bit_instruction_synonym.cpp
+++ b/source/fuzz/transformation_add_bit_instruction_synonym.cpp
@@ -230,5 +230,12 @@ void TransformationAddBitInstructionSynonym::AddOpBitwiseOrOpNotSynonym(
       MakeDataDescriptor(bit_instruction->result_id(), {}));
 }
 
+std::unordered_set<uint32_t>
+TransformationAddBitInstructionSynonym::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_bit_instruction_synonym.h
+++ b/source/fuzz/transformation_add_bit_instruction_synonym.h
@@ -120,6 +120,8 @@ class TransformationAddBitInstructionSynonym : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
   // Returns the number of fresh ids required to apply the transformation.

--- a/source/fuzz/transformation_add_constant_boolean.cpp
+++ b/source/fuzz/transformation_add_constant_boolean.cpp
@@ -63,5 +63,12 @@ protobufs::Transformation TransformationAddConstantBoolean::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationAddConstantBoolean::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_constant_boolean.cpp
+++ b/source/fuzz/transformation_add_constant_boolean.cpp
@@ -65,9 +65,7 @@ protobufs::Transformation TransformationAddConstantBoolean::ToMessage() const {
 
 std::unordered_set<uint32_t> TransformationAddConstantBoolean::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_constant_boolean.h
+++ b/source/fuzz/transformation_add_constant_boolean.h
@@ -44,6 +44,8 @@ class TransformationAddConstantBoolean : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_constant_composite.cpp
+++ b/source/fuzz/transformation_add_constant_composite.cpp
@@ -133,5 +133,12 @@ protobufs::Transformation TransformationAddConstantComposite::ToMessage()
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationAddConstantComposite::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_constant_composite.cpp
+++ b/source/fuzz/transformation_add_constant_composite.cpp
@@ -135,9 +135,7 @@ protobufs::Transformation TransformationAddConstantComposite::ToMessage()
 
 std::unordered_set<uint32_t> TransformationAddConstantComposite::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_constant_composite.h
+++ b/source/fuzz/transformation_add_constant_composite.h
@@ -50,6 +50,8 @@ class TransformationAddConstantComposite : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_constant_null.cpp
+++ b/source/fuzz/transformation_add_constant_null.cpp
@@ -64,9 +64,7 @@ protobufs::Transformation TransformationAddConstantNull::ToMessage() const {
 
 std::unordered_set<uint32_t> TransformationAddConstantNull::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_constant_null.cpp
+++ b/source/fuzz/transformation_add_constant_null.cpp
@@ -62,5 +62,12 @@ protobufs::Transformation TransformationAddConstantNull::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationAddConstantNull::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_constant_null.h
+++ b/source/fuzz/transformation_add_constant_null.h
@@ -42,6 +42,8 @@ class TransformationAddConstantNull : public Transformation {
   void Apply(opt::IRContext* context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_constant_scalar.cpp
+++ b/source/fuzz/transformation_add_constant_scalar.cpp
@@ -92,9 +92,7 @@ protobufs::Transformation TransformationAddConstantScalar::ToMessage() const {
 
 std::unordered_set<uint32_t> TransformationAddConstantScalar::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_constant_scalar.cpp
+++ b/source/fuzz/transformation_add_constant_scalar.cpp
@@ -90,5 +90,12 @@ protobufs::Transformation TransformationAddConstantScalar::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationAddConstantScalar::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_constant_scalar.h
+++ b/source/fuzz/transformation_add_constant_scalar.h
@@ -47,6 +47,8 @@ class TransformationAddConstantScalar : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_copy_memory.cpp
+++ b/source/fuzz/transformation_add_copy_memory.cpp
@@ -190,9 +190,7 @@ bool TransformationAddCopyMemory::CanUsePointeeWithCopyMemory(
 }
 
 std::unordered_set<uint32_t> TransformationAddCopyMemory::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_copy_memory.cpp
+++ b/source/fuzz/transformation_add_copy_memory.cpp
@@ -189,5 +189,11 @@ bool TransformationAddCopyMemory::CanUsePointeeWithCopyMemory(
   }
 }
 
+std::unordered_set<uint32_t> TransformationAddCopyMemory::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_copy_memory.h
+++ b/source/fuzz/transformation_add_copy_memory.h
@@ -54,6 +54,8 @@ class TransformationAddCopyMemory : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
   // Returns true if we can copy memory from |instruction| using OpCopyMemory.

--- a/source/fuzz/transformation_add_dead_block.cpp
+++ b/source/fuzz/transformation_add_dead_block.cpp
@@ -189,5 +189,11 @@ protobufs::Transformation TransformationAddDeadBlock::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationAddDeadBlock::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_dead_block.cpp
+++ b/source/fuzz/transformation_add_dead_block.cpp
@@ -190,9 +190,7 @@ protobufs::Transformation TransformationAddDeadBlock::ToMessage() const {
 }
 
 std::unordered_set<uint32_t> TransformationAddDeadBlock::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_dead_block.h
+++ b/source/fuzz/transformation_add_dead_block.h
@@ -53,6 +53,8 @@ class TransformationAddDeadBlock : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_dead_break.cpp
+++ b/source/fuzz/transformation_add_dead_break.cpp
@@ -212,9 +212,11 @@ void TransformationAddDeadBreak::ApplyImpl(
 }
 
 std::unordered_set<uint32_t> TransformationAddDeadBreak::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  std::unordered_set<uint32_t> result;
+  for (auto id : message_.phi_id()) {
+    result.insert(id);
+  }
+  return result;
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_dead_break.cpp
+++ b/source/fuzz/transformation_add_dead_break.cpp
@@ -211,5 +211,11 @@ void TransformationAddDeadBreak::ApplyImpl(
       message_.phi_id());
 }
 
+std::unordered_set<uint32_t> TransformationAddDeadBreak::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_dead_break.cpp
+++ b/source/fuzz/transformation_add_dead_break.cpp
@@ -212,7 +212,7 @@ void TransformationAddDeadBreak::ApplyImpl(
 }
 
 std::unordered_set<uint32_t> TransformationAddDeadBreak::GetFreshIds() const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_dead_break.cpp
+++ b/source/fuzz/transformation_add_dead_break.cpp
@@ -212,11 +212,7 @@ void TransformationAddDeadBreak::ApplyImpl(
 }
 
 std::unordered_set<uint32_t> TransformationAddDeadBreak::GetFreshIds() const {
-  std::unordered_set<uint32_t> result;
-  for (auto id : message_.phi_id()) {
-    result.insert(id);
-  }
-  return result;
+  return {};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_dead_break.h
+++ b/source/fuzz/transformation_add_dead_break.h
@@ -61,6 +61,8 @@ class TransformationAddDeadBreak : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_dead_continue.cpp
+++ b/source/fuzz/transformation_add_dead_continue.cpp
@@ -158,5 +158,12 @@ void TransformationAddDeadContinue::ApplyImpl(
       message_.phi_id());
 }
 
+std::unordered_set<uint32_t> TransformationAddDeadContinue::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_dead_continue.cpp
+++ b/source/fuzz/transformation_add_dead_continue.cpp
@@ -160,7 +160,7 @@ void TransformationAddDeadContinue::ApplyImpl(
 
 std::unordered_set<uint32_t> TransformationAddDeadContinue::GetFreshIds()
     const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_dead_continue.cpp
+++ b/source/fuzz/transformation_add_dead_continue.cpp
@@ -160,11 +160,7 @@ void TransformationAddDeadContinue::ApplyImpl(
 
 std::unordered_set<uint32_t> TransformationAddDeadContinue::GetFreshIds()
     const {
-  std::unordered_set<uint32_t> result;
-  for (auto id : message_.phi_id()) {
-    result.insert(id);
-  }
-  return result;
+  return {};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_dead_continue.cpp
+++ b/source/fuzz/transformation_add_dead_continue.cpp
@@ -160,9 +160,11 @@ void TransformationAddDeadContinue::ApplyImpl(
 
 std::unordered_set<uint32_t> TransformationAddDeadContinue::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  std::unordered_set<uint32_t> result;
+  for (auto id : message_.phi_id()) {
+    result.insert(id);
+  }
+  return result;
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_dead_continue.h
+++ b/source/fuzz/transformation_add_dead_continue.h
@@ -63,6 +63,8 @@ class TransformationAddDeadContinue : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_function.cpp
+++ b/source/fuzz/transformation_add_function.cpp
@@ -927,5 +927,11 @@ opt::Instruction* TransformationAddFunction::FollowCompositeIndex(
   return ir_context->get_def_use_mgr()->GetDef(sub_object_type_id);
 }
 
+std::unordered_set<uint32_t> TransformationAddFunction::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_function.cpp
+++ b/source/fuzz/transformation_add_function.cpp
@@ -928,9 +928,29 @@ opt::Instruction* TransformationAddFunction::FollowCompositeIndex(
 }
 
 std::unordered_set<uint32_t> TransformationAddFunction::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  std::unordered_set<uint32_t> result;
+  for (auto& instruction : message_.instruction()) {
+    result.insert(instruction.result_id());
+  }
+  if (message_.is_livesafe()) {
+    result.insert(message_.loop_limit_constant_id());
+  }
+  for (auto& loop_limiter_info : message_.loop_limiter_info()) {
+    result.insert(loop_limiter_info.load_id());
+    result.insert(loop_limiter_info.increment_id());
+    result.insert(loop_limiter_info.compare_id());
+    result.insert(loop_limiter_info.logical_op_id());
+    for (auto id : loop_limiter_info.phi_id()) {
+      result.insert(id);
+    }
+  }
+  for (auto& access_chain_clamping_info :
+       message_.access_chain_clamping_info()) {
+    for (auto& pair : access_chain_clamping_info.compare_and_select_ids()) {
+      result.insert(pair.first(), pair.second());
+    }
+  }
+  return result;
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_function.cpp
+++ b/source/fuzz/transformation_add_function.cpp
@@ -933,21 +933,19 @@ std::unordered_set<uint32_t> TransformationAddFunction::GetFreshIds() const {
     result.insert(instruction.result_id());
   }
   if (message_.is_livesafe()) {
-    result.insert(message_.loop_limit_constant_id());
-  }
-  for (auto& loop_limiter_info : message_.loop_limiter_info()) {
-    result.insert(loop_limiter_info.load_id());
-    result.insert(loop_limiter_info.increment_id());
-    result.insert(loop_limiter_info.compare_id());
-    result.insert(loop_limiter_info.logical_op_id());
-    for (auto id : loop_limiter_info.phi_id()) {
-      result.insert(id);
+    result.insert(message_.loop_limiter_variable_id());
+    for (auto& loop_limiter_info : message_.loop_limiter_info()) {
+      result.insert(loop_limiter_info.load_id());
+      result.insert(loop_limiter_info.increment_id());
+      result.insert(loop_limiter_info.compare_id());
+      result.insert(loop_limiter_info.logical_op_id());
     }
-  }
-  for (auto& access_chain_clamping_info :
-       message_.access_chain_clamping_info()) {
-    for (auto& pair : access_chain_clamping_info.compare_and_select_ids()) {
-      result.insert(pair.first(), pair.second());
+    for (auto& access_chain_clamping_info :
+         message_.access_chain_clamping_info()) {
+      for (auto& pair : access_chain_clamping_info.compare_and_select_ids()) {
+        result.insert(pair.first());
+        result.insert(pair.second());
+      }
     }
   }
   return result;

--- a/source/fuzz/transformation_add_function.h
+++ b/source/fuzz/transformation_add_function.h
@@ -56,6 +56,8 @@ class TransformationAddFunction : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
   // Helper method that, given composite type |composite_type_inst|, returns the

--- a/source/fuzz/transformation_add_global_undef.cpp
+++ b/source/fuzz/transformation_add_global_undef.cpp
@@ -59,9 +59,7 @@ protobufs::Transformation TransformationAddGlobalUndef::ToMessage() const {
 }
 
 std::unordered_set<uint32_t> TransformationAddGlobalUndef::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_global_undef.cpp
+++ b/source/fuzz/transformation_add_global_undef.cpp
@@ -58,5 +58,11 @@ protobufs::Transformation TransformationAddGlobalUndef::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationAddGlobalUndef::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_global_undef.h
+++ b/source/fuzz/transformation_add_global_undef.h
@@ -41,6 +41,8 @@ class TransformationAddGlobalUndef : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_global_variable.cpp
+++ b/source/fuzz/transformation_add_global_variable.cpp
@@ -117,9 +117,7 @@ protobufs::Transformation TransformationAddGlobalVariable::ToMessage() const {
 
 std::unordered_set<uint32_t> TransformationAddGlobalVariable::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_global_variable.cpp
+++ b/source/fuzz/transformation_add_global_variable.cpp
@@ -115,5 +115,12 @@ protobufs::Transformation TransformationAddGlobalVariable::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationAddGlobalVariable::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_global_variable.h
+++ b/source/fuzz/transformation_add_global_variable.h
@@ -55,6 +55,8 @@ class TransformationAddGlobalVariable : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_image_sample_unused_components.cpp
+++ b/source/fuzz/transformation_add_image_sample_unused_components.cpp
@@ -115,8 +115,6 @@ TransformationAddImageSampleUnusedComponents::ToMessage() const {
 
 std::unordered_set<uint32_t>
 TransformationAddImageSampleUnusedComponents::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
   return {};
 }
 

--- a/source/fuzz/transformation_add_image_sample_unused_components.cpp
+++ b/source/fuzz/transformation_add_image_sample_unused_components.cpp
@@ -115,7 +115,7 @@ TransformationAddImageSampleUnusedComponents::ToMessage() const {
 
 std::unordered_set<uint32_t>
 TransformationAddImageSampleUnusedComponents::GetFreshIds() const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_image_sample_unused_components.cpp
+++ b/source/fuzz/transformation_add_image_sample_unused_components.cpp
@@ -113,5 +113,12 @@ TransformationAddImageSampleUnusedComponents::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t>
+TransformationAddImageSampleUnusedComponents::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_image_sample_unused_components.h
+++ b/source/fuzz/transformation_add_image_sample_unused_components.h
@@ -45,6 +45,8 @@ class TransformationAddImageSampleUnusedComponents : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_local_variable.cpp
+++ b/source/fuzz/transformation_add_local_variable.cpp
@@ -88,5 +88,12 @@ protobufs::Transformation TransformationAddLocalVariable::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationAddLocalVariable::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_local_variable.cpp
+++ b/source/fuzz/transformation_add_local_variable.cpp
@@ -90,9 +90,7 @@ protobufs::Transformation TransformationAddLocalVariable::ToMessage() const {
 
 std::unordered_set<uint32_t> TransformationAddLocalVariable::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_local_variable.h
+++ b/source/fuzz/transformation_add_local_variable.h
@@ -50,6 +50,8 @@ class TransformationAddLocalVariable : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_loop_preheader.cpp
+++ b/source/fuzz/transformation_add_loop_preheader.cpp
@@ -221,5 +221,12 @@ protobufs::Transformation TransformationAddLoopPreheader::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationAddLoopPreheader::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_loop_preheader.cpp
+++ b/source/fuzz/transformation_add_loop_preheader.cpp
@@ -223,9 +223,11 @@ protobufs::Transformation TransformationAddLoopPreheader::ToMessage() const {
 
 std::unordered_set<uint32_t> TransformationAddLoopPreheader::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  std::unordered_set<uint32_t> result = {message_.fresh_id()};
+  for (auto id : message_.phi_id()) {
+    result.insert(id);
+  }
+  return result;
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_loop_preheader.h
+++ b/source/fuzz/transformation_add_loop_preheader.h
@@ -45,6 +45,8 @@ class TransformationAddLoopPreheader : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_loop_to_create_int_constant_synonym.cpp
+++ b/source/fuzz/transformation_add_loop_to_create_int_constant_synonym.cpp
@@ -423,5 +423,12 @@ TransformationAddLoopToCreateIntConstantSynonym::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t>
+TransformationAddLoopToCreateIntConstantSynonym::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_loop_to_create_int_constant_synonym.cpp
+++ b/source/fuzz/transformation_add_loop_to_create_int_constant_synonym.cpp
@@ -425,9 +425,10 @@ TransformationAddLoopToCreateIntConstantSynonym::ToMessage() const {
 
 std::unordered_set<uint32_t>
 TransformationAddLoopToCreateIntConstantSynonym::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.syn_id(),          message_.loop_id(),
+          message_.ctr_id(),          message_.temp_id(),
+          message_.eventual_syn_id(), message_.incremented_ctr_id(),
+          message_.cond_id(),         message_.additional_block_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_loop_to_create_int_constant_synonym.h
+++ b/source/fuzz/transformation_add_loop_to_create_int_constant_synonym.h
@@ -57,6 +57,8 @@ class TransformationAddLoopToCreateIntConstantSynonym : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_no_contraction_decoration.cpp
+++ b/source/fuzz/transformation_add_no_contraction_decoration.cpp
@@ -107,7 +107,7 @@ bool TransformationAddNoContractionDecoration::IsArithmetic(uint32_t opcode) {
 
 std::unordered_set<uint32_t>
 TransformationAddNoContractionDecoration::GetFreshIds() const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_no_contraction_decoration.cpp
+++ b/source/fuzz/transformation_add_no_contraction_decoration.cpp
@@ -105,5 +105,12 @@ bool TransformationAddNoContractionDecoration::IsArithmetic(uint32_t opcode) {
   }
 }
 
+std::unordered_set<uint32_t>
+TransformationAddNoContractionDecoration::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_no_contraction_decoration.cpp
+++ b/source/fuzz/transformation_add_no_contraction_decoration.cpp
@@ -107,8 +107,6 @@ bool TransformationAddNoContractionDecoration::IsArithmetic(uint32_t opcode) {
 
 std::unordered_set<uint32_t>
 TransformationAddNoContractionDecoration::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
   return {};
 }
 

--- a/source/fuzz/transformation_add_no_contraction_decoration.h
+++ b/source/fuzz/transformation_add_no_contraction_decoration.h
@@ -44,6 +44,8 @@ class TransformationAddNoContractionDecoration : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
   // Returns true if and only if |opcode| is the opcode of an arithmetic

--- a/source/fuzz/transformation_add_opphi_synonym.cpp
+++ b/source/fuzz/transformation_add_opphi_synonym.cpp
@@ -195,9 +195,7 @@ bool TransformationAddOpPhiSynonym::CheckTypeIsAllowed(
 
 std::unordered_set<uint32_t> TransformationAddOpPhiSynonym::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_opphi_synonym.cpp
+++ b/source/fuzz/transformation_add_opphi_synonym.cpp
@@ -193,5 +193,12 @@ bool TransformationAddOpPhiSynonym::CheckTypeIsAllowed(
   return false;
 }
 
+std::unordered_set<uint32_t> TransformationAddOpPhiSynonym::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_opphi_synonym.h
+++ b/source/fuzz/transformation_add_opphi_synonym.h
@@ -61,6 +61,8 @@ class TransformationAddOpPhiSynonym : public Transformation {
   // enabled and the storage class is Workgroup or StorageBuffer.
   static bool CheckTypeIsAllowed(opt::IRContext* ir_context, uint32_t type_id);
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_parameter.cpp
+++ b/source/fuzz/transformation_add_parameter.cpp
@@ -212,9 +212,7 @@ bool TransformationAddParameter::IsParameterTypeSupported(
 }
 
 std::unordered_set<uint32_t> TransformationAddParameter::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.parameter_fresh_id(), message_.function_type_fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_parameter.cpp
+++ b/source/fuzz/transformation_add_parameter.cpp
@@ -211,5 +211,11 @@ bool TransformationAddParameter::IsParameterTypeSupported(
   }
 }
 
+std::unordered_set<uint32_t> TransformationAddParameter::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_parameter.h
+++ b/source/fuzz/transformation_add_parameter.h
@@ -56,6 +56,8 @@ class TransformationAddParameter : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
   // Returns true if the type of the parameter is supported by this

--- a/source/fuzz/transformation_add_relaxed_decoration.cpp
+++ b/source/fuzz/transformation_add_relaxed_decoration.cpp
@@ -142,5 +142,12 @@ bool TransformationAddRelaxedDecoration::IsNumeric(uint32_t opcode) {
   }
 }
 
+std::unordered_set<uint32_t> TransformationAddRelaxedDecoration::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_relaxed_decoration.cpp
+++ b/source/fuzz/transformation_add_relaxed_decoration.cpp
@@ -144,8 +144,6 @@ bool TransformationAddRelaxedDecoration::IsNumeric(uint32_t opcode) {
 
 std::unordered_set<uint32_t> TransformationAddRelaxedDecoration::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
   return {};
 }
 

--- a/source/fuzz/transformation_add_relaxed_decoration.cpp
+++ b/source/fuzz/transformation_add_relaxed_decoration.cpp
@@ -144,7 +144,7 @@ bool TransformationAddRelaxedDecoration::IsNumeric(uint32_t opcode) {
 
 std::unordered_set<uint32_t> TransformationAddRelaxedDecoration::GetFreshIds()
     const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_relaxed_decoration.h
+++ b/source/fuzz/transformation_add_relaxed_decoration.h
@@ -45,6 +45,8 @@ class TransformationAddRelaxedDecoration : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
   // Returns true if and only if |opcode| is the opcode of an instruction

--- a/source/fuzz/transformation_add_spec_constant_op.cpp
+++ b/source/fuzz/transformation_add_spec_constant_op.cpp
@@ -83,9 +83,7 @@ protobufs::Transformation TransformationAddSpecConstantOp::ToMessage() const {
 
 std::unordered_set<uint32_t> TransformationAddSpecConstantOp::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_spec_constant_op.cpp
+++ b/source/fuzz/transformation_add_spec_constant_op.cpp
@@ -81,5 +81,12 @@ protobufs::Transformation TransformationAddSpecConstantOp::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationAddSpecConstantOp::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_spec_constant_op.h
+++ b/source/fuzz/transformation_add_spec_constant_op.h
@@ -46,6 +46,8 @@ class TransformationAddSpecConstantOp : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_synonym.cpp
+++ b/source/fuzz/transformation_add_synonym.cpp
@@ -321,9 +321,7 @@ bool TransformationAddSynonym::IsAdditionalConstantRequired(
 }
 
 std::unordered_set<uint32_t> TransformationAddSynonym::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.synonym_fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_synonym.cpp
+++ b/source/fuzz/transformation_add_synonym.cpp
@@ -320,5 +320,11 @@ bool TransformationAddSynonym::IsAdditionalConstantRequired(
   }
 }
 
+std::unordered_set<uint32_t> TransformationAddSynonym::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_synonym.h
+++ b/source/fuzz/transformation_add_synonym.h
@@ -53,6 +53,8 @@ class TransformationAddSynonym : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
   // Returns true if we can create a synonym of |inst| according to the

--- a/source/fuzz/transformation_add_type_array.cpp
+++ b/source/fuzz/transformation_add_type_array.cpp
@@ -85,9 +85,7 @@ protobufs::Transformation TransformationAddTypeArray::ToMessage() const {
 }
 
 std::unordered_set<uint32_t> TransformationAddTypeArray::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_type_array.cpp
+++ b/source/fuzz/transformation_add_type_array.cpp
@@ -84,5 +84,11 @@ protobufs::Transformation TransformationAddTypeArray::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationAddTypeArray::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_type_array.h
+++ b/source/fuzz/transformation_add_type_array.h
@@ -45,6 +45,8 @@ class TransformationAddTypeArray : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_type_boolean.cpp
+++ b/source/fuzz/transformation_add_type_boolean.cpp
@@ -57,5 +57,11 @@ protobufs::Transformation TransformationAddTypeBoolean::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationAddTypeBoolean::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_type_boolean.cpp
+++ b/source/fuzz/transformation_add_type_boolean.cpp
@@ -58,9 +58,7 @@ protobufs::Transformation TransformationAddTypeBoolean::ToMessage() const {
 }
 
 std::unordered_set<uint32_t> TransformationAddTypeBoolean::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_type_boolean.h
+++ b/source/fuzz/transformation_add_type_boolean.h
@@ -39,6 +39,8 @@ class TransformationAddTypeBoolean : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_type_float.cpp
+++ b/source/fuzz/transformation_add_type_float.cpp
@@ -78,5 +78,11 @@ protobufs::Transformation TransformationAddTypeFloat::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationAddTypeFloat::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_type_float.cpp
+++ b/source/fuzz/transformation_add_type_float.cpp
@@ -79,9 +79,7 @@ protobufs::Transformation TransformationAddTypeFloat::ToMessage() const {
 }
 
 std::unordered_set<uint32_t> TransformationAddTypeFloat::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_type_float.h
+++ b/source/fuzz/transformation_add_type_float.h
@@ -41,6 +41,8 @@ class TransformationAddTypeFloat : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_type_function.cpp
+++ b/source/fuzz/transformation_add_type_function.cpp
@@ -80,5 +80,12 @@ protobufs::Transformation TransformationAddTypeFunction::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationAddTypeFunction::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_type_function.cpp
+++ b/source/fuzz/transformation_add_type_function.cpp
@@ -82,9 +82,7 @@ protobufs::Transformation TransformationAddTypeFunction::ToMessage() const {
 
 std::unordered_set<uint32_t> TransformationAddTypeFunction::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_type_function.h
+++ b/source/fuzz/transformation_add_type_function.h
@@ -49,6 +49,8 @@ class TransformationAddTypeFunction : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_type_int.cpp
+++ b/source/fuzz/transformation_add_type_int.cpp
@@ -88,5 +88,11 @@ protobufs::Transformation TransformationAddTypeInt::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationAddTypeInt::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_type_int.cpp
+++ b/source/fuzz/transformation_add_type_int.cpp
@@ -89,9 +89,7 @@ protobufs::Transformation TransformationAddTypeInt::ToMessage() const {
 }
 
 std::unordered_set<uint32_t> TransformationAddTypeInt::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_type_int.h
+++ b/source/fuzz/transformation_add_type_int.h
@@ -42,6 +42,8 @@ class TransformationAddTypeInt : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_type_matrix.cpp
+++ b/source/fuzz/transformation_add_type_matrix.cpp
@@ -68,9 +68,7 @@ protobufs::Transformation TransformationAddTypeMatrix::ToMessage() const {
 }
 
 std::unordered_set<uint32_t> TransformationAddTypeMatrix::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_type_matrix.cpp
+++ b/source/fuzz/transformation_add_type_matrix.cpp
@@ -67,5 +67,11 @@ protobufs::Transformation TransformationAddTypeMatrix::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationAddTypeMatrix::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_type_matrix.h
+++ b/source/fuzz/transformation_add_type_matrix.h
@@ -43,6 +43,8 @@ class TransformationAddTypeMatrix : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_type_pointer.cpp
+++ b/source/fuzz/transformation_add_type_pointer.cpp
@@ -62,5 +62,11 @@ protobufs::Transformation TransformationAddTypePointer::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationAddTypePointer::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_type_pointer.cpp
+++ b/source/fuzz/transformation_add_type_pointer.cpp
@@ -63,9 +63,7 @@ protobufs::Transformation TransformationAddTypePointer::ToMessage() const {
 }
 
 std::unordered_set<uint32_t> TransformationAddTypePointer::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_type_pointer.h
+++ b/source/fuzz/transformation_add_type_pointer.h
@@ -43,6 +43,8 @@ class TransformationAddTypePointer : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_type_struct.cpp
+++ b/source/fuzz/transformation_add_type_struct.cpp
@@ -74,5 +74,11 @@ protobufs::Transformation TransformationAddTypeStruct::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationAddTypeStruct::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_type_struct.cpp
+++ b/source/fuzz/transformation_add_type_struct.cpp
@@ -75,9 +75,7 @@ protobufs::Transformation TransformationAddTypeStruct::ToMessage() const {
 }
 
 std::unordered_set<uint32_t> TransformationAddTypeStruct::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_type_struct.h
+++ b/source/fuzz/transformation_add_type_struct.h
@@ -47,6 +47,8 @@ class TransformationAddTypeStruct : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_add_type_vector.cpp
+++ b/source/fuzz/transformation_add_type_vector.cpp
@@ -62,9 +62,7 @@ protobufs::Transformation TransformationAddTypeVector::ToMessage() const {
 }
 
 std::unordered_set<uint32_t> TransformationAddTypeVector::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_add_type_vector.cpp
+++ b/source/fuzz/transformation_add_type_vector.cpp
@@ -61,5 +61,11 @@ protobufs::Transformation TransformationAddTypeVector::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationAddTypeVector::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_add_type_vector.h
+++ b/source/fuzz/transformation_add_type_vector.h
@@ -43,6 +43,8 @@ class TransformationAddTypeVector : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_adjust_branch_weights.cpp
+++ b/source/fuzz/transformation_adjust_branch_weights.cpp
@@ -93,5 +93,12 @@ protobufs::Transformation TransformationAdjustBranchWeights::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationAdjustBranchWeights::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_adjust_branch_weights.cpp
+++ b/source/fuzz/transformation_adjust_branch_weights.cpp
@@ -95,8 +95,6 @@ protobufs::Transformation TransformationAdjustBranchWeights::ToMessage() const {
 
 std::unordered_set<uint32_t> TransformationAdjustBranchWeights::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
   return {};
 }
 

--- a/source/fuzz/transformation_adjust_branch_weights.cpp
+++ b/source/fuzz/transformation_adjust_branch_weights.cpp
@@ -95,7 +95,7 @@ protobufs::Transformation TransformationAdjustBranchWeights::ToMessage() const {
 
 std::unordered_set<uint32_t> TransformationAdjustBranchWeights::GetFreshIds()
     const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_adjust_branch_weights.h
+++ b/source/fuzz/transformation_adjust_branch_weights.h
@@ -45,6 +45,8 @@ class TransformationAdjustBranchWeights : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_composite_construct.cpp
+++ b/source/fuzz/transformation_composite_construct.cpp
@@ -310,5 +310,12 @@ protobufs::Transformation TransformationCompositeConstruct::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationCompositeConstruct::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_composite_construct.cpp
+++ b/source/fuzz/transformation_composite_construct.cpp
@@ -312,9 +312,7 @@ protobufs::Transformation TransformationCompositeConstruct::ToMessage() const {
 
 std::unordered_set<uint32_t> TransformationCompositeConstruct::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_composite_construct.h
+++ b/source/fuzz/transformation_composite_construct.h
@@ -61,6 +61,8 @@ class TransformationCompositeConstruct : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_composite_extract.cpp
+++ b/source/fuzz/transformation_composite_extract.cpp
@@ -135,5 +135,12 @@ protobufs::Transformation TransformationCompositeExtract::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationCompositeExtract::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_composite_extract.cpp
+++ b/source/fuzz/transformation_composite_extract.cpp
@@ -137,9 +137,7 @@ protobufs::Transformation TransformationCompositeExtract::ToMessage() const {
 
 std::unordered_set<uint32_t> TransformationCompositeExtract::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_composite_extract.h
+++ b/source/fuzz/transformation_composite_extract.h
@@ -54,6 +54,8 @@ class TransformationCompositeExtract : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_composite_insert.cpp
+++ b/source/fuzz/transformation_composite_insert.cpp
@@ -222,9 +222,7 @@ bool TransformationCompositeInsert::IsCompositeInstructionSupported(
 
 std::unordered_set<uint32_t> TransformationCompositeInsert::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_composite_insert.cpp
+++ b/source/fuzz/transformation_composite_insert.cpp
@@ -220,5 +220,12 @@ bool TransformationCompositeInsert::IsCompositeInstructionSupported(
   return true;
 }
 
+std::unordered_set<uint32_t> TransformationCompositeInsert::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_composite_insert.h
+++ b/source/fuzz/transformation_composite_insert.h
@@ -55,6 +55,8 @@ class TransformationCompositeInsert : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
   // Checks if |instruction| is a instruction of a composite type supported by

--- a/source/fuzz/transformation_compute_data_synonym_fact_closure.cpp
+++ b/source/fuzz/transformation_compute_data_synonym_fact_closure.cpp
@@ -50,8 +50,6 @@ TransformationComputeDataSynonymFactClosure::ToMessage() const {
 
 std::unordered_set<uint32_t>
 TransformationComputeDataSynonymFactClosure::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
   return {};
 }
 

--- a/source/fuzz/transformation_compute_data_synonym_fact_closure.cpp
+++ b/source/fuzz/transformation_compute_data_synonym_fact_closure.cpp
@@ -50,7 +50,7 @@ TransformationComputeDataSynonymFactClosure::ToMessage() const {
 
 std::unordered_set<uint32_t>
 TransformationComputeDataSynonymFactClosure::GetFreshIds() const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_compute_data_synonym_fact_closure.cpp
+++ b/source/fuzz/transformation_compute_data_synonym_fact_closure.cpp
@@ -48,5 +48,12 @@ TransformationComputeDataSynonymFactClosure::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t>
+TransformationComputeDataSynonymFactClosure::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_compute_data_synonym_fact_closure.h
+++ b/source/fuzz/transformation_compute_data_synonym_fact_closure.h
@@ -41,6 +41,8 @@ class TransformationComputeDataSynonymFactClosure : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_context.cpp
+++ b/source/fuzz/transformation_context.cpp
@@ -35,6 +35,14 @@ class NullOverflowIdSource : public OverflowIdSource {
     assert(false && "Bad attempt to request an overflow id.");
     return 0;
   }
+
+  const std::unordered_set<uint32_t>& GetIssuedOverflowIds() const override {
+    assert(false && "Operation not supported.");
+    return placeholder_;
+  }
+
+ private:
+  std::unordered_set<uint32_t> placeholder_;
 };
 
 }  // namespace

--- a/source/fuzz/transformation_duplicate_region_with_selection.cpp
+++ b/source/fuzz/transformation_duplicate_region_with_selection.cpp
@@ -600,5 +600,12 @@ TransformationDuplicateRegionWithSelection::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t>
+TransformationDuplicateRegionWithSelection::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_duplicate_region_with_selection.cpp
+++ b/source/fuzz/transformation_duplicate_region_with_selection.cpp
@@ -602,9 +602,18 @@ TransformationDuplicateRegionWithSelection::ToMessage() const {
 
 std::unordered_set<uint32_t>
 TransformationDuplicateRegionWithSelection::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  std::unordered_set<uint32_t> result = {message_.new_entry_fresh_id(),
+                                         message_.merge_label_fresh_id()};
+  for (auto& pair : message_.original_label_to_duplicate_label()) {
+    result.insert(pair.second());
+  }
+  for (auto& pair : message_.original_id_to_duplicate_id()) {
+    result.insert(pair.second());
+  }
+  for (auto& pair : message_.original_id_to_phi_id()) {
+    result.insert(pair.second());
+  }
+  return result;
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_duplicate_region_with_selection.h
+++ b/source/fuzz/transformation_duplicate_region_with_selection.h
@@ -66,6 +66,8 @@ class TransformationDuplicateRegionWithSelection : public Transformation {
       opt::IRContext* ir_context, opt::BasicBlock* entry_block,
       opt::BasicBlock* exit_block);
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_equation_instruction.cpp
+++ b/source/fuzz/transformation_equation_instruction.cpp
@@ -284,9 +284,7 @@ uint32_t TransformationEquationInstruction::MaybeGetResultTypeId(
 
 std::unordered_set<uint32_t> TransformationEquationInstruction::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_equation_instruction.cpp
+++ b/source/fuzz/transformation_equation_instruction.cpp
@@ -282,5 +282,12 @@ uint32_t TransformationEquationInstruction::MaybeGetResultTypeId(
   }
 }
 
+std::unordered_set<uint32_t> TransformationEquationInstruction::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_equation_instruction.h
+++ b/source/fuzz/transformation_equation_instruction.h
@@ -60,6 +60,8 @@ class TransformationEquationInstruction : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_flatten_conditional_branch.cpp
+++ b/source/fuzz/transformation_flatten_conditional_branch.cpp
@@ -701,9 +701,15 @@ bool TransformationFlattenConditionalBranch::InstructionCanBeHandled(
 
 std::unordered_set<uint32_t>
 TransformationFlattenConditionalBranch::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  std::unordered_set<uint32_t> result;
+  for (auto& side_effect_wrapper_info : message_.side_effect_wrapper_info()) {
+    result.insert(side_effect_wrapper_info.merge_block_id());
+    result.insert(side_effect_wrapper_info.execute_block_id());
+    result.insert(side_effect_wrapper_info.actual_result_id());
+    result.insert(side_effect_wrapper_info.alternative_block_id());
+    result.insert(side_effect_wrapper_info.placeholder_result_id());
+  }
+  return result;
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_flatten_conditional_branch.cpp
+++ b/source/fuzz/transformation_flatten_conditional_branch.cpp
@@ -699,5 +699,12 @@ bool TransformationFlattenConditionalBranch::InstructionCanBeHandled(
   return true;
 }
 
+std::unordered_set<uint32_t>
+TransformationFlattenConditionalBranch::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_flatten_conditional_branch.h
+++ b/source/fuzz/transformation_flatten_conditional_branch.h
@@ -53,6 +53,8 @@ class TransformationFlattenConditionalBranch : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
   // Returns true if the conditional headed by |header| can be flattened,

--- a/source/fuzz/transformation_function_call.cpp
+++ b/source/fuzz/transformation_function_call.cpp
@@ -186,9 +186,7 @@ protobufs::Transformation TransformationFunctionCall::ToMessage() const {
 }
 
 std::unordered_set<uint32_t> TransformationFunctionCall::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_function_call.cpp
+++ b/source/fuzz/transformation_function_call.cpp
@@ -185,5 +185,11 @@ protobufs::Transformation TransformationFunctionCall::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationFunctionCall::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_function_call.h
+++ b/source/fuzz/transformation_function_call.h
@@ -55,6 +55,8 @@ class TransformationFunctionCall : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_inline_function.cpp
+++ b/source/fuzz/transformation_inline_function.cpp
@@ -292,5 +292,11 @@ void TransformationInlineFunction::AdaptInlinedInstruction(
   }
 }
 
+std::unordered_set<uint32_t> TransformationInlineFunction::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_inline_function.cpp
+++ b/source/fuzz/transformation_inline_function.cpp
@@ -293,9 +293,11 @@ void TransformationInlineFunction::AdaptInlinedInstruction(
 }
 
 std::unordered_set<uint32_t> TransformationInlineFunction::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  std::unordered_set<uint32_t> result;
+  for (auto& pair : message_.result_id_map()) {
+    result.insert(pair.second());
+  }
+  return result;
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_inline_function.h
+++ b/source/fuzz/transformation_inline_function.h
@@ -52,6 +52,8 @@ class TransformationInlineFunction : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
   // Returns true if |function_call_instruction| is defined, is an

--- a/source/fuzz/transformation_invert_comparison_operator.cpp
+++ b/source/fuzz/transformation_invert_comparison_operator.cpp
@@ -174,5 +174,12 @@ protobufs::Transformation TransformationInvertComparisonOperator::ToMessage()
   return result;
 }
 
+std::unordered_set<uint32_t>
+TransformationInvertComparisonOperator::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_invert_comparison_operator.cpp
+++ b/source/fuzz/transformation_invert_comparison_operator.cpp
@@ -176,9 +176,7 @@ protobufs::Transformation TransformationInvertComparisonOperator::ToMessage()
 
 std::unordered_set<uint32_t>
 TransformationInvertComparisonOperator::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_invert_comparison_operator.h
+++ b/source/fuzz/transformation_invert_comparison_operator.h
@@ -45,6 +45,8 @@ class TransformationInvertComparisonOperator : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
   // Returns true if |opcode| is supported by this transformation.

--- a/source/fuzz/transformation_load.cpp
+++ b/source/fuzz/transformation_load.cpp
@@ -99,9 +99,7 @@ protobufs::Transformation TransformationLoad::ToMessage() const {
 }
 
 std::unordered_set<uint32_t> TransformationLoad::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_load.cpp
+++ b/source/fuzz/transformation_load.cpp
@@ -98,5 +98,11 @@ protobufs::Transformation TransformationLoad::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationLoad::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_load.h
+++ b/source/fuzz/transformation_load.h
@@ -49,6 +49,8 @@ class TransformationLoad : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_make_vector_operation_dynamic.cpp
+++ b/source/fuzz/transformation_make_vector_operation_dynamic.cpp
@@ -109,7 +109,7 @@ bool TransformationMakeVectorOperationDynamic::IsVectorOperation(
 
 std::unordered_set<uint32_t>
 TransformationMakeVectorOperationDynamic::GetFreshIds() const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_make_vector_operation_dynamic.cpp
+++ b/source/fuzz/transformation_make_vector_operation_dynamic.cpp
@@ -107,5 +107,12 @@ bool TransformationMakeVectorOperationDynamic::IsVectorOperation(
   return true;
 }
 
+std::unordered_set<uint32_t>
+TransformationMakeVectorOperationDynamic::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_make_vector_operation_dynamic.cpp
+++ b/source/fuzz/transformation_make_vector_operation_dynamic.cpp
@@ -109,8 +109,6 @@ bool TransformationMakeVectorOperationDynamic::IsVectorOperation(
 
 std::unordered_set<uint32_t>
 TransformationMakeVectorOperationDynamic::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
   return {};
 }
 

--- a/source/fuzz/transformation_make_vector_operation_dynamic.h
+++ b/source/fuzz/transformation_make_vector_operation_dynamic.h
@@ -46,6 +46,8 @@ class TransformationMakeVectorOperationDynamic : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
   // Checks |instruction| is defined, is an OpCompositeExtract/Insert

--- a/source/fuzz/transformation_merge_blocks.cpp
+++ b/source/fuzz/transformation_merge_blocks.cpp
@@ -79,7 +79,7 @@ protobufs::Transformation TransformationMergeBlocks::ToMessage() const {
 }
 
 std::unordered_set<uint32_t> TransformationMergeBlocks::GetFreshIds() const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_merge_blocks.cpp
+++ b/source/fuzz/transformation_merge_blocks.cpp
@@ -79,8 +79,6 @@ protobufs::Transformation TransformationMergeBlocks::ToMessage() const {
 }
 
 std::unordered_set<uint32_t> TransformationMergeBlocks::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
   return {};
 }
 

--- a/source/fuzz/transformation_merge_blocks.cpp
+++ b/source/fuzz/transformation_merge_blocks.cpp
@@ -78,5 +78,11 @@ protobufs::Transformation TransformationMergeBlocks::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationMergeBlocks::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_merge_blocks.h
+++ b/source/fuzz/transformation_merge_blocks.h
@@ -44,6 +44,8 @@ class TransformationMergeBlocks : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_move_block_down.cpp
+++ b/source/fuzz/transformation_move_block_down.cpp
@@ -106,7 +106,7 @@ protobufs::Transformation TransformationMoveBlockDown::ToMessage() const {
 }
 
 std::unordered_set<uint32_t> TransformationMoveBlockDown::GetFreshIds() const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_move_block_down.cpp
+++ b/source/fuzz/transformation_move_block_down.cpp
@@ -105,5 +105,11 @@ protobufs::Transformation TransformationMoveBlockDown::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationMoveBlockDown::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_move_block_down.cpp
+++ b/source/fuzz/transformation_move_block_down.cpp
@@ -106,8 +106,6 @@ protobufs::Transformation TransformationMoveBlockDown::ToMessage() const {
 }
 
 std::unordered_set<uint32_t> TransformationMoveBlockDown::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
   return {};
 }
 

--- a/source/fuzz/transformation_move_block_down.h
+++ b/source/fuzz/transformation_move_block_down.h
@@ -44,6 +44,8 @@ class TransformationMoveBlockDown : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_move_instruction_down.cpp
+++ b/source/fuzz/transformation_move_instruction_down.cpp
@@ -727,8 +727,6 @@ bool TransformationMoveInstructionDown::CanSafelySwapInstructions(
 
 std::unordered_set<uint32_t> TransformationMoveInstructionDown::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
   return {};
 }
 

--- a/source/fuzz/transformation_move_instruction_down.cpp
+++ b/source/fuzz/transformation_move_instruction_down.cpp
@@ -725,5 +725,12 @@ bool TransformationMoveInstructionDown::CanSafelySwapInstructions(
          IsMemoryReadInstruction(ir_context, b);
 }
 
+std::unordered_set<uint32_t> TransformationMoveInstructionDown::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_move_instruction_down.cpp
+++ b/source/fuzz/transformation_move_instruction_down.cpp
@@ -727,7 +727,7 @@ bool TransformationMoveInstructionDown::CanSafelySwapInstructions(
 
 std::unordered_set<uint32_t> TransformationMoveInstructionDown::GetFreshIds()
     const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_move_instruction_down.h
+++ b/source/fuzz/transformation_move_instruction_down.h
@@ -46,6 +46,8 @@ class TransformationMoveInstructionDown : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_mutate_pointer.cpp
+++ b/source/fuzz/transformation_mutate_pointer.cpp
@@ -160,5 +160,11 @@ bool TransformationMutatePointer::IsValidPointerInstruction(
   return fuzzerutil::CanCreateConstant(*pointer_type->pointee_type());
 }
 
+std::unordered_set<uint32_t> TransformationMutatePointer::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_mutate_pointer.cpp
+++ b/source/fuzz/transformation_mutate_pointer.cpp
@@ -161,9 +161,7 @@ bool TransformationMutatePointer::IsValidPointerInstruction(
 }
 
 std::unordered_set<uint32_t> TransformationMutatePointer::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_mutate_pointer.h
+++ b/source/fuzz/transformation_mutate_pointer.h
@@ -55,6 +55,8 @@ class TransformationMutatePointer : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
   // Returns true if |inst| valid pointer according to the following:

--- a/source/fuzz/transformation_outline_function.cpp
+++ b/source/fuzz/transformation_outline_function.cpp
@@ -972,9 +972,20 @@ void TransformationOutlineFunction::ShrinkOriginalRegion(
 
 std::unordered_set<uint32_t> TransformationOutlineFunction::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  std::unordered_set<uint32_t> result = {
+      message_.new_function_struct_return_type_id(),
+      message_.new_function_type_id(),
+      message_.new_function_id(),
+      message_.new_function_region_entry_block(),
+      message_.new_caller_result_id(),
+      message_.new_callee_result_id()};
+  for (auto& pair : message_.input_id_to_fresh_id()) {
+    result.insert(pair.second());
+  }
+  for (auto& pair : message_.output_id_to_fresh_id()) {
+    result.insert(pair.second());
+  }
+  return result;
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_outline_function.cpp
+++ b/source/fuzz/transformation_outline_function.cpp
@@ -970,5 +970,12 @@ void TransformationOutlineFunction::ShrinkOriginalRegion(
       std::move(cloned_exit_block_terminator));
 }
 
+std::unordered_set<uint32_t> TransformationOutlineFunction::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_outline_function.h
+++ b/source/fuzz/transformation_outline_function.h
@@ -99,6 +99,8 @@ class TransformationOutlineFunction : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
   // Returns the set of blocks dominated by |entry_block| and post-dominated

--- a/source/fuzz/transformation_permute_function_parameters.cpp
+++ b/source/fuzz/transformation_permute_function_parameters.cpp
@@ -163,9 +163,7 @@ protobufs::Transformation TransformationPermuteFunctionParameters::ToMessage()
 
 std::unordered_set<uint32_t>
 TransformationPermuteFunctionParameters::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.function_type_fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_permute_function_parameters.cpp
+++ b/source/fuzz/transformation_permute_function_parameters.cpp
@@ -161,5 +161,12 @@ protobufs::Transformation TransformationPermuteFunctionParameters::ToMessage()
   return result;
 }
 
+std::unordered_set<uint32_t>
+TransformationPermuteFunctionParameters::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_permute_function_parameters.h
+++ b/source/fuzz/transformation_permute_function_parameters.h
@@ -51,6 +51,8 @@ class TransformationPermuteFunctionParameters : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_permute_phi_operands.cpp
+++ b/source/fuzz/transformation_permute_phi_operands.cpp
@@ -93,8 +93,6 @@ protobufs::Transformation TransformationPermutePhiOperands::ToMessage() const {
 
 std::unordered_set<uint32_t> TransformationPermutePhiOperands::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
   return {};
 }
 

--- a/source/fuzz/transformation_permute_phi_operands.cpp
+++ b/source/fuzz/transformation_permute_phi_operands.cpp
@@ -91,5 +91,12 @@ protobufs::Transformation TransformationPermutePhiOperands::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationPermutePhiOperands::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_permute_phi_operands.cpp
+++ b/source/fuzz/transformation_permute_phi_operands.cpp
@@ -93,7 +93,7 @@ protobufs::Transformation TransformationPermutePhiOperands::ToMessage() const {
 
 std::unordered_set<uint32_t> TransformationPermutePhiOperands::GetFreshIds()
     const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_permute_phi_operands.h
+++ b/source/fuzz/transformation_permute_phi_operands.h
@@ -44,6 +44,8 @@ class TransformationPermutePhiOperands : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_propagate_instruction_up.cpp
+++ b/source/fuzz/transformation_propagate_instruction_up.cpp
@@ -398,5 +398,12 @@ bool TransformationPropagateInstructionUp::IsApplicableToBlock(
                      });
 }
 
+std::unordered_set<uint32_t> TransformationPropagateInstructionUp::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_propagate_instruction_up.cpp
+++ b/source/fuzz/transformation_propagate_instruction_up.cpp
@@ -400,9 +400,11 @@ bool TransformationPropagateInstructionUp::IsApplicableToBlock(
 
 std::unordered_set<uint32_t> TransformationPropagateInstructionUp::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  std::unordered_set<uint32_t> result;
+  for (auto& pair : message_.predecessor_id_to_fresh_id()) {
+    result.insert(pair.second());
+  }
+  return result;
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_propagate_instruction_up.h
+++ b/source/fuzz/transformation_propagate_instruction_up.h
@@ -59,6 +59,8 @@ class TransformationPropagateInstructionUp : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
   // Returns true if this transformation can be applied to the block with id

--- a/source/fuzz/transformation_push_id_through_variable.cpp
+++ b/source/fuzz/transformation_push_id_through_variable.cpp
@@ -170,5 +170,12 @@ protobufs::Transformation TransformationPushIdThroughVariable::ToMessage()
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationPushIdThroughVariable::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_push_id_through_variable.cpp
+++ b/source/fuzz/transformation_push_id_through_variable.cpp
@@ -172,9 +172,7 @@ protobufs::Transformation TransformationPushIdThroughVariable::ToMessage()
 
 std::unordered_set<uint32_t> TransformationPushIdThroughVariable::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.value_synonym_id(), message_.variable_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_push_id_through_variable.h
+++ b/source/fuzz/transformation_push_id_through_variable.h
@@ -56,6 +56,8 @@ class TransformationPushIdThroughVariable : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_record_synonymous_constants.cpp
+++ b/source/fuzz/transformation_record_synonymous_constants.cpp
@@ -122,5 +122,12 @@ bool TransformationRecordSynonymousConstants::AreEquivalentConstants(
   return true;
 }
 
+std::unordered_set<uint32_t>
+TransformationRecordSynonymousConstants::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_record_synonymous_constants.cpp
+++ b/source/fuzz/transformation_record_synonymous_constants.cpp
@@ -124,8 +124,6 @@ bool TransformationRecordSynonymousConstants::AreEquivalentConstants(
 
 std::unordered_set<uint32_t>
 TransformationRecordSynonymousConstants::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
   return {};
 }
 

--- a/source/fuzz/transformation_record_synonymous_constants.cpp
+++ b/source/fuzz/transformation_record_synonymous_constants.cpp
@@ -124,7 +124,7 @@ bool TransformationRecordSynonymousConstants::AreEquivalentConstants(
 
 std::unordered_set<uint32_t>
 TransformationRecordSynonymousConstants::GetFreshIds() const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_record_synonymous_constants.h
+++ b/source/fuzz/transformation_record_synonymous_constants.h
@@ -52,6 +52,8 @@ class TransformationRecordSynonymousConstants : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_replace_add_sub_mul_with_carrying_extended.cpp
+++ b/source/fuzz/transformation_replace_add_sub_mul_with_carrying_extended.cpp
@@ -230,9 +230,7 @@ TransformationReplaceAddSubMulWithCarryingExtended::ToMessage() const {
 
 std::unordered_set<uint32_t>
 TransformationReplaceAddSubMulWithCarryingExtended::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.struct_fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_replace_add_sub_mul_with_carrying_extended.cpp
+++ b/source/fuzz/transformation_replace_add_sub_mul_with_carrying_extended.cpp
@@ -228,5 +228,12 @@ TransformationReplaceAddSubMulWithCarryingExtended::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t>
+TransformationReplaceAddSubMulWithCarryingExtended::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_replace_add_sub_mul_with_carrying_extended.h
+++ b/source/fuzz/transformation_replace_add_sub_mul_with_carrying_extended.h
@@ -52,6 +52,8 @@ class TransformationReplaceAddSubMulWithCarryingExtended
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
   // Checks if an OpIAdd, OpISub or OpIMul instruction can be used by the

--- a/source/fuzz/transformation_replace_boolean_constant_with_constant_binary.cpp
+++ b/source/fuzz/transformation_replace_boolean_constant_with_constant_binary.cpp
@@ -318,5 +318,12 @@ TransformationReplaceBooleanConstantWithConstantBinary::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t>
+TransformationReplaceBooleanConstantWithConstantBinary::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_replace_boolean_constant_with_constant_binary.cpp
+++ b/source/fuzz/transformation_replace_boolean_constant_with_constant_binary.cpp
@@ -320,9 +320,7 @@ TransformationReplaceBooleanConstantWithConstantBinary::ToMessage() const {
 
 std::unordered_set<uint32_t>
 TransformationReplaceBooleanConstantWithConstantBinary::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id_for_binary_operation()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_replace_boolean_constant_with_constant_binary.h
+++ b/source/fuzz/transformation_replace_boolean_constant_with_constant_binary.h
@@ -67,6 +67,8 @@ class TransformationReplaceBooleanConstantWithConstantBinary
       opt::IRContext* ir_context,
       TransformationContext* transformation_context) const;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_replace_constant_with_uniform.cpp
+++ b/source/fuzz/transformation_replace_constant_with_uniform.cpp
@@ -285,5 +285,12 @@ protobufs::Transformation TransformationReplaceConstantWithUniform::ToMessage()
   return result;
 }
 
+std::unordered_set<uint32_t>
+TransformationReplaceConstantWithUniform::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_replace_constant_with_uniform.cpp
+++ b/source/fuzz/transformation_replace_constant_with_uniform.cpp
@@ -287,9 +287,7 @@ protobufs::Transformation TransformationReplaceConstantWithUniform::ToMessage()
 
 std::unordered_set<uint32_t>
 TransformationReplaceConstantWithUniform::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id_for_access_chain(), message_.fresh_id_for_load()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_replace_constant_with_uniform.h
+++ b/source/fuzz/transformation_replace_constant_with_uniform.h
@@ -71,6 +71,8 @@ class TransformationReplaceConstantWithUniform : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_replace_copy_memory_with_load_store.cpp
+++ b/source/fuzz/transformation_replace_copy_memory_with_load_store.cpp
@@ -125,9 +125,7 @@ TransformationReplaceCopyMemoryWithLoadStore::ToMessage() const {
 
 std::unordered_set<uint32_t>
 TransformationReplaceCopyMemoryWithLoadStore::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_replace_copy_memory_with_load_store.cpp
+++ b/source/fuzz/transformation_replace_copy_memory_with_load_store.cpp
@@ -123,5 +123,12 @@ TransformationReplaceCopyMemoryWithLoadStore::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t>
+TransformationReplaceCopyMemoryWithLoadStore::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_replace_copy_memory_with_load_store.h
+++ b/source/fuzz/transformation_replace_copy_memory_with_load_store.h
@@ -45,6 +45,8 @@ class TransformationReplaceCopyMemoryWithLoadStore : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_replace_copy_object_with_store_load.cpp
+++ b/source/fuzz/transformation_replace_copy_object_with_store_load.cpp
@@ -143,5 +143,12 @@ TransformationReplaceCopyObjectWithStoreLoad::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t>
+TransformationReplaceCopyObjectWithStoreLoad::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_replace_copy_object_with_store_load.cpp
+++ b/source/fuzz/transformation_replace_copy_object_with_store_load.cpp
@@ -145,9 +145,7 @@ TransformationReplaceCopyObjectWithStoreLoad::ToMessage() const {
 
 std::unordered_set<uint32_t>
 TransformationReplaceCopyObjectWithStoreLoad::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_variable_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_replace_copy_object_with_store_load.h
+++ b/source/fuzz/transformation_replace_copy_object_with_store_load.h
@@ -51,6 +51,8 @@ class TransformationReplaceCopyObjectWithStoreLoad : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_replace_id_with_synonym.cpp
+++ b/source/fuzz/transformation_replace_id_with_synonym.cpp
@@ -161,7 +161,7 @@ bool TransformationReplaceIdWithSynonym::TypesAreCompatible(
 
 std::unordered_set<uint32_t> TransformationReplaceIdWithSynonym::GetFreshIds()
     const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_replace_id_with_synonym.cpp
+++ b/source/fuzz/transformation_replace_id_with_synonym.cpp
@@ -159,5 +159,12 @@ bool TransformationReplaceIdWithSynonym::TypesAreCompatible(
           fuzzerutil::TypesAreEqualUpToSign(ir_context, type_id_1, type_id_2));
 }
 
+std::unordered_set<uint32_t> TransformationReplaceIdWithSynonym::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_replace_id_with_synonym.cpp
+++ b/source/fuzz/transformation_replace_id_with_synonym.cpp
@@ -161,8 +161,6 @@ bool TransformationReplaceIdWithSynonym::TypesAreCompatible(
 
 std::unordered_set<uint32_t> TransformationReplaceIdWithSynonym::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
   return {};
 }
 

--- a/source/fuzz/transformation_replace_id_with_synonym.h
+++ b/source/fuzz/transformation_replace_id_with_synonym.h
@@ -48,6 +48,8 @@ class TransformationReplaceIdWithSynonym : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
   // Returns true if |type_id_1| and |type_id_2| represent compatible types

--- a/source/fuzz/transformation_replace_irrelevant_id.cpp
+++ b/source/fuzz/transformation_replace_irrelevant_id.cpp
@@ -108,8 +108,6 @@ protobufs::Transformation TransformationReplaceIrrelevantId::ToMessage() const {
 
 std::unordered_set<uint32_t> TransformationReplaceIrrelevantId::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
   return {};
 }
 

--- a/source/fuzz/transformation_replace_irrelevant_id.cpp
+++ b/source/fuzz/transformation_replace_irrelevant_id.cpp
@@ -106,5 +106,12 @@ protobufs::Transformation TransformationReplaceIrrelevantId::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationReplaceIrrelevantId::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_replace_irrelevant_id.cpp
+++ b/source/fuzz/transformation_replace_irrelevant_id.cpp
@@ -108,7 +108,7 @@ protobufs::Transformation TransformationReplaceIrrelevantId::ToMessage() const {
 
 std::unordered_set<uint32_t> TransformationReplaceIrrelevantId::GetFreshIds()
     const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_replace_irrelevant_id.h
+++ b/source/fuzz/transformation_replace_irrelevant_id.h
@@ -46,6 +46,8 @@ class TransformationReplaceIrrelevantId : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_replace_linear_algebra_instruction.cpp
+++ b/source/fuzz/transformation_replace_linear_algebra_instruction.cpp
@@ -1030,9 +1030,11 @@ void TransformationReplaceLinearAlgebraInstruction::ReplaceOpDot(
 
 std::unordered_set<uint32_t>
 TransformationReplaceLinearAlgebraInstruction::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  std::unordered_set<uint32_t> result;
+  for (auto id : message_.fresh_ids()) {
+    result.insert(id);
+  }
+  return result;
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_replace_linear_algebra_instruction.cpp
+++ b/source/fuzz/transformation_replace_linear_algebra_instruction.cpp
@@ -1028,5 +1028,12 @@ void TransformationReplaceLinearAlgebraInstruction::ReplaceOpDot(
   }
 }
 
+std::unordered_set<uint32_t>
+TransformationReplaceLinearAlgebraInstruction::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_replace_linear_algebra_instruction.h
+++ b/source/fuzz/transformation_replace_linear_algebra_instruction.h
@@ -43,6 +43,8 @@ class TransformationReplaceLinearAlgebraInstruction : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
   // Returns the number of ids needed to apply the transformation.

--- a/source/fuzz/transformation_replace_load_store_with_copy_memory.cpp
+++ b/source/fuzz/transformation_replace_load_store_with_copy_memory.cpp
@@ -180,5 +180,12 @@ TransformationReplaceLoadStoreWithCopyMemory::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t>
+TransformationReplaceLoadStoreWithCopyMemory::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_replace_load_store_with_copy_memory.cpp
+++ b/source/fuzz/transformation_replace_load_store_with_copy_memory.cpp
@@ -182,7 +182,7 @@ TransformationReplaceLoadStoreWithCopyMemory::ToMessage() const {
 
 std::unordered_set<uint32_t>
 TransformationReplaceLoadStoreWithCopyMemory::GetFreshIds() const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_replace_load_store_with_copy_memory.cpp
+++ b/source/fuzz/transformation_replace_load_store_with_copy_memory.cpp
@@ -182,8 +182,6 @@ TransformationReplaceLoadStoreWithCopyMemory::ToMessage() const {
 
 std::unordered_set<uint32_t>
 TransformationReplaceLoadStoreWithCopyMemory::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
   return {};
 }
 

--- a/source/fuzz/transformation_replace_load_store_with_copy_memory.h
+++ b/source/fuzz/transformation_replace_load_store_with_copy_memory.h
@@ -64,6 +64,8 @@ class TransformationReplaceLoadStoreWithCopyMemory : public Transformation {
   static bool IsStorageClassSafeAcrossMemoryBarriers(
       SpvStorageClass storage_class);
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_replace_opphi_id_from_dead_predecessor.cpp
+++ b/source/fuzz/transformation_replace_opphi_id_from_dead_predecessor.cpp
@@ -108,8 +108,6 @@ TransformationReplaceOpPhiIdFromDeadPredecessor::ToMessage() const {
 
 std::unordered_set<uint32_t>
 TransformationReplaceOpPhiIdFromDeadPredecessor::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
   return {};
 }
 

--- a/source/fuzz/transformation_replace_opphi_id_from_dead_predecessor.cpp
+++ b/source/fuzz/transformation_replace_opphi_id_from_dead_predecessor.cpp
@@ -108,7 +108,7 @@ TransformationReplaceOpPhiIdFromDeadPredecessor::ToMessage() const {
 
 std::unordered_set<uint32_t>
 TransformationReplaceOpPhiIdFromDeadPredecessor::GetFreshIds() const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_replace_opphi_id_from_dead_predecessor.cpp
+++ b/source/fuzz/transformation_replace_opphi_id_from_dead_predecessor.cpp
@@ -106,5 +106,12 @@ TransformationReplaceOpPhiIdFromDeadPredecessor::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t>
+TransformationReplaceOpPhiIdFromDeadPredecessor::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_replace_opphi_id_from_dead_predecessor.h
+++ b/source/fuzz/transformation_replace_opphi_id_from_dead_predecessor.h
@@ -45,6 +45,8 @@ class TransformationReplaceOpPhiIdFromDeadPredecessor : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_replace_opselect_with_conditional_branch.cpp
+++ b/source/fuzz/transformation_replace_opselect_with_conditional_branch.cpp
@@ -200,5 +200,12 @@ TransformationReplaceOpSelectWithConditionalBranch::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t>
+TransformationReplaceOpSelectWithConditionalBranch::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_replace_opselect_with_conditional_branch.cpp
+++ b/source/fuzz/transformation_replace_opselect_with_conditional_branch.cpp
@@ -202,9 +202,7 @@ TransformationReplaceOpSelectWithConditionalBranch::ToMessage() const {
 
 std::unordered_set<uint32_t>
 TransformationReplaceOpSelectWithConditionalBranch::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.true_block_id(), message_.false_block_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_replace_opselect_with_conditional_branch.h
+++ b/source/fuzz/transformation_replace_opselect_with_conditional_branch.h
@@ -49,6 +49,8 @@ class TransformationReplaceOpSelectWithConditionalBranch
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_replace_parameter_with_global.cpp
+++ b/source/fuzz/transformation_replace_parameter_with_global.cpp
@@ -206,9 +206,8 @@ bool TransformationReplaceParameterWithGlobal::IsParameterTypeSupported(
 
 std::unordered_set<uint32_t>
 TransformationReplaceParameterWithGlobal::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.function_type_fresh_id(),
+          message_.global_variable_fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_replace_parameter_with_global.cpp
+++ b/source/fuzz/transformation_replace_parameter_with_global.cpp
@@ -204,5 +204,12 @@ bool TransformationReplaceParameterWithGlobal::IsParameterTypeSupported(
   return fuzzerutil::CanCreateConstant(type);
 }
 
+std::unordered_set<uint32_t>
+TransformationReplaceParameterWithGlobal::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_replace_parameter_with_global.h
+++ b/source/fuzz/transformation_replace_parameter_with_global.h
@@ -51,6 +51,8 @@ class TransformationReplaceParameterWithGlobal : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
   // Returns true if the type of the parameter is supported by this

--- a/source/fuzz/transformation_replace_params_with_struct.cpp
+++ b/source/fuzz/transformation_replace_params_with_struct.cpp
@@ -306,9 +306,12 @@ TransformationReplaceParamsWithStruct::ComputeIndicesOfReplacedParameters(
 
 std::unordered_set<uint32_t>
 TransformationReplaceParamsWithStruct::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  std::unordered_set<uint32_t> result = {message_.fresh_function_type_id(),
+                                         message_.fresh_parameter_id()};
+  for (auto& pair : message_.caller_id_to_fresh_composite_id()) {
+    result.insert(pair.second());
+  }
+  return result;
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_replace_params_with_struct.cpp
+++ b/source/fuzz/transformation_replace_params_with_struct.cpp
@@ -304,5 +304,12 @@ TransformationReplaceParamsWithStruct::ComputeIndicesOfReplacedParameters(
   return result;
 }
 
+std::unordered_set<uint32_t>
+TransformationReplaceParamsWithStruct::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_replace_params_with_struct.h
+++ b/source/fuzz/transformation_replace_params_with_struct.h
@@ -63,6 +63,8 @@ class TransformationReplaceParamsWithStruct : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
   // Returns true if parameter's type is supported by this transformation.

--- a/source/fuzz/transformation_set_function_control.cpp
+++ b/source/fuzz/transformation_set_function_control.cpp
@@ -96,5 +96,12 @@ opt::Instruction* TransformationSetFunctionControl ::FindFunctionDefInstruction(
   return nullptr;
 }
 
+std::unordered_set<uint32_t> TransformationSetFunctionControl::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_set_function_control.cpp
+++ b/source/fuzz/transformation_set_function_control.cpp
@@ -98,8 +98,6 @@ opt::Instruction* TransformationSetFunctionControl ::FindFunctionDefInstruction(
 
 std::unordered_set<uint32_t> TransformationSetFunctionControl::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
   return {};
 }
 

--- a/source/fuzz/transformation_set_function_control.cpp
+++ b/source/fuzz/transformation_set_function_control.cpp
@@ -98,7 +98,7 @@ opt::Instruction* TransformationSetFunctionControl ::FindFunctionDefInstruction(
 
 std::unordered_set<uint32_t> TransformationSetFunctionControl::GetFreshIds()
     const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_set_function_control.h
+++ b/source/fuzz/transformation_set_function_control.h
@@ -46,6 +46,8 @@ class TransformationSetFunctionControl : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_set_loop_control.cpp
+++ b/source/fuzz/transformation_set_loop_control.cpp
@@ -214,7 +214,7 @@ bool TransformationSetLoopControl::PeelCountIsSupported(
 }
 
 std::unordered_set<uint32_t> TransformationSetLoopControl::GetFreshIds() const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_set_loop_control.cpp
+++ b/source/fuzz/transformation_set_loop_control.cpp
@@ -214,8 +214,6 @@ bool TransformationSetLoopControl::PeelCountIsSupported(
 }
 
 std::unordered_set<uint32_t> TransformationSetLoopControl::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
   return {};
 }
 

--- a/source/fuzz/transformation_set_loop_control.cpp
+++ b/source/fuzz/transformation_set_loop_control.cpp
@@ -213,5 +213,11 @@ bool TransformationSetLoopControl::PeelCountIsSupported(
   }
 }
 
+std::unordered_set<uint32_t> TransformationSetLoopControl::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_set_loop_control.h
+++ b/source/fuzz/transformation_set_loop_control.h
@@ -56,6 +56,8 @@ class TransformationSetLoopControl : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
   // Does the version of SPIR-V being used support the PartialCount loop

--- a/source/fuzz/transformation_set_memory_operands_mask.cpp
+++ b/source/fuzz/transformation_set_memory_operands_mask.cpp
@@ -221,7 +221,7 @@ bool TransformationSetMemoryOperandsMask::
 
 std::unordered_set<uint32_t> TransformationSetMemoryOperandsMask::GetFreshIds()
     const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_set_memory_operands_mask.cpp
+++ b/source/fuzz/transformation_set_memory_operands_mask.cpp
@@ -221,8 +221,6 @@ bool TransformationSetMemoryOperandsMask::
 
 std::unordered_set<uint32_t> TransformationSetMemoryOperandsMask::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
   return {};
 }
 

--- a/source/fuzz/transformation_set_memory_operands_mask.cpp
+++ b/source/fuzz/transformation_set_memory_operands_mask.cpp
@@ -219,5 +219,12 @@ bool TransformationSetMemoryOperandsMask::
   }
 }
 
+std::unordered_set<uint32_t> TransformationSetMemoryOperandsMask::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_set_memory_operands_mask.h
+++ b/source/fuzz/transformation_set_memory_operands_mask.h
@@ -51,6 +51,8 @@ class TransformationSetMemoryOperandsMask : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
   // Helper function that determines whether |instruction| is a memory

--- a/source/fuzz/transformation_set_selection_control.cpp
+++ b/source/fuzz/transformation_set_selection_control.cpp
@@ -58,8 +58,6 @@ protobufs::Transformation TransformationSetSelectionControl::ToMessage() const {
 
 std::unordered_set<uint32_t> TransformationSetSelectionControl::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
   return {};
 }
 

--- a/source/fuzz/transformation_set_selection_control.cpp
+++ b/source/fuzz/transformation_set_selection_control.cpp
@@ -56,5 +56,12 @@ protobufs::Transformation TransformationSetSelectionControl::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationSetSelectionControl::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_set_selection_control.cpp
+++ b/source/fuzz/transformation_set_selection_control.cpp
@@ -58,7 +58,7 @@ protobufs::Transformation TransformationSetSelectionControl::ToMessage() const {
 
 std::unordered_set<uint32_t> TransformationSetSelectionControl::GetFreshIds()
     const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_set_selection_control.h
+++ b/source/fuzz/transformation_set_selection_control.h
@@ -44,6 +44,8 @@ class TransformationSetSelectionControl : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_split_block.cpp
+++ b/source/fuzz/transformation_split_block.cpp
@@ -143,5 +143,11 @@ protobufs::Transformation TransformationSplitBlock::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationSplitBlock::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_split_block.cpp
+++ b/source/fuzz/transformation_split_block.cpp
@@ -144,9 +144,7 @@ protobufs::Transformation TransformationSplitBlock::ToMessage() const {
 }
 
 std::unordered_set<uint32_t> TransformationSplitBlock::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_split_block.h
+++ b/source/fuzz/transformation_split_block.h
@@ -53,6 +53,8 @@ class TransformationSplitBlock : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_store.cpp
+++ b/source/fuzz/transformation_store.cpp
@@ -125,5 +125,11 @@ protobufs::Transformation TransformationStore::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationStore::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_store.cpp
+++ b/source/fuzz/transformation_store.cpp
@@ -126,8 +126,6 @@ protobufs::Transformation TransformationStore::ToMessage() const {
 }
 
 std::unordered_set<uint32_t> TransformationStore::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
   return {};
 }
 

--- a/source/fuzz/transformation_store.cpp
+++ b/source/fuzz/transformation_store.cpp
@@ -126,7 +126,7 @@ protobufs::Transformation TransformationStore::ToMessage() const {
 }
 
 std::unordered_set<uint32_t> TransformationStore::GetFreshIds() const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_store.h
+++ b/source/fuzz/transformation_store.h
@@ -53,6 +53,8 @@ class TransformationStore : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_swap_commutable_operands.cpp
+++ b/source/fuzz/transformation_swap_commutable_operands.cpp
@@ -60,5 +60,12 @@ protobufs::Transformation TransformationSwapCommutableOperands::ToMessage()
   return result;
 }
 
+std::unordered_set<uint32_t> TransformationSwapCommutableOperands::GetFreshIds()
+    const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_swap_commutable_operands.cpp
+++ b/source/fuzz/transformation_swap_commutable_operands.cpp
@@ -62,8 +62,6 @@ protobufs::Transformation TransformationSwapCommutableOperands::ToMessage()
 
 std::unordered_set<uint32_t> TransformationSwapCommutableOperands::GetFreshIds()
     const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
   return {};
 }
 

--- a/source/fuzz/transformation_swap_commutable_operands.cpp
+++ b/source/fuzz/transformation_swap_commutable_operands.cpp
@@ -62,7 +62,7 @@ protobufs::Transformation TransformationSwapCommutableOperands::ToMessage()
 
 std::unordered_set<uint32_t> TransformationSwapCommutableOperands::GetFreshIds()
     const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_swap_commutable_operands.h
+++ b/source/fuzz/transformation_swap_commutable_operands.h
@@ -41,6 +41,8 @@ class TransformationSwapCommutableOperands : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_swap_conditional_branch_operands.cpp
+++ b/source/fuzz/transformation_swap_conditional_branch_operands.cpp
@@ -103,9 +103,7 @@ TransformationSwapConditionalBranchOperands::ToMessage() const {
 
 std::unordered_set<uint32_t>
 TransformationSwapConditionalBranchOperands::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_swap_conditional_branch_operands.cpp
+++ b/source/fuzz/transformation_swap_conditional_branch_operands.cpp
@@ -101,5 +101,12 @@ TransformationSwapConditionalBranchOperands::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t>
+TransformationSwapConditionalBranchOperands::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_swap_conditional_branch_operands.h
+++ b/source/fuzz/transformation_swap_conditional_branch_operands.h
@@ -46,6 +46,8 @@ class TransformationSwapConditionalBranchOperands : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_toggle_access_chain_instruction.cpp
+++ b/source/fuzz/transformation_toggle_access_chain_instruction.cpp
@@ -79,8 +79,6 @@ TransformationToggleAccessChainInstruction::ToMessage() const {
 
 std::unordered_set<uint32_t>
 TransformationToggleAccessChainInstruction::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
   return {};
 }
 

--- a/source/fuzz/transformation_toggle_access_chain_instruction.cpp
+++ b/source/fuzz/transformation_toggle_access_chain_instruction.cpp
@@ -79,7 +79,7 @@ TransformationToggleAccessChainInstruction::ToMessage() const {
 
 std::unordered_set<uint32_t>
 TransformationToggleAccessChainInstruction::GetFreshIds() const {
-  return {};
+  return std::unordered_set<uint32_t>();
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_toggle_access_chain_instruction.cpp
+++ b/source/fuzz/transformation_toggle_access_chain_instruction.cpp
@@ -77,5 +77,12 @@ TransformationToggleAccessChainInstruction::ToMessage() const {
   return result;
 }
 
+std::unordered_set<uint32_t>
+TransformationToggleAccessChainInstruction::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_toggle_access_chain_instruction.h
+++ b/source/fuzz/transformation_toggle_access_chain_instruction.h
@@ -41,6 +41,8 @@ class TransformationToggleAccessChainInstruction : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/source/fuzz/transformation_vector_shuffle.cpp
+++ b/source/fuzz/transformation_vector_shuffle.cpp
@@ -236,5 +236,11 @@ opt::analysis::Vector* TransformationVectorShuffle::GetVectorType(
       ->AsVector();
 }
 
+std::unordered_set<uint32_t> TransformationVectorShuffle::GetFreshIds() const {
+  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
+  assert(false && "Not implemented yet.");
+  return {};
+}
+
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/transformation_vector_shuffle.cpp
+++ b/source/fuzz/transformation_vector_shuffle.cpp
@@ -237,9 +237,7 @@ opt::analysis::Vector* TransformationVectorShuffle::GetVectorType(
 }
 
 std::unordered_set<uint32_t> TransformationVectorShuffle::GetFreshIds() const {
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3851): Implement.
-  assert(false && "Not implemented yet.");
-  return {};
+  return {message_.fresh_id()};
 }
 
 }  // namespace fuzz

--- a/source/fuzz/transformation_vector_shuffle.h
+++ b/source/fuzz/transformation_vector_shuffle.h
@@ -64,6 +64,8 @@ class TransformationVectorShuffle : public Transformation {
   void Apply(opt::IRContext* ir_context,
              TransformationContext* transformation_context) const override;
 
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
   protobufs::Transformation ToMessage() const override;
 
  private:

--- a/test/fuzz/fuzz_test_util.cpp
+++ b/test/fuzz/fuzz_test_util.cpp
@@ -141,8 +141,13 @@ void ApplyAndCheckFreshIds(const Transformation& transformation,
   std::unordered_set<uint32_t> fresh_ids_for_transformation =
       transformation.GetFreshIds();
   for (auto& entry : after_transformation) {
-    ASSERT_TRUE((before_transformation.count(entry.first) == 0) ==
-                (fresh_ids_for_transformation.count(entry.first) != 0));
+    uint32_t id = entry.first;
+    auto count = fresh_ids_for_transformation.count(id);
+    if (before_transformation.count(entry.first)) {
+      ASSERT_FALSE(count);
+    } else {
+      ASSERT_TRUE(count);
+    }
   }
 }
 

--- a/test/fuzz/fuzz_test_util.cpp
+++ b/test/fuzz/fuzz_test_util.cpp
@@ -161,7 +161,8 @@ void ApplyAndCheckFreshIds(
 void ApplyAndCheckFreshIds(const Transformation& transformation,
                            opt::IRContext* ir_context,
                            TransformationContext* transformation_context) {
-  ApplyAndCheckFreshIds(transformation, ir_context, transformation_context, {});
+  ApplyAndCheckFreshIds(transformation, ir_context, transformation_context,
+                        std::unordered_set<uint32_t>());
 }
 
 }  // namespace fuzz

--- a/test/fuzz/fuzz_test_util.h
+++ b/test/fuzz/fuzz_test_util.h
@@ -113,6 +113,13 @@ void DumpTransformationsJson(
     const protobufs::TransformationSequence& transformations,
     const char* filename);
 
+// TODO comment
+void ApplyAndCheckFreshIds(
+    const Transformation& transformation, opt::IRContext* ir_context,
+    TransformationContext* transformation_context,
+    const std::unordered_set<uint32_t>& issued_overflow_ids);
+
+// TODO comment
 void ApplyAndCheckFreshIds(const Transformation& transformation,
                            opt::IRContext* ir_context,
                            TransformationContext* transformation_context);

--- a/test/fuzz/fuzz_test_util.h
+++ b/test/fuzz/fuzz_test_util.h
@@ -113,13 +113,16 @@ void DumpTransformationsJson(
     const protobufs::TransformationSequence& transformations,
     const char* filename);
 
-// TODO comment
+// Applies |transformation| to |ir_context| and |transformation_context|, and
+// asserts that any ids in |ir_context| that are only present post-
+// transformation are either contained in |transformation.GetFreshIds()|, or
+// in |issued_overflow_ids|.
 void ApplyAndCheckFreshIds(
     const Transformation& transformation, opt::IRContext* ir_context,
     TransformationContext* transformation_context,
     const std::unordered_set<uint32_t>& issued_overflow_ids);
 
-// TODO comment
+// Invokes ApplyAndCheckFreshIds above, with an empty set of overflow ids.
 void ApplyAndCheckFreshIds(const Transformation& transformation,
                            opt::IRContext* ir_context,
                            TransformationContext* transformation_context);

--- a/test/fuzz/fuzz_test_util.h
+++ b/test/fuzz/fuzz_test_util.h
@@ -19,6 +19,8 @@
 
 #include "gtest/gtest.h"
 #include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
+#include "source/fuzz/transformation.h"
+#include "source/fuzz/transformation_context.h"
 #include "source/opt/build_module.h"
 #include "source/opt/ir_context.h"
 #include "spirv-tools/libspirv.h"
@@ -110,6 +112,10 @@ void DumpShader(const std::vector<uint32_t>& binary, const char* filename);
 void DumpTransformationsJson(
     const protobufs::TransformationSequence& transformations,
     const char* filename);
+
+void ApplyAndCheckFreshIds(const Transformation& transformation,
+                           opt::IRContext* ir_context,
+                           TransformationContext* transformation_context);
 
 }  // namespace fuzz
 }  // namespace spvtools

--- a/test/fuzz/fuzzer_replayer_test.cpp
+++ b/test/fuzz/fuzzer_replayer_test.cpp
@@ -1669,7 +1669,7 @@ void RunFuzzerAndReplayer(const std::string& shader,
             fuzzer_result.applied_transformations,
             static_cast<uint32_t>(
                 fuzzer_result.applied_transformations.transformation_size()),
-            0, false, validator_options)
+            false, validator_options)
             .Run();
     ASSERT_EQ(Replayer::ReplayerResultStatus::kComplete,
               replayer_result.status);

--- a/test/fuzz/replayer_test.cpp
+++ b/test/fuzz/replayer_test.cpp
@@ -97,7 +97,7 @@ TEST(ReplayerTest, PartialReplay) {
     protobufs::FactSequence empty_facts;
     auto replayer_result =
         Replayer(env, kSilentConsumer, binary_in, empty_facts, transformations,
-                 11, 0, true, validator_options)
+                 11, true, validator_options)
             .Run();
     // Replay should succeed.
     ASSERT_EQ(Replayer::ReplayerResultStatus::kComplete,
@@ -183,7 +183,7 @@ TEST(ReplayerTest, PartialReplay) {
     protobufs::FactSequence empty_facts;
     auto replayer_result =
         Replayer(env, kSilentConsumer, binary_in, empty_facts, transformations,
-                 5, 0, true, validator_options)
+                 5, true, validator_options)
             .Run();
     // Replay should succeed.
     ASSERT_EQ(Replayer::ReplayerResultStatus::kComplete,
@@ -261,7 +261,7 @@ TEST(ReplayerTest, PartialReplay) {
     protobufs::FactSequence empty_facts;
     auto replayer_result =
         Replayer(env, kSilentConsumer, binary_in, empty_facts, transformations,
-                 0, 0, true, validator_options)
+                 0, true, validator_options)
             .Run();
     // Replay should succeed.
     ASSERT_EQ(Replayer::ReplayerResultStatus::kComplete,
@@ -279,7 +279,7 @@ TEST(ReplayerTest, PartialReplay) {
     // of transformations
     auto replayer_result =
         Replayer(env, kSilentConsumer, binary_in, empty_facts, transformations,
-                 12, 0, true, validator_options)
+                 12, true, validator_options)
             .Run();
 
     // Replay should not succeed.
@@ -349,8 +349,7 @@ TEST(ReplayerTest, CheckFactsAfterReplay) {
   protobufs::FactSequence empty_facts;
   auto replayer_result =
       Replayer(env, kSilentConsumer, binary_in, empty_facts, transformations,
-               transformations.transformation_size(), 0, true,
-               validator_options)
+               transformations.transformation_size(), true, validator_options)
           .Run();
   // Replay should succeed.
   ASSERT_EQ(Replayer::ReplayerResultStatus::kComplete, replayer_result.status);

--- a/test/fuzz/transformation_access_chain_test.cpp
+++ b/test/fuzz/transformation_access_chain_test.cpp
@@ -215,7 +215,8 @@ TEST(TransformationAccessChainTest, BasicTest) {
         100, 43, {80}, MakeInstructionDescriptor(24, SpvOpLoad, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
     ASSERT_FALSE(
         transformation_context.GetFactManager()->PointeeValueIsIrrelevant(100));
@@ -226,7 +227,8 @@ TEST(TransformationAccessChainTest, BasicTest) {
         101, 28, {81}, MakeInstructionDescriptor(42, SpvOpReturn, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
     ASSERT_FALSE(
         transformation_context.GetFactManager()->PointeeValueIsIrrelevant(101));
@@ -237,7 +239,8 @@ TEST(TransformationAccessChainTest, BasicTest) {
         102, 44, {}, MakeInstructionDescriptor(44, SpvOpStore, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
     ASSERT_FALSE(
         transformation_context.GetFactManager()->PointeeValueIsIrrelevant(103));
@@ -248,7 +251,8 @@ TEST(TransformationAccessChainTest, BasicTest) {
         103, 13, {80}, MakeInstructionDescriptor(21, SpvOpAccessChain, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
     ASSERT_FALSE(
         transformation_context.GetFactManager()->PointeeValueIsIrrelevant(104));
@@ -259,7 +263,8 @@ TEST(TransformationAccessChainTest, BasicTest) {
         104, 34, {}, MakeInstructionDescriptor(44, SpvOpStore, 1));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
     ASSERT_FALSE(
         transformation_context.GetFactManager()->PointeeValueIsIrrelevant(105));
@@ -270,7 +275,8 @@ TEST(TransformationAccessChainTest, BasicTest) {
         105, 38, {}, MakeInstructionDescriptor(40, SpvOpFunctionCall, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
     ASSERT_FALSE(
         transformation_context.GetFactManager()->PointeeValueIsIrrelevant(106));
@@ -281,7 +287,8 @@ TEST(TransformationAccessChainTest, BasicTest) {
         106, 14, {}, MakeInstructionDescriptor(24, SpvOpLoad, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
     ASSERT_FALSE(
         transformation_context.GetFactManager()->PointeeValueIsIrrelevant(107));
@@ -409,7 +416,8 @@ TEST(TransformationAccessChainTest, IsomorphicStructs) {
         100, 11, {}, MakeInstructionDescriptor(5, SpvOpReturn, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
   {
@@ -417,7 +425,8 @@ TEST(TransformationAccessChainTest, IsomorphicStructs) {
         101, 12, {}, MakeInstructionDescriptor(5, SpvOpReturn, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -559,7 +568,8 @@ TEST(TransformationAccessChainTest, ClampingVariables) {
         {{200, 201}});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -569,7 +579,8 @@ TEST(TransformationAccessChainTest, ClampingVariables) {
         {{202, 203}});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -579,7 +590,8 @@ TEST(TransformationAccessChainTest, ClampingVariables) {
         {{204, 205}});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -589,7 +601,8 @@ TEST(TransformationAccessChainTest, ClampingVariables) {
         {{206, 207}});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -599,7 +612,8 @@ TEST(TransformationAccessChainTest, ClampingVariables) {
         {{208, 209}, {210, 211}});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 

--- a/test/fuzz/transformation_add_bit_instruction_synonym_test.cpp
+++ b/test/fuzz/transformation_add_bit_instruction_synonym_test.cpp
@@ -236,7 +236,7 @@ TEST(TransformationAddBitInstructionSynonymTest, AddOpBitwiseOrSynonym) {
            131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143,
            144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156,
            157, 158, 159, 160, 161, 162, 163, 164, 165, 166});
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(166, {}), MakeDataDescriptor(39, {})));
 
@@ -531,7 +531,7 @@ TEST(TransformationAddBitInstructionSynonymTest, AddOpNotSynonym) {
            96,  97,  98,  99,  100, 101, 102, 103, 104, 105, 106, 107, 108, 109,
            110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123,
            124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134});
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(134, {}), MakeDataDescriptor(39, {})));
 

--- a/test/fuzz/transformation_add_constant_boolean_test.cpp
+++ b/test/fuzz/transformation_add_constant_boolean_test.cpp
@@ -66,7 +66,7 @@ TEST(TransformationAddConstantBooleanTest, NeitherPresentInitiallyAddBoth) {
   auto add_false = TransformationAddConstantBoolean(8, false, false);
 
   ASSERT_TRUE(add_true.IsApplicable(context.get(), transformation_context));
-  add_true.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(add_true, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Having added true, we cannot add it again with the same id.
@@ -75,11 +75,11 @@ TEST(TransformationAddConstantBooleanTest, NeitherPresentInitiallyAddBoth) {
   auto add_true_again = TransformationAddConstantBoolean(100, true, false);
   ASSERT_TRUE(
       add_true_again.IsApplicable(context.get(), transformation_context));
-  add_true_again.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(add_true_again, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(add_false.IsApplicable(context.get(), transformation_context));
-  add_false.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(add_false, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Having added false, we cannot add it again with the same id.
@@ -88,21 +88,24 @@ TEST(TransformationAddConstantBooleanTest, NeitherPresentInitiallyAddBoth) {
   auto add_false_again = TransformationAddConstantBoolean(101, false, false);
   ASSERT_TRUE(
       add_false_again.IsApplicable(context.get(), transformation_context));
-  add_false_again.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(add_false_again, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // We can create an irrelevant OpConstantTrue.
   TransformationAddConstantBoolean irrelevant_true(102, true, true);
   ASSERT_TRUE(
       irrelevant_true.IsApplicable(context.get(), transformation_context));
-  irrelevant_true.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(irrelevant_true, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // We can create an irrelevant OpConstantFalse.
   TransformationAddConstantBoolean irrelevant_false(103, false, true);
   ASSERT_TRUE(
       irrelevant_false.IsApplicable(context.get(), transformation_context));
-  irrelevant_false.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(irrelevant_false, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_FALSE(transformation_context.GetFactManager()->IdIsIrrelevant(100));

--- a/test/fuzz/transformation_add_constant_composite_test.cpp
+++ b/test/fuzz/transformation_add_constant_composite_test.cpp
@@ -128,7 +128,8 @@ TEST(TransformationAddConstantCompositeTest, BasicTest) {
   for (auto& transformation : transformations) {
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   ASSERT_TRUE(IsValid(env, context.get()));
 

--- a/test/fuzz/transformation_add_constant_null_test.cpp
+++ b/test/fuzz/transformation_add_constant_null_test.cpp
@@ -98,7 +98,8 @@ TEST(TransformationAddConstantNullTest, BasicTest) {
   for (auto& transformation : transformations) {
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   ASSERT_TRUE(IsValid(env, context.get()));
 

--- a/test/fuzz/transformation_add_constant_scalar_test.cpp
+++ b/test/fuzz/transformation_add_constant_scalar_test.cpp
@@ -169,7 +169,7 @@ TEST(TransformationAddConstantScalarTest, Apply) {
       MakeUnique<FactManager>(context.get()), validator_options);
   // Adds 32-bit unsigned integer (1 logical operand with 1 word).
   auto transformation = TransformationAddConstantScalar(19, 2, {4}, false);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   auto* constant_instruction = context->get_def_use_mgr()->GetDef(19);
   EXPECT_EQ(constant_instruction->NumInOperands(), 1);
   EXPECT_EQ(constant_instruction->NumInOperandWords(), 1);
@@ -177,7 +177,7 @@ TEST(TransformationAddConstantScalarTest, Apply) {
 
   // Adds 32-bit signed integer (1 logical operand with 1 word).
   transformation = TransformationAddConstantScalar(20, 3, {5}, false);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   constant_instruction = context->get_def_use_mgr()->GetDef(20);
   EXPECT_EQ(constant_instruction->NumInOperands(), 1);
   EXPECT_EQ(constant_instruction->NumInOperandWords(), 1);
@@ -186,7 +186,7 @@ TEST(TransformationAddConstantScalarTest, Apply) {
   // Adds 32-bit float (1 logical operand with 1 word).
   transformation = TransformationAddConstantScalar(
       21, 4, {0b01000000110000000000000000000000}, false);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   constant_instruction = context->get_def_use_mgr()->GetDef(21);
   EXPECT_EQ(constant_instruction->NumInOperands(), 1);
   EXPECT_EQ(constant_instruction->NumInOperandWords(), 1);
@@ -194,7 +194,7 @@ TEST(TransformationAddConstantScalarTest, Apply) {
 
   // Adds 64-bit unsigned integer (1 logical operand with 2 words).
   transformation = TransformationAddConstantScalar(22, 5, {7, 0}, false);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   constant_instruction = context->get_def_use_mgr()->GetDef(22);
   EXPECT_EQ(constant_instruction->NumInOperands(), 1);
   EXPECT_EQ(constant_instruction->NumInOperandWords(), 2);
@@ -202,7 +202,7 @@ TEST(TransformationAddConstantScalarTest, Apply) {
 
   // Adds 64-bit signed integer (1 logical operand with 2 words).
   transformation = TransformationAddConstantScalar(23, 6, {8, 0}, false);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   constant_instruction = context->get_def_use_mgr()->GetDef(23);
   EXPECT_EQ(constant_instruction->NumInOperands(), 1);
   EXPECT_EQ(constant_instruction->NumInOperandWords(), 2);
@@ -211,7 +211,7 @@ TEST(TransformationAddConstantScalarTest, Apply) {
   // Adds 64-bit float (1 logical operand with 2 words).
   transformation = TransformationAddConstantScalar(
       24, 7, {0, 0b01000000001000100000000000000000}, false);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   constant_instruction = context->get_def_use_mgr()->GetDef(24);
   EXPECT_EQ(constant_instruction->NumInOperands(), 1);
   EXPECT_EQ(constant_instruction->NumInOperandWords(), 2);
@@ -219,7 +219,7 @@ TEST(TransformationAddConstantScalarTest, Apply) {
 
   // Adds irrelevant 32-bit unsigned integer (1 logical operand with 1 word).
   transformation = TransformationAddConstantScalar(25, 2, {10}, true);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   constant_instruction = context->get_def_use_mgr()->GetDef(25);
   EXPECT_EQ(constant_instruction->NumInOperands(), 1);
   EXPECT_EQ(constant_instruction->NumInOperandWords(), 1);
@@ -227,7 +227,7 @@ TEST(TransformationAddConstantScalarTest, Apply) {
 
   // Adds irrelevant 32-bit signed integer (1 logical operand with 1 word).
   transformation = TransformationAddConstantScalar(26, 3, {11}, true);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   constant_instruction = context->get_def_use_mgr()->GetDef(26);
   EXPECT_EQ(constant_instruction->NumInOperands(), 1);
   EXPECT_EQ(constant_instruction->NumInOperandWords(), 1);
@@ -236,7 +236,7 @@ TEST(TransformationAddConstantScalarTest, Apply) {
   // Adds irrelevant 32-bit float (1 logical operand with 1 word).
   transformation = TransformationAddConstantScalar(
       27, 4, {0b01000001010000000000000000000000}, true);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   constant_instruction = context->get_def_use_mgr()->GetDef(27);
   EXPECT_EQ(constant_instruction->NumInOperands(), 1);
   EXPECT_EQ(constant_instruction->NumInOperandWords(), 1);
@@ -244,7 +244,7 @@ TEST(TransformationAddConstantScalarTest, Apply) {
 
   // Adds irrelevant 64-bit unsigned integer (1 logical operand with 2 words).
   transformation = TransformationAddConstantScalar(28, 5, {13, 0}, true);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   constant_instruction = context->get_def_use_mgr()->GetDef(28);
   EXPECT_EQ(constant_instruction->NumInOperands(), 1);
   EXPECT_EQ(constant_instruction->NumInOperandWords(), 2);
@@ -252,7 +252,7 @@ TEST(TransformationAddConstantScalarTest, Apply) {
 
   // Adds irrelevant 64-bit signed integer (1 logical operand with 2 words).
   transformation = TransformationAddConstantScalar(29, 6, {14, 0}, true);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   constant_instruction = context->get_def_use_mgr()->GetDef(29);
   EXPECT_EQ(constant_instruction->NumInOperands(), 1);
   EXPECT_EQ(constant_instruction->NumInOperandWords(), 2);
@@ -261,7 +261,7 @@ TEST(TransformationAddConstantScalarTest, Apply) {
   // Adds irrelevant 64-bit float (1 logical operand with 2 words).
   transformation = TransformationAddConstantScalar(
       30, 7, {0, 0b01000000001011100000000000000000}, true);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   constant_instruction = context->get_def_use_mgr()->GetDef(30);
   EXPECT_EQ(constant_instruction->NumInOperands(), 1);
   EXPECT_EQ(constant_instruction->NumInOperandWords(), 2);

--- a/test/fuzz/transformation_add_copy_memory_test.cpp
+++ b/test/fuzz/transformation_add_copy_memory_test.cpp
@@ -240,7 +240,8 @@ TEST(TransformationAddCopyMemoryTest, BasicTest) {
         storage_classes[i % storage_classes.size()], initializers[i]);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
     ASSERT_TRUE(
         transformation_context.GetFactManager()->PointeeValueIsIrrelevant(

--- a/test/fuzz/transformation_add_dead_block_test.cpp
+++ b/test/fuzz/transformation_add_dead_block_test.cpp
@@ -93,7 +93,7 @@ TEST(TransformationAddDeadBlockTest, BasicTest) {
   transformation = TransformationAddDeadBlock(14, 11, true);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   ASSERT_TRUE(transformation_context.GetFactManager()->BlockIsDead(14));
 
@@ -304,7 +304,7 @@ TEST(TransformationAddDeadBlockTest, OpPhiInTarget) {
   TransformationAddDeadBlock transformation(100, 5, true);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(transformation_context.GetFactManager()->BlockIsDead(100));

--- a/test/fuzz/transformation_add_dead_break_test.cpp
+++ b/test/fuzz/transformation_add_dead_break_test.cpp
@@ -150,32 +150,38 @@ TEST(TransformationAddDeadBreakTest, BreaksOutOfSimpleIf) {
 
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation3.IsApplicable(context.get(), transformation_context));
-  transformation3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation3, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation4.IsApplicable(context.get(), transformation_context));
-  transformation4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation4, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation5.IsApplicable(context.get(), transformation_context));
-  transformation5.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation5, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation6.IsApplicable(context.get(), transformation_context));
-  transformation6.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation6, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -429,42 +435,50 @@ TEST(TransformationAddDeadBreakTest, BreakOutOfNestedIfs) {
 
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation3.IsApplicable(context.get(), transformation_context));
-  transformation3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation3, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation4.IsApplicable(context.get(), transformation_context));
-  transformation4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation4, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation5.IsApplicable(context.get(), transformation_context));
-  transformation5.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation5, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation6.IsApplicable(context.get(), transformation_context));
-  transformation6.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation6, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation7.IsApplicable(context.get(), transformation_context));
-  transformation7.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation7, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation8.IsApplicable(context.get(), transformation_context));
-  transformation8.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation8, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -813,52 +827,62 @@ TEST(TransformationAddDeadBreakTest, BreakOutOfNestedSwitches) {
 
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation3.IsApplicable(context.get(), transformation_context));
-  transformation3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation3, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation4.IsApplicable(context.get(), transformation_context));
-  transformation4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation4, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation5.IsApplicable(context.get(), transformation_context));
-  transformation5.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation5, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation6.IsApplicable(context.get(), transformation_context));
-  transformation6.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation6, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation7.IsApplicable(context.get(), transformation_context));
-  transformation7.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation7, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation8.IsApplicable(context.get(), transformation_context));
-  transformation8.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation8, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation9.IsApplicable(context.get(), transformation_context));
-  transformation9.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation9, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation10.IsApplicable(context.get(), transformation_context));
-  transformation10.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation10, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -1238,37 +1262,44 @@ TEST(TransformationAddDeadBreakTest, BreakOutOfLoopNest) {
 
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation3.IsApplicable(context.get(), transformation_context));
-  transformation3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation3, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation4.IsApplicable(context.get(), transformation_context));
-  transformation4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation4, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation5.IsApplicable(context.get(), transformation_context));
-  transformation5.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation5, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation6.IsApplicable(context.get(), transformation_context));
-  transformation6.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation6, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation7.IsApplicable(context.get(), transformation_context));
-  transformation7.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation7, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -1520,7 +1551,7 @@ TEST(TransformationAddDeadBreakTest, BreakFromBackEdgeBlock) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(context.get()), validator_options);
   auto transformation = TransformationAddDeadBreak(18, 21, true, {});
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string variant_shader = R"(
                OpCapability Shader
@@ -1682,22 +1713,26 @@ TEST(TransformationAddDeadBreakTest, SelectionInContinueConstruct) {
 
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation3.IsApplicable(context.get(), transformation_context));
-  transformation3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation3, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation4.IsApplicable(context.get(), transformation_context));
-  transformation4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation4, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -1887,12 +1922,14 @@ TEST(TransformationAddDeadBreakTest, LoopInContinueConstruct) {
 
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -2124,27 +2161,32 @@ TEST(TransformationAddDeadBreakTest, PhiInstructions) {
 
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation3.IsApplicable(context.get(), transformation_context));
-  transformation3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation3, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation4.IsApplicable(context.get(), transformation_context));
-  transformation4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation4, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation5.IsApplicable(context.get(), transformation_context));
-  transformation5.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation5, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -2383,7 +2425,8 @@ TEST(TransformationAddDeadBreakTest, RespectDominanceRules3) {
   ASSERT_TRUE(
       good_transformation.IsApplicable(context.get(), transformation_context));
 
-  good_transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(good_transformation, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -2473,7 +2516,8 @@ TEST(TransformationAddDeadBreakTest, RespectDominanceRules4) {
   ASSERT_TRUE(
       good_transformation.IsApplicable(context.get(), transformation_context));
 
-  good_transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(good_transformation, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(

--- a/test/fuzz/transformation_add_dead_continue_test.cpp
+++ b/test/fuzz/transformation_add_dead_continue_test.cpp
@@ -142,17 +142,20 @@ TEST(TransformationAddDeadContinueTest, SimpleExample) {
 
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       transformation3.IsApplicable(context.get(), transformation_context));
-  transformation3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation3, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -383,7 +386,8 @@ TEST(TransformationAddDeadContinueTest, LoopNest) {
     const TransformationAddDeadContinue transformation(from_block, true, {});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_FALSE(
         transformation.IsApplicable(context.get(), transformation_context));
   }
@@ -621,7 +625,8 @@ TEST(TransformationAddDeadConditionalTest, LoopInContinueConstruct) {
     const TransformationAddDeadContinue transformation(from_block, false, {});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_FALSE(
         transformation.IsApplicable(context.get(), transformation_context));
   }
@@ -830,12 +835,14 @@ TEST(TransformationAddDeadContinueTest, PhiInstructions) {
   auto transformation1 = TransformationAddDeadContinue(29, true, {13, 21});
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
 
   auto transformation2 = TransformationAddDeadContinue(30, true, {22, 46});
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
 
   // 75 already has the continue block as a successor, so we should not provide
   // phi ids.
@@ -846,7 +853,8 @@ TEST(TransformationAddDeadContinueTest, PhiInstructions) {
   auto transformation3 = TransformationAddDeadContinue(75, true, {});
   ASSERT_TRUE(
       transformation3.IsApplicable(context.get(), transformation_context));
-  transformation3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation3, context.get(),
+                        &transformation_context);
 
   std::string after_transformation = R"(
                OpCapability Shader
@@ -1002,19 +1010,22 @@ TEST(TransformationAddDeadContinueTest, RespectDominanceRules1) {
   auto good_transformation_1 = TransformationAddDeadContinue(7, false, {});
   ASSERT_TRUE(good_transformation_1.IsApplicable(context.get(),
                                                  transformation_context));
-  good_transformation_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(good_transformation_1, context.get(),
+                        &transformation_context);
 
   auto good_transformation_2 = TransformationAddDeadContinue(22, false, {});
   ASSERT_TRUE(good_transformation_2.IsApplicable(context.get(),
                                                  transformation_context));
-  good_transformation_2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(good_transformation_2, context.get(),
+                        &transformation_context);
 
   // This transformation is OK, because the definition of %21 in the loop body
   // is only used in an OpPhi in the loop's continue target.
   auto good_transformation_3 = TransformationAddDeadContinue(6, false, {11});
   ASSERT_TRUE(good_transformation_3.IsApplicable(context.get(),
                                                  transformation_context));
-  good_transformation_3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(good_transformation_3, context.get(),
+                        &transformation_context);
 
   std::string after_transformations = R"(
                OpCapability Shader

--- a/test/fuzz/transformation_add_function_test.cpp
+++ b/test/fuzz/transformation_add_function_test.cpp
@@ -218,7 +218,8 @@ TEST(TransformationAddFunctionTest, BasicTest) {
 
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation1 = R"(
@@ -339,7 +340,8 @@ TEST(TransformationAddFunctionTest, BasicTest) {
 
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation2 = R"(
@@ -640,7 +642,8 @@ TEST(TransformationAddFunctionTest, LoopLimiters) {
   TransformationAddFunction add_dead_function(instructions);
   ASSERT_TRUE(
       add_dead_function.IsApplicable(context1.get(), transformation_context1));
-  add_dead_function.Apply(context1.get(), &transformation_context1);
+  ApplyAndCheckFreshIds(add_dead_function, context1.get(),
+                        &transformation_context1);
   ASSERT_TRUE(IsValid(env, context1.get()));
   // The added function should not be deemed livesafe.
   ASSERT_FALSE(
@@ -725,7 +728,8 @@ TEST(TransformationAddFunctionTest, LoopLimiters) {
                                                   loop_limiters, 0, {});
   ASSERT_TRUE(add_livesafe_function.IsApplicable(context2.get(),
                                                  transformation_context2));
-  add_livesafe_function.Apply(context2.get(), &transformation_context2);
+  ApplyAndCheckFreshIds(add_livesafe_function, context2.get(),
+                        &transformation_context2);
   ASSERT_TRUE(IsValid(env, context2.get()));
   // The added function should indeed be deemed livesafe.
   ASSERT_TRUE(transformation_context2.GetFactManager()->FunctionIsLivesafe(30));
@@ -860,7 +864,8 @@ TEST(TransformationAddFunctionTest, KillAndUnreachableInVoidFunction) {
   TransformationAddFunction add_dead_function(instructions);
   ASSERT_TRUE(
       add_dead_function.IsApplicable(context1.get(), transformation_context1));
-  add_dead_function.Apply(context1.get(), &transformation_context1);
+  ApplyAndCheckFreshIds(add_dead_function, context1.get(),
+                        &transformation_context1);
   ASSERT_TRUE(IsValid(env, context1.get()));
   // The added function should not be deemed livesafe.
   ASSERT_FALSE(
@@ -906,7 +911,8 @@ TEST(TransformationAddFunctionTest, KillAndUnreachableInVoidFunction) {
                                                   {});
   ASSERT_TRUE(add_livesafe_function.IsApplicable(context2.get(),
                                                  transformation_context2));
-  add_livesafe_function.Apply(context2.get(), &transformation_context2);
+  ApplyAndCheckFreshIds(add_livesafe_function, context2.get(),
+                        &transformation_context2);
   ASSERT_TRUE(IsValid(env, context2.get()));
   // The added function should indeed be deemed livesafe.
   ASSERT_TRUE(transformation_context2.GetFactManager()->FunctionIsLivesafe(10));
@@ -1013,7 +1019,8 @@ TEST(TransformationAddFunctionTest, KillAndUnreachableInNonVoidFunction) {
   TransformationAddFunction add_dead_function(instructions);
   ASSERT_TRUE(
       add_dead_function.IsApplicable(context1.get(), transformation_context1));
-  add_dead_function.Apply(context1.get(), &transformation_context1);
+  ApplyAndCheckFreshIds(add_dead_function, context1.get(),
+                        &transformation_context1);
   ASSERT_TRUE(IsValid(env, context1.get()));
   // The added function should not be deemed livesafe.
   ASSERT_FALSE(
@@ -1060,7 +1067,8 @@ TEST(TransformationAddFunctionTest, KillAndUnreachableInNonVoidFunction) {
                                                   {});
   ASSERT_TRUE(add_livesafe_function.IsApplicable(context2.get(),
                                                  transformation_context2));
-  add_livesafe_function.Apply(context2.get(), &transformation_context2);
+  ApplyAndCheckFreshIds(add_livesafe_function, context2.get(),
+                        &transformation_context2);
   ASSERT_TRUE(IsValid(env, context2.get()));
   // The added function should indeed be deemed livesafe.
   ASSERT_TRUE(transformation_context2.GetFactManager()->FunctionIsLivesafe(10));
@@ -1298,7 +1306,8 @@ TEST(TransformationAddFunctionTest, ClampedAccessChains) {
   TransformationAddFunction add_dead_function(instructions);
   ASSERT_TRUE(
       add_dead_function.IsApplicable(context1.get(), transformation_context1));
-  add_dead_function.Apply(context1.get(), &transformation_context1);
+  ApplyAndCheckFreshIds(add_dead_function, context1.get(),
+                        &transformation_context1);
   ASSERT_TRUE(IsValid(env, context1.get()));
   // The function should not be deemed livesafe
   ASSERT_FALSE(
@@ -1438,7 +1447,8 @@ TEST(TransformationAddFunctionTest, ClampedAccessChains) {
                                                   access_chain_clamping_info);
   ASSERT_TRUE(add_livesafe_function.IsApplicable(context2.get(),
                                                  transformation_context2));
-  add_livesafe_function.Apply(context2.get(), &transformation_context2);
+  ApplyAndCheckFreshIds(add_livesafe_function, context2.get(),
+                        &transformation_context2);
   ASSERT_TRUE(IsValid(env, context2.get()));
   // The function should be deemed livesafe
   ASSERT_TRUE(transformation_context2.GetFactManager()->FunctionIsLivesafe(12));
@@ -1626,7 +1636,8 @@ TEST(TransformationAddFunctionTest, LivesafeCanCallLivesafe) {
   TransformationAddFunction add_dead_function(instructions);
   ASSERT_TRUE(
       add_dead_function.IsApplicable(context1.get(), transformation_context1));
-  add_dead_function.Apply(context1.get(), &transformation_context1);
+  ApplyAndCheckFreshIds(add_dead_function, context1.get(),
+                        &transformation_context1);
   ASSERT_TRUE(IsValid(env, context1.get()));
   // The function should not be deemed livesafe
   ASSERT_FALSE(transformation_context1.GetFactManager()->FunctionIsLivesafe(8));
@@ -1663,7 +1674,8 @@ TEST(TransformationAddFunctionTest, LivesafeCanCallLivesafe) {
                                                   {});
   ASSERT_TRUE(add_livesafe_function.IsApplicable(context2.get(),
                                                  transformation_context2));
-  add_livesafe_function.Apply(context2.get(), &transformation_context2);
+  ApplyAndCheckFreshIds(add_livesafe_function, context2.get(),
+                        &transformation_context2);
   ASSERT_TRUE(IsValid(env, context2.get()));
   // The function should be deemed livesafe
   ASSERT_TRUE(transformation_context2.GetFactManager()->FunctionIsLivesafe(8));
@@ -1721,7 +1733,8 @@ TEST(TransformationAddFunctionTest, LivesafeOnlyCallsLivesafe) {
   TransformationAddFunction add_dead_function(instructions);
   ASSERT_TRUE(
       add_dead_function.IsApplicable(context1.get(), transformation_context1));
-  add_dead_function.Apply(context1.get(), &transformation_context1);
+  ApplyAndCheckFreshIds(add_dead_function, context1.get(),
+                        &transformation_context1);
   ASSERT_TRUE(IsValid(env, context1.get()));
   // The function should not be deemed livesafe
   ASSERT_FALSE(transformation_context1.GetFactManager()->FunctionIsLivesafe(8));
@@ -1858,7 +1871,8 @@ TEST(TransformationAddFunctionTest,
                                                   {loop_limiter_info}, 0, {});
   ASSERT_TRUE(add_livesafe_function.IsApplicable(context.get(),
                                                  transformation_context));
-  add_livesafe_function.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(add_livesafe_function, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   std::string expected = R"(
                OpCapability Shader
@@ -2013,7 +2027,8 @@ TEST(TransformationAddFunctionTest,
                                                   {loop_limiter_info}, 0, {});
   ASSERT_TRUE(add_livesafe_function.IsApplicable(context.get(),
                                                  transformation_context));
-  add_livesafe_function.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(add_livesafe_function, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   std::string expected = R"(
                OpCapability Shader
@@ -2166,7 +2181,8 @@ TEST(TransformationAddFunctionTest, LoopLimitersHeaderIsBackEdgeBlock) {
                                                   {loop_limiter_info}, 0, {});
   ASSERT_TRUE(add_livesafe_function.IsApplicable(context.get(),
                                                  transformation_context));
-  add_livesafe_function.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(add_livesafe_function, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   std::string expected = R"(
                OpCapability Shader
@@ -2423,7 +2439,8 @@ TEST(TransformationAddFunctionTest, UnreachableContinueConstruct) {
                                                   {loop_limiter_info}, 0, {});
   ASSERT_TRUE(add_livesafe_function.IsApplicable(context.get(),
                                                  transformation_context));
-  add_livesafe_function.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(add_livesafe_function, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   std::string expected = R"(
                OpCapability Shader
@@ -2597,7 +2614,8 @@ TEST(TransformationAddFunctionTest, LoopLimitersAndOpPhi1) {
                                              {loop_limiter_info}, 0, {});
   ASSERT_TRUE(
       with_op_phi_data.IsApplicable(context.get(), transformation_context));
-  with_op_phi_data.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(with_op_phi_data, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   std::string expected = R"(
                OpCapability Shader
@@ -2777,7 +2795,7 @@ TEST(TransformationAddFunctionTest, LoopLimitersAndOpPhi2) {
                                            {loop_limiter_info}, 0, {});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   std::string expected = R"(
                OpCapability Shader
@@ -2918,7 +2936,8 @@ TEST(TransformationAddFunctionTest, StaticallyOutOfBoundsArrayAccess) {
       instructions, 0, 0, {}, 0, {MakeAccessClampingInfo(17, {{100, 101}})});
   ASSERT_TRUE(add_livesafe_function.IsApplicable(context.get(),
                                                  transformation_context));
-  add_livesafe_function.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(add_livesafe_function, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   std::string expected = R"(
                OpCapability Shader

--- a/test/fuzz/transformation_add_global_undef_test.cpp
+++ b/test/fuzz/transformation_add_global_undef_test.cpp
@@ -83,7 +83,8 @@ TEST(TransformationAddGlobalUndefTest, BasicTest) {
   for (auto& transformation : transformations) {
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   ASSERT_TRUE(IsValid(env, context.get()));
 

--- a/test/fuzz/transformation_add_global_variable_test.cpp
+++ b/test/fuzz/transformation_add_global_variable_test.cpp
@@ -144,7 +144,8 @@ TEST(TransformationAddGlobalVariableTest, BasicTest) {
   for (auto& transformation : transformations) {
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   ASSERT_TRUE(
       transformation_context.GetFactManager()->PointeeValueIsIrrelevant(100));
@@ -266,7 +267,8 @@ TEST(TransformationAddGlobalVariableTest, TestEntryPointInterfaceEnlargement) {
   for (auto& transformation : transformations) {
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   ASSERT_TRUE(
       transformation_context.GetFactManager()->PointeeValueIsIrrelevant(100));
@@ -364,7 +366,8 @@ TEST(TransformationAddGlobalVariableTest, TestAddingWorkgroupGlobals) {
   for (auto& transformation : transformations) {
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   ASSERT_TRUE(
       transformation_context.GetFactManager()->PointeeValueIsIrrelevant(8));

--- a/test/fuzz/transformation_add_image_sample_unused_components_test.cpp
+++ b/test/fuzz/transformation_add_image_sample_unused_components_test.cpp
@@ -199,13 +199,13 @@ TEST(TransformationAddImageSampleUnusedComponentsTest, Apply) {
       MakeInstructionDescriptor(25, SpvOpImageSampleImplicitLod, 0);
   auto transformation =
       TransformationAddImageSampleUnusedComponents(23, instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor =
       MakeInstructionDescriptor(26, SpvOpImageSampleExplicitLod, 0);
   transformation =
       TransformationAddImageSampleUnusedComponents(24, instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string variant_shader = R"(
                OpCapability Shader

--- a/test/fuzz/transformation_add_local_variable_test.cpp
+++ b/test/fuzz/transformation_add_local_variable_test.cpp
@@ -98,7 +98,8 @@ TEST(TransformationAddLocalVariableTest, BasicTest) {
     TransformationAddLocalVariable transformation(105, 50, 4, 51, true);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   // %104 = OpVariable %41 Function %46
@@ -106,7 +107,8 @@ TEST(TransformationAddLocalVariableTest, BasicTest) {
     TransformationAddLocalVariable transformation(104, 41, 4, 46, false);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   // %103 = OpVariable %35 Function %38
@@ -114,7 +116,8 @@ TEST(TransformationAddLocalVariableTest, BasicTest) {
     TransformationAddLocalVariable transformation(103, 35, 4, 38, true);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   // %102 = OpVariable %31 Function %33
@@ -122,7 +125,8 @@ TEST(TransformationAddLocalVariableTest, BasicTest) {
     TransformationAddLocalVariable transformation(102, 31, 4, 33, false);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   // %101 = OpVariable %19 Function %29
@@ -130,7 +134,8 @@ TEST(TransformationAddLocalVariableTest, BasicTest) {
     TransformationAddLocalVariable transformation(101, 19, 4, 29, true);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   // %100 = OpVariable %8 Function %12
@@ -138,7 +143,8 @@ TEST(TransformationAddLocalVariableTest, BasicTest) {
     TransformationAddLocalVariable transformation(100, 8, 4, 12, false);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   ASSERT_FALSE(

--- a/test/fuzz/transformation_add_loop_preheader_test.cpp
+++ b/test/fuzz/transformation_add_loop_preheader_test.cpp
@@ -88,12 +88,14 @@ TEST(TransformationAddLoopPreheaderTest, SimpleTest) {
   auto transformation1 = TransformationAddLoopPreheader(10, 20, {});
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
 
   auto transformation2 = TransformationAddLoopPreheader(12, 21, {});
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
 
   ASSERT_TRUE(IsValid(env, context.get()));
 
@@ -204,7 +206,8 @@ TEST(TransformationAddLoopPreheaderTest, OpPhi) {
   auto transformation1 = TransformationAddLoopPreheader(8, 40, {});
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
 
   // Not enough ids for the OpPhi instructions are given
   ASSERT_FALSE(TransformationAddLoopPreheader(13, 41, {})
@@ -225,7 +228,8 @@ TEST(TransformationAddLoopPreheaderTest, OpPhi) {
   auto transformation2 = TransformationAddLoopPreheader(13, 41, {42, 43});
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
 
   ASSERT_TRUE(IsValid(env, context.get()));
 

--- a/test/fuzz/transformation_add_loop_to_create_int_constant_synonym_test.cpp
+++ b/test/fuzz/transformation_add_loop_to_create_int_constant_synonym_test.cpp
@@ -389,7 +389,8 @@ TEST(TransformationAddLoopToCreateIntConstantSynonymTest, Simple) {
       12, 13, 11, 10, 15, 100, 101, 102, 103, 104, 105, 106, 0);
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(12, {}), MakeDataDescriptor(100, {})));
   ASSERT_TRUE(IsValid(env, context.get()));
@@ -400,7 +401,8 @@ TEST(TransformationAddLoopToCreateIntConstantSynonymTest, Simple) {
       12, 13, 11, 10, 17, 107, 108, 109, 110, 111, 112, 113, 114);
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(12, {}), MakeDataDescriptor(107, {})));
   ASSERT_TRUE(IsValid(env, context.get()));
@@ -411,7 +413,8 @@ TEST(TransformationAddLoopToCreateIntConstantSynonymTest, Simple) {
       12, 13, 11, 10, 26, 115, 116, 117, 118, 119, 120, 121, 0);
   ASSERT_TRUE(
       transformation3.IsApplicable(context.get(), transformation_context));
-  transformation3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation3, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(12, {}), MakeDataDescriptor(115, {})));
   ASSERT_TRUE(IsValid(env, context.get()));
@@ -562,7 +565,8 @@ TEST(TransformationAddLoopToCreateIntConstantSynonymTest,
       12, 18, 16, 10, 26, 100, 101, 102, 103, 104, 105, 106, 0);
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(12, {}), MakeDataDescriptor(100, {})));
   ASSERT_TRUE(IsValid(env, context.get()));
@@ -572,7 +576,8 @@ TEST(TransformationAddLoopToCreateIntConstantSynonymTest,
       12, 18, 11, 10, 27, 108, 109, 110, 111, 112, 113, 114, 0);
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(12, {}), MakeDataDescriptor(108, {})));
   ASSERT_TRUE(IsValid(env, context.get()));
@@ -582,7 +587,8 @@ TEST(TransformationAddLoopToCreateIntConstantSynonymTest,
       17, 18, 16, 10, 28, 115, 116, 117, 118, 119, 120, 121, 0);
   ASSERT_TRUE(
       transformation3.IsApplicable(context.get(), transformation_context));
-  transformation3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation3, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(17, {}), MakeDataDescriptor(115, {})));
   ASSERT_TRUE(IsValid(env, context.get()));
@@ -592,7 +598,8 @@ TEST(TransformationAddLoopToCreateIntConstantSynonymTest,
       22, 23, 24, 10, 29, 122, 123, 124, 125, 126, 127, 128, 0);
   ASSERT_TRUE(
       transformation4.IsApplicable(context.get(), transformation_context));
-  transformation4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation4, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(22, {}), MakeDataDescriptor(122, {})));
   ASSERT_TRUE(IsValid(env, context.get()));
@@ -602,7 +609,8 @@ TEST(TransformationAddLoopToCreateIntConstantSynonymTest,
       21, 23, 24, 10, 30, 129, 130, 131, 132, 133, 134, 135, 0);
   ASSERT_TRUE(
       transformation5.IsApplicable(context.get(), transformation_context));
-  transformation5.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation5, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(21, {}), MakeDataDescriptor(129, {})));
   ASSERT_TRUE(IsValid(env, context.get()));
@@ -751,7 +759,8 @@ TEST(TransformationAddLoopToCreateIntConstantSynonymTest, 64BitConstants) {
       13, 14, 12, 10, 20, 100, 101, 102, 103, 104, 105, 106, 0);
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(13, {}), MakeDataDescriptor(100, {})));
   ASSERT_TRUE(IsValid(env, context.get()));
@@ -761,7 +770,8 @@ TEST(TransformationAddLoopToCreateIntConstantSynonymTest, 64BitConstants) {
       16, 17, 18, 10, 21, 107, 108, 109, 110, 111, 112, 113, 0);
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(16, {}), MakeDataDescriptor(107, {})));
   ASSERT_TRUE(IsValid(env, context.get()));
@@ -869,7 +879,8 @@ TEST(TransformationAddLoopToCreateIntConstantSynonymTest, Underflow) {
       12, 8, 14, 11, 17, 100, 101, 102, 103, 104, 105, 106, 0);
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(12, {}), MakeDataDescriptor(100, {})));
   ASSERT_TRUE(IsValid(env, context.get()));
@@ -880,7 +891,8 @@ TEST(TransformationAddLoopToCreateIntConstantSynonymTest, Underflow) {
       15, 8, 11, 10, 18, 107, 108, 109, 110, 111, 112, 113, 0);
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(15, {}), MakeDataDescriptor(107, {})));
   ASSERT_TRUE(IsValid(env, context.get()));

--- a/test/fuzz/transformation_add_no_contraction_decoration_test.cpp
+++ b/test/fuzz/transformation_add_no_contraction_decoration_test.cpp
@@ -113,7 +113,8 @@ TEST(TransformationAddNoContractionDecorationTest, BasicScenarios) {
     TransformationAddNoContractionDecoration transformation(result_id);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 

--- a/test/fuzz/transformation_add_opphi_synonym_test.cpp
+++ b/test/fuzz/transformation_add_opphi_synonym_test.cpp
@@ -217,7 +217,8 @@ TEST(TransformationAddOpPhiSynonymTest, Apply) {
   auto transformation1 = TransformationAddOpPhiSynonym(17, {{{15, 13}}}, 100);
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(100, {}), MakeDataDescriptor(9, {})));
 
@@ -225,7 +226,8 @@ TEST(TransformationAddOpPhiSynonymTest, Apply) {
       TransformationAddOpPhiSynonym(16, {{{17, 19}, {18, 13}}}, 101);
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(101, {}), MakeDataDescriptor(9, {})));
 
@@ -233,14 +235,16 @@ TEST(TransformationAddOpPhiSynonymTest, Apply) {
       TransformationAddOpPhiSynonym(23, {{{22, 13}, {27, 28}, {29, 30}}}, 102);
   ASSERT_TRUE(
       transformation3.IsApplicable(context.get(), transformation_context));
-  transformation3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation3, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(102, {}), MakeDataDescriptor(9, {})));
 
   auto transformation4 = TransformationAddOpPhiSynonym(31, {{{23, 13}}}, 103);
   ASSERT_TRUE(
       transformation4.IsApplicable(context.get(), transformation_context));
-  transformation4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation4, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(103, {}), MakeDataDescriptor(9, {})));
 
@@ -377,7 +381,7 @@ TEST(TransformationAddOpPhiSynonymTest, VariablePointers) {
       TransformationAddOpPhiSynonym(13, {{{11, 3}, {14, 15}}}, 100);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string after_transformation = R"(
                OpCapability Shader

--- a/test/fuzz/transformation_add_parameter_test.cpp
+++ b/test/fuzz/transformation_add_parameter_test.cpp
@@ -133,28 +133,28 @@ TEST(TransformationAddParameterTest, NonPointerBasicTest) {
   {
     TransformationAddParameter correct(9, 60, 11, {{{13, 8}}}, 61);
     ASSERT_TRUE(correct.IsApplicable(context.get(), transformation_context));
-    correct.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(correct, context.get(), &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
     ASSERT_TRUE(transformation_context.GetFactManager()->IdIsIrrelevant(60));
   }
   {
     TransformationAddParameter correct(17, 62, 7, {{}}, 63);
     ASSERT_TRUE(correct.IsApplicable(context.get(), transformation_context));
-    correct.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(correct, context.get(), &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
     ASSERT_TRUE(transformation_context.GetFactManager()->IdIsIrrelevant(62));
   }
   {
     TransformationAddParameter correct(29, 64, 31, {{}}, 65);
     ASSERT_TRUE(correct.IsApplicable(context.get(), transformation_context));
-    correct.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(correct, context.get(), &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
     ASSERT_TRUE(transformation_context.GetFactManager()->IdIsIrrelevant(64));
   }
   {
     TransformationAddParameter correct(34, 66, 7, {{}}, 67);
     ASSERT_TRUE(correct.IsApplicable(context.get(), transformation_context));
-    correct.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(correct, context.get(), &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
     ASSERT_TRUE(transformation_context.GetFactManager()->IdIsIrrelevant(66));
   }
@@ -460,28 +460,32 @@ TEST(TransformationAddParameterTest, PointerFunctionTest) {
                                                    {{{38, 31}, {42, 31}}}, 51);
   ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Good: Local variable of id 34 is defined in the caller (main).
   TransformationAddParameter transformation_good_2(14, 52, 9, {{{43, 34}}}, 53);
   ASSERT_TRUE(transformation_good_2.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Good: Local variable of id 39 is defined in the caller (main).
   TransformationAddParameter transformation_good_3(6, 54, 9, {{{33, 39}}}, 55);
   ASSERT_TRUE(transformation_good_3.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_3, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Good: This adds another pointer parameter to the function of id 6.
   TransformationAddParameter transformation_good_4(6, 56, 30, {{{33, 31}}}, 57);
   ASSERT_TRUE(transformation_good_4.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_4, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string expected_shader = R"(
@@ -671,7 +675,8 @@ TEST(TransformationAddParameterTest, PointerPrivateWorkgroupTest) {
                                                    {{{38, 28}, {42, 28}}}, 71);
   ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Good: Global variable of id 61 is (storage class Workgroup) is defined in
@@ -680,14 +685,16 @@ TEST(TransformationAddParameterTest, PointerPrivateWorkgroupTest) {
                                                    {{{38, 28}, {42, 28}}}, 73);
   ASSERT_TRUE(transformation_good_2.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_2, context.get(),
+                        &transformation_context);
 
   // Good: Global variable of id 28 (storage class Private) is defined in the
   // caller (main).
   TransformationAddParameter transformation_good_3(6, 74, 27, {{{33, 28}}}, 75);
   ASSERT_TRUE(transformation_good_3.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_3, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Good: Global variable of id 61 is (storage class Workgroup) is defined in
@@ -695,7 +702,8 @@ TEST(TransformationAddParameterTest, PointerPrivateWorkgroupTest) {
   TransformationAddParameter transformation_good_4(6, 76, 60, {{{33, 61}}}, 77);
   ASSERT_TRUE(transformation_good_4.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_4, context.get(),
+                        &transformation_context);
 
   // Good: Global variable of id 28 (storage class Private) is defined in the
   // caller (main).
@@ -703,7 +711,8 @@ TEST(TransformationAddParameterTest, PointerPrivateWorkgroupTest) {
                                                    79);
   ASSERT_TRUE(transformation_good_5.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_5.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_5, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Good: Global variable of id 61 is (storage class Workgroup) is defined in
@@ -712,7 +721,8 @@ TEST(TransformationAddParameterTest, PointerPrivateWorkgroupTest) {
                                                    81);
   ASSERT_TRUE(transformation_good_6.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_6.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_6, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string expected_shader = R"(
@@ -881,7 +891,8 @@ TEST(TransformationAddParameterTest, PointerMoreEntriesInMapTest) {
       10, 70, 7, {{{27, 21}, {31, 21}, {30, 21}}}, 71);
   ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Good: Local variable of id 28 is defined in every caller (id 27 and id 31).
@@ -889,7 +900,8 @@ TEST(TransformationAddParameterTest, PointerMoreEntriesInMapTest) {
       10, 72, 7, {{{27, 28}, {31, 28}, {14, 21}, {16, 14}}}, 73);
   ASSERT_TRUE(transformation_good_2.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string expected_shader = R"(
@@ -1034,7 +1046,8 @@ TEST(TransformationAddParameterTest, PointeeValueIsIrrelevantTest) {
                                                    {{{28, 22}, {32, 22}}}, 71);
   ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Check if the fact PointeeValueIsIrrelevant is set for the new parameter
@@ -1046,7 +1059,8 @@ TEST(TransformationAddParameterTest, PointeeValueIsIrrelevantTest) {
                                                    {{{28, 20}, {32, 20}}}, 73);
   ASSERT_TRUE(transformation_good_2.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Check if the fact PointeeValueIsIrrelevant is set for the new parameter
@@ -1058,7 +1072,8 @@ TEST(TransformationAddParameterTest, PointeeValueIsIrrelevantTest) {
                                                    {{{28, 51}, {32, 51}}}, 75);
   ASSERT_TRUE(transformation_good_3.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_3, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Check if the fact PointeeValueIsIrrelevant is set for the new parameter

--- a/test/fuzz/transformation_add_relaxed_decoration_test.cpp
+++ b/test/fuzz/transformation_add_relaxed_decoration_test.cpp
@@ -90,7 +90,8 @@ TEST(TransformationAddRelaxedDecorationTest, BasicScenarios) {
     TransformationAddRelaxedDecoration transformation(result_id);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 

--- a/test/fuzz/transformation_add_synonym_test.cpp
+++ b/test/fuzz/transformation_add_synonym_test.cpp
@@ -240,7 +240,8 @@ TEST(TransformationAddSynonymTest, AddZeroSubZeroMulOne) {
                                               insert_before);
       ASSERT_TRUE(
           transformation.IsApplicable(context.get(), transformation_context));
-      transformation.Apply(context.get(), &transformation_context);
+      ApplyAndCheckFreshIds(transformation, context.get(),
+                            &transformation_context);
       ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
           MakeDataDescriptor(result_id, {}), MakeDataDescriptor(fresh_id, {})));
       ++fresh_id;
@@ -366,7 +367,8 @@ TEST(TransformationAddSynonymTest, LogicalAndLogicalOr) {
                                               insert_before);
       ASSERT_TRUE(
           transformation.IsApplicable(context.get(), transformation_context));
-      transformation.Apply(context.get(), &transformation_context);
+      ApplyAndCheckFreshIds(transformation, context.get(),
+                            &transformation_context);
       ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
           MakeDataDescriptor(result_id, {}), MakeDataDescriptor(fresh_id, {})));
       ++fresh_id;
@@ -544,7 +546,8 @@ TEST(TransformationAddSynonymTest, CopyObject) {
                                             insert_before);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
         MakeDataDescriptor(result_id, {}), MakeDataDescriptor(fresh_id, {})));
     ++fresh_id;
@@ -636,7 +639,7 @@ TEST(TransformationAddSynonymTest, CopyBooleanConstants) {
         7, protobufs::TransformationAddSynonym::COPY_OBJECT, 100,
         MakeInstructionDescriptor(5, SpvOpReturn, 0));
     ASSERT_TRUE(copy_true.IsApplicable(context.get(), transformation_context));
-    copy_true.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(copy_true, context.get(), &transformation_context);
 
     std::vector<uint32_t> ids_for_which_synonyms_are_known =
         transformation_context.GetFactManager()
@@ -657,7 +660,7 @@ TEST(TransformationAddSynonymTest, CopyBooleanConstants) {
         8, protobufs::TransformationAddSynonym::COPY_OBJECT, 101,
         MakeInstructionDescriptor(100, SpvOpReturn, 0));
     ASSERT_TRUE(copy_false.IsApplicable(context.get(), transformation_context));
-    copy_false.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(copy_false, context.get(), &transformation_context);
     std::vector<uint32_t> ids_for_which_synonyms_are_known =
         transformation_context.GetFactManager()
             ->GetIdsForWhichSynonymsAreKnown();
@@ -678,7 +681,8 @@ TEST(TransformationAddSynonymTest, CopyBooleanConstants) {
         MakeInstructionDescriptor(5, SpvOpReturn, 0));
     ASSERT_TRUE(
         copy_false_again.IsApplicable(context.get(), transformation_context));
-    copy_false_again.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(copy_false_again, context.get(),
+                          &transformation_context);
     std::vector<uint32_t> ids_for_which_synonyms_are_known =
         transformation_context.GetFactManager()
             ->GetIdsForWhichSynonymsAreKnown();
@@ -700,7 +704,8 @@ TEST(TransformationAddSynonymTest, CopyBooleanConstants) {
         MakeInstructionDescriptor(102, SpvOpReturn, 0));
     ASSERT_TRUE(
         copy_true_again.IsApplicable(context.get(), transformation_context));
-    copy_true_again.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(copy_true_again, context.get(),
+                          &transformation_context);
     std::vector<uint32_t> ids_for_which_synonyms_are_known =
         transformation_context.GetFactManager()
             ->GetIdsForWhichSynonymsAreKnown();
@@ -1152,7 +1157,8 @@ TEST(TransformationAddSynonymTest, MiscellaneousCopies) {
   for (auto& transformation : transformations) {
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   ASSERT_TRUE(IsValid(env, context.get()));
@@ -1292,13 +1298,16 @@ TEST(TransformationAddSynonymTest, PropagateIrrelevantPointeeFact) {
 
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(
       transformation3.IsApplicable(context.get(), transformation_context));
-  transformation3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation3, context.get(),
+                        &transformation_context);
 
   ASSERT_TRUE(
       transformation_context.GetFactManager()->PointeeValueIsIrrelevant(8));

--- a/test/fuzz/transformation_add_type_array_test.cpp
+++ b/test/fuzz/transformation_add_type_array_test.cpp
@@ -98,7 +98,8 @@ TEST(TransformationAddTypeArrayTest, BasicTest) {
   for (auto& transformation : transformations) {
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   ASSERT_TRUE(IsValid(env, context.get()));
 

--- a/test/fuzz/transformation_add_type_boolean_test.cpp
+++ b/test/fuzz/transformation_add_type_boolean_test.cpp
@@ -52,7 +52,7 @@ TEST(TransformationAddTypeBooleanTest, BasicTest) {
   auto add_type_bool = TransformationAddTypeBoolean(100);
   ASSERT_TRUE(
       add_type_bool.IsApplicable(context.get(), transformation_context));
-  add_type_bool.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(add_type_bool, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Not applicable as we already have this type now.

--- a/test/fuzz/transformation_add_type_float_test.cpp
+++ b/test/fuzz/transformation_add_type_float_test.cpp
@@ -101,15 +101,15 @@ TEST(TransformationAddTypeFloatTest, Apply) {
       MakeUnique<FactManager>(context.get()), validator_options);
   // Adds 16-bit float type.
   auto transformation = TransformationAddTypeFloat(6, 16);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   // Adds 32-bit float type.
   transformation = TransformationAddTypeFloat(7, 32);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   // Adds 64-bit float type.
   transformation = TransformationAddTypeFloat(8, 64);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string variant_shader = R"(
          OpCapability Shader

--- a/test/fuzz/transformation_add_type_function_test.cpp
+++ b/test/fuzz/transformation_add_type_function_test.cpp
@@ -90,7 +90,8 @@ TEST(TransformationAddTypeFunctionTest, BasicTest) {
   for (auto& transformation : transformations) {
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   ASSERT_TRUE(IsValid(env, context.get()));
 

--- a/test/fuzz/transformation_add_type_int_test.cpp
+++ b/test/fuzz/transformation_add_type_int_test.cpp
@@ -117,35 +117,35 @@ TEST(TransformationAddTypeIntTest, Apply) {
       MakeUnique<FactManager>(context.get()), validator_options);
   // Adds signed 8-bit integer type.
   auto transformation = TransformationAddTypeInt(6, 8, true);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   // Adds signed 16-bit integer type.
   transformation = TransformationAddTypeInt(7, 16, true);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   // Adds signed 32-bit integer type.
   transformation = TransformationAddTypeInt(8, 32, true);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   // Adds signed 64-bit integer type.
   transformation = TransformationAddTypeInt(9, 64, true);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   // Adds unsigned 8-bit integer type.
   transformation = TransformationAddTypeInt(10, 8, false);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   // Adds unsigned 16-bit integer type.
   transformation = TransformationAddTypeInt(11, 16, false);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   // Adds unsigned 32-bit integer type.
   transformation = TransformationAddTypeInt(12, 32, false);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   // Adds unsigned 64-bit integer type.
   transformation = TransformationAddTypeInt(13, 64, false);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string variant_shader = R"(
          OpCapability Shader

--- a/test/fuzz/transformation_add_type_matrix_test.cpp
+++ b/test/fuzz/transformation_add_type_matrix_test.cpp
@@ -92,7 +92,8 @@ TEST(TransformationAddTypeMatrixTest, BasicTest) {
   for (auto& transformation : transformations) {
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   ASSERT_TRUE(IsValid(env, context.get()));
 

--- a/test/fuzz/transformation_add_type_pointer_test.cpp
+++ b/test/fuzz/transformation_add_type_pointer_test.cpp
@@ -140,7 +140,8 @@ TEST(TransformationAddTypePointerTest, BasicTest) {
         good_new_private_pointer_to_uniform_pointer_to_vec2}) {
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 

--- a/test/fuzz/transformation_add_type_struct_test.cpp
+++ b/test/fuzz/transformation_add_type_struct_test.cpp
@@ -77,7 +77,8 @@ TEST(TransformationAddTypeStructTest, BasicTest) {
   for (auto& transformation : transformations) {
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   ASSERT_TRUE(IsValid(env, context.get()));
 

--- a/test/fuzz/transformation_add_type_vector_test.cpp
+++ b/test/fuzz/transformation_add_type_vector_test.cpp
@@ -71,7 +71,8 @@ TEST(TransformationAddTypeVectorTest, BasicTest) {
   for (auto& transformation : transformations) {
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   ASSERT_TRUE(IsValid(env, context.get()));
 

--- a/test/fuzz/transformation_adjust_branch_weights_test.cpp
+++ b/test/fuzz/transformation_adjust_branch_weights_test.cpp
@@ -256,13 +256,13 @@ TEST(TransformationAdjustBranchWeightsTest, ApplyTest) {
       MakeInstructionDescriptor(33, SpvOpBranchConditional, 0);
   auto transformation =
       TransformationAdjustBranchWeights(instruction_descriptor, {5, 6});
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor =
       MakeInstructionDescriptor(21, SpvOpBranchConditional, 0);
   transformation =
       TransformationAdjustBranchWeights(instruction_descriptor, {7, 8});
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string variant_shader = R"(
                OpCapability Shader

--- a/test/fuzz/transformation_composite_construct_test.cpp
+++ b/test/fuzz/transformation_composite_construct_test.cpp
@@ -144,7 +144,8 @@ TEST(TransformationCompositeConstructTest, ConstructArrays) {
                                                     transformation_context));
   ASSERT_FALSE(make_vec2_array_length_3_bad.IsApplicable(
       context.get(), transformation_context));
-  make_vec2_array_length_3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(make_vec2_array_length_3, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(41, {}), MakeDataDescriptor(200, {0})));
@@ -163,7 +164,8 @@ TEST(TransformationCompositeConstructTest, ConstructArrays) {
                                                      transformation_context));
   ASSERT_FALSE(make_float_array_length_2_bad.IsApplicable(
       context.get(), transformation_context));
-  make_float_array_length_2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(make_float_array_length_2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(24, {}), MakeDataDescriptor(201, {0})));
@@ -182,7 +184,8 @@ TEST(TransformationCompositeConstructTest, ConstructArrays) {
                                                     transformation_context));
   ASSERT_FALSE(make_bool_array_length_3_bad.IsApplicable(
       context.get(), transformation_context));
-  make_bool_array_length_3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(make_bool_array_length_3, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(33, {}), MakeDataDescriptor(202, {0})));
@@ -201,7 +204,8 @@ TEST(TransformationCompositeConstructTest, ConstructArrays) {
                                                        transformation_context));
   ASSERT_FALSE(make_uvec3_array_length_2_2_bad.IsApplicable(
       context.get(), transformation_context));
-  make_uvec3_array_length_2_2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(make_uvec3_array_length_2_2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(69, {}), MakeDataDescriptor(203, {0})));
@@ -405,7 +409,7 @@ TEST(TransformationCompositeConstructTest, ConstructMatrices) {
   ASSERT_TRUE(make_mat34.IsApplicable(context.get(), transformation_context));
   ASSERT_FALSE(
       make_mat34_bad.IsApplicable(context.get(), transformation_context));
-  make_mat34.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(make_mat34, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(25, {}), MakeDataDescriptor(200, {0})));
@@ -423,7 +427,7 @@ TEST(TransformationCompositeConstructTest, ConstructMatrices) {
   ASSERT_TRUE(make_mat43.IsApplicable(context.get(), transformation_context));
   ASSERT_FALSE(
       make_mat43_bad.IsApplicable(context.get(), transformation_context));
-  make_mat43.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(make_mat43, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(11, {}), MakeDataDescriptor(201, {0})));
@@ -616,7 +620,7 @@ TEST(TransformationCompositeConstructTest, ConstructStructs) {
   ASSERT_TRUE(make_inner.IsApplicable(context.get(), transformation_context));
   ASSERT_FALSE(
       make_inner_bad.IsApplicable(context.get(), transformation_context));
-  make_inner.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(make_inner, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(25, {}), MakeDataDescriptor(200, {0})));
@@ -634,7 +638,7 @@ TEST(TransformationCompositeConstructTest, ConstructStructs) {
   ASSERT_TRUE(make_outer.IsApplicable(context.get(), transformation_context));
   ASSERT_FALSE(
       make_outer_bad.IsApplicable(context.get(), transformation_context));
-  make_outer.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(make_outer, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(46, {}), MakeDataDescriptor(201, {0})));
@@ -937,7 +941,7 @@ TEST(TransformationCompositeConstructTest, ConstructVectors) {
   ASSERT_TRUE(make_vec2.IsApplicable(context.get(), transformation_context));
   ASSERT_FALSE(
       make_vec2_bad.IsApplicable(context.get(), transformation_context));
-  make_vec2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(make_vec2, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(17, {}), MakeDataDescriptor(200, {0})));
@@ -954,7 +958,7 @@ TEST(TransformationCompositeConstructTest, ConstructVectors) {
   ASSERT_TRUE(make_vec3.IsApplicable(context.get(), transformation_context));
   ASSERT_FALSE(
       make_vec3_bad.IsApplicable(context.get(), transformation_context));
-  make_vec3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(make_vec3, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(12, {0}), MakeDataDescriptor(201, {0})));
@@ -973,7 +977,7 @@ TEST(TransformationCompositeConstructTest, ConstructVectors) {
   ASSERT_TRUE(make_vec4.IsApplicable(context.get(), transformation_context));
   ASSERT_FALSE(
       make_vec4_bad.IsApplicable(context.get(), transformation_context));
-  make_vec4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(make_vec4, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(32, {}), MakeDataDescriptor(202, {0})));
@@ -992,7 +996,7 @@ TEST(TransformationCompositeConstructTest, ConstructVectors) {
   ASSERT_TRUE(make_ivec2.IsApplicable(context.get(), transformation_context));
   ASSERT_FALSE(
       make_ivec2_bad.IsApplicable(context.get(), transformation_context));
-  make_ivec2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(make_ivec2, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(126, {}), MakeDataDescriptor(203, {0})));
@@ -1009,7 +1013,7 @@ TEST(TransformationCompositeConstructTest, ConstructVectors) {
   ASSERT_TRUE(make_ivec3.IsApplicable(context.get(), transformation_context));
   ASSERT_FALSE(
       make_ivec3_bad.IsApplicable(context.get(), transformation_context));
-  make_ivec3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(make_ivec3, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(56, {}), MakeDataDescriptor(204, {0})));
@@ -1028,7 +1032,7 @@ TEST(TransformationCompositeConstructTest, ConstructVectors) {
   ASSERT_TRUE(make_ivec4.IsApplicable(context.get(), transformation_context));
   ASSERT_FALSE(
       make_ivec4_bad.IsApplicable(context.get(), transformation_context));
-  make_ivec4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(make_ivec4, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(56, {}), MakeDataDescriptor(205, {0})));
@@ -1046,7 +1050,7 @@ TEST(TransformationCompositeConstructTest, ConstructVectors) {
   ASSERT_TRUE(make_uvec2.IsApplicable(context.get(), transformation_context));
   ASSERT_FALSE(
       make_uvec2_bad.IsApplicable(context.get(), transformation_context));
-  make_uvec2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(make_uvec2, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(18, {}), MakeDataDescriptor(206, {0})));
@@ -1061,7 +1065,7 @@ TEST(TransformationCompositeConstructTest, ConstructVectors) {
   ASSERT_TRUE(make_uvec3.IsApplicable(context.get(), transformation_context));
   ASSERT_FALSE(
       make_uvec3_bad.IsApplicable(context.get(), transformation_context));
-  make_uvec3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(make_uvec3, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(14, {}), MakeDataDescriptor(207, {0})));
@@ -1080,7 +1084,7 @@ TEST(TransformationCompositeConstructTest, ConstructVectors) {
   ASSERT_TRUE(make_uvec4.IsApplicable(context.get(), transformation_context));
   ASSERT_FALSE(
       make_uvec4_bad.IsApplicable(context.get(), transformation_context));
-  make_uvec4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(make_uvec4, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(14, {}), MakeDataDescriptor(208, {0})));
@@ -1109,7 +1113,7 @@ TEST(TransformationCompositeConstructTest, ConstructVectors) {
   ASSERT_TRUE(make_bvec2.IsApplicable(context.get(), transformation_context));
   ASSERT_FALSE(
       make_bvec2_bad.IsApplicable(context.get(), transformation_context));
-  make_bvec2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(make_bvec2, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(111, {}), MakeDataDescriptor(209, {0})));
@@ -1124,7 +1128,7 @@ TEST(TransformationCompositeConstructTest, ConstructVectors) {
   ASSERT_TRUE(make_bvec3.IsApplicable(context.get(), transformation_context));
   ASSERT_FALSE(
       make_bvec3_bad.IsApplicable(context.get(), transformation_context));
-  make_bvec3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(make_bvec3, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(108, {0}), MakeDataDescriptor(210, {0})));
@@ -1141,7 +1145,7 @@ TEST(TransformationCompositeConstructTest, ConstructVectors) {
   ASSERT_TRUE(make_bvec4.IsApplicable(context.get(), transformation_context));
   ASSERT_FALSE(
       make_bvec4_bad.IsApplicable(context.get(), transformation_context));
-  make_bvec4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(make_bvec4, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(108, {0}), MakeDataDescriptor(211, {0})));
@@ -1425,7 +1429,7 @@ TEST(TransformationCompositeConstructTest, AddSynonymsForRelevantIds) {
       32, {25, 28, 31}, MakeInstructionDescriptor(31, SpvOpReturn, 0), 200);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(25, {}), MakeDataDescriptor(200, {0})));
@@ -1509,7 +1513,7 @@ TEST(TransformationCompositeConstructTest, DontAddSynonymsForIrrelevantIds) {
       32, {25, 28, 31}, MakeInstructionDescriptor(31, SpvOpReturn, 0), 200);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_FALSE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(25, {}), MakeDataDescriptor(200, {0})));

--- a/test/fuzz/transformation_composite_extract_test.cpp
+++ b/test/fuzz/transformation_composite_extract_test.cpp
@@ -142,42 +142,48 @@ TEST(TransformationCompositeExtractTest, BasicTest) {
       MakeInstructionDescriptor(36, SpvOpConvertFToS, 0), 201, 100, {2});
   ASSERT_TRUE(
       transformation_1.IsApplicable(context.get(), transformation_context));
-  transformation_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   TransformationCompositeExtract transformation_2(
       MakeInstructionDescriptor(37, SpvOpAccessChain, 0), 202, 104, {0, 2});
   ASSERT_TRUE(
       transformation_2.IsApplicable(context.get(), transformation_context));
-  transformation_2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   TransformationCompositeExtract transformation_3(
       MakeInstructionDescriptor(29, SpvOpAccessChain, 0), 203, 104, {0});
   ASSERT_TRUE(
       transformation_3.IsApplicable(context.get(), transformation_context));
-  transformation_3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_3, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   TransformationCompositeExtract transformation_4(
       MakeInstructionDescriptor(24, SpvOpStore, 0), 204, 101, {0});
   ASSERT_TRUE(
       transformation_4.IsApplicable(context.get(), transformation_context));
-  transformation_4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_4, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   TransformationCompositeExtract transformation_5(
       MakeInstructionDescriptor(29, SpvOpBranch, 0), 205, 102, {2});
   ASSERT_TRUE(
       transformation_5.IsApplicable(context.get(), transformation_context));
-  transformation_5.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_5, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   TransformationCompositeExtract transformation_6(
       MakeInstructionDescriptor(37, SpvOpReturn, 0), 206, 103, {1});
   ASSERT_TRUE(
       transformation_6.IsApplicable(context.get(), transformation_context));
-  transformation_6.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_6, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
@@ -478,7 +484,7 @@ TEST(TransformationCompositeExtractTest, AddSynonymsForRelevantIds) {
       MakeInstructionDescriptor(36, SpvOpConvertFToS, 0), 201, 100, {2});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(201, {}), MakeDataDescriptor(100, {2})));
 }
@@ -566,7 +572,7 @@ TEST(TransformationCompositeExtractTest, DontAddSynonymsForIrrelevantIds) {
       MakeInstructionDescriptor(36, SpvOpConvertFToS, 0), 201, 100, {2});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_FALSE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(201, {}), MakeDataDescriptor(100, {2})));
 }

--- a/test/fuzz/transformation_composite_insert_test.cpp
+++ b/test/fuzz/transformation_composite_insert_test.cpp
@@ -229,7 +229,8 @@ TEST(TransformationCompositeInsertTest, EmptyCompositeScenarios) {
       MakeInstructionDescriptor(64, SpvOpStore, 0), 50, 64, 62, {1});
   ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformations = R"(
@@ -365,7 +366,8 @@ TEST(TransformationCompositeInsertTest, IrrelevantCompositeNoSynonyms) {
       MakeInstructionDescriptor(30, SpvOpStore, 0), 50, 30, 11, {1, 0, 0});
   ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // No synonyms should have been added.
@@ -468,7 +470,8 @@ TEST(TransformationCompositeInsertTest, IrrelevantObjectSomeSynonyms) {
       MakeInstructionDescriptor(30, SpvOpStore, 0), 50, 30, 11, {1, 0, 0});
   ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // These synonyms should have been added.
@@ -570,7 +573,8 @@ TEST(TransformationCompositeInsertTest, ApplicableCreatedSynonyms) {
       MakeInstructionDescriptor(30, SpvOpStore, 0), 50, 30, 11, {1, 0, 0});
   ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // These synonyms should have been added.
@@ -597,7 +601,8 @@ TEST(TransformationCompositeInsertTest, ApplicableCreatedSynonyms) {
       MakeInstructionDescriptor(50, SpvOpStore, 0), 51, 50, 11, {0, 1, 1});
   ASSERT_TRUE(transformation_good_2.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // These synonyms should have been added.

--- a/test/fuzz/transformation_compute_data_synonym_fact_closure_test.cpp
+++ b/test/fuzz/transformation_compute_data_synonym_fact_closure_test.cpp
@@ -166,8 +166,8 @@ TEST(TransformationComputeDataSynonymFactClosureTest, DataSynonymFacts) {
   transformation_context.GetFactManager()->AddFactDataSynonym(
       MakeDataDescriptor(27, {1}), MakeDataDescriptor(102, {1}));
 
-  TransformationComputeDataSynonymFactClosure(100).Apply(
-      context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(TransformationComputeDataSynonymFactClosure(100),
+                        context.get(), &transformation_context);
 
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(27, {}), MakeDataDescriptor(102, {})));
@@ -251,8 +251,8 @@ TEST(TransformationComputeDataSynonymFactClosureTest, DataSynonymFacts) {
   transformation_context.GetFactManager()->AddFactDataSynonym(
       MakeDataDescriptor(21, {4}), MakeDataDescriptor(100, {4}));
 
-  TransformationComputeDataSynonymFactClosure(100).Apply(
-      context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(TransformationComputeDataSynonymFactClosure(100),
+                        context.get(), &transformation_context);
 
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(21, {}), MakeDataDescriptor(100, {})));
@@ -287,8 +287,8 @@ TEST(TransformationComputeDataSynonymFactClosureTest, DataSynonymFacts) {
   transformation_context.GetFactManager()->AddFactDataSynonym(
       MakeDataDescriptor(106, {1}), MakeDataDescriptor(37, {}));
 
-  TransformationComputeDataSynonymFactClosure(100).Apply(
-      context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(TransformationComputeDataSynonymFactClosure(100),
+                        context.get(), &transformation_context);
 
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(38, {0}), MakeDataDescriptor(36, {})));
@@ -312,8 +312,8 @@ TEST(TransformationComputeDataSynonymFactClosureTest, DataSynonymFacts) {
   transformation_context.GetFactManager()->AddFactDataSynonym(
       MakeDataDescriptor(40, {2}), MakeDataDescriptor(108, {2}));
 
-  TransformationComputeDataSynonymFactClosure(100).Apply(
-      context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(TransformationComputeDataSynonymFactClosure(100),
+                        context.get(), &transformation_context);
 
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(40, {}), MakeDataDescriptor(108, {})));

--- a/test/fuzz/transformation_duplicate_region_with_selection_test.cpp
+++ b/test/fuzz/transformation_duplicate_region_with_selection_test.cpp
@@ -88,7 +88,8 @@ TEST(TransformationDuplicateRegionWithSelectionTest, BasicUseTest) {
 
   ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_1, context.get(),
+                        &transformation_context);
 
   ASSERT_TRUE(IsValid(env, context.get()));
   std::string expected_shader = R"(
@@ -218,7 +219,8 @@ TEST(TransformationDuplicateRegionWithSelectionTest, BasicExitBlockTest) {
 
   ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_1, context.get(),
+                        &transformation_context);
 
   ASSERT_TRUE(IsValid(env, context.get()));
 
@@ -799,7 +801,8 @@ TEST(TransformationDuplicateRegionWithSelectionTest, MultipleBlocksLoopTest) {
            {21, 307}});
   ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string expected_shader = R"(
@@ -975,7 +978,8 @@ TEST(TransformationDuplicateRegionWithSelectionTest,
 
   ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string expected_shader = R"(
@@ -1203,7 +1207,8 @@ TEST(TransformationDuplicateRegionWithSelectionTest,
           500, 21, 501, 50, 50, {{50, 100}}, {{51, 201}}, {{51, 301}});
   ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string expected_shader = R"(
@@ -1399,7 +1404,8 @@ TEST(TransformationDuplicateRegionWithSelectionTest,
           {{12, 301}, {14, 302}});
   ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string expected_shader = R"(
@@ -1517,7 +1523,8 @@ TEST(TransformationDuplicateRegionWithSelectionTest,
           {{12, 301}, {14, 302}});
   ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string expected_shader = R"(

--- a/test/fuzz/transformation_equation_instruction_test.cpp
+++ b/test/fuzz/transformation_equation_instruction_test.cpp
@@ -100,14 +100,16 @@ TEST(TransformationEquationInstructionTest, SignedNegate) {
       14, SpvOpSNegate, {7}, return_instruction);
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation2 = TransformationEquationInstruction(
       15, SpvOpSNegate, {14}, return_instruction);
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
@@ -189,14 +191,16 @@ TEST(TransformationEquationInstructionTest, LogicalNot) {
       14, SpvOpLogicalNot, {7}, return_instruction);
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation2 = TransformationEquationInstruction(
       15, SpvOpLogicalNot, {14}, return_instruction);
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
@@ -285,14 +289,16 @@ TEST(TransformationEquationInstructionTest, AddSubNegate1) {
       14, SpvOpIAdd, {15, 16}, return_instruction);
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation2 = TransformationEquationInstruction(
       19, SpvOpISub, {14, 16}, return_instruction);
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(15, {}), MakeDataDescriptor(19, {})));
@@ -301,7 +307,8 @@ TEST(TransformationEquationInstructionTest, AddSubNegate1) {
       20, SpvOpISub, {14, 15}, return_instruction);
   ASSERT_TRUE(
       transformation3.IsApplicable(context.get(), transformation_context));
-  transformation3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation3, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(20, {}), MakeDataDescriptor(16, {})));
@@ -310,14 +317,16 @@ TEST(TransformationEquationInstructionTest, AddSubNegate1) {
       22, SpvOpISub, {16, 14}, return_instruction);
   ASSERT_TRUE(
       transformation4.IsApplicable(context.get(), transformation_context));
-  transformation4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation4, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation5 = TransformationEquationInstruction(
       24, SpvOpSNegate, {22}, return_instruction);
   ASSERT_TRUE(
       transformation5.IsApplicable(context.get(), transformation_context));
-  transformation5.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation5, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(24, {}), MakeDataDescriptor(15, {})));
@@ -386,14 +395,16 @@ TEST(TransformationEquationInstructionTest, AddSubNegate2) {
       14, SpvOpISub, {15, 16}, return_instruction);
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation2 = TransformationEquationInstruction(
       17, SpvOpIAdd, {14, 16}, return_instruction);
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(17, {}), MakeDataDescriptor(15, {})));
@@ -402,7 +413,8 @@ TEST(TransformationEquationInstructionTest, AddSubNegate2) {
       18, SpvOpIAdd, {16, 14}, return_instruction);
   ASSERT_TRUE(
       transformation3.IsApplicable(context.get(), transformation_context));
-  transformation3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation3, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(17, {}), MakeDataDescriptor(18, {})));
@@ -413,14 +425,16 @@ TEST(TransformationEquationInstructionTest, AddSubNegate2) {
       19, SpvOpISub, {14, 15}, return_instruction);
   ASSERT_TRUE(
       transformation4.IsApplicable(context.get(), transformation_context));
-  transformation4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation4, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation5 = TransformationEquationInstruction(
       20, SpvOpSNegate, {19}, return_instruction);
   ASSERT_TRUE(
       transformation5.IsApplicable(context.get(), transformation_context));
-  transformation5.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation5, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(20, {}), MakeDataDescriptor(16, {})));
@@ -429,7 +443,8 @@ TEST(TransformationEquationInstructionTest, AddSubNegate2) {
       21, SpvOpISub, {14, 19}, return_instruction);
   ASSERT_TRUE(
       transformation6.IsApplicable(context.get(), transformation_context));
-  transformation6.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation6, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(21, {}), MakeDataDescriptor(15, {})));
@@ -438,14 +453,16 @@ TEST(TransformationEquationInstructionTest, AddSubNegate2) {
       22, SpvOpISub, {14, 18}, return_instruction);
   ASSERT_TRUE(
       transformation7.IsApplicable(context.get(), transformation_context));
-  transformation7.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation7, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation8 = TransformationEquationInstruction(
       23, SpvOpSNegate, {22}, return_instruction);
   ASSERT_TRUE(
       transformation8.IsApplicable(context.get(), transformation_context));
-  transformation8.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation8, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(23, {}), MakeDataDescriptor(16, {})));
@@ -566,7 +583,8 @@ TEST(TransformationEquationInstructionTest, Bitcast) {
         fresh_id, SpvOpBitcast, {operand_id}, insert_before);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   std::string expected_shader = R"(
@@ -739,14 +757,16 @@ TEST(TransformationEquationInstructionTest, BitcastResultTypeIntDoesNotExist2) {
                                                      insert_before);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   {
     TransformationEquationInstruction transformation(51, SpvOpBitcast, {20},
                                                      insert_before);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   std::string expected_shader = R"(
@@ -812,14 +832,16 @@ TEST(TransformationEquationInstructionTest, BitcastResultTypeIntDoesNotExist3) {
                                                      insert_before);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   {
     TransformationEquationInstruction transformation(51, SpvOpBitcast, {20},
                                                      insert_before);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   std::string expected_shader = R"(
@@ -884,7 +906,8 @@ TEST(TransformationEquationInstructionTest, BitcastResultTypeIntDoesNotExist4) {
                                                      insert_before);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   ASSERT_FALSE(
@@ -953,7 +976,8 @@ TEST(TransformationEquationInstructionTest, BitcastResultTypeIntDoesNotExist5) {
                                                      insert_before);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   ASSERT_FALSE(
@@ -1024,14 +1048,16 @@ TEST(TransformationEquationInstructionTest, BitcastResultTypeIntDoesNotExist6) {
                                                      insert_before);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   {
     TransformationEquationInstruction transformation(51, SpvOpBitcast, {20},
                                                      insert_before);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   ASSERT_TRUE(IsValid(env, context.get()));
@@ -1101,14 +1127,16 @@ TEST(TransformationEquationInstructionTest, BitcastResultTypeIntDoesNotExist7) {
                                                      insert_before);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   {
     TransformationEquationInstruction transformation(51, SpvOpBitcast, {20},
                                                      insert_before);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   ASSERT_TRUE(IsValid(env, context.get()));
@@ -1173,14 +1201,16 @@ TEST(TransformationEquationInstructionTest, Miscellaneous1) {
       522, SpvOpISub, {113, 113}, return_instruction);
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation2 = TransformationEquationInstruction(
       570, SpvOpIAdd, {522, 113}, return_instruction);
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -1241,14 +1271,16 @@ TEST(TransformationEquationInstructionTest, Miscellaneous2) {
       522, SpvOpISub, {113, 113}, return_instruction);
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation2 = TransformationEquationInstruction(
       570, SpvOpIAdd, {522, 113}, return_instruction);
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -1354,56 +1386,64 @@ TEST(TransformationEquationInstructionTest, ConversionInstructions) {
                                                      return_instruction);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   {
     TransformationEquationInstruction transformation(51, SpvOpConvertSToF, {10},
                                                      return_instruction);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   {
     TransformationEquationInstruction transformation(52, SpvOpConvertUToF, {16},
                                                      return_instruction);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   {
     TransformationEquationInstruction transformation(53, SpvOpConvertUToF, {11},
                                                      return_instruction);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   {
     TransformationEquationInstruction transformation(58, SpvOpConvertSToF, {18},
                                                      return_instruction);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   {
     TransformationEquationInstruction transformation(59, SpvOpConvertUToF, {19},
                                                      return_instruction);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   {
     TransformationEquationInstruction transformation(60, SpvOpConvertSToF, {20},
                                                      return_instruction);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   {
     TransformationEquationInstruction transformation(61, SpvOpConvertUToF, {21},
                                                      return_instruction);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   ASSERT_TRUE(IsValid(env, context.get()));

--- a/test/fuzz/transformation_flatten_conditional_branch_test.cpp
+++ b/test/fuzz/transformation_flatten_conditional_branch_test.cpp
@@ -492,9 +492,11 @@ TEST(TransformationFlattenConditionalBranchTest, LoadStoreFunctionCall) {
   ASSERT_TRUE(transformation_context.GetFactManager()->IdIsIrrelevant(103));
 
   // Make a new transformation context with a source of overflow ids.
+  auto overflow_ids_unique_ptr = MakeUnique<CounterOverflowIdSource>(1000);
+  auto overflow_ids_ptr = overflow_ids_unique_ptr.get();
   TransformationContext new_transformation_context(
       MakeUnique<FactManager>(context.get()), validator_options,
-      MakeUnique<CounterOverflowIdSource>(1000));
+      std::move(overflow_ids_unique_ptr));
 
   auto transformation2 = TransformationFlattenConditionalBranch(
       36, false,
@@ -503,7 +505,8 @@ TEST(TransformationFlattenConditionalBranchTest, LoadStoreFunctionCall) {
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), new_transformation_context));
   ApplyAndCheckFreshIds(transformation2, context.get(),
-                        &new_transformation_context);
+                        &new_transformation_context,
+                        overflow_ids_ptr->GetIssuedOverflowIds());
 
   ASSERT_TRUE(IsValid(env, context.get()));
 

--- a/test/fuzz/transformation_flatten_conditional_branch_test.cpp
+++ b/test/fuzz/transformation_flatten_conditional_branch_test.cpp
@@ -244,22 +244,26 @@ TEST(TransformationFlattenConditionalBranchTest, Simple) {
   auto transformation1 = TransformationFlattenConditionalBranch(7, true, {});
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
 
   auto transformation2 = TransformationFlattenConditionalBranch(13, false, {});
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
 
   auto transformation3 = TransformationFlattenConditionalBranch(15, true, {});
   ASSERT_TRUE(
       transformation3.IsApplicable(context.get(), transformation_context));
-  transformation3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation3, context.get(),
+                        &transformation_context);
 
   auto transformation4 = TransformationFlattenConditionalBranch(22, false, {});
   ASSERT_TRUE(
       transformation4.IsApplicable(context.get(), transformation_context));
-  transformation4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation4, context.get(),
+                        &transformation_context);
 
   ASSERT_TRUE(IsValid(env, context.get()));
 
@@ -481,7 +485,8 @@ TEST(TransformationFlattenConditionalBranchTest, LoadStoreFunctionCall) {
                                  106, 105)});
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
 
   // Check that the placeholder id was marked as irrelevant.
   ASSERT_TRUE(transformation_context.GetFactManager()->IdIsIrrelevant(103));
@@ -497,7 +502,8 @@ TEST(TransformationFlattenConditionalBranchTest, LoadStoreFunctionCall) {
                                  114, 113)});
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), new_transformation_context));
-  transformation2.Apply(context.get(), &new_transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &new_transformation_context);
 
   ASSERT_TRUE(IsValid(env, context.get()));
 
@@ -697,7 +703,8 @@ TEST(TransformationFlattenConditionalBranchTest, EdgeCases) {
           MakeInstructionDescriptor(10, SpvOpFunctionCall, 0), 100, 101)}});
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
 
   // The selection construct headed by %8 cannot be flattened because it
   // contains a function call returning void, whose result id is used.
@@ -715,7 +722,8 @@ TEST(TransformationFlattenConditionalBranchTest, EdgeCases) {
   auto transformation2 = TransformationFlattenConditionalBranch(20, false, {});
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
 
   ASSERT_TRUE(IsValid(env, context.get()));
 

--- a/test/fuzz/transformation_function_call_test.cpp
+++ b/test/fuzz/transformation_function_call_test.cpp
@@ -256,7 +256,8 @@ TEST(TransformationFunctionCallTest, BasicTest) {
         100, 21, {71, 72}, MakeInstructionDescriptor(59, SpvOpBranch, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
   {
@@ -265,7 +266,8 @@ TEST(TransformationFunctionCallTest, BasicTest) {
         101, 21, {71, 72}, MakeInstructionDescriptor(98, SpvOpAccessChain, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
   {
@@ -274,7 +276,8 @@ TEST(TransformationFunctionCallTest, BasicTest) {
         102, 200, {19, 20}, MakeInstructionDescriptor(36, SpvOpLoad, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
   {
@@ -283,7 +286,8 @@ TEST(TransformationFunctionCallTest, BasicTest) {
         103, 10, {23}, MakeInstructionDescriptor(45, SpvOpLoad, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
   {
@@ -292,7 +296,8 @@ TEST(TransformationFunctionCallTest, BasicTest) {
         104, 10, {201}, MakeInstructionDescriptor(205, SpvOpBranch, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
   {
@@ -301,7 +306,8 @@ TEST(TransformationFunctionCallTest, BasicTest) {
         105, 21, {62, 65}, MakeInstructionDescriptor(59, SpvOpBranch, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 

--- a/test/fuzz/transformation_inline_function_test.cpp
+++ b/test/fuzz/transformation_inline_function_test.cpp
@@ -291,7 +291,7 @@ TEST(TransformationInlineFunctionTest, Apply) {
                                                           {36, 59},
                                                           {37, 60},
                                                           {38, 61}});
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string variant_shader = R"(
                OpCapability Shader
@@ -515,7 +515,7 @@ TEST(TransformationInlineFunctionTest, ApplyToMultipleFunctions) {
   auto transformation = TransformationInlineFunction(30, {});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   // Tests a parameter included in the id map.
   transformation = TransformationInlineFunction(25, {{55, 69},
@@ -559,7 +559,7 @@ TEST(TransformationInlineFunctionTest, ApplyToMultipleFunctions) {
                                                      {66, 78}});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   transformation = TransformationInlineFunction(21, {{39, 79},
                                                      {40, 80},
@@ -578,7 +578,7 @@ TEST(TransformationInlineFunctionTest, ApplyToMultipleFunctions) {
                                                      {53, 93}});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string variant_shader = R"(
                OpCapability Shader
@@ -785,7 +785,7 @@ TEST(TransformationInlineFunctionTest, HandlesOpPhisInTheSecondBlock) {
                                               {{{8, 20}, {13, 21}, {12, 22}}});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(

--- a/test/fuzz/transformation_invert_comparison_operator_test.cpp
+++ b/test/fuzz/transformation_invert_comparison_operator_test.cpp
@@ -80,7 +80,8 @@ TEST(TransformationInvertComparisonOperatorTest, BasicTest) {
                                                           fresh_id);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   std::string expected = R"(

--- a/test/fuzz/transformation_load_test.cpp
+++ b/test/fuzz/transformation_load_test.cpp
@@ -188,7 +188,8 @@ TEST(TransformationLoadTest, BasicTest) {
         100, 33, MakeInstructionDescriptor(38, SpvOpAccessChain, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -197,7 +198,8 @@ TEST(TransformationLoadTest, BasicTest) {
         101, 46, MakeInstructionDescriptor(16, SpvOpReturnValue, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -206,7 +208,8 @@ TEST(TransformationLoadTest, BasicTest) {
         102, 16, MakeInstructionDescriptor(16, SpvOpReturnValue, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -215,7 +218,8 @@ TEST(TransformationLoadTest, BasicTest) {
         103, 40, MakeInstructionDescriptor(43, SpvOpAccessChain, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 

--- a/test/fuzz/transformation_make_vector_operation_dynamic_test.cpp
+++ b/test/fuzz/transformation_make_vector_operation_dynamic_test.cpp
@@ -210,92 +210,92 @@ TEST(TransformationMakeVectorOperationDynamicTest, Apply) {
   auto transformation = TransformationMakeVectorOperationDynamic(22, 9);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   transformation = TransformationMakeVectorOperationDynamic(23, 10);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   transformation = TransformationMakeVectorOperationDynamic(24, 9);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   transformation = TransformationMakeVectorOperationDynamic(25, 10);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   transformation = TransformationMakeVectorOperationDynamic(26, 11);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   transformation = TransformationMakeVectorOperationDynamic(27, 9);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   transformation = TransformationMakeVectorOperationDynamic(28, 10);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   transformation = TransformationMakeVectorOperationDynamic(29, 11);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   transformation = TransformationMakeVectorOperationDynamic(30, 12);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   transformation = TransformationMakeVectorOperationDynamic(31, 9);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   transformation = TransformationMakeVectorOperationDynamic(32, 10);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   transformation = TransformationMakeVectorOperationDynamic(33, 9);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   transformation = TransformationMakeVectorOperationDynamic(34, 10);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   transformation = TransformationMakeVectorOperationDynamic(35, 11);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   transformation = TransformationMakeVectorOperationDynamic(36, 9);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   transformation = TransformationMakeVectorOperationDynamic(37, 10);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   transformation = TransformationMakeVectorOperationDynamic(38, 11);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   transformation = TransformationMakeVectorOperationDynamic(39, 12);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string variant_shader = R"(
                OpCapability Shader

--- a/test/fuzz/transformation_merge_blocks_test.cpp
+++ b/test/fuzz/transformation_merge_blocks_test.cpp
@@ -169,7 +169,7 @@ TEST(TransformationMergeBlocksTest, MergeWhenSecondBlockIsSelectionMerge) {
   TransformationMergeBlocks transformation(10);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -241,7 +241,7 @@ TEST(TransformationMergeBlocksTest, MergeWhenSecondBlockIsLoopMerge) {
   TransformationMergeBlocks transformation(10);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -318,7 +318,7 @@ TEST(TransformationMergeBlocksTest, MergeWhenSecondBlockIsLoopContinue) {
   TransformationMergeBlocks transformation(11);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -391,7 +391,7 @@ TEST(TransformationMergeBlocksTest, MergeWhenSecondBlockStartsWithOpPhi) {
   TransformationMergeBlocks transformation(6);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -472,7 +472,8 @@ TEST(TransformationMergeBlocksTest, BasicMerge) {
         TransformationMergeBlocks(102), TransformationMergeBlocks(103)}) {
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -561,7 +562,8 @@ TEST(TransformationMergeBlocksTest, MergeWhenSecondBlockIsSelectionHeader) {
        {TransformationMergeBlocks(101), TransformationMergeBlocks(100)}) {
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -649,7 +651,7 @@ TEST(TransformationMergeBlocksTest,
   TransformationMergeBlocks transformation(101);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(

--- a/test/fuzz/transformation_move_block_down_test.cpp
+++ b/test/fuzz/transformation_move_block_down_test.cpp
@@ -332,7 +332,7 @@ TEST(TransformationMoveBlockDownTest, ManyMovesPossible) {
 
   // Let's bubble 20 all the way down.
 
-  move_down_20.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(move_down_20, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Current ordering: 5 14 23 20 21 25 29 32 30 15
@@ -350,7 +350,7 @@ TEST(TransformationMoveBlockDownTest, ManyMovesPossible) {
   ASSERT_FALSE(
       move_down_15.IsApplicable(context.get(), transformation_context));
 
-  move_down_20.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(move_down_20, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Current ordering: 5 14 23 21 20 25 29 32 30 15
@@ -368,7 +368,7 @@ TEST(TransformationMoveBlockDownTest, ManyMovesPossible) {
   ASSERT_FALSE(
       move_down_15.IsApplicable(context.get(), transformation_context));
 
-  move_down_20.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(move_down_20, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Current ordering: 5 14 23 21 25 20 29 32 30 15
@@ -385,7 +385,7 @@ TEST(TransformationMoveBlockDownTest, ManyMovesPossible) {
   ASSERT_FALSE(
       move_down_15.IsApplicable(context.get(), transformation_context));
 
-  move_down_20.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(move_down_20, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Current ordering: 5 14 23 21 25 29 20 32 30 15
@@ -403,7 +403,7 @@ TEST(TransformationMoveBlockDownTest, ManyMovesPossible) {
   ASSERT_FALSE(
       move_down_15.IsApplicable(context.get(), transformation_context));
 
-  move_down_20.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(move_down_20, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Current ordering: 5 14 23 21 25 29 32 20 30 15
@@ -421,7 +421,7 @@ TEST(TransformationMoveBlockDownTest, ManyMovesPossible) {
   ASSERT_FALSE(
       move_down_15.IsApplicable(context.get(), transformation_context));
 
-  move_down_20.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(move_down_20, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Current ordering: 5 14 23 21 25 29 32 30 20 15
@@ -439,7 +439,7 @@ TEST(TransformationMoveBlockDownTest, ManyMovesPossible) {
   ASSERT_FALSE(
       move_down_15.IsApplicable(context.get(), transformation_context));
 
-  move_down_20.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(move_down_20, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_bubbling_20_down = R"(
@@ -529,7 +529,7 @@ TEST(TransformationMoveBlockDownTest, ManyMovesPossible) {
   ASSERT_FALSE(
       move_down_20.IsApplicable(context.get(), transformation_context));
 
-  move_down_23.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(move_down_23, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Current ordering: 5 14 21 23 25 29 32 30 15 20
@@ -547,7 +547,7 @@ TEST(TransformationMoveBlockDownTest, ManyMovesPossible) {
   ASSERT_FALSE(
       move_down_20.IsApplicable(context.get(), transformation_context));
 
-  move_down_23.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(move_down_23, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Current ordering: 5 14 21 25 23 29 32 30 15 20
@@ -564,7 +564,7 @@ TEST(TransformationMoveBlockDownTest, ManyMovesPossible) {
   ASSERT_FALSE(
       move_down_20.IsApplicable(context.get(), transformation_context));
 
-  move_down_21.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(move_down_21, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Current ordering: 5 14 25 21 23 29 32 30 15 20
@@ -580,7 +580,7 @@ TEST(TransformationMoveBlockDownTest, ManyMovesPossible) {
   ASSERT_FALSE(
       move_down_20.IsApplicable(context.get(), transformation_context));
 
-  move_down_14.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(move_down_14, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_more_shuffling = R"(

--- a/test/fuzz/transformation_move_instruction_down_test.cpp
+++ b/test/fuzz/transformation_move_instruction_down_test.cpp
@@ -111,7 +111,8 @@ TEST(TransformationMoveInstructionDownTest, BasicTest) {
         MakeInstructionDescriptor(11, SpvOpISub, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
   {
@@ -119,7 +120,8 @@ TEST(TransformationMoveInstructionDownTest, BasicTest) {
         MakeInstructionDescriptor(22, SpvOpIAdd, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -225,7 +227,7 @@ TEST(TransformationMoveInstructionDownTest, HandlesUnsupportedInstructions) {
       MakeInstructionDescriptor(8, SpvOpCopyObject, 0));
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -332,7 +334,8 @@ TEST(TransformationMoveInstructionDownTest, HandlesBarrierInstructions) {
         MakeInstructionDescriptor(23, SpvOpCopyObject, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
   {
@@ -340,7 +343,8 @@ TEST(TransformationMoveInstructionDownTest, HandlesBarrierInstructions) {
         MakeInstructionDescriptor(22, SpvOpMemoryBarrier, 1));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -398,7 +402,8 @@ TEST(TransformationMoveInstructionDownTest, HandlesSimpleInstructions) {
         MakeInstructionDescriptor(40, SpvOpCopyObject, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
   {
@@ -406,7 +411,8 @@ TEST(TransformationMoveInstructionDownTest, HandlesSimpleInstructions) {
         MakeInstructionDescriptor(21, SpvOpMemoryBarrier, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -416,7 +422,8 @@ TEST(TransformationMoveInstructionDownTest, HandlesSimpleInstructions) {
         MakeInstructionDescriptor(41, SpvOpCopyObject, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
   {
@@ -424,7 +431,8 @@ TEST(TransformationMoveInstructionDownTest, HandlesSimpleInstructions) {
         MakeInstructionDescriptor(22, SpvOpLoad, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -434,7 +442,8 @@ TEST(TransformationMoveInstructionDownTest, HandlesSimpleInstructions) {
         MakeInstructionDescriptor(23, SpvOpCopyObject, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -685,7 +694,8 @@ TEST(TransformationMoveInstructionDownTest, HandlesMemoryInstructions) {
     TransformationMoveInstructionDown transformation(descriptor);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 

--- a/test/fuzz/transformation_mutate_pointer_test.cpp
+++ b/test/fuzz/transformation_mutate_pointer_test.cpp
@@ -154,7 +154,8 @@ TEST(TransformationMutatePointerTest, BasicTest) {
                                                insert_before);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -285,7 +286,7 @@ TEST(TransformationMutatePointerTest, HandlesUnreachableBlocks) {
   TransformationMutatePointer transformation(12, 50, insert_before);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(

--- a/test/fuzz/transformation_outline_function_test.cpp
+++ b/test/fuzz/transformation_outline_function_test.cpp
@@ -2815,9 +2815,11 @@ TEST(TransformationOutlineFunctionTest, Miscellaneous1) {
     const auto context =
         BuildModule(env, consumer, reference_shader, kFuzzAssembleOption);
     ASSERT_TRUE(IsValid(env, context.get()));
+    auto overflow_ids_unique_ptr = MakeUnique<CounterOverflowIdSource>(2000);
+    auto overflow_ids_ptr = overflow_ids_unique_ptr.get();
     TransformationContext new_transformation_context(
         MakeUnique<FactManager>(context.get()), validator_options,
-        MakeUnique<CounterOverflowIdSource>(2000));
+        std::move(overflow_ids_unique_ptr));
     ASSERT_TRUE(transformation_with_missing_input_id.IsApplicable(
         context.get(), new_transformation_context));
     ASSERT_TRUE(transformation_with_missing_output_id.IsApplicable(
@@ -2825,7 +2827,8 @@ TEST(TransformationOutlineFunctionTest, Miscellaneous1) {
     ASSERT_TRUE(transformation_with_missing_input_and_output_ids.IsApplicable(
         context.get(), new_transformation_context));
     ApplyAndCheckFreshIds(transformation_with_missing_input_and_output_ids,
-                          context.get(), &new_transformation_context);
+                          context.get(), &new_transformation_context,
+                          overflow_ids_ptr->GetIssuedOverflowIds());
     ASSERT_TRUE(IsValid(env, context.get()));
 
     std::string variant_shader = R"(

--- a/test/fuzz/transformation_outline_function_test.cpp
+++ b/test/fuzz/transformation_outline_function_test.cpp
@@ -53,7 +53,7 @@ TEST(TransformationOutlineFunctionTest, TrivialOutline) {
                                                /* not relevant */ 201, {}, {});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -171,7 +171,7 @@ TEST(TransformationOutlineFunctionTest, OutlineInterestingControlFlowNoState) {
                                                /* not relevant */ 201, {}, {});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -258,7 +258,7 @@ TEST(TransformationOutlineFunctionTest, OutlineCodeThatGeneratesUnusedIds) {
                                                /* not relevant */ 201, {}, {});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -333,7 +333,7 @@ TEST(TransformationOutlineFunctionTest, OutlineCodeThatGeneratesSingleUsedId) {
                                                105, {}, {{9, 104}});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -431,7 +431,7 @@ TEST(TransformationOutlineFunctionTest, OutlineDiamondThatGeneratesSeveralIds) {
       {{15, 106}, {9, 107}, {7, 108}, {8, 109}});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -528,7 +528,7 @@ TEST(TransformationOutlineFunctionTest, OutlineCodeThatUsesASingleId) {
                                                105, {{7, 106}}, {});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -604,7 +604,7 @@ TEST(TransformationOutlineFunctionTest, OutlineCodeThatUsesAVariable) {
                                                105, {{13, 106}}, {});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -690,7 +690,7 @@ TEST(TransformationOutlineFunctionTest, OutlineCodeThatUsesAParameter) {
                                                105, {{9, 106}}, {{14, 107}});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -1186,7 +1186,7 @@ TEST(TransformationOutlineFunctionTest, OutlineRegionEndingWithReturnVoid) {
 
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -1275,7 +1275,7 @@ TEST(TransformationOutlineFunctionTest, OutlineRegionEndingWithReturnValue) {
 
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -1368,7 +1368,7 @@ TEST(TransformationOutlineFunctionTest,
 
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -1456,7 +1456,7 @@ TEST(TransformationOutlineFunctionTest,
 
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -1833,7 +1833,7 @@ TEST(TransformationOutlineFunctionTest,
 
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -1993,7 +1993,7 @@ TEST(TransformationOutlineFunctionTest, OutlineLivesafe) {
 
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // The original function should still be livesafe.
@@ -2218,7 +2218,7 @@ TEST(TransformationOutlineFunctionTest, OutlineWithDeadBlocks1) {
 
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   // All the original blocks, plus the new function entry block, should be dead.
   for (uint32_t block_id : {16u, 23u, 24u, 26u, 27u, 34u, 35u, 50u, 203u}) {
@@ -2300,7 +2300,7 @@ TEST(TransformationOutlineFunctionTest, OutlineWithDeadBlocks2) {
 
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   // The blocks that were originally dead, but not others, should be dead.
   for (uint32_t block_id : {32u, 34u, 35u}) {
@@ -2383,7 +2383,7 @@ TEST(TransformationOutlineFunctionTest,
 
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   // The variables that were originally irrelevant, plus input parameters
   // corresponding to them, should be irrelevant.  The rest should not be.
@@ -2509,7 +2509,7 @@ TEST(TransformationOutlineFunctionTest, ExitBlockHeadsLoop) {
 
   ASSERT_FALSE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 }
 
 TEST(TransformationOutlineFunctionTest, Miscellaneous1) {
@@ -2693,7 +2693,8 @@ TEST(TransformationOutlineFunctionTest, Miscellaneous1) {
 
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
 
     std::string variant_shader = R"(
@@ -2823,8 +2824,8 @@ TEST(TransformationOutlineFunctionTest, Miscellaneous1) {
         context.get(), new_transformation_context));
     ASSERT_TRUE(transformation_with_missing_input_and_output_ids.IsApplicable(
         context.get(), new_transformation_context));
-    transformation_with_missing_input_and_output_ids.Apply(
-        context.get(), &new_transformation_context);
+    ApplyAndCheckFreshIds(transformation_with_missing_input_and_output_ids,
+                          context.get(), &new_transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
 
     std::string variant_shader = R"(
@@ -3049,7 +3050,7 @@ TEST(TransformationOutlineFunctionTest, Miscellaneous3) {
 
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -3140,7 +3141,7 @@ TEST(TransformationOutlineFunctionTest, Miscellaneous4) {
 
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(

--- a/test/fuzz/transformation_permute_function_parameters_test.cpp
+++ b/test/fuzz/transformation_permute_function_parameters_test.cpp
@@ -292,35 +292,40 @@ TEST(TransformationPermuteFunctionParametersTest, BasicTest) {
     TransformationPermuteFunctionParameters transformation(12, 105, {1, 0});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
   {
     TransformationPermuteFunctionParameters transformation(28, 106, {1, 0});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
   {
     TransformationPermuteFunctionParameters transformation(200, 107, {1, 0});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
   {
     TransformationPermuteFunctionParameters transformation(219, 108, {1, 0});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
   {
     TransformationPermuteFunctionParameters transformation(229, 109, {1, 0});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 

--- a/test/fuzz/transformation_permute_phi_operands_test.cpp
+++ b/test/fuzz/transformation_permute_phi_operands_test.cpp
@@ -101,7 +101,7 @@ TEST(TransformationPermutePhiOperandsTest, BasicTest) {
   TransformationPermutePhiOperands transformation(25, {1, 0});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string after_transformation = R"(
                OpCapability Shader

--- a/test/fuzz/transformation_propagate_instruction_up_test.cpp
+++ b/test/fuzz/transformation_propagate_instruction_up_test.cpp
@@ -112,14 +112,16 @@ TEST(TransformationPropagateInstructionUpTest, BasicTest) {
     TransformationPropagateInstructionUp transformation(14, {{{5, 40}}});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
   {
     TransformationPropagateInstructionUp transformation(19, {{{5, 41}}});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -179,7 +181,8 @@ TEST(TransformationPropagateInstructionUpTest, BasicTest) {
                                                         {{{14, 43}, {19, 44}}});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -241,7 +244,8 @@ TEST(TransformationPropagateInstructionUpTest, BasicTest) {
                                                         {{{14, 45}, {19, 46}}});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -362,7 +366,7 @@ TEST(TransformationPropagateInstructionUpTest, BlockDominatesPredecessor1) {
       15, {{{14, 40}, {19, 41}, {26, 42}}});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -479,7 +483,7 @@ TEST(TransformationPropagateInstructionUpTest, BlockDominatesPredecessor2) {
       15, {{{14, 40}, {19, 41}, {26, 42}}});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -592,7 +596,7 @@ TEST(TransformationPropagateInstructionUpTest, BlockDominatesPredecessor3) {
       15, {{{14, 40}, {19, 41}, {15, 42}}});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -690,7 +694,7 @@ TEST(TransformationPropagateInstructionUpTest,
 
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -769,7 +773,7 @@ TEST(TransformationPropagateInstructionUpTest,
 
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(
@@ -842,7 +846,7 @@ TEST(TransformationPropagateInstructionUpTest, MultipleIdenticalPredecessors) {
   TransformationPropagateInstructionUp transformation(9, {{{5, 40}}});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(

--- a/test/fuzz/transformation_push_id_through_variable_test.cpp
+++ b/test/fuzz/transformation_push_id_through_variable_test.cpp
@@ -338,7 +338,7 @@ TEST(TransformationPushIdThroughVariableTest, Apply) {
   auto transformation = TransformationPushIdThroughVariable(
       value_id, value_synonym_id, variable_id, variable_storage_class,
       initializer_id, instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   value_id = 21;
   value_synonym_id = 102;
@@ -349,7 +349,7 @@ TEST(TransformationPushIdThroughVariableTest, Apply) {
   transformation = TransformationPushIdThroughVariable(
       value_id, value_synonym_id, variable_id, variable_storage_class,
       initializer_id, instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   value_id = 95;
   value_synonym_id = 104;
@@ -360,7 +360,7 @@ TEST(TransformationPushIdThroughVariableTest, Apply) {
   transformation = TransformationPushIdThroughVariable(
       value_id, value_synonym_id, variable_id, variable_storage_class,
       initializer_id, instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   value_id = 80;
   value_synonym_id = 106;
@@ -371,7 +371,7 @@ TEST(TransformationPushIdThroughVariableTest, Apply) {
   transformation = TransformationPushIdThroughVariable(
       value_id, value_synonym_id, variable_id, variable_storage_class,
       initializer_id, instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   value_id = 21;
   value_synonym_id = 108;
@@ -382,7 +382,7 @@ TEST(TransformationPushIdThroughVariableTest, Apply) {
   transformation = TransformationPushIdThroughVariable(
       value_id, value_synonym_id, variable_id, variable_storage_class,
       initializer_id, instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   value_id = 23;
   value_synonym_id = 110;
@@ -393,7 +393,7 @@ TEST(TransformationPushIdThroughVariableTest, Apply) {
   transformation = TransformationPushIdThroughVariable(
       value_id, value_synonym_id, variable_id, variable_storage_class,
       initializer_id, instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string variant_shader = R"(
                OpCapability Shader
@@ -587,7 +587,7 @@ TEST(TransformationPushIdThroughVariableTest, AddSynonymsForRelevantIds) {
       initializer_id, instruction_descriptor);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(21, {}), MakeDataDescriptor(62, {})));
@@ -688,7 +688,7 @@ TEST(TransformationPushIdThroughVariableTest, DontAddSynonymsForIrrelevantIds) {
       initializer_id, instruction_descriptor);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_FALSE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(21, {}), MakeDataDescriptor(62, {})));

--- a/test/fuzz/transformation_record_synonymous_constants_test.cpp
+++ b/test/fuzz/transformation_record_synonymous_constants_test.cpp
@@ -27,8 +27,9 @@ namespace {
 void ApplyTransformationAndCheckFactManager(
     uint32_t constant1_id, uint32_t constant2_id, opt::IRContext* ir_context,
     TransformationContext* transformation_context) {
-  TransformationRecordSynonymousConstants(constant1_id, constant2_id)
-      .Apply(ir_context, transformation_context);
+  ApplyAndCheckFreshIds(
+      TransformationRecordSynonymousConstants(constant1_id, constant2_id),
+      ir_context, transformation_context);
 
   ASSERT_TRUE(transformation_context->GetFactManager()->IsSynonymous(
       MakeDataDescriptor(constant1_id, {}),

--- a/test/fuzz/transformation_replace_add_sub_mul_with_carrying_extended_test.cpp
+++ b/test/fuzz/transformation_replace_add_sub_mul_with_carrying_extended_test.cpp
@@ -408,56 +408,64 @@ TEST(TransformationReplaceAddSubMulWithCarryingExtendedTest,
       TransformationReplaceAddSubMulWithCarryingExtended(80, 15);
   ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation_good_2 =
       TransformationReplaceAddSubMulWithCarryingExtended(81, 18);
   ASSERT_TRUE(transformation_good_2.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation_good_3 =
       TransformationReplaceAddSubMulWithCarryingExtended(82, 21);
   ASSERT_TRUE(transformation_good_3.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_3, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation_good_4 =
       TransformationReplaceAddSubMulWithCarryingExtended(83, 31);
   ASSERT_TRUE(transformation_good_4.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_4, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation_good_5 =
       TransformationReplaceAddSubMulWithCarryingExtended(84, 42);
   ASSERT_TRUE(transformation_good_5.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_5.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_5, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation_good_6 =
       TransformationReplaceAddSubMulWithCarryingExtended(85, 45);
   ASSERT_TRUE(transformation_good_6.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_6.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_6, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation_good_7 =
       TransformationReplaceAddSubMulWithCarryingExtended(86, 48);
   ASSERT_TRUE(transformation_good_7.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_7.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_7, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation_good_8 =
       TransformationReplaceAddSubMulWithCarryingExtended(87, 59);
   ASSERT_TRUE(transformation_good_8.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_8.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_8, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(

--- a/test/fuzz/transformation_replace_boolean_constant_with_constant_binary_test.cpp
+++ b/test/fuzz/transformation_replace_boolean_constant_with_constant_binary_test.cpp
@@ -290,23 +290,23 @@ TEST(TransformationReplaceBooleanConstantWithConstantBinaryTest,
 
   ASSERT_TRUE(replace_true_with_double_comparison.IsApplicable(
       context.get(), transformation_context));
-  replace_true_with_double_comparison.Apply(context.get(),
-                                            &transformation_context);
+  ApplyAndCheckFreshIds(replace_true_with_double_comparison, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(replace_true_with_uint32_comparison.IsApplicable(
       context.get(), transformation_context));
-  replace_true_with_uint32_comparison.Apply(context.get(),
-                                            &transformation_context);
+  ApplyAndCheckFreshIds(replace_true_with_uint32_comparison, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(replace_false_with_float_comparison.IsApplicable(
       context.get(), transformation_context));
-  replace_false_with_float_comparison.Apply(context.get(),
-                                            &transformation_context);
+  ApplyAndCheckFreshIds(replace_false_with_float_comparison, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(replace_false_with_sint64_comparison.IsApplicable(
       context.get(), transformation_context));
-  replace_false_with_sint64_comparison.Apply(context.get(),
-                                             &transformation_context);
+  ApplyAndCheckFreshIds(replace_false_with_sint64_comparison, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after = R"(
@@ -550,12 +550,12 @@ TEST(TransformationReplaceBooleanConstantWithConstantBinaryTest,
 
   ASSERT_TRUE(
       replacement_1.IsApplicable(context.get(), transformation_context));
-  replacement_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement_1, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(
       replacement_2.IsApplicable(context.get(), transformation_context));
-  replacement_2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement_2, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after = R"(
@@ -658,7 +658,7 @@ TEST(TransformationReplaceBooleanConstantWithConstantBinaryTest, OpPhi) {
       id_use_descriptor, 6, 7, SpvOpULessThan, 15);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string variant_shader = R"(
                OpCapability Shader

--- a/test/fuzz/transformation_replace_constant_with_uniform_test.cpp
+++ b/test/fuzz/transformation_replace_constant_with_uniform_test.cpp
@@ -185,8 +185,8 @@ TEST(TransformationReplaceConstantWithUniformTest, BasicReplacements) {
                    .IsApplicable(context.get(), transformation_context));
 
   // Apply the use of 9 in a store.
-  transformation_use_of_9_in_store.Apply(context.get(),
-                                         &transformation_context);
+  ApplyAndCheckFreshIds(transformation_use_of_9_in_store, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   std::string after_replacing_use_of_9_in_store = R"(
                OpCapability Shader
@@ -240,7 +240,8 @@ TEST(TransformationReplaceConstantWithUniformTest, BasicReplacements) {
   ASSERT_TRUE(transformation_use_of_11_in_add.IsApplicable(
       context.get(), transformation_context));
   // Apply the use of 11 in an add.
-  transformation_use_of_11_in_add.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_use_of_11_in_add, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   std::string after_replacing_use_of_11_in_add = R"(
                OpCapability Shader
@@ -296,7 +297,8 @@ TEST(TransformationReplaceConstantWithUniformTest, BasicReplacements) {
   ASSERT_TRUE(transformation_use_of_14_in_add.IsApplicable(
       context.get(), transformation_context));
   // Apply the use of 15 in an add.
-  transformation_use_of_14_in_add.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_use_of_14_in_add, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   std::string after_replacing_use_of_14_in_add = R"(
                OpCapability Shader
@@ -523,8 +525,8 @@ TEST(TransformationReplaceConstantWithUniformTest, NestedStruct) {
   ASSERT_TRUE(transformation_use_of_20_in_store.IsApplicable(
       context.get(), transformation_context));
 
-  transformation_use_of_13_in_store.Apply(context.get(),
-                                          &transformation_context);
+  ApplyAndCheckFreshIds(transformation_use_of_13_in_store, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_FALSE(transformation_use_of_13_in_store.IsApplicable(
       context.get(), transformation_context));
@@ -535,7 +537,8 @@ TEST(TransformationReplaceConstantWithUniformTest, NestedStruct) {
   ASSERT_TRUE(transformation_use_of_20_in_store.IsApplicable(
       context.get(), transformation_context));
 
-  transformation_use_of_15_in_add.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_use_of_15_in_add, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_FALSE(transformation_use_of_13_in_store.IsApplicable(
       context.get(), transformation_context));
@@ -546,7 +549,8 @@ TEST(TransformationReplaceConstantWithUniformTest, NestedStruct) {
   ASSERT_TRUE(transformation_use_of_20_in_store.IsApplicable(
       context.get(), transformation_context));
 
-  transformation_use_of_17_in_add.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_use_of_17_in_add, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_FALSE(transformation_use_of_13_in_store.IsApplicable(
       context.get(), transformation_context));
@@ -557,8 +561,8 @@ TEST(TransformationReplaceConstantWithUniformTest, NestedStruct) {
   ASSERT_TRUE(transformation_use_of_20_in_store.IsApplicable(
       context.get(), transformation_context));
 
-  transformation_use_of_20_in_store.Apply(context.get(),
-                                          &transformation_context);
+  ApplyAndCheckFreshIds(transformation_use_of_20_in_store, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_FALSE(transformation_use_of_13_in_store.IsApplicable(
       context.get(), transformation_context));
@@ -1294,7 +1298,8 @@ TEST(TransformationReplaceConstantWithUniformTest, ComplexReplacements) {
   for (auto& transformation : transformations) {
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -1568,7 +1573,8 @@ TEST(TransformationReplaceConstantWithUniformTest, ReplaceOpPhiOperand) {
         int_descriptor, 50, 51);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 

--- a/test/fuzz/transformation_replace_copy_memory_with_load_store_test.cpp
+++ b/test/fuzz/transformation_replace_copy_memory_with_load_store_test.cpp
@@ -94,14 +94,16 @@ TEST(TransformationReplaceCopyMemoryWithLoadStoreTest, BasicScenarios) {
       20, instruction_descriptor_valid_1);
   ASSERT_TRUE(transformation_valid_1.IsApplicable(context.get(),
                                                   transformation_context));
-  transformation_valid_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_valid_1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation_valid_2 = TransformationReplaceCopyMemoryWithLoadStore(
       21, instruction_descriptor_valid_2);
   ASSERT_TRUE(transformation_valid_2.IsApplicable(context.get(),
                                                   transformation_context));
-  transformation_valid_2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_valid_2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(

--- a/test/fuzz/transformation_replace_copy_object_with_store_load_test.cpp
+++ b/test/fuzz/transformation_replace_copy_object_with_store_load_test.cpp
@@ -125,14 +125,16 @@ TEST(TransformationReplaceCopyObjectWithStoreLoad, BasicScenarios) {
       27, 30, SpvStorageClassFunction, 9);
   ASSERT_TRUE(transformation_valid_1.IsApplicable(context.get(),
                                                   transformation_context));
-  transformation_valid_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_valid_1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation_valid_2 = TransformationReplaceCopyObjectWithStoreLoad(
       28, 32, SpvStorageClassPrivate, 15);
   ASSERT_TRUE(transformation_valid_2.IsApplicable(context.get(),
                                                   transformation_context));
-  transformation_valid_2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_valid_2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformation = R"(

--- a/test/fuzz/transformation_replace_id_with_synonym_test.cpp
+++ b/test/fuzz/transformation_replace_id_with_synonym_test.cpp
@@ -303,7 +303,8 @@ TEST(TransformationReplaceIdWithSynonymTest, LegalTransformations) {
       210);
   ASSERT_TRUE(global_constant_synonym.IsApplicable(context.get(),
                                                    transformation_context));
-  global_constant_synonym.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(global_constant_synonym, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto replace_vector_access_chain_index = TransformationReplaceIdWithSynonym(
@@ -312,8 +313,8 @@ TEST(TransformationReplaceIdWithSynonymTest, LegalTransformations) {
       204);
   ASSERT_TRUE(replace_vector_access_chain_index.IsApplicable(
       context.get(), transformation_context));
-  replace_vector_access_chain_index.Apply(context.get(),
-                                          &transformation_context);
+  ApplyAndCheckFreshIds(replace_vector_access_chain_index, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // This is an interesting case because it replaces something that is being
@@ -324,7 +325,8 @@ TEST(TransformationReplaceIdWithSynonymTest, LegalTransformations) {
       201);
   ASSERT_TRUE(
       regular_replacement.IsApplicable(context.get(), transformation_context));
-  regular_replacement.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(regular_replacement, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto regular_replacement2 = TransformationReplaceIdWithSynonym(
@@ -332,14 +334,15 @@ TEST(TransformationReplaceIdWithSynonymTest, LegalTransformations) {
       203);
   ASSERT_TRUE(
       regular_replacement2.IsApplicable(context.get(), transformation_context));
-  regular_replacement2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(regular_replacement2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto good_op_phi = TransformationReplaceIdWithSynonym(
       MakeIdUseDescriptor(74, MakeInstructionDescriptor(86, SpvOpPhi, 0), 2),
       205);
   ASSERT_TRUE(good_op_phi.IsApplicable(context.get(), transformation_context));
-  good_op_phi.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(good_op_phi, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   const std::string after_transformation = R"(
@@ -526,7 +529,7 @@ TEST(TransformationReplaceIdWithSynonymTest, SynonymsOfVariables) {
       MakeIdUseDescriptor(10, MakeInstructionDescriptor(11, SpvOpLoad, 0), 0),
       100);
   ASSERT_TRUE(replacement1.IsApplicable(context.get(), transformation_context));
-  replacement1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement1, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Replace %8 with %101 in:
@@ -535,7 +538,7 @@ TEST(TransformationReplaceIdWithSynonymTest, SynonymsOfVariables) {
       MakeIdUseDescriptor(8, MakeInstructionDescriptor(11, SpvOpStore, 0), 0),
       101);
   ASSERT_TRUE(replacement2.IsApplicable(context.get(), transformation_context));
-  replacement2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement2, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Replace %8 with %101 in:
@@ -544,7 +547,7 @@ TEST(TransformationReplaceIdWithSynonymTest, SynonymsOfVariables) {
       MakeIdUseDescriptor(8, MakeInstructionDescriptor(12, SpvOpLoad, 0), 0),
       101);
   ASSERT_TRUE(replacement3.IsApplicable(context.get(), transformation_context));
-  replacement3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement3, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Replace %10 with %100 in:
@@ -553,7 +556,7 @@ TEST(TransformationReplaceIdWithSynonymTest, SynonymsOfVariables) {
       MakeIdUseDescriptor(10, MakeInstructionDescriptor(12, SpvOpStore, 0), 0),
       100);
   ASSERT_TRUE(replacement4.IsApplicable(context.get(), transformation_context));
-  replacement4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement4, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   const std::string after_transformation = R"(
@@ -866,7 +869,7 @@ TEST(TransformationReplaceIdWithSynonymTest, SynonymsOfAccessChainIndices) {
           16, MakeInstructionDescriptor(52, SpvOpAccessChain, 0), 1),
       100);
   ASSERT_TRUE(replacement4.IsApplicable(context.get(), transformation_context));
-  replacement4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement4, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // %52 = OpAccessChain %23 %50 %16 *%16*
@@ -897,7 +900,7 @@ TEST(TransformationReplaceIdWithSynonymTest, SynonymsOfAccessChainIndices) {
           16, MakeInstructionDescriptor(53, SpvOpAccessChain, 0), 4),
       100);
   ASSERT_TRUE(replacement7.IsApplicable(context.get(), transformation_context));
-  replacement7.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement7, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Replacements of the form %21 -> %101
@@ -931,7 +934,7 @@ TEST(TransformationReplaceIdWithSynonymTest, SynonymsOfAccessChainIndices) {
       101);
   ASSERT_TRUE(
       replacement10.IsApplicable(context.get(), transformation_context));
-  replacement10.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement10, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // %44 = OpAccessChain %23 %37 *%21* %21 %43
@@ -973,7 +976,7 @@ TEST(TransformationReplaceIdWithSynonymTest, SynonymsOfAccessChainIndices) {
       101);
   ASSERT_TRUE(
       replacement14.IsApplicable(context.get(), transformation_context));
-  replacement14.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement14, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // %53 = OpAccessChain %19 %50 %21 *%21* %16 %16
@@ -1027,7 +1030,7 @@ TEST(TransformationReplaceIdWithSynonymTest, SynonymsOfAccessChainIndices) {
       102);
   ASSERT_TRUE(
       replacement19.IsApplicable(context.get(), transformation_context));
-  replacement19.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement19, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // %27 = OpAccessChain %26 %15 %17
@@ -1059,7 +1062,7 @@ TEST(TransformationReplaceIdWithSynonymTest, SynonymsOfAccessChainIndices) {
       102);
   ASSERT_TRUE(
       replacement22.IsApplicable(context.get(), transformation_context));
-  replacement22.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement22, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // %58 = OpInBoundsAccessChain %26 %50 %57 %21 %17
@@ -1083,7 +1086,7 @@ TEST(TransformationReplaceIdWithSynonymTest, SynonymsOfAccessChainIndices) {
       103);
   ASSERT_TRUE(
       replacement24.IsApplicable(context.get(), transformation_context));
-  replacement24.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement24, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Replacements of the form %32 -> %106
@@ -1097,7 +1100,7 @@ TEST(TransformationReplaceIdWithSynonymTest, SynonymsOfAccessChainIndices) {
       106);
   ASSERT_TRUE(
       replacement25.IsApplicable(context.get(), transformation_context));
-  replacement25.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement25, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Replacements of the form %43 -> %107
@@ -1111,7 +1114,7 @@ TEST(TransformationReplaceIdWithSynonymTest, SynonymsOfAccessChainIndices) {
       107);
   ASSERT_TRUE(
       replacement26.IsApplicable(context.get(), transformation_context));
-  replacement26.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement26, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Replacements of the form %55 -> %108
@@ -1125,7 +1128,7 @@ TEST(TransformationReplaceIdWithSynonymTest, SynonymsOfAccessChainIndices) {
       108);
   ASSERT_TRUE(
       replacement27.IsApplicable(context.get(), transformation_context));
-  replacement27.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement27, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   // Replacements of the form %8 -> %109
@@ -1139,7 +1142,7 @@ TEST(TransformationReplaceIdWithSynonymTest, SynonymsOfAccessChainIndices) {
       109);
   ASSERT_TRUE(
       replacement28.IsApplicable(context.get(), transformation_context));
-  replacement28.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement28, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   const std::string after_transformation = R"(
@@ -1315,7 +1318,7 @@ TEST(TransformationReplaceIdWithSynonymTest, RuntimeArrayTest) {
           12, MakeInstructionDescriptor(16, SpvOpAccessChain, 0), 2),
       50);
   ASSERT_TRUE(replacement1.IsApplicable(context.get(), transformation_context));
-  replacement1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement1, context.get(), &transformation_context);
 
   // Fine to replace an index into a vector inside the runtime array.
   auto replacement2 = TransformationReplaceIdWithSynonym(
@@ -1323,7 +1326,7 @@ TEST(TransformationReplaceIdWithSynonymTest, RuntimeArrayTest) {
           14, MakeInstructionDescriptor(16, SpvOpAccessChain, 0), 3),
       51);
   ASSERT_TRUE(replacement2.IsApplicable(context.get(), transformation_context));
-  replacement2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement2, context.get(), &transformation_context);
 
   ASSERT_TRUE(IsValid(env, context.get()));
 
@@ -1474,21 +1477,21 @@ TEST(TransformationReplaceIdWithSynonymTest, EquivalentIntegerConstants) {
                           0),
       13);
   ASSERT_TRUE(replacement1.IsApplicable(context.get(), transformation_context));
-  replacement1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement1, context.get(), &transformation_context);
 
   // Legal because OpIAdd does not care about the signedness of the operands
   auto replacement2 = TransformationReplaceIdWithSynonym(
       MakeIdUseDescriptor(10, MakeInstructionDescriptor(16, SpvOpIAdd, 0), 0),
       13);
   ASSERT_TRUE(replacement2.IsApplicable(context.get(), transformation_context));
-  replacement2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement2, context.get(), &transformation_context);
 
   // Legal because OpSDiv does not care about the signedness of the operands
   auto replacement3 = TransformationReplaceIdWithSynonym(
       MakeIdUseDescriptor(10, MakeInstructionDescriptor(17, SpvOpSDiv, 0), 0),
       13);
   ASSERT_TRUE(replacement3.IsApplicable(context.get(), transformation_context));
-  replacement3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement3, context.get(), &transformation_context);
 
   // Not legal because OpUDiv requires unsigned integers
   ASSERT_FALSE(TransformationReplaceIdWithSynonym(
@@ -1503,7 +1506,7 @@ TEST(TransformationReplaceIdWithSynonymTest, EquivalentIntegerConstants) {
                           0),
       13);
   ASSERT_TRUE(replacement4.IsApplicable(context.get(), transformation_context));
-  replacement4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement4, context.get(), &transformation_context);
 
   // Not legal because OpSelect requires both operands to have the same type as
   // the result type
@@ -1615,7 +1618,7 @@ TEST(TransformationReplaceIdWithSynonymTest, EquivalentIntegerVectorConstants) {
       MakeIdUseDescriptor(14, MakeInstructionDescriptor(18, SpvOpIAdd, 0), 0),
       15);
   ASSERT_TRUE(replacement1.IsApplicable(context.get(), transformation_context));
-  replacement1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement1, context.get(), &transformation_context);
 
   // Not legal because OpStore requires the object to match the type pointed
   // to by the pointer.
@@ -1635,7 +1638,7 @@ TEST(TransformationReplaceIdWithSynonymTest, EquivalentIntegerVectorConstants) {
           13, MakeInstructionDescriptor(19, SpvOpAccessChain, 0), 1),
       12);
   ASSERT_TRUE(replacement2.IsApplicable(context.get(), transformation_context));
-  replacement2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(replacement2, context.get(), &transformation_context);
 
   ASSERT_TRUE(IsValid(env, context.get()));
 

--- a/test/fuzz/transformation_replace_irrelevant_id_test.cpp
+++ b/test/fuzz/transformation_replace_irrelevant_id_test.cpp
@@ -137,7 +137,7 @@ TEST(TransformationReplaceIrrelevantIdTest, Apply) {
       MakeIdUseDescriptor(23, instruction_24_descriptor, 1), 22);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   ASSERT_TRUE(IsValid(env, context.get()));
 

--- a/test/fuzz/transformation_replace_linear_algebra_instruction_test.cpp
+++ b/test/fuzz/transformation_replace_linear_algebra_instruction_test.cpp
@@ -250,34 +250,34 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest, ReplaceOpTranspose) {
       MakeInstructionDescriptor(56, SpvOpTranspose, 0);
   auto transformation = TransformationReplaceLinearAlgebraInstruction(
       {65, 66, 67, 68, 69, 70, 71, 72, 73, 74}, instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor = MakeInstructionDescriptor(57, SpvOpTranspose, 0);
   transformation = TransformationReplaceLinearAlgebraInstruction(
       {75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88},
       instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor = MakeInstructionDescriptor(58, SpvOpTranspose, 0);
   transformation = TransformationReplaceLinearAlgebraInstruction(
       {89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105,
        106},
       instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor = MakeInstructionDescriptor(59, SpvOpTranspose, 0);
   transformation = TransformationReplaceLinearAlgebraInstruction(
       {107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120,
        121},
       instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor = MakeInstructionDescriptor(60, SpvOpTranspose, 0);
   transformation = TransformationReplaceLinearAlgebraInstruction(
       {122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132,
        133, 134, 135, 136, 137, 138, 139, 140, 141, 142},
       instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string variant_shader = R"(
                OpCapability Shader
@@ -506,19 +506,19 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest,
       MakeInstructionDescriptor(17, SpvOpVectorTimesScalar, 0);
   auto transformation = TransformationReplaceLinearAlgebraInstruction(
       {20, 21, 22, 23}, instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor =
       MakeInstructionDescriptor(18, SpvOpVectorTimesScalar, 0);
   transformation = TransformationReplaceLinearAlgebraInstruction(
       {24, 25, 26, 27, 28, 29}, instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor =
       MakeInstructionDescriptor(19, SpvOpVectorTimesScalar, 0);
   transformation = TransformationReplaceLinearAlgebraInstruction(
       {30, 31, 32, 33, 34, 35, 36, 37}, instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string variant_shader = R"(
                OpCapability Shader
@@ -676,14 +676,14 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest,
       MakeInstructionDescriptor(56, SpvOpMatrixTimesScalar, 0);
   auto transformation = TransformationReplaceLinearAlgebraInstruction(
       {65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76}, instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor =
       MakeInstructionDescriptor(57, SpvOpMatrixTimesScalar, 0);
   transformation = TransformationReplaceLinearAlgebraInstruction(
       {77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94},
       instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor =
       MakeInstructionDescriptor(58, SpvOpMatrixTimesScalar, 0);
@@ -691,7 +691,7 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest,
       {95,  96,  97,  98,  99,  100, 101, 102, 103, 104, 105, 106,
        107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118},
       instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string variant_shader = R"(
                OpCapability Shader
@@ -963,7 +963,7 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest,
   auto transformation = TransformationReplaceLinearAlgebraInstruction(
       {65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78},
       instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor =
       MakeInstructionDescriptor(57, SpvOpVectorTimesMatrix, 0);
@@ -971,7 +971,7 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest,
       {79, 80, 81, 82, 83, 84, 85, 86, 87, 88,
        89, 90, 91, 92, 93, 94, 95, 96, 97, 98},
       instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor =
       MakeInstructionDescriptor(58, SpvOpVectorTimesMatrix, 0);
@@ -979,7 +979,7 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest,
       {99,  100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111,
        112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124},
       instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor =
       MakeInstructionDescriptor(59, SpvOpVectorTimesMatrix, 0);
@@ -987,7 +987,7 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest,
       {125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135,
        136, 137, 138, 139, 140, 141, 142, 143, 144, 145},
       instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string variant_shader = R"(
                OpCapability Shader
@@ -1296,7 +1296,7 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest,
   auto transformation = TransformationReplaceLinearAlgebraInstruction(
       {65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78},
       instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor =
       MakeInstructionDescriptor(57, SpvOpMatrixTimesVector, 0);
@@ -1304,7 +1304,7 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest,
       {79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96,
        97},
       instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor =
       MakeInstructionDescriptor(58, SpvOpMatrixTimesVector, 0);
@@ -1312,7 +1312,7 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest,
       {98,  99,  100, 101, 102, 103, 104, 105, 106, 107, 108, 109,
        110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121},
       instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor =
       MakeInstructionDescriptor(59, SpvOpMatrixTimesVector, 0);
@@ -1320,7 +1320,7 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest,
       {122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132,
        133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143},
       instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string variant_shader = R"(
                OpCapability Shader
@@ -1683,7 +1683,7 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest,
        97,  98,  99,  100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110,
        111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122},
       instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor =
       MakeInstructionDescriptor(57, SpvOpMatrixTimesMatrix, 0);
@@ -1694,7 +1694,7 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest,
        159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170,
        171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182},
       instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor =
       MakeInstructionDescriptor(58, SpvOpMatrixTimesMatrix, 0);
@@ -1706,7 +1706,7 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest,
        239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252,
        253, 254, 255, 256, 257, 258, 259, 260, 261, 262},
       instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string variant_shader = R"(
                OpCapability Shader
@@ -2152,27 +2152,27 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest, ReplaceOpOuterProduct) {
       MakeInstructionDescriptor(47, SpvOpOuterProduct, 0);
   auto transformation = TransformationReplaceLinearAlgebraInstruction(
       {56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67}, instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor = MakeInstructionDescriptor(48, SpvOpOuterProduct, 0);
   transformation = TransformationReplaceLinearAlgebraInstruction(
       {68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85},
       instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor = MakeInstructionDescriptor(49, SpvOpOuterProduct, 0);
   transformation = TransformationReplaceLinearAlgebraInstruction(
       {86, 87, 88,  89,  90,  91,  92,  93,  94,  95,  96,  97,
        98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109},
       instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor = MakeInstructionDescriptor(50, SpvOpOuterProduct, 0);
   transformation = TransformationReplaceLinearAlgebraInstruction(
       {110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123,
        124, 125},
       instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string variant_shader = R"(
                OpCapability Shader
@@ -2387,18 +2387,18 @@ TEST(TransformationReplaceLinearAlgebraInstructionTest, ReplaceOpDot) {
   auto instruction_descriptor = MakeInstructionDescriptor(24, SpvOpDot, 0);
   auto transformation = TransformationReplaceLinearAlgebraInstruction(
       {27, 28, 29, 30, 31, 32}, instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor = MakeInstructionDescriptor(25, SpvOpDot, 0);
   transformation = TransformationReplaceLinearAlgebraInstruction(
       {33, 34, 35, 36, 37, 38, 39, 40, 41, 42}, instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instruction_descriptor = MakeInstructionDescriptor(26, SpvOpDot, 0);
   transformation = TransformationReplaceLinearAlgebraInstruction(
       {43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56},
       instruction_descriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string variant_shader = R"(
                OpCapability Shader

--- a/test/fuzz/transformation_replace_load_store_with_copy_memory_test.cpp
+++ b/test/fuzz/transformation_replace_load_store_with_copy_memory_test.cpp
@@ -182,14 +182,16 @@ TEST(TransformationReplaceLoadStoreWithCopyMemoryTest, BasicScenarios) {
       load_instruction_descriptor_2, store_instruction_descriptor_2);
   ASSERT_TRUE(transformation_good_1.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_1, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   auto transformation_good_2 = TransformationReplaceLoadStoreWithCopyMemory(
       load_instruction_descriptor_3, store_instruction_descriptor_3);
   ASSERT_TRUE(transformation_good_2.IsApplicable(context.get(),
                                                  transformation_context));
-  transformation_good_2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation_good_2, context.get(),
+                        &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_transformations = R"(

--- a/test/fuzz/transformation_replace_opphi_id_from_dead_predecessor_test.cpp
+++ b/test/fuzz/transformation_replace_opphi_id_from_dead_predecessor_test.cpp
@@ -130,19 +130,22 @@ TEST(TransformationReplaceOpPhiIdFromDeadPredecessorTest, Apply) {
       TransformationReplaceOpPhiIdFromDeadPredecessor(25, 20, 18);
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
 
   auto transformation2 =
       TransformationReplaceOpPhiIdFromDeadPredecessor(30, 28, 29);
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
 
   auto transformation3 =
       TransformationReplaceOpPhiIdFromDeadPredecessor(29, 17, 10);
   ASSERT_TRUE(
       transformation3.IsApplicable(context.get(), transformation_context));
-  transformation3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation3, context.get(),
+                        &transformation_context);
 
   ASSERT_TRUE(IsValid(env, context.get()));
 

--- a/test/fuzz/transformation_replace_opselect_with_conditional_branch_test.cpp
+++ b/test/fuzz/transformation_replace_opselect_with_conditional_branch_test.cpp
@@ -195,19 +195,21 @@ TEST(TransformationReplaceOpSelectWithConditionalBranchTest, Simple) {
       TransformationReplaceOpSelectWithConditionalBranch(20, 100, 101);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   auto transformation2 =
       TransformationReplaceOpSelectWithConditionalBranch(24, 0, 102);
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
 
   auto transformation3 =
       TransformationReplaceOpSelectWithConditionalBranch(26, 103, 0);
   ASSERT_TRUE(
       transformation3.IsApplicable(context.get(), transformation_context));
-  transformation3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation3, context.get(),
+                        &transformation_context);
 
   ASSERT_TRUE(IsValid(env, context.get()));
 

--- a/test/fuzz/transformation_replace_parameter_with_global_test.cpp
+++ b/test/fuzz/transformation_replace_parameter_with_global_test.cpp
@@ -155,43 +155,50 @@ TEST(TransformationReplaceParameterWithGlobalTest, BasicTest) {
     TransformationReplaceParameterWithGlobal transformation(50, 16, 51);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   {
     TransformationReplaceParameterWithGlobal transformation(52, 17, 53);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   {
     TransformationReplaceParameterWithGlobal transformation(54, 18, 55);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   {
     TransformationReplaceParameterWithGlobal transformation(56, 19, 57);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   {
     TransformationReplaceParameterWithGlobal transformation(58, 75, 59);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   {
     TransformationReplaceParameterWithGlobal transformation(60, 81, 61);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   {
     TransformationReplaceParameterWithGlobal transformation(62, 91, 63);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   ASSERT_TRUE(IsValid(env, context.get()));
@@ -333,7 +340,8 @@ TEST(TransformationReplaceParameterWithGlobalTest,
     TransformationReplaceParameterWithGlobal transformation(20, 10, 21);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(
         transformation_context.GetFactManager()->PointeeValueIsIrrelevant(21));
   }
@@ -341,7 +349,8 @@ TEST(TransformationReplaceParameterWithGlobalTest,
     TransformationReplaceParameterWithGlobal transformation(22, 11, 23);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_FALSE(
         transformation_context.GetFactManager()->PointeeValueIsIrrelevant(23));
   }

--- a/test/fuzz/transformation_replace_params_with_struct_test.cpp
+++ b/test/fuzz/transformation_replace_params_with_struct_test.cpp
@@ -192,39 +192,45 @@ TEST(TransformationReplaceParamsWithStructTest, BasicTest) {
                                                          {{33, 92}, {90, 93}});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   {
     TransformationReplaceParamsWithStruct transformation({43}, 93, 94,
                                                          {{33, 95}});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   {
     TransformationReplaceParamsWithStruct transformation({17, 91, 94}, 96, 97,
                                                          {{33, 98}});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   {
     TransformationReplaceParamsWithStruct transformation({55}, 99, 100, {{}});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   {
     TransformationReplaceParamsWithStruct transformation({61}, 101, 102, {{}});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
   {
     TransformationReplaceParamsWithStruct transformation({73}, 103, 104, {{}});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   ASSERT_TRUE(IsValid(env, context.get()));
@@ -380,7 +386,8 @@ TEST(TransformationReplaceParamsWithStructTest, ParametersRemainValid) {
                                                          {{}});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -427,7 +434,8 @@ TEST(TransformationReplaceParamsWithStructTest, ParametersRemainValid) {
                                                          {{}});
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 

--- a/test/fuzz/transformation_set_function_control_test.cpp
+++ b/test/fuzz/transformation_set_function_control_test.cpp
@@ -137,28 +137,32 @@ TEST(TransformationSetFunctionControlTest, VariousScenarios) {
                                                    SpvFunctionControlMaskNone);
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
 
   // Set to Inline; silly to do it on an entry point, but it is allowed
   TransformationSetFunctionControl transformation2(
       4, SpvFunctionControlInlineMask);
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
 
   // Set to Pure, removing DontInline
   TransformationSetFunctionControl transformation3(17,
                                                    SpvFunctionControlPureMask);
   ASSERT_TRUE(
       transformation3.IsApplicable(context.get(), transformation_context));
-  transformation3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation3, context.get(),
+                        &transformation_context);
 
   // Change from Inline to DontInline
   TransformationSetFunctionControl transformation4(
       13, SpvFunctionControlDontInlineMask);
   ASSERT_TRUE(
       transformation4.IsApplicable(context.get(), transformation_context));
-  transformation4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation4, context.get(),
+                        &transformation_context);
 
   std::string after_transformation = R"(
                OpCapability Shader

--- a/test/fuzz/transformation_set_loop_control_test.cpp
+++ b/test/fuzz/transformation_set_loop_control_test.cpp
@@ -611,49 +611,63 @@ TEST(TransformationSetLoopControlTest, VariousScenarios) {
           7, 9)
           .IsApplicable(context.get(), transformation_context));
 
-  TransformationSetLoopControl(10,
-                               SpvLoopControlUnrollMask |
-                                   SpvLoopControlPeelCountMask |
-                                   SpvLoopControlPartialCountMask,
-                               3, 3)
-      .Apply(context.get(), &transformation_context);
-  TransformationSetLoopControl(23, SpvLoopControlDontUnrollMask, 0, 0)
-      .Apply(context.get(), &transformation_context);
-  TransformationSetLoopControl(33, SpvLoopControlUnrollMask, 0, 0)
-      .Apply(context.get(), &transformation_context);
-  TransformationSetLoopControl(
-      43, SpvLoopControlDontUnrollMask | SpvLoopControlDependencyInfiniteMask,
-      0, 0)
-      .Apply(context.get(), &transformation_context);
-  TransformationSetLoopControl(53, SpvLoopControlMaskNone, 0, 0)
-      .Apply(context.get(), &transformation_context);
-  TransformationSetLoopControl(63,
-                               SpvLoopControlUnrollMask |
-                                   SpvLoopControlMinIterationsMask |
-                                   SpvLoopControlPeelCountMask,
-                               23, 0)
-      .Apply(context.get(), &transformation_context);
-  TransformationSetLoopControl(73,
-                               SpvLoopControlUnrollMask |
-                                   SpvLoopControlMaxIterationsMask |
-                                   SpvLoopControlPeelCountMask,
-                               23, 0)
-      .Apply(context.get(), &transformation_context);
-  TransformationSetLoopControl(83, SpvLoopControlDontUnrollMask, 0, 0)
-      .Apply(context.get(), &transformation_context);
-  TransformationSetLoopControl(
-      93, SpvLoopControlPeelCountMask | SpvLoopControlPartialCountMask, 16, 8)
-      .Apply(context.get(), &transformation_context);
-  TransformationSetLoopControl(103, SpvLoopControlPartialCountMask, 0, 60)
-      .Apply(context.get(), &transformation_context);
-  TransformationSetLoopControl(113, SpvLoopControlPeelCountMask, 12, 0)
-      .Apply(context.get(), &transformation_context);
-  TransformationSetLoopControl(
-      123,
-      SpvLoopControlUnrollMask | SpvLoopControlMinIterationsMask |
-          SpvLoopControlMaxIterationsMask | SpvLoopControlPartialCountMask,
-      0, 9)
-      .Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(
+      TransformationSetLoopControl(10,
+                                   SpvLoopControlUnrollMask |
+                                       SpvLoopControlPeelCountMask |
+                                       SpvLoopControlPartialCountMask,
+                                   3, 3),
+      context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(
+      TransformationSetLoopControl(23, SpvLoopControlDontUnrollMask, 0, 0),
+      context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(
+      TransformationSetLoopControl(33, SpvLoopControlUnrollMask, 0, 0),
+      context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(
+      TransformationSetLoopControl(
+          43,
+          SpvLoopControlDontUnrollMask | SpvLoopControlDependencyInfiniteMask,
+          0, 0),
+      context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(
+      TransformationSetLoopControl(53, SpvLoopControlMaskNone, 0, 0),
+      context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(
+      TransformationSetLoopControl(63,
+                                   SpvLoopControlUnrollMask |
+                                       SpvLoopControlMinIterationsMask |
+                                       SpvLoopControlPeelCountMask,
+                                   23, 0),
+      context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(
+      TransformationSetLoopControl(73,
+                                   SpvLoopControlUnrollMask |
+                                       SpvLoopControlMaxIterationsMask |
+                                       SpvLoopControlPeelCountMask,
+                                   23, 0),
+      context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(
+      TransformationSetLoopControl(83, SpvLoopControlDontUnrollMask, 0, 0),
+      context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(
+      TransformationSetLoopControl(
+          93, SpvLoopControlPeelCountMask | SpvLoopControlPartialCountMask, 16,
+          8),
+      context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(
+      TransformationSetLoopControl(103, SpvLoopControlPartialCountMask, 0, 60),
+      context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(
+      TransformationSetLoopControl(113, SpvLoopControlPeelCountMask, 12, 0),
+      context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(
+      TransformationSetLoopControl(
+          123,
+          SpvLoopControlUnrollMask | SpvLoopControlMinIterationsMask |
+              SpvLoopControlMaxIterationsMask | SpvLoopControlPartialCountMask,
+          0, 9),
+      context.get(), &transformation_context);
 
   std::string after_transformation = R"(
                OpCapability Shader

--- a/test/fuzz/transformation_set_memory_operands_mask_test.cpp
+++ b/test/fuzz/transformation_set_memory_operands_mask_test.cpp
@@ -115,7 +115,8 @@ TEST(TransformationSetMemoryOperandsMaskTest, PreSpirv14) {
         SpvMemoryAccessAlignedMask | SpvMemoryAccessVolatileMask, 0);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   // Not OK to remove Aligned
@@ -139,7 +140,8 @@ TEST(TransformationSetMemoryOperandsMaskTest, PreSpirv14) {
         0);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   // Not OK to remove Volatile
@@ -161,7 +163,8 @@ TEST(TransformationSetMemoryOperandsMaskTest, PreSpirv14) {
         SpvMemoryAccessNontemporalMask | SpvMemoryAccessVolatileMask, 0);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   {
@@ -171,7 +174,8 @@ TEST(TransformationSetMemoryOperandsMaskTest, PreSpirv14) {
         SpvMemoryAccessNontemporalMask | SpvMemoryAccessVolatileMask, 0);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   {
@@ -181,7 +185,8 @@ TEST(TransformationSetMemoryOperandsMaskTest, PreSpirv14) {
         SpvMemoryAccessNontemporalMask | SpvMemoryAccessVolatileMask, 0);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   {
@@ -191,7 +196,8 @@ TEST(TransformationSetMemoryOperandsMaskTest, PreSpirv14) {
         SpvMemoryAccessVolatileMask, 0);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   std::string after_transformation = R"(
@@ -350,7 +356,8 @@ TEST(TransformationSetMemoryOperandsMaskTest, Spirv14) {
                      .IsApplicable(context.get(), transformation_context));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   {
@@ -364,7 +371,8 @@ TEST(TransformationSetMemoryOperandsMaskTest, Spirv14) {
                      .IsApplicable(context.get(), transformation_context));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   {
@@ -374,7 +382,8 @@ TEST(TransformationSetMemoryOperandsMaskTest, Spirv14) {
         SpvMemoryAccessNontemporalMask | SpvMemoryAccessVolatileMask, 0);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   {
@@ -384,7 +393,8 @@ TEST(TransformationSetMemoryOperandsMaskTest, Spirv14) {
         SpvMemoryAccessNontemporalMask | SpvMemoryAccessVolatileMask, 1);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   {
@@ -399,7 +409,8 @@ TEST(TransformationSetMemoryOperandsMaskTest, Spirv14) {
             .IsApplicable(context.get(), transformation_context));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   {
@@ -408,7 +419,8 @@ TEST(TransformationSetMemoryOperandsMaskTest, Spirv14) {
         SpvMemoryAccessVolatileMask, 1);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   {
@@ -417,7 +429,8 @@ TEST(TransformationSetMemoryOperandsMaskTest, Spirv14) {
         SpvMemoryAccessVolatileMask | SpvMemoryAccessAlignedMask, 0);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   {
@@ -426,7 +439,8 @@ TEST(TransformationSetMemoryOperandsMaskTest, Spirv14) {
         0);
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
   }
 
   std::string after_transformation = R"(

--- a/test/fuzz/transformation_set_selection_control_test.cpp
+++ b/test/fuzz/transformation_set_selection_control_test.cpp
@@ -123,25 +123,29 @@ TEST(TransformationSetSelectionControlTest, VariousScenarios) {
       11, SpvSelectionControlDontFlattenMask);
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
 
   TransformationSetSelectionControl transformation2(
       23, SpvSelectionControlFlattenMask);
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
 
   TransformationSetSelectionControl transformation3(
       31, SpvSelectionControlMaskNone);
   ASSERT_TRUE(
       transformation3.IsApplicable(context.get(), transformation_context));
-  transformation3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation3, context.get(),
+                        &transformation_context);
 
   TransformationSetSelectionControl transformation4(
       31, SpvSelectionControlFlattenMask);
   ASSERT_TRUE(
       transformation4.IsApplicable(context.get(), transformation_context));
-  transformation4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation4, context.get(),
+                        &transformation_context);
 
   std::string after_transformation = R"(
                OpCapability Shader

--- a/test/fuzz/transformation_split_block_test.cpp
+++ b/test/fuzz/transformation_split_block_test.cpp
@@ -206,7 +206,7 @@ TEST(TransformationSplitBlockTest, SplitBlockSeveralTimes) {
   auto split_1 = TransformationSplitBlock(
       MakeInstructionDescriptor(5, SpvOpStore, 0), 100);
   ASSERT_TRUE(split_1.IsApplicable(context.get(), transformation_context));
-  split_1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(split_1, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_split_1 = R"(
@@ -254,7 +254,7 @@ TEST(TransformationSplitBlockTest, SplitBlockSeveralTimes) {
   auto split_2 = TransformationSplitBlock(
       MakeInstructionDescriptor(11, SpvOpStore, 0), 101);
   ASSERT_TRUE(split_2.IsApplicable(context.get(), transformation_context));
-  split_2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(split_2, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_split_2 = R"(
@@ -304,7 +304,7 @@ TEST(TransformationSplitBlockTest, SplitBlockSeveralTimes) {
   auto split_3 = TransformationSplitBlock(
       MakeInstructionDescriptor(14, SpvOpLoad, 0), 102);
   ASSERT_TRUE(split_3.IsApplicable(context.get(), transformation_context));
-  split_3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(split_3, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_split_3 = R"(
@@ -430,7 +430,7 @@ TEST(TransformationSplitBlockTest, SplitBlockBeforeSelectBranch) {
   auto split = TransformationSplitBlock(
       MakeInstructionDescriptor(14, SpvOpSelectionMerge, 0), 100);
   ASSERT_TRUE(split.IsApplicable(context.get(), transformation_context));
-  split.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(split, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_split = R"(
@@ -558,7 +558,7 @@ TEST(TransformationSplitBlockTest, SplitBlockBeforeSwitchBranch) {
   auto split = TransformationSplitBlock(
       MakeInstructionDescriptor(9, SpvOpSelectionMerge, 0), 100);
   ASSERT_TRUE(split.IsApplicable(context.get(), transformation_context));
-  split.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(split, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_split = R"(
@@ -742,7 +742,7 @@ TEST(TransformationSplitBlockTest, SplitOpPhiWithSinglePredecessor) {
   auto split =
       TransformationSplitBlock(MakeInstructionDescriptor(20, SpvOpPhi, 0), 100);
   ASSERT_TRUE(split.IsApplicable(context.get(), transformation_context));
-  split.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(split, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   std::string after_split = R"(
@@ -820,7 +820,7 @@ TEST(TransformationSplitBlockTest, DeadBlockShouldSplitToTwoDeadBlocks) {
   auto split = TransformationSplitBlock(
       MakeInstructionDescriptor(8, SpvOpBranch, 0), 100);
   ASSERT_TRUE(split.IsApplicable(context.get(), transformation_context));
-  split.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(split, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
 
   ASSERT_TRUE(transformation_context.GetFactManager()->BlockIsDead(8));

--- a/test/fuzz/transformation_store_test.cpp
+++ b/test/fuzz/transformation_store_test.cpp
@@ -232,7 +232,8 @@ TEST(TransformationStoreTest, BasicTest) {
         27, 80, MakeInstructionDescriptor(38, SpvOpAccessChain, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -242,7 +243,8 @@ TEST(TransformationStoreTest, BasicTest) {
         11, 95, MakeInstructionDescriptor(95, SpvOpReturnValue, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -252,7 +254,8 @@ TEST(TransformationStoreTest, BasicTest) {
         46, 80, MakeInstructionDescriptor(95, SpvOpReturnValue, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -262,7 +265,8 @@ TEST(TransformationStoreTest, BasicTest) {
         16, 21, MakeInstructionDescriptor(95, SpvOpReturnValue, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 
@@ -272,7 +276,8 @@ TEST(TransformationStoreTest, BasicTest) {
         53, 21, MakeInstructionDescriptor(38, SpvOpAccessChain, 0));
     ASSERT_TRUE(
         transformation.IsApplicable(context.get(), transformation_context));
-    transformation.Apply(context.get(), &transformation_context);
+    ApplyAndCheckFreshIds(transformation, context.get(),
+                          &transformation_context);
     ASSERT_TRUE(IsValid(env, context.get()));
   }
 

--- a/test/fuzz/transformation_swap_commutable_operands_test.cpp
+++ b/test/fuzz/transformation_swap_commutable_operands_test.cpp
@@ -343,23 +343,23 @@ TEST(TransformationSwapCommutableOperandsTest, ApplyTest) {
   auto instructionDescriptor = MakeInstructionDescriptor(22, SpvOpIAdd, 0);
   auto transformation =
       TransformationSwapCommutableOperands(instructionDescriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instructionDescriptor = MakeInstructionDescriptor(28, SpvOpIMul, 0);
   transformation = TransformationSwapCommutableOperands(instructionDescriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instructionDescriptor = MakeInstructionDescriptor(42, SpvOpFAdd, 0);
   transformation = TransformationSwapCommutableOperands(instructionDescriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instructionDescriptor = MakeInstructionDescriptor(48, SpvOpFMul, 0);
   transformation = TransformationSwapCommutableOperands(instructionDescriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instructionDescriptor = MakeInstructionDescriptor(66, SpvOpDot, 0);
   transformation = TransformationSwapCommutableOperands(instructionDescriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string variantShader = R"(
                OpCapability Shader

--- a/test/fuzz/transformation_swap_conditional_branch_operands_test.cpp
+++ b/test/fuzz/transformation_swap_conditional_branch_operands_test.cpp
@@ -91,7 +91,7 @@ TEST(TransformationSwapConditionalBranchOperandsTest, BasicTest) {
       MakeInstructionDescriptor(15, SpvOpBranchConditional, 0), 26);
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string after_transformation = R"(
                OpCapability Shader

--- a/test/fuzz/transformation_toggle_access_chain_instruction_test.cpp
+++ b/test/fuzz/transformation_toggle_access_chain_instruction_test.cpp
@@ -313,29 +313,29 @@ TEST(TransformationToggleAccessChainInstructionTest, ApplyTest) {
       MakeInstructionDescriptor(18, SpvOpAccessChain, 0);
   auto transformation =
       TransformationToggleAccessChainInstruction(instructionDescriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instructionDescriptor =
       MakeInstructionDescriptor(20, SpvOpInBoundsAccessChain, 0);
   transformation =
       TransformationToggleAccessChainInstruction(instructionDescriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instructionDescriptor = MakeInstructionDescriptor(24, SpvOpAccessChain, 0);
   transformation =
       TransformationToggleAccessChainInstruction(instructionDescriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instructionDescriptor =
       MakeInstructionDescriptor(26, SpvOpInBoundsAccessChain, 0);
   transformation =
       TransformationToggleAccessChainInstruction(instructionDescriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   instructionDescriptor = MakeInstructionDescriptor(38, SpvOpAccessChain, 0);
   transformation =
       TransformationToggleAccessChainInstruction(instructionDescriptor);
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 
   std::string variantShader = R"(
                OpCapability Shader

--- a/test/fuzz/transformation_vector_shuffle_test.cpp
+++ b/test/fuzz/transformation_vector_shuffle_test.cpp
@@ -246,7 +246,8 @@ TEST(TransformationVectorShuffle, BasicTest) {
       MakeInstructionDescriptor(100, SpvOpReturn, 0), 200, 12, 112, {1, 0});
   ASSERT_TRUE(
       transformation1.IsApplicable(context.get(), transformation_context));
-  transformation1.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation1, context.get(),
+                        &transformation_context);
   temp_dd = MakeDataDescriptor(200, {0});
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(11, {}), temp_dd));
@@ -259,7 +260,8 @@ TEST(TransformationVectorShuffle, BasicTest) {
       {0xFFFFFFFF, 3, 5});
   ASSERT_TRUE(
       transformation2.IsApplicable(context.get(), transformation_context));
-  transformation2.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation2, context.get(),
+                        &transformation_context);
   temp_dd = MakeDataDescriptor(201, {1});
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(11, {}), temp_dd));
@@ -271,7 +273,8 @@ TEST(TransformationVectorShuffle, BasicTest) {
       MakeInstructionDescriptor(100, SpvOpReturn, 0), 202, 27, 35, {5, 4, 1});
   ASSERT_TRUE(
       transformation3.IsApplicable(context.get(), transformation_context));
-  transformation3.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation3, context.get(),
+                        &transformation_context);
   temp_dd = MakeDataDescriptor(202, {0});
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(26, {}), temp_dd));
@@ -286,7 +289,8 @@ TEST(TransformationVectorShuffle, BasicTest) {
       MakeInstructionDescriptor(100, SpvOpReturn, 0), 203, 42, 46, {0, 1});
   ASSERT_TRUE(
       transformation4.IsApplicable(context.get(), transformation_context));
-  transformation4.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation4, context.get(),
+                        &transformation_context);
   temp_dd = MakeDataDescriptor(203, {0});
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(40, {}), temp_dd));
@@ -298,7 +302,8 @@ TEST(TransformationVectorShuffle, BasicTest) {
       MakeInstructionDescriptor(100, SpvOpReturn, 0), 204, 42, 46, {2, 3, 4});
   ASSERT_TRUE(
       transformation5.IsApplicable(context.get(), transformation_context));
-  transformation5.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation5, context.get(),
+                        &transformation_context);
   temp_dd = MakeDataDescriptor(204, {0});
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(40, {}), temp_dd));
@@ -314,7 +319,8 @@ TEST(TransformationVectorShuffle, BasicTest) {
       {0, 1, 2, 3});
   ASSERT_TRUE(
       transformation6.IsApplicable(context.get(), transformation_context));
-  transformation6.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation6, context.get(),
+                        &transformation_context);
   temp_dd = MakeDataDescriptor(205, {0});
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(40, {}), temp_dd));
@@ -334,7 +340,8 @@ TEST(TransformationVectorShuffle, BasicTest) {
       {0xFFFFFFFF, 3, 6, 0xFFFFFFFF});
   ASSERT_TRUE(
       transformation7.IsApplicable(context.get(), transformation_context));
-  transformation7.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation7, context.get(),
+                        &transformation_context);
   temp_dd = MakeDataDescriptor(206, {1});
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(56, {}), temp_dd));
@@ -609,7 +616,7 @@ TEST(TransformationVectorShuffle, HandlesIrrelevantIds1) {
       MakeInstructionDescriptor(100, SpvOpReturn, 0), 200, 12, 112, {2, 0});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(12, {0}), MakeDataDescriptor(200, {1})));
@@ -690,7 +697,7 @@ TEST(TransformationVectorShuffle, HandlesIrrelevantIds2) {
       MakeInstructionDescriptor(100, SpvOpReturn, 0), 200, 12, 112, {2, 0});
   ASSERT_TRUE(
       transformation.IsApplicable(context.get(), transformation_context));
-  transformation.Apply(context.get(), &transformation_context);
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
   ASSERT_TRUE(IsValid(env, context.get()));
   ASSERT_TRUE(transformation_context.GetFactManager()->IsSynonymous(
       MakeDataDescriptor(12, {0}), MakeDataDescriptor(200, {1})));

--- a/tools/fuzz/fuzz.cpp
+++ b/tools/fuzz/fuzz.cpp
@@ -478,7 +478,7 @@ bool Replay(const spv_target_env& target_env,
       spvtools::fuzz::Replayer(
           target_env, spvtools::utils::CLIMessageConsumer, binary_in,
           initial_facts, transformation_sequence, num_transformations_to_apply,
-          0, fuzzer_options->replay_validation_enabled, validator_options)
+          fuzzer_options->replay_validation_enabled, validator_options)
           .Run();
   replay_result.transformed_module->module()->ToBinary(binary_out, false);
   *transformations_applied = std::move(replay_result.applied_transformations);


### PR DESCRIPTION
Adds a virtual method, GetFreshIds(), to Transformation.  Every
transformation uses this to indicate which ids in its protobuf message
are fresh ids.  This means that when replaying a sequence of
transformations the replayer can obtain a smallest id that is not in
use by the module already and that will not be used by any
transformation by necessity.  Ids greater than or equal to this id
can be used as overflow ids.

Fixes #3851.
