### PR TITLE
clean: constexpr-ify and unify anon namespace use

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -31,18 +31,17 @@
 
 namespace spvtools {
 namespace opt {
-
 namespace {
 
-const uint32_t kTypePointerStorageClassInIdx = 0;
-const uint32_t kEntryPointFunctionIdInIdx = 1;
-const uint32_t kSelectionMergeMergeBlockIdInIdx = 0;
-const uint32_t kLoopMergeContinueBlockIdInIdx = 1;
-const uint32_t kCopyMemoryTargetAddrInIdx = 0;
-const uint32_t kCopyMemorySourceAddrInIdx = 1;
-const uint32_t kLoadSourceAddrInIdx = 0;
-const uint32_t kDebugDeclareOperandVariableIndex = 5;
-const uint32_t kGlobalVariableVariableIndex = 12;
+constexpr uint32_t kTypePointerStorageClassInIdx = 0;
+constexpr uint32_t kEntryPointFunctionIdInIdx = 1;
+constexpr uint32_t kSelectionMergeMergeBlockIdInIdx = 0;
+constexpr uint32_t kLoopMergeContinueBlockIdInIdx = 1;
+constexpr uint32_t kCopyMemoryTargetAddrInIdx = 0;
+constexpr uint32_t kCopyMemorySourceAddrInIdx = 1;
+constexpr uint32_t kLoadSourceAddrInIdx = 0;
+constexpr uint32_t kDebugDeclareOperandVariableIndex = 5;
+constexpr uint32_t kGlobalVariableVariableIndex = 12;
 
 // Sorting functor to present annotation instructions in an easy-to-process
 // order. The functor orders by opcode first and falls back on unique id

--- a/source/opt/amd_ext_to_khr.cpp
+++ b/source/opt/amd_ext_to_khr.cpp
@@ -24,7 +24,6 @@
 
 namespace spvtools {
 namespace opt {
-
 namespace {
 
 enum AmdShaderBallotExtOpcodes {

--- a/source/opt/basic_block.cpp
+++ b/source/opt/basic_block.cpp
@@ -25,11 +25,9 @@
 namespace spvtools {
 namespace opt {
 namespace {
-
-const uint32_t kLoopMergeContinueBlockIdInIdx = 1;
-const uint32_t kLoopMergeMergeBlockIdInIdx = 0;
-const uint32_t kSelectionMergeMergeBlockIdInIdx = 0;
-
+constexpr uint32_t kLoopMergeContinueBlockIdInIdx = 1;
+constexpr uint32_t kLoopMergeMergeBlockIdInIdx = 0;
+constexpr uint32_t kSelectionMergeMergeBlockIdInIdx = 0;
 }  // namespace
 
 BasicBlock* BasicBlock::Clone(IRContext* context) const {

--- a/source/opt/block_merge_util.cpp
+++ b/source/opt/block_merge_util.cpp
@@ -20,7 +20,6 @@
 namespace spvtools {
 namespace opt {
 namespace blockmergeutil {
-
 namespace {
 
 // Returns true if |block| contains a merge instruction.

--- a/source/opt/ccp_pass.cpp
+++ b/source/opt/ccp_pass.cpp
@@ -29,14 +29,11 @@
 
 namespace spvtools {
 namespace opt {
-
 namespace {
-
 // This SSA id is never defined nor referenced in the IR.  It is a special ID
 // which represents varying values.  When an ID is found to have a varying
 // value, its entry in the |values_| table maps to kVaryingSSAId.
-const uint32_t kVaryingSSAId = std::numeric_limits<uint32_t>::max();
-
+constexpr uint32_t kVaryingSSAId = std::numeric_limits<uint32_t>::max();
 }  // namespace
 
 bool CCPPass::IsVaryingValue(uint32_t id) const { return id == kVaryingSSAId; }

--- a/source/opt/cfg.cpp
+++ b/source/opt/cfg.cpp
@@ -29,7 +29,7 @@ namespace {
 using cbb_ptr = const opt::BasicBlock*;
 
 // Universal Limit of ResultID + 1
-const int kMaxResultId = 0x400000;
+constexpr int kMaxResultId = 0x400000;
 
 }  // namespace
 

--- a/source/opt/const_folding_rules.cpp
+++ b/source/opt/const_folding_rules.cpp
@@ -19,8 +19,7 @@
 namespace spvtools {
 namespace opt {
 namespace {
-
-const uint32_t kExtractCompositeIdInIdx = 0;
+constexpr uint32_t kExtractCompositeIdInIdx = 0;
 
 // Returns a constants with the value NaN of the given type.  Only works for
 // 32-bit and 64-bit float point types.  Returns |nullptr| if an error occurs.

--- a/source/opt/convert_to_half_pass.cpp
+++ b/source/opt/convert_to_half_pass.cpp
@@ -18,15 +18,12 @@
 
 #include "source/opt/ir_builder.h"
 
-namespace {
-
-// Indices of operands in SPIR-V instructions
-static const int kImageSampleDrefIdInIdx = 2;
-
-}  // anonymous namespace
-
 namespace spvtools {
 namespace opt {
+namespace {
+// Indices of operands in SPIR-V instructions
+constexpr int kImageSampleDrefIdInIdx = 2;
+}  // namespace
 
 bool ConvertToHalfPass::IsArithmetic(Instruction* inst) {
   return target_ops_core_.count(inst->opcode()) != 0 ||

--- a/source/opt/copy_prop_arrays.cpp
+++ b/source/opt/copy_prop_arrays.cpp
@@ -22,12 +22,12 @@ namespace spvtools {
 namespace opt {
 namespace {
 
-const uint32_t kLoadPointerInOperand = 0;
-const uint32_t kStorePointerInOperand = 0;
-const uint32_t kStoreObjectInOperand = 1;
-const uint32_t kCompositeExtractObjectInOperand = 0;
-const uint32_t kTypePointerStorageClassInIdx = 0;
-const uint32_t kTypePointerPointeeInIdx = 1;
+constexpr uint32_t kLoadPointerInOperand = 0;
+constexpr uint32_t kStorePointerInOperand = 0;
+constexpr uint32_t kStoreObjectInOperand = 1;
+constexpr uint32_t kCompositeExtractObjectInOperand = 0;
+constexpr uint32_t kTypePointerStorageClassInIdx = 0;
+constexpr uint32_t kTypePointerPointeeInIdx = 1;
 
 bool IsDebugDeclareOrValue(Instruction* di) {
   auto dbg_opcode = di->GetCommonDebugOpcode();

--- a/source/opt/dead_branch_elim_pass.cpp
+++ b/source/opt/dead_branch_elim_pass.cpp
@@ -29,13 +29,10 @@
 
 namespace spvtools {
 namespace opt {
-
 namespace {
-
-const uint32_t kBranchCondTrueLabIdInIdx = 1;
-const uint32_t kBranchCondFalseLabIdInIdx = 2;
-
-}  // anonymous namespace
+constexpr uint32_t kBranchCondTrueLabIdInIdx = 1;
+constexpr uint32_t kBranchCondFalseLabIdInIdx = 2;
+}  // namespace
 
 bool DeadBranchElimPass::GetConstCondition(uint32_t condId, bool* condVal) {
   bool condIsConst;

--- a/source/opt/dead_insert_elim_pass.cpp
+++ b/source/opt/dead_insert_elim_pass.cpp
@@ -23,18 +23,15 @@
 
 namespace spvtools {
 namespace opt {
-
 namespace {
-
-const uint32_t kTypeVectorCountInIdx = 1;
-const uint32_t kTypeMatrixCountInIdx = 1;
-const uint32_t kTypeArrayLengthIdInIdx = 1;
-const uint32_t kTypeIntWidthInIdx = 0;
-const uint32_t kConstantValueInIdx = 0;
-const uint32_t kInsertObjectIdInIdx = 0;
-const uint32_t kInsertCompositeIdInIdx = 1;
-
-}  // anonymous namespace
+constexpr uint32_t kTypeVectorCountInIdx = 1;
+constexpr uint32_t kTypeMatrixCountInIdx = 1;
+constexpr uint32_t kTypeArrayLengthIdInIdx = 1;
+constexpr uint32_t kTypeIntWidthInIdx = 0;
+constexpr uint32_t kConstantValueInIdx = 0;
+constexpr uint32_t kInsertObjectIdInIdx = 0;
+constexpr uint32_t kInsertCompositeIdInIdx = 1;
+}  // namespace
 
 uint32_t DeadInsertElimPass::NumComponents(Instruction* typeInst) {
   switch (typeInst->opcode()) {

--- a/source/opt/debug_info_manager.cpp
+++ b/source/opt/debug_info_manager.cpp
@@ -22,32 +22,31 @@
 // Constants for OpenCL.DebugInfo.100 & NonSemantic.Shader.DebugInfo.100
 // extension instructions.
 
-static const uint32_t kOpLineOperandLineIndex = 1;
-static const uint32_t kLineOperandIndexDebugFunction = 7;
-static const uint32_t kLineOperandIndexDebugLexicalBlock = 5;
-static const uint32_t kLineOperandIndexDebugLine = 5;
-static const uint32_t kDebugFunctionOperandFunctionIndex = 13;
-static const uint32_t kDebugFunctionDefinitionOperandDebugFunctionIndex = 4;
-static const uint32_t kDebugFunctionDefinitionOperandOpFunctionIndex = 5;
-static const uint32_t kDebugFunctionOperandParentIndex = 9;
-static const uint32_t kDebugTypeCompositeOperandParentIndex = 9;
-static const uint32_t kDebugLexicalBlockOperandParentIndex = 7;
-static const uint32_t kDebugInlinedAtOperandInlinedIndex = 6;
-static const uint32_t kDebugExpressOperandOperationIndex = 4;
-static const uint32_t kDebugDeclareOperandLocalVariableIndex = 4;
-static const uint32_t kDebugDeclareOperandVariableIndex = 5;
-static const uint32_t kDebugValueOperandExpressionIndex = 6;
-static const uint32_t kDebugOperationOperandOperationIndex = 4;
-static const uint32_t kOpVariableOperandStorageClassIndex = 2;
-static const uint32_t kDebugLocalVariableOperandParentIndex = 9;
-static const uint32_t kExtInstInstructionInIdx = 1;
-static const uint32_t kDebugGlobalVariableOperandFlagsIndex = 12;
-static const uint32_t kDebugLocalVariableOperandFlagsIndex = 10;
-
 namespace spvtools {
 namespace opt {
 namespace analysis {
 namespace {
+constexpr uint32_t kOpLineOperandLineIndex = 1;
+constexpr uint32_t kLineOperandIndexDebugFunction = 7;
+constexpr uint32_t kLineOperandIndexDebugLexicalBlock = 5;
+constexpr uint32_t kLineOperandIndexDebugLine = 5;
+constexpr uint32_t kDebugFunctionOperandFunctionIndex = 13;
+constexpr uint32_t kDebugFunctionDefinitionOperandDebugFunctionIndex = 4;
+constexpr uint32_t kDebugFunctionDefinitionOperandOpFunctionIndex = 5;
+constexpr uint32_t kDebugFunctionOperandParentIndex = 9;
+constexpr uint32_t kDebugTypeCompositeOperandParentIndex = 9;
+constexpr uint32_t kDebugLexicalBlockOperandParentIndex = 7;
+constexpr uint32_t kDebugInlinedAtOperandInlinedIndex = 6;
+constexpr uint32_t kDebugExpressOperandOperationIndex = 4;
+constexpr uint32_t kDebugDeclareOperandLocalVariableIndex = 4;
+constexpr uint32_t kDebugDeclareOperandVariableIndex = 5;
+constexpr uint32_t kDebugValueOperandExpressionIndex = 6;
+constexpr uint32_t kDebugOperationOperandOperationIndex = 4;
+constexpr uint32_t kOpVariableOperandStorageClassIndex = 2;
+constexpr uint32_t kDebugLocalVariableOperandParentIndex = 9;
+constexpr uint32_t kExtInstInstructionInIdx = 1;
+constexpr uint32_t kDebugGlobalVariableOperandFlagsIndex = 12;
+constexpr uint32_t kDebugLocalVariableOperandFlagsIndex = 10;
 
 void SetInlinedOperand(Instruction* dbg_inlined_at, uint32_t inlined_operand) {
   assert(dbg_inlined_at);

--- a/source/opt/decoration_manager.cpp
+++ b/source/opt/decoration_manager.cpp
@@ -22,6 +22,9 @@
 
 #include "source/opt/ir_context.h"
 
+namespace spvtools {
+namespace opt {
+namespace analysis {
 namespace {
 using InstructionVector = std::vector<const spvtools::opt::Instruction*>;
 using DecorationSet = std::set<std::u32string>;
@@ -48,10 +51,6 @@ bool IsSubset(const DecorationSet& a, const DecorationSet& b) {
   return true;
 }
 }  // namespace
-
-namespace spvtools {
-namespace opt {
-namespace analysis {
 
 bool DecorationManager::RemoveDecorationsFrom(
     uint32_t id, std::function<bool(const Instruction&)> pred) {

--- a/source/opt/desc_sroa_util.cpp
+++ b/source/opt/desc_sroa_util.cpp
@@ -17,8 +17,7 @@
 namespace spvtools {
 namespace opt {
 namespace {
-
-const uint32_t kOpAccessChainInOperandIndexes = 1;
+constexpr uint32_t kOpAccessChainInOperandIndexes = 1;
 
 // Returns the length of array type |type|.
 uint32_t GetLengthOfArrayType(IRContext* context, Instruction* type) {

--- a/source/opt/dominator_tree.cpp
+++ b/source/opt/dominator_tree.cpp
@@ -55,8 +55,8 @@ namespace {
 // called on each node traversed BEFORE their children.
 template <typename BBType, typename SuccessorLambda, typename PreLambda,
           typename PostLambda>
-static void DepthFirstSearch(const BBType* bb, SuccessorLambda successors,
-                             PreLambda pre, PostLambda post) {
+void DepthFirstSearch(const BBType* bb, SuccessorLambda successors,
+                      PreLambda pre, PostLambda post) {
   auto no_terminal_blocks = [](const BBType*) { return false; };
   CFA<BBType>::DepthFirstTraversal(bb, successors, pre, post,
                                    no_terminal_blocks);
@@ -73,9 +73,8 @@ static void DepthFirstSearch(const BBType* bb, SuccessorLambda successors,
 // PostLambda - Lamdba matching the signature of 'void (const BBType*)' will be
 // called on each node traversed after their children.
 template <typename BBType, typename SuccessorLambda, typename PostLambda>
-static void DepthFirstSearchPostOrder(const BBType* bb,
-                                      SuccessorLambda successors,
-                                      PostLambda post) {
+void DepthFirstSearchPostOrder(const BBType* bb, SuccessorLambda successors,
+                               PostLambda post) {
   // Ignore preorder operation.
   auto nop_preorder = [](const BBType*) {};
   DepthFirstSearch(bb, successors, nop_preorder, post);

--- a/source/opt/eliminate_dead_input_components_pass.cpp
+++ b/source/opt/eliminate_dead_input_components_pass.cpp
@@ -23,16 +23,13 @@
 #include "source/opt/ir_context.h"
 #include "source/util/bit_vector.h"
 
-namespace {
-
-const uint32_t kAccessChainBaseInIdx = 0;
-const uint32_t kAccessChainIndex0InIdx = 1;
-const uint32_t kConstantValueInIdx = 0;
-
-}  // namespace
-
 namespace spvtools {
 namespace opt {
+namespace {
+constexpr uint32_t kAccessChainBaseInIdx = 0;
+constexpr uint32_t kAccessChainIndex0InIdx = 1;
+constexpr uint32_t kConstantValueInIdx = 0;
+}  // namespace
 
 Pass::Status EliminateDeadInputComponentsPass::Process() {
   // Process non-vertex only if explicitly allowed.

--- a/source/opt/eliminate_dead_members_pass.cpp
+++ b/source/opt/eliminate_dead_members_pass.cpp
@@ -17,14 +17,13 @@
 #include "ir_builder.h"
 #include "source/opt/ir_context.h"
 
-namespace {
-const uint32_t kRemovedMember = 0xFFFFFFFF;
-const uint32_t kSpecConstOpOpcodeIdx = 0;
-constexpr uint32_t kArrayElementTypeIdx = 0;
-}  // namespace
-
 namespace spvtools {
 namespace opt {
+namespace {
+constexpr uint32_t kRemovedMember = 0xFFFFFFFF;
+constexpr uint32_t kSpecConstOpOpcodeIdx = 0;
+constexpr uint32_t kArrayElementTypeIdx = 0;
+}  // namespace
 
 Pass::Status EliminateDeadMembersPass::Process() {
   if (!context()->get_feature_mgr()->HasCapability(spv::Capability::Shader))

--- a/source/opt/eliminate_dead_output_stores_pass.cpp
+++ b/source/opt/eliminate_dead_output_stores_pass.cpp
@@ -18,19 +18,16 @@
 #include "source/opt/instruction.h"
 #include "source/opt/ir_context.h"
 
-namespace {
-
-const uint32_t kDecorationLocationInIdx = 2;
-const uint32_t kOpDecorateMemberMemberInIdx = 1;
-const uint32_t kOpDecorateBuiltInLiteralInIdx = 2;
-const uint32_t kOpDecorateMemberBuiltInLiteralInIdx = 3;
-const uint32_t kOpAccessChainIdx0InIdx = 1;
-const uint32_t kOpConstantValueInIdx = 0;
-
-}  // namespace
-
 namespace spvtools {
 namespace opt {
+namespace {
+constexpr uint32_t kDecorationLocationInIdx = 2;
+constexpr uint32_t kOpDecorateMemberMemberInIdx = 1;
+constexpr uint32_t kOpDecorateBuiltInLiteralInIdx = 2;
+constexpr uint32_t kOpDecorateMemberBuiltInLiteralInIdx = 3;
+constexpr uint32_t kOpAccessChainIdx0InIdx = 1;
+constexpr uint32_t kOpConstantValueInIdx = 0;
+}  // namespace
 
 Pass::Status EliminateDeadOutputStoresPass::Process() {
   // Current functionality assumes shader capability

--- a/source/opt/folding_rules.cpp
+++ b/source/opt/folding_rules.cpp
@@ -27,15 +27,15 @@ namespace spvtools {
 namespace opt {
 namespace {
 
-const uint32_t kExtractCompositeIdInIdx = 0;
-const uint32_t kInsertObjectIdInIdx = 0;
-const uint32_t kInsertCompositeIdInIdx = 1;
-const uint32_t kExtInstSetIdInIdx = 0;
-const uint32_t kExtInstInstructionInIdx = 1;
-const uint32_t kFMixXIdInIdx = 2;
-const uint32_t kFMixYIdInIdx = 3;
-const uint32_t kFMixAIdInIdx = 4;
-const uint32_t kStoreObjectInIdx = 1;
+constexpr uint32_t kExtractCompositeIdInIdx = 0;
+constexpr uint32_t kInsertObjectIdInIdx = 0;
+constexpr uint32_t kInsertCompositeIdInIdx = 1;
+constexpr uint32_t kExtInstSetIdInIdx = 0;
+constexpr uint32_t kExtInstInstructionInIdx = 1;
+constexpr uint32_t kFMixXIdInIdx = 2;
+constexpr uint32_t kFMixYIdInIdx = 3;
+constexpr uint32_t kFMixAIdInIdx = 4;
+constexpr uint32_t kStoreObjectInIdx = 1;
 
 // Some image instructions may contain an "image operands" argument.
 // Returns the operand index for the "image operands".
@@ -2603,7 +2603,7 @@ FoldingRule DotProductDoingExtract() {
       std::vector<const analysis::Constant*> components;
       components = constants[i]->GetVectorComponents(const_mgr);
 
-      const uint32_t kNotFound = std::numeric_limits<uint32_t>::max();
+      constexpr uint32_t kNotFound = std::numeric_limits<uint32_t>::max();
 
       uint32_t component_with_one = kNotFound;
       bool all_others_zero = true;

--- a/source/opt/inline_opaque_pass.cpp
+++ b/source/opt/inline_opaque_pass.cpp
@@ -21,10 +21,8 @@
 namespace spvtools {
 namespace opt {
 namespace {
-
-const uint32_t kTypePointerTypeIdInIdx = 1;
-
-}  // anonymous namespace
+constexpr uint32_t kTypePointerTypeIdInIdx = 1;
+}  // namespace
 
 bool InlineOpaquePass::IsOpaqueType(uint32_t typeId) {
   const Instruction* typeInst = get_def_use_mgr()->GetDef(typeId);

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -23,14 +23,14 @@
 #include "source/opt/reflect.h"
 #include "source/util/make_unique.h"
 
-// Indices of operands in SPIR-V instructions
-
-static const int kSpvFunctionCallFunctionId = 2;
-static const int kSpvFunctionCallArgumentId = 3;
-static const int kSpvReturnValueId = 0;
-
 namespace spvtools {
 namespace opt {
+namespace {
+// Indices of operands in SPIR-V instructions
+constexpr int kSpvFunctionCallFunctionId = 2;
+constexpr int kSpvFunctionCallArgumentId = 3;
+constexpr int kSpvReturnValueId = 0;
+}  // namespace
 
 uint32_t InlinePass::AddPointerToType(uint32_t type_id,
                                       spv::StorageClass storage_class) {

--- a/source/opt/inst_bindless_check_pass.cpp
+++ b/source/opt/inst_bindless_check_pass.cpp
@@ -16,31 +16,29 @@
 
 #include "inst_bindless_check_pass.h"
 
-namespace {
-
-// Input Operand Indices
-static const int kSpvImageSampleImageIdInIdx = 0;
-static const int kSpvSampledImageImageIdInIdx = 0;
-static const int kSpvSampledImageSamplerIdInIdx = 1;
-static const int kSpvImageSampledImageIdInIdx = 0;
-static const int kSpvCopyObjectOperandIdInIdx = 0;
-static const int kSpvLoadPtrIdInIdx = 0;
-static const int kSpvAccessChainBaseIdInIdx = 0;
-static const int kSpvAccessChainIndex0IdInIdx = 1;
-static const int kSpvTypeArrayTypeIdInIdx = 0;
-static const int kSpvTypeArrayLengthIdInIdx = 1;
-static const int kSpvConstantValueInIdx = 0;
-static const int kSpvVariableStorageClassInIdx = 0;
-static const int kSpvTypePtrTypeIdInIdx = 1;
-static const int kSpvTypeImageDim = 1;
-static const int kSpvTypeImageDepth = 2;
-static const int kSpvTypeImageArrayed = 3;
-static const int kSpvTypeImageMS = 4;
-static const int kSpvTypeImageSampled = 5;
-}  // anonymous namespace
-
 namespace spvtools {
 namespace opt {
+namespace {
+// Input Operand Indices
+constexpr int kSpvImageSampleImageIdInIdx = 0;
+constexpr int kSpvSampledImageImageIdInIdx = 0;
+constexpr int kSpvSampledImageSamplerIdInIdx = 1;
+constexpr int kSpvImageSampledImageIdInIdx = 0;
+constexpr int kSpvCopyObjectOperandIdInIdx = 0;
+constexpr int kSpvLoadPtrIdInIdx = 0;
+constexpr int kSpvAccessChainBaseIdInIdx = 0;
+constexpr int kSpvAccessChainIndex0IdInIdx = 1;
+constexpr int kSpvTypeArrayTypeIdInIdx = 0;
+constexpr int kSpvTypeArrayLengthIdInIdx = 1;
+constexpr int kSpvConstantValueInIdx = 0;
+constexpr int kSpvVariableStorageClassInIdx = 0;
+constexpr int kSpvTypePtrTypeIdInIdx = 1;
+constexpr int kSpvTypeImageDim = 1;
+constexpr int kSpvTypeImageDepth = 2;
+constexpr int kSpvTypeImageArrayed = 3;
+constexpr int kSpvTypeImageMS = 4;
+constexpr int kSpvTypeImageSampled = 5;
+}  // namespace
 
 uint32_t InstBindlessCheckPass::GenDebugReadLength(
     uint32_t var_id, InstructionBuilder* builder) {

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -24,26 +24,25 @@
 
 namespace spvtools {
 namespace opt {
-
 namespace {
 // Indices used to get particular operands out of instructions using InOperand.
-const uint32_t kTypeImageDimIndex = 1;
-const uint32_t kLoadBaseIndex = 0;
-const uint32_t kPointerTypeStorageClassIndex = 0;
-const uint32_t kVariableStorageClassIndex = 0;
-const uint32_t kTypeImageSampledIndex = 5;
+constexpr uint32_t kTypeImageDimIndex = 1;
+constexpr uint32_t kLoadBaseIndex = 0;
+constexpr uint32_t kPointerTypeStorageClassIndex = 0;
+constexpr uint32_t kVariableStorageClassIndex = 0;
+constexpr uint32_t kTypeImageSampledIndex = 5;
 
 // Constants for OpenCL.DebugInfo.100 / NonSemantic.Shader.DebugInfo.100
 // extension instructions.
-const uint32_t kExtInstSetIdInIdx = 0;
-const uint32_t kExtInstInstructionInIdx = 1;
-const uint32_t kDebugScopeNumWords = 7;
-const uint32_t kDebugScopeNumWordsWithoutInlinedAt = 6;
-const uint32_t kDebugNoScopeNumWords = 5;
+constexpr uint32_t kExtInstSetIdInIdx = 0;
+constexpr uint32_t kExtInstInstructionInIdx = 1;
+constexpr uint32_t kDebugScopeNumWords = 7;
+constexpr uint32_t kDebugScopeNumWordsWithoutInlinedAt = 6;
+constexpr uint32_t kDebugNoScopeNumWords = 5;
 
 // Number of operands of an OpBranchConditional instruction
 // with weights.
-const uint32_t kOpBranchConditionalWithWeightsNumOperands = 5;
+constexpr uint32_t kOpBranchConditionalWithWeightsNumOperands = 5;
 }  // namespace
 
 Instruction::Instruction(IRContext* c)

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -36,8 +36,8 @@
 #include "source/util/string_utils.h"
 #include "spirv-tools/libspirv.h"
 
-const uint32_t kNoDebugScope = 0;
-const uint32_t kNoInlinedAt = 0;
+constexpr uint32_t kNoDebugScope = 0;
+constexpr uint32_t kNoInlinedAt = 0;
 
 namespace spvtools {
 namespace opt {

--- a/source/opt/instrument_pass.cpp
+++ b/source/opt/instrument_pass.cpp
@@ -19,19 +19,15 @@
 #include "source/cfa.h"
 #include "source/spirv_constant.h"
 
-namespace {
-
-// Common Parameter Positions
-static const int kInstCommonParamInstIdx = 0;
-static const int kInstCommonParamCnt = 1;
-
-// Indices of operands in SPIR-V instructions
-static const int kEntryPointFunctionIdInIdx = 1;
-
-}  // anonymous namespace
-
 namespace spvtools {
 namespace opt {
+namespace {
+// Common Parameter Positions
+constexpr int kInstCommonParamInstIdx = 0;
+constexpr int kInstCommonParamCnt = 1;
+// Indices of operands in SPIR-V instructions
+constexpr int kEntryPointFunctionIdInIdx = 1;
+}  // namespace
 
 void InstrumentPass::MovePreludeCode(
     BasicBlock::iterator ref_inst_itr,

--- a/source/opt/instrument_pass.h
+++ b/source/opt/instrument_pass.h
@@ -55,13 +55,14 @@
 
 namespace spvtools {
 namespace opt {
-
+namespace {
 // Validation Ids
 // These are used to identify the general validation being done and map to
 // its output buffers.
-static const uint32_t kInstValidationIdBindless = 0;
-static const uint32_t kInstValidationIdBuffAddr = 1;
-static const uint32_t kInstValidationIdDebugPrintf = 2;
+constexpr uint32_t kInstValidationIdBindless = 0;
+constexpr uint32_t kInstValidationIdBuffAddr = 1;
+constexpr uint32_t kInstValidationIdDebugPrintf = 2;
+}  // namespace
 
 class InstrumentPass : public Pass {
   using cbb_ptr = const BasicBlock*;

--- a/source/opt/interface_var_sroa.cpp
+++ b/source/opt/interface_var_sroa.cpp
@@ -23,20 +23,19 @@
 #include "source/opt/type_manager.h"
 #include "source/util/make_unique.h"
 
-const static uint32_t kOpDecorateDecorationInOperandIndex = 1;
-const static uint32_t kOpDecorateLiteralInOperandIndex = 2;
-const static uint32_t kOpEntryPointInOperandInterface = 3;
-const static uint32_t kOpVariableStorageClassInOperandIndex = 0;
-const static uint32_t kOpTypeArrayElemTypeInOperandIndex = 0;
-const static uint32_t kOpTypeArrayLengthInOperandIndex = 1;
-const static uint32_t kOpTypeMatrixColCountInOperandIndex = 1;
-const static uint32_t kOpTypeMatrixColTypeInOperandIndex = 0;
-const static uint32_t kOpTypePtrTypeInOperandIndex = 1;
-const static uint32_t kOpConstantValueInOperandIndex = 0;
-
 namespace spvtools {
 namespace opt {
 namespace {
+constexpr uint32_t kOpDecorateDecorationInOperandIndex = 1;
+constexpr uint32_t kOpDecorateLiteralInOperandIndex = 2;
+constexpr uint32_t kOpEntryPointInOperandInterface = 3;
+constexpr uint32_t kOpVariableStorageClassInOperandIndex = 0;
+constexpr uint32_t kOpTypeArrayElemTypeInOperandIndex = 0;
+constexpr uint32_t kOpTypeArrayLengthInOperandIndex = 1;
+constexpr uint32_t kOpTypeMatrixColCountInOperandIndex = 1;
+constexpr uint32_t kOpTypeMatrixColTypeInOperandIndex = 0;
+constexpr uint32_t kOpTypePtrTypeInOperandIndex = 1;
+constexpr uint32_t kOpConstantValueInOperandIndex = 0;
 
 // Get the length of the OpTypeArray |array_type|.
 uint32_t GetArrayLength(analysis::DefUseManager* def_use_mgr,

--- a/source/opt/interp_fixup_pass.cpp
+++ b/source/opt/interp_fixup_pass.cpp
@@ -25,11 +25,10 @@
 
 namespace spvtools {
 namespace opt {
-
 namespace {
 
 // Input Operand Indices
-static const int kSpvVariableStorageClassInIdx = 0;
+constexpr int kSpvVariableStorageClassInIdx = 0;
 
 // Folding rule function which attempts to replace |op(OpLoad(a),...)|
 // by |op(a,...)|, where |op| is one of the GLSLstd450 InterpolateAt*

--- a/source/opt/ir_builder.h
+++ b/source/opt/ir_builder.h
@@ -30,7 +30,7 @@ namespace opt {
 
 // In SPIR-V, ids are encoded as uint16_t, this id is guaranteed to be always
 // invalid.
-const uint32_t kInvalidId = std::numeric_limits<uint32_t>::max();
+constexpr uint32_t kInvalidId = std::numeric_limits<uint32_t>::max();
 
 // Helper class to abstract instruction construction and insertion.
 // The instruction builder can preserve the following analyses (specified via

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -22,24 +22,21 @@
 #include "source/opt/mem_pass.h"
 #include "source/opt/reflect.h"
 
+namespace spvtools {
+namespace opt {
 namespace {
-
-static const int kSpvDecorateTargetIdInIdx = 0;
-static const int kSpvDecorateDecorationInIdx = 1;
-static const int kSpvDecorateBuiltinInIdx = 2;
-static const int kEntryPointInterfaceInIdx = 3;
-static const int kEntryPointFunctionIdInIdx = 1;
-static const int kEntryPointExecutionModelInIdx = 0;
+constexpr int kSpvDecorateTargetIdInIdx = 0;
+constexpr int kSpvDecorateDecorationInIdx = 1;
+constexpr int kSpvDecorateBuiltinInIdx = 2;
+constexpr int kEntryPointInterfaceInIdx = 3;
+constexpr int kEntryPointFunctionIdInIdx = 1;
+constexpr int kEntryPointExecutionModelInIdx = 0;
 
 // Constants for OpenCL.DebugInfo.100 / NonSemantic.Shader.DebugInfo.100
 // extension instructions.
-static const uint32_t kDebugFunctionOperandFunctionIndex = 13;
-static const uint32_t kDebugGlobalVariableOperandVariableIndex = 11;
-
-}  // anonymous namespace
-
-namespace spvtools {
-namespace opt {
+constexpr uint32_t kDebugFunctionOperandFunctionIndex = 13;
+constexpr uint32_t kDebugGlobalVariableOperandVariableIndex = 11;
+}  // namespace
 
 void IRContext::BuildInvalidAnalyses(IRContext::Analysis set) {
   set = Analysis(set & ~valid_analyses_);

--- a/source/opt/ir_context.h
+++ b/source/opt/ir_context.h
@@ -486,8 +486,8 @@ class IRContext {
     if (!AreAnalysesValid(kAnalysisCombinators)) {
       InitializeCombinators();
     }
-    const uint32_t kExtInstSetIdInIndx = 0;
-    const uint32_t kExtInstInstructionInIndx = 1;
+    constexpr uint32_t kExtInstSetIdInIndx = 0;
+    constexpr uint32_t kExtInstInstructionInIndx = 1;
 
     if (inst->opcode() != spv::Op::OpExtInst) {
       return combinator_ops_[0].count(uint32_t(inst->opcode())) != 0;

--- a/source/opt/ir_loader.cpp
+++ b/source/opt/ir_loader.cpp
@@ -24,12 +24,13 @@
 #include "source/opt/reflect.h"
 #include "source/util/make_unique.h"
 
-static const uint32_t kExtInstSetIndex = 4;
-static const uint32_t kLexicalScopeIndex = 5;
-static const uint32_t kInlinedAtIndex = 6;
-
 namespace spvtools {
 namespace opt {
+namespace {
+constexpr uint32_t kExtInstSetIndex = 4;
+constexpr uint32_t kLexicalScopeIndex = 5;
+constexpr uint32_t kInlinedAtIndex = 6;
+}  // namespace
 
 IrLoader::IrLoader(const MessageConsumer& consumer, Module* m)
     : consumer_(consumer),

--- a/source/opt/liveness.cpp
+++ b/source/opt/liveness.cpp
@@ -17,19 +17,16 @@
 
 #include "source/opt/ir_context.h"
 
-namespace {
-
-const uint32_t kDecorationLocationInIdx = 2;
-const uint32_t kOpDecorateMemberMemberInIdx = 1;
-const uint32_t kOpDecorateMemberLocationInIdx = 3;
-const uint32_t kOpDecorateBuiltInLiteralInIdx = 2;
-const uint32_t kOpDecorateMemberBuiltInLiteralInIdx = 3;
-
-}  // namespace
-
 namespace spvtools {
 namespace opt {
 namespace analysis {
+namespace {
+constexpr uint32_t kDecorationLocationInIdx = 2;
+constexpr uint32_t kOpDecorateMemberMemberInIdx = 1;
+constexpr uint32_t kOpDecorateMemberLocationInIdx = 3;
+constexpr uint32_t kOpDecorateBuiltInLiteralInIdx = 2;
+constexpr uint32_t kOpDecorateMemberBuiltInLiteralInIdx = 3;
+}  // namespace
 
 LivenessManager::LivenessManager(IRContext* ctx) : ctx_(ctx), computed_(false) {
   // Liveness sets computed when queried

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -23,13 +23,10 @@
 
 namespace spvtools {
 namespace opt {
-
 namespace {
-
-const uint32_t kStoreValIdInIdx = 1;
-const uint32_t kAccessChainPtrIdInIdx = 0;
-
-}  // anonymous namespace
+constexpr uint32_t kStoreValIdInIdx = 1;
+constexpr uint32_t kAccessChainPtrIdInIdx = 0;
+}  // namespace
 
 void LocalAccessChainConvertPass::BuildAndAppendInst(
     spv::Op opcode, uint32_t typeId, uint32_t resultId,

--- a/source/opt/local_single_block_elim_pass.cpp
+++ b/source/opt/local_single_block_elim_pass.cpp
@@ -24,10 +24,8 @@
 namespace spvtools {
 namespace opt {
 namespace {
-
-const uint32_t kStoreValIdInIdx = 1;
-
-}  // anonymous namespace
+constexpr uint32_t kStoreValIdInIdx = 1;
+}  // namespace
 
 bool LocalSingleBlockLoadStoreElimPass::HasOnlySupportedRefs(uint32_t ptrId) {
   if (supported_ref_ptrs_.find(ptrId) != supported_ref_ptrs_.end()) return true;

--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -23,13 +23,10 @@
 
 namespace spvtools {
 namespace opt {
-
 namespace {
-
-const uint32_t kStoreValIdInIdx = 1;
-const uint32_t kVariableInitIdInIdx = 1;
-
-}  // anonymous namespace
+constexpr uint32_t kStoreValIdInIdx = 1;
+constexpr uint32_t kVariableInitIdInIdx = 1;
+}  // namespace
 
 bool LocalSingleStoreElimPass::LocalSingleStoreElim(Function* func) {
   bool modified = false;

--- a/source/opt/loop_descriptor.cpp
+++ b/source/opt/loop_descriptor.cpp
@@ -388,7 +388,7 @@ void Loop::GetMergingBlocks(
 
 namespace {
 
-static inline bool IsBasicBlockSafeToClone(IRContext* context, BasicBlock* bb) {
+inline bool IsBasicBlockSafeToClone(IRContext* context, BasicBlock* bb) {
   for (Instruction& inst : *bb) {
     if (!inst.IsBranch() && !context->IsCombinatorInstruction(&inst))
       return false;

--- a/source/opt/loop_fusion.cpp
+++ b/source/opt/loop_fusion.cpp
@@ -23,7 +23,6 @@
 
 namespace spvtools {
 namespace opt {
-
 namespace {
 
 // Append all the loops nested in |loop| to |loops|.

--- a/source/opt/loop_unroller.cpp
+++ b/source/opt/loop_unroller.cpp
@@ -68,10 +68,10 @@ namespace opt {
 namespace {
 
 // Loop control constant value for DontUnroll flag.
-static const uint32_t kLoopControlDontUnrollIndex = 2;
+constexpr uint32_t kLoopControlDontUnrollIndex = 2;
 
 // Operand index of the loop control parameter of the OpLoopMerge.
-static const uint32_t kLoopControlIndex = 2;
+constexpr uint32_t kLoopControlIndex = 2;
 
 // This utility class encapsulates some of the state we need to maintain between
 // loop unrolls. Specifically it maintains key blocks and the induction variable
@@ -336,8 +336,7 @@ class LoopUnrollerUtilsImpl {
 
 // Retrieve the index of the OpPhi instruction |phi| which corresponds to the
 // incoming |block| id.
-static uint32_t GetPhiIndexFromLabel(const BasicBlock* block,
-                                     const Instruction* phi) {
+uint32_t GetPhiIndexFromLabel(const BasicBlock* block, const Instruction* phi) {
   for (uint32_t i = 1; i < phi->NumInOperands(); i += 2) {
     if (block->id() == phi->GetSingleWordInOperand(i)) {
       return i;
@@ -1002,7 +1001,7 @@ bool LoopUtils::CanPerformUnroll() {
   // iteration counts. This can cause timeouts and memouts during fuzzing that
   // are not classed as bugs. To avoid this noise, loop unrolling is not applied
   // to loops with large iteration counts when fuzzing.
-  const size_t kFuzzerIterationLimit = 100;
+  constexpr size_t kFuzzerIterationLimit = 100;
   size_t num_iterations;
   loop_->FindNumberOfIterations(induction, &*condition->ctail(),
                                 &num_iterations);

--- a/source/opt/loop_unswitch_pass.cpp
+++ b/source/opt/loop_unswitch_pass.cpp
@@ -37,12 +37,7 @@
 namespace spvtools {
 namespace opt {
 namespace {
-
-static const uint32_t kTypePointerStorageClassInIdx = 0;
-
-}  // anonymous namespace
-
-namespace {
+constexpr uint32_t kTypePointerStorageClassInIdx = 0;
 
 // This class handle the unswitch procedure for a given loop.
 // The unswitch will not happen if:

--- a/source/opt/loop_utils.cpp
+++ b/source/opt/loop_utils.cpp
@@ -28,12 +28,11 @@
 
 namespace spvtools {
 namespace opt {
-
 namespace {
 // Return true if |bb| is dominated by at least one block in |exits|
-static inline bool DominatesAnExit(BasicBlock* bb,
-                                   const std::unordered_set<BasicBlock*>& exits,
-                                   const DominatorTree& dom_tree) {
+inline bool DominatesAnExit(BasicBlock* bb,
+                            const std::unordered_set<BasicBlock*>& exits,
+                            const DominatorTree& dom_tree) {
   for (BasicBlock* e_bb : exits)
     if (dom_tree.Dominates(bb, e_bb)) return true;
   return false;

--- a/source/opt/mem_pass.cpp
+++ b/source/opt/mem_pass.cpp
@@ -28,13 +28,10 @@
 
 namespace spvtools {
 namespace opt {
-
 namespace {
-
-const uint32_t kCopyObjectOperandInIdx = 0;
-const uint32_t kTypePointerStorageClassInIdx = 0;
-const uint32_t kTypePointerTypeIdInIdx = 1;
-
+constexpr uint32_t kCopyObjectOperandInIdx = 0;
+constexpr uint32_t kTypePointerStorageClassInIdx = 0;
+constexpr uint32_t kTypePointerTypeIdInIdx = 1;
 }  // namespace
 
 bool MemPass::IsBaseTargetType(const Instruction* typeInst) const {

--- a/source/opt/pass.cpp
+++ b/source/opt/pass.cpp
@@ -21,11 +21,8 @@
 
 namespace spvtools {
 namespace opt {
-
 namespace {
-
-const uint32_t kTypePointerTypeIdInIdx = 1;
-
+constexpr uint32_t kTypePointerTypeIdInIdx = 1;
 }  // namespace
 
 Pass::Pass() : consumer_(nullptr), context_(nullptr), already_run_(false) {}

--- a/source/opt/private_to_local_pass.cpp
+++ b/source/opt/private_to_local_pass.cpp
@@ -24,10 +24,8 @@
 namespace spvtools {
 namespace opt {
 namespace {
-
-const uint32_t kVariableStorageClassInIdx = 0;
-const uint32_t kSpvTypePointerTypeIdInIdx = 1;
-
+constexpr uint32_t kVariableStorageClassInIdx = 0;
+constexpr uint32_t kSpvTypePointerTypeIdInIdx = 1;
 }  // namespace
 
 Pass::Status PrivateToLocalPass::Process() {

--- a/source/opt/reduce_load_size.cpp
+++ b/source/opt/reduce_load_size.cpp
@@ -22,16 +22,13 @@
 #include "source/opt/ir_context.h"
 #include "source/util/bit_vector.h"
 
-namespace {
-
-const uint32_t kExtractCompositeIdInIdx = 0;
-const uint32_t kVariableStorageClassInIdx = 0;
-const uint32_t kLoadPointerInIdx = 0;
-
-}  // namespace
-
 namespace spvtools {
 namespace opt {
+namespace {
+constexpr uint32_t kExtractCompositeIdInIdx = 0;
+constexpr uint32_t kVariableStorageClassInIdx = 0;
+constexpr uint32_t kLoadPointerInIdx = 0;
+}  // namespace
 
 Pass::Status ReduceLoadSize::Process() {
   bool modified = false;

--- a/source/opt/register_pressure.cpp
+++ b/source/opt/register_pressure.cpp
@@ -26,7 +26,6 @@
 
 namespace spvtools {
 namespace opt {
-
 namespace {
 // Predicate for the FilterIterator to only consider instructions that are not
 // phi instructions defined in the basic block |bb|.

--- a/source/opt/replace_desc_array_access_using_var_index.cpp
+++ b/source/opt/replace_desc_array_access_using_var_index.cpp
@@ -21,11 +21,10 @@
 namespace spvtools {
 namespace opt {
 namespace {
-
-const uint32_t kOpAccessChainInOperandIndexes = 1;
-const uint32_t kOpTypePointerInOperandType = 1;
-const uint32_t kOpTypeArrayInOperandType = 0;
-const uint32_t kOpTypeStructInOperandMember = 0;
+constexpr uint32_t kOpAccessChainInOperandIndexes = 1;
+constexpr uint32_t kOpTypePointerInOperandType = 1;
+constexpr uint32_t kOpTypeArrayInOperandType = 0;
+constexpr uint32_t kOpTypeStructInOperandMember = 0;
 IRContext::Analysis kAnalysisDefUseAndInstrToBlockMapping =
     IRContext::kAnalysisDefUse | IRContext::kAnalysisInstrToBlockMapping;
 

--- a/source/opt/scalar_analysis.cpp
+++ b/source/opt/scalar_analysis.cpp
@@ -573,7 +573,7 @@ struct PushToStringImpl<T, 4> {
 };
 
 template <typename T>
-static void PushToString(T id, std::u32string* str) {
+void PushToString(T id, std::u32string* str) {
   PushToStringImpl<T, sizeof(T)>{}(id, str);
 }
 
@@ -928,8 +928,8 @@ namespace {
 
 // Remove |node| from the |mul| chain (of the form A * ... * |node| * ... * Z),
 // if |node| is not in the chain, returns the original chain.
-static SENode* RemoveOneNodeFromMultiplyChain(SEMultiplyNode* mul,
-                                              const SENode* node) {
+SENode* RemoveOneNodeFromMultiplyChain(SEMultiplyNode* mul,
+                                       const SENode* node) {
   SENode* lhs = mul->GetChildren()[0];
   SENode* rhs = mul->GetChildren()[1];
   if (lhs == node) {

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -26,12 +26,13 @@
 #include "source/util/make_unique.h"
 #include "types.h"
 
-static const uint32_t kDebugValueOperandValueIndex = 5;
-static const uint32_t kDebugValueOperandExpressionIndex = 6;
-static const uint32_t kDebugDeclareOperandVariableIndex = 5;
-
 namespace spvtools {
 namespace opt {
+namespace {
+constexpr uint32_t kDebugValueOperandValueIndex = 5;
+constexpr uint32_t kDebugValueOperandExpressionIndex = 6;
+constexpr uint32_t kDebugDeclareOperandVariableIndex = 5;
+}  // namespace
 
 Pass::Status ScalarReplacementPass::Process() {
   Status status = Status::SuccessWithoutChange;

--- a/source/opt/scalar_replacement_pass.h
+++ b/source/opt/scalar_replacement_pass.h
@@ -33,7 +33,7 @@ namespace opt {
 // Documented in optimizer.hpp
 class ScalarReplacementPass : public MemPass {
  private:
-  static const uint32_t kDefaultLimit = 100;
+  static constexpr uint32_t kDefaultLimit = 100;
 
  public:
   ScalarReplacementPass(uint32_t limit = kDefaultLimit)

--- a/source/opt/set_spec_constant_default_value_pass.cpp
+++ b/source/opt/set_spec_constant_default_value_pass.cpp
@@ -30,7 +30,6 @@
 
 namespace spvtools {
 namespace opt {
-
 namespace {
 using utils::EncodeNumberStatus;
 using utils::NumberType;
@@ -217,16 +216,16 @@ Instruction* GetSpecIdTargetFromDecorationGroup(
 
 Pass::Status SetSpecConstantDefaultValuePass::Process() {
   // The operand index of decoration target in an OpDecorate instruction.
-  const uint32_t kTargetIdOperandIndex = 0;
+  constexpr uint32_t kTargetIdOperandIndex = 0;
   // The operand index of the decoration literal in an OpDecorate instruction.
-  const uint32_t kDecorationOperandIndex = 1;
+  constexpr uint32_t kDecorationOperandIndex = 1;
   // The operand index of Spec id literal value in an OpDecorate SpecId
   // instruction.
-  const uint32_t kSpecIdLiteralOperandIndex = 2;
+  constexpr uint32_t kSpecIdLiteralOperandIndex = 2;
   // The number of operands in an OpDecorate SpecId instruction.
-  const uint32_t kOpDecorateSpecIdNumOperands = 3;
+  constexpr uint32_t kOpDecorateSpecIdNumOperands = 3;
   // The in-operand index of the default value in a OpSpecConstant instruction.
-  const uint32_t kOpSpecConstantLiteralInOperandIndex = 0;
+  constexpr uint32_t kOpSpecConstantLiteralInOperandIndex = 0;
 
   bool modified = false;
   // Scan through all the annotation instructions to find 'OpDecorate SpecId'

--- a/source/opt/spread_volatile_semantics.cpp
+++ b/source/opt/spread_volatile_semantics.cpp
@@ -21,11 +21,10 @@
 namespace spvtools {
 namespace opt {
 namespace {
-
-const uint32_t kOpDecorateInOperandBuiltinDecoration = 2u;
-const uint32_t kOpLoadInOperandMemoryOperands = 1u;
-const uint32_t kOpEntryPointInOperandEntryPoint = 1u;
-const uint32_t kOpEntryPointInOperandInterface = 3u;
+constexpr uint32_t kOpDecorateInOperandBuiltinDecoration = 2u;
+constexpr uint32_t kOpLoadInOperandMemoryOperands = 1u;
+constexpr uint32_t kOpEntryPointInOperandEntryPoint = 1u;
+constexpr uint32_t kOpEntryPointInOperandInterface = 3u;
 
 bool HasBuiltinDecoration(analysis::DecorationManager* decoration_manager,
                           uint32_t var_id, uint32_t built_in) {

--- a/source/opt/ssa_rewrite_pass.cpp
+++ b/source/opt/ssa_rewrite_pass.cpp
@@ -63,10 +63,9 @@
 
 namespace spvtools {
 namespace opt {
-
 namespace {
-const uint32_t kStoreValIdInIdx = 1;
-const uint32_t kVariableInitIdInIdx = 1;
+constexpr uint32_t kStoreValIdInIdx = 1;
+constexpr uint32_t kVariableInitIdInIdx = 1;
 }  // namespace
 
 std::string SSARewriter::PhiCandidate::PrettyPrint(const CFG* cfg) const {

--- a/source/opt/strength_reduction_pass.cpp
+++ b/source/opt/strength_reduction_pass.cpp
@@ -28,6 +28,8 @@
 #include "source/opt/log.h"
 #include "source/opt/reflect.h"
 
+namespace spvtools {
+namespace opt {
 namespace {
 // Count the number of trailing zeros in the binary representation of
 // |constVal|.
@@ -52,9 +54,6 @@ bool IsPowerOf2(uint32_t val) {
 }
 
 }  // namespace
-
-namespace spvtools {
-namespace opt {
 
 Pass::Status StrengthReductionPass::Process() {
   // Initialize the member variables on a per module basis.

--- a/source/opt/struct_cfg_analysis.cpp
+++ b/source/opt/struct_cfg_analysis.cpp
@@ -16,13 +16,12 @@
 
 #include "source/opt/ir_context.h"
 
-namespace {
-const uint32_t kMergeNodeIndex = 0;
-const uint32_t kContinueNodeIndex = 1;
-}  // namespace
-
 namespace spvtools {
 namespace opt {
+namespace {
+constexpr uint32_t kMergeNodeIndex = 0;
+constexpr uint32_t kContinueNodeIndex = 1;
+}  // namespace
 
 StructuredCFGAnalysis::StructuredCFGAnalysis(IRContext* ctx) : context_(ctx) {
   // If this is not a shader, there are no merge instructions, and not

--- a/source/opt/type_manager.cpp
+++ b/source/opt/type_manager.cpp
@@ -29,10 +29,8 @@ namespace spvtools {
 namespace opt {
 namespace analysis {
 namespace {
-
-const int kSpvTypePointerStorageClass = 1;
-const int kSpvTypePointerTypeIdInIdx = 2;
-
+constexpr int kSpvTypePointerStorageClass = 1;
+constexpr int kSpvTypePointerTypeIdInIdx = 2;
 }  // namespace
 
 TypeManager::TypeManager(const MessageConsumer& consumer, IRContext* c)

--- a/source/opt/types.cpp
+++ b/source/opt/types.cpp
@@ -64,7 +64,7 @@ bool CompareTwoVectors(const U32VecVec a, const U32VecVec b) {
   return true;
 }
 
-}  // anonymous namespace
+}  // namespace
 
 std::string Type::GetDecorationStr() const {
   std::ostringstream oss;

--- a/source/opt/unify_const_pass.cpp
+++ b/source/opt/unify_const_pass.cpp
@@ -25,7 +25,6 @@
 
 namespace spvtools {
 namespace opt {
-
 namespace {
 
 // The trie that stores a bunch of result ids and, for a given instruction,
@@ -103,7 +102,7 @@ class ResultIdTrie {
 
   std::unique_ptr<Node> root_;  // The root node of the trie.
 };
-}  // anonymous namespace
+}  // namespace
 
 Pass::Status UnifyConstantPass::Process() {
   bool modified = false;

--- a/source/opt/vector_dce.cpp
+++ b/source/opt/vector_dce.cpp
@@ -19,11 +19,9 @@
 namespace spvtools {
 namespace opt {
 namespace {
-
-const uint32_t kExtractCompositeIdInIdx = 0;
-const uint32_t kInsertObjectIdInIdx = 0;
-const uint32_t kInsertCompositeIdInIdx = 1;
-
+constexpr uint32_t kExtractCompositeIdInIdx = 0;
+constexpr uint32_t kInsertObjectIdInIdx = 0;
+constexpr uint32_t kInsertCompositeIdInIdx = 1;
 }  // namespace
 
 Pass::Status VectorDCE::Process() {


### PR DESCRIPTION
Constexpr guaranteed no runtime init in addition to const semantics. Moving all opt/ to constexpr.
Moving all compile-unit statics to anonymous namespaces to uniformize the method used (anonymous namespace vs static has the same behavior here AFAIK).


changes restricted to opt/ subtree:
- changed const to constexpr on global const declaration (and some const)
- moved all static into anonymous namespace, unifying the method used for compile-unit local definition
- removed all static notation when inside an anonymous namespace

Signed-off-by: Nathan Gauër <brioche@google.com>