### PR TITLE
spirv-opt: Fix nullptr argument in MarkInsertChain

### DIFF
--- a/source/opt/dead_insert_elim_pass.cpp
+++ b/source/opt/dead_insert_elim_pass.cpp
@@ -213,7 +213,8 @@ bool DeadInsertElimPass::EliminateDeadInsertsOnePass(Function* func) {
           } break;
           default: {
             // Mark inserts in chain for all components
-            MarkInsertChain(&*ii, nullptr, 0, nullptr);
+            std::unordered_set<uint32_t> visited_phis;
+            MarkInsertChain(&*ii, nullptr, 0, &visited_phis);
           } break;
         }
       });


### PR DESCRIPTION
I observed crashes in DXC that appeared after introducing an early out conditional branch to a HLSL shader that compiles to spirv.
The culprit is a nullptr access violation that occurs in spirv-opt when DXC tries to legalize its generated spirv code. The proposed change fixed the issue for me.

Please have a look and consider taking it in.