### PR TITLE
spirv-fuzz: Allow inapplicable transformations to be ignored

### DIFF
--- a/source/fuzz/fuzzer.h
+++ b/source/fuzz/fuzzer.h
@@ -62,7 +62,8 @@ class Fuzzer {
          const std::vector<fuzzerutil::ModuleSupplier>& donor_suppliers,
          bool enable_all_passes, RepeatedPassStrategy repeated_pass_strategy,
          bool validate_after_each_fuzzer_pass,
-         spv_validator_options validator_options);
+         spv_validator_options validator_options,
+         bool ignore_inapplicable_transformations);
 
   // Disables copy/move constructor/assignment operations.
   Fuzzer(const Fuzzer&) = delete;
@@ -187,6 +188,12 @@ class Fuzzer {
   // Some passes that it does not make sense to apply repeatedly, as they do not
   // unlock other passes.
   std::vector<std::unique_ptr<FuzzerPass>> final_passes_;
+
+  // When set, this flag causes inapplicable transformations that should be
+  // applicable by construction to be ignored. This is useful when the fuzzer
+  // is being deployed at scale to test a SPIR-V processing tool, and where it
+  // is desirable to ignore bugs in the fuzzer itself.
+  const bool ignore_inapplicable_transformations_;
 };
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_pass.h
+++ b/source/fuzz/fuzzer_pass.h
@@ -33,7 +33,8 @@ class FuzzerPass {
   FuzzerPass(opt::IRContext* ir_context,
              TransformationContext* transformation_context,
              FuzzerContext* fuzzer_context,
-             protobufs::TransformationSequence* transformations);
+             protobufs::TransformationSequence* transformations,
+             bool ignore_inapplicable_transformations);
 
   virtual ~FuzzerPass();
 
@@ -321,6 +322,10 @@ class FuzzerPass {
   TransformationContext* transformation_context_;
   FuzzerContext* fuzzer_context_;
   protobufs::TransformationSequence* transformations_;
+  // If set, then transformations that should be applicable by construction are
+  // still tested for applicability, and ignored if they turn out to be
+  // inapplicable. Otherwise, applicability by construction is asserted.
+  const bool ignore_inapplicable_transformations_;
 };
 
 }  // namespace fuzz

