### PR TITLE
spirv-fuzz: Remove destructors from FuzzerPass subclasses

### DIFF
--- a/source/fuzz/fuzzer_pass_add_access_chains.cpp
+++ b/source/fuzz/fuzzer_pass_add_access_chains.cpp
@@ -27,8 +27,6 @@ FuzzerPassAddAccessChains::FuzzerPassAddAccessChains(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddAccessChains::~FuzzerPassAddAccessChains() = default;
-
 void FuzzerPassAddAccessChains::Apply() {
   ForEachInstructionWithInstructionDescriptor(
       [this](opt::Function* function, opt::BasicBlock* block,

--- a/source/fuzz/fuzzer_pass_add_access_chains.h
+++ b/source/fuzz/fuzzer_pass_add_access_chains.h
@@ -30,8 +30,6 @@ class FuzzerPassAddAccessChains : public FuzzerPass {
                             FuzzerContext* fuzzer_context,
                             protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddAccessChains();
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_add_bit_instruction_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_add_bit_instruction_synonyms.cpp
@@ -28,9 +28,6 @@ FuzzerPassAddBitInstructionSynonyms::FuzzerPassAddBitInstructionSynonyms(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddBitInstructionSynonyms::~FuzzerPassAddBitInstructionSynonyms() =
-    default;
-
 void FuzzerPassAddBitInstructionSynonyms::Apply() {
   for (auto& function : *GetIRContext()->module()) {
     for (auto& block : function) {

--- a/source/fuzz/fuzzer_pass_add_bit_instruction_synonyms.h
+++ b/source/fuzz/fuzzer_pass_add_bit_instruction_synonyms.h
@@ -30,8 +30,6 @@ class FuzzerPassAddBitInstructionSynonyms : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddBitInstructionSynonyms();
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_add_composite_extract.cpp
+++ b/source/fuzz/fuzzer_pass_add_composite_extract.cpp
@@ -30,8 +30,6 @@ FuzzerPassAddCompositeExtract::FuzzerPassAddCompositeExtract(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddCompositeExtract::~FuzzerPassAddCompositeExtract() = default;
-
 void FuzzerPassAddCompositeExtract::Apply() {
   std::vector<const protobufs::DataDescriptor*> composite_synonyms;
   for (const auto* dd :

--- a/source/fuzz/fuzzer_pass_add_composite_extract.h
+++ b/source/fuzz/fuzzer_pass_add_composite_extract.h
@@ -29,8 +29,6 @@ class FuzzerPassAddCompositeExtract : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddCompositeExtract() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_add_composite_inserts.cpp
+++ b/source/fuzz/fuzzer_pass_add_composite_inserts.cpp
@@ -29,8 +29,6 @@ FuzzerPassAddCompositeInserts::FuzzerPassAddCompositeInserts(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddCompositeInserts::~FuzzerPassAddCompositeInserts() = default;
-
 void FuzzerPassAddCompositeInserts::Apply() {
   ForEachInstructionWithInstructionDescriptor(
       [this](opt::Function* function, opt::BasicBlock* block,

--- a/source/fuzz/fuzzer_pass_add_composite_inserts.h
+++ b/source/fuzz/fuzzer_pass_add_composite_inserts.h
@@ -29,7 +29,6 @@ class FuzzerPassAddCompositeInserts : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddCompositeInserts();
   void Apply() override;
 
   // Checks if any component of a composite is a pointer.

--- a/source/fuzz/fuzzer_pass_add_composite_types.cpp
+++ b/source/fuzz/fuzzer_pass_add_composite_types.cpp
@@ -28,8 +28,6 @@ FuzzerPassAddCompositeTypes::FuzzerPassAddCompositeTypes(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddCompositeTypes::~FuzzerPassAddCompositeTypes() = default;
-
 void FuzzerPassAddCompositeTypes::Apply() {
   MaybeAddMissingVectorTypes();
   MaybeAddMissingMatrixTypes();

--- a/source/fuzz/fuzzer_pass_add_composite_types.h
+++ b/source/fuzz/fuzzer_pass_add_composite_types.h
@@ -29,8 +29,6 @@ class FuzzerPassAddCompositeTypes : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddCompositeTypes();
-
   void Apply() override;
 
  private:

--- a/source/fuzz/fuzzer_pass_add_copy_memory.cpp
+++ b/source/fuzz/fuzzer_pass_add_copy_memory.cpp
@@ -29,8 +29,6 @@ FuzzerPassAddCopyMemory::FuzzerPassAddCopyMemory(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddCopyMemory::~FuzzerPassAddCopyMemory() = default;
-
 void FuzzerPassAddCopyMemory::Apply() {
   ForEachInstructionWithInstructionDescriptor(
       [this](opt::Function* function, opt::BasicBlock* block,

--- a/source/fuzz/fuzzer_pass_add_copy_memory.h
+++ b/source/fuzz/fuzzer_pass_add_copy_memory.h
@@ -29,8 +29,6 @@ class FuzzerPassAddCopyMemory : public FuzzerPass {
                           FuzzerContext* fuzzer_context,
                           protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddCopyMemory() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_add_dead_blocks.cpp
+++ b/source/fuzz/fuzzer_pass_add_dead_blocks.cpp
@@ -27,8 +27,6 @@ FuzzerPassAddDeadBlocks::FuzzerPassAddDeadBlocks(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddDeadBlocks::~FuzzerPassAddDeadBlocks() = default;
-
 void FuzzerPassAddDeadBlocks::Apply() {
   // We iterate over all blocks in the module collecting up those at which we
   // might add a branch to a new dead block.  We then loop over all such

--- a/source/fuzz/fuzzer_pass_add_dead_blocks.h
+++ b/source/fuzz/fuzzer_pass_add_dead_blocks.h
@@ -29,8 +29,6 @@ class FuzzerPassAddDeadBlocks : public FuzzerPass {
                           FuzzerContext* fuzzer_context,
                           protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddDeadBlocks();
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_add_dead_breaks.cpp
+++ b/source/fuzz/fuzzer_pass_add_dead_breaks.cpp
@@ -28,8 +28,6 @@ FuzzerPassAddDeadBreaks::FuzzerPassAddDeadBreaks(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddDeadBreaks::~FuzzerPassAddDeadBreaks() = default;
-
 void FuzzerPassAddDeadBreaks::Apply() {
   // We first collect up lots of possibly-applicable transformations.
   std::vector<TransformationAddDeadBreak> candidate_transformations;

--- a/source/fuzz/fuzzer_pass_add_dead_breaks.h
+++ b/source/fuzz/fuzzer_pass_add_dead_breaks.h
@@ -28,8 +28,6 @@ class FuzzerPassAddDeadBreaks : public FuzzerPass {
                           FuzzerContext* fuzzer_context,
                           protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddDeadBreaks();
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_add_dead_continues.cpp
+++ b/source/fuzz/fuzzer_pass_add_dead_continues.cpp
@@ -28,8 +28,6 @@ FuzzerPassAddDeadContinues::FuzzerPassAddDeadContinues(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddDeadContinues::~FuzzerPassAddDeadContinues() = default;
-
 void FuzzerPassAddDeadContinues::Apply() {
   // Consider every block in every function.
   for (auto& function : *GetIRContext()->module()) {

--- a/source/fuzz/fuzzer_pass_add_dead_continues.h
+++ b/source/fuzz/fuzzer_pass_add_dead_continues.h
@@ -28,8 +28,6 @@ class FuzzerPassAddDeadContinues : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddDeadContinues();
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_add_equation_instructions.cpp
+++ b/source/fuzz/fuzzer_pass_add_equation_instructions.cpp
@@ -49,9 +49,6 @@ FuzzerPassAddEquationInstructions::FuzzerPassAddEquationInstructions(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddEquationInstructions::~FuzzerPassAddEquationInstructions() =
-    default;
-
 void FuzzerPassAddEquationInstructions::Apply() {
   ForEachInstructionWithInstructionDescriptor(
       [this](opt::Function* function, opt::BasicBlock* block,

--- a/source/fuzz/fuzzer_pass_add_equation_instructions.h
+++ b/source/fuzz/fuzzer_pass_add_equation_instructions.h
@@ -31,8 +31,6 @@ class FuzzerPassAddEquationInstructions : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddEquationInstructions();
-
   void Apply() override;
 
  private:

--- a/source/fuzz/fuzzer_pass_add_function_calls.cpp
+++ b/source/fuzz/fuzzer_pass_add_function_calls.cpp
@@ -30,8 +30,6 @@ FuzzerPassAddFunctionCalls::FuzzerPassAddFunctionCalls(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddFunctionCalls::~FuzzerPassAddFunctionCalls() = default;
-
 void FuzzerPassAddFunctionCalls::Apply() {
   ForEachInstructionWithInstructionDescriptor(
       [this](opt::Function* function, opt::BasicBlock* block,

--- a/source/fuzz/fuzzer_pass_add_function_calls.h
+++ b/source/fuzz/fuzzer_pass_add_function_calls.h
@@ -29,8 +29,6 @@ class FuzzerPassAddFunctionCalls : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddFunctionCalls();
-
   void Apply() override;
 
  private:

--- a/source/fuzz/fuzzer_pass_add_global_variables.cpp
+++ b/source/fuzz/fuzzer_pass_add_global_variables.cpp
@@ -27,8 +27,6 @@ FuzzerPassAddGlobalVariables::FuzzerPassAddGlobalVariables(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddGlobalVariables::~FuzzerPassAddGlobalVariables() = default;
-
 void FuzzerPassAddGlobalVariables::Apply() {
   SpvStorageClass variable_storage_class = SpvStorageClassPrivate;
   for (auto& entry_point : GetIRContext()->module()->entry_points()) {

--- a/source/fuzz/fuzzer_pass_add_global_variables.h
+++ b/source/fuzz/fuzzer_pass_add_global_variables.h
@@ -29,8 +29,6 @@ class FuzzerPassAddGlobalVariables : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddGlobalVariables();
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_add_image_sample_unused_components.cpp
+++ b/source/fuzz/fuzzer_pass_add_image_sample_unused_components.cpp
@@ -31,9 +31,6 @@ FuzzerPassAddImageSampleUnusedComponents::
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddImageSampleUnusedComponents::
-    ~FuzzerPassAddImageSampleUnusedComponents() = default;
-
 void FuzzerPassAddImageSampleUnusedComponents::Apply() {
   // SPIR-V module to help understand the transformation.
   //

--- a/source/fuzz/fuzzer_pass_add_image_sample_unused_components.h
+++ b/source/fuzz/fuzzer_pass_add_image_sample_unused_components.h
@@ -30,8 +30,6 @@ class FuzzerPassAddImageSampleUnusedComponents : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddImageSampleUnusedComponents();
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_add_loads.cpp
+++ b/source/fuzz/fuzzer_pass_add_loads.cpp
@@ -27,8 +27,6 @@ FuzzerPassAddLoads::FuzzerPassAddLoads(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddLoads::~FuzzerPassAddLoads() = default;
-
 void FuzzerPassAddLoads::Apply() {
   ForEachInstructionWithInstructionDescriptor(
       [this](opt::Function* function, opt::BasicBlock* block,

--- a/source/fuzz/fuzzer_pass_add_loads.h
+++ b/source/fuzz/fuzzer_pass_add_loads.h
@@ -28,8 +28,6 @@ class FuzzerPassAddLoads : public FuzzerPass {
                      FuzzerContext* fuzzer_context,
                      protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddLoads();
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_add_local_variables.cpp
+++ b/source/fuzz/fuzzer_pass_add_local_variables.cpp
@@ -28,8 +28,6 @@ FuzzerPassAddLocalVariables::FuzzerPassAddLocalVariables(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddLocalVariables::~FuzzerPassAddLocalVariables() = default;
-
 void FuzzerPassAddLocalVariables::Apply() {
   auto basic_type_ids_and_pointers =
       GetAvailableBasicTypesAndPointers(SpvStorageClassFunction);

--- a/source/fuzz/fuzzer_pass_add_local_variables.h
+++ b/source/fuzz/fuzzer_pass_add_local_variables.h
@@ -29,8 +29,6 @@ class FuzzerPassAddLocalVariables : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddLocalVariables();
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_add_loop_preheaders.cpp
+++ b/source/fuzz/fuzzer_pass_add_loop_preheaders.cpp
@@ -27,8 +27,6 @@ FuzzerPassAddLoopPreheaders::FuzzerPassAddLoopPreheaders(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddLoopPreheaders::~FuzzerPassAddLoopPreheaders() = default;
-
 void FuzzerPassAddLoopPreheaders::Apply() {
   for (auto& function : *GetIRContext()->module()) {
     // Keep track of all the loop headers we want to add a preheader to.

--- a/source/fuzz/fuzzer_pass_add_loop_preheaders.h
+++ b/source/fuzz/fuzzer_pass_add_loop_preheaders.h
@@ -32,8 +32,6 @@ class FuzzerPassAddLoopPreheaders : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddLoopPreheaders();
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_add_loops_to_create_int_constant_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_add_loops_to_create_int_constant_synonyms.cpp
@@ -33,9 +33,6 @@ FuzzerPassAddLoopsToCreateIntConstantSynonyms::
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddLoopsToCreateIntConstantSynonyms::
-    ~FuzzerPassAddLoopsToCreateIntConstantSynonyms() = default;
-
 void FuzzerPassAddLoopsToCreateIntConstantSynonyms::Apply() {
   std::vector<uint32_t> constants;
 

--- a/source/fuzz/fuzzer_pass_add_loops_to_create_int_constant_synonyms.h
+++ b/source/fuzz/fuzzer_pass_add_loops_to_create_int_constant_synonyms.h
@@ -30,8 +30,6 @@ class FuzzerPassAddLoopsToCreateIntConstantSynonyms : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddLoopsToCreateIntConstantSynonyms();
-
   void Apply() override;
 
  private:

--- a/source/fuzz/fuzzer_pass_add_no_contraction_decorations.cpp
+++ b/source/fuzz/fuzzer_pass_add_no_contraction_decorations.cpp
@@ -26,9 +26,6 @@ FuzzerPassAddNoContractionDecorations::FuzzerPassAddNoContractionDecorations(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddNoContractionDecorations::
-    ~FuzzerPassAddNoContractionDecorations() = default;
-
 void FuzzerPassAddNoContractionDecorations::Apply() {
   // Consider every instruction in every block in every function.
   for (auto& function : *GetIRContext()->module()) {

--- a/source/fuzz/fuzzer_pass_add_no_contraction_decorations.h
+++ b/source/fuzz/fuzzer_pass_add_no_contraction_decorations.h
@@ -28,8 +28,6 @@ class FuzzerPassAddNoContractionDecorations : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddNoContractionDecorations() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_add_opphi_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_add_opphi_synonyms.cpp
@@ -27,8 +27,6 @@ FuzzerPassAddOpPhiSynonyms::FuzzerPassAddOpPhiSynonyms(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddOpPhiSynonyms::~FuzzerPassAddOpPhiSynonyms() = default;
-
 void FuzzerPassAddOpPhiSynonyms::Apply() {
   // Get a list of synonymous ids with the same type that can be used in the
   // same OpPhi instruction.

--- a/source/fuzz/fuzzer_pass_add_opphi_synonyms.h
+++ b/source/fuzz/fuzzer_pass_add_opphi_synonyms.h
@@ -30,8 +30,6 @@ class FuzzerPassAddOpPhiSynonyms : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddOpPhiSynonyms() override;
-
   void Apply() override;
 
   // Computes the equivalence classes for the non-pointer and non-irrelevant ids

--- a/source/fuzz/fuzzer_pass_add_parameters.cpp
+++ b/source/fuzz/fuzzer_pass_add_parameters.cpp
@@ -29,8 +29,6 @@ FuzzerPassAddParameters::FuzzerPassAddParameters(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddParameters::~FuzzerPassAddParameters() = default;
-
 void FuzzerPassAddParameters::Apply() {
   // Compute type candidates for the new parameter.
   std::vector<uint32_t> type_candidates;

--- a/source/fuzz/fuzzer_pass_add_parameters.h
+++ b/source/fuzz/fuzzer_pass_add_parameters.h
@@ -32,8 +32,6 @@ class FuzzerPassAddParameters : public FuzzerPass {
                           FuzzerContext* fuzzer_context,
                           protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddParameters() override;
-
   void Apply() override;
 
  private:

--- a/source/fuzz/fuzzer_pass_add_relaxed_decorations.cpp
+++ b/source/fuzz/fuzzer_pass_add_relaxed_decorations.cpp
@@ -26,8 +26,6 @@ FuzzerPassAddRelaxedDecorations::FuzzerPassAddRelaxedDecorations(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddRelaxedDecorations::~FuzzerPassAddRelaxedDecorations() = default;
-
 void FuzzerPassAddRelaxedDecorations::Apply() {
   // Consider every instruction in every block in every function.
   for (auto& function : *GetIRContext()->module()) {

--- a/source/fuzz/fuzzer_pass_add_relaxed_decorations.h
+++ b/source/fuzz/fuzzer_pass_add_relaxed_decorations.h
@@ -28,8 +28,6 @@ class FuzzerPassAddRelaxedDecorations : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddRelaxedDecorations() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_add_stores.cpp
+++ b/source/fuzz/fuzzer_pass_add_stores.cpp
@@ -27,8 +27,6 @@ FuzzerPassAddStores::FuzzerPassAddStores(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddStores::~FuzzerPassAddStores() = default;
-
 void FuzzerPassAddStores::Apply() {
   ForEachInstructionWithInstructionDescriptor(
       [this](opt::Function* function, opt::BasicBlock* block,

--- a/source/fuzz/fuzzer_pass_add_stores.h
+++ b/source/fuzz/fuzzer_pass_add_stores.h
@@ -30,8 +30,6 @@ class FuzzerPassAddStores : public FuzzerPass {
                       FuzzerContext* fuzzer_context,
                       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddStores();
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_add_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_add_synonyms.cpp
@@ -29,8 +29,6 @@ FuzzerPassAddSynonyms::FuzzerPassAddSynonyms(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddSynonyms::~FuzzerPassAddSynonyms() = default;
-
 void FuzzerPassAddSynonyms::Apply() {
   ForEachInstructionWithInstructionDescriptor(
       [this](opt::Function* function, opt::BasicBlock* block,

--- a/source/fuzz/fuzzer_pass_add_synonyms.h
+++ b/source/fuzz/fuzzer_pass_add_synonyms.h
@@ -29,8 +29,6 @@ class FuzzerPassAddSynonyms : public FuzzerPass {
                         FuzzerContext* fuzzer_context,
                         protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddSynonyms() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_add_vector_shuffle_instructions.cpp
+++ b/source/fuzz/fuzzer_pass_add_vector_shuffle_instructions.cpp
@@ -28,9 +28,6 @@ FuzzerPassAddVectorShuffleInstructions::FuzzerPassAddVectorShuffleInstructions(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAddVectorShuffleInstructions::
-    ~FuzzerPassAddVectorShuffleInstructions() = default;
-
 void FuzzerPassAddVectorShuffleInstructions::Apply() {
   ForEachInstructionWithInstructionDescriptor(
       [this](opt::Function* function, opt::BasicBlock* block,

--- a/source/fuzz/fuzzer_pass_add_vector_shuffle_instructions.h
+++ b/source/fuzz/fuzzer_pass_add_vector_shuffle_instructions.h
@@ -28,8 +28,6 @@ class FuzzerPassAddVectorShuffleInstructions : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAddVectorShuffleInstructions();
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_adjust_branch_weights.cpp
+++ b/source/fuzz/fuzzer_pass_adjust_branch_weights.cpp
@@ -28,8 +28,6 @@ FuzzerPassAdjustBranchWeights::FuzzerPassAdjustBranchWeights(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAdjustBranchWeights::~FuzzerPassAdjustBranchWeights() = default;
-
 void FuzzerPassAdjustBranchWeights::Apply() {
   // For all OpBranchConditional instructions,
   // randomly applies the transformation.

--- a/source/fuzz/fuzzer_pass_adjust_branch_weights.h
+++ b/source/fuzz/fuzzer_pass_adjust_branch_weights.h
@@ -30,8 +30,6 @@ class FuzzerPassAdjustBranchWeights : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAdjustBranchWeights();
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_adjust_function_controls.cpp
+++ b/source/fuzz/fuzzer_pass_adjust_function_controls.cpp
@@ -26,8 +26,6 @@ FuzzerPassAdjustFunctionControls::FuzzerPassAdjustFunctionControls(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAdjustFunctionControls::~FuzzerPassAdjustFunctionControls() = default;
-
 void FuzzerPassAdjustFunctionControls::Apply() {
   // Consider every function in the module.
   for (auto& function : *GetIRContext()->module()) {

--- a/source/fuzz/fuzzer_pass_adjust_function_controls.h
+++ b/source/fuzz/fuzzer_pass_adjust_function_controls.h
@@ -28,8 +28,6 @@ class FuzzerPassAdjustFunctionControls : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAdjustFunctionControls() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_adjust_loop_controls.cpp
+++ b/source/fuzz/fuzzer_pass_adjust_loop_controls.cpp
@@ -26,8 +26,6 @@ FuzzerPassAdjustLoopControls::FuzzerPassAdjustLoopControls(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAdjustLoopControls::~FuzzerPassAdjustLoopControls() = default;
-
 void FuzzerPassAdjustLoopControls::Apply() {
   // Consider every merge instruction in the module (via looking through all
   // functions and blocks).

--- a/source/fuzz/fuzzer_pass_adjust_loop_controls.h
+++ b/source/fuzz/fuzzer_pass_adjust_loop_controls.h
@@ -28,8 +28,6 @@ class FuzzerPassAdjustLoopControls : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAdjustLoopControls() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_adjust_memory_operands_masks.cpp
+++ b/source/fuzz/fuzzer_pass_adjust_memory_operands_masks.cpp
@@ -27,9 +27,6 @@ FuzzerPassAdjustMemoryOperandsMasks::FuzzerPassAdjustMemoryOperandsMasks(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAdjustMemoryOperandsMasks::~FuzzerPassAdjustMemoryOperandsMasks() =
-    default;
-
 void FuzzerPassAdjustMemoryOperandsMasks::Apply() {
   // Consider every block in every function.
   for (auto& function : *GetIRContext()->module()) {

--- a/source/fuzz/fuzzer_pass_adjust_memory_operands_masks.h
+++ b/source/fuzz/fuzzer_pass_adjust_memory_operands_masks.h
@@ -29,8 +29,6 @@ class FuzzerPassAdjustMemoryOperandsMasks : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAdjustMemoryOperandsMasks();
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_adjust_selection_controls.cpp
+++ b/source/fuzz/fuzzer_pass_adjust_selection_controls.cpp
@@ -26,9 +26,6 @@ FuzzerPassAdjustSelectionControls::FuzzerPassAdjustSelectionControls(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassAdjustSelectionControls::~FuzzerPassAdjustSelectionControls() =
-    default;
-
 void FuzzerPassAdjustSelectionControls::Apply() {
   // Consider every merge instruction in the module (via looking through all
   // functions and blocks).

--- a/source/fuzz/fuzzer_pass_adjust_selection_controls.h
+++ b/source/fuzz/fuzzer_pass_adjust_selection_controls.h
@@ -28,8 +28,6 @@ class FuzzerPassAdjustSelectionControls : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassAdjustSelectionControls() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
@@ -32,8 +32,6 @@ FuzzerPassApplyIdSynonyms::FuzzerPassApplyIdSynonyms(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassApplyIdSynonyms::~FuzzerPassApplyIdSynonyms() = default;
-
 void FuzzerPassApplyIdSynonyms::Apply() {
   // Compute a closure of data synonym facts, to enrich the pool of synonyms
   // that are available.

--- a/source/fuzz/fuzzer_pass_apply_id_synonyms.h
+++ b/source/fuzz/fuzzer_pass_apply_id_synonyms.h
@@ -30,8 +30,6 @@ class FuzzerPassApplyIdSynonyms : public FuzzerPass {
                             FuzzerContext* fuzzer_context,
                             protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassApplyIdSynonyms() override;
-
   void Apply() override;
 
  private:

--- a/source/fuzz/fuzzer_pass_construct_composites.cpp
+++ b/source/fuzz/fuzzer_pass_construct_composites.cpp
@@ -29,8 +29,6 @@ FuzzerPassConstructComposites::FuzzerPassConstructComposites(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassConstructComposites::~FuzzerPassConstructComposites() = default;
-
 void FuzzerPassConstructComposites::Apply() {
   // Gather up the ids of all composite types, but skip block-/buffer
   // block-decorated struct types.

--- a/source/fuzz/fuzzer_pass_construct_composites.h
+++ b/source/fuzz/fuzzer_pass_construct_composites.h
@@ -31,8 +31,6 @@ class FuzzerPassConstructComposites : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassConstructComposites();
-
   void Apply() override;
 
  private:

--- a/source/fuzz/fuzzer_pass_copy_objects.cpp
+++ b/source/fuzz/fuzzer_pass_copy_objects.cpp
@@ -28,8 +28,6 @@ FuzzerPassCopyObjects::FuzzerPassCopyObjects(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassCopyObjects::~FuzzerPassCopyObjects() = default;
-
 void FuzzerPassCopyObjects::Apply() {
   ForEachInstructionWithInstructionDescriptor(
       [this](opt::Function* function, opt::BasicBlock* block,

--- a/source/fuzz/fuzzer_pass_copy_objects.h
+++ b/source/fuzz/fuzzer_pass_copy_objects.h
@@ -28,8 +28,6 @@ class FuzzerPassCopyObjects : public FuzzerPass {
                         FuzzerContext* fuzzer_context,
                         protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassCopyObjects();
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_donate_modules.cpp
+++ b/source/fuzz/fuzzer_pass_donate_modules.cpp
@@ -50,8 +50,6 @@ FuzzerPassDonateModules::FuzzerPassDonateModules(
                  transformations),
       donor_suppliers_(donor_suppliers) {}
 
-FuzzerPassDonateModules::~FuzzerPassDonateModules() = default;
-
 void FuzzerPassDonateModules::Apply() {
   // If there are no donor suppliers, this fuzzer pass is a no-op.
   if (donor_suppliers_.empty()) {

--- a/source/fuzz/fuzzer_pass_donate_modules.h
+++ b/source/fuzz/fuzzer_pass_donate_modules.h
@@ -33,8 +33,6 @@ class FuzzerPassDonateModules : public FuzzerPass {
       protobufs::TransformationSequence* transformations,
       const std::vector<fuzzerutil::ModuleSupplier>& donor_suppliers);
 
-  ~FuzzerPassDonateModules();
-
   void Apply() override;
 
   // Donates the global declarations and functions of |donor_ir_context| into

--- a/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.cpp
+++ b/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.cpp
@@ -29,9 +29,6 @@ FuzzerPassDuplicateRegionsWithSelections::
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassDuplicateRegionsWithSelections::
-    ~FuzzerPassDuplicateRegionsWithSelections() = default;
-
 void FuzzerPassDuplicateRegionsWithSelections::Apply() {
   // Iterate over all of the functions in the module.
   for (auto& function : *GetIRContext()->module()) {

--- a/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.h
+++ b/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.h
@@ -31,8 +31,6 @@ class FuzzerPassDuplicateRegionsWithSelections : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassDuplicateRegionsWithSelections() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_expand_vector_reductions.cpp
+++ b/source/fuzz/fuzzer_pass_expand_vector_reductions.cpp
@@ -28,8 +28,6 @@ FuzzerPassExpandVectorReductions::FuzzerPassExpandVectorReductions(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassExpandVectorReductions::~FuzzerPassExpandVectorReductions() = default;
-
 void FuzzerPassExpandVectorReductions::Apply() {
   for (auto& function : *GetIRContext()->module()) {
     for (auto& block : function) {

--- a/source/fuzz/fuzzer_pass_expand_vector_reductions.h
+++ b/source/fuzz/fuzzer_pass_expand_vector_reductions.h
@@ -30,8 +30,6 @@ class FuzzerPassExpandVectorReductions : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassExpandVectorReductions();
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_flatten_conditional_branches.cpp
+++ b/source/fuzz/fuzzer_pass_flatten_conditional_branches.cpp
@@ -30,9 +30,6 @@ FuzzerPassFlattenConditionalBranches::FuzzerPassFlattenConditionalBranches(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassFlattenConditionalBranches::~FuzzerPassFlattenConditionalBranches() =
-    default;
-
 void FuzzerPassFlattenConditionalBranches::Apply() {
   for (auto& function : *GetIRContext()->module()) {
     // Get all the selection headers that we want to flatten. We need to collect

--- a/source/fuzz/fuzzer_pass_flatten_conditional_branches.h
+++ b/source/fuzz/fuzzer_pass_flatten_conditional_branches.h
@@ -27,8 +27,6 @@ class FuzzerPassFlattenConditionalBranches : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassFlattenConditionalBranches() override;
-
   void Apply() override;
 
  private:

--- a/source/fuzz/fuzzer_pass_inline_functions.cpp
+++ b/source/fuzz/fuzzer_pass_inline_functions.cpp
@@ -29,8 +29,6 @@ FuzzerPassInlineFunctions::FuzzerPassInlineFunctions(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassInlineFunctions::~FuzzerPassInlineFunctions() = default;
-
 void FuzzerPassInlineFunctions::Apply() {
   // |function_call_instructions| are the instructions that will be inlined.
   // First, they will be collected and then do the inlining in another loop.

--- a/source/fuzz/fuzzer_pass_inline_functions.h
+++ b/source/fuzz/fuzzer_pass_inline_functions.h
@@ -30,8 +30,6 @@ class FuzzerPassInlineFunctions : public FuzzerPass {
                             FuzzerContext* fuzzer_context,
                             protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassInlineFunctions() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.cpp
+++ b/source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.cpp
@@ -31,9 +31,6 @@ FuzzerPassInterchangeSignednessOfIntegerOperands::
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassInterchangeSignednessOfIntegerOperands::
-    ~FuzzerPassInterchangeSignednessOfIntegerOperands() = default;
-
 void FuzzerPassInterchangeSignednessOfIntegerOperands::Apply() {
   assert(!GetFuzzerContext()->IsWgslCompatible() &&
          "Cannot interchange signedness in WGSL");

--- a/source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.h
+++ b/source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.h
@@ -34,8 +34,6 @@ class FuzzerPassInterchangeSignednessOfIntegerOperands : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassInterchangeSignednessOfIntegerOperands() override;
-
   void Apply() override;
 
  private:

--- a/source/fuzz/fuzzer_pass_interchange_zero_like_constants.cpp
+++ b/source/fuzz/fuzzer_pass_interchange_zero_like_constants.cpp
@@ -29,9 +29,6 @@ FuzzerPassInterchangeZeroLikeConstants::FuzzerPassInterchangeZeroLikeConstants(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassInterchangeZeroLikeConstants::
-    ~FuzzerPassInterchangeZeroLikeConstants() = default;
-
 uint32_t FuzzerPassInterchangeZeroLikeConstants::FindOrCreateToggledConstant(
     opt::Instruction* declaration) {
   // |declaration| must not be a specialization constant because we do not know

--- a/source/fuzz/fuzzer_pass_interchange_zero_like_constants.h
+++ b/source/fuzz/fuzzer_pass_interchange_zero_like_constants.h
@@ -35,8 +35,6 @@ class FuzzerPassInterchangeZeroLikeConstants : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassInterchangeZeroLikeConstants() override;
-
   void Apply() override;
 
  private:

--- a/source/fuzz/fuzzer_pass_invert_comparison_operators.cpp
+++ b/source/fuzz/fuzzer_pass_invert_comparison_operators.cpp
@@ -28,9 +28,6 @@ FuzzerPassInvertComparisonOperators::FuzzerPassInvertComparisonOperators(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassInvertComparisonOperators::~FuzzerPassInvertComparisonOperators() =
-    default;
-
 void FuzzerPassInvertComparisonOperators::Apply() {
   GetIRContext()->module()->ForEachInst([this](const opt::Instruction* inst) {
     if (!TransformationInvertComparisonOperator::IsInversionSupported(

--- a/source/fuzz/fuzzer_pass_invert_comparison_operators.h
+++ b/source/fuzz/fuzzer_pass_invert_comparison_operators.h
@@ -29,8 +29,6 @@ class FuzzerPassInvertComparisonOperators : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassInvertComparisonOperators() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_make_vector_operations_dynamic.cpp
+++ b/source/fuzz/fuzzer_pass_make_vector_operations_dynamic.cpp
@@ -28,9 +28,6 @@ FuzzerPassMakeVectorOperationsDynamic::FuzzerPassMakeVectorOperationsDynamic(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassMakeVectorOperationsDynamic::
-    ~FuzzerPassMakeVectorOperationsDynamic() = default;
-
 void FuzzerPassMakeVectorOperationsDynamic::Apply() {
   for (auto& function : *GetIRContext()->module()) {
     for (auto& block : function) {

--- a/source/fuzz/fuzzer_pass_make_vector_operations_dynamic.h
+++ b/source/fuzz/fuzzer_pass_make_vector_operations_dynamic.h
@@ -29,8 +29,6 @@ class FuzzerPassMakeVectorOperationsDynamic : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassMakeVectorOperationsDynamic() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_merge_blocks.cpp
+++ b/source/fuzz/fuzzer_pass_merge_blocks.cpp
@@ -28,8 +28,6 @@ FuzzerPassMergeBlocks::FuzzerPassMergeBlocks(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassMergeBlocks::~FuzzerPassMergeBlocks() = default;
-
 void FuzzerPassMergeBlocks::Apply() {
   // First we populate a sequence of transformations that we might consider
   // applying.

--- a/source/fuzz/fuzzer_pass_merge_blocks.h
+++ b/source/fuzz/fuzzer_pass_merge_blocks.h
@@ -28,8 +28,6 @@ class FuzzerPassMergeBlocks : public FuzzerPass {
                         FuzzerContext* fuzzer_context,
                         protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassMergeBlocks();
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_merge_function_returns.cpp
+++ b/source/fuzz/fuzzer_pass_merge_function_returns.cpp
@@ -30,8 +30,6 @@ FuzzerPassMergeFunctionReturns::FuzzerPassMergeFunctionReturns(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassMergeFunctionReturns::~FuzzerPassMergeFunctionReturns() = default;
-
 void FuzzerPassMergeFunctionReturns::Apply() {
   // The pass might add new functions to the module (due to wrapping early
   // terminator instructions in function calls), so we record the functions that

--- a/source/fuzz/fuzzer_pass_merge_function_returns.h
+++ b/source/fuzz/fuzzer_pass_merge_function_returns.h
@@ -33,8 +33,6 @@ class FuzzerPassMergeFunctionReturns : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassMergeFunctionReturns();
-
   void Apply() override;
 
  private:

--- a/source/fuzz/fuzzer_pass_mutate_pointers.cpp
+++ b/source/fuzz/fuzzer_pass_mutate_pointers.cpp
@@ -28,8 +28,6 @@ FuzzerPassMutatePointers::FuzzerPassMutatePointers(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassMutatePointers::~FuzzerPassMutatePointers() = default;
-
 void FuzzerPassMutatePointers::Apply() {
   ForEachInstructionWithInstructionDescriptor(
       [this](opt::Function* function, opt::BasicBlock* block,

--- a/source/fuzz/fuzzer_pass_mutate_pointers.h
+++ b/source/fuzz/fuzzer_pass_mutate_pointers.h
@@ -28,8 +28,6 @@ class FuzzerPassMutatePointers : public FuzzerPass {
                            FuzzerContext* fuzzer_context,
                            protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassMutatePointers() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_obfuscate_constants.cpp
+++ b/source/fuzz/fuzzer_pass_obfuscate_constants.cpp
@@ -34,8 +34,6 @@ FuzzerPassObfuscateConstants::FuzzerPassObfuscateConstants(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassObfuscateConstants::~FuzzerPassObfuscateConstants() = default;
-
 void FuzzerPassObfuscateConstants::ObfuscateBoolConstantViaConstantPair(
     uint32_t depth, const protobufs::IdUseDescriptor& bool_constant_use,
     const std::vector<SpvOp>& greater_than_opcodes,

--- a/source/fuzz/fuzzer_pass_obfuscate_constants.h
+++ b/source/fuzz/fuzzer_pass_obfuscate_constants.h
@@ -32,8 +32,6 @@ class FuzzerPassObfuscateConstants : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassObfuscateConstants() override;
-
   void Apply() override;
 
  private:

--- a/source/fuzz/fuzzer_pass_outline_functions.cpp
+++ b/source/fuzz/fuzzer_pass_outline_functions.cpp
@@ -31,8 +31,6 @@ FuzzerPassOutlineFunctions::FuzzerPassOutlineFunctions(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassOutlineFunctions::~FuzzerPassOutlineFunctions() = default;
-
 void FuzzerPassOutlineFunctions::Apply() {
   std::vector<opt::Function*> original_functions;
   for (auto& function : *GetIRContext()->module()) {

--- a/source/fuzz/fuzzer_pass_outline_functions.h
+++ b/source/fuzz/fuzzer_pass_outline_functions.h
@@ -29,8 +29,6 @@ class FuzzerPassOutlineFunctions : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassOutlineFunctions();
-
   void Apply() override;
 
   // Returns a block suitable to be an entry block for a region that can be

--- a/source/fuzz/fuzzer_pass_permute_blocks.cpp
+++ b/source/fuzz/fuzzer_pass_permute_blocks.cpp
@@ -26,8 +26,6 @@ FuzzerPassPermuteBlocks::FuzzerPassPermuteBlocks(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassPermuteBlocks::~FuzzerPassPermuteBlocks() = default;
-
 void FuzzerPassPermuteBlocks::Apply() {
   // For now we do something very simple: we randomly decide whether to move a
   // block, and for each block that we do move, we push it down as far as we

--- a/source/fuzz/fuzzer_pass_permute_blocks.h
+++ b/source/fuzz/fuzzer_pass_permute_blocks.h
@@ -29,8 +29,6 @@ class FuzzerPassPermuteBlocks : public FuzzerPass {
                           FuzzerContext* fuzzer_context,
                           protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassPermuteBlocks() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_permute_function_parameters.cpp
+++ b/source/fuzz/fuzzer_pass_permute_function_parameters.cpp
@@ -32,9 +32,6 @@ FuzzerPassPermuteFunctionParameters::FuzzerPassPermuteFunctionParameters(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassPermuteFunctionParameters::~FuzzerPassPermuteFunctionParameters() =
-    default;
-
 void FuzzerPassPermuteFunctionParameters::Apply() {
   for (const auto& function : *GetIRContext()->module()) {
     uint32_t function_id = function.result_id();

--- a/source/fuzz/fuzzer_pass_permute_function_parameters.h
+++ b/source/fuzz/fuzzer_pass_permute_function_parameters.h
@@ -34,8 +34,6 @@ class FuzzerPassPermuteFunctionParameters : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassPermuteFunctionParameters() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_permute_instructions.cpp
+++ b/source/fuzz/fuzzer_pass_permute_instructions.cpp
@@ -29,8 +29,6 @@ FuzzerPassPermuteInstructions::FuzzerPassPermuteInstructions(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassPermuteInstructions::~FuzzerPassPermuteInstructions() = default;
-
 void FuzzerPassPermuteInstructions::Apply() {
   // We are iterating over all instructions in all basic blocks.
   for (auto& function : *GetIRContext()->module()) {

--- a/source/fuzz/fuzzer_pass_permute_instructions.h
+++ b/source/fuzz/fuzzer_pass_permute_instructions.h
@@ -29,8 +29,6 @@ class FuzzerPassPermuteInstructions : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassPermuteInstructions() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_permute_phi_operands.cpp
+++ b/source/fuzz/fuzzer_pass_permute_phi_operands.cpp
@@ -32,8 +32,6 @@ FuzzerPassPermutePhiOperands::FuzzerPassPermutePhiOperands(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassPermutePhiOperands::~FuzzerPassPermutePhiOperands() = default;
-
 void FuzzerPassPermutePhiOperands::Apply() {
   ForEachInstructionWithInstructionDescriptor(
       [this](opt::Function* /*unused*/, opt::BasicBlock* /*unused*/,

--- a/source/fuzz/fuzzer_pass_permute_phi_operands.h
+++ b/source/fuzz/fuzzer_pass_permute_phi_operands.h
@@ -29,8 +29,6 @@ class FuzzerPassPermutePhiOperands : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassPermutePhiOperands() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_propagate_instructions_down.cpp
+++ b/source/fuzz/fuzzer_pass_propagate_instructions_down.cpp
@@ -27,9 +27,6 @@ FuzzerPassPropagateInstructionsDown::FuzzerPassPropagateInstructionsDown(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassPropagateInstructionsDown::~FuzzerPassPropagateInstructionsDown() =
-    default;
-
 void FuzzerPassPropagateInstructionsDown::Apply() {
   for (const auto& function : *GetIRContext()->module()) {
     std::vector<const opt::BasicBlock*> reachable_blocks;

--- a/source/fuzz/fuzzer_pass_propagate_instructions_down.h
+++ b/source/fuzz/fuzzer_pass_propagate_instructions_down.h
@@ -28,8 +28,6 @@ class FuzzerPassPropagateInstructionsDown : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassPropagateInstructionsDown() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_propagate_instructions_up.cpp
+++ b/source/fuzz/fuzzer_pass_propagate_instructions_up.cpp
@@ -29,9 +29,6 @@ FuzzerPassPropagateInstructionsUp::FuzzerPassPropagateInstructionsUp(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassPropagateInstructionsUp::~FuzzerPassPropagateInstructionsUp() =
-    default;
-
 void FuzzerPassPropagateInstructionsUp::Apply() {
   for (const auto& function : *GetIRContext()->module()) {
     for (const auto& block : function) {

--- a/source/fuzz/fuzzer_pass_propagate_instructions_up.h
+++ b/source/fuzz/fuzzer_pass_propagate_instructions_up.h
@@ -29,8 +29,6 @@ class FuzzerPassPropagateInstructionsUp : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassPropagateInstructionsUp() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_push_ids_through_variables.cpp
+++ b/source/fuzz/fuzzer_pass_push_ids_through_variables.cpp
@@ -28,9 +28,6 @@ FuzzerPassPushIdsThroughVariables::FuzzerPassPushIdsThroughVariables(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassPushIdsThroughVariables::~FuzzerPassPushIdsThroughVariables() =
-    default;
-
 void FuzzerPassPushIdsThroughVariables::Apply() {
   ForEachInstructionWithInstructionDescriptor(
       [this](opt::Function* function, opt::BasicBlock* block,

--- a/source/fuzz/fuzzer_pass_push_ids_through_variables.h
+++ b/source/fuzz/fuzzer_pass_push_ids_through_variables.h
@@ -30,8 +30,6 @@ class FuzzerPassPushIdsThroughVariables : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassPushIdsThroughVariables() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_replace_adds_subs_muls_with_carrying_extended.cpp
+++ b/source/fuzz/fuzzer_pass_replace_adds_subs_muls_with_carrying_extended.cpp
@@ -33,9 +33,6 @@ FuzzerPassReplaceAddsSubsMulsWithCarryingExtended::
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassReplaceAddsSubsMulsWithCarryingExtended::
-    ~FuzzerPassReplaceAddsSubsMulsWithCarryingExtended() = default;
-
 void FuzzerPassReplaceAddsSubsMulsWithCarryingExtended::Apply() {
   std::vector<opt::Instruction> instructions_for_transformation;
   for (auto& function : *GetIRContext()->module()) {

--- a/source/fuzz/fuzzer_pass_replace_adds_subs_muls_with_carrying_extended.h
+++ b/source/fuzz/fuzzer_pass_replace_adds_subs_muls_with_carrying_extended.h
@@ -31,8 +31,6 @@ class FuzzerPassReplaceAddsSubsMulsWithCarryingExtended : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassReplaceAddsSubsMulsWithCarryingExtended() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_replace_branches_from_dead_blocks_with_exits.cpp
+++ b/source/fuzz/fuzzer_pass_replace_branches_from_dead_blocks_with_exits.cpp
@@ -32,9 +32,6 @@ FuzzerPassReplaceBranchesFromDeadBlocksWithExits::
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassReplaceBranchesFromDeadBlocksWithExits::
-    ~FuzzerPassReplaceBranchesFromDeadBlocksWithExits() = default;
-
 void FuzzerPassReplaceBranchesFromDeadBlocksWithExits::Apply() {
   // OpKill can only be used as a terminator in a function that is guaranteed
   // to be executed with the Fragment execution model.  We conservatively only

--- a/source/fuzz/fuzzer_pass_replace_branches_from_dead_blocks_with_exits.h
+++ b/source/fuzz/fuzzer_pass_replace_branches_from_dead_blocks_with_exits.h
@@ -30,8 +30,6 @@ class FuzzerPassReplaceBranchesFromDeadBlocksWithExits : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassReplaceBranchesFromDeadBlocksWithExits() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_replace_copy_memories_with_loads_stores.cpp
+++ b/source/fuzz/fuzzer_pass_replace_copy_memories_with_loads_stores.cpp
@@ -30,9 +30,6 @@ FuzzerPassReplaceCopyMemoriesWithLoadsStores::
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassReplaceCopyMemoriesWithLoadsStores::
-    ~FuzzerPassReplaceCopyMemoriesWithLoadsStores() = default;
-
 void FuzzerPassReplaceCopyMemoriesWithLoadsStores::Apply() {
   GetIRContext()->module()->ForEachInst([this](opt::Instruction* instruction) {
     // Randomly decide whether to replace the OpCopyMemory.

--- a/source/fuzz/fuzzer_pass_replace_copy_memories_with_loads_stores.h
+++ b/source/fuzz/fuzzer_pass_replace_copy_memories_with_loads_stores.h
@@ -30,8 +30,6 @@ class FuzzerPassReplaceCopyMemoriesWithLoadsStores : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassReplaceCopyMemoriesWithLoadsStores() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_replace_copy_objects_with_stores_loads.cpp
+++ b/source/fuzz/fuzzer_pass_replace_copy_objects_with_stores_loads.cpp
@@ -30,9 +30,6 @@ FuzzerPassReplaceCopyObjectsWithStoresLoads::
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassReplaceCopyObjectsWithStoresLoads::
-    ~FuzzerPassReplaceCopyObjectsWithStoresLoads() = default;
-
 void FuzzerPassReplaceCopyObjectsWithStoresLoads::Apply() {
   GetIRContext()->module()->ForEachInst([this](opt::Instruction* instruction) {
     // Randomly decide whether to replace OpCopyObject.

--- a/source/fuzz/fuzzer_pass_replace_copy_objects_with_stores_loads.h
+++ b/source/fuzz/fuzzer_pass_replace_copy_objects_with_stores_loads.h
@@ -30,8 +30,6 @@ class FuzzerPassReplaceCopyObjectsWithStoresLoads : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassReplaceCopyObjectsWithStoresLoads() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_replace_irrelevant_ids.cpp
+++ b/source/fuzz/fuzzer_pass_replace_irrelevant_ids.cpp
@@ -31,8 +31,6 @@ FuzzerPassReplaceIrrelevantIds::FuzzerPassReplaceIrrelevantIds(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassReplaceIrrelevantIds::~FuzzerPassReplaceIrrelevantIds() = default;
-
 void FuzzerPassReplaceIrrelevantIds::Apply() {
   // Keep track of the irrelevant ids. This includes all the ids that are
   // irrelevant according to the fact manager and that are still present in the

--- a/source/fuzz/fuzzer_pass_replace_irrelevant_ids.h
+++ b/source/fuzz/fuzzer_pass_replace_irrelevant_ids.h
@@ -30,8 +30,6 @@ class FuzzerPassReplaceIrrelevantIds : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassReplaceIrrelevantIds();
-
   void Apply() override;
 };
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_pass_replace_linear_algebra_instructions.cpp
+++ b/source/fuzz/fuzzer_pass_replace_linear_algebra_instructions.cpp
@@ -30,9 +30,6 @@ FuzzerPassReplaceLinearAlgebraInstructions::
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassReplaceLinearAlgebraInstructions::
-    ~FuzzerPassReplaceLinearAlgebraInstructions() = default;
-
 void FuzzerPassReplaceLinearAlgebraInstructions::Apply() {
   // For each instruction, checks whether it is a linear algebra instruction. In
   // this case, the transformation is randomly applied.

--- a/source/fuzz/fuzzer_pass_replace_linear_algebra_instructions.h
+++ b/source/fuzz/fuzzer_pass_replace_linear_algebra_instructions.h
@@ -29,8 +29,6 @@ class FuzzerPassReplaceLinearAlgebraInstructions : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassReplaceLinearAlgebraInstructions();
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_replace_loads_stores_with_copy_memories.cpp
+++ b/source/fuzz/fuzzer_pass_replace_loads_stores_with_copy_memories.cpp
@@ -31,9 +31,6 @@ FuzzerPassReplaceLoadsStoresWithCopyMemories::
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassReplaceLoadsStoresWithCopyMemories::
-    ~FuzzerPassReplaceLoadsStoresWithCopyMemories() = default;
-
 void FuzzerPassReplaceLoadsStoresWithCopyMemories::Apply() {
   // We look for matching pairs of instructions OpLoad and
   // OpStore within the same block. Potential instructions OpLoad to be matched

--- a/source/fuzz/fuzzer_pass_replace_loads_stores_with_copy_memories.h
+++ b/source/fuzz/fuzzer_pass_replace_loads_stores_with_copy_memories.h
@@ -30,8 +30,6 @@ class FuzzerPassReplaceLoadsStoresWithCopyMemories : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassReplaceLoadsStoresWithCopyMemories() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_replace_opphi_ids_from_dead_predecessors.cpp
+++ b/source/fuzz/fuzzer_pass_replace_opphi_ids_from_dead_predecessors.cpp
@@ -28,9 +28,6 @@ FuzzerPassReplaceOpPhiIdsFromDeadPredecessors::
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassReplaceOpPhiIdsFromDeadPredecessors::
-    ~FuzzerPassReplaceOpPhiIdsFromDeadPredecessors() = default;
-
 void FuzzerPassReplaceOpPhiIdsFromDeadPredecessors::Apply() {
   // Keep a vector of the transformations to apply.
   std::vector<TransformationReplaceOpPhiIdFromDeadPredecessor> transformations;

--- a/source/fuzz/fuzzer_pass_replace_opphi_ids_from_dead_predecessors.h
+++ b/source/fuzz/fuzzer_pass_replace_opphi_ids_from_dead_predecessors.h
@@ -29,8 +29,6 @@ class FuzzerPassReplaceOpPhiIdsFromDeadPredecessors : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassReplaceOpPhiIdsFromDeadPredecessors();
-
   void Apply() override;
 };
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.cpp
+++ b/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.cpp
@@ -31,9 +31,6 @@ FuzzerPassReplaceOpSelectsWithConditionalBranches::
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassReplaceOpSelectsWithConditionalBranches::
-    ~FuzzerPassReplaceOpSelectsWithConditionalBranches() = default;
-
 void FuzzerPassReplaceOpSelectsWithConditionalBranches::Apply() {
   // Keep track of the instructions that we want to replace. We need to collect
   // them in a vector, since it's not safe to modify the module while iterating

--- a/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.h
+++ b/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.h
@@ -29,8 +29,6 @@ class FuzzerPassReplaceOpSelectsWithConditionalBranches : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassReplaceOpSelectsWithConditionalBranches() override;
-
   void Apply() override;
 
  private:

--- a/source/fuzz/fuzzer_pass_replace_parameter_with_global.cpp
+++ b/source/fuzz/fuzzer_pass_replace_parameter_with_global.cpp
@@ -31,9 +31,6 @@ FuzzerPassReplaceParameterWithGlobal::FuzzerPassReplaceParameterWithGlobal(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassReplaceParameterWithGlobal::~FuzzerPassReplaceParameterWithGlobal() =
-    default;
-
 void FuzzerPassReplaceParameterWithGlobal::Apply() {
   for (const auto& function : *GetIRContext()->module()) {
     if (fuzzerutil::FunctionIsEntryPoint(GetIRContext(),

--- a/source/fuzz/fuzzer_pass_replace_parameter_with_global.h
+++ b/source/fuzz/fuzzer_pass_replace_parameter_with_global.h
@@ -29,8 +29,6 @@ class FuzzerPassReplaceParameterWithGlobal : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassReplaceParameterWithGlobal() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_replace_params_with_struct.cpp
+++ b/source/fuzz/fuzzer_pass_replace_params_with_struct.cpp
@@ -31,9 +31,6 @@ FuzzerPassReplaceParamsWithStruct::FuzzerPassReplaceParamsWithStruct(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassReplaceParamsWithStruct::~FuzzerPassReplaceParamsWithStruct() =
-    default;
-
 void FuzzerPassReplaceParamsWithStruct::Apply() {
   for (const auto& function : *GetIRContext()->module()) {
     auto params =

--- a/source/fuzz/fuzzer_pass_replace_params_with_struct.h
+++ b/source/fuzz/fuzzer_pass_replace_params_with_struct.h
@@ -29,8 +29,6 @@ class FuzzerPassReplaceParamsWithStruct : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassReplaceParamsWithStruct() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_split_blocks.cpp
+++ b/source/fuzz/fuzzer_pass_split_blocks.cpp
@@ -29,8 +29,6 @@ FuzzerPassSplitBlocks::FuzzerPassSplitBlocks(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassSplitBlocks::~FuzzerPassSplitBlocks() = default;
-
 void FuzzerPassSplitBlocks::Apply() {
   // Gather up pointers to all the blocks in the module.  We are then able to
   // iterate over these pointers and split the blocks to which they point;

--- a/source/fuzz/fuzzer_pass_split_blocks.h
+++ b/source/fuzz/fuzzer_pass_split_blocks.h
@@ -29,8 +29,6 @@ class FuzzerPassSplitBlocks : public FuzzerPass {
                         FuzzerContext* fuzzer_context,
                         protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassSplitBlocks() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_swap_commutable_operands.cpp
+++ b/source/fuzz/fuzzer_pass_swap_commutable_operands.cpp
@@ -28,8 +28,6 @@ FuzzerPassSwapCommutableOperands::FuzzerPassSwapCommutableOperands(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassSwapCommutableOperands::~FuzzerPassSwapCommutableOperands() = default;
-
 void FuzzerPassSwapCommutableOperands::Apply() {
   auto context = GetIRContext();
   // Iterates over the module's instructions and checks whether it is

--- a/source/fuzz/fuzzer_pass_swap_commutable_operands.h
+++ b/source/fuzz/fuzzer_pass_swap_commutable_operands.h
@@ -30,8 +30,6 @@ class FuzzerPassSwapCommutableOperands : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassSwapCommutableOperands();
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_swap_conditional_branch_operands.cpp
+++ b/source/fuzz/fuzzer_pass_swap_conditional_branch_operands.cpp
@@ -31,9 +31,6 @@ FuzzerPassSwapBranchConditionalOperands::
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassSwapBranchConditionalOperands::
-    ~FuzzerPassSwapBranchConditionalOperands() = default;
-
 void FuzzerPassSwapBranchConditionalOperands::Apply() {
   ForEachInstructionWithInstructionDescriptor(
       [this](opt::Function* /*unused*/, opt::BasicBlock* /*unused*/,

--- a/source/fuzz/fuzzer_pass_swap_conditional_branch_operands.h
+++ b/source/fuzz/fuzzer_pass_swap_conditional_branch_operands.h
@@ -29,8 +29,6 @@ class FuzzerPassSwapBranchConditionalOperands : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassSwapBranchConditionalOperands() override;
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_toggle_access_chain_instruction.cpp
+++ b/source/fuzz/fuzzer_pass_toggle_access_chain_instruction.cpp
@@ -28,9 +28,6 @@ FuzzerPassToggleAccessChainInstruction::FuzzerPassToggleAccessChainInstruction(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassToggleAccessChainInstruction::
-    ~FuzzerPassToggleAccessChainInstruction() = default;
-
 void FuzzerPassToggleAccessChainInstruction::Apply() {
   auto context = GetIRContext();
   // Iterates over the module's instructions and checks whether it is

--- a/source/fuzz/fuzzer_pass_toggle_access_chain_instruction.h
+++ b/source/fuzz/fuzzer_pass_toggle_access_chain_instruction.h
@@ -29,8 +29,6 @@ class FuzzerPassToggleAccessChainInstruction : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassToggleAccessChainInstruction();
-
   void Apply() override;
 };
 

--- a/source/fuzz/fuzzer_pass_wrap_regions_in_selections.cpp
+++ b/source/fuzz/fuzzer_pass_wrap_regions_in_selections.cpp
@@ -29,9 +29,6 @@ FuzzerPassWrapRegionsInSelections::FuzzerPassWrapRegionsInSelections(
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
                  transformations) {}
 
-FuzzerPassWrapRegionsInSelections::~FuzzerPassWrapRegionsInSelections() =
-    default;
-
 void FuzzerPassWrapRegionsInSelections::Apply() {
   for (auto& function : *GetIRContext()->module()) {
     if (!GetFuzzerContext()->ChoosePercentage(

--- a/source/fuzz/fuzzer_pass_wrap_regions_in_selections.h
+++ b/source/fuzz/fuzzer_pass_wrap_regions_in_selections.h
@@ -29,8 +29,6 @@ class FuzzerPassWrapRegionsInSelections : public FuzzerPass {
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations);
 
-  ~FuzzerPassWrapRegionsInSelections() override;
-
   void Apply() override;
 
  private:


### PR DESCRIPTION
Subclasses of FuzzerPass no longer needlessly override the default
destructor of FuzzerPass.