### PR TITLE
spirv-val: Add VUID label for 07703

### DIFF
--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -1703,6 +1703,7 @@ spv_result_t CheckComponentDecoration(ValidationState_t& vstate,
     } else if (bit_width == 64) {
       if (dimension > 2) {
         return vstate.diag(SPV_ERROR_INVALID_ID, &inst)
+               << vstate.VkErrorID(7703)
                << "Component decoration only allowed on 64-bit scalar and "
                   "2-component vector";
       }

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2150,6 +2150,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-Base-07651);
     case 7652:
       return VUID_WRAP(VUID-StandaloneSpirv-Base-07652);
+    case 7703:
+      return VUID_WRAP(VUID-StandaloneSpirv-Component-07703);
     default:
       return "";  // unknown id
   }

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -7194,6 +7194,8 @@ TEST_F(ValidateDecorations, ComponentDecoration64VecWideBadVulkan) {
   CompileSuccessfully(spirv, env);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState(env));
   EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Component-07703"));
+  EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Component decoration only allowed on 64-bit scalar "
                         "and 2-component vector"));
 }


### PR DESCRIPTION
adds `VUID-StandaloneSpirv-Component-07703` label that was added in Vulkan 1.3.233