### PR TITLE
spirv-val: Add Vulkan decoration VUID

### DIFF
--- a/source/val/validate_annotation.cpp
+++ b/source/val/validate_annotation.cpp
@@ -219,6 +219,16 @@ spv_result_t ValidateDecorate(ValidationState_t& _, const Instruction* inst) {
            << "' is not valid for the WebGPU execution environment.";
   }
 
+  if (spvIsVulkanEnv(_.context()->target_env)) {
+    if ((decoration == SpvDecorationGLSLShared) ||
+        (decoration == SpvDecorationGLSLPacked)) {
+      return _.diag(SPV_ERROR_INVALID_ID, inst)
+             << _.VkErrorID(4669) << "OpDecorate decoration '"
+             << LogStringForDecoration(decoration)
+             << "' is not valid for the Vulkan execution environment.";
+    }
+  }
+
   if (DecorationTakesIdParameters(decoration)) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
            << "Decorations taking ID parameters may not be used with "

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -1671,6 +1671,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-OpTypeImage-04656);
     case 4658:
       return VUID_WRAP(VUID-StandaloneSpirv-OpImageTexelPointer-04658);
+    case 4669:
+      return VUID_WRAP(VUID-StandaloneSpirv-GLSLShared-04669);
     case 4675:
       return VUID_WRAP(VUID-StandaloneSpirv-FPRoundingMode-04675);
     case 4685:


### PR DESCRIPTION
Copied same style as the WebGPU `IsValidWebGPUDecoration()`

`VUID-StandaloneSpirv-GLSLShared-04669`

> The GLSLShared and GLSLPacked decorations must not be used