### PR TITLE
Check that valid bitcasted constant was returned

### DIFF
--- a/source/opt/folding_rules.cpp
+++ b/source/opt/folding_rules.cpp
@@ -1867,6 +1867,8 @@ FoldingRule BitCastScalarOrVector() {
 
     const analysis::Constant* bitcasted_constant =
         ConvertWordsToNumericScalarOrVectorConstant(const_mgr, words, type);
+    if (!bitcasted_constant) return false;
+
     auto new_feeder_id =
         const_mgr->GetDefiningInstruction(bitcasted_constant, inst->type_id())
             ->result_id();


### PR DESCRIPTION
This call returns nullptr to indicate errors.

Fixes https://crbug.com/1213365