### PR TITLE
Add spirv-opt convert-to-sampled-image pass

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -89,6 +89,7 @@ SPVTOOLS_OPT_SRC_FILES := \
 		source/opt/const_folding_rules.cpp \
 		source/opt/constants.cpp \
 		source/opt/control_dependence.cpp \
+		source/opt/convert_to_sampled_image_pass.cpp \
 		source/opt/convert_to_half_pass.cpp \
 		source/opt/copy_prop_arrays.cpp \
 		source/opt/dataflow.cpp \

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -608,6 +608,8 @@ static_library("spvtools_opt") {
     "source/opt/constants.h",
     "source/opt/control_dependence.cpp",
     "source/opt/control_dependence.h",
+    "source/opt/convert_to_sampled_image_pass.cpp",
+    "source/opt/convert_to_sampled_image_pass.h",
     "source/opt/convert_to_half_pass.cpp",
     "source/opt/convert_to_half_pass.h",
     "source/opt/copy_prop_arrays.cpp",

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -28,6 +28,7 @@ namespace spvtools {
 
 namespace opt {
 class Pass;
+struct DescriptorSetAndBinding;
 }
 
 // C++ interface for SPIR-V optimization functionalities. It wraps the context
@@ -862,7 +863,7 @@ Optimizer::PassToken CreateInterpolateFixupPass();
 // image. In addition, if only an image has the descriptor set and binding that
 // is one of the given pairs, it will be converted to a sampled image as well.
 Optimizer::PassToken CreateConvertToSampledImagePass(
-    const std::vector<std::pair<uint32_t, uint32_t>>&
+    const std::vector<opt::DescriptorSetAndBinding>&
         descriptor_set_binding_pairs);
 
 }  // namespace spvtools

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -19,6 +19,7 @@
 #include <ostream>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "libspirv.hpp"
@@ -853,6 +854,16 @@ Optimizer::PassToken CreateAmdExtToKhrPass();
 // of HLSL legalization and should be called after interpolants have been
 // propagated into their final positions.
 Optimizer::PassToken CreateInterpolateFixupPass();
+
+// Creates a convert-to-sampled-image pass to convert images and/or
+// samplers with given pairs of descriptor set and binding to sampled image.
+// If a pair of an image and a sampler have the same pair of descriptor set and
+// binding that is one of the given pairs, they will be converted to a sampled
+// image. In addition, if only an image has the descriptor set and binding that
+// is one of the given pairs, it will be converted to a sampled image as well.
+Optimizer::PassToken CreateConvertToSampledImagePass(
+    const std::vector<std::pair<uint32_t, uint32_t>>&
+        descriptor_set_binding_pairs);
 
 }  // namespace spvtools
 

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SPIRV_TOOLS_OPT_SOURCES
   const_folding_rules.h
   constants.h
   control_dependence.h
+  convert_to_sampled_image_pass.h
   convert_to_half_pass.h
   copy_prop_arrays.h
   dataflow.h
