### PR TITLE
Allow spirv-opt print-all to show pretty IDs

### DIFF
--- a/source/opt/pass_manager.cpp
+++ b/source/opt/pass_manager.cpp
@@ -39,7 +39,7 @@ Pass::Status PassManager::Run(IRContext* context) {
       t.SetMessageConsumer(consumer());
       std::string disassembly;
       std::string pass_name = (pass ? pass->name() : "");
-      if (!t.Disassemble(binary, &disassembly, 0)) {
+      if (!t.Disassemble(binary, &disassembly)) {
         std::string msg = "Disassembly failed before pass ";
         msg += pass_name + "\n";
         spv_position_t null_pos{0, 0, 0};


### PR DESCRIPTION
Disassembler was called with non-default params, loosing FRIENDLY_NAMES.
This commit changes the call options to allow the spirv-opt to show
friendly names instead of raw-ids. Might be more helpful when reading
the SPIRV-opt output.

Fixes #4882

Signed-off-by: Nathan Gauër <brioche@google.com>