### PR TITLE
Update SPIRV-Headers

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -6,7 +6,7 @@ vars = {
   'effcee_revision': '2ec8f8738118cc483b67c04a759fee53496c5659',
   'googletest_revision': '955c7f837efad184ec63e771c42542d37545eaef',
   're2_revision': '4244cd1cb492fa1d10986ec67f862964c073f844',
-  'spirv_headers_revision': '0d3c45cdbb4563b95be9037ea967aac815caf78f',
+  'spirv_headers_revision': 'ae217c17809fadb232ec94b29304b4afcd417bb4',
 }
 
 deps = {

--- a/test/operand_capabilities_test.cpp
+++ b/test/operand_capabilities_test.cpp
@@ -368,19 +368,6 @@ INSTANTIATE_TEST_SUITE_P(
                 // clang-format on
             })));
 
-// See SPIR-V Section 3.15 FP Fast Math Mode
-INSTANTIATE_TEST_SUITE_P(
-    FPFastMathMode, EnumCapabilityTest,
-    Combine(Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1),
-            ValuesIn(std::vector<EnumCapabilityCase>{
-                CASE0(FP_FAST_MATH_MODE, FPFastMathModeMaskNone),
-                CASE1(FP_FAST_MATH_MODE, FPFastMathModeNotNaNMask, Kernel),
-                CASE1(FP_FAST_MATH_MODE, FPFastMathModeNotInfMask, Kernel),
-                CASE1(FP_FAST_MATH_MODE, FPFastMathModeNSZMask, Kernel),
-                CASE1(FP_FAST_MATH_MODE, FPFastMathModeAllowRecipMask, Kernel),
-                CASE1(FP_FAST_MATH_MODE, FPFastMathModeFastMask, Kernel),
-            })));
-
 // See SPIR-V Section 3.17 Linkage Type
 INSTANTIATE_TEST_SUITE_P(
     LinkageType, EnumCapabilityTest,


### PR DESCRIPTION
* Remove tests that expected fast math mode operands to require a
  capability