### PR TITLE
Suppress -Wunused-but-set-variable on variable

### DIFF
--- a/source/util/ilist.h
+++ b/source/util/ilist.h
@@ -348,6 +348,7 @@ void IntrusiveList<NodeType>::Check(NodeType* start) {
     p = p->next_node_;
   } while (p != start);
   assert(sentinel_count == 1 && "List should have exactly 1 sentinel node.");
+  (void)sentinel_count;
 
   p = start;
   do {


### PR DESCRIPTION
sentinel_count is not used in non-assert builds.

Recent clang improvements to -Wunused-but-set-variable trigger a warning on this.

Fixes #4772.