### PR TITLE
Add IsReachable function to IRContext

### DIFF
--- a/source/fuzz/available_instructions.cpp
+++ b/source/fuzz/available_instructions.cpp
@@ -44,7 +44,7 @@ AvailableInstructions::AvailableInstructions(
     // Consider every reachable block in the function.
     auto dominator_analysis = ir_context->GetDominatorAnalysis(&function);
     for (auto& block : function) {
-      if (!fuzzerutil::BlockIsReachableInItsFunction(ir_context, &block)) {
+      if (!ir_context->IsReachable(block)) {
         // The block is not reachable.
         continue;
       }

--- a/source/fuzz/fuzzer_pass.cpp
+++ b/source/fuzz/fuzzer_pass.cpp
@@ -111,10 +111,8 @@ void FuzzerPass::ForEachInstructionWithInstructionDescriptor(
   // module.
   std::vector<opt::BasicBlock*> reachable_blocks;
 
-  const auto* dominator_analysis =
-      GetIRContext()->GetDominatorAnalysis(function);
   for (auto& block : *function) {
-    if (dominator_analysis->IsReachable(&block)) {
+    if (GetIRContext()->IsReachable(block)) {
       reachable_blocks.push_back(&block);
     }
   }

--- a/source/fuzz/fuzzer_pass_propagate_instructions_down.cpp
+++ b/source/fuzz/fuzzer_pass_propagate_instructions_down.cpp
@@ -31,8 +31,7 @@ void FuzzerPassPropagateInstructionsDown::Apply() {
   for (const auto& function : *GetIRContext()->module()) {
     std::vector<const opt::BasicBlock*> reachable_blocks;
     for (const auto& block : function) {
-      if (GetIRContext()->GetDominatorAnalysis(&function)->IsReachable(
-              &block)) {
+      if (GetIRContext()->IsReachable(block)) {
         reachable_blocks.push_back(&block);
       }
     }

--- a/source/fuzz/fuzzer_pass_push_ids_through_variables.cpp
+++ b/source/fuzz/fuzzer_pass_push_ids_through_variables.cpp
@@ -47,7 +47,7 @@ void FuzzerPassPushIdsThroughVariables::Apply() {
 
         // The block containing the instruction we are going to insert before
         // must be reachable.
-        if (!fuzzerutil::BlockIsReachableInItsFunction(GetIRContext(), block)) {
+        if (!GetIRContext()->IsReachable(*block)) {
           return;
         }
 

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -108,11 +108,6 @@ bool BlockIsInLoopContinueConstruct(opt::IRContext* context, uint32_t block_id,
 opt::BasicBlock::iterator GetIteratorForInstruction(
     opt::BasicBlock* block, const opt::Instruction* inst);
 
-// Returns true if and only if there is a path to |bb| from the entry block of
-// the function that contains |bb|.
-bool BlockIsReachableInItsFunction(opt::IRContext* context,
-                                   opt::BasicBlock* bb);
-
 // Determines whether it is OK to insert an instruction with opcode |opcode|
 // before |instruction_in_block|.
 bool CanInsertOpcodeBeforeInstruction(

--- a/source/fuzz/transformation_add_dead_block.cpp
+++ b/source/fuzz/transformation_add_dead_block.cpp
@@ -79,9 +79,7 @@ bool TransformationAddDeadBlock::IsApplicable(
   }
 
   // |existing_block| must be reachable.
-  opt::DominatorAnalysis* dominator_analysis =
-      ir_context->GetDominatorAnalysis(existing_block->GetParent());
-  if (!dominator_analysis->IsReachable(existing_block->id())) {
+  if (!ir_context->IsReachable(*existing_block)) {
     return false;
   }
 
@@ -94,6 +92,8 @@ bool TransformationAddDeadBlock::IsApplicable(
   // the selection construct, its header |existing_block| will not dominate the
   // merge block |successor_block_id|, which is invalid. Thus, |existing_block|
   // must dominate |successor_block_id|.
+  opt::DominatorAnalysis* dominator_analysis =
+      ir_context->GetDominatorAnalysis(existing_block->GetParent());
   if (!dominator_analysis->Dominates(existing_block->id(),
                                      successor_block_id)) {
     return false;

--- a/source/fuzz/transformation_add_dead_break.cpp
+++ b/source/fuzz/transformation_add_dead_break.cpp
@@ -134,7 +134,7 @@ bool TransformationAddDeadBreak::IsApplicable(
     return false;
   }
 
-  if (!fuzzerutil::BlockIsReachableInItsFunction(ir_context, bb_to)) {
+  if (!ir_context->IsReachable(*bb_to)) {
     // If the target of the break is unreachable, we conservatively do not
     // allow adding a dead break, to avoid the compilations that arise due to
     // the lack of sensible dominance information for unreachable blocks.

--- a/source/fuzz/transformation_add_dead_continue.cpp
+++ b/source/fuzz/transformation_add_dead_continue.cpp
@@ -83,8 +83,7 @@ bool TransformationAddDeadContinue::IsApplicable(
   auto continue_block =
       ir_context->cfg()->block(loop_header)->ContinueBlockId();
 
-  if (!fuzzerutil::BlockIsReachableInItsFunction(
-          ir_context, ir_context->cfg()->block(continue_block))) {
+  if (!ir_context->IsReachable(*ir_context->cfg()->block(continue_block))) {
     // If the loop's continue block is unreachable, we conservatively do not
     // allow adding a dead continue, to avoid the compilations that arise due to
     // the lack of sensible dominance information for unreachable blocks.

--- a/source/fuzz/transformation_flatten_conditional_branch.cpp
+++ b/source/fuzz/transformation_flatten_conditional_branch.cpp
@@ -441,16 +441,16 @@ bool TransformationFlattenConditionalBranch::
          header->terminator()->opcode() == SpvOpBranchConditional &&
          "|header| must be the header of a conditional.");
 
+  // |header| must be reachable.
+  if (!ir_context->IsReachable(*header)) {
+    return false;
+  }
+
   auto enclosing_function = header->GetParent();
   auto dominator_analysis =
       ir_context->GetDominatorAnalysis(enclosing_function);
   auto postdominator_analysis =
       ir_context->GetPostDominatorAnalysis(enclosing_function);
-
-  // |header| must be reachable.
-  if (!dominator_analysis->IsReachable(header)) {
-    return false;
-  }
 
   // Check that the header and the merge block describe a single-entry,
   // single-exit region.

--- a/source/fuzz/transformation_outline_function.cpp
+++ b/source/fuzz/transformation_outline_function.cpp
@@ -180,8 +180,7 @@ bool TransformationOutlineFunction::IsApplicable(
       // predecessors. If it does, then we do not regard the region as single-
       // entry-single-exit and hence do not outline it.
       for (auto pred : ir_context->cfg()->preds(block.id())) {
-        if (!fuzzerutil::BlockIsReachableInItsFunction(
-                ir_context, ir_context->cfg()->block(pred))) {
+        if (!ir_context->IsReachable(*ir_context->cfg()->block(pred))) {
           // The predecessor is unreachable.
           return false;
         }

--- a/source/fuzz/transformation_propagate_instruction_down.cpp
+++ b/source/fuzz/transformation_propagate_instruction_down.cpp
@@ -386,11 +386,8 @@ bool TransformationPropagateInstructionDown::IsApplicableToBlock(
     return false;
   }
 
-  const auto* dominator_analysis =
-      ir_context->GetDominatorAnalysis(block->GetParent());
-
   // |block| must be reachable.
-  if (!dominator_analysis->IsReachable(block)) {
+  if (!ir_context->IsReachable(*block)) {
     return false;
   }
 
@@ -429,6 +426,9 @@ bool TransformationPropagateInstructionDown::IsApplicableToBlock(
   // This is either 0 or a result id of some merge block in the function.
   auto phi_block_id =
       GetOpPhiBlockId(ir_context, block_id, *inst_to_propagate, successor_ids);
+
+  const auto* dominator_analysis =
+      ir_context->GetDominatorAnalysis(block->GetParent());
 
   // Make sure we can adjust all users of the propagated instruction.
   return ir_context->get_def_use_mgr()->WhileEachUse(
@@ -537,7 +537,7 @@ uint32_t TransformationPropagateInstructionDown::GetOpPhiBlockId(
 
   // Check that |merge_block_id| is reachable in the CFG and |block_id|
   // dominates |merge_block_id|.
-  if (!dominator_analysis->IsReachable(merge_block_id) ||
+  if (!ir_context->IsReachable(*ir_context->cfg()->block(merge_block_id)) ||
       !dominator_analysis->Dominates(block_id, merge_block_id)) {
     return 0;
   }

--- a/source/fuzz/transformation_push_id_through_variable.cpp
+++ b/source/fuzz/transformation_push_id_through_variable.cpp
@@ -61,7 +61,7 @@ bool TransformationPushIdThroughVariable::IsApplicable(
 
   // The instruction to insert before must belong to a reachable block.
   auto basic_block = ir_context->get_instr_block(instruction_to_insert_before);
-  if (!fuzzerutil::BlockIsReachableInItsFunction(ir_context, basic_block)) {
+  if (!ir_context->IsReachable(*basic_block)) {
     return false;
   }
 

--- a/source/opt/block_merge_util.cpp
+++ b/source/opt/block_merge_util.cpp
@@ -104,9 +104,7 @@ bool CanMergeWithSuccessor(IRContext* context, BasicBlock* block) {
   }
 
   // Don't bother trying to merge unreachable blocks.
-  if (auto dominators = context->GetDominatorAnalysis(block->GetParent())) {
-    if (!dominators->IsReachable(block)) return false;
-  }
+  if (!context->IsReachable(*block)) return false;
 
   Instruction* merge_inst = block->GetMergeInst();
   const bool pred_is_header = IsHeader(block);

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -1034,5 +1034,11 @@ bool IRContext::CheckCFG() {
 
   return true;
 }
+
+bool IRContext::IsReachable(const opt::BasicBlock& bb) {
+  auto enclosing_function = bb.GetParent();
+  return GetDominatorAnalysis(enclosing_function)
+      ->Dominates(enclosing_function->entry().get(), &bb);
+}
 }  // namespace opt
 }  // namespace spvtools

--- a/source/opt/ir_context.h
+++ b/source/opt/ir_context.h
@@ -598,9 +598,13 @@ class IRContext {
   bool ProcessCallTreeFromRoots(ProcessFunction& pfn,
                                 std::queue<uint32_t>* roots);
 
-  // Emmits a error message to the message consumer indicating the error
+  // Emits a error message to the message consumer indicating the error
   // described by |message| occurred in |inst|.
   void EmitErrorMessage(std::string message, Instruction* inst);
+
+  // Returns true if and only if there is a path to |bb| from the entry block of
+  // the function that contains |bb|.
+  bool IsReachable(const opt::BasicBlock& bb);
 
  private:
   // Builds the def-use manager from scratch, even if it was already valid.

--- a/source/opt/loop_descriptor.cpp
+++ b/source/opt/loop_descriptor.cpp
@@ -530,7 +530,7 @@ void LoopDescriptor::PopulateList(IRContext* context, const Function* f) {
     if (merge_inst) {
       bool all_backedge_unreachable = true;
       for (uint32_t pid : context->cfg()->preds(node.bb_->id())) {
-        if (context->IsReachable(*context->cfg()->block(pid)) &&
+        if (dom_analysis->IsReachable(pid) &&
             dom_analysis->Dominates(node.bb_->id(), pid)) {
           all_backedge_unreachable = false;
           break;

--- a/source/opt/loop_descriptor.cpp
+++ b/source/opt/loop_descriptor.cpp
@@ -268,7 +268,7 @@ bool Loop::IsBasicBlockInLoopSlow(const BasicBlock* bb) {
   assert(bb->GetParent() && "The basic block does not belong to a function");
   DominatorAnalysis* dom_analysis =
       context_->GetDominatorAnalysis(bb->GetParent());
-  if (context_->IsReachable(*bb) &&
+  if (dom_analysis->IsReachable(bb) &&
       !dom_analysis->Dominates(GetHeaderBlock(), bb))
     return false;
 

--- a/source/opt/loop_descriptor.cpp
+++ b/source/opt/loop_descriptor.cpp
@@ -268,7 +268,7 @@ bool Loop::IsBasicBlockInLoopSlow(const BasicBlock* bb) {
   assert(bb->GetParent() && "The basic block does not belong to a function");
   DominatorAnalysis* dom_analysis =
       context_->GetDominatorAnalysis(bb->GetParent());
-  if (dom_analysis->IsReachable(bb) &&
+  if (context_->IsReachable(*bb) &&
       !dom_analysis->Dominates(GetHeaderBlock(), bb))
     return false;
 
@@ -530,7 +530,7 @@ void LoopDescriptor::PopulateList(IRContext* context, const Function* f) {
     if (merge_inst) {
       bool all_backedge_unreachable = true;
       for (uint32_t pid : context->cfg()->preds(node.bb_->id())) {
-        if (dom_analysis->IsReachable(pid) &&
+        if (context->IsReachable(*context->cfg()->block(pid)) &&
             dom_analysis->Dominates(node.bb_->id(), pid)) {
           all_backedge_unreachable = false;
           break;

--- a/source/reduce/structured_loop_to_selection_reduction_opportunity.cpp
+++ b/source/reduce/structured_loop_to_selection_reduction_opportunity.cpp
@@ -27,10 +27,8 @@ const uint32_t kMergeNodeIndex = 0;
 
 bool StructuredLoopToSelectionReductionOpportunity::PreconditionHolds() {
   // Is the loop header reachable?
-  return loop_construct_header_->GetLabel()
-      ->context()
-      ->GetDominatorAnalysis(loop_construct_header_->GetParent())
-      ->IsReachable(loop_construct_header_);
+  return loop_construct_header_->GetLabel()->context()->IsReachable(
+      *loop_construct_header_);
 }
 
 void StructuredLoopToSelectionReductionOpportunity::Apply() {
@@ -78,8 +76,7 @@ void StructuredLoopToSelectionReductionOpportunity::RedirectToClosestMergeBlock(
     }
     already_seen.insert(pred);
 
-    if (!context_->GetDominatorAnalysis(loop_construct_header_->GetParent())
-             ->IsReachable(pred)) {
+    if (!context_->IsReachable(*context_->cfg()->block(pred))) {
       // We do not care about unreachable predecessors (and dominance
       // information, and thus the notion of structured control flow, makes
       // little sense for unreachable blocks).


### PR DESCRIPTION
There was a lot of code in the codebase that would get the dominator
analysis for a function and then use it to check whether a block is
reachable. In the fuzzer, a utility method had been introduced to make
this more concise, but it was not being used consistently.

This change moves the utility method to IRContext, so that it can be
used throughout the codebase, and refactors all existing checks for
block reachability to use the utility method.