### PR TITLE
BUILD.gn: Enable independent builds within the Chromium tree

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -19,6 +19,12 @@ if (build_with_chromium) {
   import("//third_party/protobuf/proto_library.gni")
 }
 
+# SPIRV-Tools may be part of multiple projects in the Chromium tree.
+# Only enable building executables if this is the main copy, or standalone.
+abspath = get_path_info(".", "abspath")
+spvtools_chromium_third_party = (abspath == "//third_party/SPIRV-Tools/")
+spvtools_build_executables = !build_with_chromium || spvtools_chromium_third_party
+
 spirv_headers = spirv_tools_spirv_headers_dir
 spirv_is_winuwp = is_win && target_os == "winuwp"
 
@@ -875,7 +881,7 @@ static_library("spvtools_reduce") {
   configs += [ ":spvtools_internal_config" ]
 }
 
-if (build_with_chromium) {
+if (build_with_chromium && spvtools_build_executables) {
   # The spirv-fuzz library is only built when in a Chromium checkout
   # due to its dependency on protobuf.
 
@@ -1304,7 +1310,7 @@ group("SPIRV-Tools") {
 
 # The tests are scoped to Chromium to avoid needing to write gtest integration.
 # See Chromium's third_party/googletest/BUILD.gn for a complete integration.
-if (build_with_chromium) {
+if (build_with_chromium && spvtools_build_executables) {
   test("spvtools_test") {
     sources = [
       "test/assembly_context_test.cpp",
@@ -1413,73 +1419,75 @@ source_set("spvtools_software_version") {
   configs += [ ":spvtools_internal_config" ]
 }
 
-executable("spirv-as") {
-  sources = [ "tools/as/as.cpp" ]
-  deps = [
-    ":spvtools",
-    ":spvtools_software_version",
-  ]
-  configs += [ ":spvtools_internal_config" ]
+if (spvtools_build_executables) {
+  executable("spirv-as") {
+    sources = [ "tools/as/as.cpp" ]
+    deps = [
+      ":spvtools",
+      ":spvtools_software_version",
+    ]
+    configs += [ ":spvtools_internal_config" ]
+  }
+
+  executable("spirv-dis") {
+    sources = [ "tools/dis/dis.cpp" ]
+    deps = [
+      ":spvtools",
+      ":spvtools_software_version",
+    ]
+    configs += [ ":spvtools_internal_config" ]
+  }
+
+  executable("spirv-val") {
+    sources = [ "tools/val/val.cpp" ]
+    deps = [
+      ":spvtools",
+      ":spvtools_software_version",
+      ":spvtools_util_cli_consumer",
+      ":spvtools_val",
+    ]
+    configs += [ ":spvtools_internal_config" ]
+  }
+
+  executable("spirv-cfg") {
+    sources = [
+      "tools/cfg/bin_to_dot.cpp",
+      "tools/cfg/bin_to_dot.h",
+      "tools/cfg/cfg.cpp",
+    ]
+    deps = [
+      ":spvtools",
+      ":spvtools_software_version",
+    ]
+    configs += [ ":spvtools_internal_config" ]
+  }
+
+  executable("spirv-opt") {
+    sources = [ "tools/opt/opt.cpp" ]
+    deps = [
+      ":spvtools",
+      ":spvtools_opt",
+      ":spvtools_software_version",
+      ":spvtools_util_cli_consumer",
+      ":spvtools_val",
+    ]
+    configs += [ ":spvtools_internal_config" ]
+  }
+
+  executable("spirv-link") {
+    sources = [ "tools/link/linker.cpp" ]
+    deps = [
+      ":spvtools",
+      ":spvtools_link",
+      ":spvtools_opt",
+      ":spvtools_software_version",
+      ":spvtools_val",
+    ]
+    configs += [ ":spvtools_internal_config" ]
+  }
 }
 
-executable("spirv-dis") {
-  sources = [ "tools/dis/dis.cpp" ]
-  deps = [
-    ":spvtools",
-    ":spvtools_software_version",
-  ]
-  configs += [ ":spvtools_internal_config" ]
-}
-
-executable("spirv-val") {
-  sources = [ "tools/val/val.cpp" ]
-  deps = [
-    ":spvtools",
-    ":spvtools_software_version",
-    ":spvtools_util_cli_consumer",
-    ":spvtools_val",
-  ]
-  configs += [ ":spvtools_internal_config" ]
-}
-
-executable("spirv-cfg") {
-  sources = [
-    "tools/cfg/bin_to_dot.cpp",
-    "tools/cfg/bin_to_dot.h",
-    "tools/cfg/cfg.cpp",
-  ]
-  deps = [
-    ":spvtools",
-    ":spvtools_software_version",
-  ]
-  configs += [ ":spvtools_internal_config" ]
-}
-
-executable("spirv-opt") {
-  sources = [ "tools/opt/opt.cpp" ]
-  deps = [
-    ":spvtools",
-    ":spvtools_opt",
-    ":spvtools_software_version",
-    ":spvtools_util_cli_consumer",
-    ":spvtools_val",
-  ]
-  configs += [ ":spvtools_internal_config" ]
-}
-
-executable("spirv-link") {
-  sources = [ "tools/link/linker.cpp" ]
-  deps = [
-    ":spvtools",
-    ":spvtools_link",
-    ":spvtools_opt",
-    ":spvtools_software_version",
-    ":spvtools_val",
-  ]
-  configs += [ ":spvtools_internal_config" ]
-}
-
-if (!is_ios && !spirv_is_winuwp && build_with_chromium) {
+if (!is_ios && !spirv_is_winuwp && build_with_chromium && spvtools_build_executables) {
   # iOS and UWP do not allow std::system calls which spirv-fuzz
   # requires. Additionally, spirv-fuzz is only built when in a
   # Chromium checkout due to its dependency on protobuf.
@@ -1500,7 +1508,7 @@ if (!is_ios && !spirv_is_winuwp && build_with_chromium) {
   }
 }
 
-if (!is_ios && !spirv_is_winuwp) {
+if (!is_ios && !spirv_is_winuwp && spvtools_build_executables) {
   # iOS and UWP do not allow std::system calls which spirv-reduce
   # requires.
 
@@ -1518,19 +1526,21 @@ if (!is_ios && !spirv_is_winuwp) {
   }
 }
 
-group("all_spirv_tools") {
-  deps = [
-    ":spirv-as",
-    ":spirv-cfg",
-    ":spirv-dis",
-    ":spirv-link",
-    ":spirv-opt",
-    ":spirv-val",
-  ]
-  if (!is_ios && !spirv_is_winuwp && build_with_chromium) {
-    deps += [ ":spirv-fuzz" ]
-  }
-  if (!is_ios && !spirv_is_winuwp) {
-    deps += [ ":spirv-reduce" ]
+if (spvtools_build_executables){
+  group("all_spirv_tools") {
+    deps = [
+      ":spirv-as",
+      ":spirv-cfg",
+      ":spirv-dis",
+      ":spirv-link",
+      ":spirv-opt",
+      ":spirv-val",
+    ]
+    if (!is_ios && !spirv_is_winuwp && build_with_chromium) {
+      deps += [ ":spirv-fuzz" ]
+    }
+    if (!is_ios && !spirv_is_winuwp) {
+      deps += [ ":spirv-reduce" ]
+    }
   }
 }


### PR DESCRIPTION
GN does not allow multiple build files to declare the same executables,
so for SwiftShader to be able to use its own internal copy of SPIRV-
Tools libraries it needs to exclude the executable targets.

This is achieved by checking if the current path is //third-party/
SPIRV-Tools/.

Bug: b/158002593