### PR TITLE
spirv-val: Add remaining Component decoration validation

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2094,6 +2094,16 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-Location-04918);
     case 4919:
       return VUID_WRAP(VUID-StandaloneSpirv-Location-04919);
+    case 4920:
+      return VUID_WRAP(VUID-StandaloneSpirv-Component-04920);
+    case 4921:
+      return VUID_WRAP(VUID-StandaloneSpirv-Component-04921);
+    case 4922:
+      return VUID_WRAP(VUID-StandaloneSpirv-Component-04922);
+    case 4923:
+      return VUID_WRAP(VUID-StandaloneSpirv-Component-04923);
+    case 4924:
+      return VUID_WRAP(VUID-StandaloneSpirv-Component-04924);
     case 6201:
       return VUID_WRAP(VUID-StandaloneSpirv-Flat-06201);
     case 6202:

--- a/test/val/val_interfaces_test.cpp
+++ b/test/val/val_interfaces_test.cpp
@@ -1456,7 +1456,7 @@ OpDecorate %struct Block
 OpMemberDecorate %struct 0 Location 0
 OpMemberDecorate %struct 0 Component 0
 OpMemberDecorate %struct 1 Location 0
-OpMemberDecorate %struct 1 Component 1
+OpMemberDecorate %struct 1 Component 2
 %void = OpTypeVoid
 %void_fn = OpTypeFunction %void
 %float = OpTypeFloat 32


### PR DESCRIPTION
closes https://github.com/KhronosGroup/SPIRV-Tools/issues/2017

Adds 

VUID-StandaloneSpirv-Component-04920
VUID-StandaloneSpirv-Component-04921
VUID-StandaloneSpirv-Component-04922
VUID-StandaloneSpirv-Component-04923
VUID-StandaloneSpirv-Component-04924