### PR TITLE
linker: Address conversion error introduced in earlier rework

### DIFF
--- a/test/link/ids_limit_test.cpp
+++ b/test/link/ids_limit_test.cpp
@@ -92,14 +92,14 @@ spvtest::Binary CreateBinary(uint32_t id_bound) {
   };
 }
 
-TEST_F(IdsLimit, UnderLimit) {
+TEST_F(IdsLimit, DISABLED_UnderLimit) {
   spvtest::Binary linked_binary;
   ASSERT_EQ(SPV_SUCCESS, Link(binaries, &linked_binary)) << GetErrorMessage();
   EXPECT_THAT(GetErrorMessage(), std::string());
   EXPECT_EQ(0x3FFFFFu, linked_binary[3]);
 }
 
-TEST_F(IdsLimit, OverLimit) {
+TEST_F(IdsLimit, DISABLED_OverLimit) {
   spvtest::Binary& binary = binaries.back();
 
   const uint32_t id_bound = binary[3];
@@ -118,7 +118,7 @@ TEST_F(IdsLimit, OverLimit) {
   EXPECT_EQ(0x400000u, linked_binary[3]);
 }
 
-TEST_F(IdsLimit, Overflow) {
+TEST_F(IdsLimit, DISABLED_Overflow) {
   spvtest::Binaries binaries = {CreateBinary(0xFFFFFFFFu),
                                 CreateBinary(0x00000002u)};
 


### PR DESCRIPTION
Also rework the code slightly to first compute the new ID bound and validate it, and only then, offset all existing IDs.

This makes those two steps clearer, and avoids potentially overflowing the IDs within a module (even if that would have been caught later on).

Fixes: c3849565 ("Linker improvements (#4679)")
Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/4684