### PR TITLE
Flush stdout before changing mode back to text

### DIFF
--- a/tools/io.h
+++ b/tools/io.h
@@ -144,6 +144,7 @@ class OutputFile {
 
   ~OutputFile() {
     if (fp_ == stdout) {
+      fflush(stdout);
       SET_STDOUT_MODE(old_mode_);
     } else if (fp_ != nullptr) {
       fclose(fp_);


### PR DESCRIPTION
The file mode is only actually respected when flushing the internal I/O buffers to the filesystem. By changing the file mode to text before flushing, the flush still ends up converting line endings, producing invalid output.