### PR TITLE
spirv-fuzz: Don't flatten conditional if condition is irrelevant

### DIFF
--- a/source/fuzz/fuzzer_pass_flatten_conditional_branches.cpp
+++ b/source/fuzz/fuzzer_pass_flatten_conditional_branches.cpp
@@ -47,10 +47,13 @@ void FuzzerPassFlattenConditionalBranches::Apply() {
         continue;
       }
 
-      // Only consider this block if it is the header of a conditional.
+      // Only consider this block if it is the header of a conditional, with a
+      // non-irrelevant condition.
       if (block.GetMergeInst() &&
           block.GetMergeInst()->opcode() == SpvOpSelectionMerge &&
-          block.terminator()->opcode() == SpvOpBranchConditional) {
+          block.terminator()->opcode() == SpvOpBranchConditional &&
+          !GetTransformationContext()->GetFactManager()->IdIsIrrelevant(
+              block.terminator()->GetSingleWordInOperand(0))) {
         selection_headers.emplace_back(&block);
       }
     }

--- a/source/fuzz/transformation_flatten_conditional_branch.cpp
+++ b/source/fuzz/transformation_flatten_conditional_branch.cpp
@@ -57,6 +57,15 @@ bool TransformationFlattenConditionalBranch::IsApplicable(
     return false;
   }
 
+  // The branch condition cannot be irrelevant: we will make reference to it
+  // multiple times and we need to be guaranteed that these references will
+  // yield the same result; if they are replaced by other ids that will not
+  // work.
+  if (transformation_context.GetFactManager()->IdIsIrrelevant(
+          header_block->terminator()->GetSingleWordInOperand(0))) {
+    return false;
+  }
+
   std::set<uint32_t> used_fresh_ids;
 
   // If ids have been provided to be used as vector guards for OpSelect

--- a/source/fuzz/transformation_flatten_conditional_branch.cpp
+++ b/source/fuzz/transformation_flatten_conditional_branch.cpp
@@ -114,6 +114,8 @@ bool TransformationFlattenConditionalBranch::IsApplicable(
                    // The transformation needs to be equipped with a fresh id
                    // in which to store the vectorized version of the selection
                    // construct's condition.
+                     return false;
+                   }
                    switch (dimension) {
                      case 2:
                        return message_.fresh_id_for_bvec2_selector() != 0;

--- a/source/fuzz/transformation_flatten_conditional_branch.cpp
+++ b/source/fuzz/transformation_flatten_conditional_branch.cpp
@@ -123,11 +123,6 @@ bool TransformationFlattenConditionalBranch::IsApplicable(
                    // The transformation needs to be equipped with a fresh id
                    // in which to store the vectorized version of the selection
                    // construct's condition.
-                     return false;
-                   }
-                   // The transformation needs to be equipped with a fresh id
-                   // in which to store the vectorized version of the selection
-                   // construct's condition.
                    switch (dimension) {
                      case 2:
                        return message_.fresh_id_for_bvec2_selector() != 0;

--- a/source/fuzz/transformation_flatten_conditional_branch.cpp
+++ b/source/fuzz/transformation_flatten_conditional_branch.cpp
@@ -116,6 +116,9 @@ bool TransformationFlattenConditionalBranch::IsApplicable(
                    // construct's condition.
                      return false;
                    }
+                   // The transformation needs to be equipped with a fresh id
+                   // in which to store the vectorized version of the selection
+                   // construct's condition.
                    switch (dimension) {
                      case 2:
                        return message_.fresh_id_for_bvec2_selector() != 0;

--- a/source/fuzz/transformation_flatten_conditional_branch.h
+++ b/source/fuzz/transformation_flatten_conditional_branch.h
@@ -35,6 +35,8 @@ class TransformationFlattenConditionalBranch : public Transformation {
 
   // - |message_.header_block_id| must be the label id of a reachable selection
   //   header, which ends with an OpBranchConditional instruction.
+  // - The condition of the OpBranchConditional instruction must not be an
+  //   irrelevant id.
   // - The header block and the merge block must describe a single-entry,
   //   single-exit region.
   // - The region must not contain barrier or OpSampledImage instructions.


### PR DESCRIPTION
Fixes #3942.
