### PR TITLE
spirv-opt: Rename ControlDependenceAnalysis::DoesBlockExist to HasBlock

### DIFF
--- a/source/opt/control_dependence.h
+++ b/source/opt/control_dependence.h
@@ -156,9 +156,7 @@ class ControlDependenceAnalysis {
   // Returns true if the block |id| exists in the control dependence graph.
   // This can be false even if the block exists in the function when it is part
   // of an infinite loop, since it is not part of the post-dominator tree.
-  bool HasBlock(uint32_t id) const {
-    return forward_nodes_.count(id) > 0;
-  }
+  bool HasBlock(uint32_t id) const { return forward_nodes_.count(id) > 0; }
 
   // Returns true if block |a| is dependent on block |b|.
   bool IsDependent(uint32_t a, uint32_t b) const {

--- a/source/opt/control_dependence.h
+++ b/source/opt/control_dependence.h
@@ -156,13 +156,13 @@ class ControlDependenceAnalysis {
   // Returns true if the block |id| exists in the control dependence graph.
   // This can be false even if the block exists in the function when it is part
   // of an infinite loop, since it is not part of the post-dominator tree.
-  bool DoesBlockExist(uint32_t id) const {
+  bool HasBlock(uint32_t id) const {
     return forward_nodes_.count(id) > 0;
   }
 
   // Returns true if block |a| is dependent on block |b|.
   bool IsDependent(uint32_t a, uint32_t b) const {
-    if (!DoesBlockExist(a)) return false;
+    if (!HasBlock(a)) return false;
     // BBs tend to have more dependents (targets) than they are dependent on
     // (sources), so search sources.
     const ControlDependenceList& a_sources = GetDependenceSources(a);

--- a/test/opt/control_dependence.cpp
+++ b/test/opt/control_dependence.cpp
@@ -122,16 +122,16 @@ TEST(ControlDependenceTest, DependenceSimpleCFG) {
     ControlDependenceAnalysis cdg;
     cdg.ComputeControlDependenceGraph(cfg, pdom);
 
-    // Test DoesBlockExist.
+    // Test HasBlock.
     for (uint32_t id = 10; id <= 19; id++) {
-      EXPECT_TRUE(cdg.DoesBlockExist(id));
+      EXPECT_TRUE(cdg.HasBlock(id));
     }
     EXPECT_TRUE(
-        cdg.DoesBlockExist(ControlDependenceAnalysis::kPseudoEntryBlock));
+        cdg.HasBlock(ControlDependenceAnalysis::kPseudoEntryBlock));
     // Check blocks before/after valid range.
-    EXPECT_FALSE(cdg.DoesBlockExist(5));
-    EXPECT_FALSE(cdg.DoesBlockExist(25));
-    EXPECT_FALSE(cdg.DoesBlockExist(UINT32_MAX));
+    EXPECT_FALSE(cdg.HasBlock(5));
+    EXPECT_FALSE(cdg.HasBlock(25));
+    EXPECT_FALSE(cdg.HasBlock(UINT32_MAX));
 
     // Test ForEachBlockLabel.
     std::set<uint32_t> block_labels;

--- a/test/opt/control_dependence.cpp
+++ b/test/opt/control_dependence.cpp
@@ -126,8 +126,7 @@ TEST(ControlDependenceTest, DependenceSimpleCFG) {
     for (uint32_t id = 10; id <= 19; id++) {
       EXPECT_TRUE(cdg.HasBlock(id));
     }
-    EXPECT_TRUE(
-        cdg.HasBlock(ControlDependenceAnalysis::kPseudoEntryBlock));
+    EXPECT_TRUE(cdg.HasBlock(ControlDependenceAnalysis::kPseudoEntryBlock));
     // Check blocks before/after valid range.
     EXPECT_FALSE(cdg.HasBlock(5));
     EXPECT_FALSE(cdg.HasBlock(25));


### PR DESCRIPTION
Suggested by Jakub as 'DoesBlockExist' was confusing.