### PR TITLE
spirv-val: Remove unused includes and code

### DIFF
--- a/source/val/basic_block.cpp
+++ b/source/val/basic_block.cpp
@@ -15,7 +15,6 @@
 #include "source/val/basic_block.h"
 
 #include <algorithm>
-#include <utility>
 #include <vector>
 
 namespace spvtools {

--- a/source/val/construct.cpp
+++ b/source/val/construct.cpp
@@ -16,7 +16,6 @@
 
 #include <cassert>
 #include <cstddef>
-#include <unordered_set>
 
 #include "source/val/function.h"
 #include "source/val/validation_state.h"

--- a/source/val/function.cpp
+++ b/source/val/function.cpp
@@ -18,7 +18,6 @@
 #include <cassert>
 #include <sstream>
 #include <unordered_map>
-#include <unordered_set>
 #include <utility>
 
 #include "source/cfa.h"

--- a/source/val/validate.cpp
+++ b/source/val/validate.cpp
@@ -14,13 +14,9 @@
 
 #include "source/val/validate.h"
 
-#include <algorithm>
-#include <cassert>
-#include <cstdio>
 #include <functional>
 #include <iterator>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -28,15 +24,11 @@
 #include "source/diagnostic.h"
 #include "source/enum_string_mapping.h"
 #include "source/extensions.h"
-#include "source/instruction.h"
 #include "source/opcode.h"
-#include "source/operand.h"
 #include "source/spirv_constant.h"
 #include "source/spirv_endian.h"
 #include "source/spirv_target_env.h"
-#include "source/spirv_validator_options.h"
 #include "source/val/construct.h"
-#include "source/val/function.h"
 #include "source/val/instruction.h"
 #include "source/val/validation_state.h"
 #include "spirv-tools/libspirv.h"

--- a/source/val/validate.h
+++ b/source/val/validate.h
@@ -31,11 +31,6 @@ class ValidationState_t;
 class BasicBlock;
 class Instruction;
 
-/// A function that returns a vector of BasicBlocks given a BasicBlock. Used to
-/// get the successor and predecessor nodes of a CFG block
-using get_blocks_func =
-    std::function<const std::vector<BasicBlock*>*(const BasicBlock*)>;
-
 /// @brief Performs the Control Flow Graph checks
 ///
 /// @param[in] _ the validation state of the module

--- a/source/val/validate_adjacency.cpp
+++ b/source/val/validate_adjacency.cpp
@@ -15,13 +15,10 @@
 // Validates correctness of the intra-block preconditions of SPIR-V
 // instructions.
 
-#include "source/val/validate.h"
-
 #include <string>
 
-#include "source/diagnostic.h"
-#include "source/opcode.h"
 #include "source/val/instruction.h"
+#include "source/val/validate.h"
 #include "source/val/validation_state.h"
 
 namespace spvtools {

--- a/source/val/validate_arithmetics.cpp
+++ b/source/val/validate_arithmetics.cpp
@@ -14,13 +14,11 @@
 
 // Performs validation of arithmetic instructions.
 
-#include "source/val/validate.h"
-
 #include <vector>
 
-#include "source/diagnostic.h"
 #include "source/opcode.h"
 #include "source/val/instruction.h"
+#include "source/val/validate.h"
 #include "source/val/validation_state.h"
 
 namespace spvtools {

--- a/source/val/validate_atomics.cpp
+++ b/source/val/validate_atomics.cpp
@@ -16,13 +16,11 @@
 
 // Validates correctness of atomic SPIR-V instructions.
 
-#include "source/val/validate.h"
-
-#include "source/diagnostic.h"
 #include "source/opcode.h"
 #include "source/spirv_target_env.h"
 #include "source/util/bitutils.h"
 #include "source/val/instruction.h"
+#include "source/val/validate.h"
 #include "source/val/validate_memory_semantics.h"
 #include "source/val/validate_scopes.h"
 #include "source/val/validation_state.h"

--- a/source/val/validate_barriers.cpp
+++ b/source/val/validate_barriers.cpp
@@ -16,11 +16,8 @@
 
 #include <string>
 
-#include "source/diagnostic.h"
 #include "source/opcode.h"
 #include "source/spirv_constant.h"
-#include "source/spirv_target_env.h"
-#include "source/util/bitutils.h"
 #include "source/val/instruction.h"
 #include "source/val/validate.h"
 #include "source/val/validate_memory_semantics.h"

--- a/source/val/validate_bitwise.cpp
+++ b/source/val/validate_bitwise.cpp
@@ -14,7 +14,6 @@
 
 // Validates correctness of bitwise instructions.
 
-#include "source/diagnostic.h"
 #include "source/opcode.h"
 #include "source/spirv_target_env.h"
 #include "source/val/instruction.h"

--- a/source/val/validate_builtins.cpp
+++ b/source/val/validate_builtins.cpp
@@ -24,10 +24,8 @@
 #include <sstream>
 #include <stack>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
-#include "source/diagnostic.h"
 #include "source/opcode.h"
 #include "source/spirv_target_env.h"
 #include "source/util/bitutils.h"

--- a/source/val/validate_capability.cpp
+++ b/source/val/validate_capability.cpp
@@ -16,9 +16,7 @@
 
 #include <cassert>
 #include <string>
-#include <unordered_set>
 
-#include "source/diagnostic.h"
 #include "source/opcode.h"
 #include "source/val/instruction.h"
 #include "source/val/validate.h"

--- a/source/val/validate_cfg.cpp
+++ b/source/val/validate_cfg.cpp
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <algorithm>
 #include <cassert>
 #include <functional>
 #include <iostream>
-#include <iterator>
 #include <map>
 #include <string>
 #include <tuple>
@@ -28,7 +26,6 @@
 #include "source/cfa.h"
 #include "source/opcode.h"
 #include "source/spirv_constant.h"
-#include "source/spirv_target_env.h"
 #include "source/spirv_validator_options.h"
 #include "source/val/basic_block.h"
 #include "source/val/construct.h"

--- a/source/val/validate_composites.cpp
+++ b/source/val/validate_composites.cpp
@@ -14,12 +14,10 @@
 
 // Validates correctness of composite SPIR-V instructions.
 
-#include "source/val/validate.h"
-
-#include "source/diagnostic.h"
 #include "source/opcode.h"
 #include "source/spirv_target_env.h"
 #include "source/val/instruction.h"
+#include "source/val/validate.h"
 #include "source/val/validation_state.h"
 
 namespace spvtools {

--- a/source/val/validate_conversion.cpp
+++ b/source/val/validate_conversion.cpp
@@ -14,7 +14,6 @@
 
 // Validates correctness of conversion instructions.
 
-#include "source/diagnostic.h"
 #include "source/opcode.h"
 #include "source/spirv_constant.h"
 #include "source/spirv_target_env.h"

--- a/source/val/validate_debug.cpp
+++ b/source/val/validate_debug.cpp
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "source/val/validate.h"
-
-#include "source/opcode.h"
 #include "source/spirv_target_env.h"
 #include "source/val/instruction.h"
+#include "source/val/validate.h"
 #include "source/val/validation_state.h"
 
 namespace spvtools {

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -21,7 +21,6 @@
 #include <utility>
 #include <vector>
 
-#include "source/binary.h"
 #include "source/diagnostic.h"
 #include "source/opcode.h"
 #include "source/spirv_constant.h"
@@ -45,13 +44,6 @@ struct PairHash {
     const uint32_t b = pair.second;
     const uint32_t rotated_b = (b >> 2) | ((b & 3) << 30);
     return a ^ rotated_b;
-  }
-};
-
-// A functor for hashing decoration types.
-struct SpvDecorationHash {
-  std::size_t operator()(spv::Decoration dec) const {
-    return static_cast<std::size_t>(dec);
   }
 };
 

--- a/source/val/validate_derivatives.cpp
+++ b/source/val/validate_derivatives.cpp
@@ -14,13 +14,11 @@
 
 // Validates correctness of derivative SPIR-V instructions.
 
-#include "source/val/validate.h"
-
 #include <string>
 
-#include "source/diagnostic.h"
 #include "source/opcode.h"
 #include "source/val/instruction.h"
+#include "source/val/validate.h"
 #include "source/val/validation_state.h"
 
 namespace spvtools {

--- a/source/val/validate_execution_limitations.cpp
+++ b/source/val/validate_execution_limitations.cpp
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 #include "source/val/validate.h"
-
-#include "source/val/function.h"
 #include "source/val/validation_state.h"
 
 namespace spvtools {

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -18,22 +18,18 @@
 #include <string>
 #include <vector>
 
-#include "spirv/unified1/NonSemanticClspvReflection.h"
-
 #include "NonSemanticShaderDebugInfo100.h"
 #include "OpenCLDebugInfo100.h"
 #include "source/common_debug_info.h"
-#include "source/diagnostic.h"
 #include "source/enum_string_mapping.h"
 #include "source/extensions.h"
 #include "source/latest_version_glsl_std_450_header.h"
 #include "source/latest_version_opencl_std_header.h"
-#include "source/opcode.h"
 #include "source/spirv_constant.h"
-#include "source/spirv_target_env.h"
 #include "source/val/instruction.h"
 #include "source/val/validate.h"
 #include "source/val/validation_state.h"
+#include "spirv/unified1/NonSemanticClspvReflection.h"
 
 namespace spvtools {
 namespace val {

--- a/source/val/validate_id.cpp
+++ b/source/val/validate_id.cpp
@@ -12,25 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "source/val/validate.h"
-
-#include <cassert>
-
-#include <algorithm>
-#include <iostream>
-#include <iterator>
-#include <stack>
-#include <string>
 #include <unordered_set>
-#include <utility>
 #include <vector>
 
-#include "source/diagnostic.h"
 #include "source/instruction.h"
 #include "source/opcode.h"
 #include "source/operand.h"
-#include "source/spirv_validator_options.h"
 #include "source/val/function.h"
+#include "source/val/validate.h"
 #include "source/val/validation_state.h"
 #include "spirv-tools/libspirv.h"
 

--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -18,7 +18,6 @@
 
 #include <string>
 
-#include "source/diagnostic.h"
 #include "source/opcode.h"
 #include "source/spirv_constant.h"
 #include "source/spirv_target_env.h"

--- a/source/val/validate_instruction.cpp
+++ b/source/val/validate_instruction.cpp
@@ -14,26 +14,20 @@
 
 // Performs validation on instructions that appear inside of a SPIR-V block.
 
-#include <algorithm>
 #include <cassert>
-#include <iomanip>
 #include <sstream>
 #include <string>
 #include <vector>
 
-#include "source/binary.h"
-#include "source/diagnostic.h"
 #include "source/enum_set.h"
 #include "source/enum_string_mapping.h"
 #include "source/extensions.h"
 #include "source/opcode.h"
 #include "source/operand.h"
 #include "source/spirv_constant.h"
-#include "source/spirv_definition.h"
 #include "source/spirv_target_env.h"
 #include "source/spirv_validator_options.h"
 #include "source/util/string_utils.h"
-#include "source/val/function.h"
 #include "source/val/validate.h"
 #include "source/val/validation_state.h"
 

--- a/source/val/validate_interfaces.cpp
+++ b/source/val/validate_interfaces.cpp
@@ -15,7 +15,6 @@
 #include <algorithm>
 #include <vector>
 
-#include "source/diagnostic.h"
 #include "source/spirv_constant.h"
 #include "source/spirv_target_env.h"
 #include "source/val/function.h"

--- a/source/val/validate_layout.cpp
+++ b/source/val/validate_layout.cpp
@@ -14,12 +14,9 @@
 
 // Source code for logical layout validation as described in section 2.4
 
-#include <cassert>
-
 #include "DebugInfo.h"
 #include "NonSemanticShaderDebugInfo100.h"
 #include "OpenCLDebugInfo100.h"
-#include "source/diagnostic.h"
 #include "source/opcode.h"
 #include "source/operand.h"
 #include "source/val/function.h"

--- a/source/val/validate_literals.cpp
+++ b/source/val/validate_literals.cpp
@@ -14,13 +14,10 @@
 
 // Validates literal numbers.
 
-#include "source/val/validate.h"
-
 #include <cassert>
 
-#include "source/diagnostic.h"
-#include "source/opcode.h"
 #include "source/val/instruction.h"
+#include "source/val/validate.h"
 #include "source/val/validation_state.h"
 
 namespace spvtools {

--- a/source/val/validate_logicals.cpp
+++ b/source/val/validate_logicals.cpp
@@ -14,11 +14,9 @@
 
 // Validates correctness of logical SPIR-V instructions.
 
-#include "source/val/validate.h"
-
-#include "source/diagnostic.h"
 #include "source/opcode.h"
 #include "source/val/instruction.h"
+#include "source/val/validate.h"
 #include "source/val/validation_state.h"
 
 namespace spvtools {

--- a/source/val/validate_memory_semantics.cpp
+++ b/source/val/validate_memory_semantics.cpp
@@ -14,7 +14,6 @@
 
 #include "source/val/validate_memory_semantics.h"
 
-#include "source/diagnostic.h"
 #include "source/spirv_target_env.h"
 #include "source/util/bitutils.h"
 #include "source/val/instruction.h"

--- a/source/val/validate_non_uniform.cpp
+++ b/source/val/validate_non_uniform.cpp
@@ -14,14 +14,11 @@
 
 // Validates correctness of barrier SPIR-V instructions.
 
-#include "source/val/validate.h"
-
-#include "source/diagnostic.h"
 #include "source/opcode.h"
 #include "source/spirv_constant.h"
 #include "source/spirv_target_env.h"
-#include "source/util/bitutils.h"
 #include "source/val/instruction.h"
+#include "source/val/validate.h"
 #include "source/val/validate_scopes.h"
 #include "source/val/validation_state.h"
 

--- a/source/val/validate_primitives.cpp
+++ b/source/val/validate_primitives.cpp
@@ -14,13 +14,11 @@
 
 // Validates correctness of primitive SPIR-V instructions.
 
-#include "source/val/validate.h"
-
 #include <string>
 
-#include "source/diagnostic.h"
 #include "source/opcode.h"
 #include "source/val/instruction.h"
+#include "source/val/validate.h"
 #include "source/val/validation_state.h"
 
 namespace spvtools {

--- a/source/val/validate_scopes.cpp
+++ b/source/val/validate_scopes.cpp
@@ -14,7 +14,6 @@
 
 #include "source/val/validate_scopes.h"
 
-#include "source/diagnostic.h"
 #include "source/spirv_target_env.h"
 #include "source/val/instruction.h"
 #include "source/val/validation_state.h"

--- a/test/val/val_annotation_test.cpp
+++ b/test/val/val_annotation_test.cpp
@@ -18,7 +18,6 @@
 #include <vector>
 
 #include "gmock/gmock.h"
-#include "test/test_fixture.h"
 #include "test/unit_spirv.h"
 #include "test/val/val_code_generator.h"
 #include "test/val/val_fixtures.h"

--- a/test/val/val_cfg_test.cpp
+++ b/test/val/val_cfg_test.cpp
@@ -16,14 +16,12 @@
 
 #include <array>
 #include <functional>
-#include <iterator>
 #include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "gmock/gmock.h"
-#include "source/diagnostic.h"
 #include "source/spirv_target_env.h"
 #include "source/val/validate.h"
 #include "test/test_fixture.h"

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -14,7 +14,6 @@
 
 // Validation tests for Data Rules.
 
-#include <sstream>
 #include <string>
 #include <utility>
 

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -19,7 +19,6 @@
 
 #include "gmock/gmock.h"
 #include "source/val/decoration.h"
-#include "test/test_fixture.h"
 #include "test/unit_spirv.h"
 #include "test/val/val_code_generator.h"
 #include "test/val/val_fixtures.h"

--- a/test/val/val_extension_spv_khr_bit_instructions_test.cpp
+++ b/test/val/val_extension_spv_khr_bit_instructions_test.cpp
@@ -18,10 +18,7 @@
 #include <vector>
 
 #include "gmock/gmock.h"
-#include "source/enum_string_mapping.h"
-#include "source/extensions.h"
 #include "source/spirv_target_env.h"
-#include "test/test_fixture.h"
 #include "test/unit_spirv.h"
 #include "test/val/val_fixtures.h"
 

--- a/test/val/val_extension_spv_khr_expect_assume_test.cpp
+++ b/test/val/val_extension_spv_khr_expect_assume_test.cpp
@@ -18,10 +18,7 @@
 #include <vector>
 
 #include "gmock/gmock.h"
-#include "source/enum_string_mapping.h"
-#include "source/extensions.h"
 #include "source/spirv_target_env.h"
-#include "test/test_fixture.h"
 #include "test/unit_spirv.h"
 #include "test/val/val_fixtures.h"
 

--- a/test/val/val_extension_spv_khr_integer_dot_product_test.cpp
+++ b/test/val/val_extension_spv_khr_integer_dot_product_test.cpp
@@ -14,15 +14,12 @@
 // limitations under the License.
 
 #include <ostream>
-#include <sstream>
 #include <string>
 #include <vector>
 
 #include "gmock/gmock.h"
-#include "source/enum_string_mapping.h"
 #include "source/extensions.h"
 #include "source/spirv_target_env.h"
-#include "test/test_fixture.h"
 #include "test/unit_spirv.h"
 #include "test/val/val_fixtures.h"
 

--- a/test/val/val_extension_spv_khr_linkonce_odr_test.cpp
+++ b/test/val/val_extension_spv_khr_linkonce_odr_test.cpp
@@ -18,10 +18,7 @@
 #include <vector>
 
 #include "gmock/gmock.h"
-#include "source/enum_string_mapping.h"
-#include "source/extensions.h"
 #include "source/spirv_target_env.h"
-#include "test/test_fixture.h"
 #include "test/unit_spirv.h"
 #include "test/val/val_fixtures.h"
 

--- a/test/val/val_extension_spv_khr_subgroup_uniform_control_flow_test.cpp
+++ b/test/val/val_extension_spv_khr_subgroup_uniform_control_flow_test.cpp
@@ -18,10 +18,7 @@
 #include <vector>
 
 #include "gmock/gmock.h"
-#include "source/enum_string_mapping.h"
-#include "source/extensions.h"
 #include "source/spirv_target_env.h"
-#include "test/test_fixture.h"
 #include "test/unit_spirv.h"
 #include "test/val/val_fixtures.h"
 

--- a/test/val/val_extension_spv_khr_terminate_invocation_test.cpp
+++ b/test/val/val_extension_spv_khr_terminate_invocation_test.cpp
@@ -18,10 +18,7 @@
 #include <vector>
 
 #include "gmock/gmock.h"
-#include "source/enum_string_mapping.h"
-#include "source/extensions.h"
 #include "source/spirv_target_env.h"
-#include "test/test_fixture.h"
 #include "test/unit_spirv.h"
 #include "test/val/val_fixtures.h"
 

--- a/test/val/val_extensions_test.cpp
+++ b/test/val/val_extensions_test.cpp
@@ -18,10 +18,8 @@
 #include <vector>
 
 #include "gmock/gmock.h"
-#include "source/enum_string_mapping.h"
 #include "source/extensions.h"
 #include "source/spirv_target_env.h"
-#include "test/test_fixture.h"
 #include "test/unit_spirv.h"
 #include "test/val/val_fixtures.h"
 

--- a/test/val/val_function_test.cpp
+++ b/test/val/val_function_test.cpp
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <sstream>
 #include <string>
 #include <tuple>
 
 #include "gmock/gmock.h"
-#include "test/test_fixture.h"
 #include "test/unit_spirv.h"
 #include "test/val/val_fixtures.h"
 

--- a/test/val/val_layout_test.cpp
+++ b/test/val/val_layout_test.cpp
@@ -14,9 +14,7 @@
 
 // Validation tests for Logical Layout
 
-#include <algorithm>
 #include <functional>
-#include <sstream>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -56,13 +54,6 @@ struct Range {
  private:
   bool inverse_;
 };
-
-template <typename... T>
-spv_result_t InvalidSet(int order) {
-  for (spv_result_t val : {T(true)(order)...})
-    if (val != SPV_SUCCESS) return val;
-  return SPV_SUCCESS;
-}
 
 // SPIRV source used to test the logical layout
 const std::vector<std::string>& getInstructions() {

--- a/test/val/val_limits_test.cpp
+++ b/test/val/val_limits_test.cpp
@@ -16,7 +16,6 @@
 
 #include <sstream>
 #include <string>
-#include <utility>
 
 #include "gmock/gmock.h"
 #include "test/unit_spirv.h"

--- a/test/val/val_mesh_shading_test.cpp
+++ b/test/val/val_mesh_shading_test.cpp
@@ -14,7 +14,6 @@
 
 // Tests instructions from SPV_EXT_mesh_shader
 
-#include <sstream>
 #include <string>
 
 #include "gmock/gmock.h"

--- a/test/val/val_modes_test.cpp
+++ b/test/val/val_modes_test.cpp
@@ -18,7 +18,6 @@
 
 #include "gmock/gmock.h"
 #include "source/spirv_target_env.h"
-#include "test/test_fixture.h"
 #include "test/unit_spirv.h"
 #include "test/val/val_fixtures.h"
 

--- a/test/val/val_state_test.cpp
+++ b/test/val/val_state_test.cpp
@@ -18,14 +18,10 @@
 #include <vector>
 
 #include "gtest/gtest.h"
-#include "source/latest_version_spirv_header.h"
-
 #include "source/enum_set.h"
 #include "source/extensions.h"
+#include "source/latest_version_spirv_header.h"
 #include "source/spirv_validator_options.h"
-#include "source/val/construct.h"
-#include "source/val/function.h"
-#include "source/val/validate.h"
 #include "source/val/validation_state.h"
 
 namespace spvtools {

--- a/test/val/val_storage_test.cpp
+++ b/test/val/val_storage_test.cpp
@@ -28,8 +28,6 @@ namespace {
 using ::testing::HasSubstr;
 using ::testing::Values;
 using ValidateStorage = spvtest::ValidateBase<std::string>;
-using ValidateStorageClass =
-    spvtest::ValidateBase<std::tuple<std::string, bool, bool, std::string>>;
 using ValidateStorageExecutionModel = spvtest::ValidateBase<std::string>;
 
 TEST_F(ValidateStorage, FunctionStorageInsideFunction) {


### PR DESCRIPTION
Running code analysis I found a lot of unused includes and removed them