### PR TITLE
Add support for SPV_EXT_shader_tile_image

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -11,7 +11,7 @@ vars = {
   'protobuf_revision': 'v21.12',
 
   're2_revision': '11073deb73b3d01018308863c0bcdfd0d51d3e70',
-  'spirv_headers_revision': '29ba2493125effc581532518add689613cebfec7',
+  'spirv_headers_revision': 'cfbe4feef20c3c0628712c2792624f0221e378ac',
 }
 
 deps = {

--- a/source/val/validate_annotation.cpp
+++ b/source/val/validate_annotation.cpp
@@ -193,7 +193,8 @@ spv_result_t ValidateDecorationTarget(ValidationState_t& _, spv::Decoration dec,
     switch (dec) {
       case spv::Decoration::Location:
       case spv::Decoration::Component:
-        // Location is used for input, output and ray tracing stages.
+        // Location is used for input, output, tile image, and ray tracing
+        // stages.
         if (sc != spv::StorageClass::Input && sc != spv::StorageClass::Output &&
             sc != spv::StorageClass::RayPayloadKHR &&
             sc != spv::StorageClass::IncomingRayPayloadKHR &&
@@ -201,7 +202,8 @@ spv_result_t ValidateDecorationTarget(ValidationState_t& _, spv::Decoration dec,
             sc != spv::StorageClass::CallableDataKHR &&
             sc != spv::StorageClass::IncomingCallableDataKHR &&
             sc != spv::StorageClass::ShaderRecordBufferKHR &&
-            sc != spv::StorageClass::HitObjectAttributeNV) {
+            sc != spv::StorageClass::HitObjectAttributeNV &&
+            sc != spv::StorageClass::TileImageEXT) {
           return _.diag(SPV_ERROR_INVALID_ID, target)
                  << _.VkErrorID(6672) << _.SpvDecorationString(dec)
                  << " decoration must not be applied to this storage class";

--- a/source/val/validate_function.cpp
+++ b/source/val/validate_function.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 
+#include "source/enum_string_mapping.h"
 #include "source/opcode.h"
 #include "source/val/instruction.h"
 #include "source/val/validate.h"
@@ -306,6 +307,16 @@ spv_result_t ValidateFunctionCall(ValidationState_t& _,
                      << "StorageBuffer pointer operand "
                      << _.getIdName(argument_id)
                      << " requires a variable pointers capability";
+            }
+            break;
+          case spv::StorageClass::TileImageEXT:
+            if (!_.HasCapability(
+                    spv::Capability::TileImageColorReadAccessEXT)) {
+              return _.diag(SPV_ERROR_INVALID_ID, inst)
+                  << "TileImageEXT pointer operand "
+                  << _.getIdName(argument_id) << " requires "
+                  << CapabilityToString(
+                            spv::Capability::TileImageColorReadAccessEXT);
             }
             break;
           default:

--- a/source/val/validate_function.cpp
+++ b/source/val/validate_function.cpp
@@ -309,16 +309,6 @@ spv_result_t ValidateFunctionCall(ValidationState_t& _,
                      << " requires a variable pointers capability";
             }
             break;
-          case spv::StorageClass::TileImageEXT:
-            if (!_.HasCapability(
-                    spv::Capability::TileImageColorReadAccessEXT)) {
-              return _.diag(SPV_ERROR_INVALID_ID, inst)
-                  << "TileImageEXT pointer operand "
-                  << _.getIdName(argument_id) << " requires "
-                  << CapabilityToString(
-                            spv::Capability::TileImageColorReadAccessEXT);
-            }
-            break;
           default:
             return _.diag(SPV_ERROR_INVALID_ID, inst)
                    << "Invalid storage class for pointer operand "

--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -210,6 +210,7 @@ uint32_t GetPlaneCoordSize(const ImageTypeInfo& info) {
     case spv::Dim::Dim2D:
     case spv::Dim::Rect:
     case spv::Dim::SubpassData:
+    case spv::Dim::TileImageDataEXT:
       plane_size = 2;
       break;
     case spv::Dim::Dim3D:
@@ -853,7 +854,30 @@ spv_result_t ValidateTypeImage(ValidationState_t& _, const Instruction* inst) {
       return _.diag(SPV_ERROR_INVALID_DATA, inst)
              << "Dim SubpassData requires format Unknown";
     }
-  } else {
+  } else if (info.dim == spv::Dim::TileImageDataEXT) {
+    if (_.IsVoidType(info.sampled_type)) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "Dim TileImageDataEXT requires Sampled Type to be not "
+                "OpTypeVoid";
+    }
+    if (info.sampled != 2) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "Dim TileImageDataEXT requires Sampled to be 2";
+    }
+    if (info.format != spv::ImageFormat::Unknown) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "Dim TileImageDataEXT requires format Unknown";
+    }
+    if (info.depth != 0) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "Dim TileImageDataEXT requires Depth to be 0";
+    }
+    if (info.arrayed != 0) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "Dim TileImageDataEXT requires Arrayed to be 0";
+    }
+  }
+  else {
     if (info.multisampled && (info.sampled == 2) &&
         !_.HasCapability(spv::Capability::StorageImageMultisample)) {
       return _.diag(SPV_ERROR_INVALID_DATA, inst)
@@ -918,6 +942,8 @@ spv_result_t ValidateTypeSampledImage(ValidationState_t& _,
   }
   // OpenCL requires Sampled=0, checked elsewhere.
   // Vulkan uses the Sampled=1 case.
+  // If Dim is TileImageDataEXT, Sampled must be 2 and this is validated
+  // elsewhere.
   if ((info.sampled != 0) && (info.sampled != 1)) {
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
            << _.VkErrorID(4657)
@@ -1115,6 +1141,11 @@ spv_result_t ValidateImageTexelPointer(ValidationState_t& _,
   if (info.dim == spv::Dim::SubpassData) {
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
            << "Image Dim SubpassData cannot be used with OpImageTexelPointer";
+  }
+
+  if (info.dim == spv::Dim::TileImageDataEXT) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+           << "Image Dim TileImageDataEXT cannot be used with OpImageTexelPointer";
   }
 
   const uint32_t coord_type = _.GetOperandTypeId(inst, 3);
@@ -1623,6 +1654,19 @@ spv_result_t ValidateImageRead(ValidationState_t& _, const Instruction* inst) {
                 spvOpcodeString(opcode));
   }
 
+  if (info.dim == spv::Dim::TileImageDataEXT) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+           << "Image Dim TileImageDataEXT cannot be used with "
+           << spvOpcodeString(opcode);
+
+    _.function(inst->function()->id())
+        ->RegisterExecutionModelLimitation(
+            spv::ExecutionModel::Fragment,
+            std::string(
+                "Dim TileImageDataEXT requires Fragment execution model: ") +
+                spvOpcodeString(opcode));
+  }
+
   if (_.GetIdOpcode(info.sampled_type) != spv::Op::OpTypeVoid) {
     const uint32_t result_component_type =
         _.GetComponentType(actual_result_type);
@@ -1683,6 +1727,11 @@ spv_result_t ValidateImageWrite(ValidationState_t& _, const Instruction* inst) {
   if (info.dim == spv::Dim::SubpassData) {
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
            << "Image 'Dim' cannot be SubpassData";
+  }
+
+  if (info.dim == spv::Dim::TileImageDataEXT) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+           << "Image 'Dim' cannot be TileImageDataEXT";
   }
 
   if (spv_result_t result = ValidateImageReadWrite(_, inst, info))
@@ -1899,9 +1948,21 @@ spv_result_t ValidateImageQueryFormatOrOrder(ValidationState_t& _,
            << "Expected Result Type to be int scalar type";
   }
 
-  if (_.GetIdOpcode(_.GetOperandTypeId(inst, 2)) != spv::Op::OpTypeImage) {
+  const uint32_t image_type = _.GetOperandTypeId(inst, 2);
+  if (_.GetIdOpcode(image_type) != spv::Op::OpTypeImage) {
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
            << "Expected operand to be of type OpTypeImage";
+  }
+
+  ImageTypeInfo info;
+  if (!GetImageTypeInfo(_, image_type, &info)) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+           << "Corrupt image type definition";
+  }
+
+  if (info.dim == spv::Dim::TileImageDataEXT) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+           << "Image 'Dim' cannot be TileImageDataEXT";
   }
   return SPV_SUCCESS;
 }

