### PR TITLE
Use schema instead of reserved in header description

### DIFF
--- a/source/link/linker.cpp
+++ b/source/link/linker.cpp
@@ -210,7 +210,7 @@ spv_result_t GenerateHeader(const MessageConsumer& consumer,
   header->version = version;
   header->generator = SPV_GENERATOR_WORD(SPV_GENERATOR_KHRONOS_LINKER, 0);
   header->bound = max_id_bound;
-  header->reserved = 0u;
+  header->schema = 0u;
 
   return SPV_SUCCESS;
 }

--- a/source/opt/module.cpp
+++ b/source/opt/module.cpp
@@ -139,7 +139,7 @@ void Module::ToBinary(std::vector<uint32_t>* binary, bool skip_nop) const {
   // TODO(antiagainst): should we change the generator number?
   binary->push_back(header_.generator);
   binary->push_back(header_.bound);
-  binary->push_back(header_.reserved);
+  binary->push_back(header_.schema);
 
   size_t bound_idx = binary->size() - 2;
   DebugScope last_scope(kNoDebugScope, kNoInlinedAt);

--- a/source/opt/module.h
+++ b/source/opt/module.h
@@ -36,7 +36,7 @@ struct ModuleHeader {
   uint32_t version;
   uint32_t generator;
   uint32_t bound;
-  uint32_t reserved;
+  uint32_t schema;
 };
 
 // A SPIR-V module. It contains all the information for a SPIR-V module and
@@ -61,7 +61,7 @@ class Module {
   }
 
   // Returns the Id bound.
-  uint32_t IdBound() { return header_.bound; }
+  uint32_t IdBound() const { return header_.bound; }
 
   // Returns the current Id bound and increases it to the next available value.
   // If the id bound has already reached its maximum value, then 0 is returned.
@@ -141,6 +141,8 @@ class Module {
   inline uint32_t id_bound() const { return header_.bound; }
 
   inline uint32_t version() const { return header_.version; }
+  inline uint32_t generator() const { return header_.generator; }
+  inline uint32_t schema() const { return header_.schema; }
 
   inline void set_version(uint32_t v) { header_.version = v; }
 


### PR DESCRIPTION
For consistency with SPIR-V disassembly which outputs Schema for this
field.