### PR TITLE
build: move from c++11 to c++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,13 +25,14 @@ include(GNUInstallDirs)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# Require at least C++11
+# Require at least C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
-if(${CMAKE_CXX_STANDARD} LESS 11)
-  message(FATAL_ERROR "SPIRV-Tools requires C++11 or later, but is configured for C++${CMAKE_CXX_STANDARD})")
+if(${CMAKE_CXX_STANDARD} LESS 17)
+  message(FATAL_ERROR "SPIRV-Tools requires C++17 or later, but is configured for C++${CMAKE_CXX_STANDARD})")
 endif()
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 
 option(ENABLE_RTTI "Enables RTTI" OFF)
@@ -189,10 +190,9 @@ function(spvtools_default_compile_options TARGET)
   target_compile_options(${TARGET} PRIVATE ${SPIRV_WARNINGS})
 
   if (${COMPILER_IS_LIKE_GNU})
-    target_compile_options(${TARGET} PRIVATE -std=c++11 -fno-exceptions)
     target_compile_options(${TARGET} PRIVATE
       -Wall -Wextra -Wno-long-long -Wshadow -Wundef -Wconversion
-      -Wno-sign-conversion)
+      -Wno-sign-conversion -fno-exceptions)
 
     if(NOT ENABLE_RTTI)
         add_compile_options(-fno-rtti)

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ On Windows
 - Visual Studio 2019
 - Visual Studio 2022
 
-Note: Visual Studio 2017 has an incomplete c++17 support. We might stop
+Note: Visual Studio 2017 has incomplete c++17 support. We might stop
 testing it soon. Other compilers or later versions may work, but they are not
 tested.
 

--- a/README.md
+++ b/README.md
@@ -438,7 +438,9 @@ On Windows
 - Visual Studio 2019
 - Visual Studio 2022
 
-Other compilers or later versions may work, but they are not tested.
+Note: Visual Studio 2017 has an incomplete c++17 support. We might stop
+testing it soon. Other compilers or later versions may work, but they are not
+tested.
 
 ### CMake options
 
@@ -499,7 +501,7 @@ The script requires Chromium's
 
 ### Usage
 
-The internals of the library use C++11 features, and are exposed via both a C
+The internals of the library use C++17 features, and are exposed via both a C
 and C++ API.
 
 In order to use the library from an application, the include path should point


### PR DESCRIPTION
Moving from cpp 11 to cpp 17 will allow us to use modern features like filesystem support, optional, any, execution policies and improved templates.