### PR TITLE
opt: Run DCE when SPV_KHR_shader_clock is used

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -995,6 +995,7 @@ void AggressiveDCEPass::InitExtensions() {
       "SPV_EXT_fragment_invocation_density",
       "SPV_EXT_physical_storage_buffer",
       "SPV_KHR_terminate_invocation",
+      "SPV_KHR_shader_clock",
   });
 }
 


### PR DESCRIPTION
Similar to [1] DCE should be ran when this extension is enabled to prevent unused bindings from showing up (in particular atomic counters attached to buffers).

[1]: https://github.com/KhronosGroup/SPIRV-Tools/pull/4047
