### PR TITLE
build: fix missing files in BUILD.gn

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -182,6 +182,7 @@ SPVTOOLS_OPT_SRC_FILES := \
 		source/opt/strip_debug_info_pass.cpp \
 		source/opt/strip_nonsemantic_info_pass.cpp \
 		source/opt/struct_cfg_analysis.cpp \
+		source/opt/trim_capabilities_pass.cpp \
 		source/opt/type_manager.cpp \
 		source/opt/types.cpp \
 		source/opt/unify_const_pass.cpp \

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -790,6 +790,8 @@ static_library("spvtools_opt") {
     "source/opt/struct_cfg_analysis.cpp",
     "source/opt/struct_cfg_analysis.h",
     "source/opt/tree_iterator.h",
+    "source/opt/trim_capabilities_pass.cpp",
+    "source/opt/trim_capabilities_pass.h",
     "source/opt/type_manager.cpp",
     "source/opt/type_manager.h",
     "source/opt/types.cpp",


### PR DESCRIPTION
PR #5278 added 2 new files, but they were not added to the BUILD.gn file. Fixing this.
Same for the Android.mk.

Fixes #5350