### PR TITLE
spirv-fuzz: Avoid unnecessary dependency

### DIFF
--- a/source/fuzz/force_render_red.cpp
+++ b/source/fuzz/force_render_red.cpp
@@ -19,12 +19,10 @@
 #include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
 #include "source/fuzz/transformation_context.h"
 #include "source/fuzz/transformation_replace_constant_with_uniform.h"
-#include "source/fuzz/uniform_buffer_element_descriptor.h"
 #include "source/opt/build_module.h"
 #include "source/opt/ir_context.h"
 #include "source/opt/types.h"
 #include "source/util/make_unique.h"
-#include "tools/util/cli_consumer.h"
 
 namespace spvtools {
 namespace fuzz {
@@ -160,8 +158,8 @@ bool ForceRenderRed(
     const spv_target_env& target_env, spv_validator_options validator_options,
     const std::vector<uint32_t>& binary_in,
     const spvtools::fuzz::protobufs::FactSequence& initial_facts,
+    const MessageConsumer& message_consumer,
     std::vector<uint32_t>* binary_out) {
-  auto message_consumer = spvtools::utils::CLIMessageConsumer;
   spvtools::SpirvTools tools(target_env);
   if (!tools.IsValid()) {
     message_consumer(SPV_MSG_ERROR, nullptr, {},

--- a/source/fuzz/force_render_red.h
+++ b/source/fuzz/force_render_red.h
@@ -41,7 +41,7 @@ bool ForceRenderRed(
     const spv_target_env& target_env, spv_validator_options validator_options,
     const std::vector<uint32_t>& binary_in,
     const spvtools::fuzz::protobufs::FactSequence& initial_facts,
-    std::vector<uint32_t>* binary_out);
+    const MessageConsumer& message_consumer, std::vector<uint32_t>* binary_out);
 
 }  // namespace fuzz
 }  // namespace spvtools

--- a/tools/fuzz/fuzz.cpp
+++ b/tools/fuzz/fuzz.cpp
@@ -721,9 +721,9 @@ int main(int argc, const char** argv) {
 
   switch (status.action) {
     case FuzzActions::FORCE_RENDER_RED:
-      if (!spvtools::fuzz::ForceRenderRed(target_env, validator_options,
-                                          binary_in, initial_facts,
-                                          &binary_out)) {
+      if (!spvtools::fuzz::ForceRenderRed(
+              target_env, validator_options, binary_in, initial_facts,
+              spvtools::utils::CLIMessageConsumer, &binary_out)) {
         return 1;
       }
       break;


### PR DESCRIPTION
The fuzzer library depended on CLIMessageConsumer, due to its explicit
use in a function. This change removes that dependency so that,
instead, a message consumer parameter is passed.