### PR TITLE
Improve decoration validation

### DIFF
--- a/source/val/validate_annotation.cpp
+++ b/source/val/validate_annotation.cpp
@@ -289,6 +289,8 @@ spv_result_t ValidateDecorationTarget(ValidationState_t& _, SpvDecoration dec,
     case SpvDecorationXfbStride:
     case SpvDecorationComponent:
     case SpvDecorationStream:
+    case SpvDecorationRestrictPointer:
+    case SpvDecorationAliasedPointer:
       if (target->opcode() != SpvOpVariable &&
           target->opcode() != SpvOpFunctionParameter) {
         return fail() << "must be a memory object declaration";
@@ -304,8 +306,6 @@ spv_result_t ValidateDecorationTarget(ValidationState_t& _, SpvDecoration dec,
     case SpvDecorationBinding:
     case SpvDecorationDescriptorSet:
     case SpvDecorationInputAttachmentIndex:
-    case SpvDecorationRestrictPointer:
-    case SpvDecorationAliasedPointer:
       if (target->opcode() != SpvOpVariable) {
         return fail() << "must be a variable";
       }

--- a/source/val/validate_annotation.cpp
+++ b/source/val/validate_annotation.cpp
@@ -138,14 +138,14 @@ std::string LogStringForDecoration(uint32_t decoration) {
       return "PerTaskNV";
     case SpvDecorationPerVertexNV:
       return "PerVertexNV";
-    case SpvDecorationNonUniformEXT:
-      return "NonUniformEXT";
-    case SpvDecorationRestrictPointerEXT:
-      return "RestrictPointerEXT";
-    case SpvDecorationAliasedPointerEXT:
-      return "AliasedPointerEXT";
-    case SpvDecorationHlslCounterBufferGOOGLE:
-      return "HlslCounterBufferGOOGLE";
+    case SpvDecorationNonUniform:
+      return "NonUniform";
+    case SpvDecorationRestrictPointer:
+      return "RestrictPointer";
+    case SpvDecorationAliasedPointer:
+      return "AliasedPointer";
+    case SpvDecorationCounterBuffer:
+      return "CounterBuffer";
     case SpvDecorationHlslSemanticGOOGLE:
       return "HlslSemanticGOOGLE";
     default:
@@ -156,8 +156,8 @@ std::string LogStringForDecoration(uint32_t decoration) {
 
 // Returns true if the decoration takes ID parameters.
 // TODO(dneto): This can be generated from the grammar.
-bool DecorationTakesIdParameters(uint32_t type) {
-  switch (static_cast<SpvDecoration>(type)) {
+bool DecorationTakesIdParameters(SpvDecoration type) {
+  switch (type) {
     case SpvDecorationUniformId:
     case SpvDecorationAlignmentId:
     case SpvDecorationMaxByteOffsetId:
@@ -169,17 +169,196 @@ bool DecorationTakesIdParameters(uint32_t type) {
   return false;
 }
 
-spv_result_t ValidateDecorate(ValidationState_t& _, const Instruction* inst) {
-  const auto decoration = inst->GetOperandAs<uint32_t>(1);
-  if (decoration == SpvDecorationSpecId) {
-    const auto target_id = inst->GetOperandAs<uint32_t>(0);
-    const auto target = _.FindDef(target_id);
-    if (!target || !spvOpcodeIsScalarSpecConstant(target->opcode())) {
-      return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "OpDecorate SpecId decoration target <id> '"
-             << _.getIdName(target_id)
-             << "' is not a scalar specialization constant.";
+bool IsMemberDecorationOnly(SpvDecoration dec) {
+  switch (dec) {
+    case SpvDecorationRowMajor:
+    case SpvDecorationColMajor:
+    case SpvDecorationMatrixStride:
+    case SpvDecorationOffset:
+      return true;
+    default:
+      break;
+  }
+  return false;
+}
+
+bool IsNotMemberDecoration(SpvDecoration dec) {
+  switch (dec) {
+    case SpvDecorationSpecId:
+    case SpvDecorationBlock:
+    case SpvDecorationBufferBlock:
+    case SpvDecorationArrayStride:
+    case SpvDecorationGLSLShared:
+    case SpvDecorationGLSLPacked:
+    case SpvDecorationCPacked:
+    case SpvDecorationRestrict:
+    case SpvDecorationAliased:
+    case SpvDecorationConstant:
+    case SpvDecorationUniform:
+    case SpvDecorationUniformId:
+    case SpvDecorationSaturatedConversion:
+    case SpvDecorationIndex:
+    case SpvDecorationBinding:
+    case SpvDecorationDescriptorSet:
+    case SpvDecorationFuncParamAttr:
+    case SpvDecorationFPRoundingMode:
+    case SpvDecorationFPFastMathMode:
+    case SpvDecorationLinkageAttributes:
+    case SpvDecorationNoContraction:
+    case SpvDecorationInputAttachmentIndex:
+    case SpvDecorationAlignment:
+    case SpvDecorationMaxByteOffset:
+    case SpvDecorationAlignmentId:
+    case SpvDecorationMaxByteOffsetId:
+    case SpvDecorationNoSignedWrap:
+    case SpvDecorationNoUnsignedWrap:
+    case SpvDecorationNonUniform:
+    case SpvDecorationRestrictPointer:
+    case SpvDecorationAliasedPointer:
+    case SpvDecorationCounterBuffer:
+      return true;
+    default:
+      break;
+  }
+  return false;
+}
+
+spv_result_t ValidateDecorationTarget(ValidationState_t& _, SpvDecoration dec,
+                                      const Instruction* inst,
+                                      const Instruction* target) {
+  auto fail = [&_, dec, inst, target]() -> DiagnosticStream {
+    DiagnosticStream ds = std::move(_.diag(SPV_ERROR_INVALID_ID, inst)
+                                    << LogStringForDecoration(dec)
+                                    << " decoration on target <id> '"
+                                    << _.getIdName(target->id()) << "' ");
+    return ds;
+  };
+  switch (dec) {
+    case SpvDecorationRelaxedPrecision:
+      // This is check is a bit permissive.
+      if (!_.ContainsType(target->type_id(), [](const Instruction* type) {
+            if (type->opcode() == SpvOpTypeInt ||
+                type->opcode() == SpvOpTypeFloat) {
+              return type->GetOperandAs<uint32_t>(1) == 32;
+            }
+            return false;
+          })) {
+        return fail() << "must contain a 32-bit numerical type";
+      }
+      break;
+    case SpvDecorationSpecId:
+      if (!spvOpcodeIsScalarSpecConstant(target->opcode())) {
+        return fail() << "must be a scalar specialization constant";
+      }
+      break;
+    case SpvDecorationBlock:
+    case SpvDecorationBufferBlock:
+      if (target->opcode() != SpvOpTypeStruct) {
+        return fail() << "must be a structure type";
+      }
+      break;
+    case SpvDecorationArrayStride:
+      if (target->opcode() != SpvOpTypeArray &&
+          target->opcode() != SpvOpTypeRuntimeArray &&
+          target->opcode() != SpvOpTypePointer) {
+        return fail() << "must be an array or pointer type";
+      }
+      break;
+    case SpvDecorationBuiltIn:
+      if (target->opcode() != SpvOpVariable &&
+          !spvOpcodeIsConstant(target->opcode())) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << "BuiltIns can only target variables, structs or constants";
+      }
+      if (inst->GetOperandAs<SpvBuiltIn>(2) == SpvBuiltInWorkgroupSize) {
+        if (!spvOpcodeIsConstant(target->opcode())) {
+          return fail() << "must be a constant for WorkgroupSize";
+        }
+      } else if (target->opcode() != SpvOpVariable) {
+        return fail() << "must be a variable";
+      }
+      break;
+    case SpvDecorationNoPerspective:
+    case SpvDecorationFlat:
+    case SpvDecorationPatch:
+    case SpvDecorationCentroid:
+    case SpvDecorationSample:
+    case SpvDecorationRestrict:
+    case SpvDecorationAliased:
+    case SpvDecorationVolatile:
+    case SpvDecorationCoherent:
+    case SpvDecorationNonWritable:
+    case SpvDecorationNonReadable:
+    case SpvDecorationXfbBuffer:
+    case SpvDecorationXfbStride:
+      if (target->opcode() != SpvOpVariable &&
+          target->opcode() != SpvOpFunctionParameter) {
+        return fail() << "must be a memory object declaration";
+      }
+      break;
+    case SpvDecorationInvariant:
+    case SpvDecorationConstant:
+    case SpvDecorationLocation:
+    case SpvDecorationComponent:
+    case SpvDecorationIndex:
+    case SpvDecorationBinding:
+    case SpvDecorationDescriptorSet:
+    case SpvDecorationInputAttachmentIndex:
+    case SpvDecorationRestrictPointer:
+    case SpvDecorationAliasedPointer:
+      if (target->opcode() != SpvOpVariable) {
+        return fail() << "must be a variable";
+      }
+      break;
+    default:
+      break;
+  }
+
+  if (spvIsVulkanEnv(_.context()->target_env)) {
+    // The following were all checked as variables above.
+    SpvStorageClass sc;
+    if (target->operands().size() > 2) {
+      sc = target->GetOperandAs<SpvStorageClass>(2);
     }
+    switch (dec) {
+      case SpvDecorationLocation:
+      case SpvDecorationComponent:
+        if (sc != SpvStorageClassInput && sc != SpvStorageClassOutput) {
+          return fail() << "must be in the Input or Output storage class";
+        }
+        break;
+      case SpvDecorationIndex:
+        if (sc != SpvStorageClassOutput) {
+          return fail() << "must be in the Output storage class";
+        }
+        break;
+      case SpvDecorationBinding:
+      case SpvDecorationDescriptorSet:
+        if (sc != SpvStorageClassStorageBuffer &&
+            sc != SpvStorageClassUniform &&
+            sc != SpvStorageClassUniformConstant) {
+          return fail() << "must be in the StorageBuffer, Uniform, or "
+                           "UniformConstant storage class";
+        }
+        break;
+      case SpvDecorationInputAttachmentIndex:
+        if (sc != SpvStorageClassUniformConstant) {
+          return fail() << "must be in the UniformConstant storage class";
+        }
+        break;
+      default:
+        break;
+    }
+  }
+  return SPV_SUCCESS;
+}
+
+spv_result_t ValidateDecorate(ValidationState_t& _, const Instruction* inst) {
+  const auto decoration = inst->GetOperandAs<SpvDecoration>(1);
+  const auto target_id = inst->GetOperandAs<uint32_t>(0);
+  const auto target = _.FindDef(target_id);
+  if (!target) {
+    return _.diag(SPV_ERROR_INVALID_ID, inst) << "target is not defined";
   }
 
   if (spvIsVulkanEnv(_.context()->target_env)) {
@@ -197,17 +376,40 @@ spv_result_t ValidateDecorate(ValidationState_t& _, const Instruction* inst) {
            << "Decorations taking ID parameters may not be used with "
               "OpDecorateId";
   }
+
+  if (target->opcode() != SpvOpDecorationGroup) {
+    if (IsMemberDecorationOnly(decoration)) {
+      return _.diag(SPV_ERROR_INVALID_ID, inst)
+             << LogStringForDecoration
+             << " can only be applied to structure members";
+    }
+
+    if (auto error = ValidateDecorationTarget(_, decoration, inst, target)) {
+      return error;
+    }
+  }
+
   // TODO: Add validations for all decorations.
   return SPV_SUCCESS;
 }
 
 spv_result_t ValidateDecorateId(ValidationState_t& _, const Instruction* inst) {
-  const auto decoration = inst->GetOperandAs<uint32_t>(1);
+  const auto decoration = inst->GetOperandAs<SpvDecoration>(1);
   if (!DecorationTakesIdParameters(decoration)) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
            << "Decorations that don't take ID parameters may not be used with "
               "OpDecorateId";
   }
+
+  const auto target_id = inst->GetOperandAs<uint32_t>(0);
+  const auto target = _.FindDef(target_id);
+  if (target->opcode() != SpvOpDecorationGroup &&
+      IsMemberDecorationOnly(decoration)) {
+    return _.diag(SPV_ERROR_INVALID_ID, inst)
+           << LogStringForDecoration
+           << " can only be applied to structure members";
+  }
+
   // TODO: Add validations for these decorations.
   // UniformId is covered elsewhere.
   return SPV_SUCCESS;
@@ -232,6 +434,13 @@ spv_result_t ValidateMemberDecorate(ValidationState_t& _,
            << _.getIdName(struct_type_id)
            << " is out of bounds. The structure has " << member_count
            << " members. Largest valid index is " << member_count - 1 << ".";
+  }
+
+  const auto decoration = inst->GetOperandAs<SpvDecoration>(2);
+  if (IsNotMemberDecoration(decoration)) {
+    return _.diag(SPV_ERROR_INVALID_ID, inst)
+           << LogStringForDecoration(decoration)
+           << " cannot be applied to structure members";
   }
 
   return SPV_SUCCESS;

--- a/source/val/validate_annotation.cpp
+++ b/source/val/validate_annotation.cpp
@@ -231,11 +231,10 @@ spv_result_t ValidateDecorationTarget(ValidationState_t& _, SpvDecoration dec,
                                       const Instruction* inst,
                                       const Instruction* target) {
   auto fail = [&_, dec, inst, target](uint32_t vuid = 0) -> DiagnosticStream {
-    DiagnosticStream ds = std::move(_.diag(SPV_ERROR_INVALID_ID, inst)
-                                    << _.VkErrorID(vuid)
-                                    << LogStringForDecoration(dec)
-                                    << " decoration on target <id> '"
-                                    << _.getIdName(target->id()) << "' ");
+    DiagnosticStream ds = std::move(
+        _.diag(SPV_ERROR_INVALID_ID, inst)
+        << _.VkErrorID(vuid) << LogStringForDecoration(dec)
+        << " decoration on target <id> '" << _.getIdName(target->id()) << "' ");
     return ds;
   };
   switch (dec) {

--- a/source/val/validate_annotation.cpp
+++ b/source/val/validate_annotation.cpp
@@ -322,7 +322,7 @@ spv_result_t ValidateDecorationTarget(ValidationState_t& _, SpvDecoration dec,
             sc == SpvStorageClassFunction) {
           return _.diag(SPV_ERROR_INVALID_ID, target)
                  << LogStringForDecoration(dec)
-                 << " decroration must not be applied to this storage class";
+                 << " decoration must not be applied to this storage class";
         }
         break;
       case SpvDecorationIndex:
@@ -399,14 +399,8 @@ spv_result_t ValidateDecorateId(ValidationState_t& _, const Instruction* inst) {
               "OpDecorateId";
   }
 
-  const auto target_id = inst->GetOperandAs<uint32_t>(0);
-  const auto target = _.FindDef(target_id);
-  if (target->opcode() != SpvOpDecorationGroup &&
-      IsMemberDecorationOnly(decoration)) {
-    return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << LogStringForDecoration
-           << " can only be applied to structure members";
-  }
+  // No member decorations take id parameters, so we don't bother checking if
+  // we are using a member only decoration here.
 
   // TODO: Add validations for these decorations.
   // UniformId is covered elsewhere.

--- a/source/val/validate_annotation.cpp
+++ b/source/val/validate_annotation.cpp
@@ -308,7 +308,7 @@ spv_result_t ValidateDecorationTarget(ValidationState_t& _, SpvDecoration dec,
 
   if (spvIsVulkanEnv(_.context()->target_env)) {
     // The following were all checked as variables above.
-    SpvStorageClass sc;
+    SpvStorageClass sc = SpvStorageClassUniform;
     if (target->operands().size() > 2) {
       sc = target->GetOperandAs<SpvStorageClass>(2);
     }

--- a/source/val/validate_annotation.cpp
+++ b/source/val/validate_annotation.cpp
@@ -245,6 +245,9 @@ spv_result_t ValidateDecorationTarget(ValidationState_t& _, SpvDecoration dec,
       break;
     case SpvDecorationBlock:
     case SpvDecorationBufferBlock:
+    case SpvDecorationGLSLShared:
+    case SpvDecorationGLSLPacked:
+    case SpvDecorationCPacked:
       if (target->opcode() != SpvOpTypeStruct) {
         return fail() << "must be a structure type";
       }

--- a/source/val/validate_builtins.cpp
+++ b/source/val/validate_builtins.cpp
@@ -3993,14 +3993,6 @@ spv_result_t BuiltInsValidator::ValidateSingleBuiltInAtDefinition(
     const Decoration& decoration, const Instruction& inst) {
   const SpvBuiltIn label = SpvBuiltIn(decoration.params()[0]);
 
-  // Builtins can only be applied to variables, structures or constants.
-  auto target_opcode = inst.opcode();
-  if (target_opcode != SpvOpTypeStruct && target_opcode != SpvOpVariable &&
-      !spvOpcodeIsConstant(target_opcode)) {
-    return _.diag(SPV_ERROR_INVALID_DATA, &inst)
-           << "BuiltIns can only target variables, structs or constants";
-  }
-
   if (!spvIsVulkanEnv(_.context()->target_env)) {
     // Early return. All currently implemented rules are based on Vulkan spec.
     //

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -1839,6 +1839,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-None-04667);
     case 4669:
       return VUID_WRAP(VUID-StandaloneSpirv-GLSLShared-04669);
+    case 4670:
+      return VUID_WRAP(VUID-StandaloneSpirv-Flat-04670);
     case 4675:
       return VUID_WRAP(VUID-StandaloneSpirv-FPRoundingMode-04675);
     case 4677:

--- a/test/opt/inline_test.cpp
+++ b/test/opt/inline_test.cpp
@@ -2300,7 +2300,6 @@ TEST_F(InlineTest, DontInlineDirectlyRecursiveFunc) {
 OpMemoryModel Logical GLSL450
 OpEntryPoint Fragment %1 "main"
 OpExecutionMode %1 OriginUpperLeft
-OpDecorate %2 DescriptorSet 439418829
 %void = OpTypeVoid
 %4 = OpTypeFunction %void
 %float = OpTypeFloat 32
@@ -2330,7 +2329,6 @@ TEST_F(InlineTest, DontInlineInDirectlyRecursiveFunc) {
 OpMemoryModel Logical GLSL450
 OpEntryPoint Fragment %1 "main"
 OpExecutionMode %1 OriginUpperLeft
-OpDecorate %2 DescriptorSet 439418829
 %void = OpTypeVoid
 %4 = OpTypeFunction %void
 %float = OpTypeFloat 32

--- a/test/opt/upgrade_memory_model_test.cpp
+++ b/test/opt/upgrade_memory_model_test.cpp
@@ -404,7 +404,7 @@ OpCapability VariablePointers
 OpExtension "SPV_KHR_variable_pointers"
 OpMemoryModel Logical GLSL450
 OpDecorate %param Coherent
-OpDecorate %param ArrayStride 4
+OpDecorate %ptr_int_StorageBuffer ArrayStride 4
 %void = OpTypeVoid
 %bool = OpTypeBool
 %int = OpTypeInt 32 0

--- a/test/val/CMakeLists.txt
+++ b/test/val/CMakeLists.txt
@@ -23,6 +23,7 @@ set(VAL_TEST_COMMON_SRCS
 add_spvtools_unittest(TARGET val_abcde
   SRCS
        val_adjacency_test.cpp
+       val_annotation_test.cpp
        val_arithmetics_test.cpp
        val_atomics_test.cpp
        val_barriers_test.cpp

--- a/test/val/val_annotation_test.cpp
+++ b/test/val/val_annotation_test.cpp
@@ -130,6 +130,7 @@ TEST_P(StructDecorations, Struct) {
   const std::string deco = GetParam();
   const std::string text = R"(
 OpCapability Shader
+OpCapability Kernel
 OpCapability Linkage
 OpMemoryModel Logical GLSL450
 OpDecorate %struct )" + deco +
@@ -145,6 +146,7 @@ TEST_P(StructDecorations, OtherType) {
   const std::string deco = GetParam();
   const std::string text = R"(
 OpCapability Shader
+OpCapability Kernel
 OpCapability Linkage
 OpMemoryModel Logical GLSL450
 OpDecorate %int )" + deco + R"(
@@ -160,6 +162,7 @@ TEST_P(StructDecorations, Variable) {
   const std::string deco = GetParam();
   const std::string text = R"(
 OpCapability Shader
+OpCapability Kernel
 OpCapability Linkage
 OpMemoryModel Logical GLSL450
 OpDecorate %var )" + deco + R"(
@@ -177,6 +180,7 @@ TEST_P(StructDecorations, FunctionParameter) {
   const auto deco = GetParam();
   const std::string text = R"(
 OpCapability Shader
+OpCapability Kernel
 OpCapability Linkage
 OpMemoryModel Logical GLSL450
 OpDecorate %func LinkageAttributes "import" Import
@@ -199,6 +203,7 @@ TEST_P(StructDecorations, Constant) {
   const std::string deco = GetParam();
   const std::string text = R"(
 OpCapability Shader
+OpCapability Kernel
 OpCapability Linkage
 OpMemoryModel Logical GLSL450
 OpDecorate %int_0 )" + deco +
@@ -213,7 +218,8 @@ OpDecorate %int_0 )" + deco +
 }
 
 INSTANTIATE_TEST_SUITE_P(ValidateStructDecorations, StructDecorations,
-                         Values("Block", "BufferBlock"));
+                         Values("Block", "BufferBlock", "GLSLShared",
+                                "GLSLPacked", "CPacked"));
 
 using ArrayDecorations = spvtest::ValidateBase<std::string>;
 

--- a/test/val/val_annotation_test.cpp
+++ b/test/val/val_annotation_test.cpp
@@ -483,6 +483,8 @@ OpCapability SampleRateShading
 OpCapability TransformFeedback
 OpCapability GeometryStreams
 OpCapability Tessellation
+OpCapability PhysicalStorageBufferAddresses
+OpExtension "SPV_KHR_physical_storage_buffer"
 OpMemoryModel Logical GLSL450
 OpDecorate %var )" + deco + R"(
 %float = OpTypeFloat 32
@@ -503,6 +505,8 @@ OpCapability SampleRateShading
 OpCapability TransformFeedback
 OpCapability GeometryStreams
 OpCapability Tessellation
+OpCapability PhysicalStorageBufferAddresses
+OpExtension "SPV_KHR_physical_storage_buffer"
 OpMemoryModel Logical GLSL450
 OpDecorate %func LinkageAttributes "import" Import
 OpDecorate %param )" + deco +
@@ -529,6 +533,8 @@ OpCapability SampleRateShading
 OpCapability TransformFeedback
 OpCapability GeometryStreams
 OpCapability Tessellation
+OpCapability PhysicalStorageBufferAddresses
+OpExtension "SPV_KHR_physical_storage_buffer"
 OpMemoryModel Logical GLSL450
 OpDecorate %func LinkageAttributes "import" Import
 OpDecorate %param )" + deco +
@@ -555,6 +561,8 @@ OpCapability SampleRateShading
 OpCapability TransformFeedback
 OpCapability GeometryStreams
 OpCapability Tessellation
+OpCapability PhysicalStorageBufferAddresses
+OpExtension "SPV_KHR_physical_storage_buffer"
 OpMemoryModel Logical GLSL450
 OpDecorate %float )" + deco +
                            R"(
@@ -576,6 +584,8 @@ OpCapability SampleRateShading
 OpCapability TransformFeedback
 OpCapability GeometryStreams
 OpCapability Tessellation
+OpCapability PhysicalStorageBufferAddresses
+OpExtension "SPV_KHR_physical_storage_buffer"
 OpMemoryModel Logical GLSL450
 OpDecorate %const )" + deco +
                            R"(
@@ -590,12 +600,11 @@ OpDecorate %const )" + deco +
 }
 
 // NonWritable and NonReadable are covered by other tests.
-INSTANTIATE_TEST_SUITE_P(ValidateMemoryObjectDecorations,
-                         MemoryObjectDecorations,
-                         Values("NoPerspective", "Flat", "Patch", "Centroid",
-                                "Component 0", "Sample", "Restrict", "Aliased",
-                                "Volatile", "Coherent", "Stream 0",
-                                "XfbBuffer 1", "XfbStride 1"));
+INSTANTIATE_TEST_SUITE_P(
+    ValidateMemoryObjectDecorations, MemoryObjectDecorations,
+    Values("NoPerspective", "Flat", "Patch", "Centroid", "Component 0",
+           "Sample", "Restrict", "Aliased", "Volatile", "Coherent", "Stream 0",
+           "XfbBuffer 1", "XfbStride 1", "AliasedPointer", "RestrictPointer"));
 
 using VariableDecorations = spvtest::ValidateBase<std::string>;
 
@@ -606,8 +615,6 @@ OpCapability Shader
 OpCapability Kernel
 OpCapability Linkage
 OpCapability InputAttachment
-OpCapability PhysicalStorageBufferAddresses
-OpExtension "SPV_KHR_physical_storage_buffer"
 OpMemoryModel Logical GLSL450
 OpDecorate %var )" + deco + R"(
 %float = OpTypeFloat 32
@@ -626,8 +633,6 @@ OpCapability Shader
 OpCapability Kernel
 OpCapability Linkage
 OpCapability InputAttachment
-OpCapability PhysicalStorageBufferAddresses
-OpExtension "SPV_KHR_physical_storage_buffer"
 OpMemoryModel Logical GLSL450
 OpDecorate %func LinkageAttributes "import" Import
 OpDecorate %param )" + deco +
@@ -652,8 +657,6 @@ OpCapability Shader
 OpCapability Kernel
 OpCapability Linkage
 OpCapability InputAttachment
-OpCapability PhysicalStorageBufferAddresses
-OpExtension "SPV_KHR_physical_storage_buffer"
 OpMemoryModel Logical GLSL450
 OpDecorate %float )" + deco +
                            R"(
@@ -672,8 +675,6 @@ OpCapability Shader
 OpCapability Kernel
 OpCapability Linkage
 OpCapability InputAttachment
-OpCapability PhysicalStorageBufferAddresses
-OpExtension "SPV_KHR_physical_storage_buffer"
 OpMemoryModel Logical GLSL450
 OpDecorate %const )" + deco +
                            R"(
@@ -688,9 +689,7 @@ OpDecorate %const )" + deco +
 
 INSTANTIATE_TEST_SUITE_P(ValidateVariableDecorations, VariableDecorations,
                          Values("Invariant", "Constant", "Location 0",
-                                "Index 0", "Binding 0", "DescriptorSet 0",
-                                "InputAttachmentIndex 0", "RestrictPointer",
-                                "AliasedPointer"));
+                                "Index 0", "Binding 0", "DescriptorSet 0"));
 
 using VulkanIOStorageClass =
     spvtest::ValidateBase<std::tuple<std::string, std::string>>;

--- a/test/val/val_annotation_test.cpp
+++ b/test/val/val_annotation_test.cpp
@@ -73,9 +73,7 @@ OpDecorate %struct )" + deco +
 }
 
 INSTANTIATE_TEST_SUITE_P(ValidateMemberOnlyDecorations, MemberOnlyDecorations,
-                         Values("RowMajor",
-                                "ColMajor",
-                                "MatrixStride 16"
+                         Values("RowMajor", "ColMajor", "MatrixStride 16"
                                 // SPIR-V spec bug?
                                 /*,"Offset 0"*/));
 
@@ -96,7 +94,8 @@ OpExtension "SPV_KHR_physical_storage_buffer"
 OpExtension "SPV_GOOGLE_hlsl_functionality1"
 OpExtension "SPV_EXT_descriptor_indexing"
 OpMemoryModel Logical GLSL450
-OpMemberDecorate %struct 0 )" + deco + R"(
+OpMemberDecorate %struct 0 )" +
+                    deco + R"(
 %float = OpTypeFloat 32
 %float2 = OpTypeVector %float 2
 %float2x2 = OpTypeMatrix %float2 2
@@ -109,40 +108,21 @@ OpMemberDecorate %struct 0 )" + deco + R"(
               HasSubstr("cannot be applied to structure members"));
 }
 
-INSTANTIATE_TEST_SUITE_P(ValidateNonMemberOnlyDecorations, NonMemberOnlyDecorations,
-                         Values("SpecId 1",
-                                "Block",
-                                "BufferBlock",
-                                "ArrayStride 4",
-                                "GLSLShared",
-                                "GLSLPacked",
-                                "CPacked",
-                                // TODO: https://github.com/KhronosGroup/glslang/issues/703:
-                                // glslang applies Restrict to structure members.
-                                //"Restrict",
-                                "Aliased",
-                                "Constant",
-                                "Uniform",
-                                "SaturatedConversion",
-                                "Index 0",
-                                "Binding 0",
-                                "DescriptorSet 0",
-                                "FuncParamAttr Zext",
-                                "FPRoundingMode RTE",
-                                "FPFastMathMode None",
-                                "LinkageAttributes \"ext\" Import",
-                                "NoContraction",
-                                "InputAttachmentIndex 0",
-                                "Alignment 4",
-                                "MaxByteOffset 4",
-                                "AlignmentId %float",
-                                "MaxByteOffsetId %float",
-                                "NoSignedWrap",
-                                "NoUnsignedWrap",
-                                "NonUniform",
-                                "RestrictPointer",
-                                "AliasedPointer",
-                                "CounterBuffer %float"));
+INSTANTIATE_TEST_SUITE_P(
+    ValidateNonMemberOnlyDecorations, NonMemberOnlyDecorations,
+    Values("SpecId 1", "Block", "BufferBlock", "ArrayStride 4", "GLSLShared",
+           "GLSLPacked", "CPacked",
+           // TODO: https://github.com/KhronosGroup/glslang/issues/703:
+           // glslang applies Restrict to structure members.
+           //"Restrict",
+           "Aliased", "Constant", "Uniform", "SaturatedConversion", "Index 0",
+           "Binding 0", "DescriptorSet 0", "FuncParamAttr Zext",
+           "FPRoundingMode RTE", "FPFastMathMode None",
+           "LinkageAttributes \"ext\" Import", "NoContraction",
+           "InputAttachmentIndex 0", "Alignment 4", "MaxByteOffset 4",
+           "AlignmentId %float", "MaxByteOffsetId %float", "NoSignedWrap",
+           "NoUnsignedWrap", "NonUniform", "RestrictPointer", "AliasedPointer",
+           "CounterBuffer %float"));
 
 using StructDecorations = spvtest::ValidateBase<std::string>;
 
@@ -152,7 +132,8 @@ TEST_P(StructDecorations, Struct) {
 OpCapability Shader
 OpCapability Linkage
 OpMemoryModel Logical GLSL450
-OpDecorate %struct )" + deco + R"(
+OpDecorate %struct )" + deco +
+                           R"(
 %struct = OpTypeStruct
 )";
 
@@ -172,8 +153,7 @@ OpDecorate %int )" + deco + R"(
 
   CompileSuccessfully(text);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("must be a structure type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("must be a structure type"));
 }
 
 TEST_P(StructDecorations, Variable) {
@@ -190,8 +170,7 @@ OpDecorate %var )" + deco + R"(
 
   CompileSuccessfully(text);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("must be a structure type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("must be a structure type"));
 }
 
 TEST_P(StructDecorations, FunctionParameter) {
@@ -201,7 +180,8 @@ OpCapability Shader
 OpCapability Linkage
 OpMemoryModel Logical GLSL450
 OpDecorate %func LinkageAttributes "import" Import
-OpDecorate %param )" + deco + R"(
+OpDecorate %param )" + deco +
+                           R"(
 %int = OpTypeInt 32 0
 %void = OpTypeVoid
 %fn = OpTypeFunction %void %int
@@ -212,8 +192,7 @@ OpFunctionEnd
 
   CompileSuccessfully(text);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("must be a structure type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("must be a structure type"));
 }
 
 TEST_P(StructDecorations, Constant) {
@@ -222,15 +201,15 @@ TEST_P(StructDecorations, Constant) {
 OpCapability Shader
 OpCapability Linkage
 OpMemoryModel Logical GLSL450
-OpDecorate %int_0 )" + deco + R"(
+OpDecorate %int_0 )" + deco +
+                           R"(
 %int = OpTypeInt 32 0
 %int_0 = OpConstant %int 0
 )";
 
   CompileSuccessfully(text);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("must be a structure type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("must be a structure type"));
 }
 
 INSTANTIATE_TEST_SUITE_P(ValidateStructDecorations, StructDecorations,
@@ -244,7 +223,8 @@ TEST_P(ArrayDecorations, Array) {
 OpCapability Shader
 OpCapability Linkage
 OpMemoryModel Logical GLSL450
-OpDecorate %array )" + deco + R"(
+OpDecorate %array )" + deco +
+                           R"(
 %int = OpTypeInt 32 0
 %int_4 = OpConstant %int 4
 %array = OpTypeArray %int %int_4
@@ -260,7 +240,8 @@ TEST_P(ArrayDecorations, RuntimeArray) {
 OpCapability Shader
 OpCapability Linkage
 OpMemoryModel Logical GLSL450
-OpDecorate %array )" + deco + R"(
+OpDecorate %array )" + deco +
+                           R"(
 %int = OpTypeInt 32 0
 %array = OpTypeRuntimeArray %int
 )";
@@ -290,7 +271,8 @@ TEST_P(ArrayDecorations, Struct) {
 OpCapability Shader
 OpCapability Linkage
 OpMemoryModel Logical GLSL450
-OpDecorate %struct )" + deco + R"(
+OpDecorate %struct )" + deco +
+                           R"(
 %int = OpTypeInt 32 0
 %struct = OpTypeStruct %int
 )";
@@ -326,7 +308,8 @@ OpCapability Shader
 OpCapability Linkage
 OpMemoryModel Logical GLSL450
 OpDecorate %func LinkageAttributes "import" Import
-OpDecorate %param )" + deco + R"(
+OpDecorate %param )" + deco +
+                           R"(
 %int = OpTypeInt 32 0
 %void = OpTypeVoid
 %fn = OpTypeFunction %void %int
@@ -347,7 +330,8 @@ TEST_P(ArrayDecorations, Constant) {
 OpCapability Shader
 OpCapability Linkage
 OpMemoryModel Logical GLSL450
-OpDecorate %null )" + deco + R"(
+OpDecorate %null )" + deco +
+                           R"(
 %int = OpTypeInt 32 0
 %int_4 = OpConstant %int 4
 %array = OpTypeArray %int %int_4
@@ -371,7 +355,8 @@ TEST_P(BuiltInDecorations, Variable) {
 OpCapability Shader
 OpCapability Linkage
 OpMemoryModel Logical GLSL450
-OpDecorate %var BuiltIn )" + deco + R"(
+OpDecorate %var BuiltIn )" +
+                           deco + R"(
 %int = OpTypeInt 32 0
 %ptr = OpTypePointer Input %int
 %var = OpVariable %ptr Input
@@ -393,7 +378,8 @@ TEST_P(BuiltInDecorations, IntegerType) {
 OpCapability Shader
 OpCapability Linkage
 OpMemoryModel Logical GLSL450
-OpDecorate %int BuiltIn )" + deco + R"(
+OpDecorate %int BuiltIn )" +
+                           deco + R"(
 %int = OpTypeInt 32 0
 )";
 
@@ -411,7 +397,8 @@ OpCapability Shader
 OpCapability Linkage
 OpMemoryModel Logical GLSL450
 OpDecorate %func LinkageAttributes "import" Import
-OpDecorate %param BuiltIn )" + deco + R"(
+OpDecorate %param BuiltIn )" +
+                           deco + R"(
 %int = OpTypeInt 32 0
 %void = OpTypeVoid
 %fn = OpTypeFunction %void %int
@@ -433,7 +420,8 @@ TEST_P(BuiltInDecorations, Constant) {
 OpCapability Shader
 OpCapability Linkage
 OpMemoryModel Logical GLSL450
-OpDecorate %const BuiltIn )" + deco + R"(
+OpDecorate %const BuiltIn )" +
+                           deco + R"(
 %int = OpTypeInt 32 0
 %int3 = OpTypeVector %int 3
 %int_1 = OpConstant %int 1
@@ -445,8 +433,7 @@ OpDecorate %const BuiltIn )" + deco + R"(
     EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
   } else {
     EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-    EXPECT_THAT(getDiagnosticString(),
-                HasSubstr("must be a variable"));
+    EXPECT_THAT(getDiagnosticString(), HasSubstr("must be a variable"));
   }
 }
 
