### PR TITLE
spirv-fuzz: Do not add synonym-creating loops in dead blocks

### DIFF
--- a/source/fuzz/fuzzer_pass_add_loops_to_create_int_constant_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_add_loops_to_create_int_constant_synonyms.cpp
@@ -72,10 +72,15 @@ void FuzzerPassAddLoopsToCreateIntConstantSynonyms::Apply() {
   // synonym. We cannot apply the transformation while iterating over the
   // module, because we are going to add new blocks.
   for (auto& function : *GetIRContext()->module()) {
-    // Consider all blocks reachable from the first block of the function.
+    // Consider all non-dead blocks reachable from the first block of the
+    // function.
     GetIRContext()->cfg()->ForEachBlockInPostOrder(
-        &*function.begin(),
-        [&blocks](opt::BasicBlock* block) { blocks.push_back(block->id()); });
+        &*function.begin(), [this, &blocks](opt::BasicBlock* block) {
+          if (!GetTransformationContext()->GetFactManager()->BlockIsDead(
+                  block->id())) {
+            blocks.push_back(block->id());
+          }
+        });
   }
 
   // Make sure that the module has an OpTypeBool instruction, and 32-bit signed


### PR DESCRIPTION
Fixes #3954.