@@ -136,6 +137,7 @@ set(SPIRV_TOOLS_OPT_SOURCES
   const_folding_rules.cpp
   constants.cpp
   control_dependence.cpp
+  convert_to_sampled_image_pass.cpp
   convert_to_half_pass.cpp
   copy_prop_arrays.cpp
   dataflow.cpp

--- a/source/opt/convert_to_sampled_image_pass.cpp
+++ b/source/opt/convert_to_sampled_image_pass.cpp
@@ -1,0 +1,446 @@
+// Copyright (c) 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/opt/convert_to_sampled_image_pass.h"
+
+#include <cctype>
+#include <cstring>
+#include <tuple>
+
+#include "source/util/make_unique.h"
+#include "source/util/parse_number.h"
+
+namespace spvtools {
+namespace opt {
+
+using DescriptorSetAndBinding =
+    ConvertToSampledImagePass::DescriptorSetAndBinding;
+using VectorOfDescriptorSetAndBindingPairs =
+    std::vector<DescriptorSetAndBinding>;
+using DescriptorSetBindingToInstruction =
+    ConvertToSampledImagePass::DescriptorSetBindingToInstruction;
+
+namespace {
+
+using utils::ParseNumber;
+
+// Inserts a pair of |descriptor_set_binding| and |inst| to
+// |descriptor_set_binding_to_inst| if the map does not contain
+// |descriptor_set_binding_to_inst| key. Returns true if the insertion took
+// place.
+bool InsertDescriptorSetBindingAndInstructionPair(
+    DescriptorSetBindingToInstruction& descriptor_set_binding_to_inst,
+    const DescriptorSetAndBinding& descriptor_set_binding, Instruction* inst) {
+  if (descriptor_set_binding_to_inst.find(descriptor_set_binding) !=
+      descriptor_set_binding_to_inst.end()) {
+    return false;
+  }
+  return descriptor_set_binding_to_inst.insert({descriptor_set_binding, inst})
+      .second;
+}
+
+// Returns true if the given char is ':', '\0' or considered as blank space
+// (i.e.: '\n', '\r', '\v', '\t', '\f' and ' ').
+bool IsSeparator(char ch) {
+  return std::strchr(":\0", ch) || std::isspace(ch) != 0;
+}
+
+// Reads characters starting from |str| until it meets a separator. Parses a
+// number from the characters and stores it into |number|. Returns the pointer
+// to the separator if it succeeds. Otherwise, returns nullptr.
+const char* ParseNumberUntilSeparator(const char* str, uint32_t* number) {
+  const char* number_begin = str;
+  while (!IsSeparator(*str)) str++;
+  const char* number_end = str;
+  std::string number_in_str(number_begin, number_end - number_begin);
+  if (!utils::ParseNumber(number_in_str.c_str(), number)) {
+    // The descriptor set is not a valid uint32 number.
+    return nullptr;
+  }
+  return str;
+}
+
+}  // namespace
+
+bool ConvertToSampledImagePass::GetDescriptorSetBinding(
+    const Instruction& inst,
+    DescriptorSetAndBinding* descriptor_set_binding) const {
+  auto* decoration_manager = context()->get_decoration_mgr();
+  bool found_descriptor_set_to_convert = false;
+  bool found_binding_to_convert = false;
+  for (auto decorate :
+       decoration_manager->GetDecorationsFor(inst.result_id(), false)) {
+    uint32_t decoration = decorate->GetSingleWordInOperand(1u);
+    if (decoration == SpvDecorationDescriptorSet) {
+      if (found_descriptor_set_to_convert) {
+        assert(false && "A resource has two OpDecorate for the descriptor set");
+        return false;
+      }
+      descriptor_set_binding->first = decorate->GetSingleWordInOperand(2u);
+      found_descriptor_set_to_convert = true;
+    } else if (decoration == SpvDecorationBinding) {
+      if (found_binding_to_convert) {
+        assert(false && "A resource has two OpDecorate for the binding");
+        return false;
+      }
+      descriptor_set_binding->second = decorate->GetSingleWordInOperand(2u);
+      found_binding_to_convert = true;
+    }
+  }
+  return found_descriptor_set_to_convert && found_binding_to_convert;
+}
+
+bool ConvertToSampledImagePass::
+    IsDescriptorSetBindingPairForSampledImageConversion(
+        const DescriptorSetAndBinding& descriptor_set_binding) const {
+  return descriptor_set_binding_pairs_.find(descriptor_set_binding) !=
+         descriptor_set_binding_pairs_.end();
+}
+
+const analysis::Type* ConvertToSampledImagePass::GetVariableType(
+    const Instruction& variable) const {
+  if (variable.opcode() != SpvOpVariable) return nullptr;
+  auto* type = context()->get_type_mgr()->GetType(variable.type_id());
+  auto* pointer_type = type->AsPointer();
+  if (!pointer_type) return nullptr;
+
+  return pointer_type->pointee_type();
+}
+
+SpvStorageClass ConvertToSampledImagePass::GetStorageClass(
+    const Instruction& variable) const {
+  assert(variable.opcode() == SpvOpVariable);
+  auto* type = context()->get_type_mgr()->GetType(variable.type_id());
+  auto* pointer_type = type->AsPointer();
+  if (!pointer_type) return SpvStorageClassMax;
+
+  return pointer_type->storage_class();
+}
+
+bool ConvertToSampledImagePass::CollectResourcesToConvert(
+    DescriptorSetBindingToInstruction& descriptor_set_binding_pair_to_sampler,
+    DescriptorSetBindingToInstruction& descriptor_set_binding_pair_to_image)
+    const {
+  for (auto& inst : context()->types_values()) {
+    const auto* variable_type = GetVariableType(inst);
+    if (variable_type == nullptr) continue;
+
+    DescriptorSetAndBinding descriptor_set_binding;
+    if (!GetDescriptorSetBinding(inst, &descriptor_set_binding)) continue;
+
+    if (!IsDescriptorSetBindingPairForSampledImageConversion(
+            descriptor_set_binding)) {
+      continue;
+    }
+
+    if (variable_type->AsImage()) {
+      if (!InsertDescriptorSetBindingAndInstructionPair(
+              descriptor_set_binding_pair_to_image, descriptor_set_binding,
+              &inst)) {
+        return false;
+      }
+    } else if (variable_type->AsSampler()) {
+      if (!InsertDescriptorSetBindingAndInstructionPair(
+              descriptor_set_binding_pair_to_sampler, descriptor_set_binding,
+              &inst)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+Pass::Status ConvertToSampledImagePass::Process() {
+  Status status = Status::SuccessWithoutChange;
+
+  DescriptorSetBindingToInstruction descriptor_set_binding_pair_to_sampler,
+      descriptor_set_binding_pair_to_image;
+  if (!CollectResourcesToConvert(descriptor_set_binding_pair_to_sampler,
+                                 descriptor_set_binding_pair_to_image)) {
+    return Status::Failure;
+  }
+
+  for (auto& image : descriptor_set_binding_pair_to_image) {
+    status = CombineStatus(
+        status, UpdateImageVariableToSampledImage(image.second, image.first));
+    if (status == Status::Failure) {
+      return status;
+    }
+  }
+
+  for (const auto& sampler : descriptor_set_binding_pair_to_sampler) {
+    // Converting only a Sampler to Sampled Image is not allowed. It must have a
+    // corresponding image to combine the sampler with.
+    auto image_itr = descriptor_set_binding_pair_to_image.find(sampler.first);
+    if (image_itr == descriptor_set_binding_pair_to_image.end() ||
+        image_itr->second == nullptr) {
+      return Status::Failure;
+    }
+
+    status = CombineStatus(
+        status, CheckUsesOfSamplerVariable(sampler.second, image_itr->second));
+    if (status == Status::Failure) {
+      return status;
+    }
+  }
+
+  return status;
+}
+
+void ConvertToSampledImagePass::FindUses(const Instruction* inst,
+                                         std::vector<Instruction*>* uses,
+                                         uint32_t user_opcode) const {
+  auto* def_use_mgr = context()->get_def_use_mgr();
+  def_use_mgr->ForEachUser(inst, [uses, user_opcode, this](Instruction* user) {
+    if (user->opcode() == user_opcode) {
+      uses->push_back(user);
+    } else if (user->opcode() == SpvOpCopyObject) {
+      FindUses(user, uses, user_opcode);
+    }
+  });
+}
+
+void ConvertToSampledImagePass::FindUsesOfImage(
+    const Instruction* image, std::vector<Instruction*>* uses) const {
+  auto* def_use_mgr = context()->get_def_use_mgr();
+  def_use_mgr->ForEachUser(image, [uses, this](Instruction* user) {
+    switch (user->opcode()) {
+      case SpvOpImageFetch:
+      case SpvOpImageRead:
+      case SpvOpImageWrite:
+      case SpvOpImageQueryFormat:
+      case SpvOpImageQueryOrder:
+      case SpvOpImageQuerySizeLod:
+      case SpvOpImageQuerySize:
+      case SpvOpImageQueryLevels:
+      case SpvOpImageQuerySamples:
+      case SpvOpImageSparseFetch:
+        uses->push_back(user);
+      default:
+        break;
+    }
+    if (user->opcode() == SpvOpCopyObject) {
+      FindUsesOfImage(user, uses);
+    }
+  });
+}
+
+void ConvertToSampledImagePass::ReplaceUsesWith(
+    const Instruction* inst, uint32_t replaced_inst_id) const {
+  auto* def_use_mgr = context()->get_def_use_mgr();
+  def_use_mgr->ForEachUser(
+      inst, [inst, replaced_inst_id, this](Instruction* user) {
+        user->ForEachInOperand([inst, replaced_inst_id](uint32_t* operand) {
+          if (*operand == inst->result_id()) *operand = replaced_inst_id;
+        });
+      });
+}
+
+Instruction* ConvertToSampledImagePass::CreateImageExtraction(
+    Instruction* sampled_image) {
+  auto* type_mgr = context()->get_type_mgr();
+  auto* sampled_image_type =
+      type_mgr->GetType(sampled_image->type_id())->AsSampledImage();
+  std::unique_ptr<Instruction> image_extraction(new Instruction(
+      context(), SpvOpImage,
+      type_mgr->GetTypeInstruction(sampled_image_type->image_type()),
+      context()->TakeNextId(),
+      {
+          {spv_operand_type_t::SPV_OPERAND_TYPE_ID,
+           {sampled_image->result_id()}},
+      }));
+  context()->get_def_use_mgr()->AnalyzeInstDefUse(image_extraction.get());
+  sampled_image->NextNode()->InsertBefore(std::move(image_extraction));
+  return sampled_image->NextNode();
+}
+
+uint32_t ConvertToSampledImagePass::GetSampledImageTypeForImage(
+    Instruction* image_variable) {
+  const auto* variable_type = GetVariableType(*image_variable);
+  if (variable_type == nullptr) return 0;
+  const auto* image_type = variable_type->AsImage();
+  if (image_type == nullptr) return 0;
+
+  analysis::Image image_type_for_sampled_image(*image_type);
+  analysis::SampledImage sampled_image_type(&image_type_for_sampled_image);
+  return context()->get_type_mgr()->GetTypeInstruction(&sampled_image_type);
+}
+
+Instruction* ConvertToSampledImagePass::UpdateImageUses(
+    Instruction* sampled_image_load) {
+  std::vector<Instruction*> uses_of_load;
+  FindUsesOfImage(sampled_image_load, &uses_of_load);
+  if (uses_of_load.empty()) return nullptr;
+
+  auto* extracted_image = CreateImageExtraction(sampled_image_load);
+  for (auto* user : uses_of_load) {
+    user->SetInOperand(0, {spv_operand_type_t::SPV_OPERAND_TYPE_ID,
+                           {extracted_image->result_id()}});
+    context()->get_def_use_mgr()->AnalyzeInstUse(user);
+  }
+  return extracted_image;
+}
+
+bool ConvertToSampledImagePass::
+    IsSamplerOfSampledImageDecoratedByDescriptorSetBinding(
+        Instruction* sampled_image_inst,
+        const DescriptorSetAndBinding& descriptor_set_binding) {
+  auto* def_use_mgr = context()->get_def_use_mgr();
+  uint32_t sampler_id = sampled_image_inst->GetSingleWordInOperand(1u);
+  auto* sampler_load = def_use_mgr->GetDef(sampler_id);
+  if (sampler_load->opcode() != SpvOpLoad) return false;
+  auto* sampler = def_use_mgr->GetDef(sampler_load->GetSingleWordInOperand(0u));
+  DescriptorSetAndBinding sampler_descriptor_set_binding;
+  return GetDescriptorSetBinding(*sampler, &sampler_descriptor_set_binding) &&
+         sampler_descriptor_set_binding == descriptor_set_binding;
+}
+
+void ConvertToSampledImagePass::UpdateSampledImageUses(
+    Instruction* image_load, Instruction* image_extraction,
+    const DescriptorSetAndBinding& image_descriptor_set_binding) {
+  std::vector<Instruction*> sampled_image_users;
+  FindUses(image_load, &sampled_image_users, SpvOpSampledImage);
+
+  auto* def_use_mgr = context()->get_def_use_mgr();
+  for (auto* sampled_image_inst : sampled_image_users) {
+    if (IsSamplerOfSampledImageDecoratedByDescriptorSetBinding(
+            sampled_image_inst, image_descriptor_set_binding)) {
+      ReplaceUsesWith(sampled_image_inst, image_load->result_id());
+      def_use_mgr->AnalyzeInstUse(image_load);
+      context()->KillInst(sampled_image_inst);
+    } else {
+      if (!image_extraction)
+        image_extraction = CreateImageExtraction(image_load);
+      sampled_image_inst->SetInOperand(0, {image_extraction->result_id()});
+      def_use_mgr->AnalyzeInstUse(sampled_image_inst);
+    }
+  }
+}
+
+bool ConvertToSampledImagePass::ConvertImageVariableToSampledImage(
+    Instruction* image_variable, uint32_t sampled_image_type_id) {
+  auto* sampled_image_type =
+      context()->get_type_mgr()->GetType(sampled_image_type_id);
+  if (sampled_image_type == nullptr) return false;
+  auto storage_class = GetStorageClass(*image_variable);
+  if (storage_class == SpvStorageClassMax) return false;
+  analysis::Pointer sampled_image_pointer(sampled_image_type, storage_class);
+
+  // Make sure |image_variable| is behind its type i.e., avoid the forward
+  // reference.
+  uint32_t type_id =
+      context()->get_type_mgr()->GetTypeInstruction(&sampled_image_pointer);
+  auto* type_inst = context()->get_def_use_mgr()->GetDef(type_id);
+  image_variable->SetResultType(type_id);
+  image_variable->RemoveFromList();
+  image_variable->InsertAfter(type_inst);
+  return true;
+}
+
+Pass::Status ConvertToSampledImagePass::UpdateImageVariableToSampledImage(
+    Instruction* image_variable,
+    const DescriptorSetAndBinding& descriptor_set_binding) {
+  std::vector<Instruction*> image_variable_loads;
+  FindUses(image_variable, &image_variable_loads, SpvOpLoad);
+  if (image_variable_loads.empty()) return Status::SuccessWithoutChange;
+
+  const uint32_t sampled_image_type_id =
+      GetSampledImageTypeForImage(image_variable);
+  if (!sampled_image_type_id) return Status::Failure;
+
+  for (auto* load : image_variable_loads) {
+    load->SetResultType(sampled_image_type_id);
+    auto* image_extraction = UpdateImageUses(load);
+    UpdateSampledImageUses(load, image_extraction, descriptor_set_binding);
+  }
+
+  return ConvertImageVariableToSampledImage(image_variable,
+                                            sampled_image_type_id)
+             ? Status::SuccessWithChange
+             : Status::Failure;
+}
+
+bool ConvertToSampledImagePass::DoesSampledImageReferenceImage(
+    Instruction* sampled_image_inst, Instruction* image_variable) {
+  if (sampled_image_inst->opcode() != SpvOpSampledImage) return false;
+  auto* def_use_mgr = context()->get_def_use_mgr();
+  auto* image_load =
+      def_use_mgr->GetDef(sampled_image_inst->GetSingleWordInOperand(0u));
+  if (image_load->opcode() != SpvOpLoad) return false;
+  auto* image = def_use_mgr->GetDef(image_load->GetSingleWordInOperand(0u));
+  return image->opcode() == SpvOpVariable &&
+         image->result_id() == image_variable->result_id();
+}
+
+Pass::Status ConvertToSampledImagePass::CheckUsesOfSamplerVariable(
+    const Instruction* sampler_variable,
+    Instruction* image_to_be_combined_with) {
+  if (image_to_be_combined_with == nullptr) return Status::Failure;
+
+  std::vector<Instruction*> sampler_variable_loads;
+  FindUses(sampler_variable, &sampler_variable_loads, SpvOpLoad);
+  for (auto* load : sampler_variable_loads) {
+    std::vector<Instruction*> sampled_image_users;
+    FindUses(load, &sampled_image_users, SpvOpSampledImage);
+    for (auto* sampled_image_inst : sampled_image_users) {
+      if (!DoesSampledImageReferenceImage(sampled_image_inst,
+                                          image_to_be_combined_with)) {
+        return Status::Failure;
+      }
+    }
+  }
+  return Status::SuccessWithoutChange;
+}
+
+std::unique_ptr<VectorOfDescriptorSetAndBindingPairs>
+ConvertToSampledImagePass::ParseDescriptorSetBindingPairsString(
+    const char* str) {
+  if (!str) return nullptr;
+
+  auto descriptor_set_binding_pairs =
+      MakeUnique<VectorOfDescriptorSetAndBindingPairs>();
+
+  // The parsing loop, break when points to the end.
+  while (*str) {
+    while (std::isspace(*str)) str++;  // skip leading spaces.
+
+    // Parse the descriptor set.
+    uint32_t descriptor_set = 0;
+    str = ParseNumberUntilSeparator(str, &descriptor_set);
+    if (str == nullptr) return nullptr;
+
+    // Find the ':', spaces between the descriptor set and the ':' are not
+    // allowed.
+    if (*str++ != ':') {
+      // ':' not found
+      return nullptr;
+    }
+
+    // Parse the binding.
+    uint32_t binding = 0;
+    str = ParseNumberUntilSeparator(str, &binding);
+    if (str == nullptr) return nullptr;
+
+    descriptor_set_binding_pairs->push_back(
+        std::make_pair(std::move(descriptor_set), std::move(binding)));
+
+    // Skip trailing spaces.
+    while (std::isspace(*str)) str++;
+  }
+
+  return descriptor_set_binding_pairs;
+}
+
+}  // namespace opt
+}  // namespace spvtools

--- a/source/opt/convert_to_sampled_image_pass.cpp
+++ b/source/opt/convert_to_sampled_image_pass.cpp
@@ -237,12 +237,11 @@ void ConvertToSampledImagePass::FindUsesOfImage(
 void ConvertToSampledImagePass::ReplaceUsesWith(
     const Instruction* inst, uint32_t replaced_inst_id) const {
   auto* def_use_mgr = context()->get_def_use_mgr();
-  def_use_mgr->ForEachUser(
-      inst, [inst, replaced_inst_id, this](Instruction* user) {
-        user->ForEachInOperand([inst, replaced_inst_id](uint32_t* operand) {
-          if (*operand == inst->result_id()) *operand = replaced_inst_id;
-        });
-      });
+  def_use_mgr->ForEachUser(inst, [inst, replaced_inst_id](Instruction* user) {
+    user->ForEachInOperand([inst, replaced_inst_id](uint32_t* operand) {
+      if (*operand == inst->result_id()) *operand = replaced_inst_id;
+    });
+  });
 }
 
 Instruction* ConvertToSampledImagePass::CreateImageExtraction(
@@ -283,8 +282,7 @@ Instruction* ConvertToSampledImagePass::UpdateImageUses(
 
   auto* extracted_image = CreateImageExtraction(sampled_image_load);
   for (auto* user : uses_of_load) {
-    user->SetInOperand(0, {spv_operand_type_t::SPV_OPERAND_TYPE_ID,
-                           {extracted_image->result_id()}});
+    user->SetInOperand(0, {extracted_image->result_id()});
     context()->get_def_use_mgr()->AnalyzeInstUse(user);
   }
   return extracted_image;

--- a/source/opt/convert_to_sampled_image_pass.cpp
+++ b/source/opt/convert_to_sampled_image_pass.cpp
@@ -24,8 +24,6 @@
 namespace spvtools {
 namespace opt {
 
-using DescriptorSetAndBinding =
-    ConvertToSampledImagePass::DescriptorSetAndBinding;
 using VectorOfDescriptorSetAndBindingPairs =
     std::vector<DescriptorSetAndBinding>;
 using DescriptorSetBindingToInstruction =
@@ -87,14 +85,15 @@ bool ConvertToSampledImagePass::GetDescriptorSetBinding(
         assert(false && "A resource has two OpDecorate for the descriptor set");
         return false;
       }
-      descriptor_set_binding->first = decorate->GetSingleWordInOperand(2u);
+      descriptor_set_binding->descriptor_set =
+          decorate->GetSingleWordInOperand(2u);
       found_descriptor_set_to_convert = true;
     } else if (decoration == SpvDecorationBinding) {
       if (found_binding_to_convert) {
         assert(false && "A resource has two OpDecorate for the binding");
         return false;
       }
-      descriptor_set_binding->second = decorate->GetSingleWordInOperand(2u);
+      descriptor_set_binding->binding = decorate->GetSingleWordInOperand(2u);
       found_binding_to_convert = true;
     }
   }
@@ -432,8 +431,7 @@ ConvertToSampledImagePass::ParseDescriptorSetBindingPairsString(
     str = ParseNumberUntilSeparator(str, &binding);
     if (str == nullptr) return nullptr;
 
-    descriptor_set_binding_pairs->push_back(
-        std::make_pair(std::move(descriptor_set), std::move(binding)));
+    descriptor_set_binding_pairs->push_back({descriptor_set, binding});
 
     // Skip trailing spaces.
     while (std::isspace(*str)) str++;

--- a/source/opt/convert_to_sampled_image_pass.h
+++ b/source/opt/convert_to_sampled_image_pass.h
@@ -71,16 +71,16 @@ class ConvertToSampledImagePass : public Pass {
   //
   //  "<descriptor set>:<binding> <descriptor set>:<binding> ..."
   //  Example:
-  //    "3:5   2:1   0:4"
+  //    "3:5 2:1 0:4"
   //
   //  Entries are separated with blank spaces (i.e.:' ', '\n', '\r', '\t',
-  //  '\f', '\v'). Each entry corresponds to a descriptor set and binding  pair.
+  //  '\f', '\v'). Each entry corresponds to a descriptor set and binding pair.
   //  Multiple spaces between, before or after entries are allowed. However,
   //  spaces are not allowed within a descriptor set or binding.
   //
   //  In each entry, the descriptor set and binding are separated by ':'.
-  //  Missing  ':' in any entry is invalid. And it is invalid to have blank
-  //  spaces in  between the spec id and ':' or the default value and ':'.
+  //  Missing ':' in any entry is invalid. And it is invalid to have blank
+  //  spaces in between the descriptor set and ':' or ':' and the binding.
   //
   //  <descriptor set>: the descriptor set.
   //    The text must represent a valid uint32_t number.

--- a/source/opt/convert_to_sampled_image_pass.h
+++ b/source/opt/convert_to_sampled_image_pass.h
@@ -97,8 +97,8 @@ class ConvertToSampledImagePass : public Pass {
   // image. Returns false if two samplers or two images have the same descriptor
   // set and binding. Otherwise, returns true.
   bool CollectResourcesToConvert(
-      DescriptorSetBindingToInstruction& descriptor_set_binding_pair_to_sampler,
-      DescriptorSetBindingToInstruction& descriptor_set_binding_pair_to_image)
+      DescriptorSetBindingToInstruction* descriptor_set_binding_pair_to_sampler,
+      DescriptorSetBindingToInstruction* descriptor_set_binding_pair_to_image)
       const;
 
   // Finds an OpDecorate with DescriptorSet decorating |inst| and another
@@ -156,6 +156,9 @@ class ConvertToSampledImagePass : public Pass {
   // Returns the id of type sampled image type whose image type is the one of
   // |image_variable|.
   uint32_t GetSampledImageTypeForImage(Instruction* image_variable);
+
+  // Moves |inst| next to the OpType* instruction with |type_id|.
+  void MoveInstructionNextToType(Instruction* inst, uint32_t type_id);
 
   // Converts |image_variable| whose type is an image pointer to sampled image
   // with the type id |sampled_image_type_id|. Returns whether it successfully

--- a/source/opt/convert_to_sampled_image_pass.h
+++ b/source/opt/convert_to_sampled_image_pass.h
@@ -1,0 +1,198 @@
+// Copyright (c) 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_OPT_CONVERT_TO_SAMPLED_IMAGE_PASS_H_
+#define SOURCE_OPT_CONVERT_TO_SAMPLED_IMAGE_PASS_H_
+
+#include <memory>
+#include <unordered_set>
+#include <utility>
+
+#include "source/opt/pass.h"
+#include "source/opt/types.h"
+
+namespace spvtools {
+namespace opt {
+
+// See optimizer.hpp for documentation.
+class ConvertToSampledImagePass : public Pass {
+ public:
+  // Hashing functor for the pair of descriptor set and binding.
+  struct DescriptorSetAndBindingHash {
+    size_t operator()(
+        const std::pair<uint32_t, uint32_t>& descriptor_set_binding) const {
+      return std::hash<uint32_t>()(descriptor_set_binding.first) ^
+             std::hash<uint32_t>()(descriptor_set_binding.second);
+    }
+  };
+
+  using DescriptorSetAndBinding = std::pair<uint32_t, uint32_t>;
+  using SetOfDescriptorSetAndBindingPairs =
+      std::unordered_set<DescriptorSetAndBinding, DescriptorSetAndBindingHash>;
+  using DescriptorSetBindingToInstruction =
+      std::unordered_map<DescriptorSetAndBinding, Instruction*,
+                         DescriptorSetAndBindingHash>;
+
+  explicit ConvertToSampledImagePass(
+      const std::vector<DescriptorSetAndBinding>& descriptor_set_binding_pairs)
+      : descriptor_set_binding_pairs_(descriptor_set_binding_pairs.begin(),
+                                      descriptor_set_binding_pairs.end()) {}
+
+  const char* name() const override { return "convert-to-sampled-image"; }
+  Status Process() override;
+
+  // Parses the given null-terminated C string to get a vector of descriptor set
+  // and binding pairs. Returns a unique pointer to the vector of descriptor set
+  // and binding pairs built from the given |str| on success. Returns a nullptr
+  // if the given string is not valid for building the vector of pairs.
+  // A valid string for building the vector of pairs should follow the rule
+  // below:
+  //
+  //  "<descriptor set>:<binding> <descriptor set>:<binding> ..."
+  //  Example:
+  //    "3:5   2:1   0:4"
+  //
+  //  Entries are separated with blank spaces (i.e.:' ', '\n', '\r', '\t',
+  //  '\f', '\v'). Each entry corresponds to a descriptor set and binding  pair.
+  //  Multiple spaces between, before or after entries are allowed. However,
+  //  spaces are not allowed within a descriptor set or binding.
+  //
+  //  In each entry, the descriptor set and binding are separated by ':'.
+  //  Missing  ':' in any entry is invalid. And it is invalid to have blank
+  //  spaces in  between the spec id and ':' or the default value and ':'.
+  //
+  //  <descriptor set>: the descriptor set.
+  //    The text must represent a valid uint32_t number.
+  //
+  //  <binding>: the binding.
+  //    The text must represent a valid uint32_t number.
+  static std::unique_ptr<std::vector<DescriptorSetAndBinding>>
+  ParseDescriptorSetBindingPairsString(const char* str);
+
+ private:
+  // Collects resources to convert to sampled image and saves them in
+  // |descriptor_set_binding_pair_to_sampler| if the resource is a sampler and
+  // saves them in |descriptor_set_binding_pair_to_image| if the resource is an
+  // image. Returns false if two samplers or two images have the same descriptor
+  // set and binding. Otherwise, returns true.
+  bool CollectResourcesToConvert(
+      DescriptorSetBindingToInstruction& descriptor_set_binding_pair_to_sampler,
+      DescriptorSetBindingToInstruction& descriptor_set_binding_pair_to_image)
+      const;
+
+  // Finds an OpDecorate with DescriptorSet decorating |inst| and another
+  // OpDecorate with Binding decorating |inst|. Stores the descriptor set and
+  // binding in |descriptor_set_binding|. Returns whether it successfully finds
+  // the descriptor set and binding or not.
+  bool GetDescriptorSetBinding(
+      const Instruction& inst,
+      DescriptorSetAndBinding* descriptor_set_binding) const;
+
+  // Returns whether |descriptor_set_binding| is a pair of a descriptor set
+  // and a binding that we have to convert resources with it to a sampled image
+  // or not.
+  bool IsDescriptorSetBindingPairForSampledImageConversion(
+      const DescriptorSetAndBinding& descriptor_set_binding) const;
+
+  // Returns the pointee type of the type of variable |variable|. If |variable|
+  // is not an OpVariable instruction, just returns nullptr.
+  const analysis::Type* GetVariableType(const Instruction& variable) const;
+
+  // Returns the storage class of |variable|.
+  SpvStorageClass GetStorageClass(const Instruction& variable) const;
+
+  // Finds |inst|'s users whose opcode is |user_opcode| or users of OpCopyObject
+  // instructions of |inst| whose opcode is |user_opcode| and puts them in
+  // |uses|.
+  void FindUses(const Instruction* inst, std::vector<Instruction*>* uses,
+                uint32_t user_opcode) const;
+
+  // Finds OpImage* instructions using |image| or OpCopyObject instructions that
+  // copy |image| and puts them in |uses|.
+  void FindUsesOfImage(const Instruction* image,
+                       std::vector<Instruction*>* uses) const;
+
+  // Creates an OpImage instruction that extracts the image from the sampled
+  // image |sampled_image|.
+  Instruction* CreateImageExtraction(Instruction* sampled_image);
+
+  // Replaces uses of |inst| with |replaced_inst_id|.
+  void ReplaceUsesWith(const Instruction* inst,
+                       uint32_t replaced_inst_id) const;
+
+  // Converts |image_variable| whose type is an image pointer to sampled image
+  // type. Updates users of |image_variable| accordingly. If some instructions
+  // e.g., OpImageRead use |image_variable| as an Image operand, creates an
+  // image extracted from the sampled image using OpImage and replace the Image
+  // operands of the users with the extracted image. If some OpSampledImage
+  // instructions use |image_variable| and sampler whose descriptor set and
+  // binding are the same with |image_variable|, just combines |image_variable|
+  // and the sampler to a sampled image.
+  Pass::Status UpdateImageVariableToSampledImage(
+      Instruction* image_variable,
+      const DescriptorSetAndBinding& descriptor_set_binding);
+
+  // Returns the id of type sampled image type whose image type is the one of
+  // |image_variable|.
+  uint32_t GetSampledImageTypeForImage(Instruction* image_variable);
+
+  // Converts |image_variable| whose type is an image pointer to sampled image
+  // with the type id |sampled_image_type_id|. Returns whether it successfully
+  // converts the type of |image_variable| or not.
+  bool ConvertImageVariableToSampledImage(Instruction* image_variable,
+                                          uint32_t sampled_image_type_id);
+
+  // Replaces |sampled_image_load| instruction used by OpImage* with the image
+  // extracted from |sampled_image_load|. Returns the extracted image or nullptr
+  // if it does not have uses.
+  Instruction* UpdateImageUses(Instruction* sampled_image_load);
+
+  // Returns true if the sampler of |sampled_image_inst| is decorated by a
+  // descriptor set and a binding |descriptor_set_binding|.
+  bool IsSamplerOfSampledImageDecoratedByDescriptorSetBinding(
+      Instruction* sampled_image_inst,
+      const DescriptorSetAndBinding& descriptor_set_binding);
+
+  // Replaces OpSampledImage instructions using |image_load| with |image_load|
+  // if the sampler of the OpSampledImage instruction has descriptor set and
+  // binding |image_descriptor_set_binding|. Otherwise, replaces |image_load|
+  // with |image_extraction|.
+  void UpdateSampledImageUses(
+      Instruction* image_load, Instruction* image_extraction,
+      const DescriptorSetAndBinding& image_descriptor_set_binding);
+
+  // Checks the uses of |sampler_variable|. When a sampler is used by
+  // OpSampledImage instruction, the corresponding image must be
+  // |image_to_be_combined_with| that should be already converted to a sampled
+  // image by UpdateImageVariableToSampledImage() method.
+  Pass::Status CheckUsesOfSamplerVariable(
+      const Instruction* sampler_variable,
+      Instruction* image_to_be_combined_with);
+
+  // Returns true if Image operand of |sampled_image_inst| is the image of
+  // |image_variable|.
+  bool DoesSampledImageReferenceImage(Instruction* sampled_image_inst,
+                                      Instruction* image_variable);
+
+  // A set of pairs of descriptor set and binding. If an image and/or a sampler
+  // have a pair of descriptor set and binding that is an element of
+  // |descriptor_set_binding_pairs_|, they/it will be converted to a sampled
+  // image by this pass.
+  const SetOfDescriptorSetAndBindingPairs descriptor_set_binding_pairs_;
+};
+
+}  // namespace opt
+}  // namespace spvtools
+
+#endif  // SOURCE_OPT_CONVERT_TO_SAMPLED_IMAGE_PASS_H_

--- a/source/opt/convert_to_sampled_image_pass.h
+++ b/source/opt/convert_to_sampled_image_pass.h
@@ -25,19 +25,29 @@
 namespace spvtools {
 namespace opt {
 
+// A struct for a pair of descriptor set and binding.
+struct DescriptorSetAndBinding {
+  uint32_t descriptor_set;
+  uint32_t binding;
+
+  bool operator==(const DescriptorSetAndBinding& descriptor_set_binding) const {
+    return descriptor_set_binding.descriptor_set == descriptor_set &&
+           descriptor_set_binding.binding == binding;
+  }
+};
+
 // See optimizer.hpp for documentation.
 class ConvertToSampledImagePass : public Pass {
  public:
   // Hashing functor for the pair of descriptor set and binding.
   struct DescriptorSetAndBindingHash {
     size_t operator()(
-        const std::pair<uint32_t, uint32_t>& descriptor_set_binding) const {
-      return std::hash<uint32_t>()(descriptor_set_binding.first) ^
-             std::hash<uint32_t>()(descriptor_set_binding.second);
+        const DescriptorSetAndBinding& descriptor_set_binding) const {
+      return std::hash<uint32_t>()(descriptor_set_binding.descriptor_set) ^
+             std::hash<uint32_t>()(descriptor_set_binding.binding);
     }
   };
 
-  using DescriptorSetAndBinding = std::pair<uint32_t, uint32_t>;
   using SetOfDescriptorSetAndBindingPairs =
       std::unordered_set<DescriptorSetAndBinding, DescriptorSetAndBindingHash>;
   using DescriptorSetBindingToInstruction =

--- a/source/opt/convert_to_sampled_image_pass.h
+++ b/source/opt/convert_to_sampled_image_pass.h
@@ -112,7 +112,7 @@ class ConvertToSampledImagePass : public Pass {
   // Returns whether |descriptor_set_binding| is a pair of a descriptor set
   // and a binding that we have to convert resources with it to a sampled image
   // or not.
-  bool IsDescriptorSetBindingPairForSampledImageConversion(
+  bool ShouldResourceBeConverted(
       const DescriptorSetAndBinding& descriptor_set_binding) const;
 
   // Returns the pointee type of the type of variable |variable|. If |variable|
@@ -136,10 +136,6 @@ class ConvertToSampledImagePass : public Pass {
   // Creates an OpImage instruction that extracts the image from the sampled
   // image |sampled_image|.
   Instruction* CreateImageExtraction(Instruction* sampled_image);
-
-  // Replaces uses of |inst| with |replaced_inst_id|.
-  void ReplaceUsesWith(const Instruction* inst,
-                       uint32_t replaced_inst_id) const;
 
   // Converts |image_variable| whose type is an image pointer to sampled image
   // type. Updates users of |image_variable| accordingly. If some instructions

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -961,7 +961,7 @@ Optimizer::PassToken CreateInterpolateFixupPass() {
 }
 
 Optimizer::PassToken CreateConvertToSampledImagePass(
-    const std::vector<std::pair<uint32_t, uint32_t>>&
+    const std::vector<opt::DescriptorSetAndBinding>&
         descriptor_set_binding_pairs) {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::ConvertToSampledImagePass>(descriptor_set_binding_pairs));

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -499,6 +499,26 @@ bool Optimizer::RegisterPassFromFlag(const std::string& flag) {
     RegisterPass(CreateAmdExtToKhrPass());
   } else if (pass_name == "interpolate-fixup") {
     RegisterPass(CreateInterpolateFixupPass());
+  } else if (pass_name == "convert-to-sampled-image") {
+    if (pass_args.size() > 0) {
+      auto descriptor_set_binding_pairs =
+          opt::ConvertToSampledImagePass::ParseDescriptorSetBindingPairsString(
+              pass_args.c_str());
+      if (!descriptor_set_binding_pairs) {
+        Errorf(consumer(), nullptr, {},
+               "Invalid argument for --convert-to-sampled-image: %s",
+               pass_args.c_str());
+        return false;
+      }
+      RegisterPass(CreateConvertToSampledImagePass(
+          std::move(*descriptor_set_binding_pairs)));
+    } else {
+      Errorf(consumer(), nullptr, {},
+             "Invalid pairs of descriptor set and binding '%s'. Expected a "
+             "string of <descriptor set>:<binding> pairs.",
+             pass_args.c_str());
+      return false;
+    }
   } else {
     Errorf(consumer(), nullptr, {},
            "Unknown flag '--%s'. Use --help for a list of valid flags",
@@ -938,6 +958,13 @@ Optimizer::PassToken CreateAmdExtToKhrPass() {
 Optimizer::PassToken CreateInterpolateFixupPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::InterpFixupPass>());
+}
+
+Optimizer::PassToken CreateConvertToSampledImagePass(
+    const std::vector<std::pair<uint32_t, uint32_t>>&
+        descriptor_set_binding_pairs) {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::ConvertToSampledImagePass>(descriptor_set_binding_pairs));
 }
 
 }  // namespace spvtools

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -26,6 +26,7 @@
 #include "source/opt/combine_access_chains.h"
 #include "source/opt/compact_ids_pass.h"
 #include "source/opt/convert_to_half_pass.h"
+#include "source/opt/convert_to_sampled_image_pass.h"
 #include "source/opt/copy_prop_arrays.h"
 #include "source/opt/dead_branch_elim_pass.h"
 #include "source/opt/dead_insert_elim_pass.h"

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -30,6 +30,7 @@ add_spvtools_unittest(TARGET opt
        constant_manager_test.cpp
        control_dependence.cpp
        convert_relaxed_to_half_test.cpp
+       convert_to_sampled_image_test.cpp
        copy_prop_array_test.cpp
        dataflow.cpp
        dead_branch_elim_test.cpp

--- a/test/opt/convert_to_sampled_image_test.cpp
+++ b/test/opt/convert_to_sampled_image_test.cpp
@@ -1,0 +1,355 @@
+// Copyright (c) 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "source/opt/convert_to_sampled_image_pass.h"
+#include "test/opt/pass_fixture.h"
+#include "test/opt/pass_utils.h"
+
+namespace spvtools {
+namespace opt {
+namespace {
+
+using testing::Eq;
+using DescriptorSetAndBinding =
+    ConvertToSampledImagePass::DescriptorSetAndBinding;
+using VectorOfDescriptorSetAndBindingPairs =
+    std::vector<DescriptorSetAndBinding>;
+
+struct DescriptorSetAndBindingStringParsingTestCase {
+  const char* descriptor_set_binding_str;
+  bool expect_success;
+  VectorOfDescriptorSetAndBindingPairs expected_descriptor_set_binding_pairs;
+};
+
+using DescriptorSetAndBindingStringParsingTest =
+    ::testing::TestWithParam<DescriptorSetAndBindingStringParsingTestCase>;
+
+TEST_P(DescriptorSetAndBindingStringParsingTest, TestCase) {
+  const auto& tc = GetParam();
+  auto actual_descriptor_set_binding_pairs =
+      ConvertToSampledImagePass::ParseDescriptorSetBindingPairsString(
+          tc.descriptor_set_binding_str);
+  if (tc.expect_success) {
+    EXPECT_NE(nullptr, actual_descriptor_set_binding_pairs);
+    if (actual_descriptor_set_binding_pairs) {
+      EXPECT_THAT(*actual_descriptor_set_binding_pairs,
+                  Eq(tc.expected_descriptor_set_binding_pairs));
+    }
+  } else {
+    EXPECT_EQ(nullptr, actual_descriptor_set_binding_pairs);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ValidString, DescriptorSetAndBindingStringParsingTest,
+    ::testing::ValuesIn(std::vector<
+                        DescriptorSetAndBindingStringParsingTestCase>{
+        // 0. empty vector
+        {"", true, VectorOfDescriptorSetAndBindingPairs({})},
+        // 1. one pair
+        {"100:1024", true,
+         VectorOfDescriptorSetAndBindingPairs({DescriptorSetAndBinding{100,
+                                                                       1024}})},
+        // 2. two pairs
+        {"100:1024 200:2048", true,
+         VectorOfDescriptorSetAndBindingPairs(
+             {DescriptorSetAndBinding{100, 1024},
+              DescriptorSetAndBinding{200, 2048}})},
+        // 3. spaces between entries
+        {"100:1024 \n \r \t \v \f 200:2048", true,
+         VectorOfDescriptorSetAndBindingPairs(
+             {DescriptorSetAndBinding{100, 1024},
+              DescriptorSetAndBinding{200, 2048}})},
+        // 4. \t, \n, \r and spaces before spec id
+        {"   \n \r\t \t \v \f 100:1024", true,
+         VectorOfDescriptorSetAndBindingPairs({DescriptorSetAndBinding{100,
+                                                                       1024}})},
+        // 5. \t, \n, \r and spaces after value string
+        {"100:1024   \n \r\t \t \v \f ", true,
+         VectorOfDescriptorSetAndBindingPairs({DescriptorSetAndBinding{100,
+                                                                       1024}})},
+        // 6. maximum spec id
+        {"4294967295:0", true,
+         VectorOfDescriptorSetAndBindingPairs({DescriptorSetAndBinding{
+             4294967295, 0}})},
+        // 7. minimum spec id
+        {"0:100", true,
+         VectorOfDescriptorSetAndBindingPairs({DescriptorSetAndBinding{0,
+                                                                       100}})},
+        // 8. multiple entries
+        {"101:1 102:2 103:3 104:4 200:201 9999:1000", true,
+         VectorOfDescriptorSetAndBindingPairs(
+             {DescriptorSetAndBinding{101, 1}, DescriptorSetAndBinding{102, 2},
+              DescriptorSetAndBinding{103, 3}, DescriptorSetAndBinding{104, 4},
+              DescriptorSetAndBinding{200, 201},
+              DescriptorSetAndBinding{9999, 1000}})},
+    }));
+
+INSTANTIATE_TEST_SUITE_P(
+    InvalidString, DescriptorSetAndBindingStringParsingTest,
+    ::testing::ValuesIn(
+        std::vector<DescriptorSetAndBindingStringParsingTestCase>{
+            // 0. missing default value
+            {"100:", false, VectorOfDescriptorSetAndBindingPairs{}},
+            // 1. descriptor set is not an integer
+            {"100.0:200", false, VectorOfDescriptorSetAndBindingPairs{}},
+            // 2. descriptor set is not a number
+            {"something_not_a_number:1", false,
+             VectorOfDescriptorSetAndBindingPairs{}},
+            // 3. only descriptor set number
+            {"100", false, VectorOfDescriptorSetAndBindingPairs{}},
+            // 4. empty descriptor set
+            {":3", false, VectorOfDescriptorSetAndBindingPairs{}},
+            // 5. only colon
+            {":", false, VectorOfDescriptorSetAndBindingPairs{}},
+            // 6. descriptor set overflow
+            {"4294967296:200", false, VectorOfDescriptorSetAndBindingPairs{}},
+            // 7. descriptor set less than 0
+            {"-1:200", false, VectorOfDescriptorSetAndBindingPairs{}},
+            // 8. nullptr
+            {nullptr, false, VectorOfDescriptorSetAndBindingPairs{}},
+            // 9. only a number is invalid
+            {"1234", false, VectorOfDescriptorSetAndBindingPairs{}},
+            // 10. invalid entry separator
+            {"12:34;23:14", false, VectorOfDescriptorSetAndBindingPairs{}},
+            // 11. invalid descriptor set and default value separator
+            {"12@34", false, VectorOfDescriptorSetAndBindingPairs{}},
+            // 12. spaces before colon
+            {"100   :1024", false, VectorOfDescriptorSetAndBindingPairs{}},
+            // 13. spaces after colon
+            {"100:   1024", false, VectorOfDescriptorSetAndBindingPairs{}},
+            // 14. descriptor set represented in hex float format is invalid
+            {"0x3p10:200", false, VectorOfDescriptorSetAndBindingPairs{}},
+        }));
+
+std::string BuildShader(const char* shader_decorate_instructions,
+                        const char* shader_image_and_sampler_variables,
+                        const char* shader_body) {
+  // Base HLSL code:
+  //
+  // SamplerState sam : register(s2);
+  // Texture2D <float4> texture : register(t5);
+  //
+  // float4 main() : SV_TARGET {
+  //     return texture.SampleLevel(sam, float2(1, 2), 10, 2);
+  // }
+  std::stringstream ss;
+  ss << R"(
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %out_var_SV_TARGET
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 600
+               OpName %type_sampler "type.sampler"
+               OpName %type_2d_image "type.2d.image"
+               OpName %out_var_SV_TARGET "out.var.SV_TARGET"
+               OpName %main "main"
+               OpName %type_sampled_image "type.sampled.image"
+               OpDecorate %out_var_SV_TARGET Location 0
+               )";
+  ss << shader_decorate_instructions;
+  ss << R"(
+      %float = OpTypeFloat 32
+    %float_1 = OpConstant %float 1
+    %float_2 = OpConstant %float 2
+    %v2float = OpTypeVector %float 2
+         %12 = OpConstantComposite %v2float %float_1 %float_2
+   %float_10 = OpConstant %float 10
+        %int = OpTypeInt 32 1
+      %int_2 = OpConstant %int 2
+      %v2int = OpTypeVector %int 2
+         %17 = OpConstantComposite %v2int %int_2 %int_2
+%type_sampler = OpTypeSampler
+%_ptr_UniformConstant_type_sampler = OpTypePointer UniformConstant %type_sampler
+%type_2d_image = OpTypeImage %float 2D 2 0 0 1 Unknown
+%_ptr_UniformConstant_type_2d_image = OpTypePointer UniformConstant %type_2d_image
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+       %void = OpTypeVoid
+         %23 = OpTypeFunction %void
+%type_sampled_image = OpTypeSampledImage %type_2d_image
+               )";
+  ss << shader_image_and_sampler_variables;
+  ss << R"(
+%out_var_SV_TARGET = OpVariable %_ptr_Output_v4float Output
+       %main = OpFunction %void None %23
+         %24 = OpLabel
+  )";
+  ss << shader_body;
+  ss << R"(
+               OpReturn
+               OpFunctionEnd
+  )";
+  return ss.str();
+}
+
+using ConvertToSampledImageTest = PassTest<::testing::Test>;
+
+TEST_F(ConvertToSampledImageTest, Texture2DAndSamplerToSampledImage) {
+  const std::string shader = BuildShader(
+      R"(
+               OpDecorate %sam DescriptorSet 0
+               OpDecorate %sam Binding 5
+               OpDecorate %texture DescriptorSet 0
+               OpDecorate %texture Binding 5
+               )",
+      R"(
+            ; CHECK-NOT: OpVariable %_ptr_UniformConstant_type_2d_image
+
+            ; CHECK: [[tex:%\w+]] = OpVariable %_ptr_UniformConstant_type_sampled_image UniformConstant
+        %sam = OpVariable %_ptr_UniformConstant_type_sampler UniformConstant
+    %texture = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant
+               )",
+      R"(
+            ; CHECK: [[load:%\w+]] = OpLoad %type_sampled_image [[tex]]
+            ; CHECK: OpImageSampleExplicitLod %v4float [[load]]
+         %25 = OpLoad %type_2d_image %texture
+         %26 = OpLoad %type_sampler %sam
+         %27 = OpSampledImage %type_sampled_image %25 %26
+         %28 = OpImageSampleExplicitLod %v4float %27 %12 Lod|ConstOffset %float_10 %17
+               OpStore %out_var_SV_TARGET %28
+               )");
+
+  auto result = SinglePassRunAndMatch<ConvertToSampledImagePass>(
+      shader, /* do_validate = */ true,
+      VectorOfDescriptorSetAndBindingPairs{DescriptorSetAndBinding{0, 5}});
+
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+TEST_F(ConvertToSampledImageTest, Texture2DToSampledImage) {
+  const std::string shader = BuildShader(
+      R"(
+               OpDecorate %sam DescriptorSet 0
+               OpDecorate %sam Binding 2
+               OpDecorate %texture DescriptorSet 0
+               OpDecorate %texture Binding 5
+               )",
+      R"(
+            ; CHECK: [[tex:%\w+]] = OpVariable %_ptr_UniformConstant_type_sampled_image UniformConstant
+        %sam = OpVariable %_ptr_UniformConstant_type_sampler UniformConstant
+    %texture = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant
+               )",
+      R"(
+            ; CHECK: [[load:%\w+]] = OpLoad %type_sampled_image [[tex]]
+            ; CHECK: [[image_extraction:%\w+]] = OpImage %type_2d_image [[load]]
+            ; CHECK: OpSampledImage %type_sampled_image [[image_extraction]]
+         %25 = OpLoad %type_2d_image %texture
+         %26 = OpLoad %type_sampler %sam
+         %27 = OpSampledImage %type_sampled_image %25 %26
+         %28 = OpImageSampleExplicitLod %v4float %27 %12 Lod|ConstOffset %float_10 %17
+               OpStore %out_var_SV_TARGET %28
+               )");
+
+  auto result = SinglePassRunAndMatch<ConvertToSampledImagePass>(
+      shader, /* do_validate = */ true,
+      VectorOfDescriptorSetAndBindingPairs{DescriptorSetAndBinding{0, 5}});
+
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+TEST_F(ConvertToSampledImageTest, SamplerToSampledImage) {
+  const std::string shader = BuildShader(
+      R"(
+               OpDecorate %sam DescriptorSet 0
+               OpDecorate %sam Binding 2
+               OpDecorate %texture DescriptorSet 0
+               OpDecorate %texture Binding 5
+               )",
+      R"(
+        %sam = OpVariable %_ptr_UniformConstant_type_sampler UniformConstant
+    %texture = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant
+               )",
+      R"(
+         %25 = OpLoad %type_2d_image %texture
+         %26 = OpLoad %type_sampler %sam
+         %27 = OpSampledImage %type_sampled_image %25 %26
+         %28 = OpImageSampleExplicitLod %v4float %27 %12 Lod|ConstOffset %float_10 %17
+               OpStore %out_var_SV_TARGET %28
+               )");
+
+  auto result = SinglePassRunToBinary<ConvertToSampledImagePass>(
+      shader, /* skip_nop = */ false,
+      VectorOfDescriptorSetAndBindingPairs{DescriptorSetAndBinding{0, 2}});
+
+  EXPECT_EQ(std::get<1>(result), Pass::Status::Failure);
+}
+
+TEST_F(ConvertToSampledImageTest, TwoImagesWithDuplicatedDescriptorSetBinding) {
+  const std::string shader = BuildShader(
+      R"(
+               OpDecorate %sam DescriptorSet 0
+               OpDecorate %sam Binding 2
+               OpDecorate %texture0 DescriptorSet 0
+               OpDecorate %texture0 Binding 5
+               OpDecorate %texture1 DescriptorSet 0
+               OpDecorate %texture1 Binding 5
+               )",
+      R"(
+        %sam = OpVariable %_ptr_UniformConstant_type_sampler UniformConstant
+   %texture0 = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant
+   %texture1 = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant
+               )",
+      R"(
+         %25 = OpLoad %type_2d_image %texture0
+         %26 = OpLoad %type_sampler %sam
+         %27 = OpSampledImage %type_sampled_image %25 %26
+         %28 = OpImageSampleExplicitLod %v4float %27 %12 Lod|ConstOffset %float_10 %17
+               OpStore %out_var_SV_TARGET %28
+               )");
+
+  auto result = SinglePassRunToBinary<ConvertToSampledImagePass>(
+      shader, /* skip_nop = */ false,
+      VectorOfDescriptorSetAndBindingPairs{DescriptorSetAndBinding{0, 5}});
+
+  EXPECT_EQ(std::get<1>(result), Pass::Status::Failure);
+}
+
+TEST_F(ConvertToSampledImageTest,
+       TwoSamplersWithDuplicatedDescriptorSetBinding) {
+  const std::string shader = BuildShader(
+      R"(
+               OpDecorate %sam0 DescriptorSet 0
+               OpDecorate %sam0 Binding 2
+               OpDecorate %sam1 DescriptorSet 0
+               OpDecorate %sam1 Binding 2
+               OpDecorate %texture DescriptorSet 0
+               OpDecorate %texture Binding 5
+               )",
+      R"(
+       %sam0 = OpVariable %_ptr_UniformConstant_type_sampler UniformConstant
+       %sam1 = OpVariable %_ptr_UniformConstant_type_sampler UniformConstant
+    %texture = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant
+               )",
+      R"(
+         %25 = OpLoad %type_2d_image %texture
+         %26 = OpLoad %type_sampler %sam0
+         %27 = OpSampledImage %type_sampled_image %25 %26
+         %28 = OpImageSampleExplicitLod %v4float %27 %12 Lod|ConstOffset %float_10 %17
+               OpStore %out_var_SV_TARGET %28
+               )");
+
+  auto result = SinglePassRunToBinary<ConvertToSampledImagePass>(
+      shader, /* skip_nop = */ false,
+      VectorOfDescriptorSetAndBindingPairs{DescriptorSetAndBinding{0, 2}});
+
+  EXPECT_EQ(std::get<1>(result), Pass::Status::Failure);
+}
+
+}  // namespace
+}  // namespace opt
+}  // namespace spvtools

--- a/test/opt/convert_to_sampled_image_test.cpp
+++ b/test/opt/convert_to_sampled_image_test.cpp
@@ -24,8 +24,6 @@ namespace opt {
 namespace {
 
 using testing::Eq;
-using DescriptorSetAndBinding =
-    ConvertToSampledImagePass::DescriptorSetAndBinding;
 using VectorOfDescriptorSetAndBindingPairs =
     std::vector<DescriptorSetAndBinding>;
 

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -143,6 +143,15 @@ Options (in lexicographical order):)",
                does not support RelaxedPrecision or ignores it. This pass also
                removes all RelaxedPrecision decorations.)");
   printf(R"(
+  --convert-to-sampled-image "<descriptor set>:<binding> ..."
+               convert images and/or samplers with the given pairs of descriptor
+               set and binding to sampled images. If a pair of an image and a
+               sampler have the same pair of descriptor set and binding that is
+               one of the given pairs, they will be converted to a sampled
+               image. In addition, if only an image or a sampler has the
+               descriptor set and binding that is one of the given pairs, it
+               will be converted to a sampled image.)");
+  printf(R"(
   --copy-propagate-arrays
                Does propagation of memory references when an array is a copy of
                another.  It will only propagate an array if the source is never


### PR DESCRIPTION
convert-to-sampled-image pass converts images and/or samplers with
given pairs of descriptor set and binding to sampled image.

If a pair of an image and a sampler have the same pair of descriptor
set and binding that is one of the given pairs, they will be
converted to a sampled image. In addition, if only an image has the
descriptor set and binding that is one of the given pairs, it will
be converted to a sampled image as well.

For example, when we have

```
  %a = OpLoad %type_2d_image %texture
  %b = OpLoad %type_sampler %sampler
  %combined = OpSampledImage %type_sampled_image %a %b
  %value = OpImageSampleExplicitLod %v4float %combined ...
```

1. If `%texture` and `%sampler` have the same descriptor set and binding

```
  %combine_texture_and_sampler = OpVaraible %ptr_type_sampled_image_Uniform
  ...
  %combined = OpLoad %type_sampled_image %combine_texture_and_sampler
  %value = OpImageSampleExplicitLod %v4float %combined ...
```

2. If `%texture` and `%sampler` have different pairs of descriptor set and binding

```
  %a = OpLoad %type_sampled_image %texture
  %extracted_image = OpImage %type_2d_image %a
  %b = OpLoad %type_sampler %sampler
  %combined = OpSampledImage %type_sampled_image %extracted_image %b
  %value = OpImageSampleExplicitLod %v4float %combined ...
```