### PR TITLE
spirv-val: Consistently quote ids in messages

### DIFF
--- a/source/val/validate_annotation.cpp
+++ b/source/val/validate_annotation.cpp
@@ -102,7 +102,7 @@ spv_result_t ValidateDecorationTarget(ValidationState_t& _, SpvDecoration dec,
     DiagnosticStream ds = std::move(
         _.diag(SPV_ERROR_INVALID_ID, inst)
         << _.VkErrorID(vuid) << _.SpvDecorationString(dec)
-        << " decoration on target <id> '" << _.getIdName(target->id()) << "' ");
+        << " decoration on target <id> " << _.getIdName(target->id()) << " ");
     return ds;
   };
   switch (dec) {
@@ -308,8 +308,8 @@ spv_result_t ValidateMemberDecorate(ValidationState_t& _,
   const auto struct_type = _.FindDef(struct_type_id);
   if (!struct_type || SpvOpTypeStruct != struct_type->opcode()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpMemberDecorate Structure type <id> '"
-           << _.getIdName(struct_type_id) << "' is not a struct type.";
+           << "OpMemberDecorate Structure type <id> "
+           << _.getIdName(struct_type_id) << " is not a struct type.";
   }
   const auto member = inst->GetOperandAs<uint32_t>(1);
   const auto member_count =
@@ -358,17 +358,16 @@ spv_result_t ValidateGroupDecorate(ValidationState_t& _,
   auto decoration_group = _.FindDef(decoration_group_id);
   if (!decoration_group || SpvOpDecorationGroup != decoration_group->opcode()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpGroupDecorate Decoration group <id> '"
-           << _.getIdName(decoration_group_id)
-           << "' is not a decoration group.";
+           << "OpGroupDecorate Decoration group <id> "
+           << _.getIdName(decoration_group_id) << " is not a decoration group.";
   }
   for (unsigned i = 1; i < inst->operands().size(); ++i) {
     auto target_id = inst->GetOperandAs<uint32_t>(i);
     auto target = _.FindDef(target_id);
     if (!target || target->opcode() == SpvOpDecorationGroup) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "OpGroupDecorate may not target OpDecorationGroup <id> '"
-             << _.getIdName(target_id) << "'";
+             << "OpGroupDecorate may not target OpDecorationGroup <id> "
+             << _.getIdName(target_id);
     }
   }
   return SPV_SUCCESS;
@@ -380,9 +379,8 @@ spv_result_t ValidateGroupMemberDecorate(ValidationState_t& _,
   const auto decoration_group = _.FindDef(decoration_group_id);
   if (!decoration_group || SpvOpDecorationGroup != decoration_group->opcode()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpGroupMemberDecorate Decoration group <id> '"
-           << _.getIdName(decoration_group_id)
-           << "' is not a decoration group.";
+           << "OpGroupMemberDecorate Decoration group <id> "
+           << _.getIdName(decoration_group_id) << " is not a decoration group.";
   }
   // Grammar checks ensures that the number of arguments to this instruction
   // is an odd number: 1 decoration group + (id,literal) pairs.
@@ -392,8 +390,8 @@ spv_result_t ValidateGroupMemberDecorate(ValidationState_t& _,
     auto struct_instr = _.FindDef(struct_id);
     if (!struct_instr || SpvOpTypeStruct != struct_instr->opcode()) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "OpGroupMemberDecorate Structure type <id> '"
-             << _.getIdName(struct_id) << "' is not a struct type.";
+             << "OpGroupMemberDecorate Structure type <id> "
+             << _.getIdName(struct_id) << " is not a struct type.";
     }
     const uint32_t num_struct_members =
         static_cast<uint32_t>(struct_instr->words().size() - 2);

--- a/source/val/validate_cfg.cpp
+++ b/source/val/validate_cfg.cpp
@@ -239,23 +239,23 @@ spv_result_t ValidateReturnValue(ValidationState_t& _,
   const auto value = _.FindDef(value_id);
   if (!value || !value->type_id()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpReturnValue Value <id> '" << _.getIdName(value_id)
-           << "' does not represent a value.";
+           << "OpReturnValue Value <id> " << _.getIdName(value_id)
+           << " does not represent a value.";
   }
   auto value_type = _.FindDef(value->type_id());
   if (!value_type || SpvOpTypeVoid == value_type->opcode()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpReturnValue value's type <id> '"
-           << _.getIdName(value->type_id()) << "' is missing or void.";
+           << "OpReturnValue value's type <id> "
+           << _.getIdName(value->type_id()) << " is missing or void.";
   }
 
   if (_.addressing_model() == SpvAddressingModelLogical &&
       SpvOpTypePointer == value_type->opcode() &&
       !_.features().variable_pointers && !_.options()->relax_logical_pointer) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpReturnValue value's type <id> '"
+           << "OpReturnValue value's type <id> "
            << _.getIdName(value->type_id())
-           << "' is a pointer, which is invalid in the Logical addressing "
+           << " is a pointer, which is invalid in the Logical addressing "
               "model.";
   }
 
@@ -263,8 +263,8 @@ spv_result_t ValidateReturnValue(ValidationState_t& _,
   const auto return_type = _.FindDef(function->GetResultTypeId());
   if (!return_type || return_type->id() != value_type->id()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpReturnValue Value <id> '" << _.getIdName(value_id)
-           << "'s type does not match OpFunction's return type.";
+           << "OpReturnValue Value <id> " << _.getIdName(value_id)
+           << "s type does not match OpFunction's return type.";
   }
 
   return SPV_SUCCESS;

--- a/source/val/validate_composites.cpp
+++ b/source/val/validate_composites.cpp
@@ -505,8 +505,8 @@ spv_result_t ValidateVectorShuffle(ValidationState_t& _,
   if (componentCount != resultVectorDimension) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
            << "OpVectorShuffle component literals count does not match "
-              "Result Type <id> '"
-           << _.getIdName(resultType->id()) << "'s vector component count.";
+              "Result Type <id> "
+           << _.getIdName(resultType->id()) << "s vector component count.";
   }
 
   // Vector 1 and Vector 2 must both have vector types, with the same Component

--- a/source/val/validate_constants.cpp
+++ b/source/val/validate_constants.cpp
@@ -26,8 +26,8 @@ spv_result_t ValidateConstantBool(ValidationState_t& _,
   auto type = _.FindDef(inst->type_id());
   if (!type || type->opcode() != SpvOpTypeBool) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "Op" << spvOpcodeString(inst->opcode()) << " Result Type <id> '"
-           << _.getIdName(inst->type_id()) << "' is not a boolean type.";
+           << "Op" << spvOpcodeString(inst->opcode()) << " Result Type <id> "
+           << _.getIdName(inst->type_id()) << " is not a boolean type.";
   }
 
   return SPV_SUCCESS;
@@ -40,8 +40,8 @@ spv_result_t ValidateConstantComposite(ValidationState_t& _,
   const auto result_type = _.FindDef(inst->type_id());
   if (!result_type || !spvOpcodeIsComposite(result_type->opcode())) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << opcode_name << " Result Type <id> '"
-           << _.getIdName(inst->type_id()) << "' is not a composite type.";
+           << opcode_name << " Result Type <id> "
+           << _.getIdName(inst->type_id()) << " is not a composite type.";
   }
 
   const auto constituent_count = inst->words().size() - 3;
@@ -53,9 +53,8 @@ spv_result_t ValidateConstantComposite(ValidationState_t& _,
         return _.diag(SPV_ERROR_INVALID_ID, inst)
                << opcode_name
                << " Constituent <id> count does not match "
-                  "Result Type <id> '"
-               << _.getIdName(result_type->id())
-               << "'s vector component count.";
+                  "Result Type <id> "
+               << _.getIdName(result_type->id()) << "s vector component count.";
       }
       const auto component_type =
           _.FindDef(result_type->GetOperandAs<uint32_t>(1));
@@ -71,18 +70,18 @@ spv_result_t ValidateConstantComposite(ValidationState_t& _,
         if (!constituent ||
             !spvOpcodeIsConstantOrUndef(constituent->opcode())) {
           return _.diag(SPV_ERROR_INVALID_ID, inst)
-                 << opcode_name << " Constituent <id> '"
+                 << opcode_name << " Constituent <id> "
                  << _.getIdName(constituent_id)
-                 << "' is not a constant or undef.";
+                 << " is not a constant or undef.";
         }
         const auto constituent_result_type = _.FindDef(constituent->type_id());
         if (!constituent_result_type ||
             component_type->opcode() != constituent_result_type->opcode()) {
           return _.diag(SPV_ERROR_INVALID_ID, inst)
-                 << opcode_name << " Constituent <id> '"
+                 << opcode_name << " Constituent <id> "
                  << _.getIdName(constituent_id)
-                 << "'s type does not match Result Type <id> '"
-                 << _.getIdName(result_type->id()) << "'s vector element type.";
+                 << "s type does not match Result Type <id> "
+                 << _.getIdName(result_type->id()) << "s vector element type.";
         }
       }
     } break;
@@ -93,8 +92,8 @@ spv_result_t ValidateConstantComposite(ValidationState_t& _,
         return _.diag(SPV_ERROR_INVALID_ID, inst)
                << opcode_name
                << " Constituent <id> count does not match "
-                  "Result Type <id> '"
-               << _.getIdName(result_type->id()) << "'s matrix column count.";
+                  "Result Type <id> "
+               << _.getIdName(result_type->id()) << "s matrix column count.";
       }
 
       const auto column_type = _.FindDef(result_type->words()[2]);
@@ -120,9 +119,9 @@ spv_result_t ValidateConstantComposite(ValidationState_t& _,
           // The message says "... or undef" because the spec does not say
           // undef is a constant.
           return _.diag(SPV_ERROR_INVALID_ID, inst)
-                 << opcode_name << " Constituent <id> '"
+                 << opcode_name << " Constituent <id> "
                  << _.getIdName(constituent_id)
-                 << "' is not a constant or undef.";
+                 << " is not a constant or undef.";
         }
         const auto vector = _.FindDef(constituent->type_id());
         if (!vector) {
@@ -131,28 +130,28 @@ spv_result_t ValidateConstantComposite(ValidationState_t& _,
         }
         if (column_type->opcode() != vector->opcode()) {
           return _.diag(SPV_ERROR_INVALID_ID, inst)
-                 << opcode_name << " Constituent <id> '"
+                 << opcode_name << " Constituent <id> "
                  << _.getIdName(constituent_id)
-                 << "' type does not match Result Type <id> '"
-                 << _.getIdName(result_type->id()) << "'s matrix column type.";
+                 << " type does not match Result Type <id> "
+                 << _.getIdName(result_type->id()) << "s matrix column type.";
         }
         const auto vector_component_type =
             _.FindDef(vector->GetOperandAs<uint32_t>(1));
         if (component_type->id() != vector_component_type->id()) {
           return _.diag(SPV_ERROR_INVALID_ID, inst)
-                 << opcode_name << " Constituent <id> '"
+                 << opcode_name << " Constituent <id> "
                  << _.getIdName(constituent_id)
-                 << "' component type does not match Result Type <id> '"
+                 << " component type does not match Result Type <id> "
                  << _.getIdName(result_type->id())
-                 << "'s matrix column component type.";
+                 << "s matrix column component type.";
         }
         if (component_count != vector->words()[3]) {
           return _.diag(SPV_ERROR_INVALID_ID, inst)
-                 << opcode_name << " Constituent <id> '"
+                 << opcode_name << " Constituent <id> "
                  << _.getIdName(constituent_id)
-                 << "' vector component count does not match Result Type <id> '"
+                 << " vector component count does not match Result Type <id> "
                  << _.getIdName(result_type->id())
-                 << "'s vector component count.";
+                 << "s vector component count.";
         }
       }
     } break;
@@ -175,8 +174,8 @@ spv_result_t ValidateConstantComposite(ValidationState_t& _,
         return _.diag(SPV_ERROR_INVALID_ID, inst)
                << opcode_name
                << " Constituent count does not match "
-                  "Result Type <id> '"
-               << _.getIdName(result_type->id()) << "'s array length.";
+                  "Result Type <id> "
+               << _.getIdName(result_type->id()) << "s array length.";
       }
       for (size_t constituent_index = 2;
            constituent_index < inst->operands().size(); constituent_index++) {
@@ -186,9 +185,9 @@ spv_result_t ValidateConstantComposite(ValidationState_t& _,
         if (!constituent ||
             !spvOpcodeIsConstantOrUndef(constituent->opcode())) {
           return _.diag(SPV_ERROR_INVALID_ID, inst)
-                 << opcode_name << " Constituent <id> '"
+                 << opcode_name << " Constituent <id> "
                  << _.getIdName(constituent_id)
-                 << "' is not a constant or undef.";
+                 << " is not a constant or undef.";
         }
         const auto constituent_type = _.FindDef(constituent->type_id());
         if (!constituent_type) {
@@ -197,10 +196,10 @@ spv_result_t ValidateConstantComposite(ValidationState_t& _,
         }
         if (element_type->id() != constituent_type->id()) {
           return _.diag(SPV_ERROR_INVALID_ID, inst)
-                 << opcode_name << " Constituent <id> '"
+                 << opcode_name << " Constituent <id> "
                  << _.getIdName(constituent_id)
-                 << "'s type does not match Result Type <id> '"
-                 << _.getIdName(result_type->id()) << "'s array element type.";
+                 << "s type does not match Result Type <id> "
+                 << _.getIdName(result_type->id()) << "s array element type.";
         }
       }
     } break;
@@ -208,10 +207,10 @@ spv_result_t ValidateConstantComposite(ValidationState_t& _,
       const auto member_count = result_type->words().size() - 2;
       if (member_count != constituent_count) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
-               << opcode_name << " Constituent <id> '"
+               << opcode_name << " Constituent <id> "
                << _.getIdName(inst->type_id())
-               << "' count does not match Result Type <id> '"
-               << _.getIdName(result_type->id()) << "'s struct member count.";
+               << " count does not match Result Type <id> "
+               << _.getIdName(result_type->id()) << "s struct member count.";
       }
       for (uint32_t constituent_index = 2, member_index = 1;
            constituent_index < inst->operands().size();
@@ -222,9 +221,9 @@ spv_result_t ValidateConstantComposite(ValidationState_t& _,
         if (!constituent ||
             !spvOpcodeIsConstantOrUndef(constituent->opcode())) {
           return _.diag(SPV_ERROR_INVALID_ID, inst)
-                 << opcode_name << " Constituent <id> '"
+                 << opcode_name << " Constituent <id> "
                  << _.getIdName(constituent_id)
-                 << "' is not a constant or undef.";
+                 << " is not a constant or undef.";
         }
         const auto constituent_type = _.FindDef(constituent->type_id());
         if (!constituent_type) {
@@ -237,26 +236,25 @@ spv_result_t ValidateConstantComposite(ValidationState_t& _,
         const auto member_type = _.FindDef(member_type_id);
         if (!member_type || member_type->id() != constituent_type->id()) {
           return _.diag(SPV_ERROR_INVALID_ID, inst)
-                 << opcode_name << " Constituent <id> '"
+                 << opcode_name << " Constituent <id> "
                  << _.getIdName(constituent_id)
-                 << "' type does not match the Result Type <id> '"
-                 << _.getIdName(result_type->id()) << "'s member type.";
+                 << " type does not match the Result Type <id> "
+                 << _.getIdName(result_type->id()) << "s member type.";
         }
       }
     } break;
     case SpvOpTypeCooperativeMatrixNV: {
       if (1 != constituent_count) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
-               << opcode_name << " Constituent <id> '"
-               << _.getIdName(inst->type_id()) << "' count must be one.";
+               << opcode_name << " Constituent <id> "
+               << _.getIdName(inst->type_id()) << " count must be one.";
       }
       const auto constituent_id = inst->GetOperandAs<uint32_t>(2);
       const auto constituent = _.FindDef(constituent_id);
       if (!constituent || !spvOpcodeIsConstantOrUndef(constituent->opcode())) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
-               << opcode_name << " Constituent <id> '"
-               << _.getIdName(constituent_id)
-               << "' is not a constant or undef.";
+               << opcode_name << " Constituent <id> "
+               << _.getIdName(constituent_id) << " is not a constant or undef.";
       }
       const auto constituent_type = _.FindDef(constituent->type_id());
       if (!constituent_type) {
@@ -268,10 +266,10 @@ spv_result_t ValidateConstantComposite(ValidationState_t& _,
       const auto component_type = _.FindDef(component_type_id);
       if (!component_type || component_type->id() != constituent_type->id()) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
-               << opcode_name << " Constituent <id> '"
+               << opcode_name << " Constituent <id> "
                << _.getIdName(constituent_id)
-               << "' type does not match the Result Type <id> '"
-               << _.getIdName(result_type->id()) << "'s component type.";
+               << " type does not match the Result Type <id> "
+               << _.getIdName(result_type->id()) << "s component type.";
       }
     } break;
     default:
@@ -285,8 +283,8 @@ spv_result_t ValidateConstantSampler(ValidationState_t& _,
   const auto result_type = _.FindDef(inst->type_id());
   if (!result_type || result_type->opcode() != SpvOpTypeSampler) {
     return _.diag(SPV_ERROR_INVALID_ID, result_type)
-           << "OpConstantSampler Result Type <id> '"
-           << _.getIdName(inst->type_id()) << "' is not a sampler type.";
+           << "OpConstantSampler Result Type <id> "
+           << _.getIdName(inst->type_id()) << " is not a sampler type.";
   }
 
   return SPV_SUCCESS;
@@ -339,8 +337,8 @@ spv_result_t ValidateConstantNull(ValidationState_t& _,
   const auto result_type = _.FindDef(inst->type_id());
   if (!result_type || !IsTypeNullable(result_type->words(), _)) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpConstantNull Result Type <id> '"
-           << _.getIdName(inst->type_id()) << "' cannot have a null value.";
+           << "OpConstantNull Result Type <id> " << _.getIdName(inst->type_id())
+           << " cannot have a null value.";
   }
 
   return SPV_SUCCESS;

--- a/source/val/validate_debug.cpp
+++ b/source/val/validate_debug.cpp
@@ -28,16 +28,16 @@ spv_result_t ValidateMemberName(ValidationState_t& _, const Instruction* inst) {
   const auto type = _.FindDef(type_id);
   if (!type || SpvOpTypeStruct != type->opcode()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpMemberName Type <id> '" << _.getIdName(type_id)
-           << "' is not a struct type.";
+           << "OpMemberName Type <id> " << _.getIdName(type_id)
+           << " is not a struct type.";
   }
   const auto member_id = inst->GetOperandAs<uint32_t>(1);
   const auto member_count = (uint32_t)(type->words().size() - 2);
   if (member_count <= member_id) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpMemberName Member <id> '" << _.getIdName(member_id)
-           << "' index is larger than Type <id> '" << _.getIdName(type->id())
-           << "'s member count.";
+           << "OpMemberName Member <id> " << _.getIdName(member_id)
+           << " index is larger than Type <id> " << _.getIdName(type->id())
+           << "s member count.";
   }
   return SPV_SUCCESS;
 }
@@ -47,8 +47,8 @@ spv_result_t ValidateLine(ValidationState_t& _, const Instruction* inst) {
   const auto file = _.FindDef(file_id);
   if (!file || SpvOpString != file->opcode()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpLine Target <id> '" << _.getIdName(file_id)
-           << "' is not an OpString.";
+           << "OpLine Target <id> " << _.getIdName(file_id)
+           << " is not an OpString.";
   }
   return SPV_SUCCESS;
 }

--- a/source/val/validate_execution_limitations.cpp
+++ b/source/val/validate_execution_limitations.cpp
@@ -44,8 +44,8 @@ spv_result_t ValidateExecutionLimitations(ValidationState_t& _,
         std::string reason;
         if (!func->IsCompatibleWithExecutionModel(model, &reason)) {
           return _.diag(SPV_ERROR_INVALID_ID, inst)
-                 << "OpEntryPoint Entry Point <id> '" << _.getIdName(entry_id)
-                 << "'s callgraph contains function <id> "
+                 << "OpEntryPoint Entry Point <id> " << _.getIdName(entry_id)
+                 << "s callgraph contains function <id> "
                  << _.getIdName(inst->id())
                  << ", which cannot be used with the current execution "
                     "model:\n"
@@ -57,9 +57,8 @@ spv_result_t ValidateExecutionLimitations(ValidationState_t& _,
     std::string reason;
     if (!func->CheckLimitations(_, _.function(entry_id), &reason)) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "OpEntryPoint Entry Point <id> '" << _.getIdName(entry_id)
-             << "'s callgraph contains function <id> "
-             << _.getIdName(inst->id())
+             << "OpEntryPoint Entry Point <id> " << _.getIdName(entry_id)
+             << "s callgraph contains function <id> " << _.getIdName(inst->id())
              << ", which cannot be used with the current execution "
                 "modes:\n"
              << reason;

--- a/source/val/validate_function.cpp
+++ b/source/val/validate_function.cpp
@@ -58,16 +58,16 @@ spv_result_t ValidateFunction(ValidationState_t& _, const Instruction* inst) {
   const auto function_type = _.FindDef(function_type_id);
   if (!function_type || SpvOpTypeFunction != function_type->opcode()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpFunction Function Type <id> '" << _.getIdName(function_type_id)
-           << "' is not a function type.";
+           << "OpFunction Function Type <id> " << _.getIdName(function_type_id)
+           << " is not a function type.";
   }
 
   const auto return_id = function_type->GetOperandAs<uint32_t>(1);
   if (return_id != inst->type_id()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpFunction Result Type <id> '" << _.getIdName(inst->type_id())
-           << "' does not match the Function Type's return type <id> '"
-           << _.getIdName(return_id) << "'.";
+           << "OpFunction Result Type <id> " << _.getIdName(inst->type_id())
+           << " does not match the Function Type's return type <id> "
+           << _.getIdName(return_id) << ".";
   }
 
   const std::vector<SpvOp> acceptable = {
@@ -141,9 +141,9 @@ spv_result_t ValidateFunctionParameter(ValidationState_t& _,
       _.FindDef(function_type->GetOperandAs<uint32_t>(param_index + 2));
   if (!param_type || inst->type_id() != param_type->id()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpFunctionParameter Result Type <id> '"
+           << "OpFunctionParameter Result Type <id> "
            << _.getIdName(inst->type_id())
-           << "' does not match the OpTypeFunction parameter "
+           << " does not match the OpTypeFunction parameter "
               "type of the same index.";
   }
 
@@ -228,17 +228,16 @@ spv_result_t ValidateFunctionCall(ValidationState_t& _,
   const auto function = _.FindDef(function_id);
   if (!function || SpvOpFunction != function->opcode()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpFunctionCall Function <id> '" << _.getIdName(function_id)
-           << "' is not a function.";
+           << "OpFunctionCall Function <id> " << _.getIdName(function_id)
+           << " is not a function.";
   }
 
   auto return_type = _.FindDef(function->type_id());
   if (!return_type || return_type->id() != inst->type_id()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpFunctionCall Result Type <id> '"
-           << _.getIdName(inst->type_id())
-           << "'s type does not match Function <id> '"
-           << _.getIdName(return_type->id()) << "'s return type.";
+           << "OpFunctionCall Result Type <id> " << _.getIdName(inst->type_id())
+           << "s type does not match Function <id> "
+           << _.getIdName(return_type->id()) << "s return type.";
   }
 
   const auto function_type_id = function->GetOperandAs<uint32_t>(3);
@@ -280,9 +279,9 @@ spv_result_t ValidateFunctionCall(ValidationState_t& _,
       if (!_.options()->before_hlsl_legalization ||
           !DoPointeesLogicallyMatch(argument_type, parameter_type, _)) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
-               << "OpFunctionCall Argument <id> '" << _.getIdName(argument_id)
-               << "'s type does not match Function <id> '"
-               << _.getIdName(parameter_type_id) << "'s parameter type.";
+               << "OpFunctionCall Argument <id> " << _.getIdName(argument_id)
+               << "s type does not match Function <id> "
+               << _.getIdName(parameter_type_id) << "s parameter type.";
       }
     }
 

--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -1020,11 +1020,11 @@ spv_result_t ValidateSampledImage(ValidationState_t& _,
                << "All OpSampledImage instructions must be in the same block "
                   "in "
                   "which their Result <id> are consumed. OpSampledImage Result "
-                  "Type <id> '"
+                  "Type <id> "
                << _.getIdName(inst->id())
-               << "' has a consumer in a different basic "
-                  "block. The consumer instruction <id> is '"
-               << _.getIdName(consumer_instr->id()) << "'.";
+               << " has a consumer in a different basic "
+                  "block. The consumer instruction <id> is "
+               << _.getIdName(consumer_instr->id()) << ".";
       }
 
       if (consumer_opcode == SpvOpPhi || consumer_opcode == SpvOpSelect) {
@@ -1033,9 +1033,9 @@ spv_result_t ValidateSampledImage(ValidationState_t& _,
                   "as "
                   "operands of Op"
                << spvOpcodeString(static_cast<SpvOp>(consumer_opcode)) << "."
-               << " Found result <id> '" << _.getIdName(inst->id())
-               << "' as an operand of <id> '"
-               << _.getIdName(consumer_instr->id()) << "'.";
+               << " Found result <id> " << _.getIdName(inst->id())
+               << " as an operand of <id> " << _.getIdName(consumer_instr->id())
+               << ".";
       }
 
       if (!IsAllowedSampledImageOperand(consumer_opcode, _)) {
@@ -1045,9 +1045,9 @@ spv_result_t ValidateSampledImage(ValidationState_t& _,
                << spvOpcodeString(static_cast<SpvOp>(consumer_opcode))
                << ", since it is not specified as taking an "
                << "OpTypeSampledImage."
-               << " Found result <id> '" << _.getIdName(inst->id())
-               << "' as an operand of <id> '"
-               << _.getIdName(consumer_instr->id()) << "'.";
+               << " Found result <id> " << _.getIdName(inst->id())
+               << " as an operand of <id> " << _.getIdName(consumer_instr->id())
+               << ".";
       }
     }
   }

--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -402,8 +402,8 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
   auto result_type = _.FindDef(inst->type_id());
   if (!result_type || result_type->opcode() != SpvOpTypePointer) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpVariable Result Type <id> '" << _.getIdName(inst->type_id())
-           << "' is not a pointer type.";
+           << "OpVariable Result Type <id> " << _.getIdName(inst->type_id())
+           << " is not a pointer type.";
   }
 
   const auto type_index = 2;
@@ -423,8 +423,8 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
         initializer && spvOpcodeIsConstant(initializer->opcode());
     if (!initializer || !(is_constant || is_module_scope_var)) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "OpVariable Initializer <id> '" << _.getIdName(initializer_id)
-             << "' is not a constant or module-scope variable.";
+             << "OpVariable Initializer <id> " << _.getIdName(initializer_id)
+             << " is not a constant or module-scope variable.";
     }
     if (initializer->type_id() != value_id) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
@@ -537,8 +537,8 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
     if (storage_class == SpvStorageClassPushConstant) {
       if (pointee->opcode() != SpvOpTypeStruct) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
-               << _.VkErrorID(6808) << "PushConstant OpVariable <id> '"
-               << _.getIdName(inst->id()) << "' has illegal type.\n"
+               << _.VkErrorID(6808) << "PushConstant OpVariable <id> "
+               << _.getIdName(inst->id()) << " has illegal type.\n"
                << "From Vulkan spec, Push Constant Interface section:\n"
                << "Such variables must be typed as OpTypeStruct";
       }
@@ -552,8 +552,8 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
               {SpvOpTypeImage, SpvOpTypeSampler, SpvOpTypeSampledImage,
                SpvOpTypeAccelerationStructureKHR})) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
-               << _.VkErrorID(4655) << "UniformConstant OpVariable <id> '"
-               << _.getIdName(inst->id()) << "' has illegal type.\n"
+               << _.VkErrorID(4655) << "UniformConstant OpVariable <id> "
+               << _.getIdName(inst->id()) << " has illegal type.\n"
                << "Variables identified with the UniformConstant storage class "
                << "are used only as handles to refer to opaque resources. Such "
                << "variables must be typed as OpTypeImage, OpTypeSampler, "
@@ -565,8 +565,8 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
     if (storage_class == SpvStorageClassUniform) {
       if (!IsAllowedTypeOrArrayOfSame(_, pointee, {SpvOpTypeStruct})) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
-               << _.VkErrorID(6807) << "Uniform OpVariable <id> '"
-               << _.getIdName(inst->id()) << "' has illegal type.\n"
+               << _.VkErrorID(6807) << "Uniform OpVariable <id> "
+               << _.getIdName(inst->id()) << " has illegal type.\n"
                << "From Vulkan spec:\n"
                << "Variables identified with the Uniform storage class are "
                << "used to access transparent buffer backed resources. Such "
@@ -578,8 +578,8 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
     if (storage_class == SpvStorageClassStorageBuffer) {
       if (!IsAllowedTypeOrArrayOfSame(_, pointee, {SpvOpTypeStruct})) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
-               << _.VkErrorID(6807) << "StorageBuffer OpVariable <id> '"
-               << _.getIdName(inst->id()) << "' has illegal type.\n"
+               << _.VkErrorID(6807) << "StorageBuffer OpVariable <id> "
+               << _.getIdName(inst->id()) << " has illegal type.\n"
                << "From Vulkan spec:\n"
                << "Variables identified with the StorageBuffer storage class "
                   "are used to access transparent buffer backed resources. "
@@ -617,9 +617,9 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
         auto init = _.FindDef(init_id);
         if (init->opcode() != SpvOpConstantNull) {
           return _.diag(SPV_ERROR_INVALID_ID, inst)
-                 << _.VkErrorID(4734) << "OpVariable, <id> '"
+                 << _.VkErrorID(4734) << "OpVariable, <id> "
                  << _.getIdName(inst->id())
-                 << "', initializers are limited to OpConstantNull in "
+                 << ", initializers are limited to OpConstantNull in "
                     "Workgroup "
                     "storage class";
         }
@@ -627,9 +627,9 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
                  storage_class != SpvStorageClassPrivate &&
                  storage_class != SpvStorageClassFunction) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
-               << _.VkErrorID(4651) << "OpVariable, <id> '"
+               << _.VkErrorID(4651) << "OpVariable, <id> "
                << _.getIdName(inst->id())
-               << "', has a disallowed initializer & storage class "
+               << ", has a disallowed initializer & storage class "
                << "combination.\n"
                << "From " << spvLogStringForEnv(_.context()->target_env)
                << " spec:\n"
@@ -643,13 +643,13 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
   if (inst->operands().size() > 3) {
     if (storage_class == SpvStorageClassTaskPayloadWorkgroupEXT) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "OpVariable, <id> '" << _.getIdName(inst->id())
-             << "', initializer are not allowed for TaskPayloadWorkgroupEXT";
+             << "OpVariable, <id> " << _.getIdName(inst->id())
+             << ", initializer are not allowed for TaskPayloadWorkgroupEXT";
     }
     if (storage_class == SpvStorageClassInput) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "OpVariable, <id> '" << _.getIdName(inst->id())
-             << "', initializer are not allowed for Input";
+             << "OpVariable, <id> " << _.getIdName(inst->id())
+             << ", initializer are not allowed for Input";
     }
   }
 
@@ -693,9 +693,9 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
     if (value_type && value_type->opcode() == SpvOpTypeRuntimeArray) {
       if (!_.HasCapability(SpvCapabilityRuntimeDescriptorArrayEXT)) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
-               << _.VkErrorID(4680) << "OpVariable, <id> '"
+               << _.VkErrorID(4680) << "OpVariable, <id> "
                << _.getIdName(inst->id())
-               << "', is attempting to create memory for an illegal type, "
+               << ", is attempting to create memory for an illegal type, "
                << "OpTypeRuntimeArray.\nFor Vulkan OpTypeRuntimeArray can only "
                << "appear as the final member of an OpTypeStruct, thus cannot "
                << "be instantiated via OpVariable";
@@ -890,8 +890,8 @@ spv_result_t ValidateLoad(ValidationState_t& _, const Instruction* inst) {
   const auto result_type = _.FindDef(inst->type_id());
   if (!result_type) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpLoad Result Type <id> '" << _.getIdName(inst->type_id())
-           << "' is not defined.";
+           << "OpLoad Result Type <id> " << _.getIdName(inst->type_id())
+           << " is not defined.";
   }
 
   const auto pointer_index = 2;
@@ -904,15 +904,15 @@ spv_result_t ValidateLoad(ValidationState_t& _, const Instruction* inst) {
         (_.features().variable_pointers &&
          !spvOpcodeReturnsLogicalVariablePointer(pointer->opcode()))))) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpLoad Pointer <id> '" << _.getIdName(pointer_id)
-           << "' is not a logical pointer.";
+           << "OpLoad Pointer <id> " << _.getIdName(pointer_id)
+           << " is not a logical pointer.";
   }
 
   const auto pointer_type = _.FindDef(pointer->type_id());
   if (!pointer_type || pointer_type->opcode() != SpvOpTypePointer) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpLoad type for pointer <id> '" << _.getIdName(pointer_id)
-           << "' is not a pointer type.";
+           << "OpLoad type for pointer <id> " << _.getIdName(pointer_id)
+           << " is not a pointer type.";
   }
 
   uint32_t pointee_data_type;
@@ -921,9 +921,9 @@ spv_result_t ValidateLoad(ValidationState_t& _, const Instruction* inst) {
                             &storage_class) ||
       result_type->id() != pointee_data_type) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpLoad Result Type <id> '" << _.getIdName(inst->type_id())
-           << "' does not match Pointer <id> '" << _.getIdName(pointer->id())
-           << "'s type.";
+           << "OpLoad Result Type <id> " << _.getIdName(inst->type_id())
+           << " does not match Pointer <id> " << _.getIdName(pointer->id())
+           << "s type.";
   }
 
   if (!_.options()->before_hlsl_legalization &&
@@ -960,21 +960,21 @@ spv_result_t ValidateStore(ValidationState_t& _, const Instruction* inst) {
         (_.features().variable_pointers &&
          !spvOpcodeReturnsLogicalVariablePointer(pointer->opcode()))))) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpStore Pointer <id> '" << _.getIdName(pointer_id)
