### PR TITLE
spirv-val: Add Vulkan Invocation Sematics check

### DIFF
--- a/source/val/validate_atomics.cpp
+++ b/source/val/validate_atomics.cpp
@@ -293,14 +293,15 @@ spv_result_t AtomicsPass(ValidationState_t& _, const Instruction* inst) {
       }
 
       const auto equal_semantics_index = operand_index++;
-      if (auto error = ValidateMemorySemantics(_, inst, equal_semantics_index))
+      if (auto error = ValidateMemorySemantics(_, inst, equal_semantics_index,
+                                               memory_scope))
         return error;
 
       if (opcode == SpvOpAtomicCompareExchange ||
           opcode == SpvOpAtomicCompareExchangeWeak) {
         const auto unequal_semantics_index = operand_index++;
-        if (auto error =
-                ValidateMemorySemantics(_, inst, unequal_semantics_index))
+        if (auto error = ValidateMemorySemantics(
+                _, inst, unequal_semantics_index, memory_scope))
           return error;
 
         // Volatile bits must match for equal and unequal semantics. Previous

--- a/source/val/validate_barriers.cpp
+++ b/source/val/validate_barriers.cpp
@@ -69,7 +69,7 @@ spv_result_t BarriersPass(ValidationState_t& _, const Instruction* inst) {
         return error;
       }
 
-      if (auto error = ValidateMemorySemantics(_, inst, 2)) {
+      if (auto error = ValidateMemorySemantics(_, inst, 2, memory_scope)) {
         return error;
       }
       break;
@@ -82,7 +82,7 @@ spv_result_t BarriersPass(ValidationState_t& _, const Instruction* inst) {
         return error;
       }
 
-      if (auto error = ValidateMemorySemantics(_, inst, 1)) {
+      if (auto error = ValidateMemorySemantics(_, inst, 1, memory_scope)) {
         return error;
       }
       break;
@@ -119,7 +119,7 @@ spv_result_t BarriersPass(ValidationState_t& _, const Instruction* inst) {
         return error;
       }
 
-      if (auto error = ValidateMemorySemantics(_, inst, 2)) {
+      if (auto error = ValidateMemorySemantics(_, inst, 2, memory_scope)) {
         return error;
       }
       break;

--- a/source/val/validate_memory_semantics.h
+++ b/source/val/validate_memory_semantics.h
@@ -22,7 +22,8 @@ namespace val {
 
 spv_result_t ValidateMemorySemantics(ValidationState_t& _,
                                      const Instruction* inst,
-                                     uint32_t operand_index);
+                                     uint32_t operand_index,
+                                     uint32_t memory_scope);
 
 }  // namespace val
 }  // namespace spvtools

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -1684,6 +1684,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-None-04639);
     case 4640:
       return VUID_WRAP(VUID-StandaloneSpirv-None-04640);
+    case 4641:
+      return VUID_WRAP(VUID-StandaloneSpirv-None-04641);
     case 4642:
       return VUID_WRAP(VUID-StandaloneSpirv-None-04642);
     case 4651:

--- a/test/val/val_barriers_test.cpp
+++ b/test/val/val_barriers_test.cpp
@@ -411,6 +411,30 @@ OpControlBarrier %workgroup %workgroup %acquire
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_1));
 }
 
+TEST_F(ValidateBarriers, OpControlBarrierVulkanInvocationSuccess) {
+  const std::string body = R"(
+OpControlBarrier %workgroup %invocation %none
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body), SPV_ENV_VULKAN_1_0);
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+}
+
+TEST_F(ValidateBarriers, OpControlBarrierVulkanInvocationFailure) {
+  const std::string body = R"(
+OpControlBarrier %workgroup %invocation %acquire
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body), SPV_ENV_VULKAN_1_0);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-None-04641"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("ControlBarrier: Vulkan specification requires Memory "
+                "Semantics to be None if used with Invocation Memory Scope"));
+}
+
 TEST_F(ValidateBarriers, OpControlBarrierAcquireAndRelease) {
   const std::string body = R"(
 OpControlBarrier %device %device %acquire_and_release_uniform


### PR DESCRIPTION
Adds validation for `VUID-StandaloneSpirv-None-04641`

>  If the Scope for memory is Invocation, then memory semantics must be None

