### PR TITLE
cmake: Remove unused SPIRV-Headers variables

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -41,8 +41,6 @@ if (IS_DIRECTORY ${SPIRV_HEADER_DIR})
   # Do this so enclosing projects can use SPIRV-Headers_SOURCE_DIR to find
   # headers to include.
   if (NOT DEFINED SPIRV-Headers_SOURCE_DIR)
-    set(SPIRV_HEADERS_SKIP_INSTALL ON)
-    set(SPIRV_HEADERS_SKIP_EXAMPLES ON)
     add_subdirectory(${SPIRV_HEADER_DIR})
   endif()
 else()


### PR DESCRIPTION
These were removed from SPIRV-Headers a while ago.