### PR TITLE
Fixed Bazel Windows build

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -81,6 +81,7 @@ genrule(
     srcs = ["@spirv_headers//:spirv_xml_registry"],
     outs = ["generators.inc"],
     cmd = "$(location generate_registry_tables) --xml=$(location @spirv_headers//:spirv_xml_registry) --generator-output=$(location generators.inc)",
+	cmd_bat = "$(location //:generate_registry_tables) --xml=$(location @spirv_headers//:spirv_xml_registry) --generator-output=$(location generators.inc)",
     tools = [":generate_registry_tables"],
 )
 
@@ -94,6 +95,7 @@ genrule(
     srcs = ["CHANGES"],
     outs = ["build-version.inc"],
     cmd = "SOURCE_DATE_EPOCH=0 $(location update_build_version) $$(dirname $(location CHANGES)) $(location build-version.inc)",
+	cmd_bat = "set SOURCE_DATE_EPOCH=0  && $(location //:update_build_version) \"$(location CHANGES)\\..\" $(location build-version.inc)",
     tools = [":update_build_version"],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -81,7 +81,7 @@ genrule(
     srcs = ["@spirv_headers//:spirv_xml_registry"],
     outs = ["generators.inc"],
     cmd = "$(location generate_registry_tables) --xml=$(location @spirv_headers//:spirv_xml_registry) --generator-output=$(location generators.inc)",
-	cmd_bat = "$(location //:generate_registry_tables) --xml=$(location @spirv_headers//:spirv_xml_registry) --generator-output=$(location generators.inc)",
+    cmd_bat = "$(location //:generate_registry_tables) --xml=$(location @spirv_headers//:spirv_xml_registry) --generator-output=$(location generators.inc)",
     tools = [":generate_registry_tables"],
 )
 
@@ -95,7 +95,7 @@ genrule(
     srcs = ["CHANGES"],
     outs = ["build-version.inc"],
     cmd = "SOURCE_DATE_EPOCH=0 $(location update_build_version) $$(dirname $(location CHANGES)) $(location build-version.inc)",
-	cmd_bat = "set SOURCE_DATE_EPOCH=0  && $(location //:update_build_version) \"$(location CHANGES)\\..\" $(location build-version.inc)",
+    cmd_bat = "set SOURCE_DATE_EPOCH=0  && $(location //:update_build_version) \"$(location CHANGES)\\..\" $(location build-version.inc)",
     tools = [":update_build_version"],
 )
 

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -68,6 +68,14 @@ def generate_core_tables(version = None):
             "--core-insts-output=$(location {3}) " +
             "--operand-kinds-output=$(location {4})"
         ).format(*fmtargs),
+        cmd_bat = (
+            "$(location :generate_grammar_tables) " +
+            "--spirv-core-grammar=$(location {0}) " +
+            "--extinst-debuginfo-grammar=$(location {1}) " +
+            "--extinst-cldebuginfo100-grammar=$(location {2}) " +
+            "--core-insts-output=$(location {3}) " +
+            "--operand-kinds-output=$(location {4})"
+        ).format(*fmtargs),
         tools = [":generate_grammar_tables"],
         visibility = ["//visibility:private"],
     )
@@ -97,6 +105,14 @@ def generate_enum_string_mapping(version = None):
             "--extension-enum-output=$(location {3}) " +
             "--enum-string-mapping-output=$(location {4})"
         ).format(*fmtargs),
+        cmd_bat = (
+            "$(location :generate_grammar_tables) " +
+            "--spirv-core-grammar=$(location {0}) " +
+            "--extinst-debuginfo-grammar=$(location {1}) " +
+            "--extinst-cldebuginfo100-grammar=$(location {2}) " +
+            "--extension-enum-output=$(location {3}) " +
+            "--enum-string-mapping-output=$(location {4})"
+        ).format(*fmtargs),
         tools = [":generate_grammar_tables"],
         visibility = ["//visibility:private"],
     )
@@ -118,6 +134,11 @@ def generate_opencl_tables(version = None):
             "--extinst-opencl-grammar=$(location {0}) " +
             "--opencl-insts-output=$(location {1})"
         ).format(*fmtargs),
+        cmd_bat = (
+            "$(location :generate_grammar_tables) " +
+            "--extinst-opencl-grammar=$(location {0}) " +
+            "--opencl-insts-output=$(location {1})"
+        ).format(*fmtargs),
         tools = [":generate_grammar_tables"],
         visibility = ["//visibility:private"],
     )
@@ -135,6 +156,11 @@ def generate_glsl_tables(version = None):
         srcs = grammars,
         outs = outs,
         cmd = (
+            "$(location :generate_grammar_tables) " +
+            "--extinst-glsl-grammar=$(location {0}) " +
+            "--glsl-insts-output=$(location {1})"
+        ).format(*fmtargs),
+        cmd_bat = (
             "$(location :generate_grammar_tables) " +
             "--extinst-glsl-grammar=$(location {0}) " +
             "--glsl-insts-output=$(location {1})"
@@ -161,6 +187,12 @@ def generate_vendor_tables(extension, operand_kind_prefix = ""):
             "--vendor-insts-output=$(location {1}) " +
             "--vendor-operand-kind-prefix={2}"
         ).format(*fmtargs),
+        cmd_bat = (
+            "$(location :generate_grammar_tables) " +
+            "--extinst-vendor-grammar=$(location {0}) " +
+            "--vendor-insts-output=$(location {1}) " +
+            "--vendor-operand-kind-prefix={2}"
+        ).format(*fmtargs),
         tools = [":generate_grammar_tables"],
         visibility = ["//visibility:private"],
     )
@@ -175,6 +207,11 @@ def generate_extinst_lang_headers(name, grammar = None):
         srcs = [grammar],
         outs = outs,
         cmd = (
+            "$(location :generate_language_headers) " +
+            "--extinst-grammar=$< " +
+            "--extinst-output-path=$(location {0})"
+        ).format(*fmtargs),
+        cmd_bat = (
             "$(location :generate_language_headers) " +
             "--extinst-grammar=$< " +
             "--extinst-output-path=$(location {0})"

--- a/kokoro/windows-msvc-2015-release-bazel/build.bat
+++ b/kokoro/windows-msvc-2015-release-bazel/build.bat
@@ -37,7 +37,6 @@ unzip -q bazel-0.29.1-windows-x86_64.zip
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
 set BAZEL_VS=C:\Program Files (x86)\Microsoft Visual Studio 14.0
 set BAZEL_VC=C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC
-set BAZEL_SH=c:\tools\msys64\usr\bin\bash.exe
 set BAZEL_PYTHON=c:\tools\python2\python.exe
 
 :: #########################################


### PR DESCRIPTION
Before this commit, the bazel build setup would not work on windows.
This is due to the fact, that genrule tries to use bash, which fails.
One fix would be to use bazel-skylib's run_binary.
This however does not work (easily) since genrules is more complex.

To (temporarily) fix the windows build, I added the `cmd_bat` property to every genrule.
This seems more like a hack, because it basically repeat commands,
 but for now it at least builds on windows.

I don't know if this is strictly necessary, since there is very little documentation of how to build this repo with bazel.