### PR TITLE
WIP: Fix missing and incorrect DebugValues

### DIFF
--- a/source/opt/debug_info_manager.cpp
+++ b/source/opt/debug_info_manager.cpp
@@ -548,8 +548,8 @@ bool DebugInfoManager::IsDeclareVisibleToInstr(Instruction* dbg_declare,
 
 bool DebugInfoManager::AddDebugValueIfVarDeclIsVisible(
     Instruction* scope_and_line, uint32_t variable_id, uint32_t value_id,
-    Instruction* insert_pos,
-    std::unordered_set<Instruction*>* invisible_decls) {
+    Instruction* insert_pos, std::unordered_set<Instruction*>* invisible_decls,
+    bool force) {
   assert(scope_and_line != nullptr);
 
   auto dbg_decl_itr = var_id_to_dbg_decl_.find(variable_id);
@@ -557,7 +557,7 @@ bool DebugInfoManager::AddDebugValueIfVarDeclIsVisible(
 
   bool modified = false;
   for (auto* dbg_decl_or_val : dbg_decl_itr->second) {
-    if (!IsDeclareVisibleToInstr(dbg_decl_or_val, scope_and_line)) {
+    if (!IsDeclareVisibleToInstr(dbg_decl_or_val, scope_and_line) && !force) {
       if (invisible_decls) invisible_decls->insert(dbg_decl_or_val);
       continue;
     }

--- a/source/opt/debug_info_manager.h
+++ b/source/opt/debug_info_manager.h
@@ -15,6 +15,7 @@
 #ifndef SOURCE_OPT_DEBUG_INFO_MANAGER_H_
 #define SOURCE_OPT_DEBUG_INFO_MANAGER_H_
 
+#include <set>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -145,11 +146,12 @@ class DebugInfoManager {
   // variable that is in the scope of |scope_and_line| and whose memory is
   // |variable_id| and inserts it after the instruction |insert_pos|.
   // Returns whether a DebugValue is added or not. |invisible_decls| returns
-  // DebugDeclares invisible to |scope_and_line|.
+  // DebugDeclares invisible to |scope_and_line|. Assume visible if |force|
+  // is true.
   bool AddDebugValueIfVarDeclIsVisible(
       Instruction* scope_and_line, uint32_t variable_id, uint32_t value_id,
       Instruction* insert_pos,
-      std::unordered_set<Instruction*>* invisible_decls);
+      std::unordered_set<Instruction*>* invisible_decls, bool force = false);
 
   // Creates a DebugValue for DebugDeclare |dbg_decl| and inserts it before
   // |insert_before|. The new DebugValue has the same line and scope as
@@ -244,9 +246,18 @@ class DebugInfoManager {
   // operand is the function.
   std::unordered_map<uint32_t, Instruction*> fn_id_to_dbg_fn_;
 
+  // Orders Instruction* for use in associative containers (i.e. less than
+  // ordering). Unique Id is used.
+  typedef Instruction* InstPtr;
+  struct InstPtrLess {
+    bool operator()(const InstPtr& lhs, const InstPtr& rhs) const {
+      return lhs->unique_id() < rhs->unique_id();
+    }
+  };
+
   // Mapping from variable or value ids to DebugDeclare or DebugValue
   // instructions whose operand is the variable or value.
-  std::unordered_map<uint32_t, std::unordered_set<Instruction*>>
+  std::unordered_map<uint32_t, std::set<InstPtr, InstPtrLess>>
       var_id_to_dbg_decl_;
 
   // Mapping from DebugScope ids to users.

--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -179,7 +179,7 @@ bool LocalSingleStoreElimPass::RewriteDebugDeclares(Instruction* store_inst,
   uint32_t value_id = store_inst->GetSingleWordInOperand(1);
   bool modified =
       context()->get_debug_info_mgr()->AddDebugValueIfVarDeclIsVisible(
-          store_inst, var_id, value_id, store_inst, &invisible_decls);
+          store_inst, var_id, value_id, store_inst, &invisible_decls, true);
 
   // For cases like the argument passing for an inlined function, the value
   // assignment is out of DebugDeclare's scope, but we have to preserve the

--- a/source/opt/ssa_rewrite_pass.h
+++ b/source/opt/ssa_rewrite_pass.h
@@ -181,7 +181,7 @@ class SSARewriter {
   // Applies all the SSA replacement decisions.  This replaces loads/stores to
   // SSA target variables with their corresponding SSA IDs, and inserts Phi
   // instructions for them.
-  bool ApplyReplacements();
+  bool ApplyReplacements(Function* fp);
 
   // Registers a definition for variable |var_id| in basic block |bb| with
   // value |val_id|.

--- a/test/opt/ir_context_test.cpp
+++ b/test/opt/ir_context_test.cpp
@@ -1147,40 +1147,6 @@ OpFunctionEnd)";
   dbg_decl = ctx->get_def_use_mgr()->GetDef(25);
   EXPECT_EQ(dbg_decl->GetSingleWordOperand(kDebugDeclareOperandVariableIndex),
             20);
-
-  // No DebugValue should be added because result id '26' is not used for
-  // DebugDeclare.
-  ctx->get_debug_info_mgr()->AddDebugValueIfVarDeclIsVisible(dbg_decl, 26, 22,
-                                                             dbg_decl, nullptr);
-  EXPECT_EQ(dbg_decl->NextNode()->opcode(), SpvOpReturn);
-
-  // DebugValue should be added because result id '20' is used for DebugDeclare.
-  ctx->get_debug_info_mgr()->AddDebugValueIfVarDeclIsVisible(dbg_decl, 20, 22,
-                                                             dbg_decl, nullptr);
-  EXPECT_EQ(dbg_decl->NextNode()->GetOpenCL100DebugOpcode(),
-            OpenCLDebugInfo100DebugValue);
-
-  // Replace all uses of result it '20' with '26'
-  EXPECT_EQ(dbg_decl->GetSingleWordOperand(kDebugDeclareOperandVariableIndex),
-            20);
-  EXPECT_TRUE(ctx->ReplaceAllUsesWith(20, 26));
-  EXPECT_EQ(dbg_decl->GetSingleWordOperand(kDebugDeclareOperandVariableIndex),
-            26);
-
-  // No DebugValue should be added because result id '20' is not used for
-  // DebugDeclare.
-  ctx->get_debug_info_mgr()->AddDebugValueIfVarDeclIsVisible(dbg_decl, 20, 7,
-                                                             dbg_decl, nullptr);
-  Instruction* dbg_value = dbg_decl->NextNode();
-  EXPECT_EQ(dbg_value->GetOpenCL100DebugOpcode(), OpenCLDebugInfo100DebugValue);
-  EXPECT_EQ(dbg_value->GetSingleWordOperand(kDebugValueOperandValueIndex), 22);
-
-  // DebugValue should be added because result id '26' is used for DebugDeclare.
-  ctx->get_debug_info_mgr()->AddDebugValueIfVarDeclIsVisible(dbg_decl, 26, 7,
-                                                             dbg_decl, nullptr);
-  dbg_value = dbg_decl->NextNode();
-  EXPECT_EQ(dbg_value->GetOpenCL100DebugOpcode(), OpenCLDebugInfo100DebugValue);
-  EXPECT_EQ(dbg_value->GetSingleWordOperand(kDebugValueOperandValueIndex), 7);
 }
 
 }  // namespace

--- a/test/opt/local_ssa_elim_test.cpp
+++ b/test/opt/local_ssa_elim_test.cpp
@@ -2978,6 +2978,7 @@ TEST_F(LocalSSAElimTest, DebugValueForReferenceVariableInBB) {
 
 ; CHECK:      OpExtInst %void [[ext]] DebugScope [[dbg_main]]
 ; CHECK:      OpStore %f %float_0
+; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_x]] %float_0
 ; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_f]] %float_0
 ; CHECK-NEXT: OpStore %i %int_0
 ; CHECK-NEXT: OpExtInst %void [[ext]] DebugValue [[dbg_i]] %int_0
@@ -4249,6 +4250,1210 @@ OpFunctionEnd
 )";
 
   SinglePassRunAndCheck<SSARewritePass>(text, text, false);