--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -876,8 +876,7 @@ spv_result_t ValidateTypeImage(ValidationState_t& _, const Instruction* inst) {
       return _.diag(SPV_ERROR_INVALID_DATA, inst)
              << "Dim TileImageDataEXT requires Arrayed to be 0";
     }
-  }
-  else {
+  } else {
     if (info.multisampled && (info.sampled == 2) &&
         !_.HasCapability(spv::Capability::StorageImageMultisample)) {
       return _.diag(SPV_ERROR_INVALID_DATA, inst)
@@ -1145,7 +1144,8 @@ spv_result_t ValidateImageTexelPointer(ValidationState_t& _,
 
   if (info.dim == spv::Dim::TileImageDataEXT) {
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
-           << "Image Dim TileImageDataEXT cannot be used with OpImageTexelPointer";
+           << "Image Dim TileImageDataEXT cannot be used with "
+              "OpImageTexelPointer";
   }
 
   const uint32_t coord_type = _.GetOperandTypeId(inst, 3);

--- a/source/val/validate_mode_setting.cpp
+++ b/source/val/validate_mode_setting.cpp
@@ -502,6 +502,9 @@ spv_result_t ValidateExecutionMode(ValidationState_t& _,
     case spv::ExecutionMode::DepthGreater:
     case spv::ExecutionMode::DepthLess:
     case spv::ExecutionMode::DepthUnchanged:
+    case spv::ExecutionMode::NonCoherentColorAttachmentReadEXT:
+    case spv::ExecutionMode::NonCoherentDepthAttachmentReadEXT:
+    case spv::ExecutionMode::NonCoherentStencilAttachmentReadEXT:
     case spv::ExecutionMode::PixelInterlockOrderedEXT:
     case spv::ExecutionMode::PixelInterlockUnorderedEXT:
     case spv::ExecutionMode::SampleInterlockOrderedEXT:

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -1572,6 +1572,7 @@ bool ValidationState_t::IsValidStorageClass(
       case spv::StorageClass::ShaderRecordBufferKHR:
       case spv::StorageClass::TaskPayloadWorkgroupEXT:
       case spv::StorageClass::HitObjectAttributeNV:
+      case spv::StorageClass::TileImageEXT:
         return true;
       default:
         return false;

--- a/test/text_to_binary.extension_test.cpp
+++ b/test/text_to_binary.extension_test.cpp
@@ -1198,5 +1198,48 @@ INSTANTIATE_TEST_SUITE_P(
                                  {1, 2, 3, 4, 5, 6})},
             })));
 
