### PR TITLE
Linker improvements

### DIFF
--- a/source/link/linker.cpp
+++ b/source/link/linker.cpp
@@ -349,7 +349,7 @@ spv_result_t MergeModules(const MessageConsumer& consumer,
 
   // If the generated module uses SPIR-V 1.1 or higher, add an
   // OpModuleProcessed instruction about the linking step.
-  if (linked_module->version() >= 0x10100) {
+  if (linked_module->version() >= SPV_SPIRV_VERSION_WORD(1, 1)) {
     const std::string processed_string("Linked by SPIR-V Tools Linker");
     std::vector<uint32_t> processed_words =
         spvtools::utils::MakeVector(processed_string);

--- a/test/link/binary_version_test.cpp
+++ b/test/link/binary_version_test.cpp
@@ -47,14 +47,14 @@ spvtest::Binary CreateBinary(uint32_t version) {
 TEST_F(BinaryVersion, LinkerChoosesMaxSpirvVersion) {
   // clang-format off
   spvtest::Binaries binaries = {
-      CreateBinary(0x00010300u),
-      CreateBinary(0x00010500u),
-      CreateBinary(0x00010100u)
+      CreateBinary(SPV_SPIRV_VERSION_WORD(1, 3)),
+      CreateBinary(SPV_SPIRV_VERSION_WORD(1, 5)),
+      CreateBinary(SPV_SPIRV_VERSION_WORD(1, 1))
   };
   // clang-format on
   spvtest::Binary linked_binary;
   ASSERT_EQ(SPV_SUCCESS, Link(binaries, &linked_binary)) << GetErrorMessage();
-  EXPECT_EQ(0x00010500u, linked_binary[1]);
+  EXPECT_EQ(SPV_SPIRV_VERSION_WORD(1, 5), linked_binary[1]);
 }
 
 }  // namespace

--- a/test/link/binary_version_test.cpp
+++ b/test/link/binary_version_test.cpp
@@ -31,6 +31,15 @@ spvtest::Binary CreateBinary(uint32_t version) {
       SPV_GENERATOR_WORD(SPV_GENERATOR_KHRONOS, 0),
       1u,  // NOTE: Bound
       0u,  // NOTE: Schema; reserved
+
+      // OpCapability Shader
+      SpvOpCapability | 2u << SpvWordCountShift,
+      SpvCapabilityShader,
+
+      // OpMemoryModel Logical Simple
+      SpvOpMemoryModel | 3u << SpvWordCountShift,
+      SpvAddressingModelLogical,
+      SpvMemoryModelSimple
       // clang-format on
   };
 }

--- a/test/link/binary_version_test.cpp
+++ b/test/link/binary_version_test.cpp
@@ -22,37 +22,29 @@ namespace {
 
 using BinaryVersion = spvtest::LinkerTest;
 
+spvtest::Binary CreateBinary(uint32_t version) {
+  return {
+      // clang-format off
+      // Header
+      SpvMagicNumber,
+      version,
+      SPV_GENERATOR_WORD(SPV_GENERATOR_KHRONOS, 0),
+      1u,  // NOTE: Bound
+      0u,  // NOTE: Schema; reserved
+      // clang-format on
+  };
+}
+
 TEST_F(BinaryVersion, LinkerChoosesMaxSpirvVersion) {
   // clang-format off
   spvtest::Binaries binaries = {
-      {
-          SpvMagicNumber,
-          0x00010300u,
-          SPV_GENERATOR_CODEPLAY,
-          1u,  // NOTE: Bound
-          0u   // NOTE: Schema; reserved
-      },
-      {
-          SpvMagicNumber,
-          0x00010500u,
-          SPV_GENERATOR_CODEPLAY,
-          1u,  // NOTE: Bound
-          0u   // NOTE: Schema; reserved
-      },
-      {
-          SpvMagicNumber,
-          0x00010100u,
-          SPV_GENERATOR_CODEPLAY,
-          1u,  // NOTE: Bound
-          0u   // NOTE: Schema; reserved
-      }
+      CreateBinary(0x00010300u),
+      CreateBinary(0x00010500u),
+      CreateBinary(0x00010100u)
   };
   // clang-format on
   spvtest::Binary linked_binary;
-
-  ASSERT_EQ(SPV_SUCCESS, Link(binaries, &linked_binary));
-  EXPECT_THAT(GetErrorMessage(), std::string());
-
+  ASSERT_EQ(SPV_SUCCESS, Link(binaries, &linked_binary)) << GetErrorMessage();
   EXPECT_EQ(0x00010500u, linked_binary[1]);
 }
 

--- a/test/link/entry_points_test.cpp
+++ b/test/link/entry_points_test.cpp
@@ -41,7 +41,8 @@ OpFunctionEnd
 )";
 
   spvtest::Binary linked_binary;
-  EXPECT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary));
+  ASSERT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary))
+      << GetErrorMessage();
   EXPECT_THAT(GetErrorMessage(), std::string());
 }
 
@@ -62,7 +63,8 @@ OpFunctionEnd
 )";
 
   spvtest::Binary linked_binary;
