### PR TITLE
Disallow loading a runtime-sized array

### DIFF
--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -893,6 +893,12 @@ spv_result_t ValidateLoad(ValidationState_t& _, const Instruction* inst) {
            << "'s type.";
   }
 
+  if (!_.options()->before_hlsl_legalization &&
+      _.ContainsRuntimeArray(inst->type_id())) {
+    return _.diag(SPV_ERROR_INVALID_ID, inst)
+           << "Cannot load a runtime-sized array";
+  }
+
   if (auto error = CheckMemoryAccess(_, inst, 3)) return error;
 
   if (_.HasCapability(SpvCapabilityShader) &&

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -1263,7 +1263,7 @@ const Instruction* ValidationState_t::TracePointer(
 }
 
 bool ValidationState_t::ContainsType(
-    uint32_t id, const std::function<bool(const Instruction* inst)>& f,
+    uint32_t id, const std::function<bool(const Instruction*)>& f,
     bool traverse_all_types) const {
   const auto inst = FindDef(id);
   if (!inst) return false;
@@ -1310,9 +1310,6 @@ bool ValidationState_t::ContainsSizedIntOrFloatType(uint32_t id, SpvOp type,
                                                     uint32_t width) const {
   if (type != SpvOpTypeInt && type != SpvOpTypeFloat) return false;
 
-  const auto inst = FindDef(id);
-  if (!inst) return false;
-
   const auto f = [type, width](const Instruction* inst) {
     if (inst->opcode() == type) {
       return inst->GetOperandAs<uint32_t>(1u) == width;
@@ -1335,9 +1332,6 @@ bool ValidationState_t::ContainsLimitedUseIntOrFloatType(uint32_t id) const {
 }
 
 bool ValidationState_t::ContainsRuntimeArray(uint32_t id) const {
-  const auto inst = FindDef(id);
-  if (!inst) return false;
-
   const auto f = [](const Instruction* inst) {
     return inst->opcode() == SpvOpTypeRuntimeArray;
   };

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -1262,16 +1262,13 @@ const Instruction* ValidationState_t::TracePointer(
   return base_ptr;
 }
 
-bool ValidationState_t::ContainsSizedIntOrFloatType(uint32_t id, SpvOp type,
-                                                    uint32_t width) const {
-  if (type != SpvOpTypeInt && type != SpvOpTypeFloat) return false;
-
+bool ValidationState_t::ContainsType(
+    uint32_t id, const std::function<bool(const Instruction* inst)>& f,
+    bool traverse_all_types) const {
   const auto inst = FindDef(id);
   if (!inst) return false;
 
-  if (inst->opcode() == type) {
-    return inst->GetOperandAs<uint32_t>(1u) == width;
-  }
+  if (f(inst)) return true;
 
   switch (inst->opcode()) {
     case SpvOpTypeArray:
@@ -1281,24 +1278,48 @@ bool ValidationState_t::ContainsSizedIntOrFloatType(uint32_t id, SpvOp type,
     case SpvOpTypeImage:
     case SpvOpTypeSampledImage:
     case SpvOpTypeCooperativeMatrixNV:
-      return ContainsSizedIntOrFloatType(inst->GetOperandAs<uint32_t>(1u), type,
-                                         width);
+      return ContainsType(inst->GetOperandAs<uint32_t>(1u), f,
+                          traverse_all_types);
     case SpvOpTypePointer:
       if (IsForwardPointer(id)) return false;
-      return ContainsSizedIntOrFloatType(inst->GetOperandAs<uint32_t>(2u), type,
-                                         width);
-    case SpvOpTypeFunction:
-    case SpvOpTypeStruct: {
-      for (uint32_t i = 1; i < inst->operands().size(); ++i) {
-        if (ContainsSizedIntOrFloatType(inst->GetOperandAs<uint32_t>(i), type,
-                                        width))
-          return true;
+      if (traverse_all_types) {
+        return ContainsType(inst->GetOperandAs<uint32_t>(2u), f,
+                            traverse_all_types);
       }
-      return false;
-    }
+      break;
+    case SpvOpTypeFunction:
+    case SpvOpTypeStruct:
+      if (inst->opcode() == SpvOpTypeFunction && !traverse_all_types) {
+        return false;
+      }
+      for (uint32_t i = 1; i < inst->operands().size(); ++i) {
+        if (ContainsType(inst->GetOperandAs<uint32_t>(i), f,
+                         traverse_all_types)) {
+          return true;
+        }
+      }
+      break;
     default:
-      return false;
+      break;
   }
+
+  return false;
+}
+
+bool ValidationState_t::ContainsSizedIntOrFloatType(uint32_t id, SpvOp type,
+                                                    uint32_t width) const {
+  if (type != SpvOpTypeInt && type != SpvOpTypeFloat) return false;
+
+  const auto inst = FindDef(id);
+  if (!inst) return false;
+
+  const auto f = [type, width](const Instruction* inst) {
+    if (inst->opcode() == type) {
+      return inst->GetOperandAs<uint32_t>(1u) == width;
+    }
+    return false;
+  };
+  return ContainsType(id, f);
 }
 
 bool ValidationState_t::ContainsLimitedUseIntOrFloatType(uint32_t id) const {
@@ -1311,6 +1332,16 @@ bool ValidationState_t::ContainsLimitedUseIntOrFloatType(uint32_t id) const {
     return true;
   }
   return false;
+}
+
+bool ValidationState_t::ContainsRuntimeArray(uint32_t id) const {
+  const auto inst = FindDef(id);
+  if (!inst) return false;
+
+  const auto f = [](const Instruction* inst) {
+    return inst->opcode() == SpvOpTypeRuntimeArray;
+  };
+  return ContainsType(id, f, /* traverse_all_types = */ false);
 }
 
 bool ValidationState_t::IsValidStorageClass(

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -603,7 +603,7 @@ class ValidationState_t {
   // Only traverse pointers and functions if |traverse_all_types| is true.
   // Recursively tests |f| against the type hierarchy headed by |id|.
   bool ContainsType(uint32_t id,
-                    const std::function<bool(const Instruction* inst)>& f,
+                    const std::function<bool(const Instruction*)>& f,
                     bool traverse_all_types = true) const;
 
   // Gets value from OpConstant and OpSpecConstant as uint64.

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -595,6 +595,17 @@ class ValidationState_t {
   // 16-bit float that is not generally enabled for use.
   bool ContainsLimitedUseIntOrFloatType(uint32_t id) const;
 
+  // Returns true if |id| is a type that contains a runtime-sized array.
+  // Does not consider a pointers as contains the array.
+  bool ContainsRuntimeArray(uint32_t id) const;
+
+  // Generic type traversal.
+  // Only traverse pointers and functions if |traverse_all_types| is true.
+  // Recursively tests |f| against the type hierarchy headed by |id|.
+  bool ContainsType(uint32_t id,
+                    const std::function<bool(const Instruction* inst)>& f,
+                    bool traverse_all_types = true) const;
+
   // Gets value from OpConstant and OpSpecConstant as uint64.
   // Returns false on failure (no instruction, wrong instruction, not int).
   bool GetConstantValUint64(uint32_t id, uint64_t* val) const;

--- a/test/opt/eliminate_dead_member_test.cpp
+++ b/test/opt/eliminate_dead_member_test.cpp
@@ -576,7 +576,6 @@ TEST_F(EliminateDeadMemberTest, RemoveMembersUpdateArrayLength) {
    %_Globals = OpVariable %_ptr_Uniform_type__Globals Uniform
        %main = OpFunction %void None %9
          %10 = OpLabel
-         %11 = OpLoad %type__Globals %_Globals
          %12 = OpArrayLength %uint %_Globals 2
                OpReturn
                OpFunctionEnd

--- a/test/val/val_composites_test.cpp
+++ b/test/val/val_composites_test.cpp
@@ -86,10 +86,10 @@ OpCapability Float64
 %f32mat23_121212 = OpConstantComposite %f32mat23 %f32vec2_12 %f32vec2_12 %f32vec2_12
 
 %f32vec2arr3 = OpTypeArray %f32vec2 %u32_3
-%f32vec2rarr = OpTypeRuntimeArray %f32vec2
+%f32vec2arr2 = OpTypeArray %f32vec2 %u32_2
 
 %f32u32struct = OpTypeStruct %f32 %u32
-%big_struct = OpTypeStruct %f32 %f32vec4 %f32mat23 %f32vec2arr3 %f32vec2rarr %f32u32struct
+%big_struct = OpTypeStruct %f32 %f32vec4 %f32mat23 %f32vec2arr3 %f32vec2arr2 %f32u32struct
 
 %ptr_big_struct = OpTypePointer Uniform %big_struct
 %var_big_struct = OpVariable %ptr_big_struct Uniform
@@ -150,7 +150,6 @@ OpMemoryModel Logical GLSL450
 ; uniform blockName {
 ;   S s;
 ;   bool cond;
-;   RunTimeArray arr;
 ; }
 
 %f32arr = OpTypeRuntimeArray %float
@@ -161,7 +160,7 @@ OpMemoryModel Logical GLSL450
 %_ptr_Function_vec4 = OpTypePointer Function %v4float
 %_ptr_Uniform_vec4 = OpTypePointer Uniform %v4float
 %struct_s = OpTypeStruct %int %array5_vec4 %int %array5_mat4x3
-%struct_blockName = OpTypeStruct %struct_s %int %f32arr
+%struct_blockName = OpTypeStruct %struct_s %int
 %_ptr_Uniform_blockName = OpTypePointer Uniform %struct_blockName
 %_ptr_Uniform_struct_s = OpTypePointer Uniform %struct_s
 %_ptr_Uniform_array5_mat4x3 = OpTypePointer Uniform %array5_mat4x3
@@ -644,8 +643,8 @@ TEST_F(ValidateComposites, CompositeExtractSuccess) {
 %val12 = OpCompositeExtract %f32 %struct 2 2 1
 %val13 = OpCompositeExtract %f32vec2 %struct 3 2
 %val14 = OpCompositeExtract %f32 %struct 3 2 1
-%val15 = OpCompositeExtract %f32vec2 %struct 4 100
-%val16 = OpCompositeExtract %f32 %struct 4 1000 1
+%val15 = OpCompositeExtract %f32vec2 %struct 4 1
+%val16 = OpCompositeExtract %f32 %struct 4 0 1
 %val17 = OpCompositeExtract %f32 %struct 5 0
 %val18 = OpCompositeExtract %u32 %struct 5 1
 )";
@@ -868,8 +867,8 @@ TEST_F(ValidateComposites, CompositeInsertSuccess) {
 %val12 = OpCompositeInsert %big_struct %f32_3 %struct 2 2 1
 %val13 = OpCompositeInsert %big_struct %f32vec2_01 %struct 3 2
 %val14 = OpCompositeInsert %big_struct %f32_3 %struct 3 2 1
-%val15 = OpCompositeInsert %big_struct %f32vec2_01 %struct 4 100
-%val16 = OpCompositeInsert %big_struct %f32_3 %struct 4 1000 1
+%val15 = OpCompositeInsert %big_struct %f32vec2_01 %struct 4 1
+%val16 = OpCompositeInsert %big_struct %f32_3 %struct 4 0 1
 %val17 = OpCompositeInsert %big_struct %f32_3 %struct 5 0
 %val18 = OpCompositeInsert %big_struct %u32_3 %struct 5 1
 )";
@@ -1382,8 +1381,8 @@ TEST_F(ValidateComposites, CompositeExtractStructIndexOutOfBoundBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Index is out of bounds, can not find index 3 in the "
-                        "structure <id> '25'. This structure has 3 members. "
-                        "Largest valid index is 2."));
+                        "structure <id> '25'. This structure has 2 members. "
+                        "Largest valid index is 1."));
 }
 
 // Invalid. Index into a struct is larger than the number of struct members.
@@ -1403,8 +1402,8 @@ TEST_F(ValidateComposites, CompositeInsertStructIndexOutOfBoundBad) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("Index is out of bounds, can not find index 3 in the structure "
-                "<id> '25'. This structure has 3 members. Largest valid index "
-                "is 2."));
+                "<id> '25'. This structure has 2 members. Largest valid index "
+                "is 1."));
 }
 
 // #1403: Ensure that the default spec constant value is not used to check the

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -4372,7 +4372,6 @@ OpFunctionEnd
               HasSubstr("Cannot load a runtime-sized array"));
 }
 
-
 }  // namespace
 }  // namespace val
 }  // namespace spvtools

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -746,7 +746,7 @@ TEST_F(ValidateMemory, ArrayLenIndexNotPointerToStruct) {
       %float = OpTypeFloat 32
      %uint = OpTypeInt 32 0
 %_runtimearr_float = OpTypeRuntimeArray %float
-  %_struct_7 = OpTypeStruct %float %_runtimearr_float
+  %_struct_7 = OpTypeStruct %float
 %_ptr_Function__struct_7  = OpTypePointer Function %_struct_7
           %1 = OpFunction %void None %3
           %9 = OpLabel
@@ -4283,6 +4283,95 @@ OpFunctionEnd
   CompileSuccessfully(spirv.c_str(), SPV_ENV_VULKAN_1_0);
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_0));
 }
