### PR TITLE
spirv-fuzz: Support atomic operations opcode

### DIFF
--- a/source/fuzz/transformation_replace_id_with_synonym.cpp
+++ b/source/fuzz/transformation_replace_id_with_synonym.cpp
@@ -139,13 +139,10 @@ bool TransformationReplaceIdWithSynonym::IsAgnosticToSignednessOfOperand(
     case SpvOpSLessThanEqual:
     case SpvOpUGreaterThanEqual:
     case SpvOpSGreaterThanEqual:
-    case SpvOpAtomicLoad:
+      return true;
+
     case SpvOpAtomicStore:
     case SpvOpAtomicExchange:
-    case SpvOpAtomicCompareExchange:
-    case SpvOpAtomicCompareExchangeWeak:
-    case SpvOpAtomicIIncrement:
-    case SpvOpAtomicIDecrement:
     case SpvOpAtomicIAdd:
     case SpvOpAtomicISub:
     case SpvOpAtomicSMin:
@@ -155,11 +152,39 @@ bool TransformationReplaceIdWithSynonym::IsAgnosticToSignednessOfOperand(
     case SpvOpAtomicAnd:
     case SpvOpAtomicOr:
     case SpvOpAtomicXor:
-    // These instructions required another capability.
-    case SpvOpAtomicFlagTestAndSet:
-    case SpvOpAtomicFlagClear:
-    case SpvOpAtomicFAddEXT:
-      return true;
+    // TBD(To Be Discussed),
+    // https://github.com/KhronosGroup/SPIRV-Registry/blob/master/extensions/EXT/SPV_EXT_shader_atomic_float_add.asciidoc#modifications-to-the-spir-v-specification-version-15
+    case SpvOpAtomicFAddEXT:  // Capability (AtomicFloat32AddEXT,
+                              // AtomicFloat64AddEXT)
+      assert(use_in_operand_index != 0 && "Forbidden.");
+
+      if (opcode == SpvOpAtomicFAddEXT) {
+        // Would you like to check Capability here?
+      }
+      return use_in_operand_index == 1 || use_in_operand_index == 2;
+
+    case SpvOpAtomicCompareExchange:
+    // Deprecated, missing after version 1.3.
+    // Would you like to remove it?
+    case SpvOpAtomicCompareExchangeWeak:  // Capability (Kernel)
+      assert(use_in_operand_index != 0 && "Forbidden.");
+      // This opcode is Deprecated!
+      if (opcode == SpvOpAtomicCompareExchangeWeak) {
+        // Would you like to check Capability here?
+      }
+      return use_in_operand_index >= 1 && use_in_operand_index <= 3;
+    case SpvOpAtomicLoad:
+    case SpvOpAtomicIIncrement:
+    case SpvOpAtomicIDecrement:
+    case SpvOpAtomicFlagTestAndSet:  // Capability (Kernel)
+    case SpvOpAtomicFlagClear:       // Capability (Kernel)
+      assert(use_in_operand_index != 0 && "Forbidden.");
+      if (opcode == SpvOpAtomicFlagTestAndSet ||
+          opcode == SpvOpAtomicFlagClear) {
+        // Would you like to check Capability here?
+      }
+      return use_in_operand_index >= 1;
+
     case SpvOpAccessChain:
       // The signedness of indices does not matter.
       return use_in_operand_index > 0;

--- a/source/fuzz/transformation_replace_id_with_synonym.cpp
+++ b/source/fuzz/transformation_replace_id_with_synonym.cpp
@@ -152,42 +152,31 @@ bool TransformationReplaceIdWithSynonym::IsAgnosticToSignednessOfOperand(
     case SpvOpAtomicAnd:
     case SpvOpAtomicOr:
     case SpvOpAtomicXor:
-    // TBD(To Be Discussed),
-    // https://github.com/KhronosGroup/SPIRV-Registry/blob/master/extensions/EXT/SPV_EXT_shader_atomic_float_add.asciidoc#modifications-to-the-spir-v-specification-version-15
-    case SpvOpAtomicFAddEXT:  // Capability (AtomicFloat32AddEXT,
-                              // AtomicFloat64AddEXT)
-      assert(use_in_operand_index != 0 && "Forbidden.");
-
-      if (opcode == SpvOpAtomicFAddEXT) {
-        // Would you like to check Capability here?
-      }
+    case SpvOpAtomicFAddEXT:  // Capability AtomicFloat32AddEXT,
+                              // AtomicFloat64AddEXT.
+      assert(use_in_operand_index != 0 &&
+             "Signedness check should not occur on a pointer operand.");
       return use_in_operand_index == 1 || use_in_operand_index == 2;
 
     case SpvOpAtomicCompareExchange:
-    // Deprecated, missing after version 1.3.
-    // Would you like to remove it?
-    case SpvOpAtomicCompareExchangeWeak:  // Capability (Kernel)
-      assert(use_in_operand_index != 0 && "Forbidden.");
-      // This opcode is Deprecated!
-      if (opcode == SpvOpAtomicCompareExchangeWeak) {
-        // Would you like to check Capability here?
-      }
+    case SpvOpAtomicCompareExchangeWeak:  // Capability Kernel.
+      assert(use_in_operand_index != 0 &&
+             "Signedness check should not occur on a pointer operand.");
       return use_in_operand_index >= 1 && use_in_operand_index <= 3;
+
     case SpvOpAtomicLoad:
     case SpvOpAtomicIIncrement:
     case SpvOpAtomicIDecrement:
-    case SpvOpAtomicFlagTestAndSet:  // Capability (Kernel)
-    case SpvOpAtomicFlagClear:       // Capability (Kernel)
-      assert(use_in_operand_index != 0 && "Forbidden.");
-      if (opcode == SpvOpAtomicFlagTestAndSet ||
-          opcode == SpvOpAtomicFlagClear) {
-        // Would you like to check Capability here?
-      }
+    case SpvOpAtomicFlagTestAndSet:  // Capability Kernel.
+    case SpvOpAtomicFlagClear:       // Capability Kernel.
+      assert(use_in_operand_index != 0 &&
+             "Signedness check should not occur on a pointer operand.");
       return use_in_operand_index >= 1;
 
     case SpvOpAccessChain:
       // The signedness of indices does not matter.
       return use_in_operand_index > 0;
+
     default:
       // Conservatively assume that the id cannot be swapped in other
       // instructions.

--- a/source/fuzz/transformation_replace_id_with_synonym.cpp
+++ b/source/fuzz/transformation_replace_id_with_synonym.cpp
@@ -139,6 +139,26 @@ bool TransformationReplaceIdWithSynonym::IsAgnosticToSignednessOfOperand(
     case SpvOpSLessThanEqual:
     case SpvOpUGreaterThanEqual:
     case SpvOpSGreaterThanEqual:
+    case SpvOpAtomicLoad:
+    case SpvOpAtomicStore:
+    case SpvOpAtomicExchange:
+    case SpvOpAtomicCompareExchange:
+    case SpvOpAtomicCompareExchangeWeak:
+    case SpvOpAtomicIIncrement:
+    case SpvOpAtomicIDecrement:
+    case SpvOpAtomicIAdd:
+    case SpvOpAtomicISub:
+    case SpvOpAtomicSMin:
+    case SpvOpAtomicUMin:
+    case SpvOpAtomicSMax:
+    case SpvOpAtomicUMax:
+    case SpvOpAtomicAnd:
+    case SpvOpAtomicOr:
+    case SpvOpAtomicXor:
+    // These instructions required another capability.
+    case SpvOpAtomicFlagTestAndSet:
+    case SpvOpAtomicFlagClear:
+    case SpvOpAtomicFAddEXT:
       return true;
     case SpvOpAccessChain:
       // The signedness of indices does not matter.

--- a/test/fuzz/transformation_replace_id_with_synonym_test.cpp
+++ b/test/fuzz/transformation_replace_id_with_synonym_test.cpp
@@ -2026,11 +2026,8 @@ TEST(TransformationReplaceIdWithSynonymTest,
                    .IsApplicable(context.get(), transformation_context));
 }
 
-// TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/4345): Improve this
-//  test so that it covers more atomic operations, and enable the test once the
-//  issue is fixed.
 TEST(TransformationReplaceIdWithSynonymTest,
-     SignOfAtomicScopeAndMemorySemanticsDoesNotMatter) {
+     DISABLED_SignOfAtomicScopeAndMemorySemanticsDoesNotMatter) {
   // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/4345): both the
   //  GLSL comment and the corresponding SPIR-V should be updated to cover a
   //  larger number of atomic operations.
@@ -2191,6 +2188,12 @@ TEST(TransformationReplaceIdWithSynonymTest, TypesAreCompatible) {
           %8 = OpTypeStruct %6
          %10 = OpTypePointer StorageBuffer %8
          %11 = OpVariable %10 StorageBuffer
+         %86 = OpTypeStruct %9
+         %87 = OpTypePointer Workgroup %86
+         %88 = OpVariable %87 Workgroup
+         %89 = OpTypePointer Workgroup %9
+         %19 = OpConstant %9 0
+         %18 = OpConstant %9 1
          %12 = OpConstant %6 0
          %13 = OpTypePointer StorageBuffer %6
          %15 = OpConstant %6 2
@@ -2199,8 +2202,21 @@ TEST(TransformationReplaceIdWithSynonymTest, TypesAreCompatible) {
           %4 = OpFunction %2 None %3
           %5 = OpLabel
          %14 = OpAccessChain %13 %11 %12
+         %90 = OpAccessChain %89 %88 %19
          %21 = OpAtomicLoad %6 %14 %15 %20
          %22 = OpAtomicExchange %6 %14 %15 %20 %16
+         %23 = OpAtomicCompareExchange %6 %14 %15 %20 %12 %16 %15
+         %24 = OpAtomicIIncrement %6 %14 %15 %20
+         %25 = OpAtomicIDecrement %6 %14 %15 %20
+         %26 = OpAtomicIAdd %6  %14 %15 %20 %16
+         %27 = OpAtomicISub %6  %14 %15 %20 %16
+         %28 = OpAtomicSMin %6  %14 %15 %20 %16
+         %29 = OpAtomicUMin %9 %90 %15 %20 %18
+         %30 = OpAtomicSMax %6  %14 %15 %20 %15
+         %31 = OpAtomicUMax %9 %90 %15 %20 %18
+         %32 = OpAtomicAnd  %6  %14 %15 %20 %16
+         %33 = OpAtomicOr   %6  %14 %15 %20 %16
+         %34 = OpAtomicXor  %6  %14 %15 %20 %16
                OpAtomicStore %14 %15 %20 %16
                OpReturn
                OpFunctionEnd
@@ -2253,8 +2269,160 @@ TEST(TransformationReplaceIdWithSynonymTest, TypesAreCompatible) {
   ASSERT_FALSE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
       context.get(), SpvOpAtomicStore, 3, int_type, uint_type));
 
-  // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/4345): Similar for
-  // other atomic instructions
+  // OpAtomicCompareExchange
+#ifndef NDEBUG
+  ASSERT_DEATH(
+      TransformationReplaceIdWithSynonym::TypesAreCompatible(
+          context.get(), SpvOpAtomicCompareExchange, 0, int_type, uint_type),
+      "Invalid operand index");
+#endif
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicCompareExchange, 1, int_type, uint_type));
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicCompareExchange, 2, int_type, uint_type));
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicCompareExchange, 3, int_type, uint_type));
+  ASSERT_FALSE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicCompareExchange, 4, int_type, uint_type));
+
+  // OpAtomicIIncrement
+#ifndef NDEBUG
+  ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+                   context.get(), OpAtomicIIncrement, 0, int_type, uint_type),
+               "Invalid operand index");
+#endif
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicIIncrement, 1, int_type, uint_type));
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicIIncrement, 2, int_type, uint_type));
+
+// OpAtomicIDecrement
+#ifndef NDEBUG
+  ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+                   context.get(), SpvOpAtomicStore, 0, int_type, uint_type),
+               "Invalid operand index");
+#endif
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicStore, 1, int_type, uint_type));
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicStore, 2, int_type, uint_type));
+
+// OpAtomicIAdd
+#ifndef NDEBUG
+  ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+                   context.get(), SpvOpAtomicIAdd, 0, int_type, uint_type),
+               "Invalid operand index");
+#endif
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicIAdd, 1, int_type, uint_type));
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicIAdd, 2, int_type, uint_type));
+  ASSERT_FALSE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicIAdd, 3, int_type, uint_type));
+
+// OpAtomicISub
+#ifndef NDEBUG
+  ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+                   context.get(), SpvOpAtomicISub, 0, int_type, uint_type),
+               "Invalid operand index");
+#endif
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicISub, 1, int_type, uint_type));
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicISub, 2, int_type, uint_type));
+  ASSERT_FALSE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicISub, 3, int_type, uint_type));
+
+// OpAtomicSMin
+#ifndef NDEBUG
+  ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+                   context.get(), SpvOpAtomicSMin, 0, int_type, uint_type),
+               "Invalid operand index");
+#endif
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicSMin, 1, int_type, uint_type));
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicSMin, 2, int_type, uint_type));
+  ASSERT_FALSE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicSMin, 3, int_type, uint_type));
+
+// OpAtomicUMin
+#ifndef NDEBUG
+  ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+                   context.get(), SpvOpAtomicUMin, 0, int_type, uint_type),
+               "Invalid operand index");
+#endif
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicUMin, 1, int_type, uint_type));
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicUMin, 2, int_type, uint_type));
+  ASSERT_FALSE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicUMin, 3, int_type, uint_type));
+
+// OpAtomicSMax
+#ifndef NDEBUG
+  ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+                   context.get(), SpvOpAtomicSMax, 0, int_type, uint_type),
+               "Invalid operand index");
+#endif
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicSMax, 1, int_type, uint_type));
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicSMax, 2, int_type, uint_type));
+  ASSERT_FALSE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicSMax, 3, int_type, uint_type));
+
+// OpAtomicUMax
+#ifndef NDEBUG
+  ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+                   context.get(), SpvOpAtomicUMax, 0, int_type, uint_type),
+               "Invalid operand index");
+#endif
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicUMax, 1, int_type, uint_type));
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicUMax, 2, int_type, uint_type));
+  ASSERT_FALSE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicUMax, 3, int_type, uint_type));
+
+// OpAtomicAnd
+#ifndef NDEBUG
+  ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+                   context.get(), SpvOpAtomicAnd, 0, int_type, uint_type),
+               "Invalid operand index");
+#endif
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicAnd, 1, int_type, uint_type));
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicAnd, 2, int_type, uint_type));
+  ASSERT_FALSE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicAnd, 3, int_type, uint_type));
+
+// OpAtomicOr
+#ifndef NDEBUG
+  ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+                   context.get(), SpvOpAtomicOr, 0, int_type, uint_type),
+               "Invalid operand index");
+#endif
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicOr, 1, int_type, uint_type));
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicOr, 2, int_type, uint_type));
+  ASSERT_FALSE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicOr, 3, int_type, uint_type));
+
+// OpAtomicXor
+#ifndef NDEBUG
+  ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+                   context.get(), SpvOpAtomicXor, 0, int_type, uint_type),
+               "Invalid operand index");
+#endif
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicXor, 1, int_type, uint_type));
+  ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicXor, 2, int_type, uint_type));
+  ASSERT_FALSE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
+      context.get(), SpvOpAtomicXor, 3, int_type, uint_type));
 }
 
 }  // namespace

