### PR TITLE
Improvements to disassembly within PassManager

### DIFF
--- a/source/opt/pass_manager.cpp
+++ b/source/opt/pass_manager.cpp
@@ -35,7 +35,7 @@ Pass::Status PassManager::Run(IRContext* context) {
     if (print_all_stream_) {
       std::vector<uint32_t> binary;
       context->module()->ToBinary(&binary, false);
-      SpirvTools t(SPV_ENV_UNIVERSAL_1_2);
+      SpirvTools t(target_env_);
       t.SetMessageConsumer(consumer());
       std::string disassembly;
       std::string pass_name = (pass ? pass->name() : "");

--- a/source/opt/pass_manager.cpp
+++ b/source/opt/pass_manager.cpp
@@ -36,9 +36,17 @@ Pass::Status PassManager::Run(IRContext* context) {
       std::vector<uint32_t> binary;
       context->module()->ToBinary(&binary, false);
       SpirvTools t(SPV_ENV_UNIVERSAL_1_2);
+      t.SetMessageConsumer(consumer());
       std::string disassembly;
-      t.Disassemble(binary, &disassembly, 0);
-      *print_all_stream_ << preamble << (pass ? pass->name() : "") << "\n"
+      std::string pass_name = (pass ? pass->name() : "");
+      if (!t.Disassemble(binary, &disassembly, 0)) {
+        std::string msg = "Disassembly failed before pass ";
+        msg += pass_name + "\n";
+        spv_position_t null_pos{0, 0, 0};
+        consumer()(SPV_MSG_WARNING, "", null_pos, msg.c_str());
+        return;
+      }
+      *print_all_stream_ << preamble << pass_name << "\n"
                          << disassembly << std::endl;
     }
   };


### PR DESCRIPTION
1. Output disassembly messages and a warning in case disassembly fails.
2. Use the specified target environment during disassembly rather than a hardcoded value.

This takes the output of `spirv-opt --print-all -Os -o out.spv in.spv` from
```
; IR before pass wrap-opkill

; IR before pass eliminate-dead-branches

; IR before pass merge-return

; IR before pass inline-entry-points-exhaustive

```
to
```
error: line 143: Invalid opcode: 400
warning: line 0: Disassembly failed before pass wrap-opkill

error: line 143: Invalid opcode: 400
warning: line 0: Disassembly failed before pass eliminate-dead-branches

error: line 143: Invalid opcode: 400
warning: line 0: Disassembly failed before pass merge-return

error: line 143: Invalid opcode: 400
warning: line 0: Disassembly failed before pass inline-entry-points-exhaustive
```
and finally, to actually displaying the disassembly.