### PR TITLE
Enable vector constant folding

### DIFF
--- a/source/opt/constants.cpp
+++ b/source/opt/constants.cpp
@@ -435,6 +435,8 @@ const Constant* ConstantManager::GetNumericVectorConstantWithWords(
     words_per_element = float_type->width() / 32;
   else if (const auto* int_type = element_type->AsInteger())
     words_per_element = int_type->width() / 32;
+  else if (element_type->AsBool() != nullptr)
+    words_per_element = 1;
 
   if (words_per_element != 1 && words_per_element != 2) return nullptr;
 

--- a/source/opt/fold.h
+++ b/source/opt/fold.h
@@ -86,6 +86,14 @@ class InstructionFolder {
   // result type is |type_inst|.
   bool IsFoldableType(Instruction* type_inst) const;
 
+  // Returns true if |FoldInstructionToConstant| could fold an instruction whose
+  // result type is |type_inst|.
+  bool IsFoldableScalarType(Instruction* type_inst) const;
+
+  // Returns true if |FoldInstructionToConstant| could fold an instruction whose
+  // result type is |type_inst|.
+  bool IsFoldableVectorType(Instruction* type_inst) const;
+
   // Tries to fold |inst| to a single constant, when the input ids to |inst|
   // have been substituted using |id_map|.  Returns a pointer to the OpConstant*
   // instruction if successful.  If necessary, a new constant instruction is

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -294,6 +294,8 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   // It is the responsibility of the caller to make sure
   // that the instruction remains valid.
   inline void AddOperand(Operand&& operand);
+  // Adds a copy of |operand| to the list of operands of this instruction.
+  inline void AddOperand(const Operand& operand);
   // Gets the |index|-th logical operand as a single SPIR-V word. This method is
   // not expected to be used with logical operands consisting of multiple SPIR-V
   // words.
@@ -522,6 +524,10 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   // constant value by |FoldScalar|.
   bool IsFoldableByFoldScalar() const;
 
+  // Returns true if |this| is an instruction which could be folded into a
+  // constant value by |FoldVector|.
+  bool IsFoldableByFoldVector() const;
+
   // Returns true if we are allowed to fold or otherwise manipulate the
   // instruction that defines |id| in the given context. This includes not
   // handling NaN values.
@@ -674,6 +680,10 @@ inline const Operand& Instruction::GetOperand(uint32_t index) const {
 
 inline void Instruction::AddOperand(Operand&& operand) {
   operands_.push_back(std::move(operand));
+}
+
+inline void Instruction::AddOperand(const Operand& operand) {
+  operands_.push_back(operand);
 }
 
 inline void Instruction::SetInOperand(uint32_t index,

--- a/test/opt/fold_test.cpp
+++ b/test/opt/fold_test.cpp
@@ -1026,7 +1026,15 @@ INSTANTIATE_TEST_SUITE_P(TestCase, UIntVectorInstructionFoldingTest,
           "%2 = OpSNegate %v2uint %v2uint_0x3f800000_0xbf800000\n" +
           "OpReturn\n" +
           "OpFunctionEnd",
-      2, {static_cast<uint32_t>(-0x3f800000), static_cast<uint32_t>(-0xbf800000)})
+      2, {static_cast<uint32_t>(-0x3f800000), static_cast<uint32_t>(-0xbf800000)}),
+    // Test case 6: fold vector components of uint (incuding integer overflow)
+    InstructionFoldingCase<std::vector<uint32_t>>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpIAdd %v2uint %v2uint_0x3f800000_0xbf800000 %v2uint_0x3f800000_0xbf800000\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, {0x7f000000u, 0x7f000000u})
 ));
 // clang-format on
 
@@ -1094,7 +1102,15 @@ INSTANTIATE_TEST_SUITE_P(TestCase, IntVectorInstructionFoldingTest,
           "%2 = OpSNegate %v2int %v2int_min_max\n" +
           "OpReturn\n" +
           "OpFunctionEnd",
-      2, {INT_MIN, -INT_MAX})
+      2, {INT_MIN, -INT_MAX}),
+    // Test case 3: fold vector components of int
+    InstructionFoldingCase<std::vector<int32_t>>(
+      Header() + "%main = OpFunction %void None %void_func\n" +
+          "%main_lab = OpLabel\n" +
+          "%2 = OpIMul %v2int %v2int_2_3 %v2int_2_3\n" +
+          "OpReturn\n" +
+          "OpFunctionEnd",
+      2, {4,9})
 ));
 // clang-format on
 


