### PR TITLE
Change exec_tools -> tools for local genrule

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -107,7 +107,9 @@ genrule(
     outs = ["build-version.inc"],
     cmd = "SOURCE_DATE_EPOCH=0 $(location :update_build_version) $(RULEDIR) $(location build-version.inc)",
     cmd_bat = "set SOURCE_DATE_EPOCH=0  && $(location :update_build_version) $(RULEDIR) $(location build-version.inc)",
-    exec_tools = [":update_build_version"],
+    # This is explicitly tools and not exec_tools because we run it locally (on the host platform) instead of
+    # (potentially remotely) on the execution platform.
+    tools = [":update_build_version"],
     local = True,
 )
 


### PR DESCRIPTION
Without this, Mac developers could not build using our remote linux RBE instance.