### PR TITLE
opt: fix missing CreateTrimCapabilitiesPass definition

### DIFF
--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -1071,6 +1071,11 @@ Optimizer::PassToken CreateFixFuncCallArgumentsPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::FixFuncCallArgumentsPass>());
 }
+
+Optimizer::PassToken CreateTrimCapabilitiesPass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::TrimCapabilitiesPass>());
+}
 }  // namespace spvtools
 
 extern "C" {


### PR DESCRIPTION
This function was unused, so we missed the lack of definition.
Found-out when integrating with DXC.