-           << "' is not a logical pointer.";
+           << "OpStore Pointer <id> " << _.getIdName(pointer_id)
+           << " is not a logical pointer.";
   }
   const auto pointer_type = _.FindDef(pointer->type_id());
   if (!pointer_type || pointer_type->opcode() != SpvOpTypePointer) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpStore type for pointer <id> '" << _.getIdName(pointer_id)
-           << "' is not a pointer type.";
+           << "OpStore type for pointer <id> " << _.getIdName(pointer_id)
+           << " is not a pointer type.";
   }
   const auto type_id = pointer_type->GetOperandAs<uint32_t>(2);
   const auto type = _.FindDef(type_id);
   if (!type || SpvOpTypeVoid == type->opcode()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpStore Pointer <id> '" << _.getIdName(pointer_id)
-           << "'s type is void.";
+           << "OpStore Pointer <id> " << _.getIdName(pointer_id)
+           << "s type is void.";
   }
 
   // validate storage class
@@ -983,16 +983,16 @@ spv_result_t ValidateStore(ValidationState_t& _, const Instruction* inst) {
     uint32_t storage_class;
     if (!_.GetPointerTypeInfo(pointer_type->id(), &data_type, &storage_class)) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "OpStore Pointer <id> '" << _.getIdName(pointer_id)
-             << "' is not pointer type";
+             << "OpStore Pointer <id> " << _.getIdName(pointer_id)
+             << " is not pointer type";
     }
 
     if (storage_class == SpvStorageClassUniformConstant ||
         storage_class == SpvStorageClassInput ||
         storage_class == SpvStorageClassPushConstant) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "OpStore Pointer <id> '" << _.getIdName(pointer_id)
