### PR TITLE
Remove duplicate lists of constant and type opcodes

### DIFF
--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -240,6 +240,7 @@ int32_t spvOpcodeIsConstant(const spv::Op opcode) {
     case spv::Op::OpConstantComposite:
     case spv::Op::OpConstantSampler:
     case spv::Op::OpConstantNull:
+    case spv::Op::OpConstantFunctionPointerINTEL:
     case spv::Op::OpSpecConstantTrue:
     case spv::Op::OpSpecConstantFalse:
     case spv::Op::OpSpecConstant:

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -906,7 +906,7 @@ bool Instruction::IsAtomicWithLoad() const {
 bool Instruction::IsAtomicOp() const { return spvOpcodeIsAtomicOp(opcode()); }
 
 bool Instruction::IsConstant() const {
-  return IsCompileTimeConstantInst(opcode());
+  return IsConstantInst(opcode()) && !IsSpecConstantInst(opcode());
 }
 }  // namespace opt
 }  // namespace spvtools

--- a/source/opt/reflect.h
+++ b/source/opt/reflect.h
@@ -46,27 +46,14 @@ inline bool IsAnnotationInst(spv::Op opcode) {
          opcode == spv::Op::OpMemberDecorateStringGOOGLE;
 }
 inline bool IsTypeInst(spv::Op opcode) {
-  return (opcode >= spv::Op::OpTypeVoid &&
-          opcode <= spv::Op::OpTypeForwardPointer) ||
-         opcode == spv::Op::OpTypePipeStorage ||
-         opcode == spv::Op::OpTypeNamedBarrier ||
-         opcode == spv::Op::OpTypeAccelerationStructureNV ||
-         opcode == spv::Op::OpTypeAccelerationStructureKHR ||
-         opcode == spv::Op::OpTypeRayQueryKHR ||
-         opcode == spv::Op::OpTypeCooperativeMatrixNV ||
-         opcode == spv::Op::OpTypeHitObjectNV;
+  return spvOpcodeGeneratesType(opcode) ||
+         opcode == spv::Op::OpTypeForwardPointer;
 }
 inline bool IsConstantInst(spv::Op opcode) {
-  return (opcode >= spv::Op::OpConstantTrue &&
-          opcode <= spv::Op::OpSpecConstantOp) ||
-         opcode == spv::Op::OpConstantFunctionPointerINTEL;
-}
-inline bool IsCompileTimeConstantInst(spv::Op opcode) {
-  return opcode >= spv::Op::OpConstantTrue && opcode <= spv::Op::OpConstantNull;
+  return spvOpcodeIsConstant(opcode);
 }
 inline bool IsSpecConstantInst(spv::Op opcode) {
-  return opcode >= spv::Op::OpSpecConstantTrue &&
-         opcode <= spv::Op::OpSpecConstantOp;
+  return spvOpcodeIsSpecConstant(opcode);
 }
 
 }  // namespace opt


### PR DESCRIPTION
Adding a new type instruction required making the same change in two places.

Also remove IsCompileTimeConstantInst that was used in a single place and replace its use by an expression that IMO better conveys the intent.

Change-Id: I49330b74bd34a35db6369c438c053224805c18e0
Signed-off-by: Kevin Petit <kevin.petit@arm.com>