### PR TITLE
wasm: Avoid use-after-free from the assembler

### DIFF
--- a/source/wasm/spirv-tools.cpp
+++ b/source/wasm/spirv-tools.cpp
@@ -39,21 +39,21 @@ std::string dis(std::string const& buffer, uint32_t env, uint32_t options) {
   return disassembly;
 }
 
-emscripten::val as(std::string const& source, uint32_t env, uint32_t options) {
+std::string as(std::string const& source, uint32_t env, uint32_t options) {
   spvtools::SpirvTools core(static_cast<spv_target_env>(env));
   core.SetMessageConsumer(print_msg_to_stderr);
 
   std::vector<uint32_t> spirv;
   if (!core.Assemble(source, &spirv, options)) spirv.clear();
-  const uint8_t* ptr = reinterpret_cast<const uint8_t*>(spirv.data());
-  return emscripten::val(emscripten::typed_memory_view(spirv.size() * 4,
-    ptr));
+  // Copy the data out.
+  const auto* ptr = reinterpret_cast<const char*>(spirv.data());
+  return std::string(ptr,spirv.size()*4);
 }
 
 EMSCRIPTEN_BINDINGS(my_module) {
   function("dis", &dis);
   function("as", &as);
-  
+
   constant("SPV_ENV_UNIVERSAL_1_0", static_cast<uint32_t>(SPV_ENV_UNIVERSAL_1_0));
   constant("SPV_ENV_VULKAN_1_0", static_cast<uint32_t>(SPV_ENV_VULKAN_1_0));
   constant("SPV_ENV_UNIVERSAL_1_1", static_cast<uint32_t>(SPV_ENV_UNIVERSAL_1_1));

--- a/test/wasm/test.js
+++ b/test/wasm/test.js
@@ -48,7 +48,7 @@ const test = async () => {
     spv.SPV_ENV_UNIVERSAL_1_3,
     spv.SPV_TEXT_TO_BINARY_OPTION_NONE
   );
-  console.log(`as returned ${asResult.byteLength} bytes`);
+  console.log(`as returned ${asResult.length} bytes`);
 
   // re-disassemble
   const disResult = spv.dis(


### PR DESCRIPTION
Copy the data out instead of returning a view into a locally-declared vector.

Fixes: #5036