### PR TITLE
build: allow update_build to generate fake version

### DIFF
--- a/utils/update_build_version.py
+++ b/utils/update_build_version.py
@@ -142,7 +142,7 @@ def get_description_for_head(repo_path):
 
     success, output = command_output(['git', 'describe'], repo_path)
     if not success:
-      output = command_output(['git', 'rev-parse', 'HEAD'], repo_path)
+      success, output = command_output(['git', 'rev-parse', 'HEAD'], repo_path)
 
     if success:
       # decode() is needed here for Python3 compatibility. In Python2,
@@ -158,16 +158,12 @@ def get_description_for_head(repo_path):
     # reproducible builds, allow the builder to override the wall
     # clock time with environment variable SOURCE_DATE_EPOCH
     # containing a (presumably) fixed timestamp.
-    timestamp = int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
-    iso_date = datetime.datetime.utcfromtimestamp(timestamp).isoformat()
-    return "unknown hash, {}".format(iso_date)
-
-def is_folder_git_repo(path):
-  try:
-    success, _ = command_output(['git', 'branch'], path)
-  except NotADirectoryError as e:
-    return False
-  return success
+    if 'SOURCE_DATE_EPOCH' in os.environ:
+      timestamp = int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+      iso_date = datetime.datetime.utcfromtimestamp(timestamp).isoformat()
+    else:
+      iso_date = datetime.datetime.now().isoformat()
+    return "unknown_hash, {}".format(iso_date)
 
 def main():
     FORMAT = '%(asctime)s %(message)s'
@@ -181,8 +177,8 @@ def main():
 
     success, version = deduce_current_release(repo_path)
     if not success:
-      logging.error("Could not deduce latest release version.")
-      sys.exit(1)
+      logging.warning("Could not deduce latest release version from history.")
+      version = "unknown_version"
 
     description = get_description_for_head(repo_path)
     content = OUTPUT_FORMAT.format(version_tag=version, description=description)


### PR DESCRIPTION
When the build is done on a shallow repo, or on a non-git copy, the version script failed. We should not hard fail, but generate a "version" (unknown).

Sample outputs:

with git history:
`"v2023.2-dev", "SPIRV-Tools v2023.2-dev v2022.4-87-g53541064"`

with shallow clone:
`"unknown_version", "SPIRV-Tools unknown_version d8759a140bc65811332d5f91f3b08febadd5a21d"`

not a git repo:
`"unknown_version", "SPIRV-Tools unknown_version unknown_hash, 2023-02-02T16:25:48.077995"`