### PR TITLE
Add a section releases to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ version.  An API call reports the software version as a C-style string.
 
 ## Releases
 
-Some versions of SPIRV-Tools are tagged as stable releases (see tags on github).
+Some versions of SPIRV-Tools are tagged as stable releases (see
+[tags](https://github.com/KhronosGroup/SPIRV-Tools/tags) on github).
 These versions undergo extra testing.
 Releases are not directly related to releases (or versions) of
 [SPIRV-Headers][spirv-headers].

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ in the DEPS file.
 The release generally uses the most recent compatible version of SPIRV-Headers
 available at the time of release.
 No version of SPIRV-Headers other than the one listed in the DEPS file is
-guaranteed to work the SPIRV-Tools release.
+guaranteed to work with the SPIRV-Tools release.
 
 ## Supported features
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ following versions are ordered from oldest to newest:
 Use the `--version` option on each command line tool to see the software
 version.  An API call reports the software version as a C-style string.
 
+## Releases
+
+Some versions of SPIRV-Tools are tagged as stable releases (see tags on github).
+These versions undergo extra testing.
+Releases are not directly related to releases (or versions) of
+[SPIRV-Headers][spirv-headers].
+Releases of SPIRV-Tools are tested against the version of SPIRV-Headers listed
+in the DEPS file.
+The release generally uses the most recent compatible version of SPIRV-Headers
+available at the time of release.
+No version of SPIRV-Headers other than the one listed in the DEPS file is
+guaranteed to work the SPIRV-Tools release.
+
 ## Supported features
 
 ### Assembler, binary parser, and disassembler


### PR DESCRIPTION
* Releases are unrelated to SPIRV-Headers releases
* SPIRV-Headers should always be taken from the DEPS file