### PR TITLE
Fix roll_deps.sh

### DIFF
--- a/utils/roll_deps.sh
+++ b/utils/roll_deps.sh
@@ -23,9 +23,9 @@ set -eo pipefail
 effcee_dir="external/effcee/"
 effcee_trunk="origin/main"
 googletest_dir="external/googletest/"
-googletest_trunk="origin/master"
+googletest_trunk="origin/main"
 re2_dir="external/re2/"
-re2_trunk="origin/master"
+re2_trunk="origin/main"
 spirv_headers_dir="external/spirv-headers/"
 spirv_headers_trunk="origin/master"
 
@@ -41,6 +41,7 @@ fi
 
 old_head=$(git rev-parse HEAD)
 
+set +e
 roll-dep --ignore-dirty-tree --roll-to="${effcee_trunk}" "${effcee_dir}"
 roll-dep --ignore-dirty-tree --roll-to="${googletest_trunk}" "${googletest_dir}"
 roll-dep --ignore-dirty-tree --roll-to="${re2_trunk}" "${re2_dir}"


### PR DESCRIPTION
Two deps changes branch names, and roll_deps.sh must be updated.

We also don't want the script to fail just because one of the deps is
already up-to-date.  Set `+e` before rolling the deps.
