### PR TITLE
spirv-fuzz: Skip OpTypeSampledImage when propagating up

### DIFF
--- a/source/fuzz/transformation_propagate_instruction_up.cpp
+++ b/source/fuzz/transformation_propagate_instruction_up.cpp
@@ -346,6 +346,12 @@ TransformationPropagateInstructionUp::GetInstructionToPropagate(
     const auto* inst_type = ir_context->get_type_mgr()->GetType(inst.type_id());
     assert(inst_type && "|inst| has invalid type");
 
+    if (inst_type->AsSampledImage()) {
+      // OpTypeSampledImage cannot be used as an argument to OpPhi instructions,
+      // thus we cannot support this type.
+      continue;
+    }
+
     if (!ir_context->get_feature_mgr()->HasCapability(
             SpvCapabilityVariablePointersStorageBuffer) &&
         ContainsPointers(*inst_type)) {


### PR DESCRIPTION
Fixes #3959.