### PR TITLE
Avoid unnecessary reallocations in GetOperandConstants

### DIFF
--- a/source/opt/constants.cpp
+++ b/source/opt/constants.cpp
@@ -158,6 +158,7 @@ Type* ConstantManager::GetType(const Instruction* inst) const {
 std::vector<const Constant*> ConstantManager::GetOperandConstants(
     const Instruction* inst) const {
   std::vector<const Constant*> constants;
+  constants.reserve(inst->NumInOperands());
   for (uint32_t i = 0; i < inst->NumInOperands(); i++) {
     const Operand* operand = &inst->GetInOperand(i);
     if (operand->type != SPV_OPERAND_TYPE_ID) {


### PR DESCRIPTION
This is 3/N, for full context please see PR#4075.

Profiling revealed ConstantManager::GetOperandConstants was a surprisingly large source of allocations.  Since we know the exact size of the returned std::vector, we can reserve the capacity up-front.