### PR TITLE
Avoid uninitialised read when parsing hex float

### DIFF
--- a/source/util/hex_float.h
+++ b/source/util/hex_float.h
@@ -199,7 +199,7 @@ bool operator==(const FloatProxy<T>& first, const FloatProxy<T>& second) {
 // Reads a FloatProxy value as a normal float from a stream.
 template <typename T>
 std::istream& operator>>(std::istream& is, FloatProxy<T>& value) {
-  T float_val;
+  T float_val = static_cast<T>(0.0);
   is >> float_val;
   value = FloatProxy<T>(float_val);
   return is;


### PR DESCRIPTION
Ensures that when an attempt to read a floating-point value from an
input stream fails, the recieving variable for the read does not end up
uninitialised.

Fixes OSS-Fuzz:40432
Fixes #4644