### PR TITLE
Hash pin workflows and config dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 3

--- a/.github/workflows/autoroll.yml
+++ b/.github/workflows/autoroll.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       # Checkout the depot tools they are needed by roll_deps.sh
       - name: Checkout depot tools

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: '0'
       - name: Download dependencies
         run: python3 utils/git-sync-deps
       - name: Mount Bazel cache
-        uses: actions/cache@v3
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           path: ~/.bazel/cache
           key: bazel-cache-${{ runner.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   prepare-release-job:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Prepare CHANGELOG for version
         run: |
           python utils/generate_changelog.py CHANGES "${{ github.ref_name }}" VERSION_CHANGELOG

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: '0'
       - name: Build web


### PR DESCRIPTION
Closes #5410 

Hi, I've hash pinned the actions (using step security tool) and configured the dependabot to run only on github actions and to group upgrades on a single PR.
