### PR TITLE
spirv-opt: Remove unused fold spec const code

### DIFF
--- a/source/opt/fold_spec_constant_op_and_composite_pass.h
+++ b/source/opt/fold_spec_constant_op_and_composite_pass.h
@@ -58,22 +58,11 @@ class FoldSpecConstantOpAndCompositePass : public Pass {
   // |inst_iter_ptr| using the instruction folder.
   Instruction* FoldWithInstructionFolder(Module::inst_iterator* inst_iter_ptr);
 
-  // Try to fold the OpSpecConstantOp VectorShuffle instruction pointed by the
-  // given instruction iterator to a normal constant defining instruction.
-  // Returns the pointer to the new constant defining instruction if succeeded.
-  // Otherwise return nullptr.
-  Instruction* DoVectorShuffle(Module::inst_iterator* inst_iter_ptr);
-
   // Try to fold the OpSpecConstantOp <component wise operations> instruction
   // pointed by the given instruction iterator to a normal constant defining
   // instruction. Returns the pointer to the new constant defining instruction
   // if succeeded, otherwise return nullptr.
   Instruction* DoComponentWiseOperation(Module::inst_iterator* inst_iter_ptr);
-
-  // Returns the |element|'th subtype of |type|.
-  //
-  // |type| must be a composite type.
-  uint32_t GetTypeComponent(uint32_t type, uint32_t element) const;
 };
 
 }  // namespace opt

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -504,26 +504,6 @@ bool Instruction::IsReadOnlyPointerKernel() const {
   return storage_class == SpvStorageClassUniformConstant;
 }
 
-uint32_t Instruction::GetTypeComponent(uint32_t element) const {
-  uint32_t subtype = 0;
-  switch (opcode()) {
-    case SpvOpTypeStruct:
-      subtype = GetSingleWordInOperand(element);
-      break;
-    case SpvOpTypeArray:
-    case SpvOpTypeRuntimeArray:
-    case SpvOpTypeVector:
-    case SpvOpTypeMatrix:
-      // These types all have uniform subtypes.
-      subtype = GetSingleWordInOperand(0u);
-      break;
-    default:
-      break;
-  }
-
-  return subtype;
-}
-
 void Instruction::UpdateLexicalScope(uint32_t scope) {
   dbg_scope_.SetLexicalScope(scope);
   for (auto& i : dbg_line_insts_) {

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -504,10 +504,6 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   // Returns true if this instruction exits this function or aborts execution.
   bool IsReturnOrAbort() const { return spvOpcodeIsReturnOrAbort(opcode()); }
 
-  // Returns the id for the |element|'th subtype. If the |this| is not a
-  // composite type, this function returns 0.
-  uint32_t GetTypeComponent(uint32_t element) const;
-
   // Returns true if this instruction is a basic block terminator.
   bool IsBlockTerminator() const {
     return spvOpcodeIsBlockTerminator(opcode());


### PR DESCRIPTION
While looking into something else for `FoldSpecConstantOpAndCompositePass` it seems that over time things were moved out to `opt/fold.cpp` and `opt/folding_rules.cpp` and these functions are not being used and threw me off while trying to grasp how the pass worked at first.