### PR TITLE
Remove environment features that are never used

### DIFF
--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -90,23 +90,6 @@ class ValidationState_t {
     // conversion opcodes
     bool use_int8_type = false;
 
-    // Use scalar block layout. See VK_EXT_scalar_block_layout:
-    // Defines scalar alignment:
-    // - scalar alignment equals the scalar size in bytes
-    // - array alignment is same as its element alignment
-    // - array alignment is max alignment of any of its members
-    // - vector alignment is same as component alignment
-    // - matrix alignment is same as component alignment
-    // For struct in Uniform, StorageBuffer, PushConstant:
-    // - Offset of a member is multiple of scalar alignment of that member
-    // - ArrayStride and MatrixStride are multiples of scalar alignment
-    // Members need not be listed in offset order
-    bool scalar_block_layout = false;
-
-    // Use scalar block layout (as defined above) for Workgroup block
-    // variables.  See VK_KHR_workgroup_memory_explicit_layout.
-    bool workgroup_scalar_block_layout = false;
-
     // SPIR-V 1.4 allows us to select between any two composite values
     // of the same type.
     bool select_between_composites = false;


### PR DESCRIPTION
The validation state contained feature bits for scalar block layout and
workgroup memory scalar block layout which were never used (the
command-line option is used in every case).