### PR TITLE
spirv-val: Add PerVertexKHR

### DIFF
--- a/source/val/validate_annotation.cpp
+++ b/source/val/validate_annotation.cpp
@@ -366,6 +366,11 @@ spv_result_t ValidateDecorationTarget(ValidationState_t& _, SpvDecoration dec,
           return fail(4670) << "storage class must be Input or Output";
         }
         break;
+      case SpvDecorationPerVertexKHR:
+        if (sc != SpvStorageClassInput) {
+          return fail(6777) << "storage class must be Input";
+        }
+        break;
       default:
         break;
     }

--- a/source/val/validate_interfaces.cpp
+++ b/source/val/validate_interfaces.cpp
@@ -273,6 +273,18 @@ spv_result_t GetLocationsForVariable(
     } else if (dec.dec_type() == SpvDecorationPerTaskNV) {
       has_per_task_nv = true;
     } else if (dec.dec_type() == SpvDecorationPerVertexKHR) {
+      if (!is_fragment) {
+        return _.diag(SPV_ERROR_INVALID_DATA, variable)
+               << _.VkErrorID(6777)
+               << "PerVertexKHR can only be applied to Fragment Execution "
+                  "Models";
+      }
+      if (type->opcode() != SpvOpTypeArray &&
+          type->opcode() != SpvOpTypeRuntimeArray) {
+        return _.diag(SPV_ERROR_INVALID_DATA, variable)
+               << _.VkErrorID(6778)
+               << "PerVertexKHR must be declared as arrays";
+      }
       has_per_vertex_khr = true;
     }
   }

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -1937,6 +1937,10 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-UniformConstant-06677);
     case 6678:
       return VUID_WRAP(VUID-StandaloneSpirv-InputAttachmentIndex-06678);
+    case 6777:
+      return VUID_WRAP(VUID-StandaloneSpirv-PerVertexKHR-06777);
+    case 6778:
+      return VUID_WRAP(VUID-StandaloneSpirv-Input-06778);
     default:
       return "";  // unknown id
   }


### PR DESCRIPTION
Add remaining validation for `SPV_KHR_fragment_shader_barycentric` for the `PerVertexKHR` decoration

Adds VUID `VUID-StandaloneSpirv-PerVertexKHR-06777` and `VUID-StandaloneSpirv-Input-06778`

tracker: https://github.com/KhronosGroup/Vulkan-Docs/issues/1863

cc @stu-s 