### PR TITLE
spirv-opt: Add optional argument to freeze-spec-const pass to allow freezing only a subset of constants

### DIFF
--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -19,6 +19,7 @@
 #include <ostream>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "libspirv.hpp"
@@ -304,6 +305,19 @@ Optimizer::PassToken CreateFlattenDecorationPass();
 // other spec constants defined by OpSpecConstantComposite or
 // OpSpecConstantOp.
 Optimizer::PassToken CreateFreezeSpecConstantValuePass();
+
+// Creates a freeze-spec-constant-value pass.
+// A freeze-spec-constant pass specializes the value of spec constants to
+// their default values. This pass only processes the spec constants that have
+// SpecId decorations with ids matching the spec-ids in id_set (defined by
+// OpSpecConstant, OpSpecConstantTrue, or OpSpecConstantFalse instructions)
+// and replaces them with their normal counterparts (OpConstant,
+// OpConstantTrue, or OpConstantFalse). The corresponding SpecId annotation
+// instructions will also be removed. This pass does not fold the newly added
+// normal constants and does not process other spec constants defined by
+// OpSpecConstantComposite or OpSpecConstantOp.
+Optimizer::PassToken CreateFreezeSpecConstantValuePass(
+    const std::unordered_set<uint32_t>& id_set);
 
 // Creates a fold-spec-constant-op-and-composite pass.
 // A fold-spec-constant-op-and-composite pass folds spec constants defined by

--- a/source/opt/freeze_spec_constant_value_pass.cpp
+++ b/source/opt/freeze_spec_constant_value_pass.cpp
@@ -13,12 +13,23 @@
 // limitations under the License.
 
 #include "source/opt/freeze_spec_constant_value_pass.h"
+
 #include "source/opt/ir_context.h"
