### PR TITLE
spirv-val: Label VUID 07290

### DIFF
--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -459,6 +459,7 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
         ContainsInvalidBool(_, value_type, storage_input_or_output)) {
       if (storage_input_or_output) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
+               << _.VkErrorID(7290)
                << "If OpTypeBool is stored in conjunction with OpVariable "
                   "using Input or Output Storage Classes it requires a BuiltIn "
                   "decoration";

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2106,6 +2106,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-Uniform-06925);
     case 6997:
       return VUID_WRAP(VUID-StandaloneSpirv-SubgroupVoteKHR-06997);
+    case 7290:
+      return VUID_WRAP(VUID-StandaloneSpirv-Input-07290);
     default:
       return "";  // unknown id
   }

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -2278,6 +2278,35 @@ OpFunctionEnd
           "or Output Storage Classes it requires a BuiltIn decoration"));
 }
 
+TEST_F(ValidateIdWithMessage, OpVariableContainsNoBuiltinBoolBadVulkan) {
+  std::string spirv = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %var
+OpExecutionMode %main OriginUpperLeft
+%bool = OpTypeBool
+%input = OpTypeStruct %bool
+%_ptr_input = OpTypePointer Input %input
+%var = OpVariable %_ptr_input Input
+%void = OpTypeVoid
+%fnty = OpTypeFunction %void
+%main = OpFunction %void None %fnty
+%entry = OpLabel
+%load = OpLoad %input %var
+OpReturn
+OpFunctionEnd
+)";
+  CompileSuccessfully(spirv.c_str(), SPV_ENV_VULKAN_1_0);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Input-07290"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(
+          "If OpTypeBool is stored in conjunction with OpVariable using Input "
+          "or Output Storage Classes it requires a BuiltIn decoration"));
+}
+
 TEST_F(ValidateIdWithMessage, OpVariableContainsRayPayloadBoolGood) {
   std::string spirv = R"(
 OpCapability RayTracingNV


### PR DESCRIPTION
`VUID-StandaloneSpirv-Input-07290` was added in the Vulkan 1.3.227 spec