### PR TITLE
kokoro: fix dubious ownership

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,6 +1,6 @@
 name: Build and Test with Bazel
 
-on: 
+on:
   push:
     branches:
       - 'main'
@@ -17,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
       - name: Download dependencies
         run: python3 utils/git-sync-deps
       - name: Mount Bazel cache

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -7,7 +7,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
       - name: Build web
         run: docker-compose -f source/wasm/docker-compose.yml --project-directory . up
       - name: Run tests

--- a/kokoro/check-format/build.sh
+++ b/kokoro/check-format/build.sh
@@ -23,6 +23,11 @@ set -x
 BUILD_ROOT=$PWD
 SRC=$PWD/github/SPIRV-Tools
 
+# This is required to run any git command in the docker since owner will
+# have changed between the clone environment, and the docker container.
+# Marking the root of the repo as safe for ownership changes.
+git config --global --add safe.directory $SRC
+
 # Get clang-format-5.0.0.
 # Once kokoro upgrades the Ubuntu VMs, we can use 'apt-get install clang-format'
 curl -L http://releases.llvm.org/5.0.0/clang+llvm-5.0.0-linux-x86_64-ubuntu14.04.tar.xz -o clang-llvm.tar.xz

--- a/kokoro/macos-clang-debug/build.sh
+++ b/kokoro/macos-clang-debug/build.sh
@@ -22,4 +22,3 @@ set -x
 
 SCRIPT_DIR=`dirname "$BASH_SOURCE"`
 source $SCRIPT_DIR/../scripts/macos/build.sh Debug
-

--- a/kokoro/macos-clang-release-bazel/build.sh
+++ b/kokoro/macos-clang-release-bazel/build.sh
@@ -24,6 +24,11 @@ CC=clang
 CXX=clang++
 SRC=$PWD/github/SPIRV-Tools
 
+# This is required to run any git command in the docker since owner will
+# have changed between the clone environment, and the docker container.
+# Marking the root of the repo as safe for ownership changes.
+git config --global --add safe.directory $SRC
+
 cd $SRC
 git clone --depth=1 https://github.com/KhronosGroup/SPIRV-Headers external/spirv-headers
 git clone https://github.com/google/googletest          external/googletest

--- a/kokoro/macos-clang-release/build.sh
+++ b/kokoro/macos-clang-release/build.sh
@@ -22,4 +22,3 @@ set -x
 
 SCRIPT_DIR=`dirname "$BASH_SOURCE"`
 source $SCRIPT_DIR/../scripts/macos/build.sh RelWithDebInfo
-

--- a/kokoro/scripts/linux/build-docker.sh
+++ b/kokoro/scripts/linux/build-docker.sh
@@ -20,6 +20,11 @@ set -e
 # Display commands being run.
 set -x
 
+# This is required to run any git command in the docker since owner will
+# have changed between the clone environment, and the docker container.
+# Marking the root of the repo as safe for ownership changes.
+git config --global --add safe.directory $ROOT_DIR
+
 . /bin/using.sh # Declare the bash `using` function for configuring toolchains.
 
 if [ $COMPILER = "clang" ]; then

--- a/kokoro/scripts/macos/build.sh
+++ b/kokoro/scripts/macos/build.sh
@@ -24,6 +24,11 @@ BUILD_ROOT=$PWD
 SRC=$PWD/github/SPIRV-Tools
 BUILD_TYPE=$1
 
+# This is required to run any git command in the docker since owner will
+# have changed between the clone environment, and the docker container.
+# Marking the root of the repo as safe for ownership changes.
+git config --global --add safe.directory $SRC
+
 # Get NINJA.
 wget -q https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-mac.zip
 unzip -q ninja-mac.zip

--- a/source/wasm/build.sh
+++ b/source/wasm/build.sh
@@ -16,6 +16,11 @@
 
 set -e
 
+# This is required to run any git command in the docker since owner will
+# have changed between the clone environment, and the docker container.
+# Marking the root of the repo as safe for ownership changes.
+git config --global --add safe.directory /app
+
 NUM_CORES=$(nproc)
 echo "Detected $NUM_CORES cores for building"
 


### PR DESCRIPTION
Kokoro clones repos with a different user used to run the build steps, meaning if some git command must be run at build time, they will fail because of this dubious ownership issue.
Running some git commands makes only sense with history, so changing checkout depth so we can run them and get the true result.

This is a known Kororo issue.
Fixing this is required to generate the version file using git history.

Signed-off-by: Nathan Gauër <brioche@google.com>