### PR TITLE
Add UBSan kokoro configuration

### DIFF
--- a/kokoro/linux-clang-ubsan/build.sh
+++ b/kokoro/linux-clang-ubsan/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright (c) 2021 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Linux Build Script.
+
+# Fail on any error.
+set -e
+# Display commands being run.
+set -x
+
+SCRIPT_DIR=`dirname "$BASH_SOURCE"`
+source $SCRIPT_DIR/../scripts/linux/build.sh UBSAN clang cmake

--- a/kokoro/linux-clang-ubsan/continuous.cfg
+++ b/kokoro/linux-clang-ubsan/continuous.cfg
@@ -1,0 +1,16 @@
+# Copyright (c) 2021 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Continuous build configuration.
+build_file: "SPIRV-Tools/kokoro/linux-clang-ubsan/build.sh"

--- a/kokoro/linux-clang-ubsan/presubmit.cfg
+++ b/kokoro/linux-clang-ubsan/presubmit.cfg
@@ -1,0 +1,16 @@
+# Copyright (c) 2021 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Presubmit build configuration.
+build_file: "SPIRV-Tools/kokoro/linux-clang-ubsan/build.sh"

--- a/kokoro/scripts/linux/build-docker.sh
+++ b/kokoro/scripts/linux/build-docker.sh
@@ -58,7 +58,7 @@ if [ $TOOL = "cmake" ]; then
   using ninja-1.10.0
 
   # Possible configurations are:
-  # ASAN, COVERAGE, RELEASE, DEBUG, DEBUG_EXCEPTION, RELEASE_MINGW
+  # ASAN, UBSAN, COVERAGE, RELEASE, DEBUG, DEBUG_EXCEPTION, RELEASE_MINGW
   BUILD_TYPE="Debug"
   if [ $CONFIG = "RELEASE" ] || [ $CONFIG = "RELEASE_MINGW" ]; then
     BUILD_TYPE="RelWithDebInfo"
@@ -68,6 +68,11 @@ if [ $TOOL = "cmake" ]; then
   ADDITIONAL_CMAKE_FLAGS=""
   if [ $CONFIG = "ASAN" ]; then
     ADDITIONAL_CMAKE_FLAGS="-DSPIRV_USE_SANITIZER=address,bounds,null"
+    [ $COMPILER = "clang" ] || { echo "$CONFIG requires clang"; exit 1; }
+  elif [ $CONFIG = "UBSAN" ]; then
+    # UBSan requires RTTI, and by default UBSan does not exit when errors are
+    # encountered - additional compiler options are required to force this.
+    ADDITIONAL_CMAKE_FLAGS="-DSPIRV_USE_SANITIZER=undefined -DENABLE_RTTI=ON -DCMAKE_C_FLAGS=-fno-sanitize-recover -DCMAKE_CXX_FLAGS=-fno-sanitize-recover"
     [ $COMPILER = "clang" ] || { echo "$CONFIG requires clang"; exit 1; }
   elif [ $CONFIG = "COVERAGE" ]; then
     ADDITIONAL_CMAKE_FLAGS="-DENABLE_CODE_COVERAGE=ON"

--- a/kokoro/scripts/linux/build-docker.sh
+++ b/kokoro/scripts/linux/build-docker.sh
@@ -72,6 +72,8 @@ if [ $TOOL = "cmake" ]; then
   elif [ $CONFIG = "UBSAN" ]; then
     # UBSan requires RTTI, and by default UBSan does not exit when errors are
     # encountered - additional compiler options are required to force this.
+    # The -DSPIRV_USE_SANITIZER=undefined option instructs SPIR-V Tools to be
+    # built with UBSan enabled.
     ADDITIONAL_CMAKE_FLAGS="-DSPIRV_USE_SANITIZER=undefined -DENABLE_RTTI=ON -DCMAKE_C_FLAGS=-fno-sanitize-recover -DCMAKE_CXX_FLAGS=-fno-sanitize-recover"
     [ $COMPILER = "clang" ] || { echo "$CONFIG requires clang"; exit 1; }
   elif [ $CONFIG = "COVERAGE" ]; then


### PR DESCRIPTION
Adds a kokoro configuration for UBSan, to allow this sanitizer to be
used during continuous integration.