### PR TITLE
spirv-fuzz: Edit TransformationLoad structure to supporting OpLoad and OpAtomicLoad together.

### DIFF
--- a/source/fuzz/fuzzer_pass_add_loads.cpp
+++ b/source/fuzz/fuzzer_pass_add_loads.cpp
@@ -86,7 +86,7 @@ void FuzzerPassAddLoads::Apply() {
             relevant_instructions[GetFuzzerContext()->RandomIndex(
                                       relevant_instructions)]
                 ->result_id(),
-            instruction_descriptor));
+            false, 0, 0, instruction_descriptor));
       });
 }
 

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -1562,15 +1562,24 @@ message TransformationLoad {
 
   // Transformation that adds an OpLoad instruction from a pointer into an id.
 
-  // The result of the load instruction
+  // The result of the load instruction.
   uint32 fresh_id = 1;
 
-  // The pointer to be loaded from
+  // The pointer to be loaded from.
   uint32 pointer_id = 2;
 
+  // Flag to check current load opCode is atomic or not, to take action for each one.
+  bool is_atomic = 3;
+
+  // Define the scope of execution.
+  uint32 memory_scope = 4;
+
+  // The control masks define bitmask hints for function optimization.
+  uint32 memory_semantics = 5;
+
   // A descriptor for an instruction in a block before which the new OpLoad
-  // instruction should be inserted
-  InstructionDescriptor instruction_to_insert_before = 3;
+  // instruction should be inserted.
+  InstructionDescriptor instruction_to_insert_before = 6;
 
 }
 

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -1568,10 +1568,10 @@ message TransformationLoad {
   // The pointer to be loaded from.
   uint32 pointer_id = 2;
 
-  // Flag to check current load opCode is atomic or not, to take action for each one.
+  // True if and only if the load should be atomic.
   bool is_atomic = 3;
 
-  // Define the scope of execution.
+  // Memory scope for the load. Ignored unless the load is atomic.
   uint32 memory_scope = 4;
 
   // The control masks define bitmask hints for function optimization.

--- a/source/fuzz/transformation_load.cpp
+++ b/source/fuzz/transformation_load.cpp
@@ -24,10 +24,16 @@ TransformationLoad::TransformationLoad(protobufs::TransformationLoad message)
     : message_(std::move(message)) {}
 
 TransformationLoad::TransformationLoad(
-    uint32_t fresh_id, uint32_t pointer_id,
+    uint32_t fresh_id, uint32_t pointer_id, bool is_atomic,
+    uint32_t memory_scope, uint32_t memory_semantics,
     const protobufs::InstructionDescriptor& instruction_to_insert_before) {
+  assert(!is_atomic && "Atomic load not fully developed yet.");
   message_.set_fresh_id(fresh_id);
   message_.set_pointer_id(pointer_id);
+  message_.set_is_atomic(is_atomic);
+  message_.set_memory_scope(memory_scope);
+  message_.set_memory_semantics(memory_semantics);
+
   *message_.mutable_instruction_to_insert_before() =
       instruction_to_insert_before;
 }

--- a/source/fuzz/transformation_load.h
+++ b/source/fuzz/transformation_load.h
@@ -28,11 +28,17 @@ class TransformationLoad : public Transformation {
   explicit TransformationLoad(protobufs::TransformationLoad message);
 
   TransformationLoad(
-      uint32_t fresh_id, uint32_t pointer_id,
+      uint32_t fresh_id, uint32_t pointer_id, bool is_atomic,
+      uint32_t memory_scope, uint32_t memory_semantics,
       const protobufs::InstructionDescriptor& instruction_to_insert_before);
 
   // - |message_.fresh_id| must be fresh
   // - |message_.pointer_id| must be the id of a pointer
+  // - |message_.is_atomic| must be true if want to work with OpAtomicLoad
+  // - |message_.memory_scope| must be value to specific scope if the opcode is
+  // OpAtomicLoad, and 0 if opcode is OpLoad
+  // - |message_.memory_semantics| mask we set when work with OpAtomicLoad, and
+  // 0 if opcode is OpLoad
   // - The pointer must not be OpConstantNull or OpUndef
   // - |message_.instruction_to_insert_before| must identify an instruction
   //   before which it is valid to insert an OpLoad, and where


### PR DESCRIPTION
This RR is just to support the "TransformationLoad" new structure. 
Part of #4324.