### PR TITLE
Set correct scope and line info for DebugValue

### DIFF
--- a/source/opt/debug_info_manager.cpp
+++ b/source/opt/debug_info_manager.cpp
@@ -500,14 +500,15 @@ bool DebugInfoManager::AddDebugValueIfVarDeclIsVisible(
            insert_before->opcode() == SpvOpVariable) {
       insert_before = insert_before->NextNode();
     }
-    modified |= AddDebugValueForDecl(dbg_decl_or_val, value_id,
-                                     insert_before) != nullptr;
+    modified |= AddDebugValueForDecl(dbg_decl_or_val, value_id, insert_before,
+                                     scope_and_line) != nullptr;
   }
   return modified;
 }
 
 Instruction* DebugInfoManager::AddDebugValueForDecl(
-    Instruction* dbg_decl, uint32_t value_id, Instruction* insert_before) {
+    Instruction* dbg_decl, uint32_t value_id, Instruction* insert_before,
+    Instruction* scope_and_line) {
   if (dbg_decl == nullptr || !IsDebugDeclare(dbg_decl)) return nullptr;
 
   std::unique_ptr<Instruction> dbg_val(dbg_decl->Clone(context()));
@@ -517,6 +518,7 @@ Instruction* DebugInfoManager::AddDebugValueForDecl(
   dbg_val->SetOperand(kDebugDeclareOperandVariableIndex, {value_id});
   dbg_val->SetOperand(kDebugValueOperandExpressionIndex,
                       {GetEmptyDebugExpression()->result_id()});
+  dbg_val->UpdateDebugInfoFrom(scope_and_line);
 
   auto* added_dbg_val = insert_before->InsertBefore(std::move(dbg_val));
   AnalyzeDebugInst(added_dbg_val);

--- a/source/opt/debug_info_manager.cpp
+++ b/source/opt/debug_info_manager.cpp
@@ -532,26 +532,6 @@ Instruction* DebugInfoManager::AddDebugValueForDecl(
   return added_dbg_val;
 }
 
-Instruction* DebugInfoManager::AddDebugDeclareForScalar(
-    Instruction* dbg_decl, Instruction* scalar_var, uint32_t scalar_index,
-    Instruction* deref_expr) {
-  Instruction* dbg_decl_for_scalar = AddDebugValueForDecl(
-      dbg_decl, scalar_var->result_id(), scalar_var->NextNode(), dbg_decl);
-  if (dbg_decl_for_scalar == nullptr) return nullptr;
-  if (deref_expr == nullptr) deref_expr = GetDebugOperationWithDeref();
-  assert(GetDbgInst(deref_expr->GetSingleWordOperand(
-                        kDebugExpressOperandOperationIndex))
-             ->GetSingleWordOperand(kDebugOperationOperandOperationIndex) ==
-         OpenCLDebugInfo100Deref);
-  dbg_decl_for_scalar->AddOperand({SPV_OPERAND_TYPE_ID, {scalar_index}});
-  dbg_decl_for_scalar->SetOperand(kDebugValueOperandExpressionIndex,
-                                  {deref_expr->result_id()});
-  AnalyzeDebugInst(dbg_decl_for_scalar);
-  if (context()->AreAnalysesValid(IRContext::Analysis::kAnalysisDefUse))
-    context()->get_def_use_mgr()->AnalyzeInstDefUse(dbg_decl_for_scalar);
-  return dbg_decl_for_scalar;
-}
-
 uint32_t DebugInfoManager::GetVariableIdOfDebugValueUsedForDeclare(
     Instruction* inst) {
   if (inst->GetOpenCL100DebugOpcode() != OpenCLDebugInfo100DebugValue) return 0;

--- a/source/opt/debug_info_manager.cpp
+++ b/source/opt/debug_info_manager.cpp
@@ -532,6 +532,26 @@ Instruction* DebugInfoManager::AddDebugValueForDecl(
   return added_dbg_val;
 }
 
+Instruction* DebugInfoManager::AddDebugDeclareForScalar(
+    Instruction* dbg_decl, Instruction* scalar_var, uint32_t scalar_index,
+    Instruction* deref_expr) {
+  Instruction* dbg_decl_for_scalar = AddDebugValueForDecl(
+      dbg_decl, scalar_var->result_id(), scalar_var->NextNode(), dbg_decl);
+  if (dbg_decl_for_scalar == nullptr) return nullptr;
+  if (deref_expr == nullptr) deref_expr = GetDebugOperationWithDeref();
+  assert(GetDbgInst(deref_expr->GetSingleWordOperand(
+                        kDebugExpressOperandOperationIndex))
+             ->GetSingleWordOperand(kDebugOperationOperandOperationIndex) ==
+         OpenCLDebugInfo100Deref);
+  dbg_decl_for_scalar->AddOperand({SPV_OPERAND_TYPE_ID, {scalar_index}});
+  dbg_decl_for_scalar->SetOperand(kDebugValueOperandExpressionIndex,
+                                  {deref_expr->result_id()});
+  AnalyzeDebugInst(dbg_decl_for_scalar);
+  if (context()->AreAnalysesValid(IRContext::Analysis::kAnalysisDefUse))
+    context()->get_def_use_mgr()->AnalyzeInstDefUse(dbg_decl_for_scalar);
+  return dbg_decl_for_scalar;
+}
+
 uint32_t DebugInfoManager::GetVariableIdOfDebugValueUsedForDeclare(
     Instruction* inst) {
   if (inst->GetOpenCL100DebugOpcode() != OpenCLDebugInfo100DebugValue) return 0;

--- a/source/opt/debug_info_manager.h
+++ b/source/opt/debug_info_manager.h
@@ -152,10 +152,11 @@ class DebugInfoManager {
       std::unordered_set<Instruction*>* invisible_decls);
 
   // Creates a DebugValue for DebugDeclare |dbg_decl| and inserts it before
-  // |insert_before|. The new DebugValue has the same line and scope with
-  // |scope_and_line| and it has the same operands with DebugDeclare but it
-  // uses |value_id| for value. Returns the added DebugValue, or nullptr if
-  // it does not add a DebugValue.
+  // |insert_before|. The new DebugValue has the same line and scope as
+  // |scope_and_line|, or no scope and line information if |scope_and_line|
+  // is nullptr. The new DebugValue has the same operands as DebugDeclare
+  // but it uses |value_id| for the value. Returns the created DebugValue,
+  // or nullptr if fails to create one.
   Instruction* AddDebugValueForDecl(Instruction* dbg_decl, uint32_t value_id,
                                     Instruction* insert_before,
                                     Instruction* scope_and_line);

--- a/source/opt/debug_info_manager.h
+++ b/source/opt/debug_info_manager.h
@@ -152,11 +152,13 @@ class DebugInfoManager {
       std::unordered_set<Instruction*>* invisible_decls);
 
   // Creates a DebugValue for DebugDeclare |dbg_decl| and inserts it before
-  // |insert_before|. The new DebugValue has the same line, scope, and
-  // operands with DebugDeclare but it uses |value_id| for value. Returns
-  // the added DebugValue, or nullptr if it does not add a DebugValue.
+  // |insert_before|. The new DebugValue has the same line and scope with
+  // |scope_and_line| and it has the same operands with DebugDeclare but it
+  // uses |value_id| for value. Returns the added DebugValue, or nullptr if
+  // it does not add a DebugValue.
   Instruction* AddDebugValueForDecl(Instruction* dbg_decl, uint32_t value_id,
-                                    Instruction* insert_before);
+                                    Instruction* insert_before,
+                                    Instruction* scope_and_line);
 
   // Erases |instr| from data structures of this class.
   void ClearDebugInfo(Instruction* instr);

--- a/source/opt/debug_info_manager.h
+++ b/source/opt/debug_info_manager.h
@@ -161,6 +161,18 @@ class DebugInfoManager {
                                     Instruction* insert_before,
                                     Instruction* scope_and_line);
 
+  // Creates a DebugValue with Deref operation that is used as a DebugDeclare
+  // for |scalar_index|th component of local variable with an aggregate type
+  // declared by |dbg_decl| and inserts it before |scalar_var|. It sets
+  // |scalar_var| as the new storage for the scalar. It uses |deref_expr| as the
+  // expression if it is not nullptr. Otherwise, it creates a new expression
+  // with Deref operation. Returns the created DebugValue, or nullptr if fails
+  // to create one.
+  Instruction* AddDebugDeclareForScalar(Instruction* dbg_decl,
+                                        Instruction* scalar_var,
+                                        uint32_t scalar_index,
+                                        Instruction* deref_expr);
+
   // Erases |instr| from data structures of this class.
   void ClearDebugInfo(Instruction* instr);
 

--- a/source/opt/debug_info_manager.h
+++ b/source/opt/debug_info_manager.h
@@ -161,18 +161,6 @@ class DebugInfoManager {
                                     Instruction* insert_before,
                                     Instruction* scope_and_line);
 
-  // Creates a DebugValue with Deref operation that is used as a DebugDeclare
-  // for |scalar_index|th component of local variable with an aggregate type
-  // declared by |dbg_decl| and inserts it before |scalar_var|. It sets
-  // |scalar_var| as the new storage for the scalar. It uses |deref_expr| as the
-  // expression if it is not nullptr. Otherwise, it creates a new expression
-  // with Deref operation. Returns the created DebugValue, or nullptr if fails
-  // to create one.
-  Instruction* AddDebugDeclareForScalar(Instruction* dbg_decl,
-                                        Instruction* scalar_var,
-                                        uint32_t scalar_index,
-                                        Instruction* deref_expr);
-
   // Erases |instr| from data structures of this class.
   void ClearDebugInfo(Instruction* instr);
 

--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -175,7 +175,7 @@ bool LocalSingleStoreElimPass::RewriteDebugDeclares(Instruction* store_inst,
     for (auto* decl : invisible_decls) {
       if (dominator_analysis->Dominates(store_inst, decl)) {
         context()->get_debug_info_mgr()->AddDebugValueForDecl(decl, value_id,
-                                                              decl);
+                                                              decl, store_inst);
         modified = true;
       }
     }

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -171,24 +171,11 @@ bool ScalarReplacementPass::ReplaceWholeDebugDeclare(
 
   // Add DebugValue instruction with Indexes operand and Deref operation.
   int32_t idx = 0;
-  for (const auto* var : replacements) {
-    // We use the nullptr instruction for the scope and line info instruction
-    // of the new DebugValue because it will be used as DebugDeclare, not
-    // DebugValue. Setting the scope and line info must be done when we
-    // distribute DebugValue instructions for a DebugDeclare.
-    Instruction* added_dbg_value =
-        context()->get_debug_info_mgr()->AddDebugValueForDecl(
-            dbg_decl, /*value_id=*/var->result_id(),
-            /*insert_before=*/var->NextNode(), nullptr);
-
-    if (added_dbg_value == nullptr) return false;
-    added_dbg_value->AddOperand(
-        {SPV_OPERAND_TYPE_ID,
-         {context()->get_constant_mgr()->GetSIntConst(idx)}});
-    added_dbg_value->SetOperand(kDebugValueOperandExpressionIndex,
-                                {deref_expr->result_id()});
-    if (context()->AreAnalysesValid(IRContext::Analysis::kAnalysisDefUse)) {
-      context()->get_def_use_mgr()->AnalyzeInstUse(added_dbg_value);
+  for (auto* var : replacements) {
+    if (context()->get_debug_info_mgr()->AddDebugDeclareForScalar(
+            dbg_decl, var, context()->get_constant_mgr()->GetSIntConst(idx),
+            deref_expr) == nullptr) {
+      return false;
     }
     ++idx;
   }

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -175,7 +175,7 @@ bool ScalarReplacementPass::ReplaceWholeDebugDeclare(
     Instruction* added_dbg_value =
         context()->get_debug_info_mgr()->AddDebugValueForDecl(
             dbg_decl, /*value_id=*/var->result_id(),
-            /*insert_before=*/var->NextNode());
+            /*insert_before=*/var->NextNode(), nullptr);
     if (added_dbg_value == nullptr) return false;
     added_dbg_value->AddOperand(
         {SPV_OPERAND_TYPE_ID,

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -172,10 +172,15 @@ bool ScalarReplacementPass::ReplaceWholeDebugDeclare(
   // Add DebugValue instruction with Indexes operand and Deref operation.
   int32_t idx = 0;
   for (const auto* var : replacements) {
+    // We use the nullptr instruction for the scope and line info instruction
+    // of the new DebugValue because it will be used as DebugDeclare, not
+    // DebugValue. Setting the scope and line info must be done when we
+    // distribute DebugValue instructions for a DebugDeclare.
     Instruction* added_dbg_value =
         context()->get_debug_info_mgr()->AddDebugValueForDecl(
             dbg_decl, /*value_id=*/var->result_id(),
             /*insert_before=*/var->NextNode(), nullptr);
+
     if (added_dbg_value == nullptr) return false;
     added_dbg_value->AddOperand(
         {SPV_OPERAND_TYPE_ID,

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -171,11 +171,24 @@ bool ScalarReplacementPass::ReplaceWholeDebugDeclare(
 
   // Add DebugValue instruction with Indexes operand and Deref operation.
   int32_t idx = 0;
-  for (auto* var : replacements) {
-    if (context()->get_debug_info_mgr()->AddDebugDeclareForScalar(
-            dbg_decl, var, context()->get_constant_mgr()->GetSIntConst(idx),
-            deref_expr) == nullptr) {
-      return false;
+  for (const auto* var : replacements) {
+    // We use the nullptr instruction for the scope and line info instruction
+    // of the new DebugValue because it will be used as DebugDeclare, not
+    // DebugValue. Setting the scope and line info must be done when we
+    // distribute DebugValue instructions for a DebugDeclare.
+    Instruction* added_dbg_value =
+        context()->get_debug_info_mgr()->AddDebugValueForDecl(
+            dbg_decl, /*value_id=*/var->result_id(),
+            /*insert_before=*/var->NextNode(), nullptr);
+
+    if (added_dbg_value == nullptr) return false;
+    added_dbg_value->AddOperand(
+        {SPV_OPERAND_TYPE_ID,
+         {context()->get_constant_mgr()->GetSIntConst(idx)}});
+    added_dbg_value->SetOperand(kDebugValueOperandExpressionIndex,
+                                {deref_expr->result_id()});
+    if (context()->AreAnalysesValid(IRContext::Analysis::kAnalysisDefUse)) {
+      context()->get_def_use_mgr()->AnalyzeInstUse(added_dbg_value);
     }
     ++idx;
   }

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -172,14 +172,10 @@ bool ScalarReplacementPass::ReplaceWholeDebugDeclare(
   // Add DebugValue instruction with Indexes operand and Deref operation.
   int32_t idx = 0;
   for (const auto* var : replacements) {
-    // We use the nullptr instruction for the scope and line info instruction
-    // of the new DebugValue because it will be used as DebugDeclare, not
-    // DebugValue. Setting the scope and line info must be done when we
-    // distribute DebugValue instructions for a DebugDeclare.
     Instruction* added_dbg_value =
         context()->get_debug_info_mgr()->AddDebugValueForDecl(
             dbg_decl, /*value_id=*/var->result_id(),
-            /*insert_before=*/var->NextNode(), nullptr);
+            /*insert_before=*/var->NextNode(), /*scope_and_line=*/dbg_decl);
 
     if (added_dbg_value == nullptr) return false;
     added_dbg_value->AddOperand(

--- a/source/opt/ssa_rewrite_pass.cpp
+++ b/source/opt/ssa_rewrite_pass.cpp
@@ -658,8 +658,8 @@ Pass::Status SSARewriter::AddDebugValuesForInvisibleDebugDecls(Function* fp) {
   //   a = 3;
   //   foo(3);
   // After inlining:
-  //   a = 3; // we want to specify "DebugValue: %x = %int_3"
-  //   foo and x disappeared!
+  //   a = 3;
+  //   foo and x disappeared but we want to specify "DebugValue: %x = %int_3".
   //
   // We want to specify the value for the variable using |defs_at_block_[bb]|,
   // where |bb| is the basic block contains the decl.
@@ -681,16 +681,17 @@ Pass::Status SSARewriter::AddDebugValuesForInvisibleDebugDecls(Function* fp) {
     if (value && (pass_->context()->get_instr_block(value) == nullptr ||
                   dom_tree->Dominates(value, decl))) {
       if (pass_->context()->get_debug_info_mgr()->AddDebugValueForDecl(
-              decl, value->result_id(), decl) == nullptr) {
+              decl, value->result_id(), decl, value) == nullptr) {
         return Pass::Status::Failure;
       }
     } else {
       // If |value| in the same basic block does not dominate |decl|, we can
       // assign the value in the immediate dominator.
       value_id = GetValueAtBlock(var_id, dom_tree->ImmediateDominator(bb));
+      if (value_id) value = pass_->get_def_use_mgr()->GetDef(value_id);
       if (value_id &&
           pass_->context()->get_debug_info_mgr()->AddDebugValueForDecl(
-              decl, value_id, decl) == nullptr) {
+              decl, value_id, decl, value) == nullptr) {
         return Pass::Status::Failure;
       }
     }

--- a/test/opt/local_single_store_elim_test.cpp
+++ b/test/opt/local_single_store_elim_test.cpp
@@ -1403,18 +1403,20 @@ TEST_F(LocalSingleStoreElimTest, AddDebugValueforStoreOutOfDebugDeclareScope) {
 %param_var_pos = OpVariable %_ptr_Function_v4float Function
 %param_var_color = OpVariable %_ptr_Function_v4float Function
          %55 = OpLoad %v4float %in_var_POSITION
+               OpLine %7 6 23
                OpStore %param_var_pos %55
+               OpNoLine
          %56 = OpLoad %v4float %in_var_COLOR
 ;CHECK:      DebugNoScope
 ;CHECK-NOT:  OpLine
 ;CHECK:      [[pos:%\w+]] = OpLoad %v4float %in_var_POSITION
 ;CHECK:      [[color:%\w+]] = OpLoad %v4float %in_var_COLOR
 
-               OpStore %param_var_color %56
-         %93 = OpExtInst %void %1 DebugScope %48
-               OpLine %7 6 23
-         %73 = OpExtInst %void %1 DebugDeclare %53 %param_var_pos %52
                OpLine %7 7 23
+               OpStore %param_var_color %56
+               OpNoLine
+         %93 = OpExtInst %void %1 DebugScope %48
+         %73 = OpExtInst %void %1 DebugDeclare %53 %param_var_pos %52
          %74 = OpExtInst %void %1 DebugDeclare %51 %param_var_color %52
 ;CHECK:      OpLine [[file:%\w+]] 6 23
 ;CHECK-NEXT: {{%\w+}} = OpExtInst %void {{%\w+}} DebugValue [[dbg_pos]] [[pos]] [[empty_expr:%\w+]]

--- a/test/opt/local_ssa_elim_test.cpp
+++ b/test/opt/local_ssa_elim_test.cpp
@@ -2261,9 +2261,13 @@ TEST_F(LocalSSAElimTest, AddDebugValueForFunctionParameterWithPhi) {
          %69 = OpExtInst %void %1 DebugLexicalBlock %60 7 21 %68
          %70 = OpExtInst %void %1 DebugLocalVariable %11 %59 %60 6 26 %67 FlagIsLocal 2
 
+; CHECK: [[color_name:%\w+]] = OpString "color"
+; CHECK: [[pos_name:%\w+]] = OpString "pos"
 ; CHECK: [[i_name:%\w+]] = OpString "i"
 ; CHECK: [[null_expr:%\w+]] = OpExtInst %void [[ext:%\w+]] DebugExpression
 ; CHECK: [[dbg_i:%\w+]] = OpExtInst %void [[ext]] DebugLocalVariable [[i_name]] {{%\w+}} {{%\w+}} 6 16 {{%\w+}} FlagIsLocal 1
+; CHECK: [[dbg_color:%\w+]] = OpExtInst %void [[ext]] DebugLocalVariable [[color_name]] {{%\w+}} {{%\w+}} 15 23
+; CHECK: [[dbg_pos:%\w+]] = OpExtInst %void [[ext]] DebugLocalVariable [[pos_name]] {{%\w+}} {{%\w+}} 14 23
          %71 = OpExtInst %void %1 DebugLocalVariable %15 %65 %60 6 16 %67 FlagIsLocal 1
          %72 = OpExtInst %void %1 DebugTypeFunction FlagIsProtected|FlagIsPrivate %62 %59 %59
          %73 = OpExtInst %void %1 DebugFunction %16 %72 %60 14 1 %61 %14 FlagIsProtected|FlagIsPrivate 15 %156
@@ -2282,13 +2286,23 @@ TEST_F(LocalSSAElimTest, AddDebugValueForFunctionParameterWithPhi) {
         %169 = OpExtInst %void %1 DebugNoScope
 %param_var_pos = OpVariable %_ptr_Function_v4float Function
 %param_var_color = OpVariable %_ptr_Function_v4float Function
+               OpLine %7 100 105
          %80 = OpLoad %v4float %in_var_POSITION
                OpStore %param_var_pos %80
+               OpNoLine
+               OpLine %7 200 205
          %81 = OpLoad %v4float %in_var_COLOR
                OpStore %param_var_color %81
+               OpNoLine
         %170 = OpExtInst %void %1 DebugScope %73
+
+; CHECK: OpLine {{%\w+}} 100 105
+; CHECK: DebugValue [[dbg_pos]]
         %124 = OpExtInst %void %1 DebugDeclare %78 %param_var_pos %77
+; CHECK: OpLine {{%\w+}} 200 205
+; CHECK: DebugValue [[dbg_color]]
         %125 = OpExtInst %void %1 DebugDeclare %76 %param_var_color %77
+
         %171 = OpExtInst %void %1 DebugScope %74
                OpLine %7 17 18
 


### PR DESCRIPTION
The existing spirv-opt `DebugInfoManager::AddDebugValueForDecl()` sets
the scope and line info of the new added DebugValue using the scope and
line of DebugDeclare. This is wrong because only a single DebugDeclare
must exist within a scope while we have to add multiple DebugValues for all the
places where the variable's value is updated. Therefore, we have to set
the scope and line of DebugValue based on the places of the variable
updates.

This bug makes
https://github.com/google/amber/blob/main/tests/cases/debugger_hlsl_shadowed_vars.amber
fail. This commit fixes the bug.