### PR TITLE
Fixed crash unrolling loops with residual iterations

### DIFF
--- a/source/opt/loop_unroller.cpp
+++ b/source/opt/loop_unroller.cpp
@@ -384,6 +384,7 @@ void LoopUnrollerUtilsImpl::PartiallyUnrollResidualFactor(Loop* loop,
   std::unique_ptr<Instruction> new_label{new Instruction(
       context_, SpvOp::SpvOpLabel, 0, context_->TakeNextId(), {})};
   std::unique_ptr<BasicBlock> new_exit_bb{new BasicBlock(std::move(new_label))};
+  new_exit_bb->SetParent(&function_);
 
   // Save the id of the block before we move it.
   uint32_t new_merge_id = new_exit_bb->id();


### PR DESCRIPTION
Current implementation crashes running pass configuration like this:

```cpp
  opt.RegisterPerformancePasses()
    .RegisterPass(spvtools::CreateStripDebugInfoPass())
    .RegisterPass(spvtools::CreateStripReflectInfoPass())
    // A pass I wrote to specialize loop ranges and it calls `LoopUtils::PartiallyUnroll`.
    .RegisterPass(spvtools::CreateMyPass())
    .RegisterPerformancePasses() // <- Crashed in a `DeadBranchElimPass` here
    ;
```

and the assertion failure reads:

```
Assertion failed: (block_to_move->GetParent() == ip->GetParent() && "Both blocks have to be in the same function."), function MoveBasicBlockToAfter, file function.h, line 234.
```

with the following stacktrace:

```
__pthread_kill (@__pthread_kill:5)
pthread_kill (@pthread_kill:75)
abort (@abort:44)
__assert_rtn (@err:3)
spvtools::opt::Function::MoveBasicBlockToAfter(unsigned int, spvtools::opt::BasicBlock*) (/Users/penguinliong/Repositories/SpirvToolsLab/third/SPIRV-Tools/source/opt/function.h:233)
spvtools::opt::DeadBranchElimPass::FixBlockOrder()::$_3::operator()(spvtools::opt::Function*) const (/Users/penguinliong/Repositories/SpirvToolsLab/third/SPIRV-Tools/source/opt/dead_branch_elim_pass.cpp:471)
decltype(static_cast<spvtools::opt::DeadBranchElimPass::FixBlockOrder()::$_3&>(fp)(static_cast<spvtools::opt::Function*>(fp0))) std::__1::__invoke<spvtools::opt::DeadBranchElimPass::FixBlockOrder()::$_3&, spvtools::opt::Function*>(spvtools::opt::DeadBranchElimPass::FixBlockOrder()::$_3&, spvtools::opt::Function*&&) (/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/type_traits:3918)
bool std::__1::__invoke_void_return_wrapper<bool, false>::__call<spvtools::opt::DeadBranchElimPass::FixBlockOrder()::$_3&, spvtools::opt::Function*>(spvtools::opt::DeadBranchElimPass::FixBlockOrder()::$_3&, spvtools::opt::Function*&&) (/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__functional/invoke.h:30)
std::__1::__function::__alloc_func<spvtools::opt::DeadBranchElimPass::FixBlockOrder()::$_3, std::__1::allocator<spvtools::opt::DeadBranchElimPass::FixBlockOrder()::$_3>, bool (spvtools::opt::Function*)>::operator()(spvtools::opt::Function*&&) (/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__functional/function.h:178)
std::__1::__function::__func<spvtools::opt::DeadBranchElimPass::FixBlockOrder()::$_3, std::__1::allocator<spvtools::opt::DeadBranchElimPass::FixBlockOrder()::$_3>, bool (spvtools::opt::Function*)>::operator()(spvtools::opt::Function*&&) (/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__functional/function.h:352)
std::__1::__function::__value_func<bool (spvtools::opt::Function*)>::operator()(spvtools::opt::Function*&&) const (/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__functional/function.h:505)
std::__1::function<bool (spvtools::opt::Function*)>::operator()(spvtools::opt::Function*) const (/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__functional/function.h:1182)
spvtools::opt::IRContext::ProcessCallTreeFromRoots(std::__1::function<bool (spvtools::opt::Function*)>&, std::__1::queue<unsigned int, std::__1::deque<unsigned int, std::__1::allocator<unsigned int> > >*) (/Users/penguinliong/Repositories/SpirvToolsLab/third/SPIRV-Tools/source/opt/ir_context.cpp:922)
spvtools::opt::IRContext::ProcessReachableCallTree(std::__1::function<bool (spvtools::opt::Function*)>&) (/Users/penguinliong/Repositories/SpirvToolsLab/third/SPIRV-Tools/source/opt/ir_context.cpp:907)
spvtools::opt::DeadBranchElimPass::FixBlockOrder() (/Users/penguinliong/Repositories/SpirvToolsLab/third/SPIRV-Tools/source/opt/dead_branch_elim_pass.cpp:478)
spvtools::opt::DeadBranchElimPass::Process() (/Users/penguinliong/Repositories/SpirvToolsLab/third/SPIRV-Tools/source/opt/dead_branch_elim_pass.cpp:495)
spvtools::opt::Pass::Run(spvtools::opt::IRContext*) (/Users/penguinliong/Repositories/SpirvToolsLab/third/SPIRV-Tools/source/opt/pass.cpp:40)
spvtools::opt::PassManager::Run(spvtools::opt::IRContext*) (/Users/penguinliong/Repositories/SpirvToolsLab/third/SPIRV-Tools/source/opt/pass_manager.cpp:58)
spvtools::Optimizer::Run(unsigned int const*, unsigned long, std::__1::vector<unsigned int, std::__1::allocator<unsigned int> >*, spv_optimizer_options_t*) const (/Users/penguinliong/Repositories/SpirvToolsLab/third/SPIRV-Tools/source/opt/optimizer.cpp:605)
spvtools::Optimizer::Run(unsigned int const*, unsigned long, std::__1::vector<unsigned int, std::__1::allocator<unsigned int> >*) const (/Users/penguinliong/Repositories/SpirvToolsLab/third/SPIRV-Tools/source/opt/optimizer.cpp:567)
guarded_main() (/Users/penguinliong/Repositories/SpirvToolsLab/src/app.cpp:129)
main (/Users/penguinliong/Repositories/SpirvToolsLab/src/app.cpp:181)
start (@start:133)
```