### PR TITLE
Avoid infinite recursion in comparison operators on SmallVector

### DIFF
--- a/source/util/small_vector.h
+++ b/source/util/small_vector.h
@@ -175,9 +175,12 @@ class SmallVector {
     return true;
   }
 
+// Avoid infinite recursion from rewritten operators in C++20
+#if __cplusplus <= 201703L
   friend bool operator==(const std::vector<T>& lhs, const SmallVector& rhs) {
     return rhs == lhs;
   }
+#endif
 
   friend bool operator!=(const SmallVector& lhs, const std::vector<T>& rhs) {
     return !(lhs == rhs);


### PR DESCRIPTION
    C++20 automatically adds reversed versions of operator overloads for
    consideration; in this particular instance this results in infinite
    recursion, which has now been pointed out elsewhere as a known issue
    when migrating to C++20. Here we just disable one of the overloads in
    C++20 mode and let the auto-reversing take care of it for us.