-             << "' storage class is read-only";
+             << "OpStore Pointer <id> " << _.getIdName(pointer_id)
+             << " storage class is read-only";
     } else if (storage_class == SpvStorageClassShaderRecordBufferKHR) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
              << "ShaderRecordBufferKHR Storage Class variables are read only";
@@ -1041,31 +1041,31 @@ spv_result_t ValidateStore(ValidationState_t& _, const Instruction* inst) {
   const auto object = _.FindDef(object_id);
   if (!object || !object->type_id()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpStore Object <id> '" << _.getIdName(object_id)
-           << "' is not an object.";
+           << "OpStore Object <id> " << _.getIdName(object_id)
+           << " is not an object.";
   }
   const auto object_type = _.FindDef(object->type_id());
   if (!object_type || SpvOpTypeVoid == object_type->opcode()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpStore Object <id> '" << _.getIdName(object_id)
-           << "'s type is void.";
+           << "OpStore Object <id> " << _.getIdName(object_id)
+           << "s type is void.";
   }
 
   if (type->id() != object_type->id()) {
     if (!_.options()->relax_struct_store || type->opcode() != SpvOpTypeStruct ||
         object_type->opcode() != SpvOpTypeStruct) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "OpStore Pointer <id> '" << _.getIdName(pointer_id)
-             << "'s type does not match Object <id> '"
-             << _.getIdName(object->id()) << "'s type.";
+             << "OpStore Pointer <id> " << _.getIdName(pointer_id)
+             << "s type does not match Object <id> "
+             << _.getIdName(object->id()) << "s type.";
     }
 
     // TODO: Check for layout compatible matricies and arrays as well.
     if (!AreLayoutCompatibleStructs(_, type, object_type)) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "OpStore Pointer <id> '" << _.getIdName(pointer_id)
-             << "'s layout does not match Object <id> '"
-             << _.getIdName(object->id()) << "'s layout.";
+             << "OpStore Pointer <id> " << _.getIdName(pointer_id)
+             << "s layout does not match Object <id> "
+             << _.getIdName(object->id()) << "s layout.";
     }
   }
 
@@ -1137,8 +1137,8 @@ spv_result_t ValidateCopyMemory(ValidationState_t& _, const Instruction* inst) {
   const auto target = _.FindDef(target_id);
   if (!target) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "Target operand <id> '" << _.getIdName(target_id)
-           << "' is not defined.";
+           << "Target operand <id> " << _.getIdName(target_id)
+           << " is not defined.";
   }
 
   const auto source_index = 1;
@@ -1146,24 +1146,24 @@ spv_result_t ValidateCopyMemory(ValidationState_t& _, const Instruction* inst) {
   const auto source = _.FindDef(source_id);
   if (!source) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "Source operand <id> '" << _.getIdName(source_id)
-           << "' is not defined.";
+           << "Source operand <id> " << _.getIdName(source_id)
+           << " is not defined.";
   }
 
   const auto target_pointer_type = _.FindDef(target->type_id());
   if (!target_pointer_type ||
       target_pointer_type->opcode() != SpvOpTypePointer) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "Target operand <id> '" << _.getIdName(target_id)
-           << "' is not a pointer.";
+           << "Target operand <id> " << _.getIdName(target_id)
+           << " is not a pointer.";
   }
 
   const auto source_pointer_type = _.FindDef(source->type_id());
   if (!source_pointer_type ||
       source_pointer_type->opcode() != SpvOpTypePointer) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "Source operand <id> '" << _.getIdName(source_id)
-           << "' is not a pointer.";
+           << "Source operand <id> " << _.getIdName(source_id)
+           << " is not a pointer.";
   }
 
   if (inst->opcode() == SpvOpCopyMemory) {
@@ -1171,60 +1171,60 @@ spv_result_t ValidateCopyMemory(ValidationState_t& _, const Instruction* inst) {
         _.FindDef(target_pointer_type->GetOperandAs<uint32_t>(2));
     if (!target_type || target_type->opcode() == SpvOpTypeVoid) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "Target operand <id> '" << _.getIdName(target_id)
-             << "' cannot be a void pointer.";
+             << "Target operand <id> " << _.getIdName(target_id)
+             << " cannot be a void pointer.";
     }
 
     const auto source_type =
         _.FindDef(source_pointer_type->GetOperandAs<uint32_t>(2));
     if (!source_type || source_type->opcode() == SpvOpTypeVoid) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "Source operand <id> '" << _.getIdName(source_id)
-             << "' cannot be a void pointer.";
+             << "Source operand <id> " << _.getIdName(source_id)
+             << " cannot be a void pointer.";
     }
 
     if (target_type->id() != source_type->id()) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "Target <id> '" << _.getIdName(source_id)
-             << "'s type does not match Source <id> '"
-             << _.getIdName(source_type->id()) << "'s type.";
+             << "Target <id> " << _.getIdName(source_id)
+             << "s type does not match Source <id> "
+             << _.getIdName(source_type->id()) << "s type.";
     }
   } else {
     const auto size_id = inst->GetOperandAs<uint32_t>(2);
     const auto size = _.FindDef(size_id);
     if (!size) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "Size operand <id> '" << _.getIdName(size_id)
-             << "' is not defined.";
+             << "Size operand <id> " << _.getIdName(size_id)
+             << " is not defined.";
     }
 
     const auto size_type = _.FindDef(size->type_id());
     if (!_.IsIntScalarType(size_type->id())) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "Size operand <id> '" << _.getIdName(size_id)
-             << "' must be a scalar integer type.";
+             << "Size operand <id> " << _.getIdName(size_id)
+             << " must be a scalar integer type.";
     }
 
     bool is_zero = true;
     switch (size->opcode()) {
       case SpvOpConstantNull:
         return _.diag(SPV_ERROR_INVALID_ID, inst)
-               << "Size operand <id> '" << _.getIdName(size_id)
-               << "' cannot be a constant zero.";
+               << "Size operand <id> " << _.getIdName(size_id)
+               << " cannot be a constant zero.";
       case SpvOpConstant:
         if (size_type->word(3) == 1 &&
             size->word(size->words().size() - 1) & 0x80000000) {
           return _.diag(SPV_ERROR_INVALID_ID, inst)
-                 << "Size operand <id> '" << _.getIdName(size_id)
-                 << "' cannot have the sign bit set to 1.";
+                 << "Size operand <id> " << _.getIdName(size_id)
+                 << " cannot have the sign bit set to 1.";
         }
         for (size_t i = 3; is_zero && i < size->words().size(); ++i) {
           is_zero &= (size->word(i) == 0);
         }
         if (is_zero) {
           return _.diag(SPV_ERROR_INVALID_ID, inst)
-                 << "Size operand <id> '" << _.getIdName(size_id)
-                 << "' cannot be a constant zero.";
+                 << "Size operand <id> " << _.getIdName(size_id)
+                 << " cannot be a constant zero.";
         }
         break;
       default:
@@ -1257,8 +1257,8 @@ spv_result_t ValidateAccessChain(ValidationState_t& _,
   auto result_type = _.FindDef(inst->type_id());
   if (SpvOpTypePointer != result_type->opcode()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "The Result Type of " << instr_name << " <id> '"
-           << _.getIdName(inst->id()) << "' must be OpTypePointer. Found Op"
+           << "The Result Type of " << instr_name << " <id> "
+           << _.getIdName(inst->id()) << " must be OpTypePointer. Found Op"
            << spvOpcodeString(static_cast<SpvOp>(result_type->opcode())) << ".";
   }
 
@@ -1274,7 +1274,7 @@ spv_result_t ValidateAccessChain(ValidationState_t& _,
   const auto base_type = _.FindDef(base->type_id());
   if (!base_type || SpvOpTypePointer != base_type->opcode()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "The Base <id> '" << _.getIdName(base_id) << "' in " << instr_name
+           << "The Base <id> " << _.getIdName(base_id) << " in " << instr_name
            << " instruction must be a pointer.";
   }
 
@@ -1366,8 +1366,8 @@ spv_result_t ValidateAccessChain(ValidationState_t& _,
           return _.diag(SPV_ERROR_INVALID_ID, cur_word_instr)
                  << "Index is out of bounds: " << instr_name
                  << " can not find index " << cur_index
-                 << " into the structure <id> '"
-                 << _.getIdName(type_pointee->id()) << "'. This structure has "
+                 << " into the structure <id> "
+                 << _.getIdName(type_pointee->id()) << ". This structure has "
                  << num_struct_members << " members. Largest valid index is "
                  << num_struct_members - 1 << ".";
         }
@@ -1424,9 +1424,9 @@ spv_result_t ValidateArrayLength(ValidationState_t& state,
       result_type->GetOperandAs<uint32_t>(1) != 32 ||
       result_type->GetOperandAs<uint32_t>(2) != 0) {
     return state.diag(SPV_ERROR_INVALID_ID, inst)
-           << "The Result Type of " << instr_name << " <id> '"
+           << "The Result Type of " << instr_name << " <id> "
            << state.getIdName(inst->id())
-           << "' must be OpTypeInt with width 32 and signedness 0.";
+           << " must be OpTypeInt with width 32 and signedness 0.";
   }
 
   // The structure that is passed in must be an pointer to a structure, whose
@@ -1435,17 +1435,17 @@ spv_result_t ValidateArrayLength(ValidationState_t& state,
   auto pointer_type = state.FindDef(pointer->type_id());
   if (pointer_type->opcode() != SpvOpTypePointer) {
     return state.diag(SPV_ERROR_INVALID_ID, inst)
-           << "The Struture's type in " << instr_name << " <id> '"
+           << "The Structure's type in " << instr_name << " <id> "
            << state.getIdName(inst->id())
-           << "' must be a pointer to an OpTypeStruct.";
+           << " must be a pointer to an OpTypeStruct.";
   }
 
   auto structure_type = state.FindDef(pointer_type->GetOperandAs<uint32_t>(2));
   if (structure_type->opcode() != SpvOpTypeStruct) {
     return state.diag(SPV_ERROR_INVALID_ID, inst)
-           << "The Struture's type in " << instr_name << " <id> '"
+           << "The Structure's type in " << instr_name << " <id> "
            << state.getIdName(inst->id())
-           << "' must be a pointer to an OpTypeStruct.";
+           << " must be a pointer to an OpTypeStruct.";
   }
 
   auto num_of_members = structure_type->operands().size() - 1;
@@ -1453,17 +1453,17 @@ spv_result_t ValidateArrayLength(ValidationState_t& state,
       state.FindDef(structure_type->GetOperandAs<uint32_t>(num_of_members));
   if (last_member->opcode() != SpvOpTypeRuntimeArray) {
     return state.diag(SPV_ERROR_INVALID_ID, inst)
-           << "The Struture's last member in " << instr_name << " <id> '"
-           << state.getIdName(inst->id()) << "' must be an OpTypeRuntimeArray.";
+           << "The Structure's last member in " << instr_name << " <id> "
+           << state.getIdName(inst->id()) << " must be an OpTypeRuntimeArray.";
   }
 
   // The array member must the index of the last element (the run time
   // array).
   if (inst->GetOperandAs<uint32_t>(3) != num_of_members - 1) {
     return state.diag(SPV_ERROR_INVALID_ID, inst)
-           << "The array member in " << instr_name << " <id> '"
+           << "The array member in " << instr_name << " <id> "
            << state.getIdName(inst->id())
-           << "' must be an the last member of the struct.";
+           << " must be an the last member of the struct.";
   }
   return SPV_SUCCESS;
 }
@@ -1479,18 +1479,17 @@ spv_result_t ValidateCooperativeMatrixLengthNV(ValidationState_t& state,
       result_type->GetOperandAs<uint32_t>(1) != 32 ||
       result_type->GetOperandAs<uint32_t>(2) != 0) {
     return state.diag(SPV_ERROR_INVALID_ID, inst)
-           << "The Result Type of " << instr_name << " <id> '"
+           << "The Result Type of " << instr_name << " <id> "
            << state.getIdName(inst->id())
-           << "' must be OpTypeInt with width 32 and signedness 0.";
+           << " must be OpTypeInt with width 32 and signedness 0.";
   }
 
   auto type_id = inst->GetOperandAs<uint32_t>(2);
   auto type = state.FindDef(type_id);
   if (type->opcode() != SpvOpTypeCooperativeMatrixNV) {
     return state.diag(SPV_ERROR_INVALID_ID, inst)
-           << "The type in " << instr_name << " <id> '"
-           << state.getIdName(type_id)
-           << "' must be OpTypeCooperativeMatrixNV.";
+           << "The type in " << instr_name << " <id> "
+           << state.getIdName(type_id) << " must be OpTypeCooperativeMatrixNV.";
   }
   return SPV_SUCCESS;
 }
@@ -1513,12 +1512,12 @@ spv_result_t ValidateCooperativeMatrixLoadStoreNV(ValidationState_t& _,
   if (matrix_type->opcode() != SpvOpTypeCooperativeMatrixNV) {
     if (inst->opcode() == SpvOpCooperativeMatrixLoadNV) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "SpvOpCooperativeMatrixLoadNV Result Type <id> '"
-             << _.getIdName(type_id) << "' is not a cooperative matrix type.";
+             << "SpvOpCooperativeMatrixLoadNV Result Type <id> "
+             << _.getIdName(type_id) << " is not a cooperative matrix type.";
     } else {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "SpvOpCooperativeMatrixStoreNV Object type <id> '"
-             << _.getIdName(type_id) << "' is not a cooperative matrix type.";
+             << "SpvOpCooperativeMatrixStoreNV Object type <id> "
+             << _.getIdName(type_id) << " is not a cooperative matrix type.";
     }
   }
 
@@ -1533,16 +1532,16 @@ spv_result_t ValidateCooperativeMatrixLoadStoreNV(ValidationState_t& _,
         (_.features().variable_pointers &&
          !spvOpcodeReturnsLogicalVariablePointer(pointer->opcode()))))) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << opname << " Pointer <id> '" << _.getIdName(pointer_id)
-           << "' is not a logical pointer.";
+           << opname << " Pointer <id> " << _.getIdName(pointer_id)
+           << " is not a logical pointer.";
   }
 
   const auto pointer_type_id = pointer->type_id();
   const auto pointer_type = _.FindDef(pointer_type_id);
   if (!pointer_type || pointer_type->opcode() != SpvOpTypePointer) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << opname << " type for pointer <id> '" << _.getIdName(pointer_id)
