### PR TITLE
instrument: Reduce number of inst_bindless_stream_write_6 calls

### DIFF
--- a/test/opt/inst_bindless_check_test.cpp
+++ b/test/opt/inst_bindless_check_test.cpp
@@ -135,19 +135,32 @@ static const std::string kCheckDesc = R"(
 ; CHECK: [[di_shader_id:%\w+]] = OpFunctionParameter %uint
 ; CHECK: [[di_line:%\w+]] = OpFunctionParameter %uint
 ; CHECK: [[di_stage_info:%\w+]] = OpFunctionParameter %v4uint
-; CHECK: [[di_desc_set_idx:%\w+]] = OpFunctionParameter %uint
-; CHECK: [[di_binding_idx:%\w+]] = OpFunctionParameter %uint
+; CHECK: [[di_desc_set:%\w+]] = OpFunctionParameter %uint
+; CHECK: [[di_binding:%\w+]] = OpFunctionParameter %uint
 ; CHECK: [[di_desc_idx:%\w+]] = OpFunctionParameter %uint
 ; CHECK: [[di_byte_offset:%\w+]] = OpFunctionParameter %uint
 ; CHECK: {{%\w+}} = OpLabel
-; CHECK: {{%\w+}} = OpUGreaterThanEqual %bool [[di_desc_set_idx]] %uint_32
+; CHECK: [[di_error:%\w+]] = OpVariable %_ptr_Function_uint Function %uint_0
+; CHECK: [[di_param5:%\w+]] = OpVariable %_ptr_Function_uint Function %uint_0
+; CHECK: [[di_param6:%\w+]] = OpVariable %_ptr_Function_uint Function %uint_0
+; CHECK: [[di_num_bindings:%\w+]] = OpVariable %_ptr_Function_uint Function %uint_0
+; CHECK: [[di_init_status:%\w+]] = OpVariable %_ptr_Function_uint Function %uint_0
+; CHECK: [[di_desc_set_ptr:%\w+]] = OpVariable %_ptr_Function__ptr_PhysicalStorageBuffer_inst_bindless_DescriptorSetData Function
+; CHECK: {{%\w+}} = OpUGreaterThanEqual %bool [[di_desc_set]] %uint_32
 ; CHECK: OpSelectionMerge {{%\w+}} None
 ; CHECK: OpBranchConditional {{%\w+}} {{%\w+}} {{%\w+}}
 ; CHECK: {{%\w+}} = OpLabel
-; CHECK: OpReturnValue %false
+; CHECK: OpStore [[di_error]] %uint_1
+; CHECK: OpBranch {{%\w+}}
 ; CHECK: {{%\w+}} = OpLabel
-; CHECK: {{%\w+}} = OpAccessChain %_ptr_StorageBuffer__ptr_PhysicalStorageBuffer_inst_bindless_DescriptorSetData %inst_bindless_input_buffer %uint_0 [[di_desc_set_idx]]
+; CHECK: {{%\w+}} = OpLoad %uint [[di_error]]
+; CHECK: {{%\w+}} = OpIEqual %bool {{%\w+}} %uint_0
+; CHECK: OpSelectionMerge {{%\w+}} None
+; CHECK: OpBranchConditional {{%\w+}} {{%\w+}} {{%\w+}}
+; CHECK: {{%\w+}} = OpLabel
+; CHECK: {{%\w+}} = OpAccessChain %_ptr_StorageBuffer__ptr_PhysicalStorageBuffer_inst_bindless_DescriptorSetData %inst_bindless_input_buffer %uint_0 [[di_desc_set]]
 ; CHECK: {{%\w+}} = OpLoad %_ptr_PhysicalStorageBuffer_inst_bindless_DescriptorSetData {{%\w+}}
+; CHECK: OpStore [[di_desc_set_ptr]] {{%\w+}}
 ; CHECK: {{%\w+}} = OpBitcast %v2uint {{%\w+}}
 ; CHECK: {{%\w+}} = OpCompositeExtract %uint {{%\w+}} 0
 ; CHECK: {{%\w+}} = OpIEqual %bool {{%\w+}} %uint_0
