### PR TITLE
spirv-fuzz: Fix def-use update in PermutePhiOperands

### DIFF
--- a/source/fuzz/transformation_permute_phi_operands.cpp
+++ b/source/fuzz/transformation_permute_phi_operands.cpp
@@ -81,8 +81,7 @@ void TransformationPermutePhiOperands::Apply(
   inst->SetInOperands(std::move(permuted_operands));
 
   // Update the def-use manager.
-  ir_context->get_def_use_mgr()->ClearInst(inst);
-  ir_context->get_def_use_mgr()->AnalyzeInstDefUse(inst);
+  ir_context->UpdateDefUse(inst);
 }
 
 protobufs::Transformation TransformationPermutePhiOperands::ToMessage() const {


### PR DESCRIPTION
The def-use manager was being incorrectly updated in
TransformationPermutePhiOperands, and this was causing future
transformations to go wrong during fuzzing. This change updates the
def-use manager in a correct manner, and adds a test exposing the
previous bug.

Fixes #4300.