### PR TITLE
spirv-opt: Legalize OpTypeImage with 16-bit float type.

### DIFF
--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -881,6 +881,11 @@ Optimizer::PassToken CreateConvertToSampledImagePass(
     const std::vector<opt::DescriptorSetAndBinding>&
         descriptor_set_binding_pairs);
 
+// Creates legalize-image-ops-pass to translate TypeImage related
+// operations from half to float for Vulkan. 
+// (VUID-StandaloneSpirv-OpTypeImage-04656)
+Optimizer::PassToken CreateLegalizeImageOpsPass();
+
 }  // namespace spvtools
 
 #endif  // INCLUDE_SPIRV_TOOLS_OPTIMIZER_HPP_

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -70,6 +70,7 @@ set(SPIRV_TOOLS_OPT_SOURCES
   ir_builder.h
   ir_context.h
   ir_loader.h
+  legalize_image_ops_pass.h
   licm_pass.h
   local_access_chain_convert_pass.h
   local_redundancy_elimination.h
@@ -179,6 +180,7 @@ set(SPIRV_TOOLS_OPT_SOURCES
   interp_fixup_pass.cpp
   ir_context.cpp
   ir_loader.cpp
+  legalize_image_ops_pass.cpp
   licm_pass.cpp
   local_access_chain_convert_pass.cpp
   local_redundancy_elimination.cpp

--- a/source/opt/legalize_image_ops_pass.cpp
+++ b/source/opt/legalize_image_ops_pass.cpp
@@ -1,0 +1,324 @@
+// Copyright (c) 2021 Tencent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/opt/legalize_image_ops_pass.h"
+
+#include <algorithm>
+#include <vector>
+
+#include "source/opt/ir_builder.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/reflect.h"
+
+namespace spvtools {
+namespace opt {
+
+Pass::Status LegalizeImageOpsPass::Process() {
+  Initialize();
+  return ProcessImpl();
+}
+
+analysis::Type* LegalizeImageOpsPass::FloatScalarType(uint32_t width) {
+  analysis::Float float_ty(width);
+  return context()->get_type_mgr()->GetRegisteredType(&float_ty);
+}
+
+analysis::Type* LegalizeImageOpsPass::FloatVectorType(uint32_t v_len,
+                                                      uint32_t width) {
+  analysis::Type* reg_float_ty = FloatScalarType(width);
+  analysis::Vector vec_ty(reg_float_ty, v_len);
+  return context()->get_type_mgr()->GetRegisteredType(&vec_ty);
+}
+
+void LegalizeImageOpsPass::SetRelaxed(Instruction* inst) {
+  get_decoration_mgr()->AddDecoration(inst->result_id(),
+                                      SpvDecorationRelaxedPrecision);
+}
+
+bool LegalizeImageOpsPass::IsSameTypeImaged(Instruction* inst_a,
+                                            Instruction* inst_b) {
+  if (inst_a == inst_b) return false;
+  if (inst_a->opcode() != SpvOp::SpvOpTypeImage) return false;
+  if (inst_b->opcode() != SpvOp::SpvOpTypeImage) return false;
+
+  auto type_a =
+      context()->get_type_mgr()->GetType(inst_a->GetOperand(1).words[0]);
+  auto type_b =
+      context()->get_type_mgr()->GetType(inst_b->GetOperand(1).words[0]);
+
+  if (!type_a->IsSame(type_b)) return false;
+
+  for (uint32_t i = 2; i < inst_a->NumOperands(); i++) {
+    if (inst_a->GetOperand(i) != inst_b->GetOperand(i)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+uint32_t LegalizeImageOpsPass::IndexOfType(Instruction* inst) {
+  uint32_t index = 0;
+  for (auto& cur_inst : context()->types_values()) {
+    if (*inst == cur_inst) {
+      break;
+    }
+    index++;
+  }
+  return index;
+}
+
+void LegalizeImageOpsPass::MoveType(Instruction* a,
+                                     Module::inst_iterator& insert_point) {
+  auto a_it = std::find(context()->types_values_begin(),
+                          context()->types_values_end(), *a);
+  if (a_it != context()->types_values_end()) {
+    insert_point.InsertBefore(std::make_unique<Instruction>(*a));
+    a_it.Erase();
+  }
+}
+
+bool LegalizeImageOpsPass::ConvertOpTypeImage(Instruction* inst) {
+  // OpTypeImage (Result, Sampled Type, Dim, Depth, ... )
+  uint32_t sampled_ty_id = inst->GetOperand(1).words[0];
+  auto sampled_ty = context()->get_type_mgr()->GetType(sampled_ty_id);
+  if (sampled_ty->kind() == analysis::Type::Kind::kFloat) {
+    if (static_cast<analysis::Float*>(sampled_ty)->width() == 32) return false;
+  } else {
+    return false;
+  }
+
+  auto fp32_ty_id =
+      context()->get_type_mgr()->GetTypeInstruction(FloatScalarType(32));
+  auto f32_ty = context()->get_def_use_mgr()->GetDef(fp32_ty_id);
+  // Covers the case when %float 32 is not defined, 
+  // which is rare in real life condictions.
+  if (IndexOfType(f32_ty) > IndexOfType(inst)) {
+    // OpFloatType is created after OpTypeImage
+    // Which causes 'Operand 13[%float] requires a previous definition'.
+    // So we need to move OpFloatType to the top of type definitions.
+    MoveType(f32_ty, context()->types_values_begin());
+  }
+
+  inst->SetOperand(1, {fp32_ty_id});
+
+  SetRelaxed(inst);
+  get_def_use_mgr()->AnalyzeInstUse(inst);
+  return true;
+}
+
+bool LegalizeImageOpsPass::ConvertImageOps(BasicBlock* bb, Instruction* inst) {
+  if (inst->opcode() == SpvOpImageWrite) {
+    // OpImageWrite (Image, Coordinate, Texel, Image Operands ...)
+
+    auto load_id = inst->GetOperand(0).words[0];
+    auto load_inst = get_def_use_mgr()->GetDef(load_id);
+    auto load_result_id = load_inst->result_id();
+
+    auto write_id = inst->GetOperand(2).words[0];
+    auto write_inst = get_def_use_mgr()->GetDef(write_id);
+
+    auto write_type_id = write_inst->type_id();
+    auto write_type = context()->get_type_mgr()->GetType(write_type_id);
+
+    if (write_type->kind() != analysis::Type::Kind::kVector) return false;
+
+    auto vector_ty = static_cast<analysis::Vector*>(write_type);
+    auto vector_ele_ty = vector_ty->element_type();
+
+    if (vector_ele_ty->kind() != analysis::Type::Kind::kFloat ||
+        static_cast<const analysis::Float*>(vector_ele_ty)->width() != 16) {
+      return false;
+    }
+
+    auto f32_type_id = context()->get_type_mgr()->GetTypeInstruction(
+        FloatVectorType(vector_ty->element_count(), 32));
+
+    // For SpvOpImageWrite:
+    // Convert From:
+    // %387 = OpCompositeConstruct %v4half %384 %385 %386 %float_1
+    // %388 = OpLoad %type_2d_image_0 %OutputTexture
+    //        OpImageWrite % 388 % 240 % 387 None
+    // To:
+    // %387 = OpCompositeConstruct %v4half %384 %385 %386 %float_1 [0]
+    // %999 = OpFConvert %v4float %387                             [1]
+    // %388 = OpLoad %type_2d_image_0 %OutputTexture               [2]
+    //        OpImageWrite %388 %240 %999 None                     [3]
+
+    Instruction* inst0 = write_inst;
+    Instruction* inst1 = nullptr;
+    Instruction* inst2 = load_inst;
+    Instruction* inst3 = inst;
+    {
+      // %999 = OpFConvert %v4float %387                             [1]
+      InstructionBuilder builder(
+          context(), inst2,
+          IRContext::kAnalysisDefUse | IRContext::kAnalysisInstrToBlockMapping);
+      inst1 =
+          builder.AddUnaryOp(f32_type_id, SpvOpFConvert, inst0->result_id());
+    }
+    
+    //        OpImageWrite %388 %240 %999 None                     [3]
+    inst3->SetOperand(2, {inst1->result_id()});
+
+    SetRelaxed(inst1);
+
+    return true;
+  } else if (image_ops_.count(inst->opcode()) > 0) {
+    // Targets OpImageXXX starts with (Result Type, Result Id ...)
+
+    auto result_ty_id = inst->GetOperand(0).words[0];
+    auto result_ty = context()->get_type_mgr()->GetType(result_ty_id);
+
+    assert(result_ty->kind() == analysis::Type::Kind::kVector &&
+           "Result Type must be a vector of floating-point or integer type.");
+
+    auto vector_ty = static_cast<analysis::Vector*>(result_ty);
+    auto vector_ele_ty = vector_ty->element_type();
+
+    if (vector_ele_ty->kind() != analysis::Type::Kind::kFloat ||
+        static_cast<const analysis::Float*>(vector_ele_ty)->width() != 16) {
+      return false;
+    }
+
+    auto f16_type_id = result_ty_id;
+    auto f32_type_id = context()->get_type_mgr()->GetTypeInstruction(
+        FloatVectorType(vector_ty->element_count(), 32));
+
+    auto result_id = inst->result_id();
+
+    Instruction* cvt_inst = nullptr;
+    {
+      auto anlysisdefs =
+          IRContext::kAnalysisDefUse | IRContext::kAnalysisInstrToBlockMapping;
+      // OpFConvert (Result Type, Result Id, Float Value)
+      if (auto next_inst = inst->NextNode()) {
+        InstructionBuilder builder(context(), next_inst, anlysisdefs);
+        cvt_inst = builder.AddUnaryOp(f16_type_id, SpvOpFConvert, result_id);
+      } else {
+        InstructionBuilder builder(context(), bb, anlysisdefs);
+        cvt_inst = builder.AddUnaryOp(f16_type_id, SpvOpFConvert, result_id);
+      }
+    }
+
+    context()->ReplaceAllUsesWith(result_id, cvt_inst->result_id());
+
+    inst->SetResultType(f32_type_id);
+    cvt_inst->SetOperand(2, {result_id});
+
+    SetRelaxed(inst);
+    SetRelaxed(cvt_inst);
+
+    return true;
+  }
+
+  return false;
+}
+
+bool LegalizeImageOpsPass::ProcessFunction(Function* func) {
+  bool modified = false;
+  cfg()->ForEachBlockInReversePostOrder(
+      func->entry().get(), [&modified, this](BasicBlock* bb) {
+        for (auto ii = bb->begin(); ii != bb->end(); ++ii)
+          modified |= ConvertImageOps(bb, &*ii);
+      });
+  return modified;
+}
+
+Pass::Status LegalizeImageOpsPass::ProcessImpl() {
+  bool modified = false;
+
+  // Collect all OpTypeImages.
+  std::vector<Instruction*> op_type_images;
+  for (auto& inst : context()->types_values()) {
+    if (inst.opcode() == SpvOp::SpvOpTypeImage) {
+      op_type_images.push_back(&inst);
+    }
+  }
+
+  // Convert F16 OpTypeImage to F32.
+  for (auto inst : op_type_images) {
+    if (ConvertOpTypeImage(inst)) {
+      modified = true;
+    }
+  }
+
+  // Remove duplicated OpTypeImage declarations.
+  if (modified) {
+    for (auto& inst_a : op_type_images) {
+      if (!inst_a) {
+        continue;
+      }
+      for (auto& inst_b : op_type_images) {
+        if (!inst_b) {
+          continue;
+        }
+        if (IsSameTypeImaged(inst_a, inst_b)) {
+          context()->ReplaceAllUsesWith(inst_b->result_id(),
+                                        inst_a->result_id());
+          context()->KillInst(inst_b);
+          inst_b = nullptr;
+        }
+      }
+    }
+  }
+
+  // Convert F16 OpImageFetch 
+  if (modified) {
+    Pass::ProcessFunction pfn = [this](Function* fp) {
+      return ProcessFunction(fp);
+    };
+
+    if (context()->ProcessEntryPointCallTree(pfn)) modified = true;
+  }
+
+  auto typesa = std::vector<Instruction*>();
+  for (auto& cur_inst : context()->types_values()) {
+    typesa.push_back(&cur_inst);
+  }
+
+  auto types = context()->module()->GetTypes();
+
+  return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
+}
+
+void LegalizeImageOpsPass::Initialize() {
+  image_ops_ = {SpvOpImageSampleImplicitLod,
+                SpvOpImageSampleExplicitLod,
+                SpvOpImageSampleDrefImplicitLod,
+                SpvOpImageSampleDrefExplicitLod,
+                SpvOpImageSampleProjImplicitLod,
+                SpvOpImageSampleProjExplicitLod,
+                SpvOpImageSampleProjDrefImplicitLod,
+                SpvOpImageSampleProjDrefExplicitLod,
+                SpvOpImageFetch,
+                SpvOpImageGather,
+                SpvOpImageDrefGather,
+                SpvOpImageRead,
+                SpvOpImageSparseSampleImplicitLod,
+                SpvOpImageSparseSampleExplicitLod,
+                SpvOpImageSparseSampleDrefImplicitLod,
+                SpvOpImageSparseSampleDrefExplicitLod,
+                SpvOpImageSparseSampleProjImplicitLod,
+                SpvOpImageSparseSampleProjExplicitLod,
+                SpvOpImageSparseSampleProjDrefImplicitLod,
+                SpvOpImageSparseSampleProjDrefExplicitLod,
+                SpvOpImageSparseFetch,
+                SpvOpImageSparseGather,
+                SpvOpImageSparseDrefGather,
+                SpvOpImageSparseTexelsResident,
+                SpvOpImageSparseRead};
+}
+
+}  // namespace opt
+}  // namespace spvtools

--- a/source/opt/legalize_image_ops_pass.h
+++ b/source/opt/legalize_image_ops_pass.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2021 Tencent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_OPT_LEGALIZE_IMAGE_OPS_H_
+#define SOURCE_OPT_LEGALIZE_IMAGE_OPS_H_
+
+#include "source/opt/pass.h"
+
+namespace spvtools {
+namespace opt {
+
+// Documented in optimizer.hpp
+class LegalizeImageOpsPass : public Pass {
+ public:
+  LegalizeImageOpsPass() = default;
+
+  const char* name() const override { return "legalize-image-ops-pass"; }
+
+  Status Process() override;
+
+  IRContext::Analysis GetPreservedAnalyses() override {
+    return IRContext::kAnalysisInstrToBlockMapping |
+           IRContext::kAnalysisConstants;
+  }
+
+ private:
+  // Return type id for float with |width|
+  analysis::Type* FloatScalarType(uint32_t width);
+
+  // Return type id for vector of length |vlen| of float of |width|
+  analysis::Type* FloatVectorType(uint32_t v_len, uint32_t width);
+
+  void SetRelaxed(Instruction* inst);
+
+  bool IsSameTypeImaged(Instruction* inst_a, Instruction* inst_b);
+
+  uint32_t IndexOfType(Instruction* inst);
+
+  void MoveType(Instruction* a, Module::inst_iterator& insert_point);
+
+  bool ConvertOpTypeImage(Instruction* inst);
+
+  bool ConvertImageOps(BasicBlock* bb, Instruction* inst);
+
+  bool ProcessFunction(Function* func);
+
+  Pass::Status ProcessImpl();
+
+  void Initialize();
+
+  // Set of sample operations
+  std::unordered_set<uint32_t> image_ops_;
+};
+
+}  // namespace opt
+}  // namespace spvtools
+
+#endif  // SOURCE_OPT_LEGALIZE_IMAGE_OPS_H_

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -156,7 +156,8 @@ Optimizer& Optimizer::RegisterLegalizationPasses() {
           .RegisterPass(CreateDeadInsertElimPass())
           .RegisterPass(CreateReduceLoadSizePass())
           .RegisterPass(CreateAggressiveDCEPass())
-          .RegisterPass(CreateInterpolateFixupPass());
+          .RegisterPass(CreateInterpolateFixupPass())
+          .RegisterPass(CreateLegalizeImageOpsPass());
 }
 
 Optimizer& Optimizer::RegisterPerformancePasses() {
@@ -989,6 +990,11 @@ Optimizer::PassToken CreateConvertToSampledImagePass(
         descriptor_set_binding_pairs) {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::ConvertToSampledImagePass>(descriptor_set_binding_pairs));
+}
+
+Optimizer::PassToken CreateLegalizeImageOpsPass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::LegalizeImageOpsPass>());
 }
 
 }  // namespace spvtools

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -48,6 +48,7 @@
 #include "source/opt/inst_buff_addr_check_pass.h"
 #include "source/opt/inst_debug_printf_pass.h"
 #include "source/opt/interp_fixup_pass.h"
+#include "source/opt/legalize_image_ops_pass.h"
 #include "source/opt/licm_pass.h"
 #include "source/opt/local_access_chain_convert_pass.h"
 #include "source/opt/local_redundancy_elimination.h"

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -65,6 +65,7 @@ add_spvtools_unittest(TARGET opt
        ir_context_test.cpp
        ir_loader_test.cpp
        iterator_test.cpp
+       legalize_image_ops_test.cpp
        line_debug_info_test.cpp
        local_access_chain_convert_test.cpp
        local_redundancy_elimination_test.cpp

--- a/test/opt/legalize_image_ops_test.cpp
+++ b/test/opt/legalize_image_ops_test.cpp
@@ -1,0 +1,171 @@
+// Copyright (c) 2021 Tencent Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+#include "test/opt/pass_fixture.h"
+#include "test/opt/pass_utils.h"
+
+namespace spvtools {
+namespace opt {
+namespace {
+
+using LegalizeImageOpsTest = PassTest<::testing::Test>;
+
+// %OpTypeImage is using half types, convert to float when necessary
+// and mark it's percision as relaxed.
+TEST_F(LegalizeImageOpsTest, ConvertImageOpPercision) {
+  const std::string before =
+      R"(OpCapability Shader
+OpCapability Float16
+OpCapability StorageInputOutput16
+OpExtension "SPV_GOOGLE_hlsl_functionality1"
+OpExtension "SPV_GOOGLE_user_type"
+OpExtension "SPV_KHR_16bit_storage"
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %MainPS "MainPS" %UV %OutColor
+OpExecutionMode %MainPS OriginUpperLeft
+OpSource HLSL 500
+OpSourceExtension "GL_GOOGLE_cpp_style_line_directive"
+OpSourceExtension "GL_GOOGLE_include_directive"
+OpName %MainPS "MainPS"
+OpName %InputTexture "InputTexture"
+OpName %InputSampler "InputSampler"
+OpName %UV "UV"
+OpName %OutColor "OutColor"
+OpDecorate %InputTexture DescriptorSet 0
+OpDecorate %InputTexture Binding 0
+OpDecorate %InputSampler DescriptorSet 0
+OpDecorate %InputSampler Binding 0
+OpDecorate %UV Location 0
+OpDecorate %OutColor Location 0
+%void = OpTypeVoid
+%3 = OpTypeFunction %void
+%Half = OpTypeFloat 16
+%v4Half = OpTypeVector %Half 4
+%14 = OpTypeImage %Half 2D 0 0 0 1 Unknown
+%_ptr_UniformConstant_14 = OpTypePointer UniformConstant %14
+%InputTexture = OpVariable %_ptr_UniformConstant_14 UniformConstant
+%18 = OpTypeSampler
+%_ptr_UniformConstant_18 = OpTypePointer UniformConstant %18
+%InputSampler = OpVariable %_ptr_UniformConstant_18 UniformConstant
+%22 = OpTypeSampledImage %14
+%v2Half = OpTypeVector %Half 2
+%_ptr_Input_v4Half = OpTypePointer Input %v4Half
+%UV = OpVariable %_ptr_Input_v4Half Input
+%_ptr_Output_v4Half = OpTypePointer Output %v4Half
+%OutColor = OpVariable %_ptr_Output_v4Half Output
+%MainPS = OpFunction %void None %3
+%5 = OpLabel
+%31 = OpLoad %v4Half %UV
+%41 = OpLoad %14 %InputTexture
+%42 = OpLoad %18 %InputSampler
+%43 = OpSampledImage %22 %41 %42
+%45 = OpVectorShuffle %v2Half %31 %31 0 1
+%46 = OpImageSampleImplicitLod %v4Half %43 %45
+OpStore %OutColor %46
+OpReturn
+OpFunctionEnd
+)";
+
+  const std::string after = 
+      R"(OpCapability Shader
+OpCapability Float16
+OpCapability StorageInputOutput16
+OpExtension "SPV_GOOGLE_hlsl_functionality1"
+OpExtension "SPV_GOOGLE_user_type"
+OpExtension "SPV_KHR_16bit_storage"
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %MainPS "MainPS" %UV %OutColor
+OpExecutionMode %MainPS OriginUpperLeft
+OpSource HLSL 500
+OpSourceExtension "GL_GOOGLE_cpp_style_line_directive"
+OpSourceExtension "GL_GOOGLE_include_directive"
+OpName %MainPS "MainPS"
+OpName %InputTexture "InputTexture"
+OpName %InputSampler "InputSampler"
+OpName %UV "UV"
+OpName %OutColor "OutColor"
+OpDecorate %InputTexture DescriptorSet 0
+OpDecorate %InputTexture Binding 0
+OpDecorate %InputSampler DescriptorSet 0
+OpDecorate %InputSampler Binding 0
+OpDecorate %UV Location 0
+OpDecorate %OutColor Location 0
+OpDecorate %14 RelaxedPrecision
+OpDecorate %46 RelaxedPrecision
+OpDecorate %49 RelaxedPrecision
+%float = OpTypeFloat 32
+%void = OpTypeVoid
+%3 = OpTypeFunction %void
+%half = OpTypeFloat 16
+%v4half = OpTypeVector %half 4
+%14 = OpTypeImage %float 2D 0 0 0 1 Unknown
+%_ptr_UniformConstant_14 = OpTypePointer UniformConstant %14
+%InputTexture = OpVariable %_ptr_UniformConstant_14 UniformConstant
+%18 = OpTypeSampler
+%_ptr_UniformConstant_18 = OpTypePointer UniformConstant %18
+%InputSampler = OpVariable %_ptr_UniformConstant_18 UniformConstant
+%22 = OpTypeSampledImage %14
+%v2half = OpTypeVector %half 2
+%_ptr_Input_v4half = OpTypePointer Input %v4half
+%UV = OpVariable %_ptr_Input_v4half Input
+%_ptr_Output_v4half = OpTypePointer Output %v4half
+%OutColor = OpVariable %_ptr_Output_v4half Output
+%v4float = OpTypeVector %float 4
+%MainPS = OpFunction %void None %3
+%5 = OpLabel
+%31 = OpLoad %v4half %UV
+%41 = OpLoad %14 %InputTexture
+%42 = OpLoad %18 %InputSampler
+%43 = OpSampledImage %22 %41 %42
+%45 = OpVectorShuffle %v2half %31 %31 0 1
+%46 = OpImageSampleImplicitLod %v4float %43 %45
+%49 = OpFConvert %v4half %46
+OpStore %OutColor %49
+OpReturn
+OpFunctionEnd
+)";
+
+  // Expected diff be like:
+  // 
+  // OpDecorate %14 RelaxedPrecision
+  // OpDecorate %46 RelaxedPrecision
+  // OpDecorate %49 RelaxedPrecision
+  // [add relaxed percision for modified]
+  // 
+  // %float = OpTypeFloat 32
+  // [Insert OpTypeFloat to the top of types]
+  //
+  // %14 = OpTypeImage %float 2D 0 0 0 1 Unknown
+  // [Change half to float to bypass vulkan spec.]
+  //
+  // %v4float = OpTypeVector %float 4
+  // [New v4float type]
+  //
+  // %46 = OpImageSampleImplicitLod %v4float %43 %45
+  // %49 = OpFConvert %v4half %46
+  // [Add convert op to convert sample back to half.]
+  // OpStore %OutColor %49
+
+  SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  SinglePassRunAndCheck<LegalizeImageOpsPass>(before, after, true, true);
+}
+
+
+}  // namespace
+}  // namespace opt
+}  // namespace spvtools


### PR DESCRIPTION
[FP16 TextureObject](https://github.com/microsoft/DirectXShaderCompiler/issues/2711) is not allowed under vulkan specs:

> VUID-StandaloneSpirv-OpTypeImage-04656: 
> OpTypeImage must declare a scalar 32-bit float or 32-bit integer type for the “Sampled Type”. (RelaxedPrecision can be applied to a sampling instruction and to the variable holding the result of a sampling instruction.)

In short, this code won't compile: 
```hlsl
Texture2D<half4> InputTexture;
SamplerState InputSampler;

void MainPS(half4 UV : TEXCOORD0, out half4 OutColor : SV_Target0) {
  OutColor = InputTexture.Sample(InputSampler, UV.xy);
}
```

But it's important for mobile platforms to use as many as half floats as we can.
This is the easiest way for us to reduce register pressure.
So, changing to Texture2D<float> is not an option.
As the vulkan specs said, We can still define OpTypeImage as full precision.
But mark it's instruction as 'relaxed', to preserve this information.
So we can **cross compile**(in Unreal Engine for example) from hlsl to essl with **no performance compromise**.

The diff of the modified spir-v looks like this:
```
OpDecorate %14 RelaxedPrecision
OpDecorate %46 RelaxedPrecision
OpDecorate %49 RelaxedPrecision
[add relaxed percision for modified]

%float = OpTypeFloat 32
[Insert OpTypeFloat to the top of types]

%14 = OpTypeImage %float 2D 0 0 0 1 Unknown
[Change half to float to bypass vulkan spec.]

%v4float = OpTypeVector %float 4
[New v4float type]

%46 = OpImageSampleImplicitLod %v4float %43 %45
%49 = OpFConvert %v4half %46
[Add convert op to convert sample back to half.]
OpStore %OutColor %49
```

I added this legalization pass to spirvToolsLegalize(), and force legalization when enable16BitTypes is true.
And there's a simple test case as well. Let me know if i'm missing something with the code.