@@ -456,7 +443,8 @@ TEST_P(BuiltInDecorations, SpecConstant) {
 OpCapability Shader
 OpCapability Linkage
 OpMemoryModel Logical GLSL450
-OpDecorate %const BuiltIn )" + deco + R"(
+OpDecorate %const BuiltIn )" +
+                           deco + R"(
 %int = OpTypeInt 32 0
 %int3 = OpTypeVector %int 3
 %int_1 = OpConstant %int 1
@@ -468,22 +456,15 @@ OpDecorate %const BuiltIn )" + deco + R"(
     EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
   } else {
     EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-    EXPECT_THAT(getDiagnosticString(),
-                HasSubstr("must be a variable"));
+    EXPECT_THAT(getDiagnosticString(), HasSubstr("must be a variable"));
   }
 }
 
 INSTANTIATE_TEST_SUITE_P(ValidateBuiltInDecorations, BuiltInDecorations,
-                         Values("Position",
-                                "PointSize",
-                                "VertexId",
-                                "InstanceId",
-                                "FragCoord",
-                                "FrontFacing",
-                                "NumWorkgroups",
-                                "WorkgroupSize",
-                                "LocalInvocationId",
-                                "GlobalInvocationId"));
+                         Values("Position", "PointSize", "VertexId",
+                                "InstanceId", "FragCoord", "FrontFacing",
+                                "NumWorkgroups", "WorkgroupSize",
+                                "LocalInvocationId", "GlobalInvocationId"));
 
 using MemoryObjectDecorations = spvtest::ValidateBase<std::string>;
 
