### PR TITLE
Consider 0xffffffff offset as missing

### DIFF
--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -141,8 +141,7 @@ bool isMissingOffsetInStruct(uint32_t struct_id, ValidationState_t& vstate) {
       if (SpvDecorationOffset == decoration.dec_type() &&
           Decoration::kInvalidMember != decoration.struct_member_index()) {
         // Offset 0xffffffff is not valid so ignore it for simplicity's sake.
-        if (decoration.params()[0] == 0xffffffff)
-          return true;
+        if (decoration.params()[0] == 0xffffffff) return true;
         hasOffset[decoration.struct_member_index()] = true;
       }
     }

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -140,6 +140,9 @@ bool isMissingOffsetInStruct(uint32_t struct_id, ValidationState_t& vstate) {
     for (auto& decoration : vstate.id_decorations(struct_id)) {
       if (SpvDecorationOffset == decoration.dec_type() &&
           Decoration::kInvalidMember != decoration.struct_member_index()) {
+        // Offset 0xffffffff is not valid so ignore it for simplicity's sake.
+        if (decoration.params()[0] == 0xffffffff)
+          return true;
         hasOffset[decoration.struct_member_index()] = true;
       }
     }

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -7825,6 +7825,36 @@ OpFunctionEnd
                         "laid out with Offset decorations"));
 }
 
+TEST_F(ValidateDecorations, AllOnesOffset) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+OpDecorate %outer Block
+OpMemberDecorate %outer 0 Offset 0
+OpMemberDecorate %struct 0 Offset 4294967295
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%struct = OpTypeStruct %int
+%outer = OpTypeStruct %struct
+%ptr = OpTypePointer Uniform %outer
+%var = OpVariable %ptr Uniform
+%void_fn = OpTypeFunction %void
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("decorated as Block must be explicitly laid out with "
+                        "Offset decorations"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
Fixes #4561

* When checking for offsets, don't accept 0xffffffff