### PR TITLE
Align git-sync-deps and CMake to use external/spirv-headers by default

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -30,11 +30,7 @@ if (DEFINED SPIRV-Headers_SOURCE_DIR)
   # This allows flexible position of the SPIRV-Headers repo.
   set(SPIRV_HEADER_DIR ${SPIRV-Headers_SOURCE_DIR})
 else()
-  if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/SPIRV-Headers)
-    set(SPIRV_HEADER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/SPIRV-Headers)
-  else()
-    set(SPIRV_HEADER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/spirv-headers)
-  endif()
+  set(SPIRV_HEADER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/spirv-headers)
 endif()
 
 if (IS_DIRECTORY ${SPIRV_HEADER_DIR})


### PR DESCRIPTION
Align git-sync-deps and CMake to use external/SPIRV-Headers by default

This should help with avoiding mistakes such as the one that happened under #4958.

Signed-off-by: Kevin Petit <kevin.petit@arm.com>
Change-Id: I922f02e25c507f3412e0e7a99f525fb617b2d426