### PR TITLE
opt: fix StorageInputOutput16 trimming.

### DIFF
--- a/source/opt/trim_capabilities_pass.cpp
+++ b/source/opt/trim_capabilities_pass.cpp
@@ -20,6 +20,7 @@
 #include <functional>
 #include <optional>
 #include <queue>
+#include <stack>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -27,6 +28,7 @@
 #include "source/enum_set.h"
 #include "source/enum_string_mapping.h"
 #include "source/opt/ir_context.h"
+#include "source/opt/reflect.h"
 #include "source/spirv_target_env.h"
 #include "source/util/string_utils.h"
 
@@ -34,52 +36,27 @@ namespace spvtools {
 namespace opt {
 
 namespace {
-constexpr uint32_t kVariableStorageClassIndex = 0;
+constexpr uint32_t kOpTypePointerStorageClassIndex = 0;
 constexpr uint32_t kTypeArrayTypeIndex = 0;
 constexpr uint32_t kOpTypeScalarBitWidthIndex = 0;
 constexpr uint32_t kTypePointerTypeIdInIdx = 1;
-}  // namespace
 
-// ============== Begin opcode handler implementations. =======================
-//
-// Adding support for a new capability should only require adding a new handler,
-// and updating the
-// kSupportedCapabilities/kUntouchableCapabilities/kFordiddenCapabilities lists.
-//
-// Handler names follow the following convention:
-//  Handler_<Opcode>_<Capability>()
-
-static std::optional<spv::Capability> Handler_OpVariable_StorageInputOutput16(
-    const Instruction* instruction) {
-  assert(instruction->opcode() == spv::Op::OpVariable &&
-         "This handler only support OpVariable opcodes.");
-
-  // This capability is only required if the variable as an Input/Output storage
-  // class.
-  spv::StorageClass storage_class = spv::StorageClass(
-      instruction->GetSingleWordInOperand(kVariableStorageClassIndex));
-  if (storage_class != spv::StorageClass::Input &&
-      storage_class != spv::StorageClass::Output) {
-    return std::nullopt;
-  }
-
-  // This capability is only required if the type involves a 16-bit component.
-  // Quick check: are 16-bit types allowed?
-  const CapabilitySet& capabilities =
-      instruction->context()->get_feature_mgr()->GetCapabilities();
-  if (!capabilities.contains(spv::Capability::Float16) &&
-      !capabilities.contains(spv::Capability::Int16)) {
-    return std::nullopt;
-  }
-
-  // We need to walk the type definition.
-  std::queue<uint32_t> instructions_to_visit;
-  instructions_to_visit.push(instruction->type_id());
+// DFS visit of the type defined by `instruction`.
+// If `condition` is true, children of the current node are visited.
+// If `condition` is false, the children of the current node are ignored.
+template <class UnaryPredicate>
+static void DFSWhile(const Instruction* instruction, UnaryPredicate condition) {
+  std::stack<uint32_t> instructions_to_visit;
+  instructions_to_visit.push(instruction->result_id());
   const auto* def_use_mgr = instruction->context()->get_def_use_mgr();
+
   while (!instructions_to_visit.empty()) {
-    const Instruction* item =
-        def_use_mgr->GetDef(instructions_to_visit.front());
+    const Instruction* item = def_use_mgr->GetDef(instructions_to_visit.top());
     instructions_to_visit.pop();
+
+    if (!condition(item)) {
+      continue;
+    }
 
     if (item->opcode() == spv::Op::OpTypePointer) {
       instructions_to_visit.push(
@@ -102,23 +79,83 @@ static std::optional<spv::Capability> Handler_OpVariable_StorageInputOutput16(
       });
       continue;
     }
+  }
+}
 
-    if (item->opcode() != spv::Op::OpTypeInt &&
-        item->opcode() != spv::Op::OpTypeFloat) {
-      continue;
+// Walks the type defined by `instruction` (OpType* only).
+// Returns `true` if any call to `predicate` with the type/subtype returns true.
+template <class UnaryPredicate>
+static bool AnyTypeOf(const Instruction* instruction,
+                      UnaryPredicate predicate) {
+  assert(IsTypeInst(instruction->opcode()) &&
+         "AnyTypeOf called with a non-type instruction.");
+
+  bool found_one = false;
+  DFSWhile(instruction, [&found_one, predicate](const Instruction* node) {
+    if (found_one || predicate(node)) {
+      found_one = true;
+      return false;
     }
 
-    if (item->GetSingleWordInOperand(kOpTypeScalarBitWidthIndex) == 16) {
-      return spv::Capability::StorageInputOutput16;
-    }
+    return true;
+  });
+  return found_one;
+}
+
+static bool is16bitType(const Instruction* instruction) {
+  if (instruction->opcode() != spv::Op::OpTypeInt &&
+      instruction->opcode() != spv::Op::OpTypeFloat) {
+    return false;
   }
 
-  return std::nullopt;
+  return instruction->GetSingleWordInOperand(kOpTypeScalarBitWidthIndex) == 16;
+}
+
+static bool Has16BitCapability(const FeatureManager* feature_manager) {
+  const CapabilitySet& capabilities = feature_manager->GetCapabilities();
+  return capabilities.contains(spv::Capability::Float16) ||
+         capabilities.contains(spv::Capability::Int16);
+}
+
+}  // namespace
+
+// ============== Begin opcode handler implementations. =======================
+//
+// Adding support for a new capability should only require adding a new handler,
+// and updating the
+// kSupportedCapabilities/kUntouchableCapabilities/kFordiddenCapabilities lists.
+//
+// Handler names follow the following convention:
+//  Handler_<Opcode>_<Capability>()
+
+static std::optional<spv::Capability>
+Handler_OpTypePointer_StorageInputOutput16(const Instruction* instruction) {
+  assert(instruction->opcode() == spv::Op::OpTypePointer &&
+         "This handler only support OpTypePointer opcodes.");
+
+  // This capability is only required if the variable as an Input/Output storage
+  // class.
+  spv::StorageClass storage_class = spv::StorageClass(
+      instruction->GetSingleWordInOperand(kOpTypePointerStorageClassIndex));
+  if (storage_class != spv::StorageClass::Input &&
+      storage_class != spv::StorageClass::Output) {
+    return std::nullopt;
+  }
+
+  if (!Has16BitCapability(instruction->context()->get_feature_mgr())) {
+    return std::nullopt;
+  }
+
+  return AnyTypeOf(instruction, is16bitType)
+             ? std::optional(spv::Capability::StorageInputOutput16)
+             : std::nullopt;
 }
 
 // Opcode of interest to determine capabilities requirements.
 constexpr std::array<std::pair<spv::Op, OpcodeHandler>, 1> kOpcodeHandlers{{
-    {spv::Op::OpVariable, Handler_OpVariable_StorageInputOutput16},
+    // clang-format off
+    {spv::Op::OpTypePointer, Handler_OpTypePointer_StorageInputOutput16},
+    // clang-format on
 }};
 
 // ==============  End opcode handler implementations.  =======================
@@ -159,8 +196,9 @@ TrimCapabilitiesPass::TrimCapabilitiesPass()
 void TrimCapabilitiesPass::addInstructionRequirements(
     Instruction* instruction, CapabilitySet* capabilities,
     ExtensionSet* extensions) const {
-  // Ignoring OpCapability instructions.
-  if (instruction->opcode() == spv::Op::OpCapability) {
+  // Ignoring OpCapability and OpExtension instructions.
+  if (instruction->opcode() == spv::Op::OpCapability ||
+      instruction->opcode() == spv::Op::OpExtension) {
     return;
   }
 
@@ -170,13 +208,8 @@ void TrimCapabilitiesPass::addInstructionRequirements(
     auto result =
         context()->grammar().lookupOpcode(instruction->opcode(), &desc);
     if (result == SPV_SUCCESS) {
-      addSupportedCapabilitiesToSet(desc->numCapabilities, desc->capabilities,
-                                    capabilities);
-      if (desc->minVersion <=
-          spvVersionForTargetEnv(context()->GetTargetEnv())) {
-        extensions->insert(desc->extensions,
-                           desc->extensions + desc->numExtensions);
-      }
+      addSupportedCapabilitiesToSet(desc, capabilities);
+      addSupportedExtensionsToSet(desc, extensions);
     }
   }
 
@@ -190,7 +223,9 @@ void TrimCapabilitiesPass::addInstructionRequirements(
     }
 
     // No supported capability relies on a literal string operand.
-    if (operand.type == SPV_OPERAND_TYPE_LITERAL_STRING) {
+    if (operand.type == SPV_OPERAND_TYPE_LITERAL_STRING ||
+        operand.type == SPV_OPERAND_TYPE_ID ||
+        operand.type == SPV_OPERAND_TYPE_RESULT_ID) {
       continue;
     }
 
@@ -201,12 +236,8 @@ void TrimCapabilitiesPass::addInstructionRequirements(
       continue;
     }
 
-    addSupportedCapabilitiesToSet(desc->numCapabilities, desc->capabilities,
-                                  capabilities);
-    if (desc->minVersion <= spvVersionForTargetEnv(context()->GetTargetEnv())) {
-      extensions->insert(desc->extensions,
-                         desc->extensions + desc->numExtensions);
-    }
+    addSupportedCapabilitiesToSet(desc, capabilities);
+    addSupportedExtensionsToSet(desc, extensions);
   }
 
   // Last case: some complex logic needs to be run to determine capabilities.
@@ -214,10 +245,23 @@ void TrimCapabilitiesPass::addInstructionRequirements(
   for (auto it = begin; it != end; it++) {
     const OpcodeHandler handler = it->second;
     auto result = handler(instruction);
-    if (result.has_value()) {
-      capabilities->insert(*result);
+    if (!result.has_value()) {
+      continue;
     }
+
+    capabilities->insert(*result);
   }
+}
+
+void TrimCapabilitiesPass::AddExtensionsForOperand(
+    const spv_operand_type_t type, const uint32_t value,
+    ExtensionSet* extensions) const {
+  const spv_operand_desc_t* desc = nullptr;
+  spv_result_t result = context()->grammar().lookupOperand(type, value, &desc);
+  if (result != SPV_SUCCESS) {
+    return;
+  }
+  addSupportedExtensionsToSet(desc, extensions);
 }
 
 std::pair<CapabilitySet, ExtensionSet>
@@ -229,6 +273,12 @@ TrimCapabilitiesPass::DetermineRequiredCapabilitiesAndExtensions() const {
     addInstructionRequirements(instruction, &required_capabilities,
                                &required_extensions);
   });
+
+  for (auto capability : required_capabilities) {
+    AddExtensionsForOperand(SPV_OPERAND_TYPE_CAPABILITY,
+                            static_cast<uint32_t>(capability),
+                            &required_extensions);
+  }
 
 #if !defined(NDEBUG)
   // Debug only. We check the outputted required capabilities against the
@@ -254,11 +304,6 @@ Pass::Status TrimCapabilitiesPass::TrimUnrequiredCapabilities(
   const FeatureManager* feature_manager = context()->get_feature_mgr();
   CapabilitySet capabilities_to_trim;
   for (auto capability : feature_manager->GetCapabilities()) {
-    // Forbidden capability completely prevents trimming. Early exit.
-    if (forbiddenCapabilities_.contains(capability)) {
-      return Pass::Status::SuccessWithoutChange;
-    }
-
     // Some capabilities cannot be safely removed. Leaving them untouched.
     if (untouchableCapabilities_.contains(capability)) {
       continue;
@@ -291,9 +336,12 @@ Pass::Status TrimCapabilitiesPass::TrimUnrequiredExtensions(
 
   bool modified_module = false;
   for (auto extension : supported_extensions) {
-    if (!required_extensions.contains(extension)) {
+    if (required_extensions.contains(extension)) {
+      continue;
+    }
+
+    if (context()->RemoveExtension(extension)) {
       modified_module = true;
-      context()->RemoveExtension(extension);
     }
   }
 
@@ -301,19 +349,31 @@ Pass::Status TrimCapabilitiesPass::TrimUnrequiredExtensions(
                          : Pass::Status::SuccessWithoutChange;
 }
 
+bool TrimCapabilitiesPass::HasForbiddenCapabilities() const {
+  // EnumSet.HasAnyOf returns `true` if the given set is empty.
+  if (forbiddenCapabilities_.size() == 0) {
+    return false;
+  }
+
+  const auto& capabilities = context()->get_feature_mgr()->GetCapabilities();
+  return capabilities.HasAnyOf(forbiddenCapabilities_);
+}
+
 Pass::Status TrimCapabilitiesPass::Process() {
+  if (HasForbiddenCapabilities()) {
+    return Status::SuccessWithoutChange;
+  }
+
   auto[required_capabilities, required_extensions] =
       DetermineRequiredCapabilitiesAndExtensions();
 
-  Pass::Status status = TrimUnrequiredCapabilities(required_capabilities);
-  // If no capabilities were removed, we have no extension to trim.
-  // Note: this is true because this pass only removes unused extensions caused
-  // by unused capabilities.
-  //       This is not an extension trimming pass.
-  if (status == Pass::Status::SuccessWithoutChange) {
-    return status;
-  }
-  return TrimUnrequiredExtensions(required_extensions);
+  Pass::Status capStatus = TrimUnrequiredCapabilities(required_capabilities);
+  Pass::Status extStatus = TrimUnrequiredExtensions(required_extensions);
+
+  return capStatus == Pass::Status::SuccessWithChange ||
+                 extStatus == Pass::Status::SuccessWithChange
+             ? Pass::Status::SuccessWithChange
+             : Pass::Status::SuccessWithoutChange;
 }
 
 }  // namespace opt

--- a/source/opt/trim_capabilities_pass.h
+++ b/source/opt/trim_capabilities_pass.h
@@ -27,6 +27,7 @@
 #include "source/opt/ir_context.h"
 #include "source/opt/module.h"
 #include "source/opt/pass.h"
+#include "source/spirv_target_env.h"
 
 namespace spvtools {
 namespace opt {
@@ -99,24 +100,47 @@ class TrimCapabilitiesPass : public Pass {
   TrimCapabilitiesPass(TrimCapabilitiesPass&&) = delete;
 
  private:
-  // Inserts every capability in `capabilities[capabilityCount]` supported by
-  // this pass into `output`.
-  inline void addSupportedCapabilitiesToSet(
-      uint32_t capabilityCount, const spv::Capability* const capabilities,
-      CapabilitySet* output) const {
+  // Inserts every capability listed by `descriptor` this pass supports into
+  // `output`. Expects a Descritor like `spv_opcode_desc_t` or
+  // `spv_operand_desc_t`.
+  template <class Descriptor>
+  inline void addSupportedCapabilitiesToSet(const Descriptor* const descriptor,
+                                            CapabilitySet* output) const {
+    const uint32_t capabilityCount = descriptor->numCapabilities;
     for (uint32_t i = 0; i < capabilityCount; ++i) {
-      if (supportedCapabilities_.contains(capabilities[i])) {
-        output->insert(capabilities[i]);
+      const auto capability = descriptor->capabilities[i];
+      if (supportedCapabilities_.contains(capability)) {
+        output->insert(capability);
       }
     }
   }
 
-  // Given an `instruction`, determines the capabilities and extension it
-  // requires, and output them in `capabilities` and `extensions`. The returned
-  // capabilities form a subset of kSupportedCapabilities.
+  // Inserts every extension listed by `descriptor` required by the module into
+  // `output`. Expects a Descritor like `spv_opcode_desc_t` or
+  // `spv_operand_desc_t`.
+  template <class Descriptor>
+  inline void addSupportedExtensionsToSet(const Descriptor* const descriptor,
+                                          ExtensionSet* output) const {
+    if (descriptor->minVersion <=
+        spvVersionForTargetEnv(context()->GetTargetEnv())) {
+      return;
+    }
+    output->insert(descriptor->extensions,
+                   descriptor->extensions + descriptor->numExtensions);
+  }
+
+  // Given an `instruction`, determines the capabilities it requires, and output
+  // them in `capabilities`. The returned capabilities form a subset of
+  // kSupportedCapabilities.
   void addInstructionRequirements(Instruction* instruction,
                                   CapabilitySet* capabilities,
                                   ExtensionSet* extensions) const;
+
+  // Given an operand `type` and `value`, adds the extensions it would require
+  // to `extensions`.
+  void AddExtensionsForOperand(const spv_operand_type_t type,
+                               const uint32_t value,
+                               ExtensionSet* extensions) const;
 
   // Returns the list of required capabilities and extensions for the module.
   // The returned capabilities form a subset of kSupportedCapabilities.
@@ -133,6 +157,9 @@ class TrimCapabilitiesPass : public Pass {
   // pass support requires it.
   Pass::Status TrimUnrequiredExtensions(
       const ExtensionSet& required_extensions) const;
+
+  // Returns if the analyzed module contains any forbidden capability.
+  bool HasForbiddenCapabilities() const;
 
  public:
   const char* name() const override { return "trim-capabilities"; }


### PR DESCRIPTION
While integrating this pass into DXC, I found a lot of missing cases. This PR fixes a few issues centered around this capability while laying out fondations for more fixes.

1. The grammar can define extensions in operand & opcode tables.
   - opcode can rely on common capabilities, but require a new extension.
   - opcode can also rely on a capability which requires an extension. Sometimes, the extension is listed twice, in the opcode, and capability. But this redundancy is not guaranteed.

2. minVersion check. The condition was flipped: we added the extension when the minVersion was less than current. Didn't noticed the issue as I only tests on the default env.

3. Capability/Extension instructions were not ignored.
   - `OpCapability Foo` will require the `Foo` capability.
   - it doesn't mean the module requires the `Foo` capability. Same for extensions.

This commit adds disabled tests, for fixes which are too large to be brought into this already large PR.