-  EXPECT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary));
+  ASSERT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary))
+      << GetErrorMessage();
   EXPECT_THAT(GetErrorMessage(), std::string());
 }
 

--- a/test/link/entry_points_test.cpp
+++ b/test/link/entry_points_test.cpp
@@ -26,6 +26,8 @@ class EntryPoints : public spvtest::LinkerTest {};
 
 TEST_F(EntryPoints, SameModelDifferentName) {
   const std::string body1 = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %3 "foo"
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
@@ -33,6 +35,8 @@ OpEntryPoint GLCompute %3 "foo"
 OpFunctionEnd
 )";
   const std::string body2 = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %3 "bar"
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
@@ -48,6 +52,8 @@ OpFunctionEnd
 
 TEST_F(EntryPoints, DifferentModelSameName) {
   const std::string body1 = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %3 "foo"
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
@@ -55,6 +61,8 @@ OpEntryPoint GLCompute %3 "foo"
 OpFunctionEnd
 )";
   const std::string body2 = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
 OpEntryPoint Vertex %3 "foo"
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
@@ -70,6 +78,8 @@ OpFunctionEnd
 
 TEST_F(EntryPoints, SameModelAndName) {
   const std::string body1 = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %3 "foo"
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
@@ -77,6 +87,8 @@ OpEntryPoint GLCompute %3 "foo"
 OpFunctionEnd
 )";
   const std::string body2 = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %3 "foo"
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1

--- a/test/link/global_values_amount_test.cpp
+++ b/test/link/global_values_amount_test.cpp
@@ -111,9 +111,10 @@ TEST_F(EntryPointsAmountTest, OverLimit) {
 
   spvtest::Binary linked_binary;
   ASSERT_EQ(SPV_SUCCESS, Link(binaries, &linked_binary)) << GetErrorMessage();
-  EXPECT_THAT(GetErrorMessage(),
-              HasSubstr("The limit of global values, 65535, was exceeded; "
-                        "65536 global values were found."));
+  EXPECT_THAT(
+      GetErrorMessage(),
+      HasSubstr("The minimum limit of global values, 65535, was exceeded; "
+                "65536 global values were found."));
 }
 
 }  // namespace

