### PR TITLE
spirv-val: Add Vulkan Group Operation VUID

### DIFF
--- a/source/val/validate_non_uniform.cpp
+++ b/source/val/validate_non_uniform.cpp
@@ -47,6 +47,19 @@ spv_result_t ValidateGroupNonUniformBallotBitCount(ValidationState_t& _,
                                                    "vector of four components "
                                                    "of integer type scalar";
   }
+
+  const auto group = inst->GetOperandAs<uint32_t>(3);
+  if (spvIsVulkanEnv(_.context()->target_env)) {
+    if ((group != SpvGroupOperationReduce) &&
+        (group != SpvGroupOperationInclusiveScan) &&
+        (group != SpvGroupOperationExclusiveScan)) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << _.VkErrorID(4685)
+             << "In Vulkan: The OpGroupNonUniformBallotBitCount group "
+                "operation must be only: Reduce, InclusiveScan, or "
+                "ExclusiveScan.";
+    }
+  }
   return SPV_SUCCESS;
 }
 

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -1667,6 +1667,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-ShadingRateKHR-ShadingRateKHR-04492);
     case 4633:
       return VUID_WRAP(VUID-StandaloneSpirv-None-04633);
+    case 4685:
+      return VUID_WRAP(VUID-StandaloneSpirv-OpGroupNonUniformBallotBitCount-04685);
     default:
       return "";  // unknown id
   };

--- a/test/val/val_non_uniform_test.cpp
+++ b/test/val/val_non_uniform_test.cpp
@@ -100,6 +100,7 @@ OpFunctionEnd)";
 SpvScope scopes[] = {SpvScopeCrossDevice, SpvScopeDevice, SpvScopeWorkgroup,
                      SpvScopeSubgroup, SpvScopeInvocation};
 
+using ValidateGroupNonUniform = spvtest::ValidateBase<bool>;
 using GroupNonUniform = spvtest::ValidateBase<
     std::tuple<std::string, std::string, SpvScope, std::string, std::string>>;
 
@@ -287,6 +288,41 @@ INSTANTIATE_TEST_SUITE_P(GroupNonUniformBallotBitCountBadValue, GroupNonUniform,
                                         "Reduce %float_0"),
                                  Values("Expected Value to be a vector of four "
                                         "components of integer type scalar")));
+
+TEST_F(ValidateGroupNonUniform, VulkanGroupNonUniformBallotBitCountOperation) {
+  std::string test = R"(
+OpCapability Shader
+OpCapability GroupNonUniform
+OpCapability GroupNonUniformBallot
+OpCapability GroupNonUniformClustered
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+%void = OpTypeVoid
+%func = OpTypeFunction %void
+%u32 = OpTypeInt 32 0
+%u32vec4 = OpTypeVector %u32 4
+%u32_0 = OpConstant %u32 0
+%u32vec4_null = OpConstantComposite %u32vec4 %u32_0 %u32_0 %u32_0 %u32_0
+%subgroup = OpConstant %u32 3
+%main = OpFunction %void None %func
+%main_entry = OpLabel
+%result = OpGroupNonUniformBallotBitCount %u32 %subgroup ClusteredReduce %u32vec4_null
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(test, SPV_ENV_VULKAN_1_1);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_1));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      AnyVUID("VUID-StandaloneSpirv-OpGroupNonUniformBallotBitCount-04685"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(
+          "In Vulkan: The OpGroupNonUniformBallotBitCount group operation must "
+          "be only: Reduce, InclusiveScan, or ExclusiveScan."));
+}
 
 }  // namespace
 }  // namespace val


### PR DESCRIPTION
`VUID-StandaloneSpirv-OpGroupNonUniformBallotBitCount-04685`

> If OpGroupNonUniformBallotBitCount is used, the group operation must be limited to Reduce, InclusiveScan, or ExclusiveScan