### PR TITLE
val: allow DebugTypeComposite to forward reference

### DIFF
--- a/source/operand.cpp
+++ b/source/operand.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 
 #include "DebugInfo.h"
+#include "NonSemanticShaderDebugInfo100.h"
 #include "OpenCLDebugInfo100.h"
 #include "source/macro.h"
 #include "source/opcode.h"
@@ -583,8 +584,13 @@ std::function<bool(unsigned)> spvOperandCanBeForwardDeclaredFunction(
 std::function<bool(unsigned)> spvDbgInfoExtOperandCanBeForwardDeclaredFunction(
     spv_ext_inst_type_t ext_type, uint32_t key) {
   // The Vulkan debug info extended instruction set is non-semantic so allows no
-  // forward references ever
+  // forward references, except if it's a DebugTypeComposite's member.
   if (ext_type == SPV_EXT_INST_TYPE_NONSEMANTIC_SHADER_DEBUGINFO_100) {
+    // For DebugTypeComposite, members can be a forward reference.
+    if (NonSemanticShaderDebugInfo100Instructions(key) ==
+        NonSemanticShaderDebugInfo100DebugTypeComposite) {
+      return [](unsigned index) { return index >= 13; };
+    }
     return [](unsigned) { return false; };
   }
 


### PR DESCRIPTION
When an HLSL object has a member, the generated debug info cannot be generated without any cycle:
 - the composite has a method as a member.
 - the method has the previously declared composite as scope.

This is not an issue as the spec clearly mentions members could be a forward reference (which goes against the blanker no-forward references statement).

This commit fixes the blanket check by verifying we are not in this specific case.

Fixes #5229, Microsoft/DirectXShaderCompiler#5218