### PR TITLE
build: change the way we set cxx version for bazel.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,0 @@
-build --cxxopt=-std=c++17

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -26,7 +26,15 @@ jobs:
         with:
           path: ~/.bazel/cache
           key: bazel-cache-${{ runner.os }}
-      - name: Build All
-        run: bazel --output_user_root=~/.bazel/cache build //...
-      - name: Test All
-        run: bazel --output_user_root=~/.bazel/cache test //...
+      - name: Build All (Windows)
+        if: ${{matrix.os == 'windows-latest' }}
+        run: bazel --output_user_root=~/.bazel/cache build --cxxopt=/std:c++17 //...
+      - name: Test All (Windows)
+        if: ${{matrix.os == 'windows-latest' }}
+        run: bazel --output_user_root=~/.bazel/cache test --cxxopt=/std:c++17 //...
+      - name: Build All (Linux, MacOS)
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: bazel --output_user_root=~/.bazel/cache build --cxxopt=-std=c++17 //...
+      - name: Test All (Linux, MacOS)
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: bazel --output_user_root=~/.bazel/cache test --cxxopt=-std=c++17 //...

--- a/README.md
+++ b/README.md
@@ -380,10 +380,18 @@ fuzzer tests.
 
 ### Build using Bazel
 You can also use [Bazel](https://bazel.build/) to build the project.
+
+On linux:
 ```sh
 cd <spirv-dir>
-bazel build :all
+bazel build --cxxopt=-std=c++17 :all
 ```
+
+On windows:
+```sh
+bazel build --cxxopt=/std:c++17 :all
+```
+
 ### Build a node.js package using Emscripten
 
 The SPIRV-Tools core library can be built to a WebAssembly [node.js](https://nodejs.org)
@@ -723,10 +731,16 @@ Use `bazel test :all` to run all tests. This will run tests in parallel by defau
 To run a single test target, specify `:my_test_target` instead of `:all`. Test target
 names get printed when you run `bazel test :all`. For example, you can run
 `opt_def_use_test` with:
+
+on linux:
 ```shell
-bazel test :opt_def_use_test
+bazel test --cxxopt=-std=c++17 :opt_def_use_test
 ```
 
+on windows:
+```shell
+bazel test --cxxopt=/std:c++17 :opt_def_use_test
+```
 
 ## Future Work
 <a name="future"></a>

--- a/kokoro/macos-clang-release-bazel/build.sh
+++ b/kokoro/macos-clang-release-bazel/build.sh
@@ -41,9 +41,9 @@ gsutil cp gs://bazel/5.0.0/release/bazel-5.0.0-darwin-x86_64 .
 chmod +x bazel-5.0.0-darwin-x86_64
 
 echo $(date): Build everything...
-./bazel-5.0.0-darwin-x86_64 build :all
+./bazel-5.0.0-darwin-x86_64 build --cxxopt=-std=c++17 :all
 echo $(date): Build completed.
 
 echo $(date): Starting bazel test...
-./bazel-5.0.0-darwin-x86_64 test :all
+./bazel-5.0.0-darwin-x86_64 test --cxxopt=-std=c++17 :all
 echo $(date): Bazel test completed.

--- a/kokoro/scripts/linux/build-docker.sh
+++ b/kokoro/scripts/linux/build-docker.sh
@@ -191,10 +191,10 @@ elif [ $TOOL = "bazel" ]; then
   using bazel-5.0.0
 
   echo $(date): Build everything...
-  bazel build :all
+  bazel build --cxxopt=-std=c++17 :all
   echo $(date): Build completed.
 
   echo $(date): Starting bazel test...
-  bazel test :all
+  bazel test --cxxopt=-std=c++17 :all
   echo $(date): Bazel test completed.
 fi


### PR DESCRIPTION
Before, we did set cxx version to c++17 using COPTS in our bazel files. This was wrong, and part of the dependencies were then built with the default standard version. This was not an issue until we moved to c++17.

Then, we decided to use the bazel --cxxopt=-std=c++17, but this was only valid for nix platforms.
The last option left is to ask the user to specify the standard when building using bazel.