### PR TITLE
Clarify how to update DEPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,11 +468,11 @@ $ANDROID_NDK/ndk-build -C ../android_test     \
 
 ### Updating DEPS
 
-Occasionally the entries in [DEPS](DEPS) will need to be updated. This is done on demand
-when there is a request to do this, often due to downstream breakages. There is
-a script `utils/roll_deps.sh` provided, which will generate a patch with the
-updated DEPS values. This will still need to be tested in your checkout to
-confirm that there are no integration issues that need to be resolved.
+Occasionally the entries in [DEPS](DEPS) will need to be updated. This is done on
+demand when there is a request to do this, often due to downstream breakages.
+To update `DEPS`, run `utils/roll_deps.sh` and confirm that tests pass.
+The script requires Chromium's
+[`depot_tools`](https://chromium.googlesource.com/chromium/tools/depot_tools).
 
 ## Library
 

--- a/utils/roll_deps.sh
+++ b/utils/roll_deps.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2019 Google Inc.
+# Copyright (c) 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,10 @@
 
 # Attempts to roll all entries in DEPS to tip-of-tree and create a commit.
 #
-# Depends on roll-dep from depot_path being in PATH.
+# Depends on roll-dep from depot_tools
+# (https://chromium.googlesource.com/chromium/tools/depot_tools) being in PATH.
+
+set -eo pipefail
 
 effcee_dir="external/effcee/"
 effcee_trunk="origin/main"
@@ -44,3 +47,4 @@ roll-dep --ignore-dirty-tree --roll-to="${re2_trunk}" "${re2_dir}"
 roll-dep --ignore-dirty-tree --roll-to="${spirv_headers_trunk}" "${spirv_headers_dir}"
 
 git rebase --interactive "${old_head}"
+


### PR DESCRIPTION
-  Mention that `depot_tools` are required and link to that repo.
-  Make `roll_deps.sh` exit on error. The script passes `shellcheck`
   with this change.
-  Reword instruction in the README.