### PR TITLE
spirv-val: Label new Vulkan OpPtrAccessChain VUs

### DIFF
--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -1436,12 +1436,14 @@ spv_result_t ValidatePtrAccessChain(ValidationState_t& _,
     if (base_type_storage_class == SpvStorageClassWorkgroup) {
       if (!_.HasCapability(SpvCapabilityVariablePointers)) {
         return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << _.VkErrorID(7651)
                << "OpPtrAccessChain Base operand pointing to Workgroup "
                   "storage class must use VariablePointers capability";
       }
     } else if (base_type_storage_class == SpvStorageClassStorageBuffer) {
       if (!_.features().variable_pointers) {
         return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << _.VkErrorID(7652)
                << "OpPtrAccessChain Base operand pointing to StorageBuffer "
                   "storage class must use VariablePointers or "
                   "VariablePointersStorageBuffer capability";
@@ -1449,6 +1451,7 @@ spv_result_t ValidatePtrAccessChain(ValidationState_t& _,
     } else if (base_type_storage_class !=
                SpvStorageClassPhysicalStorageBuffer) {
       return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << _.VkErrorID(7650)
              << "OpPtrAccessChain Base operand must point to Workgroup, "
                 "StorageBuffer, or PhysicalStorageBuffer storage class";
     }

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2144,6 +2144,12 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-ExecutionModel-07320);
     case 7290:
       return VUID_WRAP(VUID-StandaloneSpirv-Input-07290);
+    case 7650:
+      return VUID_WRAP(VUID-StandaloneSpirv-Base-07650);
+    case 7651:
+      return VUID_WRAP(VUID-StandaloneSpirv-Base-07651);
+    case 7652:
+      return VUID_WRAP(VUID-StandaloneSpirv-Base-07652);
     default:
       return "";  // unknown id
   }

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -4857,6 +4857,8 @@ TEST_F(ValidateMemory, VulkanPtrAccessChainStorageBufferCapability) {
   CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_2);
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_2));
   EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Base-07652"));
+  EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpPtrAccessChain Base operand pointing to "
                         "StorageBuffer storage class must use VariablePointers "
                         "or VariablePointersStorageBuffer capability"));
@@ -4891,6 +4893,8 @@ TEST_F(ValidateMemory, VulkanPtrAccessChainWorkgroupCapability) {
 
   CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_2);
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Base-07651"));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpPtrAccessChain Base operand pointing to Workgroup "
                         "storage class must use VariablePointers capability"));


### PR DESCRIPTION
follow up from https://github.com/KhronosGroup/SPIRV-Tools/pull/4965#discussion_r1000524643

These were added in the Vulkan 1.2.232 headers