@@ -516,7 +497,8 @@ OpCapability TransformFeedback
 OpCapability Tessellation
 OpMemoryModel Logical GLSL450
 OpDecorate %func LinkageAttributes "import" Import
-OpDecorate %param )" + deco + R"(
+OpDecorate %param )" + deco +
+                           R"(
 %float = OpTypeFloat 32
 %void = OpTypeVoid
 %fn = OpTypeFunction %void %float
@@ -538,7 +520,8 @@ OpCapability SampleRateShading
 OpCapability TransformFeedback
 OpCapability Tessellation
 OpMemoryModel Logical GLSL450
-OpDecorate %float )" + deco + R"(
+OpDecorate %float )" + deco +
+                           R"(
 %float = OpTypeFloat 32
 )";
 
@@ -557,7 +540,8 @@ OpCapability SampleRateShading
 OpCapability TransformFeedback
 OpCapability Tessellation
 OpMemoryModel Logical GLSL450
-OpDecorate %const )" + deco + R"(
+OpDecorate %const )" + deco +
+                           R"(
 %float = OpTypeFloat 32
 %const = OpConstant %float 0
 )";
@@ -571,17 +555,9 @@ OpDecorate %const )" + deco + R"(
 // NonWritable and NonReadable are covered by other tests.
 INSTANTIATE_TEST_SUITE_P(ValidateMemoryObjectDecorations,
                          MemoryObjectDecorations,
-                         Values("NoPerspective",
-                                "Flat",
-                                "Patch",
-                                "Centroid",
-                                "Sample",
-                                "Restrict",
-                                "Aliased",
-                                "Volatile",
-                                "Coherent",
-                                "XfbBuffer 1",
-                                "XfbStride 1"));
+                         Values("NoPerspective", "Flat", "Patch", "Centroid",
+                                "Sample", "Restrict", "Aliased", "Volatile",
+                                "Coherent", "XfbBuffer 1", "XfbStride 1"));
 
 using VariableDecorations = spvtest::ValidateBase<std::string>;
 