--- a/test/fuzz/transformation_replace_id_with_synonym_test.cpp
+++ b/test/fuzz/transformation_replace_id_with_synonym_test.cpp
@@ -2028,6 +2028,8 @@ TEST(TransformationReplaceIdWithSynonymTest,
 
 TEST(TransformationReplaceIdWithSynonymTest,
      DISABLED_SignOfAtomicScopeAndMemorySemanticsDoesNotMatter) {
+  //  This test is failed at (IsApplicable) line, because of updates from PR
+  //  #4349.
   // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/4345): both the
   //  GLSL comment and the corresponding SPIR-V should be updated to cover a
   //  larger number of atomic operations.
@@ -2287,9 +2289,10 @@ TEST(TransformationReplaceIdWithSynonymTest, TypesAreCompatible) {
 
   // OpAtomicIIncrement
 #ifndef NDEBUG
-  ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
-                   context.get(), OpAtomicIIncrement, 0, int_type, uint_type),
-               "Invalid operand index");
+  ASSERT_DEATH(
+      TransformationReplaceIdWithSynonym::TypesAreCompatible(
+          context.get(), SpvOpAtomicIIncrement, 0, int_type, uint_type),
+      "Invalid operand index");
 #endif
   ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
       context.get(), SpvOpAtomicIIncrement, 1, int_type, uint_type));

