### PR TITLE
optimizer: restore previous ABI.

### DIFF
--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -519,7 +519,8 @@ Optimizer::PassToken CreateDeadInsertElimPass();
 // interface are considered live and are not eliminated. This mode is needed
 // by GPU-Assisted validation instrumentation, where a change in the interface
 // is not allowed.
-Optimizer::PassToken CreateAggressiveDCEPass(bool preserve_interface = false);
+Optimizer::PassToken CreateAggressiveDCEPass();
+Optimizer::PassToken CreateAggressiveDCEPass(bool preserve_interface);
 
 // Creates a remove-unused-interface-variables pass.
 // Removes variables referenced on the |OpEntryPoint| instruction that are not

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -764,6 +764,11 @@ Optimizer::PassToken CreateLocalMultiStoreElimPass() {
       MakeUnique<opt::SSARewritePass>());
 }
 
+Optimizer::PassToken CreateAggressiveDCEPass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::AggressiveDCEPass>(false));
+}
+
 Optimizer::PassToken CreateAggressiveDCEPass(bool preserve_interface) {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::AggressiveDCEPass>(preserve_interface));


### PR DESCRIPTION
The change in
commit 4ac8e5e541ea992dc6f44a4d4eb065a8fe0888ec
Author: Greg Fischer <greg@lunarg.com>
Date:   Wed Sep 15 12:38:34 2021 -0600

    Add preserve_interface mode to aggressive_dead_code_elim (#4520)

Broke the C++ ABI for spirv-tools shared libraries on Linux, for not a great reason.

Restore the previous ABI.