### PR TITLE
Avoid bitwise and in boolean expression

### DIFF
--- a/source/val/validate_cfg.cpp
+++ b/source/val/validate_cfg.cpp
@@ -659,9 +659,9 @@ spv_result_t ValidateStructuredSelections(
       // Mark the upcoming blocks as seen now, but only error out if this block
       // was missing a merge instruction and both labels hadn't been seen
       // previously.
-      const bool both_unseen =
-          seen.insert(true_label).second & seen.insert(false_label).second;
-      if (!merge && both_unseen) {
+      const bool true_label_unseen = seen.insert(true_label).second;
+      const bool false_label_unseen = seen.insert(false_label).second;
+      if (!merge && true_label_unseen && false_label_unseen) {
         return _.diag(SPV_ERROR_INVALID_CFG, terminator)
                << "Selection must be structured";
       }


### PR DESCRIPTION
In #3404 a logical && was replaced with a bitwise & to ensure that
both side-effecting arguments were evaluated. However, this leads to
warnings from some compilers (leading to the OSS-Fuzz build breaking,
in particular).

This change reworks the relevant code so that both arguments to the
logical && are evaluated into temporaries.