### PR TITLE
spirv-val: Validate zero product workgroup size

### DIFF
--- a/source/val/validate_annotation.cpp
+++ b/source/val/validate_annotation.cpp
@@ -260,30 +260,15 @@ spv_result_t ValidateDecorationTarget(ValidationState_t& _, SpvDecoration dec,
       }
       break;
     case SpvDecorationBuiltIn:
-      if (target->opcode() != SpvOpVariable &&
-          !spvOpcodeIsConstant(target->opcode())) {
-        return _.diag(SPV_ERROR_INVALID_DATA, inst)
-               << "BuiltIns can only target variables, structure members or "
-                  "constants";
-      }
-      if (inst->GetOperandAs<SpvBuiltIn>(2) == SpvBuiltInWorkgroupSize) {
-        if (spvOpcodeIsConstant(target->opcode())) {
-          // can only validate product if static
-          uint64_t x_size, y_size, z_size;
-          bool static_x = _.GetConstantValUint64(target->word(3), &x_size);
-          bool static_y = _.GetConstantValUint64(target->word(4), &y_size);
-          bool static_z = _.GetConstantValUint64(target->word(5), &z_size);
-          if (static_x && static_y && static_z &&
-              ((x_size * y_size * z_size) == 0)) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << "WorkgroupSize decorations must not have a static "
-                      "product of zero.";
-          }
-        } else if (_.HasCapability(SpvCapabilityShader)) {
-          return fail(0) << "must be a constant for WorkgroupSize";
+      if (target->opcode() != SpvOpVariable) {
+        if (!spvOpcodeIsConstant(target->opcode())) {
+          return fail(0)
+                 << "BuiltIns can only target variables, structure members or "
+                    "constants";
+        } else if (inst->GetOperandAs<SpvBuiltIn>(2) !=
+                   SpvBuiltInWorkgroupSize) {
+          return fail(0) << "must be a variable";
         }
-      } else if (target->opcode() != SpvOpVariable) {
-        return fail(0) << "must be a variable";
       }
       break;
     case SpvDecorationNoPerspective:

--- a/source/val/validate_instruction.cpp
+++ b/source/val/validate_instruction.cpp
@@ -474,10 +474,8 @@ spv_result_t InstructionPass(ValidationState_t& _, const Instruction* inst) {
     }
     _.set_addressing_model(inst->GetOperandAs<SpvAddressingModel>(0));
     _.set_memory_model(inst->GetOperandAs<SpvMemoryModel>(1));
-  } else if (opcode == SpvOpExecutionMode) {
-    const uint32_t entry_point = inst->word(1);
-    _.RegisterExecutionModeForEntryPoint(entry_point,
-                                         SpvExecutionMode(inst->word(2)));
+  } else if (opcode == SpvOpExecutionMode || opcode == SpvOpExecutionModeId) {
+    _.RegisterExecutionModeForEntryPoint(inst);
   } else if (opcode == SpvOpVariable) {
     const auto storage_class = inst->GetOperandAs<SpvStorageClass>(2);
     if (auto error = LimitCheckNumVars(_, inst->id(), storage_class)) {

--- a/source/val/validate_mode_setting.cpp
+++ b/source/val/validate_mode_setting.cpp
@@ -286,6 +286,34 @@ spv_result_t ValidateEntryPoint(ValidationState_t& _, const Instruction* inst) {
     }
   }
 
+  const Instruction* local_size_inst =
+      _.GetLocalSizeInstruction(entry_point_id);
+  if (local_size_inst) {
+    const uint32_t x = local_size_inst->word(3);
+    const uint32_t y = local_size_inst->word(4);
+    const uint32_t z = local_size_inst->word(5);
+    if ((x * y * z) == 0) {
+      return _.diag(SPV_ERROR_INVALID_DATA, local_size_inst)
+             << "Local Size execution mode must not have a product of zero.";
+    }
+  }
+
+  const Instruction* local_size_id_inst =
+      _.GetLocalSizeIdInstruction(entry_point_id);
+  if (local_size_id_inst) {
+    uint64_t x_size, y_size, z_size;
+    bool static_x =
+        _.GetConstantValUint64(local_size_id_inst->word(3), &x_size);
+    bool static_y =
+        _.GetConstantValUint64(local_size_id_inst->word(4), &y_size);
+    bool static_z =
+        _.GetConstantValUint64(local_size_id_inst->word(5), &z_size);
+    if (static_x && static_y && static_z && ((x_size * y_size * z_size) == 0)) {
+      return _.diag(SPV_ERROR_INVALID_DATA, local_size_inst)
+             << "Local Size Id execution mode must not have a product of zero.";
+    }
+  }
+
   return SPV_SUCCESS;
 }
 

