### PR TITLE
Fixes for the vscode language server extension

### DIFF
--- a/utils/vscode/README.md
+++ b/utils/vscode/README.md
@@ -1,12 +1,20 @@
 # Visual Studio Code extension for SPIR-V disassembly files
 
-This directory holds a Visual Studio Code extension adding syntax highlighting for SPIR-V assembly files (`.spvasm`)
+This directory holds a Visual Studio Code language server extension for SPIR-V assembly files (`.spvasm`)
+
+The extension supports:
+* Syntax highlighting
+* Jump to definition
+* Find all references
+* Symbol renaming
+* Operand hover information
+* Formatting
 
 ## Dependencies
 
 In order to build and install the Visual Studio Code language server extension, you will need to install and have on your `PATH` the following dependencies:
 * [`npm`](https://www.npmjs.com/)
-* [`golang`](https://golang.org/)
+* [`golang 1.16+`](https://golang.org/)
 
 ## Installing (macOS / Linux)
 

--- a/utils/vscode/go.mod
+++ b/utils/vscode/go.mod
@@ -1,0 +1,8 @@
+module github.com/KhronosGroup/SPIRV-Tools/utils/vscode
+
+go 1.16
+
+require (
+	github.com/pkg/errors v0.9.1
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+)

--- a/utils/vscode/go.sum
+++ b/utils/vscode/go.sum
@@ -1,0 +1,4 @@
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/utils/vscode/install.bat
+++ b/utils/vscode/install.bat
@@ -23,7 +23,7 @@ copy %ROOT_PATH%\extension.js %EXT_PATH%
 copy %ROOT_PATH%\package.json %EXT_PATH%
 copy %ROOT_PATH%\spirv.json %EXT_PATH%
 
-go build -o %EXT_PATH%\langsvr %ROOT_PATH%\src\langsvr.go
+go build -o %EXT_PATH%\langsvr.exe %ROOT_PATH%\src\langsvr.go
 
 @pushd %EXT_PATH%
 call npm install

--- a/utils/vscode/spirv.json
+++ b/utils/vscode/spirv.json
@@ -11,6 +11,8 @@
 		{ "include": "#BitEnum_MemorySemantics" },
 		{ "include": "#BitEnum_MemoryAccess" },
 		{ "include": "#BitEnum_KernelProfilingInfo" },
+		{ "include": "#BitEnum_RayFlags" },
+		{ "include": "#BitEnum_FragmentShadingRate" },
 		{ "include": "#ValueEnum_SourceLanguage" },
 		{ "include": "#ValueEnum_ExecutionModel" },
 		{ "include": "#ValueEnum_AddressingModel" },
@@ -24,6 +26,8 @@
 		{ "include": "#ValueEnum_ImageChannelOrder" },
 		{ "include": "#ValueEnum_ImageChannelDataType" },
 		{ "include": "#ValueEnum_FPRoundingMode" },
+		{ "include": "#ValueEnum_FPDenormMode" },
+		{ "include": "#ValueEnum_FPOperationMode" },
 		{ "include": "#ValueEnum_LinkageType" },
 		{ "include": "#ValueEnum_AccessQualifier" },
 		{ "include": "#ValueEnum_FunctionParameterAttribute" },
@@ -33,6 +37,9 @@
 		{ "include": "#ValueEnum_GroupOperation" },
 		{ "include": "#ValueEnum_KernelEnqueueFlags" },
 		{ "include": "#ValueEnum_Capability" },
+		{ "include": "#ValueEnum_RayQueryIntersection" },
+		{ "include": "#ValueEnum_RayQueryCommittedIntersectionType" },
+		{ "include": "#ValueEnum_RayQueryCandidateIntersectionType" },
 		{ "include": "#BitEnum_DebugInfoFlags" },
 		{ "include": "#ValueEnum_DebugBaseTypeAttributeEncoding" },
 		{ "include": "#ValueEnum_DebugCompositeType" },
@@ -53,7 +60,7 @@
 			"name": "keyword.spirv"
 		},
 		"BitEnum_FPFastMathMode": {
-			"match": "\\b(None|NotNaN|NotInf|NSZ|AllowRecip|Fast)\\b",
+			"match": "\\b(None|NotNaN|NotInf|NSZ|AllowRecip|Fast|AllowContractFastINTEL|AllowReassocINTEL)\\b",
 			"name": "keyword.spirv"
 		},
 		"BitEnum_SelectionControl": {
@@ -61,7 +68,7 @@
 			"name": "keyword.spirv"
 		},
 		"BitEnum_LoopControl": {
-			"match": "\\b(None|Unroll|DontUnroll|DependencyInfinite|DependencyLength|MinIterations|MaxIterations|IterationMultiple|PeelCount|PartialCount)\\b",
+			"match": "\\b(None|Unroll|DontUnroll|DependencyInfinite|DependencyLength|MinIterations|MaxIterations|IterationMultiple|PeelCount|PartialCount|InitiationIntervalINTEL|MaxConcurrencyINTEL|DependencyArrayINTEL|PipelineEnableINTEL|LoopCoalesceINTEL|MaxInterleavingINTEL|SpeculatedIterationsINTEL|NoFusionINTEL)\\b",
 			"name": "keyword.spirv"
 		},
 		"BitEnum_FunctionControl": {
@@ -80,12 +87,20 @@
 			"match": "\\b(None|CmdExecTime)\\b",
 			"name": "keyword.spirv"
 		},
+		"BitEnum_RayFlags": {
+			"match": "\\b(NoneKHR|OpaqueKHR|NoOpaqueKHR|TerminateOnFirstHitKHR|SkipClosestHitShaderKHR|CullBackFacingTrianglesKHR|CullFrontFacingTrianglesKHR|CullOpaqueKHR|CullNoOpaqueKHR|SkipTrianglesKHR|SkipAABBsKHR)\\b",
+			"name": "keyword.spirv"
+		},
+		"BitEnum_FragmentShadingRate": {
+			"match": "\\b(Vertical2Pixels|Vertical4Pixels|Horizontal2Pixels|Horizontal4Pixels)\\b",
+			"name": "keyword.spirv"
+		},
 		"ValueEnum_SourceLanguage": {
 			"match": "\\b(Unknown|ESSL|GLSL|OpenCL_C|OpenCL_CPP|HLSL)\\b",
 			"name": "keyword.spirv"
 		},
 		"ValueEnum_ExecutionModel": {
-			"match": "\\b(Vertex|TessellationControl|TessellationEvaluation|Geometry|Fragment|GLCompute|Kernel|TaskNV|MeshNV|RayGenerationNV|IntersectionNV|AnyHitNV|ClosestHitNV|MissNV|CallableNV)\\b",
+			"match": "\\b(Vertex|TessellationControl|TessellationEvaluation|Geometry|Fragment|GLCompute|Kernel|TaskNV|MeshNV|RayGenerationNV|RayGenerationKHR|IntersectionNV|IntersectionKHR|AnyHitNV|AnyHitKHR|ClosestHitNV|ClosestHitKHR|MissNV|MissKHR|CallableNV|CallableKHR)\\b",
 			"name": "keyword.spirv"
 		},
 		"ValueEnum_AddressingModel": {
@@ -97,11 +112,11 @@
 			"name": "keyword.spirv"
 		},
 		"ValueEnum_ExecutionMode": {
-			"match": "\\b(Invocations|SpacingEqual|SpacingFractionalEven|SpacingFractionalOdd|VertexOrderCw|VertexOrderCcw|PixelCenterInteger|OriginUpperLeft|OriginLowerLeft|EarlyFragmentTests|PointMode|Xfb|DepthReplacing|DepthGreater|DepthLess|DepthUnchanged|LocalSize|LocalSizeHint|InputPoints|InputLines|InputLinesAdjacency|Triangles|InputTrianglesAdjacency|Quads|Isolines|OutputVertices|OutputPoints|OutputLineStrip|OutputTriangleStrip|VecTypeHint|ContractionOff|Initializer|Finalizer|SubgroupSize|SubgroupsPerWorkgroup|SubgroupsPerWorkgroupId|LocalSizeId|LocalSizeHintId|PostDepthCoverage|DenormPreserve|DenormFlushToZero|SignedZeroInfNanPreserve|RoundingModeRTE|RoundingModeRTZ|StencilRefReplacingEXT|OutputLinesNV|OutputPrimitivesNV|DerivativeGroupQuadsNV|DerivativeGroupLinearNV|OutputTrianglesNV|PixelInterlockOrderedEXT|PixelInterlockUnorderedEXT|SampleInterlockOrderedEXT|SampleInterlockUnorderedEXT|ShadingRateInterlockOrderedEXT|ShadingRateInterlockUnorderedEXT)\\b",
+			"match": "\\b(Invocations|SpacingEqual|SpacingFractionalEven|SpacingFractionalOdd|VertexOrderCw|VertexOrderCcw|PixelCenterInteger|OriginUpperLeft|OriginLowerLeft|EarlyFragmentTests|PointMode|Xfb|DepthReplacing|DepthGreater|DepthLess|DepthUnchanged|LocalSize|LocalSizeHint|InputPoints|InputLines|InputLinesAdjacency|Triangles|InputTrianglesAdjacency|Quads|Isolines|OutputVertices|OutputPoints|OutputLineStrip|OutputTriangleStrip|VecTypeHint|ContractionOff|Initializer|Finalizer|SubgroupSize|SubgroupsPerWorkgroup|SubgroupsPerWorkgroupId|LocalSizeId|LocalSizeHintId|PostDepthCoverage|DenormPreserve|DenormFlushToZero|SignedZeroInfNanPreserve|RoundingModeRTE|RoundingModeRTZ|StencilRefReplacingEXT|OutputLinesNV|OutputPrimitivesNV|DerivativeGroupQuadsNV|DerivativeGroupLinearNV|OutputTrianglesNV|PixelInterlockOrderedEXT|PixelInterlockUnorderedEXT|SampleInterlockOrderedEXT|SampleInterlockUnorderedEXT|ShadingRateInterlockOrderedEXT|ShadingRateInterlockUnorderedEXT|SharedLocalMemorySizeINTEL|RoundingModeRTPINTEL|RoundingModeRTNINTEL|FloatingPointModeALTINTEL|FloatingPointModeIEEEINTEL|MaxWorkgroupSizeINTEL|MaxWorkDimINTEL|NoGlobalOffsetINTEL|NumSIMDWorkitemsINTEL|SchedulerTargetFmaxMhzINTEL)\\b",
 			"name": "keyword.spirv"
 		},
 		"ValueEnum_StorageClass": {
-			"match": "\\b(UniformConstant|Input|Uniform|Output|Workgroup|CrossWorkgroup|Private|Function|Generic|PushConstant|AtomicCounter|Image|StorageBuffer|CallableDataNV|IncomingCallableDataNV|RayPayloadNV|HitAttributeNV|IncomingRayPayloadNV|ShaderRecordBufferNV|PhysicalStorageBuffer|PhysicalStorageBufferEXT)\\b",
+			"match": "\\b(UniformConstant|Input|Uniform|Output|Workgroup|CrossWorkgroup|Private|Function|Generic|PushConstant|AtomicCounter|Image|StorageBuffer|CallableDataNV|CallableDataKHR|IncomingCallableDataNV|IncomingCallableDataKHR|RayPayloadNV|RayPayloadKHR|HitAttributeNV|HitAttributeKHR|IncomingRayPayloadNV|IncomingRayPayloadKHR|ShaderRecordBufferNV|ShaderRecordBufferKHR|PhysicalStorageBuffer|PhysicalStorageBufferEXT|CodeSectionINTEL|DeviceOnlyINTEL|HostOnlyINTEL)\\b",
 			"name": "keyword.spirv"
 		},
 		"ValueEnum_Dim": {
@@ -117,7 +132,7 @@
 			"name": "keyword.spirv"
 		},
 		"ValueEnum_ImageFormat": {
-			"match": "\\b(Unknown|Rgba32f|Rgba16f|R32f|Rgba8|Rgba8Snorm|Rg32f|Rg16f|R11fG11fB10f|R16f|Rgba16|Rgb10A2|Rg16|Rg8|R16|R8|Rgba16Snorm|Rg16Snorm|Rg8Snorm|R16Snorm|R8Snorm|Rgba32i|Rgba16i|Rgba8i|R32i|Rg32i|Rg16i|Rg8i|R16i|R8i|Rgba32ui|Rgba16ui|Rgba8ui|R32ui|Rgb10a2ui|Rg32ui|Rg16ui|Rg8ui|R16ui|R8ui)\\b",
+			"match": "\\b(Unknown|Rgba32f|Rgba16f|R32f|Rgba8|Rgba8Snorm|Rg32f|Rg16f|R11fG11fB10f|R16f|Rgba16|Rgb10A2|Rg16|Rg8|R16|R8|Rgba16Snorm|Rg16Snorm|Rg8Snorm|R16Snorm|R8Snorm|Rgba32i|Rgba16i|Rgba8i|R32i|Rg32i|Rg16i|Rg8i|R16i|R8i|Rgba32ui|Rgba16ui|Rgba8ui|R32ui|Rgb10a2ui|Rg32ui|Rg16ui|Rg8ui|R16ui|R8ui|R64ui|R64i)\\b",
 			"name": "keyword.spirv"
 		},
 		"ValueEnum_ImageChannelOrder": {
@@ -130,6 +145,14 @@
 		},
 		"ValueEnum_FPRoundingMode": {
 			"match": "\\b(RTE|RTZ|RTP|RTN)\\b",
+			"name": "keyword.spirv"
+		},
+		"ValueEnum_FPDenormMode": {
+			"match": "\\b(Preserve|FlushToZero)\\b",
+			"name": "keyword.spirv"
+		},
+		"ValueEnum_FPOperationMode": {
+			"match": "\\b(IEEE|ALT)\\b",
 			"name": "keyword.spirv"
 		},
 		"ValueEnum_LinkageType": {
@@ -145,15 +168,15 @@
 			"name": "keyword.spirv"
 		},
 		"ValueEnum_Decoration": {
-			"match": "\\b(RelaxedPrecision|SpecId|Block|BufferBlock|RowMajor|ColMajor|ArrayStride|MatrixStride|GLSLShared|GLSLPacked|CPacked|BuiltIn|NoPerspective|Flat|Patch|Centroid|Sample|Invariant|Restrict|Aliased|Volatile|Constant|Coherent|NonWritable|NonReadable|Uniform|UniformId|SaturatedConversion|Stream|Location|Component|Index|Binding|DescriptorSet|Offset|XfbBuffer|XfbStride|FuncParamAttr|FPRoundingMode|FPFastMathMode|LinkageAttributes|NoContraction|InputAttachmentIndex|Alignment|MaxByteOffset|AlignmentId|MaxByteOffsetId|NoSignedWrap|NoUnsignedWrap|ExplicitInterpAMD|OverrideCoverageNV|PassthroughNV|ViewportRelativeNV|SecondaryViewportRelativeNV|PerPrimitiveNV|PerViewNV|PerTaskNV|PerVertexNV|NonUniform|NonUniformEXT|RestrictPointer|RestrictPointerEXT|AliasedPointer|AliasedPointerEXT|CounterBuffer|HlslCounterBufferGOOGLE|UserSemantic|HlslSemanticGOOGLE|UserTypeGOOGLE)\\b",
+			"match": "\\b(RelaxedPrecision|SpecId|Block|BufferBlock|RowMajor|ColMajor|ArrayStride|MatrixStride|GLSLShared|GLSLPacked|CPacked|BuiltIn|NoPerspective|Flat|Patch|Centroid|Sample|Invariant|Restrict|Aliased|Volatile|Constant|Coherent|NonWritable|NonReadable|Uniform|UniformId|SaturatedConversion|Stream|Location|Component|Index|Binding|DescriptorSet|Offset|XfbBuffer|XfbStride|FuncParamAttr|FPRoundingMode|FPFastMathMode|LinkageAttributes|NoContraction|InputAttachmentIndex|Alignment|MaxByteOffset|AlignmentId|MaxByteOffsetId|NoSignedWrap|NoUnsignedWrap|ExplicitInterpAMD|OverrideCoverageNV|PassthroughNV|ViewportRelativeNV|SecondaryViewportRelativeNV|PerPrimitiveNV|PerViewNV|PerTaskNV|PerVertexNV|NonUniform|NonUniformEXT|RestrictPointer|RestrictPointerEXT|AliasedPointer|AliasedPointerEXT|SIMTCallINTEL|ReferencedIndirectlyINTEL|ClobberINTEL|SideEffectsINTEL|VectorComputeVariableINTEL|FuncParamIOKindINTEL|VectorComputeFunctionINTEL|StackCallINTEL|GlobalVariableOffsetINTEL|CounterBuffer|HlslCounterBufferGOOGLE|UserSemantic|HlslSemanticGOOGLE|UserTypeGOOGLE|FunctionRoundingModeINTEL|FunctionDenormModeINTEL|RegisterINTEL|MemoryINTEL|NumbanksINTEL|BankwidthINTEL|MaxPrivateCopiesINTEL|SinglepumpINTEL|DoublepumpINTEL|MaxReplicatesINTEL|SimpleDualPortINTEL|MergeINTEL|BankBitsINTEL|ForcePow2DepthINTEL|BurstCoalesceINTEL|CacheSizeINTEL|DontStaticallyCoalesceINTEL|PrefetchINTEL|StallEnableINTEL|FuseLoopsInFunctionINTEL|BufferLocationINTEL|IOPipeStorageINTEL|FunctionFloatingPointModeINTEL|SingleElementVectorINTEL|VectorComputeCallableFunctionINTEL)\\b",
 			"name": "keyword.spirv"
 		},
 		"ValueEnum_BuiltIn": {
-			"match": "\\b(Position|PointSize|ClipDistance|CullDistance|VertexId|InstanceId|PrimitiveId|InvocationId|Layer|ViewportIndex|TessLevelOuter|TessLevelInner|TessCoord|PatchVertices|FragCoord|PointCoord|FrontFacing|SampleId|SamplePosition|SampleMask|FragDepth|HelperInvocation|NumWorkgroups|WorkgroupSize|WorkgroupId|LocalInvocationId|GlobalInvocationId|LocalInvocationIndex|WorkDim|GlobalSize|EnqueuedWorkgroupSize|GlobalOffset|GlobalLinearId|SubgroupSize|SubgroupMaxSize|NumSubgroups|NumEnqueuedSubgroups|SubgroupId|SubgroupLocalInvocationId|VertexIndex|InstanceIndex|SubgroupEqMask|SubgroupGeMask|SubgroupGtMask|SubgroupLeMask|SubgroupLtMask|SubgroupEqMaskKHR|SubgroupGeMaskKHR|SubgroupGtMaskKHR|SubgroupLeMaskKHR|SubgroupLtMaskKHR|BaseVertex|BaseInstance|DrawIndex|DeviceIndex|ViewIndex|BaryCoordNoPerspAMD|BaryCoordNoPerspCentroidAMD|BaryCoordNoPerspSampleAMD|BaryCoordSmoothAMD|BaryCoordSmoothCentroidAMD|BaryCoordSmoothSampleAMD|BaryCoordPullModelAMD|FragStencilRefEXT|ViewportMaskNV|SecondaryPositionNV|SecondaryViewportMaskNV|PositionPerViewNV|ViewportMaskPerViewNV|FullyCoveredEXT|TaskCountNV|PrimitiveCountNV|PrimitiveIndicesNV|ClipDistancePerViewNV|CullDistancePerViewNV|LayerPerViewNV|MeshViewCountNV|MeshViewIndicesNV|BaryCoordNV|BaryCoordNoPerspNV|FragSizeEXT|FragmentSizeNV|FragInvocationCountEXT|InvocationsPerPixelNV|LaunchIdNV|LaunchSizeNV|WorldRayOriginNV|WorldRayDirectionNV|ObjectRayOriginNV|ObjectRayDirectionNV|RayTminNV|RayTmaxNV|InstanceCustomIndexNV|ObjectToWorldNV|WorldToObjectNV|HitTNV|HitKindNV|IncomingRayFlagsNV|WarpsPerSMNV|SMCountNV|WarpIDNV|SMIDNV)\\b",
+			"match": "\\b(Position|PointSize|ClipDistance|CullDistance|VertexId|InstanceId|PrimitiveId|InvocationId|Layer|ViewportIndex|TessLevelOuter|TessLevelInner|TessCoord|PatchVertices|FragCoord|PointCoord|FrontFacing|SampleId|SamplePosition|SampleMask|FragDepth|HelperInvocation|NumWorkgroups|WorkgroupSize|WorkgroupId|LocalInvocationId|GlobalInvocationId|LocalInvocationIndex|WorkDim|GlobalSize|EnqueuedWorkgroupSize|GlobalOffset|GlobalLinearId|SubgroupSize|SubgroupMaxSize|NumSubgroups|NumEnqueuedSubgroups|SubgroupId|SubgroupLocalInvocationId|VertexIndex|InstanceIndex|SubgroupEqMask|SubgroupEqMaskKHR|SubgroupGeMask|SubgroupGeMaskKHR|SubgroupGtMask|SubgroupGtMaskKHR|SubgroupLeMask|SubgroupLeMaskKHR|SubgroupLtMask|SubgroupLtMaskKHR|BaseVertex|BaseInstance|DrawIndex|PrimitiveShadingRateKHR|DeviceIndex|ViewIndex|ShadingRateKHR|BaryCoordNoPerspAMD|BaryCoordNoPerspCentroidAMD|BaryCoordNoPerspSampleAMD|BaryCoordSmoothAMD|BaryCoordSmoothCentroidAMD|BaryCoordSmoothSampleAMD|BaryCoordPullModelAMD|FragStencilRefEXT|ViewportMaskNV|SecondaryPositionNV|SecondaryViewportMaskNV|PositionPerViewNV|ViewportMaskPerViewNV|FullyCoveredEXT|TaskCountNV|PrimitiveCountNV|PrimitiveIndicesNV|ClipDistancePerViewNV|CullDistancePerViewNV|LayerPerViewNV|MeshViewCountNV|MeshViewIndicesNV|BaryCoordNV|BaryCoordNoPerspNV|FragSizeEXT|FragmentSizeNV|FragInvocationCountEXT|InvocationsPerPixelNV|LaunchIdNV|LaunchIdKHR|LaunchSizeNV|LaunchSizeKHR|WorldRayOriginNV|WorldRayOriginKHR|WorldRayDirectionNV|WorldRayDirectionKHR|ObjectRayOriginNV|ObjectRayOriginKHR|ObjectRayDirectionNV|ObjectRayDirectionKHR|RayTminNV|RayTminKHR|RayTmaxNV|RayTmaxKHR|InstanceCustomIndexNV|InstanceCustomIndexKHR|ObjectToWorldNV|ObjectToWorldKHR|WorldToObjectNV|WorldToObjectKHR|HitTNV|HitKindNV|HitKindKHR|IncomingRayFlagsNV|IncomingRayFlagsKHR|RayGeometryIndexKHR|WarpsPerSMNV|SMCountNV|WarpIDNV|SMIDNV)\\b",
 			"name": "keyword.spirv"
 		},
 		"ValueEnum_Scope": {
-			"match": "\\b(CrossDevice|Device|Workgroup|Subgroup|Invocation|QueueFamily|QueueFamilyKHR)\\b",
+			"match": "\\b(CrossDevice|Device|Workgroup|Subgroup|Invocation|QueueFamily|QueueFamilyKHR|ShaderCallKHR)\\b",
 			"name": "keyword.spirv"
 		},
 		"ValueEnum_GroupOperation": {
@@ -165,11 +188,23 @@
 			"name": "keyword.spirv"
 		},
 		"ValueEnum_Capability": {
-			"match": "\\b(Matrix|Shader|Geometry|Tessellation|Addresses|Linkage|Kernel|Vector16|Float16Buffer|Float16|Float64|Int64|Int64Atomics|ImageBasic|ImageReadWrite|ImageMipmap|Pipes|Groups|DeviceEnqueue|LiteralSampler|AtomicStorage|Int16|TessellationPointSize|GeometryPointSize|ImageGatherExtended|StorageImageMultisample|UniformBufferArrayDynamicIndexing|SampledImageArrayDynamicIndexing|StorageBufferArrayDynamicIndexing|StorageImageArrayDynamicIndexing|ClipDistance|CullDistance|ImageCubeArray|SampleRateShading|ImageRect|SampledRect|GenericPointer|Int8|InputAttachment|SparseResidency|MinLod|Sampled1D|Image1D|SampledCubeArray|SampledBuffer|ImageBuffer|ImageMSArray|StorageImageExtendedFormats|ImageQuery|DerivativeControl|InterpolationFunction|TransformFeedback|GeometryStreams|StorageImageReadWithoutFormat|StorageImageWriteWithoutFormat|MultiViewport|SubgroupDispatch|NamedBarrier|PipeStorage|GroupNonUniform|GroupNonUniformVote|GroupNonUniformArithmetic|GroupNonUniformBallot|GroupNonUniformShuffle|GroupNonUniformShuffleRelative|GroupNonUniformClustered|GroupNonUniformQuad|ShaderLayer|ShaderViewportIndex|SubgroupBallotKHR|DrawParameters|SubgroupVoteKHR|StorageBuffer16BitAccess|StorageUniformBufferBlock16|UniformAndStorageBuffer16BitAccess|StorageUniform16|StoragePushConstant16|StorageInputOutput16|DeviceGroup|MultiView|VariablePointersStorageBuffer|VariablePointers|AtomicStorageOps|SampleMaskPostDepthCoverage|StorageBuffer8BitAccess|UniformAndStorageBuffer8BitAccess|StoragePushConstant8|DenormPreserve|DenormFlushToZero|SignedZeroInfNanPreserve|RoundingModeRTE|RoundingModeRTZ|Float16ImageAMD|ImageGatherBiasLodAMD|FragmentMaskAMD|StencilExportEXT|ImageReadWriteLodAMD|ShaderClockKHR|SampleMaskOverrideCoverageNV|GeometryShaderPassthroughNV|ShaderViewportIndexLayerEXT|ShaderViewportIndexLayerNV|ShaderViewportMaskNV|ShaderStereoViewNV|PerViewAttributesNV|FragmentFullyCoveredEXT|MeshShadingNV|ImageFootprintNV|FragmentBarycentricNV|ComputeDerivativeGroupQuadsNV|FragmentDensityEXT|ShadingRateNV|GroupNonUniformPartitionedNV|ShaderNonUniform|ShaderNonUniformEXT|RuntimeDescriptorArray|RuntimeDescriptorArrayEXT|InputAttachmentArrayDynamicIndexing|InputAttachmentArrayDynamicIndexingEXT|UniformTexelBufferArrayDynamicIndexing|UniformTexelBufferArrayDynamicIndexingEXT|StorageTexelBufferArrayDynamicIndexing|StorageTexelBufferArrayDynamicIndexingEXT|UniformBufferArrayNonUniformIndexing|UniformBufferArrayNonUniformIndexingEXT|SampledImageArrayNonUniformIndexing|SampledImageArrayNonUniformIndexingEXT|StorageBufferArrayNonUniformIndexing|StorageBufferArrayNonUniformIndexingEXT|StorageImageArrayNonUniformIndexing|StorageImageArrayNonUniformIndexingEXT|InputAttachmentArrayNonUniformIndexing|InputAttachmentArrayNonUniformIndexingEXT|UniformTexelBufferArrayNonUniformIndexing|UniformTexelBufferArrayNonUniformIndexingEXT|StorageTexelBufferArrayNonUniformIndexing|StorageTexelBufferArrayNonUniformIndexingEXT|RayTracingNV|VulkanMemoryModel|VulkanMemoryModelKHR|VulkanMemoryModelDeviceScope|VulkanMemoryModelDeviceScopeKHR|PhysicalStorageBufferAddresses|PhysicalStorageBufferAddressesEXT|ComputeDerivativeGroupLinearNV|CooperativeMatrixNV|FragmentShaderSampleInterlockEXT|FragmentShaderShadingRateInterlockEXT|ShaderSMBuiltinsNV|FragmentShaderPixelInterlockEXT|DemoteToHelperInvocationEXT|SubgroupShuffleINTEL|SubgroupBufferBlockIOINTEL|SubgroupImageBlockIOINTEL|SubgroupImageMediaBlockIOINTEL|IntegerFunctions2INTEL|SubgroupAvcMotionEstimationINTEL|SubgroupAvcMotionEstimationIntraINTEL|SubgroupAvcMotionEstimationChromaINTEL)\\b",
+			"match": "\\b(Matrix|Shader|Geometry|Tessellation|Addresses|Linkage|Kernel|Vector16|Float16Buffer|Float16|Float64|Int64|Int64Atomics|ImageBasic|ImageReadWrite|ImageMipmap|Pipes|Groups|DeviceEnqueue|LiteralSampler|AtomicStorage|Int16|TessellationPointSize|GeometryPointSize|ImageGatherExtended|StorageImageMultisample|UniformBufferArrayDynamicIndexing|SampledImageArrayDynamicIndexing|StorageBufferArrayDynamicIndexing|StorageImageArrayDynamicIndexing|ClipDistance|CullDistance|ImageCubeArray|SampleRateShading|ImageRect|SampledRect|GenericPointer|Int8|InputAttachment|SparseResidency|MinLod|Sampled1D|Image1D|SampledCubeArray|SampledBuffer|ImageBuffer|ImageMSArray|StorageImageExtendedFormats|ImageQuery|DerivativeControl|InterpolationFunction|TransformFeedback|GeometryStreams|StorageImageReadWithoutFormat|StorageImageWriteWithoutFormat|MultiViewport|SubgroupDispatch|NamedBarrier|PipeStorage|GroupNonUniform|GroupNonUniformVote|GroupNonUniformArithmetic|GroupNonUniformBallot|GroupNonUniformShuffle|GroupNonUniformShuffleRelative|GroupNonUniformClustered|GroupNonUniformQuad|ShaderLayer|ShaderViewportIndex|FragmentShadingRateKHR|SubgroupBallotKHR|DrawParameters|WorkgroupMemoryExplicitLayoutKHR|WorkgroupMemoryExplicitLayout8BitAccessKHR|WorkgroupMemoryExplicitLayout16BitAccessKHR|SubgroupVoteKHR|StorageBuffer16BitAccess|StorageUniformBufferBlock16|UniformAndStorageBuffer16BitAccess|StorageUniform16|StoragePushConstant16|StorageInputOutput16|DeviceGroup|MultiView|VariablePointersStorageBuffer|VariablePointers|AtomicStorageOps|SampleMaskPostDepthCoverage|StorageBuffer8BitAccess|UniformAndStorageBuffer8BitAccess|StoragePushConstant8|DenormPreserve|DenormFlushToZero|SignedZeroInfNanPreserve|RoundingModeRTE|RoundingModeRTZ|RayQueryProvisionalKHR|RayQueryKHR|RayTraversalPrimitiveCullingKHR|RayTracingKHR|Float16ImageAMD|ImageGatherBiasLodAMD|FragmentMaskAMD|StencilExportEXT|ImageReadWriteLodAMD|Int64ImageEXT|ShaderClockKHR|SampleMaskOverrideCoverageNV|GeometryShaderPassthroughNV|ShaderViewportIndexLayerEXT|ShaderViewportIndexLayerNV|ShaderViewportMaskNV|ShaderStereoViewNV|PerViewAttributesNV|FragmentFullyCoveredEXT|MeshShadingNV|ImageFootprintNV|FragmentBarycentricNV|ComputeDerivativeGroupQuadsNV|FragmentDensityEXT|ShadingRateNV|GroupNonUniformPartitionedNV|ShaderNonUniform|ShaderNonUniformEXT|RuntimeDescriptorArray|RuntimeDescriptorArrayEXT|InputAttachmentArrayDynamicIndexing|InputAttachmentArrayDynamicIndexingEXT|UniformTexelBufferArrayDynamicIndexing|UniformTexelBufferArrayDynamicIndexingEXT|StorageTexelBufferArrayDynamicIndexing|StorageTexelBufferArrayDynamicIndexingEXT|UniformBufferArrayNonUniformIndexing|UniformBufferArrayNonUniformIndexingEXT|SampledImageArrayNonUniformIndexing|SampledImageArrayNonUniformIndexingEXT|StorageBufferArrayNonUniformIndexing|StorageBufferArrayNonUniformIndexingEXT|StorageImageArrayNonUniformIndexing|StorageImageArrayNonUniformIndexingEXT|InputAttachmentArrayNonUniformIndexing|InputAttachmentArrayNonUniformIndexingEXT|UniformTexelBufferArrayNonUniformIndexing|UniformTexelBufferArrayNonUniformIndexingEXT|StorageTexelBufferArrayNonUniformIndexing|StorageTexelBufferArrayNonUniformIndexingEXT|RayTracingNV|VulkanMemoryModel|VulkanMemoryModelKHR|VulkanMemoryModelDeviceScope|VulkanMemoryModelDeviceScopeKHR|PhysicalStorageBufferAddresses|PhysicalStorageBufferAddressesEXT|ComputeDerivativeGroupLinearNV|RayTracingProvisionalKHR|CooperativeMatrixNV|FragmentShaderSampleInterlockEXT|FragmentShaderShadingRateInterlockEXT|ShaderSMBuiltinsNV|FragmentShaderPixelInterlockEXT|DemoteToHelperInvocationEXT|SubgroupShuffleINTEL|SubgroupBufferBlockIOINTEL|SubgroupImageBlockIOINTEL|SubgroupImageMediaBlockIOINTEL|RoundToInfinityINTEL|FloatingPointModeINTEL|IntegerFunctions2INTEL|FunctionPointersINTEL|IndirectReferencesINTEL|AsmINTEL|AtomicFloat32MinMaxEXT|AtomicFloat64MinMaxEXT|AtomicFloat16MinMaxEXT|VectorComputeINTEL|VectorAnyINTEL|SubgroupAvcMotionEstimationINTEL|SubgroupAvcMotionEstimationIntraINTEL|SubgroupAvcMotionEstimationChromaINTEL|VariableLengthArrayINTEL|FunctionFloatControlINTEL|FPGAMemoryAttributesINTEL|FPFastMathModeINTEL|ArbitraryPrecisionIntegersINTEL|UnstructuredLoopControlsINTEL|FPGALoopControlsINTEL|KernelAttributesINTEL|FPGAKernelAttributesINTEL|FPGAMemoryAccessesINTEL|FPGAClusterAttributesINTEL|LoopFuseINTEL|FPGABufferLocationINTEL|USMStorageClassesINTEL|IOPipesINTEL|BlockingPipesINTEL|FPGARegINTEL|AtomicFloat32AddEXT|AtomicFloat64AddEXT|LongConstantCompositeINTEL)\\b",
+			"name": "keyword.spirv"
+		},
+		"ValueEnum_RayQueryIntersection": {
+			"match": "\\b(RayQueryCandidateIntersectionKHR|RayQueryCommittedIntersectionKHR)\\b",
+			"name": "keyword.spirv"
+		},
+		"ValueEnum_RayQueryCommittedIntersectionType": {
+			"match": "\\b(RayQueryCommittedIntersectionNoneKHR|RayQueryCommittedIntersectionTriangleKHR|RayQueryCommittedIntersectionGeneratedKHR)\\b",
+			"name": "keyword.spirv"
+		},
+		"ValueEnum_RayQueryCandidateIntersectionType": {
+			"match": "\\b(RayQueryCandidateIntersectionTriangleKHR|RayQueryCandidateIntersectionAABBKHR)\\b",
 			"name": "keyword.spirv"
 		},
 		"BitEnum_DebugInfoFlags": {
-			"match": "\\b(FlagIsProtected|FlagIsPrivate|FlagIsPublic|FlagIsLocal|FlagIsDefinition|FlagFwdDecl|FlagArtificial|FlagExplicit|FlagPrototyped|FlagObjectPointer|FlagStaticMember|FlagIndirectVariable|FlagLValueReference|FlagRValueReference|FlagIsOptimized|FlagIsEnumClass|FlagTypePassByValue|FlagTypePassByReference)\\b",
+			"match": "\\b(None|FlagIsProtected|FlagIsPrivate|FlagIsPublic|FlagIsLocal|FlagIsDefinition|FlagFwdDecl|FlagArtificial|FlagExplicit|FlagPrototyped|FlagObjectPointer|FlagStaticMember|FlagIndirectVariable|FlagLValueReference|FlagRValueReference|FlagIsOptimized|FlagIsEnumClass|FlagTypePassByValue|FlagTypePassByReference)\\b",
 			"name": "keyword.spirv"
 		},
 		"ValueEnum_DebugBaseTypeAttributeEncoding": {

--- a/utils/vscode/src/langsvr.go
+++ b/utils/vscode/src/langsvr.go
@@ -35,6 +35,10 @@ import (
 	lsp "github.com/KhronosGroup/SPIRV-Tools/utils/vscode/src/lsp/protocol"
 )
 
+const (
+	enableDebugLogging = false
+)
+
 // rSpy is a reader 'spy' that wraps an io.Reader, and logs all data that passes
 // through it.
 type rSpy struct {
@@ -63,12 +67,13 @@ func (s wSpy) Write(p []byte) (n int, err error) {
 
 // main entry point.
 func main() {
-	// create a log file in the executable's directory.
-	if logfile, err := os.Create(path.Join(path.Dir(os.Args[0]), "log.txt")); err == nil {
-		defer logfile.Close()
-		log.SetOutput(logfile)
-	} else {
-		log.SetOutput(ioutil.Discard)
+	log.SetOutput(ioutil.Discard)
+	if enableDebugLogging {
+		// create a log file in the executable's directory.
+		if logfile, err := os.Create(path.Join(path.Dir(os.Args[0]), "log.txt")); err == nil {
+			defer logfile.Close()
+			log.SetOutput(logfile)
+		}
 	}
 
 	log.Println("language server started")

--- a/utils/vscode/src/langsvr.go
+++ b/utils/vscode/src/langsvr.go
@@ -28,11 +28,11 @@ import (
 	"sync"
 	"unicode/utf8"
 
-	"./parser"
-	"./schema"
+	"github.com/KhronosGroup/SPIRV-Tools/utils/vscode/src/parser"
+	"github.com/KhronosGroup/SPIRV-Tools/utils/vscode/src/schema"
 
-	"./lsp/jsonrpc2"
-	lsp "./lsp/protocol"
+	"github.com/KhronosGroup/SPIRV-Tools/utils/vscode/src/lsp/jsonrpc2"
+	lsp "github.com/KhronosGroup/SPIRV-Tools/utils/vscode/src/lsp/protocol"
 )
 
 // rSpy is a reader 'spy' that wraps an io.Reader, and logs all data that passes

--- a/utils/vscode/src/lsp/protocol/log.go
+++ b/utils/vscode/src/lsp/protocol/log.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	"../jsonrpc2"
+	"github.com/KhronosGroup/SPIRV-Tools/utils/vscode/src/lsp/jsonrpc2"
 )
 
 type loggingStream struct {

--- a/utils/vscode/src/lsp/protocol/protocol.go
+++ b/utils/vscode/src/lsp/protocol/protocol.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"log"
 
-	"../jsonrpc2"
+	"github.com/KhronosGroup/SPIRV-Tools/utils/vscode/src/lsp/jsonrpc2"
 )
 
 const (

--- a/utils/vscode/src/lsp/protocol/span.go
+++ b/utils/vscode/src/lsp/protocol/span.go
@@ -19,7 +19,8 @@ package protocol
 import (
 	"fmt"
 
-	"../span"
+	"github.com/KhronosGroup/SPIRV-Tools/utils/vscode/src/lsp/span"
+
 	errors "golang.org/x/xerrors"
 )
 

--- a/utils/vscode/src/lsp/protocol/tsclient.go
+++ b/utils/vscode/src/lsp/protocol/tsclient.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"log"
 
-	"../jsonrpc2"
+	"github.com/KhronosGroup/SPIRV-Tools/utils/vscode/src/lsp/jsonrpc2"
 )
 
 type Client interface {

--- a/utils/vscode/src/lsp/protocol/tsserver.go
+++ b/utils/vscode/src/lsp/protocol/tsserver.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"log"
 
-	"../jsonrpc2"
+	"github.com/KhronosGroup/SPIRV-Tools/utils/vscode/src/lsp/jsonrpc2"
 )
 
 type Server interface {

--- a/utils/vscode/src/parser/parser.go
+++ b/utils/vscode/src/parser/parser.go
@@ -23,7 +23,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"../schema"
+	"github.com/KhronosGroup/SPIRV-Tools/utils/vscode/src/schema"
 )
 
 // Type is an enumerator of token types.

--- a/utils/vscode/src/schema/schema.go
+++ b/utils/vscode/src/schema/schema.go
@@ -447,12 +447,25 @@ var (
 		"OpPtrEqual": OpPtrEqual,
 		"OpPtrNotEqual": OpPtrNotEqual,
 		"OpPtrDiff": OpPtrDiff,
+		"OpTerminateInvocation": OpTerminateInvocation,
 		"OpSubgroupBallotKHR": OpSubgroupBallotKHR,
 		"OpSubgroupFirstInvocationKHR": OpSubgroupFirstInvocationKHR,
 		"OpSubgroupAllKHR": OpSubgroupAllKHR,
 		"OpSubgroupAnyKHR": OpSubgroupAnyKHR,
 		"OpSubgroupAllEqualKHR": OpSubgroupAllEqualKHR,
 		"OpSubgroupReadInvocationKHR": OpSubgroupReadInvocationKHR,
+		"OpTraceRayKHR": OpTraceRayKHR,
+		"OpExecuteCallableKHR": OpExecuteCallableKHR,
+		"OpConvertUToAccelerationStructureKHR": OpConvertUToAccelerationStructureKHR,
+		"OpIgnoreIntersectionKHR": OpIgnoreIntersectionKHR,
+		"OpTerminateRayKHR": OpTerminateRayKHR,
+		"OpTypeRayQueryKHR": OpTypeRayQueryKHR,
+		"OpRayQueryInitializeKHR": OpRayQueryInitializeKHR,
+		"OpRayQueryTerminateKHR": OpRayQueryTerminateKHR,
+		"OpRayQueryGenerateIntersectionKHR": OpRayQueryGenerateIntersectionKHR,
+		"OpRayQueryConfirmIntersectionKHR": OpRayQueryConfirmIntersectionKHR,
+		"OpRayQueryProceedKHR": OpRayQueryProceedKHR,
+		"OpRayQueryGetIntersectionTypeKHR": OpRayQueryGetIntersectionTypeKHR,
 		"OpGroupIAddNonUniformAMD": OpGroupIAddNonUniformAMD,
 		"OpGroupFAddNonUniformAMD": OpGroupFAddNonUniformAMD,
 		"OpGroupFMinNonUniformAMD": OpGroupFMinNonUniformAMD,
@@ -470,39 +483,11 @@ var (
 		"OpReportIntersectionNV": OpReportIntersectionNV,
 		"OpReportIntersectionKHR": OpReportIntersectionKHR,
 		"OpIgnoreIntersectionNV": OpIgnoreIntersectionNV,
-		"OpIgnoreIntersectionKHR": OpIgnoreIntersectionKHR,
 		"OpTerminateRayNV": OpTerminateRayNV,
-		"OpTerminateRayKHR": OpTerminateRayKHR,
 		"OpTraceNV": OpTraceNV,
-		"OpTraceRayKHR": OpTraceRayKHR,
 		"OpTypeAccelerationStructureNV": OpTypeAccelerationStructureNV,
 		"OpTypeAccelerationStructureKHR": OpTypeAccelerationStructureKHR,
-		"OpTypeRayQueryKHR": OpTypeRayQueryKHR,
-		"OpRayQueryInitializeKHR": OpRayQueryInitializeKHR,
-		"OpRayQueryTerminateKHR": OpRayQueryTerminateKHR,
-		"OpRayQueryGenerateIntersectionKHR": OpRayQueryGenerateIntersectionKHR,
-		"OpRayQueryConfirmIntersectionKHR": OpRayQueryConfirmIntersectionKHR,
-		"OpRayQueryProceedKHR": OpRayQueryProceedKHR,
-		"OpRayQueryGetIntersectionTypeKHR": OpRayQueryGetIntersectionTypeKHR,
-		"OpRayQueryGetRayTMinKHR": OpRayQueryGetRayTMinKHR,
-		"OpRayQueryGetRayFlagsKHR": OpRayQueryGetRayFlagsKHR,
-		"OpRayQueryGetIntersectionTKHR": OpRayQueryGetIntersectionTKHR,
-		"OpRayQueryGetIntersectionInstanceCustomIndexKHR": OpRayQueryGetIntersectionInstanceCustomIndexKHR,
-		"OpRayQueryGetIntersectionInstanceIdKHR": OpRayQueryGetIntersectionInstanceIdKHR,
-		"OpRayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetKHR": OpRayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetKHR,
-		"OpRayQueryGetIntersectionGeometryIndexKHR": OpRayQueryGetIntersectionGeometryIndexKHR,
-		"OpRayQueryGetIntersectionPrimitiveIndexKHR": OpRayQueryGetIntersectionPrimitiveIndexKHR,
-		"OpRayQueryGetIntersectionBarycentricsKHR": OpRayQueryGetIntersectionBarycentricsKHR,
-		"OpRayQueryGetIntersectionFrontFaceKHR": OpRayQueryGetIntersectionFrontFaceKHR,
-		"OpRayQueryGetIntersectionCandidateAABBOpaqueKHR": OpRayQueryGetIntersectionCandidateAABBOpaqueKHR,
-		"OpRayQueryGetIntersectionObjectRayDirectionKHR": OpRayQueryGetIntersectionObjectRayDirectionKHR,
-		"OpRayQueryGetIntersectionObjectRayOriginKHR": OpRayQueryGetIntersectionObjectRayOriginKHR,
-		"OpRayQueryGetWorldRayDirectionKHR": OpRayQueryGetWorldRayDirectionKHR,
-		"OpRayQueryGetWorldRayOriginKHR": OpRayQueryGetWorldRayOriginKHR,
-		"OpRayQueryGetIntersectionObjectToWorldKHR": OpRayQueryGetIntersectionObjectToWorldKHR,
-		"OpRayQueryGetIntersectionWorldToObjectKHR": OpRayQueryGetIntersectionWorldToObjectKHR,
 		"OpExecuteCallableNV": OpExecuteCallableNV,
-		"OpExecuteCallableKHR": OpExecuteCallableKHR,
 		"OpTypeCooperativeMatrixNV": OpTypeCooperativeMatrixNV,
 		"OpCooperativeMatrixLoadNV": OpCooperativeMatrixLoadNV,
 		"OpCooperativeMatrixStoreNV": OpCooperativeMatrixStoreNV,
@@ -536,6 +521,13 @@ var (
 		"OpUSubSatINTEL": OpUSubSatINTEL,
 		"OpIMul32x16INTEL": OpIMul32x16INTEL,
 		"OpUMul32x16INTEL": OpUMul32x16INTEL,
+		"OpConstFunctionPointerINTEL": OpConstFunctionPointerINTEL,
+		"OpFunctionPointerCallINTEL": OpFunctionPointerCallINTEL,
+		"OpAsmTargetINTEL": OpAsmTargetINTEL,
+		"OpAsmINTEL": OpAsmINTEL,
+		"OpAsmCallINTEL": OpAsmCallINTEL,
+		"OpAtomicFMinEXT": OpAtomicFMinEXT,
+		"OpAtomicFMaxEXT": OpAtomicFMaxEXT,
 		"OpDecorateString": OpDecorateString,
 		"OpDecorateStringGOOGLE": OpDecorateStringGOOGLE,
 		"OpMemberDecorateString": OpMemberDecorateString,
@@ -658,6 +650,37 @@ var (
 		"OpSubgroupAvcSicGetPackedSkcLumaCountThresholdINTEL": OpSubgroupAvcSicGetPackedSkcLumaCountThresholdINTEL,
 		"OpSubgroupAvcSicGetPackedSkcLumaSumThresholdINTEL": OpSubgroupAvcSicGetPackedSkcLumaSumThresholdINTEL,
 		"OpSubgroupAvcSicGetInterRawSadsINTEL": OpSubgroupAvcSicGetInterRawSadsINTEL,
+		"OpVariableLengthArrayINTEL": OpVariableLengthArrayINTEL,
+		"OpSaveMemoryINTEL": OpSaveMemoryINTEL,
+		"OpRestoreMemoryINTEL": OpRestoreMemoryINTEL,
+		"OpLoopControlINTEL": OpLoopControlINTEL,
+		"OpPtrCastToCrossWorkgroupINTEL": OpPtrCastToCrossWorkgroupINTEL,
+		"OpCrossWorkgroupCastToPtrINTEL": OpCrossWorkgroupCastToPtrINTEL,
+		"OpReadPipeBlockingINTEL": OpReadPipeBlockingINTEL,
+		"OpWritePipeBlockingINTEL": OpWritePipeBlockingINTEL,
+		"OpFPGARegINTEL": OpFPGARegINTEL,
+		"OpRayQueryGetRayTMinKHR": OpRayQueryGetRayTMinKHR,
+		"OpRayQueryGetRayFlagsKHR": OpRayQueryGetRayFlagsKHR,
+		"OpRayQueryGetIntersectionTKHR": OpRayQueryGetIntersectionTKHR,
+		"OpRayQueryGetIntersectionInstanceCustomIndexKHR": OpRayQueryGetIntersectionInstanceCustomIndexKHR,
+		"OpRayQueryGetIntersectionInstanceIdKHR": OpRayQueryGetIntersectionInstanceIdKHR,
+		"OpRayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetKHR": OpRayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetKHR,
+		"OpRayQueryGetIntersectionGeometryIndexKHR": OpRayQueryGetIntersectionGeometryIndexKHR,
+		"OpRayQueryGetIntersectionPrimitiveIndexKHR": OpRayQueryGetIntersectionPrimitiveIndexKHR,
+		"OpRayQueryGetIntersectionBarycentricsKHR": OpRayQueryGetIntersectionBarycentricsKHR,
+		"OpRayQueryGetIntersectionFrontFaceKHR": OpRayQueryGetIntersectionFrontFaceKHR,
+		"OpRayQueryGetIntersectionCandidateAABBOpaqueKHR": OpRayQueryGetIntersectionCandidateAABBOpaqueKHR,
+		"OpRayQueryGetIntersectionObjectRayDirectionKHR": OpRayQueryGetIntersectionObjectRayDirectionKHR,
+		"OpRayQueryGetIntersectionObjectRayOriginKHR": OpRayQueryGetIntersectionObjectRayOriginKHR,
+		"OpRayQueryGetWorldRayDirectionKHR": OpRayQueryGetWorldRayDirectionKHR,
+		"OpRayQueryGetWorldRayOriginKHR": OpRayQueryGetWorldRayOriginKHR,
+		"OpRayQueryGetIntersectionObjectToWorldKHR": OpRayQueryGetIntersectionObjectToWorldKHR,
+		"OpRayQueryGetIntersectionWorldToObjectKHR": OpRayQueryGetIntersectionWorldToObjectKHR,
+		"OpAtomicFAddEXT": OpAtomicFAddEXT,
+		"OpTypeBufferSurfaceINTEL": OpTypeBufferSurfaceINTEL,
+		"OpTypeStructContinuedINTEL": OpTypeStructContinuedINTEL,
+		"OpConstantCompositeContinuedINTEL": OpConstantCompositeContinuedINTEL,
+		"OpSpecConstantCompositeContinuedINTEL": OpSpecConstantCompositeContinuedINTEL,
 	}
 
 	// ExtOpcodes is a map of extension name to Opcode description list.
@@ -10022,6 +10045,13 @@ var (
 			}, 
 		},
 	}
+	OpTerminateInvocation = &Opcode {
+		Opname:   "OpTerminateInvocation",
+		Class:    "Control-Flow",
+		Opcode:   4416,
+		Operands: []Operand {
+		},
+	}
 	OpSubgroupBallotKHR = &Opcode {
 		Opname:   "OpSubgroupBallotKHR",
 		Class:    "Group",
@@ -10155,6 +10185,270 @@ var (
 			Operand {
 				Kind:       OperandKindIdRef,
 				Name:       "'Index'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpTraceRayKHR = &Opcode {
+		Opname:   "OpTraceRayKHR",
+		Class:    "Reserved",
+		Opcode:   4445,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Accel'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Ray Flags'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Cull Mask'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'SBT Offset'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'SBT Stride'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Miss Index'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Ray Origin'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Ray Tmin'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Ray Direction'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Ray Tmax'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Payload'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpExecuteCallableKHR = &Opcode {
+		Opname:   "OpExecuteCallableKHR",
+		Class:    "Reserved",
+		Opcode:   4446,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'SBT Index'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Callable Data'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpConvertUToAccelerationStructureKHR = &Opcode {
+		Opname:   "OpConvertUToAccelerationStructureKHR",
+		Class:    "Reserved",
+		Opcode:   4447,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Accel'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpIgnoreIntersectionKHR = &Opcode {
+		Opname:   "OpIgnoreIntersectionKHR",
+		Class:    "Reserved",
+		Opcode:   4448,
+		Operands: []Operand {
+		},
+	}
+	OpTerminateRayKHR = &Opcode {
+		Opname:   "OpTerminateRayKHR",
+		Class:    "Reserved",
+		Opcode:   4449,
+		Operands: []Operand {
+		},
+	}
+	OpTypeRayQueryKHR = &Opcode {
+		Opname:   "OpTypeRayQueryKHR",
+		Class:    "Reserved",
+		Opcode:   4472,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryInitializeKHR = &Opcode {
+		Opname:   "OpRayQueryInitializeKHR",
+		Class:    "Reserved",
+		Opcode:   4473,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Accel'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayFlags'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'CullMask'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayOrigin'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayTMin'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayDirection'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayTMax'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryTerminateKHR = &Opcode {
+		Opname:   "OpRayQueryTerminateKHR",
+		Class:    "Reserved",
+		Opcode:   4474,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryGenerateIntersectionKHR = &Opcode {
+		Opname:   "OpRayQueryGenerateIntersectionKHR",
+		Class:    "Reserved",
+		Opcode:   4475,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'HitT'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryConfirmIntersectionKHR = &Opcode {
+		Opname:   "OpRayQueryConfirmIntersectionKHR",
+		Class:    "Reserved",
+		Opcode:   4476,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryProceedKHR = &Opcode {
+		Opname:   "OpRayQueryProceedKHR",
+		Class:    "Reserved",
+		Opcode:   4477,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryGetIntersectionTypeKHR = &Opcode {
+		Opname:   "OpRayQueryGetIntersectionTypeKHR",
+		Class:    "Reserved",
+		Opcode:   4479,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Intersection'",
 				Quantifier: "",
 			}, 
 		},
@@ -10638,13 +10932,6 @@ var (
 		Operands: []Operand {
 		},
 	}
-	OpIgnoreIntersectionKHR = &Opcode {
-		Opname:   "OpIgnoreIntersectionKHR",
-		Class:    "Reserved",
-		Opcode:   5335,
-		Operands: []Operand {
-		},
-	}
 	OpTerminateRayNV = &Opcode {
 		Opname:   "OpTerminateRayNV",
 		Class:    "Reserved",
@@ -10652,77 +10939,8 @@ var (
 		Operands: []Operand {
 		},
 	}
-	OpTerminateRayKHR = &Opcode {
-		Opname:   "OpTerminateRayKHR",
-		Class:    "Reserved",
-		Opcode:   5336,
-		Operands: []Operand {
-		},
-	}
 	OpTraceNV = &Opcode {
 		Opname:   "OpTraceNV",
-		Class:    "Reserved",
-		Opcode:   5337,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Accel'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Ray Flags'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Cull Mask'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'SBT Offset'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'SBT Stride'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Miss Index'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Ray Origin'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Ray Tmin'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Ray Direction'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Ray Tmax'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'PayloadId'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpTraceRayKHR = &Opcode {
-		Opname:   "OpTraceRayKHR",
 		Class:    "Reserved",
 		Opcode:   5337,
 		Operands: []Operand {
@@ -10807,608 +11025,8 @@ var (
 			}, 
 		},
 	}
-	OpTypeRayQueryKHR = &Opcode {
-		Opname:   "OpTypeRayQueryKHR",
-		Class:    "Reserved",
-		Opcode:   4472,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdResult,
-				Name:       "",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryInitializeKHR = &Opcode {
-		Opname:   "OpRayQueryInitializeKHR",
-		Class:    "Reserved",
-		Opcode:   4473,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Accel'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayFlags'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'CullMask'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayOrigin'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayTMin'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayDirection'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayTMax'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryTerminateKHR = &Opcode {
-		Opname:   "OpRayQueryTerminateKHR",
-		Class:    "Reserved",
-		Opcode:   4474,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryGenerateIntersectionKHR = &Opcode {
-		Opname:   "OpRayQueryGenerateIntersectionKHR",
-		Class:    "Reserved",
-		Opcode:   4475,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'HitT'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryConfirmIntersectionKHR = &Opcode {
-		Opname:   "OpRayQueryConfirmIntersectionKHR",
-		Class:    "Reserved",
-		Opcode:   4476,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryProceedKHR = &Opcode {
-		Opname:   "OpRayQueryProceedKHR",
-		Class:    "Reserved",
-		Opcode:   4477,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdResultType,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdResult,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryGetIntersectionTypeKHR = &Opcode {
-		Opname:   "OpRayQueryGetIntersectionTypeKHR",
-		Class:    "Reserved",
-		Opcode:   4479,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdResultType,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdResult,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Intersection'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryGetRayTMinKHR = &Opcode {
-		Opname:   "OpRayQueryGetRayTMinKHR",
-		Class:    "Reserved",
-		Opcode:   6016,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdResultType,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdResult,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryGetRayFlagsKHR = &Opcode {
-		Opname:   "OpRayQueryGetRayFlagsKHR",
-		Class:    "Reserved",
-		Opcode:   6017,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdResultType,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdResult,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryGetIntersectionTKHR = &Opcode {
-		Opname:   "OpRayQueryGetIntersectionTKHR",
-		Class:    "Reserved",
-		Opcode:   6018,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdResultType,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdResult,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Intersection'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryGetIntersectionInstanceCustomIndexKHR = &Opcode {
-		Opname:   "OpRayQueryGetIntersectionInstanceCustomIndexKHR",
-		Class:    "Reserved",
-		Opcode:   6019,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdResultType,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdResult,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Intersection'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryGetIntersectionInstanceIdKHR = &Opcode {
-		Opname:   "OpRayQueryGetIntersectionInstanceIdKHR",
-		Class:    "Reserved",
-		Opcode:   6020,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdResultType,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdResult,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Intersection'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetKHR = &Opcode {
-		Opname:   "OpRayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetKHR",
-		Class:    "Reserved",
-		Opcode:   6021,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdResultType,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdResult,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Intersection'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryGetIntersectionGeometryIndexKHR = &Opcode {
-		Opname:   "OpRayQueryGetIntersectionGeometryIndexKHR",
-		Class:    "Reserved",
-		Opcode:   6022,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdResultType,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdResult,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Intersection'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryGetIntersectionPrimitiveIndexKHR = &Opcode {
-		Opname:   "OpRayQueryGetIntersectionPrimitiveIndexKHR",
-		Class:    "Reserved",
-		Opcode:   6023,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdResultType,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdResult,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Intersection'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryGetIntersectionBarycentricsKHR = &Opcode {
-		Opname:   "OpRayQueryGetIntersectionBarycentricsKHR",
-		Class:    "Reserved",
-		Opcode:   6024,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdResultType,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdResult,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Intersection'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryGetIntersectionFrontFaceKHR = &Opcode {
-		Opname:   "OpRayQueryGetIntersectionFrontFaceKHR",
-		Class:    "Reserved",
-		Opcode:   6025,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdResultType,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdResult,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Intersection'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryGetIntersectionCandidateAABBOpaqueKHR = &Opcode {
-		Opname:   "OpRayQueryGetIntersectionCandidateAABBOpaqueKHR",
-		Class:    "Reserved",
-		Opcode:   6026,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdResultType,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdResult,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryGetIntersectionObjectRayDirectionKHR = &Opcode {
-		Opname:   "OpRayQueryGetIntersectionObjectRayDirectionKHR",
-		Class:    "Reserved",
-		Opcode:   6027,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdResultType,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdResult,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Intersection'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryGetIntersectionObjectRayOriginKHR = &Opcode {
-		Opname:   "OpRayQueryGetIntersectionObjectRayOriginKHR",
-		Class:    "Reserved",
-		Opcode:   6028,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdResultType,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdResult,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Intersection'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryGetWorldRayDirectionKHR = &Opcode {
-		Opname:   "OpRayQueryGetWorldRayDirectionKHR",
-		Class:    "Reserved",
-		Opcode:   6029,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdResultType,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdResult,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryGetWorldRayOriginKHR = &Opcode {
-		Opname:   "OpRayQueryGetWorldRayOriginKHR",
-		Class:    "Reserved",
-		Opcode:   6030,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdResultType,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdResult,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryGetIntersectionObjectToWorldKHR = &Opcode {
-		Opname:   "OpRayQueryGetIntersectionObjectToWorldKHR",
-		Class:    "Reserved",
-		Opcode:   6031,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdResultType,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdResult,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Intersection'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpRayQueryGetIntersectionWorldToObjectKHR = &Opcode {
-		Opname:   "OpRayQueryGetIntersectionWorldToObjectKHR",
-		Class:    "Reserved",
-		Opcode:   6032,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdResultType,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdResult,
-				Name:       "",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'RayQuery'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Intersection'",
-				Quantifier: "",
-			}, 
-		},
-	}
 	OpExecuteCallableNV = &Opcode {
 		Opname:   "OpExecuteCallableNV",
-		Class:    "Reserved",
-		Opcode:   5344,
-		Operands: []Operand {
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'SBT Index'",
-				Quantifier: "",
-			}, 
-			Operand {
-				Kind:       OperandKindIdRef,
-				Name:       "'Callable DataId'",
-				Quantifier: "",
-			}, 
-		},
-	}
-	OpExecuteCallableKHR = &Opcode {
-		Opname:   "OpExecuteCallableKHR",
 		Class:    "Reserved",
 		Opcode:   5344,
 		Operands: []Operand {
@@ -12256,6 +11874,210 @@ var (
 			Operand {
 				Kind:       OperandKindIdRef,
 				Name:       "'Operand 2'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpConstFunctionPointerINTEL = &Opcode {
+		Opname:   "OpConstFunctionPointerINTEL",
+		Class:    "@exclude",
+		Opcode:   5600,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Function'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpFunctionPointerCallINTEL = &Opcode {
+		Opname:   "OpFunctionPointerCallINTEL",
+		Class:    "@exclude",
+		Opcode:   5601,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Operand 1'",
+				Quantifier: "*",
+			}, 
+		},
+	}
+	OpAsmTargetINTEL = &Opcode {
+		Opname:   "OpAsmTargetINTEL",
+		Class:    "@exclude",
+		Opcode:   5609,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindLiteralString,
+				Name:       "'Asm target'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpAsmINTEL = &Opcode {
+		Opname:   "OpAsmINTEL",
+		Class:    "@exclude",
+		Opcode:   5610,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Asm type'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Target'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindLiteralString,
+				Name:       "'Asm instructions'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindLiteralString,
+				Name:       "'Constraints'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpAsmCallINTEL = &Opcode {
+		Opname:   "OpAsmCallINTEL",
+		Class:    "@exclude",
+		Opcode:   5611,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Asm'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Argument 0'",
+				Quantifier: "*",
+			}, 
+		},
+	}
+	OpAtomicFMinEXT = &Opcode {
+		Opname:   "OpAtomicFMinEXT",
+		Class:    "Atomic",
+		Opcode:   5614,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Pointer'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdScope,
+				Name:       "'Memory'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdMemorySemantics,
+				Name:       "'Semantics'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Value'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpAtomicFMaxEXT = &Opcode {
+		Opname:   "OpAtomicFMaxEXT",
+		Class:    "Atomic",
+		Opcode:   5615,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Pointer'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdScope,
+				Name:       "'Memory'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdMemorySemantics,
+				Name:       "'Semantics'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Value'",
 				Quantifier: "",
 			}, 
 		},
@@ -15436,6 +15258,713 @@ var (
 				Kind:       OperandKindIdRef,
 				Name:       "'Payload'",
 				Quantifier: "",
+			}, 
+		},
+	}
+	OpVariableLengthArrayINTEL = &Opcode {
+		Opname:   "OpVariableLengthArrayINTEL",
+		Class:    "@exclude",
+		Opcode:   5818,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Lenght'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpSaveMemoryINTEL = &Opcode {
+		Opname:   "OpSaveMemoryINTEL",
+		Class:    "@exclude",
+		Opcode:   5819,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRestoreMemoryINTEL = &Opcode {
+		Opname:   "OpRestoreMemoryINTEL",
+		Class:    "@exclude",
+		Opcode:   5820,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Ptr'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpLoopControlINTEL = &Opcode {
+		Opname:   "OpLoopControlINTEL",
+		Class:    "Reserved",
+		Opcode:   5887,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindLiteralInteger,
+				Name:       "'Loop Control Parameters'",
+				Quantifier: "*",
+			}, 
+		},
+	}
+	OpPtrCastToCrossWorkgroupINTEL = &Opcode {
+		Opname:   "OpPtrCastToCrossWorkgroupINTEL",
+		Class:    "@exclude",
+		Opcode:   5934,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Pointer'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpCrossWorkgroupCastToPtrINTEL = &Opcode {
+		Opname:   "OpCrossWorkgroupCastToPtrINTEL",
+		Class:    "@exclude",
+		Opcode:   5938,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Pointer'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpReadPipeBlockingINTEL = &Opcode {
+		Opname:   "OpReadPipeBlockingINTEL",
+		Class:    "Pipe",
+		Opcode:   5946,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Packet Size'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Packet Alignment'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpWritePipeBlockingINTEL = &Opcode {
+		Opname:   "OpWritePipeBlockingINTEL",
+		Class:    "Pipe",
+		Opcode:   5947,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Packet Size'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Packet Alignment'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpFPGARegINTEL = &Opcode {
+		Opname:   "OpFPGARegINTEL",
+		Class:    "Reserved",
+		Opcode:   5949,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Result'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Input'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryGetRayTMinKHR = &Opcode {
+		Opname:   "OpRayQueryGetRayTMinKHR",
+		Class:    "Reserved",
+		Opcode:   6016,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryGetRayFlagsKHR = &Opcode {
+		Opname:   "OpRayQueryGetRayFlagsKHR",
+		Class:    "Reserved",
+		Opcode:   6017,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryGetIntersectionTKHR = &Opcode {
+		Opname:   "OpRayQueryGetIntersectionTKHR",
+		Class:    "Reserved",
+		Opcode:   6018,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Intersection'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryGetIntersectionInstanceCustomIndexKHR = &Opcode {
+		Opname:   "OpRayQueryGetIntersectionInstanceCustomIndexKHR",
+		Class:    "Reserved",
+		Opcode:   6019,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Intersection'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryGetIntersectionInstanceIdKHR = &Opcode {
+		Opname:   "OpRayQueryGetIntersectionInstanceIdKHR",
+		Class:    "Reserved",
+		Opcode:   6020,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Intersection'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetKHR = &Opcode {
+		Opname:   "OpRayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetKHR",
+		Class:    "Reserved",
+		Opcode:   6021,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Intersection'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryGetIntersectionGeometryIndexKHR = &Opcode {
+		Opname:   "OpRayQueryGetIntersectionGeometryIndexKHR",
+		Class:    "Reserved",
+		Opcode:   6022,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Intersection'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryGetIntersectionPrimitiveIndexKHR = &Opcode {
+		Opname:   "OpRayQueryGetIntersectionPrimitiveIndexKHR",
+		Class:    "Reserved",
+		Opcode:   6023,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Intersection'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryGetIntersectionBarycentricsKHR = &Opcode {
+		Opname:   "OpRayQueryGetIntersectionBarycentricsKHR",
+		Class:    "Reserved",
+		Opcode:   6024,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Intersection'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryGetIntersectionFrontFaceKHR = &Opcode {
+		Opname:   "OpRayQueryGetIntersectionFrontFaceKHR",
+		Class:    "Reserved",
+		Opcode:   6025,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Intersection'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryGetIntersectionCandidateAABBOpaqueKHR = &Opcode {
+		Opname:   "OpRayQueryGetIntersectionCandidateAABBOpaqueKHR",
+		Class:    "Reserved",
+		Opcode:   6026,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryGetIntersectionObjectRayDirectionKHR = &Opcode {
+		Opname:   "OpRayQueryGetIntersectionObjectRayDirectionKHR",
+		Class:    "Reserved",
+		Opcode:   6027,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Intersection'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryGetIntersectionObjectRayOriginKHR = &Opcode {
+		Opname:   "OpRayQueryGetIntersectionObjectRayOriginKHR",
+		Class:    "Reserved",
+		Opcode:   6028,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Intersection'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryGetWorldRayDirectionKHR = &Opcode {
+		Opname:   "OpRayQueryGetWorldRayDirectionKHR",
+		Class:    "Reserved",
+		Opcode:   6029,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryGetWorldRayOriginKHR = &Opcode {
+		Opname:   "OpRayQueryGetWorldRayOriginKHR",
+		Class:    "Reserved",
+		Opcode:   6030,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryGetIntersectionObjectToWorldKHR = &Opcode {
+		Opname:   "OpRayQueryGetIntersectionObjectToWorldKHR",
+		Class:    "Reserved",
+		Opcode:   6031,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Intersection'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpRayQueryGetIntersectionWorldToObjectKHR = &Opcode {
+		Opname:   "OpRayQueryGetIntersectionWorldToObjectKHR",
+		Class:    "Reserved",
+		Opcode:   6032,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'RayQuery'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Intersection'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpAtomicFAddEXT = &Opcode {
+		Opname:   "OpAtomicFAddEXT",
+		Class:    "Atomic",
+		Opcode:   6035,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResultType,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Pointer'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdScope,
+				Name:       "'Memory'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdMemorySemantics,
+				Name:       "'Semantics'",
+				Quantifier: "",
+			}, 
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Value'",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpTypeBufferSurfaceINTEL = &Opcode {
+		Opname:   "OpTypeBufferSurfaceINTEL",
+		Class:    "Type-Declaration",
+		Opcode:   6086,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdResult,
+				Name:       "",
+				Quantifier: "",
+			}, 
+		},
+	}
+	OpTypeStructContinuedINTEL = &Opcode {
+		Opname:   "OpTypeStructContinuedINTEL",
+		Class:    "Type-Declaration",
+		Opcode:   6090,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Member 0 type', + 'member 1 type', + ...",
+				Quantifier: "*",
+			}, 
+		},
+	}
+	OpConstantCompositeContinuedINTEL = &Opcode {
+		Opname:   "OpConstantCompositeContinuedINTEL",
+		Class:    "Constant-Creation",
+		Opcode:   6091,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Constituents'",
+				Quantifier: "*",
+			}, 
+		},
+	}
+	OpSpecConstantCompositeContinuedINTEL = &Opcode {
+		Opname:   "OpSpecConstantCompositeContinuedINTEL",
+		Class:    "Constant-Creation",
+		Opcode:   6092,
+		Operands: []Operand {
+			Operand {
+				Kind:       OperandKindIdRef,
+				Name:       "'Constituents'",
+				Quantifier: "*",
 			}, 
 		},
 	}
@@ -19788,6 +20317,20 @@ var (
 				Parameters:   []Parameter{},
 				Version:      "",
 			},
+			Enumerant{
+				Enumerant:    "AllowContractFastINTEL",
+				Value:        0x10000,
+				Capabilities: []string{"FPFastMathModeINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "AllowReassocINTEL",
+				Value:        0x20000,
+				Capabilities: []string{"FPFastMathModeINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
 		},
 		Bases:      []*OperandKind {},
 	}
@@ -19892,6 +20435,62 @@ var (
 				Capabilities: []string{},
 				Parameters:   []Parameter{{OperandKindLiteralInteger, ""},},
 				Version:      "1.4",
+			},
+			Enumerant{
+				Enumerant:    "InitiationIntervalINTEL",
+				Value:        0x10000,
+				Capabilities: []string{"FPGALoopControlsINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, ""},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "MaxConcurrencyINTEL",
+				Value:        0x20000,
+				Capabilities: []string{"FPGALoopControlsINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, ""},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "DependencyArrayINTEL",
+				Value:        0x40000,
+				Capabilities: []string{"FPGALoopControlsINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, ""},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "PipelineEnableINTEL",
+				Value:        0x80000,
+				Capabilities: []string{"FPGALoopControlsINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, ""},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "LoopCoalesceINTEL",
+				Value:        0x100000,
+				Capabilities: []string{"FPGALoopControlsINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, ""},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "MaxInterleavingINTEL",
+				Value:        0x200000,
+				Capabilities: []string{"FPGALoopControlsINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, ""},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "SpeculatedIterationsINTEL",
+				Value:        0x400000,
+				Capabilities: []string{"FPGALoopControlsINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, ""},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "NoFusionINTEL",
+				Value:        0x800000,
+				Capabilities: []string{"FPGALoopControlsINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, ""},},
+				Version:      "None",
 			},
 		},
 		Bases:      []*OperandKind {},
@@ -20185,77 +20784,112 @@ var (
 				Value:        0x0000,
 				Capabilities: []string{"RayQueryKHR","RayTracingKHR",},
 				Parameters:   []Parameter{},
-				Version:      "",
+				Version:      "None",
 			},
 			Enumerant{
 				Enumerant:    "OpaqueKHR",
 				Value:        0x0001,
 				Capabilities: []string{"RayQueryKHR","RayTracingKHR",},
 				Parameters:   []Parameter{},
-				Version:      "",
+				Version:      "None",
 			},
 			Enumerant{
 				Enumerant:    "NoOpaqueKHR",
 				Value:        0x0002,
 				Capabilities: []string{"RayQueryKHR","RayTracingKHR",},
 				Parameters:   []Parameter{},
-				Version:      "",
+				Version:      "None",
 			},
 			Enumerant{
 				Enumerant:    "TerminateOnFirstHitKHR",
 				Value:        0x0004,
 				Capabilities: []string{"RayQueryKHR","RayTracingKHR",},
 				Parameters:   []Parameter{},
-				Version:      "",
+				Version:      "None",
 			},
 			Enumerant{
 				Enumerant:    "SkipClosestHitShaderKHR",
 				Value:        0x0008,
 				Capabilities: []string{"RayQueryKHR","RayTracingKHR",},
 				Parameters:   []Parameter{},
-				Version:      "",
+				Version:      "None",
 			},
 			Enumerant{
 				Enumerant:    "CullBackFacingTrianglesKHR",
 				Value:        0x0010,
 				Capabilities: []string{"RayQueryKHR","RayTracingKHR",},
 				Parameters:   []Parameter{},
-				Version:      "",
+				Version:      "None",
 			},
 			Enumerant{
 				Enumerant:    "CullFrontFacingTrianglesKHR",
 				Value:        0x0020,
 				Capabilities: []string{"RayQueryKHR","RayTracingKHR",},
 				Parameters:   []Parameter{},
-				Version:      "",
+				Version:      "None",
 			},
 			Enumerant{
 				Enumerant:    "CullOpaqueKHR",
 				Value:        0x0040,
 				Capabilities: []string{"RayQueryKHR","RayTracingKHR",},
 				Parameters:   []Parameter{},
-				Version:      "",
+				Version:      "None",
 			},
 			Enumerant{
 				Enumerant:    "CullNoOpaqueKHR",
 				Value:        0x0080,
 				Capabilities: []string{"RayQueryKHR","RayTracingKHR",},
 				Parameters:   []Parameter{},
-				Version:      "",
+				Version:      "None",
 			},
 			Enumerant{
 				Enumerant:    "SkipTrianglesKHR",
 				Value:        0x0100,
 				Capabilities: []string{"RayTraversalPrimitiveCullingKHR",},
 				Parameters:   []Parameter{},
-				Version:      "",
+				Version:      "None",
 			},
 			Enumerant{
 				Enumerant:    "SkipAABBsKHR",
 				Value:        0x0200,
 				Capabilities: []string{"RayTraversalPrimitiveCullingKHR",},
 				Parameters:   []Parameter{},
-				Version:      "",
+				Version:      "None",
+			},
+		},
+		Bases:      []*OperandKind {},
+	}
+	OperandKindFragmentShadingRate = &OperandKind {
+		Kind:       "FragmentShadingRate",
+		Category:   "BitEnum",
+		Enumerants: []Enumerant {
+			Enumerant{
+				Enumerant:    "Vertical2Pixels",
+				Value:        0x0001,
+				Capabilities: []string{"FragmentShadingRateKHR",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "Vertical4Pixels",
+				Value:        0x0002,
+				Capabilities: []string{"FragmentShadingRateKHR",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "Horizontal2Pixels",
+				Value:        0x0004,
+				Capabilities: []string{"FragmentShadingRateKHR",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "Horizontal4Pixels",
+				Value:        0x0008,
+				Capabilities: []string{"FragmentShadingRateKHR",},
+				Parameters:   []Parameter{},
+				Version:      "None",
 			},
 		},
 		Bases:      []*OperandKind {},
@@ -20943,6 +21577,76 @@ var (
 				Parameters:   []Parameter{},
 				Version:      "None",
 			},
+			Enumerant{
+				Enumerant:    "SharedLocalMemorySizeINTEL",
+				Value:        5618,
+				Capabilities: []string{"VectorComputeINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'Size'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "RoundingModeRTPINTEL",
+				Value:        5620,
+				Capabilities: []string{"RoundToInfinityINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'Target Width'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "RoundingModeRTNINTEL",
+				Value:        5621,
+				Capabilities: []string{"RoundToInfinityINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'Target Width'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "FloatingPointModeALTINTEL",
+				Value:        5622,
+				Capabilities: []string{"RoundToInfinityINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'Target Width'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "FloatingPointModeIEEEINTEL",
+				Value:        5623,
+				Capabilities: []string{"RoundToInfinityINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'Target Width'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "MaxWorkgroupSizeINTEL",
+				Value:        5893,
+				Capabilities: []string{"KernelAttributesINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'max_x_size'"},{OperandKindLiteralInteger, "'max_y_size'"},{OperandKindLiteralInteger, "'max_z_size'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "MaxWorkDimINTEL",
+				Value:        5894,
+				Capabilities: []string{"KernelAttributesINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'max_dimensions'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "NoGlobalOffsetINTEL",
+				Value:        5895,
+				Capabilities: []string{"KernelAttributesINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "NumSIMDWorkitemsINTEL",
+				Value:        5896,
+				Capabilities: []string{"FPGAKernelAttributesINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'vector_width'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "SchedulerTargetFmaxMhzINTEL",
+				Value:        5903,
+				Capabilities: []string{"FPGAKernelAttributesINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'target_fmax'"},},
+				Version:      "None",
+			},
 		},
 		Bases:      []*OperandKind {},
 	}
@@ -21138,6 +21842,27 @@ var (
 				Capabilities: []string{"PhysicalStorageBufferAddresses",},
 				Parameters:   []Parameter{},
 				Version:      "1.5",
+			},
+			Enumerant{
+				Enumerant:    "CodeSectionINTEL",
+				Value:        5605,
+				Capabilities: []string{"FunctionPointersINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "DeviceOnlyINTEL",
+				Value:        5936,
+				Capabilities: []string{"USMStorageClassesINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "HostOnlyINTEL",
+				Value:        5937,
+				Capabilities: []string{"USMStorageClassesINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
 			},
 		},
 		Bases:      []*OperandKind {},
@@ -21545,6 +22270,20 @@ var (
 				Parameters:   []Parameter{},
 				Version:      "",
 			},
+			Enumerant{
+				Enumerant:    "R64ui",
+				Value:        40,
+				Capabilities: []string{"Int64ImageEXT",},
+				Parameters:   []Parameter{},
+				Version:      "",
+			},
+			Enumerant{
+				Enumerant:    "R64i",
+				Value:        41,
+				Capabilities: []string{"Int64ImageEXT",},
+				Parameters:   []Parameter{},
+				Version:      "",
+			},
 		},
 		Bases:      []*OperandKind {},
 	}
@@ -21852,6 +22591,48 @@ var (
 				Capabilities: []string{},
 				Parameters:   []Parameter{},
 				Version:      "",
+			},
+		},
+		Bases:      []*OperandKind {},
+	}
+	OperandKindFPDenormMode = &OperandKind {
+		Kind:       "FPDenormMode",
+		Category:   "ValueEnum",
+		Enumerants: []Enumerant {
+			Enumerant{
+				Enumerant:    "Preserve",
+				Value:        0,
+				Capabilities: []string{"FunctionFloatControlINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "FlushToZero",
+				Value:        1,
+				Capabilities: []string{"FunctionFloatControlINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+		},
+		Bases:      []*OperandKind {},
+	}
+	OperandKindFPOperationMode = &OperandKind {
+		Kind:       "FPOperationMode",
+		Category:   "ValueEnum",
+		Enumerants: []Enumerant {
+			Enumerant{
+				Enumerant:    "IEEE",
+				Value:        0,
+				Capabilities: []string{"FunctionFloatControlINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "ALT",
+				Value:        1,
+				Capabilities: []string{"FunctionFloatControlINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
 			},
 		},
 		Bases:      []*OperandKind {},
@@ -22421,6 +23202,69 @@ var (
 				Version:      "1.5",
 			},
 			Enumerant{
+				Enumerant:    "SIMTCallINTEL",
+				Value:        5599,
+				Capabilities: []string{"VectorComputeINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'N'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "ReferencedIndirectlyINTEL",
+				Value:        5602,
+				Capabilities: []string{"IndirectReferencesINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "ClobberINTEL",
+				Value:        5607,
+				Capabilities: []string{"AsmINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralString, "'Register'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "SideEffectsINTEL",
+				Value:        5608,
+				Capabilities: []string{"AsmINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "VectorComputeVariableINTEL",
+				Value:        5624,
+				Capabilities: []string{"VectorComputeINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "FuncParamIOKindINTEL",
+				Value:        5625,
+				Capabilities: []string{"VectorComputeINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'Kind'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "VectorComputeFunctionINTEL",
+				Value:        5626,
+				Capabilities: []string{"VectorComputeINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "StackCallINTEL",
+				Value:        5627,
+				Capabilities: []string{"VectorComputeINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "GlobalVariableOffsetINTEL",
+				Value:        5628,
+				Capabilities: []string{"VectorComputeINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'Offset'"},},
+				Version:      "None",
+			},
+			Enumerant{
 				Enumerant:    "CounterBuffer",
 				Value:        5634,
 				Capabilities: []string{},
@@ -22453,6 +23297,181 @@ var (
 				Value:        5636,
 				Capabilities: []string{},
 				Parameters:   []Parameter{{OperandKindLiteralString, "'User Type'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "FunctionRoundingModeINTEL",
+				Value:        5822,
+				Capabilities: []string{"FunctionFloatControlINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'Target Width'"},{OperandKindFPRoundingMode, "'FP Rounding Mode'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "FunctionDenormModeINTEL",
+				Value:        5823,
+				Capabilities: []string{"FunctionFloatControlINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'Target Width'"},{OperandKindFPDenormMode, "'FP Denorm Mode'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "RegisterINTEL",
+				Value:        5825,
+				Capabilities: []string{"FPGAMemoryAttributesINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "MemoryINTEL",
+				Value:        5826,
+				Capabilities: []string{"FPGAMemoryAttributesINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralString, "'Memory Type'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "NumbanksINTEL",
+				Value:        5827,
+				Capabilities: []string{"FPGAMemoryAttributesINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'Banks'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "BankwidthINTEL",
+				Value:        5828,
+				Capabilities: []string{"FPGAMemoryAttributesINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'Bank Width'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "MaxPrivateCopiesINTEL",
+				Value:        5829,
+				Capabilities: []string{"FPGAMemoryAttributesINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'Maximum Copies'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "SinglepumpINTEL",
+				Value:        5830,
+				Capabilities: []string{"FPGAMemoryAttributesINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "DoublepumpINTEL",
+				Value:        5831,
+				Capabilities: []string{"FPGAMemoryAttributesINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "MaxReplicatesINTEL",
+				Value:        5832,
+				Capabilities: []string{"FPGAMemoryAttributesINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'Maximum Replicates'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "SimpleDualPortINTEL",
+				Value:        5833,
+				Capabilities: []string{"FPGAMemoryAttributesINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "MergeINTEL",
+				Value:        5834,
+				Capabilities: []string{"FPGAMemoryAttributesINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralString, "'Merge Key'"},{OperandKindLiteralString, "'Merge Type'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "BankBitsINTEL",
+				Value:        5835,
+				Capabilities: []string{"FPGAMemoryAttributesINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'Bank Bits'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "ForcePow2DepthINTEL",
+				Value:        5836,
+				Capabilities: []string{"FPGAMemoryAttributesINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'Force Key'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "BurstCoalesceINTEL",
+				Value:        5899,
+				Capabilities: []string{"FPGAMemoryAccessesINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "CacheSizeINTEL",
+				Value:        5900,
+				Capabilities: []string{"FPGAMemoryAccessesINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'Cache Size in bytes'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "DontStaticallyCoalesceINTEL",
+				Value:        5901,
+				Capabilities: []string{"FPGAMemoryAccessesINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "PrefetchINTEL",
+				Value:        5902,
+				Capabilities: []string{"FPGAMemoryAccessesINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'Prefetcher Size in bytes'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "StallEnableINTEL",
+				Value:        5905,
+				Capabilities: []string{"FPGAClusterAttributesINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "FuseLoopsInFunctionINTEL",
+				Value:        5907,
+				Capabilities: []string{"LoopFuseINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "BufferLocationINTEL",
+				Value:        5921,
+				Capabilities: []string{"FPGABufferLocationINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'Buffer Location ID'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "IOPipeStorageINTEL",
+				Value:        5944,
+				Capabilities: []string{"IOPipesINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'IO Pipe ID'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "FunctionFloatingPointModeINTEL",
+				Value:        6080,
+				Capabilities: []string{"FunctionFloatControlINTEL",},
+				Parameters:   []Parameter{{OperandKindLiteralInteger, "'Target Width'"},{OperandKindFPOperationMode, "'FP Operation Mode'"},},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "SingleElementVectorINTEL",
+				Value:        6085,
+				Capabilities: []string{"VectorComputeINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "VectorComputeCallableFunctionINTEL",
+				Value:        6087,
+				Capabilities: []string{"VectorComputeINTEL",},
+				Parameters:   []Parameter{},
 				Version:      "None",
 			},
 		},
@@ -22507,7 +23526,7 @@ var (
 			Enumerant{
 				Enumerant:    "PrimitiveId",
 				Value:        7,
-				Capabilities: []string{"Geometry","Tessellation","RayTracingNV","RayTracingKHR",},
+				Capabilities: []string{"Geometry","Tessellation","RayTracingNV","RayTracingKHR","MeshShadingNV",},
 				Parameters:   []Parameter{},
 				Version:      "",
 			},
@@ -22521,14 +23540,14 @@ var (
 			Enumerant{
 				Enumerant:    "Layer",
 				Value:        9,
-				Capabilities: []string{"Geometry","ShaderLayer","ShaderViewportIndexLayerEXT",},
+				Capabilities: []string{"Geometry","ShaderLayer","ShaderViewportIndexLayerEXT","MeshShadingNV",},
 				Parameters:   []Parameter{},
 				Version:      "",
 			},
 			Enumerant{
 				Enumerant:    "ViewportIndex",
 				Value:        10,
-				Capabilities: []string{"MultiViewport","ShaderViewportIndex","ShaderViewportIndexLayerEXT",},
+				Capabilities: []string{"MultiViewport","ShaderViewportIndex","ShaderViewportIndexLayerEXT","MeshShadingNV",},
 				Parameters:   []Parameter{},
 				Version:      "",
 			},
@@ -22757,7 +23776,21 @@ var (
 				Version:      "1.3",
 			},
 			Enumerant{
+				Enumerant:    "SubgroupEqMaskKHR",
+				Value:        4416,
+				Capabilities: []string{"SubgroupBallotKHR","GroupNonUniformBallot",},
+				Parameters:   []Parameter{},
+				Version:      "1.3",
+			},
+			Enumerant{
 				Enumerant:    "SubgroupGeMask",
+				Value:        4417,
+				Capabilities: []string{"SubgroupBallotKHR","GroupNonUniformBallot",},
+				Parameters:   []Parameter{},
+				Version:      "1.3",
+			},
+			Enumerant{
+				Enumerant:    "SubgroupGeMaskKHR",
 				Value:        4417,
 				Capabilities: []string{"SubgroupBallotKHR","GroupNonUniformBallot",},
 				Parameters:   []Parameter{},
@@ -22771,7 +23804,21 @@ var (
 				Version:      "1.3",
 			},
 			Enumerant{
+				Enumerant:    "SubgroupGtMaskKHR",
+				Value:        4418,
+				Capabilities: []string{"SubgroupBallotKHR","GroupNonUniformBallot",},
+				Parameters:   []Parameter{},
+				Version:      "1.3",
+			},
+			Enumerant{
 				Enumerant:    "SubgroupLeMask",
+				Value:        4419,
+				Capabilities: []string{"SubgroupBallotKHR","GroupNonUniformBallot",},
+				Parameters:   []Parameter{},
+				Version:      "1.3",
+			},
+			Enumerant{
+				Enumerant:    "SubgroupLeMaskKHR",
 				Value:        4419,
 				Capabilities: []string{"SubgroupBallotKHR","GroupNonUniformBallot",},
 				Parameters:   []Parameter{},
@@ -22780,34 +23827,6 @@ var (
 			Enumerant{
 				Enumerant:    "SubgroupLtMask",
 				Value:        4420,
-				Capabilities: []string{"SubgroupBallotKHR","GroupNonUniformBallot",},
-				Parameters:   []Parameter{},
-				Version:      "1.3",
-			},
-			Enumerant{
-				Enumerant:    "SubgroupEqMaskKHR",
-				Value:        4416,
-				Capabilities: []string{"SubgroupBallotKHR","GroupNonUniformBallot",},
-				Parameters:   []Parameter{},
-				Version:      "1.3",
-			},
-			Enumerant{
-				Enumerant:    "SubgroupGeMaskKHR",
-				Value:        4417,
-				Capabilities: []string{"SubgroupBallotKHR","GroupNonUniformBallot",},
-				Parameters:   []Parameter{},
-				Version:      "1.3",
-			},
-			Enumerant{
-				Enumerant:    "SubgroupGtMaskKHR",
-				Value:        4418,
-				Capabilities: []string{"SubgroupBallotKHR","GroupNonUniformBallot",},
-				Parameters:   []Parameter{},
-				Version:      "1.3",
-			},
-			Enumerant{
-				Enumerant:    "SubgroupLeMaskKHR",
-				Value:        4419,
 				Capabilities: []string{"SubgroupBallotKHR","GroupNonUniformBallot",},
 				Parameters:   []Parameter{},
 				Version:      "1.3",
@@ -22841,6 +23860,13 @@ var (
 				Version:      "1.3",
 			},
 			Enumerant{
+				Enumerant:    "PrimitiveShadingRateKHR",
+				Value:        4432,
+				Capabilities: []string{"FragmentShadingRateKHR",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
 				Enumerant:    "DeviceIndex",
 				Value:        4438,
 				Capabilities: []string{"DeviceGroup",},
@@ -22853,6 +23879,13 @@ var (
 				Capabilities: []string{"MultiView",},
 				Parameters:   []Parameter{},
 				Version:      "1.3",
+			},
+			Enumerant{
+				Enumerant:    "ShadingRateKHR",
+				Value:        4444,
+				Capabilities: []string{"FragmentShadingRateKHR",},
+				Parameters:   []Parameter{},
+				Version:      "None",
 			},
 			Enumerant{
 				Enumerant:    "BaryCoordNoPerspAMD",
@@ -23207,14 +24240,7 @@ var (
 			Enumerant{
 				Enumerant:    "HitTNV",
 				Value:        5332,
-				Capabilities: []string{"RayTracingNV","RayTracingKHR",},
-				Parameters:   []Parameter{},
-				Version:      "None",
-			},
-			Enumerant{
-				Enumerant:    "HitTKHR",
-				Value:        5332,
-				Capabilities: []string{"RayTracingNV","RayTracingKHR",},
+				Capabilities: []string{"RayTracingNV",},
 				Parameters:   []Parameter{},
 				Version:      "None",
 			},
@@ -23342,7 +24368,7 @@ var (
 				Value:        6,
 				Capabilities: []string{"RayTracingKHR",},
 				Parameters:   []Parameter{},
-				Version:      "",
+				Version:      "None",
 			},
 		},
 		Bases:      []*OperandKind {},
@@ -23919,6 +24945,13 @@ var (
 				Version:      "1.5",
 			},
 			Enumerant{
+				Enumerant:    "FragmentShadingRateKHR",
+				Value:        4422,
+				Capabilities: []string{"Shader",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
 				Enumerant:    "SubgroupBallotKHR",
 				Value:        4423,
 				Capabilities: []string{},
@@ -23931,6 +24964,27 @@ var (
 				Capabilities: []string{"Shader",},
 				Parameters:   []Parameter{},
 				Version:      "1.3",
+			},
+			Enumerant{
+				Enumerant:    "WorkgroupMemoryExplicitLayoutKHR",
+				Value:        4428,
+				Capabilities: []string{"Shader",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "WorkgroupMemoryExplicitLayout8BitAccessKHR",
+				Value:        4429,
+				Capabilities: []string{"WorkgroupMemoryExplicitLayoutKHR",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "WorkgroupMemoryExplicitLayout16BitAccessKHR",
+				Value:        4430,
+				Capabilities: []string{"Shader",},
+				Parameters:   []Parameter{},
+				Version:      "None",
 			},
 			Enumerant{
 				Enumerant:    "SubgroupVoteKHR",
@@ -24080,8 +25134,15 @@ var (
 				Version:      "1.4",
 			},
 			Enumerant{
-				Enumerant:    "RayQueryKHR",
+				Enumerant:    "RayQueryProvisionalKHR",
 				Value:        4471,
+				Capabilities: []string{"Shader",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "RayQueryKHR",
+				Value:        4472,
 				Capabilities: []string{"Shader",},
 				Parameters:   []Parameter{},
 				Version:      "None",
@@ -24090,6 +25151,13 @@ var (
 				Enumerant:    "RayTraversalPrimitiveCullingKHR",
 				Value:        4478,
 				Capabilities: []string{"RayQueryKHR","RayTracingKHR",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "RayTracingKHR",
+				Value:        4479,
+				Capabilities: []string{"Shader",},
 				Parameters:   []Parameter{},
 				Version:      "None",
 			},
@@ -24124,6 +25192,13 @@ var (
 			Enumerant{
 				Enumerant:    "ImageReadWriteLodAMD",
 				Value:        5015,
+				Capabilities: []string{"Shader",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "Int64ImageEXT",
+				Value:        5016,
 				Capabilities: []string{"Shader",},
 				Parameters:   []Parameter{},
 				Version:      "None",
@@ -24465,7 +25540,7 @@ var (
 				Version:      "None",
 			},
 			Enumerant{
-				Enumerant:    "RayTracingKHR",
+				Enumerant:    "RayTracingProvisionalKHR",
 				Value:        5353,
 				Capabilities: []string{"Shader",},
 				Parameters:   []Parameter{},
@@ -24542,9 +25617,79 @@ var (
 				Version:      "None",
 			},
 			Enumerant{
+				Enumerant:    "RoundToInfinityINTEL",
+				Value:        5582,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "FloatingPointModeINTEL",
+				Value:        5583,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
 				Enumerant:    "IntegerFunctions2INTEL",
 				Value:        5584,
 				Capabilities: []string{"Shader",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "FunctionPointersINTEL",
+				Value:        5603,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "IndirectReferencesINTEL",
+				Value:        5604,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "AsmINTEL",
+				Value:        5606,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "AtomicFloat32MinMaxEXT",
+				Value:        5612,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "AtomicFloat64MinMaxEXT",
+				Value:        5613,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "AtomicFloat16MinMaxEXT",
+				Value:        5616,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "VectorComputeINTEL",
+				Value:        5617,
+				Capabilities: []string{"VectorAnyINTEL",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "VectorAnyINTEL",
+				Value:        5619,
+				Capabilities: []string{},
 				Parameters:   []Parameter{},
 				Version:      "None",
 			},
@@ -24569,6 +25714,146 @@ var (
 				Parameters:   []Parameter{},
 				Version:      "None",
 			},
+			Enumerant{
+				Enumerant:    "VariableLengthArrayINTEL",
+				Value:        5817,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "FunctionFloatControlINTEL",
+				Value:        5821,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "FPGAMemoryAttributesINTEL",
+				Value:        5824,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "FPFastMathModeINTEL",
+				Value:        5837,
+				Capabilities: []string{"Kernel",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "ArbitraryPrecisionIntegersINTEL",
+				Value:        5844,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "UnstructuredLoopControlsINTEL",
+				Value:        5886,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "FPGALoopControlsINTEL",
+				Value:        5888,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "KernelAttributesINTEL",
+				Value:        5892,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "FPGAKernelAttributesINTEL",
+				Value:        5897,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "FPGAMemoryAccessesINTEL",
+				Value:        5898,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "FPGAClusterAttributesINTEL",
+				Value:        5904,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "LoopFuseINTEL",
+				Value:        5906,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "FPGABufferLocationINTEL",
+				Value:        5920,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "USMStorageClassesINTEL",
+				Value:        5935,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "IOPipesINTEL",
+				Value:        5943,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "BlockingPipesINTEL",
+				Value:        5945,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "FPGARegINTEL",
+				Value:        5948,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "AtomicFloat32AddEXT",
+				Value:        6033,
+				Capabilities: []string{"Shader",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "AtomicFloat64AddEXT",
+				Value:        6034,
+				Capabilities: []string{"Shader",},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
+			Enumerant{
+				Enumerant:    "LongConstantCompositeINTEL",
+				Value:        6089,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "None",
+			},
 		},
 		Bases:      []*OperandKind {},
 	}
@@ -24581,14 +25866,14 @@ var (
 				Value:        0,
 				Capabilities: []string{"RayQueryKHR",},
 				Parameters:   []Parameter{},
-				Version:      "",
+				Version:      "None",
 			},
 			Enumerant{
 				Enumerant:    "RayQueryCommittedIntersectionKHR",
 				Value:        1,
 				Capabilities: []string{"RayQueryKHR",},
 				Parameters:   []Parameter{},
-				Version:      "",
+				Version:      "None",
 			},
 		},
 		Bases:      []*OperandKind {},
@@ -24602,21 +25887,21 @@ var (
 				Value:        0,
 				Capabilities: []string{"RayQueryKHR",},
 				Parameters:   []Parameter{},
-				Version:      "",
+				Version:      "None",
 			},
 			Enumerant{
 				Enumerant:    "RayQueryCommittedIntersectionTriangleKHR",
 				Value:        1,
 				Capabilities: []string{"RayQueryKHR",},
 				Parameters:   []Parameter{},
-				Version:      "",
+				Version:      "None",
 			},
 			Enumerant{
 				Enumerant:    "RayQueryCommittedIntersectionGeneratedKHR",
 				Value:        2,
 				Capabilities: []string{"RayQueryKHR",},
 				Parameters:   []Parameter{},
-				Version:      "",
+				Version:      "None",
 			},
 		},
 		Bases:      []*OperandKind {},
@@ -24630,14 +25915,14 @@ var (
 				Value:        0,
 				Capabilities: []string{"RayQueryKHR",},
 				Parameters:   []Parameter{},
-				Version:      "",
+				Version:      "None",
 			},
 			Enumerant{
 				Enumerant:    "RayQueryCandidateIntersectionAABBKHR",
 				Value:        1,
 				Capabilities: []string{"RayQueryKHR",},
 				Parameters:   []Parameter{},
-				Version:      "",
+				Version:      "None",
 			},
 		},
 		Bases:      []*OperandKind {},
@@ -24737,6 +26022,13 @@ var (
 		Kind:       "DebugInfoFlags",
 		Category:   "BitEnum",
 		Enumerants: []Enumerant {
+			Enumerant{
+				Enumerant:    "None",
+				Value:        0x0000,
+				Capabilities: []string{},
+				Parameters:   []Parameter{},
+				Version:      "",
+			},
 			Enumerant{
 				Enumerant:    "FlagIsProtected",
 				Value:        0x01,

--- a/utils/vscode/src/tools/gen-grammar.go
+++ b/utils/vscode/src/tools/gen-grammar.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"../grammar"
+	"github.com/KhronosGroup/SPIRV-Tools/utils/vscode/src/grammar"
 )
 
 type grammarDefinition struct {
@@ -54,7 +54,7 @@ var (
 			url:  "https://raw.githubusercontent.com/KhronosGroup/SPIRV-Headers/master/include/spirv/unified1/extinst.opencl.std.100.grammar.json",
 		}, {
 			name: "OpenCL.DebugInfo.100",
-			url:  "https://raw.githubusercontent.com/KhronosGroup/SPIRV-Tools/master/source/extinst.opencl.debuginfo.100.grammar.json",
+			url:  "https://raw.githubusercontent.com/KhronosGroup/SPIRV-Headers/master/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json",
 		},
 	}
 
@@ -106,7 +106,7 @@ func run() error {
 	for _, ext := range extensionGrammars {
 		root, err := parseGrammar(ext)
 		if err != nil {
-			return errors.Wrap(err, "Failed to parse extension grammar file")
+			return errors.Wrap(err, "Failed to parse extension grammar file: "+ext.name)
 		}
 		args.Extensions = append(args.Extensions, extension{Root: root, Name: ext.name})
 		args.All.Instructions = append(args.All.Instructions, root.Instructions...)


### PR DESCRIPTION
Fix URL to the OpenCL.DebugInfo.100 grammar file, which moved from SPIRV-Tools to SPIRV-Headers.

Add a `go.mod` and `go.sum` file.
Go has now fully migrated to using modules, and relative imports no longer work.
Fixup all the relative imports to use a fully qualified path based on the module name.

Fix the `.exe` executable extension on windows.

Update the generated grammar files.

Update the README.md with more information.