--- a/test/fuzz/transformation_replace_id_with_synonym_test.cpp
+++ b/test/fuzz/transformation_replace_id_with_synonym_test.cpp
@@ -2239,7 +2239,7 @@ TEST(TransformationReplaceIdWithSynonymTest, TypesAreCompatible) {
 #ifndef NDEBUG
   ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
                    context.get(), SpvOpAtomicLoad, 0, int_type, uint_type),
-               "Invalid operand index");
+               "Signedness check should not occur on a pointer operand.");
 #endif
   ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
       context.get(), SpvOpAtomicLoad, 1, int_type, uint_type));
@@ -2250,7 +2250,7 @@ TEST(TransformationReplaceIdWithSynonymTest, TypesAreCompatible) {
 #ifndef NDEBUG
   ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
                    context.get(), SpvOpAtomicExchange, 0, int_type, uint_type),
-               "Invalid operand index");
+               "Signedness check should not occur on a pointer operand.");
 #endif
   ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
       context.get(), SpvOpAtomicExchange, 1, int_type, uint_type));
@@ -2263,7 +2263,7 @@ TEST(TransformationReplaceIdWithSynonymTest, TypesAreCompatible) {
 #ifndef NDEBUG
   ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
                    context.get(), SpvOpAtomicStore, 0, int_type, uint_type),
