### PR TITLE
Use structural reachability in CFG checks

### DIFF
--- a/source/val/basic_block.cpp
+++ b/source/val/basic_block.cpp
@@ -30,6 +30,7 @@ BasicBlock::BasicBlock(uint32_t label_id)
       successors_(),
       type_(0),
       reachable_(false),
+      structurally_reachable_(false),
       label_(nullptr),
       terminator_(nullptr) {}
 

--- a/source/val/basic_block.h
+++ b/source/val/basic_block.h
@@ -84,8 +84,11 @@ class BasicBlock {
     return &structural_successors_;
   }
 
-  /// Returns true if the block is structurally reachable in the CFG.
+  /// Returns true if the block is reachable in the CFG.
   bool reachable() const { return reachable_; }
+
+  /// Returns true if the block is structurally reachable in the CFG.
+  bool structurally_reachable() const { return structurally_reachable_; }
 
   /// Returns true if BasicBlock is of the given type
   bool is_type(BlockType type) const {
@@ -95,6 +98,11 @@ class BasicBlock {
 
   /// Sets the reachability of the basic block in the CFG
   void set_reachable(bool reachability) { reachable_ = reachability; }
+
+  /// Sets the structural reachability of the basic block in the CFG
+  void set_structurally_reachable(bool reachability) {
+    structurally_reachable_ = reachability;
+  }
 
   /// Sets the type of the BasicBlock
   void set_type(BlockType type) {
@@ -282,6 +290,9 @@ class BasicBlock {
 
   /// True if the block is reachable in the CFG
   bool reachable_;
+
+  /// True if the block is structurally reachable in the CFG
+  bool structurally_reachable_;
 
   /// label of this block, if any.
   const Instruction* label_;

--- a/test/reduce/structured_loop_to_selection_test.cpp
+++ b/test/reduce/structured_loop_to_selection_test.cpp
@@ -2957,7 +2957,7 @@ TEST(StructuredLoopToSelectionReductionPassTest,
                OpLoopMerge %12 %13 None
                OpBranch %12
          %13 = OpLabel
-               OpBranchConditional %6 %9 %11
+               OpBranch %11
          %12 = OpLabel
                OpBranch %10
          %10 = OpLabel
@@ -2999,7 +2999,7 @@ TEST(StructuredLoopToSelectionReductionPassTest,
                OpLoopMerge %12 %13 None
                OpBranch %12
          %13 = OpLabel
-               OpBranchConditional %6 %9 %11
+               OpBranch %11
          %12 = OpLabel
                OpBranch %9
          %10 = OpLabel
@@ -3036,7 +3036,7 @@ TEST(StructuredLoopToSelectionReductionPassTest,
                OpSelectionMerge %12 None
                OpBranchConditional %6 %12 %12
          %13 = OpLabel
-               OpBranchConditional %6 %9 %11
+               OpBranch %11
          %12 = OpLabel
                OpBranch %9
          %10 = OpLabel
@@ -3050,8 +3050,7 @@ TEST(StructuredLoopToSelectionReductionPassTest,
 
 TEST(StructuredLoopToSelectionReductionPassTest,
      UnreachableInnerLoopContinueBranchingToOuterLoopMerge2) {
-  // In this test, the branch to the outer loop merge from the inner loop's
-  // continue is part of a structured selection.
+  // In this test, the unreachable continue is composed of multiple blocks.
   std::string shader = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
@@ -3073,8 +3072,7 @@ TEST(StructuredLoopToSelectionReductionPassTest,
                OpLoopMerge %12 %13 None
                OpBranch %12
          %13 = OpLabel
-               OpSelectionMerge %14 None
-               OpBranchConditional %6 %9 %14
+               OpBranch %14
          %14 = OpLabel
                OpBranch %11
          %12 = OpLabel
@@ -3118,8 +3116,7 @@ TEST(StructuredLoopToSelectionReductionPassTest,
                OpLoopMerge %12 %13 None
                OpBranch %12
          %13 = OpLabel
-               OpSelectionMerge %14 None
-               OpBranchConditional %6 %9 %14
+               OpBranch %14
          %14 = OpLabel
                OpBranch %11
          %12 = OpLabel
@@ -3158,8 +3155,7 @@ TEST(StructuredLoopToSelectionReductionPassTest,
                OpSelectionMerge %12 None
                OpBranchConditional %6 %12 %12
          %13 = OpLabel
-               OpSelectionMerge %14 None
-               OpBranchConditional %6 %9 %14
+               OpBranch %14
          %14 = OpLabel
                OpBranch %11
          %12 = OpLabel

--- a/test/val/val_cfg_test.cpp
+++ b/test/val/val_cfg_test.cpp
@@ -4555,6 +4555,35 @@ OpFunctionEnd
                         "must be different labels"));
 }
 
+TEST_F(ValidateCFG, BadBackEdgeUnreachableContinue) {
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+OpBranch %5
+%5 = OpLabel
+OpLoopMerge %6 %7 None
+OpBranch %8
+%8 = OpLabel
+OpBranch %5
+%7 = OpLabel
+OpUnreachable
+%6 = OpLabel
+OpUnreachable
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("The continue construct with the continue target 7[%7] "
+                        "does not dominate the back-edge block 8[%8]"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools

--- a/test/val/val_cfg_test.cpp
+++ b/test/val/val_cfg_test.cpp
@@ -4579,9 +4579,10 @@ OpFunctionEnd
 
   CompileSuccessfully(text);
   EXPECT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("The continue construct with the continue target 7[%7] "
-                        "does not dominate the back-edge block 8[%8]"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("The continue construct with the continue target 7[%7] "
+                "does not structurally dominate the back-edge block 8[%8]"));
 }
 
 }  // namespace


### PR DESCRIPTION
Fixes https://crbug.com/oss-fuzz/48578

* Adds structural reachability to basic blocks
  * calculated in same manner as reachability, but using structural
    successors
* Change structured CFG validation to use structural reachability
  instead of reachability
* Fix some invalid reducer cases