### PR TITLE
spirv-val: Allow the ViewportIndex and Layer built-ins on SPIR-V 1.5

### DIFF
--- a/source/val/validate_builtins.cpp
+++ b/source/val/validate_builtins.cpp
@@ -2649,13 +2649,20 @@ spv_result_t BuiltInsValidator::ValidateLayerOrViewportIndexAtReference(
                 _.HasCapability(SpvCapabilityShaderLayer))
               break;  // Ok
 
+            const char *capability = "ShaderViewportIndexLayerEXT";
+
+            if (operand == SpvBuiltInViewportIndex)
+              capability = "ShaderViewportIndexLayerEXT or ShaderViewportIndex";
+            if (operand == SpvBuiltInLayer)
+              capability = "ShaderViewportIndexLayerEXT or ShaderLayer";
 
             return _.diag(SPV_ERROR_INVALID_DATA, &referenced_from_inst)
                    << "Using BuiltIn "
                    << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
                                                     operand)
-                   << " in Vertex or Tessellation execution model requires "
-                      "the ShaderViewportIndexLayerEXT capability.";
+                   << " in Vertex or Tessellation execution model requires the "
+                   << capability
+                   << " capability.";
           }
           break;
         }

--- a/source/val/validate_builtins.cpp
+++ b/source/val/validate_builtins.cpp
@@ -16,8 +16,6 @@
 
 // Validates correctness of built-in variables.
 
-#include "source/val/validate.h"
-
 #include <functional>
 #include <list>
 #include <map>
@@ -33,6 +31,7 @@
 #include "source/spirv_target_env.h"
 #include "source/util/bitutils.h"
 #include "source/val/instruction.h"
+#include "source/val/validate.h"
 #include "source/val/validation_state.h"
 
 namespace spvtools {
@@ -108,7 +107,9 @@ SpvStorageClass GetStorageClass(const Instruction& inst) {
     case SpvOpGenericCastToPtrExplicit: {
       return SpvStorageClass(inst.word(4));
     }
-    default: { break; }
+    default: {
+      break;
+    }
   }
   return SpvStorageClassMax;
 }
@@ -2641,15 +2642,14 @@ spv_result_t BuiltInsValidator::ValidateLayerOrViewportIndexAtReference(
         case SpvExecutionModelVertex:
         case SpvExecutionModelTessellationEvaluation: {
           if (!_.HasCapability(SpvCapabilityShaderViewportIndexLayerEXT)) {
-
             if (operand == SpvBuiltInViewportIndex &&
                 _.HasCapability(SpvCapabilityShaderViewportIndex))
-              break; // Ok
+              break;  // Ok
             if (operand == SpvBuiltInLayer &&
                 _.HasCapability(SpvCapabilityShaderLayer))
               break;  // Ok
 
-            const char *capability = "ShaderViewportIndexLayerEXT";
+            const char* capability = "ShaderViewportIndexLayerEXT";
 
             if (operand == SpvBuiltInViewportIndex)
               capability = "ShaderViewportIndexLayerEXT or ShaderViewportIndex";
@@ -2661,8 +2661,7 @@ spv_result_t BuiltInsValidator::ValidateLayerOrViewportIndexAtReference(
                    << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
                                                     operand)
                    << " in Vertex or Tessellation execution model requires the "
-                   << capability
-                   << " capability.";
+                   << capability << " capability.";
           }
           break;
         }

--- a/source/val/validate_builtins.cpp
+++ b/source/val/validate_builtins.cpp
@@ -107,9 +107,7 @@ SpvStorageClass GetStorageClass(const Instruction& inst) {
     case SpvOpGenericCastToPtrExplicit: {
       return SpvStorageClass(inst.word(4));
     }
-    default: {
-      break;
-    }
+    default: { break; }
   }
   return SpvStorageClassMax;
 }

