### PR TITLE
Fix segfault in `SpirvTools::Disassemble` when printing

### DIFF
--- a/source/disassemble.cpp
+++ b/source/disassemble.cpp
@@ -114,20 +114,18 @@ spv_result_t Disassembler::HandleInstruction(
 }
 
 spv_result_t Disassembler::SaveTextResult(spv_text* text_result) const {
-  if (!print_) {
-    size_t length = text_.str().size();
-    char* str = new char[length + 1];
-    if (!str) return SPV_ERROR_OUT_OF_MEMORY;
-    strncpy(str, text_.str().c_str(), length + 1);
-    spv_text text = new spv_text_t();
-    if (!text) {
-      delete[] str;
-      return SPV_ERROR_OUT_OF_MEMORY;
-    }
-    text->str = str;
-    text->length = length;
-    *text_result = text;
+  size_t length = text_.str().size();
+  char* str = new char[length + 1];
+  if (!str) return SPV_ERROR_OUT_OF_MEMORY;
+  strncpy(str, text_.str().c_str(), length + 1);
+  spv_text text = new spv_text_t();
+  if (!text) {
+    delete[] str;
+    return SPV_ERROR_OUT_OF_MEMORY;
   }
+  text->str = str;
+  text->length = length;
+  *text_result = text;
   return SPV_SUCCESS;
 }
 

--- a/source/disassemble.cpp
+++ b/source/disassemble.cpp
@@ -114,18 +114,20 @@ spv_result_t Disassembler::HandleInstruction(
 }
 
 spv_result_t Disassembler::SaveTextResult(spv_text* text_result) const {
-  size_t length = text_.str().size();
-  char* str = new char[length + 1];
-  if (!str) return SPV_ERROR_OUT_OF_MEMORY;
-  strncpy(str, text_.str().c_str(), length + 1);
-  spv_text text = new spv_text_t();
-  if (!text) {
-    delete[] str;
-    return SPV_ERROR_OUT_OF_MEMORY;
+  if (!print_) {
+    size_t length = text_.str().size();
+    char* str = new char[length + 1];
+    if (!str) return SPV_ERROR_OUT_OF_MEMORY;
+    strncpy(str, text_.str().c_str(), length + 1);
+    spv_text text = new spv_text_t();
+    if (!text) {
+      delete[] str;
+      return SPV_ERROR_OUT_OF_MEMORY;
+    }
+    text->str = str;
+    text->length = length;
+    *text_result = text;
   }
-  text->str = str;
-  text->length = length;
-  *text_result = text;
   return SPV_SUCCESS;
 }
 

--- a/source/disassemble.h
+++ b/source/disassemble.h
@@ -25,9 +25,10 @@ namespace spvtools {
 
 // Decodes the given SPIR-V instruction binary representation to its assembly
 // text. The context is inferred from the provided module binary. The options
-// parameter is a bit field of spv_binary_to_text_options_t. Decoded text will
-// be stored into *text. Any error will be written into *diagnostic if
-// diagnostic is non-null.
+// parameter is a bit field of spv_binary_to_text_options_t (note: the option
+// SPV_BINARY_TO_TEXT_OPTION_PRINT will be ignored). Decoded text will be
+// stored into *text. Any error will be written into *diagnostic if diagnostic
+// is non-null.
 std::string spvInstructionBinaryToText(const spv_target_env env,
                                        const uint32_t* inst_binary,
                                        const size_t inst_word_count,

--- a/source/libspirv.cpp
+++ b/source/libspirv.cpp
@@ -99,7 +99,10 @@ bool SpirvTools::Disassemble(const uint32_t* binary, const size_t binary_size,
   spv_text spvtext = nullptr;
   spv_result_t status = spvBinaryToText(impl_->context, binary, binary_size,
                                         options, &spvtext, nullptr);
-  if (status == SPV_SUCCESS && spvtext != nullptr) {
+  if (status == SPV_SUCCESS) {
+    if (options & SPV_BINARY_TO_TEXT_OPTION_PRINT) {
+      assert(spvtext);// make sure spvtext is created even in printing mode
+    }
     text->assign(spvtext->str, spvtext->str + spvtext->length);
   }
   spvTextDestroy(spvtext);

--- a/source/libspirv.cpp
+++ b/source/libspirv.cpp
@@ -99,10 +99,9 @@ bool SpirvTools::Disassemble(const uint32_t* binary, const size_t binary_size,
   spv_text spvtext = nullptr;
   spv_result_t status = spvBinaryToText(impl_->context, binary, binary_size,
                                         options, &spvtext, nullptr);
-  if (status == SPV_SUCCESS) {
-    if (options & SPV_BINARY_TO_TEXT_OPTION_PRINT) {
-      assert(spvtext);  // make sure spvtext is created even in printing mode
-    }
+  if (status == SPV_SUCCESS &&
+      (options & SPV_BINARY_TO_TEXT_OPTION_PRINT) == 0) {
+    assert(spvtext);
     text->assign(spvtext->str, spvtext->str + spvtext->length);
   }
   spvTextDestroy(spvtext);

--- a/source/libspirv.cpp
+++ b/source/libspirv.cpp
@@ -101,7 +101,7 @@ bool SpirvTools::Disassemble(const uint32_t* binary, const size_t binary_size,
                                         options, &spvtext, nullptr);
   if (status == SPV_SUCCESS) {
     if (options & SPV_BINARY_TO_TEXT_OPTION_PRINT) {
-      assert(spvtext);// make sure spvtext is created even in printing mode
+      assert(spvtext);  // make sure spvtext is created even in printing mode
     }
     text->assign(spvtext->str, spvtext->str + spvtext->length);
   }

--- a/source/libspirv.cpp
+++ b/source/libspirv.cpp
@@ -99,7 +99,7 @@ bool SpirvTools::Disassemble(const uint32_t* binary, const size_t binary_size,
   spv_text spvtext = nullptr;
   spv_result_t status = spvBinaryToText(impl_->context, binary, binary_size,
                                         options, &spvtext, nullptr);
-  if (status == SPV_SUCCESS) {
+  if (status == SPV_SUCCESS && spvtext != nullptr) {
     text->assign(spvtext->str, spvtext->str + spvtext->length);
   }
   spvTextDestroy(spvtext);

--- a/test/binary_to_text_test.cpp
+++ b/test/binary_to_text_test.cpp
@@ -108,7 +108,7 @@ TEST_F(BinaryToText, Print) {
       SPV_SUCCESS,
       spvBinaryToText(context, binary->code, binary->wordCount,
                       SPV_BINARY_TO_TEXT_OPTION_PRINT, &text, &diagnostic));
-  ASSERT_NE(text, nullptr);
+  ASSERT_EQ(text, nullptr);
   spvTextDestroy(text);
 }
 

--- a/test/binary_to_text_test.cpp
+++ b/test/binary_to_text_test.cpp
@@ -101,6 +101,17 @@ TEST_F(BinaryToText, Default) {
   spvTextDestroy(text);
 }
 
+TEST_F(BinaryToText, Print) {
+  spv_text text = nullptr;
+  spv_diagnostic diagnostic = nullptr;
+  ASSERT_EQ(
+      SPV_SUCCESS,
+      spvBinaryToText(context, binary->code, binary->wordCount,
+                      SPV_BINARY_TO_TEXT_OPTION_PRINT, &text, &diagnostic));
+  ASSERT_NE(text, nullptr);
+  spvTextDestroy(text);
+}
+
 TEST_F(BinaryToText, MissingModule) {
   spv_text text;
   spv_diagnostic diagnostic = nullptr;


### PR DESCRIPTION
When the `SPV_BINARY_TO_TEXT_OPTION_PRINT` option is specified, `spvtext` will not be created: https://github.com/KhronosGroup/SPIRV-Tools/blob/37d2396cabe56b29d37551ea55d0d745d5748ded/source/disassemble.cpp#L116-L132

The attempt to afterwards dereference into its members (`spvtext->str` and `spvtext->length`) then results in segmentation fault:
https://github.com/KhronosGroup/SPIRV-Tools/blob/37d2396cabe56b29d37551ea55d0d745d5748ded/source/libspirv.cpp#L103

This PR adds a check on `spvtext`.