### PR TITLE
spirv-as: Add opcode name when possible

### DIFF
--- a/source/text.cpp
+++ b/source/text.cpp
@@ -623,7 +623,8 @@ spv_result_t spvTextEncodeOpcode(const spvtools::AssemblyGrammar& grammar,
           break;
         } else {
           return context->diagnostic()
-                 << "Expected operand, found end of stream.";
+                 << "Expected operand for " << opcodeName
+                 << " instruction, but found the end of the stream.";
         }
       }
       assert(error == SPV_SUCCESS && "Somebody added another way to fail");
@@ -633,7 +634,8 @@ spv_result_t spvTextEncodeOpcode(const spvtools::AssemblyGrammar& grammar,
           break;
         } else {
           return context->diagnostic()
-                 << "Expected operand, found next instruction instead.";
+                 << "Expected operand for " << opcodeName
+                 << " instruction, but found the next instruction instead.";
         }
       }
 
@@ -667,7 +669,7 @@ spv_result_t spvTextEncodeOpcode(const spvtools::AssemblyGrammar& grammar,
 
   if (pInst->words.size() > SPV_LIMIT_INSTRUCTION_WORD_COUNT_MAX) {
     return context->diagnostic()
-           << "Instruction too long: " << pInst->words.size()
+           << opcodeName << " Instruction too long: " << pInst->words.size()
            << " words, but the limit is "
            << SPV_LIMIT_INSTRUCTION_WORD_COUNT_MAX;
   }

--- a/test/c_interface_test.cpp
+++ b/test/c_interface_test.cpp
@@ -122,7 +122,10 @@ TEST(CInterface, SpecifyConsumerNullDiagnosticForAssembling) {
         EXPECT_EQ(1u, position.line);
         EXPECT_EQ(0u, position.column);
         EXPECT_EQ(12u, position.index);
-        EXPECT_STREQ("Expected operand, found end of stream.", message);
+        EXPECT_STREQ(
+            "Expected operand for OpName instruction, but found the end of the "
+            "stream.",
+            message);
       });
 
   spv_binary binary = nullptr;
@@ -228,7 +231,10 @@ TEST(CInterface, SpecifyConsumerSpecifyDiagnosticForAssembling) {
             spvTextToBinary(context, input_text, sizeof(input_text), &binary,
                             &diagnostic));
   EXPECT_EQ(0, invocation);  // Consumer should not be invoked at all.
-  EXPECT_STREQ("Expected operand, found end of stream.", diagnostic->error);
+  EXPECT_STREQ(
+      "Expected operand for OpName instruction, but found the end of the "
+      "stream.",
+      diagnostic->error);
 
   spvDiagnosticDestroy(diagnostic);
   spvBinaryDestroy(binary);