--- a/test/link/global_values_amount_test.cpp
+++ b/test/link/global_values_amount_test.cpp
@@ -22,85 +22,49 @@ namespace {
 
 using ::testing::HasSubstr;
 
+const uint32_t binary_count = 2u;
+
 class EntryPointsAmountTest : public spvtest::LinkerTest {
  public:
-  EntryPointsAmountTest() { binaries.reserve(0xFFFF); }
+  EntryPointsAmountTest() { binaries.reserve(binary_count + 1u); }
 
   void SetUp() override {
-    binaries.push_back({SpvMagicNumber,
-                        SpvVersion,
-                        SPV_GENERATOR_CODEPLAY,
-                        10u,  // NOTE: Bound
-                        0u,   // NOTE: Schema; reserved
+    const uint32_t global_variable_count_per_binary =
+        (SPV_LIMIT_GLOBAL_VARIABLES_MAX - 1u) / binary_count;
 
-                        3u << SpvWordCountShift | SpvOpTypeFloat,
-                        1u,   // NOTE: Result ID
-                        32u,  // NOTE: Width
+    spvtest::Binary common_binary = {
+        // clang-format off
+        SpvMagicNumber,
+        SpvVersion,
+        SPV_GENERATOR_WORD(SPV_GENERATOR_KHRONOS, 0),
+        3u + global_variable_count_per_binary,  // NOTE: Bound
+        0u,                                     // NOTE: Schema; reserved
 
-                        4u << SpvWordCountShift | SpvOpTypePointer,
-                        2u,  // NOTE: Result ID
-                        SpvStorageClassInput,
-                        1u,  // NOTE: Type ID
+        SpvOpTypeFloat | 3u << SpvWordCountShift,
+        1u,   // NOTE: Result ID
+        32u,  // NOTE: Width
 
-                        2u << SpvWordCountShift | SpvOpTypeVoid,
-                        3u,  // NOTE: Result ID
+        SpvOpTypePointer | 4u << SpvWordCountShift,
+        2u,  // NOTE: Result ID
+        SpvStorageClassInput,
+        1u  // NOTE: Type ID
+        // clang-format on
+    };
 
-                        3u << SpvWordCountShift | SpvOpTypeFunction,
-                        4u,  // NOTE: Result ID
-                        3u,  // NOTE: Return type
+    binaries.push_back({});
+    spvtest::Binary& binary = binaries.back();
+    binary.reserve(common_binary.size() + global_variable_count_per_binary * 4);
+    binary.insert(binary.end(), common_binary.cbegin(), common_binary.cend());
 
-                        5u << SpvWordCountShift | SpvOpFunction,
-                        3u,  // NOTE: Result type
-                        5u,  // NOTE: Result ID
-                        SpvFunctionControlMaskNone,
-                        4u,  // NOTE: Function type
+    for (uint32_t i = 0u; i < global_variable_count_per_binary; ++i) {
+      binary.push_back(SpvOpVariable | 4u << SpvWordCountShift);
+      binary.push_back(2u);      // NOTE: Type ID
+      binary.push_back(3u + i);  // NOTE: Result ID
+      binary.push_back(SpvStorageClassInput);
+    }
 
-                        2u << SpvWordCountShift | SpvOpLabel,
-                        6u,  // NOTE: Result ID
-
-                        4u << SpvWordCountShift | SpvOpVariable,
-                        2u,  // NOTE: Type ID
-                        7u,  // NOTE: Result ID
-                        SpvStorageClassFunction,
-
-                        4u << SpvWordCountShift | SpvOpVariable,
-                        2u,  // NOTE: Type ID
-                        8u,  // NOTE: Result ID
-                        SpvStorageClassFunction,
-
-                        4u << SpvWordCountShift | SpvOpVariable,
-                        2u,  // NOTE: Type ID
-                        9u,  // NOTE: Result ID
-                        SpvStorageClassFunction,
-
-                        1u << SpvWordCountShift | SpvOpReturn,
-
-                        1u << SpvWordCountShift | SpvOpFunctionEnd});
-    for (size_t i = 0u; i < 2u; ++i) {
-      spvtest::Binary binary = {
-          SpvMagicNumber,
-          SpvVersion,
-          SPV_GENERATOR_CODEPLAY,
-          103u,  // NOTE: Bound
-          0u,    // NOTE: Schema; reserved
-
-          3u << SpvWordCountShift | SpvOpTypeFloat,
-          1u,   // NOTE: Result ID
-          32u,  // NOTE: Width
-
-          4u << SpvWordCountShift | SpvOpTypePointer,
-          2u,  // NOTE: Result ID
-          SpvStorageClassInput,
-          1u  // NOTE: Type ID
-      };
-
-      for (uint32_t j = 0u; j < 0xFFFFu / 2u; ++j) {
-        binary.push_back(4u << SpvWordCountShift | SpvOpVariable);
-        binary.push_back(2u);      // NOTE: Type ID
-        binary.push_back(j + 3u);  // NOTE: Result ID
-        binary.push_back(SpvStorageClassInput);
-      }
-      binaries.push_back(binary);
+    for (uint32_t i = 0u; i < binary_count - 1u; ++i) {
+      binaries.push_back(binaries.back());
     }
   }
   void TearDown() override { binaries.clear(); }
@@ -111,39 +75,42 @@ class EntryPointsAmountTest : public spvtest::LinkerTest {
 TEST_F(EntryPointsAmountTest, UnderLimit) {
   spvtest::Binary linked_binary;
 
-  EXPECT_EQ(SPV_SUCCESS, Link(binaries, &linked_binary));
+  ASSERT_EQ(SPV_SUCCESS, Link(binaries, &linked_binary)) << GetErrorMessage();
   EXPECT_THAT(GetErrorMessage(), std::string());
 }
 
 TEST_F(EntryPointsAmountTest, OverLimit) {
-  binaries.push_back({SpvMagicNumber,
-                      SpvVersion,
-                      SPV_GENERATOR_CODEPLAY,
-                      5u,  // NOTE: Bound
-                      0u,  // NOTE: Schema; reserved
+  binaries.push_back({
+      // clang-format off
+      SpvMagicNumber,
+      SpvVersion,
+      SPV_GENERATOR_WORD(SPV_GENERATOR_KHRONOS, 0),
+      5u,  // NOTE: Bound
+      0u,  // NOTE: Schema; reserved
 
-                      3u << SpvWordCountShift | SpvOpTypeFloat,
-                      1u,   // NOTE: Result ID
-                      32u,  // NOTE: Width
+      SpvOpTypeFloat | 3u << SpvWordCountShift,
+      1u,   // NOTE: Result ID
+      32u,  // NOTE: Width
 
-                      4u << SpvWordCountShift | SpvOpTypePointer,
-                      2u,  // NOTE: Result ID
-                      SpvStorageClassInput,
-                      1u,  // NOTE: Type ID
+      SpvOpTypePointer | 4u << SpvWordCountShift,
+      2u,  // NOTE: Result ID
+      SpvStorageClassInput,
+      1u,  // NOTE: Type ID
 
-                      4u << SpvWordCountShift | SpvOpVariable,
-                      2u,  // NOTE: Type ID
-                      3u,  // NOTE: Result ID
-                      SpvStorageClassInput,
+      SpvOpVariable | 4u << SpvWordCountShift,
+      2u,  // NOTE: Type ID
+      3u,  // NOTE: Result ID
+      SpvStorageClassInput,
 
-                      4u << SpvWordCountShift | SpvOpVariable,
-                      2u,  // NOTE: Type ID
-                      4u,  // NOTE: Result ID
-                      SpvStorageClassInput});
+      SpvOpVariable | 4u << SpvWordCountShift,
+      2u,  // NOTE: Type ID
+      4u,  // NOTE: Result ID
+      SpvStorageClassInput
+      // clang-format on
+  });
 
   spvtest::Binary linked_binary;
-
-  EXPECT_EQ(SPV_ERROR_INTERNAL, Link(binaries, &linked_binary));
+  ASSERT_EQ(SPV_SUCCESS, Link(binaries, &linked_binary)) << GetErrorMessage();
   EXPECT_THAT(GetErrorMessage(),
               HasSubstr("The limit of global values, 65535, was exceeded; "
                         "65536 global values were found."));

--- a/test/link/global_values_amount_test.cpp
+++ b/test/link/global_values_amount_test.cpp
@@ -40,6 +40,13 @@ class EntryPointsAmountTest : public spvtest::LinkerTest {
         3u + global_variable_count_per_binary,  // NOTE: Bound
         0u,                                     // NOTE: Schema; reserved
 
+        SpvOpCapability | 2u << SpvWordCountShift,
+        SpvCapabilityShader,
+
+        SpvOpMemoryModel | 3u << SpvWordCountShift,
+        SpvAddressingModelLogical,
+        SpvMemoryModelSimple,
+
         SpvOpTypeFloat | 3u << SpvWordCountShift,
         1u,   // NOTE: Result ID
         32u,  // NOTE: Width
@@ -87,6 +94,13 @@ TEST_F(EntryPointsAmountTest, OverLimit) {
       SPV_GENERATOR_WORD(SPV_GENERATOR_KHRONOS, 0),
       5u,  // NOTE: Bound
       0u,  // NOTE: Schema; reserved
+
+      SpvOpCapability | 2u << SpvWordCountShift,
+      SpvCapabilityShader,
+
+      SpvOpMemoryModel | 3u << SpvWordCountShift,
+      SpvAddressingModelLogical,
+      SpvMemoryModelSimple,
 
       SpvOpTypeFloat | 3u << SpvWordCountShift,
       1u,   // NOTE: Result ID

--- a/test/link/ids_limit_test.cpp
+++ b/test/link/ids_limit_test.cpp
@@ -52,10 +52,25 @@ TEST_F(IdsLimit, OverLimit) {
 
   spvtest::Binary linked_binary;
 
-  EXPECT_EQ(SPV_ERROR_INVALID_ID, Link(binaries, &linked_binary));
-  EXPECT_THAT(GetErrorMessage(),
-              HasSubstr("The limit of IDs, 4194303, was exceeded: 4194304 is "
-                        "the current ID bound."));
+  ASSERT_EQ(SPV_SUCCESS, Link(binaries, &linked_binary)) << GetErrorMessage();
+  EXPECT_THAT(
+      GetErrorMessage(),
+      HasSubstr("The minimum limit of IDs, 4194303, was exceeded: 4194304 is "
+                "the current ID bound."));
+  EXPECT_EQ(0x400000u, linked_binary[3]);
+}
+
+TEST_F(IdsLimit, Overflow) {
+  spvtest::Binaries binaries = {CreateBinary(0xFFFFFFFFu),
+                                CreateBinary(0x00000002u)};
+
+  spvtest::Binary linked_binary;
+
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, Link(binaries, &linked_binary));
+  EXPECT_THAT(
+      GetErrorMessage(),
+      HasSubstr("Too many IDs (4294967296): combining all modules would "
+                "overflow the 32-bit word of the SPIR-V header."));
 }
 
 }  // namespace

--- a/test/link/matching_imports_to_exports_test.cpp
+++ b/test/link/matching_imports_to_exports_test.cpp
@@ -40,7 +40,7 @@ OpDecorate %1 LinkageAttributes "foo" Export
 )";
 
   spvtest::Binary linked_binary;
-  EXPECT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary))
+  ASSERT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary))
       << GetErrorMessage();
 
   const std::string expected_res =
