### PR TITLE
spirv-fuzz: Handle more types when extending OpPhi instructions

### DIFF
--- a/source/fuzz/fuzzer_pass_add_dead_breaks.cpp
+++ b/source/fuzz/fuzzer_pass_add_dead_breaks.cpp
@@ -67,11 +67,15 @@ void FuzzerPassAddDeadBreaks::Apply() {
         // anything.
         if (!block.IsSuccessor(merge_block)) {
           merge_block->ForEachPhiInst([this, &phi_ids](opt::Instruction* phi) {
-            // Add an additional operand for OpPhi instruction.
-            //
-            // We mark the constant as irrelevant so that we can replace it with
-            // a more interesting value later.
-            phi_ids.push_back(FindOrCreateZeroConstant(phi->type_id(), true));
+            // Add an additional operand for OpPhi instruction.  Use a constant
+            // if possible, and an undef otherwise.
+            if (fuzzerutil::CanCreateConstant(GetIRContext(), phi->type_id())) {
+              // We mark the constant as irrelevant so that we can replace it
+              // with a more interesting value later.
+              phi_ids.push_back(FindOrCreateZeroConstant(phi->type_id(), true));
+            } else {
+              phi_ids.push_back(FindOrCreateGlobalUndef(phi->type_id()));
+            }
           });
         }
 

--- a/source/fuzz/fuzzer_pass_add_dead_continues.cpp
+++ b/source/fuzz/fuzzer_pass_add_dead_continues.cpp
@@ -58,11 +58,15 @@ void FuzzerPassAddDeadContinues::Apply() {
       // If this is the case, we don't need to do anything.
       if (!block.IsSuccessor(continue_block)) {
         continue_block->ForEachPhiInst([this, &phi_ids](opt::Instruction* phi) {
-          // Add an additional operand for OpPhi instruction.
-          //
-          // We mark the constant as irrelevant so that we can replace it with a
-          // more interesting value later.
-          phi_ids.push_back(FindOrCreateZeroConstant(phi->type_id(), true));
+          // Add an additional operand for OpPhi instruction.  Use a constant
+          // if possible, and an undef otherwise.
+          if (fuzzerutil::CanCreateConstant(GetIRContext(), phi->type_id())) {
+            // We mark the constant as irrelevant so that we can replace it with
+            // a more interesting value later.
+            phi_ids.push_back(FindOrCreateZeroConstant(phi->type_id(), true));
+          } else {
+            phi_ids.push_back(FindOrCreateGlobalUndef(phi->type_id()));
+          }
         });
       }
 


### PR DESCRIPTION
Fixes #3953.