### PR TITLE
Fix local size hint id tests

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -6,7 +6,7 @@ vars = {
   'effcee_revision': '2ec8f8738118cc483b67c04a759fee53496c5659',
   'googletest_revision': 'b7d472f1225c5a64943821d8483fecb469d3f382',
   're2_revision': 'f8e389f3acdc2517562924239e2a188037393683',
-  'spirv_headers_revision': 'ddf3230c14c71e81fc0eae9b781cc4bcc2d1f0f5',
+  'spirv_headers_revision': 'cf653e4ca4858583802b0d1656bc934edff6bd7f',
 }
 
 deps = {

--- a/test/binary_to_text_test.cpp
+++ b/test/binary_to_text_test.cpp
@@ -386,7 +386,7 @@ INSTANTIATE_TEST_SUITE_P(
             ::testing::ValuesIn(std::vector<std::string>{
                 "OpExecutionModeId %1 SubgroupsPerWorkgroupId %2\n",
                 "OpExecutionModeId %1 LocalSizeId %2 %3 %4\n",
-                "OpExecutionModeId %1 LocalSizeHintId %2\n",
+                "OpExecutionModeId %1 LocalSizeHintId %2 %3 %4\n",
                 "OpDecorateId %1 AlignmentId %2\n",
                 "OpDecorateId %1 MaxByteOffsetId %2\n",
             })));

--- a/test/val/val_modes_test.cpp
+++ b/test/val/val_modes_test.cpp
@@ -672,7 +672,7 @@ INSTANTIATE_TEST_SUITE_P(ValidateModeKernelOnlyGoodSpv13, ValidateModeExecution,
                                  Values("Kernel"),
                                  Values("LocalSizeHint 1 1 1", "VecTypeHint 4",
                                         "ContractionOff",
-                                        "LocalSizeHintId %int1"),
+                                        "LocalSizeHintId %int1 %int1 %int1"),
                                  Values(SPV_ENV_UNIVERSAL_1_3)));
 
 INSTANTIATE_TEST_SUITE_P(
@@ -684,7 +684,7 @@ INSTANTIATE_TEST_SUITE_P(
         Values("Geometry", "TessellationControl", "TessellationEvaluation",
                "GLCompute", "Vertex", "Fragment"),
         Values("LocalSizeHint 1 1 1", "VecTypeHint 4", "ContractionOff",
-               "LocalSizeHintId %int1"),
+               "LocalSizeHintId %int1 %int1 %int1"),
         Values(SPV_ENV_UNIVERSAL_1_3)));
 
 INSTANTIATE_TEST_SUITE_P(
@@ -863,7 +863,7 @@ OpCapability Kernel
 OpCapability Shader
 OpMemoryModel Logical GLSL450
 OpEntryPoint Kernel %main "main"
-OpExecutionMode %main LocalSizeHintId %int_1
+OpExecutionMode %main LocalSizeHintId %int_1 %int_1 %int_1
 %int = OpTypeInt 32 0
 %int_1 = OpConstant %int 1
 )" + kVoidFunction;
@@ -882,7 +882,7 @@ OpCapability Kernel
 OpCapability Shader
 OpMemoryModel Logical GLSL450
 OpEntryPoint Kernel %main "main"
-OpExecutionModeId %main LocalSizeHintId %int_1
+OpExecutionModeId %main LocalSizeHintId %int_1 %int_1 %int_1
 %int = OpTypeInt 32 0
 %int_1 = OpConstant %int 1
 )" + kVoidFunction;
@@ -898,7 +898,7 @@ OpCapability Kernel
 OpCapability Shader
 OpMemoryModel Logical GLSL450
 OpEntryPoint Vertex %main "main"
-OpExecutionModeId %main LocalSizeHintId %int_1
+OpExecutionModeId %main LocalSizeHintId %int_1 %int_1 %int_1
 %int = OpTypeInt 32 0
 %int_ptr = OpTypePointer Private %int
 %int_1 = OpVariable %int_ptr Private


### PR DESCRIPTION
The grammar was recently fixed to have the right number of operands. See https://github.com/KhronosGroup/SPIRV-Headers/pull/229