### PR TITLE
Fix validator crash

### DIFF
--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -812,7 +812,7 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
         for (uint32_t operand_index = 4; operand_index < num_operands;
              ++operand_index) {
           const uint32_t operand_type = _.GetOperandTypeId(inst, operand_index);
-          if (!_.IsIntScalarOrVectorType(operand_type)) {
+          if (!operand_type || !_.IsIntScalarOrVectorType(operand_type)) {
             return _.diag(SPV_ERROR_INVALID_DATA, inst)
                    << ext_inst_name() << ": "
                    << "expected all operands to be int scalars or vectors";

--- a/test/val/val_ext_inst_test.cpp
+++ b/test/val/val_ext_inst_test.cpp
@@ -3507,6 +3507,19 @@ TEST_P(ValidateGlslStd450SAbsLike, WrongBitWidthOperand) {
                         "Result Type"));
 }
 
+TEST_P(ValidateGlslStd450SAbsLike, TypelessOperand) {
+  const std::string ext_inst_name = GetParam();
+  const std::string body =
+      "%val1 = OpExtInst %s64 %extinst " + ext_inst_name + " %main_entry\n";
+
+  CompileSuccessfully(GenerateShaderCode(body));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("GLSL.std.450 " + ext_inst_name +
+                ": expected all operands to be int scalars or vectors"));
+}
+
 INSTANTIATE_TEST_SUITE_P(AllSAbsLike, ValidateGlslStd450SAbsLike,
                          ::testing::ValuesIn(std::vector<std::string>{
                              "SAbs",
@@ -3654,6 +3667,19 @@ TEST_P(ValidateGlslStd450UMinLike, WrongBitWidthOperand2) {
               HasSubstr("GLSL.std.450 " + ext_inst_name +
                         ": expected all operands to have the same bit width as "
                         "Result Type"));
+}
+
+TEST_P(ValidateGlslStd450UMinLike, TypelessOperand) {
+  const std::string ext_inst_name = GetParam();
+  const std::string body =
+      "%val1 = OpExtInst %s64 %extinst " + ext_inst_name + " %s64_0 %main_entry\n";
+
+  CompileSuccessfully(GenerateShaderCode(body));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("GLSL.std.450 " + ext_inst_name +
+                ": expected all operands to be int scalars or vectors"));
 }
 
 INSTANTIATE_TEST_SUITE_P(AllUMinLike, ValidateGlslStd450UMinLike,
@@ -3817,6 +3843,19 @@ TEST_P(ValidateGlslStd450UClampLike, WrongBitWidthOperand3) {
               HasSubstr("GLSL.std.450 " + ext_inst_name +
                         ": expected all operands to have the same bit width as "
                         "Result Type"));
+}
+
+TEST_P(ValidateGlslStd450UClampLike, TypelessOperand) {
+  const std::string ext_inst_name = GetParam();
+  const std::string body = "%val1 = OpExtInst %s64 %extinst " + ext_inst_name +
+                           " %main_entry %s64_0 %s64_0\n";
+
+  CompileSuccessfully(GenerateShaderCode(body));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("GLSL.std.450 " + ext_inst_name +
+                ": expected all operands to be int scalars or vectors"));
 }
 
 INSTANTIATE_TEST_SUITE_P(AllUClampLike, ValidateGlslStd450UClampLike,

--- a/test/val/val_ext_inst_test.cpp
+++ b/test/val/val_ext_inst_test.cpp
@@ -3671,8 +3671,8 @@ TEST_P(ValidateGlslStd450UMinLike, WrongBitWidthOperand2) {
 
 TEST_P(ValidateGlslStd450UMinLike, TypelessOperand) {
   const std::string ext_inst_name = GetParam();
-  const std::string body =
-      "%val1 = OpExtInst %s64 %extinst " + ext_inst_name + " %s64_0 %main_entry\n";
+  const std::string body = "%val1 = OpExtInst %s64 %extinst " + ext_inst_name +
+                           " %s64_0 %main_entry\n";
 
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());


### PR DESCRIPTION
Fixes #4411

* Some GLSL.std.450 validation didn't handle an operand without a type