### PR TITLE
Remove publish-to-npm step for Wasm build

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -12,9 +12,3 @@ jobs:
         run: docker-compose up
       - name: Run tests
         run: node test/wasm/test.js
-      - name: Publish to npm
-        uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          package: ./out/web/package.json
-          dry-run: true


### PR DESCRIPTION
The JS-Tools/npm-publish flow requires a `token` attribute, even
in dry-run mode.
There is no token, so remove the step for now.