### PR TITLE
Update SPIRV-Headers, add cache control operand kinds

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -13,7 +13,7 @@ vars = {
   'protobuf_revision': 'v21.12',
 
   're2_revision': 'a807e8a3aac2cc33c77b7071efea54fcabe38e0c',
-  'spirv_headers_revision': 'd790ced752b5bfc06b6988baadef6eb2d16bdf96',
+  'spirv_headers_revision': 'fc7d2462765183c784a0c46beb13eee9e506a067',
 }
 
 deps = {

--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -297,6 +297,10 @@ typedef enum spv_operand_type_t {
   SPV_OPERAND_TYPE_INITIALIZATION_MODE_QUALIFIER,
   // Enum type from SPV_INTEL_global_variable_host_access
   SPV_OPERAND_TYPE_HOST_ACCESS_QUALIFIER,
+  // Enum type from SPV_INTEL_cache_controls
+  SPV_OPERAND_TYPE_LOAD_CACHE_CONTROL,
+  // Enum type from SPV_INTEL_cache_controls
+  SPV_OPERAND_TYPE_STORE_CACHE_CONTROL,
 
   // This is a sentinel value, and does not represent an operand type.
   // It should come last.

--- a/source/operand.cpp
+++ b/source/operand.cpp
@@ -216,6 +216,10 @@ const char* spvOperandTypeStr(spv_operand_type_t type) {
       return "initialization mode qualifier";
     case SPV_OPERAND_TYPE_HOST_ACCESS_QUALIFIER:
       return "host access qualifier";
+    case SPV_OPERAND_TYPE_LOAD_CACHE_CONTROL:
+      return "load cache control";
+    case SPV_OPERAND_TYPE_STORE_CACHE_CONTROL:
+      return "store cache control";
     case SPV_OPERAND_TYPE_IMAGE:
     case SPV_OPERAND_TYPE_OPTIONAL_IMAGE:
       return "image";
@@ -354,6 +358,8 @@ bool spvOperandIsConcrete(spv_operand_type_t type) {
     case SPV_OPERAND_TYPE_COOPERATIVE_MATRIX_USE:
     case SPV_OPERAND_TYPE_INITIALIZATION_MODE_QUALIFIER:
     case SPV_OPERAND_TYPE_HOST_ACCESS_QUALIFIER:
+    case SPV_OPERAND_TYPE_LOAD_CACHE_CONTROL:
+    case SPV_OPERAND_TYPE_STORE_CACHE_CONTROL:
       return true;
     default:
       break;

--- a/test/operand_capabilities_test.cpp
+++ b/test/operand_capabilities_test.cpp
@@ -266,25 +266,21 @@ INSTANTIATE_TEST_SUITE_P(
     SamplerAddressingMode, EnumCapabilityTest,
     Combine(Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1),
             ValuesIn(std::vector<EnumCapabilityCase>{
-                CASE1(SAMPLER_ADDRESSING_MODE, SamplerAddressingMode::None,
-                      Kernel),
-                CASE1(SAMPLER_ADDRESSING_MODE,
-                      SamplerAddressingMode::ClampToEdge, Kernel),
-                CASE1(SAMPLER_ADDRESSING_MODE, SamplerAddressingMode::Clamp,
-                      Kernel),
-                CASE1(SAMPLER_ADDRESSING_MODE, SamplerAddressingMode::Repeat,
-                      Kernel),
-                CASE1(SAMPLER_ADDRESSING_MODE,
-                      SamplerAddressingMode::RepeatMirrored, Kernel),
-            })));
+                CASE0(SAMPLER_ADDRESSING_MODE, SamplerAddressingMode::None),
+                CASE0(SAMPLER_ADDRESSING_MODE,
+                      SamplerAddressingMode::ClampToEdge),
+                CASE0(SAMPLER_ADDRESSING_MODE, SamplerAddressingMode::Clamp),
+                CASE0(SAMPLER_ADDRESSING_MODE, SamplerAddressingMode::Repeat),
+                CASE0(SAMPLER_ADDRESSING_MODE,
+                      SamplerAddressingMode::RepeatMirrored)})));
 
 // See SPIR-V Section 3.10 Sampler Filter Mode
 INSTANTIATE_TEST_SUITE_P(
     SamplerFilterMode, EnumCapabilityTest,
     Combine(Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1),
             ValuesIn(std::vector<EnumCapabilityCase>{
-                CASE1(SAMPLER_FILTER_MODE, SamplerFilterMode::Nearest, Kernel),
-                CASE1(SAMPLER_FILTER_MODE, SamplerFilterMode::Linear, Kernel),
+                CASE0(SAMPLER_FILTER_MODE, SamplerFilterMode::Nearest),
+                CASE0(SAMPLER_FILTER_MODE, SamplerFilterMode::Linear),
             })));
 
 // See SPIR-V Section 3.11 Image Format


### PR DESCRIPTION

    Update SPIRV-Headers, add cache control operand kinds
    
    Adds SPV_OPERAND_TYPE_LOAD_CACHE_CONTROL
    and  SPV_OPERAND_TYPE_STORE_CACHE_CONTROL,
    from SPV_INTEL_cache_controls
    
Fixes: #5404


    Update tests: remove Kernel from constant sampler enum dependencies
    
    This corresponds to header change
    https://github.com/KhronosGroup/SPIRV-Headers/pull/378


