### PR TITLE
Avoid an extra map lookup

### DIFF
--- a/source/opt/def_use_manager.cpp
+++ b/source/opt/def_use_manager.cpp
@@ -260,7 +260,7 @@ void DefUseManager::EraseUseRecordsOfOperandIds(const Instruction* inst) {
       id_to_users_.erase(
           UserEntry(GetDef(use_id), const_cast<Instruction*>(inst)));
     }
-    inst_to_used_ids_.erase(inst);
+    inst_to_used_ids_.erase(iter);
   }
 }
 


### PR DESCRIPTION
Speedup: 5% less time on a real-world compilation batch
(nearly 10k parallel compilations, on 8 hardware threads)
(Durations: Before: 156.5s, After: 147.4s)