### PR TITLE
Add OpModuleProcessed to debug opcode

### DIFF
--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2020 The Khronos Group Inc.
+// Copyright (c) 2015-2022 The Khronos Group Inc.
 // Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights
 // reserved.
 //
@@ -631,6 +631,7 @@ bool spvOpcodeIsDebug(SpvOp opcode) {
     case SpvOpString:
     case SpvOpLine:
     case SpvOpNoLine:
+    case SpvOpModuleProcessed:
       return true;
     default:
       return false;


### PR DESCRIPTION
This causes a strange artifact in a `spirv-dis --comment` because `OpModuleProcessed` wasn't in the `spvOpcodeIsDebug` and it is labeled as `"class"  : "Debug"` in the grammar file