### PR TITLE
Avoid undefined divide-by-0

### DIFF
--- a/source/opt/folding_rules.cpp
+++ b/source/opt/folding_rules.cpp
@@ -277,6 +277,11 @@ uint32_t Reciprocal(analysis::ConstantManager* const_mgr,
   uint32_t width = c->type()->AsFloat()->width();
   assert(width == 32 || width == 64);
   std::vector<uint32_t> words;
+
+  if (c->IsZero()) {
+    return 0;
+  }
+
   if (width == 64) {
     spvtools::utils::FloatProxy<double> result(1.0 / c->GetDouble());
     if (!IsValidResult(result.getAsFloat())) return 0;


### PR DESCRIPTION
The Reciprocal function expects a divide-by-0 to return nan,and then Reciprocal will return 0.

Since the divide-by-0 is actually undefined, we will identify this case early, and return 0.

No new tests are needed because we already tests folding divide-by-0.

Fixes #4715
