### PR TITLE
spirv-fuzz: Do not allow Block-decorated structs when adding parameters

### DIFF
--- a/source/fuzz/fuzzer_pass_add_parameters.cpp
+++ b/source/fuzz/fuzzer_pass_add_parameters.cpp
@@ -35,10 +35,8 @@ void FuzzerPassAddParameters::Apply() {
   // Compute type candidates for the new parameter.
   std::vector<uint32_t> type_candidates;
   for (const auto& type_inst : GetIRContext()->module()->GetTypes()) {
-    const auto* type =
-        GetIRContext()->get_type_mgr()->GetType(type_inst->result_id());
-    assert(type && "Type instruction is not registered in the type manager");
-    if (TransformationAddParameter::IsParameterTypeSupported(*type)) {
+    if (TransformationAddParameter::IsParameterTypeSupported(
+            GetIRContext(), type_inst->result_id())) {
       type_candidates.push_back(type_inst->result_id());
     }
   }

--- a/source/fuzz/transformation_add_parameter.h
+++ b/source/fuzz/transformation_add_parameter.h
@@ -62,7 +62,8 @@ class TransformationAddParameter : public Transformation {
 
   // Returns true if the type of the parameter is supported by this
   // transformation.
-  static bool IsParameterTypeSupported(const opt::analysis::Type& type);
+  static bool IsParameterTypeSupported(opt::IRContext* ir_context,
+                                       uint32_t type_id);
 
  private:
   protobufs::TransformationAddParameter message_;


### PR DESCRIPTION
Fixes #3929.