### PR TITLE
spirv-fuzz: Call by value and move in transformations

### DIFF
--- a/source/fuzz/transformation_access_chain.cpp
+++ b/source/fuzz/transformation_access_chain.cpp
@@ -23,8 +23,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationAccessChain::TransformationAccessChain(
-    const spvtools::fuzz::protobufs::TransformationAccessChain& message)
-    : message_(message) {}
+    protobufs::TransformationAccessChain message)
+    : message_(std::move(message)) {}
 
 TransformationAccessChain::TransformationAccessChain(
     uint32_t fresh_id, uint32_t pointer_id,

--- a/source/fuzz/transformation_access_chain.h
+++ b/source/fuzz/transformation_access_chain.h
@@ -28,7 +28,7 @@ namespace fuzz {
 class TransformationAccessChain : public Transformation {
  public:
   explicit TransformationAccessChain(
-      const protobufs::TransformationAccessChain& message);
+      protobufs::TransformationAccessChain message);
 
   TransformationAccessChain(
       uint32_t fresh_id, uint32_t pointer_id,

--- a/source/fuzz/transformation_add_bit_instruction_synonym.cpp
+++ b/source/fuzz/transformation_add_bit_instruction_synonym.cpp
@@ -21,9 +21,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationAddBitInstructionSynonym::TransformationAddBitInstructionSynonym(
-    const spvtools::fuzz::protobufs::TransformationAddBitInstructionSynonym&
-        message)
-    : message_(message) {}
+    protobufs::TransformationAddBitInstructionSynonym message)
+    : message_(std::move(message)) {}
 
 TransformationAddBitInstructionSynonym::TransformationAddBitInstructionSynonym(
     const uint32_t instruction_result_id,

--- a/source/fuzz/transformation_add_bit_instruction_synonym.h
+++ b/source/fuzz/transformation_add_bit_instruction_synonym.h
@@ -103,7 +103,7 @@ namespace fuzz {
 class TransformationAddBitInstructionSynonym : public Transformation {
  public:
   explicit TransformationAddBitInstructionSynonym(
-      const protobufs::TransformationAddBitInstructionSynonym& message);
+      protobufs::TransformationAddBitInstructionSynonym message);
 
   TransformationAddBitInstructionSynonym(
       const uint32_t instruction_result_id,

--- a/source/fuzz/transformation_add_copy_memory.cpp
+++ b/source/fuzz/transformation_add_copy_memory.cpp
@@ -22,8 +22,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationAddCopyMemory::TransformationAddCopyMemory(
-    const protobufs::TransformationAddCopyMemory& message)
-    : message_(message) {}
+    protobufs::TransformationAddCopyMemory message)
+    : message_(std::move(message)) {}
 
 TransformationAddCopyMemory::TransformationAddCopyMemory(
     const protobufs::InstructionDescriptor& instruction_descriptor,

--- a/source/fuzz/transformation_add_copy_memory.h
+++ b/source/fuzz/transformation_add_copy_memory.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationAddCopyMemory : public Transformation {
  public:
   explicit TransformationAddCopyMemory(
-      const protobufs::TransformationAddCopyMemory& message);
+      protobufs::TransformationAddCopyMemory message);
 
   TransformationAddCopyMemory(
       const protobufs::InstructionDescriptor& instruction_descriptor,

--- a/source/fuzz/transformation_add_dead_block.cpp
+++ b/source/fuzz/transformation_add_dead_block.cpp
@@ -20,8 +20,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationAddDeadBlock::TransformationAddDeadBlock(
-    const spvtools::fuzz::protobufs::TransformationAddDeadBlock& message)
-    : message_(message) {}
+    protobufs::TransformationAddDeadBlock message)
+    : message_(std::move(message)) {}
 
 TransformationAddDeadBlock::TransformationAddDeadBlock(uint32_t fresh_id,
                                                        uint32_t existing_block,

--- a/source/fuzz/transformation_add_dead_block.h
+++ b/source/fuzz/transformation_add_dead_block.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationAddDeadBlock : public Transformation {
  public:
   explicit TransformationAddDeadBlock(
-      const protobufs::TransformationAddDeadBlock& message);
+      protobufs::TransformationAddDeadBlock message);
 
   TransformationAddDeadBlock(uint32_t fresh_id, uint32_t existing_block,
                              bool condition_value);

--- a/source/fuzz/transformation_add_dead_break.cpp
+++ b/source/fuzz/transformation_add_dead_break.cpp
@@ -24,8 +24,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationAddDeadBreak::TransformationAddDeadBreak(
-    const spvtools::fuzz::protobufs::TransformationAddDeadBreak& message)
-    : message_(message) {}
+    protobufs::TransformationAddDeadBreak message)
+    : message_(std::move(message)) {}
 
 TransformationAddDeadBreak::TransformationAddDeadBreak(
     uint32_t from_block, uint32_t to_block, bool break_condition_value,

--- a/source/fuzz/transformation_add_dead_break.h
+++ b/source/fuzz/transformation_add_dead_break.h
@@ -28,7 +28,7 @@ namespace fuzz {
 class TransformationAddDeadBreak : public Transformation {
  public:
   explicit TransformationAddDeadBreak(
-      const protobufs::TransformationAddDeadBreak& message);
+      protobufs::TransformationAddDeadBreak message);
 
   TransformationAddDeadBreak(uint32_t from_block, uint32_t to_block,
                              bool break_condition_value,

--- a/source/fuzz/transformation_add_dead_continue.cpp
+++ b/source/fuzz/transformation_add_dead_continue.cpp
@@ -20,8 +20,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationAddDeadContinue::TransformationAddDeadContinue(
-    const spvtools::fuzz::protobufs::TransformationAddDeadContinue& message)
-    : message_(message) {}
+    protobufs::TransformationAddDeadContinue message)
+    : message_(std::move(message)) {}
 
 TransformationAddDeadContinue::TransformationAddDeadContinue(
     uint32_t from_block, bool continue_condition_value,

--- a/source/fuzz/transformation_add_dead_continue.h
+++ b/source/fuzz/transformation_add_dead_continue.h
@@ -28,7 +28,7 @@ namespace fuzz {
 class TransformationAddDeadContinue : public Transformation {
  public:
   explicit TransformationAddDeadContinue(
-      const protobufs::TransformationAddDeadContinue& message);
+      protobufs::TransformationAddDeadContinue message);
 
   TransformationAddDeadContinue(uint32_t from_block,
                                 bool continue_condition_value,

--- a/source/fuzz/transformation_add_early_terminator_wrapper.cpp
+++ b/source/fuzz/transformation_add_early_terminator_wrapper.cpp
@@ -22,9 +22,8 @@ namespace fuzz {
 
 TransformationAddEarlyTerminatorWrapper::
     TransformationAddEarlyTerminatorWrapper(
-        const spvtools::fuzz::protobufs::
-            TransformationAddEarlyTerminatorWrapper& message)
-    : message_(message) {}
+        protobufs::TransformationAddEarlyTerminatorWrapper message)
+    : message_(std::move(message)) {}
 
 TransformationAddEarlyTerminatorWrapper::
     TransformationAddEarlyTerminatorWrapper(uint32_t function_fresh_id,

--- a/source/fuzz/transformation_add_early_terminator_wrapper.h
+++ b/source/fuzz/transformation_add_early_terminator_wrapper.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationAddEarlyTerminatorWrapper : public Transformation {
  public:
   explicit TransformationAddEarlyTerminatorWrapper(
-      const protobufs::TransformationAddEarlyTerminatorWrapper& message);
+      protobufs::TransformationAddEarlyTerminatorWrapper message);
 
   TransformationAddEarlyTerminatorWrapper(uint32_t function_fresh_id,
                                           uint32_t label_fresh_id,

--- a/source/fuzz/transformation_add_function.cpp
+++ b/source/fuzz/transformation_add_function.cpp
@@ -21,8 +21,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationAddFunction::TransformationAddFunction(
-    const spvtools::fuzz::protobufs::TransformationAddFunction& message)
-    : message_(message) {}
+    protobufs::TransformationAddFunction message)
+    : message_(std::move(message)) {}
 
 TransformationAddFunction::TransformationAddFunction(
     const std::vector<protobufs::Instruction>& instructions) {

--- a/source/fuzz/transformation_add_function.h
+++ b/source/fuzz/transformation_add_function.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationAddFunction : public Transformation {
  public:
   explicit TransformationAddFunction(
-      const protobufs::TransformationAddFunction& message);
+      protobufs::TransformationAddFunction message);
 
   // Creates a transformation to add a non live-safe function.
   explicit TransformationAddFunction(

--- a/source/fuzz/transformation_add_image_sample_unused_components.cpp
+++ b/source/fuzz/transformation_add_image_sample_unused_components.cpp
@@ -22,9 +22,8 @@ namespace fuzz {
 
 TransformationAddImageSampleUnusedComponents::
     TransformationAddImageSampleUnusedComponents(
-        const spvtools::fuzz::protobufs::
-            TransformationAddImageSampleUnusedComponents& message)
-    : message_(message) {}
+        protobufs::TransformationAddImageSampleUnusedComponents message)
+    : message_(std::move(message)) {}
 
 TransformationAddImageSampleUnusedComponents::
     TransformationAddImageSampleUnusedComponents(

--- a/source/fuzz/transformation_add_image_sample_unused_components.h
+++ b/source/fuzz/transformation_add_image_sample_unused_components.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationAddImageSampleUnusedComponents : public Transformation {
  public:
   explicit TransformationAddImageSampleUnusedComponents(
-      const protobufs::TransformationAddImageSampleUnusedComponents& message);
+      protobufs::TransformationAddImageSampleUnusedComponents message);
 
   TransformationAddImageSampleUnusedComponents(
       uint32_t coordinate_with_unused_components_id,

--- a/source/fuzz/transformation_add_loop_preheader.cpp
+++ b/source/fuzz/transformation_add_loop_preheader.cpp
@@ -20,8 +20,8 @@
 namespace spvtools {
 namespace fuzz {
 TransformationAddLoopPreheader::TransformationAddLoopPreheader(
-    const protobufs::TransformationAddLoopPreheader& message)
-    : message_(message) {}
+    protobufs::TransformationAddLoopPreheader message)
+    : message_(std::move(message)) {}
 
 TransformationAddLoopPreheader::TransformationAddLoopPreheader(
     uint32_t loop_header_block, uint32_t fresh_id,

--- a/source/fuzz/transformation_add_loop_preheader.h
+++ b/source/fuzz/transformation_add_loop_preheader.h
@@ -23,7 +23,7 @@ namespace fuzz {
 class TransformationAddLoopPreheader : public Transformation {
  public:
   explicit TransformationAddLoopPreheader(
-      const protobufs::TransformationAddLoopPreheader& message);
+      protobufs::TransformationAddLoopPreheader message);
 
   TransformationAddLoopPreheader(uint32_t loop_header_block, uint32_t fresh_id,
                                  std::vector<uint32_t> phi_id);

--- a/source/fuzz/transformation_add_loop_to_create_int_constant_synonym.cpp
+++ b/source/fuzz/transformation_add_loop_to_create_int_constant_synonym.cpp
@@ -23,9 +23,8 @@ uint32_t kMaxNumOfIterations = 32;
 
 TransformationAddLoopToCreateIntConstantSynonym::
     TransformationAddLoopToCreateIntConstantSynonym(
-        const protobufs::TransformationAddLoopToCreateIntConstantSynonym&
-            message)
-    : message_(message) {}
+        protobufs::TransformationAddLoopToCreateIntConstantSynonym message)
+    : message_(std::move(message)) {}
 
 TransformationAddLoopToCreateIntConstantSynonym::
     TransformationAddLoopToCreateIntConstantSynonym(

--- a/source/fuzz/transformation_add_loop_to_create_int_constant_synonym.h
+++ b/source/fuzz/transformation_add_loop_to_create_int_constant_synonym.h
@@ -22,8 +22,7 @@ namespace fuzz {
 class TransformationAddLoopToCreateIntConstantSynonym : public Transformation {
  public:
   explicit TransformationAddLoopToCreateIntConstantSynonym(
-      const protobufs::TransformationAddLoopToCreateIntConstantSynonym&
-          message);
+      protobufs::TransformationAddLoopToCreateIntConstantSynonym message);
 
   TransformationAddLoopToCreateIntConstantSynonym(
       uint32_t constant_id, uint32_t initial_val_id, uint32_t step_val_id,

--- a/source/fuzz/transformation_add_no_contraction_decoration.cpp
+++ b/source/fuzz/transformation_add_no_contraction_decoration.cpp
@@ -21,9 +21,8 @@ namespace fuzz {
 
 TransformationAddNoContractionDecoration::
     TransformationAddNoContractionDecoration(
-        const spvtools::fuzz::protobufs::
-            TransformationAddNoContractionDecoration& message)
-    : message_(message) {}
+        protobufs::TransformationAddNoContractionDecoration message)
+    : message_(std::move(message)) {}
 
 TransformationAddNoContractionDecoration::
     TransformationAddNoContractionDecoration(uint32_t result_id) {

--- a/source/fuzz/transformation_add_no_contraction_decoration.h
+++ b/source/fuzz/transformation_add_no_contraction_decoration.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationAddNoContractionDecoration : public Transformation {
  public:
   explicit TransformationAddNoContractionDecoration(
-      const protobufs::TransformationAddNoContractionDecoration& message);
+      protobufs::TransformationAddNoContractionDecoration message);
 
   explicit TransformationAddNoContractionDecoration(uint32_t fresh_id);
 

--- a/source/fuzz/transformation_add_opphi_synonym.cpp
+++ b/source/fuzz/transformation_add_opphi_synonym.cpp
@@ -19,8 +19,8 @@
 namespace spvtools {
 namespace fuzz {
 TransformationAddOpPhiSynonym::TransformationAddOpPhiSynonym(
-    const protobufs::TransformationAddOpPhiSynonym& message)
-    : message_(message) {}
+    protobufs::TransformationAddOpPhiSynonym message)
+    : message_(std::move(message)) {}
 
 TransformationAddOpPhiSynonym::TransformationAddOpPhiSynonym(
     uint32_t block_id, const std::map<uint32_t, uint32_t>& preds_to_ids,

--- a/source/fuzz/transformation_add_opphi_synonym.h
+++ b/source/fuzz/transformation_add_opphi_synonym.h
@@ -22,7 +22,7 @@ namespace fuzz {
 class TransformationAddOpPhiSynonym : public Transformation {
  public:
   explicit TransformationAddOpPhiSynonym(
-      const protobufs::TransformationAddOpPhiSynonym& message);
+      protobufs::TransformationAddOpPhiSynonym message);
 
   TransformationAddOpPhiSynonym(
       uint32_t block_id, const std::map<uint32_t, uint32_t>& preds_to_ids,

--- a/source/fuzz/transformation_add_parameter.cpp
+++ b/source/fuzz/transformation_add_parameter.cpp
@@ -20,8 +20,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationAddParameter::TransformationAddParameter(
-    const protobufs::TransformationAddParameter& message)
-    : message_(message) {}
+    protobufs::TransformationAddParameter message)
+    : message_(std::move(message)) {}
 
 TransformationAddParameter::TransformationAddParameter(
     uint32_t function_id, uint32_t parameter_fresh_id,

--- a/source/fuzz/transformation_add_parameter.h
+++ b/source/fuzz/transformation_add_parameter.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationAddParameter : public Transformation {
  public:
   explicit TransformationAddParameter(
-      const protobufs::TransformationAddParameter& message);
+      protobufs::TransformationAddParameter message);
 
   TransformationAddParameter(uint32_t function_id, uint32_t parameter_fresh_id,
                              uint32_t parameter_type_id,

--- a/source/fuzz/transformation_add_relaxed_decoration.cpp
+++ b/source/fuzz/transformation_add_relaxed_decoration.cpp
@@ -20,9 +20,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationAddRelaxedDecoration::TransformationAddRelaxedDecoration(
-    const spvtools::fuzz::protobufs::TransformationAddRelaxedDecoration&
-        message)
-    : message_(message) {}
+    protobufs::TransformationAddRelaxedDecoration message)
+    : message_(std::move(message)) {}
 
 TransformationAddRelaxedDecoration::TransformationAddRelaxedDecoration(
     uint32_t result_id) {

--- a/source/fuzz/transformation_add_relaxed_decoration.h
+++ b/source/fuzz/transformation_add_relaxed_decoration.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationAddRelaxedDecoration : public Transformation {
  public:
   explicit TransformationAddRelaxedDecoration(
-      const protobufs::TransformationAddRelaxedDecoration& message);
+      protobufs::TransformationAddRelaxedDecoration message);
 
   explicit TransformationAddRelaxedDecoration(uint32_t fresh_id);
 

--- a/source/fuzz/transformation_add_type_array.cpp
+++ b/source/fuzz/transformation_add_type_array.cpp
@@ -20,8 +20,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationAddTypeArray::TransformationAddTypeArray(
-    const spvtools::fuzz::protobufs::TransformationAddTypeArray& message)
-    : message_(message) {}
+    protobufs::TransformationAddTypeArray message)
+    : message_(std::move(message)) {}
 
 TransformationAddTypeArray::TransformationAddTypeArray(uint32_t fresh_id,
                                                        uint32_t element_type_id,

--- a/source/fuzz/transformation_add_type_array.h
+++ b/source/fuzz/transformation_add_type_array.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationAddTypeArray : public Transformation {
  public:
   explicit TransformationAddTypeArray(
-      const protobufs::TransformationAddTypeArray& message);
+      protobufs::TransformationAddTypeArray message);
 
   TransformationAddTypeArray(uint32_t fresh_id, uint32_t element_type_id,
                              uint32_t size_id);

--- a/source/fuzz/transformation_add_type_boolean.cpp
+++ b/source/fuzz/transformation_add_type_boolean.cpp
@@ -20,8 +20,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationAddTypeBoolean::TransformationAddTypeBoolean(
-    const spvtools::fuzz::protobufs::TransformationAddTypeBoolean& message)
-    : message_(message) {}
+    protobufs::TransformationAddTypeBoolean message)
+    : message_(std::move(message)) {}
 
 TransformationAddTypeBoolean::TransformationAddTypeBoolean(uint32_t fresh_id) {
   message_.set_fresh_id(fresh_id);

--- a/source/fuzz/transformation_add_type_boolean.h
+++ b/source/fuzz/transformation_add_type_boolean.h
@@ -25,7 +25,7 @@ namespace fuzz {
 class TransformationAddTypeBoolean : public Transformation {
  public:
   explicit TransformationAddTypeBoolean(
-      const protobufs::TransformationAddTypeBoolean& message);
+      protobufs::TransformationAddTypeBoolean message);
 
   explicit TransformationAddTypeBoolean(uint32_t fresh_id);
 

--- a/source/fuzz/transformation_add_type_float.cpp
+++ b/source/fuzz/transformation_add_type_float.cpp
@@ -26,8 +26,8 @@ TransformationAddTypeFloat::TransformationAddTypeFloat(uint32_t fresh_id,
 }
 
 TransformationAddTypeFloat::TransformationAddTypeFloat(
-    const spvtools::fuzz::protobufs::TransformationAddTypeFloat& message)
-    : message_(message) {}
+    protobufs::TransformationAddTypeFloat message)
+    : message_(std::move(message)) {}
 
 bool TransformationAddTypeFloat::IsApplicable(
     opt::IRContext* ir_context, const TransformationContext& /*unused*/) const {

--- a/source/fuzz/transformation_add_type_float.h
+++ b/source/fuzz/transformation_add_type_float.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationAddTypeFloat : public Transformation {
  public:
   explicit TransformationAddTypeFloat(
-      const protobufs::TransformationAddTypeFloat& message);
+      protobufs::TransformationAddTypeFloat message);
 
   TransformationAddTypeFloat(uint32_t fresh_id, uint32_t width);
 

--- a/source/fuzz/transformation_add_type_function.cpp
+++ b/source/fuzz/transformation_add_type_function.cpp
@@ -22,8 +22,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationAddTypeFunction::TransformationAddTypeFunction(
-    const spvtools::fuzz::protobufs::TransformationAddTypeFunction& message)
-    : message_(message) {}
+    protobufs::TransformationAddTypeFunction message)
+    : message_(std::move(message)) {}
 
 TransformationAddTypeFunction::TransformationAddTypeFunction(
     uint32_t fresh_id, uint32_t return_type_id,

--- a/source/fuzz/transformation_add_type_function.h
+++ b/source/fuzz/transformation_add_type_function.h
@@ -28,7 +28,7 @@ namespace fuzz {
 class TransformationAddTypeFunction : public Transformation {
  public:
   explicit TransformationAddTypeFunction(
-      const protobufs::TransformationAddTypeFunction& message);
+      protobufs::TransformationAddTypeFunction message);
 
   TransformationAddTypeFunction(uint32_t fresh_id, uint32_t return_type_id,
                                 const std::vector<uint32_t>& argument_type_ids);

--- a/source/fuzz/transformation_add_type_int.cpp
+++ b/source/fuzz/transformation_add_type_int.cpp
@@ -20,8 +20,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationAddTypeInt::TransformationAddTypeInt(
-    const spvtools::fuzz::protobufs::TransformationAddTypeInt& message)
-    : message_(message) {}
+    protobufs::TransformationAddTypeInt message)
+    : message_(std::move(message)) {}
 
 TransformationAddTypeInt::TransformationAddTypeInt(uint32_t fresh_id,
                                                    uint32_t width,

--- a/source/fuzz/transformation_add_type_int.h
+++ b/source/fuzz/transformation_add_type_int.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationAddTypeInt : public Transformation {
  public:
   explicit TransformationAddTypeInt(
-      const protobufs::TransformationAddTypeInt& message);
+      protobufs::TransformationAddTypeInt message);
 
   TransformationAddTypeInt(uint32_t fresh_id, uint32_t width, bool is_signed);
 

--- a/source/fuzz/transformation_add_type_matrix.cpp
+++ b/source/fuzz/transformation_add_type_matrix.cpp
@@ -20,8 +20,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationAddTypeMatrix::TransformationAddTypeMatrix(
-    const spvtools::fuzz::protobufs::TransformationAddTypeMatrix& message)
-    : message_(message) {}
+    protobufs::TransformationAddTypeMatrix message)
+    : message_(std::move(message)) {}
 
 TransformationAddTypeMatrix::TransformationAddTypeMatrix(
     uint32_t fresh_id, uint32_t column_type_id, uint32_t column_count) {

--- a/source/fuzz/transformation_add_type_matrix.h
+++ b/source/fuzz/transformation_add_type_matrix.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationAddTypeMatrix : public Transformation {
  public:
   explicit TransformationAddTypeMatrix(
-      const protobufs::TransformationAddTypeMatrix& message);
+      protobufs::TransformationAddTypeMatrix message);
 
   TransformationAddTypeMatrix(uint32_t fresh_id, uint32_t column_type_id,
                               uint32_t column_count);

--- a/source/fuzz/transformation_add_type_pointer.cpp
+++ b/source/fuzz/transformation_add_type_pointer.cpp
@@ -20,8 +20,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationAddTypePointer::TransformationAddTypePointer(
-    const spvtools::fuzz::protobufs::TransformationAddTypePointer& message)
-    : message_(message) {}
+    protobufs::TransformationAddTypePointer message)
+    : message_(std::move(message)) {}
 
 TransformationAddTypePointer::TransformationAddTypePointer(
     uint32_t fresh_id, SpvStorageClass storage_class, uint32_t base_type_id) {

--- a/source/fuzz/transformation_add_type_pointer.h
+++ b/source/fuzz/transformation_add_type_pointer.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationAddTypePointer : public Transformation {
  public:
   explicit TransformationAddTypePointer(
-      const protobufs::TransformationAddTypePointer& message);
+      protobufs::TransformationAddTypePointer message);
 
   TransformationAddTypePointer(uint32_t fresh_id, SpvStorageClass storage_class,
                                uint32_t base_type_id);

--- a/source/fuzz/transformation_add_type_struct.cpp
+++ b/source/fuzz/transformation_add_type_struct.cpp
@@ -20,8 +20,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationAddTypeStruct::TransformationAddTypeStruct(
-    const spvtools::fuzz::protobufs::TransformationAddTypeStruct& message)
-    : message_(message) {}
+    protobufs::TransformationAddTypeStruct message)
+    : message_(std::move(message)) {}
 
 TransformationAddTypeStruct::TransformationAddTypeStruct(
     uint32_t fresh_id, const std::vector<uint32_t>& member_type_ids) {

--- a/source/fuzz/transformation_add_type_struct.h
+++ b/source/fuzz/transformation_add_type_struct.h
@@ -28,7 +28,7 @@ namespace fuzz {
 class TransformationAddTypeStruct : public Transformation {
  public:
   explicit TransformationAddTypeStruct(
-      const protobufs::TransformationAddTypeStruct& message);
+      protobufs::TransformationAddTypeStruct message);
 
   TransformationAddTypeStruct(uint32_t fresh_id,
                               const std::vector<uint32_t>& component_type_ids);

--- a/source/fuzz/transformation_add_type_vector.cpp
+++ b/source/fuzz/transformation_add_type_vector.cpp
@@ -20,8 +20,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationAddTypeVector::TransformationAddTypeVector(
-    const spvtools::fuzz::protobufs::TransformationAddTypeVector& message)
-    : message_(message) {}
+    protobufs::TransformationAddTypeVector message)
+    : message_(std::move(message)) {}
 
 TransformationAddTypeVector::TransformationAddTypeVector(
     uint32_t fresh_id, uint32_t component_type_id, uint32_t component_count) {

--- a/source/fuzz/transformation_add_type_vector.h
+++ b/source/fuzz/transformation_add_type_vector.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationAddTypeVector : public Transformation {
  public:
   explicit TransformationAddTypeVector(
-      const protobufs::TransformationAddTypeVector& message);
+      protobufs::TransformationAddTypeVector message);
 
   TransformationAddTypeVector(uint32_t fresh_id, uint32_t component_type_id,
                               uint32_t component_count);

--- a/source/fuzz/transformation_adjust_branch_weights.cpp
+++ b/source/fuzz/transformation_adjust_branch_weights.cpp
@@ -28,8 +28,8 @@ const uint32_t kBranchWeightForFalseLabelIndex = 4;
 }  // namespace
 
 TransformationAdjustBranchWeights::TransformationAdjustBranchWeights(
-    const spvtools::fuzz::protobufs::TransformationAdjustBranchWeights& message)
-    : message_(message) {}
+    protobufs::TransformationAdjustBranchWeights message)
+    : message_(std::move(message)) {}
 
 TransformationAdjustBranchWeights::TransformationAdjustBranchWeights(
     const protobufs::InstructionDescriptor& instruction_descriptor,

--- a/source/fuzz/transformation_adjust_branch_weights.h
+++ b/source/fuzz/transformation_adjust_branch_weights.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationAdjustBranchWeights : public Transformation {
  public:
   explicit TransformationAdjustBranchWeights(
-      const protobufs::TransformationAdjustBranchWeights& message);
+      protobufs::TransformationAdjustBranchWeights message);
 
   TransformationAdjustBranchWeights(
       const protobufs::InstructionDescriptor& instruction_descriptor,

--- a/source/fuzz/transformation_composite_construct.cpp
+++ b/source/fuzz/transformation_composite_construct.cpp
@@ -23,8 +23,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationCompositeConstruct::TransformationCompositeConstruct(
-    const protobufs::TransformationCompositeConstruct& message)
-    : message_(message) {}
+    protobufs::TransformationCompositeConstruct message)
+    : message_(std::move(message)) {}
 
 TransformationCompositeConstruct::TransformationCompositeConstruct(
     uint32_t composite_type_id, std::vector<uint32_t> component,

--- a/source/fuzz/transformation_composite_construct.h
+++ b/source/fuzz/transformation_composite_construct.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationCompositeConstruct : public Transformation {
  public:
   explicit TransformationCompositeConstruct(
-      const protobufs::TransformationCompositeConstruct& message);
+      protobufs::TransformationCompositeConstruct message);
 
   TransformationCompositeConstruct(
       uint32_t composite_type_id, std::vector<uint32_t> component,

--- a/source/fuzz/transformation_composite_extract.cpp
+++ b/source/fuzz/transformation_composite_extract.cpp
@@ -24,8 +24,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationCompositeExtract::TransformationCompositeExtract(
-    const spvtools::fuzz::protobufs::TransformationCompositeExtract& message)
-    : message_(message) {}
+    protobufs::TransformationCompositeExtract message)
+    : message_(std::move(message)) {}
 
 TransformationCompositeExtract::TransformationCompositeExtract(
     const protobufs::InstructionDescriptor& instruction_to_insert_before,

--- a/source/fuzz/transformation_composite_extract.h
+++ b/source/fuzz/transformation_composite_extract.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationCompositeExtract : public Transformation {
  public:
   explicit TransformationCompositeExtract(
-      const protobufs::TransformationCompositeExtract& message);
+      protobufs::TransformationCompositeExtract message);
 
   TransformationCompositeExtract(
       const protobufs::InstructionDescriptor& instruction_to_insert_before,

--- a/source/fuzz/transformation_composite_insert.cpp
+++ b/source/fuzz/transformation_composite_insert.cpp
@@ -22,8 +22,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationCompositeInsert::TransformationCompositeInsert(
-    const spvtools::fuzz::protobufs::TransformationCompositeInsert& message)
-    : message_(message) {}
+    protobufs::TransformationCompositeInsert message)
+    : message_(std::move(message)) {}
 
 TransformationCompositeInsert::TransformationCompositeInsert(
     const protobufs::InstructionDescriptor& instruction_to_insert_before,

--- a/source/fuzz/transformation_composite_insert.h
+++ b/source/fuzz/transformation_composite_insert.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationCompositeInsert : public Transformation {
  public:
   explicit TransformationCompositeInsert(
-      const protobufs::TransformationCompositeInsert& message);
+      protobufs::TransformationCompositeInsert message);
 
   TransformationCompositeInsert(
       const protobufs::InstructionDescriptor& instruction_to_insert_before,

--- a/source/fuzz/transformation_compute_data_synonym_fact_closure.cpp
+++ b/source/fuzz/transformation_compute_data_synonym_fact_closure.cpp
@@ -19,9 +19,8 @@ namespace fuzz {
 
 TransformationComputeDataSynonymFactClosure::
     TransformationComputeDataSynonymFactClosure(
-        const spvtools::fuzz::protobufs::
-            TransformationComputeDataSynonymFactClosure& message)
-    : message_(message) {}
+        protobufs::TransformationComputeDataSynonymFactClosure message)
+    : message_(std::move(message)) {}
 
 TransformationComputeDataSynonymFactClosure::
     TransformationComputeDataSynonymFactClosure(

--- a/source/fuzz/transformation_compute_data_synonym_fact_closure.h
+++ b/source/fuzz/transformation_compute_data_synonym_fact_closure.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationComputeDataSynonymFactClosure : public Transformation {
  public:
   explicit TransformationComputeDataSynonymFactClosure(
-      const protobufs::TransformationComputeDataSynonymFactClosure& message);
+      protobufs::TransformationComputeDataSynonymFactClosure message);
 
   explicit TransformationComputeDataSynonymFactClosure(
       uint32_t maximum_equivalence_class_size);

--- a/source/fuzz/transformation_duplicate_region_with_selection.cpp
+++ b/source/fuzz/transformation_duplicate_region_with_selection.cpp
@@ -21,9 +21,8 @@ namespace fuzz {
 
 TransformationDuplicateRegionWithSelection::
     TransformationDuplicateRegionWithSelection(
-        const spvtools::fuzz::protobufs::
-            TransformationDuplicateRegionWithSelection& message)
-    : message_(message) {}
+        protobufs::TransformationDuplicateRegionWithSelection message)
+    : message_(std::move(message)) {}
 
 TransformationDuplicateRegionWithSelection::
     TransformationDuplicateRegionWithSelection(

--- a/source/fuzz/transformation_duplicate_region_with_selection.h
+++ b/source/fuzz/transformation_duplicate_region_with_selection.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationDuplicateRegionWithSelection : public Transformation {
  public:
   explicit TransformationDuplicateRegionWithSelection(
-      const protobufs::TransformationDuplicateRegionWithSelection& message);
+      protobufs::TransformationDuplicateRegionWithSelection message);
 
   explicit TransformationDuplicateRegionWithSelection(
       uint32_t new_entry_fresh_id, uint32_t condition_id,

--- a/source/fuzz/transformation_equation_instruction.cpp
+++ b/source/fuzz/transformation_equation_instruction.cpp
@@ -21,8 +21,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationEquationInstruction::TransformationEquationInstruction(
-    const spvtools::fuzz::protobufs::TransformationEquationInstruction& message)
-    : message_(message) {}
+    protobufs::TransformationEquationInstruction message)
+    : message_(std::move(message)) {}
 
 TransformationEquationInstruction::TransformationEquationInstruction(
     uint32_t fresh_id, SpvOp opcode, const std::vector<uint32_t>& in_operand_id,

--- a/source/fuzz/transformation_equation_instruction.h
+++ b/source/fuzz/transformation_equation_instruction.h
@@ -28,7 +28,7 @@ namespace fuzz {
 class TransformationEquationInstruction : public Transformation {
  public:
   explicit TransformationEquationInstruction(
-      const protobufs::TransformationEquationInstruction& message);
+      protobufs::TransformationEquationInstruction message);
 
   TransformationEquationInstruction(
       uint32_t fresh_id, SpvOp opcode,

--- a/source/fuzz/transformation_expand_vector_reduction.cpp
+++ b/source/fuzz/transformation_expand_vector_reduction.cpp
@@ -21,9 +21,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationExpandVectorReduction::TransformationExpandVectorReduction(
-    const spvtools::fuzz::protobufs::TransformationExpandVectorReduction&
-        message)
-    : message_(message) {}
+    protobufs::TransformationExpandVectorReduction message)
+    : message_(std::move(message)) {}
 
 TransformationExpandVectorReduction::TransformationExpandVectorReduction(
     const uint32_t instruction_result_id,

--- a/source/fuzz/transformation_expand_vector_reduction.h
+++ b/source/fuzz/transformation_expand_vector_reduction.h
@@ -70,7 +70,7 @@ namespace fuzz {
 class TransformationExpandVectorReduction : public Transformation {
  public:
   explicit TransformationExpandVectorReduction(
-      const protobufs::TransformationExpandVectorReduction& message);
+      protobufs::TransformationExpandVectorReduction message);
 
   TransformationExpandVectorReduction(const uint32_t instruction_result_id,
                                       const std::vector<uint32_t>& fresh_ids);

--- a/source/fuzz/transformation_flatten_conditional_branch.cpp
+++ b/source/fuzz/transformation_flatten_conditional_branch.cpp
@@ -21,8 +21,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationFlattenConditionalBranch::TransformationFlattenConditionalBranch(
-    const protobufs::TransformationFlattenConditionalBranch& message)
-    : message_(message) {}
+    protobufs::TransformationFlattenConditionalBranch message)
+    : message_(std::move(message)) {}
 
 TransformationFlattenConditionalBranch::TransformationFlattenConditionalBranch(
     uint32_t header_block_id, bool true_branch_first,

--- a/source/fuzz/transformation_flatten_conditional_branch.h
+++ b/source/fuzz/transformation_flatten_conditional_branch.h
@@ -23,7 +23,7 @@ namespace fuzz {
 class TransformationFlattenConditionalBranch : public Transformation {
  public:
   explicit TransformationFlattenConditionalBranch(
-      const protobufs::TransformationFlattenConditionalBranch& message);
+      protobufs::TransformationFlattenConditionalBranch message);
 
   TransformationFlattenConditionalBranch(
       uint32_t header_block_id, bool true_branch_first,

--- a/source/fuzz/transformation_function_call.cpp
+++ b/source/fuzz/transformation_function_call.cpp
@@ -22,8 +22,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationFunctionCall::TransformationFunctionCall(
-    const spvtools::fuzz::protobufs::TransformationFunctionCall& message)
-    : message_(message) {}
+    protobufs::TransformationFunctionCall message)
+    : message_(std::move(message)) {}
 
 TransformationFunctionCall::TransformationFunctionCall(
     uint32_t fresh_id, uint32_t callee_id,

--- a/source/fuzz/transformation_function_call.h
+++ b/source/fuzz/transformation_function_call.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationFunctionCall : public Transformation {
  public:
   explicit TransformationFunctionCall(
-      const protobufs::TransformationFunctionCall& message);
+      protobufs::TransformationFunctionCall message);
 
   TransformationFunctionCall(
       uint32_t fresh_id, uint32_t callee_id,

--- a/source/fuzz/transformation_inline_function.cpp
+++ b/source/fuzz/transformation_inline_function.cpp
@@ -21,8 +21,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationInlineFunction::TransformationInlineFunction(
-    const spvtools::fuzz::protobufs::TransformationInlineFunction& message)
-    : message_(message) {}
+    protobufs::TransformationInlineFunction message)
+    : message_(std::move(message)) {}
 
 TransformationInlineFunction::TransformationInlineFunction(
     uint32_t function_call_id,

--- a/source/fuzz/transformation_inline_function.h
+++ b/source/fuzz/transformation_inline_function.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationInlineFunction : public Transformation {
  public:
   explicit TransformationInlineFunction(
-      const protobufs::TransformationInlineFunction& message);
+      protobufs::TransformationInlineFunction message);
 
   TransformationInlineFunction(
       uint32_t function_call_id,

--- a/source/fuzz/transformation_load.cpp
+++ b/source/fuzz/transformation_load.cpp
@@ -20,9 +20,8 @@
 namespace spvtools {
 namespace fuzz {
 
-TransformationLoad::TransformationLoad(
-    const spvtools::fuzz::protobufs::TransformationLoad& message)
-    : message_(message) {}
+TransformationLoad::TransformationLoad(protobufs::TransformationLoad message)
+    : message_(std::move(message)) {}
 
 TransformationLoad::TransformationLoad(
     uint32_t fresh_id, uint32_t pointer_id,

--- a/source/fuzz/transformation_load.h
+++ b/source/fuzz/transformation_load.h
@@ -25,7 +25,7 @@ namespace fuzz {
 
 class TransformationLoad : public Transformation {
  public:
-  explicit TransformationLoad(const protobufs::TransformationLoad& message);
+  explicit TransformationLoad(protobufs::TransformationLoad message);
 
   TransformationLoad(
       uint32_t fresh_id, uint32_t pointer_id,

--- a/source/fuzz/transformation_make_vector_operation_dynamic.cpp
+++ b/source/fuzz/transformation_make_vector_operation_dynamic.cpp
@@ -22,9 +22,8 @@ namespace fuzz {
 
 TransformationMakeVectorOperationDynamic::
     TransformationMakeVectorOperationDynamic(
-        const spvtools::fuzz::protobufs::
-            TransformationMakeVectorOperationDynamic& message)
-    : message_(message) {}
+        protobufs::TransformationMakeVectorOperationDynamic message)
+    : message_(std::move(message)) {}
 
 TransformationMakeVectorOperationDynamic::
     TransformationMakeVectorOperationDynamic(uint32_t instruction_result_id,

--- a/source/fuzz/transformation_make_vector_operation_dynamic.h
+++ b/source/fuzz/transformation_make_vector_operation_dynamic.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationMakeVectorOperationDynamic : public Transformation {
  public:
   explicit TransformationMakeVectorOperationDynamic(
-      const protobufs::TransformationMakeVectorOperationDynamic& message);
+      protobufs::TransformationMakeVectorOperationDynamic message);
 
   TransformationMakeVectorOperationDynamic(uint32_t instruction_result_id,
                                            uint32_t constant_index_id);

--- a/source/fuzz/transformation_merge_blocks.cpp
+++ b/source/fuzz/transformation_merge_blocks.cpp
@@ -21,8 +21,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationMergeBlocks::TransformationMergeBlocks(
-    const spvtools::fuzz::protobufs::TransformationMergeBlocks& message)
-    : message_(message) {}
+    protobufs::TransformationMergeBlocks message)
+    : message_(std::move(message)) {}
 
 TransformationMergeBlocks::TransformationMergeBlocks(uint32_t block_id) {
   message_.set_block_id(block_id);

--- a/source/fuzz/transformation_merge_blocks.h
+++ b/source/fuzz/transformation_merge_blocks.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationMergeBlocks : public Transformation {
  public:
   explicit TransformationMergeBlocks(
-      const protobufs::TransformationMergeBlocks& message);
+      protobufs::TransformationMergeBlocks message);
 
   TransformationMergeBlocks(uint32_t block_id);
 

--- a/source/fuzz/transformation_merge_function_returns.cpp
+++ b/source/fuzz/transformation_merge_function_returns.cpp
@@ -21,8 +21,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationMergeFunctionReturns::TransformationMergeFunctionReturns(
-    const protobufs::TransformationMergeFunctionReturns& message)
-    : message_(message) {}
+    protobufs::TransformationMergeFunctionReturns message)
+    : message_(std::move(message)) {}
 
 TransformationMergeFunctionReturns::TransformationMergeFunctionReturns(
     uint32_t function_id, uint32_t outer_header_id, uint32_t outer_return_id,

--- a/source/fuzz/transformation_merge_function_returns.h
+++ b/source/fuzz/transformation_merge_function_returns.h
@@ -22,7 +22,7 @@ namespace fuzz {
 class TransformationMergeFunctionReturns : public Transformation {
  public:
   explicit TransformationMergeFunctionReturns(
-      const protobufs::TransformationMergeFunctionReturns& message);
+      protobufs::TransformationMergeFunctionReturns message);
 
   TransformationMergeFunctionReturns(
       uint32_t function_id, uint32_t outer_header_id, uint32_t outer_return_id,

--- a/source/fuzz/transformation_move_block_down.cpp
+++ b/source/fuzz/transformation_move_block_down.cpp
@@ -20,8 +20,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationMoveBlockDown::TransformationMoveBlockDown(
-    const spvtools::fuzz::protobufs::TransformationMoveBlockDown& message)
-    : message_(message) {}
+    protobufs::TransformationMoveBlockDown message)
+    : message_(std::move(message)) {}
 
 TransformationMoveBlockDown::TransformationMoveBlockDown(uint32_t id) {
   message_.set_block_id(id);

--- a/source/fuzz/transformation_move_block_down.h
+++ b/source/fuzz/transformation_move_block_down.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationMoveBlockDown : public Transformation {
  public:
   explicit TransformationMoveBlockDown(
-      const protobufs::TransformationMoveBlockDown& message);
+      protobufs::TransformationMoveBlockDown message);
 
   explicit TransformationMoveBlockDown(uint32_t id);
 

--- a/source/fuzz/transformation_move_instruction_down.cpp
+++ b/source/fuzz/transformation_move_instruction_down.cpp
@@ -38,8 +38,8 @@ std::string GetExtensionSet(opt::IRContext* ir_context,
 }  // namespace
 
 TransformationMoveInstructionDown::TransformationMoveInstructionDown(
-    const protobufs::TransformationMoveInstructionDown& message)
-    : message_(message) {}
+    protobufs::TransformationMoveInstructionDown message)
+    : message_(std::move(message)) {}
 
 TransformationMoveInstructionDown::TransformationMoveInstructionDown(
     const protobufs::InstructionDescriptor& instruction) {

--- a/source/fuzz/transformation_move_instruction_down.h
+++ b/source/fuzz/transformation_move_instruction_down.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationMoveInstructionDown : public Transformation {
  public:
   explicit TransformationMoveInstructionDown(
-      const protobufs::TransformationMoveInstructionDown& message);
+      protobufs::TransformationMoveInstructionDown message);
 
   explicit TransformationMoveInstructionDown(
       const protobufs::InstructionDescriptor& instruction);

--- a/source/fuzz/transformation_mutate_pointer.cpp
+++ b/source/fuzz/transformation_mutate_pointer.cpp
@@ -21,8 +21,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationMutatePointer::TransformationMutatePointer(
-    const protobufs::TransformationMutatePointer& message)
-    : message_(message) {}
+    protobufs::TransformationMutatePointer message)
+    : message_(std::move(message)) {}
 
 TransformationMutatePointer::TransformationMutatePointer(
     uint32_t pointer_id, uint32_t fresh_id,

--- a/source/fuzz/transformation_mutate_pointer.h
+++ b/source/fuzz/transformation_mutate_pointer.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationMutatePointer : public Transformation {
  public:
   explicit TransformationMutatePointer(
-      const protobufs::TransformationMutatePointer& message);
+      protobufs::TransformationMutatePointer message);
 
   explicit TransformationMutatePointer(
       uint32_t pointer_id, uint32_t fresh_id,

--- a/source/fuzz/transformation_outline_function.cpp
+++ b/source/fuzz/transformation_outline_function.cpp
@@ -22,8 +22,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationOutlineFunction::TransformationOutlineFunction(
-    const spvtools::fuzz::protobufs::TransformationOutlineFunction& message)
-    : message_(message) {}
+    protobufs::TransformationOutlineFunction message)
+    : message_(std::move(message)) {}
 
 TransformationOutlineFunction::TransformationOutlineFunction(
     uint32_t entry_block, uint32_t exit_block,

--- a/source/fuzz/transformation_outline_function.h
+++ b/source/fuzz/transformation_outline_function.h
@@ -30,7 +30,7 @@ namespace fuzz {
 class TransformationOutlineFunction : public Transformation {
  public:
   explicit TransformationOutlineFunction(
-      const protobufs::TransformationOutlineFunction& message);
+      protobufs::TransformationOutlineFunction message);
 
   TransformationOutlineFunction(
       uint32_t entry_block, uint32_t exit_block,

--- a/source/fuzz/transformation_permute_function_parameters.cpp
+++ b/source/fuzz/transformation_permute_function_parameters.cpp
@@ -23,9 +23,8 @@ namespace fuzz {
 
 TransformationPermuteFunctionParameters::
     TransformationPermuteFunctionParameters(
-        const spvtools::fuzz::protobufs::
-            TransformationPermuteFunctionParameters& message)
-    : message_(message) {}
+        protobufs::TransformationPermuteFunctionParameters message)
+    : message_(std::move(message)) {}
 
 TransformationPermuteFunctionParameters::
     TransformationPermuteFunctionParameters(

--- a/source/fuzz/transformation_permute_function_parameters.h
+++ b/source/fuzz/transformation_permute_function_parameters.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationPermuteFunctionParameters : public Transformation {
  public:
   explicit TransformationPermuteFunctionParameters(
-      const protobufs::TransformationPermuteFunctionParameters& message);
+      protobufs::TransformationPermuteFunctionParameters message);
 
   TransformationPermuteFunctionParameters(
       uint32_t function_id, uint32_t function_type_fresh_id,

--- a/source/fuzz/transformation_permute_phi_operands.cpp
+++ b/source/fuzz/transformation_permute_phi_operands.cpp
@@ -22,8 +22,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationPermutePhiOperands::TransformationPermutePhiOperands(
-    const spvtools::fuzz::protobufs::TransformationPermutePhiOperands& message)
-    : message_(message) {}
+    protobufs::TransformationPermutePhiOperands message)
+    : message_(std::move(message)) {}
 
 TransformationPermutePhiOperands::TransformationPermutePhiOperands(
     uint32_t result_id, const std::vector<uint32_t>& permutation) {

--- a/source/fuzz/transformation_permute_phi_operands.h
+++ b/source/fuzz/transformation_permute_phi_operands.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationPermutePhiOperands : public Transformation {
  public:
   explicit TransformationPermutePhiOperands(
-      const protobufs::TransformationPermutePhiOperands& message);
+      protobufs::TransformationPermutePhiOperands message);
 
   TransformationPermutePhiOperands(uint32_t result_id,
                                    const std::vector<uint32_t>& permutation);

--- a/source/fuzz/transformation_propagate_instruction_down.cpp
+++ b/source/fuzz/transformation_propagate_instruction_down.cpp
@@ -21,8 +21,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationPropagateInstructionDown::TransformationPropagateInstructionDown(
-    const protobufs::TransformationPropagateInstructionDown& message)
-    : message_(message) {}
+    protobufs::TransformationPropagateInstructionDown message)
+    : message_(std::move(message)) {}
 
 TransformationPropagateInstructionDown::TransformationPropagateInstructionDown(
     uint32_t block_id, uint32_t phi_fresh_id,

--- a/source/fuzz/transformation_propagate_instruction_down.h
+++ b/source/fuzz/transformation_propagate_instruction_down.h
@@ -28,7 +28,7 @@ namespace fuzz {
 class TransformationPropagateInstructionDown : public Transformation {
  public:
   explicit TransformationPropagateInstructionDown(
-      const protobufs::TransformationPropagateInstructionDown& message);
+      protobufs::TransformationPropagateInstructionDown message);
 
   TransformationPropagateInstructionDown(
       uint32_t block_id, uint32_t phi_fresh_id,

--- a/source/fuzz/transformation_propagate_instruction_up.cpp
+++ b/source/fuzz/transformation_propagate_instruction_up.cpp
@@ -79,8 +79,8 @@ bool HasValidDependencies(opt::IRContext* ir_context, opt::Instruction* inst) {
 }  // namespace
 
 TransformationPropagateInstructionUp::TransformationPropagateInstructionUp(
-    const protobufs::TransformationPropagateInstructionUp& message)
-    : message_(message) {}
+    protobufs::TransformationPropagateInstructionUp message)
+    : message_(std::move(message)) {}
 
 TransformationPropagateInstructionUp::TransformationPropagateInstructionUp(
     uint32_t block_id,

--- a/source/fuzz/transformation_propagate_instruction_up.h
+++ b/source/fuzz/transformation_propagate_instruction_up.h
@@ -28,7 +28,7 @@ namespace fuzz {
 class TransformationPropagateInstructionUp : public Transformation {
  public:
   explicit TransformationPropagateInstructionUp(
-      const protobufs::TransformationPropagateInstructionUp& message);
+      protobufs::TransformationPropagateInstructionUp message);
 
   TransformationPropagateInstructionUp(
       uint32_t block_id,

--- a/source/fuzz/transformation_push_id_through_variable.cpp
+++ b/source/fuzz/transformation_push_id_through_variable.cpp
@@ -21,9 +21,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationPushIdThroughVariable::TransformationPushIdThroughVariable(
-    const spvtools::fuzz::protobufs::TransformationPushIdThroughVariable&
-        message)
-    : message_(message) {}
+    protobufs::TransformationPushIdThroughVariable message)
+    : message_(std::move(message)) {}
 
 TransformationPushIdThroughVariable::TransformationPushIdThroughVariable(
     uint32_t value_id, uint32_t value_synonym_id, uint32_t variable_id,

--- a/source/fuzz/transformation_push_id_through_variable.h
+++ b/source/fuzz/transformation_push_id_through_variable.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationPushIdThroughVariable : public Transformation {
  public:
   explicit TransformationPushIdThroughVariable(
-      const protobufs::TransformationPushIdThroughVariable& message);
+      protobufs::TransformationPushIdThroughVariable message);
 
   TransformationPushIdThroughVariable(
       uint32_t value_id, uint32_t value_synonym_fresh_id,

--- a/source/fuzz/transformation_record_synonymous_constants.cpp
+++ b/source/fuzz/transformation_record_synonymous_constants.cpp
@@ -22,8 +22,8 @@ namespace fuzz {
 
 TransformationRecordSynonymousConstants::
     TransformationRecordSynonymousConstants(
-        const protobufs::TransformationRecordSynonymousConstants& message)
-    : message_(message) {}
+        protobufs::TransformationRecordSynonymousConstants message)
+    : message_(std::move(message)) {}
 
 TransformationRecordSynonymousConstants::
     TransformationRecordSynonymousConstants(uint32_t constant1_id,

--- a/source/fuzz/transformation_record_synonymous_constants.h
+++ b/source/fuzz/transformation_record_synonymous_constants.h
@@ -24,7 +24,7 @@ namespace fuzz {
 class TransformationRecordSynonymousConstants : public Transformation {
  public:
   explicit TransformationRecordSynonymousConstants(
-      const protobufs::TransformationRecordSynonymousConstants& message);
+      protobufs::TransformationRecordSynonymousConstants message);
 
   TransformationRecordSynonymousConstants(uint32_t constant1_id,
                                           uint32_t constant2_id);

--- a/source/fuzz/transformation_replace_add_sub_mul_with_carrying_extended.cpp
+++ b/source/fuzz/transformation_replace_add_sub_mul_with_carrying_extended.cpp
@@ -27,9 +27,8 @@ const uint32_t kArithmeticInstructionIndexRightInOperand = 1;
 
 TransformationReplaceAddSubMulWithCarryingExtended::
     TransformationReplaceAddSubMulWithCarryingExtended(
-        const spvtools::fuzz::protobufs::
-            TransformationReplaceAddSubMulWithCarryingExtended& message)
-    : message_(message) {}
+        protobufs::TransformationReplaceAddSubMulWithCarryingExtended message)
+    : message_(std::move(message)) {}
 
 TransformationReplaceAddSubMulWithCarryingExtended::
     TransformationReplaceAddSubMulWithCarryingExtended(uint32_t struct_fresh_id,

--- a/source/fuzz/transformation_replace_add_sub_mul_with_carrying_extended.h
+++ b/source/fuzz/transformation_replace_add_sub_mul_with_carrying_extended.h
@@ -27,8 +27,7 @@ class TransformationReplaceAddSubMulWithCarryingExtended
     : public Transformation {
  public:
   explicit TransformationReplaceAddSubMulWithCarryingExtended(
-      const protobufs::TransformationReplaceAddSubMulWithCarryingExtended&
-          message);
+      protobufs::TransformationReplaceAddSubMulWithCarryingExtended message);
 
   explicit TransformationReplaceAddSubMulWithCarryingExtended(
       uint32_t struct_fresh_id, uint32_t result_id);

--- a/source/fuzz/transformation_replace_boolean_constant_with_constant_binary.cpp
+++ b/source/fuzz/transformation_replace_boolean_constant_with_constant_binary.cpp
@@ -111,9 +111,9 @@ bool unsigned_int_binop_evaluates_to(T lhs, T rhs, SpvOp binop,
 
 TransformationReplaceBooleanConstantWithConstantBinary::
     TransformationReplaceBooleanConstantWithConstantBinary(
-        const spvtools::fuzz::protobufs::
-            TransformationReplaceBooleanConstantWithConstantBinary& message)
-    : message_(message) {}
+        protobufs::TransformationReplaceBooleanConstantWithConstantBinary
+            message)
+    : message_(std::move(message)) {}
 
 TransformationReplaceBooleanConstantWithConstantBinary::
     TransformationReplaceBooleanConstantWithConstantBinary(

--- a/source/fuzz/transformation_replace_boolean_constant_with_constant_binary.h
+++ b/source/fuzz/transformation_replace_boolean_constant_with_constant_binary.h
@@ -27,7 +27,7 @@ class TransformationReplaceBooleanConstantWithConstantBinary
     : public Transformation {
  public:
   explicit TransformationReplaceBooleanConstantWithConstantBinary(
-      const protobufs::TransformationReplaceBooleanConstantWithConstantBinary&
+      protobufs::TransformationReplaceBooleanConstantWithConstantBinary
           message);
 
   TransformationReplaceBooleanConstantWithConstantBinary(

--- a/source/fuzz/transformation_replace_branch_from_dead_block_with_exit.cpp
+++ b/source/fuzz/transformation_replace_branch_from_dead_block_with_exit.cpp
@@ -21,9 +21,8 @@ namespace fuzz {
 
 TransformationReplaceBranchFromDeadBlockWithExit::
     TransformationReplaceBranchFromDeadBlockWithExit(
-        const spvtools::fuzz::protobufs::
-            TransformationReplaceBranchFromDeadBlockWithExit& message)
-    : message_(message) {}
+        protobufs::TransformationReplaceBranchFromDeadBlockWithExit message)
+    : message_(std::move(message)) {}
 
 TransformationReplaceBranchFromDeadBlockWithExit::
     TransformationReplaceBranchFromDeadBlockWithExit(uint32_t block_id,

--- a/source/fuzz/transformation_replace_branch_from_dead_block_with_exit.h
+++ b/source/fuzz/transformation_replace_branch_from_dead_block_with_exit.h
@@ -27,8 +27,7 @@ namespace fuzz {
 class TransformationReplaceBranchFromDeadBlockWithExit : public Transformation {
  public:
   explicit TransformationReplaceBranchFromDeadBlockWithExit(
-      const protobufs::TransformationReplaceBranchFromDeadBlockWithExit&
-          message);
+      protobufs::TransformationReplaceBranchFromDeadBlockWithExit message);
 
   TransformationReplaceBranchFromDeadBlockWithExit(uint32_t block_id,
                                                    SpvOp opcode,

--- a/source/fuzz/transformation_replace_constant_with_uniform.cpp
+++ b/source/fuzz/transformation_replace_constant_with_uniform.cpp
@@ -22,9 +22,8 @@ namespace fuzz {
 
 TransformationReplaceConstantWithUniform::
     TransformationReplaceConstantWithUniform(
-        const spvtools::fuzz::protobufs::
-            TransformationReplaceConstantWithUniform& message)
-    : message_(message) {}
+        protobufs::TransformationReplaceConstantWithUniform message)
+    : message_(std::move(message)) {}
 
 TransformationReplaceConstantWithUniform::
     TransformationReplaceConstantWithUniform(

--- a/source/fuzz/transformation_replace_constant_with_uniform.h
+++ b/source/fuzz/transformation_replace_constant_with_uniform.h
@@ -28,7 +28,7 @@ namespace fuzz {
 class TransformationReplaceConstantWithUniform : public Transformation {
  public:
   explicit TransformationReplaceConstantWithUniform(
-      const protobufs::TransformationReplaceConstantWithUniform& message);
+      protobufs::TransformationReplaceConstantWithUniform message);
 
   TransformationReplaceConstantWithUniform(
       protobufs::IdUseDescriptor id_use,

--- a/source/fuzz/transformation_replace_copy_memory_with_load_store.cpp
+++ b/source/fuzz/transformation_replace_copy_memory_with_load_store.cpp
@@ -22,9 +22,8 @@ namespace fuzz {
 
 TransformationReplaceCopyMemoryWithLoadStore::
     TransformationReplaceCopyMemoryWithLoadStore(
-        const spvtools::fuzz::protobufs::
-            TransformationReplaceCopyMemoryWithLoadStore& message)
-    : message_(message) {}
+        protobufs::TransformationReplaceCopyMemoryWithLoadStore message)
+    : message_(std::move(message)) {}
 
 TransformationReplaceCopyMemoryWithLoadStore::
     TransformationReplaceCopyMemoryWithLoadStore(

--- a/source/fuzz/transformation_replace_copy_memory_with_load_store.h
+++ b/source/fuzz/transformation_replace_copy_memory_with_load_store.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationReplaceCopyMemoryWithLoadStore : public Transformation {
  public:
   explicit TransformationReplaceCopyMemoryWithLoadStore(
-      const protobufs::TransformationReplaceCopyMemoryWithLoadStore& message);
+      protobufs::TransformationReplaceCopyMemoryWithLoadStore message);
 
   TransformationReplaceCopyMemoryWithLoadStore(
       uint32_t fresh_id, const protobufs::InstructionDescriptor&

--- a/source/fuzz/transformation_replace_copy_object_with_store_load.cpp
+++ b/source/fuzz/transformation_replace_copy_object_with_store_load.cpp
@@ -22,9 +22,8 @@ namespace fuzz {
 
 TransformationReplaceCopyObjectWithStoreLoad::
     TransformationReplaceCopyObjectWithStoreLoad(
-        const spvtools::fuzz::protobufs::
-            TransformationReplaceCopyObjectWithStoreLoad& message)
-    : message_(message) {}
+        protobufs::TransformationReplaceCopyObjectWithStoreLoad message)
+    : message_(std::move(message)) {}
 
 TransformationReplaceCopyObjectWithStoreLoad::
     TransformationReplaceCopyObjectWithStoreLoad(

--- a/source/fuzz/transformation_replace_copy_object_with_store_load.h
+++ b/source/fuzz/transformation_replace_copy_object_with_store_load.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationReplaceCopyObjectWithStoreLoad : public Transformation {
  public:
   explicit TransformationReplaceCopyObjectWithStoreLoad(
-      const protobufs::TransformationReplaceCopyObjectWithStoreLoad& message);
+      protobufs::TransformationReplaceCopyObjectWithStoreLoad message);
 
   TransformationReplaceCopyObjectWithStoreLoad(
       uint32_t copy_object_result_id, uint32_t fresh_variable_id,

--- a/source/fuzz/transformation_replace_id_with_synonym.cpp
+++ b/source/fuzz/transformation_replace_id_with_synonym.cpp
@@ -26,9 +26,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationReplaceIdWithSynonym::TransformationReplaceIdWithSynonym(
-    const spvtools::fuzz::protobufs::TransformationReplaceIdWithSynonym&
-        message)
-    : message_(message) {}
+    protobufs::TransformationReplaceIdWithSynonym message)
+    : message_(std::move(message)) {}
 
 TransformationReplaceIdWithSynonym::TransformationReplaceIdWithSynonym(
     protobufs::IdUseDescriptor id_use_descriptor, uint32_t synonymous_id) {

--- a/source/fuzz/transformation_replace_id_with_synonym.h
+++ b/source/fuzz/transformation_replace_id_with_synonym.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationReplaceIdWithSynonym : public Transformation {
  public:
   explicit TransformationReplaceIdWithSynonym(
-      const protobufs::TransformationReplaceIdWithSynonym& message);
+      protobufs::TransformationReplaceIdWithSynonym message);
 
   TransformationReplaceIdWithSynonym(
       protobufs::IdUseDescriptor id_use_descriptor, uint32_t synonymous_id);

--- a/source/fuzz/transformation_replace_irrelevant_id.cpp
+++ b/source/fuzz/transformation_replace_irrelevant_id.cpp
@@ -21,8 +21,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationReplaceIrrelevantId::TransformationReplaceIrrelevantId(
-    const protobufs::TransformationReplaceIrrelevantId& message)
-    : message_(message) {}
+    protobufs::TransformationReplaceIrrelevantId message)
+    : message_(std::move(message)) {}
 
 TransformationReplaceIrrelevantId::TransformationReplaceIrrelevantId(
     const protobufs::IdUseDescriptor& id_use_descriptor,

--- a/source/fuzz/transformation_replace_irrelevant_id.h
+++ b/source/fuzz/transformation_replace_irrelevant_id.h
@@ -23,7 +23,7 @@ namespace fuzz {
 class TransformationReplaceIrrelevantId : public Transformation {
  public:
   explicit TransformationReplaceIrrelevantId(
-      const protobufs::TransformationReplaceIrrelevantId& message);
+      protobufs::TransformationReplaceIrrelevantId message);
 
   TransformationReplaceIrrelevantId(
       const protobufs::IdUseDescriptor& id_use_descriptor,

--- a/source/fuzz/transformation_replace_linear_algebra_instruction.cpp
+++ b/source/fuzz/transformation_replace_linear_algebra_instruction.cpp
@@ -22,9 +22,8 @@ namespace fuzz {
 
 TransformationReplaceLinearAlgebraInstruction::
     TransformationReplaceLinearAlgebraInstruction(
-        const spvtools::fuzz::protobufs::
-            TransformationReplaceLinearAlgebraInstruction& message)
-    : message_(message) {}
+        protobufs::TransformationReplaceLinearAlgebraInstruction message)
+    : message_(std::move(message)) {}
 
 TransformationReplaceLinearAlgebraInstruction::
     TransformationReplaceLinearAlgebraInstruction(

--- a/source/fuzz/transformation_replace_linear_algebra_instruction.h
+++ b/source/fuzz/transformation_replace_linear_algebra_instruction.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationReplaceLinearAlgebraInstruction : public Transformation {
  public:
   explicit TransformationReplaceLinearAlgebraInstruction(
-      const protobufs::TransformationReplaceLinearAlgebraInstruction& message);
+      protobufs::TransformationReplaceLinearAlgebraInstruction message);
 
   TransformationReplaceLinearAlgebraInstruction(
       const std::vector<uint32_t>& fresh_ids,

--- a/source/fuzz/transformation_replace_load_store_with_copy_memory.cpp
+++ b/source/fuzz/transformation_replace_load_store_with_copy_memory.cpp
@@ -29,9 +29,8 @@ const uint32_t kOpLoadOperandIndexSourceVariable = 2;
 
 TransformationReplaceLoadStoreWithCopyMemory::
     TransformationReplaceLoadStoreWithCopyMemory(
-        const spvtools::fuzz::protobufs::
-            TransformationReplaceLoadStoreWithCopyMemory& message)
-    : message_(message) {}
+        protobufs::TransformationReplaceLoadStoreWithCopyMemory message)
+    : message_(std::move(message)) {}
 
 TransformationReplaceLoadStoreWithCopyMemory::
     TransformationReplaceLoadStoreWithCopyMemory(

--- a/source/fuzz/transformation_replace_load_store_with_copy_memory.h
+++ b/source/fuzz/transformation_replace_load_store_with_copy_memory.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationReplaceLoadStoreWithCopyMemory : public Transformation {
  public:
   explicit TransformationReplaceLoadStoreWithCopyMemory(
-      const protobufs::TransformationReplaceLoadStoreWithCopyMemory& message);
+      protobufs::TransformationReplaceLoadStoreWithCopyMemory message);
 
   TransformationReplaceLoadStoreWithCopyMemory(
       const protobufs::InstructionDescriptor& load_instruction_descriptor,

--- a/source/fuzz/transformation_replace_opphi_id_from_dead_predecessor.cpp
+++ b/source/fuzz/transformation_replace_opphi_id_from_dead_predecessor.cpp
@@ -21,9 +21,8 @@ namespace fuzz {
 
 TransformationReplaceOpPhiIdFromDeadPredecessor::
     TransformationReplaceOpPhiIdFromDeadPredecessor(
-        const protobufs::TransformationReplaceOpPhiIdFromDeadPredecessor&
-            message)
-    : message_(message) {}
+        protobufs::TransformationReplaceOpPhiIdFromDeadPredecessor message)
+    : message_(std::move(message)) {}
 
 TransformationReplaceOpPhiIdFromDeadPredecessor::
     TransformationReplaceOpPhiIdFromDeadPredecessor(uint32_t opphi_id,

--- a/source/fuzz/transformation_replace_opphi_id_from_dead_predecessor.h
+++ b/source/fuzz/transformation_replace_opphi_id_from_dead_predecessor.h
@@ -23,8 +23,7 @@ namespace fuzz {
 class TransformationReplaceOpPhiIdFromDeadPredecessor : public Transformation {
  public:
   explicit TransformationReplaceOpPhiIdFromDeadPredecessor(
-      const protobufs::TransformationReplaceOpPhiIdFromDeadPredecessor&
-          message);
+      protobufs::TransformationReplaceOpPhiIdFromDeadPredecessor message);
 
   TransformationReplaceOpPhiIdFromDeadPredecessor(uint32_t opphi_id,
                                                   uint32_t pred_label_id,

--- a/source/fuzz/transformation_replace_opselect_with_conditional_branch.cpp
+++ b/source/fuzz/transformation_replace_opselect_with_conditional_branch.cpp
@@ -20,9 +20,8 @@ namespace spvtools {
 namespace fuzz {
 TransformationReplaceOpSelectWithConditionalBranch::
     TransformationReplaceOpSelectWithConditionalBranch(
-        const spvtools::fuzz::protobufs::
-            TransformationReplaceOpSelectWithConditionalBranch& message)
-    : message_(message) {}
+        protobufs::TransformationReplaceOpSelectWithConditionalBranch message)
+    : message_(std::move(message)) {}
 
 TransformationReplaceOpSelectWithConditionalBranch::
     TransformationReplaceOpSelectWithConditionalBranch(

--- a/source/fuzz/transformation_replace_opselect_with_conditional_branch.h
+++ b/source/fuzz/transformation_replace_opselect_with_conditional_branch.h
@@ -24,8 +24,7 @@ class TransformationReplaceOpSelectWithConditionalBranch
     : public Transformation {
  public:
   explicit TransformationReplaceOpSelectWithConditionalBranch(
-      const protobufs::TransformationReplaceOpSelectWithConditionalBranch&
-          message);
+      protobufs::TransformationReplaceOpSelectWithConditionalBranch message);
 
   TransformationReplaceOpSelectWithConditionalBranch(uint32_t select_id,
                                                      uint32_t true_block_id,

--- a/source/fuzz/transformation_replace_parameter_with_global.cpp
+++ b/source/fuzz/transformation_replace_parameter_with_global.cpp
@@ -23,8 +23,8 @@ namespace fuzz {
 
 TransformationReplaceParameterWithGlobal::
     TransformationReplaceParameterWithGlobal(
-        const protobufs::TransformationReplaceParameterWithGlobal& message)
-    : message_(message) {}
+        protobufs::TransformationReplaceParameterWithGlobal message)
+    : message_(std::move(message)) {}
 
 TransformationReplaceParameterWithGlobal::
     TransformationReplaceParameterWithGlobal(

--- a/source/fuzz/transformation_replace_parameter_with_global.h
+++ b/source/fuzz/transformation_replace_parameter_with_global.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationReplaceParameterWithGlobal : public Transformation {
  public:
   explicit TransformationReplaceParameterWithGlobal(
-      const protobufs::TransformationReplaceParameterWithGlobal& message);
+      protobufs::TransformationReplaceParameterWithGlobal message);
 
   TransformationReplaceParameterWithGlobal(uint32_t function_type_fresh_id,
                                            uint32_t parameter_id,

--- a/source/fuzz/transformation_replace_params_with_struct.cpp
+++ b/source/fuzz/transformation_replace_params_with_struct.cpp
@@ -22,8 +22,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationReplaceParamsWithStruct::TransformationReplaceParamsWithStruct(
-    const protobufs::TransformationReplaceParamsWithStruct& message)
-    : message_(message) {}
+    protobufs::TransformationReplaceParamsWithStruct message)
+    : message_(std::move(message)) {}
 
 TransformationReplaceParamsWithStruct::TransformationReplaceParamsWithStruct(
     const std::vector<uint32_t>& parameter_id, uint32_t fresh_function_type_id,

--- a/source/fuzz/transformation_replace_params_with_struct.h
+++ b/source/fuzz/transformation_replace_params_with_struct.h
@@ -28,7 +28,7 @@ namespace fuzz {
 class TransformationReplaceParamsWithStruct : public Transformation {
  public:
   explicit TransformationReplaceParamsWithStruct(
-      const protobufs::TransformationReplaceParamsWithStruct& message);
+      protobufs::TransformationReplaceParamsWithStruct message);
 
   TransformationReplaceParamsWithStruct(
       const std::vector<uint32_t>& parameter_id,

--- a/source/fuzz/transformation_set_function_control.cpp
+++ b/source/fuzz/transformation_set_function_control.cpp
@@ -18,8 +18,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationSetFunctionControl::TransformationSetFunctionControl(
-    const spvtools::fuzz::protobufs::TransformationSetFunctionControl& message)
-    : message_(message) {}
+    protobufs::TransformationSetFunctionControl message)
+    : message_(std::move(message)) {}
 
 TransformationSetFunctionControl::TransformationSetFunctionControl(
     uint32_t function_id, uint32_t function_control) {

--- a/source/fuzz/transformation_set_function_control.h
+++ b/source/fuzz/transformation_set_function_control.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationSetFunctionControl : public Transformation {
  public:
   explicit TransformationSetFunctionControl(
-      const protobufs::TransformationSetFunctionControl& message);
+      protobufs::TransformationSetFunctionControl message);
 
   TransformationSetFunctionControl(uint32_t function_id,
                                    uint32_t function_control);

--- a/source/fuzz/transformation_set_loop_control.cpp
+++ b/source/fuzz/transformation_set_loop_control.cpp
@@ -18,8 +18,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationSetLoopControl::TransformationSetLoopControl(
-    const spvtools::fuzz::protobufs::TransformationSetLoopControl& message)
-    : message_(message) {}
+    protobufs::TransformationSetLoopControl message)
+    : message_(std::move(message)) {}
 
 TransformationSetLoopControl::TransformationSetLoopControl(
     uint32_t block_id, uint32_t loop_control, uint32_t peel_count,

--- a/source/fuzz/transformation_set_loop_control.h
+++ b/source/fuzz/transformation_set_loop_control.h
@@ -29,7 +29,7 @@ class TransformationSetLoopControl : public Transformation {
   const static uint32_t kLoopControlFirstLiteralInOperandIndex = 3;
 
   explicit TransformationSetLoopControl(
-      const protobufs::TransformationSetLoopControl& message);
+      protobufs::TransformationSetLoopControl message);
 
   TransformationSetLoopControl(uint32_t block_id, uint32_t loop_control,
                                uint32_t peel_count, uint32_t partial_count);

--- a/source/fuzz/transformation_set_memory_operands_mask.cpp
+++ b/source/fuzz/transformation_set_memory_operands_mask.cpp
@@ -29,9 +29,8 @@ const uint32_t kOpCopyMemorySizedFirstMemoryOperandsMaskIndex = 3;
 }  // namespace
 
 TransformationSetMemoryOperandsMask::TransformationSetMemoryOperandsMask(
-    const spvtools::fuzz::protobufs::TransformationSetMemoryOperandsMask&
-        message)
-    : message_(message) {}
+    protobufs::TransformationSetMemoryOperandsMask message)
+    : message_(std::move(message)) {}
 
 TransformationSetMemoryOperandsMask::TransformationSetMemoryOperandsMask(
     const protobufs::InstructionDescriptor& memory_access_instruction,

--- a/source/fuzz/transformation_set_memory_operands_mask.h
+++ b/source/fuzz/transformation_set_memory_operands_mask.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationSetMemoryOperandsMask : public Transformation {
  public:
   explicit TransformationSetMemoryOperandsMask(
-      const protobufs::TransformationSetMemoryOperandsMask& message);
+      protobufs::TransformationSetMemoryOperandsMask message);
 
   TransformationSetMemoryOperandsMask(
       const protobufs::InstructionDescriptor& memory_access_instruction,

--- a/source/fuzz/transformation_set_selection_control.cpp
+++ b/source/fuzz/transformation_set_selection_control.cpp
@@ -18,8 +18,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationSetSelectionControl::TransformationSetSelectionControl(
-    const spvtools::fuzz::protobufs::TransformationSetSelectionControl& message)
-    : message_(message) {}
+    protobufs::TransformationSetSelectionControl message)
+    : message_(std::move(message)) {}
 
 TransformationSetSelectionControl::TransformationSetSelectionControl(
     uint32_t block_id, uint32_t selection_control) {

--- a/source/fuzz/transformation_set_selection_control.h
+++ b/source/fuzz/transformation_set_selection_control.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationSetSelectionControl : public Transformation {
  public:
   explicit TransformationSetSelectionControl(
-      const protobufs::TransformationSetSelectionControl& message);
+      protobufs::TransformationSetSelectionControl message);
 
   TransformationSetSelectionControl(uint32_t block_id,
                                     uint32_t selection_control);

--- a/source/fuzz/transformation_split_block.cpp
+++ b/source/fuzz/transformation_split_block.cpp
@@ -24,8 +24,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationSplitBlock::TransformationSplitBlock(
-    const spvtools::fuzz::protobufs::TransformationSplitBlock& message)
-    : message_(message) {}
+    protobufs::TransformationSplitBlock message)
+    : message_(std::move(message)) {}
 
 TransformationSplitBlock::TransformationSplitBlock(
     const protobufs::InstructionDescriptor& instruction_to_split_before,

--- a/source/fuzz/transformation_split_block.h
+++ b/source/fuzz/transformation_split_block.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationSplitBlock : public Transformation {
  public:
   explicit TransformationSplitBlock(
-      const protobufs::TransformationSplitBlock& message);
+      protobufs::TransformationSplitBlock message);
 
   TransformationSplitBlock(
       const protobufs::InstructionDescriptor& instruction_to_split_before,

--- a/source/fuzz/transformation_store.cpp
+++ b/source/fuzz/transformation_store.cpp
@@ -20,9 +20,8 @@
 namespace spvtools {
 namespace fuzz {
 
-TransformationStore::TransformationStore(
-    const spvtools::fuzz::protobufs::TransformationStore& message)
-    : message_(message) {}
+TransformationStore::TransformationStore(protobufs::TransformationStore message)
+    : message_(std::move(message)) {}
 
 TransformationStore::TransformationStore(
     uint32_t pointer_id, uint32_t value_id,

--- a/source/fuzz/transformation_store.h
+++ b/source/fuzz/transformation_store.h
@@ -25,7 +25,7 @@ namespace fuzz {
 
 class TransformationStore : public Transformation {
  public:
-  explicit TransformationStore(const protobufs::TransformationStore& message);
+  explicit TransformationStore(protobufs::TransformationStore message);
 
   TransformationStore(
       uint32_t pointer_id, uint32_t value_id,

--- a/source/fuzz/transformation_swap_commutable_operands.cpp
+++ b/source/fuzz/transformation_swap_commutable_operands.cpp
@@ -21,9 +21,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationSwapCommutableOperands::TransformationSwapCommutableOperands(
-    const spvtools::fuzz::protobufs::TransformationSwapCommutableOperands&
-        message)
-    : message_(message) {}
+    protobufs::TransformationSwapCommutableOperands message)
+    : message_(std::move(message)) {}
 
 TransformationSwapCommutableOperands::TransformationSwapCommutableOperands(
     const protobufs::InstructionDescriptor& instruction_descriptor) {

--- a/source/fuzz/transformation_swap_commutable_operands.h
+++ b/source/fuzz/transformation_swap_commutable_operands.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationSwapCommutableOperands : public Transformation {
  public:
   explicit TransformationSwapCommutableOperands(
-      const protobufs::TransformationSwapCommutableOperands& message);
+      protobufs::TransformationSwapCommutableOperands message);
 
   TransformationSwapCommutableOperands(
       const protobufs::InstructionDescriptor& instruction_descriptor);

--- a/source/fuzz/transformation_swap_conditional_branch_operands.cpp
+++ b/source/fuzz/transformation_swap_conditional_branch_operands.cpp
@@ -22,9 +22,8 @@ namespace fuzz {
 
 TransformationSwapConditionalBranchOperands::
     TransformationSwapConditionalBranchOperands(
-        const spvtools::fuzz::protobufs::
-            TransformationSwapConditionalBranchOperands& message)
-    : message_(message) {}
+        protobufs::TransformationSwapConditionalBranchOperands message)
+    : message_(std::move(message)) {}
 
 TransformationSwapConditionalBranchOperands::
     TransformationSwapConditionalBranchOperands(

--- a/source/fuzz/transformation_swap_conditional_branch_operands.h
+++ b/source/fuzz/transformation_swap_conditional_branch_operands.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationSwapConditionalBranchOperands : public Transformation {
  public:
   explicit TransformationSwapConditionalBranchOperands(
-      const protobufs::TransformationSwapConditionalBranchOperands& message);
+      protobufs::TransformationSwapConditionalBranchOperands message);
 
   TransformationSwapConditionalBranchOperands(
       const protobufs::InstructionDescriptor& instruction_descriptor,

--- a/source/fuzz/transformation_toggle_access_chain_instruction.cpp
+++ b/source/fuzz/transformation_toggle_access_chain_instruction.cpp
@@ -22,9 +22,8 @@ namespace fuzz {
 
 TransformationToggleAccessChainInstruction::
     TransformationToggleAccessChainInstruction(
-        const spvtools::fuzz::protobufs::
-            TransformationToggleAccessChainInstruction& message)
-    : message_(message) {}
+        protobufs::TransformationToggleAccessChainInstruction message)
+    : message_(std::move(message)) {}
 
 TransformationToggleAccessChainInstruction::
     TransformationToggleAccessChainInstruction(

--- a/source/fuzz/transformation_toggle_access_chain_instruction.h
+++ b/source/fuzz/transformation_toggle_access_chain_instruction.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationToggleAccessChainInstruction : public Transformation {
  public:
   explicit TransformationToggleAccessChainInstruction(
-      const protobufs::TransformationToggleAccessChainInstruction& message);
+      protobufs::TransformationToggleAccessChainInstruction message);
 
   TransformationToggleAccessChainInstruction(
       const protobufs::InstructionDescriptor& instruction_descriptor);

--- a/source/fuzz/transformation_vector_shuffle.cpp
+++ b/source/fuzz/transformation_vector_shuffle.cpp
@@ -21,8 +21,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationVectorShuffle::TransformationVectorShuffle(
-    const spvtools::fuzz::protobufs::TransformationVectorShuffle& message)
-    : message_(message) {}
+    protobufs::TransformationVectorShuffle message)
+    : message_(std::move(message)) {}
 
 TransformationVectorShuffle::TransformationVectorShuffle(
     const protobufs::InstructionDescriptor& instruction_to_insert_before,

--- a/source/fuzz/transformation_vector_shuffle.h
+++ b/source/fuzz/transformation_vector_shuffle.h
@@ -27,7 +27,7 @@ namespace fuzz {
 class TransformationVectorShuffle : public Transformation {
  public:
   explicit TransformationVectorShuffle(
-      const protobufs::TransformationVectorShuffle& message);
+      protobufs::TransformationVectorShuffle message);
 
   TransformationVectorShuffle(
       const protobufs::InstructionDescriptor& instruction_to_insert_before,

--- a/source/fuzz/transformation_wrap_early_terminator_in_function.cpp
+++ b/source/fuzz/transformation_wrap_early_terminator_in_function.cpp
@@ -23,9 +23,8 @@ namespace fuzz {
 
 TransformationWrapEarlyTerminatorInFunction::
     TransformationWrapEarlyTerminatorInFunction(
-        const spvtools::fuzz::protobufs::
-            TransformationWrapEarlyTerminatorInFunction& message)
-    : message_(message) {}
+        protobufs::TransformationWrapEarlyTerminatorInFunction message)
+    : message_(std::move(message)) {}
 
 TransformationWrapEarlyTerminatorInFunction::
     TransformationWrapEarlyTerminatorInFunction(

--- a/source/fuzz/transformation_wrap_early_terminator_in_function.h
+++ b/source/fuzz/transformation_wrap_early_terminator_in_function.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationWrapEarlyTerminatorInFunction : public Transformation {
  public:
   explicit TransformationWrapEarlyTerminatorInFunction(
-      const protobufs::TransformationWrapEarlyTerminatorInFunction& message);
+      protobufs::TransformationWrapEarlyTerminatorInFunction message);
 
   TransformationWrapEarlyTerminatorInFunction(
       uint32_t fresh_id,

--- a/source/fuzz/transformation_wrap_region_in_selection.cpp
+++ b/source/fuzz/transformation_wrap_region_in_selection.cpp
@@ -20,8 +20,8 @@ namespace spvtools {
 namespace fuzz {
 
 TransformationWrapRegionInSelection::TransformationWrapRegionInSelection(
-    const protobufs::TransformationWrapRegionInSelection& message)
-    : message_(message) {}
+    protobufs::TransformationWrapRegionInSelection message)
+    : message_(std::move(message)) {}
 
 TransformationWrapRegionInSelection::TransformationWrapRegionInSelection(
     uint32_t region_entry_block_id, uint32_t region_exit_block_id,

--- a/source/fuzz/transformation_wrap_region_in_selection.h
+++ b/source/fuzz/transformation_wrap_region_in_selection.h
@@ -26,7 +26,7 @@ namespace fuzz {
 class TransformationWrapRegionInSelection : public Transformation {
  public:
   explicit TransformationWrapRegionInSelection(
-      const protobufs::TransformationWrapRegionInSelection& message);
+      protobufs::TransformationWrapRegionInSelection message);
 
   TransformationWrapRegionInSelection(uint32_t region_entry_block_id,
                                       uint32_t region_exit_block_id,


### PR DESCRIPTION
Adapts all transformation classes so that their protobuf message is
passed by value and then moved into the message_ field.