### PR TITLE
Fix various source comment (doxygen) typos

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -560,7 +560,7 @@ SPIRV_TOOLS_EXPORT bool spvParseVulkanEnv(uint32_t vulkan_ver,
 // Creates a context object for most of the SPIRV-Tools API.
 // Returns null if env is invalid.
 //
-// See specific API calls for how the target environment is interpeted
+// See specific API calls for how the target environment is interpreted
 // (particularly assembly and validation).
 SPIRV_TOOLS_EXPORT spv_context spvContextCreate(spv_target_env env);
 
@@ -612,7 +612,7 @@ SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetRelaxLogicalPointer(
 //    set that option.
 // 2) Pointers that are pass as parameters to function calls do not have to
 //    match the storage class of the formal parameter.
-// 3) Pointers that are actaul parameters on function calls do not have to point
+// 3) Pointers that are actual parameters on function calls do not have to point
 //    to the same type pointed as the formal parameter.  The types just need to
 //    logically match.
 // 4) GLSLstd450 Interpolate* instructions can have a load of an interpolant
@@ -638,7 +638,7 @@ SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetUniformBufferStandardLayout(
 // Records whether the validator should use "scalar" block layout rules.
 // Scalar layout rules are more permissive than relaxed block layout.
 //
-// See Vulkan extnesion VK_EXT_scalar_block_layout.  The scalar alignment is
+// See Vulkan extension VK_EXT_scalar_block_layout.  The scalar alignment is
 // defined as follows:
 // - scalar alignment of a scalar is the scalar size
 // - scalar alignment of a vector is the scalar alignment of its component

--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -36,7 +36,7 @@ class Context {
  public:
   // Constructs a context targeting the given environment |env|.
   //
-  // See specific API calls for how the target environment is interpeted
+  // See specific API calls for how the target environment is interpreted
   // (particularly assembly and validation).
   //
   // The constructed instance will have an empty message consumer, which just
@@ -139,7 +139,7 @@ class ValidatorOptions {
   //    set that option.
   // 2) Pointers that are pass as parameters to function calls do not have to
   //    match the storage class of the formal parameter.
-  // 3) Pointers that are actaul parameters on function calls do not have to
+  // 3) Pointers that are actual parameters on function calls do not have to
   //    point to the same type pointed as the formal parameter.  The types just
   //    need to logically match.
   // 4) GLSLstd450 Interpolate* instructions can have a load of an interpolant

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -296,11 +296,11 @@ Optimizer::PassToken CreateFreezeSpecConstantValuePass();
 // and can be changed in future. A spec constant is foldable if all of its
 // value(s) can be determined from the module. E.g., an integer spec constant
 // defined with OpSpecConstantOp instruction can be folded if its value won't
-// change later. This pass will replace the original OpSpecConstantOp instruction
-// with an OpConstant instruction. When folding composite spec constants,
-// new instructions may be inserted to define the components of the composite
-// constant first, then the original spec constants will be replaced by
-// OpConstantComposite instructions.
+// change later. This pass will replace the original OpSpecConstantOp
+// instruction with an OpConstant instruction. When folding composite spec
+// constants, new instructions may be inserted to define the components of the
+// composite constant first, then the original spec constants will be replaced
+// by OpConstantComposite instructions.
 //
 // There are some operations not supported yet:
 //   OpSConvert, OpFConvert, OpQuantizeToF16 and

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -43,7 +43,7 @@ class Optimizer {
   // consumed by the RegisterPass() method. Tokens are one-time objects that
   // only support move; copying is not allowed.
   struct PassToken {
-    struct Impl;  // Opaque struct for holding inernal data.
+    struct Impl;  // Opaque struct for holding internal data.
 
     PassToken(std::unique_ptr<Impl>);
 
@@ -296,7 +296,7 @@ Optimizer::PassToken CreateFreezeSpecConstantValuePass();
 // and can be changed in future. A spec constant is foldable if all of its
 // value(s) can be determined from the module. E.g., an integer spec constant
 // defined with OpSpecConstantOp instruction can be folded if its value won't
-// change later. This pass will replace the original OpSpecContantOp instruction
+// change later. This pass will replace the original OpSpecConstantOp instruction
 // with an OpConstant instruction. When folding composite spec constants,
 // new instructions may be inserted to define the components of the composite
 // constant first, then the original spec constants will be replaced by
@@ -326,7 +326,7 @@ Optimizer::PassToken CreateUnifyConstantPass();
 
 // Creates a eliminate-dead-constant pass.
 // A eliminate-dead-constant pass removes dead constants, including normal
-// contants defined by OpConstant, OpConstantComposite, OpConstantTrue, or
+// constants defined by OpConstant, OpConstantComposite, OpConstantTrue, or
 // OpConstantFalse and spec constants defined by OpSpecConstant,
 // OpSpecConstantComposite, OpSpecConstantTrue, OpSpecConstantFalse or
 // OpSpecConstantOp.
@@ -390,7 +390,7 @@ Optimizer::PassToken CreateInlineOpaquePass();
 // Only modules with relaxed logical addressing (see opt/instruction.h) are
 // currently processed.
 //
-// This pass is most effective if preceeded by Inlining and
+// This pass is most effective if preceded by Inlining and
 // LocalAccessChainConvert. This pass will reduce the work needed to be done
 // by LocalSingleStoreElim and LocalMultiStoreElim.
 //
@@ -408,7 +408,7 @@ Optimizer::PassToken CreateLocalSingleBlockLoadStoreElimPass();
 // Note that some branches and blocks may be left to avoid creating invalid
 // control flow. Improving this is left to future work.
 //
-// This pass is most effective when preceeded by passes which eliminate
+// This pass is most effective when preceded by passes which eliminate
 // local loads and stores, effectively propagating constant values where
 // possible.
 Optimizer::PassToken CreateDeadBranchElimPass();
@@ -425,7 +425,7 @@ Optimizer::PassToken CreateDeadBranchElimPass();
 // are currently processed. Currently modules with any extensions enabled are
 // not processed. This is left for future work.
 //
-// This pass is most effective if preceeded by Inlining and
+// This pass is most effective if preceded by Inlining and
 // LocalAccessChainConvert. LocalSingleStoreElim and LocalSingleBlockElim
 // will reduce the work that this pass has to do.
 Optimizer::PassToken CreateLocalMultiStoreElimPass();
@@ -630,7 +630,7 @@ Optimizer::PassToken CreateRedundancyEliminationPass();
 Optimizer::PassToken CreateScalarReplacementPass(uint32_t size_limit = 100);
 
 // Create a private to local pass.
-// This pass looks for variables delcared in the private storage class that are
+// This pass looks for variables declared in the private storage class that are
 // used in only one function.  Those variables are moved to the function storage
 // class in the function that they are used.
 Optimizer::PassToken CreatePrivateToLocalPass();

--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -215,7 +215,7 @@ class Parser {
     size_t word_index;           // The current position in words.
     size_t instruction_count;    // The count of processed instructions
     spv_endianness_t endian;     // The endianness of the binary.
-    // Is the SPIR-V binary in a different endiannes from the host native
+    // Is the SPIR-V binary in a different endianness from the host native
     // endianness?
     bool requires_endian_conversion;
 

--- a/source/ext_inst.h
+++ b/source/ext_inst.h
@@ -27,7 +27,7 @@ bool spvExtInstIsNonSemantic(const spv_ext_inst_type_t type);
 // Returns true if the extended instruction set is debug info
 bool spvExtInstIsDebugInfo(const spv_ext_inst_type_t type);
 
-// Finds the named extented instruction of the given type in the given extended
+// Finds the named extended instruction of the given type in the given extended
 // instruction table. On success, returns SPV_SUCCESS and writes a handle of
 // the instruction entry into *entry.
 spv_result_t spvExtInstTableNameLookup(const spv_ext_inst_table table,
@@ -35,7 +35,7 @@ spv_result_t spvExtInstTableNameLookup(const spv_ext_inst_table table,
                                        const char* name,
                                        spv_ext_inst_desc* entry);
 
-// Finds the extented instruction of the given type in the given extended
+// Finds the extended instruction of the given type in the given extended
 // instruction table by value. On success, returns SPV_SUCCESS and writes a
 // handle of the instruction entry into *entry.
 spv_result_t spvExtInstTableValueLookup(const spv_ext_inst_table table,

--- a/source/fuzz/fact_manager/fact_manager.h
+++ b/source/fuzz/fact_manager/fact_manager.h
@@ -163,7 +163,7 @@ class FactManager {
   std::vector<const protobufs::DataDescriptor*> GetSynonymsForDataDescriptor(
       const protobufs::DataDescriptor& data_descriptor) const;
 
-  // Returns true if and ony if |data_descriptor1| and |data_descriptor2| are
+  // Returns true if and only if |data_descriptor1| and |data_descriptor2| are
   // known to be synonymous.
   bool IsSynonymous(const protobufs::DataDescriptor& data_descriptor1,
                     const protobufs::DataDescriptor& data_descriptor2) const;
@@ -174,7 +174,7 @@ class FactManager {
   //==============================
   // Querying facts about dead blocks
 
-  // Returns true if and ony if |block_id| is the id of a block known to be
+  // Returns true if and only if |block_id| is the id of a block known to be
   // dynamically unreachable.
   bool BlockIsDead(uint32_t block_id) const;
 
@@ -184,7 +184,7 @@ class FactManager {
   //==============================
   // Querying facts about livesafe function
 
-  // Returns true if and ony if |function_id| is the id of a function known
+  // Returns true if and only if |function_id| is the id of a function known
   // to be livesafe.
   bool FunctionIsLivesafe(uint32_t function_id) const;
 
@@ -194,7 +194,7 @@ class FactManager {
   //==============================
   // Querying facts about irrelevant values
 
-  // Returns true if and ony if the value of the pointee associated with
+  // Returns true if and only if the value of the pointee associated with
   // |pointer_id| is irrelevant.
   bool PointeeValueIsIrrelevant(uint32_t pointer_id) const;
 

--- a/source/fuzz/fuzzer_pass.cpp
+++ b/source/fuzz/fuzzer_pass.cpp
@@ -261,7 +261,7 @@ uint32_t FuzzerPass::FindOrCreateFloatType(uint32_t width) {
 
 uint32_t FuzzerPass::FindOrCreateFunctionType(
     uint32_t return_type_id, const std::vector<uint32_t>& argument_id) {
-  // FindFunctionType has a sigle argument for OpTypeFunction operands
+  // FindFunctionType has a single argument for OpTypeFunction operands
   // so we will have to copy them all in this vector
   std::vector<uint32_t> type_ids(argument_id.size() + 1);
   type_ids[0] = return_type_id;

--- a/source/fuzz/fuzzer_pass_donate_modules.cpp
+++ b/source/fuzz/fuzzer_pass_donate_modules.cpp
@@ -479,7 +479,7 @@ void FuzzerPassDonateModules::HandleTypeOrValue(
              "should have been donated.");
 
       // It is OK to have duplicate constant composite definitions, so add
-      // this to the module using remapped versions of all consituent ids and
+      // this to the module using remapped versions of all constituent ids and
       // the result type.
       new_result_id = GetFuzzerContext()->GetFreshId();
       std::vector<uint32_t> constituent_ids;

--- a/source/fuzz/protobufs/spvtoolsfuzz.proto
+++ b/source/fuzz/protobufs/spvtoolsfuzz.proto
@@ -1961,10 +1961,10 @@ message TransformationReplaceBooleanConstantWithConstantBinary {
   // A descriptor for the boolean constant id we would like to replace
   IdUseDescriptor id_use_descriptor = 1;
 
-  // Id for the constant to be used on the LHS of the comparision
+  // Id for the constant to be used on the LHS of the comparison
   uint32 lhs_id = 2;
 
-  // Id for the constant to be used on the RHS of the comparision
+  // Id for the constant to be used on the RHS of the comparison
   uint32 rhs_id = 3;
 
   // Opcode for binary operator
@@ -2403,7 +2403,7 @@ message TransformationWrapVectorSynonym {
   // va = vector(..., a, ...)
   // vb = vector(..., b, ...)
   //
-  // where a and b are in the same position i in each of their correponding vector
+  // where a and b are in the same position i in each of their corresponding vector
   // and a is synonymous with va[i] and b is synonymous with vb[i].
   //
   // The transformation then add an instruction vc = va op vb where c is synonymous

--- a/source/fuzz/transformation_add_constant_composite.cpp
+++ b/source/fuzz/transformation_add_constant_composite.cpp
@@ -75,7 +75,7 @@ bool TransformationAddConstantComposite::IsApplicable(
       // We do not create constants of structs decorated with Block nor
       // BufferBlock.  The SPIR-V spec does not explicitly disallow this, but it
       // seems like a strange thing to do, so we disallow it to avoid triggering
-      // low priorty edge case issues related to it.
+      // low priority edge case issues related to it.
       if (fuzzerutil::HasBlockOrBufferBlockDecoration(
               ir_context, composite_type_instruction->result_id())) {
         return false;

--- a/source/fuzz/transformation_duplicate_region_with_selection.cpp
+++ b/source/fuzz/transformation_duplicate_region_with_selection.cpp
@@ -325,7 +325,7 @@ void TransformationDuplicateRegionWithSelection::Apply(
   std::map<uint32_t, uint32_t> original_id_to_phi_id =
       fuzzerutil::RepeatedUInt32PairToMap(message_.original_id_to_phi_id());
 
-  // Use oveflow ids to fill in any required ids that are missing from these
+  // Use overflow ids to fill in any required ids that are missing from these
   // maps.
   for (auto block : region_blocks) {
     if (original_label_to_duplicate_label.count(block->id()) == 0) {

--- a/source/fuzz/transformation_replace_id_with_synonym.h
+++ b/source/fuzz/transformation_replace_id_with_synonym.h
@@ -32,7 +32,7 @@ class TransformationReplaceIdWithSynonym : public Transformation {
       protobufs::IdUseDescriptor id_use_descriptor, uint32_t synonymous_id);
 
   // - The fact manager must know that the id identified by
-  //   |message_.id_use_descriptor| is synonomous with |message_.synonymous_id|.
+  //   |message_.id_use_descriptor| is synonymous with |message_.synonymous_id|.
   // - Replacing the id in |message_.id_use_descriptor| by
   //   |message_.synonymous_id| must respect SPIR-V's rules about uses being
   //   dominated by their definitions.

--- a/source/link/CMakeLists.txt
+++ b/source/link/CMakeLists.txt
@@ -23,7 +23,7 @@ target_include_directories(SPIRV-Tools-link
 	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   PRIVATE ${spirv-tools_BINARY_DIR}
 )
-# We need the IR functionnalities from the optimizer
+# We need the IR functionalities from the optimizer
 target_link_libraries(SPIRV-Tools-link
   PUBLIC SPIRV-Tools-opt)
 

--- a/source/link/linker.cpp
+++ b/source/link/linker.cpp
@@ -128,7 +128,7 @@ spv_result_t CheckImportExportCompatibility(const MessageConsumer& consumer,
 
 // Remove linkage specific instructions, such as prototypes of imported
 // functions, declarations of imported variables, import (and export if
-// necessary) linkage attribtes.
+// necessary) linkage attributes.
 //
 // |linked_context| and |decoration_manager| should not be null, and the
 // 'RemoveDuplicatePass' should be run first.

--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -40,12 +40,12 @@ struct OpcodeDescPtrLen {
 static const spv_opcode_table_t kOpcodeTable = {ARRAY_SIZE(kOpcodeTableEntries),
                                                 kOpcodeTableEntries};
 
-// Represents a vendor tool entry in the SPIR-V XML Regsitry.
+// Represents a vendor tool entry in the SPIR-V XML Registry.
 struct VendorTool {
   uint32_t value;
   const char* vendor;
   const char* tool;         // Might be empty string.
-  const char* vendor_tool;  // Combiantion of vendor and tool.
+  const char* vendor_tool;  // Combination of vendor and tool.
 };
 
 const VendorTool vendor_tools[] = {

--- a/source/opt/amd_ext_to_khr.h
+++ b/source/opt/amd_ext_to_khr.h
@@ -23,7 +23,7 @@ namespace spvtools {
 namespace opt {
 
 // Replaces the extensions VK_AMD_shader_ballot, VK_AMD_gcn_shader, and
-// VK_AMD_shader_trinary_minmax with equivalant code using core instructions and
+// VK_AMD_shader_trinary_minmax with equivalent code using core instructions and
 // capabilities.
 class AmdExtensionToKhrPass : public Pass {
  public:

--- a/source/opt/basic_block.h
+++ b/source/opt/basic_block.h
@@ -83,7 +83,7 @@ class BasicBlock {
   const Instruction* GetMergeInst() const;
   Instruction* GetMergeInst();
 
-  // Returns the OpLoopMerge instruciton in this basic block, if it exists.
+  // Returns the OpLoopMerge instruction in this basic block, if it exists.
   // Otherwise return null.  May be used whenever tail() can be used.
   const Instruction* GetLoopMergeInst() const;
   Instruction* GetLoopMergeInst();

--- a/source/opt/cfg.h
+++ b/source/opt/cfg.h
@@ -30,7 +30,7 @@ class CFG {
  public:
   explicit CFG(Module* module);
 
-  // Return the list of predecesors for basic block with label |blkid|.
+  // Return the list of predecessors for basic block with label |blkid|.
   // TODO(dnovillo): Move this to BasicBlock.
   const std::vector<uint32_t>& preds(uint32_t blk_id) const {
     assert(label2preds_.count(blk_id));

--- a/source/opt/const_folding_rules.cpp
+++ b/source/opt/const_folding_rules.cpp
@@ -550,7 +550,7 @@ ConstantFoldingRule FoldFAdd() { return FoldFPBinaryOp(FOLD_FPARITH_OP(+)); }
 ConstantFoldingRule FoldFMul() { return FoldFPBinaryOp(FOLD_FPARITH_OP(*)); }
 
 // Returns the constant that results from evaluating |numerator| / 0.0.  Returns
-// |nullptr| if the result could not be evalutated.
+// |nullptr| if the result could not be evaluated.
 const analysis::Constant* FoldFPScalarDivideByZero(
     const analysis::Type* result_type, const analysis::Constant* numerator,
     analysis::ConstantManager* const_mgr) {
@@ -1346,7 +1346,7 @@ void ConstantFoldingRules::AddFoldingRules() {
         FoldFPUnaryOp(FoldFTranscendentalUnary(std::log)));
 
 #ifdef __ANDROID__
-    // Android NDK r15c tageting ABI 15 doesn't have full support for C++11
+    // Android NDK r15c targeting ABI 15 doesn't have full support for C++11
     // (no std::exp2/log2). ::exp2 is available from C99 but ::log2 isn't
     // available up until ABI 18 so we use a shim
     auto log2_shim = [](double v) -> double { return log(v) / log(2.0); };

--- a/source/opt/constants.h
+++ b/source/opt/constants.h
@@ -541,7 +541,7 @@ class ConstantManager {
   // instruction at the end of the current module's types section.
   //
   // |type_id| is an optional argument for disambiguating equivalent types. If
-  // |type_id| is specified, the contant returned will have that type id.
+  // |type_id| is specified, the constant returned will have that type id.
   Instruction* GetDefiningInstruction(const Constant* c, uint32_t type_id = 0,
                                       Module::inst_iterator* pos = nullptr);
 

--- a/source/opt/convert_to_half_pass.cpp
+++ b/source/opt/convert_to_half_pass.cpp
@@ -181,7 +181,7 @@ bool ConvertToHalfPass::ProcessPhi(Instruction* inst, uint32_t from_width,
                                    uint32_t to_width) {
   // Add converts of any float operands to to_width if they are of from_width.
   // If converting to 16, change type of phi to float16 equivalent and remember
-  // result id. Converts need to be added to preceeding blocks.
+  // result id. Converts need to be added to preceding blocks.
   uint32_t ocnt = 0;
   uint32_t* prev_idp;
   bool modified = false;

--- a/source/opt/dead_branch_elim_pass.h
+++ b/source/opt/dead_branch_elim_pass.h
@@ -158,7 +158,7 @@ class DeadBranchElimPass : public MemPass {
       uint32_t cont_id, uint32_t header_id, uint32_t merge_id,
       std::unordered_set<BasicBlock*>* blocks_with_back_edges);
 
-  // Returns true if there is a brach to the merge node of the selection
+  // Returns true if there is a branch to the merge node of the selection
   // construct |switch_header_id| that is inside a nested selection construct or
   // in the header of the nested selection construct.
   bool SwitchHasNestedBreak(uint32_t switch_header_id);

--- a/source/opt/debug_info_manager.cpp
+++ b/source/opt/debug_info_manager.cpp
@@ -149,7 +149,7 @@ void DebugInfoManager::RegisterDbgDeclare(uint32_t var_id,
 // Create new constant directly into global value area, bypassing the
 // Constant manager. This is used when the DefUse or Constant managers
 // are invalid and cannot be regenerated due to the module being in an
-// inconsistant state e.g. in the middle of significant modification
+// inconsistent state e.g. in the middle of significant modification
 // such as inlining. Invalidate Constant and DefUse managers if used.
 uint32_t AddNewConstInGlobals(IRContext* context, uint32_t const_value) {
   uint32_t id = context->TakeNextId();

--- a/source/opt/def_use_manager.h
+++ b/source/opt/def_use_manager.h
@@ -190,7 +190,7 @@ class DefUseManager {
   // Returns the annotation instrunctions which are a direct use of the given
   // |id|. This means when the decorations are applied through decoration
   // group(s), this function will just return the OpGroupDecorate
-  // instrcution(s) which refer to the given id as an operand. The OpDecorate
+  // instruction(s) which refer to the given id as an operand. The OpDecorate
   // instructions which decorate the decoration group will not be returned.
   std::vector<Instruction*> GetAnnotations(uint32_t id) const;
 
@@ -210,7 +210,7 @@ class DefUseManager {
   friend bool CompareAndPrintDifferences(const DefUseManager&,
                                          const DefUseManager&);
 
-  // If |inst| has not already been analysed, then analyses its defintion and
+  // If |inst| has not already been analysed, then analyses its definition and
   // uses.
   void UpdateDefUse(Instruction* inst);
 

--- a/source/opt/desc_sroa.cpp
+++ b/source/opt/desc_sroa.cpp
@@ -135,8 +135,8 @@ bool DescriptorScalarReplacement::ReplaceAccessChain(Instruction* var,
   // Use the replacement variable as the base address.
   new_operands.push_back({SPV_OPERAND_TYPE_ID, {replacement_var}});
 
-  // Drop the first index because it is consumed by the replacement, and copy the
-  // rest.
+  // Drop the first index because it is consumed by the replacement, and copy
+  // the rest.
   for (uint32_t i = 4; i < use->NumOperands(); i++) {
     new_operands.emplace_back(use->GetOperand(i));
   }

--- a/source/opt/desc_sroa.cpp
+++ b/source/opt/desc_sroa.cpp
@@ -118,7 +118,7 @@ bool DescriptorScalarReplacement::ReplaceAccessChain(Instruction* var,
 
   if (use->NumInOperands() == 2) {
     // We are not indexing into the replacement variable.  We can replaces the
-    // access chain with the replacement varibale itself.
+    // access chain with the replacement variable itself.
     context()->ReplaceAllUsesWith(use->result_id(), replacement_var);
     context()->KillInst(use);
     return true;
@@ -135,7 +135,7 @@ bool DescriptorScalarReplacement::ReplaceAccessChain(Instruction* var,
   // Use the replacement variable as the base address.
   new_operands.push_back({SPV_OPERAND_TYPE_ID, {replacement_var}});
 
-  // Drop the first index because it is consumed by the replacment, and copy the
+  // Drop the first index because it is consumed by the replacement, and copy the
   // rest.
   for (uint32_t i = 4; i < use->NumOperands(); i++) {
     new_operands.emplace_back(use->GetOperand(i));

--- a/source/opt/dominator_tree.cpp
+++ b/source/opt/dominator_tree.cpp
@@ -48,7 +48,7 @@ namespace {
 // BBType - BasicBlock type. Will either be BasicBlock or DominatorTreeNode
 // SuccessorLambda - Lamdba matching the signature of 'const
 // std::vector<BBType>*(const BBType *A)'. Will return a vector of the nodes
-// succeding BasicBlock A.
+// succeeding BasicBlock A.
 // PostLambda - Lamdba matching the signature of 'void (const BBType*)' will be
 // called on each node traversed AFTER their children.
 // PreLambda - Lamdba matching the signature of 'void (const BBType*)' will be
@@ -69,7 +69,7 @@ static void DepthFirstSearch(const BBType* bb, SuccessorLambda successors,
 // BBType - BasicBlock type. Will either be BasicBlock or DominatorTreeNode
 // SuccessorLambda - Lamdba matching the signature of 'const
 // std::vector<BBType>*(const BBType *A)'. Will return a vector of the nodes
-// succeding BasicBlock A.
+// succeeding BasicBlock A.
 // PostLambda - Lamdba matching the signature of 'void (const BBType*)' will be
 // called on each node traversed after their children.
 template <typename BBType, typename SuccessorLambda, typename PostLambda>

--- a/source/opt/eliminate_dead_members_pass.cpp
+++ b/source/opt/eliminate_dead_members_pass.cpp
@@ -38,7 +38,7 @@ Pass::Status EliminateDeadMembersPass::Process() {
 }
 
 void EliminateDeadMembersPass::FindLiveMembers() {
-  // Until we have implemented the rewritting of OpSpecConsantOp instructions,
+  // Until we have implemented the rewriting of OpSpecConsantOp instructions,
   // we have to mark them as fully used just to be safe.
   for (auto& inst : get_module()->types_values()) {
     if (inst.opcode() == SpvOpSpecConstantOp) {
@@ -570,7 +570,7 @@ bool EliminateDeadMembersPass::UpdateCompsiteExtract(Instruction* inst) {
     Instruction* type_inst = get_def_use_mgr()->GetDef(type_id);
     switch (type_inst->opcode()) {
       case SpvOpTypeStruct:
-        // The type will have already been rewriten, so use the new member
+        // The type will have already been rewritten, so use the new member
         // index.
         type_id = type_inst->GetSingleWordInOperand(new_member_idx);
         break;

--- a/source/opt/fold.cpp
+++ b/source/opt/fold.cpp
@@ -540,7 +540,7 @@ std::vector<uint32_t> InstructionFolder::FoldVectors(
         // in 32-bit words here. The reason of not using FoldScalars() here
         // is that we do not create temporary null constants as components
         // when the vector operand is a NullConstant because Constant creation
-        // may need extra checks for the validity and that is not manageed in
+        // may need extra checks for the validity and that is not managed in
         // here.
         if (const analysis::ScalarConstant* scalar_component =
                 vector_operand->GetComponents().at(d)->AsScalarConstant()) {

--- a/source/opt/fold_spec_constant_op_and_composite_pass.cpp
+++ b/source/opt/fold_spec_constant_op_and_composite_pass.cpp
@@ -115,7 +115,7 @@ bool FoldSpecConstantOpAndCompositePass::ProcessOpSpecConstantOp(
   Instruction* folded_inst = nullptr;
   assert(inst->GetInOperand(0).type ==
              SPV_OPERAND_TYPE_SPEC_CONSTANT_OP_NUMBER &&
-         "The first in-operand of OpSpecContantOp instruction must be of "
+         "The first in-operand of OpSpecConstantOp instruction must be of "
          "SPV_OPERAND_TYPE_SPEC_CONSTANT_OP_NUMBER type");
 
   switch (static_cast<SpvOp>(inst->GetSingleWordInOperand(0))) {

--- a/source/opt/graphics_robust_access_pass.cpp
+++ b/source/opt/graphics_robust_access_pass.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // This pass injects code in a graphics shader to implement guarantees
-// satisfying Vulkan's robustBufferAcces rules.  Robust access rules permit
+// satisfying Vulkan's robustBufferAccess rules.  Robust access rules permit
 // an out-of-bounds access to be redirected to an access of the same type
 // (load, store, etc.) but within the same root object.
 //
@@ -74,7 +74,7 @@
 //    Pointers are always (correctly) typed and so the address and number of
 //    consecutive locations are fully determined by the pointer.
 //
-//  - A pointer value orginates as one of few cases:
+//  - A pointer value originates as one of few cases:
 //
 //    - OpVariable for an interface object or an array of them: image,
 //      buffer (UBO or SSBO), sampler, sampled-image, push-constant, input
@@ -958,7 +958,7 @@ spv_result_t GraphicsRobustAccessPass::ClampCoordinateForImageTexelPointer(
       constant_mgr->GetDefiningInstruction(component_0)->result_id();
 
   // If the image is a cube array, then the last component of the queried
-  // size is the layer count.  In the query, we have to accomodate folding
+  // size is the layer count.  In the query, we have to accommodate folding
   // in the face index ranging from 0 through 5. The inclusive upper bound
   // on the third coordinate therefore is multiplied by 6.
   auto* query_size_including_faces = query_size;

--- a/source/opt/graphics_robust_access_pass.h
+++ b/source/opt/graphics_robust_access_pass.h
@@ -111,7 +111,7 @@ class GraphicsRobustAccessPass : public Pass {
                                    Instruction* max, Instruction* where);
 
   // Returns a new instruction which evaluates to the length the runtime array
-  // referenced by the access chain at the specfied index.  The instruction is
+  // referenced by the access chain at the specified index.  The instruction is
   // inserted before the access chain instruction.  Returns a null pointer in
   // some cases if assumptions are violated (rather than asserting out).
   opt::Instruction* MakeRuntimeArrayLengthInst(Instruction* access_chain,

--- a/source/opt/inst_bindless_check_pass.h
+++ b/source/opt/inst_bindless_check_pass.h
@@ -147,11 +147,11 @@ class InstBindlessCheckPass : public InstrumentPass {
   uint32_t GenLastByteIdx(RefAnalysis* ref, InstructionBuilder* builder);
 
   // Clone original image computation starting at |image_id| into |builder|.
-  // This may generate more than one instruction if neccessary.
+  // This may generate more than one instruction if necessary.
   uint32_t CloneOriginalImage(uint32_t image_id, InstructionBuilder* builder);
 
   // Clone original original reference encapsulated by |ref| into |builder|.
-  // This may generate more than one instruction if neccessary.
+  // This may generate more than one instruction if necessary.
   uint32_t CloneOriginalReference(RefAnalysis* ref,
                                   InstructionBuilder* builder);
 

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -122,7 +122,7 @@ inline bool operator!=(const Operand& o1, const Operand& o2) {
 }
 
 // This structure is used to represent a DebugScope instruction from
-// the OpenCL.100.DebugInfo extened instruction set. Note that we can
+// the OpenCL.100.DebugInfo extended instruction set. Note that we can
 // ignore the result id of DebugScope instruction because it is not
 // used for anything. We do not keep it to reduce the size of
 // structure.

--- a/source/opt/instrument_pass.h
+++ b/source/opt/instrument_pass.h
@@ -50,7 +50,7 @@
 // A validation pass may read or write multiple buffers. All such buffers
 // are located in a single debug descriptor set whose index is passed at the
 // creation of the instrumentation pass. The bindings of the buffers used by
-// a validation pass are permanantly assigned and fixed and documented by
+// a validation pass are permanently assigned and fixed and documented by
 // the kDebugOutput* static consts.
 
 namespace spvtools {
@@ -179,8 +179,8 @@ class InstrumentPass : public Pass {
   // the error. Every stage will write a fixed number of words. Vertex shaders
   // will write the Vertex and Instance ID. Fragment shaders will write
   // FragCoord.xy. Compute shaders will write the GlobalInvocation ID.
-  // The tesselation eval shader will write the Primitive ID and TessCoords.uv.
-  // The tesselation control shader and geometry shader will write the
+  // The tessellation eval shader will write the Primitive ID and TessCoords.uv.
+  // The tessellation control shader and geometry shader will write the
   // Primitive ID and Invocation ID.
   //
   // The Validation Error Code specifies the exact error which has occurred.

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -106,7 +106,7 @@ void IRContext::InvalidateAnalyses(IRContext::Analysis analyses_to_invalidate) {
     analyses_to_invalidate |= kAnalysisDebugInfo;
   }
 
-  // The dominator analysis hold the psuedo entry and exit nodes from the CFG.
+  // The dominator analysis hold the pseudo entry and exit nodes from the CFG.
   // Also if the CFG change the dominators many changed as well, so the
   // dominator analysis should be invalidated as well.
   if (analyses_to_invalidate & kAnalysisCFG) {

--- a/source/opt/ir_context.h
+++ b/source/opt/ir_context.h
@@ -302,7 +302,7 @@ class IRContext {
     }
   }
 
-  // Returns a pointer the decoration manager.  If the decoration manger is
+  // Returns a pointer the decoration manager.  If the decoration manager is
   // invalid, it is rebuilt first.
   analysis::DecorationManager* get_decoration_mgr() {
     if (!AreAnalysesValid(kAnalysisDecorations)) {
@@ -385,7 +385,7 @@ class IRContext {
 
   // Deletes the instruction defining the given |id|. Returns true on
   // success, false if the given |id| is not defined at all. This method also
-  // erases the name, decorations, and defintion of |id|.
+  // erases the name, decorations, and definition of |id|.
   //
   // Pointers and iterators pointing to the deleted instructions become invalid.
   // However other pointers and iterators are still valid.
@@ -802,7 +802,7 @@ class IRContext {
   // iterators to traverse instructions.
   std::unordered_map<uint32_t, Function*> id_to_func_;
 
-  // A bitset indicating which analyes are currently valid.
+  // A bitset indicating which analyzes are currently valid.
   Analysis valid_analyses_;
 
   // Opcodes of shader capability core executable instructions

--- a/source/opt/local_access_chain_convert_pass.h
+++ b/source/opt/local_access_chain_convert_pass.h
@@ -81,7 +81,7 @@ class LocalAccessChainConvertPass : public MemPass {
                               std::vector<Operand>* in_opnds);
 
   // Create a load/insert/store equivalent to a store of
-  // |valId| through (constant index) access chaing |ptrInst|.
+  // |valId| through (constant index) access chain |ptrInst|.
   // Append to |newInsts|.  Returns true if successful.
   bool GenAccessChainStoreReplacement(
       const Instruction* ptrInst, uint32_t valId,

--- a/source/opt/loop_descriptor.cpp
+++ b/source/opt/loop_descriptor.cpp
@@ -719,7 +719,7 @@ bool Loop::FindNumberOfIterations(const Instruction* induction,
     step_value = -step_value;
   }
 
-  // Find the inital value of the loop and make sure it is a constant integer.
+  // Find the initial value of the loop and make sure it is a constant integer.
   int64_t init_value = 0;
   if (!GetInductionInitValue(induction, &init_value)) return false;
 
@@ -751,7 +751,7 @@ bool Loop::FindNumberOfIterations(const Instruction* induction,
 // We retrieve the number of iterations using the following formula, diff /
 // |step_value| where diff is calculated differently according to the
 // |condition| and uses the |condition_value| and |init_value|. If diff /
-// |step_value| is NOT cleanly divisable then we add one to the sum.
+// |step_value| is NOT cleanly divisible then we add one to the sum.
 int64_t Loop::GetIterations(SpvOp condition, int64_t condition_value,
                             int64_t init_value, int64_t step_value) const {
   int64_t diff = 0;
@@ -795,7 +795,7 @@ int64_t Loop::GetIterations(SpvOp condition, int64_t condition_value,
       // If the condition is not met to begin with the loop will never iterate.
       if (!(init_value >= condition_value)) return 0;
 
-      // We subract one to make it the same as SpvOpGreaterThan as it is
+      // We subtract one to make it the same as SpvOpGreaterThan as it is
       // functionally equivalent.
       diff = init_value - (condition_value - 1);
 

--- a/source/opt/loop_descriptor.h
+++ b/source/opt/loop_descriptor.h
@@ -395,7 +395,7 @@ class Loop {
   // Sets |merge| as the loop merge block. No checks are performed here.
   inline void SetMergeBlockImpl(BasicBlock* merge) { loop_merge_ = merge; }
 
-  // Each differnt loop |condition| affects how we calculate the number of
+  // Each different loop |condition| affects how we calculate the number of
   // iterations using the |condition_value|, |init_value|, and |step_values| of
   // the induction variable. This method will return the number of iterations in
   // a loop with those values for a given |condition|.

--- a/source/opt/loop_fission.cpp
+++ b/source/opt/loop_fission.cpp
@@ -29,7 +29,7 @@
 // 2 - For each loop in the list, group each instruction into a set of related
 // instructions by traversing each instructions users and operands recursively.
 // We stop if we encounter an instruction we have seen before or an instruction
-// which we don't consider relevent (i.e OpLoopMerge). We then group these
+// which we don't consider relevant (i.e OpLoopMerge). We then group these
 // groups into two different sets, one for the first loop and one for the
 // second.
 //

--- a/source/opt/loop_fission.h
+++ b/source/opt/loop_fission.h
@@ -33,7 +33,7 @@ namespace opt {
 
 class LoopFissionPass : public Pass {
  public:
-  // Fuction used to determine if a given loop should be split. Takes register
+  // Function used to determine if a given loop should be split. Takes register
   // pressure region for that loop as a parameter and returns true if the loop
   // should be split.
   using FissionCriteriaFunction =

--- a/source/opt/loop_fusion.cpp
+++ b/source/opt/loop_fusion.cpp
@@ -165,7 +165,7 @@ bool LoopFusion::AreCompatible() {
 
   // Check adjacency, |loop_0_| should come just before |loop_1_|.
   // There is always at least one block between loops, even if it's empty.
-  // We'll check at most 2 preceeding blocks.
+  // We'll check at most 2 preceding blocks.
 
   auto pre_header_1 = loop_1_->GetPreHeaderBlock();
 
@@ -712,7 +712,7 @@ void LoopFusion::Fuse() {
 
   ld->RemoveLoop(loop_1_);
 
-  // Kill unnessecary instructions and remove all empty blocks.
+  // Kill unnecessary instructions and remove all empty blocks.
   for (auto inst : instr_to_delete) {
     context_->KillInst(inst);
   }

--- a/source/opt/loop_fusion.h
+++ b/source/opt/loop_fusion.h
@@ -40,7 +40,7 @@ class LoopFusion {
   // That means:
   //   * they both have one induction variable
   //   * they have the same upper and lower bounds
-  //     - same inital value
+  //     - same initial value
   //     - same condition
   //   * they have the same update step
   //   * they are adjacent, with |loop_0| appearing before |loop_1|

--- a/source/opt/loop_fusion_pass.h
+++ b/source/opt/loop_fusion_pass.h
@@ -33,7 +33,7 @@ class LoopFusionPass : public Pass {
 
   // Processes the given |module|. Returns Status::Failure if errors occur when
   // processing. Returns the corresponding Status::Success if processing is
-  // succesful to indicate whether changes have been made to the modue.
+  // successful to indicate whether changes have been made to the module.
   Status Process() override;
 
  private:

--- a/source/opt/loop_peeling.h
+++ b/source/opt/loop_peeling.h
@@ -261,7 +261,7 @@ class LoopPeelingPass : public Pass {
 
   // Processes the given |module|. Returns Status::Failure if errors occur when
   // processing. Returns the corresponding Status::Success if processing is
-  // succesful to indicate whether changes have been made to the modue.
+  // successful to indicate whether changes have been made to the module.
   Pass::Status Process() override;
 
  private:

--- a/source/opt/loop_unroller.cpp
+++ b/source/opt/loop_unroller.cpp
@@ -163,7 +163,7 @@ struct LoopUnrollState {
 };
 
 // This class implements the actual unrolling. It uses a LoopUnrollState to
-// maintain the state of the unrolling inbetween steps.
+// maintain the state of the unrolling in between steps.
 class LoopUnrollerUtilsImpl {
  public:
   using BasicBlockListTy = std::vector<std::unique_ptr<BasicBlock>>;
@@ -209,7 +209,7 @@ class LoopUnrollerUtilsImpl {
   // Add all blocks_to_add_ to function_ at the |insert_point|.
   void AddBlocksToFunction(const BasicBlock* insert_point);
 
-  // Duplicates the |old_loop|, cloning each body and remaping the ids without
+  // Duplicates the |old_loop|, cloning each body and remapping the ids without
   // removing instructions or changing relative structure. Result will be stored
   // in |new_loop|.
   void DuplicateLoop(Loop* old_loop, Loop* new_loop);
@@ -241,7 +241,7 @@ class LoopUnrollerUtilsImpl {
   // Remap all the in |basic_block| to new IDs and keep the mapping of new ids
   // to old
   // ids. |loop| is used to identify special loop blocks (header, continue,
-  // ect).
+  // etc).
   void AssignNewResultIds(BasicBlock* basic_block);
 
   // Using the map built by AssignNewResultIds, replace the uses in |inst|
@@ -320,7 +320,7 @@ class LoopUnrollerUtilsImpl {
   // and then be remapped at the end.
   std::vector<Instruction*> loop_phi_instructions_;
 
-  // The number of loop iterations that the loop would preform pre-unroll.
+  // The number of loop iterations that the loop would perform pre-unroll.
   size_t number_of_loop_iterations_;
 
   // The amount that the loop steps each iteration.
@@ -839,7 +839,7 @@ void LoopUnrollerUtilsImpl::DuplicateLoop(Loop* old_loop, Loop* new_loop) {
   new_loop->SetMergeBlock(new_merge);
 }
 
-// Whenever the utility copies a block it stores it in a tempory buffer, this
+// Whenever the utility copies a block it stores it in a temporary buffer, this
 // function adds the buffer into the Function. The blocks will be inserted
 // after the block |insert_point|.
 void LoopUnrollerUtilsImpl::AddBlocksToFunction(

--- a/source/opt/loop_unswitch_pass.cpp
+++ b/source/opt/loop_unswitch_pass.cpp
@@ -118,7 +118,7 @@ class LoopUnswitch {
 
     // Find a value that can be used to select the default path.
     // If none are possible, then it will just use 0.  The value does not matter
-    // because this path will never be taken becaues the new switch outside of
+    // because this path will never be taken because the new switch outside of
     // the loop cannot select this path either.
     std::vector<uint32_t> existing_values;
     for (uint32_t i = 2; i < switch_inst->NumInOperands(); i += 2) {

--- a/source/opt/loop_unswitch_pass.h
+++ b/source/opt/loop_unswitch_pass.h
@@ -30,7 +30,7 @@ class LoopUnswitchPass : public Pass {
 
   // Processes the given |module|. Returns Status::Failure if errors occur when
   // processing. Returns the corresponding Status::Success if processing is
-  // succesful to indicate whether changes have been made to the modue.
+  // successful to indicate whether changes have been made to the module.
   Pass::Status Process() override;
 
  private:

--- a/source/opt/loop_utils.h
+++ b/source/opt/loop_utils.h
@@ -123,7 +123,7 @@ class LoopUtils {
   // Clone the |loop_| and make the new loop branch to the second loop on exit.
   Loop* CloneAndAttachLoopToHeader(LoopCloningResult* cloning_result);
 
-  // Perfom a partial unroll of |loop| by given |factor|. This will copy the
+  // Perform a partial unroll of |loop| by given |factor|. This will copy the
   // body of the loop |factor| times. So a |factor| of one would give a new loop
   // with the original body plus one unrolled copy body.
   bool PartiallyUnroll(size_t factor);
@@ -139,7 +139,7 @@ class LoopUtils {
   // 1. That the loop is in structured order.
   // 2. That the continue block is a branch to the header.
   // 3. That the only phi used in the loop is the induction variable.
-  //  TODO(stephen@codeplay.com): This is a temporary mesure, after the loop is
+  //  TODO(stephen@codeplay.com): This is a temporary measure, after the loop is
   //  converted into LCSAA form and has a single entry and exit we can rewrite
   //  the other phis.
   // 4. That this is an inner most loop, or that loops contained within this

--- a/source/opt/merge_return_pass.h
+++ b/source/opt/merge_return_pass.h
@@ -247,7 +247,7 @@ class MergeReturnPass : public MemPass {
 
   // Add new phi nodes for any id that no longer dominate all of it uses.  A phi
   // node is added to a block |bb| for an id if the id is defined between the
-  // original immediate dominator of |bb| and its new immidiate dominator.  It
+  // original immediate dominator of |bb| and its new immediate dominator.  It
   // is assumed that at this point there are no unreachable blocks in the
   // control flow graph.
   void AddNewPhiNodes();
@@ -273,7 +273,7 @@ class MergeReturnPass : public MemPass {
   void InsertAfterElement(BasicBlock* element, BasicBlock* new_element,
                           std::list<BasicBlock*>* list);
 
-  // Creates a single case switch around all of the exectuable code of the
+  // Creates a single case switch around all of the executable code of the
   // current function where the switch and case value are both zero and the
   // default is the merge block. Returns after the switch is executed. Sets
   // |final_return_block_|.

--- a/source/opt/pass.h
+++ b/source/opt/pass.h
@@ -129,7 +129,7 @@ class Pass {
 
   // Processes the given |module|. Returns Status::Failure if errors occur when
   // processing. Returns the corresponding Status::Success if processing is
-  // succesful to indicate whether changes are made to the module.
+  // successful to indicate whether changes are made to the module.
   virtual Status Process() = 0;
 
   // Return the next available SSA id and increment it.

--- a/source/opt/pass_manager.h
+++ b/source/opt/pass_manager.h
@@ -54,7 +54,7 @@ class PassManager {
   // Adds an externally constructed pass.
   void AddPass(std::unique_ptr<Pass> pass);
   // Uses the argument |args| to construct a pass instance of type |T|, and adds
-  // the pass instance to this pass manger. The pass added will use this pass
+  // the pass instance to this pass manager. The pass added will use this pass
   // manager's message consumer.
   template <typename T, typename... Args>
   void AddPass(Args&&... args);
@@ -70,7 +70,7 @@ class PassManager {
   // Runs all passes on the given |module|. Returns Status::Failure if errors
   // occur when processing using one of the registered passes. All passes
   // registered after the error-reporting pass will be skipped. Returns the
-  // corresponding Status::Success if processing is succesful to indicate
+  // corresponding Status::Success if processing is successful to indicate
   // whether changes are made to the module.
   //
   // After running all the passes, they are removed from the list.

--- a/source/opt/private_to_local_pass.h
+++ b/source/opt/private_to_local_pass.h
@@ -44,7 +44,7 @@ class PrivateToLocalPass : public Pass {
   // class of |function|.  Returns false if the variable could not be moved.
   bool MoveVariable(Instruction* variable, Function* function);
 
-  // |inst| is an instruction declaring a varible.  If that variable is
+  // |inst| is an instruction declaring a variable.  If that variable is
   // referenced in a single function and all of uses are valid as defined by
   // |IsValidUse|, then that function is returned.  Otherwise, the return
   // value is |nullptr|.

--- a/source/opt/redundancy_elimination.h
+++ b/source/opt/redundancy_elimination.h
@@ -41,7 +41,7 @@ class RedundancyEliminationPass : public LocalRedundancyEliminationPass {
   // in the function containing |bb|.
   //
   // |value_to_ids| is a map from value number to ids.  If {vn, id} is in
-  // |value_to_ids| then vn is the value number of id, and the defintion of id
+  // |value_to_ids| then vn is the value number of id, and the definition of id
   // dominates |bb|.
   //
   // Returns true if at least one instruction is deleted.

--- a/source/opt/replace_desc_array_access_using_var_index.h
+++ b/source/opt/replace_desc_array_access_using_var_index.h
@@ -47,7 +47,7 @@ class ReplaceDescArrayAccessUsingVarIndex : public Pass {
   }
 
  private:
-  // Replaces all acceses to |var| using variable indices with constant
+  // Replaces all accesses to |var| using variable indices with constant
   // elements of the array |var|. Creates switch-case statements to determine
   // the value of the variable index for all the possible cases. Returns
   // whether replacement is done or not.
@@ -170,7 +170,7 @@ class ReplaceDescArrayAccessUsingVarIndex : public Pass {
   // Creates and adds an OpSwitch used for the selection of OpAccessChain whose
   // first Indexes operand is |access_chain_index_var_id|. The OpSwitch will be
   // added at the end of |parent_block|. It will jump to |default_id| for the
-  // default case and jumps to one of case blocks whoes ids are |case_block_ids|
+  // default case and jumps to one of case blocks whose ids are |case_block_ids|
   // if |access_chain_index_var_id| matches the case number. |merge_id| is the
   // merge block id.
   void AddSwitchForAccessChain(

--- a/source/opt/scalar_analysis.cpp
+++ b/source/opt/scalar_analysis.cpp
@@ -581,7 +581,7 @@ static void PushToString(T id, std::u32string* str) {
 
 // Implements the hashing of SENodes.
 size_t SENodeHash::operator()(const SENode* node) const {
-  // Concatinate the terms into a string which we can hash.
+  // Concatenate the terms into a string which we can hash.
   std::u32string hash_string{};
 
   // Hashing the type as a string is safer than hashing the enum as the enum is

--- a/source/opt/scalar_analysis_nodes.h
+++ b/source/opt/scalar_analysis_nodes.h
@@ -167,7 +167,7 @@ class SENode {
   const ChildContainerType& GetChildren() const { return children_; }
   ChildContainerType& GetChildren() { return children_; }
 
-  // Return true if this node is a cant compute node.
+  // Return true if this node is a can't compute node.
   bool IsCantCompute() const { return GetType() == CanNotCompute; }
 
 // Implements a casting method for each type.

--- a/source/opt/scalar_analysis_simplification.cpp
+++ b/source/opt/scalar_analysis_simplification.cpp
@@ -88,7 +88,7 @@ class SENodeSimplifyImpl {
 
  private:
   // Recursively descend through the graph to build up the accumulator objects
-  // which are used to flatten the graph. |child| is the node currenty being
+  // which are used to flatten the graph. |child| is the node currently being
   // traversed and the |negation| flag is used to signify that this operation
   // was preceded by a unary negative operation and as such the result should be
   // negated.

--- a/source/opt/unify_const_pass.cpp
+++ b/source/opt/unify_const_pass.cpp
@@ -151,7 +151,7 @@ Pass::Status UnifyConstantPass::Process() {
       // 'SpecId' decoration and all of them should be treated as unique.
       // 'SpecId' is not applicable to SpecConstants defined with
       // OpSpecConstant{Op|Composite}, their values are not necessary to be
-      // unique. When all the operands/compoents are the same between two
+      // unique. When all the operands/components are the same between two
       // OpSpecConstant{Op|Composite} results, their result values must be the
       // same so are unifiable.
       case SpvOp::SpvOpSpecConstantOp:

--- a/source/opt/vector_dce.h
+++ b/source/opt/vector_dce.h
@@ -73,7 +73,7 @@ class VectorDCE : public MemPass {
   bool RewriteInstructions(Function* function,
                            const LiveComponentMap& live_components);
 
-  // Makrs all DebugValue instructions that use |composite| for their values as
+  // Makes all DebugValue instructions that use |composite| for their values as
   // dead instructions by putting them into |dead_dbg_value|.
   void MarkDebugValueUsesAsDead(Instruction* composite,
                                 std::vector<Instruction*>* dead_dbg_value);

--- a/source/reduce/remove_struct_member_reduction_opportunity.cpp
+++ b/source/reduce/remove_struct_member_reduction_opportunity.cpp
@@ -153,7 +153,7 @@ void RemoveStructMemberReductionOpportunity::AdjustAccessedIndices(
         next_type = type_inst->GetSingleWordInOperand(0);
         break;
       case SpvOpTypeStruct: {
-        // Struct types are special becuase (a) we may need to adjust the index
+        // Struct types are special because (a) we may need to adjust the index
         // being used, if the struct type is the one from which we are removing
         // a member, and (b) the type encountered by following the current index
         // is dependent on the value of the index.

--- a/source/reduce/remove_unused_struct_member_reduction_opportunity_finder.cpp
+++ b/source/reduce/remove_unused_struct_member_reduction_opportunity_finder.cpp
@@ -136,9 +136,9 @@ RemoveUnusedStructMemberReductionOpportunityFinder::GetAvailableOpportunities(
     }
   }
 
-  // We now know those struct indices that are unsed, and we make a reduction
+  // We now know those struct indices that are unused, and we make a reduction
   // opportunity for each of them. By mapping each relevant member index to the
-  // structs in which it is unsed, we will group all opportunities to remove
+  // structs in which it is unused, we will group all opportunities to remove
   // member k of a struct (for some k) together.  This reduces the likelihood
   // that opportunities to remove members from the same struct will be adjacent,
   // which is good because such opportunities mutually disable one another.

--- a/source/reduce/structured_construct_to_block_reduction_opportunity_finder.cpp
+++ b/source/reduce/structured_construct_to_block_reduction_opportunity_finder.cpp
@@ -96,7 +96,7 @@ StructuredConstructToBlockReductionOpportunityFinder::GetAvailableOpportunities(
         // This also means that we don't add a region.
         continue;
       }
-      // We have a reachable header block with a rechable merge that
+      // We have a reachable header block with a reachable merge that
       // postdominates the header: this means we have a new region.
       regions.emplace(&block, std::unordered_set<opt::BasicBlock*>());
     }
@@ -128,7 +128,7 @@ bool StructuredConstructToBlockReductionOpportunityFinder::
     if (!block->WhileEachInst(
             [context, &header, &region](opt::Instruction* inst) -> bool {
               if (inst->result_id() == 0) {
-                // The instruction does not genreate a result id, thus it cannot
+                // The instruction does not generate a result id, thus it cannot
                 // be referred to outside the region - this is fine.
                 return true;
               }

--- a/source/spirv_definition.h
+++ b/source/spirv_definition.h
@@ -27,7 +27,7 @@ typedef struct spv_header_t {
   uint32_t generator;
   uint32_t bound;
   uint32_t schema;               // NOTE: Reserved
-  const uint32_t* instructions;  // NOTE: Unfixed pointer to instruciton stream
+  const uint32_t* instructions;  // NOTE: Unfixed pointer to instruction stream
 } spv_header_t;
 
 #endif  // SOURCE_SPIRV_DEFINITION_H_

--- a/source/spirv_endian.h
+++ b/source/spirv_endian.h
@@ -31,7 +31,7 @@ uint64_t spvFixDoubleWord(const uint32_t low, const uint32_t high,
 spv_result_t spvBinaryEndianness(const spv_const_binary binary,
                                  spv_endianness_t* endian);
 
-// Returns true if the given endianness matches the host's native endiannes.
+// Returns true if the given endianness matches the host's native endianness.
 bool spvIsHostEndian(spv_endianness_t endian);
 
 #endif  // SOURCE_SPIRV_ENDIAN_H_

--- a/source/spirv_target_env.h
+++ b/source/spirv_target_env.h
@@ -40,7 +40,7 @@ std::string spvLogStringForEnv(spv_target_env env);
 
 // Returns a formatted list of all SPIR-V target environment names that
 // can be parsed by spvParseTargetEnv.
-// |pad| is the number of space characters that the begining of each line
+// |pad| is the number of space characters that the beginning of each line
 //       except the first one will be padded with.
 // |wrap| is the max length of lines the user desires. Word-wrapping will
 //        occur to satisfy this limit.

--- a/source/util/bit_vector.h
+++ b/source/util/bit_vector.h
@@ -32,7 +32,7 @@ class BitVector {
   enum { kInitialNumBits = 1024 };
 
  public:
-  // Creates a bit vector contianing 0s.
+  // Creates a bit vector containing 0s.
   BitVector(uint32_t reserved_size = kInitialNumBits)
       : bits_((reserved_size - 1) / kBitContainerSize + 1, 0) {}
 

--- a/source/util/ilist.h
+++ b/source/util/ilist.h
@@ -59,7 +59,7 @@ class IntrusiveList {
   // Moves the contents of the given list to the list being constructed.
   IntrusiveList(IntrusiveList&&);
 
-  // Destorys the list.  Note that the elements of the list will not be deleted,
+  // Destroys the list.  Note that the elements of the list will not be deleted,
   // but they will be removed from the list.
   virtual ~IntrusiveList();
 

--- a/source/util/parse_number.h
+++ b/source/util/parse_number.h
@@ -220,7 +220,7 @@ EncodeNumberStatus ParseAndEncodeIntegerNumber(
     std::function<void(uint32_t)> emit, std::string* error_msg);
 
 // Parses a floating point value of a given |type| from the given |text| and
-// encodes the number by the given |emit| funciton. On success, returns
+// encodes the number by the given |emit| function. On success, returns
 // EncodeNumberStatus::kSuccess and the parsed number will be consumed by the
 // given |emit| function word by word (least significant word first). On
 // failure, this function returns the error code of the encoding status and

--- a/source/util/small_vector.h
+++ b/source/util/small_vector.h
@@ -366,7 +366,7 @@ class SmallVector {
       }
     }
 
-    // Upate the size.
+    // Update the size.
     size_ += num_of_new_elements;
     return pos;
   }
@@ -452,7 +452,7 @@ class SmallVector {
   T* small_data_;
 
   // The actual data used to store the array elements.  It must never be used
-  // directly, but must only be accesed through |small_data_|.
+  // directly, but must only be accessed through |small_data_|.
   typename std::aligned_storage<sizeof(T), std::alignment_of<T>::value>::type
       buffer[small_size];
 

--- a/source/util/timer.h
+++ b/source/util/timer.h
@@ -206,16 +206,16 @@ class Timer {
 
   // Variable to save the result of clock_gettime(CLOCK_PROCESS_CPUTIME_ID) when
   // Timer::Stop() is called. It is used as the last status of CPU time. The
-  // resouce usage is measured by subtracting |cpu_before_| from it.
+  // resource usage is measured by subtracting |cpu_before_| from it.
   timespec cpu_after_;
 
   // Variable to save the result of clock_gettime(CLOCK_MONOTONIC) when
   // Timer::Stop() is called. It is used as the last status of WALL time. The
-  // resouce usage is measured by subtracting |wall_before_| from it.
+  // resource usage is measured by subtracting |wall_before_| from it.
   timespec wall_after_;
 
   // Variable to save the result of getrusage() when Timer::Stop() is called. It
-  // is used as the last status of USR time, SYS time, and RSS. Those resouce
+  // is used as the last status of USR time, SYS time, and RSS. Those resource
   // usages are measured by subtracting |usage_before_| from it.
   rusage usage_after_;
 

--- a/source/val/basic_block.h
+++ b/source/val/basic_block.h
@@ -84,26 +84,26 @@ class BasicBlock {
       type_.set(type);
   }
 
-  /// Sets the immedate dominator of this basic block
+  /// Sets the immediate dominator of this basic block
   ///
   /// @param[in] dom_block The dominator block
   void SetImmediateDominator(BasicBlock* dom_block);
 
-  /// Sets the immedate post dominator of this basic block
+  /// Sets the immediate post dominator of this basic block
   ///
   /// @param[in] pdom_block The post dominator block
   void SetImmediatePostDominator(BasicBlock* pdom_block);
 
-  /// Returns the immedate dominator of this basic block
+  /// Returns the immediate dominator of this basic block
   BasicBlock* immediate_dominator();
 
-  /// Returns the immedate dominator of this basic block
+  /// Returns the immediate dominator of this basic block
   const BasicBlock* immediate_dominator() const;
 
-  /// Returns the immedate post dominator of this basic block
+  /// Returns the immediate post dominator of this basic block
   BasicBlock* immediate_post_dominator();
 
-  /// Returns the immedate post dominator of this basic block
+  /// Returns the immediate post dominator of this basic block
   const BasicBlock* immediate_post_dominator() const;
 
   /// Returns the label instruction for the block, or nullptr if not set.

--- a/source/val/function.cpp
+++ b/source/val/function.cpp
@@ -57,7 +57,7 @@ spv_result_t Function::RegisterFunctionParameter(uint32_t parameter_id,
                                                  uint32_t type_id) {
   assert(current_block_ == nullptr &&
          "RegisterFunctionParameter can only be called when parsing the binary "
-         "ouside of a block");
+         "outside of a block");
   // TODO(umar): Validate function parameter type order and count
   // TODO(umar): Use these variables to validate parameter type
   (void)parameter_id;
@@ -130,7 +130,7 @@ spv_result_t Function::RegisterBlock(uint32_t block_id, bool is_definition) {
     undefined_blocks_.erase(block_id);
     current_block_ = &inserted_block->second;
     ordered_blocks_.push_back(current_block_);
-  } else if (success) {  // Block doesn't exsist but this is not a definition
+  } else if (success) {  // Block doesn't exist but this is not a definition
     undefined_blocks_.insert(block_id);
   }
 

--- a/source/val/function.h
+++ b/source/val/function.h
@@ -73,8 +73,8 @@ class Function {
 
   /// Registers a variable in the current block
   ///
-  /// @param[in] type_id The type ID of the varaible
-  /// @param[in] id      The ID of the varaible
+  /// @param[in] type_id The type ID of the variable
+  /// @param[in] id      The ID of the variable
   /// @param[in] storage The storage of the variable
   /// @param[in] init_id The initializer ID of the variable
   ///
@@ -197,10 +197,10 @@ class Function {
   /// been identified and dominators have been computed.
   int GetBlockDepth(BasicBlock* bb);
 
-  /// Prints a GraphViz digraph of the CFG of the current funciton
+  /// Prints a GraphViz digraph of the CFG of the current function
   void PrintDotGraph() const;
 
-  /// Prints a directed graph of the CFG of the current funciton
+  /// Prints a directed graph of the CFG of the current function
   void PrintBlocks() const;
 
   /// Registers execution model limitation such as "Feature X is only available
@@ -285,7 +285,7 @@ class Function {
   /// The type of the return value
   uint32_t result_type_id_;
 
-  /// The control fo the funciton
+  /// The control fo the function
   SpvFunctionControlMask function_control_;
 
   /// The type of declaration of each function

--- a/source/val/validate.cpp
+++ b/source/val/validate.cpp
@@ -348,7 +348,7 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
   }
 
   // Validate the preconditions involving adjacent instructions. e.g. SpvOpPhi
-  // must only be preceeded by SpvOpLabel, SpvOpPhi, or SpvOpLine.
+  // must only be preceded by SpvOpLabel, SpvOpPhi, or SpvOpLine.
   if (auto error = ValidateAdjacency(*vstate)) return error;
 
   if (auto error = ValidateEntryPoints(*vstate)) return error;

--- a/source/val/validate.h
+++ b/source/val/validate.h
@@ -70,7 +70,7 @@ spv_result_t CheckIdDefinitionDominateUse(ValidationState_t& _);
 ///
 /// This function will iterate over all instructions and check for any required
 /// predecessor and/or successor instructions. e.g. SpvOpPhi must only be
-/// preceeded by SpvOpLabel, SpvOpPhi, or SpvOpLine.
+/// preceded by SpvOpLabel, SpvOpPhi, or SpvOpLine.
 ///
 /// @param[in] _ the validation state of the module
 ///

--- a/source/val/validate_arithmetics.cpp
+++ b/source/val/validate_arithmetics.cpp
@@ -155,7 +155,7 @@ spv_result_t ArithmeticsPass(ValidationState_t& _, const Instruction* inst) {
           first_vector_num_components = num_components;
         } else if (num_components != first_vector_num_components) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << "Expected operands to have the same number of componenets: "
+                 << "Expected operands to have the same number of components: "
                  << spvOpcodeString(opcode);
         }
       }

--- a/source/val/validate_cfg.cpp
+++ b/source/val/validate_cfg.cpp
@@ -675,7 +675,7 @@ spv_result_t ValidateStructuredSelections(
     } else if (terminator->opcode() == SpvOpSwitch) {
       if (!merge) {
         return _.diag(SPV_ERROR_INVALID_CFG, terminator)
-               << "OpSwitch must be preceeded by an OpSelectionMerge "
+               << "OpSwitch must be preceded by an OpSelectionMerge "
                   "instruction";
       }
       // Mark the targets as seen.
@@ -917,7 +917,7 @@ spv_result_t PerformCfgChecks(ValidationState_t& _) {
           }
         }
       }
-      // If we have structed control flow, check that no block has a control
+      // If we have structured control flow, check that no block has a control
       // flow nesting depth larger than the limit.
       if (_.HasCapability(SpvCapabilityShader)) {
         const int control_flow_nesting_depth_limit =

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -465,7 +465,7 @@ spv_result_t checkLayout(uint32_t struct_id, const char* storage_class_str,
         return lhs.offset < rhs.offset;
       });
 
-  // Now scan from lowest offest to highest offset.
+  // Now scan from lowest offset to highest offset.
   uint32_t nextValidOffset = 0;
   for (size_t ordered_member_idx = 0;
        ordered_member_idx < member_offsets.size(); ordered_member_idx++) {
@@ -720,7 +720,7 @@ spv_result_t CheckBuiltInVariable(uint32_t var_id, ValidationState_t& vstate) {
   return SPV_SUCCESS;
 }
 
-// Checks whether proper decorations have been appied to the entry points.
+// Checks whether proper decorations have been applied to the entry points.
 spv_result_t CheckDecorationsOfEntryPoints(ValidationState_t& vstate) {
   for (uint32_t entry_point : vstate.entry_points()) {
     const auto& descs = vstate.entry_point_descriptions(entry_point);

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -129,7 +129,7 @@ spv_result_t ValidateUint32ConstantOperandForDebugInfo(
   }
 
 // True if the operand of a debug info instruction |inst| at |word_index|
-// satisifies |expectation| that is given as a function. Otherwise,
+// satisfies |expectation| that is given as a function. Otherwise,
 // returns false.
 bool DoesDebugInfoOperandMatchExpectation(
     const ValidationState_t& _,

--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -502,7 +502,7 @@ spv_result_t ValidateImageOperands(ValidationState_t& _,
     if (!_.IsIntVectorType(component_type) ||
         _.GetDimension(component_type) != 2) {
       return _.diag(SPV_ERROR_INVALID_DATA, inst)
-             << "Expected Image Operand ConstOffsets array componenets to be "
+             << "Expected Image Operand ConstOffsets array components to be "
                 "int vectors of size 2";
     }
 
@@ -1043,7 +1043,7 @@ spv_result_t ValidateSampledImage(ValidationState_t& _,
                << "Result <id> from OpSampledImage instruction must not appear "
                   "as operand for Op"
                << spvOpcodeString(static_cast<SpvOp>(consumer_opcode))
-               << ", since it is not specificed as taking an "
+               << ", since it is not specified as taking an "
                << "OpTypeSampledImage."
                << " Found result <id> '" << _.getIdName(inst->id())
                << "' as an operand of <id> '"
@@ -1672,7 +1672,7 @@ spv_result_t ValidateImageWrite(ValidationState_t& _, const Instruction* inst) {
            << " components, but given only " << actual_coord_size;
   }
 
-  // TODO(atgoo@github.com) The spec doesn't explicitely say what the type
+  // TODO(atgoo@github.com) The spec doesn't explicitly say what the type
   // of texel should be.
   const uint32_t texel_type = _.GetOperandTypeId(inst, 2);
   if (!_.IsIntScalarOrVectorType(texel_type) &&

--- a/source/val/validate_instruction.cpp
+++ b/source/val/validate_instruction.cpp
@@ -297,7 +297,7 @@ spv_result_t VersionCheck(ValidationState_t& _, const Instruction* inst) {
   }
 
   // OpTerminateInvocation is special because it is enabled by Shader
-  // capability, but also requries a extension and/or version check.
+  // capability, but also requires an extension and/or version check.
   const bool capability_check_is_sufficient =
       inst->opcode() != SpvOpTerminateInvocation;
 
@@ -406,7 +406,7 @@ spv_result_t LimitCheckSwitch(ValidationState_t& _, const Instruction* inst) {
     // The instruction syntax is as follows:
     // OpSwitch <selector ID> <Default ID> literal label literal label ...
     // literal,label pairs come after the first 2 operands.
-    // It is guaranteed at this point that num_operands is an even numner.
+    // It is guaranteed at this point that num_operands is an even number.
     size_t num_pairs = (inst->operands().size() - 2) / 2;
     const unsigned int num_pairs_limit =
         _.options()->universal_limits_.max_switch_branches;

--- a/source/val/validate_scopes.cpp
+++ b/source/val/validate_scopes.cpp
@@ -225,7 +225,7 @@ spv_result_t ValidateMemoryScope(ValidationState_t& _, const Instruction* inst,
              << _.VkErrorID(4638) << spvOpcodeString(opcode)
              << ": in Vulkan environment, Memory Scope cannot be CrossDevice";
     }
-    // Vulkan 1.0 specifc rules
+    // Vulkan 1.0 specific rules
     if (_.context()->target_env == SPV_ENV_VULKAN_1_0 &&
         value != SpvScopeDevice && value != SpvScopeWorkgroup &&
         value != SpvScopeInvocation) {
@@ -234,7 +234,7 @@ spv_result_t ValidateMemoryScope(ValidationState_t& _, const Instruction* inst,
              << ": in Vulkan 1.0 environment Memory Scope is limited to "
              << "Device, Workgroup and Invocation";
     }
-    // Vulkan 1.1 specifc rules
+    // Vulkan 1.1 specific rules
     if ((_.context()->target_env == SPV_ENV_VULKAN_1_1 ||
          _.context()->target_env == SPV_ENV_VULKAN_1_2) &&
         value != SpvScopeDevice && value != SpvScopeWorkgroup &&

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -498,7 +498,7 @@ spv_result_t ValidationState_t::RegisterFunctionEnd() {
          "inside of another function");
   assert(in_block() == false &&
          "RegisterFunctionParameter can only be called when parsing the binary "
-         "ouside of a block");
+         "outside of a block");
   current_function().RegisterFunctionEnd();
   in_function_ = false;
   return SPV_SUCCESS;
@@ -610,7 +610,7 @@ void ValidationState_t::RegisterStorageClassConsumer(
               if (message) {
                 *message =
                     errorVUID +
-                    "in Vulkan evironment, Output Storage Class must not be "
+                    "in Vulkan environment, Output Storage Class must not be "
                     "used in GLCompute, RayGenerationKHR, IntersectionKHR, "
                     "AnyHitKHR, ClosestHitKHR, MissKHR, or CallableKHR "
                     "execution models";
@@ -632,7 +632,7 @@ void ValidationState_t::RegisterStorageClassConsumer(
               if (message) {
                 *message =
                     errorVUID +
-                    "in Vulkan evironment, Workgroup Storage Class is limited "
+                    "in Vulkan environment, Workgroup Storage Class is limited "
                     "to MeshNV, TaskNV, and GLCompute execution model";
               }
               return false;
@@ -1407,7 +1407,7 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
     return "";
   }
 
-  // This large switch case is only searched when an error has occured.
+  // This large switch case is only searched when an error has occurred.
   // If an id is changed, the old case must be modified or removed. Each string
   // here is interpreted as being "implemented"
 

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -67,7 +67,7 @@ class ValidationState_t {
     bool declare_int16_type = false;     // Allow OpTypeInt with 16 bit width?
     bool declare_float16_type = false;   // Allow OpTypeFloat with 16 bit width?
     bool free_fp_rounding_mode = false;  // Allow the FPRoundingMode decoration
-                                         // and its vaules to be used without
+                                         // and its values to be used without
                                          // requiring any capability
 
     // Allow functionalities enabled by VariablePointers capability.
@@ -797,7 +797,7 @@ class ValidationState_t {
   /// IDs that are entry points, ie, arguments to OpEntryPoint.
   std::vector<uint32_t> entry_points_;
 
-  /// Maps an entry point id to its desciptions.
+  /// Maps an entry point id to its descriptions.
   std::unordered_map<uint32_t, std::vector<EntryPointDescription>>
       entry_point_descriptions_;
 
@@ -844,7 +844,7 @@ class ValidationState_t {
   // have the same pointer size (for physical pointer types).
   uint32_t pointer_size_and_alignment_;
 
-  /// NOTE: See correspoding getter functions
+  /// NOTE: See corresponding getter functions
   bool in_function_;
 
   /// The state of optional features.  These are determined by capabilities

--- a/test/binary_parse_test.cpp
+++ b/test/binary_parse_test.cpp
@@ -604,7 +604,7 @@ INSTANTIATE_TEST_SUITE_P(
                       MakeInstruction(SpvOpNop, {42})}),
          "Invalid instruction OpNop starting at word 5: expected "
          "no more operands after 1 words, but stated word count is 2."},
-        // Supply several more unexpectd words.
+        // Supply several more unexpected words.
         {Concatenate({ExpectedHeaderForBound(1),
                       MakeInstruction(SpvOpNop, {42, 43, 44, 45, 46, 47})}),
          "Invalid instruction OpNop starting at word 5: expected "

--- a/test/c_interface_test.cpp
+++ b/test/c_interface_test.cpp
@@ -117,7 +117,7 @@ TEST(CInterface, SpecifyConsumerNullDiagnosticForAssembling) {
                     const spv_position_t& position, const char* message) {
         ++invocation;
         EXPECT_EQ(SPV_MSG_ERROR, level);
-        // The error happens at scanning the begining of second line.
+        // The error happens at scanning the beginning of second line.
         EXPECT_STREQ("input", source);
         EXPECT_EQ(1u, position.line);
         EXPECT_EQ(0u, position.column);

--- a/test/ext_inst.cldebug100_test.cpp
+++ b/test/ext_inst.cldebug100_test.cpp
@@ -581,7 +581,7 @@ INSTANTIATE_TEST_SUITE_P(
     OpenCLDebugInfo100DebugSource, ExtInstCLDebugInfo100RoundTripTest,
     ::testing::ValuesIn(std::vector<InstructionCase>({
         // TODO(dneto): Should this be a list of sourc texts,
-        // to accomodate length limits?
+        // to accommodate length limits?
         CASE_I(Source),
         CASE_II(Source),
     })));

--- a/test/ext_inst.opencl_test.cpp
+++ b/test/ext_inst.opencl_test.cpp
@@ -233,7 +233,7 @@ INSTANTIATE_TEST_SUITE_P(
         CASE3(UMad_hi, u_mad_hi), // enum value 204
     })));
 
-// OpenCL.std: 2.3 Common instrucitons
+// OpenCL.std: 2.3 Common instructions
 INSTANTIATE_TEST_SUITE_P(
     OpenCLCommon, ExtInstOpenCLStdRoundTripTest,
     ::testing::ValuesIn(std::vector<InstructionCase>({

--- a/test/fuzz/fuzzerutil_test.cpp
+++ b/test/fuzz/fuzzerutil_test.cpp
@@ -70,7 +70,7 @@ TEST(FuzzerUtilMaybeFindBlockTest, BasicTest) {
   ASSERT_TRUE(fuzzerutil::MaybeFindBlock(ir_context, block_id2) != nullptr);
   // Block with id 13 cannot be found.
   ASSERT_FALSE(fuzzerutil::MaybeFindBlock(ir_context, block_id3) != nullptr);
-  // Block with id 8 exisits but don't not of type OpLabel.
+  // Block with id 8 exists but don't not of type OpLabel.
   ASSERT_FALSE(fuzzerutil::MaybeFindBlock(ir_context, block_id4) != nullptr);
 }
 
@@ -965,7 +965,7 @@ TEST(FuzzerutilTest, FuzzerUtilMaybeGetPointerTypeTest) {
   ASSERT_EQ(
       91, fuzzerutil::MaybeGetPointerType(ir_context, 90, input_storage_class));
 
-  // A pointer with id=91 and pointee type 90 exisits, but the type should be
+  // A pointer with id=91 and pointee type 90 exists, but the type should be
   // input.
   ASSERT_EQ(0, fuzzerutil::MaybeGetPointerType(ir_context, 90,
                                                function_storage_class));

--- a/test/fuzz/transformation_add_parameter_test.cpp
+++ b/test/fuzz/transformation_add_parameter_test.cpp
@@ -367,7 +367,7 @@ TEST(TransformationAddParameterTest, NonPointerNotApplicableTest) {
       transformation_bad_3.IsApplicable(context.get(), transformation_context));
 
   // Function with id 14 does not have any callers.
-  // Bad: Id 18 is not a vaild type.
+  // Bad: Id 18 is not a valid type.
   TransformationAddParameter transformation_bad_4(14, 50, 18, {{}}, 51);
   ASSERT_FALSE(
       transformation_bad_4.IsApplicable(context.get(), transformation_context));

--- a/test/fuzz/transformation_add_type_int_test.cpp
+++ b/test/fuzz/transformation_add_type_int_test.cpp
@@ -87,7 +87,7 @@ TEST(TransformationAddTypeIntTest, IsApplicable) {
       transformation.IsApplicable(context.get(), transformation_context));
 
   // By default SPIR-V does not support 16-bit integers.
-  // Below we add such capability, so the test should now be succesful.
+  // Below we add such capability, so the test should now be successful.
   context.get()->get_feature_mgr()->AddCapability(SpvCapabilityInt16);
   ASSERT_TRUE(TransformationAddTypeInt(7, 16, true)
                   .IsApplicable(context.get(), transformation_context));

--- a/test/fuzz/transformation_adjust_branch_weights_test.cpp
+++ b/test/fuzz/transformation_adjust_branch_weights_test.cpp
@@ -106,7 +106,7 @@ TEST(TransformationAdjustBranchWeightsTest, IsApplicableTest) {
                                                kConsoleMessageConsumer));
   TransformationContext transformation_context(
       MakeUnique<FactManager>(context.get()), validator_options);
-  // Tests OpBranchConditional instruction with weigths.
+  // Tests OpBranchConditional instruction with weights.
   auto instruction_descriptor =
       MakeInstructionDescriptor(33, SpvOpBranchConditional, 0);
   auto transformation =

--- a/test/hex_float_test.cpp
+++ b/test/hex_float_test.cpp
@@ -1343,7 +1343,7 @@ struct StreamParseCase {
 template <typename T>
 std::ostream& operator<<(std::ostream& os, const StreamParseCase<T>& fspc) {
   os << "StreamParseCase(" << fspc.literal
-     << ", expect_succes:" << int(fspc.expect_success) << ","
+     << ", expect_success:" << int(fspc.expect_success) << ","
      << fspc.expected_suffix << "," << fspc.expected_value << ")";
   return os;
 }

--- a/test/opt/aggressive_dead_code_elim_test.cpp
+++ b/test/opt/aggressive_dead_code_elim_test.cpp
@@ -4323,7 +4323,7 @@ INSTANTIATE_TEST_SUITE_P(
         },
 
         // Uint vector type spec constants. One vector has all component dead,
-        // another vector has one dead unsigend integer and one used unsigned
+        // another vector has one dead unsigned integer and one used unsigned
         // integer.
         {
             /* .used_consts = */

--- a/test/opt/assembly_builder.h
+++ b/test/opt/assembly_builder.h
@@ -70,7 +70,7 @@ class AssemblyBuilder {
   static const uint32_t SPEC_ID_BASE = 200;
 
  public:
-  // Initalize a minimal SPIR-V assembly code as the template. The minimal
+  // Initialize a minimal SPIR-V assembly code as the template. The minimal
   // module contains an empty main function and some predefined names for the
   // main function.
   AssemblyBuilder()
@@ -102,7 +102,7 @@ class AssemblyBuilder {
     });
   }
 
-  // Appends OpName instructions to this builder. Instrcution strings that do
+  // Appends OpName instructions to this builder. Instruction strings that do
   // not start with 'OpName ' will be skipped. Returns the references of this
   // assembly builder.
   AssemblyBuilder& AppendNames(const std::vector<std::string>& vec_asm_code) {

--- a/test/opt/block_merge_test.cpp
+++ b/test/opt/block_merge_test.cpp
@@ -884,7 +884,7 @@ TEST_F(BlockMergeTest, MergeHeaders) {
 ; CHECK-NEXT: [[header]] = OpLabel
 ; CHECK-NEXT: OpSelectionMerge [[merge:%\w+]]
 ; CHECK: [[merge]] = OpLabel
-; CHEKC: OpReturn
+; CHECK: OpReturn
 OpCapability Shader
 OpMemoryModel Logical GLSL450
 OpEntryPoint Fragment %func "func"

--- a/test/opt/code_sink_test.cpp
+++ b/test/opt/code_sink_test.cpp
@@ -378,7 +378,7 @@ TEST_F(CodeSinkTest, MoveReadOnlyLoadWithSync) {
        %uint = OpTypeInt 32 0
      %uint_0 = OpConstant %uint 0
      %uint_4 = OpConstant %uint 4
-%mem_semantics = OpConstant %uint 0x42 ; Uniform memeory arquire
+%mem_semantics = OpConstant %uint 0x42 ; Uniform memory arquire
 %_arr_uint_uint_4 = OpTypeArray %uint %uint_4
 %_ptr_Uniform_uint = OpTypePointer Uniform %uint
 %_ptr_Uniform__arr_uint_uint_4 = OpTypePointer Uniform %_arr_uint_uint_4
@@ -419,7 +419,7 @@ TEST_F(CodeSinkTest, DontMoveBecauseOfSync) {
        %uint = OpTypeInt 32 0
      %uint_0 = OpConstant %uint 0
      %uint_4 = OpConstant %uint 4
-%mem_semantics = OpConstant %uint 0x42 ; Uniform memeory arquire
+%mem_semantics = OpConstant %uint 0x42 ; Uniform memory arquire
 %_arr_uint_uint_4 = OpTypeStruct %uint
 %_ptr_Uniform_uint = OpTypePointer Uniform %uint
 %_ptr_Uniform__arr_uint_uint_4 = OpTypePointer Uniform %_arr_uint_uint_4
@@ -460,7 +460,7 @@ TEST_F(CodeSinkTest, DontMoveBecauseOfAtomicWithSync) {
        %uint = OpTypeInt 32 0
      %uint_0 = OpConstant %uint 0
      %uint_4 = OpConstant %uint 4
-%mem_semantics = OpConstant %uint 0x42 ; Uniform memeory arquire
+%mem_semantics = OpConstant %uint 0x42 ; Uniform memory arquire
 %_arr_uint_uint_4 = OpTypeStruct %uint
 %_ptr_Uniform_uint = OpTypePointer Uniform %uint
 %_ptr_Uniform__arr_uint_uint_4 = OpTypePointer Uniform %_arr_uint_uint_4

--- a/test/opt/dead_branch_elim_test.cpp
+++ b/test/opt/dead_branch_elim_test.cpp
@@ -1613,7 +1613,7 @@ OpBranch %7
 %11 = OpLogicalOr %bool %true %false
 OpBranch %7
 %7 = OpLabel
-; This phi is in a block preceeding the merge %14!
+; This phi is in a block preceding the merge %14!
 %8 = OpPhi %bool %10 %5 %11 %6
 OpBranch %14
 %14 = OpLabel

--- a/test/opt/decoration_manager_test.cpp
+++ b/test/opt/decoration_manager_test.cpp
@@ -118,7 +118,7 @@ class DecorationManagerTest : public ::testing::Test {
 TEST_F(DecorationManagerTest,
        ComparingDecorationsWithDiffOpcodesDecorateDecorateId) {
   IRContext ir_context(SPV_ENV_UNIVERSAL_1_2, GetConsumer());
-  // This parameter can be interprated both as { SpvDecorationConstant }
+  // This parameter can be interpreted both as { SpvDecorationConstant }
   // and also as a list of IDs:  { 22 }
   const std::vector<uint32_t> param{SpvDecorationConstant};
   // OpDecorate %1 Constant
@@ -137,7 +137,7 @@ TEST_F(DecorationManagerTest,
 TEST_F(DecorationManagerTest,
        ComparingDecorationsWithDiffOpcodesDecorateDecorateString) {
   IRContext ir_context(SPV_ENV_UNIVERSAL_1_2, GetConsumer());
-  // This parameter can be interprated both as { SpvDecorationConstant }
+  // This parameter can be interpreted both as { SpvDecorationConstant }
   // and also as a null-terminated string with a single character with value 22.
   const std::vector<uint32_t> param{SpvDecorationConstant};
   // OpDecorate %1 Constant

--- a/test/opt/def_use_test.cpp
+++ b/test/opt/def_use_test.cpp
@@ -1656,7 +1656,7 @@ INSTANTIATE_TEST_SUITE_P(
           "OpGroupDecorate %1 %2 %3",
         },
       },
-      // memeber decorate
+      // member decorate
       {
         // code
         "OpMemberDecorate %1 0 RelaxedPrecision "

--- a/test/opt/dominator_tree/generated.cpp
+++ b/test/opt/dominator_tree/generated.cpp
@@ -57,7 +57,7 @@ void check_dominance(const DominatorAnalysisBase& dom_tree, const Function* fn,
   }
 }
 
-// Check that x does not dominates y and vise versa
+// Check that x does not dominates y and vice versa
 void check_no_dominance(const DominatorAnalysisBase& dom_tree,
                         const Function* fn, uint32_t x, uint32_t y) {
   SCOPED_TRACE("Check no domination for Basic Block " + std::to_string(x) +

--- a/test/opt/eliminate_dead_const_test.cpp
+++ b/test/opt/eliminate_dead_const_test.cpp
@@ -547,7 +547,7 @@ INSTANTIATE_TEST_SUITE_P(
         },
 
         // Uint vector type spec constants. One vector has all component dead,
-        // another vector has one dead unsigend integer and one used unsigned
+        // another vector has one dead unsigned integer and one used unsigned
         // integer.
         {
             /* .used_consts = */

--- a/test/opt/flatten_decoration_test.cpp
+++ b/test/opt/flatten_decoration_test.cpp
@@ -43,7 +43,7 @@ OpName %Camera "Camera"
 )";
 }
 
-// Retuns types
+// Returns types
 std::string TypesAndFunctionsAssembly() {
   return
       R"(%void = OpTypeVoid

--- a/test/opt/fold_test.cpp
+++ b/test/opt/fold_test.cpp
@@ -7092,7 +7092,7 @@ using MatchingInstructionWithNoResultFoldingTest =
 
 // Test folding instructions that do not have a result.  The instruction
 // that will be folded is the last instruction before the return.  If there
-// are multiple returns, there is not guarentee which one is used.
+// are multiple returns, there is not guarantee which one is used.
 TEST_P(MatchingInstructionWithNoResultFoldingTest, Case) {
   const auto& tc = GetParam();
 

--- a/test/opt/graphics_robust_access_test.cpp
+++ b/test/opt/graphics_robust_access_test.cpp
@@ -1242,7 +1242,7 @@ TEST_F(GraphicsRobustAccessTest, ACArrayRTArrayStructVectorElem) {
        ; CHECK-DAG: %int_9 = OpConstant %int 9
        ; CHECK-DAG: %[[intmax:\w+]] = OpConstant %int 2147483647
        ; CHECK: OpLabel
-       ; This access chain is manufatured only so we can compute the array length.
+       ; This access chain is manufactured only so we can compute the array length.
        ; Note that the %int_9 is already clamped
        ; CHECK: %[[ssbo_base:\w+]] = )" << ac
             << R"( %[[ssbo_p]] %var %int_9

--- a/test/opt/inline_test.cpp
+++ b/test/opt/inline_test.cpp
@@ -4238,7 +4238,7 @@ TEST_F(InlineTest, CreateConstantForInlinedAt) {
   // This shader causes CreateDebugInlinedAt to generate a constant.
   // Using the Constant manager would attempt to build the invalidated
   // DefUse manager during inlining which could cause an assert because
-  // the function is in an inconsistant state. This test verifies that
+  // the function is in an inconsistent state. This test verifies that
   // CreateDebugInlinedAt detects that the DefUse manager is disabled
   // and creates a duplicate constant safely without the Constant manager.
   //

--- a/test/opt/inst_bindless_check_test.cpp
+++ b/test/opt/inst_bindless_check_test.cpp
@@ -9984,8 +9984,8 @@ TEST_F(InstBindlessTest, SamplerBufferConstructorOOBFetch) {
 //
 //   Compute shader
 //   Geometry shader
-//   Tesselation control shader
-//   Tesselation eval shader
+//   Tessellation control shader
+//   Tessellation eval shader
 //   OpImage
 //   SampledImage variable
 

--- a/test/opt/inst_debug_printf_test.cpp
+++ b/test/opt/inst_debug_printf_test.cpp
@@ -206,8 +206,8 @@ OpFunctionEnd
 //
 //   Compute shader
 //   Geometry shader
-//   Tesselation control shader
-//   Tesselation eval shader
+//   Tessellation control shader
+//   Tessellation eval shader
 //   Vertex shader
 
 }  // namespace

--- a/test/opt/loop_optimizations/loop_descriptions.cpp
+++ b/test/opt/loop_optimizations/loop_descriptions.cpp
@@ -298,7 +298,7 @@ TEST_F(PassClassTest, NoLoop) {
 
 /*
 Generated from following GLSL with latch block artificially inserted to be
-seperate from continue.
+separate from continue.
 #version 430
 void main(void) {
     float x[10];

--- a/test/opt/loop_optimizations/loop_fission.cpp
+++ b/test/opt/loop_optimizations/loop_fission.cpp
@@ -692,7 +692,7 @@ SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
 SinglePassRunAndCheck<LoopFissionPass>(source, expected, true);
 
 // By passing 1 as argument we are using the constructor which makes the
-// critera to split the loop be if the registers in the loop exceede 1. By
+// criteria to split the loop be if the registers in the loop exceede 1. By
 // using this constructor we are also enabling multiple passes (disabled by
 // default).
 SinglePassRunAndCheck<LoopFissionPass>(source, expected_multiple_passes, true,

--- a/test/opt/loop_optimizations/unroll_simple.cpp
+++ b/test/opt/loop_optimizations/unroll_simple.cpp
@@ -886,7 +886,7 @@ OpFunctionEnd
   LoopUnroller loop_unroller;
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
   // By unrolling by a factor that doesn't divide evenly into the number of loop
-  // iterations we perfom an additional transform when partially unrolling to
+  // iterations we perform an additional transform when partially unrolling to
   // account for the remainder.
   SinglePassRunAndCheck<PartialUnrollerTestPass<3>>(text, output, false);
 }
@@ -3118,7 +3118,7 @@ OpFunctionEnd
 
 /*
 Generated from following GLSL with latch block artificially inserted to be
-seperate from continue.
+separate from continue.
 #version 430
 void main(void) {
     float x[10];

--- a/test/opt/module_test.cpp
+++ b/test/opt/module_test.cpp
@@ -52,7 +52,7 @@ inline std::unique_ptr<IRContext> BuildModule(std::string text) {
 }
 
 TEST(ModuleTest, ComputeIdBound) {
-  // Emtpy module case.
+  // Empty module case.
   EXPECT_EQ(1u, BuildModule("")->module()->ComputeIdBound());
   // Sensitive to result id
   EXPECT_EQ(2u, BuildModule("%void = OpTypeVoid")->module()->ComputeIdBound());

--- a/test/opt/pass_manager_test.cpp
+++ b/test/opt/pass_manager_test.cpp
@@ -30,7 +30,7 @@ namespace {
 using spvtest::GetIdBound;
 using ::testing::Eq;
 
-// A null pass whose construtors accept arguments
+// A null pass whose constructors accept arguments
 class NullPassWithArgs : public NullPass {
  public:
   NullPassWithArgs(uint32_t) {}

--- a/test/opt/set_spec_const_default_value_test.cpp
+++ b/test/opt/set_spec_const_default_value_test.cpp
@@ -618,7 +618,7 @@ INSTANTIATE_TEST_SUITE_P(
         {"", SpecIdToValueBitPatternMap{}, ""},
         // 1. Empty with non-empty values to set.
         {"", SpecIdToValueBitPatternMap{{1, {100}}, {2, {200}}}, ""},
-        // 2. Baisc bool type.
+        // 2. Basic bool type.
         {
             // code
             "OpDecorate %1 SpecId 100\n"

--- a/test/opt/unify_const_test.cpp
+++ b/test/opt/unify_const_test.cpp
@@ -263,7 +263,7 @@ TEST_F(UnifyFrontEndConstantSingleTest, UnifyWithDecorationOnTypes) {
           // decorated flat struct
           "%flat_d = OpTypeStruct %int %float",
           "%_pf_flat_d = OpTypePointer Function %flat_d",
-          // perserved contants. %flat_1 and %flat_d has same members, but
+          // preserved constants. %flat_1 and %flat_d has same members, but
           // their type are different in decorations, so they should not be
           // used to replace each other.
           "%int_1 = OpConstant %int 1",
@@ -682,7 +682,7 @@ INSTANTIATE_TEST_SUITE_P(
             // zero-valued composite constant built from zero-valued constant
             // component. inner_zero should not be replace by null_inner.
             "%inner_zero = OpConstantComposite %inner_struct %bool_zero %float_zero",
-            // zero-valued composite contant built from zero-valued constants
+            // zero-valued composite constant built from zero-valued constants
             // and null constants.
             "%outer_zero = OpConstantComposite %outer_struct %inner_zero %int_null %double_null",
             // outer_struct type null constant, it should not be replaced by
@@ -820,7 +820,7 @@ INSTANTIATE_TEST_SUITE_P(
           {
             "%spec_signed_add_duplicate = OpSpecConstantOp %int IAdd %spec_signed_1 %spec_signed_2",
           },
-          // use duplicated contants in main
+          // use duplicated constants in main
           {
             "%int_var = OpVariable %_pf_int Function",
             "OpStore %int_var %spec_signed_add_duplicate",

--- a/test/text_to_binary.control_flow_test.cpp
+++ b/test/text_to_binary.control_flow_test.cpp
@@ -379,7 +379,7 @@ INSTANTIATE_TEST_SUITE_P(
        "OpTypeQueue",
        "OpTypePipe ReadOnly",
 
-       // Skip OpTypeForwardPointer becasuse it doesn't even produce a result
+       // Skip OpTypeForwardPointer because it doesn't even produce a result
        // ID.
 
        // At least one thing that isn't a type at all

--- a/test/text_to_binary.extension_test.cpp
+++ b/test/text_to_binary.extension_test.cpp
@@ -197,7 +197,7 @@ INSTANTIATE_TEST_SUITE_P(
                                                  SpvBuiltInSubgroupLtMask})},
             })));
 
-// The old builtin names (with KHR suffix) still work in the assmebler, and
+// The old builtin names (with KHR suffix) still work in the assembler, and
 // map to the enums without the KHR.
 INSTANTIATE_TEST_SUITE_P(
     SPV_KHR_shader_ballot_vulkan_1_1_alias_check, ExtensionAssemblyTest,

--- a/test/text_to_binary_test.cpp
+++ b/test/text_to_binary_test.cpp
@@ -65,7 +65,7 @@ INSTANTIATE_TEST_SUITE_P(
         {SPV_OPERAND_TYPE_FP_FAST_MATH_MODE, 1, "NotNaN"},
         {SPV_OPERAND_TYPE_FP_FAST_MATH_MODE, 2, "NotInf"},
         {SPV_OPERAND_TYPE_FP_FAST_MATH_MODE, 3, "NotNaN|NotInf"},
-        // Mask experssions are symmetric.
+        // Mask expressions are symmetric.
         {SPV_OPERAND_TYPE_FP_FAST_MATH_MODE, 3, "NotInf|NotNaN"},
         // Repeating a value has no effect.
         {SPV_OPERAND_TYPE_FP_FAST_MATH_MODE, 3, "NotInf|NotNaN|NotInf"},

--- a/test/val/val_arithmetics_test.cpp
+++ b/test/val/val_arithmetics_test.cpp
@@ -656,7 +656,7 @@ TEST_F(ValidateArithmetics, DotDifferentVectorSize) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "Expected operands to have the same number of componenets: Dot"));
+          "Expected operands to have the same number of components: Dot"));
 }
 
 TEST_F(ValidateArithmetics, VectorTimesScalarSuccess) {

--- a/test/val/val_atomics_test.cpp
+++ b/test/val/val_atomics_test.cpp
@@ -280,7 +280,7 @@ TEST_F(ValidateAtomics, AtomicLoadVulkanWrongStorageClass) {
               AnyVUID("VUID-StandaloneSpirv-None-04645"));
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("in Vulkan evironment, Workgroup Storage Class is limited to "
+      HasSubstr("in Vulkan environment, Workgroup Storage Class is limited to "
                 "MeshNV, TaskNV, and GLCompute execution model"));
 }
 
@@ -708,7 +708,7 @@ OpAtomicStore %f32_var %device %relaxed %f32_1
               AnyVUID("VUID-StandaloneSpirv-None-04645"));
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("in Vulkan evironment, Workgroup Storage Class is limited to "
+      HasSubstr("in Vulkan environment, Workgroup Storage Class is limited to "
                 "MeshNV, TaskNV, and GLCompute execution model"));
 }
 

--- a/test/val/val_cfg_test.cpp
+++ b/test/val/val_cfg_test.cpp
@@ -65,7 +65,7 @@ class Block {
   /// Creates a Block with a given label
   ///
   /// @param[in]: label the label id of the block
-  /// @param[in]: type the branch instruciton that ends the block
+  /// @param[in]: type the branch instruction that ends the block
   explicit Block(std::string label, SpvOp type = SpvOpBranch)
       : label_(label), body_(), type_(type), successors_() {}
 
@@ -3523,7 +3523,7 @@ OpFunctionEnd
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpSwitch must be preceeded by an OpSelectionMerge instruction"));
+          "OpSwitch must be preceded by an OpSelectionMerge instruction"));
 }
 
 TEST_F(ValidateCFG, MissingMergeSwitchBad2) {
@@ -3550,7 +3550,7 @@ OpFunctionEnd
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpSwitch must be preceeded by an OpSelectionMerge instruction"));
+          "OpSwitch must be preceded by an OpSelectionMerge instruction"));
 }
 
 TEST_F(ValidateCFG, MissingMergeOneBranchToMergeGood) {
@@ -3622,7 +3622,7 @@ OpFunctionEnd
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpSwitch must be preceeded by an OpSelectionMerge instruction"));
+          "OpSwitch must be preceded by an OpSelectionMerge instruction"));
 }
 
 TEST_F(ValidateCFG, MissingMergeOneUnseenTargetSwitchBad) {
@@ -3654,7 +3654,7 @@ OpFunctionEnd
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "OpSwitch must be preceeded by an OpSelectionMerge instruction"));
+          "OpSwitch must be preceded by an OpSelectionMerge instruction"));
 }
 
 TEST_F(ValidateCFG, MissingMergeLoopBreakGood) {

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -1015,7 +1015,7 @@ TEST_F(ValidateIdWithMessage, OpTypeRuntimeArrayBad) {
                 "type."));
 }
 // TODO: Object of this type can only be created with OpVariable using the
-// Unifrom Storage Class
+// Uniform Storage Class
 
 TEST_F(ValidateIdWithMessage, OpTypeStructGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
@@ -2859,7 +2859,7 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeRelaxedStruct) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-// Same code as the last test excect for an extra decoration on one of the
+// Same code as the last test except for an extra decoration on one of the
 // members. With the relaxed rules, the code is still valid.
 TEST_F(ValidateIdWithMessage, OpStoreTypeRelaxedStructWithExtraDecoration) {
   std::string spirv = kGLSL450MemoryModel + R"(

--- a/test/val/val_image_test.cpp
+++ b/test/val/val_image_test.cpp
@@ -3134,7 +3134,7 @@ TEST_F(ValidateImage, GatherConstOffsetsArrayNotVector) {
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Expected Image Operand ConstOffsets array componenets "
+              HasSubstr("Expected Image Operand ConstOffsets array components "
                         "to be int vectors of size 2"));
 }
 
@@ -3149,7 +3149,7 @@ TEST_F(ValidateImage, GatherConstOffsetsArrayVectorWrongSize) {
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Expected Image Operand ConstOffsets array componenets "
+              HasSubstr("Expected Image Operand ConstOffsets array components "
                         "to be int vectors of size 2"));
 }
 

--- a/test/val/val_limits_test.cpp
+++ b/test/val/val_limits_test.cpp
@@ -750,7 +750,7 @@ TEST_F(ValidateLimits, CustomizedControlFlowDepthBad) {
 }
 
 // Valid. The purpose here is to test the CFG depth calculation code when a loop
-// continue target is the loop iteself. It also exercises the case where a loop
+// continue target is the loop itself. It also exercises the case where a loop
 // is unreachable.
 TEST_F(ValidateLimits, ControlFlowNoEntryToLoopGood) {
   std::string str = header + R"(

--- a/test/val/val_literals_test.cpp
+++ b/test/val/val_literals_test.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Validation tests for ilegal literals
+// Validation tests for illegal literals
 
 #include <string>
 #include <utility>

--- a/test/val/val_storage_test.cpp
+++ b/test/val/val_storage_test.cpp
@@ -280,7 +280,7 @@ TEST_P(ValidateStorageExecutionModel, VulkanOutsideStoreFailure) {
               AnyVUID("VUID-StandaloneSpirv-None-04644"));
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("in Vulkan evironment, Output Storage Class must not be used "
+      HasSubstr("in Vulkan environment, Output Storage Class must not be used "
                 "in GLCompute, RayGenerationKHR, IntersectionKHR, AnyHitKHR, "
                 "ClosestHitKHR, MissKHR, or CallableKHR execution models"));
 }

--- a/tools/cfg/bin_to_dot.cpp
+++ b/tools/cfg/bin_to_dot.cpp
@@ -57,13 +57,13 @@ class DotConverter {
   // Ends processing for the current block, emitting its dot code.
   void FlushBlock(const std::vector<uint32_t>& successors);
 
-  // The ID of the current functio, or 0 if outside of a function.
+  // The ID of the current function, or 0 if outside of a function.
   uint32_t current_function_id_ = 0;
 
   // The ID of the current basic block, or 0 if outside of a block.
   uint32_t current_block_id_ = 0;
 
-  // Have we completed processing for the entry block to this fuction?
+  // Have we completed processing for the entry block to this function?
   bool seen_function_entry_block_ = false;
 
   // The Id of the merge block for this block if it exists, or 0 otherwise.

--- a/tools/cfg/bin_to_dot.h
+++ b/tools/cfg/bin_to_dot.h
@@ -20,7 +20,7 @@
 #include "spirv-tools/libspirv.h"
 
 // Dumps the control flow graph for the given module to the output stream.
-// Returns SPV_SUCCESS on succes.
+// Returns SPV_SUCCESS on success.
 spv_result_t BinaryToDot(const spv_const_context context, const uint32_t* words,
                          size_t num_words, std::iostream* out,
                          spv_diagnostic* diagnostic);

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -44,7 +44,7 @@ struct OptStatus {
 // initialization and setup. Note that |source| and |position| are irrelevant
 // here because we are still not processing a SPIR-V input file.
 void opt_diagnostic(spv_message_level_t level, const char* /*source*/,
-                    const spv_position_t& /*positon*/, const char* message) {
+                    const spv_position_t& /*position*/, const char* message) {
   if (level == SPV_MSG_ERROR) {
     fprintf(stderr, "error: ");
   }

--- a/tools/sva/README.md
+++ b/tools/sva/README.md
@@ -1,6 +1,6 @@
 # SVA
 
-SPIR-V Assember for WebGPU. The SPIR-V Assembler is a JavaScript library to
+SPIR-V Assembler for WebGPU. The SPIR-V Assembler is a JavaScript library to
 convert SPIR-V assembly (as produced by spirv-dis in SPIR-V Tools) into a
 SPIR-V binary. The assembler assumes it is generating WebGPU SPIR-V and thus has
 the following limitations.

--- a/utils/generate_grammar_tables.py
+++ b/utils/generate_grammar_tables.py
@@ -23,7 +23,7 @@ import re
 PYGEN_VARIABLE_PREFIX = 'pygen_variable'
 
 # Extensions to recognize, but which don't necessarily come from the SPIR-V
-# core or KHR grammar files.  Get this list from the SPIR-V registery web page.
+# core or KHR grammar files.  Get this list from the SPIR-V registry web page.
 # NOTE: Only put things on this list if it is not in those grammar files.
 EXTENSIONS_FROM_SPIRV_REGISTRY_AND_NOT_FROM_GRAMMARS = """
 SPV_AMD_gcn_shader

--- a/utils/git-sync-deps
+++ b/utils/git-sync-deps
@@ -168,7 +168,7 @@ def git_checkout_to_directory(git, repo, checkoutable, directory, verbose):
 
   with open(os.devnull, 'w') as devnull:
     # If this fails, we will fetch before trying again.  Don't spam user
-    # with error infomation.
+    # with error information.
     if 0 == subprocess.call([git, 'checkout', '--quiet', checkoutable],
                             cwd=directory, stderr=devnull):
       # if this succeeds, skip slow `git fetch`.

--- a/utils/vscode/src/lsp/jsonrpc2/jsonrpc2.go
+++ b/utils/vscode/src/lsp/jsonrpc2/jsonrpc2.go
@@ -48,7 +48,7 @@ const (
 	requestDone
 )
 
-// Request is sent to a server to represent a Call or Notify operaton.
+// Request is sent to a server to represent a Call or Notify operation.
 type Request struct {
 	conn        *Conn
 	cancel      context.CancelFunc

--- a/utils/vscode/src/lsp/jsonrpc2/wire.go
+++ b/utils/vscode/src/lsp/jsonrpc2/wire.go
@@ -44,7 +44,7 @@ const (
 	CodeServerOverloaded = -32000
 )
 
-// WireRequest is sent to a server to represent a Call or Notify operaton.
+// WireRequest is sent to a server to represent a Call or Notify operation.
 type WireRequest struct {
 	// VersionTag is always encoded as the string "2.0"
 	VersionTag VersionTag `json:"jsonrpc"`

--- a/utils/vscode/src/lsp/protocol/tsprotocol.go
+++ b/utils/vscode/src/lsp/protocol/tsprotocol.go
@@ -143,7 +143,7 @@ type WorkspaceFoldersServerCapabilities struct {
 			 * change notifications.
 			 *
 			 * If a strings is provided the string is treated as a ID
-			 * under which the notification is registed on the client
+			 * under which the notification is registered on the client
 			 * side. The ID can be used to unregister for these events
 			 * using the `client/unregisterCapability` request.
 			 */
@@ -162,7 +162,7 @@ type WorkspaceFolder struct {
 
 	/*Name defined:
 	 * The name of the workspace folder. Used to refer to this
-	 * workspace folder in thge user interface.
+	 * workspace folder in the user interface.
 	 */
 	Name string `json:"name"`
 }
@@ -1129,7 +1129,7 @@ type ServerCapabilities struct {
 			 * change notifications.
 			 *
 			 * If a strings is provided the string is treated as a ID
-			 * under which the notification is registed on the client
+			 * under which the notification is registered on the client
 			 * side. The ID can be used to unregister for these events
 			 * using the `client/unregisterCapability` request.
 			 */
@@ -1803,7 +1803,7 @@ type CompletionOptions struct {
 
 	/*AllCommitCharacters defined:
 	 * The list of all possible characters that commit a completion. This field can be used
-	 * if clients don't support individual commmit characters per completion item. See
+	 * if clients don't support individual commit characters per completion item. See
 	 * `ClientCapabilities.textDocument.completion.completionItem.commitCharactersSupport`
 	 *
 	 * @since 3.2.0
@@ -2881,7 +2881,7 @@ type Color struct {
 type ColorInformation struct {
 
 	/*Range defined:
-	 * The range in the document where this color appers.
+	 * The range in the document where this color appears.
 	 */
 	Range Range `json:"range"`
 
@@ -3652,7 +3652,7 @@ type CodeActionContext struct {
 
 	/*Diagnostics defined:
 	 * An array of diagnostics known on the client side overlapping the range provided to the
-	 * `textDocument/codeAction` request. They are provied so that the server knows which
+	 * `textDocument/codeAction` request. They are provided so that the server knows which
 	 * errors are currently presented to the user for the given range. There is no guarantee
 	 * that these accurately reflect the error state of the resource. The primary parameter
 	 * to compute code actions is the provided range.
@@ -4081,13 +4081,13 @@ const (
 	/*TextOnlyTransactional defined:
 	 * If the workspace edit contains only textual file changes they are executed transactional.
 	 * If resource changes (create, rename or delete file) are part of the change the failure
-	 * handling startegy is abort.
+	 * handling strategy is abort.
 	 */
 	TextOnlyTransactional FailureHandlingKind = "textOnlyTransactional"
 
 	/*Undo defined:
 	 * The client tries to undo the operations already executed. But there is no
-	 * guaruntee that this is succeeding.
+	 * guarantee that this is succeeding.
 	 */
 	Undo FailureHandlingKind = "undo"
 

--- a/utils/vscode/src/parser/parser.go
+++ b/utils/vscode/src/parser/parser.go
@@ -798,7 +798,7 @@ type Identifier struct {
 	References []*Token     // all the places the identifier was referenced
 }
 
-// Severity is an enumerator of diagnositc seeverities
+// Severity is an enumerator of diagnostic severities
 type Severity int
 
 // Severity levels


### PR DESCRIPTION
Found via `codespell -q 3 -L fo,lod,parm`