-           << "' is not a pointer type.";
+           << opname << " type for pointer <id> " << _.getIdName(pointer_id)
+           << " is not a pointer type.";
   }
 
   const auto storage_class_index = 1u;
@@ -1553,9 +1552,9 @@ spv_result_t ValidateCooperativeMatrixLoadStoreNV(ValidationState_t& _,
       storage_class != SpvStorageClassStorageBuffer &&
       storage_class != SpvStorageClassPhysicalStorageBuffer) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << opname << " storage class for pointer type <id> '"
+           << opname << " storage class for pointer type <id> "
            << _.getIdName(pointer_type_id)
-           << "' is not Workgroup or StorageBuffer.";
+           << " is not Workgroup or StorageBuffer.";
   }
 
   const auto pointee_id = pointer_type->GetOperandAs<uint32_t>(2);
@@ -1563,8 +1562,8 @@ spv_result_t ValidateCooperativeMatrixLoadStoreNV(ValidationState_t& _,
   if (!pointee_type || !(_.IsIntScalarOrVectorType(pointee_id) ||
                          _.IsFloatScalarOrVectorType(pointee_id))) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << opname << " Pointer <id> '" << _.getIdName(pointer->id())
-           << "'s Type must be a scalar or vector type.";
+           << opname << " Pointer <id> " << _.getIdName(pointer->id())
+           << "s Type must be a scalar or vector type.";
   }
 
   const auto stride_index =
@@ -1573,8 +1572,8 @@ spv_result_t ValidateCooperativeMatrixLoadStoreNV(ValidationState_t& _,
   const auto stride = _.FindDef(stride_id);
   if (!stride || !_.IsIntScalarType(stride->type_id())) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "Stride operand <id> '" << _.getIdName(stride_id)
-           << "' must be a scalar integer type.";
+           << "Stride operand <id> " << _.getIdName(stride_id)
+           << " must be a scalar integer type.";
   }
 
   const auto colmajor_index =
@@ -1585,8 +1584,8 @@ spv_result_t ValidateCooperativeMatrixLoadStoreNV(ValidationState_t& _,
       !(spvOpcodeIsConstant(colmajor->opcode()) ||
         spvOpcodeIsSpecConstant(colmajor->opcode()))) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "Column Major operand <id> '" << _.getIdName(colmajor_id)
-           << "' must be a boolean constant instruction.";
+           << "Column Major operand <id> " << _.getIdName(colmajor_id)
+           << " must be a boolean constant instruction.";
   }
 
   const auto memory_access_index =

--- a/source/val/validate_mode_setting.cpp
+++ b/source/val/validate_mode_setting.cpp
@@ -29,8 +29,8 @@ spv_result_t ValidateEntryPoint(ValidationState_t& _, const Instruction* inst) {
   auto entry_point = _.FindDef(entry_point_id);
   if (!entry_point || SpvOpFunction != entry_point->opcode()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpEntryPoint Entry Point <id> '" << _.getIdName(entry_point_id)
-           << "' is not a function.";
+           << "OpEntryPoint Entry Point <id> " << _.getIdName(entry_point_id)
+           << " is not a function.";
   }
 
   // Only check the shader execution models
@@ -41,18 +41,18 @@ spv_result_t ValidateEntryPoint(ValidationState_t& _, const Instruction* inst) {
     const auto entry_point_type = _.FindDef(entry_point_type_id);
     if (!entry_point_type || 3 != entry_point_type->words().size()) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << _.VkErrorID(4633) << "OpEntryPoint Entry Point <id> '"
+             << _.VkErrorID(4633) << "OpEntryPoint Entry Point <id> "
              << _.getIdName(entry_point_id)
-             << "'s function parameter count is not zero.";
+             << "s function parameter count is not zero.";
     }
   }
 
   auto return_type = _.FindDef(entry_point->type_id());
   if (!return_type || SpvOpTypeVoid != return_type->opcode()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << _.VkErrorID(4633) << "OpEntryPoint Entry Point <id> '"
+           << _.VkErrorID(4633) << "OpEntryPoint Entry Point <id> "
            << _.getIdName(entry_point_id)
-           << "'s function return type is not void.";
+           << "s function return type is not void.";
   }
 
   const auto* execution_modes = _.GetExecutionModes(entry_point_id);
@@ -328,9 +328,8 @@ spv_result_t ValidateExecutionMode(ValidationState_t& _,
                                _.entry_points().cend(), entry_point_id);
   if (found == _.entry_points().cend()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpExecutionMode Entry Point <id> '"
-           << _.getIdName(entry_point_id)
-           << "' is not the Entry Point "
+           << "OpExecutionMode Entry Point <id> " << _.getIdName(entry_point_id)
+           << " is not the Entry Point "
               "operand of an OpEntryPoint.";
   }
 

--- a/source/val/validate_type.cpp
+++ b/source/val/validate_type.cpp
@@ -152,8 +152,8 @@ spv_result_t ValidateTypeVector(ValidationState_t& _, const Instruction* inst) {
   const auto component_type = _.FindDef(component_id);
   if (!component_type || !spvOpcodeIsScalarType(component_type->opcode())) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpTypeVector Component Type <id> '" << _.getIdName(component_id)
-           << "' is not a scalar type.";
+           << "OpTypeVector Component Type <id> " << _.getIdName(component_id)
+           << " is not a scalar type.";
   }
 
   // Validates that the number of components in the vector is valid.
@@ -215,21 +215,21 @@ spv_result_t ValidateTypeArray(ValidationState_t& _, const Instruction* inst) {
   const auto element_type = _.FindDef(element_type_id);
   if (!element_type || !spvOpcodeGeneratesType(element_type->opcode())) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpTypeArray Element Type <id> '" << _.getIdName(element_type_id)
-           << "' is not a type.";
+           << "OpTypeArray Element Type <id> " << _.getIdName(element_type_id)
+           << " is not a type.";
   }
 
   if (element_type->opcode() == SpvOpTypeVoid) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpTypeArray Element Type <id> '" << _.getIdName(element_type_id)
-           << "' is a void type.";
+           << "OpTypeArray Element Type <id> " << _.getIdName(element_type_id)
+           << " is a void type.";
   }
 
   if (spvIsVulkanEnv(_.context()->target_env) &&
       element_type->opcode() == SpvOpTypeRuntimeArray) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << _.VkErrorID(4680) << "OpTypeArray Element Type <id> '"
-           << _.getIdName(element_type_id) << "' is not valid in "
+           << _.VkErrorID(4680) << "OpTypeArray Element Type <id> "
+           << _.getIdName(element_type_id) << " is not valid in "
            << spvLogStringForEnv(_.context()->target_env) << " environments.";
   }
 
@@ -238,8 +238,8 @@ spv_result_t ValidateTypeArray(ValidationState_t& _, const Instruction* inst) {
   const auto length = _.FindDef(length_id);
   if (!length || !spvOpcodeIsConstant(length->opcode())) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpTypeArray Length <id> '" << _.getIdName(length_id)
-           << "' is not a scalar constant type.";
+           << "OpTypeArray Length <id> " << _.getIdName(length_id)
+           << " is not a scalar constant type.";
   }
 
   // NOTE: Check the initialiser value of the constant
@@ -248,8 +248,8 @@ spv_result_t ValidateTypeArray(ValidationState_t& _, const Instruction* inst) {
   const auto const_result_type = _.FindDef(const_inst[const_result_type_index]);
   if (!const_result_type || SpvOpTypeInt != const_result_type->opcode()) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpTypeArray Length <id> '" << _.getIdName(length_id)
-           << "' is not a constant integer type.";
+           << "OpTypeArray Length <id> " << _.getIdName(length_id)
+           << " is not a constant integer type.";
   }
 
   switch (length->opcode()) {
@@ -261,14 +261,14 @@ spv_result_t ValidateTypeArray(ValidationState_t& _, const Instruction* inst) {
       const int64_t ivalue = ConstantLiteralAsInt64(width, length->words());
       if (ivalue == 0 || (ivalue < 0 && is_signed)) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
-               << "OpTypeArray Length <id> '" << _.getIdName(length_id)
-               << "' default value must be at least 1: found " << ivalue;
+               << "OpTypeArray Length <id> " << _.getIdName(length_id)
+               << " default value must be at least 1: found " << ivalue;
       }
     } break;
     case SpvOpConstantNull:
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "OpTypeArray Length <id> '" << _.getIdName(length_id)
-             << "' default value must be at least 1.";
+             << "OpTypeArray Length <id> " << _.getIdName(length_id)
+             << " default value must be at least 1.";
     case SpvOpSpecConstantOp:
       // Assume it's OK, rather than try to evaluate the operation.
       break;
@@ -285,21 +285,21 @@ spv_result_t ValidateTypeRuntimeArray(ValidationState_t& _,
   const auto element_type = _.FindDef(element_id);
   if (!element_type || !spvOpcodeGeneratesType(element_type->opcode())) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpTypeRuntimeArray Element Type <id> '"
-           << _.getIdName(element_id) << "' is not a type.";
+           << "OpTypeRuntimeArray Element Type <id> " << _.getIdName(element_id)
+           << " is not a type.";
   }
 
   if (element_type->opcode() == SpvOpTypeVoid) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpTypeRuntimeArray Element Type <id> '"
-           << _.getIdName(element_id) << "' is a void type.";
+           << "OpTypeRuntimeArray Element Type <id> " << _.getIdName(element_id)
+           << " is a void type.";
   }
 
   if (spvIsVulkanEnv(_.context()->target_env) &&
       element_type->opcode() == SpvOpTypeRuntimeArray) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << _.VkErrorID(4680) << "OpTypeRuntimeArray Element Type <id> '"
-           << _.getIdName(element_id) << "' is not valid in "
+           << _.VkErrorID(4680) << "OpTypeRuntimeArray Element Type <id> "
+           << _.getIdName(element_id) << " is not valid in "
            << spvLogStringForEnv(_.context()->target_env) << " environments.";
   }
 
@@ -319,8 +319,8 @@ spv_result_t ValidateTypeStruct(ValidationState_t& _, const Instruction* inst) {
     auto member_type = _.FindDef(member_type_id);
     if (!member_type || !spvOpcodeGeneratesType(member_type->opcode())) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "OpTypeStruct Member Type <id> '" << _.getIdName(member_type_id)
-             << "' is not a type.";
+             << "OpTypeStruct Member Type <id> " << _.getIdName(member_type_id)
+             << " is not a type.";
     }
     if (member_type->opcode() == SpvOpTypeVoid) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
@@ -426,8 +426,8 @@ spv_result_t ValidateTypePointer(ValidationState_t& _,
   auto type = _.FindDef(type_id);
   if (!type || !spvOpcodeGeneratesType(type->opcode())) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpTypePointer Type <id> '" << _.getIdName(type_id)
-           << "' is not a type.";
+           << "OpTypePointer Type <id> " << _.getIdName(type_id)
+           << " is not a type.";
   }
   // See if this points to a storage image.
   const auto storage_class = inst->GetOperandAs<SpvStorageClass>(1);
