### PR TITLE
Avoid bugprone-move-forwarding-reference warning in Clang

### DIFF
--- a/source/opt/iterator.h
+++ b/source/opt/iterator.h
@@ -142,7 +142,7 @@ inline IteratorRange<IteratorType> make_range(const IteratorType& begin,
 template <typename IteratorType>
 inline IteratorRange<IteratorType> make_range(IteratorType&& begin,
                                               IteratorType&& end) {
-  return {std::move(begin), std::move(end)};
+  return {std::forward<IteratorType>(begin), std::forward<IteratorType>(end)};
 }
 
 // Returns a (begin, end) iterator pair for the given container.


### PR DESCRIPTION
Use std::forward<T> instead of std::move, on an argument with
rvalue-reference of template-deduced type.

See https://clang.llvm.org/extra/clang-tidy/checks/bugprone-move-forwarding-reference.html

Bug: crbug.com/1134310