-               "Invalid operand index");
+               "Signedness check should not occur on a pointer operand.");
 #endif
   ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
       context.get(), SpvOpAtomicStore, 1, int_type, uint_type));
@@ -2277,7 +2277,7 @@ TEST(TransformationReplaceIdWithSynonymTest, TypesAreCompatible) {
   ASSERT_DEATH(
       TransformationReplaceIdWithSynonym::TypesAreCompatible(
           context.get(), SpvOpAtomicCompareExchange, 0, int_type, uint_type),
-      "Invalid operand index");
+      "Signedness check should not occur on a pointer operand.");
 #endif
   ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
       context.get(), SpvOpAtomicCompareExchange, 1, int_type, uint_type));
@@ -2293,7 +2293,7 @@ TEST(TransformationReplaceIdWithSynonymTest, TypesAreCompatible) {
   ASSERT_DEATH(
       TransformationReplaceIdWithSynonym::TypesAreCompatible(
           context.get(), SpvOpAtomicIIncrement, 0, int_type, uint_type),
-      "Invalid operand index");
+      "Signedness check should not occur on a pointer operand.");
 #endif
   ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
       context.get(), SpvOpAtomicIIncrement, 1, int_type, uint_type));
@@ -2304,7 +2304,7 @@ TEST(TransformationReplaceIdWithSynonymTest, TypesAreCompatible) {
 #ifndef NDEBUG
   ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
                    context.get(), SpvOpAtomicStore, 0, int_type, uint_type),
