### PR TITLE
Add DebugValue for function param regardless of scope

### DIFF
--- a/source/opt/debug_info_manager.cpp
+++ b/source/opt/debug_info_manager.cpp
@@ -40,6 +40,7 @@ static const uint32_t kDebugLocalVariableOperandParentIndex = 9;
 static const uint32_t kExtInstInstructionInIdx = 1;
 static const uint32_t kDebugGlobalVariableOperandFlagsIndex = 12;
 static const uint32_t kDebugLocalVariableOperandFlagsIndex = 10;
+static const uint32_t kDebugLocalVariableOperandArgNumberIndex = 11;
 
 namespace spvtools {
 namespace opt {
@@ -440,15 +441,27 @@ bool DebugInfoManager::IsAncestorOfScope(uint32_t scope, uint32_t ancestor) {
   return false;
 }
 
-bool DebugInfoManager::IsDeclareVisibleToInstr(Instruction* dbg_declare,
-                                               uint32_t instr_scope_id) {
-  if (instr_scope_id == kNoDebugScope) return false;
-
+Instruction* DebugInfoManager::GetDebugLocalVariableFromDeclare(
+    Instruction* dbg_declare) {
+  assert(dbg_declare);
   uint32_t dbg_local_var_id =
       dbg_declare->GetSingleWordOperand(kDebugDeclareOperandLocalVariableIndex);
   auto dbg_local_var_itr = id_to_dbg_inst_.find(dbg_local_var_id);
   assert(dbg_local_var_itr != id_to_dbg_inst_.end());
-  uint32_t decl_scope_id = dbg_local_var_itr->second->GetSingleWordOperand(
+  return dbg_local_var_itr->second;
+}
+
+bool DebugInfoManager::IsFunctionParameter(Instruction* dbg_local_var) const {
+  // If a DebugLocalVariable has ArgNumber operand, it is a function parameter.
+  return dbg_local_var->NumOperands() >
+         kDebugLocalVariableOperandArgNumberIndex;
+}
+
+bool DebugInfoManager::IsLocalVariableVisibleToInstr(Instruction* dbg_local_var,
+                                                     uint32_t instr_scope_id) {
+  if (instr_scope_id == kNoDebugScope) return false;
+
+  uint32_t decl_scope_id = dbg_local_var->GetSingleWordOperand(
       kDebugLocalVariableOperandParentIndex);
 
   // If the scope of DebugDeclare is an ancestor scope of the instruction's
@@ -502,11 +515,20 @@ void DebugInfoManager::AddDebugValueIfVarDeclIsVisible(
 
   uint32_t instr_scope_id = scope_and_line->GetDebugScope().GetLexicalScope();
   for (auto* dbg_decl_or_val : dbg_decl_itr->second) {
-    if (!IsDeclareVisibleToInstr(dbg_decl_or_val, instr_scope_id)) continue;
+    // If it declares a function parameter, the store instruction for the
+    // function parameter can exist out of the function parameter's scope
+    // because of the function inlining. We always add DebugValue for a
+    // function parameter next to the DebugDeclare regardless of the scope.
+    auto* dbg_local_var = GetDebugLocalVariableFromDeclare(dbg_decl_or_val);
+    bool is_function_param = IsFunctionParameter(dbg_local_var);
+    if (!is_function_param &&
+        !IsLocalVariableVisibleToInstr(dbg_local_var, instr_scope_id))
+      continue;
 
     // Avoid inserting the new DebugValue between OpPhi or OpVariable
     // instructions.
-    Instruction* insert_before = insert_pos->NextNode();
+    Instruction* insert_before = is_function_param ? dbg_decl_or_val->NextNode()
+                                                   : insert_pos->NextNode();
     while (insert_before->opcode() == SpvOpPhi ||
            insert_before->opcode() == SpvOpVariable) {
       insert_before = insert_before->NextNode();
@@ -523,7 +545,10 @@ void DebugInfoManager::AddDebugValueIfVarDeclIsVisible(
                                    kDebugValueOperandLocalVariableIndex),
                                value_id, 0, index_id, insert_before);
     assert(added_dbg_value != nullptr);
-    added_dbg_value->UpdateDebugInfoFrom(scope_and_line);
+    if (is_function_param)
+      added_dbg_value->UpdateDebugInfoFrom(dbg_decl_or_val);
+    else
+      added_dbg_value->UpdateDebugInfoFrom(scope_and_line);
     AnalyzeDebugInst(added_dbg_value);
   }
 }

--- a/source/opt/debug_info_manager.cpp
+++ b/source/opt/debug_info_manager.cpp
@@ -545,7 +545,8 @@ void DebugInfoManager::AddDebugValueIfVarDeclIsVisible(
                                    kDebugValueOperandLocalVariableIndex),
                                value_id, 0, index_id, insert_before);
     assert(added_dbg_value != nullptr);
-    added_dbg_value->UpdateDebugInfoFrom(is_function_param ? dbg_decl_or_val : scope_and_line);
+    added_dbg_value->UpdateDebugInfoFrom(is_function_param ? dbg_decl_or_val
+                                                           : scope_and_line);
     AnalyzeDebugInst(added_dbg_value);
   }
 }

--- a/source/opt/debug_info_manager.cpp
+++ b/source/opt/debug_info_manager.cpp
@@ -545,10 +545,7 @@ void DebugInfoManager::AddDebugValueIfVarDeclIsVisible(
                                    kDebugValueOperandLocalVariableIndex),
                                value_id, 0, index_id, insert_before);
     assert(added_dbg_value != nullptr);
-    if (is_function_param)
-      added_dbg_value->UpdateDebugInfoFrom(dbg_decl_or_val);
-    else
-      added_dbg_value->UpdateDebugInfoFrom(scope_and_line);
+    added_dbg_value->UpdateDebugInfoFrom(is_function_param ? dbg_decl_or_val : scope_and_line);
     AnalyzeDebugInst(added_dbg_value);
   }
 }

