### PR TITLE
Generalize assert in ccp

### DIFF
--- a/source/opt/ccp_pass.cpp
+++ b/source/opt/ccp_pass.cpp
@@ -172,7 +172,8 @@ SSAPropagator::PropStatus CCPPass::VisitAssignment(Instruction* instr) {
   if (folded_inst != nullptr) {
     // We do not want to change the body of the function by adding new
     // instructions.  When folding we can only generate new constants.
-    assert(folded_inst->IsConstant() &&
+    assert((folded_inst->IsConstant() ||
+            IsSpecConstantInst(folded_inst->opcode())) &&
            "CCP is only interested in constant values.");
     uint32_t new_val = ComputeLatticeMeet(instr, folded_inst->result_id());
     values_[instr->result_id()] = new_val;


### PR DESCRIPTION
CCP does not want to fold an instruction unless it folds to a constant.
There is an asser to check for this.  The question if a spec constant
counts as a constant.  The constant folder considers a spec constant a
constand, but CCP does not.  I've fixed the assert in CCP to match what
the folder does.  It should not require any new changes to CCP.
