### PR TITLE
Prepare for v2023.1 release

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
 Revision history for SPIRV-Tools
 
-v2022.5-dev 2023-01-13
+v2023.1-dev 2023-01-13
   - General
     - Renamed "master" to "main" (issue#5051)
     - Validate version 5 of clspv reflection (#5050)

--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,31 @@
 Revision history for SPIRV-Tools
 
-v2022.5-dev 2022-10-12
-  - Renamed "master" to "main" (issue#5051)
+v2022.5-dev 2023-01-13
+  - General
+    - Renamed "master" to "main" (issue#5051)
+    - Validate version 5 of clspv reflection (#5050)
+    - Remove testing support for VS2015 (#5027)
+    - Fix undef behaviour in hex float parsing (#5025)
+    - Require C++11 *or later* (#5020)
+  - Optimizer
+    - Optimize allocation of spvtools::opt::Instruction::operands_ (#5024)
+    - spirv-opt: Fix OpCompositeInsert with Null Constant (#5008)
+    - spirv-opt: Handle null CompositeInsert (#4998)
+    - Add option to ADCE to remove output variables from interface. (#4994)
+    - Add support for tesc, tese and geom to EliminateDead*Components (#4990)
+    - Add pass to eliminate dead output components (#4982)
+    - spirv-opt: Add const folding for CompositeInsert (#4943)
+    - Add passes to eliminate dead output stores (#4970)
+    - Prevent eliminating case constructs in block merging (#4976)
+  - Validator
+    - Fix layout validation (#5015)
+    - Fix use of invalid analysis (#5013)
+    - Fix infinite loop in validator (#5006)
+    - Add validation support for SPV_NV_shader_invocation_reorder. (#4979)
+    - Only validate full layout in Vulkan environments (#4972)
+    - spirv-val: Label new Vulkan OpPtrAccessChain VUs (#4975)
+    - spirv-val: Add OpPtrAccessChain Base checks (#4965)
+
 
 v2022.4 2022-10-12
   - General

--- a/DEPS
+++ b/DEPS
@@ -3,7 +3,7 @@ use_relative_paths = True
 vars = {
   'github': 'https://github.com',
 
-  'effcee_revision': '35912e1b7778ec2ddcff7e7188177761539e59e0',
+  'effcee_revision': 'c7b4db79f340f7a9981e8a484f6d5785e24242d1',
 
   # Pin to the last version of googletest that supports C++11.
   # Anything later requires C++14

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@ vars = {
   # Use protobufs before they gained the dependency on abseil
   'protobuf_revision': 'v3.13.0.1',
 
-  're2_revision': 'd2836d1b1c34c4e330a85a1006201db474bf2c8a',
+  're2_revision': '954656f47fe8fb505d4818da1e128417a79ea500',
   'spirv_headers_revision': 'd13b52222c39a7e9a401b44646f0ca3a640fbd47',
 }
 

--- a/DEPS
+++ b/DEPS
@@ -7,7 +7,7 @@ vars = {
 
   # Pin to the last version of googletest that supports C++11.
   # Anything later requires C++14
-  'googletest_revision': 'v1.12.0',
+  'googletest_revision': '356fc301251378e0f6fa6aa794d73714202887ac',
 
   # Use protobufs before they gained the dependency on abseil
   'protobuf_revision': 'v3.13.0.1',

--- a/DEPS
+++ b/DEPS
@@ -7,7 +7,7 @@ vars = {
 
   # Pin to the last version of googletest that supports C++11.
   # Anything later requires C++14
-  'googletest_revision': '356fc301251378e0f6fa6aa794d73714202887ac',
+  'googletest_revision': 'v1.12.0',
 
   # Use protobufs before they gained the dependency on abseil
   'protobuf_revision': 'v3.13.0.1',


### PR DESCRIPTION
This prepares the `main` branch for the upcoming SPIRV-Tools release.  Testing in progress.