### PR TITLE
Handle out-of-bounds accesses in VDCE

### DIFF
--- a/source/opt/vector_dce.cpp
+++ b/source/opt/vector_dce.cpp
@@ -110,7 +110,11 @@ void VectorDCE::MarkExtractUseAsLive(const Instruction* current_inst,
     if (current_inst->NumInOperands() < 2) {
       new_item.components = live_elements;
     } else {
-      new_item.components.Set(current_inst->GetSingleWordInOperand(1));
+      uint32_t element_index = current_inst->GetSingleWordInOperand(1);
+      uint32_t item_size = GetVectorTypeSize(operand_inst->type_id());
+      if (element_index < item_size) {
+        new_item.components.Set(element_index);
+      }
     }
     AddItemToWorkListIfNeeded(new_item, live_components, work_list);
   }
@@ -176,10 +180,10 @@ void VectorDCE::MarkVectorShuffleUsesAsLive(
   second_operand.instruction =
       def_use_mgr->GetDef(current_item.instruction->GetSingleWordInOperand(1));
 
-  analysis::TypeManager* type_mgr = context()->get_type_mgr();
-  analysis::Vector* first_type =
-      type_mgr->GetType(first_operand.instruction->type_id())->AsVector();
-  uint32_t size_of_first_operand = first_type->element_count();
+  uint32_t size_of_first_operand =
+      GetVectorTypeSize(first_operand.instruction->type_id());
+  uint32_t size_of_second_operand =
+      GetVectorTypeSize(second_operand.instruction->type_id());
 
   for (uint32_t in_op = 2; in_op < current_item.instruction->NumInOperands();
        ++in_op) {
@@ -187,7 +191,7 @@ void VectorDCE::MarkVectorShuffleUsesAsLive(
     if (current_item.components.Get(in_op - 2)) {
       if (index < size_of_first_operand) {
         first_operand.components.Set(index);
-      } else {
+      } else if (index - size_of_first_operand < size_of_second_operand) {
         second_operand.components.Set(index - size_of_first_operand);
       }
     }
@@ -202,7 +206,6 @@ void VectorDCE::MarkCompositeContructUsesAsLive(
     VectorDCE::LiveComponentMap* live_components,
     std::vector<VectorDCE::WorkListItem>* work_list) {
   analysis::DefUseManager* def_use_mgr = context()->get_def_use_mgr();
-  analysis::TypeManager* type_mgr = context()->get_type_mgr();
 
   uint32_t current_component = 0;
   Instruction* current_inst = work_item.instruction;
@@ -223,8 +226,7 @@ void VectorDCE::MarkCompositeContructUsesAsLive(
       assert(HasVectorResult(op_inst));
       WorkListItem new_work_item;
       new_work_item.instruction = op_inst;
-      uint32_t op_vector_size =
-          type_mgr->GetType(op_inst->type_id())->AsVector()->element_count();
+      uint32_t op_vector_size = GetVectorTypeSize(op_inst->type_id());
 
       for (uint32_t op_vector_idx = 0; op_vector_idx < op_vector_size;
            op_vector_idx++, current_component++) {
@@ -295,6 +297,20 @@ bool VectorDCE::HasScalarResult(const Instruction* inst) const {
     default:
       return false;
   }
+}
+
+uint32_t VectorDCE::GetVectorTypeSize(uint32_t type_id) {
+  analysis::TypeManager* type_mgr = context()->get_type_mgr();
+  if (type_id == 0) {
+    return 0;
+  }
+
+  const analysis::Type* type = type_mgr->GetType(type_id);
+  const analysis::Vector* vector_type = type->AsVector();
+  if (vector_type == nullptr) {
+    return 0;
+  }
+  return vector_type->element_count();
 }
 
 bool VectorDCE::RewriteInstructions(

--- a/source/opt/vector_dce.cpp
+++ b/source/opt/vector_dce.cpp
@@ -305,8 +305,9 @@ uint32_t VectorDCE::GetVectorComponentCount(uint32_t type_id) {
   analysis::TypeManager* type_mgr = context()->get_type_mgr();
   const analysis::Type* type = type_mgr->GetType(type_id);
   const analysis::Vector* vector_type = type->AsVector();
-  assert(vector_type &&
-         "Trying to get the vector element count, but the type vector");
+  assert(
+      vector_type &&
+      "Trying to get the vector element count, but the type is not a vector");
   return vector_type->element_count();
 }
 

--- a/source/opt/vector_dce.h
+++ b/source/opt/vector_dce.h
@@ -100,9 +100,8 @@ class VectorDCE : public MemPass {
   // Returns true if the result of |inst| is a scalar.
   bool HasScalarResult(const Instruction* inst) const;
 
-  // Returns the number of elements in the vector type if |type_id| is the id of
-  // a veoctor type. Returns 0 otherwise.
-  uint32_t GetVectorTypeSize(uint32_t type_id);
+  // Returns the number of elements in the vector type with id |type_id|.
+  uint32_t GetVectorComponentCount(uint32_t type_id);
 
   // Adds |work_item| to |work_list| if it is not already live according to
   // |live_components|.  |live_components| is updated to indicate that

--- a/source/opt/vector_dce.h
+++ b/source/opt/vector_dce.h
@@ -94,11 +94,15 @@ class VectorDCE : public MemPass {
   // Returns true if the result of |inst| is a vector or a scalar.
   bool HasVectorOrScalarResult(const Instruction* inst) const;
 
-  // Returns true if the result of |inst| is a scalar.
+  // Returns true if the result of |inst| is a vector.
   bool HasVectorResult(const Instruction* inst) const;
 
-  // Returns true if the result of |inst| is a vector.
+  // Returns true if the result of |inst| is a scalar.
   bool HasScalarResult(const Instruction* inst) const;
+
+  // Returns the number of elements in the vector type if |type_id| is the id of
+  // a veoctor type. Returns 0 otherwise.
+  uint32_t GetVectorTypeSize(uint32_t type_id);
 
   // Adds |work_item| to |work_list| if it is not already live according to
   // |live_components|.  |live_components| is updated to indicate that


### PR DESCRIPTION
It is possible that other optimization will propagate
a value into an OpCompositeExtract or OpVectorShuffle
instruction that is larger than the vector size.
Vector DCE has to be able to handle it.

Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/4513.