### PR TITLE
Add SPV_KHR_vulkan_memory_model to aggressive_dead_code_elim

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -996,6 +996,7 @@ void AggressiveDCEPass::InitExtensions() {
       "SPV_EXT_physical_storage_buffer",
       "SPV_KHR_terminate_invocation",
       "SPV_KHR_shader_clock",
+      "SPV_KHR_vulkan_memory_model",
   });
 }
 


### PR DESCRIPTION
Fixes #4296

Related similar PRs: #4047 #4049

I don't know if this omission was intentional or not, and so I filed #4296, and seems like I should file a PR instead, so here we are.