### PR TITLE
fix ndk build standard to c++17

### DIFF
--- a/android_test/Android.mk
+++ b/android_test/Android.mk
@@ -5,7 +5,7 @@ LOCAL_CPP_EXTENSION := .cc .cpp .cxx
 LOCAL_SRC_FILES:=test.cpp
 LOCAL_MODULE:=spirvtools_test
 LOCAL_LDLIBS:=-landroid
-LOCAL_CXXFLAGS:=-std=c++11 -fno-exceptions -fno-rtti -Werror
+LOCAL_CXXFLAGS:=-std=c++17 -fno-exceptions -fno-rtti -Werror
 LOCAL_STATIC_LIBRARIES=SPIRV-Tools SPIRV-Tools-opt
 include $(BUILD_SHARED_LIBRARY)
 


### PR DESCRIPTION
SPIRV-Tools should build in c++17, but this file was forgotten.
Fixing the standard version.