### PR TITLE
Improve time to build dominators

### DIFF
--- a/source/cfa.h
+++ b/source/cfa.h
@@ -308,11 +308,9 @@ std::vector<BB*> CFA<BB>::TraversalRoots(const std::vector<BB*>& blocks,
 
   auto mark_visited = [&visited](const BB* b) { visited.insert(b); };
   auto ignore_block = [](const BB*) {};
-  auto ignore_blocks = [](const BB*, const BB*) {};
   auto no_terminal_blocks = [](const BB*) { return false; };
 
   auto traverse_from_root = [&mark_visited, &succ_func, &ignore_block,
-                             &ignore_blocks,
                              &no_terminal_blocks](const BB* entry) {
     DepthFirstTraversal(entry, succ_func, mark_visited, ignore_block,
                         no_terminal_blocks);

--- a/source/cfa.h
+++ b/source/cfa.h
@@ -81,7 +81,7 @@ class CFA {
   /// This function performs a depth first traversal from the \p entry
   /// BasicBlock and calls the pre/postorder functions when it needs to process
   /// the node in pre order, post order. It also calls the backedge function
-  /// when a back edge is encountered. The backedge function can empty.  The
+  /// when a back edge is encountered. The backedge function can be empty.  The
   /// runtime of the algorithm is improved if backedge is empty.
   ///
   /// @param[in] entry      The root BasicBlock of a CFG

--- a/source/cfa.h
+++ b/source/cfa.h
@@ -166,7 +166,8 @@ void CFA<BB>::DepthFirstTraversal(const BB* entry,
                                   std::function<void(cbb_ptr)> preorder,
                                   std::function<void(cbb_ptr)> postorder,
                                   std::function<bool(cbb_ptr)> terminal) {
-  DepthFirstTraversal(entry, successor_func, preorder, postorder, {}, terminal);
+  DepthFirstTraversal(entry, successor_func, preorder, postorder,
+                      /* backedge = */ {}, terminal);
 }
 
 template <class BB>

--- a/source/cfa.h
+++ b/source/cfa.h
@@ -177,10 +177,10 @@ void CFA<BB>::DepthFirstTraversal(
     std::function<void(cbb_ptr)> postorder,
     std::function<void(cbb_ptr, cbb_ptr)> backedge,
     std::function<bool(cbb_ptr)> terminal) {
-  assert(!successor_func && "The successor function cannot be empty.");
-  assert(!preorder && "The preorder function cannot be empty.");
-  assert(!postorder && "The postorder function cannot be empty.");
-  assert(!terminal && "The terminal function cannot be empty.");
+  assert(successor_func && "The successor function cannot be empty.");
+  assert(preorder && "The preorder function cannot be empty.");
+  assert(postorder && "The postorder function cannot be empty.");
+  assert(terminal && "The terminal function cannot be empty.");
 
   std::unordered_set<uint32_t> processed;
 

--- a/source/opt/cfg.cpp
+++ b/source/opt/cfg.cpp
@@ -87,7 +87,6 @@ void CFG::ComputeStructuredOrder(Function* func, BasicBlock* root,
   // Compute structured successors and do DFS.
   ComputeStructuredSuccessors(func);
   auto ignore_block = [](cbb_ptr) {};
-  auto ignore_edge = [](cbb_ptr, cbb_ptr) {};
   auto terminal = [end](cbb_ptr bb) { return bb == end; };
 
   auto get_structured_successors = [this](const BasicBlock* b) {
@@ -100,8 +99,7 @@ void CFG::ComputeStructuredOrder(Function* func, BasicBlock* root,
     order->push_front(const_cast<BasicBlock*>(b));
   };
   CFA<BasicBlock>::DepthFirstTraversal(root, get_structured_successors,
-                                       ignore_block, post_order, ignore_edge,
-                                       terminal);
+                                       ignore_block, post_order, terminal);
 }
 
 void CFG::ForEachBlockInPostOrder(BasicBlock* bb,

--- a/source/opt/dominator_tree.cpp
+++ b/source/opt/dominator_tree.cpp
@@ -58,9 +58,8 @@ template <typename BBType, typename SuccessorLambda, typename PreLambda,
 static void DepthFirstSearch(const BBType* bb, SuccessorLambda successors,
                              PreLambda pre, PostLambda post) {
   // Ignore backedge operation.
-  auto nop_backedge = [](const BBType*, const BBType*) {};
   auto no_terminal_blocks = [](const BBType*) { return false; };
-  CFA<BBType>::DepthFirstTraversal(bb, successors, pre, post, nop_backedge,
+  CFA<BBType>::DepthFirstTraversal(bb, successors, pre, post,
                                    no_terminal_blocks);
 }
 
@@ -105,7 +104,8 @@ class BasicBlockSuccessorHelper {
   using Function = typename GetFunctionClass<BBType>::FunctionType;
 
   using BasicBlockListTy = std::vector<BasicBlock*>;
-  using BasicBlockMapTy = std::map<const BasicBlock*, BasicBlockListTy>;
+  using BasicBlockMapTy =
+      std::unordered_map<const BasicBlock*, BasicBlockListTy>;
 
  public:
   // For compliance with the dominance tree computation, entry nodes are
@@ -160,19 +160,8 @@ BasicBlockSuccessorHelper<BBType>::BasicBlockSuccessorHelper(
 template <typename BBType>
 void BasicBlockSuccessorHelper<BBType>::CreateSuccessorMap(
     Function& f, const BasicBlock* placeholder_start_node) {
-  std::map<uint32_t, BasicBlock*> id_to_BB_map;
-  auto GetSuccessorBasicBlock = [&f, &id_to_BB_map](uint32_t successor_id) {
-    BasicBlock*& Succ = id_to_BB_map[successor_id];
-    if (!Succ) {
-      for (BasicBlock& BBIt : f) {
-        if (successor_id == BBIt.id()) {
-          Succ = &BBIt;
-          break;
-        }
-      }
-    }
-    return Succ;
-  };
+  IRContext* context = f.DefInst().context();
+  std::unordered_map<uint32_t, BasicBlock*> id_to_BB_map;
 
   if (invert_graph_) {
     // For the post dominator tree, we see the inverted graph.
@@ -186,9 +175,8 @@ void BasicBlockSuccessorHelper<BBType>::CreateSuccessorMap(
         BasicBlockListTy& pred_list = predecessors_[&bb];
         const auto& const_bb = bb;
         const_bb.ForEachSuccessorLabel(
-            [this, &pred_list, &bb,
-             &GetSuccessorBasicBlock](const uint32_t successor_id) {
-              BasicBlock* succ = GetSuccessorBasicBlock(successor_id);
+            [this, &pred_list, &bb, context](const uint32_t successor_id) {
+              BasicBlock* succ = context->get_instr_block(successor_id);
               // Inverted graph: our successors in the CFG
               // are our predecessors in the inverted graph.
               this->successors_[succ].push_back(&bb);
@@ -209,7 +197,7 @@ void BasicBlockSuccessorHelper<BBType>::CreateSuccessorMap(
 
       const auto& const_bb = bb;
       const_bb.ForEachSuccessorLabel([&](const uint32_t successor_id) {
-        BasicBlock* succ = GetSuccessorBasicBlock(successor_id);
+        BasicBlock* succ = context->get_instr_block(successor_id);
         succ_list.push_back(succ);
         predecessors_[succ].push_back(&bb);
       });

--- a/source/opt/dominator_tree.cpp
+++ b/source/opt/dominator_tree.cpp
@@ -57,7 +57,6 @@ template <typename BBType, typename SuccessorLambda, typename PreLambda,
           typename PostLambda>
 static void DepthFirstSearch(const BBType* bb, SuccessorLambda successors,
                              PreLambda pre, PostLambda post) {
-  // Ignore backedge operation.
   auto no_terminal_blocks = [](const BBType*) { return false; };
   CFA<BBType>::DepthFirstTraversal(bb, successors, pre, post,
                                    no_terminal_blocks);
@@ -161,7 +160,6 @@ template <typename BBType>
 void BasicBlockSuccessorHelper<BBType>::CreateSuccessorMap(
     Function& f, const BasicBlock* placeholder_start_node) {
   IRContext* context = f.DefInst().context();
-  std::unordered_map<uint32_t, BasicBlock*> id_to_BB_map;
 
   if (invert_graph_) {
     // For the post dominator tree, we see the inverted graph.

--- a/source/val/validate_cfg.cpp
+++ b/source/val/validate_cfg.cpp
@@ -896,14 +896,13 @@ spv_result_t PerformCfgChecks(ValidationState_t& _) {
     // CFG to ensure we cover all the blocks.
     std::vector<const BasicBlock*> postorder;
     auto ignore_block = [](const BasicBlock*) {};
-    auto ignore_edge = [](const BasicBlock*, const BasicBlock*) {};
     auto no_terminal_blocks = [](const BasicBlock*) { return false; };
     if (!function.ordered_blocks().empty()) {
       /// calculate dominators
       CFA<BasicBlock>::DepthFirstTraversal(
           function.first_block(), function.AugmentedCFGSuccessorsFunction(),
           ignore_block, [&](const BasicBlock* b) { postorder.push_back(b); },
-          ignore_edge, no_terminal_blocks);
+          no_terminal_blocks);
       auto edges = CFA<BasicBlock>::CalculateDominators(
           postorder, function.AugmentedCFGPredecessorsFunction());
       for (auto edge : edges) {
@@ -953,7 +952,7 @@ spv_result_t PerformCfgChecks(ValidationState_t& _) {
         CFA<BasicBlock>::DepthFirstTraversal(
             function.first_block(),
             function.AugmentedStructuralCFGSuccessorsFunction(), ignore_block,
-            [&](const BasicBlock* b) { postorder.push_back(b); }, ignore_edge,
+            [&](const BasicBlock* b) { postorder.push_back(b); },
             no_terminal_blocks);
         auto edges = CFA<BasicBlock>::CalculateDominators(
             postorder, function.AugmentedStructuralCFGPredecessorsFunction());
@@ -967,7 +966,7 @@ spv_result_t PerformCfgChecks(ValidationState_t& _) {
             function.pseudo_exit_block(),
             function.AugmentedStructuralCFGPredecessorsFunction(), ignore_block,
             [&](const BasicBlock* b) { postdom_postorder.push_back(b); },
-            ignore_edge, no_terminal_blocks);
+            no_terminal_blocks);
         auto postdom_edges = CFA<BasicBlock>::CalculateDominators(
             postdom_postorder,
             function.AugmentedStructuralCFGSuccessorsFunction());


### PR DESCRIPTION
Changed a couple small parts of the algorithm to reduce time to build
the dominator trees.  There should be no visible changes.

Add a depth first search algorithm that does not run a function on
backedges.  The check if an edge is a back edge is time consuming, and
pointless if the function run on it is a nop.
