### PR TITLE
Fix i386 build issues related to random generation

### DIFF
--- a/test/fuzzers/random_generator.cpp
+++ b/test/fuzzers/random_generator.cpp
@@ -29,7 +29,7 @@ namespace {
 /// @param upper - Upper bound of integer generated
 /// @returns i, where lower <= i < upper
 template <typename I>
-I RandomUInt(std::mt19937* engine, I lower, I upper) {
+I RandomUInt(std::mt19937_64* engine, I lower, I upper) {
   assert(lower < upper && "|lower| must be stictly less than |upper|");
   return std::uniform_int_distribution<I>(lower, upper - 1)(*engine);
 }
@@ -70,7 +70,8 @@ void HashCombine(size_t* hash, const T& value) {
 /// @param size - number of elements in buffer
 /// @returns hash of the data in the buffer
 size_t HashBuffer(const uint8_t* data, const size_t size) {
-  size_t hash = 0xCA8945571519E991;  // seed with an arbitrary prime
+  size_t hash =
+      static_cast<size_t>(0xCA8945571519E991);  // seed with an arbitrary prime
   HashCombine(&hash, size);
   for (size_t i = 0; i < size; i++) {
     HashCombine(&hash, data[i]);

--- a/test/fuzzers/random_generator.h
+++ b/test/fuzzers/random_generator.h
@@ -48,7 +48,7 @@ class RandomGenerator {
   spv_target_env GetTargetEnv();
 
  private:
-  std::mt19937 engine_;
+  std::mt19937_64 engine_;
 };  // class RandomGenerator
 
 }  // namespace fuzzers


### PR DESCRIPTION
The OSS-Fuzz i386 build has been failing due to errors about
64-to-32-bit conversions, relating to random generation code. This
changre fixes the problem by explicitly using a 64-bit random generator,
and by adding a cast to size_t to avoid an implicit conversion.