@@ -461,8 +461,8 @@ spv_result_t ValidateTypeFunction(ValidationState_t& _,
   const auto return_type = _.FindDef(return_type_id);
   if (!return_type || !spvOpcodeGeneratesType(return_type->opcode())) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpTypeFunction Return Type <id> '" << _.getIdName(return_type_id)
-           << "' is not a type.";
+           << "OpTypeFunction Return Type <id> " << _.getIdName(return_type_id)
+           << " is not a type.";
   }
   size_t num_args = 0;
   for (size_t param_type_index = 2; param_type_index < inst->operands().size();
@@ -471,14 +471,14 @@ spv_result_t ValidateTypeFunction(ValidationState_t& _,
     const auto param_type = _.FindDef(param_id);
     if (!param_type || !spvOpcodeGeneratesType(param_type->opcode())) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "OpTypeFunction Parameter Type <id> '" << _.getIdName(param_id)
-             << "' is not a type.";
+             << "OpTypeFunction Parameter Type <id> " << _.getIdName(param_id)
+             << " is not a type.";
     }
 
     if (param_type->opcode() == SpvOpTypeVoid) {
       return _.diag(SPV_ERROR_INVALID_ID, inst)
-             << "OpTypeFunction Parameter Type <id> '" << _.getIdName(param_id)
-             << "' cannot be OpTypeVoid.";
+             << "OpTypeFunction Parameter Type <id> " << _.getIdName(param_id)
+             << " cannot be OpTypeVoid.";
     }
   }
   const uint32_t num_function_args_limit =
@@ -486,8 +486,8 @@ spv_result_t ValidateTypeFunction(ValidationState_t& _,
   if (num_args > num_function_args_limit) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
            << "OpTypeFunction may not take more than "
-           << num_function_args_limit << " arguments. OpTypeFunction <id> '"
-           << _.getIdName(inst->GetOperandAs<uint32_t>(0)) << "' has "
+           << num_function_args_limit << " arguments. OpTypeFunction <id> "
+           << _.getIdName(inst->GetOperandAs<uint32_t>(0)) << " has "
            << num_args << " arguments.";
   }
 
@@ -550,9 +550,9 @@ spv_result_t ValidateTypeCooperativeMatrixNV(ValidationState_t& _,
   if (!component_type || (SpvOpTypeFloat != component_type->opcode() &&
                           SpvOpTypeInt != component_type->opcode())) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpTypeCooperativeMatrixNV Component Type <id> '"
+           << "OpTypeCooperativeMatrixNV Component Type <id> "
            << _.getIdName(component_type_id)
-           << "' is not a scalar numerical type.";
+           << " is not a scalar numerical type.";
   }
 
   const auto scope_index = 2;
@@ -561,8 +561,8 @@ spv_result_t ValidateTypeCooperativeMatrixNV(ValidationState_t& _,
   if (!scope || !_.IsIntScalarType(scope->type_id()) ||
       !spvOpcodeIsConstant(scope->opcode())) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpTypeCooperativeMatrixNV Scope <id> '" << _.getIdName(scope_id)
-           << "' is not a constant instruction with scalar integer type.";
+           << "OpTypeCooperativeMatrixNV Scope <id> " << _.getIdName(scope_id)
+           << " is not a constant instruction with scalar integer type.";
   }
 
   const auto rows_index = 3;
@@ -571,8 +571,8 @@ spv_result_t ValidateTypeCooperativeMatrixNV(ValidationState_t& _,
   if (!rows || !_.IsIntScalarType(rows->type_id()) ||
       !spvOpcodeIsConstant(rows->opcode())) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpTypeCooperativeMatrixNV Rows <id> '" << _.getIdName(rows_id)
-           << "' is not a constant instruction with scalar integer type.";
+           << "OpTypeCooperativeMatrixNV Rows <id> " << _.getIdName(rows_id)
+           << " is not a constant instruction with scalar integer type.";
   }
 
   const auto cols_index = 4;
@@ -581,8 +581,8 @@ spv_result_t ValidateTypeCooperativeMatrixNV(ValidationState_t& _,
   if (!cols || !_.IsIntScalarType(cols->type_id()) ||
       !spvOpcodeIsConstant(cols->opcode())) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
-           << "OpTypeCooperativeMatrixNV Cols <id> '" << _.getIdName(cols_id)
-           << "' is not a constant instruction with scalar integer type.";
+           << "OpTypeCooperativeMatrixNV Cols <id> " << _.getIdName(cols_id)
+           << " is not a constant instruction with scalar integer type.";
   }
 
   return SPV_SUCCESS;

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -245,7 +245,7 @@ std::string ValidationState_t::getIdName(uint32_t id) const {
   const std::string id_name = name_mapper_(id);
 
   std::stringstream out;
-  out << id << "[%" << id_name << "]";
+  out << "'" << id << "[%" << id_name << "]'";
   return out.str();
 }
 

--- a/test/cpp_interface_test.cpp
+++ b/test/cpp_interface_test.cpp
@@ -58,7 +58,7 @@ TEST(CppInterface, SuccessfulRoundTrip) {
     EXPECT_EQ(0u, position.line);
     EXPECT_EQ(0u, position.column);
     EXPECT_EQ(1u, position.index);
-    EXPECT_STREQ("ID 1[%1] has not been defined\n  %2 = OpSizeOf %1 %3\n",
+    EXPECT_STREQ("ID '1[%1]' has not been defined\n  %2 = OpSizeOf %1 %3\n",
                  message);
   });
   EXPECT_FALSE(t.Validate(binary));

--- a/test/val/val_adjacency_test.cpp
+++ b/test/val/val_adjacency_test.cpp
@@ -54,7 +54,7 @@ OpFunctionEnd
   CompileSuccessfully(module);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("ID 1[%bool] has not been defined"));
+              HasSubstr("ID '1[%bool]' has not been defined"));
 }
 
 TEST_F(ValidateAdjacency, OpLoopMergeEndsModuleFail) {

--- a/test/val/val_arithmetics_test.cpp
+++ b/test/val/val_arithmetics_test.cpp
@@ -606,8 +606,9 @@ TEST_F(ValidateArithmetics, DotNotVectorTypeOperand1) {
 
   CompileSuccessfully(GenerateCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 6[%float] cannot be a "
-                                               "type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand '6[%float]' cannot be a "
+                        "type"));
 }
 
 TEST_F(ValidateArithmetics, DotNotVectorTypeOperand2) {

--- a/test/val/val_atomics_test.cpp
+++ b/test/val/val_atomics_test.cpp
@@ -1000,8 +1000,9 @@ TEST_F(ValidateAtomics, AtomicLoadWrongPointerType) {
 
   CompileSuccessfully(GenerateKernelCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand 27[%_ptr_Workgroup_float] cannot be a type"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Operand '27[%_ptr_Workgroup_float]' cannot be a type"));
 }
 
 TEST_F(ValidateAtomics, AtomicLoadWrongPointerDataType) {
@@ -1273,7 +1274,7 @@ TEST_F(ValidateAtomics, AtomicExchangeWrongPointerType) {
   CompileSuccessfully(GenerateKernelCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand 33[%_ptr_Workgroup_v4float] cannot be a "
+              HasSubstr("Operand '33[%_ptr_Workgroup_v4float]' cannot be a "
                         "type"));
 }
 
@@ -1400,7 +1401,7 @@ TEST_F(ValidateAtomics, AtomicCompareExchangeWrongPointerType) {
   CompileSuccessfully(GenerateKernelCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand 33[%_ptr_Workgroup_v4float] cannot be a "
+              HasSubstr("Operand '33[%_ptr_Workgroup_v4float]' cannot be a "
                         "type"));
 }
 

--- a/test/val/val_barriers_test.cpp
+++ b/test/val/val_barriers_test.cpp
@@ -971,7 +971,7 @@ OpMemoryBarrier %u32 %u32_0
 
   CompileSuccessfully(GenerateKernelCode(body), SPV_ENV_UNIVERSAL_1_1);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_1));
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 5[%uint] cannot be a "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand '5[%uint]' cannot be a "
                                                "type"));
 }
 

--- a/test/val/val_cfg_test.cpp
+++ b/test/val/val_cfg_test.cpp
@@ -386,8 +386,8 @@ TEST_P(ValidateCFG, BlockAppearsBeforeDominatorBad) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("Block .\\[%cont\\] appears in the binary "
-                           "before its dominator .\\[%branch\\]\n"
+              MatchesRegex("Block '.\\[%cont\\]' appears in the binary "
+                           "before its dominator '.\\[%branch\\]'\n"
                            "  %branch = OpLabel\n"));
 }
 
