### PR TITLE
Enable OpConstFunctionPointerINTEL outside function

### DIFF
--- a/source/opt/reflect.h
+++ b/source/opt/reflect.h
@@ -51,7 +51,8 @@ inline bool IsTypeInst(SpvOp opcode) {
          opcode == SpvOpTypeCooperativeMatrixNV;
 }
 inline bool IsConstantInst(SpvOp opcode) {
-  return opcode >= SpvOpConstantTrue && opcode <= SpvOpSpecConstantOp;
+  return (opcode >= SpvOpConstantTrue && opcode <= SpvOpSpecConstantOp) ||
+         opcode == SpvOpConstFunctionPointerINTEL;
 }
 inline bool IsCompileTimeConstantInst(SpvOp opcode) {
   return opcode >= SpvOpConstantTrue && opcode <= SpvOpConstantNull;

--- a/test/opt/ir_loader_test.cpp
+++ b/test/opt/ir_loader_test.cpp
@@ -105,6 +105,22 @@ TEST(IrBuilder, RoundTripIncompleteFunction) {
   DoRoundTripCheck("%2 = OpFunction %1 None %3\n");
 }
 
+TEST(IrBuilder, RoundTripFunctionPointer) {
+  DoRoundTripCheck(
+      "OpCapability Linkage\n"
+      "OpCapability FunctionPointersINTEL\n"
+      "OpName %some_function \"some_function\"\n"
+      "OpName %ptr_to_function \"ptr_to_function\"\n"
+      "OpDecorate %some_function LinkageAttributes \"some_function\" Import\n"
+      "%float = OpTypeFloat 32\n"
+      "%4 = OpTypeFunction %float %float\n"
+      "%_ptr_Function_4 = OpTypePointer Function %4\n"
+      "%ptr_to_function = OpConstFunctionPointerINTEL %_ptr_Function_4 "
+      "%some_function\n"
+      "%some_function = OpFunction %float Const %4\n"
+      "%6 = OpFunctionParameter %float\n"
+      "OpFunctionEnd\n");
+}
 TEST(IrBuilder, KeepLineDebugInfo) {
   // #version 310 es
   // void main() {}


### PR DESCRIPTION
According to spec this opcode is a constant instruction - that's it
can appear outside of function bodies.