### PR TITLE
Remove asserts that float type are same object

### DIFF
--- a/source/opt/const_folding_rules.cpp
+++ b/source/opt/const_folding_rules.cpp
@@ -1361,9 +1361,10 @@ UnaryScalarFoldingRule FoldFTranscendentalUnary(double (*fp)(double)) {
       [fp](const analysis::Type* result_type, const analysis::Constant* a,
            analysis::ConstantManager* const_mgr) -> const analysis::Constant* {
         assert(result_type != nullptr && a != nullptr);
+        assert(result_type->AsFloat() != nullptr);
         const analysis::Float* float_type = a->type()->AsFloat();
         assert(float_type != nullptr);
-        assert(float_type == result_type->AsFloat());
+        assert(float_type->width() == result_type->AsFloat()->width());
         if (float_type->width() == 32) {
           float fa = a->GetFloat();
           float res = static_cast<float>(fp(fa));

--- a/test/opt/simplification_test.cpp
+++ b/test/opt/simplification_test.cpp
@@ -385,6 +385,35 @@ OpFunctionEnd
 
   SinglePassRunAndCheck<SimplificationPass>(text, text, false);
 }
+
+TEST_F(SimplificationTest, EquivalantFloatTypes) {
+  const std::string text = R"(
+; CHECK: %float_0_540302277 = OpConstant %float 0.540302277
+; CHECK: OpStore {{%\w+}} %float_0_540302277
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main" %4
+               OpExecutionMode %2 OriginUpperLeft
+               OpDecorate %float RelaxedPrecision
+               OpDecorate %4 Location 0
+       %void = OpTypeVoid
+         %67 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %float_1 = OpConstant %float 1
+%_ptr_Output_float = OpTypePointer Output %float
+          %4 = OpVariable %_ptr_Output_float Output
+          %2 = OpFunction %void None %67
+        %117 = OpLabel
+        %126 = OpFNegate %float %float_1
+        %128 = OpExtInst %float %1 Cos %126
+               OpStore %4 %128
+               OpReturn
+               OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<SimplificationPass>(text, false);
+}
 }  // namespace
 }  // namespace opt
 }  // namespace spvtools


### PR DESCRIPTION
There is an assert that checks that two float types in a folding rule
have the same address in memory.  This is overly restrictive.  As long
as they are both float with the same size, there is no problem.  I've
relaxed the assert, and added a test.

Fixes #4723
