### PR TITLE
spirv-opt: Remove unused includes and code

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -21,10 +21,8 @@
 #include <stack>
 
 #include "source/cfa.h"
-#include "source/latest_version_glsl_std_450_header.h"
 #include "source/opt/eliminate_dead_functions_util.h"
 #include "source/opt/ir_builder.h"
-#include "source/opt/iterator.h"
 #include "source/opt/reflect.h"
 #include "source/spirv_constant.h"
 #include "source/util/string_utils.h"

--- a/source/opt/basic_block.cpp
+++ b/source/opt/basic_block.cpp
@@ -16,9 +16,7 @@
 
 #include <ostream>
 
-#include "source/opt/function.h"
 #include "source/opt/ir_context.h"
-#include "source/opt/module.h"
 #include "source/opt/reflect.h"
 #include "source/util/make_unique.h"
 

--- a/source/opt/block_merge_pass.cpp
+++ b/source/opt/block_merge_pass.cpp
@@ -16,11 +16,8 @@
 
 #include "source/opt/block_merge_pass.h"
 
-#include <vector>
-
 #include "source/opt/block_merge_util.h"
 #include "source/opt/ir_context.h"
-#include "source/opt/iterator.h"
 
 namespace spvtools {
 namespace opt {

--- a/source/opt/ccp_pass.cpp
+++ b/source/opt/ccp_pass.cpp
@@ -24,7 +24,6 @@
 
 #include "source/opt/fold.h"
 #include "source/opt/function.h"
-#include "source/opt/module.h"
 #include "source/opt/propagator.h"
 
 namespace spvtools {

--- a/source/opt/cfg_cleanup_pass.cpp
+++ b/source/opt/cfg_cleanup_pass.cpp
@@ -16,13 +16,9 @@
 // constructs (e.g., unreachable basic blocks, empty control flow structures,
 // etc)
 
-#include <queue>
-#include <unordered_set>
-
 #include "source/opt/cfg_cleanup_pass.h"
 
 #include "source/opt/function.h"
-#include "source/opt/module.h"
 
 namespace spvtools {
 namespace opt {

--- a/source/opt/code_sink.cpp
+++ b/source/opt/code_sink.cpp
@@ -14,11 +14,9 @@
 
 #include "code_sink.h"
 
-#include <set>
 #include <vector>
 
 #include "source/opt/instruction.h"
-#include "source/opt/ir_builder.h"
 #include "source/opt/ir_context.h"
 #include "source/util/bit_vector.h"
 

--- a/source/opt/constants.cpp
+++ b/source/opt/constants.cpp
@@ -14,7 +14,6 @@
 
 #include "source/opt/constants.h"
 
-#include <unordered_map>
 #include <vector>
 
 #include "source/opt/ir_context.h"

--- a/source/opt/control_dependence.cpp
+++ b/source/opt/control_dependence.cpp
@@ -16,8 +16,6 @@
 
 #include <cassert>
 #include <tuple>
-#include <utility>
-#include <vector>
 
 #include "source/opt/basic_block.h"
 #include "source/opt/cfg.h"

--- a/source/opt/convert_to_sampled_image_pass.cpp
+++ b/source/opt/convert_to_sampled_image_pass.cpp
@@ -16,7 +16,6 @@
 
 #include <cctype>
 #include <cstring>
-#include <tuple>
 
 #include "source/opt/ir_builder.h"
 #include "source/util/make_unique.h"

--- a/source/opt/dataflow.cpp
+++ b/source/opt/dataflow.cpp
@@ -14,7 +14,6 @@
 
 #include "source/opt/dataflow.h"
 
-#include <algorithm>
 #include <cstdint>
 
 namespace spvtools {

--- a/source/opt/dead_branch_elim_pass.cpp
+++ b/source/opt/dead_branch_elim_pass.cpp
@@ -23,7 +23,6 @@
 
 #include "source/cfa.h"
 #include "source/opt/ir_context.h"
-#include "source/opt/iterator.h"
 #include "source/opt/struct_cfg_analysis.h"
 #include "source/util/make_unique.h"
 

--- a/source/opt/eliminate_dead_constant_pass.cpp
+++ b/source/opt/eliminate_dead_constant_pass.cpp
@@ -20,7 +20,6 @@
 #include <vector>
 
 #include "source/opt/def_use_manager.h"
-#include "source/opt/ir_context.h"
 #include "source/opt/log.h"
 #include "source/opt/reflect.h"
 

--- a/source/opt/eliminate_dead_io_components_pass.cpp
+++ b/source/opt/eliminate_dead_io_components_pass.cpp
@@ -15,11 +15,9 @@
 
 #include "source/opt/eliminate_dead_io_components_pass.h"
 
-#include <set>
 #include <vector>
 
 #include "source/opt/instruction.h"
-#include "source/opt/ir_builder.h"
 #include "source/opt/ir_context.h"
 #include "source/util/bit_vector.h"
 

--- a/source/opt/eliminate_dead_output_stores_pass.h
+++ b/source/opt/eliminate_dead_output_stores_pass.h
@@ -51,13 +51,7 @@ class EliminateDeadOutputStoresPass : public Pass {
   void InitializeElimination();
 
   // Do dead output store analysis
-  Status DoDeadOutputStoreAnalysis();
-
-  // Do dead output store analysis
   Status DoDeadOutputStoreElimination();
-
-  // Mark all locations live
-  void MarkAllLocsLive();
 
   // Kill all stores resulting from |ref|.
   void KillAllStoresOfRef(Instruction* ref);

--- a/source/opt/feature_manager.cpp
+++ b/source/opt/feature_manager.cpp
@@ -14,8 +14,6 @@
 
 #include "source/opt/feature_manager.h"
 
-#include <queue>
-#include <stack>
 #include <string>
 
 #include "source/enum_string_mapping.h"

--- a/source/opt/fold.cpp
+++ b/source/opt/fold.cpp
@@ -21,7 +21,6 @@
 #include "source/opt/const_folding_rules.h"
 #include "source/opt/def_use_manager.h"
 #include "source/opt/folding_rules.h"
-#include "source/opt/ir_builder.h"
 #include "source/opt/ir_context.h"
 
 namespace spvtools {

--- a/source/opt/fold_spec_constant_op_and_composite_pass.cpp
+++ b/source/opt/fold_spec_constant_op_and_composite_pass.cpp
@@ -15,12 +15,9 @@
 #include "source/opt/fold_spec_constant_op_and_composite_pass.h"
 
 #include <algorithm>
-#include <initializer_list>
 #include <tuple>
 
 #include "source/opt/constants.h"
-#include "source/opt/fold.h"
-#include "source/opt/ir_context.h"
 #include "source/util/make_unique.h"
 
 namespace spvtools {

--- a/source/opt/folding_rules.cpp
+++ b/source/opt/folding_rules.cpp
@@ -14,7 +14,6 @@
 
 #include "source/opt/folding_rules.h"
 
-#include <climits>
 #include <limits>
 #include <memory>
 #include <utility>

--- a/source/opt/function.cpp
+++ b/source/opt/function.cpp
@@ -15,9 +15,7 @@
 #include "source/opt/function.h"
 
 #include <ostream>
-#include <sstream>
 
-#include "function.h"
 #include "ir_context.h"
 #include "source/util/bit_vector.h"
 

--- a/source/opt/graphics_robust_access_pass.cpp
+++ b/source/opt/graphics_robust_access_pass.cpp
@@ -141,18 +141,12 @@
 
 #include "graphics_robust_access_pass.h"
 
-#include <algorithm>
-#include <cstring>
 #include <functional>
 #include <initializer_list>
-#include <limits>
 #include <utility>
 
-#include "constants.h"
-#include "def_use_manager.h"
 #include "function.h"
 #include "ir_context.h"
-#include "module.h"
 #include "pass.h"
 #include "source/diagnostic.h"
 #include "source/util/make_unique.h"

--- a/source/opt/interface_var_sroa.h
+++ b/source/opt/interface_var_sroa.h
@@ -90,10 +90,6 @@ class InterfaceVariableScalarReplacement : public Pass {
   // |component|. Returns true whether the component exists or not.
   bool GetVariableComponent(Instruction* var, uint32_t* component);
 
-  // Returns the interface variable instruction whose result id is
-  // |interface_var_id|.
-  Instruction* GetInterfaceVariable(uint32_t interface_var_id);
-
   // Returns the type of |var| as an instruction.
   Instruction* GetTypeOfVariable(Instruction* var);
 

--- a/source/opt/interp_fixup_pass.cpp
+++ b/source/opt/interp_fixup_pass.cpp
@@ -19,7 +19,6 @@
 #include <set>
 #include <string>
 
-#include "ir_builder.h"
 #include "source/opt/ir_context.h"
 #include "type_manager.h"
 

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -19,7 +19,6 @@
 #include "OpenCLDebugInfo100.h"
 #include "source/latest_version_glsl_std_450_header.h"
 #include "source/opt/log.h"
-#include "source/opt/mem_pass.h"
 #include "source/opt/reflect.h"
 
 namespace spvtools {

--- a/source/opt/licm_pass.cpp
+++ b/source/opt/licm_pass.cpp
@@ -15,7 +15,6 @@
 #include "source/opt/licm_pass.h"
 
 #include <queue>
-#include <utility>
 
 #include "source/opt/module.h"
 #include "source/opt/pass.h"

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -16,7 +16,6 @@
 
 #include "source/opt/local_access_chain_convert_pass.h"
 
-#include "ir_builder.h"
 #include "ir_context.h"
 #include "iterator.h"
 #include "source/util/string_utils.h"

--- a/source/opt/local_single_block_elim_pass.cpp
+++ b/source/opt/local_single_block_elim_pass.cpp
@@ -18,7 +18,6 @@
 
 #include <vector>
 
-#include "source/opt/iterator.h"
 #include "source/util/string_utils.h"
 
 namespace spvtools {

--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -17,8 +17,6 @@
 #include "source/opt/local_single_store_elim_pass.h"
 
 #include "source/cfa.h"
-#include "source/latest_version_glsl_std_450_header.h"
-#include "source/opt/iterator.h"
 #include "source/util/string_utils.h"
 
 namespace spvtools {

--- a/source/opt/loop_dependence.cpp
+++ b/source/opt/loop_dependence.cpp
@@ -15,14 +15,12 @@
 #include "source/opt/loop_dependence.h"
 
 #include <functional>
-#include <memory>
 #include <numeric>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "source/opt/instruction.h"
-#include "source/opt/scalar_analysis.h"
 #include "source/opt/scalar_analysis_nodes.h"
 
 namespace spvtools {

--- a/source/opt/loop_dependence_helpers.cpp
+++ b/source/opt/loop_dependence_helpers.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "source/opt/loop_dependence.h"
-
 #include <ostream>
 #include <set>
 #include <string>
@@ -23,7 +21,7 @@
 
 #include "source/opt/basic_block.h"
 #include "source/opt/instruction.h"
-#include "source/opt/scalar_analysis.h"
+#include "source/opt/loop_dependence.h"
 #include "source/opt/scalar_analysis_nodes.h"
 
 namespace spvtools {

--- a/source/opt/loop_descriptor.cpp
+++ b/source/opt/loop_descriptor.cpp
@@ -15,17 +15,14 @@
 #include "source/opt/loop_descriptor.h"
 
 #include <algorithm>
-#include <iostream>
 #include <limits>
 #include <stack>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
 #include "source/opt/cfg.h"
 #include "source/opt/constants.h"
 #include "source/opt/dominator_tree.h"
-#include "source/opt/ir_builder.h"
 #include "source/opt/ir_context.h"
 #include "source/opt/iterator.h"
 #include "source/opt/tree_iterator.h"

--- a/source/opt/loop_fusion_pass.cpp
+++ b/source/opt/loop_fusion_pass.cpp
@@ -14,7 +14,6 @@
 
 #include "source/opt/loop_fusion_pass.h"
 
-#include "source/opt/ir_context.h"
 #include "source/opt/loop_descriptor.h"
 #include "source/opt/loop_fusion.h"
 #include "source/opt/register_pressure.h"

--- a/source/opt/loop_peeling.cpp
+++ b/source/opt/loop_peeling.cpp
@@ -12,17 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <algorithm>
+#include "source/opt/loop_peeling.h"
+
 #include <functional>
 #include <memory>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "source/opt/ir_builder.h"
 #include "source/opt/ir_context.h"
 #include "source/opt/loop_descriptor.h"
-#include "source/opt/loop_peeling.h"
 #include "source/opt/loop_utils.h"
 #include "source/opt/scalar_analysis.h"
 #include "source/opt/scalar_analysis_nodes.h"

--- a/source/opt/loop_unroller.cpp
+++ b/source/opt/loop_unroller.cpp
@@ -15,7 +15,6 @@
 #include "source/opt/loop_unroller.h"
 
 #include <limits>
-#include <map>
 #include <memory>
 #include <unordered_map>
 #include <utility>

--- a/source/opt/loop_unswitch_pass.cpp
+++ b/source/opt/loop_unswitch_pass.cpp
@@ -17,7 +17,6 @@
 #include <functional>
 #include <list>
 #include <memory>
-#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -31,7 +30,6 @@
 #include "source/opt/ir_builder.h"
 #include "source/opt/ir_context.h"
 #include "source/opt/loop_descriptor.h"
-
 #include "source/opt/loop_utils.h"
 
 namespace spvtools {

--- a/source/opt/mem_pass.cpp
+++ b/source/opt/mem_pass.cpp
@@ -22,9 +22,7 @@
 
 #include "source/cfa.h"
 #include "source/opt/basic_block.h"
-#include "source/opt/dominator_analysis.h"
 #include "source/opt/ir_context.h"
-#include "source/opt/iterator.h"
 
 namespace spvtools {
 namespace opt {

--- a/source/opt/remove_duplicates_pass.cpp
+++ b/source/opt/remove_duplicates_pass.cpp
@@ -15,8 +15,6 @@
 #include "source/opt/remove_duplicates_pass.h"
 
 #include <algorithm>
-#include <cstring>
-#include <limits>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -25,7 +23,6 @@
 #include "source/opcode.h"
 #include "source/opt/decoration_manager.h"
 #include "source/opt/ir_context.h"
-#include "source/opt/reflect.h"
 
 namespace spvtools {
 namespace opt {

--- a/source/opt/scalar_analysis.cpp
+++ b/source/opt/scalar_analysis.cpp
@@ -14,7 +14,6 @@
 
 #include "source/opt/scalar_analysis.h"
 
-#include <algorithm>
 #include <functional>
 #include <string>
 #include <utility>

--- a/source/opt/scalar_analysis_simplification.cpp
+++ b/source/opt/scalar_analysis_simplification.cpp
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "source/opt/scalar_analysis.h"
-
 #include <functional>
 #include <map>
 #include <memory>
 #include <set>
-#include <unordered_set>
 #include <utility>
 #include <vector>
+
+#include "source/opt/scalar_analysis.h"
 
 // Simplifies scalar analysis DAGs.
 //

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -19,12 +19,10 @@
 #include <tuple>
 #include <utility>
 
-#include "source/enum_string_mapping.h"
 #include "source/extensions.h"
 #include "source/opt/reflect.h"
 #include "source/opt/types.h"
 #include "source/util/make_unique.h"
-#include "types.h"
 
 namespace spvtools {
 namespace opt {

--- a/source/opt/set_spec_constant_default_value_pass.cpp
+++ b/source/opt/set_spec_constant_default_value_pass.cpp
@@ -21,8 +21,6 @@
 #include <vector>
 
 #include "source/opt/def_use_manager.h"
-#include "source/opt/ir_context.h"
-#include "source/opt/type_manager.h"
 #include "source/opt/types.h"
 #include "source/util/make_unique.h"
 #include "source/util/parse_number.h"

--- a/source/opt/simplification_pass.cpp
+++ b/source/opt/simplification_pass.cpp
@@ -14,7 +14,6 @@
 
 #include "source/opt/simplification_pass.h"
 
-#include <set>
 #include <unordered_set>
 #include <vector>
 

--- a/source/opt/spread_volatile_semantics.cpp
+++ b/source/opt/spread_volatile_semantics.cpp
@@ -15,7 +15,6 @@
 #include "source/opt/spread_volatile_semantics.h"
 
 #include "source/opt/decoration_manager.h"
-#include "source/opt/ir_builder.h"
 #include "source/spirv_constant.h"
 
 namespace spvtools {

--- a/source/opt/ssa_rewrite_pass.cpp
+++ b/source/opt/ssa_rewrite_pass.cpp
@@ -48,7 +48,6 @@
 #include "source/opt/cfg.h"
 #include "source/opt/mem_pass.h"
 #include "source/opt/types.h"
-#include "source/util/make_unique.h"
 
 // Debug logging (0: Off, 1-N: Verbosity level).  Replace this with the
 // implementation done for

--- a/source/opt/strength_reduction_pass.cpp
+++ b/source/opt/strength_reduction_pass.cpp
@@ -14,12 +14,8 @@
 
 #include "source/opt/strength_reduction_pass.h"
 
-#include <algorithm>
-#include <cstdio>
 #include <cstring>
 #include <memory>
-#include <unordered_map>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 

--- a/source/opt/strip_nonsemantic_info_pass.cpp
+++ b/source/opt/strip_nonsemantic_info_pass.cpp
@@ -14,7 +14,6 @@
 
 #include "source/opt/strip_nonsemantic_info_pass.h"
 
-#include <cstring>
 #include <vector>
 
 #include "source/opt/instruction.h"

--- a/source/opt/types.cpp
+++ b/source/opt/types.cpp
@@ -16,7 +16,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <climits>
 #include <cstdint>
 #include <sstream>
 #include <string>

--- a/source/opt/unify_const_pass.cpp
+++ b/source/opt/unify_const_pass.cpp
@@ -20,7 +20,6 @@
 #include <vector>
 
 #include "source/opt/def_use_manager.h"
-#include "source/opt/ir_context.h"
 #include "source/util/make_unique.h"
 
 namespace spvtools {

--- a/test/opt/analyze_live_input_test.cpp
+++ b/test/opt/analyze_live_input_test.cpp
@@ -15,7 +15,6 @@
 
 #include <unordered_set>
 
-#include "gmock/gmock.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"
 

--- a/test/opt/ccp_test.cpp
+++ b/test/opt/ccp_test.cpp
@@ -14,7 +14,6 @@
 
 #include <string>
 
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "source/opt/ccp_pass.h"
 #include "test/opt/pass_fixture.h"

--- a/test/opt/code_sink_test.cpp
+++ b/test/opt/code_sink_test.cpp
@@ -14,7 +14,6 @@
 
 #include <string>
 
-#include "gmock/gmock.h"
 #include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"

--- a/test/opt/combine_access_chains_test.cpp
+++ b/test/opt/combine_access_chains_test.cpp
@@ -14,8 +14,6 @@
 
 #include <string>
 
-#include "gmock/gmock.h"
-#include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"
 

--- a/test/opt/compact_ids_test.cpp
+++ b/test/opt/compact_ids_test.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "gmock/gmock.h"

--- a/test/opt/constant_manager_test.cpp
+++ b/test/opt/constant_manager_test.cpp
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 #include <memory>
-#include <string>
 
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "source/opt/build_module.h"
 #include "source/opt/constants.h"

--- a/test/opt/constants_test.cpp
+++ b/test/opt/constants_test.cpp
@@ -16,7 +16,6 @@
 
 #include <gtest/gtest-param-test.h>
 
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "source/opt/types.h"
 

--- a/test/opt/copy_prop_array_test.cpp
+++ b/test/opt/copy_prop_array_test.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <iostream>
 #include <string>
 
 #include "gmock/gmock.h"

--- a/test/opt/dataflow.cpp
+++ b/test/opt/dataflow.cpp
@@ -17,7 +17,6 @@
 #include <map>
 #include <set>
 
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "opt/function_utils.h"
 #include "source/opt/build_module.h"

--- a/test/opt/debug_info_manager_test.cpp
+++ b/test/opt/debug_info_manager_test.cpp
@@ -15,11 +15,8 @@
 #include "source/opt/debug_info_manager.h"
 
 #include <memory>
-#include <string>
 #include <vector>
 
-#include "effcee/effcee.h"
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "source/opt/build_module.h"
 #include "source/opt/instruction.h"

--- a/test/opt/decoration_manager_test.cpp
+++ b/test/opt/decoration_manager_test.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>

--- a/test/opt/def_use_test.cpp
+++ b/test/opt/def_use_test.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <memory>
-#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>

--- a/test/opt/desc_sroa_test.cpp
+++ b/test/opt/desc_sroa_test.cpp
@@ -14,8 +14,6 @@
 
 #include <string>
 
-#include "gmock/gmock.h"
-#include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"
 

--- a/test/opt/dominator_tree/common_dominators.cpp
+++ b/test/opt/dominator_tree/common_dominators.cpp
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 #include <memory>
-#include <string>
 
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "source/opt/build_module.h"
 #include "source/opt/ir_context.h"

--- a/test/opt/dominator_tree/generated.cpp
+++ b/test/opt/dominator_tree/generated.cpp
@@ -14,7 +14,6 @@
 
 #include <array>
 #include <memory>
-#include <set>
 #include <string>
 #include <vector>
 

--- a/test/opt/dominator_tree/nested_ifs.cpp
+++ b/test/opt/dominator_tree/nested_ifs.cpp
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "gmock/gmock.h"

--- a/test/opt/dominator_tree/nested_ifs_post.cpp
+++ b/test/opt/dominator_tree/nested_ifs_post.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "gmock/gmock.h"

--- a/test/opt/dominator_tree/nested_loops.cpp
+++ b/test/opt/dominator_tree/nested_loops.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "gmock/gmock.h"

--- a/test/opt/dominator_tree/nested_loops_with_unreachables.cpp
+++ b/test/opt/dominator_tree/nested_loops_with_unreachables.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "gmock/gmock.h"

--- a/test/opt/dominator_tree/post.cpp
+++ b/test/opt/dominator_tree/post.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "gmock/gmock.h"

--- a/test/opt/dominator_tree/simple.cpp
+++ b/test/opt/dominator_tree/simple.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "gmock/gmock.h"

--- a/test/opt/dominator_tree/switch_case_fallthrough.cpp
+++ b/test/opt/dominator_tree/switch_case_fallthrough.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "gmock/gmock.h"

--- a/test/opt/dominator_tree/unreachable_for.cpp
+++ b/test/opt/dominator_tree/unreachable_for.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "gmock/gmock.h"

--- a/test/opt/dominator_tree/unreachable_for_post.cpp
+++ b/test/opt/dominator_tree/unreachable_for_post.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "gmock/gmock.h"

--- a/test/opt/eliminate_dead_const_test.cpp
+++ b/test/opt/eliminate_dead_const_test.cpp
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 #include <algorithm>
-#include <cstdarg>
-#include <iostream>
-#include <sstream>
 #include <string>
 #include <unordered_set>
 #include <vector>

--- a/test/opt/eliminate_dead_io_components_test.cpp
+++ b/test/opt/eliminate_dead_io_components_test.cpp
@@ -15,7 +15,6 @@
 
 #include <vector>
 
-#include "gmock/gmock.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"
 

--- a/test/opt/eliminate_dead_member_test.cpp
+++ b/test/opt/eliminate_dead_member_test.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "assembly_builder.h"
-#include "gmock/gmock.h"
 #include "pass_fixture.h"
 #include "pass_utils.h"
 

--- a/test/opt/eliminate_dead_output_stores_test.cpp
+++ b/test/opt/eliminate_dead_output_stores_test.cpp
@@ -15,7 +15,6 @@
 
 #include <unordered_set>
 
-#include "gmock/gmock.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"
 

--- a/test/opt/feature_manager_test.cpp
+++ b/test/opt/feature_manager_test.cpp
@@ -14,9 +14,7 @@
 
 #include <algorithm>
 #include <memory>
-#include <string>
 
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "source/opt/build_module.h"
 #include "source/opt/ir_context.h"

--- a/test/opt/fix_func_call_arguments_test.cpp
+++ b/test/opt/fix_func_call_arguments_test.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gmock/gmock.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"
 

--- a/test/opt/fix_storage_class_test.cpp
+++ b/test/opt/fix_storage_class_test.cpp
@@ -14,8 +14,6 @@
 
 #include <string>
 
-#include "gmock/gmock.h"
-#include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"
 

--- a/test/opt/flatten_decoration_test.cpp
+++ b/test/opt/flatten_decoration_test.cpp
@@ -16,7 +16,6 @@
 #include <string>
 #include <vector>
 
-#include "gmock/gmock.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"
 

--- a/test/opt/fold_test.cpp
+++ b/test/opt/fold_test.cpp
@@ -27,7 +27,6 @@
 #include "source/opt/ir_context.h"
 #include "source/opt/module.h"
 #include "spirv-tools/libspirv.hpp"
-#include "test/opt/pass_utils.h"
 
 namespace spvtools {
 namespace opt {

--- a/test/opt/freeze_spec_const_test.cpp
+++ b/test/opt/freeze_spec_const_test.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <algorithm>
 #include <string>
 #include <tuple>
 #include <utility>

--- a/test/opt/function_test.cpp
+++ b/test/opt/function_test.cpp
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 #include <memory>
-#include <sstream>
-#include <string>
 #include <vector>
 
 #include "function_utils.h"

--- a/test/opt/graphics_robust_access_test.cpp
+++ b/test/opt/graphics_robust_access_test.cpp
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <array>
 #include <sstream>
 #include <string>
 #include <vector>
 
-#include "gmock/gmock.h"
 #include "pass_fixture.h"
 #include "pass_utils.h"
 #include "source/opt/graphics_robust_access_pass.h"

--- a/test/opt/if_conversion_test.cpp
+++ b/test/opt/if_conversion_test.cpp
@@ -14,8 +14,6 @@
 
 #include <string>
 
-#include "gmock/gmock.h"
-#include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"
 

--- a/test/opt/inst_bindless_check_test.cpp
+++ b/test/opt/inst_bindless_check_test.cpp
@@ -18,7 +18,6 @@
 #include <string>
 #include <vector>
 
-#include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"
 

--- a/test/opt/inst_buff_addr_check_test.cpp
+++ b/test/opt/inst_buff_addr_check_test.cpp
@@ -19,7 +19,6 @@
 #include <string>
 #include <vector>
 
-#include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"
 

--- a/test/opt/inst_debug_printf_test.cpp
+++ b/test/opt/inst_debug_printf_test.cpp
@@ -18,7 +18,6 @@
 #include <string>
 #include <vector>
 
-#include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"
 

--- a/test/opt/instruction_test.cpp
+++ b/test/opt/instruction_test.cpp
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "source/opt/instruction.h"
+
 #include <memory>
-#include <string>
 #include <utility>
 #include <vector>
 
 #include "gmock/gmock.h"
-#include "source/opt/instruction.h"
 #include "source/opt/ir_context.h"
 #include "spirv-tools/libspirv.h"
 #include "test/opt/pass_fixture.h"

--- a/test/opt/interface_var_sroa_test.cpp
+++ b/test/opt/interface_var_sroa_test.cpp
@@ -14,8 +14,6 @@
 
 #include <iostream>
 
-#include "gmock/gmock.h"
-#include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"
 

--- a/test/opt/ir_builder.cpp
+++ b/test/opt/ir_builder.cpp
@@ -12,18 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <algorithm>
+#include "source/opt/ir_builder.h"
+
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "effcee/effcee.h"
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "source/opt/basic_block.h"
 #include "source/opt/build_module.h"
 #include "source/opt/instruction.h"
-#include "source/opt/ir_builder.h"
 #include "source/opt/type_manager.h"
 #include "spirv-tools/libspirv.hpp"
 

--- a/test/opt/ir_context_test.cpp
+++ b/test/opt/ir_context_test.cpp
@@ -16,7 +16,6 @@
 
 #include <algorithm>
 #include <memory>
-#include <string>
 #include <utility>
 
 #include "OpenCLDebugInfo100.h"

--- a/test/opt/ir_loader_test.cpp
+++ b/test/opt/ir_loader_test.cpp
@@ -14,7 +14,6 @@
 
 #include <algorithm>
 #include <memory>
-#include <string>
 #include <unordered_set>
 #include <utility>
 #include <vector>

--- a/test/opt/local_redundancy_elimination_test.cpp
+++ b/test/opt/local_redundancy_elimination_test.cpp
@@ -15,9 +15,7 @@
 #include <string>
 
 #include "gmock/gmock.h"
-#include "source/opt/build_module.h"
 #include "source/opt/value_number_table.h"
-#include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"
 

--- a/test/opt/loop_optimizations/dependence_analysis.cpp
+++ b/test/opt/loop_optimizations/dependence_analysis.cpp
@@ -14,17 +14,11 @@
 
 #include <memory>
 #include <set>
-#include <string>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "source/opt/iterator.h"
 #include "source/opt/loop_dependence.h"
 #include "source/opt/loop_descriptor.h"
-#include "source/opt/pass.h"
-#include "source/opt/tree_iterator.h"
 #include "test/opt//assembly_builder.h"
 #include "test/opt//function_utils.h"
 #include "test/opt//pass_fixture.h"

--- a/test/opt/loop_optimizations/dependence_analysis_helpers.cpp
+++ b/test/opt/loop_optimizations/dependence_analysis_helpers.cpp
@@ -13,17 +13,11 @@
 // limitations under the License.
 
 #include <memory>
-#include <string>
-#include <unordered_set>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "source/opt/iterator.h"
 #include "source/opt/loop_dependence.h"
 #include "source/opt/loop_descriptor.h"
-#include "source/opt/pass.h"
 #include "source/opt/scalar_analysis.h"
-#include "source/opt/tree_iterator.h"
 #include "test/opt/assembly_builder.h"
 #include "test/opt/function_utils.h"
 #include "test/opt/pass_fixture.h"

--- a/test/opt/loop_optimizations/fusion_compatibility.cpp
+++ b/test/opt/loop_optimizations/fusion_compatibility.cpp
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <algorithm>
-#include <iterator>
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "gmock/gmock.h"

--- a/test/opt/loop_optimizations/fusion_illegal.cpp
+++ b/test/opt/loop_optimizations/fusion_illegal.cpp
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <algorithm>
-#include <iterator>
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "gmock/gmock.h"

--- a/test/opt/loop_optimizations/fusion_legal.cpp
+++ b/test/opt/loop_optimizations/fusion_legal.cpp
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <algorithm>
-#include <iterator>
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "effcee/effcee.h"

--- a/test/opt/loop_optimizations/lcssa.cpp
+++ b/test/opt/loop_optimizations/lcssa.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "effcee/effcee.h"
@@ -21,7 +20,6 @@
 #include "source/opt/build_module.h"
 #include "source/opt/loop_descriptor.h"
 #include "source/opt/loop_utils.h"
-#include "source/opt/pass.h"
 #include "test/opt//assembly_builder.h"
 #include "test/opt/function_utils.h"
 

--- a/test/opt/loop_optimizations/loop_descriptions.cpp
+++ b/test/opt/loop_optimizations/loop_descriptions.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "gmock/gmock.h"

--- a/test/opt/loop_optimizations/loop_fission.cpp
+++ b/test/opt/loop_optimizations/loop_fission.cpp
@@ -12,15 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "source/opt/loop_fission.h"
+
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "gmock/gmock.h"
-#include "source/opt/loop_fission.h"
-#include "source/opt/loop_unroller.h"
 #include "source/opt/loop_utils.h"
-#include "source/opt/pass.h"
 #include "test/opt/assembly_builder.h"
 #include "test/opt/function_utils.h"
 #include "test/opt/pass_fixture.h"

--- a/test/opt/loop_optimizations/peeling.cpp
+++ b/test/opt/loop_optimizations/peeling.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "effcee/effcee.h"

--- a/test/opt/loop_optimizations/peeling_pass.cpp
+++ b/test/opt/loop_optimizations/peeling_pass.cpp
@@ -17,7 +17,6 @@
 #include <vector>
 
 #include "gmock/gmock.h"
-#include "source/opt/ir_builder.h"
 #include "source/opt/loop_descriptor.h"
 #include "source/opt/loop_peeling.h"
 #include "test/opt/pass_fixture.h"

--- a/test/opt/loop_optimizations/unroll_assumptions.cpp
+++ b/test/opt/loop_optimizations/unroll_assumptions.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "gmock/gmock.h"

--- a/test/opt/loop_optimizations/unroll_simple.cpp
+++ b/test/opt/loop_optimizations/unroll_simple.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "gmock/gmock.h"

--- a/test/opt/module_test.cpp
+++ b/test/opt/module_test.cpp
@@ -12,16 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "source/opt/module.h"
+
 #include <memory>
-#include <sstream>
-#include <string>
 #include <vector>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "source/opt/build_module.h"
-#include "source/opt/module.h"
-#include "source/opt/pass.h"
 #include "spirv-tools/libspirv.hpp"
 #include "test/opt/module_utils.h"
 

--- a/test/opt/pass_merge_return_test.cpp
+++ b/test/opt/pass_merge_return_test.cpp
@@ -14,9 +14,7 @@
 
 #include <string>
 
-#include "gmock/gmock.h"
 #include "spirv-tools/libspirv.hpp"
-#include "spirv-tools/optimizer.hpp"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"
 

--- a/test/opt/pass_remove_duplicates_test.cpp
+++ b/test/opt/pass_remove_duplicates_test.cpp
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include "gmock/gmock.h"
 #include "source/opt/build_module.h"
 #include "source/opt/ir_context.h"
 #include "source/opt/pass_manager.h"

--- a/test/opt/private_to_local_test.cpp
+++ b/test/opt/private_to_local_test.cpp
@@ -15,7 +15,6 @@
 #include <string>
 
 #include "gmock/gmock.h"
-#include "source/opt/build_module.h"
 #include "source/opt/value_number_table.h"
 #include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"

--- a/test/opt/propagator_test.cpp
+++ b/test/opt/propagator_test.cpp
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "source/opt/propagator.h"
+
 #include <map>
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "gmock/gmock.h"
@@ -22,8 +23,6 @@
 #include "source/opt/build_module.h"
 #include "source/opt/cfg.h"
 #include "source/opt/ir_context.h"
-#include "source/opt/pass.h"
-#include "source/opt/propagator.h"
 
 namespace spvtools {
 namespace opt {

--- a/test/opt/redundancy_elimination_test.cpp
+++ b/test/opt/redundancy_elimination_test.cpp
@@ -15,8 +15,6 @@
 #include <string>
 
 #include "gmock/gmock.h"
-#include "source/opt/build_module.h"
-#include "source/opt/value_number_table.h"
 #include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"

--- a/test/opt/register_liveness.cpp
+++ b/test/opt/register_liveness.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <memory>
-#include <string>
 #include <unordered_set>
 #include <vector>
 

--- a/test/opt/relax_float_ops_test.cpp
+++ b/test/opt/relax_float_ops_test.cpp
@@ -18,7 +18,6 @@
 #include <string>
 #include <vector>
 
-#include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"
 

--- a/test/opt/remove_unused_interface_variables_test.cpp
+++ b/test/opt/remove_unused_interface_variables_test.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gmock/gmock.h"
 #include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"

--- a/test/opt/replace_desc_array_access_using_var_index_test.cpp
+++ b/test/opt/replace_desc_array_access_using_var_index_test.cpp
@@ -14,8 +14,6 @@
 
 #include <string>
 
-#include "gmock/gmock.h"
-#include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"
 

--- a/test/opt/replace_invalid_opc_test.cpp
+++ b/test/opt/replace_invalid_opc_test.cpp
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdarg>
 #include <string>
 #include <vector>
 
-#include "gmock/gmock.h"
 #include "pass_utils.h"
 #include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"

--- a/test/opt/scalar_analysis.cpp
+++ b/test/opt/scalar_analysis.cpp
@@ -12,17 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "source/opt/scalar_analysis.h"
+
 #include <memory>
-#include <string>
-#include <unordered_set>
 #include <vector>
 
 #include "gmock/gmock.h"
-#include "source/opt/iterator.h"
-#include "source/opt/loop_descriptor.h"
 #include "source/opt/pass.h"
-#include "source/opt/scalar_analysis.h"
-#include "source/opt/tree_iterator.h"
 #include "test/opt/assembly_builder.h"
 #include "test/opt/function_utils.h"
 #include "test/opt/pass_fixture.h"

--- a/test/opt/scalar_replacement_test.cpp
+++ b/test/opt/scalar_replacement_test.cpp
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "source/opt/scalar_replacement_pass.h"
-
 #include <string>
 
-#include "gmock/gmock.h"
+#include "source/opt/scalar_replacement_pass.h"
 #include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"

--- a/test/opt/simplification_test.cpp
+++ b/test/opt/simplification_test.cpp
@@ -16,7 +16,6 @@
 
 #include "gmock/gmock.h"
 #include "source/opt/simplification_pass.h"
-#include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"
 
 namespace spvtools {

--- a/test/opt/spread_volatile_semantics_test.cpp
+++ b/test/opt/spread_volatile_semantics_test.cpp
@@ -14,7 +14,6 @@
 
 #include <string>
 
-#include "gmock/gmock.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"
 

--- a/test/opt/strength_reduction_test.cpp
+++ b/test/opt/strength_reduction_test.cpp
@@ -12,16 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <algorithm>
-#include <cstdarg>
-#include <iostream>
-#include <sstream>
 #include <string>
 #include <unordered_set>
 #include <vector>
 
 #include "gmock/gmock.h"
-#include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"
 

--- a/test/opt/struct_cfg_analysis_test.cpp
+++ b/test/opt/struct_cfg_analysis_test.cpp
@@ -17,7 +17,6 @@
 #include <string>
 
 #include "gmock/gmock.h"
-#include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"
 

--- a/test/opt/type_manager_test.cpp
+++ b/test/opt/type_manager_test.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "source/opt/type_manager.h"
+
 #include <memory>
-#include <string>
 #include <utility>
 #include <vector>
 
@@ -22,7 +23,6 @@
 #include "gtest/gtest.h"
 #include "source/opt/build_module.h"
 #include "source/opt/instruction.h"
-#include "source/opt/type_manager.h"
 #include "spirv-tools/libspirv.hpp"
 
 namespace spvtools {

--- a/test/opt/upgrade_memory_model_test.cpp
+++ b/test/opt/upgrade_memory_model_test.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "assembly_builder.h"
-#include "gmock/gmock.h"
 #include "pass_fixture.h"
 #include "pass_utils.h"
 

--- a/test/opt/value_table_test.cpp
+++ b/test/opt/value_table_test.cpp
@@ -17,7 +17,6 @@
 #include "gmock/gmock.h"
 #include "source/opt/build_module.h"
 #include "source/opt/value_number_table.h"
-#include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"
 
 namespace spvtools {

--- a/test/opt/workaround1209_test.cpp
+++ b/test/opt/workaround1209_test.cpp
@@ -12,15 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <algorithm>
-#include <cstdarg>
-#include <iostream>
-#include <sstream>
 #include <string>
 #include <unordered_set>
 
-#include "gmock/gmock.h"
-#include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"
 

--- a/test/opt/wrap_opkill_test.cpp
+++ b/test/opt/wrap_opkill_test.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gmock/gmock.h"
 #include "test/opt/assembly_builder.h"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"


### PR DESCRIPTION
Running code analysis I found a lot of unused includes and removed them