### PR TITLE
NFC: replace EnumSet::ForEach with range-based-for

### DIFF
--- a/source/enum_set.h
+++ b/source/enum_set.h
@@ -293,19 +293,6 @@ class EnumSet {
   // Returns the 1 if `value` is present in the set, `0` otherwise.
   inline size_t count(T value) const { return contains(value) ? 1 : 0; }
 
-  // Calls `unaryFunction` once for each value in the set.
-  // Values are sorted in increasing order using their numerical values.
-  // TODO(#5315): replace usages with either ranged-for or std::for_each.
-  void ForEach(std::function<void(T)> unaryFunction) const {
-    for (const auto& bucket : buckets_) {
-      for (ElementType i = 0; i < kBucketSize; i++) {
-        if (bucket.data & (static_cast<BucketType>(1) << i)) {
-          unaryFunction(GetValueFromBucket(bucket, i));
-        }
-      }
-    }
-  }
-
   // Returns true if the set is holds no values.
   inline bool empty() const { return size_ == 0; }
 

--- a/source/extensions.cpp
+++ b/source/extensions.cpp
@@ -40,8 +40,9 @@ std::string GetExtensionString(const spv_parsed_instruction_t* inst) {
 
 std::string ExtensionSetToString(const ExtensionSet& extensions) {
   std::stringstream ss;
-  extensions.ForEach(
-      [&ss](Extension ext) { ss << ExtensionToString(ext) << " "; });
+  for (auto extension : extensions) {
+    ss << ExtensionToString(extension) << " ";
+  }
   return ss.str();
 }
 

--- a/source/opt/feature_manager.cpp
+++ b/source/opt/feature_manager.cpp
@@ -57,8 +57,10 @@ void FeatureManager::AddCapability(spv::Capability cap) {
   spv_operand_desc desc = {};
   if (SPV_SUCCESS == grammar_.lookupOperand(SPV_OPERAND_TYPE_CAPABILITY,
                                             uint32_t(cap), &desc)) {
-    CapabilitySet(desc->numCapabilities, desc->capabilities)
-        .ForEach([this](spv::Capability c) { AddCapability(c); });
+    for (auto capability :
+         CapabilitySet(desc->numCapabilities, desc->capabilities)) {
+      AddCapability(capability);
+    }
   }
 }
 

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -718,9 +718,9 @@ void IRContext::AddCombinatorsForExtension(Instruction* extension) {
 }
 
 void IRContext::InitializeCombinators() {
-  get_feature_mgr()->GetCapabilities()->ForEach([this](spv::Capability cap) {
-    AddCombinatorsForCapability(uint32_t(cap));
-  });
+  for (auto capability : *get_feature_mgr()->GetCapabilities()) {
+    AddCombinatorsForCapability(uint32_t(capability));
+  }
 
   for (auto& extension : module()->ext_inst_imports()) {
     AddCombinatorsForExtension(&extension);

--- a/source/val/validate_instruction.cpp
+++ b/source/val/validate_instruction.cpp
@@ -38,14 +38,14 @@ namespace {
 std::string ToString(const CapabilitySet& capabilities,
                      const AssemblyGrammar& grammar) {
   std::stringstream ss;
-  capabilities.ForEach([&grammar, &ss](spv::Capability cap) {
+  for (auto capability : capabilities) {
     spv_operand_desc desc;
     if (SPV_SUCCESS == grammar.lookupOperand(SPV_OPERAND_TYPE_CAPABILITY,
-                                             uint32_t(cap), &desc))
+                                             uint32_t(capability), &desc))
       ss << desc->name << " ";
     else
-      ss << uint32_t(cap) << " ";
-  });
+      ss << uint32_t(capability) << " ";
+  }
   return ss.str();
 }
 

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -366,8 +366,10 @@ void ValidationState_t::RegisterCapability(spv::Capability cap) {
   spv_operand_desc desc;
   if (SPV_SUCCESS == grammar_.lookupOperand(SPV_OPERAND_TYPE_CAPABILITY,
                                             uint32_t(cap), &desc)) {
-    CapabilitySet(desc->numCapabilities, desc->capabilities)
-        .ForEach([this](spv::Capability c) { RegisterCapability(c); });
+    for (auto capability :
+         CapabilitySet(desc->numCapabilities, desc->capabilities)) {
+      RegisterCapability(capability);
+    }
   }
 
   switch (cap) {

--- a/test/enum_set_test.cpp
+++ b/test/enum_set_test.cpp
@@ -463,17 +463,6 @@ EnumSet<TestEnum> createSetUnorderedInsertion(
 }
 }  // namespace
 
-TEST(CapabilitySet, ForEachOrderIsEnumOrder) {
-  auto orderedValues = enumerateValuesFromToWithStep(0, 500, /* step= */ 1);
-  auto set = createSetUnorderedInsertion(orderedValues);
-
-  size_t index = 0;
-  set.ForEach([&orderedValues, &index](auto value) {
-    EXPECT_THAT(value, Eq(orderedValues[index]));
-    index++;
-  });
-}
-
 TEST(CapabilitySet, RangeBasedLoopOrderIsEnumOrder) {
   auto orderedValues = enumerateValuesFromToWithStep(0, 2, /* step= */ 1);
   auto set = createSetUnorderedInsertion(orderedValues);

--- a/test/unit_spirv.h
+++ b/test/unit_spirv.h
@@ -202,9 +202,8 @@ inline std::vector<spv_target_env> AllTargetEnvironments() {
 // Returns the capabilities in a CapabilitySet as an ordered vector.
 inline std::vector<spv::Capability> ElementsIn(
     const spvtools::CapabilitySet& capabilities) {
-  std::vector<spv::Capability> result;
-  capabilities.ForEach([&result](spv::Capability c) { result.push_back(c); });
-  return result;
+  return std::vector<spv::Capability>(capabilities.cbegin(),
+                                      capabilities.cend());
 }
 
 }  // namespace spvtest


### PR DESCRIPTION
EnumSet now supports iterators, meaning we can remove the custom ForEach.