### PR TITLE
Update SPIRV-Headers; test some coop matrix enums

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -13,7 +13,7 @@ vars = {
   'protobuf_revision': 'v21.12',
 
   're2_revision': '960c861764ff54c9a12ff683ba55ccaad1a8f73b',
-  'spirv_headers_revision': 'ae89923fa781650569ca15e5b498a9e4e46ee9c9',
+  'spirv_headers_revision': '124a9665e464ef98b8b718d572d5f329311061eb',
 }
 
 deps = {

--- a/test/val/val_arithmetics_test.cpp
+++ b/test/val/val_arithmetics_test.cpp
@@ -1555,7 +1555,10 @@ TEST_F(ValidateArithmetics, CoopMatKHRSuccess) {
 %val14 = OpMatrixTimesScalar %u32matA %u32mat_A_1 %u32_1
 %val15 = OpMatrixTimesScalar %s32matA %s32mat_A_1 %s32_1
 %val16 = OpCooperativeMatrixMulAddKHR %f32matC %f16mat_A_1 %f16mat_B_1 %f16mat_C_1
-%val17 = OpCooperativeMatrixMulAddKHR %s32matC %s32mat_A_1 %s32mat_B_1 %s32mat_C_1)";
+%val17 = OpCooperativeMatrixMulAddKHR %s32matC %s32mat_A_1 %s32mat_B_1 %s32mat_C_1
+  MatrixASignedComponentsKHR|MatrixBSignedComponentsKHR|MatrixCSignedComponentsKHR|MatrixResultSignedComponentsKHR
+%val18 = OpCooperativeMatrixMulAddKHR %u32matC %u32mat_A_1 %u32mat_B_1 %u32mat_C_1
+)";
 
   CompileSuccessfully(GenerateCoopMatKHRCode("", body).c_str());
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());


### PR DESCRIPTION
Test:
  MatrixASignedComponentsKHR
  MatrixBSignedComponentsKHR
  MatrixCSignedComponentsKHR
  ResultSignedComponentsKHR