@@ -419,7 +419,7 @@ TEST_P(ValidateCFG, MergeBlockTargetedByMultipleHeaderBlocksBad) {
   if (is_shader) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(getDiagnosticString(),
-                MatchesRegex("Block .\\[%merge\\] is already a merge block "
+                MatchesRegex("Block '.\\[%merge\\]' is already a merge block "
                              "for another header\n"
                              "  %Main = OpFunction %void None %9\n"));
   } else {
@@ -455,7 +455,7 @@ TEST_P(ValidateCFG, MergeBlockTargetedByMultipleHeaderBlocksSelectionBad) {
   if (is_shader) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(getDiagnosticString(),
-                MatchesRegex("Block .\\[%merge\\] is already a merge block "
+                MatchesRegex("Block '.\\[%merge\\]' is already a merge block "
                              "for another header\n"
                              "  %Main = OpFunction %void None %9\n"));
   } else {
@@ -480,8 +480,8 @@ TEST_P(ValidateCFG, BranchTargetFirstBlockBadSinceEntryBlock) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("First block .\\[%entry\\] of function "
-                           ".\\[%Main\\] is targeted by block .\\[%bad\\]\n"
+              MatchesRegex("First block '.\\[%entry\\]' of function "
+                           "'.\\[%Main\\]' is targeted by block '.\\[%bad\\]'\n"
                            "  %Main = OpFunction %void None %10\n"));
 }
 
@@ -529,10 +529,11 @@ TEST_P(ValidateCFG, BranchConditionalTrueTargetFirstBlockBad) {
 
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("First block .\\[%entry\\] of function .\\[%Main\\] "
-                           "is targeted by block .\\[%bad\\]\n"
-                           "  %Main = OpFunction %void None %10\n"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      MatchesRegex("First block '.\\[%entry\\]' of function '.\\[%Main\\]' "
+                   "is targeted by block '.\\[%bad\\]'\n"
+                   "  %Main = OpFunction %void None %10\n"));
 }
 
 TEST_P(ValidateCFG, BranchConditionalFalseTargetFirstBlockBad) {
@@ -558,10 +559,11 @@ TEST_P(ValidateCFG, BranchConditionalFalseTargetFirstBlockBad) {
 
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("First block .\\[%entry\\] of function .\\[%Main\\] "
-                           "is targeted by block .\\[%bad\\]\n"
-                           "  %Main = OpFunction %void None %10\n"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      MatchesRegex("First block '.\\[%entry\\]' of function '.\\[%Main\\]' "
+                   "is targeted by block '.\\[%bad\\]'\n"
+                   "  %Main = OpFunction %void None %10\n"));
 }
 
 TEST_P(ValidateCFG, SwitchTargetFirstBlockBad) {
@@ -594,10 +596,11 @@ TEST_P(ValidateCFG, SwitchTargetFirstBlockBad) {
 
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("First block .\\[%entry\\] of function .\\[%Main\\] "
-                           "is targeted by block .\\[%bad\\]\n"
-                           "  %Main = OpFunction %void None %10\n"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      MatchesRegex("First block '.\\[%entry\\]' of function '.\\[%Main\\]' "
+                   "is targeted by block '.\\[%bad\\]'\n"
+                   "  %Main = OpFunction %void None %10\n"));
 }
 
 TEST_P(ValidateCFG, BranchToBlockInOtherFunctionBad) {
@@ -630,11 +633,11 @@ TEST_P(ValidateCFG, BranchToBlockInOtherFunctionBad) {
 
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      MatchesRegex("Block\\(s\\) \\{.\\[%middle2\\]\\} are referenced but not "
-                   "defined in function .\\[%Main\\]\n"
-                   "  %Main = OpFunction %void None %9\n"));
+  EXPECT_THAT(getDiagnosticString(),
+              MatchesRegex(
+                  "Block\\(s\\) \\{'.\\[%middle2\\]'\\} are referenced but not "
+                  "defined in function '.\\[%Main\\]'\n"
+                  "  %Main = OpFunction %void None %9\n"));
 }
 
 TEST_P(ValidateCFG, HeaderDoesntStrictlyDominateMergeBad) {
@@ -662,10 +665,11 @@ TEST_P(ValidateCFG, HeaderDoesntStrictlyDominateMergeBad) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(
         getDiagnosticString(),
-        MatchesRegex("The selection construct with the selection header "
-                     ".\\[%head\\] does not strictly structurally dominate the "
-                     "merge block "
-                     ".\\[%head\\]\n  %head = OpLabel\n"));
+        MatchesRegex(
+            "The selection construct with the selection header "
+            "'.\\[%head\\]' does not strictly structurally dominate the "
+            "merge block "
+            "'.\\[%head\\]'\n  %head = OpLabel\n"));
   } else {
     ASSERT_EQ(SPV_SUCCESS, ValidateInstructions()) << str;
   }
@@ -1350,8 +1354,8 @@ TEST_P(ValidateCFG, BackEdgeBlockDoesntPostDominateContinueTargetBad) {
         getDiagnosticString(),
         MatchesRegex(
             "The continue construct with the continue target "
-            ".\\[%loop1_cont\\] is not structurally post dominated by the "
-            "back-edge block .\\[%be_block\\]\n"
+            "'.\\[%loop1_cont\\]' is not structurally post dominated by the "
+            "back-edge block '.\\[%be_block\\]'\n"
             "  %be_block = OpLabel\n"));
   } else {
     ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
@@ -1385,7 +1389,7 @@ TEST_P(ValidateCFG, BranchingToNonLoopHeaderBlockBad) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(
         getDiagnosticString(),
-        MatchesRegex("Back-edges \\(.\\[%f\\] -> .\\[%split\\]\\) can only "
+        MatchesRegex("Back-edges \\('.\\[%f\\]' -> '.\\[%split\\]'\\) can only "
                      "be formed between a block and a loop header.\n"
                      "  %f = OpLabel\n"));
   } else {
@@ -1417,7 +1421,7 @@ TEST_P(ValidateCFG, BranchingToSameNonLoopHeaderBlockBad) {
     EXPECT_THAT(
         getDiagnosticString(),
         MatchesRegex(
-            "Back-edges \\(.\\[%split\\] -> .\\[%split\\]\\) can only be "
+            "Back-edges \\('.\\[%split\\]' -> '.\\[%split\\]'\\) can only be "
             "formed between a block and a loop header.\n  %split = OpLabel\n"));
   } else {
     ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
@@ -1452,7 +1456,7 @@ TEST_P(ValidateCFG, MultipleBackEdgeBlocksToLoopHeaderBad) {
     EXPECT_THAT(
         getDiagnosticString(),
         MatchesRegex(
-            "Loop header .\\[%loop\\] is targeted by 2 back-edge blocks but "
+            "Loop header '.\\[%loop\\]' is targeted by 2 back-edge blocks but "
             "the standard requires exactly one\n  %loop = OpLabel\n"))
         << str;
   } else {
@@ -1487,12 +1491,13 @@ TEST_P(ValidateCFG, ContinueTargetMustBePostDominatedByBackEdge) {
   CompileSuccessfully(str);
   if (is_shader) {
     ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
-    EXPECT_THAT(getDiagnosticString(),
-                MatchesRegex(
-                    "The continue construct with the continue target "
-                    ".\\[%cheader\\] is not structurally post dominated by the "
-                    "back-edge block .\\[%be_block\\]\n"
-                    "  %be_block = OpLabel\n"));
+    EXPECT_THAT(
+        getDiagnosticString(),
+        MatchesRegex(
+            "The continue construct with the continue target "
+            "'.\\[%cheader\\]' is not structurally post dominated by the "
+            "back-edge block '.\\[%be_block\\]'\n"
+            "  %be_block = OpLabel\n"));
   } else {
     ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
   }
@@ -1524,8 +1529,8 @@ TEST_P(ValidateCFG, BranchOutOfConstructToMergeBad) {
     EXPECT_THAT(
         getDiagnosticString(),
         MatchesRegex("The continue construct with the continue target "
-                     ".\\[%loop\\] is not structurally post dominated by the "
-                     "back-edge block .\\[%cont\\]\n"
+                     "'.\\[%loop\\]' is not structurally post dominated by the "
+                     "back-edge block '.\\[%cont\\]'\n"
                      "  %cont = OpLabel\n"))
         << str;
   } else {
@@ -1561,8 +1566,8 @@ TEST_P(ValidateCFG, BranchOutOfConstructBad) {
     EXPECT_THAT(
         getDiagnosticString(),
         MatchesRegex("The continue construct with the continue target "
-                     ".\\[%loop\\] is not structurally post dominated by the "
-                     "back-edge block .\\[%cont\\]\n"
+                     "'.\\[%loop\\]' is not structurally post dominated by the "
+                     "back-edge block '.\\[%cont\\]'\n"
                      "  %cont = OpLabel\n"));
   } else {
     ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
@@ -1636,7 +1641,7 @@ TEST_F(ValidateCFG, LoopWithZeroBackEdgesBad) {
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      MatchesRegex("Loop header .\\[%loop\\] is targeted by "
+      MatchesRegex("Loop header '.\\[%loop\\]' is targeted by "
                    "0 back-edge blocks but the standard requires exactly "
                    "one\n  %loop = OpLabel\n"));
 }
@@ -1748,9 +1753,10 @@ TEST_P(ValidateCFG, ContinueTargetCanBeMergeBlockForNestedStructure) {
     EXPECT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
     EXPECT_THAT(
         getDiagnosticString(),
-        HasSubstr("Header block 3[%if_head] is contained in the loop construct "
-                  "headed "
-                  "by 2[%loop], but its merge block 5[%if_merge] is not"));
+        HasSubstr(
+            "Header block '3[%if_head]' is contained in the loop construct "
+            "headed "
+            "by '2[%loop]', but its merge block '5[%if_merge]' is not"));
   } else {
     EXPECT_THAT(SPV_SUCCESS, ValidateInstructions());
   }
@@ -1955,8 +1961,9 @@ OpFunctionEnd
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "Case construct that targets 10[%10] has branches to multiple other "
-          "case construct targets 12[%12] and 11[%11]\n  %10 = OpLabel"));
+          "Case construct that targets '10[%10]' has branches to multiple "
+          "other "
+          "case construct targets '12[%12]' and '11[%11]'\n  %10 = OpLabel"));
 }
 
 TEST_F(ValidateCFG, MultipleFallThroughToDefault) {
@@ -1990,7 +1997,7 @@ OpFunctionEnd
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("Multiple case constructs have branches to the case construct "
-                "that targets 10[%10]\n  %10 = OpLabel"));
+                "that targets '10[%10]'\n  %10 = OpLabel"));
 }
 
 TEST_F(ValidateCFG, MultipleFallThroughToNonDefault) {
@@ -2024,7 +2031,7 @@ OpFunctionEnd
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("Multiple case constructs have branches to the case construct "
-                "that targets 12[%12]\n  %12 = OpLabel"));
+                "that targets '12[%12]'\n  %12 = OpLabel"));
 }
 
 TEST_F(ValidateCFG, DuplicateTargetWithFallThrough) {
@@ -2085,10 +2092,11 @@ OpFunctionEnd
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Case construct that targets 12[%12] has branches to the case "
-                "construct that targets 11[%11], but does not immediately "
-                "precede it in the OpSwitch's target list\n"
-                "  OpSwitch %uint_0 %10 0 %11 1 %12"));
+      HasSubstr(
+          "Case construct that targets '12[%12]' has branches to the case "
+          "construct that targets '11[%11]', but does not immediately "
+          "precede it in the OpSwitch's target list\n"
+          "  OpSwitch %uint_0 %10 0 %11 1 %12"));
 }
 
 TEST_F(ValidateCFG, WrongOperandListThroughDefault) {
@@ -2121,10 +2129,11 @@ OpFunctionEnd
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Case construct that targets 12[%12] has branches to the case "
-                "construct that targets 11[%11], but does not immediately "
-                "precede it in the OpSwitch's target list\n"
-                "  OpSwitch %uint_0 %10 0 %11 1 %12"));
+      HasSubstr(
+          "Case construct that targets '12[%12]' has branches to the case "
+          "construct that targets '11[%11]', but does not immediately "
+          "precede it in the OpSwitch's target list\n"
+          "  OpSwitch %uint_0 %10 0 %11 1 %12"));
 }
 
 TEST_F(ValidateCFG, WrongOperandListNotLast) {
@@ -2159,10 +2168,11 @@ OpFunctionEnd
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Case construct that targets 12[%12] has branches to the case "
-                "construct that targets 11[%11], but does not immediately "
-                "precede it in the OpSwitch's target list\n"
-                "  OpSwitch %uint_0 %10 0 %11 1 %12 2 %13"));
+      HasSubstr(
+          "Case construct that targets '12[%12]' has branches to the case "
+          "construct that targets '11[%11]', but does not immediately "
+          "precede it in the OpSwitch's target list\n"
+          "  OpSwitch %uint_0 %10 0 %11 1 %12 2 %13"));
 }
 
 TEST_F(ValidateCFG, GoodUnreachableSwitch) {
@@ -2226,11 +2236,12 @@ OpFunctionEnd
 
   CompileSuccessfully(text);
   ASSERT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Case construct that targets 8[%8] has invalid branch "
-                        "to block 10[%10] (not another case construct, "
-                        "corresponding merge, outer loop merge or outer loop "
-                        "continue)"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Case construct that targets '8[%8]' has invalid branch "
+                "to block '10[%10]' (not another case construct, "
+                "corresponding merge, outer loop merge or outer loop "
+                "continue)"));
 }
 
 TEST_F(ValidateCFG, GoodCaseExitsToOuterConstructs) {
@@ -2297,8 +2308,8 @@ OpFunctionEnd
   EXPECT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Case construct that targets 1[%default] has branches to the "
-                "case construct that targets 2[%other], but does not "
+      HasSubstr("Case construct that targets '1[%default]' has branches to the "
+                "case construct that targets '2[%other]', but does not "
                 "immediately precede it in the OpSwitch's target list"));
 }
 
@@ -2330,8 +2341,8 @@ OpFunctionEnd
   EXPECT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Case construct that targets 2[%other] has branches to the "
-                "case construct that targets 1[%default], but does not "
+      HasSubstr("Case construct that targets '2[%other]' has branches to the "
+                "case construct that targets '1[%default]', but does not "
                 "immediately precede it in the OpSwitch's target list"));
 }
 
@@ -2800,7 +2811,7 @@ OpFunctionEnd
   CompileSuccessfully(text);
   EXPECT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Back-edges (10[%10] -> 9[%9]) can only be formed "
+              HasSubstr("Back-edges ('10[%10]' -> '9[%9]') can only be formed "
                         "between a block and a loop header"));
 }
 
@@ -2826,7 +2837,7 @@ OpFunctionEnd
   CompileSuccessfully(text);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Merge Block 1[%undef] must be an OpLabel"));
+              HasSubstr("Merge Block '1[%undef]' must be an OpLabel"));
 }
 
 TEST_F(ValidateCFG, LoopMergeContinueTargetNotLabel) {
@@ -2851,7 +2862,7 @@ OpFunctionEnd
   CompileSuccessfully(text);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Continue Target 1[%undef] must be an OpLabel"));
+              HasSubstr("Continue Target '1[%undef]' must be an OpLabel"));
 }
 
 TEST_F(ValidateCFG, LoopMergeMergeBlockContinueTargetSameLabel) {
@@ -3095,9 +3106,10 @@ OpFunctionEnd
 
   CompileSuccessfully(text);
   EXPECT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("block <ID> 10[%10] exits the selection headed by <ID> "
-                        "8[%8], but not via a structured exit"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("block <ID> '10[%10]' exits the selection headed by <ID> "
+                "'8[%8]', but not via a structured exit"));
 }
 
 TEST_F(ValidateCFG, InvalidLoopExit) {
@@ -3131,8 +3143,8 @@ OpFunctionEnd
   CompileSuccessfully(text);
   EXPECT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("block <ID> 11[%11] exits the loop headed by <ID> "
-                        "8[%8], but not via a structured exit"));
+              HasSubstr("block <ID> '11[%11]' exits the loop headed by <ID> "
+                        "'8[%8]', but not via a structured exit"));
 }
 
 TEST_F(ValidateCFG, InvalidContinueExit) {
@@ -3165,9 +3177,10 @@ OpFunctionEnd
 
   CompileSuccessfully(text);
   EXPECT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("block <ID> 11[%11] exits the continue headed by <ID> "
-                        "10[%10], but not via a structured exit"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("block <ID> '11[%11]' exits the continue headed by <ID> "
+                "'10[%10]', but not via a structured exit"));
 }
 
 TEST_F(ValidateCFG, InvalidSelectionExitBackedge) {
@@ -3205,8 +3218,9 @@ OpFunctionEnd
   EXPECT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("The continue construct with the continue target 9[%9] is not "
-                "structurally post dominated by the back-edge block 13[%13]"));
+      HasSubstr(
+          "The continue construct with the continue target '9[%9]' is not "
+          "structurally post dominated by the back-edge block '13[%13]'"));
 }
 
 TEST_F(ValidateCFG, BreakFromSwitch) {
@@ -3269,9 +3283,10 @@ OpFunctionEnd
 
   CompileSuccessfully(text);
   EXPECT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("block <ID> 12[%12] exits the selection headed by <ID> "
-                        "10[%10], but not via a structured exit"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("block <ID> '12[%12]' exits the selection headed by <ID> "
+                "'10[%10]', but not via a structured exit"));
 }
 
 TEST_F(ValidateCFG, BreakToOuterSwitch) {
@@ -3308,9 +3323,10 @@ OpFunctionEnd
 
   CompileSuccessfully(text);
   EXPECT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("block <ID> 14[%14] exits the selection headed by <ID> "
-                        "10[%10], but not via a structured exit"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("block <ID> '14[%14]' exits the selection headed by <ID> "
+                "'10[%10]', but not via a structured exit"));
 }
 
 TEST_F(ValidateCFG, BreakToOuterLoop) {
@@ -3352,8 +3368,8 @@ OpFunctionEnd
   CompileSuccessfully(text);
   EXPECT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("block <ID> 15[%15] exits the loop headed by <ID> "
-                        "10[%10], but not via a structured exit"));
+              HasSubstr("block <ID> '15[%15]' exits the loop headed by <ID> "
+                        "'10[%10]', but not via a structured exit"));
 }
 
 TEST_F(ValidateCFG, ContinueFromNestedSelection) {
@@ -3800,9 +3816,9 @@ OpFunctionEnd
   EXPECT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr(
-          "Header block 3[%body] is contained in the loop construct headed by "
-          "1[%loop], but its merge block 2[%continue] is not"));
+      HasSubstr("Header block '3[%body]' is contained in the loop construct "
+                "headed by "
+                "'1[%loop]', but its merge block '2[%continue]' is not"));
 }
 
 TEST_F(ValidateCFG, ContinueCannotBeLoopMergeTarget) {
@@ -3837,9 +3853,9 @@ OpFunctionEnd
   EXPECT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr(
-          "Header block 3[%inner] is contained in the loop construct headed by "
-          "1[%loop], but its merge block 2[%continue] is not"));
+      HasSubstr("Header block '3[%inner]' is contained in the loop construct "
+                "headed by "
+                "'1[%loop]', but its merge block '2[%continue]' is not"));
 }
 
 TEST_F(ValidateCFG, ExitFromConstructWhoseHeaderIsAMerge) {
@@ -4214,11 +4230,10 @@ TEST_F(ValidateCFG, StructuredSelections_RegisterBothTrueAndFalse) {
 
   CompileSuccessfully(text);
   EXPECT_NE(SPV_SUCCESS, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr(
-          "The selection construct with the selection header "
-          "8[%8] does not structurally dominate the merge block 10[%10]\n"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("The selection construct with the selection header "
+                        "'8[%8]' does not structurally dominate the merge "
+                        "block '10[%10]'\n"));
 }
 
 TEST_F(ValidateCFG, UnreachableIsStaticallyReachable) {
@@ -4386,9 +4401,10 @@ OpFunctionEnd
 
   CompileSuccessfully(text);
   EXPECT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("block <ID> 1[%BAD] exits the continue headed by <ID> "
-                        "1[%BAD], but not via a structured exit"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("block <ID> '1[%BAD]' exits the continue headed by <ID> "
+                "'1[%BAD]', but not via a structured exit"));
 }
 
 TEST_F(ValidateCFG, SwitchSelectorNotAnInt) {
@@ -4581,8 +4597,8 @@ OpFunctionEnd
   EXPECT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("The continue construct with the continue target 7[%7] "
-                "does not structurally dominate the back-edge block 8[%8]"));
+      HasSubstr("The continue construct with the continue target '7[%7]' "
+                "does not structurally dominate the back-edge block '8[%8]'"));
 }
 
 }  // namespace

--- a/test/val/val_composites_test.cpp
+++ b/test/val/val_composites_test.cpp
@@ -322,8 +322,9 @@ TEST_F(ValidateComposites, CompositeConstructVectorWrongConsituent1) {
 
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 5[%float] cannot be a "
-                                               "type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand '5[%float]' cannot be a "
+                        "type"));
 }
 
 TEST_F(ValidateComposites, CompositeConstructVectorWrongConsituent2) {
@@ -540,7 +541,7 @@ TEST_F(ValidateComposites, CopyObjectResultTypeNotType) {
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("ID 19[%float_0] is not a type id"));
+              HasSubstr("ID '19[%float_0]' is not a type id"));
 }
 
 TEST_F(ValidateComposites, CopyObjectWrongOperandType) {
@@ -660,7 +661,7 @@ TEST_F(ValidateComposites, CompositeExtractNotObject) {
 
   CompileSuccessfully(GenerateShaderCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 11[%v4float] cannot "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand '11[%v4float]' cannot "
                                                "be a type"));
 }
 