@@ -616,7 +592,8 @@ OpCapability PhysicalStorageBufferAddresses
 OpExtension "SPV_KHR_physical_storage_buffer"
 OpMemoryModel Logical GLSL450
 OpDecorate %func LinkageAttributes "import" Import
-OpDecorate %param )" + deco + R"(
+OpDecorate %param )" + deco +
+                           R"(
 %float = OpTypeFloat 32
 %void = OpTypeVoid
 %fn = OpTypeFunction %void %float
@@ -627,8 +604,7 @@ OpFunctionEnd
 
   CompileSuccessfully(text);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("must be a variable"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("must be a variable"));
 }
 
 TEST_P(VariableDecorations, FloatType) {
@@ -641,14 +617,14 @@ OpCapability InputAttachment
 OpCapability PhysicalStorageBufferAddresses
 OpExtension "SPV_KHR_physical_storage_buffer"
 OpMemoryModel Logical GLSL450
-OpDecorate %float )" + deco + R"(
+OpDecorate %float )" + deco +
+                           R"(
 %float = OpTypeFloat 32
 )";
 
   CompileSuccessfully(text);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("must be a variable"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("must be a variable"));
 }
 
 TEST_P(VariableDecorations, Constant) {
@@ -661,30 +637,25 @@ OpCapability InputAttachment
 OpCapability PhysicalStorageBufferAddresses
 OpExtension "SPV_KHR_physical_storage_buffer"
 OpMemoryModel Logical GLSL450
-OpDecorate %const )" + deco + R"(
+OpDecorate %const )" + deco +
+                           R"(
 %float = OpTypeFloat 32
 %const = OpConstant %float 0
 )";
 
   CompileSuccessfully(text);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("must be a variable"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("must be a variable"));
 }
 
 INSTANTIATE_TEST_SUITE_P(ValidateVariableDecorations, VariableDecorations,
-                         Values("Invariant",
-                                "Constant",
-                                "Location 0",
-                                "Component 0",
-                                "Index 0",
-                                "Binding 0",
-                                "DescriptorSet 0",
-                                "InputAttachmentIndex 0",
-                                "RestrictPointer",
-                                "AliasedPointer"));
+                         Values("Invariant", "Constant", "Location 0",
+                                "Component 0", "Index 0", "Binding 0",
+                                "DescriptorSet 0", "InputAttachmentIndex 0",
+                                "RestrictPointer", "AliasedPointer"));
 
-using VulkanIOStorageClass = spvtest::ValidateBase<std::tuple<std::string, std::string>>;
+using VulkanIOStorageClass =
+    spvtest::ValidateBase<std::tuple<std::string, std::string>>;
 
 TEST_P(VulkanIOStorageClass, Invalid) {
   const auto deco = std::get<0>(GetParam());
@@ -698,8 +669,10 @@ OpExecutionMode %main OriginUpperLeft
 OpDecorate %var )" + deco + R"( 0
 %void = OpTypeVoid
 %float = OpTypeFloat 32
-%ptr = OpTypePointer )" + sc + R"( %float
-%var = OpVariable %ptr )" + sc + R"(
+%ptr = OpTypePointer )" + sc +
+                           R"( %float
+%var = OpVariable %ptr )" + sc +
+                           R"(
 %void_fn = OpTypeFunction %void
 %main = OpFunction %void None %void_fn
 %entry = OpLabel
@@ -709,19 +682,19 @@ OpFunctionEnd
 
   CompileSuccessfully(text, SPV_ENV_VULKAN_1_0);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_0));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("decoration must not be applied to this storage class"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("decoration must not be applied to this storage class"));
 }
 
 INSTANTIATE_TEST_SUITE_P(ValidateVulkanIOStorageClass, VulkanIOStorageClass,
                          Combine(Values("Location", "Component"),
-                                 Values("StorageBuffer",
-                                        "Uniform",
-                                        "UniformConstant",
-                                        "Workgroup",
+                                 Values("StorageBuffer", "Uniform",
+                                        "UniformConstant", "Workgroup",
                                         "Private")));
 
-using VulkanResourceStorageClass = spvtest::ValidateBase<std::tuple<std::string, std::string>>;
+using VulkanResourceStorageClass =
+    spvtest::ValidateBase<std::tuple<std::string, std::string>>;
 
 TEST_P(VulkanResourceStorageClass, Invalid) {
   const auto deco = std::get<0>(GetParam());
@@ -734,8 +707,10 @@ OpExecutionMode %main OriginUpperLeft
 OpDecorate %var )" + deco + R"( 0
 %void = OpTypeVoid
 %float = OpTypeFloat 32
-%ptr = OpTypePointer )" + sc + R"( %float
-%var = OpVariable %ptr )" + sc + R"(
+%ptr = OpTypePointer )" + sc +
+                           R"( %float
+%var = OpVariable %ptr )" + sc +
+                           R"(
 %void_fn = OpTypeFunction %void
 %main = OpFunction %void None %void_fn
 %entry = OpLabel
@@ -750,11 +725,10 @@ OpFunctionEnd
                         "UniformConstant storage class"));
 }
 
