### PR TITLE
Roll external/googletest/ b7d472f12..955c7f837 (111 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -4,9 +4,9 @@ vars = {
   'github': 'https://github.com',
 
   'effcee_revision': '2ec8f8738118cc483b67c04a759fee53496c5659',
-  'googletest_revision': 'b7d472f1225c5a64943821d8483fecb469d3f382',
-  're2_revision': 'f8e389f3acdc2517562924239e2a188037393683',
-  'spirv_headers_revision': 'e71feddb3f17c5586ff7f4cfb5ed1258b800574b',
+  'googletest_revision': '955c7f837efad184ec63e771c42542d37545eaef',
+  're2_revision': '4244cd1cb492fa1d10986ec67f862964c073f844',
+  'spirv_headers_revision': '0d3c45cdbb4563b95be9037ea967aac815caf78f',
 }
 
 deps = {


### PR DESCRIPTION
https://github.com/google/googletest/compare/b7d472f1225c...955c7f837efa

$ git log b7d472f12..955c7f837 --date=short --no-merges --format='%ad %ae %s'
2021-08-20 absl-team Googletest export
2021-08-20 absl-team Googletest export
2021-08-19 invalid_ms_user Simplify example code with c++11
2021-08-12 absl-team Googletest export
2021-08-10 dmauro Googletest export
2021-08-09 dmauro Googletest export
2021-08-06 absl-team Internal change
2021-08-06 victordk13 Format test properties in xml printer
2021-08-05 iamberkeyavas typo fix gmock_cook_book
2021-08-03 absl-team Googletest export
2021-08-03 absl-team Googletest export
2021-08-02 absl-team Googletest export
2021-07-29 absl-team Googletest export
2021-07-29 otnaiud Typo, double "the"
2021-07-28 absl-team Internal change
2021-07-24 slowy.arfy fix: typo codespelling comment
2021-07-22 absl-team Googletest export
2021-07-21 absl-team Googletest export
2021-07-19 dmauro Googletest export
2021-07-14 761129+derekmauro Fix location of GOOGLETEST_CM0011 marker
2021-07-08 absl-team Googletest export
2021-07-08 absl-team Googletest export
2021-07-07 absl-team Googletest export
2021-07-02 absl-team Googletest export
2021-07-02 absl-team Googletest export
2021-07-07 manuel Link -lregex on QNX
2021-07-01 jeremy.nimmer Use GTEST_DONT_DEFINE_TEST_F to guard TEST_F
2021-06-29 absl-team Googletest export
2021-06-28 absl-team Googletest export
2021-06-28 absl-team Googletest export
2021-06-25 manuel Don't link pthread on QNX
2021-06-23 alex Fix EXPECT_DEATH() and ASSERT_DEATH() triggering -Wcovered-switch-default
2021-06-18 dmauro Googletest export
2021-06-03 pochkaenkov feat: make a matcher ElementsAreArray applicable for std ranges
2021-06-13 hyuk.myeong fix typos
2021-06-11 absl-team Googletest export
2021-06-10 absl-team Googletest export
2021-06-09 absl-team Googletest export
2021-06-09 dmauro Googletest export
2021-06-09 absl-team Googletest export
2021-06-09 absl-team Googletest export
2021-06-08 absl-team Googletest export
2021-06-04 absl-team Googletest export
2021-06-03 dmauro Googletest export
2021-05-28 florin.crisan #3420 Declare MarkAsIgnored as a DLL export
2021-05-28 florin.crisan #3420 Properly declare all overloads of testing::internal::PrintTo as DLL exports
2021-06-01 absl-team Googletest export
2021-06-01 absl-team Googletest export
2021-05-26 absl-team Googletest export
2021-05-25 absl-team Googletest export
(...)
2021-05-06 durandal Googletest export
2021-05-06 absl-team Googletest export
2021-05-03 absl-team Googletest export
2021-05-04 JC3 isalnum -> IsAlNum for correct handling of signed chars
2021-04-28 absl-team Googletest export
2021-04-27 absl-team Googletest export
2021-04-27 absl-team Googletest export
2021-04-27 absl-team Googletest export
2021-04-26 absl-team Googletest export
2021-04-26 absl-team Googletest export
2021-04-20 absl-team Googletest export
2021-04-19 absl-team Googletest export
2021-04-20 github Use URL instead of git-repo
2021-04-16 dmauro Googletest export
2021-04-14 absl-team Googletest export
2021-04-15 sebkraemer Apply missing suggestions from code review for GTEST_SKIP
2021-04-15 sebkraemer Apply suggestions from code review for GTEST_SKIP documentation
2020-12-15 sebkraemer Add subsection for GTEST_SKIP documentation
2021-04-15 jbampton chore: fix spelling
2021-04-14 github Mention to explicitely set the option to it's default.
2021-04-14 dmauro Googletest export
2021-04-14 github Changes like Requested.
2021-04-13 absl-team Googletest export
2021-04-09 absl-team Googletest export
2021-04-09 absl-team Googletest export
2021-04-09 absl-team Googletest export
2021-04-07 absl-team Googletest export
2021-04-07 absl-team Googletest export
2021-04-07 absl-team Googletest export
2021-04-06 absl-team Googletest export
2021-04-06 absl-team Googletest export
2021-04-05 absl-team Googletest export
2021-04-02 absl-team Googletest export
2021-03-25 absl-team Googletest export
2021-03-24 absl-team Googletest export
2021-03-24 absl-team Googletest export
2021-03-24 absl-team Googletest export
2021-03-24 absl-team Googletest export
2021-03-23 absl-team Googletest export
2021-03-22 absl-team Googletest export
2021-03-22 absl-team Googletest export
2021-03-22 absl-team Googletest export
2021-03-20 absl-team Googletest export
2021-03-17 77407429+a-sully Update nicestrictnaggy gmock cook_book links
2021-03-14 zekewarren Use @platforms instead of @bazel_tools for windows constraint
2021-03-13 github Use Fetchcontent instead of ExternalProject
2020-12-30 mattias.ellert Port to GNU/Hurd
2020-12-24 georgthegreat Use proper feature test macro to test if library supports char8_t
2020-12-05 gautham.bangalore Fix typo
2020-12-04 zed.three CMake: Add namespaced ALIAS library

Created with:
  roll-dep external/googletest

Roll external/re2/ f8e389f3a..4244cd1cb (10 commits)

https://github.com/google/re2/compare/f8e389f3acdc...4244cd1cb492

$ git log f8e389f3a..4244cd1cb --date=short --no-merges --format='%ad %ae %s'
2021-05-21 junyer Fix a bug in `Regexp::ToString()`.
2021-05-19 junyer Pass a path to `cmake` in order to avoid a warning.
2021-05-18 junyer Let CMake pass `-pthread` for us.
2021-05-18 junyer Remove unneeded policy setting.
2021-05-12 junyer (|a)* shouldn't match more text than (|a)+ does!
2021-05-10 junyer Update the R wrapper URL.
2021-05-03 junyer Add GCC 11 to the build matrix.
2021-04-29 junyer Nullify hooks::context when using RE2::Set.
2021-04-19 junyer Add Clang 12 to the build matrix.
2021-03-26 junyer Set "compatibility version" and "current version".

Created with:
  roll-dep external/re2

Roll external/spirv-headers/ e71feddb3..0d3c45cdb (6 commits)

https://github.com/KhronosGroup/SPIRV-Headers/compare/e71feddb3f17...0d3c45cdbb45

$ git log e71feddb3..0d3c45cdb --date=short --no-merges --format='%ad %ae %s'
2021-08-27 greg Add nonsemantic.shader.debuginfo to Bazel
2021-07-28 marijn spirv.core.grammar: Remove duplicate OpArbitraryFloatPowNINTEL declaration
2021-05-20 kloczek Rename spirv-headers.pc to SPIRV-Headers.pc
2021-05-19 kloczek removed excesive space in configure_file() line
2021-05-19 kloczek Fixed substituted string with paths and version
2021-05-18 kloczek Add spirv-headers pkgconfig file

Created with:
  roll-dep external/spirv-headers