### PR TITLE
Allow physical storage buffer pointer in IO

### DIFF
--- a/source/val/validate_interfaces.cpp
+++ b/source/val/validate_interfaces.cpp
@@ -181,7 +181,7 @@ spv_result_t NumConsumedLocations(ValidationState_t& _, const Instruction* type,
         *num_locations = 1;
         break;
       }
-      // Fallthrough...
+      [[fallthrough]];
     }
     default:
       return _.diag(SPV_ERROR_INVALID_DATA, type)

--- a/source/val/validate_interfaces.cpp
+++ b/source/val/validate_interfaces.cpp
@@ -14,7 +14,6 @@
 
 #include <algorithm>
 #include <vector>
-#include <iostream>
 
 #include "source/spirv_constant.h"
 #include "source/spirv_target_env.h"

--- a/source/val/validate_interfaces.cpp
+++ b/source/val/validate_interfaces.cpp
@@ -218,7 +218,6 @@ uint32_t NumConsumedComponents(ValidationState_t& _, const Instruction* type) {
       return NumConsumedComponents(_,
                                    _.FindDef(type->GetOperandAs<uint32_t>(1)));
     case spv::Op::OpTypePointer:
-      std::cout << "Pointer: " << _.Disassemble(*type) << "\n";
       if (_.addressing_model() ==
               spv::AddressingModel::PhysicalStorageBuffer64 &&
           type->GetOperandAs<spv::StorageClass>(1) ==

--- a/test/val/val_interfaces_test.cpp
+++ b/test/val/val_interfaces_test.cpp
@@ -1599,6 +1599,29 @@ TEST_F(ValidateInterfacesTest, InvalidLocationTypePointer) {
               HasSubstr("Invalid type to assign a location"));
 }
 
+TEST_F(ValidateInterfacesTest, ValidLocationTypePhysicalStorageBufferPointer) {
+  const std::string text = R"(
+OpCapability Shader
+OpCapability PhysicalStorageBufferAddresses
+OpMemoryModel PhysicalStorageBuffer64 GLSL450
+OpEntryPoint Vertex %main "main" %var
+OpDecorate %var Location 0
+OpDecorate %var RestrictPointer
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%ptr = OpTypePointer PhysicalStorageBuffer %int
+%ptr2 = OpTypePointer Input %ptr
+%var = OpVariable %ptr2 Input
+%void_fn = OpTypeFunction %void
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_3);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
Follow up to https://github.com/KhronosGroup/SPIRV-Tools/pull/5249

* glslang tests that physical storage buffer pointers can be used as
  varyings in shaders
  * Allow physical storage buffer pointers in IO interfaces as a 64-bit
    type