### PR TITLE
Fix python warning seen on Fedora 39

### DIFF
--- a/utils/update_build_version.py
+++ b/utils/update_build_version.py
@@ -131,7 +131,7 @@ def describe(repo_path):
     # clock time with environment variable SOURCE_DATE_EPOCH
     # containing a (presumably) fixed timestamp.
     timestamp = int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
-    iso_date = datetime.datetime.utcfromtimestamp(timestamp).isoformat()
+    iso_date = datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc).isoformat()
     return "unknown hash, {}".format(iso_date)
 
 def main():


### PR DESCRIPTION
Python 3.12 on Fedora 39 is producing a deprecation warning about `datetime.utcfromtimestamp`.

See
https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp for more details.