### PR TITLE
Disable RE2 autoroll

### DIFF
--- a/utils/roll_deps.sh
+++ b/utils/roll_deps.sh
@@ -29,10 +29,12 @@ function ExitIfIsInterestingError() {
 }
 
 
-# We are not rolling google test for now. The latest version requires C++14.
+# We are not rolling re2 for now. The latest version requires Abseil, and we
+# need time to determine the best way to do that. See 
+# https://github.com/KhronosGroup/SPIRV-Tools/issues/5233.
 dependencies=("external/effcee/"
               "external/googletest/"
-              "external/re2/"
+#              "external/re2/"
               "external/spirv-headers/")
 
 


### PR DESCRIPTION
RE2 now depends on Abseil. We need to figure out how to add that
dependency. Disable the autoroll for now.

https://github.com/KhronosGroup/SPIRV-Tools/issues/5233
