### PR TITLE
spirv-fuzz: Fix to TransformationDuplicateRegionWithSelection

### DIFF
--- a/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.cpp
+++ b/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.cpp
@@ -124,9 +124,8 @@ void FuzzerPassDuplicateRegionsWithSelections::Apply() {
         TransformationDuplicateRegionWithSelection(
             GetFuzzerContext()->GetFreshId(), condition_id,
             GetFuzzerContext()->GetFreshId(), entry_block->id(),
-            exit_block->id(), std::move(original_label_to_duplicate_label),
-            std::move(original_id_to_duplicate_id),
-            std::move(original_id_to_phi_id));
+            exit_block->id(), original_label_to_duplicate_label,
+            original_id_to_duplicate_id, original_id_to_phi_id);
     MaybeApplyTransformation(transformation);
   }
 }

--- a/source/fuzz/transformation_duplicate_region_with_selection.cpp
+++ b/source/fuzz/transformation_duplicate_region_with_selection.cpp
@@ -589,6 +589,21 @@ void TransformationDuplicateRegionWithSelection::Apply(
         }
       });
 
+  opt::Instruction* merge_block_terminator = merge_block->terminator();
+  switch (merge_block_terminator->opcode()) {
+    case SpvOpReturnValue:
+    case SpvOpBranchConditional: {
+      uint32_t operand = merge_block_terminator->GetSingleWordInOperand(0);
+      if (original_id_to_phi_id.count(operand)) {
+        merge_block_terminator->SetInOperand(
+            0, {original_id_to_phi_id.at(operand)});
+      }
+      break;
+    }
+    default:
+      break;
+  }
+
   // Insert the merge block after the |duplicated_exit_block| (the
   // last duplicated block).
   enclosing_function->InsertBasicBlockAfter(std::move(merge_block),

--- a/source/fuzz/transformation_merge_function_returns.cpp
+++ b/source/fuzz/transformation_merge_function_returns.cpp
@@ -509,7 +509,7 @@ void TransformationMergeFunctionReturns::Apply(
           {SPV_OPERAND_TYPE_LOOP_CONTROL, {SpvLoopControlMaskNone}}}));
 
   // Add conditional branch:
-  //    OpBranchConditional %true %block_after_entry %outer_header_id
+  //   OpBranchConditional %true %block_after_entry %outer_header_id
   // This will always branch to %block_after_entry, but it also creates a back
   // edge for the loop (which is never traversed).
   outer_loop_header->AddInstruction(MakeUnique<opt::Instruction>(

--- a/source/fuzz/transformation_merge_function_returns.cpp
+++ b/source/fuzz/transformation_merge_function_returns.cpp
@@ -509,7 +509,7 @@ void TransformationMergeFunctionReturns::Apply(
           {SPV_OPERAND_TYPE_LOOP_CONTROL, {SpvLoopControlMaskNone}}}));
 
   // Add conditional branch:
-  // 	OpBranchConditional %true %block_after_entry %outer_header_id
+  //    OpBranchConditional %true %block_after_entry %outer_header_id
   // This will always branch to %block_after_entry, but it also creates a back
   // edge for the loop (which is never traversed).
   outer_loop_header->AddInstruction(MakeUnique<opt::Instruction>(

--- a/test/fuzz/fuzzer_replayer_test.cpp
+++ b/test/fuzz/fuzzer_replayer_test.cpp
@@ -1590,7 +1590,7 @@ const std::string kTestShader6 = R"(
           %2 = OpFunction %132 None %133
         %164 = OpLabel
         %184 = OpLoad %15 %40
-	%213 = OpLoad %38 %41
+        %213 = OpLoad %38 %41
         %216 = OpSampledImage %45 %184 %213
         %217 = OpImageSampleImplicitLod %76 %216 %112 Bias %55
                OpReturn

--- a/test/fuzz/transformation_compute_data_synonym_fact_closure_test.cpp
+++ b/test/fuzz/transformation_compute_data_synonym_fact_closure_test.cpp
@@ -45,7 +45,7 @@ TEST(TransformationComputeDataSynonymFactClosureTest, DataSynonymFacts) {
   // void main() {
   //   T myT = T(bool[5](true, false, true, false, true),
   //             mat4x2(vec2(1.0, 2.0), vec2(3.0, 4.0),
-  // 	           vec2(5.0, 6.0), vec2(7.0, 8.0)),
+  //                    vec2(5.0, 6.0), vec2(7.0, 8.0)),
   //             S(10, uvec2(100u, 200u)));
   // }
 


### PR DESCRIPTION
Also incorporates a few style fixes.

Fixes #3940.