### PR TITLE
Add a new legalization pass to dedupe invocation interlock instructions

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -136,6 +136,7 @@ SPVTOOLS_OPT_SRC_FILES := \
 		source/opt/instrument_pass.cpp \
 		source/opt/interface_var_sroa.cpp \
 		source/opt/interp_fixup_pass.cpp \
+		source/opt/invocation_interlock_placement_pass.cpp \
 		source/opt/ir_context.cpp \
 		source/opt/ir_loader.cpp \
 		source/opt/licm_pass.cpp \

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -693,6 +693,7 @@ static_library("spvtools_opt") {
     "source/opt/interface_var_sroa.h",
     "source/opt/interp_fixup_pass.cpp",
     "source/opt/interp_fixup_pass.h",
+    "source/opt/invocation_interlock_placement_pass.cpp",
     "source/opt/ir_builder.h",
     "source/opt/ir_context.cpp",
     "source/opt/ir_context.h",

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -994,6 +994,12 @@ Optimizer::PassToken CreateTrimCapabilitiesPass();
 // use the new value |ds_to|.
 Optimizer::PassToken CreateSwitchDescriptorSetPass(uint32_t ds_from,
                                                    uint32_t ds_to);
+
+// Creates an invocation interlock placement pass.
+// This pass will ensure that an entry point will only have at most one
+// OpBeginInterlockInvocationEXT and one OpEndInterlockInvocationEXT, in that
+// order
+Optimizer::PassToken CreateInvocationInterlockPlacementPass();
 }  // namespace spvtools
 
 #endif  // INCLUDE_SPIRV_TOOLS_OPTIMIZER_HPP_

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -996,9 +996,9 @@ Optimizer::PassToken CreateSwitchDescriptorSetPass(uint32_t ds_from,
                                                    uint32_t ds_to);
 
 // Creates an invocation interlock placement pass.
-// This pass will ensure that an entry point will only have at most one
+// This pass ensures that an entry point will have at most one
 // OpBeginInterlockInvocationEXT and one OpEndInterlockInvocationEXT, in that
