### PR TITLE
enumset: fix bug in the new iterator class

### DIFF
--- a/source/enum_set.h
+++ b/source/enum_set.h
@@ -119,6 +119,8 @@ class EnumSet {
     }
 
     T operator*() const {
+      assert(set_->HasEnumAt(bucketIndex_, bucketOffset_) &&
+             "operator*() called on an invalid iterator.");
       return GetValueFromBucket(set_->buckets_[bucketIndex_], bucketOffset_);
     }
 
@@ -145,9 +147,9 @@ class EnumSet {
    private:
     const EnumSet* set_;
     // Index of the bucket in the vector.
-    size_t bucketIndex_;
+    size_t bucketIndex_ = 0;
     // Offset in bits in the current bucket.
-    ElementType bucketOffset_;
+    ElementType bucketOffset_ = 0;
 
     friend class EnumSet;
   };
@@ -159,7 +161,18 @@ class EnumSet {
 
  public:
   iterator cbegin() const noexcept {
-    return iterator(this, /* bucketIndex= */ 0, /* bucketOffset= */ 0);
+    auto it = iterator(this, /* bucketIndex= */ 0, /* bucketOffset= */ 0);
+    if (buckets_.size() == 0) {
+      return it;
+    }
+
+    // The iterator has the logic to find the next valid bit. If the value 0
+    // if not stored, use it to find the next valid bit.
+    if (!HasEnumAt(it.bucketIndex_, it.bucketOffset_)) {
+      ++it;
+    }
+
+    return it;
   }
 
   iterator begin() const noexcept { return cbegin(); }
@@ -440,7 +453,7 @@ class EnumSet {
   // Storage for the buckets.
   std::vector<Bucket> buckets_;
   // How many enums is this set storing.
-  size_t size_;
+  size_t size_ = 0;
 };
 
 // A set of spv::Capability.

--- a/test/enum_set_test.cpp
+++ b/test/enum_set_test.cpp
@@ -629,6 +629,61 @@ TEST(CapabilitySet, IteratorBeginToEndPrefixStep) {
   }
 }
 
+TEST(CapabilitySet, IteratorBeginOnEmpty) {
+  CapabilitySet set;
+
+  auto begin = set.begin();
+  auto end = set.end();
+  ASSERT_EQ(begin, end);
+}
+
+TEST(CapabilitySet, IteratorBeginOnSingleNonZeroValue) {
+  CapabilitySet set;
+  set.insert(spv::Capability::Shader);
+
+  auto begin = set.begin();
+  auto end = set.end();
+
+  ASSERT_NE(begin, end);
+  ASSERT_EQ(*begin, spv::Capability::Shader);
+}
+
+TEST(CapabilitySet, IteratorForLoopNonZeroValue) {
+  CapabilitySet set;
+  set.insert(spv::Capability::Shader);
+  set.insert(spv::Capability::Tessellation);
+
+  auto begin = set.begin();
+  auto end = set.end();
+
+  ASSERT_NE(begin, end);
+  ASSERT_EQ(*begin, spv::Capability::Shader);
+
+  begin++;
+  ASSERT_NE(begin, end);
+  ASSERT_EQ(*begin, spv::Capability::Tessellation);
+
+  begin++;
+  ASSERT_EQ(begin, end);
+}
+
+TEST(CapabilitySet, IteratorPastEnd) {
+  CapabilitySet set;
+  set.insert(spv::Capability::Shader);
+
+  auto begin = set.begin();
+  auto end = set.end();
+
+  ASSERT_NE(begin, end);
+  ASSERT_EQ(*begin, spv::Capability::Shader);
+
+  begin++;
+  ASSERT_EQ(begin, end);
+
+  begin++;
+  ASSERT_EQ(begin, end);
+}
+
 TEST(CapabilitySet, CompatibleWithSTLFind) {
   CapabilitySet set;
   set.insert(spv::Capability::Matrix);


### PR DESCRIPTION
The iterator class was initialized by setting the offset and bucket to 0. Big oversight: what if the first enum is not valid? Then `*iterator->begin()` would return the wrong value.

Because the first capacity is Matrix, this bug was not visible by any SPIRV test.
And this specific case wasn't tested correctly in the new enumset tests.