### PR TITLE
Add kInstErrorMax to instrument.hpp

### DIFF
--- a/include/spirv-tools/instrument.hpp
+++ b/include/spirv-tools/instrument.hpp
@@ -178,6 +178,7 @@ static const int kInstErrorBuffOOBUniform = 4;
 static const int kInstErrorBuffOOBStorage = 5;
 static const int kInstErrorBuffOOBUniformTexel = 6;
 static const int kInstErrorBuffOOBStorageTexel = 7;
+static const int kInstErrorMax = kInstErrorBuffOOBStorageTexel;
 
 // Direct Input Buffer Offsets
 //


### PR DESCRIPTION
To allow for extending GPU-AV error codes outside of spirv-tools.