### PR TITLE
Implement force-inline optimizer option

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -691,6 +691,11 @@ SPIRV_TOOLS_EXPORT void spvOptimizerOptionsSetPreserveBindings(
 SPIRV_TOOLS_EXPORT void spvOptimizerOptionsSetPreserveSpecConstants(
     spv_optimizer_options options, bool val);
 
+// Records whether to try inlining all functions, even ones using the DontInline
+// function control bit.
+SPIRV_TOOLS_EXPORT void spvOptimizerOptionsSetForceInline(
+    spv_optimizer_options options, bool val);
+
 // Creates a reducer options object with default options. Returns a valid
 // options object. The object remains valid until it is passed into
 // |spvReducerOptionsDestroy|.

--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -184,6 +184,12 @@ class OptimizerOptions {
                                                 preserve_spec_constants);
   }
 
+  // Records whether to try inlining all functions, even ones using the
+  // DontInline function control bit.
+  void set_force_inline(bool force_inline) {
+    spvOptimizerOptionsSetForceInline(options_, force_inline);
+  }
+
  private:
   spv_optimizer_options options_;
 };

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -729,9 +729,12 @@ bool InlinePass::IsInlinableFunction(Function* func) {
   // We can only inline a function if it has blocks.
   if (func->cbegin() == func->cend()) return false;
 
-  // Do not inline functions with DontInline flag.
+  // Do not inline functions with DontInline flag, unless overridden by the
+  // optimizer option.
   if (func->control_mask() & SpvFunctionControlDontInlineMask) {
-    return false;
+    if (!context()->force_inline()) {
+      return false;
+    }
   }
 
   // Do not inline functions with returns in loops. Currently early return

--- a/source/opt/ir_context.h
+++ b/source/opt/ir_context.h
@@ -104,7 +104,8 @@ class IRContext {
         id_to_name_(nullptr),
         max_id_bound_(kDefaultMaxIdBound),
         preserve_bindings_(false),
-        preserve_spec_constants_(false) {
+        preserve_spec_constants_(false),
+        force_inline_(false) {
     SetContextMessageConsumer(syntax_context_, consumer_);
     module_->SetContext(this);
   }
@@ -121,7 +122,8 @@ class IRContext {
         id_to_name_(nullptr),
         max_id_bound_(kDefaultMaxIdBound),
         preserve_bindings_(false),
-        preserve_spec_constants_(false) {
+        preserve_spec_constants_(false),
+        force_inline_(false) {
     SetContextMessageConsumer(syntax_context_, consumer_);
     module_->SetContext(this);
     InitializeCombinators();
@@ -556,6 +558,9 @@ class IRContext {
     preserve_spec_constants_ = should_preserve_spec_constants;
   }
 
+  bool force_inline() const { return force_inline_; }
+  void set_force_inline(bool force_inline) { force_inline_ = force_inline; }
+
   // Return id of input variable only decorated with |builtin|, if in module.
   // Create variable and return its id otherwise. If builtin not currently
   // supported, return 0.
@@ -840,6 +845,10 @@ class IRContext {
   // Whether all specialization constants within |module_|
   // should be preserved.
   bool preserve_spec_constants_;
+
+  // Whether to try inlining all functions, even ones using the DontInline
+  // function control bit.
+  bool force_inline_;
 };
 
 inline IRContext::Analysis operator|(IRContext::Analysis lhs,

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -551,6 +551,7 @@ bool Optimizer::Run(const uint32_t* original_binary,
   context->set_max_id_bound(opt_options->max_id_bound_);
   context->set_preserve_bindings(opt_options->preserve_bindings_);
   context->set_preserve_spec_constants(opt_options->preserve_spec_constants_);
+  context->set_force_inline(opt_options->force_inline_);
 
   impl_->pass_manager.SetValidatorOptions(&opt_options->val_options_);
   impl_->pass_manager.SetTargetEnv(impl_->target_env);

--- a/source/spirv_optimizer_options.cpp
+++ b/source/spirv_optimizer_options.cpp
@@ -49,3 +49,8 @@ SPIRV_TOOLS_EXPORT void spvOptimizerOptionsSetPreserveSpecConstants(
     spv_optimizer_options options, bool val) {
   options->preserve_spec_constants_ = val;
 }
+
+SPIRV_TOOLS_EXPORT void spvOptimizerOptionsSetForceInline(
+    spv_optimizer_options options, bool val) {
+  options->force_inline_ = val;
+}

--- a/source/spirv_optimizer_options.h
+++ b/source/spirv_optimizer_options.h
@@ -26,7 +26,8 @@ struct spv_optimizer_options_t {
         val_options_(),
         max_id_bound_(kDefaultMaxIdBound),
         preserve_bindings_(false),
-        preserve_spec_constants_(false) {}
+        preserve_spec_constants_(false),
+        force_inline_(false) {}
 
   // When true the validator will be run before optimizations are run.
   bool run_validator_;
@@ -45,5 +46,9 @@ struct spv_optimizer_options_t {
   // When true, all specialization constants within the module should be
   // preserved.
   bool preserve_spec_constants_;
+
+  // When true, try to inline all functions, even ones using the DontInline
+  // function control bit.
+  bool force_inline_;
 };
 #endif  // SOURCE_SPIRV_OPTIMIZER_OPTIONS_H_

--- a/test/opt/inline_test.cpp
+++ b/test/opt/inline_test.cpp
@@ -2430,6 +2430,39 @@ OpFunctionEnd
   SinglePassRunAndMatch<InlineExhaustivePass>(text, true);
 }
 
+TEST_F(InlineTest, ForceInlineFuncWithDontInline) {
+  // Check that the function with DontInline flag is inlined when enabling the
+  // force inline optimizer option.
+  const std::string text = R"(
+; CHECK-NOT: OpFunctionCall
+
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main"
+OpExecutionMode %main OriginUpperLeft
+OpSource HLSL 600
+OpName %main "main"
+OpName %foo "foo"
+%int = OpTypeInt 32 1
+%int_0 = OpConstant %int 0
+%void = OpTypeVoid
+%6 = OpTypeFunction %void
+%7 = OpTypeFunction %int
+%main = OpFunction %void None %6
+%8 = OpLabel
+%9 = OpFunctionCall %int %foo
+OpReturn
+OpFunctionEnd
+%foo = OpFunction %int DontInline %7
+%10 = OpLabel
+OpReturnValue %int_0
+OpFunctionEnd
+)";
+
+  OptimizerOptions()->force_inline_ = true;
+  SinglePassRunAndMatch<InlineExhaustivePass>(text, true);
+}
+
 TEST_F(InlineTest, InlineFuncWithOpKillNotInContinue) {
   const std::string before =
       R"(OpCapability Shader

--- a/test/opt/pass_fixture.h
+++ b/test/opt/pass_fixture.h
@@ -70,6 +70,7 @@ class PassTest : public TestT {
     context()->set_preserve_bindings(OptimizerOptions()->preserve_bindings_);
     context()->set_preserve_spec_constants(
         OptimizerOptions()->preserve_spec_constants_);
+    context()->set_force_inline(OptimizerOptions()->force_inline_);
 
     const auto status = pass->Run(context());
 
@@ -242,6 +243,7 @@ class PassTest : public TestT {
     context()->set_preserve_bindings(OptimizerOptions()->preserve_bindings_);
     context()->set_preserve_spec_constants(
         OptimizerOptions()->preserve_spec_constants_);
+    context()->set_force_inline(OptimizerOptions()->force_inline_);
 
     auto status = manager_->Run(context());
     EXPECT_NE(status, Pass::Status::Failure);

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -218,6 +218,10 @@ Options (in lexicographical order):)",
                OpSpecConstantComposite instructions to front-end constants
                when possible.)");
   printf(R"(
+  --force-inline
+               Try inlining all functions, even ones using the DontInline
+               function control bit.)");
+  printf(R"(
   --freeze-spec-const
                Freeze the values of specialization constants to their default
                values.)");
@@ -709,6 +713,8 @@ OptStatus ParseFlags(int argc, const char** argv,
         optimizer_options->set_preserve_bindings(true);
       } else if (0 == strcmp(cur_arg, "--preserve-spec-constants")) {
         optimizer_options->set_preserve_spec_constants(true);
+      } else if (0 == strcmp(cur_arg, "--force-inline")) {
+        optimizer_options->set_force_inline(true);
       } else if (0 == strcmp(cur_arg, "--time-report")) {
         optimizer->SetTimeReport(&std::cerr);
       } else if (0 == strcmp(cur_arg, "--relax-struct-store")) {


### PR DESCRIPTION
SwiftShader does not support function calls in shaders, and has relied
on the spirvtools::opt::InlineExhaustivePass to eliminate them through
inlining. But since #3858, functions with the DontInline control bit do
not get inlined. This makes SwiftShader fail some of the dEQP-VK.
spirv_assembly. instruction.compute.function_control.* tests

This change adds an option to the optimizer to force-inline functions
whenever possible, effectively ignoring DontInline. Note this still
produces spec-compliant SPIR-V code, since DontInline is a "Strong
request, to the extent possible, to not inline the function." but not a
demand.

Bug: https://issuetracker.google.com/issues/172212963