### PR TITLE
misc: prevent autoroll to run on forks

### DIFF
--- a/.github/workflows/autoroll.yml
+++ b/.github/workflows/autoroll.yml
@@ -14,6 +14,7 @@ jobs:
       pull-requests: write
     name: Update dependencies
     runs-on: ubuntu-latest
+    if: github.repository == 'KhronosGroup/SPIRV-Tools'
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This requires some setup on the repo (kokoro labels by ex).
Disabling this to avoid spamming forks each day with a "workflow failed" notification.