### PR TITLE
spirv-val: Add Vulkan FP Mode VUID

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -1669,6 +1669,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-None-04633);
     case 4658:
       return VUID_WRAP(VUID-StandaloneSpirv-OpImageTexelPointer-04658);
+    case 4675:
+      return VUID_WRAP(VUID-StandaloneSpirv-FPRoundingMode-04675);
     case 4685:
       return VUID_WRAP(VUID-StandaloneSpirv-OpGroupNonUniformBallotBitCount-04685);
     default:


### PR DESCRIPTION
`VUID-StandaloneSpirv-FPRoundingMode-04675`

> Only the round-to-nearest-even and the round-towards-zero rounding modes can be used for the FPRoundingMode decoration