### PR TITLE
Move string literal into `std::string` to prevent compilation failure

### DIFF
--- a/source/spirv_target_env.cpp
+++ b/source/spirv_target_env.cpp
@@ -415,7 +415,7 @@ std::string spvTargetEnvList(const int pad, const int wrap) {
       max_line_len = wrap;
     }
     line += word;
-    sep = "|";
+    sep = std::string("|");
   }
 
   ret += line;


### PR DESCRIPTION
For quite some time on recent GCC (currently using `12.2.0`) `Vulkan-ValidationLayers` fails to compile with the following `restrict` warning-as-error:

```cpp
In file included from /usr/include/c++/12.2.0/string:40,
                 from Vulkan-ValidationLayers/build/SPIRV-Tools/source/spirv_target_env.h:18,
                 from Vulkan-ValidationLayers/build/SPIRV-Tools/source/spirv_target_env.cpp:15:
In static member function ‘static std::char_traits<char>::char_type* std::char_traits<char>::copy(char_type*, const char_type*, std::size_t)’,
    inlined from ‘static void std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_S_copy(_CharT*, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12.2.0/bits/basic_string.h:423:21,
    inlined from ‘static void std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_S_copy(_CharT*, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12.2.0/bits/basic_string.h:418:7,
    inlined from ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_M_replace(size_type, size_type, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12.2.0/bits/basic_string.tcc:532:22,
    inlined from ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::assign(const _CharT*) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12.2.0/bits/basic_string.h:1647:19,
    inlined from ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::operator=(const _CharT*) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12.2.0/bits/basic_string.h:815:28,
    inlined from ‘std::string spvTargetEnvList(int, int)’ at Vulkan-ValidationLayers/build/SPIRV-Tools/source/spirv_target_env.cpp:418:11:
/usr/include/c++/12.2.0/bits/char_traits.h:431:56: error: ‘void* __builtin_memcpy(void*, const void*, long unsigned int)’ accessing 9223372036854775810 or more bytes at offsets -4611686018427387902 and [-4611686018427387903, 4611686018427387904] may overlap up to 9223372036854775813 bytes at offset -3 [-Werror=restrict]
  431 |         return static_cast<char_type*>(__builtin_memcpy(__s1, __s2, __n));
      |                                        ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/12.2.0/string:40,
                 from Vulkan-ValidationLayers/build/SPIRV-Tools/source/spirv_target_env.h:18,
                 from Vulkan-ValidationLayers/build/SPIRV-Tools/source/spirv_target_env.cpp:15:
In static member function ‘static std::char_traits<char>::char_type* std::char_traits<char>::copy(char_type*, const char_type*, std::size_t)’,
    inlined from ‘static void std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_S_copy(_CharT*, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12.2.0/bits/basic_string.h:423:21,
    inlined from ‘static void std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_S_copy(_CharT*, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12.2.0/bits/basic_string.h:418:7,
    inlined from ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_M_replace(size_type, size_type, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12.2.0/bits/basic_string.tcc:532:22,
    inlined from ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::assign(const _CharT*) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12.2.0/bits/basic_string.h:1647:19,
    inlined from ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::operator=(const _CharT*) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>]’ at /usr/include/c++/12.2.0/bits/basic_string.h:815:28,
    inlined from ‘std::string spvTargetEnvList(int, int)’ at Vulkan-ValidationLayers/build/SPIRV-Tools/source/spirv_target_env.cpp:418:11:
/usr/include/c++/12.2.0/bits/char_traits.h:431:56: error: ‘void* __builtin_memcpy(void*, const void*, long unsigned int)’ accessing 9223372036854775810 or more bytes at offsets -4611686018427387902 and [-4611686018427387903, 4611686018427387904] may overlap up to 9223372036854775813 bytes at offset -3 [-Werror=restrict]
  431 |         return static_cast<char_type*>(__builtin_memcpy(__s1, __s2, __n));
      |                                        ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
```

My C++-fu long passed, and I can only guess that it's performing some strange optimization where it attempts to copy the longer `"|"` string literal over `""` while trying to avoid allocating/instantiating a runtime `std::string`?  Either way, copying `"|"` to `std::string` before overwriting `sep` solves it, allowing me to compile `Vulkan-ValidationLayers` again.  Let me know if there's a better way of doing this (such as changing the type to `const char *` to represent the string literal const-ness, but that makes `word = sep + name_env.first` not work OOTB)!
