### PR TITLE
Optimize allocation of spvtools::opt::Instruction::operands_

### DIFF
--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -73,6 +73,7 @@ Instruction::Instruction(IRContext* c, const spv_parsed_instruction_t& inst,
       unique_id_(c->TakeNextUniqueId()),
       dbg_line_insts_(std::move(dbg_line)),
       dbg_scope_(kNoDebugScope, kNoInlinedAt) {
+  operands_.reserve(inst.num_operands);
   for (uint32_t i = 0; i < inst.num_operands; ++i) {
     const auto& current_payload = inst.operands[i];
     operands_.emplace_back(
@@ -92,6 +93,7 @@ Instruction::Instruction(IRContext* c, const spv_parsed_instruction_t& inst,
       has_result_id_(inst.result_id != 0),
       unique_id_(c->TakeNextUniqueId()),
       dbg_scope_(dbg_scope) {
+  operands_.reserve(inst.num_operands);
   for (uint32_t i = 0; i < inst.num_operands; ++i) {
     const auto& current_payload = inst.operands[i];
     operands_.emplace_back(
@@ -110,6 +112,14 @@ Instruction::Instruction(IRContext* c, spv::Op op, uint32_t ty_id,
       unique_id_(c->TakeNextUniqueId()),
       operands_(),
       dbg_scope_(kNoDebugScope, kNoInlinedAt) {
+  size_t operands_size = in_operands.size();
+  if (has_type_id_) {
+    operands_size++;
+  }
+  if (has_result_id_) {
+    operands_size++;
+  }
+  operands_.reserve(operands_size);
   if (has_type_id_) {
     operands_.emplace_back(spv_operand_type_t::SPV_OPERAND_TYPE_TYPE_ID,
                            std::initializer_list<uint32_t>{ty_id});


### PR DESCRIPTION
Reserve space for the entire operand list rather than adding them one a time.