--- a/source/val/validate_builtins.cpp
+++ b/source/val/validate_builtins.cpp
@@ -2641,6 +2641,15 @@ spv_result_t BuiltInsValidator::ValidateLayerOrViewportIndexAtReference(
         case SpvExecutionModelVertex:
         case SpvExecutionModelTessellationEvaluation: {
           if (!_.HasCapability(SpvCapabilityShaderViewportIndexLayerEXT)) {
+
+            if (operand == SpvBuiltInViewportIndex &&
+                _.HasCapability(SpvCapabilityShaderViewportIndex))
+              break; // Ok
+            if (operand == SpvBuiltInLayer &&
+                _.HasCapability(SpvCapabilityShaderLayer))
+              break;  // Ok
+
+
             return _.diag(SPV_ERROR_INVALID_DATA, &referenced_from_inst)
                    << "Using BuiltIn "
                    << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,

--- a/test/val/val_builtins_test.cpp
+++ b/test/val/val_builtins_test.cpp
@@ -72,10 +72,9 @@ using ValidateVulkanCombineBuiltInExecutionModelDataTypeCapabilityExtensionResul
                    const char*, const char*, const char*, TestResult>>;
 
 using ValidateGenericCombineBuiltInExecutionModelDataTypeCapabilityExtensionResult =
-  spvtest::ValidateBase<
-      std::tuple<spv_target_env, const char*, const char*, const char*,
-                 const char*, const char*, const char*, const char*,
-                 TestResult>>;
+    spvtest::ValidateBase<std::tuple<spv_target_env, const char*, const char*,
+                                     const char*, const char*, const char*,
+                                     const char*, const char*, TestResult>>;
 
 bool InitializerRequired(spv_target_env env, const char* const storage_class) {
   return spvIsWebGPUEnv(env) && (strncmp(storage_class, "Output", 6) == 0 ||
@@ -277,13 +276,12 @@ TEST_P(
   const char* const vuid = std::get<7>(GetParam());
   const TestResult& test_result = std::get<8>(GetParam());
 
-  CodeGenerator generator = GetInMainCodeGenerator(
-      env, built_in, execution_model, storage_class,
-      capabilities, extensions, data_type);
+  CodeGenerator generator =
+      GetInMainCodeGenerator(env, built_in, execution_model, storage_class,
+                             capabilities, extensions, data_type);
 
   CompileSuccessfully(generator.Build(), env);
-  ASSERT_EQ(test_result.validation_result,
-            ValidateInstructions(env));
+  ASSERT_EQ(test_result.validation_result, ValidateInstructions(env));
   if (test_result.error_str) {
     EXPECT_THAT(getDiagnosticString(), HasSubstr(test_result.error_str));
   }
@@ -1246,9 +1244,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     ViewportIndexExecutionModelEnabledByCapability,
     ValidateVulkanCombineBuiltInExecutionModelDataTypeResult,
-    Combine(Values("ViewportIndex"),
-            Values("Vertex", "TessellationEvaluation"), Values("Output"),
-            Values("%u32"), Values(nullptr),
+    Combine(Values("ViewportIndex"), Values("Vertex", "TessellationEvaluation"),
+            Values("Output"), Values("%u32"), Values(nullptr),
             Values(TestResult(
                 SPV_ERROR_INVALID_DATA,
                 "ShaderViewportIndexLayerEXT or ShaderViewportIndex"))));
@@ -1256,12 +1253,10 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     LayerExecutionModelEnabledByCapability,
     ValidateVulkanCombineBuiltInExecutionModelDataTypeResult,
-    Combine(Values("Layer"),
-            Values("Vertex", "TessellationEvaluation"), Values("Output"),
-            Values("%u32"), Values(nullptr),
-            Values(TestResult(
-                SPV_ERROR_INVALID_DATA,
-                "ShaderViewportIndexLayerEXT or ShaderLayer"))));
+    Combine(Values("Layer"), Values("Vertex", "TessellationEvaluation"),
+            Values("Output"), Values("%u32"), Values(nullptr),
+            Values(TestResult(SPV_ERROR_INVALID_DATA,
+                              "ShaderViewportIndexLayerEXT or ShaderLayer"))));
 
 INSTANTIATE_TEST_SUITE_P(
     LayerAndViewportIndexFragmentNotInput,
@@ -1307,28 +1302,21 @@ INSTANTIATE_TEST_SUITE_P(
                           "needs to be a 32-bit int scalar",
                           "has bit width 64"))));
 
-
 INSTANTIATE_TEST_SUITE_P(
     LayerCapability,
     ValidateGenericCombineBuiltInExecutionModelDataTypeCapabilityExtensionResult,
-    Combine(
-        Values(SPV_ENV_VULKAN_1_2),
-        Values("Layer"), Values("Vertex"), Values("Output"),
-        Values("%u32"),
-        Values("OpCapability ShaderLayer\n"), Values(nullptr),
-        Values(nullptr),
-        Values(TestResult())));
+    Combine(Values(SPV_ENV_VULKAN_1_2), Values("Layer"), Values("Vertex"),
+            Values("Output"), Values("%u32"),
+            Values("OpCapability ShaderLayer\n"), Values(nullptr),
+            Values(nullptr), Values(TestResult())));
 
 INSTANTIATE_TEST_SUITE_P(
     ViewportIndexCapability,
     ValidateGenericCombineBuiltInExecutionModelDataTypeCapabilityExtensionResult,
-    Combine(
-        Values(SPV_ENV_VULKAN_1_2),
-        Values("ViewportIndex"), Values("Vertex"), Values("Output"),
-        Values("%u32"),
-        Values("OpCapability ShaderViewportIndex\n"), Values(nullptr),
-        Values(nullptr),
-        Values(TestResult())));
+    Combine(Values(SPV_ENV_VULKAN_1_2), Values("ViewportIndex"),
+            Values("Vertex"), Values("Output"), Values("%u32"),
+            Values("OpCapability ShaderViewportIndex\n"), Values(nullptr),
+            Values(nullptr), Values(TestResult())));
 
 INSTANTIATE_TEST_SUITE_P(
     PatchVerticesSuccess,

--- a/test/val/val_builtins_test.cpp
+++ b/test/val/val_builtins_test.cpp
@@ -71,6 +71,12 @@ using ValidateVulkanCombineBuiltInExecutionModelDataTypeCapabilityExtensionResul
         std::tuple<const char*, const char*, const char*, const char*,
                    const char*, const char*, const char*, TestResult>>;
 
+using ValidateGenericCombineBuiltInExecutionModelDataTypeCapabilityExtensionResult =
+  spvtest::ValidateBase<
+      std::tuple<spv_target_env, const char*, const char*, const char*,
+                 const char*, const char*, const char*, const char*,
+                 TestResult>>;
+
 bool InitializerRequired(spv_target_env env, const char* const storage_class) {
   return spvIsWebGPUEnv(env) && (strncmp(storage_class, "Output", 6) == 0 ||
                                  strncmp(storage_class, "Private", 7) == 0 ||
@@ -247,6 +253,37 @@ TEST_P(
   CompileSuccessfully(generator.Build(), SPV_ENV_VULKAN_1_0);
   ASSERT_EQ(test_result.validation_result,
             ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  if (test_result.error_str) {
+    EXPECT_THAT(getDiagnosticString(), HasSubstr(test_result.error_str));
+  }
+  if (test_result.error_str2) {
+    EXPECT_THAT(getDiagnosticString(), HasSubstr(test_result.error_str2));
+  }
+  if (vuid) {
+    EXPECT_THAT(getDiagnosticString(), AnyVUID(vuid));
+  }
+}
+
+TEST_P(
+    ValidateGenericCombineBuiltInExecutionModelDataTypeCapabilityExtensionResult,
+    InMain) {
+  const spv_target_env env = std::get<0>(GetParam());
+  const char* const built_in = std::get<1>(GetParam());
+  const char* const execution_model = std::get<2>(GetParam());
+  const char* const storage_class = std::get<3>(GetParam());
+  const char* const data_type = std::get<4>(GetParam());
+  const char* const capabilities = std::get<5>(GetParam());
+  const char* const extensions = std::get<6>(GetParam());
+  const char* const vuid = std::get<7>(GetParam());
+  const TestResult& test_result = std::get<8>(GetParam());
+
+  CodeGenerator generator = GetInMainCodeGenerator(
+      env, built_in, execution_model, storage_class,
+      capabilities, extensions, data_type);
+
+  CompileSuccessfully(generator.Build(), env);
+  ASSERT_EQ(test_result.validation_result,
+            ValidateInstructions(env));
   if (test_result.error_str) {
     EXPECT_THAT(getDiagnosticString(), HasSubstr(test_result.error_str));
   }
@@ -1207,14 +1244,24 @@ INSTANTIATE_TEST_SUITE_P(
                        "Geometry, or Fragment execution models"))));
 
 INSTANTIATE_TEST_SUITE_P(
-    LayerAndViewportIndexExecutionModelEnabledByCapability,
+    ViewportIndexExecutionModelEnabledByCapability,
     ValidateVulkanCombineBuiltInExecutionModelDataTypeResult,
-    Combine(Values("Layer", "ViewportIndex"),
+    Combine(Values("ViewportIndex"),
             Values("Vertex", "TessellationEvaluation"), Values("Output"),
             Values("%u32"), Values(nullptr),
             Values(TestResult(
                 SPV_ERROR_INVALID_DATA,
-                "requires the ShaderViewportIndexLayerEXT capability"))));
+                "ShaderViewportIndexLayerEXT or ShaderViewportIndex"))));
+
+INSTANTIATE_TEST_SUITE_P(
+    LayerExecutionModelEnabledByCapability,
+    ValidateVulkanCombineBuiltInExecutionModelDataTypeResult,
+    Combine(Values("Layer"),
+            Values("Vertex", "TessellationEvaluation"), Values("Output"),
+            Values("%u32"), Values(nullptr),
+            Values(TestResult(
+                SPV_ERROR_INVALID_DATA,
+                "ShaderViewportIndexLayerEXT or ShaderLayer"))));
 
 INSTANTIATE_TEST_SUITE_P(
     LayerAndViewportIndexFragmentNotInput,
@@ -1259,6 +1306,29 @@ INSTANTIATE_TEST_SUITE_P(
         Values(TestResult(SPV_ERROR_INVALID_DATA,
                           "needs to be a 32-bit int scalar",
                           "has bit width 64"))));
