### PR TITLE
spirv-val: Remove VUID from 1.3.251 spec

### DIFF
--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -297,7 +297,6 @@ spv_result_t ValidateImageOperands(ValidationState_t& _,
                           spv::ImageOperandsMask::ConstOffsets |
                           spv::ImageOperandsMask::Offsets)) > 1) {
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
-           << _.VkErrorID(4662)
            << "Image Operands Offset, ConstOffset, ConstOffsets, Offsets "
               "cannot be used together";
   }

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2048,8 +2048,6 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-OpImageTexelPointer-04658);
     case 4659:
       return VUID_WRAP(VUID-StandaloneSpirv-OpImageQuerySizeLod-04659);
-    case 4662:
-      return VUID_WRAP(VUID-StandaloneSpirv-Offset-04662);
     case 4663:
       return VUID_WRAP(VUID-StandaloneSpirv-Offset-04663);
     case 4664:

--- a/test/val/val_image_test.cpp
+++ b/test/val/val_image_test.cpp
@@ -2177,8 +2177,6 @@ TEST_F(ValidateImage, SampleImplicitLodVulkanMoreThanOneOffset) {
   CompileSuccessfully(
       GenerateShaderCode(body, "", "Fragment", "", SPV_ENV_VULKAN_1_0).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
-  EXPECT_THAT(getDiagnosticString(),
-              AnyVUID("VUID-StandaloneSpirv-Offset-04662"));
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("Image Operands Offset, ConstOffset, ConstOffsets, Offsets "


### PR DESCRIPTION
As noted in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/5898 this check is already in the SPIR-V Core spec and was removed from the Vulkan Spec so the VUID doesn't exists anymore