### PR TITLE
fix compile error on visual studio 2019

### DIFF
--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Google Inc.
+﻿// Copyright (c) 2017 Google Inc.
 // Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights
 // reserved.
 //


### PR DESCRIPTION
validate_image.cpp encoding with utf8 without BOM, this will make vs2019 throw a error(warning C4819, and warning as error); I fix it after recoding to utf8-BOM