### PR TITLE
spirv-val: Vulkan 64-bit OpAtomicStore check

### DIFF
--- a/source/val/validate_atomics.cpp
+++ b/source/val/validate_atomics.cpp
@@ -225,6 +225,16 @@ spv_result_t AtomicsPass(ValidationState_t& _, const Instruction* inst) {
                       "be: Uniform, Workgroup, Image, StorageBuffer, or "
                       "PhysicalStorageBuffer.";
           }
+
+          // Can't use result_type because OpAtomicStore doesn't have a result
+          if (opcode == SpvOpAtomicStore && _.GetBitWidth(data_type) == 64 &&
+              _.IsIntScalarType(data_type) &&
+              !_.HasCapability(SpvCapabilityInt64Atomics)) {
+            return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                   << spvOpcodeString(opcode)
+                   << ": 64-bit atomics require the Int64Atomics "
+                      "capability";
+          }
         } else if (storage_class == SpvStorageClassFunction) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << spvOpcodeString(opcode)

--- a/test/val/val_atomics_test.cpp
+++ b/test/val/val_atomics_test.cpp
@@ -537,6 +537,19 @@ TEST_F(ValidateAtomics, AtomicLoadVulkanInt64) {
           "AtomicLoad: 64-bit atomics require the Int64Atomics capability"));
 }
 
+TEST_F(ValidateAtomics, AtomicStoreVulkanInt64) {
+  const std::string body = R"(
+OpAtomicStore %u64_var %device %relaxed %u64_1
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body), SPV_ENV_VULKAN_1_0);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(
+          "AtomicStore: 64-bit atomics require the Int64Atomics capability"));
+}
+
 TEST_F(ValidateAtomics, VK_KHR_shader_atomic_int64Success) {
   const std::string body = R"(
 %val1 = OpAtomicUMin %u64 %u64_var %device %relaxed %u64_1


### PR DESCRIPTION
While adding Vulkan Validation support for runtime checking of 64-bit atomics, I realized that spirv-val was using the result type to check width, which doesn't work because of `OpAtomicStore` lack of result