### PR TITLE
Fix unreachable loop increment

### DIFF
--- a/source/val/construct.cpp
+++ b/source/val/construct.cpp
@@ -78,10 +78,7 @@ Construct::ConstructBlockSet Construct::blocks(Function* /*function*/) const {
   const BasicBlock* continue_header = nullptr;
   if (is_loop) {
     // The only corresponding construct for a loop is the continue.
-    for (auto& other : corresponding_constructs()) {
-      continue_header = other->entry_block();
-      break;
-    }
+    continue_header = (*corresponding_constructs().begin())->entry_block();
   }
   std::vector<BasicBlock*> stack;
   stack.push_back(const_cast<BasicBlock*>(header));


### PR DESCRIPTION
* ANGLE builds with -Werror,-Wunreachable-code-loop-increment which had
  a problem with grabbing the first construct in a loop
  * Change the code to just use begin instead
