### PR TITLE
Adjust build for fuzzer targets to support OSS-Fuzz

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,8 @@ endif(SPIRV_BUILD_COMPRESSION)
 
 option(SPIRV_BUILD_FUZZER "Build spirv-fuzz" OFF)
 
+set(SPIRV_LIB_FUZZING_ENGINE_LINK_OPTIONS "" CACHE STRING "Used by OSS-Fuzz to control, via link options, which fuzzing engine should be used")
+
 option(SPIRV_BUILD_LIBFUZZER_TARGETS "Build libFuzzer targets" OFF)
 
 option(SPIRV_WERROR "Enable error on warning" ON)

--- a/test/fuzzers/CMakeLists.txt
+++ b/test/fuzzers/CMakeLists.txt
@@ -26,8 +26,17 @@ function(add_spvtools_libfuzzer_target)
     ${spirv-tools_BINARY_DIR}
   )
   set_property(TARGET ${ARG_TARGET} PROPERTY FOLDER "SPIRV-Tools libFuzzer targets")
-  target_compile_options(${ARG_TARGET} PRIVATE "-fsanitize=fuzzer")
-  target_link_options(${ARG_TARGET} PRIVATE "-fsanitize=fuzzer")
+  if(NOT ${SPIRV_LIB_FUZZING_ENGINE_LINK_OPTIONS} STREQUAL "")
+    # This is set when the fuzzers are being built by OSS-Fuzz. In this case the
+    # variable provides the necessary linker flags, and OSS-Fuzz will take care
+    # of passing suitable compiler flags.
+    target_link_options(${ARG_TARGET} PRIVATE ${SPIRV_LIB_FUZZING_ENGINE_LINK_OPTIONS})
+  else()
+    # When the fuzzers are being built outside of OSS-Fuzz, standard libFuzzer
+    # arguments to enable fuzzing are used.
+    target_compile_options(${ARG_TARGET} PRIVATE "-fsanitize=fuzzer")
+    target_link_options(${ARG_TARGET} PRIVATE "-fsanitize=fuzzer")    
+  endif()
 endfunction()
 
 if (${SPIRV_BUILD_LIBFUZZER_TARGETS})


### PR DESCRIPTION
With OSS-Fuzz, the build system should not directly set options such as
-fsanitize=fuzzer. Instead, these are set by OSS-Fuzz, and
linker options are provided via the LIB_FUZZER_OPTIONS environment
variable. This change allows the fuzzers to be build stand-alone,
outside of OSS-Fuzz, in the way that was already supported, as well as
inside OSS-Fuzz, when the LIB_FUZZER_OPTIONS environment variable is
set.