@@ -157,44 +170,96 @@ static const std::string kCheckDesc = R"(
 ; CHECK: OpSelectionMerge {{%\w+}} None
 ; CHECK: OpBranchConditional {{%\w+}} {{%\w+}} {{%\w+}}
 ; CHECK: {{%\w+}} = OpLabel
-; CHECK: {{%\w+}} = OpFunctionCall %void %inst_bindless_stream_write_6 [[di_shader_id]] [[di_line]] [[di_stage_info]] %uint_1 [[di_desc_set_idx]] [[di_binding_idx]] [[di_desc_idx]] %uint_0 %uint_0
-; CHECK: OpReturnValue %false
+; CHECK: OpStore [[di_error]] %uint_1
+; CHECK: OpBranch {{%\w+}}
 ; CHECK: {{%\w+}} = OpLabel
+; CHECK: OpBranch {{%\w+}}
+; CHECK: {{%\w+}} = OpLabel
+; CHECK: {{%\w+}} = OpLoad %uint [[di_error]]
+; CHECK: {{%\w+}} = OpIEqual %bool {{%\w+}} %uint_0
+; CHECK: OpSelectionMerge {{%\w+}} None
+; CHECK: OpBranchConditional {{%\w+}} {{%\w+}} {{%\w+}}
+; CHECK: {{%\w+}} = OpLabel
+; CHECK: {{%\w+}} = OpLoad %_ptr_PhysicalStorageBuffer_inst_bindless_DescriptorSetData [[di_desc_set_ptr]]
 ; CHECK: {{%\w+}} = OpAccessChain %_ptr_PhysicalStorageBuffer_uint {{%\w+}} %uint_0
-; CHECK: [[di_num_bindings:%\w+]] = OpLoad %uint {{%\w+}} Aligned 8
-; CHECK: {{%\w+}} = OpUGreaterThanEqual %bool [[di_binding_idx]] [[di_num_bindings]]
+; CHECK: {{%\w+}} = OpLoad %uint {{%\w+}} Aligned 8
+; CHECK: OpStore [[di_num_bindings]] {{%\w+}}
+; CHECK: {{%\w+}} = OpUGreaterThanEqual %bool [[di_binding]] {{%\w+}}
 ; CHECK: OpSelectionMerge {{%\w+}} None
 ; CHECK: OpBranchConditional {{%\w+}} {{%\w+}} {{%\w+}}
 ; CHECK: {{%\w+}} = OpLabel
-; CHECK: {{%\w+}} = OpFunctionCall %void %inst_bindless_stream_write_6 [[di_shader_id]] [[di_line]] [[di_stage_info]] %uint_1 [[di_desc_set_idx]] [[di_binding_idx]] [[di_desc_idx]] %uint_0 %uint_0
-; CHECK: OpReturnValue %false
+; CHECK: OpStore [[di_error]] %uint_1
+; CHECK: OpBranch {{%\w+}}
 ; CHECK: {{%\w+}} = OpLabel
-; CHECK: {{%\w+}} = OpAccessChain %_ptr_PhysicalStorageBuffer_uint {{%\w+}} %uint_1 [[di_binding_idx]]
-; CHECK: [[di_desc_array_len:%\w+]] = OpLoad %uint {{%\w+}} Aligned 4
-; CHECK: {{%\w+}} = OpUGreaterThanEqual %bool [[di_desc_idx]] [[di_desc_array_len]]
+; CHECK: OpBranch {{%\w+}}
+; CHECK: {{%\w+}} = OpLabel
+; CHECK: {{%\w+}} = OpLoad %uint [[di_error]]
+; CHECK: {{%\w+}} = OpIEqual %bool {{%\w+}} %uint_0
 ; CHECK: OpSelectionMerge {{%\w+}} None
 ; CHECK: OpBranchConditional {{%\w+}} {{%\w+}} {{%\w+}}
 ; CHECK: {{%\w+}} = OpLabel
