### PR TITLE
Support Intel extensions for fixed point and hls-float

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -264,6 +264,10 @@ typedef enum spv_operand_type_t {
   // https://github.com/intel/llvm/blob/39fa9b0cbfbae88327118990a05c5b387b56d2ef/sycl/doc/extensions/SPIRV/SPV_INTEL_float_controls2.asciidoc
   SPV_OPERAND_TYPE_FPDENORM_MODE,     // Sec 3.17 FP Denorm Mode
   SPV_OPERAND_TYPE_FPOPERATION_MODE,  // Sec 3.18 FP Operation Mode
+  // A value enum from https://github.com/KhronosGroup/SPIRV-Headers/pull/177
+  SPV_OPERAND_TYPE_QUANTIZATION_MODES,
+  // A value enum from https://github.com/KhronosGroup/SPIRV-Headers/pull/177
+  SPV_OPERAND_TYPE_OVERFLOW_MODES,
 
   // This is a sentinel value, and does not represent an operand type.
   // It should come last.

--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -657,7 +657,9 @@ spv_result_t Parser::parseOperand(size_t inst_offset,
     case SPV_OPERAND_TYPE_CLDEBUG100_DEBUG_OPERATION:
     case SPV_OPERAND_TYPE_CLDEBUG100_DEBUG_IMPORTED_ENTITY:
     case SPV_OPERAND_TYPE_FPDENORM_MODE:
-    case SPV_OPERAND_TYPE_FPOPERATION_MODE: {
+    case SPV_OPERAND_TYPE_FPOPERATION_MODE:
+    case SPV_OPERAND_TYPE_QUANTIZATION_MODES:
+    case SPV_OPERAND_TYPE_OVERFLOW_MODES: {
       // A single word that is a plain enum value.
 
       // Map an optional operand type to its corresponding concrete type.

--- a/source/disassemble.cpp
+++ b/source/disassemble.cpp
@@ -328,7 +328,9 @@ void Disassembler::EmitOperand(const spv_parsed_instruction_t& inst,
     case SPV_OPERAND_TYPE_CLDEBUG100_DEBUG_OPERATION:
     case SPV_OPERAND_TYPE_CLDEBUG100_DEBUG_IMPORTED_ENTITY:
     case SPV_OPERAND_TYPE_FPDENORM_MODE:
-    case SPV_OPERAND_TYPE_FPOPERATION_MODE: {
+    case SPV_OPERAND_TYPE_FPOPERATION_MODE:
+    case SPV_OPERAND_TYPE_QUANTIZATION_MODES:
+    case SPV_OPERAND_TYPE_OVERFLOW_MODES: {
       spv_operand_desc entry;
       if (grammar_.lookupOperand(operand.type, word, &entry))
         assert(false && "should have caught this earlier");

--- a/source/operand.cpp
+++ b/source/operand.cpp
@@ -269,6 +269,10 @@ const char* spvOperandTypeStr(spv_operand_type_t type) {
       return "FP denorm mode";
     case SPV_OPERAND_TYPE_FPOPERATION_MODE:
       return "FP operation mode";
+    case SPV_OPERAND_TYPE_QUANTIZATION_MODES:
+      return "quantization mode";
+    case SPV_OPERAND_TYPE_OVERFLOW_MODES:
+      return "overflow mode";
 
     case SPV_OPERAND_TYPE_NONE:
       return "NONE";
@@ -355,6 +359,8 @@ bool spvOperandIsConcrete(spv_operand_type_t type) {
     case SPV_OPERAND_TYPE_CLDEBUG100_DEBUG_IMPORTED_ENTITY:
     case SPV_OPERAND_TYPE_FPDENORM_MODE:
     case SPV_OPERAND_TYPE_FPOPERATION_MODE:
+    case SPV_OPERAND_TYPE_QUANTIZATION_MODES:
+    case SPV_OPERAND_TYPE_OVERFLOW_MODES:
       return true;
     default:
       break;


### PR DESCRIPTION
See https://github.com/KhronosGroup/SPIRV-Headers/pull/177

Assembly, disassembly should work, but are untested.