### PR TITLE
don't use MP4

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -426,7 +426,3 @@ if(ENABLE_SPIRV_TOOLS_INSTALL)
   install(FILES ${CMAKE_BINARY_DIR}/${SPIRV_TOOLS}Config.cmake DESTINATION ${PACKAGE_DIR})
 endif(ENABLE_SPIRV_TOOLS_INSTALL)
 
-if(MSVC AND (NOT ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")))
-  # Enable parallel builds across four cores for this lib
-  add_definitions(/MP4)
-endif()

--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -427,10 +427,6 @@ if(SPIRV_BUILD_FUZZER)
         ${CMAKE_CURRENT_BINARY_DIR}/protobufs/spvtoolsfuzz.pb.cc
         )
 
-  if(MSVC AND (NOT ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")))
-    # Enable parallel builds across four cores for this lib
-    add_definitions(/MP4)
-  endif()
 
   spvtools_pch(SPIRV_TOOLS_FUZZ_SOURCES pch_source_fuzz)
 

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -218,11 +218,6 @@ set(SPIRV_TOOLS_OPT_SOURCES
   wrap_opkill.cpp
 )
 
-if(MSVC AND (NOT ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")))
-  # Enable parallel builds across four cores for this lib
-  add_definitions(/MP4)
-endif()
-
 spvtools_pch(SPIRV_TOOLS_OPT_SOURCES pch_source_opt)
 
 add_library(SPIRV-Tools-opt ${SPIRV_TOOLS_LIBRARY_TYPE} ${SPIRV_TOOLS_OPT_SOURCES})

--- a/source/reduce/CMakeLists.txt
+++ b/source/reduce/CMakeLists.txt
@@ -71,10 +71,6 @@ set(SPIRV_TOOLS_REDUCE_SOURCES
         simple_conditional_branch_to_branch_reduction_opportunity.cpp
 )
 
-if(MSVC AND (NOT ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")))
-  # Enable parallel builds across four cores for this lib
-  add_definitions(/MP4)
-endif()
 
 spvtools_pch(SPIRV_TOOLS_REDUCE_SOURCES pch_source_reduce)
 


### PR DESCRIPTION
I have a 32 thread machine, and I noticed when updating the version of spirv-tools in vcpkg (to 2021.1) that the compiler actually bailed due to memory limits. This is because you were passing /MP4, causing the compiler process to spawn sub-processes for some files, in addition to the processes that ninja was spawning.

Inserting /MP4 like this also slows down builds for people using visual studio, since it will limit parallelism to four processes, regardless of what the top level project had set.

In general it's best to leave the setting of /MP up to the top level project instead of overriding it like this.