### PR TITLE
spirv-fuzz: Use reference in CanMakeSynonymOf

### DIFF
--- a/source/fuzz/fuzzer_pass_add_vector_shuffle_instructions.cpp
+++ b/source/fuzz/fuzzer_pass_add_vector_shuffle_instructions.cpp
@@ -75,7 +75,7 @@ void FuzzerPassAddVectorShuffleInstructions::Apply() {
                            ->IdIsIrrelevant(instruction->result_id()) &&
                       !fuzzerutil::CanMakeSynonymOf(ir_context,
                                                     *GetTransformationContext(),
-                                                    instruction)) {
+                                                    *instruction)) {
                     // If the id is irrelevant, we can use it since it will not
                     // participate in DataSynonym fact. Otherwise, we should be
                     // able to produce a synonym out of the id.

--- a/source/fuzz/fuzzer_pass_construct_composites.cpp
+++ b/source/fuzz/fuzzer_pass_construct_composites.cpp
@@ -61,7 +61,7 @@ void FuzzerPassConstructComposites::Apply() {
         return GetTransformationContext()->GetFactManager()->IdIsIrrelevant(
                    inst->result_id()) ||
                fuzzerutil::CanMakeSynonymOf(ir_context,
-                                            *GetTransformationContext(), inst);
+                                            *GetTransformationContext(), *inst);
       });
 
   ForEachInstructionWithInstructionDescriptor(

--- a/source/fuzz/fuzzer_pass_expand_vector_reductions.cpp
+++ b/source/fuzz/fuzzer_pass_expand_vector_reductions.cpp
@@ -46,7 +46,7 @@ void FuzzerPassExpandVectorReductions::Apply() {
 
         // It must be able to make a synonym of |instruction|.
         if (!fuzzerutil::CanMakeSynonymOf(
-                GetIRContext(), *GetTransformationContext(), &instruction)) {
+                GetIRContext(), *GetTransformationContext(), instruction)) {
           continue;
         }
 

--- a/source/fuzz/fuzzer_pass_push_ids_through_variables.cpp
+++ b/source/fuzz/fuzzer_pass_push_ids_through_variables.cpp
@@ -102,7 +102,7 @@ void FuzzerPassPushIdsThroughVariables::Apply() {
                            ->IdIsIrrelevant(instruction->result_id()) &&
                       !fuzzerutil::CanMakeSynonymOf(ir_context,
                                                     *GetTransformationContext(),
-                                                    instruction)) {
+                                                    *instruction)) {
                     return false;
                   }
 

--- a/source/fuzz/fuzzer_pass_wrap_vector_synonym.cpp
+++ b/source/fuzz/fuzzer_pass_wrap_vector_synonym.cpp
@@ -75,7 +75,7 @@ void FuzzerPassWrapVectorSynonym::Apply() {
         // irrelevant).
         if (!fuzzerutil::CanMakeSynonymOf(GetIRContext(),
                                           *GetTransformationContext(),
-                                          &*instruction_iterator)) {
+                                          *instruction_iterator)) {
           return;
         }
         if (!fuzzerutil::CanMakeSynonymOf(

--- a/source/fuzz/fuzzer_pass_wrap_vector_synonym.cpp
+++ b/source/fuzz/fuzzer_pass_wrap_vector_synonym.cpp
@@ -80,12 +80,12 @@ void FuzzerPassWrapVectorSynonym::Apply() {
         }
         if (!fuzzerutil::CanMakeSynonymOf(
                 GetIRContext(), *GetTransformationContext(),
-                GetIRContext()->get_def_use_mgr()->GetDef(target_id1))) {
+                *GetIRContext()->get_def_use_mgr()->GetDef(target_id1))) {
           return;
         }
         if (!fuzzerutil::CanMakeSynonymOf(
                 GetIRContext(), *GetTransformationContext(),
-                GetIRContext()->get_def_use_mgr()->GetDef(target_id2))) {
+                *GetIRContext()->get_def_use_mgr()->GetDef(target_id2))) {
           return;
         }
 

--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -326,12 +326,12 @@ bool CanMakeSynonymOf(opt::IRContext* ir_context,
     return false;
   }
   auto type_inst = ir_context->get_def_use_mgr()->GetDef(inst.type_id());
