### PR TITLE
Spirv-fuzz: Improve TransformationAddBitInstructionSynonym to check integer signedness

### DIFF
--- a/source/fuzz/fuzzer_pass_add_bit_instruction_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_add_bit_instruction_synonyms.cpp
@@ -56,6 +56,57 @@ void FuzzerPassAddBitInstructionSynonyms::Apply() {
           continue;
         }
 
+        // Make sure fuzzer never applies a transformation to a bitwise
+        // instruction with differently signed operands.
+        if (instruction.opcode() == SpvOpBitwiseOr ||
+            instruction.opcode() == SpvOpBitwiseXor ||
+            instruction.opcode() == SpvOpBitwiseAnd ||
+            instruction.opcode() == SpvOpNot) {
+          auto ir_context = this->GetIRContext();
+
+          if (instruction.opcode() == SpvOpNot) {
+            auto operand = instruction.GetInOperand(0).words[0];
+            auto operand_inst = ir_context->get_def_use_mgr()->GetDef(operand);
+            auto operand_type =
+                ir_context->get_type_mgr()->GetType(operand_inst->type_id());
+            auto operand_sign = operand_type->AsInteger()->IsSigned();
+
+            auto type_id_sign = ir_context->get_type_mgr()
+                                    ->GetType(instruction.type_id())
+                                    ->AsInteger()
+                                    ->IsSigned();
+
+            if (operand_sign != type_id_sign) {
+              continue;
+            }
+          }
+
+          // Other BitWise operations that takes two operands.
+          auto first_operand = instruction.GetInOperand(0).words[0];
+          auto first_operand_inst =
+              ir_context->get_def_use_mgr()->GetDef(first_operand);
+          auto first_operand_type = ir_context->get_type_mgr()->GetType(
+              first_operand_inst->type_id());
+          auto first_operand_sign = first_operand_type->AsInteger()->IsSigned();
+
+          auto second_operand = instruction.GetInOperand(1).words[0];
+          auto second_operand_inst =
+              ir_context->get_def_use_mgr()->GetDef(second_operand);
+          auto second_operand_type = ir_context->get_type_mgr()->GetType(
+              second_operand_inst->type_id());
+          auto second_operand_sign =
+              second_operand_type->AsInteger()->IsSigned();
+
+          auto type_id_sign = ir_context->get_type_mgr()
+                                  ->GetType(instruction.type_id())
+                                  ->AsInteger()
+                                  ->IsSigned();
+
+          if ((first_operand_sign != second_operand_sign) && type_id_sign) {
+            continue;
+          }
+        }
+
         // Right now, only integer operands are supported.
         if (GetIRContext()
                 ->get_type_mgr()

--- a/source/fuzz/transformation_add_bit_instruction_synonym.cpp
+++ b/source/fuzz/transformation_add_bit_instruction_synonym.cpp
@@ -50,6 +50,50 @@ bool TransformationAddBitInstructionSynonym::IsApplicable(
     return false;
   }
 
+  // Signedness of the operands must be the same.
+  if ((instruction->opcode() == SpvOpBitwiseOr ||
+       instruction->opcode() == SpvOpBitwiseXor ||
+       instruction->opcode() == SpvOpBitwiseAnd ||
+       instruction->opcode() == SpvOpNot)) {
+    // Operations on SpvOpNot.
+    if (instruction->opcode() == SpvOpNot) {
+      auto operand = instruction->GetInOperand(0).words[0];
+      auto operand_inst = ir_context->get_def_use_mgr()->GetDef(operand);
+      auto operand_type =
+          ir_context->get_type_mgr()->GetType(operand_inst->type_id());
+      auto operand_sign = operand_type->AsInteger()->IsSigned();
+
+      auto type_id_sign = ir_context->get_type_mgr()
+                              ->GetType(instruction->type_id())
+                              ->AsInteger()
+                              ->IsSigned();
+
+      return operand_sign == type_id_sign;
+    }
+
+    // Other BitWise operations that takes two operands.
+    auto first_operand = instruction->GetInOperand(0).words[0];
+    auto first_operand_inst =
+        ir_context->get_def_use_mgr()->GetDef(first_operand);
+    auto first_operand_type =
+        ir_context->get_type_mgr()->GetType(first_operand_inst->type_id());
+    auto first_operand_sign = first_operand_type->AsInteger()->IsSigned();
+
+    auto second_operand = instruction->GetInOperand(1).words[0];
+    auto second_operand_inst =
+        ir_context->get_def_use_mgr()->GetDef(second_operand);
+    auto second_operand_type =
+        ir_context->get_type_mgr()->GetType(second_operand_inst->type_id());
+    auto second_operand_sign = second_operand_type->AsInteger()->IsSigned();
+
+    auto type_id_sign = ir_context->get_type_mgr()
+                            ->GetType(instruction->type_id())
+                            ->AsInteger()
+                            ->IsSigned();
+
+    return (first_operand_sign == second_operand_sign) && type_id_sign;
+  }
+
   // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/3792):
   //  Right now, only integer operands are supported.
   if (ir_context->get_type_mgr()->GetType(instruction->type_id())->AsVector()) {

--- a/test/fuzz/transformation_add_bit_instruction_synonym_test.cpp
+++ b/test/fuzz/transformation_add_bit_instruction_synonym_test.cpp
@@ -937,7 +937,7 @@ TEST(TransformationAddBitInstructionSynonymTest, NoSynonymWhenBlockIsDead) {
       MakeDataDescriptor(166, {}), MakeDataDescriptor(39, {})));
 }
 
-TEST(TransformationAddBitInstructionSynonymTest, DISABLED_DifferentSingedness) {
+TEST(TransformationAddBitInstructionSynonymTest, ENABLED_DifferentSingedness) {
   // This test will fail due to a bug in the transformation. The reason is that
   // OpNot supports its operand and result type having different signedness.
   // OpBitFieldUExtract and OpBitFieldInsert, however, don't support this


### PR DESCRIPTION
This PR fixes #4170, by check the signedness of bitwise operands in transformation and fuzzer for avoiding `Expected Base Type to be equal to Result Type`.