### PR TITLE
Refactor handling OpLine in spirv-opt

### DIFF
--- a/test/opt/local_access_chain_convert_test.cpp
+++ b/test/opt/local_access_chain_convert_test.cpp
@@ -160,13 +160,10 @@ OpName %gl_FragColor "gl_FragColor"
 ; CHECK: [[st_id:%\w+]] = OpLoad %v4float %BaseColor
 ; CHECK: OpLine {{%\w+}} 1 0
 ; CHECK: [[ld1:%\w+]] = OpLoad %S_t %s0
-; CHECK: OpLine {{%\w+}} 1 0
 ; CHECK: [[ex1:%\w+]] = OpCompositeInsert %S_t [[st_id]] [[ld1]] 1
-; CHECK: OpLine {{%\w+}} 1 0
 ; CHECK: OpStore %s0 [[ex1]]
 ; CHECK: OpLine {{%\w+}} 3 0
 ; CHECK: [[ld2:%\w+]] = OpLoad %S_t %s0
-; CHECK: OpLine {{%\w+}} 3 0
 ; CHECK: [[ex2:%\w+]] = OpCompositeExtract %v4float [[ld2]] 1
 ; CHECK: OpLine {{%\w+}} 4 0
 ; CHECK: OpStore %gl_FragColor [[ex2]]
@@ -263,15 +260,12 @@ OpName %gl_FragColor "gl_FragColor"
 ; CHECK: DebugValue [[dbg_s0:%\w+]] [[s0_1_ptr]]
 ; CHECK: OpLine {{%\w+}} 1 0
 ; CHECK: [[s0:%\w+]] = OpLoad %S_t %s0
-; CHECK: OpLine {{%\w+}} 1 0
 ; CHECK: [[comp:%\w+]] = OpCompositeInsert %S_t [[st_id]] [[s0]] 1
-; CHECK: OpLine {{%\w+}} 1 0
 ; CHECK: OpStore %s0 [[comp]]
 ; CHECK: OpLine {{%\w+}} 2 0
 ; CHECK: [[s0_2_ptr:%\w+]] = OpAccessChain %_ptr_Function_v4float %s0 %int_1
 ; CHECK: OpLine {{%\w+}} 3 0
 ; CHECK: [[s0:%\w+]] = OpLoad %S_t %s0
-; CHECK: OpLine {{%\w+}} 3 0
 ; CHECK: [[s0_2_val:%\w+]] = OpCompositeExtract %v4float [[s0]] 1
 ; CHECK: DebugValue [[dbg_s0]] [[s0_2_val]]
 ; CHECK: OpLine {{%\w+}} 4 0


### PR DESCRIPTION
Based on the OpLine spec, an OpLine instruction must be applied to
the instructions physically following it up to the first occurrence
of the next end of block, the next OpLine instruction, or the next
OpNoLine instruction.

The current implementation of the debug info preservation in each
spirv-opt pass assumes that each instruction has OpLine instructions
applied to it. Therefore, we have to assign the OpLine instruction that
physically appears before an instruction to the instruction. The
existing code does not assign the OpLine instruction to the instruction
physically following it if it is not the next instruction of the OpLine
instruction.

This commit correctly assigns the OpLine instruction not only to the
next instruction of the OpLine instruction but also instructions
physically following it (up to the occurrence of one instruction that
ends the effectiveness of the OpLine).