### PR TITLE
Use exec_tools instead of tools for better RBE compatibility

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -82,7 +82,7 @@ genrule(
     outs = ["generators.inc"],
     cmd = "$(location generate_registry_tables) --xml=$(location @spirv_headers//:spirv_xml_registry) --generator-output=$(location generators.inc)",
     cmd_bat = "$(location //:generate_registry_tables) --xml=$(location @spirv_headers//:spirv_xml_registry) --generator-output=$(location generators.inc)",
-    tools = [":generate_registry_tables"],
+    exec_tools = [":generate_registry_tables"],
 )
 
 py_binary(
@@ -96,7 +96,7 @@ genrule(
     outs = ["build-version.inc"],
     cmd = "SOURCE_DATE_EPOCH=0 $(location update_build_version) $(location CHANGES) $(location build-version.inc)",
     cmd_bat = "set SOURCE_DATE_EPOCH=0  && $(location //:update_build_version) $(location CHANGES) $(location build-version.inc)",
-    tools = [":update_build_version"],
+    exec_tools = [":update_build_version"],
 )
 
 # Libraries

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -76,7 +76,7 @@ def generate_core_tables(version = None):
             "--core-insts-output=$(location {3}) " +
             "--operand-kinds-output=$(location {4})"
         ).format(*fmtargs),
-        tools = [":generate_grammar_tables"],
+        exec_tools = [":generate_grammar_tables"],
         visibility = ["//visibility:private"],
     )
 
@@ -113,7 +113,7 @@ def generate_enum_string_mapping(version = None):
             "--extension-enum-output=$(location {3}) " +
             "--enum-string-mapping-output=$(location {4})"
         ).format(*fmtargs),
-        tools = [":generate_grammar_tables"],
+        exec_tools = [":generate_grammar_tables"],
         visibility = ["//visibility:private"],
     )
 
@@ -139,7 +139,7 @@ def generate_opencl_tables(version = None):
             "--extinst-opencl-grammar=$(location {0}) " +
             "--opencl-insts-output=$(location {1})"
         ).format(*fmtargs),
-        tools = [":generate_grammar_tables"],
+        exec_tools = [":generate_grammar_tables"],
         visibility = ["//visibility:private"],
     )
 
@@ -165,7 +165,7 @@ def generate_glsl_tables(version = None):
             "--extinst-glsl-grammar=$(location {0}) " +
             "--glsl-insts-output=$(location {1})"
         ).format(*fmtargs),
-        tools = [":generate_grammar_tables"],
+        exec_tools = [":generate_grammar_tables"],
         visibility = ["//visibility:private"],
     )
 
@@ -193,7 +193,7 @@ def generate_vendor_tables(extension, operand_kind_prefix = ""):
             "--vendor-insts-output=$(location {1}) " +
             "--vendor-operand-kind-prefix={2}"
         ).format(*fmtargs),
-        tools = [":generate_grammar_tables"],
+        exec_tools = [":generate_grammar_tables"],
         visibility = ["//visibility:private"],
     )
 
@@ -216,7 +216,7 @@ def generate_extinst_lang_headers(name, grammar = None):
             "--extinst-grammar=$< " +
             "--extinst-output-path=$(location {0})"
         ).format(*fmtargs),
-        tools = [":generate_language_headers"],
+        exec_tools = [":generate_language_headers"],
         visibility = ["//visibility:private"],
     )
 


### PR DESCRIPTION
I was running into issues building with Bazel on my Mac using a Linux [RBE](https://bazel.build/docs/remote-execution) worker. The reason was that Bazel was uploading the [Host platform](https://bazel.build/docs/platforms)'s (Mac) Python executables and not the Execution Platform (Linux)'s Python executables. Thus, I was seeing an error like:
`OSError: [Errno 8] Exec format error`

The [tools](https://bazel.build/reference/be/general#genrule.tools) attribute of genrules corresponds to the Host platform, but this is largely incorrect when using RBE. [exec_tools](https://bazel.build/reference/be/general#genrule.exec_tools) matches the execution platform, which is what is desired here. If building without RBE, the Host and Execution platform will be the same, and the difference between `exec_tools` and `tools` will not matter.