### PR TITLE
utils: repos use 'main' as main devlopment branch

### DIFF
--- a/utils/check_code_format.sh
+++ b/utils/check_code_format.sh
@@ -18,7 +18,7 @@
 #
 # This script assumes to be invoked at the project root directory.
 
-BASE_BRANCH=${1:-master}
+BASE_BRANCH=${1:-main}
 
 FILES_TO_CHECK=$(git diff --name-only ${BASE_BRANCH} | grep -E ".*\.(cpp|cc|c\+\+|cxx|c|h|hpp)$")
 

--- a/utils/roll_deps.sh
+++ b/utils/roll_deps.sh
@@ -27,7 +27,7 @@ googletest_trunk="origin/main"
 re2_dir="external/re2/"
 re2_trunk="origin/main"
 spirv_headers_dir="external/spirv-headers/"
-spirv_headers_trunk="origin/master"
+spirv_headers_trunk="origin/main"
 
 # This script assumes it's parent directory is the repo root.
 repo_path=$(dirname "$0")/..


### PR DESCRIPTION
roll_deps.h: SPIRV-Headers uses 'main'
check_code_format.h: SPIRV-Tools uses 'main'