### PR TITLE
spirv-fuzz: Skip dead blocks in FuzzerPassAddOpPhiSynonyms

### DIFF
--- a/source/fuzz/fuzzer_pass_add_opphi_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_add_opphi_synonyms.cpp
@@ -51,6 +51,12 @@ void FuzzerPassAddOpPhiSynonyms::Apply() {
         continue;
       }
 
+      // The block must not be dead.
+      if (GetTransformationContext()->GetFactManager()->BlockIsDead(
+              block.id())) {
+        continue;
+      }
+
       // The block must have at least one predecessor.
       size_t num_preds = GetIRContext()->cfg()->preds(block.id()).size();
       if (num_preds == 0) {


### PR DESCRIPTION
Fixes #3949.