### PR TITLE
spirv-fuzz: Fix vector wrapping fuzzer pass

### DIFF
--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -305,7 +305,7 @@ bool CanInsertOpcodeBeforeInstruction(
 
 bool CanMakeSynonymOf(opt::IRContext* ir_context,
                       const TransformationContext& transformation_context,
-                      opt::Instruction* inst) {
+                      const opt::Instruction* inst) {
   if (inst->opcode() == SpvOpSampledImage) {
     // The SPIR-V data rules say that only very specific instructions may
     // may consume the result id of an OpSampledImage, and this excludes the

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -118,7 +118,7 @@ bool CanInsertOpcodeBeforeInstruction(
 // does not participate in IdIsIrrelevant fact.
 bool CanMakeSynonymOf(opt::IRContext* ir_context,
                       const TransformationContext& transformation_context,
-                      opt::Instruction* inst);
+                      const opt::Instruction* inst);
 
 // Determines whether the given type is a composite; that is: an array, matrix,
 // struct or vector.

--- a/source/fuzz/transformation_wrap_vector_synonym.cpp
+++ b/source/fuzz/transformation_wrap_vector_synonym.cpp
@@ -55,9 +55,12 @@ bool TransformationWrapVectorSynonym::IsApplicable(
     return false;
   }
 
-  assert(!transformation_context.GetFactManager()->IdIsIrrelevant(
-             instruction->result_id()) &&
-         "Result id of the scalar operation must be relevant.");
+  // It must be possible to make a synonym of the result id of the scalar
+  // operation
+  if (!fuzzerutil::CanMakeSynonymOf(ir_context, transformation_context,
+                                    instruction)) {
+    return false;
+  }
 
   // |vector_operand1| and |vector_operand2| must exist.
   auto vec1 = ir_context->get_def_use_mgr()->GetDef(message_.vector_operand1());


### PR DESCRIPTION
The fuzzer pass was passing the type of a scalar where a vector type
was required, and was not checking whether synonyms could be made for
the operands to the scalar instruction.