### PR TITLE
spirv-fuzz: Avoid void struct member when outlining functions

### DIFF
--- a/source/fuzz/transformation_outline_function.h
+++ b/source/fuzz/transformation_outline_function.h
@@ -178,7 +178,8 @@ class TransformationOutlineFunction : public Transformation {
   // of |original_region_exit_block| so that it returns something appropriate,
   // and patching up branches to |original_region_entry_block| to refer to its
   // clone.  Parameters |region_output_ids| and |output_id_to_fresh_id_map| are
-  // used to determine what the function should return.
+  // used to determine what the function should return.  Parameter
+  // |output_id_to_type_id| provides the type of each output id.
   //
   // The |transformation_context| argument allow facts about blocks being
   // outlined, e.g. whether they are dead blocks, to be asserted about blocks
@@ -188,6 +189,7 @@ class TransformationOutlineFunction : public Transformation {
       const opt::BasicBlock& original_region_exit_block,
       const std::set<opt::BasicBlock*>& region_blocks,
       const std::vector<uint32_t>& region_output_ids,
+      const std::map<uint32_t, uint32_t>& output_id_to_type_id,
       const std::map<uint32_t, uint32_t>& output_id_to_fresh_id_map,
       opt::IRContext* ir_context, opt::Function* outlined_function) const;
 

--- a/test/fuzz/transformation_outline_function_test.cpp
+++ b/test/fuzz/transformation_outline_function_test.cpp
@@ -2531,6 +2531,98 @@ TEST(TransformationOutlineFunctionTest, ExitBlockHeadsLoop) {
   ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
 }
 
+TEST(TransformationOutlineFunctionTest, SkipVoidOutputId) {
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %6 "main"
+               OpExecutionMode %6 OriginUpperLeft
+               OpSource ESSL 310
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+         %21 = OpTypeBool
+         %81 = OpConstantTrue %21
+          %6 = OpFunction %2 None %3
+          %7 = OpLabel
+               OpBranch %80
+         %80 = OpLabel
+         %84 = OpFunctionCall %2 %87
+               OpBranch %90
+         %90 = OpLabel
+         %86 = OpPhi %2 %84 %80
+               OpReturn
+               OpFunctionEnd
+         %87 = OpFunction %2 None %3
+         %88 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  const auto env = SPV_ENV_UNIVERSAL_1_5;
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  spvtools::ValidatorOptions validator_options;
+  ASSERT_TRUE(fuzzerutil::IsValidAndWellFormed(context.get(), validator_options,
+                                               kConsoleMessageConsumer));
+  TransformationContext transformation_context(
+      MakeUnique<FactManager>(context.get()), validator_options);
+  TransformationOutlineFunction transformation(
+      /*entry_block*/ 80,
+      /*exit_block*/ 80,
+      /*new_function_struct_return_type_id*/ 300,
+      /*new_function_type_id*/ 301,
+      /*new_function_id*/ 302,
+      /*new_function_region_entry_block*/ 304,
+      /*new_caller_result_id*/ 305,
+      /*new_callee_result_id*/ 306,
+      /*input_id_to_fresh_id*/ {},
+      /*output_id_to_fresh_id*/ {{84, 307}});
+
+  ASSERT_TRUE(
+      transformation.IsApplicable(context.get(), transformation_context));
+  ApplyAndCheckFreshIds(transformation, context.get(), &transformation_context);
+  ASSERT_TRUE(fuzzerutil::IsValidAndWellFormed(context.get(), validator_options,
+                                               kConsoleMessageConsumer));
+
+  std::string after_transformation = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %6 "main"
+               OpExecutionMode %6 OriginUpperLeft
+               OpSource ESSL 310
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+         %21 = OpTypeBool
+         %81 = OpConstantTrue %21
+        %300 = OpTypeStruct
+        %301 = OpTypeFunction %300
+          %6 = OpFunction %2 None %3
+          %7 = OpLabel
+               OpBranch %80
+         %80 = OpLabel
+        %305 = OpFunctionCall %300 %302
+         %84 = OpUndef %2
+               OpBranch %90
+         %90 = OpLabel
+         %86 = OpPhi %2 %84 %80
+               OpReturn
+               OpFunctionEnd
+         %87 = OpFunction %2 None %3
+         %88 = OpLabel
+               OpReturn
+               OpFunctionEnd
+        %302 = OpFunction %300 None %301
+        %304 = OpLabel
+        %307 = OpFunctionCall %2 %87
+        %306 = OpCompositeConstruct %300
+               OpReturnValue %306
+               OpFunctionEnd
+  )";
+  ASSERT_TRUE(IsEqual(env, after_transformation, context.get()));
+}
+
 TEST(TransformationOutlineFunctionTest, Miscellaneous1) {
   // This tests outlining of some non-trivial code, and also tests the way
   // overflow ids are used by the transformation.


### PR DESCRIPTION
Fixes #3935.