### PR TITLE
spirv-fuzz: Accept limitations in AddFunction

### DIFF
--- a/source/fuzz/fuzzer_pass_donate_modules.cpp
+++ b/source/fuzz/fuzzer_pass_donate_modules.cpp
@@ -1200,11 +1200,14 @@ bool FuzzerPassDonateModules::MaybeAddLivesafeFunction(
         false);
   }
 
-  // Add the function in a livesafe manner.
-  ApplyTransformation(TransformationAddFunction(
+  // Try to add the function in a livesafe manner. This may fail due to edge
+  // cases, e.g. where adding loop limiters changes dominance such that the
+  // module becomes invalid. It would be ideal to handle all such edge cases,
+  // but as they are rare it is more pragmatic to bail out of making the
+  // function livesafe if the transformation's precondition fails to hold.
+  return MaybeApplyTransformation(TransformationAddFunction(
       donated_instructions, loop_limiter_variable_id, loop_limit, loop_limiters,
       kill_unreachable_return_value_id, access_chain_clamping_info));
-  return true;
 }
 
 }  // namespace fuzz


### PR DESCRIPTION
There are some edge cases where adding livesafe functions does not
succeed, due to loop limiter edges breaking SPIR-V dominance rules. As
these edge cases are rare it does not seem worth implementing complex
additional logic to handle all cases. This change accepts that trying
to add a function in a livesafe manner may not succeed.