@@ -52,7 +52,7 @@ OpDecorate %1 LinkageAttributes "foo" Export
 )";
   std::string res_body;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  EXPECT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
+  ASSERT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
       << GetErrorMessage();
   EXPECT_EQ(expected_res, res_body);
 }
@@ -66,7 +66,7 @@ OpDecorate %1 LinkageAttributes "foo" Export
 )";
 
   spvtest::Binary linked_binary;
-  EXPECT_EQ(SPV_SUCCESS, AssembleAndLink({body}, &linked_binary))
+  ASSERT_EQ(SPV_SUCCESS, AssembleAndLink({body}, &linked_binary))
       << GetErrorMessage();
 
   const std::string expected_res =
@@ -76,7 +76,7 @@ OpDecorate %1 LinkageAttributes "foo" Export
 )";
   std::string res_body;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  EXPECT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
+  ASSERT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
       << GetErrorMessage();
   EXPECT_EQ(expected_res, res_body);
 }
@@ -92,7 +92,7 @@ OpDecorate %1 LinkageAttributes "foo" Export
   spvtest::Binary linked_binary;
   LinkerOptions options;
   options.SetCreateLibrary(true);
-  EXPECT_EQ(SPV_SUCCESS, AssembleAndLink({body}, &linked_binary, options))
+  ASSERT_EQ(SPV_SUCCESS, AssembleAndLink({body}, &linked_binary, options))
       << GetErrorMessage();
 
   const std::string expected_res = R"(OpCapability Linkage