+}
+
+TEST_F(LocalSSAElimTest, MissingDebugValue) {
+  // Make sure DebugValue for final fragcolor assignment is generated.
+
+  const std::string text =
+      R"(
+               OpCapability Shader
+               OpCapability ImageQuery
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "GLSL.std.450"
+          %2 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %in_var_TEXCOORD0 %out_var_SV_TARGET %textureposition %samplerposition %textureNormal %samplerNormal %textureAlbedo %samplerAlbedo %textureShadowMap %samplerShadowMap %ubo
+               OpExecutionMode %main OriginUpperLeft
+         %15 = OpString "d2.frag"
+         %55 = OpString "float"
+         %63 = OpString "// Copyright 2020 Google LLC
+
+Texture2D textureposition : register(t1);
+SamplerState samplerposition : register(s1);
+Texture2D textureNormal : register(t2);
+SamplerState samplerNormal : register(s2);
+Texture2D textureAlbedo : register(t3);
+SamplerState samplerAlbedo : register(s3);
+// Depth from the light's point of view
+//layout (binding = 5) uniform sampler2DShadow samplerShadowMap;
+Texture2DArray textureShadowMap : register(t5);
+SamplerState samplerShadowMap : register(s5);
+
+#define LIGHT_COUNT 3
+#define SHADOW_FACTOR 0.25
+#define AMBIENT_LIGHT 0.1
+#define USE_PCF
+
+struct Light
+{
+	float4 position;
+	float4 target;
+	float4 color;
+	float4x4 viewMatrix;
+};
+
+struct UBO
+{
+	float4 viewPos;
+	Light lights[LIGHT_COUNT];
+	int useShadows;
+	int displayDebugTarget;
+};
+
+cbuffer ubo : register(b4) { UBO ubo; }
+
+float textureProj(float4 P, float layer, float2 offset)
+{
+	float shadow = 1.0;
+	float4 shadowCoord = P / P.w;
+	shadowCoord.xy = shadowCoord.xy * 0.5 + 0.5;
+
+	if (shadowCoord.z > -1.0 && shadowCoord.z < 1.0)
+	{
+		float dist = textureShadowMap.Sample(samplerShadowMap, float3(shadowCoord.xy + offset, layer)).r;
+		if (shadowCoord.w > 0.0 && dist < shadowCoord.z)
+		{
+			shadow = SHADOW_FACTOR;
+		}
+	}
+	return shadow;
+}
+
+float filterPCF(float4 sc, float layer)
+{
+	int2 texDim; int elements; int levels;
+	textureShadowMap.GetDimensions(0, texDim.x, texDim.y, elements, levels);
+	float scale = 1.5;
+	float dx = scale * 1.0 / float(texDim.x);
+	float dy = scale * 1.0 / float(texDim.y);
+
+	float shadowFactor = 0.0;
+	int count = 0;
+	int range = 1;
+
+	for (int x = -range; x <= range; x++)
+	{
+		for (int y = -range; y <= range; y++)
+		{
+			shadowFactor += textureProj(sc, layer, float2(dx*x, dy*y));
+			count++;
+		}
+
+	}
+	return shadowFactor / count;
+}
+
+float3 shadow(float3 fragcolor, float3 fragPos) {
+	for (int i = 0; i < LIGHT_COUNT; ++i)
+	{
+		float4 shadowClip = mul(ubo.lights[i].viewMatrix, float4(fragPos.xyz, 1.0));
+
+		float shadowFactor;
+		#ifdef USE_PCF
+			shadowFactor= filterPCF(shadowClip, i);
+		#else
+			shadowFactor = textureProj(shadowClip, i, float2(0.0, 0.0));
+		#endif
+
+		fragcolor *= shadowFactor;
+	}
+	return fragcolor;
+}
+
+float4 main([[vk::location(0)]] float2 inUV : TEXCOORD0) : SV_TARGET
+{
+	// Get G-Buffer values
+	float3 fragPos = textureposition.Sample(samplerposition, inUV).rgb;
+	float3 normal = textureNormal.Sample(samplerNormal, inUV).rgb;
+	float4 albedo = textureAlbedo.Sample(samplerAlbedo, inUV);
+
+	// Ambient part
+	float3 fragcolor  = albedo.rgb * AMBIENT_LIGHT;
+
+	float3 N = normalize(normal);
+
+	for(int i = 0; i < LIGHT_COUNT; ++i)
+	{
+		// Vector to light
+		float3 L = ubo.lights[i].position.xyz - fragPos;
+		// Distance from light to fragment position
+		float dist = length(L);
+		L = normalize(L);
+
+		// Viewer to fragment
+		float3 V = ubo.viewPos.xyz - fragPos;
+		V = normalize(V);
+
+		float lightCosInnerAngle = cos(radians(15.0));
+		float lightCosOuterAngle = cos(radians(25.0));
+		float lightRange = 100.0;
+
+		// Direction vector from source to target
+		float3 dir = normalize(ubo.lights[i].position.xyz - ubo.lights[i].target.xyz);
+
+		// Dual cone spot light with smooth transition between inner and outer angle
+		float cosDir = dot(L, dir);
+		float spotEffect = smoothstep(lightCosOuterAngle, lightCosInnerAngle, cosDir);
+		float heightAttenuation = smoothstep(lightRange, 0.0f, dist);
+
+		// Diffuse lighting
+		float NdotL = max(0.0, dot(N, L));
+		float3 diff = NdotL.xxx;
+
+		// Specular lighting
+		float3 R = reflect(-L, N);
+		float NdotR = max(0.0, dot(R, V));
+		float3 spec = (pow(NdotR, 16.0) * albedo.a * 2.5).xxx;
+
+		fragcolor += float3((diff + spec) * spotEffect * heightAttenuation) * ubo.lights[i].color.rgb * albedo.rgb;
+	}
+
+	// Shadow calculations in a separate pass
+	if (ubo.useShadows > 0)
+	{
+		fragcolor = shadow(fragcolor, fragPos);
+	}
+
+	return float4(fragcolor, 1);
+}
+"
+         %68 = OpString "textureProj"
+         %69 = OpString ""
+         %78 = OpString "dist"
+         %82 = OpString "shadowCoord"
+         %85 = OpString "shadow"
+         %89 = OpString "offset"
+         %92 = OpString "layer"
+         %95 = OpString "P"
+         %99 = OpString "filterPCF"
+        %108 = OpString "int"
+        %110 = OpString "y"
+        %114 = OpString "x"
+        %118 = OpString "range"
+        %122 = OpString "count"
+        %125 = OpString "shadowFactor"
+        %128 = OpString "dy"
+        %131 = OpString "dx"
+        %134 = OpString "scale"
+        %137 = OpString "levels"
+        %141 = OpString "elements"
+        %145 = OpString "texDim"
+        %150 = OpString "sc"
+        %162 = OpString "shadowClip"
+        %166 = OpString "i"
+        %169 = OpString "fragPos"
+        %171 = OpString "fragcolor"
+        %175 = OpString "main"
+        %184 = OpString "spec"
+        %187 = OpString "NdotR"
+        %190 = OpString "R"
+        %193 = OpString "diff"
+        %196 = OpString "NdotL"
+        %199 = OpString "heightAttenuation"
+        %202 = OpString "spotEffect"
+        %205 = OpString "cosDir"
+        %208 = OpString "dir"
+        %211 = OpString "lightRange"
+        %214 = OpString "lightCosOuterAngle"
+        %217 = OpString "lightCosInnerAngle"
+        %220 = OpString "V"
+        %225 = OpString "L"
+        %230 = OpString "N"
+        %235 = OpString "albedo"
+        %238 = OpString "normal"
+        %244 = OpString "inUV"
+        %246 = OpString "viewPos"
+        %249 = OpString "position"
+        %252 = OpString "target"
+        %254 = OpString "color"
+        %259 = OpString "viewMatrix"
+        %263 = OpString "Light"
+        %267 = OpString "lights"
+        %271 = OpString "useShadows"
+        %275 = OpString "displayDebugTarget"
+        %278 = OpString "UBO"
+        %282 = OpString "ubo"
+        %285 = OpString "type.ubo"
+        %289 = OpString "@type.sampler"
+        %290 = OpString "type.sampler"
+        %292 = OpString "samplerShadowMap"
+        %295 = OpString "@type.2d.image.array"
+        %296 = OpString "type.2d.image.array"
+        %298 = OpString "TemplateParam"
+        %301 = OpString "textureShadowMap"
+        %304 = OpString "samplerAlbedo"
+        %306 = OpString "@type.2d.image"
+        %307 = OpString "type.2d.image"
+        %311 = OpString "textureAlbedo"
+        %313 = OpString "samplerNormal"
+        %315 = OpString "textureNormal"
+        %317 = OpString "samplerposition"
+        %319 = OpString "textureposition"
+               OpName %type_2d_image "type.2d.image"
+               OpName %textureposition "textureposition"
+               OpName %type_sampler "type.sampler"
+               OpName %samplerposition "samplerposition"
+               OpName %textureNormal "textureNormal"
+               OpName %samplerNormal "samplerNormal"
+               OpName %textureAlbedo "textureAlbedo"
+               OpName %samplerAlbedo "samplerAlbedo"
+               OpName %type_2d_image_array "type.2d.image.array"
+               OpName %textureShadowMap "textureShadowMap"
+               OpName %samplerShadowMap "samplerShadowMap"
+               OpName %type_ubo "type.ubo"
+               OpMemberName %type_ubo 0 "ubo"
+               OpName %UBO "UBO"
+               OpMemberName %UBO 0 "viewPos"
+               OpMemberName %UBO 1 "lights"
+               OpMemberName %UBO 2 "useShadows"
+               OpMemberName %UBO 3 "displayDebugTarget"
+               OpName %Light "Light"
+               OpMemberName %Light 0 "position"
+               OpMemberName %Light 1 "target"
+               OpMemberName %Light 2 "color"
+               OpMemberName %Light 3 "viewMatrix"
+               OpName %ubo "ubo"
+               OpName %in_var_TEXCOORD0 "in.var.TEXCOORD0"
+               OpName %out_var_SV_TARGET "out.var.SV_TARGET"
+               OpName %main "main"
+               OpName %param_var_inUV "param.var.inUV"
+               OpName %type_sampled_image "type.sampled.image"
+               OpName %type_sampled_image_0 "type.sampled.image"
+               OpDecorate %in_var_TEXCOORD0 Location 0
+               OpDecorate %out_var_SV_TARGET Location 0
+               OpDecorate %textureposition DescriptorSet 0
+               OpDecorate %textureposition Binding 1
+               OpDecorate %samplerposition DescriptorSet 0
+               OpDecorate %samplerposition Binding 1
+               OpDecorate %textureNormal DescriptorSet 0
+               OpDecorate %textureNormal Binding 2
+               OpDecorate %samplerNormal DescriptorSet 0
+               OpDecorate %samplerNormal Binding 2
+               OpDecorate %textureAlbedo DescriptorSet 0
+               OpDecorate %textureAlbedo Binding 3
+               OpDecorate %samplerAlbedo DescriptorSet 0
+               OpDecorate %samplerAlbedo Binding 3
+               OpDecorate %textureShadowMap DescriptorSet 0
+               OpDecorate %textureShadowMap Binding 5
+               OpDecorate %samplerShadowMap DescriptorSet 0
+               OpDecorate %samplerShadowMap Binding 5
+               OpDecorate %ubo DescriptorSet 0
+               OpDecorate %ubo Binding 4
+               OpMemberDecorate %Light 0 Offset 0
+               OpMemberDecorate %Light 1 Offset 16
+               OpMemberDecorate %Light 2 Offset 32
+               OpMemberDecorate %Light 3 Offset 48
+               OpMemberDecorate %Light 3 MatrixStride 16
+               OpMemberDecorate %Light 3 RowMajor
+               OpDecorate %_arr_Light_uint_3 ArrayStride 112
+               OpMemberDecorate %UBO 0 Offset 0
+               OpMemberDecorate %UBO 1 Offset 16
+               OpMemberDecorate %UBO 2 Offset 352
+               OpMemberDecorate %UBO 3 Offset 356
+               OpMemberDecorate %type_ubo 0 Offset 0
+               OpDecorate %type_ubo Block
+)"
+      R"(   %float = OpTypeFloat 32
+%float_0_100000001 = OpConstant %float 0.100000001
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %int_3 = OpConstant %int 3
+      %int_1 = OpConstant %int 1
+   %float_15 = OpConstant %float 15
+   %float_25 = OpConstant %float 25
+  %float_100 = OpConstant %float 100
+    %float_0 = OpConstant %float 0
+   %float_16 = OpConstant %float 16
+  %float_2_5 = OpConstant %float 2.5
+      %int_2 = OpConstant %int 2
+    %float_1 = OpConstant %float 1
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+  %float_1_5 = OpConstant %float 1.5
+  %float_0_5 = OpConstant %float 0.5
+    %v2float = OpTypeVector %float 2
+         %35 = OpConstantComposite %v2float %float_0_5 %float_0_5
+   %float_n1 = OpConstant %float -1
+ %float_0_25 = OpConstant %float 0.25
+    %uint_32 = OpConstant %uint 32
+%type_2d_image = OpTypeImage %float 2D 2 0 0 1 Unknown
+%_ptr_UniformConstant_type_2d_image = OpTypePointer UniformConstant %type_2d_image
+%type_sampler = OpTypeSampler
+%_ptr_UniformConstant_type_sampler = OpTypePointer UniformConstant %type_sampler
+%type_2d_image_array = OpTypeImage %float 2D 2 1 0 1 Unknown
+%_ptr_UniformConstant_type_2d_image_array = OpTypePointer UniformConstant %type_2d_image_array
+    %v4float = OpTypeVector %float 4
+     %uint_3 = OpConstant %uint 3
+%mat4v4float = OpTypeMatrix %v4float 4
+      %Light = OpTypeStruct %v4float %v4float %v4float %mat4v4float
+%_arr_Light_uint_3 = OpTypeArray %Light %uint_3
+        %UBO = OpTypeStruct %v4float %_arr_Light_uint_3 %int %int
+   %type_ubo = OpTypeStruct %UBO
+%_ptr_Uniform_type_ubo = OpTypePointer Uniform %type_ubo
+%_ptr_Input_v2float = OpTypePointer Input %v2float
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+       %void = OpTypeVoid
+     %uint_4 = OpConstant %uint 4
+     %uint_2 = OpConstant %uint 2
+     %uint_1 = OpConstant %uint 1
+     %uint_5 = OpConstant %uint 5
+    %uint_37 = OpConstant %uint 37
+    %uint_38 = OpConstant %uint 38
+    %uint_44 = OpConstant %uint 44
+    %uint_47 = OpConstant %uint 47
+    %uint_45 = OpConstant %uint 45
+     %uint_9 = OpConstant %uint 9
+    %uint_40 = OpConstant %uint 40
+    %uint_39 = OpConstant %uint 39
+     %uint_8 = OpConstant %uint 8
+    %uint_49 = OpConstant %uint 49
+    %uint_35 = OpConstant %uint 35
+    %uint_26 = OpConstant %uint 26
+    %uint_54 = OpConstant %uint 54
+    %uint_55 = OpConstant %uint 55
+    %uint_67 = OpConstant %uint 67
+    %uint_69 = OpConstant %uint 69
+    %uint_68 = OpConstant %uint 68
+    %uint_12 = OpConstant %uint 12
+    %uint_66 = OpConstant %uint 66
+    %uint_11 = OpConstant %uint 11
+    %uint_64 = OpConstant %uint 64
+     %uint_6 = OpConstant %uint 6
+    %uint_63 = OpConstant %uint 63
+    %uint_62 = OpConstant %uint 62
+    %uint_60 = OpConstant %uint 60
+    %uint_59 = OpConstant %uint 59
+    %uint_58 = OpConstant %uint 58
+    %uint_56 = OpConstant %uint 56
+    %uint_33 = OpConstant %uint 33
+    %uint_19 = OpConstant %uint 19
+     %uint_7 = OpConstant %uint 7
+    %uint_34 = OpConstant %uint 34
+    %uint_24 = OpConstant %uint 24
+    %uint_78 = OpConstant %uint 78
+    %uint_80 = OpConstant %uint 80
+    %uint_83 = OpConstant %uint 83
+    %uint_81 = OpConstant %uint 81
+    %uint_10 = OpConstant %uint 10
+    %uint_79 = OpConstant %uint 79
+    %uint_22 = OpConstant %uint 22
+    %uint_95 = OpConstant %uint 95
+    %uint_96 = OpConstant %uint 96
+   %uint_145 = OpConstant %uint 145
+   %uint_108 = OpConstant %uint 108
+   %uint_138 = OpConstant %uint 138
+   %uint_137 = OpConstant %uint 137
+   %uint_136 = OpConstant %uint 136
+   %uint_133 = OpConstant %uint 133
+   %uint_132 = OpConstant %uint 132
+   %uint_129 = OpConstant %uint 129
+   %uint_128 = OpConstant %uint 128
+   %uint_127 = OpConstant %uint 127
+   %uint_124 = OpConstant %uint 124
+   %uint_121 = OpConstant %uint 121
+   %uint_120 = OpConstant %uint 120
+   %uint_119 = OpConstant %uint 119
+   %uint_116 = OpConstant %uint 116
+   %uint_112 = OpConstant %uint 112
+   %uint_110 = OpConstant %uint 110
+   %uint_107 = OpConstant %uint 107
+   %uint_105 = OpConstant %uint 105
+   %uint_103 = OpConstant %uint 103
+   %uint_100 = OpConstant %uint 100
+    %uint_99 = OpConstant %uint 99
+    %uint_98 = OpConstant %uint 98
+    %uint_29 = OpConstant %uint 29
+    %uint_21 = OpConstant %uint 21
+   %uint_256 = OpConstant %uint 256
+    %uint_23 = OpConstant %uint 23
+   %uint_384 = OpConstant %uint 384
+   %uint_512 = OpConstant %uint 512
+   %uint_896 = OpConstant %uint 896
+  %uint_2688 = OpConstant %uint 2688
+    %uint_30 = OpConstant %uint 30
+  %uint_2816 = OpConstant %uint 2816
+    %uint_31 = OpConstant %uint 31
+  %uint_2848 = OpConstant %uint 2848
+  %uint_2880 = OpConstant %uint 2880
+    %uint_27 = OpConstant %uint 27
+  %uint_2944 = OpConstant %uint 2944
+    %uint_14 = OpConstant %uint 14
+    %uint_16 = OpConstant %uint 16
+        %321 = OpTypeFunction %void
+%_ptr_Function_v2float = OpTypePointer Function %v2float
+   %uint_150 = OpConstant %uint 150
+    %v3float = OpTypeVector %float 3
+%_ptr_Function_v3float = OpTypePointer Function %v3float
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+%_ptr_Function_int = OpTypePointer Function %int
+%_ptr_Function_float = OpTypePointer Function %float
+    %uint_42 = OpConstant %uint 42
+%type_sampled_image = OpTypeSampledImage %type_2d_image
+    %uint_65 = OpConstant %uint 65
+    %uint_18 = OpConstant %uint 18
+    %uint_13 = OpConstant %uint 13
+    %uint_15 = OpConstant %uint 15
+    %uint_17 = OpConstant %uint 17
+       %bool = OpTypeBool
+    %uint_25 = OpConstant %uint 25
+%_ptr_Uniform_UBO = OpTypePointer Uniform %UBO
+%_ptr_Uniform_v4float = OpTypePointer Uniform %v4float
+    %uint_28 = OpConstant %uint 28
+    %uint_43 = OpConstant %uint 43
+   %uint_113 = OpConstant %uint 113
+   %uint_117 = OpConstant %uint 117
+    %uint_46 = OpConstant %uint 46
+    %uint_76 = OpConstant %uint 76
+    %uint_53 = OpConstant %uint 53
+    %uint_73 = OpConstant %uint 73
+    %uint_48 = OpConstant %uint 48
+   %uint_140 = OpConstant %uint 140
+    %uint_52 = OpConstant %uint 52
+    %uint_93 = OpConstant %uint 93
+    %uint_87 = OpConstant %uint 87
+   %uint_106 = OpConstant %uint 106
+    %uint_36 = OpConstant %uint 36
+   %uint_144 = OpConstant %uint 144
+%_ptr_Uniform_int = OpTypePointer Uniform %int
+   %uint_146 = OpConstant %uint 146
+   %uint_147 = OpConstant %uint 147
+   %uint_149 = OpConstant %uint 149
+    %uint_41 = OpConstant %uint 41
+%_ptr_Uniform_mat4v4float = OpTypePointer Uniform %mat4v4float
+    %uint_77 = OpConstant %uint 77
+    %uint_85 = OpConstant %uint 85
+    %uint_90 = OpConstant %uint 90
+    %uint_92 = OpConstant %uint 92
+      %v2int = OpTypeVector %int 2
+%_ptr_Function_v2int = OpTypePointer Function %v2int
+    %uint_57 = OpConstant %uint 57
+     %v3uint = OpTypeVector %uint 3
+    %uint_72 = OpConstant %uint 72
+    %uint_70 = OpConstant %uint 70
+    %uint_50 = OpConstant %uint 50
+    %uint_61 = OpConstant %uint 61
+    %uint_71 = OpConstant %uint 71
+    %uint_75 = OpConstant %uint 75
+    %uint_82 = OpConstant %uint 82
+%type_sampled_image_0 = OpTypeSampledImage %type_2d_image_array
+    %uint_51 = OpConstant %uint 51
+%textureposition = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant
+%samplerposition = OpVariable %_ptr_UniformConstant_type_sampler UniformConstant
+%textureNormal = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant
+%samplerNormal = OpVariable %_ptr_UniformConstant_type_sampler UniformConstant
+%textureAlbedo = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant
+%samplerAlbedo = OpVariable %_ptr_UniformConstant_type_sampler UniformConstant
+%textureShadowMap = OpVariable %_ptr_UniformConstant_type_2d_image_array UniformConstant
+%samplerShadowMap = OpVariable %_ptr_UniformConstant_type_sampler UniformConstant
+        %ubo = OpVariable %_ptr_Uniform_type_ubo Uniform
+%in_var_TEXCOORD0 = OpVariable %_ptr_Input_v2float Input
+%out_var_SV_TARGET = OpVariable %_ptr_Output_v4float Output
+  %uint_1792 = OpConstant %uint 1792
+  %uint_1869 = OpConstant %uint 1869
+  %uint_2060 = OpConstant %uint 2060
+        %288 = OpExtInst %void %2 DebugInfoNone
+        %243 = OpExtInst %void %2 DebugExpression
+         %57 = OpExtInst %void %2 DebugTypeBasic %55 %uint_32 %uint_3 %uint_0
+         %58 = OpExtInst %void %2 DebugTypeVector %57 %uint_4
+         %60 = OpExtInst %void %2 DebugTypeVector %57 %uint_2
+         %62 = OpExtInst %void %2 DebugTypeFunction %uint_3 %57 %58 %57 %60
+         %64 = OpExtInst %void %2 DebugSource %15 %63
+         %65 = OpExtInst %void %2 DebugCompilationUnit %uint_1 %uint_4 %64 %uint_5
+         %70 = OpExtInst %void %2 DebugFunction %68 %62 %64 %uint_37 %uint_1 %65 %69 %uint_3 %uint_38
+         %73 = OpExtInst %void %2 DebugLexicalBlock %64 %uint_38 %uint_1 %70
+         %74 = OpExtInst %void %2 DebugLexicalBlock %64 %uint_44 %uint_2 %73
+         %76 = OpExtInst %void %2 DebugLexicalBlock %64 %uint_47 %uint_3 %74
+         %79 = OpExtInst %void %2 DebugLocalVariable %78 %57 %64 %uint_45 %uint_9 %74 %uint_4
+         %83 = OpExtInst %void %2 DebugLocalVariable %82 %58 %64 %uint_40 %uint_9 %73 %uint_4
+         %86 = OpExtInst %void %2 DebugLocalVariable %85 %57 %64 %uint_39 %uint_8 %73 %uint_4
+         %90 = OpExtInst %void %2 DebugLocalVariable %89 %60 %64 %uint_37 %uint_49 %70 %uint_4 %uint_3
+         %93 = OpExtInst %void %2 DebugLocalVariable %92 %57 %64 %uint_37 %uint_35 %70 %uint_4 %uint_2
+         %96 = OpExtInst %void %2 DebugLocalVariable %95 %58 %64 %uint_37 %uint_26 %70 %uint_4 %uint_1
+         %98 = OpExtInst %void %2 DebugTypeFunction %uint_3 %57 %58 %57
+        %100 = OpExtInst %void %2 DebugFunction %99 %98 %64 %uint_54 %uint_1 %65 %69 %uint_3 %uint_55
+        %103 = OpExtInst %void %2 DebugLexicalBlock %64 %uint_55 %uint_1 %100
+        %104 = OpExtInst %void %2 DebugLexicalBlock %64 %uint_67 %uint_2 %103
+        %106 = OpExtInst %void %2 DebugLexicalBlock %64 %uint_69 %uint_3 %104
+        %109 = OpExtInst %void %2 DebugTypeBasic %108 %uint_32 %uint_4 %uint_0
+        %111 = OpExtInst %void %2 DebugLocalVariable %110 %109 %64 %uint_68 %uint_12 %104 %uint_4
+        %115 = OpExtInst %void %2 DebugLocalVariable %114 %109 %64 %uint_66 %uint_11 %103 %uint_4
+        %119 = OpExtInst %void %2 DebugLocalVariable %118 %109 %64 %uint_64 %uint_6 %103 %uint_4
+        %123 = OpExtInst %void %2 DebugLocalVariable %122 %109 %64 %uint_63 %uint_6 %103 %uint_4
+        %126 = OpExtInst %void %2 DebugLocalVariable %125 %57 %64 %uint_62 %uint_8 %103 %uint_4
+        %129 = OpExtInst %void %2 DebugLocalVariable %128 %57 %64 %uint_60 %uint_8 %103 %uint_4
+        %132 = OpExtInst %void %2 DebugLocalVariable %131 %57 %64 %uint_59 %uint_8 %103 %uint_4
+        %135 = OpExtInst %void %2 DebugLocalVariable %134 %57 %64 %uint_58 %uint_8 %103 %uint_4
+        %138 = OpExtInst %void %2 DebugLocalVariable %137 %109 %64 %uint_56 %uint_33 %103 %uint_4
+        %142 = OpExtInst %void %2 DebugLocalVariable %141 %109 %64 %uint_56 %uint_19 %103 %uint_4
+        %144 = OpExtInst %void %2 DebugTypeVector %109 %uint_2
+        %146 = OpExtInst %void %2 DebugLocalVariable %145 %144 %64 %uint_56 %uint_7 %103 %uint_4
+        %148 = OpExtInst %void %2 DebugLocalVariable %92 %57 %64 %uint_54 %uint_34 %100 %uint_4 %uint_2
+        %151 = OpExtInst %void %2 DebugLocalVariable %150 %58 %64 %uint_54 %uint_24 %100 %uint_4 %uint_1
+        %153 = OpExtInst %void %2 DebugTypeVector %57 %uint_3
+        %154 = OpExtInst %void %2 DebugTypeFunction %uint_3 %153 %153 %153
+        %155 = OpExtInst %void %2 DebugFunction %85 %154 %64 %uint_78 %uint_1 %65 %69 %uint_3 %uint_78
+        %157 = OpExtInst %void %2 DebugLexicalBlock %64 %uint_78 %uint_49 %155
+        %158 = OpExtInst %void %2 DebugLexicalBlock %64 %uint_80 %uint_2 %157
+        %160 = OpExtInst %void %2 DebugLocalVariable %125 %57 %64 %uint_83 %uint_9 %158 %uint_4
+        %163 = OpExtInst %void %2 DebugLocalVariable %162 %58 %64 %uint_81 %uint_10 %158 %uint_4
+        %167 = OpExtInst %void %2 DebugLocalVariable %166 %109 %64 %uint_79 %uint_11 %157 %uint_4
+        %170 = OpExtInst %void %2 DebugLocalVariable %169 %153 %64 %uint_78 %uint_40 %155 %uint_4 %uint_2
+        %172 = OpExtInst %void %2 DebugLocalVariable %171 %153 %64 %uint_78 %uint_22 %155 %uint_4 %uint_1
+        %174 = OpExtInst %void %2 DebugTypeFunction %uint_3 %58 %60
+        %176 = OpExtInst %void %2 DebugFunction %175 %174 %64 %uint_95 %uint_1 %65 %69 %uint_3 %uint_96
+        %179 = OpExtInst %void %2 DebugLexicalBlock %64 %uint_96 %uint_1 %176
+        %180 = OpExtInst %void %2 DebugLexicalBlock %64 %uint_145 %uint_2 %179
+        %182 = OpExtInst %void %2 DebugLexicalBlock %64 %uint_108 %uint_2 %179
+        %185 = OpExtInst %void %2 DebugLocalVariable %184 %153 %64 %uint_138 %uint_10 %182 %uint_4
+        %188 = OpExtInst %void %2 DebugLocalVariable %187 %57 %64 %uint_137 %uint_9 %182 %uint_4
+        %191 = OpExtInst %void %2 DebugLocalVariable %190 %153 %64 %uint_136 %uint_10 %182 %uint_4
+        %194 = OpExtInst %void %2 DebugLocalVariable %193 %153 %64 %uint_133 %uint_10 %182 %uint_4
+        %197 = OpExtInst %void %2 DebugLocalVariable %196 %57 %64 %uint_132 %uint_9 %182 %uint_4
+        %200 = OpExtInst %void %2 DebugLocalVariable %199 %57 %64 %uint_129 %uint_9 %182 %uint_4
+        %203 = OpExtInst %void %2 DebugLocalVariable %202 %57 %64 %uint_128 %uint_9 %182 %uint_4
+        %206 = OpExtInst %void %2 DebugLocalVariable %205 %57 %64 %uint_127 %uint_9 %182 %uint_4
+        %209 = OpExtInst %void %2 DebugLocalVariable %208 %153 %64 %uint_124 %uint_10 %182 %uint_4
+        %212 = OpExtInst %void %2 DebugLocalVariable %211 %57 %64 %uint_121 %uint_9 %182 %uint_4
+        %215 = OpExtInst %void %2 DebugLocalVariable %214 %57 %64 %uint_120 %uint_9 %182 %uint_4
+        %218 = OpExtInst %void %2 DebugLocalVariable %217 %57 %64 %uint_119 %uint_9 %182 %uint_4
+        %221 = OpExtInst %void %2 DebugLocalVariable %220 %153 %64 %uint_116 %uint_10 %182 %uint_4
+        %223 = OpExtInst %void %2 DebugLocalVariable %78 %57 %64 %uint_112 %uint_9 %182 %uint_4
+        %226 = OpExtInst %void %2 DebugLocalVariable %225 %153 %64 %uint_110 %uint_10 %182 %uint_4
+        %228 = OpExtInst %void %2 DebugLocalVariable %166 %109 %64 %uint_107 %uint_10 %179 %uint_4
+        %231 = OpExtInst %void %2 DebugLocalVariable %230 %153 %64 %uint_105 %uint_9 %179 %uint_4
+        %233 = OpExtInst %void %2 DebugLocalVariable %171 %153 %64 %uint_103 %uint_9 %179 %uint_4
+        %236 = OpExtInst %void %2 DebugLocalVariable %235 %58 %64 %uint_100 %uint_9 %179 %uint_4
+        %239 = OpExtInst %void %2 DebugLocalVariable %238 %153 %64 %uint_99 %uint_9 %179 %uint_4
+        %241 = OpExtInst %void %2 DebugLocalVariable %169 %153 %64 %uint_98 %uint_9 %179 %uint_4
+        %245 = OpExtInst %void %2 DebugLocalVariable %244 %60 %64 %uint_95 %uint_40 %176 %uint_4 %uint_1
+)"
+      R"(     %247 = OpExtInst %void %2 DebugTypeMember %246 %58 %64 %uint_29 %uint_9 %uint_0 %uint_128 %uint_3
+        %250 = OpExtInst %void %2 DebugTypeMember %249 %58 %64 %uint_21 %uint_9 %uint_0 %uint_128 %uint_3
+        %253 = OpExtInst %void %2 DebugTypeMember %252 %58 %64 %uint_22 %uint_9 %uint_128 %uint_128 %uint_3
+        %256 = OpExtInst %void %2 DebugTypeMember %254 %58 %64 %uint_23 %uint_9 %uint_256 %uint_128 %uint_3
+        %258 = OpExtInst %void %2 DebugTypeArray %57 %uint_4 %uint_4
+        %262 = OpExtInst %void %2 DebugTypeMember %259 %258 %64 %uint_24 %uint_11 %uint_384 %uint_512 %uint_3
+        %265 = OpExtInst %void %2 DebugTypeComposite %263 %uint_1 %64 %uint_19 %uint_8 %65 %263 %uint_896 %uint_3 %250 %253 %256 %262
+        %266 = OpExtInst %void %2 DebugTypeArray %265 %uint_3
+        %269 = OpExtInst %void %2 DebugTypeMember %267 %266 %64 %uint_30 %uint_8 %uint_128 %uint_2688 %uint_3
+        %273 = OpExtInst %void %2 DebugTypeMember %271 %109 %64 %uint_31 %uint_6 %uint_2816 %uint_32 %uint_3
+        %277 = OpExtInst %void %2 DebugTypeMember %275 %109 %64 %uint_32 %uint_6 %uint_2848 %uint_32 %uint_3
+        %280 = OpExtInst %void %2 DebugTypeComposite %278 %uint_1 %64 %uint_27 %uint_8 %65 %278 %uint_2880 %uint_3 %247 %269 %273 %277
+        %284 = OpExtInst %void %2 DebugTypeMember %282 %280 %64 %uint_35 %uint_34 %uint_0 %uint_2944 %uint_3
+        %286 = OpExtInst %void %2 DebugTypeComposite %285 %uint_1 %64 %uint_35 %uint_9 %65 %285 %uint_2944 %uint_3 %284
+        %287 = OpExtInst %void %2 DebugGlobalVariable %282 %286 %64 %uint_35 %uint_9 %65 %282 %ubo %uint_8
+        %291 = OpExtInst %void %2 DebugTypeComposite %289 %uint_1 %64 %uint_0 %uint_0 %65 %290 %288 %uint_3
+        %293 = OpExtInst %void %2 DebugGlobalVariable %292 %291 %64 %uint_12 %uint_14 %65 %292 %samplerShadowMap %uint_8
+        %297 = OpExtInst %void %2 DebugTypeComposite %295 %uint_0 %64 %uint_0 %uint_0 %65 %296 %288 %uint_3
+        %299 = OpExtInst %void %2 DebugTypeTemplateParameter %298 %58 %288 %64 %uint_0 %uint_0
+        %300 = OpExtInst %void %2 DebugTypeTemplate %297 %299
+        %302 = OpExtInst %void %2 DebugGlobalVariable %301 %300 %64 %uint_11 %uint_16 %65 %301 %textureShadowMap %uint_8
+        %305 = OpExtInst %void %2 DebugGlobalVariable %304 %291 %64 %uint_8 %uint_14 %65 %304 %samplerAlbedo %uint_8
+        %308 = OpExtInst %void %2 DebugTypeComposite %306 %uint_0 %64 %uint_0 %uint_0 %65 %307 %288 %uint_3
+        %309 = OpExtInst %void %2 DebugTypeTemplateParameter %298 %58 %288 %64 %uint_0 %uint_0
+        %310 = OpExtInst %void %2 DebugTypeTemplate %308 %309
+        %312 = OpExtInst %void %2 DebugGlobalVariable %311 %310 %64 %uint_7 %uint_11 %65 %311 %textureAlbedo %uint_8
+        %314 = OpExtInst %void %2 DebugGlobalVariable %313 %291 %64 %uint_6 %uint_14 %65 %313 %samplerNormal %uint_8
+        %316 = OpExtInst %void %2 DebugGlobalVariable %315 %310 %64 %uint_5 %uint_11 %65 %315 %textureNormal %uint_8
+        %318 = OpExtInst %void %2 DebugGlobalVariable %317 %291 %64 %uint_4 %uint_14 %65 %317 %samplerposition %uint_8
+        %320 = OpExtInst %void %2 DebugGlobalVariable %319 %310 %64 %uint_3 %uint_11 %65 %319 %textureposition %uint_8
+       %1803 = OpExtInst %void %2 DebugInlinedAt %uint_1792 %180
+       %1885 = OpExtInst %void %2 DebugInlinedAt %uint_1869 %158 %1803
+       %2085 = OpExtInst %void %2 DebugInlinedAt %uint_2060 %106 %1885
+)"
+      R"(    %main = OpFunction %void None %321
+        %322 = OpLabel
+       %2083 = OpVariable %_ptr_Function_float Function
+       %2086 = OpVariable %_ptr_Function_v4float Function
+       %1883 = OpVariable %_ptr_Function_v2int Function
+       %1891 = OpVariable %_ptr_Function_float Function
+       %1892 = OpVariable %_ptr_Function_int Function
+       %1894 = OpVariable %_ptr_Function_int Function
+       %1895 = OpVariable %_ptr_Function_int Function
+       %1896 = OpVariable %_ptr_Function_v4float Function
+       %1801 = OpVariable %_ptr_Function_int Function
+       %1447 = OpVariable %_ptr_Function_v4float Function
+       %1448 = OpVariable %_ptr_Function_v3float Function
+       %1450 = OpVariable %_ptr_Function_int Function
+       %1451 = OpVariable %_ptr_Function_v3float Function
+       %1453 = OpVariable %_ptr_Function_v3float Function
+       %1466 = OpVariable %_ptr_Function_v3float Function
+%param_var_inUV = OpVariable %_ptr_Function_v2float Function
+        %325 = OpExtInst %void %2 DebugFunctionDefinition %176 %main
+        %326 = OpLoad %v2float %in_var_TEXCOORD0
+               OpStore %param_var_inUV %326
+       %2290 = OpExtInst %void %2 DebugScope %176
+       %1620 = OpExtInst %void %2 DebugLine %64 %uint_95 %uint_95 %uint_33 %uint_40
+       %1470 = OpExtInst %void %2 DebugDeclare %245 %param_var_inUV %243
+       %2291 = OpExtInst %void %2 DebugScope %179
+       %1621 = OpExtInst %void %2 DebugLine %64 %uint_98 %uint_98 %uint_19 %uint_19
+       %1471 = OpLoad %type_2d_image %textureposition
+       %1622 = OpExtInst %void %2 DebugLine %64 %uint_98 %uint_98 %uint_42 %uint_42
+       %1472 = OpLoad %type_sampler %samplerposition
+       %1624 = OpExtInst %void %2 DebugLine %64 %uint_98 %uint_98 %uint_19 %uint_63
+       %1474 = OpSampledImage %type_sampled_image %1471 %1472
+       %1475 = OpImageSampleImplicitLod %v4float %1474 %326 None
+       %1626 = OpExtInst %void %2 DebugLine %64 %uint_98 %uint_98 %uint_19 %uint_65
+       %1476 = OpVectorShuffle %v3float %1475 %1475 0 1 2
+       %2241 = OpExtInst %void %2 DebugLine %64 %uint_98 %uint_98 %uint_2 %uint_65
+       %2240 = OpExtInst %void %2 DebugValue %241 %1476 %243
+       %1629 = OpExtInst %void %2 DebugLine %64 %uint_99 %uint_99 %uint_18 %uint_18
+       %1478 = OpLoad %type_2d_image %textureNormal
+       %1630 = OpExtInst %void %2 DebugLine %64 %uint_99 %uint_99 %uint_39 %uint_39
+       %1479 = OpLoad %type_sampler %samplerNormal
+       %1632 = OpExtInst %void %2 DebugLine %64 %uint_99 %uint_99 %uint_18 %uint_58
+       %1481 = OpSampledImage %type_sampled_image %1478 %1479
+       %1482 = OpImageSampleImplicitLod %v4float %1481 %326 None
+       %1634 = OpExtInst %void %2 DebugLine %64 %uint_99 %uint_99 %uint_18 %uint_60
+       %1483 = OpVectorShuffle %v3float %1482 %1482 0 1 2
+       %2244 = OpExtInst %void %2 DebugLine %64 %uint_99 %uint_99 %uint_2 %uint_60
+       %2243 = OpExtInst %void %2 DebugValue %239 %1483 %243
+       %1637 = OpExtInst %void %2 DebugLine %64 %uint_100 %uint_100 %uint_18 %uint_18
+       %1485 = OpLoad %type_2d_image %textureAlbedo
+       %1638 = OpExtInst %void %2 DebugLine %64 %uint_100 %uint_100 %uint_39 %uint_39
+       %1486 = OpLoad %type_sampler %samplerAlbedo
+       %1640 = OpExtInst %void %2 DebugLine %64 %uint_100 %uint_100 %uint_18 %uint_58
+       %1488 = OpSampledImage %type_sampled_image %1485 %1486
+       %1489 = OpImageSampleImplicitLod %v4float %1488 %326 None
+       %1642 = OpExtInst %void %2 DebugLine %64 %uint_100 %uint_100 %uint_2 %uint_58
+               OpStore %1447 %1489
+       %1490 = OpExtInst %void %2 DebugDeclare %236 %1447 %243
+       %1645 = OpExtInst %void %2 DebugLine %64 %uint_103 %uint_103 %uint_22 %uint_29
+       %1492 = OpVectorShuffle %v3float %1489 %1489 0 1 2
+       %1646 = OpExtInst %void %2 DebugLine %64 %uint_103 %uint_103 %uint_22 %uint_35
+       %1493 = OpVectorTimesScalar %v3float %1492 %float_0_100000001
+       %1647 = OpExtInst %void %2 DebugLine %64 %uint_103 %uint_103 %uint_2 %uint_35
+               OpStore %1448 %1493
+       %1494 = OpExtInst %void %2 DebugDeclare %233 %1448 %243
+       %1650 = OpExtInst %void %2 DebugLine %64 %uint_105 %uint_105 %uint_13 %uint_29
+       %1496 = OpExtInst %v3float %1 Normalize %1483
+       %2247 = OpExtInst %void %2 DebugLine %64 %uint_105 %uint_105 %uint_2 %uint_29
+       %2246 = OpExtInst %void %2 DebugValue %231 %1496 %243
+       %1653 = OpExtInst %void %2 DebugLine %64 %uint_107 %uint_107 %uint_6 %uint_14
+               OpStore %1450 %int_0
+       %1498 = OpExtInst %void %2 DebugDeclare %228 %1450 %243
+       %1655 = OpExtInst %void %2 DebugLine %64 %uint_107 %uint_107 %uint_6 %uint_15
+               OpBranch %1499
+       %1499 = OpLabel
+       %2292 = OpExtInst %void %2 DebugScope %179
+       %1656 = OpExtInst %void %2 DebugLine %64 %uint_107 %uint_107 %uint_17 %uint_17
+       %1500 = OpLoad %int %1450
+       %1657 = OpExtInst %void %2 DebugLine %64 %uint_107 %uint_107 %uint_17 %uint_21
+       %1501 = OpSLessThan %bool %1500 %int_3
+       %2293 = OpExtInst %void %2 DebugNoScope
+               OpLoopMerge %1605 %1602 None
+               OpBranchConditional %1501 %1502 %1605
+       %1502 = OpLabel
+       %2294 = OpExtInst %void %2 DebugScope %182
+       %1660 = OpExtInst %void %2 DebugLine %64 %uint_110 %uint_110 %uint_25 %uint_25
+       %1503 = OpLoad %int %1450
+       %1661 = OpExtInst %void %2 DebugLine %64 %uint_110 %uint_110 %uint_14 %uint_37
+       %1504 = OpAccessChain %_ptr_Uniform_UBO %ubo %int_0
+       %1505 = OpAccessChain %_ptr_Uniform_v4float %1504 %int_1 %1503 %int_0
+       %1663 = OpExtInst %void %2 DebugLine %64 %uint_110 %uint_110 %uint_14 %uint_28
+       %1506 = OpLoad %v4float %1505
+       %1664 = OpExtInst %void %2 DebugLine %64 %uint_110 %uint_110 %uint_14 %uint_37
+       %1507 = OpVectorShuffle %v3float %1506 %1506 0 1 2
+       %1666 = OpExtInst %void %2 DebugLine %64 %uint_110 %uint_110 %uint_14 %uint_43
+       %1509 = OpFSub %v3float %1507 %1476
+       %1667 = OpExtInst %void %2 DebugLine %64 %uint_110 %uint_110 %uint_3 %uint_43
+               OpStore %1451 %1509
+       %1510 = OpExtInst %void %2 DebugDeclare %226 %1451 %243
+       %1670 = OpExtInst %void %2 DebugLine %64 %uint_112 %uint_112 %uint_16 %uint_24
+       %1512 = OpExtInst %float %1 Length %1509
+       %2250 = OpExtInst %void %2 DebugLine %64 %uint_112 %uint_112 %uint_3 %uint_24
+       %2249 = OpExtInst %void %2 DebugValue %223 %1512 %243
+       %1674 = OpExtInst %void %2 DebugLine %64 %uint_113 %uint_113 %uint_7 %uint_18
+       %1515 = OpExtInst %v3float %1 Normalize %1509
+       %1675 = OpExtInst %void %2 DebugLine %64 %uint_113 %uint_113 %uint_3 %uint_18
+               OpStore %1451 %1515
+       %1676 = OpExtInst %void %2 DebugLine %64 %uint_116 %uint_116 %uint_14 %uint_26
+       %1516 = OpAccessChain %_ptr_Uniform_UBO %ubo %int_0
+       %1517 = OpAccessChain %_ptr_Uniform_v4float %1516 %int_0
+       %1678 = OpExtInst %void %2 DebugLine %64 %uint_116 %uint_116 %uint_14 %uint_18
+       %1518 = OpLoad %v4float %1517
+       %1679 = OpExtInst %void %2 DebugLine %64 %uint_116 %uint_116 %uint_14 %uint_26
+       %1519 = OpVectorShuffle %v3float %1518 %1518 0 1 2
+       %1681 = OpExtInst %void %2 DebugLine %64 %uint_116 %uint_116 %uint_14 %uint_32
+       %1521 = OpFSub %v3float %1519 %1476
+       %1682 = OpExtInst %void %2 DebugLine %64 %uint_116 %uint_116 %uint_3 %uint_32
+               OpStore %1453 %1521
+       %1522 = OpExtInst %void %2 DebugDeclare %221 %1453 %243
+       %1685 = OpExtInst %void %2 DebugLine %64 %uint_117 %uint_117 %uint_7 %uint_18
+       %1524 = OpExtInst %v3float %1 Normalize %1521
+       %1686 = OpExtInst %void %2 DebugLine %64 %uint_117 %uint_117 %uint_3 %uint_18
+               OpStore %1453 %1524
+       %1687 = OpExtInst %void %2 DebugLine %64 %uint_119 %uint_119 %uint_34 %uint_46
+       %1525 = OpExtInst %float %1 Radians %float_15
+       %1688 = OpExtInst %void %2 DebugLine %64 %uint_119 %uint_119 %uint_30 %uint_47
+       %1526 = OpExtInst %float %1 Cos %1525
+       %2253 = OpExtInst %void %2 DebugLine %64 %uint_119 %uint_119 %uint_3 %uint_47
+       %2252 = OpExtInst %void %2 DebugValue %218 %1526 %243
+       %1691 = OpExtInst %void %2 DebugLine %64 %uint_120 %uint_120 %uint_34 %uint_46
+       %1528 = OpExtInst %float %1 Radians %float_25
+       %1692 = OpExtInst %void %2 DebugLine %64 %uint_120 %uint_120 %uint_30 %uint_47
+       %1529 = OpExtInst %float %1 Cos %1528
+       %2256 = OpExtInst %void %2 DebugLine %64 %uint_120 %uint_120 %uint_3 %uint_47
+       %2255 = OpExtInst %void %2 DebugValue %215 %1529 %243
+       %2259 = OpExtInst %void %2 DebugLine %64 %uint_121 %uint_121 %uint_3 %uint_22
+       %2258 = OpExtInst %void %2 DebugValue %212 %float_100 %243
+       %1698 = OpExtInst %void %2 DebugLine %64 %uint_124 %uint_124 %uint_26 %uint_49
+       %1533 = OpAccessChain %_ptr_Uniform_UBO %ubo %int_0
+       %1534 = OpAccessChain %_ptr_Uniform_v4float %1533 %int_1 %1503 %int_0
+       %1700 = OpExtInst %void %2 DebugLine %64 %uint_124 %uint_124 %uint_26 %uint_40
+       %1535 = OpLoad %v4float %1534
+       %1701 = OpExtInst %void %2 DebugLine %64 %uint_124 %uint_124 %uint_26 %uint_49
+       %1536 = OpVectorShuffle %v3float %1535 %1535 0 1 2
+       %1703 = OpExtInst %void %2 DebugLine %64 %uint_124 %uint_124 %uint_55 %uint_76
+       %1538 = OpAccessChain %_ptr_Uniform_UBO %ubo %int_0
+       %1539 = OpAccessChain %_ptr_Uniform_v4float %1538 %int_1 %1503 %int_1
+       %1705 = OpExtInst %void %2 DebugLine %64 %uint_124 %uint_124 %uint_55 %uint_69
+       %1540 = OpLoad %v4float %1539
+       %1706 = OpExtInst %void %2 DebugLine %64 %uint_124 %uint_124 %uint_55 %uint_76
+       %1541 = OpVectorShuffle %v3float %1540 %1540 0 1 2
+       %1707 = OpExtInst %void %2 DebugLine %64 %uint_124 %uint_124 %uint_26 %uint_76
+       %1542 = OpFSub %v3float %1536 %1541
+       %1708 = OpExtInst %void %2 DebugLine %64 %uint_124 %uint_124 %uint_16 %uint_79
+       %1543 = OpExtInst %v3float %1 Normalize %1542
+       %2262 = OpExtInst %void %2 DebugLine %64 %uint_124 %uint_124 %uint_3 %uint_79
+       %2261 = OpExtInst %void %2 DebugValue %209 %1543 %243
+       %1713 = OpExtInst %void %2 DebugLine %64 %uint_127 %uint_127 %uint_18 %uint_28
+       %1547 = OpDot %float %1515 %1543
+       %2265 = OpExtInst %void %2 DebugLine %64 %uint_127 %uint_127 %uint_3 %uint_28
+       %2264 = OpExtInst %void %2 DebugValue %206 %1547 %243
+       %1719 = OpExtInst %void %2 DebugLine %64 %uint_128 %uint_128 %uint_22 %uint_79
+       %1552 = OpExtInst %float %1 SmoothStep %1529 %1526 %1547
+       %2268 = OpExtInst %void %2 DebugLine %64 %uint_128 %uint_128 %uint_3 %uint_79
+       %2267 = OpExtInst %void %2 DebugValue %203 %1552 %243
+       %1724 = OpExtInst %void %2 DebugLine %64 %uint_129 %uint_129 %uint_29 %uint_62
+       %1556 = OpExtInst %float %1 SmoothStep %float_100 %float_0 %1512
+       %2271 = OpExtInst %void %2 DebugLine %64 %uint_129 %uint_129 %uint_3 %uint_62
+       %2270 = OpExtInst %void %2 DebugValue %200 %1556 %243
+       %1729 = OpExtInst %void %2 DebugLine %64 %uint_132 %uint_132 %uint_26 %uint_34
+       %1560 = OpDot %float %1496 %1515
+       %1730 = OpExtInst %void %2 DebugLine %64 %uint_132 %uint_132 %uint_17 %uint_35
+       %1561 = OpExtInst %float %1 FMax %float_0 %1560
+       %2274 = OpExtInst %void %2 DebugLine %64 %uint_132 %uint_132 %uint_3 %uint_35
+       %2273 = OpExtInst %void %2 DebugValue %197 %1561 %243
+       %1734 = OpExtInst %void %2 DebugLine %64 %uint_133 %uint_133 %uint_17 %uint_23
+       %1564 = OpCompositeConstruct %v3float %1561 %1561 %1561
+       %2277 = OpExtInst %void %2 DebugLine %64 %uint_133 %uint_133 %uint_3 %uint_23
+       %2276 = OpExtInst %void %2 DebugValue %194 %1564 %243
+       %1738 = OpExtInst %void %2 DebugLine %64 %uint_136 %uint_136 %uint_22 %uint_23
+       %1567 = OpFNegate %v3float %1515
+       %1740 = OpExtInst %void %2 DebugLine %64 %uint_136 %uint_136 %uint_14 %uint_27
+       %1569 = OpExtInst %v3float %1 Reflect %1567 %1496
+       %2280 = OpExtInst %void %2 DebugLine %64 %uint_136 %uint_136 %uint_3 %uint_27
+       %2279 = OpExtInst %void %2 DebugValue %191 %1569 %243
+       %1745 = OpExtInst %void %2 DebugLine %64 %uint_137 %uint_137 %uint_26 %uint_34
+       %1573 = OpDot %float %1569 %1524
+       %1746 = OpExtInst %void %2 DebugLine %64 %uint_137 %uint_137 %uint_17 %uint_35
+       %1574 = OpExtInst %float %1 FMax %float_0 %1573
+       %2283 = OpExtInst %void %2 DebugLine %64 %uint_137 %uint_137 %uint_3 %uint_35
+       %2282 = OpExtInst %void %2 DebugValue %188 %1574 %243
+       %1750 = OpExtInst %void %2 DebugLine %64 %uint_138 %uint_138 %uint_18 %uint_33
+       %1577 = OpExtInst %float %1 Pow %1574 %float_16
+       %1751 = OpExtInst %void %2 DebugLine %64 %uint_138 %uint_138 %uint_37 %uint_44
+       %1578 = OpAccessChain %_ptr_Function_float %1447 %int_3
+       %1579 = OpLoad %float %1578
+       %1753 = OpExtInst %void %2 DebugLine %64 %uint_138 %uint_138 %uint_18 %uint_44
+       %1580 = OpFMul %float %1577 %1579
+       %1754 = OpExtInst %void %2 DebugLine %64 %uint_138 %uint_138 %uint_18 %uint_48
+       %1581 = OpFMul %float %1580 %float_2_5
+       %1755 = OpExtInst %void %2 DebugLine %64 %uint_138 %uint_138 %uint_17 %uint_53
+       %1582 = OpCompositeConstruct %v3float %1581 %1581 %1581
+       %2286 = OpExtInst %void %2 DebugLine %64 %uint_138 %uint_138 %uint_3 %uint_53
+       %2285 = OpExtInst %void %2 DebugValue %185 %1582 %243
+       %1760 = OpExtInst %void %2 DebugLine %64 %uint_140 %uint_140 %uint_24 %uint_31
+       %1586 = OpFAdd %v3float %1564 %1582
+       %1762 = OpExtInst %void %2 DebugLine %64 %uint_140 %uint_140 %uint_23 %uint_39
+       %1588 = OpVectorTimesScalar %v3float %1586 %1552
+       %1764 = OpExtInst %void %2 DebugLine %64 %uint_140 %uint_140 %uint_23 %uint_52
+       %1590 = OpVectorTimesScalar %v3float %1588 %1556
+       %1766 = OpExtInst %void %2 DebugLine %64 %uint_140 %uint_140 %uint_73 %uint_93
+       %1592 = OpAccessChain %_ptr_Uniform_UBO %ubo %int_0
+       %1593 = OpAccessChain %_ptr_Uniform_v4float %1592 %int_1 %1503 %int_2
+       %1768 = OpExtInst %void %2 DebugLine %64 %uint_140 %uint_140 %uint_73 %uint_87
+       %1594 = OpLoad %v4float %1593
+       %1769 = OpExtInst %void %2 DebugLine %64 %uint_140 %uint_140 %uint_73 %uint_93
+       %1595 = OpVectorShuffle %v3float %1594 %1594 0 1 2
+       %1770 = OpExtInst %void %2 DebugLine %64 %uint_140 %uint_140 %uint_16 %uint_93
+       %1596 = OpFMul %v3float %1590 %1595
+       %1772 = OpExtInst %void %2 DebugLine %64 %uint_140 %uint_140 %uint_99 %uint_106
+       %1598 = OpVectorShuffle %v3float %1489 %1489 0 1 2
+       %1773 = OpExtInst %void %2 DebugLine %64 %uint_140 %uint_140 %uint_16 %uint_106
+       %1599 = OpFMul %v3float %1596 %1598
+       %1774 = OpExtInst %void %2 DebugLine %64 %uint_140 %uint_140 %uint_3 %uint_3
+       %1600 = OpLoad %v3float %1448
+       %1775 = OpExtInst %void %2 DebugLine %64 %uint_140 %uint_140 %uint_3 %uint_106
+       %1601 = OpFAdd %v3float %1600 %1599
+               OpStore %1448 %1601
+       %2295 = OpExtInst %void %2 DebugScope %179
+       %1777 = OpExtInst %void %2 DebugLine %64 %uint_107 %uint_107 %uint_34 %uint_36
+               OpBranch %1602
+       %1602 = OpLabel
+       %2296 = OpExtInst %void %2 DebugScope %179
+       %1778 = OpExtInst %void %2 DebugLine %64 %uint_107 %uint_107 %uint_34 %uint_36
+       %1603 = OpLoad %int %1450
+       %1604 = OpIAdd %int %1603 %int_1
+               OpStore %1450 %1604
+               OpBranch %1499
+       %1605 = OpLabel
+       %2297 = OpExtInst %void %2 DebugScope %179
+       %1782 = OpExtInst %void %2 DebugLine %64 %uint_144 %uint_144 %uint_6 %uint_10
+       %1606 = OpAccessChain %_ptr_Uniform_UBO %ubo %int_0
+       %1607 = OpAccessChain %_ptr_Uniform_int %1606 %int_2
+       %1608 = OpLoad %int %1607
+       %1785 = OpExtInst %void %2 DebugLine %64 %uint_144 %uint_144 %uint_6 %uint_23
+       %1609 = OpSGreaterThan %bool %1608 %int_0
+       %2298 = OpExtInst %void %2 DebugNoScope
+               OpSelectionMerge %1614 None
+               OpBranchConditional %1609 %1610 %1614
+)"
+      R"(    %1610 = OpLabel
+       %2299 = OpExtInst %void %2 DebugScope %180
+       %1788 = OpExtInst %void %2 DebugLine %64 %uint_146 %uint_146 %uint_22 %uint_22
+       %1611 = OpLoad %v3float %1448
+               OpStore %1466 %1611
+       %2300 = OpExtInst %void %2 DebugScope %155 %1803
+       %1842 = OpExtInst %void %2 DebugLine %64 %uint_78 %uint_78 %uint_15 %uint_22
+       %1810 = OpExtInst %void %2 DebugDeclare %172 %1466 %243
+       %2301 = OpExtInst %void %2 DebugScope %180
+       %2289 = OpExtInst %void %2 DebugLine %64 %uint_146 %uint_146 %uint_33 %uint_33
+       %2288 = OpExtInst %void %2 DebugValue %170 %1476 %243
+       %2302 = OpExtInst %void %2 DebugScope %157 %1803
+       %1844 = OpExtInst %void %2 DebugLine %64 %uint_79 %uint_79 %uint_7 %uint_15
+               OpStore %1801 %int_0
+       %1813 = OpExtInst %void %2 DebugDeclare %167 %1801 %243
+       %1846 = OpExtInst %void %2 DebugLine %64 %uint_79 %uint_79 %uint_7 %uint_16
+               OpBranch %1814
+       %1814 = OpLabel
+       %2303 = OpExtInst %void %2 DebugScope %157 %1803
+       %1847 = OpExtInst %void %2 DebugLine %64 %uint_79 %uint_79 %uint_18 %uint_18
+       %1815 = OpLoad %int %1801
+       %1848 = OpExtInst %void %2 DebugLine %64 %uint_79 %uint_79 %uint_18 %uint_22
+       %1816 = OpSLessThan %bool %1815 %int_3
+       %2304 = OpExtInst %void %2 DebugNoScope
+               OpLoopMerge %1840 %1837 None
+               OpBranchConditional %1816 %1817 %1840
+       %1817 = OpLabel
+       %2305 = OpExtInst %void %2 DebugScope %158 %1803
+       %1851 = OpExtInst %void %2 DebugLine %64 %uint_81 %uint_81 %uint_38 %uint_38
+       %1818 = OpLoad %int %1801
+       %1852 = OpExtInst %void %2 DebugLine %64 %uint_81 %uint_81 %uint_27 %uint_41
+       %1819 = OpAccessChain %_ptr_Uniform_UBO %ubo %int_0
+       %1820 = OpAccessChain %_ptr_Uniform_mat4v4float %1819 %int_1 %1818 %int_3
+       %1821 = OpLoad %mat4v4float %1820
+       %1856 = OpExtInst %void %2 DebugLine %64 %uint_81 %uint_81 %uint_60 %uint_68
+       %1823 = OpCompositeExtract %float %1476 0
+       %1824 = OpCompositeExtract %float %1476 1
+       %1825 = OpCompositeExtract %float %1476 2
+       %1859 = OpExtInst %void %2 DebugLine %64 %uint_81 %uint_81 %uint_53 %uint_76
+       %1826 = OpCompositeConstruct %v4float %1823 %1824 %1825 %float_1
+       %1860 = OpExtInst %void %2 DebugLine %64 %uint_81 %uint_81 %uint_23 %uint_77
+       %1827 = OpVectorTimesMatrix %v4float %1826 %1821
+       %2229 = OpExtInst %void %2 DebugLine %64 %uint_81 %uint_81 %uint_3 %uint_77
+       %2228 = OpExtInst %void %2 DebugValue %163 %1827 %243
+       %1867 = OpExtInst %void %2 DebugLine %64 %uint_85 %uint_85 %uint_40 %uint_40
+       %1832 = OpConvertSToF %float %1818
+       %2235 = OpExtInst %void %2 DebugLine %64 %uint_85 %uint_85 %uint_28 %uint_28
+       %2234 = OpExtInst %void %2 DebugValue %151 %1827 %243
+       %2238 = OpExtInst %void %2 DebugLine %64 %uint_85 %uint_85 %uint_40 %uint_40
+       %2237 = OpExtInst %void %2 DebugValue %148 %1832 %243
+       %2306 = OpExtInst %void %2 DebugScope %103 %1885
+       %1983 = OpExtInst %void %2 DebugLine %64 %uint_56 %uint_56 %uint_2 %uint_7
+       %1904 = OpExtInst %void %2 DebugDeclare %146 %1883 %243
+       %1986 = OpExtInst %void %2 DebugLine %64 %uint_57 %uint_57 %uint_2 %uint_2
+       %1907 = OpLoad %type_2d_image_array %textureShadowMap
+)"
+      R"(    %1987 = OpExtInst %void %2 DebugLine %64 %uint_57 %uint_57 %uint_2 %uint_72
+       %1908 = OpImageQuerySizeLod %v3uint %1907 %uint_0
+       %1909 = OpCompositeExtract %uint %1908 0
+       %1910 = OpBitcast %int %1909
+       %1911 = OpAccessChain %_ptr_Function_int %1883 %int_0
+               OpStore %1911 %1910
+       %1912 = OpCompositeExtract %uint %1908 1
+       %1913 = OpBitcast %int %1912
+       %1914 = OpAccessChain %_ptr_Function_int %1883 %int_1
+               OpStore %1914 %1913
+       %1915 = OpCompositeExtract %uint %1908 2
+       %1916 = OpBitcast %int %1915
+       %2204 = OpExtInst %void %2 DebugValue %142 %1916 %243
+       %1999 = OpExtInst %void %2 DebugLine %64 %uint_57 %uint_57 %uint_19 %uint_19
+       %1917 = OpImageQueryLevels %uint %1907
+       %2000 = OpExtInst %void %2 DebugLine %64 %uint_57 %uint_57 %uint_2 %uint_72
+       %1918 = OpBitcast %int %1917
+       %2207 = OpExtInst %void %2 DebugValue %138 %1918 %243
+       %2211 = OpExtInst %void %2 DebugLine %64 %uint_58 %uint_58 %uint_2 %uint_16
+       %2210 = OpExtInst %void %2 DebugValue %135 %float_1_5 %243
+       %2005 = OpExtInst %void %2 DebugLine %64 %uint_59 %uint_59 %uint_13 %uint_21
+       %1921 = OpFMul %float %float_1_5 %float_1
+       %2006 = OpExtInst %void %2 DebugLine %64 %uint_59 %uint_59 %uint_33 %uint_40
+       %1922 = OpAccessChain %_ptr_Function_int %1883 %int_0
+       %1923 = OpLoad %int %1922
+       %1924 = OpConvertSToF %float %1923
+       %2009 = OpExtInst %void %2 DebugLine %64 %uint_59 %uint_59 %uint_13 %uint_41
+       %1925 = OpFDiv %float %1921 %1924
+       %2214 = OpExtInst %void %2 DebugLine %64 %uint_59 %uint_59 %uint_2 %uint_41
+       %2213 = OpExtInst %void %2 DebugValue %132 %1925 %243
+       %2013 = OpExtInst %void %2 DebugLine %64 %uint_60 %uint_60 %uint_13 %uint_21
+       %1928 = OpFMul %float %float_1_5 %float_1
+       %2014 = OpExtInst %void %2 DebugLine %64 %uint_60 %uint_60 %uint_33 %uint_40
+       %1929 = OpAccessChain %_ptr_Function_int %1883 %int_1
+       %1930 = OpLoad %int %1929
+       %1931 = OpConvertSToF %float %1930
+       %2017 = OpExtInst %void %2 DebugLine %64 %uint_60 %uint_60 %uint_13 %uint_41
+       %1932 = OpFDiv %float %1928 %1931
+       %2217 = OpExtInst %void %2 DebugLine %64 %uint_60 %uint_60 %uint_2 %uint_41
+       %2216 = OpExtInst %void %2 DebugValue %129 %1932 %243
+       %2020 = OpExtInst %void %2 DebugLine %64 %uint_62 %uint_62 %uint_2 %uint_23
+               OpStore %1891 %float_0
+       %1934 = OpExtInst %void %2 DebugDeclare %126 %1891 %243
+       %2022 = OpExtInst %void %2 DebugLine %64 %uint_63 %uint_63 %uint_2 %uint_14
+               OpStore %1892 %int_0
+       %1935 = OpExtInst %void %2 DebugDeclare %123 %1892 %243
+       %2220 = OpExtInst %void %2 DebugLine %64 %uint_64 %uint_64 %uint_2 %uint_14
+       %2219 = OpExtInst %void %2 DebugValue %119 %int_1 %243
+       %2027 = OpExtInst %void %2 DebugLine %64 %uint_66 %uint_66 %uint_15 %uint_16
+       %1938 = OpSNegate %int %int_1
+       %2028 = OpExtInst %void %2 DebugLine %64 %uint_66 %uint_66 %uint_7 %uint_16
+               OpStore %1894 %1938
+       %1939 = OpExtInst %void %2 DebugDeclare %115 %1894 %243
+       %2030 = OpExtInst %void %2 DebugLine %64 %uint_66 %uint_66 %uint_7 %uint_21
+               OpBranch %1940
+       %1940 = OpLabel
+       %2307 = OpExtInst %void %2 DebugScope %103 %1885
+       %2031 = OpExtInst %void %2 DebugLine %64 %uint_66 %uint_66 %uint_23 %uint_23
+       %1941 = OpLoad %int %1894
+       %2033 = OpExtInst %void %2 DebugLine %64 %uint_66 %uint_66 %uint_23 %uint_28
+       %1943 = OpSLessThanEqual %bool %1941 %int_1
+       %2308 = OpExtInst %void %2 DebugNoScope
+               OpLoopMerge %1976 %1973 None
+               OpBranchConditional %1943 %1944 %1976
+       %1944 = OpLabel
+       %2309 = OpExtInst %void %2 DebugScope %104 %1885
+       %2037 = OpExtInst %void %2 DebugLine %64 %uint_68 %uint_68 %uint_16 %uint_17
+       %1946 = OpSNegate %int %int_1
+       %2038 = OpExtInst %void %2 DebugLine %64 %uint_68 %uint_68 %uint_8 %uint_17
+               OpStore %1895 %1946
+       %1947 = OpExtInst %void %2 DebugDeclare %111 %1895 %243
+       %2040 = OpExtInst %void %2 DebugLine %64 %uint_68 %uint_68 %uint_8 %uint_22
+               OpBranch %1948
+       %1948 = OpLabel
+       %2310 = OpExtInst %void %2 DebugScope %104 %1885
+       %2041 = OpExtInst %void %2 DebugLine %64 %uint_68 %uint_68 %uint_24 %uint_24
+       %1949 = OpLoad %int %1895
+       %2043 = OpExtInst %void %2 DebugLine %64 %uint_68 %uint_68 %uint_24 %uint_29
+       %1951 = OpSLessThanEqual %bool %1949 %int_1
+       %2311 = OpExtInst %void %2 DebugNoScope
+               OpLoopMerge %1972 %1969 None
+               OpBranchConditional %1951 %1952 %1972
+       %1952 = OpLabel
+       %2312 = OpExtInst %void %2 DebugScope %106 %1885
+       %2047 = OpExtInst %void %2 DebugLine %64 %uint_70 %uint_70 %uint_32 %uint_32
+               OpStore %1896 %1827
+       %2051 = OpExtInst %void %2 DebugLine %64 %uint_70 %uint_70 %uint_53 %uint_53
+       %1956 = OpLoad %int %1894
+       %1957 = OpConvertSToF %float %1956
+       %2053 = OpExtInst %void %2 DebugLine %64 %uint_70 %uint_70 %uint_50 %uint_53
+       %1958 = OpFMul %float %1925 %1957
+       %2055 = OpExtInst %void %2 DebugLine %64 %uint_70 %uint_70 %uint_59 %uint_59
+       %1960 = OpLoad %int %1895
+       %1961 = OpConvertSToF %float %1960
+       %2057 = OpExtInst %void %2 DebugLine %64 %uint_70 %uint_70 %uint_56 %uint_59
+       %1962 = OpFMul %float %1932 %1961
+       %2058 = OpExtInst %void %2 DebugLine %64 %uint_70 %uint_70 %uint_43 %uint_60
+       %1963 = OpCompositeConstruct %v2float %1958 %1962
+       %2313 = OpExtInst %void %2 DebugScope %70 %2085
+       %2141 = OpExtInst %void %2 DebugLine %64 %uint_37 %uint_37 %uint_19 %uint_26
+       %2090 = OpExtInst %void %2 DebugDeclare %96 %1896 %243
+       %2314 = OpExtInst %void %2 DebugScope %106 %1885
+       %2223 = OpExtInst %void %2 DebugLine %64 %uint_70 %uint_70 %uint_36 %uint_36
+       %2222 = OpExtInst %void %2 DebugValue %93 %1832 %243
+       %2226 = OpExtInst %void %2 DebugLine %64 %uint_70 %uint_70 %uint_43 %uint_60
+       %2225 = OpExtInst %void %2 DebugValue %90 %1963 %243
+       %2315 = OpExtInst %void %2 DebugScope %73 %2085
+       %2144 = OpExtInst %void %2 DebugLine %64 %uint_39 %uint_39 %uint_2 %uint_17
+               OpStore %2083 %float_1
+       %2094 = OpExtInst %void %2 DebugDeclare %86 %2083 %243
+       %2147 = OpExtInst %void %2 DebugLine %64 %uint_40 %uint_40 %uint_27 %uint_29
+       %2096 = OpAccessChain %_ptr_Function_float %1896 %int_3
+       %2097 = OpLoad %float %2096
+       %2098 = OpCompositeConstruct %v4float %2097 %2097 %2097 %2097
+       %2150 = OpExtInst %void %2 DebugLine %64 %uint_40 %uint_40 %uint_23 %uint_29
+       %2099 = OpFDiv %v4float %1827 %2098
+       %2151 = OpExtInst %void %2 DebugLine %64 %uint_40 %uint_40 %uint_2 %uint_29
+               OpStore %2086 %2099
+       %2100 = OpExtInst %void %2 DebugDeclare %83 %2086 %243
+       %2154 = OpExtInst %void %2 DebugLine %64 %uint_41 %uint_41 %uint_19 %uint_31
+       %2102 = OpVectorShuffle %v2float %2099 %2099 0 1
+       %2155 = OpExtInst %void %2 DebugLine %64 %uint_41 %uint_41 %uint_19 %uint_36
+       %2103 = OpVectorTimesScalar %v2float %2102 %float_0_5
+       %2156 = OpExtInst %void %2 DebugLine %64 %uint_41 %uint_41 %uint_19 %uint_42
+       %2104 = OpFAdd %v2float %2103 %35
+       %2158 = OpExtInst %void %2 DebugLine %64 %uint_41 %uint_41 %uint_2 %uint_42
+       %2106 = OpVectorShuffle %v4float %2099 %2104 4 5 2 3
+               OpStore %2086 %2106
+       %2160 = OpExtInst %void %2 DebugLine %64 %uint_43 %uint_43 %uint_6 %uint_18
+       %2107 = OpAccessChain %_ptr_Function_float %2086 %int_2
+       %2108 = OpLoad %float %2107
+       %2162 = OpExtInst %void %2 DebugLine %64 %uint_43 %uint_43 %uint_6 %uint_23
+       %2109 = OpFOrdGreaterThan %bool %2108 %float_n1
+       %2163 = OpExtInst %void %2 DebugLine %64 %uint_43 %uint_43 %uint_30 %uint_42
+       %2110 = OpAccessChain %_ptr_Function_float %2086 %int_2
+       %2111 = OpLoad %float %2110
+       %2165 = OpExtInst %void %2 DebugLine %64 %uint_43 %uint_43 %uint_30 %uint_46
+       %2112 = OpFOrdLessThan %bool %2111 %float_1
+       %2166 = OpExtInst %void %2 DebugLine %64 %uint_43 %uint_43 %uint_6 %uint_46
+       %2113 = OpLogicalAnd %bool %2109 %2112
+       %2316 = OpExtInst %void %2 DebugNoScope
+               OpSelectionMerge %2139 None
+               OpBranchConditional %2113 %2114 %2139
+       %2114 = OpLabel
+       %2317 = OpExtInst %void %2 DebugScope %74 %2085
+       %2169 = OpExtInst %void %2 DebugLine %64 %uint_45 %uint_45 %uint_16 %uint_16
+       %2115 = OpLoad %type_2d_image_array %textureShadowMap
+       %2170 = OpExtInst %void %2 DebugLine %64 %uint_45 %uint_45 %uint_40 %uint_40
+       %2116 = OpLoad %type_sampler %samplerShadowMap
+       %2171 = OpExtInst %void %2 DebugLine %64 %uint_45 %uint_45 %uint_65 %uint_65
+       %2117 = OpLoad %v4float %2086
+       %2172 = OpExtInst %void %2 DebugLine %64 %uint_45 %uint_45 %uint_65 %uint_77
+       %2118 = OpVectorShuffle %v2float %2117 %2117 0 1
+       %2174 = OpExtInst %void %2 DebugLine %64 %uint_45 %uint_45 %uint_65 %uint_82
+       %2120 = OpFAdd %v2float %2118 %1963
+       %2122 = OpCompositeExtract %float %2120 0
+       %2123 = OpCompositeExtract %float %2120 1
+       %2178 = OpExtInst %void %2 DebugLine %64 %uint_45 %uint_45 %uint_58 %uint_95
+       %2124 = OpCompositeConstruct %v3float %2122 %2123 %1832
+       %2179 = OpExtInst %void %2 DebugLine %64 %uint_45 %uint_45 %uint_16 %uint_96
+       %2125 = OpSampledImage %type_sampled_image_0 %2115 %2116
+       %2126 = OpImageSampleImplicitLod %v4float %2125 %2124 None
+       %2181 = OpExtInst %void %2 DebugLine %64 %uint_45 %uint_45 %uint_16 %uint_98
+       %2127 = OpCompositeExtract %float %2126 0
+       %2202 = OpExtInst %void %2 DebugLine %64 %uint_45 %uint_45 %uint_3 %uint_98
+       %2201 = OpExtInst %void %2 DebugValue %79 %2127 %243
+       %2184 = OpExtInst %void %2 DebugLine %64 %uint_46 %uint_46 %uint_7 %uint_19
+       %2129 = OpAccessChain %_ptr_Function_float %2086 %int_3
+       %2130 = OpLoad %float %2129
+       %2186 = OpExtInst %void %2 DebugLine %64 %uint_46 %uint_46 %uint_7 %uint_23
+       %2131 = OpFOrdGreaterThan %bool %2130 %float_0
+       %2188 = OpExtInst %void %2 DebugLine %64 %uint_46 %uint_46 %uint_37 %uint_49
+       %2133 = OpAccessChain %_ptr_Function_float %2086 %int_2
+       %2134 = OpLoad %float %2133
+       %2190 = OpExtInst %void %2 DebugLine %64 %uint_46 %uint_46 %uint_30 %uint_49
+       %2135 = OpFOrdLessThan %bool %2127 %2134
+       %2191 = OpExtInst %void %2 DebugLine %64 %uint_46 %uint_46 %uint_7 %uint_49
+       %2136 = OpLogicalAnd %bool %2131 %2135
+       %2318 = OpExtInst %void %2 DebugNoScope
+               OpSelectionMerge %2138 None
+               OpBranchConditional %2136 %2137 %2138
+       %2137 = OpLabel
+       %2319 = OpExtInst %void %2 DebugScope %76 %2085
+       %2194 = OpExtInst %void %2 DebugLine %64 %uint_48 %uint_48 %uint_4 %uint_13
+               OpStore %2083 %float_0_25
+       %2320 = OpExtInst %void %2 DebugScope %74 %2085
+       %2195 = OpExtInst %void %2 DebugLine %64 %uint_49 %uint_49 %uint_3 %uint_3
+               OpBranch %2138
+       %2138 = OpLabel
+       %2321 = OpExtInst %void %2 DebugScope %73 %2085
+       %2196 = OpExtInst %void %2 DebugLine %64 %uint_50 %uint_50 %uint_2 %uint_2
+               OpBranch %2139
+       %2139 = OpLabel
+       %2322 = OpExtInst %void %2 DebugScope %73 %2085
+       %2197 = OpExtInst %void %2 DebugLine %64 %uint_51 %uint_51 %uint_9 %uint_9
+       %2140 = OpLoad %float %2083
+       %2323 = OpExtInst %void %2 DebugScope %106 %1885
+       %2061 = OpExtInst %void %2 DebugLine %64 %uint_70 %uint_70 %uint_4 %uint_4
+       %1965 = OpLoad %float %1891
+       %2062 = OpExtInst %void %2 DebugLine %64 %uint_70 %uint_70 %uint_4 %uint_61
+       %1966 = OpFAdd %float %1965 %2140
+               OpStore %1891 %1966
+       %2064 = OpExtInst %void %2 DebugLine %64 %uint_71 %uint_71 %uint_4 %uint_9
+       %1967 = OpLoad %int %1892
+       %1968 = OpIAdd %int %1967 %int_1
+               OpStore %1892 %1968
+       %2324 = OpExtInst %void %2 DebugScope %104 %1885
+       %2067 = OpExtInst %void %2 DebugLine %64 %uint_68 %uint_68 %uint_36 %uint_37
+               OpBranch %1969
+       %1969 = OpLabel
+       %2325 = OpExtInst %void %2 DebugScope %104 %1885
+       %2068 = OpExtInst %void %2 DebugLine %64 %uint_68 %uint_68 %uint_36 %uint_37
+       %1970 = OpLoad %int %1895
+       %1971 = OpIAdd %int %1970 %int_1
+               OpStore %1895 %1971
+               OpBranch %1948
+       %1972 = OpLabel
+       %2326 = OpExtInst %void %2 DebugScope %103 %1885
+       %2072 = OpExtInst %void %2 DebugLine %64 %uint_66 %uint_66 %uint_35 %uint_36
+               OpBranch %1973
+       %1973 = OpLabel
+       %2327 = OpExtInst %void %2 DebugScope %103 %1885
+       %2073 = OpExtInst %void %2 DebugLine %64 %uint_66 %uint_66 %uint_35 %uint_36
+       %1974 = OpLoad %int %1894
+       %1975 = OpIAdd %int %1974 %int_1
+               OpStore %1894 %1975
+               OpBranch %1940
+       %1976 = OpLabel
+       %2328 = OpExtInst %void %2 DebugScope %103 %1885
+       %2077 = OpExtInst %void %2 DebugLine %64 %uint_75 %uint_75 %uint_9 %uint_9
+       %1977 = OpLoad %float %1891
+       %2078 = OpExtInst %void %2 DebugLine %64 %uint_75 %uint_75 %uint_24 %uint_24
+       %1978 = OpLoad %int %1892
+       %1979 = OpConvertSToF %float %1978
+       %2080 = OpExtInst %void %2 DebugLine %64 %uint_75 %uint_75 %uint_9 %uint_24
+       %1980 = OpFDiv %float %1977 %1979
+       %2329 = OpExtInst %void %2 DebugScope %158 %1803
+       %2232 = OpExtInst %void %2 DebugLine %64 %uint_85 %uint_85 %uint_4 %uint_41
+       %2231 = OpExtInst %void %2 DebugValue %160 %1980 %243
+       %1872 = OpExtInst %void %2 DebugLine %64 %uint_90 %uint_90 %uint_3 %uint_3
+       %1835 = OpLoad %v3float %1466
+       %1873 = OpExtInst %void %2 DebugLine %64 %uint_90 %uint_90 %uint_3 %uint_16
+       %1836 = OpVectorTimesScalar %v3float %1835 %1980
+               OpStore %1466 %1836
+       %2330 = OpExtInst %void %2 DebugScope %157 %1803
+       %1875 = OpExtInst %void %2 DebugLine %64 %uint_79 %uint_79 %uint_35 %uint_37
+               OpBranch %1837
+       %1837 = OpLabel
+       %2331 = OpExtInst %void %2 DebugScope %157 %1803
+       %1876 = OpExtInst %void %2 DebugLine %64 %uint_79 %uint_79 %uint_35 %uint_37
+       %1838 = OpLoad %int %1801
+       %1839 = OpIAdd %int %1838 %int_1
+               OpStore %1801 %1839
+               OpBranch %1814
+       %1840 = OpLabel
+       %2332 = OpExtInst %void %2 DebugScope %157 %1803
+       %1880 = OpExtInst %void %2 DebugLine %64 %uint_92 %uint_92 %uint_9 %uint_9
+       %1841 = OpLoad %v3float %1466
+       %2333 = OpExtInst %void %2 DebugScope %180
+       %1793 = OpExtInst %void %2 DebugLine %64 %uint_146 %uint_146 %uint_3 %uint_40
+               OpStore %1448 %1841
+       %2334 = OpExtInst %void %2 DebugScope %179
+       %1794 = OpExtInst %void %2 DebugLine %64 %uint_147 %uint_147 %uint_2 %uint_2
+               OpBranch %1614
+       %1614 = OpLabel
+;CHECK:      %1614 = OpLabel
+;CHECK-NEXT: [[phi:%\w+]] = OpPhi 
+;CHECK-NEXT: {{%\w+}} = OpExtInst %void {{%\w+}} DebugValue %233
+       %2335 = OpExtInst %void %2 DebugScope %179
+       %1795 = OpExtInst %void %2 DebugLine %64 %uint_149 %uint_149 %uint_16 %uint_16
+       %1615 = OpLoad %v3float %1448
+       %1616 = OpCompositeExtract %float %1615 0
+       %1617 = OpCompositeExtract %float %1615 1
+       %1618 = OpCompositeExtract %float %1615 2
+       %1799 = OpExtInst %void %2 DebugLine %64 %uint_149 %uint_149 %uint_9 %uint_28
+       %1619 = OpCompositeConstruct %v4float %1616 %1617 %1618 %float_1
+       %2336 = OpExtInst %void %2 DebugNoLine
+       %2337 = OpExtInst %void %2 DebugNoScope
+               OpStore %out_var_SV_TARGET %1619
+        %329 = OpExtInst %void %2 DebugLine %64 %uint_150 %uint_150 %uint_1 %uint_1
+               OpReturn
+               OpFunctionEnd
+)";
+
+  SetTargetEnv(SPV_ENV_VULKAN_1_2);
+  SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  SinglePassRunAndMatch<SSARewritePass>(text, true);
 }
 
 // TODO(greg-lunarg): Add tests to verify handling of these cases:


