### PR TITLE
kokoro: rename glslang

### DIFF
--- a/kokoro/scripts/linux/build-docker.sh
+++ b/kokoro/scripts/linux/build-docker.sh
@@ -142,7 +142,7 @@ elif [ $TOOL = "cmake-smoketest" ]; then
   cmake -GNinja -DRE2_BUILD_TESTING=OFF -DCMAKE_BUILD_TYPE="Release" ..
 
   echo $(date): Build glslang...
-  ninja glslangValidator
+  ninja glslang
 
   echo $(date): Build everything...
   ninja

--- a/kokoro/scripts/linux/build-docker.sh
+++ b/kokoro/scripts/linux/build-docker.sh
@@ -142,7 +142,7 @@ elif [ $TOOL = "cmake-smoketest" ]; then
   cmake -GNinja -DRE2_BUILD_TESTING=OFF -DCMAKE_BUILD_TYPE="Release" ..
 
   echo $(date): Build glslang...
-  ninja glslang
+  ninja glslang-standalone
 
   echo $(date): Build everything...
   ninja


### PR DESCRIPTION
glslangValidator was renamed to glslang
(https://github.com/KhronosGroup/glslang/pull/3257). Fixing build.