### PR TITLE
Suppress -Wunqualified-std-cast-call

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -349,6 +349,10 @@ config("spvtools_internal_config") {
       "-Wno-newline-eof",
       "-Wno-unreachable-code-break",
       "-Wno-unreachable-code-return",
+
+      "-Wno-unknown-warning-option",
+      "-Wno-unqualified-std-cast-call",
+      "-Wunknown-warning-option",
     ]
   } else if (!is_win) {
     # Work around a false-positive on a Skia GCC 10 builder.


### PR DESCRIPTION
-Wunqualified-std-cast-call was added to Clang in
https://reviews.llvm.org/D119670, which using this project when building
with -Werror. This change ignores this error as a stopgap; eventually
the unqualified std::move() instances should be qualified.