### PR TITLE
Fix for bug #5017

### DIFF
--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -203,11 +203,12 @@ std::string ValidateIdWithMessage::make_message(const char* msg) {
     // Parse 'num[%name]'
     size_t open_quote = message.find('\'', next);
 
-    // Copy up to the first quote
-    result.write(msg + next, open_quote - next);
     if (open_quote == std::string::npos) {
       break;
     }
+
+    // Copy up to the first quote
+    result.write(msg + next, open_quote - next);
     // Handle apostrophes
     if (!isdigit(message[open_quote + 1])) {
       result << '\'';


### PR DESCRIPTION
open_quote value becomes npos when it fails to find '\'' and then is used to compute the string length for writing to result. This causes crash in win32 builds of the test.