### PR TITLE
Add Abseil as a dep and update RE2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 compile_commands.json
 /build*/
 /buildtools/
+/external/abseil_cpp/
 /external/googletest
 /external/SPIRV-Headers
 /external/spirv-headers

--- a/DEPS
+++ b/DEPS
@@ -3,6 +3,8 @@ use_relative_paths = True
 vars = {
   'github': 'https://github.com',
 
+  'abseil_revision': '79ca5d7aad63973c83a4962a66ab07cd623131ea',
+
   'effcee_revision': '66edefd2bb641de8a2f46b476de21f227fc03a28',
 
   'googletest_revision': '45804691223635953f311cf31a10c632553bbfc3',
@@ -15,6 +17,9 @@ vars = {
 }
 
 deps = {
+  'external/abseil_cpp':
+      Var('github') + '/abseil/abseil-cpp.git@' + Var('abseil_revision'),
+
   'external/effcee':
       Var('github') + '/google/effcee.git@' + Var('effcee_revision'),
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -97,6 +97,21 @@ if (NOT ${SPIRV_SKIP_TESTS})
   # If already configured, then use that.  Otherwise, prefer to find it under 're2'
   # in this directory.
   if (NOT TARGET re2)
+
+    if(NOT TARGET absl::base)
+      set(ABSL_INTERNAL_AT_LEAST_CXX17 ON)
+      set(ABSL_PROPAGATE_CXX_STD ON)
+      set(ABSL_ENABLE_INSTALL ON)
+      add_subdirectory(abseil_cpp EXCLUDE_FROM_ALL)
+    endif()
+
+    if(NOT TARGET absl_base)
+      message(STATUS "STEVEN: abseil is not a valid target")
+    else()
+      message(STATUS "STEVEN: abseil is a valid target")
+    endif()
+
+
     # If we are configuring RE2, then turn off its testing.  It takes a long time and
     # does not add much value for us.  If an enclosing project configured RE2, then it
     # has already chosen whether to enable RE2 testing.

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -98,19 +98,13 @@ if (NOT ${SPIRV_SKIP_TESTS})
   # in this directory.
   if (NOT TARGET re2)
 
+    # RE2 depends on Abseil, so we need to add it.
     if(NOT TARGET absl::base)
       set(ABSL_INTERNAL_AT_LEAST_CXX17 ON)
       set(ABSL_PROPAGATE_CXX_STD ON)
       set(ABSL_ENABLE_INSTALL ON)
       add_subdirectory(abseil_cpp EXCLUDE_FROM_ALL)
     endif()
-
-    if(NOT TARGET absl_base)
-      message(STATUS "STEVEN: abseil is not a valid target")
-    else()
-      message(STATUS "STEVEN: abseil is a valid target")
-    endif()
-
 
     # If we are configuring RE2, then turn off its testing.  It takes a long time and
     # does not add much value for us.  If an enclosing project configured RE2, then it


### PR DESCRIPTION
The latest version of RE2 requires Abseil. This PR adds Abseil as an
external dependence, and update RE2 to use it.
