### PR TITLE
spirv-val: Fix WorkgroupSize VUID 04425

### DIFF
--- a/source/val/validate_builtins.cpp
+++ b/source/val/validate_builtins.cpp
@@ -2846,7 +2846,7 @@ spv_result_t BuiltInsValidator::ValidateComputeShaderI32Vec3InputAtReference(
                << spvLogStringForEnv(_.context()->target_env)
                << " spec allows BuiltIn "
                << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN, builtin)
-               << " to be used only with GLCompute execution model. "
+               << " to be used only with GLCompute, MeshNV, or TaskNV execution model. "
                << GetReferenceDesc(decoration, built_in_inst, referenced_inst,
                                    referenced_from_inst, execution_model);
       }
@@ -2928,7 +2928,7 @@ spv_result_t BuiltInsValidator::ValidateComputeI32InputAtReference(
                << spvLogStringForEnv(_.context()->target_env)
                << " spec allows BuiltIn "
                << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN, builtin)
-               << " to be used only with GLCompute execution model. "
+               << " to be used only with GLCompute, MeshNV, or TaskNV execution model. "
                << GetReferenceDesc(decoration, built_in_inst, referenced_inst,
                                    referenced_from_inst, execution_model);
       }
@@ -3070,14 +3070,16 @@ spv_result_t BuiltInsValidator::ValidateWorkgroupSizeAtReference(
     const Instruction& referenced_from_inst) {
   if (spvIsVulkanEnv(_.context()->target_env)) {
     for (const SpvExecutionModel execution_model : execution_models_) {
-      if (execution_model != SpvExecutionModelGLCompute) {
+      if (execution_model != SpvExecutionModelGLCompute &&
+          execution_model != SpvExecutionModelTaskNV &&
+          execution_model != SpvExecutionModelMeshNV) {
         return _.diag(SPV_ERROR_INVALID_DATA, &referenced_from_inst)
                << _.VkErrorID(4425)
                << spvLogStringForEnv(_.context()->target_env)
                << " spec allows BuiltIn "
                << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
                                                 decoration.params()[0])
-               << " to be used only with GLCompute execution model. "
+               << " to be used only with GLCompute, MeshNV, or TaskNV execution model. "
                << GetReferenceDesc(decoration, built_in_inst, referenced_inst,
                                    referenced_from_inst, execution_model);
       }

--- a/test/val/val_builtins_test.cpp
+++ b/test/val/val_builtins_test.cpp
@@ -767,18 +767,18 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     ComputeShaderInputInt32Vec3NotGLCompute,
     ValidateVulkanCombineBuiltInExecutionModelDataTypeResult,
-    Combine(
-        Values("GlobalInvocationId", "LocalInvocationId", "NumWorkgroups",
-               "WorkgroupId"),
-        Values("Vertex", "Fragment", "Geometry", "TessellationControl",
-               "TessellationEvaluation"),
-        Values("Input"), Values("%u32vec3"),
-        Values("VUID-GlobalInvocationId-GlobalInvocationId-04236 "
-               "VUID-LocalInvocationId-LocalInvocationId-04281 "
-               "VUID-NumWorkgroups-NumWorkgroups-04296 "
-               "VUID-WorkgroupId-WorkgroupId-04422"),
-        Values(TestResult(SPV_ERROR_INVALID_DATA,
-                          "to be used only with GLCompute execution model"))));
+    Combine(Values("GlobalInvocationId", "LocalInvocationId", "NumWorkgroups",
+                   "WorkgroupId"),
+            Values("Vertex", "Fragment", "Geometry", "TessellationControl",
+                   "TessellationEvaluation"),
+            Values("Input"), Values("%u32vec3"),
+            Values("VUID-GlobalInvocationId-GlobalInvocationId-04236 "
+                   "VUID-LocalInvocationId-LocalInvocationId-04281 "
+                   "VUID-NumWorkgroups-NumWorkgroups-04296 "
+                   "VUID-WorkgroupId-WorkgroupId-04422"),
+            Values(TestResult(SPV_ERROR_INVALID_DATA,
+                              "to be used only with GLCompute, MeshNV, or "
+                              "TaskNV execution model"))));
 
 INSTANTIATE_TEST_SUITE_P(
     ComputeShaderInputInt32Vec3NotInput,
@@ -2828,9 +2828,10 @@ TEST_F(ValidateBuiltIns, VulkanWorkgroupSizeFragment) {
 
   CompileSuccessfully(generator.Build(), SPV_ENV_VULKAN_1_0);
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Vulkan spec allows BuiltIn WorkgroupSize to be used "
-                        "only with GLCompute execution model"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Vulkan spec allows BuiltIn WorkgroupSize to be used "
+                "only with GLCompute, MeshNV, or TaskNV execution model"));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("is referencing ID <2> (OpConstantComposite) which is "
                         "decorated with BuiltIn WorkgroupSize in function <1> "
@@ -3711,13 +3712,13 @@ OpFunctionEnd
 
 INSTANTIATE_TEST_SUITE_P(
     SubgroupNumAndIdNotCompute, ValidateVulkanSubgroupBuiltIns,
-    Combine(
-        Values("SubgroupId", "NumSubgroups"), Values("Vertex"), Values("Input"),
-        Values("%u32"),
-        Values("VUID-SubgroupId-SubgroupId-04367 "
-               "VUID-NumSubgroups-NumSubgroups-04293"),
-        Values(TestResult(SPV_ERROR_INVALID_DATA,
-                          "to be used only with GLCompute execution model"))));
+    Combine(Values("SubgroupId", "NumSubgroups"), Values("Vertex"),
+            Values("Input"), Values("%u32"),
+            Values("VUID-SubgroupId-SubgroupId-04367 "
+                   "VUID-NumSubgroups-NumSubgroups-04293"),
+            Values(TestResult(SPV_ERROR_INVALID_DATA,
+                              "to be used only with GLCompute, MeshNV, or "
+                              "TaskNV execution model"))));
 
 INSTANTIATE_TEST_SUITE_P(
     SubgroupNumAndIdNotU32, ValidateVulkanSubgroupBuiltIns,


### PR DESCRIPTION
>  VUID-WorkgroupSize-WorkgroupSize-04425
>
> The WorkgroupSize decoration must be used only within the GLCompute, MeshNV, or TaskNV Execution Model

This was missing the mesh stages and causing issues in Validation Layers for me