### PR TITLE
Have effcee add abseil subdirectory

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -93,18 +93,21 @@ if (NOT ${SPIRV_SKIP_TESTS})
 
   # Find Effcee and RE2, for testing.
 
+  # RE2 depends on Abseil. We set absl_SOURCE_DIR if it is not already set, so
+  # that effcee can find abseil.
+  if(NOT TARGET absl::base)
+    if (NOT absl_SOURCE_DIR)
+      if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/abseil_cpp)
+        set(absl_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/abseil_cpp" CACHE STRING "Abseil source dir" )
+      endif()
+    endif()
+  endif()
+
   # First find RE2, since Effcee depends on it.
   # If already configured, then use that.  Otherwise, prefer to find it under 're2'
   # in this directory.
   if (NOT TARGET re2)
 
-    # RE2 depends on Abseil, so we need to add it.
-    if(NOT TARGET absl::base)
-      set(ABSL_INTERNAL_AT_LEAST_CXX17 ON)
-      set(ABSL_PROPAGATE_CXX_STD ON)
-      set(ABSL_ENABLE_INSTALL ON)
-      add_subdirectory(abseil_cpp EXCLUDE_FROM_ALL)
-    endif()
 
     # If we are configuring RE2, then turn off its testing.  It takes a long time and
     # does not add much value for us.  If an enclosing project configured RE2, then it


### PR DESCRIPTION
We currently add the abseil in the external/CMakeLists.txt. However, it
is not needed by spirv-tools directly. Instead we set effcee's variable
with the abseil source directory, and let effcee add it.

This will mean that abseil will be checked out only if effcee is
used. We currently get a few reports from people that use to only checkout
spirv-headers, and now get errors because abseil is missing.