@@ -103,7 +103,7 @@ OpDecorate %1 LinkageAttributes "foo" Export
 )";
   std::string res_body;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  EXPECT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
+  ASSERT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
       << GetErrorMessage();
   EXPECT_EQ(expected_res, res_body);
 }
@@ -271,7 +271,7 @@ OpFunctionEnd
 )";
 
   spvtest::Binary linked_binary;
-  EXPECT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary))
+  ASSERT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary))
       << GetErrorMessage();
 
   const std::string expected_res = R"(OpCapability Kernel
@@ -288,7 +288,7 @@ OpFunctionEnd
 )";
   std::string res_body;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  EXPECT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
+  ASSERT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
       << GetErrorMessage();
   EXPECT_EQ(expected_res, res_body);
 }
@@ -316,7 +316,7 @@ OpFunctionEnd
 )";
 
   spvtest::Binary linked_binary;
-  EXPECT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary))
+  ASSERT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary))
       << GetErrorMessage();
 
   const std::string expected_res =
@@ -332,7 +332,7 @@ OpFunctionEnd
 )";
   std::string res_body;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  EXPECT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
+  ASSERT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
       << GetErrorMessage();
   EXPECT_EQ(expected_res, res_body);
 }
@@ -371,7 +371,7 @@ OpFunctionEnd
 )";
 
   spvtest::Binary linked_binary;
-  EXPECT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary))
+  ASSERT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary))
       << GetErrorMessage();
 
   const std::string expected_res = R"(OpCapability Kernel
@@ -394,7 +394,7 @@ OpFunctionEnd
 )";
   std::string res_body;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  EXPECT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
+  ASSERT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
       << GetErrorMessage();
   EXPECT_EQ(expected_res, res_body);
 }
@@ -440,7 +440,7 @@ OpFunctionEnd
 )";
 
   spvtest::Binary linked_binary;
-  EXPECT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary))
+  ASSERT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary))
       << GetErrorMessage();
 
   const std::string expected_res = R"(OpCapability Kernel
@@ -467,7 +467,7 @@ OpFunctionEnd
 )";
   std::string res_body;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
-  EXPECT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
+  ASSERT_EQ(SPV_SUCCESS, Disassemble(linked_binary, &res_body))
       << GetErrorMessage();
   EXPECT_EQ(expected_res, res_body);
 }

--- a/test/link/matching_imports_to_exports_test.cpp
+++ b/test/link/matching_imports_to_exports_test.cpp
@@ -26,6 +26,9 @@ using MatchingImportsToExports = spvtest::LinkerTest;
 TEST_F(MatchingImportsToExports, Default) {
   const std::string body1 = R"(
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Import
 %2 = OpTypeFloat 32
 %1 = OpVariable %2 Uniform
@@ -33,6 +36,9 @@ OpDecorate %1 LinkageAttributes "foo" Import
 )";
   const std::string body2 = R"(
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Export
 %2 = OpTypeFloat 32
 %3 = OpConstant %2 42
@@ -44,7 +50,10 @@ OpDecorate %1 LinkageAttributes "foo" Export
       << GetErrorMessage();
 
   const std::string expected_res =
-      R"(OpModuleProcessed "Linked by SPIR-V Tools Linker"
+      R"(OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
+OpModuleProcessed "Linked by SPIR-V Tools Linker"
 %1 = OpTypeFloat 32
 %2 = OpVariable %1 Input
 %3 = OpConstant %1 42
@@ -60,6 +69,9 @@ OpDecorate %1 LinkageAttributes "foo" Export
 TEST_F(MatchingImportsToExports, NotALibraryExtraExports) {
   const std::string body = R"(
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Export
 %2 = OpTypeFloat 32
 %1 = OpVariable %2 Uniform
@@ -70,7 +82,10 @@ OpDecorate %1 LinkageAttributes "foo" Export
       << GetErrorMessage();
 
   const std::string expected_res =
-      R"(OpModuleProcessed "Linked by SPIR-V Tools Linker"
+      R"(OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
+OpModuleProcessed "Linked by SPIR-V Tools Linker"
 %1 = OpTypeFloat 32
 %2 = OpVariable %1 Uniform
 )";