### PR DESCRIPTION
This PR enables constant folding for vector types (Mentioned in https://github.com/KhronosGroup/SPIRV-Tools/issues/4913).

I ran the test suit and all test succeeded, but I could use some help to write up a new test case. I have this example HLSL code which can be massively reduced with SPIRV-Tools once this constant folding is enabled:
```hlsl
float4 PSMain() : SV_Target {
  int4 A = int4(1, 2, 3, 4);
  int4 B = int4(5, 6, 7, 8);	
  int4 C = A + B;	
  if (C.x == 6) { // This condition can be constant folded to true
    return 1.0;
  } else {
    return 0.0;
  }
}
```
DXC generates the following SPIR-V with `dxc -E PSMain -T ps_6_6 -spirv -O0 -Fo out.spv in.hlsl` (optimizations disabled):
```
               OpCapability Shader
          %1 = OpExtInstImport "GLSL.std.450"
               OpMemoryModel Logical GLSL450
               OpEntryPoint Fragment %PSMain "PSMain" %out_var_SV_Target
               OpExecutionMode %PSMain OriginUpperLeft
               OpSource HLSL 660
               OpName %out_var_SV_Target "out.var.SV_Target"
               OpName %PSMain "PSMain"
               OpName %src_PSMain "src.PSMain"
               OpName %bb_entry "bb.entry"
               OpName %A "A"
               OpName %B "B"
               OpName %C "C"
               OpName %if_true "if.true"
               OpName %if_false "if.false"
               OpName %if_merge "if.merge"
               OpDecorate %out_var_SV_Target Location 0
        %int = OpTypeInt 32 1
      %int_1 = OpConstant %int 1
      %int_2 = OpConstant %int 2
      %int_3 = OpConstant %int 3
      %int_4 = OpConstant %int 4
      %v4int = OpTypeVector %int 4
         %10 = OpConstantComposite %v4int %int_1 %int_2 %int_3 %int_4
      %int_5 = OpConstant %int 5
      %int_6 = OpConstant %int 6
      %int_7 = OpConstant %int 7
      %int_8 = OpConstant %int 8
         %15 = OpConstantComposite %v4int %int_5 %int_6 %int_7 %int_8
      %int_0 = OpConstant %int 0
      %float = OpTypeFloat 32
    %float_1 = OpConstant %float 1
    %v4float = OpTypeVector %float 4
         %20 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1
    %float_0 = OpConstant %float 0
         %22 = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
         %23 = OpConstantNull %v4float
%_ptr_Output_v4float = OpTypePointer Output %v4float
       %void = OpTypeVoid
         %26 = OpTypeFunction %void
         %30 = OpTypeFunction %v4float
%_ptr_Function_v4int = OpTypePointer Function %v4int
%_ptr_Function_int = OpTypePointer Function %int
       %bool = OpTypeBool
%out_var_SV_Target = OpVariable %_ptr_Output_v4float Output
     %PSMain = OpFunction %void None %26
         %27 = OpLabel
         %28 = OpFunctionCall %v4float %src_PSMain
               OpStore %out_var_SV_Target %28
               OpReturn
               OpFunctionEnd
 %src_PSMain = OpFunction %v4float None %30
   %bb_entry = OpLabel
          %A = OpVariable %_ptr_Function_v4int Function
          %B = OpVariable %_ptr_Function_v4int Function
          %C = OpVariable %_ptr_Function_v4int Function
               OpStore %A %10
               OpStore %B %15
         %36 = OpLoad %v4int %A
         %37 = OpLoad %v4int %B
         %38 = OpIAdd %v4int %36 %37
               OpStore %C %38
         %40 = OpAccessChain %_ptr_Function_int %C %int_0
         %41 = OpLoad %int %40
         %43 = OpIEqual %bool %41 %int_6
               OpSelectionMerge %if_merge None
               OpBranchConditional %43 %if_true %if_false
    %if_true = OpLabel
               OpReturnValue %20
   %if_false = OpLabel
               OpReturnValue %22
   %if_merge = OpLabel
               OpReturnValue %23
               OpFunctionEnd
```
With this PR, SPIRV-Tools via `spirv-opt -O -o opt.spv out.spv` can optimize the shader to this:
```
               OpCapability Shader
          %1 = OpExtInstImport "GLSL.std.450"
               OpMemoryModel Logical GLSL450
               OpEntryPoint Fragment %PSMain "PSMain" %out_var_SV_Target
               OpExecutionMode %PSMain OriginUpperLeft
               OpSource HLSL 660
               OpName %out_var_SV_Target "out.var.SV_Target"
               OpName %PSMain "PSMain"
               OpDecorate %out_var_SV_Target Location 0
      %float = OpTypeFloat 32
    %float_1 = OpConstant %float 1
    %v4float = OpTypeVector %float 4
         %20 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1
%_ptr_Output_v4float = OpTypePointer Output %v4float
       %void = OpTypeVoid
         %26 = OpTypeFunction %void
%out_var_SV_Target = OpVariable %_ptr_Output_v4float Output
     %PSMain = OpFunction %void None %26
         %27 = OpLabel
               OpStore %out_var_SV_Target %20
               OpReturn
               OpFunctionEnd
```