### PR TITLE
Rename OpConstFunctionPointerINTEL to OpConstantFunctionPointerINTEL

### DIFF
--- a/source/opt/reflect.h
+++ b/source/opt/reflect.h
@@ -52,7 +52,7 @@ inline bool IsTypeInst(SpvOp opcode) {
 }
 inline bool IsConstantInst(SpvOp opcode) {
   return (opcode >= SpvOpConstantTrue && opcode <= SpvOpSpecConstantOp) ||
-         opcode == SpvOpConstFunctionPointerINTEL;
+         opcode == SpvOpConstantFunctionPointerINTEL;
 }
 inline bool IsCompileTimeConstantInst(SpvOp opcode) {
   return opcode >= SpvOpConstantTrue && opcode <= SpvOpConstantNull;

--- a/test/opt/ir_loader_test.cpp
+++ b/test/opt/ir_loader_test.cpp
@@ -115,7 +115,7 @@ TEST(IrBuilder, RoundTripFunctionPointer) {
       "%float = OpTypeFloat 32\n"
       "%4 = OpTypeFunction %float %float\n"
       "%_ptr_Function_4 = OpTypePointer Function %4\n"
-      "%ptr_to_function = OpConstFunctionPointerINTEL %_ptr_Function_4 "
+      "%ptr_to_function = OpConstantFunctionPointerINTEL %_ptr_Function_4 "
       "%some_function\n"
       "%some_function = OpFunction %float Const %4\n"
       "%6 = OpFunctionParameter %float\n"


### PR DESCRIPTION
Spec update: https://github.com/intel/llvm/pull/4883/files
SPIR-V to LLVM IR Translator update: https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/1265
SPIR-V Headers update: https://github.com/KhronosGroup/SPIRV-Headers/pull/251

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>