### PR TITLE
opt: add FragmentShader*InterlockEXT to capability trim pass

### DIFF
--- a/source/opt/trim_capabilities_pass.cpp
+++ b/source/opt/trim_capabilities_pass.cpp
@@ -368,6 +368,13 @@ void TrimCapabilitiesPass::addInstructionRequirements(
     return;
   }
 
+  // Ignoring OpBeginInvocationInterlockEXT and OpEndInvocationInterlockEXT
+  // because they have three possible capabilities, only one of which is needed
+  if (instruction->opcode() == spv::Op::OpBeginInvocationInterlockEXT ||
+      instruction->opcode() == spv::Op::OpEndInvocationInterlockEXT) {
+    return;
+  }
+
   addInstructionRequirementsForOpcode(instruction->opcode(), capabilities,
                                       extensions);
 

--- a/source/opt/trim_capabilities_pass.cpp
+++ b/source/opt/trim_capabilities_pass.cpp
@@ -303,6 +303,13 @@ TrimCapabilitiesPass::TrimCapabilitiesPass()
 void TrimCapabilitiesPass::addInstructionRequirementsForOpcode(
     spv::Op opcode, CapabilitySet* capabilities,
     ExtensionSet* extensions) const {
+  // Ignoring OpBeginInvocationInterlockEXT and OpEndInvocationInterlockEXT
+  // because they have three possible capabilities, only one of which is needed
+  if (opcode == spv::Op::OpBeginInvocationInterlockEXT ||
+      opcode == spv::Op::OpEndInvocationInterlockEXT) {
+    return;
+  }
+
   const spv_opcode_desc_t* desc = {};
   auto result = context()->grammar().lookupOpcode(opcode, &desc);
   if (result != SPV_SUCCESS) {
@@ -365,13 +372,6 @@ void TrimCapabilitiesPass::addInstructionRequirements(
   // Ignoring OpCapability and OpExtension instructions.
   if (instruction->opcode() == spv::Op::OpCapability ||
       instruction->opcode() == spv::Op::OpExtension) {
-    return;
-  }
-
-  // Ignoring OpBeginInvocationInterlockEXT and OpEndInvocationInterlockEXT
-  // because they have three possible capabilities, only one of which is needed
-  if (instruction->opcode() == spv::Op::OpBeginInvocationInterlockEXT ||
-      instruction->opcode() == spv::Op::OpEndInvocationInterlockEXT) {
     return;
   }
 

--- a/source/opt/trim_capabilities_pass.h
+++ b/source/opt/trim_capabilities_pass.h
@@ -74,6 +74,9 @@ class TrimCapabilitiesPass : public Pass {
   // contains unsupported instruction, the pass could yield bad results.
   static constexpr std::array kSupportedCapabilities{
       // clang-format off
+      spv::Capability::FragmentShaderPixelInterlockEXT,
+      spv::Capability::FragmentShaderSampleInterlockEXT,
+      spv::Capability::FragmentShaderShadingRateInterlockEXT,
       spv::Capability::Groups,
       spv::Capability::Linkage,
       spv::Capability::MinLod,

--- a/test/opt/trim_capabilities_pass_test.cpp
+++ b/test/opt/trim_capabilities_pass_test.cpp
@@ -1392,6 +1392,202 @@ TEST_F(TrimCapabilitiesPassTest,
   EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
 }
 
+TEST_F(TrimCapabilitiesPassTest, FragmentShaderRemoved) {
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpCapability FragmentShaderPixelInterlockEXT
+               OpCapability FragmentShaderSampleInterlockEXT
+               OpCapability FragmentShaderShadingRateInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+; CHECK-NOT:   OpCapability FragmentShaderPixelInterlockEXT
+; CHECK-NOT:   OpCapability FragmentShaderSampleInterlockEXT
+; CHECK-NOT:   OpCapability FragmentShaderShadingRateInterlockEXT
+; CHECK-NOT:   OpExtension "SPV_EXT_fragment_shader_interlock"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %1 "main"
+       %void = OpTypeVoid
+          %1 = OpTypeFunction %void
+          %2 = OpFunction %void None %1
+          %3 = OpLabel
+               OpReturn
+               OpFunctionEnd;
+  )";
+  const auto result =
+      SinglePassRunAndMatch<TrimCapabilitiesPass>(kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+TEST_F(TrimCapabilitiesPassTest, FragmentShaderPixelInterlockOrderedRemains) {
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpCapability FragmentShaderPixelInterlockEXT
+               OpCapability FragmentShaderSampleInterlockEXT
+               OpCapability FragmentShaderShadingRateInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+; CHECK:       OpCapability FragmentShaderPixelInterlockEXT
+; CHECK-NOT:   OpCapability FragmentShaderSampleInterlockEXT
+; CHECK-NOT:   OpCapability FragmentShaderShadingRateInterlockEXT
+; CHECK:       OpExtension "SPV_EXT_fragment_shader_interlock"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %1 "main"
+               OpExecutionMode %main PixelInterlockOrderedEXT
+       %void = OpTypeVoid
+          %1 = OpTypeFunction %void
+          %2 = OpFunction %void None %1
+          %3 = OpLabel
+               OpBeginInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+               OpReturn
+               OpFunctionEnd;
+  )";
+  const auto result =
+      SinglePassRunAndMatch<TrimCapabilitiesPass>(kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+TEST_F(TrimCapabilitiesPassTest, FragmentShaderPixelInterlockUnorderedRemains) {
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpCapability FragmentShaderPixelInterlockEXT
+               OpCapability FragmentShaderSampleInterlockEXT
+               OpCapability FragmentShaderShadingRateInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+; CHECK:       OpCapability FragmentShaderPixelInterlockEXT
+; CHECK-NOT:   OpCapability FragmentShaderSampleInterlockEXT
+; CHECK-NOT:   OpCapability FragmentShaderShadingRateInterlockEXT
+; CHECK:       OpExtension "SPV_EXT_fragment_shader_interlock"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %1 "main"
+               OpExecutionMode %main PixelInterlockUnorderedEXT
+       %void = OpTypeVoid
+          %1 = OpTypeFunction %void
+          %2 = OpFunction %void None %1
+          %3 = OpLabel
+               OpBeginInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+               OpReturn
+               OpFunctionEnd;
+  )";
+  const auto result =
+      SinglePassRunAndMatch<TrimCapabilitiesPass>(kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+TEST_F(TrimCapabilitiesPassTest, FragmentShaderSampleInterlockOrderedRemains) {
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpCapability FragmentShaderPixelInterlockEXT
+               OpCapability FragmentShaderSampleInterlockEXT
+               OpCapability FragmentShaderShadingRateInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+; CHECK-NOT:   OpCapability FragmentShaderPixelInterlockEXT
+; CHECK:       OpCapability FragmentShaderSampleInterlockEXT
+; CHECK-NOT:   OpCapability FragmentShaderShadingRateInterlockEXT
+; CHECK:       OpExtension "SPV_EXT_fragment_shader_interlock"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %1 "main"
+               OpExecutionMode %main SampleInterlockOrderedEXT
+       %void = OpTypeVoid
+          %1 = OpTypeFunction %void
+          %2 = OpFunction %void None %1
+          %3 = OpLabel
+               OpBeginInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+               OpReturn
+               OpFunctionEnd;
+  )";
+  const auto result =
+      SinglePassRunAndMatch<TrimCapabilitiesPass>(kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+TEST_F(TrimCapabilitiesPassTest,
+       FragmentShaderSampleInterlockUnorderedRemains) {
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpCapability FragmentShaderPixelInterlockEXT
+               OpCapability FragmentShaderSampleInterlockEXT
+               OpCapability FragmentShaderShadingRateInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+; CHECK-NOT:   OpCapability FragmentShaderPixelInterlockEXT
+; CHECK:       OpCapability FragmentShaderSampleInterlockEXT
+; CHECK-NOT:   OpCapability FragmentShaderShadingRateInterlockEXT
+; CHECK:       OpExtension "SPV_EXT_fragment_shader_interlock"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %1 "main"
+               OpExecutionMode %main SampleInterlockUnorderedEXT
+       %void = OpTypeVoid
+          %1 = OpTypeFunction %void
+          %2 = OpFunction %void None %1
+          %3 = OpLabel
+               OpBeginInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+               OpReturn
+               OpFunctionEnd;
+  )";
+  const auto result =
+      SinglePassRunAndMatch<TrimCapabilitiesPass>(kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+TEST_F(TrimCapabilitiesPassTest,
+       FragmentShaderShadingRateInterlockOrderedRemains) {
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpCapability FragmentShaderPixelInterlockEXT
+               OpCapability FragmentShaderSampleInterlockEXT
+               OpCapability FragmentShaderShadingRateInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+; CHECK-NOT:   OpCapability FragmentShaderPixelInterlockEXT
+; CHECK-NOT:   OpCapability FragmentShaderSampleInterlockEXT
+; CHECK:       OpCapability FragmentShaderShadingRateInterlockEXT
+; CHECK:       OpExtension "SPV_EXT_fragment_shader_interlock"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %1 "main"
+               OpExecutionMode %main ShadingRateInterlockOrderedEXT
+       %void = OpTypeVoid
+          %1 = OpTypeFunction %void
+          %2 = OpFunction %void None %1
+          %3 = OpLabel
+               OpBeginInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+               OpReturn
+               OpFunctionEnd;
+  )";
+  const auto result =
+      SinglePassRunAndMatch<TrimCapabilitiesPass>(kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+TEST_F(TrimCapabilitiesPassTest,
+       FragmentShaderShadingRateInterlockUnorderedRemains) {
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpCapability FragmentShaderPixelInterlockEXT
+               OpCapability FragmentShaderSampleInterlockEXT
+               OpCapability FragmentShaderShadingRateInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+; CHECK-NOT:   OpCapability FragmentShaderPixelInterlockEXT
+; CHECK-NOT:   OpCapability FragmentShaderSampleInterlockEXT
+; CHECK:       OpCapability FragmentShaderShadingRateInterlockEXT
+; CHECK:       OpExtension "SPV_EXT_fragment_shader_interlock"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %1 "main"
+               OpExecutionMode %main ShadingRateInterlockUnorderedEXT
+       %void = OpTypeVoid
+          %1 = OpTypeFunction %void
+          %2 = OpFunction %void None %1
+          %3 = OpLabel
+               OpBeginInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+               OpReturn
+               OpFunctionEnd;
+  )";
+  const auto result =
+      SinglePassRunAndMatch<TrimCapabilitiesPass>(kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
 }  // namespace
 }  // namespace opt
 }  // namespace spvtools


### PR DESCRIPTION
This is part of adding rasterizer ordered views to DXC. `OpBeginInvocationInterlockEXT` and `OpEndInvocationInterlockEXT` require only one of the capabilities `FragmentShaderPixelInterlockEXT`, `FragmentShaderSampleInterlockEXT`, or `FragmentShaderShadingRateInterlockEXT` to be enabled. Which capability is needed will be based on which execution mode is chosen, so this code uses that for the capability and ignores the begin and end opcodes.