### PR TITLE
spirv-fuzz: Make PermutePhiOperands more efficient

### DIFF
--- a/source/fuzz/transformation_permute_phi_operands.cpp
+++ b/source/fuzz/transformation_permute_phi_operands.cpp
@@ -80,9 +80,9 @@ void TransformationPermutePhiOperands::Apply(
 
   inst->SetInOperands(std::move(permuted_operands));
 
-  // Make sure our changes are analyzed
-  ir_context->InvalidateAnalysesExceptFor(
-      opt::IRContext::Analysis::kAnalysisNone);
+  // Update the def-use manager.
+  ir_context->get_def_use_mgr()->ClearInst(inst);
+  ir_context->get_def_use_mgr()->AnalyzeInstDefUse(inst);
 }
 
 protobufs::Transformation TransformationPermutePhiOperands::ToMessage() const {


### PR DESCRIPTION
Amends def-use information rather than invalidating all analyses in
TransformationPermutePhiOperands.