### PR TITLE
 Add is_synthetic flag to opt::Instruction

### DIFF
--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -51,7 +51,8 @@ Instruction::Instruction(IRContext* c)
       has_type_id_(false),
       has_result_id_(false),
       unique_id_(c->TakeNextUniqueId()),
-      dbg_scope_(kNoDebugScope, kNoInlinedAt) {}
+      dbg_scope_(kNoDebugScope, kNoInlinedAt),
+      is_synthetic_(false) {}
 
 Instruction::Instruction(IRContext* c, SpvOp op)
     : utils::IntrusiveNodeBase<Instruction>(),
@@ -60,7 +61,8 @@ Instruction::Instruction(IRContext* c, SpvOp op)
       has_type_id_(false),
       has_result_id_(false),
       unique_id_(c->TakeNextUniqueId()),
-      dbg_scope_(kNoDebugScope, kNoInlinedAt) {}
+      dbg_scope_(kNoDebugScope, kNoInlinedAt),
+      is_synthetic_(false) {}
 
 Instruction::Instruction(IRContext* c, const spv_parsed_instruction_t& inst,
                          std::vector<Instruction>&& dbg_line)
@@ -70,7 +72,8 @@ Instruction::Instruction(IRContext* c, const spv_parsed_instruction_t& inst,
       has_result_id_(inst.result_id != 0),
       unique_id_(c->TakeNextUniqueId()),
       dbg_line_insts_(std::move(dbg_line)),
-      dbg_scope_(kNoDebugScope, kNoInlinedAt) {
+      dbg_scope_(kNoDebugScope, kNoInlinedAt),
+      is_synthetic_(false) {
   assert((!IsDebugLineInst(opcode_) || dbg_line.empty()) &&
          "Op(No)Line attaching to Op(No)Line found");
   for (uint32_t i = 0; i < inst.num_operands; ++i) {
@@ -89,7 +92,8 @@ Instruction::Instruction(IRContext* c, const spv_parsed_instruction_t& inst,
       has_type_id_(inst.type_id != 0),
       has_result_id_(inst.result_id != 0),
       unique_id_(c->TakeNextUniqueId()),
-      dbg_scope_(dbg_scope) {
+      dbg_scope_(dbg_scope),
+      is_synthetic_(false) {
   for (uint32_t i = 0; i < inst.num_operands; ++i) {
     const auto& current_payload = inst.operands[i];
     std::vector<uint32_t> words(
@@ -108,7 +112,8 @@ Instruction::Instruction(IRContext* c, SpvOp op, uint32_t ty_id,
       has_result_id_(res_id != 0),
       unique_id_(c->TakeNextUniqueId()),
       operands_(),
-      dbg_scope_(kNoDebugScope, kNoInlinedAt) {
+      dbg_scope_(kNoDebugScope, kNoInlinedAt),
+      is_synthetic_(false) {
   if (has_type_id_) {
     operands_.emplace_back(spv_operand_type_t::SPV_OPERAND_TYPE_TYPE_ID,
                            std::initializer_list<uint32_t>{ty_id});
@@ -128,7 +133,8 @@ Instruction::Instruction(Instruction&& that)
       unique_id_(that.unique_id_),
       operands_(std::move(that.operands_)),
       dbg_line_insts_(std::move(that.dbg_line_insts_)),
-      dbg_scope_(that.dbg_scope_) {
+      dbg_scope_(that.dbg_scope_),
+      is_synthetic_(that.is_synthetic_) {
   for (auto& i : dbg_line_insts_) {
     i.dbg_scope_ = that.dbg_scope_;
   }
@@ -142,6 +148,7 @@ Instruction& Instruction::operator=(Instruction&& that) {
   operands_ = std::move(that.operands_);
   dbg_line_insts_ = std::move(that.dbg_line_insts_);
   dbg_scope_ = that.dbg_scope_;
+  is_synthetic_ = that.is_synthetic_;
   return *this;
 }
 
@@ -154,6 +161,7 @@ Instruction* Instruction::Clone(IRContext* c) const {
   clone->operands_ = operands_;
   clone->dbg_line_insts_ = dbg_line_insts_;
   clone->dbg_scope_ = dbg_scope_;
+  clone->is_synthetic_ = is_synthetic_;
   return clone;
 }
 

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -117,7 +117,7 @@ inline bool operator!=(const Operand& o1, const Operand& o2) {
 }
 
 // This structure is used to represent a DebugScope instruction from
-// the OpenCL.100.DebugInfo extened instruction set. Note that we can
+// the OpenCL.100.DebugInfo extended instruction set. Note that we can
 // ignore the result id of DebugScope instruction because it is not
 // used for anything. We do not keep it to reduce the size of
 // structure.
@@ -175,7 +175,8 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
         has_type_id_(false),
         has_result_id_(false),
         unique_id_(0),
-        dbg_scope_(kNoDebugScope, kNoInlinedAt) {}
+        dbg_scope_(kNoDebugScope, kNoInlinedAt),
+        is_synthetic_(false) {}
 
   // Creates a default OpNop instruction.
   Instruction(IRContext*);
@@ -558,6 +559,12 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   // debuggers.
   void Dump() const;
 
+  // Returns true if this instruction was automatically inserted by the module
+  // loader to track debug information.
+  bool IsSynthetic() const { return is_synthetic_; }
+  // Sets whether this instruction is considered to be synthetic.
+  void SetSynthetic(bool flag) { is_synthetic_ = flag; }
+
  private:
   // Returns the total count of result type id and result id.
   uint32_t TypeResultIdCount() const {
@@ -591,6 +598,10 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
 
   // DebugScope that wraps this instruction.
   DebugScope dbg_scope_;
+
+  // True if this instruction was created by the IR loader for the purpose
+  // of recording line information.
+  bool is_synthetic_;
 
   friend InstructionList;
 };

--- a/source/opt/ir_loader.cpp
+++ b/source/opt/ir_loader.cpp
@@ -100,6 +100,7 @@ bool IrLoader::AddInstruction(const spv_parsed_instruction_t* inst) {
   } else if (last_line_inst_ != nullptr) {
     last_line_inst_->SetDebugScope(last_dbg_scope_);
     spv_inst->dbg_line_insts().push_back(*last_line_inst_);
+    spv_inst->dbg_line_insts().back().SetSynthetic(true);
   }
 
   const char* src = source_.c_str();

--- a/test/opt/instruction_test.cpp
+++ b/test/opt/instruction_test.cpp
@@ -47,6 +47,8 @@ TEST(InstructionTest, CreateTrivial) {
   EXPECT_EQ(0u, empty.NumInOperandWords());
   EXPECT_EQ(empty.cend(), empty.cbegin());
   EXPECT_EQ(empty.end(), empty.begin());
+  EXPECT_EQ(empty.end(), empty.begin());
+  EXPECT_FALSE(empty.IsSynthetic());
 }
 
 TEST(InstructionTest, CreateWithOpcodeAndNoOperands) {
@@ -60,6 +62,7 @@ TEST(InstructionTest, CreateWithOpcodeAndNoOperands) {
   EXPECT_EQ(0u, inst.NumInOperandWords());
   EXPECT_EQ(inst.cend(), inst.cbegin());
   EXPECT_EQ(inst.end(), inst.begin());
+  EXPECT_FALSE(inst.IsSynthetic());
 }
 
 TEST(InstructionTest, OperandAsCString) {
@@ -163,6 +166,7 @@ TEST(InstructionTest, CreateWithOpcodeAndOperands) {
   EXPECT_EQ(3u, inst.NumOperands());
   EXPECT_EQ(3u, inst.NumOperandWords());
   EXPECT_EQ(2u, inst.NumInOperandWords());
+  EXPECT_FALSE(inst.IsSynthetic());
 }
 
 TEST(InstructionTest, GetOperand) {
@@ -1529,6 +1533,24 @@ OpFunctionEnd
   EXPECT_EQ(true, inst->IsVulkanStorageImage());
   EXPECT_EQ(false, inst->IsVulkanSampledImage());
   EXPECT_EQ(false, inst->IsVulkanStorageTexelBuffer());
+}
+
+TEST(InstructionTest, Instruction_SetSynthetic) {
+  IRContext context(SPV_ENV_UNIVERSAL_1_2, nullptr);
+  Instruction inst(&context, kSampleParsedInstruction);
+  EXPECT_FALSE(inst.IsSynthetic());
+  inst.SetSynthetic(true);
+  EXPECT_TRUE(inst.IsSynthetic());
+  inst.SetSynthetic(false);
+  EXPECT_FALSE(inst.IsSynthetic());
+}
+
+TEST(InstructionTest, Instruction_SyntheticPropertySurvivesCopying) {
+  IRContext context(SPV_ENV_UNIVERSAL_1_2, nullptr);
+  Instruction inst(&context, kSampleParsedInstruction);
+  inst.SetSynthetic(true);
+  Instruction copy(inst);
+  EXPECT_TRUE(copy.IsSynthetic());
 }
 
 }  // namespace


### PR DESCRIPTION
The flag is true when the IR loader has created the instruction
solely for the purpose of tracking debug line information.

Add public methods to set it and query it.

Fixes #4029