### PR TITLE
Fix vector OpConstantComposite type validation

### DIFF
--- a/source/val/validate_constants.cpp
+++ b/source/val/validate_constants.cpp
@@ -76,7 +76,7 @@ spv_result_t ValidateConstantComposite(ValidationState_t& _,
         }
         const auto constituent_result_type = _.FindDef(constituent->type_id());
         if (!constituent_result_type ||
-            component_type->opcode() != constituent_result_type->opcode()) {
+            component_type->id() != constituent_result_type->id()) {
           return _.diag(SPV_ERROR_INVALID_ID, inst)
                  << opcode_name << " Constituent <id> "
                  << _.getIdName(constituent_id)

--- a/test/val/val_constants_test.cpp
+++ b/test/val/val_constants_test.cpp
@@ -478,6 +478,22 @@ OpName %ptr "ptr"
                         "a null value"));
 }
 
+TEST_F(ValidateConstant, VectorMismatchedConstituents) {
+  std::string spirv = kShaderPreamble kBasicTypes R"(
+%int = OpTypeInt 32 1
+%int_0 = OpConstantNull %int
+%const_vector = OpConstantComposite %uint2 %uint_0 %int_0
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(
+          "OpConstantComposite Constituent <id> '13[%13]'s type "
+          "does not match Result Type <id> '3[%v2uint]'s vector element type"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools

--- a/test/val/val_extension_spv_khr_integer_dot_product_test.cpp
+++ b/test/val/val_extension_spv_khr_integer_dot_product_test.cpp
@@ -128,7 +128,7 @@ std::string AssemblyForCase(const Case& c) {
          %char_0 = OpConstant %char 0
          %char_1 = OpConstant %char 1
 
-         %v4uchar_0 = OpConstantComposite %v4uchar %uchar_0 %uint_0 %uchar_0 %uchar_0
+         %v4uchar_0 = OpConstantComposite %v4uchar %uchar_0 %uchar_0 %uchar_0 %uchar_0
          %v4uchar_1 = OpConstantComposite %v4uchar %uchar_1 %uchar_1 %uchar_1 %uchar_1
          %v4char_0 = OpConstantComposite %v4char %char_0 %char_0 %char_0 %char_0
          %v4char_1 = OpConstantComposite %v4char %char_1 %char_1 %char_1 %char_1


### PR DESCRIPTION
The constituent types much fully match, not just the opcode.

Fixes #3576 