### PR TITLE
Do not assume there are execution modes

### DIFF
--- a/source/val/validate_derivatives.cpp
+++ b/source/val/validate_derivatives.cpp
@@ -79,11 +79,13 @@ spv_result_t DerivativesPass(ValidationState_t& _, const Instruction* inst) {
                                         std::string* message) {
             const auto* models = state.GetExecutionModels(entry_point->id());
             const auto* modes = state.GetExecutionModes(entry_point->id());
-            if (models->find(SpvExecutionModelGLCompute) != models->end() &&
-                modes->find(SpvExecutionModeDerivativeGroupLinearNV) ==
-                    modes->end() &&
-                modes->find(SpvExecutionModeDerivativeGroupQuadsNV) ==
-                    modes->end()) {
+            if (models &&
+                models->find(SpvExecutionModelGLCompute) != models->end() &&
+                (!modes ||
+                 (modes->find(SpvExecutionModeDerivativeGroupLinearNV) ==
+                      modes->end() &&
+                  modes->find(SpvExecutionModeDerivativeGroupQuadsNV) ==
+                      modes->end()))) {
               if (message) {
                 *message = std::string(
                                "Derivative instructions require "


### PR DESCRIPTION
Fixes #4550

* Do not assume that an entry point has any associated execution modes
  when checking derivative requirements