### PR TITLE
Fix `AddMemberDecoration` variable names.

### DIFF
--- a/source/opt/decoration_manager.h
+++ b/source/opt/decoration_manager.h
@@ -142,7 +142,7 @@ class DecorationManager {
                         uint32_t decoration_value);
 
   // Add |decoration, decoration_value| of |inst_id, member| to module.
-  void AddMemberDecoration(uint32_t member, uint32_t inst_id,
+  void AddMemberDecoration(uint32_t inst_id, uint32_t member,
                            uint32_t decoration, uint32_t decoration_value);
 
   friend bool operator==(const DecorationManager&, const DecorationManager&);


### PR DESCRIPTION
The prototype does not match the implementation.

Fixes Typo in declaration DecorationManager::AddMemberDecoration #5392