-INSTANTIATE_TEST_SUITE_P(ValidateVulkanResourceStorageClass, VulkanResourceStorageClass,
+INSTANTIATE_TEST_SUITE_P(ValidateVulkanResourceStorageClass,
+                         VulkanResourceStorageClass,
                          Combine(Values("DescriptorSet", "Binding"),
-                                 Values("Private",
-                                        "Input",
-                                        "Output",
+                                 Values("Private", "Input", "Output",
                                         "Workgroup")));
 
 }  // namespace

--- a/test/val/val_annotation_test.cpp
+++ b/test/val/val_annotation_test.cpp
@@ -1,0 +1,762 @@
+// Copyright (c) 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Validation tests for decorations
+
+#include <string>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "test/test_fixture.h"
+#include "test/unit_spirv.h"
+#include "test/val/val_code_generator.h"
+#include "test/val/val_fixtures.h"
+
+namespace spvtools {
+namespace val {
+namespace {
+
+using ::testing::Combine;
+using ::testing::Eq;
+using ::testing::HasSubstr;
+using ::testing::Values;
+
+using MemberOnlyDecorations = spvtest::ValidateBase<std::string>;
+
+TEST_P(MemberOnlyDecorations, MemberDecoration) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpMemberDecorate %struct 0 )" +
+                           deco + R"(
+%float = OpTypeFloat 32
+%float2 = OpTypeVector %float 2
+%float2x2 = OpTypeMatrix %float2 2
+%struct = OpTypeStruct %float2x2
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_P(MemberOnlyDecorations, Decoration) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %struct )" + deco +
+                           R"(
+%float = OpTypeFloat 32
+%float2 = OpTypeVector %float 2
+%float2x2 = OpTypeMatrix %float2 2
+%struct = OpTypeStruct %float2x2
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("can only be applied to structure members"));
+}
+
+INSTANTIATE_TEST_SUITE_P(ValidateMemberOnlyDecorations, MemberOnlyDecorations,
+                         Values("RowMajor",
+                                "ColMajor",
+                                "MatrixStride 16"
+                                // SPIR-V spec bug?
+                                /*,"Offset 0"*/));
+
+using NonMemberOnlyDecorations = spvtest::ValidateBase<std::string>;
+
+TEST_P(NonMemberOnlyDecorations, MemberDecoration) {
+  const auto deco = GetParam();
+  const auto text = R"(
+OpCapability Shader
+OpCapability Kernel
+OpCapability Linkage
+OpCapability InputAttachment
+OpCapability Addresses
+OpCapability PhysicalStorageBufferAddresses
+OpCapability ShaderNonUniform
+OpExtension "SPV_KHR_no_integer_wrap_decoration"
+OpExtension "SPV_KHR_physical_storage_buffer"
+OpExtension "SPV_GOOGLE_hlsl_functionality1"
+OpExtension "SPV_EXT_descriptor_indexing"
+OpMemoryModel Logical GLSL450
+OpMemberDecorate %struct 0 )" + deco + R"(
+%float = OpTypeFloat 32
+%float2 = OpTypeVector %float 2
+%float2x2 = OpTypeMatrix %float2 2
+%struct = OpTypeStruct %float2x2
+)";
+
+  CompileSuccessfully(text, SPV_ENV_UNIVERSAL_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("cannot be applied to structure members"));
+}
+
+INSTANTIATE_TEST_SUITE_P(ValidateNonMemberOnlyDecorations, NonMemberOnlyDecorations,
+                         Values("SpecId 1",
+                                "Block",
+                                "BufferBlock",
+                                "ArrayStride 4",
+                                "GLSLShared",
+                                "GLSLPacked",
+                                "CPacked",
+                                // TODO: https://github.com/KhronosGroup/glslang/issues/703:
+                                // glslang applies Restrict to structure members.
+                                //"Restrict",
+                                "Aliased",
+                                "Constant",
+                                "Uniform",
+                                "SaturatedConversion",
+                                "Index 0",
+                                "Binding 0",
+                                "DescriptorSet 0",
+                                "FuncParamAttr Zext",
+                                "FPRoundingMode RTE",
+                                "FPFastMathMode None",
+                                "LinkageAttributes \"ext\" Import",
+                                "NoContraction",
+                                "InputAttachmentIndex 0",
+                                "Alignment 4",
+                                "MaxByteOffset 4",
+                                "AlignmentId %float",
+                                "MaxByteOffsetId %float",
+                                "NoSignedWrap",
+                                "NoUnsignedWrap",
+                                "NonUniform",
+                                "RestrictPointer",
+                                "AliasedPointer",
+                                "CounterBuffer %float"));
+
+using StructDecorations = spvtest::ValidateBase<std::string>;
+
+TEST_P(StructDecorations, Struct) {
+  const std::string deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %struct )" + deco + R"(
+%struct = OpTypeStruct
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_P(StructDecorations, OtherType) {
+  const std::string deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %int )" + deco + R"(
+%int = OpTypeInt 32 0
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("must be a structure type"));
+}
+
+TEST_P(StructDecorations, Variable) {
+  const std::string deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %var )" + deco + R"(
+%int = OpTypeInt 32 0
+%ptr = OpTypePointer Private %int
+%var = OpVariable %ptr Private
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("must be a structure type"));
+}
+
+TEST_P(StructDecorations, FunctionParameter) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %func LinkageAttributes "import" Import
+OpDecorate %param )" + deco + R"(
+%int = OpTypeInt 32 0
+%void = OpTypeVoid
+%fn = OpTypeFunction %void %int
+%func = OpFunction %void None %fn
+%param = OpFunctionParameter %int
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("must be a structure type"));
+}
+
+TEST_P(StructDecorations, Constant) {
+  const std::string deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %int_0 )" + deco + R"(
+%int = OpTypeInt 32 0
+%int_0 = OpConstant %int 0
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("must be a structure type"));
+}
+
+INSTANTIATE_TEST_SUITE_P(ValidateStructDecorations, StructDecorations,
+                         Values("Block", "BufferBlock"));
+
+using ArrayDecorations = spvtest::ValidateBase<std::string>;
+
+TEST_P(ArrayDecorations, Array) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %array )" + deco + R"(
+%int = OpTypeInt 32 0
+%int_4 = OpConstant %int 4
+%array = OpTypeArray %int %int_4
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_P(ArrayDecorations, RuntimeArray) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %array )" + deco + R"(
+%int = OpTypeInt 32 0
+%array = OpTypeRuntimeArray %int
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_P(ArrayDecorations, Pointer) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %ptr )" + deco + R"(
+%int = OpTypeInt 32 0
+%ptr = OpTypePointer Workgroup %int
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_P(ArrayDecorations, Struct) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %struct )" + deco + R"(
+%int = OpTypeInt 32 0
+%struct = OpTypeStruct %int
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("must be an array or pointer type"));
+}
+
+TEST_P(ArrayDecorations, Variable) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %var )" + deco + R"(
+%int = OpTypeInt 32 0
+%ptr = OpTypePointer Private %int
+%var = OpVariable %ptr Private
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("must be an array or pointer type"));
+}
+
+TEST_P(ArrayDecorations, FunctionParameter) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %func LinkageAttributes "import" Import
+OpDecorate %param )" + deco + R"(
+%int = OpTypeInt 32 0
+%void = OpTypeVoid
+%fn = OpTypeFunction %void %int
+%func = OpFunction %void None %fn
+%param = OpFunctionParameter %int
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("must be an array or pointer type"));
+}
+
+TEST_P(ArrayDecorations, Constant) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %null )" + deco + R"(
+%int = OpTypeInt 32 0
+%int_4 = OpConstant %int 4
+%array = OpTypeArray %int %int_4
+%null = OpConstantNull %array
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("must be an array or pointer type"));
+}
+
+INSTANTIATE_TEST_SUITE_P(ValidateArrayDecorations, ArrayDecorations,
+                         Values("ArrayStride 4"));
+
+using BuiltInDecorations = spvtest::ValidateBase<std::string>;
+
+TEST_P(BuiltInDecorations, Variable) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %var BuiltIn )" + deco + R"(
+%int = OpTypeInt 32 0
+%ptr = OpTypePointer Input %int
+%var = OpVariable %ptr Input
+)";
+
+  CompileSuccessfully(text);
+  if (deco != "WorkgroupSize") {
+    EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+  } else {
+    EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+    EXPECT_THAT(getDiagnosticString(),
+                HasSubstr("must be a constant for WorkgroupSize"));
+  }
+}
+
+TEST_P(BuiltInDecorations, IntegerType) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %int BuiltIn )" + deco + R"(
+%int = OpTypeInt 32 0
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("BuiltIns can only target variables, structs or constants"));
+}
+
+TEST_P(BuiltInDecorations, FunctionParameter) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %func LinkageAttributes "import" Import
+OpDecorate %param BuiltIn )" + deco + R"(
+%int = OpTypeInt 32 0
+%void = OpTypeVoid
+%fn = OpTypeFunction %void %int
+%func = OpFunction %void None %fn
+%param = OpFunctionParameter %int
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("BuiltIns can only target variables, structs or constants"));
+}
+
+TEST_P(BuiltInDecorations, Constant) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %const BuiltIn )" + deco + R"(
+%int = OpTypeInt 32 0
+%int3 = OpTypeVector %int 3
+%int_1 = OpConstant %int 1
+%const = OpConstantComposite %int3 %int_1 %int_1 %int_1
+)";
+
+  CompileSuccessfully(text);
+  if (deco == "WorkgroupSize") {
+    EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+  } else {
+    EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+    EXPECT_THAT(getDiagnosticString(),
+                HasSubstr("must be a variable"));
+  }
+}
+
+TEST_P(BuiltInDecorations, SpecConstant) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+OpDecorate %const BuiltIn )" + deco + R"(
+%int = OpTypeInt 32 0
+%int3 = OpTypeVector %int 3
+%int_1 = OpConstant %int 1
+%const = OpSpecConstantComposite %int3 %int_1 %int_1 %int_1
+)";
+
+  CompileSuccessfully(text);
+  if (deco == "WorkgroupSize") {
+    EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+  } else {
+    EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+    EXPECT_THAT(getDiagnosticString(),
+                HasSubstr("must be a variable"));
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(ValidateBuiltInDecorations, BuiltInDecorations,
+                         Values("Position",
+                                "PointSize",
+                                "VertexId",
+                                "InstanceId",
+                                "FragCoord",
+                                "FrontFacing",
+                                "NumWorkgroups",
+                                "WorkgroupSize",
+                                "LocalInvocationId",
+                                "GlobalInvocationId"));
+
+using MemoryObjectDecorations = spvtest::ValidateBase<std::string>;
+
+TEST_P(MemoryObjectDecorations, Variable) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpCapability SampleRateShading
+OpCapability TransformFeedback
+OpCapability Tessellation
+OpMemoryModel Logical GLSL450
+OpDecorate %var )" + deco + R"(
+%float = OpTypeFloat 32
+%ptr = OpTypePointer Input %float
+%var = OpVariable %ptr Input
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_P(MemoryObjectDecorations, FunctionParameter) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpCapability SampleRateShading
+OpCapability TransformFeedback
+OpCapability Tessellation
+OpMemoryModel Logical GLSL450
+OpDecorate %func LinkageAttributes "import" Import
+OpDecorate %param )" + deco + R"(
+%float = OpTypeFloat 32
+%void = OpTypeVoid
+%fn = OpTypeFunction %void %float
+%func = OpFunction %void None %fn
+%param = OpFunctionParameter %float
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_P(MemoryObjectDecorations, FloatType) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpCapability SampleRateShading
+OpCapability TransformFeedback
+OpCapability Tessellation
+OpMemoryModel Logical GLSL450
+OpDecorate %float )" + deco + R"(
+%float = OpTypeFloat 32
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("must be a memory object declaration"));
+}
+
+TEST_P(MemoryObjectDecorations, Constant) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpCapability SampleRateShading
+OpCapability TransformFeedback
+OpCapability Tessellation
+OpMemoryModel Logical GLSL450
+OpDecorate %const )" + deco + R"(
+%float = OpTypeFloat 32
+%const = OpConstant %float 0
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("must be a memory object declaration"));
+}
+
+// NonWritable and NonReadable are covered by other tests.
+INSTANTIATE_TEST_SUITE_P(ValidateMemoryObjectDecorations,
+                         MemoryObjectDecorations,
+                         Values("NoPerspective",
+                                "Flat",
+                                "Patch",
+                                "Centroid",
+                                "Sample",
+                                "Restrict",
+                                "Aliased",
+                                "Volatile",
+                                "Coherent",
+                                "XfbBuffer 1",
+                                "XfbStride 1"));
+
+using VariableDecorations = spvtest::ValidateBase<std::string>;
+
+TEST_P(VariableDecorations, Variable) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Kernel
+OpCapability Linkage
+OpCapability InputAttachment
+OpCapability PhysicalStorageBufferAddresses
+OpExtension "SPV_KHR_physical_storage_buffer"
+OpMemoryModel Logical GLSL450
+OpDecorate %var )" + deco + R"(
+%float = OpTypeFloat 32
+%ptr = OpTypePointer Input %float
+%var = OpVariable %ptr Input
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_P(VariableDecorations, FunctionParameter) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Kernel
+OpCapability Linkage
+OpCapability InputAttachment
+OpCapability PhysicalStorageBufferAddresses
+OpExtension "SPV_KHR_physical_storage_buffer"
+OpMemoryModel Logical GLSL450
+OpDecorate %func LinkageAttributes "import" Import
+OpDecorate %param )" + deco + R"(
+%float = OpTypeFloat 32
+%void = OpTypeVoid
+%fn = OpTypeFunction %void %float
+%func = OpFunction %void None %fn
+%param = OpFunctionParameter %float
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("must be a variable"));
+}
+
+TEST_P(VariableDecorations, FloatType) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Kernel
+OpCapability Linkage
+OpCapability InputAttachment
+OpCapability PhysicalStorageBufferAddresses
+OpExtension "SPV_KHR_physical_storage_buffer"
+OpMemoryModel Logical GLSL450
+OpDecorate %float )" + deco + R"(
+%float = OpTypeFloat 32
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("must be a variable"));
+}
+
+TEST_P(VariableDecorations, Constant) {
+  const auto deco = GetParam();
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Kernel
+OpCapability Linkage
+OpCapability InputAttachment
+OpCapability PhysicalStorageBufferAddresses
+OpExtension "SPV_KHR_physical_storage_buffer"
+OpMemoryModel Logical GLSL450
+OpDecorate %const )" + deco + R"(
+%float = OpTypeFloat 32
+%const = OpConstant %float 0
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("must be a variable"));
+}
+
+INSTANTIATE_TEST_SUITE_P(ValidateVariableDecorations, VariableDecorations,
+                         Values("Invariant",
+                                "Constant",
+                                "Location 0",
+                                "Component 0",
+                                "Index 0",
+                                "Binding 0",
+                                "DescriptorSet 0",
+                                "InputAttachmentIndex 0",
+                                "RestrictPointer",
+                                "AliasedPointer"));
+
+using VulkanIOStorageClass = spvtest::ValidateBase<std::tuple<std::string, std::string>>;
+
+TEST_P(VulkanIOStorageClass, Invalid) {
+  const auto deco = std::get<0>(GetParam());
+  const auto sc = std::get<1>(GetParam());
+  const std::string text = R"(
+OpCapability Shader
+OpExtension "SPV_KHR_storage_buffer_storage_class"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main"
+OpExecutionMode %main OriginUpperLeft
+OpDecorate %var )" + deco + R"( 0
+%void = OpTypeVoid
+%float = OpTypeFloat 32
+%ptr = OpTypePointer )" + sc + R"( %float
+%var = OpVariable %ptr )" + sc + R"(
+%void_fn = OpTypeFunction %void
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_0);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("decoration must not be applied to this storage class"));
+}
+
+INSTANTIATE_TEST_SUITE_P(ValidateVulkanIOStorageClass, VulkanIOStorageClass,
+                         Combine(Values("Location", "Component"),
+                                 Values("StorageBuffer",
+                                        "Uniform",
+                                        "UniformConstant",
+                                        "Workgroup",
+                                        "Private")));
+
+using VulkanResourceStorageClass = spvtest::ValidateBase<std::tuple<std::string, std::string>>;
+
+TEST_P(VulkanResourceStorageClass, Invalid) {
+  const auto deco = std::get<0>(GetParam());
+  const auto sc = std::get<1>(GetParam());
+  const std::string text = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main"
+OpExecutionMode %main OriginUpperLeft
+OpDecorate %var )" + deco + R"( 0
+%void = OpTypeVoid
+%float = OpTypeFloat 32
+%ptr = OpTypePointer )" + sc + R"( %float
+%var = OpVariable %ptr )" + sc + R"(
+%void_fn = OpTypeFunction %void
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_0);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("must be in the StorageBuffer, Uniform, or "
+                        "UniformConstant storage class"));
+}
+
+INSTANTIATE_TEST_SUITE_P(ValidateVulkanResourceStorageClass, VulkanResourceStorageClass,
+                         Combine(Values("DescriptorSet", "Binding"),
+                                 Values("Private",
+                                        "Input",
+                                        "Output",
+                                        "Workgroup")));
+
+}  // namespace
+}  // namespace val
+}  // namespace spvtools

