### PR TITLE
Fix small bug traversing users in interface_var_sroa

### DIFF
--- a/source/opt/interface_var_sroa.cpp
+++ b/source/opt/interface_var_sroa.cpp
@@ -212,8 +212,12 @@ void InterfaceVariableScalarReplacement::KillInstructionAndUsers(
     context()->KillInst(inst);
     return;
   }
+  std::vector<Instruction*> users;
   context()->get_def_use_mgr()->ForEachUser(
-      inst, [this](Instruction* user) { KillInstructionAndUsers(user); });
+      inst, [&users](Instruction* user) { users.push_back(user); });
+  for (auto user : users) {
+    context()->KillInst(user);
+  }
   context()->KillInst(inst);
 }
 


### PR DESCRIPTION
Fix code that is traversing def-use user structure at the same time
that it is changing it. This is dicey at best and error prone at worst.
This was uncovered making a change to the id_to_user representation.