--- a/test/text_to_binary.annotation_test.cpp
+++ b/test/text_to_binary.annotation_test.cpp
@@ -398,7 +398,8 @@ TEST_F(TextToBinaryTest, GroupMemberDecorateGoodTwoTargets) {
 
 TEST_F(TextToBinaryTest, GroupMemberDecorateMissingGroupId) {
   EXPECT_THAT(CompileFailure("OpGroupMemberDecorate"),
-              Eq("Expected operand, found end of stream."));
+              Eq("Expected operand for OpGroupMemberDecorate instruction, but "
+                 "found the end of the stream."));
 }
 
 TEST_F(TextToBinaryTest, GroupMemberDecorateInvalidGroupId) {
@@ -413,7 +414,8 @@ TEST_F(TextToBinaryTest, GroupMemberDecorateInvalidTargetId) {
 
 TEST_F(TextToBinaryTest, GroupMemberDecorateMissingTargetMemberNumber) {
   EXPECT_THAT(CompileFailure("OpGroupMemberDecorate %group %id0"),
-              Eq("Expected operand, found end of stream."));
+              Eq("Expected operand for OpGroupMemberDecorate instruction, but "
+                 "found the end of the stream."));
 }
 
 TEST_F(TextToBinaryTest, GroupMemberDecorateInvalidTargetMemberNumber) {
@@ -428,7 +430,8 @@ TEST_F(TextToBinaryTest, GroupMemberDecorateInvalidSecondTargetId) {
 
 TEST_F(TextToBinaryTest, GroupMemberDecorateMissingSecondTargetMemberNumber) {
   EXPECT_THAT(CompileFailure("OpGroupMemberDecorate %group %id0 42 %id1"),
-              Eq("Expected operand, found end of stream."));
+              Eq("Expected operand for OpGroupMemberDecorate instruction, but "
+                 "found the end of the stream."));
 }
 
 TEST_F(TextToBinaryTest, GroupMemberDecorateInvalidSecondTargetMemberNumber) {

--- a/test/text_to_binary.barrier_test.cpp
+++ b/test/text_to_binary.barrier_test.cpp
@@ -44,7 +44,8 @@ TEST_F(OpMemoryBarrier, Good) {
 TEST_F(OpMemoryBarrier, BadMissingScopeId) {
   const std::string input = "OpMemoryBarrier\n";
   EXPECT_THAT(CompileFailure(input),
-              Eq("Expected operand, found end of stream."));
+              Eq("Expected operand for OpMemoryBarrier instruction, but found "
+                 "the end of the stream."));
 }
 
 TEST_F(OpMemoryBarrier, BadInvalidScopeId) {
@@ -55,7 +56,8 @@ TEST_F(OpMemoryBarrier, BadInvalidScopeId) {
 TEST_F(OpMemoryBarrier, BadMissingMemorySemanticsId) {
   const std::string input = "OpMemoryBarrier %scope\n";
   EXPECT_THAT(CompileFailure(input),
-              Eq("Expected operand, found end of stream."));
+              Eq("Expected operand for OpMemoryBarrier instruction, but found "
+                 "the end of the stream."));
 }
 
 TEST_F(OpMemoryBarrier, BadInvalidMemorySemanticsId) {
@@ -92,13 +94,16 @@ TEST_F(NamedMemoryBarrierTest, OpcodeAssemblesInV10) {
 
 TEST_F(NamedMemoryBarrierTest, ArgumentCount) {
   EXPECT_THAT(CompileFailure("OpMemoryNamedBarrier", SPV_ENV_UNIVERSAL_1_1),
-              Eq("Expected operand, found end of stream."));
+              Eq("Expected operand for OpMemoryNamedBarrier instruction, but "
+                 "found the end of the stream."));
   EXPECT_THAT(
       CompileFailure("OpMemoryNamedBarrier %bar", SPV_ENV_UNIVERSAL_1_1),
-      Eq("Expected operand, found end of stream."));
+      Eq("Expected operand for OpMemoryNamedBarrier instruction, but found the "
+         "end of the stream."));
   EXPECT_THAT(
       CompileFailure("OpMemoryNamedBarrier %bar %scope", SPV_ENV_UNIVERSAL_1_1),
-      Eq("Expected operand, found end of stream."));
+      Eq("Expected operand for OpMemoryNamedBarrier instruction, but found the "
+         "end of the stream."));
   EXPECT_THAT(
       CompiledInstructions("OpMemoryNamedBarrier %bar %scope %semantics",
                            SPV_ENV_UNIVERSAL_1_1),
@@ -151,10 +156,12 @@ TEST_F(NamedBarrierInitializeTest, OpcodeAssemblesInV10) {
 TEST_F(NamedBarrierInitializeTest, ArgumentCount) {
   EXPECT_THAT(
       CompileFailure("%bar = OpNamedBarrierInitialize", SPV_ENV_UNIVERSAL_1_1),
-      Eq("Expected operand, found end of stream."));
+      Eq("Expected operand for OpNamedBarrierInitialize instruction, but found "
+         "the end of the stream."));
   EXPECT_THAT(CompileFailure("%bar = OpNamedBarrierInitialize %ype",
                              SPV_ENV_UNIVERSAL_1_1),
-              Eq("Expected operand, found end of stream."));
+              Eq("Expected operand for OpNamedBarrierInitialize instruction, "
+                 "but found the end of the stream."));
   EXPECT_THAT(
       CompiledInstructions("%bar = OpNamedBarrierInitialize %type %count",
                            SPV_ENV_UNIVERSAL_1_1),

--- a/test/text_to_binary.control_flow_test.cpp
+++ b/test/text_to_binary.control_flow_test.cpp
@@ -163,7 +163,8 @@ TEST_F(TextToBinaryTest, SwitchGoodTwoTargets) {
 
 TEST_F(TextToBinaryTest, SwitchBadMissingSelector) {
   EXPECT_THAT(CompileFailure("OpSwitch"),
-              Eq("Expected operand, found end of stream."));
+              Eq("Expected operand for OpSwitch instruction, but found the end "
+                 "of the stream."));
 }
 
 TEST_F(TextToBinaryTest, SwitchBadInvalidSelector) {
@@ -173,7 +174,8 @@ TEST_F(TextToBinaryTest, SwitchBadInvalidSelector) {
 
 TEST_F(TextToBinaryTest, SwitchBadMissingDefault) {
   EXPECT_THAT(CompileFailure("OpSwitch %selector"),
-              Eq("Expected operand, found end of stream."));
+              Eq("Expected operand for OpSwitch instruction, but found the end "
+                 "of the stream."));
 }
 
 TEST_F(TextToBinaryTest, SwitchBadInvalidDefault) {
@@ -195,7 +197,8 @@ TEST_F(TextToBinaryTest, SwitchBadMissingTarget) {
   EXPECT_THAT(CompileFailure("%1 = OpTypeInt 32 0\n"
                              "%2 = OpConstant %1 52\n"
                              "OpSwitch %2 %default 12"),
-              Eq("Expected operand, found end of stream."));
+              Eq("Expected operand for OpSwitch instruction, but found the end "
+                 "of the stream."));
 }
 
 // A test case for an OpSwitch.

--- a/test/text_to_binary.device_side_enqueue_test.cpp
+++ b/test/text_to_binary.device_side_enqueue_test.cpp
@@ -83,7 +83,8 @@ TEST_F(OpKernelEnqueueBad, MissingLastOperand) {
       CompileFailure(
           "%result = OpEnqueueKernel %type %queue %flags %NDRange %num_events"
           " %wait_events %ret_event %invoke %param %param_size"),
-      Eq("Expected operand, found end of stream."));
+      Eq("Expected operand for OpEnqueueKernel instruction, but found the end "
+         "of the stream."));
 }
 
 TEST_F(OpKernelEnqueueBad, InvalidLastOperand) {

--- a/test/text_to_binary.image_test.cpp
+++ b/test/text_to_binary.image_test.cpp
@@ -123,7 +123,8 @@ TEST_F(OpImageTest, InvalidTypeOperand) {
 
 TEST_F(OpImageTest, MissingSampledImageOperand) {
   EXPECT_THAT(CompileFailure("%2 = OpImage %1"),
-              Eq("Expected operand, found end of stream."));
+              Eq("Expected operand for OpImage instruction, but found the end "
+                 "of the stream."));
 }
 
 TEST_F(OpImageTest, InvalidSampledImageOperand) {
@@ -222,7 +223,8 @@ TEST_F(OpImageSparseReadTest, InvalidTypeOperand) {
 
 TEST_F(OpImageSparseReadTest, MissingImageOperand) {
   EXPECT_THAT(CompileFailure("%2 = OpImageSparseRead %1"),
-              Eq("Expected operand, found end of stream."));
+              Eq("Expected operand for OpImageSparseRead instruction, but "
+                 "found the end of the stream."));
 }
 
 TEST_F(OpImageSparseReadTest, InvalidImageOperand) {
@@ -232,7 +234,8 @@ TEST_F(OpImageSparseReadTest, InvalidImageOperand) {
 
 TEST_F(OpImageSparseReadTest, MissingCoordinateOperand) {
   EXPECT_THAT(CompileFailure("%2 = OpImageSparseRead %1 %2"),
-              Eq("Expected operand, found end of stream."));
+              Eq("Expected operand for OpImageSparseRead instruction, but "
+                 "found the end of the stream."));
 }
 
 TEST_F(OpImageSparseReadTest, InvalidCoordinateOperand) {

--- a/test/text_to_binary.memory_test.cpp
+++ b/test/text_to_binary.memory_test.cpp
@@ -166,7 +166,8 @@ TEST_F(MemoryRoundTripTest, OpCopyMemoryNoMemAccessGood) {
 TEST_F(MemoryRoundTripTest, OpCopyMemoryTooFewArgsBad) {
   std::string spirv = "OpCopyMemory %1\n";
   std::string err = CompileFailure(spirv);
-  EXPECT_THAT(err, HasSubstr("Expected operand, found end of stream"));
+  EXPECT_THAT(err, HasSubstr("Expected operand for OpCopyMemory instruction, "
+                             "but found the end of the stream."));
 }
 
 TEST_F(MemoryRoundTripTest, OpCopyMemoryTooManyArgsBad) {
@@ -295,7 +296,8 @@ TEST_F(MemoryRoundTripTest, OpCopyMemorySizedNoMemAccessGood) {
 TEST_F(MemoryRoundTripTest, OpCopyMemorySizedTooFewArgsBad) {
   std::string spirv = "OpCopyMemorySized %1 %2\n";
   std::string err = CompileFailure(spirv);
-  EXPECT_THAT(err, HasSubstr("Expected operand, found end of stream"));
+  EXPECT_THAT(err, HasSubstr("Expected operand for OpCopyMemorySized "
+                             "instruction, but found the end of the stream."));
 }
 
 TEST_F(MemoryRoundTripTest, OpCopyMemorySizedTooManyArgsBad) {

--- a/test/text_to_binary.mode_setting_test.cpp
+++ b/test/text_to_binary.mode_setting_test.cpp
@@ -290,7 +290,8 @@ using TextToBinaryCapability = spvtest::TextToBinaryTest;
 
 TEST_F(TextToBinaryCapability, BadMissingCapability) {
   EXPECT_THAT(CompileFailure("OpCapability"),
-              Eq("Expected operand, found end of stream."));
+              Eq("Expected operand for OpCapability instruction, but found the "
+                 "end of the stream."));
 }
 
 TEST_F(TextToBinaryCapability, BadInvalidCapability) {

--- a/test/text_to_binary.pipe_storage_test.cpp
+++ b/test/text_to_binary.pipe_storage_test.cpp
@@ -59,10 +59,12 @@ TEST_F(OpConstantPipeStorageTest, ArgumentCount) {
          "'OpConstantPipeStorage'."));
   EXPECT_THAT(
       CompileFailure("%1 = OpConstantPipeStorage", SPV_ENV_UNIVERSAL_1_1),
-      Eq("Expected operand, found end of stream."));
+      Eq("Expected operand for OpConstantPipeStorage instruction, but found "
+         "the end of the stream."));
   EXPECT_THAT(CompileFailure("%1 = OpConstantPipeStorage %2 3 4",
                              SPV_ENV_UNIVERSAL_1_1),
-              Eq("Expected operand, found end of stream."));
+              Eq("Expected operand for OpConstantPipeStorage instruction, but "
+                 "found the end of the stream."));
   EXPECT_THAT(CompiledInstructions("%1 = OpConstantPipeStorage %2 3 4 5",
                                    SPV_ENV_UNIVERSAL_1_1),
               Eq(MakeInstruction(SpvOpConstantPipeStorage, {1, 2, 3, 4, 5})));
@@ -101,10 +103,12 @@ TEST_F(OpCreatePipeFromPipeStorageTest, ArgumentCount) {
          "'OpCreatePipeFromPipeStorage'."));
   EXPECT_THAT(
       CompileFailure("%1 = OpCreatePipeFromPipeStorage", SPV_ENV_UNIVERSAL_1_1),
-      Eq("Expected operand, found end of stream."));
+      Eq("Expected operand for OpCreatePipeFromPipeStorage instruction, but "
+         "found the end of the stream."));
   EXPECT_THAT(CompileFailure("%1 = OpCreatePipeFromPipeStorage %2 OpNop",
                              SPV_ENV_UNIVERSAL_1_1),
-              Eq("Expected operand, found next instruction instead."));
+              Eq("Expected operand for OpCreatePipeFromPipeStorage "
+                 "instruction, but found the next instruction instead."));
   EXPECT_THAT(CompiledInstructions("%1 = OpCreatePipeFromPipeStorage %2 %3",
                                    SPV_ENV_UNIVERSAL_1_1),
               Eq(MakeInstruction(SpvOpCreatePipeFromPipeStorage, {1, 2, 3})));

--- a/test/text_to_binary.subgroup_dispatch_test.cpp
+++ b/test/text_to_binary.subgroup_dispatch_test.cpp
@@ -46,11 +46,13 @@ TEST_F(OpGetKernelLocalSizeForSubgroupCountTest, ArgumentCount) {
                  "found 'OpGetKernelLocalSizeForSubgroupCount'."));
   EXPECT_THAT(CompileFailure("%res = OpGetKernelLocalSizeForSubgroupCount",
                              SPV_ENV_UNIVERSAL_1_1),
-              Eq("Expected operand, found end of stream."));
+              Eq("Expected operand for OpGetKernelLocalSizeForSubgroupCount "
+                 "instruction, but found the end of the stream."));
   EXPECT_THAT(
       CompileFailure("%1 = OpGetKernelLocalSizeForSubgroupCount %2 %3 %4 %5 %6",
                      SPV_ENV_UNIVERSAL_1_1),
-      Eq("Expected operand, found end of stream."));
+      Eq("Expected operand for OpGetKernelLocalSizeForSubgroupCount "
+         "instruction, but found the end of the stream."));
   EXPECT_THAT(
       CompiledInstructions("%res = OpGetKernelLocalSizeForSubgroupCount %type "
                            "%sgcount %invoke %param %param_size %param_align",
@@ -93,10 +95,12 @@ TEST_F(OpGetKernelMaxNumSubgroupsTest, ArgumentCount) {
          "'OpGetKernelMaxNumSubgroups'."));
   EXPECT_THAT(CompileFailure("%res = OpGetKernelMaxNumSubgroups",
                              SPV_ENV_UNIVERSAL_1_1),
-              Eq("Expected operand, found end of stream."));
+              Eq("Expected operand for OpGetKernelMaxNumSubgroups instruction, "
+                 "but found the end of the stream."));
   EXPECT_THAT(CompileFailure("%1 = OpGetKernelMaxNumSubgroups %2 %3 %4 %5",
                              SPV_ENV_UNIVERSAL_1_1),
-              Eq("Expected operand, found end of stream."));
+              Eq("Expected operand for OpGetKernelMaxNumSubgroups instruction, "
+                 "but found the end of the stream."));
   EXPECT_THAT(
       CompiledInstructions("%res = OpGetKernelMaxNumSubgroups %type "
                            "%invoke %param %param_size %param_align",

--- a/test/text_to_binary.type_declaration_test.cpp
+++ b/test/text_to_binary.type_declaration_test.cpp
@@ -223,12 +223,14 @@ TEST_F(OpTypeForwardPointerTest, ValidStorageClass) {
 
 TEST_F(OpTypeForwardPointerTest, MissingType) {
   EXPECT_THAT(CompileFailure("OpTypeForwardPointer"),
-              Eq("Expected operand, found end of stream."));
+              Eq("Expected operand for OpTypeForwardPointer instruction, but "
+                 "found the end of the stream."));
 }
 
 TEST_F(OpTypeForwardPointerTest, MissingClass) {
   EXPECT_THAT(CompileFailure("OpTypeForwardPointer %pt"),
-              Eq("Expected operand, found end of stream."));
+              Eq("Expected operand for OpTypeForwardPointer instruction, but "
+                 "found the end of the stream."));
 }
 
 TEST_F(OpTypeForwardPointerTest, WrongClass) {
@@ -252,7 +254,8 @@ TEST_F(OpSizeOfTest, ArgumentCount) {
       Eq("Expected <result-id> at the beginning of an instruction, found "
          "'OpSizeOf'."));
   EXPECT_THAT(CompileFailure("%res = OpSizeOf OpNop", SPV_ENV_UNIVERSAL_1_1),
-              Eq("Expected operand, found next instruction instead."));
+              Eq("Expected operand for OpSizeOf instruction, but found the "
+                 "next instruction instead."));
   EXPECT_THAT(
       CompiledInstructions("%1 = OpSizeOf %2 %3", SPV_ENV_UNIVERSAL_1_1),
       Eq(MakeInstruction(SpvOpSizeOf, {1, 2, 3})));


### PR DESCRIPTION
I find myself dealing with `spirv-as` failing and just giving me a line number which is not always helpful when the disassembled spirv is not available in a convenient way to make use of that information. This adds the opcode when possible on failure to help more quickly find the error