### PR TITLE
opt: add PhysicalStorageBufferAddresses to trim

### DIFF
--- a/source/opt/trim_capabilities_pass.h
+++ b/source/opt/trim_capabilities_pass.h
@@ -74,14 +74,18 @@ class TrimCapabilitiesPass : public Pass {
   // contains unsupported instruction, the pass could yield bad results.
   static constexpr std::array kSupportedCapabilities{
       // clang-format off
+      spv::Capability::ComputeDerivativeGroupLinearNV,
+      spv::Capability::ComputeDerivativeGroupQuadsNV,
       spv::Capability::Float64,
       spv::Capability::FragmentShaderPixelInterlockEXT,
       spv::Capability::FragmentShaderSampleInterlockEXT,
       spv::Capability::FragmentShaderShadingRateInterlockEXT,
       spv::Capability::Groups,
+      spv::Capability::ImageMSArray,
       spv::Capability::Int64,
       spv::Capability::Linkage,
       spv::Capability::MinLod,
+      spv::Capability::PhysicalStorageBufferAddresses,
       spv::Capability::RayQueryKHR,
       spv::Capability::RayTracingKHR,
       spv::Capability::RayTraversalPrimitiveCullingKHR,
@@ -91,10 +95,7 @@ class TrimCapabilitiesPass : public Pass {
       spv::Capability::StorageInputOutput16,
       spv::Capability::StoragePushConstant16,
       spv::Capability::StorageUniform16,
-      spv::Capability::StorageUniformBufferBlock16,
-      spv::Capability::ImageMSArray,
-      spv::Capability::ComputeDerivativeGroupQuadsNV,
-      spv::Capability::ComputeDerivativeGroupLinearNV
+      spv::Capability::StorageUniformBufferBlock16
       // clang-format on
   };
 


### PR DESCRIPTION
The PhysicalStorageBufferAddresses capability can now be trimmed. From the spec, it seems any instruction enabled by this required some operand to have the PhysicalStorageBuffer storage class. This means checking the storage class is enough.

Now, because the pass uses the grammar, we don't need to add any new logic.\

Fixes #5425 