### PR TITLE
assembly-grammar: add GetExtensionsDeclaring

### DIFF
--- a/source/assembly_grammar.cpp
+++ b/source/assembly_grammar.cpp
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <cstring>
 
+#include "source/spirv_target_env.h"
 #include "source/ext_inst.h"
 #include "source/opcode.h"
 #include "source/operand.h"
@@ -199,6 +200,11 @@ ExtensionSet AssemblyGrammar::getExtensionsDeclaring(
                                      static_cast<uint32_t>(capability),
                                      &desc)) {
       continue;
+    }
+
+    // This capability is included in core, no need for extensions.
+    if (desc->minVersion <= spvVersionForTargetEnv(target_env_)) {
+      break;
     }
 
     for (size_t i = 0; i < desc->numExtensions; i++) {

--- a/source/assembly_grammar.cpp
+++ b/source/assembly_grammar.cpp
@@ -190,6 +190,21 @@ CapabilitySet AssemblyGrammar::filterCapsAgainstTargetEnv(
   return cap_set;
 }
 
+ExtensionSet AssemblyGrammar::getExtensionsDeclaring(CapabilitySet capabilities) const {
+  ExtensionSet output;
+  const spv_operand_desc_t *desc = nullptr;
+  for (auto capability : capabilities) {
+    if (SPV_SUCCESS != lookupOperand(SPV_OPERAND_TYPE_CAPABILITY, static_cast<uint32_t>(capability), &desc)) {
+      continue;
+    }
+
+    for (size_t i = 0; i < desc->numExtensions; i++) {
+      output.insert(desc->extensions[i]);
+    }
+  }
+  return output;
+}
+
 spv_result_t AssemblyGrammar::lookupOpcode(const char* name,
                                            spv_opcode_desc* desc) const {
   return spvOpcodeTableNameLookup(target_env_, opcodeTable_, name, desc);

--- a/source/assembly_grammar.cpp
+++ b/source/assembly_grammar.cpp
@@ -18,10 +18,10 @@
 #include <cassert>
 #include <cstring>
 
-#include "source/spirv_target_env.h"
 #include "source/ext_inst.h"
 #include "source/opcode.h"
 #include "source/operand.h"
+#include "source/spirv_target_env.h"
 #include "source/table.h"
 
 namespace spvtools {

--- a/source/assembly_grammar.cpp
+++ b/source/assembly_grammar.cpp
@@ -190,11 +190,14 @@ CapabilitySet AssemblyGrammar::filterCapsAgainstTargetEnv(
   return cap_set;
 }
 
-ExtensionSet AssemblyGrammar::getExtensionsDeclaring(CapabilitySet capabilities) const {
+ExtensionSet AssemblyGrammar::getExtensionsDeclaring(
+    CapabilitySet capabilities) const {
   ExtensionSet output;
-  const spv_operand_desc_t *desc = nullptr;
+  const spv_operand_desc_t* desc = nullptr;
   for (auto capability : capabilities) {
-    if (SPV_SUCCESS != lookupOperand(SPV_OPERAND_TYPE_CAPABILITY, static_cast<uint32_t>(capability), &desc)) {
+    if (SPV_SUCCESS != lookupOperand(SPV_OPERAND_TYPE_CAPABILITY,
+                                     static_cast<uint32_t>(capability),
+                                     &desc)) {
       continue;
     }
 

--- a/source/assembly_grammar.h
+++ b/source/assembly_grammar.h
@@ -44,6 +44,11 @@ class AssemblyGrammar {
   CapabilitySet filterCapsAgainstTargetEnv(const spv::Capability* cap_array,
                                            uint32_t count) const;
 
+  // Returns all the extensions declaring at least one capability listed
+  // in `capabilities`.
+  // FIXME(#5332): makes the operand table depend on the target env.
+  ExtensionSet getExtensionsDeclaring(CapabilitySet capabilities) const;
+
   // Fills in the desc parameter with the information about the opcode
   // of the given name. Returns SPV_SUCCESS if the opcode was found, and
   // SPV_ERROR_INVALID_LOOKUP if the opcode does not exist.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -90,6 +90,7 @@ set(TEST_SOURCES
 
   assembly_context_test.cpp
   assembly_format_test.cpp
+  assembly_grammar_test.cpp
   binary_destroy_test.cpp
   binary_endianness_test.cpp
   binary_header_get_test.cpp

--- a/test/assembly_grammar_test.cpp
+++ b/test/assembly_grammar_test.cpp
@@ -90,9 +90,8 @@ TEST_P(AssemblyGrammarTest, ReportsCorrectTargetEnv) {
   EXPECT_EQ(grammar().target_env(), target_env());
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    AssemblyGrammarTestSuite, AssemblyGrammarTest,
-    ValuesIn(spvtest::AllTargetEnvironments()));
+INSTANTIATE_TEST_SUITE_P(AssemblyGrammarTestSuite, AssemblyGrammarTest,
+                         ValuesIn(spvtest::AllTargetEnvironments()));
 
 TEST_P(AssemblyGrammarExtensionTest, CheckExtensionDeclaredForCapability) {
   const spv_target_env target_env = std::get<0>(GetParam());

--- a/test/assembly_grammar_test.cpp
+++ b/test/assembly_grammar_test.cpp
@@ -106,9 +106,9 @@ TEST_P(AssemblyGrammarExtensionTest, CheckExtensionDeclaredForCapability) {
 
 INSTANTIATE_TEST_SUITE_P(
     AssemblyGrammarExtensionTestSuite, AssemblyGrammarExtensionTest,
-    ValuesIn(
-        std::vector<std::tuple<spv_target_env, spv::Capability, ExtensionSet>>{
-            // clang-format off
+    ValuesIn(std::vector<
+             std::tuple<spv_target_env, spv::Capability, ExtensionSet>>{
+        // clang-format off
             {SPV_ENV_UNIVERSAL_1_0, spv::Capability::Matrix,  {}},
             {SPV_ENV_UNIVERSAL_1_0, spv::Capability::Shader,  {}},
             {SPV_ENV_UNIVERSAL_1_0, spv::Capability::Float16, {}},
@@ -141,8 +141,8 @@ INSTANTIATE_TEST_SUITE_P(
             {SPV_ENV_VULKAN_1_3, spv::Capability::FragmentBarycentricKHR,
               { kSPV_NV_fragment_shader_barycentric, kSPV_KHR_fragment_shader_barycentric }},
 
-            // clang-format on
-        }),
+        // clang-format on
+    }),
     AssemblyGrammarExtensionTest::PrintToStringParamName);
 
 }  // namespace

--- a/test/assembly_grammar_test.cpp
+++ b/test/assembly_grammar_test.cpp
@@ -1,0 +1,119 @@
+// Copyright (c) 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <tuple>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "source/enum_set.h"
+#include "test/unit_spirv.h"
+#include "source/enum_string_mapping.h"
+#include "source/spirv_target_env.h"
+
+namespace spvtools {
+
+// Useful to pretty-print the set when a test fails.
+void PrintTo(const ExtensionSet& set, std::ostream* os) {
+  *os << "{ ";
+  for (auto extension : set) {
+    *os << ExtensionToString(extension) << ", ";
+  }
+  *os << "}";
+}
+
+namespace {
+
+using ::testing::TestWithParam;
+using ::testing::Combine;
+using ::testing::Values;
+using ::testing::ValuesIn;
+
+class AssemblyGrammarTest : public ::testing::TestWithParam<spv_target_env> {
+ public:
+  inline spv_target_env target_env() const { return target_env_; }
+  inline const AssemblyGrammar& grammar() const { return *grammar_; }
+  inline const spv_context& context() const { return context_; }
+
+private:
+  void SetUp() override {
+    target_env_ = GetParam();
+    context_ = spvContextCreate(target_env_);
+    grammar_ = std::make_unique<AssemblyGrammar>(context_);
+  }
+
+  void TearDown() override {
+    spvContextDestroy(context_);
+  }
+
+
+  spv_target_env target_env_;
+  spv_context context_;
+  std::unique_ptr<AssemblyGrammar> grammar_;
+};
+
+struct AssemblyGrammarExtensionTestData {
+  spv::Capability capability;
+  ExtensionSet extensions;
+};
+
+
+class AssemblyGrammarExtensionTest : public ::testing::TestWithParam<std::tuple<spv_target_env, spv::Capability, ExtensionSet>> {
+  public:
+    // This allows GTest to name the tests with something more useful than /0, /1 etc.
+    static std::string PrintToStringParamName(const testing::TestParamInfo<ParamType>& info) {
+      auto spirv_version = spvVersionForTargetEnv(std::get<0>(info.param));
+
+      std::stringstream stream;
+      stream << "spv" << SPV_SPIRV_VERSION_MAJOR_PART(spirv_version)
+             << "_" << SPV_SPIRV_VERSION_MINOR_PART(spirv_version)
+             << "_" << CapabilityToString(std::get<1>(info.param));
+      return stream.str();
+    }
+};
+
+TEST_P(AssemblyGrammarTest, ReportsIsValid) {
+  EXPECT_TRUE(grammar().isValid());
+}
+
+TEST_P(AssemblyGrammarTest, ReportsCorrectTargetEnv) {
+  EXPECT_EQ(grammar().target_env(), target_env());
+}
+
+TEST_P(AssemblyGrammarExtensionTest, CheckExtensionDeclaredForCapability) {
+    const spv_target_env target_env = std::get<0>(GetParam());
+    spv_context context = spvContextCreate(target_env);
+    AssemblyGrammar grammar = AssemblyGrammar(context);
+
+    ExtensionSet result = grammar.getExtensionsDeclaring(std::get<1>(GetParam()));
+    EXPECT_EQ(result, std::get<2>(GetParam()));
+
+    spvContextDestroy(context);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AssemblyGrammarExtensionTestSuite, AssemblyGrammarExtensionTest,
+    ValuesIn(std::vector<std::tuple<spv_target_env, spv::Capability, ExtensionSet>>{
+      {SPV_ENV_UNIVERSAL_1_0, spv::Capability::Matrix, {}},
+      {SPV_ENV_UNIVERSAL_1_0, spv::Capability::Shader, {}},
+      {SPV_ENV_UNIVERSAL_1_0, spv::Capability::Groups, { kSPV_AMD_shader_ballot }},
+      {SPV_ENV_UNIVERSAL_1_0, spv::Capability::Float16, {}},
+      {SPV_ENV_UNIVERSAL_1_0, spv::Capability::MultiView, { kSPV_KHR_multiview }},
+
+      // FIXME(#5332): This should report no extensions.
+      {SPV_ENV_VULKAN_1_3, spv::Capability::MultiView, { kSPV_KHR_multiview }},
+    }),
+    AssemblyGrammarExtensionTest::PrintToStringParamName);
+
+}  // namespace
+}  // namespace spvtools

--- a/test/assembly_grammar_test.cpp
+++ b/test/assembly_grammar_test.cpp
@@ -108,20 +108,40 @@ INSTANTIATE_TEST_SUITE_P(
     AssemblyGrammarExtensionTestSuite, AssemblyGrammarExtensionTest,
     ValuesIn(
         std::vector<std::tuple<spv_target_env, spv::Capability, ExtensionSet>>{
-            {SPV_ENV_UNIVERSAL_1_0, spv::Capability::Matrix, {}},
-            {SPV_ENV_UNIVERSAL_1_0, spv::Capability::Shader, {}},
-            {SPV_ENV_UNIVERSAL_1_0,
-             spv::Capability::Groups,
-             {kSPV_AMD_shader_ballot}},
+            // clang-format off
+            {SPV_ENV_UNIVERSAL_1_0, spv::Capability::Matrix,  {}},
+            {SPV_ENV_UNIVERSAL_1_0, spv::Capability::Shader,  {}},
             {SPV_ENV_UNIVERSAL_1_0, spv::Capability::Float16, {}},
-            {SPV_ENV_UNIVERSAL_1_0,
-             spv::Capability::MultiView,
-             {kSPV_KHR_multiview}},
 
-            // FIXME(#5332): This should report no extensions.
-            {SPV_ENV_VULKAN_1_3,
-             spv::Capability::MultiView,
-             {kSPV_KHR_multiview}},
+            // Those capabilities were brought into core.
+            // Extension requirement depend on the SPIRV version.
+            {SPV_ENV_UNIVERSAL_1_0, spv::Capability::MultiView,      { kSPV_KHR_multiview }},
+            {SPV_ENV_VULKAN_1_3,    spv::Capability::MultiView,      {}},
+            {SPV_ENV_VULKAN_1_0,    spv::Capability::DrawParameters, { kSPV_KHR_shader_draw_parameters }},
+            {SPV_ENV_VULKAN_1_3,    spv::Capability::DrawParameters, { }},
+
+            // This capability was added with Spirv 1.1.
+            // Not returning any extension is valid in both cases.
+            {SPV_ENV_UNIVERSAL_1_0,    spv::Capability::SubgroupDispatch, {}},
+            {SPV_ENV_UNIVERSAL_1_1,    spv::Capability::SubgroupDispatch, {}},
+
+            // Groups can be used with SPV_AMD_shader_ballot if some opcodes
+            // are used, but it is also a core capability.
+            {SPV_ENV_UNIVERSAL_1_0, spv::Capability::Groups,  {}},
+
+            // This capability implies RayQueryKHR & RayTracingKHR, each depending on an extension.
+            {SPV_ENV_VULKAN_1_3, spv::Capability::RayTraversalPrimitiveCullingKHR,  { kSPV_KHR_ray_query, kSPV_KHR_ray_tracing }},
+
+            // PerViewAttributesNV implies MultiView. But the extension is enough to allow the
+            // MultiView capability, even in 1.0 (No need for SPV_KHR_multiview).
+            {SPV_ENV_VULKAN_1_0, spv::Capability::PerViewAttributesNV,  { kSPV_NVX_multiview_per_view_attributes }},
+            {SPV_ENV_VULKAN_1_3, spv::Capability::PerViewAttributesNV,  { kSPV_NVX_multiview_per_view_attributes }},
+
+            // This capability can be enabled by either the core, of the vendor extension.
+            {SPV_ENV_VULKAN_1_3, spv::Capability::FragmentBarycentricKHR,
+              { kSPV_NV_fragment_shader_barycentric, kSPV_KHR_fragment_shader_barycentric }},
+
+            // clang-format on
         }),
     AssemblyGrammarExtensionTest::PrintToStringParamName);
 

--- a/test/assembly_grammar_test.cpp
+++ b/test/assembly_grammar_test.cpp
@@ -90,6 +90,10 @@ TEST_P(AssemblyGrammarTest, ReportsCorrectTargetEnv) {
   EXPECT_EQ(grammar().target_env(), target_env());
 }
 
+INSTANTIATE_TEST_SUITE_P(
+    AssemblyGrammarTestSuite, AssemblyGrammarTest,
+    ValuesIn(spvtest::AllTargetEnvironments()));
+
 TEST_P(AssemblyGrammarExtensionTest, CheckExtensionDeclaredForCapability) {
   const spv_target_env target_env = std::get<0>(GetParam());
   spv_context context = spvContextCreate(target_env);


### PR DESCRIPTION
This new function allows one to retrieve the extensions needed to declare a set of capabilities.
This would be used by the capability trimming pass.