### PR TITLE
spirv-reduce: Invalidate DefUse analysis

### DIFF
--- a/source/reduce/change_operand_to_undef_reduction_opportunity.cpp
+++ b/source/reduce/change_operand_to_undef_reduction_opportunity.cpp
@@ -35,6 +35,7 @@ void ChangeOperandToUndefReductionOpportunity::Apply() {
   assert(operand_type_id);
   auto undef_id = FindOrCreateGlobalUndef(context_, operand_type_id);
   inst_->SetOperand(operand_index_, {undef_id});
+  context_->InvalidateAnalyses(opt::IRContext::kAnalysisDefUse);
 }
 
 }  // namespace reduce


### PR DESCRIPTION
Fixes #4252.

Also, I've noticed that if you add `CheckValid` to unit tests to all the places it's missing from (e.g. when the initial binary is constructed, after every `TryToApply` etc), a bunch of tests fail. I also have doubts about whether `CheckValid` ensures that the module is well-formed (i.e. all analyses are correct) - maybe `fuzzerutil::IsValidAndWellFormed` can help with that?

Either way, I think refactoring tests (if at all) is better left for a separate PR.