### PR TITLE
validate OpUndef OpConstantNull yielding pointer types

### DIFF
--- a/source/val/validate_constants.cpp
+++ b/source/val/validate_constants.cpp
@@ -324,14 +324,15 @@ bool IsTypeNullable(const std::vector<uint32_t>& instruction,
       }
       return true;
     }
-    case SpvOpTypePointer:
-      if (instruction[2] == SpvStorageClassPhysicalStorageBuffer) {
-        return false;
-      }
-      return true;
+    case SpvOpTypePointer: {
+      const auto type_id = instruction[1];
+      return !_.SupportsLogicalPointers() ||
+             _.TypeSupportsVariablePointers(type_id);
+    }
     default:
-      return false;
+      break;
   }
+  return false;
 }
 
 spv_result_t ValidateConstantNull(ValidationState_t& _,

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -582,10 +582,18 @@ class ValidationState_t {
   bool IsBoolVectorType(uint32_t id) const;
   bool IsBoolScalarOrVectorType(uint32_t id) const;
   bool IsPointerType(uint32_t id) const;
+  bool IsLogicalPointerType(uint32_t id) const;
   bool IsCooperativeMatrixType(uint32_t id) const;
   bool IsFloatCooperativeMatrixType(uint32_t id) const;
   bool IsIntCooperativeMatrixType(uint32_t id) const;
   bool IsUnsignedIntCooperativeMatrixType(uint32_t id) const;
+
+  // Returns true iff the addressing model supports logical pointers.
+  bool SupportsLogicalPointers() const;
+
+  // Returns true if the given id is a logical pointer type that supports
+  // variable pointers.
+  bool TypeSupportsVariablePointers(uint32_t id) const;
 
   // Returns true if |id| is a type id that contains |type| (or integer or
   // floating point type) of |width| bits.

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -1484,8 +1484,7 @@ TEST_F(ValidateIdWithMessage, OpConstantNullGood) {
  %4 = OpConstantNull %3
  %5 = OpTypeFloat 32
  %6 = OpConstantNull %5
- %7 = OpTypePointer UniformConstant %3
- %8 = OpConstantNull %7
+ ; OpConstantNull on pointer types is tested in val_constants_test.cpp
  %9 = OpTypeEvent
 %10 = OpConstantNull %9
 %11 = OpTypeDeviceEvent
@@ -1505,7 +1504,7 @@ TEST_F(ValidateIdWithMessage, OpConstantNullGood) {
 %24 = OpConstantNull %23
 %26 = OpTypeArray %17 %25
 %27 = OpConstantNull %26
-%28 = OpTypeStruct %7 %26 %26 %1
+%28 = OpTypeStruct %26 %26 %1
 %29 = OpConstantNull %28
 )";
   CompileSuccessfully(spirv.c_str());


### PR DESCRIPTION
Fixes: #4354
- Can't create null logical pointers that are not variable pointers
- Can't create undef logical pointers that are not variable pointers

Khronos SPIR-V internal issue 660:
- Can't create undef pointers into PhysicalStorageBuffer