### PR TITLE
Complete handling of RayQueryKHR type

### DIFF
--- a/source/opt/type_manager.cpp
+++ b/source/opt/type_manager.cpp
@@ -235,6 +235,7 @@ uint32_t TypeManager::GetTypeInstruction(const Type* type) {
     DefineParameterlessCase(PipeStorage);
     DefineParameterlessCase(NamedBarrier);
     DefineParameterlessCase(AccelerationStructureNV);
+    DefineParameterlessCase(RayQueryKHR);
 #undef DefineParameterlessCase
     case Type::kInteger:
       typeInst = MakeUnique<Instruction>(
@@ -527,6 +528,7 @@ Type* TypeManager::RebuildType(const Type& type) {
     DefineNoSubtypeCase(PipeStorage);
     DefineNoSubtypeCase(NamedBarrier);
     DefineNoSubtypeCase(AccelerationStructureNV);
+    DefineNoSubtypeCase(RayQueryKHR);
 #undef DefineNoSubtypeCase
     case Type::kVector: {
       const Vector* vec_ty = type.AsVector();

--- a/source/opt/types.h
+++ b/source/opt/types.h
@@ -96,7 +96,8 @@ class Type {
     kNamedBarrier,
     kAccelerationStructureNV,
     kCooperativeMatrixNV,
-    kRayQueryKHR
+    kRayQueryKHR,
+    kLast
   };
 
   Type(Kind k) : kind_(k) {}

--- a/test/opt/type_manager_test.cpp
+++ b/test/opt/type_manager_test.cpp
@@ -174,12 +174,12 @@ std::vector<std::unique_ptr<Type>> GenerateAllTypes() {
 
 TEST(TypeManager, GenerateAllTypesGeneratesAllTypes) {
   std::set<Type::Kind> generated_types;
-  for(auto& type : GenerateAllTypes()) {
+  for (auto& type : GenerateAllTypes()) {
     generated_types.insert(type->kind());
   }
 
   std::vector<Type::Kind> all_types;
-  for(uint32_t kind = 0; kind != Type::Kind::kLast; ++kind) {
+  for (uint32_t kind = 0; kind != Type::Kind::kLast; ++kind) {
     all_types.push_back(static_cast<Type::Kind>(kind));
   }
 

--- a/test/opt/type_manager_test.cpp
+++ b/test/opt/type_manager_test.cpp
@@ -167,8 +167,23 @@ std::vector<std::unique_ptr<Type>> GenerateAllTypes() {
   types.emplace_back(new NamedBarrier());
   types.emplace_back(new AccelerationStructureNV());
   types.emplace_back(new CooperativeMatrixNV(f32, 24, 24, 24));
+  types.emplace_back(new RayQueryKHR());
 
   return types;
+}
+
+TEST(TypeManager, GenerateAllTypesGeneratesAllTypes) {
+  std::set<Type::Kind> generated_types;
+  for(auto& type : GenerateAllTypes()) {
+    generated_types.insert(type->kind());
+  }
+
+  std::vector<Type::Kind> all_types;
+  for(uint32_t kind = 0; kind != Type::Kind::kLast; ++kind) {
+    all_types.push_back(static_cast<Type::Kind>(kind));
+  }
+
+  EXPECT_THAT(generated_types, testing::UnorderedElementsAreArray(all_types));
 }
 
 TEST(TypeManager, TypeStrings) {
@@ -1065,6 +1080,7 @@ TEST(TypeManager, GetTypeInstructionAllTypes) {
 ; CHECK: OpTypeNamedBarrier
 ; CHECK: OpTypeAccelerationStructureKHR
 ; CHECK: OpTypeCooperativeMatrixNV [[f32]] [[uint24]] [[uint24]] [[uint24]]
+; CHECK: OpTypeRayQueryKHR
 OpCapability Shader
 OpCapability Int64
 OpCapability Linkage


### PR DESCRIPTION
The handling of the RayQueryKHR type is not complete in the type
manager.  The tests were not picking this up.  I've added a test to make
sure that the `GenerateAllTypes` function actually does generate all of
the types.  Once it is added there other tests should pick up on the
other parts that were missing.
