### PR TITLE
Add default case for spv::Dim for TileImageEXT

### DIFF
--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -218,6 +218,7 @@ uint32_t GetPlaneCoordSize(const ImageTypeInfo& info) {
       plane_size = 3;
       break;
     case spv::Dim::Max:
+    default:
       assert(0);
       break;
   }


### PR DESCRIPTION
Without this the switch statement must be updated at the same time as the SPIR-V headers, which makes rolls impossible.