### PR TITLE
spirv-val: Add GLCompute to VUID 04644 message

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -591,8 +591,9 @@ void ValidationState_t::RegisterStorageClassConsumer(
                 *message =
                     errorVUID +
                     "in Vulkan evironment, Output Storage Class must not be "
-                    "used in RayGenerationKHR, IntersectionKHR, AnyHitKHR, "
-                    "ClosestHitKHR, MissKHR, or CallableKHR execution models";
+                    "used in GLCompute, RayGenerationKHR, IntersectionKHR, "
+                    "AnyHitKHR, ClosestHitKHR, MissKHR, or CallableKHR "
+                    "execution models";
               }
               return false;
             }

--- a/test/val/val_storage_test.cpp
+++ b/test/val/val_storage_test.cpp
@@ -281,7 +281,7 @@ TEST_P(ValidateStorageExecutionModel, VulkanOutsideStoreFailure) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("in Vulkan evironment, Output Storage Class must not be used "
-                "in RayGenerationKHR, IntersectionKHR, AnyHitKHR, "
+                "in GLCompute, RayGenerationKHR, IntersectionKHR, AnyHitKHR, "
                 "ClosestHitKHR, MissKHR, or CallableKHR execution models"));
 }
 


### PR DESCRIPTION
Based on https://github.com/KhronosGroup/SPIRV-Tools/pull/4212 but the Vulkan spec now has `GLCompute` but realize the message was never updated