### PR TITLE
spirv-val: Add an option to use friendly names or not

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -670,6 +670,10 @@ SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetSkipBlockLayout(
 SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetAllowLocalSizeId(
     spv_validator_options options, bool val);
 
+// Whether friendly names should be used in validation error messages.
+SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetFriendlyNames(
+    spv_validator_options options, bool val);
+
 // Creates an optimizer options object with default options. Returns a valid
 // options object. The object remains valid until it is passed into
 // |spvOptimizerOptionsDestroy|.

--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -148,6 +148,11 @@ class ValidatorOptions {
     spvValidatorOptionsSetBeforeHlslLegalization(options_, val);
   }
 
+  // Whether friendly names should be used in validation error messages.
+  void SetFriendlyNames(bool val) {
+    spvValidatorOptionsSetFriendlyNames(options_, val);
+  }
+
  private:
   spv_validator_options options_;
 };

--- a/source/spirv_validator_options.cpp
+++ b/source/spirv_validator_options.cpp
@@ -125,3 +125,8 @@ void spvValidatorOptionsSetAllowLocalSizeId(spv_validator_options options,
                                             bool val) {
   options->allow_localsizeid = val;
 }
+
+void spvValidatorOptionsSetFriendlyNames(spv_validator_options options,
+                                         bool val) {
+  options->use_friendly_names = val;
+}

--- a/source/spirv_validator_options.h
+++ b/source/spirv_validator_options.h
@@ -48,7 +48,8 @@ struct spv_validator_options_t {
         workgroup_scalar_block_layout(false),
         skip_block_layout(false),
         allow_localsizeid(false),
-        before_hlsl_legalization(false) {}
+        before_hlsl_legalization(false),
+        use_friendly_names(true) {}
 
   validator_universal_limits_t universal_limits_;
   bool relax_struct_store;
@@ -60,6 +61,7 @@ struct spv_validator_options_t {
   bool skip_block_layout;
   bool allow_localsizeid;
   bool before_hlsl_legalization;
+  bool use_friendly_names;
 };
 
 #endif  // SOURCE_SPIRV_VALIDATOR_OPTIONS_H_

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -208,9 +208,12 @@ ValidationState_t::ValidationState_t(const spv_const_context ctx,
   }
   UpdateFeaturesBasedOnSpirvVersion(&features_, version_);
 
-  friendly_mapper_ = spvtools::MakeUnique<spvtools::FriendlyNameMapper>(
-      context_, words_, num_words_);
-  name_mapper_ = friendly_mapper_->GetNameMapper();
+  name_mapper_ = spvtools::GetTrivialNameMapper();
+  if (options_->use_friendly_names) {
+    friendly_mapper_ = spvtools::MakeUnique<spvtools::FriendlyNameMapper>(
+        context_, words_, num_words_);
+    name_mapper_ = friendly_mapper_->GetNameMapper();
+  }
 }
 
 void ValidationState_t::preallocateStorage() {

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -35,7 +35,15 @@ using spvtest::ScopedContext;
 using ::testing::HasSubstr;
 using ::testing::ValuesIn;
 
-using ValidateIdWithMessage = spvtest::ValidateBase<bool>;
+class ValidateIdWithMessage : public spvtest::ValidateBase<bool> {
+ public:
+  ValidateIdWithMessage() {
+    const bool use_friendly_names = GetParam();
+    spvValidatorOptionsSetFriendlyNames(options_, use_friendly_names);
+  }
+
+  std::string make_message(const char* msg);
+};
 
 std::string kOpCapabilitySetupWithoutVector16 = R"(
      OpCapability Shader
@@ -177,9 +185,62 @@ std::string BranchConditionalTail = R"(
                OpFunctionEnd
 )";
 
+// Transform an expected validation message to either use friendly names (as
+// provided in the message) or replace the friendly names by the corresponding
+// id.  The same flag used to configure the validator to output friendly names
+// or not is used here.
+std::string ValidateIdWithMessage::make_message(const char* msg) {
+  const bool use_friendly_names = GetParam();
+  if (use_friendly_names) {
+    return msg;
+  }
+
+  std::string message(msg);
+  std::string result;
+
+  size_t next = 0;
+  while (next < message.size()) {
+    // Parse 'num[%name]'
+    size_t open_quote = message.find('\'', next);
+
+    // Copy up to the first quote
+    result.append(message, next, open_quote - next);
+    if (open_quote == std::string::npos) {
+      break;
+    }
+    // Handle apostrophes
+    if (!isdigit(message[open_quote + 1])) {
+      result.append("'");
+      next = open_quote + 1;
+      continue;
+    }
+
+    size_t open_bracket = message.find('[', open_quote + 1);
+    assert(open_bracket != std::string::npos);
+
+    size_t close_bracket = message.find(']', open_bracket + 1);
+    assert(close_bracket != std::string::npos);
+
+    size_t close_quote = close_bracket + 1;
+    assert(close_quote < message.size() && message[close_quote] == '\'');
+
+    // Change to 'num[%num]' because friendly names are not being used.
+    result.append(message, open_quote, open_bracket - open_quote + 1);  // 'num[
+    result.append("%");  //      %
+    result.append(message, open_quote + 1,
+                  open_bracket - open_quote - 1);  //       num
+    result.append("]'");                           //          ]'
+
+    // Continue to the next id, or end of string.
+    next = close_quote + 1;
+  }
+
+  return result;
+}
+
 // TODO: OpUndef
 
-TEST_F(ValidateIdWithMessage, OpName) {
+TEST_P(ValidateIdWithMessage, OpName) {
   std::string spirv = kGLSL450MemoryModel + R"(
      OpName %2 "name"
 %1 = OpTypeInt 32 0
@@ -189,7 +250,7 @@ TEST_F(ValidateIdWithMessage, OpName) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpMemberNameGood) {
+TEST_P(ValidateIdWithMessage, OpMemberNameGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
      OpMemberName %2 0 "foo"
 %1 = OpTypeInt 32 0
@@ -197,30 +258,30 @@ TEST_F(ValidateIdWithMessage, OpMemberNameGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpMemberNameTypeBad) {
+TEST_P(ValidateIdWithMessage, OpMemberNameTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
      OpMemberName %1 0 "foo"
 %1 = OpTypeInt 32 0)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpMemberName Type <id> '1[%uint]' is not a struct type."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "OpMemberName Type <id> '1[%uint]' is not a struct type.")));
 }
-TEST_F(ValidateIdWithMessage, OpMemberNameMemberBad) {
+TEST_P(ValidateIdWithMessage, OpMemberNameMemberBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
      OpMemberName %1 1 "foo"
 %2 = OpTypeInt 32 0
 %1 = OpTypeStruct %2)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpMemberName Member <id> '1[%_struct_1]' index is larger "
-                "than Type <id> '1[%_struct_1]'s member count."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "OpMemberName Member <id> '1[%_struct_1]' index is larger "
+                  "than Type <id> '1[%_struct_1]'s member count.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpLineGood) {
+TEST_P(ValidateIdWithMessage, OpLineGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpString "/path/to/source.file"
      OpLine %1 0 0
@@ -231,7 +292,7 @@ TEST_F(ValidateIdWithMessage, OpLineGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpLineFileBad) {
+TEST_P(ValidateIdWithMessage, OpLineFileBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
   %1 = OpTypeInt 32 0
      OpLine %1 0 0
@@ -239,10 +300,11 @@ TEST_F(ValidateIdWithMessage, OpLineFileBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpLine Target <id> '1[%uint]' is not an OpString."));
+              HasSubstr(make_message(
+                  "OpLine Target <id> '1[%uint]' is not an OpString.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpDecorateGood) {
+TEST_P(ValidateIdWithMessage, OpDecorateGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
      OpDecorate %2 GLSLShared
 %1 = OpTypeInt 64 0
@@ -250,16 +312,17 @@ TEST_F(ValidateIdWithMessage, OpDecorateGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpDecorateBad) {
+TEST_P(ValidateIdWithMessage, OpDecorateBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 OpDecorate %1 GLSLShared)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("forward referenced IDs have not been defined"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("forward referenced IDs have not been defined")));
 }
 
-TEST_F(ValidateIdWithMessage, OpMemberDecorateGood) {
+TEST_P(ValidateIdWithMessage, OpMemberDecorateGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
      OpMemberDecorate %2 0 RelaxedPrecision
 %1 = OpTypeInt 32 0
@@ -267,17 +330,18 @@ TEST_F(ValidateIdWithMessage, OpMemberDecorateGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpMemberDecorateBad) {
+TEST_P(ValidateIdWithMessage, OpMemberDecorateBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
      OpMemberDecorate %1 0 RelaxedPrecision
 %1 = OpTypeInt 32 0)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpMemberDecorate Structure type <id> '1[%uint]' is "
-                        "not a struct type."));
+              HasSubstr(make_message(
+                  "OpMemberDecorate Structure type <id> '1[%uint]' is "
+                  "not a struct type.")));
 }
-TEST_F(ValidateIdWithMessage, OpMemberDecorateMemberBad) {
+TEST_P(ValidateIdWithMessage, OpMemberDecorateMemberBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
      OpMemberDecorate %1 3 RelaxedPrecision
 %int = OpTypeInt 32 0
@@ -285,12 +349,13 @@ TEST_F(ValidateIdWithMessage, OpMemberDecorateMemberBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Index 3 provided in OpMemberDecorate for struct <id> "
-                        "'1[%_struct_1]' is out of bounds. The structure has 2 "
-                        "members. Largest valid index is 1."));
+              HasSubstr(make_message(
+                  "Index 3 provided in OpMemberDecorate for struct <id> "
+                  "'1[%_struct_1]' is out of bounds. The structure has 2 "
+                  "members. Largest valid index is 1.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpGroupDecorateGood) {
+TEST_P(ValidateIdWithMessage, OpGroupDecorateGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpDecorationGroup
      OpDecorate %1 RelaxedPrecision
@@ -302,7 +367,7 @@ TEST_F(ValidateIdWithMessage, OpGroupDecorateGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpDecorationGroupBad) {
+TEST_P(ValidateIdWithMessage, OpDecorationGroupBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpDecorationGroup
      OpDecorate %1 RelaxedPrecision
@@ -312,11 +377,12 @@ TEST_F(ValidateIdWithMessage, OpDecorationGroupBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Result id of OpDecorationGroup can only "
-                        "be targeted by OpName, OpGroupDecorate, "
-                        "OpDecorate, OpDecorateId, and OpGroupMemberDecorate"));
+              HasSubstr(make_message(
+                  "Result id of OpDecorationGroup can only "
+                  "be targeted by OpName, OpGroupDecorate, "
+                  "OpDecorate, OpDecorateId, and OpGroupMemberDecorate")));
 }
-TEST_F(ValidateIdWithMessage, OpGroupDecorateDecorationGroupBad) {
+TEST_P(ValidateIdWithMessage, OpGroupDecorateDecorationGroupBad) {
   std::string spirv = R"(
     OpCapability Shader
     OpCapability Linkage
@@ -328,10 +394,11 @@ TEST_F(ValidateIdWithMessage, OpGroupDecorateDecorationGroupBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpGroupDecorate Decoration group <id> '1[%1]' is not "
-                        "a decoration group."));
+              HasSubstr(make_message(
+                  "OpGroupDecorate Decoration group <id> '1[%1]' is not "
+                  "a decoration group.")));
 }
-TEST_F(ValidateIdWithMessage, OpGroupDecorateTargetBad) {
+TEST_P(ValidateIdWithMessage, OpGroupDecorateTargetBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpDecorationGroup
      OpDecorate %1 RelaxedPrecision
@@ -340,10 +407,11 @@ TEST_F(ValidateIdWithMessage, OpGroupDecorateTargetBad) {
 %2 = OpTypeInt 32 0)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("forward referenced IDs have not been defined"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("forward referenced IDs have not been defined")));
 }
-TEST_F(ValidateIdWithMessage, OpGroupMemberDecorateDecorationGroupBad) {
+TEST_P(ValidateIdWithMessage, OpGroupMemberDecorateDecorationGroupBad) {
   std::string spirv = R"(
     OpCapability Shader
     OpCapability Linkage
@@ -354,10 +422,11 @@ TEST_F(ValidateIdWithMessage, OpGroupMemberDecorateDecorationGroupBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpGroupMemberDecorate Decoration group <id> '1[%1]' "
-                        "is not a decoration group."));
+              HasSubstr(make_message(
+                  "OpGroupMemberDecorate Decoration group <id> '1[%1]' "
+                  "is not a decoration group.")));
 }
-TEST_F(ValidateIdWithMessage, OpGroupMemberDecorateIdNotStructBad) {
+TEST_P(ValidateIdWithMessage, OpGroupMemberDecorateIdNotStructBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
      %1 = OpDecorationGroup
      OpGroupMemberDecorate %1 %2 0
@@ -365,10 +434,11 @@ TEST_F(ValidateIdWithMessage, OpGroupMemberDecorateIdNotStructBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpGroupMemberDecorate Structure type <id> '2[%uint]' "
-                        "is not a struct type."));
+              HasSubstr(make_message(
+                  "OpGroupMemberDecorate Structure type <id> '2[%uint]' "
+                  "is not a struct type.")));
 }
-TEST_F(ValidateIdWithMessage, OpGroupMemberDecorateIndexOutOfBoundBad) {
+TEST_P(ValidateIdWithMessage, OpGroupMemberDecorateIndexOutOfBoundBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
   OpDecorate %1 Offset 0
   %1 = OpDecorationGroup
@@ -379,14 +449,15 @@ TEST_F(ValidateIdWithMessage, OpGroupMemberDecorateIndexOutOfBoundBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Index 3 provided in OpGroupMemberDecorate for struct "
-                        "<id> '2[%_struct_2]' is out of bounds. The structure "
-                        "has 3 members. Largest valid index is 2."));
+              HasSubstr(make_message(
+                  "Index 3 provided in OpGroupMemberDecorate for struct "
+                  "<id> '2[%_struct_2]' is out of bounds. The structure "
+                  "has 3 members. Largest valid index is 2.")));
 }
 
 // TODO: OpExtInst
 
-TEST_F(ValidateIdWithMessage, OpEntryPointGood) {
+TEST_P(ValidateIdWithMessage, OpEntryPointGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
      OpEntryPoint GLCompute %3 ""
 %1 = OpTypeVoid
@@ -399,17 +470,18 @@ TEST_F(ValidateIdWithMessage, OpEntryPointGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpEntryPointFunctionBad) {
+TEST_P(ValidateIdWithMessage, OpEntryPointFunctionBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
      OpEntryPoint GLCompute %1 ""
 %1 = OpTypeVoid)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpEntryPoint Entry Point <id> '1[%void]' is not a "
-                        "function."));
+              HasSubstr(make_message(
+                  "OpEntryPoint Entry Point <id> '1[%void]' is not a "
+                  "function.")));
 }
-TEST_F(ValidateIdWithMessage, OpEntryPointParameterCountBad) {
+TEST_P(ValidateIdWithMessage, OpEntryPointParameterCountBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
      OpEntryPoint GLCompute %1 ""
 %2 = OpTypeVoid
@@ -420,11 +492,12 @@ TEST_F(ValidateIdWithMessage, OpEntryPointParameterCountBad) {
      OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpEntryPoint Entry Point <id> '1[%1]'s function "
-                        "parameter count is not zero"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("OpEntryPoint Entry Point <id> '1[%1]'s function "
+                             "parameter count is not zero")));
 }
-TEST_F(ValidateIdWithMessage, OpEntryPointReturnTypeBad) {
+TEST_P(ValidateIdWithMessage, OpEntryPointReturnTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
      OpEntryPoint GLCompute %1 ""
 %2 = OpTypeInt 32 0
@@ -436,11 +509,12 @@ TEST_F(ValidateIdWithMessage, OpEntryPointReturnTypeBad) {
      OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpEntryPoint Entry Point <id> '1[%1]'s function "
-                        "return type is not void."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("OpEntryPoint Entry Point <id> '1[%1]'s function "
+                             "return type is not void.")));
 }
-TEST_F(ValidateIdWithMessage, OpEntryPointParameterCountBadInVulkan) {
+TEST_P(ValidateIdWithMessage, OpEntryPointParameterCountBadInVulkan) {
   std::string spirv = R"(
      OpCapability Shader
      OpMemoryModel Logical GLSL450
@@ -455,11 +529,12 @@ TEST_F(ValidateIdWithMessage, OpEntryPointParameterCountBadInVulkan) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_0));
   EXPECT_THAT(getDiagnosticString(),
               AnyVUID("VUID-StandaloneSpirv-None-04633"));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpEntryPoint Entry Point <id> '1[%1]'s function "
-                        "parameter count is not zero"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("OpEntryPoint Entry Point <id> '1[%1]'s function "
+                             "parameter count is not zero")));
 }
-TEST_F(ValidateIdWithMessage, OpEntryPointReturnTypeBadInVulkan) {
+TEST_P(ValidateIdWithMessage, OpEntryPointReturnTypeBadInVulkan) {
   std::string spirv = R"(
      OpCapability Shader
      OpMemoryModel Logical GLSL450
@@ -475,12 +550,13 @@ TEST_F(ValidateIdWithMessage, OpEntryPointReturnTypeBadInVulkan) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_0));
   EXPECT_THAT(getDiagnosticString(),
               AnyVUID("VUID-StandaloneSpirv-None-04633"));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpEntryPoint Entry Point <id> '1[%1]'s function "
-                        "return type is not void."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("OpEntryPoint Entry Point <id> '1[%1]'s function "
+                             "return type is not void.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpEntryPointInterfaceIsNotVariableTypeBad) {
+TEST_P(ValidateIdWithMessage, OpEntryPointInterfaceIsNotVariableTypeBad) {
   std::string spirv = R"(
                OpCapability Shader
                OpCapability Geometry
@@ -502,11 +578,12 @@ TEST_F(ValidateIdWithMessage, OpEntryPointInterfaceIsNotVariableTypeBad) {
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Interfaces passed to OpEntryPoint must be of type "
-                        "OpTypeVariable. Found OpTypePointer."));
+              HasSubstr(make_message(
+                  "Interfaces passed to OpEntryPoint must be of type "
+                  "OpTypeVariable. Found OpTypePointer.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpEntryPointInterfaceStorageClassBad) {
+TEST_P(ValidateIdWithMessage, OpEntryPointInterfaceStorageClassBad) {
   std::string spirv = R"(
                OpCapability Shader
                OpCapability Geometry
@@ -529,12 +606,13 @@ TEST_F(ValidateIdWithMessage, OpEntryPointInterfaceStorageClassBad) {
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpEntryPoint interfaces must be OpVariables with "
-                        "Storage Class of Input(1) or Output(3). Found Storage "
-                        "Class 2 for Entry Point id 1."));
+              HasSubstr(make_message(
+                  "OpEntryPoint interfaces must be OpVariables with "
+                  "Storage Class of Input(1) or Output(3). Found Storage "
+                  "Class 2 for Entry Point id 1.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpExecutionModeGood) {
+TEST_P(ValidateIdWithMessage, OpExecutionModeGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
      OpEntryPoint GLCompute %3 ""
      OpExecutionMode %3 LocalSize 1 1 1
@@ -548,7 +626,7 @@ TEST_F(ValidateIdWithMessage, OpExecutionModeGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpExecutionModeEntryPointMissing) {
+TEST_P(ValidateIdWithMessage, OpExecutionModeEntryPointMissing) {
   std::string spirv = kGLSL450MemoryModel + R"(
      OpExecutionMode %3 LocalSize 1 1 1
 %1 = OpTypeVoid
@@ -560,11 +638,12 @@ TEST_F(ValidateIdWithMessage, OpExecutionModeEntryPointMissing) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpExecutionMode Entry Point <id> '1[%1]' is not the "
-                        "Entry Point operand of an OpEntryPoint."));
+              HasSubstr(make_message(
+                  "OpExecutionMode Entry Point <id> '1[%1]' is not the "
+                  "Entry Point operand of an OpEntryPoint.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpExecutionModeEntryPointBad) {
+TEST_P(ValidateIdWithMessage, OpExecutionModeEntryPointBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
      OpEntryPoint GLCompute %3 "" %a
      OpExecutionMode %a LocalSize 1 1 1
@@ -579,11 +658,12 @@ TEST_F(ValidateIdWithMessage, OpExecutionModeEntryPointBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpExecutionMode Entry Point <id> '2[%2]' is not the "
-                        "Entry Point operand of an OpEntryPoint."));
+              HasSubstr(make_message(
+                  "OpExecutionMode Entry Point <id> '2[%2]' is not the "
+                  "Entry Point operand of an OpEntryPoint.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeVectorFloat) {
+TEST_P(ValidateIdWithMessage, OpTypeVectorFloat) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
 %2 = OpTypeVector %1 4)";
@@ -591,7 +671,7 @@ TEST_F(ValidateIdWithMessage, OpTypeVectorFloat) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeVectorInt) {
+TEST_P(ValidateIdWithMessage, OpTypeVectorInt) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpTypeVector %1 4)";
@@ -599,7 +679,7 @@ TEST_F(ValidateIdWithMessage, OpTypeVectorInt) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeVectorUInt) {
+TEST_P(ValidateIdWithMessage, OpTypeVectorUInt) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 64 0
 %2 = OpTypeVector %1 4)";
@@ -607,7 +687,7 @@ TEST_F(ValidateIdWithMessage, OpTypeVectorUInt) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeVectorBool) {
+TEST_P(ValidateIdWithMessage, OpTypeVectorBool) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeBool
 %2 = OpTypeVector %1 4)";
@@ -615,20 +695,20 @@ TEST_F(ValidateIdWithMessage, OpTypeVectorBool) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeVectorComponentTypeBad) {
+TEST_P(ValidateIdWithMessage, OpTypeVectorComponentTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
 %2 = OpTypePointer UniformConstant %1
 %3 = OpTypeVector %2 4)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpTypeVector Component Type <id> "
-                "'2[%_ptr_UniformConstant_float]' is not a scalar type."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "OpTypeVector Component Type <id> "
+                  "'2[%_ptr_UniformConstant_float]' is not a scalar type.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeVectorColumnCountLessThanTwoBad) {
+TEST_P(ValidateIdWithMessage, OpTypeVectorColumnCountLessThanTwoBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
 %2 = OpTypeVector %1 1)";
@@ -636,11 +716,12 @@ TEST_F(ValidateIdWithMessage, OpTypeVectorColumnCountLessThanTwoBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Illegal number of components (1) for TypeVector\n  %v1float = "
-                "OpTypeVector %float 1\n"));
+      HasSubstr(make_message(
+          "Illegal number of components (1) for TypeVector\n  %v1float = "
+          "OpTypeVector %float 1\n")));
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeVectorColumnCountGreaterThanFourBad) {
+TEST_P(ValidateIdWithMessage, OpTypeVectorColumnCountGreaterThanFourBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
 %2 = OpTypeVector %1 5)";
@@ -648,24 +729,25 @@ TEST_F(ValidateIdWithMessage, OpTypeVectorColumnCountGreaterThanFourBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Illegal number of components (5) for TypeVector\n  %v5float = "
-                "OpTypeVector %float 5\n"));
+      HasSubstr(make_message(
+          "Illegal number of components (5) for TypeVector\n  %v5float = "
+          "OpTypeVector %float 5\n")));
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeVectorColumnCountEightWithoutVector16Bad) {
+TEST_P(ValidateIdWithMessage, OpTypeVectorColumnCountEightWithoutVector16Bad) {
   std::string spirv = kGLSL450MemoryModelWithoutVector16 + R"(
 %1 = OpTypeFloat 32
 %2 = OpTypeVector %1 8)";
 
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Having 8 components for TypeVector requires the Vector16 "
-                "capability\n  %v8float = OpTypeVector %float 8\n"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "Having 8 components for TypeVector requires the Vector16 "
+                  "capability\n  %v8float = OpTypeVector %float 8\n")));
 }
 
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        OpTypeVectorColumnCountSixteenWithoutVector16Bad) {
   std::string spirv = kGLSL450MemoryModelWithoutVector16 + R"(
 %1 = OpTypeFloat 32
@@ -673,13 +755,13 @@ TEST_F(ValidateIdWithMessage,
 
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Having 16 components for TypeVector requires the Vector16 "
-                "capability\n  %v16float = OpTypeVector %float 16\n"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "Having 16 components for TypeVector requires the Vector16 "
+                  "capability\n  %v16float = OpTypeVector %float 16\n")));
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeVectorColumnCountOfEightWithVector16Good) {
+TEST_P(ValidateIdWithMessage, OpTypeVectorColumnCountOfEightWithVector16Good) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
 %2 = OpTypeVector %1 8)";
