### PR TITLE
spirv-val: Add first StandAlone VUID 04633

### DIFF
--- a/source/val/validate_mode_setting.cpp
+++ b/source/val/validate_mode_setting.cpp
@@ -42,7 +42,8 @@ spv_result_t ValidateEntryPoint(ValidationState_t& _, const Instruction* inst) {
     const auto entry_point_type = _.FindDef(entry_point_type_id);
     if (!entry_point_type || 3 != entry_point_type->words().size()) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "OpEntryPoint Entry Point <id> '" << _.getIdName(entry_point_id)
+             << _.VkErrorID(4633) << "OpEntryPoint Entry Point <id> '"
+             << _.getIdName(entry_point_id)
              << "'s function parameter count is not zero.";
     }
   }
@@ -50,7 +51,8 @@ spv_result_t ValidateEntryPoint(ValidationState_t& _, const Instruction* inst) {
   auto return_type = _.FindDef(entry_point->type_id());
   if (!return_type || SpvOpTypeVoid != return_type->opcode()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpEntryPoint Entry Point <id> '" << _.getIdName(entry_point_id)
+           << _.VkErrorID(4633) << "OpEntryPoint Entry Point <id> '"
+           << _.getIdName(entry_point_id)
            << "'s function return type is not void.";
   }
 

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -1665,6 +1665,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-ShadingRateKHR-ShadingRateKHR-04491);
     case 4492:
       return VUID_WRAP(VUID-ShadingRateKHR-ShadingRateKHR-04492);
+    case 4633:
+      return VUID_WRAP(VUID-StandaloneSpirv-None-04633);
     default:
       return "";  // unknown id
   };

--- a/test/val/val_builtins_test.cpp
+++ b/test/val/val_builtins_test.cpp
@@ -159,44 +159,6 @@ CodeGenerator GetInMainCodeGenerator(spv_target_env env,
   return generator;
 }
 
-// Allows test parameter test to list all possible VUIDs with a delimiter that
-// is then split here to check if one VUID was in the error message
-MATCHER_P(AnyVUID, vuid_set, "VUID from the set is in error message") {
-  // use space as delimiter because clang-format will properly line break VUID
-  // strings which is important the entire VUID is in a single line for script
-  // to scan
-  std::string delimiter = " ";
-  std::string token;
-  std::string vuids = std::string(vuid_set);
-  size_t position;
-
-  // Catch case were someone accidentally left spaces by trimming string
-  // clang-format off
-  vuids.erase(std::find_if(vuids.rbegin(), vuids.rend(), [](unsigned char c) {
-    return (c != ' ');
-  }).base(), vuids.end());
-  vuids.erase(vuids.begin(), std::find_if(vuids.begin(), vuids.end(), [](unsigned char c) {
-    return (c != ' ');
-  }));
-  // clang-format on
-
-  do {
-    position = vuids.find(delimiter);
-    if (position != std::string::npos) {
-      token = vuids.substr(0, position);
-      vuids.erase(0, position + delimiter.length());
-    } else {
-      token = vuids.substr(0);  // last item
-    }
-
-    // arg contains diagnostic message
-    if (arg.find(token) != std::string::npos) {
-      return true;
-    }
-  } while (position != std::string::npos);
-  return false;
-}
-
 TEST_P(ValidateVulkanCombineBuiltInExecutionModelDataTypeResult, InMain) {
   const char* const built_in = std::get<0>(GetParam());
   const char* const execution_model = std::get<1>(GetParam());


### PR DESCRIPTION
Adds `VUID-StandaloneSpirv-None-04633`

Now that most of the Built-ins are done, the next goal is to add VUID labels to all the Vulkan Spec's SPIR-V Standalone validation rules
https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/chap46.html#spirvenv-module-validation

This will make it easy to see the gaps missing in `spirv-val` which I can then add