### PR TITLE
spirv-val: Loosen restriction on base type of DebugTypePointer and DebugTypeQualifier

### DIFF
--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -3168,16 +3168,16 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
           break;
         }
         case CommonDebugInfoDebugTypePointer: {
-          auto validate_base_type =
-              ValidateOperandBaseType(_, inst, 5, ext_inst_name);
+          auto validate_base_type = ValidateOperandDebugType(
+              _, "Base Type", inst, 5, ext_inst_name, false);
           if (validate_base_type != SPV_SUCCESS) return validate_base_type;
           CHECK_CONST_UINT_OPERAND("Storage Class", 6);
           CHECK_CONST_UINT_OPERAND("Flags", 7);
           break;
         }
         case CommonDebugInfoDebugTypeQualifier: {
-          auto validate_base_type =
-              ValidateOperandBaseType(_, inst, 5, ext_inst_name);
+          auto validate_base_type = ValidateOperandDebugType(
+              _, "Base Type", inst, 5, ext_inst_name, false);
           if (validate_base_type != SPV_SUCCESS) return validate_base_type;
           CHECK_CONST_UINT_OPERAND("Type Qualifier", 6);
           break;

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -482,8 +482,8 @@ spv_result_t ValidateClspvReflectionArgumentBuffer(ValidationState_t& _,
   return SPV_SUCCESS;
 }
 
-spv_result_t ValidateClspvReflectionArgumentOffsetBuffer(ValidationState_t& _,
-                                                         const Instruction* inst) {
+spv_result_t ValidateClspvReflectionArgumentOffsetBuffer(
+    ValidationState_t& _, const Instruction* inst) {
   const auto num_operands = inst->operands().size();
   if (auto error = ValidateKernelDecl(_, inst)) {
     return error;
@@ -802,7 +802,7 @@ spv_result_t ValidateClspvReflectionPushConstantData(ValidationState_t& _,
 }
 
 spv_result_t ValidateClspvReflectionPrintfInfo(ValidationState_t& _,
-                                              const Instruction* inst) {
+                                               const Instruction* inst) {
   if (!IsUint32Constant(_, inst->GetOperandAs<uint32_t>(4))) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
            << "PrintfID must be a 32-bit unsigned integer OpConstant";
@@ -823,8 +823,8 @@ spv_result_t ValidateClspvReflectionPrintfInfo(ValidationState_t& _,
   return SPV_SUCCESS;
 }
 
-spv_result_t ValidateClspvReflectionPrintfStorageBuffer(ValidationState_t& _,
-                                                        const Instruction* inst) {
+spv_result_t ValidateClspvReflectionPrintfStorageBuffer(
+    ValidationState_t& _, const Instruction* inst) {
   if (!IsUint32Constant(_, inst->GetOperandAs<uint32_t>(4))) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
            << "DescriptorSet must be a 32-bit unsigned integer OpConstant";
@@ -843,8 +843,8 @@ spv_result_t ValidateClspvReflectionPrintfStorageBuffer(ValidationState_t& _,
   return SPV_SUCCESS;
 }
 
-spv_result_t ValidateClspvReflectionPrintfPushConstant(ValidationState_t& _,
-                                                       const Instruction* inst) {
+spv_result_t ValidateClspvReflectionPrintfPushConstant(
+    ValidationState_t& _, const Instruction* inst) {
   if (!IsUint32Constant(_, inst->GetOperandAs<uint32_t>(4))) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
            << "Offset must be a 32-bit unsigned integer OpConstant";

--- a/test/val/val_ext_inst_debug_test.cpp
+++ b/test/val/val_ext_inst_debug_test.cpp
@@ -1012,8 +1012,9 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypePointerFail) {
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
       src, size_const, dbg_inst_header, "", extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("expected operand Base Type is not a valid debug type"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("expected operand Base Type is not a valid debug type"));
 }
 
 TEST_F(ValidateOpenCL100DebugInfo, DebugTypeQualifier) {
@@ -1076,8 +1077,9 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeQualifierFail) {
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
       src, size_const, dbg_inst_header, "", extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("expected operand Base Type is not a valid debug type"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("expected operand Base Type is not a valid debug type"));
 }
 TEST_F(ValidateVulkan100DebugInfo, DebugTypeQualifier) {
   const std::string src = R"(
@@ -1145,8 +1147,9 @@ OpExtension "SPV_KHR_non_semantic_info"
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
       src, constants, dbg_inst_header, "", extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("expected operand Base Type is not a valid debug type"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("expected operand Base Type is not a valid debug type"));
 }
 
 TEST_F(ValidateOpenCL100DebugInfo, DebugTypeArray) {

--- a/test/val/val_ext_inst_debug_test.cpp
+++ b/test/val/val_ext_inst_debug_test.cpp
@@ -1013,8 +1013,7 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypePointerFail) {
       src, size_const, dbg_inst_header, "", extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("expected operand Base Type must be a result id of "
-                        "DebugTypeBasic"));
+              HasSubstr("expected operand Base Type is not a valid debug type"));
 }
 
 TEST_F(ValidateOpenCL100DebugInfo, DebugTypeQualifier) {
@@ -1078,8 +1077,7 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeQualifierFail) {
       src, size_const, dbg_inst_header, "", extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("expected operand Base Type must be a result id of "
-                        "DebugTypeBasic"));
+              HasSubstr("expected operand Base Type is not a valid debug type"));
 }
 TEST_F(ValidateVulkan100DebugInfo, DebugTypeQualifier) {
   const std::string src = R"(
@@ -1148,8 +1146,7 @@ OpExtension "SPV_KHR_non_semantic_info"
       src, constants, dbg_inst_header, "", extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("expected operand Base Type must be a result id of "
-                        "DebugTypeBasic"));
+              HasSubstr("expected operand Base Type is not a valid debug type"));
 }
 
 TEST_F(ValidateOpenCL100DebugInfo, DebugTypeArray) {


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/5471

Problem: The base type operand for these instructions can be any DebugType instruction, but currently spirv-val forces it to be a DebugBasicType.

Solution: Change validator code to accept any DebugType instruction.