@@ -687,7 +769,7 @@ TEST_F(ValidateIdWithMessage, OpTypeVectorColumnCountOfEightWithVector16Good) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        OpTypeVectorColumnCountOfSixteenWithVector16Good) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
@@ -696,7 +778,7 @@ TEST_F(ValidateIdWithMessage,
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeMatrixGood) {
+TEST_P(ValidateIdWithMessage, OpTypeMatrixGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
 %2 = OpTypeVector %1 2
@@ -705,32 +787,32 @@ TEST_F(ValidateIdWithMessage, OpTypeMatrixGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeMatrixColumnTypeNonVectorBad) {
+TEST_P(ValidateIdWithMessage, OpTypeMatrixColumnTypeNonVectorBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
 %2 = OpTypeMatrix %1 3)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("olumns in a matrix must be of type vector.\n  %mat3float = "
-                "OpTypeMatrix %float 3\n"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "olumns in a matrix must be of type vector.\n  %mat3float = "
+                  "OpTypeMatrix %float 3\n")));
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeMatrixVectorTypeNonFloatBad) {
+TEST_P(ValidateIdWithMessage, OpTypeMatrixVectorTypeNonFloatBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 16 0
 %2 = OpTypeVector %1 2
 %3 = OpTypeMatrix %2 2)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Matrix types can only be parameterized with floating-point "
-                "types.\n  %mat2v2ushort = OpTypeMatrix %v2ushort 2\n"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "Matrix types can only be parameterized with floating-point "
+                  "types.\n  %mat2v2ushort = OpTypeMatrix %v2ushort 2\n")));
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeMatrixColumnCountLessThanTwoBad) {
+TEST_P(ValidateIdWithMessage, OpTypeMatrixColumnCountLessThanTwoBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
 %2 = OpTypeVector %1 2
@@ -739,11 +821,12 @@ TEST_F(ValidateIdWithMessage, OpTypeMatrixColumnCountLessThanTwoBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Matrix types can only be parameterized as having only 2, 3, "
-                "or 4 columns.\n  %mat1v2float = OpTypeMatrix %v2float 1\n"));
+      HasSubstr(make_message(
+          "Matrix types can only be parameterized as having only 2, 3, "
+          "or 4 columns.\n  %mat1v2float = OpTypeMatrix %v2float 1\n")));
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeMatrixColumnCountGreaterThanFourBad) {
+TEST_P(ValidateIdWithMessage, OpTypeMatrixColumnCountGreaterThanFourBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
 %2 = OpTypeVector %1 2
@@ -752,11 +835,12 @@ TEST_F(ValidateIdWithMessage, OpTypeMatrixColumnCountGreaterThanFourBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Matrix types can only be parameterized as having only 2, 3, "
-                "or 4 columns.\n  %mat8v2float = OpTypeMatrix %v2float 8\n"));
+      HasSubstr(make_message(
+          "Matrix types can only be parameterized as having only 2, 3, "
+          "or 4 columns.\n  %mat8v2float = OpTypeMatrix %v2float 8\n")));
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeSamplerGood) {
+TEST_P(ValidateIdWithMessage, OpTypeSamplerGood) {
   // In Rev31, OpTypeSampler takes no arguments.
   std::string spirv = kGLSL450MemoryModel + R"(
 %s = OpTypeSampler)";
@@ -764,7 +848,7 @@ TEST_F(ValidateIdWithMessage, OpTypeSamplerGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeArrayGood) {
+TEST_P(ValidateIdWithMessage, OpTypeArrayGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpConstant %1 1
@@ -773,7 +857,7 @@ TEST_F(ValidateIdWithMessage, OpTypeArrayGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeArrayElementTypeBad) {
+TEST_P(ValidateIdWithMessage, OpTypeArrayElementTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpConstant %1 1
@@ -781,8 +865,9 @@ TEST_F(ValidateIdWithMessage, OpTypeArrayElementTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpTypeArray Element Type <id> '2[%uint_1]' is not a "
-                        "type."));
+              HasSubstr(make_message(
+                  "OpTypeArray Element Type <id> '2[%uint_1]' is not a "
+                  "type.")));
 }
 
 // Signed or unsigned.
@@ -962,20 +1047,19 @@ TEST_P(OpTypeArrayLengthTest, LengthPositiveHugeEnding1InVulkan) {
 INSTANTIATE_TEST_SUITE_P(Widths, OpTypeArrayLengthTest,
                          ValuesIn(std::vector<int>{16, 32, 64}));
 
-TEST_F(ValidateIdWithMessage, OpTypeArrayLengthNull) {
+TEST_P(ValidateIdWithMessage, OpTypeArrayLengthNull) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %i32 = OpTypeInt 32 0
 %len = OpConstantNull %i32
 %ary = OpTypeArray %i32 %len)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr(
-          "OpTypeArray Length <id> '2[%2]' default value must be at least 1."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message("OpTypeArray Length <id> '2[%2]' default "
+                                     "value must be at least 1.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeArrayLengthSpecConst) {
+TEST_P(ValidateIdWithMessage, OpTypeArrayLengthSpecConst) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %i32 = OpTypeInt 32 0
 %len = OpSpecConstant %i32 2
@@ -984,7 +1068,7 @@ TEST_F(ValidateIdWithMessage, OpTypeArrayLengthSpecConst) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeArrayLengthSpecConstOp) {
+TEST_P(ValidateIdWithMessage, OpTypeArrayLengthSpecConstOp) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %i32 = OpTypeInt 32 0
 %c1 = OpConstant %i32 1
@@ -995,29 +1079,29 @@ TEST_F(ValidateIdWithMessage, OpTypeArrayLengthSpecConstOp) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeRuntimeArrayGood) {
+TEST_P(ValidateIdWithMessage, OpTypeRuntimeArrayGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpTypeRuntimeArray %1)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpTypeRuntimeArrayBad) {
+TEST_P(ValidateIdWithMessage, OpTypeRuntimeArrayBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpConstant %1 0
 %3 = OpTypeRuntimeArray %2)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpTypeRuntimeArray Element Type <id> '2[%uint_0]' is not a "
-                "type."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "OpTypeRuntimeArray Element Type <id> '2[%uint_0]' is not a "
+                  "type.")));
 }
 // TODO: Object of this type can only be created with OpVariable using the
 // Uniform Storage Class
 
-TEST_F(ValidateIdWithMessage, OpTypeStructGood) {
+TEST_P(ValidateIdWithMessage, OpTypeStructGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpTypeFloat 64
@@ -1026,7 +1110,7 @@ TEST_F(ValidateIdWithMessage, OpTypeStructGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpTypeStructMemberTypeBad) {
+TEST_P(ValidateIdWithMessage, OpTypeStructMemberTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpTypeFloat 64
@@ -1035,11 +1119,12 @@ TEST_F(ValidateIdWithMessage, OpTypeStructMemberTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpTypeStruct Member Type <id> '3[%double_0]' is not "
-                        "a type."));
+              HasSubstr(make_message(
+                  "OpTypeStruct Member Type <id> '3[%double_0]' is not "
+                  "a type.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeStructOpaqueTypeBad) {
+TEST_P(ValidateIdWithMessage, OpTypeStructOpaqueTypeBad) {
   std::string spirv = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
@@ -1057,37 +1142,39 @@ TEST_F(ValidateIdWithMessage, OpTypeStructOpaqueTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_0));
   EXPECT_THAT(getDiagnosticString(),
               AnyVUID("VUID-StandaloneSpirv-None-04667"));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpTypeStruct must not contain an opaque type"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("OpTypeStruct must not contain an opaque type")));
 }
 
-TEST_F(ValidateIdWithMessage, OpTypePointerGood) {
+TEST_P(ValidateIdWithMessage, OpTypePointerGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpTypePointer Input %1)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpTypePointerBad) {
+TEST_P(ValidateIdWithMessage, OpTypePointerBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpConstant %1 0
 %3 = OpTypePointer Input %2)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpTypePointer Type <id> '2[%uint_0]' is not a "
-                        "type."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("OpTypePointer Type <id> '2[%uint_0]' is not a "
+                             "type.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeFunctionGood) {
+TEST_P(ValidateIdWithMessage, OpTypeFunctionGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpTypeFunctionReturnTypeBad) {
+TEST_P(ValidateIdWithMessage, OpTypeFunctionReturnTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpConstant %1 0
@@ -1095,10 +1182,11 @@ TEST_F(ValidateIdWithMessage, OpTypeFunctionReturnTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpTypeFunction Return Type <id> '2[%uint_0]' is not "
-                        "a type."));
+              HasSubstr(make_message(
+                  "OpTypeFunction Return Type <id> '2[%uint_0]' is not "
+                  "a type.")));
 }
-TEST_F(ValidateIdWithMessage, OpTypeFunctionParameterBad) {
+TEST_P(ValidateIdWithMessage, OpTypeFunctionParameterBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -1106,13 +1194,13 @@ TEST_F(ValidateIdWithMessage, OpTypeFunctionParameterBad) {
 %4 = OpTypeFunction %1 %2 %3)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpTypeFunction Parameter Type <id> '3[%uint_0]' is not a "
-                "type."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "OpTypeFunction Parameter Type <id> '3[%uint_0]' is not a "
+                  "type.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeFunctionParameterTypeVoidBad) {
+TEST_P(ValidateIdWithMessage, OpTypeFunctionParameterTypeVoidBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -1120,11 +1208,12 @@ TEST_F(ValidateIdWithMessage, OpTypeFunctionParameterTypeVoidBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpTypeFunction Parameter Type <id> '1[%void]' cannot "
-                        "be OpTypeVoid."));
+              HasSubstr(make_message(
+                  "OpTypeFunction Parameter Type <id> '1[%void]' cannot "
+                  "be OpTypeVoid.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpTypePipeGood) {
+TEST_P(ValidateIdWithMessage, OpTypePipeGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
 %2 = OpTypeVector %1 16
@@ -1133,33 +1222,33 @@ TEST_F(ValidateIdWithMessage, OpTypePipeGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpConstantTrueGood) {
+TEST_P(ValidateIdWithMessage, OpConstantTrueGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeBool
 %2 = OpConstantTrue %1)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpConstantTrueBad) {
+TEST_P(ValidateIdWithMessage, OpConstantTrueBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpConstantTrue %1)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpConstantTrue Result Type <id> '1[%void]' is not a boolean "
-                "type."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "OpConstantTrue Result Type <id> '1[%void]' is not a boolean "
+                  "type.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpConstantFalseGood) {
+TEST_P(ValidateIdWithMessage, OpConstantFalseGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeBool
 %2 = OpConstantTrue %1)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpConstantFalseBad) {
+TEST_P(ValidateIdWithMessage, OpConstantFalseBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpConstantFalse %1)";
@@ -1167,18 +1256,19 @@ TEST_F(ValidateIdWithMessage, OpConstantFalseBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpConstantFalse Result Type <id> '1[%void]' is not a boolean "
-                "type."));
+      HasSubstr(make_message(
+          "OpConstantFalse Result Type <id> '1[%void]' is not a boolean "
+          "type.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpConstantGood) {
+TEST_P(ValidateIdWithMessage, OpConstantGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpConstant %1 1)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpConstantBad) {
+TEST_P(ValidateIdWithMessage, OpConstantBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpConstant !1 !0)";
@@ -1189,7 +1279,7 @@ TEST_F(ValidateIdWithMessage, OpConstantBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_BINARY, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpConstantCompositeVectorGood) {
+TEST_P(ValidateIdWithMessage, OpConstantCompositeVectorGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
 %2 = OpTypeVector %1 4
@@ -1198,7 +1288,7 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeVectorGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpConstantCompositeVectorWithUndefGood) {
+TEST_P(ValidateIdWithMessage, OpConstantCompositeVectorWithUndefGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
 %2 = OpTypeVector %1 4
@@ -1208,7 +1298,7 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeVectorWithUndefGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpConstantCompositeVectorResultTypeBad) {
+TEST_P(ValidateIdWithMessage, OpConstantCompositeVectorResultTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
 %2 = OpTypeVector %1 4
@@ -1216,12 +1306,12 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeVectorResultTypeBad) {
 %4 = OpConstantComposite %1 %3 %3 %3 %3)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpConstantComposite Result Type <id> '1[%float]' is not a "
-                "composite type."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "OpConstantComposite Result Type <id> '1[%float]' is not a "
+                  "composite type.")));
 }
-TEST_F(ValidateIdWithMessage, OpConstantCompositeVectorConstituentTypeBad) {
+TEST_P(ValidateIdWithMessage, OpConstantCompositeVectorConstituentTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
 %2 = OpTypeVector %1 4
@@ -1231,13 +1321,13 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeVectorConstituentTypeBad) {
 %6 = OpConstantComposite %2 %3 %5 %3 %3)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpConstantComposite Constituent <id> '5[%uint_42]'s type "
-                "does not match Result Type <id> '2[%v4float]'s vector "
-                "element type."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "OpConstantComposite Constituent <id> '5[%uint_42]'s type "
+                  "does not match Result Type <id> '2[%v4float]'s vector "
+                  "element type.")));
 }
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        OpConstantCompositeVectorConstituentUndefTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
@@ -1250,10 +1340,11 @@ TEST_F(ValidateIdWithMessage,
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpConstantComposite Constituent <id> '5[%5]'s type does not "
-                "match Result Type <id> '2[%v4float]'s vector element type."));
+      HasSubstr(make_message(
+          "OpConstantComposite Constituent <id> '5[%5]'s type does not "
+          "match Result Type <id> '2[%v4float]'s vector element type.")));
 }
-TEST_F(ValidateIdWithMessage, OpConstantCompositeMatrixGood) {
+TEST_P(ValidateIdWithMessage, OpConstantCompositeMatrixGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
  %1 = OpTypeFloat 32
  %2 = OpTypeVector %1 4
@@ -1268,7 +1359,7 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeMatrixGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpConstantCompositeMatrixUndefGood) {
+TEST_P(ValidateIdWithMessage, OpConstantCompositeMatrixUndefGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
  %1 = OpTypeFloat 32
  %2 = OpTypeVector %1 4
@@ -1283,7 +1374,7 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeMatrixUndefGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpConstantCompositeMatrixConstituentTypeBad) {
+TEST_P(ValidateIdWithMessage, OpConstantCompositeMatrixConstituentTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
  %1 = OpTypeFloat 32
  %2 = OpTypeVector %1 4
@@ -1299,11 +1390,12 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeMatrixConstituentTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpConstantComposite Constituent <id> '10[%10]' vector "
-                        "component count does not match Result Type <id> "
-                        "'4[%mat4v4float]'s vector component count."));
+              HasSubstr(make_message(
+                  "OpConstantComposite Constituent <id> '10[%10]' vector "
+                  "component count does not match Result Type <id> "
+                  "'4[%mat4v4float]'s vector component count.")));
 }
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        OpConstantCompositeMatrixConstituentUndefTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
  %1 = OpTypeFloat 32
@@ -1320,11 +1412,12 @@ TEST_F(ValidateIdWithMessage,
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpConstantComposite Constituent <id> '10[%10]' vector "
-                        "component count does not match Result Type <id> "
-                        "'4[%mat4v4float]'s vector component count."));
+              HasSubstr(make_message(
+                  "OpConstantComposite Constituent <id> '10[%10]' vector "
+                  "component count does not match Result Type <id> "
+                  "'4[%mat4v4float]'s vector component count.")));
 }
-TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayGood) {
+TEST_P(ValidateIdWithMessage, OpConstantCompositeArrayGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpConstant %1 4
@@ -1333,7 +1426,7 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayWithUndefGood) {
+TEST_P(ValidateIdWithMessage, OpConstantCompositeArrayWithUndefGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpConstant %1 4
@@ -1344,7 +1437,7 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayWithUndefGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstConstituentTypeBad) {
+TEST_P(ValidateIdWithMessage, OpConstantCompositeArrayConstConstituentTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpConstant %1 4
@@ -1352,10 +1445,11 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstConstituentTypeBad) {
 %4 = OpConstantComposite %3 %2 %2 %2 %1)";  // Uses a type as operand
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand '1[%uint]' cannot be a "
-                                               "type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message("Operand '1[%uint]' cannot be a "
+                                     "type")));
 }
-TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstConstituentBad) {
+TEST_P(ValidateIdWithMessage, OpConstantCompositeArrayConstConstituentBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpConstant %1 4
@@ -1366,10 +1460,11 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstConstituentBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpConstantComposite Constituent <id> '5[%5]' is not a "
-                        "constant or undef."));
+              HasSubstr(make_message(
+                  "OpConstantComposite Constituent <id> '5[%5]' is not a "
+                  "constant or undef.")));
 }
-TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstituentTypeBad) {
+TEST_P(ValidateIdWithMessage, OpConstantCompositeArrayConstituentTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpConstant %1 4
@@ -1380,12 +1475,13 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstituentTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpConstantComposite Constituent <id> "
-                        "'5[%float_3_1400001]'s type does not match Result "
-                        "Type <id> '3[%_arr_uint_uint_4]'s array element "
-                        "type."));
+              HasSubstr(make_message(
+                  "OpConstantComposite Constituent <id> "
+                  "'5[%float_3_1400001]'s type does not match Result "
+                  "Type <id> '3[%_arr_uint_uint_4]'s array element "
+                  "type.")));
 }
-TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstituentUndefTypeBad) {
+TEST_P(ValidateIdWithMessage, OpConstantCompositeArrayConstituentUndefTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpConstant %1 4
@@ -1395,13 +1491,14 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeArrayConstituentUndefTypeBad) {
 %4 = OpConstantComposite %3 %2 %2 %2 %6)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpConstantComposite Constituent <id> "
-                        "'5[%5]'s type does not match Result "
-                        "Type <id> '3[%_arr_uint_uint_4]'s array element "
-                        "type."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("OpConstantComposite Constituent <id> "
+                             "'5[%5]'s type does not match Result "
+                             "Type <id> '3[%_arr_uint_uint_4]'s array element "
+                             "type.")));
 }
-TEST_F(ValidateIdWithMessage, OpConstantCompositeStructGood) {
+TEST_P(ValidateIdWithMessage, OpConstantCompositeStructGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpTypeInt 64 0
@@ -1412,7 +1509,7 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeStructGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpConstantCompositeStructUndefGood) {
+TEST_P(ValidateIdWithMessage, OpConstantCompositeStructUndefGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpTypeInt 64 0
@@ -1423,7 +1520,7 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeStructUndefGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpConstantCompositeStructMemberTypeBad) {
+TEST_P(ValidateIdWithMessage, OpConstantCompositeStructMemberTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpTypeInt 64 0
@@ -1434,12 +1531,13 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeStructMemberTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpConstantComposite Constituent <id> "
-                        "'5[%ulong_4300000000]' type does not match the "
-                        "Result Type <id> '3[%_struct_3]'s member type."));
+              HasSubstr(make_message(
+                  "OpConstantComposite Constituent <id> "
+                  "'5[%ulong_4300000000]' type does not match the "
+                  "Result Type <id> '3[%_struct_3]'s member type.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpConstantCompositeStructMemberUndefTypeBad) {
+TEST_P(ValidateIdWithMessage, OpConstantCompositeStructMemberUndefTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpTypeInt 64 0
@@ -1450,12 +1548,13 @@ TEST_F(ValidateIdWithMessage, OpConstantCompositeStructMemberUndefTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpConstantComposite Constituent <id> '5[%5]' type "
-                        "does not match the Result Type <id> '3[%_struct_3]'s "
-                        "member type."));
+              HasSubstr(make_message(
+                  "OpConstantComposite Constituent <id> '5[%5]' type "
+                  "does not match the Result Type <id> '3[%_struct_3]'s "
+                  "member type.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpConstantSamplerGood) {
+TEST_P(ValidateIdWithMessage, OpConstantSamplerGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %float = OpTypeFloat 32
 %samplerType = OpTypeSampler
@@ -1463,7 +1562,7 @@ TEST_F(ValidateIdWithMessage, OpConstantSamplerGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpConstantSamplerResultTypeBad) {
+TEST_P(ValidateIdWithMessage, OpConstantSamplerResultTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
 %2 = OpConstantSampler %1 Clamp 0 Nearest)";
@@ -1471,12 +1570,12 @@ TEST_F(ValidateIdWithMessage, OpConstantSamplerResultTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr(
+      HasSubstr(make_message(
           "OpConstantSampler Result Type <id> '1[%float]' is not a sampler "
-          "type."));
+          "type.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpConstantNullGood) {
+TEST_P(ValidateIdWithMessage, OpConstantNullGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
  %1 = OpTypeBool
  %2 = OpConstantNull %1
@@ -1512,7 +1611,7 @@ TEST_F(ValidateIdWithMessage, OpConstantNullGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpConstantNullBasicBad) {
+TEST_P(ValidateIdWithMessage, OpConstantNullBasicBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpConstantNull %1)";
@@ -1520,11 +1619,12 @@ TEST_F(ValidateIdWithMessage, OpConstantNullBasicBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpConstantNull Result Type <id> '1[%void]' cannot have a null "
-                "value."));
+      HasSubstr(make_message(
+          "OpConstantNull Result Type <id> '1[%void]' cannot have a null "
+          "value.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpConstantNullArrayBad) {
+TEST_P(ValidateIdWithMessage, OpConstantNullArrayBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %2 = OpTypeInt 32 0
 %3 = OpTypeSampler
@@ -1535,24 +1635,25 @@ TEST_F(ValidateIdWithMessage, OpConstantNullArrayBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr(
+      HasSubstr(make_message(
           "OpConstantNull Result Type <id> '4[%_arr_2_uint_4]' cannot have a "
-          "null value."));
+          "null value.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpConstantNullStructBad) {
+TEST_P(ValidateIdWithMessage, OpConstantNullStructBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %2 = OpTypeSampler
 %3 = OpTypeStruct %2 %2
 %4 = OpConstantNull %3)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpConstantNull Result Type <id> '2[%_struct_2]' "
-                        "cannot have a null value."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("OpConstantNull Result Type <id> '2[%_struct_2]' "
+                             "cannot have a null value.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpConstantNullRuntimeArrayBad) {
+TEST_P(ValidateIdWithMessage, OpConstantNullRuntimeArrayBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %bool = OpTypeBool
 %array = OpTypeRuntimeArray %bool
@@ -1561,56 +1662,57 @@ TEST_F(ValidateIdWithMessage, OpConstantNullRuntimeArrayBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr(
+      HasSubstr(make_message(
           "OpConstantNull Result Type <id> '2[%_runtimearr_bool]' cannot have "
-          "a null value."));
+          "a null value.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpSpecConstantTrueGood) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantTrueGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeBool
 %2 = OpSpecConstantTrue %1)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpSpecConstantTrueBad) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantTrueBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpSpecConstantTrue %1)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantTrue Result Type <id> '1[%void]' is not "
-                        "a boolean type"));
+              HasSubstr(make_message(
+                  "OpSpecConstantTrue Result Type <id> '1[%void]' is not "
+                  "a boolean type")));
 }
 
-TEST_F(ValidateIdWithMessage, OpSpecConstantFalseGood) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantFalseGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeBool
 %2 = OpSpecConstantFalse %1)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpSpecConstantFalseBad) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantFalseBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpSpecConstantFalse %1)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpSpecConstantFalse Result Type <id> '1[%void]' is not "
-                "a boolean type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "OpSpecConstantFalse Result Type <id> '1[%void]' is not "
+                  "a boolean type")));
 }
 
-TEST_F(ValidateIdWithMessage, OpSpecConstantGood) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
 %2 = OpSpecConstant %1 42)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpSpecConstantBad) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpSpecConstant !1 !4)";
@@ -1619,12 +1721,13 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantBad) {
   // change over time, but this must always fail.
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_BINARY, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Type Id 1 is not a scalar numeric type"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("Type Id 1 is not a scalar numeric type")));
 }
 
 // Valid: SpecConstantComposite specializes to a vector.
-TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeVectorGood) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantCompositeVectorGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
 %2 = OpTypeVector %1 4
@@ -1636,7 +1739,7 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeVectorGood) {
 }
 
 // Valid: Vector of floats and Undefs.
-TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeVectorWithUndefGood) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantCompositeVectorWithUndefGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
 %2 = OpTypeVector %1 4
@@ -1649,7 +1752,7 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeVectorWithUndefGood) {
 }
 
 // Invalid: result type is float.
-TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeVectorResultTypeBad) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantCompositeVectorResultTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
 %2 = OpTypeVector %1 4
@@ -1657,11 +1760,12 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeVectorResultTypeBad) {
 %4 = OpSpecConstantComposite %1 %3 %3 %3 %3)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("is not a composite type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message("is not a composite type")));
 }
 
 // Invalid: Vector contains a mix of Int and Float.
-TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeVectorConstituentTypeBad) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantCompositeVectorConstituentTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
 %2 = OpTypeVector %1 4
@@ -1672,13 +1776,14 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeVectorConstituentTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> "
-                        "'5[%uint_42]'s type does not match Result Type <id> "
-                        "'2[%v4float]'s vector element type."));
+              HasSubstr(make_message(
+                  "OpSpecConstantComposite Constituent <id> "
+                  "'5[%uint_42]'s type does not match Result Type <id> "
+                  "'2[%v4float]'s vector element type.")));
 }
 
 // Invalid: Constituent is not a constant
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        OpSpecConstantCompositeVectorConstituentNotConstantBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
@@ -1691,12 +1796,13 @@ TEST_F(ValidateIdWithMessage,
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '6[%6]' is "
-                        "not a constant or undef."));
+              HasSubstr(make_message(
+                  "OpSpecConstantComposite Constituent <id> '6[%6]' is "
+                  "not a constant or undef.")));
 }
 
 // Invalid: Vector contains a mix of Undef-int and Float.
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        OpSpecConstantCompositeVectorConstituentUndefTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
@@ -1708,13 +1814,14 @@ TEST_F(ValidateIdWithMessage,
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '5[%5]'s "
-                        "type does not match Result Type <id> '2[%v4float]'s "
-                        "vector element type."));
+              HasSubstr(make_message(
+                  "OpSpecConstantComposite Constituent <id> '5[%5]'s "
+                  "type does not match Result Type <id> '2[%v4float]'s "
+                  "vector element type.")));
 }
 
 // Invalid: Vector expects 3 components, but 4 specified.
-TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeVectorNumComponentsBad) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantCompositeVectorNumComponentsBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
 %2 = OpTypeVector %1 3
@@ -1724,13 +1831,14 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeVectorNumComponentsBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> count does "
-                        "not match Result Type <id> '2[%v3float]'s vector "
-                        "component count."));
+              HasSubstr(make_message(
+                  "OpSpecConstantComposite Constituent <id> count does "
+                  "not match Result Type <id> '2[%v3float]'s vector "
+                  "component count.")));
 }
 
 // Valid: 4x4 matrix of floats
-TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeMatrixGood) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantCompositeMatrixGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
  %1 = OpTypeFloat 32
  %2 = OpTypeVector %1 4
@@ -1747,7 +1855,7 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeMatrixGood) {
 }
 
 // Valid: Matrix in which one column is Undef
-TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeMatrixUndefGood) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantCompositeMatrixUndefGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
  %1 = OpTypeFloat 32
  %2 = OpTypeVector %1 4
@@ -1764,7 +1872,7 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeMatrixUndefGood) {
 }
 
 // Invalid: Matrix in which the sizes of column vectors are not equal.
-TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeMatrixConstituentTypeBad) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantCompositeMatrixConstituentTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
  %1 = OpTypeFloat 32
  %2 = OpTypeVector %1 4
@@ -1780,13 +1888,14 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeMatrixConstituentTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '10[%10]' "
-                        "vector component count does not match Result Type "
-                        "<id> '4[%mat4v4float]'s vector component count."));
+              HasSubstr(make_message(
+                  "OpSpecConstantComposite Constituent <id> '10[%10]' "
+                  "vector component count does not match Result Type "
+                  "<id> '4[%mat4v4float]'s vector component count.")));
 }
 
 // Invalid: Matrix type expects 4 columns but only 3 specified.
-TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeMatrixNumColsBad) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantCompositeMatrixNumColsBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
  %1 = OpTypeFloat 32
  %2 = OpTypeVector %1 4
@@ -1799,15 +1908,15 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeMatrixNumColsBad) {
 %10 = OpSpecConstantComposite %3 %6 %7 %8)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpSpecConstantComposite Constituent <id> count does "
-                "not match Result Type <id> '3[%mat4v4float]'s matrix column "
-                "count."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "OpSpecConstantComposite Constituent <id> count does "
+                  "not match Result Type <id> '3[%mat4v4float]'s matrix column "
+                  "count.")));
 }
 
 // Invalid: Composite contains a non-const/undef component
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        OpSpecConstantCompositeMatrixConstituentNotConstBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
  %1 = OpTypeFloat 32
@@ -1821,12 +1930,13 @@ TEST_F(ValidateIdWithMessage,
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '7[%7]' is "
-                        "not a constant or undef."));
+              HasSubstr(make_message(
+                  "OpSpecConstantComposite Constituent <id> '7[%7]' is "
+                  "not a constant or undef.")));
 }
 
 // Invalid: Composite contains a column that is *not* a vector (it's an array)
-TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeMatrixColTypeBad) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantCompositeMatrixColTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
  %1 = OpTypeFloat 32
  %2 = OpTypeInt 32 0
@@ -1841,13 +1951,14 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeMatrixColTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '8[%8]' type "
-                        "does not match Result Type <id> '7[%mat4v4float]'s "
-                        "matrix column type."));
+              HasSubstr(make_message(
+                  "OpSpecConstantComposite Constituent <id> '8[%8]' type "
+                  "does not match Result Type <id> '7[%mat4v4float]'s "
+                  "matrix column type.")));
 }
 
 // Invalid: Matrix with an Undef column of the wrong size.
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        OpSpecConstantCompositeMatrixConstituentUndefTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
  %1 = OpTypeFloat 32