@@ -84,6 +99,9 @@ OpDecorate %1 LinkageAttributes "foo" Export
 TEST_F(MatchingImportsToExports, LibraryExtraExports) {
   const std::string body = R"(
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Export
 %2 = OpTypeFloat 32
 %1 = OpVariable %2 Uniform
@@ -96,6 +114,9 @@ OpDecorate %1 LinkageAttributes "foo" Export
       << GetErrorMessage();
 
   const std::string expected_res = R"(OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpModuleProcessed "Linked by SPIR-V Tools Linker"
 OpDecorate %1 LinkageAttributes "foo" Export
 %2 = OpTypeFloat 32
@@ -111,11 +132,18 @@ OpDecorate %1 LinkageAttributes "foo" Export
 TEST_F(MatchingImportsToExports, UnresolvedImports) {
   const std::string body1 = R"(
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Import
 %2 = OpTypeFloat 32
 %1 = OpVariable %2 Uniform
 )";
-  const std::string body2 = R"()";
+  const std::string body2 = R"(
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
+)";
 
   spvtest::Binary linked_binary;
   EXPECT_EQ(SPV_ERROR_INVALID_BINARY,
@@ -127,6 +155,9 @@ OpDecorate %1 LinkageAttributes "foo" Import
 TEST_F(MatchingImportsToExports, TypeMismatch) {
   const std::string body1 = R"(
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Import
 %2 = OpTypeFloat 32
 %1 = OpVariable %2 Uniform
@@ -134,6 +165,9 @@ OpDecorate %1 LinkageAttributes "foo" Import
 )";
   const std::string body2 = R"(
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Export
 %2 = OpTypeInt 32 0
 %3 = OpConstant %2 42
@@ -153,6 +187,9 @@ OpDecorate %1 LinkageAttributes "foo" Export
 TEST_F(MatchingImportsToExports, MultipleDefinitions) {
   const std::string body1 = R"(
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Import
 %2 = OpTypeFloat 32
 %1 = OpVariable %2 Uniform
@@ -160,6 +197,9 @@ OpDecorate %1 LinkageAttributes "foo" Import
 )";
   const std::string body2 = R"(
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Export
 %2 = OpTypeFloat 32
 %3 = OpConstant %2 42
@@ -167,6 +207,9 @@ OpDecorate %1 LinkageAttributes "foo" Export
 )";
   const std::string body3 = R"(
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Export
 %2 = OpTypeFloat 32
 %3 = OpConstant %2 -1
@@ -185,6 +228,9 @@ OpDecorate %1 LinkageAttributes "foo" Export
 TEST_F(MatchingImportsToExports, SameNameDifferentTypes) {
   const std::string body1 = R"(
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Import
 %2 = OpTypeFloat 32
 %1 = OpVariable %2 Uniform
@@ -192,6 +238,9 @@ OpDecorate %1 LinkageAttributes "foo" Import
 )";
   const std::string body2 = R"(
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Export
 %2 = OpTypeInt 32 0
 %3 = OpConstant %2 42
@@ -199,6 +248,9 @@ OpDecorate %1 LinkageAttributes "foo" Export
 )";
   const std::string body3 = R"(
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Export
 %2 = OpTypeFloat 32
 %3 = OpConstant %2 12
@@ -217,6 +269,9 @@ OpDecorate %1 LinkageAttributes "foo" Export
 TEST_F(MatchingImportsToExports, DecorationMismatch) {
   const std::string body1 = R"(
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Import
 OpDecorate %2 Constant
 %2 = OpTypeFloat 32
@@ -225,6 +280,9 @@ OpDecorate %2 Constant
 )";
   const std::string body2 = R"(
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Export
 %2 = OpTypeFloat 32
 %3 = OpConstant %2 42
@@ -244,8 +302,10 @@ OpDecorate %1 LinkageAttributes "foo" Export
 TEST_F(MatchingImportsToExports,
        FuncParamAttrDifferButStillMatchExportToImport) {
   const std::string body1 = R"(
-OpCapability Kernel
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Import
 OpDecorate %2 FuncParamAttr Zext
 %3 = OpTypeVoid
@@ -256,8 +316,10 @@ OpDecorate %2 FuncParamAttr Zext
 OpFunctionEnd
 )";
   const std::string body2 = R"(
-OpCapability Kernel
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Export
 OpDecorate %2 FuncParamAttr Sext
 %3 = OpTypeVoid
@@ -274,7 +336,9 @@ OpFunctionEnd
   ASSERT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary))
       << GetErrorMessage();
 
-  const std::string expected_res = R"(OpCapability Kernel
+  const std::string expected_res = R"(OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpModuleProcessed "Linked by SPIR-V Tools Linker"
 OpDecorate %1 FuncParamAttr Sext
 %2 = OpTypeVoid
@@ -296,6 +360,9 @@ OpFunctionEnd
 TEST_F(MatchingImportsToExports, FunctionCtrl) {
   const std::string body1 = R"(
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Import
 %2 = OpTypeVoid
 %3 = OpTypeFunction %2
@@ -306,6 +373,9 @@ OpFunctionEnd
 )";
   const std::string body2 = R"(
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Export
 %2 = OpTypeVoid
 %3 = OpTypeFunction %2
@@ -320,7 +390,10 @@ OpFunctionEnd
       << GetErrorMessage();
 
   const std::string expected_res =
-      R"(OpModuleProcessed "Linked by SPIR-V Tools Linker"
+      R"(OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
+OpModuleProcessed "Linked by SPIR-V Tools Linker"
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
 %3 = OpTypeFloat 32
@@ -339,8 +412,10 @@ OpFunctionEnd
 
 TEST_F(MatchingImportsToExports, UseExportedFuncParamAttr) {
   const std::string body1 = R"(
-OpCapability Kernel
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Import
 OpDecorate %2 FuncParamAttr Zext
 %2 = OpDecorationGroup
@@ -356,8 +431,10 @@ OpFunctionEnd
 OpFunctionEnd
 )";
   const std::string body2 = R"(
