### PR TITLE
spirv-val: Add Vulkan Image Format check

### DIFF
--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -178,7 +178,8 @@ bool IsValidGatherLodBiasAMD(const ValidationState_t& _, spv::Op opcode) {
   return false;
 }
 
-bool IsSignedInt32ImageFormat(spv::ImageFormat format) {
+// Signed or Unsigned Integer Format
+bool IsIntImageFormat(spv::ImageFormat format) {
   switch (format) {
     case spv::ImageFormat::Rgba32i:
     case spv::ImageFormat::Rgba16i:
@@ -199,6 +200,8 @@ bool IsSignedInt32ImageFormat(spv::ImageFormat format) {
     case spv::ImageFormat::Rg8ui:
     case spv::ImageFormat::R16ui:
     case spv::ImageFormat::R8ui:
+    case spv::ImageFormat::R64ui:
+    case spv::ImageFormat::R64i:
       return true;
     default:
       break;
@@ -206,7 +209,7 @@ bool IsSignedInt32ImageFormat(spv::ImageFormat format) {
   return false;
 }
 
-bool IsSignedInt64ImageFormat(spv::ImageFormat format) {
+bool IsInt64ImageFormat(spv::ImageFormat format) {
   switch (format) {
     case spv::ImageFormat::R64ui:
     case spv::ImageFormat::R64i:
@@ -263,10 +266,6 @@ bool IsFloatImageFormat(spv::ImageFormat format) {
       break;
   }
   return false;
-}
-
-bool IsIntImageFormat(spv::ImageFormat format) {
-  return IsSignedInt32ImageFormat(format) || IsSignedInt64ImageFormat(format);
 }
 
 // Returns true if the opcode is a Image instruction which applies
@@ -1066,11 +1065,11 @@ spv_result_t ValidateTypeImage(ValidationState_t& _, const Instruction* inst) {
                << _.VkErrorID(4965)
                << "Image Format type (float or int) does not match Sample Type "
                   "operand";
-      }
-      if (is_int) {
+      } else if (is_int) {
         const uint32_t bit_width = _.GetBitWidth(info.sampled_type);
-        if ((bit_width == 32 && !IsSignedInt32ImageFormat(info.format)) ||
-            (bit_width == 64 && !IsSignedInt64ImageFormat(info.format))) {
+        // format check above to be int
+        if ((bit_width == 32 && IsInt64ImageFormat(info.format)) ||
+            (bit_width == 64 && !IsInt64ImageFormat(info.format))) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << _.VkErrorID(4965)
                  << "Image Format width (32 or 64) does not match Sample Type "

--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -759,15 +759,10 @@ spv_result_t ValidateImageOperands(ValidationState_t& _,
     // void, and the Format is Unknown.
     // In Vulkan, the texel type is only known in all cases by the pipeline
     // setup.
-    if (!_.IsIntScalarOrVectorType(result_type)) {
+    if (!_.IsUnsignedIntScalarOrVectorType(result_type)) {
       return _.diag(SPV_ERROR_INVALID_DATA, inst)
              << _.VkErrorID(4965)
-             << "Using SignExtend, but result type is not a scalar or vector "
-                "integer type.";
-    } else if (!_.IsUnsignedIntScalarOrVectorType(result_type)) {
-      return _.diag(SPV_ERROR_INVALID_DATA, inst)
-             << _.VkErrorID(4965)
-             << "Using SignExtend, but result type is a signed integer type.";
+             << "Using ZeroExtend, but result type is a signed integer type.";
     }
   }
 

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2225,6 +2225,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-Component-04923);
     case 4924:
       return VUID_WRAP(VUID-StandaloneSpirv-Component-04924);
+    case 4965:
+      return VUID_WRAP(VUID-StandaloneSpirv-Image-04965);
     case 6201:
       return VUID_WRAP(VUID-StandaloneSpirv-Flat-06201);
     case 6202:

--- a/test/val/val_image_test.cpp
+++ b/test/val/val_image_test.cpp
@@ -82,7 +82,7 @@ OpCapability ImageBuffer
 %uniform_sampler
 %private_image_u32_buffer_0002_r32ui
 %private_image_u32_spd_0002
-%private_image_f32_buffer_0002_r32ui
+%private_image_f32_buffer_0002_r32f
 %input_flat_u32
 )";
 
@@ -311,10 +311,10 @@ OpDecorate %input_flat_u32 Location 0
 %ptr_image_u32_spd_0002 = OpTypePointer Private %type_image_u32_spd_0002
 %private_image_u32_spd_0002 = OpVariable %ptr_image_u32_spd_0002 Private
 
-%type_image_f32_buffer_0002_r32ui = OpTypeImage %f32 Buffer 0 0 0 2 R32ui
+%type_image_f32_buffer_0002_r32f = OpTypeImage %f32 Buffer 0 0 0 2 R32f
 %ptr_Image_f32 = OpTypePointer Image %f32
-%ptr_image_f32_buffer_0002_r32ui = OpTypePointer Private %type_image_f32_buffer_0002_r32ui
-%private_image_f32_buffer_0002_r32ui = OpVariable %ptr_image_f32_buffer_0002_r32ui Private
+%ptr_image_f32_buffer_0002_r32f = OpTypePointer Private %type_image_f32_buffer_0002_r32f
+%private_image_f32_buffer_0002_r32f = OpVariable %ptr_image_f32_buffer_0002_r32f Private
 
 %ptr_input_flat_u32 = OpTypePointer Input %u32
 %input_flat_u32 = OpVariable %ptr_input_flat_u32 Input
@@ -1397,7 +1397,7 @@ TEST_F(ValidateImage, ImageTexelPointerResultTypeNotNumericNorVoid) {
 
 TEST_F(ValidateImage, ImageTexelPointerImageNotResultTypePointer) {
   const std::string body = R"(
-%texel_ptr = OpImageTexelPointer %ptr_Image_u32 %type_image_f32_buffer_0002_r32ui %u32_0 %u32_0
+%texel_ptr = OpImageTexelPointer %ptr_Image_u32 %type_image_f32_buffer_0002_r32f %u32_0 %u32_0
 %sum = OpAtomicIAdd %u32 %texel_ptr %u32_1 %u32_0 %u32_1
 )";
 
@@ -1450,7 +1450,7 @@ TEST_F(ValidateImage, ImageTexelPointerImageDimSubpassDataBad) {
 
 TEST_F(ValidateImage, ImageTexelPointerImageCoordTypeBad) {
   const std::string body = R"(
-%texel_ptr = OpImageTexelPointer %ptr_Image_f32 %private_image_f32_buffer_0002_r32ui %f32_0 %f32_0
+%texel_ptr = OpImageTexelPointer %ptr_Image_f32 %private_image_f32_buffer_0002_r32f %f32_0 %f32_0
 %sum = OpAtomicIAdd %f32 %texel_ptr %f32_1 %f32_0 %f32_1
 )";
 
@@ -6390,20 +6390,13 @@ TEST_F(ValidateImage, ImageTexelPointerR64iSuccessVulkan) {
 }
 
 TEST_F(ValidateImage, ImageTexelPointerR32fSuccessVulkan) {
-  const std::string& declarations = R"(
-%type_image_f32_buffer_0002_r32f = OpTypeImage %f32 Buffer 0 0 0 2 R32f
-%ptr_image_f32_buffer_0002_r32f = OpTypePointer Private %type_image_f32_buffer_0002_r32f
-%private_image_f32_buffer_0002_r32f = OpVariable %ptr_image_f32_buffer_0002_r32f Private
-)";
-
   const std::string body = R"(
 %texel_ptr = OpImageTexelPointer %ptr_Image_f32 %private_image_f32_buffer_0002_r32f %u32_0 %u32_0
 )";
 
   spv_target_env env = SPV_ENV_VULKAN_1_0;
   CompileSuccessfully(
-      GenerateShaderCode(body, "", "Fragment", "", env, "GLSL450", declarations)
-          .c_str(),
+      GenerateShaderCode(body, "", "Fragment", "", env, "GLSL450").c_str(),
       env);
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions(env));
 }
@@ -6435,14 +6428,13 @@ TEST_F(ValidateImage, ImageTexelPointerRgba32iVulkan) {
 
 TEST_F(ValidateImage, ImageTexelPointerRgba16fVulkan) {
   const std::string& declarations = R"(
-%type_image_s32_buffer_0002_rgba16f = OpTypeImage %s32 Buffer 0 0 0 2 Rgba16f
-%ptr_Image_s32 = OpTypePointer Image %s32
-%ptr_image_s32_buffer_0002_rgba16f = OpTypePointer Private %type_image_s32_buffer_0002_rgba16f
-%private_image_s32_buffer_0002_rgba16f = OpVariable %ptr_image_s32_buffer_0002_rgba16f Private
+%type_image_f32_buffer_0002_rgba16f = OpTypeImage %f32 Buffer 0 0 0 2 Rgba16f
+%ptr_image_f32_buffer_0002_rgba16f = OpTypePointer Private %type_image_f32_buffer_0002_rgba16f
+%private_image_f32_buffer_0002_rgba16f = OpVariable %ptr_image_f32_buffer_0002_rgba16f Private
 )";
 
   const std::string body = R"(
-%texel_ptr = OpImageTexelPointer %ptr_Image_s32 %private_image_s32_buffer_0002_rgba16f %u32_0 %u32_0
+%texel_ptr = OpImageTexelPointer %ptr_Image_f32 %private_image_f32_buffer_0002_rgba16f %u32_0 %u32_0
 )";
 
   spv_target_env env = SPV_ENV_VULKAN_1_0;
@@ -8044,6 +8036,302 @@ TEST_F(ValidateImage, ImageMSArray_ArrayedTypeDoesNotRequireCapability) {
   CompileSuccessfully(code, env);
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions(env));
   EXPECT_THAT(getDiagnosticString(), Eq(""));
+}
+
+TEST_F(ValidateImage, TypeImageVulkanStorageNotFloat) {
+  const std::string code = GetShaderHeader() + R"(
+%img_type = OpTypeImage %f32 2D 0 0 0 2 R32i
+)" + TrivialMain();
+
+  CompileSuccessfully(code.c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Image-04965"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Image Format type (float or int) does not match "
+                        "Sample Type operand"));
+}
+
+TEST_F(ValidateImage, TypeImageVulkanStorageNotInt) {
+  const std::string code = GetShaderHeader() + R"(
+%img_type = OpTypeImage %s32 2D 0 0 0 2 R32f
+)" + TrivialMain();
+
+  CompileSuccessfully(code.c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Image-04965"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Image Format type (float or int) does not match "
+                        "Sample Type operand"));
+}
+
+TEST_F(ValidateImage, TypeImageVulkanStorageNot64Width) {
+  const std::string code = GetShaderHeader(
+                               "OpCapability Int64ImageEXT\nOpExtension "
+                               "\"SPV_EXT_shader_image_int64\"\n") +
+                           R"(
+%img_type = OpTypeImage %s64 2D 0 0 0 2 R32i
+)" + TrivialMain();
+
+  CompileSuccessfully(code.c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Image-04965"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(
+          "Image Format width (32 or 64) does not match Sample Type operand"));
+}
+
+TEST_F(ValidateImage, TypeImageVulkanStorageNot32Width) {
+  const std::string code = GetShaderHeader(
+                               "OpCapability Int64ImageEXT\nOpExtension "
+                               "\"SPV_EXT_shader_image_int64\"\n") +
+                           R"(
+%img_type = OpTypeImage %s32 2D 0 0 0 2 R64i
+)" + TrivialMain();
+
+  CompileSuccessfully(code.c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Image-04965"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(
+          "Image Format width (32 or 64) does not match Sample Type operand"));
+}
+
+TEST_F(ValidateImage, TypeImageVulkanStorageNot64Signedness) {
+  const std::string code = R"(
+    OpCapability Shader
+    OpCapability Int64
+    OpCapability Int64ImageEXT
+    OpExtension "SPV_EXT_shader_image_int64"
+    OpMemoryModel Logical GLSL450
+    OpEntryPoint Fragment %main "main" %image_var
+    OpExecutionMode %main OriginUpperLeft
+    OpDecorate %image_var Location 0
+     %void = OpTypeVoid
+     %func = OpTypeFunction %void
+      %u32 = OpTypeInt 32 0
+      %s64 = OpTypeInt 64 1
+    %u32_0 = OpConstant %u32 0
+    %u32_1 = OpConstant %u32 1
+  %u32vec2 = OpTypeVector %u32 2
+  %s64vec4 = OpTypeVector %s64 4
+%u32vec2_01 = OpConstantComposite %u32vec2 %u32_0 %u32_1
+ %img_type = OpTypeImage %s64 2D 0 0 0 1 R64ui
+%ptr_image = OpTypePointer Input %img_type
+%image_var = OpVariable %ptr_image Input
+     %main = OpFunction %void None %func
+    %label = OpLabel
+      %img = OpLoad %img_type %image_var
+     %res1 = OpImageFetch %s64vec4 %img %u32vec2_01
+    OpReturn
+    OpFunctionEnd
+)";
+
+  CompileSuccessfully(code.c_str(), SPV_ENV_VULKAN_1_0);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Image-04965"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Image Format signedness does not match Sample Type operand "
+                "including possible SignExtend or ZeroExtend operand"));
+}
+
+TEST_F(ValidateImage, TypeImageVulkanStorageNot32Signedness) {
+  const std::string code = R"(
+    OpCapability Shader
+    OpMemoryModel Logical GLSL450
+    OpEntryPoint Fragment %main "main" %image_var
+    OpExecutionMode %main OriginUpperLeft
+    OpDecorate %image_var Location 0
+     %void = OpTypeVoid
+     %func = OpTypeFunction %void
+      %u32 = OpTypeInt 32 0
+    %u32_0 = OpConstant %u32 0
+    %u32_1 = OpConstant %u32 1
+  %u32vec2 = OpTypeVector %u32 2
+  %u32vec4 = OpTypeVector %u32 4
+%u32vec2_01 = OpConstantComposite %u32vec2 %u32_0 %u32_1
+ %img_type = OpTypeImage %u32 2D 0 0 0 1 R32i
+%ptr_image = OpTypePointer Input %img_type
+%image_var = OpVariable %ptr_image Input
+     %main = OpFunction %void None %func
+    %label = OpLabel
+      %img = OpLoad %img_type %image_var
+     %res1 = OpImageFetch %u32vec4 %img %u32vec2_01
+    OpReturn
+    OpFunctionEnd
+)";
+
+  CompileSuccessfully(code.c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Image-04965"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Image Format signedness does not match Sample Type operand "
+                "including possible SignExtend or ZeroExtend operand"));
+}
+
+TEST_F(ValidateImage, TypeImageVulkanStorageSignExtendOverride) {
+  const std::string code = R"(
+    OpCapability Shader
+    OpMemoryModel Logical GLSL450
+    OpEntryPoint Fragment %main "main" %uniform_image
+    OpExecutionMode %main OriginUpperLeft
+    OpDecorate %uniform_image DescriptorSet 0
+    OpDecorate %uniform_image Binding 0
+     %void = OpTypeVoid
+     %func = OpTypeFunction %void
+      %u32 = OpTypeInt 32 0
+    %u32_0 = OpConstant %u32 0
+    %u32_1 = OpConstant %u32 1
+  %u32vec2 = OpTypeVector %u32 2
+  %u32vec4 = OpTypeVector %u32 4
+%u32vec2_01 = OpConstantComposite %u32vec2 %u32_0 %u32_1
+ %img_type = OpTypeImage %u32 2D 0 0 0 1 R32i
+%ptr_image = OpTypePointer UniformConstant %img_type
+%uniform_image = OpVariable %ptr_image UniformConstant
+     %main = OpFunction %void None %func
+    %label = OpLabel
+      %img = OpLoad %img_type %uniform_image
+     %res1 = OpImageFetch %u32vec4 %img %u32vec2_01 SignExtend
+    OpReturn
+    OpFunctionEnd
+)";
+
+  CompileSuccessfully(code.c_str(), SPV_ENV_VULKAN_1_2);
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+}
+
+TEST_F(ValidateImage, TypeImageVulkanStorageZeroExtendOverride) {
+  const std::string code = R"(
+    OpCapability Shader
+    OpMemoryModel Logical GLSL450
+    OpEntryPoint Fragment %main "main" %uniform_image
+    OpExecutionMode %main OriginUpperLeft
+    OpDecorate %uniform_image DescriptorSet 0
+    OpDecorate %uniform_image Binding 0
+     %void = OpTypeVoid
+     %func = OpTypeFunction %void
+      %i32 = OpTypeInt 32 1
+      %u32 = OpTypeInt 32 0
+    %u32_0 = OpConstant %u32 0
+    %u32_1 = OpConstant %u32 1
+  %u32vec2 = OpTypeVector %u32 2
+  %i32vec4 = OpTypeVector %i32 4
+%u32vec2_01 = OpConstantComposite %u32vec2 %u32_0 %u32_1
+ %img_type = OpTypeImage %i32 2D 0 0 0 2 R32ui
+%ptr_image = OpTypePointer UniformConstant %img_type
+%uniform_image = OpVariable %ptr_image UniformConstant
+     %main = OpFunction %void None %func
+    %label = OpLabel
+      %img = OpLoad %img_type %uniform_image
+     %res1 = OpImageRead %i32vec4 %img %u32vec2_01 ZeroExtend
+    OpReturn
+    OpFunctionEnd
+)";
+
+  CompileSuccessfully(code.c_str(), SPV_ENV_VULKAN_1_2);
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+}
+
+TEST_F(ValidateImage, TypeImageVulkanStorageZeroExtendRedundant) {
+  // use ZeroExtend when sample type is already unsigned but still has signed
+  // format
+  const std::string code = R"(
+    OpCapability Shader
+    OpMemoryModel Logical GLSL450
+    OpEntryPoint Fragment %main "main" %uniform_image
+    OpExecutionMode %main OriginUpperLeft
+    OpDecorate %uniform_image DescriptorSet 0
+    OpDecorate %uniform_image Binding 0
+     %void = OpTypeVoid
+     %func = OpTypeFunction %void
+      %u32 = OpTypeInt 32 0
+    %u32_0 = OpConstant %u32 0
+    %u32_1 = OpConstant %u32 1
+  %u32vec2 = OpTypeVector %u32 2
+  %u32vec4 = OpTypeVector %u32 4
+%u32vec2_01 = OpConstantComposite %u32vec2 %u32_0 %u32_1
+ %img_type = OpTypeImage %u32 2D 0 0 0 1 R32i
+%ptr_image = OpTypePointer UniformConstant %img_type
+%uniform_image = OpVariable %ptr_image UniformConstant
+     %main = OpFunction %void None %func
+    %label = OpLabel
+      %img = OpLoad %img_type %uniform_image
+     %res1 = OpImageFetch %u32vec4 %img %u32vec2_01 ZeroExtend
+    OpReturn
+    OpFunctionEnd
+)";
+
+  CompileSuccessfully(code.c_str(), SPV_ENV_VULKAN_1_2);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Image-04965"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Image Format signedness does not match Sample Type operand "
+                "including possible SignExtend or ZeroExtend operand"));
+}
+
+TEST_F(ValidateImage, TypeImageVulkanStorageZeroExtendFloat) {
+  // use ZeroExtend on Float image
+  const std::string code = R"(
+            OpCapability Shader
+            OpCapability StorageImageWriteWithoutFormat
+            OpMemoryModel Logical GLSL450
+            OpEntryPoint GLCompute %main "main" %var
+            OpExecutionMode %main LocalSize 1 1 1
+            OpDecorate %var DescriptorSet 0
+            OpDecorate %var Binding 0
+            OpDecorate %var NonReadable
+    %void = OpTypeVoid
+    %func = OpTypeFunction %void
+    %int = OpTypeInt 32 1
+    %float = OpTypeFloat 32
+    %image = OpTypeImage %float 2D 0 0 0 2 Unknown
+    %ptr = OpTypePointer UniformConstant %image
+    %var = OpVariable %ptr UniformConstant
+    %v2int = OpTypeVector %int 2
+    %int_1 = OpConstant %int 1
+    %coord = OpConstantComposite %v2int %int_1 %int_1
+    %v3float = OpTypeVector %float 3
+    %float_1 = OpConstant %float 1
+%texelU3 = OpConstantComposite %v3float %float_1 %float_1 %float_1
+    %main = OpFunction %void None %func
+    %label = OpLabel
+    %load = OpLoad %image %var
+            OpImageWrite %load %coord %texelU3 ZeroExtend
+            OpReturn
+            OpFunctionEnd
+)";
+
+  CompileSuccessfully(code.c_str(), SPV_ENV_VULKAN_1_2);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Image-04965"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Can't use SignExtend or ZeroExtend on float images"));
+}
+
+TEST_F(ValidateImage, BothSignExtendZeroExtendTogether) {
+  const std::string body = R"(
+%img = OpLoad %type_image_s32_2d_0002 %uniform_image_s32_2d_0002
+%res1 = OpImageRead %s32vec4 %img %u32vec2_01 SignExtend ZeroExtend
+)";
+  const std::string extra = "\nOpCapability StorageImageReadWithoutFormat\n";
+
+  EXPECT_THAT(CompileFailure(GenerateShaderCode(body, extra, "Fragment", "",
+                                                SPV_ENV_UNIVERSAL_1_4),
+                             SPV_ENV_UNIVERSAL_1_4),
+              HasSubstr("Expected <opcode> or <result-id> at the beginning of "
+                        "an instruction"));
 }
 
 }  // namespace

