### PR TITLE
Add Github Actions to test Bazel builds.

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    timeout-minutes: 10
+    timeout-minutes: 120
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -15,7 +15,12 @@ jobs:
       - uses: actions/checkout@v3
       - name: Download dependencies
         run: python3 utils/git-sync-deps
+      - name: Mount Bazel cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.bazel/cache
+          key: bazel-cache-${{ runner.os }}
       - name: Build All
-        run: bazel build //...
+        run: bazel --output_user_root=~/.bazel/cache build //...
       - name: Test All
-        run: bazel test //...
+        run: bazel --output_user_root=~/.bazel/cache test //...

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,0 +1,21 @@
+name: Build and Test with Bazel
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{matrix.os}}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download dependencies
+        run: python3 utils/git-sync-deps
+      - name: Build All
+        run: bazel build //...
+      - name: Test All
+        run: bazel test //...

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,6 +1,6 @@
 name: Wasm Build
 
-on: [ push, pull_request ]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
SPIRV-Tools already uses Kokoro to run CI but it requires a member of the organization to manually add tags to the PR to start the CI process. This is somewhat cumbersome if you have contributors from multiple timezones.

To fix that I'm adding Github Actions to Build/Test this repository using the Bazel builds. The build is relatively slow (~30m) due to the small amount of resources on the freely hosted Github runners. We use caches to bring no-op Linux/Mac builds to ~2m. The Windows ones are unfortunately not working right now but it does not break the build.