### PR TITLE
spirv-opt: create OpDecorate for OpMemberDecorate in desc-sroa

### DIFF
--- a/source/opt/desc_sroa.cpp
+++ b/source/opt/desc_sroa.cpp
@@ -216,7 +216,7 @@ void DescriptorScalarReplacement::CreateNewDecorationForNewVariable(
   std::unique_ptr<Instruction> new_decoration(old_decoration->Clone(context()));
   new_decoration->SetInOperand(0, {new_var_id});
 
-  if (IsDecorationBinding(new_decoration)) {
+  if (IsDecorationBinding(new_decoration.get())) {
     new_decoration->SetInOperand(2, {new_binding});
   }
   context()->AddAnnotationInst(std::move(new_decoration));

--- a/source/opt/desc_sroa.cpp
+++ b/source/opt/desc_sroa.cpp
@@ -216,8 +216,7 @@ void DescriptorScalarReplacement::CreateNewDecorationForNewVariable(
   std::unique_ptr<Instruction> new_decoration(old_decoration->Clone(context()));
   new_decoration->SetInOperand(0, {new_var_id});
 
-  uint32_t decoration = new_decoration->GetSingleWordInOperand(1u);
-  if (decoration == SpvDecorationBinding) {
+  if (IsDecorationBinding(new_decoration)) {
     new_decoration->SetInOperand(2, {new_binding});
   }
   context()->AddAnnotationInst(std::move(new_decoration));

--- a/source/opt/desc_sroa.cpp
+++ b/source/opt/desc_sroa.cpp
@@ -19,6 +19,14 @@
 
 namespace spvtools {
 namespace opt {
+namespace {
+
+bool IsDecorationBinding(Instruction* inst) {
+  if (inst->opcode() != SpvOpDecorate) return false;
+  return inst->GetSingleWordInOperand(1u) == SpvDecorationBinding;
+}
+
+}  // namespace
 
 Pass::Status DescriptorScalarReplacement::Process() {
   bool modified = false;
@@ -157,6 +165,55 @@ uint32_t DescriptorScalarReplacement::GetReplacementVariable(Instruction* var,
   return replacement_vars->second[idx];
 }
 
+void DescriptorScalarReplacement::CopyDecorationsForNewVariable(
+    Instruction* old_var, uint32_t index, uint32_t new_var_id,
+    uint32_t new_var_ptr_type_id, const bool is_old_var_array,
+    const bool is_old_var_struct, Instruction* old_var_type) {
+  for (auto old_decoration :
+       get_decoration_mgr()->GetDecorationsFor(old_var->result_id(), true)) {
+    uint32_t new_binding = 0;
+    if (IsDecorationBinding(old_decoration)) {
+      new_binding = GetNewBindingForElement(
+          old_decoration->GetSingleWordInOperand(2), index, new_var_ptr_type_id,
+          is_old_var_array, is_old_var_struct, old_var_type);
+    }
+    CreateNewDecorationForNewVariable(old_decoration, new_var_id, new_binding);
+  }
+}
+
+uint32_t DescriptorScalarReplacement::GetNewBindingForElement(
+    uint32_t old_binding, uint32_t index, uint32_t new_var_ptr_type_id,
+    const bool is_old_var_array, const bool is_old_var_struct,
+    Instruction* old_var_type) {
+  if (is_old_var_array) {
+    return old_binding + index * GetNumBindingsUsedByType(new_var_ptr_type_id);
+  }
+  if (is_old_var_struct) {
+    // The binding offset that should be added is the sum of binding
+    // numbers used by previous members of the current struct.
+    uint32_t new_binding = old_binding;
+    for (uint32_t i = 0; i < index; ++i) {
+      new_binding +=
+          GetNumBindingsUsedByType(old_var_type->GetSingleWordInOperand(i));
+    }
+    return new_binding;
+  }
+  return old_binding;
+}
+
+void DescriptorScalarReplacement::CreateNewDecorationForNewVariable(
+    Instruction* old_decoration, uint32_t new_var_id, uint32_t new_binding) {
+  assert(old_decoration->opcode() == SpvOpDecorate);
+  std::unique_ptr<Instruction> new_decoration(old_decoration->Clone(context()));
+  new_decoration->SetInOperand(0, {new_var_id});
+
+  uint32_t decoration = new_decoration->GetSingleWordInOperand(1u);
+  if (decoration == SpvDecorationBinding) {
+    new_decoration->SetInOperand(2, {new_binding});
+  }
+  context()->AddAnnotationInst(std::move(new_decoration));
+}
+
 uint32_t DescriptorScalarReplacement::CreateReplacementVariable(
     Instruction* var, uint32_t idx) {
   // The storage class for the new variable is the same as the original.
@@ -192,33 +249,8 @@ uint32_t DescriptorScalarReplacement::CreateReplacementVariable(
                            {static_cast<uint32_t>(storage_class)}}}));
   context()->AddGlobalValue(std::move(variable));
 
-  // Copy all of the decorations to the new variable.  The only difference is
-  // the Binding decoration needs to be adjusted.
-  for (auto old_decoration :
-       get_decoration_mgr()->GetDecorationsFor(var->result_id(), true)) {
-    assert(old_decoration->opcode() == SpvOpDecorate);
-    std::unique_ptr<Instruction> new_decoration(
-        old_decoration->Clone(context()));
-    new_decoration->SetInOperand(0, {id});
-
-    uint32_t decoration = new_decoration->GetSingleWordInOperand(1u);
-    if (decoration == SpvDecorationBinding) {
-      uint32_t new_binding = new_decoration->GetSingleWordInOperand(2);
-      if (is_array) {
-        new_binding += idx * GetNumBindingsUsedByType(ptr_element_type_id);
-      }
-      if (is_struct) {
-        // The binding offset that should be added is the sum of binding numbers
-        // used by previous members of the current struct.
-        for (uint32_t i = 0; i < idx; ++i) {
-          new_binding += GetNumBindingsUsedByType(
-              pointee_type_inst->GetSingleWordInOperand(i));
-        }
-      }
-      new_decoration->SetInOperand(2, {new_binding});
-    }
-    context()->AddAnnotationInst(std::move(new_decoration));
-  }
+  CopyDecorationsForNewVariable(var, idx, id, ptr_element_type_id, is_array,
+                                is_struct, pointee_type_inst);
 
   // Create a new OpName for the replacement variable.
   std::vector<std::unique_ptr<Instruction>> names_to_add;

--- a/source/opt/desc_sroa.h
+++ b/source/opt/desc_sroa.h
@@ -123,6 +123,12 @@ class DescriptorScalarReplacement : public Pass {
                                          uint32_t new_var_id,
                                          uint32_t new_binding);
 
+  // Create a new OpDecorate instruction whose operand is the same as an
+  // OpMemberDecorate instruction |old_member_decoration| except Target operand.
+  // The Target operand of the new OpDecorate instruction will be |new_var_id|.
+  void CreateNewDecorationForMemberDecorate(Instruction* old_decoration,
+                                            uint32_t new_var_id);
+
   // A map from an OpVariable instruction to the set of variables that will be
   // used to replace it. The entry |replacement_variables_[var][i]| is the id of
   // a variable that will be used in the place of the the ith element of the

--- a/source/opt/desc_sroa.h
+++ b/source/opt/desc_sroa.h
@@ -89,6 +89,40 @@ class DescriptorScalarReplacement : public Pass {
   // bindings used by its members.
   uint32_t GetNumBindingsUsedByType(uint32_t type_id);
 
+  // Copy all of the decorations of variable |old_var| and make them as
+  // decorations for the new variable whose id is |new_var_id|. The new variable
+  // is supposed to replace |index|th element of |old_var|.
+  // |new_var_ptr_type_id| is the id of the pointer to the type of the new
+  // variable. |is_old_var_array| is true if |old_var| has an array type.
+  // |is_old_var_struct| is true if |old_var| has a structure type.
+  // |old_var_type| is the pointee type of |old_var|.
+  void CopyDecorationsForNewVariable(Instruction* old_var, uint32_t index,
+                                     uint32_t new_var_id,
+                                     uint32_t new_var_ptr_type_id,
+                                     const bool is_old_var_array,
+                                     const bool is_old_var_struct,
+                                     Instruction* old_var_type);
+
+  // Get the new binding number for a new variable that will be replaced with an
+  // |index|th element of an old variable. The old variable has |old_binding|
+  // as its binding number. |ptr_elem_type_id| the id of the pointer to the
+  // element type. |is_old_var_array| is true if the old variable has an array
+  // type. |is_old_var_struct| is true if the old variable has a structure type.
+  // |old_var_type| is the pointee type of the old variable.
+  uint32_t GetNewBindingForElement(uint32_t old_binding, uint32_t index,
+                                   uint32_t ptr_elem_type_id,
+                                   const bool is_old_var_array,
+                                   const bool is_old_var_struct,
+                                   Instruction* old_var_type);
+
+  // Create a new OpDecorate instruction by cloning |old_decoration|. The new
+  // OpDecorate instruction will be used for a variable whose id is
+  // |new_var_ptr_type_id|. If |old_decoration| is a decoration for a binding,
+  // the new OpDecorate instruction will have |new_binding| as its binding.
+  void CreateNewDecorationForNewVariable(Instruction* old_decoration,
+                                         uint32_t new_var_id,
+                                         uint32_t new_binding);
+
   // A map from an OpVariable instruction to the set of variables that will be
   // used to replace it. The entry |replacement_variables_[var][i]| is the id of
   // a variable that will be used in the place of the the ith element of the


### PR DESCRIPTION
If a struct/array of resources has `OpMemberDecorate` instructions,
the desc-sroa pass must correctly create `OpDecorate` instructions
when it creates variables for its elements. For example, desc-sroa
has to convert

```
OpMemberDecorate %struct 0 RelaxedPrecision
...
%struct = %resource0 %resource1
```

to

```
OpDecorate %resource0_var RelaxedPrecision
...
%resource0_var = OpVariable ..
```

This will fix https://github.com/microsoft/DirectXShaderCompiler/issues/4047