### PR TITLE
Revert "Finalize v2023.1 release"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,6 @@
 Revision history for SPIRV-Tools
 
-v2023.2-dev 2023-01-17
-   - Start v2023.2-dev
-
-v2023.1 2023-01-17
+v2023.1-dev 2023-01-13
   - General
     - Renamed "master" to "main" (issue#5051)
     - Validate version 5 of clspv reflection (#5050)


### PR DESCRIPTION
Reverts KhronosGroup/SPIRV-Tools#5062

I did not pay attention to the fact that we want these two commits registered separately in the repo.  This way we can mark the end point of the v2023.1 release properly.  Apologies for the carelessness.