### PR TITLE
Limit when the github action bazel builds run

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,6 +1,10 @@
 name: Build and Test with Bazel
 
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - 'main'
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
The bazel build are set up to run any time there is a push to any branch. This
cause the same workflow to be run twice when a PR is updated.

I'm changing the workflow to trigger on there is a push to "main", for the
continuous test, and leaving the pull_request trigger for the presubmit test.