--- a/test/val/val_conversion_test.cpp
+++ b/test/val/val_conversion_test.cpp
@@ -813,8 +813,9 @@ TEST_F(ValidateConversion, PtrCastToGenericWrongInputType) {
 
   CompileSuccessfully(GenerateKernelCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 4[%float] cannot be a "
-                                               "type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand '4[%float]' cannot be a "
+                        "type"));
 }
 
 TEST_F(ValidateConversion, PtrCastToGenericWrongInputStorageClass) {
@@ -1258,8 +1259,9 @@ TEST_F(ValidateConversion, BitcastInputHasNoType) {
 
   CompileSuccessfully(GenerateKernelCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 4[%float] cannot be a "
-                                               "type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand '4[%float]' cannot be a "
+                        "type"));
 }
 
 TEST_F(ValidateConversion, BitcastWrongResultType) {
@@ -1458,7 +1460,7 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 1[%uint] cannot be a "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand '1[%uint]' cannot be a "
                                                "type"));
 }
 

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -387,7 +387,7 @@ TEST_F(ValidateData, ids_should_be_validated_before_data) {
   CompileSuccessfully(str.c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand 3[%3] requires a previous definition"));
+              HasSubstr("Operand '3[%3]' requires a previous definition"));
 }
 
 TEST_F(ValidateData, matrix_bad_column_type) {
@@ -549,7 +549,7 @@ TEST_F(ValidateData, missing_forward_pointer_decl) {
   CompileSuccessfully(str.c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand 3[%3] requires a previous definition"));
+              HasSubstr("Operand '3[%3]' requires a previous definition"));
 }
 
 TEST_F(ValidateData, missing_forward_pointer_decl_self_reference) {
@@ -561,7 +561,7 @@ TEST_F(ValidateData, missing_forward_pointer_decl_self_reference) {
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Operand 2[%_struct_2] requires a previous definition"));
+      HasSubstr("Operand '2[%_struct_2]' requires a previous definition"));
 }
 
 TEST_F(ValidateData, forward_pointer_missing_definition) {
@@ -824,7 +824,7 @@ OpMemoryModel Logical GLSL450
   CompileSuccessfully(test, SPV_ENV_UNIVERSAL_1_5);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand 3[%_ptr_PhysicalStorageBuffer__struct_1] "
+              HasSubstr("Operand '3[%_ptr_PhysicalStorageBuffer__struct_1]' "
                         "requires a previous definition"));
 }
 

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -120,7 +120,7 @@ TEST_F(ValidateDecorations, ValidateOpMemberDecorateOutOfBound) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Index 1 provided in OpMemberDecorate for struct <id> "
-                        "2[%_struct_2] is out of bounds. The structure has 1 "
+                        "'2[%_struct_2]' is out of bounds. The structure has 1 "
                         "members. Largest valid index is 0."));
 }
 
@@ -280,12 +280,13 @@ TEST_F(ValidateDecorations, StructContainsBuiltInStructBad) {
   )";
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Structure <id> 1[%_struct_1] contains members with "
-                        "BuiltIn decoration. Therefore this structure may not "
-                        "be contained as a member of another structure type. "
-                        "Structure <id> 4[%_struct_4] contains structure <id> "
-                        "1[%_struct_1]."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Structure <id> '1[%_struct_1]' contains members with "
+                "BuiltIn decoration. Therefore this structure may not "
+                "be contained as a member of another structure type. "
+                "Structure <id> '4[%_struct_4]' contains structure <id> "
+                "'1[%_struct_1]'."));
 }
 
 TEST_F(ValidateDecorations, StructContainsNonBuiltInStructGood) {
@@ -4687,7 +4688,7 @@ OpDecorate %1 Coherent
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Coherent decoration targeting 1[%1] is "
+              HasSubstr("Coherent decoration targeting '1[%1]' is "
                         "banned when using the Vulkan memory model."));
 }
 
@@ -4707,8 +4708,9 @@ OpMemberDecorate %1 0 Coherent
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Coherent decoration targeting 1[%_struct_1] (member index 0) "
-                "is banned when using the Vulkan memory model."));
+      HasSubstr(
+          "Coherent decoration targeting '1[%_struct_1]' (member index 0) "
+          "is banned when using the Vulkan memory model."));
 }
 
 TEST_F(ValidateDecorations, VulkanMemoryModelNoVolatile) {
@@ -4728,7 +4730,7 @@ OpDecorate %1 Volatile
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Volatile decoration targeting 1[%1] is banned when "
+              HasSubstr("Volatile decoration targeting '1[%1]' is banned when "
                         "using the Vulkan memory model."));
 }
 
@@ -4747,7 +4749,7 @@ OpMemberDecorate %1 1 Volatile
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Volatile decoration targeting 1[%_struct_1] (member "
+              HasSubstr("Volatile decoration targeting '1[%_struct_1]' (member "
                         "index 1) is banned when using the Vulkan memory "
                         "model."));
 }

--- a/test/val/val_derivatives_test.cpp
+++ b/test/val/val_derivatives_test.cpp
@@ -130,7 +130,7 @@ TEST_F(ValidateDerivatives, OpDPdxWrongResultType) {
 
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 10[%v4float] cannot "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand '10[%v4float]' cannot "
                                                "be a type"));
 }
 

--- a/test/val/val_ext_inst_test.cpp
+++ b/test/val/val_ext_inst_test.cpp
@@ -4321,7 +4321,7 @@ TEST_P(ValidateOpenCLStdVStoreHalfLike, PNotPointer) {
   CompileSuccessfully(GenerateKernelCode(ss.str()));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand 89[%_ptr_Workgroup_half] cannot be a type"));
+              HasSubstr("Operand '89[%_ptr_Workgroup_half]' cannot be a type"));
 }
 
 TEST_P(ValidateOpenCLStdVStoreHalfLike, ConstPointer) {
@@ -4493,7 +4493,7 @@ TEST_P(ValidateOpenCLStdVLoadHalfLike, PNotPointer) {
   CompileSuccessfully(GenerateKernelCode(ss.str()));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand 89[%_ptr_Workgroup_half] cannot be a type"));
+              HasSubstr("Operand '89[%_ptr_Workgroup_half]' cannot be a type"));
 }
 
 TEST_P(ValidateOpenCLStdVLoadHalfLike, OffsetWrongStorageType) {
@@ -4664,9 +4664,10 @@ TEST_F(ValidateExtInst, VLoadNPNotPointer) {
 
   CompileSuccessfully(GenerateKernelCode(ss.str()));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand 120[%_ptr_UniformConstant_float] cannot be a "
-                        "type"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Operand '120[%_ptr_UniformConstant_float]' cannot be a "
+                "type"));
 }
 
 TEST_F(ValidateExtInst, VLoadNWrongStorageClass) {
@@ -4779,7 +4780,7 @@ TEST_F(ValidateExtInst, VLoadHalfPNotPointer) {
   CompileSuccessfully(GenerateKernelCode(ss.str()));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand 114[%_ptr_UniformConstant_half] cannot be a "
+              HasSubstr("Operand '114[%_ptr_UniformConstant_half]' cannot be a "
                         "type"));
 }
 
@@ -4933,7 +4934,7 @@ TEST_F(ValidateExtInst, VStoreNPNotPointer) {
   CompileSuccessfully(GenerateKernelCode(ss.str()));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand 127[%_ptr_Generic_float] cannot be a type"));
+              HasSubstr("Operand '127[%_ptr_Generic_float]' cannot be a type"));
 }
 
 TEST_F(ValidateExtInst, VStoreNWrongStorageClass) {
@@ -5248,9 +5249,10 @@ TEST_F(ValidateExtInst, OpenCLStdPrintfFormatNotPointer) {
 
   CompileSuccessfully(GenerateKernelCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand 137[%_ptr_UniformConstant_uchar] cannot be a "
-                        "type"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Operand '137[%_ptr_UniformConstant_uchar]' cannot be a "
+                "type"));
 }
 
 TEST_F(ValidateExtInst, OpenCLStdPrintfFormatNotUniformConstStorageClass) {
@@ -5342,7 +5344,7 @@ TEST_F(ValidateExtInst, OpenCLStdPrefetchPtrNotPointer) {
   CompileSuccessfully(GenerateKernelCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand 99[%_ptr_CrossWorkgroup_uint] cannot be a "
+              HasSubstr("Operand '99[%_ptr_CrossWorkgroup_uint]' cannot be a "
                         "type"));
 }
 

--- a/test/val/val_function_test.cpp
+++ b/test/val/val_function_test.cpp
@@ -181,13 +181,14 @@ TEST_P(ValidateFunctionCall, VariableNoVariablePointers) {
   } else {
     EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
     if (storage_class == "StorageBuffer") {
-      EXPECT_THAT(getDiagnosticString(),
-                  HasSubstr("StorageBuffer pointer operand 1[%var] requires a "
-                            "variable pointers capability"));
+      EXPECT_THAT(
+          getDiagnosticString(),
+          HasSubstr("StorageBuffer pointer operand '1[%var]' requires a "
+                    "variable pointers capability"));
     } else {
       EXPECT_THAT(
           getDiagnosticString(),
-          HasSubstr("Invalid storage class for pointer operand 1[%var]"));
+          HasSubstr("Invalid storage class for pointer operand '1[%var]'"));
     }
   }
 }
@@ -211,8 +212,9 @@ TEST_P(ValidateFunctionCall, VariableVariablePointersStorageClass) {
     EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
   } else {
     EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-    EXPECT_THAT(getDiagnosticString(),
-                HasSubstr("Invalid storage class for pointer operand 1[%var]"));
+    EXPECT_THAT(
+        getDiagnosticString(),
+        HasSubstr("Invalid storage class for pointer operand '1[%var]'"));
   }
 }
 
@@ -235,8 +237,9 @@ TEST_P(ValidateFunctionCall, VariableVariablePointers) {
     EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
   } else {
     EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-    EXPECT_THAT(getDiagnosticString(),
-                HasSubstr("Invalid storage class for pointer operand 1[%var]"));
+    EXPECT_THAT(
+        getDiagnosticString(),
+        HasSubstr("Invalid storage class for pointer operand '1[%var]'"));
   }
 }
 
@@ -258,11 +261,12 @@ TEST_P(ValidateFunctionCall, ParameterNoVariablePointers) {
     EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
     if (storage_class == "StorageBuffer") {
       EXPECT_THAT(getDiagnosticString(),
-                  HasSubstr("StorageBuffer pointer operand 1[%p] requires a "
+                  HasSubstr("StorageBuffer pointer operand '1[%p]' requires a "
                             "variable pointers capability"));
     } else {
-      EXPECT_THAT(getDiagnosticString(),
-                  HasSubstr("Invalid storage class for pointer operand 1[%p]"));
+      EXPECT_THAT(
+          getDiagnosticString(),
+          HasSubstr("Invalid storage class for pointer operand '1[%p]'"));
     }
   }
 }
@@ -287,7 +291,7 @@ TEST_P(ValidateFunctionCall, ParameterVariablePointersStorageBuffer) {
   } else {
     EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
     EXPECT_THAT(getDiagnosticString(),
-                HasSubstr("Invalid storage class for pointer operand 1[%p]"));
+                HasSubstr("Invalid storage class for pointer operand '1[%p]'"));
   }
 }
 
@@ -311,7 +315,7 @@ TEST_P(ValidateFunctionCall, ParameterVariablePointers) {
   } else {
     EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
     EXPECT_THAT(getDiagnosticString(),
-                HasSubstr("Invalid storage class for pointer operand 1[%p]"));
+                HasSubstr("Invalid storage class for pointer operand '1[%p]'"));
   }
 }
 
@@ -334,16 +338,17 @@ TEST_P(ValidateFunctionCall, NonMemoryObjectDeclarationNoVariablePointers) {
     EXPECT_THAT(
         getDiagnosticString(),
         HasSubstr(
-            "Pointer operand 2[%gep] must be a memory object declaration"));
+            "Pointer operand '2[%gep]' must be a memory object declaration"));
   } else {
     if (storage_class == "StorageBuffer") {
-      EXPECT_THAT(getDiagnosticString(),
-                  HasSubstr("StorageBuffer pointer operand 2[%gep] requires a "
-                            "variable pointers capability"));
+      EXPECT_THAT(
+          getDiagnosticString(),
+          HasSubstr("StorageBuffer pointer operand '2[%gep]' requires a "
+                    "variable pointers capability"));
     } else if (storage_class != "UniformConstant") {
       EXPECT_THAT(
           getDiagnosticString(),
-          HasSubstr("Invalid storage class for pointer operand 2[%gep]"));
+          HasSubstr("Invalid storage class for pointer operand '2[%gep]'"));
     }
   }
 }
@@ -373,11 +378,11 @@ TEST_P(ValidateFunctionCall,
       EXPECT_THAT(
           getDiagnosticString(),
           HasSubstr(
-              "Pointer operand 2[%gep] must be a memory object declaration"));
+              "Pointer operand '2[%gep]' must be a memory object declaration"));
     } else {
       EXPECT_THAT(
           getDiagnosticString(),
-          HasSubstr("Invalid storage class for pointer operand 2[%gep]"));
+          HasSubstr("Invalid storage class for pointer operand '2[%gep]'"));
     }
   }
 }
@@ -407,11 +412,11 @@ TEST_P(ValidateFunctionCall, NonMemoryObjectDeclarationVariablePointers) {
       EXPECT_THAT(
           getDiagnosticString(),
           HasSubstr(
-              "Pointer operand 2[%gep] must be a memory object declaration"));
+              "Pointer operand '2[%gep]' must be a memory object declaration"));
     } else {
       EXPECT_THAT(
           getDiagnosticString(),
-          HasSubstr("Invalid storage class for pointer operand 2[%gep]"));
+          HasSubstr("Invalid storage class for pointer operand '2[%gep]'"));
     }
   }
 }

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -286,7 +286,7 @@ TEST_F(ValidateIdWithMessage, OpMemberDecorateMemberBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Index 3 provided in OpMemberDecorate for struct <id> "
-                        "1[%_struct_1] is out of bounds. The structure has 2 "
+                        "'1[%_struct_1]' is out of bounds. The structure has 2 "
                         "members. Largest valid index is 1."));
 }
 
@@ -380,7 +380,7 @@ TEST_F(ValidateIdWithMessage, OpGroupMemberDecorateIndexOutOfBoundBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Index 3 provided in OpGroupMemberDecorate for struct "
-                        "<id> 2[%_struct_2] is out of bounds. The structure "
+                        "<id> '2[%_struct_2]' is out of bounds. The structure "
                         "has 3 members. Largest valid index is 2."));
 }
 
@@ -1352,7 +1352,7 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstConstituentTypeBad) {
 %4 = OpConstantComposite %3 %2 %2 %2 %1)";  // Uses a type as operand
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 1[%uint] cannot be a "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand '1[%uint]' cannot be a "
                                                "type"));
 }
 TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstConstituentBad) {
@@ -2127,7 +2127,7 @@ TEST_F(ValidateIdWithMessage, OpVariableInitializerIsTypeBad) {
 %3 = OpVariable %2 Input %2)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 2[%_ptr_Input_uint] "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand '2[%_ptr_Input_uint]' "
                                                "cannot be a type"));
 }
 
@@ -2702,7 +2702,7 @@ TEST_F(ValidateIdWithMessage, OpLoadPointerBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   // Prove that SSA checks trigger for a bad Id value.
   // The next test case show the not-a-logical-pointer case.
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 8[%8] has not been "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID '8[%8]' has not been "
                                                "defined"));
 }
 
