### PR TITLE
ci: fix dependency updater bot

### DIFF
--- a/.github/workflows/autoroll.yml
+++ b/.github/workflows/autoroll.yml
@@ -11,6 +11,7 @@ jobs:
   update-dependencies:
     permissions:
       contents: write
+      pull-requests: write
     name: Update dependencies
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Thought `content` permission was enough to create (not merge) PRs, but turns out the `pull-request` permission is also required. This should unblock the bot.

Related links:
https://docs.github.com/en/rest/overview/permissions-required-for-github-apps?apiVersion=2022-11-28#pull-requests
