### PR TITLE
spirv-reduce: Clean up a few things

### DIFF
--- a/source/reduce/CMakeLists.txt
+++ b/source/reduce/CMakeLists.txt
@@ -14,6 +14,8 @@
 set(SPIRV_TOOLS_REDUCE_SOURCES
         change_operand_reduction_opportunity.h
         change_operand_to_undef_reduction_opportunity.h
+        conditional_branch_to_simple_conditional_branch_opportunity_finder.h
+        conditional_branch_to_simple_conditional_branch_reduction_opportunity.h
         merge_blocks_reduction_opportunity.h
         merge_blocks_reduction_opportunity_finder.h
         operand_to_const_reduction_opportunity_finder.h
@@ -34,15 +36,15 @@ set(SPIRV_TOOLS_REDUCE_SOURCES
         remove_struct_member_reduction_opportunity.h
         remove_unused_instruction_reduction_opportunity_finder.h
         remove_unused_struct_member_reduction_opportunity_finder.h
-        structured_loop_to_selection_reduction_opportunity.h
-        structured_loop_to_selection_reduction_opportunity_finder.h
-        conditional_branch_to_simple_conditional_branch_opportunity_finder.h
-        conditional_branch_to_simple_conditional_branch_reduction_opportunity.h
         simple_conditional_branch_to_branch_opportunity_finder.h
         simple_conditional_branch_to_branch_reduction_opportunity.h
+        structured_loop_to_selection_reduction_opportunity.h
+        structured_loop_to_selection_reduction_opportunity_finder.h
 
         change_operand_reduction_opportunity.cpp
         change_operand_to_undef_reduction_opportunity.cpp
+        conditional_branch_to_simple_conditional_branch_opportunity_finder.cpp
+        conditional_branch_to_simple_conditional_branch_reduction_opportunity.cpp
         merge_blocks_reduction_opportunity.cpp
         merge_blocks_reduction_opportunity_finder.cpp
         operand_to_const_reduction_opportunity_finder.cpp
@@ -63,12 +65,10 @@ set(SPIRV_TOOLS_REDUCE_SOURCES
         remove_struct_member_reduction_opportunity.cpp
         remove_unused_instruction_reduction_opportunity_finder.cpp
         remove_unused_struct_member_reduction_opportunity_finder.cpp
-        structured_loop_to_selection_reduction_opportunity.cpp
-        structured_loop_to_selection_reduction_opportunity_finder.cpp
-        conditional_branch_to_simple_conditional_branch_opportunity_finder.cpp
-        conditional_branch_to_simple_conditional_branch_reduction_opportunity.cpp
         simple_conditional_branch_to_branch_opportunity_finder.cpp
         simple_conditional_branch_to_branch_reduction_opportunity.cpp
+        structured_loop_to_selection_reduction_opportunity.cpp
+        structured_loop_to_selection_reduction_opportunity_finder.cpp
 )
 
 if(MSVC AND (NOT ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")))

--- a/source/reduce/structured_loop_to_selection_reduction_opportunity.cpp
+++ b/source/reduce/structured_loop_to_selection_reduction_opportunity.cpp
@@ -29,14 +29,14 @@ bool StructuredLoopToSelectionReductionOpportunity::PreconditionHolds() {
   // Is the loop header reachable?
   return loop_construct_header_->GetLabel()
       ->context()
-      ->GetDominatorAnalysis(enclosing_function_)
+      ->GetDominatorAnalysis(loop_construct_header_->GetParent())
       ->IsReachable(loop_construct_header_);
 }
 
 void StructuredLoopToSelectionReductionOpportunity::Apply() {
   // Force computation of dominator analysis, CFG and structured CFG analysis
   // before we start to mess with edges in the function.
-  context_->GetDominatorAnalysis(enclosing_function_);
+  context_->GetDominatorAnalysis(loop_construct_header_->GetParent());
   context_->cfg();
   context_->GetStructuredCFGAnalysis();
 
@@ -78,7 +78,7 @@ void StructuredLoopToSelectionReductionOpportunity::RedirectToClosestMergeBlock(
     }
     already_seen.insert(pred);
 
-    if (!context_->GetDominatorAnalysis(enclosing_function_)
+    if (!context_->GetDominatorAnalysis(loop_construct_header_->GetParent())
              ->IsReachable(pred)) {
       // We do not care about unreachable predecessors (and dominance
       // information, and thus the notion of structured control flow, makes
@@ -216,7 +216,7 @@ void StructuredLoopToSelectionReductionOpportunity::ChangeLoopToSelection() {
 
 void StructuredLoopToSelectionReductionOpportunity::FixNonDominatedIdUses() {
   // Consider each instruction in the function.
-  for (auto& block : *enclosing_function_) {
+  for (auto& block : *loop_construct_header_->GetParent()) {
     for (auto& def : block) {
       if (def.opcode() == SpvOpVariable) {
         // Variables are defined at the start of the function, and can be
@@ -243,7 +243,7 @@ void StructuredLoopToSelectionReductionOpportunity::FixNonDominatedIdUses() {
               case SpvStorageClassFunction:
                 use->SetOperand(
                     index, {FindOrCreateFunctionVariable(
-                               context_, enclosing_function_,
+                               context_, loop_construct_header_->GetParent(),
                                context_->get_type_mgr()->GetId(pointer_type))});
                 break;
               default:
@@ -276,11 +276,11 @@ bool StructuredLoopToSelectionReductionOpportunity::
   if (use->opcode() == SpvOpPhi) {
     // A use in a phi doesn't need to be dominated by its definition, but the
     // associated parent block does need to be dominated by the definition.
-    return context_->GetDominatorAnalysis(enclosing_function_)
+    return context_->GetDominatorAnalysis(loop_construct_header_->GetParent())
         ->Dominates(def_block.id(), use->GetSingleWordOperand(use_index + 1));
   }
   // In non-phi cases, a use needs to be dominated by its definition.
-  return context_->GetDominatorAnalysis(enclosing_function_)
+  return context_->GetDominatorAnalysis(loop_construct_header_->GetParent())
       ->Dominates(def, use);
 }
 

--- a/source/reduce/structured_loop_to_selection_reduction_opportunity.h
+++ b/source/reduce/structured_loop_to_selection_reduction_opportunity.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SOURCE_REDUCE_CUT_LOOP_REDUCTION_OPPORTUNITY_H_
-#define SOURCE_REDUCE_CUT_LOOP_REDUCTION_OPPORTUNITY_H_
+#ifndef SOURCE_REDUCE_STRUCTURED_LOOP_TO_SELECTION_REDUCTION_OPPORTUNITY_H_
+#define SOURCE_REDUCE_STRUCTURED_LOOP_TO_SELECTION_REDUCTION_OPPORTUNITY_H_
 
 #include "source/opt/def_use_manager.h"
 #include "source/opt/dominator_analysis.h"
@@ -30,11 +30,8 @@ class StructuredLoopToSelectionReductionOpportunity
   // Constructs an opportunity from a loop header block and the function that
   // encloses it.
   explicit StructuredLoopToSelectionReductionOpportunity(
-      opt::IRContext* context, opt::BasicBlock* loop_construct_header,
-      opt::Function* enclosing_function)
-      : context_(context),
-        loop_construct_header_(loop_construct_header),
-        enclosing_function_(enclosing_function) {}
+      opt::IRContext* context, opt::BasicBlock* loop_construct_header)
+      : context_(context), loop_construct_header_(loop_construct_header) {}
 
   // Returns true if the loop header is reachable.  A structured loop might
   // become unreachable as a result of turning another structured loop into
@@ -88,10 +85,9 @@ class StructuredLoopToSelectionReductionOpportunity
 
   opt::IRContext* context_;
   opt::BasicBlock* loop_construct_header_;
-  opt::Function* enclosing_function_;
 };
 
 }  // namespace reduce
 }  // namespace spvtools
 
-#endif  // SOURCE_REDUCE_CUT_LOOP_REDUCTION_OPPORTUNITY_H_
+#endif  // SOURCE_REDUCE_STRUCTURED_LOOP_TO_SELECTION_REDUCTION_OPPORTUNITY_H_

--- a/source/reduce/structured_loop_to_selection_reduction_opportunity_finder.cpp
+++ b/source/reduce/structured_loop_to_selection_reduction_opportunity_finder.cpp
@@ -86,8 +86,8 @@ StructuredLoopToSelectionReductionOpportunityFinder::GetAvailableOpportunities(
       // We can turn this structured loop into a selection, so add the
       // opportunity to do so.
       result.push_back(
-          MakeUnique<StructuredLoopToSelectionReductionOpportunity>(
-              context, &block, function));
+          MakeUnique<StructuredLoopToSelectionReductionOpportunity>(context,
+                                                                    &block));
     }
   }
   return result;


### PR DESCRIPTION
Cleans up a CMakeLists.txt file and the header guard for a reduction
opportunity, and gets rid of an unnecessary parent function field that
can be derived from an existing block field.