@@ -3153,7 +3153,7 @@ TEST_F(ValidateIdWithMessage, OpStoreLabel) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand 7[%7] requires a type"));
+              HasSubstr("Operand '7[%7]' requires a type"));
 }
 
 // TODO: enable when this bug is fixed:
@@ -3730,7 +3730,7 @@ OpFunctionEnd
   )";
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 1[%void] cannot be a "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand '1[%void]' cannot be a "
                                                "type"));
 }
 
@@ -3749,7 +3749,7 @@ OpFunctionEnd
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand 8[%_ptr_Private_float] cannot be a type"));
+              HasSubstr("Operand '8[%_ptr_Private_float]' cannot be a type"));
 }
 
 // Invalid: The storage class of Base and Result do not match.
@@ -4248,7 +4248,7 @@ OpFunctionEnd
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Invalid use of function result id 3[%3]."));
+              HasSubstr("Invalid use of function result id '3[%3]'."));
 }
 
 TEST_F(ValidateIdWithMessage, OpFunctionParameterGood) {
@@ -4883,7 +4883,7 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 3[%true] is not a type "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID '3[%true]' is not a type "
                                                "id"));
 }
 
@@ -4996,9 +4996,9 @@ OpFunctionEnd
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpPhi's result type <id> 2[%bool] does not match "
-                        "incoming value <id> 6[%uint_0] type <id> "
-                        "5[%uint]."));
+              HasSubstr("OpPhi's result type <id> '2[%bool]' does not match "
+                        "incoming value <id> '6[%uint_0]' type <id> "
+                        "'5[%uint]'."));
 }
 
 TEST_F(ValidateIdWithMessage, OpPhiPredecessorNotABlock) {
@@ -5022,9 +5022,10 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpPhi's incoming basic block <id> 3[%true] is not an "
-                        "OpLabel."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("OpPhi's incoming basic block <id> '3[%true]' is not an "
+                "OpLabel."));
 }
 
 TEST_F(ValidateIdWithMessage, OpPhiNotAPredecessor) {
@@ -5049,8 +5050,8 @@ OpFunctionEnd
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpPhi's incoming basic block <id> 9[%9] is not a "
-                        "predecessor of <id> 8[%8]."));
+              HasSubstr("OpPhi's incoming basic block <id> '9[%9]' is not a "
+                        "predecessor of <id> '8[%8]'."));
 }
 
 TEST_F(ValidateIdWithMessage, OpBranchConditionalGood) {
@@ -5150,7 +5151,7 @@ OpBranchConditional %bool %target_t %target_f
 
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 3[%bool] cannot be a "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand '3[%bool]' cannot be a "
                                                "type"));
 }
 
@@ -5213,7 +5214,7 @@ TEST_F(ValidateIdWithMessage, OpReturnValueIsType) {
      OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 1[%void] cannot be a "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand '1[%void]' cannot be a "
                                                "type"));
 }
 
@@ -5229,7 +5230,7 @@ TEST_F(ValidateIdWithMessage, OpReturnValueIsLabel) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand 5[%5] requires a type"));
+              HasSubstr("Operand '5[%5]' requires a type"));
 }
 
 TEST_F(ValidateIdWithMessage, OpReturnValueIsVoid) {
@@ -5339,7 +5340,7 @@ TEST_F(ValidateIdWithMessage, UndefinedTypeId) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand 2[%2] requires a previous definition"));
+              HasSubstr("Operand '2[%2]' requires a previous definition"));
 }
 
 TEST_F(ValidateIdWithMessage, UndefinedIdScope) {
@@ -5356,7 +5357,7 @@ TEST_F(ValidateIdWithMessage, UndefinedIdScope) {
 )";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 7[%7] has not been "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID '7[%7]' has not been "
                                                "defined"));
 }
 
@@ -5374,7 +5375,7 @@ TEST_F(ValidateIdWithMessage, UndefinedIdMemSem) {
 )";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 7[%7] has not been "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID '7[%7]' has not been "
                                                "defined"));
 }
 
@@ -5576,11 +5577,10 @@ OpFunctionEnd
   )";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr(
-          "ID 7[%7] defined in block 6[%6] does not dominate its use in block "
-          "9[%9]"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("ID '7[%7]' defined in block '6[%6]' does not dominate "
+                        "its use in block "
+                        "'9[%9]'"));
 }
 
 TEST_F(ValidateIdWithMessage, SpecIdTargetNotSpecializationConstant) {
@@ -5717,7 +5717,7 @@ TEST_F(ValidateIdWithMessage, TypeFunctionBadUse) {
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Invalid use of function type result id 2[%2]."));
+              HasSubstr("Invalid use of function type result id '2[%2]'."));
 }
 
 TEST_F(ValidateIdWithMessage, BadTypeId) {
@@ -5735,7 +5735,7 @@ TEST_F(ValidateIdWithMessage, BadTypeId) {
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID 4[%float_0] is not a type "
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID '4[%float_0]' is not a type "
                                                "id"));
 }
 
@@ -6398,9 +6398,10 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("ID 8[%8] defined in block 7[%7] does not dominate its "
-                        "use in block 10[%10]\n  %10 = OpLabel"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("ID '8[%8]' defined in block '7[%7]' does not dominate its "
+                "use in block '10[%10]'\n  %10 = OpLabel"));
 }
 
 TEST_F(ValidateIdWithMessage, IdDefInUnreachableBlock2) {
@@ -6424,9 +6425,10 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("ID 8[%8] defined in block 7[%7] does not dominate its "
-                        "use in block 10[%10]\n  %10 = OpLabel"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("ID '8[%8]' defined in block '7[%7]' does not dominate its "
+                "use in block '10[%10]'\n  %10 = OpLabel"));
 }
 
 TEST_F(ValidateIdWithMessage, IdDefInUnreachableBlock3) {
@@ -6450,9 +6452,10 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("ID 8[%8] defined in block 7[%7] does not dominate its "
-                        "use in block 10[%10]\n  %10 = OpLabel"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("ID '8[%8]' defined in block '7[%7]' does not dominate its "
+                "use in block '10[%10]'\n  %10 = OpLabel"));
 }
 
 TEST_F(ValidateIdWithMessage, IdDefInUnreachableBlock4) {
@@ -6517,9 +6520,10 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("ID 9[%9] defined in block 8[%8] does not dominate its "
-                        "use in block 7[%7]\n  %7 = OpLabel"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("ID '9[%9]' defined in block '8[%8]' does not dominate its "
+                "use in block '7[%7]'\n  %7 = OpLabel"));
 }
 
 TEST_F(ValidateIdWithMessage, ReachableDefUnreachableUse) {
@@ -6570,9 +6574,10 @@ TEST_F(ValidateIdWithMessage, UnreachableDefUsedInPhi) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("In OpPhi instruction 14[%14], ID 13[%13] definition does not "
-                "dominate its parent 7[%7]\n  %14 = OpPhi %float %11 %10 %13 "
-                "%7"));
+      HasSubstr(
+          "In OpPhi instruction '14[%14]', ID '13[%13]' definition does not "
+          "dominate its parent '7[%7]'\n  %14 = OpPhi %float %11 %10 %13 "
+          "%7"));
 }
 
 TEST_F(ValidateIdWithMessage, OpTypeForwardPointerNotAPointerType) {
@@ -6638,10 +6643,9 @@ TEST_F(ValidateIdWithMessage, MissingForwardPointer) {
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr(
-          "Operand 3[%_ptr_Uniform__struct_2] requires a previous definition"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand '3[%_ptr_Uniform__struct_2]' requires a "
+                        "previous definition"));
 }
 
 TEST_F(ValidateIdWithMessage, NVBindlessSamplerInStruct) {

--- a/test/val/val_image_test.cpp
+++ b/test/val/val_image_test.cpp
@@ -1125,8 +1125,9 @@ TEST_F(ValidateImage, ImageTexelPointerImageNotResultTypePointer) {
 
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 148[%148] cannot be a "
-                                               "type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand '148[%148]' cannot be a "
+                        "type"));
 }
 
 TEST_F(ValidateImage, ImageTexelPointerImageNotImage) {

--- a/test/val/val_interfaces_test.cpp
+++ b/test/val/val_interfaces_test.cpp
@@ -217,7 +217,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_4));
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Non-unique OpEntryPoint interface 2[%var] is disallowed"));
+      HasSubstr("Non-unique OpEntryPoint interface '2[%var]' is disallowed"));
 }
 
 TEST_F(ValidateInterfacesTest, MissingGlobalVarSPV1p3) {

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -693,7 +693,7 @@ TEST_F(ValidateMemory, ArrayLenInputNotStruct) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("The Struture's type in OpArrayLength <id> '11[%11]' "
+              HasSubstr("The Structure's type in OpArrayLength <id> '11[%11]' "
                         "must be a pointer to an OpTypeStruct."));
 }
 
@@ -723,7 +723,7 @@ TEST_F(ValidateMemory, ArrayLenInputLastMemberNoRTA) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("The Struture's last member in OpArrayLength <id> '11[%11]' "
+      HasSubstr("The Structure's last member in OpArrayLength <id> '11[%11]' "
                 "must be an OpTypeRuntimeArray.\n  %11 = OpArrayLength %uint "
                 "%10 0\n"));
 }
@@ -754,7 +754,7 @@ TEST_F(ValidateMemory, ArrayLenInputLastMemberNoRTA2) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("The Struture's last member in OpArrayLength <id> '11[%11]' "
+      HasSubstr("The Structure's last member in OpArrayLength <id> '11[%11]' "
                 "must be an OpTypeRuntimeArray.\n  %11 = OpArrayLength %uint "
                 "%10 1\n"));
 }
@@ -818,7 +818,7 @@ TEST_F(ValidateMemory, ArrayLenIndexNotPointerToStruct) {
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
-          "The Struture's type in OpArrayLength <id> '12[%12]' must be a "
+          "The Structure's type in OpArrayLength <id> '12[%12]' must be a "
           "pointer to an OpTypeStruct.\n  %12 = OpArrayLength %uint %11 0\n"));
 }
 
@@ -842,8 +842,9 @@ TEST_F(ValidateMemory, ArrayLenPointerIsAType) {
 
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand 4[%float] cannot be a "
-                                               "type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand '4[%float]' cannot be a "
+                        "type"));
 }
 
 TEST_F(ValidateMemory, PushConstantNotStructGood) {
@@ -1651,7 +1652,7 @@ OpFunctionEnd
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand 1[%incorrect] requires a type"));
+              HasSubstr("Operand '1[%incorrect]' requires a type"));
 }
 
 TEST_F(ValidateMemory, PSBLoadAlignedSuccess) {

--- a/test/val/val_non_semantic_test.cpp
+++ b/test/val/val_non_semantic_test.cpp
@@ -187,7 +187,7 @@ OpEntryPoint Vertex %main "main"
   // there's no specific error for using an OpExtInst too early, it requires a
   // type so by definition any use of a type in it will be an undefined ID
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("ID 2[%2] has not been defined"));
+              HasSubstr("ID '2[%2]' has not been defined"));
 }
 
 TEST_F(ValidateNonSemanticString, MissingOpExtensionPost1p6) {

--- a/test/val/val_ray_query_test.cpp
+++ b/test/val/val_ray_query_test.cpp
@@ -447,7 +447,7 @@ OpRayQueryInitializeKHR %ray_query %load %u32vec2 %u32_0 %f32vec3_0 %f32_0 %f32v
   CompileSuccessfully(GenerateShaderCode(body).c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand 15[%v2uint] cannot be a type"));
+              HasSubstr("Operand '15[%v2uint]' cannot be a type"));
 }
 
 TEST_F(ValidateRayQuery, InitializeBadCullMask) {

--- a/test/val/val_ssa_test.cpp
+++ b/test/val/val_ssa_test.cpp
@@ -118,7 +118,7 @@ TEST_F(ValidateSSA, DominateUsageWithinBlockBad) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("ID .\\[%bad\\] has not been defined\n"
+              MatchesRegex("ID '.\\[%bad\\]' has not been defined\n"
                            "  %8 = OpIAdd %uint %uint_1 %bad\n"));
 }
 
@@ -141,7 +141,7 @@ TEST_F(ValidateSSA, DominateUsageSameInstructionBad) {
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("ID .\\[%sum\\] has not been defined\n"
+              MatchesRegex("ID '.\\[%sum\\]' has not been defined\n"
                            "  %sum = OpIAdd %uint %uint_1 %sum\n"));
 }
 
@@ -204,7 +204,7 @@ TEST_F(ValidateSSA, ForwardMemberNameMissingTargetBad) {
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("The following forward referenced IDs have not been "
-                        "defined:\n2[%2]"));
+                        "defined:\n'2[%2]'"));
 }
 
 TEST_F(ValidateSSA, ForwardDecorateGood) {
@@ -1126,8 +1126,8 @@ TEST_F(ValidateSSA, IdDoesNotDominateItsUseBad) {
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      MatchesRegex("ID .\\[%eleven\\] defined in block .\\[%true_block\\] "
-                   "does not dominate its use in block .\\[%false_block\\]\n"
+      MatchesRegex("ID '.\\[%eleven\\]' defined in block '.\\[%true_block\\]' "
+                   "does not dominate its use in block '.\\[%false_block\\]'\n"
                    "  %false_block = OpLabel\n"));
 }
 
@@ -1187,7 +1187,7 @@ TEST_F(ValidateSSA,
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              MatchesRegex("ID .\\[%inew\\] has not been defined\n"
+              MatchesRegex("ID '.\\[%inew\\]' has not been defined\n"
                            "  %19 = OpIAdd %uint %inew %uint_1\n"));
 }
 
@@ -1268,12 +1268,12 @@ TEST_F(ValidateSSA, PhiVariableDefNotDominatedByParentBlockBad) {
 
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      MatchesRegex("In OpPhi instruction .\\[%phi\\], ID .\\[%true_copy\\] "
-                   "definition does not dominate its parent .\\[%if_false\\]\n"
-                   "  %phi = OpPhi %bool %true_copy %if_false %false_copy "
-                   "%if_true\n"));
+  EXPECT_THAT(getDiagnosticString(),
+              MatchesRegex(
+                  "In OpPhi instruction '.\\[%phi\\]', ID '.\\[%true_copy\\]' "
+                  "definition does not dominate its parent '.\\[%if_false\\]'\n"
+                  "  %phi = OpPhi %bool %true_copy %if_false %false_copy "
+                  "%if_true\n"));
 }
 
 TEST_F(ValidateSSA, PhiVariableDefDominatesButNotDefinedInParentBlock) {
@@ -1396,11 +1396,11 @@ TEST_F(ValidateSSA, UseFunctionParameterFromOtherFunctionBad) {
 
   CompileSuccessfully(str);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      MatchesRegex("ID .\\[%first\\] used in function .\\[%func2\\] is used "
-                   "outside of it's defining function .\\[%func\\]\n"
-                   "  %func = OpFunction %void None %14\n"));
+  EXPECT_THAT(getDiagnosticString(),
+              MatchesRegex(
+                  "ID '.\\[%first\\]' used in function '.\\[%func2\\]' is used "
+                  "outside of it's defining function '.\\[%func\\]'\n"
+                  "  %func = OpFunction %void None %14\n"));
 }
 
 TEST_F(ValidateSSA, TypeForwardPointerForwardReference) {


### PR DESCRIPTION
Half the messages used to output 'id[%name]' and half id[%name].  With this change, all messages consistently output 'id[%name]'.  Some typos are also fixed in the process.