### PR TITLE
Apply scalar replacement on vars with Pointer decorations

### DIFF
--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -30,7 +30,6 @@ namespace {
 constexpr uint32_t kDebugValueOperandValueIndex = 5;
 constexpr uint32_t kDebugValueOperandExpressionIndex = 6;
 constexpr uint32_t kDebugDeclareOperandVariableIndex = 5;
-constexpr uint32_t kPointerTypeIdInOperandIndex = 1;
 }  // namespace
 
 Pass::Status ScalarReplacementPass::Process() {

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -949,11 +949,11 @@ uint64_t ScalarReplacementPass::GetMaxLegalIndex(
 void ScalarReplacementPass::CopyDecorationsToVariable(Instruction* from,
                                                       Instruction* to,
                                                       uint32_t member_index) {
-  CopyVariableDecorationsToVariable(from, to);
-  CopyMemberDecorationsToVariable(from, to, member_index);
+  CopyPointerDecorationsToVariable(from, to);
+  CopyRelaxPrecisionDecorationToVariable(from, to, member_index);
 }
 
-void ScalarReplacementPass::CopyVariableDecorationsToVariable(Instruction* from,
+void ScalarReplacementPass::CopyPointerDecorationsToVariable(Instruction* from,
                                                               Instruction* to) {
   // The RestrictPointer and AliasedPointer decorations are copied to all
   // members even if the new variable does not contain a pointer. It does
@@ -975,7 +975,7 @@ void ScalarReplacementPass::CopyVariableDecorationsToVariable(Instruction* from,
   }
 }
 
-void ScalarReplacementPass::CopyMemberDecorationsToVariable(
+void ScalarReplacementPass::CopyRelaxPrecisionDecorationToVariable(
     Instruction* from, Instruction* to, uint32_t member_index) {
   Instruction* type_inst = GetStorageType(from);
   for (auto dec_inst :

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -30,6 +30,7 @@ namespace {
 constexpr uint32_t kDebugValueOperandValueIndex = 5;
 constexpr uint32_t kDebugValueOperandExpressionIndex = 6;
 constexpr uint32_t kDebugDeclareOperandVariableIndex = 5;
+constexpr uint32_t kPointerTypeIdInOperandIndex = 1;
 }  // namespace
 
 Pass::Status ScalarReplacementPass::Process() {
@@ -466,9 +467,9 @@ void ScalarReplacementPass::TransferAnnotations(
 }
 
 void ScalarReplacementPass::CreateVariable(
-    uint32_t typeId, Instruction* varInst, uint32_t index,
+    uint32_t type_id, Instruction* var_inst, uint32_t index,
     std::vector<Instruction*>* replacements) {
-  uint32_t ptrId = GetOrCreatePointerType(typeId);
+  uint32_t ptr_id = GetOrCreatePointerType(type_id);
   uint32_t id = TakeNextId();
 
   if (id == 0) {
@@ -476,51 +477,22 @@ void ScalarReplacementPass::CreateVariable(
   }
 
   std::unique_ptr<Instruction> variable(
-      new Instruction(context(), spv::Op::OpVariable, ptrId, id,
+      new Instruction(context(), spv::Op::OpVariable, ptr_id, id,
                       std::initializer_list<Operand>{
                           {SPV_OPERAND_TYPE_STORAGE_CLASS,
                            {uint32_t(spv::StorageClass::Function)}}}));
 
-  BasicBlock* block = context()->get_instr_block(varInst);
+  BasicBlock* block = context()->get_instr_block(var_inst);
   block->begin().InsertBefore(std::move(variable));
   Instruction* inst = &*block->begin();
 
   // If varInst was initialized, make sure to initialize its replacement.
-  GetOrCreateInitialValue(varInst, index, inst);
+  GetOrCreateInitialValue(var_inst, index, inst);
   get_def_use_mgr()->AnalyzeInstDefUse(inst);
   context()->set_instr_block(inst, block);
 
-  // Copy decorations from the member to the new variable.
-  Instruction* typeInst = GetStorageType(varInst);
-  for (auto dec_inst :
-       get_decoration_mgr()->GetDecorationsFor(typeInst->result_id(), false)) {
-    uint32_t decoration;
-    if (dec_inst->opcode() != spv::Op::OpMemberDecorate) {
-      continue;
-    }
-
-    if (dec_inst->GetSingleWordInOperand(1) != index) {
-      continue;
-    }
-
-    decoration = dec_inst->GetSingleWordInOperand(2u);
-    switch (spv::Decoration(decoration)) {
-      case spv::Decoration::RelaxedPrecision: {
-        std::unique_ptr<Instruction> new_dec_inst(
-            new Instruction(context(), spv::Op::OpDecorate, 0, 0, {}));
-        new_dec_inst->AddOperand(Operand(SPV_OPERAND_TYPE_ID, {id}));
-        for (uint32_t i = 2; i < dec_inst->NumInOperandWords(); ++i) {
-          new_dec_inst->AddOperand(Operand(dec_inst->GetInOperand(i)));
-        }
-        context()->AddAnnotationInst(std::move(new_dec_inst));
-      } break;
-      default:
-        break;
-    }
-  }
-
-  // Update the DebugInfo debug information.
-  inst->UpdateDebugInfoFrom(varInst);
+  CopyDecorationsToVariable(var_inst, inst, index);
+  inst->UpdateDebugInfoFrom(var_inst);
 
   replacements->push_back(inst);
 }
@@ -529,21 +501,26 @@ uint32_t ScalarReplacementPass::GetOrCreatePointerType(uint32_t id) {
   auto iter = pointee_to_pointer_.find(id);
   if (iter != pointee_to_pointer_.end()) return iter->second;
 
+  analysis::TypeManager* type_mgr = context()->get_type_mgr();
   analysis::Type* pointeeTy;
   std::unique_ptr<analysis::Pointer> pointerTy;
   std::tie(pointeeTy, pointerTy) =
-      context()->get_type_mgr()->GetTypeAndPointerType(
-          id, spv::StorageClass::Function);
-  uint32_t ptrId = 0;
-  if (pointeeTy->IsUniqueType()) {
-    // Non-ambiguous type, just ask the type manager for an id.
-    ptrId = context()->get_type_mgr()->GetTypeInstruction(pointerTy.get());
-    pointee_to_pointer_[id] = ptrId;
-    return ptrId;
+      type_mgr->GetTypeAndPointerType(id, spv::StorageClass::Function);
+
+  // If `pointeeTy` is ambiguous, then the type manager may have found the wrong
+  // type. This is why we check if we have the correct pointee type.
+  if (pointerTy && PointsToTypeId(pointerTy.get(), id)) {
+    // The type manager returned the correct type.
+    uint32_t ptr_type_id = type_mgr->GetTypeInstruction(pointerTy.get());
+    pointee_to_pointer_[id] = ptr_type_id;
+    return ptr_type_id;
   }
 
-  // Ambiguous type. We must perform a linear search to try and find the right
-  // type.
+  // If we did not get the right pointee type, we have to do a linear search for
+  // the correct pointer type. We do not want to do the linear search all of the
+  // time because the hash table look up above will work most of the time and is
+  // faster.
+  uint32_t ptr_type_id = 0;
   for (auto global : context()->types_values()) {
     if (global.opcode() == spv::Op::OpTypePointer &&
         spv::StorageClass(global.GetSingleWordInOperand(0u)) ==
@@ -551,30 +528,30 @@ uint32_t ScalarReplacementPass::GetOrCreatePointerType(uint32_t id) {
         global.GetSingleWordInOperand(1u) == id) {
       if (get_decoration_mgr()->GetDecorationsFor(id, false).empty()) {
         // Only reuse a decoration-less pointer of the correct type.
-        ptrId = global.result_id();
+        ptr_type_id = global.result_id();
         break;
       }
     }
   }
 
-  if (ptrId != 0) {
-    pointee_to_pointer_[id] = ptrId;
-    return ptrId;
+  if (ptr_type_id != 0) {
+    pointee_to_pointer_[id] = ptr_type_id;
+    return ptr_type_id;
   }
 
-  ptrId = TakeNextId();
+  ptr_type_id = TakeNextId();
   context()->AddType(MakeUnique<Instruction>(
-      context(), spv::Op::OpTypePointer, 0, ptrId,
+      context(), spv::Op::OpTypePointer, 0, ptr_type_id,
       std::initializer_list<Operand>{{SPV_OPERAND_TYPE_STORAGE_CLASS,
                                       {uint32_t(spv::StorageClass::Function)}},
                                      {SPV_OPERAND_TYPE_ID, {id}}}));
   Instruction* ptr = &*--context()->types_values_end();
   get_def_use_mgr()->AnalyzeInstDefUse(ptr);
-  pointee_to_pointer_[id] = ptrId;
+  pointee_to_pointer_[id] = ptr_type_id;
   // Register with the type manager if necessary.
-  context()->get_type_mgr()->RegisterType(ptrId, *pointerTy);
+  type_mgr->RegisterType(ptr_type_id, *pointerTy);
 
-  return ptrId;
+  return ptr_type_id;
 }
 
 void ScalarReplacementPass::GetOrCreateInitialValue(Instruction* source,
@@ -761,6 +738,8 @@ bool ScalarReplacementPass::CheckTypeAnnotations(
       case spv::Decoration::AlignmentId:
       case spv::Decoration::MaxByteOffset:
       case spv::Decoration::RelaxedPrecision:
+      case spv::Decoration::AliasedPointer:
+      case spv::Decoration::RestrictPointer:
         break;
       default:
         return false;
@@ -781,6 +760,8 @@ bool ScalarReplacementPass::CheckAnnotations(const Instruction* varInst) const {
       case spv::Decoration::Alignment:
       case spv::Decoration::AlignmentId:
       case spv::Decoration::MaxByteOffset:
+      case spv::Decoration::AliasedPointer:
+      case spv::Decoration::RestrictPointer:
         break;
       default:
         return false;
@@ -1009,6 +990,75 @@ uint64_t ScalarReplacementPass::GetMaxLegalIndex(
       return 0;
   }
   return 0;
+}
+
+void ScalarReplacementPass::CopyDecorationsToVariable(Instruction* from,
+                                                      Instruction* to,
+                                                      uint32_t member_index) {
+  CopyVariableDecorationsToVariable(from, to);
+  CopyMemberDecorationsToVariable(from, to, member_index);
+}
+
+void ScalarReplacementPass::CopyVariableDecorationsToVariable(Instruction* from,
+                                                              Instruction* to) {
+  // The RestrictPointer and AliasedPointer decorations are copied to all
+  // members even if the new variable does not contain a pointer. It is does
+  // not hurt to do so.
+  for (auto dec_inst :
+       get_decoration_mgr()->GetDecorationsFor(from->result_id(), false)) {
+    uint32_t decoration;
+    decoration = dec_inst->GetSingleWordInOperand(1u);
+    switch (spv::Decoration(decoration)) {
+      case spv::Decoration::AliasedPointer:
+      case spv::Decoration::RestrictPointer: {
+        std::unique_ptr<Instruction> new_dec_inst(dec_inst->Clone(context()));
+        new_dec_inst->SetInOperand(0, {to->result_id()});
+        context()->AddAnnotationInst(std::move(new_dec_inst));
+      } break;
+      default:
+        break;
+    }
+  }
+}
+
+void ScalarReplacementPass::CopyMemberDecorationsToVariable(
+    Instruction* from, Instruction* to, uint32_t member_index) {
+  Instruction* type_inst = GetStorageType(from);
+  for (auto dec_inst :
+       get_decoration_mgr()->GetDecorationsFor(type_inst->result_id(), false)) {
+    uint32_t decoration;
+    if (dec_inst->opcode() == spv::Op::OpMemberDecorate) {
+      if (dec_inst->GetSingleWordInOperand(1) != member_index) {
+        continue;
+      }
+
+      decoration = dec_inst->GetSingleWordInOperand(2u);
+      switch (spv::Decoration(decoration)) {
+        case spv::Decoration::RelaxedPrecision: {
+          std::unique_ptr<Instruction> new_dec_inst(
+              new Instruction(context(), spv::Op::OpDecorate, 0, 0, {}));
+          new_dec_inst->AddOperand(
+              Operand(SPV_OPERAND_TYPE_ID, {to->result_id()}));
+          for (uint32_t i = 2; i < dec_inst->NumInOperandWords(); ++i) {
+            new_dec_inst->AddOperand(Operand(dec_inst->GetInOperand(i)));
+          }
+          context()->AddAnnotationInst(std::move(new_dec_inst));
+        } break;
+        default:
+          break;
+      }
+    }
+  }
+}
+
+bool ScalarReplacementPass::PointsToTypeId(analysis::Pointer* pointer_type,
+                                           uint32_t id) {
+  analysis::TypeManager* type_mgr = context()->get_type_mgr();
+  uint32_t ptr_type_id = type_mgr->GetTypeInstruction(pointer_type);
+  Instruction* ptr_type_inst =
+      context()->get_def_use_mgr()->GetDef(ptr_type_id);
+  return ptr_type_inst->GetSingleWordInOperand(kPointerTypeIdInOperandIndex) ==
+         id;
 }
 
 }  // namespace opt

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -954,7 +954,7 @@ void ScalarReplacementPass::CopyDecorationsToVariable(Instruction* from,
 }
 
 void ScalarReplacementPass::CopyPointerDecorationsToVariable(Instruction* from,
-                                                              Instruction* to) {
+                                                             Instruction* to) {
   // The RestrictPointer and AliasedPointer decorations are copied to all
   // members even if the new variable does not contain a pointer. It does
   // not hurt to do so.

--- a/source/opt/scalar_replacement_pass.h
+++ b/source/opt/scalar_replacement_pass.h
@@ -264,21 +264,19 @@ class ScalarReplacementPass : public MemPass {
 
   // Copies all relevant decorations from `from` to `to`. This includes
   // decorations applied to the variable, and to the members of the type.
-  // It is assumed that `to` is a variable that is indended to replace the
+  // It is assumed that `to` is a variable that is intended to replace the
   // `member_index`th member of `from`.
   void CopyDecorationsToVariable(Instruction* from, Instruction* to,
                                  uint32_t member_index);
 
-  // Copies all relevant variable decorations from `from` to `to`.
-  // It is assumed that `to` is a variable that is intended to replace a member
-  // of `from`.
-  void CopyVariableDecorationsToVariable(Instruction* from, Instruction* to);
+  // Copies pointer related decoration from `from` to `to` if they exist.
+  void CopyPointerDecorationsToVariable(Instruction* from, Instruction* to);
 
-  // Copies all relevant member decorations from `from` to `to`.
-  // It is assumed that `to` is a variable that is intended to replace the
-  // `member_index`th member of `from`.
-  void CopyMemberDecorationsToVariable(Instruction* from, Instruction* to,
-                                       uint32_t member_index);
+  // Copies the relax precision decoration from the `member_index` of `from` to
+  // `to, if there was one.
+  void CopyRelaxPrecisionDecorationToVariable(Instruction* from,
+                                              Instruction* to,
+                                              uint32_t member_index);
 
   // Return true if `pointer_type` points to type `id`.  The result will be
   // false even if `pointer_type` points to a type that is isomorphic to `id`

--- a/source/opt/scalar_replacement_pass.h
+++ b/source/opt/scalar_replacement_pass.h
@@ -272,16 +272,11 @@ class ScalarReplacementPass : public MemPass {
   // Copies pointer related decoration from `from` to `to` if they exist.
   void CopyPointerDecorationsToVariable(Instruction* from, Instruction* to);
 
-  // Copies the relax precision decoration from the `member_index` of `from` to
+  // Copies decorations that are needed from the `member_index` of `from` to
   // `to, if there was one.
-  void CopyRelaxPrecisionDecorationToVariable(Instruction* from,
-                                              Instruction* to,
-                                              uint32_t member_index);
-
-  // Return true if `pointer_type` points to type `id`.  The result will be
-  // false even if `pointer_type` points to a type that is isomorphic to `id`
-  // but not `id`.
-  bool PointsToTypeId(analysis::Pointer* pointer_type, uint32_t id);
+  void CopyNecessaryMemberDecorationsToVariable(Instruction* from,
+                                                Instruction* to,
+                                                uint32_t member_index);
 
   // Limit on the number of members in an object that will be replaced.
   // 0 means there is no limit.

--- a/source/opt/scalar_replacement_pass.h
+++ b/source/opt/scalar_replacement_pass.h
@@ -262,9 +262,33 @@ class ScalarReplacementPass : public MemPass {
   // that we will be willing to split.
   bool IsLargerThanSizeLimit(uint64_t length) const;
 
+  // Copies all relevant decorations from `from` to `to`. This includes
+  // decorations applied to the variable, and to the members of the type.
+  // It is assumed that `to` is a variable that is indended to replace the
+  // `member_index`th member of `from`.
+  void CopyDecorationsToVariable(Instruction* from, Instruction* to,
+                                 uint32_t member_index);
+
+  // Copies all relevant variable decorations from `from` to `to`.
+  // It is assumed that `to` is a variable that is intended to replace a member
+  // of `from`.
+  void CopyVariableDecorationsToVariable(Instruction* from, Instruction* to);
+
+  // Copies all relevant member decorations from `from` to `to`.
+  // It is assumed that `to` is a variable that is intended to replace the
+  // `member_index`th member of `from`.
+  void CopyMemberDecorationsToVariable(Instruction* from, Instruction* to,
+                                       uint32_t member_index);
+
+  // Return true if `pointer_type` points to type `id`.  The result will be
+  // false even if `pointer_type` points to a type that is isomorphic to `id`
+  // but not `id`.
+  bool PointsToTypeId(analysis::Pointer* pointer_type, uint32_t id);
+
   // Limit on the number of members in an object that will be replaced.
   // 0 means there is no limit.
   uint32_t max_num_elements_;
+
   // This has to be big enough to fit "scalar-replacement=" followed by a
   // uint32_t number written in decimal (so 10 digits), and then a
   // terminating nul.

--- a/source/opt/type_manager.cpp
+++ b/source/opt/type_manager.cpp
@@ -178,7 +178,7 @@ void TypeManager::RemoveId(uint32_t id) {
   if (iter == id_to_type_.end()) return;
 
   auto& type = iter->second;
-  if (!type->IsUniqueType(true)) {
+  if (!type->IsUniqueType()) {
     auto tIter = type_to_id_.find(type);
     if (tIter != type_to_id_.end() && tIter->second == id) {
       // |type| currently maps to |id|.
@@ -437,7 +437,7 @@ uint32_t TypeManager::FindPointerToType(uint32_t type_id,
                                         spv::StorageClass storage_class) {
   Type* pointeeTy = GetType(type_id);
   Pointer pointerTy(pointeeTy, storage_class);
-  if (pointeeTy->IsUniqueType(true)) {
+  if (pointeeTy->IsUniqueType()) {
     // Non-ambiguous type. Get the pointer type through the type manager.
     return GetTypeInstruction(&pointerTy);
   }

--- a/source/opt/types.cpp
+++ b/source/opt/types.cpp
@@ -84,10 +84,9 @@ bool Type::HasSameDecorations(const Type* that) const {
   return CompareTwoVectors(decorations_, that->decorations_);
 }
 
-bool Type::IsUniqueType(bool allowVariablePointers) const {
+bool Type::IsUniqueType() const {
   switch (kind_) {
     case kPointer:
-      return !allowVariablePointers;
     case kStruct:
     case kArray:
     case kRuntimeArray:

--- a/source/opt/types.h
+++ b/source/opt/types.h
@@ -148,12 +148,9 @@ class Type {
   // Returns a clone of |this| minus any decorations.
   std::unique_ptr<Type> RemoveDecorations() const;
 
-  // Returns true if this type must be unique.
-  //
-  // If variable pointers are allowed, then pointers are not required to be
-  // unique.
-  // TODO(alanbaker): Update this if variable pointers become a core feature.
-  bool IsUniqueType(bool allowVariablePointers = false) const;
+  // Returns true if this cannot hash to the same value as another type in the
+  // module.
+  bool IsUniqueType() const;
 
   bool operator==(const Type& other) const;
 

--- a/source/opt/types.h
+++ b/source/opt/types.h
@@ -149,7 +149,14 @@ class Type {
   std::unique_ptr<Type> RemoveDecorations() const;
 
   // Returns true if this cannot hash to the same value as another type in the
-  // module.
+  // module. For example, structs are not unique types because the module could
+  // have two types
+  //
+  //  %1 = OpTypeStruct %int
+  //  %2 = OpTypeStruct %int
+  //
+  // The only way to distinguish these types is the result id. The type manager
+  // will hash them to the same value.
   bool IsUniqueType() const;
 
   bool operator==(const Type& other) const;

--- a/test/opt/scalar_replacement_test.cpp
+++ b/test/opt/scalar_replacement_test.cpp
@@ -2308,6 +2308,54 @@ TEST_F(ScalarReplacementTest, UndefImageMember) {
   SinglePassRunAndMatch<ScalarReplacementPass>(text, true);
 }
 
+TEST_F(ScalarReplacementTest, RestrictPointer) {
+  // This test makes sure that a variable with the restrict pointer decoration
+  // is replaced, and that the pointer is applied to the new variable.
+  const std::string text = R"(
+; CHECK: OpDecorate [[new_var:%\w+]] RestrictPointer
+; CHECK: [[struct_type:%\w+]] = OpTypeStruct %int
+; CHECK: [[ptr_type:%\w+]] = OpTypePointer PhysicalStorageBuffer [[struct_type]]
+; CHECK: [[dup_struct_type:%\w+]] = OpTypeStruct %int
+; CHECK: {{%\w+}} = OpTypePointer PhysicalStorageBuffer [[dup_struct_type]]
+; CHECK: [[var_type:%\w+]] = OpTypePointer Function [[ptr_type]]
+; CHECK: [[new_var]] = OpVariable [[var_type]] Function
+               OpCapability Shader
+               OpCapability PhysicalStorageBufferAddresses
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel PhysicalStorageBuffer64 GLSL450
+               OpEntryPoint Fragment %2 "main"
+               OpExecutionMode %2 OriginUpperLeft
+               OpMemberDecorate %3 0 Offset 0
+               OpDecorate %3 Block
+               OpMemberDecorate %4 0 Offset 0
+               OpDecorate %4 Block
+               OpDecorate %5 RestrictPointer
+          %6 = OpTypeVoid
+          %7 = OpTypeFunction %6
+          %8 = OpTypeInt 32 1
+          %9 = OpConstant %8 0
+          %3 = OpTypeStruct %8
+         %10 = OpTypePointer PhysicalStorageBuffer %3
+         %11 = OpTypeStruct %10
+          %4 = OpTypeStruct %8
+         %12 = OpTypePointer PhysicalStorageBuffer %4
+         %13 = OpTypePointer Function %11
+         %14 = OpTypePointer Function %10
+         %15 = OpTypePointer Function %12
+         %16 = OpUndef %11
+          %2 = OpFunction %6 None %7
+         %17 = OpLabel
+          %5 = OpVariable %13 Function
+               OpStore %5 %16
+         %18 = OpAccessChain %14 %5 %9
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  SetTargetEnv(SPV_ENV_UNIVERSAL_1_6);
+  SinglePassRunAndMatch<ScalarReplacementPass>(text, true);
+}
+
 }  // namespace
 }  // namespace opt
 }  // namespace spvtools

--- a/test/opt/types_test.cpp
+++ b/test/opt/types_test.cpp
@@ -391,18 +391,13 @@ TEST(Types, IsUniqueType) {
       case Type::kArray:
       case Type::kRuntimeArray:
       case Type::kStruct:
+      case Type::kPointer:
         expectation = false;
         break;
       default:
         break;
     }
-    EXPECT_EQ(t->IsUniqueType(false), expectation)
-        << "expected '" << t->str() << "' to be a "
-        << (expectation ? "" : "non-") << "unique type";
-
-    // Allowing variables pointers.
-    if (t->AsPointer()) expectation = false;
-    EXPECT_EQ(t->IsUniqueType(true), expectation)
+    EXPECT_EQ(t->IsUniqueType(), expectation)
         << "expected '" << t->str() << "' to be a "
         << (expectation ? "" : "non-") << "unique type";
   }


### PR DESCRIPTION
We want to be able to apply scalar replacement on variables that have
the AliasPointer and RestrictPointer decorations.

This exposed a bug that needs to be fixed as well.

Scalar replacement sometimes uses the type manager to get the type id for the
variables it is creating. The variable type is a pointer to a pointee
type. Currently, scalar replacement uses the type manager when only if
the pointee type has to be unique in the module. This is done to try to avoid the case where two type hash to the same
value in the type manager, and it returns the wrong one.

However, this check is not the correct check. Pointer types still have to be
unique in the spir-v module. However, two unique pointer types can hash
to the same value if their pointee types are isomorphic. For example,

```
%s1 = OpTypeStruct %int
%s2 = OpTypeStruct %int
; %p1 and %p2 will hash to the same value even though they are still
; considered "unique".
%p1 = OpTypePointer Function %s1
%p2 = OpTypePointer Function %s2
```

To fix this, we now use `FindPointerToType`, and we modified `TypeManager::IsUnique` to refer to the whether or not a type will hash to a unique value and say that pointers are not unique.

Fixes #5196
