### PR TITLE
opt: add bitmask support for capability trimming

### DIFF
--- a/source/opt/trim_capabilities_pass.h
+++ b/source/opt/trim_capabilities_pass.h
@@ -132,6 +132,13 @@ class TrimCapabilitiesPass : public Pass {
                    descriptor->extensions + descriptor->numExtensions);
   }
 
+  void addInstructionRequirementsForOpcode(spv::Op opcode,
+                                           CapabilitySet* capabilities,
+                                           ExtensionSet* extensions) const;
+  void addInstructionRequirementsForOperand(const Operand& operand,
+                                            CapabilitySet* capabilities,
+                                            ExtensionSet* extensions) const;
+
   // Given an `instruction`, determines the capabilities it requires, and output
   // them in `capabilities`. The returned capabilities form a subset of
   // kSupportedCapabilities.

--- a/test/opt/trim_capabilities_pass_test.cpp
+++ b/test/opt/trim_capabilities_pass_test.cpp
@@ -517,9 +517,7 @@ TEST_F(TrimCapabilitiesPassTest,
   EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithoutChange);
 }
 
-// FIXME(Keenuts): Add support for bitmask operands.
-TEST_F(TrimCapabilitiesPassTest,
-       DISABLED_MinLod_DetectsMinLodWithBitmaskImageOperand) {
+TEST_F(TrimCapabilitiesPassTest, MinLod_DetectsMinLodWithBitmaskImageOperand) {
   const std::string kTest = R"(
                             OpCapability MinLod
 ; CHECK:                    OpCapability MinLod


### PR DESCRIPTION
Some operands are not simple values, but bitmasks. The lookup in the table for required decomposing the mask into single values.
This commit adds support for such operands, like MinLod|Offset.