### PR TITLE
opt: add ImageMSArray capability to trim pass.

### DIFF
--- a/source/opt/trim_capabilities_pass.h
+++ b/source/opt/trim_capabilities_pass.h
@@ -89,7 +89,8 @@ class TrimCapabilitiesPass : public Pass {
       spv::Capability::StorageInputOutput16,
       spv::Capability::StoragePushConstant16,
       spv::Capability::StorageUniform16,
-      spv::Capability::StorageUniformBufferBlock16
+      spv::Capability::StorageUniformBufferBlock16,
+      spv::Capability::ImageMSArray
       // clang-format on
   };
 


### PR DESCRIPTION
From the Capability's text in the SPIRV spec:

```
An MS operand in OpTypeImage indicates multisampled, used with an
OpTypeImage having Sampled == 2 and Arrayed == 1.
```

Adding this logic to the capability trimming pass.