+
+
+INSTANTIATE_TEST_SUITE_P(
+    LayerCapability,
+    ValidateGenericCombineBuiltInExecutionModelDataTypeCapabilityExtensionResult,
+    Combine(
+        Values(SPV_ENV_VULKAN_1_2),
+        Values("Layer"), Values("Vertex"), Values("Output"),
+        Values("%u32"),
+        Values("OpCapability ShaderLayer\n"), Values(nullptr),
+        Values(nullptr),
+        Values(TestResult())));
+
+INSTANTIATE_TEST_SUITE_P(
+    ViewportIndexCapability,
+    ValidateGenericCombineBuiltInExecutionModelDataTypeCapabilityExtensionResult,
+    Combine(
+        Values(SPV_ENV_VULKAN_1_2),
+        Values("ViewportIndex"), Values("Vertex"), Values("Output"),
+        Values("%u32"),
+        Values("OpCapability ShaderViewportIndex\n"), Values(nullptr),
+        Values(nullptr),
+        Values(TestResult())));
 
 INSTANTIATE_TEST_SUITE_P(
     PatchVerticesSuccess,


### PR DESCRIPTION
This patch adds support for the `ViewportIndex` and `Layer` built-ins when their corresponding capabilities are present. Previously, the validator would produce a false positive when encountering them without seeing the old `ShaderViewportIndexLayerEXT` capability.

I also have a pull request for [glslang](https://github.com/KhronosGroup/glslang/pull/2432) which adds support for emitting these new capabilities when targeting SPIR-V 1.5