+// SPV_EXT_shader_tile_image
+
+INSTANTIATE_TEST_SUITE_P(
+    SPV_EXT_shader_tile_image, ExtensionRoundTripTest,
+    Combine(
+        Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_5, SPV_ENV_VULKAN_1_0,
+               SPV_ENV_VULKAN_1_1, SPV_ENV_VULKAN_1_2, SPV_ENV_VULKAN_1_3),
+        ValuesIn(std::vector<AssemblyCase>{
+            {"OpExtension \"SPV_EXT_shader_tile_image\"\n",
+             MakeInstruction(spv::Op::OpExtension,
+                             MakeVector("SPV_EXT_shader_tile_image"))},
+            {"OpCapability TileImageColorReadAccessEXT\n",
+             MakeInstruction(spv::Op::OpCapability,
+                 {(uint32_t)spv::Capability::TileImageColorReadAccessEXT})},
+            {"OpCapability TileImageDepthReadAccessEXT\n",
+             MakeInstruction(spv::Op::OpCapability,
+                 {(uint32_t)spv::Capability::TileImageDepthReadAccessEXT})},
+            {"OpCapability TileImageStencilReadAccessEXT\n",
+             MakeInstruction(spv::Op::OpCapability,
+                 {(uint32_t)spv::Capability::TileImageStencilReadAccessEXT})},
+            {"OpExecutionMode %1 NonCoherentColorAttachmentReadEXT\n",
+                MakeInstruction(spv::Op::OpExecutionMode,
+                 {1, (uint32_t)spv::ExecutionMode::NonCoherentColorAttachmentReadEXT})},
+            {"OpExecutionMode %1 NonCoherentDepthAttachmentReadEXT\n",
+             MakeInstruction(spv::Op::OpExecutionMode,
+                 {1, (uint32_t)spv::ExecutionMode::NonCoherentDepthAttachmentReadEXT})},
+            {"OpExecutionMode %1 NonCoherentStencilAttachmentReadEXT\n",
+             MakeInstruction(spv::Op::OpExecutionMode,
+                 {1, (uint32_t)spv::ExecutionMode::NonCoherentStencilAttachmentReadEXT})},
+            {"%2 = OpColorAttachmentReadEXT %1 %3\n",
+             MakeInstruction(spv::Op::OpColorAttachmentReadEXT, {1, 2, 3})},
+            {"%2 = OpColorAttachmentReadEXT %1 %3 %4\n",
+             MakeInstruction(spv::Op::OpColorAttachmentReadEXT, {1, 2, 3, 4})},
+            {"%2 = OpDepthAttachmentReadEXT %1\n",
+             MakeInstruction(spv::Op::OpDepthAttachmentReadEXT, {1, 2})},
+            {"%2 = OpDepthAttachmentReadEXT %1 %3\n",
+             MakeInstruction(spv::Op::OpDepthAttachmentReadEXT, {1, 2, 3})},
+            {"%2 = OpStencilAttachmentReadEXT %1\n",
+             MakeInstruction(spv::Op::OpStencilAttachmentReadEXT, {1, 2})},
+            {"%2 = OpStencilAttachmentReadEXT %1 %3\n",
+             MakeInstruction(spv::Op::OpStencilAttachmentReadEXT, {1, 2, 3})},
+        })));
+
 }  // namespace
 }  // namespace spvtools

