### PR TITLE
spirv-val: Label Vulkan VUID 04734

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -1882,6 +1882,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-OpMemoryBarrier-04732);
     case 4733:
       return VUID_WRAP(VUID-StandaloneSpirv-OpMemoryBarrier-04733);
+    case 4734:
+      return VUID_WRAP(VUID-StandaloneSpirv-OpVariable-04734);
     case 4780:
       return VUID_WRAP(VUID-StandaloneSpirv-Result-04780);
     case 4915:

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -4259,8 +4259,10 @@ OpFunctionEnd
   CompileSuccessfully(spirv.c_str(), SPV_ENV_VULKAN_1_0);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_0));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Variable initializers in Workgroup storage class are "
-                        "limited to OpConstantNull"));
+              AnyVUID(" VUID-StandaloneSpirv-OpVariable-04734"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpVariable, <id> '5[%5]', initializers are limited to "
+                        "OpConstantNull in Workgroup storage class"));
 }
 
 TEST_F(ValidateMemory, VulkanInitializerWithWorkgroupStorageClassGood) {


### PR DESCRIPTION
Add a label for `VUID-StandaloneSpirv-OpVariable-04734` as well as refactored error message and the logic be consistent in wrapping `spvIsVulkanEnv()` as the top check