### PR TITLE
spirv-lint: add basic CLI argument handling

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -347,6 +347,7 @@ cc_binary(
 cc_binary(
     name = "spirv-lint",
     srcs = [
+        "tools/io.h",
         "tools/lint/lint.cpp",
     ],
     copts = COMMON_COPTS,

--- a/tools/lint/lint.cpp
+++ b/tools/lint/lint.cpp
@@ -14,21 +14,62 @@
 
 #include <iostream>
 
+#include "source/opt/log.h"
 #include "spirv-tools/linter.hpp"
+#include "tools/io.h"
 #include "tools/util/cli_consumer.h"
 
 const auto kDefaultEnvironment = SPV_ENV_UNIVERSAL_1_5;
 
+namespace {
+// Status and actions to perform after parsing command-line arguments.
+enum LintActions { LINT_CONTINUE, LINT_STOP };
+
+struct LintStatus {
+  LintActions action;
+  int code;
+};
+
+// Parses command-line flags. |argc| contains the number of command-line flags.
+// |argv| points to an array of strings holding the flags.
+//
+// On return, this function stores the name of the input program in |in_file|.
+// The return value indicates whether optimization should continue and a status
+// code indicating an error or success.
+LintStatus ParseFlags(int argc, const char** argv, const char** in_file) {
+  // TODO (dongja): actually parse flags, etc.
+  if (argc != 2) {
+    spvtools::Error(spvtools::utils::CLIMessageConsumer, nullptr, {},
+                    "expected exactly one argument: in_file");
+    return {LINT_STOP, 1};
+  }
+
+  *in_file = argv[1];
+
+  return {LINT_CONTINUE, 0};
+}
+}  // namespace
+
 int main(int argc, const char** argv) {
-  (void)argc;
-  (void)argv;
+  const char* in_file = nullptr;
 
   spv_target_env target_env = kDefaultEnvironment;
 
   spvtools::Linter linter(target_env);
   linter.SetMessageConsumer(spvtools::utils::CLIMessageConsumer);
 
-  bool ok = linter.Run(nullptr, 0);
+  LintStatus status = ParseFlags(argc, argv, &in_file);
+
+  if (status.action == LINT_STOP) {
+    return status.code;
+  }
+
+  std::vector<uint32_t> binary;
+  if (!ReadBinaryFile(in_file, &binary)) {
+    return 1;
+  }
+
+  bool ok = linter.Run(binary.data(), binary.size());
 
   return ok ? 0 : 1;
 }


### PR DESCRIPTION
Mostly copied from spirv-opt. Simply reads in a single input file.

Issue: #3196