-               "Invalid operand index");
+               "Signedness check should not occur on a pointer operand.");
 #endif
   ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
       context.get(), SpvOpAtomicStore, 1, int_type, uint_type));
@@ -2315,7 +2315,7 @@ TEST(TransformationReplaceIdWithSynonymTest, TypesAreCompatible) {
 #ifndef NDEBUG
   ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
                    context.get(), SpvOpAtomicIAdd, 0, int_type, uint_type),
-               "Invalid operand index");
+               "Signedness check should not occur on a pointer operand.");
 #endif
   ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
       context.get(), SpvOpAtomicIAdd, 1, int_type, uint_type));
@@ -2328,7 +2328,7 @@ TEST(TransformationReplaceIdWithSynonymTest, TypesAreCompatible) {
 #ifndef NDEBUG
   ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
                    context.get(), SpvOpAtomicISub, 0, int_type, uint_type),
-               "Invalid operand index");
+               "Signedness check should not occur on a pointer operand.");
 #endif
   ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
       context.get(), SpvOpAtomicISub, 1, int_type, uint_type));
@@ -2341,7 +2341,7 @@ TEST(TransformationReplaceIdWithSynonymTest, TypesAreCompatible) {
 #ifndef NDEBUG
   ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
                    context.get(), SpvOpAtomicSMin, 0, int_type, uint_type),
-               "Invalid operand index");
+               "Signedness check should not occur on a pointer operand.");
 #endif
   ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
       context.get(), SpvOpAtomicSMin, 1, int_type, uint_type));
@@ -2354,7 +2354,7 @@ TEST(TransformationReplaceIdWithSynonymTest, TypesAreCompatible) {
 #ifndef NDEBUG
   ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
                    context.get(), SpvOpAtomicUMin, 0, int_type, uint_type),
