### PR TITLE
fix(build): repair --version "unknown hash" from cmake

### DIFF
--- a/utils/update_build_version.py
+++ b/utils/update_build_version.py
@@ -112,10 +112,13 @@ def describe(repo_path):
     successful, returns the output; otherwise returns 'unknown hash, <date>'."""
 
     # if we're in a git repository, attempt to extract version info
-    if os.path.exists(".git"):
-        success, output = command_output(["git", "describe"], repo_path)
+    is_git_repo = subprocess.run(["git", "rev-parse"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL).returncode == 0
+    if is_git_repo:
+        success, output = command_output(["git", "describe", "--tags", "--match=v*", "--long"], repo_path)
         if not success:
-            output = command_output(["git", "rev-parse", "HEAD"], repo_path)
+            success, output = command_output(["git", "rev-parse", "HEAD"], repo_path)
 
         if success:
             # decode() is needed here for Python3 compatibility. In Python2,


### PR DESCRIPTION
Prior to this change, building the tools according to the README with `cmake --build` produced a version output that started like this:

```
SPIRV-Tools v2023.4 unknown hash, 2023-09-23T17:14:42
```

Now, building the same repository state produces a version string like so:

```
SPIRV-Tools v2023.4 v2023.4.rc2-43-gee7598d4
```