### PR TITLE
Fuzzer: Default the new constructor parameter

### DIFF
--- a/source/fuzz/fuzzer.cpp
+++ b/source/fuzz/fuzzer.cpp
@@ -111,7 +111,7 @@ Fuzzer::Fuzzer(std::unique_ptr<opt::IRContext> ir_context,
                RepeatedPassStrategy repeated_pass_strategy,
                bool validate_after_each_fuzzer_pass,
                spv_validator_options validator_options,
-               bool ignore_inapplicable_transformations)
+               bool ignore_inapplicable_transformations /* = true */)
     : consumer_(std::move(consumer)),
       enable_all_passes_(enable_all_passes),
       validate_after_each_fuzzer_pass_(validate_after_each_fuzzer_pass),

--- a/source/fuzz/fuzzer.h
+++ b/source/fuzz/fuzzer.h
@@ -63,7 +63,7 @@ class Fuzzer {
          bool enable_all_passes, RepeatedPassStrategy repeated_pass_strategy,
          bool validate_after_each_fuzzer_pass,
          spv_validator_options validator_options,
-         bool ignore_inapplicable_transformations);
+         bool ignore_inapplicable_transformations = true);
 
   // Disables copy/move constructor/assignment operations.
   Fuzzer(const Fuzzer&) = delete;


### PR DESCRIPTION
Introducing a new mandatory parameter makes it very difficult to roll
Chromium to a new version of SPIRV-Tools, as this project is used by
several third-party projects, and an atomic update of all projects
is very hard to coordinate.