### PR TITLE
Avoid uninitialized access to instruction opcode

### DIFF
--- a/source/text.cpp
+++ b/source/text.cpp
@@ -715,6 +715,12 @@ spv_result_t GetNumericIds(const spvtools::AssemblyGrammar& grammar,
   while (context.hasText()) {
     spv_instruction_t inst;
 
+    // Operand parsing sometimes involves knowing the opcode of the instruction
+    // being parsed. A malformed input might feature such an operand *before*
+    // the opcode is known. To guard against accessing an uninitialized opcode,
+    // the instruction's opcode is initialized to a default value.
+    inst.opcode = SpvOpMax;
+
     if (spvTextEncodeOpcode(grammar, &context, &inst)) {
       return SPV_ERROR_INVALID_TEXT;
     }


### PR DESCRIPTION
Ensures that instruction's opcode is set to something default when
parsing the module with --preserve-numeric-ids enabled. This avoids
uninitialized accesses and knock-on buffer overflows.

Fixes #4672.