--- a/test/text_to_binary.extension_test.cpp
+++ b/test/text_to_binary.extension_test.cpp
@@ -1210,23 +1210,29 @@ INSTANTIATE_TEST_SUITE_P(
              MakeInstruction(spv::Op::OpExtension,
                              MakeVector("SPV_EXT_shader_tile_image"))},
             {"OpCapability TileImageColorReadAccessEXT\n",
-             MakeInstruction(spv::Op::OpCapability,
+             MakeInstruction(
+                 spv::Op::OpCapability,
                  {(uint32_t)spv::Capability::TileImageColorReadAccessEXT})},
             {"OpCapability TileImageDepthReadAccessEXT\n",
-             MakeInstruction(spv::Op::OpCapability,
+             MakeInstruction(
+                 spv::Op::OpCapability,
                  {(uint32_t)spv::Capability::TileImageDepthReadAccessEXT})},
             {"OpCapability TileImageStencilReadAccessEXT\n",
-             MakeInstruction(spv::Op::OpCapability,
+             MakeInstruction(
+                 spv::Op::OpCapability,
                  {(uint32_t)spv::Capability::TileImageStencilReadAccessEXT})},
             {"OpExecutionMode %1 NonCoherentColorAttachmentReadEXT\n",
-                MakeInstruction(spv::Op::OpExecutionMode,
-                 {1, (uint32_t)spv::ExecutionMode::NonCoherentColorAttachmentReadEXT})},
+             MakeInstruction(spv::Op::OpExecutionMode,
+                             {1, (uint32_t)spv::ExecutionMode::
+                                     NonCoherentColorAttachmentReadEXT})},
             {"OpExecutionMode %1 NonCoherentDepthAttachmentReadEXT\n",
              MakeInstruction(spv::Op::OpExecutionMode,
-                 {1, (uint32_t)spv::ExecutionMode::NonCoherentDepthAttachmentReadEXT})},
+                             {1, (uint32_t)spv::ExecutionMode::
+                                     NonCoherentDepthAttachmentReadEXT})},
             {"OpExecutionMode %1 NonCoherentStencilAttachmentReadEXT\n",
              MakeInstruction(spv::Op::OpExecutionMode,
-                 {1, (uint32_t)spv::ExecutionMode::NonCoherentStencilAttachmentReadEXT})},
+                             {1, (uint32_t)spv::ExecutionMode::
+                                     NonCoherentStencilAttachmentReadEXT})},
             {"%2 = OpColorAttachmentReadEXT %1 %3\n",
              MakeInstruction(spv::Op::OpColorAttachmentReadEXT, {1, 2, 3})},
             {"%2 = OpColorAttachmentReadEXT %1 %3 %4\n",

--- a/test/text_to_binary.type_declaration_test.cpp
+++ b/test/text_to_binary.type_declaration_test.cpp
@@ -59,6 +59,7 @@ INSTANTIATE_TEST_SUITE_P(
         CASE(Rect),
         CASE(Buffer),
         CASE(SubpassData),
+        CASE(TileImageDataEXT),
     }));
 #undef CASE
 // clang-format on
