### PR TITLE
Handle propagation of arrays with decorations

### DIFF
--- a/source/opt/copy_prop_arrays.cpp
+++ b/source/opt/copy_prop_arrays.cpp
@@ -745,11 +745,11 @@ void CopyPropagateArrays::UpdateUses(Instruction* original_ptr_inst,
           context()->AnalyzeUses(use);
         }
         break;
+      case SpvOpDecorate:
+      // We treat an OpImageTexelPointer as a load.  The result type should
+      // always have the Image storage class, and should not need to be
+      // updated.
       case SpvOpImageTexelPointer:
-        // We treat an OpImageTexelPointer as a load.  The result type should
-        // always have the Image storage class, and should not need to be
-        // updated.
-
         // Replace the actual use.
         context()->ForgetUses(use);
         use->SetOperand(index, {new_ptr_inst->result_id()});

--- a/source/opt/copy_prop_arrays.h
+++ b/source/opt/copy_prop_arrays.h
@@ -35,7 +35,7 @@ namespace opt {
 //
 // The hard part is keeping all of the types correct.  We do not want to
 // have to do too large a search to update everything, which may not be
-// possible, do we give up if we see any instruction that might be hard to
+// possible, so we give up if we see any instruction that might be hard to
 // update.
 
 class CopyPropagateArrays : public MemPass {

--- a/source/opt/replace_desc_array_access_using_var_index.cpp
+++ b/source/opt/replace_desc_array_access_using_var_index.cpp
@@ -254,8 +254,8 @@ void ReplaceDescArrayAccessUsingVarIndex::ReplaceNonUniformAccessWithSwitchCase(
     uint32_t number_of_elements,
     const std::deque<Instruction*>& insts_to_be_cloned) const {
   auto* block = context()->get_instr_block(access_chain_final_user);
-  // If instruction does not belong to a block (i.e. in the case of OpDecorate),
-  // no replacement needed
+  // If the instruction does not belong to a block (i.e. in the case of OpDecorate),
+  // no replacement is needed.
   if (!block) return;
 
   // Create merge block and add terminator

--- a/source/opt/replace_desc_array_access_using_var_index.cpp
+++ b/source/opt/replace_desc_array_access_using_var_index.cpp
@@ -253,8 +253,12 @@ void ReplaceDescArrayAccessUsingVarIndex::ReplaceNonUniformAccessWithSwitchCase(
     Instruction* access_chain_final_user, Instruction* access_chain,
     uint32_t number_of_elements,
     const std::deque<Instruction*>& insts_to_be_cloned) const {
-  // Create merge block and add terminator
   auto* block = context()->get_instr_block(access_chain_final_user);
+  // If instruction does not belong to a block (i.e. in the case of OpDecorate),
+  // no replacement needed
+  if (!block) return;
+
+  // Create merge block and add terminator
   auto* merge_block = SeparateInstructionsIntoNewBlock(
       block, access_chain_final_user->NextNode());
 

--- a/source/opt/replace_desc_array_access_using_var_index.cpp
+++ b/source/opt/replace_desc_array_access_using_var_index.cpp
@@ -254,8 +254,8 @@ void ReplaceDescArrayAccessUsingVarIndex::ReplaceNonUniformAccessWithSwitchCase(
     uint32_t number_of_elements,
     const std::deque<Instruction*>& insts_to_be_cloned) const {
   auto* block = context()->get_instr_block(access_chain_final_user);
-  // If the instruction does not belong to a block (i.e. in the case of OpDecorate),
-  // no replacement is needed.
+  // If the instruction does not belong to a block (i.e. in the case of
+  // OpDecorate), no replacement is needed.
   if (!block) return;
 
   // Create merge block and add terminator


### PR DESCRIPTION
When copy propagating, OpDecorate instructions can be copied as is. For
array flattening, they should be ignored.