### PR TITLE
Fix opt fuzzer test harness

### DIFF
--- a/test/fuzzers/spvtools_opt_fuzzer_common.h
+++ b/test/fuzzers/spvtools_opt_fuzzer_common.h
@@ -27,7 +27,7 @@ namespace fuzzers {
 // Helper function capturing the common logic for the various optimizer fuzzers.
 int OptFuzzerTestOneInput(
     const uint8_t* data, size_t size,
-    std::function<void(spvtools::Optimizer&)> register_passes);
+    const std::function<void(spvtools::Optimizer&)>& register_passes);
 
 }  // namespace fuzzers
 }  // namespace spvtools


### PR DESCRIPTION
The test harness for the opt fuzzer was failing to consider that the
input might use a very large id bound, despite no id approaching this
bound actually being used in the module. This change modifies the test
harness to use the module's id bound, rather than looking through the
module for large ids.

Fixes: oss-fuzz:42386