### PR TITLE
instrument: Ensure linking works even of nothing is changed

### DIFF
--- a/source/opt/inst_bindless_check_pass.cpp
+++ b/source/opt/inst_bindless_check_pass.cpp
@@ -724,7 +724,6 @@ void InstBindlessCheckPass::InitializeInstBindlessCheck() {
 }
 
 Pass::Status InstBindlessCheckPass::ProcessImpl() {
-  bool modified = false;
   // The memory model and linkage must always be updated for spirv-link to work
   // correctly.
   AddStorageBufferExt();
@@ -747,8 +746,10 @@ Pass::Status InstBindlessCheckPass::ProcessImpl() {
                                 new_blocks);
       };
 
-  modified = InstProcessEntryPointCallTree(pfn);
-  return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
+  InstProcessEntryPointCallTree(pfn);
+  // This pass always changes the memory model, so that linking will work
+  // properly.
+  return Status::SuccessWithChange;
 }
 
 Pass::Status InstBindlessCheckPass::Process() {

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -438,10 +438,8 @@ bool Optimizer::RegisterPassFromFlag(const std::string& flag) {
     RegisterPass(CreateSimplificationPass());
     RegisterPass(CreateDeadBranchElimPass());
     RegisterPass(CreateBlockMergePass());
-    RegisterPass(CreateAggressiveDCEPass(true));
   } else if (pass_name == "inst-buff-addr-check") {
     RegisterPass(CreateInstBuffAddrCheckPass(23));
-    RegisterPass(CreateAggressiveDCEPass(true));
   } else if (pass_name == "convert-relaxed-to-half") {
     RegisterPass(CreateConvertRelaxedToHalfPass());
   } else if (pass_name == "relax-float-ops") {


### PR DESCRIPTION
spirv-link requires that memory models match between its input files. Ensure this is the case by always returning SuccessWithChange and always changing the memory model to match the instrumentation code in Vulkan-ValidationLayers.

Also, disable the DCE pass in the --inst-* command line options, since it will only work after linking.