### PR TITLE
Mark module as modified if convert-to-half removes decorations.

### DIFF
--- a/source/opt/convert_to_half_pass.h
+++ b/source/opt/convert_to_half_pass.h
@@ -74,7 +74,7 @@ class ConvertToHalfPass : public Pass {
   void GenConvert(uint32_t* val_idp, uint32_t width, Instruction* inst);
 
   // Remove RelaxedPrecision decoration of |id|.
-  void RemoveRelaxedDecoration(uint32_t id);
+  bool RemoveRelaxedDecoration(uint32_t id);
 
   // Add |inst| to relaxed instruction set if warranted. Specifically, if
   // it is float32 and either decorated relaxed or a composite or phi

--- a/source/opt/decoration_manager.cpp
+++ b/source/opt/decoration_manager.cpp
@@ -55,10 +55,10 @@ namespace analysis {
 
 bool DecorationManager::RemoveDecorationsFrom(
     uint32_t id, std::function<bool(const Instruction&)> pred) {
-  bool modified = false;
+  bool was_modified = false;
   const auto ids_iter = id_to_decoration_insts_.find(id);
   if (ids_iter == id_to_decoration_insts_.end()) {
-    return modified;
+    return was_modified;
   }
 
   TargetData& decorations_info = ids_iter->second;
@@ -100,7 +100,6 @@ bool DecorationManager::RemoveDecorationsFrom(
 
     // Otherwise, remove |id| from the targets of |group_id|
     const uint32_t stride = inst->opcode() == SpvOpGroupDecorate ? 1u : 2u;
-    bool was_modified = false;
     for (uint32_t i = 1u; i < inst->NumInOperands();) {
       if (inst->GetSingleWordInOperand(i) != id) {
         i += stride;
@@ -156,7 +155,7 @@ bool DecorationManager::RemoveDecorationsFrom(
           }),
       indirect_decorations.end());
 
-  modified |= !insts_to_kill.empty();
+  was_modified |= !insts_to_kill.empty();
   for (Instruction* inst : insts_to_kill) context->KillInst(inst);
   insts_to_kill.clear();
 
@@ -167,7 +166,7 @@ bool DecorationManager::RemoveDecorationsFrom(
     for (Instruction* inst : decorations_info.decorate_insts)
       insts_to_kill.push_back(inst);
   }
-  modified |= !insts_to_kill.empty();
+  was_modified |= !insts_to_kill.empty();
   for (Instruction* inst : insts_to_kill) context->KillInst(inst);
 
   if (decorations_info.direct_decorations.empty() &&
@@ -175,7 +174,7 @@ bool DecorationManager::RemoveDecorationsFrom(
       decorations_info.decorate_insts.empty()) {
     id_to_decoration_insts_.erase(ids_iter);
   }
-  return modified;
+  return was_modified;
 }
 
 std::vector<Instruction*> DecorationManager::GetDecorationsFor(

--- a/source/opt/decoration_manager.h
+++ b/source/opt/decoration_manager.h
@@ -52,9 +52,9 @@ class DecorationManager {
   // removed, then the |OpGroupDecorate| and
   // |OpGroupMemberDecorate| for the group will be killed, but not the defining
   // |OpDecorationGroup| instruction.
-  void RemoveDecorationsFrom(uint32_t id,
-                             std::function<bool(const Instruction&)> pred =
-                                 [](const Instruction&) { return true; });
+  bool RemoveDecorationsFrom(
+      uint32_t id, std::function<bool(const Instruction&)> pred =
+                       [](const Instruction&) { return true; });
 
   // Removes all decorations from the result id of |inst|.
   //

--- a/source/opt/decoration_manager.h
+++ b/source/opt/decoration_manager.h
@@ -36,8 +36,9 @@ class DecorationManager {
   }
   DecorationManager() = delete;
 
-  // Changes all of the decorations (direct and through groups) where |pred| is
-  // true and that apply to |id| so that they no longer apply to |id|.
+  // Removes all decorations (direct and through groups) where |pred| is
+  // true and that apply to |id| so that they no longer apply to |id|.  Returns
+  // true if something changed.
   //
   // If |id| is part of a group, it will be removed from the group if it
   // does not use all of the group's decorations, or, if there are no


### PR DESCRIPTION
If the convert-to-half pass does not change the body of the function,
but removes decorations, it returns that nothing changed.  This is
incorrect, and will be fixed.

Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/4117