@@ -1864,13 +1975,14 @@ TEST_F(ValidateIdWithMessage,
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '10[%10]' "
-                        "vector component count does not match Result Type "
-                        "<id> '4[%mat4v4float]'s vector component count."));
+              HasSubstr(make_message(
+                  "OpSpecConstantComposite Constituent <id> '10[%10]' "
+                  "vector component count does not match Result Type "
+                  "<id> '4[%mat4v4float]'s vector component count.")));
 }
 
 // Invalid: Matrix in which some columns are Int and some are Float.
-TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeMatrixColumnTypeBad) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantCompositeMatrixColumnTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
  %1 = OpTypeInt 32 0
  %2 = OpTypeFloat 32
@@ -1885,13 +1997,14 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeMatrixColumnTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '8[%8]' "
-                        "component type does not match Result Type <id> "
-                        "'5[%mat2v2float]'s matrix column component type."));
+              HasSubstr(make_message(
+                  "OpSpecConstantComposite Constituent <id> '8[%8]' "
+                  "component type does not match Result Type <id> "
+                  "'5[%mat2v2float]'s matrix column component type.")));
 }
 
 // Valid: Array of integers
-TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeArrayGood) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantCompositeArrayGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpSpecConstant %1 4
@@ -1905,7 +2018,7 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeArrayGood) {
 }
 
 // Invalid: Expecting an array of 4 components, but 3 specified.
-TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeArrayNumComponentsBad) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantCompositeArrayNumComponentsBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpConstant %1 4
@@ -1914,13 +2027,14 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeArrayNumComponentsBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent count does not "
-                        "match Result Type <id> '3[%_arr_uint_uint_4]'s array "
-                        "length."));
+              HasSubstr(make_message(
+                  "OpSpecConstantComposite Constituent count does not "
+                  "match Result Type <id> '3[%_arr_uint_uint_4]'s array "
+                  "length.")));
 }
 
 // Valid: Array of Integers and Undef-int
-TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeArrayWithUndefGood) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantCompositeArrayWithUndefGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpSpecConstant %1 4
@@ -1932,7 +2046,7 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeArrayWithUndefGood) {
 }
 
 // Invalid: Array uses a type as operand.
-TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeArrayConstConstituentBad) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantCompositeArrayConstConstituentBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpConstant %1 4
@@ -1943,12 +2057,13 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeArrayConstConstituentBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '5[%5]' is "
-                        "not a constant or undef."));
+              HasSubstr(make_message(
+                  "OpSpecConstantComposite Constituent <id> '5[%5]' is "
+                  "not a constant or undef.")));
 }
 
 // Invalid: Array has a mix of Int and Float components.
-TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeArrayConstituentTypeBad) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantCompositeArrayConstituentTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpConstant %1 4
@@ -1959,13 +2074,14 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeArrayConstituentTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '5[%5]'s "
-                        "type does not match Result Type <id> "
-                        "'3[%_arr_uint_uint_4]'s array element type."));
+              HasSubstr(make_message(
+                  "OpSpecConstantComposite Constituent <id> '5[%5]'s "
+                  "type does not match Result Type <id> "
+                  "'3[%_arr_uint_uint_4]'s array element type.")));
 }
 
 // Invalid: Array has a mix of Int and Undef-float.
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        OpSpecConstantCompositeArrayConstituentUndefTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
@@ -1977,13 +2093,14 @@ TEST_F(ValidateIdWithMessage,
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '5[%5]'s "
-                        "type does not match Result Type <id> "
-                        "'3[%_arr_uint_2]'s array element type."));
+              HasSubstr(make_message(
+                  "OpSpecConstantComposite Constituent <id> '5[%5]'s "
+                  "type does not match Result Type <id> "
+                  "'3[%_arr_uint_2]'s array element type.")));
 }
 
 // Valid: Struct of {Int32,Int32,Int64}.
-TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeStructGood) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantCompositeStructGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpTypeInt 64 0
@@ -1996,7 +2113,7 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeStructGood) {
 }
 
 // Invalid: missing one int32 struct member.
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        OpSpecConstantCompositeStructMissingComponentBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
@@ -2006,14 +2123,15 @@ TEST_F(ValidateIdWithMessage,
 %6 = OpSpecConstantComposite %3 %4 %5)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> "
-                        "'2[%_struct_2]' count does not match Result Type "
-                        "<id> '2[%_struct_2]'s struct member count."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("OpSpecConstantComposite Constituent <id> "
+                             "'2[%_struct_2]' count does not match Result Type "
+                             "<id> '2[%_struct_2]'s struct member count.")));
 }
 
 // Valid: Struct uses Undef-int64.
-TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeStructUndefGood) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantCompositeStructUndefGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpTypeInt 64 0
@@ -2026,7 +2144,7 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeStructUndefGood) {
 }
 
 // Invalid: Composite contains non-const/undef component.
-TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeStructNonConstBad) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantCompositeStructNonConstBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpTypeInt 64 0
@@ -2039,13 +2157,14 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeStructNonConstBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '7[%7]' is "
-                        "not a constant or undef."));
+              HasSubstr(make_message(
+                  "OpSpecConstantComposite Constituent <id> '7[%7]' is "
+                  "not a constant or undef.")));
 }
 
 // Invalid: Struct component type does not match expected specialization type.
 // Second component was expected to be Int32, but got Int64.
-TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeStructMemberTypeBad) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantCompositeStructMemberTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpTypeInt 64 0
@@ -2056,13 +2175,14 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeStructMemberTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '5[%5]' type "
-                        "does not match the Result Type <id> '3[%_struct_3]'s "
-                        "member type."));
+              HasSubstr(make_message(
+                  "OpSpecConstantComposite Constituent <id> '5[%5]' type "
+                  "does not match the Result Type <id> '3[%_struct_3]'s "
+                  "member type.")));
 }
 
 // Invalid: Undef-int64 used when Int32 was expected.
-TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeStructMemberUndefTypeBad) {
+TEST_P(ValidateIdWithMessage, OpSpecConstantCompositeStructMemberUndefTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpTypeInt 64 0
@@ -2073,14 +2193,15 @@ TEST_F(ValidateIdWithMessage, OpSpecConstantCompositeStructMemberUndefTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpSpecConstantComposite Constituent <id> '5[%5]' type "
-                        "does not match the Result Type <id> '3[%_struct_3]'s "
-                        "member type."));
+              HasSubstr(make_message(
+                  "OpSpecConstantComposite Constituent <id> '5[%5]' type "
+                  "does not match the Result Type <id> '3[%_struct_3]'s "
+                  "member type.")));
 }
 
 // TODO: OpSpecConstantOp
 
-TEST_F(ValidateIdWithMessage, OpVariableGood) {
+TEST_P(ValidateIdWithMessage, OpVariableGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpTypePointer Input %1
@@ -2088,7 +2209,7 @@ TEST_F(ValidateIdWithMessage, OpVariableGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpVariableInitializerConstantGood) {
+TEST_P(ValidateIdWithMessage, OpVariableInitializerConstantGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpTypePointer Output %1
@@ -2097,7 +2218,7 @@ TEST_F(ValidateIdWithMessage, OpVariableInitializerConstantGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpVariableInitializerGlobalVariableGood) {
+TEST_P(ValidateIdWithMessage, OpVariableInitializerGlobalVariableGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpTypePointer Uniform %1
@@ -2109,29 +2230,30 @@ TEST_F(ValidateIdWithMessage, OpVariableInitializerGlobalVariableGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 // TODO: Positive test OpVariable with OpConstantNull of OpTypePointer
-TEST_F(ValidateIdWithMessage, OpVariableResultTypeBad) {
+TEST_P(ValidateIdWithMessage, OpVariableResultTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpVariable %1 Input)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpVariable Result Type <id> '1[%uint]' is not a pointer "
-                "type."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "OpVariable Result Type <id> '1[%uint]' is not a pointer "
+                  "type.")));
 }
-TEST_F(ValidateIdWithMessage, OpVariableInitializerIsTypeBad) {
+TEST_P(ValidateIdWithMessage, OpVariableInitializerIsTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpTypePointer Input %1
 %3 = OpVariable %2 Input %2)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand '2[%_ptr_Input_uint]' "
-                                               "cannot be a type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message("Operand '2[%_ptr_Input_uint]' "
+                                     "cannot be a type")));
 }
 
-TEST_F(ValidateIdWithMessage, OpVariableInitializerIsFunctionVarBad) {
+TEST_P(ValidateIdWithMessage, OpVariableInitializerIsFunctionVarBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %int = OpTypeInt 32 0
 %ptrint = OpTypePointer Function %int
@@ -2148,11 +2270,12 @@ OpFunctionEnd
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpVariable Initializer <id> '8[%8]' is not a constant "
-                        "or module-scope variable"));
+              HasSubstr(make_message(
+                  "OpVariable Initializer <id> '8[%8]' is not a constant "
+                  "or module-scope variable")));
 }
 
-TEST_F(ValidateIdWithMessage, OpVariableInitializerIsModuleVarGood) {
+TEST_P(ValidateIdWithMessage, OpVariableInitializerIsModuleVarGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %int = OpTypeInt 32 0
 %ptrint = OpTypePointer Uniform %int
@@ -2170,7 +2293,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpVariableContainsBoolBad) {
+TEST_P(ValidateIdWithMessage, OpVariableContainsBoolBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %bool = OpTypeBool
 %int = OpTypeInt 32 0
@@ -2189,15 +2312,15 @@ OpFunctionEnd
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr(
+      HasSubstr(make_message(
           "If OpTypeBool is stored in conjunction with OpVariable, it can only "
           "be used with non-externally visible shader Storage Classes: "
           "Workgroup, CrossWorkgroup, Private, Function, Input, Output, "
           "RayPayloadKHR, IncomingRayPayloadKHR, HitAttributeKHR, "
-          "CallableDataKHR, or IncomingCallableDataKHR"));
+          "CallableDataKHR, or IncomingCallableDataKHR")));
 }
 
-TEST_F(ValidateIdWithMessage, OpVariableContainsBoolPrivateGood) {
+TEST_P(ValidateIdWithMessage, OpVariableContainsBoolPrivateGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %bool = OpTypeBool
 %int = OpTypeInt 32 0
@@ -2216,7 +2339,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpVariableContainsBoolPointerGood) {
+TEST_P(ValidateIdWithMessage, OpVariableContainsBoolPointerGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %bool = OpTypeBool
 %boolptr = OpTypePointer Uniform %bool
@@ -2236,7 +2359,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpVariableContainsBuiltinBoolGood) {
+TEST_P(ValidateIdWithMessage, OpVariableContainsBuiltinBoolGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 OpMemberDecorate %input 0 BuiltIn FrontFacing
 %bool = OpTypeBool
@@ -2255,7 +2378,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpVariableContainsNoBuiltinBoolBad) {
+TEST_P(ValidateIdWithMessage, OpVariableContainsNoBuiltinBoolBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %bool = OpTypeBool
 %input = OpTypeStruct %bool
@@ -2273,12 +2396,12 @@ OpFunctionEnd
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr(
+      HasSubstr(make_message(
           "If OpTypeBool is stored in conjunction with OpVariable using Input "
-          "or Output Storage Classes it requires a BuiltIn decoration"));
+          "or Output Storage Classes it requires a BuiltIn decoration")));
 }
 
-TEST_F(ValidateIdWithMessage, OpVariableContainsNoBuiltinBoolBadVulkan) {
+TEST_P(ValidateIdWithMessage, OpVariableContainsNoBuiltinBoolBadVulkan) {
   std::string spirv = R"(
 OpCapability Shader
 OpMemoryModel Logical GLSL450
@@ -2302,12 +2425,12 @@ OpFunctionEnd
               AnyVUID("VUID-StandaloneSpirv-Input-07290"));
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr(
+      HasSubstr(make_message(
           "If OpTypeBool is stored in conjunction with OpVariable using Input "
-          "or Output Storage Classes it requires a BuiltIn decoration"));
+          "or Output Storage Classes it requires a BuiltIn decoration")));
 }
 
