### PR TITLE
Change default permissions for workflows

### DIFF
--- a/.github/workflows/autoroll.yml
+++ b/.github/workflows/autoroll.yml
@@ -1,4 +1,5 @@
 name: Update dependencies
+permissions: read-all
 
 on:
   schedule:
@@ -7,6 +8,8 @@ on:
 
 jobs:
   update-dependencies:
+    permissions:
+      contents: write
     name: Update dependencies
     runs-on: ubuntu-latest
 
@@ -38,8 +41,10 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
         id: update_dependencies
-     
+
       - name: Push changes and create PR
+        permissions:
+          contents: write
         if: steps.update_dependencies.outputs.changed == 'true'
         run: |
           git push --force --set-upstream origin roll_deps

--- a/.github/workflows/autoroll.yml
+++ b/.github/workflows/autoroll.yml
@@ -1,5 +1,6 @@
 name: Update dependencies
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   schedule:

--- a/.github/workflows/autoroll.yml
+++ b/.github/workflows/autoroll.yml
@@ -42,10 +42,7 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
         id: update_dependencies
-
       - name: Push changes and create PR
-        permissions:
-          contents: write
         if: steps.update_dependencies.outputs.changed == 'true'
         run: |
           git push --force --set-upstream origin roll_deps

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,5 +1,6 @@
 name: Build and Test with Bazel
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,4 +1,5 @@
 name: Build and Test with Bazel
+permissions: read-all
 
 on:
   push:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,6 +1,8 @@
 name: Wasm Build
+permissions: read-all
 
 on: [push, pull_request]
+
 
 jobs:
   build:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -4,7 +4,6 @@ permissions:
 
 on: [push, pull_request]
 
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,5 +1,6 @@
 name: Wasm Build
-permissions: read-all
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
This PR sets the minimal permission needed for each workflow:
 `content = read`, to read the repo, rest to `none`.
 `content = write` for the autoroll workflow as it needs to push to a branch to create a PR.

See:
https://docs.github.com/en/rest/overview/permissions-required-for-github-apps?apiVersion=2022-11-28#contents
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions