### PR TITLE
Reset the id bound on the module in compact ids

### DIFF
--- a/source/opt/compact_ids_pass.cpp
+++ b/source/opt/compact_ids_pass.cpp
@@ -86,7 +86,8 @@ Pass::Status CompactIdsPass::Process() {
       },
       true);
 
-  if (modified) {
+  if (context()->module()->id_bound() != result_id_mapping.size() + 1) {
+    modified = true;
     context()->module()->SetIdBound(
         static_cast<uint32_t>(result_id_mapping.size() + 1));
     // There are ids in the feature manager that could now be invalid


### PR DESCRIPTION
If the body of the module does not have any ids change, compact ids will
not change the id bound.  This can cause problems because the id bound
could be much higher than the largest id in that is used.  It should be
reset any time it is not the larger id used +1.
    
Fixes #4604