### PR DESCRIPTION
Specificially, this fixes DebugValues coming out of eliminate-local-single-store and eliminate-local-multi-store AKA SSA rewrite.

This is done by bypassing the IsDeclareVisibleToInstr() analysis in the DebugInfoManager and just always generating a DebugValue when calling AddDebugValueIfVarDeclIsVisible() ie. assuming that the associated DebugDeclare is always visible. This is currently done through a force argument to AddDebugValueIfVarDeclIsVisible(), but this method will ultimately be changed to just AddDebugValue() along with other clean-up once this change is approved.

This change was created because several different issues with DebugValues were tracked back to this logic: several cases of missing DebugValues, one case of a DebugValue generated with stale (ie. no longer defined) operands.

While contemplating fixing AddDebugValueIfVarDeclIsVisible(), it became apparent that the visibility analysis is unnecessary, at least for generating valid and correct SPIR-V. This was confirmed empirically when bypassing this logic and always generating DebugDeclares fixed all the issues and generated valid and correct code for the shaders at issue. The two regression tests that changed likewise still generated valid and correct SPIR-V. Subsequent use of the fix by RenderDoc revealed no problems.

The theoretical reason the visibility analysis is not necessary is because the position of a DebugDeclare within a function is not truly significant. Admittedly, the description of DebugDeclare is misleading: `Define point of declaration of a [local variable]`. However, if one looks at the operands of DebugDeclare, one realizes the true purpose of this instruction: to link a (whole or partial) DebugLocalVariable to a (whole or partial) OpVariable. The line, column and scope of the DebugLocalVariable declaration is actually already contained in the the DebugLocalVariable instruction itself. To have the position of the DebugDeclare also represent this information would be redundant at best and error-prone at worst.

Given that the position of a DebugDeclare within a function is not truly significant, any analysis based on that position consequently is not meaningful. Another way to think about this is that a DebugDeclare is visible everywhere in the function it appears in.

While it is tempting to think that a DebugValue instruction must have a scope that is contained in the scope of its DebugLocalVariable, that in fact is not stated in either of the DebugInfo specs. This allows DebugValues to be easily generated at the spot of the OpStore that it is replacing. The DebugLocalVariable in the DebugValue contains all the information the tool needs to figure out what local variable is truly changed.

Once this change is approved, I will complete cleanup of this change.