### PR TITLE
Copy OpDecorateStrings in DescriptorScalarReplacementPass

### DIFF
--- a/source/opt/desc_sroa.cpp
+++ b/source/opt/desc_sroa.cpp
@@ -169,7 +169,7 @@ void DescriptorScalarReplacement::CopyDecorationsForNewVariable(
     Instruction* old_var, uint32_t index, uint32_t new_var_id,
     uint32_t new_var_ptr_type_id, const bool is_old_var_array,
     const bool is_old_var_struct, Instruction* old_var_type) {
-  // Handle OpDecorate instructions.
+  // Handle OpDecorate and OpDecorateString instructions.
   for (auto old_decoration :
        get_decoration_mgr()->GetDecorationsFor(old_var->result_id(), true)) {
     uint32_t new_binding = 0;
@@ -212,7 +212,8 @@ uint32_t DescriptorScalarReplacement::GetNewBindingForElement(
 
 void DescriptorScalarReplacement::CreateNewDecorationForNewVariable(
     Instruction* old_decoration, uint32_t new_var_id, uint32_t new_binding) {
-  assert(old_decoration->opcode() == SpvOpDecorate);
+  assert(old_decoration->opcode() == SpvOpDecorate ||
+         old_decoration->opcode() == SpvOpDecorateString);
   std::unique_ptr<Instruction> new_decoration(old_decoration->Clone(context()));
   new_decoration->SetInOperand(0, {new_var_id});
 

--- a/source/opt/desc_sroa.h
+++ b/source/opt/desc_sroa.h
@@ -115,10 +115,11 @@ class DescriptorScalarReplacement : public Pass {
                                    const bool is_old_var_struct,
                                    Instruction* old_var_type);
 
-  // Create a new OpDecorate instruction by cloning |old_decoration|. The new
-  // OpDecorate instruction will be used for a variable whose id is
-  // |new_var_ptr_type_id|. If |old_decoration| is a decoration for a binding,
-  // the new OpDecorate instruction will have |new_binding| as its binding.
+  // Create a new OpDecorate(String) instruction by cloning |old_decoration|.
+  // The new OpDecorate(String) instruction will be used for a variable whose id
+  // is |new_var_ptr_type_id|. If |old_decoration| is a decoration for a
+  // binding, the new OpDecorate(String) instruction will have |new_binding| as
+  // its binding.
   void CreateNewDecorationForNewVariable(Instruction* old_decoration,
                                          uint32_t new_var_id,
                                          uint32_t new_binding);


### PR DESCRIPTION
Along with OpDecorate, also clone the OpDecorateString instructions for
variables created in the descriptor scalar replacement pass.

Fixes microsoft/DirectXShaderCompiler#3705