--- a/source/fuzz/fuzzer_pass_add_access_chains.cpp
+++ b/source/fuzz/fuzzer_pass_add_access_chains.cpp
@@ -23,9 +23,10 @@ namespace fuzz {
 FuzzerPassAddAccessChains::FuzzerPassAddAccessChains(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddAccessChains::Apply() {
   ForEachInstructionWithInstructionDescriptor(

--- a/source/fuzz/fuzzer_pass_add_access_chains.h
+++ b/source/fuzz/fuzzer_pass_add_access_chains.h
@@ -28,7 +28,8 @@ class FuzzerPassAddAccessChains : public FuzzerPass {
   FuzzerPassAddAccessChains(opt::IRContext* ir_context,
                             TransformationContext* transformation_context,
                             FuzzerContext* fuzzer_context,
-                            protobufs::TransformationSequence* transformations);
+                            protobufs::TransformationSequence* transformations,
+                            bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_add_bit_instruction_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_add_bit_instruction_synonyms.cpp
@@ -24,9 +24,10 @@ namespace fuzz {
 FuzzerPassAddBitInstructionSynonyms::FuzzerPassAddBitInstructionSynonyms(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddBitInstructionSynonyms::Apply() {
   for (auto& function : *GetIRContext()->module()) {

--- a/source/fuzz/fuzzer_pass_add_bit_instruction_synonyms.h
+++ b/source/fuzz/fuzzer_pass_add_bit_instruction_synonyms.h
@@ -28,7 +28,8 @@ class FuzzerPassAddBitInstructionSynonyms : public FuzzerPass {
   FuzzerPassAddBitInstructionSynonyms(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_add_composite_extract.cpp
+++ b/source/fuzz/fuzzer_pass_add_composite_extract.cpp
@@ -26,9 +26,10 @@ namespace fuzz {
 FuzzerPassAddCompositeExtract::FuzzerPassAddCompositeExtract(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddCompositeExtract::Apply() {
   std::vector<const protobufs::DataDescriptor*> composite_synonyms;

--- a/source/fuzz/fuzzer_pass_add_composite_extract.h
+++ b/source/fuzz/fuzzer_pass_add_composite_extract.h
@@ -27,7 +27,8 @@ class FuzzerPassAddCompositeExtract : public FuzzerPass {
   FuzzerPassAddCompositeExtract(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_add_composite_inserts.cpp
+++ b/source/fuzz/fuzzer_pass_add_composite_inserts.cpp
@@ -25,9 +25,10 @@ namespace fuzz {
 FuzzerPassAddCompositeInserts::FuzzerPassAddCompositeInserts(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddCompositeInserts::Apply() {
   ForEachInstructionWithInstructionDescriptor(

--- a/source/fuzz/fuzzer_pass_add_composite_inserts.h
+++ b/source/fuzz/fuzzer_pass_add_composite_inserts.h
@@ -27,7 +27,8 @@ class FuzzerPassAddCompositeInserts : public FuzzerPass {
   FuzzerPassAddCompositeInserts(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 

--- a/source/fuzz/fuzzer_pass_add_composite_types.cpp
+++ b/source/fuzz/fuzzer_pass_add_composite_types.cpp
@@ -24,9 +24,10 @@ namespace fuzz {
 FuzzerPassAddCompositeTypes::FuzzerPassAddCompositeTypes(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddCompositeTypes::Apply() {
   MaybeAddMissingVectorTypes();

--- a/source/fuzz/fuzzer_pass_add_composite_types.h
+++ b/source/fuzz/fuzzer_pass_add_composite_types.h
@@ -27,7 +27,8 @@ class FuzzerPassAddCompositeTypes : public FuzzerPass {
   FuzzerPassAddCompositeTypes(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 

--- a/source/fuzz/fuzzer_pass_add_copy_memory.cpp
+++ b/source/fuzz/fuzzer_pass_add_copy_memory.cpp
@@ -25,9 +25,10 @@ namespace fuzz {
 FuzzerPassAddCopyMemory::FuzzerPassAddCopyMemory(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddCopyMemory::Apply() {
   ForEachInstructionWithInstructionDescriptor(

--- a/source/fuzz/fuzzer_pass_add_copy_memory.h
+++ b/source/fuzz/fuzzer_pass_add_copy_memory.h
@@ -27,7 +27,8 @@ class FuzzerPassAddCopyMemory : public FuzzerPass {
   FuzzerPassAddCopyMemory(opt::IRContext* ir_context,
                           TransformationContext* transformation_context,
                           FuzzerContext* fuzzer_context,
-                          protobufs::TransformationSequence* transformations);
+                          protobufs::TransformationSequence* transformations,
+                          bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_add_dead_blocks.cpp
+++ b/source/fuzz/fuzzer_pass_add_dead_blocks.cpp
@@ -31,9 +31,10 @@ const size_t kMaxTransformationsInOnePass = 100U;
 FuzzerPassAddDeadBlocks::FuzzerPassAddDeadBlocks(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddDeadBlocks::Apply() {
   // We iterate over all blocks in the module collecting up those at which we

--- a/source/fuzz/fuzzer_pass_add_dead_blocks.h
+++ b/source/fuzz/fuzzer_pass_add_dead_blocks.h
@@ -27,7 +27,8 @@ class FuzzerPassAddDeadBlocks : public FuzzerPass {
   FuzzerPassAddDeadBlocks(opt::IRContext* ir_context,
                           TransformationContext* transformation_context,
                           FuzzerContext* fuzzer_context,
-                          protobufs::TransformationSequence* transformations);
+                          protobufs::TransformationSequence* transformations,
+                          bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_add_dead_breaks.cpp
+++ b/source/fuzz/fuzzer_pass_add_dead_breaks.cpp
@@ -24,9 +24,10 @@ namespace fuzz {
 FuzzerPassAddDeadBreaks::FuzzerPassAddDeadBreaks(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddDeadBreaks::Apply() {
   // We first collect up lots of possibly-applicable transformations.

--- a/source/fuzz/fuzzer_pass_add_dead_breaks.h
+++ b/source/fuzz/fuzzer_pass_add_dead_breaks.h
@@ -26,7 +26,8 @@ class FuzzerPassAddDeadBreaks : public FuzzerPass {
   FuzzerPassAddDeadBreaks(opt::IRContext* ir_context,
                           TransformationContext* transformation_context,
                           FuzzerContext* fuzzer_context,
-                          protobufs::TransformationSequence* transformations);
+                          protobufs::TransformationSequence* transformations,
+                          bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_add_dead_continues.cpp
+++ b/source/fuzz/fuzzer_pass_add_dead_continues.cpp
@@ -24,9 +24,10 @@ namespace fuzz {
 FuzzerPassAddDeadContinues::FuzzerPassAddDeadContinues(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddDeadContinues::Apply() {
   // Consider every block in every function.

--- a/source/fuzz/fuzzer_pass_add_dead_continues.h
+++ b/source/fuzz/fuzzer_pass_add_dead_continues.h
@@ -23,10 +23,11 @@ namespace fuzz {
 // A fuzzer pass for adding dead continue edges to the module.
 class FuzzerPassAddDeadContinues : public FuzzerPass {
  public:
-  FuzzerPassAddDeadContinues(
-      opt::IRContext* ir_context, TransformationContext* transformation_context,
-      FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+  FuzzerPassAddDeadContinues(opt::IRContext* ir_context,
+                             TransformationContext* transformation_context,
+                             FuzzerContext* fuzzer_context,
+                             protobufs::TransformationSequence* transformations,
+                             bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_add_equation_instructions.cpp
+++ b/source/fuzz/fuzzer_pass_add_equation_instructions.cpp
@@ -45,9 +45,10 @@ bool IsBitWidthSupported(opt::IRContext* ir_context, uint32_t bit_width) {
 FuzzerPassAddEquationInstructions::FuzzerPassAddEquationInstructions(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddEquationInstructions::Apply() {
   ForEachInstructionWithInstructionDescriptor(

--- a/source/fuzz/fuzzer_pass_add_equation_instructions.h
+++ b/source/fuzz/fuzzer_pass_add_equation_instructions.h
@@ -29,7 +29,8 @@ class FuzzerPassAddEquationInstructions : public FuzzerPass {
   FuzzerPassAddEquationInstructions(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 

--- a/source/fuzz/fuzzer_pass_add_function_calls.cpp
+++ b/source/fuzz/fuzzer_pass_add_function_calls.cpp
@@ -26,9 +26,10 @@ namespace fuzz {
 FuzzerPassAddFunctionCalls::FuzzerPassAddFunctionCalls(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddFunctionCalls::Apply() {
   ForEachInstructionWithInstructionDescriptor(

--- a/source/fuzz/fuzzer_pass_add_function_calls.h
+++ b/source/fuzz/fuzzer_pass_add_function_calls.h
@@ -24,10 +24,11 @@ namespace fuzz {
 // anywhere, and (b) any functions, from dead blocks.
 class FuzzerPassAddFunctionCalls : public FuzzerPass {
  public:
-  FuzzerPassAddFunctionCalls(
-      opt::IRContext* ir_context, TransformationContext* transformation_context,
-      FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+  FuzzerPassAddFunctionCalls(opt::IRContext* ir_context,
+                             TransformationContext* transformation_context,
+                             FuzzerContext* fuzzer_context,
+                             protobufs::TransformationSequence* transformations,
+                             bool ignore_inapplicable_transformations);
 
   void Apply() override;
 

--- a/source/fuzz/fuzzer_pass_add_global_variables.cpp
+++ b/source/fuzz/fuzzer_pass_add_global_variables.cpp
@@ -23,9 +23,10 @@ namespace fuzz {
 FuzzerPassAddGlobalVariables::FuzzerPassAddGlobalVariables(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddGlobalVariables::Apply() {
   SpvStorageClass variable_storage_class = SpvStorageClassPrivate;

--- a/source/fuzz/fuzzer_pass_add_global_variables.h
+++ b/source/fuzz/fuzzer_pass_add_global_variables.h
@@ -27,7 +27,8 @@ class FuzzerPassAddGlobalVariables : public FuzzerPass {
   FuzzerPassAddGlobalVariables(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_add_image_sample_unused_components.cpp
+++ b/source/fuzz/fuzzer_pass_add_image_sample_unused_components.cpp
@@ -27,9 +27,10 @@ FuzzerPassAddImageSampleUnusedComponents::
         opt::IRContext* ir_context,
         TransformationContext* transformation_context,
         FuzzerContext* fuzzer_context,
-        protobufs::TransformationSequence* transformations)
+        protobufs::TransformationSequence* transformations,
+        bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddImageSampleUnusedComponents::Apply() {
   // SPIR-V module to help understand the transformation.

--- a/source/fuzz/fuzzer_pass_add_image_sample_unused_components.h
+++ b/source/fuzz/fuzzer_pass_add_image_sample_unused_components.h
@@ -28,7 +28,8 @@ class FuzzerPassAddImageSampleUnusedComponents : public FuzzerPass {
   FuzzerPassAddImageSampleUnusedComponents(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_add_loads.cpp
+++ b/source/fuzz/fuzzer_pass_add_loads.cpp
@@ -23,9 +23,10 @@ namespace fuzz {
 FuzzerPassAddLoads::FuzzerPassAddLoads(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddLoads::Apply() {
   ForEachInstructionWithInstructionDescriptor(

--- a/source/fuzz/fuzzer_pass_add_loads.h
+++ b/source/fuzz/fuzzer_pass_add_loads.h
@@ -26,7 +26,8 @@ class FuzzerPassAddLoads : public FuzzerPass {
   FuzzerPassAddLoads(opt::IRContext* ir_context,
                      TransformationContext* transformation_context,
                      FuzzerContext* fuzzer_context,
-                     protobufs::TransformationSequence* transformations);
+                     protobufs::TransformationSequence* transformations,
+                     bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_add_local_variables.cpp
+++ b/source/fuzz/fuzzer_pass_add_local_variables.cpp
@@ -24,9 +24,10 @@ namespace fuzz {
 FuzzerPassAddLocalVariables::FuzzerPassAddLocalVariables(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddLocalVariables::Apply() {
   auto basic_type_ids_and_pointers =

--- a/source/fuzz/fuzzer_pass_add_local_variables.h
+++ b/source/fuzz/fuzzer_pass_add_local_variables.h
@@ -27,7 +27,8 @@ class FuzzerPassAddLocalVariables : public FuzzerPass {
   FuzzerPassAddLocalVariables(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_add_loop_preheaders.cpp
+++ b/source/fuzz/fuzzer_pass_add_loop_preheaders.cpp
@@ -23,9 +23,10 @@ namespace fuzz {
 FuzzerPassAddLoopPreheaders::FuzzerPassAddLoopPreheaders(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddLoopPreheaders::Apply() {
   for (auto& function : *GetIRContext()->module()) {

--- a/source/fuzz/fuzzer_pass_add_loop_preheaders.h
+++ b/source/fuzz/fuzzer_pass_add_loop_preheaders.h
@@ -30,7 +30,8 @@ class FuzzerPassAddLoopPreheaders : public FuzzerPass {
   FuzzerPassAddLoopPreheaders(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_add_loops_to_create_int_constant_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_add_loops_to_create_int_constant_synonyms.cpp
@@ -29,9 +29,10 @@ FuzzerPassAddLoopsToCreateIntConstantSynonyms::
         opt::IRContext* ir_context,
         TransformationContext* transformation_context,
         FuzzerContext* fuzzer_context,
-        protobufs::TransformationSequence* transformations)
+        protobufs::TransformationSequence* transformations,
+        bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddLoopsToCreateIntConstantSynonyms::Apply() {
   std::vector<uint32_t> constants;

--- a/source/fuzz/fuzzer_pass_add_loops_to_create_int_constant_synonyms.h
+++ b/source/fuzz/fuzzer_pass_add_loops_to_create_int_constant_synonyms.h
@@ -28,7 +28,8 @@ class FuzzerPassAddLoopsToCreateIntConstantSynonyms : public FuzzerPass {
   FuzzerPassAddLoopsToCreateIntConstantSynonyms(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 

--- a/source/fuzz/fuzzer_pass_add_no_contraction_decorations.cpp
+++ b/source/fuzz/fuzzer_pass_add_no_contraction_decorations.cpp
@@ -22,9 +22,10 @@ namespace fuzz {
 FuzzerPassAddNoContractionDecorations::FuzzerPassAddNoContractionDecorations(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddNoContractionDecorations::Apply() {
   // Consider every instruction in every block in every function.

--- a/source/fuzz/fuzzer_pass_add_no_contraction_decorations.h
+++ b/source/fuzz/fuzzer_pass_add_no_contraction_decorations.h
@@ -26,7 +26,8 @@ class FuzzerPassAddNoContractionDecorations : public FuzzerPass {
   FuzzerPassAddNoContractionDecorations(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_add_opphi_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_add_opphi_synonyms.cpp
@@ -23,9 +23,10 @@ namespace fuzz {
 FuzzerPassAddOpPhiSynonyms::FuzzerPassAddOpPhiSynonyms(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddOpPhiSynonyms::Apply() {
   // Get a list of synonymous ids with the same type that can be used in the

--- a/source/fuzz/fuzzer_pass_add_opphi_synonyms.h
+++ b/source/fuzz/fuzzer_pass_add_opphi_synonyms.h
@@ -25,10 +25,11 @@ namespace fuzz {
 // synonymous with the others.
 class FuzzerPassAddOpPhiSynonyms : public FuzzerPass {
  public:
-  FuzzerPassAddOpPhiSynonyms(
-      opt::IRContext* ir_context, TransformationContext* transformation_context,
-      FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+  FuzzerPassAddOpPhiSynonyms(opt::IRContext* ir_context,
+                             TransformationContext* transformation_context,
+                             FuzzerContext* fuzzer_context,
+                             protobufs::TransformationSequence* transformations,
+                             bool ignore_inapplicable_transformations);
 
   void Apply() override;
 

--- a/source/fuzz/fuzzer_pass_add_parameters.cpp
+++ b/source/fuzz/fuzzer_pass_add_parameters.cpp
@@ -25,9 +25,10 @@ namespace fuzz {
 FuzzerPassAddParameters::FuzzerPassAddParameters(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddParameters::Apply() {
   // Compute type candidates for the new parameter.

--- a/source/fuzz/fuzzer_pass_add_parameters.h
+++ b/source/fuzz/fuzzer_pass_add_parameters.h
@@ -30,7 +30,8 @@ class FuzzerPassAddParameters : public FuzzerPass {
   FuzzerPassAddParameters(opt::IRContext* ir_context,
                           TransformationContext* transformation_context,
                           FuzzerContext* fuzzer_context,
-                          protobufs::TransformationSequence* transformations);
+                          protobufs::TransformationSequence* transformations,
+                          bool ignore_inapplicable_transformations);
 
   void Apply() override;
 

--- a/source/fuzz/fuzzer_pass_add_relaxed_decorations.cpp
+++ b/source/fuzz/fuzzer_pass_add_relaxed_decorations.cpp
@@ -22,9 +22,10 @@ namespace fuzz {
 FuzzerPassAddRelaxedDecorations::FuzzerPassAddRelaxedDecorations(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddRelaxedDecorations::Apply() {
   // Consider every instruction in every block in every function.

--- a/source/fuzz/fuzzer_pass_add_relaxed_decorations.h
+++ b/source/fuzz/fuzzer_pass_add_relaxed_decorations.h
@@ -26,7 +26,8 @@ class FuzzerPassAddRelaxedDecorations : public FuzzerPass {
   FuzzerPassAddRelaxedDecorations(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_add_stores.cpp
+++ b/source/fuzz/fuzzer_pass_add_stores.cpp
@@ -23,9 +23,10 @@ namespace fuzz {
 FuzzerPassAddStores::FuzzerPassAddStores(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddStores::Apply() {
   ForEachInstructionWithInstructionDescriptor(

--- a/source/fuzz/fuzzer_pass_add_stores.h
+++ b/source/fuzz/fuzzer_pass_add_stores.h
@@ -28,7 +28,8 @@ class FuzzerPassAddStores : public FuzzerPass {
   FuzzerPassAddStores(opt::IRContext* ir_context,
                       TransformationContext* transformation_context,
                       FuzzerContext* fuzzer_context,
-                      protobufs::TransformationSequence* transformations);
+                      protobufs::TransformationSequence* transformations,
+                      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_add_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_add_synonyms.cpp
@@ -25,9 +25,10 @@ namespace fuzz {
 FuzzerPassAddSynonyms::FuzzerPassAddSynonyms(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddSynonyms::Apply() {
   ForEachInstructionWithInstructionDescriptor(

--- a/source/fuzz/fuzzer_pass_add_synonyms.h
+++ b/source/fuzz/fuzzer_pass_add_synonyms.h
@@ -27,7 +27,8 @@ class FuzzerPassAddSynonyms : public FuzzerPass {
   FuzzerPassAddSynonyms(opt::IRContext* ir_context,
                         TransformationContext* transformation_context,
                         FuzzerContext* fuzzer_context,
-                        protobufs::TransformationSequence* transformations);
+                        protobufs::TransformationSequence* transformations,
+                        bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_add_vector_shuffle_instructions.cpp
+++ b/source/fuzz/fuzzer_pass_add_vector_shuffle_instructions.cpp
@@ -24,9 +24,10 @@ namespace fuzz {
 FuzzerPassAddVectorShuffleInstructions::FuzzerPassAddVectorShuffleInstructions(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAddVectorShuffleInstructions::Apply() {
   ForEachInstructionWithInstructionDescriptor(

--- a/source/fuzz/fuzzer_pass_add_vector_shuffle_instructions.h
+++ b/source/fuzz/fuzzer_pass_add_vector_shuffle_instructions.h
@@ -26,7 +26,8 @@ class FuzzerPassAddVectorShuffleInstructions : public FuzzerPass {
   FuzzerPassAddVectorShuffleInstructions(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_adjust_branch_weights.cpp
+++ b/source/fuzz/fuzzer_pass_adjust_branch_weights.cpp
@@ -24,9 +24,10 @@ namespace fuzz {
 FuzzerPassAdjustBranchWeights::FuzzerPassAdjustBranchWeights(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAdjustBranchWeights::Apply() {
   // For all OpBranchConditional instructions,

--- a/source/fuzz/fuzzer_pass_adjust_branch_weights.h
+++ b/source/fuzz/fuzzer_pass_adjust_branch_weights.h
@@ -28,7 +28,8 @@ class FuzzerPassAdjustBranchWeights : public FuzzerPass {
   FuzzerPassAdjustBranchWeights(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_adjust_function_controls.cpp
+++ b/source/fuzz/fuzzer_pass_adjust_function_controls.cpp
@@ -22,9 +22,10 @@ namespace fuzz {
 FuzzerPassAdjustFunctionControls::FuzzerPassAdjustFunctionControls(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAdjustFunctionControls::Apply() {
   // Consider every function in the module.

--- a/source/fuzz/fuzzer_pass_adjust_function_controls.h
+++ b/source/fuzz/fuzzer_pass_adjust_function_controls.h
@@ -26,7 +26,8 @@ class FuzzerPassAdjustFunctionControls : public FuzzerPass {
   FuzzerPassAdjustFunctionControls(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_adjust_loop_controls.cpp
+++ b/source/fuzz/fuzzer_pass_adjust_loop_controls.cpp
@@ -22,9 +22,10 @@ namespace fuzz {
 FuzzerPassAdjustLoopControls::FuzzerPassAdjustLoopControls(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAdjustLoopControls::Apply() {
   // Consider every merge instruction in the module (via looking through all

--- a/source/fuzz/fuzzer_pass_adjust_loop_controls.h
+++ b/source/fuzz/fuzzer_pass_adjust_loop_controls.h
@@ -26,7 +26,8 @@ class FuzzerPassAdjustLoopControls : public FuzzerPass {
   FuzzerPassAdjustLoopControls(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_adjust_memory_operands_masks.cpp
+++ b/source/fuzz/fuzzer_pass_adjust_memory_operands_masks.cpp
@@ -23,9 +23,10 @@ namespace fuzz {
 FuzzerPassAdjustMemoryOperandsMasks::FuzzerPassAdjustMemoryOperandsMasks(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAdjustMemoryOperandsMasks::Apply() {
   // Consider every block in every function.

--- a/source/fuzz/fuzzer_pass_adjust_memory_operands_masks.h
+++ b/source/fuzz/fuzzer_pass_adjust_memory_operands_masks.h
@@ -27,7 +27,8 @@ class FuzzerPassAdjustMemoryOperandsMasks : public FuzzerPass {
   FuzzerPassAdjustMemoryOperandsMasks(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_adjust_selection_controls.cpp
+++ b/source/fuzz/fuzzer_pass_adjust_selection_controls.cpp
@@ -22,9 +22,10 @@ namespace fuzz {
 FuzzerPassAdjustSelectionControls::FuzzerPassAdjustSelectionControls(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassAdjustSelectionControls::Apply() {
   // Consider every merge instruction in the module (via looking through all

--- a/source/fuzz/fuzzer_pass_adjust_selection_controls.h
+++ b/source/fuzz/fuzzer_pass_adjust_selection_controls.h
@@ -26,7 +26,8 @@ class FuzzerPassAdjustSelectionControls : public FuzzerPass {
   FuzzerPassAdjustSelectionControls(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
+++ b/source/fuzz/fuzzer_pass_apply_id_synonyms.cpp
@@ -28,9 +28,10 @@ namespace fuzz {
 FuzzerPassApplyIdSynonyms::FuzzerPassApplyIdSynonyms(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassApplyIdSynonyms::Apply() {
   // Compute a closure of data synonym facts, to enrich the pool of synonyms

--- a/source/fuzz/fuzzer_pass_apply_id_synonyms.h
+++ b/source/fuzz/fuzzer_pass_apply_id_synonyms.h
@@ -28,7 +28,8 @@ class FuzzerPassApplyIdSynonyms : public FuzzerPass {
   FuzzerPassApplyIdSynonyms(opt::IRContext* ir_context,
                             TransformationContext* transformation_context,
                             FuzzerContext* fuzzer_context,
-                            protobufs::TransformationSequence* transformations);
+                            protobufs::TransformationSequence* transformations,
+                            bool ignore_inapplicable_transformations);
 
   void Apply() override;
 

--- a/source/fuzz/fuzzer_pass_construct_composites.cpp
+++ b/source/fuzz/fuzzer_pass_construct_composites.cpp
@@ -26,9 +26,10 @@ namespace fuzz {
 FuzzerPassConstructComposites::FuzzerPassConstructComposites(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassConstructComposites::Apply() {
   // Gather up the ids of all composite types, but skip block-/buffer

--- a/source/fuzz/fuzzer_pass_construct_composites.h
+++ b/source/fuzz/fuzzer_pass_construct_composites.h
@@ -29,7 +29,8 @@ class FuzzerPassConstructComposites : public FuzzerPass {
   FuzzerPassConstructComposites(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 

--- a/source/fuzz/fuzzer_pass_copy_objects.cpp
+++ b/source/fuzz/fuzzer_pass_copy_objects.cpp
@@ -24,9 +24,10 @@ namespace fuzz {
 FuzzerPassCopyObjects::FuzzerPassCopyObjects(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassCopyObjects::Apply() {
   ForEachInstructionWithInstructionDescriptor(

--- a/source/fuzz/fuzzer_pass_copy_objects.h
+++ b/source/fuzz/fuzzer_pass_copy_objects.h
@@ -26,7 +26,8 @@ class FuzzerPassCopyObjects : public FuzzerPass {
   FuzzerPassCopyObjects(opt::IRContext* ir_context,
                         TransformationContext* transformation_context,
                         FuzzerContext* fuzzer_context,
-                        protobufs::TransformationSequence* transformations);
+                        protobufs::TransformationSequence* transformations,
+                        bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_donate_modules.cpp
+++ b/source/fuzz/fuzzer_pass_donate_modules.cpp
@@ -45,10 +45,11 @@ FuzzerPassDonateModules::FuzzerPassDonateModules(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
     protobufs::TransformationSequence* transformations,
-    const std::vector<fuzzerutil::ModuleSupplier>& donor_suppliers)
+    bool ignore_inapplicable_transformations,
+    std::vector<fuzzerutil::ModuleSupplier> donor_suppliers)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations),
-      donor_suppliers_(donor_suppliers) {}
+                 transformations, ignore_inapplicable_transformations),
+      donor_suppliers_(std::move(donor_suppliers)) {}
 
 void FuzzerPassDonateModules::Apply() {
   // If there are no donor suppliers, this fuzzer pass is a no-op.

--- a/source/fuzz/fuzzer_pass_donate_modules.h
+++ b/source/fuzz/fuzzer_pass_donate_modules.h
@@ -31,7 +31,8 @@ class FuzzerPassDonateModules : public FuzzerPass {
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
       protobufs::TransformationSequence* transformations,
-      const std::vector<fuzzerutil::ModuleSupplier>& donor_suppliers);
+      bool ignore_inapplicable_transformations,
+      std::vector<fuzzerutil::ModuleSupplier> donor_suppliers);
 
   void Apply() override;
 

--- a/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.cpp
+++ b/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.cpp
@@ -25,9 +25,10 @@ FuzzerPassDuplicateRegionsWithSelections::
         opt::IRContext* ir_context,
         TransformationContext* transformation_context,
         FuzzerContext* fuzzer_context,
-        protobufs::TransformationSequence* transformations)
+        protobufs::TransformationSequence* transformations,
+        bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassDuplicateRegionsWithSelections::Apply() {
   // Iterate over all of the functions in the module.

--- a/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.h
+++ b/source/fuzz/fuzzer_pass_duplicate_regions_with_selections.h
@@ -29,7 +29,8 @@ class FuzzerPassDuplicateRegionsWithSelections : public FuzzerPass {
   FuzzerPassDuplicateRegionsWithSelections(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_expand_vector_reductions.cpp
+++ b/source/fuzz/fuzzer_pass_expand_vector_reductions.cpp
@@ -24,9 +24,10 @@ namespace fuzz {
 FuzzerPassExpandVectorReductions::FuzzerPassExpandVectorReductions(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassExpandVectorReductions::Apply() {
   for (auto& function : *GetIRContext()->module()) {

--- a/source/fuzz/fuzzer_pass_expand_vector_reductions.h
+++ b/source/fuzz/fuzzer_pass_expand_vector_reductions.h
@@ -28,7 +28,8 @@ class FuzzerPassExpandVectorReductions : public FuzzerPass {
   FuzzerPassExpandVectorReductions(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_flatten_conditional_branches.cpp
+++ b/source/fuzz/fuzzer_pass_flatten_conditional_branches.cpp
@@ -26,9 +26,10 @@ namespace fuzz {
 FuzzerPassFlattenConditionalBranches::FuzzerPassFlattenConditionalBranches(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassFlattenConditionalBranches::Apply() {
   for (auto& function : *GetIRContext()->module()) {

--- a/source/fuzz/fuzzer_pass_flatten_conditional_branches.h
+++ b/source/fuzz/fuzzer_pass_flatten_conditional_branches.h
@@ -25,7 +25,8 @@ class FuzzerPassFlattenConditionalBranches : public FuzzerPass {
   FuzzerPassFlattenConditionalBranches(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 

--- a/source/fuzz/fuzzer_pass_inline_functions.cpp
+++ b/source/fuzz/fuzzer_pass_inline_functions.cpp
@@ -25,9 +25,10 @@ namespace fuzz {
 FuzzerPassInlineFunctions::FuzzerPassInlineFunctions(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassInlineFunctions::Apply() {
   // |function_call_instructions| are the instructions that will be inlined.

--- a/source/fuzz/fuzzer_pass_inline_functions.h
+++ b/source/fuzz/fuzzer_pass_inline_functions.h
@@ -28,7 +28,8 @@ class FuzzerPassInlineFunctions : public FuzzerPass {
   FuzzerPassInlineFunctions(opt::IRContext* ir_context,
                             TransformationContext* transformation_context,
                             FuzzerContext* fuzzer_context,
-                            protobufs::TransformationSequence* transformations);
+                            protobufs::TransformationSequence* transformations,
+                            bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.cpp
+++ b/source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.cpp
@@ -27,9 +27,10 @@ FuzzerPassInterchangeSignednessOfIntegerOperands::
         opt::IRContext* ir_context,
         TransformationContext* transformation_context,
         FuzzerContext* fuzzer_context,
-        protobufs::TransformationSequence* transformations)
+        protobufs::TransformationSequence* transformations,
+        bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassInterchangeSignednessOfIntegerOperands::Apply() {
   assert(!GetFuzzerContext()->IsWgslCompatible() &&

--- a/source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.h
+++ b/source/fuzz/fuzzer_pass_interchange_signedness_of_integer_operands.h
@@ -32,7 +32,8 @@ class FuzzerPassInterchangeSignednessOfIntegerOperands : public FuzzerPass {
   FuzzerPassInterchangeSignednessOfIntegerOperands(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 

--- a/source/fuzz/fuzzer_pass_interchange_zero_like_constants.cpp
+++ b/source/fuzz/fuzzer_pass_interchange_zero_like_constants.cpp
@@ -25,9 +25,10 @@ namespace fuzz {
 FuzzerPassInterchangeZeroLikeConstants::FuzzerPassInterchangeZeroLikeConstants(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 uint32_t FuzzerPassInterchangeZeroLikeConstants::FindOrCreateToggledConstant(
     opt::Instruction* declaration) {

--- a/source/fuzz/fuzzer_pass_interchange_zero_like_constants.h
+++ b/source/fuzz/fuzzer_pass_interchange_zero_like_constants.h
@@ -33,7 +33,8 @@ class FuzzerPassInterchangeZeroLikeConstants : public FuzzerPass {
   FuzzerPassInterchangeZeroLikeConstants(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 

--- a/source/fuzz/fuzzer_pass_invert_comparison_operators.cpp
+++ b/source/fuzz/fuzzer_pass_invert_comparison_operators.cpp
@@ -24,9 +24,10 @@ namespace fuzz {
 FuzzerPassInvertComparisonOperators::FuzzerPassInvertComparisonOperators(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassInvertComparisonOperators::Apply() {
   GetIRContext()->module()->ForEachInst([this](const opt::Instruction* inst) {

--- a/source/fuzz/fuzzer_pass_invert_comparison_operators.h
+++ b/source/fuzz/fuzzer_pass_invert_comparison_operators.h
@@ -27,7 +27,8 @@ class FuzzerPassInvertComparisonOperators : public FuzzerPass {
   FuzzerPassInvertComparisonOperators(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_make_vector_operations_dynamic.cpp
+++ b/source/fuzz/fuzzer_pass_make_vector_operations_dynamic.cpp
@@ -24,9 +24,10 @@ namespace fuzz {
 FuzzerPassMakeVectorOperationsDynamic::FuzzerPassMakeVectorOperationsDynamic(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassMakeVectorOperationsDynamic::Apply() {
   for (auto& function : *GetIRContext()->module()) {

--- a/source/fuzz/fuzzer_pass_make_vector_operations_dynamic.h
+++ b/source/fuzz/fuzzer_pass_make_vector_operations_dynamic.h
@@ -27,7 +27,8 @@ class FuzzerPassMakeVectorOperationsDynamic : public FuzzerPass {
   FuzzerPassMakeVectorOperationsDynamic(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_merge_blocks.cpp
+++ b/source/fuzz/fuzzer_pass_merge_blocks.cpp
@@ -24,9 +24,10 @@ namespace fuzz {
 FuzzerPassMergeBlocks::FuzzerPassMergeBlocks(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassMergeBlocks::Apply() {
   // First we populate a sequence of transformations that we might consider

--- a/source/fuzz/fuzzer_pass_merge_blocks.h
+++ b/source/fuzz/fuzzer_pass_merge_blocks.h
@@ -26,7 +26,8 @@ class FuzzerPassMergeBlocks : public FuzzerPass {
   FuzzerPassMergeBlocks(opt::IRContext* ir_context,
                         TransformationContext* transformation_context,
                         FuzzerContext* fuzzer_context,
-                        protobufs::TransformationSequence* transformations);
+                        protobufs::TransformationSequence* transformations,
+                        bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_merge_function_returns.cpp
+++ b/source/fuzz/fuzzer_pass_merge_function_returns.cpp
@@ -26,9 +26,10 @@ namespace fuzz {
 FuzzerPassMergeFunctionReturns::FuzzerPassMergeFunctionReturns(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassMergeFunctionReturns::Apply() {
   // The pass might add new functions to the module (due to wrapping early

--- a/source/fuzz/fuzzer_pass_merge_function_returns.h
+++ b/source/fuzz/fuzzer_pass_merge_function_returns.h
@@ -31,7 +31,8 @@ class FuzzerPassMergeFunctionReturns : public FuzzerPass {
   FuzzerPassMergeFunctionReturns(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 

--- a/source/fuzz/fuzzer_pass_mutate_pointers.cpp
+++ b/source/fuzz/fuzzer_pass_mutate_pointers.cpp
@@ -24,9 +24,10 @@ namespace fuzz {
 FuzzerPassMutatePointers::FuzzerPassMutatePointers(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassMutatePointers::Apply() {
   ForEachInstructionWithInstructionDescriptor(

--- a/source/fuzz/fuzzer_pass_mutate_pointers.h
+++ b/source/fuzz/fuzzer_pass_mutate_pointers.h
@@ -26,7 +26,8 @@ class FuzzerPassMutatePointers : public FuzzerPass {
   FuzzerPassMutatePointers(opt::IRContext* ir_context,
                            TransformationContext* transformation_context,
                            FuzzerContext* fuzzer_context,
-                           protobufs::TransformationSequence* transformations);
+                           protobufs::TransformationSequence* transformations,
+                           bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_obfuscate_constants.cpp
+++ b/source/fuzz/fuzzer_pass_obfuscate_constants.cpp
@@ -30,9 +30,10 @@ namespace fuzz {
 FuzzerPassObfuscateConstants::FuzzerPassObfuscateConstants(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassObfuscateConstants::ObfuscateBoolConstantViaConstantPair(
     uint32_t depth, const protobufs::IdUseDescriptor& bool_constant_use,

--- a/source/fuzz/fuzzer_pass_obfuscate_constants.h
+++ b/source/fuzz/fuzzer_pass_obfuscate_constants.h
@@ -30,7 +30,8 @@ class FuzzerPassObfuscateConstants : public FuzzerPass {
   FuzzerPassObfuscateConstants(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 

--- a/source/fuzz/fuzzer_pass_outline_functions.cpp
+++ b/source/fuzz/fuzzer_pass_outline_functions.cpp
@@ -27,9 +27,10 @@ namespace fuzz {
 FuzzerPassOutlineFunctions::FuzzerPassOutlineFunctions(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassOutlineFunctions::Apply() {
   std::vector<opt::Function*> original_functions;

--- a/source/fuzz/fuzzer_pass_outline_functions.h
+++ b/source/fuzz/fuzzer_pass_outline_functions.h
@@ -24,10 +24,11 @@ namespace fuzz {
 // flow graph into their own functions.
 class FuzzerPassOutlineFunctions : public FuzzerPass {
  public:
-  FuzzerPassOutlineFunctions(
-      opt::IRContext* ir_context, TransformationContext* transformation_context,
-      FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+  FuzzerPassOutlineFunctions(opt::IRContext* ir_context,
+                             TransformationContext* transformation_context,
+                             FuzzerContext* fuzzer_context,
+                             protobufs::TransformationSequence* transformations,
+                             bool ignore_inapplicable_transformations);
 
   void Apply() override;
 

--- a/source/fuzz/fuzzer_pass_permute_blocks.cpp
+++ b/source/fuzz/fuzzer_pass_permute_blocks.cpp
@@ -22,9 +22,10 @@ namespace fuzz {
 FuzzerPassPermuteBlocks::FuzzerPassPermuteBlocks(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassPermuteBlocks::Apply() {
   // For now we do something very simple: we randomly decide whether to move a

--- a/source/fuzz/fuzzer_pass_permute_blocks.h
+++ b/source/fuzz/fuzzer_pass_permute_blocks.h
@@ -27,7 +27,8 @@ class FuzzerPassPermuteBlocks : public FuzzerPass {
   FuzzerPassPermuteBlocks(opt::IRContext* ir_context,
                           TransformationContext* transformation_context,
                           FuzzerContext* fuzzer_context,
-                          protobufs::TransformationSequence* transformations);
+                          protobufs::TransformationSequence* transformations,
+                          bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_permute_function_parameters.cpp
+++ b/source/fuzz/fuzzer_pass_permute_function_parameters.cpp
@@ -28,9 +28,10 @@ namespace fuzz {
 FuzzerPassPermuteFunctionParameters::FuzzerPassPermuteFunctionParameters(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassPermuteFunctionParameters::Apply() {
   for (const auto& function : *GetIRContext()->module()) {

--- a/source/fuzz/fuzzer_pass_permute_function_parameters.h
+++ b/source/fuzz/fuzzer_pass_permute_function_parameters.h
@@ -32,7 +32,8 @@ class FuzzerPassPermuteFunctionParameters : public FuzzerPass {
   FuzzerPassPermuteFunctionParameters(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_permute_function_variables.cpp
+++ b/source/fuzz/fuzzer_pass_permute_function_variables.cpp
@@ -29,9 +29,11 @@ namespace fuzz {
 FuzzerPassPermuteFunctionVariables::FuzzerPassPermuteFunctionVariables(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}  // Here we call parent constructor.
+                 transformations, ignore_inapplicable_transformations) {
+}  // Here we call parent constructor.
 
 void FuzzerPassPermuteFunctionVariables::Apply() {
   // Permuting OpVariable instructions in each function.

--- a/source/fuzz/fuzzer_pass_permute_function_variables.h
+++ b/source/fuzz/fuzzer_pass_permute_function_variables.h
@@ -26,7 +26,8 @@ class FuzzerPassPermuteFunctionVariables : public FuzzerPass {
   FuzzerPassPermuteFunctionVariables(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_permute_instructions.cpp
+++ b/source/fuzz/fuzzer_pass_permute_instructions.cpp
@@ -25,9 +25,10 @@ namespace fuzz {
 FuzzerPassPermuteInstructions::FuzzerPassPermuteInstructions(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassPermuteInstructions::Apply() {
   // We are iterating over all instructions in all basic blocks.

--- a/source/fuzz/fuzzer_pass_permute_instructions.h
+++ b/source/fuzz/fuzzer_pass_permute_instructions.h
@@ -27,7 +27,8 @@ class FuzzerPassPermuteInstructions : public FuzzerPass {
   FuzzerPassPermuteInstructions(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_permute_phi_operands.cpp
+++ b/source/fuzz/fuzzer_pass_permute_phi_operands.cpp
@@ -28,9 +28,10 @@ namespace fuzz {
 FuzzerPassPermutePhiOperands::FuzzerPassPermutePhiOperands(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassPermutePhiOperands::Apply() {
   ForEachInstructionWithInstructionDescriptor(

--- a/source/fuzz/fuzzer_pass_permute_phi_operands.h
+++ b/source/fuzz/fuzzer_pass_permute_phi_operands.h
@@ -27,7 +27,8 @@ class FuzzerPassPermutePhiOperands : public FuzzerPass {
   FuzzerPassPermutePhiOperands(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_propagate_instructions_down.cpp
+++ b/source/fuzz/fuzzer_pass_propagate_instructions_down.cpp
@@ -23,9 +23,10 @@ namespace fuzz {
 FuzzerPassPropagateInstructionsDown::FuzzerPassPropagateInstructionsDown(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassPropagateInstructionsDown::Apply() {
   for (const auto& function : *GetIRContext()->module()) {

--- a/source/fuzz/fuzzer_pass_propagate_instructions_down.h
+++ b/source/fuzz/fuzzer_pass_propagate_instructions_down.h
@@ -26,7 +26,8 @@ class FuzzerPassPropagateInstructionsDown : public FuzzerPass {
   FuzzerPassPropagateInstructionsDown(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_propagate_instructions_up.cpp
+++ b/source/fuzz/fuzzer_pass_propagate_instructions_up.cpp
@@ -25,9 +25,10 @@ namespace fuzz {
 FuzzerPassPropagateInstructionsUp::FuzzerPassPropagateInstructionsUp(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassPropagateInstructionsUp::Apply() {
   for (const auto& function : *GetIRContext()->module()) {

--- a/source/fuzz/fuzzer_pass_propagate_instructions_up.h
+++ b/source/fuzz/fuzzer_pass_propagate_instructions_up.h
@@ -27,7 +27,8 @@ class FuzzerPassPropagateInstructionsUp : public FuzzerPass {
   FuzzerPassPropagateInstructionsUp(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_push_ids_through_variables.cpp
+++ b/source/fuzz/fuzzer_pass_push_ids_through_variables.cpp
@@ -24,9 +24,10 @@ namespace fuzz {
 FuzzerPassPushIdsThroughVariables::FuzzerPassPushIdsThroughVariables(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassPushIdsThroughVariables::Apply() {
   ForEachInstructionWithInstructionDescriptor(

--- a/source/fuzz/fuzzer_pass_push_ids_through_variables.h
+++ b/source/fuzz/fuzzer_pass_push_ids_through_variables.h
@@ -28,7 +28,8 @@ class FuzzerPassPushIdsThroughVariables : public FuzzerPass {
   FuzzerPassPushIdsThroughVariables(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_replace_adds_subs_muls_with_carrying_extended.cpp
+++ b/source/fuzz/fuzzer_pass_replace_adds_subs_muls_with_carrying_extended.cpp
@@ -29,9 +29,10 @@ FuzzerPassReplaceAddsSubsMulsWithCarryingExtended::
         opt::IRContext* ir_context,
         TransformationContext* transformation_context,
         FuzzerContext* fuzzer_context,
-        protobufs::TransformationSequence* transformations)
+        protobufs::TransformationSequence* transformations,
+        bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassReplaceAddsSubsMulsWithCarryingExtended::Apply() {
   std::vector<opt::Instruction> instructions_for_transformation;

--- a/source/fuzz/fuzzer_pass_replace_adds_subs_muls_with_carrying_extended.h
+++ b/source/fuzz/fuzzer_pass_replace_adds_subs_muls_with_carrying_extended.h
@@ -29,7 +29,8 @@ class FuzzerPassReplaceAddsSubsMulsWithCarryingExtended : public FuzzerPass {
   FuzzerPassReplaceAddsSubsMulsWithCarryingExtended(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_replace_branches_from_dead_blocks_with_exits.cpp
+++ b/source/fuzz/fuzzer_pass_replace_branches_from_dead_blocks_with_exits.cpp
@@ -28,9 +28,10 @@ FuzzerPassReplaceBranchesFromDeadBlocksWithExits::
         opt::IRContext* ir_context,
         TransformationContext* transformation_context,
         FuzzerContext* fuzzer_context,
-        protobufs::TransformationSequence* transformations)
+        protobufs::TransformationSequence* transformations,
+        bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassReplaceBranchesFromDeadBlocksWithExits::Apply() {
   // OpKill can only be used as a terminator in a function that is guaranteed

--- a/source/fuzz/fuzzer_pass_replace_branches_from_dead_blocks_with_exits.h
+++ b/source/fuzz/fuzzer_pass_replace_branches_from_dead_blocks_with_exits.h
@@ -28,7 +28,8 @@ class FuzzerPassReplaceBranchesFromDeadBlocksWithExits : public FuzzerPass {
   FuzzerPassReplaceBranchesFromDeadBlocksWithExits(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_replace_copy_memories_with_loads_stores.cpp
+++ b/source/fuzz/fuzzer_pass_replace_copy_memories_with_loads_stores.cpp
@@ -26,9 +26,10 @@ FuzzerPassReplaceCopyMemoriesWithLoadsStores::
         opt::IRContext* ir_context,
         TransformationContext* transformation_context,
         FuzzerContext* fuzzer_context,
-        protobufs::TransformationSequence* transformations)
+        protobufs::TransformationSequence* transformations,
+        bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassReplaceCopyMemoriesWithLoadsStores::Apply() {
   GetIRContext()->module()->ForEachInst([this](opt::Instruction* instruction) {

--- a/source/fuzz/fuzzer_pass_replace_copy_memories_with_loads_stores.h
+++ b/source/fuzz/fuzzer_pass_replace_copy_memories_with_loads_stores.h
@@ -28,7 +28,8 @@ class FuzzerPassReplaceCopyMemoriesWithLoadsStores : public FuzzerPass {
   FuzzerPassReplaceCopyMemoriesWithLoadsStores(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_replace_copy_objects_with_stores_loads.cpp
+++ b/source/fuzz/fuzzer_pass_replace_copy_objects_with_stores_loads.cpp
@@ -26,9 +26,10 @@ FuzzerPassReplaceCopyObjectsWithStoresLoads::
         opt::IRContext* ir_context,
         TransformationContext* transformation_context,
         FuzzerContext* fuzzer_context,
-        protobufs::TransformationSequence* transformations)
+        protobufs::TransformationSequence* transformations,
+        bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassReplaceCopyObjectsWithStoresLoads::Apply() {
   GetIRContext()->module()->ForEachInst([this](opt::Instruction* instruction) {

--- a/source/fuzz/fuzzer_pass_replace_copy_objects_with_stores_loads.h
+++ b/source/fuzz/fuzzer_pass_replace_copy_objects_with_stores_loads.h
@@ -28,7 +28,8 @@ class FuzzerPassReplaceCopyObjectsWithStoresLoads : public FuzzerPass {
   FuzzerPassReplaceCopyObjectsWithStoresLoads(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_replace_irrelevant_ids.cpp
+++ b/source/fuzz/fuzzer_pass_replace_irrelevant_ids.cpp
@@ -27,9 +27,10 @@ namespace fuzz {
 FuzzerPassReplaceIrrelevantIds::FuzzerPassReplaceIrrelevantIds(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassReplaceIrrelevantIds::Apply() {
   // Keep track of the irrelevant ids. This includes all the ids that are

--- a/source/fuzz/fuzzer_pass_replace_irrelevant_ids.h
+++ b/source/fuzz/fuzzer_pass_replace_irrelevant_ids.h
@@ -28,7 +28,8 @@ class FuzzerPassReplaceIrrelevantIds : public FuzzerPass {
   FuzzerPassReplaceIrrelevantIds(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_replace_linear_algebra_instructions.cpp
+++ b/source/fuzz/fuzzer_pass_replace_linear_algebra_instructions.cpp
@@ -26,9 +26,10 @@ FuzzerPassReplaceLinearAlgebraInstructions::
         opt::IRContext* ir_context,
         TransformationContext* transformation_context,
         FuzzerContext* fuzzer_context,
-        protobufs::TransformationSequence* transformations)
+        protobufs::TransformationSequence* transformations,
+        bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassReplaceLinearAlgebraInstructions::Apply() {
   // For each instruction, checks whether it is a linear algebra instruction. In

--- a/source/fuzz/fuzzer_pass_replace_linear_algebra_instructions.h
+++ b/source/fuzz/fuzzer_pass_replace_linear_algebra_instructions.h
@@ -27,7 +27,8 @@ class FuzzerPassReplaceLinearAlgebraInstructions : public FuzzerPass {
   FuzzerPassReplaceLinearAlgebraInstructions(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_replace_loads_stores_with_copy_memories.cpp
+++ b/source/fuzz/fuzzer_pass_replace_loads_stores_with_copy_memories.cpp
@@ -27,9 +27,10 @@ FuzzerPassReplaceLoadsStoresWithCopyMemories::
         opt::IRContext* ir_context,
         TransformationContext* transformation_context,
         FuzzerContext* fuzzer_context,
-        protobufs::TransformationSequence* transformations)
+        protobufs::TransformationSequence* transformations,
+        bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassReplaceLoadsStoresWithCopyMemories::Apply() {
   // We look for matching pairs of instructions OpLoad and

--- a/source/fuzz/fuzzer_pass_replace_loads_stores_with_copy_memories.h
+++ b/source/fuzz/fuzzer_pass_replace_loads_stores_with_copy_memories.h
@@ -28,7 +28,8 @@ class FuzzerPassReplaceLoadsStoresWithCopyMemories : public FuzzerPass {
   FuzzerPassReplaceLoadsStoresWithCopyMemories(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_replace_opphi_ids_from_dead_predecessors.cpp
+++ b/source/fuzz/fuzzer_pass_replace_opphi_ids_from_dead_predecessors.cpp
@@ -24,9 +24,10 @@ FuzzerPassReplaceOpPhiIdsFromDeadPredecessors::
         opt::IRContext* ir_context,
         TransformationContext* transformation_context,
         FuzzerContext* fuzzer_context,
-        protobufs::TransformationSequence* transformations)
+        protobufs::TransformationSequence* transformations,
+        bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassReplaceOpPhiIdsFromDeadPredecessors::Apply() {
   // Keep a vector of the transformations to apply.

--- a/source/fuzz/fuzzer_pass_replace_opphi_ids_from_dead_predecessors.h
+++ b/source/fuzz/fuzzer_pass_replace_opphi_ids_from_dead_predecessors.h
@@ -27,7 +27,8 @@ class FuzzerPassReplaceOpPhiIdsFromDeadPredecessors : public FuzzerPass {
   FuzzerPassReplaceOpPhiIdsFromDeadPredecessors(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.cpp
+++ b/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.cpp
@@ -27,9 +27,10 @@ FuzzerPassReplaceOpSelectsWithConditionalBranches::
         opt::IRContext* ir_context,
         TransformationContext* transformation_context,
         FuzzerContext* fuzzer_context,
-        protobufs::TransformationSequence* transformations)
+        protobufs::TransformationSequence* transformations,
+        bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassReplaceOpSelectsWithConditionalBranches::Apply() {
   // Keep track of the instructions that we want to replace. We need to collect

--- a/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.h
+++ b/source/fuzz/fuzzer_pass_replace_opselects_with_conditional_branches.h
@@ -27,7 +27,8 @@ class FuzzerPassReplaceOpSelectsWithConditionalBranches : public FuzzerPass {
   FuzzerPassReplaceOpSelectsWithConditionalBranches(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 

--- a/source/fuzz/fuzzer_pass_replace_parameter_with_global.cpp
+++ b/source/fuzz/fuzzer_pass_replace_parameter_with_global.cpp
@@ -27,9 +27,10 @@ namespace fuzz {
 FuzzerPassReplaceParameterWithGlobal::FuzzerPassReplaceParameterWithGlobal(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassReplaceParameterWithGlobal::Apply() {
   for (const auto& function : *GetIRContext()->module()) {

--- a/source/fuzz/fuzzer_pass_replace_parameter_with_global.h
+++ b/source/fuzz/fuzzer_pass_replace_parameter_with_global.h
@@ -27,7 +27,8 @@ class FuzzerPassReplaceParameterWithGlobal : public FuzzerPass {
   FuzzerPassReplaceParameterWithGlobal(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_replace_params_with_struct.cpp
+++ b/source/fuzz/fuzzer_pass_replace_params_with_struct.cpp
@@ -27,9 +27,10 @@ namespace fuzz {
 FuzzerPassReplaceParamsWithStruct::FuzzerPassReplaceParamsWithStruct(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassReplaceParamsWithStruct::Apply() {
   for (const auto& function : *GetIRContext()->module()) {

--- a/source/fuzz/fuzzer_pass_replace_params_with_struct.h
+++ b/source/fuzz/fuzzer_pass_replace_params_with_struct.h
@@ -27,7 +27,8 @@ class FuzzerPassReplaceParamsWithStruct : public FuzzerPass {
   FuzzerPassReplaceParamsWithStruct(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_split_blocks.cpp
+++ b/source/fuzz/fuzzer_pass_split_blocks.cpp
@@ -25,9 +25,10 @@ namespace fuzz {
 FuzzerPassSplitBlocks::FuzzerPassSplitBlocks(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassSplitBlocks::Apply() {
   // Gather up pointers to all the blocks in the module.  We are then able to

--- a/source/fuzz/fuzzer_pass_split_blocks.h
+++ b/source/fuzz/fuzzer_pass_split_blocks.h
@@ -27,7 +27,8 @@ class FuzzerPassSplitBlocks : public FuzzerPass {
   FuzzerPassSplitBlocks(opt::IRContext* ir_context,
                         TransformationContext* transformation_context,
                         FuzzerContext* fuzzer_context,
-                        protobufs::TransformationSequence* transformations);
+                        protobufs::TransformationSequence* transformations,
+                        bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_swap_commutable_operands.cpp
+++ b/source/fuzz/fuzzer_pass_swap_commutable_operands.cpp
@@ -24,9 +24,10 @@ namespace fuzz {
 FuzzerPassSwapCommutableOperands::FuzzerPassSwapCommutableOperands(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassSwapCommutableOperands::Apply() {
   auto context = GetIRContext();

--- a/source/fuzz/fuzzer_pass_swap_commutable_operands.h
+++ b/source/fuzz/fuzzer_pass_swap_commutable_operands.h
@@ -28,7 +28,8 @@ class FuzzerPassSwapCommutableOperands : public FuzzerPass {
   FuzzerPassSwapCommutableOperands(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_swap_conditional_branch_operands.cpp
+++ b/source/fuzz/fuzzer_pass_swap_conditional_branch_operands.cpp
@@ -27,9 +27,10 @@ FuzzerPassSwapBranchConditionalOperands::
         opt::IRContext* ir_context,
         TransformationContext* transformation_context,
         FuzzerContext* fuzzer_context,
-        protobufs::TransformationSequence* transformations)
+        protobufs::TransformationSequence* transformations,
+        bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassSwapBranchConditionalOperands::Apply() {
   ForEachInstructionWithInstructionDescriptor(

--- a/source/fuzz/fuzzer_pass_swap_conditional_branch_operands.h
+++ b/source/fuzz/fuzzer_pass_swap_conditional_branch_operands.h
@@ -27,7 +27,8 @@ class FuzzerPassSwapBranchConditionalOperands : public FuzzerPass {
   FuzzerPassSwapBranchConditionalOperands(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_swap_functions.cpp
+++ b/source/fuzz/fuzzer_pass_swap_functions.cpp
@@ -23,9 +23,10 @@ namespace fuzz {
 FuzzerPassSwapFunctions::FuzzerPassSwapFunctions(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassSwapFunctions::Apply() {
   // Collect all function ids in a module.

--- a/source/fuzz/fuzzer_pass_swap_functions.h
+++ b/source/fuzz/fuzzer_pass_swap_functions.h
@@ -26,7 +26,8 @@ class FuzzerPassSwapFunctions : public FuzzerPass {
   FuzzerPassSwapFunctions(opt::IRContext* ir_context,
                           TransformationContext* transformation_context,
                           FuzzerContext* fuzzer_context,
-                          protobufs::TransformationSequence* transformations);
+                          protobufs::TransformationSequence* transformations,
+                          bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_toggle_access_chain_instruction.cpp
+++ b/source/fuzz/fuzzer_pass_toggle_access_chain_instruction.cpp
@@ -24,9 +24,10 @@ namespace fuzz {
 FuzzerPassToggleAccessChainInstruction::FuzzerPassToggleAccessChainInstruction(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassToggleAccessChainInstruction::Apply() {
   auto context = GetIRContext();

--- a/source/fuzz/fuzzer_pass_toggle_access_chain_instruction.h
+++ b/source/fuzz/fuzzer_pass_toggle_access_chain_instruction.h
@@ -27,7 +27,8 @@ class FuzzerPassToggleAccessChainInstruction : public FuzzerPass {
   FuzzerPassToggleAccessChainInstruction(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/source/fuzz/fuzzer_pass_wrap_regions_in_selections.cpp
+++ b/source/fuzz/fuzzer_pass_wrap_regions_in_selections.cpp
@@ -25,9 +25,10 @@ namespace fuzz {
 FuzzerPassWrapRegionsInSelections::FuzzerPassWrapRegionsInSelections(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassWrapRegionsInSelections::Apply() {
   for (auto& function : *GetIRContext()->module()) {

--- a/source/fuzz/fuzzer_pass_wrap_regions_in_selections.h
+++ b/source/fuzz/fuzzer_pass_wrap_regions_in_selections.h
@@ -27,7 +27,8 @@ class FuzzerPassWrapRegionsInSelections : public FuzzerPass {
   FuzzerPassWrapRegionsInSelections(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 

--- a/source/fuzz/fuzzer_pass_wrap_vector_synonym.cpp
+++ b/source/fuzz/fuzzer_pass_wrap_vector_synonym.cpp
@@ -24,9 +24,10 @@ namespace fuzz {
 FuzzerPassWrapVectorSynonym::FuzzerPassWrapVectorSynonym(
     opt::IRContext* ir_context, TransformationContext* transformation_context,
     FuzzerContext* fuzzer_context,
-    protobufs::TransformationSequence* transformations)
+    protobufs::TransformationSequence* transformations,
+    bool ignore_inapplicable_transformations)
     : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                 transformations) {}
+                 transformations, ignore_inapplicable_transformations) {}
 
 void FuzzerPassWrapVectorSynonym::Apply() {
   ForEachInstructionWithInstructionDescriptor(

--- a/source/fuzz/fuzzer_pass_wrap_vector_synonym.h
+++ b/source/fuzz/fuzzer_pass_wrap_vector_synonym.h
@@ -26,7 +26,8 @@ class FuzzerPassWrapVectorSynonym : public FuzzerPass {
   FuzzerPassWrapVectorSynonym(
       opt::IRContext* ir_context, TransformationContext* transformation_context,
       FuzzerContext* fuzzer_context,
-      protobufs::TransformationSequence* transformations);
+      protobufs::TransformationSequence* transformations,
+      bool ignore_inapplicable_transformations);
 
   void Apply() override;
 };

--- a/test/fuzz/fuzzer_pass_add_opphi_synonyms_test.cpp
+++ b/test/fuzz/fuzzer_pass_add_opphi_synonyms_test.cpp
@@ -134,7 +134,7 @@ TEST(FuzzerPassAddOpPhiSynonymsTest, HelperFunctions) {
 
   FuzzerPassAddOpPhiSynonyms fuzzer_pass(context.get(), &transformation_context,
                                          &fuzzer_context,
-                                         &transformation_sequence);
+                                         &transformation_sequence, false);
 
   SetUpIdSynonyms(transformation_context.GetFactManager());
 

--- a/test/fuzz/fuzzer_pass_construct_composites_test.cpp
+++ b/test/fuzz/fuzzer_pass_construct_composites_test.cpp
@@ -92,7 +92,7 @@ TEST(FuzzerPassConstructCompositesTest, IsomorphicStructs) {
 
     FuzzerPassConstructComposites fuzzer_pass(
         context.get(), &transformation_context, &fuzzer_context,
-        &transformation_sequence);
+        &transformation_sequence, false);
 
     fuzzer_pass.Apply();
 
@@ -173,7 +173,7 @@ TEST(FuzzerPassConstructCompositesTest, IsomorphicArrays) {
 
     FuzzerPassConstructComposites fuzzer_pass(
         context.get(), &transformation_context, &fuzzer_context,
-        &transformation_sequence);
+        &transformation_sequence, false);
 
     fuzzer_pass.Apply();
 

--- a/test/fuzz/fuzzer_pass_donate_modules_test.cpp
+++ b/test/fuzz/fuzzer_pass_donate_modules_test.cpp
@@ -210,7 +210,7 @@ TEST(FuzzerPassDonateModulesTest, BasicDonation) {
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
                                       &transformation_context, &fuzzer_context,
-                                      &transformation_sequence, {});
+                                      &transformation_sequence, false, {});
 
   fuzzer_pass.DonateSingleModule(donor_context.get(), false);
 
@@ -291,7 +291,7 @@ TEST(FuzzerPassDonateModulesTest, DonationWithUniforms) {
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
                                       &transformation_context, &fuzzer_context,
-                                      &transformation_sequence, {});
+                                      &transformation_sequence, false, {});
 
   fuzzer_pass.DonateSingleModule(donor_context.get(), false);
 
@@ -422,7 +422,7 @@ TEST(FuzzerPassDonateModulesTest, DonationWithInputAndOutputVariables) {
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
                                       &transformation_context, &fuzzer_context,
-                                      &transformation_sequence, {});
+                                      &transformation_sequence, false, {});
 
   fuzzer_pass.DonateSingleModule(donor_context.get(), false);
 
@@ -517,7 +517,7 @@ TEST(FuzzerPassDonateModulesTest, DonateFunctionTypeWithDifferentPointers) {
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
                                       &transformation_context, &fuzzer_context,
-                                      &transformation_sequence, {});
+                                      &transformation_sequence, false, {});
 
   fuzzer_pass.DonateSingleModule(donor_context.get(), false);
 
@@ -589,7 +589,7 @@ TEST(FuzzerPassDonateModulesTest, DonateOpConstantNull) {
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
                                       &transformation_context, &fuzzer_context,
-                                      &transformation_sequence, {});
+                                      &transformation_sequence, false, {});
 
   fuzzer_pass.DonateSingleModule(donor_context.get(), false);
 
@@ -717,7 +717,7 @@ TEST(FuzzerPassDonateModulesTest, DonateCodeThatUsesImages) {
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
                                       &transformation_context, &fuzzer_context,
-                                      &transformation_sequence, {});
+                                      &transformation_sequence, false, {});
 
   fuzzer_pass.DonateSingleModule(donor_context.get(), false);
 
@@ -813,7 +813,7 @@ TEST(FuzzerPassDonateModulesTest, DonateCodeThatUsesSampler) {
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
                                       &transformation_context, &fuzzer_context,
-                                      &transformation_sequence, {});
+                                      &transformation_sequence, false, {});
 
   fuzzer_pass.DonateSingleModule(donor_context.get(), false);
 
@@ -945,7 +945,7 @@ TEST(FuzzerPassDonateModulesTest, DonateCodeThatUsesImageStructField) {
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
                                       &transformation_context, &fuzzer_context,
-                                      &transformation_sequence, {});
+                                      &transformation_sequence, false, {});
 
   fuzzer_pass.DonateSingleModule(donor_context.get(), false);
 
@@ -1081,7 +1081,7 @@ TEST(FuzzerPassDonateModulesTest, DonateCodeThatUsesImageFunctionParameter) {
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
                                       &transformation_context, &fuzzer_context,
-                                      &transformation_sequence, {});
+                                      &transformation_sequence, false, {});
 
   fuzzer_pass.DonateSingleModule(donor_context.get(), false);
 
@@ -1163,7 +1163,7 @@ TEST(FuzzerPassDonateModulesTest, DonateShaderWithImageStorageClass) {
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
                                       &transformation_context, &fuzzer_context,
-                                      &transformation_sequence, {});
+                                      &transformation_sequence, false, {});
 
   fuzzer_pass.DonateSingleModule(donor_context.get(), true);
 
@@ -1250,7 +1250,7 @@ TEST(FuzzerPassDonateModulesTest, DonateComputeShaderWithRuntimeArray) {
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
                                       &transformation_context, &fuzzer_context,
-                                      &transformation_sequence, {});
+                                      &transformation_sequence, false, {});
 
   fuzzer_pass.DonateSingleModule(donor_context.get(), false);
 
@@ -1354,7 +1354,7 @@ TEST(FuzzerPassDonateModulesTest, DonateComputeShaderWithRuntimeArrayLivesafe) {
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
                                       &transformation_context, &fuzzer_context,
-                                      &transformation_sequence, {});
+                                      &transformation_sequence, false, {});
 
   fuzzer_pass.DonateSingleModule(donor_context.get(), true);
 
@@ -1426,7 +1426,7 @@ TEST(FuzzerPassDonateModulesTest, DonateComputeShaderWithWorkgroupVariables) {
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
                                       &transformation_context, &fuzzer_context,
-                                      &transformation_sequence, {});
+                                      &transformation_sequence, false, {});
 
   fuzzer_pass.DonateSingleModule(donor_context.get(), true);
 
@@ -1536,7 +1536,7 @@ TEST(FuzzerPassDonateModulesTest, DonateComputeShaderWithAtomics) {
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
                                       &transformation_context, &fuzzer_context,
-                                      &transformation_sequence, {});
+                                      &transformation_sequence, false, {});
 
   fuzzer_pass.DonateSingleModule(donor_context.get(), true);
 
@@ -1720,7 +1720,7 @@ TEST(FuzzerPassDonateModulesTest, Miscellaneous1) {
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
                                       &transformation_context, &fuzzer_context,
-                                      &transformation_sequence, {});
+                                      &transformation_sequence, false, {});
 
   fuzzer_pass.DonateSingleModule(donor_context.get(), false);
 
@@ -1792,7 +1792,7 @@ TEST(FuzzerPassDonateModulesTest, OpSpecConstantInstructions) {
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
                                       &transformation_context, &fuzzer_context,
-                                      &transformation_sequence, {});
+                                      &transformation_sequence, false, {});
 
   fuzzer_pass.DonateSingleModule(donor_context.get(), false);
 
@@ -1949,7 +1949,7 @@ TEST(FuzzerPassDonateModulesTest, DonationSupportsOpTypeRuntimeArray) {
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
                                       &transformation_context, &fuzzer_context,
-                                      &transformation_sequence, {});
+                                      &transformation_sequence, false, {});
 
   fuzzer_pass.DonateSingleModule(donor_context.get(), false);
 
@@ -2022,7 +2022,7 @@ TEST(FuzzerPassDonateModulesTest, HandlesCapabilities) {
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
                                       &transformation_context, &fuzzer_context,
-                                      &transformation_sequence, {});
+                                      &transformation_sequence, false, {});
 
   ASSERT_TRUE(donor_context->get_feature_mgr()->HasCapability(
       SpvCapabilityVariablePointersStorageBuffer));
@@ -2255,7 +2255,7 @@ TEST(FuzzerPassDonateModulesTest, HandlesOpPhisInMergeBlock) {
 
   FuzzerPassDonateModules fuzzer_pass(recipient_context.get(),
                                       &transformation_context, &fuzzer_context,
-                                      &transformation_sequence, {});
+                                      &transformation_sequence, false, {});
 
   fuzzer_pass.DonateSingleModule(donor_context.get(), true);
 

--- a/test/fuzz/fuzzer_pass_outline_functions_test.cpp
+++ b/test/fuzz/fuzzer_pass_outline_functions_test.cpp
@@ -130,7 +130,7 @@ TEST(FuzzerPassOutlineFunctionsTest, EntryIsAlreadySuitable) {
 
   FuzzerPassOutlineFunctions fuzzer_pass(context.get(), &transformation_context,
                                          &fuzzer_context,
-                                         &transformation_sequence);
+                                         &transformation_sequence, false);
 
   // Block 28
   auto suitable_entry_block =
@@ -173,7 +173,7 @@ TEST(FuzzerPassOutlineFunctionsTest, EntryHasOpVariable) {
 
   FuzzerPassOutlineFunctions fuzzer_pass(context.get(), &transformation_context,
                                          &fuzzer_context,
-                                         &transformation_sequence);
+                                         &transformation_sequence, false);
 
   // Block 20
   auto suitable_entry_block =
@@ -297,7 +297,7 @@ TEST(FuzzerPassOutlineFunctionsTest, EntryBlockIsHeader) {
 
   FuzzerPassOutlineFunctions fuzzer_pass(context.get(), &transformation_context,
                                          &fuzzer_context,
-                                         &transformation_sequence);
+                                         &transformation_sequence, false);
 
   // Block 21
   auto suitable_entry_block =
@@ -464,7 +464,7 @@ TEST(FuzzerPassOutlineFunctionsTest, ExitBlock) {
 
   FuzzerPassOutlineFunctions fuzzer_pass(context.get(), &transformation_context,
                                          &fuzzer_context,
-                                         &transformation_sequence);
+                                         &transformation_sequence, false);
 
   // Block 39 is not a merge block, so it is already suitable.
   auto suitable_exit_block = fuzzer_pass.MaybeGetExitBlockSuitableForOutlining(

--- a/test/fuzz/fuzzer_pass_test.cpp
+++ b/test/fuzz/fuzzer_pass_test.cpp
@@ -29,7 +29,7 @@ class FuzzerPassMock : public FuzzerPass {
                  FuzzerContext* fuzzer_context,
                  protobufs::TransformationSequence* transformations)
       : FuzzerPass(ir_context, transformation_context, fuzzer_context,
-                   transformations) {}
+                   transformations, false) {}
 
   ~FuzzerPassMock() override = default;
 

--- a/test/fuzz/fuzzer_replayer_test.cpp
+++ b/test/fuzz/fuzzer_replayer_test.cpp
@@ -1668,7 +1668,7 @@ void RunFuzzerAndReplayer(const std::string& shader,
     Fuzzer fuzzer(std::move(ir_context), std::move(transformation_context),
                   std::move(fuzzer_context), kConsoleMessageConsumer,
                   donor_suppliers, enable_all_passes,
-                  strategies[strategy_index], true, validator_options);
+                  strategies[strategy_index], true, validator_options, false);
     auto fuzzer_result = fuzzer.Run(0);
 
     // Cycle the repeated pass strategy so that we try a different one next time

--- a/test/fuzz/fuzzer_shrinker_test.cpp
+++ b/test/fuzz/fuzzer_shrinker_test.cpp
@@ -1068,7 +1068,7 @@ void RunFuzzerAndShrinker(const std::string& shader,
   Fuzzer fuzzer(std::move(ir_context), std::move(transformation_context),
                 std::move(fuzzer_context), kConsoleMessageConsumer,
                 donor_suppliers, enable_all_passes, repeated_pass_strategy,
-                true, validator_options);
+                true, validator_options, false);
   auto fuzzer_result = fuzzer.Run(0);
   ASSERT_NE(Fuzzer::Status::kFuzzerPassLedToInvalidModule,
             fuzzer_result.status);

--- a/test/fuzz/shrinker_test.cpp
+++ b/test/fuzz/shrinker_test.cpp
@@ -171,7 +171,7 @@ TEST(ShrinkerTest, ReduceAddedFunctions) {
   protobufs::TransformationSequence transformations;
   FuzzerPassDonateModules pass(variant_ir_context.get(),
                                &transformation_context, &fuzzer_context,
-                               &transformations, {});
+                               &transformations, false, {});
   pass.DonateSingleModule(donor_ir_context.get(), true);
 
   protobufs::FactSequence no_facts;
@@ -349,7 +349,7 @@ TEST(ShrinkerTest, HitStepLimitWhenReducingAddedFunctions) {
   protobufs::TransformationSequence transformations;
   FuzzerPassDonateModules pass(variant_ir_context.get(),
                                &transformation_context, &fuzzer_context,
-                               &transformations, {});
+                               &transformations, false, {});
   pass.DonateSingleModule(donor_ir_context.get(), true);
 
   protobufs::FactSequence no_facts;

--- a/tools/fuzz/fuzz.cpp
+++ b/tools/fuzz/fuzz.cpp
@@ -630,7 +630,7 @@ bool Fuzz(const spv_target_env& target_env,
       std::move(ir_context), std::move(transformation_context),
       std::move(fuzzer_context), message_consumer, donor_suppliers,
       fuzzer_options->all_passes_enabled, repeated_pass_strategy,
-      fuzzer_options->fuzzer_pass_validation_enabled, validator_options);
+      fuzzer_options->fuzzer_pass_validation_enabled, validator_options, false);
   auto fuzz_result = fuzzer.Run(0);
   if (fuzz_result.status ==
       spvtools::fuzz::Fuzzer::Status::kFuzzerPassLedToInvalidModule) {


### PR DESCRIPTION
spirv-fuzz features transformations that should be applicable by
construction. Assertions are used to detect when such transformations
turn out to be inapplicable. Failures of such assertions indicate bugs
in the fuzzer. However, when using the fuzzer at scale (e.g. in
ClusterFuzz) reports of these assertion failures create noise, and
cause the fuzzer to exit early. This change adds an option whereby
inapplicable transformations can be ignored. This reduces noise and
allows fuzzing to continue even when a transformation that should be
applicable but is not has been erroneously created.