### PR TITLE
opt: add StorageImageReadWithoutFormat to cap trim

### DIFF
--- a/source/opt/trim_capabilities_pass.cpp
+++ b/source/opt/trim_capabilities_pass.cpp
@@ -42,9 +42,13 @@ constexpr uint32_t kTypeArrayTypeIndex = 0;
 constexpr uint32_t kOpTypeScalarBitWidthIndex = 0;
 constexpr uint32_t kTypePointerTypeIdInIndex = 1;
 constexpr uint32_t kOpTypeIntSizeIndex = 0;
-constexpr uint32_t kOpTypeImageArrayedIndex = 3;
+constexpr uint32_t kOpTypeImageDimIndex = 1;
+constexpr uint32_t kOpTypeImageArrayedIndex = kOpTypeImageDimIndex + 2;
 constexpr uint32_t kOpTypeImageMSIndex = kOpTypeImageArrayedIndex + 1;
 constexpr uint32_t kOpTypeImageSampledIndex = kOpTypeImageMSIndex + 1;
+constexpr uint32_t kOpTypeImageFormatIndex = kOpTypeImageSampledIndex + 1;
+constexpr uint32_t kOpImageReadImageIndex = 0;
+constexpr uint32_t kOpImageSparseReadImageIndex = 0;
 
 // DFS visit of the type defined by `instruction`.
 // If `condition` is true, children of the current node are visited.
@@ -296,17 +300,59 @@ static std::optional<spv::Capability> Handler_OpTypeImage_ImageMSArray(
              : std::nullopt;
 }
 
+static std::optional<spv::Capability>
+Handler_OpImageRead_StorageImageReadWithoutFormat(
+    const Instruction* instruction) {
+  assert(instruction->opcode() == spv::Op::OpImageRead &&
+         "This handler only support OpImageRead opcodes.");
+  const auto* def_use_mgr = instruction->context()->get_def_use_mgr();
+
+  const uint32_t image_index =
+      instruction->GetSingleWordInOperand(kOpImageReadImageIndex);
+  const uint32_t type_index = def_use_mgr->GetDef(image_index)->type_id();
+  const Instruction* type = def_use_mgr->GetDef(type_index);
+  const uint32_t dim = type->GetSingleWordInOperand(kOpTypeImageDimIndex);
+  const uint32_t format = type->GetSingleWordInOperand(kOpTypeImageFormatIndex);
+
+  const bool is_unknown = spv::ImageFormat(format) == spv::ImageFormat::Unknown;
+  const bool requires_capability_for_unknown =
+      spv::Dim(dim) != spv::Dim::SubpassData;
+  return is_unknown && requires_capability_for_unknown
+             ? std::optional(spv::Capability::StorageImageReadWithoutFormat)
+             : std::nullopt;
+}
+
+static std::optional<spv::Capability>
+Handler_OpImageSparseRead_StorageImageReadWithoutFormat(
+    const Instruction* instruction) {
+  assert(instruction->opcode() == spv::Op::OpImageSparseRead &&
+         "This handler only support OpImageSparseRead opcodes.");
+  const auto* def_use_mgr = instruction->context()->get_def_use_mgr();
+
+  const uint32_t image_index =
+      instruction->GetSingleWordInOperand(kOpImageSparseReadImageIndex);
+  const uint32_t type_index = def_use_mgr->GetDef(image_index)->type_id();
+  const Instruction* type = def_use_mgr->GetDef(type_index);
+  const uint32_t format = type->GetSingleWordInOperand(kOpTypeImageFormatIndex);
+
+  return spv::ImageFormat(format) == spv::ImageFormat::Unknown
+             ? std::optional(spv::Capability::StorageImageReadWithoutFormat)
+             : std::nullopt;
+}
+
 // Opcode of interest to determine capabilities requirements.
-constexpr std::array<std::pair<spv::Op, OpcodeHandler>, 8> kOpcodeHandlers{{
+constexpr std::array<std::pair<spv::Op, OpcodeHandler>, 10> kOpcodeHandlers{{
     // clang-format off
-    {spv::Op::OpTypeFloat,   Handler_OpTypeFloat_Float64 },
-    {spv::Op::OpTypeImage,   Handler_OpTypeImage_ImageMSArray},
-    {spv::Op::OpTypeInt,     Handler_OpTypeInt_Int64 },
-    {spv::Op::OpTypePointer, Handler_OpTypePointer_StorageInputOutput16},
-    {spv::Op::OpTypePointer, Handler_OpTypePointer_StoragePushConstant16},
-    {spv::Op::OpTypePointer, Handler_OpTypePointer_StorageUniform16},
-    {spv::Op::OpTypePointer, Handler_OpTypePointer_StorageUniform16},
-    {spv::Op::OpTypePointer, Handler_OpTypePointer_StorageUniformBufferBlock16},
+    {spv::Op::OpImageRead,         Handler_OpImageRead_StorageImageReadWithoutFormat},
+    {spv::Op::OpImageSparseRead,   Handler_OpImageSparseRead_StorageImageReadWithoutFormat},
+    {spv::Op::OpTypeFloat,         Handler_OpTypeFloat_Float64 },
+    {spv::Op::OpTypeImage,         Handler_OpTypeImage_ImageMSArray},
+    {spv::Op::OpTypeInt,           Handler_OpTypeInt_Int64 },
+    {spv::Op::OpTypePointer,       Handler_OpTypePointer_StorageInputOutput16},
+    {spv::Op::OpTypePointer,       Handler_OpTypePointer_StoragePushConstant16},
+    {spv::Op::OpTypePointer,       Handler_OpTypePointer_StorageUniform16},
+    {spv::Op::OpTypePointer,       Handler_OpTypePointer_StorageUniform16},
+    {spv::Op::OpTypePointer,       Handler_OpTypePointer_StorageUniformBufferBlock16},
     // clang-format on
 }};
 

--- a/source/opt/trim_capabilities_pass.h
+++ b/source/opt/trim_capabilities_pass.h
@@ -87,6 +87,7 @@ class TrimCapabilitiesPass : public Pass {
       spv::Capability::RayTraversalPrimitiveCullingKHR,
       spv::Capability::Shader,
       spv::Capability::ShaderClockKHR,
+      spv::Capability::StorageImageReadWithoutFormat,
       spv::Capability::StorageInputOutput16,
       spv::Capability::StoragePushConstant16,
       spv::Capability::StorageUniform16,


### PR DESCRIPTION
The StorageImageReadWithoutFormat capability is only required when an image type with the format set to Unknown is used with some specific OpImageRead or OpImageSparseRead instructions.

This patch adds the required code to the capability trimming pass to remove the StorageImageReadWithoutFormat capability when not required.

This would fix https://github.com/microsoft/DirectXShaderCompiler/issues/5906 once merged in DXC.