### PR TITLE
Fix dangling phi bug from loop-unroll

### DIFF
--- a/source/opt/loop_unroller.cpp
+++ b/source/opt/loop_unroller.cpp
@@ -108,11 +108,11 @@ struct LoopUnrollState {
     previous_phi_ = new_phi;
     previous_latch_block_ = new_latch_block;
     previous_condition_block_ = new_condition_block;
-    previous_phis_ = std::move(new_phis_);
     for (size_t index = 0; index < previous_phis_.size(); ++index) {
       previous_phi_value_ids_[index] =
           new_inst[previous_phis_[index]->result_id()];
     }
+    previous_phis_ = std::move(new_phis_);
 
     // Clear new nodes.
     new_phi = nullptr;

--- a/source/opt/loop_unroller.cpp
+++ b/source/opt/loop_unroller.cpp
@@ -90,8 +90,7 @@ struct LoopUnrollState {
 
   // Initialize from the loop descriptor class.
   LoopUnrollState(Instruction* induction, BasicBlock* latch_block,
-                  BasicBlock* condition, std::vector<Instruction*>&& phis,
-                  std::vector<uint32_t>&& phi_initial_value_ids)
+                  BasicBlock* condition, std::vector<Instruction*>&& phis)
       : previous_phi_(induction),
         previous_latch_block_(latch_block),
         previous_condition_block_(condition),
@@ -100,7 +99,6 @@ struct LoopUnrollState {
         new_condition_block(nullptr),
         new_header_block(nullptr) {
     previous_phis_ = std::move(phis);
-    previous_phi_value_ids_ = std::move(phi_initial_value_ids);
   }
 
   // Swap the state so that the new nodes are now the previous nodes.
@@ -108,10 +106,6 @@ struct LoopUnrollState {
     previous_phi_ = new_phi;
     previous_latch_block_ = new_latch_block;
     previous_condition_block_ = new_condition_block;
-    for (size_t index = 0; index < previous_phis_.size(); ++index) {
-      previous_phi_value_ids_[index] =
-          new_inst[previous_phis_[index]->result_id()];
-    }
     previous_phis_ = std::move(new_phis_);
 
     // Clear new nodes.
@@ -132,9 +126,6 @@ struct LoopUnrollState {
 
   // All the phi nodes from the previous loop iteration.
   std::vector<Instruction*> previous_phis_;
-
-  // All the ids of phi node values from the previous loop iteration.
-  std::vector<uint32_t> previous_phi_value_ids_;
 
   std::vector<Instruction*> new_phis_;
 
@@ -205,10 +196,6 @@ class LoopUnrollerUtilsImpl {
 
   // Get the ID of the variable in the |phi| paired with |label|.
   uint32_t GetPhiDefID(const Instruction* phi, uint32_t label) const;
-
-  // Get the ID of the value of phi instruction with |phi_id| from the previous
-  // loop iteration. If |phi_id| is not a loop induction, it returns 0.
-  uint32_t GetPhiValueFromPreviousIterationAsId(uint32_t phi_id);
 
   // Close the loop by removing the OpLoopMerge from the |loop| header block and
   // making the backedge point to the merge block.
@@ -550,18 +537,8 @@ void LoopUnrollerUtilsImpl::Unroll(Loop* loop, size_t factor) {
 
   std::vector<Instruction*> inductions;
   loop->GetInductionVariables(inductions);
-  std::vector<uint32_t> induction_initial_value_ids(inductions.size(), 0);
-  auto* preheader_block = loop->GetPreHeaderBlock();
-  if (preheader_block != nullptr) {
-    for (size_t index = 0; index < inductions.size(); ++index) {
-      induction_initial_value_ids[index] =
-          GetPhiDefID(inductions[index], preheader_block->id());
-    }
-  }
-
   state_ = LoopUnrollState{loop_induction_variable_, loop->GetLatchBlock(),
-                           loop_condition_block_, std::move(inductions),
-                           std::move(induction_initial_value_ids)};
+                           loop_condition_block_, std::move(inductions)};
   for (size_t i = 0; i < factor - 1; ++i) {
     CopyBody(loop, true);
   }
@@ -727,14 +704,8 @@ void LoopUnrollerUtilsImpl::CopyBody(Loop* loop, bool eliminate_conditions) {
     assert(induction_clone->result_id() != 0);
 
     if (!state_.previous_phis_.empty()) {
-      auto phi_value_id_from_latch = GetPhiDefID(
+      state_.new_inst[primary_copy->result_id()] = GetPhiDefID(
           state_.previous_phis_[index], state_.previous_latch_block_->id());
-      auto phi_value_id_from_previous_iteration =
-          GetPhiValueFromPreviousIterationAsId(phi_value_id_from_latch);
-      state_.new_inst[primary_copy->result_id()] =
-          phi_value_id_from_previous_iteration == 0
-              ? phi_value_id_from_latch
-              : phi_value_id_from_previous_iteration;
     } else {
       // Do not replace the first phi block ids.
       state_.new_inst[primary_copy->result_id()] = primary_copy->result_id();
@@ -769,16 +740,6 @@ uint32_t LoopUnrollerUtilsImpl::GetPhiDefID(const Instruction* phi,
     }
   }
   assert(false && "Could not find a phi index matching the provided label");
-  return 0;
-}
-
-uint32_t LoopUnrollerUtilsImpl::GetPhiValueFromPreviousIterationAsId(
-    uint32_t phi_id) {
-  for (size_t index = 0; index < state_.previous_phis_.size(); ++index) {
-    if (state_.previous_phis_[index]->result_id() == phi_id) {
-      return state_.previous_phi_value_ids_[index];
-    }
-  }
   return 0;
 }
 
@@ -835,6 +796,9 @@ void LoopUnrollerUtilsImpl::CloseUnrolledLoop(Loop* loop) {
 
   for (BasicBlock* block : loop_blocks_inorder_) {
     RemapOperands(block);
+  }
+  for (auto& block_itr : blocks_to_add_) {
+    RemapOperands(block_itr.get());
   }
 
   // Rewrite the last phis, since they may still reference the original phi.

--- a/test/opt/loop_optimizations/unroll_simple.cpp
+++ b/test/opt/loop_optimizations/unroll_simple.cpp
@@ -3406,86 +3406,51 @@ TEST_F(PassClassTest, UnrollWithPhiReferencesPhi) {
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
-               OpEntryPoint GLCompute %csMain "csMain" %gl_LocalInvocationID %gl_WorkGroupID %gl_GlobalInvocationID
-               OpExecutionMode %csMain LocalSize 64 1 1
+               OpEntryPoint Fragment %main "main" %color
+               OpExecutionMode %main OriginUpperLeft
                OpSource HLSL 600
-               OpName %type_2d_image "type.2d.image"
-               OpName %blurOutput "blurOutput"
-               OpName %csMain "csMain"
-               OpDecorate %gl_LocalInvocationID BuiltIn LocalInvocationId
-               OpDecorate %gl_WorkGroupID BuiltIn WorkgroupId
-               OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
-               OpDecorate %blurOutput DescriptorSet 0
-               OpDecorate %blurOutput Binding 0
-               OpDecorate %138 NoContraction
+               OpName %main "main"
+               OpName %color "color"
+               OpDecorate %color Location 0
        %uint = OpTypeInt 32 0
-     %uint_0 = OpConstant %uint 0
-     %v2uint = OpTypeVector %uint 2
-         %37 = OpConstantComposite %v2uint %uint_0 %uint_0
       %float = OpTypeFloat 32
     %float_0 = OpConstant %float 0
     %float_1 = OpConstant %float 1
      %uint_1 = OpConstant %uint 1
      %uint_3 = OpConstant %uint 3
-%type_2d_image = OpTypeImage %float 2D 2 0 0 2 R32f
-%_ptr_UniformConstant_type_2d_image = OpTypePointer UniformConstant %type_2d_image
-     %v3uint = OpTypeVector %uint 3
-%_ptr_Input_v3uint = OpTypePointer Input %v3uint
        %void = OpTypeVoid
-         %51 = OpTypeFunction %void
+         %11 = OpTypeFunction %void
        %bool = OpTypeBool
- %blurOutput = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant
-%gl_LocalInvocationID = OpVariable %_ptr_Input_v3uint Input
-%gl_WorkGroupID = OpVariable %_ptr_Input_v3uint Input
-%gl_GlobalInvocationID = OpVariable %_ptr_Input_v3uint Input
-        %158 = OpUndef %float
-       %true = OpConstantTrue %bool
-     %uint_2 = OpConstant %uint 2
-     %csMain = OpFunction %void None %51
-         %59 = OpLabel
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+      %color = OpVariable %_ptr_Output_v4float Output
+       %main = OpFunction %void None %11
+         %15 = OpLabel
+               OpBranch %16
+         %16 = OpLabel
+         %17 = OpPhi %float %float_0 %15 %18 %19
+         %18 = OpPhi %float %float_1 %15 %20 %19
+         %21 = OpPhi %uint %uint_1 %15 %22 %19
+         %23 = OpULessThanEqual %bool %21 %uint_3
+               OpLoopMerge %24 %19 Unroll
+               OpBranchConditional %23 %25 %24
+         %25 = OpLabel
 
-; CHECK: [[phi0_init:%\w+]] = OpUndef %float
-; CHECK: [[phi1_init:%\w+]] = OpFSub %float [[phi0_init]] [[phi0_init]]
+; First loop iteration
+; CHECK: [[next_phi1_0:%\w+]] = OpFSub %float %float_1 %float_0
 
-        %117 = OpFSub %float %158 %158
-               OpBranch %118
-        %118 = OpLabel
+; Second loop iteration
+; CHECK: [[next_phi1_1:%\w+]] = OpFSub %float [[next_phi1_0]] %float_1
 
-; CHECK:      [[next_phi1_0:%\w+]] = OpFSub %float [[phi1_init]] [[phi0_init]]
-; CHECK-NEXT:                        OpFSub %float [[next_phi1_0]] [[phi1_init]]
+; Third loop iteration
+; CHECK:                        OpFSub %float [[next_phi1_1]] [[next_phi1_0]]
 
-; CHECK:      [[next_phi1_1:%\w+]] = OpFSub %float [[next_phi1_0]] [[phi1_init]]
-; CHECK-NEXT:                        OpFSub %float [[next_phi1_1]] [[next_phi1_0]]
-
-; CHECK:      [[next_phi1_2:%\w+]] = OpFSub %float [[next_phi1_1]] [[next_phi1_0]]
-; CHECK-NEXT:                        OpFSub %float [[next_phi1_2]] [[next_phi1_1]]
-
-        %164 = OpPhi %float %float_1 %59 %130 %148
-        %163 = OpPhi %float %158 %59 %162 %148
-        %162 = OpPhi %float %117 %59 %124 %148
-        %161 = OpPhi %float %float_0 %59 %138 %148
-        %160 = OpPhi %float %float_0 %59 %141 %148
-        %159 = OpPhi %uint %uint_1 %59 %150 %148
-        %120 = OpULessThanEqual %bool %159 %uint_3
-               OpLoopMerge %151 %148 Unroll
-               OpBranchConditional %120 %121 %151
-        %121 = OpLabel
-        %124 = OpFSub %float %162 %163
-        %127 = OpFSub %float %124 %162
-        %128 = OpExtInst %float %1 FAbs %127
-        %130 = OpFMul %float %164 %128
-        %132 = OpConvertUToF %float %159
-        %134 = OpFMul %float %132 %130
-        %138 = OpExtInst %float %1 Fma %float_0 %134 %161
-        %141 = OpFAdd %float %160 %134
-               OpBranch %148
-        %148 = OpLabel
-        %150 = OpIAdd %uint %159 %uint_1
-               OpBranch %118
-        %151 = OpLabel
-        %154 = OpFDiv %float %161 %160
-        %157 = OpLoad %type_2d_image %blurOutput
-               OpImageWrite %157 %37 %154 None
+         %20 = OpFSub %float %18 %17
+               OpBranch %19
+         %19 = OpLabel
+         %22 = OpIAdd %uint %21 %uint_1
+               OpBranch %16
+         %24 = OpLabel
                OpReturn
                OpFunctionEnd
 )";
@@ -3508,89 +3473,56 @@ TEST_F(PassClassTest, UnrollWithTwoPhisReferencePhis) {
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
-               OpEntryPoint GLCompute %csMain "csMain" %gl_LocalInvocationID %gl_WorkGroupID %gl_GlobalInvocationID
-               OpExecutionMode %csMain LocalSize 64 1 1
+               OpEntryPoint Fragment %main "main" %color
+               OpExecutionMode %main OriginUpperLeft
                OpSource HLSL 600
-               OpName %type_2d_image "type.2d.image"
-               OpName %blurOutput "blurOutput"
-               OpName %csMain "csMain"
-               OpDecorate %gl_LocalInvocationID BuiltIn LocalInvocationId
-               OpDecorate %gl_WorkGroupID BuiltIn WorkgroupId
-               OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
-               OpDecorate %blurOutput DescriptorSet 0
-               OpDecorate %blurOutput Binding 0
-               OpDecorate %138 NoContraction
+               OpName %main "main"
+               OpName %color "color"
+               OpDecorate %color Location 0
        %uint = OpTypeInt 32 0
-     %uint_0 = OpConstant %uint 0
-     %v2uint = OpTypeVector %uint 2
-         %37 = OpConstantComposite %v2uint %uint_0 %uint_0
       %float = OpTypeFloat 32
     %float_0 = OpConstant %float 0
     %float_1 = OpConstant %float 1
      %uint_1 = OpConstant %uint 1
      %uint_3 = OpConstant %uint 3
-%type_2d_image = OpTypeImage %float 2D 2 0 0 2 R32f
-%_ptr_UniformConstant_type_2d_image = OpTypePointer UniformConstant %type_2d_image
-     %v3uint = OpTypeVector %uint 3
-%_ptr_Input_v3uint = OpTypePointer Input %v3uint
        %void = OpTypeVoid
-         %51 = OpTypeFunction %void
+         %11 = OpTypeFunction %void
        %bool = OpTypeBool
- %blurOutput = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant
-%gl_LocalInvocationID = OpVariable %_ptr_Input_v3uint Input
-%gl_WorkGroupID = OpVariable %_ptr_Input_v3uint Input
-%gl_GlobalInvocationID = OpVariable %_ptr_Input_v3uint Input
-        %158 = OpUndef %float
-       %true = OpConstantTrue %bool
-     %uint_2 = OpConstant %uint 2
-     %csMain = OpFunction %void None %51
-         %59 = OpLabel
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+      %color = OpVariable %_ptr_Output_v4float Output
+       %main = OpFunction %void None %11
+         %15 = OpLabel
+               OpBranch %16
+         %16 = OpLabel
+         %17 = OpPhi %float %float_1 %15 %18 %19
+         %18 = OpPhi %float %float_0 %15 %20 %19
+         %20 = OpPhi %float %float_1 %15 %21 %19
+         %22 = OpPhi %uint %uint_1 %15 %23 %19
+         %24 = OpULessThanEqual %bool %22 %uint_3
+               OpLoopMerge %25 %19 Unroll
+               OpBranchConditional %24 %26 %25
+         %26 = OpLabel
 
-; CHECK: [[phi0_init:%\w+]] = OpUndef %float
-; CHECK: [[phi1_init:%\w+]] = OpFSub %float [[phi0_init]] [[phi0_init]]
+; First loop iteration
+; CHECK: [[next_phi1_0:%\w+]] = OpFSub %float %float_1 %float_0
+; CHECK:                        OpFMul %float %float_1
 
-        %117 = OpFSub %float %158 %158
-               OpBranch %118
-        %118 = OpLabel
+; Second loop iteration
+; CHECK: [[next_phi1_1:%\w+]] = OpFSub %float [[next_phi1_0]] %float_1
+; CHECK:                        OpFMul %float %float_0
 
-; CHECK:      [[next_phi1_0:%\w+]] = OpFSub %float [[phi1_init]] [[phi0_init]]
-; CHECK-NEXT:                        OpFSub %float [[next_phi1_0]] [[phi1_init]]
-; CHECK:                             OpFMul %float %float_1
+; Third loop iteration
+; CHECK:                        OpFSub %float [[next_phi1_1]] [[next_phi1_0]]
+; CHECK:                        OpFMul %float %float_1
 
-; CHECK:      [[next_phi1_1:%\w+]] = OpFSub %float [[next_phi1_0]] [[phi1_init]]
-; CHECK-NEXT:                        OpFSub %float [[next_phi1_1]] [[next_phi1_0]]
-; CHECK:                             OpFMul %float [[phi0_init]]
-
-; CHECK:      [[next_phi1_2:%\w+]] = OpFSub %float [[next_phi1_1]] [[next_phi1_0]]
-; CHECK-NEXT:                        OpFSub %float [[next_phi1_2]] [[next_phi1_1]]
-; CHECK:                             OpFMul %float [[phi1_init]]
-
-        %164 = OpPhi %float %float_1 %59 %163 %148
-        %163 = OpPhi %float %158 %59 %162 %148
-        %162 = OpPhi %float %117 %59 %124 %148
-        %161 = OpPhi %float %float_0 %59 %138 %148
-        %160 = OpPhi %float %float_0 %59 %141 %148
-        %159 = OpPhi %uint %uint_1 %59 %150 %148
-        %120 = OpULessThanEqual %bool %159 %uint_3
-               OpLoopMerge %151 %148 Unroll
-               OpBranchConditional %120 %121 %151
-        %121 = OpLabel
-        %124 = OpFSub %float %162 %163
-        %127 = OpFSub %float %124 %162
-        %128 = OpExtInst %float %1 FAbs %127
-        %130 = OpFMul %float %164 %128
-        %132 = OpConvertUToF %float %159
-        %134 = OpFMul %float %132 %130
-        %138 = OpExtInst %float %1 Fma %float_0 %134 %161
-        %141 = OpFAdd %float %160 %134
-               OpBranch %148
-        %148 = OpLabel
-        %150 = OpIAdd %uint %159 %uint_1
-               OpBranch %118
-        %151 = OpLabel
-        %154 = OpFDiv %float %161 %160
-        %157 = OpLoad %type_2d_image %blurOutput
-               OpImageWrite %157 %37 %154 None
+         %21 = OpFSub %float %20 %18
+         %27 = OpFMul %float %17 %21
+               OpBranch %19
+         %19 = OpLabel
+         %23 = OpIAdd %uint %22 %uint_1
+               OpBranch %16
+         %25 = OpLabel
                OpReturn
                OpFunctionEnd
 )";

--- a/test/opt/loop_optimizations/unroll_simple.cpp
+++ b/test/opt/loop_optimizations/unroll_simple.cpp
@@ -3401,6 +3401,108 @@ OpFunctionEnd
   SinglePassRunAndCheck<LoopUnroller>(shader, output, false);
 }
 
+TEST_F(PassClassTest, UnrollWithPhisCrossReferencing) {
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %csMain "csMain" %gl_LocalInvocationID %gl_WorkGroupID %gl_GlobalInvocationID
+               OpExecutionMode %csMain LocalSize 64 1 1
+               OpSource HLSL 600
+               OpName %type_2d_image "type.2d.image"
+               OpName %blurOutput "blurOutput"
+               OpName %csMain "csMain"
+               OpDecorate %gl_LocalInvocationID BuiltIn LocalInvocationId
+               OpDecorate %gl_WorkGroupID BuiltIn WorkgroupId
+               OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
+               OpDecorate %blurOutput DescriptorSet 0
+               OpDecorate %blurOutput Binding 0
+               OpDecorate %138 NoContraction
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+     %v2uint = OpTypeVector %uint 2
+         %37 = OpConstantComposite %v2uint %uint_0 %uint_0
+      %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
+    %float_1 = OpConstant %float 1
+     %uint_1 = OpConstant %uint 1
+     %uint_3 = OpConstant %uint 3
+%type_2d_image = OpTypeImage %float 2D 2 0 0 2 R32f
+%_ptr_UniformConstant_type_2d_image = OpTypePointer UniformConstant %type_2d_image
+     %v3uint = OpTypeVector %uint 3
+%_ptr_Input_v3uint = OpTypePointer Input %v3uint
+       %void = OpTypeVoid
+         %51 = OpTypeFunction %void
+       %bool = OpTypeBool
+ %blurOutput = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant
+%gl_LocalInvocationID = OpVariable %_ptr_Input_v3uint Input
+%gl_WorkGroupID = OpVariable %_ptr_Input_v3uint Input
+%gl_GlobalInvocationID = OpVariable %_ptr_Input_v3uint Input
+        %158 = OpUndef %float
+       %true = OpConstantTrue %bool
+     %uint_2 = OpConstant %uint 2
+     %csMain = OpFunction %void None %51
+         %59 = OpLabel
+
+; CHECK: [[phi0_init:%\w+]] = OpUndef %float
+; CHECK: [[phi1_init:%\w+]] = OpFSub %float [[phi0_init]] [[phi0_init]]
+
+        %117 = OpFSub %float %158 %158
+               OpBranch %118
+        %118 = OpLabel
+
+; CHECK:      [[next_phi1_0:%\w+]] = OpFSub %float [[phi1_init]] [[phi0_init]]
+; CHECK-NEXT:                        OpFSub %float [[next_phi1_0]] [[phi1_init]]
+
+; CHECK:      [[next_phi1_1:%\w+]] = OpFSub %float [[next_phi1_0]] [[phi1_init]]
+; CHECK-NEXT:                        OpFSub %float [[next_phi1_1]] [[next_phi1_0]]
+
+; CHECK:      [[next_phi1_2:%\w+]] = OpFSub %float [[next_phi1_1]] [[next_phi1_0]]
+; CHECK-NEXT:                        OpFSub %float [[next_phi1_2]] [[next_phi1_1]]
+
+        %164 = OpPhi %float %float_1 %59 %130 %148
+        %163 = OpPhi %float %158 %59 %162 %148
+        %162 = OpPhi %float %117 %59 %124 %148
+        %161 = OpPhi %float %float_0 %59 %138 %148
+        %160 = OpPhi %float %float_0 %59 %141 %148
+        %159 = OpPhi %uint %uint_1 %59 %150 %148
+        %120 = OpULessThanEqual %bool %159 %uint_3
+               OpLoopMerge %151 %148 Unroll
+               OpBranchConditional %120 %121 %151
+        %121 = OpLabel
+        %124 = OpFSub %float %162 %163
+        %127 = OpFSub %float %124 %162
+        %128 = OpExtInst %float %1 FAbs %127
+        %130 = OpFMul %float %164 %128
+        %132 = OpConvertUToF %float %159
+        %134 = OpFMul %float %132 %130
+        %138 = OpExtInst %float %1 Fma %float_0 %134 %161
+        %141 = OpFAdd %float %160 %134
+               OpBranch %148
+        %148 = OpLabel
+        %150 = OpIAdd %uint %159 %uint_1
+               OpBranch %118
+        %151 = OpLabel
+        %154 = OpFDiv %float %161 %160
+        %157 = OpLoad %type_2d_image %blurOutput
+               OpImageWrite %157 %37 %154 None
+               OpReturn
+               OpFunctionEnd
+)";
+
+  std::unique_ptr<IRContext> context =
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  Module* module = context->module();
+  EXPECT_NE(nullptr, module) << "Assembling failed for ushader:\n"
+                             << text << std::endl;
+
+  LoopUnroller loop_unroller;
+  SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
+                        SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
+  SinglePassRunAndMatch<LoopUnroller>(text, true);
+}
+
 }  // namespace
 }  // namespace opt
 }  // namespace spvtools

--- a/test/opt/loop_optimizations/unroll_simple.cpp
+++ b/test/opt/loop_optimizations/unroll_simple.cpp
@@ -3468,7 +3468,7 @@ TEST_F(PassClassTest, UnrollWithPhiReferencesPhi) {
   SinglePassRunAndMatch<LoopUnroller>(text, true);
 }
 
-TEST_F(PassClassTest, UnrollWithTwoPhisReferencePhis) {
+TEST_F(PassClassTest, UnrollWithDoublePhiReferencesPhi) {
   const std::string text = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
@@ -3538,6 +3538,76 @@ TEST_F(PassClassTest, UnrollWithTwoPhisReferencePhis) {
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
                         SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
   SinglePassRunAndMatch<LoopUnroller>(text, true);
+}
+
+TEST_F(PassClassTest, PartialUnrollWithPhiReferencesPhi) {
+  // With LocalMultiStoreElimPass
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %color
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 600
+               OpName %main "main"
+               OpName %color "color"
+               OpDecorate %color Location 0
+       %uint = OpTypeInt 32 0
+      %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
+    %float_1 = OpConstant %float 1
+     %uint_1 = OpConstant %uint 1
+     %uint_3 = OpConstant %uint 3
+       %void = OpTypeVoid
+         %11 = OpTypeFunction %void
+       %bool = OpTypeBool
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+      %color = OpVariable %_ptr_Output_v4float Output
+       %main = OpFunction %void None %11
+         %15 = OpLabel
+               OpBranch %16
+         %16 = OpLabel
+         %17 = OpPhi %float %float_0 %15 %18 %19
+         %18 = OpPhi %float %float_1 %15 %20 %19
+         %21 = OpPhi %uint %uint_1 %15 %22 %19
+         %23 = OpULessThanEqual %bool %21 %uint_3
+               OpLoopMerge %24 %19 Unroll
+               OpBranchConditional %23 %25 %24
+         %25 = OpLabel
+
+; CHECK: [[phi0_0:%\w+]] = OpPhi {{%\w+}} {{%\w+}} {{%\w+}} [[phi1_0:%\w+]]
+; CHECK:      [[phi1_0]] = OpPhi {{%\w+}} {{%\w+}} {{%\w+}} [[sub:%\w+]]
+
+; CHECK: [[sub]] = OpFSub {{%\w+}} [[phi1_0]] [[phi0_0]]
+
+; CHECK: [[phi0_1:%\w+]] = OpPhi {{%\w+}} [[phi0_0]]
+; CHECK: [[phi1_1:%\w+]] = OpPhi {{%\w+}} [[phi1_0]]
+
+; CHECK: [[sub:%\w+]] = OpFSub {{%\w+}} [[phi1_1]] [[phi0_1]]
+
+; CHECK: OpFSub {{%\w+}} [[sub]] [[phi1_1]]
+
+         %20 = OpFSub %float %18 %17
+               OpBranch %19
+         %19 = OpLabel
+         %22 = OpIAdd %uint %21 %uint_1
+               OpBranch %16
+         %24 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  std::unique_ptr<IRContext> context =
+      BuildModule(SPV_ENV_UNIVERSAL_1_1, nullptr, text,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  Module* module = context->module();
+  EXPECT_NE(nullptr, module) << "Assembling failed for ushader:\n"
+                             << text << std::endl;
+
+  LoopUnroller loop_unroller;
+  SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
+  SinglePassRunAndMatch<PartialUnrollerTestPass<2>>(text, true);
 }
 
 }  // namespace


### PR DESCRIPTION
When unrolling the following loop:
```
%const0 = OpConstant ...
%const1 = OpConstant ...
...
%LoopHeader = OpLabel
%phi0 = OpPhi %float %const0 %PreHeader %phi1 %Latch
%phi1 = OpPhi %float %const1 %PreHeader %x    %Latch
...
%LoopBody = OpLabel
%x = OpFSub %float %phi1 %phi0
...
```

the loop-unroll pass sets the value of `%phi0` as `%phi1` for the second
copy of the loop body. For example, the second copy of
`%x = OpFSub %float %phi1 %phi0` will be
`%y = OpFSub %float %x %phi1`.

Since all phi instructions for inductions will be removed after the
loop unrolling, `%phi1` will be a dead dangling phi. This CL keeps the
phi value from the previous loop iteration to map instruction operands
to the phi value instead of using phi.

For example, the second copy of `%x = OpFSub %float %phi1 %phi0` will be
`%y = OpFSub %float %x %const1` because the value of `%phi1` from the
first loop iteration is `%const1`.