### PR TITLE
Roll external/spirv-headers/ 47f2465ee..1d31a1004 (13 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -6,7 +6,7 @@ vars = {
   'effcee_revision': '35912e1b7778ec2ddcff7e7188177761539e59e0',
   'googletest_revision': 'd9bb8412d60b993365abb53f00b6dad9b2c01b62',
   're2_revision': 'd2836d1b1c34c4e330a85a1006201db474bf2c8a',
-  'spirv_headers_revision': '47f2465ee3e78ec5ec38f00b2c405d9475797228',
+  'spirv_headers_revision': '1d31a100405cf8783ca7a31e31cdd727c9fc54c3',
 }
 
 deps = {


### PR DESCRIPTION
https://github.com/KhronosGroup/SPIRV-Headers/compare/47f2465ee3e7...1d31a100405c

$ git log 47f2465ee..1d31a1004 --date=short --no-merges --format='%ad %ae %s' 2022-12-01 admin Update spir-v.xml
2022-12-01 admin Update spir-v.xml
2022-11-25 stephen.clarke Update spir-v.xml
2022-11-17 admin Register Taichi as SPIR-V generator 2022-11-16 dmitry.sidorov Remove unnecessary extensions addition 2022-11-14 alele Remove extension
2022-11-07 alele Fix typo.
2022-11-07 alele Review feedback 1.
2022-10-05 alele Add headers for SPV_NV_shader_invocation_reorder. 2022-10-17 dmitry.sidorov Add SPV_INTEL_runtime_aligned 2022-10-17 dmitry.sidorov Add SPV_INTEL_fpga_dsp_control 2022-10-17 dmitry.sidorov Add SPV_INTEL_fpga_invocation_pipelining_attributes 2022-10-17 dmitry.sidorov Update SPV_INTEL_fpga_loop_controls to rev I

Created with:
  roll-dep external/spirv-headers