### PR TITLE
spirv-fuzz: Add persistent state to the fuzzer

### DIFF
--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -200,8 +200,7 @@ void Fuzzer::BuildState() {
     // the original module and the ids used for fuzzing, as a readability aid.
     //
     // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/2541) consider
-    // the
-    //  case where the maximum id bound is reached.
+    // the case where the maximum id bound is reached.
     auto minimum_fresh_id = ir_context->module()->id_bound() + kIdBoundGap;
     auto fuzzer_context =
         MakeUnique<FuzzerContext>(random_generator_.get(), minimum_fresh_id);

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -322,9 +322,12 @@ Fuzzer::Result Fuzzer::Run(uint32_t num_of_transformations_to_apply) {
       status = Status::kFuzzerPassLedToInvalidModule;
       break;
     }
-  } while (ShouldContinueFuzzing(num_of_transformations_to_apply == 0));
+  } while (ShouldContinueRepeatedPasses(num_of_transformations_to_apply == 0));
 
   if (status != Status::kFuzzerPassLedToInvalidModule) {
+    // We apply this transformations despite the fact that we might exceed
+    // |num_of_transformations_to_apply|. This is not a problem for us since
+    // these fuzzer passes are relatively simple yet might trigger some bugs.
     for (auto& pass : final_passes_) {
       if (!ApplyPassAndCheckValidity(pass.get())) {
         status = Status::kFuzzerPassLedToInvalidModule;
@@ -339,7 +342,8 @@ Fuzzer::Result Fuzzer::Run(uint32_t num_of_transformations_to_apply) {
                       initial_num_of_transformations};
 }
 
-bool Fuzzer::ShouldContinueFuzzing(bool continue_fuzzing_probabilistically) {
+bool Fuzzer::ShouldContinueRepeatedPasses(
+    bool continue_fuzzing_probabilistically) {
   if (continue_fuzzing_probabilistically) {
     // If we have applied T transformations so far, and the limit on the number
     // of transformations to apply is L (where T < L), the chance that we will

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -14,8 +14,6 @@
 
 #include "source/fuzz/fuzzer.h"
 
-#include <test/fuzz/fuzz_test_util.h>
-
 #include <cassert>
 #include <memory>
 #include <numeric>

--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -14,10 +14,11 @@
 
 #include "source/fuzz/fuzzer.h"
 
+#include <test/fuzz/fuzz_test_util.h>
+
 #include <cassert>
 #include <memory>
 #include <numeric>
-#include <sstream>
 
 #include "source/fuzz/fact_manager/fact_manager.h"
 #include "source/fuzz/fuzzer_context.h"
@@ -91,9 +92,6 @@
 #include "source/fuzz/fuzzer_pass_toggle_access_chain_instruction.h"
 #include "source/fuzz/fuzzer_pass_wrap_regions_in_selections.h"
 #include "source/fuzz/pass_management/repeated_pass_manager.h"
-#include "source/fuzz/pass_management/repeated_pass_manager_looped_with_recommendations.h"
-#include "source/fuzz/pass_management/repeated_pass_manager_random_with_recommendations.h"
-#include "source/fuzz/pass_management/repeated_pass_manager_simple.h"
 #include "source/fuzz/pass_management/repeated_pass_recommender_standard.h"
 #include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
 #include "source/fuzz/transformation_context.h"
@@ -104,35 +102,47 @@
 namespace spvtools {
 namespace fuzz {
 
-namespace {
-const uint32_t kIdBoundGap = 100;
-
-}  // namespace
-
 Fuzzer::Fuzzer(spv_target_env target_env, MessageConsumer consumer,
-               const std::vector<uint32_t>& binary_in,
-               const protobufs::FactSequence& initial_facts,
-               const std::vector<fuzzerutil::ModuleSupplier>& donor_suppliers,
+               std::vector<uint32_t> binary_in,
+               protobufs::FactSequence initial_facts,
+               std::vector<fuzzerutil::ModuleSupplier> donor_suppliers,
                std::unique_ptr<RandomGenerator> random_generator,
                bool enable_all_passes,
                RepeatedPassStrategy repeated_pass_strategy,
                bool validate_after_each_fuzzer_pass,
-               spv_validator_options validator_options)
+               spv_validator_options validator_options,
+               bool continue_fuzzing_probabilistically)
     : target_env_(target_env),
       consumer_(std::move(consumer)),
-      binary_in_(binary_in),
-      initial_facts_(initial_facts),
-      donor_suppliers_(donor_suppliers),
+      binary_in_(std::move(binary_in)),
+      initial_facts_(std::move(initial_facts)),
+      donor_suppliers_(std::move(donor_suppliers)),
       random_generator_(std::move(random_generator)),
       enable_all_passes_(enable_all_passes),
       repeated_pass_strategy_(repeated_pass_strategy),
       validate_after_each_fuzzer_pass_(validate_after_each_fuzzer_pass),
       validator_options_(validator_options),
-      num_repeated_passes_applied_(0),
-      ir_context_(nullptr),
-      fuzzer_context_(nullptr),
-      transformation_context_(nullptr),
-      transformation_sequence_out_() {}
+      continue_fuzzing_probabilistically_(continue_fuzzing_probabilistically),
+      state_() {}
+
+Fuzzer::State::State(
+    std::unique_ptr<opt::IRContext> ir_context_,
+    std::unique_ptr<FuzzerContext> fuzzer_context_,
+    std::unique_ptr<TransformationContext> transformation_context_)
+    : num_repeated_passes_applied(0),
+      ir_context(std::move(ir_context_)),
+      fuzzer_context(std::move(fuzzer_context_)),
+      transformation_context(std::move(transformation_context_)),
+      transformation_sequence_out(),
+      pass_instances(),
+      // These objects will be initialized in the |BuildState| method.
+      repeated_pass_recommender(),
+      repeated_pass_manager() {}
+
+namespace {
+const uint32_t kIdBoundGap = 100;
+
+}  // namespace
 
 Fuzzer::~Fuzzer() = default;
 
@@ -140,194 +150,232 @@ template <typename FuzzerPassT, typename... Args>
 void Fuzzer::MaybeAddRepeatedPass(uint32_t percentage_chance_of_adding_pass,
                                   RepeatedPassInstances* pass_instances,
                                   Args&&... extra_args) {
-  if (enable_all_passes_ ||
-      fuzzer_context_->ChoosePercentage(percentage_chance_of_adding_pass)) {
+  if (enable_all_passes_ || state_->fuzzer_context->ChoosePercentage(
+                                percentage_chance_of_adding_pass)) {
     pass_instances->SetPass(MakeUnique<FuzzerPassT>(
-        ir_context_.get(), transformation_context_.get(), fuzzer_context_.get(),
-        &transformation_sequence_out_, std::forward<Args>(extra_args)...));
+        state_->ir_context.get(), state_->transformation_context.get(),
+        state_->fuzzer_context.get(), &state_->transformation_sequence_out,
+        std::forward<Args>(extra_args)...));
   }
 }
 
 template <typename FuzzerPassT, typename... Args>
 void Fuzzer::MaybeAddFinalPass(std::vector<std::unique_ptr<FuzzerPass>>* passes,
                                Args&&... extra_args) {
-  if (enable_all_passes_ || fuzzer_context_->ChooseEven()) {
+  if (enable_all_passes_ || state_->fuzzer_context->ChooseEven()) {
     passes->push_back(MakeUnique<FuzzerPassT>(
-        ir_context_.get(), transformation_context_.get(), fuzzer_context_.get(),
-        &transformation_sequence_out_, std::forward<Args>(extra_args)...));
+        state_->ir_context.get(), state_->transformation_context.get(),
+        state_->fuzzer_context.get(), &state_->transformation_sequence_out,
+        std::forward<Args>(extra_args)...));
   }
 }
 
 bool Fuzzer::ApplyPassAndCheckValidity(FuzzerPass* pass) const {
   pass->Apply();
   return !validate_after_each_fuzzer_pass_ ||
-         fuzzerutil::IsValidAndWellFormed(ir_context_.get(), validator_options_,
-                                          consumer_);
+         fuzzerutil::IsValidAndWellFormed(state_->ir_context.get(),
+                                          validator_options_, consumer_);
 }
 
-Fuzzer::FuzzerResult Fuzzer::Run() {
-  // Check compatibility between the library version being linked with and the
-  // header files being used.
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
+const protobufs::TransformationSequence& Fuzzer::GetAppliedTransformations()
+    const {
+  assert(state_ && "Run method hasn't been called");
+  return state_->transformation_sequence_out;
+}
 
-  assert(ir_context_ == nullptr && fuzzer_context_ == nullptr &&
-         transformation_context_ == nullptr &&
-         transformation_sequence_out_.transformation_size() == 0 &&
-         "'Run' must not be invoked more than once.");
+void Fuzzer::BuildState() {
+  assert(!state_ && "state_ has already been initialized");
 
-  spvtools::SpirvTools tools(target_env_);
-  tools.SetMessageConsumer(consumer_);
-  if (!tools.IsValid()) {
-    consumer_(SPV_MSG_ERROR, nullptr, {},
-              "Failed to create SPIRV-Tools interface; stopping.");
-    return {Fuzzer::FuzzerResultStatus::kFailedToCreateSpirvToolsInterface,
-            std::vector<uint32_t>(), protobufs::TransformationSequence()};
+  {
+    // Variables in this scope are unique pointers that will be invalidated when
+    // the |state_| is created. Thus, it's better not to keep them around when
+    // that happens.
+
+    // Build the module from the input binary.
+    auto ir_context = BuildModule(target_env_, consumer_, binary_in_.data(),
+                                  binary_in_.size());
+    assert(ir_context && "SPIR-V binary should've already been validated");
+
+    // The fuzzer will introduce new ids into the module.  The module's id bound
+    // gives the smallest id that can be used for this purpose.  We add an
+    // offset to this so that there is a sizeable gap between the ids used in
+    // the original module and the ids used for fuzzing, as a readability aid.
+    //
+    // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/2541) consider
+    // the
+    //  case where the maximum id bound is reached.
+    auto minimum_fresh_id = ir_context->module()->id_bound() + kIdBoundGap;
+    auto fuzzer_context =
+        MakeUnique<FuzzerContext>(random_generator_.get(), minimum_fresh_id);
+
+    auto transformation_context = MakeUnique<TransformationContext>(
+        MakeUnique<FactManager>(ir_context.get()), validator_options_);
+    transformation_context->GetFactManager()->AddInitialFacts(consumer_,
+                                                              initial_facts_);
+
+    state_ = MakeUnique<State>(std::move(ir_context), std::move(fuzzer_context),
+                               std::move(transformation_context));
   }
-
-  // Initial binary should be valid.
-  if (!tools.Validate(&binary_in_[0], binary_in_.size(), validator_options_)) {
-    consumer_(SPV_MSG_ERROR, nullptr, {},
-              "Initial binary is invalid; stopping.");
-    return {Fuzzer::FuzzerResultStatus::kInitialBinaryInvalid,
-            std::vector<uint32_t>(), protobufs::TransformationSequence()};
-  }
-
-  // Build the module from the input binary.
-  ir_context_ =
-      BuildModule(target_env_, consumer_, binary_in_.data(), binary_in_.size());
-  assert(ir_context_);
-
-  // The fuzzer will introduce new ids into the module.  The module's id bound
-  // gives the smallest id that can be used for this purpose.  We add an offset
-  // to this so that there is a sizeable gap between the ids used in the
-  // original module and the ids used for fuzzing, as a readability aid.
-  //
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/2541) consider the
-  //  case where the maximum id bound is reached.
-  auto minimum_fresh_id = ir_context_->module()->id_bound() + kIdBoundGap;
-  fuzzer_context_ =
-      MakeUnique<FuzzerContext>(random_generator_.get(), minimum_fresh_id);
-
-  transformation_context_ = MakeUnique<TransformationContext>(
-      MakeUnique<FactManager>(ir_context_.get()), validator_options_);
-  transformation_context_->GetFactManager()->AddInitialFacts(consumer_,
-                                                             initial_facts_);
-
-  RepeatedPassInstances pass_instances{};
 
   // The following passes are likely to be very useful: many other passes
   // introduce synonyms, irrelevant ids and constants that these passes can work
   // with.  We thus enable them with high probability.
-  MaybeAddRepeatedPass<FuzzerPassObfuscateConstants>(90, &pass_instances);
-  MaybeAddRepeatedPass<FuzzerPassApplyIdSynonyms>(90, &pass_instances);
-  MaybeAddRepeatedPass<FuzzerPassReplaceIrrelevantIds>(90, &pass_instances);
+  MaybeAddRepeatedPass<FuzzerPassObfuscateConstants>(90,
+                                                     &state_->pass_instances);
+  MaybeAddRepeatedPass<FuzzerPassApplyIdSynonyms>(90, &state_->pass_instances);
+  MaybeAddRepeatedPass<FuzzerPassReplaceIrrelevantIds>(90,
+                                                       &state_->pass_instances);
 
   do {
     // Each call to MaybeAddRepeatedPass randomly decides whether the given pass
     // should be enabled, and adds an instance of the pass to |pass_instances|
     // if it is enabled.
-    MaybeAddRepeatedPass<FuzzerPassAddAccessChains>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassAddBitInstructionSynonyms>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassAddCompositeExtract>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassAddCompositeInserts>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassAddCompositeTypes>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassAddCopyMemory>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassAddDeadBlocks>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassAddDeadBreaks>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassAddDeadContinues>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassAddEquationInstructions>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassAddFunctionCalls>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassAddGlobalVariables>(&pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassAddAccessChains>(&state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassAddBitInstructionSynonyms>(
+        &state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassAddCompositeExtract>(
+        &state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassAddCompositeInserts>(
+        &state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassAddCompositeTypes>(&state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassAddCopyMemory>(&state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassAddDeadBlocks>(&state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassAddDeadBreaks>(&state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassAddDeadContinues>(&state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassAddEquationInstructions>(
+        &state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassAddFunctionCalls>(&state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassAddGlobalVariables>(&state_->pass_instances);
     MaybeAddRepeatedPass<FuzzerPassAddImageSampleUnusedComponents>(
-        &pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassAddLoads>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassAddLocalVariables>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassAddLoopPreheaders>(&pass_instances);
+        &state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassAddLoads>(&state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassAddLocalVariables>(&state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassAddLoopPreheaders>(&state_->pass_instances);
     MaybeAddRepeatedPass<FuzzerPassAddLoopsToCreateIntConstantSynonyms>(
-        &pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassAddOpPhiSynonyms>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassAddParameters>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassAddRelaxedDecorations>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassAddStores>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassAddSynonyms>(&pass_instances);
+        &state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassAddOpPhiSynonyms>(&state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassAddParameters>(&state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassAddRelaxedDecorations>(
+        &state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassAddStores>(&state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassAddSynonyms>(&state_->pass_instances);
     MaybeAddRepeatedPass<FuzzerPassAddVectorShuffleInstructions>(
-        &pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassConstructComposites>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassCopyObjects>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassDonateModules>(&pass_instances,
+        &state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassConstructComposites>(
+        &state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassCopyObjects>(&state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassDonateModules>(&state_->pass_instances,
                                                   donor_suppliers_);
     MaybeAddRepeatedPass<FuzzerPassDuplicateRegionsWithSelections>(
-        &pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassExpandVectorReductions>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassFlattenConditionalBranches>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassInlineFunctions>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassInvertComparisonOperators>(&pass_instances);
+        &state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassExpandVectorReductions>(
+        &state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassFlattenConditionalBranches>(
+        &state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassInlineFunctions>(&state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassInvertComparisonOperators>(
+        &state_->pass_instances);
     MaybeAddRepeatedPass<FuzzerPassMakeVectorOperationsDynamic>(
-        &pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassMergeBlocks>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassMergeFunctionReturns>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassMutatePointers>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassOutlineFunctions>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassPermuteBlocks>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassPermuteFunctionParameters>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassPermuteInstructions>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassPropagateInstructionsDown>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassPropagateInstructionsUp>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassPushIdsThroughVariables>(&pass_instances);
+        &state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassMergeBlocks>(&state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassMergeFunctionReturns>(
+        &state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassMutatePointers>(&state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassOutlineFunctions>(&state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassPermuteBlocks>(&state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassPermuteFunctionParameters>(
+        &state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassPermuteInstructions>(
+        &state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassPropagateInstructionsDown>(
+        &state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassPropagateInstructionsUp>(
+        &state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassPushIdsThroughVariables>(
+        &state_->pass_instances);
     MaybeAddRepeatedPass<FuzzerPassReplaceAddsSubsMulsWithCarryingExtended>(
-        &pass_instances);
+        &state_->pass_instances);
     MaybeAddRepeatedPass<FuzzerPassReplaceBranchesFromDeadBlocksWithExits>(
-        &pass_instances);
+        &state_->pass_instances);
     MaybeAddRepeatedPass<FuzzerPassReplaceCopyMemoriesWithLoadsStores>(
-        &pass_instances);
+        &state_->pass_instances);
     MaybeAddRepeatedPass<FuzzerPassReplaceCopyObjectsWithStoresLoads>(
-        &pass_instances);
+        &state_->pass_instances);
     MaybeAddRepeatedPass<FuzzerPassReplaceLoadsStoresWithCopyMemories>(
-        &pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassReplaceParameterWithGlobal>(&pass_instances);
+        &state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassReplaceParameterWithGlobal>(
+        &state_->pass_instances);
     MaybeAddRepeatedPass<FuzzerPassReplaceLinearAlgebraInstructions>(
-        &pass_instances);
+        &state_->pass_instances);
     MaybeAddRepeatedPass<FuzzerPassReplaceOpPhiIdsFromDeadPredecessors>(
-        &pass_instances);
+        &state_->pass_instances);
     MaybeAddRepeatedPass<FuzzerPassReplaceOpSelectsWithConditionalBranches>(
-        &pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassReplaceParamsWithStruct>(&pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassSplitBlocks>(&pass_instances);
+        &state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassReplaceParamsWithStruct>(
+        &state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassSplitBlocks>(&state_->pass_instances);
     MaybeAddRepeatedPass<FuzzerPassSwapBranchConditionalOperands>(
-        &pass_instances);
-    MaybeAddRepeatedPass<FuzzerPassWrapRegionsInSelections>(&pass_instances);
+        &state_->pass_instances);
+    MaybeAddRepeatedPass<FuzzerPassWrapRegionsInSelections>(
+        &state_->pass_instances);
     // There is a theoretical possibility that no pass instances were created
     // until now; loop again if so.
-  } while (pass_instances.GetPasses().empty());
+  } while (state_->pass_instances.GetPasses().empty());
 
-  RepeatedPassRecommenderStandard pass_recommender(&pass_instances,
-                                                   fuzzer_context_.get());
+  state_->repeated_pass_recommender =
+      MakeUnique<RepeatedPassRecommenderStandard>(&state_->pass_instances,
+                                                  state_->fuzzer_context.get());
+  state_->repeated_pass_manager = RepeatedPassManager::Create(
+      repeated_pass_strategy_, state_->fuzzer_context.get(),
+      &state_->pass_instances, state_->repeated_pass_recommender.get());
+}
 
-  std::unique_ptr<RepeatedPassManager> repeated_pass_manager = nullptr;
-  switch (repeated_pass_strategy_) {
-    case RepeatedPassStrategy::kSimple:
-      repeated_pass_manager = MakeUnique<RepeatedPassManagerSimple>(
-          fuzzer_context_.get(), &pass_instances);
-      break;
-    case RepeatedPassStrategy::kLoopedWithRecommendations:
-      repeated_pass_manager =
-          MakeUnique<RepeatedPassManagerLoopedWithRecommendations>(
-              fuzzer_context_.get(), &pass_instances, &pass_recommender);
-      break;
-    case RepeatedPassStrategy::kRandomWithRecommendations:
-      repeated_pass_manager =
-          MakeUnique<RepeatedPassManagerRandomWithRecommendations>(
-              fuzzer_context_.get(), &pass_instances, &pass_recommender);
-      break;
+Fuzzer::FuzzerResult Fuzzer::Run(uint32_t num_of_transformations_to_apply) {
+  // Check compatibility between the library version being linked with and the
+  // header files being used.
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  if (!state_) {
+    spvtools::SpirvTools tools(target_env_);
+    tools.SetMessageConsumer(consumer_);
+    if (!tools.IsValid()) {
+      consumer_(SPV_MSG_ERROR, nullptr, {},
+                "Failed to create SPIRV-Tools interface; stopping.");
+      return {FuzzerResultStatus::kFailedToCreateSpirvToolsInterface, {}};
+    }
+
+    // Initial binary should be valid.
+    if (!tools.Validate(binary_in_.data(), binary_in_.size(),
+                        validator_options_)) {
+      consumer_(SPV_MSG_ERROR, nullptr, {},
+                "Initial binary is invalid; stopping.");
+      return {FuzzerResultStatus::kInitialBinaryInvalid, {}};
+    }
+
+    BuildState();
+  }
+
+  assert(state_ && "state_ is not initialized");
+
+  const auto initial_num_of_transformations = static_cast<uint32_t>(
+      state_->transformation_sequence_out.transformation_size());
+  if (initial_num_of_transformations >=
+      state_->fuzzer_context->GetTransformationLimit()) {
+    return {FuzzerResultStatus::kTransformationLimitReached, {}};
+  }
+
+  if (state_->num_repeated_passes_applied >=
+      state_->fuzzer_context->GetTransformationLimit()) {
+    return {FuzzerResultStatus::kFuzzerStuck, {}};
   }
 
   do {
-    if (!ApplyPassAndCheckValidity(
-            repeated_pass_manager->ChoosePass(transformation_sequence_out_))) {
-      return {Fuzzer::FuzzerResultStatus::kFuzzerPassLedToInvalidModule,
-              std::vector<uint32_t>(), protobufs::TransformationSequence()};
+    if (!ApplyPassAndCheckValidity(state_->repeated_pass_manager->ChoosePass(
+            state_->transformation_sequence_out))) {
+      return {Fuzzer::FuzzerResultStatus::kFuzzerPassLedToInvalidModule, {}};
     }
-  } while (ShouldContinueFuzzing());
+  } while (ShouldContinueFuzzing(initial_num_of_transformations,
+                                 num_of_transformations_to_apply));
 
   // Now apply some passes that it does not make sense to apply repeatedly,
   // as they do not unlock other passes.
@@ -346,62 +394,75 @@ Fuzzer::FuzzerResult Fuzzer::Run() {
   MaybeAddFinalPass<FuzzerPassToggleAccessChainInstruction>(&final_passes);
   for (auto& pass : final_passes) {
     if (!ApplyPassAndCheckValidity(pass.get())) {
-      return {Fuzzer::FuzzerResultStatus::kFuzzerPassLedToInvalidModule,
-              std::vector<uint32_t>(), protobufs::TransformationSequence()};
+      return {Fuzzer::FuzzerResultStatus::kFuzzerPassLedToInvalidModule, {}};
     }
   }
   // Encode the module as a binary.
   std::vector<uint32_t> binary_out;
-  ir_context_->module()->ToBinary(&binary_out, false);
+  state_->ir_context->module()->ToBinary(&binary_out, false);
 
-  return {Fuzzer::FuzzerResultStatus::kComplete, std::move(binary_out),
-          std::move(transformation_sequence_out_)};
+  return {Fuzzer::FuzzerResultStatus::kComplete, std::move(binary_out)};
 }
 
-bool Fuzzer::ShouldContinueFuzzing() {
+bool Fuzzer::ShouldContinueFuzzing(uint32_t initial_num_of_transformations,
+                                   uint32_t num_of_transformations_to_apply) {
   // There's a risk that fuzzing could get stuck, if none of the enabled fuzzer
   // passes are able to apply any transformations.  To guard against this we
   // count the number of times some repeated pass has been applied and ensure
   // that fuzzing stops if the number of repeated passes hits the limit on the
   // number of transformations that can be applied.
   assert(
-      num_repeated_passes_applied_ <=
-          fuzzer_context_->GetTransformationLimit() &&
+      state_->num_repeated_passes_applied <=
+          state_->fuzzer_context->GetTransformationLimit() &&
       "The number of repeated passes applied must not exceed its upper limit.");
-  if (ir_context_->module()->id_bound() >= fuzzer_context_->GetIdBoundLimit()) {
+  if (state_->ir_context->module()->id_bound() >=
+      state_->fuzzer_context->GetIdBoundLimit()) {
     return false;
   }
-  if (num_repeated_passes_applied_ ==
-      fuzzer_context_->GetTransformationLimit()) {
+  if (state_->num_repeated_passes_applied ==
+      state_->fuzzer_context->GetTransformationLimit()) {
     // Stop because fuzzing has got stuck.
     return false;
   }
-  auto transformations_applied_so_far =
-      static_cast<uint32_t>(transformation_sequence_out_.transformation_size());
+  auto transformations_applied_so_far = static_cast<uint32_t>(
+      state_->transformation_sequence_out.transformation_size());
   if (transformations_applied_so_far >=
-      fuzzer_context_->GetTransformationLimit()) {
+      state_->fuzzer_context->GetTransformationLimit()) {
     // Stop because we have reached the transformation limit.
     return false;
   }
-  // If we have applied T transformations so far, and the limit on the number of
-  // transformations to apply is L (where T < L), the chance that we will
-  // continue fuzzing is:
-  //
-  //     1 - T/(2*L)
-  //
-  // That is, the chance of continuing decreases as more transformations are
-  // applied.  Using 2*L instead of L increases the number of transformations
-  // that are applied on average.
-  auto chance_of_continuing = static_cast<uint32_t>(
-      100.0 * (1.0 - (static_cast<double>(transformations_applied_so_far) /
-                      (2.0 * static_cast<double>(
-                                 fuzzer_context_->GetTransformationLimit())))));
-  if (!fuzzer_context_->ChoosePercentage(chance_of_continuing)) {
-    // We have probabilistically decided to stop.
+  assert(transformations_applied_so_far >= initial_num_of_transformations &&
+         "Number of transformations cannot decrease");
+  if (num_of_transformations_to_apply != 0 &&
+      transformations_applied_so_far - initial_num_of_transformations >=
+          num_of_transformations_to_apply) {
+    // Stop because we've applied the maximum number of transformations for a
+    // single execution of a |Run| method.
     return false;
   }
+  if (continue_fuzzing_probabilistically_) {
+    // If we have applied T transformations so far, and the limit on the number
+    // of transformations to apply is L (where T < L), the chance that we will
+    // continue fuzzing is:
+    //
+    //     1 - T/(2*L)
+    //
+    // That is, the chance of continuing decreases as more transformations are
+    // applied.  Using 2*L instead of L increases the number of transformations
+    // that are applied on average.
+    auto chance_of_continuing = static_cast<uint32_t>(
+        100.0 *
+        (1.0 -
+         (static_cast<double>(transformations_applied_so_far) /
+          (2.0 * static_cast<double>(
+                     state_->fuzzer_context->GetTransformationLimit())))));
+    if (!state_->fuzzer_context->ChoosePercentage(chance_of_continuing)) {
+      // We have probabilistically decided to stop.
+      return false;
+    }
+  }
   // Continue fuzzing!
-  num_repeated_passes_applied_++;
+  state_->num_repeated_passes_applied++;
   return true;
 }
 

--- a/source/fuzz/fuzzer.h
+++ b/source/fuzz/fuzzer.h
@@ -125,7 +125,7 @@ class Fuzzer {
   // the number of transformations that have been applied increases.
   // The described probability is only applied if
   // |continue_fuzzing_probabilistically| is true.
-  bool ShouldContinueFuzzing(bool continue_fuzzing_probabilistically);
+  bool ShouldContinueRepeatedPasses(bool continue_fuzzing_probabilistically);
 
   // Applies |pass|, which must be a pass constructed with |ir_context|.
   // If |validate_after_each_fuzzer_pass_| is not set, true is always returned.

--- a/source/fuzz/fuzzer.h
+++ b/source/fuzz/fuzzer.h
@@ -23,6 +23,7 @@
 #include "source/fuzz/fuzzer_pass.h"
 #include "source/fuzz/fuzzer_util.h"
 #include "source/fuzz/pass_management/repeated_pass_instances.h"
+#include "source/fuzz/pass_management/repeated_pass_manager.h"
 #include "source/fuzz/pass_management/repeated_pass_recommender.h"
 #include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
 #include "source/fuzz/random_generator.h"
@@ -39,6 +40,8 @@ class Fuzzer {
   // Possible statuses that can result from running the fuzzer.
   enum class FuzzerResultStatus {
     kComplete,
+    kTransformationLimitReached,
+    kFuzzerStuck,
     kFailedToCreateSpirvToolsInterface,
     kFuzzerPassLedToInvalidModule,
     kInitialBinaryInvalid,
@@ -47,26 +50,16 @@ class Fuzzer {
   struct FuzzerResult {
     FuzzerResultStatus status;
     std::vector<uint32_t> transformed_binary;
-    protobufs::TransformationSequence applied_transformations;
-  };
-
-  // Each field of this enum corresponds to an available repeated pass
-  // strategy, and is used to decide which kind of RepeatedPassManager object
-  // to create.
-  enum class RepeatedPassStrategy {
-    kSimple,
-    kRandomWithRecommendations,
-    kLoopedWithRecommendations
   };
 
   Fuzzer(spv_target_env target_env, MessageConsumer consumer,
-         const std::vector<uint32_t>& binary_in,
-         const protobufs::FactSequence& initial_facts,
-         const std::vector<fuzzerutil::ModuleSupplier>& donor_suppliers,
+         std::vector<uint32_t> binary_in, protobufs::FactSequence initial_facts,
+         std::vector<fuzzerutil::ModuleSupplier> donor_suppliers,
          std::unique_ptr<RandomGenerator> random_generator,
          bool enable_all_passes, RepeatedPassStrategy repeated_pass_strategy,
          bool validate_after_each_fuzzer_pass,
-         spv_validator_options validator_options);
+         spv_validator_options validator_options,
+         bool continue_fuzzing_probabilistically);
 
   // Disables copy/move constructor/assignment operations.
   Fuzzer(const Fuzzer&) = delete;
@@ -83,10 +76,58 @@ class Fuzzer {
   // returns a successful result status together with the transformed binary and
   // the sequence of transformations that were applied.  Otherwise, returns an
   // appropriate result status together with an empty binary and empty
-  // transformation sequence.
-  FuzzerResult Run();
+  // transformation sequence. |num_of_transformations| is equal to the maximum
+  // number of transformations applied in a single call to this method. This
+  // parameter is ignored if it's value is equal to 0.
+  FuzzerResult Run(uint32_t num_of_transformations_to_apply = 0);
+
+  // Returns all applied transformations.
+  const protobufs::TransformationSequence& GetAppliedTransformations() const;
 
  private:
+  // This struct holds all the data that is created once during the call to the
+  // |Run| method and is persisted during the life of the fuzzer.
+  struct State {
+    State(std::unique_ptr<opt::IRContext> ir_context_,
+          std::unique_ptr<FuzzerContext> fuzzer_context_,
+          std::unique_ptr<TransformationContext> transformation_context_);
+
+    // The number of repeated fuzzer passes that have been applied is kept track
+    // of, in order to enforce a hard limit on the number of times such passes
+    // can be applied.
+    uint32_t num_repeated_passes_applied;
+
+    // Intermediate representation for the module being fuzzed, which gets
+    // mutated as fuzzing proceeds.
+    std::unique_ptr<opt::IRContext> ir_context;
+
+    // Provides probabilities that control the fuzzing process.
+    std::unique_ptr<FuzzerContext> fuzzer_context;
+
+    // Contextual information that is required in order to apply
+    // transformations.
+    std::unique_ptr<TransformationContext> transformation_context;
+
+    // The sequence of transformations that have been applied during fuzzing. It
+    // is initially empty and grows as fuzzer passes are applied.
+    protobufs::TransformationSequence transformation_sequence_out;
+
+    // This object contains instances of all fuzzer passes that will participate
+    // in the fuzzing.
+    RepeatedPassInstances pass_instances;
+
+    // This object defines the recommendation logic for fuzzer passes.
+    std::unique_ptr<RepeatedPassRecommender> repeated_pass_recommender;
+
+    // This object manager a list of fuzzer pass and their available
+    // recommendations.
+    std::unique_ptr<RepeatedPassManager> repeated_pass_manager;
+  };
+
+  // Initializes the |state_| field. This method is called once in the lifetime
+  // of a fuzzer when the |Run| method is called first.
+  void BuildState();
+
   // A convenience method to add a repeated fuzzer pass to |pass_instances| with
   // probability |percentage_chance_of_adding_pass|%, or with probability 100%
   // if |enable_all_passes_| is true.
@@ -119,7 +160,11 @@ class Fuzzer {
 
   // Decides whether to apply more repeated passes. The probability decreases as
   // the number of transformations that have been applied increases.
-  bool ShouldContinueFuzzing();
+  // |initial_num_of_transformations| - number of applied transformations when
+  // the |Run| method has been called. |num_of_transformations_to_apply| -
+  // number of transformations to apply in this execution of the |Run| method.
+  bool ShouldContinueFuzzing(uint32_t initial_num_of_transformations,
+                             uint32_t num_of_transformations_to_apply);
 
   // Applies |pass|, which must be a pass constructed with |ir_context|.
   // If |validate_after_each_fuzzer_pass_| is not set, true is always returned.
@@ -133,52 +178,41 @@ class Fuzzer {
 
   // Message consumer that will be invoked once for each message communicated
   // from the library.
-  MessageConsumer consumer_;
+  const MessageConsumer consumer_;
 
   // The initial binary to which fuzzing should be applied.
-  const std::vector<uint32_t>& binary_in_;
+  const std::vector<uint32_t> binary_in_;
 
   // Initial facts known to hold in advance of applying any transformations.
-  const protobufs::FactSequence& initial_facts_;
+  const protobufs::FactSequence initial_facts_;
 
   // A source of modules whose contents can be donated into the module being
   // fuzzed.
-  const std::vector<fuzzerutil::ModuleSupplier>& donor_suppliers_;
+  const std::vector<fuzzerutil::ModuleSupplier> donor_suppliers_;
 
   // Random number generator to control decision making during fuzzing.
-  std::unique_ptr<RandomGenerator> random_generator_;
+  const std::unique_ptr<RandomGenerator> random_generator_;
 
   // Determines whether all passes should be enabled, vs. having passes be
   // probabilistically enabled.
-  bool enable_all_passes_;
+  const bool enable_all_passes_;
 
   // Controls which type of RepeatedPassManager object to create.
-  RepeatedPassStrategy repeated_pass_strategy_;
+  const RepeatedPassStrategy repeated_pass_strategy_;
 
   // Determines whether the validator should be invoked after every fuzzer pass.
-  bool validate_after_each_fuzzer_pass_;
+  const bool validate_after_each_fuzzer_pass_;
 
   // Options to control validation.
-  spv_validator_options validator_options_;
+  const spv_validator_options validator_options_;
 
-  // The number of repeated fuzzer passes that have been applied is kept track
-  // of, in order to enforce a hard limit on the number of times such passes
-  // can be applied.
-  uint32_t num_repeated_passes_applied_;
+  // Determines whether the probability of applying another fuzzer pass
+  // decreases as the number of applied transformations increases.
+  const bool continue_fuzzing_probabilistically_;
 
-  // Intermediate representation for the module being fuzzed, which gets
-  // mutated as fuzzing proceeds.
-  std::unique_ptr<opt::IRContext> ir_context_;
-
-  // Provides probabilities that control the fuzzing process.
-  std::unique_ptr<FuzzerContext> fuzzer_context_;
-
-  // Contextual information that is required in order to apply transformations.
-  std::unique_ptr<TransformationContext> transformation_context_;
-
-  // The sequence of transformations that have been applied during fuzzing.  It
-  // is initially empty and grows as fuzzer passes are applied.
-  protobufs::TransformationSequence transformation_sequence_out_;
+  // Holds the state that is used to fuzz a single shader over multiple
+  // invocations of the |Run| method.
+  std::unique_ptr<State> state_;
 };
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_context.cpp
+++ b/source/fuzz/fuzzer_context.cpp
@@ -21,6 +21,12 @@ namespace fuzz {
 
 namespace {
 
+// An offset between the the module's id bound and the minimum fresh id.
+//
+// TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/2541): consider
+//  the case where the maximum id bound is reached.
+const uint32_t kIdBoundGap = 100;
+
 // Limits to help control the overall fuzzing process and rein in individual
 // fuzzer passes.
 const uint32_t kIdBoundLimit = 50000;
@@ -177,9 +183,9 @@ const std::function<bool(uint32_t, RandomGenerator*)>
 
 }  // namespace
 
-FuzzerContext::FuzzerContext(RandomGenerator* random_generator,
+FuzzerContext::FuzzerContext(std::unique_ptr<RandomGenerator> random_generator,
                              uint32_t min_fresh_id)
-    : random_generator_(random_generator),
+    : random_generator_(std::move(random_generator)),
       next_fresh_id_(min_fresh_id),
       max_equivalence_class_size_for_data_synonym_fact_closure_(
           kDefaultMaxEquivalenceClassSizeForDataSynonymFactClosure),
@@ -401,6 +407,10 @@ uint32_t FuzzerContext::GetIdBoundLimit() const { return kIdBoundLimit; }
 
 uint32_t FuzzerContext::GetTransformationLimit() const {
   return kTransformationLimit;
+}
+
+uint32_t FuzzerContext::GetMinFreshId(opt::IRContext* ir_context) {
+  return ir_context->module()->id_bound() + kIdBoundGap;
 }
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_context.h
+++ b/source/fuzz/fuzzer_context.h
@@ -21,6 +21,7 @@
 #include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
 #include "source/fuzz/random_generator.h"
 #include "source/opt/function.h"
+#include "source/opt/ir_context.h"
 
 namespace spvtools {
 namespace fuzz {
@@ -32,7 +33,8 @@ class FuzzerContext {
  public:
   // Constructs a fuzzer context with a given random generator and the minimum
   // value that can be used for fresh ids.
-  FuzzerContext(RandomGenerator* random_generator, uint32_t min_fresh_id);
+  FuzzerContext(std::unique_ptr<RandomGenerator> random_generator,
+                uint32_t min_fresh_id);
 
   ~FuzzerContext();
 
@@ -114,6 +116,9 @@ class FuzzerContext {
   // Also useful to control the overall fuzzing process and rein in individual
   // fuzzer passes.
   uint32_t GetTransformationLimit() const;
+
+  // Returns the minimum fresh id that can be used given the |ir_context|.
+  static uint32_t GetMinFreshId(opt::IRContext* ir_context);
 
   // Probabilities associated with applying various transformations.
   // Keep them in alphabetical order.
@@ -442,12 +447,12 @@ class FuzzerContext {
     return random_generator_->RandomUint32(max_unused_component_count) + 1;
   }
   bool GoDeeperInConstantObfuscation(uint32_t depth) {
-    return go_deeper_in_constant_obfuscation_(depth, random_generator_);
+    return go_deeper_in_constant_obfuscation_(depth, random_generator_.get());
   }
 
  private:
   // The source of randomness.
-  RandomGenerator* random_generator_;
+  std::unique_ptr<RandomGenerator> random_generator_;
   // The next fresh id to be issued.
   uint32_t next_fresh_id_;
 

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -38,6 +38,15 @@ extern const spvtools::MessageConsumer kSilentMessageConsumer;
 // Function type that produces a SPIR-V module.
 using ModuleSupplier = std::function<std::unique_ptr<opt::IRContext>()>;
 
+// Builds a new opt::IRContext object. Returns true if successful and changes
+// the |ir_context| parameter. Otherwise (if any errors occur), returns false
+// and |ir_context| remains unchanged.
+bool BuildIRContext(spv_target_env target_env,
+                    const spvtools::MessageConsumer& message_consumer,
+                    const std::vector<uint32_t>& binary_in,
+                    spv_validator_options validator_options,
+                    std::unique_ptr<spvtools::opt::IRContext>* ir_context);
+
 // Returns true if and only if the module does not define the given id.
 bool IsFreshId(opt::IRContext* context, uint32_t id);
 

--- a/source/fuzz/pass_management/repeated_pass_manager.cpp
+++ b/source/fuzz/pass_management/repeated_pass_manager.cpp
@@ -14,6 +14,10 @@
 
 #include "source/fuzz/pass_management/repeated_pass_manager.h"
 
+#include "source/fuzz/pass_management/repeated_pass_manager_looped_with_recommendations.h"
+#include "source/fuzz/pass_management/repeated_pass_manager_random_with_recommendations.h"
+#include "source/fuzz/pass_management/repeated_pass_manager_simple.h"
+
 namespace spvtools {
 namespace fuzz {
 
@@ -22,6 +26,26 @@ RepeatedPassManager::RepeatedPassManager(FuzzerContext* fuzzer_context,
     : fuzzer_context_(fuzzer_context), pass_instances_(pass_instances) {}
 
 RepeatedPassManager::~RepeatedPassManager() = default;
+
+std::unique_ptr<RepeatedPassManager> RepeatedPassManager::Create(
+    RepeatedPassStrategy strategy, FuzzerContext* fuzzer_context,
+    RepeatedPassInstances* pass_instances,
+    RepeatedPassRecommender* pass_recommender) {
+  switch (strategy) {
+    case RepeatedPassStrategy::kSimple:
+      return MakeUnique<RepeatedPassManagerSimple>(fuzzer_context,
+                                                   pass_instances);
+    case RepeatedPassStrategy::kLoopedWithRecommendations:
+      return MakeUnique<RepeatedPassManagerLoopedWithRecommendations>(
+          fuzzer_context, pass_instances, pass_recommender);
+    case RepeatedPassStrategy::kRandomWithRecommendations:
+      return MakeUnique<RepeatedPassManagerRandomWithRecommendations>(
+          fuzzer_context, pass_instances, pass_recommender);
+  }
+
+  assert(false && "Unreachable");
+  return nullptr;
+}
 
 }  // namespace fuzz
 }  // namespace spvtools

--- a/source/fuzz/pass_management/repeated_pass_manager.h
+++ b/source/fuzz/pass_management/repeated_pass_manager.h
@@ -18,10 +18,20 @@
 #include "source/fuzz/fuzzer_context.h"
 #include "source/fuzz/fuzzer_pass.h"
 #include "source/fuzz/pass_management/repeated_pass_instances.h"
+#include "source/fuzz/pass_management/repeated_pass_recommender.h"
 #include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
 
 namespace spvtools {
 namespace fuzz {
+
+// Each field of this enum corresponds to an available repeated pass
+// strategy, and is used to decide which kind of RepeatedPassManager object
+// to create.
+enum class RepeatedPassStrategy {
+  kSimple,
+  kRandomWithRecommendations,
+  kLoopedWithRecommendations
+};
 
 // An interface to encapsulate the manner in which the sequence of repeated
 // passes that are applied during fuzzing is chosen.  An implementation of this
@@ -39,6 +49,12 @@ class RepeatedPassManager {
   // |applied_transformations| and can be used to influence the decision.
   virtual FuzzerPass* ChoosePass(
       const protobufs::TransformationSequence& applied_transformations) = 0;
+
+  // Creates a corresponding RepeatedPassManager based on the |strategy|.
+  static std::unique_ptr<RepeatedPassManager> Create(
+      RepeatedPassStrategy strategy, FuzzerContext* fuzzer_context,
+      RepeatedPassInstances* pass_instances,
+      RepeatedPassRecommender* pass_recommender);
 
  protected:
   FuzzerContext* GetFuzzerContext() { return fuzzer_context_; }

--- a/test/fuzz/fuzzer_pass_add_opphi_synonyms_test.cpp
+++ b/test/fuzz/fuzzer_pass_add_opphi_synonyms_test.cpp
@@ -128,8 +128,7 @@ TEST(FuzzerPassAddOpPhiSynonymsTest, HelperFunctions) {
                                                kConsoleMessageConsumer));
   TransformationContext transformation_context(
       MakeUnique<FactManager>(context.get()), validator_options);
-  PseudoRandomGenerator prng(0);
-  FuzzerContext fuzzer_context(&prng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassAddOpPhiSynonyms fuzzer_pass(context.get(), &transformation_context,

--- a/test/fuzz/fuzzer_pass_construct_composites_test.cpp
+++ b/test/fuzz/fuzzer_pass_construct_composites_test.cpp
@@ -77,7 +77,7 @@ TEST(FuzzerPassConstructCompositesTest, IsomorphicStructs) {
   const auto env = SPV_ENV_UNIVERSAL_1_3;
   const auto consumer = nullptr;
 
-  auto prng = MakeUnique<PseudoRandomGenerator>(0);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
 
   for (uint32_t i = 0; i < 10; i++) {
     const auto context =
@@ -87,7 +87,6 @@ TEST(FuzzerPassConstructCompositesTest, IsomorphicStructs) {
         context.get(), validator_options, kConsoleMessageConsumer));
     TransformationContext transformation_context(
         MakeUnique<FactManager>(context.get()), validator_options);
-    FuzzerContext fuzzer_context(prng.get(), 100);
     protobufs::TransformationSequence transformation_sequence;
 
     FuzzerPassConstructComposites fuzzer_pass(
@@ -158,7 +157,7 @@ TEST(FuzzerPassConstructCompositesTest, IsomorphicArrays) {
   const auto env = SPV_ENV_UNIVERSAL_1_3;
   const auto consumer = nullptr;
 
-  auto prng = MakeUnique<PseudoRandomGenerator>(0);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
 
   for (uint32_t i = 0; i < 10; i++) {
     const auto context =
@@ -168,7 +167,6 @@ TEST(FuzzerPassConstructCompositesTest, IsomorphicArrays) {
         context.get(), validator_options, kConsoleMessageConsumer));
     TransformationContext transformation_context(
         MakeUnique<FactManager>(context.get()), validator_options);
-    FuzzerContext fuzzer_context(prng.get(), 100);
     protobufs::TransformationSequence transformation_sequence;
 
     FuzzerPassConstructComposites fuzzer_pass(

--- a/test/fuzz/fuzzer_pass_donate_modules_test.cpp
+++ b/test/fuzz/fuzzer_pass_donate_modules_test.cpp
@@ -204,8 +204,7 @@ TEST(FuzzerPassDonateModulesTest, BasicDonation) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(recipient_context.get()), validator_options);
 
-  PseudoRandomGenerator prng(0);
-  FuzzerContext fuzzer_context(&prng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
@@ -285,8 +284,7 @@ TEST(FuzzerPassDonateModulesTest, DonationWithUniforms) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(recipient_context.get()), validator_options);
 
-  PseudoRandomGenerator prng(0);
-  FuzzerContext fuzzer_context(&prng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
@@ -416,8 +414,7 @@ TEST(FuzzerPassDonateModulesTest, DonationWithInputAndOutputVariables) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(recipient_context.get()), validator_options);
 
-  PseudoRandomGenerator prng(0);
-  FuzzerContext fuzzer_context(&prng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
@@ -511,8 +508,7 @@ TEST(FuzzerPassDonateModulesTest, DonateFunctionTypeWithDifferentPointers) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(recipient_context.get()), validator_options);
 
-  PseudoRandomGenerator prng(0);
-  FuzzerContext fuzzer_context(&prng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
@@ -581,8 +577,7 @@ TEST(FuzzerPassDonateModulesTest, DonateOpConstantNull) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(recipient_context.get()), validator_options);
 
-  PseudoRandomGenerator prng(0);
-  FuzzerContext fuzzer_context(&prng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
@@ -709,8 +704,7 @@ TEST(FuzzerPassDonateModulesTest, DonateCodeThatUsesImages) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(recipient_context.get()), validator_options);
 
-  PseudoRandomGenerator prng(0);
-  FuzzerContext fuzzer_context(&prng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
@@ -805,8 +799,7 @@ TEST(FuzzerPassDonateModulesTest, DonateCodeThatUsesSampler) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(recipient_context.get()), validator_options);
 
-  PseudoRandomGenerator prng(0);
-  FuzzerContext fuzzer_context(&prng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
@@ -937,8 +930,7 @@ TEST(FuzzerPassDonateModulesTest, DonateCodeThatUsesImageStructField) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(recipient_context.get()), validator_options);
 
-  PseudoRandomGenerator prng(0);
-  FuzzerContext fuzzer_context(&prng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
@@ -1073,8 +1065,7 @@ TEST(FuzzerPassDonateModulesTest, DonateCodeThatUsesImageFunctionParameter) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(recipient_context.get()), validator_options);
 
-  PseudoRandomGenerator prng(0);
-  FuzzerContext fuzzer_context(&prng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
@@ -1155,8 +1146,7 @@ TEST(FuzzerPassDonateModulesTest, DonateShaderWithImageStorageClass) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(recipient_context.get()), validator_options);
 
-  PseudoRandomGenerator prng(0);
-  FuzzerContext fuzzer_context(&prng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
@@ -1242,8 +1232,7 @@ TEST(FuzzerPassDonateModulesTest, DonateComputeShaderWithRuntimeArray) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(recipient_context.get()), validator_options);
 
-  PseudoRandomGenerator prng(0);
-  FuzzerContext fuzzer_context(&prng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
@@ -1346,8 +1335,7 @@ TEST(FuzzerPassDonateModulesTest, DonateComputeShaderWithRuntimeArrayLivesafe) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(recipient_context.get()), validator_options);
 
-  PseudoRandomGenerator prng(0);
-  FuzzerContext fuzzer_context(&prng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
@@ -1418,8 +1406,7 @@ TEST(FuzzerPassDonateModulesTest, DonateComputeShaderWithWorkgroupVariables) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(recipient_context.get()), validator_options);
 
-  PseudoRandomGenerator prng(0);
-  FuzzerContext fuzzer_context(&prng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
@@ -1528,8 +1515,7 @@ TEST(FuzzerPassDonateModulesTest, DonateComputeShaderWithAtomics) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(recipient_context.get()), validator_options);
 
-  PseudoRandomGenerator prng(0);
-  FuzzerContext fuzzer_context(&prng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
@@ -1712,8 +1698,7 @@ TEST(FuzzerPassDonateModulesTest, Miscellaneous1) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(recipient_context.get()), validator_options);
 
-  PseudoRandomGenerator rng(0);
-  FuzzerContext fuzzer_context(&rng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
@@ -1784,8 +1769,7 @@ TEST(FuzzerPassDonateModulesTest, OpSpecConstantInstructions) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(recipient_context.get()), validator_options);
 
-  PseudoRandomGenerator prng(0);
-  FuzzerContext fuzzer_context(&prng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
@@ -1941,8 +1925,7 @@ TEST(FuzzerPassDonateModulesTest, DonationSupportsOpTypeRuntimeArray) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(recipient_context.get()), validator_options);
 
-  PseudoRandomGenerator rng(0);
-  FuzzerContext fuzzer_context(&rng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
@@ -2014,8 +1997,7 @@ TEST(FuzzerPassDonateModulesTest, HandlesCapabilities) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(recipient_context.get()), validator_options);
 
-  PseudoRandomGenerator rng(0);
-  FuzzerContext fuzzer_context(&rng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
@@ -2247,8 +2229,7 @@ TEST(FuzzerPassDonateModulesTest, HandlesOpPhisInMergeBlock) {
   TransformationContext transformation_context(
       MakeUnique<FactManager>(recipient_context.get()), validator_options);
 
-  PseudoRandomGenerator prng(0);
-  FuzzerContext fuzzer_context(&prng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),

--- a/test/fuzz/fuzzer_pass_outline_functions_test.cpp
+++ b/test/fuzz/fuzzer_pass_outline_functions_test.cpp
@@ -124,8 +124,7 @@ TEST(FuzzerPassOutlineFunctionsTest, EntryIsAlreadySuitable) {
                                                kConsoleMessageConsumer));
   TransformationContext transformation_context(
       MakeUnique<FactManager>(context.get()), validator_options);
-  PseudoRandomGenerator prng(0);
-  FuzzerContext fuzzer_context(&prng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassOutlineFunctions fuzzer_pass(context.get(), &transformation_context,
@@ -167,8 +166,7 @@ TEST(FuzzerPassOutlineFunctionsTest, EntryHasOpVariable) {
                                                kConsoleMessageConsumer));
   TransformationContext transformation_context(
       MakeUnique<FactManager>(context.get()), validator_options);
-  PseudoRandomGenerator prng(0);
-  FuzzerContext fuzzer_context(&prng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassOutlineFunctions fuzzer_pass(context.get(), &transformation_context,
@@ -291,8 +289,7 @@ TEST(FuzzerPassOutlineFunctionsTest, EntryBlockIsHeader) {
                                                kConsoleMessageConsumer));
   TransformationContext transformation_context(
       MakeUnique<FactManager>(context.get()), validator_options);
-  PseudoRandomGenerator prng(0);
-  FuzzerContext fuzzer_context(&prng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassOutlineFunctions fuzzer_pass(context.get(), &transformation_context,
@@ -458,8 +455,7 @@ TEST(FuzzerPassOutlineFunctionsTest, ExitBlock) {
                                                kConsoleMessageConsumer));
   TransformationContext transformation_context(
       MakeUnique<FactManager>(context.get()), validator_options);
-  PseudoRandomGenerator prng(0);
-  FuzzerContext fuzzer_context(&prng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformation_sequence;
 
   FuzzerPassOutlineFunctions fuzzer_pass(context.get(), &transformation_context,

--- a/test/fuzz/fuzzer_pass_test.cpp
+++ b/test/fuzz/fuzzer_pass_test.cpp
@@ -87,8 +87,7 @@ TEST(FuzzerPassTest, ForEachInstructionWithInstructionDescriptor) {
   ASSERT_TRUE(dominator_analysis->IsReachable(5));
   ASSERT_FALSE(dominator_analysis->IsReachable(8));
 
-  PseudoRandomGenerator prng(0);
-  FuzzerContext fuzzer_context(&prng, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   protobufs::TransformationSequence transformations;
   FuzzerPassMock fuzzer_pass_mock(context.get(), &transformation_context,
                                   &fuzzer_context, &transformations);

--- a/test/fuzz/fuzzer_replayer_test.cpp
+++ b/test/fuzz/fuzzer_replayer_test.cpp
@@ -1696,7 +1696,7 @@ TEST(FuzzerReplayerTest, Miscellaneous1) {
                        kNumFuzzerRuns);
 }
 
-TEST(FuzzerReplayerTest, DISABLED_Miscellaneous2) {
+TEST(FuzzerReplayerTest, Miscellaneous2) {
   // Do some fuzzer runs, starting from an initial seed of 10 (seed value chosen
   // arbitrarily).
   RunFuzzerAndReplayer(kTestShader2, protobufs::FactSequence(), 10,

--- a/test/fuzz/shrinker_test.cpp
+++ b/test/fuzz/shrinker_test.cpp
@@ -163,8 +163,7 @@ TEST(ShrinkerTest, ReduceAddedFunctions) {
   ASSERT_TRUE(fuzzerutil::IsValidAndWellFormed(
       donor_ir_context.get(), validator_options, kConsoleMessageConsumer));
 
-  PseudoRandomGenerator random_generator(0);
-  FuzzerContext fuzzer_context(&random_generator, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   TransformationContext transformation_context(
       MakeUnique<FactManager>(variant_ir_context.get()), validator_options);
 
@@ -341,8 +340,7 @@ TEST(ShrinkerTest, HitStepLimitWhenReducingAddedFunctions) {
   ASSERT_TRUE(fuzzerutil::IsValidAndWellFormed(
       donor_ir_context.get(), validator_options, kConsoleMessageConsumer));
 
-  PseudoRandomGenerator random_generator(0);
-  FuzzerContext fuzzer_context(&random_generator, 100);
+  FuzzerContext fuzzer_context(MakeUnique<PseudoRandomGenerator>(0), 100);
   TransformationContext transformation_context(
       MakeUnique<FactManager>(variant_ir_context.get()), validator_options);
 

--- a/tools/fuzz/fuzz.cpp
+++ b/tools/fuzz/fuzz.cpp
@@ -204,7 +204,7 @@ FuzzStatus ParseFlags(
     std::vector<std::string>* interestingness_test,
     std::string* shrink_transformations_file,
     std::string* shrink_temp_file_prefix,
-    spvtools::fuzz::Fuzzer::RepeatedPassStrategy* repeated_pass_strategy,
+    spvtools::fuzz::RepeatedPassStrategy* repeated_pass_strategy,
     spvtools::FuzzerOptions* fuzzer_options,
     spvtools::ValidatorOptions* validator_options) {
   uint32_t positional_arg_index = 0;
@@ -212,7 +212,7 @@ FuzzStatus ParseFlags(
   bool force_render_red = false;
 
   *repeated_pass_strategy =
-      spvtools::fuzz::Fuzzer::RepeatedPassStrategy::kLoopedWithRecommendations;
+      spvtools::fuzz::RepeatedPassStrategy::kLoopedWithRecommendations;
 
   for (int argi = 1; argi < argc; ++argi) {
     const char* cur_arg = argv[argi];
@@ -250,14 +250,14 @@ FuzzStatus ParseFlags(
                               sizeof("--repeated-pass-strategy=") - 1)) {
         std::string strategy = spvtools::utils::SplitFlagArgs(cur_arg).second;
         if (strategy == "looped") {
-          *repeated_pass_strategy = spvtools::fuzz::Fuzzer::
-              RepeatedPassStrategy::kLoopedWithRecommendations;
+          *repeated_pass_strategy =
+              spvtools::fuzz::RepeatedPassStrategy::kLoopedWithRecommendations;
         } else if (strategy == "random") {
-          *repeated_pass_strategy = spvtools::fuzz::Fuzzer::
-              RepeatedPassStrategy::kRandomWithRecommendations;
+          *repeated_pass_strategy =
+              spvtools::fuzz::RepeatedPassStrategy::kRandomWithRecommendations;
         } else if (strategy == "simple") {
           *repeated_pass_strategy =
-              spvtools::fuzz::Fuzzer::RepeatedPassStrategy::kSimple;
+              spvtools::fuzz::RepeatedPassStrategy::kSimple;
         } else {
           std::stringstream ss;
           ss << "Unknown repeated pass strategy '" << strategy << "'"
@@ -549,7 +549,7 @@ bool Fuzz(const spv_target_env& target_env,
           const std::vector<uint32_t>& binary_in,
           const spvtools::fuzz::protobufs::FactSequence& initial_facts,
           const std::string& donors,
-          spvtools::fuzz::Fuzzer::RepeatedPassStrategy repeated_pass_strategy,
+          spvtools::fuzz::RepeatedPassStrategy repeated_pass_strategy,
           std::vector<uint32_t>* binary_out,
           spvtools::fuzz::protobufs::TransformationSequence*
               transformations_applied) {
@@ -578,19 +578,17 @@ bool Fuzz(const spv_target_env& target_env,
         });
   }
 
-  auto fuzz_result =
-      spvtools::fuzz::Fuzzer(
-          target_env, message_consumer, binary_in, initial_facts,
-          donor_suppliers,
-          spvtools::MakeUnique<spvtools::fuzz::PseudoRandomGenerator>(
-              fuzzer_options->has_random_seed
-                  ? fuzzer_options->random_seed
-                  : static_cast<uint32_t>(std::random_device()())),
-          fuzzer_options->all_passes_enabled, repeated_pass_strategy,
-          fuzzer_options->fuzzer_pass_validation_enabled, validator_options)
-          .Run();
+  spvtools::fuzz::Fuzzer fuzzer(
+      target_env, message_consumer, binary_in, initial_facts, donor_suppliers,
+      spvtools::MakeUnique<spvtools::fuzz::PseudoRandomGenerator>(
+          fuzzer_options->has_random_seed
+              ? fuzzer_options->random_seed
+              : static_cast<uint32_t>(std::random_device()())),
+      fuzzer_options->all_passes_enabled, repeated_pass_strategy,
+      fuzzer_options->fuzzer_pass_validation_enabled, validator_options, true);
+  auto fuzz_result = fuzzer.Run();
   *binary_out = std::move(fuzz_result.transformed_binary);
-  *transformations_applied = std::move(fuzz_result.applied_transformations);
+  *transformations_applied = fuzzer.GetAppliedTransformations();
   if (fuzz_result.status !=
       spvtools::fuzz::Fuzzer::FuzzerResultStatus::kComplete) {
     spvtools::Error(FuzzDiagnostic, nullptr, {}, "Error running fuzzer");
@@ -656,7 +654,7 @@ int main(int argc, const char** argv) {
   std::vector<std::string> interestingness_test;
   std::string shrink_transformations_file;
   std::string shrink_temp_file_prefix = "temp_";
-  spvtools::fuzz::Fuzzer::RepeatedPassStrategy repeated_pass_strategy;
+  spvtools::fuzz::RepeatedPassStrategy repeated_pass_strategy;
 
   spvtools::FuzzerOptions fuzzer_options;
   spvtools::ValidatorOptions validator_options;


### PR DESCRIPTION
This PR adds the ability to call `Fuzzer::Run` multiple times in a single lifetime of the `Fuzzer`.

@afd for info.