### PR TITLE
spirv-opt: Add OpExecutionModeId support

### DIFF
--- a/source/opt/ir_loader.cpp
+++ b/source/opt/ir_loader.cpp
@@ -189,7 +189,8 @@ bool IrLoader::AddInstruction(const spv_parsed_instruction_t* inst) {
         module_->SetMemoryModel(std::move(spv_inst));
       } else if (opcode == SpvOpEntryPoint) {
         module_->AddEntryPoint(std::move(spv_inst));
-      } else if (opcode == SpvOpExecutionMode) {
+      } else if (opcode == SpvOpExecutionMode ||
+                 opcode == SpvOpExecutionModeId) {
         module_->AddExecutionMode(std::move(spv_inst));
       } else if (IsDebug1Inst(opcode)) {
         module_->AddDebug1Inst(std::move(spv_inst));


### PR DESCRIPTION
Needed for Vulkan1.3 adding `LocalSizeId` support

Came across when trying to add proper `LocalSizeId`/`SpecConstant` support for the Vulkan-Validation Layers (cc @ncesario-lunarg)