### PR TITLE
Identity operator in check_copyright.py is not reliable

### DIFF
--- a/utils/check_copyright.py
+++ b/utils/check_copyright.py
@@ -129,7 +129,7 @@ def insert_copyright(author, glob, comment_prefix):
         update_file = False
         for line in fileinput.input(file, inplace=1):
             emit = True
-            if state is 0:
+            if state == 0:
                 if COPYRIGHT_RE.search(line):
                     state = 1
                 elif skip(line):
@@ -140,7 +140,7 @@ def insert_copyright(author, glob, comment_prefix):
                     sys.stdout.write(licensed)
                     # Assume there isn't a previous license notice.
                     state = 1
-            elif state is 1:
+            elif state == 1:
                 if MIT_BEGIN_RE.search(line):
                     state = 2
                     emit = False
@@ -148,7 +148,7 @@ def insert_copyright(author, glob, comment_prefix):
                     # Assume an Apache license is preceded by a copyright
                     # notice.  So just emit it like the rest of the file.
                     state = 9
-            elif state is 2:
+            elif state == 2:
                 # Replace the MIT license with Apache 2
                 emit = False
                 if MIT_END_RE.search(line):


### PR DESCRIPTION
identity operator is not reliable here, because we use the `is` Keyword if we want to check if two variables refer to the same object, and use the `==` operator to check if two variables are equal, e.g.
```python
    x = ['1', '2', '3']
    y = ['1', '2', '3']
    print(x is y) # False 
    print(x == y) # True
```