### PR TITLE
spirv-opt: Don't eliminate dead members from StructuredBuffer

### DIFF
--- a/source/opt/eliminate_dead_members_pass.cpp
+++ b/source/opt/eliminate_dead_members_pass.cpp
@@ -64,6 +64,10 @@ void EliminateDeadMembersPass::FindLiveMembers() {
           MarkPointeeTypeAsFullUsed(inst.type_id());
           break;
         default:
+          // Ignore structured buffers as layout(offset) qualifiers cannot be
+          // applied to structure fields
+          if (inst.IsVulkanStorageBufferVariable())
+            MarkPointeeTypeAsFullUsed(inst.type_id());
           break;
       }
     }

--- a/source/opt/eliminate_dead_members_pass.cpp
+++ b/source/opt/eliminate_dead_members_pass.cpp
@@ -20,6 +20,7 @@
 namespace {
 const uint32_t kRemovedMember = 0xFFFFFFFF;
 const uint32_t kSpecConstOpOpcodeIdx = 0;
+constexpr uint32_t kArrayElementTypeIdx = 0;
 }  // namespace
 
 namespace spvtools {
@@ -140,18 +141,22 @@ void EliminateDeadMembersPass::MarkMembersAsLiveForStore(
 void EliminateDeadMembersPass::MarkTypeAsFullyUsed(uint32_t type_id) {
   Instruction* type_inst = get_def_use_mgr()->GetDef(type_id);
   assert(type_inst != nullptr);
-  if (type_inst->opcode() != SpvOpTypeStruct) {
-    return;
-  }
 
-  // Mark every member of the current struct as used.
-  for (uint32_t i = 0; i < type_inst->NumInOperands(); ++i) {
-    used_members_[type_id].insert(i);
-  }
-
-  // Mark any sub struct as fully used.
-  for (uint32_t i = 0; i < type_inst->NumInOperands(); ++i) {
-    MarkTypeAsFullyUsed(type_inst->GetSingleWordInOperand(i));
+  switch (type_inst->opcode()) {
+    case SpvOpTypeStruct:
+      // Mark every member and its type as fully used.
+      for (uint32_t i = 0; i < type_inst->NumInOperands(); ++i) {
+        used_members_[type_id].insert(i);
+        MarkTypeAsFullyUsed(type_inst->GetSingleWordInOperand(i));
+      }
+      break;
+    case SpvOpTypeArray:
+    case SpvOpTypeRuntimeArray:
+      MarkTypeAsFullyUsed(
+          type_inst->GetSingleWordInOperand(kArrayElementTypeIdx));
+      break;
+    default:
+      break;
   }
 }
 

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -30,6 +30,7 @@ namespace {
 const uint32_t kTypeImageDimIndex = 1;
 const uint32_t kLoadBaseIndex = 0;
 const uint32_t kPointerTypeStorageClassIndex = 0;
+const uint32_t kVariableStorageClassIndex = 0;
 const uint32_t kTypeImageSampledIndex = 5;
 
 // Constants for OpenCL.DebugInfo.100 / NonSemantic.Shader.DebugInfo.100
@@ -400,6 +401,21 @@ bool Instruction::IsVulkanStorageBuffer() const {
         [&is_block](const Instruction&) { is_block = true; });
     return is_block;
   }
+  return false;
+}
+
+bool Instruction::IsVulkanStorageBufferVariable() const {
+  if (opcode() != SpvOpVariable) {
+    return false;
+  }
+
+  uint32_t storage_class = GetSingleWordInOperand(kVariableStorageClassIndex);
+  if (storage_class == SpvStorageClassStorageBuffer ||
+      storage_class == SpvStorageClassUniform) {
+    Instruction* var_type = context()->get_def_use_mgr()->GetDef(type_id());
+    return var_type != nullptr && var_type->IsVulkanStorageBuffer();
+  }
+
   return false;
 }
 

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -464,6 +464,10 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   // storage buffer.
   bool IsVulkanStorageBuffer() const;
 
+  // Returns true if the instruction defines a variable in StorageBuffer or
+  // Uniform storage class with a pointer type that points to a storage buffer.
+  bool IsVulkanStorageBufferVariable() const;
+
   // Returns true if the instruction defines a pointer type that points to a
   // uniform buffer.
   bool IsVulkanUniformBuffer() const;

--- a/test/opt/eliminate_dead_member_test.cpp
+++ b/test/opt/eliminate_dead_member_test.cpp
@@ -626,6 +626,67 @@ TEST_F(EliminateDeadMemberTest, KeepMembersOpStore) {
   EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
 }
 
+TEST_F(EliminateDeadMemberTest, KeepStorageBufferMembers) {
+  // Test that all members of the storage buffer struct %S are kept.
+  // No change expected.
+  const std::string text = R"(
+               OpCapability Shader
+               OpExtension "SPV_GOOGLE_hlsl_functionality1"
+               OpExtension "SPV_GOOGLE_user_type"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %PSMain "PSMain" %out_var_SV_TARGET
+               OpExecutionMode %PSMain OriginUpperLeft
+               OpSource HLSL 600
+               OpName %type_StructuredBuffer_S "type.StructuredBuffer.S"
+               OpName %S "S"
+               OpMemberName %S 0 "A"
+               OpMemberName %S 1 "B"
+               OpName %Buf "Buf"
+               OpName %out_var_SV_TARGET "out.var.SV_TARGET"
+               OpName %PSMain "PSMain"
+               OpDecorateString %out_var_SV_TARGET UserSemantic "SV_TARGET"
+               OpDecorate %out_var_SV_TARGET Location 0
+               OpDecorate %Buf DescriptorSet 0
+               OpDecorate %Buf Binding 0
+               OpMemberDecorate %S 0 Offset 0
+               OpMemberDecorate %S 1 Offset 16
+               OpDecorate %_runtimearr_S ArrayStride 32
+               OpMemberDecorate %type_StructuredBuffer_S 0 Offset 0
+               OpMemberDecorate %type_StructuredBuffer_S 0 NonWritable
+               OpDecorate %type_StructuredBuffer_S BufferBlock
+               OpDecorateString %Buf UserTypeGOOGLE "structuredbuffer"
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+      %int_1 = OpConstant %int 1
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+          %S = OpTypeStruct %v4float %v4float
+%_runtimearr_S = OpTypeRuntimeArray %S
+%type_StructuredBuffer_S = OpTypeStruct %_runtimearr_S
+%_ptr_Uniform_type_StructuredBuffer_S = OpTypePointer Uniform %type_StructuredBuffer_S
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+       %void = OpTypeVoid
+         %18 = OpTypeFunction %void
+%_ptr_Uniform_v4float = OpTypePointer Uniform %v4float
+        %Buf = OpVariable %_ptr_Uniform_type_StructuredBuffer_S Uniform
+%out_var_SV_TARGET = OpVariable %_ptr_Output_v4float Output
+     %PSMain = OpFunction %void None %18
+         %20 = OpLabel
+         %21 = OpAccessChain %_ptr_Uniform_v4float %Buf %int_0 %uint_0 %int_1
+         %22 = OpLoad %v4float %21
+               OpStore %out_var_SV_TARGET %22
+               OpReturn
+               OpFunctionEnd
+)";
+
+  auto result = SinglePassRunAndDisassemble<opt::EliminateDeadMembersPass>(
+      text, /* skip_nop = */ true, /* do_validation = */ true);
+  EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
+}
+
 TEST_F(EliminateDeadMemberTest, KeepMembersOpCopyMemory) {
   // Test that all members are kept because of an OpCopyMemory.
   // No change expected.


### PR DESCRIPTION
This PR fixes the **eliminate_dead_members_pass** for structured buffers which UnrealEngine heavily relies on to significantly reduce the `$Globals` constant buffer.

However, we cannot remove any fields from a structured buffer (i.e. SSBO in GLSL) since `layout(offset)` qualifiers cannot be applied to structure fields, so the `ArrayStride` decoration is not sufficient in SPIR-V to translate a `StructuredBuffer` to an SSBO in GLSL.

Here is an HLSL example:
```hlsl
struct S {
    float4 A;
    float4 B;
};

ConstantBuffer<S> Buf1;
StructuredBuffer<S> Buf2;

float4 PSMain() : SV_TARGET {
    return Buf1.A + Buf2[0].B;
}
```
We can use the following commands to translate that into SPIR-V with optimization for size (to trigger the eliminate_dead_members_pass):
```
$ dxc -E PSMain -T ps_6_0 -spirv -Fo Output.spv Input.hlsl
$ spirv-opt -Os -o Output.opt.spv Output.spv
$ spirv-cross --output Output.opt.frag Output.opt.spv
```
SPIRV-Cross will complaint because the memory layout for the SSBO is invalid, but if we modify SPIRV-Cross and always output `std430` as last resort (in the last branch of `buffer_to_packing_standard`), we get the following GLSL:
```glsl
#version 450

struct S
{
    vec4 B;
};

layout(binding = 0, std140) uniform type_ConstantBuffer_S
{
    vec4 A;
} Buf1;

layout(binding = 1, 430) readonly buffer type_StructuredBuffer_S
{
    S _m0[];
} Buf2;

layout(location = 0) out vec4 out_var_SV_TARGET;

void main()
{
    out_var_SV_TARGET = Buf1.A + Buf2._m0[0u].B;
}
```
The `ArrayStride` decoration for the runtime array in SPIR-V cannot be expressed in GLSL and `layout(offset = 16)` cannot be applied in `struct S`. The correct output can be achieved with this fix which looks like this:
```glsl
#version 450

struct S
{
    vec4 A; // <-- THIS WAS MISSING
    vec4 B;
};

layout(binding = 0, std140) uniform type_ConstantBuffer_S
{
    vec4 A;
} Buf1;

layout(binding = 1, std430) readonly buffer type_StructuredBuffer_S
{
    S _m0[];
} Buf2;

layout(location = 0) out vec4 out_var_SV_TARGET;

void main()
{
    out_var_SV_TARGET = Buf1.A + Buf2._m0[0u].B;
}
```
This solution relies on the `SpvDecorationUserTypeGOOGLE` decoration, which might not be optimal but seems to be generated by default in DXC. I could also use some help with the unit tests if this PR requires one.

Thanks
Lukas