### PR TITLE
Migrate `exec_tools` back to `tools`.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -94,7 +94,7 @@ genrule(
     outs = ["generators.inc"],
     cmd = "$(location :generate_registry_tables) --xml=$(location @spirv_headers//:spirv_xml_registry) --generator-output=$(location generators.inc)",
     cmd_bat = "$(location :generate_registry_tables) --xml=$(location @spirv_headers//:spirv_xml_registry) --generator-output=$(location generators.inc)",
-    exec_tools = [":generate_registry_tables"],
+    tools = [":generate_registry_tables"],
 )
 
 py_binary(
@@ -108,10 +108,8 @@ genrule(
     outs = ["build-version.inc"],
     cmd = "SOURCE_DATE_EPOCH=0 $(location :update_build_version) $(location CHANGES) $(location build-version.inc)",
     cmd_bat = "set SOURCE_DATE_EPOCH=0  && $(location :update_build_version) $(location CHANGES) $(location build-version.inc)",
-    # This is explicitly tools and not exec_tools because we run it locally (on the host platform) instead of
-    # (potentially remotely) on the execution platform.
-    tools = [":update_build_version"],
     local = True,
+    tools = [":update_build_version"],
 )
 
 # Libraries
@@ -146,7 +144,6 @@ cc_library(
         ":gen_extinst_lang_headers_OpenCLDebugInfo100",
         ":gen_glsl_tables_unified1",
         ":gen_opencl_tables_unified1",
-        ":generators_inc",
         ":gen_vendor_tables_debuginfo",
         ":gen_vendor_tables_nonsemantic_clspvreflection",
         ":gen_vendor_tables_nonsemantic_shader_debuginfo_100",
@@ -155,6 +152,7 @@ cc_library(
         ":gen_vendor_tables_spv_amd_shader_ballot",
         ":gen_vendor_tables_spv_amd_shader_explicit_vertex_parameter",
         ":gen_vendor_tables_spv_amd_shader_trinary_minmax",
+        ":generators_inc",
     ],
     hdrs = [
         "include/spirv-tools/libspirv.h",
@@ -307,17 +305,17 @@ cc_binary(
 cc_binary(
     name = "spirv-objdump",
     srcs = [
-        "tools/objdump/objdump.cpp",
         "tools/objdump/extract_source.cpp",
         "tools/objdump/extract_source.h",
+        "tools/objdump/objdump.cpp",
     ],
     copts = COMMON_COPTS,
     visibility = ["//visibility:public"],
     deps = [
-        ":tools_io",
-        ":tools_util",
         ":spirv_tools_internal",
         ":spirv_tools_opt_internal",
+        ":tools_io",
+        ":tools_util",
         "@spirv_headers//:spirv_cpp_headers",
     ],
 )
@@ -439,20 +437,23 @@ cc_library(
     name = "base_{testcase}_test".format(testcase = f[len("test/"):-len("_test.cpp")]),
     size = "small",
     srcs = [f],
-    copts = TEST_COPTS + ['-DTESTING'],
+    copts = TEST_COPTS + ["-DTESTING"],
     linkstatic = 1,
     target_compatible_with = {
         "test/timer_test.cpp": incompatible_with(["@bazel_tools//src/conditions:windows"]),
     }.get(f, []),
     deps = [
+        "tools_util",
         ":spirv_tools_internal",
         ":test_lib",
-        "tools_util",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 ) for f in glob(
-    ["test/*_test.cpp", "test/tools/*_test.cpp"],
+    [
+        "test/*_test.cpp",
+        "test/tools/*_test.cpp",
+    ],
     exclude = [
         "test/cpp_interface_test.cpp",
         "test/log_test.cpp",

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -88,7 +88,7 @@ def generate_core_tables(version):
         outs = outs.values(),
         cmd = cmd,
         cmd_bat = cmd,
-        exec_tools = [":generate_grammar_tables"],
+        tools = [":generate_grammar_tables"],
         visibility = ["//visibility:private"],
     )
 
@@ -123,7 +123,7 @@ def generate_enum_string_mapping(version):
         outs = outs.values(),
         cmd = cmd,
         cmd_bat = cmd,
-        exec_tools = [":generate_grammar_tables"],
+        tools = [":generate_grammar_tables"],
         visibility = ["//visibility:private"],
     )
 
@@ -151,7 +151,7 @@ def generate_opencl_tables(version):
         outs = outs.values(),
         cmd = cmd,
         cmd_bat = cmd,
-        exec_tools = [":generate_grammar_tables"],
+        tools = [":generate_grammar_tables"],
         visibility = ["//visibility:private"],
     )
 
@@ -179,7 +179,7 @@ def generate_glsl_tables(version):
         outs = outs.values(),
         cmd = cmd,
         cmd_bat = cmd,
-        exec_tools = [":generate_grammar_tables"],
+        tools = [":generate_grammar_tables"],
         visibility = ["//visibility:private"],
     )
 
@@ -207,7 +207,7 @@ def generate_vendor_tables(extension, operand_kind_prefix = ""):
         outs = outs.values(),
         cmd = cmd,
         cmd_bat = cmd,
-        exec_tools = [":generate_grammar_tables"],
+        tools = [":generate_grammar_tables"],
         visibility = ["//visibility:private"],
     )
 
@@ -229,6 +229,6 @@ def generate_extinst_lang_headers(name, grammar = None):
         outs = outs.values(),
         cmd = cmd,
         cmd_bat = cmd,
-        exec_tools = [":generate_language_headers"],
+        tools = [":generate_language_headers"],
         visibility = ["//visibility:private"],
     )


### PR DESCRIPTION
The host transition migration is done so these can now be moved back and `exec_tools` can be removed.