### PR TITLE
Increase tested Android API level

### DIFF
--- a/android_test/jni/Application.mk
+++ b/android_test/jni/Application.mk
@@ -1,5 +1,5 @@
 APP_ABI := all
 APP_BUILD_SCRIPT := Android.mk
 APP_STL := c++_static
-APP_PLATFORM := android-9
+APP_PLATFORM := android-24
 NDK_TOOLCHAIN_VERSION := 4.9

--- a/kokoro/scripts/linux/build-docker.sh
+++ b/kokoro/scripts/linux/build-docker.sh
@@ -164,7 +164,7 @@ elif [ $TOOL = "cmake-android-ndk" ]; then
 
   echo $(date): Starting build...
   cmake -DCMAKE_BUILD_TYPE=Release \
-        -DANDROID_NATIVE_API_LEVEL=android-16 \
+        -DANDROID_NATIVE_API_LEVEL=android-24 \
         -DANDROID_ABI="armeabi-v7a with NEON" \
         -DSPIRV_SKIP_TESTS=ON \
         -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake" \


### PR DESCRIPTION
Vulkan was introduced in Android API 24.
Test that.

The Android NDK drops support for very old APIs.