### PR TITLE
spirv-opt: Allow image type mismatch in GenerateCopy

### DIFF
--- a/source/opt/pass.cpp
+++ b/source/opt/pass.cpp
@@ -141,11 +141,6 @@ uint32_t Pass::GenerateCopy(Instruction* object_to_copy, uint32_t new_type_id,
     }
     return ir_builder.AddCompositeConstruct(new_type_id, element_ids)
         ->result_id();
-  } else if (original_type->AsImage() && new_type->AsImage()) {
-    // Allow storing an image with a different format.
-    // For example in function parameters the format is unknown, but inlining
-    // fixes this
-    return object_to_copy->result_id();
   } else {
     // If we do not have an aggregate type, then we have a problem.  Either we
     // found multiple instances of the same type, or we are copying to an

--- a/source/opt/pass.cpp
+++ b/source/opt/pass.cpp
@@ -141,6 +141,11 @@ uint32_t Pass::GenerateCopy(Instruction* object_to_copy, uint32_t new_type_id,
     }
     return ir_builder.AddCompositeConstruct(new_type_id, element_ids)
         ->result_id();
+  } else if (original_type->AsImage() && new_type->AsImage()) {
+    // Allow storing an image with a different format.
+    // For example in function parameters the format is unknown, but inlining
+    // fixes this
+    return object_to_copy->result_id();
   } else {
     // If we do not have an aggregate type, then we have a problem.  Either we
     // found multiple instances of the same type, or we are copying to an

--- a/test/opt/fix_storage_class_test.cpp
+++ b/test/opt/fix_storage_class_test.cpp
@@ -528,6 +528,48 @@ TEST_F(FixStorageClassTest, FixLinkedAccessChain2) {
   SinglePassRunAndMatch<FixStorageClass>(text, false);
 }
 
+TEST_F(FixStorageClassTest, AllowImageFormatMismatch) {
+  const std::string text = R"(OpCapability Shader
+OpCapability SampledBuffer
+OpCapability ImageBuffer
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpSource HLSL 600
+OpName %type_buffer_image "type.buffer.image"
+OpName %Buf "Buf"
+OpName %main "main"
+OpName %src_main "src.main"
+OpName %bb_entry "bb.entry"
+OpName %type_buffer_image_0 "type.buffer.image"
+OpName %b "b"
+OpDecorate %Buf DescriptorSet 0
+OpDecorate %Buf Binding 0
+%float = OpTypeFloat 32
+%type_buffer_image = OpTypeImage %float Buffer 2 0 0 2 Rgba16f
+%_ptr_UniformConstant_type_buffer_image = OpTypePointer UniformConstant %type_buffer_image
+%void = OpTypeVoid
+%11 = OpTypeFunction %void
+%type_buffer_image_0 = OpTypeImage %float Buffer 2 0 0 2 Rgba32f
+%_ptr_Function_type_buffer_image_0 = OpTypePointer Function %type_buffer_image_0
+%Buf = OpVariable %_ptr_UniformConstant_type_buffer_image UniformConstant
+%main = OpFunction %void None %11
+%13 = OpLabel
+%14 = OpFunctionCall %void %src_main
+OpReturn
+OpFunctionEnd
+%src_main = OpFunction %void None %11
+%bb_entry = OpLabel
+%b = OpVariable %_ptr_Function_type_buffer_image_0 Function
+%15 = OpLoad %type_buffer_image %Buf
+OpStore %b %15
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndCheck<FixStorageClass>(text, text, false, false);
+}
+
 using FixTypeTest = PassTest<::testing::Test>;
 
 TEST_F(FixTypeTest, FixAccessChain) {


### PR DESCRIPTION
This change is needed by this DirectXShaderCompiler pull request: https://github.com/microsoft/DirectXShaderCompiler/pull/3395

Since the DirectXShaderCompiler change linked above adds the ImageFormat only for global texture/buffer variables, they need to be propagated by the legalization pass to all variables and function parameters where the global resource is assigned.

However, the generated SPIR-V will initially have mismatches in the formats, and this change in Pass::GenerateCopy allows the source and destination to have
separate image formats. Legalization seems to generate valid SPIR-V in this case so allowing the type mismatch between source and destination in case of image types seems to be OK. Not sure if this is the cleanest/proper way to do it though, but not being very familiar with the SPIRV-Tools codebase this is what I came up with and after a quick test it seems to work for our purposes.