### PR TITLE
spirv-val: Vulkan atomic storage class

### DIFF
--- a/source/val/validate_atomics.cpp
+++ b/source/val/validate_atomics.cpp
@@ -217,11 +217,13 @@ spv_result_t AtomicsPass(ValidationState_t& _, const Instruction* inst) {
           if ((storage_class != SpvStorageClassUniform) &&
               (storage_class != SpvStorageClassStorageBuffer) &&
               (storage_class != SpvStorageClassWorkgroup) &&
-              (storage_class != SpvStorageClassImage)) {
+              (storage_class != SpvStorageClassImage) &&
+              (storage_class != SpvStorageClassPhysicalStorageBuffer)) {
             return _.diag(SPV_ERROR_INVALID_DATA, inst)
                    << _.VkErrorID(4686) << spvOpcodeString(opcode)
                    << ": Vulkan spec only allows storage classes for atomic to "
-                      "be: Uniform, Workgroup, Image, StorageBuffer.";
+                      "be: Uniform, Workgroup, Image, StorageBuffer, or "
+                      "PhysicalStorageBuffer.";
           }
         } else if (storage_class == SpvStorageClassFunction) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)

--- a/source/val/validate_atomics.cpp
+++ b/source/val/validate_atomics.cpp
@@ -213,7 +213,17 @@ spv_result_t AtomicsPass(ValidationState_t& _, const Instruction* inst) {
 
       // Then Shader rules
       if (_.HasCapability(SpvCapabilityShader)) {
-        if (storage_class == SpvStorageClassFunction) {
+        if (spvIsVulkanEnv(_.context()->target_env)) {
+          if ((storage_class != SpvStorageClassUniform) &&
+              (storage_class != SpvStorageClassStorageBuffer) &&
+              (storage_class != SpvStorageClassWorkgroup) &&
+              (storage_class != SpvStorageClassImage)) {
+            return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                   << _.VkErrorID(4686) << spvOpcodeString(opcode)
+                   << ": Vulkan spec only allows storage classes for atomic to "
+                      "be: Uniform, Workgroup, Image, StorageBuffer.";
+          }
+        } else if (storage_class == SpvStorageClassFunction) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << spvOpcodeString(opcode)
                  << ": Function storage class forbidden when the Shader "

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -1691,6 +1691,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-FPRoundingMode-04675);
     case 4685:
       return VUID_WRAP(VUID-StandaloneSpirv-OpGroupNonUniformBallotBitCount-04685);
+    case 4686:
+      return VUID_WRAP(VUID-StandaloneSpirv-None-04686);
     case 4711:
       return VUID_WRAP(VUID-StandaloneSpirv-OpTypeForwardPointer-04711);
     default:

--- a/test/val/val_atomics_test.cpp
+++ b/test/val/val_atomics_test.cpp
@@ -430,6 +430,19 @@ OpAtomicStore %f32_var_function %device %relaxed %f32_1
                 "PhysicalStorageBuffer."));
 }
 
+TEST_F(ValidateAtomics, AtomicStoreFunctionPointerStorageType) {
+  const std::string body = R"(
+%f32_var_function = OpVariable %f32_ptr_function Function
+OpAtomicStore %f32_var_function %device %relaxed %f32_1
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("AtomicStore: Function storage class forbidden when "
+                        "the Shader capability is declared."));
+}
+
 // TODO(atgoo@github.com): the corresponding check fails Vulkan CTS,
 // reenable once fixed.
 TEST_F(ValidateAtomics, DISABLED_AtomicLoadVulkanSubgroup) {

--- a/test/val/val_atomics_test.cpp
+++ b/test/val/val_atomics_test.cpp
@@ -426,7 +426,8 @@ OpAtomicStore %f32_var_function %device %relaxed %f32_1
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("AtomicStore: Vulkan spec only allows storage classes for "
-                "atomic to be: Uniform, Workgroup, Image, StorageBuffer."));
+                "atomic to be: Uniform, Workgroup, Image, StorageBuffer, or "
+                "PhysicalStorageBuffer."));
 }
 
 // TODO(atgoo@github.com): the corresponding check fails Vulkan CTS,

--- a/test/val/val_atomics_test.cpp
+++ b/test/val/val_atomics_test.cpp
@@ -422,8 +422,11 @@ OpAtomicStore %f32_var_function %device %relaxed %f32_1
   CompileSuccessfully(GenerateShaderCode(body), SPV_ENV_VULKAN_1_0);
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("AtomicStore: Function storage class forbidden when "
-                        "the Shader capability is declared."));
+              AnyVUID("VUID-StandaloneSpirv-None-04686"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("AtomicStore: Vulkan spec only allows storage classes for "
+                "atomic to be: Uniform, Workgroup, Image, StorageBuffer."));
 }
 
 // TODO(atgoo@github.com): the corresponding check fails Vulkan CTS,


### PR DESCRIPTION
`VUID-StandaloneSpirv-None-04686`

> The Pointer operand of all atomic instructions must have a Storage Class limited to Uniform, Workgroup, Image, StorageBuffer