### PR TITLE
BUILD.gn: Make MSVC report the correct __cplusplus value

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -370,6 +370,9 @@ config("spvtools_internal_config") {
   } else if (!is_win) {
     # Work around a false-positive on a Skia GCC 10 builder.
     cflags += [ "-Wno-format-truncation" ]
+  } else {
+    # Make MSVC report the correct value for __cplusplus
+    cflags += [ "/Zc:__cplusplus" ]
   }
 }
 


### PR DESCRIPTION
PTAL @ben-clayton 