-OpCapability Kernel
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Export
 OpDecorate %2 FuncParamAttr Sext
 %3 = OpTypeVoid
@@ -374,7 +451,9 @@ OpFunctionEnd
   ASSERT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary))
       << GetErrorMessage();
 
-  const std::string expected_res = R"(OpCapability Kernel
+  const std::string expected_res = R"(OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpModuleProcessed "Linked by SPIR-V Tools Linker"
 OpDecorate %1 FuncParamAttr Zext
 %1 = OpDecorationGroup
@@ -401,8 +480,10 @@ OpFunctionEnd
 
 TEST_F(MatchingImportsToExports, NamesAndDecorations) {
   const std::string body1 = R"(
-OpCapability Kernel
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpName %1 "foo"
 OpName %3 "param"
 OpDecorate %1 LinkageAttributes "foo" Import
@@ -422,8 +503,10 @@ OpFunctionEnd
 OpFunctionEnd
 )";
   const std::string body2 = R"(
-OpCapability Kernel
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpName %1 "foo"
 OpName %2 "param"
 OpDecorate %1 LinkageAttributes "foo" Export
@@ -443,7 +526,9 @@ OpFunctionEnd
   ASSERT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary))
       << GetErrorMessage();
 
-  const std::string expected_res = R"(OpCapability Kernel
+  const std::string expected_res = R"(OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpName %1 "foo"
 OpName %2 "param"
 OpModuleProcessed "Linked by SPIR-V Tools Linker"

--- a/test/link/memory_model_test.cpp
+++ b/test/link/memory_model_test.cpp
@@ -50,9 +50,9 @@ OpMemoryModel Physical32 Simple
   spvtest::Binary linked_binary;
   EXPECT_EQ(SPV_ERROR_INTERNAL,
             AssembleAndLink({body1, body2}, &linked_binary));
-  EXPECT_THAT(
-      GetErrorMessage(),
-      HasSubstr("Conflicting addressing models: Logical vs Physical32."));
+  EXPECT_THAT(GetErrorMessage(),
+              HasSubstr("Conflicting addressing models: Logical (input modules "
+                        "1 through 1) vs Physical32 (input module 2)."));
 }
 
 TEST_F(MemoryModel, MemoryMismatch) {
@@ -67,7 +67,38 @@ OpMemoryModel Logical GLSL450
   EXPECT_EQ(SPV_ERROR_INTERNAL,
             AssembleAndLink({body1, body2}, &linked_binary));
   EXPECT_THAT(GetErrorMessage(),
-              HasSubstr("Conflicting memory models: Simple vs GLSL450."));
+              HasSubstr("Conflicting memory models: Simple (input modules 1 "
+                        "through 1) vs GLSL450 (input module 2)."));
+}
+
+TEST_F(MemoryModel, FirstLackMemoryModel) {
+  const std::string body1 = R"(
+)";
+  const std::string body2 = R"(
+OpMemoryModel Logical GLSL450
+)";
+
+  spvtest::Binary linked_binary;
+  EXPECT_EQ(SPV_ERROR_INVALID_BINARY,
+            AssembleAndLink({body1, body2}, &linked_binary));
+  EXPECT_THAT(
+      GetErrorMessage(),
+      HasSubstr("Input module 1 is lacking an OpMemoryModel instruction."));
+}
+
+TEST_F(MemoryModel, SecondLackMemoryModel) {
+  const std::string body1 = R"(
+OpMemoryModel Logical GLSL450
+)";
+  const std::string body2 = R"(
+)";
+
+  spvtest::Binary linked_binary;
+  EXPECT_EQ(SPV_ERROR_INVALID_BINARY,
+            AssembleAndLink({body1, body2}, &linked_binary));
+  EXPECT_THAT(
+      GetErrorMessage(),
+      HasSubstr("Input module 2 is lacking an OpMemoryModel instruction."));
 }
 
 }  // namespace

--- a/test/link/partial_linkage_test.cpp
+++ b/test/link/partial_linkage_test.cpp
@@ -44,7 +44,8 @@ OpDecorate %1 LinkageAttributes "bar" Export
   LinkerOptions linker_options;
   linker_options.SetAllowPartialLinkage(true);
   ASSERT_EQ(SPV_SUCCESS,
-            AssembleAndLink({body1, body2}, &linked_binary, linker_options));
+            AssembleAndLink({body1, body2}, &linked_binary, linker_options))
+      << GetErrorMessage();
 
   const std::string expected_res = R"(OpCapability Linkage
 OpModuleProcessed "Linked by SPIR-V Tools Linker"

--- a/test/link/partial_linkage_test.cpp
+++ b/test/link/partial_linkage_test.cpp
@@ -26,6 +26,9 @@ using PartialLinkage = spvtest::LinkerTest;
 TEST_F(PartialLinkage, Allowed) {
   const std::string body1 = R"(
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Import
 OpDecorate %2 LinkageAttributes "bar" Import
 %3 = OpTypeFloat 32
@@ -34,6 +37,9 @@ OpDecorate %2 LinkageAttributes "bar" Import
 )";
   const std::string body2 = R"(
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "bar" Export
 %2 = OpTypeFloat 32
 %3 = OpConstant %2 3.1415
