### PR TITLE
Fix early-out for Clamp constant folding

### DIFF
--- a/source/opt/const_folding_rules.cpp
+++ b/source/opt/const_folding_rules.cpp
@@ -1002,7 +1002,7 @@ const analysis::Constant* FoldClamp1(
          "Expecting a GLSLstd450 extended instruction.");
 
   // Make sure all Clamp operands are constants.
-  for (uint32_t i = 1; i < 3; i++) {
+  for (uint32_t i = 1; i < 4; i++) {
     if (constants[i] == nullptr) {
       return nullptr;
     }
@@ -1017,7 +1017,7 @@ const analysis::Constant* FoldClamp1(
                         context);
 }
 
-// Fold a clamp instruction when |x >= min_val|.
+// Fold a clamp instruction when |x <= min_val|.
 const analysis::Constant* FoldClamp2(
     IRContext* context, Instruction* inst,
     const std::vector<const analysis::Constant*>& constants) {


### PR DESCRIPTION
Only the first two operands were tested for constness, missing the third
one. Since the FoldFPBinaryOp() at the end of FoldClamp1() returns null
when not both of its operands are constant, this doesn't change any
behavior, but it avoids some needless work.

Also the comment for FoldClamp2() was fixed.