### PR TITLE
Do not check if the binary changed if encoding is different

### DIFF
--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -623,10 +623,16 @@ bool Optimizer::Run(const uint32_t* original_binary,
     assert(optimized_binary_with_nop.size() == original_binary_size &&
            "Binary size unexpectedly changed despite the optimizer saying "
            "there was no change");
-    assert(memcmp(optimized_binary_with_nop.data(), original_binary,
-                  original_binary_size) == 0 &&
-           "Binary content unexpectedly changed despite the optimizer saying "
-           "there was no change");
+
+    // Compare the magic number to make sure the binaries were encoded in the
+    // endianness.  If not, the contents of the binaries will be different, so
+    // do not check the contents.
+    if (optimized_binary_with_nop[0] == original_binary[0]) {
+      assert(memcmp(optimized_binary_with_nop.data(), original_binary,
+                    original_binary_size) == 0 &&
+             "Binary content unexpectedly changed despite the optimizer saying "
+             "there was no change");
+    }
   }
 #endif  // !NDEBUG
 


### PR DESCRIPTION
There is an assert that verifies that the binary did not change when the
optimizer said that it did not.  However, if the input binary is in big endian
format, the optimizer will encode the optimized binary in little endian.  This
causes the assert to fail.  Since we do not believe that anybody cares about a
big endien format, we will disable the assert in that case.
    
Fixes #4722
