### PR TITLE
Fixes for various endianness issues

### DIFF
--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -173,7 +173,7 @@ class Parser {
   // Returns the endian-corrected word at the given position.
   uint32_t peekAt(size_t index) const {
     assert(index < _.num_words);
-    return spvFixWord(_.words[index], _.endian);
+    return _.native_words[index];
   }
 
   // Data members

--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -591,7 +591,7 @@ spv_result_t Parser::parseOperand(size_t inst_offset,
     case SPV_OPERAND_TYPE_OPTIONAL_LITERAL_STRING: {
       const size_t max_words = _.num_words - _.word_index;
       std::string string =
-          spvtools::utils::MakeString(_.words + _.word_index, max_words, false);
+          spvtools::utils::MakeString(_.native_words.get() + _.word_index, max_words, false);
 
       if (string.length() == max_words * 4)
         return exhaustedInputDiagnostic(inst_offset, opcode, type);

--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -440,10 +440,6 @@ spv_result_t Parser::parseOperand(size_t inst_offset,
 
   const uint32_t word = peek();
 
-  // Do the words in this operand have to be converted to native endianness?
-  // True for all but literal strings.
-  bool convert_operand_endianness = true;
-
   switch (type) {
     case SPV_OPERAND_TYPE_TYPE_ID:
       if (!word)
@@ -752,17 +748,12 @@ spv_result_t Parser::parseOperand(size_t inst_offset,
 
   if (_.requires_endian_conversion) {
     // Copy instruction words.  Translate to native endianness as needed.
-    if (convert_operand_endianness) {
-      const spv_endianness_t endianness = _.endian;
-      std::transform(_.words + _.word_index, _.words + index_after_operand,
-                     std::back_inserter(*words),
-                     [endianness](const uint32_t raw_word) {
-                       return spvFixWord(raw_word, endianness);
-                     });
-    } else {
-      words->insert(words->end(), _.words + _.word_index,
-                    _.words + index_after_operand);
-    }
+    const spv_endianness_t endianness = _.endian;
+    std::transform(_.words + _.word_index, _.words + index_after_operand,
+                   std::back_inserter(*words),
+                   [endianness](const uint32_t raw_word) {
+                     return spvFixWord(raw_word, endianness);
+                   });
   }
 
   // Advance past the operand.

--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -207,10 +207,6 @@ class Parser {
       operands.reserve(25);
       endian_converted_words.reserve(25);
       expected_operands.reserve(25);
-
-      native_words = std::make_unique<uint32_t[]>(num_words);
-      for (size_t i = 0; i < num_words; i++)
-        native_words[i] = spvFixWord(words[i], endian);
     }
     State() : State(0, 0, nullptr) {}
     const uint32_t* words;       // Words in the binary SPIR-V module.
@@ -267,6 +263,9 @@ spv_result_t Parser::parseModule() {
                         << _.words[0] << "'.";
   }
   _.requires_endian_conversion = !spvIsHostEndian(_.endian);
+  _.native_words = std::make_unique<uint32_t[]>(_.num_words);
+  for (size_t i = 0; i < _.num_words; i++)
+    _.native_words[i] = _.requires_endian_conversion ? spvFixWord(_.words[i], _.endian) : _.words[i];
 
   // Process the header.
   spv_header_t header;


### PR DESCRIPTION
The SPIR-V specifications is agnostic on the issue of endianness (at least at the 32-bit word level), and tooling has some supporting code for it. It sadly appears to suffer from quite a bit of rot, this PR tackles the following:

* `spirv-dis` fails to disassemble a SPIR-V file in the non-native endianness
  * This is caused by trying to parse a string literal before the words are converted into native order, as assumed by `MakeString`
  * I changed it so that the whole file is byte-swapped when the parser is initialized, which opens the path for further simplifications
* source extraction code duplicates the logic added in https://github.com/mhillenbrand/SPIRV-Tools/commit/a95b262677b80d45278a593b1a5aa8faea85b8c2 and fails to account for mismatched endianness
* Some amount of dead code resulting from the prior commit

I ran and passed all tests on a real PowerPC G5, which is as fun a way to spend a day as any other. There's probably more I can do, but I'd like this to be reviewed before just so I know I'm on the right track.

Additionally, I'm not sure how relevant big-endian SPIR-V support really is considering the state of the tooling. Rather it would probably be beneficial to have big-endian architectures default to emitting little-endian files, as I doubt there are many, if any implementations that correctly implement endianness agnosticism. I think it needs to at least be an option!