### PR TITLE
Add control dependence analysis to opt

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -88,6 +88,7 @@ SPVTOOLS_OPT_SRC_FILES := \
 		source/opt/composite.cpp \
 		source/opt/const_folding_rules.cpp \
 		source/opt/constants.cpp \
+		source/opt/control_dependence.cpp \
 		source/opt/convert_to_half_pass.cpp \
 		source/opt/copy_prop_arrays.cpp \
 		source/opt/dead_branch_elim_pass.cpp \

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -606,6 +606,8 @@ static_library("spvtools_opt") {
     "source/opt/const_folding_rules.h",
     "source/opt/constants.cpp",
     "source/opt/constants.h",
+    "source/opt/control_dependence.cpp",
+    "source/opt/control_dependence.h",
     "source/opt/convert_to_half_pass.cpp",
     "source/opt/convert_to_half_pass.h",
     "source/opt/copy_prop_arrays.cpp",

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -27,6 +27,7 @@ set(SPIRV_TOOLS_OPT_SOURCES
   composite.h
   const_folding_rules.h
   constants.h
+  control_dependence.h
   convert_to_half_pass.h
   copy_prop_arrays.h
   dead_branch_elim_pass.h
@@ -133,6 +134,7 @@ set(SPIRV_TOOLS_OPT_SOURCES
   composite.cpp
   const_folding_rules.cpp
   constants.cpp
+  control_dependence.cpp
   convert_to_half_pass.cpp
   copy_prop_arrays.cpp
   dead_branch_elim_pass.cpp

--- a/source/opt/control_dependence.cpp
+++ b/source/opt/control_dependence.cpp
@@ -1,0 +1,243 @@
+// Copyright (c) 2021 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/opt/control_dependence.h"
+
+#include <cassert>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "source/opt/basic_block.h"
+#include "source/opt/cfg.h"
+#include "source/opt/dominator_analysis.h"
+#include "source/opt/function.h"
+#include "source/opt/instruction.h"
+#include "spirv/unified1/spirv.h"
+
+// Computes the control dependence graph (CDG). The algorithm in Cytron 1991,
+// "Efficiently Computing Static Single Assignment Form and the Control
+// Dependence Graph." It relies on the fact that the control dependees (blocks
+// on which a block is control dependent on) are exactly the post-dominance
+// frontier for that block. The explanation and proofs are given in Section 6 of
+// that paper.
+// Link: https://www.cs.utexas.edu/~pingali/CS380C/2010/papers/ssaCytron.pdf
+//
+// The algorithm in Section 4.2 of the same paper is used to construct the
+// dominance frontier. It uses the post-dominance tree, which is available in
+// the IR context).
+
+namespace spvtools {
+namespace opt {
+namespace {
+// Returns a list of (case value, label id) pairs associated with the given
+// OpSwitch instruction.
+std::vector<std::pair<uint32_t, uint32_t>> GetSwitchCases(
+    const Instruction& inst) {
+  assert(inst.opcode() == SpvOpSwitch);
+  uint32_t num_labels = (inst.NumInOperands() - 2) / 2;
+  std::vector<std::pair<uint32_t, uint32_t>> ret;
+  ret.reserve(num_labels);
+  for (uint32_t i = 0; i < num_labels; ++i) {
+    ret.push_back(std::make_pair(inst.GetSingleWordInOperand(2 + 2 * i),
+                                 inst.GetSingleWordInOperand(2 + 2 * i + 1)));
+  }
+  return ret;
+}
+
+// Returns the control dependence corresponding to the CFG edge between |source|
+// and |target| (label IDs). Fails if there is no direct edge.
+ControlDependence ClassifyControlDependence(const CFG& cfg, uint32_t source,
+                                            uint32_t target) {
+  ControlDependence dep;
+  dep.source_bb_id = source;
+  dep.target_bb_id = target;
+  if (source == ControlDependenceAnalysis::kPseudoEntryBlock) {
+    dep.dependence_type = ControlDependence::DependenceType::kEntry;
+    return dep;
+  }
+  BasicBlock* bb = cfg.block(source);
+  const Instruction& branch = *bb->rbegin();
+  switch (branch.opcode()) {
+    case SpvOpBranchConditional: {
+      uint32_t label_true = branch.GetSingleWordInOperand(1);
+      uint32_t label_false = branch.GetSingleWordInOperand(2);
+      dep.dependence_type =
+          ControlDependence::DependenceType::kConditionalBranch;
+      dep.dependent_value_id = branch.GetSingleWordInOperand(0);
+      assert(label_true != label_false &&
+             "true and false labels are the same; control dependence "
+             "impossible");
+      if (target == label_true) {
+        dep.condition_value = true;
+      } else if (target == label_false) {
+        dep.condition_value = false;
+      } else {
+        assert(false && "impossible control dependence; non-existent edge");
+      }
+      break;
+    }
+    case SpvOpSwitch: {
+      dep.dependence_type = ControlDependence::DependenceType::kSwitchCase;
+      dep.dependent_value_id = branch.GetSingleWordInOperand(0);
+      for (const auto& switch_case : GetSwitchCases(branch)) {
+        uint32_t case_value = switch_case.first;
+        uint32_t label = switch_case.second;
+        if (target == label) {
+          dep.switch_case_values.push_back(case_value);
+        }
+      }
+      dep.is_switch_default = target == branch.GetSingleWordInOperand(1);
+      assert((dep.is_switch_default || !dep.switch_case_values.empty()) &&
+             "impossible control dependence; non-existent edge");
+      break;
+    }
+    default:
+      assert(false &&
+             "invalid control dependence; opcode of last instruction is not "
+             "conditional branch");
+  }
+  return dep;
+}
+}  // namespace
+
+constexpr uint32_t ControlDependenceAnalysis::kPseudoEntryBlock;
+
+bool ControlDependence::operator<(const ControlDependence& other) const {
+  return std::tie(source_bb_id, target_bb_id, dependence_type,
+                  dependent_value_id, switch_case_values, is_switch_default,
+                  condition_value) <
+         std::tie(other.source_bb_id, other.target_bb_id, other.dependence_type,
+                  other.dependent_value_id, other.switch_case_values,
+                  other.is_switch_default, other.condition_value);
+}
+
+bool ControlDependence::operator==(const ControlDependence& other) const {
+  return std::tie(source_bb_id, target_bb_id, dependence_type,
+                  dependent_value_id, switch_case_values, is_switch_default,
+                  condition_value) ==
+         std::tie(other.source_bb_id, other.target_bb_id, other.dependence_type,
+                  other.dependent_value_id, other.switch_case_values,
+                  other.is_switch_default, other.condition_value);
+}
+
+std::ostream& operator<<(std::ostream& os, const ControlDependence& dep) {
+  os << dep.source_bb_id << "->" << dep.target_bb_id;
+  switch (dep.dependence_type) {
+    case ControlDependence::DependenceType::kConditionalBranch:
+      os << " if %" << dep.dependent_value_id << " is "
+         << (dep.condition_value ? "true" : "false");
+      break;
+    case ControlDependence::DependenceType::kSwitchCase: {
+      os << " switch %" << dep.dependent_value_id << " case ";
+      bool first = true;
+      for (uint32_t case_value : dep.switch_case_values) {
+        if (first) {
+          first = false;
+        } else {
+          os << ", ";
+        }
+        os << case_value;
+      }
+      if (dep.is_switch_default) {
+        if (!first) {
+          first = false;
+          os << ", ";
+        }
+        os << "default";
+      }
+    } break;
+    case ControlDependence::DependenceType::kEntry:
+      os << " entry";
+      break;
+    default:
+      os << " (unknown)";
+  }
+  return os;
+}
+
+void ControlDependenceAnalysis::ComputePostDominanceFrontiers(
+    const CFG& cfg, const PostDominatorAnalysis& pdom) {
+  // Compute post-dominance frontiers (reverse graph).
+  // The dominance frontier for a block X is equal to (Equation 4)
+  //   DF_local(X) U { B in DF_up(Z) | X = ipdom(Z) }
+  //   (ipdom(Z) is the immediate post-dominator of Z.)
+  // where
+  //   DF_local(X) = { Y | X -> Y in CFG, X does not strictly post-dominate Y }
+  //     represents the contribution of X's predecessors to the DF, and
+  //   DF_up(Z) = { Y | Y in DF(Z), ipdom(Z) does not strictly post-dominate Y }
+  //     (note: ipdom(Z) = X.)
+  //     represents the contribution of a block to its immediate post-
+  //     dominator's DF.
+  // This is computed in one pass through a post-order traversal of the
+  // post-dominator tree.
+
+  // Assert that there is a block other than the pseudo exit in the pdom tree,
+  // as we need one to get the function entry point (as the pseudo exit is not
+  // actually part of the function.)
+  assert(!cfg.IsPseudoExitBlock(pdom.GetDomTree().post_begin()->bb_));
+  Function* function = pdom.GetDomTree().post_begin()->bb_->GetParent();
+  uint32_t function_entry = function->entry()->id();
+  reverse_nodes_[kPseudoEntryBlock];  // Ensure GetDependees(0) does not crash.
+  for (auto it = pdom.GetDomTree().post_cbegin();
+       it != pdom.GetDomTree().post_cend(); ++it) {
+    const uint32_t label = it->id();
+    ControlDependenceList& edges = reverse_nodes_[label];
+    size_t new_size = edges.size();
+    new_size += cfg.preds(label).size();
+    for (DominatorTreeNode* child : *it) {
+      const ControlDependenceList& child_edges = reverse_nodes_[child->id()];
+      new_size += child_edges.size();
+    }
+    edges.reserve(new_size);
+    for (uint32_t pred : cfg.preds(label)) {
+      if (!pdom.StrictlyDominates(label, pred)) {
+        edges.push_back(ClassifyControlDependence(cfg, pred, label));
+      }
+    }
+    if (label == function_entry) {
+      // Add edge from pseudo-entry to entry.
+      // In CDG construction, an edge is added from entry to exit, so only the
+      // exit node can post-dominate entry.
+      edges.push_back(ClassifyControlDependence(cfg, kPseudoEntryBlock, label));
+    }
+    for (DominatorTreeNode* child : *it) {
+      // Note: iterate dependences by value, as we need a copy.
+      for (ControlDependence dep : reverse_nodes_[child->id()]) {
+        // Special-case pseudo-entry, as above.
+        if (dep.source_bb_id == kPseudoEntryBlock ||
+            !pdom.StrictlyDominates(label, dep.source_bb_id)) {
+          dep.target_bb_id = label;
+          edges.push_back(dep);
+        }
+      }
+    }
+  }
+}
+
+void ControlDependenceAnalysis::InitializeGraph(
+    const CFG& cfg, const PostDominatorAnalysis& pdom) {
+  ComputePostDominanceFrontiers(cfg, pdom);
+  // Compute the forward graph from the reverse graph.
+  for (const auto& entry : reverse_nodes_) {
+    // Ensure an entry is created for each node.
+    forward_nodes_[entry.first];
+    for (const ControlDependence& dep : entry.second) {
+      forward_nodes_[dep.source_bb_id].push_back(dep);
+    }
+  }
+}
+
+}  // namespace opt
+}  // namespace spvtools

--- a/source/opt/control_dependence.cpp
+++ b/source/opt/control_dependence.cpp
@@ -26,17 +26,17 @@
 #include "source/opt/instruction.h"
 #include "spirv/unified1/spirv.h"
 
-// Computes the control dependence graph (CDG). The algorithm in Cytron 1991,
-// "Efficiently Computing Static Single Assignment Form and the Control
+// Computes the control dependence graph (CDG) using the algorithm in Cytron
+// 1991, "Efficiently Computing Static Single Assignment Form and the Control
 // Dependence Graph." It relies on the fact that the control dependence sources
-// (blocks on which a block is control dependent on) are exactly the
-// post-dominance frontier for that block. The explanation and proofs are given
-// in Section 6 of that paper.
+// (blocks on which a block is control dependent) are exactly the post-dominance
+// frontier for that block. The explanation and proofs are given in Section 6 of
+// that paper.
 // Link: https://www.cs.utexas.edu/~pingali/CS380C/2010/papers/ssaCytron.pdf
 //
 // The algorithm in Section 4.2 of the same paper is used to construct the
 // dominance frontier. It uses the post-dominance tree, which is available in
-// the IR context).
+// the IR context.
 
 namespace spvtools {
 namespace opt {

--- a/source/opt/control_dependence.h
+++ b/source/opt/control_dependence.h
@@ -1,0 +1,157 @@
+// Copyright (c) 2021 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_OPT_CONTROL_DEPENDENCE_H_
+#define SOURCE_OPT_CONTROL_DEPENDENCE_H_
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <ostream>
+#include <vector>
+
+#include "source/opt/cfg.h"
+#include "source/opt/dominator_analysis.h"
+
+namespace spvtools {
+namespace opt {
+
+struct ControlDependence {
+  enum class DependenceType {
+    kConditionalBranch,
+    kSwitchCase,
+    kEntry,
+  };
+  // The label of the source of this dependence, i.e. the dependee.
+  uint32_t source_bb_id = 0;
+  // The label of the target of this dependence, i.e. the dependent.
+  uint32_t target_bb_id = 0;
+  // The type of dependence: either a conditional branch, switch-case (any
+  // combination of numbered labels and default), or entry (the only condition
+  // for this block is that the function is entered.)
+  DependenceType dependence_type = DependenceType::kEntry;
+  // The id for the value which this dependence is on.
+  // For conditional branches, this is the branch condition, and
+  // for switch cases, this is the value on which the switch is performed.
+  uint32_t dependent_value_id = 0;
+  // For switch cases, the values of the cases for this dependence.
+  std::vector<uint32_t> switch_case_values;
+  // For switch cases, true if this dependence happens when the default branch
+  // is taken.
+  bool is_switch_default = false;
+  // For conditional branches, the value of the condition required for the
+  // dependence to happen.
+  bool condition_value = false;
+
+  bool operator==(const ControlDependence& other) const;
+
+  // Comparison operators, ordered lexicographically. Total ordering.
+  bool operator<(const ControlDependence& other) const;
+  bool operator>(const ControlDependence& other) const { return other < *this; }
+  bool operator<=(const ControlDependence& other) const {
+    return !(*this > other);
+  }
+  bool operator>=(const ControlDependence& other) const {
+    return !(*this < other);
+  }
+};
+
+// Prints |dep| to |os| in a human-readable way. Examples:
+//   %1 -> %2 if %3 is true
+//   %4 -> %5 switch %6 case 1, default
+//   %0 -> %7 entry
+std::ostream& operator<<(std::ostream& os, const ControlDependence& dep);
+
+// Represents the control dependence graph. A basic block is control dependent
+// on another if the result of that block (e.g. the condition of a conditional
+// branch) influences whether it is executed or not. More formally, a block A is
+// control dependent on B iff:
+// 1. there exists a path from A to the exit node that does *not* go through B
+//    (i.e., A does not postdominate B), and
+// 2. there exists a path B -> b_1 -> ... -> b_n -> A such that A post-dominates
+//    all nodes b_i.
+class ControlDependenceAnalysis {
+ public:
+  // Map basic block labels to control dependencies/dependents.
+  // Not guaranteed to be in any particular order.
+  using ControlDependenceList = std::vector<ControlDependence>;
+  using ControlDependenceListMap = std::map<uint32_t, ControlDependenceList>;
+
+  // 0, the label number for the pseudo entry block.
+  // All control dependences on the pseudo entry block are of type kEntry, and
+  // vice versa.
+  static constexpr uint32_t kPseudoEntryBlock = 0;
+
+  // Build the control dependence graph for the given control flow graph |cfg|
+  // and corresponding post-dominator analysis |pdom|.
+  void InitializeGraph(const CFG& cfg, const PostDominatorAnalysis& pdom);
+
+  // Get the list of the nodes that depend on a block.
+  // Return value is not guaranteed to be in any particular order.
+  const ControlDependenceList& GetDependents(uint32_t block) const {
+    return forward_nodes_.at(block);
+  }
+
+  // Get the list of the nodes on which a block depends on.
+  // Return value is not guaranteed to be in any particular order.
+  const ControlDependenceList& GetDependees(uint32_t block) const {
+    return reverse_nodes_.at(block);
+  }
+
+  // Runs the function |f| on each block label in the CDG. If any iteration
+  // returns false, immediately stops iteration and returns false. Otherwise
+  // returns true. Nodes are iterated in order of label, including the
+  // pseudo-entry block.
+  bool WhileEachBlockLabel(std::function<bool(uint32_t)> f) const {
+    for (const auto& entry : forward_nodes_) {
+      if (!f(entry.first)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // Runs the function |f| on each block label in the CDG. Nodes are iterated in
+  // order of label, including the pseudo-entry block.
+  void ForEachBlockLabel(std::function<void(uint32_t)> f) const {
+    WhileEachBlockLabel([&f](uint32_t label) {
+      f(label);
+      return true;
+    });
+  }
+
+  // Is block |a| (directly) dependent on block |b|?
+  bool IsDependent(uint32_t a, uint32_t b) const {
+    if (forward_nodes_.find(a) == forward_nodes_.end()) return false;
+    // BBs tend to have more dependents than dependees, so search dependees.
+    const ControlDependenceList& a_dependees = GetDependees(a);
+    return std::find_if(a_dependees.begin(), a_dependees.end(),
+                        [b](const ControlDependence& dep) {
+                          return dep.source_bb_id == b;
+                        }) != a_dependees.end();
+  }
+
+ private:
+  ControlDependenceListMap forward_nodes_;
+  ControlDependenceListMap reverse_nodes_;
+
+  void ComputePostDominanceFrontiers(const CFG& cfg,
+                                     const PostDominatorAnalysis& pdom);
+};
+
+}  // namespace opt
+}  // namespace spvtools
+
+#endif  // SOURCE_OPT_CONTROL_DEPENDENCE_H_

--- a/source/opt/control_dependence.h
+++ b/source/opt/control_dependence.h
@@ -142,6 +142,13 @@ class ControlDependenceAnalysis {
     });
   }
 
+  // Does the block |id| exist in this graph? This can be false even if the
+  // block exists in the function when it is part of an infinite loop, as then
+  // it is not part of the post-dominator tree.
+  bool DoesBlockExist(uint32_t id) const {
+    return forward_nodes_.count(id) > 0;
+  }
+
   // Is block |a| (directly) dependent on block |b|?
   bool IsDependent(uint32_t a, uint32_t b) const {
     if (forward_nodes_.find(a) == forward_nodes_.end()) return false;

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -28,6 +28,7 @@ add_spvtools_unittest(TARGET opt
        compact_ids_test.cpp
        constants_test.cpp
        constant_manager_test.cpp
+       control_dependence.cpp
        convert_relaxed_to_half_test.cpp
        copy_prop_array_test.cpp
        dead_branch_elim_test.cpp

--- a/test/opt/control_dependence.cpp
+++ b/test/opt/control_dependence.cpp
@@ -120,7 +120,7 @@ TEST(ControlDependenceTest, DependenceSimpleCFG) {
     const CFG& cfg = *context->cfg();
     pdom.InitializeTree(cfg, fn);
     ControlDependenceAnalysis cdg;
-    cdg.InitializeGraph(cfg, pdom);
+    cdg.ComputeControlDependenceGraph(cfg, pdom);
 
     EXPECT_TRUE(cdg.IsDependent(12, 11));
     EXPECT_TRUE(cdg.IsDependent(13, 11));
@@ -236,7 +236,7 @@ TEST(ControlDependenceTest, DependencePaperCFG) {
     const CFG& cfg = *context->cfg();
     pdom.InitializeTree(cfg, fn);
     ControlDependenceAnalysis cdg;
-    cdg.InitializeGraph(cfg, pdom);
+    cdg.ComputeControlDependenceGraph(cfg, pdom);
 
     std::vector<ControlDependence> edges;
     GatherEdges(cdg, edges);

--- a/test/opt/control_dependence.cpp
+++ b/test/opt/control_dependence.cpp
@@ -1,0 +1,291 @@
+// Copyright (c) 2021 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/opt/control_dependence.h"
+
+#include <algorithm>
+#include <vector>
+
+#include "gmock/gmock-matchers.h"
+#include "gtest/gtest.h"
+#include "source/opt/build_module.h"
+#include "source/opt/cfg.h"
+#include "test/opt/function_utils.h"
+
+namespace spvtools {
+namespace opt {
+
+namespace {
+void GatherEdges(const ControlDependenceAnalysis& cdg,
+                 std::vector<ControlDependence>& ret) {
+  cdg.ForEachBlockLabel([&](uint32_t label) {
+    ret.reserve(ret.size() + cdg.GetDependents(label).size());
+    ret.insert(ret.end(), cdg.GetDependents(label).begin(),
+               cdg.GetDependents(label).end());
+  });
+  std::sort(ret.begin(), ret.end());
+  // Verify that reverse graph is the same.
+  std::vector<ControlDependence> reverse_edges;
+  reverse_edges.reserve(ret.size());
+  cdg.ForEachBlockLabel([&](uint32_t label) {
+    reverse_edges.insert(reverse_edges.end(), cdg.GetDependees(label).begin(),
+                         cdg.GetDependees(label).end());
+  });
+  std::sort(reverse_edges.begin(), reverse_edges.end());
+  ASSERT_THAT(reverse_edges, testing::ElementsAreArray(ret));
+}
+
+static ControlDependence MakeCondBranchDep(uint32_t source, uint32_t target,
+                                           uint32_t condition_label,
+                                           bool value) {
+  ControlDependence dep;
+  dep.source_bb_id = source;
+  dep.target_bb_id = target;
+  dep.dependence_type = ControlDependence::DependenceType::kConditionalBranch;
+  dep.dependent_value_id = condition_label;
+  dep.condition_value = value;
+  return dep;
+}
+
+static ControlDependence MakeSwitchCaseDep(uint32_t source, uint32_t target,
+                                           uint32_t switch_value,
+                                           bool is_default,
+                                           std::vector<uint32_t> cases) {
+  ControlDependence dep;
+  dep.source_bb_id = source;
+  dep.target_bb_id = target;
+  dep.dependence_type = ControlDependence::DependenceType::kSwitchCase;
+  dep.dependent_value_id = switch_value;
+  dep.is_switch_default = is_default;
+  dep.switch_case_values = cases;
+  return dep;
+}
+
+static ControlDependence MakeEntryDep(uint32_t target) {
+  ControlDependence dep;
+  dep.source_bb_id = ControlDependenceAnalysis::kPseudoEntryBlock;
+  dep.target_bb_id = target;
+  dep.dependence_type = ControlDependence::DependenceType::kEntry;
+  return dep;
+}
+
+using ControlDependenceTest = ::testing::Test;
+
+TEST(ControlDependenceTest, DependenceSimpleCFG) {
+  const std::string text = R"(
+               OpCapability Addresses
+               OpCapability Kernel
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %1 "main"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %4 = OpTypeBool
+          %5 = OpTypeInt 32 0
+          %6 = OpConstant %5 0
+          %7 = OpConstantFalse %4
+          %8 = OpConstantTrue %4
+          %9 = OpConstant %5 1
+          %1 = OpFunction %2 None %3
+         %10 = OpLabel
+               OpBranch %11
+         %11 = OpLabel
+               OpSwitch %6 %12 1 %13
+         %12 = OpLabel
+               OpBranch %14
+         %13 = OpLabel
+               OpBranch %14
+         %14 = OpLabel
+               OpBranchConditional %8 %15 %16
+         %15 = OpLabel
+               OpBranch %19
+         %16 = OpLabel
+               OpBranchConditional %8 %17 %18
+         %17 = OpLabel
+               OpBranch %18
+         %18 = OpLabel
+               OpBranch %19
+         %19 = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+
+  // CFG: (all edges pointing downward)
+  //   %10
+  //    |
+  //   %11
+  //  /   \ (R: %6 == 1, L: default)
+  // %12 %13
+  //  \   /
+  //   %14
+  // T/   \F
+  // %15  %16
+  //  | T/ |F
+  //  | %17|
+  //  |  \ |
+  //  |   %18
+  //  |  /
+  // %19
+
+  std::unique_ptr<IRContext> context =
+      BuildModule(SPV_ENV_UNIVERSAL_1_0, nullptr, text,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  Module* module = context->module();
+  EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
+                             << text << std::endl;
+  const Function* fn = spvtest::GetFunction(module, 1);
+  const BasicBlock* entry = spvtest::GetBasicBlock(fn, 10);
+  EXPECT_EQ(entry, fn->entry().get())
+      << "The entry node is not the expected one";
+
+  {
+    PostDominatorAnalysis pdom;
+    const CFG& cfg = *context->cfg();
+    pdom.InitializeTree(cfg, fn);
+    ControlDependenceAnalysis cdg;
+    cdg.InitializeGraph(cfg, pdom);
+
+    EXPECT_TRUE(cdg.IsDependent(12, 11));
+    EXPECT_TRUE(cdg.IsDependent(13, 11));
+    EXPECT_TRUE(cdg.IsDependent(15, 14));
+    EXPECT_TRUE(cdg.IsDependent(16, 14));
+    EXPECT_TRUE(cdg.IsDependent(18, 14));
+    EXPECT_TRUE(cdg.IsDependent(17, 16));
+    EXPECT_TRUE(cdg.IsDependent(10, 0));
+    EXPECT_TRUE(cdg.IsDependent(11, 0));
+    EXPECT_TRUE(cdg.IsDependent(14, 0));
+    EXPECT_TRUE(cdg.IsDependent(19, 0));
+    EXPECT_FALSE(cdg.IsDependent(14, 11));
+    EXPECT_FALSE(cdg.IsDependent(17, 14));
+    EXPECT_FALSE(cdg.IsDependent(19, 14));
+    EXPECT_FALSE(cdg.IsDependent(12, 0));
+
+    std::vector<ControlDependence> edges;
+    GatherEdges(cdg, edges);
+    EXPECT_THAT(edges,
+                testing::ElementsAre(MakeEntryDep(10), MakeEntryDep(11),
+                                     MakeEntryDep(14), MakeEntryDep(19),
+                                     MakeSwitchCaseDep(11, 12, 6, true, {}),
+                                     MakeSwitchCaseDep(11, 13, 6, false, {1}),
+                                     MakeCondBranchDep(14, 15, 8, true),
+                                     MakeCondBranchDep(14, 16, 8, false),
+                                     MakeCondBranchDep(14, 18, 8, false),
+                                     MakeCondBranchDep(16, 17, 8, true)));
+  }
+}
+
+TEST(ControlDependenceTest, DependencePaperCFG) {
+  const std::string text = R"(
+               OpCapability Addresses
+               OpCapability Kernel
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %101 "main"
+        %102 = OpTypeVoid
+        %103 = OpTypeFunction %102
+        %104 = OpTypeBool
+        %108 = OpConstantTrue %104
+        %101 = OpFunction %102 None %103
+          %1 = OpLabel
+               OpBranch %2
+          %2 = OpLabel
+               OpBranchConditional %108 %3 %7
+          %3 = OpLabel
+               OpBranchConditional %108 %4 %5
+          %4 = OpLabel
+               OpBranch %6
+          %5 = OpLabel
+               OpBranch %6
+          %6 = OpLabel
+               OpBranch %8
+          %7 = OpLabel
+               OpBranch %8
+          %8 = OpLabel
+               OpBranch %9
+          %9 = OpLabel
+               OpBranchConditional %108 %10 %11
+         %10 = OpLabel
+               OpBranch %11
+         %11 = OpLabel
+               OpBranchConditional %108 %12 %9
+         %12 = OpLabel
+               OpBranchConditional %108 %13 %2
+         %13 = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+
+  // CFG: (edges pointing downward if no arrow)
+  //         %1
+  //         |
+  //         %2 <----+
+  //       T/  \F    |
+  //      %3    \    |
+  //    T/  \F   \   |
+  //    %4  %5    %7 |
+  //     \  /    /   |
+  //      %6    /    |
+  //        \  /     |
+  //         %8      |
+  //         |       |
+  //         %9 <-+  |
+  //       T/  |  |  |
+  //       %10 |  |  |
+  //        \  |  |  |
+  //         %11-F+  |
+  //         T|      |
+  //         %12-F---+
+  //         T|
+  //         %13
+
+  std::unique_ptr<IRContext> context =
+      BuildModule(SPV_ENV_UNIVERSAL_1_0, nullptr, text,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  Module* module = context->module();
+  EXPECT_NE(nullptr, module) << "Assembling failed for shader:\n"
+                             << text << std::endl;
+  const Function* fn = spvtest::GetFunction(module, 101);
+  const BasicBlock* entry = spvtest::GetBasicBlock(fn, 1);
+  EXPECT_EQ(entry, fn->entry().get())
+      << "The entry node is not the expected one";
+
+  {
+    PostDominatorAnalysis pdom;
+    const CFG& cfg = *context->cfg();
+    pdom.InitializeTree(cfg, fn);
+    ControlDependenceAnalysis cdg;
+    cdg.InitializeGraph(cfg, pdom);
+
+    std::vector<ControlDependence> edges;
+    GatherEdges(cdg, edges);
+    EXPECT_THAT(edges, testing::ElementsAre(
+                           MakeEntryDep(1), MakeEntryDep(2), MakeEntryDep(8),
+                           MakeEntryDep(9), MakeEntryDep(11), MakeEntryDep(12),
+                           MakeEntryDep(13), MakeCondBranchDep(2, 3, 108, true),
+                           MakeCondBranchDep(2, 6, 108, true),
+                           MakeCondBranchDep(2, 7, 108, false),
+                           MakeCondBranchDep(3, 4, 108, true),
+                           MakeCondBranchDep(3, 5, 108, false),
+                           MakeCondBranchDep(9, 10, 108, true),
+                           MakeCondBranchDep(11, 9, 108, false),
+                           MakeCondBranchDep(11, 11, 108, false),
+                           MakeCondBranchDep(12, 2, 108, false),
+                           MakeCondBranchDep(12, 8, 108, false),
+                           MakeCondBranchDep(12, 9, 108, false),
+                           MakeCondBranchDep(12, 11, 108, false),
+                           MakeCondBranchDep(12, 12, 108, false)));
+  }
+}
+
+}  // namespace
+}  // namespace opt
+}  // namespace spvtools


### PR DESCRIPTION
Control dependence analysis constructs a control dependence graph, representing the conditions for a block's execution relative to the results of other blocks with conditional branches, etc.
This is an analysis pass that will be useful for the linter and potentially also useful in opt. Currently it is unused except for the added unit tests.