### PR TITLE
spirv-fuzz: Fix problem with instruction context

### DIFF
--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -504,6 +504,8 @@ bool IsValidAndWellFormed(const opt::IRContext* ir_context,
   bool found_duplicate = false;
   ir_context->module()->ForEachInst([&consumer, &found_duplicate, ir_context,
                                      &unique_ids](opt::Instruction* inst) {
+    (void)ir_context;  // Only used in an assertion; keep release-mode compilers
+                       // happy.
     assert(inst->context() == ir_context &&
            "Instruction has wrong IR context.");
     if (unique_ids.count(inst->unique_id()) != 0) {

--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -502,8 +502,10 @@ bool IsValidAndWellFormed(const opt::IRContext* ir_context,
   // this is a useful aid to debugging.
   std::unordered_map<uint32_t, opt::Instruction*> unique_ids;
   bool found_duplicate = false;
-  ir_context->module()->ForEachInst([&consumer, &found_duplicate,
+  ir_context->module()->ForEachInst([&consumer, &found_duplicate, ir_context,
                                      &unique_ids](opt::Instruction* inst) {
+    assert(inst->context() == ir_context &&
+           "Instruction has wrong IR context.");
     if (unique_ids.count(inst->unique_id()) != 0) {
       consumer(SPV_MSG_INFO, nullptr, {},
                "Two instructions have the same unique id (set a breakpoint to "

--- a/source/fuzz/transformation_duplicate_region_with_selection.cpp
+++ b/source/fuzz/transformation_duplicate_region_with_selection.cpp
@@ -309,9 +309,9 @@ void TransformationDuplicateRegionWithSelection::Apply(
 
   // Construct the merge block.
   std::unique_ptr<opt::BasicBlock> merge_block =
-      MakeUnique<opt::BasicBlock>(MakeUnique<opt::Instruction>(opt::Instruction(
+      MakeUnique<opt::BasicBlock>(MakeUnique<opt::Instruction>(
           ir_context, SpvOpLabel, 0, message_.merge_label_fresh_id(),
-          opt::Instruction::OperandList())));
+          opt::Instruction::OperandList()));
 
   // Get the maps from the protobuf.
   std::map<uint32_t, uint32_t> original_label_to_duplicate_label =


### PR DESCRIPTION
Adds an additional validity check to ensure that every instruction's
context pointer matches the enclosing IR context. Avoids a redundant
copy constructor call in TransformationDuplicateRegionWithSelection
that was leading to a bad IR context for some instructions.

Related: #4387, #4388.
Fixes #4393.