-               "Invalid operand index");
+               "Signedness check should not occur on a pointer operand.");
 #endif
   ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
       context.get(), SpvOpAtomicUMin, 1, int_type, uint_type));
@@ -2367,7 +2367,7 @@ TEST(TransformationReplaceIdWithSynonymTest, TypesAreCompatible) {
 #ifndef NDEBUG
   ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
                    context.get(), SpvOpAtomicSMax, 0, int_type, uint_type),
-               "Invalid operand index");
+               "Signedness check should not occur on a pointer operand.");
 #endif
   ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
       context.get(), SpvOpAtomicSMax, 1, int_type, uint_type));
@@ -2380,7 +2380,7 @@ TEST(TransformationReplaceIdWithSynonymTest, TypesAreCompatible) {
 #ifndef NDEBUG
   ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
                    context.get(), SpvOpAtomicUMax, 0, int_type, uint_type),
-               "Invalid operand index");
+               "Signedness check should not occur on a pointer operand.");
 #endif
   ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
       context.get(), SpvOpAtomicUMax, 1, int_type, uint_type));
@@ -2393,7 +2393,7 @@ TEST(TransformationReplaceIdWithSynonymTest, TypesAreCompatible) {
 #ifndef NDEBUG
   ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
                    context.get(), SpvOpAtomicAnd, 0, int_type, uint_type),
-               "Invalid operand index");
+               "Signedness check should not occur on a pointer operand.");
 #endif
   ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
       context.get(), SpvOpAtomicAnd, 1, int_type, uint_type));
@@ -2406,7 +2406,7 @@ TEST(TransformationReplaceIdWithSynonymTest, TypesAreCompatible) {
 #ifndef NDEBUG
   ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
                    context.get(), SpvOpAtomicOr, 0, int_type, uint_type),
-               "Invalid operand index");
+               "Signedness check should not occur on a pointer operand.");
 #endif
   ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
       context.get(), SpvOpAtomicOr, 1, int_type, uint_type));
@@ -2419,7 +2419,7 @@ TEST(TransformationReplaceIdWithSynonymTest, TypesAreCompatible) {
 #ifndef NDEBUG
   ASSERT_DEATH(TransformationReplaceIdWithSynonym::TypesAreCompatible(
                    context.get(), SpvOpAtomicXor, 0, int_type, uint_type),
-               "Invalid operand index");
+               "Signedness check should not occur on a pointer operand.");
 #endif
   ASSERT_TRUE(TransformationReplaceIdWithSynonym::TypesAreCompatible(
       context.get(), SpvOpAtomicXor, 1, int_type, uint_type));

--- a/test/fuzz/transformation_replace_id_with_synonym_test.cpp
+++ b/test/fuzz/transformation_replace_id_with_synonym_test.cpp
@@ -2026,10 +2026,11 @@ TEST(TransformationReplaceIdWithSynonymTest,
                    .IsApplicable(context.get(), transformation_context));
 }
 
+// TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/4345): Improve this
+//  test so that it covers more atomic operations, and enable the test once the
+//  issue is fixed.
 TEST(TransformationReplaceIdWithSynonymTest,
      DISABLED_SignOfAtomicScopeAndMemorySemanticsDoesNotMatter) {
-  //  This test is failed at (IsApplicable) line, because of updates from PR
-  //  #4349.
   // TODO(https://github.com/KhronosGroup/SPIRV-Tools/issues/4345): both the
   //  GLSL comment and the corresponding SPIR-V should be updated to cover a
   //  larger number of atomic operations.


### PR DESCRIPTION
Fixes #4345. 

This PR is responsible for supporting atomic operations opcode and checks it's in operands signedness neutrality.

### Example:

Original shader 

https://github.com/KhronosGroup/SPIRV-Tools/blob/8cc8b6562be9de063a22ddf7f75d11c641779e36/test/fuzz/transformation_replace_id_with_synonym_test.cpp#L1911-L1948

After applying transformation

https://github.com/KhronosGroup/SPIRV-Tools/blob/8cc8b6562be9de063a22ddf7f75d11c641779e36/test/fuzz/transformation_replace_id_with_synonym_test.cpp#L1992-L2029

That's the Important changes from original shader ` %21 = OpAtomicLoad %6 %14 %15 %20`, and this transformed  shader ` %21 = OpAtomicLoad %6 %14 %100 %101`. 