### PR TITLE
Use absolute path to depot_tools

### DIFF
--- a/.github/workflows/autoroll.yml
+++ b/.github/workflows/autoroll.yml
@@ -23,7 +23,7 @@ jobs:
         run: git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
 
       - name: Update PATH
-        run: echo "./depot_tools" >> $GITHUB_PATH
+        run: echo "$(pwd)/depot_tools" >> $GITHUB_PATH
 
       - name: Download dependencies
         run: python3 utils/git-sync-deps


### PR DESCRIPTION
The autoroll workflow is currently failing due to being unable to find some depot_tools executables. This is due to a limitation in Go os/exec which effectively rejects all relative paths in PATH, and is exposed by a recent update to depot_tools
(https://crrev.com/43083529de5802a83f53f1d53d7f5f9615999996).