### PR TITLE
Handle NonSemantic.Shader Debug[No]Line

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -441,6 +441,14 @@ bool AggressiveDCEPass::AggressiveDCE(Function* func) {
   // Perform closure on live instruction set.
   while (!worklist_.empty()) {
     Instruction* liveInst = worklist_.front();
+    // Add all operand instructions of Debug[No]Lines
+    for (auto& lineInst : liveInst->dbg_line_insts()) {
+      if (lineInst.IsDebugLineInst()) {
+        lineInst.ForEachInId([this](const uint32_t* iid) {
+          AddToWorklist(get_def_use_mgr()->GetDef(*iid));
+        });
+      }
+    }
     // Add all operand instructions if not already live
     liveInst->ForEachInId([&liveInst, this](const uint32_t* iid) {
       Instruction* inInst = get_def_use_mgr()->GetDef(*iid);

--- a/source/opt/block_merge_util.cpp
+++ b/source/opt/block_merge_util.cpp
@@ -173,7 +173,9 @@ void MergeWithSuccessor(IRContext* context, Function* func,
       auto& vec = terminator->dbg_line_insts();
       auto& new_vec = merge_inst->dbg_line_insts();
       new_vec.insert(new_vec.end(), vec.begin(), vec.end());
-      terminator->clear_dbg_line_insts();
+      terminator->ClearDbgLineInsts();
+      for (auto& l_inst : new_vec)
+        context->get_def_use_mgr()->AnalyzeInstDefUse(&l_inst);
 
       // Move the merge instruction to just before the terminator.
       merge_inst->InsertBefore(terminator);

--- a/source/opt/compact_ids_pass.cpp
+++ b/source/opt/compact_ids_pass.cpp
@@ -86,9 +86,12 @@ Pass::Status CompactIdsPass::Process() {
       },
       true);
 
-  if (modified)
+  if (modified) {
     context()->module()->SetIdBound(
         static_cast<uint32_t>(result_id_mapping.size() + 1));
+    // There are ids in the feature manager that could now be invalid
+    context()->ResetFeatureManager();
+  }
 
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }

--- a/source/opt/debug_info_manager.cpp
+++ b/source/opt/debug_info_manager.cpp
@@ -86,7 +86,7 @@ uint32_t DebugInfoManager::GetDbgSetImportId() {
       context()->get_feature_mgr()->GetExtInstImportId_OpenCL100DebugInfo();
   if (setId == 0) {
     setId =
-        context()->get_feature_mgr()->GetExtInstImportId_Vulkan100DebugInfo();
+        context()->get_feature_mgr()->GetExtInstImportId_Shader100DebugInfo();
   }
   return setId;
 }
@@ -158,7 +158,7 @@ uint32_t DebugInfoManager::CreateDebugInlinedAt(const Instruction* line,
   // In NonSemantic.Shader.DebugInfo.100, all constants are IDs of OpConstant,
   // not literals.
   if (setId ==
-      context()->get_feature_mgr()->GetExtInstImportId_Vulkan100DebugInfo())
+      context()->get_feature_mgr()->GetExtInstImportId_Shader100DebugInfo())
     line_number_type = spv_operand_type_t::SPV_OPERAND_TYPE_ID;
 
   uint32_t line_number = 0;

--- a/source/opt/def_use_manager.cpp
+++ b/source/opt/def_use_manager.cpp
@@ -58,7 +58,7 @@ void DefUseManager::AnalyzeInstUse(Instruction* inst) {
       case SPV_OPERAND_TYPE_SCOPE_ID: {
         uint32_t use_id = inst->GetSingleWordOperand(i);
         Instruction* def = GetDef(use_id);
-        assert(def && "Definition is not registered.");
+        if (!def) assert(false && "Definition is not registered.");
         id_to_users_.insert(UserEntry(def, inst));
         used_ids->push_back(use_id);
       } break;
@@ -71,6 +71,9 @@ void DefUseManager::AnalyzeInstUse(Instruction* inst) {
 void DefUseManager::AnalyzeInstDefUse(Instruction* inst) {
   AnalyzeInstDef(inst);
   AnalyzeInstUse(inst);
+  // Analyze lines last otherwise they will be cleared when inst is
+  // cleared by preceding two calls
+  for (auto& l_inst : inst->dbg_line_insts()) AnalyzeInstDefUse(&l_inst);
 }
 
 void DefUseManager::UpdateDefUse(Instruction* inst) {
@@ -224,9 +227,11 @@ void DefUseManager::AnalyzeDefUse(Module* module) {
   if (!module) return;
   // Analyze all the defs before any uses to catch forward references.
   module->ForEachInst(
-      std::bind(&DefUseManager::AnalyzeInstDef, this, std::placeholders::_1));
+      std::bind(&DefUseManager::AnalyzeInstDef, this, std::placeholders::_1),
+      true);
   module->ForEachInst(
-      std::bind(&DefUseManager::AnalyzeInstUse, this, std::placeholders::_1));
+      std::bind(&DefUseManager::AnalyzeInstUse, this, std::placeholders::_1),
+      true);
 }
 
 void DefUseManager::ClearInst(Instruction* inst) {
@@ -261,6 +266,16 @@ void DefUseManager::EraseUseRecordsOfOperandIds(const Instruction* inst) {
 
 bool operator==(const DefUseManager& lhs, const DefUseManager& rhs) {
   if (lhs.id_to_def_ != rhs.id_to_def_) {
+    for (auto p : lhs.id_to_def_) {
+      if (rhs.id_to_def_.find(p.first) == rhs.id_to_def_.end()) {
+        return false;
+      }
+    }
+    for (auto p : rhs.id_to_def_) {
+      if (lhs.id_to_def_.find(p.first) == lhs.id_to_def_.end()) {
+        return false;
+      }
+    }
     return false;
   }
 

--- a/source/opt/feature_manager.cpp
+++ b/source/opt/feature_manager.cpp
@@ -80,7 +80,7 @@ void FeatureManager::AddExtInstImportIds(Module* module) {
   extinst_importid_GLSLstd450_ = module->GetExtInstImportId("GLSL.std.450");
   extinst_importid_OpenCL100DebugInfo_ =
       module->GetExtInstImportId("OpenCL.DebugInfo.100");
-  extinst_importid_Vulkan100DebugInfo_ =
+  extinst_importid_Shader100DebugInfo_ =
       module->GetExtInstImportId("NonSemantic.Shader.DebugInfo.100");
 }
 
@@ -109,8 +109,8 @@ bool operator==(const FeatureManager& a, const FeatureManager& b) {
     return false;
   }
 
-  if (a.extinst_importid_Vulkan100DebugInfo_ !=
-      b.extinst_importid_Vulkan100DebugInfo_) {
+  if (a.extinst_importid_Shader100DebugInfo_ !=
+      b.extinst_importid_Shader100DebugInfo_) {
     return false;
   }
 

--- a/source/opt/feature_manager.h
+++ b/source/opt/feature_manager.h
@@ -55,8 +55,8 @@ class FeatureManager {
     return extinst_importid_OpenCL100DebugInfo_;
   }
 
-  uint32_t GetExtInstImportId_Vulkan100DebugInfo() const {
-    return extinst_importid_Vulkan100DebugInfo_;
+  uint32_t GetExtInstImportId_Shader100DebugInfo() const {
+    return extinst_importid_Shader100DebugInfo_;
   }
 
   friend bool operator==(const FeatureManager& a, const FeatureManager& b);
@@ -99,7 +99,7 @@ class FeatureManager {
 
   // Common NonSemanticShader100DebugInfo external instruction import ids,
   // cached for performance.
-  uint32_t extinst_importid_Vulkan100DebugInfo_ = 0;
+  uint32_t extinst_importid_Shader100DebugInfo_ = 0;
 };
 
 }  // namespace opt

--- a/source/opt/if_conversion.cpp
+++ b/source/opt/if_conversion.cpp
@@ -129,6 +129,7 @@ Pass::Status IfConversion::Process() {
         Instruction* select = builder.AddSelect(phi->type_id(), condition,
                                                 true_value->result_id(),
                                                 false_value->result_id());
+        context()->get_def_use_mgr()->AnalyzeInstDefUse(select);
         select->UpdateDebugInfoFrom(phi);
         context()->ReplaceAllUsesWith(phi->result_id(), select->result_id());
         to_kill.push_back(phi);

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -92,7 +92,7 @@ void InlinePass::AddStore(uint32_t ptr_id, uint32_t val_id,
                       {{spv_operand_type_t::SPV_OPERAND_TYPE_ID, {ptr_id}},
                        {spv_operand_type_t::SPV_OPERAND_TYPE_ID, {val_id}}}));
   if (line_inst != nullptr) {
-    newStore->dbg_line_insts().push_back(*line_inst);
+    newStore->AddDebugLine(line_inst);
   }
   newStore->SetDebugScope(dbg_scope);
   (*block_ptr)->AddInstruction(std::move(newStore));
@@ -106,7 +106,7 @@ void InlinePass::AddLoad(uint32_t type_id, uint32_t resultId, uint32_t ptr_id,
       new Instruction(context(), SpvOpLoad, type_id, resultId,
                       {{spv_operand_type_t::SPV_OPERAND_TYPE_ID, {ptr_id}}}));
   if (line_inst != nullptr) {
-    newLoad->dbg_line_insts().push_back(*line_inst);
+    newLoad->AddDebugLine(line_inst);
   }
   newLoad->SetDebugScope(dbg_scope);
   (*block_ptr)->AddInstruction(std::move(newLoad));

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -73,8 +73,6 @@ Instruction::Instruction(IRContext* c, const spv_parsed_instruction_t& inst,
       unique_id_(c->TakeNextUniqueId()),
       dbg_line_insts_(std::move(dbg_line)),
       dbg_scope_(kNoDebugScope, kNoInlinedAt) {
-  assert((!IsDebugLineInst(opcode_) || dbg_line.empty()) &&
-         "Op(No)Line attaching to Op(No)Line found");
   for (uint32_t i = 0; i < inst.num_operands; ++i) {
     const auto& current_payload = inst.operands[i];
     std::vector<uint32_t> words(
@@ -82,6 +80,8 @@ Instruction::Instruction(IRContext* c, const spv_parsed_instruction_t& inst,
         inst.words + current_payload.offset + current_payload.num_words);
     operands_.emplace_back(current_payload.type, std::move(words));
   }
+  assert((!IsLineInst() || dbg_line.empty()) &&
+         "Op(No)Line attaching to Op(No)Line found");
 }
 
 Instruction::Instruction(IRContext* c, const spv_parsed_instruction_t& inst,
@@ -158,6 +158,10 @@ Instruction* Instruction::Clone(IRContext* c) const {
   clone->unique_id_ = c->TakeNextUniqueId();
   clone->operands_ = operands_;
   clone->dbg_line_insts_ = dbg_line_insts_;
+  for (auto& i : clone->dbg_line_insts_) {
+    i.unique_id_ = c->TakeNextUniqueId();
+    if (i.IsDebugLineInst()) i.SetResultId(c->TakeNextId());
+  }
   clone->dbg_scope_ = dbg_scope_;
   return clone;
 }
@@ -511,7 +515,7 @@ void Instruction::UpdateLexicalScope(uint32_t scope) {
   for (auto& i : dbg_line_insts_) {
     i.dbg_scope_.SetLexicalScope(scope);
   }
-  if (!IsDebugLineInst(opcode()) &&
+  if (!IsLineInst() &&
       context()->AreAnalysesValid(IRContext::kAnalysisDebugInfo)) {
     context()->get_debug_info_mgr()->AnalyzeDebugInst(this);
   }
@@ -522,22 +526,59 @@ void Instruction::UpdateDebugInlinedAt(uint32_t new_inlined_at) {
   for (auto& i : dbg_line_insts_) {
     i.dbg_scope_.SetInlinedAt(new_inlined_at);
   }
-  if (!IsDebugLineInst(opcode()) &&
+  if (!IsLineInst() &&
       context()->AreAnalysesValid(IRContext::kAnalysisDebugInfo)) {
     context()->get_debug_info_mgr()->AnalyzeDebugInst(this);
   }
 }
 
+void Instruction::ClearDbgLineInsts() {
+  if (context()->AreAnalysesValid(IRContext::kAnalysisDefUse)) {
+    auto def_use_mgr = context()->get_def_use_mgr();
+    for (auto& l_inst : dbg_line_insts_) def_use_mgr->ClearInst(&l_inst);
+  }
+  clear_dbg_line_insts();
+}
+
 void Instruction::UpdateDebugInfoFrom(const Instruction* from) {
   if (from == nullptr) return;
-  clear_dbg_line_insts();
+  ClearDbgLineInsts();
   if (!from->dbg_line_insts().empty())
-    dbg_line_insts().push_back(from->dbg_line_insts().back());
+    AddDebugLine(&from->dbg_line_insts().back());
   SetDebugScope(from->GetDebugScope());
-  if (!IsDebugLineInst(opcode()) &&
+  if (!IsLineInst() &&
       context()->AreAnalysesValid(IRContext::kAnalysisDebugInfo)) {
     context()->get_debug_info_mgr()->AnalyzeDebugInst(this);
   }
+}
+
+void Instruction::AddDebugLine(const Instruction* inst) {
+  dbg_line_insts_.push_back(*inst);
+  dbg_line_insts_.back().unique_id_ = context()->TakeNextUniqueId();
+  if (inst->IsDebugLineInst())
+    dbg_line_insts_.back().SetResultId(context_->TakeNextId());
+  if (context()->AreAnalysesValid(IRContext::kAnalysisDefUse))
+    context()->get_def_use_mgr()->AnalyzeInstDefUse(&dbg_line_insts_.back());
+}
+
+bool Instruction::IsDebugLineInst() const {
+  NonSemanticShaderDebugInfo100Instructions ext_opt = GetShader100DebugOpcode();
+  return ((ext_opt == NonSemanticShaderDebugInfo100DebugLine) ||
+          (ext_opt == NonSemanticShaderDebugInfo100DebugNoLine));
+}
+
+bool Instruction::IsLineInst() const { return IsLine() || IsNoLine(); }
+
+bool Instruction::IsLine() const {
+  if (opcode() == SpvOpLine) return true;
+  NonSemanticShaderDebugInfo100Instructions ext_opt = GetShader100DebugOpcode();
+  return ext_opt == NonSemanticShaderDebugInfo100DebugLine;
+}
+
+bool Instruction::IsNoLine() const {
+  if (opcode() == SpvOpNoLine) return true;
+  NonSemanticShaderDebugInfo100Instructions ext_opt = GetShader100DebugOpcode();
+  return ext_opt == NonSemanticShaderDebugInfo100DebugNoLine;
 }
 
 Instruction* Instruction::InsertBefore(std::unique_ptr<Instruction>&& inst) {
@@ -629,12 +670,12 @@ NonSemanticShaderDebugInfo100Instructions Instruction::GetShader100DebugOpcode()
     return NonSemanticShaderDebugInfo100InstructionsMax;
   }
 
-  if (!context()->get_feature_mgr()->GetExtInstImportId_Vulkan100DebugInfo()) {
+  if (!context()->get_feature_mgr()->GetExtInstImportId_Shader100DebugInfo()) {
     return NonSemanticShaderDebugInfo100InstructionsMax;
   }
 
   if (GetSingleWordInOperand(kExtInstSetIdInIdx) !=
-      context()->get_feature_mgr()->GetExtInstImportId_Vulkan100DebugInfo()) {
+      context()->get_feature_mgr()->GetExtInstImportId_Shader100DebugInfo()) {
     return NonSemanticShaderDebugInfo100InstructionsMax;
   }
 
@@ -649,16 +690,16 @@ CommonDebugInfoInstructions Instruction::GetCommonDebugOpcode() const {
 
   const uint32_t opencl_set_id =
       context()->get_feature_mgr()->GetExtInstImportId_OpenCL100DebugInfo();
-  const uint32_t vulkan_set_id =
-      context()->get_feature_mgr()->GetExtInstImportId_Vulkan100DebugInfo();
+  const uint32_t shader_set_id =
+      context()->get_feature_mgr()->GetExtInstImportId_Shader100DebugInfo();
 
-  if (!opencl_set_id && !vulkan_set_id) {
+  if (!opencl_set_id && !shader_set_id) {
     return CommonDebugInfoInstructionsMax;
   }
 
   const uint32_t used_set_id = GetSingleWordInOperand(kExtInstSetIdInIdx);
 
-  if (used_set_id != opencl_set_id && used_set_id != vulkan_set_id) {
+  if (used_set_id != opencl_set_id && used_set_id != shader_set_id) {
     return CommonDebugInfoInstructionsMax;
   }
 

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -252,11 +252,6 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   // Clear line-related debug instructions attached to this instruction.
   void clear_dbg_line_insts() { dbg_line_insts_.clear(); }
 
-  // Set line-related debug instructions.
-  void set_dbg_line_insts(const std::vector<Instruction>& lines) {
-    dbg_line_insts_ = lines;
-  }
-
   // Same semantics as in the base class except the list the InstructionList
   // containing |pos| will now assume ownership of |this|.
   // inline void MoveBefore(Instruction* pos);
@@ -306,8 +301,21 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   // Sets DebugScope.
   inline void SetDebugScope(const DebugScope& scope);
   inline const DebugScope& GetDebugScope() const { return dbg_scope_; }
+  // Add debug line inst. Renew result id if Debug[No]Line
+  void AddDebugLine(const Instruction* inst);
   // Updates DebugInlinedAt of DebugScope and OpLine.
   void UpdateDebugInlinedAt(uint32_t new_inlined_at);
+  // Clear line-related debug instructions attached to this instruction
+  // along with def-use entries.
+  void ClearDbgLineInsts();
+  // Return true if Shader100:Debug[No]Line
+  bool IsDebugLineInst() const;
+  // Return true if Op[No]Line or Shader100:Debug[No]Line
+  bool IsLineInst() const;
+  // Return true if OpLine or Shader100:DebugLine
+  bool IsLine() const;
+  // Return true if OpNoLine or Shader100:DebugNoLine
+  bool IsNoLine() const;
   inline uint32_t GetDebugInlinedAt() const {
     return dbg_scope_.GetInlinedAt();
   }
@@ -609,9 +617,9 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   uint32_t unique_id_;  // Unique instruction id
   // All logical operands, including result type id and result id.
   OperandList operands_;
-  // Opline and OpNoLine instructions preceding this instruction. Note that for
-  // Instructions representing OpLine or OpNonLine itself, this field should be
-  // empty.
+  // Op[No]Line or Debug[No]Line instructions preceding this instruction. Note
+  // that for Instructions representing Op[No]Line or Debug[No]Line themselves,
+  // this field should be empty.
   std::vector<Instruction> dbg_line_insts_;
 
   // DebugScope that wraps this instruction.

--- a/source/opt/ir_context.h
+++ b/source/opt/ir_context.h
@@ -98,6 +98,7 @@ class IRContext {
         module_(new Module()),
         consumer_(std::move(c)),
         def_use_mgr_(nullptr),
+        feature_mgr_(nullptr),
         valid_analyses_(kAnalysisNone),
         constant_mgr_(nullptr),
         type_mgr_(nullptr),
@@ -116,6 +117,7 @@ class IRContext {
         module_(std::move(m)),
         consumer_(std::move(c)),
         def_use_mgr_(nullptr),
+        feature_mgr_(nullptr),
         valid_analyses_(kAnalysisNone),
         type_mgr_(nullptr),
         id_to_name_(nullptr),
@@ -769,6 +771,8 @@ class IRContext {
 
   // The instruction decoration manager for |module_|.
   std::unique_ptr<analysis::DecorationManager> decoration_mgr_;
+
+  // The feature manager for |module_|.
   std::unique_ptr<FeatureManager> feature_mgr_;
 
   // A map from instructions to the basic block they belong to. This mapping is

--- a/source/opt/loop_unroller.cpp
+++ b/source/opt/loop_unroller.cpp
@@ -760,7 +760,7 @@ void LoopUnrollerUtilsImpl::FoldConditionBlock(BasicBlock* condition_block,
           IRContext::Analysis::kAnalysisInstrToBlockMapping);
   Instruction* new_branch = builder.AddBranch(new_target);
 
-  new_branch->set_dbg_line_insts(lines);
+  if (!lines.empty()) new_branch->AddDebugLine(&lines.back());
   new_branch->SetDebugScope(scope);
 }
 
@@ -873,6 +873,10 @@ void LoopUnrollerUtilsImpl::AssignNewResultIds(BasicBlock* basic_block) {
   def_use_mgr->AnalyzeInstDefUse(basic_block->GetLabelInst());
 
   for (Instruction& inst : *basic_block) {
+    // Do def/use analysis on new lines
+    for (auto& line : inst.dbg_line_insts())
+      def_use_mgr->AnalyzeInstDefUse(&line);
+
     uint32_t old_id = inst.result_id();
 
     // Ignore stores etc.

--- a/source/opt/pass.cpp
+++ b/source/opt/pass.cpp
@@ -43,8 +43,8 @@ Pass::Status Pass::Run(IRContext* ctx) {
   if (status == Status::SuccessWithChange) {
     ctx->InvalidateAnalysesExceptFor(GetPreservedAnalyses());
   }
-  assert((status == Status::Failure || ctx->IsConsistent()) &&
-         "An analysis in the context is out of date.");
+  if (!(status == Status::Failure || ctx->IsConsistent()))
+    assert(false && "An analysis in the context is out of date.");
   return status;
 }
 

--- a/source/opt/reflect.h
+++ b/source/opt/reflect.h
@@ -34,7 +34,7 @@ inline bool IsDebug2Inst(SpvOp opcode) {
 inline bool IsDebug3Inst(SpvOp opcode) {
   return opcode == SpvOpModuleProcessed;
 }
-inline bool IsDebugLineInst(SpvOp opcode) {
+inline bool IsOpLineInst(SpvOp opcode) {
   return opcode == SpvOpLine || opcode == SpvOpNoLine;
 }
 inline bool IsAnnotationInst(SpvOp opcode) {

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -27,6 +27,7 @@
 
 static const uint32_t kDebugValueOperandValueIndex = 5;
 static const uint32_t kDebugValueOperandExpressionIndex = 6;
+static const uint32_t kDebugDeclareOperandVariableIndex = 5;
 
 namespace spvtools {
 namespace opt {
@@ -868,6 +869,11 @@ bool ScalarReplacementPass::CheckUsesRelaxed(const Instruction* inst) const {
           case SpvOpImageTexelPointer:
             if (!CheckImageTexelPointer(index)) ok = false;
             break;
+          case SpvOpExtInst:
+            if (user->GetCommonDebugOpcode() != CommonDebugInfoDebugDeclare ||
+                !CheckDebugDeclare(index))
+              ok = false;
+            break;
           default:
             ok = false;
             break;
@@ -898,6 +904,12 @@ bool ScalarReplacementPass::CheckStore(const Instruction* inst,
     return false;
   return true;
 }
+
+bool ScalarReplacementPass::CheckDebugDeclare(uint32_t index) const {
+  if (index != kDebugDeclareOperandVariableIndex) return false;
+  return true;
+}
+
 bool ScalarReplacementPass::IsLargerThanSizeLimit(uint64_t length) const {
   if (max_num_elements_ == 0) {
     return false;

--- a/source/opt/scalar_replacement_pass.h
+++ b/source/opt/scalar_replacement_pass.h
@@ -142,6 +142,9 @@ class ScalarReplacementPass : public Pass {
   // of |inst| and the store is not to volatile memory.
   bool CheckStore(const Instruction* inst, uint32_t index) const;
 
+  // Returns true if the DebugDeclare can be scalarized at |index|.
+  bool CheckDebugDeclare(uint32_t index) const;
+
   // Returns true if |index| is the pointer operand of an OpImageTexelPointer
   // instruction.
   bool CheckImageTexelPointer(uint32_t index) const;

--- a/source/val/validate_layout.cpp
+++ b/source/val/validate_layout.cpp
@@ -58,6 +58,8 @@ spv_result_t ModuleScopedInstructions(ValidationState_t& _,
               ext_inst_key == NonSemanticShaderDebugInfo100DebugNoScope ||
               ext_inst_key == NonSemanticShaderDebugInfo100DebugDeclare ||
               ext_inst_key == NonSemanticShaderDebugInfo100DebugValue ||
+              ext_inst_key == NonSemanticShaderDebugInfo100DebugLine ||
+              ext_inst_key == NonSemanticShaderDebugInfo100DebugNoLine ||
               ext_inst_key ==
                   NonSemanticShaderDebugInfo100DebugFunctionDefinition) {
             local_debug_info = true;
@@ -263,6 +265,8 @@ spv_result_t FunctionScopedInstructions(ValidationState_t& _,
                 ext_inst_key == NonSemanticShaderDebugInfo100DebugNoScope ||
                 ext_inst_key == NonSemanticShaderDebugInfo100DebugDeclare ||
                 ext_inst_key == NonSemanticShaderDebugInfo100DebugValue ||
+                ext_inst_key == NonSemanticShaderDebugInfo100DebugLine ||
+                ext_inst_key == NonSemanticShaderDebugInfo100DebugNoLine ||
                 ext_inst_key ==
                     NonSemanticShaderDebugInfo100DebugFunctionDefinition) {
               local_debug_info = true;

--- a/test/opt/aggressive_dead_code_elim_test.cpp
+++ b/test/opt/aggressive_dead_code_elim_test.cpp
@@ -7141,7 +7141,15 @@ TEST_F(AggressiveDCETest, ShaderDebugInfoKeepInFunctionElimStoreVar) {
     %uint_16 = OpConstant %uint 16
     %uint_17 = OpConstant %uint 17
     %uint_19 = OpConstant %uint 19
+    %uint_20 = OpConstant %uint 20
+    %uint_21 = OpConstant %uint 21
+    %uint_25 = OpConstant %uint 25
     %uint_29 = OpConstant %uint 29
+    %uint_30 = OpConstant %uint 30
+    %uint_35 = OpConstant %uint 35
+    %uint_41 = OpConstant %uint 41
+    %uint_48 = OpConstant %uint 48
+    %uint_53 = OpConstant %uint 53
     %uint_64 = OpConstant %uint 64
          %45 = OpTypeFunction %void
    %PS_INPUT = OpTypeStruct %v2float
@@ -7198,20 +7206,33 @@ TEST_F(AggressiveDCETest, ShaderDebugInfoKeepInFunctionElimStoreVar) {
 ;CHECK: {{%\w+}} = OpExtInst %void %1 DebugDeclare %72 %param_var_i %52
 ;CHECK: {{%\w+}} = OpExtInst %void %1 DebugScope %69
 ;CHECK: {{%\w+}} = OpExtInst %void %1 DebugDeclare %71 %78 %52
+        %300 = OpExtInst %void %1 DebugLine %55 %uint_19 %uint_19 %uint_17 %uint_30
+;CHECK: {{%\w+}} = OpExtInst %void %1 DebugLine %55 %uint_19 %uint_19 %uint_17 %uint_30
          %88 = OpAccessChain %_ptr_Function_v2float %param_var_i %int_0
          %89 = OpLoad %v2float %88
+        %301 = OpExtInst %void %1 DebugLine %55 %uint_19 %uint_19 %uint_12 %uint_35
                OpStore %79 %89
 ;CHECK-NOT:    OpStore %79 %89
+        %302 = OpExtInst %void %1 DebugLine %55 %uint_19 %uint_19 %uint_12 %uint_35
+;CHECK: {{%\w+}} = OpExtInst %void %1 DebugLine %55 %uint_19 %uint_19 %uint_12 %uint_35
         %106 = OpExtInst %void %1 DebugValue %70 %89 %52
 ;CHECK: {{%\w+}} = OpExtInst %void %1 DebugValue %70 %89 %52
+        %303 = OpExtInst %void %1 DebugLine %55 %uint_20 %uint_20 %uint_25 %uint_32
          %91 = OpLoad %type_2d_image %g_tColor
+        %304 = OpExtInst %void %1 DebugLine %55 %uint_20 %uint_20 %uint_41 %uint_48
          %92 = OpLoad %type_sampler %g_sAniso
+        %305 = OpExtInst %void %1 DebugLine %55 %uint_20 %uint_20 %uint_25 %uint_53
          %94 = OpSampledImage %type_sampled_image %91 %92
          %95 = OpImageSampleImplicitLod %v4float %94 %89 None
+        %306 = OpExtInst %void %1 DebugLine %55 %uint_20 %uint_20 %uint_5 %uint_53
          %96 = OpAccessChain %_ptr_Function_v4float %78 %int_0
                OpStore %96 %95
+        %307 = OpExtInst %void %1 DebugLine %55 %uint_21 %uint_21 %uint_12 %uint_20
          %97 = OpLoad %PS_OUTPUT %78
+        %308 = OpExtInst %void %1 DebugLine %55 %uint_21 %uint_21 %uint_5 %uint_20
                OpStore %81 %97
+        %309 = OpExtInst %void %1 DebugNoLine
+;CHECK: {{%\w+}} = OpExtInst %void %1 DebugNoLine
         %111 = OpExtInst %void %1 DebugNoScope
 ;CHECK: {{%\w+}} = OpExtInst %void %1 DebugNoScope
         %100 = OpCompositeExtract %v4float %97 0


### PR DESCRIPTION
Debug[No]Line instructions are tracked and optimized using the same mechanism
that tracks and optimizes Op[No]Line.

Also:
    - Fix missing DebugScope at top of block.
    - Allow scalar replacement of access chain in DebugDeclare