### PR TITLE
spirv-val: label tests for VUID 04659

### DIFF
--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -899,7 +899,7 @@ spv_result_t ValidateTypeSampledImage(ValidationState_t& _,
   // Vulkan uses the Sampled=1 case.
   if ((info.sampled != 0) && (info.sampled != 1)) {
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
-           << _.VkErrorID(4659)
+           << _.VkErrorID(4657)
            << "Sampled image type requires an image type with \"Sampled\" "
               "operand set to 0 or 1";
   }

--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -899,6 +899,7 @@ spv_result_t ValidateTypeSampledImage(ValidationState_t& _,
   // Vulkan uses the Sampled=1 case.
   if ((info.sampled != 0) && (info.sampled != 1)) {
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
+           << _.VkErrorID(4659)
            << "Sampled image type requires an image type with \"Sampled\" "
               "operand set to 0 or 1";
   }

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -1700,6 +1700,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-OpTypeImage-04657);
     case 4658:
       return VUID_WRAP(VUID-StandaloneSpirv-OpImageTexelPointer-04658);
+    case 4659:
+      return VUID_WRAP(VUID-StandaloneSpirv-OpImageQuerySizeLod-04659);
     case 4662:
       return VUID_WRAP(VUID-StandaloneSpirv-Offset-04662);
     case 4663:

--- a/test/val/val_image_test.cpp
+++ b/test/val/val_image_test.cpp
@@ -4453,7 +4453,7 @@ OpFunctionEnd
   CompileSuccessfully(body.c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
   EXPECT_THAT(getDiagnosticString(),
-              AnyVUID("VUID-StandaloneSpirv-OpImageQuerySizeLod-04659"));
+              AnyVUID("VUID-StandaloneSpirv-OpTypeImage-04657"));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Sampled image type requires an image type with "
                         "\"Sampled\" operand set to 0 or 1"));

--- a/test/val/val_image_test.cpp
+++ b/test/val/val_image_test.cpp
@@ -3929,6 +3929,8 @@ OpFunctionEnd
 
   CompileSuccessfully(body.c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-OpImageQuerySizeLod-04659"));
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
@@ -4263,6 +4265,8 @@ OpFunctionEnd
 
   CompileSuccessfully(body.c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-OpImageQuerySizeLod-04659"));
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("OpImageQueryLevels must only consume an \"Image\" operand "
@@ -4448,6 +4452,8 @@ OpFunctionEnd
 
   CompileSuccessfully(body.c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-OpImageQuerySizeLod-04659"));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Sampled image type requires an image type with "
                         "\"Sampled\" operand set to 0 or 1"));


### PR DESCRIPTION
VUID-StandaloneSpirv-OpImageQuerySizeLod-04659