### PR TITLE
Remove misleading comment.

### DIFF
--- a/source/opt/types.cpp
+++ b/source/opt/types.cpp
@@ -425,7 +425,6 @@ std::string Array::str() const {
 void Array::GetExtraHashWords(std::vector<uint32_t>* words,
                               std::unordered_set<const Type*>* seen) const {
   element_type_->GetHashWords(words, seen);
-  // This should mirror the logic in IsSameImpl
   words->insert(words->end(), length_info_.words.begin(),
                 length_info_.words.end());
 }


### PR DESCRIPTION
The comment in `Array::GetExtraHashWords` is misleading because getting
the hash words is split up between the generic `Type::GetHashWords` and
the type specific `Type::GetExtraHashWords`.  While `IsSameImpl` is
self-contained.  Removing the comment since it is misleading and no
comment is really needed.

Fixes #3248
