### PR TITLE
Use windows 2019 to workaround bazel issue

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 120
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2019]
 
     runs-on: ${{matrix.os}}
 
@@ -28,15 +28,7 @@ jobs:
         with:
           path: ~/.bazel/cache
           key: bazel-cache-${{ runner.os }}
-      - name: Build All (Windows)
-        if: ${{matrix.os == 'windows-latest' }}
+      - name: Build All
         run: bazel --output_user_root=~/.bazel/cache build //...
-      - name: Test All (Windows)
-        if: ${{matrix.os == 'windows-latest' }}
-        run: bazel --output_user_root=~/.bazel/cache test //...
-      - name: Build All (Linux, MacOS)
-        if: ${{ matrix.os != 'windows-latest' }}
-        run: bazel --output_user_root=~/.bazel/cache build //...
-      - name: Test All (Linux, MacOS)
-        if: ${{ matrix.os != 'windows-latest' }}
+      - name: Test All
         run: bazel --output_user_root=~/.bazel/cache test //...


### PR DESCRIPTION
In the latest windows images, MSVC is not installed in the default
directory, and bazel is not able to find it.  See
https://github.com/actions/runner-images/issues/7675. Because of that, I
will change the github action so that is uses windows-2019 instead of
latest.

At the same time, I merged the build and test commands for the different
platforms because they are now the same.
