### PR TITLE
Don't rebuilt valid analyses.

### DIFF
--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -41,6 +41,8 @@ namespace spvtools {
 namespace opt {
 
 void IRContext::BuildInvalidAnalyses(IRContext::Analysis set) {
+  set &= ~valid_analyses_;
+
   if (set & kAnalysisDefUse) {
     BuildDefUseManager();
   }

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -41,7 +41,7 @@ namespace spvtools {
 namespace opt {
 
 void IRContext::BuildInvalidAnalyses(IRContext::Analysis set) {
-  set &= ~valid_analyses_;
+  set = Analysis(set & ~valid_analyses_);
 
   if (set & kAnalysisDefUse) {
     BuildDefUseManager();

--- a/source/opt/ir_context.h
+++ b/source/opt/ir_context.h
@@ -88,11 +88,8 @@ class IRContext {
 
   friend inline Analysis operator|(Analysis lhs, Analysis rhs);
   friend inline Analysis& operator|=(Analysis& lhs, Analysis rhs);
-  friend inline Analysis operator&(Analysis lhs, Analysis rhs);
-  friend inline Analysis& operator&=(Analysis& lhs, Analysis rhs);
   friend inline Analysis operator<<(Analysis a, int shift);
   friend inline Analysis& operator<<=(Analysis& a, int shift);
-  friend inline Analysis operator~(Analysis a);
 
   // Creates an |IRContext| that contains an owned |Module|
   IRContext(spv_target_env env, MessageConsumer c)
@@ -874,18 +871,6 @@ inline IRContext::Analysis& operator|=(IRContext::Analysis& lhs,
   return lhs;
 }
 
-inline IRContext::Analysis operator&(IRContext::Analysis lhs,
-                                     IRContext::Analysis rhs) {
-  return static_cast<IRContext::Analysis>(static_cast<int>(lhs) &
-                                          static_cast<int>(rhs));
-}
-
-inline IRContext::Analysis& operator&=(IRContext::Analysis& lhs,
-                                       IRContext::Analysis rhs) {
-  lhs = lhs & rhs;
-  return lhs;
-}
-
 inline IRContext::Analysis operator<<(IRContext::Analysis a, int shift) {
   return static_cast<IRContext::Analysis>(static_cast<int>(a) << shift);
 }
@@ -893,10 +878,6 @@ inline IRContext::Analysis operator<<(IRContext::Analysis a, int shift) {
 inline IRContext::Analysis& operator<<=(IRContext::Analysis& a, int shift) {
   a = static_cast<IRContext::Analysis>(static_cast<int>(a) << shift);
   return a;
-}
-
-inline IRContext::Analysis operator~(IRContext::Analysis a) {
-  return static_cast<IRContext::Analysis>(~static_cast<int>(a));
 }
 
 std::vector<Instruction*> IRContext::GetConstants() {

--- a/source/opt/ir_context.h
+++ b/source/opt/ir_context.h
@@ -88,8 +88,11 @@ class IRContext {
 
   friend inline Analysis operator|(Analysis lhs, Analysis rhs);
   friend inline Analysis& operator|=(Analysis& lhs, Analysis rhs);
+  friend inline Analysis operator&(Analysis lhs, Analysis rhs);
+  friend inline Analysis& operator&=(Analysis& lhs, Analysis rhs);
   friend inline Analysis operator<<(Analysis a, int shift);
   friend inline Analysis& operator<<=(Analysis& a, int shift);
+  friend inline Analysis operator~(Analysis a);
 
   // Creates an |IRContext| that contains an owned |Module|
   IRContext(spv_target_env env, MessageConsumer c)
@@ -867,8 +870,19 @@ inline IRContext::Analysis operator|(IRContext::Analysis lhs,
 
 inline IRContext::Analysis& operator|=(IRContext::Analysis& lhs,
                                        IRContext::Analysis rhs) {
-  lhs = static_cast<IRContext::Analysis>(static_cast<int>(lhs) |
-                                         static_cast<int>(rhs));
+  lhs = lhs | rhs;
+  return lhs;
+}
+
+inline IRContext::Analysis operator&(IRContext::Analysis lhs,
+                                     IRContext::Analysis rhs) {
+  return static_cast<IRContext::Analysis>(static_cast<int>(lhs) &
+                                          static_cast<int>(rhs));
+}
+
+inline IRContext::Analysis& operator&=(IRContext::Analysis& lhs,
+                                       IRContext::Analysis rhs) {
+  lhs = lhs & rhs;
   return lhs;
 }
 
@@ -879,6 +893,10 @@ inline IRContext::Analysis operator<<(IRContext::Analysis a, int shift) {
 inline IRContext::Analysis& operator<<=(IRContext::Analysis& a, int shift) {
   a = static_cast<IRContext::Analysis>(static_cast<int>(a) << shift);
   return a;
+}
+
+inline IRContext::Analysis operator~(IRContext::Analysis a) {
+  return static_cast<IRContext::Analysis>(~static_cast<int>(a));
 }
 
 std::vector<Instruction*> IRContext::GetConstants() {

--- a/source/opt/merge_return_pass.cpp
+++ b/source/opt/merge_return_pass.cpp
@@ -431,6 +431,7 @@ bool MergeReturnPass::BreakFromConstruct(
     std::list<BasicBlock*>* order, Instruction* break_merge_inst) {
   // Make sure the CFG is build here.  If we don't then it becomes very hard
   // to know which new blocks need to be updated.
+  context()->InvalidateAnalyses(IRContext::kAnalysisCFG);
   context()->BuildInvalidAnalyses(IRContext::kAnalysisCFG);
 
   // When predicating, be aware of whether this block is a header block, a

--- a/test/opt/ir_context_test.cpp
+++ b/test/opt/ir_context_test.cpp
@@ -90,6 +90,21 @@ TEST_F(IRContextTest, IndividualValidAfterBuild) {
   }
 }
 
+TEST_F(IRContextTest, DontRebuildValidAnalysis) {
+  std::unique_ptr<Module> module(new Module());
+  IRContext localContext(SPV_ENV_UNIVERSAL_1_2, std::move(module),
+                         spvtools::MessageConsumer());
+
+  auto* oldCfg = localContext.cfg();
+  auto* oldDefUse = localContext.get_def_use_mgr();
+  localContext.BuildInvalidAnalyses(IRContext::kAnalysisCFG |
+                                    IRContext::kAnalysisDefUse);
+  auto* newCfg = localContext.cfg();
+  auto* newDefUse = localContext.get_def_use_mgr();
+  EXPECT_EQ(oldCfg, newCfg);
+  EXPECT_EQ(oldDefUse, newDefUse);
+}
+
 TEST_F(IRContextTest, AllValidAfterBuild) {
   std::unique_ptr<Module> module = MakeUnique<Module>();
   IRContext localContext(SPV_ENV_UNIVERSAL_1_2, std::move(module),


### PR DESCRIPTION
In BuildInvalidAnalyses, we state that it will only rebuild the invalid
analyses.  However, the code will rebuild all analyses that have been
requested, even if they were already valid.

We fix that, and add a couple tests.  The tests cannot check every
analysis because there are no visible differences for all of the
analyses.  We test two of them as representatives.  Note that the new
code is generic, so this should be good enough.

Fixes #3635
