### PR TITLE
Remove default copy constructor in header.

### DIFF
--- a/source/opt/merge_return_pass.h
+++ b/source/opt/merge_return_pass.h
@@ -118,8 +118,6 @@ class MergeReturnPass : public MemPass {
     StructuredControlState(Instruction* break_merge, Instruction* merge)
         : break_merge_(break_merge), current_merge_(merge) {}
 
-    StructuredControlState(const StructuredControlState&) = default;
-
     bool InBreakable() const { return break_merge_; }
     bool InStructuredFlow() const { return CurrentMergeId() != 0; }
 


### PR DESCRIPTION
A recent libc++ roll in Chrome warned of a deprecated copy. We're
still looking if this is a bug in libc++ or a valid warning, but
removing the redundant line is a safe workaround or fix in either
case.

See discussion in https://crrev.com/c/3791771

@alan-baker PTAL