--- a/test/val/val_annotation_test.cpp
+++ b/test/val/val_annotation_test.cpp
@@ -669,7 +669,8 @@ OpExecutionMode %main OriginUpperLeft
 OpDecorate %var )" + deco + R"( 0
 %void = OpTypeVoid
 %float = OpTypeFloat 32
-%ptr = OpTypePointer )" + sc +
+%ptr = OpTypePointer )" +
+                           sc +
                            R"( %float
 %var = OpVariable %ptr )" + sc +
                            R"(
@@ -707,7 +708,8 @@ OpExecutionMode %main OriginUpperLeft
 OpDecorate %var )" + deco + R"( 0
 %void = OpTypeVoid
 %float = OpTypeFloat 32
-%ptr = OpTypePointer )" + sc +
+%ptr = OpTypePointer )" +
+                           sc +
                            R"( %float
 %var = OpVariable %ptr )" + sc +
                            R"(

--- a/test/val/val_builtins_test.cpp
+++ b/test/val/val_builtins_test.cpp
@@ -2861,9 +2861,9 @@ OpDecorate %copy BuiltIn WorkgroupSize
 
   CompileSuccessfully(generator.Build(), SPV_ENV_VULKAN_1_0);
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("BuiltIns can only target variables, structs or constants"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("BuiltIns can only target variables, structure "
+                        "members or constants"));
 }
 
 CodeGenerator GetWorkgroupSizeNotVectorGenerator() {
@@ -3752,9 +3752,9 @@ OpDecorate %void BuiltIn Position
 
   CompileSuccessfully(text);
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("BuiltIns can only target variables, structs or constants"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("BuiltIns can only target variables, structure members "
+                        "or constants"));
 }
 
 TEST_F(ValidateBuiltIns, TargetIsVariable) {

--- a/test/val/val_builtins_test.cpp
+++ b/test/val/val_builtins_test.cpp
@@ -3482,35 +3482,6 @@ OpDecorate %gl_ViewportIndex PerPrimitiveNV
   EXPECT_THAT(getDiagnosticString(), HasSubstr("is not an int scalar"));
 }
 
-TEST_F(ValidateBuiltIns, GetUnderlyingTypeNoAssert) {
-  std::string spirv = R"(
-                      OpCapability Shader
-                      OpMemoryModel Logical GLSL450
-                      OpEntryPoint Fragment %4 "PSMa" %12 %17
-                      OpExecutionMode %4 OriginUpperLeft
-                      OpDecorate %gl_PointCoord BuiltIn PointCoord
-                      OpDecorate %12 Location 0
-                      OpDecorate %17 Location 0
-              %void = OpTypeVoid
-                 %3 = OpTypeFunction %void
-             %float = OpTypeFloat 32
-           %v4float = OpTypeVector %float 4
-       %gl_PointCoord = OpTypeStruct %v4float
-       %_ptr_Input_v4float = OpTypePointer Input %v4float
-       %_ptr_Output_v4float = OpTypePointer Output %v4float
-                %12 = OpVariable %_ptr_Input_v4float Input
-                %17 = OpVariable %_ptr_Output_v4float Output
-                 %4 = OpFunction %void None %3
-                %15 = OpLabel
-                      OpReturn
-                      OpFunctionEnd)";
-  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_1);
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_1));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("did not find an member index to get underlying data "
-                        "type"));
-}
-
 TEST_P(ValidateVulkanSubgroupBuiltIns, InMain) {
   const char* const built_in = std::get<0>(GetParam());
   const char* const execution_model = std::get<1>(GetParam());
@@ -3795,47 +3766,6 @@ OpDecorate %wg_var BuiltIn Position
 %int = OpTypeInt 32 0
 %int_wg_ptr = OpTypePointer Workgroup %int
 %wg_var = OpVariable %int_wg_ptr Workgroup
-)";
-
-  CompileSuccessfully(text);
-  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
-}
-
-TEST_F(ValidateBuiltIns, TargetIsStruct) {
-  const std::string text = R"(
-OpCapability Shader
-OpCapability Linkage
-OpMemoryModel Logical GLSL450
-OpDecorate %struct BuiltIn Position
-%struct = OpTypeStruct
-)";
-
-  CompileSuccessfully(text);
-  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
-}
-
-TEST_F(ValidateBuiltIns, TargetIsConstant) {
-  const std::string text = R"(
-OpCapability Shader
-OpCapability Linkage
-OpMemoryModel Logical GLSL450
-OpDecorate %int0 BuiltIn Position
-%int = OpTypeInt 32 0
-%int0 = OpConstant %int 0
-)";
-
-  CompileSuccessfully(text);
-  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
-}
-
-TEST_F(ValidateBuiltIns, TargetIsSpecConstant) {
-  const std::string text = R"(
-OpCapability Shader
-OpCapability Linkage
-OpMemoryModel Logical GLSL450
-OpDecorate %int0 BuiltIn Position
-%int = OpTypeInt 32 0
-%int0 = OpSpecConstant %int 0
 )";
 
   CompileSuccessfully(text);