@@ -221,6 +222,7 @@ TEST_F(OpTypeForwardPointerTest, ValidStorageClass) {
   CASE(AtomicCounter);
   CASE(Image);
   CASE(StorageBuffer);
+  CASE(TileImageEXT);
 }
 
 #undef CASE

--- a/test/val/val_modes_test.cpp
+++ b/test/val/val_modes_test.cpp
@@ -578,6 +578,11 @@ TEST_P(ValidateModeExecution, ExecutionMode) {
     sstr << "OpCapability Kernel\n";
     if (env == SPV_ENV_UNIVERSAL_1_3) {
       sstr << "OpCapability SubgroupDispatch\n";
+    } else if (env == SPV_ENV_UNIVERSAL_1_5) {
+      sstr << "OpCapability TileImageColorReadAccessEXT\n";
+      sstr << "OpCapability TileImageDepthReadAccessEXT\n";
+      sstr << "OpCapability TileImageStencilReadAccessEXT\n";
+      sstr << "OpExtension \"SPV_EXT_shader_tile_image\"\n";
     }
   }
   sstr << "OpMemoryModel Logical GLSL450\n";
@@ -700,6 +705,27 @@ INSTANTIATE_TEST_SUITE_P(
                    "EarlyFragmentTests", "DepthReplacing", "DepthGreater",
                    "DepthLess", "DepthUnchanged"),
             Values(SPV_ENV_UNIVERSAL_1_0)));
+
+INSTANTIATE_TEST_SUITE_P(ValidateModeFragmentOnlyGoodSpv15,
+                         ValidateModeExecution,
+                         Combine(Values(SPV_SUCCESS), Values(""),
+                                 Values("Fragment"),
+                                 Values("NonCoherentColorAttachmentReadEXT",
+                                        "NonCoherentDepthAttachmentReadEXT",
+                                        "NonCoherentStencilAttachmentReadEXT"),
+                                 Values(SPV_ENV_UNIVERSAL_1_5)));
+
+INSTANTIATE_TEST_SUITE_P(
+    ValidateModeFragmentOnlyBadSpv15, ValidateModeExecution,
+    Combine(Values(SPV_ERROR_INVALID_DATA),
+            Values("Execution mode can only be used with the Fragment "
+                   "execution model."),
+            Values("Geometry", "TessellationControl", "TessellationEvaluation",
+                   "GLCompute", "Vertex", "Kernel"),
+            Values("NonCoherentColorAttachmentReadEXT",
+                   "NonCoherentDepthAttachmentReadEXT",
+                   "NonCoherentStencilAttachmentReadEXT"),
+            Values(SPV_ENV_UNIVERSAL_1_5)));
 
 INSTANTIATE_TEST_SUITE_P(ValidateModeKernelOnlyGoodSpv13, ValidateModeExecution,
                          Combine(Values(SPV_SUCCESS), Values(""),


### PR DESCRIPTION

Adds the basic validation corresponding to https://github.com/KhronosGroup/SPIRV-Registry/pull/198 and https://github.com/KhronosGroup/SPIRV-Headers/pull/335


This requires the header PR to land first.