### PR TITLE
Allow invoking git.bat as git on Windows

### DIFF
--- a/utils/update_build_version.py
+++ b/utils/update_build_version.py
@@ -71,10 +71,13 @@ def command_output(cmd, directory):
     Raises a RuntimeError if the command fails to launch or otherwise fails.
     """
     try:
+      # Set shell=True on Windows so that Chromium's git.bat can be found when
+      # 'git' is invoked.
       p = subprocess.Popen(cmd,
                            cwd=directory,
                            stdout=subprocess.PIPE,
-                           stderr=subprocess.PIPE)
+                           stderr=subprocess.PIPE,
+                           shell=os.name == 'nt')
       (stdout, stderr) = p.communicate()
       if p.returncode != 0:
         logging.error('Failed to run "{}" in "{}": {}'.format(cmd, directory, stderr.decode()))


### PR DESCRIPTION
In a Chromium build environment on Windows git is supplied by depot_tools as git.bat. This was causing build errors on Windows that are most easily reproduced with this command:

  gn gen out\default && gn clean out\default && ninja -C out\default spirv-as

The errors included:

[12:55:40][ERROR   ] Failed to run "['git', 'tag', '--sort=-v:refname']" in "C:\src\chromium\src\third_party\vulkan-deps\spirv-tools\src": [WinError 2] The system cannot find the file specified
[12:55:40][WARNING ] Could not deduce latest release version from history.

This is because 'git' does not resolve to git.bat unless shell=True is passed to subprocess.Popen. This change passes shell=True but only on Windows which resolves these errors.