### PR TITLE
Fix MinGW build error (#4935)

### DIFF
--- a/tools/io.h
+++ b/tools/io.h
@@ -127,7 +127,7 @@ class OutputFile {
  public:
   // Opens |filename| in the given mode.  If |filename| is nullptr, the empty
   // string or "-", stdout will be set to the given mode.
-  OutputFile(const char* filename, const char* mode) {
+  OutputFile(const char* filename, const char* mode) : old_mode_(0) {
     const bool use_stdout =
         !filename || (filename[0] == '-' && filename[1] == '\0');
     if (use_stdout) {


### PR DESCRIPTION
This commit fixes the following build error when the source code is build with MinGW gcc 12 and compiler switch '-Werror=maybe-uninitialized' is added:

    'file.{anonymous}::OutputFile::old_mode_' may be used uninitialized
     in this function [-Werror=maybe-uninitialized]

Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/4935