### PR TITLE
update_build_version.py produce deterministic header.

### DIFF
--- a/utils/update_build_version.py
+++ b/utils/update_build_version.py
@@ -112,10 +112,11 @@ def describe(repo_path):
     successful, returns the output; otherwise returns 'unknown hash, <date>'."""
 
     # if we're in a git repository, attempt to extract version info
-    if os.path.exists(".git"):
+    success, output = command_output(["git", "rev-parse", "--show-toplevel"], repo_path)
+    if success:
         success, output = command_output(["git", "describe"], repo_path)
         if not success:
-            output = command_output(["git", "rev-parse", "HEAD"], repo_path)
+            success, output = command_output(["git", "rev-parse", "HEAD"], repo_path)
 
         if success:
             # decode() is needed here for Python3 compatibility. In Python2,


### PR DESCRIPTION
When building, .git directory may not exist in current directory (e.g. chromium build), so it will produce with current timestamp, which becomes non-deterministic build.

Check if repo_path is in git repository and use git info. Also fix fallback logic when 'git describe' failed. 'git rev-parse HEAD' result was not used because it didn't update success.