-  if (type_inst.opcode() == SpvOpTypeVoid) {
+  if (type_inst->opcode() == SpvOpTypeVoid) {
     // We only make synonyms of instructions that define objects, and an object
     // cannot have void type.
     return false;
   }
-  if (type_inst.opcode() == SpvOpTypePointer) {
+  if (type_inst->opcode() == SpvOpTypePointer) {
     switch (inst.opcode()) {
       case SpvOpConstantNull:
       case SpvOpUndef:

--- a/source/fuzz/fuzzer_util.cpp
+++ b/source/fuzz/fuzzer_util.cpp
@@ -305,34 +305,34 @@ bool CanInsertOpcodeBeforeInstruction(
 
 bool CanMakeSynonymOf(opt::IRContext* ir_context,
                       const TransformationContext& transformation_context,
-                      const opt::Instruction* inst) {
-  if (inst->opcode() == SpvOpSampledImage) {
+                      const opt::Instruction& inst) {
+  if (inst.opcode() == SpvOpSampledImage) {
     // The SPIR-V data rules say that only very specific instructions may
     // may consume the result id of an OpSampledImage, and this excludes the
     // instructions that are used for making synonyms.
     return false;
   }
-  if (!inst->HasResultId()) {
+  if (!inst.HasResultId()) {
     // We can only make a synonym of an instruction that generates an id.
     return false;
   }
   if (transformation_context.GetFactManager()->IdIsIrrelevant(
-          inst->result_id())) {
+          inst.result_id())) {
     // An irrelevant id can't be a synonym of anything.
     return false;
   }
-  if (!inst->type_id()) {
+  if (!inst.type_id()) {
     // We can only make a synonym of an instruction that has a type.
     return false;
   }
-  auto type_inst = ir_context->get_def_use_mgr()->GetDef(inst->type_id());
-  if (type_inst->opcode() == SpvOpTypeVoid) {
+  auto type_inst = ir_context->get_def_use_mgr()->GetDef(inst.type_id());
+  if (type_inst.opcode() == SpvOpTypeVoid) {
     // We only make synonyms of instructions that define objects, and an object
     // cannot have void type.
     return false;
   }
-  if (type_inst->opcode() == SpvOpTypePointer) {
-    switch (inst->opcode()) {
+  if (type_inst.opcode() == SpvOpTypePointer) {
+    switch (inst.opcode()) {
       case SpvOpConstantNull:
       case SpvOpUndef:
         // We disallow making synonyms of null or undefined pointers.  This is
@@ -348,7 +348,7 @@ bool CanMakeSynonymOf(opt::IRContext* ir_context,
   // not decorated analogously, using the original object vs. its synonymous
   // form may not be equivalent.
   return ir_context->get_decoration_mgr()
-      ->GetDecorationsFor(inst->result_id(), true)
+      ->GetDecorationsFor(inst.result_id(), true)
       .empty();
 }
 

--- a/source/fuzz/fuzzer_util.h
+++ b/source/fuzz/fuzzer_util.h
@@ -118,7 +118,7 @@ bool CanInsertOpcodeBeforeInstruction(
 // does not participate in IdIsIrrelevant fact.
 bool CanMakeSynonymOf(opt::IRContext* ir_context,
                       const TransformationContext& transformation_context,
-                      const opt::Instruction* inst);
+                      const opt::Instruction& inst);
 
 // Determines whether the given type is a composite; that is: an array, matrix,
 // struct or vector.

--- a/source/fuzz/transformation_add_synonym.cpp
+++ b/source/fuzz/transformation_add_synonym.cpp
@@ -151,7 +151,8 @@ bool TransformationAddSynonym::IsInstructionValid(
     return false;
   }
 
-  if (!fuzzerutil::CanMakeSynonymOf(ir_context, transformation_context, inst)) {
+  if (!fuzzerutil::CanMakeSynonymOf(ir_context, transformation_context,
+                                    *inst)) {
     return false;
   }
 

--- a/source/fuzz/transformation_composite_construct.cpp
+++ b/source/fuzz/transformation_composite_construct.cpp
@@ -297,7 +297,7 @@ void TransformationCompositeConstruct::AddDataSynonymFacts(
         composite_type->AsVector() && component_type->AsVector();
     if (!fuzzerutil::CanMakeSynonymOf(
             ir_context, *transformation_context,
-            ir_context->get_def_use_mgr()->GetDef(component))) {
+            *ir_context->get_def_use_mgr()->GetDef(component))) {
       // We can't make a synonym of this component, so we skip on to the next
       // component.  In the case where we're packing a vector into a vector we
       // have to skip as many components of the resulting vectors as there are

--- a/source/fuzz/transformation_composite_extract.cpp
+++ b/source/fuzz/transformation_composite_extract.cpp
@@ -125,7 +125,7 @@ void TransformationCompositeExtract::AddDataSynonymFacts(
   // or if the result id into which we are extracting is irrelevant.
   if (!fuzzerutil::CanMakeSynonymOf(
           ir_context, *transformation_context,
-          ir_context->get_def_use_mgr()->GetDef(message_.composite_id())) ||
+          *ir_context->get_def_use_mgr()->GetDef(message_.composite_id())) ||
       transformation_context->GetFactManager()->IdIsIrrelevant(
           message_.fresh_id())) {
     return;

--- a/source/fuzz/transformation_composite_insert.cpp
+++ b/source/fuzz/transformation_composite_insert.cpp
@@ -235,7 +235,7 @@ void TransformationCompositeInsert::AddDataSynonymFacts(
   // synonymous with the result of the insert instruction at the given index.
   if (fuzzerutil::CanMakeSynonymOf(
           ir_context, *transformation_context,
-          ir_context->get_def_use_mgr()->GetDef(message_.object_id()))) {
+          *ir_context->get_def_use_mgr()->GetDef(message_.object_id()))) {
     transformation_context->GetFactManager()->AddFactDataSynonym(
         MakeDataDescriptor(message_.object_id(), {}),
         MakeDataDescriptor(message_.fresh_id(), index));

--- a/source/fuzz/transformation_composite_insert.cpp
+++ b/source/fuzz/transformation_composite_insert.cpp
@@ -219,9 +219,9 @@ void TransformationCompositeInsert::AddDataSynonymFacts(
         continue;
       }
       current_index.push_back(i);
-      if (fuzzerutil::CanMakeSynonymOf(
-              ir_context, *transformation_context,
-              ir_context->get_def_use_mgr()->GetDef(message_.composite_id()))) {
+      if (fuzzerutil::CanMakeSynonymOf(ir_context, *transformation_context,
+                                       *ir_context->get_def_use_mgr()->GetDef(
+                                           message_.composite_id()))) {
         transformation_context->GetFactManager()->AddFactDataSynonym(
             MakeDataDescriptor(message_.fresh_id(), current_index),
             MakeDataDescriptor(message_.composite_id(), current_index));

--- a/source/fuzz/transformation_expand_vector_reduction.cpp
+++ b/source/fuzz/transformation_expand_vector_reduction.cpp
@@ -129,7 +129,7 @@ void TransformationExpandVectorReduction::Apply(
   // If it's possible to make a synonym of |instruction|, then add the fact that
   // the last |logical_instruction| is a synonym of |instruction|.
   if (fuzzerutil::CanMakeSynonymOf(ir_context, *transformation_context,
-                                   instruction)) {
+                                   *instruction)) {
     transformation_context->GetFactManager()->AddFactDataSynonym(
         MakeDataDescriptor(logical_instruction.result_id(), {}),
         MakeDataDescriptor(instruction->result_id(), {}));

--- a/source/fuzz/transformation_push_id_through_variable.cpp
+++ b/source/fuzz/transformation_push_id_through_variable.cpp
@@ -155,7 +155,7 @@ void TransformationPushIdThroughVariable::Apply(
 
   // We should be able to create a synonym of |value_id| if it's not irrelevant.
   if (fuzzerutil::CanMakeSynonymOf(ir_context, *transformation_context,
-                                   value_instruction) &&
+                                   *value_instruction) &&
       !transformation_context->GetFactManager()->IdIsIrrelevant(
           message_.value_synonym_id())) {
     // Adds the fact that |message_.value_synonym_id|

--- a/source/fuzz/transformation_vector_shuffle.cpp
+++ b/source/fuzz/transformation_vector_shuffle.cpp
@@ -204,7 +204,7 @@ void TransformationVectorShuffle::AddDataSynonymFacts(
       // Check that the first vector can participate in data synonym facts.
       if (!fuzzerutil::CanMakeSynonymOf(
               ir_context, *transformation_context,
-              ir_context->get_def_use_mgr()->GetDef(message_.vector1()))) {
+              *ir_context->get_def_use_mgr()->GetDef(message_.vector1()))) {
         continue;
       }
       descriptor_for_source_component =
@@ -213,7 +213,7 @@ void TransformationVectorShuffle::AddDataSynonymFacts(
       // Check that the second vector can participate in data synonym facts.
       if (!fuzzerutil::CanMakeSynonymOf(
               ir_context, *transformation_context,
-              ir_context->get_def_use_mgr()->GetDef(message_.vector2()))) {
+              *ir_context->get_def_use_mgr()->GetDef(message_.vector2()))) {
         continue;
       }
       auto index_into_vector_2 =

--- a/source/fuzz/transformation_wrap_vector_synonym.cpp
+++ b/source/fuzz/transformation_wrap_vector_synonym.cpp
@@ -58,7 +58,7 @@ bool TransformationWrapVectorSynonym::IsApplicable(
   // It must be possible to make a synonym of the result id of the scalar
   // operation
   if (!fuzzerutil::CanMakeSynonymOf(ir_context, transformation_context,
-                                    instruction)) {
+                                    *instruction)) {
     return false;
   }
 


### PR DESCRIPTION
The instruction parameter of CanMakeSynonymOf is an input parameter
that should never be null, so a const reference is a more appropriate
type than a const pointer.