### PR TITLE
Fix the install scripts for the vscode extension

### DIFF
--- a/utils/vscode/install.bat
+++ b/utils/vscode/install.bat
@@ -15,6 +15,8 @@
 @set EXT_PATH=%userprofile%\.vscode\extensions\google.spirvls-0.0.1
 @set ROOT_PATH=%~dp0
 
+go get -u golang.org/x/xerrors
+
 go run %ROOT_PATH%\src\tools\gen-grammar.go --cache %ROOT_PATH%\cache --template %ROOT_PATH%\spirv.json.tmpl --out %ROOT_PATH%\spirv.json
 go run %ROOT_PATH%\src\tools\gen-grammar.go --cache %ROOT_PATH%\cache --template %ROOT_PATH%\src\schema\schema.go.tmpl --out %ROOT_PATH%\src\schema\schema.go
 
@@ -23,7 +25,7 @@ copy %ROOT_PATH%\extension.js %EXT_PATH%
 copy %ROOT_PATH%\package.json %EXT_PATH%
 copy %ROOT_PATH%\spirv.json %EXT_PATH%
 
-go build -o %EXT_PATH%\langsvr %ROOT_PATH%\src\langsvr.go
+go build -o %EXT_PATH%\langsvr.exe %ROOT_PATH%\src\langsvr.go
 
 @pushd %EXT_PATH%
 call npm install

--- a/utils/vscode/install.sh
+++ b/utils/vscode/install.sh
@@ -18,6 +18,8 @@ set -e # Fail on any error.
 EXT_PATH=~/.vscode/extensions/google.spirvls-0.0.1
 ROOT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+go get -u golang.org/x/xerrors
+
 go run ${ROOT_PATH}/src/tools/gen-grammar.go --cache ${ROOT_PATH}/cache --template ${ROOT_PATH}/spirv.json.tmpl --out ${ROOT_PATH}/spirv.json
 go run ${ROOT_PATH}/src/tools/gen-grammar.go --cache ${ROOT_PATH}/cache --template ${ROOT_PATH}/src/schema/schema.go.tmpl --out ${ROOT_PATH}/src/schema/schema.go
 


### PR DESCRIPTION
These were not fetching the `golang.org/x/xerrors` package, which are a dependency.

Also fix the `.exe` executable extension on windows.