### PR TITLE
fix(build): git describe all tagged versions

### DIFF
--- a/utils/update_build_version.py
+++ b/utils/update_build_version.py
@@ -114,7 +114,7 @@ def describe(repo_path):
     # if we're in a git repository, attempt to extract version info
     success, output = command_output(["git", "rev-parse", "--show-toplevel"], repo_path)
     if success:
-        success, output = command_output(["git", "describe"], repo_path)
+        success, output = command_output(["git", "describe", "--tags", "--match=v*", "--long"], repo_path)
         if not success:
             success, output = command_output(["git", "rev-parse", "HEAD"], repo_path)
 


### PR DESCRIPTION
Previously, the version string would include `v2022.4-N-...` indicating N commits since the last annotated tag (`v2022.4`).

This change broadens the search from just annotated tags to all tags that match `v*`, including the latest version `v2023.4.rc2`.

See also: https://github.com/KhronosGroup/SPIRV-Tools/pull/5417#issuecomment-1764772856

/cc @Keenuts -- as ~threatened~ promised, here's the `git describe` changes pulled into a separate PR. Thanks for your help!