@@ -48,6 +54,9 @@ OpDecorate %1 LinkageAttributes "bar" Export
       << GetErrorMessage();
 
   const std::string expected_res = R"(OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpModuleProcessed "Linked by SPIR-V Tools Linker"
 OpDecorate %1 LinkageAttributes "foo" Import
 %2 = OpTypeFloat 32
@@ -65,6 +74,9 @@ OpDecorate %1 LinkageAttributes "foo" Import
 TEST_F(PartialLinkage, Disallowed) {
   const std::string body1 = R"(
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "foo" Import
 OpDecorate %2 LinkageAttributes "bar" Import
 %3 = OpTypeFloat 32
@@ -73,6 +85,9 @@ OpDecorate %2 LinkageAttributes "bar" Import
 )";
   const std::string body2 = R"(
 OpCapability Linkage
+OpCapability Addresses
+OpCapability Kernel
+OpMemoryModel Physical64 OpenCL
 OpDecorate %1 LinkageAttributes "bar" Export
 %2 = OpTypeFloat 32
 %3 = OpConstant %2 3.1415

--- a/test/link/type_match_test.cpp
+++ b/test/link/type_match_test.cpp
@@ -66,6 +66,7 @@ using TypeMatch = spvtest::LinkerTest;
         "OpCapability Kernel\n"                                 \
         "OpCapability Shader\n"                                 \
         "OpCapability Addresses\n"                              \
+        "OpMemoryModel Physical64 OpenCL\n"                     \
         "OpDecorate %var LinkageAttributes \"foo\" "            \
         "{Import,Export}\n"                                     \
         "; CHECK: [[baseint:%\\w+]] = OpTypeInt 32 1\n"         \

--- a/test/link/unique_ids_test.cpp
+++ b/test/link/unique_ids_test.cpp
@@ -135,7 +135,8 @@ TEST_F(UniqueIds, UniquelyMerged) {
   LinkerOptions options;
   options.SetVerifyIds(true);
   spv_result_t res = AssembleAndLink(bodies, &linked_binary, options);
-  EXPECT_EQ(SPV_SUCCESS, res);
+  ASSERT_EQ(SPV_SUCCESS, res) << GetErrorMessage();
+  EXPECT_THAT(GetErrorMessage(), std::string());
 }
 
 }  // namespace

--- a/tools/link/linker.cpp
+++ b/tools/link/linker.cpp
@@ -49,7 +49,7 @@ Options (in lexicographical order):
   --create-library
                Link the binaries into a library, keeping all exported symbols.
   -h, --help
-                  Print this help.
+               Print this help.
   --target-env <env>
                Set the target environment. Without this flag the target
                environment defaults to spv1.5. <env> must be one of
@@ -57,7 +57,7 @@ Options (in lexicographical order):
   --verify-ids
                Verify that IDs in the resulting modules are truly unique.
   --version
-               Display linker version information
+               Display linker version information.
 )",
       program, program, target_env_list.c_str());
 }

--- a/tools/link/linker.cpp
+++ b/tools/link/linker.cpp
@@ -51,9 +51,12 @@ Options (in lexicographical order):
   -h, --help
                Print this help.
   --target-env <env>
-               Set the target environment. Without this flag the target
-               environment defaults to spv1.5. <env> must be one of
-               {%s}
+               Set the environment used for interpreting the inputs. Without
+               this option the environment defaults to spv1.6. <env> must be
+               one of {%s}.
+               NOTE: The SPIR-V version used by the linked binary module
+               depends only on the version of the inputs, and is not affected
+               by this option.
   --verify-ids
                Verify that IDs in the resulting modules are truly unique.
   --version

--- a/tools/link/linker.cpp
+++ b/tools/link/linker.cpp
@@ -160,10 +160,11 @@ int main(int argc, char** argv) {
 
   std::vector<uint32_t> linkingResult;
   spv_result_t status = Link(context, contents, &linkingResult, options);
+  if (status != SPV_SUCCESS && status != SPV_WARNING) return 1;
 
   if (!WriteFile<uint32_t>(outFile, "wb", linkingResult.data(),
                            linkingResult.size()))
     return 1;
 
-  return status == SPV_SUCCESS ? 0 : 1;
+  return 0;
 }


### PR DESCRIPTION
# Breaking changes

* Require a memory model in each input module.
* Error out when merging input modules using different SPIR-V versions, whereas before the linker would allow that scenario and use the highest version for the linked module.  (#4135)

# Non-breaking behaviour changes

* Replace an error with a warning when going universal limits, as some implementations might accept higher limits.
* Only check for universal limits right before emitting the linked binary as, for example, passes like type de-duplication might reduce the amount of IDs present.

# Improvements and bug fixes

* The tests benefited from some code factorisation and tweaks regarding what was considered as `EXPECT_*` versus `ASSERT_*`.
* Avoid having the ID count overflow when merging binaries.
* Use existing macros instead of hardcoded values.
* In spirv-link, do not write to disk if linking failed.
* Improve the help message of spirv-link. (#4135)