### PR TITLE
Add workflow for github releases.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,25 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup git user information
-        run: |
-          git config user.name "GitHub Actions[bot]"
-          git config user.email "<>"
-          git checkout -b ${{ github.ref_name }}
-      - name: Create VERSION file.
-        run: 'echo "{ \"version\": \"${{ github.ref_name }}\", \"hash\": \"${{ github.sha }}\" }" > VERSION'
       - name: Prepare CHANGELOG for version
         run: |
           python utils/generate_changelog.py CHANGES ${{ github.ref_name }} VERSION_CHANGELOG
-      - name: Prepare release branch
-        run: |
-          git add VERSION
-          git commit -m "prepare release ${{ github.ref_name }}"
-          git push --force origin refs/heads/${{ github.ref_name }}
-          git tag -f ${{ github.ref_name }}
-          git push --force --tags origin
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
       - name: Create release
         run: |
           gh release create -F VERSION_CHANGELOG ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Create a release branch from release tag
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+'
+      - '!v[0-9]+.[0-9]+.rc*'
+
+jobs:
+  prepare-release-job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup git user information
+        run: |
+          git config user.name "GitHub Actions[bot]"
+          git config user.email "<>"
+          git checkout -b ${{ github.ref_name }}
+      - name: Create VERSION file.
+        run: 'echo "{ \"version\": \"${{ github.ref_name }}\", \"hash\": \"${{ github.sha }}\" }" > VERSION'
+      - name: Prepare CHANGELOG for version
+        run: |
+          python utils/generate_changelog.py CHANGES ${{ github.ref_name }} VERSION_CHANGELOG
+      - name: Prepare release branch
+        run: |
+          git add VERSION
+          git commit -m "prepare release ${{ github.ref_name }}"
+          git push --force origin refs/heads/${{ github.ref_name }}
+          git tag -f ${{ github.ref_name }}
+          git push --force --tags origin
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Create release
+        run: |
+          gh release create -F VERSION_CHANGELOG ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This github workflow will generate a new release when pushing a tag with the correct format.
Meaning release now will be done with the following process:

 - push a release candidate tag
 - let all partners run tests
 - push a new release candidate tag if some failure have been found and fixed.
 - once all green, push the release tag on the green release candidate.
 
 The release will be done.
 No release branch will be created as we don't need them anymore.
 Also no stable/canary branch update anymore, as we won't use them anymore.