+
+TEST_F(ValidateMemory, LoadRuntimeArray) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpExtension "SPV_KHR_storage_buffer_storage_class"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%int_0 = OpConstant %int 0
+%rta = OpTypeRuntimeArray %int
+%block = OpTypeStruct %rta
+%ptr_rta = OpTypePointer StorageBuffer %rta
+%ptr_block = OpTypePointer StorageBuffer %block
+%var = OpVariable %ptr_block StorageBuffer
+%void_fn = OpTypeFunction %void
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%gep = OpAccessChain %ptr_rta %var %int_0
+%ld = OpLoad %rta %gep
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Cannot load a runtime-sized array"));
+}
+
+TEST_F(ValidateMemory, LoadRuntimeArrayInStruct) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpExtension "SPV_KHR_storage_buffer_storage_class"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%int_0 = OpConstant %int 0
+%rta = OpTypeRuntimeArray %int
+%block = OpTypeStruct %rta
+%ptr_rta = OpTypePointer StorageBuffer %rta
+%ptr_block = OpTypePointer StorageBuffer %block
+%var = OpVariable %ptr_block StorageBuffer
+%void_fn = OpTypeFunction %void
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%ld = OpLoad %block %var
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Cannot load a runtime-sized array"));
+}
+
+TEST_F(ValidateMemory, LoadRuntimeArrayInArray) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpExtension "SPV_KHR_storage_buffer_storage_class"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%int_0 = OpConstant %int 0
+%int_4 = OpConstant %int 4
+%rta = OpTypeRuntimeArray %int
+%block = OpTypeStruct %rta
+%array = OpTypeArray %block %int_4
+%ptr_rta = OpTypePointer StorageBuffer %rta
+%ptr_block = OpTypePointer StorageBuffer %block
+%ptr_array = OpTypePointer StorageBuffer %array
+%var = OpVariable %ptr_array StorageBuffer
+%void_fn = OpTypeFunction %void
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%ld = OpLoad %array %var
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Cannot load a runtime-sized array"));
+}
+
 
 }  // namespace
 }  // namespace val


### PR DESCRIPTION
Fixes #4472

* Disallow loading a runtime-sized array or a composite containing one
* Refactor type traversal into a separate function used by both runtime
  array checks and sized int/float checks
* Update invalid tests