### PR TITLE
spirv-fuzz: Fixes to pass management

### DIFF
--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -383,10 +383,19 @@ bool Fuzzer::ShouldContinueFuzzing() {
     // Stop because we have reached the transformation limit.
     return false;
   }
+  // If we have applied T transformations so far, and the limit on the number of
+  // transformations to apply is L (where T < L), the chance that we will
+  // continue fuzzing is:
+  //
+  //     1 - T/(2*L)
+  //
+  // That is, the chance of continuing decreases as more transformations are
+  // applied.  Using 2*L instead of L increases the number of transformations
+  // that are applied on average.
   auto chance_of_continuing = static_cast<uint32_t>(
-      100.0 *
-      (1.0 - (static_cast<double>(transformations_applied_so_far) /
-              static_cast<double>(fuzzer_context_->GetTransformationLimit()))));
+      100.0 * (1.0 - (static_cast<double>(transformations_applied_so_far) /
+                      (2.0 * static_cast<double>(
+                                 fuzzer_context_->GetTransformationLimit())))));
   if (!fuzzer_context_->ChoosePercentage(chance_of_continuing)) {
     // We have probabilistically decided to stop.
     return false;

--- a/source/fuzz/fuzzer_context.cpp
+++ b/source/fuzz/fuzzer_context.cpp
@@ -29,10 +29,10 @@ const uint32_t kTransformationLimit = 2000;
 // Default <minimum, maximum> pairs of probabilities for applying various
 // transformations. All values are percentages. Keep them in alphabetical order.
 const std::pair<uint32_t, uint32_t>
-    kChanceOfAcceptingRepeatedPassRecommendation = {70, 100};
+    kChanceOfAcceptingRepeatedPassRecommendation = {50, 80};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingAccessChain = {5, 50};
-const std::pair<uint32_t, uint32_t> kChanceOfAddingAnotherPassToPassLoop = {85,
-                                                                            95};
+const std::pair<uint32_t, uint32_t> kChanceOfAddingAnotherPassToPassLoop = {50,
+                                                                            90};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingAnotherStructField = {20,
                                                                          90};
 const std::pair<uint32_t, uint32_t> kChanceOfAddingArrayOrStructType = {20, 90};

--- a/source/fuzz/pass_management/repeated_pass_manager_random_with_recommendations.cpp
+++ b/source/fuzz/pass_management/repeated_pass_manager_random_with_recommendations.cpp
@@ -53,6 +53,8 @@ FuzzerPass* RepeatedPassManagerRandomWithRecommendations::ChoosePass(
     result = recommended_passes_.front();
     recommended_passes_.pop_front();
   }
+  assert(result != nullptr && "A pass must have been chosen.");
+  last_pass_choice_ = result;
   return result;
 }
 


### PR DESCRIPTION
Fixes a bug in the "random with recommendations" strategy, and tweaks
various probabilities to aim for more interesting fuzzer pass
combinations.