--- a/test/val/val_capability_test.cpp
+++ b/test/val/val_capability_test.cpp
@@ -1256,18 +1256,18 @@ std::make_pair(std::string(kOpenCLMemoryModel) +
           MatrixDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt GLSLShared\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %struct GLSLShared\n"
+          "%struct = OpTypeStruct\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt GLSLPacked\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %struct GLSLPacked\n"
+          "%struct = OpTypeStruct\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kGLSL450MemoryModel) +
           "OpEntryPoint Vertex %func \"shader\" \n"
-          "OpDecorate %intt CPacked\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %struct CPacked\n"
+          "%struct = OpTypeStruct\n" + std::string(kVoidFVoid),
           KernelDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"

--- a/test/val/val_capability_test.cpp
+++ b/test/val/val_capability_test.cpp
@@ -1205,8 +1205,10 @@ INSTANTIATE_TEST_SUITE_P(Decoration, ValidateCapability,
                             Values(
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt RelaxedPrecision\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %var RelaxedPrecision\n"
+          "%intt = OpTypeInt 32 0\n"
+          "%ptr = OpTypePointer Private %intt\n"
+          "%var = OpVariable %ptr Private\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           // Block applies to struct type.
@@ -1224,23 +1226,33 @@ std::make_pair(std::string(kOpenCLMemoryModel) +
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt RowMajor\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpMemberDecorate %structt 0 RowMajor\n"
+          "%floatt = OpTypeFloat 32\n"
+          "%float2 = OpTypeVector %floatt 2\n"
+          "%mat2x2 = OpTypeMatrix %float2 2\n"
+          "%structt = OpTypeStruct %mat2x2\n" + std::string(kVoidFVoid),
           MatrixDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt ColMajor\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpMemberDecorate %structt 0 ColMajor\n"
+          "%floatt = OpTypeFloat 32\n"
+          "%float2 = OpTypeVector %floatt 2\n"
+          "%mat2x2 = OpTypeMatrix %float2 2\n"
+          "%structt = OpTypeStruct %mat2x2\n" + std::string(kVoidFVoid),
           MatrixDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt ArrayStride 1\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %array ArrayStride 4\n"
+          "%intt = OpTypeInt 32 0\n"
+          "%array = OpTypeRuntimeArray %intt\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt MatrixStride 1\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpMemberDecorate %structt 0 MatrixStride 8\n"
+          "%floatt = OpTypeFloat 32\n"
+          "%float2 = OpTypeVector %floatt 2\n"
+          "%mat2x2 = OpTypeMatrix %float2 2\n"
+          "%structt = OpTypeStruct %mat2x2\n" + std::string(kVoidFVoid),
           MatrixDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
@@ -1259,58 +1271,80 @@ std::make_pair(std::string(kGLSL450MemoryModel) +
           KernelDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt NoPerspective\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %var NoPerspective\n"
+          "%intt = OpTypeInt 32 0\n"
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt Flat\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %var Flat\n"
+          "%intt = OpTypeInt 32 0\n"
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt Patch\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %var Patch\n"
+          "%intt = OpTypeInt 32 0\n"
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           TessellationDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt Centroid\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %var Centroid\n"
+          "%intt = OpTypeInt 32 0\n"
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt Sample\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %var Sample\n"
+          "%intt = OpTypeInt 32 0\n"
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           std::vector<std::string>{"SampleRateShading"}),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt Invariant\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %var Invariant\n"
+          "%intt = OpTypeInt 32 0\n"
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt Restrict\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %var Restrict\n"
+          "%intt = OpTypeInt 32 0\n"
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           AllCapabilities()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt Aliased\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %var Aliased\n"
+          "%intt = OpTypeInt 32 0\n"
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           AllCapabilities()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt Volatile\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %var Volatile\n"
+          "%intt = OpTypeInt 32 0\n"
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           AllCapabilities()),
 std::make_pair(std::string(kGLSL450MemoryModel) +
           "OpEntryPoint Vertex %func \"shader\" \n"
-          "OpDecorate %intt Constant\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %var Constant\n"
+          "%intt = OpTypeInt 32 0\n"
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           KernelDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt Coherent\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %var Coherent\n"
+          "%intt = OpTypeInt 32 0\n"
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           AllCapabilities()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           // NonWritable must target something valid, such as a storage image.
@@ -1324,8 +1358,12 @@ std::make_pair(std::string(kOpenCLMemoryModel) +
           AllCapabilities()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt NonReadable\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %var NonReadable "
+          "%float = OpTypeFloat 32 "
+          "%imstor = OpTypeImage %float 2D 0 0 0 2 Unknown "
+          "%ptr = OpTypePointer UniformConstant %imstor "
+          "%var = OpVariable %ptr UniformConstant "
+          + std::string(kVoidFVoid),
           AllCapabilities()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           // Uniform must target a non-void value.
@@ -1360,33 +1398,44 @@ std::make_pair(std::string(kOpenCLMemoryModel) +
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt Index 0\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %var Index 0\n"
+          "%intt = OpTypeInt 32 0\n"
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt Binding 0\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %var Binding 0\n"
+          "%intt = OpTypeInt 32 0\n"
+          "%ptr = OpTypePointer Uniform %intt\n"
+          "%var = OpVariable %ptr Uniform\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt DescriptorSet 0\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %var DescriptorSet 0\n"
+          "%intt = OpTypeInt 32 0\n"
+          "%ptr = OpTypePointer Uniform %intt\n"
+          "%var = OpVariable %ptr Uniform\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt Offset 0\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpMemberDecorate %structt 0 Offset 0\n"
+          "%intt = OpTypeInt 32 0\n"
+          "%structt = OpTypeStruct %intt\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt XfbBuffer 0\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %var XfbBuffer 0\n"
+          "%intt = OpTypeInt 32 0\n"
+          "%ptr = OpTypePointer Uniform %intt\n"
+          "%var = OpVariable %ptr Uniform\n" + std::string(kVoidFVoid),
           std::vector<std::string>{"TransformFeedback"}),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt XfbStride 0\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %var XfbStride 0\n"
+          "%intt = OpTypeInt 32 0\n"
+          "%ptr = OpTypePointer Uniform %intt\n"
+          "%var = OpVariable %ptr Uniform\n" + std::string(kVoidFVoid),
           std::vector<std::string>{"TransformFeedback"}),
 std::make_pair(std::string(kGLSL450MemoryModel) +
           "OpEntryPoint Vertex %func \"shader\" \n"
@@ -1410,8 +1459,10 @@ std::make_pair(std::string(kOpenCLMemoryModel) +
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt InputAttachmentIndex 0\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %var InputAttachmentIndex 0\n"
+          "%intt = OpTypeInt 32 0\n"
+          "%ptr = OpTypePointer UniformConstant %intt\n"
+          "%var = OpVariable %ptr UniformConstant\n" + std::string(kVoidFVoid),
           std::vector<std::string>{"InputAttachment"}),
 std::make_pair(std::string(kGLSL450MemoryModel) +
           "OpEntryPoint Vertex %func \"shader\" \n"
@@ -1471,264 +1522,308 @@ INSTANTIATE_TEST_SUITE_P(BuiltIn, ValidateCapability,
                             Values(
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn Position\n"
+          "OpDecorate %var BuiltIn Position\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 // Just mentioning PointSize, ClipDistance, or CullDistance as a BuiltIn does
 // not trigger the requirement for the associated capability.
 // See https://github.com/KhronosGroup/SPIRV-Tools/issues/365
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn PointSize\n"
+          "OpDecorate %var BuiltIn PointSize\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           AllCapabilities()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn ClipDistance\n"
+          "OpDecorate %var BuiltIn ClipDistance\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           AllCapabilities()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn CullDistance\n"
+          "OpDecorate %var BuiltIn CullDistance\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           AllCapabilities()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn VertexId\n"
+          "OpDecorate %var BuiltIn VertexId\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn InstanceId\n"
+          "OpDecorate %var BuiltIn InstanceId\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn PrimitiveId\n"
+          "OpDecorate %var BuiltIn PrimitiveId\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           GeometryTessellationDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn InvocationId\n"
+          "OpDecorate %var BuiltIn InvocationId\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           GeometryTessellationDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn Layer\n"
+          "OpDecorate %var BuiltIn Layer\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           GeometryDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn ViewportIndex\n"
+          "OpDecorate %var BuiltIn ViewportIndex\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           std::vector<std::string>{"MultiViewport"}),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn TessLevelOuter\n"
+          "OpDecorate %var BuiltIn TessLevelOuter\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           TessellationDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn TessLevelInner\n"
+          "OpDecorate %var BuiltIn TessLevelInner\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           TessellationDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn TessCoord\n"
+          "OpDecorate %var BuiltIn TessCoord\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           TessellationDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn PatchVertices\n"
+          "OpDecorate %var BuiltIn PatchVertices\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           TessellationDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn FragCoord\n"
+          "OpDecorate %var BuiltIn FragCoord\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn PointCoord\n"
+          "OpDecorate %var BuiltIn PointCoord\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn FrontFacing\n"
+          "OpDecorate %var BuiltIn FrontFacing\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn SampleId\n"
+          "OpDecorate %var BuiltIn SampleId\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           std::vector<std::string>{"SampleRateShading"}),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn SamplePosition\n"
+          "OpDecorate %var BuiltIn SamplePosition\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           std::vector<std::string>{"SampleRateShading"}),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn SampleMask\n"
+          "OpDecorate %var BuiltIn SampleMask\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn FragDepth\n"
+          "OpDecorate %var BuiltIn FragDepth\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn HelperInvocation\n"
+          "OpDecorate %var BuiltIn HelperInvocation\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn VertexIndex\n"
+          "OpDecorate %var BuiltIn VertexIndex\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn InstanceIndex\n"
+          "OpDecorate %var BuiltIn InstanceIndex\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn NumWorkgroups\n"
+          "OpDecorate %var BuiltIn NumWorkgroups\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           AllCapabilities()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn WorkgroupSize\n"
+          "OpDecorate %ones BuiltIn WorkgroupSize\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%int3 = OpTypeVector %intt 3\n"
+          "%int_1 = OpConstant %intt 1\n"
+          "%ones = OpConstantComposite %int3 %int_1 %int_1 %int_1\n" + std::string(kVoidFVoid),
           AllCapabilities()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn WorkgroupId\n"
+          "OpDecorate %var BuiltIn WorkgroupId\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           AllCapabilities()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn LocalInvocationId\n"
+          "OpDecorate %var BuiltIn LocalInvocationId\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           AllCapabilities()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn GlobalInvocationId\n"
+          "OpDecorate %var BuiltIn GlobalInvocationId\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           AllCapabilities()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn LocalInvocationIndex\n"
+          "OpDecorate %var BuiltIn LocalInvocationIndex\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           AllCapabilities()),
 std::make_pair(std::string(kGLSL450MemoryModel) +
           "OpEntryPoint Vertex %func \"shader\" \n" +
-          "OpDecorate %int0 BuiltIn WorkDim\n"
+          "OpDecorate %var BuiltIn WorkDim\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           KernelDependencies()),
 std::make_pair(std::string(kGLSL450MemoryModel) +
           "OpEntryPoint Vertex %func \"shader\" \n" +
-          "OpDecorate %int0 BuiltIn GlobalSize\n"
+          "OpDecorate %var BuiltIn GlobalSize\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           KernelDependencies()),
 std::make_pair(std::string(kGLSL450MemoryModel) +
           "OpEntryPoint Vertex %func \"shader\" \n" +
-          "OpDecorate %int0 BuiltIn EnqueuedWorkgroupSize\n"
+          "OpDecorate %var BuiltIn EnqueuedWorkgroupSize\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           KernelDependencies()),
 std::make_pair(std::string(kGLSL450MemoryModel) +
           "OpEntryPoint Vertex %func \"shader\" \n" +
-          "OpDecorate %int0 BuiltIn GlobalOffset\n"
+          "OpDecorate %var BuiltIn GlobalOffset\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           KernelDependencies()),
 std::make_pair(std::string(kGLSL450MemoryModel) +
           "OpEntryPoint Vertex %func \"shader\" \n" +
-          "OpDecorate %int0 BuiltIn GlobalLinearId\n"
+          "OpDecorate %var BuiltIn GlobalLinearId\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           KernelDependencies()),
 std::make_pair(std::string(kGLSL450MemoryModel) +
           "OpEntryPoint Vertex %func \"shader\" \n" +
-          "OpDecorate %int0 BuiltIn SubgroupSize\n"
+          "OpDecorate %var BuiltIn SubgroupSize\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           KernelAndGroupNonUniformDependencies()),
 std::make_pair(std::string(kGLSL450MemoryModel) +
           "OpEntryPoint Vertex %func \"shader\" \n" +
-          "OpDecorate %int0 BuiltIn SubgroupMaxSize\n"
+          "OpDecorate %var BuiltIn SubgroupMaxSize\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           KernelDependencies()),
 std::make_pair(std::string(kGLSL450MemoryModel) +
           "OpEntryPoint Vertex %func \"shader\" \n" +
-          "OpDecorate %int0 BuiltIn NumSubgroups\n"
+          "OpDecorate %var BuiltIn NumSubgroups\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           KernelAndGroupNonUniformDependencies()),
 std::make_pair(std::string(kGLSL450MemoryModel) +
           "OpEntryPoint Vertex %func \"shader\" \n" +
-          "OpDecorate %int0 BuiltIn NumEnqueuedSubgroups\n"
+          "OpDecorate %var BuiltIn NumEnqueuedSubgroups\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           KernelDependencies()),
 std::make_pair(std::string(kGLSL450MemoryModel) +
           "OpEntryPoint Vertex %func \"shader\" \n" +
-          "OpDecorate %int0 BuiltIn SubgroupId\n"
+          "OpDecorate %var BuiltIn SubgroupId\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           KernelAndGroupNonUniformDependencies()),
 std::make_pair(std::string(kGLSL450MemoryModel) +
           "OpEntryPoint Vertex %func \"shader\" \n" +
-          "OpDecorate %int0 BuiltIn SubgroupLocalInvocationId\n"
+          "OpDecorate %var BuiltIn SubgroupLocalInvocationId\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           KernelAndGroupNonUniformDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn VertexIndex\n"
+          "OpDecorate %var BuiltIn VertexIndex\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           ShaderDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n" +
-          "OpDecorate %int0 BuiltIn InstanceIndex\n"
+          "OpDecorate %var BuiltIn InstanceIndex\n"
           "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "%ptr = OpTypePointer Input %intt\n"
+          "%var = OpVariable %ptr Input\n" + std::string(kVoidFVoid),
           ShaderDependencies())
 )));
 
@@ -1742,11 +1837,11 @@ INSTANTIATE_TEST_SUITE_P(BuiltIn, ValidateCapabilityVulkan10,
                             ValuesIn(AllSpirV10Capabilities()),
                             Values(
 std::make_pair(std::string(kGLSL450MemoryModel) +
-          "OpEntryPoint Vertex %func \"shader\" \n"
-          "OpMemberDecorate %block 0 BuiltIn PointSize\n"
-          "%f32 = OpTypeFloat 32\n"
-          "%block = OpTypeStruct %f32\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpEntryPoint Vertex %func \"shader\" %var\n" +
+          "OpDecorate %var BuiltIn PointSize\n"
+          "%float = OpTypeFloat 32\n"
+          "%ptr_output_float = OpTypePointer Output %float\n"
+          "%var = OpVariable %ptr_output_float Output\n" + std::string(kVoidFVoid),
           // Capabilities which should succeed.
           AllVulkan10Capabilities()),
 std::make_pair(std::string(kGLSL450MemoryModel) +
@@ -1775,22 +1870,31 @@ INSTANTIATE_TEST_SUITE_P(BuiltIn, ValidateCapabilityOpenGL40,
                             ValuesIn(AllSpirV10Capabilities()),
                             Values(
 std::make_pair(std::string(kGLSL450MemoryModel) +
-          "OpEntryPoint Vertex %func \"shader\" \n" +
-          "OpDecorate %int0 BuiltIn PointSize\n"
-          "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "OpEntryPoint Vertex %func \"shader\" %var\n" +
+          "OpDecorate %var BuiltIn PointSize\n"
+          "%float = OpTypeFloat 32\n"
+          "%ptr_output_float = OpTypePointer Output %float\n"
+          "%var = OpVariable %ptr_output_float Output\n" + std::string(kVoidFVoid),
           AllSpirV10Capabilities()),
 std::make_pair(std::string(kGLSL450MemoryModel) +
-          "OpEntryPoint Vertex %func \"shader\" \n" +
-          "OpDecorate %int0 BuiltIn ClipDistance\n"
-          "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "OpEntryPoint Vertex %func \"shader\" %var\n" +
+          "OpDecorate %var BuiltIn ClipDistance\n"
+          "%float = OpTypeFloat 32\n"
+          "%int = OpTypeInt 32 0\n"
+          "%int_1 = OpConstant %int 1\n"
+          "%array = OpTypeArray %float %int_1\n"
+          "%ptr = OpTypePointer Output %array\n"
+          "%var = OpVariable %ptr Output\n" + std::string(kVoidFVoid),
           AllSpirV10Capabilities()),
 std::make_pair(std::string(kGLSL450MemoryModel) +
-          "OpEntryPoint Vertex %func \"shader\" \n" +
-          "OpDecorate %int0 BuiltIn CullDistance\n"
-          "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "OpEntryPoint Vertex %func \"shader\" %var\n" +
+          "OpDecorate %var BuiltIn CullDistance\n"
+          "%float = OpTypeFloat 32\n"
+          "%int = OpTypeInt 32 0\n"
+          "%int_1 = OpConstant %int 1\n"
+          "%array = OpTypeArray %float %int_1\n"
+          "%ptr = OpTypePointer Output %array\n"
+          "%var = OpVariable %ptr Output\n" + std::string(kVoidFVoid),
           AllSpirV10Capabilities())
 )));
 
@@ -1800,16 +1904,21 @@ INSTANTIATE_TEST_SUITE_P(Capabilities, ValidateCapabilityVulkan11,
                             ValuesIn(AllCapabilities()),
                             Values(
 std::make_pair(std::string(kGLSL450MemoryModel) +
-          "OpEntryPoint Vertex %func \"shader\" \n" +
-          "OpDecorate %int0 BuiltIn PointSize\n"
-          "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "OpEntryPoint Vertex %func \"shader\" %var\n" +
+          "OpDecorate %var BuiltIn PointSize\n"
+          "%float = OpTypeFloat 32\n"
+          "%ptr_output_float = OpTypePointer Output %float\n"
+          "%var = OpVariable %ptr_output_float Output\n" + std::string(kVoidFVoid),
           AllVulkan11Capabilities()),
 std::make_pair(std::string(kGLSL450MemoryModel) +
-          "OpEntryPoint Vertex %func \"shader\" \n" +
-          "OpDecorate %int0 BuiltIn CullDistance\n"
-          "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "OpEntryPoint Vertex %func \"shader\" %var\n" +
+          "OpDecorate %var BuiltIn CullDistance\n"
+          "%float = OpTypeFloat 32\n"
+          "%int = OpTypeInt 32 0\n"
+          "%int_1 = OpConstant %int 1\n"
+          "%array = OpTypeArray %float %int_1\n"
+          "%ptr = OpTypePointer Output %array\n"
+          "%var = OpVariable %ptr Output\n" + std::string(kVoidFVoid),
           AllVulkan11Capabilities())
 )));
 
@@ -1819,16 +1928,21 @@ INSTANTIATE_TEST_SUITE_P(Capabilities, ValidateCapabilityVulkan12,
                             ValuesIn(AllSpirV15Capabilities()),
                             Values(
 std::make_pair(std::string(kGLSL450MemoryModel) +
-          "OpEntryPoint Vertex %func \"shader\" \n" +
-          "OpDecorate %int0 BuiltIn PointSize\n"
-          "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "OpEntryPoint Vertex %func \"shader\" %var\n" +
+          "OpDecorate %var BuiltIn PointSize\n"
+          "%float = OpTypeFloat 32\n"
+          "%ptr_output_float = OpTypePointer Output %float\n"
+          "%var = OpVariable %ptr_output_float Output\n" + std::string(kVoidFVoid),
           AllVulkan12Capabilities()),
 std::make_pair(std::string(kGLSL450MemoryModel) +
-          "OpEntryPoint Vertex %func \"shader\" \n" +
-          "OpDecorate %int0 BuiltIn CullDistance\n"
-          "%intt = OpTypeInt 32 0\n"
-          "%int0 = OpConstant %intt 0\n" + std::string(kVoidFVoid),
+          "OpEntryPoint Vertex %func \"shader\" %var\n" +
+          "OpDecorate %var BuiltIn CullDistance\n"
+          "%float = OpTypeFloat 32\n"
+          "%int = OpTypeInt 32 0\n"
+          "%int_1 = OpConstant %int 1\n"
+          "%array = OpTypeArray %float %int_1\n"
+          "%ptr = OpTypePointer Output %array\n"
+          "%var = OpVariable %ptr Output\n" + std::string(kVoidFVoid),
           AllVulkan12Capabilities())
 )));
 

--- a/test/val/val_capability_test.cpp
+++ b/test/val/val_capability_test.cpp
@@ -1380,8 +1380,10 @@ std::make_pair(std::string(kGLSL450MemoryModel) +
           KernelDependencies()),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"
-          "OpDecorate %intt Stream 0\n"
-          "%intt = OpTypeInt 32 0\n" + std::string(kVoidFVoid),
+          "OpDecorate %var Stream 0\n"
+          "%intt = OpTypeInt 32 0\n"
+          "%ptr = OpTypePointer Output %intt\n"
+          "%var = OpVariable %ptr Output\n" + std::string(kVoidFVoid),
           std::vector<std::string>{"GeometryStreams"}),
 std::make_pair(std::string(kOpenCLMemoryModel) +
           "OpEntryPoint Kernel %func \"compute\" \n"

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -688,7 +688,7 @@ TEST_F(ValidateDecorations, BlockDecoratingArrayBad) {
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Block decoration on a non-struct type"));
+              HasSubstr("must be a structure type"));
 }
 
 TEST_F(ValidateDecorations, BlockDecoratingIntBad) {
@@ -714,7 +714,7 @@ TEST_F(ValidateDecorations, BlockDecoratingIntBad) {
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Block decoration on a non-struct type"));
+              HasSubstr("must be a structure type"));
 }
 
 TEST_F(ValidateDecorations, BlockMissingOffsetBad) {
@@ -6129,9 +6129,7 @@ TEST_F(ValidateDecorations, NonWritableLabelTargetBad) {
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Target of NonWritable decoration must be a "
-                        "memory object declaration (a variable or a function "
-                        "parameter)\n  %label = OpLabel"));
+              HasSubstr("must be a memory object declaration"));
 }
 
 TEST_F(ValidateDecorations, NonWritableTypeTargetBad) {
@@ -6140,9 +6138,7 @@ TEST_F(ValidateDecorations, NonWritableTypeTargetBad) {
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Target of NonWritable decoration must be a "
-                        "memory object declaration (a variable or a function "
-                        "parameter)\n  %void = OpTypeVoid"));
+              HasSubstr("must be a memory object declaration"));
 }
 
 TEST_F(ValidateDecorations, NonWritableValueTargetBad) {
@@ -6151,9 +6147,7 @@ TEST_F(ValidateDecorations, NonWritableValueTargetBad) {
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Target of NonWritable decoration must be a "
-                        "memory object declaration (a variable or a function "
-                        "parameter)\n  %float_0 = OpConstant %float 0"));
+              HasSubstr("must be a memory object declaration"));
 }
 
 TEST_F(ValidateDecorations, NonWritableValueParamBad) {
@@ -6467,8 +6461,7 @@ OpFunctionEnd
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Target of Component decoration must be "
-                        "a memory object declaration"));
+              HasSubstr("must be a variable"));
 }
 
 TEST_F(ValidateDecorations, ComponentDecorationBadStorageClass) {
@@ -6767,8 +6760,9 @@ TEST_F(ValidateDecorations, ComponentDecorationFunctionParameter) {
 )";
 
   CompileSuccessfully(spirv);
-  EXPECT_EQ(SPV_SUCCESS, ValidateAndRetrieveValidationState());
-  EXPECT_THAT(getDiagnosticString(), Eq(""));
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("must be a variable"));
 }
 
 TEST_F(ValidateDecorations, VulkanStorageBufferBlock) {
@@ -7165,8 +7159,7 @@ OpDecorate %struct Location 0
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Location decoration can only be applied to a variable "
-                        "or member of a structure type"));
+              HasSubstr("must be a variable"));
 }
 
 TEST_F(ValidateDecorations, LocationFloatBad) {
@@ -7181,8 +7174,7 @@ OpDecorate %float Location 0
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Location decoration can only be applied to a variable "
-                        "or member of a structure type"));
+              HasSubstr("must be a variable"));
 }
 
 TEST_F(ValidateDecorations, WorkgroupSingleBlockVariable) {
@@ -7571,9 +7563,7 @@ TEST_F(ValidateDecorations, WorkgroupSingleBlockVariableNotAStruct) {
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_4);
   EXPECT_EQ(SPV_ERROR_INVALID_ID,
             ValidateAndRetrieveValidationState(SPV_ENV_UNIVERSAL_1_4));
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Block decoration on a non-struct type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("must be a structure type"));
 }
 
 TEST_F(ValidateDecorations, WorkgroupSingleBlockVariableMissingLayout) {

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -6153,10 +6153,7 @@ TEST_F(ValidateDecorations, NonWritableValueParamBad) {
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Target of NonWritable decoration is invalid: must "
-                        "point to a storage image, uniform block, or storage "
-                        "buffer\n  %param_f = OpFunctionParameter %float"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("must be a pointer type"));
 }
 
 TEST_F(ValidateDecorations, NonWritablePointerParamButWrongTypeBad) {
@@ -6458,7 +6455,8 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("must be a variable"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("must be a memory object declaration"));
 }
 
 TEST_F(ValidateDecorations, ComponentDecorationBadStorageClass) {
@@ -6758,7 +6756,7 @@ TEST_F(ValidateDecorations, ComponentDecorationFunctionParameter) {
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("must be a variable"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("must be a pointer type"));
 }
 
 TEST_F(ValidateDecorations, VulkanStorageBufferBlock) {

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -687,8 +687,7 @@ TEST_F(ValidateDecorations, BlockDecoratingArrayBad) {
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("must be a structure type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("must be a structure type"));
 }
 
 TEST_F(ValidateDecorations, BlockDecoratingIntBad) {
@@ -713,8 +712,7 @@ TEST_F(ValidateDecorations, BlockDecoratingIntBad) {
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("must be a structure type"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("must be a structure type"));
 }
 
 TEST_F(ValidateDecorations, BlockMissingOffsetBad) {
@@ -6460,8 +6458,7 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("must be a variable"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("must be a variable"));
 }
 
 TEST_F(ValidateDecorations, ComponentDecorationBadStorageClass) {
@@ -6761,8 +6758,7 @@ TEST_F(ValidateDecorations, ComponentDecorationFunctionParameter) {
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("must be a variable"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("must be a variable"));
 }
 
 TEST_F(ValidateDecorations, VulkanStorageBufferBlock) {
@@ -7158,8 +7154,7 @@ OpDecorate %struct Location 0
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("must be a variable"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("must be a variable"));
 }
 
 TEST_F(ValidateDecorations, LocationFloatBad) {
@@ -7173,8 +7168,7 @@ OpDecorate %float Location 0
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("must be a variable"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("must be a variable"));
 }
 
 TEST_F(ValidateDecorations, WorkgroupSingleBlockVariable) {

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -5524,9 +5524,9 @@ OpFunctionEnd
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpDecorate SpecId decoration target <id> "
-                        "'1[%uint_3]' is not a scalar specialization "
-                        "constant."));
+              HasSubstr("SpecId decoration on target <id> "
+                        "'1[%uint_3]' must be a scalar specialization "
+                        "constant"));
 }
 
 TEST_F(ValidateIdWithMessage, SpecIdTargetOpSpecConstantOpBad) {
@@ -5546,8 +5546,8 @@ OpFunctionEnd
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpDecorate SpecId decoration target <id> '1[%1]' is "
-                        "not a scalar specialization constant."));
+              HasSubstr("SpecId decoration on target <id> '1[%1]' "
+                        "must be a scalar specialization constant"));
 }
 
 TEST_F(ValidateIdWithMessage, SpecIdTargetOpSpecConstantCompositeBad) {
@@ -5566,8 +5566,8 @@ OpFunctionEnd
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpDecorate SpecId decoration target <id> '1[%1]' is "
-                        "not a scalar specialization constant."));
+              HasSubstr("SpecId decoration on target <id> '1[%1]' "
+                        "must be a scalar specialization constant"));
 }
 
 TEST_F(ValidateIdWithMessage, SpecIdTargetGood) {

--- a/test/val/val_interfaces_test.cpp
+++ b/test/val/val_interfaces_test.cpp
@@ -1267,10 +1267,9 @@ OpFunctionEnd
 )";
 
   CompileSuccessfully(text, SPV_ENV_VULKAN_1_0);