-; CHECK: {{%\w+}} = OpFunctionCall %void %inst_bindless_stream_write_6 [[di_shader_id]] [[di_line]] [[di_stage_info]] %uint_1 [[di_desc_set_idx]] [[di_binding_idx]] [[di_desc_idx]] [[di_desc_array_len]] %uint_0
-; CHECK: OpReturnValue %false
+; CHECK: {{%\w+}} = OpLoad %_ptr_PhysicalStorageBuffer_inst_bindless_DescriptorSetData [[di_desc_set_ptr]]
+; CHECK: {{%\w+}} = OpAccessChain %_ptr_PhysicalStorageBuffer_uint {{%\w+}} %uint_1 [[di_binding]]
+; CHECK: {{%\w+}} = OpLoad %uint {{%\w+}} Aligned 4
+; CHECK: {{%\w+}} = OpUGreaterThanEqual %bool [[di_desc_idx]] {{%\w+}}
+; CHECK: OpSelectionMerge {{%\w+}} None
+; CHECK: OpBranchConditional {{%\w+}} {{%\w+}} {{%\w+}}
 ; CHECK: {{%\w+}} = OpLabel
-; CHECK: {{%\w+}} = OpIAdd %uint {{%\w+}} {{%\w+}}
+; CHECK: OpStore [[di_error]] %uint_1
+; CHECK: OpStore [[di_param5]] {{%\w+}}
+; CHECK: OpBranch {{%\w+}}
+; CHECK: {{%\w+}} = OpLabel
+; CHECK: OpBranch {{%\w+}}
+; CHECK: {{%\w+}} = OpLabel
+; CHECK: {{%\w+}} = OpLoad %uint [[di_error]]
+; CHECK: {{%\w+}} = OpLoad %uint [[di_error]]
+; CHECK: {{%\w+}} = OpIEqual %bool %uint_0 {{%\w+}}
+; CHECK: OpSelectionMerge {{%\w+}} None
+; CHECK: OpBranchConditional {{%\w+}} {{%\w+}} {{%\w+}}
+; CHECK: {{%\w+}} = OpLabel
+; CHECK: {{%\w+}} = OpLoad %_ptr_PhysicalStorageBuffer_inst_bindless_DescriptorSetData [[di_desc_set_ptr]]
+; CHECK: {{%\w+}} = OpLoad %uint [[di_num_bindings]]
+; CHECK: {{%\w+}} = OpIAdd %uint {{%\w+}} [[di_binding]]
 ; CHECK: {{%\w+}} = OpAccessChain %_ptr_PhysicalStorageBuffer_uint {{%\w+}} %uint_1 {{%\w+}}
 ; CHECK: {{%\w+}} = OpLoad %uint {{%\w+}} Aligned 4
+; CHECK: {{%\w+}} = OpIAdd %uint {{%\w+}} [[di_desc_idx]]
 ; CHECK: {{%\w+}} = OpAccessChain %_ptr_PhysicalStorageBuffer_uint {{%\w+}} %uint_1 {{%\w+}}
-; CHECK: [[di_init_status:%\w+]] = OpLoad %uint {{%\w+}} Aligned 4
-; CHECK: {{%\w+}} = OpIEqual %bool [[di_init_status]] %uint_0
+; CHECK: {{%\w+}} = OpLoad %uint {{%\w+}} Aligned 4
+; CHECK: OpStore [[di_init_status]] {{%\w+}}
+; CHECK: {{%\w+}} = OpIEqual %bool {{%\w+}} %uint_0
 ; CHECK: OpSelectionMerge {{%\w+}} None
 ; CHECK: OpBranchConditional {{%\w+}} {{%\w+}} {{%\w+}}
 ; CHECK: {{%\w+}} = OpLabel
-; CHECK: {{%\w+}} = OpFunctionCall %void %inst_bindless_stream_write_6 [[di_shader_id]] [[di_line]] [[di_stage_info]] %uint_2 [[di_desc_set_idx]] [[di_binding_idx]] [[di_desc_idx]] %uint_0 %uint_0
-; CHECK: OpReturnValue %false
+; CHECK: OpStore [[di_error]] %uint_2
+; CHECK: OpBranch {{%\w+}}
 ; CHECK: {{%\w+}} = OpLabel