+#include "source/opt/set_spec_constant_default_value_pass.h"
+#include "source/util/parse_number.h"
 
 namespace spvtools {
 namespace opt {
 
 Pass::Status FreezeSpecConstantValuePass::Process() {
+  if (spec_ids_.empty()) {
+    return FreezeAllSpecIds();
+  } else {
+    return FreezeSpecIds(spec_ids_);
+  }
+}
+
+Pass::Status FreezeSpecConstantValuePass::FreezeAllSpecIds() {
   bool modified = false;
   auto ctx = context();
   ctx->module()->ForEachInst([&modified, ctx](Instruction* inst) {
@@ -47,6 +58,116 @@ Pass::Status FreezeSpecConstantValuePass::Process() {
     }
   });
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
+}
+
+Pass::Status FreezeSpecConstantValuePass::FreezeSpecIds(
+    const SpecIdSet& spec_ids) {
+  // The operand index of decoration target in an OpDecorate instruction.
+  const uint32_t kTargetIdOperandIndex = 0;
+  // The operand index of the decoration literal in an OpDecorate instruction.
+  const uint32_t kDecorationOperandIndex = 1;
+  // The operand index of Spec id literal value in an OpDecorate SpecId
+  // instruction.
+  const uint32_t kSpecIdLiteralOperandIndex = 2;
+  // The number of operands in an OpDecorate SpecId instruction.
+  const uint32_t kOpDecorateSpecIdNumOperands = 3;
+
+  auto ctx = context();
+  auto def = get_def_use_mgr();
+  bool modified = false;
+
+  // Scan through all the annotation instructions to find 'OpDecorate SpecId'
+  // instructions. This iteration style is modeled on
+  // |InstructionList::ForEachInst| so that calling |KillInst| doesn't
+  // invalidate the iterator.
+  auto next = ctx->annotation_begin();
+  for (auto i = next; i != ctx->annotation_end(); i = next) {
+    ++next;
+
+    // Only process 'OpDecorate SpecId' instructions
+    Instruction& inst = *i;
+    if (inst.opcode() != SpvOp::SpvOpDecorate) continue;
+    if (inst.NumOperands() != kOpDecorateSpecIdNumOperands) continue;
+    if (inst.GetSingleWordInOperand(kDecorationOperandIndex) !=
+        uint32_t(SpvDecoration::SpvDecorationSpecId)) {
+      continue;
+    }
+
+    // 'inst' is an OpDecorate SpecId instruction.
+    uint32_t spec_id = inst.GetSingleWordOperand(kSpecIdLiteralOperandIndex);
+    uint32_t target_id = inst.GetSingleWordOperand(kTargetIdOperandIndex);
+
+    // Only process spec-ids specified by the caller.
+    if (spec_ids.find(spec_id) == spec_ids.end()) {
+      continue;
+    }
+
+    // Find the spec constant defining instruction. Note that the
+    // target_id might be a decoration group id.
+    Instruction* spec_inst = nullptr;
+    if (Instruction* target_inst = def->GetDef(target_id)) {
+      if (target_inst->opcode() == SpvOp::SpvOpDecorationGroup) {
+        spec_inst =
+            SetSpecConstantDefaultValuePass::GetSpecIdTargetFromDecorationGroup(
+                *target_inst, def);
+      } else {
+        spec_inst = target_inst;
+      }
+    }
+    if (!spec_inst) continue;
+
+    // Freeze the OpSpecConstant{|True|False} instruction and remove the
+    // OpDecorate SpecId instruction
+    switch (spec_inst->opcode()) {
+      case SpvOp::SpvOpSpecConstant:
+        spec_inst->SetOpcode(SpvOp::SpvOpConstant);
+        ctx->KillInst(&inst);
+        modified = true;
+        break;
+      case SpvOp::SpvOpSpecConstantTrue:
+        spec_inst->SetOpcode(SpvOp::SpvOpConstantTrue);
+        ctx->KillInst(&inst);
+        modified = true;
+        break;
+      case SpvOp::SpvOpSpecConstantFalse:
+        spec_inst->SetOpcode(SpvOp::SpvOpConstantFalse);
+        ctx->KillInst(&inst);
+        modified = true;
+        break;
+      default:
+        break;
+    }
+  }
+  return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
+}
+
+std::unique_ptr<FreezeSpecConstantValuePass::SpecIdSet>
+FreezeSpecConstantValuePass::ParseSpecIdsString(const char* str) {
+  if (!str) return nullptr;
+
+  auto spec_ids = MakeUnique<SpecIdSet>();
+
+  // The parsing loop, break when points to the end.
+  while (*str) {
+    // Find the next spec id.
+    while (std::isspace(*str)) str++;  // Skip leading spaces.
+    const char* id_begin = str;
+    while (!std::isspace(*str) && *str) str++;
+    const char* id_end = str;
+    std::string spec_id_str(id_begin, id_end - id_begin);
+    uint32_t spec_id = 0;
+    if (!utils::ParseNumber(spec_id_str.c_str(), &spec_id)) {
+      // The spec id is not a valid uint32 number.
+      return nullptr;
+    }
+    // Add to set.
+    spec_ids->insert(spec_id);
+
+    // Skip trailing spaces.
+    while (std::isspace(*str)) str++;
+  }
+
+  return spec_ids;
 }
 
 }  // namespace opt

--- a/source/opt/set_spec_constant_default_value_pass.h
+++ b/source/opt/set_spec_constant_default_value_pass.h
@@ -96,6 +96,14 @@ class SetSpecConstantDefaultValuePass : public Pass {
   static std::unique_ptr<SpecIdToValueStrMap> ParseDefaultValuesString(
       const char* str);
 
+  // Given a decoration group defining instruction that is decorated with SpecId
+  // decoration, finds the spec constant defining instruction which is the real
+  // target of the SpecId decoration. Returns the spec constant defining
+  // instruction if such an instruction is found, otherwise returns a nullptr.
+  static Instruction* GetSpecIdTargetFromDecorationGroup(
+      const Instruction& decoration_group_defining_inst,
+      analysis::DefUseManager* def_use_mgr);
+
  private:
   // The mappings from spec ids to default values. Two maps are defined here,
   // each to be used for one specific form of the default values. Only one of

--- a/test/opt/optimizer_test.cpp
+++ b/test/opt/optimizer_test.cpp
@@ -150,6 +150,7 @@ TEST(Optimizer, CanRegisterPassesFromFlags) {
       "--strip-reflect",
       "--set-spec-const-default-value=23:42 21:12",
       "--if-conversion",
+      "--freeze-spec-const=23 21",
       "--freeze-spec-const",
       "--inline-entry-points-exhaustive",
       "--inline-entry-points-opaque",
@@ -206,6 +207,9 @@ TEST(Optimizer, CanRegisterPassesFromFlags) {
   EXPECT_EQ(msg_level, SPV_MSG_ERROR);
 
   EXPECT_FALSE(opt.RegisterPassFromFlag("--set-spec-const-default-value"));
+  EXPECT_EQ(msg_level, SPV_MSG_ERROR);
+
+  EXPECT_FALSE(opt.RegisterPassFromFlag("--freeze-spec-const=s"));
   EXPECT_EQ(msg_level, SPV_MSG_ERROR);
 
   EXPECT_FALSE(opt.RegisterPassFromFlag("--scalar-replacement=s"));

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -230,9 +230,12 @@ Options (in lexicographical order):)",
                OpSpecConstantComposite instructions to front-end constants
                when possible.)");
   printf(R"(
-  --freeze-spec-const
+  --freeze-spec-const[="<spec id> ..."]
                Freeze the values of specialization constants to their default
-               values.)");
+               values. An optional double-quoted, space-separated list of
+               <spec id> values may be provided to freeze only a subet of all
+               specialization constants.
+               e.g.: --freeze-spec-const="1 2 3")");
   printf(R"(
   --graphics-robust-access
                Clamp indices used to access buffers and internal composite


### PR DESCRIPTION
This PR adds an optional argument to the `--freeze-spec-const` pass to allow the user to freeze only a subset of `OpSpecConstant{|True|False}` instructions. The pass can be specified as it was before to freeze all spec constants (i.e. `--freeze-spec-const`), but now can optionally be provided an argument like `--freeze-spec-const="1 2 3"`. The motivating use-cases for me are:
- Specialization constants as a replacement for #define-based uber shaders. Could compile the base uber shader to SPIR-V once, then generate optimized variants by modifying spec constant values + freezing.
- Performing static specialization for platforms with known/fixed specs (e.g. compute shader threadgroup size for Console Z might always be 8x4 or 8x8, but PC could be left to be specified at runtime, or statically enabling/disabling code paths optimized for specific platforms).

My intent is to use specialization constants in place of #define-based solutions, code generation, or custom parsing.

Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/4048

Cheers,
Matt