### PR TITLE
spirv-val: Label new Vulkan VUID 07951

### DIFF
--- a/source/val/validate_scopes.cpp
+++ b/source/val/validate_scopes.cpp
@@ -240,7 +240,7 @@ spv_result_t ValidateMemoryScope(ValidationState_t& _, const Instruction* inst,
                !_.HasCapability(spv::Capability::SubgroupBallotKHR) &&
                !_.HasCapability(spv::Capability::SubgroupVoteKHR)) {
       return _.diag(SPV_ERROR_INVALID_DATA, inst)
-             << _.VkErrorID(6997) << spvOpcodeString(opcode)
+             << _.VkErrorID(7951) << spvOpcodeString(opcode)
              << ": in Vulkan 1.0 environment Memory Scope is can not be "
                 "Subgroup without SubgroupBallotKHR or SubgroupVoteKHR "
                 "declared";

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2163,8 +2163,6 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-PushConstant-06808);
     case 6925:
       return VUID_WRAP(VUID-StandaloneSpirv-Uniform-06925);
-    case 6997:
-      return VUID_WRAP(VUID-StandaloneSpirv-SubgroupVoteKHR-06997);
     case 7102:
       return VUID_WRAP(VUID-StandaloneSpirv-MeshEXT-07102);
     case 7320:
@@ -2179,6 +2177,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-Base-07652);
     case 7703:
       return VUID_WRAP(VUID-StandaloneSpirv-Component-07703);
+    case 7951:
+      return VUID_WRAP(VUID-StandaloneSpirv-SubgroupVoteKHR-07951);
     default:
       return "";  // unknown id
   }

--- a/test/val/val_barriers_test.cpp
+++ b/test/val/val_barriers_test.cpp
@@ -361,7 +361,7 @@ OpControlBarrier %subgroup %subgroup %none
   CompileSuccessfully(GenerateShaderCode(body), SPV_ENV_VULKAN_1_0);
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
   EXPECT_THAT(getDiagnosticString(),
-              AnyVUID("VUID-StandaloneSpirv-SubgroupVoteKHR-06997"));
+              AnyVUID("VUID-StandaloneSpirv-SubgroupVoteKHR-07951"));
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(
@@ -775,7 +775,7 @@ OpMemoryBarrier %subgroup %acquire_release_uniform_workgroup
   CompileSuccessfully(GenerateShaderCode(body), SPV_ENV_VULKAN_1_0);
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
   EXPECT_THAT(getDiagnosticString(),
-              AnyVUID("VUID-StandaloneSpirv-SubgroupVoteKHR-06997"));
+              AnyVUID("VUID-StandaloneSpirv-SubgroupVoteKHR-07951"));
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(


### PR DESCRIPTION
The new 1.3.243 Vulkan spec created a new VU

> VUID-StandaloneSpirv-SubgroupVoteKHR-07951
If none of the SubgroupVoteKHR, GroupNonUniform, or SubgroupBallotKHR capabilities are declared, Scope for memory must not be Subgroup