--- a/test/val/val_image_test.cpp
+++ b/test/val/val_image_test.cpp
@@ -5965,7 +5965,7 @@ TEST_F(ValidateImage, ZeroExtendScalarSIntTexelV14) {
             ValidateInstructions(SPV_ENV_UNIVERSAL_1_4));
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Using SignExtend, but result type is a signed integer type."));
+      HasSubstr("Using ZeroExtend, but result type is a signed integer type."));
 }
 
 TEST_F(ValidateImage, ZeroExtendScalarVectorUIntTexelV14Good) {
@@ -5996,7 +5996,7 @@ TEST_F(ValidateImage, ZeroExtendVectorSIntTexelV14) {
             ValidateInstructions(SPV_ENV_UNIVERSAL_1_4));
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Using SignExtend, but result type is a signed integer type."));
+      HasSubstr("Using ZeroExtend, but result type is a signed integer type."));
 }
 
 TEST_F(ValidateImage, ReadLodAMDSuccess1) {
@@ -8249,7 +8249,7 @@ TEST_F(ValidateImage, TypeImageVulkanStorageZeroExtendSigned) {
               AnyVUID("VUID-StandaloneSpirv-Image-04965"));
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Using SignExtend, but result type is a signed integer type"));
+      HasSubstr("Using ZeroExtend, but result type is a signed integer type"));
 }
 
 TEST_F(ValidateImage, TypeImageVulkanStorageZeroExtendRedundant) {
@@ -8327,9 +8327,9 @@ TEST_F(ValidateImage, TypeImageVulkanStorageZeroExtendFloat) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_2));
   EXPECT_THAT(getDiagnosticString(),
               AnyVUID("VUID-StandaloneSpirv-Image-04965"));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Using SignExtend, but result type is not a scalar or "
-                        "vector integer type."));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Using ZeroExtend, but result type is a signed integer type."));
 }
 
 }  // namespace


### PR DESCRIPTION
Second attempt at https://github.com/KhronosGroup/SPIRV-Tools/pull/4748

checks for `VUID-StandaloneSpirv-Image-04965`