### PR TITLE
spirv-fuzz: Skip OpFunction when replacing irrelevant ids

### DIFF
--- a/source/fuzz/fuzzer_pass_replace_irrelevant_ids.cpp
+++ b/source/fuzz/fuzzer_pass_replace_irrelevant_ids.cpp
@@ -70,7 +70,7 @@ void FuzzerPassReplaceIrrelevantIds::Apply() {
   }
 
   // For every type for which we have at least one irrelevant id, record all ids
-  // in the module which have that type.  Skip ids of OpFunction instructions as
+  // in the module which have that type. Skip ids of OpFunction instructions as
   // we cannot use these as replacements.
   for (const auto& pair : GetIRContext()->get_def_use_mgr()->id_to_defs()) {
     uint32_t type_id = pair.second->type_id();

--- a/source/fuzz/fuzzer_pass_replace_irrelevant_ids.cpp
+++ b/source/fuzz/fuzzer_pass_replace_irrelevant_ids.cpp
@@ -70,10 +70,12 @@ void FuzzerPassReplaceIrrelevantIds::Apply() {
   }
 
   // For every type for which we have at least one irrelevant id, record all ids
-  // in the module which have that type.
+  // in the module which have that type.  Skip ids of OpFunction instructions as
+  // we cannot use these as replacements.
   for (const auto& pair : GetIRContext()->get_def_use_mgr()->id_to_defs()) {
     uint32_t type_id = pair.second->type_id();
-    if (type_id && types_to_ids.count(type_id)) {
+    if (pair.second->opcode() != SpvOpFunction && type_id &&
+        types_to_ids.count(type_id)) {
       types_to_ids[type_id].push_back(pair.first);
     }
   }
@@ -122,7 +124,7 @@ void FuzzerPassReplaceIrrelevantIds::Apply() {
           std::vector<uint32_t> available_replacement_ids;
 
           for (auto replacement_id : types_to_ids[type_id]) {
-            // We cannot replace an id with itself.
+            // It would be pointless to replace an id with itself.
             if (replacement_id == irrelevant_id) {
               continue;
             }

--- a/source/fuzz/transformation_replace_irrelevant_id.cpp
+++ b/source/fuzz/transformation_replace_irrelevant_id.cpp
@@ -64,6 +64,11 @@ bool TransformationReplaceIrrelevantId::IsApplicable(
     return false;
   }
 
+  // The replacement id must not be the result of an OpFunction instruction.
+  if (replacement_id_def->opcode() == SpvOpFunction) {
+    return false;
+  }
+
   // Consistency check: an irrelevant id cannot be a pointer.
   assert(
       !ir_context->get_type_mgr()->GetType(type_id_of_interest)->AsPointer() &&

--- a/source/fuzz/transformation_replace_irrelevant_id.h
+++ b/source/fuzz/transformation_replace_irrelevant_id.h
@@ -32,6 +32,7 @@ class TransformationReplaceIrrelevantId : public Transformation {
   // - The id of interest in |message_.id_use_descriptor| is irrelevant
   //   according to the fact manager.
   // - The types of the original id and of the replacement ids are the same.
+  // - The replacement must not be the result id of an OpFunction instruction.
   // - |message_.replacement_id| is available to use at the enclosing
   //   instruction of |message_.id_use_descriptor|.
   // - The original id is in principle replaceable with any other id of the same


### PR DESCRIPTION
Fixes #3927.