### PR TITLE
build: Fix Android CMake build

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -402,6 +402,12 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
   endif()
 endif()
 
+if (ANDROID)
+    foreach(target ${SPIRV_TOOLS_TARGETS})
+        target_link_libraries(${target} PRIVATE android log)
+    endforeach()
+endif()
+
 if(ENABLE_SPIRV_TOOLS_INSTALL)
   install(TARGETS ${SPIRV_TOOLS_TARGETS} EXPORT ${SPIRV_TOOLS}Targets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
Fixes the following linker errors when building Android binaries using cmake (e.g., using `android.toolchain.cmake`) rather than  ndk-build/Android.mk/etc.:
```
ld: error: undefined symbol: AHardwareBuffer_describe
...
ld: error: undefined symbol: __android_log_print
```