### PR TITLE
linker: Add --use-first-entrypoint option

### DIFF
--- a/include/spirv-tools/linker.hpp
+++ b/include/spirv-tools/linker.hpp
@@ -63,10 +63,16 @@ class LinkerOptions {
     allow_partial_linkage_ = allow_partial_linkage;
   }
 
+  bool GetUseFirstEntrypoint() const { return use_first_entrypoint_; }
+  void SetUseFirstEntrypoint(bool use_first_entry) {
+    use_first_entrypoint_ = use_first_entry;
+  }
+
  private:
-  bool create_library_;
-  bool verify_ids_;
-  bool allow_partial_linkage_;
+  bool create_library_{false};
+  bool verify_ids_{false};
+  bool allow_partial_linkage_{false};
+  bool use_first_entrypoint_{false};
 };
 
 // Links one or more SPIR-V modules into a new SPIR-V module. That is, combine

--- a/test/link/entry_points_test.cpp
+++ b/test/link/entry_points_test.cpp
@@ -147,5 +147,40 @@ OpFunctionEnd
   EXPECT_THAT(GetErrorMessage(), std::string());
 }
 
+TEST_F(EntryPoints, UseFirstEntrypoint) {
+  const std::string body1 = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %3 "main"
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+  const std::string body2 = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %3 "main"
+%1 = OpTypeVoid
+%2 = OpTypeFunction %1
+%3 = OpFunction %1 None %2
+%4 = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  LinkerOptions options;
+  options.SetUseFirstEntrypoint(true);
+
+  spvtest::Binary linked_binary;
+  EXPECT_EQ(SPV_SUCCESS,
+            AssembleAndLink({body1, body2}, &linked_binary, options));
+  EXPECT_THAT(GetErrorMessage(), std::string());
+  EXPECT_TRUE(Validate(linked_binary));
+  EXPECT_THAT(GetErrorMessage(), std::string());
+}
+
 }  // namespace
 }  // namespace spvtools

--- a/tools/link/linker.cpp
+++ b/tools/link/linker.cpp
@@ -59,6 +59,9 @@ Options (in lexicographical order):
                NOTE: The SPIR-V version used by the linked binary module
                depends only on the version of the inputs, and is not affected
                by this option.
+  --use-first-entrypoint
+               Use the entrypoint from the first input file and ignore any
+	       in subsequent input files.
   --verify-ids
                Verify that IDs in the resulting modules are truly unique.
   --version
@@ -78,6 +81,7 @@ FLAG_LONG_bool(   create_library,        /* default_value= */ false,            
 FLAG_LONG_bool(   allow_partial_linkage, /* default_value= */ false,               /* required= */ false);
 FLAG_SHORT_string(o,                     /* default_value= */ "",                  /* required= */ false);
 FLAG_LONG_string( target_env,            /* default_value= */ kDefaultEnvironment, /* required= */ false);
+FLAG_LONG_bool(   use_first_entrypoint,  /* default_value= */ false,               /* required= */ false);
 // clang-format on
 
 int main(int, const char* argv[]) {
@@ -120,6 +124,7 @@ int main(int, const char* argv[]) {
   options.SetAllowPartialLinkage(flags::allow_partial_linkage.value());
   options.SetCreateLibrary(flags::create_library.value());
   options.SetVerifyIds(flags::verify_ids.value());
+  options.SetUseFirstEntrypoint(flags::use_first_entrypoint.value());
 
   if (inFiles.empty()) {
     fprintf(stderr, "error: No input file specified\n");


### PR DESCRIPTION
Currently spirv-link adds all entrypoints found in input files into the output file. If multiple input files define the same entrypoint, linking fails.

When this option is set, the entrypoints defined in the first input file are used in the output and any entrypoints found in subsequent input files are ignored.