### PR TITLE
Optimize Type::HashValue

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -448,6 +448,7 @@ static_library("spvtools") {
     "source/util/bit_vector.cpp",
     "source/util/bit_vector.h",
     "source/util/bitutils.h",
+    "source/util/hash_combine.h",
     "source/util/hex_float.h",
     "source/util/ilist.h",
     "source/util/ilist_node.h",

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -224,6 +224,7 @@ set(SPIRV_SOURCES
 
   ${CMAKE_CURRENT_SOURCE_DIR}/util/bitutils.h
   ${CMAKE_CURRENT_SOURCE_DIR}/util/bit_vector.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/util/hash_combine.h
   ${CMAKE_CURRENT_SOURCE_DIR}/util/hex_float.h
   ${CMAKE_CURRENT_SOURCE_DIR}/util/make_unique.h
   ${CMAKE_CURRENT_SOURCE_DIR}/util/parse_number.h

--- a/source/opt/types.cpp
+++ b/source/opt/types.cpp
@@ -182,8 +182,7 @@ bool Type::operator==(const Type& other) const {
   }
 }
 
-size_t Type::ComputeHashValue(size_t hash,
-                              std::vector<const Type*>* seen) const {
+size_t Type::ComputeHashValue(size_t hash, SeenTypes *seen) const {
   // Linear search through a dense, cache coherent vector is faster than O(log n)
   // search in a complex data structure (eg std::set) for the generally small 
   // number of nodes.  It also skips the overhead of an new/delete per Type 
@@ -241,7 +240,7 @@ size_t Type::ComputeHashValue(size_t hash,
 }
 
 size_t Type::HashValue() const {
-  std::vector<const Type*> seen;
+  SeenTypes seen;
   return ComputeHashValue(0, &seen);
 }
 
@@ -257,8 +256,7 @@ std::string Integer::str() const {
   return oss.str();
 }
 
-size_t Integer::ComputeExtraStateHash(size_t hash,
-                                      std::vector<const Type*>*) const {
+size_t Integer::ComputeExtraStateHash(size_t hash, SeenTypes* seen) const {
   return hash_combine(hash, width_, signed_);
 }
 
@@ -273,8 +271,7 @@ std::string Float::str() const {
   return oss.str();
 }
 
-size_t Float::ComputeExtraStateHash(size_t hash,
-                                    std::vector<const Type*>*) const {
+size_t Float::ComputeExtraStateHash(size_t hash, SeenTypes* seen) const {
   return hash_combine(hash, width_);
 }
 
@@ -297,7 +294,7 @@ std::string Vector::str() const {
   return oss.str();
 }
 
-size_t Vector::ComputeExtraStateHash(size_t hash, std::vector<const Type*>* seen) const {
+size_t Vector::ComputeExtraStateHash(size_t hash, SeenTypes* seen) const {
   // prefer form that doesn't require push/pop from stack: add state and
   // make tail call.
   hash = hash_combine(hash, count_);
@@ -323,7 +320,7 @@ std::string Matrix::str() const {
   return oss.str();
 }
 
-size_t Matrix::ComputeExtraStateHash(size_t hash, std::vector<const Type*>* seen) const {
+size_t Matrix::ComputeExtraStateHash(size_t hash, SeenTypes* seen) const {
   hash = hash_combine(hash, count_);
   return element_type_->ComputeHashValue(hash, seen);
 }
@@ -360,7 +357,7 @@ std::string Image::str() const {
   return oss.str();
 }
 
-size_t Image::ComputeExtraStateHash(size_t hash, std::vector<const Type*>* seen) const {
+size_t Image::ComputeExtraStateHash(size_t hash, SeenTypes* seen) const {
   hash = hash_combine(hash, dim_, depth_, arrayed_, ms_, sampled_, format_,
                       access_qualifier_);
   return sampled_type_->ComputeHashValue(hash, seen);
@@ -379,7 +376,7 @@ std::string SampledImage::str() const {
   return oss.str();
 }
 
-size_t SampledImage::ComputeExtraStateHash(size_t hash, std::vector<const Type*>* seen) const {
+size_t SampledImage::ComputeExtraStateHash(size_t hash, SeenTypes* seen) const {
   return image_type_->ComputeHashValue(hash, seen);
 }
 
@@ -413,7 +410,7 @@ std::string Array::str() const {
   return oss.str();
 }
 
-size_t Array::ComputeExtraStateHash(size_t hash, std::vector<const Type*>* seen) const {
+size_t Array::ComputeExtraStateHash(size_t hash, SeenTypes* seen) const {
   hash = hash_combine(hash, length_info_.words);
   return element_type_->ComputeHashValue(hash, seen);
 }
@@ -438,7 +435,7 @@ std::string RuntimeArray::str() const {
   return oss.str();
 }
 
-size_t RuntimeArray::ComputeExtraStateHash(size_t hash, std::vector<const Type*>* seen) const {
+size_t RuntimeArray::ComputeExtraStateHash(size_t hash, SeenTypes* seen) const {
   return element_type_->ComputeHashValue(hash, seen);
 }
 
@@ -496,7 +493,7 @@ std::string Struct::str() const {
   return oss.str();
 }
 
-size_t Struct::ComputeExtraStateHash(size_t hash, std::vector<const Type*>* seen) const {
+size_t Struct::ComputeExtraStateHash(size_t hash, SeenTypes* seen) const {
   for (auto* t : element_types_) {
     hash = t->ComputeHashValue(hash, seen);
   }
@@ -518,7 +515,7 @@ std::string Opaque::str() const {
   return oss.str();
 }
 
-size_t Opaque::ComputeExtraStateHash(size_t hash, std::vector<const Type*>*) const {
+size_t Opaque::ComputeExtraStateHash(size_t hash, SeenTypes*) const {
   return hash_combine(hash, name_);
 }
 
@@ -548,7 +545,7 @@ std::string Pointer::str() const {
   return os.str();
 }
 
-size_t Pointer::ComputeExtraStateHash(size_t hash, std::vector<const Type*>* seen) const {
+size_t Pointer::ComputeExtraStateHash(size_t hash, SeenTypes* seen) const {
   hash = hash_combine(hash, storage_class_);
   return pointee_type_->ComputeHashValue(hash, seen);
 }
@@ -584,7 +581,7 @@ std::string Function::str() const {
   return oss.str();
 }
 
-size_t Function::ComputeExtraStateHash(size_t hash, std::vector<const Type*>* seen) const {
+size_t Function::ComputeExtraStateHash(size_t hash, SeenTypes* seen) const {
   for (const auto* t : param_types_) {
     hash = t->ComputeHashValue(hash, seen);
   }
@@ -605,8 +602,7 @@ std::string Pipe::str() const {
   return oss.str();
 }
 
-size_t Pipe::ComputeExtraStateHash(size_t hash,
-                                   std::vector<const Type*>*) const {
+size_t Pipe::ComputeExtraStateHash(size_t hash, SeenTypes*) const {
   return hash_combine(hash, access_qualifier_);
 }
 
@@ -630,7 +626,7 @@ std::string ForwardPointer::str() const {
   return oss.str();
 }
 
-size_t ForwardPointer::ComputeExtraStateHash(size_t hash, std::vector<const Type*>* seen) const {
+size_t ForwardPointer::ComputeExtraStateHash(size_t hash, SeenTypes* seen) const {
   hash = hash_combine(hash, target_id_, storage_class_);
   if (pointer_) hash = pointer_->ComputeHashValue(hash, seen);
   return hash;
@@ -657,8 +653,8 @@ std::string CooperativeMatrixNV::str() const {
   return oss.str();
 }
 
-size_t CooperativeMatrixNV::ComputeExtraStateHash(
-    size_t hash, std::vector<const Type*>* seen) const {
+size_t CooperativeMatrixNV::ComputeExtraStateHash(size_t hash,
+                                                  SeenTypes* seen) const {
   hash = hash_combine(hash, scope_id_, rows_id_, columns_id_);
   return component_type_->ComputeHashValue(hash, seen);
 }

--- a/source/opt/types.cpp
+++ b/source/opt/types.cpp
@@ -182,23 +182,27 @@ bool Type::operator==(const Type& other) const {
   }
 }
 
-void Type::GetHashWords(std::vector<uint32_t>* words,
-                        std::unordered_set<const Type*>* seen) const {
-  if (!seen->insert(this).second) {
-    return;
+size_t Type::ComputeHashValue(size_t hash,
+                              std::vector<const Type*>* seen) const {
+  // Linear search through a dense, cache coherent vector is faster than O(log n)
+  // search in a complex data structure (eg std::set) for the generally small 
+  // number of nodes.  It also skips the overhead of an new/delete per Type 
+  // (when inserting/removing from a set).
+  if (std::find(seen->begin(), seen->end(), this) != seen->end()) {
+    return hash;
   }
 
-  words->push_back(kind_);
+  seen->push_back(this);
+  
+  hash = hash_combine(hash, kind_);
   for (const auto& d : decorations_) {
-    for (auto w : d) {
-      words->push_back(w);
-    }
+    hash = hash_combine(hash, d);
   }
 
   switch (kind_) {
-#define DeclareKindCase(type)                   \
-  case k##type:                                 \
-    As##type()->GetExtraHashWords(words, seen); \
+#define DeclareKindCase(type)                             \
+  case k##type:                                           \
+    hash = As##type()->ComputeExtraStateHash(hash, seen); \
     break
     DeclareKindCase(Void);
     DeclareKindCase(Bool);
@@ -232,18 +236,13 @@ void Type::GetHashWords(std::vector<uint32_t>* words,
       break;
   }
 
-  seen->erase(this);
+  seen->pop_back();
+  return hash;
 }
 
 size_t Type::HashValue() const {
-  std::u32string h;
-  std::vector<uint32_t> words;
-  GetHashWords(&words);
-  for (auto w : words) {
-    h.push_back(w);
-  }
-
-  return std::hash<std::u32string>()(h);
+  std::vector<const Type*> seen;
+  return ComputeHashValue(0, &seen);
 }
 
 bool Integer::IsSameImpl(const Type* that, IsSameCache*) const {
@@ -258,10 +257,9 @@ std::string Integer::str() const {
   return oss.str();
 }
 
-void Integer::GetExtraHashWords(std::vector<uint32_t>* words,
-                                std::unordered_set<const Type*>*) const {
-  words->push_back(width_);
-  words->push_back(signed_);
+size_t Integer::ComputeExtraStateHash(size_t hash,
+                                      std::vector<const Type*>*) const {
+  return hash_combine(hash, width_, signed_);
 }
 
 bool Float::IsSameImpl(const Type* that, IsSameCache*) const {
@@ -275,9 +273,9 @@ std::string Float::str() const {
   return oss.str();
 }
 
-void Float::GetExtraHashWords(std::vector<uint32_t>* words,
-                              std::unordered_set<const Type*>*) const {
-  words->push_back(width_);
+size_t Float::ComputeExtraStateHash(size_t hash,
+                                    std::vector<const Type*>*) const {
+  return hash_combine(hash, width_);
 }
 
 Vector::Vector(const Type* type, uint32_t count)
@@ -299,10 +297,11 @@ std::string Vector::str() const {
   return oss.str();
 }
 
-void Vector::GetExtraHashWords(std::vector<uint32_t>* words,
-                               std::unordered_set<const Type*>* seen) const {
-  element_type_->GetHashWords(words, seen);
-  words->push_back(count_);
+size_t Vector::ComputeExtraStateHash(size_t hash, std::vector<const Type*>* seen) const {
+  // prefer form that doesn't require push/pop from stack: add state and
+  // make tail call.
+  hash = hash_combine(hash, count_);
+  return element_type_->ComputeHashValue(hash, seen);
 }
 
 Matrix::Matrix(const Type* type, uint32_t count)
@@ -324,10 +323,9 @@ std::string Matrix::str() const {
   return oss.str();
 }
 
-void Matrix::GetExtraHashWords(std::vector<uint32_t>* words,
-                               std::unordered_set<const Type*>* seen) const {
-  element_type_->GetHashWords(words, seen);
-  words->push_back(count_);
+size_t Matrix::ComputeExtraStateHash(size_t hash, std::vector<const Type*>* seen) const {
+  hash = hash_combine(hash, count_);
+  return element_type_->ComputeHashValue(hash, seen);
 }
 
 Image::Image(Type* type, SpvDim dimen, uint32_t d, bool array, bool multisample,
@@ -362,16 +360,10 @@ std::string Image::str() const {
   return oss.str();
 }
 
-void Image::GetExtraHashWords(std::vector<uint32_t>* words,
-                              std::unordered_set<const Type*>* seen) const {
-  sampled_type_->GetHashWords(words, seen);
-  words->push_back(dim_);
-  words->push_back(depth_);
-  words->push_back(arrayed_);
-  words->push_back(ms_);
-  words->push_back(sampled_);
-  words->push_back(format_);
-  words->push_back(access_qualifier_);
+size_t Image::ComputeExtraStateHash(size_t hash, std::vector<const Type*>* seen) const {
+  hash = hash_combine(hash, dim_, depth_, arrayed_, ms_, sampled_, format_,
+                      access_qualifier_);
+  return sampled_type_->ComputeHashValue(hash, seen);
 }
 
 bool SampledImage::IsSameImpl(const Type* that, IsSameCache* seen) const {
@@ -387,9 +379,8 @@ std::string SampledImage::str() const {
   return oss.str();
 }
 
-void SampledImage::GetExtraHashWords(
-    std::vector<uint32_t>* words, std::unordered_set<const Type*>* seen) const {
-  image_type_->GetHashWords(words, seen);
+size_t SampledImage::ComputeExtraStateHash(size_t hash, std::vector<const Type*>* seen) const {
+  return image_type_->ComputeHashValue(hash, seen);
 }
 
 Array::Array(const Type* type, const Array::LengthInfo& length_info_arg)
@@ -422,11 +413,9 @@ std::string Array::str() const {
   return oss.str();
 }
 
-void Array::GetExtraHashWords(std::vector<uint32_t>* words,
-                              std::unordered_set<const Type*>* seen) const {
-  element_type_->GetHashWords(words, seen);
-  words->insert(words->end(), length_info_.words.begin(),
-                length_info_.words.end());
+size_t Array::ComputeExtraStateHash(size_t hash, std::vector<const Type*>* seen) const {
+  hash = hash_combine(hash, length_info_.words);
+  return element_type_->ComputeHashValue(hash, seen);
 }
 
 void Array::ReplaceElementType(const Type* type) { element_type_ = type; }
@@ -449,9 +438,8 @@ std::string RuntimeArray::str() const {
   return oss.str();
 }
 
-void RuntimeArray::GetExtraHashWords(
-    std::vector<uint32_t>* words, std::unordered_set<const Type*>* seen) const {
-  element_type_->GetHashWords(words, seen);
+size_t RuntimeArray::ComputeExtraStateHash(size_t hash, std::vector<const Type*>* seen) const {
+  return element_type_->ComputeHashValue(hash, seen);
 }
 
 void RuntimeArray::ReplaceElementType(const Type* type) {
@@ -508,19 +496,14 @@ std::string Struct::str() const {
   return oss.str();
 }
 
-void Struct::GetExtraHashWords(std::vector<uint32_t>* words,
-                               std::unordered_set<const Type*>* seen) const {
+size_t Struct::ComputeExtraStateHash(size_t hash, std::vector<const Type*>* seen) const {
   for (auto* t : element_types_) {
-    t->GetHashWords(words, seen);
+    hash = t->ComputeHashValue(hash, seen);
   }
   for (const auto& pair : element_decorations_) {
-    words->push_back(pair.first);
-    for (const auto& d : pair.second) {
-      for (auto w : d) {
-        words->push_back(w);
-      }
-    }
+    hash = hash_combine(hash, pair.first, pair.second);
   }
+  return hash;
 }
 
 bool Opaque::IsSameImpl(const Type* that, IsSameCache*) const {
@@ -535,11 +518,8 @@ std::string Opaque::str() const {
   return oss.str();
 }
 
-void Opaque::GetExtraHashWords(std::vector<uint32_t>* words,
-                               std::unordered_set<const Type*>*) const {
-  for (auto c : name_) {
-    words->push_back(static_cast<char32_t>(c));
-  }
+size_t Opaque::ComputeExtraStateHash(size_t hash, std::vector<const Type*>*) const {
+  return hash_combine(hash, name_);
 }
 
 Pointer::Pointer(const Type* type, SpvStorageClass sc)
@@ -568,10 +548,9 @@ std::string Pointer::str() const {
   return os.str();
 }
 
-void Pointer::GetExtraHashWords(std::vector<uint32_t>* words,
-                                std::unordered_set<const Type*>* seen) const {
-  pointee_type_->GetHashWords(words, seen);
-  words->push_back(storage_class_);
+size_t Pointer::ComputeExtraStateHash(size_t hash, std::vector<const Type*>* seen) const {
+  hash = hash_combine(hash, storage_class_);
+  return pointee_type_->ComputeHashValue(hash, seen);
 }
 
 void Pointer::SetPointeeType(const Type* type) { pointee_type_ = type; }
@@ -605,12 +584,11 @@ std::string Function::str() const {
   return oss.str();
 }
 
-void Function::GetExtraHashWords(std::vector<uint32_t>* words,
-                                 std::unordered_set<const Type*>* seen) const {
-  return_type_->GetHashWords(words, seen);
+size_t Function::ComputeExtraStateHash(size_t hash, std::vector<const Type*>* seen) const {
   for (const auto* t : param_types_) {
-    t->GetHashWords(words, seen);
+    hash = t->ComputeHashValue(hash, seen);
   }
+  return return_type_->ComputeHashValue(hash, seen);
 }
 
 void Function::SetReturnType(const Type* type) { return_type_ = type; }
@@ -627,9 +605,9 @@ std::string Pipe::str() const {
   return oss.str();
 }
 
-void Pipe::GetExtraHashWords(std::vector<uint32_t>* words,
-                             std::unordered_set<const Type*>*) const {
-  words->push_back(access_qualifier_);
+size_t Pipe::ComputeExtraStateHash(size_t hash,
+                                   std::vector<const Type*>*) const {
+  return hash_combine(hash, access_qualifier_);
 }
 
 bool ForwardPointer::IsSameImpl(const Type* that, IsSameCache*) const {
@@ -652,11 +630,10 @@ std::string ForwardPointer::str() const {
   return oss.str();
 }
 
-void ForwardPointer::GetExtraHashWords(
-    std::vector<uint32_t>* words, std::unordered_set<const Type*>* seen) const {
-  words->push_back(target_id_);
-  words->push_back(storage_class_);
-  if (pointer_) pointer_->GetHashWords(words, seen);
+size_t ForwardPointer::ComputeExtraStateHash(size_t hash, std::vector<const Type*>* seen) const {
+  hash = hash_combine(hash, target_id_, storage_class_);
+  if (pointer_) hash = pointer_->ComputeHashValue(hash, seen);
+  return hash;
 }
 
 CooperativeMatrixNV::CooperativeMatrixNV(const Type* type, const uint32_t scope,
@@ -680,12 +657,10 @@ std::string CooperativeMatrixNV::str() const {
   return oss.str();
 }
 
-void CooperativeMatrixNV::GetExtraHashWords(
-    std::vector<uint32_t>* words, std::unordered_set<const Type*>* pSet) const {
-  component_type_->GetHashWords(words, pSet);
-  words->push_back(scope_id_);
-  words->push_back(rows_id_);
-  words->push_back(columns_id_);
+size_t CooperativeMatrixNV::ComputeExtraStateHash(
+    size_t hash, std::vector<const Type*>* seen) const {
+  hash = hash_combine(hash, scope_id_, rows_id_, columns_id_);
+  return component_type_->ComputeHashValue(hash, seen);
 }
 
 bool CooperativeMatrixNV::IsSameImpl(const Type* that,

--- a/source/opt/types.cpp
+++ b/source/opt/types.cpp
@@ -21,8 +21,8 @@
 #include <string>
 #include <unordered_set>
 
-#include "source/util/make_unique.h"
 #include "source/util/hash_combine.h"
+#include "source/util/make_unique.h"
 #include "spirv/unified1/spirv.h"
 
 namespace spvtools {
@@ -185,16 +185,16 @@ bool Type::operator==(const Type& other) const {
 }
 
 size_t Type::ComputeHashValue(size_t hash, SeenTypes *seen) const {
-  // Linear search through a dense, cache coherent vector is faster than O(log n)
-  // search in a complex data structure (eg std::set) for the generally small 
-  // number of nodes.  It also skips the overhead of an new/delete per Type 
+  // Linear search through a dense, cache coherent vector is faster than O(log
+  // n) search in a complex data structure (eg std::set) for the generally small
+  // number of nodes.  It also skips the overhead of an new/delete per Type
   // (when inserting/removing from a set).
   if (std::find(seen->begin(), seen->end(), this) != seen->end()) {
     return hash;
   }
 
   seen->push_back(this);
-  
+
   hash = hash_combine(hash, kind_);
   for (const auto& d : decorations_) {
     hash = hash_combine(hash, d);
@@ -628,7 +628,8 @@ std::string ForwardPointer::str() const {
   return oss.str();
 }
 
-size_t ForwardPointer::ComputeExtraStateHash(size_t hash, SeenTypes* seen) const {
+size_t ForwardPointer::ComputeExtraStateHash(size_t hash,
+                                             SeenTypes* seen) const {
   hash = hash_combine(hash, target_id_, storage_class_);
   if (pointer_) hash = pointer_->ComputeHashValue(hash, seen);
   return hash;

--- a/source/opt/types.cpp
+++ b/source/opt/types.cpp
@@ -22,12 +22,14 @@
 #include <unordered_set>
 
 #include "source/util/make_unique.h"
+#include "source/util/hash_combine.h"
 #include "spirv/unified1/spirv.h"
 
 namespace spvtools {
 namespace opt {
 namespace analysis {
 
+using spvtools::utils::hash_combine;
 using U32VecVec = std::vector<std::vector<uint32_t>>;
 
 namespace {
@@ -256,7 +258,7 @@ std::string Integer::str() const {
   return oss.str();
 }
 
-size_t Integer::ComputeExtraStateHash(size_t hash, SeenTypes* seen) const {
+size_t Integer::ComputeExtraStateHash(size_t hash, SeenTypes*) const {
   return hash_combine(hash, width_, signed_);
 }
 
@@ -271,7 +273,7 @@ std::string Float::str() const {
   return oss.str();
 }
 
-size_t Float::ComputeExtraStateHash(size_t hash, SeenTypes* seen) const {
+size_t Float::ComputeExtraStateHash(size_t hash, SeenTypes*) const {
   return hash_combine(hash, width_);
 }
 

--- a/source/opt/types.cpp
+++ b/source/opt/types.cpp
@@ -195,7 +195,7 @@ size_t Type::ComputeHashValue(size_t hash, SeenTypes* seen) const {
 
   seen->push_back(this);
 
-  hash = hash_combine(hash, kind_);
+  hash = hash_combine(hash, uint32_t(kind_));
   for (const auto& d : decorations_) {
     hash = hash_combine(hash, d);
   }
@@ -360,8 +360,8 @@ std::string Image::str() const {
 }
 
 size_t Image::ComputeExtraStateHash(size_t hash, SeenTypes* seen) const {
-  hash = hash_combine(hash, dim_, depth_, arrayed_, ms_, sampled_, format_,
-                      access_qualifier_);
+  hash = hash_combine(hash, uint32_t(dim_), depth_, arrayed_, ms_, sampled_,
+                      uint32_t(format_), uint32_t(access_qualifier_));
   return sampled_type_->ComputeHashValue(hash, seen);
 }
 
@@ -548,7 +548,7 @@ std::string Pointer::str() const {
 }
 
 size_t Pointer::ComputeExtraStateHash(size_t hash, SeenTypes* seen) const {
-  hash = hash_combine(hash, storage_class_);
+  hash = hash_combine(hash, uint32_t(storage_class_));
   return pointee_type_->ComputeHashValue(hash, seen);
 }
 
@@ -605,7 +605,7 @@ std::string Pipe::str() const {
 }
 
 size_t Pipe::ComputeExtraStateHash(size_t hash, SeenTypes*) const {
-  return hash_combine(hash, access_qualifier_);
+  return hash_combine(hash, uint32_t(access_qualifier_));
 }
 
 bool ForwardPointer::IsSameImpl(const Type* that, IsSameCache*) const {
@@ -630,7 +630,7 @@ std::string ForwardPointer::str() const {
 
 size_t ForwardPointer::ComputeExtraStateHash(size_t hash,
                                              SeenTypes* seen) const {
-  hash = hash_combine(hash, target_id_, storage_class_);
+  hash = hash_combine(hash, target_id_, uint32_t(storage_class_));
   if (pointer_) hash = pointer_->ComputeHashValue(hash, seen);
   return hash;
 }

--- a/source/opt/types.cpp
+++ b/source/opt/types.cpp
@@ -184,7 +184,7 @@ bool Type::operator==(const Type& other) const {
   }
 }
 
-size_t Type::ComputeHashValue(size_t hash, SeenTypes *seen) const {
+size_t Type::ComputeHashValue(size_t hash, SeenTypes* seen) const {
   // Linear search through a dense, cache coherent vector is faster than O(log
   // n) search in a complex data structure (eg std::set) for the generally small
   // number of nodes.  It also skips the overhead of an new/delete per Type

--- a/source/opt/types.h
+++ b/source/opt/types.h
@@ -612,25 +612,25 @@ class CooperativeMatrixNV : public Type {
   const uint32_t columns_id_;
 };
 
-#define DefineParameterlessType(type, name)                                    \
-  class type : public Type {                                                   \
-   public:                                                                     \
-    type() : Type(k##type) {}                                                  \
-    type(const type&) = default;                                               \
-                                                                               \
-    std::string str() const override { return #name; }                         \
-                                                                               \
-    type* As##type() override { return this; }                                 \
-    const type* As##type() const override { return this; }                     \
-                                                                               \
-    size_t ComputeExtraStateHash(size_t hash, SeenTypes*) const override {     \
-      return hash;                                                             \
-    }                                                                          \
-                                                                               \
-   private:                                                                    \
-    bool IsSameImpl(const Type* that, IsSameCache*) const override {           \
-      return that->As##type() && HasSameDecorations(that);                     \
-    }                                                                          \
+#define DefineParameterlessType(type, name)                                \
+  class type : public Type {                                               \
+   public:                                                                 \
+    type() : Type(k##type) {}                                              \
+    type(const type&) = default;                                           \
+                                                                           \
+    std::string str() const override { return #name; }                     \
+                                                                           \
+    type* As##type() override { return this; }                             \
+    const type* As##type() const override { return this; }                 \
+                                                                           \
+    size_t ComputeExtraStateHash(size_t hash, SeenTypes*) const override { \
+      return hash;                                                         \
+    }                                                                      \
+                                                                           \
+   private:                                                                \
+    bool IsSameImpl(const Type* that, IsSameCache*) const override {       \
+      return that->As##type() && HasSameDecorations(that);                 \
+    }                                                                      \
   }
 DefineParameterlessType(Void, void);
 DefineParameterlessType(Bool, bool);

--- a/source/opt/types.h
+++ b/source/opt/types.h
@@ -198,30 +198,6 @@ protected:
   // Add any type-specific state to |hash| and returns new hash.
   virtual size_t ComputeExtraStateHash(size_t hash, SeenTypes* seen) const = 0;
 
-  // helpers for incrementally computing hash value
-  // http://open-std.org/jtc1/sc22/wg21/docs/papers/2014/n3876.pdf
-  template <typename T>
-  static size_t hash_combine(std::size_t seed, const T& val) {
-    return seed ^ std::hash<T>()(val) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-  }
-
-  static size_t hash_combine(std::size_t hash) {
-      return hash;
-  }
-
-  template <typename T, typename... Types>
-  static size_t hash_combine(std::size_t hash, const T& val, const Types&... args) {
-    return hash_combine(hash_combine(hash, val), args...);
-  }
-
-  template <typename T>
-  static size_t hash_combine(std::size_t hash, const std::vector<T>& vals) {
-    for (const T& val : vals) {
-      hash = hash_combine(hash, val);
-    }
-    return hash;
-  }
-
  protected:
   // Decorations attached to this type. Each decoration is encoded as a vector
   // of uint32_t numbers. The first uint32_t number is the decoration value,

--- a/source/util/hash_combine.h
+++ b/source/util/hash_combine.h
@@ -15,7 +15,8 @@
 #ifndef SOURCE_UTIL_HASH_COMBINE_H_
 #define SOURCE_UTIL_HASH_COMBINE_H_
 
-#include <cstdint>
+#include <cstddef>
+#include <functional>
 #include <vector>
 
 namespace spvtools {

--- a/source/util/hash_combine.h
+++ b/source/util/hash_combine.h
@@ -30,20 +30,20 @@ inline size_t hash_combine(std::size_t seed, const T& val) {
   return seed ^ (std::hash<T>()(val) + 0x9e3779b9 + (seed << 6) + (seed >> 2));
 }
 
-inline size_t hash_combine(std::size_t hash) { return hash; }
-
-template <typename T, typename... Types>
-inline size_t hash_combine(std::size_t hash, const T& val,
-                           const Types&... args) {
-  return hash_combine(hash_combine(hash, val), args...);
-}
-
 template <typename T>
 inline size_t hash_combine(std::size_t hash, const std::vector<T>& vals) {
   for (const T& val : vals) {
     hash = hash_combine(hash, val);
   }
   return hash;
+}
+
+inline size_t hash_combine(std::size_t hash) { return hash; }
+
+template <typename T, typename... Types>
+inline size_t hash_combine(std::size_t hash, const T& val,
+                           const Types&... args) {
+  return hash_combine(hash_combine(hash, val), args...);
 }
 
 }  // namespace utils

--- a/source/util/hash_combine.h
+++ b/source/util/hash_combine.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2022 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_UTIL_HASH_COMBINE_H_
+#define SOURCE_UTIL_HASH_COMBINE_H_
+
+#include <cstdint>
+#include <vector>
+
+namespace spvtools {
+namespace utils {
+
+// Helpers for incrementally computing hashes.
+// For reference, see http://open-std.org/jtc1/sc22/wg21/docs/papers/2014/n3876.pdf
+
+template <typename T>
+inline size_t hash_combine(std::size_t seed, const T& val) {
+  return seed ^ (std::hash<T>()(val) + 0x9e3779b9 + (seed << 6) + (seed >> 2));
+}
+
+inline size_t hash_combine(std::size_t hash) { return hash; }
+
+template <typename T, typename... Types>
+inline size_t hash_combine(std::size_t hash, const T& val,
+                           const Types&... args) {
+  return hash_combine(hash_combine(hash, val), args...);
+}
+
+template <typename T>
+inline size_t hash_combine(std::size_t hash, const std::vector<T>& vals) {
+  for (const T& val : vals) {
+    hash = hash_combine(hash, val);
+  }
+  return hash;
+}
+
+}  // namespace utils
+}  // namespace spvtools
+
+#endif  // SOURCE_UTIL_HASH_COMBINE_H_

--- a/source/util/hash_combine.h
+++ b/source/util/hash_combine.h
@@ -22,7 +22,8 @@ namespace spvtools {
 namespace utils {
 
 // Helpers for incrementally computing hashes.
-// For reference, see http://open-std.org/jtc1/sc22/wg21/docs/papers/2014/n3876.pdf
+// For reference, see
+// http://open-std.org/jtc1/sc22/wg21/docs/papers/2014/n3876.pdf
 
 template <typename T>
 inline size_t hash_combine(std::size_t seed, const T& val) {

--- a/source/util/small_vector.h
+++ b/source/util/small_vector.h
@@ -333,6 +333,7 @@ class SmallVector {
       large_data_->pop_back();
     } else {
       --size_;
+      small_data_[size_].~T();
     }
   }
 

--- a/source/util/small_vector.h
+++ b/source/util/small_vector.h
@@ -328,6 +328,14 @@ class SmallVector {
     ++size_;
   }
 
+  void pop_back() {
+    if (large_data_) {
+      large_data_->pop_back();
+    } else {
+      --size_;
+    }
+  }
+
   template <class InputIt>
   iterator insert(iterator pos, InputIt first, InputIt last) {
     size_t element_idx = (pos - begin());

--- a/test/util/CMakeLists.txt
+++ b/test/util/CMakeLists.txt
@@ -16,6 +16,7 @@ add_spvtools_unittest(TARGET utils
   SRCS ilist_test.cpp
        bit_vector_test.cpp
        bitutils_test.cpp
+       hash_combine_test.cpp
        small_vector_test.cpp
   LIBS SPIRV-Tools-opt
 )

--- a/test/util/hash_combine_test.cpp
+++ b/test/util/hash_combine_test.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2022 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <utility>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "source/util/hash_combine.h"
+
+namespace spvtools {
+namespace utils {
+namespace {
+
+using HashCombineTest = ::testing::Test;
+
+TEST(HashCombineTest, Identity) { EXPECT_EQ(hash_combine(0), 0); }
+
+TEST(HashCombineTest, Variadic) {
+  // Expect manual and variadic template versions be the same.
+  EXPECT_EQ(hash_combine(hash_combine(hash_combine(0, 1), 2), 3),
+            hash_combine(0, 1, 2, 3));
+}
+
+TEST(HashCombineTest, Vector) {
+  // Expect variadic and vector versions be the same.
+  EXPECT_EQ(hash_combine(0, std::vector<uint32_t>({1, 2, 3})),
+            hash_combine(0, 1, 2, 3));
+}
+
+
+}  // namespace
+}  // namespace utils
+}  // namespace spvtools

--- a/test/util/hash_combine_test.cpp
+++ b/test/util/hash_combine_test.cpp
@@ -38,7 +38,6 @@ TEST(HashCombineTest, Vector) {
             hash_combine(0, 1, 2, 3));
 }
 
-
 }  // namespace
 }  // namespace utils
 }  // namespace spvtools

--- a/test/util/small_vector_test.cpp
+++ b/test/util/small_vector_test.cpp
@@ -638,19 +638,19 @@ TEST(SmallVectorTest, Pop_back_TestDestructor) {
 
   EXPECT_EQ(num_ctors, capacity);
   while (!vec.empty()) {
-      vec.pop_back();
+    vec.pop_back();
   }
 
   EXPECT_EQ(num_ctors, capacity);
   EXPECT_EQ(num_dtors, num_ctors);
 
   // And when larger than builtin capacity
-  for (int i = 0; i < capacity*2; ++i) {
+  for (int i = 0; i < capacity * 2; ++i) {
     vec.emplace_back(num_ctors, num_dtors);
   }
 
   while (!vec.empty()) {
-      vec.pop_back();
+    vec.pop_back();
   }
   EXPECT_EQ(num_dtors, num_ctors);
 }

--- a/test/util/small_vector_test.cpp
+++ b/test/util/small_vector_test.cpp
@@ -605,6 +605,56 @@ TEST(SmallVectorTest, Pop_back) {
   EXPECT_EQ(vec, result);
 }
 
+TEST(SmallVectorTest, Pop_back_TestDestructor) {
+  // Tracks number of constructions and destructions to ensure they are called.
+  struct TracksDtor {
+    TracksDtor& operator=(TracksDtor&&) = delete;
+    TracksDtor& operator=(const TracksDtor&) = delete;
+
+    TracksDtor(int& num_ctors, int& num_dtors)
+        : num_ctors_(num_ctors), num_dtors_(num_dtors) {
+      num_ctors_++;
+    }
+    TracksDtor(const TracksDtor& that)
+        : TracksDtor(that.num_ctors_, that.num_dtors_) {}
+    TracksDtor(TracksDtor&& that)
+        : TracksDtor(that.num_ctors_, that.num_dtors_) {}
+    ~TracksDtor() { num_dtors_++; }
+
+    int& num_dtors_;
+    int& num_ctors_;
+  };
+
+  constexpr int capacity = 4;
+  SmallVector<TracksDtor, capacity> vec;
+
+  int num_ctors = 0;
+  int num_dtors = 0;
+
+  // Make sure it works when staying within the smallvector capacity
+  for (int i = 0; i < capacity; ++i) {
+    vec.emplace_back(num_ctors, num_dtors);
+  }
+
+  EXPECT_EQ(num_ctors, capacity);
+  while (!vec.empty()) {
+      vec.pop_back();
+  }
+
+  EXPECT_EQ(num_ctors, capacity);
+  EXPECT_EQ(num_dtors, num_ctors);
+
+  // And when larger than builtin capacity
+  for (int i = 0; i < capacity*2; ++i) {
+    vec.emplace_back(num_ctors, num_dtors);
+  }
+
+  while (!vec.empty()) {
+      vec.pop_back();
+  }
+  EXPECT_EQ(num_dtors, num_ctors);
+}
+
 }  // namespace
 }  // namespace utils
 }  // namespace spvtools

--- a/test/util/small_vector_test.cpp
+++ b/test/util/small_vector_test.cpp
@@ -621,8 +621,8 @@ TEST(SmallVectorTest, Pop_back_TestDestructor) {
         : TracksDtor(that.num_ctors_, that.num_dtors_) {}
     ~TracksDtor() { num_dtors_++; }
 
-    int& num_dtors_;
     int& num_ctors_;
+    int& num_dtors_;
   };
 
   constexpr int capacity = 4;

--- a/test/util/small_vector_test.cpp
+++ b/test/util/small_vector_test.cpp
@@ -593,6 +593,18 @@ TEST(SmallVectorTest, Resize6) {
   EXPECT_EQ(vec, result);
 }
 
+TEST(SmallVectorTest, Pop_back) {
+  SmallVector<uint32_t, 8> vec = {0, 1, 2, 10, 10, 10};
+  SmallVector<uint32_t, 8> result = {0, 1, 2};
+
+  EXPECT_EQ(vec.size(), 6);
+  vec.pop_back();
+  vec.pop_back();
+  vec.pop_back();
+  EXPECT_EQ(vec.size(), 3);
+  EXPECT_EQ(vec, result);
+}
+
 }  // namespace
 }  // namespace utils
 }  // namespace spvtools


### PR DESCRIPTION
Hello - this is 2/N, please see PR#4705 for context

This change is the result of seeing Type::HashValue was ~7.5% of our runtime when compiling shaders.  These changes get it down to < .5%.

First, we compute the hash incrementally instead of gathering the "words" into a std::vector, inserting them into a u32string, and then hashing that string.  This avoids two series of [re]allocations, and avoids making three total passes over the hashed data.

Next, instead of using a std::unordered_set to avoid processing duplicates, we use a std::vector -- the unordered_set requires an alloc/free when inserting/removing, and has a larger constant-factor than a linear search through a small, dense, cache coherent vector.  I've never seen the vector contain more than a few items.

Last, swap out the std::vector for a utils::SmallVector to avoid Type::HashValue making any allocations at all in the common case.