### PR TITLE
Force using Python 3 git-sync-deps

### DIFF
--- a/utils/git-sync-deps
+++ b/utils/git-sync-deps
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2014 Google Inc.
 #
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This scripts fails to run in Python 2.
For systems that have both Python 2 and 3 installed, 
depending on your PATH the existing code may or 
may not run. Explictly using Python 3 to avoid this.