### PR TITLE
Do run DCE if SPV_KHR_ray_query is used.

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -991,6 +991,7 @@ void AggressiveDCEPass::InitExtensions() {
       "SPV_NV_mesh_shader",
       "SPV_NV_ray_tracing",
       "SPV_KHR_ray_tracing",
+      "SPV_KHR_ray_query",
       "SPV_EXT_fragment_invocation_density",
       "SPV_EXT_physical_storage_buffer",
       "SPV_KHR_terminate_invocation",


### PR DESCRIPTION
When support for `KHR_ray_query` and `KHR_ray_tracing` [landed in SPIRV-Tools](https://github.com/KhronosGroup/SPIRV-Tools/commit/5a97e3a391677ff9baae8ccdf5c03c4d403d848b), it missed adding ray_query to acceptable extensions for DCE.

Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/3287