-// order
+// order.
 Optimizer::PassToken CreateInvocationInterlockPlacementPass();
 }  // namespace spvtools
 

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -71,6 +71,7 @@ set(SPIRV_TOOLS_OPT_SOURCES
   instruction_list.h
   instrument_pass.h
   interface_var_sroa.h
+  invocation_interlock_placement_pass.h
   interp_fixup_pass.h
   ir_builder.h
   ir_context.h
@@ -191,6 +192,7 @@ set(SPIRV_TOOLS_OPT_SOURCES
   instruction_list.cpp
   instrument_pass.cpp
   interface_var_sroa.cpp
+  invocation_interlock_placement_pass.cpp
   interp_fixup_pass.cpp
   ir_context.cpp
   ir_loader.cpp

--- a/source/opt/invocation_interlock_placement_pass.cpp
+++ b/source/opt/invocation_interlock_placement_pass.cpp
@@ -1,0 +1,416 @@
+// Copyright (c) 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/opt/invocation_interlock_placement_pass.h"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <functional>
+#include <optional>
+#include <queue>
+#include <stack>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "source/enum_set.h"
+#include "source/enum_string_mapping.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/reflect.h"
+#include "source/spirv_target_env.h"
+#include "source/util/string_utils.h"
+
+namespace spvtools {
+namespace opt {
+
+namespace {
+constexpr uint32_t kEntryPointExecutionModelInIdx = 0;
+constexpr uint32_t kEntryPointFunctionIdInIdx = 1;
+constexpr uint32_t kFunctionCallFunctionIdInIdx = 0;
+
+template <typename T, typename U>
+constexpr bool has(T container, U value) {
+  return container.find(value) != container.end();
+}
+}  // namespace
+
+bool InvocationInterlockPlacementPass::hasSingleNextBlock(uint32_t block_id,
+                                                          bool forward_flow) {
+  if (forward_flow) {
+    // We are traversing forward, so check whether there is a single successor.
+    BasicBlock* block = cfg()->block(block_id);
+
+    return block->tail()->opcode() != spv::Op::OpBranchConditional &&
+           block->tail()->opcode() != spv::Op::OpSwitch;
+  } else {
+    // We are traversing backward, so check whether there is a single
+    // predecessor.
+    return cfg()->preds(block_id).size() == 1;
+  }
+}
+
+void InvocationInterlockPlacementPass::forEachNext(
+    uint32_t block_id, bool forward_flow, std::function<void(uint32_t)> f) {
+  if (forward_flow) {
+    BasicBlock* block = cfg()->block(block_id);
+
+    block->ForEachSuccessorLabel([f](uint32_t succ_id) { f(succ_id); });
+  } else {
+    for (uint32_t pred_id : cfg()->preds(block_id)) {
+      f(pred_id);
+    }
+  }
+}
+
+void InvocationInterlockPlacementPass::addInstructionAtEdge(BasicBlock* block,
+                                                            bool forward_flow) {
+  if (forward_flow) {
+    // Insert a begin instruction at the end of the block.
+    Instruction* begin_inst =
+        new Instruction(context(), spv::Op::OpBeginInvocationInterlockEXT);
+    begin_inst->InsertAfter(&*--block->tail());
+  } else {
+    // Insert an end instruction at the end of the block.
+    Instruction* end_inst =
+        new Instruction(context(), spv::Op::OpEndInvocationInterlockEXT);
+    end_inst->InsertBefore(&*block->begin());
+  }
+}
+
+bool InvocationInterlockPlacementPass::killDuplicateBegin(BasicBlock* block) {
+  bool found = false;
+
+  return context()->KillInstructionIf(
+      block->begin(), block->end(), [&found](Instruction* inst) {
+        if (inst->opcode() == spv::Op::OpBeginInvocationInterlockEXT) {
+          if (found) {
+            return true;
+          }
+          found = true;
+        }
+        return false;
+      });
+}
+
+bool InvocationInterlockPlacementPass::killDuplicateEnd(BasicBlock* block) {
+  std::vector<Instruction*> to_kill;
+  block->ForEachInst([&to_kill](Instruction* inst) {
+    if (inst->opcode() == spv::Op::OpEndInvocationInterlockEXT) {
+      to_kill.push_back(inst);
+    }
+  });
+
+  if (to_kill.size() <= 1) {
+    return false;
+  }
+
+  to_kill.pop_back();
+
+  for (Instruction* inst : to_kill) {
+    context()->KillInst(inst);
+  }
+
+  return true;
+}
+
+InvocationInterlockPlacementPass::ExtractionResult
+InvocationInterlockPlacementPass::removeInstructionsFromFunction(
+    Function* func) {
+  if (has(extracted_functions_, func)) {
+    return extracted_functions_[func];
+  }
+
+  bool had_begin = false;
+  bool had_end = false;
+
+  func->ForEachInst([this, func, &had_begin, &had_end](Instruction* inst) {
+    switch (inst->opcode()) {
+      case spv::Op::OpBeginInvocationInterlockEXT:
+        context()->KillInst(inst);
+        had_begin = true;
+        break;
+      case spv::Op::OpEndInvocationInterlockEXT:
+        context()->KillInst(inst);
+        had_end = true;
+        break;
+      case spv::Op::OpFunctionCall: {
+        uint32_t function_id =
+            inst->GetSingleWordInOperand(kFunctionCallFunctionIdInIdx);
+        Function* inner_func = context()->GetFunction(function_id);
+        if (inner_func == func) {
+          // ignore recursive calls
+          return;
+        }
+        ExtractionResult result = removeInstructionsFromFunction(inner_func);
+        had_begin = had_begin || result.had_begin;
+        had_end = had_end || result.had_end;
+        break;
+      }
+      default:
+        break;
+    }
+  });
+
+  ExtractionResult result = {had_begin, had_end};
+  extracted_functions_[func] = result;
+  return result;
+}
+
+bool InvocationInterlockPlacementPass::extractInstructionsFromCalls(
+    std::vector<BasicBlock*> blocks) {
+  bool modified = false;
+
+  for (BasicBlock* block : blocks) {
+    block->ForEachInst([this, &modified](Instruction* inst) {
+      if (inst->opcode() == spv::Op::OpFunctionCall) {
+        uint32_t function_id =
+            inst->GetSingleWordInOperand(kFunctionCallFunctionIdInIdx);
+        Function* func = context()->GetFunction(function_id);
+        ExtractionResult result = removeInstructionsFromFunction(func);
+
+        if (result.had_begin) {
+          Instruction* new_inst = new Instruction(
+              context(), spv::Op::OpBeginInvocationInterlockEXT);
+          new_inst->InsertBefore(inst);
+          modified = true;
+        }
+        if (result.had_end) {
+          Instruction* new_inst =
+              new Instruction(context(), spv::Op::OpEndInvocationInterlockEXT);
+          new_inst->InsertAfter(inst);
+          modified = true;
+        }
+      }
+    });
+  }
+  return modified;
+}
+
+void InvocationInterlockPlacementPass::computeBeginAndEnd(
+    std::vector<BasicBlock*> blocks) {
+  for (BasicBlock* block : blocks) {
+    block->ForEachInst([this, block](Instruction* inst) {
+      switch (inst->opcode()) {
+        case spv::Op::OpBeginInvocationInterlockEXT:
+          begin_.insert(block->id());
+          break;
+        case spv::Op::OpEndInvocationInterlockEXT:
+          end_.insert(block->id());
+          break;
+        default:
+          break;
+      }
+    });
+  }
+}
+
+void InvocationInterlockPlacementPass::computeReachableBlocks(
+    BlockSet& inside, BlockSet& previous_inside, bool forward_flow) {
+  BlockSet& starting_nodes = forward_flow ? begin_ : end_;
+  inside = starting_nodes;
+
+  std::deque<uint32_t> worklist;
+  worklist.insert(worklist.begin(), starting_nodes.begin(),
+                  starting_nodes.end());
+
+  while (!worklist.empty()) {
+    uint32_t block_id = worklist.front();
+    worklist.pop_front();
+
+    forEachNext(block_id, forward_flow,
+                [&inside, &previous_inside, &worklist](uint32_t next_id) {
+                  previous_inside.insert(next_id);
+                  if (!has(inside, next_id)) {
+                    worklist.push_back(next_id);
+                  }
+                  inside.insert(next_id);
+                });
+  }
+}
+
+bool InvocationInterlockPlacementPass::removeUnneededInstructions(
+    BasicBlock* block) {
+  bool modified = false;
+  if (!has(predecessors_after_begin_, block->id()) &&
+      has(after_begin_, block->id())) {
+    // None of the previous blocks are in the critical section, but this block
+    // is. This can only happen if this block already has at least one begin
+    // instruction. Leave the first begin instruction, and remove any others.
+    modified |= killDuplicateBegin(block);
+  } else if (has(predecessors_after_begin_, block->id())) {
+    // At least one previous block is in the critical section; remove all
+    // begin instructions in this block.
+    modified |= context()->KillInstructionIf(
+        block->begin(), block->end(), [](Instruction* inst) {
+          return inst->opcode() == spv::Op::OpBeginInvocationInterlockEXT;
+        });
+  }
+
+  if (!has(successors_before_end_, block->id()) &&
+      has(before_end_, block->id())) {
+    // Same as above
+    modified |= killDuplicateEnd(block);
+  } else if (has(successors_before_end_, block->id())) {
+    modified |= context()->KillInstructionIf(
+        block->begin(), block->end(), [](Instruction* inst) {
+          return inst->opcode() == spv::Op::OpEndInvocationInterlockEXT;
+        });
+  }
+  return modified;
+}
+
+BasicBlock* InvocationInterlockPlacementPass::splitEdge(BasicBlock* block,
+                                                        uint32_t succ_id) {
+  // Create a new block to replace the critical edge.
+  auto new_succ_temp = MakeUnique<BasicBlock>(
+      MakeUnique<Instruction>(context(), spv::Op::OpLabel, 0, TakeNextId(),
+                              std::initializer_list<Operand>{}));
+  auto* new_succ = new_succ_temp.get();
+
+  // Insert the new block into the function.
+  block->GetParent()->InsertBasicBlockAfter(std::move(new_succ_temp), block);
+
+  new_succ->AddInstruction(MakeUnique<Instruction>(
+      context(), spv::Op::OpBranch, 0, 0,
+      std::initializer_list<Operand>{
+          Operand(spv_operand_type_t::SPV_OPERAND_TYPE_ID, {succ_id})}));
+
+  assert(block->tail()->opcode() == spv::Op::OpBranchConditional ||
+         block->tail()->opcode() == spv::Op::OpSwitch);
+
+  // Update the first branch to successor to instead branch to
+  // new_successor
+  block->tail()->WhileEachInId([new_succ, succ_id](uint32_t* branch_id) {
+    if (*branch_id == succ_id) {
+      *branch_id = new_succ->id();
+      return false;
+    }
+    return true;
+  });
+
+  return new_succ;
+}
+
+bool InvocationInterlockPlacementPass::placeInstructionsForEdge(
+    BasicBlock* block, uint32_t next_id, bool forward_flow) {
+  bool modified = false;
+
+  BlockSet& inside = forward_flow ? after_begin_ : before_end_;
+  BlockSet& previous_inside =
+      forward_flow ? predecessors_after_begin_ : successors_before_end_;
+
+  if (has(previous_inside, next_id) && !has(inside, block->id())) {
+    // This block is not in the critical section but the next block is, so
+    // we need to add begin or end instructions to the edge.
+
+    modified = true;
+
+    if (hasSingleNextBlock(block->id(), forward_flow)) {
+      // This is the only next block.
+      addInstructionAtEdge(block, forward_flow);
+    } else {
+      // This block has multiple next blocks. Split the edge and insert the
+      // instruction in the new next block.
+      BasicBlock* new_branch;
+      if (forward_flow) {
+        new_branch = splitEdge(block, next_id);
+      } else {
+        new_branch = splitEdge(cfg()->block(next_id), block->id());
+      }
+
+      auto inst = new Instruction(
+          context(), forward_flow ? spv::Op::OpBeginInvocationInterlockEXT
+                                  : spv::Op::OpEndInvocationInterlockEXT);
+      inst->InsertBefore(&*new_branch->tail());
+    }
+  }
+
+  return modified;
+}
+
+bool InvocationInterlockPlacementPass::placeInstructions(BasicBlock* block) {
+  bool modified = false;
+
+  block->ForEachSuccessorLabel([this, block, &modified](uint32_t succ_id) {
+    modified |=
+        placeInstructionsForEdge(block, succ_id, /* flowForward= */ true);
+    modified |= placeInstructionsForEdge(cfg()->block(succ_id), block->id(),
+                                         /* flowForward= */ false);
+  });
+
+  return modified;
+}
+
+bool InvocationInterlockPlacementPass::processFragmentShaderEntry(
+    Function* entry_func) {
+  bool modified = false;
+
+  // Save the original order of blocks in the function, so we don't iterate over
+  // newly-added blocks.
+  std::vector<BasicBlock*> original_blocks;
+  for (auto bi = entry_func->begin(); bi != entry_func->end(); ++bi) {
+    original_blocks.push_back(&*bi);
+  }
+
+  modified |= extractInstructionsFromCalls(original_blocks);
+  computeBeginAndEnd(original_blocks);
+
+  computeReachableBlocks(after_begin_, predecessors_after_begin_,
+                         /* forward_flow= */ true);
+  computeReachableBlocks(before_end_, successors_before_end_,
+                         /* forward_flow= */ false);
+
+  for (BasicBlock* block : original_blocks) {
+    modified |= removeUnneededInstructions(block);
+    modified |= placeInstructions(block);
+  }
+  return modified;
+}
+
+Pass::Status InvocationInterlockPlacementPass::Process() {
+  // Skip this pass if the necessary extension or capability is missing
+  if (!context()->get_feature_mgr()->HasExtension(
+          kSPV_EXT_fragment_shader_interlock) ||
+      !(context()->get_feature_mgr()->HasCapability(
+            spv::Capability::FragmentShaderSampleInterlockEXT) ||
+        context()->get_feature_mgr()->HasCapability(
+            spv::Capability::FragmentShaderPixelInterlockEXT) ||
+        context()->get_feature_mgr()->HasCapability(
+            spv::Capability::FragmentShaderShadingRateInterlockEXT)))
+    return Status::SuccessWithoutChange;
+
+  bool modified = false;
+
+  for (Instruction& entry_inst : context()->module()->entry_points()) {
+    uint32_t entry_id =
+        entry_inst.GetSingleWordInOperand(kEntryPointFunctionIdInIdx);
+    Function* entry_func = context()->GetFunction(entry_id);
+
+    auto execution_model = spv::ExecutionModel(
+        entry_inst.GetSingleWordInOperand(kEntryPointExecutionModelInIdx));
+
+    if (execution_model != spv::ExecutionModel::Fragment) {
+      continue;
+    }
+
+    modified |= processFragmentShaderEntry(entry_func);
+  }
+
+  return modified ? Pass::Status::SuccessWithChange
+                  : Pass::Status::SuccessWithoutChange;
+}
+
+}  // namespace opt
+}  // namespace spvtools

--- a/source/opt/invocation_interlock_placement_pass.cpp
+++ b/source/opt/invocation_interlock_placement_pass.cpp
@@ -353,7 +353,9 @@ bool InvocationInterlockPlacementPass::placeInstructionsForEdge(
       // the previous blocks.
       forEachNext(next_id, !reverse_cfg,
                   [&next_has_previous_inside, inside](uint32_t previous_id) {
-                    next_has_previous_inside |= inside.count(previous_id);
+                    if (inside.count(previous_id)) {
+                      next_has_previous_inside = true;
+                    }
                   });
       assert(next_has_previous_inside &&
              "`previous_inside` must be the set of blocks with at least one "

--- a/source/opt/invocation_interlock_placement_pass.cpp
+++ b/source/opt/invocation_interlock_placement_pass.cpp
@@ -317,6 +317,11 @@ bool InvocationInterlockPlacementPass::placeInstructionsForEdge(
 
     if (hasSingleNextBlock(block->id(), reverse_cfg)) {
       // This is the only next block.
+
+      // Additionally, because `next_id` is in `previous_inside`, we know that
+      // `next_id` has at least one previous block in `inside`. And because
+      // 'block` is not in `inside`, that means there `next_id` has to have at
+      // least one other previous block in `inside.
       addInstructionAtEdge(block, opcode, reverse_cfg);
     } else {
       // This block has multiple next blocks. Split the edge and insert the

--- a/source/opt/invocation_interlock_placement_pass.h
+++ b/source/opt/invocation_interlock_placement_pass.h
@@ -83,10 +83,13 @@ class InvocationInterlockPlacementPass : public Pass {
   // last. Returns whether any instructions were removed.
   bool killDuplicateEnd(BasicBlock* block);
 
+  // Records whether a function will potentially execute a begin or end
+  // instruction.
+  void recordBeginOrEndInFunction(Function* func);
+
   // Recursively removes any begin or end instructions from func and any
-  // function func calls. Returns whether any begin or end instructions were
-  // removed.
-  ExtractionResult removeInstructionsFromFunction(Function* func);
+  // function func calls. Returns whether any instructions were removed.
+  bool removeInstructionsFromFunction(Function* func);
 
   // For every function call in any of the passed blocks, move any begin or end
   // instructions outside of the function call. Returns whether any extractions
@@ -127,6 +130,8 @@ class InvocationInterlockPlacementPass : public Pass {
   // Processes a single fragment shader entry function.
   bool processFragmentShaderEntry(Function* entry_func);
 
+  // Returns whether the module has the SPV_EXT_fragment_shader_interlock
+  // extension and one of the FragmentShader*InterlockEXT capabilities.
   bool isFragmentShaderInterlockEnabled();
 
   // Maps a function to whether that function originally held a begin or end

--- a/source/opt/invocation_interlock_placement_pass.h
+++ b/source/opt/invocation_interlock_placement_pass.h
@@ -69,12 +69,10 @@ class InvocationInterlockPlacementPass : public Pass {
                    std::function<void(uint32_t)> f);
 
   // Add either a begin or end instruction to the edge of the basic block. If
-  // reverse_cfg is true, we are walking forward through the CFG, and want to
-  // add a begin instruction to the end of the block. Otherwise, we are walking
-  // backward through the CFG, and want to add an end instruction to the
-  // beginning of the basic block.
-  void addInstructionAtEdge(BasicBlock* block, spv::Op opcode,
-                            bool reverse_cfg);
+  // at_end is true, add the instruction to the end of the block; otherwise add
+  // the instruction to the beginning of the basic block.
+  void addInstructionAtBlockBoundary(BasicBlock* block, spv::Op opcode,
+                                     bool at_end);
 
   // Remove every OpBeginInvocationInterlockEXT instruction in block after the
   // first. Returns whether any instructions were removed.
@@ -89,7 +87,7 @@ class InvocationInterlockPlacementPass : public Pass {
 
   // Recursively removes any begin or end instructions from func and any
   // function func calls. Returns whether any instructions were removed.
-  bool removeInstructionsFromFunction(Function* func);
+  bool removeBeginAndEndInstructionsFromFunction(Function* func);
 
   // For every function call in any of the passed blocks, move any begin or end
   // instructions outside of the function call. Returns whether any extractions
@@ -107,7 +105,8 @@ class InvocationInterlockPlacementPass : public Pass {
   // after_begin_ and predecessors_after_begin_computing after_begin_ and
   // predecessors_after_begin_, otherwise, move backward through the CFG,
   // computing before_end_ and successors_before_end_.
-  BlockSet computeReachableBlocks(BlockSet& in_set, BlockSet& starting_nodes,
+  BlockSet computeReachableBlocks(BlockSet& in_set,
+                                  const BlockSet& starting_nodes,
                                   bool reverse_cfg);
 
   // Remove unneeded begin and end instructions in block.

--- a/source/opt/invocation_interlock_placement_pass.h
+++ b/source/opt/invocation_interlock_placement_pass.h
@@ -1,0 +1,155 @@
+// Copyright (c) 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_OPT_DEDUPE_INTERLOCK_INVOCATION_PASS_H_
+#define SOURCE_OPT_DEDUPE_INTERLOCK_INVOCATION_PASS_H_
+
+#include <algorithm>
+#include <array>
+#include <functional>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "source/enum_set.h"
+#include "source/extensions.h"
+#include "source/opt/ir_context.h"
+#include "source/opt/module.h"
+#include "source/opt/pass.h"
+#include "source/spirv_target_env.h"
+
+namespace spvtools {
+namespace opt {
+
+// This pass will ensure that an entry point will only have at most one
+// OpBeginInterlockInvocationEXT and one OpEndInterlockInvocationEXT, in that
+// order
+class InvocationInterlockPlacementPass : public Pass {
+ public:
+  InvocationInterlockPlacementPass() {}
+  InvocationInterlockPlacementPass(const InvocationInterlockPlacementPass&) =
+      delete;
+  InvocationInterlockPlacementPass(InvocationInterlockPlacementPass&&) = delete;
+
+  const char* name() const override { return "dedupe-interlock-invocation"; }
+  Status Process() override;
+
+ private:
+  using BlockSet = std::unordered_set<uint32_t>;
+
+  // Specifies whether a function originally had a begin or end instruction.
+  struct ExtractionResult {
+    bool had_begin : 1;
+    bool had_end : 2;
+  };
+
+  // Check if a block has only a single next block, depending on the directing
+  // that we are traversing the CFG. If forward_flow is true, we are walking
+  // forward through the CFG, and will return if the block has only one
+  // successor. Otherwise, we are walking backward through the CFG, and will
+  // return if the block has only one predecessor.
+  bool hasSingleNextBlock(uint32_t block_id, bool forward_flow);
+
+  // Iterate over each of a block's predecessors or successors, depending on
+  // direction. If forward_flow is true, we are walking forward through the CFG,
+  // and need to iterate over the successors. Otherwise, we are walking backward
+  // through the CFG, and need to iterate over the predecessors.
+  void forEachNext(uint32_t block_id, bool forward_flow,
+                   std::function<void(uint32_t)> f);
+
+  // Add either a begin or end instruction to the edge of the basic block. If
+  // forward_flow is true, we are walking forward through the CFG, and want to
+  // add a begin instruction to the end of the block. Otherwise, we are walking
+  // backward through the CFG, and want to add an end instruction to the
+  // beginning of the basic block.
+  void addInstructionAtEdge(BasicBlock* block, bool forward_flow);
+
+  // Populates begin_ with the set of blocks that
+  // contain OpBeginInvocationInterlockEXT, and end_ with the set of blocks that
+  // contain OpEndInvocationInterlockEXT
+  // void computeBeginAndEnd();
+
+  // Remove every OpBeginInvocationInterlockEXT instruction in block after the
+  // first. Returns whether any instructions were removed.
+  bool killDuplicateBegin(BasicBlock* block);
+  // Remove every OpBeginInvocationInterlockEXT instruction in block before the
+  // last. Returns whether any instructions were removed.
+  bool killDuplicateEnd(BasicBlock* block);
+
+  // Recursively removes any begin or end instructions from func and any
+  // function func calls. Returns whether any begin or end instructions were
+  // removed.
+  ExtractionResult removeInstructionsFromFunction(Function* func);
+
+  // For every function call in any of the passed blocks, move any begin or end
+  // instructions outside of the function call. Returns whether any extractions
+  // occurred.
+  bool extractInstructionsFromCalls(std::vector<BasicBlock*> blocks);
+
+  // Finds the sets of blocks begin_ and end_ that contain
+  // OpBeginInvocationInterlockEXT and OpEndInvocationInterlockEXT,
+  // respectively.
+  void computeBeginAndEnd(std::vector<BasicBlock*> blocks);
+
+  // Compute the set of blocks including or after the barrier instruction, and
+  // the set of blocks with any previous blocks inside the barrier instruction.
+  // If forward_flow is true, move forward through the CFG, computing
+  // after_begin_ and predecessors_after_begin_computing after_begin_ and
+  // predecessors_after_begin_, otherwise, move backward through the CFG,
+  // computing before_end_ and successors_before_end_.
+  void computeReachableBlocks(BlockSet& out_set, BlockSet& in_set,
+                              bool forwardFlow);
+
+  // Remove unneeded begin and end instructions in block.
+  bool removeUnneededInstructions(BasicBlock* block);
+
+  // Given a block which branches to multiple successors, and a specific
+  // successor, creates a new empty block, and update the branch instruction to
+  // branch to the new block instead.
+  BasicBlock* splitEdge(BasicBlock* block, uint32_t succ_id);
+
+  // For the edge from block to next_id, places a begin or end instruction on
+  // the edge, based on the direction we are walking the CFG, specified in
+  // forward_flow.
+  bool placeInstructionsForEdge(BasicBlock* block, uint32_t next_id,
+                                bool forward_flow);
+  // Calls placeInstructionsForEdge for each edge in block.
+  bool placeInstructions(BasicBlock* block);
+
+  // Processes a single fragment shader entry function.
+  bool processFragmentShaderEntry(Function* entry_func);
+
+  // Maps a function to whether that function originally held a begin or end
+  // instruction.
+  std::unordered_map<Function*, ExtractionResult> extracted_functions_;
+
+  // The set of blocks which have an OpBeginInvocationInterlockEXT instruction.
+  BlockSet begin_;
+  // The set of blocks which have an OpEndInvocationInterlockEXT instruction.
+  BlockSet end_;
+  // The set of blocks which either have a begin instruction, or have a
+  // predecessor which has a begin instruction.
+  BlockSet after_begin_;
+  // The set of blocks which either have an end instruction, or have a successor
+  // which have an end instruction.
+  BlockSet before_end_;
+  // The set of blocks which have a predecessor in after_begin_.
+  BlockSet predecessors_after_begin_;
+  // The set of blocks which have a successor in before_end_.
+  BlockSet successors_before_end_;
+};
+
+}  // namespace opt
+}  // namespace spvtools
+#endif  // SOURCE_OPT_DEDUPE_INTERLOCK_INVOCATION_PASS_H_

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -158,7 +158,8 @@ Optimizer& Optimizer::RegisterLegalizationPasses(bool preserve_interface) {
           .RegisterPass(CreateDeadInsertElimPass())
           .RegisterPass(CreateReduceLoadSizePass())
           .RegisterPass(CreateAggressiveDCEPass(preserve_interface))
-          .RegisterPass(CreateInterpolateFixupPass());
+          .RegisterPass(CreateInterpolateFixupPass())
+          .RegisterPass(CreateInvocationInterlockPlacementPass());
 }
 
 Optimizer& Optimizer::RegisterLegalizationPasses() {
@@ -1112,6 +1113,11 @@ Optimizer::PassToken CreateTrimCapabilitiesPass() {
 Optimizer::PassToken CreateSwitchDescriptorSetPass(uint32_t from, uint32_t to) {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::SwitchDescriptorSetPass>(from, to));
+}
+
+Optimizer::PassToken CreateInvocationInterlockPlacementPass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::InvocationInterlockPlacementPass>());
 }
 }  // namespace spvtools
 

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -53,6 +53,7 @@
 #include "source/opt/inst_debug_printf_pass.h"
 #include "source/opt/interface_var_sroa.h"
 #include "source/opt/interp_fixup_pass.h"
+#include "source/opt/invocation_interlock_placement_pass.h"
 #include "source/opt/licm_pass.h"
 #include "source/opt/local_access_chain_convert_pass.h"
 #include "source/opt/local_redundancy_elimination.h"

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -66,6 +66,7 @@ add_spvtools_unittest(TARGET opt
        instruction_list_test.cpp
        instruction_test.cpp
        interface_var_sroa_test.cpp
+       invocation_interlock_placement_test.cpp
        interp_fixup_test.cpp
        ir_builder.cpp
        ir_context_test.cpp

--- a/test/opt/invocation_interlock_placement_test.cpp
+++ b/test/opt/invocation_interlock_placement_test.cpp
@@ -631,7 +631,7 @@ TEST_F(InterlockInvocationPlacementTest, CheckSplitSwitch) {
 ; CHECK-NEXT: OpBranch [[merge]]
                OpBranch %8
 
-; CHECK-DAG: [[merge]] = OpLabel
+; CHECK-NEXT: [[merge]] = OpLabel
           %8 = OpLabel
 ; CHECK-NOT: OpBeginInvocationInterlockEXT
                OpBeginInvocationInterlockEXT

--- a/test/opt/invocation_interlock_placement_test.cpp
+++ b/test/opt/invocation_interlock_placement_test.cpp
@@ -192,44 +192,6 @@ TEST_F(InterlockInvocationPlacementTest, CheckFunctionCallExtractionEnd) {
   EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
 }
 
-TEST_F(InterlockInvocationPlacementTest, CheckFunctionCallExtractionRecursive) {
-  const std::string kTest = R"(
-               OpCapability Shader
-               OpCapability FragmentShaderSampleInterlockEXT
-               OpExtension "SPV_EXT_fragment_shader_interlock"
-               OpMemoryModel Logical GLSL450
-               OpEntryPoint Fragment %main "main"
-               OpExecutionMode %main OriginUpperLeft
-               OpExecutionMode %main SampleInterlockOrderedEXT
-               OpName %main "main"
-       %void = OpTypeVoid
-          %1 = OpTypeFunction %void
-        %foo = OpFunction %void None %1
-; CHECK: OpLabel
-; CHECK-NOT: OpEndInvocationInterlockEXT
-          %2 = OpLabel
-               OpEndInvocationInterlockEXT
-               OpEndInvocationInterlockEXT
-          %3 = OpFunctionCall %void %foo
-               OpReturn
-; CHECK: OpFunctionEnd
-               OpFunctionEnd
-       %main = OpFunction %void None %1
-; CHECK: OpLabel
-          %4 = OpLabel
-; CHECK-NEXT: OpFunctionCall
-          %5 = OpFunctionCall %void %foo
-; CHECK-NEXT: OpEndInvocationInterlockEXT
-; CHECK-NEXT: OpReturn
-               OpReturn
-               OpFunctionEnd
-  )";
-  SetTargetEnv(SPV_ENV_VULKAN_1_3);
-  const auto result = SinglePassRunAndMatch<InvocationInterlockPlacementPass>(
-      kTest, /* skip_nop= */ false);
-  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
-}
-
 TEST_F(InterlockInvocationPlacementTest,
        CheckFunctionCallExtractionRepeatedCall) {
   const std::string kTest = R"(

--- a/test/opt/invocation_interlock_placement_test.cpp
+++ b/test/opt/invocation_interlock_placement_test.cpp
@@ -1,0 +1,651 @@
+// Copyright (c) 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "spirv-tools/optimizer.hpp"
+#include "test/opt/pass_fixture.h"
+#include "test/opt/pass_utils.h"
+
+namespace spvtools {
+namespace opt {
+namespace {
+
+using InterlockInvocationPlacementTest = PassTest<::testing::Test>;
+
+TEST_F(InterlockInvocationPlacementTest, CheckUnchangedIfNotFragment) {
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpCapability FragmentShaderSampleInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main"
+               OpExecutionMode %main SampleInterlockOrderedEXT
+               OpName %main "main"
+       %void = OpTypeVoid
+          %1 = OpTypeFunction %void
+       %main = OpFunction %void None %1
+          %2 = OpLabel
+               OpBeginInvocationInterlockEXT
+               OpBeginInvocationInterlockEXT
+	             OpEndInvocationInterlockEXT
+	             OpBeginInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+               OpReturn
+               OpFunctionEnd
+  )";
+  SetTargetEnv(SPV_ENV_VULKAN_1_3);
+  EXPECT_EQ(
+      Pass::Status::SuccessWithoutChange,
+      std::get<1>(SinglePassRunAndDisassemble<InvocationInterlockPlacementPass>(
+          kTest, /* skip_nop= */ false, /* do_validation= */ false)));
+}
+
+TEST_F(InterlockInvocationPlacementTest, CheckUnchangedWithoutCapability) {
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main SampleInterlockOrderedEXT
+               OpName %main "main"
+       %void = OpTypeVoid
+          %1 = OpTypeFunction %void
+       %main = OpFunction %void None %1
+          %2 = OpLabel
+               OpBeginInvocationInterlockEXT
+               OpBeginInvocationInterlockEXT
+	             OpEndInvocationInterlockEXT
+	             OpBeginInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+               OpReturn
+               OpFunctionEnd
+  )";
+  SetTargetEnv(SPV_ENV_VULKAN_1_3);
+  EXPECT_EQ(
+      Pass::Status::SuccessWithoutChange,
+      std::get<1>(SinglePassRunAndDisassemble<InvocationInterlockPlacementPass>(
+          kTest, /* skip_nop= */ false, /* do_validation= */ false)));
+}
+
+TEST_F(InterlockInvocationPlacementTest, CheckSingleBasicBlock) {
+  // We're using OpNoLine as a generic standin for any other instruction, to
+  // test that begin and end aren't moved.
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpCapability FragmentShaderSampleInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main SampleInterlockOrderedEXT
+               OpName %main "main"
+       %void = OpTypeVoid
+          %1 = OpTypeFunction %void
+       %main = OpFunction %void None %1
+; CHECK: OpLabel
+          %2 = OpLabel
+; CHECK-NEXT: OpNoLine
+               OpNoLine
+; CHECK-NEXT: OpBeginInvocationInterlockEXT
+               OpBeginInvocationInterlockEXT
+               OpBeginInvocationInterlockEXT
+	             OpEndInvocationInterlockEXT
+	             OpBeginInvocationInterlockEXT
+; CHECK-NEXT: OpNoLine
+               OpNoLine
+; CHECK-NEXT: OpEndInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+; CHECK-NEXT: OpNoLine
+               OpNoLine
+; CHECK-NEXT: OpReturn
+               OpReturn
+               OpFunctionEnd
+  )";
+  SetTargetEnv(SPV_ENV_VULKAN_1_3);
+  const auto result = SinglePassRunAndMatch<InvocationInterlockPlacementPass>(
+      kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+TEST_F(InterlockInvocationPlacementTest, CheckFunctionCallExtractionBegin) {
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpCapability FragmentShaderSampleInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main SampleInterlockOrderedEXT
+               OpName %main "main"
+       %void = OpTypeVoid
+          %1 = OpTypeFunction %void
+        %foo = OpFunction %void None %1
+; CHECK: OpLabel
+; CHECK-NOT: OpBeginInvocationInterlockEXT
+          %2 = OpLabel
+               OpBeginInvocationInterlockEXT
+               OpBeginInvocationInterlockEXT
+               OpReturn
+; CHECK: OpFunctionEnd
+               OpFunctionEnd
+       %main = OpFunction %void None %1
+; CHECK: OpLabel
+          %3 = OpLabel
+; CHECK-NEXT: OpBeginInvocationInterlockEXT
+; CHECK-NEXT: OpFunctionCall
+          %4 = OpFunctionCall %void %foo
+; CHECK-NEXT: OpReturn
+               OpReturn
+               OpFunctionEnd
+  )";
+  SetTargetEnv(SPV_ENV_VULKAN_1_3);
+  const auto result = SinglePassRunAndMatch<InvocationInterlockPlacementPass>(
+      kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+TEST_F(InterlockInvocationPlacementTest, CheckFunctionCallExtractionEnd) {
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpCapability FragmentShaderSampleInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main SampleInterlockOrderedEXT
+               OpName %main "main"
+       %void = OpTypeVoid
+          %1 = OpTypeFunction %void
+        %foo = OpFunction %void None %1
+; CHECK: OpLabel
+; CHECK-NOT: OpEndInvocationInterlockEXT
+          %2 = OpLabel
+               OpEndInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+               OpReturn
+; CHECK: OpFunctionEnd
+               OpFunctionEnd
+       %main = OpFunction %void None %1
+; CHECK: OpLabel
+          %3 = OpLabel
+; CHECK-NEXT: OpFunctionCall
+          %4 = OpFunctionCall %void %foo
+; CHECK-NEXT: OpEndInvocationInterlockEXT
+; CHECK-NEXT: OpReturn
+               OpReturn
+               OpFunctionEnd
+  )";
+  SetTargetEnv(SPV_ENV_VULKAN_1_3);
+  const auto result = SinglePassRunAndMatch<InvocationInterlockPlacementPass>(
+      kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+TEST_F(InterlockInvocationPlacementTest, CheckFunctionCallExtractionRecursive) {
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpCapability FragmentShaderSampleInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main SampleInterlockOrderedEXT
+               OpName %main "main"
+       %void = OpTypeVoid
+          %1 = OpTypeFunction %void
+        %foo = OpFunction %void None %1
+; CHECK: OpLabel
+; CHECK-NOT: OpEndInvocationInterlockEXT
+          %2 = OpLabel
+               OpEndInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+          %3 = OpFunctionCall %void %foo
+               OpReturn
+; CHECK: OpFunctionEnd
+               OpFunctionEnd
+       %main = OpFunction %void None %1
+; CHECK: OpLabel
+          %4 = OpLabel
+; CHECK-NEXT: OpFunctionCall
+          %5 = OpFunctionCall %void %foo
+; CHECK-NEXT: OpEndInvocationInterlockEXT
+; CHECK-NEXT: OpReturn
+               OpReturn
+               OpFunctionEnd
+  )";
+  SetTargetEnv(SPV_ENV_VULKAN_1_3);
+  const auto result = SinglePassRunAndMatch<InvocationInterlockPlacementPass>(
+      kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+TEST_F(InterlockInvocationPlacementTest,
+       CheckFunctionCallExtractionRepeatedCall) {
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpCapability FragmentShaderSampleInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main SampleInterlockOrderedEXT
+               OpName %main "main"
+       %void = OpTypeVoid
+          %1 = OpTypeFunction %void
+        %foo = OpFunction %void None %1
+; CHECK: OpLabel
+; CHECK-NOT: OpBeginInvocationInterlockEXT
+; CHECK-NOT: OpEndInvocationInterlockEXT
+          %2 = OpLabel
+               OpBeginInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+               OpReturn
+; CHECK: OpFunctionEnd
+               OpFunctionEnd
+       %main = OpFunction %void None %1
+; CHECK: OpLabel
+          %3 = OpLabel
+; CHECK-NEXT: OpBeginInvocationInterlockEXT
+; CHECK-NEXT: OpFunctionCall
+          %4 = OpFunctionCall %void %foo
+; CHECK-NEXT: OpFunctionCall
+          %5 = OpFunctionCall %void %foo
+; CHECK-NEXT: OpEndInvocationInterlockEXT
+; CHECK-NEXT: OpReturn
+               OpReturn
+               OpFunctionEnd
+  )";
+  SetTargetEnv(SPV_ENV_VULKAN_1_3);
+  const auto result = SinglePassRunAndMatch<InvocationInterlockPlacementPass>(
+      kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+TEST_F(InterlockInvocationPlacementTest,
+       CheckFunctionCallExtractionNestedCall) {
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpCapability FragmentShaderSampleInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main SampleInterlockOrderedEXT
+               OpName %main "main"
+       %void = OpTypeVoid
+          %1 = OpTypeFunction %void
+        %foo = OpFunction %void None %1
+; CHECK: OpLabel
+; CHECK-NOT: OpBeginInvocationInterlockEXT
+; CHECK-NOT: OpEndInvocationInterlockEXT
+          %2 = OpLabel
+               OpBeginInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+               OpReturn
+; CHECK: OpFunctionEnd
+               OpFunctionEnd
+        %bar = OpFunction %void None %1
+; CHECK: OpLabel
+; CHECK-NOT: OpBeginInvocationInterlockEXT
+; CHECK-NOT: OpEndInvocationInterlockEXT
+          %3 = OpLabel
+          %4 = OpFunctionCall %void %foo
+               OpReturn
+; CHECK: OpFunctionEnd
+               OpFunctionEnd
+       %main = OpFunction %void None %1
+; CHECK: OpLabel
+          %5 = OpLabel
+; CHECK-NEXT: OpBeginInvocationInterlockEXT
+; CHECK-NEXT: OpFunctionCall
+          %6 = OpFunctionCall %void %bar
+; CHECK-NEXT: OpEndInvocationInterlockEXT
+; CHECK-NEXT: OpReturn
+               OpReturn
+               OpFunctionEnd
+  )";
+  SetTargetEnv(SPV_ENV_VULKAN_1_3);
+  const auto result = SinglePassRunAndMatch<InvocationInterlockPlacementPass>(
+      kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+TEST_F(InterlockInvocationPlacementTest, CheckLoopExtraction) {
+  // Tests that any begin or end instructions in a loop are moved outside of the
+  // loop.
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpCapability FragmentShaderSampleInterlockEXT
+               OpExtension "SPV_EXT_fragment_shader_interlock"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main SampleInterlockOrderedEXT
+       %void = OpTypeVoid
+       %bool = OpTypeBool
+       %true = OpConstantTrue %bool
+           %1 = OpTypeFunction %void
+       %main = OpFunction %void None %1
+
+          %2 = OpLabel
+; CHECK: OpBeginInvocationInterlockEXT
+; CHECK-NOT: OpBeginInvocationInterlockEXT
+; CHECK-NOT: OpEndInvocationInterlockEXT
+               OpBranch %3
+
+          %3 = OpLabel
+               OpLoopMerge %3 %4 None
+; CHECK: OpBranchConditional
+; CHECK-NOT: OpBeginInvocationInterlockEXT
+; CHECK-NOT: OpEndInvocationInterlockEXT
+               OpBranchConditional %true %4 %5
+
+          %4 = OpLabel
+               OpBeginInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+; CHECK: OpBranch
+               OpBranch %3
+
+; CHECK-NEXT: OpLabel
+          %5 = OpLabel
+; CHECK-NEXT: OpEndInvocationInterlockEXT
+; CHECK-NOT: OpEndInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+               OpReturn
+               OpFunctionEnd
+  )";
+  SetTargetEnv(SPV_ENV_VULKAN_1_3);
+  const auto result = SinglePassRunAndMatch<InvocationInterlockPlacementPass>(
+      kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+TEST_F(InterlockInvocationPlacementTest, CheckAddBeginToElse) {
+  // Test that if there is a begin in a single branch of a conditional, begin
+  // will be added to the other branch.
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpCapability FragmentShaderSampleInterlockEXT
+	             OpExtension "SPV_EXT_fragment_shader_interlock"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main SampleInterlockOrderedEXT
+               OpName %main "main"
+       %void = OpTypeVoid
+       %bool = OpTypeBool
+       %true = OpConstantTrue %bool
+           %1 = OpTypeFunction %void
+       %main = OpFunction %void None %1
+
+          %2 = OpLabel
+; CHECK-NOT: OpBeginInvocationInterlockEXT
+               OpSelectionMerge %5 None
+; CHECK: OpBranchConditional
+               OpBranchConditional %true %3 %4
+
+; CHECK-NEXT: OpLabel
+          %3 = OpLabel
+; CHECK-NEXT: OpBeginInvocationInterlockEXT
+               OpBeginInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+; CHECK-NEXT: OpBranch
+               OpBranch %5
+
+          %4 = OpLabel
+; CHECK: OpBeginInvocationInterlockEXT
+; CHECK-NEXT: OpBranch
+               OpBranch %5
+
+; CHECK-NEXT: OpLabel
+          %5 = OpLabel
+               OpBeginInvocationInterlockEXT
+; CHECK-NEXT: OpEndInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+               OpReturn
+               OpFunctionEnd
+  )";
+  SetTargetEnv(SPV_ENV_VULKAN_1_3);
+  const auto result = SinglePassRunAndMatch<InvocationInterlockPlacementPass>(
+      kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+TEST_F(InterlockInvocationPlacementTest, CheckAddEndToElse) {
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpCapability FragmentShaderSampleInterlockEXT
+	             OpExtension "SPV_EXT_fragment_shader_interlock"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main SampleInterlockOrderedEXT
+               OpName %main "main"
+       %void = OpTypeVoid
+       %bool = OpTypeBool
+       %true = OpConstantTrue %bool
+           %1 = OpTypeFunction %void
+       %main = OpFunction %void None %1
+
+          %2 = OpLabel
+; CHECK: OpBeginInvocationInterlockEXT
+               OpBeginInvocationInterlockEXT
+; CHECK-NOT: OpEndInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+               OpSelectionMerge %5 None
+; CHECK: OpBranchConditional
+               OpBranchConditional %true %3 %4
+
+; CHECK-NEXT: OpLabel
+          %3 = OpLabel
+               OpBeginInvocationInterlockEXT
+; CHECK-NEXT: OpEndInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+; CHECK-NEXT: OpBranch
+               OpBranch %5
+
+          %4 = OpLabel
+; CHECK: OpEndInvocationInterlockEXT
+; CHECK-NEXT: OpBranch
+               OpBranch %5
+
+; CHECK-NEXT: OpLabel
+          %5 = OpLabel
+; CHECK-NOT: OpEndInvocationInterlockEXT
+               OpReturn
+               OpFunctionEnd
+  )";
+  SetTargetEnv(SPV_ENV_VULKAN_1_3);
+  const auto result = SinglePassRunAndMatch<InvocationInterlockPlacementPass>(
+      kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+TEST_F(InterlockInvocationPlacementTest, CheckSplitIfWithoutElseBegin) {
+  // Test that if there is a begin in the then branch of a conditional, and no
+  // else branch, an else branch with a begin will created.
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpCapability FragmentShaderSampleInterlockEXT
+	             OpExtension "SPV_EXT_fragment_shader_interlock"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main SampleInterlockOrderedEXT
+               OpName %main "main"
+       %void = OpTypeVoid
+       %bool = OpTypeBool
+       %true = OpConstantTrue %bool
+           %1 = OpTypeFunction %void
+       %main = OpFunction %void None %1
+
+          %2 = OpLabel
+; CHECK-NOT: OpBeginInvocationInterlockEXT
+               OpSelectionMerge %5 None
+; CHECK: OpBranchConditional
+               OpBranchConditional %true %3 %5
+
+; CHECK-NEXT: OpLabel
+; CHECK-NEXT: OpBeginInvocationInterlockEXT
+; CHECK-NEXT: OpBranch
+
+; CHECK-NEXT: OpLabel
+          %3 = OpLabel
+; CHECK-NEXT: OpBeginInvocationInterlockEXT
+; CHECK-NOT: OpEndInvocationInterlockEXT
+               OpBeginInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+               OpBranch %5
+
+; CHECK: OpLabel
+          %5 = OpLabel
+; CHECK-NOT: OpBeginInvocationInterlockEXT
+               OpBeginInvocationInterlockEXT
+; CHECK-NEXT: OpEndInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+               OpReturn
+               OpFunctionEnd
+  )";
+  SetTargetEnv(SPV_ENV_VULKAN_1_3);
+  const auto result = SinglePassRunAndMatch<InvocationInterlockPlacementPass>(
+      kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+TEST_F(InterlockInvocationPlacementTest, CheckSplitIfWithoutElseEnd) {
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpCapability FragmentShaderSampleInterlockEXT
+	             OpExtension "SPV_EXT_fragment_shader_interlock"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main SampleInterlockOrderedEXT
+               OpName %main "main"
+       %void = OpTypeVoid
+       %bool = OpTypeBool
+       %true = OpConstantTrue %bool
+           %1 = OpTypeFunction %void
+       %main = OpFunction %void None %1
+
+          %2 = OpLabel
+
+; CHECK: OpBeginInvocationInterlockEXT
+               OpBeginInvocationInterlockEXT
+; CHECK-NOT: OpEndInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+; CHECK-NEXT: OpSelectionMerge [[merge:%\d+]]
+               OpSelectionMerge %5 None
+; CHECK-NEXT: OpBranchConditional %true [[then:%\d+]] [[else:%\d+]]
+               OpBranchConditional %true %3 %5
+
+; CHECK-NEXT: [[else]] = OpLabel
+; CHECK-NEXT: OpEndInvocationInterlockEXT
+; CHECK-NEXT: OpBranch [[merge]]
+
+; CHECK-NEXT: [[then]] = OpLabel
+          %3 = OpLabel
+; CHECK-NEXT: OpEndInvocationInterlockEXT
+               OpBeginInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+; CHECK-NEXT: OpBranch [[merge]]
+               OpBranch %5
+
+; CHECK-NEXT: [[merge]] = OpLabel
+          %5 = OpLabel
+; CHECK-NEXT: OpReturn
+               OpReturn
+               OpFunctionEnd
+  )";
+  SetTargetEnv(SPV_ENV_VULKAN_1_3);
+  const auto result = SinglePassRunAndMatch<InvocationInterlockPlacementPass>(
+      kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+TEST_F(InterlockInvocationPlacementTest, CheckSplitSwitch) {
+  // Test that if there is a begin or end in a single branch of a switch, begin
+  // or end will be added to all the other branches.
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpCapability FragmentShaderSampleInterlockEXT
+	             OpExtension "SPV_EXT_fragment_shader_interlock"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main SampleInterlockOrderedEXT
+               OpName %main "main"
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+     %uint_1 = OpConstant %uint 1
+           %1 = OpTypeFunction %void
+       %main = OpFunction %void None %1
+
+; CHECK: OpLabel
+          %2 = OpLabel
+; CHECK-NEXT: OpSelectionMerge [[merge:%\d+]]
+               OpSelectionMerge %8 None
+; CHECK-NEXT: OpSwitch %uint_1 [[default:%\d+]] 0 [[case_0:%\d+]] 1 [[case_1:%\d+]] 2 [[case_2:%\d+]]
+               OpSwitch %uint_1 %8 0 %4 1 %5 2 %8
+
+; CHECK-NEXT: [[case_2]] = OpLabel
+; CHECK-NEXT: OpBeginInvocationInterlockEXT
+; CHECK-NEXT: OpBranch [[merge]]
+
+; CHECK-NEXT: [[default]] = OpLabel
+; CHECK-NEXT: OpBeginInvocationInterlockEXT
+; CHECK-NEXT: OpBranch [[merge]]
+
+; CHECK-NEXT: [[case_0]] = OpLabel
+          %4 = OpLabel
+; CHECK-NEXT: OpBeginInvocationInterlockEXT
+; CHECK-NOT: OpEndInvocationInterlockEXT
+               OpBeginInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+; CHECK-NEXT: OpNoLine
+               OpNoLine
+; CHECK-NEXT: OpBranch [[merge]]
+               OpBranch %8
+
+; CHECK-NEXT: [[case_1]] = OpLabel
+          %5 = OpLabel
+; CHECK-NEXT: OpBeginInvocationInterlockEXT
+; CHECK-NOT: OpEndInvocationInterlockEXT
+               OpBeginInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+; CHECK-NEXT: OpNoLine
+               OpNoLine
+; CHECK-NEXT: OpNoLine
+               OpNoLine
+; CHECK-NEXT: OpBranch [[merge]]
+               OpBranch %8
+
+; CHECK-DAG: [[merge]] = OpLabel
+          %8 = OpLabel
+; CHECK-NOT: OpBeginInvocationInterlockEXT
+               OpBeginInvocationInterlockEXT
+; CHECK-NEXT: OpEndInvocationInterlockEXT
+               OpEndInvocationInterlockEXT
+               OpReturn
+               OpFunctionEnd
+  )";
+  SetTargetEnv(SPV_ENV_VULKAN_1_3);
+  const auto result = SinglePassRunAndMatch<InvocationInterlockPlacementPass>(
+      kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+}  // namespace
+}  // namespace opt
+}  // namespace spvtools


### PR DESCRIPTION
DXC will be adding support for HLSL's rasterizer ordered views by using the [SPV_EXT_fragment_shader_interlock_extension](https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/EXT/SPV_EXT_fragment_shader_interlock.asciidoc). That extension stipulates that if an entry point has an interlock ordering execution mode, it must dynamically execute `OpBeginInvocationInterlockEXT` and `OpEndInvocationInterlockEXT`, in that order, exactly once. This would be difficult to determine in DXC's SPIR-V backend, so instead we will emit these instructions potentially multiple times, and use this legalization pass to ensure that the final SPIR-V follows the specification.

This PR uses data-flow analysis to determine where to place begin and end instructions; in essence, determining whether a block contains or is preceded by a begin instruction is similar to a specialized case of a reaching definitions analysis, where we have only a single definition, such as `bool has_begun = true`. For this simpler case, we can compute the set of blocks using BFS to determine the reachability of the begin instruction.

We need to do this for both begin and end instructions, so I have generalized portions of the code to run both forward and backward over the CFG for each respective case. In these parts of the code, `previous` and `next` are used in place of `predecessor` and `successor`, and which they are depends on the direction we are traversing the CFG.

@s-perron I think this is decently readable, but let me know if you think I should split the bidirectional portions or inline any of the helpers.