-  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Index can only be applied to Fragment output variables"));
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("must be in the Output storage class"));
 }
 
 TEST_F(ValidateInterfacesTest, VulkanLocationsArrayWithComponent) {

--- a/test/val/val_layout_test.cpp
+++ b/test/val/val_layout_test.cpp
@@ -538,7 +538,6 @@ TEST_F(ValidateLayout, ModuleProcessedInvalidIn10) {
            OpMemoryModel Logical GLSL450
            OpName %void "void"
            OpModuleProcessed "this is ok in 1.1 and later"
-           OpDecorate %void Volatile ; bogus, but makes the example short
 %void    = OpTypeVoid
 )";
 
@@ -558,7 +557,6 @@ TEST_F(ValidateLayout, ModuleProcessedValidIn11) {
            OpMemoryModel Logical GLSL450
            OpName %void "void"
            OpModuleProcessed "this is ok in 1.1 and later"
-           OpDecorate %void Volatile ; bogus, but makes the example short
 %void    = OpTypeVoid
 )";
 

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -2344,11 +2344,12 @@ OpExtension "SPV_EXT_descriptor_indexing"
 OpMemoryModel Logical GLSL450
 OpEntryPoint Fragment %func "func"
 OpExecutionMode %func OriginUpperLeft
-OpDecorate %array_t Block
+OpDecorate %struct Block
 %uint_t = OpTypeInt 32 0
 %inner_array_t = OpTypeRuntimeArray %uint_t
 %array_t = OpTypeRuntimeArray %inner_array_t
-%array_ptr = OpTypePointer StorageBuffer %array_t
+%struct = OpTypeStruct %array_t
+%array_ptr = OpTypePointer StorageBuffer %struct
 %2 = OpVariable %array_ptr StorageBuffer
 %void = OpTypeVoid
 %func_t = OpTypeFunction %void
@@ -2504,13 +2505,14 @@ OpExtension "SPV_EXT_descriptor_indexing"
 OpMemoryModel Logical GLSL450
 OpEntryPoint Fragment %func "func"
 OpExecutionMode %func OriginUpperLeft
-OpDecorate %array_t Block
+OpDecorate %struct Block
 %uint_t = OpTypeInt 32 0
 %dim = OpConstant %uint_t 1
 %sampler_t = OpTypeSampler
 %inner_array_t = OpTypeRuntimeArray %uint_t
 %array_t = OpTypeRuntimeArray %inner_array_t
-%array_ptr = OpTypePointer StorageBuffer %array_t
+%struct = OpTypeStruct %array_t
+%array_ptr = OpTypePointer StorageBuffer %struct
 %2 = OpVariable %array_ptr StorageBuffer
 %void = OpTypeVoid
 %func_t = OpTypeFunction %void


### PR DESCRIPTION
Fixes #4469

* Checks that decorations only usable with structure members are not
  used by OpDecorate or OpDecorateId
* Checks that decorations not allowed on structure members are not used
  with OpMemberDecorate
* Checks decoration targets for most core decorations
* Performs some Vulkan specific validation on decorations

VK-GL-CTS Issue: 3063
This PR breaks some Vulkan CTS tests that are invalid.