### PR TITLE
Update invalid layout error message.

### DIFF
--- a/source/val/validate_layout.cpp
+++ b/source/val/validate_layout.cpp
@@ -302,7 +302,7 @@ spv_result_t FunctionScopedInstructions(ValidationState_t& _,
   } else {
     return _.diag(SPV_ERROR_INVALID_LAYOUT, inst)
            << spvOpcodeString(opcode)
-           << " cannot appear in a function declaration";
+           << " is in an invalid module layout section";
   }
   return SPV_SUCCESS;
 }

--- a/test/val/val_layout_test.cpp
+++ b/test/val/val_layout_test.cpp
@@ -583,7 +583,7 @@ TEST_F(ValidateLayout, ModuleProcessedBeforeLastNameIsTooEarly) {
   // By the mechanics of the validator, we assume ModuleProcessed is in the
   // right spot, but then that OpName is in the wrong spot.
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Name cannot appear in a function declaration"));
+              HasSubstr("Name is in an invalid module layout section"));
 }
 
 TEST_F(ValidateLayout, ModuleProcessedInvalidAfterFirstAnnotation) {
@@ -601,7 +601,7 @@ TEST_F(ValidateLayout, ModuleProcessedInvalidAfterFirstAnnotation) {
             ValidateInstructions(SPV_ENV_UNIVERSAL_1_1));
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("ModuleProcessed cannot appear in a function declaration"));
+      HasSubstr("ModuleProcessed is in an invalid module layout section"));
 }
 
 TEST_F(ValidateLayout, ModuleProcessedInvalidInFunctionBeforeLabel) {
@@ -623,7 +623,7 @@ TEST_F(ValidateLayout, ModuleProcessedInvalidInFunctionBeforeLabel) {
             ValidateInstructions(SPV_ENV_UNIVERSAL_1_1));
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("ModuleProcessed cannot appear in a function declaration"));
+      HasSubstr("ModuleProcessed is in an invalid module layout section"));
 }
 
 TEST_F(ValidateLayout, ModuleProcessedInvalidInBasicBlock) {
@@ -645,7 +645,7 @@ TEST_F(ValidateLayout, ModuleProcessedInvalidInBasicBlock) {
             ValidateInstructions(SPV_ENV_UNIVERSAL_1_1));
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("ModuleProcessed cannot appear in a function declaration"));
+      HasSubstr("ModuleProcessed is in an invalid module layout section"));
 }
 
 TEST_F(ValidateLayout, WebGPUCallerBeforeCalleeBad) {


### PR DESCRIPTION
Currently if an opcode appears in the incorrect module section the error
message will be misleading as it says the opcode is in a function
declaration. This cl updates the error message accordingly.