### PR TITLE
Include a maximum value for spv_target_env

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -516,6 +516,7 @@ typedef enum {
 
   SPV_ENV_UNIVERSAL_1_5,  // SPIR-V 1.5 latest revision, no other restrictions.
   SPV_ENV_VULKAN_1_2,     // Vulkan 1.2 latest revision.
+  SPV_ENV_MAX             // Keep this as the last enum value.
 } spv_target_env;
 
 // SPIR-V Validator can be parameterized with the following Universal Limits.

--- a/source/spirv_target_env.cpp
+++ b/source/spirv_target_env.cpp
@@ -62,7 +62,7 @@ const char* spvTargetEnvDescription(spv_target_env env) {
     case SPV_ENV_VULKAN_1_1:
       return "SPIR-V 1.3 (under Vulkan 1.1 semantics)";
     case SPV_ENV_WEBGPU_0:
-      assert(false);
+      assert(false && "Deprecated target environment value.");
       break;
     case SPV_ENV_UNIVERSAL_1_4:
       return "SPIR-V 1.4";
@@ -72,6 +72,9 @@ const char* spvTargetEnvDescription(spv_target_env env) {
       return "SPIR-V 1.5";
     case SPV_ENV_VULKAN_1_2:
       return "SPIR-V 1.5 (under Vulkan 1.2 semantics)";
+    case SPV_ENV_MAX:
+      assert(false && "Invalid target environment value.");
+      break;
   }
   return "";
 }
@@ -102,7 +105,7 @@ uint32_t spvVersionForTargetEnv(spv_target_env env) {
     case SPV_ENV_VULKAN_1_1:
       return SPV_SPIRV_VERSION_WORD(1, 3);
     case SPV_ENV_WEBGPU_0:
-      assert(false);
+      assert(false && "Deprecated target environment value.");
       break;
     case SPV_ENV_UNIVERSAL_1_4:
     case SPV_ENV_VULKAN_1_1_SPIRV_1_4:
@@ -110,6 +113,9 @@ uint32_t spvVersionForTargetEnv(spv_target_env env) {
     case SPV_ENV_UNIVERSAL_1_5:
     case SPV_ENV_VULKAN_1_2:
       return SPV_SPIRV_VERSION_WORD(1, 5);
+    case SPV_ENV_MAX:
+      assert(false && "Invalid target environment value.");
+      break;
   }
   return SPV_SPIRV_VERSION_WORD(0, 0);
 }
@@ -212,7 +218,10 @@ bool spvIsVulkanEnv(spv_target_env env) {
     case SPV_ENV_VULKAN_1_2:
       return true;
     case SPV_ENV_WEBGPU_0:
-      assert(false);
+      assert(false && "Deprecated target environment value.");
+      break;
+    case SPV_ENV_MAX:
+      assert(false && "Invalid target environment value.");
       break;
   }
   return false;
@@ -246,7 +255,10 @@ bool spvIsOpenCLEnv(spv_target_env env) {
     case SPV_ENV_OPENCL_2_2:
       return true;
     case SPV_ENV_WEBGPU_0:
-      assert(false);
+      assert(false && "Deprecated target environment value.");
+      break;
+    case SPV_ENV_MAX:
+      assert(false && "Invalid target environment value.");
       break;
   }
   return false;
@@ -280,7 +292,10 @@ bool spvIsOpenGLEnv(spv_target_env env) {
     case SPV_ENV_OPENGL_4_5:
       return true;
     case SPV_ENV_WEBGPU_0:
-      assert(false);
+      assert(false && "Deprecated target environment value.");
+      break;
+    case SPV_ENV_MAX:
+      assert(false && "Invalid target environment value.");
       break;
   }
   return false;
@@ -313,6 +328,7 @@ bool spvIsValidEnv(spv_target_env env) {
     case SPV_ENV_OPENGL_4_5:
       return true;
     case SPV_ENV_WEBGPU_0:
+    case SPV_ENV_MAX:
       break;
   }
   return false;
@@ -352,7 +368,10 @@ std::string spvLogStringForEnv(spv_target_env env) {
       return "Universal";
     }
     case SPV_ENV_WEBGPU_0:
-      assert(false);
+      assert(false && "Deprecated target environment value.");
+      break;
+    case SPV_ENV_MAX:
+      assert(false && "Invalid target environment value.");
       break;
   }
   return "Unknown";


### PR DESCRIPTION
To allow querying the range of target environments (to ensure that a
target environment value is within the valid range of the associated
enum), this change adds a maximum value to the spv_target_env
enumeration.

Fixes #4558.