### PR TITLE
BUILD.gn: fix typo for 'cflags'

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -334,7 +334,7 @@ config("spvtools_internal_config") {
     ]
   } else if (!is_win) {
     # Work around a false-positive on a Skia GCC 10 builder.
-    cflgas += [ "-Wno-format-truncation" ]
+    cflags += [ "-Wno-format-truncation" ]
   }
 }
 


### PR DESCRIPTION
@ben-clayton PTAL this trivial fix (and also, whooops)