### PR TITLE
enumset: STL-ize container

### DIFF
--- a/source/assembly_grammar.cpp
+++ b/source/assembly_grammar.cpp
@@ -184,7 +184,7 @@ CapabilitySet AssemblyGrammar::filterCapsAgainstTargetEnv(
       // spvOperandTableValueLookup() filters capabilities internally
       // according to the current target environment by itself. So we
       // should be safe to add this capability if the lookup succeeds.
-      cap_set.Add(cap_array[i]);
+      cap_set.insert(cap_array[i]);
     }
   }
   return cap_set;

--- a/source/enum_set.h
+++ b/source/enum_set.h
@@ -78,68 +78,198 @@ class EnumSet {
   static constexpr size_t kBucketSize = sizeof(BucketType) * 8ULL;
 
  public:
+  class Iterator {
+   public:
+    typedef Iterator self_type;
+    typedef T value_type;
+    typedef T& reference;
+    typedef T* pointer;
+    typedef std::forward_iterator_tag iterator_category;
+    typedef size_t difference_type;
+
+    Iterator(const EnumSet* set, size_t bucketIndex, ElementType bucketOffset)
+        : set_(set), bucketIndex_(bucketIndex), bucketOffset_(bucketOffset) {}
+
+    Iterator(const Iterator& other)
+        : set_(other.set_),
+          bucketIndex_(other.bucketIndex_),
+          bucketOffset_(other.bucketOffset_) {}
+
+    Iterator& operator++() {
+      do {
+        if (bucketIndex_ >= set_->buckets_.size()) {
+          bucketIndex_ = set_->buckets_.size();
+          bucketOffset_ = 0;
+          break;
+        }
+
+        if (bucketOffset_ + 1 == kBucketSize) {
+          bucketOffset_ = 0;
+          ++bucketIndex_;
+        } else {
+          ++bucketOffset_;
+        }
+
+      } while (bucketIndex_ < set_->buckets_.size() &&
+               !set_->HasEnumAt(bucketIndex_, bucketOffset_));
+      return *this;
+    }
+
+    Iterator operator++(int) {
+      Iterator old = *this;
+      operator++();
+      return old;
+    }
+
+    T operator*() const {
+      return GetValueFromBucket(set_->buckets_[bucketIndex_], bucketOffset_);
+    }
+
+    bool operator!=(const Iterator& other) const {
+      return set_ != other.set_ || bucketOffset_ != other.bucketOffset_ ||
+             bucketIndex_ != other.bucketIndex_;
+    }
+
+    bool operator==(const Iterator& other) const {
+      return !(operator!=(other));
+    }
+
+    Iterator& operator=(const Iterator& other) const {
+      set_ = other.set_;
+      bucketIndex_ = other.bucketIndex_;
+      bucketOffset_ = other.bucketOffset_;
+      return *this;
+    }
+
+   private:
+    const EnumSet* set_;
+    // Index of the bucket in the vector.
+    size_t bucketIndex_;
+    // Offset in bits in the current bucket.
+    ElementType bucketOffset_;
+  };
+
+  // Required to allow the use of std::inserter.
+  using value_type = T;
+  using const_iterator = Iterator;
+  using iterator = Iterator;
+
+ public:
+  iterator cbegin() const noexcept {
+    return iterator(this, /* bucketIndex= */ 0, /* bucketOffset= */ 0);
+  }
+
+  iterator begin() const noexcept { return cbegin(); }
+
+  iterator begin() noexcept {
+    return iterator(this, /* bucketIndex= */ 0, /* bucketOffset= */ 0);
+  }
+
+  iterator cend() const noexcept {
+    return iterator(this, buckets_.size(), /* bucketOffset= */ 0);
+  }
+
+  iterator end() const noexcept { return cend(); }
+
+  iterator end() noexcept {
+    return iterator(this, buckets_.size(), /* bucketOffset= */ 0);
+  }
+
   // Creates an empty set.
-  EnumSet() : buckets_(0) {}
+  EnumSet() : buckets_(0), size_(0) {}
 
   // Creates a set and store `value` in it.
-  EnumSet(T value) : EnumSet() { Add(value); }
+  EnumSet(T value) : EnumSet() { insert(value); }
 
   // Creates a set and stores each `values` in it.
   EnumSet(std::initializer_list<T> values) : EnumSet() {
     for (auto item : values) {
-      Add(item);
+      insert(item);
     }
   }
 
   // Creates a set, and insert `count` enum values pointed by `array` in it.
   EnumSet(ElementType count, const T* array) : EnumSet() {
     for (ElementType i = 0; i < count; i++) {
-      Add(array[i]);
+      insert(array[i]);
     }
   }
 
   // Copies the EnumSet `other` into a new EnumSet.
-  EnumSet(const EnumSet& other) : buckets_(other.buckets_) {}
+  EnumSet(const EnumSet& other)
+      : buckets_(other.buckets_), size_(other.size_) {}
 
   // Moves the EnumSet `other` into a new EnumSet.
-  EnumSet(EnumSet&& other) : buckets_(std::move(other.buckets_)) {}
+  EnumSet(EnumSet&& other)
+      : buckets_(std::move(other.buckets_)), size_(other.size_) {}
 
   // Deep-copies the EnumSet `other` into this EnumSet.
   EnumSet& operator=(const EnumSet& other) {
     buckets_ = other.buckets_;
+    size_ = other.size_;
     return *this;
   }
 
   // Add the enum value `value` into the set.
   // The set is unchanged if the value already exists.
-  void Add(T value) {
+  // Matches std::unordered_set::insert behavior.
+  std::pair<iterator, bool> insert(const T& value) {
     const size_t index = FindBucketForValue(value);
+    const ElementType offset = ComputeBucketOffset(value);
+
     if (index >= buckets_.size() ||
         buckets_[index].start != ComputeBucketStart(value)) {
+      size_ += 1;
       InsertBucketFor(index, value);
-      return;
+      return std::make_pair(Iterator(this, index, offset), true);
     }
+
     auto& bucket = buckets_[index];
+    const auto mask = ComputeMaskForValue(value);
+    if (bucket.data & mask) {
+      return std::make_pair(Iterator(this, index, offset), false);
+    }
+
+    size_ += 1;
     bucket.data |= ComputeMaskForValue(value);
+    return std::make_pair(Iterator(this, index, offset), true);
   }
+
+  // `insert` overload to allow STL compatibility.
+  // The hint is ignored.
+  iterator insert(const_iterator, const T& value) {
+    return insert(value).first;
+  }
+
+  // `insert` overload to allow STL compatibility.
+  // The hint is ignored.
+  iterator insert(const_iterator, T&& value) { return insert(value).first; }
 
   // Removes the value `value` into the set.
   // The set is unchanged if the value is not in the set.
-  void Remove(T value) {
+  size_t erase(const T& value) {
     const size_t index = FindBucketForValue(value);
     if (index >= buckets_.size() ||
         buckets_[index].start != ComputeBucketStart(value)) {
-      return;
+      return 0;
     }
+
     auto& bucket = buckets_[index];
-    bucket.data &= ~ComputeMaskForValue(value);
+    const auto mask = ComputeMaskForValue(value);
+    if (!(bucket.data & mask)) {
+      return 0;
+    }
+
+    size_ -= 1;
+    bucket.data &= ~mask;
     if (bucket.data == 0) {
       buckets_.erase(buckets_.cbegin() + index);
     }
+    return 1;
   }
 
   // Returns true if `value` is present in the set.
-  bool Contains(T value) const {
+  bool contains(T value) const {
     const size_t index = FindBucketForValue(value);
     if (index >= buckets_.size() ||
         buckets_[index].start != ComputeBucketStart(value)) {
@@ -149,12 +279,16 @@ class EnumSet {
     return bucket.data & ComputeMaskForValue(value);
   }
 
+  // Wrapper on `Contains` which matches the STL API for sets.
+  inline size_t count(T value) const { return contains(value) ? 1 : 0; }
+
   // Calls `unaryFunction` once for each value in the set.
   // Values are sorted in increasing order using their numerical values.
+  // FIXME(Keenuts): replace usages with either ranged-for or std::for_each.
   void ForEach(std::function<void(T)> unaryFunction) const {
     for (const auto& bucket : buckets_) {
-      for (uint8_t i = 0; i < kBucketSize; i++) {
-        if (bucket.data & (1ULL << i)) {
+      for (ElementType i = 0; i < kBucketSize; i++) {
+        if (bucket.data & (static_cast<BucketType>(1) << i)) {
           unaryFunction(GetValueFromBucket(bucket, i));
         }
       }
@@ -162,12 +296,14 @@ class EnumSet {
   }
 
   // Returns true if the set is holds no values.
-  bool IsEmpty() const { return buckets_.size() == 0; }
+  inline bool empty() const { return size_ == 0; }
+
+  size_t size() const { return size_; }
 
   // Returns true if this set contains at least one value contained in `in_set`.
   // Note: If `in_set` is empty, this function returns true.
   bool HasAnyOf(const EnumSet<T>& in_set) const {
-    if (in_set.IsEmpty()) {
+    if (in_set.empty()) {
       return true;
     }
 
@@ -213,7 +349,7 @@ class EnumSet {
   }
 
   //  Returns the index of the bit that corresponds to `value` in the bucket.
-  static constexpr inline size_t ComputeBucketOffset(T value) {
+  static constexpr inline ElementType ComputeBucketOffset(T value) {
     return static_cast<ElementType>(value) % kBucketSize;
   }
 
@@ -225,7 +361,7 @@ class EnumSet {
   // Returns the `enum` stored in `bucket` at `offset`.
   // `offset` is the bit-offset in the bucket storage.
   static constexpr inline T GetValueFromBucket(const Bucket& bucket,
-                                               ElementType offset) {
+                                               BucketType offset) {
     return static_cast<T>(static_cast<ElementType>(bucket.start) + offset);
   }
 
@@ -277,8 +413,18 @@ class EnumSet {
 #endif
   }
 
+  bool HasEnumAt(size_t bucketIndex, BucketType bucketOffset) const {
+    assert(bucketIndex < buckets_.size());
+    assert(bucketOffset < kBucketSize);
+    return buckets_[bucketIndex].data & (1ULL << bucketOffset);
+  }
+
   // Returns true if `lhs` and `rhs` hold the exact same values.
   friend bool operator==(const EnumSet& lhs, const EnumSet& rhs) {
+    if (lhs.size_ != rhs.size_) {
+      return false;
+    }
+
     if (lhs.buckets_.size() != rhs.buckets_.size()) {
       return false;
     }
@@ -292,6 +438,8 @@ class EnumSet {
 
   // Storage for the buckets.
   std::vector<Bucket> buckets_;
+  // How many enums is this set storing.
+  size_t size_;
 };
 
 // A set of spv::Capability.

--- a/source/enum_set.h
+++ b/source/enum_set.h
@@ -134,7 +134,7 @@ class EnumSet {
       return !(operator!=(other));
     }
 
-    Iterator& operator=(const Iterator& other) const {
+    Iterator& operator=(const Iterator& other) {
       set_ = other.set_;
       bucketIndex_ = other.bucketIndex_;
       bucketOffset_ = other.bucketOffset_;

--- a/source/enum_set.h
+++ b/source/enum_set.h
@@ -161,19 +161,11 @@ class EnumSet {
 
   iterator begin() const noexcept { return cbegin(); }
 
-  iterator begin() noexcept {
-    return iterator(this, /* bucketIndex= */ 0, /* bucketOffset= */ 0);
-  }
-
   iterator cend() const noexcept {
     return iterator(this, buckets_.size(), /* bucketOffset= */ 0);
   }
 
   iterator end() const noexcept { return cend(); }
-
-  iterator end() noexcept {
-    return iterator(this, buckets_.size(), /* bucketOffset= */ 0);
-  }
 
   // Creates an empty set.
   EnumSet() : buckets_(0), size_(0) {}

--- a/source/opt/feature_manager.cpp
+++ b/source/opt/feature_manager.cpp
@@ -40,19 +40,19 @@ void FeatureManager::AddExtension(Instruction* ext) {
   const std::string name = ext->GetInOperand(0u).AsString();
   Extension extension;
   if (GetExtensionFromString(name.c_str(), &extension)) {
-    extensions_.Add(extension);
+    extensions_.insert(extension);
   }
 }
 
 void FeatureManager::RemoveExtension(Extension ext) {
-  if (!extensions_.Contains(ext)) return;
-  extensions_.Remove(ext);
+  if (!extensions_.contains(ext)) return;
+  extensions_.erase(ext);
 }
 
 void FeatureManager::AddCapability(spv::Capability cap) {
-  if (capabilities_.Contains(cap)) return;
+  if (capabilities_.contains(cap)) return;
 
-  capabilities_.Add(cap);
+  capabilities_.insert(cap);
 
   spv_operand_desc desc = {};
   if (SPV_SUCCESS == grammar_.lookupOperand(SPV_OPERAND_TYPE_CAPABILITY,
@@ -63,8 +63,8 @@ void FeatureManager::AddCapability(spv::Capability cap) {
 }
 
 void FeatureManager::RemoveCapability(spv::Capability cap) {
-  if (!capabilities_.Contains(cap)) return;
-  capabilities_.Remove(cap);
+  if (!capabilities_.contains(cap)) return;
+  capabilities_.erase(cap);
 }
 
 void FeatureManager::AddCapabilities(Module* module) {

--- a/source/opt/feature_manager.h
+++ b/source/opt/feature_manager.h
@@ -28,14 +28,14 @@ class FeatureManager {
   explicit FeatureManager(const AssemblyGrammar& grammar) : grammar_(grammar) {}
 
   // Returns true if |ext| is an enabled extension in the module.
-  bool HasExtension(Extension ext) const { return extensions_.Contains(ext); }
+  bool HasExtension(Extension ext) const { return extensions_.contains(ext); }
 
   // Removes the given |extension| from the current FeatureManager.
   void RemoveExtension(Extension extension);
 
   // Returns true if |cap| is an enabled capability in the module.
   bool HasCapability(spv::Capability cap) const {
-    return capabilities_.Contains(cap);
+    return capabilities_.contains(cap);
   }
 
   // Removes the given |capability| from the current FeatureManager.

--- a/source/val/validate_capability.cpp
+++ b/source/val/validate_capability.cpp
@@ -240,7 +240,7 @@ bool IsEnabledByExtension(ValidationState_t& _, uint32_t capability) {
 
   ExtensionSet operand_exts(operand_desc->numExtensions,
                             operand_desc->extensions);
-  if (operand_exts.IsEmpty()) return false;
+  if (operand_exts.empty()) return false;
 
   return _.HasAnyOfExtensions(operand_exts);
 }

--- a/source/val/validate_instruction.cpp
+++ b/source/val/validate_instruction.cpp
@@ -178,10 +178,11 @@ spv_result_t CheckRequiredCapabilities(ValidationState_t& state,
 
       // Vulkan API requires more capabilities on rounding mode.
       if (spvIsVulkanEnv(state.context()->target_env)) {
-        enabling_capabilities.Add(spv::Capability::StorageUniformBufferBlock16);
-        enabling_capabilities.Add(spv::Capability::StorageUniform16);
-        enabling_capabilities.Add(spv::Capability::StoragePushConstant16);
-        enabling_capabilities.Add(spv::Capability::StorageInputOutput16);
+        enabling_capabilities.insert(
+            spv::Capability::StorageUniformBufferBlock16);
+        enabling_capabilities.insert(spv::Capability::StorageUniform16);
+        enabling_capabilities.insert(spv::Capability::StoragePushConstant16);
+        enabling_capabilities.insert(spv::Capability::StorageInputOutput16);
       }
     } else {
       enabling_capabilities = state.grammar().filterCapsAgainstTargetEnv(
@@ -195,7 +196,7 @@ spv_result_t CheckRequiredCapabilities(ValidationState_t& state,
     if (inst->opcode() != spv::Op::OpCapability) {
       const bool enabled_by_cap =
           state.HasAnyOfCapabilities(enabling_capabilities);
-      if (!enabling_capabilities.IsEmpty() && !enabled_by_cap) {
+      if (!enabling_capabilities.empty() && !enabled_by_cap) {
         return state.diag(SPV_ERROR_INVALID_CAPABILITY, inst)
                << "Operand " << which_operand << " of "
                << spvOpcodeString(inst->opcode())
@@ -303,7 +304,7 @@ spv_result_t VersionCheck(ValidationState_t& _, const Instruction* inst) {
   }
 
   ExtensionSet exts(inst_desc->numExtensions, inst_desc->extensions);
-  if (exts.IsEmpty()) {
+  if (exts.empty()) {
     // If no extensions can enable this instruction, then emit error
     // messages only concerning core SPIR-V versions if errors happen.
     if (min_version == ~0u) {

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -360,9 +360,9 @@ void ValidationState_t::RegisterCapability(spv::Capability cap) {
   // Avoid redundant work.  Otherwise the recursion could induce work
   // quadrdatic in the capability dependency depth. (Ok, not much, but
   // it's something.)
-  if (module_capabilities_.Contains(cap)) return;
+  if (module_capabilities_.contains(cap)) return;
 
-  module_capabilities_.Add(cap);
+  module_capabilities_.insert(cap);
   spv_operand_desc desc;
   if (SPV_SUCCESS == grammar_.lookupOperand(SPV_OPERAND_TYPE_CAPABILITY,
                                             uint32_t(cap), &desc)) {
@@ -419,9 +419,9 @@ void ValidationState_t::RegisterCapability(spv::Capability cap) {
 }
 
 void ValidationState_t::RegisterExtension(Extension ext) {
-  if (module_extensions_.Contains(ext)) return;
+  if (module_extensions_.contains(ext)) return;
 
-  module_extensions_.Add(ext);
+  module_extensions_.insert(ext);
 
   switch (ext) {
     case kSPV_AMD_gpu_shader_half_float:

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -317,7 +317,7 @@ class ValidationState_t {
 
   /// Returns true if the capability is enabled in the module.
   bool HasCapability(spv::Capability cap) const {
-    return module_capabilities_.Contains(cap);
+    return module_capabilities_.contains(cap);
   }
 
   /// Returns a reference to the set of capabilities in the module.
@@ -328,7 +328,7 @@ class ValidationState_t {
 
   /// Returns true if the extension is enabled in the module.
   bool HasExtension(Extension ext) const {
-    return module_extensions_.Contains(ext);
+    return module_extensions_.contains(ext);
   }
 
   /// Returns true if any of the capabilities is enabled, or if |capabilities|

--- a/test/enum_set_test.cpp
+++ b/test/enum_set_test.cpp
@@ -288,26 +288,26 @@ constexpr std::array kCapabilities{
 
 TEST(EnumSet, IsEmpty1) {
   EnumSet<TestEnum> set;
-  EXPECT_TRUE(set.IsEmpty());
-  set.Add(TestEnum::ZERO);
-  EXPECT_FALSE(set.IsEmpty());
+  EXPECT_TRUE(set.empty());
+  set.insert(TestEnum::ZERO);
+  EXPECT_FALSE(set.empty());
 }
 
 TEST(EnumSet, IsEmpty2) {
   EnumSet<TestEnum> set;
-  EXPECT_TRUE(set.IsEmpty());
-  set.Add(TestEnum::ONE_HUNDRED_FIFTY);
-  EXPECT_FALSE(set.IsEmpty());
+  EXPECT_TRUE(set.empty());
+  set.insert(TestEnum::ONE_HUNDRED_FIFTY);
+  EXPECT_FALSE(set.empty());
 }
 
 TEST(EnumSet, IsEmpty3) {
   EnumSet<TestEnum> set(TestEnum::FOUR);
-  EXPECT_FALSE(set.IsEmpty());
+  EXPECT_FALSE(set.empty());
 }
 
 TEST(EnumSet, IsEmpty4) {
   EnumSet<TestEnum> set(TestEnum::THREE_HUNDRED);
-  EXPECT_FALSE(set.IsEmpty());
+  EXPECT_FALSE(set.empty());
 }
 
 TEST(EnumSetHasAnyOf, EmptySetEmptyQuery) {
@@ -320,26 +320,26 @@ TEST(EnumSetHasAnyOf, EmptySetEmptyQuery) {
 TEST(EnumSetHasAnyOf, MaskSetEmptyQuery) {
   EnumSet<TestEnum> set;
   const EnumSet<TestEnum> empty;
-  set.Add(TestEnum::FIVE);
-  set.Add(TestEnum::EIGHT);
+  set.insert(TestEnum::FIVE);
+  set.insert(TestEnum::EIGHT);
   EXPECT_TRUE(set.HasAnyOf(empty));
 }
 
 TEST(EnumSetHasAnyOf, OverflowSetEmptyQuery) {
   EnumSet<TestEnum> set;
   const EnumSet<TestEnum> empty;
-  set.Add(TestEnum::TWO_HUNDRED);
-  set.Add(TestEnum::THREE_HUNDRED);
+  set.insert(TestEnum::TWO_HUNDRED);
+  set.insert(TestEnum::THREE_HUNDRED);
   EXPECT_TRUE(set.HasAnyOf(empty));
 }
 
 TEST(EnumSetHasAnyOf, EmptyQuery) {
   EnumSet<TestEnum> set;
   const EnumSet<TestEnum> empty;
-  set.Add(TestEnum::FIVE);
-  set.Add(TestEnum::EIGHT);
-  set.Add(TestEnum::TWO_HUNDRED);
-  set.Add(TestEnum::THREE_HUNDRED);
+  set.insert(TestEnum::FIVE);
+  set.insert(TestEnum::EIGHT);
+  set.insert(TestEnum::TWO_HUNDRED);
+  set.insert(TestEnum::THREE_HUNDRED);
   EXPECT_TRUE(set.HasAnyOf(empty));
 }
 
@@ -347,7 +347,7 @@ TEST(EnumSetHasAnyOf, EmptyQueryAlwaysTrue) {
   EnumSet<TestEnum> set;
   const EnumSet<TestEnum> empty;
   EXPECT_TRUE(set.HasAnyOf(empty));
-  set.Add(TestEnum::FIVE);
+  set.insert(TestEnum::FIVE);
   EXPECT_TRUE(set.HasAnyOf(empty));
 
   EXPECT_TRUE(
@@ -356,23 +356,23 @@ TEST(EnumSetHasAnyOf, EmptyQueryAlwaysTrue) {
 
 TEST(EnumSetHasAnyOf, ReflexiveMask) {
   EnumSet<TestEnum> set(TestEnum::THREE);
-  set.Add(TestEnum::TWENTY_FOUR);
-  set.Add(TestEnum::THIRTY);
+  set.insert(TestEnum::TWENTY_FOUR);
+  set.insert(TestEnum::THIRTY);
   EXPECT_TRUE(set.HasAnyOf(set));
 }
 
 TEST(EnumSetHasAnyOf, ReflexiveOverflow) {
   EnumSet<TestEnum> set(TestEnum::TWO_HUNDRED);
-  set.Add(TestEnum::TWO_HUNDRED);
-  set.Add(TestEnum::FOUR_HUNDRED);
+  set.insert(TestEnum::TWO_HUNDRED);
+  set.insert(TestEnum::FOUR_HUNDRED);
   EXPECT_TRUE(set.HasAnyOf(set));
 }
 
 TEST(EnumSetHasAnyOf, Reflexive) {
   EnumSet<TestEnum> set(TestEnum::THREE);
-  set.Add(TestEnum::TWENTY_FOUR);
-  set.Add(TestEnum::THREE_HUNDRED);
-  set.Add(TestEnum::FOUR_HUNDRED);
+  set.insert(TestEnum::TWENTY_FOUR);
+  set.insert(TestEnum::THREE_HUNDRED);
+  set.insert(TestEnum::FOUR_HUNDRED);
   EXPECT_TRUE(set.HasAnyOf(set));
 }
 
@@ -381,7 +381,7 @@ TEST(EnumSetHasAnyOf, EmptySetHasNone) {
   EnumSet<TestEnum> items;
   for (uint32_t i = 0; i < 200; ++i) {
     TestEnum enumValue = static_cast<TestEnum>(i);
-    items.Add(enumValue);
+    items.insert(enumValue);
     EXPECT_FALSE(set.HasAnyOf(items));
     EXPECT_FALSE(set.HasAnyOf(EnumSet<TestEnum>(enumValue)));
   }
@@ -391,12 +391,12 @@ TEST(EnumSetHasAnyOf, MaskSetMaskQuery) {
   EnumSet<TestEnum> set(TestEnum::ZERO);
   EnumSet<TestEnum> items(TestEnum::ONE);
   EXPECT_FALSE(set.HasAnyOf(items));
-  set.Add(TestEnum::TWO);
-  items.Add(TestEnum::THREE);
+  set.insert(TestEnum::TWO);
+  items.insert(TestEnum::THREE);
   EXPECT_FALSE(set.HasAnyOf(items));
-  set.Add(TestEnum::THREE);
+  set.insert(TestEnum::THREE);
   EXPECT_TRUE(set.HasAnyOf(items));
-  set.Add(TestEnum::FOUR);
+  set.insert(TestEnum::FOUR);
   EXPECT_TRUE(set.HasAnyOf(items));
 }
 
@@ -404,12 +404,12 @@ TEST(EnumSetHasAnyOf, OverflowSetOverflowQuery) {
   EnumSet<TestEnum> set(TestEnum::ONE_HUNDRED);
   EnumSet<TestEnum> items(TestEnum::TWO_HUNDRED);
   EXPECT_FALSE(set.HasAnyOf(items));
-  set.Add(TestEnum::THREE_HUNDRED);
-  items.Add(TestEnum::FOUR_HUNDRED);
+  set.insert(TestEnum::THREE_HUNDRED);
+  items.insert(TestEnum::FOUR_HUNDRED);
   EXPECT_FALSE(set.HasAnyOf(items));
-  set.Add(TestEnum::TWO_HUNDRED);
+  set.insert(TestEnum::TWO_HUNDRED);
   EXPECT_TRUE(set.HasAnyOf(items));
-  set.Add(TestEnum::FIVE_HUNDRED);
+  set.insert(TestEnum::FIVE_HUNDRED);
   EXPECT_TRUE(set.HasAnyOf(items));
 }
 
@@ -417,13 +417,13 @@ TEST(EnumSetHasAnyOf, GeneralCase) {
   EnumSet<TestEnum> set(TestEnum::ZERO);
   EnumSet<TestEnum> items(TestEnum::ONE_HUNDRED);
   EXPECT_FALSE(set.HasAnyOf(items));
-  set.Add(TestEnum::THREE_HUNDRED);
-  items.Add(TestEnum::FOUR);
+  set.insert(TestEnum::THREE_HUNDRED);
+  items.insert(TestEnum::FOUR);
   EXPECT_FALSE(set.HasAnyOf(items));
-  set.Add(TestEnum::FIVE);
-  items.Add(TestEnum::FIVE_HUNDRED);
+  set.insert(TestEnum::FIVE);
+  items.insert(TestEnum::FIVE_HUNDRED);
   EXPECT_FALSE(set.HasAnyOf(items));
-  set.Add(TestEnum::FIVE_HUNDRED);
+  set.insert(TestEnum::FIVE_HUNDRED);
   EXPECT_TRUE(set.HasAnyOf(items));
   EXPECT_FALSE(set.HasAnyOf(EnumSet<TestEnum>(TestEnum::TWENTY)));
   EXPECT_FALSE(set.HasAnyOf(EnumSet<TestEnum>(TestEnum::SIX_HUNDRED)));
@@ -435,24 +435,37 @@ TEST(EnumSetHasAnyOf, GeneralCase) {
 TEST(EnumSet, DefaultIsEmpty) {
   EnumSet<TestEnum> set;
   for (uint32_t i = 0; i < 1000; ++i) {
-    EXPECT_FALSE(set.Contains(static_cast<TestEnum>(i)));
+    EXPECT_FALSE(set.contains(static_cast<TestEnum>(i)));
   }
 }
 
-TEST(CapabilitySet, ForEachOrderIsEnumOrder) {
-  constexpr size_t kValueCount = 500;
-  std::vector<TestEnum> orderedValues(kValueCount);
-  for (size_t i = 0; i < kValueCount; i++) {
-    orderedValues[i] = static_cast<TestEnum>(i);
+namespace {
+std::vector<TestEnum> enumerateValuesFromToWithStep(size_t start, size_t end,
+                                                    size_t step) {
+  assert(end > start && "end > start");
+  std::vector<TestEnum> orderedValues;
+  for (size_t i = start; i < end; i += step) {
+    orderedValues.push_back(static_cast<TestEnum>(i));
   }
-  std::vector shuffledValues(orderedValues.cbegin(), orderedValues.cend());
+  return orderedValues;
+}
+
+EnumSet<TestEnum> createSetUnorderedInsertion(
+    const std::vector<TestEnum>& values) {
+  std::vector shuffledValues(values.cbegin(), values.cend());
   std::mt19937 rng(0);
   std::shuffle(shuffledValues.begin(), shuffledValues.end(), rng);
-
   EnumSet<TestEnum> set;
   for (auto value : shuffledValues) {
-    set.Add(value);
+    set.insert(value);
   }
+  return set;
+}
+}  // namespace
+
+TEST(CapabilitySet, ForEachOrderIsEnumOrder) {
+  auto orderedValues = enumerateValuesFromToWithStep(0, 500, /* step= */ 1);
+  auto set = createSetUnorderedInsertion(orderedValues);
 
   size_t index = 0;
   set.ForEach([&orderedValues, &index](auto value) {
@@ -461,71 +474,194 @@ TEST(CapabilitySet, ForEachOrderIsEnumOrder) {
   });
 }
 
+TEST(CapabilitySet, RangeBasedLoopOrderIsEnumOrder) {
+  auto orderedValues = enumerateValuesFromToWithStep(0, 2, /* step= */ 1);
+  auto set = createSetUnorderedInsertion(orderedValues);
+
+  size_t index = 0;
+  for (auto value : set) {
+    ASSERT_THAT(value, Eq(orderedValues[index]));
+    index++;
+  }
+}
+
 TEST(CapabilitySet, ConstructSingleMemberMatrix) {
   CapabilitySet s(spv::Capability::Matrix);
-  EXPECT_TRUE(s.Contains(spv::Capability::Matrix));
-  EXPECT_FALSE(s.Contains(spv::Capability::Shader));
-  EXPECT_FALSE(s.Contains(static_cast<spv::Capability>(1000)));
+  EXPECT_TRUE(s.contains(spv::Capability::Matrix));
+  EXPECT_FALSE(s.contains(spv::Capability::Shader));
+  EXPECT_FALSE(s.contains(static_cast<spv::Capability>(1000)));
 }
 
 TEST(CapabilitySet, ConstructSingleMemberMaxInMask) {
   CapabilitySet s(static_cast<spv::Capability>(63));
-  EXPECT_FALSE(s.Contains(spv::Capability::Matrix));
-  EXPECT_FALSE(s.Contains(spv::Capability::Shader));
-  EXPECT_TRUE(s.Contains(static_cast<spv::Capability>(63)));
-  EXPECT_FALSE(s.Contains(static_cast<spv::Capability>(64)));
-  EXPECT_FALSE(s.Contains(static_cast<spv::Capability>(1000)));
+  EXPECT_FALSE(s.contains(spv::Capability::Matrix));
+  EXPECT_FALSE(s.contains(spv::Capability::Shader));
+  EXPECT_TRUE(s.contains(static_cast<spv::Capability>(63)));
+  EXPECT_FALSE(s.contains(static_cast<spv::Capability>(64)));
+  EXPECT_FALSE(s.contains(static_cast<spv::Capability>(1000)));
 }
 
 TEST(CapabilitySet, ConstructSingleMemberMinOverflow) {
   // Check the first one that forces overflow beyond the mask.
   CapabilitySet s(static_cast<spv::Capability>(64));
-  EXPECT_FALSE(s.Contains(spv::Capability::Matrix));
-  EXPECT_FALSE(s.Contains(spv::Capability::Shader));
-  EXPECT_FALSE(s.Contains(static_cast<spv::Capability>(63)));
-  EXPECT_TRUE(s.Contains(static_cast<spv::Capability>(64)));
-  EXPECT_FALSE(s.Contains(static_cast<spv::Capability>(1000)));
+  EXPECT_FALSE(s.contains(spv::Capability::Matrix));
+  EXPECT_FALSE(s.contains(spv::Capability::Shader));
+  EXPECT_FALSE(s.contains(static_cast<spv::Capability>(63)));
+  EXPECT_TRUE(s.contains(static_cast<spv::Capability>(64)));
+  EXPECT_FALSE(s.contains(static_cast<spv::Capability>(1000)));
 }
 
 TEST(CapabilitySet, ConstructSingleMemberMaxOverflow) {
   // Check the max 32-bit signed int.
   CapabilitySet s(static_cast<spv::Capability>(0x7fffffffu));
-  EXPECT_FALSE(s.Contains(spv::Capability::Matrix));
-  EXPECT_FALSE(s.Contains(spv::Capability::Shader));
-  EXPECT_FALSE(s.Contains(static_cast<spv::Capability>(1000)));
-  EXPECT_TRUE(s.Contains(static_cast<spv::Capability>(0x7fffffffu)));
+  EXPECT_FALSE(s.contains(spv::Capability::Matrix));
+  EXPECT_FALSE(s.contains(spv::Capability::Shader));
+  EXPECT_FALSE(s.contains(static_cast<spv::Capability>(1000)));
+  EXPECT_TRUE(s.contains(static_cast<spv::Capability>(0x7fffffffu)));
 }
 
 TEST(CapabilitySet, AddEnum) {
   CapabilitySet s(spv::Capability::Shader);
-  s.Add(spv::Capability::Kernel);
-  s.Add(static_cast<spv::Capability>(42));
-  EXPECT_FALSE(s.Contains(spv::Capability::Matrix));
-  EXPECT_TRUE(s.Contains(spv::Capability::Shader));
-  EXPECT_TRUE(s.Contains(spv::Capability::Kernel));
-  EXPECT_TRUE(s.Contains(static_cast<spv::Capability>(42)));
+  s.insert(spv::Capability::Kernel);
+  s.insert(static_cast<spv::Capability>(42));
+  EXPECT_FALSE(s.contains(spv::Capability::Matrix));
+  EXPECT_TRUE(s.contains(spv::Capability::Shader));
+  EXPECT_TRUE(s.contains(spv::Capability::Kernel));
+  EXPECT_TRUE(s.contains(static_cast<spv::Capability>(42)));
+}
+
+TEST(CapabilitySet, InsertReturnsIteratorToInserted) {
+  CapabilitySet set;
+
+  auto [it, inserted] = set.insert(spv::Capability::Kernel);
+
+  EXPECT_TRUE(inserted);
+  EXPECT_EQ(*it, spv::Capability::Kernel);
+}
+
+TEST(CapabilitySet, InsertReturnsIteratorToElementOnDoubleInsertion) {
+  CapabilitySet set;
+  EXPECT_FALSE(set.contains(spv::Capability::Shader));
+  {
+    auto [it, inserted] = set.insert(spv::Capability::Shader);
+    EXPECT_TRUE(inserted);
+    EXPECT_EQ(*it, spv::Capability::Shader);
+  }
+  EXPECT_TRUE(set.contains(spv::Capability::Shader));
+
+  auto [it, inserted] = set.insert(spv::Capability::Shader);
+
+  EXPECT_FALSE(inserted);
+  EXPECT_EQ(*it, spv::Capability::Shader);
+  EXPECT_TRUE(set.contains(spv::Capability::Shader));
+}
+
+TEST(CapabilitySet, InsertWithHintWorks) {
+  CapabilitySet set;
+  EXPECT_FALSE(set.contains(spv::Capability::Shader));
+
+  auto it = set.insert(set.begin(), spv::Capability::Shader);
+
+  EXPECT_EQ(*it, spv::Capability::Shader);
+  EXPECT_TRUE(set.contains(spv::Capability::Shader));
+}
+
+TEST(CapabilitySet, InsertWithEndHintWorks) {
+  CapabilitySet set;
+  EXPECT_FALSE(set.contains(spv::Capability::Shader));
+
+  auto it = set.insert(set.end(), spv::Capability::Shader);
+
+  EXPECT_EQ(*it, spv::Capability::Shader);
+  EXPECT_TRUE(set.contains(spv::Capability::Shader));
+}
+
+TEST(CapabilitySet, IteratorBeginToEndPostfix) {
+  auto orderedValues = enumerateValuesFromToWithStep(0, 100, /* step= */ 1);
+  auto set = createSetUnorderedInsertion(orderedValues);
+
+  size_t index = 0;
+  for (auto it = set.cbegin(); it != set.cend(); it++, index++) {
+    EXPECT_EQ(*it, orderedValues[index]);
+  }
+}
+
+TEST(CapabilitySet, IteratorBeginToEndPrefix) {
+  auto orderedValues = enumerateValuesFromToWithStep(0, 100, /* step= */ 1);
+  auto set = createSetUnorderedInsertion(orderedValues);
+
+  size_t index = 0;
+  for (auto it = set.cbegin(); it != set.cend(); ++it, index++) {
+    EXPECT_EQ(*it, orderedValues[index]);
+  }
+}
+
+TEST(CapabilitySet, IteratorBeginToEndPrefixStep) {
+  auto orderedValues = enumerateValuesFromToWithStep(0, 100, /* step= */ 8);
+  auto set = createSetUnorderedInsertion(orderedValues);
+
+  size_t index = 0;
+  for (auto it = set.cbegin(); it != set.cend(); ++it, index++) {
+    ASSERT_EQ(*it, orderedValues[index]);
+  }
+}
+
+TEST(CapabilitySet, CompatibleWithSTLFind) {
+  CapabilitySet set;
+  set.insert(spv::Capability::Matrix);
+  set.insert(spv::Capability::Shader);
+  set.insert(spv::Capability::Geometry);
+  set.insert(spv::Capability::Tessellation);
+  set.insert(spv::Capability::Addresses);
+  set.insert(spv::Capability::Linkage);
+  set.insert(spv::Capability::Kernel);
+  set.insert(spv::Capability::Vector16);
+  set.insert(spv::Capability::Float16Buffer);
+  set.insert(spv::Capability::Float64);
+
+  {
+    auto it = std::find(set.cbegin(), set.cend(), spv::Capability::Vector16);
+    ASSERT_NE(it, set.end());
+    ASSERT_EQ(*it, spv::Capability::Vector16);
+  }
+
+  {
+    auto it = std::find(set.cbegin(), set.cend(), spv::Capability::Float16);
+    ASSERT_EQ(it, set.end());
+  }
+}
+
+TEST(CapabilitySet, CompatibleWithSTLForEach) {
+  auto orderedValues = enumerateValuesFromToWithStep(0, 100, /* step= */ 15);
+  auto set = createSetUnorderedInsertion(orderedValues);
+
+  size_t index = 0;
+  std::for_each(set.cbegin(), set.cend(), [&](auto item) {
+    ASSERT_EQ(item, orderedValues[index]);
+    index++;
+  });
 }
 
 TEST(CapabilitySet, InitializerListEmpty) {
   CapabilitySet s{};
   for (uint32_t i = 0; i < 1000; i++) {
-    EXPECT_FALSE(s.Contains(static_cast<spv::Capability>(i)));
+    EXPECT_FALSE(s.contains(static_cast<spv::Capability>(i)));
   }
 }
 
 TEST(CapabilitySet, LargeSetHasInsertedElements) {
   CapabilitySet set;
   for (auto c : kCapabilities) {
-    EXPECT_FALSE(set.Contains(c));
+    EXPECT_FALSE(set.contains(c));
   }
 
   for (auto c : kCapabilities) {
-    set.Add(c);
-    EXPECT_TRUE(set.Contains(c));
+    set.insert(c);
+    EXPECT_TRUE(set.contains(c));
   }
 
   for (auto c : kCapabilities) {
-    EXPECT_TRUE(set.Contains(c));
+    EXPECT_TRUE(set.contains(c));
   }
 }
 
@@ -536,16 +672,16 @@ TEST(CapabilitySet, LargeSetHasUnsortedInsertedElements) {
   std::shuffle(shuffledCapabilities.begin(), shuffledCapabilities.end(), rng);
   CapabilitySet set;
   for (auto c : shuffledCapabilities) {
-    EXPECT_FALSE(set.Contains(c));
+    EXPECT_FALSE(set.contains(c));
   }
 
   for (auto c : shuffledCapabilities) {
-    set.Add(c);
-    EXPECT_TRUE(set.Contains(c));
+    set.insert(c);
+    EXPECT_TRUE(set.contains(c));
   }
 
   for (auto c : shuffledCapabilities) {
-    EXPECT_TRUE(set.Contains(c));
+    EXPECT_TRUE(set.contains(c));
   }
 }
 
@@ -556,16 +692,16 @@ TEST(CapabilitySet, LargeSetHasUnsortedRemovedElement) {
   std::shuffle(shuffledCapabilities.begin(), shuffledCapabilities.end(), rng);
   CapabilitySet set;
   for (auto c : shuffledCapabilities) {
-    set.Add(c);
-    EXPECT_TRUE(set.Contains(c));
+    set.insert(c);
+    EXPECT_TRUE(set.contains(c));
   }
 
   for (auto c : kCapabilities) {
-    set.Remove(c);
+    set.erase(c);
   }
 
   for (auto c : shuffledCapabilities) {
-    EXPECT_FALSE(set.Contains(c));
+    EXPECT_FALSE(set.contains(c));
   }
 }
 
@@ -630,8 +766,8 @@ using BoundaryTestWithParam = ::testing::TestWithParam<spv::Capability>;
 
 TEST_P(BoundaryTestWithParam, InsertedContains) {
   CapabilitySet set;
-  set.Add(GetParam());
-  EXPECT_TRUE(set.Contains(GetParam()));
+  set.insert(GetParam());
+  EXPECT_TRUE(set.contains(GetParam()));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/test/enum_set_test.cpp
+++ b/test/enum_set_test.cpp
@@ -533,7 +533,7 @@ TEST(CapabilitySet, AddEnum) {
 TEST(CapabilitySet, InsertReturnsIteratorToInserted) {
   CapabilitySet set;
 
-  auto [it, inserted] = set.insert(spv::Capability::Kernel);
+  auto[it, inserted] = set.insert(spv::Capability::Kernel);
 
   EXPECT_TRUE(inserted);
   EXPECT_EQ(*it, spv::Capability::Kernel);
@@ -543,13 +543,13 @@ TEST(CapabilitySet, InsertReturnsIteratorToElementOnDoubleInsertion) {
   CapabilitySet set;
   EXPECT_FALSE(set.contains(spv::Capability::Shader));
   {
-    auto [it, inserted] = set.insert(spv::Capability::Shader);
+    auto[it, inserted] = set.insert(spv::Capability::Shader);
     EXPECT_TRUE(inserted);
     EXPECT_EQ(*it, spv::Capability::Shader);
   }
   EXPECT_TRUE(set.contains(spv::Capability::Shader));
 
-  auto [it, inserted] = set.insert(spv::Capability::Shader);
+  auto[it, inserted] = set.insert(spv::Capability::Shader);
 
   EXPECT_FALSE(inserted);
   EXPECT_EQ(*it, spv::Capability::Shader);

--- a/test/enum_set_test.cpp
+++ b/test/enum_set_test.cpp
@@ -576,6 +576,29 @@ TEST(CapabilitySet, InsertWithEndHintWorks) {
   EXPECT_TRUE(set.contains(spv::Capability::Shader));
 }
 
+TEST(CapabilitySet, IteratorCanBeCopied) {
+  CapabilitySet set;
+  set.insert(spv::Capability::Matrix);
+  set.insert(spv::Capability::Shader);
+  set.insert(spv::Capability::Geometry);
+  set.insert(spv::Capability::Float64);
+  set.insert(spv::Capability::Float16);
+
+  auto a = set.begin();
+  ++a;
+  auto b = a;
+
+  EXPECT_EQ(*b, *a);
+  ++b;
+  EXPECT_NE(*b, *a);
+
+  ++a;
+  EXPECT_EQ(*b, *a);
+
+  ++a;
+  EXPECT_NE(*b, *a);
+}
+
 TEST(CapabilitySet, IteratorBeginToEndPostfix) {
   auto orderedValues = enumerateValuesFromToWithStep(0, 100, /* step= */ 1);
   auto set = createSetUnorderedInsertion(orderedValues);


### PR DESCRIPTION
This commit adds forward iterator, and renames functions to it matches the std::unordered_set/std::set better. This goes against the SPIR-V coding style, but might be better in the long run, especially when this set is used along real STL sets.
(Right now, they are not compatible, and requires 2 syntaxes).

This container could in theory handle bidirectional iterator, but for now, only forward seemed required for our use-cases.