### PR TITLE
Fix bad order of checks in atomic validation

### DIFF
--- a/source/val/validate_atomics.cpp
+++ b/source/val/validate_atomics.cpp
@@ -184,7 +184,7 @@ spv_result_t AtomicsPass(ValidationState_t& _, const Instruction* inst) {
       }
 
       // Can't use result_type because OpAtomicStore doesn't have a result
-      if (_.GetBitWidth(data_type) == 64 && _.IsIntScalarType(data_type) &&
+      if ( _.IsIntScalarType(data_type) &&_.GetBitWidth(data_type) == 64 &&
           !_.HasCapability(SpvCapabilityInt64Atomics)) {
         return _.diag(SPV_ERROR_INVALID_DATA, inst)
                << spvOpcodeString(opcode)

--- a/test/val/val_atomics_test.cpp
+++ b/test/val/val_atomics_test.cpp
@@ -2679,6 +2679,39 @@ OpFunctionEnd
                         "CooperativeMatrixNV capability is present"));
 }
 
+TEST_F(ValidateAtomics, IIncrementBadPointerDataType) {
+  const std::string spirv = R"(
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+       %uint = OpTypeInt 32 0
+%_ptr_Input_uint = OpTypePointer Input %uint
+     %v3uint = OpTypeVector %uint 3
+%_ptr_Input_v3uint = OpTypePointer Input %v3uint
+       %void = OpTypeVoid
+         %16 = OpTypeFunction %void
+%uint_538976288 = OpConstant %uint 538976288
+        %int = OpTypeInt 32 1
+%_runtimearr_int = OpTypeRuntimeArray %int
+  %_struct_5 = OpTypeStruct %_runtimearr_int
+%_ptr_Uniform__struct_5 = OpTypePointer Uniform %_struct_5
+          %3 = OpVariable %_ptr_Input_v3uint Input
+          %7 = OpVariable %_ptr_Uniform__struct_5 Uniform
+       %8224 = OpFunction %void None %16
+      %65312 = OpLabel
+         %25 = OpAccessChain %_ptr_Input_uint %3 %uint_538976288
+         %26 = OpLoad %uint %25
+    %2097184 = OpAtomicIIncrement %int %7 %uint_538976288 %26
+               OpUnreachable
+               OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("AtomicIIncrement: expected Pointer to point to a "
+                        "value of type Result Type"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
Fixes https://crbug.com/38625

* Check the type is an integer before checking it's bit width