### PR TITLE
source: Give better message if using new Source Langauge

### DIFF
--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -626,7 +626,6 @@ spv_result_t Parser::parseOperand(size_t inst_offset,
     } break;
 
     case SPV_OPERAND_TYPE_CAPABILITY:
-    case SPV_OPERAND_TYPE_SOURCE_LANGUAGE:
     case SPV_OPERAND_TYPE_EXECUTION_MODEL:
     case SPV_OPERAND_TYPE_ADDRESSING_MODEL:
     case SPV_OPERAND_TYPE_MEMORY_MODEL:
@@ -678,6 +677,20 @@ spv_result_t Parser::parseOperand(size_t inst_offset,
         return diagnostic()
                << "Invalid " << spvOperandTypeStr(parsed_operand.type)
                << " operand: " << word;
+      }
+      // Prepare to accept operands to this operand, if needed.
+      spvPushOperandTypes(entry->operandTypes, expected_operands);
+    } break;
+
+    case SPV_OPERAND_TYPE_SOURCE_LANGUAGE: {
+      spv_operand_desc entry;
+      if (grammar_.lookupOperand(type, word, &entry)) {
+        return diagnostic()
+               << "Invalid " << spvOperandTypeStr(parsed_operand.type)
+               << " operand: " << word
+               << ", if createing a new source language please use value 0 "
+                  "(Unknown) and when ready, register your source language to "
+                  "the SPRIV-Headers";
       }
       // Prepare to accept operands to this operand, if needed.
       spvPushOperandTypes(entry->operandTypes, expected_operands);

--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -688,9 +688,10 @@ spv_result_t Parser::parseOperand(size_t inst_offset,
         return diagnostic()
                << "Invalid " << spvOperandTypeStr(parsed_operand.type)
                << " operand: " << word
-               << ", if createing a new source language please use value 0 "
-                  "(Unknown) and when ready, register your source language to "
-                  "the SPRIV-Headers";
+               << ", if you are creating a new source language please use "
+                  "value 0 "
+                  "(Unknown) and when ready, add your source language to "
+                  "SPRIV-Headers";
       }
       // Prepare to accept operands to this operand, if needed.
       spvPushOperandTypes(entry->operandTypes, expected_operands);

--- a/test/binary_parse_test.cpp
+++ b/test/binary_parse_test.cpp
@@ -1155,9 +1155,9 @@ INSTANTIATE_TEST_SUITE_P(
          "Invalid OpSpecConstantOp opcode: 1000"},
         {"OpCapability !9999", "Invalid capability operand: 9999"},
         {"OpSource !9999 100",
-         "Invalid source language operand: 9999, if createing a new source "
-         "language please use value 0 (Unknown) and when ready, register your "
-         "source language to the SPRIV-Headers"},
+         "Invalid source language operand: 9999, if you are creating a new "
+         "source language please use value 0 (Unknown) and when ready, add "
+         "your source language to SPRIV-Headers"},
         {"OpEntryPoint !9999", "Invalid execution model operand: 9999"},
         {"OpMemoryModel !9999", "Invalid addressing model operand: 9999"},
         {"OpMemoryModel Logical !9999", "Invalid memory model operand: 9999"},

--- a/test/binary_parse_test.cpp
+++ b/test/binary_parse_test.cpp
@@ -1154,7 +1154,10 @@ INSTANTIATE_TEST_SUITE_P(
         {"%2 = OpSpecConstantOp %1 !1000 %2",
          "Invalid OpSpecConstantOp opcode: 1000"},
         {"OpCapability !9999", "Invalid capability operand: 9999"},
-        {"OpSource !9999 100", "Invalid source language operand: 9999"},
+        {"OpSource !9999 100",
+         "Invalid source language operand: 9999, if createing a new source "
+         "language please use value 0 (Unknown) and when ready, register your "
+         "source language to the SPRIV-Headers"},
         {"OpEntryPoint !9999", "Invalid execution model operand: 9999"},
         {"OpMemoryModel !9999", "Invalid addressing model operand: 9999"},
         {"OpMemoryModel Logical !9999", "Invalid memory model operand: 9999"},


### PR DESCRIPTION
Currently when people are creating new source languages, it would be nice to add information that they can just use `0` as a value and it can be registered