### PR TITLE
spirv-val: Conditional Branch without an exit is invalid in loop header

### DIFF
--- a/source/val/validate_cfg.cpp
+++ b/source/val/validate_cfg.cpp
@@ -671,7 +671,8 @@ spv_result_t ValidateStructuredSelections(
       // previously.
       const bool true_label_unseen = seen.insert(true_label).second;
       const bool false_label_unseen = seen.insert(false_label).second;
-      if (!merge && true_label_unseen && false_label_unseen) {
+      if ((!merge || merge->opcode() == spv::Op::OpLoopMerge) &&
+          true_label_unseen && false_label_unseen) {
         return _.diag(SPV_ERROR_INVALID_CFG, terminator)
                << "Selection must be structured";
       }

--- a/test/fuzz/transformation_add_dead_block_test.cpp
+++ b/test/fuzz/transformation_add_dead_block_test.cpp
@@ -295,11 +295,16 @@ TEST(TransformationAddDeadBlockTest, TargetBlockMustNotBeLoopMergeOrContinue) {
                OpBranch %8
           %8 = OpLabel
                OpLoopMerge %12 %11 None
+               OpBranch %13
+         %13 = OpLabel
+               OpSelectionMerge %14 None
                OpBranchConditional %5 %9 %10
           %9 = OpLabel
                OpBranch %11
          %10 = OpLabel
                OpBranch %12
+         %14 = OpLabel
+               OpUnreachable
          %11 = OpLabel
                OpBranch %8
          %12 = OpLabel

--- a/test/fuzz/transformation_add_dead_break_test.cpp
+++ b/test/fuzz/transformation_add_dead_break_test.cpp
@@ -2743,6 +2743,9 @@ TEST(TransformationAddDeadBreakTest, RespectDominanceRules7) {
                OpBranch %100
         %100 = OpLabel
                OpLoopMerge %101 %104 None
+               OpBranch %105
+        %105 = OpLabel
+               OpSelectionMerge %106 None
                OpBranchConditional %11 %102 %103
         %103 = OpLabel
         %200 = OpCopyObject %10 %11
@@ -2752,6 +2755,8 @@ TEST(TransformationAddDeadBreakTest, RespectDominanceRules7) {
                OpReturn
         %102 = OpLabel
                OpBranch %103
+        %106 = OpLabel
+               OpUnreachable
         %104 = OpLabel
                OpBranch %100
                OpFunctionEnd
@@ -2791,12 +2796,17 @@ TEST(TransformationAddDeadBreakTest, RespectDominanceRules8) {
                OpBranch %100
         %100 = OpLabel
                OpLoopMerge %101 %104 None
+               OpBranch %105
+        %105 = OpLabel
+               OpSelectionMerge %106 None
                OpBranchConditional %11 %102 %103
         %103 = OpLabel
         %200 = OpCopyObject %10 %11
                OpBranch %101
         %102 = OpLabel
                OpBranch %103
+        %106 = OpLabel
+               OpUnreachable
         %101 = OpLabel
         %201 = OpCopyObject %10 %200
                OpReturn

--- a/test/val/val_cfg_test.cpp
+++ b/test/val/val_cfg_test.cpp
@@ -3546,6 +3546,37 @@ OpFunctionEnd
   EXPECT_THAT(getDiagnosticString(), HasSubstr("Selection must be structured"));
 }
 
+TEST_F(ValidateCFG, LoopConditionalBranchWithoutExitBad) {
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Linkage
+OpMemoryModel Logical GLSL450
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%bool = OpTypeBool
+%undef = OpUndef %bool
+%func = OpFunction %void None %void_fn
+%entry = OpLabel
+OpBranch %loop
+%loop = OpLabel
+OpLoopMerge %exit %continue None
+OpBranchConditional %undef %then %else
+%then = OpLabel
+OpBranch %continue
+%else = OpLabel
+OpBranch %exit
+%continue = OpLabel
+OpBranch %loop
+%exit = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text);
+  EXPECT_EQ(SPV_ERROR_INVALID_CFG, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Selection must be structured"));
+}
+
 TEST_F(ValidateCFG, MissingMergeSwitchBad) {
   const std::string text = R"(
 OpCapability Shader


### PR DESCRIPTION
From 2.16.2, for CFG:

```
Selections must be structured. That is, an OpSelectionMerge instruction is required to precede:

    an OpSwitch instruction

    an OpBranchConditional instruction that has different True Label and False Label operands where neither are declared merge blocks or Continue Targets.
```