### PR TITLE
Split EliminateDeadInputComponents into safe and unsafe versions.

### DIFF
--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -913,6 +913,14 @@ Optimizer::PassToken CreateEliminateDeadInputComponentsPass();
 // shader, then apply EliminateDeadOutputStores to this shader.
 Optimizer::PassToken CreateEliminateDeadOutputComponentsPass();
 
+// Removes unused components from composite input variables. This safe
+// version will not cause interface incompatibilities since it only changes
+// vertex shaders. The current implementation just removes trailing unused
+// components from input structs and input arrays. The pass performs best
+// after maximizing dead code removal. A subsequent dead code elimination
+// pass would be beneficial in removing newly unused component types.
+Optimizer::PassToken CreateEliminateDeadInputComponentsSafePass();
+
 // Analyzes shader and populates |live_locs| and |live_builtins|. Best results
 // will be obtained if shader has all dead code eliminated first. |live_locs|
 // and |live_builtins| are subsequently used when calling

--- a/source/opt/eliminate_dead_input_components_pass.h
+++ b/source/opt/eliminate_dead_input_components_pass.h
@@ -28,13 +28,14 @@ namespace opt {
 // See optimizer.hpp for documentation.
 class EliminateDeadInputComponentsPass : public Pass {
  public:
-  explicit EliminateDeadInputComponentsPass(bool output_instead = false)
-      : output_instead_(output_instead) {}
+  explicit EliminateDeadInputComponentsPass(bool output_instead = false,
+                                            bool vertex_shader_only = true)
+      : output_instead_(output_instead),
+        vertex_shader_only_(vertex_shader_only) {}
 
   const char* name() const override {
     return "eliminate-dead-input-components";
   }
-
   Status Process() override;
 
   // Return the mask of preserved Analyses.
@@ -61,6 +62,9 @@ class EliminateDeadInputComponentsPass : public Pass {
 
   // Process output variables instead
   bool output_instead_;
+
+  // Only process vertex shaders
+  bool vertex_shader_only_;
 };
 
 }  // namespace opt

--- a/source/opt/instrument_pass.cpp
+++ b/source/opt/instrument_pass.cpp
@@ -26,7 +26,6 @@ static const int kInstCommonParamInstIdx = 0;
 static const int kInstCommonParamCnt = 1;
 
 // Indices of operands in SPIR-V instructions
-static const int kEntryPointExecutionModelInIdx = 0;
 static const int kEntryPointFunctionIdInIdx = 1;
 
 }  // anonymous namespace
@@ -1056,22 +1055,7 @@ bool InstrumentPass::InstProcessEntryPointCallTree(InstProcessFunction& pfn) {
   // one model per module. In such cases we will need
   // to clone any functions which are in the call trees of entrypoints
   // with differing execution models.
-  uint32_t ecnt = 0;
-  auto stage = spv::ExecutionModel::Max;
-  for (auto& e : get_module()->entry_points()) {
-    if (ecnt == 0)
-      stage = spv::ExecutionModel(
-          e.GetSingleWordInOperand(kEntryPointExecutionModelInIdx));
-    else if (spv::ExecutionModel(e.GetSingleWordInOperand(
-                 kEntryPointExecutionModelInIdx)) != stage) {
-      if (consumer()) {
-        std::string message = "Mixed stage shader module not supported";
-        consumer()(SPV_MSG_ERROR, 0, {0, 0, 0}, message.c_str());
-      }
-      return false;
-    }
-    ++ecnt;
-  }
+  spv::ExecutionModel stage = context()->GetStage();
   // Check for supported stages
   if (stage != spv::ExecutionModel::Vertex &&
       stage != spv::ExecutionModel::Fragment &&

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -525,7 +525,7 @@ bool Optimizer::RegisterPassFromFlag(const std::string& flag) {
   } else if (pass_name == "remove-dont-inline") {
     RegisterPass(CreateRemoveDontInlinePass());
   } else if (pass_name == "eliminate-dead-input-components") {
-    RegisterPass(CreateEliminateDeadInputComponentsPass());
+    RegisterPass(CreateEliminateDeadInputComponentsSafePass());
   } else if (pass_name == "fix-func-call-param") {
     RegisterPass(CreateFixFuncCallArgumentsPass());
   } else if (pass_name == "convert-to-sampled-image") {
@@ -1017,6 +1017,18 @@ Optimizer::PassToken CreateInterpolateFixupPass() {
 
 Optimizer::PassToken CreateEliminateDeadInputComponentsPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::EliminateDeadInputComponentsPass>(
+          /* output_instead */ false, /* vertex_shader_only */ false));
+}
+
+Optimizer::PassToken CreateEliminateDeadOutputComponentsPass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::EliminateDeadInputComponentsPass>(
+          /* output_instead */ true, /* vertex_shader_only */ false));
+}
+
+Optimizer::PassToken CreateEliminateDeadInputComponentsSafePass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::EliminateDeadInputComponentsPass>());
 }
 
@@ -1032,12 +1044,6 @@ Optimizer::PassToken CreateEliminateDeadOutputStoresPass(
     std::unordered_set<uint32_t>* live_builtins) {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::EliminateDeadOutputStoresPass>(live_locs, live_builtins));
-}
-
-Optimizer::PassToken CreateEliminateDeadOutputComponentsPass() {
-  return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::EliminateDeadInputComponentsPass>(
-          /* output_instead */ true));
 }
 
 Optimizer::PassToken CreateConvertToSampledImagePass(


### PR DESCRIPTION
Safe version will only optimize vertex shaders. All other shaders will succeed without change.

Change --eliminate-dead-input-components to use new safe version.

Unsafe version (allowing non-vertex shaders) currently only available through API. Should only be used in combination with other optimizations to keep interfaces consistent. See optimizer.hpp for more details.