### PR TITLE
Fix SIGSEGV when reading from a non-existent file

### DIFF
--- a/tools/io.h
+++ b/tools/io.h
@@ -89,7 +89,7 @@ bool ReadBinaryFile(const char* filename, std::vector<T>* data) {
 
   ReadFile(fp, data);
   bool succeeded = WasFileCorrectlyRead<T>(fp, filename);
-  if (use_file) fclose(fp);
+  if (use_file && fp) fclose(fp);
   return succeeded;
 }
 
@@ -111,7 +111,7 @@ bool ReadTextFile(const char* filename, std::vector<T>* data) {
 
   ReadFile(fp, data);
   bool succeeded = WasFileCorrectlyRead<T>(fp, filename);
-  if (use_file) fclose(fp);
+  if (use_file && fp) fclose(fp);
   return succeeded;
 }
 


### PR DESCRIPTION
When a tool (tested with spirv-dis and spirv-as) runs on a file that
does not exist, it notifies the user and tries to close the stream that
was never successfully opened.