### PR TITLE
Rename bot in autoroll.yml

### DIFF
--- a/.github/workflows/autoroll.yml
+++ b/.github/workflows/autoroll.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Setup git user information
         run: |
-          git config user.name "GitHub Actions bot"
+          git config user.name "GitHub Actions[bot]"
           git config user.email "<>"
           git checkout -b roll_deps
 


### PR DESCRIPTION
The current bot is having trouble with the CLA. I checked with the Khronos
admin, and this was his reply:

> We already safe list *[bot] which should account for all GitHub bots. If you
have manually named the GitHub Actions bot to GitHub Actions bot, it should be
renamed to GitHub Actions[bot]. This should resolve the issue.

Trying that to see if it works.
