### PR TITLE
spirv-val: Validate SpecConstantOp arguments

### DIFF
--- a/source/val/validate.cpp
+++ b/source/val/validate.cpp
@@ -375,6 +375,11 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
     if (auto error = ValidateSmallTypeUses(*vstate, &inst)) return error;
   }
 
+  // The following functions need to be end of the validation check because they
+  // will be creating a new instruciton out-of-stream that would interfere with
+  // other validation
+  if (auto error = ValidateSpecConstantOpValue(*vstate)) return error;
+
   return SPV_SUCCESS;
 }
 

--- a/source/val/validate.h
+++ b/source/val/validate.h
@@ -138,6 +138,7 @@ spv_result_t TypePass(ValidationState_t& _, const Instruction* inst);
 
 /// Validates constant instructions.
 spv_result_t ConstantPass(ValidationState_t& _, const Instruction* inst);
+spv_result_t ValidateSpecConstantOpValue(ValidationState_t& _);
 
 /// Validates correctness of arithmetic instructions.
 spv_result_t ArithmeticsPass(ValidationState_t& _, const Instruction* inst);

--- a/source/val/validate_constants.cpp
+++ b/source/val/validate_constants.cpp
@@ -467,11 +467,12 @@ spv_result_t ValidateSpecConstantOp(ValidationState_t& _,
     case SpvOpPtrCastToGeneric:
     case SpvOpBitcast:
     case SpvOpQuantizeToF16:
-      if (auto error = ConversionPass(_, &new_inst)) {
+      if (SPV_SUCCESS != ConversionPass(_, &new_inst)) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
                << "OpSpecConstantOp opcode " << spvOpcodeString(op)
                << " has invalid types or operands.";
       }
+      break;
     case SpvOpNot:
     case SpvOpShiftRightLogical:
     case SpvOpShiftRightArithmetic:
@@ -479,11 +480,12 @@ spv_result_t ValidateSpecConstantOp(ValidationState_t& _,
     case SpvOpBitwiseOr:
     case SpvOpBitwiseAnd:
     case SpvOpBitwiseXor:
-      if (auto error = BitwisePass(_, &new_inst)) {
+      if (SPV_SUCCESS != BitwisePass(_, &new_inst)) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
                << "OpSpecConstantOp opcode " << spvOpcodeString(op)
                << " has invalid types or operands.";
       }
+      break;
     case SpvOpSNegate:
     case SpvOpIAdd:
     case SpvOpISub:
@@ -500,19 +502,21 @@ spv_result_t ValidateSpecConstantOp(ValidationState_t& _,
     case SpvOpFDiv:
     case SpvOpFRem:
     case SpvOpFMod:
-      if (auto error = ArithmeticsPass(_, &new_inst)) {
+      if (SPV_SUCCESS != ArithmeticsPass(_, &new_inst)) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
                << "OpSpecConstantOp opcode " << spvOpcodeString(op)
                << " has invalid types or operands.";
       }
+      break;
     case SpvOpVectorShuffle:
     case SpvOpCompositeExtract:
     case SpvOpCompositeInsert:
-      if (auto error = CompositesPass(_, &new_inst)) {
+      if (SPV_SUCCESS != CompositesPass(_, &new_inst)) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
                << "OpSpecConstantOp opcode " << spvOpcodeString(op)
                << " has invalid types or operands.";
       }
+      break;
     case SpvOpLogicalOr:
     case SpvOpLogicalAnd:
     case SpvOpLogicalNot:
@@ -529,21 +533,23 @@ spv_result_t ValidateSpecConstantOp(ValidationState_t& _,
     case SpvOpSLessThanEqual:
     case SpvOpUGreaterThanEqual:
     case SpvOpSGreaterThanEqual:
-      if (auto error = LogicalsPass(_, &new_inst)) {
+      if (SPV_SUCCESS != LogicalsPass(_, &new_inst)) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
                << "OpSpecConstantOp opcode " << spvOpcodeString(op)
                << " has invalid types or operands.";
       }
+      break;
     case SpvOpAccessChain:
     case SpvOpInBoundsAccessChain:
     case SpvOpPtrAccessChain:
     case SpvOpInBoundsPtrAccessChain:
     case SpvOpCooperativeMatrixLengthNV:
-      if (auto error = MemoryPass(_, &new_inst)) {
+      if (SPV_SUCCESS != MemoryPass(_, &new_inst)) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
                << "OpSpecConstantOp opcode " << spvOpcodeString(op)
                << " has invalid types or operands.";
       }
+      break;
     default:
       break;
   }

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -506,6 +506,16 @@ class ValidationState_t {
   /// Inserts a new <id> to the set of Local Variables.
   void registerLocalVariable(const uint32_t id) { local_vars_.insert(id); }
 
+  /// Returns the list of OpSpecConstantOp instructions.
+  std::vector<const Instruction*>& spec_constant_ops() {
+    return spec_costant_ops_;
+  }
+
+  /// Inserts a new instruciton to the list of OpSpecConstantOp
+  void registerSpecConstantOp(const Instruction* inst) {
+    spec_costant_ops_.push_back(inst);
+  }
+
   // Returns true if using relaxed block layout, equivalent to
   // VK_KHR_relaxed_block_layout.
   bool IsRelaxedBlockLayout() const {
@@ -880,6 +890,9 @@ class ValidationState_t {
   /// Using ordered set to avoid the need for a vector hash function.
   /// The size of this container is expected not to exceed double-digits.
   std::set<std::vector<uint32_t>> unique_type_declarations_;
+
+  /// All the OpSpecConstantOp to be validated separately
+  std::vector<const Instruction*> spec_costant_ops_;
 
   AssemblyGrammar grammar_;
 

--- a/test/val/val_constants_test.cpp
+++ b/test/val/val_constants_test.cpp
@@ -37,28 +37,37 @@ using ::testing::ValuesIn;
 
 using ValidateConstant = spvtest::ValidateBase<bool>;
 
-#define kBasicTypes                             \
-  "%bool = OpTypeBool "                         \
-  "%uint = OpTypeInt 32 0 "                     \
-  "%uint2 = OpTypeVector %uint 2 "              \
-  "%float = OpTypeFloat 32 "                    \
-  "%_ptr_uint = OpTypePointer Workgroup %uint " \
-  "%uint_0 = OpConstantNull %uint "             \
-  "%uint2_0 = OpConstantNull %uint "            \
-  "%float_0 = OpConstantNull %float "           \
-  "%false = OpConstantFalse %bool "             \
-  "%true = OpConstantTrue %bool "               \
+#define kBasicTypes                                        \
+  "%bool = OpTypeBool "                                    \
+  "%uint = OpTypeInt 32 0 "                                \
+  "%uint64 = OpTypeInt 64 0 "                              \
+  "%uint2 = OpTypeVector %uint 2 "                         \
+  "%float = OpTypeFloat 32 "                               \
+  "%float64 = OpTypeFloat 64 "                             \
+  "%_ptr_uint = OpTypePointer Workgroup %uint "            \
+  "%uint_0 = OpConstantNull %uint "                        \
+  "%uint64_0 = OpConstantNull %uint64 "                    \
+  "%uint2_0 = OpConstantComposite %uint2 %uint_0 %uint_0 " \
+  "%float_0 = OpConstantNull %float "                      \
+  "%float64_0 = OpConstantNull %float64 "                  \
+  "%false = OpConstantFalse %bool "                        \
+  "%true = OpConstantTrue %bool "                          \
   "%null = OpConstantNull %_ptr_uint "
 
 #define kShaderPreamble    \
   "OpCapability Shader\n"  \
   "OpCapability Linkage\n" \
+  "OpCapability Int64\n"   \
+  "OpCapability Float64\n" \
   "OpMemoryModel Logical Simple\n"
 
-#define kKernelPreamble      \
-  "OpCapability Kernel\n"    \
-  "OpCapability Linkage\n"   \
-  "OpCapability Addresses\n" \
+#define kKernelPreamble           \
+  "OpCapability Kernel\n"         \
+  "OpCapability Linkage\n"        \
+  "OpCapability Int64\n"          \
+  "OpCapability Float64\n"        \
+  "OpCapability GenericPointer\n" \
+  "OpCapability Addresses\n"      \
   "OpMemoryModel Physical32 OpenCL\n"
 
 struct ConstantOpCase {
@@ -90,9 +99,8 @@ TEST_P(ValidateConstantOp, Samples) {
 INSTANTIATE_TEST_SUITE_P(
     UniversalInShader, ValidateConstantOp,
     ValuesIn(std::vector<ConstantOpCase>{
-        // TODO(dneto): Conversions must change width.
-        GOOD_SHADER_10("%v = OpSpecConstantOp %uint SConvert %uint_0"),
-        GOOD_SHADER_10("%v = OpSpecConstantOp %float FConvert %float_0"),
+        GOOD_SHADER_10("%v = OpSpecConstantOp %uint SConvert %uint64_0"),
+        GOOD_SHADER_10("%v = OpSpecConstantOp %float FConvert %float64_0"),
         GOOD_SHADER_10("%v = OpSpecConstantOp %uint SNegate %uint_0"),
         GOOD_SHADER_10("%v = OpSpecConstantOp %uint Not %uint_0"),
         GOOD_SHADER_10("%v = OpSpecConstantOp %uint IAdd %uint_0 %uint_0"),
@@ -147,9 +155,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     UniversalInKernel, ValidateConstantOp,
     ValuesIn(std::vector<ConstantOpCase>{
-        // TODO(dneto): Conversions must change width.
-        GOOD_KERNEL_10("%v = OpSpecConstantOp %uint SConvert %uint_0"),
-        GOOD_KERNEL_10("%v = OpSpecConstantOp %float FConvert %float_0"),
+        GOOD_KERNEL_10("%v = OpSpecConstantOp %uint SConvert %uint64_0"),
+        GOOD_KERNEL_10("%v = OpSpecConstantOp %float FConvert %float64_0"),
         GOOD_KERNEL_10("%v = OpSpecConstantOp %uint SNegate %uint_0"),
         GOOD_KERNEL_10("%v = OpSpecConstantOp %uint Not %uint_0"),
         GOOD_KERNEL_10("%v = OpSpecConstantOp %uint IAdd %uint_0 %uint_0"),
@@ -204,70 +211,64 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     UConvert, ValidateConstantOp,
     ValuesIn(std::vector<ConstantOpCase>{
-        // TODO(dneto): Conversions must change width.
         {SPV_ENV_UNIVERSAL_1_0,
          kKernelPreamble kBasicTypes
-         "%v = OpSpecConstantOp %uint UConvert %uint_0",
+         "%v = OpSpecConstantOp %uint UConvert %uint64_0",
          true, ""},
         {SPV_ENV_UNIVERSAL_1_1,
          kKernelPreamble kBasicTypes
-         "%v = OpSpecConstantOp %uint UConvert %uint_0",
+         "%v = OpSpecConstantOp %uint UConvert %uint64_0",
          true, ""},
         {SPV_ENV_UNIVERSAL_1_3,
          kKernelPreamble kBasicTypes
-         "%v = OpSpecConstantOp %uint UConvert %uint_0",
+         "%v = OpSpecConstantOp %uint UConvert %uint64_0",
          true, ""},
         {SPV_ENV_UNIVERSAL_1_3,
          kKernelPreamble kBasicTypes
-         "%v = OpSpecConstantOp %uint UConvert %uint_0",
+         "%v = OpSpecConstantOp %uint UConvert %uint64_0",
          true, ""},
         {SPV_ENV_UNIVERSAL_1_4,
          kKernelPreamble kBasicTypes
-         "%v = OpSpecConstantOp %uint UConvert %uint_0",
+         "%v = OpSpecConstantOp %uint UConvert %uint64_0",
          true, ""},
         {SPV_ENV_UNIVERSAL_1_0,
          kShaderPreamble kBasicTypes
-         "%v = OpSpecConstantOp %uint UConvert %uint_0",
+         "%v = OpSpecConstantOp %uint UConvert %uint64_0",
          false,
          "Prior to SPIR-V 1.4, specialization constant operation "
          "UConvert requires Kernel capability"},
         {SPV_ENV_UNIVERSAL_1_1,
          kShaderPreamble kBasicTypes
-         "%v = OpSpecConstantOp %uint UConvert %uint_0",
+         "%v = OpSpecConstantOp %uint UConvert %uint64_0",
          false,
          "Prior to SPIR-V 1.4, specialization constant operation "
          "UConvert requires Kernel capability"},
         {SPV_ENV_UNIVERSAL_1_3,
          kShaderPreamble kBasicTypes
-         "%v = OpSpecConstantOp %uint UConvert %uint_0",
+         "%v = OpSpecConstantOp %uint UConvert %uint64_0",
          false,
          "Prior to SPIR-V 1.4, specialization constant operation "
          "UConvert requires Kernel capability"},
         {SPV_ENV_UNIVERSAL_1_3,
          kShaderPreamble kBasicTypes
-         "%v = OpSpecConstantOp %uint UConvert %uint_0",
+         "%v = OpSpecConstantOp %uint UConvert %uint64_0",
          false,
          "Prior to SPIR-V 1.4, specialization constant operation "
          "UConvert requires Kernel capability"},
         {SPV_ENV_UNIVERSAL_1_4,
          kShaderPreamble kBasicTypes
-         "%v = OpSpecConstantOp %uint UConvert %uint_0",
+         "%v = OpSpecConstantOp %uint UConvert %uint64_0",
          true, ""},
     }));
 
 INSTANTIATE_TEST_SUITE_P(
     KernelInKernel, ValidateConstantOp,
     ValuesIn(std::vector<ConstantOpCase>{
-        // TODO(dneto): Conversions must change width.
         GOOD_KERNEL_10("%v = OpSpecConstantOp %uint ConvertFToS %float_0"),
         GOOD_KERNEL_10("%v = OpSpecConstantOp %float ConvertSToF %uint_0"),
         GOOD_KERNEL_10("%v = OpSpecConstantOp %uint ConvertFToU %float_0"),
         GOOD_KERNEL_10("%v = OpSpecConstantOp %float ConvertUToF %uint_0"),
-        GOOD_KERNEL_10("%v = OpSpecConstantOp %uint UConvert %uint_0"),
-        GOOD_KERNEL_10(
-            "%v = OpSpecConstantOp %_ptr_uint GenericCastToPtr %null"),
-        GOOD_KERNEL_10(
-            "%v = OpSpecConstantOp %_ptr_uint PtrCastToGeneric %null"),
+        GOOD_KERNEL_10("%v = OpSpecConstantOp %uint UConvert %uint64_0"),
         GOOD_KERNEL_10("%v = OpSpecConstantOp %uint Bitcast %uint_0"),
         GOOD_KERNEL_10("%v = OpSpecConstantOp %float FNegate %float_0"),
         GOOD_KERNEL_10("%v = OpSpecConstantOp %float FAdd %float_0 %float_0"),
@@ -276,10 +277,9 @@ INSTANTIATE_TEST_SUITE_P(
         GOOD_KERNEL_10("%v = OpSpecConstantOp %float FDiv %float_0 %float_0"),
         GOOD_KERNEL_10("%v = OpSpecConstantOp %float FRem %float_0 %float_0"),
         GOOD_KERNEL_10("%v = OpSpecConstantOp %float FMod %float_0 %float_0"),
+        GOOD_KERNEL_10("%v = OpSpecConstantOp %_ptr_uint AccessChain %null"),
         GOOD_KERNEL_10(
-            "%v = OpSpecConstantOp %_ptr_uint AccessChain %null %uint_0"),
-        GOOD_KERNEL_10("%v = OpSpecConstantOp %_ptr_uint InBoundsAccessChain "
-                       "%null %uint_0"),
+            "%v = OpSpecConstantOp %_ptr_uint InBoundsAccessChain %null"),
         GOOD_KERNEL_10(
             "%v = OpSpecConstantOp %_ptr_uint PtrAccessChain %null %uint_0"),
         GOOD_KERNEL_10("%v = OpSpecConstantOp %_ptr_uint "
@@ -295,7 +295,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     KernelInShader, ValidateConstantOp,
     ValuesIn(std::vector<ConstantOpCase>{
-        // TODO(dneto): Conversions must change width.
+        // Don't need to test GenericCastToPtr or PtrCastToGeneric as a valid
+        // module can't have a Generic storage class with Shader capability
         BAD_SHADER_10("%v = OpSpecConstantOp %uint ConvertFToS %float_0",
                       "ConvertFToS"),
         BAD_SHADER_10("%v = OpSpecConstantOp %float ConvertSToF %uint_0",
@@ -304,10 +305,6 @@ INSTANTIATE_TEST_SUITE_P(
                       "ConvertFToU"),
         BAD_SHADER_10("%v = OpSpecConstantOp %float ConvertUToF %uint_0",
                       "ConvertUToF"),
-        BAD_SHADER_10("%v = OpSpecConstantOp %_ptr_uint GenericCastToPtr %null",
-                      "GenericCastToPtr"),
-        BAD_SHADER_10("%v = OpSpecConstantOp %_ptr_uint PtrCastToGeneric %null",
-                      "PtrCastToGeneric"),
         BAD_SHADER_10("%v = OpSpecConstantOp %uint Bitcast %uint_0", "Bitcast"),
         BAD_SHADER_10("%v = OpSpecConstantOp %float FNegate %float_0",
                       "FNegate"),
@@ -323,12 +320,11 @@ INSTANTIATE_TEST_SUITE_P(
                       "FRem"),
         BAD_SHADER_10("%v = OpSpecConstantOp %float FMod %float_0 %float_0",
                       "FMod"),
+        BAD_SHADER_10("%v = OpSpecConstantOp %_ptr_uint AccessChain %null",
+                      "AccessChain"),
         BAD_SHADER_10(
-            "%v = OpSpecConstantOp %_ptr_uint AccessChain %null %uint_0",
-            "AccessChain"),
-        BAD_SHADER_10("%v = OpSpecConstantOp %_ptr_uint InBoundsAccessChain "
-                      "%null %uint_0",
-                      "InBoundsAccessChain"),
+            "%v = OpSpecConstantOp %_ptr_uint InBoundsAccessChain %null",
+            "InBoundsAccessChain"),
         BAD_SHADER_10(
             "%v = OpSpecConstantOp %_ptr_uint PtrAccessChain %null %uint_0",
             "PtrAccessChain"),
@@ -344,10 +340,12 @@ INSTANTIATE_TEST_SUITE_P(
         // https://github.com/KhronosGroup/glslang/issues/848
         {SPV_ENV_UNIVERSAL_1_0,
          "OpCapability Shader "
+         "OpCapability Int64 "
+         "OpCapability Float64 "
          "OpCapability Linkage ; So we don't need to define a function\n"
          "OpExtension \"SPV_AMD_gpu_shader_int16\" "
          "OpMemoryModel Logical Simple " kBasicTypes
-         "%v = OpSpecConstantOp %uint UConvert %uint_0",
+         "%v = OpSpecConstantOp %uint UConvert %uint64_0",
          true, ""},
     }));
 
@@ -477,6 +475,299 @@ OpName %ptr "ptr"
               HasSubstr("OpConstantNull Result Type <id> '1[%ptr]' cannot have "
                         "a null value"));
 }
+
+TEST_F(ValidateConstant, BadShaderOperandsQuantizeToF16) {
+  std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+%uint = OpTypeInt 32 0
+%float = OpTypeFloat 32
+%uint_1 = OpConstant %uint 1
+%float_1 = OpConstant %float 1
+%good = OpSpecConstantOp %float QuantizeToF16 %float_1
+%bad1 = OpSpecConstantOp %uint QuantizeToF16 %float_1
+%bad2 = OpSpecConstantOp %float QuantizeToF16 %uint_1
+)";
+
+  CompileSuccessfully(spirv);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpSpecConstantOp opcode QuantizeToF16 has invalid "
+                        "types or operands."));
+}
+
+#define BAD_KERNEL_OPERANDS(STR, NAME)                                    \
+  {                                                                       \
+    SPV_ENV_UNIVERSAL_1_0, kKernelPreamble kBasicTypes STR, false,        \
+        "OpSpecConstantOp opcode " NAME " has invalid types or operands." \
+  }
+
+INSTANTIATE_TEST_SUITE_P(
+    BadOperandsKernel, ValidateConstantOp,
+    ValuesIn(std::vector<ConstantOpCase>{
+        // 2 of each, first has bad return type, second has bad operand
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %float SConvert %uint_0",
+                            "SConvert"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %uint SConvert %uint_0",
+                            "SConvert"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %uint FConvert %float_0",
+                            "FConvert"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %float FConvert %float_0",
+                            "FConvert"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %float SNegate %uint_0",
+                            "SNegate"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %uint SNegate %float_0",
+                            "SNegate"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %float Not %uint_0", "Not"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %uint Not %float_0", "Not"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %float IAdd %uint_0 %uint_0",
+                            "IAdd"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %uint IAdd %uint_0 %float_0",
+                            "IAdd"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %float ISub %uint_0 %uint_0",
+                            "ISub"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %uint ISub %uint_0 %float_0",
+                            "ISub"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %float IMul %uint_0 %uint_0",
+                            "IMul"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %uint IMul %uint_0 %float_0",
+                            "IMul"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %float UDiv %uint_0 %uint_0",
+                            "UDiv"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %uint UDiv %uint_0 %float_0",
+                            "UDiv"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %float SDiv %uint_0 %uint_0",
+                            "SDiv"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %uint SDiv %uint_0 %float_0",
+                            "SDiv"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %float UMod %uint_0 %uint_0",
+                            "UMod"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %uint UMod %uint_0 %float_0",
+                            "UMod"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %float SRem %uint_0 %uint_0",
+                            "SRem"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %uint SRem %uint_0 %float_0",
+                            "SRem"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %float SMod %uint_0 %uint_0",
+                            "SMod"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %uint SMod %uint_0 %float_0",
+                            "SMod"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float ShiftRightLogical %uint_0 %uint_0",
+            "ShiftRightLogical"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %uint ShiftRightLogical %uint_0 %float_0",
+            "ShiftRightLogical"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float ShiftRightArithmetic %uint_0 %uint_0",
+            "ShiftRightArithmetic"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %uint ShiftRightArithmetic %uint_0 %float_0",
+            "ShiftRightArithmetic"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float ShiftLeftLogical %uint_0 %uint_0",
+            "ShiftLeftLogical"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %uint ShiftLeftLogical %uint_0 %float_0",
+            "ShiftLeftLogical"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float BitwiseOr %uint_0 %uint_0",
+            "BitwiseOr"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %uint BitwiseOr %uint_0 %float_0",
+            "BitwiseOr"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float BitwiseXor %uint_0 %uint_0",
+            "BitwiseXor"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %uint BitwiseXor %uint_0 %float_0",
+            "BitwiseXor"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float VectorShuffle %uint2_0 %uint2_0 1 3",
+            "VectorShuffle"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %uint2 VectorShuffle %uint2_0 %uint_0 1 3",
+            "VectorShuffle"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float CompositeExtract %uint2_0 1",
+            "CompositeExtract"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %uint CompositeExtract %uint_0 1",
+            "CompositeExtract"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float CompositeInsert %uint_0 %uint2_0 1",
+            "CompositeInsert"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %uint2 CompositeInsert %uint_0 %uint_0 1",
+            "CompositeInsert"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float LogicalOr %true %false", "LogicalOr"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool LogicalOr %true %uint_0", "LogicalOr"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %float LogicalNot %true",
+                            "LogicalNot"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %bool LogicalNot %uint_0",
+                            "LogicalNot"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float LogicalAnd %true %false",
+            "LogicalAnd"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool LogicalAnd %true %uint_0",
+            "LogicalAnd"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float LogicalEqual %true %false",
+            "LogicalEqual"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool LogicalEqual %true %uint_0",
+            "LogicalEqual"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float LogicalNotEqual %true %false",
+            "LogicalNotEqual"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool LogicalNotEqual %uint_0 %false",
+            "LogicalNotEqual"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float Select %true %uint_0 %uint_0",
+            "Select"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %uint Select %uint_0 %uint_0 %uint_0",
+            "Select"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float IEqual %uint_0 %uint_0", "IEqual"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool IEqual %uint_0 %float_0", "IEqual"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float INotEqual %uint_0 %uint_0",
+            "INotEqual"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool INotEqual %uint_0 %float_0",
+            "INotEqual"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float ULessThan %uint_0 %uint_0",
+            "ULessThan"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool ULessThan %uint_0 %float_0",
+            "ULessThan"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float SLessThan %uint_0 %uint_0",
+            "SLessThan"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool SLessThan %uint_0 %float_0",
+            "SLessThan"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float ULessThanEqual %uint_0 %uint_0",
+            "ULessThanEqual"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool ULessThanEqual %uint_0 %float_0",
+            "ULessThanEqual"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float SLessThanEqual %uint_0 %uint_0",
+            "SLessThanEqual"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool SLessThanEqual %uint_0 %float_0",
+            "SLessThanEqual"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float UGreaterThan %uint_0 %uint_0",
+            "UGreaterThan"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool UGreaterThan %uint_0 %float_0",
+            "UGreaterThan"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float UGreaterThanEqual %uint_0 %uint_0",
+            "UGreaterThanEqual"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool UGreaterThanEqual %uint_0 %float_0",
+            "UGreaterThanEqual"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float SGreaterThan %uint_0 %uint_0",
+            "SGreaterThan"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool SGreaterThan %uint_0 %float_0",
+            "SGreaterThan"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float SGreaterThanEqual %uint_0 %uint_0",
+            "SGreaterThanEqual"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool SGreaterThanEqual %uint_0 %float_0",
+            "SGreaterThanEqual"),
+        // // Kernel only
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %float ConvertFToS %float_0",
+                            "ConvertFToS"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %uint ConvertFToS %uint2_0",
+                            "ConvertFToS"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %uint ConvertSToF %uint_0",
+                            "ConvertSToF"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %float ConvertSToF %float_0",
+                            "ConvertSToF"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %float ConvertFToU %float_0",
+                            "ConvertFToU"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %uint ConvertFToU %uint2_0",
+                            "ConvertFToU"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %uint ConvertUToF %uint_0",
+                            "ConvertUToF"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %float ConvertUToF %float_0",
+                            "ConvertUToF"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %float UConvert %uint_0",
+                            "UConvert"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %uint UConvert %uint_0",
+                            "UConvert"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %bool Bitcast %uint_0",
+                            "Bitcast"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %uint Bitcast %true",
+                            "Bitcast"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %uint FNegate %float_0",
+                            "FNegate"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %float FNegate %uint_0",
+                            "FNegate"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %uint FAdd %float_0 %float_0", "FAdd"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float FAdd %float_0 %uint_0", "FAdd"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %uint FSub %float_0 %float_0", "FSub"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float FSub %float_0 %uint_0", "FSub"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %uint FMul %float_0 %float_0", "FMul"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float FMul %float_0 %uint_0", "FMul"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %uint FDiv %float_0 %float_0", "FDiv"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float FDiv %float_0 %uint_0", "FDiv"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %uint FRem %float_0 %float_0", "FRem"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float FRem %float_0 %uint_0", "FRem"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %uint FMod %float_0 %float_0", "FMod"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float FMod %float_0 %uint_0", "FMod"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %uint AccessChain %null",
+                            "AccessChain"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %_ptr_uint AccessChain %null %float_0",
+            "AccessChain"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %uint InBoundsAccessChain %null",
+            "InBoundsAccessChain"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %_ptr_uint "
+                            "InBoundsAccessChain %null %float_0",
+                            "InBoundsAccessChain"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %uint PtrAccessChain %null %uint_0",
+            "PtrAccessChain"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %_ptr_uint PtrAccessChain %float_0 %float_0",
+            "PtrAccessChain"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %uint InBoundsPtrAccessChain %null %uint_0",
+            "InBoundsPtrAccessChain"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %_ptr_uint "
+                            "InBoundsPtrAccessChain %float_0 %float_0",
+                            "InBoundsPtrAccessChain"),
+    }));
 
 }  // namespace
 }  // namespace val


### PR DESCRIPTION
Add validation for `OpSpecConstantOp` result type and `opcode`'s arguments

Currently removed the tests for `OpPtrCastToGeneric` or `OpGenericCastToPtr ` and raised an issue
https://github.com/KhronosGroup/SPIRV-Registry/issues/162