### PR TITLE
Fix removal of dependent non-semantic instructions

### DIFF
--- a/source/opt/eliminate_dead_functions_util.cpp
+++ b/source/opt/eliminate_dead_functions_util.cpp
@@ -37,7 +37,9 @@ Module::iterator EliminateFunction(IRContext* context,
               assert(inst->IsNonSemanticInstruction());
               if (to_kill.find(inst) != to_kill.end()) return;
               std::unique_ptr<Instruction> clone(inst->Clone(context));
-              context->ForgetUses(inst);
+              // Clear uses of "inst" to in case this moves a dependent chain of
+              // instructions.
+              context->get_def_use_mgr()->ClearInst(inst);
               context->AnalyzeDefUse(clone.get());
               if (first_func) {
                 context->AddGlobalValue(std::move(clone));


### PR DESCRIPTION
Fixes #5121

* If the non-semantic info instructions depended on other moved instructions the def/use manager would get corrupted.