### PR TITLE
Fix public deps on generated headers

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -772,12 +772,14 @@ static_library("spvtools_opt") {
 
   deps = [
     ":spvtools",
-    ":spvtools_language_header_cldebuginfo100",
     ":spvtools_language_header_debuginfo",
-    ":spvtools_language_header_vkdebuginfo100",
     ":spvtools_vendor_tables_spv-amd-shader-ballot",
   ]
-  public_deps = [ ":spvtools_headers" ]
+  public_deps = [
+    ":spvtools_headers",
+    ":spvtools_language_header_cldebuginfo100",
+    ":spvtools_language_header_vkdebuginfo100",
+  ]
 
   if (build_with_chromium) {
     configs -= [ "//build/config/compiler:chromium_code" ]


### PR DESCRIPTION
Some generated headers are exposed by headers in the spvtools_opt
target, but its GN dependency on them is private. This can result in
build flake, since the headers don't need to be generated before
compiling any spvtools_opt dependents.

This fixes the build flake by correctly expressing these as public
dependencies.