### PR TITLE
fix strncpy bound error

### DIFF
--- a/source/diagnostic.cpp
+++ b/source/diagnostic.cpp
@@ -37,7 +37,7 @@ spv_diagnostic spvDiagnosticCreate(const spv_position position,
   diagnostic->position = *position;
   diagnostic->isTextSource = false;
   memset(diagnostic->error, 0, length);
-  strncpy(diagnostic->error, message, length);
+  memcpy(diagnostic->error, message, length);
   return diagnostic;
 }
 


### PR DESCRIPTION
This patch fixes the following error while using gcc 11
error: 'char* __builtin_strncpy(char*, const char*, long unsigned int)' specified bound depends on the length of the source argument [-Werror=stringop-overflow=]

Signed-off-by: Khem Raj <raj.khem@gmail.com>