### PR TITLE
opt: fix spirv ABI on Linux again.

### DIFF
--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -525,8 +525,10 @@ Optimizer::PassToken CreateDeadInsertElimPass();
 // If |remove_outputs| is true, allow outputs to be removed from the interface.
 // This is only safe if the caller knows that there is no corresponding input
 // variable in the following shader. It is false by default.
-Optimizer::PassToken CreateAggressiveDCEPass(bool preserve_interface = false,
-                                             bool remove_outputs = false);
+Optimizer::PassToken CreateAggressiveDCEPass();
+Optimizer::PassToken CreateAggressiveDCEPass(bool preserve_interface);
+Optimizer::PassToken CreateAggressiveDCEPass(bool preserve_interface,
+                                             bool remove_outputs);
 
 // Creates a remove-unused-interface-variables pass.
 // Removes variables referenced on the |OpEntryPoint| instruction that are not

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -785,6 +785,16 @@ Optimizer::PassToken CreateLocalMultiStoreElimPass() {
       MakeUnique<opt::SSARewritePass>());
 }
 
+Optimizer::PassToken CreateAggressiveDCEPass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::AggressiveDCEPass>(false, false));
+}
+
+Optimizer::PassToken CreateAggressiveDCEPass(bool preserve_interface) {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::AggressiveDCEPass>(preserve_interface, false));
+}
+
 Optimizer::PassToken CreateAggressiveDCEPass(bool preserve_interface,
                                              bool remove_outputs) {
   return MakeUnique<Optimizer::PassToken::Impl>(


### PR DESCRIPTION
Breaking the ABI for this API isn't worth it when the fix is so simple.

81ec2aaa0e170afbeaaf3deaccf88f7dc88672d7
Author: Greg Fischer <greg@lunarg.com>
Date:   Wed Nov 23 10:48:58 2022 -0700

    Add option to ADCE to remove output variables from interface. (#4994)

in #4994 broke ABI for the library incompatibility.

Just avoid that.
