### PR TITLE
Handle chains of OpAccessChain in flattened resources' variable index replacement

### DIFF
--- a/source/opt/replace_desc_array_access_using_var_index.cpp
+++ b/source/opt/replace_desc_array_access_using_var_index.cpp
@@ -95,7 +95,7 @@ void ReplaceDescArrayAccessUsingVarIndex::ReplaceUsersOfAccessChain(
   CollectRecursiveUsersWithConcreteType(access_chain, &final_users);
   for (auto* inst : final_users) {
     std::deque<Instruction*> insts_to_be_cloned =
-        CollectRequiredImageInsts(inst);
+        CollectRequiredImageAndAccessInsts(inst);
     ReplaceNonUniformAccessWithSwitchCase(
         inst, access_chain, number_of_elements, insts_to_be_cloned);
   }
@@ -121,8 +121,8 @@ void ReplaceDescArrayAccessUsingVarIndex::CollectRecursiveUsersWithConcreteType(
 }
 
 std::deque<Instruction*>
-ReplaceDescArrayAccessUsingVarIndex::CollectRequiredImageInsts(
-    Instruction* user_of_image_insts) const {
+ReplaceDescArrayAccessUsingVarIndex::CollectRequiredImageAndAccessInsts(
+    Instruction* user) const {
   std::unordered_set<uint32_t> seen_inst_ids;
   std::queue<Instruction*> work_list;
 
@@ -131,21 +131,23 @@ ReplaceDescArrayAccessUsingVarIndex::CollectRequiredImageInsts(
     if (!seen_inst_ids.insert(*idp).second) return;
     Instruction* operand = get_def_use_mgr()->GetDef(*idp);
     if (context()->get_instr_block(operand) != nullptr &&
-        HasImageOrImagePtrType(operand)) {
+        (HasImageOrImagePtrType(operand) ||
+         operand->opcode() == SpvOpAccessChain ||
+         operand->opcode() == SpvOpInBoundsAccessChain)) {
       work_list.push(operand);
     }
   };
 
-  std::deque<Instruction*> required_image_insts;
-  required_image_insts.push_front(user_of_image_insts);
-  user_of_image_insts->ForEachInId(decision_to_include_operand);
+  std::deque<Instruction*> required_insts;
+  required_insts.push_front(user);
+  user->ForEachInId(decision_to_include_operand);
   while (!work_list.empty()) {
     auto* inst_from_work_list = work_list.front();
     work_list.pop();
-    required_image_insts.push_front(inst_from_work_list);
+    required_insts.push_front(inst_from_work_list);
     inst_from_work_list->ForEachInId(decision_to_include_operand);
   }
-  return required_image_insts;
+  return required_insts;
 }
 
 bool ReplaceDescArrayAccessUsingVarIndex::HasImageOrImagePtrType(

--- a/source/opt/replace_desc_array_access_using_var_index.h
+++ b/source/opt/replace_desc_array_access_using_var_index.h
@@ -76,11 +76,12 @@ class ReplaceDescArrayAccessUsingVarIndex : public Pass {
   void CollectRecursiveUsersWithConcreteType(
       Instruction* access_chain, std::vector<Instruction*>* final_users) const;
 
-  // Recursively collects the operands of |user_of_image_insts| (and operands
-  // of the operands) whose result types are images/samplers or pointers/array/
-  // struct of them and returns them.
-  std::deque<Instruction*> CollectRequiredImageInsts(
-      Instruction* user_of_image_insts) const;
+  // Recursively collects the operands of |user| (and operands of the operands)
+  // whose result types are images/samplers (or pointers/arrays/ structs of
+  // them) and access chains instructions and returns them. The returned
+  // collection includes |user|.
+  std::deque<Instruction*> CollectRequiredImageAndAccessInsts(
+      Instruction* user) const;
 
   // Returns whether result type of |inst| is an image/sampler/pointer of image
   // or sampler or not.


### PR DESCRIPTION
Previously, a chain of `OpAccessChain` instructions would not be handled correctly by the `replace_desc_array_access_using_var_index` pass, which is required to legalize variable-index accesses to flattened resource arrays. The pass works by transforming each variable index access into a switch-case block where each case block references a constant index instead.

Consider this code in HLSL:
```
struct TestStruct
{
    uint unused;
    uint val;
};
ConstantBuffer<TestStruct> TestResources[2];

TestStruct test = TestResources[chosenIndex];
test.val; 
```
which becomes in SPIR-V:
```
%75 = OpAccessChain %85 %3 %90
%94 = OpAccessChain %93 %75 %6
%95 = OpLoad %5 %94
```

The `replace_desc_array_access_using_var_index` pass does not handle this case correctly, as it looks for final users of the first `OpAccessChain` (in this case, the only final user is the `OpLoad`) ignoring the second `OpAccessChain`. When the variable index is transformed into a switch-case of constant indices, `OpLoad` still references the second, unmodified `OpAccessChain`:

```
%94 = OpAccessChain %93 %75 %6
%95 = OpLoad %5 %94
OpSelectionMerge %96 None
OpSwitch %90 %103 0 %97 1 %100
%97 = OpLabel
%98 = OpAccessChain %85 %3 %6
%99 = OpLoad %5 %94
OpBranch %96
%100 = OpLabel
%101 = OpAccessChain %85 %3 %8
%102 = OpLoad %5 %94
OpBranch %96
%103 = OpLabel
OpBranch %96
%96 = OpLabel
%105 = OpPhi %5 %99 %97 %102 %100 %104 %103
```

This PR addresses this issue by making sure that `OpAccessChain` instructions are cloned into each case block (as it's already done for image instructions).