-; CHECK: {{%\w+}} = OpUGreaterThanEqual %bool {{%\w+}} {{%\w+}}
+; CHECK: OpBranch {{%\w+}}
+; CHECK: {{%\w+}} = OpLabel
+; CHECK: {{%\w+}} = OpLoad %uint [[di_error]]
+; CHECK: {{%\w+}} = OpIEqual %bool {{%\w+}} %uint_0
 ; CHECK: OpSelectionMerge {{%\w+}} None
 ; CHECK: OpBranchConditional {{%\w+}} {{%\w+}} {{%\w+}}
 ; CHECK: {{%\w+}} = OpLabel
-; CHECK: {{%\w+}} = OpFunctionCall %void %inst_bindless_stream_write_6 [[di_shader_id]] [[di_line]] [[di_stage_info]] %uint_4 [[di_desc_set_idx]] [[di_binding_idx]] [[di_desc_idx]] [[di_byte_offset]] [[di_init_status]]
+; CHECK: {{%\w+}} = OpLoad %uint [[di_init_status]]
+; CHECK: {{%\w+}} = OpUGreaterThanEqual %bool [[di_byte_offset]] {{%\w+}}
+; CHECK: OpSelectionMerge {{%\w+}} None
+; CHECK: OpBranchConditional {{%\w+}} {{%\w+}} {{%\w+}}
+; CHECK: {{%\w+}} = OpLabel
+; CHECK: OpStore [[di_error]] %uint_4
+; CHECK: OpStore [[di_param5]] [[di_byte_offset]]
+; CHECK: OpStore [[di_param6]] {{%\w+}}
+; CHECK: OpBranch {{%\w+}}
+; CHECK: {{%\w+}} = OpLabel
+; CHECK: OpBranch {{%\w+}}
+; CHECK: {{%\w+}} = OpLabel
+; CHECK: {{%\w+}} = OpLoad %uint [[di_error]]
+; CHECK: {{%\w+}} = OpINotEqual %bool %uint_0 {{%\w+}}
+; CHECK: OpSelectionMerge {{%\w+}} None
+; CHECK: OpBranchConditional {{%\w+}} {{%\w+}} {{%\w+}}
+; CHECK: {{%\w+}} = OpLabel
+; CHECK: {{%\w+}} = OpLoad %uint [[di_param5]]
+; CHECK: {{%\w+}} = OpLoad %uint [[di_param6]]
+; CHECK: {{%\w+}} = OpFunctionCall %void %inst_bindless_stream_write_6 [[di_shader_id]] [[di_line]] [[di_stage_info]] {{%\w+}} [[di_desc_set]] [[di_binding]] [[di_desc_idx]] {{%\w+}} {{%\w+}}
 ; CHECK: OpReturnValue %false
 ; CHECK: {{%\w+}} = OpLabel
 ; CHECK: OpReturnValue %true
@@ -4377,7 +4442,7 @@ TEST_F(InstBindlessTest, UniformMatrixRefRowMajor) {
 ;CHECK: {{%\w+}} = OpLabel
 ;CHECK: [[phi_result]] = OpPhi %float [[load_result]] {{%\w+}} [[null_float]] {{%\w+}}
                OpStore %v_vtxResult %21
-;CHECK-NOT:    OpStore %v_vtxResult %21
+;CHECK-NOT:    OpStore %v_vtxResult %21$
 ;CHECK:  OpStore %v_vtxResult [[phi_result]]
                OpReturn
                OpFunctionEnd
@@ -4493,7 +4558,7 @@ TEST_F(InstBindlessTest, UniformMatrixRefColumnMajor) {
 ;CHECK: {{%\w+}} = OpLabel
 ;CHECK: [[phi_result]] = OpPhi %float [[load_result]] {{%\w+}} [[null_float]] {{%\w+}}
                OpStore %v_vtxResult %21
-;CHECK-NOT:    OpStore %v_vtxResult %21
+;CHECK-NOT:    OpStore %v_vtxResult %21$
 ;CHECK: OpStore %v_vtxResult [[phi_result]]
                OpReturn
                OpFunctionEnd


### PR DESCRIPTION
Multiple calls to this function were causing vkCreateGraphicsPipelines to be 3x slower on some drivers. I suspect this was because each call had to be inlined separately which bloated the code and caused more work in the driver's SPIRV -> native instruction compilation.