### PR TITLE
Disable DebugInfoMgr during the entire CompactIds pass

### DIFF
--- a/source/opt/compact_ids_pass.cpp
+++ b/source/opt/compact_ids_pass.cpp
@@ -44,6 +44,11 @@ Pass::Status CompactIdsPass::Process() {
   bool modified = false;
   std::unordered_map<uint32_t, uint32_t> result_id_mapping;
 
+  // Disable automatic DebugInfo analysis for the life of the CompactIds pass.
+  // The DebugInfo manager requires the SPIR-V to be valid to run, but this is
+  // not true at all times in CompactIds as it remaps all ids.
+  context()->InvalidateAnalyses(IRContext::kAnalysisDebugInfo);
+
   context()->module()->ForEachInst(
       [&result_id_mapping, &modified](Instruction* inst) {
         auto operand = inst->begin();


### PR DESCRIPTION
This is because the DebugInfo manager requires valid SPIR-V
which is not always true during this pass.