--- a/test/val/val_annotation_test.cpp
+++ b/test/val/val_annotation_test.cpp
@@ -402,14 +402,9 @@ OpDecorate %var BuiltIn )" +
 %var = OpVariable %ptr Input
 )";
 
+  // Workgroup are valid unless used with Vulkan env (VUID 04427)
   CompileSuccessfully(text);
-  if (deco != "WorkgroupSize") {
-    EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
-  } else {
-    EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-    EXPECT_THAT(getDiagnosticString(),
-                HasSubstr("must be a constant for WorkgroupSize"));
-  }
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
 TEST_P(BuiltInDecorations, IntegerType) {
@@ -424,7 +419,7 @@ OpDecorate %int BuiltIn )" +
 )";
 
   CompileSuccessfully(text);
-  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("BuiltIns can only target variables, structure members "
                         "or constants"));
@@ -448,7 +443,7 @@ OpFunctionEnd
 )";
 
   CompileSuccessfully(text);
-  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("BuiltIns can only target variables, structure members "
                         "or constants"));

--- a/test/val/val_builtins_test.cpp
+++ b/test/val/val_builtins_test.cpp
@@ -2923,7 +2923,7 @@ OpDecorate %copy BuiltIn WorkgroupSize
   generator.entry_points_.push_back(std::move(entry_point));
 
   CompileSuccessfully(generator.Build(), SPV_ENV_VULKAN_1_0);
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_0));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("BuiltIns can only target variables, structure "
                         "members or constants"));
@@ -3825,7 +3825,7 @@ OpDecorate %void BuiltIn Position
 )";
 
   CompileSuccessfully(text);
-  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("BuiltIns can only target variables, structure members "
                         "or constants"));

--- a/test/val/val_modes_test.cpp
+++ b/test/val/val_modes_test.cpp
@@ -106,7 +106,8 @@ OpDecorate %int3_1 BuiltIn WorkgroupSize
   EXPECT_THAT(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("WorkgroupSize decorations must not have a product of zero."));
+      HasSubstr(
+          "WorkgroupSize decorations must not have a static product of zero."));
 }
 
 TEST_F(ValidateMode, GLComputeZeroSpecWorkgroupSize) {
@@ -126,10 +127,11 @@ OpDecorate %int3_1 BuiltIn WorkgroupSize
   EXPECT_THAT(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("WorkgroupSize decorations must not have a product of zero."));
+      HasSubstr(
+          "WorkgroupSize decorations must not have a static product of zero."));
 }
 
-TEST_F(ValidateMode, KernelZeroWorkgroupSize) {
+TEST_F(ValidateMode, KernelZeroWorkgroupSizeConstant) {
   const std::string spirv = R"(
 OpCapability Addresses
 OpCapability Linkage
@@ -148,7 +150,26 @@ OpDecorate %int3_1 BuiltIn WorkgroupSize
   EXPECT_THAT(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("WorkgroupSize decorations must not have a product of zero."));
+      HasSubstr(
+          "WorkgroupSize decorations must not have a static product of zero."));
+}
+
+TEST_F(ValidateMode, KernelZeroWorkgroupSizeVariable) {
+  const std::string spirv = R"(
+OpCapability Addresses
+OpCapability Linkage
+OpCapability Kernel
+OpMemoryModel Physical32 OpenCL
+OpEntryPoint Kernel %main "main"
+OpDecorate %var BuiltIn WorkgroupSize
+%int = OpTypeInt 32 0
+%int3 = OpTypeVector %int 3
+%ptr = OpTypePointer Input %int3
+%var = OpVariable %ptr Input
+)" + kVoidFunction;
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
 TEST_F(ValidateMode, GLComputeVulkanLocalSize) {


### PR DESCRIPTION
closes https://github.com/KhronosGroup/SPIRV-Tools/issues/4801

Created a `EntryPointData` reduce number of hash maps with the `entry_point_id` as the key