--- a/source/opt/debug_info_manager.h
+++ b/source/opt/debug_info_manager.h
@@ -215,10 +215,17 @@ class DebugInfoManager {
   // of |scope|.
   bool IsAncestorOfScope(uint32_t scope, uint32_t ancestor);
 
-  // Returns true if the declaration of a local variable |dbg_declare|
-  // is visible in the scope of an instruction |instr_scope_id|.
-  bool IsDeclareVisibleToInstr(Instruction* dbg_declare,
-                               uint32_t instr_scope_id);
+  // Returns the DebugLocalVariable declared by |dbg_declare|.
+  Instruction* GetDebugLocalVariableFromDeclare(Instruction* dbg_declare);
+
+  // Returns true if the DebugLocalVariable |dbg_local_var| is a function
+  // parameter.
+  bool IsFunctionParameter(Instruction* dbg_local_var) const;
+
+  // Returns true if the DebugLocalVariable |dbg_local_var| is visible
+  // in the scope of an instruction |instr_scope_id|.
+  bool IsLocalVariableVisibleToInstr(Instruction* dbg_local_var,
+                                     uint32_t instr_scope_id);
 
   // Returns the parent scope of the scope |child_scope|.
   uint32_t GetParentScope(uint32_t child_scope);


### PR DESCRIPTION
`DebugInfoManager::AddDebugValueIfVarDeclIsVisible()` adds
OpenCL.DebugInfo.100 DebugValue from DebugDeclare only when the
DebugDeclare is visible to the given scope. It helps us correctly
handle a reference variable e.g.,

```
{ // scope #1.
  int foo = /* init */;
  { // scope #2.
    int& bar = foo;
    ...
```

in the above code, we must not propagate DebugValue of `int& bar` for
store instructions in the `scope #1` because it is alive only in
the `scope #2`.

We have an exception: If the given DebugDeclare is used for a function
parameter, `DebugInfoManager::AddDebugValueIfVarDeclIsVisible()` has
to always add DebugValue instruction regardless
of the scope. It is because the initializer (store instruction) for
the function parameter can be out of the function parameter's scope
(the function) in particular when the function was inlined.

Without this change, the function parameter value information always
disappears whenever we run the function inlining pass and
`DebugInfoManager::AddDebugValueIfVarDeclIsVisible()`.