### PR TITLE
NFC: fix missing algorithm include in enumset file

### DIFF
--- a/source/enum_set.h
+++ b/source/enum_set.h
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <functional>


### PR DESCRIPTION
Caused issues with vs2017, required for std::min.