### PR TITLE
spirv-val: Add Vulkan Addressing Model check

### DIFF
--- a/source/val/validate_mode_setting.cpp
+++ b/source/val/validate_mode_setting.cpp
@@ -520,6 +520,15 @@ spv_result_t ValidateMemoryModel(ValidationState_t& _,
     }
   }
 
+  if (spvIsVulkanEnv(_.context()->target_env)) {
+    if ((_.addressing_model() != SpvAddressingModelLogical) &&
+        (_.addressing_model() != SpvAddressingModelPhysicalStorageBuffer64)) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << _.VkErrorID(4635)
+             << "Addressing model must be Logical or PhysicalStorageBuffer64 "
+             << "in the Vulkan environment.";
+    }
+  }
   return SPV_SUCCESS;
 }
 

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -1667,6 +1667,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-ShadingRateKHR-ShadingRateKHR-04492);
     case 4633:
       return VUID_WRAP(VUID-StandaloneSpirv-None-04633);
+    case 4635:
+      return VUID_WRAP(VUID-StandaloneSpirv-None-04635);
     case 4642:
       return VUID_WRAP(VUID-StandaloneSpirv-None-04642);
     case 4649:


### PR DESCRIPTION
I tried writing a negative test, but the issue is the only invalid addressing models currently are Physical32/64 which both need the `Addresses` capability and it will hit that error first

Adding for future-proofing if a Non-Vulkan API adds a new addressing model

Also covers `VUID-StandaloneSpirv-None-04635`