-TEST_F(ValidateIdWithMessage, OpVariableContainsRayPayloadBoolGood) {
+TEST_P(ValidateIdWithMessage, OpVariableContainsRayPayloadBoolGood) {
   std::string spirv = R"(
 OpCapability RayTracingNV
 OpCapability Shader
@@ -2330,7 +2453,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpVariablePointerNoVariablePointersBad) {
+TEST_P(ValidateIdWithMessage, OpVariablePointerNoVariablePointersBad) {
   const std::string spirv = R"(
 OpCapability Shader
 OpCapability Linkage
@@ -2351,11 +2474,11 @@ OpFunctionEnd
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr(
-          "In Logical addressing, variables may not allocate a pointer type"));
+      HasSubstr(make_message(
+          "In Logical addressing, variables may not allocate a pointer type")));
 }
 
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        OpVariablePointerNoVariablePointersRelaxedLogicalGood) {
   const std::string spirv = R"(
 OpCapability Shader
@@ -2379,7 +2502,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpFunctionWithNonMemoryObject) {
+TEST_P(ValidateIdWithMessage, OpFunctionWithNonMemoryObject) {
   // DXC generates code that looks like when given something like:
   //   T t;
   //   t.s.fn_1();
@@ -2420,7 +2543,7 @@ TEST_F(ValidateIdWithMessage, OpFunctionWithNonMemoryObject) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        OpVariablePointerVariablePointersStorageBufferGood) {
   const std::string spirv = R"(
 OpCapability Shader
@@ -2444,7 +2567,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpVariablePointerVariablePointersGood) {
+TEST_P(ValidateIdWithMessage, OpVariablePointerVariablePointersGood) {
   const std::string spirv = R"(
 OpCapability Shader
 OpCapability Linkage
@@ -2467,7 +2590,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpVariablePointerVariablePointersBad) {
+TEST_P(ValidateIdWithMessage, OpVariablePointerVariablePointersBad) {
   const std::string spirv = R"(
 OpCapability Shader
 OpCapability VariablePointers
@@ -2483,12 +2606,13 @@ OpMemoryModel Logical GLSL450
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("In Logical addressing with variable pointers, "
-                        "variables that allocate pointers must be in Function "
-                        "or Private storage classes"));
+              HasSubstr(make_message(
+                  "In Logical addressing with variable pointers, "
+                  "variables that allocate pointers must be in Function "
+                  "or Private storage classes")));
 }
 
-TEST_F(ValidateIdWithMessage, OpLoadGood) {
+TEST_P(ValidateIdWithMessage, OpLoadGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
  %1 = OpTypeVoid
  %2 = OpTypeInt 32 0
@@ -2561,7 +2685,7 @@ void createVariablePointerSpirvProgram(std::ostringstream* spirv,
 
 // With the VariablePointer Capability, OpLoad should allow loading a
 // VaiablePointer. In this test the variable pointer is obtained by an OpSelect
-TEST_F(ValidateIdWithMessage, OpLoadVarPtrOpSelectGood) {
+TEST_P(ValidateIdWithMessage, OpLoadVarPtrOpSelectGood) {
   std::string result_strategy = R"(
     %isneg     = OpSLessThan %bool %i %zero
     %varptr    = OpSelect %f32ptr %isneg %ptr1 %ptr2
@@ -2580,7 +2704,7 @@ TEST_F(ValidateIdWithMessage, OpLoadVarPtrOpSelectGood) {
 // through a variable pointer.
 // Disabled since using OpSelect with pointers without VariablePointers will
 // fail LogicalsPass.
-TEST_F(ValidateIdWithMessage, DISABLED_OpLoadVarPtrOpSelectBad) {
+TEST_P(ValidateIdWithMessage, DISABLED_OpLoadVarPtrOpSelectBad) {
   std::string result_strategy = R"(
     %isneg     = OpSLessThan %bool %i %zero
     %varptr    = OpSelect %f32ptr %isneg %ptr1 %ptr2
@@ -2593,12 +2717,13 @@ TEST_F(ValidateIdWithMessage, DISABLED_OpLoadVarPtrOpSelectBad) {
                                     false /* Use Helper Function? */);
   CompileSuccessfully(spirv.str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("is not a logical pointer."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message("is not a logical pointer.")));
 }
 
 // With the VariablePointer Capability, OpLoad should allow loading a
 // VaiablePointer. In this test the variable pointer is obtained by an OpPhi
-TEST_F(ValidateIdWithMessage, OpLoadVarPtrOpPhiGood) {
+TEST_P(ValidateIdWithMessage, OpLoadVarPtrOpPhiGood) {
   std::string result_strategy = R"(
     %is_neg      = OpSLessThan %bool %i %zero
     OpSelectionMerge %end_label None
@@ -2622,7 +2747,7 @@ TEST_F(ValidateIdWithMessage, OpLoadVarPtrOpPhiGood) {
 
 // Without the VariablePointers Capability, OpPhi can have a pointer result
 // type.
-TEST_F(ValidateIdWithMessage, OpPhiBad) {
+TEST_P(ValidateIdWithMessage, OpPhiBad) {
   std::string result_strategy = R"(
     %is_neg      = OpSLessThan %bool %i %zero
     OpSelectionMerge %end_label None
@@ -2643,14 +2768,15 @@ TEST_F(ValidateIdWithMessage, OpPhiBad) {
   CompileSuccessfully(spirv.str());
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Using pointers with OpPhi requires capability "
-                        "VariablePointers or VariablePointersStorageBuffer"));
+              HasSubstr(make_message(
+                  "Using pointers with OpPhi requires capability "
+                  "VariablePointers or VariablePointersStorageBuffer")));
 }
 
 // With the VariablePointer Capability, OpLoad should allow loading through a
 // VaiablePointer. In this test the variable pointer is obtained from an
 // OpFunctionCall (return value from a function)
-TEST_F(ValidateIdWithMessage, OpLoadVarPtrOpFunctionCallGood) {
+TEST_P(ValidateIdWithMessage, OpLoadVarPtrOpFunctionCallGood) {
   std::ostringstream spirv;
   std::string result_strategy = R"(
     %isneg     = OpSLessThan %bool %i %zero
@@ -2665,7 +2791,7 @@ TEST_F(ValidateIdWithMessage, OpLoadVarPtrOpFunctionCallGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpLoadResultTypeBad) {
+TEST_P(ValidateIdWithMessage, OpLoadResultTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -2680,13 +2806,14 @@ TEST_F(ValidateIdWithMessage, OpLoadResultTypeBad) {
 )";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpLoad Result Type <id> "
-                        "'3[%_ptr_UniformConstant_uint]' does not match "
-                        "Pointer <id> '5[%5]'s type."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("OpLoad Result Type <id> "
+                             "'3[%_ptr_UniformConstant_uint]' does not match "
+                             "Pointer <id> '5[%5]'s type.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpLoadPointerBad) {
+TEST_P(ValidateIdWithMessage, OpLoadPointerBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -2702,12 +2829,13 @@ TEST_F(ValidateIdWithMessage, OpLoadPointerBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   // Prove that SSA checks trigger for a bad Id value.
   // The next test case show the not-a-logical-pointer case.
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID '8[%8]' has not been "
-                                               "defined"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message("ID '8[%8]' has not been "
+                                     "defined")));
 }
 
 // Disabled as bitcasting type to object is now not valid.
-TEST_F(ValidateIdWithMessage, DISABLED_OpLoadLogicalPointerBad) {
+TEST_P(ValidateIdWithMessage, DISABLED_OpLoadLogicalPointerBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -2729,10 +2857,11 @@ TEST_F(ValidateIdWithMessage, DISABLED_OpLoadLogicalPointerBad) {
   // I don't know if it's possible to generate a bad case
   // if/when the validator is complete.
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpLoad Pointer <id> '9' is not a logical pointer."));
+              HasSubstr(make_message(
+                  "OpLoad Pointer <id> '9' is not a logical pointer.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpStoreGood) {
+TEST_P(ValidateIdWithMessage, OpStoreGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -2748,7 +2877,7 @@ TEST_F(ValidateIdWithMessage, OpStoreGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpStorePointerBad) {
+TEST_P(ValidateIdWithMessage, OpStorePointerBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -2765,12 +2894,13 @@ TEST_F(ValidateIdWithMessage, OpStorePointerBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpStore Pointer <id> '7[%uint_0]' is not a logical "
-                        "pointer."));
+              HasSubstr(make_message(
+                  "OpStore Pointer <id> '7[%uint_0]' is not a logical "
+                  "pointer.")));
 }
 
 // Disabled as bitcasting type to object is now not valid.
-TEST_F(ValidateIdWithMessage, DISABLED_OpStoreLogicalPointerBad) {
+TEST_P(ValidateIdWithMessage, DISABLED_OpStoreLogicalPointerBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -2789,14 +2919,15 @@ TEST_F(ValidateIdWithMessage, DISABLED_OpStoreLogicalPointerBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpStore Pointer <id> '10' is not a logical pointer."));
+              HasSubstr(make_message(
+                  "OpStore Pointer <id> '10' is not a logical pointer.")));
 }
 
 // Without the VariablePointer Capability, OpStore should may not store
 // through a variable pointer.
 // Disabled since using OpSelect with pointers without VariablePointers will
 // fail LogicalsPass.
-TEST_F(ValidateIdWithMessage, DISABLED_OpStoreVarPtrBad) {
+TEST_P(ValidateIdWithMessage, DISABLED_OpStoreVarPtrBad) {
   std::string result_strategy = R"(
     %isneg     = OpSLessThan %bool %i %zero
     %varptr    = OpSelect %f32ptr %isneg %ptr1 %ptr2
@@ -2809,12 +2940,13 @@ TEST_F(ValidateIdWithMessage, DISABLED_OpStoreVarPtrBad) {
       false /* Use Helper Function? */);
   CompileSuccessfully(spirv.str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("is not a logical pointer."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message("is not a logical pointer.")));
 }
 
 // With the VariablePointer Capability, OpStore should allow storing through a
 // variable pointer.
-TEST_F(ValidateIdWithMessage, OpStoreVarPtrGood) {
+TEST_P(ValidateIdWithMessage, OpStoreVarPtrGood) {
   std::string result_strategy = R"(
     %isneg     = OpSLessThan %bool %i %zero
     %varptr    = OpSelect %f32ptr %isneg %ptr1 %ptr2
@@ -2829,7 +2961,7 @@ TEST_F(ValidateIdWithMessage, OpStoreVarPtrGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpStoreObjectGood) {
+TEST_P(ValidateIdWithMessage, OpStoreObjectGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -2849,10 +2981,11 @@ TEST_F(ValidateIdWithMessage, OpStoreObjectGood) {
      OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpStore Object <id> '9[%9]'s type is void."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("OpStore Object <id> '9[%9]'s type is void.")));
 }
-TEST_F(ValidateIdWithMessage, OpStoreTypeBad) {
+TEST_P(ValidateIdWithMessage, OpStoreTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -2869,8 +3002,9 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpStore Pointer <id> '7[%7]'s type does not match "
-                        "Object <id> '6[%float_3_1400001]'s type."));
+              HasSubstr(make_message(
+                  "OpStore Pointer <id> '7[%7]'s type does not match "
+                  "Object <id> '6[%float_3_1400001]'s type.")));
 }
 
 // The next series of test check test a relaxation of the rules for stores to
@@ -2879,7 +3013,7 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeBad) {
 // TODO: Add tests for layout compatible arrays and matricies when the validator
 //       relaxes the rules for them as well.  Also need test to check for layout
 //       decorations specific to those types.
-TEST_F(ValidateIdWithMessage, OpStoreTypeBadStruct) {
+TEST_P(ValidateIdWithMessage, OpStoreTypeBadStruct) {
   std::string spirv = kGLSL450MemoryModel + R"(
      OpMemberDecorate %1 0 Offset 0
      OpMemberDecorate %1 1 Offset 4
@@ -2902,13 +3036,14 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeBadStruct) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpStore Pointer <id> '8[%8]'s type does not match "
-                        "Object <id> '11[%11]'s type."));
+              HasSubstr(make_message(
+                  "OpStore Pointer <id> '8[%8]'s type does not match "
+                  "Object <id> '11[%11]'s type.")));
 }
 
 // Same code as the last test.  The difference is that we relax the rule.
 // Because the structs %3 and %5 are defined the same way.
-TEST_F(ValidateIdWithMessage, OpStoreTypeRelaxedStruct) {
+TEST_P(ValidateIdWithMessage, OpStoreTypeRelaxedStruct) {
   std::string spirv = kGLSL450MemoryModel + R"(
      OpMemberDecorate %1 0 Offset 0
      OpMemberDecorate %1 1 Offset 4
@@ -2935,7 +3070,7 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeRelaxedStruct) {
 
 // Same code as the last test except for an extra decoration on one of the
 // members. With the relaxed rules, the code is still valid.
-TEST_F(ValidateIdWithMessage, OpStoreTypeRelaxedStructWithExtraDecoration) {
+TEST_P(ValidateIdWithMessage, OpStoreTypeRelaxedStructWithExtraDecoration) {
   std::string spirv = kGLSL450MemoryModel + R"(
      OpMemberDecorate %1 0 Offset 0
      OpMemberDecorate %1 1 Offset 4
@@ -2963,7 +3098,7 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeRelaxedStructWithExtraDecoration) {
 
 // This test check that we recursively traverse the struct to check if they are
 // interchangable.
-TEST_F(ValidateIdWithMessage, OpStoreTypeRelaxedNestedStruct) {
+TEST_P(ValidateIdWithMessage, OpStoreTypeRelaxedNestedStruct) {
   std::string spirv = kGLSL450MemoryModel + R"(
      OpMemberDecorate %1 0 Offset 0
      OpMemberDecorate %1 1 Offset 4
@@ -2999,7 +3134,7 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeRelaxedNestedStruct) {
 
 // This test check that the even with the relaxed rules an error is identified
 // if the members of the struct are in a different order.
-TEST_F(ValidateIdWithMessage, OpStoreTypeBadRelaxedStruct1) {
+TEST_P(ValidateIdWithMessage, OpStoreTypeBadRelaxedStruct1) {
   std::string spirv = kGLSL450MemoryModel + R"(
      OpMemberDecorate %1 0 Offset 0
      OpMemberDecorate %1 1 Offset 4
@@ -3033,13 +3168,14 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeBadRelaxedStruct1) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpStore Pointer <id> '13[%13]'s layout does not match Object "
-                "<id> '16[%16]'s layout."));
+      HasSubstr(make_message(
+          "OpStore Pointer <id> '13[%13]'s layout does not match Object "
+          "<id> '16[%16]'s layout.")));
 }
 
 // This test check that the even with the relaxed rules an error is identified
 // if the members of the struct are at different offsets.
-TEST_F(ValidateIdWithMessage, OpStoreTypeBadRelaxedStruct2) {
+TEST_P(ValidateIdWithMessage, OpStoreTypeBadRelaxedStruct2) {
   std::string spirv = kGLSL450MemoryModel + R"(
      OpMemberDecorate %1 0 Offset 4
      OpMemberDecorate %1 1 Offset 0
@@ -3073,11 +3209,12 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeBadRelaxedStruct2) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpStore Pointer <id> '13[%13]'s layout does not match Object "
-                "<id> '16[%16]'s layout."));
+      HasSubstr(make_message(
+          "OpStore Pointer <id> '13[%13]'s layout does not match Object "
+          "<id> '16[%16]'s layout.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpStoreTypeRelaxedLogicalPointerReturnPointer) {
+TEST_P(ValidateIdWithMessage, OpStoreTypeRelaxedLogicalPointerReturnPointer) {
   const std::string spirv = R"(
      OpCapability Shader
      OpCapability Linkage
@@ -3096,7 +3233,7 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeRelaxedLogicalPointerReturnPointer) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpStoreTypeRelaxedLogicalPointerAllocPointer) {
+TEST_P(ValidateIdWithMessage, OpStoreTypeRelaxedLogicalPointerAllocPointer) {
   const std::string spirv = R"(
       OpCapability Shader
       OpCapability Linkage
@@ -3119,7 +3256,7 @@ TEST_F(ValidateIdWithMessage, OpStoreTypeRelaxedLogicalPointerAllocPointer) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpStoreVoid) {
+TEST_P(ValidateIdWithMessage, OpStoreVoid) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -3134,11 +3271,12 @@ TEST_F(ValidateIdWithMessage, OpStoreVoid) {
      OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpStore Object <id> '8[%8]'s type is void."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("OpStore Object <id> '8[%8]'s type is void.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpStoreLabel) {
+TEST_P(ValidateIdWithMessage, OpStoreLabel) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -3153,12 +3291,12 @@ TEST_F(ValidateIdWithMessage, OpStoreLabel) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand '7[%7]' requires a type"));
+              HasSubstr(make_message("Operand '7[%7]' requires a type")));
 }
 
 // TODO: enable when this bug is fixed:
 // https://cvs.khronos.org/bugzilla/show_bug.cgi?id=15404
-TEST_F(ValidateIdWithMessage, DISABLED_OpStoreFunction) {
+TEST_P(ValidateIdWithMessage, DISABLED_OpStoreFunction) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %2 = OpTypeInt 32 0
 %3 = OpTypePointer UniformConstant %2
@@ -3174,7 +3312,7 @@ TEST_F(ValidateIdWithMessage, DISABLED_OpStoreFunction) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpStoreBuiltin) {
+TEST_P(ValidateIdWithMessage, OpStoreBuiltin) {
   std::string spirv = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
@@ -3209,10 +3347,11 @@ TEST_F(ValidateIdWithMessage, OpStoreBuiltin) {
 
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("storage class is read-only"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message("storage class is read-only")));
 }
 
-TEST_F(ValidateIdWithMessage, OpCopyMemoryGood) {
+TEST_P(ValidateIdWithMessage, OpCopyMemoryGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
  %1 = OpTypeVoid
  %2 = OpTypeInt 32 0
@@ -3232,7 +3371,7 @@ TEST_F(ValidateIdWithMessage, OpCopyMemoryGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpCopyMemoryNonPointerTarget) {
+TEST_P(ValidateIdWithMessage, OpCopyMemoryNonPointerTarget) {
   const std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -3249,11 +3388,12 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Target operand <id> '6[%6]' is not a pointer."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("Target operand <id> '6[%6]' is not a pointer.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpCopyMemoryNonPointerSource) {
+TEST_P(ValidateIdWithMessage, OpCopyMemoryNonPointerSource) {
   const std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -3270,11 +3410,12 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Source operand <id> '6[%6]' is not a pointer."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("Source operand <id> '6[%6]' is not a pointer.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpCopyMemoryBad) {
+TEST_P(ValidateIdWithMessage, OpCopyMemoryBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
  %1 = OpTypeVoid
  %2 = OpTypeInt 32 0
@@ -3294,11 +3435,11 @@ TEST_F(ValidateIdWithMessage, OpCopyMemoryBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Target <id> '5[%5]'s type does not match "
-                        "Source <id> '2[%uint]'s type."));
+              HasSubstr(make_message("Target <id> '5[%5]'s type does not match "
+                                     "Source <id> '2[%uint]'s type.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpCopyMemoryVoidTarget) {
+TEST_P(ValidateIdWithMessage, OpCopyMemoryVoidTarget) {
   const std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -3316,12 +3457,13 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Target operand <id> '7[%7]' cannot be a void "
-                        "pointer."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("Target operand <id> '7[%7]' cannot be a void "
+                             "pointer.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpCopyMemoryVoidSource) {
+TEST_P(ValidateIdWithMessage, OpCopyMemoryVoidSource) {
   const std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -3339,12 +3481,13 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Source operand <id> '7[%7]' cannot be a void "
-                        "pointer."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("Source operand <id> '7[%7]' cannot be a void "
+                             "pointer.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpCopyMemorySizedGood) {
+TEST_P(ValidateIdWithMessage, OpCopyMemorySizedGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
  %1 = OpTypeVoid
  %2 = OpTypeInt 32 0
@@ -3362,7 +3505,7 @@ TEST_F(ValidateIdWithMessage, OpCopyMemorySizedGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpCopyMemorySizedTargetBad) {
+TEST_P(ValidateIdWithMessage, OpCopyMemorySizedTargetBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -3379,9 +3522,10 @@ TEST_F(ValidateIdWithMessage, OpCopyMemorySizedTargetBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Target operand <id> '5[%uint_4]' is not a pointer."));
+              HasSubstr(make_message(
+                  "Target operand <id> '5[%uint_4]' is not a pointer.")));
 }
-TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSourceBad) {
+TEST_P(ValidateIdWithMessage, OpCopyMemorySizedSourceBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -3398,9 +3542,10 @@ TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSourceBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Source operand <id> '5[%uint_4]' is not a pointer."));
+              HasSubstr(make_message(
+                  "Source operand <id> '5[%uint_4]' is not a pointer.")));
 }
-TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeBad) {
+TEST_P(ValidateIdWithMessage, OpCopyMemorySizedSizeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
  %1 = OpTypeVoid
  %2 = OpTypeInt 32 0
@@ -3417,11 +3562,11 @@ TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeBad) {
       OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Size operand <id> '6[%6]' must be a scalar integer type."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "Size operand <id> '6[%6]' must be a scalar integer type.")));
 }
-TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeTypeBad) {
+TEST_P(ValidateIdWithMessage, OpCopyMemorySizedSizeTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
  %1 = OpTypeVoid
  %2 = OpTypeInt 32 0
@@ -3440,13 +3585,13 @@ TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeTypeBad) {
       OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Size operand <id> '9[%float_1]' must be a scalar integer "
-                "type."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "Size operand <id> '9[%float_1]' must be a scalar integer "
+                  "type.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeConstantNull) {
+TEST_P(ValidateIdWithMessage, OpCopyMemorySizedSizeConstantNull) {
   const std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -3466,12 +3611,13 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Size operand <id> '3[%3]' cannot be a constant "
-                        "zero."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("Size operand <id> '3[%3]' cannot be a constant "
+                             "zero.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeConstantZero) {
+TEST_P(ValidateIdWithMessage, OpCopyMemorySizedSizeConstantZero) {
   const std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -3492,11 +3638,12 @@ OpFunctionEnd
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Size operand <id> '3[%uint_0]' cannot be a constant "
-                        "zero."));
+              HasSubstr(make_message(
+                  "Size operand <id> '3[%uint_0]' cannot be a constant "
+                  "zero.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeConstantZero64) {
+TEST_P(ValidateIdWithMessage, OpCopyMemorySizedSizeConstantZero64) {
   const std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 64 0
@@ -3517,11 +3664,12 @@ OpFunctionEnd
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Size operand <id> '3[%ulong_0]' cannot be a constant "
-                        "zero."));
+              HasSubstr(make_message(
+                  "Size operand <id> '3[%ulong_0]' cannot be a constant "
+                  "zero.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeConstantNegative) {
+TEST_P(ValidateIdWithMessage, OpCopyMemorySizedSizeConstantNegative) {
   const std::string spirv = kNoKernelGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 1
@@ -3541,13 +3689,13 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Size operand <id> '3[%int_n1]' cannot have the sign bit set "
-                "to 1."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "Size operand <id> '3[%int_n1]' cannot have the sign bit set "
+                  "to 1.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeConstantNegative64) {
+TEST_P(ValidateIdWithMessage, OpCopyMemorySizedSizeConstantNegative64) {
   const std::string spirv = kNoKernelGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 64 1
@@ -3569,11 +3717,12 @@ OpFunctionEnd
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Size operand <id> '3[%long_n1]' cannot have the sign bit set "
-                "to 1."));
+      HasSubstr(make_message(
+          "Size operand <id> '3[%long_n1]' cannot have the sign bit set "
+          "to 1.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeUnsignedNegative) {
+TEST_P(ValidateIdWithMessage, OpCopyMemorySizedSizeUnsignedNegative) {
   const std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -3595,7 +3744,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpCopyMemorySizedSizeUnsignedNegative64) {
+TEST_P(ValidateIdWithMessage, OpCopyMemorySizedSizeUnsignedNegative64) {
   const std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 64 0
@@ -4174,7 +4323,7 @@ INSTANTIATE_TEST_SUITE_P(
 // TODO: OpImagePointer
 // TODO: OpGenericPtrMemSemantics
 
-TEST_F(ValidateIdWithMessage, OpFunctionGood) {
+TEST_P(ValidateIdWithMessage, OpFunctionGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -4186,7 +4335,7 @@ TEST_F(ValidateIdWithMessage, OpFunctionGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpFunctionResultTypeBad) {
+TEST_P(ValidateIdWithMessage, OpFunctionResultTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -4198,12 +4347,13 @@ TEST_F(ValidateIdWithMessage, OpFunctionResultTypeBad) {
      OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpFunction Result Type <id> '2[%uint]' does not "
-                        "match the Function Type's return type <id> "
-                        "'1[%void]'."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("OpFunction Result Type <id> '2[%uint]' does not "
+                             "match the Function Type's return type <id> "
+                             "'1[%void]'.")));
 }
-TEST_F(ValidateIdWithMessage, OpReturnValueTypeBad) {
+TEST_P(ValidateIdWithMessage, OpReturnValueTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeInt 32 0
 %2 = OpTypeFloat 32
@@ -4216,10 +4366,11 @@ TEST_F(ValidateIdWithMessage, OpReturnValueTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpReturnValue Value <id> '3[%float_0]'s type does "
-                        "not match OpFunction's return type."));
+              HasSubstr(make_message(
+                  "OpReturnValue Value <id> '3[%float_0]'s type does "
+                  "not match OpFunction's return type.")));
 }
-TEST_F(ValidateIdWithMessage, OpFunctionFunctionTypeBad) {
+TEST_P(ValidateIdWithMessage, OpFunctionFunctionTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -4229,13 +4380,13 @@ TEST_F(ValidateIdWithMessage, OpFunctionFunctionTypeBad) {
 OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpFunction Function Type <id> '2[%uint]' is not a function "
-                "type."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "OpFunction Function Type <id> '2[%uint]' is not a function "
+                  "type.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpFunctionUseBad) {
+TEST_P(ValidateIdWithMessage, OpFunctionUseBad) {
   const std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeFloat 32
 %2 = OpTypeFunction %1
@@ -4247,11 +4398,12 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Invalid use of function result id '3[%3]'."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("Invalid use of function result id '3[%3]'.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpFunctionParameterGood) {
+TEST_P(ValidateIdWithMessage, OpFunctionParameterGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -4264,7 +4416,7 @@ TEST_F(ValidateIdWithMessage, OpFunctionParameterGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpFunctionParameterMultipleGood) {
+TEST_P(ValidateIdWithMessage, OpFunctionParameterMultipleGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -4278,7 +4430,7 @@ TEST_F(ValidateIdWithMessage, OpFunctionParameterMultipleGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpFunctionParameterResultTypeBad) {
+TEST_P(ValidateIdWithMessage, OpFunctionParameterResultTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -4292,11 +4444,12 @@ TEST_F(ValidateIdWithMessage, OpFunctionParameterResultTypeBad) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("OpFunctionParameter Result Type <id> '1[%void]' does not "
-                "match the OpTypeFunction parameter type of the same index."));
+      HasSubstr(make_message(
+          "OpFunctionParameter Result Type <id> '1[%void]' does not "
+          "match the OpTypeFunction parameter type of the same index.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpFunctionCallGood) {
+TEST_P(ValidateIdWithMessage, OpFunctionCallGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -4318,7 +4471,7 @@ TEST_F(ValidateIdWithMessage, OpFunctionCallGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpFunctionCallResultTypeBad) {
+TEST_P(ValidateIdWithMessage, OpFunctionCallResultTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -4340,12 +4493,13 @@ TEST_F(ValidateIdWithMessage, OpFunctionCallResultTypeBad) {
       OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpFunctionCall Result Type <id> '1[%void]'s type "
-                        "does not match Function <id> '2[%uint]'s return "
-                        "type."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("OpFunctionCall Result Type <id> '1[%void]'s type "
+                             "does not match Function <id> '2[%uint]'s return "
+                             "type.")));
 }
-TEST_F(ValidateIdWithMessage, OpFunctionCallFunctionBad) {
+TEST_P(ValidateIdWithMessage, OpFunctionCallFunctionBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -4361,10 +4515,11 @@ TEST_F(ValidateIdWithMessage, OpFunctionCallFunctionBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpFunctionCall Function <id> '5[%uint_42]' is not a "
-                        "function."));
+              HasSubstr(make_message(
+                  "OpFunctionCall Function <id> '5[%uint_42]' is not a "
+                  "function.")));
 }
-TEST_F(ValidateIdWithMessage, OpFunctionCallArgumentTypeBad) {
+TEST_P(ValidateIdWithMessage, OpFunctionCallArgumentTypeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -4390,14 +4545,15 @@ TEST_F(ValidateIdWithMessage, OpFunctionCallArgumentTypeBad) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpFunctionCall Argument <id> '7[%float_3_1400001]'s "
-                        "type does not match Function <id> '2[%uint]'s "
-                        "parameter type."));
+              HasSubstr(make_message(
+                  "OpFunctionCall Argument <id> '7[%float_3_1400001]'s "
+                  "type does not match Function <id> '2[%uint]'s "
+                  "parameter type.")));
 }
 
 // Valid: OpSampledImage result <id> is used in the same block by
 // OpImageSampleImplictLod
-TEST_F(ValidateIdWithMessage, OpSampledImageGood) {
+TEST_P(ValidateIdWithMessage, OpSampledImageGood) {
   std::string spirv = kGLSL450MemoryModel + sampledImageSetup + R"(
 %smpld_img = OpSampledImage %sampled_image_type %image_inst %sampler_inst
 %si_lod    = OpImageSampleImplicitLod %v4float %smpld_img %const_vec_1_1
@@ -4409,7 +4565,7 @@ TEST_F(ValidateIdWithMessage, OpSampledImageGood) {
 
 // Invalid: OpSampledImage result <id> is defined in one block and used in a
 // different block.
-TEST_F(ValidateIdWithMessage, OpSampledImageUsedInDifferentBlockBad) {
+TEST_P(ValidateIdWithMessage, OpSampledImageUsedInDifferentBlockBad) {
   std::string spirv = kGLSL450MemoryModel + sampledImageSetup + R"(
 %smpld_img = OpSampledImage %sampled_image_type %image_inst %sampler_inst
 OpBranch %label_2
@@ -4421,10 +4577,11 @@ OpFunctionEnd)";
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("All OpSampledImage instructions must be in the same block in "
-                "which their Result <id> are consumed. OpSampledImage Result "
-                "Type <id> '23[%23]' has a consumer in a different basic "
-                "block. The consumer instruction <id> is '25[%25]'."));
+      HasSubstr(make_message(
+          "All OpSampledImage instructions must be in the same block in "
+          "which their Result <id> are consumed. OpSampledImage Result "
+          "Type <id> '23[%23]' has a consumer in a different basic "
+          "block. The consumer instruction <id> is '25[%25]'.")));
 }
 
 // Invalid: OpSampledImage result <id> is used by OpSelect
@@ -4435,7 +4592,7 @@ OpFunctionEnd)";
 // updated, the error message for this test may change.
 //
 // Disabled since OpSelect catches this now.
-TEST_F(ValidateIdWithMessage, DISABLED_OpSampledImageUsedInOpSelectBad) {
+TEST_P(ValidateIdWithMessage, DISABLED_OpSampledImageUsedInOpSelectBad) {
   std::string spirv = kGLSL450MemoryModel + sampledImageSetup + R"(
 %smpld_img  = OpSampledImage %sampled_image_type %image_inst %sampler_inst
 %select_img = OpSelect %sampled_image_type %spec_true %smpld_img %smpld_img
@@ -4444,12 +4601,13 @@ OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Result <id> from OpSampledImage instruction must not "
-                        "appear as operands of OpSelect. Found result <id> "
-                        "'23' as an operand of <id> '24'."));
+              HasSubstr(make_message(
+                  "Result <id> from OpSampledImage instruction must not "
+                  "appear as operands of OpSelect. Found result <id> "
+                  "'23' as an operand of <id> '24'.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpCopyObjectSampledImageGood) {
+TEST_P(ValidateIdWithMessage, OpCopyObjectSampledImageGood) {
   std::string spirv = kGLSL450MemoryModel + sampledImageSetup + R"(
 %smpld_img  = OpSampledImage %sampled_image_type %image_inst %sampler_inst
 %smpld_img2 = OpCopyObject %sampled_image_type %smpld_img
@@ -4462,7 +4620,7 @@ OpFunctionEnd)";
 
 // Valid: Get a float in a matrix using CompositeExtract.
 // Valid: Insert float into a matrix using CompositeInsert.
-TEST_F(ValidateIdWithMessage, CompositeExtractInsertGood) {
+TEST_P(ValidateIdWithMessage, CompositeExtractInsertGood) {
   std::ostringstream spirv;
   spirv << kGLSL450MemoryModel << kDeeplyNestedStructureSetup << std::endl;
   spirv << "%matrix = OpLoad %mat4x3 %my_matrix" << std::endl;
@@ -4478,7 +4636,7 @@ TEST_F(ValidateIdWithMessage, CompositeExtractInsertGood) {
 }
 
 #if 0
-TEST_F(ValidateIdWithMessage, OpFunctionCallArgumentCountBar) {
+TEST_P(ValidateIdWithMessage, OpFunctionCallArgumentCountBar) {
   const char *spirv = R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -4545,7 +4703,7 @@ TEST_F(ValidateIdWithMessage, OpFunctionCallArgumentCountBar) {
 // TODO: OpVectorExtractDynamic
 // TODO: OpVectorInsertDynamic
 
-TEST_F(ValidateIdWithMessage, OpVectorShuffleIntGood) {
+TEST_P(ValidateIdWithMessage, OpVectorShuffleIntGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %int = OpTypeInt 32 0
 %ivec3 = OpTypeVector %int 3
@@ -4568,7 +4726,7 @@ TEST_F(ValidateIdWithMessage, OpVectorShuffleIntGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpVectorShuffleFloatGood) {
+TEST_P(ValidateIdWithMessage, OpVectorShuffleFloatGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %float = OpTypeFloat 32
 %vec2 = OpTypeVector %float 2
@@ -4594,7 +4752,7 @@ TEST_F(ValidateIdWithMessage, OpVectorShuffleFloatGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpVectorShuffleScalarResultType) {
+TEST_P(ValidateIdWithMessage, OpVectorShuffleScalarResultType) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %float = OpTypeFloat 32
 %vec2 = OpTypeVector %float 2
@@ -4612,12 +4770,12 @@ TEST_F(ValidateIdWithMessage, OpVectorShuffleScalarResultType) {
      OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Result Type of OpVectorShuffle must be OpTypeVector."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "Result Type of OpVectorShuffle must be OpTypeVector.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpVectorShuffleComponentCount) {
+TEST_P(ValidateIdWithMessage, OpVectorShuffleComponentCount) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %int = OpTypeInt 32 0
 %ivec3 = OpTypeVector %int 3
@@ -4636,13 +4794,13 @@ TEST_F(ValidateIdWithMessage, OpVectorShuffleComponentCount) {
      OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpVectorShuffle component literals count does not match "
-                "Result Type <id> '2[%v3uint]'s vector component count."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "OpVectorShuffle component literals count does not match "
+                  "Result Type <id> '2[%v3uint]'s vector component count.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpVectorShuffleVector1Type) {
+TEST_P(ValidateIdWithMessage, OpVectorShuffleVector1Type) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %int = OpTypeInt 32 0
 %ivec2 = OpTypeVector %int 2
@@ -4659,11 +4817,12 @@ TEST_F(ValidateIdWithMessage, OpVectorShuffleVector1Type) {
      OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("The type of Vector 1 must be OpTypeVector."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("The type of Vector 1 must be OpTypeVector.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpVectorShuffleVector2Type) {
+TEST_P(ValidateIdWithMessage, OpVectorShuffleVector2Type) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %int = OpTypeInt 32 0
 %ivec2 = OpTypeVector %int 2
@@ -4681,11 +4840,12 @@ TEST_F(ValidateIdWithMessage, OpVectorShuffleVector2Type) {
      OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("The type of Vector 2 must be OpTypeVector."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("The type of Vector 2 must be OpTypeVector.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpVectorShuffleVector1ComponentType) {
+TEST_P(ValidateIdWithMessage, OpVectorShuffleVector1ComponentType) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %int = OpTypeInt 32 0
 %ivec3 = OpTypeVector %int 3
@@ -4714,11 +4874,12 @@ TEST_F(ValidateIdWithMessage, OpVectorShuffleVector1ComponentType) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("The Component Type of Vector 1 must be the same as "
-                        "ResultType."));
+              HasSubstr(make_message(
+                  "The Component Type of Vector 1 must be the same as "
+                  "ResultType.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpVectorShuffleVector2ComponentType) {
+TEST_P(ValidateIdWithMessage, OpVectorShuffleVector2ComponentType) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %int = OpTypeInt 32 0
 %ivec3 = OpTypeVector %int 3
@@ -4747,11 +4908,12 @@ TEST_F(ValidateIdWithMessage, OpVectorShuffleVector2ComponentType) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("The Component Type of Vector 2 must be the same as "
-                        "ResultType."));
+              HasSubstr(make_message(
+                  "The Component Type of Vector 2 must be the same as "
+                  "ResultType.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpVectorShuffleLiterals) {
+TEST_P(ValidateIdWithMessage, OpVectorShuffleLiterals) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %float = OpTypeFloat 32
 %vec2 = OpTypeVector %float 2
@@ -4777,9 +4939,9 @@ TEST_F(ValidateIdWithMessage, OpVectorShuffleLiterals) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr(
+      HasSubstr(make_message(
           "Component index 8 is out of bounds for combined (Vector1 + Vector2) "
-          "size of 5."));
+          "size of 5.")));
 }
 
 // TODO: OpCompositeConstruct
@@ -4866,7 +5028,7 @@ TEST_F(ValidateIdWithMessage, OpVectorShuffleLiterals) {
 // TODO: OpSelectionMerge
 // TODO: OpBranch
 
-TEST_F(ValidateIdWithMessage, OpPhiNotAType) {
+TEST_P(ValidateIdWithMessage, OpPhiNotAType) {
   std::string spirv = kOpenCLMemoryModel32 + R"(
 %2 = OpTypeBool
 %3 = OpConstantTrue %2
@@ -4883,11 +5045,12 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID '3[%true]' is not a type "
-                                               "id"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message("ID '3[%true]' is not a type "
+                                     "id")));
 }
 
-TEST_F(ValidateIdWithMessage, OpPhiSamePredecessor) {
+TEST_P(ValidateIdWithMessage, OpPhiSamePredecessor) {
   std::string spirv = kOpenCLMemoryModel32 + R"(
 %2 = OpTypeBool
 %3 = OpConstantTrue %2
@@ -4906,7 +5069,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpPhiOddArgumentNumber) {
+TEST_P(ValidateIdWithMessage, OpPhiOddArgumentNumber) {
   std::string spirv = kOpenCLMemoryModel32 + R"(
 %2 = OpTypeBool
 %3 = OpConstantTrue %2
@@ -4923,12 +5086,13 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpPhi does not have an equal number of incoming "
-                        "values and basic blocks."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("OpPhi does not have an equal number of incoming "
+                             "values and basic blocks.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpPhiTooFewPredecessors) {
+TEST_P(ValidateIdWithMessage, OpPhiTooFewPredecessors) {
   std::string spirv = kOpenCLMemoryModel32 + R"(
 %2 = OpTypeBool
 %3 = OpConstantTrue %2
@@ -4946,11 +5110,12 @@ OpFunctionEnd
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpPhi's number of incoming blocks (0) does not match "
-                        "block's predecessor count (1)."));
+              HasSubstr(make_message(
+                  "OpPhi's number of incoming blocks (0) does not match "
+                  "block's predecessor count (1).")));
 }
 
-TEST_F(ValidateIdWithMessage, OpPhiTooManyPredecessors) {
+TEST_P(ValidateIdWithMessage, OpPhiTooManyPredecessors) {
   std::string spirv = kOpenCLMemoryModel32 + R"(
 %2 = OpTypeBool
 %3 = OpConstantTrue %2
@@ -4970,11 +5135,12 @@ OpFunctionEnd
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpPhi's number of incoming blocks (2) does not match "
-                        "block's predecessor count (1)."));
+              HasSubstr(make_message(
+                  "OpPhi's number of incoming blocks (2) does not match "
+                  "block's predecessor count (1).")));
 }
 
-TEST_F(ValidateIdWithMessage, OpPhiMismatchedTypes) {
+TEST_P(ValidateIdWithMessage, OpPhiMismatchedTypes) {
   std::string spirv = kOpenCLMemoryModel32 + R"(
 %2 = OpTypeBool
 %3 = OpConstantTrue %2
@@ -4996,12 +5162,13 @@ OpFunctionEnd
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpPhi's result type <id> '2[%bool]' does not match "
-                        "incoming value <id> '6[%uint_0]' type <id> "
-                        "'5[%uint]'."));
+              HasSubstr(make_message(
+                  "OpPhi's result type <id> '2[%bool]' does not match "
+                  "incoming value <id> '6[%uint_0]' type <id> "
+                  "'5[%uint]'.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpPhiPredecessorNotABlock) {
+TEST_P(ValidateIdWithMessage, OpPhiPredecessorNotABlock) {
   std::string spirv = kOpenCLMemoryModel32 + R"(
 %2 = OpTypeBool
 %3 = OpConstantTrue %2
@@ -5022,13 +5189,13 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpPhi's incoming basic block <id> '3[%true]' is not an "
-                "OpLabel."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "OpPhi's incoming basic block <id> '3[%true]' is not an "
+                  "OpLabel.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpPhiNotAPredecessor) {
+TEST_P(ValidateIdWithMessage, OpPhiNotAPredecessor) {
   std::string spirv = kOpenCLMemoryModel32 + R"(
 %2 = OpTypeBool
 %3 = OpConstantTrue %2
@@ -5050,11 +5217,12 @@ OpFunctionEnd
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpPhi's incoming basic block <id> '9[%9]' is not a "
-                        "predecessor of <id> '8[%8]'."));
+              HasSubstr(make_message(
+                  "OpPhi's incoming basic block <id> '9[%9]' is not a "
+                  "predecessor of <id> '8[%8]'.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpBranchConditionalGood) {
+TEST_P(ValidateIdWithMessage, OpBranchConditionalGood) {
   std::string spirv = BranchConditionalSetup + R"(
     %branch_cond = OpINotEqual %bool %i0 %i1
                    OpSelectionMerge %end None
@@ -5065,7 +5233,7 @@ TEST_F(ValidateIdWithMessage, OpBranchConditionalGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateAndRetrieveValidationState());
 }
 
-TEST_F(ValidateIdWithMessage, OpBranchConditionalWithWeightsGood) {
+TEST_P(ValidateIdWithMessage, OpBranchConditionalWithWeightsGood) {
   std::string spirv = BranchConditionalSetup + R"(
     %branch_cond = OpINotEqual %bool %i0 %i1
                    OpSelectionMerge %end None
@@ -5076,7 +5244,7 @@ TEST_F(ValidateIdWithMessage, OpBranchConditionalWithWeightsGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateAndRetrieveValidationState());
 }
 
-TEST_F(ValidateIdWithMessage, OpBranchConditional_CondIsScalarInt) {
+TEST_P(ValidateIdWithMessage, OpBranchConditional_CondIsScalarInt) {
   std::string spirv = BranchConditionalSetup + R"(
                    OpSelectionMerge %end None
                    OpBranchConditional %i0 %target_t %target_f
@@ -5086,11 +5254,11 @@ TEST_F(ValidateIdWithMessage, OpBranchConditional_CondIsScalarInt) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr(
-          "Condition operand for OpBranchConditional must be of boolean type"));
+      HasSubstr(make_message("Condition operand for OpBranchConditional must "
+                             "be of boolean type")));
 }
 
-TEST_F(ValidateIdWithMessage, OpBranchConditional_TrueTargetIsNotLabel) {
+TEST_P(ValidateIdWithMessage, OpBranchConditional_TrueTargetIsNotLabel) {
   std::string spirv = BranchConditionalSetup + R"(
                    OpSelectionMerge %end None
                    OpBranchConditional %true %i0 %target_f
@@ -5099,11 +5267,12 @@ TEST_F(ValidateIdWithMessage, OpBranchConditional_TrueTargetIsNotLabel) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("The 'True Label' operand for OpBranchConditional must "
-                        "be the ID of an OpLabel instruction"));
+              HasSubstr(make_message(
+                  "The 'True Label' operand for OpBranchConditional must "
+                  "be the ID of an OpLabel instruction")));
 }
 
-TEST_F(ValidateIdWithMessage, OpBranchConditional_FalseTargetIsNotLabel) {
+TEST_P(ValidateIdWithMessage, OpBranchConditional_FalseTargetIsNotLabel) {
   std::string spirv = BranchConditionalSetup + R"(
                    OpSelectionMerge %end None
                    OpBranchConditional %true %target_t %i0
@@ -5112,11 +5281,12 @@ TEST_F(ValidateIdWithMessage, OpBranchConditional_FalseTargetIsNotLabel) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("The 'False Label' operand for OpBranchConditional "
-                        "must be the ID of an OpLabel instruction"));
+              HasSubstr(make_message(
+                  "The 'False Label' operand for OpBranchConditional "
+                  "must be the ID of an OpLabel instruction")));
 }
 
-TEST_F(ValidateIdWithMessage, OpBranchConditional_NotEnoughWeights) {
+TEST_P(ValidateIdWithMessage, OpBranchConditional_NotEnoughWeights) {
   std::string spirv = BranchConditionalSetup + R"(
     %branch_cond = OpINotEqual %bool %i0 %i1
                    OpSelectionMerge %end None
@@ -5125,12 +5295,12 @@ TEST_F(ValidateIdWithMessage, OpBranchConditional_NotEnoughWeights) {
 
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpBranchConditional requires either 3 or 5 parameters"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "OpBranchConditional requires either 3 or 5 parameters")));
 }
 
-TEST_F(ValidateIdWithMessage, OpBranchConditional_TooManyWeights) {
+TEST_P(ValidateIdWithMessage, OpBranchConditional_TooManyWeights) {
   std::string spirv = BranchConditionalSetup + R"(
     %branch_cond = OpINotEqual %bool %i0 %i1
                    OpSelectionMerge %end None
@@ -5139,25 +5309,26 @@ TEST_F(ValidateIdWithMessage, OpBranchConditional_TooManyWeights) {
 
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpBranchConditional requires either 3 or 5 parameters"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "OpBranchConditional requires either 3 or 5 parameters")));
 }
 
-TEST_F(ValidateIdWithMessage, OpBranchConditional_ConditionIsAType) {
+TEST_P(ValidateIdWithMessage, OpBranchConditional_ConditionIsAType) {
   std::string spirv = BranchConditionalSetup + R"(
 OpBranchConditional %bool %target_t %target_f
 )" + BranchConditionalTail;
 
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand '3[%bool]' cannot be a "
-                                               "type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message("Operand '3[%bool]' cannot be a "
+                                     "type")));
 }
 
 // TODO: OpSwitch
 
-TEST_F(ValidateIdWithMessage, OpReturnValueConstantGood) {
+TEST_P(ValidateIdWithMessage, OpReturnValueConstantGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -5171,7 +5342,7 @@ TEST_F(ValidateIdWithMessage, OpReturnValueConstantGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpReturnValueVariableGood) {
+TEST_P(ValidateIdWithMessage, OpReturnValueVariableGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0 ;10
@@ -5188,7 +5359,7 @@ TEST_F(ValidateIdWithMessage, OpReturnValueVariableGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpReturnValueExpressionGood) {
+TEST_P(ValidateIdWithMessage, OpReturnValueExpressionGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -5203,7 +5374,7 @@ TEST_F(ValidateIdWithMessage, OpReturnValueExpressionGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpReturnValueIsType) {
+TEST_P(ValidateIdWithMessage, OpReturnValueIsType) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -5214,11 +5385,12 @@ TEST_F(ValidateIdWithMessage, OpReturnValueIsType) {
      OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Operand '1[%void]' cannot be a "
-                                               "type"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message("Operand '1[%void]' cannot be a "
+                                     "type")));
 }
 
-TEST_F(ValidateIdWithMessage, OpReturnValueIsLabel) {
+TEST_P(ValidateIdWithMessage, OpReturnValueIsLabel) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -5230,10 +5402,10 @@ TEST_F(ValidateIdWithMessage, OpReturnValueIsLabel) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand '5[%5]' requires a type"));
+              HasSubstr(make_message("Operand '5[%5]' requires a type")));
 }
 
-TEST_F(ValidateIdWithMessage, OpReturnValueIsVoid) {
+TEST_P(ValidateIdWithMessage, OpReturnValueIsVoid) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -5245,13 +5417,13 @@ TEST_F(ValidateIdWithMessage, OpReturnValueIsVoid) {
      OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpReturnValue value's type <id> '1[%void]' is missing or "
-                "void."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "OpReturnValue value's type <id> '1[%void]' is missing or "
+                  "void.")));
 }
 
-TEST_F(ValidateIdWithMessage, OpReturnValueIsVariableInPhysical) {
+TEST_P(ValidateIdWithMessage, OpReturnValueIsVariableInPhysical) {
   // It's valid to return a pointer in a physical addressing model.
   std::string spirv = kOpCapabilitySetup + R"(
      OpMemoryModel Physical32 OpenCL
@@ -5268,7 +5440,7 @@ TEST_F(ValidateIdWithMessage, OpReturnValueIsVariableInPhysical) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpReturnValueIsVariableInLogical) {
+TEST_P(ValidateIdWithMessage, OpReturnValueIsVariableInLogical) {
   // It's invalid to return a pointer in a physical addressing model.
   std::string spirv = kOpCapabilitySetup + R"(
      OpMemoryModel Logical GLSL450
@@ -5283,15 +5455,16 @@ TEST_F(ValidateIdWithMessage, OpReturnValueIsVariableInLogical) {
      OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpReturnValue value's type <id> "
-                        "'3[%_ptr_Function_uint]' is a pointer, which is "
-                        "invalid in the Logical addressing model."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("OpReturnValue value's type <id> "
+                             "'3[%_ptr_Function_uint]' is a pointer, which is "
+                             "invalid in the Logical addressing model.")));
 }
 
 // With the VariablePointer Capability, the return value of a function is
 // allowed to be a pointer.
-TEST_F(ValidateIdWithMessage, OpReturnValueVarPtrGood) {
+TEST_P(ValidateIdWithMessage, OpReturnValueVarPtrGood) {
   std::ostringstream spirv;
   createVariablePointerSpirvProgram(&spirv,
                                     "" /* Instructions to add to "main" */,
@@ -5305,7 +5478,7 @@ TEST_F(ValidateIdWithMessage, OpReturnValueVarPtrGood) {
 // *not* allowed to be a pointer.
 // Disabled since using OpSelect with pointers without VariablePointers will
 // fail LogicalsPass.
-TEST_F(ValidateIdWithMessage, DISABLED_OpReturnValueVarPtrBad) {
+TEST_P(ValidateIdWithMessage, DISABLED_OpReturnValueVarPtrBad) {
   std::ostringstream spirv;
   createVariablePointerSpirvProgram(&spirv,
                                     "" /* Instructions to add to "main" */,
@@ -5314,13 +5487,14 @@ TEST_F(ValidateIdWithMessage, DISABLED_OpReturnValueVarPtrBad) {
   CompileSuccessfully(spirv.str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("OpReturnValue value's type <id> '7' is a pointer, "
-                        "which is invalid in the Logical addressing model."));
+              HasSubstr(make_message(
+                  "OpReturnValue value's type <id> '7' is a pointer, "
+                  "which is invalid in the Logical addressing model.")));
 }
 
 // TODO: enable when this bug is fixed:
 // https://cvs.khronos.org/bugzilla/show_bug.cgi?id=15404
-TEST_F(ValidateIdWithMessage, DISABLED_OpReturnValueIsFunction) {
+TEST_P(ValidateIdWithMessage, DISABLED_OpReturnValueIsFunction) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeInt 32 0
@@ -5333,17 +5507,18 @@ TEST_F(ValidateIdWithMessage, DISABLED_OpReturnValueIsFunction) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, UndefinedTypeId) {
+TEST_P(ValidateIdWithMessage, UndefinedTypeId) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %s = OpTypeStruct %i32
 )";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand '2[%2]' requires a previous definition"));
+              HasSubstr(make_message(
+                  "Operand '2[%2]' requires a previous definition")));
 }
 
-TEST_F(ValidateIdWithMessage, UndefinedIdScope) {
+TEST_P(ValidateIdWithMessage, UndefinedIdScope) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %u32    = OpTypeInt 32 0
 %memsem = OpConstant %u32 0
@@ -5357,11 +5532,12 @@ TEST_F(ValidateIdWithMessage, UndefinedIdScope) {
 )";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID '7[%7]' has not been "
-                                               "defined"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message("ID '7[%7]' has not been "
+                                     "defined")));
 }
 
-TEST_F(ValidateIdWithMessage, UndefinedIdMemSem) {
+TEST_P(ValidateIdWithMessage, UndefinedIdMemSem) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %u32    = OpTypeInt 32 0
 %scope  = OpConstant %u32 0
@@ -5375,11 +5551,12 @@ TEST_F(ValidateIdWithMessage, UndefinedIdMemSem) {
 )";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID '7[%7]' has not been "
-                                               "defined"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message("ID '7[%7]' has not been "
+                                     "defined")));
 }
 
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        KernelOpEntryPointAndOpInBoundsPtrAccessChainGood) {
   std::string spirv = kOpenCLMemoryModel32 + R"(
       OpEntryPoint Kernel %2 "simple_kernel"
@@ -5412,7 +5589,7 @@ TEST_F(ValidateIdWithMessage,
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpPtrAccessChainGood) {
+TEST_P(ValidateIdWithMessage, OpPtrAccessChainGood) {
   std::string spirv = kOpenCLMemoryModel64 + R"(
       OpEntryPoint Kernel %2 "another_kernel"
       OpSource OpenCL_C 200000
@@ -5447,7 +5624,7 @@ TEST_F(ValidateIdWithMessage, OpPtrAccessChainGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, StgBufOpPtrAccessChainGood) {
+TEST_P(ValidateIdWithMessage, StgBufOpPtrAccessChainGood) {
   std::string spirv = R"(
      OpCapability Shader
      OpCapability Linkage
@@ -5474,7 +5651,7 @@ TEST_F(ValidateIdWithMessage, StgBufOpPtrAccessChainGood) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateIdWithMessage, OpLoadBitcastPointerGood) {
+TEST_P(ValidateIdWithMessage, OpLoadBitcastPointerGood) {
   std::string spirv = kOpenCLMemoryModel64 + R"(
 %2  = OpTypeVoid
 %3  = OpTypeInt 32 0
@@ -5492,7 +5669,7 @@ TEST_F(ValidateIdWithMessage, OpLoadBitcastPointerGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpLoadBitcastNonPointerBad) {
+TEST_P(ValidateIdWithMessage, OpLoadBitcastNonPointerBad) {
   std::string spirv = kOpenCLMemoryModel64 + R"(
 %2  = OpTypeVoid
 %3  = OpTypeInt 32 0
@@ -5509,12 +5686,12 @@ TEST_F(ValidateIdWithMessage, OpLoadBitcastNonPointerBad) {
       OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpLoad type for pointer <id> '11[%11]' is not a pointer "
-                "type."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "OpLoad type for pointer <id> '11[%11]' is not a pointer "
+                  "type.")));
 }
-TEST_F(ValidateIdWithMessage, OpStoreBitcastPointerGood) {
+TEST_P(ValidateIdWithMessage, OpStoreBitcastPointerGood) {
   std::string spirv = kOpenCLMemoryModel64 + R"(
 %2  = OpTypeVoid
 %3  = OpTypeInt 32 0
@@ -5533,7 +5710,7 @@ TEST_F(ValidateIdWithMessage, OpStoreBitcastPointerGood) {
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
-TEST_F(ValidateIdWithMessage, OpStoreBitcastNonPointerBad) {
+TEST_P(ValidateIdWithMessage, OpStoreBitcastNonPointerBad) {
   std::string spirv = kOpenCLMemoryModel64 + R"(
 %2  = OpTypeVoid
 %3  = OpTypeInt 32 0
@@ -5550,15 +5727,15 @@ TEST_F(ValidateIdWithMessage, OpStoreBitcastNonPointerBad) {
       OpFunctionEnd)";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("OpStore type for pointer <id> '11[%11]' is not a pointer "
-                "type."));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "OpStore type for pointer <id> '11[%11]' is not a pointer "
+                  "type.")));
 }
 
 // Result <id> resulting from an instruction within a function may not be used
 // outside that function.
-TEST_F(ValidateIdWithMessage, ResultIdUsedOutsideOfFunctionBad) {
+TEST_P(ValidateIdWithMessage, ResultIdUsedOutsideOfFunctionBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
@@ -5578,12 +5755,12 @@ OpFunctionEnd
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("ID '7[%7]' defined in block '6[%6]' does not dominate "
-                        "its use in block "
-                        "'9[%9]'"));
+              HasSubstr(make_message("ID '7[%7]' defined in block '6[%6]' does "
+                                     "not dominate its use in block "
+                                     "'9[%9]'")));
 }
 
-TEST_F(ValidateIdWithMessage, SpecIdTargetNotSpecializationConstant) {
+TEST_P(ValidateIdWithMessage, SpecIdTargetNotSpecializationConstant) {
   std::string spirv = kGLSL450MemoryModel + R"(
 OpDecorate %1 SpecId 200
 %void = OpTypeVoid
@@ -5597,13 +5774,14 @@ OpFunctionEnd
   )";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("SpecId decoration on target <id> "
-                        "'1[%uint_3]' must be a scalar specialization "
-                        "constant"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("SpecId decoration on target <id> "
+                             "'1[%uint_3]' must be a scalar specialization "
+                             "constant")));
 }
 
-TEST_F(ValidateIdWithMessage, SpecIdTargetOpSpecConstantOpBad) {
+TEST_P(ValidateIdWithMessage, SpecIdTargetOpSpecConstantOpBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 OpDecorate %1 SpecId 200
 %void = OpTypeVoid
@@ -5619,12 +5797,13 @@ OpFunctionEnd
   )";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("SpecId decoration on target <id> '1[%1]' "
-                        "must be a scalar specialization constant"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("SpecId decoration on target <id> '1[%1]' "
+                             "must be a scalar specialization constant")));
 }
 
-TEST_F(ValidateIdWithMessage, SpecIdTargetOpSpecConstantCompositeBad) {
+TEST_P(ValidateIdWithMessage, SpecIdTargetOpSpecConstantCompositeBad) {
   std::string spirv = kGLSL450MemoryModel + R"(
 OpDecorate %1 SpecId 200
 %void = OpTypeVoid
@@ -5639,12 +5818,13 @@ OpFunctionEnd
   )";
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("SpecId decoration on target <id> '1[%1]' "
-                        "must be a scalar specialization constant"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("SpecId decoration on target <id> '1[%1]' "
+                             "must be a scalar specialization constant")));
 }
 
-TEST_F(ValidateIdWithMessage, SpecIdTargetGood) {
+TEST_P(ValidateIdWithMessage, SpecIdTargetGood) {
   std::string spirv = kGLSL450MemoryModel + R"(
 OpDecorate %3 SpecId 200
 OpDecorate %4 SpecId 201
@@ -5665,7 +5845,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateAndRetrieveValidationState());
 }
 
-TEST_F(ValidateIdWithMessage, CorrectErrorForShuffle) {
+TEST_P(ValidateIdWithMessage, CorrectErrorForShuffle) {
   std::string spirv = kGLSL450MemoryModel + R"(
    %uint = OpTypeInt 32 0
   %float = OpTypeFloat 32
@@ -5686,13 +5866,13 @@ TEST_F(ValidateIdWithMessage, CorrectErrorForShuffle) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr(
+      HasSubstr(make_message(
           "Component index 4 is out of bounds for combined (Vector1 + Vector2) "
-          "size of 4."));
+          "size of 4.")));
   EXPECT_EQ(25, getErrorPosition().index);
 }
 
-TEST_F(ValidateIdWithMessage, VoidStructMember) {
+TEST_P(ValidateIdWithMessage, VoidStructMember) {
   const std::string spirv = kGLSL450MemoryModel + R"(
 %void = OpTypeVoid
 %struct = OpTypeStruct %void
@@ -5700,11 +5880,12 @@ TEST_F(ValidateIdWithMessage, VoidStructMember) {
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Structures cannot contain a void type."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("Structures cannot contain a void type.")));
 }
 
-TEST_F(ValidateIdWithMessage, TypeFunctionBadUse) {
+TEST_P(ValidateIdWithMessage, TypeFunctionBadUse) {
   std::string spirv = kGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
@@ -5717,10 +5898,11 @@ TEST_F(ValidateIdWithMessage, TypeFunctionBadUse) {
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Invalid use of function type result id '2[%2]'."));
+              HasSubstr(make_message(
+                  "Invalid use of function type result id '2[%2]'.")));
 }
 
-TEST_F(ValidateIdWithMessage, BadTypeId) {
+TEST_P(ValidateIdWithMessage, BadTypeId) {
   std::string spirv = kGLSL450MemoryModel + R"(
           %1 = OpTypeVoid
           %2 = OpTypeFunction %1
@@ -5735,11 +5917,12 @@ TEST_F(ValidateIdWithMessage, BadTypeId) {
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("ID '4[%float_0]' is not a type "
-                                               "id"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message("ID '4[%float_0]' is not a type "
+                                     "id")));
 }
 
-TEST_F(ValidateIdWithMessage, VulkanMemoryModelLoadMakePointerVisibleGood) {
+TEST_P(ValidateIdWithMessage, VulkanMemoryModelLoadMakePointerVisibleGood) {
   std::string spirv = R"(
 OpCapability Shader
 OpCapability VulkanMemoryModelKHR
@@ -5763,7 +5946,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
 }
 
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        VulkanMemoryModelLoadMakePointerVisibleMissingNonPrivatePointer) {
   std::string spirv = R"(
 OpCapability Shader
@@ -5786,12 +5969,13 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("NonPrivatePointerKHR must be specified if "
-                        "MakePointerVisibleKHR is specified."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("NonPrivatePointerKHR must be specified if "
+                             "MakePointerVisibleKHR is specified.")));
 }
 
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        VulkanMemoryModelLoadNonPrivatePointerBadStorageClass) {
   std::string spirv = R"(
 OpCapability Shader
@@ -5815,12 +5999,13 @@ OpFunctionEnd
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("NonPrivatePointerKHR requires a pointer in Uniform, "
-                        "Workgroup, CrossWorkgroup, Generic, Image or "
-                        "StorageBuffer storage classes."));
+              HasSubstr(make_message(
+                  "NonPrivatePointerKHR requires a pointer in Uniform, "
+                  "Workgroup, CrossWorkgroup, Generic, Image or "
+                  "StorageBuffer storage classes.")));
 }
 
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        VulkanMemoryModelLoadMakePointerAvailableCannotBeUsed) {
   std::string spirv = R"(
 OpCapability Shader
@@ -5844,10 +6029,11 @@ OpFunctionEnd
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("MakePointerAvailableKHR cannot be used with OpLoad"));
+              HasSubstr(make_message(
+                  "MakePointerAvailableKHR cannot be used with OpLoad")));
 }
 
-TEST_F(ValidateIdWithMessage, VulkanMemoryModelStoreMakePointerAvailableGood) {
+TEST_P(ValidateIdWithMessage, VulkanMemoryModelStoreMakePointerAvailableGood) {
   std::string spirv = R"(
 OpCapability Shader
 OpCapability VulkanMemoryModelKHR
@@ -5871,7 +6057,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
 }
 
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        VulkanMemoryModelStoreMakePointerAvailableMissingNonPrivatePointer) {
   std::string spirv = R"(
 OpCapability Shader
@@ -5894,12 +6080,13 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("NonPrivatePointerKHR must be specified if "
-                        "MakePointerAvailableKHR is specified."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("NonPrivatePointerKHR must be specified if "
+                             "MakePointerAvailableKHR is specified.")));
 }
 
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        VulkanMemoryModelStoreNonPrivatePointerBadStorageClass) {
   std::string spirv = R"(
 OpCapability Shader
@@ -5923,12 +6110,13 @@ OpFunctionEnd
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("NonPrivatePointerKHR requires a pointer in Uniform, "
-                        "Workgroup, CrossWorkgroup, Generic, Image or "
-                        "StorageBuffer storage classes."));
+              HasSubstr(make_message(
+                  "NonPrivatePointerKHR requires a pointer in Uniform, "
+                  "Workgroup, CrossWorkgroup, Generic, Image or "
+                  "StorageBuffer storage classes.")));
 }
 
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        VulkanMemoryModelStoreMakePointerVisibleCannotBeUsed) {
   std::string spirv = R"(
 OpCapability Shader
@@ -5952,10 +6140,11 @@ OpFunctionEnd
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("MakePointerVisibleKHR cannot be used with OpStore."));
+              HasSubstr(make_message(
+                  "MakePointerVisibleKHR cannot be used with OpStore.")));
 }
 
-TEST_F(ValidateIdWithMessage, VulkanMemoryModelCopyMemoryAvailable) {
+TEST_P(ValidateIdWithMessage, VulkanMemoryModelCopyMemoryAvailable) {
   std::string spirv = R"(
 OpCapability Shader
 OpCapability Linkage
@@ -5982,7 +6171,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
 }
 
-TEST_F(ValidateIdWithMessage, VulkanMemoryModelCopyMemoryVisible) {
+TEST_P(ValidateIdWithMessage, VulkanMemoryModelCopyMemoryVisible) {
   std::string spirv = R"(
 OpCapability Shader
 OpCapability Linkage
@@ -6009,7 +6198,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
 }
 
-TEST_F(ValidateIdWithMessage, VulkanMemoryModelCopyMemoryAvailableAndVisible) {
+TEST_P(ValidateIdWithMessage, VulkanMemoryModelCopyMemoryAvailableAndVisible) {
   std::string spirv = R"(
 OpCapability Shader
 OpCapability Linkage
@@ -6036,7 +6225,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
 }
 
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        VulkanMemoryModelCopyMemoryAvailableMissingNonPrivatePointer) {
   std::string spirv = R"(
 OpCapability Shader
@@ -6062,12 +6251,13 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("NonPrivatePointerKHR must be specified if "
-                        "MakePointerAvailableKHR is specified."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("NonPrivatePointerKHR must be specified if "
+                             "MakePointerAvailableKHR is specified.")));
 }
 
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        VulkanMemoryModelCopyMemoryVisibleMissingNonPrivatePointer) {
   std::string spirv = R"(
 OpCapability Shader
@@ -6093,12 +6283,13 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("NonPrivatePointerKHR must be specified if "
-                        "MakePointerVisibleKHR is specified."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("NonPrivatePointerKHR must be specified if "
+                             "MakePointerVisibleKHR is specified.")));
 }
 
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        VulkanMemoryModelCopyMemoryAvailableBadStorageClass) {
   std::string spirv = R"(
 OpCapability Shader
@@ -6125,12 +6316,13 @@ OpFunctionEnd
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("NonPrivatePointerKHR requires a pointer in Uniform, "
-                        "Workgroup, CrossWorkgroup, Generic, Image or "
-                        "StorageBuffer storage classes."));
+              HasSubstr(make_message(
+                  "NonPrivatePointerKHR requires a pointer in Uniform, "
+                  "Workgroup, CrossWorkgroup, Generic, Image or "
+                  "StorageBuffer storage classes.")));
 }
 
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        VulkanMemoryModelCopyMemoryVisibleBadStorageClass) {
   std::string spirv = R"(
 OpCapability Shader
@@ -6157,12 +6349,13 @@ OpFunctionEnd
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("NonPrivatePointerKHR requires a pointer in Uniform, "
-                        "Workgroup, CrossWorkgroup, Generic, Image or "
-                        "StorageBuffer storage classes."));
+              HasSubstr(make_message(
+                  "NonPrivatePointerKHR requires a pointer in Uniform, "
+                  "Workgroup, CrossWorkgroup, Generic, Image or "
+                  "StorageBuffer storage classes.")));
 }
 
-TEST_F(ValidateIdWithMessage, VulkanMemoryModelCopyMemorySizedAvailable) {
+TEST_P(ValidateIdWithMessage, VulkanMemoryModelCopyMemorySizedAvailable) {
   std::string spirv = R"(
 OpCapability Shader
 OpCapability Linkage
@@ -6190,7 +6383,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
 }
 
-TEST_F(ValidateIdWithMessage, VulkanMemoryModelCopyMemorySizedVisible) {
+TEST_P(ValidateIdWithMessage, VulkanMemoryModelCopyMemorySizedVisible) {
   std::string spirv = R"(
 OpCapability Shader
 OpCapability Linkage
@@ -6218,7 +6411,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
 }
 
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        VulkanMemoryModelCopyMemorySizedAvailableAndVisible) {
   std::string spirv = R"(
 OpCapability Shader
@@ -6247,7 +6440,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
 }
 
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        VulkanMemoryModelCopyMemorySizedAvailableMissingNonPrivatePointer) {
   std::string spirv = R"(
 OpCapability Shader
@@ -6274,12 +6467,13 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("NonPrivatePointerKHR must be specified if "
-                        "MakePointerAvailableKHR is specified."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("NonPrivatePointerKHR must be specified if "
+                             "MakePointerAvailableKHR is specified.")));
 }
 
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        VulkanMemoryModelCopyMemorySizedVisibleMissingNonPrivatePointer) {
   std::string spirv = R"(
 OpCapability Shader
@@ -6306,12 +6500,13 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("NonPrivatePointerKHR must be specified if "
-                        "MakePointerVisibleKHR is specified."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(make_message("NonPrivatePointerKHR must be specified if "
+                             "MakePointerVisibleKHR is specified.")));
 }
 
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        VulkanMemoryModelCopyMemorySizedAvailableBadStorageClass) {
   std::string spirv = R"(
 OpCapability Shader
@@ -6339,12 +6534,13 @@ OpFunctionEnd
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("NonPrivatePointerKHR requires a pointer in Uniform, "
-                        "Workgroup, CrossWorkgroup, Generic, Image or "
-                        "StorageBuffer storage classes."));
+              HasSubstr(make_message(
+                  "NonPrivatePointerKHR requires a pointer in Uniform, "
+                  "Workgroup, CrossWorkgroup, Generic, Image or "
+                  "StorageBuffer storage classes.")));
 }
 
-TEST_F(ValidateIdWithMessage,
+TEST_P(ValidateIdWithMessage,
        VulkanMemoryModelCopyMemorySizedVisibleBadStorageClass) {
   std::string spirv = R"(
 OpCapability Shader
@@ -6372,12 +6568,13 @@ OpFunctionEnd
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("NonPrivatePointerKHR requires a pointer in Uniform, "
-                        "Workgroup, CrossWorkgroup, Generic, Image or "
-                        "StorageBuffer storage classes."));
+              HasSubstr(make_message(
+                  "NonPrivatePointerKHR requires a pointer in Uniform, "
+                  "Workgroup, CrossWorkgroup, Generic, Image or "
+                  "StorageBuffer storage classes.")));
 }
 
-TEST_F(ValidateIdWithMessage, IdDefInUnreachableBlock1) {
+TEST_P(ValidateIdWithMessage, IdDefInUnreachableBlock1) {
   const std::string spirv = kNoKernelGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
@@ -6398,13 +6595,13 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("ID '8[%8]' defined in block '7[%7]' does not dominate its "
-                "use in block '10[%10]'\n  %10 = OpLabel"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "ID '8[%8]' defined in block '7[%7]' does not dominate its "
+                  "use in block '10[%10]'\n  %10 = OpLabel")));
 }
 
-TEST_F(ValidateIdWithMessage, IdDefInUnreachableBlock2) {
+TEST_P(ValidateIdWithMessage, IdDefInUnreachableBlock2) {
   const std::string spirv = kNoKernelGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
@@ -6425,13 +6622,13 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("ID '8[%8]' defined in block '7[%7]' does not dominate its "
-                "use in block '10[%10]'\n  %10 = OpLabel"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "ID '8[%8]' defined in block '7[%7]' does not dominate its "
+                  "use in block '10[%10]'\n  %10 = OpLabel")));
 }
 
-TEST_F(ValidateIdWithMessage, IdDefInUnreachableBlock3) {
+TEST_P(ValidateIdWithMessage, IdDefInUnreachableBlock3) {
   const std::string spirv = kNoKernelGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
@@ -6452,13 +6649,13 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("ID '8[%8]' defined in block '7[%7]' does not dominate its "
-                "use in block '10[%10]'\n  %10 = OpLabel"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "ID '8[%8]' defined in block '7[%7]' does not dominate its "
+                  "use in block '10[%10]'\n  %10 = OpLabel")));
 }
 
-TEST_F(ValidateIdWithMessage, IdDefInUnreachableBlock4) {
+TEST_P(ValidateIdWithMessage, IdDefInUnreachableBlock4) {
   const std::string spirv = kNoKernelGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
@@ -6478,7 +6675,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
 }
 
-TEST_F(ValidateIdWithMessage, IdDefInUnreachableBlock5) {
+TEST_P(ValidateIdWithMessage, IdDefInUnreachableBlock5) {
   const std::string spirv = kNoKernelGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
@@ -6500,7 +6697,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
 }
 
-TEST_F(ValidateIdWithMessage, IdDefInUnreachableBlock6) {
+TEST_P(ValidateIdWithMessage, IdDefInUnreachableBlock6) {
   const std::string spirv = kNoKernelGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
@@ -6520,13 +6717,13 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("ID '9[%9]' defined in block '8[%8]' does not dominate its "
-                "use in block '7[%7]'\n  %7 = OpLabel"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "ID '9[%9]' defined in block '8[%8]' does not dominate its "
+                  "use in block '7[%7]'\n  %7 = OpLabel")));
 }
 
-TEST_F(ValidateIdWithMessage, ReachableDefUnreachableUse) {
+TEST_P(ValidateIdWithMessage, ReachableDefUnreachableUse) {
   const std::string spirv = kNoKernelGLSL450MemoryModel + R"(
 %1 = OpTypeVoid
 %2 = OpTypeFunction %1
@@ -6546,7 +6743,7 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
 }
 
-TEST_F(ValidateIdWithMessage, UnreachableDefUsedInPhi) {
+TEST_P(ValidateIdWithMessage, UnreachableDefUsedInPhi) {
   const std::string spirv = kNoKernelGLSL450MemoryModel + R"(
        %void = OpTypeVoid
           %3 = OpTypeFunction %void
@@ -6574,13 +6771,13 @@ TEST_F(ValidateIdWithMessage, UnreachableDefUsedInPhi) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr(
+      HasSubstr(make_message(
           "In OpPhi instruction '14[%14]', ID '13[%13]' definition does not "
           "dominate its parent '7[%7]'\n  %14 = OpPhi %float %11 %10 %13 "
-          "%7"));
+          "%7")));
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeForwardPointerNotAPointerType) {
+TEST_P(ValidateIdWithMessage, OpTypeForwardPointerNotAPointerType) {
   std::string spirv = R"(
      OpCapability GenericPointer
      OpCapability VariablePointersStorageBuffer
@@ -6599,11 +6796,12 @@ TEST_F(ValidateIdWithMessage, OpTypeForwardPointerNotAPointerType) {
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Pointer type in OpTypeForwardPointer is not a pointer "
-                        "type.\n  OpTypeForwardPointer %void CrossWorkgroup"));
+              HasSubstr(make_message(
+                  "Pointer type in OpTypeForwardPointer is not a pointer "
+                  "type.\n  OpTypeForwardPointer %void CrossWorkgroup")));
 }
 
-TEST_F(ValidateIdWithMessage, OpTypeForwardPointerWrongStorageClass) {
+TEST_P(ValidateIdWithMessage, OpTypeForwardPointerWrongStorageClass) {
   std::string spirv = R"(
      OpCapability GenericPointer
      OpCapability VariablePointersStorageBuffer
@@ -6623,14 +6821,14 @@ TEST_F(ValidateIdWithMessage, OpTypeForwardPointerWrongStorageClass) {
 
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Storage class in OpTypeForwardPointer does not match the "
-                "pointer definition.\n  OpTypeForwardPointer "
-                "%_ptr_Function_int CrossWorkgroup"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr(make_message(
+                  "Storage class in OpTypeForwardPointer does not match the "
+                  "pointer definition.\n  OpTypeForwardPointer "
+                  "%_ptr_Function_int CrossWorkgroup")));
 }
 
-TEST_F(ValidateIdWithMessage, MissingForwardPointer) {
+TEST_P(ValidateIdWithMessage, MissingForwardPointer) {
   const std::string spirv = R"(
                OpCapability Linkage
                OpCapability Shader
@@ -6644,11 +6842,11 @@ TEST_F(ValidateIdWithMessage, MissingForwardPointer) {
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Operand '3[%_ptr_Uniform__struct_2]' requires a "
-                        "previous definition"));
+              HasSubstr(make_message("Operand '3[%_ptr_Uniform__struct_2]' "
+                                     "requires a previous definition")));
 }
 
-TEST_F(ValidateIdWithMessage, NVBindlessSamplerInStruct) {
+TEST_P(ValidateIdWithMessage, NVBindlessSamplerInStruct) {
   std::string spirv = R"(
             OpCapability Shader
             OpCapability BindlessTextureNV
@@ -6676,6 +6874,8 @@ TEST_F(ValidateIdWithMessage, NVBindlessSamplerInStruct) {
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
 }
+
+INSTANTIATE_TEST_SUITE_P(, ValidateIdWithMessage, ::testing::Bool());
 
 }  // namespace
 }  // namespace val


### PR DESCRIPTION
The always-friendly messages make it harder to debug when the
disassembly is later generated without friendly names.

Additionally, the friendly-name-mapper is slow.  Disabling it improves
performance of an ANGLE test that creates numerous shaders by ~5%.