### PR TITLE
Add transformation class for swapping functions

### DIFF
--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -120,6 +120,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_split_blocks.h
         fuzzer_pass_swap_commutable_operands.h
         fuzzer_pass_swap_conditional_branch_operands.h
+        fuzzer_pass_swap_functions.h
         fuzzer_pass_toggle_access_chain_instruction.h
         fuzzer_pass_wrap_regions_in_selections.h
         fuzzer_util.h
@@ -311,6 +312,7 @@ if(SPIRV_BUILD_FUZZER)
         fuzzer_pass_split_blocks.cpp
         fuzzer_pass_swap_commutable_operands.cpp
         fuzzer_pass_swap_conditional_branch_operands.cpp
+        fuzzer_pass_swap_functions.cpp
         fuzzer_pass_toggle_access_chain_instruction.cpp
         fuzzer_pass_wrap_regions_in_selections.cpp
         fuzzer_util.cpp

--- a/source/fuzz/fuzzer_pass_swap_functions.cpp
+++ b/source/fuzz/fuzzer_pass_swap_functions.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Shiyu Liu
+// Copyright (c) 2021 Google, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/fuzz/fuzzer_pass_swap_functions.cpp
+++ b/source/fuzz/fuzzer_pass_swap_functions.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2021 Shiyu Liu
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/fuzzer_pass_swap_functions.h"
+
+#include "source/fuzz/transformation_swap_two_functions.h"
+
+namespace spvtools {
+namespace fuzz {
+
+FuzzerPassSwapFunctions::FuzzerPassSwapFunctions(
+    opt::IRContext* ir_contex, TransformationContext* transformation_context, 
+    FuzzerContext* fuzzer_context, 
+    protobufs::TransformationSequence* transformations)
+    : FuzzerPass(ir_context, transformation_context, fuzzer_context, 
+                 transformations) {}
+
+void FuzzerPassSwapFunctions::Apply() {
+    // Here we start by doing exhaustive swap testing: 
+    // For every function a and function b, where a and b has a valid id in [function_ids] set
+    // and a and b are not the same function (ie, have a different id). 
+    // For every combination of a and b, we do transformation_swap_two_functions(a.id, b.id) and 
+    // make sure everyone of them have the correct result returned. 
+    // When the function space is large, we might choose functions arbitrarily from the function space
+    // and do random swaps.
+
+    // we first collect all functions by their id from the given module
+    std::vector<uint32_t> function_ids; 
+    for(auto& function : *GetIRContext()->module()) {
+        function_ids.emplace_back(function.result_id());
+    }
+    
+    // Number of functions (& function ids) in the set.
+    int id_sz = function_ids.size(); 
+
+    // We iterate through every combination of id i & j where i!=j.
+    for(int i = 0; i<id_sz-1; ++i) {
+       for(int j = i+1; j<id_sz; ++j) {
+         // We do a swap between functions and break if such swap cannot be performed.
+         TransformationSwapTwoFunctions transformation(function_ids[i], function_ids[j]); 
+         if(!MaybeApplyTransformation(transformation)) {
+           break; 
+         }
+       }
+    }
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/fuzzer_pass_swap_functions.h
+++ b/source/fuzz/fuzzer_pass_swap_functions.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2021 Shiyu Liu
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_FUZZER_PASS_SWAP_FUNCTIONS_H_
+#define SOURCE_FUZZ_FUZZER_PASS_SWAP_FUNCTIONS_H_
+
+#include "source/fuzz/fuzzer_pass.h"
+
+namespace spvtools {
+namespace fuzz {
+
+// Randomly swap functions within a module.
+class FuzzerPassSwapFunctions : public FuzzerPass {
+ public:
+  FuzzerPassSwapFunctions(
+      opt::IRContext* ir_context, TransformationContext* transformation_context,
+      FuzzerContext* fuzzer_context,
+      protobufs::TransformationSequence* transformations);
+
+  void Apply() override;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_FUZZER_PASS_SWAP_FUNCTIONS_H_

--- a/source/fuzz/fuzzer_pass_swap_functions.h
+++ b/source/fuzz/fuzzer_pass_swap_functions.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Shiyu Liu
+// Copyright (c) 2021 Google, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -557,6 +557,7 @@ message Transformation {
     TransformationWrapEarlyTerminatorInFunction wrap_early_terminator_in_function = 83;
     TransformationMergeFunctionReturns merge_function_returns = 84;
     TransformationExpandVectorReduction expand_vector_reduction = 85;
+    TransformationSwapTwoFunctions swap_two_functions = 86;
     // Add additional option using the next available number.
   }
 }
@@ -2258,6 +2259,14 @@ message TransformationSwapConditionalBranchOperands {
   // to invert the guard.
   uint32 fresh_id = 2;
 
+}
+
+message TransformationSwapTwoFunctions {
+   // A transformation that swaps the position of two functions within the same module.
+   
+   // the IDs for the two functions that are swapped.  
+    uint32 function_id1 = 1;
+    uint32 function_id2 = 2; 
 }
 
 message TransformationToggleAccessChainInstruction {

--- a/source/fuzz/transformation_swap_two_functions.cpp
+++ b/source/fuzz/transformation_swap_two_functions.cpp
@@ -50,10 +50,11 @@ bool TransformationMoveSwapTwoFunctions::IsApplicable(
 void TransformationSwapTwoFunctions::Apply(
     opt::IRContext* ir_context, TransformationContext* /*unused*/) const {
   // Found the two functions in ir_context and swap their position. 
-  auto ptr1 = nullptr, iter2 = nullptr; 
+  auto ptr1 = nullptr;
+  auto ptr2 = nullptr; 
   for(auto func_it = *ir_context->module().begin(); func_it!=*ir_context->module().end();++func_it) {
-    if(func_it->result_id()==message_.function_id1()) iter1 = func_it; 
-    if(func_it->result_id()==message_.function_id2()) iter2 = func_it; 
+    if(func_it->result_id()==message_.function_id1()) ptr1 = func_it; 
+    if(func_it->result_id()==message_.function_id2()) ptr2 = func_it; 
   } 
   
   
@@ -62,7 +63,7 @@ void TransformationSwapTwoFunctions::Apply(
   assert(&ptr1!=&ptr2 && "ERRPR: Two functions cannot be the same.");
   //two function pointers are all set, swap the two functions within the module  
   //TODO 
-  std::iter_swap(ptr1, pt2); 
+  std::iter_swap(ptr1, ptr2); 
 }
 
 protobufs::Transformation TransformationSwapTwoFunctions::ToMessage() const {

--- a/source/fuzz/transformation_swap_two_functions.cpp
+++ b/source/fuzz/transformation_swap_two_functions.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Shiyu Liu 
+// Copyright (c) 2021 Google, LLC 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/fuzz/transformation_swap_two_functions.cpp
+++ b/source/fuzz/transformation_swap_two_functions.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Google LLC
+// Copyright (c) 2021 Shiyu Liu 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,17 +31,19 @@ TransformationSwapTwoFunctions::TransformationSwapTwoFunctions(uint32_t id1, uin
 bool TransformationMoveSwapTwoFunctions::IsApplicable(
     opt::IRContext* ir_context, const TransformationContext& /*unused*/) const {
   // Go through every function in ir_context and return true only when both ids are found.
-  //not applicable since two swapped functions are the same one. 
+  // not applicable since two swapped functions are the same one. 
   if(message_.function_id1()==message_.function_id2()) return false;  
 
-  bool foundFunc1 = false, foundFunc2 = false;
+  bool found_func1 = false; 
+  bool found_func2 = false;
   
-  for (auto& function : *ir_context->module()) {//iterate through every functions in module
-    if(function->result_id()==message_.function_id1()) foundFunc1 = true;
-    if(function->result_id()==message_.function_id2()) foundFunc2 = true;
+  // Iterate through every functions in a module
+  for (auto& function : *ir_context->module()) {
+    if(function->result_id()==message_.function_id1()) found_func1 = true;
+    if(function->result_id()==message_.function_id2()) found_func2 = true;
   }
 
-  // return true only when both functions are found with given ids
+  // Return true only when both functions are found with given ids
   return foundFunc1 && foundFunc2;
 }
 
@@ -55,9 +57,9 @@ void TransformationSwapTwoFunctions::Apply(
   } 
   
   
-  assert(ptr1!=nullptr && "Whoops, function 1 was not found."); 
-  assert(ptr2!=nullptr && "Whoops, function 2 was not found.");
-  assert(&ptr1!=&ptr2 && "Whoops, two functions cannot be the same");
+  assert(ptr1!=nullptr && "ERROR: Function 1 was not found with the given id."); 
+  assert(ptr2!=nullptr && "ERROR: Function 2 was not found with the given id.");
+  assert(&ptr1!=&ptr2 && "ERRPR: Two functions cannot be the same.");
   //two function pointers are all set, swap the two functions within the module  
   //TODO 
   std::iter_swap(ptr1, pt2); 

--- a/source/fuzz/transformation_swap_two_functions.cpp
+++ b/source/fuzz/transformation_swap_two_functions.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/fuzz/transformation_swap_two_functions.h"
+
+#include "source/opt/function.h"
+
+namespace spvtools {
+namespace fuzz {
+
+TransformationSwapTwoFunctions::TransformationSwapTwoFunctions(
+    protobufs::TransformationSwapTwoFunctions message)
+    : message_(std::move(message)) {}
+
+TransformationSwapTwoFunctions::TransformationSwapTwoFunctions(uint32_t id1, uint32_t id2) {
+  message_.set_function_id1(id1);
+  message_.set_function_id2(id2);
+}
+
+bool TransformationMoveSwapTwoFunctions::IsApplicable(
+    opt::IRContext* ir_context, const TransformationContext& /*unused*/) const {
+  // Go through every function in ir_context and return true only when both ids are found.
+  //not applicable since two swapped functions are the same one. 
+  if(message_.function_id1()==message_.function_id2()) return false;  
+
+  bool foundFunc1 = false, foundFunc2 = false;
+  
+  for (auto& function : *ir_context->module()) {//iterate through every functions in module
+    if(function->result_id()==message_.function_id1()) foundFunc1 = true;
+    if(function->result_id()==message_.function_id2()) foundFunc2 = true;
+  }
+
+  // return true only when both functions are found with given ids
+  return foundFunc1 && foundFunc2;
+}
+
+void TransformationSwapTwoFunctions::Apply(
+    opt::IRContext* ir_context, TransformationContext* /*unused*/) const {
+  // Found the two functions in ir_context and swap their position. 
+  auto ptr1 = nullptr, iter2 = nullptr; 
+  for(auto func_it = *ir_context->module().begin(); func_it!=*ir_context->module().end();++func_it) {
+    if(func_it->result_id()==message_.function_id1()) iter1 = func_it; 
+    if(func_it->result_id()==message_.function_id2()) iter2 = func_it; 
+  } 
+  
+  
+  assert(ptr1!=nullptr && "Whoops, function 1 was not found."); 
+  assert(ptr2!=nullptr && "Whoops, function 2 was not found.");
+  assert(&ptr1!=&ptr2 && "Whoops, two functions cannot be the same");
+  //two function pointers are all set, swap the two functions within the module  
+  //TODO 
+  std::iter_swap(ptr1, pt2); 
+}
+
+protobufs::Transformation TransformationSwapTwoFunctions::ToMessage() const {
+  protobufs::Transformation result;
+  *result.mutable_swap_two_functions() = message_;
+  return result;
+}
+
+std::unordered_set<uint32_t> TransformationSwapTwoFunctions::GetFreshIds() const {
+  return std::unordered_set<uint32_t>();
+}
+
+}  // namespace fuzz
+}  // namespace spvtools

--- a/source/fuzz/transformation_swap_two_functions.h
+++ b/source/fuzz/transformation_swap_two_functions.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Shiyu Liu
+// Copyright (c) 2021 Google, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/fuzz/transformation_swap_two_functions.h
+++ b/source/fuzz/transformation_swap_two_functions.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_FUZZ_TRANSFORMATION_SWAP_TWO_FUNCTIONS_H_
+#define SOURCE_FUZZ_TRANSFORMATION_SWAP_TWO_FUNCTIONS_H_
+
+#include "source/fuzz/protobufs/spirvfuzz_protobufs.h"
+#include "source/fuzz/transformation.h"
+#include "source/fuzz/transformation_context.h"
+#include "source/opt/ir_context.h"
+
+namespace spvtools {
+namespace fuzz {
+
+class TransformationSwapTwoFunctions : public Transformation {
+ public:
+  explicit TransformationSwapTwoFunctions(
+      protobufs::TransformationSwapTwoFunctions message);
+
+  explicit TransformationSwapTwoFunctions(uint32_t id1, uint32_t id2);
+
+  // TODO: edit requirements
+  // a and b cannot be the same  
+  // both a and b should be reachable
+  bool IsApplicable(
+      opt::IRContext* ir_context,
+      const TransformationContext& transformation_context) const override;
+
+  // The position between functions with |message_.id1| and |message_.id2| are swapped.
+  void Apply(opt::IRContext* ir_context,
+             TransformationContext* transformation_context) const override;
+
+  std::unordered_set<uint32_t> GetFreshIds() const override;
+
+  protobufs::Transformation ToMessage() const override;
+
+ private:
+  protobufs::TransformationSwapTwoFunctions message_;
+};
+
+}  // namespace fuzz
+}  // namespace spvtools
+
+#endif  // SOURCE_FUZZ_TRANSFORMATION_SWAP_TWO_FUNCTIONS_H_

--- a/source/fuzz/transformation_swap_two_functions.h
+++ b/source/fuzz/transformation_swap_two_functions.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Google LLC
+// Copyright (c) 2021 Shiyu Liu
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ class TransformationSwapTwoFunctions : public Transformation {
   explicit TransformationSwapTwoFunctions(
       protobufs::TransformationSwapTwoFunctions message);
 
-  explicit TransformationSwapTwoFunctions(uint32_t id1, uint32_t id2);
+  TransformationSwapTwoFunctions(uint32_t id1, uint32_t id2);
 
   // TODO: edit requirements
   // a and b cannot be the same  

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -114,6 +114,7 @@ if (${SPIRV_BUILD_FUZZER})
           transformation_store_test.cpp
           transformation_swap_commutable_operands_test.cpp
           transformation_swap_conditional_branch_operands_test.cpp
+          tramsformation_swap_two_functions_test.cpp
           transformation_toggle_access_chain_instruction_test.cpp
           transformation_record_synonymous_constants_test.cpp
           transformation_vector_shuffle_test.cpp

--- a/test/fuzz/transformation_swap_two_functions_test.cpp
+++ b/test/fuzz/transformation_swap_two_functions_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Shiyu Liu
+// Copyright (c) 2021 Google, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,5 +12,100 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "source/fuzz/transformation_swap_two_functions.h"
+
+#include "gtest/gtest.h"
+#include "source/fuzz/fuzzer_util.h"
+#include "test/fuzz/fuzz_test_util.h"
 
 
+namespace spvtools {
+namespace fuzz {
+namespace {
+
+TEST(TransformationSwapTwoFunctionsTest, SimpleTest) {
+
+
+// layout(location=0) in float value;
+// void main() {
+// 
+// }
+//
+// float multiplyBy2(in float value) {
+//   return value*2.0;
+// }
+//
+// float multiplyBy4(in float value) {
+//   return multiplyBy2(value)*2.0;
+// }
+
+// float multiplyBy8(in float value) {
+//   return multiplyBy2(value)*multiplyBy4(value);
+// }
+  std::string shader = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main" %8
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %8 "value"
+               OpDecorate %8 Location 0
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeFloat 32
+          %7 = OpTypePointer Input %6
+          %8 = OpVariable %7 Input
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+
+  )";
+  const auto env = SPV_ENV_UNIVERSAL_1_3; 
+  const auto consumer = nullptr;
+  const auto context = BuildModule(env, consumer, shader, kFuzzAssembleOption);
+  spvtools::ValidatorOptions validator_options;
+  TransformationContext transformation_context(
+      MakeUnique<FactManager>(context.get()), validator_options);
+
+  // Function 1 should not swap with itself
+  auto same_func_swap = TransformationSwapTwoFunctions(1, 1);
+  ASSERT_FALSE(
+     same_func_swap.IsApplicable(context.get(), transformation_context)); 
+
+  // Function 1 is reachable, Function with id 5 is not reachable (not in range)
+  auto swap_1_and_5 = TransformationSwapTwoFunctions(1, 5); 
+  ASSERT_FALSE(
+    swap_1_and_5.IsApplicable(context.get(), transformation_context));
+
+  // Function 5 is not reachable, function 2 is.
+  auto swap_5_and_2 = TransformationSwapTwoFunctions(5,2)
+  ASSERT_FALSE(
+    swap_5_and_2.IsApplicable(context.get(), transformation_context));  
+
+  // Both function 5 and 6 are not reachable. 
+  auto swap_5_and_6 = TransformationSwapTwoFunctions(5,6); 
+  ASSERT_FALSE(
+    swap_5_and_6.IsApplicable(context.get(), transformation_context));   
+
+  //Function 2 and 3 should swap successfully. 
+  ASSERT_TRUE(
+    TransformationSwapTwoFunctions(2,3).IsApplicable(context.get(), transformation_context));  
+
+  //Function 1 and 4 should swap successfully. 
+   ASSERT_TRUE(                                                                                                       TransformationSwapTwoFunctions(1,4).IsApplicable(context.get(), transformation_context));
+
+  std::string after_transformation = R"(
+
+
+
+  )";
+  // Final check to make sure the serious transformation above is correct. 
+  ASSERT_TRUE(IsEqual(env, after_transformation, context.get()));
+}
+
+} // namespace 
+} // namespace fuzz
+} // namespace spvtools

--- a/test/fuzz/transformation_swap_two_functions_test.cpp
+++ b/test/fuzz/transformation_swap_two_functions_test.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2021 Shiyu Liu
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+


### PR DESCRIPTION
I do have some questions about the swap implementation though. 
I think that for consistency of style and convenience, it might be beneficial to add something like "SwapFunctions" 
function in source/opt/module.h and apply the function directly in transformation_swap_two_functions.cpp. 

In the header file, I don't know whether functions have more requirements needed to consider. Functions within the same 
module don't have any dominance as the order should not affect how functions are connected to each other, unlike blocks 
of code within a function where certain blocks predominate others. Other than the swapped functions cannot be the same 
and the functions should have an existing id within the module, I can not think of other requirements at this point.

But right now, I'm not sure if iter_swap would work as intended. This is different from the way move_block_down was 
implemented.